### PR TITLE
Fix encoding in tracing exporter #130

### DIFF
--- a/packages/agents-openai/src/openaiTracingExporter.ts
+++ b/packages/agents-openai/src/openaiTracingExporter.ts
@@ -55,6 +55,8 @@ export class OpenAITracingExporter implements TracingExporter {
       data: items.map((items) => items.toJSON()).filter((item) => !!item),
     };
 
+    const body = Buffer.from(JSON.stringify(payload), 'utf8');
+
     let attempts = 0;
     let delay = this.#options.baseDelay;
 
@@ -68,7 +70,7 @@ export class OpenAITracingExporter implements TracingExporter {
             'OpenAI-Beta': 'traces=v1',
             ...HEADERS,
           },
-          body: JSON.stringify(payload),
+          body,
           signal,
         });
 


### PR DESCRIPTION
## Summary
- fix OpenAI tracing exporter body encoding so non-Latin1 chars work
- update tracing exporter tests for new Buffer payload
- add regression test covering Unicode characters

Resolves #130 

## Testing
- `pnpm -r build-check` *(fails: Cannot find module '@openai/agents-core' in examples)*
- `CI=1 pnpm test` *(fails: Failed to load url @openai/agents-core/_shims)*
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_i_68563b9d3aec8331b64b19f61e9b4dab