### PR TITLE
fix: #597 hostedMcpTool fails to send authorization parameter to Responses API

### DIFF
--- a/.changeset/long-mangos-think.md
+++ b/.changeset/long-mangos-think.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: #597 hostedMcpTool fails to send authorization parameter to Responses API

--- a/packages/agents-core/src/tool.ts
+++ b/packages/agents-core/src/tool.ts
@@ -196,6 +196,7 @@ export function hostedMcpTool<Context = UnknownContext>(
             type: 'mcp',
             server_label: options.serverLabel,
             server_url: options.serverUrl,
+            authorization: options.authorization,
             require_approval: 'never',
             allowed_tools: toMcpAllowedToolsFilter(options.allowedTools),
             headers: options.headers,
@@ -204,6 +205,7 @@ export function hostedMcpTool<Context = UnknownContext>(
             type: 'mcp',
             server_label: options.serverLabel,
             server_url: options.serverUrl,
+            authorization: options.authorization,
             allowed_tools: toMcpAllowedToolsFilter(options.allowedTools),
             headers: options.headers,
             require_approval:

--- a/packages/agents-core/test/tool.test.ts
+++ b/packages/agents-core/test/tool.test.ts
@@ -49,6 +49,30 @@ describe('create a tool using hostedMcpTool utility', () => {
     expect(t.providerData.type).toBe('mcp');
     expect(t.providerData.server_label).toBe('gitmcp');
   });
+
+  it('propagates authorization when approval is never required', () => {
+    const t = hostedMcpTool({
+      serverLabel: 'gitmcp',
+      serverUrl: 'https://gitmcp.io/openai/codex',
+      authorization: 'secret-token',
+      requireApproval: 'never',
+    });
+
+    expect(t.providerData.authorization).toBe('secret-token');
+  });
+
+  it('propagates authorization when approval is required', () => {
+    const t = hostedMcpTool({
+      serverLabel: 'gitmcp',
+      serverUrl: 'https://gitmcp.io/openai/codex',
+      authorization: 'secret-token',
+      requireApproval: {
+        always: { toolNames: ['tool-name'] },
+      },
+    });
+
+    expect(t.providerData.authorization).toBe('secret-token');
+  });
 });
 
 describe('tool.invoke', () => {


### PR DESCRIPTION
This pull request resolves #597 