### PR TITLE
feat: #794 Expose `ToolInputParameters` and `ToolOptions` from the top-level exports so wrappers can import the tool types

### DIFF
--- a/.changeset/expose-tool-types.md
+++ b/.changeset/expose-tool-types.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents': patch
+---
+
+feat: #794 Expose `ToolInputParameters` and `ToolOptions` from the top-level exports so wrappers can import the tool types

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -140,6 +140,7 @@ export {
   ToolExecuteArgument,
   ToolEnabledFunction,
 } from './tool';
+export type { ToolInputParameters, ToolOptions } from './tool';
 export type {
   ToolOutputText,
   ToolOutputImage,


### PR DESCRIPTION
This pull request resolves #794 