### PR TITLE
docs: clarify completion report guidance in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,7 @@ When `$code-change-verification` applies (see Mandatory Skill Usage), run the fu
 4.  When `$code-change-verification` applies (see Mandatory Skill Usage), run it to execute the full verification stack in order before considering the work complete.
 5.  Commit using Conventional Commits.
 6.  Push and open a pull request.
+7.  When reporting code changes as complete, include what you changed plus a draft pull request title and description for your local changes; start the description with prose such as “This pull request resolves/updates/adds …” using a verb that matches the change (you can use bullets later), explain the change background (for bugs, clearly describe the bug, symptoms, or repro; for features, what is needed and why), any behavior changes or considerations to be aware of, and you do not need to mention any tests you ran.
 
 ## Pull Request & Commit Guidelines
 


### PR DESCRIPTION
This pull request updates AGENTS.md to clarify how contributors should share completion reports. It requires including a draft PR title and a prose description that matches the change type (e.g., "This pull request resolves/updates/adds …"), explains the background (for bugs, describe the bug, symptoms, or repro; for features, what is needed and why), and notes any behavior changes or considerations to be aware of, without listing tests that were run.