### PR TITLE
Tentative fix for #187 : Lock zod version to <=3.25.67 (prev: >=3.25.40 <4)

### DIFF
--- a/.changeset/odd-rice-call.md
+++ b/.changeset/odd-rice-call.md
@@ -1,0 +1,8 @@
+---
+'@openai/agents-extensions': patch
+'@openai/agents-realtime': patch
+'@openai/agents-openai': patch
+'@openai/agents-core': patch
+---
+
+Tentative fix for #187 : Lock zod version to <=3.25.67

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.12.1
+          version: 10.13.1
           run_install: true
       - name: Build all packages
         run: pnpm build

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -156,7 +156,7 @@
         "xxhash-wasm": "^1.1.0",
         "yargs-parser": "^21.1.1",
         "yocto-spinner": "^0.2.1",
-        "zod": "~3.25.40",
+        "zod": "3.25.40 - 3.25.67",
         "zod-to-json-schema": "^3.24.5",
         "zod-to-ts": "^1.2.0"
       },

--- a/examples/agent-patterns/package.json
+++ b/examples/agent-patterns/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@openai/agents": "workspace:*",
     "chalk": "^5.4.1",
-    "zod": "~3.25.40"
+    "zod": "3.25.40 - 3.25.67"
   },
   "scripts": {
     "build-check": "tsc --noEmit",

--- a/examples/ai-sdk/package.json
+++ b/examples/ai-sdk/package.json
@@ -5,7 +5,7 @@
     "@openai/agents": "workspace:*",
     "@openai/agents-extensions": "workspace:*",
     "@ai-sdk/openai": "^1.1.3",
-    "zod": "~3.25.40"
+    "zod": "3.25.40 - 3.25.67"
   },
   "scripts": {
     "build-check": "tsc --noEmit",

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -3,7 +3,7 @@
   "name": "basic",
   "dependencies": {
     "@openai/agents": "workspace:*",
-    "zod": "~3.25.40"
+    "zod": "3.25.40 - 3.25.67"
   },
   "scripts": {
     "build-check": "tsc --noEmit",

--- a/examples/customer-service/package.json
+++ b/examples/customer-service/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@openai/agents": "workspace:*",
     "@openai/agents-core": "workspace:*",
-    "zod": "~3.25.40"
+    "zod": "3.25.40 - 3.25.67"
   },
   "scripts": {
     "build-check": "tsc --noEmit",

--- a/examples/docs/package.json
+++ b/examples/docs/package.json
@@ -9,7 +9,7 @@
     "@ai-sdk/openai": "^1.0.0",
     "server-only": "^0.0.1",
     "openai": "^5.0.1",
-    "zod": "~3.25.40"
+    "zod": "3.25.40 - 3.25.67"
   },
   "scripts": {
     "build-check": "tsc --noEmit"

--- a/examples/financial-research-agent/package.json
+++ b/examples/financial-research-agent/package.json
@@ -3,7 +3,7 @@
   "name": "financial-research-agent",
   "dependencies": {
     "@openai/agents": "workspace:*",
-    "zod": "~3.25.40"
+    "zod": "3.25.40 - 3.25.67"
   },
   "scripts": {
     "build-check": "tsc --noEmit",

--- a/examples/handoffs/package.json
+++ b/examples/handoffs/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@openai/agents": "workspace:*",
     "@openai/agents-core": "workspace:*",
-    "zod": "~3.25.40"
+    "zod": "3.25.40 - 3.25.67"
   },
   "scripts": {
     "build-check": "tsc --noEmit",

--- a/examples/mcp/package.json
+++ b/examples/mcp/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
     "@openai/agents": "workspace:*",
-    "zod": "~3.25.40"
+    "zod": "3.25.40 - 3.25.67"
   },
   "scripts": {
     "build-check": "tsc --noEmit",

--- a/examples/model-providers/package.json
+++ b/examples/model-providers/package.json
@@ -3,7 +3,7 @@
   "name": "model-providers",
   "dependencies": {
     "@openai/agents": "workspace:*",
-    "zod": "~3.25.40"
+    "zod": "3.25.40 - 3.25.67"
   },
   "scripts": {
     "build-check": "tsc --noEmit",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.3.1",
     "wavtools": "^0.1.5",
-    "zod": "~3.25.40"
+    "zod": "3.25.40 - 3.25.67"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/examples/realtime-next/package.json
+++ b/examples/realtime-next/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.3.0",
     "wavtools": "^0.1.5",
-    "zod": "~3.25.40"
+    "zod": "3.25.40 - 3.25.67"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/examples/realtime-twilio/package.json
+++ b/examples/realtime-twilio/package.json
@@ -9,7 +9,7 @@
     "dotenv": "^16.5.0",
     "fastify": "^5.3.3",
     "ws": "^8.18.1",
-    "zod": "~3.25.40"
+    "zod": "3.25.40 - 3.25.67"
   },
   "scripts": {
     "build-check": "tsc --noEmit",

--- a/examples/research-bot/package.json
+++ b/examples/research-bot/package.json
@@ -3,7 +3,7 @@
   "name": "research-bot",
   "dependencies": {
     "@openai/agents": "workspace:*",
-    "zod": "~3.25.40"
+    "zod": "3.25.40 - 3.25.67"
   },
   "scripts": {
     "build-check": "tsc --noEmit",

--- a/examples/tools/package.json
+++ b/examples/tools/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@openai/agents": "workspace:*",
     "playwright": "^1.52.0",
-    "zod": "~3.25.40"
+    "zod": "3.25.40 - 3.25.67"
   },
   "scripts": {
     "build-check": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -67,5 +67,5 @@
     "verdaccio": "^6.1.2",
     "vitest": "^3.2.3"
   },
-  "packageManager": "pnpm@10.12.1"
+  "packageManager": "pnpm@10.13.1"
 }

--- a/packages/agents-core/package.json
+++ b/packages/agents-core/package.json
@@ -88,12 +88,12 @@
     "@modelcontextprotocol/sdk": "^1.12.0"
   },
   "dependencies": {
-    "@openai/zod": "npm:zod@^3.25.40",
+    "@openai/zod": "npm:zod@3.25.40 - 3.25.67",
     "debug": "^4.4.0",
     "openai": "^5.0.1"
   },
   "peerDependencies": {
-    "zod": "^3.25.40"
+    "zod": "3.25.40 - 3.25.67"
   },
   "peerDependenciesMeta": {
     "zod": {
@@ -121,7 +121,7 @@
   },
   "devDependencies": {
     "@types/debug": "^4.1.12",
-    "zod": "^3.25.40"
+    "zod": "3.25.40 - 3.25.67"
   },
   "files": [
     "dist"

--- a/packages/agents-core/src/metadata.ts
+++ b/packages/agents-core/src/metadata.ts
@@ -6,7 +6,7 @@ export const METADATA = {
   "version": "0.0.7",
   "versions": {
     "@openai/agents-core": "0.0.7",
-    "@openai/zod": "npm:zod@^3.25.40",
+    "@openai/zod": "npm:zod@3.25.40 - 3.25.67",
     "openai": "^5.0.1"
   }
 };

--- a/packages/agents-extensions/package.json
+++ b/packages/agents-extensions/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@ai-sdk/provider": "^1.1.3",
-    "@openai/zod": "npm:zod@^3.25.40",
+    "@openai/zod": "npm:zod@3.25.40 - 3.25.67",
     "@types/ws": "^8.18.1",
     "debug": "^4.4.0"
   },

--- a/packages/agents-extensions/src/metadata.ts
+++ b/packages/agents-extensions/src/metadata.ts
@@ -6,7 +6,7 @@ export const METADATA = {
   "version": "0.0.7",
   "versions": {
     "@openai/agents-extensions": "0.0.7",
-    "@openai/zod": "npm:zod@^3.25.40"
+    "@openai/zod": "npm:zod@3.25.40 - 3.25.67"
   }
 };
 

--- a/packages/agents-openai/package.json
+++ b/packages/agents-openai/package.json
@@ -21,7 +21,7 @@
     "@openai/agents-core": "workspace:*",
     "debug": "^4.4.0",
     "openai": "^5.0.1",
-    "@openai/zod": "npm:zod@^3.25.40"
+    "@openai/zod": "npm:zod@3.25.40 - 3.25.67"
   },
   "scripts": {
     "prebuild": "tsx ../../scripts/embedMeta.ts",

--- a/packages/agents-openai/src/metadata.ts
+++ b/packages/agents-openai/src/metadata.ts
@@ -8,7 +8,7 @@ export const METADATA = {
     "@openai/agents-openai": "0.0.7",
     "@openai/agents-core": "workspace:*",
     "openai": "^5.0.1",
-    "@openai/zod": "npm:zod@^3.25.40"
+    "@openai/zod": "npm:zod@3.25.40 - 3.25.67"
   }
 };
 

--- a/packages/agents-realtime/package.json
+++ b/packages/agents-realtime/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@openai/agents-core": "workspace:*",
-    "@openai/zod": "npm:zod@^3.25.40",
+    "@openai/zod": "npm:zod@3.25.40 - 3.25.67",
     "@types/ws": "^8.18.1",
     "debug": "^4.4.0",
     "ws": "^8.18.1"

--- a/packages/agents-realtime/src/metadata.ts
+++ b/packages/agents-realtime/src/metadata.ts
@@ -7,7 +7,7 @@ export const METADATA = {
   "versions": {
     "@openai/agents-realtime": "0.0.7",
     "@openai/agents-core": "workspace:*",
-    "@openai/zod": "npm:zod@^3.25.40"
+    "@openai/zod": "npm:zod@3.25.40 - 3.25.67"
   }
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,7 +124,7 @@ importers:
         specifier: ^5.4.1
         version: 5.4.1
       zod:
-        specifier: ~3.25.40
+        specifier: 3.25.40 - 3.25.67
         version: 3.25.62
 
   examples/ai-sdk:
@@ -139,7 +139,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/agents-extensions
       zod:
-        specifier: ~3.25.40
+        specifier: 3.25.40 - 3.25.67
         version: 3.25.62
 
   examples/basic:
@@ -148,7 +148,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/agents
       zod:
-        specifier: ~3.25.40
+        specifier: 3.25.40 - 3.25.67
         version: 3.25.62
 
   examples/customer-service:
@@ -160,7 +160,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/agents-core
       zod:
-        specifier: ~3.25.40
+        specifier: 3.25.40 - 3.25.67
         version: 3.25.62
 
   examples/docs:
@@ -187,7 +187,7 @@ importers:
         specifier: ^0.0.1
         version: 0.0.1
       zod:
-        specifier: ~3.25.40
+        specifier: 3.25.40 - 3.25.67
         version: 3.25.62
     devDependencies:
       typedoc-plugin-zod:
@@ -200,7 +200,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/agents
       zod:
-        specifier: ~3.25.40
+        specifier: 3.25.40 - 3.25.67
         version: 3.25.62
 
   examples/handoffs:
@@ -212,7 +212,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/agents-core
       zod:
-        specifier: ~3.25.40
+        specifier: 3.25.40 - 3.25.67
         version: 3.25.62
 
   examples/mcp:
@@ -224,7 +224,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/agents
       zod:
-        specifier: ~3.25.40
+        specifier: 3.25.40 - 3.25.67
         version: 3.25.62
 
   examples/model-providers:
@@ -233,7 +233,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/agents
       zod:
-        specifier: ~3.25.40
+        specifier: 3.25.40 - 3.25.67
         version: 3.25.62
 
   examples/nextjs:
@@ -275,7 +275,7 @@ importers:
         specifier: ^0.1.5
         version: 0.1.5
       zod:
-        specifier: ~3.25.40
+        specifier: 3.25.40 - 3.25.67
         version: 3.25.62
     devDependencies:
       '@tailwindcss/postcss':
@@ -352,7 +352,7 @@ importers:
         specifier: ^0.1.5
         version: 0.1.5
       zod:
-        specifier: ~3.25.40
+        specifier: 3.25.40 - 3.25.67
         version: 3.25.62
     devDependencies:
       '@tailwindcss/postcss':
@@ -398,7 +398,7 @@ importers:
         specifier: ^8.18.1
         version: 8.18.2
       zod:
-        specifier: ~3.25.40
+        specifier: 3.25.40 - 3.25.67
         version: 3.25.62
 
   examples/research-bot:
@@ -407,7 +407,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/agents
       zod:
-        specifier: ~3.25.40
+        specifier: 3.25.40 - 3.25.67
         version: 3.25.62
 
   examples/tools:
@@ -419,7 +419,7 @@ importers:
         specifier: ^1.52.0
         version: 1.53.0
       zod:
-        specifier: ~3.25.40
+        specifier: 3.25.40 - 3.25.67
         version: 3.25.62
 
   packages/agents:
@@ -447,7 +447,7 @@ importers:
   packages/agents-core:
     dependencies:
       '@openai/zod':
-        specifier: npm:zod@^3.25.40
+        specifier: npm:zod@3.25.40 - 3.25.67
         version: zod@3.25.62
       debug:
         specifier: ^4.4.0
@@ -460,7 +460,7 @@ importers:
         specifier: ^4.1.12
         version: 4.1.12
       zod:
-        specifier: ^3.25.40
+        specifier: 3.25.40 - 3.25.67
         version: 3.25.62
     optionalDependencies:
       '@modelcontextprotocol/sdk':
@@ -473,7 +473,7 @@ importers:
         specifier: ^1.1.3
         version: 1.1.3
       '@openai/zod':
-        specifier: npm:zod@^3.25.40
+        specifier: npm:zod@3.25.40 - 3.25.67
         version: zod@3.25.62
       '@types/ws':
         specifier: ^8.18.1
@@ -498,7 +498,7 @@ importers:
         specifier: workspace:*
         version: link:../agents-core
       '@openai/zod':
-        specifier: npm:zod@^3.25.40
+        specifier: npm:zod@3.25.40 - 3.25.67
         version: zod@3.25.62
       debug:
         specifier: ^4.4.0
@@ -520,7 +520,7 @@ importers:
         specifier: workspace:*
         version: link:../agents-core
       '@openai/zod':
-        specifier: npm:zod@^3.25.40
+        specifier: npm:zod@3.25.40 - 3.25.67
         version: zod@3.25.62
       '@types/ws':
         specifier: ^8.18.1


### PR DESCRIPTION
This pull applies a quick workaround of #187 for everyone; Ultimately, we should resolve the compatibility with the latest (more specifically 3.25.68 and any newer versions), but for now, this fix is crucial for onboarding with this SDK.