### PR TITLE
Fix duplicate "Overview" in sidebar by renaming root label to "Home"

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -93,7 +93,7 @@ const plugins = [
 
 const sidebar = [
   {
-    label: 'Overview',
+    label: 'Home',
     link: '/',
     translations: {
       ja: '概要',


### PR DESCRIPTION
## 📝 PR Description

This PR fixes the **duplicate "Overview" entry** in the sidebar navigation.  
Previously, both the `Overview` section and the root (`/`) link were displayed as "Overview," causing confusion.

### ✅ Changes Made
- Updated root label from **"Overview" → "Home"**
- Preserved translations:
  - Japanese: `概要`
  - Chinese: `概述`
  - Korean: `개요`
- Root link still points to `/` (docs homepage)

### 🎯 Why This Fix?
- Removes redundancy in the sidebar
- Improves clarity and navigation for users
- Keeps consistency with common documentation practices

---
⚡ Ready for review & merge.
