### PR TITLE
Add remote MCP server (Streamable HTTP) support; fixes #78

### DIFF
--- a/.changeset/crazy-coats-give.md
+++ b/.changeset/crazy-coats-give.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+Add remote MCP server (Streamable HTTP) support

--- a/examples/mcp/package.json
+++ b/examples/mcp/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build-check": "tsc --noEmit",
     "start:stdio": "tsx filesystem-example.ts",
+    "start:streamable-http": "tsx streamable-http-example.ts",
     "start:hosted-mcp-on-approval": "tsx hosted-mcp-on-approval.ts",
     "start:hosted-mcp-human-in-the-loop": "tsx hosted-mcp-human-in-the-loop.ts",
     "start:hosted-mcp-simple": "tsx hosted-mcp-simple.ts"

--- a/examples/mcp/streamable-http-example.ts
+++ b/examples/mcp/streamable-http-example.ts
@@ -18,7 +18,7 @@ async function main() {
         agent,
         'Which language is this repo written in?',
       );
-      console.log(result.finalOutput ?? result.output ?? result);
+      console.log(result.finalOutput);
     });
   } finally {
     await mcpServer.close();

--- a/examples/mcp/streamable-http-example.ts
+++ b/examples/mcp/streamable-http-example.ts
@@ -1,0 +1,31 @@
+import { Agent, run, MCPServerStreamableHttp, withTrace } from '@openai/agents';
+
+async function main() {
+  const mcpServer = new MCPServerStreamableHttp({
+    url: 'https://gitmcp.io/openai/codex',
+    name: 'GitMCP Documentation Server',
+  });
+  const agent = new Agent({
+    name: 'GitMCP Assistant',
+    instructions: 'Use the tools to respond to user requests.',
+    mcpServers: [mcpServer],
+  });
+
+  try {
+    await withTrace('GitMCP Documentation Server Example', async () => {
+      await mcpServer.connect();
+      const result = await run(
+        agent,
+        'Which language is this repo written in?',
+      );
+      console.log(result.finalOutput ?? result.output ?? result);
+    });
+  } finally {
+    await mcpServer.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -71,6 +71,7 @@ export {
   invalidateServerToolsCache,
   MCPServer,
   MCPServerStdio,
+  MCPServerStreamableHttp,
 } from './mcp';
 export {
   Model,

--- a/packages/agents-core/src/shims/mcp-server/browser.ts
+++ b/packages/agents-core/src/shims/mcp-server/browser.ts
@@ -1,12 +1,38 @@
 import {
   BaseMCPServerStdio,
+  BaseMCPServerStreamableHttp,
   CallToolResultContent,
   MCPServerStdioOptions,
+  MCPServerStreamableHttpOptions,
   MCPTool,
 } from '../../mcp';
 
 export class MCPServerStdio extends BaseMCPServerStdio {
   constructor(params: MCPServerStdioOptions) {
+    super(params);
+  }
+  get name(): string {
+    return 'MCPServerStdio';
+  }
+  connect(): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+  close(): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+  listTools(): Promise<MCPTool[]> {
+    throw new Error('Method not implemented.');
+  }
+  callTool(
+    _toolName: string,
+    _args: Record<string, unknown> | null,
+  ): Promise<CallToolResultContent> {
+    throw new Error('Method not implemented.');
+  }
+}
+
+export class MCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
+  constructor(params: MCPServerStreamableHttpOptions) {
     super(params);
   }
   get name(): string {

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -2,10 +2,12 @@ import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 
 import {
   BaseMCPServerStdio,
+  BaseMCPServerStreamableHttp,
   CallToolResultContent,
   DefaultMCPServerStdioOptions,
   InitializeResult,
   MCPServerStdioOptions,
+  MCPServerStreamableHttpOptions,
   MCPTool,
   invalidateServerToolsCache,
 } from '../../mcp';
@@ -73,6 +75,123 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
         env: this.params.env,
         cwd: this.params.cwd,
       });
+      this.session = new Client({
+        name: this._name,
+        version: '1.0.0', // You may want to make this configurable
+      });
+      await this.session.connect(this.transport);
+      this.serverInitializeResult = {
+        serverInfo: { name: this._name, version: '1.0.0' },
+      } as InitializeResult;
+    } catch (e) {
+      this.logger.error('Error initializing MCP server:', e);
+      await this.close();
+      throw e;
+    }
+    this.debugLog(() => `Connected to MCP server: ${this._name}`);
+  }
+
+  invalidateToolsCache() {
+    invalidateServerToolsCache(this.name);
+    this._cacheDirty = true;
+  }
+
+  // The response element type is intentionally left as `any` to avoid explosing MCP SDK type dependencies.
+  async listTools(): Promise<MCPTool[]> {
+    const { ListToolsResultSchema } = await import(
+      '@modelcontextprotocol/sdk/types.js'
+    ).catch(failedToImport);
+    if (!this.session) {
+      throw new Error(
+        'Server not initialized. Make sure you call connect() first.',
+      );
+    }
+    if (this.cacheToolsList && !this._cacheDirty && this._toolsList) {
+      return this._toolsList;
+    }
+    this._cacheDirty = false;
+    const response = await this.session.listTools();
+    this.debugLog(() => `Listed tools: ${JSON.stringify(response)}`);
+    this._toolsList = ListToolsResultSchema.parse(response).tools;
+    return this._toolsList;
+  }
+
+  async callTool(
+    toolName: string,
+    args: Record<string, unknown> | null,
+  ): Promise<CallToolResultContent> {
+    const { CallToolResultSchema } = await import(
+      '@modelcontextprotocol/sdk/types.js'
+    ).catch(failedToImport);
+    if (!this.session) {
+      throw new Error(
+        'Server not initialized. Make sure you call connect() first.',
+      );
+    }
+    const response = await this.session.callTool({
+      name: toolName,
+      arguments: args ?? {},
+    });
+    const parsed = CallToolResultSchema.parse(response);
+    const result = parsed.content;
+    this.debugLog(
+      () =>
+        `Called tool ${toolName} (args: ${JSON.stringify(args)}, result: ${JSON.stringify(result)})`,
+    );
+    return result as CallToolResultContent;
+  }
+
+  get name() {
+    return this._name;
+  }
+
+  async close(): Promise<void> {
+    if (this.transport) {
+      await this.transport.close();
+      this.transport = null;
+    }
+    if (this.session) {
+      await this.session.close();
+      this.session = null;
+    }
+  }
+}
+
+export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
+  protected session: Client | null = null;
+  protected _cacheDirty = true;
+  protected _toolsList: any[] = [];
+  protected serverInitializeResult: InitializeResult | null = null;
+  protected clientSessionTimeoutSeconds?: number;
+
+  params: MCPServerStreamableHttpOptions;
+  private _name: string;
+  private transport: any = null;
+
+  constructor(params: MCPServerStreamableHttpOptions) {
+    super(params);
+    this.clientSessionTimeoutSeconds = params.clientSessionTimeoutSeconds ?? 5;
+    this.params = params;
+    this._name = params.name || `streamable-http: ${this.params.url}`;
+  }
+
+  async connect(): Promise<void> {
+    try {
+      const { StreamableHTTPClientTransport } = await import(
+        '@modelcontextprotocol/sdk/client/streamableHttp.js'
+      ).catch(failedToImport);
+      const { Client } = await import(
+        '@modelcontextprotocol/sdk/client/index.js'
+      ).catch(failedToImport);
+      this.transport = new StreamableHTTPClientTransport(
+        new URL(this.params.url),
+        {
+          authProvider: this.params.authProvider,
+          requestInit: this.params.requestInit,
+          reconnectionOptions: this.params.reconnectionOptions,
+          sessionId: this.params.sessionId,
+        },
+      );
       this.session = new Client({
         name: this._name,
         version: '1.0.0', // You may want to make this configurable

--- a/packages/agents-core/src/shims/shims-browser.ts
+++ b/packages/agents-core/src/shims/shims-browser.ts
@@ -109,7 +109,7 @@ export function isTracingLoopRunningByDefault(): boolean {
   return false;
 }
 
-export { MCPServerStdio } from './mcp-stdio/browser';
+export { MCPServerStdio, MCPServerStreamableHttp } from './mcp-server/browser';
 
 class BrowserTimer implements Timer {
   constructor() {}

--- a/packages/agents-core/src/shims/shims-node.ts
+++ b/packages/agents-core/src/shims/shims-node.ts
@@ -41,7 +41,10 @@ export function isTracingLoopRunningByDefault(): boolean {
 export function isBrowserEnvironment(): boolean {
   return false;
 }
-export { NodeMCPServerStdio as MCPServerStdio } from './mcp-stdio/node';
+export {
+  NodeMCPServerStdio as MCPServerStdio,
+  NodeMCPServerStreamableHttp as MCPServerStreamableHttp,
+} from './mcp-server/node';
 
 export { clearTimeout } from 'node:timers';
 

--- a/packages/agents-core/src/shims/shims-workerd.ts
+++ b/packages/agents-core/src/shims/shims-workerd.ts
@@ -54,7 +54,7 @@ export function isTracingLoopRunningByDefault(): boolean {
 /**
  * Right now Cloudflare Workers does not support MCP
  */
-export { MCPServerStdio } from './mcp-stdio/browser';
+export { MCPServerStdio, MCPServerStreamableHttp } from './mcp-server/browser';
 
 export { clearTimeout, setTimeout } from 'node:timers';
 

--- a/packages/agents-core/test/mcpCache.test.ts
+++ b/packages/agents-core/test/mcpCache.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { getAllMcpTools } from '../src/mcp';
 import { withTrace } from '../src/tracing';
-import { NodeMCPServerStdio } from '../src/shims/mcp-stdio/node';
+import { NodeMCPServerStdio } from '../src/shims/mcp-server/node';
 import type { CallToolResultContent } from '../src/mcp';
 
 class StubServer extends NodeMCPServerStdio {
@@ -20,7 +20,10 @@ class StubServer extends NodeMCPServerStdio {
     this._toolsList = this.toolList;
     return this.toolList;
   }
-  async callTool(_toolName: string, _args: Record<string, unknown> | null): Promise<CallToolResultContent> {
+  async callTool(
+    _toolName: string,
+    _args: Record<string, unknown> | null,
+  ): Promise<CallToolResultContent> {
     return [];
   }
 }
@@ -29,10 +32,18 @@ describe('MCP tools cache invalidation', () => {
   it('fetches fresh tools after cache invalidation', async () => {
     await withTrace('test', async () => {
       const toolsA = [
-        { name: 'a', description: '', inputSchema: { type: 'object', properties: {} } },
+        {
+          name: 'a',
+          description: '',
+          inputSchema: { type: 'object', properties: {} },
+        },
       ];
       const toolsB = [
-        { name: 'b', description: '', inputSchema: { type: 'object', properties: {} } },
+        {
+          name: 'b',
+          description: '',
+          inputSchema: { type: 'object', properties: {} },
+        },
       ];
       const server = new StubServer('server', toolsA);
 

--- a/packages/agents-core/test/shims/mcp-server/browser.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/browser.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest';
-import { MCPServerStdio } from '../../../src/shims/mcp-stdio/browser';
+import { MCPServerStdio } from '../../../src/shims/mcp-server/browser';
 
 describe('MCPServerStdio', () => {
   test('should be available', async () => {

--- a/packages/agents-core/test/shims/mcp-server/node.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/node.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi, afterAll, beforeAll } from 'vitest';
-import { NodeMCPServerStdio } from '../../../src/shims/mcp-stdio/node';
+import { NodeMCPServerStdio } from '../../../src/shims/mcp-server/node';
 import { TransportSendOptions } from '@modelcontextprotocol/sdk/shared/transport';
 import { JSONRPCMessage } from '@modelcontextprotocol/sdk/types';
 


### PR DESCRIPTION
This pull request adds remote MCP server support (Streamable HTTP) to the `mcpServers` parameter of the Agent constructor. Having this change resolves #78. We don't plan to support SSE, which is now a legacy protocol.