### PR TITLE
Revert "Fix release tagging"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
           NPM_CONFIG_ACCESS: public
 
       - name: Tag release
+        # currently this step does not work due to https://github.com/openai/openai-agents-js/pull/232
         if: steps.changesets.outputs.published == 'true'
         run: |
           version=$(jq -r '.version' packages/agents/package.json)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
           NPM_CONFIG_ACCESS: public
 
       - name: Tag release
+        if: steps.changesets.outputs.published == 'true'
         run: |
           version=$(jq -r '.version' packages/agents/package.json)
           tag="v${version}"


### PR DESCRIPTION
Reverts openai/openai-agents-js#231

The root cause is that we are not using `changeset publish` for publishing and our custom publish command does `pnpm publish -r --no-git-checks`. In this case, the step outputs are empty, and there is no workaround so far.

@dkundel-openai was there any specific reason to avoid `changeset publish`? If `changeset publish` works, the following step to push tags should work.