### PR TITLE
fix: prefer error handler output for agent tools (ref #896)

### DIFF
--- a/.changeset/agent-tool-error-handler-output.md
+++ b/.changeset/agent-tool-error-handler-output.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents': patch
+---
+
+fix: prefer error handler output for agent tools (ref #896)

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -323,6 +323,8 @@ export const SerializedRunState = z.object({
   trace: serializedTraceSchema.nullable(),
 });
 
+export type FinalOutputSource = 'error_handler' | 'turn_resolution';
+
 /**
  * Serializable snapshot of an agent's run, including context, usage and trace.
  * While this class has publicly writable properties (prefixed with `_`), they are not meant to be
@@ -430,6 +432,11 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
    * Next step computed for the agent to take.
    */
   public _currentStep: NextStep | undefined = undefined;
+  /**
+   * Indicates how the final output was produced for the current run.
+   * This value is not serialized.
+   */
+  public _finalOutputSource: FinalOutputSource | undefined;
   /**
    * Parsed model response after applying guardrails and tools.
    */

--- a/packages/agents-core/src/runner/errorHandlers.ts
+++ b/packages/agents-core/src/runner/errorHandlers.ts
@@ -161,6 +161,7 @@ export const tryHandleRunError = async <
     type: 'next_step_final_output',
     output: outputText,
   };
+  state._finalOutputSource = 'error_handler';
   await runOutputGuardrails(state, outputGuardrailDefs, outputText);
   state._currentTurnInProgress = false;
   emitAgentEnd(state._context, state._currentAgent, outputText);

--- a/packages/agents-core/src/runner/runLoop.ts
+++ b/packages/agents-core/src/runner/runLoop.ts
@@ -50,6 +50,10 @@ export function applyTurnResult<
     state.resetTurnPersistence();
   }
   state._currentStep = turnResult.nextStep;
+  state._finalOutputSource =
+    turnResult.nextStep.type === 'next_step_final_output'
+      ? 'turn_resolution'
+      : undefined;
 }
 
 export async function resumeInterruptedTurn<

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -389,7 +389,10 @@ describe('ConsoleSpanExporter', () => {
   it('logs traces and spans when tracing is enabled', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const originalEnv = process.env.NODE_ENV;
+    const originalDisableTracing = process.env.OPENAI_AGENTS_DISABLE_TRACING;
     process.env.NODE_ENV = 'production';
+    delete process.env.OPENAI_AGENTS_DISABLE_TRACING;
+    setTracingDisabled(false);
 
     const exporter = new ConsoleSpanExporter();
     const trace = new Trace({ name: 'trace', groupId: 'group_123' });
@@ -417,6 +420,12 @@ describe('ConsoleSpanExporter', () => {
 
     logSpy.mockRestore();
     process.env.NODE_ENV = originalEnv;
+    if (typeof originalDisableTracing === 'undefined') {
+      delete process.env.OPENAI_AGENTS_DISABLE_TRACING;
+    } else {
+      process.env.OPENAI_AGENTS_DISABLE_TRACING = originalDisableTracing;
+    }
+    setTracingDisabled(true);
   });
 });
 


### PR DESCRIPTION
This pull request resolves a regression bug introduced by https://github.com/openai/openai-agents-js/pull/896 The final release review pointed the following out, and this is a valid feedback:

>Agent tool output now favors finalOutput for non-text outputs
>Risk: MODERATE. Structured agent tools may emit JSON instead of the last raw response text, which could change downstream tool parsing for callers relying on previous stringified model output.
>Files: packages/agents-core/src/agent.ts

This pull request fixes `Agent.asTool()` output selection so runs completed via `maxTurns` error handlers return the handler's finalOutput, while normal runs still prefer the last raw response text for compatibility. It introduces a `finalOutputSource` marker in `RunState`, wires it in `runner/errorHandlers.ts` and `runner/runLoop.ts`, and updates `agent.ts` accordingly, plus adds a regression test.