### PR TITLE
feat(realtime): make websocket URL configurable

### DIFF
--- a/.changeset/realtime-url-configurable.md
+++ b/.changeset/realtime-url-configurable.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': minor
+---
+
+Expose configurable URL in OpenAIRealtimeWebSocket constructor and RealtimeSession.connect.

--- a/packages/agents-realtime/src/realtimeSession.ts
+++ b/packages/agents-realtime/src/realtimeSession.ts
@@ -672,6 +672,7 @@ export class RealtimeSession<
     await this.#transport.connect({
       apiKey: options.apiKey ?? this.options.apiKey,
       model: this.options.model,
+      url: options.url,
       initialSessionConfig: await this.#getSessionConfig(this.options.config),
     });
 

--- a/packages/agents-realtime/test/openaiRealtimeWebsocket.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeWebsocket.test.ts
@@ -58,6 +58,14 @@ describe('OpenAIRealtimeWebSocket', () => {
     expect(statuses).toEqual(['connecting', 'connected']);
   });
 
+  it('uses custom url from constructor', async () => {
+    const ws = new OpenAIRealtimeWebSocket({ url: 'ws://test' });
+    const p = ws.connect({ apiKey: 'ek_test', model: 'm' });
+    await vi.runAllTimersAsync();
+    await p;
+    expect(lastFakeSocket!.url).toBe('ws://test');
+  });
+
   it('handles audio delta, speech started and created/done events', async () => {
     const ws = new OpenAIRealtimeWebSocket();
     const audioSpy = vi.fn();

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -113,6 +113,14 @@ describe('RealtimeSession', () => {
     expect(transport.closeCalls).toBe(1);
   });
 
+  it('forwards url in connect options to transport', async () => {
+    const t = new FakeTransport();
+    const agent = new RealtimeAgent({ name: 'A', handoffs: [] });
+    const s = new RealtimeSession(agent, { transport: t });
+    await s.connect({ apiKey: 'test', url: 'ws://example' });
+    expect(t.connectCalls[0]?.url).toBe('ws://example');
+  });
+
   it('updateHistory accepts callback', () => {
     const item = createMessage('1', 'hi');
     session.updateHistory([item]);


### PR DESCRIPTION
## Summary
- allow passing a `url` in `OpenAIRealtimeWebSocket` constructor
- forward `url` from `RealtimeSession.connect` to the transport layer
- add related tests
- add changeset for `@openai/agents-realtime`

## Testing
- `pnpm lint`
- `pnpm build`
- `CI=1 pnpm test`


------
https://chatgpt.com/codex/tasks/task_i_687e86dc9b3c833188d28264766aa580