### PR TITLE
Fix #219 MCPServer#invalidateToolsCache() not exposed while being mentioned in the documents

### DIFF
--- a/.changeset/open-candies-watch.md
+++ b/.changeset/open-candies-watch.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+Fix #219 MCPServer#invalidateToolsCache() not exposed while being mentioned in the documents

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -35,6 +35,7 @@ export interface MCPServer {
     toolName: string,
     args: Record<string, unknown> | null,
   ): Promise<CallToolResultContent>;
+  invalidateToolsCache(): Promise<void>;
 }
 
 export abstract class BaseMCPServerStdio implements MCPServer {
@@ -56,6 +57,7 @@ export abstract class BaseMCPServerStdio implements MCPServer {
     _toolName: string,
     _args: Record<string, unknown> | null,
   ): Promise<CallToolResultContent>;
+  abstract invalidateToolsCache(): Promise<void>;
 
   /**
    * Logs a debug message when debug logging is enabled.
@@ -89,6 +91,7 @@ export abstract class BaseMCPServerStreamableHttp implements MCPServer {
     _toolName: string,
     _args: Record<string, unknown> | null,
   ): Promise<CallToolResultContent>;
+  abstract invalidateToolsCache(): Promise<void>;
 
   /**
    * Logs a debug message when debug logging is enabled.
@@ -154,6 +157,9 @@ export class MCPServerStdio extends BaseMCPServerStdio {
   ): Promise<CallToolResultContent> {
     return this.underlying.callTool(toolName, args);
   }
+  invalidateToolsCache(): Promise<void> {
+    return this.underlying.invalidateToolsCache();
+  }
 }
 
 export class MCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
@@ -186,6 +192,9 @@ export class MCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     args: Record<string, unknown> | null,
   ): Promise<CallToolResultContent> {
     return this.underlying.callTool(toolName, args);
+  }
+  invalidateToolsCache(): Promise<void> {
+    return this.underlying.invalidateToolsCache();
   }
 }
 
@@ -225,7 +234,7 @@ const _cachedTools: Record<string, MCPTool[]> = {};
  *
  * @param serverName - Name of the MCP server whose cache should be cleared.
  */
-export function invalidateServerToolsCache(serverName: string) {
+export async function invalidateServerToolsCache(serverName: string) {
   delete _cachedTools[serverName];
 }
 /**

--- a/packages/agents-core/src/shims/mcp-server/browser.ts
+++ b/packages/agents-core/src/shims/mcp-server/browser.ts
@@ -29,6 +29,9 @@ export class MCPServerStdio extends BaseMCPServerStdio {
   ): Promise<CallToolResultContent> {
     throw new Error('Method not implemented.');
   }
+  invalidateToolsCache(): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
 }
 
 export class MCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
@@ -51,6 +54,9 @@ export class MCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     _toolName: string,
     _args: Record<string, unknown> | null,
   ): Promise<CallToolResultContent> {
+    throw new Error('Method not implemented.');
+  }
+  invalidateToolsCache(): Promise<void> {
     throw new Error('Method not implemented.');
   }
 }

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -91,8 +91,8 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
     this.debugLog(() => `Connected to MCP server: ${this._name}`);
   }
 
-  invalidateToolsCache() {
-    invalidateServerToolsCache(this.name);
+  async invalidateToolsCache(): Promise<void> {
+    await invalidateServerToolsCache(this.name);
     this._cacheDirty = true;
   }
 
@@ -208,8 +208,8 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     this.debugLog(() => `Connected to MCP server: ${this._name}`);
   }
 
-  invalidateToolsCache() {
-    invalidateServerToolsCache(this.name);
+  async invalidateToolsCache(): Promise<void> {
+    await invalidateServerToolsCache(this.name);
     this._cacheDirty = true;
   }
 

--- a/packages/agents-core/test/mcpCache.test.ts
+++ b/packages/agents-core/test/mcpCache.test.ts
@@ -56,7 +56,7 @@ describe('MCP tools cache invalidation', () => {
       tools = await getAllMcpTools([server]);
       expect(tools.map((t) => t.name)).toEqual(['a']);
 
-      server.invalidateToolsCache();
+      await server.invalidateToolsCache();
       tools = await getAllMcpTools([server]);
       expect(tools.map((t) => t.name)).toEqual(['b']);
     });


### PR DESCRIPTION
This pull request resolves #219 