### PR TITLE
fix: if prompt is not specified return undefined - fixes #159

### DIFF
--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -365,13 +365,15 @@ function isMessageItem(item: protocol.ModelItem): item is protocol.MessageItem {
   return false;
 }
 
-function getPrompt(prompt: ModelRequest['prompt']): {
-  id: string;
-  version?: string;
-  variables?: Record<string, any>;
-} | null {
+function getPrompt(prompt: ModelRequest['prompt']):
+  | {
+      id: string;
+      version?: string;
+      variables?: Record<string, any>;
+    }
+  | undefined {
   if (!prompt) {
-    return null;
+    return undefined;
   }
 
   const transformedVariables: Record<string, any> = {};


### PR DESCRIPTION
Azure OpenAI Responses API does not accept `null` values. It fails with `400 Unknown parameter: ''` error if `prompt` value is passed as `null`. Returning undefined, removes the prompt field and makes it work with Azure Open AI Responses API.