### PR TITLE
fix: #551 preserve pre-tool assistant transcript in realtime agent_end events

### DIFF
--- a/.changeset/moody-pigs-shine.md
+++ b/.changeset/moody-pigs-shine.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: #551 preserve pre-tool assistant transcript in realtime agent_end events

--- a/packages/agents-realtime/src/realtimeSession.ts
+++ b/packages/agents-realtime/src/realtimeSession.ts
@@ -802,9 +802,27 @@ export class RealtimeSession<
       this.#currentAgent.emit('agent_start', this.#context, this.#currentAgent);
     });
     this.#transport.on('turn_done', (event) => {
-      const item = event.response.output[event.response.output.length - 1];
-      const textOutput = getLastTextFromAudioOutputMessage(item) ?? '';
-      const itemId = item?.id ?? '';
+      const outputItems = event.response.output ?? [];
+      let textOutput = '';
+      let itemId = '';
+
+      for (let idx = outputItems.length - 1; idx >= 0; idx--) {
+        const candidate = outputItems[idx];
+        const candidateText = getLastTextFromAudioOutputMessage(candidate);
+        if (typeof candidateText === 'string') {
+          textOutput = candidateText;
+          const candidateId = (candidate as { id?: unknown })?.id;
+          itemId = typeof candidateId === 'string' ? candidateId : '';
+          break;
+        }
+      }
+
+      if (!itemId && outputItems.length > 0) {
+        const lastItem = outputItems[outputItems.length - 1] as {
+          id?: unknown;
+        };
+        itemId = typeof lastItem?.id === 'string' ? lastItem.id : '';
+      }
       this.emit('agent_end', this.#context, this.#currentAgent, textOutput);
       this.#currentAgent.emit('agent_end', this.#context, textOutput);
 


### PR DESCRIPTION
This pull request resolves #551. It fixes a RealtimeSession bug where agent_end emitted an empty output when a turn ended with a function_call item after assistant speech. The turn_done handler now scans response outputs from the end and picks the latest assistant message text/transcript, then emits that value to session/agent agent_end hooks.