### PR TITLE
fix: #562 invalid model settings when prompt is set in Agent

### DIFF
--- a/.changeset/young-bars-hide.md
+++ b/.changeset/young-bars-hide.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: #562 invalid model settings when prompt is set in Agent

--- a/examples/basic/prompt-id.ts
+++ b/examples/basic/prompt-id.ts
@@ -5,7 +5,6 @@ async function main() {
     name: 'Assistant',
     prompt: {
       promptId: 'pmpt_68d50b26524c81958c1425070180b5e10ab840669e470fc7',
-      version: '1',
       variables: { name: 'Kaz' },
     },
   });

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -878,7 +878,7 @@ export class OpenAIResponsesModel implements Model {
     }
 
     const requestData = {
-      model: this.#model,
+      ...(!request.prompt ? { model: this.#model } : {}),
       instructions: normalizeInstructions(request.systemInstructions),
       input,
       include,


### PR DESCRIPTION
this pull request resolves #562; i confirmed the behavior using a few examples as well; probably python sdk should have the same issue; i will send a pull request to python repo later on.