### PR TITLE
Improve guardrail tripwire logic in examples

### DIFF
--- a/.changeset/wise-pianos-lead.md
+++ b/.changeset/wise-pianos-lead.md
@@ -1,5 +1,0 @@
----
-'@openai/agents': patch
----
-
-Fixed incorrect tripwire logic in guardrails documentation example


### PR DESCRIPTION
   ## Description
   Fixed inverted logic in the input guardrail example. The `tripwireTriggered` value now correctly evaluates to:
   - `true` when `isMathHomework` is `false` (block the request, query not related to math)
   - `false` when `isMathHomework` is `true` (allow the request, query related to math)
   - `false` when `isMathHomework` is `undefined` (allow the request, unknown error at guardrail)
   
   ## Changes
   - Updated `examples/docs/guardrails/guardrails-input.ts`
   
   ## Testing
   - [x] All tests pass
   - [x] Linting passes
   - [x] Build succeeds