### PR TITLE
feat: support speed session configuration

### DIFF
--- a/.changeset/silly-geese-wear.md
+++ b/.changeset/silly-geese-wear.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+Adds support for the speed parameter

--- a/packages/agents-realtime/src/clientMessages.ts
+++ b/packages/agents-realtime/src/clientMessages.ts
@@ -83,6 +83,7 @@ export type RealtimeSessionConfig = {
   tools: FunctionToolDefinition[];
   tracing?: RealtimeTracingConfig | null;
   providerData?: Record<string, any>;
+  speed: number;
 };
 
 export type FunctionToolDefinition = {

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -65,6 +65,7 @@ export const DEFAULT_OPENAI_REALTIME_SESSION_CONFIG: Partial<RealtimeSessionConf
     turnDetection: {
       type: 'semantic_vad',
     },
+    speed: 1,
   };
 
 /**
@@ -380,6 +381,7 @@ export abstract class OpenAIRealtimeBase
         this.#model ??
         DEFAULT_OPENAI_REALTIME_SESSION_CONFIG.model,
       voice: config.voice ?? DEFAULT_OPENAI_REALTIME_SESSION_CONFIG.voice,
+      speed: config.speed ?? DEFAULT_OPENAI_REALTIME_SESSION_CONFIG.speed,
       modalities:
         config.modalities ?? DEFAULT_OPENAI_REALTIME_SESSION_CONFIG.modalities,
       input_audio_format:


### PR DESCRIPTION
Adds support for the speed parameter per https://platform.openai.com/docs/api-reference/realtime-sessions/session_object#realtime-sessions/session_object-speed