### PR TITLE
fix: preserve OpenAI Responses request IDs in raw responses

### DIFF
--- a/.changeset/funny-snakes-teach.md
+++ b/.changeset/funny-snakes-teach.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+---
+
+fix: preserve OpenAI Responses request IDs in raw responses

--- a/packages/agents-core/src/model.ts
+++ b/packages/agents-core/src/model.ts
@@ -331,6 +331,11 @@ export type ModelResponse = {
   responseId?: string;
 
   /**
+   * The transport request ID for this model call, if provided by the model SDK or transport.
+   */
+  requestId?: string;
+
+  /**
    * Raw response data from the underlying model provider.
    */
   providerData?: Record<string, any>;

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1194,6 +1194,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                   usage: new Usage(parsed.response.usage),
                   output: parsed.response.output,
                   responseId: parsed.response.id,
+                  requestId: parsed.response.requestId,
                 };
                 result.state._context.usage.add(finalResponse.usage);
               }

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -49,14 +49,16 @@ import { HostedMCPTool, ShellTool, ApplyPatchTool } from './tool';
  * - 1.3: Adds computer tool approval items to serialized tool_approval_item unions.
  * - 1.4: Adds optional toolInput to serialized run context.
  * - 1.5: Adds optional reasoningItemIdPolicy to preserve reasoning input policy across resume.
+ * - 1.6: Adds optional requestId to serialized model responses.
  */
-export const CURRENT_SCHEMA_VERSION = '1.5' as const;
+export const CURRENT_SCHEMA_VERSION = '1.6' as const;
 const SUPPORTED_SCHEMA_VERSIONS = [
   '1.0',
   '1.1',
   '1.2',
   '1.3',
   '1.4',
+  '1.5',
   CURRENT_SCHEMA_VERSION,
 ] as const;
 type SupportedSchemaVersion = (typeof SUPPORTED_SCHEMA_VERSIONS)[number];
@@ -122,6 +124,7 @@ const modelResponseSchema = z.object({
   usage: usageSchema,
   output: z.array(protocol.OutputModelItem),
   responseId: z.string().optional(),
+  requestId: z.string().optional(),
   providerData: z.record(z.string(), z.any()).optional(),
 });
 
@@ -711,6 +714,7 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
           },
           output: response.output as any,
           responseId: response.responseId,
+          requestId: response.requestId,
           providerData: response.providerData,
         };
       }),
@@ -1052,6 +1056,7 @@ export function deserializeModelResponse(
       protocol.OutputModelItem.parse(item),
     ),
     responseId: serializedModelResponse.responseId,
+    requestId: serializedModelResponse.requestId,
     providerData: serializedModelResponse.providerData,
   };
 }

--- a/packages/agents-core/src/types/protocol.ts
+++ b/packages/agents-core/src/types/protocol.ts
@@ -840,6 +840,11 @@ export const StreamEventResponseCompleted = SharedBase.extend({
     id: z.string(),
 
     /**
+     * The transport request ID for this model call, if provided by the model SDK or transport.
+     */
+    requestId: z.string().optional(),
+
+    /**
      * The usage data for the response.
      */
     usage: UsageData,

--- a/packages/agents-openai/test/openaiResponsesWSModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesWSModel.test.ts
@@ -570,6 +570,7 @@ describe('OpenAIResponsesWSModel', () => {
       );
       expect(responseDone).toBeDefined();
       expect((responseDone as any).response.id).toBe('resp_terminal');
+      expect((responseDone as any).response.requestId).toBeUndefined();
       expect((responseDone as any).response.providerData?.status).toBe(
         expectedStatus,
       );


### PR DESCRIPTION
This pull request fixes a gap in the OpenAI Responses integration where transport request IDs were available on SDK responses but were dropped before they reached `result.rawResponses`, especially for streamed runs.

It updates `@openai/agents-core` and `@openai/agents-openai` to carry `requestId` through the normalized `ModelResponse` shape, streamed `response_done` events, and serialized `RunState`, while keeping the websocket Responses transport explicitly unset because it does not currently expose a successful per-request ID. The change also adds focused coverage around HTTP non-streaming, HTTP streaming, streamed run aggregation, websocket behavior, and run-state round-tripping, and includes a patch changeset for the affected packages.

Behaviorally, users can now inspect `rawResponses[n].requestId` alongside `responseId` after HTTP-based Responses runs, including `stream: true` runs. `RunState` now serializes this additive field under schema version `1.6`, so resumed runs preserve the same debugging metadata. No untracked files were detected in the working tree when preparing this summary.

see also: https://github.com/openai/openai-agents-python/pull/2552