### PR TITLE
fix: preserve Gemini thought_signature in multi-turn tool calls

### DIFF
--- a/.changeset/fine-symbols-jam.md
+++ b/.changeset/fine-symbols-jam.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: preserve Gemini thought_signature in multi-turn tool calls

--- a/packages/agents-extensions/src/aiSdk.ts
+++ b/packages/agents-extensions/src/aiSdk.ts
@@ -711,7 +711,9 @@ export class AiSdkModel implements Model {
             name: toolCall.toolName,
             arguments: toolCallArguments,
             status: 'completed',
-            providerData: hasToolCalls ? result.providerMetadata : undefined,
+            providerData:
+              toolCall.providerMetadata ??
+              (hasToolCalls ? result.providerMetadata : undefined),
           });
         }
 
@@ -916,6 +918,9 @@ export class AiSdkModel implements Model {
                 name: (part as any).toolName,
                 arguments: (part as any).input ?? '',
                 status: 'completed',
+                ...((part as any).providerMetadata
+                  ? { providerData: (part as any).providerMetadata }
+                  : {}),
               };
             }
             break;


### PR DESCRIPTION
## Summary

  - Fix Gemini `thought_signature` not being preserved in multi-turn conversations with tool calls
  - Prioritize per-tool-call `providerMetadata` over overall response metadata in both streaming and non-streaming modes

  ## Related Issues

  - Related: openai/openai-agents-python#2137

  ## Problem

  When using Gemini models with thinking/reasoning enabled (e.g., `gemini-3.0-pro-preview`) through the AI SDK integration, the `thought_signature` field was not preserved across agent
  loop iterations, causing subsequent API calls to fail with:

  > Function call is missing a thought_signature in functionCall parts.

  Reference: https://ai.google.dev/gemini-api/docs/thought-signatures

  ## Root Cause

  - **Non-streaming mode**: `providerData` was set to `result.providerMetadata` (overall response metadata containing `usageMetadata`, `safetyRatings`, etc.) instead of 
  `toolCall.providerMetadata` (per-tool-call metadata containing `thoughtSignature`)
  - **Streaming mode**: `providerData` was not captured at all from tool-call parts

  ## Changes

  - **Non-streaming mode** (`aiSdk.ts` ~line 714): Prioritize `toolCall.providerMetadata` with fallback to `result.providerMetadata`
  - **Streaming mode** (`aiSdk.ts` ~line 921): Capture `part.providerMetadata` as `providerData`

  ## Test Plan

  - [x] Tested with Gemini 3.0 Pro Preview
  - [x] Verified multi-turn conversation with tool calls works correctly
  - [x] Both streaming and non-streaming modes tested