### PR TITLE
Add unit tests using $test-coverage-improver

### DIFF
--- a/packages/agents-core/test/utils/base64.test.ts
+++ b/packages/agents-core/test/utils/base64.test.ts
@@ -1,8 +1,16 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 
 import { encodeUint8ArrayToBase64 } from '../../src/utils/base64';
 
 describe('encodeUint8ArrayToBase64', () => {
+  const originalBuffer = (globalThis as any).Buffer;
+  const originalBtoa = (globalThis as any).btoa;
+
+  afterEach(() => {
+    (globalThis as any).Buffer = originalBuffer;
+    (globalThis as any).btoa = originalBtoa;
+  });
+
   it('returns an empty string for empty input', () => {
     expect(encodeUint8ArrayToBase64(new Uint8Array())).toBe('');
   });
@@ -15,5 +23,33 @@ describe('encodeUint8ArrayToBase64', () => {
   it('encodes arbitrary binary data', () => {
     const bytes = new Uint8Array([0, 255, 34, 17, 128, 64]);
     expect(encodeUint8ArrayToBase64(bytes)).toBe('AP8iEYBA');
+  });
+
+  it('uses btoa when Buffer is unavailable', () => {
+    (globalThis as any).Buffer = undefined;
+    const btoaSpy = vi.fn((input: string) =>
+      (originalBuffer as typeof Buffer)
+        .from(input, 'binary')
+        .toString('base64'),
+    );
+    (globalThis as any).btoa = btoaSpy;
+
+    const bytes = new Uint8Array([1, 2, 3]);
+    const result = encodeUint8ArrayToBase64(bytes);
+
+    expect(result).toBe('AQID');
+    expect(btoaSpy).toHaveBeenCalledWith('\u0001\u0002\u0003');
+  });
+
+  it('falls back to manual encoding when Buffer and btoa are unavailable', () => {
+    (globalThis as any).Buffer = undefined;
+    (globalThis as any).btoa = undefined;
+
+    const bytes = new Uint8Array([255, 254, 253]);
+    const result = encodeUint8ArrayToBase64(bytes);
+
+    expect(result).toBe(
+      (originalBuffer as typeof Buffer).from(bytes).toString('base64'),
+    );
   });
 });

--- a/packages/agents-core/test/utils/binary.test.ts
+++ b/packages/agents-core/test/utils/binary.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  serializeBinary,
+  toUint8ArrayFromBinary,
+} from '../../src/utils/binary';
+
+describe('utils/binary', () => {
+  it('serializes array buffers, typed views, node buffers, and snapshots', () => {
+    const arrayBuffer = new Uint8Array([1, 2, 3]).buffer;
+    const typedView = new Uint16Array([256, 512]);
+    const nodeBuffer = Buffer.from([9, 8, 7]);
+    const snapshot = { type: 'Buffer', data: [5, 6, 7] };
+
+    expect(serializeBinary(arrayBuffer)).toEqual({
+      __type: 'ArrayBuffer',
+      data: Buffer.from(arrayBuffer).toString('base64'),
+    });
+
+    expect(serializeBinary(typedView)).toEqual({
+      __type: 'Uint16Array',
+      data: Buffer.from(
+        new Uint8Array(
+          typedView.buffer,
+          typedView.byteOffset,
+          typedView.byteLength,
+        ),
+      ).toString('base64'),
+    });
+
+    expect(serializeBinary(nodeBuffer)).toEqual({
+      __type: 'Buffer',
+      data: Buffer.from(nodeBuffer).toString('base64'),
+    });
+
+    expect(serializeBinary(snapshot)).toEqual({
+      __type: 'Buffer',
+      data: Buffer.from(Uint8Array.from(snapshot.data)).toString('base64'),
+    });
+
+    expect(serializeBinary(42)).toBeUndefined();
+  });
+
+  it('round-trips to Uint8Array for supported inputs', () => {
+    const arrayBuffer = new Uint8Array([1, 2, 3]).buffer;
+    const typedView = new Uint16Array([256, 512]);
+    const nodeBuffer = Buffer.from([9, 8, 7]);
+    const snapshot = { type: 'Buffer', data: [5, 6, 7] };
+
+    expect(toUint8ArrayFromBinary(arrayBuffer)).toEqual(
+      new Uint8Array(arrayBuffer),
+    );
+    expect(toUint8ArrayFromBinary(typedView)).toEqual(
+      new Uint8Array(
+        typedView.buffer,
+        typedView.byteOffset,
+        typedView.byteLength,
+      ),
+    );
+    expect(toUint8ArrayFromBinary(nodeBuffer)).toEqual(
+      new Uint8Array(
+        nodeBuffer.buffer,
+        nodeBuffer.byteOffset,
+        nodeBuffer.byteLength,
+      ),
+    );
+    expect(toUint8ArrayFromBinary(snapshot)).toEqual(
+      Uint8Array.from(snapshot.data),
+    );
+    expect(toUint8ArrayFromBinary('nope')).toBeUndefined();
+  });
+});

--- a/packages/agents-realtime/test/tool.test.ts
+++ b/packages/agents-realtime/test/tool.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  BACKGROUND_RESULT_SYMBOL,
+  RealtimeTool,
+  backgroundResult,
+  isBackgroundResult,
+  isValidRealtimeTool,
+  toRealtimeToolDefinition,
+} from '../src/tool';
+import { RealtimeToolDefinition } from '../src/clientMessages';
+
+const functionTool: RealtimeTool = {
+  type: 'function',
+  name: 'echo',
+  description: 'echo input',
+  parameters: {
+    type: 'object',
+    properties: {},
+    required: [],
+    additionalProperties: false,
+  },
+  strict: true,
+  invoke: async () => 'ok',
+  needsApproval: async () => false,
+  isEnabled: async () => true,
+};
+
+const hostedMcpTool: RealtimeTool = {
+  type: 'hosted_tool',
+  name: 'hosted_mcp',
+  providerData: {
+    type: 'mcp',
+    server_label: 'my-mcp',
+    server_url: 'https://example.com',
+    headers: { Authorization: 'Bearer token' },
+    allowed_tools: ['one', 'two'],
+    require_approval: 'never',
+  },
+};
+
+describe('realtime tool helpers', () => {
+  it('creates and detects background results', () => {
+    const payload = backgroundResult({ value: 42 });
+    expect(payload[BACKGROUND_RESULT_SYMBOL]).toBe(true);
+    expect(isBackgroundResult(payload)).toBe(true);
+    expect(isBackgroundResult({ value: 42 })).toBe(false);
+  });
+
+  it('validates realtime tool shapes', () => {
+    expect(isValidRealtimeTool(functionTool)).toBe(true);
+    expect(isValidRealtimeTool(hostedMcpTool)).toBe(true);
+    expect(
+      isValidRealtimeTool({
+        ...hostedMcpTool,
+        name: 'other',
+        type: 'hosted_tool',
+      }),
+    ).toBe(false);
+    expect(isValidRealtimeTool({ type: 'computer' } as any)).toBe(false);
+  });
+
+  it('converts realtime tools to wire definitions', () => {
+    const funcDef = toRealtimeToolDefinition(functionTool);
+    expect(funcDef).toEqual(functionTool);
+
+    const mcpDef = toRealtimeToolDefinition(hostedMcpTool);
+    if (mcpDef.type !== 'mcp') {
+      throw new Error('Expected mcp definition');
+    }
+    const expected: RealtimeToolDefinition = {
+      type: 'mcp',
+      server_label: 'my-mcp',
+      server_url: 'https://example.com',
+      headers: { Authorization: 'Bearer token' },
+      allowed_tools: ['one', 'two'],
+      require_approval: 'never',
+    };
+    expect(mcpDef).toEqual(expected);
+
+    const withoutUrl = toRealtimeToolDefinition({
+      ...hostedMcpTool,
+      providerData: { ...hostedMcpTool.providerData, server_url: '' },
+    });
+    if (withoutUrl.type !== 'mcp') {
+      throw new Error('Expected mcp definition');
+    }
+    expect(withoutUrl.server_url).toBeUndefined();
+
+    expect(() =>
+      toRealtimeToolDefinition({ ...functionTool, type: 'computer' } as any),
+    ).toThrowError(/Invalid tool type/);
+  });
+});


### PR DESCRIPTION
- Added binary serialization round-trip tests (packages/agents-core/test/utils/binary.test.ts) covering ArrayBuffer, typed views, Node Buffer, and buffer snapshots.
- Extended realtime tool helper coverage (packages/agents-realtime/test/tool.test.ts) for background results, tool validation, hosted MCP conversion, and error handling.
- Broadened schema converter coverage for map/set/nullable/native-enum shapes and failure cases (packages/agents-core/test/utils/zodJsonSchemaCompat.test.ts).
- Hardened realtime base behavior tests (packages/agents-realtime/test/openaiRealtimeBase.test.ts) across usage/turn events, audio-done hook, MCP messaging item updates, tracing config updates, and transcription completion/truncation retrievals.
- Added Buffer-less and pure JS fallbacks to base64 tests (packages/agents-core/test/utils/base64.test.ts).

Coverage after changes: 84.71% statements / 81.13% branches (was 83.80% / 80.65%). Notable lifts: agents-realtime/src/tool.ts now 100% statements/
branches; agents-core/src/utils/base64.ts 100% statements; agents-realtime/src/openaiRealtimeBase.ts to ~76.7% statements.

Tests run:
- CI=1 pnpm test:coverage
- .codex/skills/code-change-verification/scripts/run.sh (pnpm i, build, bundle, build-check, dist-check, lint, test)