### PR TITLE
Do not cache the toolsList per default

### DIFF
--- a/.changeset/ten-lizards-deny.md
+++ b/.changeset/ten-lizards-deny.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': minor
+---
+
+Don't enable `cacheToolsList` per default for MCP servers

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -45,7 +45,7 @@ export abstract class BaseMCPServerStdio implements MCPServer {
   constructor(options: MCPServerStdioOptions) {
     this.logger =
       options.logger ?? getLogger(DEFAULT_STDIO_MCP_CLIENT_LOGGER_NAME);
-    this.cacheToolsList = options.cacheToolsList ?? true;
+    this.cacheToolsList = options.cacheToolsList ?? false;
   }
 
   abstract get name(): string;
@@ -78,7 +78,7 @@ export abstract class BaseMCPServerStreamableHttp implements MCPServer {
     this.logger =
       options.logger ??
       getLogger(DEFAULT_STREAMABLE_HTTP_MCP_CLIENT_LOGGER_NAME);
-    this.cacheToolsList = options.cacheToolsList ?? true;
+    this.cacheToolsList = options.cacheToolsList ?? false;
   }
 
   abstract get name(): string;

--- a/packages/agents-core/test/mcpCache.test.ts
+++ b/packages/agents-core/test/mcpCache.test.ts
@@ -9,6 +9,7 @@ class StubServer extends NodeMCPServerStdio {
   constructor(name: string, tools: any[]) {
     super({ command: 'noop', name });
     this.toolList = tools;
+    this.cacheToolsList = true;
   }
   async connect(): Promise<void> {}
   async close(): Promise<void> {}


### PR DESCRIPTION
This PR changes the default for `cacheToolsList` from `true` to `false`. The documentation makes is sound like the default is `false` (see https://openai.github.io/openai-agents-js/guides/mcp/#other-things-to-know), and enabling caching has some unwanted side effects, especially when working with multiple local stdio MCP servers.

Defaulting to `false` is the safer option.