### PR TITLE
fix: correct typo in RealtimeTransportEventTypes identifier

### DIFF
--- a/.changeset/funny-memes-cover.md
+++ b/.changeset/funny-memes-cover.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+Correct typo in RealtimeTransportEventTypes in code and docs

--- a/docs/src/content/docs/guides/voice-agents/transport.mdx
+++ b/docs/src/content/docs/guides/voice-agents/transport.mdx
@@ -49,7 +49,7 @@ Use any recording/playback library to handle the raw PCM16 audio bytes.
 ### Building your own transport mechanism
 
 If you want to use a different speech-to-speech API or have your own custom transport mechanism, you
-can create your own by implementing the `RealtimeTransportLayer` interface and emit the `RealtimeTranportEventTypes` events.
+can create your own by implementing the `RealtimeTransportLayer` interface and emit the `RealtimeTransportEventTypes` events.
 
 ## Interacting with the Realtime API more directly
 

--- a/docs/src/content/docs/ja/guides/voice-agents/transport.mdx
+++ b/docs/src/content/docs/ja/guides/voice-agents/transport.mdx
@@ -45,7 +45,7 @@ WebRTC の代わりに WebSocket 接続を使用する場合は、セッショ�
 
 ### 独自のトランスポートメカニズムの構築
 
-別の speech-to-speech API を使用したい場合や独自のトランスポートメカニズムを持っている場合は、`RealtimeTransportLayer` インターフェースを実装し、`RealtimeTranportEventTypes` イベントを発火することで独自実装が可能です。
+別の speech-to-speech API を使用したい場合や独自のトランスポートメカニズムを持っている場合は、`RealtimeTransportLayer` インターフェースを実装し、`RealtimeTransportEventTypes` イベントを発火することで独自実装が可能です。
 
 ## Realtime API との直接的なインタラクション
 

--- a/packages/agents-realtime/src/index.ts
+++ b/packages/agents-realtime/src/index.ts
@@ -19,7 +19,7 @@ export {
   TransportLayerTranscriptDelta,
   TransportError,
   TransportToolCallEvent,
-  RealtimeTranportEventTypes,
+  RealtimeTransportEventTypes,
 } from './transportLayerEvents';
 
 export {

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -25,7 +25,7 @@ import {
   RealtimeTransportLayerConnectOptions,
 } from './transportLayer';
 import {
-  RealtimeTranportEventTypes,
+  RealtimeTransportEventTypes,
   TransportToolCallEvent,
 } from './transportLayerEvents';
 import { arrayBufferToBase64, diffRealtimeHistory } from './utils';
@@ -93,7 +93,7 @@ export type OpenAIRealtimeEventTypes = {
    * Triggered when the connection is closed.
    */
   disconnected: [];
-} & RealtimeTranportEventTypes;
+} & RealtimeTransportEventTypes;
 
 export abstract class OpenAIRealtimeBase
   extends EventEmitterDelegate<OpenAIRealtimeEventTypes>

--- a/packages/agents-realtime/src/transportLayer.ts
+++ b/packages/agents-realtime/src/transportLayer.ts
@@ -6,7 +6,7 @@ import {
 } from './clientMessages';
 import { RealtimeItem } from './items';
 import {
-  RealtimeTranportEventTypes,
+  RealtimeTransportEventTypes,
   TransportToolCallEvent,
 } from './transportLayerEvents';
 
@@ -46,7 +46,7 @@ export type RealtimeTransportLayerConnectOptions = {
  * and the communication with the model.
  */
 export interface RealtimeTransportLayer
-  extends EventEmitter<RealtimeTranportEventTypes> {
+  extends EventEmitter<RealtimeTransportEventTypes> {
   status: 'connected' | 'disconnected' | 'connecting' | 'disconnecting';
 
   /**

--- a/packages/agents-realtime/src/transportLayerEvents.ts
+++ b/packages/agents-realtime/src/transportLayerEvents.ts
@@ -51,7 +51,7 @@ export type TransportEvent =
       [key: string]: any;
     };
 
-export type RealtimeTranportEventTypes = {
+export type RealtimeTransportEventTypes = {
   /**
    * A raw event from the transport layer. Allows a user to tap directly into the events of the
    * transport layer.

--- a/packages/agents-realtime/test/stubs.ts
+++ b/packages/agents-realtime/test/stubs.ts
@@ -22,7 +22,7 @@ import type {
   RealtimeTransportLayerConnectOptions,
 } from '../src/transportLayer';
 import type { TransportToolCallEvent } from '../src/transportLayerEvents';
-import { RealtimeTranportEventTypes } from '../src/transportLayerEvents';
+import { RealtimeTransportEventTypes } from '../src/transportLayerEvents';
 
 export const TEST_MODEL_MESSAGE: protocol.AssistantMessageItem = {
   id: '123',
@@ -123,7 +123,7 @@ export class FakeModelProvider implements ModelProvider {
 }
 
 export class FakeTransport
-  extends EventEmitterDelegate<RealtimeTranportEventTypes>
+  extends EventEmitterDelegate<RealtimeTransportEventTypes>
   implements RealtimeTransportLayer
 {
   status: 'connected' | 'disconnected' | 'connecting' | 'disconnecting' =
@@ -135,7 +135,7 @@ export class FakeTransport
   sendAudioCalls: [ArrayBuffer, { commit?: boolean }][] = [];
   updateSessionConfigCalls: Partial<RealtimeSessionConfig>[] = [];
   closeCalls = 0;
-  eventEmitter = new RuntimeEventEmitter<RealtimeTranportEventTypes>();
+  eventEmitter = new RuntimeEventEmitter<RealtimeTransportEventTypes>();
   muteCalls: boolean[] = [];
   sendFunctionCallOutputCalls: [TransportToolCallEvent, string, boolean][] = [];
   interruptCalls = 0;


### PR DESCRIPTION
Renamed all occurrences of `RealtimeTranportEventTypes` to `RealtimeTransportEventTypes`. Confirmed all tests pass. Resolves #166 