### PR TITLE
feat: add timeout parameter to mcp callTool

### DIFF
--- a/.changeset/three-monkeys-bake.md
+++ b/.changeset/three-monkeys-bake.md
@@ -1,0 +1,5 @@
+---
+"@openai/agents-core": patch
+---
+
+feat: add timeout parameter to callTool method

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -431,6 +431,7 @@ export interface BaseMCPServerStdioOptions {
   encodingErrorHandler?: 'strict' | 'ignore' | 'replace';
   logger?: Logger;
   toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
+  timeout?: number;
 }
 export interface DefaultMCPServerStdioOptions
   extends BaseMCPServerStdioOptions {
@@ -463,6 +464,7 @@ export interface MCPServerStreamableHttpOptions {
   reconnectionOptions?: any;
   sessionId?: string;
   // ----------------------------------------------------
+  timeout?: number;
 }
 
 /**

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -453,6 +453,7 @@ export interface MCPServerStreamableHttpOptions {
   name?: string;
   logger?: Logger;
   toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
+  timeout?: number;
 
   // ----------------------------------------------------
   // OAuth
@@ -464,7 +465,6 @@ export interface MCPServerStreamableHttpOptions {
   reconnectionOptions?: any;
   sessionId?: string;
   // ----------------------------------------------------
-  timeout?: number;
 }
 
 /**

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -36,6 +36,7 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
   protected _toolsList: any[] = [];
   protected serverInitializeResult: InitializeResult | null = null;
   protected clientSessionTimeoutSeconds?: number;
+  protected timeout: number;
 
   params: DefaultMCPServerStdioOptions;
   private _name: string;
@@ -44,6 +45,7 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
   constructor(params: MCPServerStdioOptions) {
     super(params);
     this.clientSessionTimeoutSeconds = params.clientSessionTimeoutSeconds ?? 5;
+    this.timeout = params.timeout ?? DEFAULT_TOOL_CALL_TIMEOUT;
     if ('fullCommand' in params) {
       const elements = params.fullCommand.split(' ');
       const command = elements.shift();
@@ -121,7 +123,6 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
   async callTool(
     toolName: string,
     args: Record<string, unknown> | null,
-    timeout?: number,
   ): Promise<CallToolResultContent> {
     const { CallToolResultSchema } = await import(
       '@modelcontextprotocol/sdk/types.js'
@@ -131,12 +132,16 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
         'Server not initialized. Make sure you call connect() first.',
       );
     }
-    const response = await this.session.callTool({
-      name: toolName,
-      arguments: args ?? {},
-    }, undefined, {
-      timeout: timeout ?? DEFAULT_TOOL_CALL_TIMEOUT
-    });
+    const response = await this.session.callTool(
+      {
+        name: toolName,
+        arguments: args ?? {},
+      },
+      undefined,
+      {
+        timeout: this.timeout,
+      },
+    );
     const parsed = CallToolResultSchema.parse(response);
     const result = parsed.content;
     this.debugLog(
@@ -168,6 +173,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
   protected _toolsList: any[] = [];
   protected serverInitializeResult: InitializeResult | null = null;
   protected clientSessionTimeoutSeconds?: number;
+  protected timeout: number;
 
   params: MCPServerStreamableHttpOptions;
   private _name: string;
@@ -178,6 +184,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     this.clientSessionTimeoutSeconds = params.clientSessionTimeoutSeconds ?? 5;
     this.params = params;
     this._name = params.name || `streamable-http: ${this.params.url}`;
+    this.timeout = params.timeout ?? DEFAULT_TOOL_CALL_TIMEOUT;
   }
 
   async connect(): Promise<void> {
@@ -241,7 +248,6 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
   async callTool(
     toolName: string,
     args: Record<string, unknown> | null,
-    timeout?: number,
   ): Promise<CallToolResultContent> {
     const { CallToolResultSchema } = await import(
       '@modelcontextprotocol/sdk/types.js'
@@ -251,12 +257,16 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
         'Server not initialized. Make sure you call connect() first.',
       );
     }
-    const response = await this.session.callTool({
-      name: toolName,
-      arguments: args ?? {},
-    }, undefined, {
-      timeout: timeout ?? DEFAULT_TOOL_CALL_TIMEOUT
-    });
+    const response = await this.session.callTool(
+      {
+        name: toolName,
+        arguments: args ?? {},
+      },
+      undefined,
+      {
+        timeout: this.timeout,
+      },
+    );
     const parsed = CallToolResultSchema.parse(response);
     const result = parsed.content;
     this.debugLog(

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -13,6 +13,8 @@ import {
 } from '../../mcp';
 import logger from '../../logger';
 
+const DEFAULT_TOOL_CALL_TIMEOUT = 60000;
+
 export interface SessionMessage {
   message: any;
 }
@@ -119,6 +121,7 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
   async callTool(
     toolName: string,
     args: Record<string, unknown> | null,
+    timeout?: number,
   ): Promise<CallToolResultContent> {
     const { CallToolResultSchema } = await import(
       '@modelcontextprotocol/sdk/types.js'
@@ -131,6 +134,8 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
     const response = await this.session.callTool({
       name: toolName,
       arguments: args ?? {},
+    }, undefined, {
+      timeout: timeout ?? DEFAULT_TOOL_CALL_TIMEOUT
     });
     const parsed = CallToolResultSchema.parse(response);
     const result = parsed.content;
@@ -236,6 +241,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
   async callTool(
     toolName: string,
     args: Record<string, unknown> | null,
+    timeout?: number,
   ): Promise<CallToolResultContent> {
     const { CallToolResultSchema } = await import(
       '@modelcontextprotocol/sdk/types.js'
@@ -248,6 +254,8 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     const response = await this.session.callTool({
       name: toolName,
       arguments: args ?? {},
+    }, undefined, {
+      timeout: timeout ?? DEFAULT_TOOL_CALL_TIMEOUT
     });
     const parsed = CallToolResultSchema.parse(response);
     const result = parsed.content;

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -1,4 +1,5 @@
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { DEFAULT_REQUEST_TIMEOUT_MSEC } from '@modelcontextprotocol/sdk/shared/protocol';
 
 import {
   BaseMCPServerStdio,
@@ -12,8 +13,6 @@ import {
   invalidateServerToolsCache,
 } from '../../mcp';
 import logger from '../../logger';
-
-const DEFAULT_TOOL_CALL_TIMEOUT = 60000;
 
 export interface SessionMessage {
   message: any;
@@ -45,7 +44,7 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
   constructor(params: MCPServerStdioOptions) {
     super(params);
     this.clientSessionTimeoutSeconds = params.clientSessionTimeoutSeconds ?? 5;
-    this.timeout = params.timeout ?? DEFAULT_TOOL_CALL_TIMEOUT;
+    this.timeout = params.timeout ?? DEFAULT_REQUEST_TIMEOUT_MSEC;
     if ('fullCommand' in params) {
       const elements = params.fullCommand.split(' ');
       const command = elements.shift();
@@ -184,7 +183,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     this.clientSessionTimeoutSeconds = params.clientSessionTimeoutSeconds ?? 5;
     this.params = params;
     this._name = params.name || `streamable-http: ${this.params.url}`;
-    this.timeout = params.timeout ?? DEFAULT_TOOL_CALL_TIMEOUT;
+    this.timeout = params.timeout ?? DEFAULT_REQUEST_TIMEOUT_MSEC;
   }
 
   async connect(): Promise<void> {


### PR DESCRIPTION
Some MCP operations may timeout when execution takes too long. In such cases, we want to be able to customize the timeout duration to ensure MCP can execute successfully.
<img width="1666" height="134" alt="image" src="https://github.com/user-attachments/assets/8bd3a00a-2c68-4306-b33d-7eee69f6977f" />