### PR TITLE
fix(realtime-session): preserve audio format and config fields on agent update

### DIFF
--- a/.changeset/preserve-audio-formats-on-agent-update.md
+++ b/.changeset/preserve-audio-formats-on-agent-update.md
@@ -3,12 +3,3 @@
 ---
 
 fix(realtime-session): preserve audio format & other session config fields on agent update
-
-Previously, calling `updateAgent()` rebuilt the session config from a minimal subset of fields and
-omitted properties like `inputAudioFormat` / `outputAudioFormat`, `modalities`, `speed`, etc. This
-caused the server to fall back to defaults (e.g. `pcm16`), producing loud static in Twilio calls
-when a custom format (e.g. `g711_ulaw`) was required.
-
-This change caches the last full session config and merges it when generating a new config so
-updates only override dynamic fields (instructions, voice, tools, tracing) while preserving the
-rest. A regression test was added to ensure audio formats persist across `updateAgent` calls.

--- a/.changeset/preserve-audio-formats-on-agent-update.md
+++ b/.changeset/preserve-audio-formats-on-agent-update.md
@@ -1,0 +1,14 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix(realtime-session): preserve audio format & other session config fields on agent update
+
+Previously, calling `updateAgent()` rebuilt the session config from a minimal subset of fields and
+omitted properties like `inputAudioFormat` / `outputAudioFormat`, `modalities`, `speed`, etc. This
+caused the server to fall back to defaults (e.g. `pcm16`), producing loud static in Twilio calls
+when a custom format (e.g. `g711_ulaw`) was required.
+
+This change caches the last full session config and merges it when generating a new config so
+updates only override dynamic fields (instructions, voice, tools, tracing) while preserving the
+rest. A regression test was added to ensure audio formats persist across `updateAgent` calls.

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -300,4 +300,20 @@ describe('RealtimeSession', () => {
     } as any);
     expect(startEvents).toBe(2);
   });
+
+  it('preserves custom audio formats across updateAgent', async () => {
+    const t = new FakeTransport();
+    const agent = new RealtimeAgent({ name: 'Orig', handoffs: [] });
+    const s = new RealtimeSession(agent, {
+      transport: t,
+      config: { inputAudioFormat: 'g711_ulaw', outputAudioFormat: 'g711_ulaw' },
+    });
+    await s.connect({ apiKey: 'test' });
+    const newAgent = new RealtimeAgent({ name: 'Next', handoffs: [] });
+    await s.updateAgent(newAgent);
+    // Find the last updateSessionConfig call
+    const last = t.updateSessionConfigCalls.at(-1)!;
+    expect(last.inputAudioFormat).toBe('g711_ulaw');
+    expect(last.outputAudioFormat).toBe('g711_ulaw');
+  });
 });


### PR DESCRIPTION
### Summary
This pull request fixes a critical bug where updating the agent in a `RealtimeSession` would cause important session config fields (such as `inputAudioFormat` and `outputAudioFormat`) to revert to defaults, breaking integrations like Twilio that require specific audio formats.

### Related Issue
Fixes #317 

### Problem

When calling `updateAgent()`on a `RealtimeSession`, the session config was rebuilt from a minimal set of fields, omitting values like `inputAudioFormat`, `outputAudioFormat`, `modalities`, `speed`, etc.

This caused the server to fall back to defaults (e.g., `pcm16`), resulting in loud static or broken audio for Twilio and other integrations that require a specific format.

### Steps to Reproduce

Create a `RealtimeSession` with a custom `inputAudioFormat` (e.g., `g711_ulaw`).

Call `updateAgent()` to switch to a new agent.

Observe that the session config sent to the server reverts to pcm16 and Twilio calls break.

### Solution

Added a `#lastSessionConfig` cache to `RealtimeSession` to store the last full session config sent to the server.
Updated `#getSessionConfig` to merge the last config, user options, and per-call overrides, always refreshing dynamic fields (instructions, voice, tools, tracing). This ensures all config fields (including audio formats) are preserved across agent updates.

Added a regression test to ensure this behavior is maintained.

### Testing

Ran pnpm build && pnpm test && pnpm lint — all checks pass.
Added a test that verifies `inputAudioFormat` and `outputAudioFormat` persist after `updateAgent()`.

### Checklist
-  Branch is up to date with main
-  All tests pass (pnpm build && pnpm test && pnpm lint)
-  Changeset generated
-  No secrets committed (Trufflehog run)
-  Follows Conventional Commits

### Notes
If you have any feedback or need further changes, let me know!