### PR TITLE
Add a changeset to consistenly bump minor versions for all packages

### DIFF
--- a/.changeset/pink-moles-travel.md
+++ b/.changeset/pink-moles-travel.md
@@ -1,0 +1,15 @@
+---
+'@openai/agents': minor
+'@openai/agents-core': minor
+'@openai/agents-extensions': minor
+'@openai/agents-openai': minor
+'@openai/agents-realtime': minor
+---
+
+Bump to v0.1 with the following chnages:
+
+- gpt-5 model support
+- opt-in: gpt-5 as default option
+- ai-sdk model provider v2 migration
+
+and more


### PR DESCRIPTION
As you can see at https://github.com/openai/openai-agents-js/pull/357, `@openai/agents` package has only patch upgrades, so if we go with the current list of changeset files, the package with be 0.0.18 while others are 0.1.0. This pull request makes the versioning consistent for the upcoming release.
