### PR TITLE
fix: allow setting an initial tracing configuration for Realtime

### DIFF
--- a/.changeset/sharp-planets-rescue.md
+++ b/.changeset/sharp-planets-rescue.md
@@ -1,0 +1,5 @@
+---
+"@openai/agents-realtime": patch
+---
+
+fix: allow setting an initial tracing configuration for Realtime

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -665,6 +665,7 @@ export abstract class OpenAIRealtimeBase
     }
 
     if (
+      this.#tracingConfig !== null && 
       typeof this.#tracingConfig !== 'string' &&
       typeof tracingConfig !== 'string'
     ) {


### PR DESCRIPTION
with the current implementation, the initial tracing (workflow name and metadata) wasn't taking into account, it was rejecting configuration update even if there wasn't one set.