### PR TITLE
docs(guides): add missing option coverage across runner, mcp, sessions, and extensions

### DIFF
--- a/docs/src/content/docs/extensions/ai-sdk.mdx
+++ b/docs/src/content/docs/extensions/ai-sdk.mdx
@@ -85,3 +85,14 @@ providerMetadata: {
 ```
 
 when using the AI SDK integration.
+
+## AI SDK UI stream helpers
+
+`@openai/agents-extensions/ai-sdk-ui` provides response helpers for wiring Agents SDK streams into AI SDK UI routes:
+
+- `createAiSdkTextStreamResponse(source, options?)` for plain text streaming responses.
+- `createAiSdkUiMessageStreamResponse(source, options?)` for `UIMessageChunk` streaming responses.
+
+Both helpers accept a `StreamedRunResult`, stream-like source, or compatible wrapper object and return a `Response` with streaming-friendly headers.
+
+For end-to-end usage, see the `examples/ai-sdk-ui` app in this repository.

--- a/docs/src/content/docs/guides/agents.mdx
+++ b/docs/src/content/docs/guides/agents.mdx
@@ -44,7 +44,7 @@ properties are shown below.
 | `modelSettings`                   | no       | Tuning parameters (temperature, top_p, etc.). If the properties you need aren’t at the top level, you can include them under `providerData`. |
 | `tools`                           | no       | Array of [`Tool`](/openai-agents-js/openai/agents/type-aliases/tool/) instances the model can call.                                          |
 | `mcpServers`                      | no       | MCP servers that provide tools to the agent. See the [MCP guide](/openai-agents-js/guides/mcp).                                              |
-| `resetToolChoice`                 | no       | Reset `tool_choice` to the default after a tool call (default: `true`) to prevent tool-use loops. See [Forcing tool use](#forcing-tool-use). |
+| `resetToolChoice`                 | no       | Reset `toolChoice` to the default after a tool call (default: `true`) to prevent tool-use loops. See [Forcing tool use](#forcing-tool-use).  |
 | `handoffOutputTypeWarningEnabled` | no       | Emit a warning when handoff output types differ (default: `true`).                                                                           |
 
 <Code lang="typescript" code={agentWithTools} title="Agent with tools" />
@@ -153,7 +153,7 @@ an entirely new `Agent` instance.
 ## Forcing tool use
 
 Supplying tools doesn’t guarantee the LLM will call one. You can **force** tool use with
-`modelSettings.tool_choice`:
+`modelSettings.toolChoice`:
 
 1. `'auto'` (default) – the LLM decides whether to use a tool.
 2. `'required'` – the LLM _must_ call a tool (it can choose which one).
@@ -164,7 +164,7 @@ Supplying tools doesn’t guarantee the LLM will call one. You can **force** too
 
 ### Preventing infinite loops
 
-After a tool call the SDK automatically resets `tool_choice` back to `'auto'`. This prevents
+After a tool call the SDK automatically resets `toolChoice` back to `'auto'`. This prevents
 the model from entering an infinite loop where it repeatedly tries to call the tool. You can
 override this behavior via the `resetToolChoice` flag or by configuring
 `toolUseBehavior`:

--- a/docs/src/content/docs/guides/mcp.mdx
+++ b/docs/src/content/docs/guides/mcp.mdx
@@ -98,20 +98,22 @@ When your Agent talks directly to a Streamable HTTP MCP server—local or remote
 
 Constructor options:
 
-| Option                        | Type                                           | Notes                                       |
-| ----------------------------- | ---------------------------------------------- | ------------------------------------------- |
-| `url`                         | `string`                                       | Streamable HTTP server URL.                 |
-| `name`                        | `string`                                       | Optional label for the server.              |
-| `cacheToolsList`              | `boolean`                                      | Cache tools list to reduce latency.         |
-| `clientSessionTimeoutSeconds` | `number`                                       | Timeout for MCP client sessions.            |
-| `toolFilter`                  | `MCPToolFilterCallable \| MCPToolFilterStatic` | Filter available tools.                     |
-| `timeout`                     | `number`                                       | Per-request timeout (milliseconds).         |
-| `logger`                      | `Logger`                                       | Custom logger.                              |
-| `authProvider`                | `OAuthClientProvider`                          | OAuth provider from the MCP TypeScript SDK. |
-| `requestInit`                 | `RequestInit`                                  | Fetch init options for requests.            |
-| `fetch`                       | `FetchLike`                                    | Custom fetch implementation.                |
-| `reconnectionOptions`         | `StreamableHTTPReconnectionOptions`            | Reconnection tuning options.                |
-| `sessionId`                   | `string`                                       | Explicit session id for MCP connections.    |
+| Option                        | Type                                           | Notes                                        |
+| ----------------------------- | ---------------------------------------------- | -------------------------------------------- |
+| `url`                         | `string`                                       | Streamable HTTP server URL.                  |
+| `name`                        | `string`                                       | Optional label for the server.               |
+| `cacheToolsList`              | `boolean`                                      | Cache tools list to reduce latency.          |
+| `clientSessionTimeoutSeconds` | `number`                                       | Timeout for MCP client sessions.             |
+| `toolFilter`                  | `MCPToolFilterCallable \| MCPToolFilterStatic` | Filter available tools.                      |
+| `toolMetaResolver`            | `MCPToolMetaResolver`                          | Inject per-call MCP `_meta` request fields.  |
+| `errorFunction`               | `MCPToolErrorFunction \| null`                 | Map MCP call failures to model-visible text. |
+| `timeout`                     | `number`                                       | Per-request timeout (milliseconds).          |
+| `logger`                      | `Logger`                                       | Custom logger.                               |
+| `authProvider`                | `OAuthClientProvider`                          | OAuth provider from the MCP TypeScript SDK.  |
+| `requestInit`                 | `RequestInit`                                  | Fetch init options for requests.             |
+| `fetch`                       | `FetchLike`                                    | Custom fetch implementation.                 |
+| `reconnectionOptions`         | `StreamableHTTPReconnectionOptions`            | Reconnection tuning options.                 |
+| `sessionId`                   | `string`                                       | Explicit session id for MCP connections.     |
 
 The constructor also accepts additional MCP TypeScript‑SDK options such as `authProvider`, `requestInit`, `fetch`, `reconnectionOptions`, and `sessionId`. See the [MCP TypeScript SDK repository](https://github.com/modelcontextprotocol/typescript-sdk) and its documents for details.
 
@@ -139,6 +141,8 @@ Constructor options:
 | `encoding`                    | `string`                                       | Encoding for stdio streams.                            |
 | `encodingErrorHandler`        | `'strict' \| 'ignore' \| 'replace'`            | Encoding error strategy.                               |
 | `toolFilter`                  | `MCPToolFilterCallable \| MCPToolFilterStatic` | Filter available tools.                                |
+| `toolMetaResolver`            | `MCPToolMetaResolver`                          | Inject per-call MCP `_meta` request fields.            |
+| `errorFunction`               | `MCPToolErrorFunction \| null`                 | Map MCP call failures to model-visible text.           |
 | `timeout`                     | `number`                                       | Per-request timeout (milliseconds).                    |
 | `logger`                      | `Logger`                                       | Custom logger.                                         |
 
@@ -160,6 +164,23 @@ Use cases:
 - **Retry failed servers**: call `mcpServers.reconnect()` (defaults to retrying failed servers only).
 
 If you want a strict “all or nothing” connection or different timeouts, use `connectMcpServers(servers, options)` and tune the options for your environment.
+
+`connectMcpServers` options:
+
+| Option               | Type             | Default | Notes                                                         |
+| -------------------- | ---------------- | ------- | ------------------------------------------------------------- |
+| `connectTimeoutMs`   | `number \| null` | `10000` | Timeout for each server `connect()`. Use `null` to disable.   |
+| `closeTimeoutMs`     | `number \| null` | `10000` | Timeout for each server `close()`. Use `null` to disable.     |
+| `dropFailed`         | `boolean`        | `true`  | Exclude failed servers from `active`.                         |
+| `strict`             | `boolean`        | `false` | Throw if any server fails to connect.                         |
+| `suppressAbortError` | `boolean`        | `true`  | Ignore abort-like errors while still tracking failed servers. |
+| `connectInParallel`  | `boolean`        | `false` | Connect all servers concurrently instead of sequentially.     |
+
+`mcpServers.reconnect(options)` supports:
+
+| Option       | Type      | Default | Notes                                                                  |
+| ------------ | --------- | ------- | ---------------------------------------------------------------------- |
+| `failedOnly` | `boolean` | `true`  | Retry only failed servers (`true`) or reconnect all servers (`false`). |
 
 ### Async disposal (optional)
 

--- a/docs/src/content/docs/guides/models.mdx
+++ b/docs/src/content/docs/guides/models.mdx
@@ -92,19 +92,22 @@ custom networking settings.
 
 `ModelSettings` mirrors the OpenAI parameters but is provider‑agnostic.
 
-| Field               | Type                                                            | Notes                                                                     |
-| ------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `temperature`       | `number`                                                        | Creativity vs. determinism.                                               |
-| `topP`              | `number`                                                        | Nucleus sampling.                                                         |
-| `frequencyPenalty`  | `number`                                                        | Penalise repeated tokens.                                                 |
-| `presencePenalty`   | `number`                                                        | Encourage new tokens.                                                     |
-| `toolChoice`        | `'auto' \| 'required' \| 'none' \| string`                      | See [forcing tool use](/openai-agents-js/guides/agents#forcing-tool-use). |
-| `parallelToolCalls` | `boolean`                                                       | Allow parallel function calls where supported.                            |
-| `truncation`        | `'auto' \| 'disabled'`                                          | Token truncation strategy.                                                |
-| `maxTokens`         | `number`                                                        | Maximum tokens in the response.                                           |
-| `store`             | `boolean`                                                       | Persist the response for retrieval / RAG workflows.                       |
-| `reasoning.effort`  | `'none' \| 'minimal' \| 'low' \| 'medium' \| 'high' \| 'xhigh'` | Reasoning effort for gpt-5.x models.                                      |
-| `text.verbosity`    | `'low' \| 'medium' \| 'high'`                                   | Text verbosity for gpt-5.x etc.                                           |
+| Field                  | Type                                                            | Notes                                                                     |
+| ---------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `temperature`          | `number`                                                        | Creativity vs. determinism.                                               |
+| `topP`                 | `number`                                                        | Nucleus sampling.                                                         |
+| `frequencyPenalty`     | `number`                                                        | Penalise repeated tokens.                                                 |
+| `presencePenalty`      | `number`                                                        | Encourage new tokens.                                                     |
+| `toolChoice`           | `'auto' \| 'required' \| 'none' \| string`                      | See [forcing tool use](/openai-agents-js/guides/agents#forcing-tool-use). |
+| `parallelToolCalls`    | `boolean`                                                       | Allow parallel function calls where supported.                            |
+| `truncation`           | `'auto' \| 'disabled'`                                          | Token truncation strategy.                                                |
+| `maxTokens`            | `number`                                                        | Maximum tokens in the response.                                           |
+| `store`                | `boolean`                                                       | Persist the response for retrieval / RAG workflows.                       |
+| `promptCacheRetention` | `'in-memory' \| '24h' \| null`                                  | Controls provider prompt-cache retention when supported.                  |
+| `reasoning.effort`     | `'none' \| 'minimal' \| 'low' \| 'medium' \| 'high' \| 'xhigh'` | Reasoning effort for gpt-5.x models.                                      |
+| `reasoning.summary`    | `'auto' \| 'concise' \| 'detailed'`                             | Controls how much reasoning summary the model returns.                    |
+| `text.verbosity`       | `'low' \| 'medium' \| 'high'`                                   | Text verbosity for gpt-5.x etc.                                           |
+| `providerData`         | `Record<string, any>`                                           | Provider-specific passthrough options forwarded to the underlying model.  |
 
 Attach settings at either level:
 

--- a/docs/src/content/docs/guides/running-agents.mdx
+++ b/docs/src/content/docs/guides/running-agents.mdx
@@ -65,7 +65,9 @@ The additional options are:
 | `session`              | –       | Session persistence implementation. See the [sessions guide](/openai-agents-js/guides/sessions).                                                     |
 | `sessionInputCallback` | –       | Custom merge logic for session history and new input; runs before the model call. See [sessions](/openai-agents-js/guides/sessions).                 |
 | `callModelInputFilter` | –       | Hook to edit the model input (items + optional instructions) just before calling the model. See [Call model input filter](#call-model-input-filter). |
+| `toolErrorFormatter`   | –       | Hook to customize tool approval rejection messages returned to the model. See [Tool error formatter](#tool-error-formatter).                         |
 | `tracing`              | –       | Per-run tracing configuration overrides (for example, export API key).                                                                               |
+| `errorHandlers`        | –       | Handlers for supported runtime errors (currently `maxTurns`). See [Error handlers](#error-handlers).                                                 |
 | `conversationId`       | –       | Reuse a server-side conversation (OpenAI Responses API + Conversations API only).                                                                    |
 | `previousResponseId`   | –       | Continue from the previous Responses API call without creating a conversation (OpenAI Responses API only).                                           |
 
@@ -93,6 +95,7 @@ If you are creating your own `Runner` instance, you can pass in a `RunConfig` ob
 | `tracing`                   | `TracingConfig`          | Per-run tracing overrides (for example, export API key).                                         |
 | `sessionInputCallback`      | `SessionInputCallback`   | Default history merge strategy for all runs on this runner.                                      |
 | `callModelInputFilter`      | `CallModelInputFilter`   | Global hook to edit model inputs before each model call.                                         |
+| `toolErrorFormatter`        | `ToolErrorFormatter`     | Global hook to customize tool approval rejection messages returned to the model.                 |
 
 ## Conversations / chat threads
 
@@ -137,6 +140,20 @@ If you want to start only with Responses API anyway, you can chain each request 
 Use `callModelInputFilter` to edit the model input _right before_ the model is called. This hook receives the current agent, context, and the combined input items (including session history when present). Return the updated `input` array and optional `instructions` to redact sensitive data, drop old messages, or inject additional system guidance.
 
 Set it per run in `runner.run(..., { callModelInputFilter })` or as a default in the `Runner` config (`callModelInputFilter` in `RunConfig`).
+
+## Tool error formatter
+
+Use `toolErrorFormatter` to customize approval-rejection messages that are sent back to the model when a tool call is rejected. This lets you return domain-specific wording (for example, compliance guidance) instead of the SDK default message.
+
+The formatter can be set per-run (`runner.run(..., { toolErrorFormatter })`) or globally in `RunConfig` (`toolErrorFormatter` in `new Runner(...)`).
+
+## Error handlers
+
+Use `errorHandlers` to convert supported runtime errors into a final output instead of throwing. Currently, only `maxTurns` is supported.
+
+- `errorHandlers.maxTurns` handles only max-turn errors.
+- `errorHandlers.default` is used as a fallback for supported kinds.
+- Handlers receive `{ error, context, runData }` and can return `{ finalOutput, includeInHistory? }`.
 
 ## Exceptions
 

--- a/docs/src/content/docs/guides/sessions.mdx
+++ b/docs/src/content/docs/guides/sessions.mdx
@@ -35,6 +35,17 @@ Use `OpenAIConversationsSession` to sync memory with the [Conversations API](htt
 
 Reusing the same session instance ensures the agent receives the full conversation history before every turn and automatically persists new items. Switching to a different `Session` implementation requires no other code changes.
 
+`OpenAIConversationsSession` constructor options:
+
+| Option           | Type     | Notes                                                          |
+| ---------------- | -------- | -------------------------------------------------------------- |
+| `conversationId` | `string` | Reuse an existing conversation instead of creating one lazily. |
+| `client`         | `OpenAI` | Pass a preconfigured OpenAI client.                            |
+| `apiKey`         | `string` | API key used when creating an internal OpenAI client.          |
+| `baseURL`        | `string` | Base URL for OpenAI-compatible endpoints.                      |
+| `organization`   | `string` | OpenAI organization ID for requests.                           |
+| `project`        | `string` | OpenAI project ID for requests.                                |
+
 ---
 
 ## How the runner uses sessions
@@ -118,6 +129,25 @@ When you resume from a previous `RunState`, the new turn is appended to the same
   code={responsesCompactionSession}
   title="Decorate a session with OpenAIResponsesCompactionSession"
 />
+
+`OpenAIResponsesCompactionSession` constructor options:
+
+| Option                    | Type                                          | Notes                                                                                                    |
+| ------------------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `client`                  | `OpenAI`                                      | OpenAI client used for `responses.compact`.                                                              |
+| `underlyingSession`       | `Session`                                     | Backing session store to clear/rewrite with compacted items (must not be `OpenAIConversationsSession`).  |
+| `model`                   | `OpenAI.ResponsesModel`                       | Model used for compaction requests.                                                                      |
+| `compactionMode`          | `'auto' \| 'previous_response_id' \| 'input'` | Controls whether compaction uses server response chaining or local input items.                          |
+| `shouldTriggerCompaction` | `(context) => boolean \| Promise<boolean>`    | Custom trigger hook based on `responseId`, `compactionMode`, candidate items, and current session items. |
+
+`runCompaction(args)` options:
+
+| Option           | Type                                          | Notes                                                             |
+| ---------------- | --------------------------------------------- | ----------------------------------------------------------------- |
+| `responseId`     | `string`                                      | Latest Responses API response id for `previous_response_id` mode. |
+| `compactionMode` | `'auto' \| 'previous_response_id' \| 'input'` | Optional per-call override of the configured mode.                |
+| `store`          | `boolean`                                     | Indicates whether the last run stored server state.               |
+| `force`          | `boolean`                                     | Bypass `shouldTriggerCompaction` and compact immediately.         |
 
 ### Manual compaction for low-latency streaming
 

--- a/docs/src/content/docs/guides/tools.mdx
+++ b/docs/src/content/docs/guides/tools.mdx
@@ -117,6 +117,12 @@ When you run an agent as a tool, Agents SDK creates a runner with the default se
 
 You can also set `needsApproval` and `isEnabled` on the agent tool via `asTool()` options to integrate with human‑in‑the‑loop flows and conditional tool availability.
 
+Advanced structured-input options for `agent.asTool()`:
+
+- `inputBuilder`: maps structured tool args to the nested agent input payload.
+- `includeInputSchema`: includes the input JSON schema in the nested run for stronger schema-aware behavior.
+- `resumeState`: controls context reconciliation strategy when resuming nested serialized `RunState`.
+
 ### Streaming events from agent tools
 
 Agent tools can stream all nested run events back to your app. Choose the hook style that fits how you construct the tool:
@@ -175,7 +181,7 @@ What to know:
 ## Tool use behavior
 
 Refer to the [Agents guide](/openai-agents-js/guides/agents#forcing-tool-use) for controlling when and how a model
-must use tools (`tool_choice`, `toolUseBehavior`, etc.).
+must use tools (`modelSettings.toolChoice`, `toolUseBehavior`, etc.).
 
 ---
 

--- a/docs/src/content/docs/guides/voice-agents/build.mdx
+++ b/docs/src/content/docs/guides/voice-agents/build.mdx
@@ -60,6 +60,7 @@ Additional `RealtimeSession` options you can set at construction time:
 | `traceMetadata`                               | `Record<string, any>`             | Custom metadata to attach to session traces.                                     |
 | `workflowName`                                | `string`                          | Friendly name for the trace workflow.                                            |
 | `automaticallyTriggerResponseForMcpToolCalls` | `boolean`                         | Auto-trigger a model response when an MCP tool call completes (default: `true`). |
+| `toolErrorFormatter`                          | `ToolErrorFormatter`              | Customize tool approval rejection messages returned to the model.                |
 
 ## Handoffs
 


### PR DESCRIPTION
This pull request updates document pages to cover missing options etc.