### PR TITLE
fix: #261 add support for other models that could produce JSON output in text content

### DIFF
--- a/.changeset/spotty-kids-follow.md
+++ b/.changeset/spotty-kids-follow.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: #261 add support for other models that could produce JSON output in text content


### PR DESCRIPTION
This pull request resolves #261 

Here are the actual request and response data in the scenario mentioned in the issue:

### request

```json
{
  "tools": [],
  "prompt": [
    {
      "role": "system",
      "content": "You are a helpful assistant\n\nYou must respond with a JSON object that matches this schema:\n{\n  \"type\": \"object\",\n  \"properties\": {\n    \"content\": {\n      \"type\": \"string\",\n      \"description\": \"Markdown formatted content \"\n    }\n  },\n  \"required\": [\n    \"content\"\n  ],\n  \"additionalProperties\": false,\n  \"$schema\": \"http://json-schema.org/draft-07/schema#\"\n}\nReturn only valid JSON without code fences or extra commentary."
    },
    {
      "role": "user",
      "content": [
        {
          "type": "text",
          "text": "Write a haiku about  programming."
        }
      ],
      "providerOptions": {}
    }
  ],
  "responseFormat": {
    "type": "json",
    "name": "output",
    "schema": {
      "type": "object",
      "properties": {
        "content": {
          "type": "string",
          "description": "Markdown formatted content "
        }
      },
      "required": [
        "content"
      ],
      "additionalProperties": false,
      "$schema": "http://json-schema.org/draft-07/schema#"
    }
  }
}
```
### response

```json
{
  "responseId": "gen-1758930715-v132zfskAXPfAUDr5trQ",
  "usage": {
    "requests": 1,
    "inputTokens": 139,
    "outputTokens": 37,
    "totalTokens": 176,
    "inputTokensDetails": [],
    "outputTokensDetails": []
  },
  "output": [
    {
      "type": "message",
      "content": [
        {
          "type": "output_text",
          "text": "{\n  \"content\": \"Code flows like water,\\nBugs hide in silent shadows—\\nDebug, breathe, repeat.\"\n}"
        }
      ],
      "role": "assistant",
      "status": "completed",
      "providerData": {
        "openrouter": {
          "provider": "Google",
          "usage": {
            "promptTokens": 139,
            "completionTokens": 37,
            "totalTokens": 176,
            "promptTokensDetails": {
              "cachedTokens": 0
            },
            "completionTokensDetails": {
              "reasoningTokens": 0
            },
            "costDetails": {
              "upstreamInferenceCost": 0
            }
          }
        }
      }
    }
  ],
  "providerData": {
    "content": [
      {
        "type": "text",
        "text": "{\n  \"content\": \"Code flows like water,\\nBugs hide in silent shadows—\\nDebug, breathe, repeat.\"\n}"
      }
    ],
    "finishReason": "stop",
    "usage": {
      "inputTokens": 139,
      "outputTokens": 37,
      "totalTokens": 176,
      "reasoningTokens": 0,
      "cachedInputTokens": 0
    },
    "warnings": [],
    "providerMetadata": {
      "openrouter": {
        "provider": "Google",
        "usage": {
          "promptTokens": 139,
          "completionTokens": 37,
          "totalTokens": 176,
          "promptTokensDetails": {
            "cachedTokens": 0
          },
          "completionTokensDetails": {
            "reasoningTokens": 0
          },
          "costDetails": {
            "upstreamInferenceCost": 0
          }
        }
      }
    },
    "request": {
      "body": {
        "model": "anthropic/claude-sonnet-4",
        "response_format": {
          "type": "json_schema",
          "json_schema": {
            "schema": {
              "type": "object",
              "properties": {
                "content": {
                  "type": "string",
                  "description": "Markdown formatted content "
                }
              },
              "required": [
                "content"
              ],
              "additionalProperties": false,
              "$schema": "http://json-schema.org/draft-07/schema#"
            },
            "strict": true,
            "name": "output"
          }
        },
        "messages": [
          {
            "role": "system",
            "content": "You are a helpful assistant\n\nYou must respond with a JSON object that matches this schema:\n{\n  \"type\": \"object\",\n  \"properties\": {\n    \"content\": {\n      \"type\": \"string\",\n      \"description\": \"Markdown formatted content \"\n    }\n  },\n  \"required\": [\n    \"content\"\n  ],\n  \"additionalProperties\": false,\n  \"$schema\": \"http://json-schema.org/draft-07/schema#\"\n}\nReturn only valid JSON without code fences or extra commentary."
          },
          {
            "role": "user",
            "content": "Write a haiku about  programming."
          }
        ]
      }
    },
    "response": {
      "id": "gen-1758930715-v132zfskAXPfAUDr5trQ",
      "modelId": "anthropic/claude-sonnet-4",
      "headers": {
        "access-control-allow-origin": "*",
        "cf-ray": "9856ac076f8f986e-NRT",
        "connection": "keep-alive",
        "content-encoding": "gzip",
        "content-type": "application/json",
        "date": "Fri, 26 Sep 2025 23:51:56 GMT",
        "permissions-policy": "payment=(self \"https://checkout.stripe.com\" \"https://connect-js.stripe.com\" \"https://js.stripe.com\" \"https://*.js.stripe.com\" \"https://hooks.stripe.com\")",
        "referrer-policy": "no-referrer, strict-origin-when-cross-origin",
        "server": "cloudflare",
        "transfer-encoding": "chunked",
        "vary": "Accept-Encoding",
        "x-content-type-options": "nosniff"
      }
    }
  }
}
```

### code

```typescript
import { Agent } from '@openai/agents';
import { aisdk } from '@openai/agents-extensions';
import { createOpenRouter } from '@openrouter/ai-sdk-provider';
import { Runner } from '@openai/agents';
import { z } from 'zod';
import dotenv from 'dotenv';
dotenv.config();
const StartAgentResponseSchema2 = z.object({
  content: z.string().describe('Markdown formatted content ')
});

const modelName = 'anthropic/claude-sonnet-4';
const openrouter = createOpenRouter({
  apiKey: process.env.OPENROUTER_API_KEY || ''
});
const model = aisdk(openrouter(modelName));

const runner = new Runner({
  model: model,
  tracingDisabled: true
});
const agent = new Agent({
  name: 'Assistant',
  instructions: 'You are a helpful assistant',
  outputType: StartAgentResponseSchema2
});

async function main() {
  try {
    const result = await runner.run(agent, 'Write a haiku about  programming.');
    console.log(result.finalOutput);
  } catch (e) {
    console.log(e);
  }
}

main().catch(console.error);
```