### PR TITLE
docs: Clarify `name` parameter in Basic Configuration

### DIFF
--- a/docs/src/content/docs/guides/agents.mdx
+++ b/docs/src/content/docs/guides/agents.mdx
@@ -17,6 +17,7 @@ import agentForcingToolUse from '../../../../../examples/docs/agents/agentForcin
 Agents are the main building‑block of the OpenAI Agents SDK. An **Agent** is a Large Language
 Model (LLM) that has been configured with:
 
+- **Name** – A required string that identifies your agent.
 - **Instructions** – the system prompt that tells the model _who it is_ and _how it should
   respond_.
 - **Model** – which OpenAI model to call, plus any optional model tuning parameters.


### PR DESCRIPTION
This pull request aims to improve the clarity and consistency of the `Agent` documentation for the JavaScript SDK.

Currently, the `name` parameter is used in the code example but is not explicitly listed in the "Basic Agent definition" bullet points. This can be confusing for new users who may not immediately realize that `name` is a core and required property.

This change aligns the JavaScript documentation with the Python documentation, where `name` is clearly listed as a required parameter in the "Basic configuration" section.

The update will make the documentation more explicit and easier to follow, providing a better experience for developers defining their agents.