### PR TITLE
fix: #563 enable explicit model override for prompt

### DIFF
--- a/.changeset/blue-symbols-kiss.md
+++ b/.changeset/blue-symbols-kiss.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-openai': patch
+'@openai/agents-core': patch
+---
+
+fix: #563 enable explicit model override for prompt

--- a/packages/agents-core/src/model.ts
+++ b/packages/agents-core/src/model.ts
@@ -269,6 +269,13 @@ export type ModelRequest = {
    * The prompt template to use for the model, if any.
    */
   prompt?: Prompt;
+
+  /**
+   * When true, the resolved model should override the model configured in the prompt template.
+   * Providers that support prompt templates should include the explicit model name in the request
+   * even when a prompt is supplied.
+   */
+  overridePromptModel?: boolean;
 };
 
 export type ModelResponse = {

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -558,6 +558,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 state._context,
               ),
               prompt: await state._currentAgent.getPrompt(state._context),
+              // Explicit agent/run config models should take precedence over prompt defaults.
+              ...(explictlyModelSet ? { overridePromptModel: true } : {}),
               input: turnInput,
               previousResponseId,
               conversationId,
@@ -957,6 +959,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               result.state._context,
             ),
             prompt: await currentAgent.getPrompt(result.state._context),
+            // Streaming requests should also honor explicitly chosen models.
+            ...(explictlyModelSet ? { overridePromptModel: true } : {}),
             input: turnInput,
             previousResponseId,
             conversationId,

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -877,8 +877,13 @@ export class OpenAIResponsesModel implements Model {
       parallelToolCalls = request.modelSettings.parallelToolCalls;
     }
 
+    // When a prompt template already declares a model, skip sending the agent's default model.
+    // If the caller explicitly requests an override, include the resolved model name in the request.
+    const shouldSendModel =
+      !request.prompt || request.overridePromptModel === true;
+
     const requestData = {
-      ...(!request.prompt ? { model: this.#model } : {}),
+      ...(shouldSendModel ? { model: this.#model } : {}),
       instructions: normalizeInstructions(request.systemInstructions),
       input,
       include,

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -104,6 +104,37 @@ describe('OpenAIResponsesModel', () => {
     });
   });
 
+  it('includes model when overridePromptModel is true', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = { id: 'res-prompt-override', usage: {}, output: [] };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-override');
+
+      const request = {
+        systemInstructions: undefined,
+        prompt: { promptId: 'pmpt_456' },
+        input: 'hello',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+        overridePromptModel: true,
+      };
+
+      await model.getResponse(request as any);
+
+      expect(createMock).toHaveBeenCalledTimes(1);
+      const [args] = createMock.mock.calls[0];
+      expect(args.model).toBe('gpt-override');
+      expect(args.prompt).toMatchObject({ id: 'pmpt_456' });
+    });
+  });
+
   it('normalizes systemInstructions so empty strings are omitted', async () => {
     await withTrace('test', async () => {
       const fakeResponse = {


### PR DESCRIPTION
This pull request applies additional changes to support model override for prompt to #563 changes. This means explicitly set model in an agent should be used while the default model won't be set when a prompt exists in a request.