### PR TITLE
Adjust precommit secret scan for CI

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -7,4 +7,6 @@ pnpm eslint $(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g'
 git update-index --again
 
 # check for secrets
-trufflehog git file://. --since-commit HEAD --fail
+if [ -z "$CI" ] && [ -z "$GITHUB_ACTIONS" ]; then
+  trufflehog git file://. --since-commit HEAD --fail
+fi


### PR DESCRIPTION
## Summary
- skip running trufflehog when `CI` or `GITHUB_ACTIONS` are set in the precommit hook

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_i_683fe86d7d1c83318bc4691b88f6a8fd