### PR TITLE
Feat: api client invalidation

### DIFF
--- a/.changeset/tasty-dots-relax.md
+++ b/.changeset/tasty-dots-relax.md
@@ -1,0 +1,9 @@
+---
+'@openai/agents-extensions': patch
+'@openai/agents-realtime': patch
+'@openai/agents-openai': patch
+'@openai/agents-core': patch
+'@openai/agents': patch
+---
+
+introduce api client invalidation

--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -383,7 +383,7 @@ export class Agent<
   }
 
   /**
-   * Ouput schema name
+   * Output schema name
    */
   get outputSchemaName(): string {
     if (this.outputType === 'text') {

--- a/packages/agents-core/src/metadata.ts
+++ b/packages/agents-core/src/metadata.ts
@@ -3,9 +3,9 @@
 
 export const METADATA = {
   "name": "@openai/agents-core",
-  "version": "0.0.7",
+  "version": "0.0.11",
   "versions": {
-    "@openai/agents-core": "0.0.7",
+    "@openai/agents-core": "0.0.11",
     "@openai/zod": "npm:zod@3.25.40 - 3.25.67",
     "openai": "^5.0.1"
   }

--- a/packages/agents-extensions/src/metadata.ts
+++ b/packages/agents-extensions/src/metadata.ts
@@ -3,9 +3,9 @@
 
 export const METADATA = {
   "name": "@openai/agents-extensions",
-  "version": "0.0.7",
+  "version": "0.0.11",
   "versions": {
-    "@openai/agents-extensions": "0.0.7",
+    "@openai/agents-extensions": "0.0.11",
     "@openai/zod": "npm:zod@3.25.40 - 3.25.67"
   }
 };

--- a/packages/agents-openai/package.json
+++ b/packages/agents-openai/package.json
@@ -2,7 +2,7 @@
   "name": "@openai/agents-openai",
   "repository": "https://github.com/openai/openai-agents-js",
   "homepage": "https://openai.github.io/openai-agents-js/",
-  "version": "0.0.11-D",
+  "version": "0.0.11",
   "description": "The OpenAI Agents SDK is a lightweight yet powerful framework for building multi-agent workflows.",
   "author": "OpenAI <support@openai.com>",
   "main": "dist/index.js",

--- a/packages/agents-openai/package.json
+++ b/packages/agents-openai/package.json
@@ -2,7 +2,7 @@
   "name": "@openai/agents-openai",
   "repository": "https://github.com/openai/openai-agents-js",
   "homepage": "https://openai.github.io/openai-agents-js/",
-  "version": "0.0.11",
+  "version": "0.0.11-D",
   "description": "The OpenAI Agents SDK is a lightweight yet powerful framework for building multi-agent workflows.",
   "author": "OpenAI <support@openai.com>",
   "main": "dist/index.js",

--- a/packages/agents-openai/src/defaults.ts
+++ b/packages/agents-openai/src/defaults.ts
@@ -13,16 +13,28 @@ let _defaultTracingApiKey: string | undefined = undefined;
 // Registry for tracking OpenAI providers that need to be notified of key changes
 const _providerRegistry = new Set<{ invalidateClient(): void }>();
 
+/**
+ * Registers an OpenAI provider to receive notifications when the default API key or client changes.
+ * @param provider The provider to register for key change notifications
+ */
 export function registerOpenAIProvider(provider: { invalidateClient(): void }) {
   _providerRegistry.add(provider);
 }
 
+/**
+ * Unregisters an OpenAI provider from key change notifications.
+ * @param provider The provider to unregister
+ */
 export function unregisterOpenAIProvider(provider: {
   invalidateClient(): void;
 }) {
   _providerRegistry.delete(provider);
 }
 
+/**
+ * Notifies all registered providers that the default API key or client has changed.
+ * This causes providers to invalidate their cached clients.
+ */
 function notifyProvidersOfKeyChange() {
   _providerRegistry.forEach((provider) => {
     try {
@@ -50,28 +62,31 @@ export function setOpenAIAPI(value: 'chat_completions' | 'responses') {
   _defaultOpenAIAPI = value;
 }
 
+/**
+ * Sets the default OpenAI client to use for all providers.
+ * This will invalidate cached clients in existing providers that rely on the default client.
+ * @param client The OpenAI client to use as the default
+ */
 export function setDefaultOpenAIClient(client: OpenAI) {
-  console.log('Setting default OpenAI client', client.project, client.apiKey);
   _defaultOpenAIClient = client;
+  notifyProvidersOfKeyChange();
 }
 
 export function getDefaultOpenAIClient(): OpenAI | undefined {
-  console.log(
-    'Getting default OpenAI client',
-    _defaultOpenAIClient?.project,
-    _defaultOpenAIClient?.apiKey,
-  );
   return _defaultOpenAIClient;
 }
 
+/**
+ * Sets the default OpenAI API key to use for all providers.
+ * This will invalidate cached clients in existing providers that rely on the default key.
+ * @param key The OpenAI API key to use as the default
+ */
 export function setDefaultOpenAIKey(key: string) {
-  console.log('setting default OpenAI key', key);
   _defaultOpenAIKey = key;
   notifyProvidersOfKeyChange();
 }
 
 export function getDefaultOpenAIKey(): string | undefined {
-  console.log('getting default OpenAI key', _defaultOpenAIKey);
   return _defaultOpenAIKey ?? loadEnv().OPENAI_API_KEY;
 }
 

--- a/packages/agents-openai/src/metadata.ts
+++ b/packages/agents-openai/src/metadata.ts
@@ -3,9 +3,9 @@
 
 export const METADATA = {
   "name": "@openai/agents-openai",
-  "version": "0.0.7",
+  "version": "0.0.11-D",
   "versions": {
-    "@openai/agents-openai": "0.0.7",
+    "@openai/agents-openai": "0.0.11-D",
     "@openai/agents-core": "workspace:*",
     "openai": "^5.0.1",
     "@openai/zod": "npm:zod@3.25.40 - 3.25.67"

--- a/packages/agents-openai/src/openaiProvider.ts
+++ b/packages/agents-openai/src/openaiProvider.ts
@@ -41,11 +41,9 @@ export class OpenAIProvider implements ModelProvider {
       if (this.#options.baseURL) {
         throw new Error('Cannot provide both baseURL and openAIClient');
       }
-      console.log('Using provided OpenAI client');
       this.#client = this.#options.openAIClient;
       this.#shouldRegisterForKeyChanges = false;
     } else {
-      console.log('Using default OpenAI client');
       // Only register for key changes if we don't have a pre-built client
       // and don't have a specific API key (using default key)
       this.#shouldRegisterForKeyChanges = !this.#options.apiKey;
@@ -60,17 +58,16 @@ export class OpenAIProvider implements ModelProvider {
    * Invalidates the cached client. Called when the default API key changes.
    */
   invalidateClient(): void {
-    console.log('Invalidating OpenAI client due to key change');
     this.#client = undefined;
   }
 
   /**
    * Cleanup method to unregister from key change notifications.
-   * Should be called when the provider is no longer needed.
+   * Should be called when the provider is no longer needed to prevent memory leaks.
+   * Only providers that use the default API key need to call this method.
    */
   destroy(): void {
     if (this.#shouldRegisterForKeyChanges) {
-      console.log('Unregistering OpenAI provider for key changes');
       unregisterOpenAIProvider(this);
     }
   }
@@ -80,10 +77,8 @@ export class OpenAIProvider implements ModelProvider {
    * never actually use the client.
    */
   #getClient(): OpenAI {
-    console.log('Getting OpenAI client');
     // If the constructor does not accept the OpenAI client,
     if (!this.#client) {
-      console.log('Creating new OpenAI client', this.#options);
       this.#client =
         // this provider checks if there is the default client first,
         getDefaultOpenAIClient() ??
@@ -95,11 +90,13 @@ export class OpenAIProvider implements ModelProvider {
           project: this.#options.project,
         });
     }
+    // LEFT ON PURPOSE: will delete when merged
     console.log(
-      'Returning OpenAI client:',
-      this.#client.apiKey,
+      'Using OpenAI client',
       this.#client.project,
+      this.#client.apiKey,
     );
+    // Return
     return this.#client;
   }
 

--- a/packages/agents-openai/src/openaiProvider.ts
+++ b/packages/agents-openai/src/openaiProvider.ts
@@ -90,13 +90,6 @@ export class OpenAIProvider implements ModelProvider {
           project: this.#options.project,
         });
     }
-    // LEFT ON PURPOSE: will delete when merged
-    console.log(
-      'Using OpenAI client',
-      this.#client.project,
-      this.#client.apiKey,
-    );
-    // Return
     return this.#client;
   }
 

--- a/packages/agents-openai/test/defaults.test.ts
+++ b/packages/agents-openai/test/defaults.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, vi } from 'vitest';
 import {
   DEFAULT_OPENAI_MODEL,
   setTracingExportApiKey,
@@ -34,5 +34,20 @@ describe('Defaults', () => {
   test('get/setDefaultOpenAIKey', async () => {
     setDefaultOpenAIKey('foo');
     expect(getDefaultOpenAIKey()).toBe('foo');
+  });
+
+  test('setDefaultOpenAIKey notifies registered providers', async () => {
+    const mockProvider = { invalidateClient: vi.fn() };
+    const { registerOpenAIProvider, unregisterOpenAIProvider } = await import(
+      '../src/defaults'
+    );
+
+    registerOpenAIProvider(mockProvider);
+    setDefaultOpenAIKey('new-key');
+
+    expect(mockProvider.invalidateClient).toHaveBeenCalledTimes(1);
+
+    // Cleanup
+    unregisterOpenAIProvider(mockProvider);
   });
 });

--- a/packages/agents-openai/test/defaults.test.ts
+++ b/packages/agents-openai/test/defaults.test.ts
@@ -50,4 +50,20 @@ describe('Defaults', () => {
     // Cleanup
     unregisterOpenAIProvider(mockProvider);
   });
+
+  test('setDefaultOpenAIClient notifies registered providers', async () => {
+    const mockProvider = { invalidateClient: vi.fn() };
+    const { registerOpenAIProvider, unregisterOpenAIProvider } = await import(
+      '../src/defaults'
+    );
+
+    registerOpenAIProvider(mockProvider);
+    const client = new OpenAI({ apiKey: 'test-key' });
+    setDefaultOpenAIClient(client);
+
+    expect(mockProvider.invalidateClient).toHaveBeenCalledTimes(1);
+
+    // Cleanup
+    unregisterOpenAIProvider(mockProvider);
+  });
 });

--- a/packages/agents-openai/test/openaiProvider.test.ts
+++ b/packages/agents-openai/test/openaiProvider.test.ts
@@ -1,33 +1,93 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { OpenAIProvider } from '../src/openaiProvider';
 import { OpenAIResponsesModel } from '../src/openaiResponsesModel';
 import { OpenAIChatCompletionsModel } from '../src/openaiChatCompletionsModel';
 import { setOpenAIAPI } from '../src/defaults';
+import * as defaults from '../src/defaults';
 
 class FakeClient {}
 
 describe('OpenAIProvider', () => {
   it('throws when apiKey and openAIClient are provided', () => {
-    expect(() => new OpenAIProvider({ apiKey: 'k', openAIClient: {} as any })).toThrow();
+    expect(
+      () => new OpenAIProvider({ apiKey: 'k', openAIClient: {} as any }),
+    ).toThrow();
   });
 
   it('throws when baseURL and openAIClient are provided', () => {
-    expect(() => new OpenAIProvider({ baseURL: 'x', openAIClient: {} as any })).toThrow();
+    expect(
+      () => new OpenAIProvider({ baseURL: 'x', openAIClient: {} as any }),
+    ).toThrow();
   });
 
   it('returns responses model when useResponses true', async () => {
-    const provider = new OpenAIProvider({ openAIClient: new FakeClient() as any, useResponses: true });
+    const provider = new OpenAIProvider({
+      openAIClient: new FakeClient() as any,
+      useResponses: true,
+    });
     const model = await provider.getModel('m');
     expect(model).toBeInstanceOf(OpenAIResponsesModel);
   });
 
   it('uses default API when useResponses not set', async () => {
     setOpenAIAPI('responses');
-    let provider = new OpenAIProvider({ openAIClient: new FakeClient() as any });
+    let provider = new OpenAIProvider({
+      openAIClient: new FakeClient() as any,
+    });
     expect(await provider.getModel('m')).toBeInstanceOf(OpenAIResponsesModel);
 
     setOpenAIAPI('chat_completions');
     provider = new OpenAIProvider({ openAIClient: new FakeClient() as any });
-    expect(await provider.getModel('m')).toBeInstanceOf(OpenAIChatCompletionsModel);
+    expect(await provider.getModel('m')).toBeInstanceOf(
+      OpenAIChatCompletionsModel,
+    );
+  });
+
+  it('registers for key changes when using default key', () => {
+    const registerSpy = vi.spyOn(defaults, 'registerOpenAIProvider');
+
+    // Provider without specific apiKey should register
+    new OpenAIProvider({});
+    expect(registerSpy).toHaveBeenCalledTimes(1);
+
+    registerSpy.mockRestore();
+  });
+
+  it('does not register for key changes when using custom client', () => {
+    const registerSpy = vi.spyOn(defaults, 'registerOpenAIProvider');
+
+    // Provider with custom client should not register
+    new OpenAIProvider({ openAIClient: new FakeClient() as any });
+    expect(registerSpy).not.toHaveBeenCalled();
+
+    registerSpy.mockRestore();
+  });
+
+  it('does not register for key changes when using custom apiKey', () => {
+    const registerSpy = vi.spyOn(defaults, 'registerOpenAIProvider');
+
+    // Provider with custom apiKey should not register
+    new OpenAIProvider({ apiKey: 'custom-key' });
+    expect(registerSpy).not.toHaveBeenCalled();
+
+    registerSpy.mockRestore();
+  });
+
+  it('invalidates client when API key changes', async () => {
+    const provider = new OpenAIProvider({ apiKey: 'test-key' });
+
+    // Get a model to ensure client is created
+    const model1 = await provider.getModel('test-model');
+    expect(model1).toBeDefined();
+
+    // Invalidate the client
+    provider.invalidateClient();
+
+    // Getting a model should still work after invalidation
+    const model2 = await provider.getModel('test-model');
+    expect(model2).toBeDefined();
+
+    // Cleanup
+    provider.destroy();
   });
 });

--- a/packages/agents-realtime/src/metadata.ts
+++ b/packages/agents-realtime/src/metadata.ts
@@ -3,9 +3,9 @@
 
 export const METADATA = {
   "name": "@openai/agents-realtime",
-  "version": "0.0.7",
+  "version": "0.0.11",
   "versions": {
-    "@openai/agents-realtime": "0.0.7",
+    "@openai/agents-realtime": "0.0.11",
     "@openai/agents-core": "workspace:*",
     "@openai/zod": "npm:zod@3.25.40 - 3.25.67"
   }

--- a/packages/agents/src/metadata.ts
+++ b/packages/agents/src/metadata.ts
@@ -3,9 +3,9 @@
 
 export const METADATA = {
   "name": "@openai/agents",
-  "version": "0.0.7",
+  "version": "0.0.11",
   "versions": {
-    "@openai/agents": "0.0.7",
+    "@openai/agents": "0.0.11",
     "@openai/agents-core": "workspace:*",
     "@openai/agents-openai": "workspace:*",
     "@openai/agents-realtime": "workspace:*",


### PR DESCRIPTION
Fixes an issue where OpenAI API keys would persist forever once set, preventing proper switching between different API keys/clients in multi-tenant (nextjs) applications.

The issue was that once an OpenAI API key was set using setDefaultOpenAIKey() or setDefaultOpenAIClient(), the OpenAI client would be cached in the OpenAIProvider class and never updated, even when switching to a different API key. This prevented proper API key switching in multi-tenant applications where different requests need different OpenAI clients with different keys/projects.

Changes Made:                                                                                                      

- Provider Registry System: Added a registry to track OpenAI providers that need to be notified when default keys/clients change 
- Automatic Client Invalidation: When `setDefaultOpenAIKey()` or `setDefaultOpenAIClient()` is called, all registered providers invalidate their cached clients

Best Regards,
Diederik

PS: I also fixed a type on the docs ;)