### PR TITLE
fix: the aisdk extension should grab output when toolCalls is a blank…

### DIFF
--- a/.changeset/big-horses-itch.md
+++ b/.changeset/big-horses-itch.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: the aisdk extension should grab output when toolCalls is a blank array
+
+When the output of a provider includes an empty tool calls array, we'd mistakenly skip over the text result. This patch checks for that condition.

--- a/packages/agents-extensions/src/aiSdk.ts
+++ b/packages/agents-extensions/src/aiSdk.ts
@@ -463,7 +463,10 @@ export class AiSdkModel implements Model {
         // Putting a text message here will let the agent loop to complete,
         // so adding this item only when the tool calls are empty.
         // Note that the same support is not available for streaming mode.
-        if (!result.toolCalls && result.text) {
+        if (
+          (!result.toolCalls || result.toolCalls.length === 0) &&
+          result.text
+        ) {
           output.push({
             type: 'message',
             content: [{ type: 'output_text', text: result.text }],


### PR DESCRIPTION
… array

When the output of a provider includes an empty tool calls array, we'd mistakenly skip over the text result. This patch checks for that condition.