### PR TITLE
Add typed reasoning / text options to ModelSettings

### DIFF
--- a/.changeset/hungry-sheep-end.md
+++ b/.changeset/hungry-sheep-end.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-openai': patch
+'@openai/agents-core': patch
+---
+
+Add typed reasoning / text options to ModelSettings

--- a/examples/ai-sdk/gpt-5.ts
+++ b/examples/ai-sdk/gpt-5.ts
@@ -1,0 +1,38 @@
+import { Agent, run, tool } from '@openai/agents';
+import { aisdk } from '@openai/agents-extensions';
+import { z } from 'zod';
+import { openai } from '@ai-sdk/openai';
+
+export async function main() {
+  const getWeatherTool = tool({
+    name: 'get_weather',
+    description: 'Get the weather for a given city',
+    parameters: z.object({ city: z.string() }),
+    execute: async ({ city }) => `The weather in ${city} is sunny`,
+  });
+  const agent = new Agent({
+    name: 'Helpful Assistant',
+    instructions:
+      'You are a helpful assistant. When you need to get the weather, you must use tools.',
+    tools: [getWeatherTool],
+    model: aisdk(openai('gpt-5-mini')),
+    modelSettings: {
+      providerData: {
+        providerOptions: {
+          openai: {
+            reasoningEffort: 'minimal',
+            textVerbosity: 'low',
+          },
+        },
+      },
+    },
+  });
+
+  const result = await run(
+    agent,
+    'Hello what is the weather in San Francisco?',
+  );
+  console.log(result.finalOutput);
+}
+
+main().catch(console.error);

--- a/examples/ai-sdk/package.json
+++ b/examples/ai-sdk/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build-check": "tsc --noEmit",
     "start": "tsx index.ts",
+    "start:gpt-5": "tsx gpt-5.ts",
     "start:stream": "tsx stream.ts"
   }
 }

--- a/examples/basic/hello-world-gpt-5.ts
+++ b/examples/basic/hello-world-gpt-5.ts
@@ -8,38 +8,59 @@ const output = z.object({
 });
 
 async function main() {
+  const prompt =
+    'Tell me about recursion in programming. Quickly responding with a single answer is fine.';
+
   const agent = new Agent({
     name: 'GPT-5 Assistant',
     model: 'gpt-5',
     instructions: "You're a helpful assistant.",
     modelSettings: {
-      providerData: {
-        reasoning: { effort: 'minimal' },
-        text: { verbosity: 'low' },
-      },
+      reasoning: { effort: 'minimal' },
+      text: { verbosity: 'low' },
     },
     outputType: output,
   });
 
-  const prompt =
-    'Tell me about recursion in programming. Quickly responding with a single answer is fine.';
   const result = await run(agent, prompt);
   console.log(result.finalOutput);
+
+  // The following code works in the same way:
+  // const agent2 = agent.clone({
+  //   modelSettings: {
+  //     providerData: {
+  //       reasoning: { effort: 'minimal' },
+  //       text: { verbosity: 'low' },
+  //     }
+  //   },
+  // });
+  // const result2 = await run(agent2, prompt);
+  // console.log(result2.finalOutput);
 
   const completionsAgent = new Agent({
     name: 'GPT-5 Assistant',
     model: new OpenAIChatCompletionsModel(new OpenAI(), 'gpt-5'),
     instructions: "You're a helpful assistant.",
     modelSettings: {
-      providerData: {
-        reasoning_effort: 'minimal',
-        verbosity: 'low',
-      },
+      reasoning: { effort: 'minimal' },
+      text: { verbosity: 'low' },
     },
     outputType: output,
   });
   const completionsResult = await run(completionsAgent, prompt);
   console.log(completionsResult.finalOutput);
+
+  // The following code works in the same way:
+  // const completionsAgent2 = completionsAgent.clone({
+  //   modelSettings: {
+  //     providerData: {
+  //       reasoning_effort: 'minimal',
+  //       verbosity: 'low',
+  //     }
+  //   },
+  // });
+  // const completionsResult2 = await run(completionsAgent2, prompt);
+  // console.log(completionsResult2.finalOutput);
 }
 
 if (require.main === module) {

--- a/packages/agents-core/src/model.ts
+++ b/packages/agents-core/src/model.ts
@@ -19,6 +19,46 @@ export type ModelSettingsToolChoice =
   | (string & {});
 
 /**
+ * Constrains effort on reasoning for [reasoning models](https://platform.openai.com/docs/guides/reasoning).
+ * Currently supported values are `minimal`, `low`, `medium`, and `high`.
+ * Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
+ */
+export type ModelSettingsReasoningEffort =
+  | 'minimal'
+  | 'low'
+  | 'medium'
+  | 'high'
+  | null;
+
+/**
+ * Configuration options for [reasoning models](https://platform.openai.com/docs/guides/reasoning).
+ */
+export type ModelSettingsReasoning = {
+  /**
+   * Constrains effort on reasoning for [reasoning models](https://platform.openai.com/docs/guides/reasoning).
+   * Currently supported values are `minimal`, `low`, `medium`, and `high`.
+   * Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
+   */
+  effort?: ModelSettingsReasoningEffort | null;
+
+  /**
+   * A summary of the reasoning performed by the model.
+   * This can be useful for debugging and understanding the model's reasoning process.
+   * One of `auto`, `concise`, or `detailed`.
+   */
+  summary?: 'auto' | 'concise' | 'detailed' | null;
+};
+
+export interface ModelSettingsText {
+  /**
+   * Constrains the verbosity of the model's response.
+   * Lower values will result in more concise responses, while higher values will result in more verbose responses.
+   * Currently supported values are `low`, `medium`, and `high`.
+   */
+  verbosity?: 'low' | 'medium' | 'high' | null;
+}
+
+/**
  * Settings to use when calling an LLM.
  *
  * This class holds optional model configuration parameters (e.g. temperature,
@@ -74,6 +114,16 @@ export type ModelSettings = {
    * Defaults to true if not provided.
    */
   store?: boolean;
+
+  /**
+   * The reasoning settings to use when calling the model.
+   */
+  reasoning?: ModelSettingsReasoning;
+
+  /**
+   * The text settings to use when calling the model.
+   */
+  text?: ModelSettingsText;
 
   /**
    * Additional provider specific settings to be passed directly to the model

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -72,6 +72,8 @@ export class OpenAIChatCompletionsModel implements Model {
             top_p: request.modelSettings.topP,
             frequency_penalty: request.modelSettings.frequencyPenalty,
             presence_penalty: request.modelSettings.presencePenalty,
+            reasoning_effort: request.modelSettings.reasoning?.effort,
+            verbosity: request.modelSettings.text?.verbosity,
           }
         : { base_url: this.#client.baseURL };
       const response = await this.#fetchResponse(request, span, false);
@@ -296,6 +298,19 @@ export class OpenAIChatCompletionsModel implements Model {
       span.spanData.input = messages;
     }
 
+    const providerData = request.modelSettings.providerData ?? {};
+    if (
+      request.modelSettings.reasoning &&
+      request.modelSettings.reasoning.effort
+    ) {
+      // merge the top-level reasoning.effort into provider data
+      providerData.reasoning_effort = request.modelSettings.reasoning.effort;
+    }
+    if (request.modelSettings.text && request.modelSettings.text.verbosity) {
+      // merge the top-level text.verbosity into provider data
+      providerData.verbosity = request.modelSettings.text.verbosity;
+    }
+
     const requestData = {
       model: this.#model,
       messages,
@@ -310,7 +325,7 @@ export class OpenAIChatCompletionsModel implements Model {
       parallel_tool_calls: parallelToolCalls,
       stream,
       store: request.modelSettings.store,
-      ...request.modelSettings.providerData,
+      ...providerData,
     };
 
     if (logger.dontLogModelData) {

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -852,7 +852,20 @@ export class OpenAIResponsesModel implements Model {
     const toolChoice = getToolChoice(request.modelSettings.toolChoice);
     const { text, ...restOfProviderData } =
       request.modelSettings.providerData ?? {};
-    const responseFormat = getResponseFormat(request.outputType, text);
+    if (request.modelSettings.reasoning) {
+      // Merge top-level reasoning settings with provider data
+      restOfProviderData.reasoning = {
+        ...request.modelSettings.reasoning,
+        ...restOfProviderData.reasoning,
+      };
+    }
+    let mergedText = text;
+    if (request.modelSettings.text) {
+      // Merge top-level text settings with provider data
+      mergedText = { ...request.modelSettings.text, ...text };
+    }
+    const responseFormat = getResponseFormat(request.outputType, mergedText);
+
     const prompt = getPrompt(request.prompt);
 
     let parallelToolCalls: boolean | undefined = undefined;


### PR DESCRIPTION
This pull request adds type-safe reasoning.effort/summary and text.verbosity to ModelSettings. See the updated examples for how they can be used.