### PR TITLE
Fix CURL request for ephemeral key

### DIFF
--- a/docs/src/content/docs/guides/voice-agents/quickstart.mdx
+++ b/docs/src/content/docs/guides/voice-agents/quickstart.mdx
@@ -49,11 +49,7 @@ import thinClientExample from '../../../../../../examples/docs/voice-agents/thin
    ```bash
    curl -X POST https://api.openai.com/v1/realtime/client_secrets \
       -H "Authorization: Bearer $OPENAI_API_KEY" \
-      -H "Content-Type: application/json" \
-      -d '{
-        "type": "realtime",
-        "model": "gpt-realtime"
-      }'
+      -H "Content-Type: application/json"
    ```
 
    The response will contain a `client_secret.value` value that you can use to connect later on. Note that this key is only valid for a short period of time and will need to be regenerated.


### PR DESCRIPTION
I get "Unknown parameter: 'model' and 'type'" making the request to get an ephemeral key for the Realtime API. Omitting the request body gave me the key I needed.

API Responses
```json
{
  "error": {
    "message": "Unknown parameter: 'type'.",
    "type": "invalid_request_error",
    "param": "type",
    "code": "unknown_parameter"
  }
}
```

```json
{
  "error": {
    "message": "Unknown parameter: 'model'.",
    "type": "invalid_request_error",
    "param": "model",
    "code": "unknown_parameter"
  }
}
```