### PR TITLE
Fix a bug where some of the exceptions thrown from runImplementation.ts could be unhandled

### DIFF
--- a/.changeset/poor-regions-try.md
+++ b/.changeset/poor-regions-try.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+Fix a bug where some of the exceptions thrown from runImplementation.ts could be unhandled

--- a/packages/agents-core/src/result.ts
+++ b/packages/agents-core/src/result.ts
@@ -308,6 +308,9 @@ export class StreamedRunResult<
     }
     this.#error = err;
     this.#completedPromiseReject?.(err);
+    this.#completedPromise.catch((e) => {
+      logger.debug(`Resulted in an error: ${e}`);
+    });
   }
 
   /**


### PR DESCRIPTION
This pull request resolves the issue reported at https://github.com/openai/openai-agents-js/issues/139#issuecomment-2998999137