### PR TITLE
chore(*): types package should be devDependency

### DIFF
--- a/packages/agents-extensions/package.json
+++ b/packages/agents-extensions/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@ai-sdk/provider": "^1.1.3",
     "@openai/zod": "npm:zod@^3.25.40",
-    "@types/ws": "^8.18.1",
     "debug": "^4.4.0"
   },
   "exports": {
@@ -42,6 +41,7 @@
   "devDependencies": {
     "@openai/agents": "workspace:*",
     "@types/debug": "^4.1.12",
+    "@types/ws": "^8.18.1",
     "ws": "^8.18.1"
   },
   "files": [

--- a/packages/agents-realtime/package.json
+++ b/packages/agents-realtime/package.json
@@ -57,7 +57,6 @@
   "dependencies": {
     "@openai/agents-core": "workspace:*",
     "@openai/zod": "npm:zod@^3.25.40",
-    "@types/ws": "^8.18.1",
     "debug": "^4.4.0",
     "ws": "^8.18.1"
   },
@@ -70,6 +69,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/debug": "^4.1.12",
+    "@types/ws": "^8.18.1",
     "vite": "^6.3.5"
   },
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -411,9 +411,6 @@ importers:
       '@openai/zod':
         specifier: npm:zod@^3.25.40
         version: zod@3.25.62
-      '@types/ws':
-        specifier: ^8.18.1
-        version: 8.18.1
       debug:
         specifier: ^4.4.0
         version: 4.4.1
@@ -424,6 +421,9 @@ importers:
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       ws:
         specifier: ^8.18.1
         version: 8.18.2
@@ -458,9 +458,6 @@ importers:
       '@openai/zod':
         specifier: npm:zod@^3.25.40
         version: zod@3.25.62
-      '@types/ws':
-        specifier: ^8.18.1
-        version: 8.18.1
       debug:
         specifier: ^4.4.0
         version: 4.4.1
@@ -471,6 +468,9 @@ importers:
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       vite:
         specifier: ^6.3.5
         version: 6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.1)(yaml@2.7.1)


### PR DESCRIPTION
This pull request reorganizes the dependency structure for `@types/ws` across multiple packages, moving it from `dependencies` to `devDependencies`. The changes also ensure consistency in the `pnpm-lock.yaml` file to reflect this reorganization.

### Dependency Reorganization:

* [`packages/agents-extensions/package.json`](diffhunk://#diff-58469234b407b6f894cc3f17ac2d443f2ec6f2df56848177d73af7cca948b944L18): Moved `@types/ws` from `dependencies` to `devDependencies`. [[1]](diffhunk://#diff-58469234b407b6f894cc3f17ac2d443f2ec6f2df56848177d73af7cca948b944L18) [[2]](diffhunk://#diff-58469234b407b6f894cc3f17ac2d443f2ec6f2df56848177d73af7cca948b944R44)
* [`packages/agents-realtime/package.json`](diffhunk://#diff-94bcc74761fcde2de3546d873089020c681499b0c2ea947f1da34090e812b726L60): Moved `@types/ws` from `dependencies` to `devDependencies`. [[1]](diffhunk://#diff-94bcc74761fcde2de3546d873089020c681499b0c2ea947f1da34090e812b726L60) [[2]](diffhunk://#diff-94bcc74761fcde2de3546d873089020c681499b0c2ea947f1da34090e812b726R72)

### Lockfile Consistency:

* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL414-L416): Updated the `importers` section to reflect the reclassification of `@types/ws` as a `devDependency` for both `agents-extensions` and `agents-realtime` packages. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL414-L416) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR424-R426) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL461-L463) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR471-R473)