### PR TITLE
fix(agents-core): await parallel input guardrails before resolving turn in non-streaming run

### DIFF
--- a/.changeset/fix-parallel-guardrail-priority.md
+++ b/.changeset/fix-parallel-guardrail-priority.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+Fix parallel input guardrail tripwire being preempted by ModelBehaviorError when using structured output in non-streaming run

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -816,6 +816,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             );
 
             state._lastProcessedResponse = processedResponse;
+
+            await guardrailTracker.awaitCompletion();
+
             const turnResult = await resolveTurnAfterModelResponse<TContext>(
               state._currentAgent,
               state._originalInput,
@@ -834,8 +837,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               toolsUsed: state._lastProcessedResponse?.toolsUsed ?? [],
               resetTurnPersistence: !isResumedState,
             });
-
-            await guardrailTracker.awaitCompletion();
           }
 
           const currentStep = state._currentStep;


### PR DESCRIPTION
My setup includes a single non-streaming agent with 3 tools, 1 input guardrail with the `runInParallel: true` property, a structured output schema (Zod) with 3 fields, and the gpt-4.1 model.

For some inputs, I was encountering the following issue (sorry, I can't share the exact prompts or inputs):

```
{"context":"ExceptionsHandler","error":{"name":"ModelBehaviorError"},"level":"error","message":"Invalid output type: Unexpected token 'I', \"I'm really\"... is not valid JSON","stack":["ModelBehaviorError: Invalid output type: Unexpected token 'I', \"I'm really\"... is not valid JSON\n    at resolveTurnAfterModelResponse (/app/node_modules/@openai/agents-core/src/runner/turnResolution.ts:833:15)\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at async <anonymous> (/app/node_modules/@openai/agents-core/src/run.ts:819:32)\n    at async executeRun (/app/node_modules/@openai/agents-core/src/run.ts:523:25)\n    at async <anonymous> (/app/node_modules/@openai/agents-core/src/tracing/context.ts:115:22)\n    at async run (/app/node_modules/@openai/agents-core/src/run.ts:325:12)\n    at async AgentRunnerService.runAgent (/app/src/ai-engine/runners/agent-runner.service.ts:54:61)\n    at async AiEngineService.chat (/app/src/ai-engine/ai-engine.service.ts:65:20)\n    at async TestChatService.testChat (/app/src/ai-engine/testing/test-chat.service.ts:64:24)\n    at async /app/node_modules/@nestjs/core/router/router-execution-context.js:46:28"],"timestamp":"2026-02-18T12:19:01.724Z"}
```

I'm still not sure why this `ModelBehaviorError` is happening in the first place (why would the model produce a plain string when I passed a Zod schema with 3 fields?), but I was able to reproduce it with the test added in this PR.

Reordering `await guardrailTracker.awaitCompletion()` to run before `resolveTurnAfterModelResponse` fixed the issue.

Note: This issue does not reproduce in streaming mode, where `await guardrailTracker.awaitCompletion();` is called before resolving the turn rather than after.