### PR TITLE
fix(shims): Naively polyfill AsyncLocalStorage in browser

### DIFF
--- a/.changeset/purple-oranges-shout.md
+++ b/.changeset/purple-oranges-shout.md
@@ -1,0 +1,5 @@
+---
+"@openai/agents-core": patch
+---
+
+fix(shims): Naively polyfill AsyncLocalStorage in browser

--- a/packages/agents-core/src/shims/shims-browser.ts
+++ b/packages/agents-core/src/shims/shims-browser.ts
@@ -87,10 +87,16 @@ export const ReadableStreamController =
 export const TransformStream = globalThis.TransformStream;
 
 export class AsyncLocalStorage {
-  constructor() {}
-  run() {}
-  getStore() {}
-  enterWith() {}
+  context = null;
+  constructor() { }
+  run(context: any, fn: () => any) {
+      this.context = context;
+      return fn();
+  }
+  getStore() {
+      return this.context;
+  }
+  enterWith() { }
 }
 
 export function isBrowserEnvironment(): boolean {


### PR DESCRIPTION
Some code like `packages/agents-core/src/tracing/context.ts:25` will call this function.