### PR TITLE
fix(tracing): propagate trace metadata to spans for processors

### DIFF
--- a/.changeset/few-schools-bathe.md
+++ b/.changeset/few-schools-bathe.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix(tracing): expose trace metadata on spans for processors

--- a/examples/ai-sdk/index.ts
+++ b/examples/ai-sdk/index.ts
@@ -1,4 +1,4 @@
-import { Agent, ModelSettings, run, tool } from '@openai/agents';
+import { Agent, ModelSettings, Runner, tool } from '@openai/agents';
 import { aisdk, AiSdkModel } from '@openai/agents-extensions';
 import { z } from 'zod';
 
@@ -38,7 +38,13 @@ export async function runAgents(
     modelSettings,
   });
 
-  const result = await run(
+  const runner = new Runner({
+    traceMetadata: {
+      userId: 'u_123',
+      chatType: 'support',
+    },
+  });
+  const result = await runner.run(
     agent,
     'Hello what is the weather in San Francisco and oakland?',
   );

--- a/packages/agents-core/src/runner/tracing.ts
+++ b/packages/agents-core/src/runner/tracing.ts
@@ -75,6 +75,9 @@ export function applyTraceOverrides(
   const tracingApiKeyOverride =
     overrides.tracingApiKey !== undefined &&
     overrides.tracingApiKey !== trace.tracingApiKey;
+  const traceMetadataOverride =
+    overrides.traceMetadata !== undefined &&
+    overrides.traceMetadata !== trace.metadata;
 
   if (overrides.traceId !== undefined) {
     trace.traceId = overrides.traceId;
@@ -92,7 +95,10 @@ export function applyTraceOverrides(
     trace.tracingApiKey = overrides.tracingApiKey;
   }
 
-  if (currentSpan && (traceIdOverride || tracingApiKeyOverride)) {
+  if (
+    currentSpan &&
+    (traceIdOverride || tracingApiKeyOverride || traceMetadataOverride)
+  ) {
     return { trace, currentSpan: rebaseSpanChain(currentSpan, trace) };
   }
 

--- a/packages/agents-core/src/tracing/provider.ts
+++ b/packages/agents-core/src/tracing/provider.ts
@@ -87,6 +87,7 @@ export class TraceProvider {
     let parentId;
     let traceId;
     let tracingApiKey: string | undefined;
+    let traceMetadata: Record<string, any> | undefined;
 
     if (!parent) {
       const currentTrace = getCurrentTrace();
@@ -111,6 +112,7 @@ export class TraceProvider {
 
       traceId = currentTrace.traceId;
       tracingApiKey = currentTrace.tracingApiKey;
+      traceMetadata = currentTrace.metadata;
       if (currentSpan) {
         logger.debug('Using parent span %s', currentSpan.spanId);
         parentId = currentSpan.spanId;
@@ -128,6 +130,7 @@ export class TraceProvider {
 
       traceId = parent.traceId;
       tracingApiKey = parent.tracingApiKey;
+      traceMetadata = parent.metadata;
     } else if (parent instanceof Span) {
       if (parent instanceof NoopSpan) {
         logger.debug('Parent span is no-op, returning NoopSpan');
@@ -137,6 +140,7 @@ export class TraceProvider {
       parentId = parent.spanId;
       traceId = parent.traceId;
       tracingApiKey = parent.tracingApiKey;
+      traceMetadata = parent.traceMetadata;
     }
 
     if (!traceId) {
@@ -155,6 +159,7 @@ export class TraceProvider {
         ...spanOptions,
         traceId,
         parentId,
+        traceMetadata: traceMetadata ?? spanOptions.traceMetadata,
         tracingApiKey: tracingApiKey ?? spanOptions.tracingApiKey,
       },
       this.#multiProcessor,

--- a/packages/agents-core/src/tracing/spans.ts
+++ b/packages/agents-core/src/tracing/spans.ts
@@ -127,6 +127,7 @@ export type SpanOptions<TData extends SpanData> = {
   spanId?: string;
   parentId?: string;
   data: TData;
+  traceMetadata?: Record<string, any>;
   startedAt?: string;
   endedAt?: string;
   error?: SpanError;
@@ -145,6 +146,7 @@ export class Span<TData extends SpanData> {
   #traceId: string;
   #spanId: string;
   #parentId: string | null;
+  #traceMetadata: Record<string, any> | undefined;
   #processor: TracingProcessor;
   #startedAt: string | null;
   #endedAt: string | null;
@@ -159,6 +161,7 @@ export class Span<TData extends SpanData> {
     this.#data = options.data;
     this.#processor = processor;
     this.#parentId = options.parentId ?? null;
+    this.#traceMetadata = options.traceMetadata;
     this.#error = options.error ?? null;
     this.#startedAt = options.startedAt ?? null;
     this.#endedAt = options.endedAt ?? null;
@@ -171,6 +174,10 @@ export class Span<TData extends SpanData> {
 
   get spanData() {
     return this.#data;
+  }
+
+  get traceMetadata() {
+    return this.#traceMetadata;
   }
 
   get spanId() {
@@ -236,6 +243,7 @@ export class Span<TData extends SpanData> {
         spanId: this.spanId,
         parentId: this.parentId ?? undefined,
         data: this.spanData,
+        traceMetadata: this.traceMetadata,
         startedAt: this.#startedAt ?? undefined,
         endedAt: this.#endedAt ?? undefined,
         error: this.#error ?? undefined,

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -699,6 +699,9 @@ describe('Runner.run', () => {
       expect(resumed.state._currentAgentSpan?.traceId).toBe(
         'override-trace-id',
       );
+      expect(resumed.state._currentAgentSpan?.traceMetadata).toEqual({
+        source: 'runner',
+      });
       expect(resumed.state._currentAgentSpan?.tracingApiKey).toBe(
         'override-key',
       );


### PR DESCRIPTION
This pull request fixes #954 trace metadata propagation so processors can reliably access trace-level metadata from child spans. It updates span creation and rebasing paths to carry traceMetadata, exposes span.traceMetadata for processor use, and adds regression tests that mirror a MetadataPropagatingProcessor pattern (onTraceStart map + lookup by span.traceId in onSpanEnd).