### PR TITLE
fix(mcp): rebind cached tools to connected server

### DIFF
--- a/.changeset/funny-dragons-tell.md
+++ b/.changeset/funny-dragons-tell.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+Rebinds cached tools to the current MCP server to avoid stale tool invocation (fixes #195)

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -219,7 +219,7 @@ export async function getAllMcpFunctionTools<TContext = UnknownContext>(
   return allTools;
 }
 
-const _cachedTools: Record<string, FunctionTool<any, any, unknown>[]> = {};
+const _cachedTools: Record<string, MCPTool[]> = {};
 /**
  * Remove cached tools for the given server so the next lookup fetches fresh data.
  *
@@ -236,7 +236,9 @@ async function getFunctionToolsFromServer<TContext = UnknownContext>(
   convertSchemasToStrict: boolean,
 ): Promise<FunctionTool<TContext, any, unknown>[]> {
   if (server.cacheToolsList && _cachedTools[server.name]) {
-    return _cachedTools[server.name];
+    return _cachedTools[server.name].map((t) =>
+      mcpToFunctionTool(t, server, convertSchemasToStrict),
+    );
   }
   return withMCPListToolsSpan(
     async (span) => {
@@ -246,7 +248,7 @@ async function getFunctionToolsFromServer<TContext = UnknownContext>(
         mcpToFunctionTool(t, server, convertSchemasToStrict),
       );
       if (server.cacheToolsList) {
-        _cachedTools[server.name] = tools;
+        _cachedTools[server.name] = mcpTools;
       }
       return tools;
     },


### PR DESCRIPTION
Cached MCP tools are now stored as raw tool data and rebound to the current server when retrieved, preventing stale server references

Added a regression test ensuring cached tools execute on the new server instance rather than an old one.

Resolves #195 

