### PR TITLE
fix: ensure BrowserEventEmitter off removes listeners

### DIFF
--- a/packages/agents-core/test/shims/browser-event-emitter.test.ts
+++ b/packages/agents-core/test/shims/browser-event-emitter.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest';
+
+import { BrowserEventEmitter } from '../../src/shims/shims-browser';
+
+describe('BrowserEventEmitter', () => {
+  test('off removes previously registered listener', () => {
+    const emitter = new BrowserEventEmitter<{ foo: [string] }>();
+    const calls: string[] = [];
+
+    const handler = (value: string) => {
+      calls.push(value);
+    };
+
+    emitter.on('foo', handler);
+    emitter.emit('foo', 'first');
+    emitter.off('foo', handler);
+    emitter.emit('foo', 'second');
+
+    expect(calls).toEqual(['first']);
+  });
+
+  test('once triggers listener only once', () => {
+    const emitter = new BrowserEventEmitter<{ foo: [string] }>();
+    let callCount = 0;
+
+    emitter.once('foo', () => {
+      callCount += 1;
+    });
+
+    emitter.emit('foo', 'first');
+    emitter.emit('foo', 'second');
+
+    expect(callCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- track event listener wrappers in `BrowserEventEmitter` so `off` removes the correct handler
- add unit tests covering `off` and `once` behavior for browser shims

## Testing
- pnpm -F agents-core test

------
https://chatgpt.com/codex/tasks/task_i_68b50f48c5dc83208d1569d506a925a2