### PR TITLE
fix: Fix #809 chat completions tool calls when content is present

### DIFF
--- a/.changeset/funky-lemons-help.md
+++ b/.changeset/funky-lemons-help.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: Fix chat completions tool calls when content is present

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -99,12 +99,13 @@ export class OpenAIChatCompletionsModel implements Model {
           ],
         });
       }
-      if (
+      const hasContent =
         message.content !== undefined &&
         message.content !== null &&
         // Azure OpenAI returns empty string instead of null for tool calls, causing parser rejection
-        !(message.tool_calls && message.content === '')
-      ) {
+        !(message.tool_calls && message.content === '');
+
+      if (hasContent) {
         const { content, ...rest } = message;
         output.push({
           id: response.id,
@@ -149,7 +150,9 @@ export class OpenAIChatCompletionsModel implements Model {
           ],
           status: 'completed',
         });
-      } else if (message.tool_calls) {
+      }
+
+      if (message.tool_calls) {
         for (const tool_call of message.tool_calls) {
           if (tool_call.type === 'function') {
             // Note: custom tools are not supported for now


### PR DESCRIPTION
This pull request resolves #809 

- Make chat completions parsing emit function_call items even when assistant content and tool_calls are in the same message so tools execute in chat_completions mode.
- Add a unit test covering mixed content + tool_calls in chat completions responses.