### PR TITLE
docs: improve TypeScript docs entry points and guide navigation

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -111,7 +111,7 @@ const sidebar = [
     },
   },
   {
-    label: 'Configuring the SDK',
+    label: 'Configuration',
     link: '/guides/config',
     translations: {
       ja: 'SDK の設定',
@@ -127,15 +127,6 @@ const sidebar = [
       ko: '가이드',
     },
     items: [
-      {
-        label: 'Agent orchestration',
-        link: '/guides/multi-agent',
-        translations: {
-          ja: 'エージェントオーケストレーション',
-          zh: '智能体编排',
-          ko: '에이전트 오케스트레이션',
-        },
-      },
       {
         label: 'Agents',
         link: '/guides/agents',
@@ -188,6 +179,15 @@ const sidebar = [
           ja: 'ストリーミング',
           zh: '流式传输',
           ko: '스트리밍',
+        },
+      },
+      {
+        label: 'Agent orchestration',
+        link: '/guides/multi-agent',
+        translations: {
+          ja: 'エージェントオーケストレーション',
+          zh: '智能体编排',
+          ko: '에이전트 오케스트레이션',
         },
       },
       {
@@ -348,15 +348,6 @@ const sidebar = [
     },
   },
   {
-    label: 'Release process',
-    link: '/guides/release',
-    translations: {
-      ja: 'リリースプロセス',
-      zh: '发布流程',
-      ko: '릴리스 프로세스',
-    },
-  },
-  {
     label: 'API Reference',
     translations: {
       ja: 'APIリファレンス',
@@ -396,6 +387,15 @@ const sidebar = [
         items: [extensionsTypeDocSidebarGroup],
       },
     ],
+  },
+  {
+    label: 'Maintainers: release process',
+    link: '/guides/release',
+    translations: {
+      ja: 'リリースプロセス',
+      zh: '发布流程',
+      ko: '릴리스 프로세스',
+    },
   },
 ];
 

--- a/docs/src/content/docs/guides/agents.mdx
+++ b/docs/src/content/docs/guides/agents.mdx
@@ -25,6 +25,9 @@ Model (LLM) that has been configured with:
 
 <Code lang="typescript" code={simpleAgent} title="Basic Agent definition" />
 
+> Use this page when you want to define or customize a single `Agent`. If you are deciding how
+> several agents should collaborate, read [Agent orchestration](/openai-agents-js/guides/multi-agent).
+
 The rest of this page walks through every Agent feature in more detail.
 
 ---
@@ -84,17 +87,14 @@ plain text.
 
 ---
 
-## Composition patterns
+## Agents in multi-agent systems
 
-### Multi-agent system design patterns
-
-There are many ways to compose agents together. Two patterns we regularly see in
-production apps are:
+Two SDK entry points show up most often when an agent participates in a larger workflow:
 
 1. **Manager (agents as tools)** – a central agent owns the conversation and invokes specialized agents that are exposed as tools.
 2. **Handoffs** – the initial agent delegates the entire conversation to a specialist once it has identified the user's request.
 
-These approaches are complementary. Managers give you a single place to enforce guardrails or rate limits, while handoffs let each agent focus on a single task without retaining control of the conversation.
+These approaches are complementary. Managers give you a single place to enforce guardrails or rate limits, while handoffs let each agent focus on a single task without retaining control of the conversation. For the design tradeoffs and when to choose each pattern, see [Agent orchestration](/openai-agents-js/guides/multi-agent).
 
 #### Manager (agents as tools)
 

--- a/docs/src/content/docs/guides/config.mdx
+++ b/docs/src/content/docs/guides/config.mdx
@@ -1,6 +1,6 @@
 ---
-title: Configuring the SDK
-description: Customize API keys, tracing and logging behavior
+title: Configuration
+description: Configure process-wide OpenAI client, transport, tracing, and logging defaults
 ---
 
 import { Code } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/guides/multi-agent.md
+++ b/docs/src/content/docs/guides/multi-agent.md
@@ -5,6 +5,8 @@ description: Coordinate the flow between several agents
 
 Orchestration refers to the flow of agents in your app. Which agents run, in what order, and how do they decide what happens next? There are two main ways to orchestrate agents:
 
+> Read this page after the [Quickstart](/openai-agents-js/guides/quickstart) or [Agents](/openai-agents-js/guides/agents) guide. This page is about workflow design across multiple agents, not the `Agent` constructor itself.
+
 1. Allowing the LLM to make decisions: this uses the intelligence of an LLM to plan, reason, and decide on what steps to take based on that.
 2. Orchestrating via code: determining the flow of agents via your code.
 

--- a/docs/src/content/docs/guides/voice-agents/quickstart.mdx
+++ b/docs/src/content/docs/guides/voice-agents/quickstart.mdx
@@ -5,24 +5,13 @@ description: Build your first realtime voice assistant using the OpenAI Agents S
 
 import { Steps, Aside, Code } from '@astrojs/starlight/components';
 import helloWorldExample from '../../../../../../examples/docs/voice-agents/helloWorld.ts?raw';
-import createAgentExample from '../../../../../../examples/docs/voice-agents/createAgent.ts?raw';
-import multiAgentsExample from '../../../../../../examples/docs/voice-agents/multiAgents.ts?raw';
-import createSessionExample from '../../../../../../examples/docs/voice-agents/createSession.ts?raw';
-import configureSessionExample from '../../../../../../examples/docs/voice-agents/configureSession.ts?raw';
-import handleAudioExample from '../../../../../../examples/docs/voice-agents/handleAudio.ts?raw';
-import defineToolExample from '../../../../../../examples/docs/voice-agents/defineTool.ts?raw';
-import toolApprovalEventExample from '../../../../../../examples/docs/voice-agents/toolApprovalEvent.ts?raw';
-import guardrailsExample from '../../../../../../examples/docs/voice-agents/guardrails.ts?raw';
-import guardrailSettingsExample from '../../../../../../examples/docs/voice-agents/guardrailSettings.ts?raw';
-import audioInterruptedExample from '../../../../../../examples/docs/voice-agents/audioInterrupted.ts?raw';
-import sessionInterruptExample from '../../../../../../examples/docs/voice-agents/sessionInterrupt.ts?raw';
-import sessionHistoryExample from '../../../../../../examples/docs/voice-agents/sessionHistory.ts?raw';
-import historyUpdatedExample from '../../../../../../examples/docs/voice-agents/historyUpdated.ts?raw';
-import updateHistoryExample from '../../../../../../examples/docs/voice-agents/updateHistory.ts?raw';
-import customWebRTCTransportExample from '../../../../../../examples/docs/voice-agents/customWebRTCTransport.ts?raw';
-import websocketSessionExample from '../../../../../../examples/docs/voice-agents/websocketSession.ts?raw';
-import transportEventsExample from '../../../../../../examples/docs/voice-agents/transportEvents.ts?raw';
-import thinClientExample from '../../../../../../examples/docs/voice-agents/thinClient.ts?raw';
+
+<Aside type="note">
+  This quickstart uses `@openai/agents`, which is the recommended default for
+  most apps. If you prefer the standalone Realtime package, install
+  `@openai/agents-realtime` and replace imports from `@openai/agents/realtime`
+  with `@openai/agents-realtime` in the examples below.
+</Aside>
 
 ## Project setup and credentials
 
@@ -36,13 +25,11 @@ import thinClientExample from '../../../../../../examples/docs/voice-agents/thin
    npm create vite@latest my-project -- --template vanilla-ts
    ```
 
-2. **Install the Agents SDK** (requires Zod v4)
+2. **Install the recommended package** (requires Zod v4)
 
    ```bash
    npm install @openai/agents zod
    ```
-
-   Alternatively you can install `@openai/agents-realtime` for a standalone browser package.
 
 3. **Generate a client ephemeral token**
 
@@ -61,7 +48,9 @@ import thinClientExample from '../../../../../../examples/docs/voice-agents/thin
       }'
    ```
 
-   The response will contain a "value" string a the top level, which starts with "ek\_" prefix. You can use this ephemeral key to establish a WebRTC connection later on. Note that this key is only valid for a short period of time and will need to be regenerated.
+   The response contains a top-level `value` field that starts with the `ek_` prefix, plus the
+   effective `session` object. Use `value` as the client secret when establishing the WebRTC
+   connection. This token is short-lived, so your backend should mint a fresh one when needed.
 
 </Steps>
 
@@ -128,16 +117,8 @@ import thinClientExample from '../../../../../../examples/docs/voice-agents/thin
 
 ## Next Steps
 
-From here you can start designing and building your own voice agent. Voice agents include a lot of the same features as regular agents, but have some of their own unique features.
+From here you can start designing and building your own voice agent:
 
-- Learn how to give your voice agent:
-  - [Tools](/openai-agents-js/guides/voice-agents/build#tools)
-  - [Handoffs](/openai-agents-js/guides/voice-agents/build#handoffs)
-  - [Guardrails](/openai-agents-js/guides/voice-agents/build#guardrails)
-  - [Handle audio interruptions](/openai-agents-js/guides/voice-agents/build#interruptions)
-  - [Manage session history](/openai-agents-js/guides/voice-agents/build#conversation-history-management)
-
-- Learn more about the different transport layers.
-  - [WebRTC](/openai-agents-js/guides/voice-agents/transport#connecting-over-webrtc)
-  - [WebSocket](/openai-agents-js/guides/voice-agents/transport#connecting-over-websocket)
-  - [Building your own transport mechanism](/openai-agents-js/guides/voice-agents/transport#building-your-own-transport-mechanism)
+- Add [tools](/openai-agents-js/guides/voice-agents/build#tools), [handoffs](/openai-agents-js/guides/voice-agents/build#handoffs), and [guardrails](/openai-agents-js/guides/voice-agents/build#guardrails).
+- Learn how to [handle audio interruptions](/openai-agents-js/guides/voice-agents/build#interruptions) and [manage session history](/openai-agents-js/guides/voice-agents/build#conversation-history-management).
+- Choose the right transport for your deployment: [WebRTC](/openai-agents-js/guides/voice-agents/transport#connecting-over-webrtc), [WebSocket](/openai-agents-js/guides/voice-agents/transport#connecting-over-websocket), or [a custom transport](/openai-agents-js/guides/voice-agents/transport#building-your-own-transport-mechanism).

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -10,8 +10,10 @@ import Hero from '../../components/Hero.astro';
 import helloWorldExample from '../../../../examples/docs/hello-world.ts?raw';
 
 <Hero>
-  <Fragment slot="title">Quickstart</Fragment>
-  <Fragment slot="description">Build your first agent in minutes.</Fragment>
+  <Fragment slot="title">OpenAI Agents SDK</Fragment>
+  <Fragment slot="description">
+    Build text and voice agents with a small set of primitives.
+  </Fragment>
   <Fragment slot="cta">Let's build</Fragment>
 </Hero>
 
@@ -53,6 +55,16 @@ npm install @openai/agents zod
 
 The SDK requires Zod v4; installing `zod` via npm will fetch the latest v4 release.
 
+## Choose your starting point
+
+Most first-time users only need one of these entry points:
+
+| Start with                                                                                         | Use it when                                                                         | Notes                                                                                                              |
+| -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `@openai/agents`                                                                                   | You are building most text or voice applications.                                   | Recommended default. It includes the OpenAI provider setup and exposes voice APIs under `@openai/agents/realtime`. |
+| `@openai/agents-realtime`                                                                          | You only need the standalone Realtime package.                                      | Useful for browser-only voice apps or when you want a narrower package boundary.                                   |
+| Lower-level packages (`@openai/agents-core`, `@openai/agents-openai`, `@openai/agents-extensions`) | You need lower-level composition, custom provider wiring, or specific integrations. | Most new users can ignore these until they have a concrete need.                                                   |
+
 ## Hello world example
 
 <Code lang="typescript" code={helloWorldExample} title="Hello World" />
@@ -65,6 +77,8 @@ export OPENAI_API_KEY=sk-...
 
 ## Start here
 
+Pick one path first, get it working end to end, then come back for the deeper guides.
+
 <LinkCard
   title="Quickstart"
   href="/openai-agents-js/guides/quickstart"
@@ -76,3 +90,17 @@ export OPENAI_API_KEY=sk-...
   href="/openai-agents-js/guides/voice-agents/quickstart"
   description="Start with the Realtime voice path when you are building spoken interactions."
 />
+
+## Choose your path
+
+Use this table when you know the job you want to do, but not which page explains it.
+
+| Goal                                                            | Start here                                                                                                  |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Build the first text agent and see one complete run             | [Quickstart](/openai-agents-js/guides/quickstart)                                                           |
+| Add function tools, hosted tools, or agents as tools            | [Tools](/openai-agents-js/guides/tools)                                                                     |
+| Decide between handoffs and manager-style orchestration         | [Agent orchestration](/openai-agents-js/guides/multi-agent)                                                 |
+| Keep memory across turns                                        | [Running agents](/openai-agents-js/guides/running-agents) and [Sessions](/openai-agents-js/guides/sessions) |
+| Use OpenAI models, websocket transport, or non-OpenAI providers | [Models](/openai-agents-js/guides/models)                                                                   |
+| Review outputs, run items, interruptions, and resume state      | [Results](/openai-agents-js/guides/results)                                                                 |
+| Build a low-latency voice agent                                 | [Voice Agents Quickstart](/openai-agents-js/guides/voice-agents/quickstart)                                 |


### PR DESCRIPTION
This pull request updates the TypeScript documentation entry points and guide structure to make the first-time reading path clearer without changing the underlying SDK behavior.

It updates six docs files across the homepage, sidebar, and core guides:
- `docs/src/content/docs/index.mdx` reframes the homepage as an overview, adds package-selection guidance, and adds a goal-to-guide lookup table for common tasks.
- `docs/astro.config.mjs` renames `Configuring the SDK` to `Configuration`, moves `Agent orchestration` to follow `Streaming` and precede `Handoffs`, and demotes the release guide to a maintainer-facing nav item.
- `docs/src/content/docs/guides/agents.mdx` and `docs/src/content/docs/guides/multi-agent.md` clarify the boundary between single-agent setup and multi-agent workflow design.
- `docs/src/content/docs/guides/config.mdx` narrows the page framing to process-wide configuration defaults.
- `docs/src/content/docs/guides/voice-agents/quickstart.mdx` removes unused snippet imports, clarifies the recommended `@openai/agents` path versus `@openai/agents-realtime`, and tightens the next-step guidance.

The main behavior change for readers is navigational: the docs now do a better job of answering “where do I start?” and “which page explains this task?” while preserving the existing quickstart depth for multi-agent workflows.