### PR TITLE
Handle function call messages with empty content

### DIFF
--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -67,7 +67,7 @@ export class OpenAIChatCompletionsModel implements Model {
     const output: protocol.OutputModelItem[] = [];
     if (response.choices && response.choices[0]) {
       const message = response.choices[0].message;
-      if (message.content !== undefined && message.content !== null) {
+      if (message.content !== undefined && message.content !== null && message.content !== '') {
         const { content, ...rest } = message;
         output.push({
           id: response.id,


### PR DESCRIPTION
When using OpenAI, assisnt reply tool-call like so

```
{
  "role": "assistant",
  "content": null,
  "tool_calls": [...]
}
```

When dealing with images, Azure OpenAI chat completions endpoint return an empty string instead of null

(example) 

```
{
  "role": "assistant",
  "content": "",
  "tool_calls": [
    {
      "id": "call_RoAWzCh7KdKkR3LhmA9H0hqN",
      "type": "function",
      "function": {
        "name": "verify_invoice_number",
        "arguments": "{\"query\":\"74012938475019283746502391\"}"
      }
    }
  ]
}

```

Because the parser rejects this shape, the SDK:
1. treats the message as an ordinary assistant response,
2. never invokes the tool’s execute() handler,
3. asks the model to “try again,” and
4. eventually throws “Max turns (N) exceeded.”


# Reproduction steps
1. Create any agent with a simple tool (e.g., check_image_color).2
2. set OpenAI client but with Azure as the endpoint
3. Call await run(agent, [{ role: "user", content: <some image> }])

