### PR TITLE
Update quickstart.mdx - outdated example for tool call. 

### DIFF
--- a/docs/src/content/docs/guides/quickstart.mdx
+++ b/docs/src/content/docs/guides/quickstart.mdx
@@ -85,6 +85,13 @@ const historyFunFact = tool({
   name: 'history_fun_fact',
   // The description is used to describe **when** to use the tool by telling it **what** it does.
   description: 'Give a fun fact about a historical event',
+  // This agent takes no parameters, so we provide an empty JSON schema.
+  parameters: {
+    type: 'object',
+    properties: {},
+    required: [],
+    additionalProperties: false
+  }
   execute: async () => {
     // The output will be returned back to the Agent to use
     return 'Sharks are older than trees.';


### PR DESCRIPTION
The given example doesn’t work anymore because the “parameters” field is now required.
I wasent able to run it without providing a JSON Schema for parameters. 