### PR TITLE
fix: #829 Ensure generated declarations are type-checked and expose PreparedInputWithSessionResult

### DIFF
--- a/.changeset/bumpy-melons-roll.md
+++ b/.changeset/bumpy-melons-roll.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: #829 Ensure generated declarations are type-checked and expose PreparedInputWithSessionResult

--- a/.codex/skills/verify-changes/SKILL.md
+++ b/.codex/skills/verify-changes/SKILL.md
@@ -7,7 +7,7 @@ description: Run all mandatory verification steps for code changes in the OpenAI
 
 ## Overview
 
-Ensure work is only marked complete after installing dependencies, building, linting, type checking, and tests pass. Use this skill whenever wrapping up a task, before opening a PR, or when asked to confirm that changes are ready to hand off.
+Ensure work is only marked complete after installing dependencies, building, linting, type checking (including generated declarations), and tests pass. Use this skill whenever wrapping up a task, before opening a PR, or when asked to confirm that changes are ready to hand off.
 
 ## Quick start
 
@@ -19,7 +19,7 @@ Ensure work is only marked complete after installing dependencies, building, lin
 
 ## Manual workflow
 
-- Run from the repository root in this order: `pnpm i`, `pnpm build`, `pnpm -r build-check`, `pnpm lint`, `pnpm test`.
+- Run from the repository root in this order: `pnpm i`, `pnpm build`, `pnpm -r build-check`, `pnpm -r -F "@openai/*" dist:check`, `pnpm lint`, `pnpm test`.
 - Do not skip steps; stop and fix issues immediately when a command fails.
 - Re-run the full stack after applying fixes so the commands execute in the required order.
 
@@ -27,7 +27,7 @@ Ensure work is only marked complete after installing dependencies, building, lin
 
 ### scripts/run.sh
 
-- Executes the full verification sequence with fail-fast semantics.
+- Executes the full verification sequence (including declaration checks) with fail-fast semantics.
 - Prefer this entry point to ensure the commands always run in the correct order from the repo root.
 
 ### scripts/run.ps1

--- a/.codex/skills/verify-changes/scripts/run.ps1
+++ b/.codex/skills/verify-changes/scripts/run.ps1
@@ -34,6 +34,7 @@ function Invoke-PnpmStep {
 Invoke-PnpmStep -Args @("i")
 Invoke-PnpmStep -Args @("build")
 Invoke-PnpmStep -Args @("-r", "build-check")
+Invoke-PnpmStep -Args @("-r", "-F", "@openai/*", "dist:check")
 Invoke-PnpmStep -Args @("lint")
 Invoke-PnpmStep -Args @("test")
 

--- a/.codex/skills/verify-changes/scripts/run.sh
+++ b/.codex/skills/verify-changes/scripts/run.sh
@@ -18,6 +18,9 @@ pnpm build
 echo "Running pnpm -r build-check..."
 pnpm -r build-check
 
+echo "Running pnpm -r -F \"@openai/*\" dist:check..."
+pnpm -r -F "@openai/*" dist:check
+
 echo "Running pnpm lint..."
 pnpm lint
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
         run: pnpm install
       - name: Build all packages
         run: pnpm build
+      - name: Check generated declarations
+        run: pnpm -r -F "@openai/*" dist:check
       - name: Run linter
         run: pnpm lint
       - name: Type-check docs scripts

--- a/packages/agents-core/package.json
+++ b/packages/agents-core/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "prebuild": "tsx ../../scripts/embedMeta.ts",
     "build": "tsc",
-    "build-check": "tsc --noEmit -p ./tsconfig.test.json"
+    "build-check": "tsc --noEmit -p ./tsconfig.test.json",
+    "dist:check": "tsc --noEmit -p ./tsconfig.dist-check.json"
   },
   "exports": {
     ".": {

--- a/packages/agents-core/src/runImplementation.ts
+++ b/packages/agents-core/src/runImplementation.ts
@@ -2438,7 +2438,6 @@ export async function saveStreamResultToSession(
 }
 
 /**
- * @internal
  * If a session is provided, expands the input with session history; otherwise returns the input.
  */
 export type PreparedInputWithSessionResult = {

--- a/packages/agents-core/tsconfig.dist-check.json
+++ b/packages/agents-core/tsconfig.dist-check.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "skipLibCheck": false,
+    "types": ["node"],
+    "lib": ["ES2018", "DOM"]
+  },
+  "include": ["./dist/**/*.d.ts"],
+  "exclude": ["./dist/runner/**"]
+}

--- a/packages/agents-extensions/package.json
+++ b/packages/agents-extensions/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "prebuild": "tsx ../../scripts/embedMeta.ts",
     "build": "tsc",
-    "build-check": "tsc --noEmit -p ./tsconfig.test.json"
+    "build-check": "tsc --noEmit -p ./tsconfig.test.json",
+    "dist:check": "tsc --noEmit -p ./tsconfig.dist-check.json"
   },
   "dependencies": {
     "@ai-sdk/provider": "^2.0.0",

--- a/packages/agents-extensions/tsconfig.dist-check.json
+++ b/packages/agents-extensions/tsconfig.dist-check.json
@@ -1,0 +1,24 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "skipLibCheck": false,
+    "types": ["node"],
+    "lib": ["ES2018", "DOM"],
+    "baseUrl": ".",
+    "paths": {
+      "@openai/agents-core/_shims": [
+        "../agents-core/dist/shims/shims-node.d.ts"
+      ],
+      "@openai/agents-core": ["../agents-core/dist/index.d.ts"],
+      "@openai/agents-core/*": ["../agents-core/dist/*"],
+      "@openai/agents-realtime/_shims": [
+        "../agents-realtime/dist/shims/shims-node.d.ts"
+      ],
+      "@openai/agents-realtime": ["../agents-realtime/dist/index.d.ts"],
+      "@openai/agents-realtime/*": ["../agents-realtime/dist/*"]
+    }
+  },
+  "include": ["./dist/**/*.d.ts"],
+  "exclude": []
+}

--- a/packages/agents-openai/package.json
+++ b/packages/agents-openai/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "prebuild": "tsx ../../scripts/embedMeta.ts",
     "build": "tsc",
-    "build-check": "tsc --noEmit -p ./tsconfig.test.json"
+    "build-check": "tsc --noEmit -p ./tsconfig.test.json",
+    "dist:check": "tsc --noEmit -p ./tsconfig.dist-check.json"
   },
   "keywords": [
     "openai",

--- a/packages/agents-openai/tsconfig.dist-check.json
+++ b/packages/agents-openai/tsconfig.dist-check.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "skipLibCheck": false,
+    "types": ["node"],
+    "lib": ["ES2018", "DOM"],
+    "baseUrl": ".",
+    "paths": {
+      "@openai/agents-core/_shims": [
+        "../agents-core/dist/shims/shims-node.d.ts"
+      ],
+      "@openai/agents-core": ["../agents-core/dist/index.d.ts"],
+      "@openai/agents-core/*": ["../agents-core/dist/*"]
+    }
+  },
+  "include": ["./dist/**/*.d.ts"],
+  "exclude": []
+}

--- a/packages/agents-realtime/package.json
+++ b/packages/agents-realtime/package.json
@@ -51,6 +51,7 @@
     "prebuild": "tsx ../../scripts/embedMeta.ts",
     "build": "tsc",
     "build-check": "tsc --noEmit -p ./tsconfig.test.json",
+    "dist:check": "tsc --noEmit -p ./tsconfig.dist-check.json",
     "bundle": "vite build"
   },
   "dependencies": {

--- a/packages/agents-realtime/tsconfig.dist-check.json
+++ b/packages/agents-realtime/tsconfig.dist-check.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "skipLibCheck": false,
+    "types": ["node"],
+    "lib": ["ES2018", "DOM"],
+    "baseUrl": ".",
+    "paths": {
+      "@openai/agents-realtime/_shims": ["./dist/shims/shims-node.d.ts"],
+      "@openai/agents-core/_shims": [
+        "../agents-core/dist/shims/shims-node.d.ts"
+      ],
+      "@openai/agents-core": ["../agents-core/dist/index.d.ts"],
+      "@openai/agents-core/*": ["../agents-core/dist/*"]
+    }
+  },
+  "include": ["./dist/**/*.d.ts"],
+  "exclude": []
+}

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -27,7 +27,8 @@
   "scripts": {
     "prebuild": "tsx ../../scripts/embedMeta.ts",
     "build": "tsc",
-    "build-check": "tsc --noEmit -p ./tsconfig.test.json"
+    "build-check": "tsc --noEmit -p ./tsconfig.test.json",
+    "dist:check": "tsc --noEmit -p ./tsconfig.dist-check.json"
   },
   "dependencies": {
     "@openai/agents-core": "workspace:*",

--- a/packages/agents/tsconfig.dist-check.json
+++ b/packages/agents/tsconfig.dist-check.json
@@ -1,0 +1,28 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "skipLibCheck": false,
+    "types": ["node"],
+    "lib": ["ES2018", "DOM"],
+    "baseUrl": ".",
+    "paths": {
+      "@openai/agents-core/_shims": [
+        "../agents-core/dist/shims/shims-node.d.ts"
+      ],
+      "@openai/agents-core": ["../agents-core/dist/index.d.ts"],
+      "@openai/agents-core/*": ["../agents-core/dist/*"],
+      "@openai/agents-openai": ["../agents-openai/dist/index.d.ts"],
+      "@openai/agents-openai/*": ["../agents-openai/dist/*"],
+      "@openai/agents-realtime/_shims": [
+        "../agents-realtime/dist/shims/shims-node.d.ts"
+      ],
+      "@openai/agents-realtime": ["../agents-realtime/dist/index.d.ts"],
+      "@openai/agents-realtime/*": ["../agents-realtime/dist/*"],
+      "@openai/agents-extensions": ["../agents-extensions/dist/index.d.ts"],
+      "@openai/agents-extensions/*": ["../agents-extensions/dist/*"]
+    }
+  },
+  "include": ["./dist/**/*.d.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
This change fixes a missing type in the published declarations by unmarking PreparedInputWithSessionResult as internal, then adds a dist:check step to every package so we type-check emitted .d.ts files with proper path mappings (including _shims). The verify-changes skill and CI workflow now run dist:check after the build to catch declaration regressions automatically.

Resolves #829 