### PR TITLE
test(agents-core): silence expected MCP server error logs

### DIFF
--- a/.changeset/silent-mcp-server-errors.md
+++ b/.changeset/silent-mcp-server-errors.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+test(agents-core): silence expected MCP server error logs in tests

--- a/packages/agents-core/test/mcpServers.test.ts
+++ b/packages/agents-core/test/mcpServers.test.ts
@@ -1,6 +1,23 @@
-import { describe, it, expect } from 'vitest';
-import { connectMcpServers } from '../src/mcpServers';
+import { describe, expect, it, vi } from 'vitest';
 import type { CallToolResultContent, MCPServer, MCPTool } from '../src/mcp';
+
+vi.mock('../src/logger', async () => {
+  const actual =
+    await vi.importActual<typeof import('../src/logger')>('../src/logger');
+  return {
+    ...actual,
+    getLogger: (namespace?: string) => {
+      const base = actual.getLogger(namespace);
+      return {
+        ...base,
+        error: () => {},
+        warn: () => {},
+      };
+    },
+  };
+});
+
+import { connectMcpServers } from '../src/mcpServers';
 
 class BaseTestServer implements MCPServer {
   public cacheToolsList = false;


### PR DESCRIPTION
This pull request updates the MCP server tests in `@openai/agents-core` to silence expected error/warn logs by mocking the logger. It keeps runtime behavior unchanged while reducing noisy test output.