### PR TITLE
fix: Reduce warning/stdout outputs during test executions

### DIFF
--- a/.changeset/hip-needles-love.md
+++ b/.changeset/hip-needles-love.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+Update internal module in agents-core to accept a custom logger

--- a/packages/agents-core/src/runImplementation.ts
+++ b/packages/agents-core/src/runImplementation.ts
@@ -12,7 +12,7 @@ import {
   RunToolCallItem,
   RunToolCallOutputItem,
 } from './items';
-import logger from './logger';
+import logger, { Logger } from './logger';
 import { ModelResponse, ModelSettings } from './model';
 import { ComputerTool, FunctionTool, Tool, FunctionToolResult } from './tool';
 import { AgentInputItem, UnknownContext } from './types';
@@ -695,7 +695,9 @@ export async function executeComputerActions(
   actions: ToolRunComputer[],
   runner: Runner,
   runContext: RunContext,
+  customLogger: Logger | undefined = undefined,
 ): Promise<RunItem[]> {
+  const _logger = customLogger ?? logger;
   const results: RunItem[] = [];
   for (const action of actions) {
     const computer = action.computer.computer;
@@ -712,7 +714,7 @@ export async function executeComputerActions(
     try {
       output = await _runComputerActionAndScreenshot(computer, toolCall);
     } catch (err) {
-      logger.error('Failed to execute computer action:', err);
+      _logger.error('Failed to execute computer action:', err);
       output = '';
     }
 
@@ -930,7 +932,6 @@ export async function checkForFinalOutputFromTools<
     return toolUseBehavior(state._context, toolResults);
   }
 
-  logger.error('Invalid toolUseBehavior: ', toolUseBehavior);
   throw new UserError(`Invalid toolUseBehavior: ${toolUseBehavior}`, state);
 }
 

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -8,7 +8,9 @@ import {
   run,
   Runner,
   setDefaultModelProvider,
+  setTraceProcessors,
   setTracingDisabled,
+  BatchTraceProcessor,
 } from '../src';
 import { RunStreamEvent } from '../src/events';
 import { handoff } from '../src/handoff';
@@ -25,6 +27,7 @@ import {
   FakeModel,
   fakeModelMessage,
   FakeModelProvider,
+  FakeTracingExporter,
   TEST_MODEL_MESSAGE,
   TEST_MODEL_RESPONSE_BASIC,
   TEST_TOOL,
@@ -425,6 +428,7 @@ describe('Runner.run', () => {
 
     it('does nothing when no input guardrails are configured', async () => {
       setTracingDisabled(false);
+      setTraceProcessors([new BatchTraceProcessor(new FakeTracingExporter())]);
       const agent = new Agent({
         name: 'NoIG',
         model: new FakeModel([

--- a/packages/agents-core/test/runImplementation.test.ts
+++ b/packages/agents-core/test/runImplementation.test.ts
@@ -46,6 +46,7 @@ import * as protocol from '../src/types/protocol';
 import { Runner } from '../src/run';
 import { RunContext } from '../src/runContext';
 import { setDefaultModelProvider } from '../src';
+import { Logger } from '../src/logger';
 
 beforeAll(() => {
   setTracingDisabled(true);
@@ -627,6 +628,7 @@ describe('executeComputerActions', () => {
         [call],
         new Runner({ tracingDisabled: true }),
         new RunContext(),
+        { error: (_: string) => {} } as unknown as Logger,
       ),
     );
 

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -50,7 +50,7 @@ describe('RunState', () => {
     expect(JSON.parse(str)).toEqual(json);
   });
 
-  it('throws error if schema version is missing or invalid', () => {
+  it('throws error if schema version is missing or invalid', async () => {
     const context = new RunContext();
     const agent = new Agent({ name: 'Agent1' });
     const state = new RunState(context, 'input1', agent, 2);
@@ -58,13 +58,13 @@ describe('RunState', () => {
     delete jsonVersion.$schemaVersion;
 
     const str = JSON.stringify(jsonVersion);
-    expect(async () => await RunState.fromString(agent, str)).rejects.toThrow(
+    await expect(() => RunState.fromString(agent, str)).rejects.toThrow(
       'Run state is missing schema version',
     );
 
     jsonVersion.$schemaVersion = '0.1';
-    expect(
-      async () => await RunState.fromString(agent, JSON.stringify(jsonVersion)),
+    await expect(() =>
+      RunState.fromString(agent, JSON.stringify(jsonVersion)),
     ).rejects.toThrow(
       `Run state schema version 0.1 is not supported. Please use version ${CURRENT_SCHEMA_VERSION}`,
     );

--- a/packages/agents-core/test/shims/mcp-stdio/node.test.ts
+++ b/packages/agents-core/test/shims/mcp-stdio/node.test.ts
@@ -1,7 +1,29 @@
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, vi, afterAll, beforeAll } from 'vitest';
 import { NodeMCPServerStdio } from '../../../src/shims/mcp-stdio/node';
+import { TransportSendOptions } from '@modelcontextprotocol/sdk/shared/transport';
+import { JSONRPCMessage } from '@modelcontextprotocol/sdk/types';
 
 describe('NodeMCPServerStdio', () => {
+  beforeAll(() => {
+    vi.mock(
+      '@modelcontextprotocol/sdk/client/stdio.js',
+      async (importOriginal) => {
+        return {
+          ...(await importOriginal()),
+          StdioClientTransport: MockStdioClientTransport,
+        };
+      },
+    );
+    vi.mock(
+      '@modelcontextprotocol/sdk/client/index.js',
+      async (importOriginal) => {
+        return {
+          ...(await importOriginal()),
+          Client: MockClient,
+        };
+      },
+    );
+  });
   test('should be available', async () => {
     const server = new NodeMCPServerStdio({
       name: 'test',
@@ -11,6 +33,56 @@ describe('NodeMCPServerStdio', () => {
     expect(server).toBeDefined();
     expect(server.name).toBe('test');
     expect(server.cacheToolsList).toBe(true);
-    await expect(server.connect()).rejects.toThrow();
+    await server.connect();
+    await server.close();
+  });
+
+  afterAll(() => {
+    vi.clearAllMocks();
   });
 });
+
+class MockStdioClientTransport {
+  options: {
+    command: string;
+    args: string[];
+    env: Record<string, string>;
+    cwd: string;
+  };
+  constructor(options: {
+    command: string;
+    args: string[];
+    env: Record<string, string>;
+    cwd: string;
+  }) {
+    this.options = options;
+  }
+  start(): Promise<void> {
+    return Promise.resolve();
+  }
+  send(
+    _message: JSONRPCMessage,
+    _options?: TransportSendOptions,
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class MockClient {
+  options: {
+    name: string;
+    version: string;
+  };
+  constructor(options: { name: string; version: string }) {
+    this.options = options;
+  }
+  connect(): Promise<void> {
+    return Promise.resolve();
+  }
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/packages/agents-core/test/stubs.ts
+++ b/packages/agents-core/test/stubs.ts
@@ -11,6 +11,7 @@ import type { Computer } from '../src/computer';
 import type { Environment } from '../src/computer';
 import * as protocol from '../src/types/protocol';
 import { Usage } from '../src/usage';
+import { Span, Trace, TracingExporter } from '../src';
 
 export const TEST_MODEL_MESSAGE: protocol.AssistantMessageItem = {
   id: '123',
@@ -93,7 +94,7 @@ export class FakeComputer implements Computer {
   dimensions: [number, number] = [1, 1];
 
   async screenshot(): Promise<string> {
-    return '';
+    return 'img';
   }
   async click(_x: number, _y: number, _button: any): Promise<void> {}
   async doubleClick(_x: number, _y: number): Promise<void> {}
@@ -132,5 +133,11 @@ export class FakeModel implements Model {
 export class FakeModelProvider implements ModelProvider {
   async getModel(_name: string): Promise<Model> {
     return new FakeModel([TEST_MODEL_RESPONSE_BASIC]);
+  }
+}
+
+export class FakeTracingExporter implements TracingExporter {
+  export(_items: (Trace | Span<any>)[], _signal?: AbortSignal): Promise<void> {
+    return Promise.resolve();
   }
 }

--- a/packages/agents-extensions/test/aiSdk.test.ts
+++ b/packages/agents-extensions/test/aiSdk.test.ts
@@ -551,7 +551,7 @@ describe('AiSdkModel.getStreamedResponse', () => {
       }),
     );
 
-    expect(async () => {
+    await expect(async () => {
       const iter = model.getStreamedResponse({
         input: 'hi',
         tools: [],

--- a/packages/agents-extensions/test/index.test.ts
+++ b/packages/agents-extensions/test/index.test.ts
@@ -60,7 +60,6 @@ describe('TwilioRealtimeTransportLayer', () => {
     const call = sendEventSpy.mock.calls.find(
       (c) => c[0]?.type === 'conversation.item.truncate',
     );
-    console.log('call', call);
     expect(call?.[0].audio_end_ms).toBe(50);
   });
 });


### PR DESCRIPTION
This pull request reduces unnecessary stdout outputs during `pnpm test` execution. Not yet eliminated (mainly agents-realtime has a few more outputs that should be managed properly) but this PR definitely improves it.

Current outputs:

```
> CI=1 NODE_ENV=test vitest

 RUN  v3.1.1 /path-to/openai-agents-js

 ✓  @openai/agents-realtime  test/utils.test.ts (8 tests) 2ms
 ✓  @openai/agents-core  test/tracing.test.ts (10 tests) 5ms
 ✓  @openai/agents-openai  test/openaiChatCompletionsConverter.test.ts (14 tests) 3ms
 ✓  @openai/agents-core  test/items.test.ts (8 tests) 2ms
 ✓  @openai/agents-core  test/runState.test.ts (14 tests) 6ms
 ✓  @openai/agents-openai  test/openaiChatCompletionsModel.test.ts (8 tests) 6ms
 ✓  @openai/agents-realtime  test/openaiRealtimeWebRtc.test.ts (6 tests) 7ms
 ✓  @openai/agents-openai  test/openaiResponsesModel.helpers.test.ts (14 tests) 4ms
 ✓  @openai/agents-core  test/agent.test.ts (15 tests) 5ms
stdout | test/openaiRealtimeWebsocket.test.ts > OpenAIRealtimeWebSocket > handles audio delta, speech started and created/done events
Interrupting response after 0ms
Audio length: 0.020833333333333332ms
Interrupting response after 0ms
Audio length: 0.020833333333333332ms

 ✓  @openai/agents-core  test/runImplementation.test.ts (31 tests) 8ms
stdout | test/openaiRealtimeWebsocket.test.ts > OpenAIRealtimeWebSocket > full interrupt/_interrupt flow
Interrupting response after 0ms
Audio length: 0.020833333333333332ms

 ✓  @openai/agents-realtime  test/openaiRealtimeWebsocket.test.ts (8 tests) 9ms
stderr | test/realtimeSession.test.ts > RealtimeSession > sets the trace config correctly
In order to set traceMetadata or a groupId you need to specify a workflowName.

 ✓  @openai/agents-core  test/run.test.ts (18 tests) 17ms
stderr | test/realtimeSession.test.ts > RealtimeSession > propagates errors from handleFunctionCall
Error handling function call ModelBehaviorError: Tool missing not found
    at RealtimeSession.#handleFunctionCall (/Users/seratch/code/openai-agents-js/packages/agents-realtime/src/realtimeSession.ts:444:15)
    at EventEmitter.<anonymous> (/Users/seratch/code/openai-agents-js/packages/agents-realtime/src/realtimeSession.ts:589:9) {
  state: undefined
}

 ✓  @openai/agents-extensions  test/aiSdk.test.ts (22 tests) 8ms
 ✓  @openai/agents-realtime  test/realtimeSession.test.ts (11 tests) 109ms
 ✓  @openai/agents-realtime  test/openaiRealtimeEvents.test.ts (5 tests) 3ms
 ✓  @openai/agents-openai  test/openaiChatCompletionsStreaming.test.ts (2 tests) 2ms
 ✓  @openai/agents-openai  test/openaiResponsesModel.test.ts (2 tests) 4ms
stderr | test/openaiTracingExporter.test.ts > OpenAITracingExporter > skips export when no apiKey
No API key provided for OpenAI tracing exporter. Exports will be skipped

stderr | test/openaiTracingExporter.test.ts > OpenAITracingExporter > retries on server errors
[non-fatal] Tracing: server error 500, retrying.

stderr | test/openaiTracingExporter.test.ts > OpenAITracingExporter > stops on client error
[non-fatal] Tracing client error 400: bad

 ✓  @openai/agents-core  test/guardrail.test.ts (5 tests) 3ms
 ✓  @openai/agents-realtime  test/openaiRealtimeBase.test.ts (6 tests) 4ms
stderr | test/TwilioRealtimeTransport.test.ts > TwilioRealtimeTransportLayer > connect handles messages and events
Error parsing message: SyntaxError: Unexpected token 'b', "bad{" is not valid JSON
    at JSON.parse (<anonymous>)
    at FakeTwilioWebSocket.<anonymous> (/Users/seratch/code/openai-agents-js/packages/agents-extensions/src/TwilioRealtimeTransport.ts:87:27)
    at FakeTwilioWebSocket.emit (node:events:518:28)
    at /Users/seratch/code/openai-agents-js/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts:89:12
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at file:///Users/seratch/code/openai-agents-js/node_modules/@vitest/runner/dist/index.js:595:20 Message: { toString: [Function: toString] }

 ✓  @openai/agents-core  test/tool.test.ts (5 tests) 4ms
 ✓  @openai/agents-extensions  test/TwilioRealtimeTransport.test.ts (3 tests) 5ms
 ✓  @openai/agents-core  test/handoffs.test.ts (3 tests) 5ms
 ✓  @openai/agents-core  test/result.test.ts (4 tests) 5ms
stderr | test/handoff.test.ts > handoff() > parses JSON and reports errors
Invalid JSON when parsing: bad. Error: SyntaxError: Unexpected token 'b', "bad" is not valid JSON

 ✓  @openai/agents-core  test/handoff.test.ts (5 tests) 4ms
 ✓  @openai/agents-core  test/shims/mcp-stdio/node.test.ts (1 test) 32ms
 ✓  @openai/agents-openai  test/openaiTracingExporter.test.ts (5 tests) 36ms
 ✓  @openai/agents-extensions  test/index.test.ts (2 tests) 3ms
 ✓  @openai/agents-core  test/utils/messages.test.ts (4 tests) 1ms
 ✓  @openai/agents-core  test/utils/serialize.test.ts (4 tests) 1ms
 ✓  @openai/agents-core  test/utils/tools.test.ts (5 tests) 3ms
 ✓  @openai/agents-core  test/helpers/message.test.ts (4 tests) 2ms
 ✓  @openai/agents-core  test/utils/smartString.test.ts (7 tests) 2ms
 ✓  @openai/agents-core  test/usage.test.ts (3 tests) 2ms
 ✓  @openai/agents-openai  test/tools.test.ts (2 tests) 1ms
 ✓  @openai/agents-core  test/utils/typeGuards.test.ts (2 tests) 1ms
 ✓  @openai/agents-core  test/mcpCache.test.ts (1 test) 3ms
 ✓  @openai/agents-core  test/errors.test.ts (1 test) 2ms
 ✓  @openai/agents-openai  test/defaults.test.ts (5 tests) 2ms
 ✓  @openai/agents-core  test/runContext.test.ts (3 tests) 2ms
 ✓  @openai/agents-core  test/run.stream.test.ts (2 tests) 4ms
 ✓  @openai/agents-openai  test/openaiProvider.test.ts (4 tests) 2ms
 ✓  @openai/agents-core  test/model.test.ts (1 test) 1ms
 ✓  @openai/agents-core  test/utils/safeExecute.test.ts (2 tests) 1ms
 ✓  @openai/agents-core  test/run.utils.test.ts (1 test) 1ms
 ✓  @openai/agents-core  test/extensions/handoffPrompt.test.ts (2 tests) 1ms
 ✓  @openai/agents-realtime  test/openaiRealtimeWebRtc.environment.test.ts (1 test) 1ms
 ✓  @openai/agents-realtime  test/index.test.ts (2 tests) 1ms
 ✓  @openai/agents-core  test/extensions/handoffFilters.test.ts (1 test) 1ms
 ✓  @openai/agents  test/metadata.test.ts (1 test) 1ms
 ✓  @openai/agents-core  test/metadata.test.ts (1 test) 1ms
 ✓  @openai/agents-core  test/providers.test.ts (1 test) 1ms
 ✓  @openai/agents-core  test/shims/mcp-stdio/browser.test.ts (1 test) 1ms
 ✓  @openai/agents-core  test/utils/index.test.ts (1 test) 1ms
 ✓  @openai/agents-core  test/index.test.ts (1 test) 1ms
 ✓  @openai/agents-core  test/mcp.test.ts (1 test) 1ms
 ✓  @openai/agents-openai  test/index.test.ts (1 test) 1ms
 ✓  @openai/agents  test/index.test.ts (3 tests) 1ms

 Test Files  57 passed (57)
      Tests  303 passed (303)
   Start at  17:44:23
   Duration  4.33s (transform 1.75s, setup 0ms, collect 8.28s, tests 348ms, environment 5ms, prepare 4.06s)
```