### PR TITLE
docs: mention connectors in MCP guide

### DIFF
--- a/docs/src/content/docs/guides/mcp.mdx
+++ b/docs/src/content/docs/guides/mcp.mdx
@@ -102,11 +102,11 @@ Only enable this if you're confident the tool list won't change. To invalidate t
 
 You can restrict which tools are exposed from each server by passing either a static filter via `createMCPToolStaticFilter` or a custom function. Here’s a combined example showing both approaches:
 
-<Code 
-  lang="typescript" 
-  code={toolFilterExample} 
-  title="Tool filtering" 
-/>
+<Code lang="typescript" code={toolFilterExample} title="Tool filtering" />
+
+## Connectors
+
+The TypeScript SDK also supports [connectors](https://platform.openai.com/docs/guides/tools-connectors-mcp#connectors) so you can expose existing systems or data sources as MCP tools. The [connectors example](https://github.com/openai/openai-agents-js/blob/main/examples/connectors/index.ts) shows how to register connectors alongside other MCP servers in an agent.
 
 ## Further reading
 

--- a/docs/src/content/docs/ja/guides/mcp.mdx
+++ b/docs/src/content/docs/ja/guides/mcp.mdx
@@ -104,6 +104,10 @@ Hosted ツールは、往復の処理全体をモデル側に任せます。あ�
 
 <Code lang="typescript" code={toolFilterExample} title="Tool filtering" />
 
+## コネクタ
+
+TypeScript SDK は [コネクタ](https://platform.openai.com/docs/guides/tools-connectors-mcp#connectors) にも対応しており、既存のシステムやデータソースを MCP ツールとして公開できます。エージェントで他の MCP サーバーと並行してコネクタを登録する例は、[connectors のサンプルコード](https://github.com/openai/openai-agents-js/blob/main/examples/connectors/index.ts) を参照してください。
+
 ## 参考資料
 
 - [Model Context Protocol](https://modelcontextprotocol.io/) – 公式仕様


### PR DESCRIPTION
## Summary
- add a Connectors section to the MCP guide after the tool filtering content
- link to the connectors example repository code and the platform connector guide
- localize the new section for the Japanese MCP guide

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_i_68be9dac67b08320aa6bd57124481f52