### PR TITLE
GPT‑5 model settings under providerData

### DIFF
--- a/docs/src/content/docs/guides/models.mdx
+++ b/docs/src/content/docs/guides/models.mdx
@@ -60,15 +60,15 @@ import { Agent } from '@openai/agents';
 const myAgent = new Agent({
   name: 'My Agent',
   instructions: "You're a helpful agent.",
-    modelSettings: {
-      providerData: {
-        reasoning: {
-          effort: 'minimal',
-        },
-        text: {
-          verbosity: 'low',
-        },
+  modelSettings: {
+    providerData: {
+      reasoning: {
+        effort: 'minimal',
       },
+      text: {
+        verbosity: 'low',
+      },
+    },
   // If OPENAI_DEFAULT_MODEL=gpt-5 is set, passing only modelSettings works.
   // It's also fine to pass a GPT-5 model name explicitly:
   // model: 'gpt-5',

--- a/docs/src/content/docs/guides/models.mdx
+++ b/docs/src/content/docs/guides/models.mdx
@@ -60,10 +60,15 @@ import { Agent } from '@openai/agents';
 const myAgent = new Agent({
   name: 'My Agent',
   instructions: "You're a helpful agent.",
-  modelSettings: {
-    reasoning: { effort: 'minimal' },
-    text: { verbosity: 'low' },
-  },
+    modelSettings: {
+      providerData: {
+        reasoning: {
+          effort: 'minimal',
+        },
+        text: {
+          verbosity: 'low',
+        },
+      },
   // If OPENAI_DEFAULT_MODEL=gpt-5 is set, passing only modelSettings works.
   // It's also fine to pass a GPT-5 model name explicitly:
   // model: 'gpt-5',

--- a/docs/src/content/docs/guides/models.mdx
+++ b/docs/src/content/docs/guides/models.mdx
@@ -62,12 +62,8 @@ const myAgent = new Agent({
   instructions: "You're a helpful agent.",
   modelSettings: {
     providerData: {
-      reasoning: {
-        effort: 'minimal',
-      },
-      text: {
-        verbosity: 'low',
-      },
+      reasoning: { effort: 'minimal' },
+      text: { verbosity: 'low' },
     },
   // If OPENAI_DEFAULT_MODEL=gpt-5 is set, passing only modelSettings works.
   // It's also fine to pass a GPT-5 model name explicitly:


### PR DESCRIPTION
**Summary:** Update the models guide to show GPT‑5 settings inside the providerData object so provider-specific options are placed in the correct location.

**Changes:** edit docs/src/content/docs/guides/models.mdx to demonstrate modelSettings.providerData.

**Example:** see example usage in examples/basic/hello-world-gpt-5.ts (shows modelSettings.providerData and an OpenAIChatCompletionsModel example).

**Impact:** docs-only change; no changeset required.