### PR TITLE
feat(realtime): add changePeerConnection option

### DIFF
--- a/.changeset/change-peer-connection.md
+++ b/.changeset/change-peer-connection.md
@@ -1,5 +1,5 @@
 ---
-'@openai/agents-realtime': minor
+'@openai/agents-realtime': patch
 ---
 
 Add `changePeerConnection` option to `OpenAIRealtimeWebRTC` allowing interception

--- a/.changeset/change-peer-connection.md
+++ b/.changeset/change-peer-connection.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-realtime': minor
+---
+
+Add `changePeerConnection` option to `OpenAIRealtimeWebRTC` allowing interception
+and replacement of the created `RTCPeerConnection` before the offer is made.

--- a/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
@@ -167,10 +167,6 @@ export class OpenAIRealtimeWebRTC
         const connectionUrl = new URL(baseUrl);
 
         let peerConnection: RTCPeerConnection = new RTCPeerConnection();
-        if (this.options.changePeerConnection) {
-          peerConnection =
-            await this.options.changePeerConnection(peerConnection);
-        }
         const dataChannel = peerConnection.createDataChannel('oai-events');
 
         this.#state = {
@@ -237,6 +233,12 @@ export class OpenAIRealtimeWebRTC
             audio: true,
           }));
         peerConnection.addTrack(stream.getAudioTracks()[0]);
+
+        if (this.options.changePeerConnection) {
+          peerConnection =
+            await this.options.changePeerConnection(peerConnection);
+          this.#state = { ...this.#state, peerConnection };
+        }
 
         const offer = await peerConnection.createOffer();
         await peerConnection.setLocalDescription(offer);

--- a/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
@@ -195,4 +195,14 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
     const rtc = new OpenAIRealtimeWebRTC();
     expect(() => rtc.sendEvent({ type: 'test' } as any)).toThrow();
   });
+
+  it('allows overriding the peer connection', async () => {
+    class NewPeerConnection extends FakeRTCPeerConnection {}
+    const custom = new NewPeerConnection();
+    const rtc = new OpenAIRealtimeWebRTC({
+      changePeerConnection: async () => custom as any,
+    });
+    await rtc.connect({ apiKey: 'ek_test' });
+    expect(rtc.connectionState.peerConnection).toBe(custom as any);
+  });
 });


### PR DESCRIPTION
## Summary
- allow overriding the RTCPeerConnection during connection setup via `changePeerConnection`
- test new option
- add a changeset for the new minor feature

## Testing
- `pnpm build`
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_i_68475de5e98c8331b3472e3db36ce562