### PR TITLE
fix(agents-extensions): ##711 improve AI SDK error details in tracing

### DIFF
--- a/.changeset/comprehensive-ai-sdk-error-messages.md
+++ b/.changeset/comprehensive-ai-sdk-error-messages.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+Improve AI SDK error messages in tracing to include comprehensive error details like responseBody, statusCode, and responseHeaders when tracing is enabled.

--- a/packages/agents-extensions/src/aiSdk.ts
+++ b/packages/agents-extensions/src/aiSdk.ts
@@ -784,22 +784,38 @@ export class AiSdkModel implements Model {
             data: {
               error:
                 request.tracing === true
-                  ? String(error)
-                  : error instanceof Error
-                    ? error.name
-                    : undefined,
+                  ? {
+                      name: error.name,
+                      message: error.message,
+                      // Include AI SDK specific error fields if they exist.
+                      ...(typeof error === 'object' && error !== null
+                        ? {
+                            ...('responseBody' in error
+                              ? { responseBody: (error as any).responseBody }
+                              : {}),
+                            ...('responseHeaders' in error
+                              ? {
+                                  responseHeaders: (error as any)
+                                    .responseHeaders,
+                                }
+                              : {}),
+                            ...('statusCode' in error
+                              ? { statusCode: (error as any).statusCode }
+                              : {}),
+                            ...('cause' in error
+                              ? { cause: (error as any).cause }
+                              : {}),
+                          }
+                        : {}),
+                    }
+                  : error.name,
             },
           });
         } else {
           span.setError({
             message: 'Unknown error',
             data: {
-              error:
-                request.tracing === true
-                  ? String(error)
-                  : error instanceof Error
-                    ? error.name
-                    : undefined,
+              error: request.tracing === true ? String(error) : undefined,
             },
           });
         }
@@ -999,11 +1015,37 @@ export class AiSdkModel implements Model {
     } catch (error) {
       if (span) {
         span.setError({
-          message: 'Error streaming response',
+          message:
+            error instanceof Error ? error.message : 'Error streaming response',
           data: {
             error:
               request.tracing === true
-                ? String(error)
+                ? error instanceof Error
+                  ? {
+                      name: error.name,
+                      message: error.message,
+                      // Include AI SDK specific error fields if they exist.
+                      ...(typeof error === 'object' && error !== null
+                        ? {
+                            ...('responseBody' in error
+                              ? { responseBody: (error as any).responseBody }
+                              : {}),
+                            ...('responseHeaders' in error
+                              ? {
+                                  responseHeaders: (error as any)
+                                    .responseHeaders,
+                                }
+                              : {}),
+                            ...('statusCode' in error
+                              ? { statusCode: (error as any).statusCode }
+                              : {}),
+                            ...('cause' in error
+                              ? { cause: (error as any).cause }
+                              : {}),
+                          }
+                        : {}),
+                    }
+                  : String(error)
                 : error instanceof Error
                   ? error.name
                   : undefined,


### PR DESCRIPTION
## Summary
Fixes #711
Improves AI SDK error handling in tracing to capture comprehensive error details including `responseBody`, `statusCode`, `responseHeaders`, and `cause` fields. Previously, only the error name was captured via `String(error)`, which lost critical debugging information.

## Changes

  - **Updated error handling in `aiSdk.ts`** (3 locations):
    - Non-streaming error handler (lines 780-824)
    - Streaming error handler (lines 1007-1044)
    - Now manually constructs error objects to preserve all
  available fields

  - **Added comprehensive unit tests** in `aiSdk.test.ts`:
    - Test for non-streaming error handling with tracing enabled
    - Test for streaming error handling with tracing enabled
    - Both tests verify that error fields like `responseBody` and `statusCode` are preserved

  - **Created changeset** for version management
  
## Technical Details
When `tracing` is enabled, errors are now captured as:

  ```typescript
  {
    name: error.name,
    message: error.message,
    responseBody: error.responseBody,    // ← New!
    responseHeaders: error.responseHeaders, // ← New!
    statusCode: error.statusCode,        // ← New!
    cause: error.cause                   // ← New!
  }
  ```

  This provides developers with complete error context for debugging AI SDK errors, including:
  - Rate limit error details and retry information
  - API-specific error codes and messages
  - Request IDs for support tickets
  - HTTP status codes

Safety: Error details are only captured when tracing is explicitly enabled by the user.