### PR TITLE
fix: preserve BrowserEventEmitter duplicate listener behavior

### DIFF
--- a/packages/agents-core/test/shims/browser-event-emitter.test.ts
+++ b/packages/agents-core/test/shims/browser-event-emitter.test.ts
@@ -32,4 +32,24 @@ describe('BrowserEventEmitter', () => {
 
     expect(callCount).toBe(1);
   });
+
+  test('multiple identical listeners fire for each registration and are removed by off', () => {
+    const emitter = new BrowserEventEmitter<{ foo: [string] }>();
+    const calls: string[] = [];
+
+    const handler = (value: string) => {
+      calls.push(value);
+    };
+
+    emitter.on('foo', handler);
+    emitter.on('foo', handler);
+
+    emitter.emit('foo', 'first');
+    expect(calls).toEqual(['first', 'first']);
+
+    emitter.off('foo', handler);
+    emitter.emit('foo', 'second');
+
+    expect(calls).toEqual(['first', 'first']);
+  });
 });


### PR DESCRIPTION
## Summary
- allow `BrowserEventEmitter` to maintain multiple wrappers per listener so repeated registrations behave like Node's `EventEmitter`
- clean up every wrapper when `off` is called to avoid leaking listeners
- add a regression test that covers duplicate registration semantics

## Testing
- pnpm -F agents-core test

------
https://chatgpt.com/codex/tasks/task_i_68b7c9be58148320b18aba3f8ecb5cf6