### PR TITLE
docs: correct `toolChoice` per the example description

### DIFF
--- a/examples/docs/agents/agentForcingToolUse.ts
+++ b/examples/docs/agents/agentForcingToolUse.ts
@@ -14,5 +14,5 @@ const agent = new Agent({
   name: 'Strict tool user',
   instructions: 'Always answer using the calculator tool.',
   tools: [calculatorTool],
-  modelSettings: { toolChoice: 'auto' },
+  modelSettings: { toolChoice: 'required' },
 });


### PR DESCRIPTION
Per the documentation, `auto` is confusing when the example description mentions "must call".

From the ["Forcing tool use"](https://openai.github.io/openai-agents-js/guides/agents/#forcing-tool-use) example.

> Forcing tool use
> Supplying tools doesn’t guarantee the LLM will call one. You can force tool use with modelSettings.toolChoice:
> 1. 'auto' (default) – the LLM decides whether to use a tool.
> 2. 'required' – the LLM must call a tool (it can choose which one).
> 3. 'none' – the LLM must not call a tool.
> 4. A specific tool name, e.g. 'calculator' – the LLM must call that particular tool.