### PR TITLE
feat: enable mcp exports for cloudflare workers

### DIFF
--- a/.changeset/tasty-wings-fry.md
+++ b/.changeset/tasty-wings-fry.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+feat: enable mcp exports for cloudflare workers

--- a/packages/agents-core/src/shims/shims-workerd.ts
+++ b/packages/agents-core/src/shims/shims-workerd.ts
@@ -59,13 +59,13 @@ export function isTracingLoopRunningByDefault(): boolean {
 }
 
 /**
- * Right now Cloudflare Workers does not support MCP
+ * Use the Node versions of MCP helpers
  */
 export {
-  MCPServerStdio,
-  MCPServerStreamableHttp,
-  MCPServerSSE,
-} from './mcp-server/browser';
+  NodeMCPServerStdio as MCPServerStdio,
+  NodeMCPServerStreamableHttp as MCPServerStreamableHttp,
+  NodeMCPServerSSE as MCPServerSSE,
+} from './mcp-server/node';
 
 export { clearTimeout, setTimeout } from 'node:timers';
 


### PR DESCRIPTION
This is simple, it just enables MCP support for workerd/cloudflare workers. I did some basic tests and it seemed to work just fine! 