### PR TITLE
docs: clarify dynamic prompts and runtime doc caveats

### DIFF
--- a/docs/src/content/docs/guides/agents.mdx
+++ b/docs/src/content/docs/guides/agents.mdx
@@ -11,6 +11,7 @@ import agentWithAodOutputType from '../../../../../examples/docs/agents/agentWit
 import agentsAsTools from '../../../../../examples/docs/agents/agentsAsTools.ts?raw';
 import agentWithHandoffs from '../../../../../examples/docs/agents/agentWithHandoffs.ts?raw';
 import agentWithDynamicInstructions from '../../../../../examples/docs/agents/agentWithDynamicInstructions.ts?raw';
+import agentWithDynamicPrompt from '../../../../../examples/docs/agents/agentWithDynamicPrompt.ts?raw';
 import agentWithLifecycleHooks from '../../../../../examples/docs/agents/agentWithLifecycleHooks.ts?raw';
 import agentCloning from '../../../../../examples/docs/agents/agentCloning.ts?raw';
 import agentForcingToolUse from '../../../../../examples/docs/agents/agentForcingToolUse.ts?raw';
@@ -39,18 +40,18 @@ The rest of this page walks through every Agent feature in more detail.
 The `Agent` constructor takes a single configuration object. The most commonly‑used
 properties are shown below.
 
-| Property                          | Required | Description                                                                                                                                  |
-| --------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                            | yes      | A short human‑readable identifier.                                                                                                           |
-| `instructions`                    | yes      | System prompt (string **or** function – see [Dynamic instructions](#dynamic-instructions)).                                                  |
-| `prompt`                          | no       | OpenAI Responses API prompt configuration. See [Prompt](/openai-agents-js/guides/models#prompt).                                             |
-| `handoffDescription`              | no       | Short description used when this agent is offered as a handoff tool.                                                                         |
-| `model`                           | no       | Model name **or** a custom [`Model`](/openai-agents-js/openai/agents/interfaces/model/) implementation.                                      |
-| `modelSettings`                   | no       | Tuning parameters (temperature, top_p, etc.). If the properties you need aren’t at the top level, you can include them under `providerData`. |
-| `tools`                           | no       | Array of [`Tool`](/openai-agents-js/openai/agents/type-aliases/tool/) instances the model can call.                                          |
-| `mcpServers`                      | no       | MCP servers that provide tools to the agent. See the [MCP guide](/openai-agents-js/guides/mcp).                                              |
-| `resetToolChoice`                 | no       | Reset `toolChoice` to the default after a tool call (default: `true`) to prevent tool-use loops. See [Forcing tool use](#forcing-tool-use).  |
-| `handoffOutputTypeWarningEnabled` | no       | Emit a warning when handoff output types differ (default: `true`).                                                                           |
+| Property                          | Required | Description                                                                                                                                    |
+| --------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                            | yes      | A short human‑readable identifier.                                                                                                             |
+| `instructions`                    | yes      | System prompt (string **or** function – see [Dynamic instructions](#dynamic-instructions)).                                                    |
+| `prompt`                          | no       | OpenAI Responses API prompt configuration. Accepts a static prompt object or a function. See [Prompt](/openai-agents-js/guides/models#prompt). |
+| `handoffDescription`              | no       | Short description used when this agent is offered as a handoff tool.                                                                           |
+| `model`                           | no       | Model name **or** a custom [`Model`](/openai-agents-js/openai/agents/interfaces/model/) implementation.                                        |
+| `modelSettings`                   | no       | Tuning parameters (temperature, top_p, etc.). If the properties you need aren’t at the top level, you can include them under `providerData`.   |
+| `tools`                           | no       | Array of [`Tool`](/openai-agents-js/openai/agents/type-aliases/tool/) instances the model can call.                                            |
+| `mcpServers`                      | no       | MCP servers that provide tools to the agent. See the [MCP guide](/openai-agents-js/guides/mcp).                                                |
+| `resetToolChoice`                 | no       | Reset `toolChoice` to the default after a tool call (default: `true`) to prevent tool-use loops. See [Forcing tool use](#forcing-tool-use).    |
+| `handoffOutputTypeWarningEnabled` | no       | Emit a warning when handoff output types differ (default: `true`).                                                                             |
 
 <Code lang="typescript" code={agentWithTools} title="Agent with tools" />
 
@@ -108,6 +109,12 @@ With handoffs the triage agent routes requests, but once a handoff occurs the sp
 
 <Code lang="typescript" code={agentWithHandoffs} title="Agent with handoffs" />
 
+If your handoff targets can return different output types, prefer `Agent.create(...)` over
+`new Agent(...)`. That lets TypeScript infer the union of possible `finalOutput` shapes across the
+handoff graph and avoids the runtime warning controlled by
+`handoffOutputTypeWarningEnabled`. See the [results guide](/openai-agents-js/guides/results#final-output)
+for an end-to-end example.
+
 ---
 
 ## Advanced configuration and runtime controls
@@ -124,6 +131,23 @@ With handoffs the triage agent routes requests, but once a handoff occurs the sp
 />
 
 Both synchronous and `async` functions are supported.
+
+---
+
+### Dynamic prompts
+
+`prompt` supports the same callback shape as `instructions`, but returns a prompt configuration
+object instead of a string. This is useful when the prompt ID, version, or variables depend on the
+current run context.
+
+<Code
+  lang="typescript"
+  code={agentWithDynamicPrompt}
+  title="Agent with dynamic prompt"
+/>
+
+This is only supported when you use the OpenAI Responses API. Both synchronous and `async`
+functions are supported.
 
 ---
 

--- a/docs/src/content/docs/guides/models.mdx
+++ b/docs/src/content/docs/guides/models.mdx
@@ -159,6 +159,9 @@ prompt configuration that should be used to control the Agent's behavior. Curren
 this option is only supported when you use the OpenAI
 [Responses API](https://platform.openai.com/docs/api-reference/responses).
 
+`prompt` can be either a static object or a function that returns one at runtime. For the callback
+shape, see [Dynamic prompts](/openai-agents-js/guides/agents#dynamic-prompts).
+
 | Field       | Type     | Notes                                                                                                                                  |
 | ----------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `promptId`  | `string` | Unique identifier for a prompt.                                                                                                        |

--- a/docs/src/content/docs/guides/running-agents.mdx
+++ b/docs/src/content/docs/guides/running-agents.mdx
@@ -174,6 +174,19 @@ Use `callModelInputFilter` to edit the model input _right before_ the model is c
 
 Set it per run in `runner.run(..., { callModelInputFilter })` or as a default in the `Runner` config (`callModelInputFilter` in `RunConfig`).
 
+The return value must be a `ModelInputData` object: `{ input: AgentInputItem[], instructions? }`.
+The `input` field is required and must be an array. Returning any other shape throws a `UserError`.
+
+The SDK clones the prepared turn input before invoking the filter. If you are also using a
+`session`, the filtered clones are what get persisted, so redaction or truncation applied here is
+reflected in stored session history as well.
+
+With `conversationId` or `previousResponseId`, the hook runs on the prepared payload for the next
+Responses API call. Prior server-managed context is recovered by the API, so the filtered array for
+that call may already represent only the new turn delta rather than a full replay of earlier
+history. If you need to change how stored history and the current turn are merged before this final
+filter step, use `sessionInputCallback`.
+
 ### Tool error formatter
 
 Use `toolErrorFormatter` to customize approval-rejection messages that are sent back to the model when a tool call is rejected. This lets you return domain-specific wording (for example, compliance guidance) instead of the SDK default message.

--- a/docs/src/content/docs/guides/sessions.mdx
+++ b/docs/src/content/docs/guides/sessions.mdx
@@ -132,6 +132,11 @@ When you pass an array of `AgentInputItem`s as the run input, provide a `session
 For string inputs the runner merges history automatically, so the callback is optional. The callback
 only runs when your turn input is already an item array.
 
+If you are also using `conversationId` or `previousResponseId`, keep at least one new item from the
+current turn in the callback result. Those server-managed APIs depend on the current-turn delta. If
+the callback drops every new item, the SDK restores the original new inputs and logs a warning
+instead of sending an empty delta.
+
 ---
 
 ## Resumable runs
@@ -164,13 +169,13 @@ When you resume from a previous `RunState`, the new turn is appended to the same
 
 `OpenAIResponsesCompactionSession` constructor options:
 
-| Option                    | Type                                          | Notes                                                                                                    |
-| ------------------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `client`                  | `OpenAI`                                      | OpenAI client used for `responses.compact`.                                                              |
-| `underlyingSession`       | `Session`                                     | Backing session store to clear/rewrite with compacted items (must not be `OpenAIConversationsSession`).  |
-| `model`                   | `OpenAI.ResponsesModel`                       | Model used for compaction requests.                                                                      |
-| `compactionMode`          | `'auto' \| 'previous_response_id' \| 'input'` | Controls whether compaction uses server response chaining or local input items.                          |
-| `shouldTriggerCompaction` | `(context) => boolean \| Promise<boolean>`    | Custom trigger hook based on `responseId`, `compactionMode`, candidate items, and current session items. |
+| Option                    | Type                                          | Notes                                                                                                                                                 |
+| ------------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `client`                  | `OpenAI`                                      | OpenAI client used for `responses.compact`.                                                                                                           |
+| `underlyingSession`       | `Session`                                     | Backing session store to clear/rewrite with compacted items. Defaults to an in-memory session for demos and must not be `OpenAIConversationsSession`. |
+| `model`                   | `OpenAI.ResponsesModel`                       | Model used for compaction requests. Defaults to the SDK's current default OpenAI model.                                                               |
+| `compactionMode`          | `'auto' \| 'previous_response_id' \| 'input'` | Controls whether compaction uses server response chaining or local input items.                                                                       |
+| `shouldTriggerCompaction` | `(context) => boolean \| Promise<boolean>`    | Custom trigger hook based on `responseId`, `compactionMode`, candidate items, and current session items.                                              |
 
 `compactionMode: 'previous_response_id'` is useful when you are already chaining turns with
 Responses API response IDs. `compactionMode: 'input'` rebuilds compaction requests from the current

--- a/docs/src/content/docs/guides/voice-agents/build.mdx
+++ b/docs/src/content/docs/guides/voice-agents/build.mdx
@@ -156,6 +156,12 @@ If you define your tool with `needsApproval: true` the agent will emit a `tool_a
 
 By listening to this event you can show a UI to the user to approve or reject the tool call.
 
+Resolve the request with `await session.approve(request.approvalItem)` or
+`await session.reject(request.approvalItem)`. For function tools you can pass
+`{ alwaysApprove: true }` or `{ alwaysReject: true }` to reuse the same decision for repeated
+calls during the rest of the session. Hosted MCP approvals do not support sticky approve/reject;
+restrict those tools with the hosted MCP `allowedTools` configuration instead.
+
 <Code lang="typescript" code={toolApprovalEventExample} />
 
 <Aside type="note">

--- a/examples/docs/agents/agentWithDynamicPrompt.ts
+++ b/examples/docs/agents/agentWithDynamicPrompt.ts
@@ -1,0 +1,20 @@
+import { Agent, RunContext } from '@openai/agents';
+
+interface PromptContext {
+  customerTier: 'free' | 'pro';
+}
+
+function buildPrompt(runContext: RunContext<PromptContext>) {
+  return {
+    promptId: 'pmpt_support_agent',
+    version: '7',
+    variables: {
+      customer_tier: runContext.context.customerTier,
+    },
+  };
+}
+
+const agent = new Agent<PromptContext>({
+  name: 'Prompt-backed helper',
+  prompt: buildPrompt,
+});

--- a/examples/docs/voice-agents/toolApprovalEvent.ts
+++ b/examples/docs/voice-agents/toolApprovalEvent.ts
@@ -4,5 +4,5 @@ session.on('tool_approval_requested', (_context, _agent, request) => {
   // show a UI to the user to approve or reject the tool call
   // you can use the `session.approve(...)` or `session.reject(...)` methods to approve or reject the tool call
 
-  session.approve(request.approvalItem); // or session.reject(request.rawItem);
+  session.approve(request.approvalItem); // or session.reject(request.approvalItem);
 });


### PR DESCRIPTION
This pull request updates the SDK documentation for runtime behaviors that were already supported but not clearly explained in the English docs. It adds dynamic `prompt` callback guidance, clarifies when to use `Agent.create(...)` for mixed handoff output types, documents `callModelInputFilter` and `sessionInputCallback` behavior around persisted history and server-managed conversation deltas, and fills in the Realtime approval flow for `session.approve(...)` and `session.reject(...)`.
