### PR TITLE
feat: expand example runner filtering and refresh sample images

### DIFF
--- a/examples/ai-sdk/image-tool-output.ts
+++ b/examples/ai-sdk/image-tool-output.ts
@@ -11,7 +11,7 @@ const fetchRandomImage = tool({
     return {
       type: 'image',
       image:
-        'https://upload.wikimedia.org/wikipedia/commons/0/0c/GoldenGateBridge-001.jpg',
+        'https://images.unsplash.com/photo-1505761671935-60b3a7427bad?auto=format&fit=crop&w=400&q=80',
       detail: 'auto',
     };
   },
@@ -30,7 +30,7 @@ export async function runAgents(model: AiSdkModel) {
   );
 
   console.log(result.finalOutput);
-  // The image shows a large, iconic suspension bridge painted in a bright reddish-orange color. The bridge spans over a large body of water, connecting two landmasses. The weather is clear, with a blue sky and soft clouds in the background. Vehicles can be seen traveling along the bridge, and there is some greenery in the foreground. The overall atmosphere is serene and scenic.
+  // This image features the clock tower commonly known as Big Ben attached to the Palace of Westminster in London, captured against a clear blue sky. The ornate architecture and the clock face stand out prominently above surrounding buildings, with a hint of passing traffic below.
 }
 
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';

--- a/examples/basic/image-tool-output.ts
+++ b/examples/basic/image-tool-output.ts
@@ -10,7 +10,7 @@ const fetchRandomImage = tool({
     return {
       type: 'image',
       image:
-        'https://upload.wikimedia.org/wikipedia/commons/0/0c/GoldenGateBridge-001.jpg',
+        'https://images.unsplash.com/photo-1505761671935-60b3a7427bad?auto=format&fit=crop&w=400&q=80',
       detail: 'auto',
     };
   },
@@ -29,7 +29,7 @@ async function main() {
   );
 
   console.log(result.finalOutput);
-  // The image shows a large, iconic suspension bridge painted in a bright reddish-orange color. The bridge spans over a large body of water, connecting two landmasses. The weather is clear, with a blue sky and soft clouds in the background. Vehicles can be seen traveling along the bridge, and there is some greenery in the foreground. The overall atmosphere is serene and scenic.
+  // This image features the clock tower commonly known as Big Ben attached to the Palace of Westminster in London, captured against a clear blue sky. The ornate architecture and the clock face stand out prominently above surrounding buildings, with a hint of passing traffic below.
 }
 
 if (require.main === module) {

--- a/examples/basic/remote-image.ts
+++ b/examples/basic/remote-image.ts
@@ -1,7 +1,7 @@
 import { Agent, run } from '@openai/agents';
 
 const url =
-  'https://upload.wikimedia.org/wikipedia/commons/0/0c/GoldenGateBridge-001.jpg';
+  'https://images.unsplash.com/photo-1505761671935-60b3a7427bad?auto=format&fit=crop&w=400&q=80';
 
 async function main() {
   const agent = new Agent({
@@ -29,7 +29,7 @@ async function main() {
   ]);
 
   console.log(result.finalOutput);
-  // This image shows the Golden Gate Bridge, a famous suspension bridge located in San Francisco, California. The bridge is painted in its signature "International Orange" color and spans the Golden Gate Strait, connecting San Francisco to Marin County. The photo is taken during daylight, with the city and hills visible in the background and water beneath the bridge. The bridge is an iconic landmark and a symbol of San Francisco.
+  // This image features the clock tower commonly known as Big Ben attached to the Palace of Westminster in London, captured against a clear blue sky. The ornate architecture and the clock face stand out prominently above surrounding buildings, with a hint of passing traffic below.
 }
 
 main().catch((error) => {

--- a/scripts/run-example-starts.mjs
+++ b/scripts/run-example-starts.mjs
@@ -9,18 +9,31 @@ import { execa } from 'execa';
  * Run all example start scripts in order.
  *
  * Usage:
- *   node scripts/run-example-starts.mjs --dry-run           # list only
- *   node scripts/run-example-starts.mjs --filter basic      # run only matches
- *   node scripts/run-example-starts.mjs --include-server    # include server-like scripts
+ *   node scripts/run-example-starts.mjs --dry-run                # list only
+ *   node scripts/run-example-starts.mjs --filter basic           # run only matches
+ *   node scripts/run-example-starts.mjs --include-interactive    # include HITL/interactive scripts
+ *   node scripts/run-example-starts.mjs --include-server         # include server-like scripts
+ *   node scripts/run-example-starts.mjs --include-audio          # include realtime/voice scripts
+ *   node scripts/run-example-starts.mjs --include-external       # include scripts needing extra services
+ *   node scripts/run-example-starts.mjs --fail-fast              # stop after first failure
  *
  * Via package.json:
  *   pnpm examples:start-all --dry-run
  *   pnpm examples:start-all --filter basic
- *   pnpm examples:start-all --include-server
+ *   pnpm examples:start-all --include-interactive
  */
 const START_PATTERN = /^start(?::|$)/;
 const SERVER_COMMAND_KEYWORDS = ['next', 'vite', 'serve', 'server', 'dev '];
 const SERVER_PATH_KEYWORDS = ['realtime', 'nextjs'];
+const INTERACTIVE_NAME_KEYWORDS = ['hitl', 'human'];
+const AUDIO_PATH_KEYWORDS = ['realtime', 'voice', 'audio'];
+const EXTERNAL_COMMAND_KEYWORDS = [
+  'prisma',
+  'redis',
+  'twilio',
+  'dapr',
+  'playwright',
+];
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -31,6 +44,11 @@ const parseArgs = (args) => {
   let dryRun = false;
   let filter = null;
   let includeServer = false;
+  let includeInteractive = false;
+  let includeAudio = false;
+  let includeExternal = false;
+  let failFast = false;
+  let verbose = false;
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
@@ -50,10 +68,44 @@ const parseArgs = (args) => {
       continue;
     }
 
+    if (arg === '--include-interactive') {
+      includeInteractive = true;
+      continue;
+    }
+
+    if (arg === '--include-audio') {
+      includeAudio = true;
+      continue;
+    }
+
+    if (arg === '--include-external') {
+      includeExternal = true;
+      continue;
+    }
+
+    if (arg === '--fail-fast') {
+      failFast = true;
+      continue;
+    }
+
+    if (arg === '--verbose') {
+      verbose = true;
+      continue;
+    }
+
     console.warn(`Ignoring unknown argument: ${arg}`);
   }
 
-  return { dryRun, filter, includeServer };
+  return {
+    dryRun,
+    filter,
+    includeServer,
+    includeInteractive,
+    includeAudio,
+    includeExternal,
+    failFast,
+    verbose,
+  };
 };
 
 const matchesFilter = (start, filter) => {
@@ -69,24 +121,39 @@ const matchesFilter = (start, filter) => {
   );
 };
 
-const isServerLike = (start, includeServer) => {
-  if (includeServer) {
-    return false;
-  }
-
+const detectTags = (start) => {
+  const tags = new Set();
   const commandLower = start.command.toLowerCase();
-  if (
-    SERVER_COMMAND_KEYWORDS.some((keyword) => commandLower.includes(keyword))
-  ) {
-    return true;
-  }
-
   const dirLower = start.dir.toLowerCase();
-  if (SERVER_PATH_KEYWORDS.some((keyword) => dirLower.includes(keyword))) {
-    return true;
+  const nameLower = `${start.packageName}:${start.scriptName}`.toLowerCase();
+
+  if (
+    SERVER_COMMAND_KEYWORDS.some((keyword) => commandLower.includes(keyword)) ||
+    SERVER_PATH_KEYWORDS.some((keyword) => dirLower.includes(keyword))
+  ) {
+    tags.add('server');
   }
 
-  return false;
+  if (
+    INTERACTIVE_NAME_KEYWORDS.some((keyword) => nameLower.includes(keyword))
+  ) {
+    tags.add('interactive');
+  }
+
+  if (
+    AUDIO_PATH_KEYWORDS.some((keyword) => dirLower.includes(keyword)) ||
+    AUDIO_PATH_KEYWORDS.some((keyword) => commandLower.includes(keyword))
+  ) {
+    tags.add('audio');
+  }
+
+  if (
+    EXTERNAL_COMMAND_KEYWORDS.some((keyword) => commandLower.includes(keyword))
+  ) {
+    tags.add('external');
+  }
+
+  return tags;
 };
 
 const collectStartScripts = async (filter) => {
@@ -110,7 +177,9 @@ const collectStartScripts = async (filter) => {
       }
 
       throw new Error(
-        `Failed to read ${packageJsonPath}: ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to read ${packageJsonPath}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
       );
     }
 
@@ -119,7 +188,9 @@ const collectStartScripts = async (filter) => {
       packageJson = JSON.parse(packageJsonRaw);
     } catch (error) {
       throw new Error(
-        `Failed to parse ${packageJsonPath}: ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to parse ${packageJsonPath}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
       );
     }
 
@@ -139,7 +210,7 @@ const collectStartScripts = async (filter) => {
       };
 
       if (matchesFilter(start, filter)) {
-        starts.push(start);
+        starts.push({ ...start, tags: detectTags(start) });
       }
     }
   }
@@ -151,49 +222,122 @@ const collectStartScripts = async (filter) => {
   );
 };
 
-const runStarts = async (starts, dryRun, includeServer) => {
+const shouldSkip = (tags, overrides) => {
+  const blocked = new Set(['interactive', 'server', 'audio', 'external']);
+  for (const override of overrides) {
+    blocked.delete(override);
+  }
+
+  const reasons = new Set([...tags].filter((tag) => blocked.has(tag)));
+  return { skip: reasons.size > 0, reasons };
+};
+
+const formatTags = (tags) =>
+  tags.size ? `[tags: ${[...tags].sort().join(', ')}]` : '';
+
+const runStarts = async (starts, dryRun, overrides, failFast, verbose) => {
+  let executed = 0;
+  let skipped = 0;
+  let failed = 0;
+
   for (const start of starts) {
-    if (isServerLike(start, includeServer)) {
+    const { skip, reasons } = shouldSkip(start.tags, overrides);
+    const tagLabel =
+      verbose && start.tags.size ? ` ${formatTags(start.tags)}` : '';
+
+    if (skip) {
+      const reasonLabel = reasons.size
+        ? ` (skipped: ${[...reasons].sort().join(', ')})`
+        : '';
       const relativeDir = path.relative(rootDir, start.dir) || '.';
       console.log(
-        `\n↷ Skipping server-like script ${start.packageName}:${start.scriptName} (pnpm -C ${relativeDir} run ${start.scriptName}). Use --include-server to run.`,
+        `\n↷ Skipping ${start.packageName}:${start.scriptName}${tagLabel}${reasonLabel}. pnpm -C ${relativeDir} run ${start.scriptName}`,
       );
+      skipped += 1;
       continue;
     }
 
     const relativeDir = path.relative(rootDir, start.dir) || '.';
     console.log(
-      `\n→ ${start.packageName}:${start.scriptName}\n   pnpm -C ${relativeDir} run ${start.scriptName}\n   ${start.command}`,
+      `\n→ ${start.packageName}:${start.scriptName}${tagLabel}\n   pnpm -C ${relativeDir} run ${start.scriptName}\n   ${start.command}`,
     );
 
     if (dryRun) {
       continue;
     }
 
-    await execa('pnpm', ['-C', start.dir, 'run', start.scriptName], {
-      stdio: 'inherit',
-    });
+    try {
+      await execa('pnpm', ['-C', start.dir, 'run', start.scriptName], {
+        stdio: 'inherit',
+      });
+      executed += 1;
+    } catch (error) {
+      failed += 1;
+      const exitCode =
+        typeof error?.exitCode === 'number' ? error.exitCode : 'unknown';
+      console.error(
+        `   !! ${start.packageName}:${start.scriptName} exited with ${exitCode}`,
+      );
+      if (failFast) {
+        break;
+      }
+    }
   }
+
+  console.log(
+    `\nDone. Ran ${executed} start script(s), skipped ${skipped}, failed ${failed}.`,
+  );
+
+  return failed === 0 ? 0 : 1;
 };
 
 const main = async () => {
-  const { dryRun, filter, includeServer } = parseArgs(process.argv.slice(2));
+  const {
+    dryRun,
+    filter,
+    includeServer,
+    includeInteractive,
+    includeAudio,
+    includeExternal,
+    failFast,
+    verbose,
+  } = parseArgs(process.argv.slice(2));
 
   const starts = await collectStartScripts(filter);
 
   if (starts.length === 0) {
     console.log('No start scripts found under examples.');
-    return;
+    return 0;
   }
 
   console.log(
-    `Found ${starts.length} start scripts under examples${filter ? ` (filtered by "${filter}")` : ''}.`,
+    `Found ${starts.length} start scripts under examples${
+      filter ? ` (filtered by "${filter}")` : ''
+    }.`,
   );
 
-  await runStarts(starts, dryRun, includeServer);
+  const overrides = new Set();
+  if (includeServer) {
+    overrides.add('server');
+  }
+  if (includeInteractive) {
+    overrides.add('interactive');
+  }
+  if (includeAudio) {
+    overrides.add('audio');
+  }
+  if (includeExternal) {
+    overrides.add('external');
+  }
+
+  return runStarts(starts, dryRun, overrides, failFast, verbose);
 };
 
-main().catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
+main()
+  .then((exitCode) => {
+    process.exitCode = exitCode ?? 0;
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
This pull request adds richer tagging plus opt-in flags to `scripts/run-example-starts.mjs` so example start scripts can be skipped or included by category (interactive, server, audio, external), with new `--fail-fast`/`--verbose` options, tag-aware logging, and explicit exit codes for CI friendliness. It refreshes the sample image URLs and narrated outputs in `examples/ai-sdk/image-tool-output.ts`, `examples/basic/image-tool-output.ts`, and `examples/basic/remote-image.ts` to use a fetchable image URL.