### PR TITLE
Fix #732  Ensure SpanData types are exported

### DIFF
--- a/.changeset/warm-beans-build.md
+++ b/.changeset/warm-beans-build.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+SpanData types are exported from distribution types for use when writing custom TracingExporters and Tracingprocessors

--- a/packages/agents-core/src/tracing/index.ts
+++ b/packages/agents-core/src/tracing/index.ts
@@ -17,9 +17,24 @@ export {
   ConsoleSpanExporter,
 } from './processor';
 export { NoopSpan, Span } from './spans';
+export type {
+  SpanData,
+  AgentSpanData,
+  FunctionSpanData,
+  GenerationSpanData,
+  ResponseSpanData,
+  HandoffSpanData,
+  CustomSpanData,
+  GuardrailSpanData,
+  TranscriptionSpanData,
+  SpeechSpanData,
+  SpeechGroupSpanData,
+  MCPListToolsSpanData,
+  SpanOptions,
+  SpanError,
+} from './spans';
 export { NoopTrace, Trace } from './traces';
 export { generateGroupId, generateSpanId, generateTraceId } from './utils';
-export type { MCPListToolsSpanData } from './spans';
 
 /**
  * Add a processor to the list of processors. Each processor will receive all traces/spans.


### PR DESCRIPTION
This means you don't have to duplicate the types if you're implementing your own TracingExporter and want type safety.

Fixes #732