### PR TITLE
fix: #257 normalize response message content metadata into providerData

### DIFF
--- a/.changeset/green-spoons-yell.md
+++ b/.changeset/green-spoons-yell.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: #257 normalize response message content metadata into providerData

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -1496,20 +1496,20 @@ function convertToMessageContentItem(
   item: OpenAI.Responses.ResponseOutputMessage['content'][number],
 ): protocol.AssistantContent {
   if (item.type === 'output_text') {
-    const { type, text, ...remainingItem } = item;
+    const { type, text, ...providerData } = item;
     return {
       type,
       text,
-      ...remainingItem,
+      ...(Object.keys(providerData).length > 0 ? { providerData } : {}),
     };
   }
 
   if (item.type === 'refusal') {
-    const { type, refusal, ...remainingItem } = item;
+    const { type, refusal, ...providerData } = item;
     return {
       type,
       refusal,
-      ...remainingItem,
+      ...(Object.keys(providerData).length > 0 ? { providerData } : {}),
     };
   }
 

--- a/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
@@ -1430,7 +1430,13 @@ describe('convertToOutputItem', () => {
         type: 'message',
         id: 'm',
         role: 'assistant',
-        content: [{ type: 'output_text', text: 'hi' }],
+        content: [
+          {
+            type: 'output_text',
+            text: 'hi',
+            annotations: [{ type: 'url_citation', url: 'https://example.com' }],
+          },
+        ],
         status: 'completed',
       },
       {
@@ -1458,6 +1464,13 @@ describe('convertToOutputItem', () => {
       name: 'web_search_call',
     });
     expect(out[3]).toMatchObject({ type: 'computer_call' });
+    expect((out[0] as any).content[0]).toEqual({
+      type: 'output_text',
+      text: 'hi',
+      providerData: {
+        annotations: [{ type: 'url_citation', url: 'https://example.com' }],
+      },
+    });
   });
 
   it('rejects unknown message content', () => {


### PR DESCRIPTION
This pull request fixes a typing/shape mismatch in OpenAI Responses message conversion where `output_text` metadata (such as `annotations`) was being emitted at the top level instead of under `providerData`, which could conflict with `AssistantMessageItem` expectations and provider-agnostic handling. This pull request resolves #257.