### PR TITLE
fix(agents-core): respect tracingDisabled for function tool calls

### DIFF
--- a/.changeset/fix-tracing-disabled-function-tools.md
+++ b/.changeset/fix-tracing-disabled-function-tools.md
@@ -1,0 +1,15 @@
+---
+'@openai/agents-core': patch
+---
+
+fix(agents-core): respect tracingDisabled for function tool calls
+
+`buildApprovalRejectionResult` and `runApprovedFunctionTool` called
+`withFunctionSpan()` directly, bypassing the `tracingDisabled` /
+`getCurrentTrace()` guard that the existing `withToolFunctionSpan` helper
+provides. This caused span creation even when `tracingDisabled: true` was
+set in `RunConfig`, and could trigger "No existing trace found" errors.
+
+Both functions now use `withToolFunctionSpan`, consistent with
+`executeShellActions`, `executeApplyPatchOperations`, and
+`executeComputerActions`.


### PR DESCRIPTION
## Summary

- `buildApprovalRejectionResult` and `runApprovedFunctionTool` in `toolExecution.ts` called `withFunctionSpan()` directly, bypassing the `tracingDisabled` / `getCurrentTrace()` guard that the existing `withToolFunctionSpan` helper provides
- This caused span creation even when `tracingDisabled: true` was set in `RunConfig`, and could trigger "No existing trace found" errors
- Both functions now use `withToolFunctionSpan` with optional chaining on `span`, consistent with `executeShellActions`, `executeApplyPatchOperations`, and `executeComputerActions`

## Test plan

- [x] `pnpm build` — 0 errors in both CJS and ESM outputs
- [x] `pnpm -r build-check` — type checking clean across all packages
- [x] `npx vitest run` — 1230/1230 tests pass
- [x] `pnpm lint` — clean