### PR TITLE
fix: #708 data: string in an input_image message item does not work with some providers

### DIFF
--- a/.changeset/heavy-knives-ask.md
+++ b/.changeset/heavy-knives-ask.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: #708 data: string in an input_image message item does not work with some providers

--- a/packages/agents-extensions/src/aiSdk.ts
+++ b/packages/agents-extensions/src/aiSdk.ts
@@ -94,7 +94,7 @@ export function itemsToLanguageV2Messages(
                     const url = new URL(imageSource);
                     return {
                       type: 'file',
-                      data: url.toString(),
+                      data: url,
                       mediaType: 'image/*',
                       providerOptions: {
                         ...(contentProviderData ?? {}),

--- a/packages/agents-extensions/test/aiSdk.test.ts
+++ b/packages/agents-extensions/test/aiSdk.test.ts
@@ -230,7 +230,7 @@ describe('itemsToLanguageV2Messages', () => {
           { type: 'text', text: 'hi', providerOptions: {} },
           {
             type: 'file',
-            data: 'http://x/img',
+            data: new URL('http://x/img'),
             mediaType: 'image/*',
             providerOptions: {},
           },


### PR DESCRIPTION
This pull request resolves #708 