### PR TITLE
fix(shims): Bind crypto to randomUUID

### DIFF
--- a/.changeset/quiet-flies-march.md
+++ b/.changeset/quiet-flies-march.md
@@ -1,0 +1,5 @@
+---
+"@openai/agents-core": patch
+---
+
+fix(shims): Bind crypto to randomUUID

--- a/packages/agents-core/src/shims/shims-browser.ts
+++ b/packages/agents-core/src/shims/shims-browser.ts
@@ -61,7 +61,7 @@ export class BrowserEventEmitter<
 
 export { BrowserEventEmitter as RuntimeEventEmitter };
 
-export const randomUUID = crypto.randomUUID;
+export const randomUUID = crypto.randomUUID.bind(crypto);
 export const Readable = class Readable {
   constructor() {}
   pipeTo(


### PR DESCRIPTION
Fix a bug when call `randomUUID` in the browser.