### PR TITLE
fix(agents-core): #670 set subclass error names

### DIFF
--- a/.changeset/bright-comets-spark.md
+++ b/.changeset/bright-comets-spark.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix(agents-core): #670 set subclass error names

--- a/packages/agents-core/src/errors.ts
+++ b/packages/agents-core/src/errors.ts
@@ -21,6 +21,7 @@ export abstract class AgentsError extends Error {
 
   constructor(message: string, state?: RunState<any, Agent<any, any>>) {
     super(message);
+    this.name = new.target.name;
     this.state = state;
   }
 }

--- a/packages/agents-core/test/agent.test.ts
+++ b/packages/agents-core/test/agent.test.ts
@@ -177,7 +177,7 @@ describe('Agent', () => {
 
     const result1 = await tool.invoke({} as any, 'hey how are you?');
     expect(result1).toBe(
-      'An error occurred while running the tool. Please try again. Error: Error: Invalid JSON input for tool',
+      'An error occurred while running the tool. Please try again. Error: InvalidToolInputError: Invalid JSON input for tool',
     );
     setDefaultModelProvider(new FakeModelProvider());
     const result2 = await tool.invoke(

--- a/packages/agents-core/test/errors.test.ts
+++ b/packages/agents-core/test/errors.test.ts
@@ -50,4 +50,29 @@ describe('errors', () => {
       throw toolCallError;
     }).toThrow('Test error');
   });
+
+  test('should set error names', () => {
+    expect(new MaxTurnsExceededError('Test error', {} as any).name).toBe(
+      'MaxTurnsExceededError',
+    );
+    expect(new ModelBehaviorError('Test error', {} as any).name).toBe(
+      'ModelBehaviorError',
+    );
+    expect(new UserError('Test error', {} as any).name).toBe('UserError');
+    expect(
+      new InputGuardrailTripwireTriggered('Test error', {} as any, {} as any)
+        .name,
+    ).toBe('InputGuardrailTripwireTriggered');
+    expect(
+      new OutputGuardrailTripwireTriggered('Test error', {} as any, {} as any)
+        .name,
+    ).toBe('OutputGuardrailTripwireTriggered');
+    expect(
+      new GuardrailExecutionError('Test error', new Error('cause'), {} as any)
+        .name,
+    ).toBe('GuardrailExecutionError');
+    expect(
+      new ToolCallError('Test error', new Error('cause'), {} as any).name,
+    ).toBe('ToolCallError');
+  });
 });


### PR DESCRIPTION
This pull request fixes error name reporting by setting AgentsError.name to the subclass name, so error strings and logging reflect the concrete error type (see https://github.com/openai/openai-agents-js/issues/670). It also adds coverage for error names, updates the agent tool error expectation, and includes a changeset for the behavior change. This pull request resolves #670.