### PR TITLE
feat(agents-realtime): add fetch-based WebSocket upgrade for Cloudflare/workerd

### DIFF
--- a/.changeset/cloudflare-fetch-upgrade.md
+++ b/.changeset/cloudflare-fetch-upgrade.md
@@ -1,0 +1,11 @@
+---
+'@openai/agents-realtime': minor
+'@openai/agents-extensions': minor
+---
+
+feat: add factory-based Cloudflare support.
+
+- Realtime (WebSocket): add `createWebSocket` and `skipOpenEventListeners` options to enable
+  custom socket creation and connection state control for specialized runtimes.
+- Extensions: add `CloudflareRealtimeTransportLayer`, which performs a `fetch()`-based WebSocket
+  upgrade on Cloudflare/workerd and integrates via the WebSocket factory.

--- a/.changeset/cloudflare-fetch-upgrade.md
+++ b/.changeset/cloudflare-fetch-upgrade.md
@@ -1,6 +1,6 @@
 ---
-'@openai/agents-realtime': minor
-'@openai/agents-extensions': minor
+'@openai/agents-realtime': patch
+'@openai/agents-extensions': patch
 ---
 
 feat: add factory-based Cloudflare support.

--- a/packages/agents-extensions/src/CloudflareRealtimeTransport.ts
+++ b/packages/agents-extensions/src/CloudflareRealtimeTransport.ts
@@ -1,0 +1,76 @@
+import {
+  RealtimeTransportLayer,
+  OpenAIRealtimeWebSocket,
+  OpenAIRealtimeWebSocketOptions,
+} from '@openai/agents/realtime';
+
+/**
+ * An adapter transport for Cloudflare Workers (workerd) environments.
+ *
+ * Cloudflare Workers cannot open outbound client WebSockets using the global `WebSocket`
+ * constructor. Instead, a `fetch()` request with `Upgrade: websocket` must be performed and the
+ * returned `response.webSocket` must be `accept()`ed. This transport encapsulates that pattern and
+ * plugs into the Realtime SDK via the factory-based `createWebSocket` option.
+ *
+ * It behaves like `OpenAIRealtimeWebSocket`, but establishes the connection using `fetch()` and
+ * sets `skipOpenEventListeners: true` since workerd sockets do not emit a traditional `open`
+ * event after acceptance.
+ *
+ * Reference: Response API — `response.webSocket` (Cloudflare Workers).
+ * https://developers.cloudflare.com/workers/runtime-apis/response/.
+ */
+export class CloudflareRealtimeTransportLayer
+  extends OpenAIRealtimeWebSocket
+  implements RealtimeTransportLayer
+{
+  protected _audioLengthMs: number = 0;
+
+  constructor(options: OpenAIRealtimeWebSocketOptions) {
+    super({
+      ...options,
+      createWebSocket: async ({ url, apiKey }) => {
+        return await this.#buildCloudflareWebSocket({ url, apiKey });
+      },
+      skipOpenEventListeners: true,
+    });
+  }
+
+  /**
+   * Builds a WebSocket using Cloudflare's `fetch()` + `Upgrade: websocket` flow and accepts it.
+   * Transforms `ws(s)` to `http(s)` for the upgrade request and forwards standard headers.
+   */
+  async #buildCloudflareWebSocket({
+    url,
+    apiKey,
+  }: {
+    url: string;
+    apiKey: string;
+  }): Promise<WebSocket> {
+    const transformedUrl = url.replace(/^ws/i, 'http');
+    if (!transformedUrl) {
+      throw new Error('Realtime URL is not defined');
+    }
+
+    const response = await fetch(transformedUrl, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Sec-WebSocket-Protocol': 'realtime',
+        Connection: 'Upgrade',
+        Upgrade: 'websocket',
+        ...this.getCommonRequestHeaders(),
+      },
+    });
+
+    const upgradedSocket = (response as any).webSocket;
+    if (!upgradedSocket) {
+      const body = await response.text().catch(() => '');
+      throw new Error(
+        `Failed to upgrade websocket: ${response.status} ${body}`,
+      );
+    }
+
+    upgradedSocket.accept();
+    return upgradedSocket as unknown as WebSocket;
+  }
+}

--- a/packages/agents-extensions/src/index.ts
+++ b/packages/agents-extensions/src/index.ts
@@ -1,2 +1,3 @@
-export * from './TwilioRealtimeTransport';
 export * from './aiSdk';
+export * from './CloudflareRealtimeTransport';
+export * from './TwilioRealtimeTransport';

--- a/packages/agents-extensions/test/CloudflareRealtimeTransport.test.ts
+++ b/packages/agents-extensions/test/CloudflareRealtimeTransport.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { CloudflareRealtimeTransportLayer } from '../src/CloudflareRealtimeTransport';
+
+class FakeWorkersWebSocket {
+  url: string;
+  listeners: Record<string, ((ev: any) => void)[]> = {};
+  accepted = false;
+  constructor(url: string) {
+    this.url = url;
+  }
+  addEventListener(type: string, listener: (ev: any) => void) {
+    this.listeners[type] = this.listeners[type] || [];
+    this.listeners[type].push(listener);
+  }
+  accept() {
+    this.accepted = true;
+  }
+  send(_data: any) {}
+  close() {
+    this.emit('close', {});
+  }
+  emit(type: string, ev: any) {
+    (this.listeners[type] || []).forEach((fn) => fn(ev));
+  }
+}
+
+describe('CloudflareRealtimeTransportLayer', () => {
+  let savedFetch: any;
+
+  beforeEach(() => {
+    savedFetch = (globalThis as any).fetch;
+  });
+
+  afterEach(() => {
+    (globalThis as any).fetch = savedFetch;
+  });
+
+  it('connects via fetch upgrade and emits connection changes', async () => {
+    const fakeSocket = new FakeWorkersWebSocket('ws://example');
+    const fetchSpy = vi.fn().mockResolvedValue({
+      webSocket: fakeSocket,
+      status: 101,
+      text: vi.fn().mockResolvedValue(''),
+    });
+    (globalThis as any).fetch = fetchSpy;
+
+    const transport = new CloudflareRealtimeTransportLayer({
+      url: 'wss://api.openai.com/v1/realtime?model=foo',
+    });
+
+    const statuses: string[] = [];
+    transport.on('connection_change', (s) => statuses.push(s));
+
+    await transport.connect({ apiKey: 'ek_test', model: 'foo' });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    // wss -> https
+    expect(fetchSpy.mock.calls[0][0]).toBe(
+      'https://api.openai.com/v1/realtime?model=foo',
+    );
+    const init = fetchSpy.mock.calls[0][1];
+    expect(init.method).toBe('GET');
+    expect(init.headers['Authorization']).toBe('Bearer ek_test');
+    expect(init.headers['Upgrade']).toBe('websocket');
+    expect(init.headers['Connection']).toBe('Upgrade');
+    expect(init.headers['Sec-WebSocket-Protocol']).toBe('realtime');
+
+    // connected without relying on 'open' listener.
+    expect(statuses).toEqual(['connecting', 'connected']);
+  });
+
+  it('propagates fetch-upgrade failures with detailed error', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      status: 400,
+      text: vi.fn().mockResolvedValue('No upgrade'),
+    });
+    (globalThis as any).fetch = fetchSpy;
+
+    const transport = new CloudflareRealtimeTransportLayer({
+      url: 'wss://api.openai.com/v1/realtime?model=bar',
+    });
+
+    await expect(
+      transport.connect({ apiKey: 'ek_x', model: 'bar' }),
+    ).rejects.toThrow('Failed to upgrade websocket: 400 No upgrade');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `useWorkersFetchUpgrade` option to `OpenAIRealtimeWebSocket` for Cloudflare/workerd ([Cloudflare Workers: WebSockets — Make outbound WebSocket connections](https://developers.cloudflare.com/workers/runtime-apis/websockets/)).
- Implements `connectViaFetchUpgrade()` to establish WS via `fetch()` + `Upgrade: websocket` (see same docs above).
- Keeps default constructor-based WebSocket path unchanged for other environments.

## Motivation

Cloudflare Workers and other workerd runtimes (e.g., Miniflare) cannot create client WebSockets via the global `WebSocket` constructor. Instead, Cloudflare’s documentation specifies using an HTTP `fetch()` upgrade flow that returns `response.webSocket`, which must be `accept()`ed ([docs](https://developers.cloudflare.com/workers/runtime-apis/websockets/)). This PR enables first-class support for that environment. For additional runtime context, see [Durable Objects and WebSockets](https://developers.cloudflare.com/workers/learning/using-durable-objects/#websockets).

## Changes

- Option: `useWorkersFetchUpgrade?: boolean` on `OpenAIRealtimeWebSocketOptions`.
- Method: `connectViaFetchUpgrade()` performs the GET + upgrade headers and accepts `response.webSocket`.
- Connection flow: in fetch-upgrade mode, transition to `connected` without relying on an `'open'` event.
- Errors: failed upgrades include HTTP status and response text for easier debugging.
- Comments: simplify option/property comments; keep detailed explanation on `connectViaFetchUpgrade()`.
- Tests: add coverage for fetch-upgrade success/failure.

## Before/After

- Before: workerd environments couldn’t connect using the default constructor-based WebSocket flow.
- After: set `useWorkersFetchUpgrade: true` to connect under Cloudflare/workerd while preserving default behavior elsewhere.

Example:

```ts
const ws = new OpenAIRealtimeWebSocket({
  url: 'ws://test',
  useWorkersFetchUpgrade: true,
});
await ws.connect({ apiKey: 'ek_...', model: 'gpt-4o-realtime' });
```

## Tests

- File: `packages/agents-realtime/test/openaiRealtimeWebsocket.test.ts`
  - Verifies URL transform (`ws:` → `http:`), required headers, and connection transitions in fetch-upgrade mode.
  - Validates error propagation when `response.webSocket` is missing.
  - Existing WebSocket tests remain passing; test URLs unified.

## Docs

- Inlined JSDoc updates: option/property one-liners; detailed method docs on `connectViaFetchUpgrade()`.

## Breaking Impact

- None. Default path remains unchanged; the new option is opt-in.

## Checklist

- [x] Builds and full test suite pass
- [x] Docs updated
- [x] Changeset added (minor bump for @openai/agents-realtime)
