### PR TITLE
fix: #816 preserve falsy turn detection config values

### DIFF
--- a/.changeset/nice-keys-ask.md
+++ b/.changeset/nice-keys-ask.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: #816 preserve falsy turn detection config values

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -648,16 +648,12 @@ export abstract class OpenAIRealtimeBase
 
     const config: RealtimeTurnDetectionConfigAsIs & Record<string, any> = {
       type,
-      create_response: createResponse ? createResponse : create_response,
+      create_response: createResponse ?? create_response,
       eagerness,
-      interrupt_response: interruptResponse
-        ? interruptResponse
-        : interrupt_response,
-      prefix_padding_ms: prefixPaddingMs ? prefixPaddingMs : prefix_padding_ms,
-      silence_duration_ms: silenceDurationMs
-        ? silenceDurationMs
-        : silence_duration_ms,
-      idle_timeout_ms: idleTimeoutMs ? idleTimeoutMs : idle_timeout_ms,
+      interrupt_response: interruptResponse ?? interrupt_response,
+      prefix_padding_ms: prefixPaddingMs ?? prefix_padding_ms,
+      silence_duration_ms: silenceDurationMs ?? silence_duration_ms,
+      idle_timeout_ms: idleTimeoutMs ?? idle_timeout_ms,
       threshold,
       ...rest,
     };

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -51,6 +51,35 @@ describe('OpenAIRealtimeBase helpers', () => {
     expect(config.audio?.output?.voice).toBeUndefined();
   });
 
+  it('preserves falsy turn detection values when building payload', () => {
+    const base = new TestBase();
+    const config = (base as any)._getMergedSessionConfig({
+      audio: {
+        input: {
+          turnDetection: {
+            type: 'semantic_vad',
+            createResponse: false,
+            interruptResponse: false,
+            prefixPaddingMs: 0,
+            silenceDurationMs: 0,
+            idleTimeoutMs: 0,
+            threshold: 0,
+          },
+        },
+      },
+    });
+
+    expect(config.audio?.input?.turn_detection).toEqual({
+      type: 'semantic_vad',
+      create_response: false,
+      interrupt_response: false,
+      prefix_padding_ms: 0,
+      silence_duration_ms: 0,
+      idle_timeout_ms: 0,
+      threshold: 0,
+    });
+  });
+
   it('updateSessionConfig sends session.update', () => {
     const base = new TestBase();
     base.updateSessionConfig({ voice: 'echo' });


### PR DESCRIPTION
This pull request resolves #816 