### PR TITLE
Fix #366 Add conversations API support

### DIFF
--- a/.changeset/thin-plants-hear.md
+++ b/.changeset/thin-plants-hear.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-openai': patch
+'@openai/agents-core': patch
+'@openai/agents': patch
+---
+
+#366 Add conversations API support

--- a/examples/basic/conversations.ts
+++ b/examples/basic/conversations.ts
@@ -1,0 +1,40 @@
+import { Agent, run } from '@openai/agents';
+import OpenAI from 'openai';
+
+async function main() {
+  const client = new OpenAI();
+
+  console.log('### New conversation:\n');
+  const newConvo = await client.conversations.create({});
+  console.log(`New conversation: ${JSON.stringify(newConvo, null, 2)}`);
+  const conversationId = newConvo.id;
+
+  const agent = new Agent({
+    name: 'Assistant',
+    instructions: 'You are a helpful assistant. be VERY concise.',
+  });
+
+  // Set the conversation ID for the runs
+  console.log('\n### Agent runs:\n');
+  const runOptions = { conversationId };
+  let result = await run(
+    agent,
+    'What is the largest country in South America?',
+    runOptions,
+  );
+  console.log(`First run: ${result.finalOutput}`); // e.g., Brazil
+  result = await run(agent, 'What is the capital of that country?', runOptions);
+  console.log(`Second run: ${result.finalOutput}`); // e.g., Brasilia
+
+  console.log('\n### Conversation items:\n');
+  const convo = await client.conversations.items.list(conversationId);
+  for await (const page of convo.iterPages()) {
+    for (const item of page.getPaginatedItems()) {
+      // desc order
+      console.log(JSON.stringify(item, null, 2));
+    }
+  }
+}
+if (require.main === module) {
+  main().catch(console.error);
+}

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -26,6 +26,7 @@
     "start:tool-use-behavior": "tsx tool-use-behavior.ts",
     "start:tools": "tsx tools.ts",
     "start:reasoning": "tsx reasoning.ts",
-    "start:local-file": "tsx local-file.ts"
+    "start:local-file": "tsx local-file.ts",
+    "start:conversations": "tsx conversations.ts"
   }
 }

--- a/examples/docs/package.json
+++ b/examples/docs/package.json
@@ -7,7 +7,6 @@
     "@openai/agents-core": "workspace:*",
     "@openai/agents-extensions": "workspace:*",
     "@openai/agents-realtime": "workspace:*",
-    "openai": "^5.12.2",
     "server-only": "^0.0.1",
     "zod": "^3.25.40"
   },

--- a/packages/agents-core/package.json
+++ b/packages/agents-core/package.json
@@ -70,7 +70,7 @@
     "@modelcontextprotocol/sdk": "^1.17.2"
   },
   "dependencies": {
-    "openai": "^5.12.2",
+    "openai": "^5.15",
     "debug": "^4.4.0"
   },
   "peerDependencies": {

--- a/packages/agents-core/src/metadata.ts
+++ b/packages/agents-core/src/metadata.ts
@@ -6,7 +6,7 @@ export const METADATA = {
   "version": "0.0.17",
   "versions": {
     "@openai/agents-core": "0.0.17",
-    "openai": "^5.12.2"
+    "openai": "^5.15"
   }
 };
 

--- a/packages/agents-core/src/model.ts
+++ b/packages/agents-core/src/model.ts
@@ -178,6 +178,14 @@ export type ModelRequest = {
   previousResponseId?: string;
 
   /**
+   * The ID of stored conversation to use for the model.
+   *
+   * see https://platform.openai.com/docs/guides/conversation-state?api-mode=responses#openai-apis-for-conversation-state
+   * see https://platform.openai.com/docs/api-reference/conversations/create
+   */
+  conversationId?: string;
+
+  /**
    * The model settings to use for the model.
    */
   modelSettings: ModelSettings;

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -136,6 +136,7 @@ type SharedRunOptions<TContext = undefined> = {
   maxTurns?: number;
   signal?: AbortSignal;
   previousResponseId?: string;
+  conversationId?: string;
 };
 
 export type StreamRunOptions<TContext = undefined> =
@@ -393,6 +394,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               prompt: await state._currentAgent.getPrompt(state._context),
               input: turnInput,
               previousResponseId: options.previousResponseId,
+              conversationId: options.conversationId,
               modelSettings,
               tools: serializedTools,
               outputType: convertAgentOutputTypeToSerializable(
@@ -757,6 +759,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             prompt: await currentAgent.getPrompt(result.state._context),
             input: turnInput,
             previousResponseId: options.previousResponseId,
+            conversationId: options.conversationId,
             modelSettings,
             tools: serializedTools,
             handoffs: serializedHandoffs,

--- a/packages/agents-openai/package.json
+++ b/packages/agents-openai/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@openai/agents-core": "workspace:*",
     "debug": "^4.4.0",
-    "openai": "^5.12.2"
+    "openai": "^5.15"
   },
   "scripts": {
     "prebuild": "tsx ../../scripts/embedMeta.ts",

--- a/packages/agents-openai/src/metadata.ts
+++ b/packages/agents-openai/src/metadata.ts
@@ -7,7 +7,7 @@ export const METADATA = {
   "versions": {
     "@openai/agents-openai": "0.0.17",
     "@openai/agents-core": "workspace:*",
-    "openai": "^5.12.2"
+    "openai": "^5.15"
   }
 };
 

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -853,6 +853,7 @@ export class OpenAIResponsesModel implements Model {
       include,
       tools,
       previous_response_id: request.previousResponseId,
+      conversation: request.conversationId,
       prompt,
       temperature: request.modelSettings.temperature,
       top_p: request.modelSettings.topP,

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -34,7 +34,7 @@
     "@openai/agents-openai": "workspace:*",
     "@openai/agents-realtime": "workspace:*",
     "debug": "^4.4.0",
-    "openai": "^5.12.2"
+    "openai": "^5.15"
   },
   "keywords": [
     "openai",

--- a/packages/agents/src/metadata.ts
+++ b/packages/agents/src/metadata.ts
@@ -9,7 +9,7 @@ export const METADATA = {
     "@openai/agents-core": "workspace:*",
     "@openai/agents-openai": "workspace:*",
     "@openai/agents-realtime": "workspace:*",
-    "openai": "^5.12.2"
+    "openai": "^5.15"
   }
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,9 +198,6 @@ importers:
       '@openai/agents-realtime':
         specifier: workspace:*
         version: link:../../packages/agents-realtime
-      openai:
-        specifier: ^5.12.2
-        version: 5.12.2(ws@8.18.2)(zod@3.25.62)
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
@@ -452,8 +449,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.1
       openai:
-        specifier: ^5.12.2
-        version: 5.12.2(ws@8.18.2)(zod@3.25.62)
+        specifier: ^5.15
+        version: 5.15.0(ws@8.18.2)(zod@3.25.62)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -468,8 +465,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.1
       openai:
-        specifier: ^5.12.2
-        version: 5.12.2(ws@8.18.2)(zod@3.25.62)
+        specifier: ^5.15
+        version: 5.15.0(ws@8.18.2)(zod@3.25.62)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -516,8 +513,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.1
       openai:
-        specifier: ^5.12.2
-        version: 5.12.2(ws@8.18.2)(zod@3.25.62)
+        specifier: ^5.15
+        version: 5.15.0(ws@8.18.2)(zod@3.25.62)
     devDependencies:
       '@ai-sdk/provider':
         specifier: ^1.1.3
@@ -4607,8 +4604,8 @@ packages:
   oniguruma-to-es@4.3.3:
     resolution: {integrity: sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg==}
 
-  openai@5.12.2:
-    resolution: {integrity: sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==}
+  openai@5.15.0:
+    resolution: {integrity: sha512-kcUdws8K/A8m02I+IqFBwO51gS+87GP89yWEufGbzEi8anBz4FB/bti2QxaJdGwwY4mwJGzx85XO7TuL/Tpu1w==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -10825,7 +10822,7 @@ snapshots:
       regex: 6.0.1
       regex-recursion: 6.0.2
 
-  openai@5.12.2(ws@8.18.2)(zod@3.25.62):
+  openai@5.15.0(ws@8.18.2)(zod@3.25.62):
     optionalDependencies:
       ws: 8.18.2
       zod: 3.25.62


### PR DESCRIPTION
This pull request adds a new option for Responses API calls. While the underlying API's parameter name is `conversation`, I propose to go with `conversationId` for this SDK. I will come up with the same PR for Python SDK.

references:
- https://platform.openai.com/docs/guides/conversation-state?api-mode=responses#openai-apis-for-conversation-state
- https://platform.openai.com/docs/api-reference/conversations/create