### PR TITLE
feat: #261 add ai-sdk output text transform hook for provider compatibility

### DIFF
--- a/.changeset/olive-lobsters-smile.md
+++ b/.changeset/olive-lobsters-smile.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+feat: #261 add ai-sdk output text transform hook for provider compatibility


### PR DESCRIPTION
This pull request adds an opt-in `transformOutputText` hook to the AI SDK adapter so applications can normalize finalized assistant text before the Agents runtime validates structured output. It provides a user-land alternative to core-side special casing for provider quirks such as fenced JSON or plain-text output that still needs to be coerced into a schema.

The change updates the `aisdk()` helper and `AiSdkModel` constructor to accept adapter options, applies the transform only to finalized assistant text in both non-streamed responses and streamed `response_done` payloads, and leaves incremental text deltas unchanged. It also adds adapter-level and end-to-end tests plus documentation showing how to use the hook for provider compatibility cases.

Resolves #261 