### PR TITLE
fix(docs): fix link to results in human-in-the-loop guide

### DIFF
--- a/docs/src/content/docs/guides/human-in-the-loop.mdx
+++ b/docs/src/content/docs/guides/human-in-the-loop.mdx
@@ -29,7 +29,7 @@ You can define a tool that requires approval by setting the `needsApproval` opti
    - If approval has not been granted or rejected, the tool will return a static message to the agent that the tool call cannot be executed.
    - If approval / rejection is missing it will trigger a tool approval request.
 3. The agent will gather all tool approval requests and interrupt the execution.
-4. If there are any interruptions, the [result](/openai-agents-js/guides/result) will contain an `interruptions` array describing pending steps. A `ToolApprovalItem` with `type: "tool_approval_item"` appears when a tool call requires confirmation.
+4. If there are any interruptions, the [result](/openai-agents-js/guides/results) will contain an `interruptions` array describing pending steps. A `ToolApprovalItem` with `type: "tool_approval_item"` appears when a tool call requires confirmation.
 5. You can call `result.state.approve(interruption)` or `result.state.reject(interruption)` to approve or reject the tool call.
 6. After handling all interruptions, you can resume execution by passing the `result.state` back into `runner.run(agent, state)` where `agent` is the original agent that triggered the overall run.
 7. The flow starts again from step 1.


### PR DESCRIPTION
Hey,

Just noticed this link in the docs was giving a 404 while browsing this page: https://openai.github.io/openai-agents-js/guides/human-in-the-loop/

<img width="2046" height="864" alt="image" src="https://github.com/user-attachments/assets/3c7577f3-7f54-4277-8766-bc3d11ece272" />

The correct link appears to be https://openai.github.io/openai-agents-js/guides/results