### PR TITLE
fix(agents-core): prefer run tracing config when resuming run state

### DIFF
--- a/.changeset/trace-runstate-overrides.md
+++ b/.changeset/trace-runstate-overrides.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix(agents-core): prefer run tracing config when resuming run state


### PR DESCRIPTION
This pull request fixes trace config precedence when resuming from a serialized RunState, ensuring run-level tracing settings (traceId/workflowName/groupId/metadata/apiKey) override stored state values. It also rebases any existing span chain to the updated trace when needed and adds a regression test to confirm the precedence behavior. This is not a breaking change but a bug fix.