### PR TITLE
fix: Add content: null when having tool calls for Chat Completions

### DIFF
--- a/.changeset/nine-signs-shine.md
+++ b/.changeset/nine-signs-shine.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: Add content: null when having tool calls for Chat Completions

--- a/packages/agents-openai/src/openaiChatCompletionsConverter.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsConverter.ts
@@ -179,7 +179,11 @@ export function itemsToMessages(
   };
   const ensureAssistantMessage = () => {
     if (!currentAssistantMsg) {
-      currentAssistantMsg = { role: 'assistant', tool_calls: [] };
+      currentAssistantMsg = {
+        role: 'assistant',
+        content: null,
+        tool_calls: [],
+      };
     }
     return currentAssistantMsg;
   };

--- a/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
@@ -297,6 +297,7 @@ describe('itemsToMessages', () => {
     expect(msgs).toEqual([
       {
         role: 'assistant',
+        content: null,
         tool_calls: [
           {
             id: 'call1',
@@ -335,6 +336,24 @@ describe('itemsToMessages', () => {
     expect(() => itemsToMessages(bad)).toThrow(UserError);
   });
 
+  test('includes explicit null content for assistant tool calls', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call',
+        id: '1',
+        callId: 'call1',
+        name: 'f',
+        arguments: '{}',
+        status: 'in_progress',
+      } as protocol.FunctionCallItem,
+    ];
+    const msgs = itemsToMessages(items);
+    expect(msgs).toHaveLength(1);
+    const toolMsg = msgs[0] as any;
+    expect(toolMsg.role).toBe('assistant');
+    expect(toolMsg).toHaveProperty('content', null);
+  });
+
   test('converts reasoning items into assistant reasoning', () => {
     const items: protocol.ModelItem[] = [
       {
@@ -347,6 +366,7 @@ describe('itemsToMessages', () => {
     expect(msgs).toEqual([
       {
         role: 'assistant',
+        content: null,
         reasoning: 'why',
       },
     ]);


### PR DESCRIPTION
This pull request applies the same improvement with https://github.com/openai/openai-agents-python/pull/2238