### PR TITLE
fix aiSDK providerMetadata wrapping

### DIFF
--- a/docs/src/content/docs/extensions/ai-sdk.mdx
+++ b/docs/src/content/docs/extensions/ai-sdk.mdx
@@ -51,3 +51,33 @@ of supported models that can be brought into the Agents SDK through this adapter
 ## Example
 
 <Code lang="typescript" code={aiSdkSetupExample} title="AI SDK Setup" />
+
+## Passing provider metadata
+
+If you need to send provider-specific options with a message, pass them through
+`providerMetadata`. The values are forwarded directly to the underlying AI SDK
+model. For example, the following `providerData` in the Agents SDK
+
+```ts
+providerData: {
+  anthropic: {
+    cacheControl: {
+      type: 'ephemeral';
+    }
+  }
+}
+```
+
+would become
+
+```ts
+providerMetadata: {
+  anthropic: {
+    cacheControl: {
+      type: 'ephemeral';
+    }
+  }
+}
+```
+
+when using the AI SDK integration.

--- a/docs/src/content/docs/ja/extensions/ai-sdk.mdx
+++ b/docs/src/content/docs/ja/extensions/ai-sdk.mdx
@@ -48,3 +48,29 @@ import aiSdkSetupExample from '../../../../../../examples/docs/extensions/ai-sdk
 ## 例
 
 <Code lang="typescript" code={aiSdkSetupExample} title="AI SDK Setup" />
+
+## プロバイダーメタデータの渡し方
+
+メッセージにプロバイダー固有のオプションを設定したい場合は、`providerMetadata` にその値を直接指定します。例えば Agents SDK で
+
+```ts
+providerData: {
+  anthropic: {
+    cacheControl: {
+      type: 'ephemeral';
+    }
+  }
+}
+```
+
+と指定していた場合、AI SDK 連携では次のようになります。
+
+```ts
+providerMetadata: {
+  anthropic: {
+    cacheControl: {
+      type: 'ephemeral';
+    }
+  }
+}
+```

--- a/packages/agents-extensions/src/aiSdk.ts
+++ b/packages/agents-extensions/src/aiSdk.ts
@@ -50,9 +50,7 @@ export function itemsToLanguageV1Messages(
           role: 'system',
           content: content,
           providerMetadata: {
-            [model.provider]: {
-              ...(providerData ?? {}),
-            },
+            ...(providerData ?? {}),
           },
         });
         continue;
@@ -86,9 +84,7 @@ export function itemsToLanguageV1Messages(
                   throw new UserError(`Unknown content type: ${c.type}`);
                 }),
           providerMetadata: {
-            [model.provider]: {
-              ...(providerData ?? {}),
-            },
+            ...(providerData ?? {}),
           },
         });
         continue;
@@ -115,9 +111,7 @@ export function itemsToLanguageV1Messages(
               throw new UserError(`Unknown content type: ${exhaustiveCheck}`);
             }),
           providerMetadata: {
-            [model.provider]: {
-              ...(providerData ?? {}),
-            },
+            ...(providerData ?? {}),
           },
         });
         continue;
@@ -131,9 +125,7 @@ export function itemsToLanguageV1Messages(
           role: 'assistant',
           content: [],
           providerMetadata: {
-            [model.provider]: {
-              ...(item.providerData ?? {}),
-            },
+            ...(item.providerData ?? {}),
           },
         };
       }
@@ -166,9 +158,7 @@ export function itemsToLanguageV1Messages(
         role: 'tool',
         content: [toolResult],
         providerMetadata: {
-          [model.provider]: {
-            ...(item.providerData ?? {}),
-          },
+          ...(item.providerData ?? {}),
         },
       });
       continue;
@@ -195,9 +185,7 @@ export function itemsToLanguageV1Messages(
         role: 'assistant',
         content: [{ type: 'reasoning', text: item.content[0].text }],
         providerMetadata: {
-          [model.provider]: {
-            ...(item.providerData ?? {}),
-          },
+          ...(item.providerData ?? {}),
         },
       });
       continue;
@@ -416,9 +404,7 @@ export class AiSdkModel implements Model {
             name: toolCall.toolName,
             arguments: toolCall.args,
             status: 'completed',
-            providerData: !result.text
-              ? result.providerMetadata?.[this.#model.provider]
-              : undefined,
+            providerData: !result.text ? result.providerMetadata : undefined,
           });
         });
 
@@ -432,7 +418,7 @@ export class AiSdkModel implements Model {
             content: [{ type: 'output_text', text: result.text }],
             role: 'assistant',
             status: 'completed',
-            providerData: result.providerMetadata?.[this.#model.provider],
+            providerData: result.providerMetadata,
           });
         }
 

--- a/packages/agents-extensions/test/aiSdk.test.ts
+++ b/packages/agents-extensions/test/aiSdk.test.ts
@@ -109,7 +109,7 @@ describe('itemsToLanguageV1Messages', () => {
       {
         role: 'user',
         content: [{ type: 'text', text: 'hi' }],
-        providerMetadata: { stub: {} },
+        providerMetadata: {},
       },
       {
         role: 'assistant',
@@ -121,7 +121,7 @@ describe('itemsToLanguageV1Messages', () => {
             args: {},
           },
         ],
-        providerMetadata: { stub: { a: 1 } },
+        providerMetadata: { a: 1 },
       },
       {
         role: 'tool',
@@ -133,7 +133,7 @@ describe('itemsToLanguageV1Messages', () => {
             result: { type: 'output_text', text: 'out' },
           },
         ],
-        providerMetadata: { stub: { b: 2 } },
+        providerMetadata: { b: 2 },
       },
     ]);
   });
@@ -176,14 +176,14 @@ describe('itemsToLanguageV1Messages', () => {
           { type: 'text', text: 'hi' },
           { type: 'image', image: new URL('http://x/img') },
         ],
-        providerMetadata: { stub: {} },
+        providerMetadata: {},
       },
       {
         role: 'assistant',
         content: [
           { type: 'tool-call', toolCallId: '1', toolName: 'do', args: {} },
         ],
-        providerMetadata: { stub: {} },
+        providerMetadata: {},
       },
       {
         role: 'tool',
@@ -195,12 +195,12 @@ describe('itemsToLanguageV1Messages', () => {
             result: { type: 'output_text', text: 'out' },
           },
         ],
-        providerMetadata: { stub: {} },
+        providerMetadata: {},
       },
       {
         role: 'assistant',
         content: [{ type: 'reasoning', text: 'why' }],
-        providerMetadata: { stub: {} },
+        providerMetadata: {},
       },
     ]);
   });
@@ -219,7 +219,7 @@ describe('itemsToLanguageV1Messages', () => {
       {
         role: 'user',
         content: [{ type: 'text', text: 'hi' }],
-        providerMetadata: { stub: {} },
+        providerMetadata: {},
       },
     ]);
   });
@@ -300,7 +300,7 @@ describe('AiSdkModel.getResponse', () => {
             text: 'ok',
             finishReason: 'stop',
             usage: { promptTokens: 1, completionTokens: 2 },
-            providerMetadata: { stub: { p: 1 } },
+            providerMetadata: { p: 1 },
             rawCall: { rawPrompt: '', rawSettings: {} },
           };
         },
@@ -381,7 +381,7 @@ describe('AiSdkModel.getResponse', () => {
             ],
             finishReason: 'stop',
             usage: { promptTokens: 1, completionTokens: 2 },
-            providerMetadata: { stub: { p: 1 } },
+            providerMetadata: { p: 1 },
             rawCall: { rawPrompt: '', rawSettings: {} },
           };
         },
@@ -771,7 +771,7 @@ describe('AiSdkModel', () => {
             args: {},
           },
         ],
-        providerMetadata: { fake: { meta: 1 } },
+        providerMetadata: { meta: 1 },
       },
     ]);
   });


### PR DESCRIPTION
## Summary
- adjust `AiSdkModel` to forward providerData directly to providerMetadata
- update tests to expect unwrapped providerMetadata
- document how to pass providerMetadata when using the AI SDK integration

## Testing
- `npx pnpm lint`
- `npx pnpm build`
- `CI=1 npx pnpm test`


------
https://chatgpt.com/codex/tasks/task_i_6850f9b766648331bb83d1b5a7474a44