### PR TITLE
feat: Add tool input/output guardrails to TS SDK

### DIFF
--- a/.changeset/fresh-adults-retire.md
+++ b/.changeset/fresh-adults-retire.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-realtime': patch
+'@openai/agents-core': patch
+---
+
+feat: Add tool input/output guardrails to TS SDK

--- a/examples/basic/tools.ts
+++ b/examples/basic/tools.ts
@@ -18,6 +18,34 @@ const getWeather = tool({
       conditions: 'Sunny with wind.',
     };
   },
+  // these guardrails are optional
+  inputGuardrails: [
+    {
+      name: 'get_weather_input_guardrail',
+      run: async ({ toolCall }) => {
+        console.log(`tool input: ${toolCall.arguments}`);
+        const toolArgs = JSON.parse(toolCall.arguments);
+        if (toolArgs.city.toLowerCase() !== 'tokyo') {
+          return {
+            behavior: {
+              type: 'rejectContent',
+              message: 'I can help you only for cities in Japan.',
+            },
+          };
+        }
+        return { behavior: { type: 'allow' } };
+      },
+    },
+  ],
+  outputGuardrails: [
+    {
+      name: 'get_weather_output_guardrail',
+      run: async ({ output }) => {
+        console.log(`tool output: ${JSON.stringify(output)}`);
+        return { behavior: { type: 'allow' } };
+      },
+    },
+  ],
 });
 
 const agent = new Agent({
@@ -30,6 +58,16 @@ async function main() {
   const result = await run(agent, "What's the weather in Tokyo?");
   console.log(result.finalOutput);
   // The weather in Tokyo is sunny with some wind, and the temperature ranges between 14°C and 20°C.
+
+  // console.log(JSON.stringify(result.toolInputGuardrailResults));
+  // [{"guardrail":{"type":"tool_input","name":"get_weather_guardrail"},"output":{"behavior":{"type":"allow"}}}]
+
+  const result2 = await run(agent, "What's the weather in San Francisco?");
+  console.log(result2.finalOutput);
+  // I’m only able to provide weather information for cities in Japan. If you’re interested in the weather for a Japanese city, please let me know which one!
+
+  // console.log(JSON.stringify(result2.toolInputGuardrailResults));
+  // [{"guardrail":{"type":"tool_input","name":"get_weather_guardrail"},"output":{"behavior":{"type":"rejectContent","message":"I can help you only for cities in Japan."}}}]
 }
 
 main().catch((error) => {

--- a/packages/agents-core/src/errors.ts
+++ b/packages/agents-core/src/errors.ts
@@ -4,6 +4,10 @@ import {
   OutputGuardrailMetadata,
   OutputGuardrailResult,
 } from './guardrail';
+import {
+  ToolInputGuardrailResult,
+  ToolOutputGuardrailResult,
+} from './toolGuardrail';
 import { RunContext } from './runContext';
 import { RunState } from './runState';
 import { TextOutput } from './types';
@@ -132,6 +136,36 @@ export class OutputGuardrailTripwireTriggered<
   constructor(
     message: string,
     result: OutputGuardrailResult<TMeta, TOutputType>,
+    state?: RunState<any, any>,
+  ) {
+    super(message, state);
+    this.result = result;
+  }
+}
+
+/**
+ * Error thrown when a tool input guardrail tripwire is triggered.
+ */
+export class ToolInputGuardrailTripwireTriggered extends AgentsError {
+  result: ToolInputGuardrailResult;
+  constructor(
+    message: string,
+    result: ToolInputGuardrailResult,
+    state?: RunState<any, any>,
+  ) {
+    super(message, state);
+    this.result = result;
+  }
+}
+
+/**
+ * Error thrown when a tool output guardrail tripwire is triggered.
+ */
+export class ToolOutputGuardrailTripwireTriggered extends AgentsError {
+  result: ToolOutputGuardrailResult;
+  constructor(
+    message: string,
+    result: ToolOutputGuardrailResult,
     state?: RunState<any, any>,
   ) {
     super(message, state);

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -23,6 +23,8 @@ export {
   MaxTurnsExceededError,
   ModelBehaviorError,
   OutputGuardrailTripwireTriggered,
+  ToolInputGuardrailTripwireTriggered,
+  ToolOutputGuardrailTripwireTriggered,
   ToolCallError,
   UserError,
   SystemError,
@@ -48,6 +50,24 @@ export {
   OutputGuardrailMetadata,
   OutputGuardrailResult,
 } from './guardrail';
+export {
+  ToolGuardrailBehavior,
+  ToolGuardrailFunctionOutput,
+  ToolGuardrailMetadata,
+  ToolInputGuardrailData,
+  ToolInputGuardrailDefinition,
+  ToolInputGuardrailFunction,
+  ToolInputGuardrailResult,
+  ToolOutputGuardrailData,
+  ToolOutputGuardrailDefinition,
+  ToolOutputGuardrailFunction,
+  ToolOutputGuardrailResult,
+  ToolGuardrailFunctionOutputFactory,
+  defineToolInputGuardrail,
+  defineToolOutputGuardrail,
+  resolveToolInputGuardrails,
+  resolveToolOutputGuardrails,
+} from './toolGuardrail';
 export {
   getHandoff,
   getTransferMessage,
@@ -139,6 +159,7 @@ export {
   tool,
   ToolExecuteArgument,
   ToolEnabledFunction,
+  ToolOptionsWithGuardrails,
 } from './tool';
 export type { ToolInputParameters, ToolOptions } from './tool';
 export type {
@@ -150,6 +171,10 @@ export type {
 } from './types/protocol';
 export * from './tracing';
 export { getGlobalTraceProvider, TraceProvider } from './tracing/provider';
+export {
+  runToolInputGuardrails,
+  runToolOutputGuardrails,
+} from './utils/toolGuardrails';
 /* only export the types not the parsers */
 export type {
   AgentInputItem,

--- a/packages/agents-core/src/result.ts
+++ b/packages/agents-core/src/result.ts
@@ -21,6 +21,10 @@ import { RunState } from './runState';
 import type { InputGuardrailResult, OutputGuardrailResult } from './guardrail';
 import logger from './logger';
 import { StreamEventTextStream } from './types/protocol';
+import type {
+  ToolInputGuardrailResult,
+  ToolOutputGuardrailResult,
+} from './toolGuardrail';
 
 /**
  * Data returned by the run() method of an agent.
@@ -67,6 +71,16 @@ export interface RunResultData<
   outputGuardrailResults: OutputGuardrailResult[];
 
   /**
+   * Guardrail results for tool inputs during the run.
+   */
+  toolInputGuardrailResults: ToolInputGuardrailResult[];
+
+  /**
+   * Guardrail results for tool outputs during the run.
+   */
+  toolOutputGuardrailResults: ToolOutputGuardrailResult[];
+
+  /**
    * The output of the last agent, or any handoff agent.
    */
   finalOutput?:
@@ -84,9 +98,10 @@ export interface RunResultData<
   state: RunState<any, TAgent>;
 }
 
-class RunResultBase<TContext, TAgent extends Agent<TContext, any>>
-  implements RunResultData<TAgent>
-{
+class RunResultBase<
+  TContext,
+  TAgent extends Agent<TContext, any>,
+> implements RunResultData<TAgent> {
   readonly state: RunState<TContext, TAgent>;
 
   constructor(state: RunState<TContext, TAgent>) {
@@ -170,6 +185,20 @@ class RunResultBase<TContext, TAgent extends Agent<TContext, any>>
   }
 
   /**
+   * Guardrail results for tool inputs.
+   */
+  get toolInputGuardrailResults(): ToolInputGuardrailResult[] {
+    return this.state._toolInputGuardrailResults;
+  }
+
+  /**
+   * Guardrail results for tool outputs.
+   */
+  get toolOutputGuardrailResults(): ToolOutputGuardrailResult[] {
+    return this.state._toolOutputGuardrailResults;
+  }
+
+  /**
    * Any interruptions that occurred during the agent run for example for tool approvals.
    */
   get interruptions(): RunToolApprovalItem[] {
@@ -212,9 +241,9 @@ export class RunResult<
  * The result of an agent run in streaming mode.
  */
 export class StreamedRunResult<
-    TContext,
-    TAgent extends Agent<TContext, AgentOutputType>,
-  >
+  TContext,
+  TAgent extends Agent<TContext, AgentOutputType>,
+>
   extends RunResultBase<TContext, TAgent>
   implements AsyncIterable<RunStreamEvent>
 {

--- a/packages/agents-core/src/toolGuardrail.ts
+++ b/packages/agents-core/src/toolGuardrail.ts
@@ -1,0 +1,177 @@
+import type { Agent } from './agent';
+import type { RunContext } from './runContext';
+import type * as protocol from './types/protocol';
+import type { UnknownContext } from './types';
+
+/**
+ * The action a tool guardrail should take after evaluation.
+ *
+ * - `allow`: proceed to the next guardrail or tool execution/output handling.
+ * - `rejectContent`: treat the guardrail as rejecting the call/output and short‑circuit with a message.
+ * - `throwException`: escalate immediately as a tripwire to fail fast and surface diagnostics.
+ */
+export type ToolGuardrailBehavior =
+  | { type: 'allow' }
+  | { type: 'rejectContent'; message: string }
+  | { type: 'throwException' };
+
+/**
+ * The output of a tool guardrail function.
+ *
+ * `behavior` drives runner control flow; `outputInfo` is optional, structured metadata for tracing or debugging.
+ */
+export interface ToolGuardrailFunctionOutput {
+  /**
+   * Additional data about the guardrail evaluation.
+   */
+  outputInfo?: any;
+  /**
+   * The behavior the runner should take in response to this guardrail.
+   */
+  behavior: ToolGuardrailBehavior;
+}
+
+export interface ToolGuardrailMetadata {
+  type: 'tool_input' | 'tool_output';
+  name: string;
+}
+
+export interface ToolGuardrailBase {
+  name: string;
+}
+
+/**
+ * Input data passed to a tool input guardrail function.
+ */
+export interface ToolInputGuardrailData<TContext = UnknownContext> {
+  context: RunContext<TContext>;
+  agent: Agent<any, any>;
+  toolCall: protocol.FunctionCallItem;
+}
+
+/**
+ * Input data passed to a tool output guardrail function.
+ */
+export interface ToolOutputGuardrailData<
+  TContext = UnknownContext,
+> extends ToolInputGuardrailData<TContext> {
+  output: unknown;
+}
+
+export type ToolInputGuardrailFunction<TContext = UnknownContext> = (
+  data: ToolInputGuardrailData<TContext>,
+) => Promise<ToolGuardrailFunctionOutput>;
+
+export type ToolOutputGuardrailFunction<TContext = UnknownContext> = (
+  data: ToolOutputGuardrailData<TContext>,
+) => Promise<ToolGuardrailFunctionOutput>;
+
+export interface ToolInputGuardrailDefinition<
+  TContext = UnknownContext,
+> extends ToolGuardrailBase {
+  type: 'tool_input';
+  run: ToolInputGuardrailFunction<TContext>;
+}
+
+export interface ToolOutputGuardrailDefinition<
+  TContext = UnknownContext,
+> extends ToolGuardrailBase {
+  type: 'tool_output';
+  run: ToolOutputGuardrailFunction<TContext>;
+}
+
+export interface ToolInputGuardrailResult {
+  guardrail: ToolGuardrailMetadata & { type: 'tool_input' };
+  output: ToolGuardrailFunctionOutput;
+}
+
+export interface ToolOutputGuardrailResult {
+  guardrail: ToolGuardrailMetadata & { type: 'tool_output' };
+  output: ToolGuardrailFunctionOutput;
+}
+
+export function defineToolInputGuardrail<TContext = UnknownContext>(args: {
+  name: string;
+  run: ToolInputGuardrailFunction<TContext>;
+}): ToolInputGuardrailDefinition<TContext> {
+  return {
+    type: 'tool_input',
+    name: args.name,
+    run: args.run,
+  };
+}
+
+export function defineToolOutputGuardrail<TContext = UnknownContext>(args: {
+  name: string;
+  run: ToolOutputGuardrailFunction<TContext>;
+}): ToolOutputGuardrailDefinition<TContext> {
+  return {
+    type: 'tool_output',
+    name: args.name,
+    run: args.run,
+  };
+}
+
+export const ToolGuardrailFunctionOutputFactory = {
+  allow(outputInfo?: any): ToolGuardrailFunctionOutput {
+    return {
+      behavior: { type: 'allow' },
+      outputInfo,
+    };
+  },
+  rejectContent(
+    message: string,
+    outputInfo?: any,
+  ): ToolGuardrailFunctionOutput {
+    return {
+      behavior: { type: 'rejectContent', message },
+      outputInfo,
+    };
+  },
+  throwException(outputInfo?: any): ToolGuardrailFunctionOutput {
+    return {
+      behavior: { type: 'throwException' },
+      outputInfo,
+    };
+  },
+};
+
+type ToolInputGuardrailInit<TContext = UnknownContext> =
+  | ToolInputGuardrailDefinition<TContext>
+  | {
+      name: string;
+      run: ToolInputGuardrailFunction<TContext>;
+    };
+
+type ToolOutputGuardrailInit<TContext = UnknownContext> =
+  | ToolOutputGuardrailDefinition<TContext>
+  | {
+      name: string;
+      run: ToolOutputGuardrailFunction<TContext>;
+    };
+
+export function resolveToolInputGuardrails<TContext = UnknownContext>(
+  guardrails?: ToolInputGuardrailInit<TContext>[],
+): ToolInputGuardrailDefinition<TContext>[] {
+  if (!guardrails) {
+    return [];
+  }
+  return guardrails.map((gr) =>
+    'type' in gr && gr.type === 'tool_input'
+      ? (gr as ToolInputGuardrailDefinition<TContext>)
+      : defineToolInputGuardrail(gr as { name: string; run: any }),
+  );
+}
+
+export function resolveToolOutputGuardrails<TContext = UnknownContext>(
+  guardrails?: ToolOutputGuardrailInit<TContext>[],
+): ToolOutputGuardrailDefinition<TContext>[] {
+  if (!guardrails) {
+    return [];
+  }
+  return guardrails.map((gr) =>
+    'type' in gr && gr.type === 'tool_output'
+      ? (gr as ToolOutputGuardrailDefinition<TContext>)
+      : defineToolOutputGuardrail(gr as { name: string; run: any }),
+  );
+}

--- a/packages/agents-core/src/utils/toolGuardrails.ts
+++ b/packages/agents-core/src/utils/toolGuardrails.ts
@@ -1,0 +1,109 @@
+import type {
+  ToolGuardrailFunctionOutput,
+  ToolInputGuardrailDefinition,
+  ToolInputGuardrailResult,
+  ToolOutputGuardrailDefinition,
+  ToolOutputGuardrailResult,
+} from '../toolGuardrail';
+import type { Agent } from '../agent';
+import type { RunContext } from '../runContext';
+import type * as protocol from '../types/protocol';
+import {
+  ToolInputGuardrailTripwireTriggered,
+  ToolOutputGuardrailTripwireTriggered,
+} from '../errors';
+
+function normalizeBehavior(
+  output: ToolGuardrailFunctionOutput,
+): ToolGuardrailFunctionOutput['behavior'] {
+  return output.behavior ?? { type: 'allow' };
+}
+
+export async function runToolInputGuardrails<
+  TContext,
+  TAgent extends Agent<any, any>,
+>({
+  guardrails,
+  context,
+  agent,
+  toolCall,
+  onResult,
+}: {
+  guardrails?: ToolInputGuardrailDefinition<TContext>[];
+  context: RunContext<TContext>;
+  agent: TAgent;
+  toolCall: protocol.FunctionCallItem;
+  onResult?: (result: ToolInputGuardrailResult) => void;
+}): Promise<{ type: 'allow' } | { type: 'reject'; message: string }> {
+  const list = guardrails ?? [];
+  for (const guardrail of list) {
+    const output = await guardrail.run({
+      context,
+      agent,
+      toolCall,
+    });
+    const behavior = normalizeBehavior(output);
+    const result: ToolInputGuardrailResult = {
+      guardrail: { type: 'tool_input', name: guardrail.name },
+      output: { ...output, behavior },
+    };
+    onResult?.(result);
+    if (behavior.type === 'rejectContent') {
+      return { type: 'reject', message: behavior.message };
+    }
+    if (behavior.type === 'throwException') {
+      throw new ToolInputGuardrailTripwireTriggered(
+        `Tool input guardrail triggered: ${guardrail.name}`,
+        result,
+      );
+    }
+  }
+  return { type: 'allow' };
+}
+
+export async function runToolOutputGuardrails<
+  TContext,
+  TAgent extends Agent<any, any>,
+>({
+  guardrails,
+  context,
+  agent,
+  toolCall,
+  toolOutput,
+  onResult,
+}: {
+  guardrails?: ToolOutputGuardrailDefinition<TContext>[];
+  context: RunContext<TContext>;
+  agent: TAgent;
+  toolCall: protocol.FunctionCallItem;
+  toolOutput: unknown;
+  onResult?: (result: ToolOutputGuardrailResult) => void;
+}): Promise<unknown> {
+  const list = guardrails ?? [];
+  let finalOutput = toolOutput;
+  for (const guardrail of list) {
+    const output = await guardrail.run({
+      context,
+      agent,
+      toolCall,
+      output: toolOutput,
+    });
+    const behavior = normalizeBehavior(output);
+    const result: ToolOutputGuardrailResult = {
+      guardrail: { type: 'tool_output', name: guardrail.name },
+      output: { ...output, behavior },
+    };
+    onResult?.(result);
+    if (behavior.type === 'rejectContent') {
+      finalOutput = behavior.message;
+      break;
+    }
+    if (behavior.type === 'throwException') {
+      throw new ToolOutputGuardrailTripwireTriggered(
+        `Tool output guardrail triggered: ${guardrail.name}`,
+        result,
+      );
+    }
+  }
+  return finalOutput;
+}

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -40,6 +40,8 @@ describe('RunState', () => {
     expect(state._currentStep).toBeUndefined();
     expect(state._trace).toBeNull();
     expect(state._context.context).toEqual({ foo: 'bar' });
+    expect(state._toolInputGuardrailResults).toEqual([]);
+    expect(state._toolOutputGuardrailResults).toEqual([]);
   });
 
   it('returns history including original input and generated items', () => {
@@ -214,6 +216,24 @@ describe('RunState', () => {
         output: { tripwireTriggered: true, outputInfo: { done: true } },
       },
     ];
+    state._toolInputGuardrailResults = [
+      {
+        guardrail: { type: 'tool_input', name: 'tig' },
+        output: {
+          behavior: { type: 'rejectContent', message: 'nope' },
+          outputInfo: { a: 1 },
+        },
+      },
+    ];
+    state._toolOutputGuardrailResults = [
+      {
+        guardrail: { type: 'tool_output', name: 'tog' },
+        output: {
+          behavior: { type: 'allow' },
+          outputInfo: { b: 2 },
+        },
+      },
+    ];
 
     const str = state.toString();
     const newState = await RunState.fromString(agentA, str);
@@ -231,6 +251,12 @@ describe('RunState', () => {
       tripwireTriggered: true,
       outputInfo: { done: true },
     });
+    expect(newState._toolInputGuardrailResults).toEqual(
+      state._toolInputGuardrailResults,
+    );
+    expect(newState._toolOutputGuardrailResults).toEqual(
+      state._toolOutputGuardrailResults,
+    );
   });
 
   it('buildAgentMap collects agents without looping', () => {


### PR DESCRIPTION
This pull request adds tool input/output guardrails to this SDK. The Python SDK already has the feature: https://github.com/openai/openai-agents-python/pull/1792

Here is a simple example code:
```typescript
const getWeather = tool({
  name: 'get_weather',
  description: 'Get the weather for a city.',
  parameters: z.object({ city: z.string() }),
  execute: async ({ city }): Promise<Weather> => {
    return {
      city,
      temperatureRange: '14-20C',
      conditions: 'Sunny with wind.',
    };
  },
  inputGuardrails: [
    {
      name: 'get_weather_input_guardrail',
      run: async ({ agent, toolCall, context }) => {
        const toolArgs = JSON.parse(toolCall.arguments);
        if (toolArgs.city.toLowerCase() !== 'tokyo') {
          return {
            behavior: {
              type: 'rejectContent',
              message: 'I can help you only for cities in Japan.',
            },
          };
        }
        return { behavior: { type: 'allow' } };
      },
    },
  ],
  outputGuardrails: [
    {
      name: 'get_weather_output_guardrail',
      run: async ({ agent, toolCall, context, output }) => {
        return { behavior: { type: 'allow' } };
      },
    },
  ],
});
```