### PR TITLE
Fix changeset configuration to follow consistent minor version bumps

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,9 +3,20 @@
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
-  "linked": [["@openai/agents-*"]],
+  "linked": [
+    [
+      "@openai/agents",
+      "@openai/agents-core",
+      "@openai/agents-openai",
+      "@openai/agents-realtime",
+      "@openai/agents-extensions"
+    ]
+  ],
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  },
   "ignore": []
 }

--- a/.changeset/wicked-snails-camp.md
+++ b/.changeset/wicked-snails-camp.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+Loosen the `@openai/agents` dep's version range

--- a/packages/agents-extensions/package.json
+++ b/packages/agents-extensions/package.json
@@ -25,7 +25,7 @@
     }
   },
   "peerDependencies": {
-    "@openai/agents": "workspace:*",
+    "@openai/agents": "workspace:>=0.0.0",
     "ws": "^8.18.1",
     "zod": "^3.25.40"
   },
@@ -37,7 +37,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@openai/agents": "workspace:*",
+    "@openai/agents": "workspace:>=0.0.0",
     "@types/debug": "^4.1.12",
     "ws": "^8.18.1",
     "zod": "^3.25.40"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,7 +85,7 @@ importers:
         version: link:../packages/agents
       '@tailwindcss/vite':
         specifier: ^4.0.17
-        version: 4.1.10(vite@6.3.5(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.1)(yaml@2.7.1))
+        version: 4.1.10(vite@7.0.4(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.1)(yaml@2.7.1))
       astro:
         specifier: ^5.13.0
         version: 5.13.0(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.2)(tsx@4.20.1)(typescript@5.8.3)(yaml@2.7.1)
@@ -495,7 +495,7 @@ importers:
         version: 4.4.1
     devDependencies:
       '@openai/agents':
-        specifier: workspace:*
+        specifier: workspace:>=0.0.0
         version: link:../agents
       '@types/debug':
         specifier: ^4.1.12
@@ -7747,19 +7747,19 @@ snapshots:
       postcss: 8.5.5
       tailwindcss: 4.1.10
 
-  '@tailwindcss/vite@4.1.10(vite@6.3.5(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.1)(yaml@2.7.1))':
-    dependencies:
-      '@tailwindcss/node': 4.1.10
-      '@tailwindcss/oxide': 4.1.10
-      tailwindcss: 4.1.10
-      vite: 6.3.5(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.1)(yaml@2.7.1)
-
   '@tailwindcss/vite@4.1.10(vite@6.3.5(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))':
     dependencies:
       '@tailwindcss/node': 4.1.10
       '@tailwindcss/oxide': 4.1.10
       tailwindcss: 4.1.10
       vite: 6.3.5(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1)
+
+  '@tailwindcss/vite@4.1.10(vite@7.0.4(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.1)(yaml@2.7.1))':
+    dependencies:
+      '@tailwindcss/node': 4.1.10
+      '@tailwindcss/oxide': 4.1.10
+      tailwindcss: 4.1.10
+      vite: 7.0.4(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.1)(yaml@2.7.1)
 
   '@tanstack/query-core@5.80.7': {}
 
@@ -12449,6 +12449,22 @@ snapshots:
       jiti: 2.4.2
       lightningcss: 1.30.1
       tsx: 4.20.3
+      yaml: 2.7.1
+
+  vite@7.0.4(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.1)(yaml@2.7.1):
+    dependencies:
+      esbuild: 0.25.6
+      fdir: 6.4.6(picomatch@4.0.2)
+      picomatch: 4.0.2
+      postcss: 8.5.6
+      rollup: 4.44.2
+      tinyglobby: 0.2.14
+    optionalDependencies:
+      '@types/node': 24.0.13
+      fsevents: 2.3.3
+      jiti: 2.4.2
+      lightningcss: 1.30.1
+      tsx: 4.20.1
       yaml: 2.7.1
 
   vitefu@1.0.6(vite@6.3.5(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.1)(yaml@2.7.1)):


### PR DESCRIPTION
This pull request aims to resolve the unexpected major bump behavior of the changesets like this one: https://github.com/openai/openai-agents-js/pull/386

I've added an experimental option to better control this versioning policy for us: https://github.com/changesets/changesets/blob/%40changesets/config%403.1.1/docs/experimental-options.md plus added `@openai/agents` the `linked` list to aign versioning with other packages.

Also, `@openai/agents-extensions` depends on `@openai/agents`, which brings all the sub packages. This results in the major bump for `@openai/agents-extensions` at least. Therefore, I loosen the versioning range for the package.