### PR TITLE
Fix #245 CJS resolution failure

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,6 +24,7 @@ export default tseslint.config(
     'examples/realtime-demo/**',
     'examples/nextjs/**',
     'integration-tests//**',
+    'tsc-multi.json',
   ]),
   eslint.configs.recommended,
   tseslint.configs.recommended,

--- a/integration-tests/node.test.ts
+++ b/integration-tests/node.test.ts
@@ -1,7 +1,15 @@
 import { describe, test, expect, beforeAll } from 'vitest';
 import { execa as execaBase } from 'execa';
 
-const execa = execaBase({ cwd: './integration-tests/node' });
+const execa = execaBase({
+  cwd: './integration-tests/node',
+  env: {
+    ...process.env,
+    NODE_OPTIONS: '',
+    TS_NODE_PROJECT: '',
+    TS_NODE_COMPILER_OPTIONS: '',
+  },
+});
 
 describe('Node.js', () => {
   beforeAll(async () => {

--- a/integration-tests/node/package.json
+++ b/integration-tests/node/package.json
@@ -1,10 +1,12 @@
 {
   "private": true,
+  "type": "commonjs",
   "scripts": {
-    "start:cjs": "node index.cjs",
-    "start:esm": "node index.mjs"
+    "start:cjs": "node --no-experimental-require-module index.cjs",
+    "start:esm": "node --no-experimental-require-module index.mjs"
   },
   "dependencies": {
-    "@openai/agents": "latest"
+    "@openai/agents": "latest",
+    "typescript": "^5.9.2"
   }
 }

--- a/packages/agents-core/src/shims/shims-node.ts
+++ b/packages/agents-core/src/shims/shims-node.ts
@@ -14,11 +14,18 @@ declare global {
 // circular dependency resolution issues caused by other exports in '@openai/agents-core/_shims'
 export function loadEnv(): Record<string, string | undefined> {
   if (typeof process === 'undefined' || typeof process.env === 'undefined') {
-    if (
-      typeof import.meta === 'object' &&
-      typeof import.meta.env === 'object'
-    ) {
-      return import.meta.env as unknown as Record<string, string | undefined>;
+    // In CommonJS builds, import.meta is not available, so we return empty object
+    try {
+      // Use eval to avoid TypeScript compilation errors in CommonJS builds
+      const importMeta = (0, eval)('import.meta');
+      if (
+        typeof importMeta === 'object' &&
+        typeof importMeta.env === 'object'
+      ) {
+        return importMeta.env as unknown as Record<string, string | undefined>;
+      }
+    } catch {
+      // import.meta not available (CommonJS build)
     }
     return {};
   }

--- a/packages/agents-core/src/shims/shims-workerd.ts
+++ b/packages/agents-core/src/shims/shims-workerd.ts
@@ -15,11 +15,18 @@ declare global {
 // circular dependency resolution issues caused by other exports in '@openai/agents-core/_shims'
 export function loadEnv(): Record<string, string | undefined> {
   if (typeof process === 'undefined' || typeof process.env === 'undefined') {
-    if (
-      typeof import.meta === 'object' &&
-      typeof import.meta.env === 'object'
-    ) {
-      return import.meta.env as unknown as Record<string, string | undefined>;
+    // In CommonJS builds, import.meta is not available, so we return empty object
+    try {
+      // Use eval to avoid TypeScript compilation errors in CommonJS builds
+      const importMeta = (0, eval)('import.meta');
+      if (
+        typeof importMeta === 'object' &&
+        typeof importMeta.env === 'object'
+      ) {
+        return importMeta.env as unknown as Record<string, string | undefined>;
+      }
+    } catch {
+      // import.meta not available (CommonJS build)
     }
     return {};
   }

--- a/tsc-multi.json
+++ b/tsc-multi.json
@@ -1,6 +1,6 @@
 {
   "targets": [
-    { "extname": ".js", "module": "es2022", "moduleResolution": "node" },
+    { "extname": ".js", "module": "commonjs", "moduleResolution": "node" },
     { "extname": ".mjs", "module": "esnext" }
   ],
   "projects": [


### PR DESCRIPTION
This pull request adds the integration test correction on top of @CharlieGreenman's amazing contribution https://github.com/openai/openai-agents-js/pull/258; it resolves #245 

You can verify this PR resolves the CJS issue by the following steps:

Step 1. before merging the changes in this PR; follow the steps at https://github.com/openai/openai-agents-js/blob/main/integration-tests/README.md the test fails this way:
```
 FAIL  integration-tests/node.test.ts > Node.js > should be able to run using CommonJS
ExecaError: Command failed with exit code 1: npm run 'start:cjs'

(node:67335) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
/Users/seratch/code/openai-agents-js/integration-tests/node/node_modules/@openai/agents/dist/index.js:1
import { setDefaultModelProvider } from '@openai/agents-core';
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at wrapSafe (node:internal/modules/cjs/loader:1472:18)
    at Module._compile (node:internal/modules/cjs/loader:1501:20)
    at Module._extensions..js (node:internal/modules/cjs/loader:1613:10)
    at Module.load (node:internal/modules/cjs/loader:1275:32)
    at Module._load (node:internal/modules/cjs/loader:1096:12)
    at Module.require (node:internal/modules/cjs/loader:1298:19)
    at require (node:internal/modules/helpers:182:18)
    at Object.<anonymous> (/Users/seratch/code/openai-agents-js/integration-tests/node/index.cjs:9:5)
    at Module._compile (node:internal/modules/cjs/loader:1529:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1613:10)

Node.js v20.19.4


> start:cjs
> node --no-experimental-require-module index.cjs
```

With the changes in this PR, all the integration tests pass.