### PR TITLE
fix: access message history correctly in customer service example

### DIFF
--- a/examples/customer-service/index.ts
+++ b/examples/customer-service/index.ts
@@ -169,9 +169,9 @@ async function main() {
           console.log(`${agentName}: Skipping item: ${newItem.type}`);
         }
       }
-      // Defensive: check if toInputList and lastAgent exist
-      if (typeof (result as any).toInputList === 'function') {
-        inputItems = (result as any).toInputList();
+      // Defensive: check if history and lastAgent exist
+      if ((result as any).history) {
+        inputItems = (result as any).history;
       }
       if ((result as any).lastAgent) {
         currentAgent = (result as any).lastAgent;


### PR DESCRIPTION
When running the customer-service example, I noticed that the assistant messages are currently never added to the `inputItems` collection because the example is looking for a function called `toInputList`, which doesn't exist on the `RunResult` class (I think `to_input_list` is used in the Python SDK though).

However, the `history` getter does exist and should be used instead.