### PR TITLE
docs: clarify run context, handoffs, and human-in-the-loop guides

### DIFF
--- a/docs/src/content/docs/guides/context.mdx
+++ b/docs/src/content/docs/guides/context.mdx
@@ -34,6 +34,32 @@ Use local context for things like:
   read from or write to it freely.
 </Aside>
 
+Within a single run, derived contexts share the same underlying app context, approvals, and usage tracking. Nested `agent.asTool()` runs may attach a different `toolInput`, but they do not get an isolated copy of your app state by default.
+
+### What `RunContext` exposes
+
+`RunContext<T>` is a wrapper around your app-defined context object. In practice you will most often use:
+
+- `runContext.context` for your own mutable app state and dependencies.
+- `runContext.usage` for the aggregated token/request usage of the current run.
+- `runContext.toolInput` for structured input when the current run is executing inside `agent.asTool()`.
+- `runContext.approveTool(...)` / `runContext.rejectTool(...)` when you need to update approval state programmatically.
+
+Only `runContext.context` is your app-defined object. The other fields are runtime metadata managed by the SDK.
+
+If you later serialize a [`RunState`](/openai-agents-js/guides/results#state) for [human-in-the-loop](/openai-agents-js/guides/human-in-the-loop), that runtime metadata is saved with the state. Avoid putting secrets in `runContext.context` if you intend to persist or transmit serialized state.
+
+<Aside type="note">
+  `RunContext` is about local app state for the current run. Conversation state
+  is a separate concern: use `result.history`, `session`, `conversationId`, or
+  `previousResponseId` depending on how you want to carry turns forward. See
+  [Running
+  agents](/openai-agents-js/guides/running-agents#state-and-conversation-management)
+  for that decision.
+</Aside>
+
+If you subclass `RunContext`, verify that nested or derived runs still preserve any subclass-specific instance state you rely on. The SDK creates forked contexts internally during nested runs.
+
 ## Agent/LLM context
 
 When the LLM is called, the only data it can see comes from the conversation history. To make additional information available you have a few options:

--- a/docs/src/content/docs/guides/guardrails.mdx
+++ b/docs/src/content/docs/guides/guardrails.mdx
@@ -15,6 +15,16 @@ There are two kinds of guardrails:
 1. **Input guardrails** run on the initial user input.
 2. **Output guardrails** run on the final agent output.
 
+## Workflow boundaries
+
+Guardrails are attached to agents, but they do not necessarily run on every agent in a workflow:
+
+- **Input guardrails** run only for the first agent in the chain.
+- **Output guardrails** run only for the agent that produces the final output.
+- **Tool guardrails** run on every function-tool invocation, with input guardrails before execution and output guardrails after execution.
+
+If you need checks around each custom function-tool call in a workflow that includes managers or handoffs, use **tool guardrails** instead of agent-level input/output guardrails.
+
 ## Input guardrails
 
 Input guardrails run in three steps:
@@ -23,8 +33,7 @@ Input guardrails run in three steps:
 2. The guardrail function executes and returns a [`GuardrailFunctionOutput`](/openai-agents-js/openai/agents/interfaces/guardrailfunctionoutput) wrapped inside an [`InputGuardrailResult`](/openai-agents-js/openai/agents/interfaces/inputguardrailresult).
 3. If `tripwireTriggered` is `true`, an [`InputGuardrailTripwireTriggered`](/openai-agents-js/openai/agents/classes/inputguardrailtripwiretriggered) error is thrown.
 
-> **Note**
-> Input guardrails are intended for user input, so they only run if the agent is the _first_ agent in the workflow. Guardrails are configured on the agent itself because different agents often require different guardrails.
+> **Note** Input guardrails are intended for user input, so they only run if the agent is the _first_ agent in the workflow. Guardrails are configured on the agent itself because different agents often require different guardrails.
 
 ### Execution modes
 
@@ -39,12 +48,15 @@ Output guardrails run in 3 steps:
 2. The guardrail function executes and returns a [`GuardrailFunctionOutput`](/openai-agents-js/openai/agents/interfaces/guardrailfunctionoutput) wrapped inside an [`OutputGuardrailResult`](/openai-agents-js/openai/agents/interfaces/outputguardrailresult).
 3. If `tripwireTriggered` is `true`, an [`OutputGuardrailTripwireTriggered`](/openai-agents-js/openai/agents/classes/outputguardrailtripwiretriggered) error is thrown.
 
-> **Note**
-> Output guardrails only run if the agent is the _last_ agent in the workflow. For realtime voice interactions see [the voice agents guide](/openai-agents-js/guides/voice-agents/build#guardrails).
+> **Note** Output guardrails only run if the agent is the _last_ agent in the workflow. For realtime voice interactions see [the voice agents guide](/openai-agents-js/guides/voice-agents/build#guardrails).
+
+Output guardrail functions also receive an optional `details` object with the underlying `modelResponse` and the generated output items for the turn. Use this when the final output alone is not enough to decide whether the response should pass, for example when you want to inspect the full generated item list or provider response metadata before tripping the guardrail.
 
 ## Tool guardrails
 
-Tool guardrails wrap **function tools** and let you validate or block tool calls before and after execution. They are configured on the tool itself (via `tool()` options) and run for every tool invocation.
+Tool guardrails wrap **function tools** and let you validate or block tool calls before and after execution. They are configured on the tool itself (via `tool()` options) and run for every invocation of that tool.
+
+In practice, this means custom function tools where you set `inputGuardrails` and/or `outputGuardrails` on `tool({...})`.
 
 - **Input tool guardrails** run before the tool executes and can reject the call with a message or throw a tripwire.
 - **Output tool guardrails** run after the tool executes and can replace the output with a rejection message or throw a tripwire.
@@ -55,7 +67,7 @@ Tool guardrails return a `behavior`:
 - `rejectContent` — short‑circuit with a message (tool call is skipped or output is replaced).
 - `throwException` — throw a tripwire error immediately.
 
-Tool guardrails apply to function tools created with `tool()`. Hosted tools and built-in execution tools (`computerTool`, `shellTool`, `applyPatchTool`) do not use this guardrail pipeline.
+Tool guardrails apply to function tools you define with `tool()`. Handoffs are presented to the model as function-like tools, but they run through the SDK's handoff path rather than the normal function-tool pipeline, so tool guardrails do not apply to the handoff call itself. Hosted tools and built-in execution tools (`computerTool`, `shellTool`, `applyPatchTool`) also do not use this guardrail pipeline, and `agent.asTool()` does not currently expose tool-guardrail options directly.
 
 ## Tripwires
 

--- a/docs/src/content/docs/guides/handoffs.mdx
+++ b/docs/src/content/docs/guides/handoffs.mdx
@@ -3,7 +3,7 @@ title: Handoffs
 description: Delegate tasks from one agent to another
 ---
 
-import { Code } from '@astrojs/starlight/components';
+import { Aside, Code } from '@astrojs/starlight/components';
 import basicUsageExample from '../../../../../examples/docs/handoffs/basicUsage.ts?raw';
 import customizeHandoffExample from '../../../../../examples/docs/handoffs/customizeHandoff.ts?raw';
 import handoffInputExample from '../../../../../examples/docs/handoffs/handoffInput.ts?raw';
@@ -33,10 +33,12 @@ The `handoff()` function lets you tweak the generated tool.
 - `agent` – the agent to hand off to.
 - `toolNameOverride` – override the default `transfer_to_<agent_name>` tool name.
 - `toolDescriptionOverride` – override the default tool description.
-- `onHandoff` – callback when the handoff occurs. Receives a `RunContext` and optionally parsed input.
-- `inputType` – expected input schema for the handoff.
+- `onHandoff` – callback when the handoff occurs. Receives a `RunContext` and, when `inputType` is configured, the parsed handoff payload.
+- `inputType` – schema for the handoff tool-call arguments.
 - `inputFilter` – filter the history passed to the next agent.
 - `isEnabled` – boolean or predicate that exposes the handoff only for matching runs.
+
+The `handoff()` helper always transfers control to the specific `agent` you passed in. If you have multiple possible destinations, register one handoff per destination and let the model choose among them. Use a custom `Handoff` when your own handoff code must decide which agent to return at invocation time.
 
 <Code
   lang="typescript"
@@ -46,15 +48,48 @@ The `handoff()` function lets you tweak the generated tool.
 
 ## Handoff inputs
 
-Sometimes you want the LLM to provide data when invoking a handoff. Define an input schema and use it in `handoff()`.
+Sometimes you want the model to attach a small structured payload when it chooses a handoff. Define `inputType` and `onHandoff` together for that case.
 
 <Code lang="typescript" code={handoffInputExample} title="Handoff inputs" />
+
+`inputType` describes the arguments for the handoff tool call itself. The SDK exposes that schema to the model as the handoff tool's `parameters`, parses the returned arguments locally, and passes the parsed value to `onHandoff`.
+
+It does not replace the next agent's main input, and it does not choose a different destination. The `handoff()` helper still transfers to the specific agent you wrapped, and the receiving agent still sees the conversation history unless you change it with an `inputFilter`.
+
+`inputType` is also separate from `RunContext`. Use it for metadata the model decides at handoff time, not for application state or dependencies you already have locally.
+
+### When to use `inputType`
+
+Use `inputType` when the handoff needs a small piece of model-generated routing metadata such as `reason`, `language`, `priority`, or `summary`. For example, a triage agent can hand off to a refund agent with `{ reason: 'duplicate_charge', priority: 'high' }`, and `onHandoff` can log or persist that metadata before the refund agent takes over.
+
+Choose a different mechanism when the goal is different:
+
+- Put existing application state in `RunContext`.
+- Use `inputFilter` if you want to change what history the receiving agent sees.
+- Register one handoff per destination if there are multiple possible specialists. `inputType` can add metadata to the chosen handoff, but it does not dispatch between destinations.
+- Prefer a Zod schema when you want the SDK to validate the parsed payload before `onHandoff` runs; a raw JSON Schema only defines the tool contract sent to the model.
 
 ## Input filters
 
 By default a handoff receives the entire conversation history. To modify what gets passed to the next agent, provide an `inputFilter`. Common helpers live in `@openai/agents-core/extensions`.
 
 <Code lang="typescript" code={inputFilterExample} title="Input filters" />
+
+An `inputFilter` receives and returns a `HandoffInputData` object:
+
+- `inputHistory` – the input history before the run started.
+- `preHandoffItems` – items generated before the turn where the handoff happened.
+- `newItems` – items generated during the current turn, including the handoff call/output items.
+- `runContext` – the active run context.
+
+If you also configure `handoffInputFilter` on the `Runner`, the per-handoff `inputFilter` takes precedence for that specific handoff.
+
+<Aside type="note">
+  Handoffs stay within a single run. Input guardrails still apply only to the
+  first agent in the chain, and output guardrails only to the agent that
+  produces the final output. Use tool guardrails when you need checks around
+  each custom function-tool call inside the workflow.
+</Aside>
 
 ## Recommended prompts
 

--- a/docs/src/content/docs/guides/human-in-the-loop.mdx
+++ b/docs/src/content/docs/guides/human-in-the-loop.mdx
@@ -7,11 +7,15 @@ import { Aside, Code } from '@astrojs/starlight/components';
 import humanInTheLoopExample from '../../../../../examples/docs/human-in-the-loop/index.ts?raw';
 import toolApprovalDefinition from '../../../../../examples/docs/human-in-the-loop/toolApprovalDefinition.ts?raw';
 
-This guide demonstrates how to use the built-in human-in-the-loop support in the SDK to pause and resume agent runs based on human intervention.
+This guide covers the SDK's approval-based human-in-the-loop flow. When a tool call requires approval, the SDK pauses the run, returns `interruptions`, and lets you resume later from the same `RunState`.
 
-The primary use case for this right now is asking for approval for sensitive tool executions.
+That approval surface is run-wide, not limited to the current top-level agent. The same pattern applies when the tool belongs to the current agent, to an agent reached through a handoff, or to a nested `agent.asTool()` execution. In the nested `agent.asTool()` case, the interruption still surfaces on the outer run, so you approve or reject it on the outer `result.state` and resume the original root run.
 
-## Approval requests
+With `agent.asTool()`, approvals can happen at two different layers: the agent tool itself can require approval via `asTool({ needsApproval })`, and tools inside the nested agent can later raise their own approvals after the nested run starts. Both are handled through the same outer-run interruption flow.
+
+This page focuses on the manual approval flow via `interruptions`. If your app can decide in code, some tool types also support programmatic approval callbacks so the run can continue without pausing. If you are setting up `agent.asTool()` itself, see the [tools guide](/openai-agents-js/guides/tools#4-agents-as-tools); this page covers what happens once any tool in that run hierarchy needs approval.
+
+## Approval flow
 
 You can define a tool that requires approval by setting the `needsApproval` option to `true` or to an async function that returns a boolean.
 
@@ -24,15 +28,31 @@ You can define a tool that requires approval by setting the `needsApproval` opti
 
 ### Flow
 
-1. If the agent decides to call a tool (or many) it will check if this tool needs approval by evaluating `needsApproval`.
-2. If the approval is required, the agent will check if approval is already granted or rejected.
-   - If approval has not been granted or rejected, the tool will return a static message to the agent that the tool call cannot be executed.
-   - If approval / rejection is missing it will trigger a tool approval request.
-3. The agent will gather all tool approval requests and interrupt the execution.
-4. If there are any interruptions, the [result](/openai-agents-js/guides/results) will contain an `interruptions` array describing pending steps. A `ToolApprovalItem` with `type: "tool_approval_item"` appears when a tool call requires confirmation.
-5. You can call `result.state.approve(interruption)` or `result.state.reject(interruption)` to approve or reject the tool call. Pass `{ alwaysApprove: true }` or `{ alwaysReject: true }` if the same tool should stay approved or rejected for the rest of the run.
-6. After handling all interruptions, you can resume execution by passing the `result.state` back into `runner.run(agent, state)` where `agent` is the original agent that triggered the overall run.
-7. The flow starts again from step 1.
+1. When a tool invocation is about to execute, the SDK evaluates its approval rule (`needsApproval` or the hosted MCP equivalent).
+2. If approval is required and no decision is stored yet, the tool call does not execute. Instead, the run records a [`RunToolApprovalItem`](/openai-agents-js/openai/agents/classes/runtoolapprovalitem).
+3. At the end of that turn, the run pauses and returns all pending approvals in the [result](/openai-agents-js/guides/results) `interruptions` array. This includes approvals raised inside nested `agent.asTool()` runs.
+4. Resolve each pending item with `result.state.approve(interruption)` or `result.state.reject(interruption)`. Pass `{ alwaysApprove: true }` or `{ alwaysReject: true }` if the same tool should stay approved or rejected for the rest of the run.
+5. Resume by passing the updated `result.state` back into `runner.run(agent, state)`, where `agent` is the original top-level agent for the run. The SDK continues from the interrupted point, including nested agent-tool executions.
+
+Sticky decisions created with `{ alwaysApprove: true }` or `{ alwaysReject: true }` are stored in the run state, so they survive `toString()` / `fromString()` when you resume the same paused run later.
+
+You do not need to resolve every pending approval in the same pass. If you rerun after approving or rejecting only some items, those resolved calls can continue while unresolved ones remain in `interruptions` and pause the run again.
+
+### Automatic approval decisions
+
+Manual `interruptions` are the most general pattern, but they are not the only one:
+
+- Local `shellTool()` and `applyPatchTool()` can use `onApproval` to approve or reject immediately in code.
+- Hosted MCP tools can use `requireApproval` together with `onApproval` for the same kind of programmatic decision.
+- Plain function tools use the manual interruption flow on this page.
+
+When these callbacks return a decision, the run continues without pausing for a human response. For Realtime / voice session APIs, see the approval flow in the [voice agents build guide](/openai-agents-js/guides/voice-agents/build#approval-requests).
+
+### Streaming and sessions
+
+The same interruption flow works in streaming runs. After a streamed run pauses, wait for `stream.completed`, read `stream.interruptions`, resolve them, and call `run()` again with `{ stream: true }` if you want the resumed output to keep streaming. See [Human in the loop while streaming](/openai-agents-js/guides/streaming#human-in-the-loop-while-streaming) for the streamed version of this pattern.
+
+If you are also using a `session`, keep passing the same `session` when you resume from `RunState`. The resumed turn is then appended to session memory without re-preparing the input. See the [sessions guide](/openai-agents-js/guides/sessions) for the session lifecycle details.
 
 ## Example
 
@@ -54,8 +74,10 @@ You can serialize the state using `result.state.toString()` (or `JSON.stringify(
 
 If the resumed process needs to inject a fresh context object, use `RunState.fromStringWithContext(agent, serializedState, context, { contextStrategy })` instead.
 
-- `contextStrategy: 'merge'` (default) keeps the serialized approval state and merges it into the provided `RunContext`.
+- `contextStrategy: 'merge'` (default) keeps the provided `RunContext`, merges in the serialized approval state, and restores serialized `toolInput` when the new context does not already define one.
 - `contextStrategy: 'replace'` rebuilds the run using the provided `RunContext` as-is.
+
+Serialized run state includes your app context plus SDK-managed runtime metadata such as approvals, usage, nested `toolInput`, and pending nested agent-tool resumptions. If you plan to store or transmit serialized state, treat `runContext.context` as persisted data and avoid placing secrets there unless you intentionally want them to travel with the state.
 
 By default tracing API keys are omitted from serialized state so you do not accidentally persist secrets. Pass `result.state.toString({ includeTracingApiKey: true })` only when you intentionally need to move tracing credentials with the state.
 

--- a/docs/src/content/docs/guides/results.mdx
+++ b/docs/src/content/docs/guides/results.mdx
@@ -13,21 +13,24 @@ When you [run your agent](/openai-agents-js/guides/running-agents), you will eit
 - [`RunResult`](/openai-agents-js/openai/agents/classes/runresult) if you call `run` without `stream: true`
 - [`StreamedRunResult`](/openai-agents-js/openai/agents/classes/streamedrunresult) if you call `run` with `stream: true`. For details on streaming, also check the [streaming guide](/openai-agents-js/guides/streaming).
 
-## Which property should I use?
+Both result types expose the same core result surfaces such as `finalOutput`, `newItems`, `interruptions`, and `state`. `StreamedRunResult` adds streaming controls like `completed`, `toStream()`, `toTextStream()`, and `currentAgent`.
 
-Most applications only need a few result properties:
+## Choose the right result surface
 
-| Property                    | Use it when you need...                                                         |
-| --------------------------- | ------------------------------------------------------------------------------- |
-| `finalOutput`               | The final answer to show the user.                                              |
-| `history`                   | A full next-turn input array (`input + generated items`) for manual chat loops. |
-| `output`                    | Only the model-output-shaped items generated in this run.                       |
-| `newItems`                  | Rich run items with agent/tool metadata for logs, UIs, or audits.               |
-| `lastAgent` / `activeAgent` | The agent that should usually handle the next turn.                             |
-| `lastResponseId`            | Continuation with `previousResponseId` on the next OpenAI Responses turn.       |
-| `interruptions`             | Pending tool approvals you must resolve before resuming.                        |
-| `runContext`                | App context, approvals, usage, and nested `toolInput`.                          |
-| `state`                     | A serializable snapshot for resume/retry flows.                                 |
+Most applications only need a few properties:
+
+| If you need... | Use |
+| --- | --- |
+| The final answer to show the user | `finalOutput` |
+| A replay-ready next-turn input with the full local transcript | `history` |
+| Only the newly generated model-shaped items from this run | `output` |
+| Rich run items with agent/tool/handoff metadata | `newItems` |
+| The agent that should usually handle the next user turn | `lastAgent` or `activeAgent` |
+| OpenAI Responses API chaining with `previousResponseId` | `lastResponseId` |
+| Pending approvals and a resumable snapshot | `interruptions` and `state` |
+| App context, approvals, usage, and nested agent-tool input | `runContext` |
+| Metadata about the current nested `Agent.asTool()` invocation, for example inside `customOutputExtractor` | `agentToolInvocation` |
+| Raw model calls or guardrail diagnostics | `rawResponses` and the guardrail result arrays |
 
 ## Final output
 
@@ -37,6 +40,8 @@ The `finalOutput` property contains the final output of the last agent that ran.
 - `unknown` — if the agent has a JSON schema defined as output type. In this case the JSON was parsed but you still have to verify its type manually.
 - `z.infer<outputType>` — if the agent has a Zod schema defined as output type. The output will automatically be parsed against this schema.
 - `undefined` — if the agent did not produce an output (for example stopped before it could produce an output)
+
+`finalOutput` is also `undefined` while a streamed run is still in progress or when the run paused on an approval interruption before reaching a final output.
 
 If you are using handoffs with different output types, you should use the `Agent.create()` method instead of the `new Agent()` constructor to create your agents.
 
@@ -50,79 +55,106 @@ For example:
   title="Handoff final output types"
 />
 
-## Inputs for the next turn
+## Input and output surfaces
 
-There are two ways you can access the inputs for your next turn:
+These properties answer different questions:
 
-- `result.history` — contains a copy of both your input and the output of the agents.
-- `result.output` — contains the output of the full agent run.
+| Property | What it contains | Best for |
+| --- | --- | --- |
+| `input` | The base input for this run. If a handoff input filter rewrote the history, this reflects the filtered input the run continued with. | Auditing what this run actually used as input |
+| `output` | Only the model-shaped items generated in this run, without agent metadata. | Storing or replaying just the new model delta |
+| `newItems` | Rich [`RunItem`](/openai-agents-js/openai/agents/type-aliases/runitem) wrappers with agent/tool/handoff metadata. | Logs, UIs, audits, and debugging |
+| `history` | A replay-ready next-turn input built from `input + newItems`. | Manual chat loops and client-managed conversation state |
 
 In practice:
 
-- Use `result.history` when you are manually carrying the whole conversation in your application.
-- Use `result.output` when you already store the prior conversation history elsewhere and only want the new
-  output items from this run.
-- If you are using `conversationId` or `previousResponseId`, you usually do not pass either one
-  back into `run()`. Instead, pass only the new user input and reuse the server-managed ID.
+- Use `history` when you are manually carrying the whole conversation in your application.
+- Use `output` when you already store prior history elsewhere and only want the new generated items from this run.
+- Use `newItems` when you need agent associations, tool outputs, handoff boundaries, or approval items.
+- If you are using `conversationId` or `previousResponseId`, you usually do not pass `history` back into `run()`. Instead, pass only the new user input and reuse the server-managed ID. See [Running agents](/openai-agents-js/guides/running-agents#state-and-conversation-management) for the full comparison.
 
 `history` is a convenient way to maintain a full history in a chat-like use case:
 
 <Code lang="typescript" code={historyLoop} title="History loop" />
 
-## Last agent
-
-The `lastAgent` property contains the last agent that ran. Depending on your application, this is often useful for the next time the user inputs something. For example, if you have a frontline triage agent that hands off to a language-specific agent, you can store the last agent, and reuse it the next time the user messages the agent.
-
-`activeAgent` is an alias for the same value.
-
-In streaming mode it can also be useful to access the `currentAgent` property that's mapping to the current agent that is running.
-
 ## New items
 
-The `newItems` property contains the new items generated during the run. The items are [`RunItem`](/openai-agents-js/openai/agents/type-aliases/runitem)s. A run item wraps the raw item generated by the LLM. These can be used to access additionally to the output of the LLM which agent these events were associated with.
+`newItems` gives you the richest view of what happened during the run. Common item types are:
 
-- [`RunMessageOutputItem`](/openai-agents-js/openai/agents/classes/runmessageoutputitem) indicates a message from the LLM. The raw item is the message generated.
-- [`RunHandoffCallItem`](/openai-agents-js/openai/agents/classes/runhandoffcallitem) indicates that the LLM called the handoff tool. The raw item is the tool call item from the LLM.
-- [`RunHandoffOutputItem`](/openai-agents-js/openai/agents/classes/runhandoffoutputitem) indicates that a handoff occurred. The raw item is the tool response to the handoff tool call. You can also access the source/target agents from the item.
-- [`RunToolCallItem`](/openai-agents-js/openai/agents/classes/runtoolcallitem) indicates that the LLM invoked a tool.
-- [`RunToolCallOutputItem`](/openai-agents-js/openai/agents/classes/runtoolcalloutputitem) indicates that a tool was called. The raw item is the tool response. You can also access the tool output from the item.
-- [`RunReasoningItem`](/openai-agents-js/openai/agents/classes/runreasoningitem) indicates a reasoning item from the LLM. The raw item is the reasoning generated.
-- [`RunToolApprovalItem`](/openai-agents-js/openai/agents/classes/runtoolapprovalitem) indicates that the LLM requested approval for a tool call. The raw item is the tool call item from the LLM.
+- [`RunMessageOutputItem`](/openai-agents-js/openai/agents/classes/runmessageoutputitem) for assistant messages.
+- [`RunReasoningItem`](/openai-agents-js/openai/agents/classes/runreasoningitem) for reasoning items.
+- [`RunToolCallItem`](/openai-agents-js/openai/agents/classes/runtoolcallitem) and [`RunToolCallOutputItem`](/openai-agents-js/openai/agents/classes/runtoolcalloutputitem) for tool calls and their results.
+- [`RunToolApprovalItem`](/openai-agents-js/openai/agents/classes/runtoolapprovalitem) for tool calls that paused for approval.
+- [`RunHandoffCallItem`](/openai-agents-js/openai/agents/classes/runhandoffcallitem) and [`RunHandoffOutputItem`](/openai-agents-js/openai/agents/classes/runhandoffoutputitem) for handoff requests and completed transfers.
 
-## State
+Choose `newItems` over `output` whenever you need to know which agent produced an item or whether it marks a tool, handoff, or approval boundary.
 
-The `state` property contains the state of the run. Most of what is attached to the `result` is derived from the `state`, but `state` is also serializable/deserializable and can be used as input for a subsequent call to `run()` if you need to [recover from an error](/openai-agents-js/guides/running-agents#exceptions) or resume a paused [human-in-the-loop](/openai-agents-js/guides/human-in-the-loop) flow.
+## Continue or resume the conversation
 
-## Run context
+### Active agent
 
-The `runContext` property is the supported way to read the public run context for a result. `result.runContext.context` is the app context you passed into `run()`, and `result.runContext.toolInput` contains structured agent-tool input when that nested run was given one.
+The `lastAgent` property contains the last agent that ran. This is often the best agent to reuse for the next user turn after handoffs. `activeAgent` is an alias for the same value.
 
-## Interruptions
+In streaming mode, `currentAgent` tells you which agent is currently active while the run is still in progress.
 
-If you are using `needsApproval` in your agent, your run might pause and expose `interruptions`. This array contains the `RunToolApprovalItem`s that require a decision before the run can continue. Resolve them through `result.state.approve(...)` / `result.state.reject(...)`, then call `run()` again with that same state. Check the [human-in-the-loop guide](/openai-agents-js/guides/human-in-the-loop) for end-to-end patterns.
+### Interruptions and resumable state
 
-## Other information
+If a tool needs approval, the run pauses and `interruptions` contains the pending [`RunToolApprovalItem`](/openai-agents-js/openai/agents/classes/runtoolapprovalitem)s. This can include approvals raised by direct tools, by tools reached after a handoff, or by nested `agent.asTool()` runs.
+
+Resolve approvals through `result.state.approve(...)` / `result.state.reject(...)`, then pass the same `state` back into `run()` to resume. You do not need to resolve every interruption at once. If you rerun after handling only some items, resolved calls can continue while unresolved ones stay pending and pause the run again.
+
+The `state` property is the serializable snapshot behind the result. Use it for [human-in-the-loop](/openai-agents-js/guides/human-in-the-loop), retry flows, or any case where you need to resume a paused run later.
+
+### Server-managed continuation
+
+`lastResponseId` is the value to pass as `previousResponseId` on the next turn when you are using OpenAI Responses API chaining.
+
+If you are already continuing the conversation with `history`, `session`, or `conversationId`, you usually do not need `lastResponseId`. If you need every raw model response from a multi-step run, inspect `rawResponses` instead.
+
+## Nested agent-tool metadata
+
+`agentToolInvocation` is for nested `Agent.asTool()` results, especially when you are inside `customOutputExtractor` and want metadata about the current tool invocation. It is not a general "the whole run has finished" summary field.
+
+In that nested context, `agentToolInvocation` exposes:
+
+- `toolName`
+- `toolCallId`
+- `toolArguments`
+
+Pair it with `result.runContext.toolInput` when you also need the structured input passed into that nested agent-tool run.
+
+On normal top-level `run()` results this is usually `undefined`. The metadata is runtime-only and is not serialized into `RunState`. See [Agents as tools](/openai-agents-js/guides/tools#4-agents-as-tools) for the surrounding pattern.
+
+## Streamed results
+
+`StreamedRunResult` inherits the same result surfaces above, but adds streaming-specific controls:
+
+- `toTextStream()` for assistant text only.
+- `toStream()` or `for await ... of stream` for the full event stream.
+- `completed` to wait until the run and all post-processing callbacks finish.
+- `error` and `cancelled` to inspect the terminal streaming state.
+- `currentAgent` to track the active agent mid-run.
+
+If you need the settled final state of a streamed run, wait for `completed` before reading `finalOutput`, `history`, `interruptions`, or other summary properties. For event-by-event handling, see the [streaming guide](/openai-agents-js/guides/streaming).
+
+## Diagnostics and advanced fields
+
+### Run context
+
+The `runContext` property is the supported public view of the run context on the result. `result.runContext.context` is your app context, and the same object also carries SDK-managed runtime metadata such as approvals, usage, and nested `toolInput`. See [Context](/openai-agents-js/guides/context) for the full shape.
 
 ### Raw responses
 
-The `rawResponses` property contains the raw LLM responses generated by the model during the agent run.
-
-### Last response ID
-
-The `lastResponseId` property contains the ID of the last response generated by the model during the agent run. This is the value you pass back as `previousResponseId` on the next turn when using OpenAI Responses API chaining.
+`rawResponses` contains the raw model responses collected during the run. Multi-step runs can produce more than one response, for example across handoffs or repeated tool/model cycles.
 
 ### Guardrail results
 
-The `inputGuardrailResults` and `outputGuardrailResults` properties contain the results of the guardrails, if any. Guardrail results can sometimes contain useful information you want to log or store, so we make these available to you.
+The `inputGuardrailResults` and `outputGuardrailResults` properties contain agent-level guardrail results. Tool guardrail results are exposed separately via `toolInputGuardrailResults` and `toolOutputGuardrailResults`.
 
-Tool guardrail results are exposed separately via `toolInputGuardrailResults` and `toolOutputGuardrailResults`.
+Use these arrays when you want to log guardrail decisions, inspect extra metadata returned by guardrail functions, or debug why a run was blocked.
 
 ### Usage
 
-Token usage is aggregated in `result.state.usage`, which tracks request counts and token totals for the run. For streaming runs this data updates as responses arrive.
+Token usage is aggregated in `result.state.usage`, which tracks request counts and token totals for the run. The same usage object is also available through `result.runContext.usage`. For streaming runs this data updates as responses arrive.
 
 <Code lang="typescript" code={usageExample} title="Read usage from RunState" />
-
-### Original input
-
-The `input` property contains the original input you provided to the run method. In most cases you won't need this, but it's available in case you do.


### PR DESCRIPTION
This pull request updates five core guides under `docs/src/content/docs/guides/` to make advanced run behavior easier to reason about. It clarifies `RunContext` and serialization in `context.mdx`, guardrail scope and workflow boundaries in `guardrails.mdx`, handoff `inputType` and `inputFilter` behavior in `handoffs.mdx`, approval/resume behavior for nested `agent.asTool()` flows in `human-in-the-loop.mdx`, and result-surface selection in `results.mdx`.

The main goal is to remove ambiguity around nested runs, handoffs, approvals, and resumable state. In particular, the docs now spell out which guardrails run where, how handoff metadata differs from destination selection, how interruptions behave across nested agent-tool executions, and when to use `history`, `output`, `newItems`, `interruptions`, `state`, and streamed-result fields.