### PR TITLE
fix(agents-openai): omit named tool_choice when prompt supplies tools

### DIFF
--- a/.changeset/twenty-donuts-cheer.md
+++ b/.changeset/twenty-donuts-cheer.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: omit named tool_choice when prompt-managed tools are used without local tools.

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -1859,6 +1859,10 @@ export class OpenAIResponsesModel implements Model {
       tools.length > 0 ||
       request.toolsExplicitlyProvided === true ||
       !request.prompt;
+    const shouldOmitToolChoice =
+      Boolean(request.prompt) &&
+      !shouldSendTools &&
+      typeof toolChoice === 'object';
 
     const requestData = {
       ...(shouldSendModel ? { model: this.#model } : {}),
@@ -1877,7 +1881,9 @@ export class OpenAIResponsesModel implements Model {
       top_p: request.modelSettings.topP,
       truncation: request.modelSettings.truncation,
       max_output_tokens: request.modelSettings.maxTokens,
-      tool_choice: toolChoice as ToolChoiceOptions,
+      ...(!shouldOmitToolChoice
+        ? { tool_choice: toolChoice as ToolChoiceOptions }
+        : {}),
       parallel_tool_calls: parallelToolCalls,
       stream,
       text: responseFormat,


### PR DESCRIPTION
This pull request applies the same improvement with https://github.com/openai/openai-agents-python/pull/2464

It fixes prompt-managed tool flows in the OpenAI Responses model request builder. When a prompt is provided and no local tools payload is sent, named/object tool_choice values are now omitted so they do not conflict with prompt-managed tools, while literal values like none and required are still preserved.
