### PR TITLE
Add connector example to hosted MCP docs

### DIFF
--- a/docs/src/content/docs/guides/mcp.mdx
+++ b/docs/src/content/docs/guides/mcp.mdx
@@ -8,6 +8,7 @@ import hostedAgentExample from '../../../../../examples/docs/mcp/hostedAgent.ts?
 import hostedExample from '../../../../../examples/docs/mcp/hosted.ts?raw';
 import hostedStreamExample from '../../../../../examples/docs/mcp/hostedStream.ts?raw';
 import hostedHITLExample from '../../../../../examples/docs/mcp/hostedHITL.ts?raw';
+import hostedConnectorExample from '../../../../../examples/docs/mcp/hostedConnector.ts?raw';
 import streamableHttpExample from '../../../../../examples/docs/mcp/streamableHttp.ts?raw';
 import stdioExample from '../../../../../examples/docs/mcp/stdio.ts?raw';
 import toolFilterExample from '../../../../../examples/docs/mcp/tool-filter.ts?raw';
@@ -68,6 +69,18 @@ If you can programmatically determine whether a tool call is safe, you can use t
   title="Human in the loop with hosted MCP tools"
 />
 
+### Connector-backed hosted servers
+
+Hosted MCP also supports OpenAI connectors. Instead of providing a `serverUrl`, pass the connector's `connectorId` and an `authorization` token. The Responses API then handles authentication and exposes the connector's tools through the hosted MCP interface.
+
+<Code
+  lang="typescript"
+  code={hostedConnectorExample}
+  title="Connector-backed hosted MCP tool"
+/>
+
+In this example the `GOOGLE_CALENDAR_AUTHORIZATION` environment variable holds an OAuth token obtained from the Google OAuth Playground, which authorizes the connector-backed server to call the Calendar API. For a runnable sample that also demonstrates streaming, see [`examples/connectors`](https://github.com/openai/openai-agents-js/tree/main/examples/connectors).
+
 Fully working samples (Hosted tools/Streamable HTTP/stdio + Streaming, HITL, onApproval) are [examples/mcp](https://github.com/openai/openai-agents-js/tree/main/examples/mcp) in our GitHub repository.
 
 ## 2. Streamable HTTP MCP servers
@@ -102,11 +115,7 @@ Only enable this if you're confident the tool list won't change. To invalidate t
 
 You can restrict which tools are exposed from each server by passing either a static filter via `createMCPToolStaticFilter` or a custom function. Here’s a combined example showing both approaches:
 
-<Code 
-  lang="typescript" 
-  code={toolFilterExample} 
-  title="Tool filtering" 
-/>
+<Code lang="typescript" code={toolFilterExample} title="Tool filtering" />
 
 ## Further reading
 

--- a/docs/src/content/docs/ja/guides/mcp.mdx
+++ b/docs/src/content/docs/ja/guides/mcp.mdx
@@ -8,6 +8,7 @@ import hostedAgentExample from '../../../../../../examples/docs/mcp/hostedAgent.
 import hostedExample from '../../../../../../examples/docs/mcp/hosted.ts?raw';
 import hostedStreamExample from '../../../../../../examples/docs/mcp/hostedStream.ts?raw';
 import hostedHITLExample from '../../../../../../examples/docs/mcp/hostedHITL.ts?raw';
+import hostedConnectorExample from '../../../../../../examples/docs/mcp/hostedConnector.ts?raw';
 import streamableHttpExample from '../../../../../../examples/docs/mcp/streamableHttp.ts?raw';
 import stdioExample from '../../../../../../examples/docs/mcp/stdio.ts?raw';
 import toolFilterExample from '../../../../../../examples/docs/mcp/tool-filter.ts?raw';
@@ -67,6 +68,18 @@ Hosted ツールは、往復の処理全体をモデル側に任せます。あ�
   code={hostedHITLExample}
   title="Human in the loop with hosted MCP tools"
 />
+
+### コネクター対応の Hosted サーバー
+
+Hosted MCP は OpenAI コネクターにも対応しています。`serverUrl` の代わりにコネクターの `connectorId` と `authorization` トークンを指定すると、Responses API が認証を処理し、コネクターが公開するツールを hosted MCP インターフェース経由で利用できます。
+
+<Code
+  lang="typescript"
+  code={hostedConnectorExample}
+  title="Connector-backed hosted MCP tool"
+/>
+
+この例では、`GOOGLE_CALENDAR_AUTHORIZATION` 環境変数に Google OAuth Playground で取得した OAuth トークンを保存し、コネクター経由で Calendar API を呼び出しています。ストリーミングを含む実行可能なサンプルは [`examples/connectors`](https://github.com/openai/openai-agents-js/tree/main/examples/connectors) を参照してください。
 
 完全に動作するサンプル（Hosted ツール/Streamable HTTP/stdio + Streaming、HITL、onApproval）は、GitHub リポジトリの [examples/mcp](https://github.com/openai/openai-agents-js/tree/main/examples/mcp) にあります。
 

--- a/examples/docs/mcp/hostedConnector.ts
+++ b/examples/docs/mcp/hostedConnector.ts
@@ -1,0 +1,17 @@
+import { Agent, hostedMcpTool } from '@openai/agents';
+
+const authorization = process.env.GOOGLE_CALENDAR_AUTHORIZATION!;
+
+export const connectorAgent = new Agent({
+  name: 'Calendar Assistant',
+  instructions:
+    "You are a helpful assistant that can answer questions about the user's calendar.",
+  tools: [
+    hostedMcpTool({
+      serverLabel: 'google_calendar',
+      connectorId: 'connector_googlecalendar',
+      authorization,
+      requireApproval: 'never',
+    }),
+  ],
+});


### PR DESCRIPTION
## Summary
- document how to configure hosted MCP tools that are backed by OpenAI connectors
- add TypeScript example for creating a hosted connector-based tool
- localize the connector guidance for the Japanese MCP guide

## Testing
- pnpm lint


------
https://chatgpt.com/codex/tasks/task_i_68bea8f5fdfc832086daf19c143c220e