### PR TITLE
Fix document build error due to underlying openai package changes

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -329,6 +329,14 @@ export default defineConfig({
   integrations: [
     starlight({
       title: 'OpenAI Agents SDK',
+      // Exclude generated TypeDoc pages that lack frontmatter.
+      // These are still linked via the Starlight TypeDoc plugin sidebar.
+      content: {
+        exclude: [
+          // Problematic namespace output without frontmatter.
+          'openai/agents/@openai/**/*.md',
+        ],
+      },
       components: {
         SiteTitle: './src/components/Title.astro',
         PageTitle: './src/components/PageTitle.astro',


### PR DESCRIPTION
when you run `pnpm docs:build`, the following error rises:

```
[info] Loaded plugin typedoc-plugin-markdown
07:10:53 [starlight-typedoc-plugin] markdown generated at ./src/content/docs/openai/agents-extensions
07:10:53 [vite] Re-optimizing dependencies because lockfile has changed
07:10:53 [content] Syncing content
07:10:53 [content] Astro version changed
07:10:53 [content] Clearing content store
[InvalidContentEntryDataError] docs → openai/agents/openai/namespaces/realtime/readme data does not match collection schema.

  title**: **title: Required

  Hint:
    See https://docs.astro.build/en/guides/content-collections/ for more information on content schemas.
  Error reference:
    https://docs.astro.build/en/reference/errors/invalid-content-entry-data-error/
  Location:
    /Users/seratch/code/openai-agents-js/docs/src/content/docs/openai/agents/@openai/namespaces/realtime/README.md:0:0
  Stack trace:
    at getEntryDataAndImages (file:///Users/seratch/code/openai-agents-js/node_modules/astro/dist/content/utils.js:157:26)
    at async syncData (/Users/seratch/code/openai-agents-js/node_modules/astro/dist/content/loaders/glob.js:97:28)
```