### PR TITLE
feat: #987 pass run context into applyPatch editor operations

### DIFF
--- a/.changeset/deep-lies-poke.md
+++ b/.changeset/deep-lies-poke.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+feat: #987 pass run context into applyPatch editor operations

--- a/packages/agents-core/src/editor.ts
+++ b/packages/agents-core/src/editor.ts
@@ -1,4 +1,5 @@
 import type { ApplyPatchOperation } from './types/protocol';
+import type { RunContext } from './runContext';
 export type { ApplyPatchOperation } from './types/protocol';
 
 /**
@@ -16,6 +17,16 @@ export type ApplyPatchResult = {
 };
 
 /**
+ * Runtime context passed to editor operations.
+ */
+export type EditorInvocationContext = {
+  /**
+   * Current run context.
+   */
+  runContext: RunContext;
+};
+
+/**
  * Host interface responsible for applying diffs on disk.
  */
 export interface Editor {
@@ -24,6 +35,7 @@ export interface Editor {
    */
   createFile(
     operation: Extract<ApplyPatchOperation, { type: 'create_file' }>,
+    context?: EditorInvocationContext,
   ): Promise<ApplyPatchResult | void>;
 
   /**
@@ -31,6 +43,7 @@ export interface Editor {
    */
   updateFile(
     operation: Extract<ApplyPatchOperation, { type: 'update_file' }>,
+    context?: EditorInvocationContext,
   ): Promise<ApplyPatchResult | void>;
 
   /**
@@ -38,5 +51,6 @@ export interface Editor {
    */
   deleteFile(
     operation: Extract<ApplyPatchOperation, { type: 'delete_file' }>,
+    context?: EditorInvocationContext,
   ): Promise<ApplyPatchResult | void>;
 }

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -15,7 +15,12 @@ export {
 } from './agent';
 export { Computer } from './computer';
 export { ShellAction, ShellResult, ShellOutputResult, Shell } from './shell';
-export { ApplyPatchOperation, ApplyPatchResult, Editor } from './editor';
+export {
+  ApplyPatchOperation,
+  ApplyPatchResult,
+  Editor,
+  EditorInvocationContext,
+} from './editor';
 export {
   AgentsError,
   GuardrailExecutionError,

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -866,6 +866,7 @@ export async function executeApplyPatchOperations(
   for (const action of actions) {
     const applyPatchTool = action.applyPatch;
     const toolCall = action.toolCall;
+    const editorContext = { runContext };
     const approvalItem = new RunToolApprovalItem(
       toolCall,
       agent,
@@ -927,16 +928,19 @@ export async function executeApplyPatchOperations(
             case 'create_file':
               result = await applyPatchTool.editor.createFile(
                 toolCall.operation,
+                editorContext,
               );
               break;
             case 'update_file':
               result = await applyPatchTool.editor.updateFile(
                 toolCall.operation,
+                editorContext,
               );
               break;
             case 'delete_file':
               result = await applyPatchTool.editor.deleteFile(
                 toolCall.operation,
+                editorContext,
               );
               break;
             default:

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -1503,6 +1503,33 @@ describe('executeShellActions', () => {
       expect(editor.operations).toHaveLength(1);
     });
 
+    it('passes RunContext to apply_patch editor operations', async () => {
+      const editor = new FakeEditor();
+      const applyPatch = applyPatchTool({ editor });
+      const agent = new Agent({ name: 'EditorAgent' });
+      const runContext = new RunContext({ run: 'ctx' });
+      const runner = new Runner({ tracingDisabled: true });
+      const toolCall: protocol.ApplyPatchCallItem = {
+        type: 'apply_patch_call',
+        callId: 'call_patch_context',
+        status: 'completed',
+        operation: {
+          type: 'delete_file',
+          path: 'README.md',
+        },
+      };
+
+      await executeApplyPatchOperations(
+        agent,
+        [{ toolCall, applyPatch } as any],
+        runner,
+        runContext,
+      );
+
+      expect(editor.contexts).toHaveLength(1);
+      expect(editor.contexts[0]?.runContext).toBe(runContext);
+    });
+
     it('emits a function span for apply_patch operations', async () => {
       const editor = new FakeEditor();
       const applyPatch = applyPatchTool({ editor });

--- a/packages/agents-core/test/stubs.ts
+++ b/packages/agents-core/test/stubs.ts
@@ -14,6 +14,7 @@ import type {
   Editor,
   ApplyPatchOperation,
   ApplyPatchResult,
+  EditorInvocationContext,
 } from '../src/editor';
 import * as protocol from '../src/types/protocol';
 import { Usage } from '../src/usage';
@@ -172,31 +173,37 @@ export class FakeShell implements Shell {
 
 export class FakeEditor implements Editor {
   public readonly operations: ApplyPatchOperation[] = [];
+  public readonly contexts: (EditorInvocationContext | undefined)[] = [];
   public result: ApplyPatchResult | void = { status: 'completed' };
   public errors: Partial<Record<ApplyPatchOperation['type'], Error>> = {};
 
   async createFile(
     operation: Extract<ApplyPatchOperation, { type: 'create_file' }>,
+    context?: EditorInvocationContext,
   ): Promise<ApplyPatchResult | void> {
-    return this.handle(operation);
+    return this.handle(operation, context);
   }
 
   async updateFile(
     operation: Extract<ApplyPatchOperation, { type: 'update_file' }>,
+    context?: EditorInvocationContext,
   ): Promise<ApplyPatchResult | void> {
-    return this.handle(operation);
+    return this.handle(operation, context);
   }
 
   async deleteFile(
     operation: Extract<ApplyPatchOperation, { type: 'delete_file' }>,
+    context?: EditorInvocationContext,
   ): Promise<ApplyPatchResult | void> {
-    return this.handle(operation);
+    return this.handle(operation, context);
   }
 
   private async handle(
     operation: ApplyPatchOperation,
+    context?: EditorInvocationContext,
   ): Promise<ApplyPatchResult | void> {
     this.operations.push(operation);
+    this.contexts.push(context);
     const error = this.errors[operation.type];
     if (error) {
       throw error;


### PR DESCRIPTION
This pull request fixes #987 a gap in `applyPatchTool` where `Editor` callbacks could not access the active run context, which prevented context-aware editor implementations. It adds an optional invocation context parameter (`{ runContext }`) to the `Editor` interface, wires that context through apply_patch execution, and exports `EditorInvocationContext` from `@openai/agents-core` for consumers. The update is backward compatible because existing editors that only accept the operation argument continue to work unchanged, and the tool execution tests now verify that the same `RunContext` instance is propagated into editor callbacks.