### PR TITLE
fix: populate streamed chat completion choices in generation traces

### DIFF
--- a/.changeset/clean-rice-admire.md
+++ b/.changeset/clean-rice-admire.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: populate streamed chat completion choices in generation traces


### PR DESCRIPTION
This pull request adds the missing `choices` data in Chat Completions tracing when using `stream: true`.