### PR TITLE
chore(changesets): switch OpenAI package group from linked to fixed versioning

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,8 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
-  "linked": [
+  "fixed": [
     [
       "@openai/agents",
       "@openai/agents-core",
@@ -12,6 +11,7 @@
       "@openai/agents-extensions"
     ]
   ],
+  "linked": [],
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",


### PR DESCRIPTION
This pull request updates release configuration to prevent version skew across the OpenAI agents packages. Previously, a changeset that targeted only one package (for example `@openai/agents-realtime`) could leave `@openai/agents-core` unchanged, which does not match the repository’s desired versioning policy.

- Updated `.changeset/config.json` to move the existing 5-package group from `linked` to `fixed`.
- Kept the same package membership: `@openai/agents`, `@openai/agents-core`, `@openai/agents-openai`, `@openai/agents-realtime`, and `@openai/agents-extensions`.
- Set `linked` to an empty array so version alignment is controlled by `fixed`.

With this change, any release that bumps one package in this group will bump all five packages together to the same version. No untracked files are included.