### PR TITLE
chore(examples): update ai-sdk-v1 example deps

### DIFF
--- a/examples/ai-sdk-v1/README.md
+++ b/examples/ai-sdk-v1/README.md
@@ -14,7 +14,7 @@ The [ai-sdk-model.ts](./ai-sdk-model.ts) script:
 From the repository root, execute:
 
 ```bash
-pnpm -F ai-sdk start:sdk-model
+pnpm -F ai-sdk-v1 start
 ```
 
 The script prints the final output produced by the runner.

--- a/examples/ai-sdk-v1/package.json
+++ b/examples/ai-sdk-v1/package.json
@@ -3,9 +3,11 @@
   "name": "ai-sdk-v1",
   "dependencies": {
     "@ai-sdk/openai": "1",
-    "@openai/agents": "workspace:*",
-    "@openai/agents-extensions": "workspace:*",
-    "zod": "^4.0.0"
+    "@ai-sdk/provider": "1.1.3",
+    "@openai/agents": "0.3.9",
+    "@openai/agents-extensions": "0.3.9",
+    "hono": "^4.11.3",
+    "zod": "^3.23.8"
   },
   "scripts": {
     "build-check": "tsc --noEmit",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,16 +152,22 @@ importers:
     dependencies:
       '@ai-sdk/openai':
         specifier: '1'
-        version: 1.3.24(zod@4.3.5)
+        version: 1.3.24(zod@3.25.76)
+      '@ai-sdk/provider':
+        specifier: 1.1.3
+        version: 1.1.3
       '@openai/agents':
-        specifier: workspace:*
-        version: link:../../packages/agents
+        specifier: 0.3.9
+        version: 0.3.9(hono@4.11.3)(ws@8.18.2)(zod@3.25.76)
       '@openai/agents-extensions':
-        specifier: workspace:*
-        version: link:../../packages/agents-extensions
+        specifier: 0.3.9
+        version: 0.3.9(@openai/agents@0.3.9(hono@4.11.3)(ws@8.18.2)(zod@3.25.76))(@openai/codex-sdk@0.86.0)(hono@4.11.3)(ws@8.18.2)(zod@3.25.76)
+      hono:
+        specifier: ^4.11.3
+        version: 4.11.3
       zod:
-        specifier: ^4.0.0
-        version: 4.3.5
+        specifier: ^3.23.8
+        version: 3.25.76
 
   examples/basic:
     dependencies:
@@ -1629,6 +1635,40 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@openai/agents-core@0.3.9':
+    resolution: {integrity: sha512-6Fr/VkA3lMaTT9EV2+OsmkMX9Yx+/PeWtlmaWNKDRG8D15IWuK13NOC9eFklTsa7otbuwbw/Xmjes+h4Z+CwSQ==}
+    peerDependencies:
+      zod: ^3.25.40 || ^4.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@openai/agents-extensions@0.3.9':
+    resolution: {integrity: sha512-skpprb7bRF7ycugq+87Nu/mCaK2yN02Bq7Kqb0YpnlK/UONAC8UojGQVtoIfsVpgcNhVi1KtxrTjYAQ3+/Wu2w==}
+    peerDependencies:
+      '@openai/agents': '>=0.0.0'
+      '@openai/codex-sdk': '>=0.86.0'
+      ws: ^8.18.1
+      zod: ^3.25.40 || ^4.0
+    peerDependenciesMeta:
+      '@openai/codex-sdk':
+        optional: true
+
+  '@openai/agents-openai@0.3.9':
+    resolution: {integrity: sha512-duXUt0xU6K/+c7ae4m8BrJIUzZal6Pzln8V0frnJfNyfYO4SvHMV4qwPRzVDvv/ANj4DQXWI2L1JdPxKJeSHkw==}
+    peerDependencies:
+      zod: ^3.25.40 || ^4.0
+
+  '@openai/agents-realtime@0.3.9':
+    resolution: {integrity: sha512-51zHO/zao/LHv70gseU1otTvXyS81tuVaewHlUBiNMXvqSZNkYViiO69hpXMoTYn5c3gCjUrXPxxI+NlHUtaHg==}
+    peerDependencies:
+      zod: ^3.25.40 || ^4.0
+
+  '@openai/agents@0.3.9':
+    resolution: {integrity: sha512-YaKnqv0M6bCVvn47pThkFfyHz8xWJ+0Ll9ZnhvwJZ5gyPX0UxHIUeUs9SMG9BSvNuJNJHlc5uvfUDGYAmKJClw==}
+    peerDependencies:
+      zod: ^3.25.40 || ^4.0
 
   '@openai/codex-sdk@0.86.0':
     resolution: {integrity: sha512-FhdeMmaufS3N7noOtfq28YyGA5us+UYpVxL10guUt2gXwMPqJ/7S6D7Ci5KG2e9UECC2OKHkzKtxSHzybvK2/A==}
@@ -6414,11 +6454,11 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.4(zod@4.3.5)
       zod: 4.3.5
 
-  '@ai-sdk/openai@1.3.24(zod@4.3.5)':
+  '@ai-sdk/openai@1.3.24(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.5)
-      zod: 4.3.5
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      zod: 3.25.76
 
   '@ai-sdk/openai@2.0.15(zod@4.3.5)':
     dependencies:
@@ -6432,12 +6472,12 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.4(zod@4.3.5)
       zod: 4.3.5
 
-  '@ai-sdk/provider-utils@2.2.8(zod@4.3.5)':
+  '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
-      zod: 4.3.5
+      zod: 3.25.76
 
   '@ai-sdk/provider-utils@3.0.3(zod@4.3.5)':
     dependencies:
@@ -7337,6 +7377,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.7(hono@4.11.3)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 7.5.1(express@5.2.1)
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - hono
+      - supports-color
+    optional: true
+
   '@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5)':
     dependencies:
       '@hono/node-server': 1.19.7(hono@4.11.3)
@@ -7396,6 +7459,77 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@openai/agents-core@0.3.9(hono@4.11.3)(ws@8.18.2)(zod@3.25.76)':
+    dependencies:
+      debug: 4.4.3
+      openai: 6.10.0(ws@8.18.2)(zod@3.25.76)
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.25.2(hono@4.11.3)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - hono
+      - supports-color
+      - ws
+
+  '@openai/agents-extensions@0.3.9(@openai/agents@0.3.9(hono@4.11.3)(ws@8.18.2)(zod@3.25.76))(@openai/codex-sdk@0.86.0)(hono@4.11.3)(ws@8.18.2)(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@openai/agents': 0.3.9(hono@4.11.3)(ws@8.18.2)(zod@3.25.76)
+      '@openai/agents-core': 0.3.9(hono@4.11.3)(ws@8.18.2)(zod@3.25.76)
+      '@types/ws': 8.18.1
+      debug: 4.4.3
+      ws: 8.18.2
+      zod: 3.25.76
+    optionalDependencies:
+      '@openai/codex-sdk': 0.86.0
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - hono
+      - supports-color
+
+  '@openai/agents-openai@0.3.9(hono@4.11.3)(ws@8.18.2)(zod@3.25.76)':
+    dependencies:
+      '@openai/agents-core': 0.3.9(hono@4.11.3)(ws@8.18.2)(zod@3.25.76)
+      debug: 4.4.3
+      openai: 6.10.0(ws@8.18.2)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - hono
+      - supports-color
+      - ws
+
+  '@openai/agents-realtime@0.3.9(hono@4.11.3)(zod@3.25.76)':
+    dependencies:
+      '@openai/agents-core': 0.3.9(hono@4.11.3)(ws@8.18.2)(zod@3.25.76)
+      '@types/ws': 8.18.1
+      debug: 4.4.3
+      ws: 8.18.2
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - bufferutil
+      - hono
+      - supports-color
+      - utf-8-validate
+
+  '@openai/agents@0.3.9(hono@4.11.3)(ws@8.18.2)(zod@3.25.76)':
+    dependencies:
+      '@openai/agents-core': 0.3.9(hono@4.11.3)(ws@8.18.2)(zod@3.25.76)
+      '@openai/agents-openai': 0.3.9(hono@4.11.3)(ws@8.18.2)(zod@3.25.76)
+      '@openai/agents-realtime': 0.3.9(hono@4.11.3)(zod@3.25.76)
+      debug: 4.4.3
+      openai: 6.10.0(ws@8.18.2)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - bufferutil
+      - hono
+      - supports-color
+      - utf-8-validate
+      - ws
 
   '@openai/codex-sdk@0.86.0': {}
 
@@ -11159,6 +11293,11 @@ snapshots:
       oniguruma-parser: 0.12.1
       regex: 6.1.0
       regex-recursion: 6.0.2
+
+  openai@6.10.0(ws@8.18.2)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.18.2
+      zod: 3.25.76
 
   openai@6.10.0(ws@8.18.2)(zod@4.3.5):
     optionalDependencies:


### PR DESCRIPTION
This pull request updates the ai-sdk-v1 example dependencies and refreshes the workspace lockfile to keep the example build aligned. It also makes a small README tweak in examples/ai-sdk-v1/README.md. No public API changes are expected; the impact is limited to the example and dependency resolution in pnpm-lock.yaml.