### PR TITLE
feat: add responses websocket transport and websocket session helper

### DIFF
--- a/.changeset/fair-timers-trade.md
+++ b/.changeset/fair-timers-trade.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents': patch
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+---
+
+feat: add responses websocket transport and scoped websocket session helper

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -19,6 +19,10 @@ Run them with `pnpm` using the commands shown below.
   ```bash
   pnpm -F basic start:stream-items
   ```
+- `stream-ws.ts` – Responses WebSocket streaming with tools, HITL approval, and `previousResponseId`.
+  ```bash
+  pnpm -F basic start:stream-ws
+  ```
 - `dynamic-system-prompt.ts` – Instructions picked dynamically per run.
   ```bash
   pnpm -F basic start:dynamic-system-prompt

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -23,6 +23,7 @@
     "start:remote-image": "tsx remote-image.ts",
     "start:remote-pdf": "tsx remote-pdf.ts",
     "start:stream-items": "tsx stream-items.ts",
+    "start:stream-ws": "tsx stream-ws.ts",
     "start:stream-text": "tsx stream-text.ts",
     "start:json-schema-output-type": "tsx json-schema-output-type.ts",
     "start:tool-use-behavior": "tsx tool-use-behavior.ts",

--- a/examples/basic/stream-ws.ts
+++ b/examples/basic/stream-ws.ts
@@ -1,0 +1,282 @@
+/**
+ * Responses WebSocket streaming example with function tools, agent-as-tool, and HITL approval.
+ *
+ * This example enables the OpenAI Responses WebSocket transport and demonstrates:
+ * - Streaming output (including reasoning summary deltas when available).
+ * - Regular function tools.
+ * - An `Agent.asTool(...)` specialist agent.
+ * - Human-in-the-loop approval for a sensitive tool call.
+ * - A follow-up turn using `previousResponseId`.
+ *
+ * Required environment variables:
+ * - `OPENAI_API_KEY`.
+ *
+ * Optional environment variables:
+ * - `OPENAI_MODEL` (defaults to `gpt-5.2-codex`).
+ * - `OPENAI_BASE_URL`.
+ * - `OPENAI_WEBSOCKET_BASE_URL`.
+ * - `EXAMPLES_INTERACTIVE_MODE=auto` (auto-approve HITL prompts for scripted runs).
+ * - `AUTO_APPROVE_HITL=1` (auto-approve HITL prompts).
+ */
+import readline from 'node:readline/promises';
+import { stdin, stdout } from 'node:process';
+import {
+  Agent,
+  Runner,
+  tool,
+  withResponsesWebSocketSession,
+  withTrace,
+} from '@openai/agents';
+import { z } from 'zod';
+
+type OrderRecord = {
+  order_id: string;
+  status: string;
+  delivered_days_ago: number;
+  amount: number;
+  currency: string;
+  item: string;
+};
+
+const AUTO_MODE = process.env.EXAMPLES_INTERACTIVE_MODE === 'auto';
+const AUTO_APPROVE_HITL = process.env.AUTO_APPROVE_HITL === '1';
+
+async function confirm(question: string): Promise<boolean> {
+  if (AUTO_MODE || AUTO_APPROVE_HITL) {
+    console.log(`[auto-approve] ${question}`);
+    return true;
+  }
+
+  const rl = readline.createInterface({ input: stdin, output: stdout });
+  const answer = await rl.question(`${question} (y/n): `);
+  rl.close();
+  return ['y', 'yes'].includes(answer.trim().toLowerCase());
+}
+
+const lookupOrderTool = tool({
+  name: 'lookup_order',
+  description: 'Return deterministic order data for the demo.',
+  parameters: z.object({
+    order_id: z.string(),
+  }),
+  execute: async ({ order_id }): Promise<OrderRecord> => {
+    const orders: Record<string, OrderRecord> = {
+      'ORD-1001': {
+        order_id: 'ORD-1001',
+        status: 'delivered',
+        delivered_days_ago: 3,
+        amount: 49.99,
+        currency: 'USD',
+        item: 'Wireless Mouse',
+      },
+      'ORD-2002': {
+        order_id: 'ORD-2002',
+        status: 'delivered',
+        delivered_days_ago: 12,
+        amount: 129.0,
+        currency: 'USD',
+        item: 'Keyboard',
+      },
+    };
+
+    return (
+      orders[order_id] ?? {
+        order_id,
+        status: 'unknown',
+        delivered_days_ago: 999,
+        amount: 0,
+        currency: 'USD',
+        item: 'unknown',
+      }
+    );
+  },
+});
+
+const submitRefundTool = tool({
+  name: 'submit_refund',
+  description: 'Create a refund request. This tool requires approval.',
+  needsApproval: true,
+  parameters: z.object({
+    order_id: z.string(),
+    amount: z.number(),
+    reason: z.string(),
+  }),
+  execute: async ({ order_id, amount, reason }) => {
+    const ticket =
+      order_id === 'ORD-1001' ? 'RF-1001' : `RF-${order_id.slice(-4)}`;
+    return {
+      refund_ticket: ticket,
+      order_id,
+      amount,
+      reason,
+      status: 'approved_pending_processing',
+    };
+  },
+});
+
+async function runStreamedTurn(
+  runner: Runner,
+  agent: Agent,
+  prompt: string,
+  previousResponseId?: string,
+): Promise<{ responseId: string; finalOutput: string }> {
+  console.log(`\nUser: ${prompt}\n`);
+
+  let streamedResult = await runner.run(agent, prompt, {
+    stream: true,
+    ...(previousResponseId ? { previousResponseId } : {}),
+  });
+
+  while (true) {
+    let printedReasoning = false;
+    let printedOutput = false;
+
+    for await (const event of streamedResult.toStream()) {
+      if (event.type === 'raw_model_stream_event') {
+        if (event.data.type !== 'model') {
+          continue;
+        }
+
+        const raw = event.data.event as { type?: string; delta?: string };
+        if (raw.type === 'response.reasoning_summary_text.delta') {
+          if (!printedReasoning) {
+            console.log('Reasoning:');
+            printedReasoning = true;
+          }
+          process.stdout.write(raw.delta ?? '');
+        } else if (raw.type === 'response.output_text.delta') {
+          if (printedReasoning && !printedOutput) {
+            process.stdout.write('\n\n');
+          }
+          if (!printedOutput) {
+            console.log('Assistant:');
+            printedOutput = true;
+          }
+          process.stdout.write(raw.delta ?? '');
+        }
+        continue;
+      }
+
+      if (event.type !== 'run_item_stream_event') {
+        continue;
+      }
+
+      if (event.item.type === 'tool_call_item') {
+        const rawItem = event.item.rawItem as {
+          name?: string;
+          arguments?: string;
+        };
+        console.log(
+          `\n[tool call] ${rawItem.name ?? 'unknown'}(${rawItem.arguments ?? ''})`,
+        );
+      } else if (event.item.type === 'tool_call_output_item') {
+        console.log(`[tool result] ${JSON.stringify(event.item.output)}`);
+      }
+    }
+
+    if (printedReasoning || printedOutput) {
+      process.stdout.write('\n');
+    }
+
+    if (!streamedResult.interruptions?.length) {
+      break;
+    }
+
+    console.log('\nHuman-in-the-loop: approval required for tool calls.');
+    const state = streamedResult.state;
+    for (const interruption of streamedResult.interruptions) {
+      const approved = await confirm(
+        `Approve ${interruption.name} with args ${interruption.arguments ?? '{}'}`,
+      );
+      if (approved) {
+        state.approve(interruption);
+      } else {
+        state.reject(interruption);
+      }
+    }
+
+    streamedResult = await runner.run(agent, state, { stream: true });
+  }
+
+  if (!streamedResult.lastResponseId) {
+    throw new Error('The streamed run completed without a responseId.');
+  }
+
+  const finalOutput = String(streamedResult.finalOutput ?? '');
+  console.log(`responseId: ${streamedResult.lastResponseId}`);
+  console.log(`finalOutput: ${finalOutput}\n`);
+
+  return {
+    responseId: streamedResult.lastResponseId,
+    finalOutput,
+  };
+}
+
+async function main() {
+  const model = process.env.OPENAI_MODEL ?? 'gpt-5.2-codex';
+
+  const policyAgent = new Agent({
+    name: 'RefundPolicySpecialist',
+    instructions:
+      'You are a refund policy specialist. Orders delivered within 7 days are eligible for a full refund. Older delivered orders are not. Return a short answer with eligibility and a one-line reason.',
+    model,
+    modelSettings: { maxTokens: 120 },
+  });
+
+  const supportAgent = new Agent({
+    name: 'SupportAgent',
+    instructions:
+      'You are a support agent. For refund requests: 1) call lookup_order, 2) call refund_policy_specialist, 3) if the user asked to proceed and the order is eligible, call submit_refund. When asked only for the refund ticket, return only the ticket token (for example RF-1001).',
+    model,
+    modelSettings: {
+      maxTokens: 240,
+      reasoning: { effort: 'medium', summary: 'detailed' },
+    },
+    tools: [
+      lookupOrderTool,
+      policyAgent.asTool({
+        toolName: 'refund_policy_specialist',
+        toolDescription:
+          'Check refund eligibility and explain the policy decision.',
+      }),
+      submitRefundTool,
+    ],
+  });
+
+  try {
+    await withResponsesWebSocketSession(async ({ runner }) => {
+      await withTrace('Responses WS support example', async () => {
+        console.log(`Using model=${model}`);
+
+        const firstTurn = await runStreamedTurn(
+          runner,
+          supportAgent,
+          'Customer wants a refund for order ORD-1001 because the mouse arrived damaged. Check the order, ask the refund policy specialist, and if it is eligible submit the refund. Reply with only the refund ticket.',
+        );
+
+        await runStreamedTurn(
+          runner,
+          supportAgent,
+          'What refund ticket did you just create? Reply with only the ticket.',
+          firstTurn.responseId,
+        );
+      });
+    });
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes('closed before any response events')
+    ) {
+      console.log(
+        '\nWebSocket mode closed before sending events. This usually means the feature is not enabled for this account or model yet.',
+      );
+      return;
+    }
+    throw error;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -46,6 +46,11 @@ import {
   resolveAgentToolInput,
   type StructuredToolInputBuilder,
 } from './agentToolInput';
+import {
+  getAgentToolParentRunConfigFromDetails,
+  getInheritedAgentToolRunConfig,
+  mergeAgentToolRunConfig,
+} from './agentToolRunConfig';
 import type { ZodObjectLike } from './utils/zodCompat';
 import { saveAgentToolRunResult } from './agentToolRunResults';
 import { registerAgentToolSourceAgent } from './agentToolSourceRegistry';
@@ -706,7 +711,15 @@ export class Agent<
         ) {
           throw new ModelBehaviorError('Agent tool called with invalid input');
         }
-        const runner = new Runner(runConfig ?? {});
+        const inheritedRunConfig = getInheritedAgentToolRunConfig(
+          getAgentToolParentRunConfigFromDetails(details),
+          runConfig,
+        );
+        const nestedRunConfig = mergeAgentToolRunConfig(
+          inheritedRunConfig,
+          runConfig,
+        );
+        const runner = new Runner(nestedRunConfig);
         const resumeContextStrategy = resumeState?.contextStrategy ?? 'merge';
         const resumeContext =
           resumeContextStrategy === 'preferSerialized' ? undefined : runContext;

--- a/packages/agents-core/src/agentToolRunConfig.ts
+++ b/packages/agents-core/src/agentToolRunConfig.ts
@@ -1,0 +1,322 @@
+import type { RunConfig } from './run';
+
+const TRANSPORT_OVERRIDE_PROVIDER_DATA_ALIAS_KEYS = [
+  ['extra_headers', 'extraHeaders'],
+  ['extra_query', 'extraQuery'],
+  ['extra_body', 'extraBody'],
+] as const;
+const NESTED_MODEL_SETTINGS_MERGE_KEYS = ['reasoning', 'text'] as const;
+const AGENT_TOOL_PARENT_RUN_CONFIG_SYMBOL = Symbol(
+  'openai.agents.agentToolParentRunConfig',
+);
+
+function isPlainObjectLike(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasOwn(value: object, key: PropertyKey): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+export function setAgentToolParentRunConfigOnDetails(
+  details: object,
+  parentRunConfig: Partial<RunConfig> | undefined,
+): void {
+  const safeParentRunConfig = getInheritedAgentToolRunConfig(
+    parentRunConfig,
+    undefined,
+  );
+  if (!safeParentRunConfig) {
+    return;
+  }
+
+  Object.defineProperty(details, AGENT_TOOL_PARENT_RUN_CONFIG_SYMBOL, {
+    value: safeParentRunConfig,
+    enumerable: false,
+    configurable: true,
+    writable: false,
+  });
+}
+
+export function getAgentToolParentRunConfigFromDetails(
+  details: unknown,
+): Partial<RunConfig> | undefined {
+  if (!details || typeof details !== 'object') {
+    return undefined;
+  }
+
+  const detailsRecord = details as Record<PropertyKey, unknown>;
+  const internalParentRunConfig =
+    detailsRecord[AGENT_TOOL_PARENT_RUN_CONFIG_SYMBOL];
+  if (typeof internalParentRunConfig !== 'undefined') {
+    return internalParentRunConfig as Partial<RunConfig>;
+  }
+
+  // Backward compatibility for direct/manual tool invocation tests and callers.
+  const legacyParentRunConfig = detailsRecord.parentRunConfig;
+  return isPlainObjectLike(legacyParentRunConfig)
+    ? (legacyParentRunConfig as Partial<RunConfig>)
+    : undefined;
+}
+
+function getSafeInheritedAgentToolModelSettings(
+  modelSettings: Partial<RunConfig>['modelSettings'],
+): Partial<RunConfig>['modelSettings'] | undefined {
+  if (!modelSettings) {
+    return undefined;
+  }
+
+  // Tool-selection settings are specific to the outer agent/tool set and can
+  // break nested Agent.asTool runs when inherited blindly.
+  const {
+    toolChoice: _toolChoice,
+    parallelToolCalls: _parallelToolCalls,
+    ...safeModelSettings
+  } = modelSettings;
+
+  return Object.keys(safeModelSettings).length > 0
+    ? safeModelSettings
+    : undefined;
+}
+
+function mergeNestedObjectMap(
+  targetRecord: Record<string, unknown>,
+  inheritedRecord: Record<string, unknown>,
+  overrideRecord: Record<string, unknown>,
+  key: string,
+): void {
+  if (
+    isPlainObjectLike(inheritedRecord[key]) &&
+    isPlainObjectLike(overrideRecord[key])
+  ) {
+    targetRecord[key] = {
+      ...inheritedRecord[key],
+      ...overrideRecord[key],
+    };
+  }
+}
+
+function getMergedProviderDataAliasMap(
+  providerData: Record<string, unknown>,
+  firstKey: string,
+  secondKey: string,
+): Record<string, unknown> | undefined {
+  const firstValue = providerData[firstKey];
+  const secondValue = providerData[secondKey];
+  const hasFirst = typeof firstValue !== 'undefined';
+  const hasSecond = typeof secondValue !== 'undefined';
+
+  if (!hasFirst && !hasSecond) {
+    return undefined;
+  }
+
+  if (
+    (hasFirst && !isPlainObjectLike(firstValue)) ||
+    (hasSecond && !isPlainObjectLike(secondValue))
+  ) {
+    return undefined;
+  }
+
+  return {
+    ...(hasFirst ? (firstValue as Record<string, unknown>) : {}),
+    ...(hasSecond ? (secondValue as Record<string, unknown>) : {}),
+  };
+}
+
+function mergeTransportOverrideAliasMaps(
+  targetProviderData: Record<string, unknown>,
+  inheritedProviderData: Record<string, unknown>,
+  toolProviderData: Record<string, unknown>,
+  snakeKey: string,
+  camelKey: string,
+): void {
+  const inheritedMerged = getMergedProviderDataAliasMap(
+    inheritedProviderData,
+    snakeKey,
+    camelKey,
+  );
+  const toolMerged = getMergedProviderDataAliasMap(
+    toolProviderData,
+    snakeKey,
+    camelKey,
+  );
+
+  if (!inheritedMerged || !toolMerged) {
+    return;
+  }
+
+  const mergedAliasMap = {
+    ...inheritedMerged,
+    ...toolMerged,
+  };
+
+  const aliasKeys = [snakeKey, camelKey] as const;
+  for (const aliasKey of aliasKeys) {
+    if (
+      hasOwn(inheritedProviderData, aliasKey) ||
+      hasOwn(toolProviderData, aliasKey)
+    ) {
+      targetProviderData[aliasKey] = mergedAliasMap;
+    }
+  }
+}
+
+function mergeAgentToolProviderData(
+  inheritedProviderData: Record<string, unknown>,
+  toolProviderData: Record<string, unknown>,
+): Record<string, unknown> {
+  const mergedProviderData: Record<string, unknown> = {
+    ...inheritedProviderData,
+    ...toolProviderData,
+  };
+
+  for (const [
+    snakeKey,
+    camelKey,
+  ] of TRANSPORT_OVERRIDE_PROVIDER_DATA_ALIAS_KEYS) {
+    mergeNestedObjectMap(
+      mergedProviderData,
+      inheritedProviderData,
+      toolProviderData,
+      snakeKey,
+    );
+    mergeNestedObjectMap(
+      mergedProviderData,
+      inheritedProviderData,
+      toolProviderData,
+      camelKey,
+    );
+  }
+
+  for (const [
+    snakeKey,
+    camelKey,
+  ] of TRANSPORT_OVERRIDE_PROVIDER_DATA_ALIAS_KEYS) {
+    mergeTransportOverrideAliasMaps(
+      mergedProviderData,
+      inheritedProviderData,
+      toolProviderData,
+      snakeKey,
+      camelKey,
+    );
+  }
+
+  return mergedProviderData;
+}
+
+function mergeAgentToolModelSettings(
+  inheritedRunConfig: Partial<RunConfig>,
+  toolRunConfigOverride: Partial<RunConfig>,
+): Partial<RunConfig>['modelSettings'] | undefined {
+  const inheritedModelSettings = inheritedRunConfig.modelSettings;
+  const toolModelSettings = toolRunConfigOverride.modelSettings;
+  const hasToolModelSettingsOverride = hasOwn(
+    toolRunConfigOverride,
+    'modelSettings',
+  );
+
+  if (
+    !inheritedModelSettings ||
+    !hasToolModelSettingsOverride ||
+    !toolModelSettings
+  ) {
+    return undefined;
+  }
+
+  const mergedModelSettings: Record<string, unknown> = {
+    ...inheritedModelSettings,
+    ...toolModelSettings,
+  };
+  const inheritedModelSettingsRecord = inheritedModelSettings as Record<
+    string,
+    unknown
+  >;
+  const toolModelSettingsRecord = toolModelSettings as Record<string, unknown>;
+
+  for (const key of NESTED_MODEL_SETTINGS_MERGE_KEYS) {
+    mergeNestedObjectMap(
+      mergedModelSettings,
+      inheritedModelSettingsRecord,
+      toolModelSettingsRecord,
+      key,
+    );
+  }
+
+  const inheritedProviderData = inheritedModelSettings.providerData;
+  const toolProviderData = toolModelSettings.providerData;
+  const hasToolProviderDataOverride = hasOwn(toolModelSettings, 'providerData');
+
+  if (
+    hasToolProviderDataOverride &&
+    isPlainObjectLike(inheritedProviderData) &&
+    isPlainObjectLike(toolProviderData)
+  ) {
+    mergedModelSettings.providerData = mergeAgentToolProviderData(
+      inheritedProviderData,
+      toolProviderData,
+    );
+  }
+
+  return mergedModelSettings as Partial<RunConfig>['modelSettings'];
+}
+
+export function getInheritedAgentToolRunConfig(
+  parentRunConfig: Partial<RunConfig> | undefined,
+  toolRunConfigOverride: Partial<RunConfig> | undefined,
+): Partial<RunConfig> | undefined {
+  if (!parentRunConfig) {
+    return undefined;
+  }
+
+  const inheritedRunConfig: Partial<RunConfig> = {};
+  const overridesModelProvider =
+    typeof toolRunConfigOverride?.modelProvider !== 'undefined';
+
+  if (typeof parentRunConfig.modelProvider !== 'undefined') {
+    inheritedRunConfig.modelProvider = parentRunConfig.modelProvider;
+  }
+  if (!overridesModelProvider && typeof parentRunConfig.model !== 'undefined') {
+    inheritedRunConfig.model = parentRunConfig.model;
+  }
+  if (
+    !overridesModelProvider &&
+    typeof parentRunConfig.modelSettings !== 'undefined'
+  ) {
+    const inheritedModelSettings = getSafeInheritedAgentToolModelSettings(
+      parentRunConfig.modelSettings,
+    );
+    if (typeof inheritedModelSettings !== 'undefined') {
+      inheritedRunConfig.modelSettings = inheritedModelSettings;
+    }
+  }
+
+  return Object.keys(inheritedRunConfig).length > 0
+    ? inheritedRunConfig
+    : undefined;
+}
+
+export function mergeAgentToolRunConfig(
+  inheritedRunConfig: Partial<RunConfig> | undefined,
+  toolRunConfigOverride: Partial<RunConfig> | undefined,
+): Partial<RunConfig> {
+  if (!inheritedRunConfig) {
+    return toolRunConfigOverride ?? {};
+  }
+  if (!toolRunConfigOverride) {
+    return inheritedRunConfig;
+  }
+
+  const mergedRunConfig: Partial<RunConfig> = {
+    ...inheritedRunConfig,
+    ...toolRunConfigOverride,
+  };
+  const mergedModelSettings = mergeAgentToolModelSettings(
+    inheritedRunConfig,
+    toolRunConfigOverride,
+  );
+  if (typeof mergedModelSettings !== 'undefined') {
+    mergedRunConfig.modelSettings = mergedModelSettings;
+  }
+
+  return mergedRunConfig;
+}

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -6,6 +6,7 @@ import type {
   ToolOutputText,
 } from '../types/protocol';
 import { Agent, AgentOutputType, ToolsToFinalOutputResult } from '../agent';
+import { setAgentToolParentRunConfigOnDetails } from '../agentToolRunConfig';
 import { consumeAgentToolRunResult } from '../agentToolRunResults';
 import { ToolCallError, ToolTimeoutError, UserError } from '../errors';
 import { getTransferMessage, HandoffInputData } from '../handoff';
@@ -378,11 +379,16 @@ async function runApprovedFunctionTool<TContext>(
           toolRun.tool.name,
           toolRun.toolCall.callId,
         );
+        const toolDetails = {
+          toolCall: toolRun.toolCall,
+          resumeState,
+        };
+        setAgentToolParentRunConfigOnDetails(toolDetails, runner.config);
         toolOutput = await invokeFunctionTool({
           tool: toolRun.tool,
           runContext: state._context,
           input: toolRun.toolCall.arguments,
-          details: { toolCall: toolRun.toolCall, resumeState },
+          details: toolDetails,
         });
         toolOutput = await runToolOutputGuardrails({
           guardrails: toolRun.tool.outputGuardrails,

--- a/packages/agents-openai/src/defaults.ts
+++ b/packages/agents-openai/src/defaults.ts
@@ -4,8 +4,10 @@ import METADATA from './metadata';
 
 export const DEFAULT_OPENAI_API = 'responses';
 export const DEFAULT_OPENAI_MODEL = 'gpt-4.1';
+export const DEFAULT_OPENAI_RESPONSES_TRANSPORT = 'http';
 
 let _defaultOpenAIAPI = DEFAULT_OPENAI_API;
+let _defaultOpenAIResponsesTransport = DEFAULT_OPENAI_RESPONSES_TRANSPORT;
 let _defaultOpenAIClient: OpenAI | undefined;
 let _defaultOpenAIKey: string | undefined = undefined;
 let _defaultTracingApiKey: string | undefined = undefined;
@@ -22,8 +24,16 @@ export function shouldUseResponsesByDefault() {
   return _defaultOpenAIAPI === 'responses';
 }
 
+export function shouldUseResponsesWebSocketByDefault() {
+  return _defaultOpenAIResponsesTransport === 'websocket';
+}
+
 export function setOpenAIAPI(value: 'chat_completions' | 'responses') {
   _defaultOpenAIAPI = value;
+}
+
+export function setOpenAIResponsesTransport(value: 'http' | 'websocket') {
+  _defaultOpenAIResponsesTransport = value;
 }
 
 export function setDefaultOpenAIClient(client: OpenAI) {
@@ -40,6 +50,10 @@ export function setDefaultOpenAIKey(key: string) {
 
 export function getDefaultOpenAIKey(): string | undefined {
   return _defaultOpenAIKey ?? loadEnv().OPENAI_API_KEY;
+}
+
+export function getDefaultOpenAIWebSocketBaseURL(): string | undefined {
+  return loadEnv().OPENAI_WEBSOCKET_BASE_URL;
 }
 
 export const HEADERS = {

--- a/packages/agents-openai/src/index.ts
+++ b/packages/agents-openai/src/index.ts
@@ -1,9 +1,18 @@
 export { OpenAIProvider } from './openaiProvider';
-export { OpenAIResponsesModel } from './openaiResponsesModel';
+export {
+  withResponsesWebSocketSession,
+  type ResponsesWebSocketSession,
+  type ResponsesWebSocketSessionOptions,
+} from './responsesWebSocketSession';
+export {
+  OpenAIResponsesModel,
+  OpenAIResponsesWSModel,
+} from './openaiResponsesModel';
 export { OpenAIChatCompletionsModel } from './openaiChatCompletionsModel';
 export {
   setDefaultOpenAIClient,
   setOpenAIAPI,
+  setOpenAIResponsesTransport,
   setDefaultOpenAIKey,
   setTracingExportApiKey,
 } from './defaults';

--- a/packages/agents-openai/src/responsesTransportUtils.ts
+++ b/packages/agents-openai/src/responsesTransportUtils.ts
@@ -1,0 +1,297 @@
+import { UserError } from '@openai/agents-core';
+
+export type ResponsesTransportOverrides = {
+  extraHeaders?: Record<string, unknown>;
+  extraQuery?: Record<string, unknown>;
+  extraBody?: Record<string, unknown>;
+};
+
+export type HeaderAccumulator = {
+  blockedLowercaseNames: Set<string>;
+  valuesByLowercaseName: Map<string, { key: string; value: string }>;
+};
+
+export type NullableHeadersLike = {
+  values: Headers;
+  nulls: Set<string>;
+};
+
+function isRecordLike(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isPlainTransportOverrideMapping(
+  value: unknown,
+): value is Record<string, unknown> {
+  if (!isRecordLike(value) || Array.isArray(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function normalizeTransportOverrideMapping(
+  value: unknown,
+  fieldName: string,
+): Record<string, unknown> | undefined {
+  if (typeof value === 'undefined') {
+    return undefined;
+  }
+
+  if (!isPlainTransportOverrideMapping(value)) {
+    throw new UserError(`Responses websocket ${fieldName} must be a mapping.`);
+  }
+
+  return { ...value };
+}
+
+export function splitResponsesTransportOverrides(providerData: unknown): {
+  providerData: Record<string, any>;
+  overrides: ResponsesTransportOverrides;
+} {
+  if (!isRecordLike(providerData) || Array.isArray(providerData)) {
+    return {
+      providerData: {},
+      overrides: {},
+    };
+  }
+
+  const {
+    extra_headers,
+    extraHeaders,
+    extra_query,
+    extraQuery,
+    extra_body,
+    extraBody,
+    ...remainingProviderData
+  } = providerData;
+
+  return {
+    providerData: { ...remainingProviderData },
+    overrides: {
+      extraHeaders: normalizeTransportOverrideMapping(
+        typeof extra_headers !== 'undefined' ? extra_headers : extraHeaders,
+        'extra headers',
+      ),
+      extraQuery: normalizeTransportOverrideMapping(
+        typeof extra_query !== 'undefined' ? extra_query : extraQuery,
+        'extra query',
+      ),
+      extraBody: normalizeTransportOverrideMapping(
+        typeof extra_body !== 'undefined' ? extra_body : extraBody,
+        'extra_body',
+      ),
+    },
+  };
+}
+
+type ParsedHeaderInput = {
+  entries: Array<[key: string, value: string]>;
+  unsetLowercaseNames: string[];
+};
+
+function parseHeaderInput(headers: unknown): ParsedHeaderInput {
+  const parsed: ParsedHeaderInput = {
+    entries: [],
+    unsetLowercaseNames: [],
+  };
+
+  if (!headers) {
+    return parsed;
+  }
+
+  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
+    headers.forEach((value, key) => {
+      parsed.entries.push([key, value]);
+    });
+    return parsed;
+  }
+
+  if (isRecordLike(headers) && typeof Headers !== 'undefined') {
+    const values = (headers as { values?: unknown }).values;
+    const nulls = (headers as { nulls?: unknown }).nulls;
+    if (values instanceof Headers) {
+      values.forEach((value, key) => {
+        parsed.entries.push([key, value]);
+      });
+      if (nulls instanceof Set) {
+        for (const maybeHeaderName of nulls) {
+          if (typeof maybeHeaderName === 'string') {
+            parsed.unsetLowercaseNames.push(maybeHeaderName.toLowerCase());
+          }
+        }
+      }
+      return parsed;
+    }
+  }
+
+  if (Array.isArray(headers)) {
+    for (const entry of headers) {
+      if (!Array.isArray(entry) || entry.length < 2) {
+        continue;
+      }
+      const [key, value] = entry;
+      if (typeof key === 'undefined' || value == null) {
+        continue;
+      }
+      parsed.entries.push([String(key), String(value)]);
+    }
+    return parsed;
+  }
+
+  if (!isRecordLike(headers)) {
+    return parsed;
+  }
+
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof value === 'undefined') {
+      continue;
+    }
+    if (value === null) {
+      parsed.unsetLowercaseNames.push(key.toLowerCase());
+      continue;
+    }
+    parsed.entries.push([key, String(value)]);
+  }
+
+  return parsed;
+}
+
+export function mergeHeadersIntoRecord(
+  target: Record<string, string>,
+  headers: unknown,
+): void {
+  const parsed = parseHeaderInput(headers);
+  for (const lowercaseName of parsed.unsetLowercaseNames) {
+    for (const existingKey of Object.keys(target)) {
+      if (existingKey.toLowerCase() === lowercaseName) {
+        delete target[existingKey];
+      }
+    }
+  }
+  for (const [key, value] of parsed.entries) {
+    target[key] = value;
+  }
+}
+
+export function createHeaderAccumulator(): HeaderAccumulator {
+  return {
+    blockedLowercaseNames: new Set<string>(),
+    valuesByLowercaseName: new Map<string, { key: string; value: string }>(),
+  };
+}
+
+export function applyHeadersToAccumulator(
+  accumulator: HeaderAccumulator,
+  headers: unknown,
+  options?: { allowBlockedOverride?: boolean },
+): void {
+  const allowBlockedOverride = options?.allowBlockedOverride ?? false;
+  const parsed = parseHeaderInput(headers);
+
+  for (const lowercaseName of parsed.unsetLowercaseNames) {
+    accumulator.valuesByLowercaseName.delete(lowercaseName);
+    accumulator.blockedLowercaseNames.add(lowercaseName);
+  }
+
+  for (const [key, value] of parsed.entries) {
+    const lowercaseKey = key.toLowerCase();
+    if (
+      accumulator.blockedLowercaseNames.has(lowercaseKey) &&
+      !allowBlockedOverride
+    ) {
+      continue;
+    }
+
+    accumulator.valuesByLowercaseName.set(lowercaseKey, { key, value });
+    if (allowBlockedOverride) {
+      accumulator.blockedLowercaseNames.delete(lowercaseKey);
+    }
+  }
+}
+
+export function headerAccumulatorToRecord(
+  accumulator: HeaderAccumulator,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const { key, value } of accumulator.valuesByLowercaseName.values()) {
+    headers[key] = value;
+  }
+  return headers;
+}
+
+export function headerAccumulatorToSDKHeaders(
+  accumulator: HeaderAccumulator,
+): Record<string, string | null> {
+  const headers: Record<string, string | null> =
+    headerAccumulatorToRecord(accumulator);
+  for (const lowercaseName of accumulator.blockedLowercaseNames) {
+    headers[lowercaseName] = null;
+  }
+  return headers;
+}
+
+function appendQueryParamValue(url: URL, key: string, rawValue: unknown): void {
+  if (typeof rawValue === 'undefined' || rawValue === null) {
+    return;
+  }
+
+  if (Array.isArray(rawValue)) {
+    for (const value of rawValue) {
+      appendQueryParamValue(url, `${key}[]`, value);
+    }
+    return;
+  }
+
+  if (isPlainTransportOverrideMapping(rawValue)) {
+    for (const [nestedKey, nestedValue] of Object.entries(rawValue)) {
+      appendQueryParamValue(url, `${key}[${nestedKey}]`, nestedValue);
+    }
+    return;
+  }
+
+  if (rawValue instanceof Date) {
+    url.searchParams.append(key, rawValue.toISOString());
+    return;
+  }
+
+  url.searchParams.append(key, String(rawValue));
+}
+
+export function mergeQueryParamsIntoURL(
+  url: URL,
+  query: Record<string, unknown> | undefined,
+): void {
+  if (!query) {
+    return;
+  }
+
+  for (const [key, rawValue] of Object.entries(query)) {
+    if (typeof rawValue === 'undefined') {
+      continue;
+    }
+
+    for (const existingKey of Array.from(url.searchParams.keys())) {
+      if (existingKey === key || existingKey.startsWith(`${key}[`)) {
+        url.searchParams.delete(existingKey);
+      }
+    }
+    if (rawValue === null) {
+      continue;
+    }
+
+    appendQueryParamValue(url, key, rawValue);
+  }
+}
+
+export function ensureResponsesWebSocketPath(pathname: string): string {
+  const normalizedPath = pathname.replace(/\/+$/, '');
+  if (
+    normalizedPath === '/responses' ||
+    normalizedPath.endsWith('/responses')
+  ) {
+    return normalizedPath;
+  }
+  return `${normalizedPath}/responses`;
+}

--- a/packages/agents-openai/src/responsesWebSocketConnection.ts
+++ b/packages/agents-openai/src/responsesWebSocketConnection.ts
@@ -1,0 +1,392 @@
+import { UserError } from '@openai/agents-core';
+import OpenAI from 'openai';
+
+export type WebSocketMessageValue =
+  | string
+  | Blob
+  | ArrayBuffer
+  | ArrayBufferView;
+
+export type ResponsesWebSocketInternalErrorCode =
+  | 'connection_closed_before_opening'
+  | 'connection_closed_before_terminal_response_event'
+  | 'socket_not_open';
+
+export class ResponsesWebSocketInternalError extends Error {
+  readonly code: ResponsesWebSocketInternalErrorCode;
+
+  constructor(code: ResponsesWebSocketInternalErrorCode, message: string) {
+    super(message);
+    this.name = 'ResponsesWebSocketInternalError';
+    this.code = code;
+  }
+}
+
+export function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw new OpenAI.APIUserAbortError();
+  }
+}
+
+export async function withAbortSignal<T>(
+  promise: Promise<T>,
+  signal: AbortSignal | undefined,
+): Promise<T> {
+  throwIfAborted(signal);
+  if (!signal) {
+    return promise;
+  }
+
+  return await new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      reject(new OpenAI.APIUserAbortError());
+    };
+
+    signal.addEventListener('abort', onAbort, { once: true });
+
+    promise.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number | undefined,
+  errorMessage: string,
+): Promise<T> {
+  if (
+    typeof timeoutMs !== 'number' ||
+    !Number.isFinite(timeoutMs) ||
+    timeoutMs <= 0
+  ) {
+    return await promise;
+  }
+
+  return await new Promise<T>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error(errorMessage));
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timeoutId);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeoutId);
+        reject(error);
+      },
+    );
+  });
+}
+
+export async function webSocketFrameToText(
+  frame: WebSocketMessageValue,
+): Promise<string> {
+  if (typeof frame === 'string') {
+    return frame;
+  }
+
+  if (typeof Blob !== 'undefined' && frame instanceof Blob) {
+    return await frame.text();
+  }
+
+  if (frame instanceof ArrayBuffer) {
+    return new TextDecoder().decode(new Uint8Array(frame));
+  }
+
+  if (ArrayBuffer.isView(frame)) {
+    return new TextDecoder().decode(
+      new Uint8Array(frame.buffer, frame.byteOffset, frame.byteLength),
+    );
+  }
+
+  throw new Error('Unsupported websocket frame type for Responses API.');
+}
+
+export function shouldWrapNoEventWebSocketError(error: unknown): boolean {
+  if (error instanceof ResponsesWebSocketInternalError) {
+    return (
+      error.code === 'connection_closed_before_opening' ||
+      error.code === 'connection_closed_before_terminal_response_event'
+    );
+  }
+
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return (
+    error.message === 'Responses websocket connection closed before opening.' ||
+    error.message ===
+      'Responses websocket connection closed before a terminal response event.'
+  );
+}
+
+export function isWebSocketNotOpenError(error: unknown): boolean {
+  if (error instanceof ResponsesWebSocketInternalError) {
+    return error.code === 'socket_not_open';
+  }
+
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  if (error.message === 'Responses websocket is not open.') {
+    return true;
+  }
+
+  // Native WebSocket implementations can throw InvalidStateError/DOMException
+  // if the socket closes after the readyState check but before send().
+  if (error.name === 'InvalidStateError') {
+    return true;
+  }
+
+  // `ws` throws a plain Error with this message shape for send races.
+  if (error.message.startsWith('WebSocket is not open: readyState ')) {
+    return true;
+  }
+
+  return false;
+}
+
+export class ResponsesWebSocketConnection {
+  #socket: WebSocket;
+  #messages: WebSocketMessageValue[] = [];
+  #waiters: Array<{
+    resolve: (value: WebSocketMessageValue | null) => void;
+    reject: (reason: unknown) => void;
+  }> = [];
+  #closed = false;
+  #error: Error | undefined;
+  #closedPromise: Promise<void>;
+  #resolveClosed!: () => void;
+
+  constructor(socket: WebSocket) {
+    this.#socket = socket;
+    this.#closedPromise = new Promise<void>((resolve) => {
+      this.#resolveClosed = resolve;
+    });
+
+    this.#socket.addEventListener('message', this.#onMessage as any);
+    this.#socket.addEventListener('error', this.#onError as any);
+    this.#socket.addEventListener('close', this.#onClose as any);
+  }
+
+  static async connect(
+    url: string,
+    headers: Record<string, string>,
+    signal: AbortSignal | undefined,
+    timeoutMs?: number,
+    timeoutErrorMessage?: string,
+  ): Promise<ResponsesWebSocketConnection> {
+    const WebSocketCtor = (globalThis as any).WebSocket as
+      | (new (url: string, init?: unknown) => WebSocket)
+      | undefined;
+
+    if (!WebSocketCtor) {
+      throw new UserError(
+        'Responses websocket transport requires a global WebSocket implementation.',
+      );
+    }
+
+    let socket: WebSocket;
+    try {
+      socket = new WebSocketCtor(url, { headers });
+    } catch (error) {
+      const wrappedError = new UserError(
+        'Responses websocket transport requires a WebSocket implementation that supports custom headers.',
+      );
+      (wrappedError as Error & { cause?: unknown }).cause = error;
+      throw wrappedError;
+    }
+
+    const connection = new ResponsesWebSocketConnection(socket);
+    try {
+      await connection.waitForOpen(signal, timeoutMs, timeoutErrorMessage);
+    } catch (error) {
+      await connection.close();
+      throw error;
+    }
+    return connection;
+  }
+
+  async waitForOpen(
+    signal: AbortSignal | undefined,
+    timeoutMs?: number,
+    timeoutErrorMessage?: string,
+  ): Promise<void> {
+    if (this.#socket.readyState === this.#socket.OPEN) {
+      return;
+    }
+    if (this.#error) {
+      throw this.#error;
+    }
+    if (
+      this.#closed ||
+      this.#socket.readyState === this.#socket.CLOSED ||
+      this.#socket.readyState === this.#socket.CLOSING
+    ) {
+      throw new ResponsesWebSocketInternalError(
+        'connection_closed_before_opening',
+        'Responses websocket connection closed before opening.',
+      );
+    }
+
+    const openPromise = new Promise<void>((resolve, reject) => {
+      const onOpen = () => {
+        cleanup();
+        resolve();
+      };
+
+      const onError = () => {
+        cleanup();
+        reject(
+          this.#error ??
+            new Error('Responses websocket connection failed to open.'),
+        );
+      };
+
+      const onClose = () => {
+        cleanup();
+        reject(
+          this.#error ??
+            new ResponsesWebSocketInternalError(
+              'connection_closed_before_opening',
+              'Responses websocket connection closed before opening.',
+            ),
+        );
+      };
+
+      const cleanup = () => {
+        this.#socket.removeEventListener('open', onOpen as any);
+        this.#socket.removeEventListener('error', onError as any);
+        this.#socket.removeEventListener('close', onClose as any);
+      };
+
+      this.#socket.addEventListener('open', onOpen as any);
+      this.#socket.addEventListener('error', onError as any);
+      this.#socket.addEventListener('close', onClose as any);
+    });
+
+    await withAbortSignal(
+      withTimeout(
+        openPromise,
+        timeoutMs,
+        timeoutErrorMessage ??
+          `Responses websocket connection timed out before opening after ${timeoutMs}ms.`,
+      ),
+      signal,
+    );
+  }
+
+  async send(data: string): Promise<void> {
+    if (this.#socket.readyState !== this.#socket.OPEN) {
+      throw new ResponsesWebSocketInternalError(
+        'socket_not_open',
+        'Responses websocket is not open.',
+      );
+    }
+
+    this.#socket.send(data);
+  }
+
+  isReusable(): boolean {
+    return (
+      !this.#closed &&
+      !this.#error &&
+      this.#socket.readyState === this.#socket.OPEN
+    );
+  }
+
+  async nextFrame(
+    signal: AbortSignal | undefined,
+  ): Promise<WebSocketMessageValue | null> {
+    throwIfAborted(signal);
+    return await withAbortSignal(this.#nextFrameInternal(), signal);
+  }
+
+  async close(): Promise<void> {
+    if (!this.#closed) {
+      try {
+        this.#socket.close();
+      } catch {
+        // Ignore close errors and wait for the socket to settle.
+      }
+    }
+
+    await this.#closedPromise;
+  }
+
+  async #nextFrameInternal(): Promise<WebSocketMessageValue | null> {
+    if (this.#messages.length > 0) {
+      return this.#messages.shift() ?? null;
+    }
+
+    if (this.#error) {
+      throw this.#error;
+    }
+
+    if (this.#closed) {
+      return null;
+    }
+
+    return await new Promise<WebSocketMessageValue | null>(
+      (resolve, reject) => {
+        this.#waiters.push({ resolve, reject });
+      },
+    );
+  }
+
+  #onMessage = (event: MessageEvent) => {
+    const data = event.data as WebSocketMessageValue;
+
+    const waiter = this.#waiters.shift();
+    if (waiter) {
+      waiter.resolve(data);
+      return;
+    }
+
+    this.#messages.push(data);
+  };
+
+  #onError = (event: any) => {
+    const maybeError = event?.error;
+    const maybeMessage = event?.message;
+    this.#error =
+      maybeError instanceof Error
+        ? maybeError
+        : new Error(
+            typeof maybeMessage === 'string' && maybeMessage.length > 0
+              ? maybeMessage
+              : 'Responses websocket connection error.',
+          );
+
+    const waiters = this.#waiters.splice(0);
+    for (const waiter of waiters) {
+      waiter.reject(this.#error);
+    }
+  };
+
+  #onClose = () => {
+    this.#closed = true;
+    this.#resolveClosed();
+
+    const waiters = this.#waiters.splice(0);
+    for (const waiter of waiters) {
+      if (this.#error) {
+        waiter.reject(this.#error);
+      } else {
+        waiter.resolve(null);
+      }
+    }
+  };
+}

--- a/packages/agents-openai/src/responsesWebSocketSession.ts
+++ b/packages/agents-openai/src/responsesWebSocketSession.ts
@@ -1,0 +1,86 @@
+import { Runner, type RunConfig } from '@openai/agents-core';
+import { OpenAIProvider, type OpenAIProviderOptions } from './openaiProvider';
+
+export type ResponsesWebSocketSessionOptions = {
+  /**
+   * Options used to construct the session-scoped OpenAI provider.
+   */
+  providerOptions?: OpenAIProviderOptions;
+  /**
+   * Runner configuration for the session. modelProvider is controlled by this helper.
+   */
+  runnerConfig?: Omit<Partial<RunConfig>, 'modelProvider'>;
+};
+
+export type ResponsesWebSocketSession = {
+  provider: OpenAIProvider;
+  runner: Runner;
+  run: Runner['run'];
+};
+
+function attachCleanupErrorToThrownError(
+  callbackError: unknown,
+  cleanupError: unknown,
+): void {
+  if (!(callbackError instanceof Error)) {
+    return;
+  }
+
+  const callbackErrorWithMetadata = callbackError as Error & {
+    cause?: unknown;
+    cleanupError?: unknown;
+  };
+
+  if (typeof callbackErrorWithMetadata.cause === 'undefined') {
+    callbackErrorWithMetadata.cause = cleanupError;
+    return;
+  }
+
+  callbackErrorWithMetadata.cleanupError = cleanupError;
+}
+
+/**
+ * Runs a callback within a session-scoped Responses API websocket provider/runner and closes the
+ * provider afterwards so websocket connections do not keep the process alive.
+ */
+export async function withResponsesWebSocketSession<T>(
+  callback: (session: ResponsesWebSocketSession) => Promise<T> | T,
+  options: ResponsesWebSocketSessionOptions = {},
+): Promise<T> {
+  const provider = new OpenAIProvider({
+    ...(options.providerOptions ?? {}),
+    useResponses: true,
+    useResponsesWebSocket: true,
+  });
+  const runner = new Runner({
+    ...(options.runnerConfig ?? {}),
+    modelProvider: provider,
+  });
+  const run = runner.run.bind(runner) as Runner['run'];
+
+  let callbackFailed = false;
+  let callbackError: unknown;
+  let callbackResult!: T;
+
+  try {
+    callbackResult = await callback({ provider, runner, run });
+  } catch (error) {
+    callbackFailed = true;
+    callbackError = error;
+  }
+
+  try {
+    await provider.close();
+  } catch (closeError) {
+    if (!callbackFailed) {
+      throw closeError;
+    }
+    attachCleanupErrorToThrownError(callbackError, closeError);
+  }
+
+  if (callbackFailed) {
+    throw callbackError;
+  }
+
+  return callbackResult;
+}

--- a/packages/agents-openai/test/defaults.test.ts
+++ b/packages/agents-openai/test/defaults.test.ts
@@ -4,7 +4,9 @@ import {
   setTracingExportApiKey,
   getTracingExportApiKey,
   shouldUseResponsesByDefault,
+  shouldUseResponsesWebSocketByDefault,
   setOpenAIAPI,
+  setOpenAIResponsesTransport,
   getDefaultOpenAIClient,
   setDefaultOpenAIClient,
   setDefaultOpenAIKey,
@@ -25,6 +27,12 @@ describe('Defaults', () => {
     expect(shouldUseResponsesByDefault()).toBe(true);
     setOpenAIAPI('chat_completions');
     expect(shouldUseResponsesByDefault()).toBe(false);
+  });
+  test('shouldUseResponsesWebSocketByDefault', async () => {
+    setOpenAIResponsesTransport('websocket');
+    expect(shouldUseResponsesWebSocketByDefault()).toBe(true);
+    setOpenAIResponsesTransport('http');
+    expect(shouldUseResponsesWebSocketByDefault()).toBe(false);
   });
   test('get/setDefaultOpenAIClient', async () => {
     const client = new OpenAI({ apiKey: 'foo' });

--- a/packages/agents-openai/test/openaiProvider.test.ts
+++ b/packages/agents-openai/test/openaiProvider.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { OpenAIProvider } from '../src/openaiProvider';
-import { OpenAIResponsesModel } from '../src/openaiResponsesModel';
+import {
+  OpenAIResponsesModel,
+  OpenAIResponsesWSModel,
+} from '../src/openaiResponsesModel';
 import { OpenAIChatCompletionsModel } from '../src/openaiChatCompletionsModel';
+import * as defaultsModule from '../src/defaults';
 import {
   setDefaultOpenAIClient,
   setDefaultOpenAIKey,
   setOpenAIAPI,
+  setOpenAIResponsesTransport,
 } from '../src/defaults';
 
 const OpenAIMock = vi.hoisted(() =>
@@ -26,6 +31,7 @@ class FakeClient {}
 describe('OpenAIProvider', () => {
   afterEach(() => {
     setOpenAIAPI('responses');
+    setOpenAIResponsesTransport('http');
     setDefaultOpenAIClient(undefined as any);
     setDefaultOpenAIKey(undefined as any);
     OpenAIMock.mockClear();
@@ -43,6 +49,16 @@ describe('OpenAIProvider', () => {
     ).toThrow();
   });
 
+  it('throws when websocketBaseURL and openAIClient are provided', () => {
+    expect(
+      () =>
+        new OpenAIProvider({
+          websocketBaseURL: 'wss://proxy.example.test/v1',
+          openAIClient: {} as any,
+        }),
+    ).toThrow();
+  });
+
   it('returns responses model when useResponses true', async () => {
     const provider = new OpenAIProvider({
       openAIClient: new FakeClient() as any,
@@ -50,6 +66,73 @@ describe('OpenAIProvider', () => {
     });
     const model = await provider.getModel('m');
     expect(model).toBeInstanceOf(OpenAIResponsesModel);
+  });
+
+  it('returns websocket responses model when useResponsesWebSocket is enabled', async () => {
+    const provider = new OpenAIProvider({
+      openAIClient: new FakeClient() as any,
+      useResponses: true,
+      useResponsesWebSocket: true,
+    });
+    const model = await provider.getModel('m');
+    expect(model).toBeInstanceOf(OpenAIResponsesWSModel);
+  });
+
+  it('does not use env websocket base URL fallback for a custom OpenAI client', async () => {
+    const getDefaultWebSocketBaseURLSpy = vi
+      .spyOn(defaultsModule, 'getDefaultOpenAIWebSocketBaseURL')
+      .mockReturnValue('wss://env-proxy.example.test/v1');
+    const customClient = {
+      baseURL: 'https://custom-openai.example/v1',
+      responses: { create: vi.fn(), compact: vi.fn() },
+      chat: { completions: { create: vi.fn() } },
+    } as any;
+    const provider = new OpenAIProvider({
+      openAIClient: customClient,
+      useResponses: true,
+      useResponsesWebSocket: true,
+    });
+
+    const model = await provider.getModel('m');
+
+    expect(model).toBeInstanceOf(OpenAIResponsesWSModel);
+    expect(getDefaultWebSocketBaseURLSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not use env websocket base URL fallback when provider baseURL is explicit', async () => {
+    const getDefaultWebSocketBaseURLSpy = vi
+      .spyOn(defaultsModule, 'getDefaultOpenAIWebSocketBaseURL')
+      .mockReturnValue('wss://env-proxy.example.test/v1');
+    const provider = new OpenAIProvider({
+      baseURL: 'https://proxy.example.test/v1',
+      useResponses: true,
+      useResponsesWebSocket: true,
+    });
+
+    const model = await provider.getModel('m');
+
+    expect(model).toBeInstanceOf(OpenAIResponsesWSModel);
+    expect(getDefaultWebSocketBaseURLSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not use env websocket base URL fallback when using a default injected client', async () => {
+    const getDefaultWebSocketBaseURLSpy = vi
+      .spyOn(defaultsModule, 'getDefaultOpenAIWebSocketBaseURL')
+      .mockReturnValue('wss://env-proxy.example.test/v1');
+    setDefaultOpenAIClient({
+      baseURL: 'https://default-client.example/v1',
+      responses: { create: vi.fn(), compact: vi.fn() },
+      chat: { completions: { create: vi.fn() } },
+    } as any);
+    const provider = new OpenAIProvider({
+      useResponses: true,
+      useResponsesWebSocket: true,
+    });
+
+    const model = await provider.getModel('m');
+
+    expect(model).toBeInstanceOf(OpenAIResponsesWSModel);
+    expect(getDefaultWebSocketBaseURLSpy).not.toHaveBeenCalled();
   });
 
   it('uses default API when useResponses not set', async () => {
@@ -66,6 +149,17 @@ describe('OpenAIProvider', () => {
     );
   });
 
+  it('uses default responses transport when useResponsesWebSocket is not set', async () => {
+    setOpenAIAPI('responses');
+    setOpenAIResponsesTransport('websocket');
+
+    const provider = new OpenAIProvider({
+      openAIClient: new FakeClient() as any,
+    });
+
+    expect(await provider.getModel('m')).toBeInstanceOf(OpenAIResponsesWSModel);
+  });
+
   it('reuses a default client when opting out of the responses API', async () => {
     const defaultClient = { client: true } as any;
     setDefaultOpenAIClient(defaultClient);
@@ -75,6 +169,72 @@ describe('OpenAIProvider', () => {
 
     expect(model).toBeInstanceOf(OpenAIChatCompletionsModel);
     expect(OpenAIMock).not.toHaveBeenCalled();
+  });
+
+  it('caches model wrappers so websocket transport can reuse a connection', async () => {
+    const provider = new OpenAIProvider({
+      openAIClient: new FakeClient() as any,
+      useResponses: true,
+      useResponsesWebSocket: true,
+    });
+
+    const first = await provider.getModel('gpt-4.1');
+    const second = await provider.getModel('gpt-4.1');
+
+    expect(first).toBe(second);
+    expect(first).toBeInstanceOf(OpenAIResponsesWSModel);
+  });
+
+  it('can disable websocket model wrapper caching', async () => {
+    const provider = new OpenAIProvider({
+      openAIClient: new FakeClient() as any,
+      useResponses: true,
+      useResponsesWebSocket: true,
+      cacheResponsesWebSocketModels: false,
+    });
+
+    const first = await provider.getModel('gpt-4.1');
+    const second = await provider.getModel('gpt-4.1');
+
+    expect(first).not.toBe(second);
+    expect(first).toBeInstanceOf(OpenAIResponsesWSModel);
+    expect(second).toBeInstanceOf(OpenAIResponsesWSModel);
+  });
+
+  it('does not retain uncached websocket models for provider.close', async () => {
+    const closeSpy = vi
+      .spyOn(OpenAIResponsesWSModel.prototype, 'close')
+      .mockResolvedValue(undefined);
+    const provider = new OpenAIProvider({
+      openAIClient: new FakeClient() as any,
+      useResponses: true,
+      useResponsesWebSocket: true,
+      cacheResponsesWebSocketModels: false,
+    });
+
+    await provider.getModel('gpt-4.1');
+    await provider.getModel('gpt-4.1');
+    await provider.close();
+
+    expect(closeSpy).not.toHaveBeenCalled();
+  });
+
+  it('closes cached closeable models and clears the cache', async () => {
+    const closeSpy = vi
+      .spyOn(OpenAIResponsesWSModel.prototype, 'close')
+      .mockResolvedValue(undefined);
+    const provider = new OpenAIProvider({
+      openAIClient: new FakeClient() as any,
+      useResponses: true,
+      useResponsesWebSocket: true,
+    });
+
+    const first = await provider.getModel('gpt-4.1');
+    await provider.close();
+    const second = await provider.getModel('gpt-4.1');
+
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+    expect(second).not.toBe(first);
   });
 
   it('constructs a client using default env configuration for responses', async () => {

--- a/packages/agents-openai/test/openaiResponsesWSModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesWSModel.test.ts
@@ -1,0 +1,2434 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import type OpenAI from 'openai';
+import type { ResponseStreamEvent as OpenAIResponseStreamEvent } from 'openai/resources/responses/responses';
+import {
+  setTracingDisabled,
+  type ResponseStreamEvent,
+} from '@openai/agents-core';
+import { HEADERS } from '../src/defaults';
+import { OpenAIResponsesWSModel } from '../src/openaiResponsesModel';
+import { ResponsesWebSocketConnection } from '../src/responsesWebSocketConnection';
+
+type Listener = (event: any) => void;
+
+class TestWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances: TestWebSocket[] = [];
+  static onCreate: ((socket: TestWebSocket) => void) | undefined;
+
+  CONNECTING = TestWebSocket.CONNECTING;
+  OPEN = TestWebSocket.OPEN;
+  CLOSING = TestWebSocket.CLOSING;
+  CLOSED = TestWebSocket.CLOSED;
+
+  readonly url: string;
+  readonly init: any;
+  readyState = TestWebSocket.CONNECTING;
+  sent: string[] = [];
+  private listeners = new Map<string, Set<Listener>>();
+
+  constructor(url: string, init?: unknown) {
+    this.url = url;
+    this.init = init;
+    TestWebSocket.instances.push(this);
+    TestWebSocket.onCreate?.(this);
+
+    Promise.resolve().then(() => {
+      if (this.readyState !== TestWebSocket.CONNECTING) {
+        return;
+      }
+      this.readyState = TestWebSocket.OPEN;
+      this.emit('open', { type: 'open' });
+    });
+  }
+
+  static reset() {
+    TestWebSocket.instances = [];
+    TestWebSocket.onCreate = undefined;
+  }
+
+  addEventListener(type: string, listener: Listener) {
+    const set = this.listeners.get(type) ?? new Set<Listener>();
+    set.add(listener);
+    this.listeners.set(type, set);
+  }
+
+  removeEventListener(type: string, listener: Listener) {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  send(data: string) {
+    this.sent.push(String(data));
+    this.emit('send', { data: String(data) });
+  }
+
+  close() {
+    if (this.readyState === TestWebSocket.CLOSED) {
+      return;
+    }
+
+    this.readyState = TestWebSocket.CLOSED;
+    this.emit('close', { type: 'close' });
+  }
+
+  queueJSON(payload: unknown) {
+    this.emit('message', { data: JSON.stringify(payload) });
+  }
+
+  onSend(handler: (data: string) => void) {
+    this.addEventListener('send', (event) => {
+      handler(String(event.data));
+    });
+  }
+
+  private emit(type: string, event: any) {
+    const listeners = [...(this.listeners.get(type) ?? [])];
+    for (const listener of listeners) {
+      listener(event);
+    }
+  }
+}
+
+function createFakeClient(): OpenAI & {
+  _callApiKey: ReturnType<typeof vi.fn>;
+} {
+  const callApiKey = vi.fn().mockResolvedValue(false);
+  return {
+    apiKey: 'sk-test',
+    baseURL: 'https://api.openai.example/v1',
+    organization: 'org_test',
+    project: 'proj_test',
+    responses: {
+      create: vi.fn(),
+    },
+    _callApiKey: callApiKey,
+    _options: {
+      defaultHeaders: {
+        'X-Client-Header': 'client',
+      },
+    },
+  } as unknown as OpenAI & { _callApiKey: ReturnType<typeof vi.fn> };
+}
+
+describe('OpenAIResponsesWSModel', () => {
+  const originalWebSocket = (globalThis as any).WebSocket;
+
+  beforeAll(() => {
+    setTracingDisabled(true);
+  });
+
+  beforeEach(() => {
+    TestWebSocket.reset();
+    (globalThis as any).WebSocket = TestWebSocket as any;
+  });
+
+  afterEach(() => {
+    if (typeof originalWebSocket === 'undefined') {
+      delete (globalThis as any).WebSocket;
+    } else {
+      (globalThis as any).WebSocket = originalWebSocket;
+    }
+    TestWebSocket.reset();
+  });
+
+  it('streams responses over websocket and maps events', async () => {
+    const fakeClient = createFakeClient();
+    const sentFrames: Record<string, any>[] = [];
+
+    TestWebSocket.onCreate = (socket) => {
+      socket.onSend((rawFrame) => {
+        const frame = JSON.parse(rawFrame);
+        sentFrames.push(frame);
+
+        const createdEvent: OpenAIResponseStreamEvent = {
+          type: 'response.created',
+          response: { id: 'resp_init' } as any,
+          sequence_number: 0,
+        };
+        const deltaEvent: OpenAIResponseStreamEvent = {
+          type: 'response.output_text.delta',
+          content_index: 0,
+          delta: 'hello',
+          item_id: 'item_1',
+          logprobs: [],
+          output_index: 0,
+          sequence_number: 1,
+        } as any;
+        const completedEvent: OpenAIResponseStreamEvent = {
+          type: 'response.completed',
+          response: {
+            id: 'resp_done',
+            output: [
+              {
+                id: 'msg_1',
+                type: 'message',
+                status: 'completed',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'hello' }],
+              },
+            ],
+            usage: {
+              input_tokens: 2,
+              output_tokens: 1,
+              total_tokens: 3,
+            },
+          } as any,
+          sequence_number: 2,
+        } as any;
+
+        socket.queueJSON(createdEvent);
+        socket.queueJSON(deltaEvent);
+        socket.queueJSON(completedEvent);
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws', {
+      websocketBaseURL: 'wss://proxy.example.test/v1?base_param=1',
+    });
+
+    const request = {
+      systemInstructions: 'inst',
+      input: 'hello',
+      modelSettings: {
+        providerData: {
+          extra_headers: { 'X-Extra-Header': 'extra' },
+          extra_query: { tenant: 'acme' },
+          extra_body: { metadata: { transport: 'ws' } },
+        },
+      },
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    const received: ResponseStreamEvent[] = [];
+    for await (const event of model.getStreamedResponse(request as any)) {
+      received.push(event);
+    }
+
+    expect(fakeClient.responses.create as any).not.toHaveBeenCalled();
+    expect(fakeClient._callApiKey).toHaveBeenCalledTimes(1);
+    expect(TestWebSocket.instances).toHaveLength(1);
+    expect(TestWebSocket.instances[0]?.url).toBe(
+      'wss://proxy.example.test/v1/responses?base_param=1&tenant=acme',
+    );
+    expect(TestWebSocket.instances[0]?.init).toMatchObject({
+      headers: {
+        Authorization: 'Bearer sk-test',
+        'OpenAI-Organization': 'org_test',
+        'OpenAI-Project': 'proj_test',
+        'X-Client-Header': 'client',
+        'X-Extra-Header': 'extra',
+        'User-Agent': HEADERS['User-Agent'],
+      },
+    });
+
+    expect(sentFrames).toHaveLength(1);
+    expect(sentFrames[0]).toMatchObject({
+      type: 'response.create',
+      model: 'gpt-ws',
+      stream: true,
+      instructions: 'inst',
+      metadata: { transport: 'ws' },
+    });
+    expect(sentFrames[0]?.extra_headers).toBeUndefined();
+    expect(sentFrames[0]?.extra_query).toBeUndefined();
+    expect(sentFrames[0]?.extra_body).toBeUndefined();
+
+    expect(received.some((event) => event.type === 'response_started')).toBe(
+      true,
+    );
+    expect(received.some((event) => event.type === 'output_text_delta')).toBe(
+      true,
+    );
+    const responseDone = received.find(
+      (event) => event.type === 'response_done',
+    );
+    expect(responseDone).toBeDefined();
+    expect((responseDone as any).response.id).toBe('resp_done');
+  });
+
+  it('serializes websocket query array params with bracket-style encoding', async () => {
+    const fakeClient = createFakeClient();
+
+    TestWebSocket.onCreate = (socket) => {
+      socket.onSend(() => {
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: 'resp_init' },
+          sequence_number: 0,
+        });
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: 'resp_done',
+            output: [],
+            usage: {},
+          },
+          sequence_number: 1,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws', {
+      websocketBaseURL: 'wss://proxy.example.test/v1',
+    });
+
+    const request = {
+      systemInstructions: undefined,
+      input: 'hello',
+      modelSettings: {
+        providerData: {
+          extra_query: {
+            scopes: ['alpha', 'beta'],
+          },
+        },
+      },
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    for await (const _event of model.getStreamedResponse(request as any)) {
+      // Consume stream to capture the websocket URL.
+    }
+
+    const wsURL = new URL(TestWebSocket.instances[0]!.url);
+    expect(wsURL.searchParams.getAll('scopes[]')).toEqual(['alpha', 'beta']);
+    expect(wsURL.searchParams.getAll('scopes')).toEqual([]);
+  });
+
+  it('serializes nested websocket query params with bracket-style object encoding', async () => {
+    const fakeClient = createFakeClient() as any;
+    fakeClient._options.defaultQuery = {
+      filters: {
+        tenant: 'client',
+        tags: ['client-a'],
+      },
+    };
+
+    TestWebSocket.onCreate = (socket) => {
+      socket.onSend(() => {
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: 'resp_init' },
+          sequence_number: 0,
+        });
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: 'resp_done',
+            output: [],
+            usage: {},
+          },
+          sequence_number: 1,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws', {
+      websocketBaseURL: 'wss://proxy.example.test/v1',
+    });
+
+    const request = {
+      systemInstructions: undefined,
+      input: 'hello',
+      modelSettings: {
+        providerData: {
+          extra_query: {
+            filters: {
+              tenant: 'request',
+              tags: ['alpha', 'beta'],
+              nested: {
+                region: 'us',
+              },
+            },
+          },
+        },
+      },
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    for await (const _event of model.getStreamedResponse(request as any)) {
+      // Consume stream to capture the websocket URL.
+    }
+
+    const wsURL = new URL(TestWebSocket.instances[0]!.url);
+    expect(wsURL.searchParams.get('filters[tenant]')).toBe('request');
+    expect(wsURL.searchParams.getAll('filters[tags][]')).toEqual([
+      'alpha',
+      'beta',
+    ]);
+    expect(wsURL.searchParams.get('filters[nested][region]')).toBe('us');
+    expect(wsURL.searchParams.get('filters')).toBeNull();
+    expect(Array.from(wsURL.searchParams.values())).not.toContain(
+      '[object Object]',
+    );
+  });
+
+  it('uses the client authHeaders strategy for websocket handshakes', async () => {
+    const fakeClient = createFakeClient() as any;
+    fakeClient._options.defaultQuery = { client_default: '1' };
+    const authHeadersSpy = vi.fn().mockResolvedValue({
+      values: new Headers({ 'api-key': 'azure-key' }),
+      nulls: new Set<string>(),
+    });
+    fakeClient.authHeaders = authHeadersSpy;
+
+    TestWebSocket.onCreate = (socket) => {
+      socket.onSend(() => {
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: 'resp_init' },
+          sequence_number: 0,
+        });
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: 'resp_done',
+            output: [],
+            usage: {},
+          },
+          sequence_number: 1,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws', {
+      websocketBaseURL: 'wss://proxy.example.test/v1?base_param=1',
+    });
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {
+        providerData: {
+          extra_query: {
+            tenant: 'acme',
+          },
+        },
+      },
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    for await (const _event of model.getStreamedResponse(request as any)) {
+      // Consume the stream to trigger the websocket handshake.
+    }
+
+    expect(authHeadersSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'get',
+        path: '/v1/responses',
+        query: expect.objectContaining({
+          base_param: '1',
+          client_default: '1',
+          tenant: 'acme',
+        }),
+      }),
+    );
+    expect(TestWebSocket.instances[0]?.init).toMatchObject({
+      headers: {
+        'api-key': 'azure-key',
+      },
+    });
+    expect(
+      TestWebSocket.instances[0]?.init?.headers?.Authorization,
+    ).toBeUndefined();
+  });
+
+  it('preserves NullableHeaders null unsets across websocket header merges', async () => {
+    const fakeClient = createFakeClient() as any;
+    fakeClient.authHeaders = vi.fn().mockResolvedValue({
+      values: new Headers({ 'api-key': 'azure-key' }),
+      nulls: new Set<string>([
+        'OpenAI-Organization',
+        'OpenAI-Project',
+        'X-Client-Header',
+        'User-Agent',
+      ]),
+    });
+
+    TestWebSocket.onCreate = (socket) => {
+      socket.onSend(() => {
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: 'resp_init' },
+          sequence_number: 0,
+        });
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: 'resp_done',
+            output: [],
+            usage: {},
+          },
+          sequence_number: 1,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    for await (const _event of model.getStreamedResponse(request as any)) {
+      // Consume the stream to trigger the websocket handshake.
+    }
+
+    const wsHeaders = TestWebSocket.instances[0]?.init?.headers ?? {};
+    expect(wsHeaders['api-key']).toBe('azure-key');
+    expect(wsHeaders['OpenAI-Organization']).toBeUndefined();
+    expect(wsHeaders['OpenAI-Project']).toBeUndefined();
+    expect(wsHeaders['X-Client-Header']).toBeUndefined();
+    expect(wsHeaders['User-Agent']).toBeUndefined();
+  });
+
+  it.each([
+    ['response.incomplete', 'incomplete'],
+    ['response.failed', 'failed'],
+    ['response.error', 'failed'],
+  ] as const)(
+    'emits response_done for terminal websocket stream event %s',
+    async (terminalEventType, expectedStatus) => {
+      const fakeClient = createFakeClient();
+
+      TestWebSocket.onCreate = (socket) => {
+        socket.onSend(() => {
+          socket.queueJSON({
+            type: 'response.created',
+            response: { id: 'resp_init', status: 'in_progress' },
+            sequence_number: 0,
+          } as any);
+          socket.queueJSON({
+            type: terminalEventType,
+            response: {
+              id: 'resp_terminal',
+              status: expectedStatus,
+              output: [],
+              usage: {},
+              ...(terminalEventType === 'response.incomplete'
+                ? { incomplete_details: { reason: 'max_output_tokens' } }
+                : {}),
+            },
+            sequence_number: 1,
+          } as any);
+        });
+      };
+
+      const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+      const request = {
+        systemInstructions: undefined,
+        input: 'ping',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      const received: ResponseStreamEvent[] = [];
+      for await (const event of model.getStreamedResponse(request as any)) {
+        received.push(event);
+      }
+
+      expect(received.some((event) => event.type === 'response_started')).toBe(
+        true,
+      );
+      const responseDone = received.find(
+        (event) => event.type === 'response_done',
+      );
+      expect(responseDone).toBeDefined();
+      expect((responseDone as any).response.id).toBe('resp_terminal');
+      expect((responseDone as any).response.providerData?.status).toBe(
+        expectedStatus,
+      );
+      expect(
+        received.some(
+          (event) =>
+            event.type === 'model' &&
+            (event as any).event?.type === terminalEventType,
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it('merges client defaultQuery into websocket request URLs', async () => {
+    const fakeClient = createFakeClient();
+    (fakeClient as any)._options.defaultQuery = {
+      client_param: 'client',
+      tenant: 'client',
+    };
+
+    TestWebSocket.onCreate = (socket) => {
+      socket.onSend(() => {
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: 'resp_init' },
+          sequence_number: 0,
+        });
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: 'resp_done',
+            output: [],
+            usage: {},
+          },
+          sequence_number: 1,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws', {
+      websocketBaseURL: 'wss://proxy.example.test/v1?base_param=1',
+    });
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {
+        providerData: {
+          extra_query: {
+            tenant: 'request',
+            request_param: 'request',
+          },
+        },
+      },
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    for await (const _event of model.getStreamedResponse(request as any)) {
+      // Consume stream.
+    }
+
+    const wsURL = new URL(TestWebSocket.instances[0]!.url);
+    expect(wsURL.searchParams.get('base_param')).toBe('1');
+    expect(wsURL.searchParams.get('client_param')).toBe('client');
+    expect(wsURL.searchParams.get('tenant')).toBe('request');
+    expect(wsURL.searchParams.get('request_param')).toBe('request');
+  });
+
+  it('preserves explicit websocketBaseURL query params over client defaultQuery', async () => {
+    const fakeClient = createFakeClient();
+    (fakeClient as any)._options.defaultQuery = {
+      'api-version': '2024-01-01',
+      tenant: 'client',
+      client_param: 'client',
+    };
+
+    TestWebSocket.onCreate = (socket) => {
+      socket.onSend(() => {
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: 'resp_init' },
+          sequence_number: 0,
+        });
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: 'resp_done',
+            output: [],
+            usage: {},
+          },
+          sequence_number: 1,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws', {
+      websocketBaseURL:
+        'wss://proxy.example.test/v1?base_param=1&api-version=2025-02-01-preview&tenant=base',
+    });
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {
+        providerData: {
+          extra_query: {
+            tenant: 'request',
+          },
+        },
+      },
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    for await (const _event of model.getStreamedResponse(request as any)) {
+      // Consume stream.
+    }
+
+    const wsURL = new URL(TestWebSocket.instances[0]!.url);
+    expect(wsURL.searchParams.get('base_param')).toBe('1');
+    expect(wsURL.searchParams.get('client_param')).toBe('client');
+    expect(wsURL.searchParams.get('api-version')).toBe('2025-02-01-preview');
+    expect(wsURL.searchParams.get('tenant')).toBe('request');
+  });
+
+  it('does not append /responses twice when websocketBaseURL already targets /responses', async () => {
+    const fakeClient = createFakeClient();
+
+    TestWebSocket.onCreate = (socket) => {
+      socket.onSend(() => {
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: 'resp_init' },
+          sequence_number: 0,
+        });
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: 'resp_done',
+            output: [],
+            usage: {},
+          },
+          sequence_number: 1,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws', {
+      websocketBaseURL: 'wss://proxy.example.test/v1/responses?base_param=1',
+    });
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {
+        providerData: {
+          extra_query: { tenant: 'acme' },
+        },
+      },
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    for await (const _event of model.getStreamedResponse(request as any)) {
+      // Consume stream.
+    }
+
+    expect(TestWebSocket.instances[0]?.url).toBe(
+      'wss://proxy.example.test/v1/responses?base_param=1&tenant=acme',
+    );
+  });
+
+  it.each([
+    ['response.incomplete', 'incomplete'],
+    ['response.failed', 'failed'],
+    ['response.error', 'failed'],
+  ] as const)(
+    'returns terminal websocket responses in non-stream mode (%s)',
+    async (terminalEventType, expectedStatus) => {
+      const fakeClient = createFakeClient();
+
+      TestWebSocket.onCreate = (socket) => {
+        socket.onSend(() => {
+          socket.queueJSON({
+            type: 'response.created',
+            response: { id: 'resp_init' },
+            sequence_number: 0,
+          } as any);
+          socket.queueJSON({
+            type: terminalEventType,
+            response: {
+              id: 'resp_done',
+              status: expectedStatus,
+              output: [],
+              usage: {},
+            },
+            sequence_number: 1,
+          } as any);
+        });
+      };
+
+      const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+      const request = {
+        systemInstructions: undefined,
+        input: 'ping',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      const result = await (model as any)._fetchResponse(request as any, false);
+
+      expect(result.id).toBe('resp_done');
+      expect(result.status).toBe(expectedStatus);
+      expect(TestWebSocket.instances[0]?.sent).toHaveLength(1);
+    },
+  );
+
+  it('surfaces first-frame websocket error payloads without feature-disabled wrapping', async () => {
+    const fakeClient = createFakeClient();
+
+    TestWebSocket.onCreate = (socket) => {
+      socket.onSend(() => {
+        socket.queueJSON({
+          type: 'error',
+          error: {
+            message: 'invalid request',
+          },
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    const error = await (model as any)
+      ._fetchResponse(request as any, false)
+      .catch((err: unknown) => err as Error);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toContain('Responses websocket error:');
+    expect(error.message).toContain('invalid request');
+    expect(error.message).not.toContain('feature may not be enabled');
+  });
+
+  it('preserves local websocket setup errors before first event', async () => {
+    const fakeClient = createFakeClient();
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws', {
+      websocketBaseURL: 'ftp://proxy.example.test/v1',
+    });
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    const error = await (model as any)
+      ._fetchResponse(request as any, false)
+      .catch((err: unknown) => err as Error);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toContain(
+      'Unsupported websocket base URL protocol: ftp:',
+    );
+    expect(error.message).not.toContain('feature may not be enabled');
+  });
+
+  it('preserves websocket constructor errors as the cause of header-support failures', async () => {
+    class ThrowingCtorWebSocket {
+      constructor(_url: string, _init?: unknown) {
+        throw new Error('ctor exploded');
+      }
+    }
+
+    (globalThis as any).WebSocket = ThrowingCtorWebSocket as any;
+    const fakeClient = createFakeClient();
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    const error = await (model as any)
+      ._fetchResponse(request as any, false)
+      .catch((err: unknown) => err as Error & { cause?: unknown });
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toContain(
+      'Responses websocket transport requires a WebSocket implementation that supports custom headers.',
+    );
+    expect((error.cause as Error | undefined)?.message).toBe('ctor exploded');
+    expect(error.message).not.toContain('feature may not be enabled');
+  });
+
+  it('fails fast when websocket closes before waitForOpen attaches listeners', async () => {
+    class FailFastCloseWebSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+
+      CONNECTING = FailFastCloseWebSocket.CONNECTING;
+      OPEN = FailFastCloseWebSocket.OPEN;
+      CLOSING = FailFastCloseWebSocket.CLOSING;
+      CLOSED = FailFastCloseWebSocket.CLOSED;
+
+      readyState = FailFastCloseWebSocket.CONNECTING;
+      private listeners = new Map<string, Set<(event: any) => void>>();
+
+      constructor(_url: string, _init?: unknown) {}
+
+      addEventListener(type: string, listener: (event: any) => void) {
+        const set = this.listeners.get(type) ?? new Set<(event: any) => void>();
+        set.add(listener);
+        this.listeners.set(type, set);
+
+        // Trigger a fail-fast close after the connection object's persistent close
+        // listener is attached but before waitForOpen() registers its temporary listeners.
+        if (
+          type === 'close' &&
+          this.readyState === FailFastCloseWebSocket.CONNECTING
+        ) {
+          this.readyState = FailFastCloseWebSocket.CLOSED;
+          this.emit('close', { type: 'close' });
+        }
+      }
+
+      removeEventListener(type: string, listener: (event: any) => void) {
+        this.listeners.get(type)?.delete(listener);
+      }
+
+      send(_data: string) {
+        throw new Error('unexpected send');
+      }
+
+      close() {
+        if (this.readyState === FailFastCloseWebSocket.CLOSED) {
+          return;
+        }
+        this.readyState = FailFastCloseWebSocket.CLOSED;
+        this.emit('close', { type: 'close' });
+      }
+
+      private emit(type: string, event: any) {
+        const listeners = [...(this.listeners.get(type) ?? [])];
+        for (const listener of listeners) {
+          listener(event);
+        }
+      }
+    }
+
+    (globalThis as any).WebSocket = FailFastCloseWebSocket as any;
+    const fakeClient = createFakeClient();
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    const result = await Promise.race([
+      (model as any)._fetchResponse(request as any, false).then(
+        () => ({ kind: 'resolved' as const }),
+        (error: unknown) => ({ kind: 'rejected' as const, error }),
+      ),
+      new Promise<{ kind: 'timeout' }>((resolve) =>
+        setTimeout(() => resolve({ kind: 'timeout' }), 100),
+      ),
+    ]);
+
+    expect(result.kind).toBe('rejected');
+    expect((result as any).error).toBeInstanceOf(Error);
+    expect(((result as any).error as Error).message).toContain(
+      'feature may not be enabled',
+    );
+    expect(
+      (((result as any).error as Error & { cause?: unknown }).cause as Error)
+        ?.message ?? '',
+    ).toContain('closed before opening');
+  });
+
+  it('times out a stalled websocket handshake and unblocks queued requests', async () => {
+    const fakeClient = createFakeClient() as any;
+    fakeClient.timeout = 25;
+    fakeClient._options = { ...(fakeClient._options ?? {}), timeout: 25 };
+    let socketCreateCount = 0;
+    let resolveFirstSocketCreated!: () => void;
+    const firstSocketCreated = new Promise<void>((resolve) => {
+      resolveFirstSocketCreated = resolve;
+    });
+
+    TestWebSocket.onCreate = (socket) => {
+      socketCreateCount += 1;
+      if (socketCreateCount === 1) {
+        socket.readyState = 99 as any;
+        resolveFirstSocketCreated();
+        return;
+      }
+
+      socket.onSend(() => {
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: 'resp_init_2' },
+          sequence_number: 0,
+        });
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: 'resp_done_2',
+            output: [],
+            usage: {},
+          },
+          sequence_number: 1,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const baseRequest = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    const firstResponsePromise = (model as any)._fetchResponse(
+      {
+        ...baseRequest,
+        input: 'first',
+      } as any,
+      false,
+    );
+    await firstSocketCreated;
+
+    // The second request snapshots timeout at request start (before queue wait),
+    // so give it a larger budget explicitly to keep this test focused on lock
+    // release/unblocking behavior after the first handshake timeout.
+    fakeClient.timeout = 1000;
+    fakeClient._options.timeout = 1000;
+
+    const secondResponsePromise = (model as any)._fetchResponse(
+      {
+        ...baseRequest,
+        input: 'second',
+      } as any,
+      false,
+    );
+
+    await expect(firstResponsePromise).rejects.toThrow(
+      'Responses websocket connection timed out before opening after 25ms.',
+    );
+    await expect(secondResponsePromise).resolves.toMatchObject({
+      id: 'resp_done_2',
+    });
+    expect(TestWebSocket.instances).toHaveLength(2);
+    expect(TestWebSocket.instances[0]?.sent).toHaveLength(0);
+    expect(TestWebSocket.instances[1]?.sent).toHaveLength(1);
+  });
+
+  it('times out stalled websocket auth header preparation and unblocks queued requests', async () => {
+    const fakeClient = createFakeClient() as any;
+    fakeClient.timeout = 25;
+    fakeClient._options = { ...(fakeClient._options ?? {}), timeout: 25 };
+    let authHeadersCallCount = 0;
+    let resolveFirstAuthHeadersStarted!: () => void;
+    const firstAuthHeadersStarted = new Promise<void>((resolve) => {
+      resolveFirstAuthHeadersStarted = resolve;
+    });
+
+    fakeClient.authHeaders = vi.fn(async () => {
+      authHeadersCallCount += 1;
+      if (authHeadersCallCount === 1) {
+        resolveFirstAuthHeadersStarted();
+        return await new Promise<never>(() => {
+          // Intentionally never resolves; timeout handling should release the lock.
+        });
+      }
+
+      return {
+        values: new Headers({ 'api-key': 'azure-key' }),
+        nulls: new Set<string>(),
+      };
+    });
+
+    TestWebSocket.onCreate = (socket) => {
+      socket.onSend(() => {
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: 'resp_init_auth' },
+          sequence_number: 0,
+        });
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: 'resp_done_auth',
+            output: [],
+            usage: {},
+          },
+          sequence_number: 1,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const baseRequest = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    const firstResponsePromise = (model as any)._fetchResponse(
+      {
+        ...baseRequest,
+        input: 'first',
+      } as any,
+      false,
+    );
+    await firstAuthHeadersStarted;
+
+    // Timeout is captured at request start, so explicitly give the queued
+    // request enough budget to wait for the first timeout and then proceed.
+    fakeClient.timeout = 1000;
+    fakeClient._options.timeout = 1000;
+
+    const secondResponsePromise = (model as any)._fetchResponse(
+      {
+        ...baseRequest,
+        input: 'second',
+      } as any,
+      false,
+    );
+
+    await expect(firstResponsePromise).rejects.toThrow(
+      'Responses websocket auth header preparation timed out after 25ms.',
+    );
+    await expect(secondResponsePromise).resolves.toMatchObject({
+      id: 'resp_done_auth',
+    });
+    expect(fakeClient.authHeaders).toHaveBeenCalledTimes(2);
+    expect(TestWebSocket.instances).toHaveLength(1);
+    expect(TestWebSocket.instances[0]?.sent).toHaveLength(1);
+  });
+
+  it('prevents request providerData from overriding websocket frame type', async () => {
+    const fakeClient = createFakeClient();
+    const sentFrames: Record<string, any>[] = [];
+
+    TestWebSocket.onCreate = (socket) => {
+      socket.onSend((rawFrame) => {
+        sentFrames.push(JSON.parse(rawFrame));
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: 'resp_init' },
+          sequence_number: 0,
+        });
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: 'resp_done',
+            output: [],
+            usage: {},
+          },
+          sequence_number: 1,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {
+        providerData: {
+          extra_body: {
+            type: 'user.overridden.type',
+            metadata: { transport: 'ws' },
+          },
+        },
+      },
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    await (model as any)._fetchResponse(request as any, false);
+
+    expect(sentFrames).toHaveLength(1);
+    expect(sentFrames[0]).toMatchObject({
+      type: 'response.create',
+      metadata: { transport: 'ws' },
+      stream: true,
+    });
+  });
+
+  it('reuses the websocket connection across sequential requests', async () => {
+    const fakeClient = createFakeClient();
+    let sendCount = 0;
+
+    TestWebSocket.onCreate = (socket) => {
+      socket.onSend(() => {
+        sendCount += 1;
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: `resp_init_${sendCount}` },
+          sequence_number: 0,
+        });
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: `resp_done_${sendCount}`,
+            output: [],
+            usage: {},
+          },
+          sequence_number: 1,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    const consumeStream = async () => {
+      let responseId = '';
+      for await (const event of model.getStreamedResponse(request as any)) {
+        if (event.type === 'response_done') {
+          responseId = event.response.id;
+        }
+      }
+      return responseId;
+    };
+
+    const first = await consumeStream();
+    const second = await consumeStream();
+
+    expect(first).toBe('resp_done_1');
+    expect(second).toBe('resp_done_2');
+    expect(TestWebSocket.instances).toHaveLength(1);
+    expect(fakeClient._callApiKey).toHaveBeenCalledTimes(2);
+  });
+
+  it('drops the websocket connection after terminal events when reuse is disabled', async () => {
+    const fakeClient = createFakeClient();
+    let sendCount = 0;
+
+    TestWebSocket.onCreate = (socket) => {
+      socket.onSend(() => {
+        sendCount += 1;
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: `resp_init_${sendCount}` },
+          sequence_number: 0,
+        });
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: `resp_done_${sendCount}`,
+            output: [],
+            usage: {},
+          },
+          sequence_number: 1,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws', {
+      reuseConnection: false,
+    });
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    const consumeStream = async () => {
+      let responseId = '';
+      for await (const event of model.getStreamedResponse(request as any)) {
+        if (event.type === 'response_done') {
+          responseId = event.response.id;
+        }
+      }
+      return responseId;
+    };
+
+    const first = await consumeStream();
+    expect(TestWebSocket.instances[0]?.readyState).toBe(TestWebSocket.CLOSED);
+    const second = await consumeStream();
+
+    expect(first).toBe('resp_done_1');
+    expect(second).toBe('resp_done_2');
+    expect(TestWebSocket.instances).toHaveLength(2);
+  });
+
+  it('releases the request lock before awaiting websocket close', async () => {
+    const fakeClient = createFakeClient() as any;
+    fakeClient.timeout = 25;
+    fakeClient._options = { ...(fakeClient._options ?? {}), timeout: 25 };
+    let sendCount = 0;
+    let resolveFirstCloseStarted!: () => void;
+    let releaseFirstClose!: () => void;
+
+    const firstCloseStarted = new Promise<void>((resolve) => {
+      resolveFirstCloseStarted = resolve;
+    });
+    const firstCloseReleased = new Promise<void>((resolve) => {
+      releaseFirstClose = resolve;
+    });
+
+    TestWebSocket.onCreate = (socket) => {
+      const socketId = TestWebSocket.instances.length;
+      if (socketId === 1) {
+        let closeDelayed = false;
+        socket.close = (() => {
+          if (socket.readyState === TestWebSocket.CLOSED) {
+            return;
+          }
+          if (closeDelayed) {
+            return;
+          }
+          closeDelayed = true;
+          socket.readyState = TestWebSocket.CLOSING;
+          resolveFirstCloseStarted();
+          void firstCloseReleased.then(() => {
+            socket.readyState = TestWebSocket.CLOSED;
+            (socket as any).emit('close', { type: 'close' });
+          });
+        }) as TestWebSocket['close'];
+      }
+
+      socket.onSend(() => {
+        sendCount += 1;
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: `resp_init_${socketId}` },
+          sequence_number: 0,
+        });
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: `resp_done_${socketId}`,
+            output: [],
+            usage: {},
+          },
+          sequence_number: 1,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws', {
+      reuseConnection: false,
+    });
+    const baseRequest = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    const firstResponsePromise = (model as any)._fetchResponse(
+      { ...baseRequest, input: 'first' } as any,
+      false,
+    );
+    void firstResponsePromise.catch(() => undefined);
+
+    await firstCloseStarted;
+
+    const secondResponsePromise = (model as any)._fetchResponse(
+      { ...baseRequest, input: 'second' } as any,
+      false,
+    );
+    void secondResponsePromise.catch(() => undefined);
+
+    const queuedOutcome = await Promise.race([
+      secondResponsePromise.then(
+        (response: any) => ({ kind: 'resolved' as const, response }),
+        (error: unknown) => ({ kind: 'rejected' as const, error }),
+      ),
+      new Promise<{ kind: 'timeout' }>((resolve) => {
+        setTimeout(() => resolve({ kind: 'timeout' }), 200);
+      }),
+    ]);
+
+    try {
+      expect(queuedOutcome.kind).toBe('resolved');
+      if (queuedOutcome.kind === 'resolved') {
+        expect(queuedOutcome.response).toMatchObject({ id: 'resp_done_2' });
+      }
+      expect(sendCount).toBe(2);
+      expect(TestWebSocket.instances).toHaveLength(2);
+    } finally {
+      releaseFirstClose();
+    }
+
+    await expect(firstResponsePromise).resolves.toMatchObject({
+      id: 'resp_done_1',
+    });
+  });
+
+  it('reconnects before reuse when the cached websocket has been closed', async () => {
+    const fakeClient = createFakeClient();
+    let socketCreateCount = 0;
+
+    TestWebSocket.onCreate = (socket) => {
+      const socketId = ++socketCreateCount;
+      socket.onSend(() => {
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: `resp_init_${socketId}` },
+          sequence_number: 0,
+        });
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: `resp_done_${socketId}`,
+            output: [],
+            usage: {},
+          },
+          sequence_number: 1,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    const consumeStream = async () => {
+      let responseId = '';
+      for await (const event of model.getStreamedResponse(request as any)) {
+        if (event.type === 'response_done') {
+          responseId = event.response.id;
+        }
+      }
+      return responseId;
+    };
+
+    const first = await consumeStream();
+    TestWebSocket.instances[0]?.close();
+    const second = await consumeStream();
+
+    expect(first).toBe('resp_done_1');
+    expect(second).toBe('resp_done_2');
+    expect(TestWebSocket.instances).toHaveLength(2);
+  });
+
+  it('reconnects when a reused websocket closes before the request frame is sent', async () => {
+    const fakeClient = createFakeClient();
+    let socketCreateCount = 0;
+
+    TestWebSocket.onCreate = (socket) => {
+      const socketId = ++socketCreateCount;
+      socket.onSend(() => {
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: `resp_init_${socketId}` },
+          sequence_number: 0,
+        });
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: `resp_done_${socketId}`,
+            output: [],
+            usage: {},
+          },
+          sequence_number: 1,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    const consumeStream = async () => {
+      let responseId = '';
+      for await (const event of model.getStreamedResponse(request as any)) {
+        if (event.type === 'response_done') {
+          responseId = event.response.id;
+        }
+      }
+      return responseId;
+    };
+
+    const first = await consumeStream();
+    const firstSocket = TestWebSocket.instances[0];
+    expect(firstSocket).toBeDefined();
+
+    let readyState = firstSocket!.readyState;
+    let closeBeforeSendScheduled = false;
+    Object.defineProperty(firstSocket!, 'readyState', {
+      configurable: true,
+      get() {
+        if (!closeBeforeSendScheduled && readyState === TestWebSocket.OPEN) {
+          closeBeforeSendScheduled = true;
+          void Promise.resolve().then(() => {
+            firstSocket!.close();
+          });
+        }
+        return readyState;
+      },
+      set(value) {
+        readyState = value as number;
+      },
+    });
+
+    const second = await consumeStream();
+
+    expect(first).toBe('resp_done_1');
+    expect(second).toBe('resp_done_2');
+    expect(TestWebSocket.instances).toHaveLength(2);
+    expect(TestWebSocket.instances[0]?.sent).toHaveLength(1);
+    expect(TestWebSocket.instances[1]?.sent).toHaveLength(1);
+  });
+
+  it('does not replay after a reused websocket closes post-send before the first response frame', async () => {
+    const fakeClient = createFakeClient();
+    let socketCreateCount = 0;
+
+    TestWebSocket.onCreate = (socket) => {
+      const socketId = ++socketCreateCount;
+      let sendCount = 0;
+      socket.onSend(() => {
+        sendCount += 1;
+        if (socketId === 1 && sendCount === 2) {
+          void Promise.resolve().then(() => {
+            socket.close();
+          });
+          return;
+        }
+
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: `resp_init_${socketId}` },
+          sequence_number: 0,
+        });
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: `resp_done_${socketId}`,
+            output: [],
+            usage: {},
+          },
+          sequence_number: 1,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    const consumeStream = async () => {
+      let responseId = '';
+      for await (const event of model.getStreamedResponse(request as any)) {
+        if (event.type === 'response_done') {
+          responseId = event.response.id;
+        }
+      }
+      return responseId;
+    };
+
+    const first = await consumeStream();
+    await expect(consumeStream()).rejects.toThrow(
+      'The request may have been accepted, so the SDK will not automatically retry this websocket request.',
+    );
+
+    expect(first).toBe('resp_done_1');
+    expect(TestWebSocket.instances).toHaveLength(1);
+    expect(TestWebSocket.instances[0]?.sent).toHaveLength(2);
+  });
+
+  it('reconnects when a reused websocket send throws native InvalidStateError', async () => {
+    const fakeClient = createFakeClient();
+    let socketCreateCount = 0;
+
+    TestWebSocket.onCreate = (socket) => {
+      const socketId = ++socketCreateCount;
+      socket.onSend(() => {
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: `resp_init_${socketId}` },
+          sequence_number: 0,
+        });
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: `resp_done_${socketId}`,
+            output: [],
+            usage: {},
+          },
+          sequence_number: 1,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    const consumeStream = async () => {
+      let responseId = '';
+      for await (const event of model.getStreamedResponse(request as any)) {
+        if (event.type === 'response_done') {
+          responseId = event.response.id;
+        }
+      }
+      return responseId;
+    };
+
+    const first = await consumeStream();
+    const firstSocket = TestWebSocket.instances[0];
+    expect(firstSocket).toBeDefined();
+
+    const originalSend = firstSocket!.send.bind(firstSocket!);
+    let throwNativeInvalidStateOnce = true;
+    firstSocket!.send = ((data: string) => {
+      if (throwNativeInvalidStateOnce) {
+        throwNativeInvalidStateOnce = false;
+        firstSocket!.close();
+        const invalidStateError = new Error(
+          'WebSocket is already in CLOSING or CLOSED state.',
+        );
+        invalidStateError.name = 'InvalidStateError';
+        throw invalidStateError;
+      }
+      originalSend(data);
+    }) as TestWebSocket['send'];
+
+    const second = await consumeStream();
+
+    expect(first).toBe('resp_done_1');
+    expect(second).toBe('resp_done_2');
+    expect(TestWebSocket.instances).toHaveLength(2);
+    expect(TestWebSocket.instances[0]?.sent).toHaveLength(1);
+    expect(TestWebSocket.instances[1]?.sent).toHaveLength(1);
+  });
+
+  it('reconnects when a reused websocket send throws ws readyState error', async () => {
+    const fakeClient = createFakeClient();
+    let socketCreateCount = 0;
+
+    TestWebSocket.onCreate = (socket) => {
+      const socketId = ++socketCreateCount;
+      socket.onSend(() => {
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: `resp_init_${socketId}` },
+          sequence_number: 0,
+        });
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: `resp_done_${socketId}`,
+            output: [],
+            usage: {},
+          },
+          sequence_number: 1,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    const consumeStream = async () => {
+      let responseId = '';
+      for await (const event of model.getStreamedResponse(request as any)) {
+        if (event.type === 'response_done') {
+          responseId = event.response.id;
+        }
+      }
+      return responseId;
+    };
+
+    const first = await consumeStream();
+    const firstSocket = TestWebSocket.instances[0];
+    expect(firstSocket).toBeDefined();
+
+    const originalSend = firstSocket!.send.bind(firstSocket!);
+    let throwWsReadyStateErrorOnce = true;
+    firstSocket!.send = ((data: string) => {
+      if (throwWsReadyStateErrorOnce) {
+        throwWsReadyStateErrorOnce = false;
+        firstSocket!.close();
+        throw new Error('WebSocket is not open: readyState 2 (CLOSING)');
+      }
+      originalSend(data);
+    }) as TestWebSocket['send'];
+
+    const second = await consumeStream();
+
+    expect(first).toBe('resp_done_1');
+    expect(second).toBe('resp_done_2');
+    expect(TestWebSocket.instances).toHaveLength(2);
+    expect(TestWebSocket.instances[0]?.sent).toHaveLength(1);
+    expect(TestWebSocket.instances[1]?.sent).toHaveLength(1);
+  });
+
+  it('times out silent websocket frame reads and unblocks queued requests', async () => {
+    const fakeClient = createFakeClient() as any;
+    fakeClient.timeout = 25;
+    fakeClient._options = { ...(fakeClient._options ?? {}), timeout: 25 };
+    let sendCount = 0;
+    let resolveFirstFrameWaitStarted!: () => void;
+    const firstFrameWaitStarted = new Promise<void>((resolve) => {
+      resolveFirstFrameWaitStarted = resolve;
+    });
+    const originalNextFrame = ResponsesWebSocketConnection.prototype.nextFrame;
+    let sawFirstNextFrameCall = false;
+    const nextFrameSpy = vi
+      .spyOn(ResponsesWebSocketConnection.prototype, 'nextFrame')
+      .mockImplementation(function (
+        this: ResponsesWebSocketConnection,
+        signal,
+      ) {
+        if (!sawFirstNextFrameCall) {
+          sawFirstNextFrameCall = true;
+          resolveFirstFrameWaitStarted();
+        }
+        return originalNextFrame.call(this, signal);
+      });
+
+    try {
+      TestWebSocket.onCreate = (socket) => {
+        socket.onSend(() => {
+          sendCount += 1;
+          if (sendCount === 1) {
+            return;
+          }
+
+          socket.queueJSON({
+            type: 'response.created',
+            response: { id: 'resp_init_2' },
+            sequence_number: 0,
+          });
+          socket.queueJSON({
+            type: 'response.completed',
+            response: {
+              id: 'resp_done_2',
+              output: [],
+              usage: {},
+            },
+            sequence_number: 1,
+          });
+        });
+      };
+
+      const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+      const baseRequest = {
+        systemInstructions: undefined,
+        input: 'ping',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      const firstResponsePromise = (model as any)._fetchResponse(
+        {
+          ...baseRequest,
+          input: 'first',
+        } as any,
+        false,
+      );
+      await firstFrameWaitStarted;
+
+      // Keep the first request on a short frame-read timeout while allowing the
+      // queued request to wait long enough to proceed after the first fails.
+      fakeClient.timeout = 1000;
+      fakeClient._options.timeout = 1000;
+
+      const secondResponsePromise = (model as any)._fetchResponse(
+        {
+          ...baseRequest,
+          input: 'second',
+        } as any,
+        false,
+      );
+      void secondResponsePromise.catch(() => undefined);
+
+      await expect(firstResponsePromise).rejects.toThrow(
+        'Responses websocket frame read timed out after 25ms.',
+      );
+      await expect(secondResponsePromise).resolves.toMatchObject({
+        id: 'resp_done_2',
+      });
+      expect(TestWebSocket.instances).toHaveLength(2);
+      expect(TestWebSocket.instances[0]?.sent).toHaveLength(1);
+      expect(TestWebSocket.instances[1]?.sent).toHaveLength(1);
+    } finally {
+      nextFrameSpy.mockRestore();
+    }
+  });
+
+  it('bounds websocket requests by the total client timeout even while frames keep arriving', async () => {
+    const fakeClient = createFakeClient() as any;
+    fakeClient.timeout = 25;
+    fakeClient._options = { ...(fakeClient._options ?? {}), timeout: 25 };
+    let deltaInterval: ReturnType<typeof setInterval> | undefined;
+
+    TestWebSocket.onCreate = (socket) => {
+      let startedStreaming = false;
+      let sequenceNumber = 1;
+      socket.onSend(() => {
+        if (startedStreaming) {
+          return;
+        }
+        startedStreaming = true;
+
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: 'resp_init' },
+          sequence_number: 0,
+        });
+
+        deltaInterval = setInterval(() => {
+          socket.queueJSON({
+            type: 'response.output_text.delta',
+            content_index: 0,
+            delta: '.',
+            item_id: 'item_1',
+            logprobs: [],
+            output_index: 0,
+            sequence_number: sequenceNumber++,
+          } as any);
+        }, 5);
+      });
+      socket.addEventListener('close', () => {
+        if (deltaInterval) {
+          clearInterval(deltaInterval);
+          deltaInterval = undefined;
+        }
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    const responsePromise = (model as any)._fetchResponse(
+      request as any,
+      false,
+    );
+    const outcome = await Promise.race([
+      responsePromise.then(
+        (response: any) => ({ kind: 'resolved' as const, response }),
+        (error: unknown) => ({ kind: 'rejected' as const, error }),
+      ),
+      new Promise<{ kind: 'timeout' }>((resolve) => {
+        setTimeout(() => resolve({ kind: 'timeout' }), 150);
+      }),
+    ]);
+
+    try {
+      expect(outcome.kind).toBe('rejected');
+      if (outcome.kind === 'rejected') {
+        expect(outcome.error).toBeInstanceOf(Error);
+        expect((outcome.error as Error).message).toContain(
+          'Responses websocket frame read timed out after 25ms.',
+        );
+      }
+    } finally {
+      if (deltaInterval) {
+        clearInterval(deltaInterval);
+      }
+      await model.close();
+    }
+  });
+
+  it('applies the client timeout while waiting for queued websocket requests', async () => {
+    const fakeClient = createFakeClient() as any;
+    fakeClient.timeout = 1000;
+    fakeClient._options = { ...(fakeClient._options ?? {}), timeout: 1000 };
+    let sendCount = 0;
+    let resolveFirstSend!: () => void;
+    let resolveFirstRequest!: () => void;
+    const firstSendSeen = new Promise<void>((resolve) => {
+      resolveFirstSend = resolve;
+    });
+    const firstRequestReleased = new Promise<void>((resolve) => {
+      resolveFirstRequest = resolve;
+    });
+
+    TestWebSocket.onCreate = (socket) => {
+      socket.onSend(() => {
+        sendCount += 1;
+        if (sendCount === 1) {
+          resolveFirstSend();
+          socket.queueJSON({
+            type: 'response.created',
+            response: { id: 'resp_init_1' },
+            sequence_number: 0,
+          });
+          void firstRequestReleased.then(() => {
+            socket.queueJSON({
+              type: 'response.completed',
+              response: {
+                id: 'resp_done_1',
+                output: [],
+                usage: {},
+              },
+              sequence_number: 1,
+            });
+          });
+          return;
+        }
+
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: `resp_init_${sendCount}` },
+          sequence_number: 0,
+        });
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: `resp_done_${sendCount}`,
+            output: [],
+            usage: {},
+          },
+          sequence_number: 1,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const baseRequest = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    const firstResponsePromise = (model as any)._fetchResponse(
+      {
+        ...baseRequest,
+        input: 'first',
+      } as any,
+      false,
+    );
+    await firstSendSeen;
+
+    fakeClient.timeout = 25;
+    fakeClient._options.timeout = 25;
+
+    const queuedResponsePromise = (model as any)._fetchResponse(
+      {
+        ...baseRequest,
+        input: 'queued',
+      } as any,
+      false,
+    );
+    void queuedResponsePromise.catch(() => undefined);
+
+    const queuedOutcome = await Promise.race([
+      queuedResponsePromise.then(
+        () => ({ kind: 'resolved' as const }),
+        (error: unknown) => ({ kind: 'rejected' as const, error }),
+      ),
+      new Promise<{ kind: 'timeout' }>((resolve) => {
+        setTimeout(() => resolve({ kind: 'timeout' }), 200);
+      }),
+    ]);
+
+    try {
+      expect(queuedOutcome.kind).toBe('rejected');
+      expect((queuedOutcome as any).error).toBeInstanceOf(Error);
+      expect(((queuedOutcome as any).error as Error).message).toContain(
+        'Responses websocket request queue wait timed out after 25ms.',
+      );
+      expect(sendCount).toBe(1);
+      expect(TestWebSocket.instances).toHaveLength(1);
+      expect(TestWebSocket.instances[0]?.sent).toHaveLength(1);
+    } finally {
+      resolveFirstRequest();
+    }
+
+    await expect(firstResponsePromise).resolves.toMatchObject({
+      id: 'resp_done_1',
+    });
+    await expect(queuedResponsePromise).rejects.toThrow(
+      'Responses websocket request queue wait timed out after 25ms.',
+    );
+  });
+
+  it('does not send an already-aborted queued websocket request', async () => {
+    const fakeClient = createFakeClient();
+    let sendCount = 0;
+    let resolveFirstRequest!: () => void;
+    let resolveFirstSend!: () => void;
+
+    const firstRequestReleased = new Promise<void>((resolve) => {
+      resolveFirstRequest = resolve;
+    });
+    const firstSendSeen = new Promise<void>((resolve) => {
+      resolveFirstSend = resolve;
+    });
+
+    TestWebSocket.onCreate = (socket) => {
+      socket.onSend(() => {
+        sendCount += 1;
+        if (sendCount === 1) {
+          resolveFirstSend();
+          socket.queueJSON({
+            type: 'response.created',
+            response: { id: 'resp_init_1' },
+            sequence_number: 0,
+          });
+          void firstRequestReleased.then(() => {
+            socket.queueJSON({
+              type: 'response.completed',
+              response: {
+                id: 'resp_done_1',
+                output: [],
+                usage: {},
+              },
+              sequence_number: 1,
+            });
+          });
+        }
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const baseRequest = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+    };
+
+    const firstResponsePromise = (model as any)._fetchResponse(
+      {
+        ...baseRequest,
+        signal: undefined,
+      } as any,
+      false,
+    );
+    await firstSendSeen;
+
+    const abortController = new AbortController();
+    const queuedAbortedResponsePromise = (model as any)._fetchResponse(
+      {
+        ...baseRequest,
+        input: 'queued',
+        signal: abortController.signal,
+      } as any,
+      false,
+    );
+    abortController.abort();
+
+    const queuedAbortOutcome = await Promise.race([
+      queuedAbortedResponsePromise.then(
+        () => 'resolved' as const,
+        () => 'rejected' as const,
+      ),
+      new Promise<'timeout'>((resolve) => {
+        setTimeout(() => resolve('timeout'), 50);
+      }),
+    ]);
+    try {
+      expect(queuedAbortOutcome).toBe('rejected');
+    } finally {
+      resolveFirstRequest();
+    }
+
+    await expect(firstResponsePromise).resolves.toMatchObject({
+      id: 'resp_done_1',
+    });
+    await expect(queuedAbortedResponsePromise).rejects.toThrow();
+    expect(TestWebSocket.instances).toHaveLength(1);
+    expect(TestWebSocket.instances[0]?.sent).toHaveLength(1);
+  });
+
+  it('does not emit unhandled rejection when aborted between websocket events', async () => {
+    const fakeClient = createFakeClient();
+
+    TestWebSocket.onCreate = (socket) => {
+      socket.onSend(() => {
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: 'resp_init_1' },
+          sequence_number: 0,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const abortController = new AbortController();
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: abortController.signal,
+    };
+
+    const rawStream = (await (model as any)._fetchResponse(
+      request as any,
+      true,
+    )) as AsyncIterable<OpenAIResponseStreamEvent>;
+    const iterator = rawStream[Symbol.asyncIterator]();
+    const rejections: unknown[] = [];
+    const handler = (error: unknown) => {
+      rejections.push(error);
+    };
+    process.on('unhandledRejection', handler);
+
+    try {
+      const first = await iterator.next();
+      expect(first.done).toBe(false);
+      expect((first.value as any).type).toBe('response.created');
+
+      abortController.abort();
+
+      await expect(iterator.next()).rejects.toThrow();
+
+      // Give socket cleanup a tick to surface any orphaned waiter rejection.
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(rejections).toHaveLength(0);
+    } finally {
+      process.off('unhandledRejection', handler);
+      await iterator.return?.();
+    }
+  });
+
+  it('refreshes auth only after a queued websocket request acquires the request lock', async () => {
+    const fakeClient = createFakeClient();
+    let sendCount = 0;
+    let resolveFirstRequest!: () => void;
+    let resolveFirstSend!: () => void;
+
+    fakeClient._callApiKey.mockImplementation(async () => {
+      const callIndex = fakeClient._callApiKey.mock.calls.length;
+      (fakeClient as any).apiKey = `sk-dynamic-${callIndex}`;
+      return true;
+    });
+
+    const firstRequestReleased = new Promise<void>((resolve) => {
+      resolveFirstRequest = resolve;
+    });
+    const firstSendSeen = new Promise<void>((resolve) => {
+      resolveFirstSend = resolve;
+    });
+
+    TestWebSocket.onCreate = (socket) => {
+      socket.onSend(() => {
+        sendCount += 1;
+        if (sendCount === 1) {
+          resolveFirstSend();
+          socket.queueJSON({
+            type: 'response.created',
+            response: { id: 'resp_init_1' },
+            sequence_number: 0,
+          });
+          void firstRequestReleased.then(() => {
+            socket.queueJSON({
+              type: 'response.completed',
+              response: {
+                id: 'resp_done_1',
+                output: [],
+                usage: {},
+              },
+              sequence_number: 1,
+            });
+          });
+          return;
+        }
+
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: 'resp_init_2' },
+          sequence_number: 0,
+        });
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: 'resp_done_2',
+            output: [],
+            usage: {},
+          },
+          sequence_number: 1,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const baseRequest = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    const firstResponsePromise = (model as any)._fetchResponse(
+      baseRequest as any,
+      false,
+    );
+    await firstSendSeen;
+    expect(fakeClient._callApiKey).toHaveBeenCalledTimes(1);
+
+    const queuedResponsePromise = (model as any)._fetchResponse(
+      {
+        ...baseRequest,
+        input: 'queued',
+      } as any,
+      false,
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fakeClient._callApiKey).toHaveBeenCalledTimes(1);
+
+    resolveFirstRequest();
+
+    await expect(firstResponsePromise).resolves.toMatchObject({
+      id: 'resp_done_1',
+    });
+    await expect(queuedResponsePromise).resolves.toMatchObject({
+      id: 'resp_done_2',
+    });
+    expect(fakeClient._callApiKey).toHaveBeenCalledTimes(2);
+  });
+
+  it('drops the websocket connection when a stream is ended early', async () => {
+    const fakeClient = createFakeClient();
+    let socketCreateCount = 0;
+
+    TestWebSocket.onCreate = (socket) => {
+      const socketId = ++socketCreateCount;
+      socket.onSend(() => {
+        if (socketId === 1) {
+          socket.queueJSON({
+            type: 'response.created',
+            response: { id: 'resp_init_1' },
+            sequence_number: 0,
+          });
+          socket.queueJSON({
+            type: 'response.output_text.delta',
+            delta: 'partial',
+            content_index: 0,
+            item_id: 'item_1',
+            logprobs: [],
+            output_index: 0,
+            sequence_number: 1,
+          });
+          socket.queueJSON({
+            type: 'response.completed',
+            response: {
+              id: 'resp_done_1',
+              output: [],
+              usage: {},
+            },
+            sequence_number: 2,
+          });
+          return;
+        }
+
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: 'resp_init_2' },
+          sequence_number: 0,
+        });
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: 'resp_done_2',
+            output: [],
+            usage: {},
+          },
+          sequence_number: 1,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    for await (const _event of model.getStreamedResponse(request as any)) {
+      break;
+    }
+
+    expect(TestWebSocket.instances[0]?.readyState).toBe(TestWebSocket.CLOSED);
+
+    let secondResponseId = '';
+    for await (const event of model.getStreamedResponse(request as any)) {
+      if (event.type === 'response_done') {
+        secondResponseId = event.response.id;
+      }
+    }
+
+    expect(secondResponseId).toBe('resp_done_2');
+    expect(TestWebSocket.instances).toHaveLength(2);
+  });
+
+  it('validates extra_query transport overrides', async () => {
+    const fakeClient = createFakeClient();
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {
+        providerData: {
+          extra_query: 'not-a-mapping',
+        },
+      },
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    const consumeStream = async () => {
+      for await (const _event of model.getStreamedResponse(request as any)) {
+        // No-op.
+      }
+    };
+
+    await expect(consumeStream()).rejects.toThrow(
+      'Responses websocket extra query must be a mapping.',
+    );
+    expect(TestWebSocket.instances).toHaveLength(0);
+  });
+});

--- a/packages/agents-openai/test/responsesTransportUtils.test.ts
+++ b/packages/agents-openai/test/responsesTransportUtils.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { HEADERS } from '../src/defaults';
+import {
+  applyHeadersToAccumulator,
+  createHeaderAccumulator,
+  headerAccumulatorToRecord,
+  mergeHeadersIntoRecord,
+  mergeQueryParamsIntoURL,
+} from '../src/responsesTransportUtils';
+
+describe('responsesTransportUtils', () => {
+  it('treats null-valued plain-object headers as explicit unsets', () => {
+    const requestHeaders: Record<string, string> = {
+      ...HEADERS,
+      'X-Existing': 'keep',
+    };
+
+    mergeHeadersIntoRecord(requestHeaders, {
+      'User-Agent': null,
+      'X-Existing': 'override',
+      'X-New': 'new',
+    });
+
+    expect(requestHeaders['User-Agent']).toBeUndefined();
+    expect(requestHeaders).not.toHaveProperty('User-Agent');
+    expect(requestHeaders['X-Existing']).toBe('override');
+    expect(requestHeaders['X-New']).toBe('new');
+  });
+
+  it('applies plain-object header nulls as unsets in the header accumulator', () => {
+    const accumulator = createHeaderAccumulator();
+
+    applyHeadersToAccumulator(accumulator, {
+      'User-Agent': HEADERS['User-Agent'],
+      'X-Client-Header': 'client',
+    });
+    applyHeadersToAccumulator(accumulator, {
+      'User-Agent': null,
+    });
+
+    const headers = headerAccumulatorToRecord(accumulator);
+    expect(headers).not.toHaveProperty('User-Agent');
+    expect(headers['X-Client-Header']).toBe('client');
+  });
+
+  it('serializes Date query values as ISO-8601 strings', () => {
+    const url = new URL('wss://proxy.example.test/v1/responses');
+    const timestamp = new Date('2025-01-02T03:04:05.678Z');
+    const nestedTimestamp = new Date('2025-04-06T07:08:09.010Z');
+    const arrayTimestamp = new Date('2025-11-12T13:14:15.016Z');
+
+    mergeQueryParamsIntoURL(url, {
+      at: timestamp,
+      filter: { since: nestedTimestamp },
+      many: [arrayTimestamp],
+    });
+
+    expect(url.searchParams.get('at')).toBe(timestamp.toISOString());
+    expect(url.searchParams.get('filter[since]')).toBe(
+      nestedTimestamp.toISOString(),
+    );
+    expect(url.searchParams.get('many[]')).toBe(arrayTimestamp.toISOString());
+    expect(url.searchParams.get('at[]')).toBeNull();
+    expect(Array.from(url.searchParams.keys())).not.toContain('at[valueOf]');
+  });
+});

--- a/packages/agents-openai/test/responsesWebSocketSession.test.ts
+++ b/packages/agents-openai/test/responsesWebSocketSession.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Runner } from '@openai/agents-core';
+import { OpenAIProvider } from '../src/openaiProvider';
+import { OpenAIResponsesWSModel } from '../src/openaiResponsesModel';
+import { withResponsesWebSocketSession } from '../src/responsesWebSocketSession';
+
+const OpenAIMock = vi.hoisted(() =>
+  vi.fn(function FakeOpenAI(this: any, config: any) {
+    Object.assign(this, config);
+    this.chat = { completions: { create: vi.fn() } };
+    this.responses = { create: vi.fn(), compact: vi.fn() };
+  }),
+);
+
+vi.mock('openai', () => ({
+  default: OpenAIMock,
+  OpenAI: OpenAIMock,
+}));
+
+class FakeClient {}
+
+describe('withResponsesWebSocketSession', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    OpenAIMock.mockClear();
+  });
+
+  it('creates a websocket responses provider, exposes a bound run function, and closes on success', async () => {
+    const runSpy = vi
+      .spyOn(Runner.prototype, 'run')
+      .mockResolvedValue({ rawResponses: [] } as any);
+    const closeSpy = vi
+      .spyOn(OpenAIProvider.prototype, 'close')
+      .mockResolvedValue(undefined);
+
+    const result = await withResponsesWebSocketSession(
+      async ({ provider, runner, run }) => {
+        const model = await provider.getModel('gpt-4.1');
+        expect(model).toBeInstanceOf(OpenAIResponsesWSModel);
+        expect(runner.config.model).toBe('gpt-5.2-mini');
+
+        const fakeAgent = {} as any;
+        const fakeInput = 'hello' as any;
+        await run(fakeAgent, fakeInput);
+
+        const call = runSpy.mock.calls[0];
+        expect(call?.[0]).toBe(fakeAgent);
+        expect(call?.[1]).toBe(fakeInput);
+        expect(runSpy.mock.instances[0]).toBe(runner);
+        return 'ok';
+      },
+      {
+        providerOptions: { openAIClient: new FakeClient() as any },
+        runnerConfig: { model: 'gpt-5.2-mini' },
+      },
+    );
+
+    expect(result).toBe('ok');
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the provider when the callback throws', async () => {
+    const closeSpy = vi
+      .spyOn(OpenAIProvider.prototype, 'close')
+      .mockResolvedValue(undefined);
+
+    await expect(
+      withResponsesWebSocketSession(async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the callback error when provider.close also fails', async () => {
+    const closeError = new Error('close failed');
+    const closeSpy = vi
+      .spyOn(OpenAIProvider.prototype, 'close')
+      .mockRejectedValue(closeError);
+
+    const error = await withResponsesWebSocketSession(async () => {
+      throw new Error('boom');
+    }).catch((err: unknown) => err as Error & { cause?: unknown });
+
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+    expect(error.message).toBe('boom');
+    expect(error.cause).toBe(closeError);
+  });
+});

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -2,7 +2,9 @@ import { setDefaultModelProvider } from '@openai/agents-core';
 import { OpenAIProvider } from '@openai/agents-openai';
 import { setDefaultOpenAITracingExporter } from '@openai/agents-openai';
 
-setDefaultModelProvider(new OpenAIProvider());
+setDefaultModelProvider(
+  new OpenAIProvider({ cacheResponsesWebSocketModels: false }),
+);
 setDefaultOpenAITracingExporter();
 
 export * from '@openai/agents-core';


### PR DESCRIPTION
This pull request adds a Responses WebSocket transport path in `@openai/agents-openai`, including new connection/session helpers (`responsesWebSocketConnection.ts`, `responsesWebSocketSession.ts`), transport utilities, provider/defaults wiring, and exports through `@openai/agents`. The transport implementation and the new basic example (`examples/basic/stream-ws.ts`) are intended to support the OpenAI Responses WebSocket mode flow described in the [WebSocket mode guide](https://developers.openai.com/api/docs/guides/websocket-mode).

It also updates `@openai/agents-core` nested agent-tool execution (`Agent.asTool`) to pass a scoped parent runner config into nested runs, preserves tool-call detail object descriptors while injecting timeout/signal metadata, and adds coverage for the new inheritance and WebSocket transport/session behaviors.

```typescript
import { Agent, withResponsesWebSocketSession } from '@openai/agents';

const agent = new Agent({
  name: 'Assistant',
  instructions: 'You are a helpful assistant.',
  model: 'gpt-5.2-codex',
});
await withResponsesWebSocketSession(async ({ run }) => {
  const streamed = await run(agent, 'Say hello in one sentence.', {
    stream: true,
  });
  for await (const _event of streamed.toStream()) {
    // Drain the stream.
  }
  console.log(streamed.finalOutput);
});
```