### PR TITLE
fix: #485 Abort during streaming throws “ReadableStream is locked” in StreamedRunResult

### DIFF
--- a/.changeset/thick-parrots-cover.md
+++ b/.changeset/thick-parrots-cover.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: #485 Abort during streaming throws “ReadableStream is locked” in StreamedRunResult

--- a/packages/agents-core/test/result.test.ts
+++ b/packages/agents-core/test/result.test.ts
@@ -61,4 +61,25 @@ describe('StreamedRunResult', () => {
     await expect(sr.completed).rejects.toBe(err);
     expect(sr.error).toBe(err);
   });
+
+  it('handles abort while iterating without throwing', async () => {
+    const state = createState();
+    const controller = new AbortController();
+    const sr = new StreamedRunResult({ state, signal: controller.signal });
+
+    const consumePromise = (async () => {
+      for await (const _ of sr) {
+        // Intentionally empty.
+      }
+    })();
+
+    await Promise.resolve();
+
+    controller.abort();
+
+    await expect(consumePromise).resolves.toBeUndefined();
+    await expect(sr.completed).resolves.toBeUndefined();
+    expect(sr.cancelled).toBe(true);
+    expect(sr.error).toBe(null);
+  });
 });


### PR DESCRIPTION
This pull request resolves #485; I've confirmed the issue is resolved using the provided code snippet too.