### PR TITLE
fix: #579 use streamed chunk IDs in Chat Completions traces and output items

### DIFF
--- a/.changeset/odd-melons-jog.md
+++ b/.changeset/odd-melons-jog.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: #579 use streamed chunk IDs in Chat Completions traces and output items

--- a/packages/agents-openai/test/openaiChatCompletionsModel.scenario.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.scenario.test.ts
@@ -1,10 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { setTracingDisabled, withTrace } from '@openai/agents-core';
 import * as AgentsCore from '@openai/agents-core';
-import {
-  OpenAIChatCompletionsModel,
-  FAKE_ID,
-} from '../src/openaiChatCompletionsModel';
+import { OpenAIChatCompletionsModel } from '../src/openaiChatCompletionsModel';
 import { HEADERS } from '../src/defaults';
 
 type ChunkDelta = {
@@ -116,7 +113,7 @@ describe('OpenAIChatCompletionsModel streaming scenarios', () => {
         rawContent: [{ type: 'reasoning_text', text: 'Step 1 continued' }],
       },
       {
-        id: FAKE_ID,
+        id: 'res-stream',
         type: 'message',
         role: 'assistant',
         status: 'completed',
@@ -130,7 +127,7 @@ describe('OpenAIChatCompletionsModel streaming scenarios', () => {
         ],
       },
       {
-        id: FAKE_ID,
+        id: 'res-stream',
         type: 'function_call',
         name: 'lookup',
         callId: 'call-1',


### PR DESCRIPTION
This pull request resolves #579. It fixes Chat Completions streaming so trace/output item IDs use the real streamed completion ID instead of `FAKE_ID` when chunk IDs are available. The streaming converter now promotes the first observed chunk ID into `response.id`, reuses that ID for final `message` and `function_call` output items, and keeps `FAKE_ID` as a safe fallback for providers that omit chunk IDs. Tests were updated to assert real ID propagation and a new fallback test was added to prevent regressions.