### PR TITLE
fix: Add init option validation to detect client side agents as tools to RealtimeAgent

### DIFF
--- a/.changeset/wide-results-invite.md
+++ b/.changeset/wide-results-invite.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-realtime': patch
+'@openai/agents-core': patch
+---
+
+- Add safeToRunInBrowser property to FunctionTool inteface
+- Add init option validation to detect local agents as tools in web browser to RealtimeAgent

--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -437,6 +437,7 @@ export class Agent<
         additionalProperties: false,
       },
       strict: true,
+      localAgentAsTool: true,
       execute: async (data, context) => {
         if (!isAgentToolInput(data)) {
           throw new ModelBehaviorError('Agent tool called with invalid input');

--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -217,6 +217,11 @@ export interface AgentConfiguration<
    * to `true`. This ensures that the agent doesn't enter an infinite loop of tool usage.
    */
   resetToolChoice: boolean;
+
+  /**
+   * Whether the agent is safe to run in a browser environment. Defaults to false.
+   */
+  safeToRunInBrowser?: boolean;
 }
 
 export type AgentOptions<
@@ -314,6 +319,7 @@ export class Agent<
   outputType: TOutput = 'text' as TOutput;
   toolUseBehavior: ToolUseBehavior;
   resetToolChoice: boolean;
+  safeToRunInBrowser: boolean;
 
   constructor(config: AgentOptions<TContext, TOutput>) {
     super();
@@ -335,6 +341,7 @@ export class Agent<
     }
     this.toolUseBehavior = config.toolUseBehavior ?? 'run_llm_again';
     this.resetToolChoice = config.resetToolChoice ?? true;
+    this.safeToRunInBrowser = config.safeToRunInBrowser ?? false;
 
     // --- Runtime warning for handoff output type compatibility ---
     if (
@@ -437,7 +444,7 @@ export class Agent<
         additionalProperties: false,
       },
       strict: true,
-      localAgentAsTool: true,
+      safeToRunInBrowser: this.safeToRunInBrowser,
       execute: async (data, context) => {
         if (!isAgentToolInput(data)) {
           throw new ModelBehaviorError('Agent tool called with invalid input');

--- a/packages/agents-core/src/tool.ts
+++ b/packages/agents-core/src/tool.ts
@@ -73,6 +73,13 @@ export type FunctionTool<
    * program has to resolve by approving or rejecting the tool call.
    */
   needsApproval: ToolApprovalFunction<TParameters>;
+
+  /**
+   * Whether the tool is a local agent. If true, the tool is a different agent that will be called
+   * locally. Note that an agent running on web frontend client side does not work for RealtimeAgent.
+   * If the property is absent, it means false.
+   */
+  localAgentAsTool?: boolean;
 };
 
 /**
@@ -326,6 +333,13 @@ type StrictToolOptions<
    * program has to resolve by approving or rejecting the tool call.
    */
   needsApproval?: boolean | ToolApprovalFunction<TParameters>;
+
+  /**
+   * Whether the tool is a local agent. If true, the tool is a different agent that will be called
+   * locally. Note that an agent running on web frontend client side does not work for RealtimeAgent.
+   * If the property is absent, it means false.
+   */
+  localAgentAsTool?: boolean;
 };
 
 /**
@@ -373,6 +387,13 @@ type NonStrictToolOptions<
    * program has to resolve by approving or rejecting the tool call.
    */
   needsApproval?: boolean | ToolApprovalFunction<TParameters>;
+
+  /**
+   * Whether the tool is a local agent. If true, the tool is a different agent that will be called
+   * locally. Note that an agent running on web frontend client side does not work for RealtimeAgent.
+   * If the property is absent, it means false.
+   */
+  localAgentAsTool?: boolean;
 };
 
 /**
@@ -497,5 +518,6 @@ export function tool<
     strict: strictMode,
     invoke,
     needsApproval,
+    localAgentAsTool: options.localAgentAsTool,
   };
 }

--- a/packages/agents-core/src/tool.ts
+++ b/packages/agents-core/src/tool.ts
@@ -75,11 +75,9 @@ export type FunctionTool<
   needsApproval: ToolApprovalFunction<TParameters>;
 
   /**
-   * Whether the tool is a local agent. If true, the tool is a different agent that will be called
-   * locally. Note that an agent running on web frontend client side does not work for RealtimeAgent.
-   * If the property is absent, it means false.
+   * Whether the tool is safe to run in a browser. If true, the tool can be called from a browser. Default: false
    */
-  localAgentAsTool?: boolean;
+  safeToRunInBrowser?: boolean;
 };
 
 /**
@@ -335,11 +333,9 @@ type StrictToolOptions<
   needsApproval?: boolean | ToolApprovalFunction<TParameters>;
 
   /**
-   * Whether the tool is a local agent. If true, the tool is a different agent that will be called
-   * locally. Note that an agent running on web frontend client side does not work for RealtimeAgent.
-   * If the property is absent, it means false.
+   * Whether the tool is safe to run in a browser. If true, the tool can be called from a browser. Default: false
    */
-  localAgentAsTool?: boolean;
+  safeToRunInBrowser?: boolean;
 };
 
 /**
@@ -389,11 +385,9 @@ type NonStrictToolOptions<
   needsApproval?: boolean | ToolApprovalFunction<TParameters>;
 
   /**
-   * Whether the tool is a local agent. If true, the tool is a different agent that will be called
-   * locally. Note that an agent running on web frontend client side does not work for RealtimeAgent.
-   * If the property is absent, it means false.
+   * Whether the tool is safe to run in a browser. If true, the tool can be called from a browser. Default: false
    */
-  localAgentAsTool?: boolean;
+  safeToRunInBrowser?: boolean;
 };
 
 /**
@@ -518,6 +512,6 @@ export function tool<
     strict: strictMode,
     invoke,
     needsApproval,
-    localAgentAsTool: options.localAgentAsTool,
+    safeToRunInBrowser: options.safeToRunInBrowser,
   };
 }

--- a/packages/agents-realtime/src/realtimeAgent.ts
+++ b/packages/agents-realtime/src/realtimeAgent.ts
@@ -78,7 +78,7 @@ export class RealtimeAgent<TContext = UnknownContext> extends Agent<
       for (const tool of config.tools) {
         if (tool.type === 'function' && tool.safeToRunInBrowser !== true) {
           throw new UserError(
-            `Local agent as a tool detected: ${tool.name}. Please use a tool that makes requests to your server-side agent logic, rather than converting a locally running client-side agent into a tool.`,
+            `Local agent as a tool detected: ${tool.name}. Please use a tool that makes requests to your server-side agent logic, rather than converting a locally running client-side agent into a tool. If the agent is safe to run with sufficient security measures (e.g., custom proxy / authentication for model requests), set the agent's safeToRunInBrowser option to true.`,
           );
         }
       }

--- a/packages/agents-realtime/src/realtimeAgent.ts
+++ b/packages/agents-realtime/src/realtimeAgent.ts
@@ -76,7 +76,7 @@ export class RealtimeAgent<TContext = UnknownContext> extends Agent<
   constructor(config: RealtimeAgentConfiguration<TContext>) {
     if (isBrowserEnvironment() && config.tools) {
       for (const tool of config.tools) {
-        if (tool.type === 'function' && tool.localAgentAsTool === true) {
+        if (tool.type === 'function' && tool.safeToRunInBrowser !== true) {
           throw new UserError(
             `Local agent as a tool detected: ${tool.name}. Please use a tool that makes requests to your server-side agent logic, rather than converting a locally running client-side agent into a tool.`,
           );

--- a/packages/agents-realtime/test/realtimeAgent.test.ts
+++ b/packages/agents-realtime/test/realtimeAgent.test.ts
@@ -28,7 +28,7 @@ describe('RealtimeAgent', () => {
         ],
       });
     }).toThrowError(
-      'Local agent as a tool detected: local_agent_tool. Please use a tool that makes requests to your server-side agent logic, rather than converting a locally running client-side agent into a tool.',
+      "Local agent as a tool detected: local_agent_tool. Please use a tool that makes requests to your server-side agent logic, rather than converting a locally running client-side agent into a tool. If the agent is safe to run with sufficient security measures (e.g., custom proxy / authentication for model requests), set the agent's safeToRunInBrowser option to true.",
     );
   });
 

--- a/packages/agents-realtime/test/realtimeAgent.test.ts
+++ b/packages/agents-realtime/test/realtimeAgent.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { RealtimeAgent } from '../src/realtimeAgent';
 import { Agent } from '@openai/agents-core';
 
-const mockResponses = [true, false];
+const mockResponses = [true, true, false];
 vi.mock('@openai/agents-core/_shims', async (importOriginal) => {
   return {
     ...(await importOriginal()),
@@ -30,6 +30,24 @@ describe('RealtimeAgent', () => {
     }).toThrowError(
       'Local agent as a tool detected: local_agent_tool. Please use a tool that makes requests to your server-side agent logic, rather than converting a locally running client-side agent into a tool.',
     );
+  });
+
+  it('accepts safeToRunInBrowser agents as tools (browser)', async () => {
+    const localToolAgent = new Agent({
+      name: 'local_agent',
+      instructions: 'You are a local agent',
+      safeToRunInBrowser: true,
+    });
+    const realtimeAgent = new RealtimeAgent({
+      name: 'A',
+      tools: [
+        localToolAgent.asTool({
+          toolName: 'local_agent tool',
+          toolDescription: 'You are a local agent',
+        }),
+      ],
+    });
+    expect(realtimeAgent).toBeDefined();
   });
 
   it('does not detect local agents as tools (server)', () => {

--- a/packages/agents-realtime/test/realtimeAgent.test.ts
+++ b/packages/agents-realtime/test/realtimeAgent.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { RealtimeAgent } from '../src/realtimeAgent';
+import { Agent } from '@openai/agents-core';
+
+const mockResponses = [true, false];
+vi.mock('@openai/agents-core/_shims', async (importOriginal) => {
+  return {
+    ...(await importOriginal()),
+    isBrowserEnvironment: vi.fn(() => mockResponses.shift() ?? true),
+  };
+});
+
+describe('RealtimeAgent', () => {
+  it('detects local agents as tools (browser)', async () => {
+    const localToolAgent = new Agent({
+      name: 'local_agent',
+      instructions: 'You are a local agent',
+    });
+    expect(() => {
+      new RealtimeAgent({
+        name: 'A',
+        tools: [
+          localToolAgent.asTool({
+            toolName: 'local_agent tool',
+            toolDescription: 'You are a local agent',
+          }),
+        ],
+      });
+    }).toThrowError(
+      'Local agent as a tool detected: local_agent_tool. Please use a tool that makes requests to your server-side agent logic, rather than converting a locally running client-side agent into a tool.',
+    );
+  });
+
+  it('does not detect local agents as tools (server)', () => {
+    const localToolAgent = new Agent({
+      name: 'local_agent',
+      instructions: 'You are a local agent',
+    });
+    const realtimeAgent = new RealtimeAgent({
+      name: 'A',
+      tools: [
+        localToolAgent.asTool({
+          toolName: 'local_agent tool',
+          toolDescription: 'You are a local agent',
+        }),
+      ],
+    });
+    expect(realtimeAgent).toBeDefined();
+  });
+});


### PR DESCRIPTION
This pull request proposes adding a new input validation to RealtimeAgent constructor. This check is helpful for developers to learn why local agents as tools on the client side does not work and what to do next.

Implementation details can be changed as necessary. Still in draft mode but please feel free to add comments and let me know what you think.