### PR TITLE
fix(realtime): sync OpenAI realtime model type list

### DIFF
--- a/.changeset/late-bugs-attend.md
+++ b/.changeset/late-bugs-attend.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: sync OpenAI realtime model autocomplete names

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -40,16 +40,18 @@ import { EventEmitterDelegate } from '@openai/agents-core/utils';
  * The models that are supported by the OpenAI Realtime API.
  */
 export type OpenAIRealtimeModels =
-  | 'gpt-4o-realtime-preview'
-  | 'gpt-4o-mini-realtime-preview'
-  | 'gpt-4o-realtime-preview-2025-06-03'
-  | 'gpt-4o-realtime-preview-2024-12-17'
-  | 'gpt-4o-realtime-preview-2024-10-01'
-  | 'gpt-4o-mini-realtime-preview-2024-12-17'
   | 'gpt-realtime'
+  | 'gpt-realtime-1.5'
   | 'gpt-realtime-2025-08-28'
+  | 'gpt-4o-realtime-preview'
+  | 'gpt-4o-realtime-preview-2024-10-01'
+  | 'gpt-4o-realtime-preview-2024-12-17'
+  | 'gpt-4o-realtime-preview-2025-06-03'
+  | 'gpt-4o-mini-realtime-preview'
+  | 'gpt-4o-mini-realtime-preview-2024-12-17'
   | 'gpt-realtime-mini'
   | 'gpt-realtime-mini-2025-10-06'
+  | 'gpt-realtime-mini-2025-12-15'
   | (string & {}); // ensures autocomplete works
 
 /**


### PR DESCRIPTION
This pull request fixes the `OpenAIRealtimeModels` autocomplete/type union in `@openai/agents-realtime` so it matches the current supported realtime model names and versions. The change updates the union in `packages/agents-realtime/src/openaiRealtimeBase.ts` (including new entries such as `gpt-realtime-1.5` and `gpt-realtime-mini-2025-12-15`) and keeps the list ordered to match the canonical model list.