### PR TITLE
Add example for integrating external model providers (e.g., Gemini,Grok) using OpenAI Agents SDK

### DIFF
--- a/examples/external-provider/index.ts
+++ b/examples/external-provider/index.ts
@@ -1,0 +1,26 @@
+import { Agent, Runner, OpenAIChatCompletionsModel } from '@openai/agents';
+import { OpenAI } from 'openai';
+
+const BASE_URL = process.env.EXAMPLE_BASE_URL || '';
+const API_KEY = process.env.EXAMPLE_API_KEY || '';
+const MODEL_NAME = process.env.EXAMPLE_MODEL_NAME || '';
+
+const client = new OpenAI({
+    apiKey: API_KEY,
+    baseURL: BASE_URL, // external endpoint
+});
+
+const model = new OpenAIChatCompletionsModel(client, MODEL_NAME);
+
+async function main() {
+    const agent = new Agent({
+        name: 'Assistant',
+        instructions: 'You are a helpful AI assistant.',
+    });
+
+    const runner = new Runner({ model });
+    const result = await runner.run(agent, "What's 2 + 2?");
+    console.log(result.finalOutput);
+}
+
+main();


### PR DESCRIPTION

I noticed that the documentation and examples currently don’t include a clear demonstration of how to use **external OpenAI-compatible providers** (such as Gemini or other APIs) with the **OpenAI Agents SDK**.

While the SDK internally supports custom `baseURL` and external client configurations, there’s **no simple example** showing how developers can integrate these providers step-by-step — which can be confusing for new users.

I created a working example that shows:

-   How to configure a custom `OpenAI` client with an external `baseURL`
    
-   How to use that client with `OpenAIChatCompletionsModel`
    
-   How to connect it with `Agent` and `Runner` to run responses smoothly
    

This example will save other developers a lot of time.  
I personally spent almost a full day figuring this out and testing it, so I’m sharing it to make things easier for future contributors and users.

Proposed addition:

-   New example file: `examples/external-provider.ts` (or under `examples/model-providers/`)
    
-   Demonstrates integration with any OpenAI-compatible endpoint
    

Would you like me to open a PR adding this example under `examples/model-providers/`?