### PR TITLE
Export OpenAI Response object on ResponseSpanData.

### DIFF
--- a/.changeset/clever-needles-flow.md
+++ b/.changeset/clever-needles-flow.md
@@ -1,0 +1,6 @@
+---
+"@openai/agents-core": patch
+"@openai/agents-openai": patch
+---
+
+Add OpenAI Response object on ResponseSpanData for other exporters.

--- a/packages/agents-core/src/tracing/spans.ts
+++ b/packages/agents-core/src/tracing/spans.ts
@@ -1,3 +1,4 @@
+import OpenAI from 'openai';
 import logger from '../logger';
 import { TracingProcessor } from './processor';
 import { generateSpanId, removePrivateFields, timeIso } from './utils';
@@ -38,6 +39,7 @@ export type ResponseSpanData = SpanDataBase & {
    * Not used by the OpenAI tracing provider but helpful for other tracing providers.
    */
   _input?: string | Record<string, any>[];
+  _response?: OpenAI.Responses.Response;
 };
 
 export type HandoffSpanData = SpanDataBase & {

--- a/packages/agents-core/src/tracing/spans.ts
+++ b/packages/agents-core/src/tracing/spans.ts
@@ -1,4 +1,3 @@
-import OpenAI from 'openai';
 import logger from '../logger';
 import { TracingProcessor } from './processor';
 import { generateSpanId, removePrivateFields, timeIso } from './utils';
@@ -39,7 +38,7 @@ export type ResponseSpanData = SpanDataBase & {
    * Not used by the OpenAI tracing provider but helpful for other tracing providers.
    */
   _input?: string | Record<string, any>[];
-  _response?: OpenAI.Responses.Response;
+  _response?: Record<string, any>;
 };
 
 export type HandoffSpanData = SpanDataBase & {

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -10,7 +10,12 @@ import {
 
 import { Trace, NoopTrace } from '../src/tracing/traces';
 
-import { Span, CustomSpanData, NoopSpan } from '../src/tracing/spans';
+import {
+  Span,
+  CustomSpanData,
+  ResponseSpanData,
+  NoopSpan,
+} from '../src/tracing/spans';
 
 import {
   BatchTraceProcessor,
@@ -299,5 +304,29 @@ describe('TraceProvider disabled behaviour', () => {
       trace,
     );
     expect(span).toBeInstanceOf(NoopSpan);
+  });
+});
+
+// -----------------------------------------------------------------------------------------
+// Tests for ResponseSpanData serialization
+// -----------------------------------------------------------------------------------------
+
+describe('ResponseSpanData serialization', () => {
+  it('removes private fields _input and _response from JSON output', () => {
+    const data: ResponseSpanData = {
+      type: 'response',
+      response_id: 'resp_123',
+      _input: 'private input data',
+      _response: { id: 'response_obj' } as any,
+    };
+
+    const span = new Span({ traceId: 'trace_123', data }, new TestProcessor());
+
+    const json = span.toJSON() as any;
+
+    expect(json.span_data.type).toBe('response');
+    expect(json.span_data.response_id).toBe('resp_123');
+    expect(json.span_data).not.toHaveProperty('_input');
+    expect(json.span_data).not.toHaveProperty('_response');
   });
 });

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -837,9 +837,8 @@ export class OpenAIResponsesModel implements Model {
 
       if (request.tracing) {
         span.spanData.response_id = response.id;
-        if (request.tracing === true) {
-          span.spanData._input = request.input;
-        }
+        span.spanData._input = request.input;
+        span.spanData._response = response;
       }
 
       return response;
@@ -931,8 +930,9 @@ export class OpenAIResponsesModel implements Model {
         };
       }
 
-      if (span && finalResponse && request.tracing) {
+      if (request.tracing && span && finalResponse) {
         span.spanData.response_id = finalResponse.id;
+        span.spanData._response = finalResponse;
       }
     } catch (error) {
       if (span) {


### PR DESCRIPTION
Adds `_response` as an attribute to `ResponseSpanData` for use by third-party tracing integrations. 

Adds a test to verify that the new attribute does not get exported to the default tracer. 