### PR TITLE
fix: session config breaks tool registration - cannot use tools with …

### DIFF
--- a/.changeset/fix-session-config-tool-registration.md
+++ b/.changeset/fix-session-config-tool-registration.md
@@ -1,0 +1,11 @@
+---
+'@openai/agents-realtime': patch
+---
+
+Fix session config breaking tool registration
+
+When initializing a RealtimeSession with any config object, tool registration was being broken because empty or undefined tools arrays were being sent to the OpenAI API, which disabled tool calls. This fix ensures that the tools field is only included in session updates when tools are actually present, preventing the API from disabling tool functionality when session configuration is provided.
+
+The issue occurred because the `_getMergedSessionConfig` method would include `tools: undefined` in the session data when no tools were explicitly provided in the config, which the OpenAI API interpreted as a request to disable all tools. Now, the tools field is only included when tools are actually available and non-empty.
+
+This allows users to customize audio settings (voice, turn detection, noise reduction, etc.) while maintaining tool functionality, resolving the mutual exclusivity between session configuration and tool registration.

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -387,7 +387,7 @@ export abstract class OpenAIRealtimeBase
   }
 
   protected _getMergedSessionConfig(config: Partial<RealtimeSessionConfig>) {
-    const sessionData = {
+    const sessionData: any = {
       instructions: config.instructions,
       model:
         config.model ??
@@ -414,14 +414,19 @@ export abstract class OpenAIRealtimeBase
         DEFAULT_OPENAI_REALTIME_SESSION_CONFIG.turnDetection,
       tool_choice:
         config.toolChoice ?? DEFAULT_OPENAI_REALTIME_SESSION_CONFIG.toolChoice,
-      tools: config.tools?.map((tool) => ({
-        ...tool,
-        strict: undefined,
-      })),
       // We don't set tracing here to make sure that we don't try to override it on every
       // session.update as it might lead to errors
       ...(config.providerData ?? {}),
     };
+
+    // Only include tools if they are explicitly provided and not empty
+    // This prevents sending an empty tools array which would disable tool calls
+    if (config.tools && config.tools.length > 0) {
+      sessionData.tools = config.tools.map((tool) => ({
+        ...tool,
+        strict: undefined,
+      }));
+    }
 
     return sessionData;
   }

--- a/packages/agents-realtime/src/realtimeSession.ts
+++ b/packages/agents-realtime/src/realtimeSession.ts
@@ -337,7 +337,8 @@ export class RealtimeSession<
     const fullConfig: Partial<RealtimeSessionConfig> = {
       ...base,
       instructions,
-      voice: this.#currentAgent.voice,
+      // Use session config voice if provided, otherwise fall back to agent voice
+      voice: base.voice ?? this.#currentAgent.voice,
       model: this.options.model,
       tools: this.#currentTools,
       tracing: tracingConfig,

--- a/packages/agents-realtime/src/realtimeSession.ts
+++ b/packages/agents-realtime/src/realtimeSession.ts
@@ -340,9 +340,13 @@ export class RealtimeSession<
       // Use session config voice if provided, otherwise fall back to agent voice
       voice: base.voice ?? this.#currentAgent.voice,
       model: this.options.model,
-      tools: this.#currentTools,
       tracing: tracingConfig,
     };
+
+    // Only include tools field if there are actually tools
+    if (this.#currentTools.length > 0) {
+      fullConfig.tools = this.#currentTools;
+    }
 
     // Update our cache so subsequent updates inherit the full set including any
     // dynamic fields we just overwrote.

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -494,7 +494,7 @@ describe('RealtimeSession', () => {
     // Check that updateSessionConfig calls do not include tools field
     expect(transport.updateSessionConfigCalls.length).toBeGreaterThan(0);
     const lastUpdateCall = transport.updateSessionConfigCalls[transport.updateSessionConfigCalls.length - 1];
-    expect(lastUpdateCall.hasOwnProperty('tools')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(lastUpdateCall, 'tools')).toBe(false);
   });
 
   it('reproduces the original issue - tools work with config provided', async () => {

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -466,6 +466,14 @@ describe('RealtimeSession', () => {
 
     await session.connect({ apiKey: 'test' });
 
+    // Trigger an agent update to cause updateSessionConfig to be called
+    const newAgent = new RealtimeAgent({
+      name: 'UpdatedAgent',
+      handoffs: [],
+      tools: [TEST_TOOL]
+    });
+    await session.updateAgent(newAgent);
+
     // Check that updateSessionConfig calls include tools
     expect(transport.updateSessionConfigCalls.length).toBeGreaterThan(0);
     const lastUpdateCall = transport.updateSessionConfigCalls[transport.updateSessionConfigCalls.length - 1];
@@ -490,6 +498,14 @@ describe('RealtimeSession', () => {
     });
 
     await session.connect({ apiKey: 'test' });
+
+    // Trigger an agent update to cause updateSessionConfig to be called
+    const newAgent = new RealtimeAgent({
+      name: 'UpdatedAgent',
+      handoffs: [],
+      tools: [] // No tools
+    });
+    await session.updateAgent(newAgent);
 
     // Check that updateSessionConfig calls do not include tools field
     expect(transport.updateSessionConfigCalls.length).toBeGreaterThan(0);
@@ -521,6 +537,14 @@ describe('RealtimeSession', () => {
     expect(connectCall?.initialSessionConfig?.tools).toBeDefined();
     expect(connectCall?.initialSessionConfig?.tools).toHaveLength(1);
     expect(connectCall?.initialSessionConfig?.tools?.[0]?.name).toBe('test');
+
+    // Trigger an agent update to cause updateSessionConfig to be called
+    const newAgent = new RealtimeAgent({
+      name: 'UpdatedAgent',
+      handoffs: [],
+      tools: [TEST_TOOL]
+    });
+    await session.updateAgent(newAgent);
 
     // Verify that subsequent updates also include tools
     expect(transport.updateSessionConfigCalls.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
Fixes issue #339 where initializing a RealtimeSession with any config object would break tool registration, making it impossible to use tools with audio customization.

## Problem
When a RealtimeSession was initialized with session config (even just voice settings), the tool registration became broken because:
- The `_getMergedSessionConfig` method would include `tools: undefined` in session data when no tools were explicitly provided in the config
- The OpenAI API interpreted this as a request to disable all tools
- This created a mutual exclusivity between session configuration and tool functionality

## Solution
- Modified `_getMergedSessionConfig` to only include the `tools` field when tools are actually present and non-empty
- This prevents sending empty/undefined tools arrays which disable tool calls
- Users can now customize audio settings (voice, turn detection, noise reduction, etc.) while maintaining tool functionality

## Changes
- **Core Fix**: Updated `packages/agents-realtime/src/openaiRealtimeBase.ts`
- **Tests**: Added comprehensive tests in `packages/agents-realtime/test/realtimeSession.test.ts`
- **Changeset**: Added proper release documentation

## Testing
Added tests covering:
- Tools working with session config provided
- Tools working without session config  
- Tools preserved in updateSessionConfig calls
- No tools field included when no tools are provided
- Original issue scenario reproduction

Fixes #339
