### PR TITLE
fix: #247 logging for a sub-agent w/ stopAtToolNames

### DIFF
--- a/.changeset/cuddly-states-begin.md
+++ b/.changeset/cuddly-states-begin.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: #247 logging for a sub-agent w/ stopAtToolNames

--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -556,6 +556,20 @@ export class Agent<
           context,
           ...(runOptions ?? {}),
         });
+
+        const usesStopAtToolNames =
+          typeof this.toolUseBehavior === 'object' &&
+          this.toolUseBehavior !== null &&
+          'stopAtToolNames' in this.toolUseBehavior;
+
+        if (
+          typeof customOutputExtractor !== 'function' &&
+          usesStopAtToolNames
+        ) {
+          logger.debug(
+            `You're passing the agent (name: ${this.name}) with toolUseBehavior.stopAtToolNames configured as a tool to a different agent; this may not work as you expect. You may want to have a wrapper function tool to consistently return the final output.`,
+          );
+        }
         const outputText =
           typeof customOutputExtractor === 'function'
             ? await customOutputExtractor(result as any)


### PR DESCRIPTION
This pull request improves the clarity of the behavior of agents w/ stopAtToolNames as tools; I was initially going to add warn-level logging, but it could be a noise for some edge cases. So, I've set the logging level to debug for now. We may revisit this in the future.

resolves #247 (for now)