### PR TITLE
fix: #116 respect toolChoice none overrides after tool lifecycle updates

### DIFF
--- a/.changeset/blue-poets-relax.md
+++ b/.changeset/blue-poets-relax.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: #116 respect toolChoice none overrides after tool lifecycle updates

--- a/packages/agents-core/src/runner/modelSettings.ts
+++ b/packages/agents-core/src/runner/modelSettings.ts
@@ -46,7 +46,11 @@ export function maybeResetToolChoice(
   toolUseTracker: AgentToolUseTracker,
   modelSettings: ModelSettings,
 ) {
-  if (agent.resetToolChoice && toolUseTracker.hasUsedTools(agent)) {
+  if (
+    agent.resetToolChoice &&
+    toolUseTracker.hasUsedTools(agent) &&
+    modelSettings.toolChoice !== 'none'
+  ) {
     return { ...modelSettings, toolChoice: undefined };
   }
   return modelSettings;

--- a/packages/agents-core/test/runner/modelSettings.test.ts
+++ b/packages/agents-core/test/runner/modelSettings.test.ts
@@ -39,6 +39,17 @@ describe('maybeResetToolChoice', () => {
     const result = maybeResetToolChoice(resetAgent, tracker, modelSettings);
     expect(result.toolChoice).toBe('auto');
   });
+
+  it('keeps explicit none tool choice after tool usage', () => {
+    const resetAgent = new Agent({ name: 'D', resetToolChoice: true });
+    tracker.addToolUse(resetAgent, ['some_tool']);
+
+    const result = maybeResetToolChoice(resetAgent, tracker, {
+      ...modelSettings,
+      toolChoice: 'none',
+    });
+    expect(result.toolChoice).toBe('none');
+  });
 });
 
 describe('adjustModelSettingsForNonGPT5RunnerModel', () => {


### PR DESCRIPTION
This pull request resolves #116. It fixes a bug where `agent_tool_end` lifecycle hooks could set `agent.modelSettings.toolChoice = 'none'`, but that value was cleared before the next model call when `resetToolChoice` was enabled.  
