### PR TITLE
feat: add MCP tool meta resolver support

### DIFF
--- a/.changeset/mcp-tool-meta-resolver.md
+++ b/.changeset/mcp-tool-meta-resolver.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+feat: add MCP tool meta resolver support

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -112,6 +112,8 @@ export {
   MCPToolFilterCallable,
   MCPToolFilterContext,
   MCPToolFilterStatic,
+  MCPToolMetaContext,
+  MCPToolMetaResolver,
   createMCPToolStaticFilter,
 } from './mcpUtil';
 export {

--- a/packages/agents-core/src/mcpUtil.ts
+++ b/packages/agents-core/src/mcpUtil.ts
@@ -13,6 +13,27 @@ export interface MCPToolFilterContext<TContext = UnknownContext> {
   serverName: string;
 }
 
+/** Context information available to MCP tool meta resolver functions. */
+export interface MCPToolMetaContext<TContext = UnknownContext> {
+  /** The current run context. */
+  runContext: RunContext<TContext>;
+  /** Name of the MCP server. */
+  serverName: string;
+  /** Name of the tool being invoked. */
+  toolName: string;
+  /** Parsed tool arguments. */
+  arguments: Record<string, unknown> | null;
+}
+
+/** A function that produces MCP request metadata (`_meta`) for tool calls. */
+export type MCPToolMetaResolver<TContext = UnknownContext> = (
+  context: MCPToolMetaContext<TContext>,
+) =>
+  | Promise<Record<string, unknown> | null | undefined>
+  | Record<string, unknown>
+  | null
+  | undefined;
+
 /** A function that determines whether a tool should be available. */
 export type MCPToolFilterCallable<TContext = UnknownContext> = (
   context: MCPToolFilterContext<TContext>,

--- a/packages/agents-core/src/shims/mcp-server/browser.ts
+++ b/packages/agents-core/src/shims/mcp-server/browser.ts
@@ -28,6 +28,7 @@ export class MCPServerStdio extends BaseMCPServerStdio {
   callTool(
     _toolName: string,
     _args: Record<string, unknown> | null,
+    _meta?: Record<string, unknown> | null,
   ): Promise<CallToolResultContent> {
     throw new Error('Method not implemented.');
   }
@@ -55,6 +56,7 @@ export class MCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
   callTool(
     _toolName: string,
     _args: Record<string, unknown> | null,
+    _meta?: Record<string, unknown> | null,
   ): Promise<CallToolResultContent> {
     throw new Error('Method not implemented.');
   }
@@ -84,6 +86,7 @@ export class MCPServerSSE extends BaseMCPServerSSE {
   callTool(
     _toolName: string,
     _args: Record<string, unknown> | null,
+    _meta?: Record<string, unknown> | null,
   ): Promise<CallToolResultContent> {
     throw new Error('Method not implemented.');
   }

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -161,6 +161,7 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
   async callTool(
     toolName: string,
     args: Record<string, unknown> | null,
+    meta?: Record<string, unknown> | null,
   ): Promise<CallToolResultContent> {
     const { CallToolResultSchema } =
       await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
@@ -173,11 +174,13 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
       this.clientSessionTimeoutSeconds,
       { timeout: this.timeout },
     );
+    const params = {
+      name: toolName,
+      arguments: args ?? {},
+      ...(meta != null ? { _meta: meta } : {}),
+    };
     const response = await this.session.callTool(
-      {
-        name: toolName,
-        arguments: args ?? {},
-      },
+      params,
       undefined,
       requestOptions,
     );
@@ -302,6 +305,7 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
   async callTool(
     toolName: string,
     args: Record<string, unknown> | null,
+    meta?: Record<string, unknown> | null,
   ): Promise<CallToolResultContent> {
     const { CallToolResultSchema } =
       await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
@@ -314,11 +318,13 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
       this.clientSessionTimeoutSeconds,
       { timeout: this.timeout },
     );
+    const params = {
+      name: toolName,
+      arguments: args ?? {},
+      ...(meta != null ? { _meta: meta } : {}),
+    };
     const response = await this.session.callTool(
-      {
-        name: toolName,
-        arguments: args ?? {},
-      },
+      params,
       undefined,
       requestOptions,
     );
@@ -452,6 +458,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
   async callTool(
     toolName: string,
     args: Record<string, unknown> | null,
+    meta?: Record<string, unknown> | null,
   ): Promise<CallToolResultContent> {
     const { CallToolResultSchema } =
       await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
@@ -464,11 +471,13 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
       this.clientSessionTimeoutSeconds,
       { timeout: this.timeout },
     );
+    const params = {
+      name: toolName,
+      arguments: args ?? {},
+      ...(meta != null ? { _meta: meta } : {}),
+    };
     const response = await this.session.callTool(
-      {
-        name: toolName,
-        arguments: args ?? {},
-      },
+      params,
       undefined,
       requestOptions,
     );

--- a/packages/agents-core/test/mcpCache.test.ts
+++ b/packages/agents-core/test/mcpCache.test.ts
@@ -28,6 +28,7 @@ class StubServer extends NodeMCPServerStdio {
   async callTool(
     _toolName: string,
     _args: Record<string, unknown> | null,
+    _meta?: Record<string, unknown> | null,
   ): Promise<CallToolResultContent> {
     return [];
   }
@@ -212,7 +213,11 @@ describe('MCP tools cache invalidation', () => {
         async listTools() {
           return tools as any;
         },
-        async callTool() {
+        async callTool(
+          _toolName: string,
+          _args: Record<string, unknown> | null,
+          _meta?: Record<string, unknown> | null,
+        ) {
           return [];
         },
         async invalidateToolsCache() {},
@@ -451,7 +456,11 @@ describe('MCP tools without tracing', () => {
           },
         ] as any;
       },
-      async callTool() {
+      async callTool(
+        _toolName: string,
+        _args: Record<string, unknown> | null,
+        _meta?: Record<string, unknown> | null,
+      ) {
         return [];
       },
       async invalidateToolsCache() {},

--- a/packages/agents-core/test/mcpServers.test.ts
+++ b/packages/agents-core/test/mcpServers.test.ts
@@ -44,6 +44,7 @@ class BaseTestServer implements MCPServer {
   async callTool(
     _toolName: string,
     _args: Record<string, unknown> | null,
+    _meta?: Record<string, unknown> | null,
   ): Promise<CallToolResultContent> {
     return [] as CallToolResultContent;
   }

--- a/packages/agents-core/test/mcpToolFilter.integration.test.ts
+++ b/packages/agents-core/test/mcpToolFilter.integration.test.ts
@@ -57,7 +57,11 @@ class StubFilesystemServer extends NodeMCPServerStdio {
   async listTools() {
     return this.tools;
   }
-  async callTool(name: string, args: any) {
+  async callTool(
+    name: string,
+    args: any,
+    _meta?: Record<string, unknown> | null,
+  ) {
     const blocked = (this.toolFilter as any)?.blockedToolNames ?? [];
     if (blocked.includes(name)) {
       return [

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -495,7 +495,11 @@ describe('deserialize helpers', () => {
       async listTools() {
         return [];
       },
-      async callTool() {
+      async callTool(
+        _toolName: string,
+        _args: Record<string, unknown> | null,
+        _meta?: Record<string, unknown> | null,
+      ) {
         return [];
       },
       async invalidateToolsCache() {},
@@ -558,7 +562,11 @@ describe('deserialize helpers', () => {
         listCalled = true;
         return [stubMcpTool];
       },
-      async callTool() {
+      async callTool(
+        _toolName: string,
+        _args: Record<string, unknown> | null,
+        _meta?: Record<string, unknown> | null,
+      ) {
         return [];
       },
       async invalidateToolsCache() {},

--- a/packages/agents-core/test/shims/mcp-server/node.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/node.test.ts
@@ -19,11 +19,13 @@ import { DEFAULT_REQUEST_TIMEOUT_MSEC } from '@modelcontextprotocol/sdk/shared/p
 let lastConnectOptions: any;
 let lastListToolsOptions: any;
 let lastCallToolOptions: any;
+let lastCallToolParams: any;
 
 beforeEach(() => {
   lastConnectOptions = undefined;
   lastListToolsOptions = undefined;
   lastCallToolOptions = undefined;
+  lastCallToolParams = undefined;
 });
 
 describe('NodeMCPServerStdio', () => {
@@ -93,6 +95,26 @@ describe('NodeMCPServerStdio', () => {
     await server.close();
   });
 
+  test('should pass _meta to tool calls', async () => {
+    const server = new NodeMCPServerStdio({
+      name: 'meta-test',
+      fullCommand: 'test',
+    });
+
+    await server.connect();
+    await server.callTool(
+      'mock-tool',
+      { foo: 'bar' },
+      {
+        request_id: 'req-123',
+      },
+    );
+
+    expect(lastCallToolParams?._meta).toEqual({ request_id: 'req-123' });
+
+    await server.close();
+  });
+
   afterAll(() => {
     vi.clearAllMocks();
   });
@@ -154,6 +176,7 @@ class MockClient {
     });
   }
   callTool(_params: any, _resultSchema?: any, options?: any): Promise<any> {
+    lastCallToolParams = _params;
     lastCallToolOptions = options;
     return Promise.resolve({
       content: [{ type: 'text', text: 'ok' }],


### PR DESCRIPTION
This pull request adds MCP tool meta resolver support so local MCP tool calls can attach request metadata (_meta) through the server shim path. It wires optional toolMetaResolver into MCP server interfaces, threads metadata through callTool, and updates node/browser shims plus MCP tool invocation logic, with tests covering meta propagation and resolver context.

see also: https://github.com/openai/openai-agents-python/pull/2375