### PR TITLE
fix: emit agent_end lifecycle event for streaming agents

### DIFF
--- a/.changeset/fix-streaming-agent-end-lifecycle.md
+++ b/.changeset/fix-streaming-agent-end-lifecycle.md
@@ -1,0 +1,9 @@
+---
+'@openai/agents-core': patch
+---
+
+Fix streaming agents not calling agent_end lifecycle hook
+
+Streaming agents were not emitting the `agent_end` lifecycle event when completing execution, while non-streaming agents were correctly emitting this event. This fix ensures that both the agent instance and the runner emit the `agent_end` event for streaming agents when they produce a final output, maintaining consistency with the non-streaming behavior.
+
+This resolves the issue where users could not collect usage information or perform cleanup tasks at the end of streaming agent runs using the `agent_end` event handler.

--- a/.changeset/fix-streaming-agent-end-lifecycle.md
+++ b/.changeset/fix-streaming-agent-end-lifecycle.md
@@ -2,8 +2,4 @@
 '@openai/agents-core': patch
 ---
 
-Fix streaming agents not calling agent_end lifecycle hook
-
-Streaming agents were not emitting the `agent_end` lifecycle event when completing execution, while non-streaming agents were correctly emitting this event. This fix ensures that both the agent instance and the runner emit the `agent_end` event for streaming agents when they produce a final output, maintaining consistency with the non-streaming behavior.
-
-This resolves the issue where users could not collect usage information or perform cleanup tasks at the end of streaming agent runs using the `agent_end` event handler.
+Fix #371 streaming agents not calling agent_end lifecycle hook

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -832,6 +832,17 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             result.state,
             result.state._currentStep.output,
           );
+          this.emit(
+            'agent_end',
+            result.state._context,
+            currentAgent,
+            result.state._currentStep.output,
+          );
+          currentAgent.emit(
+            'agent_end',
+            result.state._context,
+            result.state._currentStep.output,
+          );
           return;
         } else if (
           result.state._currentStep.type === 'next_step_interruption'

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import {
   Agent,
   run,
+  Runner,
   setDefaultModelProvider,
   setTracingDisabled,
   Usage,
@@ -114,5 +115,68 @@ describe('Runner.run (streaming)', () => {
         e.type === 'agent_updated_stream_event',
     );
     expect(update?.agent).toBe(agentB);
+  });
+
+  it('emits agent_end lifecycle event for streaming agents', async () => {
+    class SimpleStreamingModel implements Model {
+      constructor(private resp: ModelResponse) {}
+      async getResponse(_req: ModelRequest): Promise<ModelResponse> {
+        return this.resp;
+      }
+      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
+        yield {
+          type: 'response_done',
+          response: {
+            id: 'r',
+            usage: {
+              requests: 1,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            output: this.resp.output,
+          },
+        } as any;
+      }
+    }
+
+    const agent = new Agent({
+      name: 'TestAgent',
+      model: new SimpleStreamingModel({
+        output: [fakeModelMessage('Final output')],
+        usage: new Usage(),
+      }),
+    });
+
+    // Track agent_end events on both the agent and runner
+    const agentEndEvents: Array<{ context: any; output: string }> = [];
+    const runnerEndEvents: Array<{ context: any; agent: any; output: string }> = [];
+
+    agent.on('agent_end', (context, output) => {
+      agentEndEvents.push({ context, output });
+    });
+
+    // Create a runner instance to listen for events
+    const runner = new Runner();
+    runner.on('agent_end', (context, agent, output) => {
+      runnerEndEvents.push({ context, agent, output });
+    });
+
+    const result = await runner.run(agent, 'test input', { stream: true });
+
+    // Consume the stream
+    const events: RunStreamEvent[] = [];
+    for await (const e of result.toStream()) {
+      events.push(e);
+    }
+    await result.completed;
+
+    // Verify agent_end was called on both agent and runner
+    expect(agentEndEvents).toHaveLength(1);
+    expect(agentEndEvents[0].output).toBe('Final output');
+    
+    expect(runnerEndEvents).toHaveLength(1);
+    expect(runnerEndEvents[0].agent).toBe(agent);
+    expect(runnerEndEvents[0].output).toBe('Final output');
   });
 });

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -161,10 +161,13 @@ describe('Runner.run', () => {
 
       const result = await runner.run(agent, 'test input');
 
+      // Verify the result has the expected output
+      expect(result.finalOutput).toBe('Hello World');
+
       // Verify agent_end was called on both agent and runner
       expect(agentEndEvents).toHaveLength(1);
       expect(agentEndEvents[0].output).toBe('Hello World');
-      
+
       expect(runnerEndEvents).toHaveLength(1);
       expect(runnerEndEvents[0].agent).toBe(agent);
       expect(runnerEndEvents[0].output).toBe('Hello World');
@@ -404,7 +407,7 @@ describe('Runner.run', () => {
         usage: new Usage(),
       };
       class SimpleStreamingModel implements Model {
-        constructor(private resps: ModelResponse[]) {}
+        constructor(private resps: ModelResponse[]) { }
         async getResponse(_req: ModelRequest): Promise<ModelResponse> {
           const r = this.resps.shift();
           if (!r) {

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -140,6 +140,35 @@ describe('Runner.run', () => {
 
       await expect(run(agent, 'fail')).rejects.toThrow('No response found');
     });
+
+    it('emits agent_end lifecycle event for non-streaming agents', async () => {
+      const agent = new Agent({
+        name: 'TestAgent',
+      });
+
+      // Track agent_end events on both the agent and runner
+      const agentEndEvents: Array<{ context: any; output: string }> = [];
+      const runnerEndEvents: Array<{ context: any; agent: any; output: string }> = [];
+
+      agent.on('agent_end', (context, output) => {
+        agentEndEvents.push({ context, output });
+      });
+
+      const runner = new Runner();
+      runner.on('agent_end', (context, agent, output) => {
+        runnerEndEvents.push({ context, agent, output });
+      });
+
+      const result = await runner.run(agent, 'test input');
+
+      // Verify agent_end was called on both agent and runner
+      expect(agentEndEvents).toHaveLength(1);
+      expect(agentEndEvents[0].output).toBe('Hello World');
+      
+      expect(runnerEndEvents).toHaveLength(1);
+      expect(runnerEndEvents[0].agent).toBe(agent);
+      expect(runnerEndEvents[0].output).toBe('Hello World');
+    });
   });
 
   describe('additional scenarios', () => {


### PR DESCRIPTION
## Summary

Fixes #371 - Streaming agents do not call the agent_end lifecycle hook

## Changes

- Fix streaming agents not calling agent_end lifecycle hook when completing execution
- Add agent_end event emissions in streaming loop to match non-streaming behavior  
- Add tests to verify agent_end events are emitted for both streaming and non-streaming agents
- Resolves issue where users could not collect usage information from streaming agent runs

## Problem

Users reported that `agent_end` lifecycle hooks work for non-streaming agents but are never called for streaming agents, preventing them from collecting usage information at the end of agent runs.

## Solution

Added missing `agent_end` event emissions in the streaming implementation (`packages/agents-core/src/run.ts`) to match the non-streaming behavior. Both the runner and agent instances now emit the `agent_end` event when streaming agents complete execution.

## Testing

- ✅ Added test for streaming agents emitting `agent_end` events
- ✅ Added regression test for non-streaming agents  
- ✅ Verified both agent and runner instances emit events
- ✅ Confirmed event signatures are consistent

## Impact

- **Type**: Bug fix (patch)
- **Breaking Changes**: None
- **Backward Compatibility**: Full
- **Performance**: Minimal impact (two additional event emissions)

Fixes #371
