### PR TITLE
Fix #175 by removing system.exit calls in the built-in handlers

### DIFF
--- a/.changeset/tame-hotels-hope.md
+++ b/.changeset/tame-hotels-hope.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+Fix #175 by removing internal system.exit calls

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
           version: 10.13.1
           run_install: false  # do manual install to avoid heap memory errors
       - name: Install dependencies
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
         # lower parallelism to save RAM
         run: pnpm install --frozen-lockfile --network-concurrency=1
       - name: Build all packages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: "--max_old_space_size=4096"
     strategy:
       matrix:
         # https://nodejs.org/en/about/previous-releases
@@ -15,20 +17,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 10.13.1
-          run_install: false  # do manual install to avoid heap memory errors
+          run_install: false
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
       - name: Install dependencies
-        env:
-          NODE_OPTIONS: --max_old_space_size=4096
-        # lower parallelism to save RAM
-        run: pnpm install --frozen-lockfile --network-concurrency=1
+        run: pnpm install
       - name: Build all packages
         run: pnpm build
       - name: Run linter

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,11 +19,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 10.13.1
-          run_install: true
+          run_install: false  # do manual install to avoid heap memory errors
+      - name: Install dependencies
+        # lower parallelism to save RAM
+        run: pnpm install --frozen-lockfile --network-concurrency=1
       - name: Build all packages
         run: pnpm build
       - name: Run linter

--- a/packages/agents-core/src/tracing/provider.ts
+++ b/packages/agents-core/src/tracing/provider.ts
@@ -188,19 +188,16 @@ export class TraceProvider {
       // Handle CTRL+C (SIGINT)
       process.on('SIGINT', async () => {
         await cleanup();
-        process.exit(130);
       });
 
       // Handle termination (SIGTERM)
       process.on('SIGTERM', async () => {
         await cleanup();
-        process.exit(0);
       });
 
       process.on('unhandledRejection', async (reason, promise) => {
         logger.error('Unhandled rejection', reason, promise);
         await cleanup();
-        process.exit(1);
       });
     }
   }

--- a/packages/agents-core/src/tracing/provider.ts
+++ b/packages/agents-core/src/tracing/provider.ts
@@ -188,16 +188,28 @@ export class TraceProvider {
       // Handle CTRL+C (SIGINT)
       process.on('SIGINT', async () => {
         await cleanup();
+        if (!hasOtherListenersForSignals('SIGINT')) {
+          // Only when there are no other listeners, exit the process on this SDK side
+          process.exit(130);
+        }
       });
 
       // Handle termination (SIGTERM)
       process.on('SIGTERM', async () => {
         await cleanup();
+        if (!hasOtherListenersForSignals('SIGTERM')) {
+          // Only when there are no other listeners, exit the process on this SDK side
+          process.exit(0);
+        }
       });
 
       process.on('unhandledRejection', async (reason, promise) => {
         logger.error('Unhandled rejection', reason, promise);
         await cleanup();
+        if (!hasOtherListenersForEvents('unhandledRejection')) {
+          // Only when there are no other listeners, exit the process on this SDK side
+          process.exit(1);
+        }
       });
     }
   }
@@ -205,6 +217,14 @@ export class TraceProvider {
   async forceFlush(): Promise<void> {
     await this.#multiProcessor.forceFlush();
   }
+}
+
+function hasOtherListenersForSignals(event: 'SIGINT' | 'SIGTERM'): boolean {
+  return process.listeners(event).length > 1;
+}
+
+function hasOtherListenersForEvents(event: 'unhandledRejection'): boolean {
+  return process.listeners(event).length > 1;
 }
 
 let GLOBAL_TRACE_PROVIDER: TraceProvider | undefined = undefined;


### PR DESCRIPTION
This pull request resolves #175 and related reports. This commit https://github.com/openai/openai-agents-js/commit/25165dfe29de59014398dea503b4bf5282fb9d23 in #45 introduced system.exit calls, which didn't exist before the fix. So, reverting them should make sense. An alternative approach would be to introduce a new flag env variable to turn this on/off but I don't think it's necessary.