### PR TITLE
feat: add Responses tool search support

### DIFF
--- a/.changeset/tool-search-support.md
+++ b/.changeset/tool-search-support.md
@@ -1,0 +1,8 @@
+---
+'@openai/agents': patch
+'@openai/agents-core': patch
+'@openai/agents-extensions': patch
+'@openai/agents-openai': patch
+---
+
+feat: add Responses tool search support

--- a/examples/realtime-twilio-sip/package.json
+++ b/examples/realtime-twilio-sip/package.json
@@ -8,7 +8,7 @@
     "dotenv": "^16.5.0",
     "fastify": "^5.8.1",
     "fastify-raw-body": "^5.0.0",
-    "openai": "^6.20.0"
+    "openai": "^6.26.0"
   },
   "scripts": {
     "build-check": "tsc --noEmit",

--- a/examples/tools/README.md
+++ b/examples/tools/README.md
@@ -16,6 +16,12 @@ These examples demonstrate the hosted tools provided by the Agents SDK.
   pnpm examples:tools-file-search
   ```
 
+- `tool-search.ts` – Demonstrates deferred namespace loading plus a top-level deferred `tool_search` example with selective loading.
+
+  ```bash
+  pnpm examples:tools-tool-search
+  ```
+
 - `codex.ts` – Runs the Codex CLI via the codex tool wrapper with streaming event logs and skill usage. Requires `CODEX_API_KEY` or `OPENAI_API_KEY` (Codex falls back to this unless `CODEX_API_KEY` is set). You can set `CODEX_PATH` to override the Codex CLI path.
 
   ```bash

--- a/examples/tools/package.json
+++ b/examples/tools/package.json
@@ -17,6 +17,7 @@
     "start:computer-use": "tsx computer-use.ts",
     "start:computer-use-hitl": "tsx computer-use-hitl.ts",
     "start:file-search": "tsx file-search.ts",
+    "start:tool-search": "tsx tool-search.ts",
     "start:web-search": "tsx web-search.ts",
     "start:web-search-filters": "tsx web-search-filters.ts",
     "start:code-interpreter": "tsx code-interpreter.ts",

--- a/examples/tools/tool-search.ts
+++ b/examples/tools/tool-search.ts
@@ -1,0 +1,309 @@
+import {
+  Agent,
+  run,
+  tool,
+  toolNamespace,
+  toolSearchTool,
+  withTrace,
+} from '@openai/agents';
+import { z } from 'zod';
+
+const customerIdParams = z.object({
+  customerId: z.string().describe('The customer identifier to look up.'),
+});
+
+const trackingNumberParams = z.object({
+  trackingNumber: z.string().describe('The tracking number to look up.'),
+});
+
+const crmTools = toolNamespace({
+  name: 'crm',
+  description: 'CRM tools for customer profile and support lookups.',
+  tools: [
+    tool({
+      name: 'get_customer_profile',
+      description: 'Fetch a basic customer profile.',
+      parameters: customerIdParams,
+      deferLoading: true,
+      execute: async ({ customerId }) => {
+        if (customerId !== 'customer_42') {
+          return null;
+        }
+
+        return {
+          customerId,
+          fullName: 'Avery Chen',
+          tier: 'enterprise',
+        };
+      },
+    }),
+    tool({
+      name: 'list_recent_support_tickets',
+      description: 'List recent support tickets for a customer.',
+      parameters: customerIdParams,
+      deferLoading: true,
+      execute: async ({ customerId }) => {
+        if (customerId !== 'customer_42') {
+          return [];
+        }
+
+        return [
+          {
+            ticketId: 'ticket_991',
+            status: 'open',
+            summary: 'Requested shipment ETA after warehouse split.',
+          },
+        ];
+      },
+    }),
+  ],
+});
+
+const billingTools = toolNamespace({
+  name: 'billing',
+  description: 'Billing tools for invoice lookups.',
+  tools: [
+    tool({
+      name: 'get_invoice_status',
+      description: 'Look up invoice status for a customer.',
+      parameters: customerIdParams,
+      deferLoading: true,
+      execute: async ({ customerId }) => {
+        if (customerId !== 'customer_42') {
+          return null;
+        }
+
+        return {
+          invoiceId: 'inv_4201',
+          status: 'paid',
+        };
+      },
+    }),
+  ],
+});
+
+const getShippingEta = tool({
+  name: 'get_shipping_eta',
+  description: 'Look up a shipment ETA by tracking number.',
+  parameters: trackingNumberParams,
+  deferLoading: true,
+  execute: async ({ trackingNumber }) => {
+    if (trackingNumber !== 'ZX-123') {
+      return null;
+    }
+
+    return {
+      trackingNumber,
+      eta: '2026-03-07',
+      carrier: 'Priority Express',
+    };
+  },
+});
+
+const getShippingCreditBalance = tool({
+  name: 'get_shipping_credit_balance',
+  description: 'Look up a customer shipping credit balance.',
+  parameters: customerIdParams,
+  deferLoading: true,
+  execute: async ({ customerId }) => {
+    if (customerId !== 'customer_42') {
+      return null;
+    }
+
+    return {
+      customerId,
+      creditBalance: 125,
+      currency: 'USD',
+    };
+  },
+});
+
+async function main() {
+  const namespacedAgent = new Agent({
+    name: 'CRM assistant',
+    model: 'gpt-5.4',
+    instructions:
+      'For customer questions in this example, load the full crm namespace with no query filter before calling tools. Do not search billing unless the user explicitly asks about invoices.',
+    modelSettings: {
+      parallelToolCalls: false,
+    },
+    tools: [...crmTools, ...billingTools, toolSearchTool()],
+  });
+  const topLevelAgent = new Agent({
+    name: 'Shipping assistant',
+    model: 'gpt-5.4',
+    instructions:
+      'Use shipping tools to answer shipping questions. For tracking-number ETA questions, search only get_shipping_eta. Do not search get_shipping_credit_balance unless the user asks about credits or balances.',
+    modelSettings: {
+      parallelToolCalls: false,
+    },
+    tools: [getShippingEta, getShippingCreditBalance, toolSearchTool()],
+  });
+
+  await withTrace('Tool search example', async () => {
+    const namespacedResult = await run(
+      namespacedAgent,
+      'Look up customer_42 and summarize their profile and recent support activity.',
+    );
+    const namespacedLoadedTools = getLoadedTools(namespacedResult.newItems);
+    const namespacedCalledTools = getCalledTools(namespacedResult.newItems);
+    const allNamespacedTools = [
+      'crm.get_customer_profile',
+      'crm.list_recent_support_tickets',
+      'billing.get_invoice_status',
+    ];
+
+    console.log('### Tool search with namespaces');
+    console.log(namespacedResult.finalOutput);
+    console.log(`Loaded tools: ${formatList(namespacedLoadedTools)}`);
+    console.log(
+      `Not loaded tools: ${formatList(
+        allNamespacedTools.filter(
+          (toolName) => !namespacedLoadedTools.includes(toolName),
+        ),
+      )}`,
+    );
+    console.log(`Called tools: ${formatList(namespacedCalledTools)}`);
+    console.log();
+
+    const topLevelResult = await run(
+      topLevelAgent,
+      'Can you check the shipping ETA for tracking number ZX-123?',
+    );
+    const topLevelLoadedTools = getLoadedTools(topLevelResult.newItems);
+    const topLevelCalledTools = getCalledTools(topLevelResult.newItems);
+    const allTopLevelTools = [
+      'get_shipping_eta',
+      'get_shipping_credit_balance',
+    ];
+
+    console.log('### Top-level deferred tools');
+    console.log(topLevelResult.finalOutput);
+    console.log(`Loaded tools: ${formatList(topLevelLoadedTools)}`);
+    console.log(
+      `Not loaded tools: ${formatList(
+        allTopLevelTools.filter(
+          (toolName) => !topLevelLoadedTools.includes(toolName),
+        ),
+      )}`,
+    );
+    console.log(`Called tools: ${formatList(topLevelCalledTools)}`);
+  });
+}
+
+type ExampleRunItem = {
+  type: string;
+  rawItem?: unknown;
+};
+
+function getLoadedTools(newItems: ExampleRunItem[]): string[] {
+  return [
+    ...new Set(
+      newItems.flatMap((item) => {
+        if (
+          item.type !== 'tool_search_output_item' ||
+          typeof item.rawItem !== 'object' ||
+          item.rawItem === null
+        ) {
+          return [];
+        }
+
+        const tools = (item.rawItem as { tools?: unknown }).tools;
+        if (!Array.isArray(tools)) {
+          return [];
+        }
+
+        return extractLoadedToolNames(tools);
+      }),
+    ),
+  ];
+}
+
+function extractLoadedToolNames(
+  tools: unknown[],
+  namespacePrefix?: string,
+): string[] {
+  return tools.flatMap((toolEntry) => {
+    if (typeof toolEntry !== 'object' || toolEntry === null) {
+      return [];
+    }
+
+    const tool = toolEntry as {
+      type?: unknown;
+      name?: unknown;
+      tools?: unknown;
+      functionName?: unknown;
+      namespace?: unknown;
+    };
+
+    if (tool.type === 'namespace') {
+      const namespace =
+        typeof tool.name === 'string'
+          ? namespacePrefix
+            ? `${namespacePrefix}.${tool.name}`
+            : tool.name
+          : namespacePrefix;
+      if (!namespace) {
+        return [];
+      }
+      if (!Array.isArray(tool.tools) || tool.tools.length === 0) {
+        return [namespace];
+      }
+      return extractLoadedToolNames(tool.tools, namespace);
+    }
+
+    if (
+      tool.type === 'tool_reference' &&
+      typeof tool.functionName === 'string'
+    ) {
+      const namespace =
+        typeof tool.namespace === 'string' ? tool.namespace : namespacePrefix;
+      return [
+        namespace ? `${namespace}.${tool.functionName}` : tool.functionName,
+      ];
+    }
+
+    if (tool.type === 'function' && typeof tool.name === 'string') {
+      return [namespacePrefix ? `${namespacePrefix}.${tool.name}` : tool.name];
+    }
+
+    return [];
+  });
+}
+
+function getCalledTools(newItems: ExampleRunItem[]): string[] {
+  return [
+    ...new Set(
+      newItems.flatMap((item) => {
+        if (
+          item.type !== 'tool_call_item' ||
+          typeof item.rawItem !== 'object' ||
+          item.rawItem === null
+        ) {
+          return [];
+        }
+
+        const name = (item.rawItem as { name?: unknown }).name;
+        if (typeof name !== 'string') {
+          return [];
+        }
+
+        const namespace = (item.rawItem as { namespace?: unknown }).namespace;
+        if (typeof namespace !== 'string' || namespace === name) {
+          return [name];
+        }
+
+        return [`${namespace}.${name}`];
+      }),
+    ),
+  ];
+}
+
+function formatList(values: string[]): string {
+  return values.join(', ') || 'none';
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "examples:tools-codex": "pnpm -F tools start:codex",
     "examples:tools-codex-same-thread": "pnpm -F tools start:codex-same-thread",
     "examples:tools-file-search": "pnpm -F tools start:file-search",
+    "examples:tools-tool-search": "pnpm -F tools start:tool-search",
     "examples:tools-web-search": "pnpm -F tools start:web-search",
     "examples:tools-shell": "pnpm -F tools start:shell",
     "examples:tools-container-shell": "pnpm -F tools start:container-shell",

--- a/packages/agents-core/package.json
+++ b/packages/agents-core/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "debug": "^4.4.0",
-    "openai": "^6.20.0"
+    "openai": "^6.26.0"
   },
   "peerDependencies": {
     "zod": "^4.0.0"

--- a/packages/agents-core/src/events.ts
+++ b/packages/agents-core/src/events.ts
@@ -25,6 +25,8 @@ export type RunItemStreamEventName =
   | 'message_output_created'
   | 'handoff_requested'
   | 'handoff_occurred'
+  | 'tool_search_called'
+  | 'tool_search_output_created'
   | 'tool_called'
   | 'tool_output'
   | 'reasoning_item_created'

--- a/packages/agents-core/src/extensions/handoffFilters.ts
+++ b/packages/agents-core/src/extensions/handoffFilters.ts
@@ -5,12 +5,16 @@ import {
   RunItem,
   RunToolCallItem,
   RunToolCallOutputItem,
+  RunToolSearchCallItem,
+  RunToolSearchOutputItem,
 } from '../items';
 import { AgentInputItem } from '../types';
 
 const TOOL_TYPES = new Set([
   'function_call',
   'function_call_result',
+  'tool_search_call',
+  'tool_search_output',
   'computer_call',
   'computer_call_result',
   'shell_call',
@@ -21,9 +25,10 @@ const TOOL_TYPES = new Set([
 ]);
 
 /**
- * Filters out all tool items: file search, web search and function calls+output
- * @param handoffInputData
- * @returns
+ * Filters out tool-related history and run items before a handoff.
+ *
+ * @param handoffInputData The collected handoff input to sanitize.
+ * @returns Handoff input without tool calls, tool outputs, or tool search items.
  */
 export function removeAllTools(
   handoffInputData: HandoffInputData,
@@ -51,6 +56,8 @@ function removeToolsFromItems(items: RunItem[]): RunItem[] {
     (item) =>
       !(item instanceof RunHandoffCallItem) &&
       !(item instanceof RunHandoffOutputItem) &&
+      !(item instanceof RunToolSearchCallItem) &&
+      !(item instanceof RunToolSearchOutputItem) &&
       !(item instanceof RunToolCallItem) &&
       !(item instanceof RunToolCallOutputItem),
   );

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -94,6 +94,8 @@ export {
   RunToolApprovalItem,
   RunToolCallItem,
   RunToolCallOutputItem,
+  RunToolSearchCallItem,
+  RunToolSearchOutputItem,
 } from './items';
 export { AgentHooks } from './lifecycle';
 export { getLogger } from './logger';
@@ -171,6 +173,7 @@ export { RunState } from './runState';
 export type { TracingConfig } from './tracing';
 export {
   HostedTool,
+  attachClientToolSearchExecutor,
   ComputerTool,
   computerTool,
   ShellTool,
@@ -185,12 +188,18 @@ export {
   ToolTimeoutErrorFunction,
   Tool,
   tool,
+  toolNamespace,
   invokeFunctionTool,
+  getClientToolSearchExecutor,
+  getToolSearchRuntimeToolKey,
   ToolExecuteArgument,
   ToolEnabledFunction,
   ToolOptionsWithGuardrails,
 } from './tool';
 export type {
+  ClientToolSearchExecutor,
+  ClientToolSearchExecutorArgs,
+  ClientToolSearchExecutorResult,
   ComputerOnSafetyCheckFunction,
   ComputerSafetyCheck,
   ComputerSafetyCheckResult,
@@ -210,6 +219,7 @@ export type {
   ShellToolContainerNetworkPolicyDomainSecret,
   ToolInputParameters,
   ToolOptions,
+  ToolNamespaceOptions,
 } from './tool';
 export type {
   ToolOutputText,
@@ -240,6 +250,11 @@ export type {
   FunctionCallResultItem,
   JsonSchemaDefinition,
   ReasoningItem,
+  ToolReference,
+  ToolSearchOutputTool,
+  ToolSearchCallArguments,
+  ToolSearchCallItem,
+  ToolSearchOutputItem,
   ResponseStreamEvent,
   SystemMessageItem,
   TextOutput,

--- a/packages/agents-core/src/items.ts
+++ b/packages/agents-core/src/items.ts
@@ -1,6 +1,10 @@
 import { Agent } from './agent';
 import { toSmartString } from './utils/smartString';
 import * as protocol from './types/protocol';
+import {
+  getFunctionToolQualifiedName,
+  resolveFunctionToolCallName,
+} from './toolIdentity';
 
 export class RunItemBase {
   public readonly type: string = 'base_item' as const;
@@ -47,6 +51,42 @@ export class RunToolCallItem extends RunItemBase {
 
   constructor(
     public rawItem: protocol.ToolCallItem,
+    public agent: Agent,
+  ) {
+    super();
+  }
+
+  toJSON() {
+    return {
+      ...super.toJSON(),
+      agent: this.agent.toJSON(),
+    };
+  }
+}
+
+export class RunToolSearchCallItem extends RunItemBase {
+  public readonly type = 'tool_search_call_item' as const;
+
+  constructor(
+    public rawItem: protocol.ToolSearchCallItem,
+    public agent: Agent,
+  ) {
+    super();
+  }
+
+  toJSON() {
+    return {
+      ...super.toJSON(),
+      agent: this.agent.toJSON(),
+    };
+  }
+}
+
+export class RunToolSearchOutputItem extends RunItemBase {
+  public readonly type = 'tool_search_output_item' as const;
+
+  constructor(
+    public rawItem: protocol.ToolSearchOutputItem,
     public agent: Agent,
   ) {
     super();
@@ -157,7 +197,7 @@ export class RunToolApprovalItem extends RunItemBase {
     public toolName?: string,
   ) {
     super();
-    this.toolName = toolName ?? (rawItem as any).name;
+    this.toolName = toolName ?? getDefaultApprovalToolName(rawItem, agent);
   }
 
   /**
@@ -184,9 +224,45 @@ export class RunToolApprovalItem extends RunItemBase {
   }
 }
 
+function getDefaultApprovalToolName(
+  rawItem: RunToolApprovalItem['rawItem'],
+  agent: Agent<any, any>,
+): string | undefined {
+  if (rawItem.type !== 'function_call') {
+    return (rawItem as any).name;
+  }
+
+  const availableFunctionTools = new Map(
+    agent.tools.flatMap((tool) => {
+      if (tool.type !== 'function' || typeof tool.name !== 'string') {
+        return [];
+      }
+      return [[getFunctionToolQualifiedName(tool) ?? tool.name, tool] as const];
+    }),
+  );
+
+  const resolvedToolName = resolveFunctionToolCallName(
+    rawItem,
+    availableFunctionTools,
+  );
+
+  if (
+    typeof rawItem.name === 'string' &&
+    typeof rawItem.namespace === 'string' &&
+    rawItem.namespace === rawItem.name &&
+    !availableFunctionTools.has(`${rawItem.namespace}.${rawItem.name}`)
+  ) {
+    return rawItem.name;
+  }
+
+  return resolvedToolName ?? rawItem.name;
+}
+
 export type RunItem =
   | RunMessageOutputItem
   | RunToolCallItem
+  | RunToolSearchCallItem
+  | RunToolSearchOutputItem
   | RunReasoningItem
   | RunHandoffCallItem
   | RunToolCallOutputItem

--- a/packages/agents-core/src/metadata.ts
+++ b/packages/agents-core/src/metadata.ts
@@ -6,7 +6,7 @@ export const METADATA = {
   "version": "0.5.4",
   "versions": {
     "@openai/agents-core": "0.5.4",
-    "openai": "^6.20.0"
+    "openai": "^6.26.0"
   }
 };
 

--- a/packages/agents-core/src/model.ts
+++ b/packages/agents-core/src/model.ts
@@ -175,6 +175,21 @@ export type SerializedFunctionTool = {
    * (might result in slower response times).
    */
   strict: FunctionTool['strict'];
+
+  /**
+   * Responses API only. Whether a top-level function tool stays hidden until tool search loads it.
+   */
+  deferLoading?: FunctionTool['deferLoading'];
+
+  /**
+   * Responses API only. Explicit namespace used to group related function tools.
+   */
+  namespace?: string;
+
+  /**
+   * Responses API only. Description shared by all tools in the namespace. Required when namespace is set.
+   */
+  namespaceDescription?: string;
 };
 
 export type SerializedComputerTool = {

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -50,7 +50,7 @@ import {
   maybeResetToolChoice,
   selectModel,
 } from './runner/modelSettings';
-import { processModelResponse } from './runner/modelOutputs';
+import { processModelResponseAsync } from './runner/modelOutputs';
 import {
   addStepToRunResult,
   streamStepItemsToRunResult,
@@ -827,11 +827,13 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               );
             }
 
-            const processedResponse = processModelResponse(
+            const processedResponse = await processModelResponseAsync(
               state._lastTurnResponse,
               state._currentAgent,
               preparedCall.tools,
               preparedCall.handoffs,
+              state,
+              [...preparedCall.turnInput, ...state._generatedItems],
             );
 
             state._lastProcessedResponse = processedResponse;
@@ -1249,11 +1251,13 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           }
           result.state._modelResponses.push(result.state._lastTurnResponse);
 
-          const processedResponse = processModelResponse(
+          const processedResponse = await processModelResponseAsync(
             result.state._lastTurnResponse,
             currentAgent,
             preparedCall.tools,
             preparedCall.handoffs,
+            result.state,
+            [...preparedCall.turnInput, ...result.state._generatedItems],
           );
 
           result.state._lastProcessedResponse = processedResponse;

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -7,6 +7,8 @@ import {
   RunToolApprovalItem,
   RunToolCallItem,
   RunToolCallOutputItem,
+  RunToolSearchCallItem,
+  RunToolSearchOutputItem,
   RunReasoningItem,
   RunHandoffCallItem,
   RunHandoffOutputItem,
@@ -33,8 +35,19 @@ import type {
   ToolOutputGuardrailResult,
 } from './toolGuardrail';
 import { safeExecute } from './utils/safeExecute';
-import { HostedMCPTool, ShellTool, ApplyPatchTool } from './tool';
+import {
+  getToolSearchRuntimeToolKey,
+  HostedMCPTool,
+  ShellTool,
+  ApplyPatchTool,
+  Tool,
+} from './tool';
 import type { AgentToolInvocation } from './agentToolInvocation';
+import {
+  getFunctionToolQualifiedName,
+  resolveFunctionToolCallName,
+} from './toolIdentity';
+import { getToolSearchOutputReplacementKey } from './utils/toolSearch';
 
 /**
  * The schema version of the serialized run state. This is used to ensure that the serialized
@@ -51,9 +64,10 @@ import type { AgentToolInvocation } from './agentToolInvocation';
  * - 1.4: Adds optional toolInput to serialized run context.
  * - 1.5: Adds optional reasoningItemIdPolicy to preserve reasoning input policy across resume.
  * - 1.6: Adds optional requestId to serialized model responses.
- * - 1.7: Adds optional approval rejection messages to serialized run context.
+ * - 1.7: Adds optional approval rejection messages.
+ * - 1.8: Adds tool search item variants to serialized run state payloads.
  */
-export const CURRENT_SCHEMA_VERSION = '1.7' as const;
+export const CURRENT_SCHEMA_VERSION = '1.8' as const;
 const SUPPORTED_SCHEMA_VERSIONS = [
   '1.0',
   '1.1',
@@ -62,6 +76,7 @@ const SUPPORTED_SCHEMA_VERSIONS = [
   '1.4',
   '1.5',
   '1.6',
+  '1.7',
   CURRENT_SCHEMA_VERSION,
 ] as const;
 type SupportedSchemaVersion = (typeof SUPPORTED_SCHEMA_VERSIONS)[number];
@@ -135,6 +150,16 @@ const itemSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('message_output_item'),
     rawItem: protocol.AssistantMessageItem,
+    agent: serializedAgentSchema,
+  }),
+  z.object({
+    type: z.literal('tool_search_call_item'),
+    rawItem: protocol.ToolSearchCallItem,
+    agent: serializedAgentSchema,
+  }),
+  z.object({
+    type: z.literal('tool_search_output_item'),
+    rawItem: protocol.ToolSearchOutputItem,
     agent: serializedAgentSchema,
   }),
   z.object({
@@ -356,6 +381,17 @@ export const SerializedRunState = z.object({
 
 export type FinalOutputSource = 'error_handler' | 'turn_resolution';
 
+type ToolSearchRuntimeToolEntry<TContext = UnknownContext> = {
+  order: number;
+  tools: Tool<TContext>[];
+};
+
+type ToolSearchRuntimeToolState<TContext = UnknownContext> = {
+  anonymousEntries: ToolSearchRuntimeToolEntry<TContext>[];
+  keyedEntries: Map<string, ToolSearchRuntimeToolEntry<TContext>>;
+  nextOrder: number;
+};
+
 /**
  * Serializable snapshot of an agent's run, including context, usage and trace.
  * While this class has publicly writable properties (prefixed with `_`), they are not meant to be
@@ -490,6 +526,14 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
    * Trace associated with this run if tracing is enabled.
    */
   public _trace: Trace | null = null;
+  /**
+   * Runtime-only tool_search-loaded tools, scoped by agent name and preserved across turns for
+   * the lifetime of this in-memory run.
+   */
+  public _toolSearchRuntimeToolsByAgentName = new Map<
+    string,
+    ToolSearchRuntimeToolState<TContext>
+  >();
 
   constructor(
     context: RunContext<TContext>,
@@ -539,6 +583,67 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
    */
   public setCurrentAgentSpan(span?: Span<AgentSpanData>): void {
     this._currentAgentSpan = span;
+  }
+
+  private getOrCreateToolSearchRuntimeToolState(
+    agentName: string,
+  ): ToolSearchRuntimeToolState<TContext> {
+    let state = this._toolSearchRuntimeToolsByAgentName.get(agentName);
+    if (!state) {
+      state = {
+        anonymousEntries: [],
+        keyedEntries: new Map(),
+        nextOrder: 0,
+      };
+      this._toolSearchRuntimeToolsByAgentName.set(agentName, state);
+    }
+    return state;
+  }
+
+  public recordToolSearchRuntimeTools(
+    agent: Agent<any, any>,
+    toolSearchOutput: protocol.ToolSearchOutputItem,
+    tools: Tool<TContext>[],
+  ): void {
+    const runtimeState = this.getOrCreateToolSearchRuntimeToolState(agent.name);
+    const entry: ToolSearchRuntimeToolEntry<TContext> = {
+      order: runtimeState.nextOrder++,
+      tools,
+    };
+    const replacementKey = getToolSearchOutputReplacementKey(toolSearchOutput);
+    if (replacementKey) {
+      runtimeState.keyedEntries.set(replacementKey, entry);
+      return;
+    }
+
+    runtimeState.anonymousEntries.push(entry);
+  }
+
+  public getToolSearchRuntimeTools(agent: Agent<any, any>): Tool<TContext>[] {
+    const runtimeState = this._toolSearchRuntimeToolsByAgentName.get(
+      agent.name,
+    );
+    if (!runtimeState) {
+      return [];
+    }
+
+    const dedupedTools = new Map<string, Tool<TContext>>();
+    const orderedEntries = [
+      ...runtimeState.keyedEntries.values(),
+      ...runtimeState.anonymousEntries,
+    ].sort((a, b) => a.order - b.order);
+    let anonymousCounter = 0;
+
+    for (const entry of orderedEntries) {
+      for (const tool of entry.tools) {
+        const key =
+          getToolSearchRuntimeToolKey(tool) ??
+          `anonymous:${entry.order}:${anonymousCounter++}`;
+        dedupedTools.set(key, tool);
+      }
+    }
+
+    return [...dedupedTools.values()];
   }
 
   /**
@@ -846,9 +951,88 @@ async function buildRunStateFromString<
       `Run state schema version ${currentSchemaVersion} is not supported. Please use version ${CURRENT_SCHEMA_VERSION}.`,
     );
   }
-
-  const stateJson = SerializedRunState.parse(JSON.parse(str));
+  const stateJson = SerializedRunState.parse(jsonResult);
+  assertSchemaVersionSupportsToolSearch(
+    currentSchemaVersion as SupportedSchemaVersion,
+    stateJson,
+  );
   return buildRunStateFromJson(initialAgent, stateJson, options);
+}
+
+function assertSchemaVersionSupportsToolSearch(
+  schemaVersion: SupportedSchemaVersion,
+  stateJson: z.infer<typeof SerializedRunState>,
+): void {
+  if (schemaVersion === '1.8') {
+    return;
+  }
+
+  if (!containsSerializedToolSearchState(stateJson)) {
+    return;
+  }
+
+  throw new UserError(
+    `Run state schema version ${schemaVersion} does not support tool_search items. Please reserialize the run state with schema ${CURRENT_SCHEMA_VERSION}.`,
+  );
+}
+
+function containsSerializedToolSearchState(
+  stateJson: z.infer<typeof SerializedRunState>,
+): boolean {
+  return (
+    containsToolSearchProtocolItems(stateJson.originalInput) ||
+    containsToolSearchInModelResponses(stateJson.modelResponses) ||
+    containsToolSearchInModelResponse(stateJson.lastModelResponse) ||
+    containsToolSearchRunItems(stateJson.generatedItems) ||
+    containsToolSearchInProcessedResponse(stateJson.lastProcessedResponse)
+  );
+}
+
+function containsToolSearchInModelResponses(
+  modelResponses: z.infer<typeof modelResponseSchema>[],
+): boolean {
+  return modelResponses.some(containsToolSearchInModelResponse);
+}
+
+function containsToolSearchInModelResponse(
+  modelResponse: z.infer<typeof modelResponseSchema> | undefined,
+): boolean {
+  return Boolean(
+    modelResponse?.output.some((item) => isToolSearchProtocolType(item.type)),
+  );
+}
+
+function containsToolSearchRunItems(
+  items: z.infer<typeof itemSchema>[] | undefined,
+): boolean {
+  return Boolean(
+    items?.some(
+      (item) =>
+        item.type === 'tool_search_call_item' ||
+        item.type === 'tool_search_output_item' ||
+        isToolSearchProtocolType(item.rawItem?.type),
+    ),
+  );
+}
+
+function containsToolSearchProtocolItems(
+  items: string | protocol.ModelItem[],
+): boolean {
+  return Array.isArray(items)
+    ? items.some((item) => isToolSearchProtocolType(item.type))
+    : false;
+}
+
+function containsToolSearchInProcessedResponse(
+  processedResponse:
+    | z.infer<typeof serializedProcessedResponseSchema>
+    | undefined,
+): boolean {
+  return containsToolSearchRunItems(processedResponse?.newItems);
+}
+
+function isToolSearchProtocolType(type: unknown): boolean {
+  return type === 'tool_search_call' || type === 'tool_search_output';
 }
 
 async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
@@ -1096,6 +1280,16 @@ export function deserializeItem(
         serializedItem.rawItem,
         agentMap.get(serializedItem.agent.name) as Agent<any, any>,
       );
+    case 'tool_search_call_item':
+      return new RunToolSearchCallItem(
+        serializedItem.rawItem,
+        agentMap.get(serializedItem.agent.name) as Agent<any, any>,
+      );
+    case 'tool_search_output_item':
+      return new RunToolSearchOutputItem(
+        serializedItem.rawItem,
+        agentMap.get(serializedItem.agent.name) as Agent<any, any>,
+      );
     case 'tool_call_item':
       return new RunToolCallItem(
         serializedItem.rawItem,
@@ -1233,7 +1427,7 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
   const tools = new Map(
     allTools
       .filter((tool) => tool.type === 'function')
-      .map((tool) => [tool.name, tool]),
+      .map((tool) => [getFunctionToolQualifiedName(tool) ?? tool.name, tool]),
   );
   const computerTools = new Map(
     allTools
@@ -1277,13 +1471,16 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
     }),
     functions: await Promise.all(
       serializedProcessedResponse.functions.map(async (functionCall) => {
-        if (!tools.has(functionCall.tool.name)) {
-          throw new UserError(`Tool ${functionCall.tool.name} not found`);
+        const toolIdentity =
+          resolveFunctionToolCallName(functionCall.toolCall, tools) ??
+          functionCall.tool.name;
+        if (!tools.has(toolIdentity)) {
+          throw new UserError(`Tool ${toolIdentity} not found`);
         }
 
         return {
           toolCall: functionCall.toolCall,
-          tool: tools.get(functionCall.tool.name)!,
+          tool: tools.get(toolIdentity)!,
         };
       }),
     ),

--- a/packages/agents-core/src/runner/modelOutputs.ts
+++ b/packages/agents-core/src/runner/modelOutputs.ts
@@ -9,8 +9,12 @@ import {
   RunToolApprovalItem,
   RunToolCallItem,
   RunToolCallOutputItem,
+  RunToolSearchCallItem,
+  RunToolSearchOutputItem,
 } from '../items';
 import { ModelResponse } from '../model';
+import { RunState } from '../runState';
+import type { AgentInputItem } from '../types';
 import {
   ApplyPatchTool,
   ComputerTool,
@@ -18,9 +22,23 @@ import {
   HostedMCPTool,
   ShellTool,
   Tool,
+  getClientToolSearchExecutor,
+  getToolSearchRuntimeToolKey,
 } from '../tool';
 import * as ProviderData from '../types/providerData';
 import { addErrorToCurrentSpan } from '../tracing/context';
+import {
+  getFunctionToolQualifiedName,
+  getFunctionToolNamespace,
+  getToolCallNamespace,
+  resolveFunctionToolCallName,
+} from '../toolIdentity';
+import {
+  getToolSearchMatchKey,
+  getToolSearchExecution,
+  getToolSearchOutputReplacementKey,
+  getToolSearchProviderCallId,
+} from '../utils';
 import type {
   ProcessedResponse,
   ToolRunApplyPatch,
@@ -31,6 +49,13 @@ import type {
   ToolRunShell,
 } from './types';
 import * as protocol from '../types/protocol';
+import {
+  addHostedMcpToolsFromToolSearchOutput,
+  addLoadedToolNamesFromToolSearchOutput,
+  createBuiltInClientToolSearchOutput,
+  executeCustomClientToolSearch,
+  getClientToolSearchHelper,
+} from './toolSearch';
 
 function ensureToolAvailable<T>(
   tool: T | undefined,
@@ -87,18 +112,40 @@ function resolveFunctionOrHandoff(
 ):
   | { type: 'handoff'; handoff: Handoff<any, any> }
   | { type: 'function'; tool: FunctionTool<any> } {
-  const handoff = handoffMap.get(toolCall.name);
-  if (handoff) {
-    return { type: 'handoff', handoff };
+  const resolvedToolName =
+    resolveFunctionToolCallName(toolCall, functionMap) ?? toolCall.name;
+  const namespace = getToolCallNamespace(toolCall);
+  if (!namespace && typeof resolvedToolName === 'string') {
+    const functionTool = functionMap.get(resolvedToolName);
+    const handoff = handoffMap.get(toolCall.name);
+    if (functionTool && handoff && resolvedToolName.includes('.')) {
+      const message = `Ambiguous dotted tool call ${resolvedToolName} in agent ${agent.name}: it matches both a namespaced function tool and a handoff. Rename one of them or emit the function call with explicit namespace metadata.`;
+      addErrorToCurrentSpan({
+        message,
+        data: {
+          tool_name: resolvedToolName,
+          agent_name: agent.name,
+        },
+      });
+      throw new ModelBehaviorError(message);
+    }
+
+    if (functionTool && resolvedToolName.includes('.')) {
+      return { type: 'function', tool: functionTool };
+    }
+
+    if (handoff) {
+      return { type: 'handoff', handoff };
+    }
   }
 
-  const functionTool = functionMap.get(toolCall.name);
+  const functionTool = functionMap.get(resolvedToolName);
   if (!functionTool) {
-    const message = `Tool ${toolCall.name} not found in agent ${agent.name}.`;
+    const message = `Tool ${resolvedToolName} not found in agent ${agent.name}.`;
     addErrorToCurrentSpan({
       message,
       data: {
-        tool_name: toolCall.name,
+        tool_name: resolvedToolName,
         agent_name: agent.name,
       },
     });
@@ -106,6 +153,419 @@ function resolveFunctionOrHandoff(
     throw new ModelBehaviorError(message);
   }
   return { type: 'function', tool: functionTool };
+}
+
+function normalizeFunctionToolCallForStorage(
+  toolCall: protocol.FunctionCallItem,
+  tool: FunctionTool<any>,
+): protocol.FunctionCallItem {
+  const namespace = getToolCallNamespace(toolCall);
+  const explicitNamespace = getFunctionToolNamespace(tool);
+  const qualifiedToolName = getFunctionToolQualifiedName(tool);
+
+  if (
+    namespace ||
+    !explicitNamespace ||
+    !qualifiedToolName ||
+    toolCall.name !== qualifiedToolName
+  ) {
+    return toolCall;
+  }
+
+  return {
+    ...toolCall,
+    name: tool.name,
+    namespace: explicitNamespace,
+  };
+}
+
+type LoadedDeferredToolState = {
+  anonymousToolSearchOutputs: protocol.ToolSearchOutputItem[];
+  keyedToolSearchOutputsByKey: Map<string, protocol.ToolSearchOutputItem>;
+  loadedToolNames: Set<string>;
+};
+
+function getRawAgentInputItem(
+  item: RunItem | AgentInputItem,
+): AgentInputItem | undefined {
+  if (
+    item &&
+    typeof item === 'object' &&
+    'rawItem' in item &&
+    item.rawItem &&
+    typeof item.rawItem === 'object'
+  ) {
+    return item.rawItem as AgentInputItem;
+  }
+
+  return item as AgentInputItem;
+}
+
+function refreshLoadedDeferredToolNames(state: LoadedDeferredToolState): void {
+  state.loadedToolNames.clear();
+
+  for (const toolSearchOutput of state.keyedToolSearchOutputsByKey.values()) {
+    addLoadedToolNamesFromToolSearchOutput(
+      toolSearchOutput,
+      state.loadedToolNames,
+    );
+  }
+
+  for (const toolSearchOutput of state.anonymousToolSearchOutputs) {
+    addLoadedToolNamesFromToolSearchOutput(
+      toolSearchOutput,
+      state.loadedToolNames,
+    );
+  }
+}
+
+function recordLoadedToolSearchOutput(
+  state: LoadedDeferredToolState,
+  toolSearchOutput: protocol.ToolSearchOutputItem,
+): void {
+  const replacementKey = getToolSearchOutputReplacementKey(toolSearchOutput);
+  if (replacementKey) {
+    state.keyedToolSearchOutputsByKey.set(replacementKey, toolSearchOutput);
+  } else {
+    state.anonymousToolSearchOutputs.push(toolSearchOutput);
+  }
+
+  refreshLoadedDeferredToolNames(state);
+}
+
+function collectLoadedDeferredToolStateFromHistory(
+  items: Array<RunItem | AgentInputItem>,
+  agent: Agent<any, any>,
+): LoadedDeferredToolState {
+  const state: LoadedDeferredToolState = {
+    anonymousToolSearchOutputs: [],
+    keyedToolSearchOutputsByKey: new Map(),
+    loadedToolNames: new Set<string>(),
+  };
+
+  for (const item of items) {
+    if (
+      item instanceof RunToolSearchOutputItem &&
+      item.agent.name !== agent.name
+    ) {
+      continue;
+    }
+
+    const rawItem = getRawAgentInputItem(item);
+    if (rawItem?.type !== 'tool_search_output') {
+      continue;
+    }
+
+    const replacementKey = getToolSearchOutputReplacementKey(rawItem);
+    if (replacementKey) {
+      state.keyedToolSearchOutputsByKey.set(replacementKey, rawItem);
+    } else {
+      state.anonymousToolSearchOutputs.push(rawItem);
+    }
+  }
+
+  refreshLoadedDeferredToolNames(state);
+  return state;
+}
+
+function seedHostedMcpToolsFromLoadedDeferredToolState(
+  state: LoadedDeferredToolState,
+  mcpToolMap: Map<string, HostedMCPTool>,
+  preserveExistingServerLabels: Set<string>,
+): void {
+  for (const toolSearchOutput of state.keyedToolSearchOutputsByKey.values()) {
+    addHostedMcpToolsFromToolSearchOutput(toolSearchOutput, mcpToolMap, {
+      preserveExistingServerLabels,
+    });
+  }
+
+  for (const toolSearchOutput of state.anonymousToolSearchOutputs) {
+    addHostedMcpToolsFromToolSearchOutput(toolSearchOutput, mcpToolMap, {
+      preserveExistingServerLabels,
+    });
+  }
+}
+
+function buildFunctionToolMap<TContext>(
+  tools: Tool<TContext>[],
+): Map<string, FunctionTool<TContext>> {
+  return new Map(
+    tools
+      .filter((t): t is FunctionTool<TContext> => t.type === 'function')
+      .map((t) => [getFunctionToolQualifiedName(t) ?? t.name, t]),
+  );
+}
+
+function registerRuntimeToolSearchTools<TContext>(args: {
+  availableTools: Tool<TContext>[];
+  functionMap: Map<string, FunctionTool<TContext>>;
+  mcpToolMap: Map<string, HostedMCPTool>;
+  replaceableRuntimeToolKeys?: Set<string>;
+  runtimeTools: Tool<TContext>[];
+}): Tool<TContext>[] {
+  const {
+    availableTools,
+    functionMap,
+    mcpToolMap,
+    replaceableRuntimeToolKeys,
+    runtimeTools,
+  } = args;
+  const availableToolsByKey = new Map<string, Tool<TContext>>();
+  for (const tool of availableTools) {
+    const key = getToolSearchRuntimeToolKey(tool);
+    if (key) {
+      availableToolsByKey.set(key, tool);
+    }
+  }
+
+  const novelTools: Tool<TContext>[] = [];
+  for (const runtimeTool of runtimeTools) {
+    const runtimeToolKey = getToolSearchRuntimeToolKey(runtimeTool);
+    if (!runtimeToolKey) {
+      throw new ModelBehaviorError(
+        'Client tool_search execute() returned an unsupported tool type.',
+      );
+    }
+
+    const existingTool = availableToolsByKey.get(runtimeToolKey);
+    if (existingTool && existingTool !== runtimeTool) {
+      if (!replaceableRuntimeToolKeys?.has(runtimeToolKey)) {
+        throw new ModelBehaviorError(
+          `Client tool_search execute() returned tool "${runtimeToolKey}" that conflicts with an existing available tool.`,
+        );
+      }
+    } else if (existingTool === runtimeTool) {
+      continue;
+    }
+
+    availableToolsByKey.set(runtimeToolKey, runtimeTool);
+    novelTools.push(runtimeTool);
+    if (runtimeTool.type === 'function') {
+      functionMap.set(
+        getFunctionToolQualifiedName(runtimeTool) ?? runtimeTool.name,
+        runtimeTool,
+      );
+      continue;
+    }
+
+    if (
+      runtimeTool.type === 'hosted_tool' &&
+      runtimeTool.providerData?.type === 'mcp'
+    ) {
+      mcpToolMap.set(
+        runtimeTool.providerData.server_label,
+        runtimeTool as HostedMCPTool,
+      );
+      continue;
+    }
+
+    throw new ModelBehaviorError(
+      'Client tool_search execute() returned an unsupported tool type.',
+    );
+  }
+
+  return novelTools;
+}
+
+type GeneratedClientToolSearchOutput<TContext> = {
+  output: protocol.ToolSearchOutputItem;
+  runtimeTools: Tool<TContext>[];
+};
+
+function buildGeneratedClientToolSearchOutputMap<TContext>(
+  modelResponse: ModelResponse,
+  tools: Tool<TContext>[],
+  hasClientToolSearchTool: boolean,
+): Map<protocol.ToolSearchCallItem, protocol.ToolSearchOutputItem> {
+  const clientToolSearchCalls: protocol.ToolSearchCallItem[] = [];
+  const pendingClientToolSearchMatchKeys: string[] = [];
+  const resolvedToolSearchCallIds = new Set<string>();
+
+  for (const output of modelResponse.output) {
+    if (output.type === 'tool_search_call') {
+      const toolSearchExecution = getToolSearchExecution(output);
+      if (
+        toolSearchExecution === 'client' ||
+        (typeof toolSearchExecution === 'undefined' && hasClientToolSearchTool)
+      ) {
+        clientToolSearchCalls.push(output);
+        const matchKey = getToolSearchMatchKey(output);
+        if (matchKey) {
+          pendingClientToolSearchMatchKeys.push(matchKey);
+        }
+      }
+      continue;
+    }
+
+    if (output.type !== 'tool_search_output') {
+      continue;
+    }
+
+    const explicitCallId = getToolSearchProviderCallId(output);
+    const toolSearchExecution = getToolSearchExecution(output);
+    if (explicitCallId) {
+      resolvedToolSearchCallIds.add(explicitCallId);
+      const pendingIndex =
+        pendingClientToolSearchMatchKeys.indexOf(explicitCallId);
+      if (pendingIndex >= 0) {
+        pendingClientToolSearchMatchKeys.splice(pendingIndex, 1);
+      }
+      continue;
+    }
+
+    if (toolSearchExecution !== 'server') {
+      const pendingMatchKey = pendingClientToolSearchMatchKeys.shift();
+      if (pendingMatchKey) {
+        resolvedToolSearchCallIds.add(pendingMatchKey);
+      }
+    }
+  }
+
+  const generatedOutputs = new Map<
+    protocol.ToolSearchCallItem,
+    protocol.ToolSearchOutputItem
+  >();
+  for (const toolSearchCall of clientToolSearchCalls) {
+    const matchKey = getToolSearchMatchKey(toolSearchCall);
+    if (matchKey && resolvedToolSearchCallIds.has(matchKey)) {
+      continue;
+    }
+
+    generatedOutputs.set(
+      toolSearchCall,
+      createBuiltInClientToolSearchOutput(toolSearchCall, tools),
+    );
+  }
+
+  return generatedOutputs;
+}
+
+async function buildGeneratedClientToolSearchOutputMapAsync<TContext>(args: {
+  agent: Agent<any, any>;
+  modelResponse: ModelResponse;
+  runContext: RunState<TContext, Agent<any, any>>['_context'];
+  tools: Tool<TContext>[];
+}): Promise<
+  Map<protocol.ToolSearchCallItem, GeneratedClientToolSearchOutput<TContext>>
+> {
+  const { agent, modelResponse, runContext, tools } = args;
+  const clientToolSearchTool = getClientToolSearchHelper(tools);
+  const hasClientToolSearchTool = typeof clientToolSearchTool !== 'undefined';
+  const executionTools = [...tools];
+  const clientToolSearchCalls: protocol.ToolSearchCallItem[] = [];
+  const pendingClientToolSearchMatchKeys: string[] = [];
+  const resolvedToolSearchCallIds = new Set<string>();
+
+  for (const output of modelResponse.output) {
+    if (output.type === 'tool_search_call') {
+      const toolSearchExecution = getToolSearchExecution(output);
+      if (
+        toolSearchExecution === 'client' ||
+        (typeof toolSearchExecution === 'undefined' && hasClientToolSearchTool)
+      ) {
+        clientToolSearchCalls.push(output);
+        const matchKey = getToolSearchMatchKey(output);
+        if (matchKey) {
+          pendingClientToolSearchMatchKeys.push(matchKey);
+        }
+      }
+      continue;
+    }
+
+    if (output.type !== 'tool_search_output') {
+      continue;
+    }
+
+    const explicitCallId = getToolSearchProviderCallId(output);
+    const toolSearchExecution = getToolSearchExecution(output);
+    if (explicitCallId) {
+      resolvedToolSearchCallIds.add(explicitCallId);
+      const pendingIndex =
+        pendingClientToolSearchMatchKeys.indexOf(explicitCallId);
+      if (pendingIndex >= 0) {
+        pendingClientToolSearchMatchKeys.splice(pendingIndex, 1);
+      }
+      continue;
+    }
+
+    if (toolSearchExecution !== 'server') {
+      const pendingMatchKey = pendingClientToolSearchMatchKeys.shift();
+      if (pendingMatchKey) {
+        resolvedToolSearchCallIds.add(pendingMatchKey);
+      }
+    }
+  }
+
+  const generatedOutputs = new Map<
+    protocol.ToolSearchCallItem,
+    GeneratedClientToolSearchOutput<TContext>
+  >();
+  for (const toolSearchCall of clientToolSearchCalls) {
+    const matchKey = getToolSearchMatchKey(toolSearchCall);
+    if (matchKey && resolvedToolSearchCallIds.has(matchKey)) {
+      continue;
+    }
+
+    if (
+      clientToolSearchTool &&
+      getClientToolSearchExecutor(clientToolSearchTool)
+    ) {
+      const generatedOutput = await executeCustomClientToolSearch({
+        agent,
+        runContext,
+        toolSearchCall,
+        toolSearchTool: clientToolSearchTool,
+        tools: executionTools,
+      });
+      generatedOutputs.set(toolSearchCall, generatedOutput);
+      executionTools.push(...generatedOutput.runtimeTools);
+      continue;
+    }
+
+    generatedOutputs.set(toolSearchCall, {
+      output: createBuiltInClientToolSearchOutput(
+        toolSearchCall,
+        executionTools,
+      ),
+      runtimeTools: [],
+    });
+  }
+
+  return generatedOutputs;
+}
+
+function ensureDeferredFunctionToolLoaded(
+  toolCall: protocol.FunctionCallItem,
+  tool: FunctionTool<any>,
+  loadedToolNames: Set<string>,
+  agent: Agent<any, any>,
+): void {
+  if (tool.deferLoading !== true) {
+    return;
+  }
+
+  const explicitNamespace = getFunctionToolNamespace(tool);
+  const qualifiedName = getFunctionToolQualifiedName(tool);
+  const isLoaded =
+    (qualifiedName ? loadedToolNames.has(qualifiedName) : false) ||
+    ((!explicitNamespace || explicitNamespace === tool.name) &&
+      loadedToolNames.has(tool.name));
+
+  if (isLoaded) {
+    return;
+  }
+
+  const toolName = qualifiedName ?? tool.name;
+  const message = `Model produced deferred function call ${toolName} before it was loaded via tool_search.`;
+  addErrorToCurrentSpan({
+    message,
+    data: {
+      agent_name: agent.name,
+      tool_name: toolName,
+      tool_call_id: toolCall.callId,
+    },
+  });
+  throw new ModelBehaviorError(message);
 }
 
 type ShellCallStatus = 'in_progress' | 'completed' | 'incomplete';
@@ -148,6 +608,7 @@ export function processModelResponse<TContext>(
   agent: Agent<any, any>,
   tools: Tool<TContext>[],
   handoffs: Handoff<any, any>[],
+  priorItems: Array<RunItem | AgentInputItem> = [],
 ): ProcessedResponse<TContext> {
   const items: RunItem[] = [];
   const runHandoffs: ToolRunHandoff[] = [];
@@ -163,7 +624,7 @@ export function processModelResponse<TContext>(
   const functionMap = new Map(
     tools
       .filter((t): t is FunctionTool<TContext> => t.type === 'function')
-      .map((t) => [t.name, t]),
+      .map((t) => [getFunctionToolQualifiedName(t) ?? t.name, t]),
   );
   const computerTool = tools.find(
     (t): t is ComputerTool<TContext, any> => t.type === 'computer',
@@ -178,12 +639,54 @@ export function processModelResponse<TContext>(
       .map((t) => t as HostedMCPTool)
       .map((t) => [t.providerData.server_label, t]),
   );
+  const originalMcpServerLabels = new Set(mcpToolMap.keys());
+  const hasClientToolSearchTool = tools.some(
+    (tool) =>
+      tool.type === 'hosted_tool' &&
+      tool.providerData?.type === 'tool_search' &&
+      tool.providerData.execution === 'client',
+  );
+  const loadedDeferredToolState = collectLoadedDeferredToolStateFromHistory(
+    priorItems,
+    agent,
+  );
+  seedHostedMcpToolsFromLoadedDeferredToolState(
+    loadedDeferredToolState,
+    mcpToolMap,
+    originalMcpServerLabels,
+  );
+  const generatedClientToolSearchOutputsByCall =
+    buildGeneratedClientToolSearchOutputMap(
+      modelResponse,
+      tools,
+      hasClientToolSearchTool,
+    );
+  let hasGeneratedClientToolSearchOutputs = false;
 
   for (const output of modelResponse.output) {
     if (output.type === 'message') {
       if (output.role === 'assistant') {
         items.push(new RunMessageOutputItem(output, agent));
       }
+    } else if (output.type === 'tool_search_call') {
+      items.push(new RunToolSearchCallItem(output, agent));
+      toolsUsed.push('tool_search');
+      const generatedOutput =
+        generatedClientToolSearchOutputsByCall.get(output);
+      if (generatedOutput) {
+        items.push(new RunToolSearchOutputItem(generatedOutput, agent));
+        recordLoadedToolSearchOutput(loadedDeferredToolState, generatedOutput);
+        addHostedMcpToolsFromToolSearchOutput(generatedOutput, mcpToolMap, {
+          preserveExistingServerLabels: originalMcpServerLabels,
+        });
+        hasGeneratedClientToolSearchOutputs = true;
+      }
+    } else if (output.type === 'tool_search_output') {
+      items.push(new RunToolSearchOutputItem(output, agent));
+      recordLoadedToolSearchOutput(loadedDeferredToolState, output);
+      addHostedMcpToolsFromToolSearchOutput(output, mcpToolMap, {
+        preserveExistingServerLabels: originalMcpServerLabels,
+      });
     } else if (output.type === 'hosted_tool_call') {
       items.push(new RunToolCallItem(output, agent));
       const toolName = output.name;
@@ -311,8 +814,6 @@ export function processModelResponse<TContext>(
       continue;
     }
 
-    toolsUsed.push(output.name);
-
     const resolved = resolveFunctionOrHandoff(
       output,
       handoffMap,
@@ -320,15 +821,29 @@ export function processModelResponse<TContext>(
       agent,
     );
     if (resolved.type === 'handoff') {
+      toolsUsed.push(output.name);
       items.push(new RunHandoffCallItem(output, agent));
       runHandoffs.push({
         toolCall: output,
         handoff: resolved.handoff,
       });
     } else {
-      items.push(new RunToolCallItem(output, agent));
+      ensureDeferredFunctionToolLoaded(
+        output,
+        resolved.tool,
+        loadedDeferredToolState.loadedToolNames,
+        agent,
+      );
+      const normalizedToolCall = normalizeFunctionToolCallForStorage(
+        output,
+        resolved.tool,
+      );
+      toolsUsed.push(
+        getFunctionToolQualifiedName(resolved.tool) ?? resolved.tool.name,
+      );
+      items.push(new RunToolCallItem(normalizedToolCall, agent));
       runFunctions.push({
-        toolCall: output,
+        toolCall: normalizedToolCall,
         tool: resolved.tool,
       });
     }
@@ -351,7 +866,306 @@ export function processModelResponse<TContext>(
         runComputerActions.length > 0 ||
         runShellActions.length > 0 ||
         hasHostedShellCall ||
-        runApplyPatchActions.length > 0
+        runApplyPatchActions.length > 0 ||
+        hasGeneratedClientToolSearchOutputs
+      );
+    },
+  };
+}
+
+export async function processModelResponseAsync<TContext>(
+  modelResponse: ModelResponse,
+  agent: Agent<any, any>,
+  tools: Tool<TContext>[],
+  handoffs: Handoff<any, any>[],
+  state: RunState<TContext, Agent<any, any>>,
+  priorItems: Array<RunItem | AgentInputItem> = [],
+): Promise<ProcessedResponse<TContext>> {
+  const clientToolSearchTool = getClientToolSearchHelper(tools);
+  const hasCustomClientToolSearchExecutor = Boolean(
+    clientToolSearchTool && getClientToolSearchExecutor(clientToolSearchTool),
+  );
+  const hasRelevantClientToolSearchCall = modelResponse.output.some(
+    (output) =>
+      output.type === 'tool_search_call' &&
+      (getToolSearchExecution(output) === 'client' ||
+        (typeof getToolSearchExecution(output) === 'undefined' &&
+          typeof clientToolSearchTool !== 'undefined')),
+  );
+  if (!hasCustomClientToolSearchExecutor || !hasRelevantClientToolSearchCall) {
+    return processModelResponse(
+      modelResponse,
+      agent,
+      tools,
+      handoffs,
+      priorItems,
+    );
+  }
+
+  const items: RunItem[] = [];
+  const runHandoffs: ToolRunHandoff[] = [];
+  const runFunctions: ToolRunFunction<TContext>[] = [];
+  const runComputerActions: ToolRunComputer[] = [];
+  const runShellActions: ToolRunShell[] = [];
+  let hasHostedShellCall = false;
+  const runApplyPatchActions: ToolRunApplyPatch[] = [];
+  const runMCPApprovalRequests: ToolRunMCPApprovalRequest[] = [];
+  const toolsUsed: string[] = [];
+  const handoffMap = new Map(handoffs.map((h) => [h.toolName, h]));
+  const functionMap = buildFunctionToolMap(tools);
+  const computerTool = tools.find(
+    (t): t is ComputerTool<TContext, any> => t.type === 'computer',
+  );
+  const shellTool = tools.find((t): t is ShellTool => t.type === 'shell');
+  const applyPatchTool = tools.find(
+    (t): t is ApplyPatchTool => t.type === 'apply_patch',
+  );
+  const mcpToolMap = new Map(
+    tools
+      .filter((t) => t.type === 'hosted_tool' && t.providerData?.type === 'mcp')
+      .map((t) => t as HostedMCPTool)
+      .map((t) => [t.providerData.server_label, t]),
+  );
+  const originalMcpServerLabels = new Set(mcpToolMap.keys());
+  const replaceableRuntimeToolKeys = new Set(
+    state
+      .getToolSearchRuntimeTools(agent)
+      .map((tool) => getToolSearchRuntimeToolKey(tool))
+      .filter((key): key is string => typeof key === 'string'),
+  );
+  const loadedDeferredToolState = collectLoadedDeferredToolStateFromHistory(
+    priorItems,
+    agent,
+  );
+  seedHostedMcpToolsFromLoadedDeferredToolState(
+    loadedDeferredToolState,
+    mcpToolMap,
+    originalMcpServerLabels,
+  );
+  const generatedClientToolSearchOutputsByCall =
+    await buildGeneratedClientToolSearchOutputMapAsync({
+      agent,
+      modelResponse,
+      runContext: state._context,
+      tools,
+    });
+  let hasGeneratedClientToolSearchOutputs = false;
+  const availableTools = [...tools];
+
+  for (const output of modelResponse.output) {
+    if (output.type === 'message') {
+      if (output.role === 'assistant') {
+        items.push(new RunMessageOutputItem(output, agent));
+      }
+    } else if (output.type === 'tool_search_call') {
+      items.push(new RunToolSearchCallItem(output, agent));
+      toolsUsed.push('tool_search');
+      const generatedOutput =
+        generatedClientToolSearchOutputsByCall.get(output);
+      if (generatedOutput) {
+        items.push(new RunToolSearchOutputItem(generatedOutput.output, agent));
+        recordLoadedToolSearchOutput(
+          loadedDeferredToolState,
+          generatedOutput.output,
+        );
+        addHostedMcpToolsFromToolSearchOutput(
+          generatedOutput.output,
+          mcpToolMap,
+          {
+            preserveExistingServerLabels: originalMcpServerLabels,
+          },
+        );
+        const novelRuntimeTools = registerRuntimeToolSearchTools({
+          availableTools,
+          functionMap,
+          mcpToolMap,
+          replaceableRuntimeToolKeys,
+          runtimeTools: generatedOutput.runtimeTools,
+        });
+        state.recordToolSearchRuntimeTools(
+          agent,
+          generatedOutput.output,
+          novelRuntimeTools,
+        );
+        hasGeneratedClientToolSearchOutputs = true;
+      }
+    } else if (output.type === 'tool_search_output') {
+      items.push(new RunToolSearchOutputItem(output, agent));
+      recordLoadedToolSearchOutput(loadedDeferredToolState, output);
+      addHostedMcpToolsFromToolSearchOutput(output, mcpToolMap, {
+        preserveExistingServerLabels: originalMcpServerLabels,
+      });
+    } else if (output.type === 'hosted_tool_call') {
+      items.push(new RunToolCallItem(output, agent));
+      const toolName = output.name;
+      toolsUsed.push(toolName);
+
+      if (
+        output.providerData?.type === 'mcp_approval_request' ||
+        output.name === 'mcp_approval_request'
+      ) {
+        const providerData =
+          output.providerData as ProviderData.HostedMCPApprovalRequest;
+
+        const mcpServerLabel = providerData.server_label;
+        const mcpServerTool = mcpToolMap.get(mcpServerLabel);
+        if (typeof mcpServerTool === 'undefined') {
+          const message = `MCP server (${mcpServerLabel}) not found in Agent (${agent.name})`;
+          addErrorToCurrentSpan({
+            message,
+            data: { mcp_server_label: mcpServerLabel },
+          });
+          throw new ModelBehaviorError(message);
+        }
+
+        const approvalItem = new RunToolApprovalItem(
+          {
+            type: 'hosted_tool_call',
+            name: providerData.name,
+            id: providerData.id,
+            status: 'in_progress',
+            providerData,
+          },
+          agent,
+        );
+        runMCPApprovalRequests.push({
+          requestItem: approvalItem,
+          mcpTool: mcpServerTool,
+        });
+        if (!mcpServerTool.providerData.on_approval) {
+          items.push(approvalItem);
+        }
+      }
+    } else if (output.type === 'reasoning') {
+      items.push(new RunReasoningItem(output, agent));
+    } else if (output.type === 'computer_call') {
+      handleToolCallAction({
+        output,
+        tool: computerTool,
+        agent,
+        errorMessage: 'Model produced computer action without a computer tool.',
+        errorData: { agent_name: agent.name },
+        items,
+        toolsUsed,
+        actions: runComputerActions,
+        buildAction: (resolvedTool) => ({
+          toolCall: output,
+          computer: resolvedTool,
+        }),
+      });
+    } else if (output.type === 'shell_call') {
+      const resolvedShellTool = ensureToolAvailable(
+        shellTool,
+        'Model produced shell action without a shell tool.',
+        { agent_name: agent.name },
+      );
+      items.push(new RunToolCallItem(output, agent));
+      toolsUsed.push(resolvedShellTool.name);
+      const shellEnvironmentType =
+        resolvedShellTool.environment?.type ?? 'local';
+
+      if (shellEnvironmentType !== 'local') {
+        if (isShellCallPendingStatus(output.status)) {
+          hasHostedShellCall = true;
+        }
+        continue;
+      }
+
+      if (!resolvedShellTool.shell) {
+        const message =
+          'Model produced local shell action without a local shell implementation.';
+        addErrorToCurrentSpan({
+          message,
+          data: { agent_name: agent.name },
+        });
+        throw new ModelBehaviorError(message);
+      }
+
+      runShellActions.push({
+        toolCall: output,
+        shell: resolvedShellTool,
+      });
+    } else if (output.type === 'shell_call_output') {
+      items.push(new RunToolCallOutputItem(output, agent, output.output));
+      if (hasPendingShellOutputStatus(output)) {
+        hasHostedShellCall = true;
+      }
+    } else if (output.type === 'apply_patch_call') {
+      handleToolCallAction({
+        output,
+        tool: applyPatchTool,
+        agent,
+        errorMessage:
+          'Model produced apply_patch action without an apply_patch tool.',
+        errorData: { agent_name: agent.name },
+        items,
+        toolsUsed,
+        actions: runApplyPatchActions,
+        buildAction: (resolvedTool) => ({
+          toolCall: output,
+          applyPatch: resolvedTool,
+        }),
+      });
+    }
+
+    if (output.type !== 'function_call') {
+      continue;
+    }
+
+    const resolved = resolveFunctionOrHandoff(
+      output,
+      handoffMap,
+      functionMap,
+      agent,
+    );
+    if (resolved.type === 'handoff') {
+      toolsUsed.push(output.name);
+      items.push(new RunHandoffCallItem(output, agent));
+      runHandoffs.push({
+        toolCall: output,
+        handoff: resolved.handoff,
+      });
+    } else {
+      ensureDeferredFunctionToolLoaded(
+        output,
+        resolved.tool,
+        loadedDeferredToolState.loadedToolNames,
+        agent,
+      );
+      const normalizedToolCall = normalizeFunctionToolCallForStorage(
+        output,
+        resolved.tool,
+      );
+      toolsUsed.push(
+        getFunctionToolQualifiedName(resolved.tool) ?? resolved.tool.name,
+      );
+      items.push(new RunToolCallItem(normalizedToolCall, agent));
+      runFunctions.push({
+        toolCall: normalizedToolCall,
+        tool: resolved.tool,
+      });
+    }
+  }
+
+  return {
+    newItems: items,
+    handoffs: runHandoffs,
+    functions: runFunctions,
+    computerActions: runComputerActions,
+    shellActions: runShellActions,
+    applyPatchActions: runApplyPatchActions,
+    mcpApprovalRequests: runMCPApprovalRequests,
+    toolsUsed,
+    hasToolsOrApprovalsToRun(): boolean {
+      return (
+        runHandoffs.length > 0 ||
+        runFunctions.length > 0 ||
+        runMCPApprovalRequests.length > 0 ||
+        runComputerActions.length > 0 ||
+        runShellActions.length > 0 ||
+        hasHostedShellCall ||
+        runApplyPatchActions.length > 0 ||
+        hasGeneratedClientToolSearchOutputs
       );
     },
   };

--- a/packages/agents-core/src/runner/modelPreparation.ts
+++ b/packages/agents-core/src/runner/modelPreparation.ts
@@ -5,6 +5,7 @@ import { RunState } from '../runState';
 import { ComputerTool, Tool, resolveComputer } from '../tool';
 import { serializeHandoff, serializeTool } from '../utils/serialize';
 import { ensureAgentSpan } from './tracing';
+import { validateClientToolSearchSupport } from './toolSearch';
 import { AgentArtifacts } from './types';
 
 const computerInitPromisesByRunState = new WeakMap<
@@ -57,6 +58,7 @@ export async function prepareAgentArtifacts<
   TAgent extends Agent<TContext, AgentOutputType>,
 >(state: RunState<TContext, TAgent>): Promise<AgentArtifacts<TContext>> {
   const capabilities = await collectAgentCapabilities(state);
+  validateClientToolSearchSupport(capabilities.tools);
   await warmUpComputerTools(capabilities.tools, state._context);
   await initializeComputerTools(capabilities.tools, state);
   state.setCurrentAgentSpan(
@@ -85,10 +87,13 @@ async function collectAgentCapabilities<TContext>(
   tools: Tool<TContext>[];
 }> {
   const handoffs = await state._currentAgent.getEnabledHandoffs(state._context);
-  const tools = (await state._currentAgent.getAllTools(
+  const configuredTools = (await state._currentAgent.getAllTools(
     state._context,
   )) as Tool<TContext>[];
-  return { handoffs, tools };
+  const runtimeLoadedTools = state.getToolSearchRuntimeTools(
+    state._currentAgent,
+  ) as Tool<TContext>[];
+  return { handoffs, tools: [...configuredTools, ...runtimeLoadedTools] };
 }
 
 async function warmUpComputerTools<TContext>(

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -508,8 +508,7 @@ function stripTransientCallIds(value: unknown): unknown {
   const result: Record<string, unknown> = {};
   const isProtocolItem =
     typeof record.type === 'string' && record.type.length > 0;
-  const shouldStripId =
-    isProtocolItem && shouldStripIdForType(record.type as string);
+  const shouldStripId = isProtocolItem && shouldStripIdForProtocolItem(record);
   for (const [key, entry] of Object.entries(record)) {
     if (shouldStripId && key === 'id') {
       continue;
@@ -519,14 +518,32 @@ function stripTransientCallIds(value: unknown): unknown {
   return result;
 }
 
-function shouldStripIdForType(type: string): boolean {
-  switch (type) {
+function shouldStripIdForProtocolItem(
+  record: Record<string, unknown>,
+): boolean {
+  switch (record.type) {
     case 'function_call':
     case 'function_call_result':
       return true;
+    case 'tool_search_call':
+    case 'tool_search_output':
+      return hasToolSearchCallId(record);
     default:
       return false;
   }
+}
+
+function hasToolSearchCallId(record: Record<string, unknown>): boolean {
+  const topLevelCallId = record.call_id ?? record.callId;
+  if (typeof topLevelCallId === 'string' && topLevelCallId.length > 0) {
+    return true;
+  }
+
+  const providerData = isPlainObject(record.providerData)
+    ? (record.providerData as Record<string, unknown>)
+    : undefined;
+  const providerCallId = providerData?.call_id ?? providerData?.callId;
+  return typeof providerCallId === 'string' && providerCallId.length > 0;
 }
 
 async function persistRunItemsToSession(options: {

--- a/packages/agents-core/src/runner/streaming.ts
+++ b/packages/agents-core/src/runner/streaming.ts
@@ -9,6 +9,8 @@ import {
   RunToolApprovalItem,
   RunToolCallItem,
   RunToolCallOutputItem,
+  RunToolSearchCallItem,
+  RunToolSearchOutputItem,
 } from '../items';
 import { StreamedRunResult } from '../result';
 
@@ -42,6 +44,14 @@ function getRunItemStreamEventName(
   }
   if (item instanceof RunHandoffOutputItem) {
     return 'handoff_occurred';
+  }
+  // tool_search uses dedicated run items because its payload shape and
+  // downstream UI correlation differ from generic tool call/output events.
+  if (item instanceof RunToolSearchCallItem) {
+    return 'tool_search_called';
+  }
+  if (item instanceof RunToolSearchOutputItem) {
+    return 'tool_search_output_created';
   }
   if (item instanceof RunToolCallItem) {
     return 'tool_called';

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -44,6 +44,10 @@ import { RunState } from '../runState';
 import type { AgentInputItem, UnknownContext } from '../types';
 import type { Runner, ToolErrorFormatter } from '../run';
 import {
+  getFunctionToolQualifiedName,
+  matchesFunctionToolName,
+} from '../toolIdentity';
+import {
   runToolInputGuardrails,
   runToolOutputGuardrails,
 } from '../utils/toolGuardrails';
@@ -77,6 +81,18 @@ type ParseToolArgumentsResult =
   | { success: true; args: any }
   | { success: false; error: Error };
 
+function getFunctionToolIdentity<TContext>(
+  toolRun: ToolRunFunction<TContext>,
+): string {
+  return getFunctionToolQualifiedName(toolRun.tool) ?? toolRun.tool.name;
+}
+
+function getFunctionToolTraceName<TContext>(
+  toolRun: ToolRunFunction<TContext>,
+): string {
+  return getFunctionToolIdentity(toolRun);
+}
+
 /**
  * @internal
  * Normalizes tool outputs once so downstream code works with fully structured protocol items.
@@ -96,6 +112,9 @@ export function getToolCallOutputItem(
     return {
       type: 'function_call_result',
       name: toolCall.name,
+      ...(typeof toolCall.namespace === 'string'
+        ? { namespace: toolCall.namespace }
+        : {}),
       callId: toolCall.callId,
       status: 'completed',
       output: structuredItems,
@@ -105,6 +124,9 @@ export function getToolCallOutputItem(
   return {
     type: 'function_call_result',
     name: toolCall.name,
+    ...(typeof toolCall.namespace === 'string'
+      ? { namespace: toolCall.namespace }
+      : {}),
     callId: toolCall.callId,
     status: 'completed',
     output: {
@@ -172,6 +194,7 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
 function parseToolArguments<TContext>(
   toolRun: ToolRunFunction<TContext>,
 ): ParseToolArgumentsResult {
+  const toolName = getFunctionToolIdentity(toolRun);
   try {
     let parsedArgs: any = toolRun.toolCall.arguments;
     if (toolRun.tool.parameters) {
@@ -183,9 +206,7 @@ function parseToolArguments<TContext>(
     }
     return { success: true, args: parsedArgs };
   } catch (error) {
-    logger.debug(
-      `Failed to parse tool arguments for ${toolRun.tool.name}: ${error}`,
-    );
+    logger.debug(`Failed to parse tool arguments for ${toolName}: ${error}`);
     return { success: false, error: error as Error };
   }
 }
@@ -197,7 +218,11 @@ function buildApprovalRequestResult<TContext>(
   return {
     type: 'function_approval' as const,
     tool: toolRun.tool,
-    runItem: new RunToolApprovalItem(toolRun.toolCall, deps.agent),
+    runItem: new RunToolApprovalItem(
+      toolRun.toolCall,
+      deps.agent,
+      getFunctionToolIdentity(toolRun),
+    ),
   };
 }
 
@@ -224,11 +249,13 @@ async function buildApprovalRejectionResult<TContext>(
   toolRun: ToolRunFunction<TContext>,
 ): Promise<FunctionToolResult<TContext>> {
   const { agent, runner, state, toolErrorFormatter } = deps;
-  return withToolFunctionSpan(runner, toolRun.tool.name, async (span) => {
+  const toolName = getFunctionToolIdentity(toolRun);
+  const traceToolName = getFunctionToolTraceName(toolRun);
+  return withToolFunctionSpan(runner, traceToolName, async (span) => {
     const response = await resolveApprovalRejectionMessage({
       runContext: state._context,
       toolType: 'function',
-      toolName: toolRun.tool.name,
+      toolName,
       callId: toolRun.toolCall.callId,
       toolErrorFormatter,
     });
@@ -239,7 +266,7 @@ async function buildApprovalRejectionResult<TContext>(
     span?.setError({
       message: traceErrorMessage,
       data: {
-        tool_name: toolRun.tool.name,
+        tool_name: traceToolName,
         error: `Tool execution for ${toolRun.toolCall.callId} was manually rejected by user.`,
       },
     });
@@ -266,6 +293,7 @@ async function handleFunctionApproval<TContext>(
   parsedArgs: any,
 ): Promise<'approved' | FunctionToolResult<TContext>> {
   const { state } = deps;
+  const toolName = getFunctionToolIdentity(toolRun);
   const needsApproval = await toolRun.tool.needsApproval(
     state._context,
     parsedArgs,
@@ -277,12 +305,12 @@ async function handleFunctionApproval<TContext>(
   }
 
   const approval = state._context.isToolApproved({
-    toolName: toolRun.tool.name,
+    toolName,
     callId: toolRun.toolCall.callId,
   });
 
   if (approval === false) {
-    state.clearPendingAgentToolRun(toolRun.tool.name, toolRun.toolCall.callId);
+    state.clearPendingAgentToolRun(toolName, toolRun.toolCall.callId);
     return await buildApprovalRejectionResult(deps, toolRun);
   }
 
@@ -298,7 +326,9 @@ async function runApprovedFunctionTool<TContext>(
   toolRun: ToolRunFunction<TContext>,
 ): Promise<FunctionToolResult<TContext>> {
   const { agent, runner, state } = deps;
-  return withToolFunctionSpan(runner, toolRun.tool.name, async (span) => {
+  const toolName = getFunctionToolIdentity(toolRun);
+  const traceToolName = getFunctionToolTraceName(toolRun);
+  return withToolFunctionSpan(runner, traceToolName, async (span) => {
     if (span && runner.config.traceIncludeSensitiveData) {
       span.spanData.input = toolRun.toolCall.arguments;
     }
@@ -327,7 +357,7 @@ async function runApprovedFunctionTool<TContext>(
         toolOutput = inputGuardrailResult.message;
       } else {
         const resumeState = state.getPendingAgentToolRun(
-          toolRun.tool.name,
+          toolName,
           toolRun.toolCall.callId,
         );
         const toolDetails = {
@@ -388,15 +418,12 @@ async function runApprovedFunctionTool<TContext>(
           functionResult.interruptions = nestedInterruptions;
           const nestedRunStateJson = nestedRunResult.state.toJSON();
           state.setPendingAgentToolRun(
-            toolRun.tool.name,
+            toolName,
             toolRun.toolCall.callId,
             JSON.stringify(nestedRunStateJson),
           );
         } else {
-          state.clearPendingAgentToolRun(
-            toolRun.tool.name,
-            toolRun.toolCall.callId,
-          );
+          state.clearPendingAgentToolRun(toolName, toolRun.toolCall.callId);
         }
       }
 
@@ -405,7 +432,7 @@ async function runApprovedFunctionTool<TContext>(
       span?.setError({
         message: 'Error running tool',
         data: {
-          tool_name: toolRun.tool.name,
+          tool_name: traceToolName,
           error: String(error),
         },
       });
@@ -1341,9 +1368,11 @@ export async function checkForFinalOutputFromTools<
 
   const toolUseBehavior = agent.toolUseBehavior;
   if (typeof toolUseBehavior === 'object') {
-    const stoppingTool = toolResults.find((r) =>
-      toolUseBehavior.stopAtToolNames.includes(r.tool.name),
-    );
+    const stoppingTool = toolResults.find((r) => {
+      return toolUseBehavior.stopAtToolNames.some((toolName) =>
+        matchesFunctionToolName(r.tool, toolName),
+      );
+    });
     if (stoppingTool?.type === 'function_output') {
       const stringOutput = toSmartString(stoppingTool.output);
       return {

--- a/packages/agents-core/src/runner/toolSearch.ts
+++ b/packages/agents-core/src/runner/toolSearch.ts
@@ -1,0 +1,706 @@
+import type { Agent } from '../agent';
+import { UserError } from '../errors';
+import type { RunContext } from '../runContext';
+import {
+  getClientToolSearchExecutor,
+  getToolSearchRuntimeToolKey,
+  type FunctionTool,
+  type HostedMCPTool,
+  type Tool,
+} from '../tool';
+import type * as protocol from '../types/protocol';
+import * as ProviderData from '../types/providerData';
+import {
+  getExplicitFunctionToolNamespace,
+  getFunctionToolNamespaceDescription,
+  getFunctionToolQualifiedName,
+  toolQualifiedName,
+} from '../toolIdentity';
+import { serializeTool } from '../utils/serialize';
+import { resolveToolSearchCallId } from '../utils/toolSearch';
+
+type BuiltInClientToolSearchArguments = {
+  paths: string[];
+};
+
+type DeferredNamespaceTools = {
+  description: string;
+  tools: FunctionTool<any>[];
+};
+
+function isDeferredFunctionTool(tool: Tool<any>): tool is FunctionTool<any> {
+  return tool.type === 'function' && tool.deferLoading === true;
+}
+
+function isTopLevelDeferredFunctionTool(
+  tool: Tool<any>,
+): tool is FunctionTool<any> {
+  return (
+    isDeferredFunctionTool(tool) && !getExplicitFunctionToolNamespace(tool)
+  );
+}
+
+function isDeferredHostedMcpTool(tool: Tool<any>): tool is HostedMCPTool<any> {
+  return (
+    tool.type === 'hosted_tool' &&
+    tool.providerData?.type === 'mcp' &&
+    tool.providerData.defer_loading === true
+  );
+}
+
+function getBuiltInClientToolSearchArguments(
+  value: unknown,
+): BuiltInClientToolSearchArguments | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const paths = (value as { paths?: unknown }).paths;
+  if (!Array.isArray(paths)) {
+    return undefined;
+  }
+
+  return {
+    paths: paths.filter(
+      (path): path is string => typeof path === 'string' && path.length > 0,
+    ),
+  };
+}
+
+function getDeferredFunctionToolsByName(
+  tools: Tool<any>[],
+): Map<string, FunctionTool<any>> {
+  return new Map(
+    tools
+      .filter(isTopLevelDeferredFunctionTool)
+      .map((tool) => [tool.name, tool] as const),
+  );
+}
+
+function getDeferredNamespaceToolsByName(
+  tools: Tool<any>[],
+): Map<string, DeferredNamespaceTools> {
+  const namespaces = new Map<string, DeferredNamespaceTools>();
+
+  for (const tool of tools) {
+    if (!isDeferredFunctionTool(tool)) {
+      continue;
+    }
+
+    const namespace = getExplicitFunctionToolNamespace(tool);
+    if (!namespace) {
+      continue;
+    }
+
+    const description = getFunctionToolNamespaceDescription(tool);
+    if (!description) {
+      throw new UserError(
+        `Deferred namespace "${namespace}" must provide a description for built-in client tool_search.`,
+      );
+    }
+
+    const existing = namespaces.get(namespace);
+    if (!existing) {
+      namespaces.set(namespace, { description, tools: [tool] });
+      continue;
+    }
+
+    existing.tools.push(tool);
+  }
+
+  return namespaces;
+}
+
+function getDeferredHostedMcpToolsByServerLabel(
+  tools: Tool<any>[],
+): Map<string, HostedMCPTool<any>> {
+  return new Map(
+    tools
+      .filter(isDeferredHostedMcpTool)
+      .map((tool) => [tool.providerData.server_label, tool] as const),
+  );
+}
+
+function getDeferredNamespacedFunctionToolsByQualifiedName(
+  tools: Tool<any>[],
+): Map<
+  string,
+  { namespace: string; description: string; tool: FunctionTool<any> }
+> {
+  const qualifiedTools = new Map<
+    string,
+    { namespace: string; description: string; tool: FunctionTool<any> }
+  >();
+
+  for (const tool of tools) {
+    if (!isDeferredFunctionTool(tool)) {
+      continue;
+    }
+
+    const namespace = getExplicitFunctionToolNamespace(tool);
+    if (!namespace) {
+      continue;
+    }
+
+    const description = getFunctionToolNamespaceDescription(tool);
+    const qualifiedName = getFunctionToolQualifiedName(tool);
+    if (!description || !qualifiedName) {
+      continue;
+    }
+
+    qualifiedTools.set(qualifiedName, { namespace, description, tool });
+  }
+
+  return qualifiedTools;
+}
+
+function serializeFunctionToolForToolSearchOutput(
+  tool: FunctionTool<any>,
+): protocol.ToolSearchOutputTool {
+  const serialized = serializeTool(tool) as Record<string, unknown>;
+  const namespace = getExplicitFunctionToolNamespace(tool);
+
+  if (!namespace) {
+    return serialized as protocol.ToolSearchOutputTool;
+  }
+
+  const {
+    namespace: _namespace,
+    namespaceDescription,
+    ...toolPayload
+  } = serialized;
+  void namespaceDescription;
+  return toolPayload as protocol.ToolSearchOutputTool;
+}
+
+function serializeHostedMcpToolForToolSearchOutput(
+  tool: HostedMCPTool<any>,
+): protocol.ToolSearchOutputTool {
+  const { on_approval: _onApproval, ...providerData } = tool.providerData;
+  void _onApproval;
+  return providerData as protocol.ToolSearchOutputTool;
+}
+
+function appendNamespaceMemberToolSearchOutput(args: {
+  namespace: string;
+  description: string;
+  tool: FunctionTool<any>;
+  namespaceOutputIndexByName: Map<string, number>;
+  resolvedTools: protocol.ToolSearchOutputTool[];
+}): void {
+  const {
+    namespace,
+    description,
+    tool,
+    namespaceOutputIndexByName,
+    resolvedTools,
+  } = args;
+  const existingIndex = namespaceOutputIndexByName.get(namespace);
+  const serializedTool = serializeFunctionToolForToolSearchOutput(tool);
+
+  if (typeof existingIndex === 'number') {
+    const existingNamespace = resolvedTools[existingIndex] as
+      | (protocol.ToolSearchOutputTool & {
+          type?: unknown;
+          description?: unknown;
+          tools?: unknown;
+        })
+      | undefined;
+    if (
+      existingNamespace?.type === 'namespace' &&
+      Array.isArray(existingNamespace.tools)
+    ) {
+      existingNamespace.tools.push(serializedTool);
+      return;
+    }
+  }
+
+  namespaceOutputIndexByName.set(namespace, resolvedTools.length);
+  resolvedTools.push({
+    type: 'namespace',
+    name: namespace,
+    description,
+    tools: [serializedTool],
+  });
+}
+
+function isClientToolSearchToolWithCustomParameters(tool: Tool<any>): boolean {
+  return (
+    tool.type === 'hosted_tool' &&
+    tool.providerData?.type === 'tool_search' &&
+    tool.providerData.execution === 'client' &&
+    tool.providerData.parameters != null
+  );
+}
+
+function isClientToolSearchTool(tool: Tool<any>): boolean {
+  return (
+    tool.type === 'hosted_tool' &&
+    tool.providerData?.type === 'tool_search' &&
+    tool.providerData.execution === 'client'
+  );
+}
+
+function normalizeClientToolSearchExecutorResult<TContext>(
+  result: Tool<TContext> | Tool<TContext>[] | null | undefined,
+): Tool<TContext>[] {
+  if (typeof result === 'undefined' || result === null) {
+    return [];
+  }
+
+  return Array.isArray(result) ? result : [result];
+}
+
+function addLoadedToolName(
+  loadedToolNames: Set<string>,
+  name: unknown,
+  namespace?: unknown,
+): void {
+  if (typeof name !== 'string' || name.length === 0) {
+    return;
+  }
+
+  const explicitNamespace =
+    typeof namespace === 'string' && namespace.length > 0
+      ? namespace
+      : undefined;
+  const qualifiedName = toolQualifiedName(name, explicitNamespace);
+  if (qualifiedName) {
+    loadedToolNames.add(qualifiedName);
+  }
+
+  if (!explicitNamespace || explicitNamespace === name) {
+    loadedToolNames.add(name);
+  }
+}
+
+function collectLoadedToolNamesFromSearchResult(
+  searchResult: unknown,
+  loadedToolNames: Set<string>,
+  namespace?: string,
+): void {
+  if (!searchResult || typeof searchResult !== 'object') {
+    return;
+  }
+
+  const candidate = searchResult as {
+    type?: unknown;
+    name?: unknown;
+    namespace?: unknown;
+    functionName?: unknown;
+    tools?: unknown;
+  };
+
+  if (candidate.type === 'tool_reference') {
+    addLoadedToolName(
+      loadedToolNames,
+      candidate.functionName,
+      candidate.namespace ?? namespace,
+    );
+    return;
+  }
+
+  if (candidate.type === 'function') {
+    addLoadedToolName(
+      loadedToolNames,
+      candidate.name,
+      candidate.namespace ?? namespace,
+    );
+    return;
+  }
+
+  const mcpProviderData = getHostedMcpProviderDataFromSearchResult(candidate);
+  if (mcpProviderData) {
+    addLoadedToolName(loadedToolNames, mcpProviderData.server_label);
+    return;
+  }
+
+  if (candidate.type === 'namespace' && Array.isArray(candidate.tools)) {
+    const nestedNamespace =
+      typeof candidate.name === 'string' && candidate.name.length > 0
+        ? candidate.name
+        : namespace;
+    for (const nestedTool of candidate.tools) {
+      collectLoadedToolNamesFromSearchResult(
+        nestedTool,
+        loadedToolNames,
+        nestedNamespace,
+      );
+    }
+  }
+}
+
+function normalizeStringRecord(
+  value: unknown,
+): Record<string, string> | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const entries = Object.entries(value).filter(
+    ([key, entryValue]) =>
+      typeof key === 'string' && typeof entryValue === 'string',
+  );
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(entries);
+}
+
+function normalizeHostedMcpProviderData(
+  value: unknown,
+): ProviderData.HostedMCPTool<any> | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const candidate = value as {
+    type?: unknown;
+    server_label?: unknown;
+    server_url?: unknown;
+    connector_id?: unknown;
+    authorization?: unknown;
+    allowed_tools?: unknown;
+    defer_loading?: unknown;
+    headers?: unknown;
+    require_approval?: unknown;
+    server_description?: unknown;
+  };
+
+  if (
+    candidate.type !== 'mcp' ||
+    typeof candidate.server_label !== 'string' ||
+    candidate.server_label.length === 0
+  ) {
+    return undefined;
+  }
+
+  const normalized: Record<string, unknown> = {
+    type: 'mcp',
+    server_label: candidate.server_label,
+    require_approval:
+      candidate.require_approval === undefined
+        ? 'never'
+        : candidate.require_approval,
+  };
+
+  if (typeof candidate.server_url === 'string') {
+    normalized.server_url = candidate.server_url;
+  }
+  if (typeof candidate.connector_id === 'string') {
+    normalized.connector_id = candidate.connector_id;
+  }
+  if (typeof candidate.authorization === 'string') {
+    normalized.authorization = candidate.authorization;
+  }
+  if (candidate.allowed_tools !== undefined) {
+    normalized.allowed_tools =
+      candidate.allowed_tools as ProviderData.HostedMCPTool<any>['allowed_tools'];
+  }
+  if (candidate.defer_loading === true) {
+    normalized.defer_loading = true;
+  }
+  const headers = normalizeStringRecord(candidate.headers);
+  if (headers) {
+    normalized.headers = headers;
+  }
+  if (typeof candidate.server_description === 'string') {
+    normalized.server_description = candidate.server_description;
+  }
+
+  return normalized as ProviderData.HostedMCPTool<any>;
+}
+
+function getHostedMcpProviderDataFromSearchResult(
+  searchResult: unknown,
+): ProviderData.HostedMCPTool<any> | undefined {
+  const directProviderData = normalizeHostedMcpProviderData(searchResult);
+  if (directProviderData) {
+    return directProviderData;
+  }
+
+  if (!searchResult || typeof searchResult !== 'object') {
+    return undefined;
+  }
+
+  const hostedCandidate = searchResult as {
+    type?: unknown;
+    providerData?: unknown;
+  };
+  if (hostedCandidate.type !== 'hosted_tool') {
+    return undefined;
+  }
+
+  return normalizeHostedMcpProviderData(hostedCandidate.providerData);
+}
+
+export function addLoadedToolNamesFromToolSearchOutput(
+  toolSearchOutput: protocol.ToolSearchOutputItem,
+  loadedToolNames: Set<string>,
+): void {
+  for (const tool of toolSearchOutput.tools) {
+    collectLoadedToolNamesFromSearchResult(tool, loadedToolNames);
+  }
+}
+
+export function addHostedMcpToolsFromToolSearchOutput(
+  toolSearchOutput: protocol.ToolSearchOutputItem,
+  hostedMcpToolsByServerLabel: Map<string, HostedMCPTool<any>>,
+  options?: {
+    preserveExistingServerLabels?: Set<string>;
+  },
+): void {
+  const preserveExistingServerLabels = options?.preserveExistingServerLabels;
+  for (const tool of toolSearchOutput.tools) {
+    const providerData = getHostedMcpProviderDataFromSearchResult(tool);
+    if (!providerData) {
+      continue;
+    }
+
+    if (
+      preserveExistingServerLabels?.has(providerData.server_label) &&
+      hostedMcpToolsByServerLabel.has(providerData.server_label)
+    ) {
+      continue;
+    }
+
+    hostedMcpToolsByServerLabel.set(providerData.server_label, {
+      type: 'hosted_tool',
+      name: 'hosted_mcp',
+      providerData,
+    });
+  }
+}
+
+export function validateClientToolSearchSupport(tools: Tool<any>[]): void {
+  if (
+    !tools.some(
+      (tool) =>
+        isClientToolSearchToolWithCustomParameters(tool) &&
+        !getClientToolSearchExecutor(tool),
+    )
+  ) {
+    return;
+  }
+
+  throw new UserError(
+    'Runner.run() and Runner.runStreamed() require toolSearchTool({ execution: "client", execute }) when custom client tool_search parameters are provided. Leave parameters unset to use the default built-in { paths: string[] } loader, or use server execution / a custom model loop instead.',
+  );
+}
+
+export function resolveBuiltInClientToolSearchTools(
+  paths: string[],
+  tools: Tool<any>[],
+): Tool<any>[] {
+  const deferredToolsByName = getDeferredFunctionToolsByName(tools);
+  const deferredNamespaceToolsByName = getDeferredNamespaceToolsByName(tools);
+  const deferredNamespacedToolsByQualifiedName =
+    getDeferredNamespacedFunctionToolsByQualifiedName(tools);
+  const deferredHostedMcpToolsByServerLabel =
+    getDeferredHostedMcpToolsByServerLabel(tools);
+  const ambiguousPath = paths.find(
+    (path) =>
+      Number(deferredToolsByName.has(path)) +
+        Number(deferredNamespaceToolsByName.has(path)) +
+        Number(deferredNamespacedToolsByQualifiedName.has(path)) +
+        Number(deferredHostedMcpToolsByServerLabel.has(path)) >
+      1,
+  );
+  if (ambiguousPath) {
+    throw new UserError(
+      `Runner.run() and Runner.runStreamed() cannot disambiguate built-in client tool_search path "${ambiguousPath}" because it matches multiple deferred tool_search surfaces. Rename one of them or use server tool_search execution.`,
+    );
+  }
+  const requestedNamespacePaths = new Set(
+    paths.filter((path) => deferredNamespaceToolsByName.has(path)),
+  );
+  const resolvedTools: Tool<any>[] = [];
+  const seenPaths = new Set<string>();
+  const resolvedQualifiedNames = new Set<string>();
+
+  for (const path of paths) {
+    if (seenPaths.has(path)) {
+      continue;
+    }
+    seenPaths.add(path);
+
+    const tool = deferredToolsByName.get(path);
+    if (!tool) {
+      const namespaceTools = deferredNamespaceToolsByName.get(path);
+      if (namespaceTools) {
+        const unresolvedTools = namespaceTools.tools.filter((tool) => {
+          const qualifiedName = getFunctionToolQualifiedName(tool);
+          return !qualifiedName || !resolvedQualifiedNames.has(qualifiedName);
+        });
+        if (unresolvedTools.length === 0) {
+          continue;
+        }
+
+        for (const namespaceTool of unresolvedTools) {
+          const qualifiedName = getFunctionToolQualifiedName(namespaceTool);
+          if (qualifiedName) {
+            resolvedQualifiedNames.add(qualifiedName);
+          }
+        }
+
+        resolvedTools.push(...unresolvedTools);
+        continue;
+      }
+
+      const namespacedTool = deferredNamespacedToolsByQualifiedName.get(path);
+      if (namespacedTool) {
+        if (requestedNamespacePaths.has(namespacedTool.namespace)) {
+          continue;
+        }
+
+        if (resolvedQualifiedNames.has(path)) {
+          continue;
+        }
+
+        resolvedQualifiedNames.add(path);
+        resolvedTools.push(namespacedTool.tool);
+        continue;
+      }
+    }
+
+    if (tool) {
+      resolvedTools.push(tool);
+      continue;
+    }
+
+    const hostedMcpTool = deferredHostedMcpToolsByServerLabel.get(path);
+    if (hostedMcpTool) {
+      resolvedTools.push(hostedMcpTool);
+    }
+  }
+
+  return resolvedTools;
+}
+
+export function createClientToolSearchOutputFromTools(
+  toolSearchCall: protocol.ToolSearchCallItem,
+  tools: Tool<any>[],
+): protocol.ToolSearchOutputItem {
+  const callId = resolveToolSearchCallId(toolSearchCall);
+  const resolvedTools: protocol.ToolSearchOutputTool[] = [];
+  const namespaceOutputIndexByName = new Map<string, number>();
+  const seenToolKeys = new Set<string>();
+
+  for (const tool of tools) {
+    const runtimeToolKey = getToolSearchRuntimeToolKey(tool);
+    if (runtimeToolKey && seenToolKeys.has(runtimeToolKey)) {
+      continue;
+    }
+    if (runtimeToolKey) {
+      seenToolKeys.add(runtimeToolKey);
+    }
+
+    if (tool.type === 'function') {
+      const namespace = getExplicitFunctionToolNamespace(tool);
+      if (namespace) {
+        const description = getFunctionToolNamespaceDescription(tool);
+        if (!description) {
+          throw new UserError(
+            `Client tool_search execute() returned namespace member "${namespace}.${tool.name}" without a namespace description.`,
+          );
+        }
+        appendNamespaceMemberToolSearchOutput({
+          namespace,
+          description,
+          tool,
+          namespaceOutputIndexByName,
+          resolvedTools,
+        });
+        continue;
+      }
+
+      resolvedTools.push(serializeFunctionToolForToolSearchOutput(tool));
+      continue;
+    }
+
+    if (isDeferredHostedMcpTool(tool) || tool.type === 'hosted_tool') {
+      if (tool.type === 'hosted_tool' && tool.providerData?.type === 'mcp') {
+        resolvedTools.push(
+          serializeHostedMcpToolForToolSearchOutput(tool as HostedMCPTool<any>),
+        );
+        continue;
+      }
+    }
+
+    throw new UserError(
+      'Client tool_search execute() may only return function tools or hosted MCP tools.',
+    );
+  }
+
+  return {
+    type: 'tool_search_output',
+    status: 'completed',
+    tools: resolvedTools,
+    providerData: {
+      call_id: callId,
+      execution: 'client',
+    },
+  };
+}
+
+export function createBuiltInClientToolSearchOutput(
+  toolSearchCall: protocol.ToolSearchCallItem,
+  tools: Tool<any>[],
+): protocol.ToolSearchOutputItem {
+  const callId = resolveToolSearchCallId(toolSearchCall);
+  const builtInArgs = getBuiltInClientToolSearchArguments(
+    toolSearchCall.arguments,
+  );
+
+  if (!builtInArgs) {
+    throw new UserError(
+      `Runner.run() and Runner.runStreamed() only auto-execute built-in client tool_search calls with { paths: string[] }. Custom client tool_search schemas require toolSearchTool({ execution: "client", execute }) or a custom model loop before re-processing call ${callId}.`,
+    );
+  }
+
+  return createClientToolSearchOutputFromTools(
+    toolSearchCall,
+    resolveBuiltInClientToolSearchTools(builtInArgs.paths, tools),
+  );
+}
+
+export async function executeCustomClientToolSearch<TContext>(args: {
+  agent: Agent<TContext, any>;
+  runContext: RunContext<TContext>;
+  toolSearchCall: protocol.ToolSearchCallItem;
+  toolSearchTool: Tool<TContext>;
+  tools: Tool<TContext>[];
+}): Promise<{
+  output: protocol.ToolSearchOutputItem;
+  runtimeTools: Tool<TContext>[];
+}> {
+  const { agent, runContext, toolSearchCall, toolSearchTool, tools } = args;
+  const executor = getClientToolSearchExecutor(toolSearchTool);
+  if (!executor) {
+    throw new UserError(
+      'Client tool_search execution requires a registered execute callback.',
+    );
+  }
+
+  const runtimeTools = normalizeClientToolSearchExecutorResult(
+    await executor({
+      agent,
+      availableTools: [...tools],
+      loadDefault: (paths) => resolveBuiltInClientToolSearchTools(paths, tools),
+      runContext,
+      toolCall: toolSearchCall,
+    }),
+  );
+
+  return {
+    output: createClientToolSearchOutputFromTools(toolSearchCall, runtimeTools),
+    runtimeTools,
+  };
+}
+
+export function getClientToolSearchHelper<TContext>(
+  tools: Tool<TContext>[],
+): Tool<TContext> | undefined {
+  return tools.find(isClientToolSearchTool);
+}

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -25,6 +25,7 @@ import * as ProviderData from '../types/providerData';
 import * as protocol from '../types/protocol';
 import { AgentInputItem } from '../types';
 import type { FunctionToolResult } from '../tool';
+import { getFunctionToolQualifiedName } from '../toolIdentity';
 
 type ApprovalItemLike =
   | RunToolApprovalItem
@@ -402,7 +403,10 @@ export async function resolveInterruptedTurn<TContext>(
       return false;
     }
     const isApprovedCall = functionCallIds.includes(callId);
-    const isPendingNested = state.hasPendingAgentToolRun(run.tool.name, callId);
+    const isPendingNested = state.hasPendingAgentToolRun(
+      getFunctionToolQualifiedName(run.tool) ?? run.tool.name,
+      callId,
+    );
     if (!isApprovedCall && !isPendingNested) {
       return false;
     }

--- a/packages/agents-core/src/tool.ts
+++ b/packages/agents-core/src/tool.ts
@@ -25,6 +25,11 @@ import * as ProviderData from './types/providerData';
 import * as protocol from './types/protocol';
 import type { ZodInfer, ZodObjectLike } from './utils/zodCompat';
 import {
+  FUNCTION_TOOL_NAMESPACE,
+  FUNCTION_TOOL_NAMESPACE_DESCRIPTION,
+  getFunctionToolQualifiedName,
+} from './toolIdentity';
+import {
   resolveToolInputGuardrails,
   resolveToolOutputGuardrails,
   ToolInputGuardrailDefinition,
@@ -236,6 +241,11 @@ export type FunctionTool<
    * Whether the tool is strict. If true, the model must try to strictly follow the schema (might result in slower response times).
    */
   strict: boolean;
+
+  /**
+   * Responses API only. Hides a top-level function tool definition until tool search loads it.
+   */
+  deferLoading?: boolean;
 
   /**
    * The function to invoke when the tool is called.
@@ -884,6 +894,8 @@ export type HostedMCPTool<Context = UnknownContext> = HostedTool & {
 export function hostedMcpTool<Context = UnknownContext>(
   options: {
     allowedTools?: string[] | { toolNames?: string[] };
+    deferLoading?: boolean;
+    serverDescription?: string;
   } &
     // MCP server
     (| {
@@ -926,7 +938,9 @@ export function hostedMcpTool<Context = UnknownContext>(
             authorization: options.authorization,
             require_approval: 'never',
             allowed_tools: toMcpAllowedToolsFilter(options.allowedTools),
+            defer_loading: options.deferLoading,
             headers: options.headers,
+            server_description: options.serverDescription,
           }
         : {
             type: 'mcp',
@@ -934,12 +948,14 @@ export function hostedMcpTool<Context = UnknownContext>(
             server_url: options.serverUrl,
             authorization: options.authorization,
             allowed_tools: toMcpAllowedToolsFilter(options.allowedTools),
+            defer_loading: options.deferLoading,
             headers: options.headers,
             require_approval:
               typeof options.requireApproval === 'string'
                 ? 'always'
                 : buildRequireApproval(options.requireApproval),
             on_approval: options.onApproval,
+            server_description: options.serverDescription,
           };
     return {
       type: 'hosted_tool',
@@ -958,7 +974,9 @@ export function hostedMcpTool<Context = UnknownContext>(
             authorization: options.authorization,
             require_approval: 'never',
             allowed_tools: toMcpAllowedToolsFilter(options.allowedTools),
+            defer_loading: options.deferLoading,
             headers: options.headers,
+            server_description: options.serverDescription,
           }
         : {
             type: 'mcp',
@@ -966,12 +984,14 @@ export function hostedMcpTool<Context = UnknownContext>(
             connector_id: options.connectorId,
             authorization: options.authorization,
             allowed_tools: toMcpAllowedToolsFilter(options.allowedTools),
+            defer_loading: options.deferLoading,
             headers: options.headers,
             require_approval:
               typeof options.requireApproval === 'string'
                 ? 'always'
                 : buildRequireApproval(options.requireApproval),
             on_approval: options.onApproval,
+            server_description: options.serverDescription,
           };
     return {
       type: 'hosted_tool',
@@ -988,16 +1008,20 @@ export function hostedMcpTool<Context = UnknownContext>(
             server_label: options.serverLabel,
             require_approval: 'never',
             allowed_tools: toMcpAllowedToolsFilter(options.allowedTools),
+            defer_loading: options.deferLoading,
+            server_description: options.serverDescription,
           }
         : {
             type: 'mcp',
             server_label: options.serverLabel,
             allowed_tools: toMcpAllowedToolsFilter(options.allowedTools),
+            defer_loading: options.deferLoading,
             require_approval:
               typeof options.requireApproval === 'string'
                 ? 'always'
                 : buildRequireApproval(options.requireApproval),
             on_approval: options.onApproval,
+            server_description: options.serverDescription,
           };
     return {
       type: 'hosted_tool',
@@ -1025,6 +1049,80 @@ export type HostedTool = {
    */
   providerData?: Record<string, any>;
 };
+
+export type ClientToolSearchLoadDefaultFunction<Context = UnknownContext> = (
+  paths: string[],
+) => Tool<Context>[];
+
+export type ClientToolSearchExecutorArgs<Context = UnknownContext> = {
+  agent: Agent<Context, any>;
+  availableTools: Tool<Context>[];
+  loadDefault: ClientToolSearchLoadDefaultFunction<Context>;
+  runContext: RunContext<Context>;
+  toolCall: protocol.ToolSearchCallItem;
+};
+
+export type ClientToolSearchExecutorResult<Context = UnknownContext> =
+  | Tool<Context>
+  | Tool<Context>[]
+  | null
+  | undefined;
+
+export type ClientToolSearchExecutor<Context = UnknownContext> = (
+  args: ClientToolSearchExecutorArgs<Context>,
+) =>
+  | ClientToolSearchExecutorResult<Context>
+  | Promise<ClientToolSearchExecutorResult<Context>>;
+
+export const CLIENT_TOOL_SEARCH_EXECUTOR = Symbol('clientToolSearchExecutor');
+
+type HostedToolWithClientToolSearchExecutor<Context = UnknownContext> =
+  HostedTool & {
+    [CLIENT_TOOL_SEARCH_EXECUTOR]?: ClientToolSearchExecutor<Context>;
+  };
+
+export function attachClientToolSearchExecutor<Context = UnknownContext>(
+  tool: HostedTool,
+  executor: ClientToolSearchExecutor<Context>,
+): HostedTool {
+  Object.defineProperty(tool, CLIENT_TOOL_SEARCH_EXECUTOR, {
+    value: executor,
+    enumerable: false,
+    configurable: true,
+  });
+  return tool;
+}
+
+export function getClientToolSearchExecutor<Context = UnknownContext>(
+  tool: Tool<Context>,
+): ClientToolSearchExecutor<Context> | undefined {
+  if (tool.type !== 'hosted_tool') {
+    return undefined;
+  }
+
+  return (tool as HostedToolWithClientToolSearchExecutor<Context>)[
+    CLIENT_TOOL_SEARCH_EXECUTOR
+  ];
+}
+
+export function getToolSearchRuntimeToolKey<Context = UnknownContext>(
+  tool: Tool<Context>,
+): string | undefined {
+  if (tool.type === 'function') {
+    return getFunctionToolQualifiedName(tool) ?? tool.name;
+  }
+
+  if (
+    tool.type === 'hosted_tool' &&
+    tool.providerData?.type === 'mcp' &&
+    typeof tool.providerData.server_label === 'string' &&
+    tool.providerData.server_label.length > 0
+  ) {
+    return `mcp:${tool.providerData.server_label}`;
+  }
+
+  return undefined;
+}
 
 /**
  * A tool that can be called by the model.
@@ -1274,6 +1372,11 @@ type StrictToolOptions<
   strict?: true;
 
   /**
+   * Responses API only. Hides a top-level function tool definition until tool search loads it.
+   */
+  deferLoading?: boolean;
+
+  /**
    * The function to invoke when the tool is called.
    */
   execute: ToolExecuteFunction<TParameters, Context>;
@@ -1342,6 +1445,11 @@ type NonStrictToolOptions<
   strict: false;
 
   /**
+   * Responses API only. Hides a top-level function tool definition until tool search loads it.
+   */
+  deferLoading?: boolean;
+
+  /**
    * The function to invoke when the tool is called.
    */
   execute: ToolExecuteFunction<TParameters, Context>;
@@ -1399,6 +1507,17 @@ export type ToolOptionsWithGuardrails<
   TParameters extends ToolInputParameters,
   Context = UnknownContext,
 > = ToolOptions<TParameters, Context>;
+
+type NamespacedFunctionTool<
+  Context = UnknownContext,
+  TParameters extends ToolInputParameters = ToolInputParameters,
+  Result = unknown,
+> = FunctionTool<Context, TParameters, Result> & {
+  [FUNCTION_TOOL_NAMESPACE]?: string;
+  [FUNCTION_TOOL_NAMESPACE_DESCRIPTION]?: string;
+};
+
+type AnyFunctionTool = FunctionTool<any, any, any>;
 
 type FunctionToolInvocationArgs<
   Context = UnknownContext,
@@ -1787,6 +1906,7 @@ export function tool<
     description: options.description,
     parameters,
     strict: strictMode,
+    deferLoading: options.deferLoading ?? false,
     invoke,
     needsApproval,
     timeoutMs,
@@ -1796,6 +1916,73 @@ export function tool<
     inputGuardrails: resolveToolInputGuardrails(options.inputGuardrails),
     outputGuardrails: resolveToolOutputGuardrails(options.outputGuardrails),
   };
+}
+
+export type ToolNamespaceOptions<
+  TTools extends readonly AnyFunctionTool[] = readonly AnyFunctionTool[],
+> = {
+  /**
+   * The namespace name to expose to the model.
+   */
+  name: string;
+
+  /**
+   * Description shared by all tools in the namespace.
+   */
+  description: string;
+
+  /**
+   * Function tools to attach to the namespace.
+   */
+  tools: TTools;
+};
+
+/**
+ * Responses API only. Group function tools under a shared namespace.
+ *
+ * @param options - Namespace metadata and function tools to attach.
+ * @returns shallow-cloned function tools carrying namespace metadata.
+ */
+export function toolNamespace<TTools extends readonly AnyFunctionTool[]>(
+  options: ToolNamespaceOptions<TTools>,
+): TTools {
+  if (typeof options !== 'object' || options === null) {
+    throw new UserError('toolNamespace() requires a namespace config object.');
+  }
+
+  const { name, description, tools } = options;
+
+  if (typeof name !== 'string' || name.trim().length === 0) {
+    throw new UserError('toolNamespace() requires a non-empty namespace name.');
+  }
+  if (typeof description !== 'string' || description.trim().length === 0) {
+    throw new UserError(
+      'toolNamespace() requires a non-empty description because the Responses API requires namespace descriptions.',
+    );
+  }
+  if (!Array.isArray(tools)) {
+    throw new UserError('toolNamespace() requires an array of function tools.');
+  }
+  if (tools.some((tool) => tool?.type !== 'function')) {
+    throw new UserError(
+      'toolNamespace() only supports FunctionTool instances.',
+    );
+  }
+
+  const namespaceName = toFunctionToolName(name.trim());
+  if (tools.some((tool) => tool.name === namespaceName)) {
+    throw new UserError(
+      `toolNamespace() does not allow a tool named "${namespaceName}" inside namespace "${namespaceName}" because Responses self-namespaced calls would be ambiguous.`,
+    );
+  }
+  const normalizedDescription = description.trim();
+
+  return tools.map((tool) =>
+    cloneObjectWithDescriptorsAndOverrides(tool as NamespacedFunctionTool, {
+      [FUNCTION_TOOL_NAMESPACE]: namespaceName,
+      [FUNCTION_TOOL_NAMESPACE_DESCRIPTION]: normalizedDescription,
+    }),
+  ) as unknown as TTools;
 }
 
 function buildRequireApproval(requireApproval: {

--- a/packages/agents-core/src/toolIdentity.ts
+++ b/packages/agents-core/src/toolIdentity.ts
@@ -1,0 +1,175 @@
+import type { FunctionTool } from './tool';
+import { toolDisplayName, toolQualifiedName } from './tooling';
+export { toolDisplayName, toolQualifiedName } from './tooling';
+
+export const FUNCTION_TOOL_NAMESPACE = Symbol('functionToolNamespace');
+export const FUNCTION_TOOL_NAMESPACE_DESCRIPTION = Symbol(
+  'functionToolNamespaceDescription',
+);
+
+type MaybeFunctionToolWithNamespaceMetadata = {
+  name?: unknown;
+  deferLoading?: unknown;
+  [FUNCTION_TOOL_NAMESPACE]?: unknown;
+  [FUNCTION_TOOL_NAMESPACE_DESCRIPTION]?: unknown;
+};
+
+type MaybeToolCallWithNamespace = {
+  name?: unknown;
+  namespace?: unknown;
+};
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+export function getToolCallNamespace(
+  toolCall: MaybeToolCallWithNamespace,
+): string | undefined {
+  return isNonEmptyString(toolCall.namespace) ? toolCall.namespace : undefined;
+}
+
+export function getToolCallName(
+  toolCall: MaybeToolCallWithNamespace,
+): string | undefined {
+  return isNonEmptyString(toolCall.name) ? toolCall.name : undefined;
+}
+
+export function getToolCallQualifiedName(
+  toolCall: MaybeToolCallWithNamespace,
+): string | undefined {
+  return toolQualifiedName(
+    getToolCallName(toolCall),
+    getToolCallNamespace(toolCall),
+  );
+}
+
+export function getToolCallDisplayName(
+  toolCall: MaybeToolCallWithNamespace,
+): string | undefined {
+  return toolDisplayName(
+    getToolCallName(toolCall),
+    getToolCallNamespace(toolCall),
+  );
+}
+
+type ToolNameLookup = {
+  has(name: string): boolean;
+  get?(name: string): unknown;
+};
+
+function isTopLevelDeferredFunctionTool(
+  candidate: unknown,
+  bareName: string,
+): boolean {
+  const tool = candidate as MaybeFunctionToolWithNamespaceMetadata & {
+    type?: unknown;
+    name?: unknown;
+  };
+  return (
+    tool?.type === 'function' &&
+    tool.name === bareName &&
+    tool.deferLoading === true &&
+    !isNonEmptyString(tool?.[FUNCTION_TOOL_NAMESPACE])
+  );
+}
+
+export function resolveFunctionToolCallName(
+  toolCall: MaybeToolCallWithNamespace,
+  availableToolNames: ToolNameLookup,
+): string | undefined {
+  const bareName = getToolCallName(toolCall);
+  const namespace = getToolCallNamespace(toolCall);
+  if (bareName && !namespace && availableToolNames.has(bareName)) {
+    return bareName;
+  }
+
+  const qualifiedName = getToolCallQualifiedName(toolCall);
+  const bareTool =
+    bareName && typeof availableToolNames.get === 'function'
+      ? availableToolNames.get(bareName)
+      : undefined;
+  const preferBareSelfNamespacedDeferredTool =
+    bareName &&
+    namespace === bareName &&
+    availableToolNames.has(bareName) &&
+    isTopLevelDeferredFunctionTool(bareTool, bareName);
+
+  if (qualifiedName && availableToolNames.has(qualifiedName)) {
+    if (preferBareSelfNamespacedDeferredTool) {
+      return bareName;
+    }
+    return qualifiedName;
+  }
+
+  if (bareName && namespace === bareName && availableToolNames.has(bareName)) {
+    return bareName;
+  }
+
+  return qualifiedName ?? bareName;
+}
+
+export function getExplicitFunctionToolNamespace(
+  tool: unknown,
+): string | undefined {
+  const candidate = tool as MaybeFunctionToolWithNamespaceMetadata;
+  return isNonEmptyString(candidate?.[FUNCTION_TOOL_NAMESPACE])
+    ? candidate[FUNCTION_TOOL_NAMESPACE]
+    : undefined;
+}
+
+export function getFunctionToolNamespace(tool: unknown): string | undefined {
+  return getExplicitFunctionToolNamespace(tool);
+}
+
+export function getFunctionToolNamespaceDescription(
+  tool: unknown,
+): string | undefined {
+  const candidate = tool as MaybeFunctionToolWithNamespaceMetadata;
+  return isNonEmptyString(candidate?.[FUNCTION_TOOL_NAMESPACE_DESCRIPTION])
+    ? candidate[FUNCTION_TOOL_NAMESPACE_DESCRIPTION]
+    : undefined;
+}
+
+export function getFunctionToolQualifiedName(
+  tool: Pick<FunctionTool<any, any, any>, 'name'> | unknown,
+): string | undefined {
+  const candidate = tool as MaybeFunctionToolWithNamespaceMetadata;
+  return toolQualifiedName(
+    isNonEmptyString(candidate?.name) ? candidate.name : undefined,
+    getFunctionToolNamespace(tool),
+  );
+}
+
+export function getFunctionToolDisplayName(
+  tool: Pick<FunctionTool<any, any, any>, 'name'> | unknown,
+): string | undefined {
+  const candidate = tool as MaybeFunctionToolWithNamespaceMetadata;
+  return toolDisplayName(
+    isNonEmptyString(candidate?.name) ? candidate.name : undefined,
+    getFunctionToolNamespace(tool),
+  );
+}
+
+export function matchesFunctionToolName(
+  tool: Pick<FunctionTool<any, any, any>, 'name'> | unknown,
+  candidate: string | undefined,
+): boolean {
+  if (!isNonEmptyString(candidate)) {
+    return false;
+  }
+
+  const bareName = getFunctionToolName(tool);
+  if (bareName === candidate) {
+    return true;
+  }
+
+  return getFunctionToolQualifiedName(tool) === candidate;
+}
+
+function getFunctionToolName(
+  tool: Pick<FunctionTool<any, any, any>, 'name'> | unknown,
+): string | undefined {
+  const candidate = tool as MaybeFunctionToolWithNamespaceMetadata;
+  return isNonEmptyString(candidate?.name) ? candidate.name : undefined;
+}

--- a/packages/agents-core/src/tooling.ts
+++ b/packages/agents-core/src/tooling.ts
@@ -1,0 +1,169 @@
+type ToolSearchExecution = 'client' | 'server';
+
+type MaybeToolWithNamespace = {
+  name?: unknown;
+  namespace?: unknown;
+};
+
+type MaybeToolSearchItem = {
+  id?: unknown;
+  providerData?: unknown;
+  call_id?: unknown;
+  callId?: unknown;
+  execution?: unknown;
+};
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function getToolSearchProviderData(
+  value: MaybeToolSearchItem,
+): Record<string, unknown> | undefined {
+  return typeof value.providerData === 'object' && value.providerData
+    ? (value.providerData as Record<string, unknown>)
+    : undefined;
+}
+
+export function toolQualifiedName(
+  name: string | undefined,
+  namespace?: string,
+): string | undefined {
+  if (!isNonEmptyString(name)) {
+    return undefined;
+  }
+  if (isNonEmptyString(namespace)) {
+    return `${namespace}.${name}`;
+  }
+  return name;
+}
+
+export function toolDisplayName(
+  name: string | undefined,
+  namespace?: string,
+): string | undefined {
+  if (!isNonEmptyString(name)) {
+    return undefined;
+  }
+
+  if (!isNonEmptyString(namespace) || namespace === name) {
+    return name;
+  }
+
+  return `${namespace}.${name}`;
+}
+
+export function getToolCallDisplayName(
+  toolCall: MaybeToolWithNamespace,
+): string | undefined {
+  return toolDisplayName(
+    isNonEmptyString(toolCall.name) ? toolCall.name : undefined,
+    isNonEmptyString(toolCall.namespace) ? toolCall.namespace : undefined,
+  );
+}
+
+export function getToolSearchProviderCallId(
+  value: MaybeToolSearchItem,
+): string | undefined {
+  const providerData = getToolSearchProviderData(value);
+  const providerCallId = providerData?.call_id ?? providerData?.callId;
+  if (isNonEmptyString(providerCallId)) {
+    return providerCallId;
+  }
+
+  if (isNonEmptyString(value.call_id)) {
+    return value.call_id;
+  }
+
+  if (isNonEmptyString(value.callId)) {
+    return value.callId;
+  }
+
+  return undefined;
+}
+
+export function getToolSearchMatchKey(
+  value: MaybeToolSearchItem,
+): string | undefined {
+  if (isNonEmptyString(value.id)) {
+    return getToolSearchProviderCallId(value) ?? value.id;
+  }
+
+  return getToolSearchProviderCallId(value);
+}
+
+export function getToolSearchOutputReplacementKey(
+  value: MaybeToolSearchItem,
+): string | undefined {
+  const providerCallId = getToolSearchProviderCallId(value);
+  if (providerCallId) {
+    return `call:${providerCallId}`;
+  }
+
+  return isNonEmptyString(value.id) ? `item:${value.id}` : undefined;
+}
+
+export function getToolSearchExecution(
+  value: MaybeToolSearchItem,
+): ToolSearchExecution | undefined {
+  if (value.execution === 'client' || value.execution === 'server') {
+    return value.execution;
+  }
+
+  const providerData = getToolSearchProviderData(value);
+  const execution = providerData?.execution;
+  return execution === 'client' || execution === 'server'
+    ? execution
+    : undefined;
+}
+
+export function isClientToolSearchCall(value: MaybeToolSearchItem): boolean {
+  return getToolSearchExecution(value) === 'client';
+}
+
+export function shouldQueuePendingToolSearchCall(
+  value: MaybeToolSearchItem,
+): boolean {
+  return getToolSearchExecution(value) !== 'server';
+}
+
+export function resolveToolSearchCallId(
+  value: MaybeToolSearchItem,
+  generateFallbackId?: () => string,
+): string {
+  const explicitMatchKey = getToolSearchMatchKey(value);
+  if (explicitMatchKey) {
+    return explicitMatchKey;
+  }
+
+  if (generateFallbackId) {
+    return generateFallbackId();
+  }
+
+  throw new Error(
+    'Tool search item is missing both call_id and id. Provide a fallback generator when resolving client-side tool_search history.',
+  );
+}
+
+export function takePendingToolSearchCallId(
+  value: MaybeToolSearchItem,
+  pendingCallIds: string[],
+  generateFallbackId?: () => string,
+): string {
+  const explicitCallId = getToolSearchProviderCallId(value);
+  if (explicitCallId) {
+    const pendingIndex = pendingCallIds.indexOf(explicitCallId);
+    if (pendingIndex >= 0) {
+      pendingCallIds.splice(pendingIndex, 1);
+    }
+    return explicitCallId;
+  }
+
+  if (getToolSearchExecution(value) === 'server') {
+    return resolveToolSearchCallId(value, generateFallbackId);
+  }
+
+  return (
+    pendingCallIds.shift() ?? resolveToolSearchCallId(value, generateFallbackId)
+  );
+}

--- a/packages/agents-core/src/types/aliases.ts
+++ b/packages/agents-core/src/types/aliases.ts
@@ -4,6 +4,8 @@ import {
   SystemMessageItem,
   HostedToolCallItem,
   FunctionCallItem,
+  ToolSearchCallItem,
+  ToolSearchOutputItem,
   ComputerUseCallItem,
   ShellCallItem,
   FunctionCallResultItem,
@@ -33,6 +35,8 @@ export type AgentOutputItem =
   | UserMessageItem
   | AssistantMessageItem
   | SystemMessageItem
+  | ToolSearchCallItem
+  | ToolSearchOutputItem
   | HostedToolCallItem
   | FunctionCallItem
   | ComputerUseCallItem
@@ -53,6 +57,8 @@ export type AgentInputItem =
   | UserMessageItem
   | AssistantMessageItem
   | SystemMessageItem
+  | ToolSearchCallItem
+  | ToolSearchOutputItem
   | HostedToolCallItem
   | FunctionCallItem
   | ComputerUseCallItem

--- a/packages/agents-core/src/types/protocol.ts
+++ b/packages/agents-core/src/types/protocol.ts
@@ -456,6 +456,11 @@ export const FunctionCallItem = ItemBase.extend({
   name: z.string().describe('The name of the function'),
 
   /**
+   * Optional namespace used to qualify the function name for tool search.
+   */
+  namespace: z.string().optional(),
+
+  /**
    * The status of the function call.
    */
   status: z.enum(['in_progress', 'completed', 'incomplete']).optional(),
@@ -467,6 +472,52 @@ export const FunctionCallItem = ItemBase.extend({
 });
 
 export type FunctionCallItem = z.infer<typeof FunctionCallItem>;
+
+export const ToolReference = z.object({
+  type: z.literal('tool_reference'),
+  functionName: z.string(),
+  namespace: z.string().optional(),
+});
+
+export type ToolReference = z.infer<typeof ToolReference>;
+
+/**
+ * Tool search outputs may contain tool references or concrete tool definitions.
+ * Preserve the payload as returned so stateless continuation can replay it losslessly.
+ */
+export const ToolSearchOutputTool = z.record(z.string(), z.any());
+
+export type ToolSearchOutputTool = z.infer<typeof ToolSearchOutputTool>;
+
+/**
+ * Tool search call arguments are provider-defined. Hosted tool search uses
+ * `{ paths, query }`, while client-executed tool search can use a custom schema.
+ */
+export const ToolSearchCallArguments = z.unknown();
+
+export type ToolSearchCallArguments = z.infer<typeof ToolSearchCallArguments>;
+
+export const ToolSearchCallItem = ItemBase.extend({
+  type: z.literal('tool_search_call'),
+  call_id: z.string().nullable().optional(),
+  callId: z.string().nullable().optional(),
+  execution: z.enum(['client', 'server']).optional(),
+  arguments: ToolSearchCallArguments,
+  status: z.string().optional(),
+});
+
+export type ToolSearchCallItem = z.infer<typeof ToolSearchCallItem>;
+
+export const ToolSearchOutputItem = ItemBase.extend({
+  type: z.literal('tool_search_output'),
+  call_id: z.string().nullable().optional(),
+  callId: z.string().nullable().optional(),
+  execution: z.enum(['client', 'server']).optional(),
+  status: z.string().optional(),
+  tools: z.array(ToolSearchOutputTool),
+});
+
+export type ToolSearchOutputItem = z.infer<typeof ToolSearchOutputItem>;
 
 export const ToolCallOutputContent = z.discriminatedUnion('type', [
   ToolOutputText,
@@ -490,6 +541,11 @@ export const FunctionCallResultItem = ItemBase.extend({
    * The name of the tool that was called
    */
   name: z.string().describe('The name of the tool'),
+
+  /**
+   * Optional namespace preserved from the originating function call.
+   */
+  namespace: z.string().optional(),
 
   /**
    * The ID of the tool call. Required to match up the respective tool call result.
@@ -725,6 +781,8 @@ export type UnknownItem = z.infer<typeof UnknownItem>;
 
 export const OutputModelItem = z.discriminatedUnion('type', [
   AssistantMessageItem,
+  ToolSearchCallItem,
+  ToolSearchOutputItem,
   HostedToolCallItem,
   FunctionCallItem,
   ComputerUseCallItem,
@@ -744,6 +802,8 @@ export const ModelItem = z.union([
   UserMessageItem,
   AssistantMessageItem,
   SystemMessageItem,
+  ToolSearchCallItem,
+  ToolSearchOutputItem,
   HostedToolCallItem,
   FunctionCallItem,
   ComputerUseCallItem,

--- a/packages/agents-core/src/types/providerData.ts
+++ b/packages/agents-core/src/types/providerData.ts
@@ -7,6 +7,8 @@ import { UnknownContext } from './aliases';
 export type HostedMCPTool<Context = UnknownContext> = {
   type: 'mcp';
   allowed_tools?: string[] | { tool_names: string[] };
+  defer_loading?: boolean;
+  server_description?: string;
 } &
   // MCP server
   (| {

--- a/packages/agents-core/src/utils/index.ts
+++ b/packages/agents-core/src/utils/index.ts
@@ -4,3 +4,19 @@ export { toFunctionToolName } from './tools';
 export { EventEmitterDelegate } from '../lifecycle';
 export { encodeUint8ArrayToBase64 } from './base64';
 export { applyDiff } from './applyDiff';
+export {
+  getToolSearchProviderCallId,
+  getToolSearchMatchKey,
+  getToolSearchOutputReplacementKey,
+  getToolSearchExecution,
+  isClientToolSearchCall,
+  resolveToolSearchCallId,
+  shouldQueuePendingToolSearchCall,
+  takePendingToolSearchCallId,
+} from './toolSearch';
+export {
+  matchesFunctionToolName,
+  toolQualifiedName,
+  getToolCallDisplayName,
+  getFunctionToolDisplayName,
+} from '../toolIdentity';

--- a/packages/agents-core/src/utils/serialize.ts
+++ b/packages/agents-core/src/utils/serialize.ts
@@ -5,6 +5,10 @@ import { AgentOutputType } from '../agent';
 import { SerializedHandoff, SerializedTool } from '../model';
 import { UserError } from '../errors';
 import type { Computer } from '../computer';
+import {
+  getExplicitFunctionToolNamespace,
+  getFunctionToolNamespaceDescription,
+} from '../toolIdentity';
 
 function isComputerInstance(value: unknown): value is Computer {
   return (
@@ -17,12 +21,20 @@ function isComputerInstance(value: unknown): value is Computer {
 
 export function serializeTool(tool: Tool<any>): SerializedTool {
   if (tool.type === 'function') {
+    const namespace = getExplicitFunctionToolNamespace(tool);
     return {
       type: 'function',
       name: tool.name,
       description: tool.description,
       parameters: tool.parameters as JsonObjectSchema<any>,
       strict: tool.strict,
+      deferLoading: tool.deferLoading,
+      ...(namespace ? { namespace } : {}),
+      ...(namespace
+        ? {
+            namespaceDescription: getFunctionToolNamespaceDescription(tool),
+          }
+        : {}),
     };
   }
   if (tool.type === 'computer') {

--- a/packages/agents-core/src/utils/toolSearch.ts
+++ b/packages/agents-core/src/utils/toolSearch.ts
@@ -1,0 +1,10 @@
+export {
+  getToolSearchProviderCallId,
+  getToolSearchMatchKey,
+  getToolSearchOutputReplacementKey,
+  getToolSearchExecution,
+  isClientToolSearchCall,
+  resolveToolSearchCallId,
+  shouldQueuePendingToolSearchCall,
+  takePendingToolSearchCallId,
+} from '../tooling';

--- a/packages/agents-core/test/extensions/handoffFilters.test.ts
+++ b/packages/agents-core/test/extensions/handoffFilters.test.ts
@@ -6,6 +6,8 @@ import {
   RunMessageOutputItem,
   RunToolCallItem,
   RunToolCallOutputItem,
+  RunToolSearchCallItem,
+  RunToolSearchOutputItem,
 } from '../../src/items';
 import type { AgentInputItem } from '../../src/types';
 import type * as protocol from '../../src/types/protocol';
@@ -73,6 +75,29 @@ const applyPatchCallResult: protocol.ApplyPatchCallResultItem = {
   output: 'done',
 };
 
+const toolSearchCall: protocol.ToolSearchCallItem = {
+  type: 'tool_search_call',
+  id: 'tool-search-call',
+  status: 'completed',
+  arguments: {
+    paths: ['crm'],
+    query: 'lookup account',
+  },
+};
+
+const toolSearchOutput: protocol.ToolSearchOutputItem = {
+  type: 'tool_search_output',
+  id: 'tool-search-output',
+  status: 'completed',
+  tools: [
+    {
+      type: 'tool_reference',
+      functionName: 'lookup_account',
+      namespace: 'crm',
+    },
+  ],
+};
+
 describe('removeAllTools', () => {
   test('should be available', () => {
     const result = removeAllTools({
@@ -102,9 +127,11 @@ describe('removeAllTools', () => {
       preHandoffItems: [
         new RunHandoffCallItem(TEST_MODEL_FUNCTION_CALL, TEST_AGENT),
         message,
+        new RunToolSearchCallItem(toolSearchCall, TEST_AGENT),
         new RunToolCallItem(TEST_MODEL_FUNCTION_CALL, TEST_AGENT),
       ],
       newItems: [
+        new RunToolSearchOutputItem(toolSearchOutput, TEST_AGENT),
         new RunToolCallOutputItem(functionCallResult, TEST_AGENT, 'ok'),
         new RunHandoffOutputItem(functionCallResult, TEST_AGENT, TEST_AGENT),
         anotherMessage,
@@ -126,6 +153,8 @@ describe('removeAllTools', () => {
       userMessage,
       TEST_MODEL_FUNCTION_CALL,
       functionCallResult,
+      toolSearchCall,
+      toolSearchOutput,
       computerCall,
       computerCallResult,
       hostedToolCall,
@@ -142,7 +171,7 @@ describe('removeAllTools', () => {
     });
 
     expect(result.inputHistory).toStrictEqual([userMessage]);
-    expect(history).toHaveLength(10);
+    expect(history).toHaveLength(12);
     expect((result.inputHistory as AgentInputItem[])[0]).toBe(userMessage);
   });
 });

--- a/packages/agents-core/test/items.test.ts
+++ b/packages/agents-core/test/items.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
 
 import { Agent } from '../src/agent';
 import {
@@ -11,6 +12,11 @@ import {
   RunToolCallOutputItem as ToolCallOutputItem,
   extractAllTextOutput,
 } from '../src/items';
+import { tool } from '../src/tool';
+import {
+  FUNCTION_TOOL_NAMESPACE,
+  FUNCTION_TOOL_NAMESPACE_DESCRIPTION,
+} from '../src/toolIdentity';
 
 import { TEST_MODEL_MESSAGE, TEST_MODEL_FUNCTION_CALL } from './stubs';
 
@@ -54,6 +60,25 @@ describe('items.extractAllTextOutput', () => {
 });
 
 describe('items toJSON()', () => {
+  function createLegacyNamespacedTool<T extends Record<string, any>>(
+    tool: T,
+    namespace: string,
+    description: string,
+  ): T {
+    return Object.defineProperties(tool, {
+      [FUNCTION_TOOL_NAMESPACE]: {
+        value: namespace,
+        enumerable: false,
+        configurable: true,
+      },
+      [FUNCTION_TOOL_NAMESPACE_DESCRIPTION]: {
+        value: description,
+        enumerable: false,
+        configurable: true,
+      },
+    });
+  }
+
   describe('ToolCallItem', () => {
     const item = new ToolCallItem(
       {
@@ -185,6 +210,59 @@ describe('items toJSON()', () => {
         agent: item.agent.toJSON(),
         toolName: 'test',
       });
+    });
+
+    it('keeps top-level deferred approval names unqualified without agent tool metadata', () => {
+      const deferredItem = new ToolApprovalItem(
+        {
+          id: 'approval_1',
+          type: 'function_call',
+          callId: 'call_1',
+          name: 'get_shipping_eta',
+          namespace: 'get_shipping_eta',
+          arguments: '{}',
+          status: 'completed',
+        },
+        new Agent({ name: 'DeferredApprovalAgent' }),
+      );
+
+      expect(deferredItem.toolName).toBe('get_shipping_eta');
+      expect(deferredItem.name).toBe('get_shipping_eta');
+    });
+
+    it('keeps qualified approval names when agent tools resolve a same-name namespace', () => {
+      const namespacedLookupAccount = createLegacyNamespacedTool(
+        tool({
+          name: 'lookup_account',
+          description: 'Look up an account.',
+          parameters: z.object({
+            accountId: z.string(),
+          }),
+          deferLoading: true,
+          execute: async () => 'ok',
+        }),
+        'lookup_account',
+        'Resolve same-name namespace members.',
+      );
+
+      const namespacedItem = new ToolApprovalItem(
+        {
+          id: 'approval_2',
+          type: 'function_call',
+          callId: 'call_2',
+          name: 'lookup_account',
+          namespace: 'lookup_account',
+          arguments: '{}',
+          status: 'completed',
+        },
+        new Agent({
+          name: 'NamespacedApprovalAgent',
+          tools: [namespacedLookupAccount],
+        }),
+      );
+
+      expect(namespacedItem.toolName).toBe('lookup_account.lookup_account');
+      expect(namespacedItem.name).toBe('lookup_account.lookup_account');
     });
   });
 });

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -94,6 +94,94 @@ describe('Runner.run (streaming)', () => {
     expect((result.error as Error).message).toBe('Not implemented');
   });
 
+  it('treats prior tool_search outputs in input history as loaded deferred tools', async () => {
+    class QueueStreamingModel implements Model {
+      constructor(private readonly responses: ModelResponse[]) {}
+
+      async getResponse(_request: ModelRequest): Promise<ModelResponse> {
+        const response = this.responses.shift();
+        if (!response) {
+          throw new Error('No response found');
+        }
+        return response;
+      }
+
+      async *getStreamedResponse(
+        request: ModelRequest,
+      ): AsyncIterable<StreamEvent> {
+        const response = await this.getResponse(request);
+        const output = response.output.map((item) =>
+          protocol.OutputModelItem.parse(item),
+        );
+        yield {
+          type: 'response_done',
+          response: {
+            id: response.responseId ?? 'resp-stream-tool-search',
+            usage: {
+              requests: response.usage.requests,
+              inputTokens: response.usage.inputTokens,
+              outputTokens: response.usage.outputTokens,
+              totalTokens: response.usage.totalTokens,
+            },
+            output,
+          },
+        } satisfies StreamEvent;
+      }
+    }
+
+    const getShippingEta = tool({
+      name: 'get_shipping_eta',
+      description: 'Look up a shipping ETA.',
+      parameters: z.object({
+        trackingNumber: z.string(),
+      }),
+      deferLoading: true,
+      execute: async () => 'tomorrow',
+    });
+    const agent = new Agent({
+      name: 'StreamingShippingAgent',
+      model: new QueueStreamingModel([
+        {
+          output: [
+            {
+              type: 'function_call',
+              id: 'fc_shipping_eta',
+              callId: 'call_shipping_eta',
+              name: 'get_shipping_eta',
+              status: 'completed',
+              arguments: JSON.stringify({ trackingNumber: 'ZX-123' }),
+            } as protocol.FunctionCallItem,
+          ],
+          usage: new Usage(),
+        },
+        {
+          output: [fakeModelMessage('The package arrives tomorrow.')],
+          usage: new Usage(),
+        },
+      ]),
+      tools: [getShippingEta],
+      toolUseBehavior: 'run_llm_again',
+    });
+    const inputHistory: AgentInputItem[] = [
+      user('Load shipping tools first.'),
+      {
+        type: 'tool_search_output',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'get_shipping_eta',
+          },
+        ],
+      } as any,
+    ];
+
+    const result = await run(agent, inputHistory, { stream: true });
+
+    await result.completed;
+    expect(result.finalOutput).toBe('The package arrives tomorrow.');
+  });
+
   it('detaches abort listeners after streaming completion when signal is retained', async () => {
     const agent = new Agent({
       name: 'AbortDetach',

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -17,6 +17,7 @@ import {
   ModelResponse,
   OutputGuardrailTripwireTriggered,
   Session,
+  UserError,
   ModelInputData,
   type OutputGuardrailFunctionArgs,
   type AgentInputItem,
@@ -43,7 +44,12 @@ import { RunContext } from '../src/runContext';
 import { RunState } from '../src/runState';
 import * as protocol from '../src/types/protocol';
 import { Usage } from '../src/usage';
-import { tool, hostedMcpTool, computerTool } from '../src/tool';
+import {
+  attachClientToolSearchExecutor,
+  tool,
+  hostedMcpTool,
+  computerTool,
+} from '../src/tool';
 import logger from '../src/logger';
 import { getGlobalTraceProvider } from '../src/tracing/provider';
 import {
@@ -191,6 +197,204 @@ describe('Runner.run', () => {
 
       expect(result.finalOutput).toBe('Hello World');
       expectTypeOf(result.finalOutput).toEqualTypeOf<string | undefined>();
+    });
+
+    it('rejects custom client tool_search parameters without execute before calling the model', async () => {
+      const getResponse = vi.fn().mockResolvedValue(TEST_MODEL_RESPONSE_BASIC);
+      const model: Model = {
+        getResponse,
+        async *getStreamedResponse() {
+          yield* [];
+        },
+      };
+      const agent = new Agent({
+        name: 'ClientToolSearchValidationAgent',
+        model,
+        tools: [
+          {
+            type: 'hosted_tool',
+            name: 'tool_search',
+            providerData: {
+              type: 'tool_search',
+              execution: 'client',
+              parameters: {
+                type: 'object',
+                properties: {
+                  namespaceHints: {
+                    type: 'array',
+                    items: { type: 'string' },
+                  },
+                },
+                required: ['namespaceHints'],
+                additionalProperties: false,
+              },
+            },
+          } as any,
+        ],
+      });
+
+      const runPromise = new Runner().run(agent, 'hello');
+
+      await expect(runPromise).rejects.toThrow(UserError);
+      await expect(runPromise).rejects.toThrow(
+        /require toolSearchTool\(\{ execution: "client", execute \}\)/,
+      );
+      expect(getResponse).not.toHaveBeenCalled();
+    });
+
+    it('loads runtime tools from custom client tool_search execute callbacks across turns', async () => {
+      const lookupAccount = tool({
+        name: 'lookup_account',
+        description: 'Look up an account in CRM.',
+        parameters: z.object({
+          accountId: z.string(),
+        }),
+        execute: async ({ accountId }) => `account:${accountId}`,
+      });
+      const execute = vi.fn().mockResolvedValue(lookupAccount);
+      const toolSearch = attachClientToolSearchExecutor(
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: {
+            type: 'tool_search',
+            execution: 'client',
+            parameters: {
+              type: 'object',
+              properties: {
+                namespaceHints: {
+                  type: 'array',
+                  items: { type: 'string' },
+                },
+              },
+              required: ['namespaceHints'],
+              additionalProperties: false,
+            },
+          },
+        },
+        execute,
+      );
+      const model = new FakeModel([
+        {
+          output: [
+            {
+              type: 'tool_search_call',
+              id: 'ts_call_lookup',
+              status: 'completed',
+              arguments: {
+                namespaceHints: ['crm'],
+              },
+              providerData: {
+                call_id: 'call_tool_search_lookup',
+                execution: 'client',
+              },
+            } as protocol.ToolSearchCallItem,
+          ],
+          usage: new Usage(),
+        },
+        {
+          output: [
+            {
+              type: 'function_call',
+              id: 'fc_lookup_account',
+              callId: 'call_lookup_account',
+              name: 'lookup_account',
+              status: 'completed',
+              arguments: JSON.stringify({ accountId: 'acct_42' }),
+            } as protocol.FunctionCallItem,
+          ],
+          usage: new Usage(),
+        },
+        {
+          output: [fakeModelMessage('Account loaded.')],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'CustomClientToolSearchAgent',
+        model,
+        tools: [toolSearch],
+      });
+      const state = new RunState(new RunContext(), 'hello', agent, 10);
+
+      const result = await new Runner().run(agent, state);
+
+      expect(result.finalOutput).toBe('Account loaded.');
+      expect(execute).toHaveBeenCalledTimes(1);
+      const executeArgs = execute.mock.calls[0]?.[0];
+      expect(executeArgs?.agent).toBe(agent);
+      expect(executeArgs?.availableTools).toEqual([toolSearch]);
+      expect(executeArgs?.runContext).toBe(state._context);
+      expect(executeArgs?.toolCall).toMatchObject({
+        type: 'tool_search_call',
+        arguments: {
+          namespaceHints: ['crm'],
+        },
+      });
+      expect(executeArgs?.loadDefault).toEqual(expect.any(Function));
+      expect(state.getToolSearchRuntimeTools(agent)).toEqual([lookupAccount]);
+      expect(executeArgs?.loadDefault(['missing_tool'])).toEqual([]);
+    });
+
+    it('treats prior tool_search outputs in input history as loaded deferred tools', async () => {
+      const getShippingEta = tool({
+        name: 'get_shipping_eta',
+        description: 'Look up a shipping ETA.',
+        parameters: z.object({
+          trackingNumber: z.string(),
+        }),
+        deferLoading: true,
+        execute: async () => 'tomorrow',
+      });
+      const model = new FakeModel([
+        {
+          output: [
+            {
+              type: 'function_call',
+              id: 'fc_shipping_eta',
+              callId: 'call_shipping_eta',
+              name: 'get_shipping_eta',
+              status: 'completed',
+              arguments: JSON.stringify({ trackingNumber: 'ZX-123' }),
+            } as protocol.FunctionCallItem,
+          ],
+          usage: new Usage(),
+        },
+        {
+          output: [fakeModelMessage('The package arrives tomorrow.')],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'ShippingAgent',
+        instructions: 'Use the tool when it is available.',
+        model,
+        tools: [getShippingEta],
+        toolUseBehavior: 'run_llm_again',
+      });
+      const inputHistory: AgentInputItem[] = [
+        user('Load shipping tools first.'),
+        {
+          type: 'tool_search_output',
+          status: 'completed',
+          tools: [
+            {
+              type: 'tool_reference',
+              functionName: 'get_shipping_eta',
+            },
+          ],
+        } as any,
+      ];
+
+      const result = await run(agent, inputHistory);
+
+      expect(result.finalOutput).toBe('The package arrives tomorrow.');
+      expect(result.history).toContainEqual(
+        expect.objectContaining({
+          type: 'function_call',
+          name: 'get_shipping_eta',
+        }),
+      );
     });
 
     it('exposes aggregated usage on run results', async () => {

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -14,8 +14,16 @@ import {
   RunMessageOutputItem,
   RunReasoningItem,
   RunToolCallOutputItem,
+  RunToolSearchCallItem,
+  RunToolSearchOutputItem,
 } from '../src/items';
-import { applyPatchTool, computerTool, shellTool } from '../src/tool';
+import {
+  applyPatchTool,
+  computerTool,
+  shellTool,
+  tool,
+  toolNamespace,
+} from '../src/tool';
 import * as protocol from '../src/types/protocol';
 import {
   TEST_MODEL_MESSAGE,
@@ -27,6 +35,7 @@ import { RunResult } from '../src/result';
 import { createAgentSpan } from '../src/tracing';
 import { getGlobalTraceProvider } from '../src/tracing/provider';
 import type { MCPServer, MCPTool } from '../src/mcp';
+import { z } from 'zod';
 
 describe('RunState', () => {
   it('initializes with default values', () => {
@@ -515,6 +524,190 @@ describe('RunState', () => {
     );
   });
 
+  it('accepts schema version 1.6 payloads during deserialization', async () => {
+    const context = new RunContext();
+    const agent = new Agent({ name: 'Agent16' });
+    const state = new RunState(context, 'input1', agent, 2);
+    state._modelResponses = [
+      {
+        usage: new Usage(),
+        output: [TEST_MODEL_MESSAGE],
+        responseId: 'resp_16',
+        requestId: 'req_16',
+      },
+    ];
+    state._lastTurnResponse = state._modelResponses[0];
+
+    const jsonVersion = state.toJSON() as any;
+    jsonVersion.$schemaVersion = '1.6';
+
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(jsonVersion),
+    );
+
+    expect(restored._lastTurnResponse?.responseId).toBe('resp_16');
+    expect(restored._lastTurnResponse?.requestId).toBe('req_16');
+  });
+
+  it('rejects schema version 1.7 payloads with tool_search items during deserialization', async () => {
+    const context = new RunContext();
+    const agent = new Agent({ name: 'Agent18' });
+    const state = new RunState(context, 'input1', agent, 2);
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_17',
+          callId: 'ts_call_17',
+          status: 'completed',
+          arguments: { paths: ['crm'], query: 'profile' },
+        } as any,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_17',
+          callId: 'ts_call_17',
+          status: 'completed',
+          tools: [
+            {
+              type: 'tool_reference',
+              functionName: 'lookup_account',
+              namespace: 'crm',
+            },
+          ],
+        } as any,
+        agent,
+      ),
+    );
+
+    const jsonVersion = state.toJSON() as any;
+    jsonVersion.$schemaVersion = '1.7';
+
+    await expect(() =>
+      RunState.fromString(agent, JSON.stringify(jsonVersion)),
+    ).rejects.toThrow(
+      'Run state schema version 1.7 does not support tool_search items.',
+    );
+  });
+
+  it('accepts schema version 1.8 payloads with tool_search items during deserialization', async () => {
+    const context = new RunContext();
+    const agent = new Agent({ name: 'Agent18' });
+    const state = new RunState(context, 'input1', agent, 2);
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_18',
+          callId: 'ts_call_18',
+          status: 'completed',
+          arguments: { paths: ['crm'], query: 'profile' },
+        } as any,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_18',
+          callId: 'ts_call_18',
+          status: 'completed',
+          tools: [
+            {
+              type: 'tool_reference',
+              functionName: 'lookup_account',
+              namespace: 'crm',
+            },
+          ],
+        } as any,
+        agent,
+      ),
+    );
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(restored._generatedItems[0]).toBeInstanceOf(RunToolSearchCallItem);
+    expect(restored._generatedItems[1]).toBeInstanceOf(RunToolSearchOutputItem);
+  });
+
+  it('preserves raw tool_search call_id and execution fields through RunState serialization', async () => {
+    const context = new RunContext();
+    const agent = new Agent({ name: 'Agent18RawSearch' });
+    const state = new RunState(context, 'input1', agent, 2);
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_raw',
+          call_id: 'call_ts_raw',
+          execution: 'server',
+          status: 'completed',
+          arguments: { paths: ['crm'], query: 'profile' },
+        } as any,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_raw',
+          call_id: 'call_ts_raw',
+          execution: 'server',
+          status: 'completed',
+          tools: [
+            {
+              type: 'tool_reference',
+              functionName: 'lookup_account',
+              namespace: 'crm',
+            },
+          ],
+        } as any,
+        agent,
+      ),
+    );
+
+    const restored = await RunState.fromString(agent, state.toString());
+    const restoredCall = restored._generatedItems[0] as RunToolSearchCallItem;
+    const restoredOutput = restored
+      ._generatedItems[1] as RunToolSearchOutputItem;
+
+    expect(restoredCall.rawItem).toMatchObject({
+      type: 'tool_search_call',
+      call_id: 'call_ts_raw',
+      execution: 'server',
+    });
+    expect(restoredOutput.rawItem).toMatchObject({
+      type: 'tool_search_output',
+      call_id: 'call_ts_raw',
+      execution: 'server',
+    });
+  });
+
+  it('accepts schema version 1.7 payloads when non-item context data mentions tool_search types', async () => {
+    const context = new RunContext({
+      custom: {
+        type: 'tool_search_output',
+        note: 'This is plain context data, not a serialized run item.',
+      },
+    });
+    const agent = new Agent({ name: 'Agent17' });
+    const state = new RunState(context, 'input1', agent, 2);
+
+    const jsonVersion = state.toJSON() as any;
+    jsonVersion.$schemaVersion = '1.7';
+
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(jsonVersion),
+    );
+
+    expect((restored._context.context as any).custom).toEqual({
+      type: 'tool_search_output',
+      note: 'This is plain context data, not a serialized run item.',
+    });
+  });
+
   it('approve updates context approvals correctly', () => {
     const context = new RunContext();
     const agent = new Agent({ name: 'Agent2' });
@@ -808,6 +1001,121 @@ describe('RunState', () => {
     ).toBe('Blocked everywhere');
   });
 
+  it('tracks qualified tool names for namespaced approvals', () => {
+    const context = new RunContext();
+    const agent = new Agent({ name: 'AgentNamespaceApproval' });
+    const state = new RunState(context, '', agent, 1);
+    const rawItem: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'lookup_account',
+      namespace: 'crm',
+      callId: 'cid_namespace',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const approvalItem = new ToolApprovalItem(rawItem, agent);
+
+    state.approve(approvalItem);
+
+    expect(
+      state._context.isToolApproved({
+        toolName: 'crm.lookup_account',
+        callId: 'cid_namespace',
+      }),
+    ).toBe(true);
+    expect(approvalItem.toolName).toBe('crm.lookup_account');
+  });
+
+  it('preserves declared tool names for top-level deferred approvals across resume', async () => {
+    const context = new RunContext();
+    const agent = new Agent({ name: 'AgentDeferredApproval' });
+    const state = new RunState(context, '', agent, 1);
+    const rawItem: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'get_shipping_eta',
+      namespace: 'get_shipping_eta',
+      callId: 'cid_shipping_eta',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: {
+        interruptions: [
+          new ToolApprovalItem(rawItem, agent, 'get_shipping_eta'),
+        ],
+      },
+    };
+
+    const restored = await RunState.fromString(agent, state.toString());
+    const [approvalItem] = restored.getInterruptions();
+    restored.approve(approvalItem);
+
+    expect(
+      restored._context.isToolApproved({
+        toolName: 'get_shipping_eta',
+        callId: 'cid_shipping_eta',
+      }),
+    ).toBe(true);
+    expect(
+      restored._context.isToolApproved({
+        toolName: 'get_shipping_eta.get_shipping_eta',
+        callId: 'cid_shipping_eta',
+      }),
+    ).toBeUndefined();
+    expect(approvalItem.toolName).toBe('get_shipping_eta');
+  });
+
+  it('resolves top-level deferred approval names from the agent tool set across resume', async () => {
+    const context = new RunContext();
+    const shippingEta = tool({
+      name: 'get_shipping_eta',
+      description: 'Look up a shipping ETA.',
+      parameters: z.object({
+        trackingNumber: z.string(),
+      }),
+      deferLoading: true,
+      execute: async () => 'tomorrow',
+    });
+    const agent = new Agent({
+      name: 'AgentDeferredApprovalResolved',
+      tools: [shippingEta],
+    });
+    const state = new RunState(context, '', agent, 1);
+    const rawItem: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'get_shipping_eta',
+      namespace: 'get_shipping_eta',
+      callId: 'cid_shipping_eta',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: {
+        interruptions: [new ToolApprovalItem(rawItem, agent)],
+      },
+    };
+
+    const restored = await RunState.fromString(agent, state.toString());
+    const [approvalItem] = restored.getInterruptions();
+    restored.approve(approvalItem);
+
+    expect(
+      restored._context.isToolApproved({
+        toolName: 'get_shipping_eta',
+        callId: 'cid_shipping_eta',
+      }),
+    ).toBe(true);
+    expect(
+      restored._context.isToolApproved({
+        toolName: 'get_shipping_eta.get_shipping_eta',
+        callId: 'cid_shipping_eta',
+      }),
+    ).toBeUndefined();
+    expect(approvalItem.toolName).toBe('get_shipping_eta');
+  });
+
   it('fromString reconstructs state for simple agent', async () => {
     const context = new RunContext({ a: 1 });
     const agent = new Agent({ name: 'Solo' });
@@ -1061,6 +1369,245 @@ describe('deserialize helpers', () => {
     );
     expect(item.type).toBe('message_output_item');
     expect((item as any).agent).toBe(agent);
+  });
+
+  it('deserializeItem restores ToolSearchCallItem', () => {
+    const agent = new Agent({ name: 'SearchAgent' });
+    const map = new Map([[agent.name, agent]]);
+    const item = deserializeItem(
+      {
+        type: 'tool_search_call_item',
+        rawItem: {
+          type: 'tool_search_call',
+          id: 'ts_call',
+          status: 'completed',
+          arguments: { paths: ['crm'], query: 'profile' },
+        },
+        agent: { name: 'SearchAgent' },
+      },
+      map,
+    );
+
+    expect(item).toBeInstanceOf(RunToolSearchCallItem);
+    expect((item as RunToolSearchCallItem).rawItem.arguments).toEqual({
+      paths: ['crm'],
+      query: 'profile',
+    });
+  });
+
+  it('deserializeItem restores ToolSearchOutputItem', () => {
+    const agent = new Agent({ name: 'SearchAgent' });
+    const map = new Map([[agent.name, agent]]);
+    const item = deserializeItem(
+      {
+        type: 'tool_search_output_item',
+        rawItem: {
+          type: 'tool_search_output',
+          id: 'ts_output',
+          status: 'completed',
+          tools: [
+            {
+              type: 'tool_reference',
+              functionName: 'lookup_account',
+              namespace: 'crm',
+            },
+          ],
+        },
+        agent: { name: 'SearchAgent' },
+      },
+      map,
+    );
+
+    expect(item).toBeInstanceOf(RunToolSearchOutputItem);
+    expect((item as RunToolSearchOutputItem).rawItem.tools).toEqual([
+      {
+        type: 'tool_reference',
+        functionName: 'lookup_account',
+        namespace: 'crm',
+      },
+    ]);
+  });
+
+  it('deserializeItem restores ToolSearchOutputItem with concrete tool payloads', () => {
+    const agent = new Agent({ name: 'SearchAgent' });
+    const map = new Map([[agent.name, agent]]);
+    const item = deserializeItem(
+      {
+        type: 'tool_search_output_item',
+        rawItem: {
+          type: 'tool_search_output',
+          id: 'ts_output',
+          status: 'completed',
+          tools: [
+            {
+              type: 'namespace',
+              name: 'crm',
+              description: 'CRM tools.',
+              tools: [
+                {
+                  type: 'function',
+                  name: 'lookup_account',
+                  description: 'Look up an account.',
+                  deferLoading: true,
+                  strict: true,
+                  parameters: {
+                    type: 'object',
+                    properties: {
+                      customerId: {
+                        type: 'string',
+                      },
+                    },
+                    required: ['customerId'],
+                    additionalProperties: false,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        agent: { name: 'SearchAgent' },
+      },
+      map,
+    );
+
+    expect(item).toBeInstanceOf(RunToolSearchOutputItem);
+    expect((item as RunToolSearchOutputItem).rawItem.tools).toEqual([
+      {
+        type: 'namespace',
+        name: 'crm',
+        description: 'CRM tools.',
+        tools: [
+          {
+            type: 'function',
+            name: 'lookup_account',
+            description: 'Look up an account.',
+            deferLoading: true,
+            strict: true,
+            parameters: {
+              type: 'object',
+              properties: {
+                customerId: {
+                  type: 'string',
+                },
+              },
+              required: ['customerId'],
+              additionalProperties: false,
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('deserializeProcessedResponse restores namespaced function tools', async () => {
+    const crmLookup = tool({
+      name: 'lookup_account',
+      description: 'Look up an account in CRM.',
+      parameters: z.object({
+        accountId: z.string(),
+      }),
+      execute: async () => 'crm',
+    });
+    const billingLookup = tool({
+      name: 'lookup_account',
+      description: 'Look up an account in billing.',
+      parameters: z.object({
+        accountId: z.string(),
+      }),
+      execute: async () => 'billing',
+    });
+    const crmNamespace = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools',
+      tools: [crmLookup],
+    });
+    const billingNamespace = toolNamespace({
+      name: 'billing',
+      description: 'Billing tools',
+      tools: [billingLookup],
+    });
+    const agent = new Agent({
+      name: 'NamespacedRestore',
+      tools: [...crmNamespace, ...billingNamespace],
+    });
+    const state = new RunState(new RunContext(), '', agent, 1);
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_restore',
+      callId: 'call_restore',
+      name: 'lookup_account',
+      namespace: 'billing',
+      status: 'completed',
+      arguments: '{"accountId":"acct_42"}',
+    };
+
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall: functionCall, tool: billingNamespace[0] as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['billing.lookup_account'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(restored._lastProcessedResponse?.functions[0]?.tool).toBe(
+      billingNamespace[0],
+    );
+    expect(restored._lastProcessedResponse?.functions[0]?.toolCall).toEqual(
+      functionCall,
+    );
+  });
+
+  it('deserializeProcessedResponse restores top-level deferred function tools', async () => {
+    const shippingEta = tool({
+      name: 'get_shipping_eta',
+      description: 'Look up a shipping ETA.',
+      parameters: z.object({
+        trackingNumber: z.string(),
+      }),
+      deferLoading: true,
+      execute: async () => 'tomorrow',
+    });
+    const agent = new Agent({
+      name: 'DeferredRestore',
+      tools: [shippingEta],
+    });
+    const state = new RunState(new RunContext(), '', agent, 1);
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_shipping_eta',
+      callId: 'call_shipping_eta',
+      name: 'get_shipping_eta',
+      namespace: 'get_shipping_eta',
+      status: 'completed',
+      arguments: '{"trackingNumber":"ZX-123"}',
+    };
+
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall: functionCall, tool: shippingEta as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['get_shipping_eta'],
+      hasToolsOrApprovalsToRun: () => true,
+    } as any;
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(restored._lastProcessedResponse?.functions[0]?.tool).toBe(
+      shippingEta,
+    );
+    expect(restored._lastProcessedResponse?.functions[0]?.toolCall).toEqual(
+      functionCall,
+    );
   });
 
   it('deserializeProcessedResponse restores computer actions', async () => {
@@ -1345,5 +1892,58 @@ describe('deserialize helpers', () => {
       state._lastProcessedResponse?.mcpApprovalRequests[0].requestItem.rawItem
         .providerData,
     );
+  });
+
+  it('rejects resumed function tools when isEnabled is false in replacement context', async () => {
+    const lookupAccountParams = z.object({
+      accountId: z.string(),
+    });
+    const crmLookup = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools',
+      tools: [
+        tool<typeof lookupAccountParams, { enabled: boolean }>({
+          name: 'lookup_account',
+          description: 'Look up an account.',
+          parameters: lookupAccountParams,
+          isEnabled: async ({ runContext }) => runContext.context.enabled,
+          execute: async () => 'crm',
+        }),
+      ],
+    })[0];
+    const agent = new Agent({
+      name: 'CRM',
+      tools: [crmLookup as any],
+    });
+    const state = new RunState(new RunContext({ enabled: true }), '', agent, 1);
+    const toolCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_lookup',
+      callId: 'call_lookup',
+      name: 'lookup_account',
+      namespace: 'crm',
+      status: 'completed',
+      arguments: '{"accountId":"acct_42"}',
+    };
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall, tool: crmLookup as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['crm.lookup_account'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+
+    await expect(
+      RunState.fromStringWithContext(
+        agent,
+        state.toString(),
+        new RunContext({ enabled: false }),
+        { contextStrategy: 'replace' },
+      ),
+    ).rejects.toThrow(/Tool .*lookup_account.* not found/);
   });
 });

--- a/packages/agents-core/test/runner/modelOutputs.test.ts
+++ b/packages/agents-core/test/runner/modelOutputs.test.ts
@@ -2,17 +2,36 @@ import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { setDefaultModelProvider, setTracingDisabled } from '../../src';
 import { Agent } from '../../src/agent';
-import { ModelBehaviorError } from '../../src/errors';
+import { ModelBehaviorError, UserError } from '../../src/errors';
 import { handoff } from '../../src/handoff';
 import {
   RunMessageOutputItem as MessageOutputItem,
   RunReasoningItem as ReasoningItem,
   RunToolCallItem as ToolCallItem,
   RunToolCallOutputItem as ToolCallOutputItem,
+  RunToolSearchCallItem as ToolSearchCallItem,
+  RunToolSearchOutputItem as ToolSearchOutputItem,
 } from '../../src/items';
 import { ModelResponse } from '../../src/model';
-import { processModelResponse } from '../../src/runner/modelOutputs';
-import { computerTool, applyPatchTool, shellTool } from '../../src/tool';
+import {
+  processModelResponse,
+  processModelResponseAsync,
+} from '../../src/runner/modelOutputs';
+import { RunContext } from '../../src/runContext';
+import { RunState } from '../../src/runState';
+import {
+  attachClientToolSearchExecutor,
+  computerTool,
+  applyPatchTool,
+  hostedMcpTool,
+  shellTool,
+  tool,
+  toolNamespace,
+} from '../../src/tool';
+import {
+  FUNCTION_TOOL_NAMESPACE,
+  FUNCTION_TOOL_NAMESPACE_DESCRIPTION,
+} from '../../src/toolIdentity';
 import { Usage } from '../../src/usage';
 import {
   FakeEditor,
@@ -25,11 +44,31 @@ import {
   TEST_TOOL,
 } from '../stubs';
 import * as protocol from '../../src/types/protocol';
+import { z } from 'zod';
 
 beforeAll(() => {
   setTracingDisabled(true);
   setDefaultModelProvider(new FakeModelProvider());
 });
+
+function createLegacyNamespacedTool<T extends Record<string, any>>(
+  tool: T,
+  namespace: string,
+  description: string,
+): T {
+  return Object.defineProperties(tool, {
+    [FUNCTION_TOOL_NAMESPACE]: {
+      value: namespace,
+      enumerable: false,
+      configurable: true,
+    },
+    [FUNCTION_TOOL_NAMESPACE_DESCRIPTION]: {
+      value: description,
+      enumerable: false,
+      configurable: true,
+    },
+  });
+}
 
 describe('processModelResponse', () => {
   it('processes message outputs and tool calls', () => {
@@ -57,6 +96,1439 @@ describe('processModelResponse', () => {
       TEST_MODEL_RESPONSE_WITH_FUNCTION.output[1],
     );
     expect(result.hasToolsOrApprovalsToRun()).toBe(true);
+  });
+
+  it('classifies tool search items as run items and records tool usage', () => {
+    const modelResponse: ModelResponse = {
+      output: [
+        {
+          type: 'tool_search_call',
+          id: 'ts_call',
+          status: 'completed',
+          arguments: {
+            paths: ['crm'],
+            query: 'profile',
+          },
+        },
+        {
+          type: 'tool_search_output',
+          id: 'ts_output',
+          status: 'completed',
+          tools: [
+            {
+              type: 'tool_reference',
+              functionName: 'lookup_account',
+              namespace: 'crm',
+            },
+          ],
+        },
+      ],
+      usage: new Usage(),
+    };
+
+    const result = processModelResponse(modelResponse, TEST_AGENT, [], []);
+
+    expect(result.newItems[0]).toBeInstanceOf(ToolSearchCallItem);
+    expect(result.newItems[1]).toBeInstanceOf(ToolSearchOutputItem);
+    expect(result.toolsUsed).toEqual(['tool_search']);
+    expect(result.hasToolsOrApprovalsToRun()).toBe(false);
+  });
+
+  it('auto-executes built-in client tool_search calls for deferred tools', () => {
+    const shippingEta = tool({
+      name: 'get_shipping_eta',
+      description: 'Look up a shipping ETA.',
+      parameters: z.object({
+        trackingNumber: z.string(),
+      }),
+      deferLoading: true,
+      execute: async () => 'tomorrow',
+    });
+    const shippingCredit = tool({
+      name: 'get_shipping_credit_balance',
+      description: 'Look up a shipping credit balance.',
+      parameters: z.object({
+        customerId: z.string(),
+      }),
+      deferLoading: true,
+      execute: async () => 125,
+    });
+    const modelResponse: ModelResponse = {
+      output: [
+        {
+          type: 'tool_search_call',
+          id: 'ts_call',
+          status: 'completed',
+          arguments: {
+            paths: ['get_shipping_eta', 'missing_tool', 'get_shipping_eta'],
+            query: 'shipping ETA',
+          },
+          providerData: {
+            call_id: 'call_ts_1',
+            execution: 'client',
+          },
+        },
+      ],
+      usage: new Usage(),
+    };
+
+    const result = processModelResponse(
+      modelResponse,
+      TEST_AGENT,
+      [shippingEta, shippingCredit],
+      [],
+    );
+
+    expect(result.newItems[0]).toBeInstanceOf(ToolSearchCallItem);
+    expect(result.newItems[1]).toBeInstanceOf(ToolSearchOutputItem);
+    expect((result.newItems[1] as ToolSearchOutputItem).rawItem).toMatchObject({
+      type: 'tool_search_output',
+      status: 'completed',
+      tools: [
+        {
+          type: 'function',
+          name: 'get_shipping_eta',
+          description: 'Look up a shipping ETA.',
+          deferLoading: true,
+        },
+      ],
+      providerData: {
+        call_id: 'call_ts_1',
+        execution: 'client',
+      },
+    });
+    expect(result.hasToolsOrApprovalsToRun()).toBe(true);
+  });
+
+  it('auto-executes built-in client tool_search calls for deferred namespaces', () => {
+    const crmTools = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup_account',
+          description: 'Look up an account.',
+          parameters: z.object({
+            customerId: z.string(),
+          }),
+          deferLoading: true,
+          execute: async () => 'account',
+        }),
+        tool({
+          name: 'list_recent_tickets',
+          description: 'List recent tickets.',
+          parameters: z.object({
+            customerId: z.string(),
+          }),
+          deferLoading: true,
+          execute: async () => ['ticket'],
+        }),
+        tool({
+          name: 'ping',
+          description: 'Immediate CRM ping.',
+          parameters: z.object({}),
+          execute: async () => 'pong',
+        }),
+      ],
+    });
+    const modelResponse: ModelResponse = {
+      output: [
+        {
+          type: 'tool_search_call',
+          id: 'ts_call',
+          status: 'completed',
+          arguments: {
+            paths: ['crm', 'missing_tool', 'crm'],
+            query: 'crm tools',
+          },
+          providerData: {
+            call_id: 'call_ts_namespace',
+            execution: 'client',
+          },
+        },
+      ],
+      usage: new Usage(),
+    };
+
+    const result = processModelResponse(
+      modelResponse,
+      TEST_AGENT,
+      crmTools,
+      [],
+    );
+
+    expect(result.newItems[0]).toBeInstanceOf(ToolSearchCallItem);
+    expect(result.newItems[1]).toBeInstanceOf(ToolSearchOutputItem);
+    expect((result.newItems[1] as ToolSearchOutputItem).rawItem).toMatchObject({
+      type: 'tool_search_output',
+      status: 'completed',
+      tools: [
+        {
+          type: 'namespace',
+          name: 'crm',
+          description: 'CRM tools.',
+          tools: [
+            {
+              type: 'function',
+              name: 'lookup_account',
+              description: 'Look up an account.',
+              deferLoading: true,
+            },
+            {
+              type: 'function',
+              name: 'list_recent_tickets',
+              description: 'List recent tickets.',
+              deferLoading: true,
+            },
+          ],
+        },
+      ],
+      providerData: {
+        call_id: 'call_ts_namespace',
+        execution: 'client',
+      },
+    });
+    expect(result.hasToolsOrApprovalsToRun()).toBe(true);
+  });
+
+  it('auto-executes built-in client tool_search calls for deferred namespace members', () => {
+    const crmTools = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup_account',
+          description: 'Look up an account.',
+          parameters: z.object({
+            customerId: z.string(),
+          }),
+          deferLoading: true,
+          execute: async () => 'account',
+        }),
+        tool({
+          name: 'list_recent_tickets',
+          description: 'List recent tickets.',
+          parameters: z.object({
+            customerId: z.string(),
+          }),
+          deferLoading: true,
+          execute: async () => ['ticket'],
+        }),
+      ],
+    });
+    const modelResponse: ModelResponse = {
+      output: [
+        {
+          type: 'tool_search_call',
+          id: 'ts_call',
+          status: 'completed',
+          arguments: {
+            paths: ['crm.lookup_account'],
+            query: 'account lookup',
+          },
+          providerData: {
+            call_id: 'call_ts_member',
+            execution: 'client',
+          },
+        },
+      ],
+      usage: new Usage(),
+    };
+
+    const result = processModelResponse(
+      modelResponse,
+      TEST_AGENT,
+      crmTools,
+      [],
+    );
+
+    expect((result.newItems[1] as ToolSearchOutputItem).rawItem).toMatchObject({
+      type: 'tool_search_output',
+      status: 'completed',
+      tools: [
+        {
+          type: 'namespace',
+          name: 'crm',
+          description: 'CRM tools.',
+          tools: [
+            {
+              type: 'function',
+              name: 'lookup_account',
+              description: 'Look up an account.',
+              deferLoading: true,
+            },
+          ],
+        },
+      ],
+      providerData: {
+        call_id: 'call_ts_member',
+        execution: 'client',
+      },
+    });
+    expect(result.hasToolsOrApprovalsToRun()).toBe(true);
+  });
+
+  it('coalesces multiple deferred namespace members into a single namespace output', () => {
+    const crmTools = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup_account',
+          description: 'Look up an account.',
+          parameters: z.object({
+            customerId: z.string(),
+          }),
+          deferLoading: true,
+          execute: async () => 'account',
+        }),
+        tool({
+          name: 'list_recent_tickets',
+          description: 'List recent tickets.',
+          parameters: z.object({
+            customerId: z.string(),
+          }),
+          deferLoading: true,
+          execute: async () => ['ticket'],
+        }),
+      ],
+    });
+    const modelResponse: ModelResponse = {
+      output: [
+        {
+          type: 'tool_search_call',
+          id: 'ts_call',
+          status: 'completed',
+          arguments: {
+            paths: [
+              'crm.lookup_account',
+              'crm.list_recent_tickets',
+              'crm.lookup_account',
+            ],
+          },
+          providerData: {
+            call_id: 'call_ts_member_batch',
+            execution: 'client',
+          },
+        },
+      ],
+      usage: new Usage(),
+    };
+
+    const result = processModelResponse(
+      modelResponse,
+      TEST_AGENT,
+      crmTools,
+      [],
+    );
+
+    expect((result.newItems[1] as ToolSearchOutputItem).rawItem).toMatchObject({
+      type: 'tool_search_output',
+      status: 'completed',
+      tools: [
+        {
+          type: 'namespace',
+          name: 'crm',
+          description: 'CRM tools.',
+          tools: [
+            {
+              type: 'function',
+              name: 'lookup_account',
+              description: 'Look up an account.',
+              deferLoading: true,
+            },
+            {
+              type: 'function',
+              name: 'list_recent_tickets',
+              description: 'List recent tickets.',
+              deferLoading: true,
+            },
+          ],
+        },
+      ],
+      providerData: {
+        call_id: 'call_ts_member_batch',
+        execution: 'client',
+      },
+    });
+  });
+
+  it('auto-executes built-in client tool_search calls for deferred hosted MCP servers', () => {
+    const shopify = hostedMcpTool({
+      serverLabel: 'shopify',
+      serverUrl: 'https://mcp.example.com/shopify',
+      serverDescription: 'Orders and customer records.',
+      deferLoading: true,
+      requireApproval: 'always',
+    });
+    const clientToolSearch = {
+      type: 'hosted_tool',
+      name: 'tool_search',
+      providerData: {
+        type: 'tool_search',
+        execution: 'client',
+      },
+    } as any;
+    const modelResponse: ModelResponse = {
+      output: [
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_mcp',
+          status: 'completed',
+          arguments: {
+            paths: ['shopify'],
+            query: 'shopify tools',
+          },
+          providerData: {
+            call_id: 'call_ts_mcp',
+            execution: 'client',
+          },
+        },
+      ],
+      usage: new Usage(),
+    };
+
+    const result = processModelResponse(
+      modelResponse,
+      TEST_AGENT,
+      [clientToolSearch, shopify],
+      [],
+    );
+
+    expect((result.newItems[1] as ToolSearchOutputItem).rawItem).toMatchObject({
+      type: 'tool_search_output',
+      status: 'completed',
+      tools: [
+        {
+          type: 'mcp',
+          server_label: 'shopify',
+          server_url: 'https://mcp.example.com/shopify',
+          server_description: 'Orders and customer records.',
+          defer_loading: true,
+          require_approval: 'always',
+        },
+      ],
+      providerData: {
+        call_id: 'call_ts_mcp',
+        execution: 'client',
+      },
+    });
+  });
+
+  it('preserves the original hosted MCP tool when prior search results match it', () => {
+    const onApproval = vi.fn(async () => ({ approve: true }));
+    const shopify = hostedMcpTool({
+      serverLabel: 'shopify',
+      serverUrl: 'https://mcp.example.com/shopify',
+      serverDescription: 'Orders and customer records.',
+      deferLoading: true,
+      requireApproval: 'always',
+      onApproval,
+    });
+    const priorItems = [
+      new ToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_shopify',
+          status: 'completed',
+          tools: [
+            {
+              type: 'mcp',
+              server_label: 'shopify',
+              server_url: 'https://mcp.example.com/shopify',
+              server_description: 'Orders and customer records.',
+              defer_loading: true,
+              require_approval: 'always',
+            },
+          ],
+        } as any,
+        TEST_AGENT,
+      ),
+    ];
+    const modelResponse: ModelResponse = {
+      output: [
+        {
+          type: 'hosted_tool_call',
+          id: 'approval-1',
+          name: 'mcp_approval_request',
+          status: 'completed',
+          providerData: {
+            type: 'mcp_approval_request',
+            server_label: 'shopify',
+            name: 'list_orders',
+            id: 'approval-1',
+            arguments: '{}',
+          },
+        } as any,
+      ],
+      usage: new Usage(),
+    };
+
+    const result = processModelResponse(
+      modelResponse,
+      TEST_AGENT,
+      [shopify],
+      [],
+      priorItems,
+    );
+
+    expect(result.mcpApprovalRequests).toHaveLength(1);
+    expect(result.mcpApprovalRequests[0].mcpTool).toBe(shopify);
+    expect(result.mcpApprovalRequests[0].mcpTool.providerData.on_approval).toBe(
+      onApproval,
+    );
+  });
+
+  it('rejects ambiguous built-in client tool_search paths that match both a deferred tool and a namespace', () => {
+    const topLevelCrm = tool({
+      name: 'crm',
+      description: 'Top-level CRM loader.',
+      parameters: z.object({}),
+      deferLoading: true,
+      execute: async () => 'top-level crm',
+    });
+    const crmTools = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup_account',
+          description: 'Look up an account.',
+          parameters: z.object({
+            customerId: z.string(),
+          }),
+          deferLoading: true,
+          execute: async () => 'account',
+        }),
+      ],
+    });
+    const modelResponse: ModelResponse = {
+      output: [
+        {
+          type: 'tool_search_call',
+          id: 'ts_call',
+          status: 'completed',
+          arguments: {
+            paths: ['crm'],
+            query: 'crm tools',
+          },
+          providerData: {
+            call_id: 'call_ts_namespace_ambiguous',
+            execution: 'client',
+          },
+        },
+      ],
+      usage: new Usage(),
+    };
+
+    expect(() =>
+      processModelResponse(
+        modelResponse,
+        TEST_AGENT,
+        [topLevelCrm, ...crmTools],
+        [],
+      ),
+    ).toThrow(/cannot disambiguate built-in client tool_search path "crm"/);
+  });
+
+  it('throws when asked to auto-execute custom client tool_search schemas', () => {
+    const modelResponse: ModelResponse = {
+      output: [
+        {
+          type: 'tool_search_call',
+          id: 'ts_call',
+          status: 'completed',
+          arguments: { namespaceHints: ['crm'] },
+          providerData: {
+            call_id: 'call_ts_1',
+            execution: 'client',
+          },
+        },
+      ],
+      usage: new Usage(),
+    };
+
+    expect(() =>
+      processModelResponse(modelResponse, TEST_AGENT, [], []),
+    ).toThrow(UserError);
+    expect(() =>
+      processModelResponse(modelResponse, TEST_AGENT, [], []),
+    ).toThrow(/only auto-execute built-in client tool_search calls/);
+  });
+
+  it('auto-executes custom client tool_search callbacks before later function calls in the same response', async () => {
+    const lookupAccount = tool({
+      name: 'lookup_account',
+      description: 'Look up an account.',
+      parameters: z.object({
+        accountId: z.string(),
+      }),
+      execute: async () => 'account',
+    });
+    const execute = vi.fn().mockResolvedValue(lookupAccount);
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: {
+          type: 'tool_search',
+          execution: 'client',
+          parameters: {
+            type: 'object',
+            properties: {
+              namespaceHints: {
+                type: 'array',
+                items: { type: 'string' },
+              },
+            },
+            required: ['namespaceHints'],
+            additionalProperties: false,
+          },
+        },
+      },
+      execute,
+    );
+    const toolSearchCall: protocol.ToolSearchCallItem = {
+      type: 'tool_search_call',
+      id: 'ts_call_lookup',
+      status: 'completed',
+      arguments: {
+        namespaceHints: ['crm'],
+      },
+      providerData: {
+        call_id: 'call_tool_search_lookup',
+        execution: 'client',
+      },
+    } as any;
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_lookup_account',
+      callId: 'call_lookup_account',
+      name: 'lookup_account',
+      status: 'completed',
+      arguments: '{"accountId":"acct_42"}',
+    };
+    const modelResponse: ModelResponse = {
+      output: [toolSearchCall, functionCall],
+      usage: new Usage(),
+    };
+    const agent = new Agent({
+      name: 'CustomClientToolSearchAgent',
+    });
+    const state = new RunState(new RunContext(), 'hello', agent, 3);
+
+    const result = await processModelResponseAsync(
+      modelResponse,
+      agent,
+      [clientToolSearch],
+      [],
+      state,
+      [],
+    );
+
+    expect(result.newItems.map((item) => item.type)).toEqual([
+      'tool_search_call_item',
+      'tool_search_output_item',
+      'tool_call_item',
+    ]);
+    expect(result.functions).toEqual([
+      {
+        toolCall: functionCall,
+        tool: lookupAccount,
+      },
+    ]);
+    expect((result.newItems[1] as ToolSearchOutputItem).rawItem).toMatchObject({
+      type: 'tool_search_output',
+      providerData: {
+        call_id: 'call_tool_search_lookup',
+        execution: 'client',
+      },
+      tools: [
+        {
+          type: 'function',
+          name: 'lookup_account',
+        },
+      ],
+    });
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(state.getToolSearchRuntimeTools(agent)).toEqual([lookupAccount]);
+  });
+
+  it('does not auto-execute tool_search calls that explicitly request server execution', () => {
+    const modelResponse: ModelResponse = {
+      output: [
+        {
+          type: 'tool_search_call',
+          id: 'ts_call',
+          execution: 'server',
+          status: 'completed',
+          arguments: { namespaceHints: ['crm'] },
+        } as any,
+      ],
+      usage: new Usage(),
+    };
+    const clientToolSearch = {
+      type: 'hosted_tool',
+      name: 'tool_search',
+      providerData: {
+        type: 'tool_search',
+        execution: 'client',
+      },
+    } as any;
+
+    expect(() =>
+      processModelResponse(modelResponse, TEST_AGENT, [clientToolSearch], []),
+    ).not.toThrow();
+
+    const result = processModelResponse(
+      modelResponse,
+      TEST_AGENT,
+      [clientToolSearch],
+      [],
+    );
+
+    expect(result.newItems).toHaveLength(1);
+    expect(result.newItems[0]).toBeInstanceOf(ToolSearchCallItem);
+    expect(result.hasToolsOrApprovalsToRun()).toBe(false);
+  });
+
+  it('does not let server tool_search outputs without call_id resolve pending client searches', () => {
+    const shippingEta = tool({
+      name: 'get_shipping_eta',
+      description: 'Look up a shipping ETA.',
+      parameters: z.object({
+        trackingNumber: z.string(),
+      }),
+      deferLoading: true,
+      execute: async () => 'tomorrow',
+    });
+    const modelResponse: ModelResponse = {
+      output: [
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_client',
+          status: 'completed',
+          arguments: {
+            paths: ['get_shipping_eta'],
+          },
+          providerData: {
+            execution: 'client',
+          },
+        },
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_server',
+          execution: 'server',
+          status: 'completed',
+          tools: [],
+        } as any,
+      ],
+      usage: new Usage(),
+    };
+
+    const result = processModelResponse(
+      modelResponse,
+      TEST_AGENT,
+      [shippingEta],
+      [],
+    );
+
+    expect(result.newItems).toHaveLength(3);
+    expect(result.newItems[0]).toBeInstanceOf(ToolSearchCallItem);
+    expect(result.newItems[1]).toBeInstanceOf(ToolSearchOutputItem);
+    expect(result.newItems[2]).toBeInstanceOf(ToolSearchOutputItem);
+    expect((result.newItems[1] as ToolSearchOutputItem).rawItem).toMatchObject({
+      type: 'tool_search_output',
+      providerData: {
+        execution: 'client',
+      },
+      tools: [
+        {
+          type: 'function',
+          name: 'get_shipping_eta',
+        },
+      ],
+    });
+    expect((result.newItems[2] as ToolSearchOutputItem).rawItem).toMatchObject({
+      type: 'tool_search_output',
+      execution: 'server',
+      tools: [],
+    });
+    expect(result.hasToolsOrApprovalsToRun()).toBe(true);
+  });
+
+  it('reads top-level execution and call_id on raw SDK tool_search items', () => {
+    const modelResponse: ModelResponse = {
+      output: [
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_a',
+          call_id: 'call_ts_a',
+          execution: 'client',
+          status: 'completed',
+          arguments: { namespaceHints: ['crm'] },
+        } as any,
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_b',
+          call_id: 'call_ts_b',
+          execution: 'client',
+          status: 'completed',
+          arguments: { namespaceHints: ['billing'] },
+        } as any,
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_b',
+          call_id: 'call_ts_b',
+          execution: 'client',
+          status: 'completed',
+          tools: [
+            {
+              type: 'tool_reference',
+              functionName: 'lookup_invoice',
+              namespace: 'billing',
+            },
+          ],
+        } as any,
+      ],
+      usage: new Usage(),
+    };
+
+    expect(() =>
+      processModelResponse(modelResponse, TEST_AGENT, [], []),
+    ).toThrow(/call_ts_a/);
+    expect(() =>
+      processModelResponse(modelResponse, TEST_AGENT, [], []),
+    ).not.toThrow(/call_ts_b/);
+  });
+
+  it('resolves completed client tool_search calls without explicit call_id', () => {
+    const modelResponse: ModelResponse = {
+      output: [
+        {
+          type: 'tool_search_call',
+          id: 'ts_call',
+          status: 'completed',
+          arguments: { namespaceHints: ['crm'] },
+          providerData: {
+            execution: 'client',
+          },
+        },
+        {
+          type: 'tool_search_output',
+          id: 'ts_output',
+          status: 'completed',
+          tools: [
+            {
+              type: 'tool_reference',
+              functionName: 'lookup_account',
+              namespace: 'crm',
+            },
+          ],
+        },
+      ],
+      usage: new Usage(),
+    };
+
+    expect(() =>
+      processModelResponse(modelResponse, TEST_AGENT, [], []),
+    ).not.toThrow();
+    const result = processModelResponse(modelResponse, TEST_AGENT, [], []);
+    expect(result.newItems[0]).toBeInstanceOf(ToolSearchCallItem);
+    expect(result.newItems[1]).toBeInstanceOf(ToolSearchOutputItem);
+  });
+
+  it('uses namespace-qualified names to resolve duplicate function tools', () => {
+    const crmLookup = tool({
+      name: 'lookup_account',
+      description: 'Look up an account in CRM.',
+      parameters: z.object({
+        accountId: z.string(),
+      }),
+      execute: async () => 'crm',
+    });
+    const billingLookup = tool({
+      name: 'lookup_account',
+      description: 'Look up an account in billing.',
+      parameters: z.object({
+        accountId: z.string(),
+      }),
+      execute: async () => 'billing',
+    });
+    const crmNamespace = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools',
+      tools: [crmLookup],
+    });
+    const billingNamespace = toolNamespace({
+      name: 'billing',
+      description: 'Billing tools',
+      tools: [billingLookup],
+    });
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_namespace',
+      callId: 'call_namespace',
+      name: 'lookup_account',
+      namespace: 'billing',
+      status: 'completed',
+      arguments: '{"accountId":"acct_42"}',
+    };
+    const modelResponse: ModelResponse = {
+      output: [functionCall],
+      usage: new Usage(),
+    };
+
+    const result = processModelResponse(
+      modelResponse,
+      TEST_AGENT,
+      [...crmNamespace, ...billingNamespace],
+      [],
+    );
+
+    expect(result.functions).toHaveLength(1);
+    expect(result.functions[0]).toEqual({
+      toolCall: functionCall,
+      tool: billingNamespace[0],
+    });
+    expect(result.toolsUsed).toEqual(['billing.lookup_account']);
+  });
+
+  it('rejects top-level deferred tool calls before tool_search loads them', () => {
+    const shippingEta = tool({
+      name: 'get_shipping_eta',
+      description: 'Look up a shipping ETA.',
+      parameters: z.object({
+        trackingNumber: z.string(),
+      }),
+      deferLoading: true,
+      execute: async () => 'tomorrow',
+    });
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_shipping_eta',
+      callId: 'call_shipping_eta',
+      name: 'get_shipping_eta',
+      namespace: 'get_shipping_eta',
+      status: 'completed',
+      arguments: '{"trackingNumber":"ZX-123"}',
+    };
+    const modelResponse: ModelResponse = {
+      output: [functionCall],
+      usage: new Usage(),
+    };
+
+    expect(() =>
+      processModelResponse(modelResponse, TEST_AGENT, [shippingEta], []),
+    ).toThrow(
+      /deferred function call get_shipping_eta before it was loaded via tool_search/,
+    );
+  });
+
+  it('falls back to the bare tool name for top-level deferred tool calls after tool_search loads them', () => {
+    const shippingEta = tool({
+      name: 'get_shipping_eta',
+      description: 'Look up a shipping ETA.',
+      parameters: z.object({
+        trackingNumber: z.string(),
+      }),
+      deferLoading: true,
+      execute: async () => 'tomorrow',
+    });
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_shipping_eta',
+      callId: 'call_shipping_eta',
+      name: 'get_shipping_eta',
+      namespace: 'get_shipping_eta',
+      status: 'completed',
+      arguments: '{"trackingNumber":"ZX-123"}',
+    };
+    const modelResponse: ModelResponse = {
+      output: [functionCall],
+      usage: new Usage(),
+    };
+    const priorItems = [
+      new ToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_shipping_eta',
+          status: 'completed',
+          tools: [
+            {
+              type: 'tool_reference',
+              functionName: 'get_shipping_eta',
+              namespace: 'get_shipping_eta',
+            },
+          ],
+        } as any,
+        TEST_AGENT,
+      ),
+    ];
+
+    const result = processModelResponse(
+      modelResponse,
+      TEST_AGENT,
+      [shippingEta],
+      [],
+      priorItems,
+    );
+
+    expect(result.functions).toHaveLength(1);
+    expect(result.functions[0]).toEqual({
+      toolCall: functionCall,
+      tool: shippingEta,
+    });
+    expect(result.toolsUsed).toEqual(['get_shipping_eta']);
+  });
+
+  it('does not treat tool_search outputs from other agents as loaded for the current agent', () => {
+    const otherAgent = new Agent({ name: 'OtherAgent' });
+    const shippingEta = tool({
+      name: 'get_shipping_eta',
+      description: 'Look up a shipping ETA.',
+      parameters: z.object({
+        trackingNumber: z.string(),
+      }),
+      deferLoading: true,
+      execute: async () => 'tomorrow',
+    });
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_shipping_eta',
+      callId: 'call_shipping_eta',
+      name: 'get_shipping_eta',
+      namespace: 'get_shipping_eta',
+      status: 'completed',
+      arguments: '{"trackingNumber":"ZX-123"}',
+    };
+    const modelResponse: ModelResponse = {
+      output: [functionCall],
+      usage: new Usage(),
+    };
+    const priorItems = [
+      new ToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_other_agent',
+          status: 'completed',
+          tools: [
+            {
+              type: 'tool_reference',
+              functionName: 'get_shipping_eta',
+              namespace: 'get_shipping_eta',
+            },
+          ],
+        } as any,
+        otherAgent,
+      ),
+    ];
+
+    expect(() =>
+      processModelResponse(
+        modelResponse,
+        TEST_AGENT,
+        [shippingEta],
+        [],
+        priorItems,
+      ),
+    ).toThrow(
+      /deferred function call get_shipping_eta before it was loaded via tool_search/,
+    );
+  });
+
+  it('treats later tool_search outputs with the same call_id as replacements for loaded deferred tools', () => {
+    const shippingEta = tool({
+      name: 'get_shipping_eta',
+      description: 'Look up a shipping ETA.',
+      parameters: z.object({
+        trackingNumber: z.string(),
+      }),
+      deferLoading: true,
+      execute: async () => 'tomorrow',
+    });
+    const shippingCredit = tool({
+      name: 'get_shipping_credit_balance',
+      description: 'Look up a shipping credit balance.',
+      parameters: z.object({
+        customerId: z.string(),
+      }),
+      deferLoading: true,
+      execute: async () => 125,
+    });
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_shipping_credit',
+      callId: 'call_shipping_credit',
+      name: 'get_shipping_credit_balance',
+      namespace: 'get_shipping_credit_balance',
+      status: 'completed',
+      arguments: '{"customerId":"cust_123"}',
+    };
+    const modelResponse: ModelResponse = {
+      output: [functionCall],
+      usage: new Usage(),
+    };
+    const priorItems = [
+      new ToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_shipping_full',
+          status: 'completed',
+          tools: [
+            {
+              type: 'tool_reference',
+              functionName: 'get_shipping_eta',
+              namespace: 'get_shipping_eta',
+            },
+            {
+              type: 'tool_reference',
+              functionName: 'get_shipping_credit_balance',
+              namespace: 'get_shipping_credit_balance',
+            },
+          ],
+          providerData: {
+            call_id: 'call_ts_shipping',
+          },
+        } as any,
+        TEST_AGENT,
+      ),
+      new ToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_shipping_eta_only',
+          status: 'completed',
+          tools: [
+            {
+              type: 'tool_reference',
+              functionName: 'get_shipping_eta',
+              namespace: 'get_shipping_eta',
+            },
+          ],
+          providerData: {
+            call_id: 'call_ts_shipping',
+          },
+        } as any,
+        TEST_AGENT,
+      ),
+    ];
+
+    expect(() =>
+      processModelResponse(
+        modelResponse,
+        TEST_AGENT,
+        [shippingEta, shippingCredit],
+        [],
+        priorItems,
+      ),
+    ).toThrow(
+      /deferred function call get_shipping_credit_balance before it was loaded via tool_search/,
+    );
+  });
+
+  it('auto-loads built-in client tool_search results before later deferred tool calls in the same response', () => {
+    const shippingEta = tool({
+      name: 'get_shipping_eta',
+      description: 'Look up a shipping ETA.',
+      parameters: z.object({
+        trackingNumber: z.string(),
+      }),
+      deferLoading: true,
+      execute: async () => 'tomorrow',
+    });
+    const toolSearchCall: protocol.ToolSearchCallItem = {
+      type: 'tool_search_call',
+      id: 'ts_call_shipping_eta',
+      status: 'completed',
+      arguments: {
+        paths: ['get_shipping_eta'],
+      },
+      providerData: {
+        execution: 'client',
+      },
+    } as any;
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_shipping_eta',
+      callId: 'call_shipping_eta',
+      name: 'get_shipping_eta',
+      status: 'completed',
+      arguments: '{"trackingNumber":"ZX-123"}',
+    };
+    const modelResponse: ModelResponse = {
+      output: [toolSearchCall, functionCall],
+      usage: new Usage(),
+    };
+    const clientToolSearch = {
+      type: 'hosted_tool',
+      name: 'tool_search',
+      providerData: {
+        type: 'tool_search',
+        execution: 'client',
+      },
+    } as any;
+
+    const result = processModelResponse(
+      modelResponse,
+      TEST_AGENT,
+      [clientToolSearch, shippingEta],
+      [],
+    );
+
+    expect(result.newItems.map((item) => item.type)).toEqual([
+      'tool_search_call_item',
+      'tool_search_output_item',
+      'tool_call_item',
+    ]);
+    expect(result.functions).toEqual([
+      {
+        toolCall: functionCall,
+        tool: shippingEta,
+      },
+    ]);
+  });
+
+  it('prefers namespaced function tools over bare-name handoffs', () => {
+    const target = new Agent({ name: 'EscalationTarget' });
+    const h = handoff(target, {
+      toolNameOverride: 'lookup_account',
+    });
+    const crmLookup = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools',
+      tools: [
+        tool({
+          name: 'lookup_account',
+          description: 'Look up an account in CRM.',
+          parameters: z.object({
+            accountId: z.string(),
+          }),
+          execute: async () => 'crm',
+        }),
+      ],
+    })[0];
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_crm_lookup',
+      callId: 'call_crm_lookup',
+      name: 'lookup_account',
+      namespace: 'crm',
+      status: 'completed',
+      arguments: '{"accountId":"acct_42"}',
+    };
+    const modelResponse: ModelResponse = {
+      output: [functionCall],
+      usage: new Usage(),
+    };
+
+    const result = processModelResponse(
+      modelResponse,
+      TEST_AGENT,
+      [crmLookup],
+      [h],
+    );
+
+    expect(result.functions).toEqual([
+      {
+        toolCall: {
+          ...functionCall,
+          name: 'lookup_account',
+          namespace: 'crm',
+        },
+        tool: crmLookup,
+      },
+    ]);
+    expect(result.handoffs).toEqual([]);
+    expect(result.toolsUsed).toEqual(['crm.lookup_account']);
+  });
+
+  it('prefers real same-name namespaces over bare top-level tools', () => {
+    const topLevelLookup = tool({
+      name: 'lookup_account',
+      description: 'Look up a top-level account.',
+      parameters: z.object({
+        accountId: z.string(),
+      }),
+      execute: async () => 'top-level',
+    });
+    const namespacedLookup = createLegacyNamespacedTool(
+      tool({
+        name: 'lookup_account',
+        description: 'Look up an account in a matching namespace.',
+        parameters: z.object({
+          accountId: z.string(),
+        }),
+        deferLoading: true,
+        execute: async () => 'namespaced',
+      }),
+      'lookup_account',
+      'Nested lookup tools',
+    );
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_same_name_namespace',
+      callId: 'call_same_name_namespace',
+      name: 'lookup_account',
+      namespace: 'lookup_account',
+      status: 'completed',
+      arguments: '{"accountId":"acct_42"}',
+    };
+    const modelResponse: ModelResponse = {
+      output: [functionCall],
+      usage: new Usage(),
+    };
+    const priorItems = [
+      new ToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_same_name_namespace',
+          status: 'completed',
+          tools: [
+            {
+              type: 'tool_reference',
+              functionName: 'lookup_account',
+              namespace: 'lookup_account',
+            },
+          ],
+        } as any,
+        TEST_AGENT,
+      ),
+    ];
+
+    const result = processModelResponse(
+      modelResponse,
+      TEST_AGENT,
+      [topLevelLookup, namespacedLookup],
+      [],
+      priorItems,
+    );
+
+    expect(result.functions).toEqual([
+      {
+        toolCall: functionCall,
+        tool: namespacedLookup,
+      },
+    ]);
+    expect(result.toolsUsed).toEqual(['lookup_account.lookup_account']);
+  });
+
+  it('rejects ambiguous dotted handoff overrides that clash with namespace tools', () => {
+    const target = new Agent({ name: 'EscalationTarget' });
+    const h = handoff(target, {
+      toolNameOverride: 'crm.lookup_account',
+    });
+    const crmLookup = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools',
+      tools: [
+        tool({
+          name: 'lookup_account',
+          description: 'Look up an account in CRM.',
+          parameters: z.object({
+            accountId: z.string(),
+          }),
+          execute: async () => 'crm',
+        }),
+      ],
+    })[0];
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_crm_lookup',
+      callId: 'call_crm_lookup',
+      name: 'crm.lookup_account',
+      status: 'completed',
+      arguments: '{"accountId":"acct_42"}',
+    };
+    const modelResponse: ModelResponse = {
+      output: [functionCall],
+      usage: new Usage(),
+    };
+
+    expect(() =>
+      processModelResponse(modelResponse, TEST_AGENT, [crmLookup], [h]),
+    ).toThrow(
+      /Ambiguous dotted tool call crm\.lookup_account in agent TestAgent: it matches both a namespaced function tool and a handoff/,
+    );
+  });
+
+  it('still resolves dotted handoff overrides when no matching function tool exists', () => {
+    const target = new Agent({ name: 'EscalationTarget' });
+    const h = handoff(target, {
+      toolNameOverride: 'crm.lookup_account',
+    });
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_crm_lookup',
+      callId: 'call_crm_lookup',
+      name: 'crm.lookup_account',
+      status: 'completed',
+      arguments: '{"accountId":"acct_42"}',
+    };
+    const modelResponse: ModelResponse = {
+      output: [functionCall],
+      usage: new Usage(),
+    };
+
+    const result = processModelResponse(modelResponse, TEST_AGENT, [], [h]);
+
+    expect(result.functions).toEqual([]);
+    expect(result.handoffs).toEqual([
+      {
+        toolCall: functionCall,
+        handoff: h,
+      },
+    ]);
+    expect(result.toolsUsed).toEqual(['crm.lookup_account']);
+  });
+
+  it('still resolves explicit namespace function calls when a dotted handoff override shares the qualified name', () => {
+    const target = new Agent({ name: 'EscalationTarget' });
+    const h = handoff(target, {
+      toolNameOverride: 'crm.lookup_account',
+    });
+    const crmLookup = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools',
+      tools: [
+        tool({
+          name: 'lookup_account',
+          description: 'Look up an account in CRM.',
+          parameters: z.object({
+            accountId: z.string(),
+          }),
+          execute: async () => 'crm',
+        }),
+      ],
+    })[0];
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_crm_lookup_explicit_namespace',
+      callId: 'call_crm_lookup_explicit_namespace',
+      name: 'lookup_account',
+      namespace: 'crm',
+      status: 'completed',
+      arguments: '{"accountId":"acct_42"}',
+    };
+    const modelResponse: ModelResponse = {
+      output: [functionCall],
+      usage: new Usage(),
+    };
+
+    const result = processModelResponse(
+      modelResponse,
+      TEST_AGENT,
+      [crmLookup],
+      [h],
+    );
+
+    expect(result.functions).toEqual([
+      {
+        toolCall: functionCall,
+        tool: crmLookup,
+      },
+    ]);
+    expect(result.handoffs).toEqual([]);
+    expect(result.toolsUsed).toEqual(['crm.lookup_account']);
   });
 
   it('queues shell actions when shell tool registered', () => {
@@ -433,6 +1905,49 @@ describe('processModelResponse', () => {
     expect(() =>
       processModelResponse(response, TEST_AGENT, [TEST_TOOL], []),
     ).toThrow(ModelBehaviorError);
+  });
+
+  it('resolves hosted MCP approval requests from tool_search-loaded servers', () => {
+    const toolSearchOutput: protocol.ToolSearchOutputItem = {
+      type: 'tool_search_output',
+      id: 'ts_output_shopify',
+      status: 'completed',
+      tools: [
+        {
+          type: 'mcp',
+          server_label: 'shopify',
+          server_url: 'https://mcp.example.com/shopify',
+          require_approval: 'always',
+        },
+      ],
+    } as any;
+    const hostedCall: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      name: 'mcp_approval_request',
+      id: 'mcpr_shopify',
+      status: 'in_progress',
+      providerData: {
+        type: 'mcp_approval_request',
+        server_label: 'shopify',
+        name: 'mcp_approval_request',
+        id: 'mcpr_shopify',
+        arguments: {},
+      },
+    };
+    const response: ModelResponse = {
+      output: [toolSearchOutput, hostedCall],
+      usage: new Usage(),
+    };
+
+    const result = processModelResponse(response, TEST_AGENT, [], []);
+
+    expect(result.mcpApprovalRequests).toHaveLength(1);
+    expect(result.mcpApprovalRequests[0].mcpTool.providerData).toMatchObject({
+      type: 'mcp',
+      server_label: 'shopify',
+      server_url: 'https://mcp.example.com/shopify',
+      require_approval: 'always',
+    });
   });
 
   it('captures reasoning items', () => {

--- a/packages/agents-core/test/runner/sessionPersistence.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.test.ts
@@ -12,6 +12,8 @@ import {
   RunToolApprovalItem as ToolApprovalItem,
   RunToolCallItem as ToolCallItem,
   RunToolCallOutputItem as ToolCallOutputItem,
+  RunToolSearchCallItem as ToolSearchCallItem,
+  RunToolSearchOutputItem as ToolSearchOutputItem,
 } from '../../src/items';
 import { ModelResponse } from '../../src/model';
 import {
@@ -729,6 +731,156 @@ describe('saveToSession', () => {
       this.items = [];
     }
   }
+
+  it('keeps tool_search ids when persisting session history without call ids', async () => {
+    const agent = new Agent<UnknownContext, 'text'>({
+      name: 'ToolSearchSessionAgent',
+      outputType: 'text',
+      instructions: 'test',
+    });
+    const session = new MemorySession();
+    const state = new RunState(new RunContext(), 'hello', agent as any, 10);
+
+    state._generatedItems = [
+      new ToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call',
+          status: 'completed',
+          arguments: {
+            query: 'shipping eta',
+            paths: ['shipping'],
+          },
+        },
+        agent,
+      ),
+      new ToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output',
+          call_id: null,
+          status: 'completed',
+          tools: [
+            {
+              type: 'tool_reference',
+              functionName: 'get_shipping_eta',
+            },
+          ],
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    ];
+
+    await saveToSession(
+      session,
+      toAgentInputList(state._originalInput),
+      new RunResult(state),
+    );
+
+    expect(session.items).toEqual([
+      {
+        type: 'message',
+        role: 'user',
+        content: 'hello',
+      },
+      {
+        type: 'tool_search_call',
+        id: 'ts_call',
+        status: 'completed',
+        arguments: {
+          query: 'shipping eta',
+          paths: ['shipping'],
+        },
+      },
+      {
+        type: 'tool_search_output',
+        call_id: null,
+        id: 'ts_output',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'get_shipping_eta',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('strips tool_search ids when persisting session history with call ids', async () => {
+    const agent = new Agent<UnknownContext, 'text'>({
+      name: 'ToolSearchSessionAgent',
+      outputType: 'text',
+      instructions: 'test',
+    });
+    const session = new MemorySession();
+    const state = new RunState(new RunContext(), 'hello', agent as any, 10);
+
+    state._generatedItems = [
+      new ToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call',
+          call_id: 'tool_search_call_1',
+          status: 'completed',
+          arguments: {
+            query: 'shipping eta',
+            paths: ['shipping'],
+          },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new ToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output',
+          call_id: 'tool_search_call_1',
+          status: 'completed',
+          tools: [
+            {
+              type: 'tool_reference',
+              functionName: 'get_shipping_eta',
+            },
+          ],
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    ];
+
+    await saveToSession(
+      session,
+      toAgentInputList(state._originalInput),
+      new RunResult(state),
+    );
+
+    expect(session.items).toEqual([
+      {
+        type: 'message',
+        role: 'user',
+        content: 'hello',
+      },
+      {
+        type: 'tool_search_call',
+        call_id: 'tool_search_call_1',
+        status: 'completed',
+        arguments: {
+          query: 'shipping eta',
+          paths: ['shipping'],
+        },
+      },
+      {
+        type: 'tool_search_output',
+        call_id: 'tool_search_call_1',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'get_shipping_eta',
+          },
+        ],
+      },
+    ]);
+  });
 
   it('persists tool outputs when resuming a turn after approvals', async () => {
     const textAgent = new Agent<UnknownContext, 'text'>({

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -18,6 +18,8 @@ import {
   RunToolApprovalItem as ToolApprovalItem,
   RunToolCallItem as ToolCallItem,
   RunToolCallOutputItem as ToolCallOutputItem,
+  RunToolSearchCallItem as ToolSearchCallItem,
+  RunToolSearchOutputItem as ToolSearchOutputItem,
 } from '../../src/items';
 import {
   addStepToRunResult,
@@ -58,6 +60,7 @@ import {
   computerTool,
   shellTool,
   tool,
+  toolNamespace,
 } from '../../src/tool';
 import {
   TEST_AGENT,
@@ -159,6 +162,28 @@ describe('getToolCallOutputItem', () => {
     expect(output).toEqual({
       type: 'function_call_result',
       name: TEST_MODEL_FUNCTION_CALL.name,
+      callId: TEST_MODEL_FUNCTION_CALL.callId,
+      status: 'completed',
+      output: {
+        type: 'text',
+        text: 'hi',
+      },
+    });
+  });
+
+  it('preserves namespace on function_call_result items', () => {
+    const output = getToolCallOutputItem(
+      {
+        ...TEST_MODEL_FUNCTION_CALL,
+        namespace: 'crm',
+      },
+      'hi',
+    );
+
+    expect(output).toEqual({
+      type: 'function_call_result',
+      name: TEST_MODEL_FUNCTION_CALL.name,
+      namespace: 'crm',
       callId: TEST_MODEL_FUNCTION_CALL.callId,
       status: 'completed',
       output: {
@@ -355,6 +380,76 @@ describe('checkForFinalOutputFromTools', () => {
     expect(res.isFinalOutput).toBe(false);
   });
 
+  it('matches stopAtToolNames against namespaced tool identities', async () => {
+    const [crmLookup] = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools',
+      tools: [
+        tool({
+          name: 'lookup_account',
+          description: 'Look up an account in CRM.',
+          parameters: z.object({
+            accountId: z.string(),
+          }),
+          execute: async () => 'crm result',
+        }),
+      ],
+    });
+    const agent = new Agent({
+      name: 'NamespacedStop',
+      toolUseBehavior: { stopAtToolNames: ['crm.lookup_account'] },
+    });
+    const toolResult: FunctionToolResult = {
+      type: 'function_output',
+      tool: crmLookup,
+      output: 'crm result',
+      runItem: {} as any,
+    };
+
+    const res = await checkForFinalOutputFromTools(agent, [toolResult], state);
+
+    expect(res).toEqual({
+      isFinalOutput: true,
+      isInterrupted: undefined,
+      finalOutput: 'crm result',
+    });
+  });
+
+  it('matches namespaced tools by bare stopAtToolNames entries', async () => {
+    const [crmLookup] = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools',
+      tools: [
+        tool({
+          name: 'lookup_account',
+          description: 'Look up an account in CRM.',
+          parameters: z.object({
+            accountId: z.string(),
+          }),
+          execute: async () => 'crm result',
+        }),
+      ],
+    });
+    const agent = new Agent({
+      name: 'NamespacedStopNoMatch',
+      toolUseBehavior: { stopAtToolNames: ['lookup_account'] },
+    });
+    const toolResult: FunctionToolResult = {
+      type: 'function_output',
+      tool: crmLookup,
+      output: 'crm result',
+      runItem: {} as any,
+    };
+
+    const res = await checkForFinalOutputFromTools(agent, [toolResult], state);
+
+    expect(res).toEqual({
+      isFinalOutput: true,
+      isInterrupted: undefined,
+      finalOutput: 'crm result',
+    });
+  });
+
   it('Function based toolUseBehavior delegates decision', async () => {
     const agent = new Agent({
       name: 'Func',
@@ -396,6 +491,33 @@ describe('addStepToRunResult', () => {
       agent,
     );
     const toolCallItem = new ToolCallItem(TEST_MODEL_FUNCTION_CALL, agent);
+    const toolSearchCallItem = new ToolSearchCallItem(
+      {
+        type: 'tool_search_call',
+        id: 'ts_call',
+        status: 'completed',
+        arguments: {
+          paths: ['crm'],
+          query: 'profile',
+        },
+      },
+      agent,
+    );
+    const toolSearchOutputItem = new ToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        id: 'ts_output',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_account',
+            namespace: 'crm',
+          },
+        ],
+      },
+      agent,
+    );
     const toolOutputItem = new ToolCallOutputItem(
       getToolCallOutputItem(TEST_MODEL_FUNCTION_CALL, 'hi'),
       agent,
@@ -416,6 +538,8 @@ describe('addStepToRunResult', () => {
         messageItem,
         handoffCallItem,
         handoffOutputItem,
+        toolSearchCallItem,
+        toolSearchOutputItem,
         toolCallItem,
         toolOutputItem,
         reasoningItem,
@@ -435,6 +559,8 @@ describe('addStepToRunResult', () => {
       'message_output_created',
       'handoff_requested',
       'handoff_occurred',
+      'tool_search_called',
+      'tool_search_output_created',
       'tool_called',
       'tool_output',
       'reasoning_item_created',
@@ -1977,6 +2103,98 @@ describe('executeShellActions', () => {
         setTraceProcessors([defaultProcessor()]);
         setTracingDisabled(true);
       }
+    });
+
+    it('uses the bare tool name for top-level deferred tool trace spans', async () => {
+      const t = tool({
+        name: 'get_shipping_eta',
+        description: 'Look up a shipping ETA.',
+        parameters: z.object({
+          tracking_number: z.string(),
+        }),
+        deferLoading: true,
+        needsApproval: true,
+        execute: vi.fn(async () => 'Tomorrow'),
+      }) as unknown as FunctionTool;
+      const deferredToolCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        id: 'fc_shipping_eta',
+        callId: 'call_shipping_eta',
+        name: 'get_shipping_eta',
+        namespace: 'get_shipping_eta',
+        status: 'completed',
+        arguments: '{"tracking_number":"ZX-123"}',
+      };
+      const approvalSpy = vi
+        .spyOn(state._context, 'isToolApproved')
+        .mockReturnValue(false as any);
+      const customRunner = new Runner({ tracingDisabled: false });
+
+      await withRecordingTrace(async (processor) => {
+        const res = await withTrace('test', () =>
+          executeFunctionToolCalls(
+            state._currentAgent,
+            [{ toolCall: deferredToolCall, tool: t }],
+            customRunner,
+            state,
+          ),
+        );
+
+        expect(res[0].type).toBe('function_output');
+        expect(approvalSpy).toHaveBeenCalledWith({
+          toolName: 'get_shipping_eta',
+          callId: 'call_shipping_eta',
+        });
+        getEndedFunctionSpan(processor, 'get_shipping_eta');
+        expect(
+          processor.spansEnded.some(
+            (span) =>
+              span.spanData.type === 'function' &&
+              span.spanData.name === 'get_shipping_eta.get_shipping_eta',
+          ),
+        ).toBe(false);
+      });
+    });
+
+    it('keeps explicit namespaces in function trace span names', async () => {
+      const [crmLookup] = toolNamespace({
+        name: 'crm',
+        description: 'CRM tools',
+        tools: [
+          tool({
+            name: 'lookup_account',
+            description: 'Look up an account in CRM.',
+            parameters: z.object({
+              accountId: z.string(),
+            }),
+            execute: vi.fn(async () => 'crm'),
+          }),
+        ],
+      }) as unknown as FunctionTool[];
+      const namespacedToolCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        id: 'fc_lookup_account',
+        callId: 'call_lookup_account',
+        name: 'lookup_account',
+        namespace: 'crm',
+        status: 'completed',
+        arguments: '{"accountId":"acct_42"}',
+      };
+      const customRunner = new Runner({ tracingDisabled: false });
+
+      await withRecordingTrace(async (processor) => {
+        const res = await withTrace('test', () =>
+          executeFunctionToolCalls(
+            state._currentAgent,
+            [{ toolCall: namespacedToolCall, tool: crmLookup }],
+            customRunner,
+            state,
+          ),
+        );
+
+        expect(res[0].type).toBe('function_output');
+        getEndedFunctionSpan(processor, 'crm.lookup_account');
+      });
     });
 
     it('falls back to default rejection message when toolErrorFormatter throws', async () => {

--- a/packages/agents-core/test/tool.test.ts
+++ b/packages/agents-core/test/tool.test.ts
@@ -6,6 +6,7 @@ import {
   invokeFunctionTool,
   shellTool,
   tool,
+  toolNamespace,
   resolveComputer,
   disposeResolvedComputers,
 } from '../src/tool';
@@ -14,6 +15,7 @@ import { z } from 'zod';
 import { Computer } from '../src';
 import { Agent } from '../src/agent';
 import { RunContext } from '../src/runContext';
+import { serializeTool } from '../src/utils/serialize';
 import { FakeEditor, FakeShell } from './stubs';
 import { ToolTimeoutError } from '../src/errors';
 
@@ -36,6 +38,161 @@ describe('Tool', () => {
     });
     expect(Object.keys(t.parameters.properties).length).toEqual(1);
     expect(t.parameters.required.length).toEqual(1);
+  });
+
+  it('records deferLoading when requested', () => {
+    const t = tool({
+      name: 'deferred_lookup',
+      description: 'Deferred lookup tool.',
+      parameters: z.object({
+        foo: z.string(),
+      }),
+      deferLoading: true,
+      execute: async () => ({ bar: 'ok' }),
+    });
+
+    expect(t.deferLoading).toBe(true);
+  });
+
+  it('toolNamespace returns shallow-cloned function tools', () => {
+    const t = tool({
+      name: 'lookup_account',
+      description: 'Look up an account.',
+      parameters: z.object({
+        foo: z.string(),
+      }),
+      execute: async () => ({ bar: 'ok' }),
+    });
+
+    const [namespacedTool] = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools',
+      tools: [t],
+    });
+
+    expect(namespacedTool).not.toBe(t);
+    expect(namespacedTool.name).toBe(t.name);
+    expect(namespacedTool.description).toBe(t.description);
+    expect(namespacedTool.invoke).toBe(t.invoke);
+  });
+
+  it('toolNamespace supports immediate-loading function tools', () => {
+    const immediate = tool({
+      name: 'lookup_account',
+      description: 'Look up an account.',
+      parameters: z.object({
+        foo: z.string(),
+      }),
+      execute: async () => ({ bar: 'ok' }),
+    });
+
+    const namespacedTools = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools',
+      tools: [immediate],
+    });
+
+    expect(namespacedTools).toHaveLength(1);
+    for (const namespacedTool of namespacedTools) {
+      expect(serializeTool(namespacedTool)).toMatchObject({
+        namespace: 'crm',
+        namespaceDescription: 'CRM tools',
+      });
+    }
+  });
+
+  it('toolNamespace supports deferred-loading function tools', () => {
+    const deferred = tool({
+      name: 'list_recent_tickets',
+      description: 'List recent tickets.',
+      parameters: z.object({
+        foo: z.string(),
+      }),
+      deferLoading: true,
+      execute: async () => ({ bar: 'ok' }),
+    });
+
+    const [namespacedTool] = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools',
+      tools: [deferred],
+    });
+
+    expect(serializeTool(namespacedTool)).toMatchObject({
+      namespace: 'crm',
+      namespaceDescription: 'CRM tools',
+      deferLoading: true,
+    });
+  });
+
+  it('toolNamespace requires a namespace config object', () => {
+    expect(() => toolNamespace(undefined as any)).toThrow(
+      'toolNamespace() requires a namespace config object.',
+    );
+  });
+
+  it('toolNamespace requires a non-empty description', () => {
+    const t = tool({
+      name: 'lookup_account',
+      description: 'Look up an account.',
+      parameters: z.object({
+        foo: z.string(),
+      }),
+      execute: async () => ({ bar: 'ok' }),
+    });
+
+    expect(() =>
+      toolNamespace({
+        name: 'crm',
+        description: '',
+        tools: [t],
+      }),
+    ).toThrow(
+      'toolNamespace() requires a non-empty description because the Responses API requires namespace descriptions.',
+    );
+  });
+
+  it('toolNamespace normalizes namespace names to tool-safe identifiers', () => {
+    const t = tool({
+      name: 'lookup_account',
+      description: 'Look up an account.',
+      parameters: z.object({
+        foo: z.string(),
+      }),
+      execute: async () => ({ bar: 'ok' }),
+    });
+
+    const [namespacedTool] = toolNamespace({
+      name: 'CRM tools',
+      description: 'CRM tools',
+      tools: [t],
+    });
+
+    expect(serializeTool(namespacedTool)).toMatchObject({
+      namespace: 'CRM_tools',
+      namespaceDescription: 'CRM tools',
+    });
+  });
+
+  it('toolNamespace rejects members whose name matches the namespace', () => {
+    const t = tool({
+      name: 'lookup_account',
+      description: 'Look up an account.',
+      parameters: z.object({
+        foo: z.string(),
+      }),
+      execute: async () => ({ bar: 'ok' }),
+    });
+
+    expect(() =>
+      toolNamespace({
+        name: 'lookup_account',
+        description: 'Lookup account tools',
+        tools: [t],
+      }),
+    ).toThrow(
+      'toolNamespace() does not allow a tool named "lookup_account" inside namespace "lookup_account" because Responses self-namespaced calls would be ambiguous.',
+    );
   });
 
   it('computerTool', () => {
@@ -410,6 +567,19 @@ describe('create a tool using hostedMcpTool utility', () => {
     });
 
     expect(t.providerData.authorization).toBe('secret-token');
+  });
+
+  it('propagates tool_search metadata for hosted MCP servers', () => {
+    const t = hostedMcpTool({
+      serverLabel: 'gitmcp',
+      serverUrl: 'https://gitmcp.io/openai/codex',
+      serverDescription: 'Repository operations',
+      deferLoading: true,
+      requireApproval: 'never',
+    });
+
+    expect(t.providerData.server_description).toBe('Repository operations');
+    expect(t.providerData.defer_loading).toBe(true);
   });
 });
 

--- a/packages/agents-core/test/toolIdentity.test.ts
+++ b/packages/agents-core/test/toolIdentity.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FUNCTION_TOOL_NAMESPACE,
+  resolveFunctionToolCallName,
+} from '../src/toolIdentity';
+
+function createToolLookup(
+  tools: Array<{ key: string; value?: Record<string, any> }>,
+): Map<string, Record<string, any>> {
+  return new Map(tools.map(({ key, value }) => [key, value ?? { name: key }]));
+}
+
+describe('resolveFunctionToolCallName', () => {
+  it('prefers the bare name for self-namespaced top-level deferred calls', () => {
+    const availableToolNames = createToolLookup([
+      {
+        key: 'lookup_account',
+        value: {
+          type: 'function',
+          name: 'lookup_account',
+          deferLoading: true,
+        },
+      },
+    ]);
+
+    expect(
+      resolveFunctionToolCallName(
+        {
+          name: 'lookup_account',
+          namespace: 'lookup_account',
+        },
+        availableToolNames,
+      ),
+    ).toBe('lookup_account');
+  });
+
+  it('falls back to the qualified name when a self-namespaced bare tool is absent', () => {
+    const availableToolNames = new Set(['lookup_account.lookup_account']);
+
+    expect(
+      resolveFunctionToolCallName(
+        {
+          name: 'lookup_account',
+          namespace: 'lookup_account',
+        },
+        availableToolNames,
+      ),
+    ).toBe('lookup_account.lookup_account');
+  });
+
+  it('prefers the bare name when both self-namespaced candidates are present', () => {
+    const availableToolNames = createToolLookup([
+      {
+        key: 'lookup_account',
+        value: {
+          type: 'function',
+          name: 'lookup_account',
+          deferLoading: true,
+        },
+      },
+      {
+        key: 'lookup_account.lookup_account',
+        value: {
+          type: 'function',
+          name: 'lookup_account',
+          deferLoading: true,
+          [FUNCTION_TOOL_NAMESPACE]: 'lookup_account',
+        },
+      },
+    ]);
+
+    expect(
+      resolveFunctionToolCallName(
+        {
+          name: 'lookup_account',
+          namespace: 'lookup_account',
+        },
+        availableToolNames,
+      ),
+    ).toBe('lookup_account');
+  });
+
+  it('prefers the qualified name when the bare tool is not deferred', () => {
+    const availableToolNames = createToolLookup([
+      {
+        key: 'lookup_account',
+        value: {
+          type: 'function',
+          name: 'lookup_account',
+          deferLoading: false,
+        },
+      },
+      {
+        key: 'lookup_account.lookup_account',
+        value: {
+          type: 'function',
+          name: 'lookup_account',
+          deferLoading: true,
+          [FUNCTION_TOOL_NAMESPACE]: 'lookup_account',
+        },
+      },
+    ]);
+
+    expect(
+      resolveFunctionToolCallName(
+        {
+          name: 'lookup_account',
+          namespace: 'lookup_account',
+        },
+        availableToolNames,
+      ),
+    ).toBe('lookup_account.lookup_account');
+  });
+
+  it('keeps qualified matches for real namespace calls', () => {
+    const availableToolNames = new Set([
+      'lookup_account',
+      'crm.lookup_account',
+    ]);
+
+    expect(
+      resolveFunctionToolCallName(
+        {
+          name: 'lookup_account',
+          namespace: 'crm',
+        },
+        availableToolNames,
+      ),
+    ).toBe('crm.lookup_account');
+  });
+});

--- a/packages/agents-core/test/utils/serialize.test.ts
+++ b/packages/agents-core/test/utils/serialize.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { serializeTool, serializeHandoff } from '../../src/utils/serialize';
+import { tool, toolNamespace } from '../../src/tool';
+import { z } from 'zod';
 
 describe('serialize utilities', () => {
   it('serializes function tools', () => {
@@ -82,6 +84,49 @@ describe('serialize utilities', () => {
       type: 'hosted_tool',
       name: 'bt',
       providerData: { a: 1 },
+    });
+  });
+
+  it('serializes deferred and namespaced function tools', () => {
+    const deferredLookup = tool({
+      name: 'lookup_account',
+      description: 'Look up an account.',
+      parameters: z.object({
+        accountId: z.string(),
+      }),
+      deferLoading: true,
+      execute: async () => 'ok',
+    });
+    const namespacedLookup = tool({
+      name: 'lookup_account',
+      description: 'Look up an account.',
+      parameters: z.object({
+        accountId: z.string(),
+      }),
+      deferLoading: true,
+      execute: async () => 'ok',
+    });
+    const [crmLookup] = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools',
+      tools: [namespacedLookup],
+    });
+
+    expect(serializeTool(deferredLookup)).toMatchObject({
+      type: 'function',
+      name: 'lookup_account',
+      description: 'Look up an account.',
+      deferLoading: true,
+    });
+    expect(serializeTool(deferredLookup)).not.toHaveProperty('namespace');
+
+    expect(serializeTool(crmLookup)).toMatchObject({
+      type: 'function',
+      name: 'lookup_account',
+      description: 'Look up an account.',
+      deferLoading: true,
+      namespace: 'crm',
+      namespaceDescription: 'CRM tools',
     });
   });
 

--- a/packages/agents-extensions/src/ai-sdk-ui/uiMessageStream.ts
+++ b/packages/agents-extensions/src/ai-sdk-ui/uiMessageStream.ts
@@ -6,7 +6,17 @@ import type {
   RunToolCallOutputItem,
   RunReasoningItem,
   RunToolApprovalItem,
+  RunToolSearchCallItem,
+  RunToolSearchOutputItem,
 } from '@openai/agents';
+import {
+  getToolCallDisplayName,
+  getToolSearchExecution,
+  getToolSearchProviderCallId,
+  resolveToolSearchCallId,
+  shouldQueuePendingToolSearchCall,
+  takePendingToolSearchCallId,
+} from '@openai/agents-core/utils';
 import type { UIMessageChunk } from 'ai';
 import { createUIMessageStreamResponse } from 'ai';
 
@@ -39,7 +49,7 @@ type ToolOutputPayload = {
 };
 
 function resolveToolName(raw: any): string {
-  return typeof raw.name === 'string' ? raw.name : String(raw.type ?? 'tool');
+  return getToolCallDisplayName(raw) ?? String(raw.type ?? 'tool');
 }
 
 function resolveToolCallId(raw: any, toolName: string): string {
@@ -112,6 +122,22 @@ function extractToolInput(item: RunToolCallItem): ToolInputPayload | null {
   return null;
 }
 
+function extractToolSearchInput(
+  item: RunToolSearchCallItem,
+): ToolInputPayload | null {
+  const raw = item.rawItem as any;
+  const toolName = 'tool_search';
+  const toolCallId = resolveToolSearchCallId(
+    raw,
+    () => `tool_search-${createId('call')}`,
+  );
+  return {
+    toolCallId,
+    toolName,
+    input: raw.arguments ?? {},
+  };
+}
+
 function extractHostedToolOutput(
   item: RunToolCallItem,
   toolCallId?: string,
@@ -140,6 +166,42 @@ function extractToolOutput(
   return { toolCallId, output };
 }
 
+function extractToolSearchOutput(
+  item: RunToolSearchOutputItem,
+  toolCallId: string,
+): ToolOutputPayload {
+  const raw = item.rawItem as any;
+  return {
+    toolCallId,
+    output: Array.isArray(raw.tools) ? raw.tools : [],
+  };
+}
+
+function takeQueuedToolSearchResultCallId(
+  rawItem: {
+    providerData?: unknown;
+    call_id?: unknown;
+    callId?: unknown;
+    id?: unknown;
+  },
+  pendingCallIds: string[],
+  generateFallbackId?: () => string,
+): string {
+  const explicitCallId = getToolSearchProviderCallId(rawItem);
+  if (explicitCallId) {
+    const pendingIndex = pendingCallIds.indexOf(explicitCallId);
+    if (pendingIndex >= 0) {
+      pendingCallIds.splice(pendingIndex, 1);
+    }
+    return explicitCallId;
+  }
+
+  return (
+    pendingCallIds.shift() ??
+    resolveToolSearchCallId(rawItem, generateFallbackId)
+  );
+}
+
 function extractReasoningText(item: RunReasoningItem): string {
   return item.rawItem.content
     .map((entry) => (entry.type === 'input_text' ? entry.text : ''))
@@ -158,6 +220,9 @@ async function* buildUiMessageStream(
   let currentTextId = '';
   const startedToolCalls = new Set<string>();
   const emittedToolOutputs = new Set<string>();
+  // FIFO fallback for tool_search outputs that do not carry an explicit call_id.
+  const pendingToolSearchCallIds: string[] = [];
+  const pendingServerToolSearchCallIds: string[] = [];
 
   const ensureMessageStart = function* (): Generator<
     UIMessageChunk,
@@ -285,6 +350,77 @@ async function* buildUiMessageStream(
             dynamic: true,
           };
         }
+      }
+
+      if (event.name === 'tool_search_called') {
+        yield* ensureMessageStart();
+        const payload = extractToolSearchInput(
+          event.item as RunToolSearchCallItem,
+        );
+        if (payload) {
+          if (
+            shouldQueuePendingToolSearchCall(
+              (event.item as RunToolSearchCallItem).rawItem,
+            )
+          ) {
+            pendingToolSearchCallIds.push(payload.toolCallId);
+          } else {
+            pendingServerToolSearchCallIds.push(payload.toolCallId);
+          }
+          if (!startedToolCalls.has(payload.toolCallId)) {
+            startedToolCalls.add(payload.toolCallId);
+            yield {
+              type: 'tool-input-start',
+              toolCallId: payload.toolCallId,
+              toolName: payload.toolName,
+              dynamic: true,
+            };
+          }
+          yield {
+            type: 'tool-input-available',
+            toolCallId: payload.toolCallId,
+            toolName: payload.toolName,
+            input: payload.input,
+            dynamic: true,
+          };
+        }
+      }
+
+      if (event.name === 'tool_search_output_created') {
+        yield* ensureMessageStart();
+        const item = event.item as RunToolSearchOutputItem;
+        const rawItem = (item.rawItem as any) ?? {};
+        const explicitToolCallId = getToolSearchProviderCallId(rawItem);
+        if (explicitToolCallId) {
+          const pendingIndex =
+            pendingToolSearchCallIds.indexOf(explicitToolCallId);
+          if (pendingIndex >= 0) {
+            pendingToolSearchCallIds.splice(pendingIndex, 1);
+          }
+        }
+        const toolCallId =
+          getToolSearchExecution(rawItem) === 'server'
+            ? takeQueuedToolSearchResultCallId(
+                rawItem,
+                pendingServerToolSearchCallIds,
+                () => `tool_search-${createId('call')}`,
+              )
+            : takePendingToolSearchCallId(
+                rawItem,
+                pendingToolSearchCallIds,
+                () => `tool_search-${createId('call')}`,
+              );
+        // Prefer explicit call_id matching first; the queue only covers older
+        // payloads that omit call_id metadata.
+        const payload = extractToolSearchOutput(item, toolCallId);
+        // tool_search outputs can legitimately update the same call_id more than
+        // once, so emit every event instead of suppressing later replacements.
+        yield {
+          type: 'tool-output-available',
+          toolCallId: payload.toolCallId,
+          output: payload.output,
+          dynamic: true,
+        };
       }
 
       if (event.name === 'tool_output') {

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -30,9 +30,15 @@ import {
   getLogger,
   ModelSettingsToolChoice,
 } from '@openai/agents';
+import {
+  getToolSearchProviderCallId,
+  resolveToolSearchCallId,
+  shouldQueuePendingToolSearchCall,
+  takePendingToolSearchCallId,
+  toolQualifiedName,
+} from '@openai/agents-core/utils';
 import type { GenerationUsageData } from '@openai/agents';
-import { isZodObject } from '@openai/agents/utils';
-import { encodeUint8ArrayToBase64 } from '@openai/agents/utils';
+import { isZodObject, encodeUint8ArrayToBase64 } from '@openai/agents/utils';
 
 // Minimal compatibility type to allow V3 (or future) models that follow the same shape as V2.
 type LanguageModelV3Compatible = {
@@ -172,10 +178,15 @@ export function itemsToLanguageV2Messages(
   modelSettings?: ModelSettings,
 ): LanguageModelV2Message[] {
   const messages: LanguageModelV2Message[] = [];
+  const toolCallNamesById = new Map<string, string>();
+  const pendingToolSearchCallIds: string[] = [];
+  const pendingServerToolSearchCallIds: string[] = [];
+  let generatedToolSearchCallId = 0;
   let currentAssistantMessage: LanguageModelV2Message | undefined;
   let pendingReasonerReasoning:
     | { text: string; providerOptions: Record<string, any> }
     | undefined;
+  const collapsedItems = collapseReplacedToolSearchOutputs(items);
   const flushPendingReasonerReasoningToMessages = () => {
     if (
       !(
@@ -213,7 +224,7 @@ export function itemsToLanguageV2Messages(
     pendingReasonerReasoning = undefined;
   };
 
-  for (const item of items) {
+  for (const item of collapsedItems) {
     if (item.type === 'message' || typeof item.type === 'undefined') {
       const { role, content, providerData } = item;
       if (role === 'system') {
@@ -373,10 +384,12 @@ export function itemsToLanguageV2Messages(
           };
           pendingReasonerReasoning = undefined;
         }
+        const toolName = getAiSdkToolName(item);
+        toolCallNamesById.set(item.callId, toolName);
         const content: LanguageModelV2ToolCallPart = {
           type: 'tool-call',
           toolCallId: item.callId,
-          toolName: item.name,
+          toolName,
           input: parseArguments(item.arguments),
           providerOptions: toProviderOptions(item.providerData, model),
         };
@@ -389,11 +402,109 @@ export function itemsToLanguageV2Messages(
         messages.push(currentAssistantMessage);
         currentAssistantMessage = undefined;
       }
+      const toolName =
+        toolCallNamesById.get(item.callId) ?? getAiSdkToolName(item);
       const toolResult: LanguageModelV2ToolResultPart = {
         type: 'tool-result',
         toolCallId: item.callId,
-        toolName: item.name,
+        toolName,
         output: convertToAiSdkOutput(item.output),
+        providerOptions: toProviderOptions(item.providerData, model),
+      };
+      messages.push({
+        role: 'tool',
+        content: [toolResult],
+        providerOptions: toProviderOptions(item.providerData, model),
+      });
+      continue;
+    } else if (item.type === 'tool_search_call') {
+      if (!currentAssistantMessage) {
+        currentAssistantMessage = {
+          role: 'assistant',
+          content: [],
+          providerOptions: toProviderOptions(item.providerData, model),
+        };
+      }
+
+      if (
+        Array.isArray(currentAssistantMessage.content) &&
+        currentAssistantMessage.role === 'assistant'
+      ) {
+        if (
+          shouldIncludeReasoningContent(model, modelSettings) &&
+          pendingReasonerReasoning
+        ) {
+          currentAssistantMessage.content.push({
+            type: 'reasoning',
+            text: pendingReasonerReasoning.text,
+            providerOptions: pendingReasonerReasoning.providerOptions,
+          });
+          currentAssistantMessage.providerOptions = {
+            ...pendingReasonerReasoning.providerOptions,
+            ...currentAssistantMessage.providerOptions,
+          };
+          pendingReasonerReasoning = undefined;
+        }
+        const toolCallId = resolveToolSearchCallId(item, () => {
+          generatedToolSearchCallId += 1;
+          return `tool_search_${generatedToolSearchCallId}`;
+        });
+        if (shouldQueuePendingToolSearchCall(item)) {
+          pendingToolSearchCallIds.push(toolCallId);
+        } else {
+          pendingServerToolSearchCallIds.push(toolCallId);
+        }
+        toolCallNamesById.set(toolCallId, 'tool_search');
+        const content: LanguageModelV2ToolCallPart = {
+          type: 'tool-call',
+          toolCallId,
+          toolName: 'tool_search',
+          input: item.arguments,
+          providerOptions: toProviderOptions(item.providerData, model),
+        };
+        currentAssistantMessage.content.push(content);
+      }
+      continue;
+    } else if (item.type === 'tool_search_output') {
+      flushPendingReasonerReasoningToMessages();
+      if (currentAssistantMessage) {
+        messages.push(currentAssistantMessage);
+        currentAssistantMessage = undefined;
+      }
+      const rawToolSearchExecution =
+        (item as { execution?: unknown }).execution ??
+        item.providerData?.execution;
+      const toolSearchExecution =
+        rawToolSearchExecution === 'client' ||
+        rawToolSearchExecution === 'server'
+          ? rawToolSearchExecution
+          : undefined;
+      const toolCallId =
+        toolSearchExecution === 'server'
+          ? takeQueuedToolSearchResultCallId(
+              item,
+              pendingServerToolSearchCallIds,
+              () => {
+                generatedToolSearchCallId += 1;
+                return `tool_search_${generatedToolSearchCallId}`;
+              },
+            )
+          : takePendingToolSearchCallId(item, pendingToolSearchCallIds, () => {
+              generatedToolSearchCallId += 1;
+              return `tool_search_${generatedToolSearchCallId}`;
+            });
+      const toolName = toolCallNamesById.get(toolCallId) ?? 'tool_search';
+      const toolResult: LanguageModelV2ToolResultPart = {
+        type: 'tool-result',
+        toolCallId,
+        toolName,
+        output: {
+          type: 'json',
+          value: {
+            ...(typeof item.status === 'string' ? { status: item.status } : {}),
+            tools: item.tools,
+          },
+        },
         providerOptions: toProviderOptions(item.providerData, model),
       };
       messages.push({
@@ -622,6 +733,181 @@ function expectsObjectArguments(
   return false;
 }
 
+function buildRequestedToolsByName(
+  request: Pick<ModelRequest, 'tools' | 'handoffs'>,
+): Map<string, SerializedTool | SerializedHandoff> {
+  const toolsByName = new Map<string, SerializedTool | SerializedHandoff>();
+
+  const addRequestedTool = (
+    name: string,
+    tool: SerializedTool | SerializedHandoff,
+  ) => {
+    const existing = toolsByName.get(name);
+    if (
+      name === 'tool_search' &&
+      existing &&
+      isHostedToolSearchTool(existing) !== isHostedToolSearchTool(tool)
+    ) {
+      throw new UserError(
+        'AiSdkModel cannot disambiguate a hosted tool_search helper from a custom tool or handoff that is also named "tool_search". Rename the custom tool or use a different adapter.',
+      );
+    }
+
+    toolsByName.set(name, tool);
+  };
+
+  for (const tool of request.tools) {
+    addRequestedTool(
+      tool.type === 'function'
+        ? getSerializedFunctionToolName(tool)
+        : tool.name,
+      tool,
+    );
+  }
+
+  for (const handoff of request.handoffs) {
+    addRequestedTool(handoff.toolName, handoff);
+  }
+
+  return toolsByName;
+}
+
+function isHostedToolSearchTool(
+  tool: SerializedTool | SerializedHandoff | undefined,
+): tool is Extract<SerializedTool, { type: 'hosted_tool' }> {
+  return (
+    !!tool &&
+    !('toolName' in tool) &&
+    tool.type === 'hosted_tool' &&
+    tool.providerData?.type === 'tool_search'
+  );
+}
+
+function normalizeToolSearchArguments(value: unknown): unknown {
+  if (typeof value !== 'string') {
+    return value ?? {};
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function takeQueuedToolSearchResultCallId(
+  value: {
+    providerData?: unknown;
+    call_id?: unknown;
+    callId?: unknown;
+    id?: unknown;
+  },
+  pendingCallIds: string[],
+  generateFallbackId?: () => string,
+): string {
+  const explicitCallId = getToolSearchProviderCallId(value);
+  if (explicitCallId) {
+    const pendingIndex = pendingCallIds.indexOf(explicitCallId);
+    if (pendingIndex >= 0) {
+      pendingCallIds.splice(pendingIndex, 1);
+    }
+    return explicitCallId;
+  }
+
+  return (
+    pendingCallIds.shift() ?? resolveToolSearchCallId(value, generateFallbackId)
+  );
+}
+
+function getToolSearchOutputReplacementKey(
+  item: protocol.ToolSearchOutputItem,
+): string | undefined {
+  const providerCallId = getToolSearchProviderCallId(item);
+  if (providerCallId) {
+    return `call:${providerCallId}`;
+  }
+
+  if (typeof item.id === 'string' && item.id.length > 0) {
+    return `item:${item.id}`;
+  }
+
+  return undefined;
+}
+
+function collapseReplacedToolSearchOutputs(
+  items: protocol.ModelItem[],
+): protocol.ModelItem[] {
+  const latestIndexByReplacementKey = new Map<string, number>();
+
+  items.forEach((item, index) => {
+    if (item.type !== 'tool_search_output') {
+      return;
+    }
+
+    const replacementKey = getToolSearchOutputReplacementKey(item);
+    if (replacementKey) {
+      latestIndexByReplacementKey.set(replacementKey, index);
+    }
+  });
+
+  return items.filter((item, index) => {
+    if (item.type !== 'tool_search_output') {
+      return true;
+    }
+
+    const replacementKey = getToolSearchOutputReplacementKey(item);
+    if (!replacementKey) {
+      return true;
+    }
+
+    return latestIndexByReplacementKey.get(replacementKey) === index;
+  });
+}
+
+function createProtocolToolCallItem(args: {
+  requestedTool: SerializedTool | SerializedHandoff | undefined;
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+  providerData: Record<string, any> | undefined;
+}): protocol.FunctionCallItem | protocol.ToolSearchCallItem {
+  const { requestedTool, toolCallId, toolName, input, providerData } = args;
+
+  if (isHostedToolSearchTool(requestedTool)) {
+    return {
+      type: 'tool_search_call',
+      id: toolCallId,
+      arguments: normalizeToolSearchArguments(input),
+      status: 'completed',
+      providerData,
+    };
+  }
+
+  let toolCallArguments: string;
+  if (typeof input === 'string') {
+    toolCallArguments =
+      input === '' && expectsObjectArguments(requestedTool)
+        ? JSON.stringify({})
+        : input;
+  } else {
+    toolCallArguments = JSON.stringify(input ?? {});
+  }
+
+  return {
+    type: 'function_call',
+    callId: toolCallId,
+    name: toolName,
+    arguments: toolCallArguments,
+    status: 'completed',
+    providerData,
+  };
+}
+
 /**
  * Maps the protocol-level structured outputs into the Language Model V2 result primitives.
  * The AI SDK expects either plain text or content parts (text + media), so we merge multiple
@@ -704,6 +990,16 @@ function convertStructuredOutputsToAiSdkOutput(
 
 function isRecord(value: unknown): value is Record<string, any> {
   return typeof value === 'object' && value !== null;
+}
+
+function getAiSdkToolName(tool: { name: string; namespace?: string }): string {
+  return toolQualifiedName(tool.name, tool.namespace) ?? tool.name;
+}
+
+function getSerializedFunctionToolName(
+  tool: Extract<SerializedTool, { type: 'function' }>,
+): string {
+  return getAiSdkToolName(tool);
 }
 
 function getModelIdentifier(model: LanguageModelCompatible): string {
@@ -893,6 +1189,19 @@ function formatInlineData(
   return mediaType ? `data:${mediaType};base64,${base64}` : base64;
 }
 
+function getHostedToolArgs(providerData: unknown): Record<string, any> {
+  if (!isRecord(providerData)) {
+    return {};
+  }
+
+  if (isRecord(providerData.args)) {
+    return providerData.args;
+  }
+
+  const { type: _type, name: _name, args: _args, ...rest } = providerData;
+  return rest;
+}
+
 /**
  * @internal
  * Converts a tool to a language model V2 tool.
@@ -905,9 +1214,14 @@ export function toolToLanguageV2Tool(
   tool: SerializedTool,
 ): LanguageModelV2FunctionTool | LanguageModelV2ProviderToolCompat {
   if (tool.type === 'function') {
+    if (tool.deferLoading) {
+      throw new UserError(
+        'The AI SDK adapter does not support deferred Responses function tools (`toolNamespace()` or `deferLoading: true`). Use a Responses API model directly.',
+      );
+    }
     return {
       type: 'function',
-      name: tool.name,
+      name: getSerializedFunctionToolName(tool),
       description: tool.description,
       inputSchema: tool.parameters as JSONSchema7,
     };
@@ -922,7 +1236,7 @@ export function toolToLanguageV2Tool(
       type: providerToolType,
       id: `${providerToolPrefix}.${tool.name}`,
       name: tool.name,
-      args: tool.providerData?.args ?? {},
+      args: getHostedToolArgs(tool.providerData),
     };
   }
 
@@ -1107,6 +1421,8 @@ export class AiSdkModel implements Model {
           throw new UserError('Zod output type is not yet supported');
         }
 
+        const requestedToolsByName = buildRequestedToolsByName(request);
+
         const responseFormat: LanguageModelV2CallOptions['responseFormat'] =
           getResponseFormat(request.outputType);
 
@@ -1167,19 +1483,10 @@ export class AiSdkModel implements Model {
           (c: any) => c && c.type === 'tool-call',
         );
         const hasToolCalls = toolCalls.length > 0;
-
-        const toolsNameToToolMap = new Map<
-          string,
-          SerializedTool | SerializedHandoff
-        >(request.tools.map((tool) => [tool.name, tool] as const));
-
-        for (const handoff of request.handoffs) {
-          toolsNameToToolMap.set(handoff.toolName, handoff);
-        }
         for (const toolCall of toolCalls) {
           const requestedTool =
             typeof toolCall.toolName === 'string'
-              ? toolsNameToToolMap.get(toolCall.toolName)
+              ? requestedToolsByName.get(toolCall.toolName)
               : undefined;
 
           if (!requestedTool && toolCall.toolName) {
@@ -1188,27 +1495,19 @@ export class AiSdkModel implements Model {
             );
           }
 
-          let toolCallArguments: string;
-          if (typeof toolCall.input === 'string') {
-            toolCallArguments =
-              toolCall.input === '' && expectsObjectArguments(requestedTool)
-                ? JSON.stringify({})
-                : toolCall.input;
-          } else {
-            toolCallArguments = JSON.stringify(toolCall.input ?? {});
-          }
-          output.push({
-            type: 'function_call',
-            callId: toolCall.toolCallId,
-            name: toolCall.toolName,
-            arguments: toolCallArguments,
-            status: 'completed',
-            providerData: mergeProviderData(
-              baseProviderData,
-              toolCall.providerMetadata ??
-                (hasToolCalls ? result.providerMetadata : undefined),
-            ),
-          });
+          output.push(
+            createProtocolToolCallItem({
+              requestedTool,
+              toolCallId: toolCall.toolCallId,
+              toolName: toolCall.toolName,
+              input: toolCall.input,
+              providerData: mergeProviderData(
+                baseProviderData,
+                toolCall.providerMetadata ??
+                  (hasToolCalls ? result.providerMetadata : undefined),
+              ),
+            }),
+          );
         }
 
         // Some of other platforms may return both tool calls and text.
@@ -1380,6 +1679,7 @@ export class AiSdkModel implements Model {
         abortSignal: request.signal,
         ...(request.modelSettings.providerData ?? {}),
       };
+      const requestedToolsByName = buildRequestedToolsByName(request);
 
       if (this.#logger.dontLogModelData) {
         this.#logger.debug('Request received (streamed)');
@@ -1398,7 +1698,10 @@ export class AiSdkModel implements Model {
       let usagePromptTokens = 0;
       let usageCompletionTokens = 0;
       let usageInputTokensDetails: Record<string, number> | undefined;
-      const functionCalls: Record<string, protocol.FunctionCallItem> = {};
+      const functionCalls: Record<
+        string,
+        protocol.FunctionCallItem | protocol.ToolSearchCallItem
+      > = {};
       let textOutput: protocol.OutputText | undefined;
 
       // State for tracking reasoning blocks (for Anthropic extended thinking):
@@ -1465,17 +1768,20 @@ export class AiSdkModel implements Model {
           case 'tool-call': {
             const toolCallId = (part as any).toolCallId;
             if (toolCallId) {
-              functionCalls[toolCallId] = {
-                type: 'function_call',
-                callId: toolCallId,
-                name: (part as any).toolName,
-                arguments: (part as any).input ?? '',
-                status: 'completed',
+              const requestedTool =
+                typeof (part as any).toolName === 'string'
+                  ? requestedToolsByName.get((part as any).toolName)
+                  : undefined;
+              functionCalls[toolCallId] = createProtocolToolCallItem({
+                requestedTool,
+                toolCallId,
+                toolName: (part as any).toolName,
+                input: (part as any).input,
                 providerData: mergeProviderData(
                   baseProviderData,
                   (part as any).providerMetadata,
                 ),
-              };
+              });
             }
             break;
           }

--- a/packages/agents-extensions/test/ai-sdk-ui/uiMessageStream.test.ts
+++ b/packages/agents-extensions/test/ai-sdk-ui/uiMessageStream.test.ts
@@ -7,6 +7,8 @@ import {
   RunReasoningItem,
   RunToolCallItem,
   RunToolCallOutputItem,
+  RunToolSearchCallItem,
+  RunToolSearchOutputItem,
 } from '@openai/agents';
 import type { UIMessageChunk } from 'ai';
 import { createAiSdkUiMessageStreamResponse } from '../../src/ai-sdk-ui/index';
@@ -311,6 +313,633 @@ describe('createAiSdkUiMessageStreamResponse', () => {
     expect(toolOutput).toMatchObject({
       toolCallId: 'call-1',
       output: 'Inline results',
+      dynamic: true,
+    });
+  });
+
+  test('preserves namespaced tool names and emits tool_search events', async () => {
+    const agent = new Agent({ name: 'Test Agent' });
+
+    const toolSearchCall = new RunToolSearchCallItem(
+      {
+        type: 'tool_search_call',
+        id: 'tool-search-call-1',
+        status: 'completed',
+        arguments: {
+          paths: ['crm'],
+          query: 'lookup account',
+        },
+      },
+      agent,
+    );
+
+    const toolSearchOutput = new RunToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        id: 'tool-search-output-1',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_account',
+            namespace: 'crm',
+          },
+        ],
+      },
+      agent,
+    );
+
+    const namespacedToolCall = new RunToolCallItem(
+      {
+        type: 'function_call',
+        callId: 'call-namespace-1',
+        name: 'lookup_account',
+        namespace: 'crm',
+        arguments: JSON.stringify({ accountId: 'acct_42' }),
+      },
+      agent,
+    );
+
+    const events = (async function* () {
+      yield new RunItemStreamEvent('tool_search_called', toolSearchCall);
+      yield new RunItemStreamEvent(
+        'tool_search_output_created',
+        toolSearchOutput,
+      );
+      yield new RunItemStreamEvent('tool_called', namespacedToolCall);
+    })();
+
+    const response = createAiSdkUiMessageStreamResponse(events);
+    const chunks = await readUiMessageChunks(response);
+
+    expect(chunks.map((chunk) => chunk.type)).toEqual([
+      'start',
+      'tool-input-start',
+      'tool-input-available',
+      'tool-output-available',
+      'tool-input-start',
+      'tool-input-available',
+      'finish',
+    ]);
+
+    const toolSearchInput = chunks.find(
+      (chunk) =>
+        chunk.type === 'tool-input-available' &&
+        (chunk as any).toolName === 'tool_search',
+    );
+    const toolSearchOutputChunk = chunks.find(
+      (chunk) => chunk.type === 'tool-output-available',
+    );
+    const namespacedInput = chunks.find(
+      (chunk) =>
+        chunk.type === 'tool-input-available' &&
+        (chunk as any).toolName === 'crm.lookup_account',
+    );
+
+    expect(toolSearchInput).toMatchObject({
+      toolCallId: 'tool-search-call-1',
+      toolName: 'tool_search',
+      input: {
+        paths: ['crm'],
+        query: 'lookup account',
+      },
+      dynamic: true,
+    });
+    expect(toolSearchOutputChunk).toMatchObject({
+      toolCallId: 'tool-search-call-1',
+      output: [
+        {
+          type: 'tool_reference',
+          functionName: 'lookup_account',
+          namespace: 'crm',
+        },
+      ],
+      dynamic: true,
+    });
+    expect(namespacedInput).toMatchObject({
+      toolCallId: 'call-namespace-1',
+      toolName: 'crm.lookup_account',
+      input: { accountId: 'acct_42' },
+      dynamic: true,
+    });
+  });
+
+  test('matches tool_search outputs by call_id when outputs arrive out of order', async () => {
+    const agent = new Agent({ name: 'Test Agent' });
+
+    const toolSearchCall1 = new RunToolSearchCallItem(
+      {
+        type: 'tool_search_call',
+        id: 'tool-search-call-1',
+        status: 'completed',
+        arguments: {
+          paths: ['crm'],
+          query: 'lookup account',
+        },
+        providerData: {
+          call_id: 'call-ts-1',
+        },
+      },
+      agent,
+    );
+    const toolSearchCall2 = new RunToolSearchCallItem(
+      {
+        type: 'tool_search_call',
+        id: 'tool-search-call-2',
+        status: 'completed',
+        arguments: {
+          paths: ['billing'],
+          query: 'lookup invoice',
+        },
+        providerData: {
+          call_id: 'call-ts-2',
+        },
+      },
+      agent,
+    );
+
+    const toolSearchOutput2 = new RunToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        id: 'tool-search-output-2',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_invoice',
+            namespace: 'billing',
+          },
+        ],
+        providerData: {
+          call_id: 'call-ts-2',
+        },
+      },
+      agent,
+    );
+    const toolSearchOutput1 = new RunToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        id: 'tool-search-output-1',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_account',
+            namespace: 'crm',
+          },
+        ],
+        providerData: {
+          call_id: 'call-ts-1',
+        },
+      },
+      agent,
+    );
+
+    const events = (async function* () {
+      yield new RunItemStreamEvent('tool_search_called', toolSearchCall1);
+      yield new RunItemStreamEvent('tool_search_called', toolSearchCall2);
+      yield new RunItemStreamEvent(
+        'tool_search_output_created',
+        toolSearchOutput2,
+      );
+      yield new RunItemStreamEvent(
+        'tool_search_output_created',
+        toolSearchOutput1,
+      );
+    })();
+
+    const response = createAiSdkUiMessageStreamResponse(events);
+    const chunks = await readUiMessageChunks(response);
+    const outputs = chunks.filter(
+      (chunk) => chunk.type === 'tool-output-available',
+    );
+
+    expect(outputs).toEqual([
+      {
+        type: 'tool-output-available',
+        toolCallId: 'call-ts-2',
+        output: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_invoice',
+            namespace: 'billing',
+          },
+        ],
+        dynamic: true,
+      },
+      {
+        type: 'tool-output-available',
+        toolCallId: 'call-ts-1',
+        output: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_account',
+            namespace: 'crm',
+          },
+        ],
+        dynamic: true,
+      },
+    ]);
+  });
+
+  test('does not let server tool_search outputs without call_id consume pending client searches', async () => {
+    const agent = new Agent({ name: 'Test Agent' });
+
+    const toolSearchCall = new RunToolSearchCallItem(
+      {
+        type: 'tool_search_call',
+        id: 'tool-search-call-client',
+        status: 'completed',
+        arguments: {
+          paths: ['crm'],
+          query: 'lookup account',
+        },
+        providerData: {
+          execution: 'client',
+        },
+      },
+      agent,
+    );
+    const serverOutput = new RunToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        id: 'tool-search-output-server',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_invoice',
+            namespace: 'billing',
+          },
+        ],
+        providerData: {
+          execution: 'server',
+        },
+      },
+      agent,
+    );
+    const clientOutput = new RunToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        id: 'tool-search-output-client',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_account',
+            namespace: 'crm',
+          },
+        ],
+        providerData: {
+          execution: 'client',
+        },
+      },
+      agent,
+    );
+
+    const events = (async function* () {
+      yield new RunItemStreamEvent('tool_search_called', toolSearchCall);
+      yield new RunItemStreamEvent('tool_search_output_created', serverOutput);
+      yield new RunItemStreamEvent('tool_search_output_created', clientOutput);
+    })();
+
+    const response = createAiSdkUiMessageStreamResponse(events);
+    const chunks = await readUiMessageChunks(response);
+    const outputs = chunks.filter(
+      (chunk) => chunk.type === 'tool-output-available',
+    );
+
+    expect(outputs).toEqual([
+      {
+        type: 'tool-output-available',
+        toolCallId: 'tool-search-output-server',
+        output: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_invoice',
+            namespace: 'billing',
+          },
+        ],
+        dynamic: true,
+      },
+      {
+        type: 'tool-output-available',
+        toolCallId: 'tool-search-call-client',
+        output: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_account',
+            namespace: 'crm',
+          },
+        ],
+        dynamic: true,
+      },
+    ]);
+  });
+
+  test('does not queue hosted tool_search calls as pending client searches in streamed events', async () => {
+    const agent = new Agent({ name: 'Test Agent' });
+
+    const serverCall = new RunToolSearchCallItem(
+      {
+        type: 'tool_search_call',
+        id: 'tool-search-call-server',
+        status: 'completed',
+        arguments: {
+          paths: ['billing'],
+          query: 'lookup invoice',
+        },
+        providerData: {
+          call_id: 'ts_call_server',
+          execution: 'server',
+        },
+      },
+      agent,
+    );
+    const serverOutput = new RunToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        id: 'tool-search-output-server',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_invoice',
+            namespace: 'billing',
+          },
+        ],
+        providerData: {
+          execution: 'server',
+        },
+      },
+      agent,
+    );
+    const clientCall = new RunToolSearchCallItem(
+      {
+        type: 'tool_search_call',
+        id: 'tool-search-call-client',
+        status: 'completed',
+        arguments: {
+          paths: ['crm'],
+          query: 'lookup account',
+        },
+        providerData: {
+          call_id: 'ts_call_client',
+          execution: 'client',
+        },
+      },
+      agent,
+    );
+    const clientOutput = new RunToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        id: 'tool-search-output-client',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_account',
+            namespace: 'crm',
+          },
+        ],
+        providerData: {
+          execution: 'client',
+        },
+      },
+      agent,
+    );
+
+    const events = (async function* () {
+      yield new RunItemStreamEvent('tool_search_called', serverCall);
+      yield new RunItemStreamEvent('tool_search_output_created', serverOutput);
+      yield new RunItemStreamEvent('tool_search_called', clientCall);
+      yield new RunItemStreamEvent('tool_search_output_created', clientOutput);
+    })();
+
+    const response = createAiSdkUiMessageStreamResponse(events);
+    const chunks = await readUiMessageChunks(response);
+    const outputs = chunks.filter(
+      (chunk) => chunk.type === 'tool-output-available',
+    );
+
+    expect(outputs).toEqual([
+      {
+        type: 'tool-output-available',
+        toolCallId: 'ts_call_server',
+        output: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_invoice',
+            namespace: 'billing',
+          },
+        ],
+        dynamic: true,
+      },
+      {
+        type: 'tool-output-available',
+        toolCallId: 'ts_call_client',
+        output: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_account',
+            namespace: 'crm',
+          },
+        ],
+        dynamic: true,
+      },
+    ]);
+  });
+
+  test('reuses hosted tool_search call ids when streamed server outputs omit call_id', async () => {
+    const agent = new Agent({ name: 'Test Agent' });
+
+    const serverCall = new RunToolSearchCallItem(
+      {
+        type: 'tool_search_call',
+        id: 'tool-search-call-server',
+        status: 'completed',
+        arguments: {
+          paths: ['billing'],
+          query: 'lookup invoice',
+        },
+        providerData: {
+          execution: 'server',
+        },
+      },
+      agent,
+    );
+    const serverOutput = new RunToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        id: 'tool-search-output-server',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_invoice',
+            namespace: 'billing',
+          },
+        ],
+        providerData: {
+          execution: 'server',
+        },
+      },
+      agent,
+    );
+
+    const events = (async function* () {
+      yield new RunItemStreamEvent('tool_search_called', serverCall);
+      yield new RunItemStreamEvent('tool_search_output_created', serverOutput);
+    })();
+
+    const response = createAiSdkUiMessageStreamResponse(events);
+    const chunks = await readUiMessageChunks(response);
+    const outputs = chunks.filter(
+      (chunk) => chunk.type === 'tool-output-available',
+    );
+
+    expect(outputs).toEqual([
+      {
+        type: 'tool-output-available',
+        toolCallId: 'tool-search-call-server',
+        output: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_invoice',
+            namespace: 'billing',
+          },
+        ],
+        dynamic: true,
+      },
+    ]);
+  });
+
+  test('emits updated tool_search outputs when the same call_id repeats', async () => {
+    const agent = new Agent({ name: 'Test Agent' });
+
+    const toolSearchCall = new RunToolSearchCallItem(
+      {
+        type: 'tool_search_call',
+        id: 'tool-search-call-1',
+        status: 'completed',
+        arguments: {
+          paths: ['crm'],
+          query: 'lookup account',
+        },
+        providerData: {
+          call_id: 'call-ts-1',
+        },
+      },
+      agent,
+    );
+    const staleOutput = new RunToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        id: 'tool-search-output-stale',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_account_old',
+            namespace: 'crm',
+          },
+        ],
+        providerData: {
+          call_id: 'call-ts-1',
+        },
+      },
+      agent,
+    );
+    const freshOutput = new RunToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        id: 'tool-search-output-fresh',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_account',
+            namespace: 'crm',
+          },
+        ],
+        providerData: {
+          call_id: 'call-ts-1',
+        },
+      },
+      agent,
+    );
+
+    const events = (async function* () {
+      yield new RunItemStreamEvent('tool_search_called', toolSearchCall);
+      yield new RunItemStreamEvent('tool_search_output_created', staleOutput);
+      yield new RunItemStreamEvent('tool_search_output_created', freshOutput);
+    })();
+
+    const response = createAiSdkUiMessageStreamResponse(events);
+    const chunks = await readUiMessageChunks(response);
+    const outputs = chunks.filter(
+      (chunk) => chunk.type === 'tool-output-available',
+    );
+
+    expect(outputs).toEqual([
+      {
+        type: 'tool-output-available',
+        toolCallId: 'call-ts-1',
+        output: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_account_old',
+            namespace: 'crm',
+          },
+        ],
+        dynamic: true,
+      },
+      {
+        type: 'tool-output-available',
+        toolCallId: 'call-ts-1',
+        output: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_account',
+            namespace: 'crm',
+          },
+        ],
+        dynamic: true,
+      },
+    ]);
+  });
+
+  test('collapses same-name namespace tool names in streamed events', async () => {
+    const agent = new Agent({ name: 'Test Agent' });
+
+    const namespacedToolCall = new RunToolCallItem(
+      {
+        type: 'function_call',
+        callId: 'call-namespace-self-1',
+        name: 'lookup_account',
+        namespace: 'lookup_account',
+        arguments: JSON.stringify({ accountId: 'acct_42' }),
+      },
+      agent,
+    );
+
+    const events = (async function* () {
+      yield new RunItemStreamEvent('tool_called', namespacedToolCall);
+    })();
+
+    const response = createAiSdkUiMessageStreamResponse(events);
+    const chunks = await readUiMessageChunks(response);
+
+    const namespacedInput = chunks.find(
+      (chunk) =>
+        chunk.type === 'tool-input-available' &&
+        (chunk as any).toolCallId === 'call-namespace-self-1',
+    );
+
+    expect(namespacedInput).toMatchObject({
+      toolCallId: 'call-namespace-self-1',
+      toolName: 'lookup_account',
+      input: { accountId: 'acct_42' },
       dynamic: true,
     });
   });

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -426,6 +426,598 @@ describe('itemsToLanguageV2Messages', () => {
     ]);
   });
 
+  test('preserves qualified names for namespaced function calls', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call',
+        callId: '1',
+        name: 'lookup_account',
+        namespace: 'crm',
+        arguments: '{}',
+      } as any,
+      {
+        type: 'function_call_result',
+        callId: '1',
+        name: 'lookup_account',
+        output: 'crm result',
+      } as any,
+      {
+        type: 'function_call',
+        callId: '2',
+        name: 'get_shipping_eta',
+        namespace: 'get_shipping_eta',
+        arguments: '{}',
+      } as any,
+      {
+        type: 'function_call_result',
+        callId: '2',
+        name: 'get_shipping_eta',
+        output: 'eta result',
+      } as any,
+    ];
+
+    const msgs = itemsToLanguageV2Messages(stubModel({}), items);
+    expect(msgs).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: '1',
+            toolName: 'crm.lookup_account',
+            input: {},
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: '1',
+            toolName: 'crm.lookup_account',
+            output: { type: 'text', value: 'crm result' },
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: '2',
+            toolName: 'get_shipping_eta.get_shipping_eta',
+            input: {},
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: '2',
+            toolName: 'get_shipping_eta.get_shipping_eta',
+            output: { type: 'text', value: 'eta result' },
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+    ]);
+  });
+
+  test('converts tool_search items into tool call and tool output messages', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'tool_search_call',
+        id: 'ts_call',
+        status: 'completed',
+        arguments: { paths: ['crm'], query: 'lookup account' },
+        providerData: { a: 1 },
+      } as any,
+      {
+        type: 'tool_search_output',
+        id: 'ts_output',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_account',
+            namespace: 'crm',
+          },
+        ],
+        providerData: { b: 2 },
+      } as any,
+    ];
+
+    const msgs = itemsToLanguageV2Messages(stubModel({}), items);
+    expect(msgs).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'ts_call',
+            toolName: 'tool_search',
+            input: { paths: ['crm'], query: 'lookup account' },
+            providerOptions: { a: 1 },
+          },
+        ],
+        providerOptions: { a: 1 },
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'ts_call',
+            toolName: 'tool_search',
+            output: {
+              type: 'json',
+              value: {
+                status: 'completed',
+                tools: [
+                  {
+                    type: 'tool_reference',
+                    functionName: 'lookup_account',
+                    namespace: 'crm',
+                  },
+                ],
+              },
+            },
+            providerOptions: { b: 2 },
+          },
+        ],
+        providerOptions: { b: 2 },
+      },
+    ]);
+  });
+
+  test('matches tool_search outputs by call_id when they arrive out of order', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'tool_search_call',
+        id: 'ts_item_1',
+        status: 'completed',
+        arguments: { paths: ['crm'], query: 'lookup account' },
+        providerData: { call_id: 'call_ts_1' },
+      } as any,
+      {
+        type: 'tool_search_call',
+        id: 'ts_item_2',
+        status: 'completed',
+        arguments: { paths: ['billing'], query: 'lookup invoice' },
+        providerData: { call_id: 'call_ts_2' },
+      } as any,
+      {
+        type: 'tool_search_output',
+        id: 'ts_output_2',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_invoice',
+            namespace: 'billing',
+          },
+        ],
+        providerData: { call_id: 'call_ts_2' },
+      } as any,
+      {
+        type: 'tool_search_output',
+        id: 'ts_output_1',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_account',
+            namespace: 'crm',
+          },
+        ],
+        providerData: { call_id: 'call_ts_1' },
+      } as any,
+    ];
+
+    const msgs = itemsToLanguageV2Messages(stubModel({}), items);
+    expect(msgs[0]).toMatchObject({
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: 'call_ts_1',
+          toolName: 'tool_search',
+          input: { paths: ['crm'], query: 'lookup account' },
+          providerOptions: { call_id: 'call_ts_1' },
+        },
+        {
+          type: 'tool-call',
+          toolCallId: 'call_ts_2',
+          toolName: 'tool_search',
+          input: { paths: ['billing'], query: 'lookup invoice' },
+          providerOptions: { call_id: 'call_ts_2' },
+        },
+      ],
+    });
+    expect(msgs[1]).toEqual({
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: 'call_ts_2',
+          toolName: 'tool_search',
+          output: {
+            type: 'json',
+            value: {
+              status: 'completed',
+              tools: [
+                {
+                  type: 'tool_reference',
+                  functionName: 'lookup_invoice',
+                  namespace: 'billing',
+                },
+              ],
+            },
+          },
+          providerOptions: { call_id: 'call_ts_2' },
+        },
+      ],
+      providerOptions: { call_id: 'call_ts_2' },
+    });
+    expect(msgs[2]).toEqual({
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: 'call_ts_1',
+          toolName: 'tool_search',
+          output: {
+            type: 'json',
+            value: {
+              status: 'completed',
+              tools: [
+                {
+                  type: 'tool_reference',
+                  functionName: 'lookup_account',
+                  namespace: 'crm',
+                },
+              ],
+            },
+          },
+          providerOptions: { call_id: 'call_ts_1' },
+        },
+      ],
+      providerOptions: { call_id: 'call_ts_1' },
+    });
+  });
+
+  test('does not let server tool_search outputs without call_id hijack pending client searches', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'tool_search_call',
+        id: 'ts_call_client',
+        status: 'completed',
+        arguments: { paths: ['crm'], query: 'lookup account' },
+        providerData: { execution: 'client' },
+      } as any,
+      {
+        type: 'tool_search_output',
+        id: 'ts_output_server',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_invoice',
+            namespace: 'billing',
+          },
+        ],
+        providerData: { execution: 'server' },
+      } as any,
+      {
+        type: 'tool_search_output',
+        id: 'ts_output_client',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_account',
+            namespace: 'crm',
+          },
+        ],
+        providerData: { execution: 'client' },
+      } as any,
+    ];
+
+    const msgs = itemsToLanguageV2Messages(stubModel({}), items);
+    expect(msgs[0]).toMatchObject({
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: 'ts_call_client',
+          toolName: 'tool_search',
+        },
+      ],
+    });
+    expect(msgs[1]).toEqual({
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: 'ts_output_server',
+          toolName: 'tool_search',
+          output: {
+            type: 'json',
+            value: {
+              status: 'completed',
+              tools: [
+                {
+                  type: 'tool_reference',
+                  functionName: 'lookup_invoice',
+                  namespace: 'billing',
+                },
+              ],
+            },
+          },
+          providerOptions: { execution: 'server' },
+        },
+      ],
+      providerOptions: { execution: 'server' },
+    });
+    expect(msgs[2]).toEqual({
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: 'ts_call_client',
+          toolName: 'tool_search',
+          output: {
+            type: 'json',
+            value: {
+              status: 'completed',
+              tools: [
+                {
+                  type: 'tool_reference',
+                  functionName: 'lookup_account',
+                  namespace: 'crm',
+                },
+              ],
+            },
+          },
+          providerOptions: { execution: 'client' },
+        },
+      ],
+      providerOptions: { execution: 'client' },
+    });
+  });
+
+  test('reuses hosted tool_search call ids when server outputs omit call_id', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'tool_search_call',
+        id: 'ts_call_server',
+        status: 'completed',
+        arguments: { paths: ['billing'], query: 'lookup invoice' },
+        providerData: {
+          execution: 'server',
+        },
+      } as any,
+      {
+        type: 'tool_search_output',
+        id: 'ts_output_server',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_invoice',
+            namespace: 'billing',
+          },
+        ],
+        providerData: { execution: 'server' },
+      } as any,
+    ];
+
+    const msgs = itemsToLanguageV2Messages(stubModel({}), items);
+    expect(msgs[0]).toMatchObject({
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: 'ts_call_server',
+          toolName: 'tool_search',
+        },
+      ],
+    });
+    expect(msgs[1]).toEqual({
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: 'ts_call_server',
+          toolName: 'tool_search',
+          output: {
+            type: 'json',
+            value: {
+              status: 'completed',
+              tools: [
+                {
+                  type: 'tool_reference',
+                  functionName: 'lookup_invoice',
+                  namespace: 'billing',
+                },
+              ],
+            },
+          },
+          providerOptions: { execution: 'server' },
+        },
+      ],
+      providerOptions: { execution: 'server' },
+    });
+  });
+
+  test('does not queue hosted tool_search calls as pending client searches', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'tool_search_call',
+        id: 'ts_call_server',
+        status: 'completed',
+        arguments: { paths: ['billing'], query: 'lookup invoice' },
+        providerData: {
+          call_id: 'ts_call_server',
+          execution: 'server',
+        },
+      } as any,
+      {
+        type: 'tool_search_output',
+        id: 'ts_output_server',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_invoice',
+            namespace: 'billing',
+          },
+        ],
+        providerData: { execution: 'server' },
+      } as any,
+      {
+        type: 'tool_search_call',
+        id: 'ts_call_client',
+        status: 'completed',
+        arguments: { paths: ['crm'], query: 'lookup account' },
+        providerData: {
+          call_id: 'ts_call_client',
+          execution: 'client',
+        },
+      } as any,
+      {
+        type: 'tool_search_output',
+        id: 'ts_output_client',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_account',
+            namespace: 'crm',
+          },
+        ],
+        providerData: { execution: 'client' },
+      } as any,
+    ];
+
+    const msgs = itemsToLanguageV2Messages(stubModel({}), items);
+    expect(msgs[3]).toEqual({
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: 'ts_call_client',
+          toolName: 'tool_search',
+          output: {
+            type: 'json',
+            value: {
+              status: 'completed',
+              tools: [
+                {
+                  type: 'tool_reference',
+                  functionName: 'lookup_account',
+                  namespace: 'crm',
+                },
+              ],
+            },
+          },
+          providerOptions: { execution: 'client' },
+        },
+      ],
+      providerOptions: { execution: 'client' },
+    });
+  });
+
+  test('treats later tool_search outputs with the same call_id as replacements', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'tool_search_call',
+        id: 'ts_item_1',
+        status: 'completed',
+        arguments: { paths: ['crm'], query: 'lookup account' },
+        providerData: { call_id: 'call_ts_1' },
+      } as any,
+      {
+        type: 'tool_search_output',
+        id: 'ts_output_stale',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_account_old',
+            namespace: 'crm',
+          },
+        ],
+        providerData: { call_id: 'call_ts_1' },
+      } as any,
+      {
+        type: 'tool_search_output',
+        id: 'ts_output_fresh',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'lookup_account',
+            namespace: 'crm',
+          },
+        ],
+        providerData: { call_id: 'call_ts_1' },
+      } as any,
+    ];
+
+    const msgs = itemsToLanguageV2Messages(stubModel({}), items);
+    expect(msgs).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call_ts_1',
+            toolName: 'tool_search',
+            input: { paths: ['crm'], query: 'lookup account' },
+            providerOptions: { call_id: 'call_ts_1' },
+          },
+        ],
+        providerOptions: { call_id: 'call_ts_1' },
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call_ts_1',
+            toolName: 'tool_search',
+            output: {
+              type: 'json',
+              value: {
+                status: 'completed',
+                tools: [
+                  {
+                    type: 'tool_reference',
+                    functionName: 'lookup_account',
+                    namespace: 'crm',
+                  },
+                ],
+              },
+            },
+            providerOptions: { call_id: 'call_ts_1' },
+          },
+        ],
+        providerOptions: { call_id: 'call_ts_1' },
+      },
+    ]);
+  });
+
   test('throws on built-in tool calls', () => {
     const items: protocol.ModelItem[] = [
       { type: 'hosted_tool_call', name: 'search' } as any,
@@ -537,6 +1129,35 @@ describe('itemsToLanguageV2Messages', () => {
       {
         role: 'assistant',
         content: [{ type: 'reasoning', text: 'why', providerOptions: {} }],
+        providerOptions: {},
+      },
+    ]);
+  });
+
+  test('uses namespace-qualified tool names for result-only function_call_result items', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call_result',
+        callId: 'call_1',
+        name: 'lookup_account',
+        namespace: 'billing',
+        output: { type: 'text', text: 'found' },
+      } as any,
+    ];
+
+    const msgs = itemsToLanguageV2Messages(stubModel({}), items);
+    expect(msgs).toEqual([
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call_1',
+            toolName: 'billing.lookup_account',
+            output: { type: 'text', value: 'found' },
+            providerOptions: {},
+          },
+        ],
         providerOptions: {},
       },
     ]);
@@ -718,6 +1339,51 @@ describe('toolToLanguageV2Tool', () => {
     });
   });
 
+  test('maps namespaced function tools to qualified names', () => {
+    const tool = {
+      type: 'function',
+      name: 'lookup_account',
+      namespace: 'crm',
+      description: 'd',
+      parameters: {} as any,
+    } as any;
+    expect(toolToLanguageV2Tool(model, tool)).toEqual({
+      type: 'function',
+      name: 'crm.lookup_account',
+      description: 'd',
+      inputSchema: {},
+    });
+  });
+
+  test('maps same-name namespaces to qualified names', () => {
+    const tool = {
+      type: 'function',
+      name: 'lookup_account',
+      namespace: 'lookup_account',
+      description: 'd',
+      parameters: {} as any,
+    } as any;
+    expect(toolToLanguageV2Tool(model, tool)).toEqual({
+      type: 'function',
+      name: 'lookup_account.lookup_account',
+      description: 'd',
+      inputSchema: {},
+    });
+  });
+
+  test('rejects deferred Responses function tools', () => {
+    const tool = {
+      type: 'function',
+      name: 'lookup_account',
+      description: 'd',
+      parameters: {} as any,
+      deferLoading: true,
+    } as any;
+    expect(() => toolToLanguageV2Tool(model, tool)).toThrow(
+      /AI SDK adapter does not support deferred Responses function tools/,
+    );
+  });
+
   test('maps builtin tools', () => {
     const tool = {
       type: 'hosted_tool',
@@ -729,6 +1395,40 @@ describe('toolToLanguageV2Tool', () => {
       id: `${model.provider}.search`,
       name: 'search',
       args: { q: 1 },
+    });
+  });
+
+  test('maps tool_search config from providerData when hosted args are implicit', () => {
+    const tool = {
+      type: 'hosted_tool',
+      name: 'tool_search',
+      providerData: {
+        type: 'tool_search',
+        name: 'tool_search',
+        execution: 'client',
+        description: 'Search local deferred tools.',
+        parameters: {
+          type: 'object',
+          properties: {
+            namespace: { type: 'string' },
+          },
+        },
+      },
+    } as any;
+    expect(toolToLanguageV2Tool(model, tool)).toEqual({
+      type: 'provider-defined',
+      id: `${model.provider}.tool_search`,
+      name: 'tool_search',
+      args: {
+        execution: 'client',
+        description: 'Search local deferred tools.',
+        parameters: {
+          type: 'object',
+          properties: {
+            namespace: { type: 'string' },
+          },
+        },
+      },
     });
   });
 
@@ -958,6 +1658,244 @@ describe('AiSdkModel.getResponse', () => {
       type: 'function_call',
       arguments: '{}',
     });
+  });
+
+  test('normalizes empty string input for namespaced object tools in doGenerate', async () => {
+    allowConsole(['warn']);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const model = new AiSdkModel(
+      stubModel({
+        async doGenerate() {
+          return {
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'crm.lookup_account',
+                input: '',
+              },
+            ],
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            providerMetadata: { meta: true },
+            response: { id: 'id' },
+            finishReason: 'tool-calls',
+            warnings: [],
+          } as any;
+        },
+      }),
+    );
+
+    const res = await withTrace('t', () =>
+      model.getResponse({
+        input: 'hi',
+        tools: [
+          {
+            type: 'function',
+            name: 'lookup_account',
+            namespace: 'crm',
+            description: 'accepts object',
+            parameters: {
+              type: 'object',
+              properties: {},
+              additionalProperties: false,
+            },
+          } as any,
+        ],
+        handoffs: [],
+        modelSettings: {},
+        outputType: 'text',
+        tracing: false,
+      } as any),
+    );
+
+    expect(res.output).toHaveLength(1);
+    expect(res.output[0]).toMatchObject({
+      type: 'function_call',
+      name: 'crm.lookup_account',
+      arguments: '{}',
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  test('preserves hosted tool_search calls in doGenerate', async () => {
+    allowConsole(['warn']);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const model = new AiSdkModel(
+      stubModel({
+        async doGenerate() {
+          return {
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'ts_call_1',
+                toolName: 'tool_search',
+                input: '{"paths":["crm"],"query":"lookup account"}',
+                providerMetadata: { execution: 'client' },
+              },
+            ],
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            providerMetadata: { meta: true },
+            response: { id: 'id' },
+            finishReason: 'tool-calls',
+            warnings: [],
+          } as any;
+        },
+      }),
+    );
+
+    const res = await withTrace('t', () =>
+      model.getResponse({
+        input: 'hi',
+        tools: [
+          {
+            type: 'hosted_tool',
+            name: 'tool_search',
+            providerData: {
+              type: 'tool_search',
+              execution: 'client',
+            },
+          } as any,
+        ],
+        handoffs: [],
+        modelSettings: {},
+        outputType: 'text',
+        tracing: false,
+      } as any),
+    );
+
+    expect(res.output).toEqual([
+      {
+        type: 'tool_search_call',
+        id: 'ts_call_1',
+        arguments: {
+          paths: ['crm'],
+          query: 'lookup account',
+        },
+        status: 'completed',
+        providerData: {
+          model: 'stub:m',
+          responseId: 'id',
+          execution: 'client',
+        },
+      },
+    ]);
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  test('rejects ambiguous hosted and custom tool_search names in doGenerate', async () => {
+    const doGenerate = vi.fn();
+    const model = new AiSdkModel(
+      stubModel({
+        async doGenerate(...args: any[]) {
+          return doGenerate(...args);
+        },
+      }),
+    );
+
+    await expect(
+      withTrace('t', () =>
+        model.getResponse({
+          input: 'hi',
+          tools: [
+            {
+              type: 'hosted_tool',
+              name: 'tool_search',
+              providerData: {
+                type: 'tool_search',
+                execution: 'client',
+              },
+            } as any,
+            {
+              type: 'function',
+              name: 'tool_search',
+              description: 'Custom tool_search function',
+              parameters: {
+                type: 'object',
+                properties: {},
+                additionalProperties: false,
+              },
+            } as any,
+          ],
+          handoffs: [],
+          modelSettings: {},
+          outputType: 'text',
+          tracing: false,
+        } as any),
+      ),
+    ).rejects.toThrow(
+      /cannot disambiguate a hosted tool_search helper from a custom tool or handoff/,
+    );
+    expect(doGenerate).not.toHaveBeenCalled();
+  });
+
+  test('keeps same-name namespace tool calls distinct from bare tools in doGenerate', async () => {
+    allowConsole(['warn']);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const model = new AiSdkModel(
+      stubModel({
+        async doGenerate() {
+          return {
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'lookup_account.lookup_account',
+                input: '',
+              },
+            ],
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            providerMetadata: { meta: true },
+            response: { id: 'id' },
+            finishReason: 'tool-calls',
+            warnings: [],
+          } as any;
+        },
+      }),
+    );
+
+    const res = await withTrace('t', () =>
+      model.getResponse({
+        input: 'hi',
+        tools: [
+          {
+            type: 'function',
+            name: 'lookup_account',
+            description: 'Top-level lookup tool.',
+            parameters: {
+              type: 'object',
+              properties: {},
+              additionalProperties: false,
+            },
+          } as any,
+          {
+            type: 'function',
+            name: 'lookup_account',
+            namespace: 'lookup_account',
+            description: 'Same-name namespace lookup tool.',
+            parameters: {
+              type: 'object',
+              properties: {},
+              additionalProperties: false,
+            },
+          } as any,
+        ],
+        handoffs: [],
+        modelSettings: {},
+        outputType: 'text',
+        tracing: false,
+      } as any),
+    );
+
+    expect(res.output).toHaveLength(1);
+    expect(res.output[0]).toMatchObject({
+      type: 'function_call',
+      name: 'lookup_account.lookup_account',
+      arguments: '{}',
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 
   test('normalizes empty string tool input for handoff schemas', async () => {
@@ -1589,6 +2527,78 @@ describe('AiSdkModel.getStreamedResponse', () => {
         ...toolCallProviderMetadata,
       },
     });
+  });
+
+  test('preserves hosted tool_search calls in streaming mode', async () => {
+    allowConsole(['warn']);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const parts = [
+      {
+        type: 'tool-call',
+        toolCallId: 'ts_call_1',
+        toolName: 'tool_search',
+        input: '{"paths":["crm"],"query":"lookup account"}',
+        providerMetadata: { execution: 'client' },
+      },
+      { type: 'response-metadata', id: 'resp-stream-tool-search' },
+      {
+        type: 'finish',
+        finishReason: 'tool-calls',
+        usage: { inputTokens: 3, outputTokens: 4 },
+      },
+    ];
+
+    const model = new AiSdkModel(
+      stubModel({
+        async doStream() {
+          return {
+            stream: partsStream(parts),
+          } as any;
+        },
+      }),
+    );
+
+    const events: any[] = [];
+    for await (const ev of model.getStreamedResponse({
+      input: 'hi',
+      tools: [
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: {
+            type: 'tool_search',
+            execution: 'client',
+          },
+        } as any,
+      ],
+      handoffs: [],
+      modelSettings: {},
+      outputType: 'text',
+      tracing: false,
+    } as any)) {
+      events.push(ev);
+    }
+
+    const final = events.at(-1);
+    expect(final.type).toBe('response_done');
+    expect(final.response.output).toEqual([
+      {
+        type: 'tool_search_call',
+        id: 'ts_call_1',
+        arguments: {
+          paths: ['crm'],
+          query: 'lookup account',
+        },
+        status: 'completed',
+        providerData: {
+          model: 'stub:m',
+          responseId: 'resp-stream-tool-search',
+          execution: 'client',
+        },
+      },
+    ]);
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 
   test('includes base providerData in streaming mode even when providerMetadata is not present', async () => {
@@ -2707,6 +3717,52 @@ describe('AiSdkModel', () => {
         providerOptions: { meta: 1 },
       },
     ]);
+  });
+
+  test('rejects ambiguous hosted and custom tool_search names in streaming mode', async () => {
+    const doStream = vi.fn();
+    const model = new AiSdkModel(
+      stubModel({
+        async doStream(...args: any[]) {
+          return doStream(...args);
+        },
+      }),
+    );
+
+    await expect(async () => {
+      for await (const _event of model.getStreamedResponse({
+        input: 'hi',
+        tools: [
+          {
+            type: 'hosted_tool',
+            name: 'tool_search',
+            providerData: {
+              type: 'tool_search',
+              execution: 'client',
+            },
+          } as any,
+          {
+            type: 'function',
+            name: 'tool_search',
+            description: 'Custom tool_search function',
+            parameters: {
+              type: 'object',
+              properties: {},
+              additionalProperties: false,
+            },
+          } as any,
+        ],
+        handoffs: [],
+        modelSettings: {},
+        outputType: 'text',
+        tracing: false,
+      } as any)) {
+        void _event;
+      }
+    }).rejects.toThrow(
+      /cannot disambiguate a hosted tool_search helper from a custom tool or handoff/,
+    );
+    expect(doStream).not.toHaveBeenCalled();
   });
 
   describe('parseArguments', () => {

--- a/packages/agents-extensions/tsconfig.json
+++ b/packages/agents-extensions/tsconfig.json
@@ -6,4 +6,3 @@
   },
   "exclude": ["dist/**", "test/**"]
 }
-

--- a/packages/agents-openai/package.json
+++ b/packages/agents-openai/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@openai/agents-core": "workspace:*",
     "debug": "^4.4.0",
-    "openai": "^6.20.0"
+    "openai": "^6.26.0"
   },
   "scripts": {
     "prebuild": "tsx ../../scripts/embedMeta.ts",

--- a/packages/agents-openai/src/index.ts
+++ b/packages/agents-openai/src/index.ts
@@ -25,8 +25,10 @@ export {
   webSearchTool,
   fileSearchTool,
   codeInterpreterTool,
+  toolSearchTool,
   imageGenerationTool,
 } from './tools';
+export type { ToolSearchTool } from './tools';
 export {
   OpenAIConversationsSession,
   startOpenAIConversationsSession,

--- a/packages/agents-openai/src/metadata.ts
+++ b/packages/agents-openai/src/metadata.ts
@@ -7,7 +7,7 @@ export const METADATA = {
   "versions": {
     "@openai/agents-openai": "0.5.4",
     "@openai/agents-core": "workspace:*",
-    "openai": "^6.20.0"
+    "openai": "^6.26.0"
   }
 };
 

--- a/packages/agents-openai/src/openaiChatCompletionsConverter.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsConverter.ts
@@ -15,6 +15,8 @@ import {
 } from '@openai/agents-core';
 import { getProviderDataWithoutReservedKeys } from './utils/providerData';
 
+const CHAT_COMPLETIONS_FUNCTION_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
 export function convertToolChoice(
   toolChoice: 'auto' | 'required' | 'none' | (string & {}) | undefined | null,
 ): ChatCompletionToolChoiceOption | undefined {
@@ -26,6 +28,46 @@ export function convertToolChoice(
     type: 'function',
     function: { name: toolChoice },
   };
+}
+
+export function getCompatibleToolChoice(
+  toolChoice: 'auto' | 'required' | 'none' | (string & {}) | undefined | null,
+  tools: ChatCompletionTool[],
+): ChatCompletionToolChoiceOption | undefined {
+  const converted = convertToolChoice(toolChoice);
+  if (converted == undefined || converted === 'auto' || converted === 'none') {
+    return converted;
+  }
+
+  if (converted === 'required') {
+    if (tools.length === 0) {
+      throw new UserError(
+        'modelSettings.toolChoice="required" requires at least one available tool in Chat Completions mode.',
+      );
+    }
+    return converted;
+  }
+
+  if (typeof converted !== 'object' || !('function' in converted)) {
+    return converted;
+  }
+
+  const availableToolNames = new Set(
+    tools
+      .map((tool) =>
+        tool.type === 'function' && 'function' in tool
+          ? tool.function.name
+          : undefined,
+      )
+      .filter((name): name is string => typeof name === 'string'),
+  );
+  if (!availableToolNames.has(converted.function.name)) {
+    throw new UserError(
+      `modelSettings.toolChoice="${converted.function.name}" does not match any available tool or handoff in Chat Completions mode.`,
+    );
+  }
+
+  return converted;
 }
 
 export function extractAllAssistantContent(
@@ -148,18 +190,36 @@ export function extractAllUserContent(
         ...rest,
       });
     } else if (c.type === 'audio') {
+      if (typeof c.audio !== 'string') {
+        throw new UserError(
+          `Chat Completions only supports inline audio data for input_audio: ${JSON.stringify(c)}`,
+        );
+      }
+      const inputAudioFormat =
+        c.format === 'wav' || c.format === 'mp3'
+          ? c.format
+          : c.providerData?.input_audio?.format === 'wav' ||
+              c.providerData?.input_audio?.format === 'mp3'
+            ? c.providerData.input_audio.format
+            : undefined;
+      if (!inputAudioFormat) {
+        throw new UserError(
+          `Chat Completions input_audio requires format "wav" or "mp3": ${JSON.stringify(c)}`,
+        );
+      }
       const rest = getProviderDataWithoutReservedKeys(c.providerData, [
         'type',
         'input_audio',
       ]);
       const inputAudio = getProviderDataWithoutReservedKeys(
         c.providerData?.input_audio,
-        ['data'],
+        ['data', 'format'],
       );
       out.push({
         type: 'input_audio',
         input_audio: {
-          data: c.audio as string,
+          data: c.audio,
+          format: inputAudioFormat,
           ...inputAudio,
         } as ChatCompletionContentPartInputAudio['input_audio'],
         ...rest,
@@ -320,7 +380,25 @@ export function itemsToMessages(
         'Computer use calls are not supported for chat completions. Got item: ' +
           JSON.stringify(item),
       );
+    } else if (
+      item.type === 'tool_search_call' ||
+      item.type === 'tool_search_output'
+    ) {
+      throw new UserError(
+        'Tool search items are not supported for chat completions. Please use the Responses API when replaying tool search history.',
+      );
     } else if (item.type === 'function_call') {
+      const hasQualifiedOrInvalidName =
+        typeof item.name === 'string' &&
+        !CHAT_COMPLETIONS_FUNCTION_NAME_PATTERN.test(item.name);
+      if (
+        hasQualifiedOrInvalidName ||
+        (typeof item.namespace === 'string' && item.namespace.trim().length > 0)
+      ) {
+        throw new UserError(
+          'Namespaced function call history is not supported for chat completions. Please use the Responses API when replaying namespaced tool calls.',
+        );
+      }
       const asst = ensureAssistantMessage();
       const toolCalls = asst.tool_calls ?? [];
       const funcCall = item;

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -1,6 +1,7 @@
 import {
   Model,
   Usage,
+  UserError,
   withGenerationSpan,
   resetCurrentSpan,
   createGenerationSpan,
@@ -26,7 +27,7 @@ import { Span } from '@openai/agents-core/dist/tracing/spans';
 import { GenerationSpanData } from '@openai/agents-core/dist/tracing/spans';
 import { convertChatCompletionsStreamToResponses } from './openaiChatCompletionsStreaming';
 import {
-  convertToolChoice,
+  getCompatibleToolChoice,
   toolToOpenAI,
   convertHandoffTool,
   itemsToMessages,
@@ -290,6 +291,21 @@ export class OpenAIChatCompletionsModel implements Model {
     const tools: OpenAI.Chat.Completions.ChatCompletionTool[] = [];
     if (request.tools) {
       for (const tool of request.tools) {
+        if (tool.type === 'function') {
+          if (
+            typeof tool.namespace === 'string' &&
+            tool.namespace.trim().length > 0
+          ) {
+            throw new UserError(
+              'Namespaced function tools created with toolNamespace() are only supported with the Responses API.',
+            );
+          }
+          if (tool.deferLoading === true) {
+            throw new UserError(
+              'Function tools with deferLoading: true are only supported with the Responses API.',
+            );
+          }
+        }
         tools.push(toolToOpenAI(tool));
       }
     }
@@ -349,7 +365,10 @@ export class OpenAIChatCompletionsModel implements Model {
       frequency_penalty: request.modelSettings.frequencyPenalty,
       presence_penalty: request.modelSettings.presencePenalty,
       max_tokens: request.modelSettings.maxTokens,
-      tool_choice: convertToolChoice(request.modelSettings.toolChoice),
+      tool_choice: getCompatibleToolChoice(
+        request.modelSettings.toolChoice,
+        tools,
+      ),
       parallel_tool_calls: parallelToolCalls,
       stream: stream ? true : false,
       stream_options: stream ? { include_usage: true } : undefined,

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -53,15 +53,24 @@ import {
   ImageGenerationStatus,
   WebSearchStatus,
 } from './tools';
-import { camelOrSnakeToSnakeCase } from './utils/providerData';
+import {
+  camelOrSnakeToSnakeCase,
+  getSnakeCasedProviderDataWithoutReservedKeys,
+} from './utils/providerData';
 import { ProviderData } from '@openai/agents-core/types';
-import { encodeUint8ArrayToBase64 } from '@openai/agents-core/utils';
+import {
+  encodeUint8ArrayToBase64,
+  getToolSearchExecution,
+  getToolSearchProviderCallId,
+} from '@openai/agents-core/utils';
 
 type ToolChoice =
   | ToolChoiceOptions
   | ToolChoiceTypes
-  // TOOD: remove this once the underlying ToolChoiceTypes include this
+  // TODO: remove this once the underlying ToolChoiceTypes include this.
   | { type: 'web_search' }
+  // TODO: remove this once the underlying ToolChoiceTypes include this.
+  | { type: 'tool_search' }
   | ToolChoiceFunction;
 
 type ResponsesCreateRequestSDKHeaders = ReturnType<
@@ -87,23 +96,7 @@ type EnsuredResponsesWebSocketConnection = {
 };
 
 type ResponseFunctionCallOutputListItem =
-  | {
-      type: 'input_text';
-      text: string;
-    }
-  | {
-      type: 'input_image';
-      image_url?: string | null;
-      file_id?: string | null;
-      detail?: 'low' | 'high' | 'auto' | null;
-    }
-  | {
-      type: 'input_file';
-      file_data?: string | null;
-      file_url?: string | null;
-      file_id?: string | null;
-      filename?: string | null;
-    };
+  OpenAI.Responses.ResponseFunctionCallOutputItemList[number];
 
 type ExtendedFunctionCallOutput = Omit<
   OpenAI.Responses.ResponseInputItem.FunctionCallOutput,
@@ -117,7 +110,106 @@ type ResponseOutputItemWithFunctionResult =
   | (OpenAI.Responses.ResponseFunctionToolCallOutputItem & {
       name?: string;
       function_name?: string;
-    });
+      namespace?: string;
+    })
+  | OpenAI.Responses.ResponseToolSearchCall
+  | OpenAI.Responses.ResponseToolSearchOutputItem;
+
+type OpenAIToolSearchOutputToolPayload = Record<string, any>;
+
+/**
+ * Tool search outputs are replayed through agents-core protocol items, which use camelCase
+ * field names, while the Responses API wire shape uses snake_case. Keep this codec even with
+ * first-class upstream types because the local protocol still normalizes these payloads.
+ */
+function toOpenAIToolSearchOutputToolPayload(
+  tool: OpenAIToolSearchOutputToolPayload,
+  _withinNamespace = false,
+): Record<string, any> {
+  if (!tool || typeof tool !== 'object' || Array.isArray(tool)) {
+    return tool as Record<string, any>;
+  }
+
+  if (tool.type === 'tool_reference' && typeof tool.functionName === 'string') {
+    return {
+      type: 'tool_reference',
+      function_name: tool.functionName,
+      ...(typeof tool.namespace === 'string'
+        ? { namespace: tool.namespace }
+        : {}),
+    };
+  }
+
+  if (tool.type === 'namespace' && Array.isArray(tool.tools)) {
+    return {
+      ...tool,
+      tools: tool.tools.map((entry: OpenAIToolSearchOutputToolPayload) =>
+        toOpenAIToolSearchOutputToolPayload(entry, true),
+      ),
+    };
+  }
+
+  if (tool.type === 'function') {
+    const { deferLoading, ...rest } = tool as Record<string, any>;
+    return {
+      ...rest,
+      ...(typeof deferLoading === 'boolean'
+        ? { defer_loading: deferLoading }
+        : {}),
+    };
+  }
+
+  return tool as Record<string, any>;
+}
+
+function fromOpenAIToolSearchOutputToolPayload(
+  tool: Record<string, any>,
+  _withinNamespace = false,
+): OpenAIToolSearchOutputToolPayload {
+  if (!tool || typeof tool !== 'object' || Array.isArray(tool)) {
+    return tool as OpenAIToolSearchOutputToolPayload;
+  }
+
+  if (
+    tool.type === 'tool_reference' &&
+    typeof tool.function_name === 'string'
+  ) {
+    return {
+      type: 'tool_reference',
+      functionName: tool.function_name,
+      ...(typeof tool.namespace === 'string'
+        ? { namespace: tool.namespace }
+        : {}),
+    };
+  }
+
+  if (tool.type === 'namespace' && Array.isArray(tool.tools)) {
+    return {
+      ...tool,
+      tools: tool.tools.map((entry: Record<string, any>) =>
+        fromOpenAIToolSearchOutputToolPayload(entry, true),
+      ),
+    };
+  }
+
+  if (tool.type === 'function') {
+    const { defer_loading, ...rest } = tool;
+    return {
+      ...rest,
+      ...(typeof defer_loading === 'boolean'
+        ? { deferLoading: defer_loading }
+        : {}),
+    };
+  }
+
+  return tool as OpenAIToolSearchOutputToolPayload;
+}
+
+type ResponseFunctionToolCallWithNamespace =
+  OpenAI.Responses.ResponseFunctionToolCall & {
+    namespace?: string;
+  };
+type ResponsesTool = OpenAI.Responses.Tool | Record<string, any>;
 
 type ResponseShellCallOutput =
   OpenAI.Responses.ResponseInputItem.ShellCallOutput;
@@ -135,6 +227,9 @@ type OpenAIShellEnvironment = NonNullable<
 type OpenAIShellNetworkPolicy =
   | OpenAI.Responses.ContainerNetworkPolicyAllowlist
   | OpenAI.Responses.ContainerNetworkPolicyDisabled;
+type OpenAINamespaceMemberTool =
+  OpenAI.Responses.NamespaceTool['tools'][number];
+type OpenAIToolSearchStatus = 'in_progress' | 'completed' | 'incomplete';
 type SerializedShellContainerAutoEnvironment = Extract<
   SerializedShellEnvironment,
   { type: 'container_auto' }
@@ -178,6 +273,237 @@ function getToolChoice(
   }
 
   return { type: 'function', name: toolChoice };
+}
+
+function normalizeToolSearchStatus(
+  status?: string,
+): OpenAIToolSearchStatus | null {
+  return status === 'in_progress' ||
+    status === 'completed' ||
+    status === 'incomplete'
+    ? status
+    : null;
+}
+
+function isToolChoiceAvailable(
+  toolChoice: ToolChoice,
+  tools: ResponsesTool[],
+): boolean {
+  if (toolChoice === 'auto' || toolChoice === 'none') {
+    return true;
+  }
+
+  if (toolChoice === 'required') {
+    return tools.length > 0;
+  }
+
+  if (toolChoice.type === 'function') {
+    return hasFunctionToolChoiceName(toolChoice.name, tools);
+  }
+
+  return tools.some((tool) => tool.type === toolChoice.type);
+}
+
+function hasFunctionToolChoiceName(
+  toolChoiceName: string,
+  tools: ResponsesTool[],
+  namespacePrefix?: string,
+): boolean {
+  return (
+    findFunctionToolChoice(toolChoiceName, tools, namespacePrefix) !== undefined
+  );
+}
+
+function findFunctionToolChoice(
+  toolChoiceName: string,
+  tools: ResponsesTool[],
+  namespacePrefix?: string,
+):
+  | (Extract<ResponsesTool, { type: 'function' }> & { name: string })
+  | undefined {
+  for (const tool of tools) {
+    if (isNamedFunctionTool(tool)) {
+      const qualifiedName = namespacePrefix
+        ? `${namespacePrefix}.${tool.name}`
+        : tool.name;
+      if (toolChoiceName === qualifiedName) {
+        return tool;
+      }
+      continue;
+    }
+
+    if (isNamespaceTool(tool)) {
+      const nestedNamespace = namespacePrefix
+        ? `${namespacePrefix}.${tool.name}`
+        : tool.name;
+      const matchedTool = findFunctionToolChoice(
+        toolChoiceName,
+        tool.tools,
+        nestedNamespace,
+      );
+      if (matchedTool) {
+        return matchedTool;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function collectAvailableToolChoiceNames(
+  tools: ResponsesTool[],
+  namespacePrefix?: string,
+): string[] {
+  const availableToolChoices: string[] = [];
+
+  for (const tool of tools) {
+    if (isNamedFunctionTool(tool)) {
+      availableToolChoices.push(
+        namespacePrefix ? `${namespacePrefix}.${tool.name}` : tool.name,
+      );
+      continue;
+    }
+
+    if (isNamespaceTool(tool)) {
+      const nestedNamespace = namespacePrefix
+        ? `${namespacePrefix}.${tool.name}`
+        : tool.name;
+      availableToolChoices.push(
+        ...collectAvailableToolChoiceNames(tool.tools, nestedNamespace),
+      );
+      continue;
+    }
+
+    availableToolChoices.push(tool.type);
+  }
+
+  return availableToolChoices;
+}
+
+function isNamedFunctionTool(
+  tool: ResponsesTool,
+): tool is Extract<ResponsesTool, { type: 'function' }> & { name: string } {
+  return (
+    tool.type === 'function' &&
+    typeof (tool as { name?: unknown }).name === 'string'
+  );
+}
+
+function isNamespaceTool(tool: ResponsesTool): tool is ResponsesTool & {
+  type: 'namespace';
+  name: string;
+  tools: ResponsesTool[];
+} {
+  const candidate = tool as { name?: unknown; tools?: unknown };
+  return (
+    tool.type === 'namespace' &&
+    typeof candidate.name === 'string' &&
+    Array.isArray(candidate.tools)
+  );
+}
+
+function getExtraBodyToolsForToolChoiceValidation(
+  extraBody: Record<string, unknown> | undefined,
+): ResponsesTool[] {
+  if (!extraBody || !Array.isArray(extraBody.tools)) {
+    return [];
+  }
+
+  return extraBody.tools as ResponsesTool[];
+}
+
+function assertSupportedToolChoice(
+  toolChoice: ToolChoice | undefined,
+  tools: ResponsesTool[],
+  options?: {
+    allowPromptSuppliedTools?: boolean;
+  },
+): void {
+  const allowPromptSuppliedTools = options?.allowPromptSuppliedTools === true;
+  if (
+    !toolChoice ||
+    toolChoice === 'auto' ||
+    toolChoice === 'required' ||
+    toolChoice === 'none' ||
+    toolChoice.type !== 'function'
+  ) {
+    return;
+  }
+
+  const matchedFunctionTool = findFunctionToolChoice(toolChoice.name, tools);
+
+  if (
+    !matchedFunctionTool &&
+    allowPromptSuppliedTools &&
+    toolChoice.name !== 'tool_search'
+  ) {
+    return;
+  }
+
+  if (
+    (matchedFunctionTool as { defer_loading?: unknown } | undefined)
+      ?.defer_loading === true
+  ) {
+    throw new UserError(
+      `modelSettings.toolChoice="${toolChoice.name}" cannot force a deferred function tool in Responses. Use "auto" so tool_search can load it.`,
+    );
+  }
+
+  if (
+    toolChoice.name === 'tool_search' &&
+    !hasFunctionToolChoiceName(toolChoice.name, tools)
+  ) {
+    throw new UserError(
+      'modelSettings.toolChoice="tool_search" is only supported for a custom function named "tool_search". Responses does not support forcing the built-in tool_search tool. Use "auto" instead.',
+    );
+  }
+}
+
+function getCompatibleToolChoice(
+  toolChoice: ToolChoice | undefined,
+  tools: ResponsesTool[],
+  options?: {
+    allowPromptSuppliedTools?: boolean;
+  },
+): ToolChoice | undefined {
+  const allowPromptSuppliedTools = options?.allowPromptSuppliedTools === true;
+  if (typeof toolChoice === 'undefined') {
+    return undefined;
+  }
+
+  if (isToolChoiceAvailable(toolChoice, tools) || allowPromptSuppliedTools) {
+    return toolChoice;
+  }
+
+  const availableToolChoices = [
+    ...new Set(collectAvailableToolChoiceNames(tools)),
+  ];
+  const availableToolChoicesMessage =
+    availableToolChoices.length > 0
+      ? ` Available tools: ${availableToolChoices.join(', ')}.`
+      : ' No tools are available in the outgoing Responses request.';
+
+  if (toolChoice === 'required') {
+    throw new UserError(
+      `modelSettings.toolChoice="required" requires at least one available tool in the outgoing Responses request.${availableToolChoicesMessage}`,
+    );
+  }
+
+  if (toolChoice === 'auto' || toolChoice === 'none') {
+    throw new Error(
+      `Unexpected unavailable tool choice: ${JSON.stringify(toolChoice)}`,
+    );
+  }
+
+  if (toolChoice.type === 'function') {
+    throw new UserError(
+      `modelSettings.toolChoice="${toolChoice.name}" does not match any available tool in the outgoing Responses request.${availableToolChoicesMessage}`,
+    );
+  }
+
+  throw new UserError(
+    `modelSettings.toolChoice="${toolChoice.type}" is unavailable in the outgoing Responses request.${availableToolChoicesMessage}`,
+  );
 }
 
 function getResponseFormat(
@@ -802,12 +1128,88 @@ function getTools<_TContext = unknown>(
   tools: SerializedTool[],
   handoffs: SerializedHandoff[],
 ): {
-  tools: OpenAI.Responses.Tool[];
+  tools: ResponsesTool[];
   include: OpenAI.Responses.ResponseIncludable[];
 } {
-  const openaiTools: OpenAI.Responses.Tool[] = [];
+  const openaiTools: ResponsesTool[] = [];
   const include: OpenAI.Responses.ResponseIncludable[] = [];
+  const namespaceStateByName = new Map<
+    string,
+    {
+      index: number;
+      description: string;
+      functionNames: Set<string>;
+      tools: OpenAINamespaceMemberTool[];
+    }
+  >();
+  let hasDeferredSearchableTool = false;
+  let hasToolSearch = false;
   for (const tool of tools) {
+    if (tool.type === 'function') {
+      const isDeferredFunction = tool.deferLoading === true;
+      hasDeferredSearchableTool ||= isDeferredFunction;
+
+      const namespaceName =
+        typeof tool.namespace === 'string' ? tool.namespace.trim() : '';
+      if (namespaceName.length > 0) {
+        const namespaceDescription =
+          typeof tool.namespaceDescription === 'string'
+            ? tool.namespaceDescription.trim()
+            : '';
+        if (namespaceDescription.length === 0) {
+          throw new UserError(
+            `All tools in namespace "${namespaceName}" must provide a non-empty description.`,
+          );
+        }
+
+        let namespaceState = namespaceStateByName.get(namespaceName);
+        if (!namespaceState) {
+          namespaceState = {
+            index: openaiTools.length,
+            description: namespaceDescription,
+            functionNames: new Set(),
+            tools: [],
+          };
+          namespaceStateByName.set(namespaceName, namespaceState);
+          openaiTools.push({});
+        } else if (namespaceState.description !== namespaceDescription) {
+          throw new UserError(
+            `All tools in namespace "${namespaceName}" must share the same description.`,
+          );
+        }
+
+        const { tool: openaiTool, include: openaiIncludes } = converTool(tool);
+        if (namespaceState.functionNames.has(tool.name)) {
+          throw new UserError(
+            `Namespace "${namespaceName}" cannot contain duplicate function tool name "${tool.name}".`,
+          );
+        }
+        namespaceState.functionNames.add(tool.name);
+        namespaceState.tools.push(openaiTool as OpenAINamespaceMemberTool);
+        if (openaiIncludes && openaiIncludes.length > 0) {
+          for (const item of openaiIncludes) {
+            include.push(item);
+          }
+        }
+        continue;
+      }
+    }
+
+    if (
+      tool.type === 'hosted_tool' &&
+      tool.providerData?.type === 'tool_search'
+    ) {
+      hasToolSearch = true;
+    }
+
+    if (
+      tool.type === 'hosted_tool' &&
+      tool.providerData?.type === 'mcp' &&
+      tool.providerData.defer_loading === true
+    ) {
+      hasDeferredSearchableTool = true;
+    }
+
     const { tool: openaiTool, include: openaiIncludes } = converTool(tool);
     openaiTools.push(openaiTool);
     if (openaiIncludes && openaiIncludes.length > 0) {
@@ -815,6 +1217,24 @@ function getTools<_TContext = unknown>(
         include.push(item);
       }
     }
+  }
+
+  if (hasDeferredSearchableTool && !hasToolSearch) {
+    throw new UserError(
+      'Deferred function tools and hosted MCP tools with deferLoading: true require toolSearchTool() in the same request.',
+    );
+  }
+
+  for (const [
+    namespaceName,
+    namespaceState,
+  ] of namespaceStateByName.entries()) {
+    openaiTools[namespaceState.index] = {
+      type: 'namespace',
+      name: namespaceName,
+      description: namespaceState.description,
+      tools: namespaceState.tools,
+    };
   }
 
   return {
@@ -826,18 +1246,22 @@ function getTools<_TContext = unknown>(
 function converTool<_TContext = unknown>(
   tool: SerializedTool,
 ): {
-  tool: OpenAI.Responses.Tool;
+  tool: ResponsesTool;
   include?: OpenAI.Responses.ResponseIncludable[];
 } {
   if (tool.type === 'function') {
+    const openaiTool: Record<string, any> = {
+      type: 'function',
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.parameters,
+      strict: tool.strict,
+    };
+    if (tool.deferLoading) {
+      openaiTool.defer_loading = true;
+    }
     return {
-      tool: {
-        type: 'function',
-        name: tool.name,
-        description: tool.description,
-        parameters: tool.parameters,
-        strict: tool.strict,
-      },
+      tool: openaiTool,
       include: undefined,
     };
   } else if (tool.type === 'computer') {
@@ -911,6 +1335,16 @@ function converTool<_TContext = unknown>(
         },
         include: undefined,
       };
+    } else if (tool.providerData?.type === 'tool_search') {
+      return {
+        tool: {
+          type: 'tool_search',
+          execution: tool.providerData.execution,
+          description: tool.providerData.description,
+          parameters: tool.providerData.parameters,
+        },
+        include: undefined,
+      };
     } else if (tool.providerData?.type === 'image_generation') {
       return {
         tool: {
@@ -929,19 +1363,24 @@ function converTool<_TContext = unknown>(
         include: undefined,
       };
     } else if (tool.providerData?.type === 'mcp') {
+      const openaiTool: Record<string, any> = {
+        type: 'mcp',
+        server_label: tool.providerData.server_label,
+        server_url: tool.providerData.server_url,
+        connector_id: tool.providerData.connector_id,
+        authorization: tool.providerData.authorization,
+        allowed_tools: tool.providerData.allowed_tools,
+        headers: tool.providerData.headers,
+        require_approval: convertMCPRequireApproval(
+          tool.providerData.require_approval,
+        ),
+        server_description: tool.providerData.server_description,
+      };
+      if (tool.providerData.defer_loading === true) {
+        openaiTool.defer_loading = true;
+      }
       return {
-        tool: {
-          type: 'mcp',
-          server_label: tool.providerData.server_label,
-          server_url: tool.providerData.server_url,
-          connector_id: tool.providerData.connector_id,
-          authorization: tool.providerData.authorization,
-          allowed_tools: tool.providerData.allowed_tools,
-          headers: tool.providerData.headers,
-          require_approval: convertMCPRequireApproval(
-            tool.providerData.require_approval,
-          ),
-        },
+        tool: openaiTool as OpenAI.Responses.Tool.Mcp,
         include: undefined,
       };
     } else if (tool.providerData) {
@@ -989,7 +1428,10 @@ function getInputMessageContent(
     return {
       type: 'input_text',
       text: entry.text,
-      ...camelOrSnakeToSnakeCase(entry.providerData),
+      ...getSnakeCasedProviderDataWithoutReservedKeys(entry.providerData, [
+        'type',
+        'text',
+      ]),
     };
   } else if (entry.type === 'input_image') {
     const imageEntry: OpenAI.Responses.ResponseInputImage = {
@@ -1007,7 +1449,12 @@ function getInputMessageContent(
     }
     return {
       ...imageEntry,
-      ...camelOrSnakeToSnakeCase(entry.providerData),
+      ...getSnakeCasedProviderDataWithoutReservedKeys(entry.providerData, [
+        'type',
+        'detail',
+        'image_url',
+        'file_id',
+      ]),
     };
   } else if (entry.type === 'input_file') {
     const fileEntry: OpenAI.Responses.ResponseInputFile = {
@@ -1054,7 +1501,13 @@ function getInputMessageContent(
     }
     return {
       ...fileEntry,
-      ...camelOrSnakeToSnakeCase(entry.providerData),
+      ...getSnakeCasedProviderDataWithoutReservedKeys(entry.providerData, [
+        'type',
+        'file_data',
+        'file_url',
+        'file_id',
+        'filename',
+      ]),
     };
   }
 
@@ -1063,15 +1516,46 @@ function getInputMessageContent(
   );
 }
 
+function getProviderDataField<T>(
+  providerData: unknown,
+  keys: readonly string[],
+): T | undefined {
+  if (
+    !providerData ||
+    typeof providerData !== 'object' ||
+    Array.isArray(providerData)
+  ) {
+    return undefined;
+  }
+
+  const record = providerData as Record<string, unknown>;
+  for (const key of keys) {
+    if (typeof record[key] !== 'undefined') {
+      return record[key] as T;
+    }
+  }
+
+  return undefined;
+}
+
 function getOutputMessageContent(
   entry: protocol.AssistantContent,
 ): OpenAI.Responses.ResponseOutputMessage['content'][number] {
   if (entry.type === 'output_text') {
+    const annotations = getProviderDataField<
+      OpenAI.Responses.ResponseOutputText['annotations']
+    >(entry.providerData, ['annotations']);
+    const normalizedAnnotations: OpenAI.Responses.ResponseOutputText['annotations'] =
+      Array.isArray(annotations) ? annotations : [];
     return {
       type: 'output_text',
       text: entry.text,
-      annotations: [],
-      ...camelOrSnakeToSnakeCase(entry.providerData),
+      annotations: normalizedAnnotations,
+      ...getSnakeCasedProviderDataWithoutReservedKeys(entry.providerData, [
+        'type',
+        'text',
+        'annotations',
+      ]),
     };
   }
 
@@ -1079,7 +1563,10 @@ function getOutputMessageContent(
     return {
       type: 'refusal',
       refusal: entry.refusal,
-      ...camelOrSnakeToSnakeCase(entry.providerData),
+      ...getSnakeCasedProviderDataWithoutReservedKeys(entry.providerData, [
+        'type',
+        'refusal',
+      ]),
     };
   }
 
@@ -1099,7 +1586,11 @@ function getMessageItem(
       id: item.id,
       role: 'system',
       content: item.content,
-      ...camelOrSnakeToSnakeCase(item.providerData),
+      ...getSnakeCasedProviderDataWithoutReservedKeys(item.providerData, [
+        'id',
+        'role',
+        'content',
+      ]),
     };
   }
 
@@ -1109,7 +1600,11 @@ function getMessageItem(
         id: item.id,
         role: 'user',
         content: item.content,
-        ...camelOrSnakeToSnakeCase(item.providerData),
+        ...getSnakeCasedProviderDataWithoutReservedKeys(item.providerData, [
+          'id',
+          'role',
+          'content',
+        ]),
       };
     }
 
@@ -1117,7 +1612,11 @@ function getMessageItem(
       id: item.id,
       role: 'user',
       content: item.content.map(getInputMessageContent),
-      ...camelOrSnakeToSnakeCase(item.providerData),
+      ...getSnakeCasedProviderDataWithoutReservedKeys(item.providerData, [
+        'id',
+        'role',
+        'content',
+      ]),
     };
   }
 
@@ -1128,7 +1627,13 @@ function getMessageItem(
       role: 'assistant',
       content: item.content.map(getOutputMessageContent),
       status: item.status,
-      ...camelOrSnakeToSnakeCase(item.providerData),
+      ...getSnakeCasedProviderDataWithoutReservedKeys(item.providerData, [
+        'type',
+        'id',
+        'role',
+        'content',
+        'status',
+      ]),
     };
     return assistantMessage;
   }
@@ -1193,15 +1698,81 @@ function getInputItems(
       return getMessageItem(item);
     }
 
+    if (item.type === 'tool_search_call') {
+      const status = normalizeToolSearchStatus(item.status);
+      const callId = getToolSearchProviderCallId(item);
+      const execution = getToolSearchExecution(item);
+      const toolSearchCall: OpenAI.Responses.ResponseInputItem.ToolSearchCall =
+        {
+          type: 'tool_search_call',
+          id: item.id,
+          ...(status !== null ? { status } : {}),
+          arguments: item.arguments,
+          ...(callId ? { call_id: callId } : {}),
+          ...(execution ? { execution } : {}),
+          ...getSnakeCasedProviderDataWithoutReservedKeys(item.providerData, [
+            'type',
+            'id',
+            'status',
+            'arguments',
+            'call_id',
+            'callId',
+            'execution',
+          ]),
+        };
+      return toolSearchCall;
+    }
+
+    if (item.type === 'tool_search_output') {
+      const status = normalizeToolSearchStatus(item.status);
+      const callId = getToolSearchProviderCallId(item);
+      const execution = getToolSearchExecution(item);
+      const toolSearchOutput: OpenAI.Responses.ResponseToolSearchOutputItemParam =
+        {
+          type: 'tool_search_output',
+          id: item.id,
+          ...(status !== null ? { status } : {}),
+          tools: item.tools.map(
+            (tool) =>
+              toOpenAIToolSearchOutputToolPayload(
+                tool,
+              ) as OpenAI.Responses.Tool,
+          ),
+          ...(callId ? { call_id: callId } : {}),
+          ...(execution ? { execution } : {}),
+          ...getSnakeCasedProviderDataWithoutReservedKeys(item.providerData, [
+            'type',
+            'id',
+            'status',
+            'tools',
+            'call_id',
+            'callId',
+            'execution',
+          ]),
+        };
+      return toolSearchOutput;
+    }
+
     if (item.type === 'function_call') {
-      const entry: OpenAI.Responses.ResponseFunctionToolCall = {
+      const entry: ResponseFunctionToolCallWithNamespace = {
         id: item.id,
         type: 'function_call',
         name: item.name,
         call_id: item.callId,
         arguments: item.arguments,
         status: item.status,
-        ...camelOrSnakeToSnakeCase(item.providerData),
+        ...(typeof item.namespace === 'string'
+          ? { namespace: item.namespace }
+          : {}),
+        ...getSnakeCasedProviderDataWithoutReservedKeys(item.providerData, [
+          'id',
+          'type',
+          'name',
+          'call_id',
+          'arguments',
+          'status',
+          'namespace',
+        ]),
       };
 
       return entry;
@@ -1218,49 +1789,97 @@ function getInputItems(
         call_id: item.callId,
         output: normalizedOutput,
         status: item.status,
-        ...camelOrSnakeToSnakeCase(item.providerData),
+        ...getSnakeCasedProviderDataWithoutReservedKeys(item.providerData, [
+          'type',
+          'id',
+          'call_id',
+          'output',
+          'status',
+          'namespace',
+        ]),
       };
       return entry as unknown as OpenAI.Responses.ResponseInputItem.FunctionCallOutput;
     }
 
     if (item.type === 'reasoning') {
+      const encryptedContent = getProviderDataField<string>(item.providerData, [
+        'encryptedContent',
+        'encrypted_content',
+      ]);
       const entry: OpenAI.Responses.ResponseReasoningItem = {
         id: item.id!,
         type: 'reasoning',
         summary: item.content.map((content) => ({
           type: 'summary_text',
           text: content.text,
-          ...camelOrSnakeToSnakeCase(content.providerData),
+          ...getSnakeCasedProviderDataWithoutReservedKeys(
+            content.providerData,
+            ['type', 'text'],
+          ),
         })),
-        encrypted_content: item.providerData?.encryptedContent,
-        ...camelOrSnakeToSnakeCase(item.providerData),
+        ...(typeof encryptedContent === 'string'
+          ? { encrypted_content: encryptedContent }
+          : {}),
+        ...getSnakeCasedProviderDataWithoutReservedKeys(item.providerData, [
+          'id',
+          'type',
+          'summary',
+          'encrypted_content',
+        ]),
       };
       return entry;
     }
 
     if (item.type === 'computer_call') {
+      const pendingSafetyChecks = getProviderDataField<
+        OpenAI.Responses.ResponseComputerToolCall['pending_safety_checks']
+      >(item.providerData, ['pendingSafetyChecks', 'pending_safety_checks']);
+      const normalizedPendingSafetyChecks: OpenAI.Responses.ResponseComputerToolCall['pending_safety_checks'] =
+        Array.isArray(pendingSafetyChecks) ? pendingSafetyChecks : [];
       const entry: OpenAI.Responses.ResponseComputerToolCall = {
         type: 'computer_call',
         call_id: item.callId,
         id: item.id!,
         action: item.action,
         status: item.status,
-        pending_safety_checks: [],
-        ...camelOrSnakeToSnakeCase(item.providerData),
+        pending_safety_checks: normalizedPendingSafetyChecks,
+        ...getSnakeCasedProviderDataWithoutReservedKeys(item.providerData, [
+          'type',
+          'call_id',
+          'id',
+          'action',
+          'status',
+          'pending_safety_checks',
+        ]),
       };
 
       return entry;
     }
 
     if (item.type === 'computer_call_result') {
+      const acknowledgedSafetyChecks = getProviderDataField<
+        OpenAI.Responses.ResponseInputItem.ComputerCallOutput['acknowledged_safety_checks']
+      >(item.providerData, [
+        'acknowledgedSafetyChecks',
+        'acknowledged_safety_checks',
+      ]);
       const entry: OpenAI.Responses.ResponseInputItem.ComputerCallOutput = {
         type: 'computer_call_output',
         id: item.id,
         call_id: item.callId,
         output: buildResponseOutput(item),
         status: item.providerData?.status,
-        acknowledged_safety_checks: item.providerData?.acknowledgedSafetyChecks,
-        ...camelOrSnakeToSnakeCase(item.providerData),
+        acknowledged_safety_checks: Array.isArray(acknowledgedSafetyChecks)
+          ? acknowledgedSafetyChecks
+          : [],
+        ...getSnakeCasedProviderDataWithoutReservedKeys(item.providerData, [
+          'type',
+          'id',
+          'call_id',
+          'output',
+          'status',
+          'acknowledged_safety_checks',
+        ]),
       };
       return entry;
     }
@@ -1571,6 +2190,43 @@ function convertToOutputItem(
         status,
         providerData,
       };
+    } else if (item.type === 'tool_search_call') {
+      const {
+        id,
+        type: _type,
+        status,
+        arguments: args,
+        ...providerData
+      } = item as OpenAI.Responses.ResponseToolSearchCall & Record<string, any>;
+      const output: protocol.ToolSearchCallItem = {
+        type: 'tool_search_call',
+        id,
+        status,
+        arguments: args,
+        providerData,
+      };
+      return output;
+    } else if (item.type === 'tool_search_output') {
+      const {
+        id,
+        type: _type,
+        status,
+        tools,
+        ...providerData
+      } = item as OpenAI.Responses.ResponseToolSearchOutputItem &
+        Record<string, any>;
+      const output: protocol.ToolSearchOutputItem = {
+        type: 'tool_search_output',
+        id,
+        status,
+        tools: Array.isArray(tools)
+          ? (tools.map((tool) =>
+              fromOpenAIToolSearchOutputToolPayload(tool),
+            ) as any)
+          : [],
+        providerData,
+      };
+      return output;
     } else if (
       item.type === 'file_search_call' ||
       item.type === 'web_search_call' ||
@@ -1594,12 +2250,21 @@ function convertToOutputItem(
       };
       return output;
     } else if (item.type === 'function_call') {
-      const { call_id, name, status, arguments: args, ...providerData } = item;
+      const functionCall = item as ResponseFunctionToolCallWithNamespace;
+      const {
+        call_id,
+        name,
+        namespace,
+        status,
+        arguments: args,
+        ...providerData
+      } = functionCall;
       const output: protocol.FunctionCallItem = {
         type: 'function_call',
-        id: item.id!,
+        id: functionCall.id!,
         callId: call_id,
         name,
+        ...(typeof namespace === 'string' ? { namespace } : {}),
         status,
         arguments: args,
         providerData,
@@ -1612,16 +2277,19 @@ function convertToOutputItem(
         output: rawOutput,
         name: toolName,
         function_name: functionName,
+        namespace,
         ...providerData
       } = item as OpenAI.Responses.ResponseFunctionToolCallOutputItem & {
         name?: string;
         function_name?: string;
+        namespace?: string;
       };
       const output: protocol.FunctionCallResultItem = {
         type: 'function_call_result',
         id: item.id,
         callId: call_id,
         name: toolName ?? functionName ?? call_id,
+        ...(typeof namespace === 'string' ? { namespace } : {}),
         status: status ?? 'completed',
         output: convertFunctionCallOutputToProtocol(rawOutput),
         providerData,
@@ -1629,12 +2297,18 @@ function convertToOutputItem(
       return output;
     } else if (item.type === 'computer_call') {
       const { call_id, status, action, ...providerData } = item;
+      const resolvedAction = action ?? item.actions?.[0];
+      if (!resolvedAction) {
+        throw new UserError(
+          `Unsupported computer call item without an action: ${JSON.stringify(item)}`,
+        );
+      }
       const output: protocol.ComputerUseCallItem = {
         type: 'computer_call',
         id: item.id!,
         callId: call_id,
         status,
-        action,
+        action: resolvedAction,
         providerData,
       };
       return output;
@@ -1992,6 +2666,16 @@ export class OpenAIResponsesModel implements Model {
       providerData: providerDataWithoutTransport,
       overrides: transportOverrides,
     } = splitResponsesTransportOverrides(request.modelSettings.providerData);
+    const toolChoiceValidationTools = [
+      ...tools,
+      ...getExtraBodyToolsForToolChoiceValidation(transportOverrides.extraBody),
+    ];
+    const allowPromptSuppliedTools =
+      Boolean(request.prompt) &&
+      !(request.toolsExplicitlyProvided === true && tools.length === 0);
+    assertSupportedToolChoice(toolChoice, toolChoiceValidationTools, {
+      allowPromptSuppliedTools,
+    });
     const { text, ...restOfProviderData } = providerDataWithoutTransport;
 
     if (request.modelSettings.reasoning) {
@@ -2012,10 +2696,6 @@ export class OpenAIResponsesModel implements Model {
 
     let parallelToolCalls: boolean | undefined = undefined;
     if (typeof request.modelSettings.parallelToolCalls === 'boolean') {
-      if (request.modelSettings.parallelToolCalls && tools.length === 0) {
-        throw new Error('Parallel tool calls are not supported without tools');
-      }
-
       parallelToolCalls = request.modelSettings.parallelToolCalls;
     }
 
@@ -2028,10 +2708,14 @@ export class OpenAIResponsesModel implements Model {
       tools.length > 0 ||
       request.toolsExplicitlyProvided === true ||
       !request.prompt;
-    const shouldOmitToolChoice =
-      Boolean(request.prompt) &&
-      !shouldSendTools &&
-      typeof toolChoice === 'object';
+    const compatibleToolChoice = getCompatibleToolChoice(
+      toolChoice,
+      toolChoiceValidationTools,
+      {
+        allowPromptSuppliedTools,
+      },
+    );
+    const shouldOmitToolChoice = typeof compatibleToolChoice === 'undefined';
 
     let requestData = {
       ...(shouldSendModel ? { model: this._model } : {}),
@@ -2051,7 +2735,7 @@ export class OpenAIResponsesModel implements Model {
       truncation: request.modelSettings.truncation,
       max_output_tokens: request.modelSettings.maxTokens,
       ...(!shouldOmitToolChoice
-        ? { tool_choice: toolChoice as ToolChoiceOptions }
+        ? { tool_choice: compatibleToolChoice as ToolChoiceOptions }
         : {}),
       parallel_tool_calls: parallelToolCalls,
       stream,

--- a/packages/agents-openai/src/tools.ts
+++ b/packages/agents-openai/src/tools.ts
@@ -1,4 +1,9 @@
-import { HostedTool } from '@openai/agents-core';
+import {
+  attachClientToolSearchExecutor,
+  HostedTool,
+  type ClientToolSearchExecutor,
+  UserError,
+} from '@openai/agents-core';
 import type OpenAI from 'openai';
 import { z } from 'zod';
 import * as ProviderData from './types/providerData';
@@ -141,6 +146,15 @@ export type CodeInterpreterTool = {
     | OpenAI.Responses.Tool.CodeInterpreter.CodeInterpreterToolAuto;
 };
 
+export type ToolSearchTool<Context = unknown> = {
+  type: 'tool_search';
+  name?: 'tool_search';
+  execution?: OpenAI.Responses.ToolSearchTool['execution'];
+  description?: string | null;
+  parameters?: unknown | null;
+  execute?: ClientToolSearchExecutor<Context>;
+};
+
 /**
  * Adds code interpreter abilities to your agent
  * @param options Additional configuration for the code interpreter
@@ -159,6 +173,53 @@ export function codeInterpreterTool(
     name: options.name ?? 'code_interpreter',
     providerData,
   };
+}
+
+/**
+ * Adds tool_search capabilities to your agent.
+ *
+ * This lets the model search deferred function tools and load them into context on demand.
+ * By default, tool search is executed by OpenAI. Set `execution: 'client'` to
+ * use a custom loop that receives `tool_search_call` / `tool_search_output`
+ * items. The standard runner only supports the default built-in client schema
+ * (leave `parameters` unset) and auto-executes `{ paths: string[] }` searches
+ * over deferred top-level function tools and deferred namespace members.
+ *
+ * @returns a hosted tool_search definition.
+ */
+export function toolSearchTool<Context = unknown>(
+  options: Partial<Omit<ToolSearchTool<Context>, 'type'>> = {},
+): HostedTool {
+  if (typeof options.name === 'string' && options.name !== 'tool_search') {
+    throw new UserError(
+      'toolSearchTool() only supports the canonical built-in name "tool_search".',
+    );
+  }
+
+  if (typeof options.execute === 'function' && options.execution !== 'client') {
+    throw new UserError(
+      'toolSearchTool() only supports execute when execution is "client".',
+    );
+  }
+
+  const providerData: ProviderData.ToolSearchTool = {
+    type: 'tool_search',
+    name: 'tool_search',
+    execution: options.execution,
+    description: options.description,
+    parameters: options.parameters,
+  };
+  const hostedTool: HostedTool = {
+    type: 'hosted_tool',
+    name: 'tool_search',
+    providerData,
+  };
+
+  if (typeof options.execute === 'function') {
+    attachClientToolSearchExecutor(hostedTool, options.execute);
+  }
+
+  return hostedTool;
 }
 
 /**

--- a/packages/agents-openai/src/types/providerData.ts
+++ b/packages/agents-openai/src/types/providerData.ts
@@ -19,6 +19,11 @@ export type CodeInterpreterTool = Omit<
   name: 'code_interpreter' | (string & {});
 };
 
+export type ToolSearchTool = Omit<OpenAI.Responses.ToolSearchTool, 'type'> & {
+  type: 'tool_search';
+  name: 'tool_search';
+};
+
 export type ImageGenerationTool = Omit<
   OpenAI.Responses.Tool.ImageGeneration,
   | 'type'

--- a/packages/agents-openai/src/utils/providerData.ts
+++ b/packages/agents-openai/src/utils/providerData.ts
@@ -1,27 +1,103 @@
+type UnknownRecord = Record<string, unknown>;
+
+type SnakeCaseKey<S extends string> = S extends `${infer Head}${infer Tail}`
+  ? `${Head extends Lowercase<Head> ? Head : `_${Lowercase<Head>}`}${SnakeCaseKey<Tail>}`
+  : S;
+
+type CamelCaseKey<S extends string> = S extends `${infer Head}_${infer Tail}`
+  ? `${Head}${Capitalize<CamelCaseKey<Tail>>}`
+  : S;
+
+type SnakeCased<T> = T extends readonly unknown[]
+  ? T
+  : T extends UnknownRecord
+    ? {
+        [K in keyof T as K extends string ? SnakeCaseKey<K> : K]: SnakeCased<
+          T[K]
+        >;
+      }
+    : T;
+
+type CamelCased<T> = T extends readonly unknown[]
+  ? {
+      [K in keyof T]: CamelCased<T[K]>;
+    }
+  : T extends UnknownRecord
+    ? {
+        [K in keyof T as K extends string ? CamelCaseKey<K> : K]: CamelCased<
+          T[K]
+        >;
+      }
+    : T;
+
 /**
- * Converts camelCase or snake_case keys of an object to snake_case recursively.
+ * Converts object keys to snake_case recursively while preserving array entries as-is.
  */
-export function camelOrSnakeToSnakeCase<
-  T extends Record<string, any> | undefined,
->(providerData: T | undefined): Record<string, any> | undefined {
-  if (
-    !providerData ||
-    typeof providerData !== 'object' ||
-    Array.isArray(providerData)
-  ) {
-    return providerData;
+export function camelOrSnakeToSnakeCase<T>(value: T): SnakeCased<T> {
+  if (Array.isArray(value)) {
+    return value.slice() as SnakeCased<T>;
   }
 
-  const result: Record<string, any> = {};
-  for (const [key, value] of Object.entries(providerData)) {
-    const snakeKey = key.replace(/([A-Z])/g, '_$1').toLowerCase();
-    result[snakeKey] = camelOrSnakeToSnakeCase(value);
+  if (!isRecord(value)) {
+    return value as SnakeCased<T>;
   }
-  return result;
+
+  const result: UnknownRecord = {};
+  for (const [key, entry] of Object.entries(value)) {
+    const snakeKey = key.replace(/([A-Z])/g, '_$1').toLowerCase();
+    result[snakeKey] = camelOrSnakeToSnakeCase(entry);
+  }
+  return result as SnakeCased<T>;
 }
 
-function isRecord(value: unknown): value is Record<string, any> {
+/**
+ * Converts snake_case or camelCase keys of a JSON-like value to camelCase recursively.
+ */
+export function snakeOrCamelToCamelCase<T>(value: T): CamelCased<T> {
+  if (Array.isArray(value)) {
+    return value.map((entry) =>
+      snakeOrCamelToCamelCase(entry),
+    ) as CamelCased<T>;
+  }
+
+  if (!isRecord(value)) {
+    return value as CamelCased<T>;
+  }
+
+  const result: UnknownRecord = {};
+  for (const [key, entry] of Object.entries(value)) {
+    const camelKey = key.replace(/_([a-z])/g, (_match, char: string) =>
+      char.toUpperCase(),
+    );
+    result[camelKey] = snakeOrCamelToCamelCase(entry);
+  }
+  return result as CamelCased<T>;
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function toSnakeCase(key: string): string {
+  return key.replace(/([A-Z])/g, '_$1').toLowerCase();
+}
+
+function omitReservedKeys(
+  value: unknown,
+  reservedKeys: ReadonlySet<string>,
+): UnknownRecord {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  const result: UnknownRecord = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (reservedKeys.has(key)) {
+      continue;
+    }
+    result[key] = entry;
+  }
+  return result;
 }
 
 /**
@@ -30,18 +106,19 @@ function isRecord(value: unknown): value is Record<string, any> {
 export function getProviderDataWithoutReservedKeys(
   value: unknown,
   reservedKeys: readonly string[],
-): Record<string, any> {
-  if (!isRecord(value)) {
-    return {};
-  }
+): UnknownRecord {
+  return omitReservedKeys(value, new Set(reservedKeys));
+}
 
-  const reserved = new Set(reservedKeys);
-  const result: Record<string, any> = {};
-  for (const [key, entry] of Object.entries(value)) {
-    if (reserved.has(key)) {
-      continue;
-    }
-    result[key] = entry;
-  }
-  return result;
+/**
+ * Normalizes providerData keys to snake_case, then removes reserved top-level keys.
+ */
+export function getSnakeCasedProviderDataWithoutReservedKeys(
+  value: unknown,
+  reservedKeys: readonly string[],
+): UnknownRecord {
+  return omitReservedKeys(
+    camelOrSnakeToSnakeCase(value),
+    new Set(reservedKeys.map((key) => toSnakeCase(key))),
+  );
 }

--- a/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
@@ -3,6 +3,7 @@ import {
   convertToolChoice,
   extractAllAssistantContent,
   extractAllUserContent,
+  getCompatibleToolChoice,
   itemsToMessages,
   toolToOpenAI,
   convertHandoffTool,
@@ -57,6 +58,24 @@ describe('convertToolChoice', () => {
       function: { name: 'myFunc' },
     });
   });
+
+  test('getCompatibleToolChoice rejects impossible choices', () => {
+    expect(() => getCompatibleToolChoice('required', [])).toThrow(
+      /requires at least one available tool/,
+    );
+    expect(() =>
+      getCompatibleToolChoice('missing', [
+        {
+          type: 'function',
+          function: {
+            name: 'available',
+            description: 'Available tool',
+            parameters: { type: 'object', properties: {}, required: [] },
+          },
+        },
+      ]),
+    ).toThrow(/does not match any available tool or handoff/);
+  });
 });
 
 describe('content extraction helpers', () => {
@@ -71,14 +90,68 @@ describe('content extraction helpers', () => {
       {
         type: 'audio',
         audio: 'abc',
-        providerData: { input_audio: { foo: 'bar' } },
+        providerData: { input_audio: { format: 'mp3', foo: 'bar' } },
       },
     ];
     const converted = extractAllUserContent(userContent);
     expect(converted).toEqual([
       { type: 'text', text: 'u1', a: 1 },
       { type: 'image_url', image_url: { url: 'http://img', detail: 'auto' } },
-      { type: 'input_audio', input_audio: { data: 'abc', foo: 'bar' } },
+      {
+        type: 'input_audio',
+        input_audio: { data: 'abc', format: 'mp3', foo: 'bar' },
+      },
+    ]);
+  });
+
+  test('extractAllUserContent preserves extras but ignores reserved providerData fields', () => {
+    const userContent: protocol.UserMessageItem['content'] = [
+      {
+        type: 'input_text',
+        text: 'u1',
+        providerData: {
+          type: 'override_type',
+          text: 'override_text',
+          extraText: true,
+        },
+      },
+      {
+        type: 'input_image',
+        image: 'http://img',
+        providerData: {
+          type: 'override_image',
+          image_url: { url: 'http://override', detail: 'high' },
+          extraImage: true,
+        },
+      },
+      {
+        type: 'audio',
+        audio: 'abc',
+        format: 'wav',
+        providerData: {
+          type: 'override_audio',
+          input_audio: { data: 'override', format: 'mp3', foo: 'bar' },
+          extraAudio: true,
+        },
+      },
+    ];
+
+    expect(extractAllUserContent(userContent)).toEqual([
+      {
+        type: 'text',
+        text: 'u1',
+        extraText: true,
+      },
+      {
+        type: 'image_url',
+        image_url: { url: 'http://img', detail: 'high' },
+        extraImage: true,
+      },
+      {
+        type: 'input_audio',
+        input_audio: { data: 'abc', format: 'wav', foo: 'bar' },
+        extraAudio: true,
+      },
     ]);
   });
 
@@ -107,7 +180,7 @@ describe('content extraction helpers', () => {
         audio: 'abc',
         providerData: {
           type: 'override_audio',
-          input_audio: { data: 'override', foo: 'bar' },
+          input_audio: { data: 'override', format: 'wav', foo: 'bar' },
           extraAudio: true,
         },
       },
@@ -126,7 +199,7 @@ describe('content extraction helpers', () => {
       },
       {
         type: 'input_audio',
-        input_audio: { data: 'abc', foo: 'bar' },
+        input_audio: { data: 'abc', format: 'wav', foo: 'bar' },
         extraAudio: true,
       },
     ]);
@@ -196,6 +269,30 @@ describe('content extraction helpers', () => {
     ];
     expect(() => extractAllUserContent(userContent)).toThrow(
       /requires a data URL or file ID/,
+    );
+  });
+
+  test('extractAllUserContent throws on audio file IDs', () => {
+    const userContent: protocol.UserMessageItem['content'] = [
+      {
+        type: 'audio',
+        audio: { id: 'file-audio' },
+      },
+    ];
+    expect(() => extractAllUserContent(userContent)).toThrow(
+      /only supports inline audio data/i,
+    );
+  });
+
+  test('extractAllUserContent throws when audio format is missing', () => {
+    const userContent: protocol.UserMessageItem['content'] = [
+      {
+        type: 'audio',
+        audio: 'abc',
+      },
+    ];
+    expect(() => extractAllUserContent(userContent)).toThrow(
+      /requires format "wav" or "mp3"/i,
     );
   });
 
@@ -358,6 +455,64 @@ describe('itemsToMessages', () => {
       },
       { role: 'tool', tool_call_id: 'call1', content: 'res' },
     ]);
+  });
+
+  test('rejects namespaced function call history', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call',
+        id: '1',
+        callId: 'call1',
+        name: 'lookup_account',
+        namespace: 'crm',
+        arguments: '{}',
+        status: 'in_progress',
+      } as protocol.FunctionCallItem,
+    ];
+
+    expect(() => itemsToMessages(items)).toThrow(
+      /Namespaced function call history is not supported for chat completions/,
+    );
+  });
+
+  test('rejects dotted function call names without namespace metadata', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call',
+        id: '1',
+        callId: 'call1',
+        name: 'crm.lookup_account',
+        arguments: '{}',
+        status: 'in_progress',
+      } as protocol.FunctionCallItem,
+    ];
+
+    expect(() => itemsToMessages(items)).toThrow(
+      /Namespaced function call history is not supported for chat completions/,
+    );
+  });
+
+  test('rejects self-namespaced function call history', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call',
+        id: '1',
+        callId: 'call1',
+        name: 'get_shipping_eta',
+        namespace: 'get_shipping_eta',
+        arguments: '{}',
+        status: 'completed',
+      } as protocol.FunctionCallItem,
+      {
+        type: 'function_call_result',
+        callId: 'call1',
+        output: 'tomorrow',
+      } as protocol.FunctionCallResultItem,
+    ];
+
+    expect(() => itemsToMessages(items)).toThrow(
+      /Namespaced function call history is not supported for chat completions/,
+    );
   });
 
   test('handles built-in file_search_call and errors on unsupported type', () => {

--- a/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
@@ -395,6 +395,114 @@ describe('OpenAIChatCompletionsModel', () => {
     ]);
   });
 
+  it('rejects namespaced function tools before sending a request', async () => {
+    const client = new FakeClient();
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const req: any = {
+      input: 'u',
+      modelSettings: {},
+      tools: [
+        {
+          type: 'function',
+          name: 'lookup_account',
+          description: 'Look up CRM accounts.',
+          parameters: { type: 'object', properties: {}, required: [] },
+          strict: true,
+          namespace: 'crm',
+          namespaceDescription: 'CRM tools',
+        },
+        {
+          type: 'function',
+          name: 'lookup_account',
+          description: 'Look up billing accounts.',
+          parameters: { type: 'object', properties: {}, required: [] },
+          strict: true,
+          namespace: 'billing',
+          namespaceDescription: 'Billing tools',
+        },
+      ],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+    };
+
+    await expect(withTrace('t', () => model.getResponse(req))).rejects.toThrow(
+      'Namespaced function tools created with toolNamespace() are only supported with the Responses API.',
+    );
+    expect(client.chat.completions.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects deferred function tools before sending a request', async () => {
+    const client = new FakeClient();
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const req: any = {
+      input: 'u',
+      modelSettings: {},
+      tools: [
+        {
+          type: 'function',
+          name: 'lookup_account',
+          description: 'Look up an account.',
+          parameters: { type: 'object', properties: {}, required: [] },
+          strict: true,
+          deferLoading: true,
+        },
+      ],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+    };
+
+    await expect(withTrace('t', () => model.getResponse(req))).rejects.toThrow(
+      'Function tools with deferLoading: true are only supported with the Responses API.',
+    );
+    expect(client.chat.completions.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects required toolChoice when no tools are available', async () => {
+    const client = new FakeClient();
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const req: any = {
+      input: 'u',
+      modelSettings: { toolChoice: 'required' },
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+    };
+
+    await expect(withTrace('t', () => model.getResponse(req))).rejects.toThrow(
+      'modelSettings.toolChoice="required" requires at least one available tool in Chat Completions mode.',
+    );
+    expect(client.chat.completions.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects named toolChoice when the tool is unavailable', async () => {
+    const client = new FakeClient();
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const req: any = {
+      input: 'u',
+      modelSettings: { toolChoice: 'missing_tool' },
+      tools: [
+        {
+          type: 'function',
+          name: 'available_tool',
+          description: 'Available tool.',
+          parameters: { type: 'object', properties: {}, required: [] },
+          strict: true,
+        },
+      ],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+    };
+
+    await expect(withTrace('t', () => model.getResponse(req))).rejects.toThrow(
+      'modelSettings.toolChoice="missing_tool" does not match any available tool or handoff in Chat Completions mode.',
+    );
+    expect(client.chat.completions.create).not.toHaveBeenCalled();
+  });
+
   it('handles content and tool calls in the same message', async () => {
     const client = new FakeClient();
     const response = {

--- a/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
@@ -36,6 +36,10 @@ describe('getToolChoice', () => {
       type: 'function',
       name: 'my_func',
     });
+    expect(getToolChoice('tool_search')).toEqual({
+      type: 'function',
+      name: 'tool_search',
+    });
   });
 
   it('returns undefined when omitted', () => {
@@ -57,6 +61,24 @@ describe('converTool', () => {
       description: 'd',
       parameters: {},
       strict: undefined,
+    });
+  });
+
+  it('converts deferred function tools', () => {
+    const t = converTool({
+      type: 'function',
+      name: 'f',
+      description: 'd',
+      parameters: {},
+      deferLoading: true,
+    } as any);
+    expect(t.tool).toEqual({
+      type: 'function',
+      name: 'f',
+      description: 'd',
+      parameters: {},
+      strict: undefined,
+      defer_loading: true,
     });
   });
 
@@ -311,6 +333,46 @@ describe('converTool', () => {
       container: 'python',
     });
 
+    const toolSearch = converTool({
+      type: 'hosted_tool',
+      providerData: { type: 'tool_search' },
+    } as any);
+    expect(toolSearch.tool).toEqual({
+      type: 'tool_search',
+    });
+
+    const clientToolSearch = converTool({
+      type: 'hosted_tool',
+      providerData: {
+        type: 'tool_search',
+        execution: 'client',
+        description: 'Search deferred tools locally.',
+        parameters: {
+          type: 'object',
+          properties: {
+            paths: {
+              type: 'array',
+              items: { type: 'string' },
+            },
+          },
+        },
+      },
+    } as any);
+    expect(clientToolSearch.tool).toEqual({
+      type: 'tool_search',
+      execution: 'client',
+      description: 'Search deferred tools locally.',
+      parameters: {
+        type: 'object',
+        properties: {
+          paths: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+        },
+      },
+    });
+
     const img = converTool({
       type: 'hosted_tool',
       providerData: { type: 'image_generation', background: 'auto' },
@@ -334,6 +396,8 @@ describe('converTool', () => {
         type: 'mcp',
         server_label: 'deepwiki',
         server_url: 'https://mcp.deepwiki.com/mcp',
+        server_description: 'Repository knowledge',
+        defer_loading: true,
         require_approval: 'never',
       },
     } as any);
@@ -342,6 +406,8 @@ describe('converTool', () => {
       type: 'mcp',
       server_label: 'deepwiki',
       server_url: 'https://mcp.deepwiki.com/mcp',
+      server_description: 'Repository knowledge',
+      defer_loading: true,
       require_approval: 'never',
     });
 
@@ -519,11 +585,323 @@ describe('getInputItems', () => {
     expect(items.some((entry) => entry.type === 'reasoning')).toBe(true);
   });
 
+  it('preserves replay-only Responses fields when rebuilding input items', () => {
+    const items = getInputItems([
+      {
+        type: 'message',
+        id: 'assistant-1',
+        role: 'assistant',
+        status: 'completed',
+        content: [
+          {
+            type: 'output_text',
+            text: 'done',
+            providerData: {
+              annotations: [
+                { type: 'url_citation', url: 'https://example.com' },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        type: 'reasoning',
+        id: 'reasoning-1',
+        content: [{ type: 'input_text', text: 'thinking' }],
+        providerData: {
+          encrypted_content: 'enc_reasoning',
+        },
+      },
+      {
+        type: 'computer_call',
+        id: 'computer-1',
+        callId: 'computer-call-1',
+        action: 'open',
+        status: 'in_progress',
+        providerData: {
+          pending_safety_checks: [{ id: 'check-1', code: 'confirm' }],
+        },
+      },
+      {
+        type: 'computer_call_result',
+        id: 'computer-result-1',
+        callId: 'computer-call-1',
+        output: { data: 'https://example.com/screenshot.png' },
+        providerData: {
+          acknowledged_safety_checks: [{ id: 'check-1', code: 'confirm' }],
+        },
+      },
+    ] as any);
+
+    expect(items[0]).toMatchObject({
+      type: 'message',
+      id: 'assistant-1',
+      role: 'assistant',
+      content: [
+        {
+          type: 'output_text',
+          text: 'done',
+          annotations: [{ type: 'url_citation', url: 'https://example.com' }],
+        },
+      ],
+    });
+    expect(items[1]).toMatchObject({
+      type: 'reasoning',
+      id: 'reasoning-1',
+      encrypted_content: 'enc_reasoning',
+    });
+    expect(items[2]).toMatchObject({
+      type: 'computer_call',
+      id: 'computer-1',
+      call_id: 'computer-call-1',
+      pending_safety_checks: [{ id: 'check-1', code: 'confirm' }],
+    });
+    expect(items[3]).toMatchObject({
+      type: 'computer_call_output',
+      id: 'computer-result-1',
+      call_id: 'computer-call-1',
+      acknowledged_safety_checks: [{ id: 'check-1', code: 'confirm' }],
+    });
+  });
+
+  it('converts tool search items and namespaced function calls', () => {
+    const items = getInputItems([
+      {
+        type: 'tool_search_call',
+        id: 'ts_call',
+        status: 'completed',
+        arguments: {
+          namespaceHints: ['crm'],
+          terms: ['orders'],
+          maxResults: 3,
+        },
+      },
+      {
+        type: 'tool_search_output',
+        id: 'ts_output',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'list_open_orders',
+            namespace: 'crm',
+          },
+        ],
+      },
+      {
+        type: 'function_call',
+        id: 'fc1',
+        callId: 'call_1',
+        name: 'list_open_orders',
+        namespace: 'crm',
+        arguments: '{"customer_id":"customer_42"}',
+        status: 'completed',
+      },
+    ] as any);
+
+    expect(items[0]).toEqual({
+      type: 'tool_search_call',
+      id: 'ts_call',
+      status: 'completed',
+      arguments: {
+        namespaceHints: ['crm'],
+        terms: ['orders'],
+        maxResults: 3,
+      },
+    });
+    expect(items[1]).toEqual({
+      type: 'tool_search_output',
+      id: 'ts_output',
+      status: 'completed',
+      tools: [
+        {
+          type: 'tool_reference',
+          function_name: 'list_open_orders',
+          namespace: 'crm',
+        },
+      ],
+    });
+    expect(items[2]).toMatchObject({
+      type: 'function_call',
+      id: 'fc1',
+      call_id: 'call_1',
+      name: 'list_open_orders',
+      namespace: 'crm',
+      arguments: '{"customer_id":"customer_42"}',
+      status: 'completed',
+    });
+  });
+
+  it('converts top-level tool search references without a namespace', () => {
+    const items = getInputItems([
+      {
+        type: 'tool_search_output',
+        id: 'ts_output',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'get_shipping_eta',
+          },
+        ],
+      },
+    ] as any);
+
+    expect(items[0]).toEqual({
+      type: 'tool_search_output',
+      id: 'ts_output',
+      status: 'completed',
+      tools: [
+        {
+          type: 'tool_reference',
+          function_name: 'get_shipping_eta',
+        },
+      ],
+    });
+  });
+
+  it('preserves concrete tool payloads in tool search outputs', () => {
+    const items = getInputItems([
+      {
+        type: 'tool_search_output',
+        id: 'ts_output',
+        status: 'completed',
+        tools: [
+          {
+            type: 'namespace',
+            name: 'crm',
+            description: 'CRM tools.',
+            tools: [
+              {
+                type: 'function',
+                name: 'list_open_orders',
+                description: 'List open orders.',
+                deferLoading: true,
+                strict: true,
+                parameters: {
+                  type: 'object',
+                  properties: {
+                    customerId: {
+                      type: 'string',
+                    },
+                  },
+                  required: ['customerId'],
+                  additionalProperties: false,
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ] as any);
+
+    expect(items[0]).toEqual({
+      type: 'tool_search_output',
+      id: 'ts_output',
+      status: 'completed',
+      tools: [
+        {
+          type: 'namespace',
+          name: 'crm',
+          description: 'CRM tools.',
+          tools: [
+            {
+              type: 'function',
+              name: 'list_open_orders',
+              description: 'List open orders.',
+              defer_loading: true,
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {
+                  customerId: {
+                    type: 'string',
+                  },
+                },
+                required: ['customerId'],
+                additionalProperties: false,
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('preserves official tool search metadata when replaying tool search outputs', () => {
+    const items = getInputItems([
+      {
+        type: 'tool_search_output',
+        id: 'ts_output',
+        status: 'completed',
+        tools: [],
+        providerData: {
+          call_id: 'call_ts_1',
+          execution: 'client',
+          created_by: 'assistant',
+        },
+      },
+    ] as any);
+
+    expect(items[0]).toEqual({
+      type: 'tool_search_output',
+      id: 'ts_output',
+      status: 'completed',
+      tools: [],
+      call_id: 'call_ts_1',
+      execution: 'client',
+      created_by: 'assistant',
+    });
+  });
+
+  it('preserves raw tool search call_id and execution fields when replaying raw Responses items', () => {
+    const items = getInputItems([
+      {
+        type: 'tool_search_call',
+        id: 'ts_call',
+        call_id: 'call_ts_1',
+        execution: 'client',
+        status: 'completed',
+        arguments: {
+          paths: ['crm.lookup_account'],
+        },
+      },
+      {
+        type: 'tool_search_output',
+        id: 'ts_output',
+        call_id: 'call_ts_1',
+        execution: 'client',
+        status: 'completed',
+        tools: [],
+      },
+    ] as any);
+
+    expect(items[0]).toEqual({
+      type: 'tool_search_call',
+      id: 'ts_call',
+      call_id: 'call_ts_1',
+      execution: 'client',
+      status: 'completed',
+      arguments: {
+        paths: ['crm.lookup_account'],
+      },
+    });
+    expect(items[1]).toEqual({
+      type: 'tool_search_output',
+      id: 'ts_output',
+      call_id: 'call_ts_1',
+      execution: 'client',
+      status: 'completed',
+      tools: [],
+    });
+  });
+
   it('converts structured tool outputs into input items', () => {
     const items = getInputItems([
       {
         type: 'function_call_result',
         callId: 'c2',
+        namespace: 'crm',
         output: [
           { type: 'input_text', text: 'hello' },
           {
@@ -1473,6 +1851,234 @@ describe('convertToOutputItem', () => {
     });
   });
 
+  it('converts tool search outputs and preserves function namespaces', () => {
+    const out = convertToOutputItem([
+      {
+        type: 'tool_search_call',
+        id: 'ts_call',
+        status: 'completed',
+        arguments: {
+          namespaceHints: ['crm'],
+          terms: ['orders'],
+          maxResults: 3,
+        },
+      },
+      {
+        type: 'tool_search_output',
+        id: 'ts_output',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            function_name: 'list_open_orders',
+            namespace: 'crm',
+          },
+        ],
+      },
+      {
+        type: 'function_call',
+        id: 'fc1',
+        call_id: 'call_1',
+        name: 'list_open_orders',
+        namespace: 'crm',
+        arguments: '{"customer_id":"customer_42"}',
+        status: 'completed',
+      },
+    ] as any);
+
+    expect(out[0]).toEqual({
+      type: 'tool_search_call',
+      id: 'ts_call',
+      status: 'completed',
+      arguments: {
+        namespaceHints: ['crm'],
+        terms: ['orders'],
+        maxResults: 3,
+      },
+      providerData: {},
+    });
+    expect(out[1]).toEqual({
+      type: 'tool_search_output',
+      id: 'ts_output',
+      status: 'completed',
+      tools: [
+        {
+          type: 'tool_reference',
+          functionName: 'list_open_orders',
+          namespace: 'crm',
+        },
+      ],
+      providerData: {},
+    });
+    expect(out[2]).toMatchObject({
+      type: 'function_call',
+      id: 'fc1',
+      callId: 'call_1',
+      name: 'list_open_orders',
+      namespace: 'crm',
+      arguments: '{"customer_id":"customer_42"}',
+      status: 'completed',
+    });
+  });
+
+  it('converts top-level tool search outputs without a namespace', () => {
+    const out = convertToOutputItem([
+      {
+        type: 'tool_search_output',
+        id: 'ts_output',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            function_name: 'get_shipping_eta',
+          },
+        ],
+      },
+    ] as any);
+
+    expect(out[0]).toEqual({
+      type: 'tool_search_output',
+      id: 'ts_output',
+      status: 'completed',
+      tools: [
+        {
+          type: 'tool_reference',
+          functionName: 'get_shipping_eta',
+        },
+      ],
+      providerData: {},
+    });
+  });
+
+  it('preserves concrete tool payloads from tool search outputs', () => {
+    const out = convertToOutputItem([
+      {
+        type: 'tool_search_output',
+        id: 'ts_output',
+        status: 'completed',
+        tools: [
+          {
+            type: 'namespace',
+            name: 'crm',
+            description: 'CRM tools.',
+            tools: [
+              {
+                type: 'function',
+                name: 'list_open_orders',
+                description: 'List open orders.',
+                defer_loading: true,
+                strict: true,
+                parameters: {
+                  type: 'object',
+                  properties: {
+                    customerId: {
+                      type: 'string',
+                    },
+                  },
+                  required: ['customerId'],
+                  additionalProperties: false,
+                },
+              },
+            ],
+          },
+          {
+            type: 'function',
+            name: 'get_shipping_eta',
+            description: 'Look up a shipment ETA.',
+            defer_loading: true,
+            strict: true,
+            parameters: {
+              type: 'object',
+              properties: {
+                trackingNumber: {
+                  type: 'string',
+                },
+              },
+              required: ['trackingNumber'],
+              additionalProperties: false,
+            },
+          },
+        ],
+      },
+    ] as any);
+
+    expect(out[0]).toEqual({
+      type: 'tool_search_output',
+      id: 'ts_output',
+      status: 'completed',
+      tools: [
+        {
+          type: 'namespace',
+          name: 'crm',
+          description: 'CRM tools.',
+          tools: [
+            {
+              type: 'function',
+              name: 'list_open_orders',
+              description: 'List open orders.',
+              deferLoading: true,
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {
+                  customerId: {
+                    type: 'string',
+                  },
+                },
+                required: ['customerId'],
+                additionalProperties: false,
+              },
+            },
+          ],
+        },
+        {
+          type: 'function',
+          name: 'get_shipping_eta',
+          description: 'Look up a shipment ETA.',
+          deferLoading: true,
+          strict: true,
+          parameters: {
+            type: 'object',
+            properties: {
+              trackingNumber: {
+                type: 'string',
+              },
+            },
+            required: ['trackingNumber'],
+            additionalProperties: false,
+          },
+        },
+      ],
+      providerData: {},
+    });
+  });
+
+  it('preserves official tool search metadata when converting outputs', () => {
+    const out = convertToOutputItem([
+      {
+        type: 'tool_search_output',
+        id: 'ts_output',
+        status: 'completed',
+        call_id: 'call_ts_1',
+        execution: 'client',
+        created_by: 'assistant',
+        tools: [],
+      },
+    ] as any);
+
+    expect(out[0]).toEqual({
+      type: 'tool_search_output',
+      id: 'ts_output',
+      status: 'completed',
+      tools: [],
+      providerData: {
+        call_id: 'call_ts_1',
+        execution: 'client',
+        created_by: 'assistant',
+      },
+    });
+  });
+
   it('rejects unknown message content', () => {
     expect(() =>
       convertToOutputItem([
@@ -1494,6 +2100,7 @@ describe('convertToOutputItem', () => {
         id: 'out-1',
         call_id: 'call-1',
         name: 'lookup',
+        namespace: 'crm',
         output: 'done',
       } as any,
     ]);
@@ -1503,6 +2110,7 @@ describe('convertToOutputItem', () => {
       id: 'out-1',
       callId: 'call-1',
       name: 'lookup',
+      namespace: 'crm',
       output: 'done',
       status: 'completed',
     });

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -111,6 +111,164 @@ describe('OpenAIResponsesModel', () => {
     });
   });
 
+  it('ignores providerData reserved fields when building replay input items', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = { id: 'res-provider-data', usage: {}, output: [] };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-test');
+
+      const request = {
+        systemInstructions: undefined,
+        input: [
+          {
+            type: 'message',
+            id: 'sys_1',
+            role: 'system',
+            content: 'keep-system',
+            providerData: {
+              role: 'user',
+              content: 'override',
+              customFlag: 'keep-system-metadata',
+            },
+          },
+          {
+            type: 'message',
+            id: 'user_1',
+            role: 'user',
+            content: [
+              {
+                type: 'input_text',
+                text: 'keep-text',
+                providerData: {
+                  type: 'bad_text',
+                  text: 'override-text',
+                  customText: 'keep-text-metadata',
+                },
+              },
+              {
+                type: 'input_image',
+                image: 'https://example.com/image.png',
+                providerData: {
+                  type: 'bad_image',
+                  imageUrl: 'https://example.com/override.png',
+                  detail: 'low',
+                  customImage: 'keep-image-metadata',
+                },
+              },
+            ],
+          },
+          {
+            type: 'tool_search_call',
+            id: 'search_1',
+            status: 'completed',
+            arguments: {
+              paths: ['crm'],
+              query: 'profile',
+            },
+            providerData: {
+              type: 'function_call',
+              arguments: { paths: ['billing'] },
+              customSearch: 'keep-search-metadata',
+            },
+          },
+          {
+            type: 'function_call',
+            id: 'fc_1',
+            callId: 'call_1',
+            name: 'lookup_account',
+            namespace: 'crm',
+            arguments: '{"accountId":"acct_1"}',
+            status: 'completed',
+            providerData: {
+              name: 'override_name',
+              namespace: 'override_namespace',
+              arguments: '{"accountId":"override"}',
+              customFunction: 'keep-function-metadata',
+            },
+          },
+          {
+            type: 'function_call_result',
+            id: 'fco_1',
+            callId: 'call_1',
+            output: 'tool output',
+            status: 'completed',
+            providerData: {
+              type: 'message',
+              output: 'override-output',
+              customResult: 'keep-result-metadata',
+            },
+          },
+        ],
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await model.getResponse(request as any);
+
+      const [args] = createMock.mock.calls[0];
+      expect(args.input).toEqual([
+        {
+          id: 'sys_1',
+          role: 'system',
+          content: 'keep-system',
+          custom_flag: 'keep-system-metadata',
+        },
+        {
+          id: 'user_1',
+          role: 'user',
+          content: [
+            {
+              type: 'input_text',
+              text: 'keep-text',
+              custom_text: 'keep-text-metadata',
+            },
+            {
+              type: 'input_image',
+              detail: 'auto',
+              image_url: 'https://example.com/image.png',
+              custom_image: 'keep-image-metadata',
+            },
+          ],
+        },
+        {
+          type: 'tool_search_call',
+          id: 'search_1',
+          status: 'completed',
+          arguments: {
+            paths: ['crm'],
+            query: 'profile',
+          },
+          custom_search: 'keep-search-metadata',
+        },
+        {
+          id: 'fc_1',
+          type: 'function_call',
+          name: 'lookup_account',
+          call_id: 'call_1',
+          arguments: '{"accountId":"acct_1"}',
+          status: 'completed',
+          namespace: 'crm',
+          custom_function: 'keep-function-metadata',
+        },
+        {
+          type: 'function_call_output',
+          id: 'fco_1',
+          call_id: 'call_1',
+          output: 'tool output',
+          status: 'completed',
+          custom_result: 'keep-result-metadata',
+        },
+      ]);
+    });
+  });
+
   it('omits previous_response_id when conversation is provided', async () => {
     await withTrace('test', async () => {
       const fakeResponse = { id: 'res-conv', usage: {}, output: [] };
@@ -327,6 +485,1609 @@ describe('OpenAIResponsesModel', () => {
     });
   });
 
+  it('allows deferred namespace members in requests', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = { id: 'res-tool-search', usage: {}, output: [] };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        input: 'look up customer_42 and list their open orders',
+        modelSettings: {},
+        tools: [
+          {
+            type: 'function',
+            name: 'get_customer_profile',
+            description: 'Fetch customer profile data.',
+            parameters: {
+              type: 'object',
+              properties: {
+                customer_id: { type: 'string' },
+              },
+              required: ['customer_id'],
+              additionalProperties: false,
+            },
+            strict: true,
+            deferLoading: true,
+            namespace: 'crm',
+            namespaceDescription:
+              'CRM tools for customer profile and order lookup.',
+          },
+          {
+            type: 'function',
+            name: 'list_open_orders',
+            description: 'List open orders for a customer.',
+            parameters: {
+              type: 'object',
+              properties: {
+                customer_id: { type: 'string' },
+              },
+              required: ['customer_id'],
+              additionalProperties: false,
+            },
+            strict: true,
+            deferLoading: true,
+            namespace: 'crm',
+            namespaceDescription:
+              'CRM tools for customer profile and order lookup.',
+          },
+          {
+            type: 'hosted_tool',
+            name: 'tool_search',
+            providerData: { type: 'tool_search' },
+          },
+        ],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await model.getResponse(request as any);
+
+      expect(createMock).toHaveBeenCalledTimes(1);
+      const [args] = createMock.mock.calls[0];
+      expect(args.tools).toEqual([
+        {
+          type: 'namespace',
+          name: 'crm',
+          description: 'CRM tools for customer profile and order lookup.',
+          tools: [
+            {
+              type: 'function',
+              name: 'get_customer_profile',
+              description: 'Fetch customer profile data.',
+              parameters: {
+                type: 'object',
+                properties: {
+                  customer_id: { type: 'string' },
+                },
+                required: ['customer_id'],
+                additionalProperties: false,
+              },
+              strict: true,
+              defer_loading: true,
+            },
+            {
+              type: 'function',
+              name: 'list_open_orders',
+              description: 'List open orders for a customer.',
+              parameters: {
+                type: 'object',
+                properties: {
+                  customer_id: { type: 'string' },
+                },
+                required: ['customer_id'],
+                additionalProperties: false,
+              },
+              strict: true,
+              defer_loading: true,
+            },
+          ],
+        },
+        {
+          type: 'tool_search',
+          execution: undefined,
+          description: undefined,
+          parameters: undefined,
+        },
+      ]);
+    });
+  });
+
+  it('rejects namespaced tools without a namespace description', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-missing-namespace-description',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        input: 'look up customer_42',
+        modelSettings: {},
+        tools: [
+          {
+            type: 'function',
+            name: 'get_customer_profile',
+            description: 'Fetch customer profile data.',
+            parameters: {
+              type: 'object',
+              properties: {
+                customer_id: { type: 'string' },
+              },
+              required: ['customer_id'],
+              additionalProperties: false,
+            },
+            strict: true,
+            namespace: 'crm',
+          },
+          {
+            type: 'hosted_tool',
+            name: 'tool_search',
+            providerData: { type: 'tool_search' },
+          },
+        ],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await expect(model.getResponse(request as any)).rejects.toThrow(
+        'All tools in namespace "crm" must provide a non-empty description.',
+      );
+      expect(createMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('allows namespace tools that mix immediate and deferred members', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-mixed-namespace-members',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        input: 'look up customer_42',
+        modelSettings: {},
+        tools: [
+          {
+            type: 'function',
+            name: 'get_customer_profile',
+            description: 'Fetch customer profile data.',
+            parameters: {
+              type: 'object',
+              properties: {
+                customer_id: { type: 'string' },
+              },
+              required: ['customer_id'],
+              additionalProperties: false,
+            },
+            strict: true,
+            namespace: 'crm',
+            namespaceDescription:
+              'CRM tools for customer profile and order lookup.',
+          },
+          {
+            type: 'function',
+            name: 'list_recent_support_tickets',
+            description: 'List recent support tickets.',
+            parameters: {
+              type: 'object',
+              properties: {
+                customer_id: { type: 'string' },
+              },
+              required: ['customer_id'],
+              additionalProperties: false,
+            },
+            strict: true,
+            deferLoading: true,
+            namespace: 'crm',
+            namespaceDescription:
+              'CRM tools for customer profile and order lookup.',
+          },
+          {
+            type: 'hosted_tool',
+            name: 'tool_search',
+            providerData: { type: 'tool_search' },
+          },
+        ],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await model.getResponse(request as any);
+
+      expect(createMock).toHaveBeenCalledTimes(1);
+      const [args] = createMock.mock.calls[0];
+      expect(args.tools).toEqual([
+        {
+          type: 'namespace',
+          name: 'crm',
+          description: 'CRM tools for customer profile and order lookup.',
+          tools: [
+            {
+              type: 'function',
+              name: 'get_customer_profile',
+              description: 'Fetch customer profile data.',
+              parameters: {
+                type: 'object',
+                properties: {
+                  customer_id: { type: 'string' },
+                },
+                required: ['customer_id'],
+                additionalProperties: false,
+              },
+              strict: true,
+            },
+            {
+              type: 'function',
+              name: 'list_recent_support_tickets',
+              description: 'List recent support tickets.',
+              parameters: {
+                type: 'object',
+                properties: {
+                  customer_id: { type: 'string' },
+                },
+                required: ['customer_id'],
+                additionalProperties: false,
+              },
+              strict: true,
+              defer_loading: true,
+            },
+          ],
+        },
+        {
+          type: 'tool_search',
+          execution: undefined,
+          description: undefined,
+          parameters: undefined,
+        },
+      ]);
+    });
+  });
+
+  it('rejects duplicate function tool names within a namespace', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-duplicate-namespace-function',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        input: 'look up customer_42',
+        modelSettings: {},
+        tools: [
+          {
+            type: 'function',
+            name: 'lookup_account',
+            description: 'Look up an account in CRM.',
+            parameters: {
+              type: 'object',
+              properties: {
+                account_id: { type: 'string' },
+              },
+              required: ['account_id'],
+              additionalProperties: false,
+            },
+            strict: true,
+            namespace: 'crm',
+            namespaceDescription: 'CRM tools.',
+          },
+          {
+            type: 'function',
+            name: 'lookup_account',
+            description: 'Look up a premium account in CRM.',
+            parameters: {
+              type: 'object',
+              properties: {
+                account_id: { type: 'string' },
+              },
+              required: ['account_id'],
+              additionalProperties: false,
+            },
+            strict: true,
+            namespace: 'crm',
+            namespaceDescription: 'CRM tools.',
+          },
+          {
+            type: 'hosted_tool',
+            name: 'tool_search',
+            providerData: { type: 'tool_search' },
+          },
+        ],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await expect(model.getResponse(request as any)).rejects.toThrow(
+        'Namespace "crm" cannot contain duplicate function tool name "lookup_account".',
+      );
+      expect(createMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('keeps top-level deferred function tools flat in requests', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-top-level-deferred',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        input: 'look up the shipment eta',
+        modelSettings: {},
+        tools: [
+          {
+            type: 'function',
+            name: 'get_shipping_eta',
+            description: 'Look up a shipment ETA by tracking number.',
+            parameters: {
+              type: 'object',
+              properties: {
+                tracking_number: { type: 'string' },
+              },
+              required: ['tracking_number'],
+              additionalProperties: false,
+            },
+            strict: true,
+            deferLoading: true,
+          },
+          {
+            type: 'hosted_tool',
+            name: 'tool_search',
+            providerData: { type: 'tool_search' },
+          },
+        ],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await model.getResponse(request as any);
+
+      const [args] = createMock.mock.calls[0];
+      expect(args.tools).toEqual([
+        {
+          type: 'function',
+          name: 'get_shipping_eta',
+          description: 'Look up a shipment ETA by tracking number.',
+          parameters: {
+            type: 'object',
+            properties: {
+              tracking_number: { type: 'string' },
+            },
+            required: ['tracking_number'],
+            additionalProperties: false,
+          },
+          strict: true,
+          defer_loading: true,
+        },
+        {
+          type: 'tool_search',
+        },
+      ]);
+    });
+  });
+
+  it('rejects deferLoading without toolSearchTool', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-missing-tool-search',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        input: 'look up the shipment eta',
+        modelSettings: {},
+        tools: [
+          {
+            type: 'function',
+            name: 'get_shipping_eta',
+            description: 'Look up a shipment ETA by tracking number.',
+            parameters: {
+              type: 'object',
+              properties: {
+                tracking_number: { type: 'string' },
+              },
+              required: ['tracking_number'],
+              additionalProperties: false,
+            },
+            strict: true,
+            deferLoading: true,
+          },
+        ],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await expect(model.getResponse(request as any)).rejects.toThrow(
+        'Deferred function tools and hosted MCP tools with deferLoading: true require toolSearchTool() in the same request.',
+      );
+      expect(createMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('includes deferred hosted MCP tools when paired with toolSearchTool', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-deferred-mcp',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        input: 'find the latest order',
+        modelSettings: {},
+        tools: [
+          {
+            type: 'hosted_tool',
+            name: 'hosted_mcp',
+            providerData: {
+              type: 'mcp',
+              server_label: 'shopify',
+              server_url: 'https://mcp.example.com/shopify',
+              server_description: 'Orders and customer records.',
+              defer_loading: true,
+              require_approval: 'never',
+            },
+          },
+          {
+            type: 'hosted_tool',
+            name: 'tool_search',
+            providerData: { type: 'tool_search' },
+          },
+        ],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await model.getResponse(request as any);
+
+      const [args] = createMock.mock.calls[0];
+      expect(args.tools).toEqual([
+        {
+          type: 'mcp',
+          server_label: 'shopify',
+          server_url: 'https://mcp.example.com/shopify',
+          server_description: 'Orders and customer records.',
+          defer_loading: true,
+          require_approval: 'never',
+        },
+        {
+          type: 'tool_search',
+        },
+      ]);
+    });
+  });
+
+  it('rejects deferred hosted MCP tools without toolSearchTool', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-missing-tool-search-mcp',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        input: 'find the latest order',
+        modelSettings: {},
+        tools: [
+          {
+            type: 'hosted_tool',
+            name: 'hosted_mcp',
+            providerData: {
+              type: 'mcp',
+              server_label: 'shopify',
+              server_url: 'https://mcp.example.com/shopify',
+              defer_loading: true,
+              require_approval: 'never',
+            },
+          },
+        ],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await expect(model.getResponse(request as any)).rejects.toThrow(
+        'Deferred function tools and hosted MCP tools with deferLoading: true require toolSearchTool() in the same request.',
+      );
+      expect(createMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('rejects deferred function tools when a prompt is present without explicit toolSearchTool', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-prompt-tool-search',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        prompt: { promptId: 'pmpt_tool_search_support' },
+        input: 'look up the shipment eta',
+        modelSettings: {},
+        tools: [
+          {
+            type: 'function',
+            name: 'get_shipping_eta',
+            description: 'Look up a shipment ETA by tracking number.',
+            parameters: {
+              type: 'object',
+              properties: {
+                tracking_number: { type: 'string' },
+              },
+              required: ['tracking_number'],
+              additionalProperties: false,
+            },
+            strict: true,
+            deferLoading: true,
+          },
+        ],
+        toolsExplicitlyProvided: false,
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await expect(model.getResponse(request as any)).rejects.toThrow(
+        'Deferred function tools and hosted MCP tools with deferLoading: true require toolSearchTool() in the same request.',
+      );
+      expect(createMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('rejects deferred function tools from explicit prompt-backed tool config without explicit toolSearchTool', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-prompt-tool-search-explicit-tools',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        prompt: { promptId: 'pmpt_tool_search_support' },
+        input: 'look up the shipment eta',
+        modelSettings: {},
+        tools: [
+          {
+            type: 'function',
+            name: 'get_shipping_eta',
+            description: 'Look up a shipment ETA by tracking number.',
+            parameters: {
+              type: 'object',
+              properties: {
+                tracking_number: { type: 'string' },
+              },
+              required: ['tracking_number'],
+              additionalProperties: false,
+            },
+            strict: true,
+            deferLoading: true,
+          },
+        ],
+        toolsExplicitlyProvided: true,
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await expect(model.getResponse(request as any)).rejects.toThrow(
+        'Deferred function tools and hosted MCP tools with deferLoading: true require toolSearchTool() in the same request.',
+      );
+      expect(createMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('allows deferred function tools with explicit toolSearchTool when a prompt is present', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-prompt-tool-search-explicit-helper',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        prompt: { promptId: 'pmpt_tool_search_support' },
+        input: 'look up the shipment eta',
+        modelSettings: {},
+        tools: [
+          {
+            type: 'function',
+            name: 'get_shipping_eta',
+            description: 'Look up a shipment ETA by tracking number.',
+            parameters: {
+              type: 'object',
+              properties: {
+                tracking_number: { type: 'string' },
+              },
+              required: ['tracking_number'],
+              additionalProperties: false,
+            },
+            strict: true,
+            deferLoading: true,
+          },
+          {
+            type: 'hosted_tool',
+            name: 'tool_search',
+            providerData: { type: 'tool_search' },
+          },
+        ],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await model.getResponse(request as any);
+
+      expect(createMock).toHaveBeenCalledTimes(1);
+      const [args] = createMock.mock.calls[0];
+      expect(args.prompt).toMatchObject({ id: 'pmpt_tool_search_support' });
+      expect(args.tools).toEqual([
+        {
+          type: 'function',
+          name: 'get_shipping_eta',
+          description: 'Look up a shipment ETA by tracking number.',
+          parameters: {
+            type: 'object',
+            properties: {
+              tracking_number: { type: 'string' },
+            },
+            required: ['tracking_number'],
+            additionalProperties: false,
+          },
+          strict: true,
+          defer_loading: true,
+        },
+        {
+          type: 'tool_search',
+        },
+      ]);
+    });
+  });
+
+  it.each([false, true])(
+    'preserves explicit tool_search for prompt-backed requests when toolsExplicitlyProvided=%s',
+    async (toolsExplicitlyProvided) => {
+      await withTrace('test', async () => {
+        const fakeResponse = {
+          id: 'res-prompt-tool-search-helper',
+          usage: {},
+          output: [],
+        };
+        const createMock = vi.fn().mockResolvedValue(fakeResponse);
+        const fakeClient = {
+          responses: { create: createMock },
+        } as unknown as OpenAI;
+        const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+        const request = {
+          systemInstructions: undefined,
+          prompt: { promptId: 'pmpt_tool_search_support' },
+          input: 'look up the shipment eta',
+          modelSettings: {},
+          tools: [
+            {
+              type: 'hosted_tool',
+              name: 'tool_search',
+              providerData: { type: 'tool_search' },
+            },
+          ],
+          toolsExplicitlyProvided,
+          outputType: 'text',
+          handoffs: [],
+          tracing: false,
+          signal: undefined,
+        };
+
+        await model.getResponse(request as any);
+
+        expect(createMock).toHaveBeenCalledTimes(1);
+        const [args] = createMock.mock.calls[0];
+        expect(args.tools).toEqual([
+          {
+            type: 'tool_search',
+          },
+        ]);
+      });
+    },
+  );
+
+  it('rejects deferred namespaced function tools before toolChoice validation', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-namespaced-tool-choice',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        input: 'look up customer_42',
+        modelSettings: { toolChoice: 'crm.lookup_account' },
+        tools: [
+          {
+            type: 'function',
+            name: 'lookup_account',
+            description: 'Look up an account in CRM.',
+            parameters: {
+              type: 'object',
+              properties: {
+                account_id: { type: 'string' },
+              },
+              required: ['account_id'],
+              additionalProperties: false,
+            },
+            strict: true,
+            deferLoading: true,
+            namespace: 'crm',
+            namespaceDescription: 'CRM tools.',
+          },
+          {
+            type: 'hosted_tool',
+            name: 'tool_search',
+            providerData: { type: 'tool_search' },
+          },
+        ],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await expect(model.getResponse(request as any)).rejects.toThrow(
+        'modelSettings.toolChoice="crm.lookup_account" cannot force a deferred function tool in Responses. Use "auto" so tool_search can load it.',
+      );
+      expect(createMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('rejects forced toolChoice for top-level deferred function tools', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-top-level-deferred-tool-choice',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        input: 'look up shipment ZX-123',
+        modelSettings: { toolChoice: 'get_shipping_eta' },
+        tools: [
+          {
+            type: 'function',
+            name: 'get_shipping_eta',
+            description: 'Look up a shipment ETA.',
+            parameters: {
+              type: 'object',
+              properties: {
+                tracking_number: { type: 'string' },
+              },
+              required: ['tracking_number'],
+              additionalProperties: false,
+            },
+            strict: true,
+            deferLoading: true,
+          },
+          {
+            type: 'hosted_tool',
+            name: 'tool_search',
+            providerData: { type: 'tool_search' },
+          },
+        ],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await expect(model.getResponse(request as any)).rejects.toThrow(
+        'modelSettings.toolChoice="get_shipping_eta" cannot force a deferred function tool in Responses. Use "auto" so tool_search can load it.',
+      );
+      expect(createMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('allows namespaced function tool_choice values for immediate namespace tools', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-immediate-namespaced-tool-choice',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        input: 'look up customer_42',
+        modelSettings: { toolChoice: 'crm.lookup_account' },
+        tools: [
+          {
+            type: 'function',
+            name: 'lookup_account',
+            description: 'Look up an account in CRM.',
+            parameters: {
+              type: 'object',
+              properties: {
+                account_id: { type: 'string' },
+              },
+              required: ['account_id'],
+              additionalProperties: false,
+            },
+            strict: true,
+            namespace: 'crm',
+            namespaceDescription: 'CRM tools.',
+          },
+        ],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await model.getResponse(request as any);
+
+      expect(createMock).toHaveBeenCalledTimes(1);
+      const [args] = createMock.mock.calls[0];
+      expect(args.tools).toEqual([
+        {
+          type: 'namespace',
+          name: 'crm',
+          description: 'CRM tools.',
+          tools: [
+            {
+              type: 'function',
+              name: 'lookup_account',
+              description: 'Look up an account in CRM.',
+              parameters: {
+                type: 'object',
+                properties: {
+                  account_id: { type: 'string' },
+                },
+                required: ['account_id'],
+                additionalProperties: false,
+              },
+              strict: true,
+            },
+          ],
+        },
+      ]);
+      expect(args.tool_choice).toEqual({
+        type: 'function',
+        name: 'crm.lookup_account',
+      });
+    });
+  });
+
+  it('preserves explicit server toolSearchTool when no deferred function tools remain', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-orphan-tool-search',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        input: 'look up the shipment eta',
+        modelSettings: {},
+        tools: [
+          {
+            type: 'function',
+            name: 'get_shipping_eta',
+            description: 'Look up a shipment ETA by tracking number.',
+            parameters: {
+              type: 'object',
+              properties: {
+                tracking_number: { type: 'string' },
+              },
+              required: ['tracking_number'],
+              additionalProperties: false,
+            },
+            strict: true,
+          },
+          {
+            type: 'hosted_tool',
+            name: 'tool_search',
+            providerData: { type: 'tool_search' },
+          },
+        ],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await model.getResponse(request as any);
+
+      expect(createMock).toHaveBeenCalledTimes(1);
+      const [args] = createMock.mock.calls[0];
+      expect(args.tools).toEqual([
+        {
+          type: 'function',
+          name: 'get_shipping_eta',
+          description: 'Look up a shipment ETA by tracking number.',
+          parameters: {
+            type: 'object',
+            properties: {
+              tracking_number: { type: 'string' },
+            },
+            required: ['tracking_number'],
+            additionalProperties: false,
+          },
+          strict: true,
+        },
+        {
+          type: 'tool_search',
+        },
+      ]);
+    });
+  });
+
+  it('keeps explicit toolSearchTool when a prompt is present', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-prompt-deferred-tool',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        prompt: { promptId: 'pmpt_deferred_tool_support' },
+        input: 'look up the shipment eta',
+        modelSettings: {},
+        tools: [
+          {
+            type: 'hosted_tool',
+            name: 'tool_search',
+            providerData: { type: 'tool_search' },
+          },
+        ],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await model.getResponse(request as any);
+
+      expect(createMock).toHaveBeenCalledTimes(1);
+      const [args] = createMock.mock.calls[0];
+      expect(args.tools).toEqual([
+        {
+          type: 'tool_search',
+        },
+      ]);
+    });
+  });
+
+  it('keeps explicit client toolSearchTool even without deferred local tools', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-client-tool-search-helper',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        input: 'load deferred tools from the client runtime',
+        modelSettings: {},
+        tools: [
+          {
+            type: 'hosted_tool',
+            name: 'tool_search',
+            providerData: {
+              type: 'tool_search',
+              execution: 'client',
+              description: 'Search local deferred tools.',
+              parameters: {
+                type: 'object',
+                properties: {
+                  namespace: { type: 'string' },
+                },
+              },
+            },
+          },
+        ],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await model.getResponse(request as any);
+
+      expect(createMock).toHaveBeenCalledTimes(1);
+      const [args] = createMock.mock.calls[0];
+      expect(args.tools).toEqual([
+        {
+          type: 'tool_search',
+          execution: 'client',
+          description: 'Search local deferred tools.',
+          parameters: {
+            type: 'object',
+            properties: {
+              namespace: { type: 'string' },
+            },
+          },
+        },
+      ]);
+    });
+  });
+
+  it('keeps explicit server toolSearchTool without deferred local tools', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-server-tool-search-helper',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        input: 'look up the shipment eta',
+        modelSettings: { parallelToolCalls: true },
+        tools: [
+          {
+            type: 'hosted_tool',
+            name: 'tool_search',
+            providerData: { type: 'tool_search' },
+          },
+        ],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await model.getResponse(request as any);
+
+      expect(createMock).toHaveBeenCalledTimes(1);
+      const [args] = createMock.mock.calls[0];
+      expect(args.tools).toEqual([
+        {
+          type: 'tool_search',
+        },
+      ]);
+      expect(args.parallel_tool_calls).toBe(true);
+    });
+  });
+
+  it('treats tool_search toolChoice as a custom function name even when the hosted tool is present', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-function-tool-search-choice',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        input: 'look up the shipment eta',
+        modelSettings: { toolChoice: 'tool_search' },
+        tools: [
+          {
+            type: 'function',
+            name: 'tool_search',
+            description: 'Force a custom tool named tool_search.',
+            parameters: {
+              type: 'object',
+              properties: {
+                tracking_number: { type: 'string' },
+              },
+              required: ['tracking_number'],
+              additionalProperties: false,
+            },
+            strict: true,
+          },
+          {
+            type: 'function',
+            name: 'get_shipping_eta',
+            description: 'Look up a shipment ETA by tracking number.',
+            parameters: {
+              type: 'object',
+              properties: {
+                tracking_number: { type: 'string' },
+              },
+              required: ['tracking_number'],
+              additionalProperties: false,
+            },
+            strict: true,
+          },
+          {
+            type: 'hosted_tool',
+            name: 'tool_search',
+            providerData: { type: 'tool_search' },
+          },
+        ],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await model.getResponse(request as any);
+
+      expect(createMock).toHaveBeenCalledTimes(1);
+      const [args] = createMock.mock.calls[0];
+      expect(args.tool_choice).toEqual({
+        type: 'function',
+        name: 'tool_search',
+      });
+    });
+  });
+
+  it('treats tool_search toolChoice as a custom function name when no hosted tool is present', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-function-tool-search-choice-no-hosted-tool',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        input: 'look up the shipment eta',
+        modelSettings: { toolChoice: 'tool_search' },
+        tools: [
+          {
+            type: 'function',
+            name: 'tool_search',
+            description: 'Force a custom tool named tool_search.',
+            parameters: {
+              type: 'object',
+              properties: {
+                tracking_number: { type: 'string' },
+              },
+              required: ['tracking_number'],
+              additionalProperties: false,
+            },
+            strict: true,
+          },
+        ],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await model.getResponse(request as any);
+
+      expect(createMock).toHaveBeenCalledTimes(1);
+      const [args] = createMock.mock.calls[0];
+      expect(args.tool_choice).toEqual({
+        type: 'function',
+        name: 'tool_search',
+      });
+    });
+  });
+
+  it('rejects tool_search toolChoice when only the built-in tool_search tool is available', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-hosted-tool-search-choice',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        input: 'look up the shipment eta',
+        modelSettings: { toolChoice: 'tool_search' },
+        tools: [
+          {
+            type: 'function',
+            name: 'get_shipping_eta',
+            description: 'Look up a shipment ETA by tracking number.',
+            parameters: {
+              type: 'object',
+              properties: {
+                tracking_number: { type: 'string' },
+              },
+              required: ['tracking_number'],
+              additionalProperties: false,
+            },
+            strict: true,
+            deferLoading: true,
+          },
+          {
+            type: 'hosted_tool',
+            name: 'tool_search',
+            providerData: { type: 'tool_search' },
+          },
+        ],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await expect(model.getResponse(request as any)).rejects.toThrow(
+        /modelSettings\.toolChoice="tool_search" is only supported for a custom function named "tool_search"/,
+      );
+      expect(createMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('rejects tool_search toolChoice when only a prompt may supply the built-in tool', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-prompt-hosted-tool-search-choice',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        prompt: { promptId: 'pmpt_tool_search_support' },
+        input: 'look up the shipment eta',
+        modelSettings: { toolChoice: 'tool_search' },
+        tools: [],
+        toolsExplicitlyProvided: false,
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await expect(model.getResponse(request as any)).rejects.toThrow(
+        /modelSettings\.toolChoice="tool_search" is only supported for a custom function named "tool_search"/,
+      );
+      expect(createMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('rejects a named function tool choice when no matching tool remains', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-missing-function-tool-choice',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        input: 'look up customer_42',
+        modelSettings: { toolChoice: 'lookup_account' },
+        tools: [
+          {
+            type: 'function',
+            name: 'get_shipping_eta',
+            description: 'Look up a shipment ETA by tracking number.',
+            parameters: {
+              type: 'object',
+              properties: {
+                tracking_number: { type: 'string' },
+              },
+              required: ['tracking_number'],
+              additionalProperties: false,
+            },
+            strict: true,
+          },
+        ],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await expect(model.getResponse(request as any)).rejects.toThrow(
+        /modelSettings\.toolChoice="lookup_account" does not match any available tool/,
+      );
+      expect(createMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('rejects required tool choice when the outgoing tool list is empty', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-empty-tool-choice',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        input: 'look up the shipment eta',
+        modelSettings: { toolChoice: 'required' },
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await expect(model.getResponse(request as any)).rejects.toThrow(
+        /modelSettings\.toolChoice="required" requires at least one available tool/,
+      );
+      expect(createMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('accepts named tool choice when extra_body supplies the selected tool', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-extra-body-tool-choice',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        input: 'look up customer_42',
+        modelSettings: {
+          toolChoice: 'prompt_lookup',
+          providerData: {
+            extra_body: {
+              tools: [
+                {
+                  type: 'function',
+                  name: 'prompt_lookup',
+                  description:
+                    'Look up a customer from a prompt-supplied tool.',
+                  parameters: {
+                    type: 'object',
+                    properties: {},
+                    additionalProperties: false,
+                  },
+                  strict: true,
+                },
+              ],
+            },
+          },
+        },
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await model.getResponse(request as any);
+
+      expect(createMock).toHaveBeenCalledTimes(1);
+      const [args] = createMock.mock.calls[0];
+      expect(args.tools).toEqual([
+        {
+          type: 'function',
+          name: 'prompt_lookup',
+          description: 'Look up a customer from a prompt-supplied tool.',
+          parameters: {
+            type: 'object',
+            properties: {},
+            additionalProperties: false,
+          },
+          strict: true,
+        },
+      ]);
+      expect(args.tool_choice).toEqual({
+        type: 'function',
+        name: 'prompt_lookup',
+      });
+    });
+  });
+
+  it('accepts required tool choice when extra_body supplies tools', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-extra-body-required-tool-choice',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+
+      const request = {
+        systemInstructions: undefined,
+        input: 'look up customer_42',
+        modelSettings: {
+          toolChoice: 'required',
+          providerData: {
+            extra_body: {
+              tools: [
+                {
+                  type: 'function',
+                  name: 'prompt_lookup',
+                  description:
+                    'Look up a customer from a prompt-supplied tool.',
+                  parameters: {
+                    type: 'object',
+                    properties: {},
+                    additionalProperties: false,
+                  },
+                  strict: true,
+                },
+              ],
+            },
+          },
+        },
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await model.getResponse(request as any);
+
+      expect(createMock).toHaveBeenCalledTimes(1);
+      const [args] = createMock.mock.calls[0];
+      expect(args.tools).toEqual([
+        {
+          type: 'function',
+          name: 'prompt_lookup',
+          description: 'Look up a customer from a prompt-supplied tool.',
+          parameters: {
+            type: 'object',
+            properties: {},
+            additionalProperties: false,
+          },
+          strict: true,
+        },
+      ]);
+      expect(args.tool_choice).toBe('required');
+    });
+  });
+
   it('omits model when a prompt is provided', async () => {
     await withTrace('test', async () => {
       const fakeResponse = { id: 'res-prompt', usage: {}, output: [] };
@@ -500,10 +2261,10 @@ describe('OpenAIResponsesModel', () => {
     });
   });
 
-  it('omits named tool_choice when prompt should supply tools', async () => {
+  it('keeps named tool_choice when a prompt may supply the selected tool', async () => {
     await withTrace('test', async () => {
       const fakeResponse = {
-        id: 'res-tool-choice-omit',
+        id: 'res-tool-choice-prompt-only',
         usage: {},
         output: [],
       };
@@ -531,11 +2292,137 @@ describe('OpenAIResponsesModel', () => {
       expect(createMock).toHaveBeenCalledTimes(1);
       const [args] = createMock.mock.calls[0];
       expect('tools' in args).toBe(false);
-      expect('tool_choice' in args).toBe(false);
+      expect(args.tool_choice).toEqual({
+        type: 'web_search_preview',
+      });
     });
   });
 
-  it('keeps literal tool_choice when prompt should supply tools', async () => {
+  it('keeps named tool_choice when a prompt may supply the selected function alongside local tools', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-tool-choice-prompt-plus-local-tools',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-default');
+
+      const request = {
+        systemInstructions: undefined,
+        prompt: { promptId: 'pmpt_tool_choice_prompt_plus_local_tools' },
+        input: 'hello',
+        modelSettings: { toolChoice: 'prompt_lookup' },
+        tools: [
+          {
+            type: 'function',
+            name: 'local_lookup',
+            description: 'Available locally but not selected by toolChoice.',
+            parameters: {
+              type: 'object',
+              properties: {},
+              additionalProperties: false,
+            },
+            strict: true,
+          },
+        ],
+        toolsExplicitlyProvided: false,
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await model.getResponse(request as any);
+
+      expect(createMock).toHaveBeenCalledTimes(1);
+      const [args] = createMock.mock.calls[0];
+      expect(args.tools).toEqual([
+        {
+          type: 'function',
+          name: 'local_lookup',
+          description: 'Available locally but not selected by toolChoice.',
+          parameters: {
+            type: 'object',
+            properties: {},
+            additionalProperties: false,
+          },
+          strict: true,
+        },
+      ]);
+      expect(args.tool_choice).toEqual({
+        type: 'function',
+        name: 'prompt_lookup',
+      });
+    });
+  });
+
+  it('keeps named tool_choice when a prompt may supply the selected function alongside explicitly provided local tools', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-tool-choice-explicit-prompt-tools',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-default');
+
+      const request = {
+        systemInstructions: undefined,
+        prompt: { promptId: 'pmpt_tool_choice_explicit_tools' },
+        input: 'hello',
+        modelSettings: { toolChoice: 'missing_tool' },
+        tools: [
+          {
+            type: 'function',
+            name: 'available_tool',
+            description: 'Available locally.',
+            parameters: {
+              type: 'object',
+              properties: {},
+              additionalProperties: false,
+            },
+            strict: true,
+          },
+        ],
+        toolsExplicitlyProvided: true,
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await model.getResponse(request as any);
+
+      expect(createMock).toHaveBeenCalledTimes(1);
+      const [args] = createMock.mock.calls[0];
+      expect(args.tools).toEqual([
+        {
+          type: 'function',
+          name: 'available_tool',
+          description: 'Available locally.',
+          parameters: {
+            type: 'object',
+            properties: {},
+            additionalProperties: false,
+          },
+          strict: true,
+        },
+      ]);
+      expect(args.tool_choice).toEqual({
+        type: 'function',
+        name: 'missing_tool',
+      });
+    });
+  });
+
+  it('keeps tool_choice="none" when prompt omits outgoing tools', async () => {
     await withTrace('test', async () => {
       const fakeResponse = {
         id: 'res-tool-choice-literal',
@@ -547,30 +2434,92 @@ describe('OpenAIResponsesModel', () => {
         responses: { create: createMock },
       } as unknown as OpenAI;
       const model = new OpenAIResponsesModel(fakeClient, 'gpt-default');
-      const toolChoices = ['none', 'required'] as const;
+      const request = {
+        systemInstructions: undefined,
+        prompt: { promptId: 'pmpt_tool_choice_literal' },
+        input: 'hello',
+        modelSettings: { toolChoice: 'none' as const },
+        tools: [],
+        toolsExplicitlyProvided: false,
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+      await model.getResponse(request as any);
 
-      for (const toolChoice of toolChoices) {
-        const request = {
-          systemInstructions: undefined,
-          prompt: { promptId: 'pmpt_tool_choice_literal' },
-          input: 'hello',
-          modelSettings: { toolChoice },
-          tools: [],
-          toolsExplicitlyProvided: false,
-          outputType: 'text',
-          handoffs: [],
-          tracing: false,
-          signal: undefined,
-        };
-        await model.getResponse(request as any);
-      }
+      expect(createMock).toHaveBeenCalledTimes(1);
+      const [args] = createMock.mock.calls[0];
+      expect('tools' in args).toBe(false);
+      expect(args.tool_choice).toBe('none');
+    });
+  });
 
-      expect(createMock).toHaveBeenCalledTimes(toolChoices.length);
-      for (const [index, toolChoice] of toolChoices.entries()) {
-        const [args] = createMock.mock.calls[index];
-        expect('tools' in args).toBe(false);
-        expect(args.tool_choice).toBe(toolChoice);
-      }
+  it('keeps tool_choice="required" when a prompt may supply tools', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-tool-choice-literal-required',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-default');
+
+      const request = {
+        systemInstructions: undefined,
+        prompt: { promptId: 'pmpt_tool_choice_literal' },
+        input: 'hello',
+        modelSettings: { toolChoice: 'required' as const },
+        tools: [],
+        toolsExplicitlyProvided: false,
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await model.getResponse(request as any);
+
+      expect(createMock).toHaveBeenCalledTimes(1);
+      const [args] = createMock.mock.calls[0];
+      expect('tools' in args).toBe(false);
+      expect(args.tool_choice).toBe('required');
+    });
+  });
+
+  it('rejects tool_choice="required" when prompt-backed tools were explicitly disabled', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-tool-choice-literal-required-disabled',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-default');
+
+      const request = {
+        systemInstructions: undefined,
+        prompt: { promptId: 'pmpt_tool_choice_literal' },
+        input: 'hello',
+        modelSettings: { toolChoice: 'required' as const },
+        tools: [],
+        toolsExplicitlyProvided: true,
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await expect(model.getResponse(request as any)).rejects.toThrow(
+        /modelSettings\.toolChoice="required" requires at least one available tool in the outgoing Responses request/,
+      );
+      expect(createMock).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/agents-openai/test/tools.test.ts
+++ b/packages/agents-openai/test/tools.test.ts
@@ -1,5 +1,11 @@
+import { getClientToolSearchExecutor } from '@openai/agents-core';
 import { describe, it, expect } from 'vitest';
-import { fileSearchTool, webSearchTool, imageGenerationTool } from '../src/tools';
+import {
+  fileSearchTool,
+  imageGenerationTool,
+  toolSearchTool,
+  webSearchTool,
+} from '../src/tools';
 
 describe('Tool', () => {
   it('webSearchTool', () => {
@@ -57,5 +63,83 @@ describe('Tool', () => {
     expect(t.name).toBe('image_generation');
     expect(t.providerData!.type).toBe('image_generation');
     expect(t.providerData!.model).toBeUndefined();
+  });
+
+  it('toolSearchTool', () => {
+    const t = toolSearchTool();
+    expect(t).toBeDefined();
+    expect(t.type).toBe('hosted_tool');
+    expect(t.name).toBe('tool_search');
+    expect(t.providerData).toEqual({
+      type: 'tool_search',
+      name: 'tool_search',
+      execution: undefined,
+      description: undefined,
+      parameters: undefined,
+    });
+  });
+
+  it('toolSearchTool supports client execution options', () => {
+    const t = toolSearchTool({
+      execution: 'client',
+      description: 'Search local deferred tools.',
+      parameters: {
+        type: 'object',
+        properties: {
+          paths: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+        },
+      },
+    });
+    expect(t).toMatchObject({
+      type: 'hosted_tool',
+      name: 'tool_search',
+      providerData: {
+        type: 'tool_search',
+        execution: 'client',
+        description: 'Search local deferred tools.',
+        parameters: {
+          type: 'object',
+          properties: {
+            paths: {
+              type: 'array',
+              items: { type: 'string' },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('toolSearchTool attaches client execute handlers', () => {
+    const execute = async () => null;
+    const t = toolSearchTool({
+      execution: 'client',
+      execute,
+    });
+
+    expect(getClientToolSearchExecutor(t)).toBe(execute);
+  });
+
+  it('toolSearchTool rejects execute without client execution', () => {
+    expect(() =>
+      toolSearchTool({
+        execute: async () => null,
+      }),
+    ).toThrow(
+      'toolSearchTool() only supports execute when execution is "client".',
+    );
+  });
+
+  it('toolSearchTool rejects custom names', () => {
+    expect(() =>
+      toolSearchTool({
+        name: 'client_search' as 'tool_search',
+      }),
+    ).toThrow(
+      'toolSearchTool() only supports the canonical built-in name "tool_search".',
+    );
   });
 });

--- a/packages/agents-openai/test/utils/providerData.test.ts
+++ b/packages/agents-openai/test/utils/providerData.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, expectTypeOf } from 'vitest';
 import {
   camelOrSnakeToSnakeCase,
   getProviderDataWithoutReservedKeys,
+  getSnakeCasedProviderDataWithoutReservedKeys,
+  snakeOrCamelToCamelCase,
 } from '../../src/utils/providerData';
 
 describe('camelToSnakeCase', () => {
@@ -55,6 +57,32 @@ describe('camelToSnakeCase', () => {
     expect(camelOrSnakeToSnakeCase(undefined)).toBe(undefined);
   });
 
+  it('preserves object keys inside arrays', () => {
+    expect(
+      camelOrSnakeToSnakeCase({
+        toolResults: [
+          {
+            inputSchema: {
+              properties: {
+                customerId: { type: 'string' },
+              },
+            },
+          },
+        ],
+      }),
+    ).toEqual({
+      tool_results: [
+        {
+          inputSchema: {
+            properties: {
+              customerId: { type: 'string' },
+            },
+          },
+        },
+      ],
+    });
+  });
+
   it('leaves already snake_case keys as is', () => {
     expect(
       camelOrSnakeToSnakeCase({ already_snake: 1, also_snake_case: 2 }),
@@ -69,6 +97,59 @@ describe('camelToSnakeCase', () => {
       foo_bar: 1,
       already_snake: 2,
     });
+  });
+
+  it('preserves a typed snake_cased object shape', () => {
+    const result = camelOrSnakeToSnakeCase({
+      fooBar: 1,
+      nestedValue: { deepKey: 'x' },
+    });
+
+    expectTypeOf(result).toEqualTypeOf<{
+      foo_bar: number;
+      nested_value: { deep_key: string };
+    }>();
+  });
+
+  it('preserves array entry types when arrays are passed through', () => {
+    const result = camelOrSnakeToSnakeCase({
+      toolResults: [{ inputSchema: { customerId: { type: 'string' } } }],
+    });
+
+    expectTypeOf(result.tool_results).toEqualTypeOf<
+      Array<{ inputSchema: { customerId: { type: string } } }>
+    >();
+  });
+});
+
+describe('snakeOrCamelToCamelCase', () => {
+  it('converts snake_case keys recursively', () => {
+    expect(
+      snakeOrCamelToCamelCase({
+        outer_key: {
+          nested_tools: [{ defer_loading: true, function_name: 'lookup' }],
+        },
+      }),
+    ).toEqual({
+      outerKey: {
+        nestedTools: [{ deferLoading: true, functionName: 'lookup' }],
+      },
+    });
+  });
+
+  it('preserves arrays and primitives', () => {
+    expect(snakeOrCamelToCamelCase([1, 2, 3])).toEqual([1, 2, 3]);
+    expect(snakeOrCamelToCamelCase(undefined)).toBe(undefined);
+  });
+
+  it('preserves a typed camelCased object shape', () => {
+    const result = snakeOrCamelToCamelCase({
+      outer_key: { nested_tools: [{ function_name: 'lookup' }] },
+    });
+
+    expectTypeOf(result).toEqualTypeOf<{
+      outerKey: { nestedTools: Array<{ functionName: string }> };
+    }>();
   });
 });
 
@@ -87,6 +168,21 @@ describe('reserved providerData filtering', () => {
     ).toEqual({
       customFlag: true,
       nested: { role: 'keep nested values' },
+    });
+  });
+
+  it('normalizes keys to snake_case before removing reserved keys', () => {
+    expect(
+      getSnakeCasedProviderDataWithoutReservedKeys(
+        {
+          callId: 'override',
+          toolCallId: 'override-too',
+          customFlag: true,
+        },
+        ['call_id', 'tool_call_id'],
+      ),
+    ).toEqual({
+      custom_flag: true,
     });
   });
 });

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -35,7 +35,7 @@
     "@openai/agents-openai": "workspace:*",
     "@openai/agents-realtime": "workspace:*",
     "debug": "^4.4.0",
-    "openai": "^6.20.0"
+    "openai": "^6.26.0"
   },
   "keywords": [
     "openai",

--- a/packages/agents/src/metadata.ts
+++ b/packages/agents/src/metadata.ts
@@ -9,7 +9,7 @@ export const METADATA = {
     "@openai/agents-core": "workspace:*",
     "@openai/agents-openai": "workspace:*",
     "@openai/agents-realtime": "workspace:*",
-    "openai": "^6.20.0"
+    "openai": "^6.26.0"
   }
 };
 

--- a/packages/agents/test/index.test.ts
+++ b/packages/agents/test/index.test.ts
@@ -1,4 +1,4 @@
-import { Agent } from '../src/index';
+import { Agent, toolNamespace, toolSearchTool } from '../src/index';
 import { RealtimeAgent } from '../src/realtime';
 import { isZodObject } from '../src/utils';
 import { describe, test, expect } from 'vitest';
@@ -20,5 +20,26 @@ describe('RealtimeAgent', () => {
 describe('isZodObject', () => {
   test('should be available', () => {
     expect(isZodObject({})).toBe(false);
+  });
+});
+
+describe('Tool search exports', () => {
+  test('toolNamespace and toolSearchTool should be available', () => {
+    expect(typeof toolNamespace).toBe('function');
+    expect(toolSearchTool()).toMatchObject({
+      type: 'hosted_tool',
+      name: 'tool_search',
+      providerData: { type: 'tool_search' },
+    });
+    expect(
+      toolSearchTool({
+        execution: 'client',
+      }),
+    ).toMatchObject({
+      providerData: {
+        type: 'tool_search',
+        execution: 'client',
+      },
+    });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -497,8 +497,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       openai:
-        specifier: ^6.20.0
-        version: 6.20.0(ws@8.18.2)(zod@4.3.5)
+        specifier: ^6.26.0
+        version: 6.26.0(ws@8.18.2)(zod@4.3.5)
 
   examples/research-bot:
     dependencies:
@@ -542,8 +542,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.1
       openai:
-        specifier: ^6.20.0
-        version: 6.20.0(ws@8.18.2)(zod@4.3.5)
+        specifier: ^6.26.0
+        version: 6.26.0(ws@8.18.2)(zod@4.3.5)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -558,8 +558,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.1
       openai:
-        specifier: ^6.20.0
-        version: 6.20.0(ws@8.18.2)(zod@4.3.5)
+        specifier: ^6.26.0
+        version: 6.26.0(ws@8.18.2)(zod@4.3.5)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -615,8 +615,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.1
       openai:
-        specifier: ^6.20.0
-        version: 6.20.0(ws@8.18.2)(zod@4.3.5)
+        specifier: ^6.26.0
+        version: 6.26.0(ws@8.18.2)(zod@4.3.5)
     devDependencies:
       '@ai-sdk/provider':
         specifier: ^1.1.3
@@ -5081,20 +5081,8 @@ packages:
   oniguruma-to-es@4.3.4:
     resolution: {integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==}
 
-  openai@6.10.0:
-    resolution: {integrity: sha512-ITxOGo7rO3XRMiKA5l7tQ43iNNu+iXGFAcf2t+aWVzzqRaS0i7m1K2BhxNdaveB+5eENhO0VY1FkiZzhBk4v3A==}
-    hasBin: true
-    peerDependencies:
-      ws: ^8.18.0
-      zod: ^3.25 || ^4.0
-    peerDependenciesMeta:
-      ws:
-        optional: true
-      zod:
-        optional: true
-
-  openai@6.20.0:
-    resolution: {integrity: sha512-BD3FbcTeQiFE41sCVsGSrY68wjDrcynw0f0g6VjCm0bvhRqUxzKgQGtFZMiSOoazxsN2Tk4NWlzVnjGA8R2QrQ==}
+  openai@6.26.0:
+    resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -7740,7 +7728,7 @@ snapshots:
   '@openai/agents-core@0.3.9(ws@8.18.2)(zod@3.25.76)':
     dependencies:
       debug: 4.4.3
-      openai: 6.10.0(ws@8.18.2)(zod@3.25.76)
+      openai: 6.26.0(ws@8.18.2)(zod@3.25.76)
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.26.0(zod@3.25.76)
       zod: 3.25.76
@@ -7768,7 +7756,7 @@ snapshots:
     dependencies:
       '@openai/agents-core': 0.3.9(ws@8.18.2)(zod@3.25.76)
       debug: 4.4.3
-      openai: 6.10.0(ws@8.18.2)(zod@3.25.76)
+      openai: 6.26.0(ws@8.18.2)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -7794,7 +7782,7 @@ snapshots:
       '@openai/agents-openai': 0.3.9(ws@8.18.2)(zod@3.25.76)
       '@openai/agents-realtime': 0.3.9(zod@3.25.76)
       debug: 4.4.3
-      openai: 6.10.0(ws@8.18.2)(zod@3.25.76)
+      openai: 6.26.0(ws@8.18.2)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -11643,12 +11631,12 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  openai@6.10.0(ws@8.18.2)(zod@3.25.76):
+  openai@6.26.0(ws@8.18.2)(zod@3.25.76):
     optionalDependencies:
       ws: 8.18.2
       zod: 3.25.76
 
-  openai@6.20.0(ws@8.18.2)(zod@4.3.5):
+  openai@6.26.0(ws@8.18.2)(zod@4.3.5):
     optionalDependencies:
       ws: 8.18.2
       zod: 4.3.5


### PR DESCRIPTION
This pull request adds public Responses `tool_search` support across the JS SDK: https://developers.openai.com/api/docs/guides/tools-tool-search

It introduces hosted `toolSearchTool()` support, deferred function and namespace loading in the core runner, `tool_search_call` / `tool_search_output` protocol handling, RunState schema `1.8` serialization, and AI SDK/UI adapter handling that matches tool-search outputs by `call_id` before FIFO fallback.

It also updates the tools example and regression coverage so deferred namespace loading, replay/resume behavior, and streamed output ordering are exercised in the public repo, while bumping the `openai` dependency to the SDK release that exposes the official tool-search response types.