### PR TITLE
fix: Skip response_format when "text" in Chat Completions calls

### DIFF
--- a/.changeset/fluffy-parrots-cough.md
+++ b/.changeset/fluffy-parrots-cough.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: Skip response_format when "text" in Chat Completions calls

--- a/packages/agents-openai/test/openaiChatCompletionsModel.scenario.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.scenario.test.ts
@@ -100,7 +100,6 @@ describe('OpenAIChatCompletionsModel streaming scenarios', () => {
             content: 'hi there',
           },
         ],
-        response_format: { type: 'text' },
         reasoning_effort: 'medium',
         verbosity: 'high',
       }),

--- a/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
@@ -493,7 +493,7 @@ describe('OpenAIChatCompletionsModel', () => {
     );
     expect(
       client.chat.completions.create.mock.calls[0][0].response_format,
-    ).toEqual({ type: 'text' });
+    ).toBeUndefined();
 
     const schema: SerializedOutputType = {
       type: 'json_schema',


### PR DESCRIPTION
This PR makes Chat Completions requests safer and more interoperable with OpenAI-compatible providers. Text outputs now omit response_format, matching OpenAI’s default behavior and avoiding 400 errors on providers like Claude that reject non-json_schema values. A clarifying comment documents this behavior, and the request payload is now strongly typed (streaming/non-streaming union with provider overrides) instead of using any. All builds, lint, and tests pass via the verify-changes workflow.