### PR TITLE
Fix: Updated Python SDK link in docs config

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -427,7 +427,7 @@ export default defineConfig({
       social: [
         {
           icon: 'seti:python',
-          href: 'https://github.com/openai/openai-agents-python',
+          href: 'https://openai.github.io/openai-agents-python/',
           label: 'Python SDK',
         },
       ],


### PR DESCRIPTION
### Summary
This PR updates the **Python SDK** link in the Astro docs configuration.

- **Before:** The link pointed to the GitHub repo  
  ➡️ https://github.com/openai/openai-agents-python  

- **After:** The link now correctly points to the official Python SDK documentation site  
  ✅ https://openai.github.io/openai-agents-python/  

### Why This Fix?
- Ensures users are redirected to the correct documentation.
- Provides consistency across SDK docs (JS and Python).
- Avoids confusion for new users who expect docs, not the repo.

### Files Updated
- `astro.config.ts` (docs site configuration)

### Notes
Verified locally — the updated **Python SDK** link in the top navigation/social icons now redirects to the correct docs site.
