### PR TITLE
docs: inline streaming event types in guide (follows #205)

### DIFF
--- a/docs/src/content/docs/guides/streaming.mdx
+++ b/docs/src/content/docs/guides/streaming.mdx
@@ -26,7 +26,8 @@ object rather than a full result:
 
 When streaming is enabled the returned `stream` implements the
 `AsyncIterable` interface. Each yielded event is an object describing
-what happened within the run. Most applications only want the model's
+what happened within the run. The stream yields one of three event types, each describing a different part of the agent's execution.
+Most applications only want the model's
 text though, so the stream provides helpers.
 
 ### Get the text output
@@ -62,6 +63,76 @@ and SDK specific run information:
 See [the streamed example](https://github.com/openai/openai-agents-js/tree/main/examples/agent-patterns/streamed.ts)
 for a fully worked script that prints both the plain text stream and the
 raw event stream.
+
+## Event types
+
+The stream yields three different event types:
+
+### raw_model_stream_event
+
+```ts
+type RunRawModelStreamEvent = {
+  type: 'raw_model_stream_event';
+  data: ResponseStreamEvent;
+};
+```
+
+Example:
+
+```json
+{
+  "type": "raw_model_stream_event",
+  "data": {
+    "type": "output_text_delta",
+    "delta": "Hello"
+  }
+}
+```
+
+### run_item_stream_event
+
+```ts
+type RunItemStreamEvent = {
+  type: 'run_item_stream_event';
+  name: RunItemStreamEventName;
+  item: RunItem;
+};
+```
+
+Example handoff payload:
+
+```json
+{
+  "type": "run_item_stream_event",
+  "name": "handoff_occurred",
+  "item": {
+    "type": "handoff_call",
+    "id": "h1",
+    "status": "completed",
+    "name": "transfer_to_refund_agent"
+  }
+}
+```
+
+### agent_updated_stream_event
+
+```ts
+type RunAgentUpdatedStreamEvent = {
+  type: 'agent_updated_stream_event';
+  agent: Agent<any, any>;
+};
+```
+
+Example:
+
+```json
+{
+  "type": "agent_updated_stream_event",
+  "agent": {
+    "name": "Refund Agent"
+  }
+}
+```
 
 ## Human in the loop while streaming
 


### PR DESCRIPTION
This PR updates the Streaming guide to include inline documentation for the three event types emitted during streaming:

`raw_model_stream_event`

`run_item_stream_event`

`agent_updated_stream_event`

This aims to bring the JS SDK streaming docs in line with the Python SDK, which includes event references on the same page. It also fully resolves the request from #202, and complements the behavior fix in #205.

Screenshot shows output via pnpm docs:dev

Resolves #217 

<img width="1491" height="1714" alt="screenshot14-03-45" src="https://github.com/user-attachments/assets/231243d7-a2c2-40c1-9ad0-e932864201f1" />
