### PR TITLE
fix: save streaming input to session before outputs

### DIFF
--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1014,14 +1014,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
 
     const executeRun = async () => {
       if (resolvedOptions.stream) {
-        const streamResult = await this.#runIndividualStream(
-          agent,
-          preparedInput,
-          resolvedOptions,
-        );
-        // for streaming runs, the outputs will be save later on
+        // Persist the user's input before streaming outputs so the session
+        // transcript preserves the turn order.
         await saveStreamInputToSession(session, sessionOriginalInput);
-        return streamResult;
+        return this.#runIndividualStream(agent, preparedInput, resolvedOptions);
       }
       const runResult = await this.#runIndividualNonStream(
         agent,


### PR DESCRIPTION
## Summary
- persist the streamed run input in the session before outputs so the transcript order is correct

## Testing
- pnpm -r build-check *(fails: @openai/agents-openai build-check: `tsc --noEmit -p ./tsconfig.test.json`)*

------
https://chatgpt.com/codex/tasks/task_i_68b7c67600cc832094220231a8aade48