### PR TITLE
Add allowed_tools and headers to hosted mcp server factory method

### DIFF
--- a/.changeset/eighty-dingos-pump.md
+++ b/.changeset/eighty-dingos-pump.md
@@ -1,0 +1,6 @@
+---
+"@openai/agents-core": patch
+"@openai/agents-openai": patch
+---
+
+Add allowed_tools and headers to hosted mcp server factory method

--- a/examples/mcp/filesystem-example.ts
+++ b/examples/mcp/filesystem-example.ts
@@ -16,7 +16,7 @@ async function main() {
   try {
     await withTrace('MCP Filesystem Example', async () => {
       const agent = new Agent({
-        name: 'Assistant',
+        name: 'MCP Assistant',
         instructions:
           'Use the tools to read the filesystem and answer questions based on those files. If you are unable to find any files, you can say so instead of assuming they exist.',
         mcpServers: [mcpServer],
@@ -25,20 +25,20 @@ async function main() {
       let message = 'Read the files and list them.';
       console.log(`Running: ${message}`);
       let result = await run(agent, message);
-      console.log(result.finalOutput ?? result.output ?? result);
+      console.log(result.finalOutput);
 
       // Ask about books
       message = 'What is my #1 favorite book?';
       console.log(`\nRunning: ${message}\n`);
       result = await run(agent, message);
-      console.log(result.finalOutput ?? result.output ?? result);
+      console.log(result.finalOutput);
 
       // Ask a question that reads then reasons
       message =
         'Look at my favorite songs. Suggest one new song that I might like.';
       console.log(`\nRunning: ${message}\n`);
       result = await run(agent, message);
-      console.log(result.finalOutput ?? result.output ?? result);
+      console.log(result.finalOutput);
     });
   } finally {
     await mcpServer.close();

--- a/examples/mcp/hosted-mcp-on-approval.ts
+++ b/examples/mcp/hosted-mcp-on-approval.ts
@@ -14,9 +14,7 @@ async function promptApproval(item: RunToolApprovalItem): Promise<boolean> {
 }
 
 async function main(verbose: boolean, stream: boolean): Promise<void> {
-  // 'always' |
-  // 'never'  |
-  // { never?: { toolNames: string[] }; always?: { toolNames: string[] } }
+  // 'always' | 'never' | { never, always }
   const requireApproval = {
     never: {
       toolNames: ['fetch_codex_documentation', 'fetch_generic_url_content'],
@@ -34,6 +32,7 @@ async function main(verbose: boolean, stream: boolean): Promise<void> {
         serverUrl: 'https://gitmcp.io/openai/codex',
         requireApproval,
         onApproval: async (_context, item) => {
+          // Human in the loop here
           const approval = await promptApproval(item);
           return { approve: approval, reason: undefined };
         },

--- a/examples/mcp/hosted-mcp-simple.ts
+++ b/examples/mcp/hosted-mcp-simple.ts
@@ -9,7 +9,6 @@ async function main(verbose: boolean, stream: boolean): Promise<void> {
         hostedMcpTool({
           serverLabel: 'gitmcp',
           serverUrl: 'https://gitmcp.io/openai/codex',
-          requireApproval: 'never',
         }),
       ],
     });

--- a/packages/agents-core/src/types/providerData.ts
+++ b/packages/agents-core/src/types/providerData.ts
@@ -8,6 +8,8 @@ export type HostedMCPTool<Context = UnknownContext> = {
   type: 'mcp';
   server_label: string;
   server_url: string;
+  allowed_tools?: string[] | { tool_names: string[] };
+  headers?: Record<string, string>;
 } & (
   | { require_approval?: 'never'; on_approval?: never }
   | {

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -191,6 +191,8 @@ function converTool<_TContext = unknown>(
           type: 'mcp',
           server_label: tool.providerData.server_label,
           server_url: tool.providerData.server_url,
+          allowed_tools: tool.providerData.allowed_tools,
+          headers: tool.providerData.headers,
           require_approval: convertMCPRequireApproval(
             tool.providerData.require_approval,
           ),


### PR DESCRIPTION
This pull request adds two more parameters for hosted mcp server tool initialization, which are missing in #33 :
- allowed_tools
- headers