### PR TITLE
fix: Omit tools parameter when prompt ID is set but tools in the agent is absent

### DIFF
--- a/.changeset/plain-breads-enjoy.md
+++ b/.changeset/plain-breads-enjoy.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-openai': patch
+'@openai/agents-core': patch
+---
+
+fix: Omit tools parameter when prompt ID is set but tools in the agent is absent

--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -382,6 +382,7 @@ export class Agent<
   outputType: TOutput = 'text' as TOutput;
   toolUseBehavior: ToolUseBehavior;
   resetToolChoice: boolean;
+  private readonly _toolsExplicitlyConfigured: boolean;
 
   constructor(config: AgentOptions<TContext, TOutput>) {
     super();
@@ -396,6 +397,7 @@ export class Agent<
     this.model = config.model ?? '';
     this.modelSettings = config.modelSettings ?? getDefaultModelSettings();
     this.tools = config.tools ?? [];
+    this._toolsExplicitlyConfigured = config.tools !== undefined;
     this.mcpServers = config.mcpServers ?? [];
     this.inputGuardrails = config.inputGuardrails ?? [];
     this.outputGuardrails = config.outputGuardrails ?? [];
@@ -677,6 +679,10 @@ export class Agent<
     }
 
     return [...mcpTools, ...enabledTools];
+  }
+
+  hasExplicitToolConfig(): boolean {
+    return this._toolsExplicitlyConfigured;
   }
 
   /**

--- a/packages/agents-core/src/model.ts
+++ b/packages/agents-core/src/model.ts
@@ -264,6 +264,13 @@ export type ModelRequest = {
   tools: SerializedTool[];
 
   /**
+   * When true, the caller explicitly configured the tools list (even if empty).
+   * Providers can use this to avoid overwriting prompt-defined tools when an agent
+   * does not specify its own tools.
+   */
+  toolsExplicitlyProvided?: boolean;
+
+  /**
    * The type of the output to use for the model.
    */
   outputType: SerializedOutputType;

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -779,6 +779,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               conversationId: preparedCall.conversationId,
               modelSettings: preparedCall.modelSettings,
               tools: preparedCall.serializedTools,
+              toolsExplicitlyProvided: preparedCall.toolsExplicitlyProvided,
               outputType: convertAgentOutputTypeToSerializable(
                 state._currentAgent.outputType,
               ),
@@ -1052,6 +1053,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             conversationId: preparedCall.conversationId,
             modelSettings: preparedCall.modelSettings,
             tools: preparedCall.serializedTools,
+            toolsExplicitlyProvided: preparedCall.toolsExplicitlyProvided,
             handoffs: preparedCall.serializedHandoffs,
             outputType: convertAgentOutputTypeToSerializable(
               currentAgent.outputType,
@@ -1946,6 +1948,7 @@ type AgentArtifacts<TContext = unknown> = {
   tools: Tool<TContext>[];
   serializedHandoffs: SerializedHandoff[];
   serializedTools: SerializedTool[];
+  toolsExplicitlyProvided: boolean;
 };
 
 /**
@@ -1980,6 +1983,7 @@ async function prepareAgentArtifacts<
     tools,
     serializedHandoffs: handoffs.map((handoff) => serializeHandoff(handoff)),
     serializedTools: tools.map((tool) => serializeTool(tool)),
+    toolsExplicitlyProvided: state._currentAgent.hasExplicitToolConfig(),
   };
 }
 

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -1599,12 +1599,17 @@ export class OpenAIResponsesModel implements Model {
     const shouldSendModel =
       !request.prompt || request.overridePromptModel === true;
 
+    const shouldSendTools =
+      tools.length > 0 ||
+      request.toolsExplicitlyProvided === true ||
+      !request.prompt;
+
     const requestData = {
       ...(shouldSendModel ? { model: this.#model } : {}),
       instructions: normalizeInstructions(request.systemInstructions),
       input,
       include,
-      tools,
+      ...(shouldSendTools ? { tools } : {}),
       previous_response_id: request.previousResponseId,
       conversation: request.conversationId,
       prompt,


### PR DESCRIPTION
This pull request fixes a bug where an empty `tools` parameter in the Responses API could reset the saved `tools` in the OpenAI server-side prompt settings. To address this, I've updated the default behavior of the Responses API to omit the `tools` parameter when the `Agent` has no tools. This ensures that the server-side tools remain intact, as developers would expect.