### PR TITLE
feat: add MCP server errorFunction support

### DIFF
--- a/.changeset/mcp-server-error-function.md
+++ b/.changeset/mcp-server-error-function.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+feat: add MCP server errorFunction support


### PR DESCRIPTION
This pull request adds the same error handler with https://github.com/openai/openai-agents-python/pull/2378

With this hook, developers can customize the output for failed MCP server tool calls.