### PR TITLE
fix: normalize realtime turnDetection modelVersion to model_version

### DIFF
--- a/.changeset/green-squids-work.md
+++ b/.changeset/green-squids-work.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: normalize realtime turnDetection modelVersion to model_version

--- a/packages/agents-realtime/src/clientMessages.ts
+++ b/packages/agents-realtime/src/clientMessages.ts
@@ -81,6 +81,7 @@ export type RealtimeTurnDetectionConfigAsIs = {
   silence_duration_ms?: number;
   threshold?: number;
   idle_timeout_ms?: number;
+  model_version?: string;
 };
 
 // The Realtime API accepts snake_cased keys, so when using this, this SDK converts the keys to snake_case ones before passing it to the API.
@@ -93,6 +94,7 @@ export type RealtimeTurnDetectionConfigCamelCase = {
   silenceDurationMs?: number;
   threshold?: number;
   idleTimeoutMs?: number;
+  modelVersion?: string;
 };
 
 export type RealtimeTurnDetectionConfig = (

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -683,6 +683,8 @@ export abstract class OpenAIRealtimeBase
       threshold,
       idleTimeoutMs,
       idle_timeout_ms,
+      modelVersion,
+      model_version,
       ...rest
     } = c;
 
@@ -694,6 +696,7 @@ export abstract class OpenAIRealtimeBase
       prefix_padding_ms: prefixPaddingMs ?? prefix_padding_ms,
       silence_duration_ms: silenceDurationMs ?? silence_duration_ms,
       idle_timeout_ms: idleTimeoutMs ?? idle_timeout_ms,
+      model_version: modelVersion ?? model_version,
       threshold,
       ...rest,
     };

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -97,6 +97,7 @@ describe('OpenAIRealtimeBase helpers', () => {
             silenceDurationMs: 0,
             idleTimeoutMs: 0,
             threshold: 0,
+            modelVersion: 'default',
           },
         },
       },
@@ -110,6 +111,7 @@ describe('OpenAIRealtimeBase helpers', () => {
       silence_duration_ms: 0,
       idle_timeout_ms: 0,
       threshold: 0,
+      model_version: 'default',
     });
   });
 


### PR DESCRIPTION
This pull request enables developers to pass modelVersion for realtime apps in a consistent way with other properties. Both model_version and modelVersion work after this change.