### PR TITLE
feat: console @ai-sdk generation warnings

### DIFF
--- a/packages/agents-extensions/src/aiSdk.ts
+++ b/packages/agents-extensions/src/aiSdk.ts
@@ -446,6 +446,20 @@ export class AiSdkModel implements Model {
 
         const result = await this.#model.doGenerate(aiSdkRequest);
 
+        for (const warning of result.warnings ?? []) {
+          this.#logger.warn(`@ai-sdk generation warning`, {
+            type: warning.type,
+            message: (warning as any)?.message ?? 'Unknown warning',
+            details: (warning as any)?.details ?? 'Unknown details',
+            model: {
+              modelId: this.#model.modelId,
+              version: this.#model.specificationVersion,
+              provider: this.#model.provider,
+              supportsStructuredOutputs: this.#model.supportsStructuredOutputs,
+            },
+          });
+        }
+
         const output: ModelResponse['output'] = [];
 
         result.toolCalls?.forEach((toolCall) => {


### PR DESCRIPTION
example warning log with `@ai-sdk/anthropic@1.2.12`

```
@ai-sdk generation {
  type: 'unsupported-setting',
  message: 'Unknown warning',
  details: 'JSON response format is not supported.',
  model: {
    modelId: 'claude-3-7-sonnet-20250219',
    version: 'v1',
    provider: 'anthropic.messages',
    supportsStructuredOutputs: undefined
  }
}
```