### PR TITLE
fix: prevent crash when importing in cloudflare workers

### DIFF
--- a/.changeset/free-jokes-walk.md
+++ b/.changeset/free-jokes-walk.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: prevent crash when importing in cloudflare workers
+
+An export was missed in https://github.com/openai/openai-agents-js/pull/290 for the workerd shim, this prevents the crash when importing there. Long term we should just add an implementation for cloudflare workers (and I suspect the node implementation might just work)

--- a/packages/agents-core/src/shims/shims-workerd.ts
+++ b/packages/agents-core/src/shims/shims-workerd.ts
@@ -54,7 +54,11 @@ export function isTracingLoopRunningByDefault(): boolean {
 /**
  * Right now Cloudflare Workers does not support MCP
  */
-export { MCPServerStdio, MCPServerStreamableHttp } from './mcp-server/browser';
+export {
+  MCPServerStdio,
+  MCPServerStreamableHttp,
+  MCPServerSSE,
+} from './mcp-server/browser';
 
 export { clearTimeout, setTimeout } from 'node:timers';
 


### PR DESCRIPTION
Looks like an export was missed in https://github.com/openai/openai-agents-js/pull/290 for the workerd shim, this prevents the crash when importing there. Loing term we should just add an implementation for cloudflare workers (and I suspect the node implementation might just work)