### PR TITLE
fix(realtime): history_updated reflects completed status from output_item.done

### DIFF
--- a/.changeset/public-eels-design.md
+++ b/.changeset/public-eels-design.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+Fix: ensure assistant message items from `response.output_item.done` preserve API status and default to `"completed"` when missing, so `history_updated` no longer stays `"in_progress"` after completion.

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -329,7 +329,10 @@ export abstract class OpenAIRealtimeBase
           type: parsed.item.type,
           role: parsed.item.role,
           content: parsed.item.content,
-          status: 'in_progress',
+          status:
+            parsed.type === 'response.output_item.done'
+              ? (item.status ?? 'completed')
+              : (item.status ?? 'in_progress')
         });
         this.emit('item_update', realtimeItem);
         return;


### PR DESCRIPTION
fixes the bug where `history_updated` kept items stuck as "in_progress" even after `response.output_item.done` arrived.

With these changes:

We preserve whatever status the API sends.

If the status is missing on a done event, we default to "completed".

Added regression tests to cover both cases. `history_updated` now correctly flips to "completed" once the response finishes.

Resolves #336 