### PR TITLE
docs: update Node.js and pnpm version prerequisites in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,8 @@ Other important directories:
 
 ### Prerequisites
 
-- Node.js v18 or later
-- pnpm v7 or later
+- Node.js 22 or later
+- pnpm 10 or later
 
 ### Setup
 


### PR DESCRIPTION
Updated the prerequisites section to align with the current project requirements:
- Node.js v18 -> Node.js 22 or later
- pnpm v7 -> pnpm 10 or later

This ensures consistency with README.md and AGENTS.md documentation.