### PR TITLE
Defer final output until tool calls finish

### DIFF
--- a/packages/agents-core/src/runImplementation.ts
+++ b/packages/agents-core/src/runImplementation.ts
@@ -583,44 +583,45 @@ export async function executeToolsAndSideEffects<TContext>(
     );
   }
 
-  if (
-    agent.outputType === 'text' &&
-    !processedResponse.hasToolsOrApprovalsToRun()
-  ) {
-    return new SingleStepResult(
-      originalInput,
-      newResponse,
-      preStepItems,
-      newItems,
-      {
-        type: 'next_step_final_output',
-        output: potentialFinalOutput,
-      },
-    );
-  } else if (agent.outputType !== 'text' && potentialFinalOutput) {
-    // Structured output schema => always leads to a final output if we have text
-    const { parser } = getSchemaAndParserFromInputType(
-      agent.outputType,
-      'final_output',
-    );
-    const [error] = await safeExecute(() => parser(potentialFinalOutput));
-    if (error) {
-      addErrorToCurrentSpan({
-        message: 'Invalid output type',
-        data: {
-          error: String(error),
+  if (!processedResponse.hasToolsOrApprovalsToRun()) {
+    if (agent.outputType === 'text') {
+      return new SingleStepResult(
+        originalInput,
+        newResponse,
+        preStepItems,
+        newItems,
+        {
+          type: 'next_step_final_output',
+          output: potentialFinalOutput,
         },
-      });
-      throw new ModelBehaviorError('Invalid output type');
+      );
     }
 
-    return new SingleStepResult(
-      originalInput,
-      newResponse,
-      preStepItems,
-      newItems,
-      { type: 'next_step_final_output', output: potentialFinalOutput },
-    );
+    if (agent.outputType !== 'text' && potentialFinalOutput) {
+      // Structured output schema => always leads to a final output if we have text
+      const { parser } = getSchemaAndParserFromInputType(
+        agent.outputType,
+        'final_output',
+      );
+      const [error] = await safeExecute(() => parser(potentialFinalOutput));
+      if (error) {
+        addErrorToCurrentSpan({
+          message: 'Invalid output type',
+          data: {
+            error: String(error),
+          },
+        });
+        throw new ModelBehaviorError('Invalid output type');
+      }
+
+      return new SingleStepResult(
+        originalInput,
+        newResponse,
+        preStepItems,
+        newItems,
+        { type: 'next_step_final_output', output: potentialFinalOutput },
+      );
+    }
   }
 
   return new SingleStepResult(


### PR DESCRIPTION
## Summary
- gate final output generation on the absence of pending tools or approvals for both text and structured agents
- keep structured-output runs in the same state machine path as text runs by returning `next_step_run_again` when tools are pending
- add a regression test ensuring structured-output agents continue execution when tool calls are present in the same turn

## Testing
- pnpm -r build-check *(fails: @openai/agents-openai@0.1.1 build-check: `tsc --noEmit -p ./tsconfig.test.json`)*
- CI=1 pnpm test *(fails: Cannot find package '@openai/agents-core/_shims' imported from tracing/context.ts)*
- pnpm lint


------
https://chatgpt.com/codex/tasks/task_i_68bfc2a3ab288320835d2a8c84f0bf60