### PR TITLE
fix(openai): keep compaction auto mode aligned with store=false

### DIFF
--- a/.changeset/compaction-input-mode.md
+++ b/.changeset/compaction-input-mode.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+---
+
+Default compaction mode to auto and switch to input when store is false.

--- a/examples/memory/oai-compact-stateless.ts
+++ b/examples/memory/oai-compact-stateless.ts
@@ -1,0 +1,77 @@
+import {
+  Agent,
+  MemorySession,
+  OpenAIResponsesCompactionSession,
+  run,
+  withTrace,
+} from '@openai/agents';
+import { fetchImageData } from './tools';
+
+async function main() {
+  const session = new OpenAIResponsesCompactionSession({
+    model: 'gpt-5.2',
+    // If store: false in modelSettings, auto switches to input mode.
+    // compactionMode: 'input',
+    // Use a local session store because the server is stateless when store is false.
+    underlyingSession: new MemorySession(),
+    // Auto mode chooses input compaction when store is false.
+    // Set a low threshold to observe compaction in action.
+    shouldTriggerCompaction: ({ compactionCandidateItems }) =>
+      compactionCandidateItems.length >= 4,
+  });
+
+  const agent = new Agent({
+    name: 'Assistant',
+    model: 'gpt-5.2',
+    instructions:
+      'Keep answers short. This example demonstrates responses.compact with input mode and store=false. For every user turn, call fetch_image_data with the provided label. Do not include raw image bytes or data URLs in your final answer.',
+    modelSettings: {
+      toolChoice: 'required',
+      // When you disable store, auto compaction mode is used.
+      store: false,
+    },
+    tools: [fetchImageData],
+  });
+
+  // To see compaction debug logs, run: DEBUG=openai-agents:openai:compaction pnpm -C examples/memory start:oai-compact-stateless.
+  await withTrace('memory:compactSession:stateless', async () => {
+    const prompts = [
+      'Call fetch_image_data with label "alpha". Then explain compaction in 1 sentence.',
+      'Call fetch_image_data with label "beta". Then add a fun fact about space in 1 sentence.',
+      'Call fetch_image_data with label "gamma". Then add a fun fact about oceans in 1 sentence.',
+      'Call fetch_image_data with label "delta". Then add a fun fact about volcanoes in 1 sentence.',
+      'Call fetch_image_data with label "epsilon". Then add a fun fact about deserts in 1 sentence.',
+    ];
+
+    for (const prompt of prompts) {
+      const result = await run(agent, prompt, { session });
+      console.log(`\nUser: ${prompt}`);
+      console.log(`Assistant: ${result.finalOutput}`);
+      console.log(
+        'Usage for the turn:',
+        result.state.usage.requestUsageEntries,
+      );
+    }
+
+    const compactedHistory = await session.getItems();
+    console.log('\nHistory including compaction and newer items:');
+    for (const item of compactedHistory) {
+      console.log(`- ${item.type}`);
+    }
+
+    // You can manually run compaction without a response id in input mode.
+    const compactionResult = await session.runCompaction({ force: true });
+    console.log('Manual compaction result:', compactionResult);
+
+    const finalHistory = await session.getItems();
+    console.log('\nStored history after final compaction:');
+    for (const item of finalHistory) {
+      console.log(`- ${item.type}`);
+    }
+  });
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/memory/package.json
+++ b/examples/memory/package.json
@@ -13,6 +13,7 @@
     "start:oai": "tsx oai.ts",
     "start:oai-hitl": "tsx oai-hitl.ts",
     "start:oai-compact": "tsx oai-compact.ts",
+    "start:oai-compact-stateless": "tsx oai-compact-stateless.ts",
     "start:file": "tsx file.ts",
     "start:file-hitl": "tsx file-hitl.ts",
     "start:prisma": "pnpm prisma db push --schema ./prisma/schema.prisma && pnpm prisma generate --schema ./prisma/schema.prisma && tsx prisma.ts"

--- a/packages/agents-core/src/memory/session.ts
+++ b/packages/agents-core/src/memory/session.ts
@@ -56,6 +56,18 @@ export type OpenAIResponsesCompactionArgs = {
    */
   responseId?: string | undefined;
   /**
+   * How the compaction request should provide conversation history.
+   *
+   * When omitted, implementations use their configured default.
+   */
+  compactionMode?: 'previous_response_id' | 'input' | 'auto';
+  /**
+   * Whether the last model response was stored on the server.
+   *
+   * When set to false, compaction should avoid `previous_response_id` unless explicitly overridden.
+   */
+  store?: boolean;
+  /**
    * When true, compaction should run regardless of any internal thresholds or hooks.
    */
   force?: boolean;

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1361,6 +1361,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       state._toolUseTracker,
       modelSettings,
     );
+    state._lastModelSettings = modelSettings;
 
     const systemInstructions = await state._currentAgent.getSystemPrompt(
       state._context,

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -10,7 +10,7 @@ import {
   RunHandoffCallItem,
   RunHandoffOutputItem,
 } from './items';
-import type { ModelResponse } from './model';
+import type { ModelResponse, ModelSettings } from './model';
 import { RunContext } from './runContext';
 import { getTurnInput } from './runner/items';
 import { AgentToolUseTracker } from './runner/toolUseTracker';
@@ -360,6 +360,10 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
    * Latest response identifier returned by the server for server-managed conversations.
    */
   public _previousResponseId: string | undefined;
+  /**
+   * Effective model settings used for the most recent model call.
+   */
+  public _lastModelSettings: ModelSettings | undefined;
   /**
    * Active tracing span for the current agent if tracing is enabled.
    */

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -577,9 +577,16 @@ async function runCompactionOnSession(
   if (!isOpenAIResponsesCompactionAwareSession(session)) {
     return;
   }
-  const compactionResult = await session.runCompaction(
-    typeof responseId === 'undefined' ? undefined : { responseId },
-  );
+  const store =
+    state._lastModelSettings?.store ?? state._currentAgent.modelSettings?.store;
+  const compactionArgs =
+    typeof responseId === 'undefined' && typeof store === 'undefined'
+      ? undefined
+      : {
+          ...(typeof responseId === 'undefined' ? {} : { responseId }),
+          ...(typeof store === 'undefined' ? {} : { store }),
+        };
+  const compactionResult = await session.runCompaction(compactionArgs);
   if (!compactionResult) {
     return;
   }

--- a/packages/agents-core/test/runner/sessionPersistence.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.test.ts
@@ -27,6 +27,7 @@ import { RunState } from '../../src/runState';
 import { resolveInterruptedTurn } from '../../src/runner/turnResolution';
 import type { ProcessedResponse } from '../../src/runner/types';
 import type {
+  OpenAIResponsesCompactionArgs,
   OpenAIResponsesCompactionResult,
   Session,
 } from '../../src/memory/session';
@@ -108,9 +109,9 @@ describe('saveStreamResultToSession', () => {
       this.items = [];
     }
 
-    async runCompaction(args?: {
-      responseId: string | undefined;
-    }): Promise<OpenAIResponsesCompactionResult | null> {
+    async runCompaction(
+      args?: OpenAIResponsesCompactionArgs,
+    ): Promise<OpenAIResponsesCompactionResult | null> {
       this.events.push(`runCompaction:${args?.responseId}`);
       return null;
     }
@@ -954,9 +955,9 @@ describe('saveToSession', () => {
         this.items = [];
       }
 
-      async runCompaction(args?: {
-        responseId: string | undefined;
-      }): Promise<OpenAIResponsesCompactionResult | null> {
+      async runCompaction(
+        args?: OpenAIResponsesCompactionArgs,
+      ): Promise<OpenAIResponsesCompactionResult | null> {
         this.events.push(`runCompaction:${args?.responseId}`);
         return null;
       }
@@ -1043,9 +1044,9 @@ describe('saveToSession', () => {
         this.items = [];
       }
 
-      async runCompaction(args?: {
-        responseId: string | undefined;
-      }): Promise<OpenAIResponsesCompactionResult | null> {
+      async runCompaction(
+        args?: OpenAIResponsesCompactionArgs,
+      ): Promise<OpenAIResponsesCompactionResult | null> {
         this.events.push(`runCompaction:${args?.responseId}`);
         return null;
       }

--- a/packages/agents-openai/src/index.ts
+++ b/packages/agents-openai/src/index.ts
@@ -25,6 +25,7 @@ export {
 } from './memory/openaiConversationsSession';
 export {
   OpenAIResponsesCompactionSession,
+  type OpenAIResponsesCompactionMode,
   type OpenAIResponsesCompactionSessionOptions,
   type OpenAIResponsesCompactionDecisionContext,
 } from './memory/openaiResponsesCompactionSession';


### PR DESCRIPTION
This pull request fixes OpenAI Responses compaction auto mode so it consistently uses input when store is false, including manual compaction calls, by remembering the last store setting and resolving mode accordingly. It updates session persistence to pass store settings to compaction, adds input-mode coverage tests, and introduces a stateless compaction example script for verification.

See also: https://github.com/openai/openai-agents-python/issues/2333