### PR TITLE
Add docs for MCP tools

### DIFF
--- a/docs/src/content/docs/guides/tools.mdx
+++ b/docs/src/content/docs/guides/tools.mdx
@@ -8,13 +8,15 @@ import toolsFunctionExample from '../../../../../examples/docs/tools/functionToo
 import toolsHostedToolsExample from '../../../../../examples/docs/tools/hostedTools.ts?raw';
 import nonStrictSchemaTools from '../../../../../examples/docs/tools/nonStrictSchemaTools.ts?raw';
 import agentsAsToolsExample from '../../../../../examples/docs/tools/agentsAsTools.ts?raw';
+import mcpLocalServer from '../../../../../examples/docs/tools/mcpLocalServer.ts?raw';
 
 Tools let an Agent **take actions** – fetch data, call external APIs, execute code, or even use a
-computer. The JavaScript/TypeScript SDK supports three categories:
+computer. The JavaScript/TypeScript SDK supports four categories:
 
 1. **Hosted tools** – run alongside the model on OpenAI servers. _(web search, file search, computer use, code interpreter, image generation)_
 2. **Function tools** – wrap any local function with a JSON schema so the LLM can call it.
 3. **Agents as tools** – expose an entire Agent as a callable tool.
+4. **Local MCP servers** – attach a Model Context Protocol server running on your machine.
 
 ---
 
@@ -83,6 +85,17 @@ Under the hood the SDK:
 - Creates a function tool with a single `input` parameter.
 - Runs the sub‑agent with that input when the tool is called.
 - Returns either the last message or the output extracted by `customOutputExtractor`.
+
+---
+
+## 4. Local MCP servers
+
+You can expose tools via a local [Model Context Protocol](https://modelcontextprotocol.io/) server and attach them to an agent.
+Use `MCPServerStdio` to spawn and connect to the server:
+
+<Code lang="typescript" code={mcpLocalServer} title="Local MCP server" />
+
+See [`filesystem-example.ts`](https://github.com/openai/openai-agents-js/tree/main/examples/mcp/filesystem-example.ts) for a complete example.
 
 ---
 

--- a/docs/src/content/docs/ja/guides/tools.mdx
+++ b/docs/src/content/docs/ja/guides/tools.mdx
@@ -8,12 +8,14 @@ import toolsFunctionExample from '../../../../../../examples/docs/tools/function
 import toolsHostedToolsExample from '../../../../../../examples/docs/tools/hostedTools.ts?raw';
 import nonStrictSchemaTools from '../../../../../../examples/docs/tools/nonStrictSchemaTools.ts?raw';
 import agentsAsToolsExample from '../../../../../../examples/docs/tools/agentsAsTools.ts?raw';
+import mcpLocalServer from '../../../../../../examples/docs/tools/mcpLocalServer.ts?raw';
 
-ツールを使うことで、エージェントは **行動を実行** できます。たとえばデータの取得、外部 API の呼び出し、コードの実行、さらにはコンピュータ操作まで可能です。JavaScript / TypeScript SDK は次の 3 カテゴリーをサポートします:
+ツールを使うことで、エージェントは **行動を実行** できます。たとえばデータの取得、外部 API の呼び出し、コードの実行、さらにはコンピュータ操作まで可能です。JavaScript / TypeScript SDK は次の 4 カテゴリーをサポートします:
 
 1. **組み込みツール（Hosted）** – モデルと同じ OpenAI サーバー上で動作します。 _(Web 検索、ファイル検索、コンピュータ操作、Code Interpreter、画像生成)_
 2. **関数ツール** – 任意のローカル関数を JSON スキーマでラップし、LLM から呼び出せるようにします。
 3. **エージェントをツールとして使用** – エージェント全体を呼び出し可能なツールとして公開します。
+4. **ローカル MCP サーバー** – ローカルで動作する Model Context Protocol サーバーをエージェントに追加します。
 
 ---
 
@@ -79,6 +81,16 @@ SDK は内部で次の処理を行います:
 - 単一の `input` パラメーターを持つ関数ツールを生成
 - ツール呼び出し時にサブエージェントをその入力で実行
 - 最後のメッセージ、または `customOutputExtractor` で抽出した出力を返却
+
+---
+
+## 4. ローカル MCP サーバー
+
+ローカルで動作する [Model Context Protocol](https://modelcontextprotocol.io/) サーバーからツールを公開し、エージェントに接続できます。`MCPServerStdio` を使用してサーバーを起動し接続します:
+
+<Code lang="typescript" code={mcpLocalServer} title="Local MCP server" />
+
+`filesystem-example.ts` の完全な例もご覧ください。
 
 ---
 

--- a/examples/docs/tools/mcpLocalServer.ts
+++ b/examples/docs/tools/mcpLocalServer.ts
@@ -1,0 +1,12 @@
+import { Agent, MCPServerStdio } from '@openai/agents';
+
+const server = new MCPServerStdio({
+  fullCommand: 'npx -y @modelcontextprotocol/server-filesystem ./sample_files',
+});
+
+await server.connect();
+
+const agent = new Agent({
+  name: 'Assistant',
+  mcpServers: [server],
+});


### PR DESCRIPTION
## Summary
- add example for connecting to a local MCP server
- document local MCP servers in the tools guide
- add matching docs update in Japanese

## Testing
- `pnpm -r build-check` *(fails: Cannot find module '@openai/agents-core')*
- `CI=1 pnpm test` *(fails: Failed to load url @openai/agents-core/_shims)*
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_i_68473ef962ac833191252842e176195a