### PR TITLE
Add commit context to docs update PRs

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -60,6 +60,10 @@ jobs:
         with:
           commit-message: "Update all translated document pages"
           title: "Update all translated document pages"
-          body: "Automated update of translated documentation"
+          body: |
+            Automated update of translated documentation.
+
+            Triggered by commit: [${{ github.event.head_commit.id }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.event.head_commit.id }}).
+            Message: `${{ github.event.head_commit.message }}`
           branch: update-translated-docs-${{ github.run_id }}
           delete-branch: true


### PR DESCRIPTION
## Summary
- include the triggering commit id and message in the body of the automated translated docs PR

## Testing
- pnpm -r build-check *(fails: @openai/agents-openai build-check cannot resolve @openai/agents-core types in tsconfig.test.json)*
- pnpm build
- CI=1 pnpm test
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_i_68b8c1657f74832083334c9239d16b17