### PR TITLE
docs(ai-sdk): #758 document actual scripts and prerequisites

### DIFF
--- a/examples/ai-sdk/README.md
+++ b/examples/ai-sdk/README.md
@@ -1,21 +1,19 @@
-# AI SDK Example
+# AI SDK Examples
 
-This example shows how to run the Agents SDK with a model provided by the [AI SDK](https://www.npmjs.com/package/@ai-sdk/openai).
+These examples show how to wrap models from the [AI SDK](https://www.npmjs.com/package/@ai-sdk/openai) (and compatible providers) with the `aisdk()` helper from `@openai/agents-extensions`, then run them inside the Agents runtime.
 
-The [ai-sdk-model.ts](./ai-sdk-model.ts) script:
+## Available scripts
 
-- Wraps the AI SDK `openai` provider with `aisdk` from `@openai/agents-extensions`.
-- Creates a simple `get_weather` tool that returns a mock weather string.
-- Defines a data agent that uses this model and tool.
-- Runs a parent agent that hands off to the data agent to answer a weather question.
+| Script                                         | Command                                  | Provider                          | Description                                                                                                 |
+| ---------------------------------------------- | ---------------------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| [index.ts](./index.ts)                         | `pnpm -F ai-sdk start`                   | OpenRouter (`OPENROUTER_API_KEY`) | Runs a parent agent that hands off a weather question to a child agent equipped with a `get_weather` tool.  |
+| [gpt-5.ts](./gpt-5.ts)                         | `pnpm -F ai-sdk start:gpt-5`             | OpenAI (`OPENAI_API_KEY`)         | Shows a single agent that must call the `get_weather` tool using `gpt-5-mini` with custom provider options. |
+| [stream.ts](./stream.ts)                       | `pnpm -F ai-sdk start:stream`            | OpenAI (`OPENAI_API_KEY`)         | Demonstrates streaming text output from an AI SDK model wrapped with `aisdk()`.                             |
+| [image-tool-output.ts](./image-tool-output.ts) | `pnpm -F ai-sdk start:image-tool-output` | OpenRouter (`OPENROUTER_API_KEY`) | Returns a `ToolOutputImage` from a tool call and asks the model to describe the image.                      |
 
-## Running the script
+## Prerequisites
 
-From the repository root, execute:
+- Run `pnpm install` at the repo root.
+- Export the relevant API key(s) shown in the table above before running a script.
 
-```bash
-pnpm -F ai-sdk start:sdk-model
-```
-
-The script prints the final output produced by the runner.
-
+Once the environment variable is set, run the corresponding command from the repository root. Each script prints the final output produced by the Agents runner.


### PR DESCRIPTION
## Summary
- Replace the outdated README copy that referenced `ai-sdk-model.ts` with a table covering every runnable script and its provider.
- Highlight the required API keys and remind readers to run the commands from the repo root after installing dependencies.

Fixes #758