### PR TITLE
fix: use web standard event apis for twilio websocket

### DIFF
--- a/.changeset/shiny-berries-kiss.md
+++ b/.changeset/shiny-berries-kiss.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-extensions': patch
+'@openai/agents-realtime': patch
+---
+
+fix: use web standard event apis for twilio websocket

--- a/.changeset/shiny-berries-kiss.md
+++ b/.changeset/shiny-berries-kiss.md
@@ -1,4 +1,5 @@
 ---
+'@openai/agents': patch
 '@openai/agents-extensions': patch
 '@openai/agents-realtime': patch
 ---

--- a/examples/docs/extensions/twilio-basic.ts
+++ b/examples/docs/extensions/twilio-basic.ts
@@ -9,7 +9,7 @@ const agent = new RealtimeAgent({
 // the OpenAI Realtime API.
 const twilioTransport = new TwilioRealtimeTransportLayer({
   // @ts-expect-error - this is not defined
-  twilioWebSocket: websoketConnection,
+  twilioWebSocket: websocketConnection,
 });
 
 const session = new RealtimeSession(agent, {

--- a/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
+++ b/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
@@ -2,6 +2,9 @@ import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'events';
 import { TwilioRealtimeTransportLayer } from '../src/TwilioRealtimeTransport';
 
+import type { MessageEvent as NodeMessageEvent } from 'ws';
+import type { MessageEvent } from 'undici-types';
+
 vi.mock('@openai/agents/realtime', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { EventEmitter } = require('events');
@@ -30,6 +33,14 @@ class FakeTwilioWebSocket extends EventEmitter {
   send = vi.fn();
   close = vi.fn();
 }
+
+// @ts-expect-error - we're making the node event emitter compatible with the browser event emitter
+FakeTwilioWebSocket.prototype.addEventListener = function (
+  type: string,
+  listener: (evt: MessageEvent | NodeMessageEvent) => void,
+) {
+  this.on(type, (evt) => listener(type === 'message' ? { data: evt } : evt));
+};
 
 const base64 = (data: string) => Buffer.from(data).toString('base64');
 

--- a/packages/agents-extensions/test/index.test.ts
+++ b/packages/agents-extensions/test/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi } from 'vitest';
 import { EventEmitter } from 'events';
 import { TwilioRealtimeTransportLayer } from '../src';
+import type { MessageEvent as NodeMessageEvent } from 'ws';
 
 vi.mock('ws', () => {
   class FakeWebSocket {
@@ -29,6 +30,14 @@ class FakeTwilioWebSocket extends EventEmitter {
   send = vi.fn();
   close = vi.fn();
 }
+
+// @ts-expect-error - we're making the node event emitter compatible with the browser event emitter
+FakeTwilioWebSocket.prototype.addEventListener = function (
+  type: string,
+  listener: (evt: MessageEvent | NodeMessageEvent) => void,
+) {
+  this.on(type, (evt) => listener(type === 'message' ? { data: evt } : evt));
+};
 
 describe('TwilioRealtimeTransportLayer', () => {
   test('should be available', () => {

--- a/packages/agents-realtime/package.json
+++ b/packages/agents-realtime/package.json
@@ -23,6 +23,11 @@
       "default": "./dist/index.mjs"
     },
     "./_shims": {
+      "workerd": {
+        "require": "./dist/shims/shims-workerd.js",
+        "types": "./dist/shims/shims-workerd.d.ts",
+        "default": "./dist/shims/shims-workerd.mjs"
+      },
       "browser": {
         "require": "./dist/shims/shims-browser.js",
         "types": "./dist/shims/shims-browser.d.ts",

--- a/packages/agents-realtime/src/openaiRealtimeWebsocket.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebsocket.ts
@@ -1,5 +1,6 @@
 import {
   isBrowserEnvironment,
+  useWebSocketProtocols,
   WebSocket,
 } from '@openai/agents-realtime/_shims';
 import {
@@ -149,7 +150,8 @@ export class OpenAIRealtimeWebSocket
       );
     }
 
-    const websocketArguments = isBrowserEnvironment()
+    // browsers and workerd should use the protocols argument, node should use the headers argument
+    const websocketArguments = useWebSocketProtocols
       ? [
           'realtime',
           // Auth

--- a/packages/agents-realtime/src/shims/shims-browser.ts
+++ b/packages/agents-realtime/src/shims/shims-browser.ts
@@ -4,3 +4,4 @@ export const WebSocket = globalThis.WebSocket;
 export function isBrowserEnvironment(): boolean {
   return true;
 }
+export const useWebSocketProtocols = true;

--- a/packages/agents-realtime/src/shims/shims-node.ts
+++ b/packages/agents-realtime/src/shims/shims-node.ts
@@ -2,3 +2,4 @@ export { WebSocket } from 'ws';
 export function isBrowserEnvironment(): boolean {
   return false;
 }
+export const useWebSocketProtocols = false;

--- a/packages/agents-realtime/src/shims/shims-workerd.ts
+++ b/packages/agents-realtime/src/shims/shims-workerd.ts
@@ -1,0 +1,4 @@
+export const WebSocket = globalThis.WebSocket;
+export function isBrowserEnvironment(): boolean {
+  return false;
+}

--- a/packages/agents-realtime/src/shims/shims-workerd.ts
+++ b/packages/agents-realtime/src/shims/shims-workerd.ts
@@ -2,3 +2,4 @@ export const WebSocket = globalThis.WebSocket;
 export function isBrowserEnvironment(): boolean {
   return false;
 }
+export const useWebSocketProtocols = true;

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,10 @@ packages:
   - packages/*
   - examples/*
   - docs
+
 onlyBuiltDependencies:
+  - '@tailwindcss/oxide'
   - esbuild
   - sharp
+
 publishBranch: main


### PR DESCRIPTION
the twilio websocket extension used the node `ws` specific apis for attaching event handlers, which made it throw in a cloudflare environment. this patch adds a fix to the types, and uses `.addEventListener` on the websocket instead of `.on`. this also adds a fix to load the right shim for workerd when using `@openai/agents-realtime`