### PR TITLE
ci: fix changeset milestone selection for patch bumps

### DIFF
--- a/.codex/skills/changeset-validation/scripts/changeset-assign-milestone.mjs
+++ b/.codex/skills/changeset-validation/scripts/changeset-assign-milestone.mjs
@@ -94,8 +94,9 @@ async function assignMilestone(requiredBump) {
     return;
   }
 
-  const targetEntry =
-    requiredBump === 'minor' ? (parsed[1] ?? parsed[0]) : parsed[0];
+  const patchTarget = parsed[parsed.length - 1];
+  const minorTarget = parsed[1] ?? parsed[0];
+  const targetEntry = requiredBump === 'minor' ? minorTarget : patchTarget;
   if (!targetEntry) {
     console.warn(
       'Milestone assignment skipped (not enough open milestones for selection).',


### PR DESCRIPTION
This pull request fixes the milestone assignment script so patch changesets are attached to the lowest available X.Y.x milestone instead of always picking the newest series. It also clarifies minor bump handling by selecting the second-most-recent milestone when available. Changes are limited to .codex/skills/changeset-validation/scripts/changeset-assign-milestone.mjs.