### PR TITLE
docs: align agent and voice agent guides with current SDK behavior

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,13 @@
 {
   "singleQuote": true,
   "tabWidth": 2,
-  "useTabs": false
+  "useTabs": false,
+  "overrides": [
+    {
+      "files": ["*.md", "*.mdx"],
+      "options": {
+        "proseWrap": "never"
+      }
+    }
+  ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,7 @@ When working on OpenAI API or OpenAI platform integrations in this repo (Respons
 
 ### ExecPlans
 
-When writing complex features or significant refactors, use an ExecPlan (as described in PLANS.md) from design to implementation. Store each ExecPlan file in the repository root (top level) with a descriptive name.
-Call out potential backward compatibility or public API risks in your plan and confirm the approach when changes could impact package consumers.
+When writing complex features or significant refactors, use an ExecPlan (as described in PLANS.md) from design to implementation. Store each ExecPlan file in the repository root (top level) with a descriptive name. Call out potential backward compatibility or public API risks in your plan and confirm the approach when changes could impact package consumers.
 
 ## Project Structure Guide
 
@@ -159,6 +158,7 @@ See [this README](integration-tests/README.md) for details.
   pnpm lint
   ```
 - Code style follows `eslint.config.mjs` and Prettier defaults.
+- Markdown / MDX prose should not be manually hard-wrapped; keep paragraphs unwrapped and let Prettier formatting decide line breaks.
 - Comments must end with a period.
 
 #### Build Details
@@ -177,8 +177,7 @@ Before opening a pull request, always run `$changeset-validation` to ensure all 
 
 ### Utilities & Tips
 
-- `pnpm dev`:
-  Runs concurrent watch builds for all packages and starts the docs dev server.
+- `pnpm dev`: Runs concurrent watch builds for all packages and starts the docs dev server.
   ```bash
   pnpm dev
   ```

--- a/docs/src/content/docs/guides/agents.mdx
+++ b/docs/src/content/docs/guides/agents.mdx
@@ -16,18 +16,28 @@ import agentWithLifecycleHooks from '../../../../../examples/docs/agents/agentWi
 import agentCloning from '../../../../../examples/docs/agents/agentCloning.ts?raw';
 import agentForcingToolUse from '../../../../../examples/docs/agents/agentForcingToolUse.ts?raw';
 
-Agents are the main building‑block of the OpenAI Agents SDK. An **Agent** is a Large Language
-Model (LLM) that has been configured with:
+Agents are the main building‑block of the OpenAI Agents SDK. An **Agent** is a Large Language Model (LLM) that has been configured with:
 
-- **Instructions** – the system prompt that tells the model _who it is_ and _how it should
-  respond_.
+- **Instructions** – the system prompt that tells the model _who it is_ and _how it should respond_.
 - **Model** – which OpenAI model to call, plus any optional model tuning parameters.
 - **Tools** – a list of functions or APIs the LLM can invoke to accomplish a task.
 
 <Code lang="typescript" code={simpleAgent} title="Basic Agent definition" />
 
-> Use this page when you want to define or customize a single `Agent`. If you are deciding how
-> several agents should collaborate, read [Agent orchestration](/openai-agents-js/guides/multi-agent).
+> Use this page when you want to define or customize a single `Agent`. If you are deciding how several agents should collaborate, read [Agent orchestration](/openai-agents-js/guides/multi-agent).
+
+### Choose the next guide
+
+Use this page as the hub for agent definition. Jump out to the adjacent guide that matches the next decision you need to make.
+
+| If you want to... | Read next |
+| --- | --- |
+| Choose a model or configure stored prompts | [Models](/openai-agents-js/guides/models) |
+| Add capabilities to the agent | [Tools](/openai-agents-js/guides/tools) |
+| Decide between managers and handoffs | [Agent orchestration](/openai-agents-js/guides/multi-agent) |
+| Configure handoff behavior | [Handoffs](/openai-agents-js/guides/handoffs) |
+| Run turns, stream events, or manage state | [Running agents](/openai-agents-js/guides/running-agents) |
+| Inspect final output, run items, or resume | [Results](/openai-agents-js/guides/results) |
 
 The rest of this page walks through every Agent feature in more detail.
 
@@ -37,21 +47,25 @@ The rest of this page walks through every Agent feature in more detail.
 
 ### Basic configuration
 
-The `Agent` constructor takes a single configuration object. The most commonly‑used
-properties are shown below.
+The `Agent` constructor takes a single configuration object. The most commonly‑used properties are shown below.
 
-| Property                          | Required | Description                                                                                                                                    |
-| --------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                            | yes      | A short human‑readable identifier.                                                                                                             |
-| `instructions`                    | yes      | System prompt (string **or** function – see [Dynamic instructions](#dynamic-instructions)).                                                    |
-| `prompt`                          | no       | OpenAI Responses API prompt configuration. Accepts a static prompt object or a function. See [Prompt](/openai-agents-js/guides/models#prompt). |
-| `handoffDescription`              | no       | Short description used when this agent is offered as a handoff tool.                                                                           |
-| `model`                           | no       | Model name **or** a custom [`Model`](/openai-agents-js/openai/agents/interfaces/model/) implementation.                                        |
-| `modelSettings`                   | no       | Tuning parameters (temperature, top_p, etc.). If the properties you need aren’t at the top level, you can include them under `providerData`.   |
-| `tools`                           | no       | Array of [`Tool`](/openai-agents-js/openai/agents/type-aliases/tool/) instances the model can call.                                            |
-| `mcpServers`                      | no       | MCP servers that provide tools to the agent. See the [MCP guide](/openai-agents-js/guides/mcp).                                                |
-| `resetToolChoice`                 | no       | Reset `toolChoice` to the default after a tool call (default: `true`) to prevent tool-use loops. See [Forcing tool use](#forcing-tool-use).    |
-| `handoffOutputTypeWarningEnabled` | no       | Emit a warning when handoff output types differ (default: `true`).                                                                             |
+| Property | Required | Description |
+| --- | --- | --- |
+| `name` | yes | A short human‑readable identifier. |
+| `instructions` | yes | System prompt (string **or** function – see [Dynamic instructions](#dynamic-instructions)). |
+| `prompt` | no | OpenAI Responses API prompt configuration. Accepts a static prompt object or a function. See [Prompt](/openai-agents-js/guides/models#prompt). |
+| `handoffDescription` | no | Short description used when this agent is offered as a handoff tool. |
+| `handoffs` | no | Delegate the conversation to specialist agents. See [Composition patterns](#composition-patterns) and the [Handoffs guide](/openai-agents-js/guides/handoffs). |
+| `model` | no | Model name **or** a custom [`Model`](/openai-agents-js/openai/agents/interfaces/model/) implementation. |
+| `modelSettings` | no | Tuning parameters (temperature, top_p, etc.). See [Models](/openai-agents-js/guides/models#modelsettings). If the properties you need aren’t at the top level, you can include them under `providerData`. |
+| `tools` | no | Array of [`Tool`](/openai-agents-js/openai/agents/type-aliases/tool/) instances the model can call. See [Tools](/openai-agents-js/guides/tools). |
+| `mcpServers` | no | MCP-backed tools for the agent. See the [MCP guide](/openai-agents-js/guides/mcp). |
+| `inputGuardrails` | no | Guardrails applied to the first user input for this agent chain. See [Guardrails](/openai-agents-js/guides/guardrails). |
+| `outputGuardrails` | no | Guardrails applied to the final output for this agent. See [Guardrails](/openai-agents-js/guides/guardrails). |
+| `outputType` | no | Return structured output instead of plain text. See [Output types](#output-types) and [Results](/openai-agents-js/guides/results#final-output). |
+| `toolUseBehavior` | no | Control whether function-tool results loop back to the model or finish the run. See [Forcing tool use](#forcing-tool-use). |
+| `resetToolChoice` | no | Reset `toolChoice` to the default after a tool call (default: `true`) to prevent tool-use loops. See [Forcing tool use](#forcing-tool-use). |
+| `handoffOutputTypeWarningEnabled` | no | Emit a warning when handoff output types differ (default: `true`). See [Results](/openai-agents-js/guides/results#final-output). |
 
 <Code lang="typescript" code={agentWithTools} title="Agent with tools" />
 
@@ -59,10 +73,7 @@ properties are shown below.
 
 ### Context
 
-Agents are **generic on their context type** – i.e. `Agent<TContext, TOutput>`. The _context_
-is a dependency‑injection object that you create and pass to `Runner.run()`. It is forwarded to
-every tool, guardrail, handoff, etc. and is useful for storing state or providing shared
-services (database connections, user metadata, feature flags, …).
+Agents are **generic on their context type** – i.e. `Agent<TContext, TOutput>`. The _context_ is a dependency‑injection object that you create and pass to `Runner.run()`. It is forwarded to every tool, guardrail, handoff, etc. and is useful for storing state or providing shared services (database connections, user metadata, feature flags, …).
 
 <Code lang="typescript" code={agentWithContext} title="Agent with context" />
 
@@ -70,8 +81,7 @@ services (database connections, user metadata, feature flags, …).
 
 ### Output types
 
-By default, an Agent returns **plain text** (`string`). If you want the model to return a
-structured object you can specify the `outputType` property. The SDK accepts:
+By default, an Agent returns **plain text** (`string`). If you want the model to return a structured object you can specify the `outputType` property. The SDK accepts:
 
 1. A [Zod](https://github.com/colinhacks/zod) schema (`z.object({...})`).
 2. Any JSON‑schema‑compatible object.
@@ -82,13 +92,25 @@ structured object you can specify the `outputType` property. The SDK accepts:
   title="Structured output with Zod"
 />
 
-When `outputType` is provided, the SDK automatically uses
-[structured outputs](https://platform.openai.com/docs/guides/structured-outputs) instead of
-plain text.
+When `outputType` is provided, the SDK automatically uses [structured outputs](https://developers.openai.com/api/docs/guides/structured-outputs) instead of plain text.
 
 ---
 
-## Agents in multi-agent systems
+### OpenAI platform mapping
+
+Some agent concepts map directly to OpenAI platform concepts, while others are configured when you run the agent rather than when you define it.
+
+| SDK concept | OpenAI guide | When it matters |
+| --- | --- | --- |
+| `outputType` | [Structured Outputs](https://developers.openai.com/api/docs/guides/structured-outputs) | The agent should return typed JSON or a Zod-validated object instead of text. |
+| `tools` / hosted tools | [Tools guide](https://developers.openai.com/api/docs/guides/tools) | The model should search, retrieve, execute code, or call your functions/tools. |
+| `conversationId` / `previousResponseId` | [Conversation state](https://developers.openai.com/api/docs/guides/conversation-state) | You want OpenAI to persist or chain conversation state between turns. |
+
+`conversationId` and `previousResponseId` are run-time controls, not `Agent` constructor fields. Use [Running agents](/openai-agents-js/guides/running-agents) when you need those SDK entry points.
+
+---
+
+## Composition patterns
 
 Two SDK entry points show up most often when an agent participates in a larger workflow:
 
@@ -109,11 +131,7 @@ With handoffs the triage agent routes requests, but once a handoff occurs the sp
 
 <Code lang="typescript" code={agentWithHandoffs} title="Agent with handoffs" />
 
-If your handoff targets can return different output types, prefer `Agent.create(...)` over
-`new Agent(...)`. That lets TypeScript infer the union of possible `finalOutput` shapes across the
-handoff graph and avoids the runtime warning controlled by
-`handoffOutputTypeWarningEnabled`. See the [results guide](/openai-agents-js/guides/results#final-output)
-for an end-to-end example.
+If your handoff targets can return different output types, prefer `Agent.create(...)` over `new Agent(...)`. That lets TypeScript infer the union of possible `finalOutput` shapes across the handoff graph and avoids the runtime warning controlled by `handoffOutputTypeWarningEnabled`. See the [results guide](/openai-agents-js/guides/results#final-output) for an end-to-end example.
 
 ---
 
@@ -121,8 +139,7 @@ for an end-to-end example.
 
 ### Dynamic instructions
 
-`instructions` can be a **function** instead of a string. The function receives the current
-`RunContext` and the Agent instance and can return a string _or_ a `Promise<string>`.
+`instructions` can be a **function** instead of a string. The function receives the current `RunContext` and the Agent instance and can return a string _or_ a `Promise<string>`.
 
 <Code
   lang="typescript"
@@ -136,9 +153,7 @@ Both synchronous and `async` functions are supported.
 
 ### Dynamic prompts
 
-`prompt` supports the same callback shape as `instructions`, but returns a prompt configuration
-object instead of a string. This is useful when the prompt ID, version, or variables depend on the
-current run context.
+`prompt` supports the same callback shape as `instructions`, but returns a prompt configuration object instead of a string. This is useful when the prompt ID, version, or variables depend on the current run context.
 
 <Code
   lang="typescript"
@@ -146,8 +161,7 @@ current run context.
   title="Agent with dynamic prompt"
 />
 
-This is only supported when you use the OpenAI Responses API. Both synchronous and `async`
-functions are supported.
+This is only supported when you use the OpenAI Responses API. Both synchronous and `async` functions are supported.
 
 ---
 
@@ -155,19 +169,17 @@ functions are supported.
 
 For advanced use‑cases you can observe the Agent lifecycle by listening on events.
 
-`Agent` instances emit lifecycle events for that specific agent instance, while `Runner` emits the
-same event names as a single stream across the whole run. This is useful for multi-agent
-workflows where you want one place to observe handoffs and tool calls.
+`Agent` instances emit lifecycle events for that specific agent instance, while `Runner` emits the same event names as a single stream across the whole run. This is useful for multi-agent workflows where you want one place to observe handoffs and tool calls.
 
 The shared event names are:
 
-| Event              | Agent hook arguments                    | Runner hook arguments                          |
-| ------------------ | --------------------------------------- | ---------------------------------------------- |
-| `agent_start`      | `(context, agent, turnInput?)`          | `(context, agent, turnInput?)`                 |
-| `agent_end`        | `(context, output)`                     | `(context, agent, output)`                     |
-| `agent_handoff`    | `(context, nextAgent)`                  | `(context, fromAgent, toAgent)`                |
-| `agent_tool_start` | `(context, tool, { toolCall })`         | `(context, agent, tool, { toolCall })`         |
-| `agent_tool_end`   | `(context, tool, result, { toolCall })` | `(context, agent, tool, result, { toolCall })` |
+| Event | Agent hook arguments | Runner hook arguments |
+| --- | --- | --- |
+| `agent_start` | `(context, agent, turnInput?)` | `(context, agent, turnInput?)` |
+| `agent_end` | `(context, output)` | `(context, agent, output)` |
+| `agent_handoff` | `(context, nextAgent)` | `(context, fromAgent, toAgent)` |
+| `agent_tool_start` | `(context, tool, { toolCall })` | `(context, agent, tool, { toolCall })` |
+| `agent_tool_end` | `(context, tool, result, { toolCall })` | `(context, agent, tool, result, { toolCall })` |
 
 <Code
   lang="typescript"
@@ -179,16 +191,13 @@ The shared event names are:
 
 ### Guardrails
 
-Guardrails allow you to validate or transform user input and agent output. They are configured
-via the `inputGuardrails` and `outputGuardrails` arrays. See the
-[guardrails guide](/openai-agents-js/guides/guardrails) for details.
+Guardrails allow you to validate or transform user input and agent output. They are configured via the `inputGuardrails` and `outputGuardrails` arrays. See the [guardrails guide](/openai-agents-js/guides/guardrails) for details.
 
 ---
 
 ### Cloning / copying agents
 
-Need a slightly modified version of an existing agent? Use the `clone()` method, which returns
-an entirely new `Agent` instance.
+Need a slightly modified version of an existing agent? Use the `clone()` method, which returns an entirely new `Agent` instance.
 
 <Code lang="typescript" code={agentCloning} title="Cloning Agents" />
 
@@ -196,8 +205,7 @@ an entirely new `Agent` instance.
 
 ### Forcing tool use
 
-Supplying tools doesn’t guarantee the LLM will call one. You can **force** tool use with
-`modelSettings.toolChoice`:
+Supplying tools doesn’t guarantee the LLM will call one. You can **force** tool use with `modelSettings.toolChoice`:
 
 1. `'auto'` (default) – the LLM decides whether to use a tool.
 2. `'required'` – the LLM _must_ call a tool (it can choose which one).
@@ -208,10 +216,7 @@ Supplying tools doesn’t guarantee the LLM will call one. You can **force** too
 
 #### Preventing infinite loops
 
-After a tool call the SDK automatically resets `toolChoice` back to `'auto'`. This prevents
-the model from entering an infinite loop where it repeatedly tries to call the tool. You can
-override this behavior via the `resetToolChoice` flag or by configuring
-`toolUseBehavior`:
+After a tool call the SDK automatically resets `toolChoice` back to `'auto'`. This prevents the model from entering an infinite loop where it repeatedly tries to call the tool. You can override this behavior via the `resetToolChoice` flag or by configuring `toolUseBehavior`:
 
 - `'run_llm_again'` (default) – run the LLM again with the tool result.
 - `'stop_on_first_tool'` – treat the first tool result as the final answer.
@@ -229,8 +234,12 @@ Note: `toolUseBehavior` only applies to **function tools**. Hosted tools always 
 
 ---
 
-## Next steps
+## Related guides
 
-- Learn how to [run agents](/openai-agents-js/guides/running-agents).
-- Dive into [tools](/openai-agents-js/guides/tools), [guardrails](/openai-agents-js/guides/guardrails), and [models](/openai-agents-js/guides/models).
+- [Models](/openai-agents-js/guides/models) for model selection, stored prompts, and provider configuration.
+- [Tools](/openai-agents-js/guides/tools) for function tools, hosted tools, MCP, and `agent.asTool()`.
+- [Agent orchestration](/openai-agents-js/guides/multi-agent) for choosing between managers, handoffs, and code-driven orchestration.
+- [Handoffs](/openai-agents-js/guides/handoffs) for configuring specialist delegation.
+- [Running agents](/openai-agents-js/guides/running-agents) for executing turns, streaming, and conversation state.
+- [Results](/openai-agents-js/guides/results) for `finalOutput`, run items, and resume state.
 - Explore the full TypeDoc reference under **@openai/agents** in the sidebar.

--- a/docs/src/content/docs/guides/context.mdx
+++ b/docs/src/content/docs/guides/context.mdx
@@ -1,5 +1,5 @@
 ---
-title: Context management
+title: Context Management
 description: Learn how to provide local data via RunContext and expose context to the LLM
 ---
 

--- a/docs/src/content/docs/guides/handoffs.mdx
+++ b/docs/src/content/docs/guides/handoffs.mdx
@@ -14,6 +14,8 @@ Handoffs let an agent delegate part of a conversation to another agent. This is 
 
 Handoffs are represented as tools to the LLM. If you hand off to an agent called `Refund Agent`, the tool name would be `transfer_to_refund_agent`.
 
+> Read this page after [Agents](/openai-agents-js/guides/agents#composition-patterns) once you know the specialist should take over the conversation. If the specialist should stay behind the original agent, use [agents as tools](/openai-agents-js/guides/tools#4-agents-as-tools) instead.
+
 ## Creating a handoff
 
 Every agent accepts a `handoffs` option. It can contain other `Agent` instances or `Handoff` objects returned by the `handoff()` helper.
@@ -50,8 +52,7 @@ Sometimes you want the LLM to provide data when invoking a handoff. Define an in
 
 ## Input filters
 
-By default a handoff receives the entire conversation history. To modify what gets passed to the next agent, provide an `inputFilter`.
-Common helpers live in `@openai/agents-core/extensions`.
+By default a handoff receives the entire conversation history. To modify what gets passed to the next agent, provide an `inputFilter`. Common helpers live in `@openai/agents-core/extensions`.
 
 <Code lang="typescript" code={inputFilterExample} title="Input filters" />
 
@@ -64,3 +65,11 @@ LLMs respond more reliably when your prompts mention handoffs. The SDK exposes a
   code={recommendedPromptExample}
   title="Recommended prompts"
 />
+
+## Related guides
+
+- [Agents](/openai-agents-js/guides/agents#composition-patterns) for choosing between managers and handoffs.
+- [Agent orchestration](/openai-agents-js/guides/multi-agent) for the broader workflow tradeoffs.
+- [Tools](/openai-agents-js/guides/tools#4-agents-as-tools) for the manager-style alternative using `agent.asTool()`.
+- [Running agents](/openai-agents-js/guides/running-agents) for how handoffs behave at run time.
+- [Results](/openai-agents-js/guides/results#final-output) for typed `finalOutput` across handoff graphs.

--- a/docs/src/content/docs/guides/human-in-the-loop.mdx
+++ b/docs/src/content/docs/guides/human-in-the-loop.mdx
@@ -1,5 +1,5 @@
 ---
-title: Human in the loop
+title: Human-in-the-loop
 description: Add a human in the loop check for your agent executions
 ---
 

--- a/docs/src/content/docs/guides/multi-agent.md
+++ b/docs/src/content/docs/guides/multi-agent.md
@@ -1,11 +1,11 @@
 ---
-title: Agent orchestration
+title: Agent Orchestration
 description: Coordinate the flow between several agents
 ---
 
 Orchestration refers to the flow of agents in your app. Which agents run, in what order, and how do they decide what happens next? There are two main ways to orchestrate agents:
 
-> Read this page after the [Quickstart](/openai-agents-js/guides/quickstart) or [Agents](/openai-agents-js/guides/agents) guide. This page is about workflow design across multiple agents, not the `Agent` constructor itself.
+> Read this page after the [Quickstart](/openai-agents-js/guides/quickstart) or the [Agents guide](/openai-agents-js/guides/agents#composition-patterns). This page is about workflow design across multiple agents, not the `Agent` constructor itself.
 
 1. Allowing the LLM to make decisions: this uses the intelligence of an LLM to plan, reason, and decide on what steps to take based on that.
 2. Orchestrating via code: determining the flow of agents via your code.
@@ -26,10 +26,10 @@ An agent is an LLM equipped with instructions, tools and handoffs. This means th
 
 In the Agents SDK, two orchestration patterns come up most often:
 
-| Pattern         | How it works                                                                                                                   | Best when                                                                                                                         |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
-| Agents as tools | A manager agent keeps control of the conversation and calls specialist agents through `agent.asTool()`.                        | You want one agent to own the final answer, combine outputs from multiple specialists, or enforce shared guardrails in one place. |
-| Handoffs        | A triage agent routes the conversation to a specialist, and that specialist becomes the active agent for the rest of the turn. | You want the specialist to speak directly to the user, keep prompts focused, or use different instructions/models per specialist. |
+| Pattern | How it works | Best when |
+| --- | --- | --- |
+| Agents as tools | A manager agent keeps control of the conversation and calls specialist agents through `agent.asTool()`. | You want one agent to own the final answer, combine outputs from multiple specialists, or enforce shared guardrails in one place. |
+| Handoffs | A triage agent routes the conversation to a specialist, and that specialist becomes the active agent for the rest of the turn. | You want the specialist to speak directly to the user, keep prompts focused, or use different instructions/models per specialist. |
 
 Use **agents as tools** when the specialist should help with a subtask but should not take over the user-facing conversation. The manager stays responsible for deciding which tools to call and how to present the final response. See the [tools guide](/openai-agents-js/guides/tools#agents-as-tools) for the API details, and the [agents guide](/openai-agents-js/guides/agents#composition-patterns) for a side-by-side example.
 
@@ -51,7 +51,7 @@ If you want the SDK primitives behind this style of orchestration, start with [t
 
 While orchestrating via LLM is powerful, orchestrating via code makes tasks more deterministic and predictable, in terms of speed, cost and performance. Common patterns here are:
 
-- Using [structured outputs](https://platform.openai.com/docs/guides/structured-outputs) to generate well formed data that you can inspect with your code. For example, you might ask an agent to classify the task into a few categories, and then pick the next agent based on the category.
+- Using [structured outputs](https://developers.openai.com/api/docs/guides/structured-outputs) to generate well formed data that you can inspect with your code. For example, you might ask an agent to classify the task into a few categories, and then pick the next agent based on the category.
 - Chaining multiple agents by transforming the output of one into the input of the next. You can decompose a task like writing a blog post into a series of steps - do research, write an outline, write the blog post, critique it, and then improve it.
 - Running the agent that performs the task in a `while` loop with an agent that evaluates and provides feedback, until the evaluator says the output passes certain criteria.
 - Running multiple agents in parallel, e.g. via JavaScript primitives like `Promise.all`. This is useful for speed when you have multiple tasks that don't depend on each other.

--- a/docs/src/content/docs/guides/running-agents.mdx
+++ b/docs/src/content/docs/guides/running-agents.mdx
@@ -1,5 +1,5 @@
 ---
-title: Running agents
+title: Running Agents
 description: Configure and execute agent workflows with the Runner class
 ---
 
@@ -12,6 +12,8 @@ import conversationIdExample from '../../../../../examples/docs/running-agents/c
 import previousResponseIdExample from '../../../../../examples/docs/running-agents/previousResponseId.ts?raw';
 
 Agents do nothing by themselves – you **run** them with the `Runner` class or the `run()` utility.
+
+> Read this page after [Agents](/openai-agents-js/guides/agents) once you want to execute turns, stream events, or manage conversation state. If you are still deciding how the agent should be defined, start with [Agents](/openai-agents-js/guides/agents) first.
 
 <Code lang="typescript" code={helloWorldExample} title="Simple run" />
 
@@ -45,10 +47,7 @@ The runner then runs a loop:
 
 #### Runner lifecycle
 
-Create a `Runner` when your app starts and reuse it across requests. The instance
-stores global configuration such as model provider and tracing options. Only
-create another `Runner` if you need a completely different setup. For simple
-scripts you can also call `run()` which uses a default runner internally.
+Create a `Runner` when your app starts and reuse it across requests. The instance stores global configuration such as model provider and tracing options. Only create another `Runner` if you need a completely different setup. For simple scripts you can also call `run()` which uses a default runner internally.
 
 ### Run arguments
 
@@ -58,21 +57,21 @@ The input can either be a string (which is considered a user message), or a list
 
 The additional options are:
 
-| Option                  | Default | Description                                                                                                                                                                      |
-| ----------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `stream`                | `false` | If `true` the call returns a `StreamedRunResult` and emits events as they arrive from the model.                                                                                 |
-| `context`               | –       | Context object forwarded to every tool / guardrail / handoff. Learn more in the [context guide](/openai-agents-js/guides/context).                                               |
-| `maxTurns`              | `10`    | Safety limit – throws [`MaxTurnsExceededError`](/openai-agents-js/openai/agents-core/classes/maxturnsexceedederror) when reached.                                                |
-| `signal`                | –       | `AbortSignal` for cancellation.                                                                                                                                                  |
-| `session`               | –       | Session persistence implementation. See the [sessions guide](/openai-agents-js/guides/sessions).                                                                                 |
-| `sessionInputCallback`  | –       | Custom merge logic for session history and new input; runs before the model call. See [sessions](/openai-agents-js/guides/sessions).                                             |
-| `callModelInputFilter`  | –       | Hook to edit the model input (items + optional instructions) just before calling the model. See [Call model input filter](#call-model-input-filter).                             |
-| `toolErrorFormatter`    | –       | Hook to customize tool approval rejection messages returned to the model. See [Tool error formatter](#tool-error-formatter).                                                     |
-| `reasoningItemIdPolicy` | –       | Controls whether reasoning-item `id`s are preserved or omitted when prior run items are turned back into model input. See [Reasoning item ID policy](#reasoning-item-id-policy). |
-| `tracing`               | –       | Per-run tracing configuration overrides (for example, export API key).                                                                                                           |
-| `errorHandlers`         | –       | Handlers for supported runtime errors (currently `maxTurns`). See [Error handlers](#error-handlers).                                                                             |
-| `conversationId`        | –       | Reuse a server-side conversation (OpenAI Responses API + Conversations API only).                                                                                                |
-| `previousResponseId`    | –       | Continue from the previous Responses API call without creating a conversation (OpenAI Responses API only).                                                                       |
+| Option | Default | Description |
+| --- | --- | --- |
+| `stream` | `false` | If `true` the call returns a `StreamedRunResult` and emits events as they arrive from the model. |
+| `context` | – | Context object forwarded to every tool / guardrail / handoff. Learn more in the [context guide](/openai-agents-js/guides/context). |
+| `maxTurns` | `10` | Safety limit – throws [`MaxTurnsExceededError`](/openai-agents-js/openai/agents-core/classes/maxturnsexceedederror) when reached. |
+| `signal` | – | `AbortSignal` for cancellation. |
+| `session` | – | Session persistence implementation. See the [sessions guide](/openai-agents-js/guides/sessions). |
+| `sessionInputCallback` | – | Custom merge logic for session history and new input; runs before the model call. See [sessions](/openai-agents-js/guides/sessions). |
+| `callModelInputFilter` | – | Hook to edit the model input (items + optional instructions) just before calling the model. See [Call model input filter](#call-model-input-filter). |
+| `toolErrorFormatter` | – | Hook to customize tool approval rejection messages returned to the model. See [Tool error formatter](#tool-error-formatter). |
+| `reasoningItemIdPolicy` | – | Controls whether reasoning-item `id`s are preserved or omitted when prior run items are turned back into model input. See [Reasoning item ID policy](#reasoning-item-id-policy). |
+| `tracing` | – | Per-run tracing configuration overrides (for example, export API key). |
+| `errorHandlers` | – | Handlers for supported runtime errors (currently `maxTurns`). See [Error handlers](#error-handlers). |
+| `conversationId` | – | Reuse a server-side conversation (OpenAI Responses API + Conversations API only). |
+| `previousResponseId` | – | Continue from the previous Responses API call without creating a conversation (OpenAI Responses API only). |
 
 ### Streaming
 
@@ -82,24 +81,24 @@ Streaming allows you to additionally receive streaming events as the LLM runs. O
 
 If you are creating your own `Runner` instance, you can pass in a `RunConfig` object to configure the runner.
 
-| Field                       | Type                     | Purpose                                                                                                               |
-| --------------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------- |
-| `model`                     | `string \| Model`        | Force a specific model for **all** agents in the run.                                                                 |
-| `modelProvider`             | `ModelProvider`          | Resolves model names – defaults to the OpenAI provider.                                                               |
-| `modelSettings`             | `ModelSettings`          | Global tuning parameters that override per‑agent settings.                                                            |
-| `handoffInputFilter`        | `HandoffInputFilter`     | Mutates input items when performing handoffs (if the handoff itself doesn’t already define one).                      |
-| `inputGuardrails`           | `InputGuardrail[]`       | Guardrails applied to the _initial_ user input.                                                                       |
-| `outputGuardrails`          | `OutputGuardrail[]`      | Guardrails applied to the _final_ output.                                                                             |
-| `tracingDisabled`           | `boolean`                | Disable OpenAI Tracing completely.                                                                                    |
-| `traceIncludeSensitiveData` | `boolean`                | Exclude LLM/tool inputs & outputs from traces while still emitting spans.                                             |
-| `workflowName`              | `string`                 | Appears in the Traces dashboard – helps group related runs.                                                           |
-| `traceId` / `groupId`       | `string`                 | Manually specify the trace or group ID instead of letting the SDK generate one.                                       |
-| `traceMetadata`             | `Record<string, string>` | Arbitrary metadata to attach to every span.                                                                           |
-| `tracing`                   | `TracingConfig`          | Per-run tracing overrides (for example, export API key).                                                              |
-| `sessionInputCallback`      | `SessionInputCallback`   | Default history merge strategy for all runs on this runner.                                                           |
-| `callModelInputFilter`      | `CallModelInputFilter`   | Global hook to edit model inputs before each model call.                                                              |
-| `toolErrorFormatter`        | `ToolErrorFormatter`     | Global hook to customize tool approval rejection messages returned to the model.                                      |
-| `reasoningItemIdPolicy`     | `ReasoningItemIdPolicy`  | Default policy for preserving or omitting reasoning-item `id`s when replaying generated items into later model calls. |
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `model` | `string \| Model` | Force a specific model for **all** agents in the run. |
+| `modelProvider` | `ModelProvider` | Resolves model names – defaults to the OpenAI provider. |
+| `modelSettings` | `ModelSettings` | Global tuning parameters that override per‑agent settings. |
+| `handoffInputFilter` | `HandoffInputFilter` | Mutates input items when performing handoffs (if the handoff itself doesn’t already define one). |
+| `inputGuardrails` | `InputGuardrail[]` | Guardrails applied to the _initial_ user input. |
+| `outputGuardrails` | `OutputGuardrail[]` | Guardrails applied to the _final_ output. |
+| `tracingDisabled` | `boolean` | Disable OpenAI Tracing completely. |
+| `traceIncludeSensitiveData` | `boolean` | Exclude LLM/tool inputs & outputs from traces while still emitting spans. |
+| `workflowName` | `string` | Appears in the Traces dashboard – helps group related runs. |
+| `traceId` / `groupId` | `string` | Manually specify the trace or group ID instead of letting the SDK generate one. |
+| `traceMetadata` | `Record<string, string>` | Arbitrary metadata to attach to every span. |
+| `tracing` | `TracingConfig` | Per-run tracing overrides (for example, export API key). |
+| `sessionInputCallback` | `SessionInputCallback` | Default history merge strategy for all runs on this runner. |
+| `callModelInputFilter` | `CallModelInputFilter` | Global hook to edit model inputs before each model call. |
+| `toolErrorFormatter` | `ToolErrorFormatter` | Global hook to customize tool approval rejection messages returned to the model. |
+| `reasoningItemIdPolicy` | `ReasoningItemIdPolicy` | Default policy for preserving or omitting reasoning-item `id`s when replaying generated items into later model calls. |
 
 ## State and conversation management
 
@@ -107,17 +106,14 @@ If you are creating your own `Runner` instance, you can pass in a `RunConfig` ob
 
 There are four common ways to carry state into the next turn:
 
-| Strategy             | Where state lives         | Best for                                                                 | What you pass on the next turn                        |
-| -------------------- | ------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------- |
-| `result.history`     | Your app memory           | Small chat loops, full manual control, any provider                      | `result.history`                                      |
-| `session`            | Your storage + the SDK    | Persistent chat state, resumable runs, custom stores                     | The same `session` instance (or a store-backed one)   |
-| `conversationId`     | OpenAI Conversations API  | Shared server-side state across workers/services                         | The same `conversationId` plus only the new user turn |
-| `previousResponseId` | OpenAI Responses API only | The simplest server-managed continuation without creating a conversation | `result.lastResponseId` plus only the new user turn   |
+| Strategy | Where state lives | Best for | What you pass on the next turn |
+| --- | --- | --- | --- |
+| `result.history` | Your app memory | Small chat loops, full manual control, any provider | `result.history` |
+| `session` | Your storage + the SDK | Persistent chat state, resumable runs, custom stores | The same `session` instance (or a store-backed one) |
+| `conversationId` | OpenAI Conversations API | Shared server-side state across workers/services | The same `conversationId` plus only the new user turn |
+| `previousResponseId` | OpenAI Responses API only | The simplest server-managed continuation without creating a conversation | `result.lastResponseId` plus only the new user turn |
 
-`result.history` and `session` are client-managed. `conversationId` and `previousResponseId` are
-OpenAI-managed and only apply when you are using the OpenAI Responses API. In most applications,
-pick one persistence strategy per conversation. Mixing client-managed history with server-managed
-state can duplicate context unless you are deliberately reconciling both layers.
+`result.history` and `session` are client-managed. `conversationId` and `previousResponseId` are OpenAI-managed and only apply when you are using the OpenAI Responses API. In most applications, pick one persistence strategy per conversation. Mixing client-managed history with server-managed state can duplicate context unless you are deliberately reconciling both layers.
 
 ### Conversations / chat threads
 
@@ -133,12 +129,7 @@ See [the chat example](https://github.com/openai/openai-agents-js/tree/main/exam
 
 #### Server-managed conversations
 
-You can let the OpenAI Responses API persist conversation history for you instead of sending your
-entire local conversation history on every turn. This is useful when you are coordinating long conversations
-or multiple services. With either server-managed approach below, pass only the new turn's input on
-each request. The API reuses prior state for you. See the
-[Conversation state guide](https://platform.openai.com/docs/guides/conversation-state?api-mode=responses)
-for details.
+You can let the OpenAI Responses API persist conversation history for you instead of sending your entire local conversation history on every turn. This is useful when you are coordinating long conversations or multiple services. With either server-managed approach below, pass only the new turn's input on each request. The API reuses prior state for you. See the [Conversation state guide](https://developers.openai.com/api/docs/guides/conversation-state) for details.
 
 OpenAI exposes two ways to reuse server-side state:
 
@@ -162,9 +153,7 @@ If you want to start only with Responses API anyway, you can chain each request 
   title="Chaining with previousResponseId"
 />
 
-`conversationId` and `previousResponseId` are mutually exclusive. Use `conversationId` when you
-want a named conversation resource you can share across systems, and `previousResponseId` when you
-just want the cheapest SDK-level continuation primitive from one response to the next.
+`conversationId` and `previousResponseId` are mutually exclusive. Use `conversationId` when you want a named conversation resource you can share across systems, and `previousResponseId` when you just want the cheapest SDK-level continuation primitive from one response to the next.
 
 ## Hooks and customization
 
@@ -174,18 +163,11 @@ Use `callModelInputFilter` to edit the model input _right before_ the model is c
 
 Set it per run in `runner.run(..., { callModelInputFilter })` or as a default in the `Runner` config (`callModelInputFilter` in `RunConfig`).
 
-The return value must be a `ModelInputData` object: `{ input: AgentInputItem[], instructions? }`.
-The `input` field is required and must be an array. Returning any other shape throws a `UserError`.
+The return value must be a `ModelInputData` object: `{ input: AgentInputItem[], instructions? }`. The `input` field is required and must be an array. Returning any other shape throws a `UserError`.
 
-The SDK clones the prepared turn input before invoking the filter. If you are also using a
-`session`, the filtered clones are what get persisted, so redaction or truncation applied here is
-reflected in stored session history as well.
+The SDK clones the prepared turn input before invoking the filter. If you are also using a `session`, the filtered clones are what get persisted, so redaction or truncation applied here is reflected in stored session history as well.
 
-With `conversationId` or `previousResponseId`, the hook runs on the prepared payload for the next
-Responses API call. Prior server-managed context is recovered by the API, so the filtered array for
-that call may already represent only the new turn delta rather than a full replay of earlier
-history. If you need to change how stored history and the current turn are merged before this final
-filter step, use `sessionInputCallback`.
+With `conversationId` or `previousResponseId`, the hook runs on the prepared payload for the next Responses API call. Prior server-managed context is recovered by the API, so the filtered array for that call may already represent only the new turn delta rather than a full replay of earlier history. If you need to change how stored history and the current turn are merged before this final filter step, use `sessionInputCallback`.
 
 ### Tool error formatter
 
@@ -289,8 +271,11 @@ Output guardrail tripped after retry with saved state
 
 ---
 
-## Next steps
+## Related guides
 
-- Learn how to [configure models](/openai-agents-js/guides/models).
-- Provide your agents with [tools](/openai-agents-js/guides/tools).
+- [Agents](/openai-agents-js/guides/agents) for defining the agent before you run it.
+- [Results](/openai-agents-js/guides/results) for `finalOutput`, run items, interruptions, and resume state.
+- [Sessions](/openai-agents-js/guides/sessions) for persistent SDK-managed memory.
+- [Tools](/openai-agents-js/guides/tools) for the capabilities used during the run loop.
+- [Models](/openai-agents-js/guides/models) for provider configuration and Responses transport.
 - Add [guardrails](/openai-agents-js/guides/guardrails) or [tracing](/openai-agents-js/guides/tracing) for production readiness.

--- a/docs/src/content/docs/guides/tools.mdx
+++ b/docs/src/content/docs/guides/tools.mdx
@@ -15,8 +15,9 @@ import mcpLocalServer from '../../../../../examples/docs/tools/mcpLocalServer.ts
 import codexToolExample from '../../../../../examples/docs/tools/codexTool.ts?raw';
 import codexRunContextThreadExample from '../../../../../examples/docs/tools/codexRunContextThread.ts?raw';
 
-Tools let an Agent **take actions** – fetch data, call external APIs, execute code, or even use a
-computer. The JavaScript/TypeScript SDK supports six categories:
+Tools let an Agent **take actions** – fetch data, call external APIs, execute code, or even use a computer. The JavaScript/TypeScript SDK supports six categories:
+
+> Read this page after [Agents](/openai-agents-js/guides/agents) once you know which agent should own the task and you want to give it capabilities. If you are still deciding between delegation patterns, see [Agent orchestration](/openai-agents-js/guides/multi-agent).
 
 1. **Hosted OpenAI tools** – run alongside the model on OpenAI servers. _(web search, file search, code interpreter, image generation)_
 2. **Built-in execution tools** – SDK-provided tools that execute outside the model. _(computer use and apply_patch run locally; shell can run locally or in hosted containers)_
@@ -29,34 +30,31 @@ computer. The JavaScript/TypeScript SDK supports six categories:
 
 ## Tool categories
 
-The rest of this guide first covers each tool category, then summarizes cross-cutting tool
-selection and prompting guidance.
+The rest of this guide first covers each tool category, then summarizes cross-cutting tool selection and prompting guidance.
 
 ### 1. Hosted tools (OpenAI Responses API)
 
 When you use the `OpenAIResponsesModel` you can add the following built‑in tools:
 
-| Tool                    | Type string          | Purpose                               |
-| ----------------------- | -------------------- | ------------------------------------- |
-| Web search              | `'web_search'`       | Internet search.                      |
-| File / retrieval search | `'file_search'`      | Query vector stores hosted on OpenAI. |
-| Code Interpreter        | `'code_interpreter'` | Run code in a sandboxed environment.  |
-| Image generation        | `'image_generation'` | Generate images based on text.        |
+| Tool | Type string | Purpose |
+| --- | --- | --- |
+| Web search | `'web_search'` | Internet search. |
+| File / retrieval search | `'file_search'` | Query vector stores hosted on OpenAI. |
+| Code Interpreter | `'code_interpreter'` | Run code in a sandboxed environment. |
+| Image generation | `'image_generation'` | Generate images based on text. |
 
 <Code lang="typescript" code={toolsHostedToolsExample} title="Hosted tools" />
 
 The SDK provides helper functions that return hosted tool definitions:
 
-| Helper function                 | Notes                                                                                                                                                                                               |
-| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `webSearchTool(options?)`       | JS-friendly options such as `searchContextSize`, `userLocation`, and `filters.allowedDomains`.                                                                                                      |
-| `fileSearchTool(ids, options?)` | Accepts one or more vector store IDs as the first argument, plus options like `maxNumResults`, `includeSearchResults`, `rankingOptions`, and filters.                                               |
-| `codeInterpreterTool(options?)` | Defaults to an auto-managed container when no `container` is provided.                                                                                                                              |
+| Helper function | Notes |
+| --- | --- |
+| `webSearchTool(options?)` | JS-friendly options such as `searchContextSize`, `userLocation`, and `filters.allowedDomains`. |
+| `fileSearchTool(ids, options?)` | Accepts one or more vector store IDs as the first argument, plus options like `maxNumResults`, `includeSearchResults`, `rankingOptions`, and filters. |
+| `codeInterpreterTool(options?)` | Defaults to an auto-managed container when no `container` is provided. |
 | `imageGenerationTool(options?)` | Supports image generation configuration such as `model`, `size`, `quality`, `background`, `inputFidelity`, `inputImageMask`, `moderation`, `outputCompression`, `partialImages`, and output format. |
 
-These helpers map JavaScript/TypeScript-friendly option names to the underlying OpenAI Responses API tool
-payloads. Refer to the official OpenAI documentation for the full tool schemas and advanced options like
-ranking options or semantic filters.
+These helpers map JavaScript/TypeScript-friendly option names to the underlying OpenAI Responses API tool payloads. Refer to the official [OpenAI tools guide](https://developers.openai.com/api/docs/guides/tools) for the full tool schemas and advanced options like ranking options or semantic filters.
 
 ---
 
@@ -68,8 +66,7 @@ These tools are built into the SDK, but execution happens outside the model resp
 - **Shell** – either provide a local `Shell` implementation, or configure a hosted container environment with `shellTool({ environment })`.
 - **Apply patch** – implement the `Editor` interface and pass it to `applyPatchTool()`. This always runs against a local `Editor` implementation that you provide.
 
-The tool calls are still requested by the model, but your application or configured execution
-environment performs the work.
+The tool calls are still requested by the model, but your application or configured execution environment performs the work.
 
 <Code
   lang="typescript"
@@ -85,8 +82,7 @@ environment performs the work.
 - An initializer function that creates a `Computer` per run.
 - A provider object with `{ create, dispose }` when you need run-scoped setup and teardown.
 
-Use `needsApproval` when computer actions should pause for user review, and `onSafetyCheck` when
-you want to acknowledge or reject pending safety checks raised during a computer action.
+Use `needsApproval` when computer actions should pause for user review, and `onSafetyCheck` when you want to acknowledge or reject pending safety checks raised during a computer action.
 
 #### Shell tool specifics
 
@@ -109,16 +105,13 @@ Hosted `container_auto` environments support:
 - `memoryLimit` for container sizing.
 - `skills`, either by `skill_reference` or inline zip bundles.
 
-Hosted shell environments do not accept `shell`, `needsApproval`, or `onApproval`, because the
-execution happens in the hosted container environment instead of your local process.
+Hosted shell environments do not accept `shell`, `needsApproval`, or `onApproval`, because the execution happens in the hosted container environment instead of your local process.
 
-See `examples/tools/local-shell.ts`, `examples/tools/container-shell-skill-ref.ts`, and
-`examples/tools/container-shell-inline-skill.ts` for end-to-end usage.
+See `examples/tools/local-shell.ts`, `examples/tools/container-shell-skill-ref.ts`, and `examples/tools/container-shell-inline-skill.ts` for end-to-end usage.
 
 #### Apply-patch tool specifics
 
-`applyPatchTool()` mirrors the local approval flow from `shellTool()`: use `needsApproval` to pause
-before file edits and `onApproval` when you want an app-level callback to auto-approve or reject.
+`applyPatchTool()` mirrors the local approval flow from `shellTool()`: use `needsApproval` to pause before file edits and `onApproval` when you want an app-level callback to auto-approve or reject.
 
 ---
 
@@ -134,21 +127,21 @@ You can turn **any** function into a tool with the `tool()` helper.
 
 #### Options reference
 
-| Field                  | Required | Description                                                                                                                                                                                                                                           |
-| ---------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                 | No       | Defaults to the function name (e.g., `get_weather`).                                                                                                                                                                                                  |
-| `description`          | Yes      | Clear, human-readable description shown to the LLM.                                                                                                                                                                                                   |
-| `parameters`           | Yes      | Either a Zod schema or a raw JSON schema object. Zod parameters automatically enable **strict** mode.                                                                                                                                                 |
-| `strict`               | No       | When `true` (default), the SDK returns a model error if the arguments don't validate. Set to `false` for fuzzy matching.                                                                                                                              |
-| `execute`              | Yes      | `(args, context, details) => string \| unknown \| Promise<...>` – your business logic. Non-string outputs are serialized for the model. `context` is optional `RunContext`; `details` includes metadata like `toolCall`, `resumeState`, and `signal`. |
-| `errorFunction`        | No       | Custom handler `(context, error) => string` for transforming internal errors into a user-visible string.                                                                                                                                              |
-| `timeoutMs`            | No       | Per-call timeout in milliseconds. Must be greater than 0 and less than or equal to `2147483647`.                                                                                                                                                      |
-| `timeoutBehavior`      | No       | Timeout mode: `error_as_result` (default) returns a model-visible timeout message, and `raise_exception` throws `ToolTimeoutError`.                                                                                                                   |
-| `timeoutErrorFunction` | No       | Custom handler `(context, timeoutError) => string` for timeout output when `timeoutBehavior` is `error_as_result`.                                                                                                                                    |
-| `needsApproval`        | No       | Require human approval before execution. See the [human-in-the-loop guide](/openai-agents-js/guides/human-in-the-loop).                                                                                                                               |
-| `isEnabled`            | No       | Conditionally expose the tool per run; accepts a boolean or predicate.                                                                                                                                                                                |
-| `inputGuardrails`      | No       | Guardrails that run before the tool executes; can reject or throw. See [Guardrails](/openai-agents-js/guides/guardrails#tool-guardrails).                                                                                                             |
-| `outputGuardrails`     | No       | Guardrails that run after the tool executes; can reject or throw. See [Guardrails](/openai-agents-js/guides/guardrails#tool-guardrails).                                                                                                              |
+| Field | Required | Description |
+| --- | --- | --- |
+| `name` | No | Defaults to the function name (e.g., `get_weather`). |
+| `description` | Yes | Clear, human-readable description shown to the LLM. |
+| `parameters` | Yes | Either a Zod schema or a raw JSON schema object. Zod parameters automatically enable **strict** mode. |
+| `strict` | No | When `true` (default), the SDK returns a model error if the arguments don't validate. Set to `false` for fuzzy matching. |
+| `execute` | Yes | `(args, context, details) => string \| unknown \| Promise<...>` – your business logic. Non-string outputs are serialized for the model. `context` is optional `RunContext`; `details` includes metadata like `toolCall`, `resumeState`, and `signal`. |
+| `errorFunction` | No | Custom handler `(context, error) => string` for transforming internal errors into a user-visible string. |
+| `timeoutMs` | No | Per-call timeout in milliseconds. Must be greater than 0 and less than or equal to `2147483647`. |
+| `timeoutBehavior` | No | Timeout mode: `error_as_result` (default) returns a model-visible timeout message, and `raise_exception` throws `ToolTimeoutError`. |
+| `timeoutErrorFunction` | No | Custom handler `(context, timeoutError) => string` for timeout output when `timeoutBehavior` is `error_as_result`. |
+| `needsApproval` | No | Require human approval before execution. See the [human-in-the-loop guide](/openai-agents-js/guides/human-in-the-loop). |
+| `isEnabled` | No | Conditionally expose the tool per run; accepts a boolean or predicate. |
+| `inputGuardrails` | No | Guardrails that run before the tool executes; can reject or throw. See [Guardrails](/openai-agents-js/guides/guardrails#tool-guardrails). |
+| `outputGuardrails` | No | Guardrails that run after the tool executes; can reject or throw. See [Guardrails](/openai-agents-js/guides/guardrails#tool-guardrails). |
 
 #### Function tool timeouts
 
@@ -163,8 +156,7 @@ If you invoke a function tool directly, use [`invokeFunctionTool`](/openai-agent
 
 #### Non‑strict JSON‑schema tools
 
-If you need the model to _guess_ invalid or partial input you can disable strict mode when using
-raw JSON schema:
+If you need the model to _guess_ invalid or partial input you can disable strict mode when using raw JSON schema:
 
 <Code
   lang="typescript"
@@ -177,6 +169,8 @@ raw JSON schema:
 ### 4. Agents as tools
 
 Sometimes you want an Agent to _assist_ another Agent without fully handing off the conversation. Use `agent.asTool()`:
+
+If you are still choosing between `agent.asTool()` and `handoff()`, compare the patterns in the [Agents guide](/openai-agents-js/guides/agents#composition-patterns) and [Agent orchestration](/openai-agents-js/guides/multi-agent).
 
 <Code lang="typescript" code={agentsAsToolsExample} title="Agents as tools" />
 
@@ -225,13 +219,11 @@ Agent tools can stream all nested run events back to your app. Choose the hook s
 
 ### 5. MCP servers
 
-You can expose tools via [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers and attach them to an agent.
-For instance, you can use `MCPServerStdio` to spawn and connect to the stdio MCP server:
+You can expose tools via [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers and attach them to an agent. For instance, you can use `MCPServerStdio` to spawn and connect to the stdio MCP server:
 
 <Code lang="typescript" code={mcpLocalServer} title="Local MCP server" />
 
-See [`filesystem-example.ts`](https://github.com/openai/openai-agents-js/tree/main/examples/mcp/filesystem-example.ts) for a complete example. Also, if you're looking for a comprehensitve guide for MCP server tool integration, refer to [MCP guide](/openai-agents-js/guides/mcp) for details.
-When managing multiple servers (or partial failures), use `connectMcpServers` and the lifecycle guidance in the [MCP guide](/openai-agents-js/guides/mcp#managing-mcp-server-lifecycle).
+See [`filesystem-example.ts`](https://github.com/openai/openai-agents-js/tree/main/examples/mcp/filesystem-example.ts) for a complete example. Also, if you're looking for a comprehensitve guide for MCP server tool integration, refer to [MCP guide](/openai-agents-js/guides/mcp) for details. When managing multiple servers (or partial failures), use `connectMcpServers` and the lifecycle guidance in the [MCP guide](/openai-agents-js/guides/mcp#managing-mcp-server-lifecycle).
 
 ---
 
@@ -281,8 +273,7 @@ Run-context thread reuse example:
 
 ### Tool use behavior
 
-Refer to the [Agents guide](/openai-agents-js/guides/agents#forcing-tool-use) for controlling when and how a model
-must use tools (`modelSettings.toolChoice`, `toolUseBehavior`, etc.).
+Refer to the [Agents guide](/openai-agents-js/guides/agents#forcing-tool-use) for controlling when and how a model must use tools (`modelSettings.toolChoice`, `toolUseBehavior`, etc.).
 
 ---
 
@@ -295,8 +286,11 @@ must use tools (`modelSettings.toolChoice`, `toolUseBehavior`, etc.).
 
 ---
 
-## Next steps
+## Related guides
 
-- Learn about [forcing tool use](/openai-agents-js/guides/agents#forcing-tool-use).
-- Add [guardrails](/openai-agents-js/guides/guardrails) to validate tool inputs or outputs.
+- [Agents](/openai-agents-js/guides/agents) for defining tool-bearing agents and controlling `toolUseBehavior`.
+- [Agent orchestration](/openai-agents-js/guides/multi-agent) for deciding when to use agents as tools versus handoffs.
+- [Running agents](/openai-agents-js/guides/running-agents) for execution flow, streaming, and conversation state.
+- [Models](/openai-agents-js/guides/models) for hosted OpenAI model configuration and Responses transport choices.
+- [Guardrails](/openai-agents-js/guides/guardrails) to validate tool inputs or outputs.
 - Dive into the TypeDoc reference for [`tool()`](/openai-agents-js/openai/agents/functions/tool) and the various hosted tool types.

--- a/docs/src/content/docs/guides/voice-agents.mdx
+++ b/docs/src/content/docs/guides/voice-agents.mdx
@@ -3,33 +3,21 @@ title: Voice Agents
 description: Build realtime voice assistants using RealtimeAgent and RealtimeSession
 ---
 
-import { Aside, Code, LinkCard } from '@astrojs/starlight/components';
-import createAgentExample from '../../../../../examples/docs/voice-agents/createAgent.ts?raw';
-import multiAgentsExample from '../../../../../examples/docs/voice-agents/multiAgents.ts?raw';
-import createSessionExample from '../../../../../examples/docs/voice-agents/createSession.ts?raw';
-import configureSessionExample from '../../../../../examples/docs/voice-agents/configureSession.ts?raw';
-import handleAudioExample from '../../../../../examples/docs/voice-agents/handleAudio.ts?raw';
-import defineToolExample from '../../../../../examples/docs/voice-agents/defineTool.ts?raw';
-import toolApprovalEventExample from '../../../../../examples/docs/voice-agents/toolApprovalEvent.ts?raw';
-import guardrailsExample from '../../../../../examples/docs/voice-agents/guardrails.ts?raw';
-import guardrailSettingsExample from '../../../../../examples/docs/voice-agents/guardrailSettings.ts?raw';
-import audioInterruptedExample from '../../../../../examples/docs/voice-agents/audioInterrupted.ts?raw';
-import sessionInterruptExample from '../../../../../examples/docs/voice-agents/sessionInterrupt.ts?raw';
-import sessionHistoryExample from '../../../../../examples/docs/voice-agents/sessionHistory.ts?raw';
-import historyUpdatedExample from '../../../../../examples/docs/voice-agents/historyUpdated.ts?raw';
-import updateHistoryExample from '../../../../../examples/docs/voice-agents/updateHistory.ts?raw';
-import customWebRTCTransportExample from '../../../../../examples/docs/voice-agents/customWebRTCTransport.ts?raw';
-import websocketSessionExample from '../../../../../examples/docs/voice-agents/websocketSession.ts?raw';
-import transportEventsExample from '../../../../../examples/docs/voice-agents/transportEvents.ts?raw';
-import thinClientExample from '../../../../../examples/docs/voice-agents/thinClient.ts?raw';
+import { Aside, LinkCard } from '@astrojs/starlight/components';
 
 ## Overview
 
 ![Realtime Agents](https://cdn.openai.com/API/docs/images/diagram-speech-to-speech.png)
 
-Voice Agents use OpenAI speech-to-speech models to provide realtime voice chat. These models support streaming audio, text, and tool calls and are great for applications like voice/phone customer support, mobile app experiences, and voice chat.
+Voice Agents let you build low-latency spoken interfaces on top of OpenAI speech-to-speech models. The SDK keeps the Realtime API mental model intact, but wraps the raw event flow in `RealtimeAgent`, `RealtimeSession`, and transport helpers that make tools, guardrails, handoffs, and session history easier to work with.
 
-The Voice Agents SDK provides a TypeScript client for the [OpenAI Realtime API](https://platform.openai.com/docs/guides/realtime).
+Under the hood, the same Realtime concepts from the official [Realtime API with WebRTC](https://developers.openai.com/api/docs/guides/realtime-webrtc/), [Realtime conversations](https://developers.openai.com/api/docs/guides/realtime-conversations/), and [voice activity detection](https://developers.openai.com/api/docs/guides/realtime-vad/) guides still apply. The Voice Agents SDK adds a TypeScript-first layer on top of that API so you can stay focused on product logic instead of rebuilding transport and event handling from scratch.
+
+<Aside type="note">
+  Start with the Quickstart if you are connecting a browser client with WebRTC.
+  Jump to the transport guide first if you are deciding between WebRTC,
+  WebSocket, SIP, Twilio, or Cloudflare Workers.
+</Aside>
 
 ## Start here
 
@@ -39,24 +27,39 @@ The Voice Agents SDK provides a TypeScript client for the [OpenAI Realtime API](
   description="Build your first realtime voice assistant using the OpenAI Agents SDK in minutes."
 />
 
-## Key features
+<LinkCard
+  title="Building Voice Agents"
+  href="/openai-agents-js/guides/voice-agents/build"
+  description="Learn how session lifecycle, VAD, interruptions, multimodal input, tools, and history work in the SDK."
+/>
 
-- Connect over WebSocket or WebRTC
-- Can be used both in the browser and for backend connections
-- Audio and interruption handling
-- Multi-agent orchestration through handoffs
-- Tool definition and calling
-- Custom guardrails to monitor model output
-- Callbacks for streamed events
-- Reuse the same components for both text and voice agents
+<LinkCard
+  title="Realtime Transport Layer"
+  href="/openai-agents-js/guides/voice-agents/transport"
+  description="Choose between WebRTC, WebSocket, SIP, or a custom transport, and know when to drop down to raw events."
+/>
 
-## Explore the voice guides
+## What the SDK adds
 
-- [Building Voice Agents](/openai-agents-js/guides/voice-agents/build) for session setup, tools, guardrails, interruptions, and history management.
-- [Realtime Transport Layer](/openai-agents-js/guides/voice-agents/transport) for WebRTC/WebSocket/SIP transport choices and custom transports.
+- Browser-first WebRTC setup with ephemeral client tokens.
+- Server-side WebSocket and SIP transport options.
+- Automatic interruption handling and local conversation history updates.
+- Multi-agent orchestration through realtime handoffs.
+- Function tools, hosted MCP tools, approvals, and delegation patterns.
+- Output guardrails and tracing support for live spoken interactions.
+
+## Pick the next page
+
+| If you need to... | Go here |
+| --- | --- |
+| Connect a browser client safely with WebRTC and ephemeral tokens | [Voice Agents Quickstart](/openai-agents-js/guides/voice-agents/quickstart) |
+| Understand session lifecycle, VAD, interruptions, image input, tools, and history | [Building Voice Agents](/openai-agents-js/guides/voice-agents/build) |
+| Decide between WebRTC, WebSocket, SIP, and custom transports | [Realtime Transport Layer](/openai-agents-js/guides/voice-agents/transport) |
+| Run a phone or telephony experience on Twilio | [Realtime Agents on Twilio](/openai-agents-js/extensions/twilio) |
+| Connect from Cloudflare Workers or other workerd runtimes | [Realtime Agents on Cloudflare](/openai-agents-js/extensions/cloudflare) |
 
 ## Why speech-to-speech
 
-By using speech-to-speech models, we can leverage the model's ability to process the audio in realtime without the need of transcribing and reconverting the text back to audio after the model acted.
+Speech-to-speech models process user audio directly, so you do not have to build a separate speech-to-text, text reasoning, and text-to-speech chain for every turn. That keeps latency down and makes interruptions, mixed text and voice input, and tool calls feel much more natural in realtime applications.
 
 ![Speech-to-speech model](https://cdn.openai.com/API/docs/images/diagram-chained-agent.png)

--- a/docs/src/content/docs/guides/voice-agents/build.mdx
+++ b/docs/src/content/docs/guides/voice-agents/build.mdx
@@ -1,12 +1,10 @@
 ---
 title: Building Voice Agents
-description: Learn how to build voice agents using the OpenAI Agents SDK, what features are available, how to architecture your application, and more.
+description: Learn how to build voice agents using the OpenAI Agents SDK, how session behavior works, and which realtime features are available.
 ---
 
-import { Steps, Aside, Code } from '@astrojs/starlight/components';
-import createAgentExample from '../../../../../../examples/docs/voice-agents/createAgent.ts?raw';
+import { Aside, Code } from '@astrojs/starlight/components';
 import multiAgentsExample from '../../../../../../examples/docs/voice-agents/multiAgents.ts?raw';
-import createSessionExample from '../../../../../../examples/docs/voice-agents/createSession.ts?raw';
 import configureSessionExample from '../../../../../../examples/docs/voice-agents/configureSession.ts?raw';
 import handleAudioExample from '../../../../../../examples/docs/voice-agents/handleAudio.ts?raw';
 import defineToolExample from '../../../../../../examples/docs/voice-agents/defineTool.ts?raw';
@@ -15,15 +13,11 @@ import guardrailsExample from '../../../../../../examples/docs/voice-agents/guar
 import guardrailSettingsExample from '../../../../../../examples/docs/voice-agents/guardrailSettings.ts?raw';
 import audioInterruptedExample from '../../../../../../examples/docs/voice-agents/audioInterrupted.ts?raw';
 import sessionInterruptExample from '../../../../../../examples/docs/voice-agents/sessionInterrupt.ts?raw';
-import sessionHistoryExample from '../../../../../../examples/docs/voice-agents/sessionHistory.ts?raw';
-import historyUpdatedExample from '../../../../../../examples/docs/voice-agents/historyUpdated.ts?raw';
 import updateHistoryExample from '../../../../../../examples/docs/voice-agents/updateHistory.ts?raw';
-import customWebRTCTransportExample from '../../../../../../examples/docs/voice-agents/customWebRTCTransport.ts?raw';
-import websocketSessionExample from '../../../../../../examples/docs/voice-agents/websocketSession.ts?raw';
 import transportEventsExample from '../../../../../../examples/docs/voice-agents/transportEvents.ts?raw';
-import thinClientExample from '../../../../../../examples/docs/voice-agents/thinClient.ts?raw';
 import toolHistoryExample from '../../../../../../examples/docs/voice-agents/toolHistory.ts?raw';
 import sendMessageExample from '../../../../../../examples/docs/voice-agents/sendMessage.ts?raw';
+import addImageExample from '../../../../../../examples/docs/voice-agents/addImage.ts?raw';
 import serverAgentExample from '../../../../../../examples/docs/voice-agents/serverAgent.ts?raw';
 import delegationAgentExample from '../../../../../../examples/docs/voice-agents/delegationAgent.ts?raw';
 import turnDetectionExample from '../../../../../../examples/docs/voice-agents/turnDetection.ts?raw';
@@ -35,7 +29,7 @@ Choose your architecture early:
 - `OpenAIRealtimeWebRTC` is the simplest browser path and handles audio input/output for you.
 - `OpenAIRealtimeWebSocket` gives you more control, but you must manage audio capture and playback yourself.
 - Function tools run wherever the `RealtimeSession` runs. If the session runs in the browser, the tool runs in the browser too.
-- Realtime handoffs keep the same voice and model. If you need a different backend model, delegate through a tool instead of a handoff.
+- Realtime handoffs keep the same live session model. Voice changes only work before the session has produced audio output. If you need a different backend model, delegate through a tool instead of a handoff.
 
 </Aside>
 
@@ -43,69 +37,135 @@ Choose your architecture early:
 
 ### Audio handling
 
-Some transport layers like the default `OpenAIRealtimeWebRTC` will handle audio input and output
-automatically for you. For other transport mechanisms like `OpenAIRealtimeWebSocket` you will have to
-handle session audio yourself:
+Some transport layers like the default `OpenAIRealtimeWebRTC` handle audio input and output automatically for you. For other transport mechanisms like `OpenAIRealtimeWebSocket` you have to handle session audio yourself:
 
 <Code lang="typescript" code={handleAudioExample} />
 
-When the underlying transport supports it, `session.muted` reports the current mute state and
-`session.mute(true | false)` toggles microphone capture. `OpenAIRealtimeWebSocket` does not
-implement muting: `session.muted` returns `null` and `session.mute()` throws, so for websocket
-setups you should pause capture on your side and stop calling `sendAudio()` until the microphone
-should be live again.
+When the underlying transport supports it, `session.muted` reports the current mute state and `session.mute(true | false)` toggles microphone capture. `OpenAIRealtimeWebSocket` does not implement muting: `session.muted` returns `null` and `session.mute()` throws, so for websocket setups you should pause capture on your side and stop calling `sendAudio()` until the microphone should be live again.
 
 ### Session configuration
 
-You can configure your session by passing additional options to either the [`RealtimeSession`](/openai-agents-js/openai/agents-realtime/classes/realtimesession/) during construction or
-when you call `connect(...)`.
+Configure the session itself when you create [`RealtimeSession`](/openai-agents-js/openai/agents-realtime/classes/realtimesession/), usually through the `model` option and the `config` object. `connect(...)` is for connection-time concerns such as credentials, endpoint URL, and SIP call attachment rather than arbitrary session fields.
 
 <Code lang="typescript" code={configureSessionExample} />
 
-These transport layers allow you to pass any parameter that matches [session](https://platform.openai.com/docs/api-reference/realtime-client-events/session/update).
+Under the hood, the SDK normalizes this configuration into the Realtime [`session.update`](https://developers.openai.com/api/reference/resources/realtime/client-events/#session.update) shape. If you need a raw session field that does not have a matching property in [RealtimeSessionConfig](/openai-agents-js/openai/agents-realtime/type-aliases/realtimesessionconfig/), use `providerData` or send a raw `session.update` through `session.transport.sendEvent(...)`.
 
-Prefer the newer config shape with `outputModalities`, `audio.input`, and `audio.output`. Legacy
-top-level fields such as `modalities`, `inputAudioFormat`, `outputAudioFormat`,
-`inputAudioTranscription`, and `turnDetection` are still normalized for backwards compatibility,
-but new code should use the nested `audio` structure shown here.
+Prefer the newer SDK config shape with `outputModalities`, `audio.input`, and `audio.output`. Older SDK aliases such as `modalities`, `inputAudioFormat`, `outputAudioFormat`, `inputAudioTranscription`, and `turnDetection` are still normalized for backwards compatibility, but new code should use the nested `audio` structure shown here.
 
-For parameters that are new and don't have a matching parameter in the [RealtimeSessionConfig](/openai-agents-js/openai/agents-realtime/type-aliases/realtimesessionconfig/) you can use `providerData`. Anything passed in `providerData` will be passed directly as part of the `session` object.
+For speech-to-speech sessions, the usual choice is `outputModalities: ['audio']`, which gives you audio output plus transcripts. Switch to `['text']` only when you want text-only responses.
+
+For parameters that are new and do not have a matching parameter in [RealtimeSessionConfig](/openai-agents-js/openai/agents-realtime/type-aliases/realtimesessionconfig/), you can use `providerData`. Anything passed in `providerData` is forwarded as part of the raw `session` object.
 
 Additional `RealtimeSession` options you can set at construction time:
 
-| Option                                        | Type                              | Purpose                                                                                 |
-| --------------------------------------------- | --------------------------------- | --------------------------------------------------------------------------------------- |
-| `context`                                     | `TContext`                        | Extra local context merged into the session context.                                    |
-| `historyStoreAudio`                           | `boolean`                         | Store audio data in the local history snapshot (disabled by default).                   |
-| `outputGuardrails`                            | `RealtimeOutputGuardrail[]`       | Output guardrails for the session (see [Guardrails](#guardrails)).                      |
-| `outputGuardrailSettings`                     | `{ debounceTextLength?: number }` | Guardrail cadence. Defaults to `100`; use `-1` to only run once full text is available. |
-| `tracingDisabled`                             | `boolean`                         | Disable tracing for the session.                                                        |
-| `groupId`                                     | `string`                          | Group traces across sessions or backend runs.                                           |
-| `traceMetadata`                               | `Record<string, any>`             | Custom metadata to attach to session traces.                                            |
-| `workflowName`                                | `string`                          | Friendly name for the trace workflow.                                                   |
-| `automaticallyTriggerResponseForMcpToolCalls` | `boolean`                         | Auto-trigger a model response when an MCP tool call completes (default: `true`).        |
-| `toolErrorFormatter`                          | `ToolErrorFormatter`              | Customize tool approval rejection messages returned to the model.                       |
+| Option | Type | Purpose |
+| --- | --- | --- |
+| `context` | `TContext` | Extra local context merged into the session context. |
+| `historyStoreAudio` | `boolean` | Store audio data in the local history snapshot (disabled by default). |
+| `outputGuardrails` | `RealtimeOutputGuardrail[]` | Output guardrails for the session (see [Guardrails](#guardrails)). |
+| `outputGuardrailSettings` | `{ debounceTextLength?: number }` | Guardrail cadence. Defaults to `100`; use `-1` to only run once full text is available. |
+| `tracingDisabled` | `boolean` | Disable tracing for the session. |
+| `groupId` | `string` | Group traces across sessions or backend runs. Requires `workflowName`. |
+| `traceMetadata` | `Record<string, any>` | Custom metadata to attach to session traces. Requires `workflowName`. |
+| `workflowName` | `string` | Friendly name for the trace workflow. |
+| `automaticallyTriggerResponseForMcpToolCalls` | `boolean` | Auto-trigger a model response when an MCP tool call completes (default: `true`). |
+| `toolErrorFormatter` | `ToolErrorFormatter` | Customize tool approval rejection messages returned to the model. |
 
 `connect(...)` options:
 
-| Option   | Type                                          | Purpose                                               |
-| -------- | --------------------------------------------- | ----------------------------------------------------- |
-| `apiKey` | `string \| (() => string \| Promise<string>)` | API key (or lazy loader) used for this connection.    |
-| `model`  | `OpenAIRealtimeModels \| string`              | Optional model override for the transport connection. |
-| `url`    | `string`                                      | Optional custom Realtime endpoint URL.                |
-| `callId` | `string`                                      | Attach to an existing SIP-initiated call/session.     |
+| Option | Type | Purpose |
+| --- | --- | --- |
+| `apiKey` | `string \| (() => string \| Promise<string>)` | API key (or lazy loader) used for this connection. |
+| `model` | `OpenAIRealtimeModels \| string` | Present in the transport-level options type. For `RealtimeSession`, set the model in the constructor; raw transports can also use a model at connect time. |
+| `url` | `string` | Optional custom Realtime endpoint URL. |
+| `callId` | `string` | Attach to an existing SIP-initiated call/session. |
+
+### Conversation lifecycle
+
+`RealtimeSession` sits on top of a long-lived Realtime connection. It keeps a local copy of conversation history, listens for transport events, runs tools and output guardrails, and keeps the active agent configuration synchronized with the transport.
+
+The underlying API behavior still matters:
+
+- A successful connection starts with a `session.created` event, and later config changes produce `session.updated`.
+- Most session properties can be changed over time, but `model` cannot change mid-conversation, `voice` can only change before the session has produced audio output, and tracing should be decided up front because the Realtime API does not let you modify tracing after it is enabled.
+- The Realtime API currently limits a single session to 60 minutes.
+- Input audio transcription is asynchronous, so the transcript for the latest utterance can arrive after response generation has already started.
+
+At the SDK layer, `await session.connect()` means "the transport is ready enough to start the conversation", but the exact point differs by transport:
+
+- In the default browser WebRTC transport, the SDK sends the initial `session.update` as soon as the data channel opens and tries to wait for the corresponding `session.updated` event before resolving `connect()`. This is there to avoid audio reaching the server before your instructions, tools, and modalities are applied. If that acknowledgement never arrives, `connect()` falls back to resolving after a short timeout.
+- In the default server-side WebSocket transport, `connect()` resolves once the socket is open and the initial config has been sent. The matching `session.updated` event can therefore arrive after `connect()` has already resolved.
+
+If you need the raw event model, read the official [Realtime conversations guide](https://developers.openai.com/api/docs/guides/realtime-conversations/) alongside this page.
+
+## Interaction flow
+
+### Turn detection and voice activity detection
+
+By default, Realtime sessions use built-in voice activity detection (VAD) so the API can decide when the user has started or stopped speaking and when to create a response. The SDK exposes this through `audio.input.turnDetection`.
+
+<Code lang="typescript" code={turnDetectionExample} />
+
+Two common modes are:
+
+- `semantic_vad`, which aims for more natural turn boundaries and can wait a little longer when the user sounds like they are not finished yet.
+- `server_vad`, which is more threshold-driven and exposes settings such as `threshold`, `prefixPaddingMs`, `silenceDurationMs`, and `idleTimeoutMs`.
+
+Set `audio.input.turnDetection` to `null` if you want to manage turn boundaries yourself. The official [voice activity detection guide](https://developers.openai.com/api/docs/guides/realtime-vad/) and [Realtime conversations guide](https://developers.openai.com/api/docs/guides/realtime-conversations/#voice-activity-detection) describe the underlying behavior in more detail.
+
+### Interruptions
+
+When VAD is enabled, speaking over the agent can interrupt the current response. On the WebSocket transport, the SDK listens for `input_audio_buffer.speech_started`, truncates the assistant audio to what the user actually heard, and emits an `audio_interrupted` event. That event is especially useful when you manage playback yourself in WebSocket setups.
+
+<Code lang="typescript" code={audioInterruptedExample} />
+
+If you want to expose a manual stop button, call `interrupt()` yourself:
+
+<Code lang="typescript" code={sessionInterruptExample} />
+
+WebRTC and WebSocket both stop the in-progress response, but the low-level mechanics differ by transport. WebRTC clears buffered output audio for you. In WebSocket setups you still need to stop local playback yourself, and the local history updates when the corresponding truncation and conversation events come back from the transport.
+
+### Text input
+
+Use `sendMessage()` when you want to send typed input or additional structured user content into the live conversation.
+
+<Code lang="typescript" code={sendMessageExample} />
+
+This is useful for mixed text and voice UIs, out-of-band context injection, or pairing spoken input with explicit typed clarifications.
+
+### Image input
+
+Realtime speech-to-speech sessions can also include images. In the SDK, use `addImage()` to attach an image to the current conversation.
+
+<Code lang="typescript" code={addImageExample} />
+
+Passing `triggerResponse: false` lets you batch the image with a later text or audio turn before asking the model to respond. This lines up with the official [Realtime conversations image input guidance](https://developers.openai.com/api/docs/guides/realtime-conversations/#image-inputs).
+
+### Manual response control
+
+At the higher SDK layer, `sendMessage()` and `addImage()` trigger a response for you by default. Manual response control matters when you are working with raw transport events, push-to-talk flows, or custom moderation / validation steps.
+
+<Code lang="typescript" code={transportEventsExample} />
+
+There are two common cases:
+
+1. If you disable VAD entirely with `audio.input.turnDetection = null`, you are responsible for committing audio turns and then sending `response.create`.
+2. If you keep VAD enabled but set `turnDetection.interruptResponse = false` and `turnDetection.createResponse = false`, the API still detects turns but leaves response creation up to you.
+
+That second pattern is useful when you want to inspect or moderate user input before the model responds. It matches the official [Realtime conversations guidance on disabling automatic responses](https://developers.openai.com/api/docs/guides/realtime-conversations/#keep-vad-but-disable-automatic-responses).
 
 ## Agent capabilities
 
 ### Handoffs
 
-Similarly to regular agents, you can use handoffs to break your agent into multiple agents and orchestrate between them to improve the performance of your agents and better scope the problem.
+Similarly to regular agents, you can use handoffs to break your agent into multiple agents and orchestrate between them to improve performance and better scope the problem.
 
 <Code lang="typescript" code={multiAgentsExample} />
 
-Unlike regular agents, handoffs behave slightly differently for Realtime Agents. When a handoff is performed, the ongoing session will be updated with the new agent configuration. Because of this, the agent automatically has access to the ongoing conversation history and input filters are currently not applied.
+Unlike regular agents, handoffs behave slightly differently for Realtime Agents. When a handoff is performed, the ongoing session is updated with the new agent configuration in place. Because of this, the new agent automatically has access to the ongoing conversation history and input filters are currently not applied.
 
-Additionally, this means that the `voice` or `model` cannot be changed as part of the handoff. You can also only connect to other Realtime Agents. If you need to use a different model, for example a reasoning model like `gpt-5.2`, you can use [delegation through tools](#delegation-through-tools).
+Because the session stays live, the model for that session does not change during a handoff. Voice changes follow the underlying Realtime API rule: they only work before the session has produced audio output. Realtime handoffs are primarily for swapping between `RealtimeAgent` configurations on the same session; if you need to use a different model, for example a reasoning model like `gpt-5.2`, or delegate to a non-realtime backend agent, use [delegation through tools](#delegation-through-tools).
 
 ### Tools
 
@@ -123,16 +183,19 @@ This lets a browser-side tool act as a thin backchannel to server-side logic. Fo
 
 Hosted MCP tools can be configured with `hostedMcpTool` and are executed remotely. When MCP tool availability changes the session emits `mcp_tools_changed`. To prevent the session from auto-triggering a model response after MCP tool calls complete, set `automaticallyTriggerResponseForMcpToolCalls: false`.
 
-The current filtered MCP tool list is also available as `session.availableMcpTools`. Both that
-property and the `mcp_tools_changed` event reflect only the hosted MCP servers enabled on the
-active agent, after applying any `allowed_tools` filters from the agent configuration.
+The current filtered MCP tool list is also available as `session.availableMcpTools`. Both that property and the `mcp_tools_changed` event reflect only the hosted MCP servers enabled on the active agent, after applying any `allowed_tools` filters from the agent configuration.
+
+Hosted MCP setup is easiest to reason about if you treat secure server selection, headers, and approvals as pre-connect configuration. Before `RealtimeSession.connect()` opens the transport, the SDK resolves the active agent's hosted MCP tool definitions and includes the supported MCP fields in the initial session config it sends to the Realtime API.
+
+That timing matters most in browser WebRTC apps. The ephemeral client secret is always minted on your server, so any hosted MCP credentials or custom `headers` that must stay secret should be attached in that server-side `POST /v1/realtime/client_secrets` request as part of the initial `session` payload. Do not put long-lived credentials in browser code and plan to add them later after `connect()` starts.
+
+At the Realtime API level, later `session.update` calls can still change tools and other mutable session fields, and the SDK itself sends `session.update` when the active agent changes. In browser apps, though, you should treat secure Hosted MCP initialization as a server-side, pre-connect concern and keep the browser-side `RealtimeSession` config aligned with what your server minted.
 
 #### Background results
 
 While the tool is executing the agent will not be able to process new requests from the user. One way to improve the experience is by telling your agent to announce when it is about to execute a tool or say specific phrases to buy the agent some time to execute the tool.
 
-If a function tool should finish without immediately triggering another model response, return `backgroundResult(output)` from `@openai/agents/realtime`.
-This sends the tool output back to the session while leaving response triggering under your control.
+If a function tool should finish without immediately triggering another model response, return `backgroundResult(output)` from `@openai/agents/realtime`. This sends the tool output back to the session while leaving response triggering under your control.
 
 #### Timeouts
 
@@ -140,7 +203,7 @@ Function tool timeout options (`timeoutMs`, `timeoutBehavior`, `timeoutErrorFunc
 
 #### Accessing the conversation history
 
-Additionally to the arguments that the agent called a particular tool with, you can also access a snapshot of the current conversation history that is tracked by the Realtime Session. This can be useful if you need to perform a more complex action based on the current state of the conversation or are planning to use [tools for delegation](#delegation-through-tools).
+In addition to the arguments that the agent called a particular tool with, you can also access a snapshot of the current conversation history tracked by the Realtime Session. This can be useful if you need to perform a more complex action based on the current state of the conversation or are planning to use [tools for delegation](#delegation-through-tools).
 
 <Code lang="typescript" code={toolHistoryExample} />
 
@@ -152,28 +215,24 @@ Additionally to the arguments that the agent called a particular tool with, you 
 
 #### Approval before tool execution
 
-If you define your tool with `needsApproval: true` the agent will emit a `tool_approval_requested` event before executing the tool.
+If you define your tool with `needsApproval: true` the agent emits a `tool_approval_requested` event before executing the tool.
 
 By listening to this event you can show a UI to the user to approve or reject the tool call.
 
-Resolve the request with `await session.approve(request.approvalItem)` or
-`await session.reject(request.approvalItem)`. For function tools you can pass
-`{ alwaysApprove: true }` or `{ alwaysReject: true }` to reuse the same decision for repeated
-calls during the rest of the session. Hosted MCP approvals do not support sticky approve/reject;
-restrict those tools with the hosted MCP `allowedTools` configuration instead.
+Resolve the request with `await session.approve(request.approvalItem)` or `await session.reject(request.approvalItem)`. For function tools you can pass `{ alwaysApprove: true }` or `{ alwaysReject: true }` to reuse the same decision for repeated calls during the rest of the session. Hosted MCP approvals do not support sticky approve/reject; restrict those tools with the hosted MCP `allowedTools` configuration instead.
 
 <Code lang="typescript" code={toolApprovalEventExample} />
 
 <Aside type="note">
   While the voice agent is waiting for approval for the tool call, the agent
-  won't be able to process new requests from the user.
+  will not be able to process new requests from the user.
 </Aside>
 
 ### Guardrails
 
-Guardrails offer a way to monitor whether what the agent has said violated a set of rules and immediately cut off the response. These guardrail checks will be performed based on the transcript of the agent's response and therefore requires that the text output of your model is enabled (it is enabled by default).
+Guardrails offer a way to monitor whether what the agent has said violated a set of rules and immediately cut off the response. These checks run against the transcript stream of the agent's response. In audio sessions, the SDK uses output audio transcripts and transcript deltas, so the important prerequisite is transcript availability rather than a separate text output modality.
 
-The guardrails that you provide will run asynchronously as a model response is returned, allowing you to cut off the response based a predefined classification trigger, for example "mentions a specific banned word".
+The guardrails you provide run asynchronously as a model response is returned, allowing you to cut off the response based on a predefined classification trigger, for example "mentions a specific banned word".
 
 When a guardrail trips the session emits a `guardrail_tripped` event. The event also provides a `details` object containing the `itemId` that triggered the guardrail.
 
@@ -181,70 +240,28 @@ When a guardrail trips the session emits a `guardrail_tripped` event. The event 
 
 By default guardrails run every 100 characters and again when the final transcript is available. Because speaking the text usually takes longer than generating the transcript, this often lets the guardrail cut off unsafe output before the user hears it.
 
-If you want to modify this behavior you can pass a `outputGuardrailSettings` object to the session.
+If you want to modify this behavior you can pass an `outputGuardrailSettings` object to the session.
 
 Set `debounceTextLength: -1` when you only want to evaluate the fully generated transcript once, at the end of the response.
 
 <Code lang="typescript" code={guardrailSettingsExample} />
 
-## Interaction flow
-
-### Turn detection / voice activity detection
-
-The Realtime Session will automatically detect when the user is speaking and trigger new turns using the built-in [voice activity detection modes of the Realtime API](https://platform.openai.com/docs/guides/realtime-vad).
-
-You can change the voice activity detection mode by passing `audio.input.turnDetection` in the
-session config.
-
-<Code lang="typescript" code={turnDetectionExample} />
-
-Modifying the turn detection settings can help calibrate unwanted interruptions and dealing with silence. Check out the [Realtime API documentation for more details on the different settings](https://platform.openai.com/docs/guides/realtime-vad)
-
-### Interruptions
-
-When using the built-in voice activity detection, speaking over the agent automatically triggers
-the agent to detect and update its context based on what was said. It will also emit an
-`audio_interrupted` event. This can be used to immediately stop all audio playback (only applicable to WebSocket connections).
-
-<Code lang="typescript" code={audioInterruptedExample} />
-
-If you want to perform a manual interruption, for example if you want to offer a "stop" button in
-your UI, you can call `interrupt()` manually:
-
-<Code lang="typescript" code={sessionInterruptExample} />
-
-In either way, the Realtime Session will handle both interrupting the generation of the agent, truncate its knowledge of what was said to the user, and update the history.
-
-If you are using WebRTC to connect to your agent, it will also clear the audio output. If you are using WebSocket, you will need to handle this yourself by stopping audio playack of whatever has been queued up to be played.
-
-### Text input
-
-If you want to send text input to your agent, you can use the `sendMessage` method on the `RealtimeSession`.
-
-This can be useful if you want to enable your user to interface in both modalities with the agent, or to
-provide additional context to the conversation.
-
-<Code lang="typescript" code={sendMessageExample} />
-
 ## Conversation state and delegation
 
 ### Conversation history management
 
-The `RealtimeSession` automatically manages the conversation history in a `history` property:
+`RealtimeSession` automatically maintains a local `history` snapshot that tracks user messages, assistant output, tool calls, and truncation state. You can render it in the UI, inspect it inside tools, or update it when you need to correct or remove items.
 
-You can use this to render the history to the customer or perform additional actions on it. As this
-history will constantly change during the course of the conversation you can listen for the `history_updated` event.
-
-If you want to modify the history, like removing a message entirely or updating its transcript,
-you can use the `updateHistory` method.
+As the conversation changes the session emits `history_updated`. If you need to request history changes, use `updateHistory()`. It asks the transport to diff the current history and send the necessary delete/create events; the local `session.history` view updates as the corresponding conversation events come back.
 
 <Code lang="typescript" code={updateHistoryExample} />
 
 #### Limitations
 
-1. You can currently not update/change function tool calls after the fact
-2. Text output in the history requires transcripts and text modalities to be enabled
-3. Responses that were truncated due to an interruption do not have a transcript
+1. You cannot currently edit function tool calls after the fact.
+2. Assistant text in history depends on available transcripts, including `output_audio.transcript`.
+3. Responses truncated by interruption do not retain a final transcript.
+4. Input audio transcription is best treated as a rough guide to what the user said, not an exact copy of how the model interpreted the audio.
 
 ### Delegation through tools
 
@@ -254,6 +271,6 @@ By combining the conversation history with a tool call, you can delegate the con
 
 <Code lang="typescript" code={delegationAgentExample} />
 
-The code below will then be executed on the server. In this example through a server actions in Next.js.
+The code below then runs on the server, in this example via a Next.js Server Action.
 
 <Code lang="typescript" code={serverAgentExample} />

--- a/docs/src/content/docs/guides/voice-agents/quickstart.mdx
+++ b/docs/src/content/docs/guides/voice-agents/quickstart.mdx
@@ -19,7 +19,7 @@ import helloWorldExample from '../../../../../../examples/docs/voice-agents/hell
 
 1. **Create a project**
 
-   In this quickstart we will create a voice agent you can use in the browser. If you want to check out a new project, you can try out [`Next.js`](https://nextjs.org/docs/getting-started/installation) or [`Vite`](https://vite.dev/guide/installation.html).
+   In this quickstart we will create a voice agent you can use in the browser. If you want to scaffold a new project, you can start with [`Next.js`](https://nextjs.org/docs/getting-started/installation) or [`Vite`](https://vite.dev/guide/installation.html).
 
    ```bash
    npm create vite@latest my-project -- --template vanilla-ts
@@ -33,7 +33,7 @@ import helloWorldExample from '../../../../../../examples/docs/voice-agents/hell
 
 3. **Generate a client ephemeral token**
 
-   As this application will run in the user's browser, we need a secure way to connect to the model through the Realtime API. For this we can use an [ephemeral client key](https://platform.openai.com/docs/guides/realtime#creating-an-ephemeral-token) that should be generated on your backend server. For testing purposes you can also generate a key using `curl` and your regular OpenAI API key.
+   As this application will run in the user's browser, we need a secure way to connect to the model through the Realtime API. The recommended flow matches the official [Realtime API with WebRTC](https://developers.openai.com/api/docs/guides/realtime-webrtc/) guide: your backend creates a short-lived ephemeral client token, then your browser uses that token to establish the WebRTC connection. For testing purposes you can also generate a token using `curl` and your regular OpenAI API key.
 
    ```bash
    export OPENAI_API_KEY="sk-proj-...(your own key here)"
@@ -48,11 +48,16 @@ import helloWorldExample from '../../../../../../examples/docs/voice-agents/hell
       }'
    ```
 
-   The response contains a top-level `value` field that starts with the `ek_` prefix, plus the
-   effective `session` object. Use `value` as the client secret when establishing the WebRTC
-   connection. This token is short-lived, so your backend should mint a fresh one when needed.
+   The response contains a top-level `value` field that starts with the `ek_` prefix, plus the effective `session` object. Use `value` as the client secret when establishing the WebRTC connection. This token is short-lived, so your backend should mint a fresh one when needed. If your browser session needs hosted MCP tools with `authorization` or custom `headers`, include that hosted MCP configuration in the server-side `session` payload you send to `POST /v1/realtime/client_secrets` instead of exposing those credentials in browser code.
 
 </Steps>
+
+<Aside type="note">
+  Production browser flow: the browser asks your backend for a fresh ephemeral
+  token, your backend calls `POST /v1/realtime/client_secrets` with a server API
+  key, and the browser passes the returned `ek_...` token to
+  `session.connect(...)`.
+</Aside>
 
 ## Create and connect the voice agent
 
@@ -73,7 +78,7 @@ import helloWorldExample from '../../../../../../examples/docs/voice-agents/hell
 
 2. **Create a session**
 
-   Unlike a regular agent, a Voice Agent is continuously running and listening inside a `RealtimeSession` that handles the conversation and connection to the model over time. This session will also handle the audio processing, interruptions, and a lot of the other lifecycle functionality we will cover later on.
+   Unlike a regular agent, a voice agent is continuously running inside a `RealtimeSession` that handles the conversation and connection to the model over time. This session also manages audio processing, interruptions, and the broader conversation lifecycle that you will configure later on.
 
    ```typescript
    import { RealtimeSession } from '@openai/agents/realtime';
@@ -83,19 +88,25 @@ import helloWorldExample from '../../../../../../examples/docs/voice-agents/hell
    });
    ```
 
-   The `RealtimeSession` constructor takes an `agent` as the first argument. This agent will be the first agent that your user will be able to interact with.
+   The `RealtimeSession` constructor takes an `agent` as the first argument. This agent will be the first one your user interacts with.
 
 3. **Connect to the session**
 
-   To connect to the session you need to pass the client ephemeral token you generated earlier on.
+   To connect to the session you need to pass the client ephemeral token you generated earlier.
 
    ```typescript
    await session.connect({ apiKey: 'ek_...(put your own key here)' });
    ```
 
-   This will connect to the Realtime API using WebRTC in the browser and automatically configure your microphone and speaker for audio input and output. If you are running your `RealtimeSession` on a backend server (like Node.js) the SDK will automatically use WebSocket as a connection. You can learn more about the different transport layers in the [Realtime Transport Layer](/openai-agents-js/guides/voice-agents/transport) guide.
+   In the browser, this connects to the Realtime API using WebRTC and automatically configures microphone capture and audio playback for you. On that default WebRTC path, the SDK sends the initial session configuration as soon as the data channel opens and tries to wait for the matching `session.updated` acknowledgement before `connect()` resolves, with a timeout fallback if that acknowledgement never arrives. If you run `RealtimeSession` in a server runtime such as Node.js, the SDK automatically falls back to WebSocket instead; on the WebSocket path, `connect()` resolves after the socket opens and the initial config has been sent, so `session.updated` may arrive slightly later. You can learn more about the transport choices in the [Realtime Transport Layer](/openai-agents-js/guides/voice-agents/transport) guide.
 
 </Steps>
+
+<Aside type="note">
+  If you want lower-level control over the peer connection or raw transport
+  events, see the [`/raw-client` example in
+  `examples/realtime-next`](https://github.com/openai/openai-agents-js/tree/main/examples/realtime-next).
+</Aside>
 
 ## Run and test the app
 
@@ -105,9 +116,9 @@ import helloWorldExample from '../../../../../../examples/docs/voice-agents/hell
 
    <Code lang="typescript" code={helloWorldExample} />
 
-2. **Fire up the engines and start talking**
+2. **Fire up the app and start talking**
 
-   Start up your webserver and navigate to the page that includes your new Realtime Agent code. You should see a request for microphone access. Once you grant access you should be able to start talking to your agent.
+   Start your web server and open the page that includes your new Realtime Agent code. You should see a microphone permission request. Once you grant access, you should be able to start talking to your agent.
 
    ```bash
    npm run dev
@@ -120,5 +131,6 @@ import helloWorldExample from '../../../../../../examples/docs/voice-agents/hell
 From here you can start designing and building your own voice agent:
 
 - Add [tools](/openai-agents-js/guides/voice-agents/build#tools), [handoffs](/openai-agents-js/guides/voice-agents/build#handoffs), and [guardrails](/openai-agents-js/guides/voice-agents/build#guardrails).
-- Learn how to [handle audio interruptions](/openai-agents-js/guides/voice-agents/build#interruptions) and [manage session history](/openai-agents-js/guides/voice-agents/build#conversation-history-management).
-- Choose the right transport for your deployment: [WebRTC](/openai-agents-js/guides/voice-agents/transport#connecting-over-webrtc), [WebSocket](/openai-agents-js/guides/voice-agents/transport#connecting-over-websocket), or [a custom transport](/openai-agents-js/guides/voice-agents/transport#building-your-own-transport-mechanism).
+- Learn how [turn detection and voice activity detection](/openai-agents-js/guides/voice-agents/build#turn-detection-and-voice-activity-detection), [interruptions](/openai-agents-js/guides/voice-agents/build#interruptions), and [manual response control](/openai-agents-js/guides/voice-agents/build#manual-response-control) affect the conversation loop.
+- Add [text input](/openai-agents-js/guides/voice-agents/build#text-input), [image input](/openai-agents-js/guides/voice-agents/build#image-input), and [session history management](/openai-agents-js/guides/voice-agents/build#conversation-history-management).
+- Choose the right transport for your deployment: [WebRTC](/openai-agents-js/guides/voice-agents/transport#webrtc-is-the-default-browser-choice), [WebSocket](/openai-agents-js/guides/voice-agents/transport#websocket-is-the-default-server-choice), or [a custom transport](/openai-agents-js/guides/voice-agents/transport#bring-your-own-transport).

--- a/docs/src/content/docs/guides/voice-agents/transport.mdx
+++ b/docs/src/content/docs/guides/voice-agents/transport.mdx
@@ -3,23 +3,7 @@ title: Realtime Transport Layer
 description: Learn about the different transport layers that can be used with Realtime Agents.
 ---
 
-import { Steps } from '@astrojs/starlight/components';
-import { Code } from '@astrojs/starlight/components';
-
-import createAgentExample from '../../../../../../examples/docs/voice-agents/createAgent.ts?raw';
-import multiAgentsExample from '../../../../../../examples/docs/voice-agents/multiAgents.ts?raw';
-import createSessionExample from '../../../../../../examples/docs/voice-agents/createSession.ts?raw';
-import configureSessionExample from '../../../../../../examples/docs/voice-agents/configureSession.ts?raw';
-import handleAudioExample from '../../../../../../examples/docs/voice-agents/handleAudio.ts?raw';
-import defineToolExample from '../../../../../../examples/docs/voice-agents/defineTool.ts?raw';
-import toolApprovalEventExample from '../../../../../../examples/docs/voice-agents/toolApprovalEvent.ts?raw';
-import guardrailsExample from '../../../../../../examples/docs/voice-agents/guardrails.ts?raw';
-import guardrailSettingsExample from '../../../../../../examples/docs/voice-agents/guardrailSettings.ts?raw';
-import audioInterruptedExample from '../../../../../../examples/docs/voice-agents/audioInterrupted.ts?raw';
-import sessionInterruptExample from '../../../../../../examples/docs/voice-agents/sessionInterrupt.ts?raw';
-import sessionHistoryExample from '../../../../../../examples/docs/voice-agents/sessionHistory.ts?raw';
-import historyUpdatedExample from '../../../../../../examples/docs/voice-agents/historyUpdated.ts?raw';
-import updateHistoryExample from '../../../../../../examples/docs/voice-agents/updateHistory.ts?raw';
+import { Aside, Code } from '@astrojs/starlight/components';
 import customWebRTCTransportExample from '../../../../../../examples/docs/voice-agents/customWebRTCTransport.ts?raw';
 import websocketSessionExample from '../../../../../../examples/docs/voice-agents/websocketSession.ts?raw';
 import sipTransportExample from '../../../../../../examples/docs/voice-agents/sipTransport.ts?raw';
@@ -27,74 +11,90 @@ import transportEventsExample from '../../../../../../examples/docs/voice-agents
 import thinClientExample from '../../../../../../examples/docs/voice-agents/thinClient.ts?raw';
 import cloudflareTransportExample from '../../../../../../examples/docs/extensions/cloudflare-basic.ts?raw';
 
+Choose the transport based on where the session runs and how much raw media or event control you need.
+
+| Scenario | Recommended transport | Why |
+| --- | --- | --- |
+| Browser speech-to-speech app | `OpenAIRealtimeWebRTC` | Lowest-friction path. The SDK manages microphone capture, playback, and the WebRTC connection for you. |
+| Server-side voice loop or custom audio pipeline | `OpenAIRealtimeWebSocket` | Works well when you already control audio capture/playback and want direct event access. |
+| SIP or telephony bridge | `OpenAIRealtimeSIP` | Attaches a `RealtimeSession` to an existing SIP-initiated Realtime call by `callId`. |
+| Cloudflare Workers / workerd | Cloudflare extension transport | workerd cannot open outbound WebSockets with the global `WebSocket` constructor. |
+| Provider-specific phone flow on Twilio | Twilio extension transport | Handles Twilio audio forwarding and interruption behavior for you. |
+
+<Aside type="note">
+  If you are building a browser product and do not have a reason to manage raw
+  audio yourself, start with WebRTC. If you are running on the server or
+  bridging another media system, start with WebSocket or SIP.
+</Aside>
+
 ## Default transport layers
 
-### Connecting over WebRTC
+### WebRTC is the default browser choice
 
-The default transport layer uses WebRTC. Audio is recorded from the microphone
-and played back automatically.
+The default browser transport uses WebRTC. Audio is captured from the microphone and played back automatically, which is why the [Quickstart](/openai-agents-js/guides/voice-agents/quickstart) can connect with just an ephemeral token and `session.connect(...)`.
 
-To use your own media stream or audio element, provide an
-`OpenAIRealtimeWebRTC` instance when creating the session.
+On this path, `session.connect()` tries to wait until the initial session configuration has been acknowledged with `session.updated` before it resolves, so your instructions and tools are applied before audio starts flowing. There is still a timeout fallback if that acknowledgement never arrives.
+
+To use your own media stream or audio element, provide an `OpenAIRealtimeWebRTC` instance when creating the session.
 
 <Code lang="typescript" code={customWebRTCTransportExample} />
 
-For lower-level customization, `OpenAIRealtimeWebRTC` also accepts `changePeerConnection`, which
-lets you inspect or replace the freshly created `RTCPeerConnection` before the offer is generated.
+For lower-level customization, `OpenAIRealtimeWebRTC` also accepts `changePeerConnection`, which lets you inspect or replace the freshly created `RTCPeerConnection` before the offer is generated.
 
-### Connecting over WebSocket
+### WebSocket is the default server choice
 
-Pass `transport: 'websocket'` or an instance of `OpenAIRealtimeWebSocket` when creating the session to use a WebSocket connection instead of WebRTC. This works well for server-side use cases, for example
-building a phone agent with Twilio.
+Pass `transport: 'websocket'` or an instance of `OpenAIRealtimeWebSocket` when creating the session to use a WebSocket connection instead of WebRTC. This works well for server-side use cases, telephony bridges, and custom audio pipelines.
+
+On the WebSocket path, `session.connect()` resolves once the socket is open and the initial config has been sent. The matching `session.updated` event may arrive slightly later, so do not assume `connect()` means that update has already been echoed back.
 
 <Code lang="typescript" code={websocketSessionExample} />
 
 Use any recording/playback library to handle the raw PCM16 audio bytes.
 
-For advanced integrations, `OpenAIRealtimeWebSocket` accepts `createWebSocket()` so you can supply
-your own socket implementation, and `skipOpenEventListeners` when that custom connector is
-responsible for transitioning the socket into the connected state. The Cloudflare transport in
-`@openai/agents-extensions` is built on these hooks.
+For advanced integrations, `OpenAIRealtimeWebSocket` accepts `createWebSocket()` so you can supply your own socket implementation, and `skipOpenEventListeners` when that custom connector is responsible for transitioning the socket into the connected state. The Cloudflare transport in `@openai/agents-extensions` is built on these hooks.
 
-### Connecting over SIP
+### SIP is for call providers and telephony bridges
 
-Bridge SIP calls from providers such as Twilio by using the `OpenAIRealtimeSIP` transport. The transport keeps the Realtime session synchronized with SIP events emitted by your telephony provider.
+Use `OpenAIRealtimeSIP` when you want a `RealtimeSession` to attach to an existing SIP-initiated Realtime call. It is a thin SIP-aware transport: audio is handled by the SIP call itself, and you connect the SDK session by `callId`.
 
-1. Accept the incoming call by generating an initial session configuration with `OpenAIRealtimeSIP.buildInitialConfig()`. This ensures the SIP invitation and Realtime session share identical defaults.
+1. Accept the incoming call by generating an initial session configuration with `OpenAIRealtimeSIP.buildInitialConfig()`. This ensures the SIP invitation and the later SDK session start from the same defaults.
 2. Attach a `RealtimeSession` that uses the `OpenAIRealtimeSIP` transport and connect with the `callId` issued by the provider webhook.
-3. Listen for session events to drive call analytics, transcripts, or escalation logic.
+3. If you need provider-specific media forwarding or event bridging, use an integration transport such as the Twilio extension.
 
 <Code lang="typescript" code={sipTransportExample} />
 
-#### Cloudflare Workers (workerd) note
+### Cloudflare Workers and workerd
 
 Cloudflare Workers and other workerd runtimes cannot open outbound WebSockets using the global `WebSocket` constructor. Use the Cloudflare transport from the extensions package, which performs the `fetch()`-based upgrade internally.
 
 <Code lang="typescript" code={cloudflareTransportExample} />
 
-### Building your own transport mechanism
+For the full setup, read [Realtime Agents on Cloudflare](/openai-agents-js/extensions/cloudflare).
 
-If you want to use a different speech-to-speech API or have your own custom transport mechanism, you
-can create your own by implementing the `RealtimeTransportLayer` interface and emit the `RealtimeTransportEventTypes` events.
+### Twilio phone calls
 
-## Interacting with the Realtime API more directly
+You can connect a `RealtimeSession` to Twilio using either raw WebSockets or the dedicated Twilio transport in `@openai/agents-extensions`. The dedicated transport is the better default when you want the SDK to handle interruption timing and audio forwarding for Twilio Media Streams.
 
-If you want to use the OpenAI Realtime API but have more direct access to the Realtime API, you have
-two options:
+For the full setup, read [Realtime Agents on Twilio](/openai-agents-js/extensions/twilio).
+
+### Bring your own transport
+
+If you want to use a different speech-to-speech API or have your own custom transport mechanism, you can implement the `RealtimeTransportLayer` interface and emit the `RealtimeTransportEventTypes` events yourself.
+
+## Access raw Realtime events when you need them
+
+If you want more direct access to the underlying Realtime API, you have two options.
 
 ### Option 1 - Accessing the transport layer
 
-If you still want to benefit from all of the capabilities of the `RealtimeSession` you can access
-your transport layer through `session.transport`.
+If you still want to benefit from all of the capabilities of the `RealtimeSession` you can access your transport layer through `session.transport`.
 
-The transport layer will emit every event it receives under the `*` event and you can send raw
-events using the `sendEvent()` method.
+The transport layer emits every event it receives under the `*` event and you can send raw events using `sendEvent()`. This is the escape hatch for low-level operations such as `session.update`, `response.create`, or `response.cancel`.
 
 <Code lang="typescript" code={transportEventsExample} />
 
-### Option 2 — Only using the transport layer
+### Option 2 - Only using the transport layer
 
-If you don't need automatic tool execution, guardrails, etc. you can also use the transport layer
-as a "thin" client that just manages connection and interruptions.
+If you do not need automatic tool execution, guardrails, or local history management, you can also use the transport layer as a "thin" client that just manages connection and interruptions.
 
 <Code lang="typescript" code={thinClientExample} />

--- a/examples/docs/voice-agents/addImage.ts
+++ b/examples/docs/voice-agents/addImage.ts
@@ -1,0 +1,14 @@
+import { RealtimeAgent, RealtimeSession } from '@openai/agents/realtime';
+
+const agent = new RealtimeAgent({
+  name: 'Assistant',
+});
+
+const session = new RealtimeSession(agent, {
+  model: 'gpt-realtime',
+});
+
+const imageDataUrl = 'data:image/png;base64,...';
+
+session.addImage(imageDataUrl, { triggerResponse: false });
+session.sendMessage('Describe what is in this image.');

--- a/examples/docs/voice-agents/configureSession.ts
+++ b/examples/docs/voice-agents/configureSession.ts
@@ -8,7 +8,7 @@ const agent = new RealtimeAgent({
 const session = new RealtimeSession(agent, {
   model: 'gpt-realtime',
   config: {
-    outputModalities: ['text', 'audio'],
+    outputModalities: ['audio'],
     audio: {
       input: {
         format: 'pcm16',

--- a/examples/docs/voice-agents/thinClient.ts
+++ b/examples/docs/voice-agents/thinClient.ts
@@ -5,10 +5,10 @@ const audioBuffer = new ArrayBuffer(0);
 
 await client.connect({
   apiKey: '<api key>',
-  model: 'gpt-4o-mini-realtime-preview',
+  model: 'gpt-realtime',
   initialSessionConfig: {
     instructions: 'Speak like a pirate',
-    outputModalities: ['text', 'audio'],
+    outputModalities: ['audio'],
     audio: {
       input: {
         format: 'pcm16',


### PR DESCRIPTION
This pull request updates the Agents, Running Agents, Tools, and Voice Agents guides to match the current SDK behavior and improve how the docs route readers between related topics. It also refreshes the docs-backed voice examples to reflect the current Realtime defaults and adds markdown formatting configuration so MD/MDX prose stays intentionally unwrapped.

Key updates in this change:
- Clarify agent, tool, handoff, and run-loop guidance with better cross-links, decision tables, and more accurate parameter descriptions across the core guides.
- Rework the Voice Agents overview, quickstart, build, and transport docs around current WebRTC/WebSocket/SIP behavior, ephemeral token flow, session configuration, interruptions, history handling, and low-level transport access.
- Refresh the voice-agent snippets to use `gpt-realtime`, prefer audio-first session examples, and add a new image-input example with `session.addImage(...)`.
- Update `.prettierrc` and `AGENTS.md` so markdown and MDX prose are not manually hard-wrapped and repository guidance matches that formatting policy.

This is a docs-and-examples alignment pass rather than a runtime SDK change, so the main user-facing impact is clearer, more accurate guidance for integrating the current Agents and Realtime APIs.