### PR TITLE
fix: preserve zod descriptions in json schema output

### DIFF
--- a/.changeset/json-schema-description-merge.md
+++ b/.changeset/json-schema-description-merge.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: include zod descriptions in json schema output

--- a/packages/agents-core/src/types/helpers.ts
+++ b/packages/agents-core/src/types/helpers.ts
@@ -47,6 +47,7 @@ export type JsonObjectSchemaStrict<
   properties: Properties;
   required: (keyof Properties)[];
   additionalProperties: false;
+  description?: string;
 };
 
 export type JsonObjectSchemaNonStrict<
@@ -56,6 +57,7 @@ export type JsonObjectSchemaNonStrict<
   properties: Properties;
   required: (keyof Properties)[];
   additionalProperties: true;
+  description?: string;
 };
 
 export type JsonObjectSchema<

--- a/packages/agents-core/src/utils/tools.ts
+++ b/packages/agents-core/src/utils/tools.ts
@@ -7,6 +7,7 @@ import { AgentOutputType } from '../agent';
 import {
   zodJsonSchemaCompat,
   hasJsonSchemaObjectShape,
+  mergeJsonSchemaDescriptions,
 } from './zodJsonSchemaCompat';
 import type { ZodObjectLike } from './zodCompat';
 import { asZodType } from './zodCompat';
@@ -133,6 +134,13 @@ export function getSchemaAndParserFromInputType<T extends ToolInputParameters>(
     }
 
     if (hasJsonSchemaObjectShape(formattedFunction.parameters)) {
+      const fallbackSchema = buildJsonSchemaFromZod(inputType);
+      if (fallbackSchema) {
+        mergeJsonSchemaDescriptions(
+          formattedFunction.parameters as JsonObjectSchema<any>,
+          fallbackSchema,
+        );
+      }
       return {
         schema: formattedFunction.parameters as JsonObjectSchema<any>,
         parser: formattedFunction.$parseRaw,

--- a/packages/agents-core/test/utils/tools.test.ts
+++ b/packages/agents-core/test/utils/tools.test.ts
@@ -38,6 +38,23 @@ describe('utils/tools', () => {
     expect(res.parser('{"bar":2}')).toEqual({ bar: 2 });
   });
 
+  it('getSchemaAndParserFromInputType includes zod descriptions when available', () => {
+    const zodSchema = z
+      .object({
+        text: z.string().describe('Text to translate'),
+      })
+      .describe('Translation input');
+    const res = getSchemaAndParserFromInputType(zodSchema, 'tool');
+    expect(res.schema).toMatchObject({
+      description: 'Translation input',
+      properties: {
+        text: {
+          description: 'Text to translate',
+        },
+      },
+    });
+  });
+
   it('getSchemaAndParserFromInputType rejects invalid input', () => {
     expect(() => getSchemaAndParserFromInputType('bad' as any, 't')).toThrow(
       UserError,

--- a/packages/agents-core/test/utils/zodJsonSchemaCompat.test.ts
+++ b/packages/agents-core/test/utils/zodJsonSchemaCompat.test.ts
@@ -201,4 +201,21 @@ describe('utils/zodJsonSchemaCompat', () => {
     const jsonSchema = zodJsonSchemaCompat(schema);
     expect(jsonSchema?.properties.title).toEqual({ type: 'string' });
   });
+
+  it('includes descriptions from zod schemas when available', () => {
+    const schema = z
+      .object({
+        text: z.string().describe('Text to translate'),
+        target: z.string(),
+      })
+      .describe('Translation input');
+
+    const jsonSchema = zodJsonSchemaCompat(schema);
+    expect(jsonSchema?.description).toBe('Translation input');
+    expect(jsonSchema?.properties.text).toEqual({
+      type: 'string',
+      description: 'Text to translate',
+    });
+    expect(jsonSchema?.properties.target).toEqual({ type: 'string' });
+  });
 });


### PR DESCRIPTION
This pull request fixes JSON Schema generation to carry Zod description metadata through the compat layer and into tool schema outputs.