### PR TITLE
fix: merge completed input_audio transcripts into realtime history

### DIFF
--- a/packages/agents-realtime/src/transportLayerEvents.ts
+++ b/packages/agents-realtime/src/transportLayerEvents.ts
@@ -30,6 +30,16 @@ export type TransportLayerAudio = {
   responseId: string;
 };
 
+/**
+ * Event representing the completion of user audio transcription.
+ * Contains the finalized transcript string and the ID of the associated item.
+ */
+export type InputAudioTranscriptionCompletedEvent = {
+  type: 'conversation.item.input_audio_transcription.completed';
+  item_id: string;
+  transcript: string;
+};
+
 export type TransportLayerTranscriptDelta = {
   type: 'transcript_delta';
   itemId: string;
@@ -46,6 +56,7 @@ export type ConnectionStatus = 'connecting' | 'connected' | 'disconnected';
 export type TransportEvent =
   | TransportError
   | TransportToolCallEvent
+  | InputAudioTranscriptionCompletedEvent
   | {
       type: string;
       [key: string]: any;


### PR DESCRIPTION
Resolves #106 
- Adds support for the 'conversation.item.input_audio_transcription.completed' event
- Updates updateRealtimeHistory() to merge transcripts into existing user messages
- Prevents null transcripts from showing as '...' in the UI
- Resolves issue #106  where if a user spoke multiple times before receiving a response, the
SDK would insert a `user` message with a `null` transcript, causing the UI to
render a placeholder ("...").  This PR eliminates need for frontend workaround

Tested with pnpm test and pnpm lint and also in various browsers