### PR TITLE
fix: quantize audio_end_ms to integer in interrupts for twilio realtime (#315)

### DIFF
--- a/.changeset/bright-fox-hill.md
+++ b/.changeset/bright-fox-hill.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-extensions': patch
+'@openai/agents-realtime': patch
+---
+
+Fix: clamp and floor `audio_end_ms` in interrupts to prevent Realtime API error with fractional speeds (#315)

--- a/packages/agents-realtime/src/openaiRealtimeWebsocket.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebsocket.ts
@@ -360,7 +360,7 @@ export class OpenAIRealtimeWebSocket
    * @param elapsedTime - The elapsed time since the response started.
    */
   _interrupt(elapsedTime: number, cancelOngoingResponse: boolean = true) {
-    if (elapsedTime < 0 || elapsedTime > this._audioLengthMs) {
+    if (elapsedTime < 0) {
       return;
     }
 
@@ -369,12 +369,15 @@ export class OpenAIRealtimeWebSocket
       this._cancelResponse();
     }
 
+    const length = this._audioLengthMs ?? Number.POSITIVE_INFINITY;
+    const audio_end_ms = Math.max(0, Math.min(Math.floor(elapsedTime), length));
+
     this.emit('audio_interrupted');
     this.sendEvent({
       type: 'conversation.item.truncate',
       item_id: this.#currentItemId,
       content_index: this.#currentAudioContentIndex,
-      audio_end_ms: elapsedTime,
+      audio_end_ms,
     });
   }
 


### PR DESCRIPTION
Quantizes `audio_end_ms` by flooring and clamping to ensure it’s always an integer, preventing realtime api errors with fractional speeds (e.g. 1.1). 

Also, adds tests for both the base WebSocket and Twilio transport layers. 

All tests pass including pnpm -r build-check.

Resolves #315 