### PR TITLE
fix(tracing): include groupId in trace export log message

### DIFF
--- a/packages/agents-core/src/tracing/processor.ts
+++ b/packages/agents-core/src/tracing/processor.ts
@@ -76,7 +76,7 @@ export class ConsoleSpanExporter implements TracingExporter {
     for (const item of items) {
       if (item.type === 'trace') {
         console.log(
-          `[Exporter] Export trace traceId=${item.traceId} name=${item.name}`,
+          `[Exporter] Export trace traceId=${item.traceId} name=${item.name}${item.groupId ? ` groupId=${item.groupId}` : ''}`,
         );
       } else {
         console.log(`[Exporter] Export span: ${JSON.stringify(item)}`);


### PR DESCRIPTION
Closes: #361 
This will conditionally append the groupId to the console output only when it's present (not null).