### PR TITLE
Consistently use node: prefix in example apps

### DIFF
--- a/examples/agent-patterns/routing.ts
+++ b/examples/agent-patterns/routing.ts
@@ -6,7 +6,7 @@ import {
   StreamedRunResult,
 } from '@openai/agents';
 import readline from 'node:readline/promises';
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 const rl = readline.createInterface({
   input: process.stdin,

--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -4,11 +4,9 @@ import { Agent, run, tool } from '@openai/agents';
 const getWeatherTool = tool({
   name: 'get_weather',
   description: 'Get the weather for a given city',
-  parameters: z.object({
-    demo: z.string(),
-  }),
+  parameters: z.object({ city: z.string() }),
   execute: async (input) => {
-    return `The weather in ${input.demo} is sunny`;
+    return `The weather in ${input.city} is sunny`;
   },
 });
 

--- a/examples/basic/local-image.ts
+++ b/examples/basic/local-image.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import { Agent, run } from '@openai/agents';
 
 const bisonImagePath = path.join(__dirname, 'media/image_bison.jpg');

--- a/examples/customer-service/index.ts
+++ b/examples/customer-service/index.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import readline from 'readline';
+import readline from 'node:readline';
 import { Agent, withTrace, tool, run, RunContext } from '@openai/agents';
 import { RECOMMENDED_PROMPT_PREFIX } from '@openai/agents-core/extensions';
 

--- a/examples/docs/models/customProviders.ts
+++ b/examples/docs/models/customProviders.ts
@@ -2,10 +2,8 @@ import {
   ModelProvider,
   Model,
   ModelRequest,
-  AgentOutputType,
   ModelResponse,
   ResponseStreamEvent,
-  TextOutput,
 } from '@openai/agents-core';
 
 import { Agent, Runner } from '@openai/agents';

--- a/examples/docs/streaming/streamedHITL.ts
+++ b/examples/docs/streaming/streamedHITL.ts
@@ -20,10 +20,10 @@ while (stream.interruptions?.length) {
   );
   const state = stream.state;
   for (const interruption of stream.interruptions) {
-    const ok = await confirm(
+    const approved = confirm(
       `Agent ${interruption.agent.name} would like to use the tool ${interruption.rawItem.name} with "${interruption.rawItem.arguments}". Do you approve?`,
     );
-    if (ok) {
+    if (approved) {
       state.approve(interruption);
     } else {
       state.reject(interruption);

--- a/examples/research-bot/main.ts
+++ b/examples/research-bot/main.ts
@@ -1,7 +1,7 @@
 import { ResearchManager } from './manager';
 
 async function main() {
-  const readline = await import('readline');
+  const readline = await import('node:readline');
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,

--- a/examples/tools/image-generation.ts
+++ b/examples/tools/image-generation.ts
@@ -1,8 +1,8 @@
 import { Agent, run, imageGenerationTool, withTrace } from '@openai/agents';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-import { spawnSync } from 'child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { spawnSync } from 'node:child_process';
 
 function openFile(filePath: string): void {
   if (process.platform === 'darwin') {


### PR DESCRIPTION
This pull request updates the examples to use `node:` prefix when it's necessary.