### PR TITLE
Fix release tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,6 @@ jobs:
           NPM_CONFIG_ACCESS: public
 
       - name: Tag release
-        if: steps.changesets.outputs.published == 'true'
         run: |
           version=$(jq -r '.version' packages/agents/package.json)
           tag="v${version}"


### PR DESCRIPTION
## Summary
- ensure tagging step runs regardless of `published` flag

Fixes https://github.com/openai/openai-agents-js/pull/207#issuecomment-3086224884

## Testing
- `pnpm build`
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_i_68799f99f6dc83208fb2d3f66e4f69f8