### PR TITLE
fix: opt-in run state enhancement for #813

### DIFF
--- a/.changeset/major-candles-act.md
+++ b/.changeset/major-candles-act.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: opt-in run state enhancement for #813

--- a/packages/agents-core/src/tracing/traces.ts
+++ b/packages/agents-core/src/tracing/traces.ts
@@ -60,14 +60,26 @@ export class Trace {
     });
   }
 
-  toJSON(): object | null {
-    return {
+  /**
+   * Serializes the trace for export or persistence.
+   * Set `includeTracingApiKey` to true only when you intentionally need to persist the
+   * exporter credentials (for example, when handing off a run to another process that
+   * cannot access the original environment). Defaults to false to avoid leaking secrets.
+   */
+  toJSON(options?: { includeTracingApiKey?: boolean }): object | null {
+    const base = {
       object: this.type,
       id: this.traceId,
       workflow_name: this.name,
       group_id: this.groupId,
       metadata: this.metadata,
-    };
+    } as Record<string, any>;
+
+    if (options?.includeTracingApiKey && this.tracingApiKey) {
+      base.tracing_api_key = this.tracingApiKey;
+    }
+
+    return base;
   }
 }
 

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -186,6 +186,19 @@ describe('Trace & Span lifecycle', () => {
       { tracingApiKey: 'run-key' },
     );
   });
+
+  it('only serializes tracing api key when explicitly requested', () => {
+    const trace = new Trace({
+      name: 'test-trace',
+      tracingApiKey: 'secret-key',
+    });
+
+    const defaultJson = trace.toJSON();
+    expect(defaultJson).not.toHaveProperty('tracing_api_key');
+
+    const withKey = trace.toJSON({ includeTracingApiKey: true }) as any;
+    expect(withKey.tracing_api_key).toBe('secret-key');
+  });
 });
 
 describe('Span creation inherits tracing api key from parents', () => {


### PR DESCRIPTION
This pull request is a follow-up for #813 enhancement. It adds an opt-in option to include the passed tracing api key as part JSON data of run state. It's totally optional, so there is no risk to accidentally save credential data in files/database rows by default.