### PR TITLE
fix: #722 normalize data URL images for AI SDK providers

### DIFF
--- a/.changeset/witty-snails-fry.md
+++ b/.changeset/witty-snails-fry.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: #722 normalize data URL images for AI SDK providers

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -451,6 +451,32 @@ describe('itemsToLanguageV2Messages', () => {
     ]);
   });
 
+  test('converts user data URL images to raw base64 with specific mediaType', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'input_image', image: 'data:image/png;base64,aGVsbG8=' },
+        ],
+      } as any,
+    ];
+    const msgs = itemsToLanguageV2Messages(stubModel({}), items);
+    expect(msgs).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: 'aGVsbG8=',
+            mediaType: 'image/png',
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+    ]);
+  });
+
   test('converts structured tool output lists', () => {
     const items: protocol.ModelItem[] = [
       {
@@ -468,6 +494,10 @@ describe('itemsToLanguageV2Messages', () => {
           {
             type: 'input_image',
             image: 'https://example.com/image.png',
+          },
+          {
+            type: 'input_image',
+            image: 'data:image/png;base64,aGVsbG8=',
           },
         ],
       } as any,
@@ -503,6 +533,11 @@ describe('itemsToLanguageV2Messages', () => {
                   type: 'media',
                   data: 'https://example.com/image.png',
                   mediaType: 'image/*',
+                },
+                {
+                  type: 'media',
+                  data: 'aGVsbG8=',
+                  mediaType: 'image/png',
                 },
               ],
             },


### PR DESCRIPTION
This pull request resolves #722.  

This pull request fixes image data URL conversion in `packages/agents-extensions/src/ai-sdk/index.ts`, where data URLs were previously forwarded with the full `data:` payload and `image/*`, causing provider incompatibilities (notably Bedrock). It now parses base64 data URLs into raw base64 `data` plus concrete MIME `mediaType` and applies the same normalization in structured tool output conversion.
