### PR TITLE
fix(agents-realtime): preserve GA audio formats when top-level voice is present

### DIFF
--- a/packages/agents-realtime/src/clientMessages.ts
+++ b/packages/agents-realtime/src/clientMessages.ts
@@ -175,7 +175,6 @@ function isDeprecatedConfig(
 ): config is Partial<RealtimeSessionConfigDeprecated> {
   return (
     isDefined('modalities', config) ||
-    isDefined('voice', config) ||
     isDefined('inputAudioFormat', config) ||
     isDefined('outputAudioFormat', config) ||
     isDefined('inputAudioTranscription', config) ||
@@ -215,12 +214,17 @@ export function toNewSessionConfig(
             output: config.audio.output
               ? {
                   format: normalizeAudioFormat(config.audio.output.format),
-                  voice: config.audio.output.voice,
+                  // Prefer GA output.voice; if absent, lift top-level voice into GA.
+                  voice: config.audio.output.voice ?? (config as any).voice,
                   speed: config.audio.output.speed,
                 }
-              : undefined,
+              : ((config as any).voice
+                  ? ({ voice: (config as any).voice } as RealtimeAudioOutputConfig)
+                  : undefined),
           }
-        : undefined,
+        : ((config as any).voice
+            ? ({ output: { voice: (config as any).voice } } as RealtimeAudioConfig)
+            : undefined),
     };
   }
 

--- a/packages/agents-realtime/test/realtimeVoiceConfigRegression.test.ts
+++ b/packages/agents-realtime/test/realtimeVoiceConfigRegression.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { toNewSessionConfig } from '../src/clientMessages';
+
+const TELEPHONY_AUDIO_FORMAT = { type: 'audio/pcmu' as const };
+
+describe('Realtime session voice config regression', () => {
+  it('preserves GA audio formats when top-level voice is present', () => {
+    const converted = toNewSessionConfig({
+      voice: 'alloy',
+      audio: {
+        input: { format: TELEPHONY_AUDIO_FORMAT },
+        output: { format: TELEPHONY_AUDIO_FORMAT },
+      },
+    });
+
+    expect(converted.audio?.input?.format).toEqual(TELEPHONY_AUDIO_FORMAT);
+    expect(converted.audio?.output?.format).toEqual(TELEPHONY_AUDIO_FORMAT);
+    // Also ensure GA voice lifting occurs if GA output.voice is not set explicitly
+    expect(converted.audio?.output?.voice).toEqual('alloy');
+  });
+});
+


### PR DESCRIPTION
## Summary
When a session config includes top-level , the converter treated the config as legacy and discarded GA audio formats. This change refines legacy detection and lifts top-level  into  in the GA path, preserving GA formats.

## Rationale
Issue #495 reports that adding  causes fallback to legacy, resetting telephony formats like . GA-shaped configs should remain GA even when  is provided.

## Changes
- Remove top-level  from the legacy detection heuristic.
- In GA conversion, set  from top-level  if GA audio config is present, or construct a minimal GA audio block if not.
- Add regression test to ensure GA formats persist when  is present.

## Tests
- New test  validates  preserves  and lifts .

Fixes #495
