### PR TITLE
docs(sessions): add manual compaction guidance for streaming

### DIFF
--- a/docs/src/content/docs/guides/sessions.mdx
+++ b/docs/src/content/docs/guides/sessions.mdx
@@ -9,6 +9,7 @@ import manageHistory from '../../../../../examples/docs/sessions/manageHistory.t
 import customSession from '../../../../../examples/docs/sessions/customSession.ts?raw';
 import sessionInputCallback from '../../../../../examples/docs/sessions/sessionInputCallback.ts?raw';
 import responsesCompactionSession from '../../../../../examples/docs/sessions/responsesCompactionSession.ts?raw';
+import manualCompactionSession from '../../../../../examples/docs/sessions/responsesCompactionManualSession.ts?raw';
 
 Sessions give the Agents SDK a **persistent memory layer**. Provide any object that implements the `Session` interface to `Runner.run`, and the SDK handles the rest. When a session is present, the runner automatically:
 
@@ -116,6 +117,16 @@ When you resume from a previous `RunState`, the new turn is appended to the same
   lang="typescript"
   code={responsesCompactionSession}
   title="Decorate a session with OpenAIResponsesCompactionSession"
+/>
+
+### Manual compaction for low-latency streaming
+
+Compaction clears and rewrites the underlying session, so the SDK waits for it before resolving a streaming run. If compaction is heavy, `result.completed` can stay pending for a few seconds after the last output token. For low-latency streaming or faster turn-taking, disable auto-compaction and call `runCompaction` yourself between turns (or during idle time).
+
+<Code
+  lang="typescript"
+  code={manualCompactionSession}
+  title="Disable auto-compaction and compact between turns"
 />
 
 You can call `runCompaction({ force: true })` at any time to shrink history before archiving or handoff. Enable debug logs with `DEBUG=openai-agents:openai:compaction` to trace compaction decisions.

--- a/examples/docs/sessions/responsesCompactionManualSession.ts
+++ b/examples/docs/sessions/responsesCompactionManualSession.ts
@@ -1,0 +1,29 @@
+import {
+  Agent,
+  MemorySession,
+  OpenAIResponsesCompactionSession,
+  run,
+} from '@openai/agents';
+
+const agent = new Agent({
+  name: 'Support',
+  instructions: 'Answer briefly and keep track of prior context.',
+  model: 'gpt-5.2',
+});
+
+// Disable auto-compaction to avoid delaying stream completion.
+const session = new OpenAIResponsesCompactionSession({
+  underlyingSession: new MemorySession(),
+  shouldTriggerCompaction: () => false,
+});
+
+const result = await run(agent, 'Share the latest ticket update.', {
+  session,
+  stream: true,
+});
+
+// Wait for the streaming run to finish before compacting.
+await result.completed;
+
+// Choose force based on your own thresholds or heuristics, between turns or during idle time.
+await session.runCompaction({ force: true });


### PR DESCRIPTION
This pull request updates the Sessions guide to explain that auto-compaction can delay streaming completion and recommends manual compaction for low-latency use cases. It also adds a manual compaction example under examples/docs/sessions/ showing how to disable auto-compaction, await stream completion, and run compaction between turns or during idle time while choosing force based on your own heuristics.

see also: https://github.com/openai/openai-agents-python/pull/2344