### PR TITLE
fix: #479 avoid Bun browser startup crash when shim modules are temporarily unresolved

### DIFF
--- a/.changeset/tiny-gorillas-wave.md
+++ b/.changeset/tiny-gorillas-wave.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: #479 avoid Bun browser startup crash when shim modules are temporarily unresolved

--- a/packages/agents-core/src/config.ts
+++ b/packages/agents-core/src/config.ts
@@ -1,9 +1,25 @@
 // Use function instead of exporting the value to prevent
 // circular dependency resolution issues caused by other exports in '@openai/agents-core/_shims'
-import {
-  loadEnv as _loadEnv,
-  isBrowserEnvironment,
-} from '@openai/agents-core/_shims';
+import * as _shims from '@openai/agents-core/_shims';
+
+function fallbackIsBrowserEnvironment(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof document !== 'undefined' &&
+    typeof document.createElement === 'function'
+  );
+}
+
+function isBrowserEnvironment(): boolean {
+  try {
+    if (typeof _shims?.isBrowserEnvironment === 'function') {
+      return _shims.isBrowserEnvironment();
+    }
+  } catch {
+    // Fallback below.
+  }
+  return fallbackIsBrowserEnvironment();
+}
 
 /**
  * Loads environment variables from the process environment.
@@ -11,7 +27,12 @@ import {
  * @returns An object containing the environment variables.
  */
 export function loadEnv(): Record<string, string | undefined> {
-  return _loadEnv();
+  try {
+    const env = _shims?.loadEnv?.();
+    return typeof env === 'object' && env != null ? env : {};
+  } catch {
+    return {};
+  }
 }
 
 /**

--- a/packages/agents-core/src/logger.ts
+++ b/packages/agents-core/src/logger.ts
@@ -2,18 +2,6 @@ import debug from 'debug';
 import { logging } from './config';
 
 /**
- * By default we don't log LLM inputs/outputs, to prevent exposing sensitive data. Set this flag
- * to enable logging them.
- */
-const dontLogModelData = logging.dontLogModelData;
-
-/**
- * By default we don't log tool inputs/outputs, to prevent exposing sensitive data. Set this flag
- * to enable logging them.
- */
-const dontLogToolData = logging.dontLogToolData;
-
-/**
  * A logger instance with debug, error, warn, and dontLogModelData and dontLogToolData methods.
  */
 export type Logger = {
@@ -62,8 +50,12 @@ export function getLogger(namespace: string = 'openai-agents'): Logger {
     debug: debug(namespace),
     error: (...args: any[]) => console.error(...args),
     warn: (...args: any[]) => console.warn(...args),
-    dontLogModelData,
-    dontLogToolData,
+    get dontLogModelData() {
+      return logging.dontLogModelData;
+    },
+    get dontLogToolData() {
+      return logging.dontLogToolData;
+    },
   };
 }
 

--- a/packages/agents-core/test/logger.test.ts
+++ b/packages/agents-core/test/logger.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+describe('logger', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  test('does not evaluate logging flags at module initialization', async () => {
+    const configModule = await import('../src/config');
+    const modelDataSpy = vi.spyOn(
+      configModule.logging,
+      'dontLogModelData',
+      'get',
+    );
+    const toolDataSpy = vi.spyOn(
+      configModule.logging,
+      'dontLogToolData',
+      'get',
+    );
+
+    const loggerModule = await import('../src/logger');
+
+    expect(modelDataSpy).not.toHaveBeenCalled();
+    expect(toolDataSpy).not.toHaveBeenCalled();
+
+    const logger = loggerModule.getLogger('test');
+
+    expect(modelDataSpy).not.toHaveBeenCalled();
+    expect(toolDataSpy).not.toHaveBeenCalled();
+
+    void logger.dontLogModelData;
+    void logger.dontLogToolData;
+
+    expect(modelDataSpy).toHaveBeenCalledTimes(1);
+    expect(toolDataSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
This pull request fixes #479 a Bun browser startup crash where `@openai/agents-core` could throw `TypeError: Cannot read properties of null (reading 'loadEnv')` during module initialization. The fix makes `config.loadEnv` and browser-environment checks resilient when shim exports are temporarily unavailable, and updates `logger` so logging flags are evaluated lazily instead of at module load time. A regression test was added to ensure logger initialization does not eagerly evaluate logging flags. This change is a backwards-compatible runtime hardening update for `@openai/agents-core`.