### PR TITLE
chore: change #1004 to minor version changes

### DIFF
--- a/.changeset/fair-timers-trade.md
+++ b/.changeset/fair-timers-trade.md
@@ -1,7 +1,7 @@
 ---
-'@openai/agents': patch
-'@openai/agents-core': patch
-'@openai/agents-openai': patch
+'@openai/agents': minor
+'@openai/agents-core': minor
+'@openai/agents-openai': minor
 ---
 
 feat: add responses websocket transport and scoped websocket session helper


### PR DESCRIPTION
#1004 does not bring breaking changes, but it introduces a major feature plus refactors internals a lot. So, we'll move it to minor version bump.