### PR TITLE
docs: fix import path typos in Voice Agents Quickstart

### DIFF
--- a/docs/src/content/docs/guides/voice-agents/quickstart.mdx
+++ b/docs/src/content/docs/guides/voice-agents/quickstart.mdx
@@ -66,7 +66,7 @@ import thinClientExample from '../../../../../../examples/docs/voice-agents/thin
    Creating a new [`RealtimeAgent`](/openai-agents-js/openai/agents-realtime/classes/realtimeagent/) is very similar to creating a regular [`Agent`](/openai-agents-js/guides/agents).
 
    ```typescript
-   import { RealtimeAgent } from '@openai/agents-realtime';
+   import { RealtimeAgent } from '@openai/agents/realtime';
 
    const agent = new RealtimeAgent({
      name: 'Assistant',
@@ -79,7 +79,7 @@ import thinClientExample from '../../../../../../examples/docs/voice-agents/thin
    Unlike a regular agent, a Voice Agent is continuously running and listening inside a `RealtimeSession` that handles the conversation and connection to the model over time. This session will also handle the audio processing, interruptions, and a lot of the other lifecycle functionality we will cover later on.
 
    ```typescript
-   import { RealtimeSession } from '@openai/agents-realtime';
+   import { RealtimeSession } from '@openai/agents/realtime';
 
    const session = new RealtimeSession(agent, {
      model: 'gpt-realtime',

--- a/docs/src/content/docs/ja/guides/voice-agents/quickstart.mdx
+++ b/docs/src/content/docs/ja/guides/voice-agents/quickstart.mdx
@@ -66,7 +66,7 @@ import thinClientExample from '../../../../../../../examples/docs/voice-agents/t
    新しい [`RealtimeAgent`](/openai-agents-js/openai/agents-realtime/classes/realtimeagent/) の作成は、通常の [`Agent`](/openai-agents-js/ja/guides/agents) の作成と非常によく似ています。
 
    ```typescript
-   import { RealtimeAgent } from '@openai/agents-realtime';
+   import { RealtimeAgent } from '@openai/agents/realtime';
 
    const agent = new RealtimeAgent({
      name: 'Assistant',
@@ -79,7 +79,7 @@ import thinClientExample from '../../../../../../../examples/docs/voice-agents/t
    通常のエージェントと異なり、音声エージェントは会話とモデルへの継続的な接続を扱う `RealtimeSession` 内で常時動作し、リッスンします。このセッションは、音声処理、中断、その他多くのライフサイクル機能も扱います。これらは後ほど説明します。
 
    ```typescript
-   import { RealtimeSession } from '@openai/agents-realtime';
+   import { RealtimeSession } from '@openai/agents/realtime';
 
    const session = new RealtimeSession(agent, {
      model: 'gpt-realtime',

--- a/docs/src/content/docs/ko/guides/voice-agents/quickstart.mdx
+++ b/docs/src/content/docs/ko/guides/voice-agents/quickstart.mdx
@@ -66,7 +66,7 @@ import thinClientExample from '../../../../../../../examples/docs/voice-agents/t
    새로운 [`RealtimeAgent`](/openai-agents-js/openai/agents-realtime/classes/realtimeagent/)를 생성하는 방법은 일반 [`Agent`](/openai-agents-js/ko/guides/agents)를 만드는 것과 매우 유사합니다.
 
    ```typescript
-   import { RealtimeAgent } from '@openai/agents-realtime';
+   import { RealtimeAgent } from '@openai/agents/realtime';
 
    const agent = new RealtimeAgent({
      name: 'Assistant',
@@ -79,7 +79,7 @@ import thinClientExample from '../../../../../../../examples/docs/voice-agents/t
    일반 에이전트와 달리, 음성 에이전트는 대화와 모델 연결을 지속적으로 처리하는 `RealtimeSession` 안에서 계속 실행되며 청취합니다. 이 세션은 오디오 처리, 인터럽션(중단 처리), 그리고 이후 다룰 다양한 라이프사이클 기능도 담당합니다.
 
    ```typescript
-   import { RealtimeSession } from '@openai/agents-realtime';
+   import { RealtimeSession } from '@openai/agents/realtime';
 
    const session = new RealtimeSession(agent, {
      model: 'gpt-realtime',

--- a/docs/src/content/docs/zh/guides/voice-agents/quickstart.mdx
+++ b/docs/src/content/docs/zh/guides/voice-agents/quickstart.mdx
@@ -66,7 +66,7 @@ import thinClientExample from '../../../../../../../examples/docs/voice-agents/t
    创建一个新的 [`RealtimeAgent`](/openai-agents-js/openai/agents-realtime/classes/realtimeagent/) 与创建常规的 [`Agent`](/openai-agents-js/zh/guides/agents) 非常相似。
 
    ```typescript
-   import { RealtimeAgent } from '@openai/agents-realtime';
+   import { RealtimeAgent } from '@openai/agents/realtime';
 
    const agent = new RealtimeAgent({
      name: 'Assistant',
@@ -79,7 +79,7 @@ import thinClientExample from '../../../../../../../examples/docs/voice-agents/t
    与常规智能体不同，语音智能体会在一个持续运行并监听的 `RealtimeSession` 中工作，它负责在一段时间内处理与模型的对话与连接。该会话还将处理音频处理、打断，以及我们稍后会介绍的许多生命周期功能。
 
    ```typescript
-   import { RealtimeSession } from '@openai/agents-realtime';
+   import { RealtimeSession } from '@openai/agents/realtime';
 
    const session = new RealtimeSession(agent, {
      model: 'gpt-realtime',


### PR DESCRIPTION
## Summary
Align import path references for consistency in the voice agents quickstart guides.

## Changes

- Before: `import { RealtimeAgent } from '@openai/agents-realtime'`
- After: `import { RealtimeAgent } from '@openai/agents/realtime'`
- Before: `import { RealtimeSession } from '@openai/agents-realtime'`
- After: `import { RealtimeSession } from '@openai/agents/realtime'`

## Notes
- Docs-only change. No runtime code affected.
- Applies to en/ja/ko/zh quickstart pages.