### PR TITLE
fix: ugprade openai package from v5 to v6

### DIFF
--- a/.changeset/heavy-crabs-start.md
+++ b/.changeset/heavy-crabs-start.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-openai': patch
+'@openai/agents-core': patch
+'@openai/agents': patch
+---
+
+fix: ugprade openai package from v5 to v6

--- a/packages/agents-core/package.json
+++ b/packages/agents-core/package.json
@@ -70,7 +70,7 @@
     "@modelcontextprotocol/sdk": "^1.17.2"
   },
   "dependencies": {
-    "openai": "^5.20.2",
+    "openai": "^6",
     "debug": "^4.4.0"
   },
   "peerDependencies": {

--- a/packages/agents-core/src/metadata.ts
+++ b/packages/agents-core/src/metadata.ts
@@ -6,7 +6,7 @@ export const METADATA = {
   "version": "0.2.0",
   "versions": {
     "@openai/agents-core": "0.2.0",
-    "openai": "^5.20.2"
+    "openai": "^6"
   }
 };
 

--- a/packages/agents-openai/package.json
+++ b/packages/agents-openai/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@openai/agents-core": "workspace:*",
     "debug": "^4.4.0",
-    "openai": "^5.20.2"
+    "openai": "^6"
   },
   "scripts": {
     "prebuild": "tsx ../../scripts/embedMeta.ts",

--- a/packages/agents-openai/src/metadata.ts
+++ b/packages/agents-openai/src/metadata.ts
@@ -7,7 +7,7 @@ export const METADATA = {
   "versions": {
     "@openai/agents-openai": "0.2.0",
     "@openai/agents-core": "workspace:*",
-    "openai": "^5.20.2"
+    "openai": "^6"
   }
 };
 

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -34,7 +34,7 @@
     "@openai/agents-openai": "workspace:*",
     "@openai/agents-realtime": "workspace:*",
     "debug": "^4.4.0",
-    "openai": "^5.20.2"
+    "openai": "^6"
   },
   "keywords": [
     "openai",

--- a/packages/agents/src/metadata.ts
+++ b/packages/agents/src/metadata.ts
@@ -9,7 +9,7 @@ export const METADATA = {
     "@openai/agents-core": "workspace:*",
     "@openai/agents-openai": "workspace:*",
     "@openai/agents-realtime": "workspace:*",
-    "openai": "^5.20.2"
+    "openai": "^6"
   }
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,8 +416,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.3
       openai:
-        specifier: ^5.20.2
-        version: 5.23.2(ws@8.18.3)(zod@3.25.76)
+        specifier: ^6
+        version: 6.7.0(ws@8.18.3)(zod@3.25.76)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -432,8 +432,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.3
       openai:
-        specifier: ^5.20.2
-        version: 5.23.2(ws@8.18.3)(zod@3.25.76)
+        specifier: ^6
+        version: 6.7.0(ws@8.18.3)(zod@3.25.76)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -483,8 +483,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.3
       openai:
-        specifier: ^5.20.2
-        version: 5.23.2(ws@8.18.3)(zod@3.25.76)
+        specifier: ^6
+        version: 6.7.0(ws@8.18.3)(zod@3.25.76)
     devDependencies:
       '@ai-sdk/provider':
         specifier: ^1.1.3
@@ -4188,12 +4188,12 @@ packages:
   oniguruma-to-es@4.3.3:
     resolution: {integrity: sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg==}
 
-  openai@5.23.2:
-    resolution: {integrity: sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==}
+  openai@6.7.0:
+    resolution: {integrity: sha512-mgSQXa3O/UXTbA8qFzoa7aydbXBJR5dbLQXCRapAOtoNT+v69sLdKMZzgiakpqhclRnhPggPAXoniVGn2kMY2A==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
-      zod: ^3.23.8
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       ws:
         optional: true
@@ -10028,7 +10028,7 @@ snapshots:
       regex: 6.0.1
       regex-recursion: 6.0.2
 
-  openai@5.23.2(ws@8.18.3)(zod@3.25.76):
+  openai@6.7.0(ws@8.18.3)(zod@3.25.76):
     optionalDependencies:
       ws: 8.18.3
       zod: 3.25.76


### PR DESCRIPTION
This pull request upgrades underlying openai package from 5.x to 6.x for 0.2.x series. This should have been done but I missed the change and unfortunately the integration tests didn't detect this necessary changes. 

After releasing 0.2.0, I found:
- the zod 4 support is still incomplete
   - runtime: a bug with agent output type exists; this PR resolves it
   - tsc: MCP SDK still sorely relies on zod 3.x, so supporting only v4 is not yet an option
   - tsc: This SDK's public interface relies on zod 3.x object interface; the latter one needs to be changed to embrace both zod 4 and 3 interfaces

This is a necessary change, so we'll merge this. The remaining tasks are:
- continue research for zod 4 full support
- check MCP SDK updates for zod support
- reivist the integration tests to better detect this type of issues