### PR TITLE
fix: streaming guide link on running-agents page

### DIFF
--- a/docs/src/content/docs/guides/running-agents.mdx
+++ b/docs/src/content/docs/guides/running-agents.mdx
@@ -63,7 +63,7 @@ The additional options are:
 
 ## Streaming
 
-Streaming allows you to additionally receive streaming events as the LLM runs. Once the stream is started, the `StreamedRunResult` will contain the complete information about the run, including all the new outputs produces. You can iterate over the streaming events using a `for await` loop. Read more in the [streaming guide](/guides/streaming).
+Streaming allows you to additionally receive streaming events as the LLM runs. Once the stream is started, the `StreamedRunResult` will contain the complete information about the run, including all the new outputs produces. You can iterate over the streaming events using a `for await` loop. Read more in the [streaming guide](/openai-agents-js/guides/streaming).
 
 ## Run config
 


### PR DESCRIPTION
This PR fixes the "Streaming guide" link on [Running-agents](https://openai.github.io/openai-agents-js/guides/running-agents/#streaming) page.

Recording of the issue


https://github.com/user-attachments/assets/30ba0718-6345-4a60-8f15-1d5d828af56f


Previous Link:  /guides/streaming
Updated Link: /openai-agents-js/guides/streaming

