### PR TITLE
chore: add implementation strategy guidance for compatibility decisions

### DIFF
--- a/.agents/skills/changeset-validation/references/validation-prompt.md
+++ b/.agents/skills/changeset-validation/references/validation-prompt.md
@@ -20,36 +20,26 @@ Rules to enforce:
 5. If no packages changed, changesets are optional; if present, they still must be consistent with the diff.
 6. Each changeset summary must be 1-2 non-empty lines.
 7. If the PR body contains GitHub issue references like #123 and a changeset exists, the changeset summary should include those references.
-8. Default bump is patch. Require minor only when there is a breaking change, dropped support, or a behaviorally significant feature that changes existing workflows or expectations (not simply additive APIs or types). Do not require minor solely because new APIs, options, or types were added; additive features can stay patch when they do not change existing behavior. If you are unsure between patch and minor, prefer patch. Major is allowed only after the first major release and only for changes that warrant a major release (breaking changes, dropped support, or significant behavior shifts). Before the first major release, do not use major bumps for feature-level changes. Exception: if the new feature is explicitly labeled experimental/preview in the diff (e.g., module name, docs, comments, or exports) and does not change existing behavior, a patch bump is acceptable.
+8. Default bump is patch. Judge breaking changes against the latest release tag, not against unreleased branch-only churn or post-tag changes already on `main`. Rewriting or removing APIs introduced after the latest release tag is not by itself a breaking change. Require minor only when there is a breaking change, dropped support, or a behaviorally significant feature that changes existing workflows or expectations (not simply additive APIs or types). Do not require minor solely because new APIs, options, or types were added; additive features can stay patch when they do not change existing behavior. If you are unsure between patch and minor, prefer patch. Major is allowed only after the first major release and only for changes that warrant a major release (breaking changes, dropped support, or significant behavior shifts). Before the first major release, do not use major bumps for feature-level changes. Exception: if the new feature is explicitly labeled experimental/preview in the diff (e.g., module name, docs, comments, or exports) and does not change existing behavior, a patch bump is acceptable.
 9. required_bump must be "none" when there are no package changes.
 10. If unknown package directories are changed, treat it as an error.
 
-If changeset entries include packages that do not appear changed, add a warning (unless the diff indicates a valid reason).
-If the changeset summary is too vague or clearly unrelated to the diff, add an error.
-When a changeset file exists in CHANGESET_FILES but is missing packages or no longer reflects the diff, the error should instruct updating the existing changeset file(s), not creating a new one. Do not treat changeset files outside CHANGESET_FILES as satisfying the requirement.
+If changeset entries include packages that do not appear changed, add a warning (unless the diff indicates a valid reason). If the changeset summary is too vague or clearly unrelated to the diff, add an error. When a changeset file exists in CHANGESET_FILES but is missing packages or no longer reflects the diff, the error should instruct updating the existing changeset file(s), not creating a new one. Do not treat changeset files outside CHANGESET_FILES as satisfying the requirement.
 
-Context:
-Allowed packages:
-{{ALLOWED_PACKAGES}}
+Context: Allowed packages: {{ALLOWED_PACKAGES}}
 
-Unknown package directories:
-{{UNKNOWN_PACKAGE_DIRS}}
+Unknown package directories: {{UNKNOWN_PACKAGE_DIRS}}
 
-Changed packages:
-{{CHANGED_PACKAGES}}
+Changed packages: {{CHANGED_PACKAGES}}
 
-Changed files:
-{{CHANGED_FILES}}
+Changed files: {{CHANGED_FILES}}
 
-Changeset files:
-{{CHANGESET_FILES}}
+Changeset files: {{CHANGESET_FILES}}
 
 Notes:
 
 - The changeset file list includes only files present in the head commit; deleted or renamed source paths may be omitted.
 
-PR body (CI only; otherwise this may be "(not provided)"):
-{{PR_BODY}}
+PR body (CI only; otherwise this may be "(not provided)"): {{PR_BODY}}
 
-Package diff (truncated if large):
-{{PACKAGE_DIFF}}
+Package diff (truncated if large): {{PACKAGE_DIFF}}

--- a/.agents/skills/implementation-strategy/SKILL.md
+++ b/.agents/skills/implementation-strategy/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: implementation-strategy
+description: Decide how to implement runtime and API changes in openai-agents-js before editing code. Use when a task changes exported APIs, runtime behavior, schemas, tests, or docs and you need to choose the compatibility boundary, whether shims or migrations are warranted, and when unreleased interfaces can be rewritten directly.
+---
+
+# Implementation Strategy
+
+## Overview
+
+Use this skill before editing code when the task changes runtime behavior or anything that might look like a compatibility concern. The goal is to keep implementations simple while protecting real released contracts.
+
+## Quick start
+
+1. Identify the surface you are changing: released public API, unreleased branch-local API, internal helper, persisted schema, wire protocol, CLI/config/env surface, or docs/examples only.
+2. Determine the latest release boundary:
+   ```bash
+   git tag -l 'v*' --sort=-v:refname | head -n1
+   ```
+3. Judge breaking-change risk against that latest release tag, not against unreleased branch churn or post-tag changes already on `main`.
+4. Prefer the simplest implementation that satisfies the current task. Update callers, tests, docs, and examples directly instead of preserving superseded unreleased interfaces.
+5. Add a compatibility layer only when there is a concrete released consumer or durable external state that requires it, or when the user explicitly asks for a migration path.
+
+## Compatibility boundary rules
+
+- Released public API or documented external behavior: preserve compatibility or provide an explicit migration path.
+- Persisted schema, serialized state, wire protocol, CLI flags, environment variables, and externally consumed config: treat as compatibility-sensitive even if the implementation is local.
+- Interface changes introduced only on the current branch: not a compatibility target. Rewrite them directly.
+- Interface changes present on `main` but added after the latest release tag: not a semver breaking change by themselves. Rewrite them directly unless they already define durable external state.
+- Internal helpers, private types, same-branch tests, fixtures, and examples: update them directly instead of adding adapters.
+
+## Default implementation stance
+
+- Prefer deletion or replacement over aliases, overloads, shims, feature flags, and dual-write logic when the old shape is unreleased.
+- Do not preserve a confusing abstraction just because it exists in the current branch diff.
+- If review feedback claims a change is breaking, verify it against the latest release tag and actual external impact before accepting the feedback.
+- If a change truly crosses the latest released contract boundary, call that out explicitly in the ExecPlan, changeset, and user-facing summary.
+
+## When to stop and confirm
+
+- The change would alter behavior shipped in the latest release tag.
+- The change would modify durable external data or protocol formats.
+- The user explicitly asked for backward compatibility, deprecation, or migration support.
+
+## Output expectations
+
+When this skill materially affects the implementation approach, state the decision briefly in your reasoning or handoff, for example:
+
+- `Compatibility boundary: latest release tag v0.x.y; branch-local interface rewrite, no shim needed.`
+- `Compatibility boundary: released RunState schema; preserve compatibility and add migration coverage.`

--- a/.agents/skills/pr-draft-summary/SKILL.md
+++ b/.agents/skills/pr-draft-summary/SKILL.md
@@ -31,7 +31,7 @@ Produce the PR-ready summary required in this repository after substantive code 
 
 1. Run the commands above without asking the user; compute `BASE_REF`/`BASE_COMMIT` first so later commands reuse them.
 2. If there are no staged/unstaged/untracked changes and no commits ahead of `${BASE_COMMIT}`, reply briefly that no code changes were detected and skip emitting the PR block.
-3. Infer change type from the touched paths listed under "Category signals"; classify as feature, fix, refactor, or docs-with-impact, and flag backward-compatibility risk when runtime code changed.
+3. Infer change type from the touched paths listed under "Category signals"; classify as feature, fix, refactor, or docs-with-impact, and flag backward-compatibility risk only when the diff changes released public APIs, external config, persisted data, or wire protocols. Judge that risk against the latest release tag, not unreleased branch-only churn.
 4. Summarize changes in 1–3 short sentences using the key paths (top 5) and `git diff --stat` output; explicitly call out untracked files from `git status -sb`/`git ls-files --others --exclude-standard` because `--stat` does not include them. If the working tree is clean but there are commits ahead of `${BASE_COMMIT}`, summarize using those commit messages.
 5. Choose the lead verb for the description: feature → `adds`, bug fix → `fixes`, refactor/perf → `improves` or `updates`, docs-only → `updates`.
 6. Suggest a branch name. If already off `main`, keep it; otherwise propose `feat/<slug>`, `fix/<slug>`, or `docs/<slug>` based on the primary area (for example `docs/pr-draft-summary-guidance`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,13 @@ When you change anything under `packages/` or touch `.changeset/`, use `$changes
 
 When working on OpenAI API or OpenAI platform integrations in this repo (Responses API, tools, streaming, Realtime API, auth, models, rate limits, MCP, Agents SDK/ChatGPT Apps SDK), use `$openai-knowledge` to pull authoritative docs via the OpenAI Developer Docs MCP server (and guide setup if it is not configured).
 
+#### `$implementation-strategy`
+
+Before changing runtime code, exported APIs, external configuration, persisted schemas, wire protocols, or other user-facing behavior, use `$implementation-strategy` to decide the compatibility boundary and implementation shape. Judge breaking changes against the latest release tag, not unreleased branch-local churn. Interfaces introduced or changed after the latest release tag may be rewritten without compatibility shims unless they define durable external state or the user explicitly asks for a migration path.
+
 ### ExecPlans
 
-When writing complex features or significant refactors, use an ExecPlan (as described in PLANS.md) from design to implementation. Store each ExecPlan file in the repository root (top level) with a descriptive name. Call out potential backward compatibility or public API risks in your plan and confirm the approach when changes could impact package consumers.
+When writing complex features or significant refactors, use an ExecPlan (as described in PLANS.md) from design to implementation. Store each ExecPlan file in the repository root (top level) with a descriptive name. Call out compatibility risk only when the plan changes behavior shipped in the latest release tag or durable external state. Do not treat branch-local interface churn or unreleased post-tag changes on `main` as breaking by default; prefer direct replacement over compatibility layers in those cases. Confirm the approach when changes could impact package consumers or durable external data.
 
 ## Project Structure Guide
 


### PR DESCRIPTION
This pull request adds a repo-local `implementation-strategy` skill so Codex chooses the correct compatibility boundary before changing runtime behavior, exported APIs, schemas, configuration, or wire protocols.

It updates `AGENTS.md` to require that skill for compatibility-sensitive work and clarifies that ExecPlans should treat only behavior shipped in the latest release tag, or durable external state, as compatibility-sensitive by default. Branch-local interface churn and unreleased post-tag changes on `main` are explicitly not treated as breaking changes unless they already define durable external state or a migration path is requested.

This pull request also updates the local `pr-draft-summary` and `changeset-validation` guidance so the same latest-release-tag rule is applied consistently when summarizing compatibility risk and deciding version bump expectations. The result is a simpler implementation default: rewrite unreleased interfaces directly, and reserve shims or migration layers for real released contracts.