### PR TITLE
fix: Remove empty tools param

### DIFF
--- a/.changeset/better-shoes-march.md
+++ b/.changeset/better-shoes-march.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+Ignore empty tool list when callling LLM

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -260,7 +260,7 @@ export class OpenAIChatCompletionsModel implements Model {
     const requestData = {
       model: this.#model,
       messages,
-      tools,
+      tools: tools.length ? tools : undefined,
       temperature: request.modelSettings.temperature,
       top_p: request.modelSettings.topP,
       frequency_penalty: request.modelSettings.frequencyPenalty,


### PR DESCRIPTION
Some OpenAI API compatible model will throw error with empty `tools` param.

To make **OpenAIChatCompletionsModel** more robust 