### PR TITLE
fix(agents-core): rehydrate RunState interruption items on resume

### DIFF
--- a/.changeset/four-olives-grin.md
+++ b/.changeset/four-olives-grin.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: rehydrate RunState interruptions and type getInterruptions


### PR DESCRIPTION
This pull request fixes a runtime bug in resumed runs where `RunState.fromString()` left `next_step_interruption` items as plain JSON objects instead of `RunToolApprovalItem` instances. The bug caused post-resume behavior mismatches, including missing class getters (for example `.name`) and inconsistent interruption handling expectations.

The change explicitly types `getInterruptions()` as `RunToolApprovalItem[]` in `packages/agents-core/src/runState.ts`, and rehydrates interruption entries during deserialization so resumed state matches in-memory state. It supports both the current serialized item format and legacy raw interruption shapes.

The update also expands unit coverage in `packages/agents-core/test/runState.test.ts` for:
- function-tool interruption rehydration,
- hosted-tool interruption rehydration plus approval flow,
- legacy interruption payload compatibility.
