### PR TITLE
fix(examples): correct AgentInputItem import type usage in examples

### DIFF
--- a/examples/agent-patterns/llm-as-a-judge.ts
+++ b/examples/agent-patterns/llm-as-a-judge.ts
@@ -1,4 +1,5 @@
-import { Agent, AgentInputItem, run, withTrace } from '@openai/agents';
+import { Agent, run, withTrace } from '@openai/agents';
+import type { AgentInputItem } from '@openai/agents';
 import { z } from 'zod';
 import readline from 'node:readline/promises';
 

--- a/examples/agent-patterns/routing.ts
+++ b/examples/agent-patterns/routing.ts
@@ -1,10 +1,6 @@
-import {
-  Agent,
-  run,
-  withTrace,
-  AgentInputItem,
-  StreamedRunResult,
-} from '@openai/agents';
+import { Agent, run, withTrace } from '@openai/agents';
+import type { AgentInputItem } from '@openai/agents';
+import type { StreamedRunResult } from '@openai/agents';
 import readline from 'node:readline/promises';
 import { randomUUID } from 'node:crypto';
 

--- a/examples/basic/chat.ts
+++ b/examples/basic/chat.ts
@@ -1,11 +1,5 @@
-import {
-  Agent,
-  AgentInputItem,
-  run,
-  tool,
-  user,
-  withTrace,
-} from '@openai/agents';
+import { Agent, run, tool, user, withTrace } from '@openai/agents';
+import type { AgentInputItem } from '@openai/agents';
 import { createInterface } from 'node:readline/promises';
 import { z } from 'zod';
 

--- a/examples/docs/results/historyLoop.ts
+++ b/examples/docs/results/historyLoop.ts
@@ -1,4 +1,5 @@
-import { AgentInputItem, Agent, user, run } from '@openai/agents';
+import { Agent, user, run } from '@openai/agents';
+import type { AgentInputItem } from '@openai/agents';
 
 const agent = new Agent({
   name: 'Assistant',

--- a/examples/docs/running-agents/chatLoop.ts
+++ b/examples/docs/running-agents/chatLoop.ts
@@ -1,4 +1,5 @@
-import { Agent, AgentInputItem, run } from '@openai/agents';
+import { Agent, run } from '@openai/agents';
+import type { AgentInputItem } from '@openai/agents';
 
 let thread: AgentInputItem[] = [];
 

--- a/examples/nextjs/src/app/api/basic/route.ts
+++ b/examples/nextjs/src/app/api/basic/route.ts
@@ -2,12 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { randomUUID } from 'node:crypto';
 
 import { agent } from '@/agents';
-import {
-  AgentInputItem,
-  Runner,
-  RunState,
-  RunToolApprovalItem,
-} from '@openai/agents';
+import { Runner, RunState, RunToolApprovalItem } from '@openai/agents';
+import type { AgentInputItem } from '@openai/agents';
 import { db } from '@/db';
 
 function generateConversationId() {


### PR DESCRIPTION
### Summary
Corrects AgentInputItem imports in documentation examples to use import type

### Affected Docs
- Running agents guide: chat-threads
- Any example code that imports AgentInputItem

This is a documentation/examples fix only; no runtime behavior changes. This fixes #277.
