### PR TITLE
revert minor in extensions package

### DIFF
--- a/.changeset/kind-states-listen.md
+++ b/.changeset/kind-states-listen.md
@@ -1,5 +1,5 @@
 ---
-'@openai/agents-extensions': minor
+'@openai/agents-extensions': patch
 ---
 
 Fix #283 #291 #300 migrate ai-sdk/provider to v2


### PR DESCRIPTION
I found that any of the sub packages has minor bump, it results in major bump for other packages. See:

- https://github.com/openai/openai-agents-js/pull/357
- https://github.com/openai/openai-agents-js/pull/386

Thus, we must always set patch for sub packages and only set minor to `@openai/agents`. If merging this PR does not work, I will come up with another one to trigger a new release PR.