### PR TITLE
fix(agents-extensions): remove deprecated top-level AI SDK exports

### DIFF
--- a/.changeset/slow-pears-report.md
+++ b/.changeset/slow-pears-report.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-extensions': minor
+---
+
+fix: remove deprecated top-level AI SDK exports from agents-extensions
+
+Import `aisdk` and `AiSdkModel` from `@openai/agents-extensions/ai-sdk` instead of `@openai/agents-extensions`.

--- a/examples/ai-sdk-v1/ai-sdk-v1.ts
+++ b/examples/ai-sdk-v1/ai-sdk-v1.ts
@@ -350,7 +350,7 @@ export function getResponseFormat(
  * If tracing is enabled, the model will send generation spans to your traces processor.
  *
  * ```ts
- * import { aisdk } from '@openai/agents-extensions';
+ * import { aisdk } from '@openai/agents-extensions/ai-sdk';
  * import { openai } from '@ai-sdk/openai';
  *
  * const model = aisdk(openai('gpt-4o'));
@@ -783,7 +783,7 @@ export class AiSdkModel implements Model {
  * If tracing is enabled, the model will send generation spans to your traces processor.
  *
  * ```ts
- * import { aisdk } from '@openai/agents-extensions';
+ * import { aisdk } from '@openai/agents-extensions/ai-sdk';
  * import { openai } from '@ai-sdk/openai';
  *
  * const model = aisdk(openai('gpt-4o'));

--- a/examples/ai-sdk/README.md
+++ b/examples/ai-sdk/README.md
@@ -1,15 +1,15 @@
 # AI SDK Examples
 
-These examples show how to wrap models from the [AI SDK](https://www.npmjs.com/package/@ai-sdk/openai) (and compatible providers) with the `aisdk()` helper from `@openai/agents-extensions`, then run them inside the Agents runtime.
+These examples show how to wrap models from the [AI SDK](https://www.npmjs.com/package/@ai-sdk/openai) (and compatible providers) with the `aisdk()` helper from `@openai/agents-extensions/ai-sdk`, then run them inside the Agents runtime.
 
 ## Available scripts
 
-| Script                                         | Command                                  | Provider                          | Description                                                                                                |
-| ---------------------------------------------- | ---------------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| [index.ts](./index.ts)                         | `pnpm -F ai-sdk start`                   | OpenRouter (`OPENROUTER_API_KEY`) | Runs a parent agent that hands off a weather question to a child agent equipped with a `get_weather` tool. |
-| [gpt-5.ts](./gpt-5.ts)                         | `pnpm -F ai-sdk start:gpt-5`             | OpenAI (`OPENAI_API_KEY`)         | Shows a single agent that must call the `get_weather` tool using `gpt-5.2` with custom provider options.   |
-| [stream.ts](./stream.ts)                       | `pnpm -F ai-sdk start:stream`            | OpenAI (`OPENAI_API_KEY`)         | Demonstrates streaming text output from an AI SDK model wrapped with `aisdk()`.                            |
-| [image-tool-output.ts](./image-tool-output.ts) | `pnpm -F ai-sdk start:image-tool-output` | OpenRouter (`OPENROUTER_API_KEY`) | Returns a `ToolOutputImage` from a tool call and asks the model to describe the image.                     |
+| Script | Command | Provider | Description |
+| --- | --- | --- | --- |
+| [index.ts](./index.ts) | `pnpm -F ai-sdk start` | OpenRouter (`OPENROUTER_API_KEY`) | Runs a parent agent that hands off a weather question to a child agent equipped with a `get_weather` tool. |
+| [gpt-5.ts](./gpt-5.ts) | `pnpm -F ai-sdk start:gpt-5` | OpenAI (`OPENAI_API_KEY`) | Shows a single agent that must call the `get_weather` tool using `gpt-5.2` with custom provider options. |
+| [stream.ts](./stream.ts) | `pnpm -F ai-sdk start:stream` | OpenAI (`OPENAI_API_KEY`) | Demonstrates streaming text output from an AI SDK model wrapped with `aisdk()`. |
+| [image-tool-output.ts](./image-tool-output.ts) | `pnpm -F ai-sdk start:image-tool-output` | OpenRouter (`OPENROUTER_API_KEY`) | Returns a `ToolOutputImage` from a tool call and asks the model to describe the image. |
 
 ## Prerequisites
 

--- a/examples/ai-sdk/gpt-5.ts
+++ b/examples/ai-sdk/gpt-5.ts
@@ -1,5 +1,5 @@
 import { Agent, run, tool } from '@openai/agents';
-import { aisdk } from '@openai/agents-extensions';
+import { aisdk } from '@openai/agents-extensions/ai-sdk';
 import { z } from 'zod';
 import { openai } from '@ai-sdk/openai';
 

--- a/examples/ai-sdk/image-tool-output.ts
+++ b/examples/ai-sdk/image-tool-output.ts
@@ -1,5 +1,5 @@
 import { Agent, run, tool, ToolOutputImage } from '@openai/agents';
-import { aisdk, AiSdkModel } from '@openai/agents-extensions';
+import { aisdk, AiSdkModel } from '@openai/agents-extensions/ai-sdk';
 import { z } from 'zod';
 
 const fetchRandomImage = tool({

--- a/examples/ai-sdk/index.ts
+++ b/examples/ai-sdk/index.ts
@@ -1,5 +1,5 @@
 import { Agent, ModelSettings, Runner, tool } from '@openai/agents';
-import { aisdk, AiSdkModel } from '@openai/agents-extensions';
+import { aisdk, AiSdkModel } from '@openai/agents-extensions/ai-sdk';
 import { z } from 'zod';
 
 export async function runAgents(

--- a/examples/ai-sdk/stream.ts
+++ b/examples/ai-sdk/stream.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { Agent, run, tool } from '@openai/agents';
-import { aisdk, AiSdkModel } from '@openai/agents-extensions';
+import { aisdk, AiSdkModel } from '@openai/agents-extensions/ai-sdk';
 
 export async function runAgents(model: AiSdkModel) {
   const getWeatherTool = tool({

--- a/examples/ai-sdk/tsconfig.json
+++ b/examples/ai-sdk/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../../tsconfig.examples.json"
+  "extends": "../../tsconfig.examples.json",
+  "compilerOptions": {
+    "moduleResolution": "bundler"
+  }
 }

--- a/integration-tests/bun/aisdk.ts
+++ b/integration-tests/bun/aisdk.ts
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { Agent, Runner } from '@openai/agents';
-import { aisdk } from '@openai/agents-extensions';
+import { aisdk } from '@openai/agents-extensions/ai-sdk';
 
 const fakeModel = {
   provider: 'fake',

--- a/integration-tests/cloudflare-workers/worker/src/index.ts
+++ b/integration-tests/cloudflare-workers/worker/src/index.ts
@@ -27,7 +27,7 @@ import {
   setTraceProcessors,
   withTrace,
 } from '@openai/agents';
-import { aisdk } from '@openai/agents-extensions';
+import { aisdk } from '@openai/agents-extensions/ai-sdk';
 
 export default {
   async fetch(request, env, ctx): Promise<Response> {

--- a/integration-tests/deno/aisdk.ts
+++ b/integration-tests/deno/aisdk.ts
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { Agent, Runner } from '@openai/agents';
-import { aisdk } from '@openai/agents-extensions';
+import { aisdk } from '@openai/agents-extensions/ai-sdk';
 
 const fakeModel = {
   provider: 'fake',

--- a/integration-tests/node-ai-sdk-v2-ts/src/index.ts
+++ b/integration-tests/node-ai-sdk-v2-ts/src/index.ts
@@ -1,5 +1,5 @@
 import { Agent, run, tool } from '@openai/agents';
-import { aisdk } from '@openai/agents-extensions';
+import { aisdk } from '@openai/agents-extensions/ai-sdk';
 import { z } from 'zod';
 import { openai } from '@ai-sdk/openai';
 

--- a/integration-tests/node-ai-sdk-v3-ts/src/index.ts
+++ b/integration-tests/node-ai-sdk-v3-ts/src/index.ts
@@ -1,5 +1,5 @@
 import { Agent, run, tool } from '@openai/agents';
-import { aisdk } from '@openai/agents-extensions';
+import { aisdk } from '@openai/agents-extensions/ai-sdk';
 import { z } from 'zod';
 import { openai } from '@ai-sdk/openai';
 

--- a/integration-tests/node/aisdk.cjs
+++ b/integration-tests/node/aisdk.cjs
@@ -1,7 +1,7 @@
 // @ts-check
 
 const { Agent, Runner } = require('@openai/agents');
-const { aisdk } = require('@openai/agents-extensions');
+const { aisdk } = require('@openai/agents-extensions/ai-sdk');
 
 const fakeModel = {
   provider: 'fake',

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -1008,7 +1008,7 @@ export type AiSdkModelOptions = {
  * If tracing is enabled, the model will send generation spans to your traces processor.
  *
  * ```ts
- * import { aisdk } from '@openai/agents-extensions';
+ * import { aisdk } from '@openai/agents-extensions/ai-sdk';
  * import { openai } from '@ai-sdk/openai';
  *
  * const model = aisdk(openai('gpt-4o'));
@@ -1652,7 +1652,7 @@ export class AiSdkModel implements Model {
  * If tracing is enabled, the model will send generation spans to your traces processor.
  *
  * ```ts
- * import { aisdk } from '@openai/agents-extensions';
+ * import { aisdk } from '@openai/agents-extensions/ai-sdk';
  * import { openai } from '@ai-sdk/openai';
  *
  * const model = aisdk(openai('gpt-4o'));

--- a/packages/agents-extensions/src/index.ts
+++ b/packages/agents-extensions/src/index.ts
@@ -1,8 +1,2 @@
 export * from './CloudflareRealtimeTransport';
 export * from './TwilioRealtimeTransport';
-
-// Optional peer dependency: @ai-sdk/provider.
-// Kept for backward compatibility; prefer importing from "@openai/agents-extensions/ai-sdk".
-// If you see TypeScript errors without using aiSdk(), please install @ai-sdk/provider for now.
-// This re-export will be removed in v0.5.
-export * from './ai-sdk/index';


### PR DESCRIPTION
This pull request removes the deprecated top-level AI SDK exports from `@openai/agents-extensions` ahead of the `0.6.0` release. Consumers must now import `aisdk` and `AiSdkModel` from `@openai/agents-extensions/ai-sdk` instead of the package root.

The change updates the package root exports, switches the repo's AI SDK examples and integration fixtures to the subpath import, and adjusts the `examples/ai-sdk` TypeScript configuration so the subpath export resolves during local type checking. A minor changeset is included to document the breaking import-path change for `@openai/agents-extensions`.