### PR TITLE
feat: handle unknown hosted tools in responses model

### DIFF
--- a/.changeset/rich-buses-marry.md
+++ b/.changeset/rich-buses-marry.md
@@ -1,0 +1,5 @@
+---
+"@openai/agents-openai": patch
+---
+
+feat: handle unknown hosted tools in responses model

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -175,6 +175,11 @@ function converTool<_TContext = unknown>(
         },
         include: undefined,
       };
+    } else if (tool.providerData) {
+      return {
+        tool: tool.providerData as unknown as OpenAI.Responses.Tool,
+        include: undefined,
+      };
     }
   }
 

--- a/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
@@ -125,6 +125,23 @@ describe('converTool', () => {
       quality: undefined,
       size: undefined,
     });
+
+    const custom = converTool({
+      type: 'hosted_tool',
+      providerData: {
+        type: 'mcp',
+        server_label: 'deepwiki',
+        server_url: 'https://mcp.deepwiki.com/mcp',
+        require_approval: 'never',
+      },
+    } as any);
+
+    expect(custom.tool).toEqual({
+      type: 'mcp',
+      server_label: 'deepwiki',
+      server_url: 'https://mcp.deepwiki.com/mcp',
+      require_approval: 'never',
+    });
   });
 
   it('throws on unsupported tool', () => {


### PR DESCRIPTION
## Summary
- allow OpenAIResponsesModel to pass through unhandled hosted tools
- test conversion of custom hosted tools

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_i_6847093447a48331b7392a8c25310a96