### PR TITLE
fix: #638 Add usage data from stream on response (Chat Completions)

### DIFF
--- a/.changeset/shaky-bananas-check.md
+++ b/.changeset/shaky-bananas-check.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+Export usage data from Chat Completions response for trace

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -214,6 +214,18 @@ export class OpenAIChatCompletionsModel implements Model {
         response,
         stream,
       )) {
+        if (
+          event.type === 'response_done' &&
+          response.usage?.total_tokens === 0
+        ) {
+          response.usage = {
+            prompt_tokens: event.response.usage.inputTokens,
+            completion_tokens: event.response.usage.outputTokens,
+            total_tokens: event.response.usage.totalTokens,
+            prompt_tokens_details: event.response.usage.inputTokensDetails,
+            completion_tokens_details: event.response.usage.outputTokensDetails,
+          };
+        }
         yield event;
       }
 

--- a/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
@@ -482,4 +482,57 @@ describe('OpenAIChatCompletionsModel', () => {
     expect(convertChatCompletionsStreamToResponses).toHaveBeenCalled();
     expect(events).toEqual([{ type: 'first' }, { type: 'second' }]);
   });
+
+  it('populates usage from response_done event when initial usage is zero', async () => {
+    // override the original implementation to add the response_done event.
+    vi.mocked(convertChatCompletionsStreamToResponses).mockImplementationOnce(
+      async function* () {
+        yield { type: 'first' } as any;
+        yield { type: 'second' } as any;
+        yield {
+          type: 'response_done',
+          response: {
+            usage: {
+              inputTokens: 10,
+              outputTokens: 5,
+              totalTokens: 15,
+              inputTokensDetails: { cached_tokens: 2 },
+              outputTokensDetails: { reasoning_tokens: 3 },
+            },
+          },
+        } as any;
+      },
+    );
+
+    const client = new FakeClient();
+    async function* fakeStream() {
+      yield { id: 'c' } as any;
+    }
+    client.chat.completions.create.mockResolvedValue(fakeStream());
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const req: any = {
+      input: 'hi',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+    };
+    const events: any[] = [];
+    await withTrace('t', async () => {
+      for await (const e of model.getStreamedResponse(req)) {
+        events.push(e);
+      }
+    });
+
+    expect(client.chat.completions.create).toHaveBeenCalledWith(
+      expect.objectContaining({ stream: true }),
+      { headers: HEADERS, signal: undefined },
+    );
+    expect(convertChatCompletionsStreamToResponses).toHaveBeenCalled();
+    const responseDone = events.find((e) => e.type === 'response_done');
+    expect(responseDone).toBeDefined();
+    expect(responseDone.response.usage.totalTokens).toBe(15);
+  });
 });


### PR DESCRIPTION
Streaming results may not include usage data for providers like LiteLLM, causing "generation spans" (`onSpanEnd`) to not have usage results.  Adding a simple check to provide usage data from the last stream event fixes the issue.

No usage data is on the response unless it's supplied via streaming chunks (LiteLLM doesn't do this):
<img width="2208" height="922" alt="image" src="https://github.com/user-attachments/assets/770c8e0c-9f1c-4e19-9143-ab86c7e308ca" />

However, the last event has the usage data:
<img width="2510" height="1204" alt="image" src="https://github.com/user-attachments/assets/064e1426-16e2-482e-ae90-2a453de340ec" />

This PR grabs the usage data from the `response_done` event on the stream, appending it to the response.

Note:  there is a bit of friction in the model.  The `openaiChatCompletionStreaming.ts` component converts the OAI usage from "snake case" variables to Pascal case.  However, the response type requires "snake case".  I chose to not do anything fancy, preferring a direct mapping. 

Refer to: https://github.com/openai/openai-agents-js/issues/638#issuecomment-3524532698