### PR TITLE
docs: note setDefaultOpenAIKey in quickstart

### DIFF
--- a/docs/src/content/docs/guides/quickstart.mdx
+++ b/docs/src/content/docs/guides/quickstart.mdx
@@ -31,6 +31,10 @@ import quickstartExample from '../../../../../examples/docs/quickstart/index.ts?
    export OPENAI_API_KEY=sk-...
    ```
 
+   Alternatively you can call `setDefaultOpenAIKey('<api key>')` to set the key
+   programmatically and use `setTracingExportApiKey('<api key>')` for tracing.
+   See [the config guide](/openai-agents-js/guides/config) for more details.
+
 </Steps>
 
 ## Create your first agent

--- a/docs/src/content/docs/ja/guides/quickstart.mdx
+++ b/docs/src/content/docs/ja/guides/quickstart.mdx
@@ -31,7 +31,7 @@ import quickstartExample from '../../../../../../examples/docs/quickstart/index.
    export OPENAI_API_KEY=sk-...
    ```
 
-   代わりに `setDefaultOpenAIKey('<api key>')` を呼び出して API キーを設定することもできます。トレーシング用には `setTracingExportApiKey('<api key>')` を使用してください。詳しくは [設定ガイド](/openai-agents-js/guides/config) をご覧ください。
+   代わりに `setDefaultOpenAIKey('<api key>')` を呼び出して API キーを設定することもできます。トレーシング用には `setTracingExportApiKey('<api key>')` を使用してください。詳しくは [設定ガイド](/openai-agents-js/ja/guides/config) をご覧ください。
 
 </Steps>
 

--- a/docs/src/content/docs/ja/guides/quickstart.mdx
+++ b/docs/src/content/docs/ja/guides/quickstart.mdx
@@ -31,6 +31,8 @@ import quickstartExample from '../../../../../../examples/docs/quickstart/index.
    export OPENAI_API_KEY=sk-...
    ```
 
+   代わりに `setDefaultOpenAIKey('<api key>')` を呼び出して API キーを設定することもできます。トレーシング用には `setTracingExportApiKey('<api key>')` を使用してください。詳しくは [設定ガイド](/openai-agents-js/guides/config) をご覧ください。
+
 </Steps>
 
 ## 最初のエージェントの作成


### PR DESCRIPTION
## Summary
- mention `setDefaultOpenAIKey()` and `setTracingExportApiKey()` in quickstart

## Testing
- `pnpm lint`
- `pnpm -r build-check` *(fails: Cannot find module '@openai/agents-extensions')*
- `pnpm build`
- `CI=1 pnpm test`

------
https://chatgpt.com/codex/tasks/task_i_6848ca9d087c833185aecfe2c72ac7b7