### PR TITLE
fix(openai): fix tracing exception in model response getting method when tracing is disabled

### DIFF
--- a/.changeset/seven-kings-drop.md
+++ b/.changeset/seven-kings-drop.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+Fix tracing exception in model response getting method when tracing is disabled

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -74,6 +74,47 @@ describe('OpenAIResponsesModel', () => {
     });
   });
 
+  it('getResponse should not throw tracing exception when tracing is disabled', async () => {
+    const fakeResponse = {
+      id: 'res1',
+      usage: {
+        input_tokens: 3,
+        output_tokens: 4,
+        total_tokens: 7,
+      },
+      output: [
+        {
+          id: 'test_id',
+          type: 'message',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'hi' }],
+          role: 'assistant',
+        },
+      ],
+    };
+    const createMock = vi.fn().mockResolvedValue(fakeResponse);
+    const fakeClient = {
+      responses: { create: createMock },
+    } as unknown as OpenAI;
+    const model = new OpenAIResponsesModel(fakeClient, 'gpt-test');
+
+    const request = {
+      systemInstructions: 'inst',
+      input: 'hello',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    await expect(model.getResponse(request as any)).resolves.not.toThrow();
+    await expect(model.getResponse(request as any)).resolves.not.toThrow(
+      'No existing trace found',
+    );
+  });
+
   it('getStreamedResponse yields events and calls client with stream flag', async () => {
     withTrace('test', async () => {
       const fakeResponse = { id: 'res2', usage: {}, output: [] };


### PR DESCRIPTION
This pull request addresses a possible issue in the `OpenAIResponsesModel` where an exception could occur during getting a response when tracing is **disabled**. When tracing is disabled there is no parent trace so `withResponseSpan` fails with not finding a context trace for the span it attempts to create. This leads to the whole `getResponse` failing. Fix found below copies the same style of span creation only when tracing is enabled as seen in `getStreamedResponse` method.