### PR TITLE
Hacky way to add Tool Image support

### DIFF
--- a/packages/agents-core/src/items.ts
+++ b/packages/agents-core/src/items.ts
@@ -156,6 +156,24 @@ export class RunToolApprovalItem extends RunItemBase {
   }
 }
 
+export class RunInjectedMessageItem extends RunItemBase {
+  public readonly type = 'injected_message_item' as const;
+
+  constructor(
+    public rawItem: protocol.MessageItem,
+    public agent: Agent,
+  ) {
+    super();
+  }
+
+  toJSON() {
+    return {
+      ...super.toJSON(),
+      agent: this.agent.toJSON(),
+    };
+  }
+}
+
 export type RunItem =
   | RunMessageOutputItem
   | RunToolCallItem
@@ -163,7 +181,8 @@ export type RunItem =
   | RunHandoffCallItem
   | RunToolCallOutputItem
   | RunHandoffOutputItem
-  | RunToolApprovalItem;
+  | RunToolApprovalItem
+  | RunInjectedMessageItem;
 
 /**
  * Extract all text output from a list of run items by concatenating the content of all


### PR DESCRIPTION

Chat Completions allow only Tool messages with string content

**How this bypasses the Chat Completions limitation**
- To bypass: 
```
    } else if (item.type === 'function_call_result') {
      flushAssistantMessage();
      const funcOutput = item;
      if (funcOutput.output.type !== 'text') {
        throw new UserError(
          'Only text output is supported for chat completions. Got item: ' +
            JSON.stringify(item),
        );
      }

      result.push({
        role: 'tool',
        tool_call_id: funcOutput.callId,
        content: funcOutput.output.text,
        ...funcOutput.providerData,
      });
```