### PR TITLE
chore: upgrade pnpm to 10.30.3 and clarify SHA pinning

### DIFF
--- a/.agents/skills/pnpm-upgrade/SKILL.md
+++ b/.agents/skills/pnpm-upgrade/SKILL.md
@@ -21,18 +21,23 @@ Use these steps to update pnpm and CI pins without blunt search/replace.
    - Use `GITHUB_TOKEN`/`GH_TOKEN` if available for higher rate limits.
    - Store as `ACTION_TAG` (e.g., `v4.2.0`). Abort if missing.
 
-4. Update workflows carefully (no broad regex)
+4. Resolve the action tag to an immutable commit SHA
+   - Run `git ls-remote https://github.com/pnpm/action-setup "refs/tags/${ACTION_TAG}^{}"` and capture the SHA as `ACTION_SHA`.
+   - If the dereferenced tag is missing, fall back to `git ls-remote https://github.com/pnpm/action-setup "refs/tags/${ACTION_TAG}"`.
+   - Abort if `ACTION_SHA` is empty.
+
+5. Update workflows carefully (no broad regex)
    - Files: everything under `.github/workflows/` that uses `pnpm/action-setup`.
    - For each file, edit by hand:
-     - Set `uses: pnpm/action-setup@${ACTION_TAG}`.
+     - Set `uses: pnpm/action-setup@${ACTION_SHA}`.
      - If a `with: version:` field exists, set it to `${PNPM_VERSION}` (keep quoting style/indent).
    - Do not touch unrelated steps. Avoid multiline sed/perl one-liners.
 
-5. Verify
+6. Verify
    - Run `pnpm -v` and confirm it matches `packageManager`.
    - `git diff` to ensure only intended workflow/package.json changes.
 
-6. Follow-up
+7. Follow-up
    - If runtime code/build/test config was changed (not typical here), run `$code-change-verification`; otherwise, a light check is enough.
    - Commit with `chore: upgrade pnpm toolchain` and open a PR (automation may do this).
 
@@ -40,4 +45,5 @@ Use these steps to update pnpm and CI pins without blunt search/replace.
 
 - Tools needed: `curl`, `jq`, `node`, `pnpm`/`corepack`. Install if missing.
 - Keep edits minimal and readable—prefer explicit file edits over global replacements.
+- GitHub Actions must stay pinned to commit SHAs, not tags. Use the latest release tag only to discover the commit SHA to pin.
 - If GitHub API is rate-limited, retry with a token or bail out rather than guessing the tag.

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
         with:
-          version: 10.29.2
+          version: 10.30.3
           run_install: false
       - name: Setup Node
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
         with:
-          version: 10.29.2
+          version: 10.30.3
           run_install: true
       - name: Run build
         run: pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
         with:
-          version: 10.29.2
+          version: 10.30.3
 
       - name: Setup node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,7 @@ jobs:
         if: ${{ needs.changes.outputs.run_ci == 'true' }}
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
         with:
-          version: 10.29.2
+          version: 10.30.3
           run_install: false
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.run_ci == 'true' }}
@@ -157,7 +157,7 @@ jobs:
         if: ${{ needs.changes.outputs.run_ci == 'true' }}
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
         with:
-          version: 10.29.2
+          version: 10.30.3
           run_install: false
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.run_ci == 'true' }}

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
         with:
-          version: 10.29.2
+          version: 10.30.3
           run_install: false
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238

--- a/package.json
+++ b/package.json
@@ -83,5 +83,5 @@
     "verdaccio": "^6.2.5",
     "vitest": "^3.2.4"
   },
-  "packageManager": "pnpm@10.29.2"
+  "packageManager": "pnpm@10.30.3"
 }


### PR DESCRIPTION
This pull request updates the repository's pnpm toolchain from 10.29.2 to 10.30.3 in package.json:86 and the GitHub Actions workflows that install pnpm, including changeset.yml:57, docs.yml:30, release.yml:33, test.yml:112, and update-docs.yml:59.

It also updates pnpm-upgrade skill guidance:24 so future toolchain refreshes resolve the latest pnpm/action-setup release tag to an immutable commit SHA and keep workflow uses: entries SHA-pinned instead of switching to tags.