### PR TITLE
fix: event data adjustment for #749

### DIFF
--- a/.changeset/two-terms-walk.md
+++ b/.changeset/two-terms-walk.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: event data adjustment for #749

--- a/examples/agent-patterns/agents-as-tools-streaming.ts
+++ b/examples/agent-patterns/agents-as-tools-streaming.ts
@@ -36,7 +36,7 @@ async function main() {
       // When you pass onStream handler, the agent is executed in streaming mode.
       onStream: (event) => {
         console.log(
-          `### onStream method streaming event from ${event.agentName} in streaming mode:\n\n` +
+          `### onStream method streaming event from ${event.agent.name} in streaming mode:\n\n` +
             JSON.stringify(event) +
             '\n',
         );
@@ -47,7 +47,7 @@ async function main() {
     /*
     billingAgentTool.on('raw_model_stream_event', (event) => {
       console.log(
-        `### on method streaming event from ${event.agentName} in streaming mode:\n\n` +
+        `### on method streaming event from ${event.agent.name} in streaming mode:\n\n` +
         JSON.stringify(event) +
         '\n',
       );


### PR DESCRIPTION
This pull request adjusts the event data passed to streaming event data handler for agents as tools to make #749 more robust. context: https://github.com/openai/openai-agents-python/pull/2169#discussion_r2611304756