### PR TITLE
fix: terminate streamable HTTP MCP sessions safely with typed guard

### DIFF
--- a/.changeset/old-things-punch.md
+++ b/.changeset/old-things-punch.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: terminate streamable HTTP MCP sessions safely with typed guard


### PR DESCRIPTION
This pull request resolves improper session cleanup for Streamable HTTP MCP clients by adding a typed guard in close() that uses the sessionId getter and only invokes terminateSession when the transport actually supports sessions, eliminating reliance on internal or non-existent fields. It clarifies the best-effort cleanup intent in comments and adjusts tests to validate both the presence and absence of terminateSession under the sessionId-based flow.