### PR TITLE
fix: #582 prevent duplicate realtime session events after reconnect

### DIFF
--- a/.changeset/calm-bears-smile.md
+++ b/.changeset/calm-bears-smile.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: #582 prevent duplicate realtime session events after reconnect

--- a/packages/agents-realtime/src/realtimeSession.ts
+++ b/packages/agents-realtime/src/realtimeSession.ts
@@ -242,6 +242,7 @@ export class RealtimeSession<
   #lastSessionConfig: Partial<RealtimeSessionConfig> | null =
     cloneDefaultSessionConfig();
   #automaticallyTriggerResponseForMcpToolCalls: boolean = true;
+  #eventListenersAttached = false;
 
   constructor(
     public readonly initialAgent:
@@ -1006,7 +1007,10 @@ export class RealtimeSession<
     // makes sure the current agent is correctly set and loads the tools
     await this.#setCurrentAgent(this.initialAgent);
 
-    this.#setEventListeners();
+    if (!this.#eventListenersAttached) {
+      this.#setEventListeners();
+      this.#eventListenersAttached = true;
+    }
     await this.#transport.connect({
       apiKey: options.apiKey ?? this.options.apiKey,
       model: this.options.model,


### PR DESCRIPTION
This pull request fixes #582 duplicated `RealtimeSession` events after reconnecting by ensuring transport event listeners are attached only once per session instance. It also adds a regression test that reconnects the same session and verifies `history_updated` fires exactly once for a single `item_update` event. A patch changeset for `@openai/agents-realtime` is included.