### PR TITLE
docs: refresh docs and examples to gpt-5.4

### DIFF
--- a/docs/src/content/docs/guides/models.mdx
+++ b/docs/src/content/docs/guides/models.mdx
@@ -17,7 +17,7 @@ import setTracingExportApiKeyExample from '../../../../../examples/docs/config/s
 Every Agent ultimately calls an LLM. The SDK abstracts models behind two lightweight interfaces:
 
 - [`Model`](/openai-agents-js/openai/agents/interfaces/model) – knows how to make _one_ request against a specific API.
-- [`ModelProvider`](/openai-agents-js/openai/agents/interfaces/modelprovider) – resolves human‑readable model **names** (e.g. `'gpt‑5.2'`) to `Model` instances.
+- [`ModelProvider`](/openai-agents-js/openai/agents/interfaces/modelprovider) – resolves human‑readable model **names** (e.g. `'gpt‑5.4'`) to `Model` instances.
 
 In day‑to‑day work you normally only interact with model **names** and occasionally `ModelSettings`.
 
@@ -31,14 +31,14 @@ In day‑to‑day work you normally only interact with model **names** and occas
 
 ### Default model
 
-When you don't specify a model when initializing an `Agent`, the default model will be used. The default is currently [`gpt-4.1`](https://platform.openai.com/docs/models/gpt-4.1) for compatibility and low latency. If you have access, we recommend setting your agents to [`gpt-5.2`](https://platform.openai.com/docs/models/gpt-5.2) for higher quality while keeping explicit `modelSettings`.
+When you don't specify a model when initializing an `Agent`, the default model will be used. The default is currently [`gpt-4.1`](https://developers.openai.com/api/docs/models/gpt-4.1) for compatibility and low latency. If you have access, we recommend setting your agents to [`gpt-5.4`](https://developers.openai.com/api/docs/models/gpt-5.4) for higher quality while keeping explicit `modelSettings`.
 
-If you want to switch to other models like [`gpt-5.2`](https://platform.openai.com/docs/models/gpt-5.2), there are two ways to configure your agents.
+If you want to switch to other models like [`gpt-5.4`](https://developers.openai.com/api/docs/models/gpt-5.4), there are two ways to configure your agents.
 
 First, if you want to consistently use a specific model for all agents that do not set a custom model, set the `OPENAI_DEFAULT_MODEL` environment variable before running your agents.
 
 ```bash
-export OPENAI_DEFAULT_MODEL=gpt-5.2
+export OPENAI_DEFAULT_MODEL=gpt-5.4
 node my-awesome-agent.js
 ```
 
@@ -52,7 +52,7 @@ Second, you can set a default model for a `Runner` instance. If you don't set a 
 
 #### GPT-5.x models
 
-When you use any GPT-5.x model such as [`gpt-5.2`](https://platform.openai.com/docs/models/gpt-5.2) in this way, the SDK applies default `modelSettings`. It sets the ones that work the best for most use cases. To adjust the reasoning effort for the default model, pass your own `modelSettings`:
+When you use any GPT-5.x model such as [`gpt-5.4`](https://developers.openai.com/api/docs/models/gpt-5.4) in this way, the SDK applies default `modelSettings`. It sets the ones that work the best for most use cases. To adjust the reasoning effort for the default model, pass your own `modelSettings`:
 
 <Code
   lang="typescript"
@@ -60,7 +60,7 @@ When you use any GPT-5.x model such as [`gpt-5.2`](https://platform.openai.com/d
   title="Customize GPT-5 default settings"
 />
 
-For lower latency, using `reasoning.effort: "none"` with `gpt-5.2` is recommended. The gpt-4.1 family (including mini and nano variants) also remains a solid choice for building interactive agent apps.
+If latency matters, start with `reasoning.effort: "none"` on `gpt-5.4` and increase it only if your task needs more deliberate reasoning. The gpt-4.1 family (including mini and nano variants) also remains a solid choice for building interactive agent apps.
 
 #### Non-GPT-5 models
 
@@ -72,13 +72,12 @@ If you pass a non–GPT-5 model name without custom `modelSettings`, the SDK rev
 
 ### The OpenAI provider
 
-The default `ModelProvider` resolves names using the OpenAI APIs. It supports two distinct
-endpoints:
+The default `ModelProvider` resolves names using the OpenAI APIs. It supports two distinct endpoints:
 
-| API              | Usage                                                             | Call `setOpenAIAPI()`                   |
-| ---------------- | ----------------------------------------------------------------- | --------------------------------------- |
-| Chat Completions | Standard chat & function calls                                    | `setOpenAIAPI('chat_completions')`      |
-| Responses        | New streaming‑first generative API (tool calls, flexible outputs) | `setOpenAIAPI('responses')` _(default)_ |
+| API | Usage | Call `setOpenAIAPI()` |
+| --- | --- | --- |
+| Chat Completions | Standard chat & function calls | `setOpenAIAPI('chat_completions')` |
+| Responses | New streaming‑first generative API (tool calls, flexible outputs) | `setOpenAIAPI('responses')` _(default)_ |
 
 #### Authentication
 
@@ -88,8 +87,7 @@ endpoints:
   title="Set default OpenAI key"
 />
 
-You can also plug your own `OpenAI` client via `setDefaultOpenAIClient(client)` if you need
-custom networking settings.
+You can also plug your own `OpenAI` client via `setDefaultOpenAIClient(client)` if you need custom networking settings.
 
 #### Responses WebSocket transport
 
@@ -127,22 +125,22 @@ See [`examples/basic/stream-ws.ts`](https://github.com/openai/openai-agents-js/t
 
 `ModelSettings` mirrors the OpenAI parameters but is provider‑agnostic.
 
-| Field                  | Type                                                            | Notes                                                                     |
-| ---------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `temperature`          | `number`                                                        | Creativity vs. determinism.                                               |
-| `topP`                 | `number`                                                        | Nucleus sampling.                                                         |
-| `frequencyPenalty`     | `number`                                                        | Penalise repeated tokens.                                                 |
-| `presencePenalty`      | `number`                                                        | Encourage new tokens.                                                     |
-| `toolChoice`           | `'auto' \| 'required' \| 'none' \| string`                      | See [forcing tool use](/openai-agents-js/guides/agents#forcing-tool-use). |
-| `parallelToolCalls`    | `boolean`                                                       | Allow parallel function calls where supported.                            |
-| `truncation`           | `'auto' \| 'disabled'`                                          | Token truncation strategy.                                                |
-| `maxTokens`            | `number`                                                        | Maximum tokens in the response.                                           |
-| `store`                | `boolean`                                                       | Persist the response for retrieval / RAG workflows.                       |
-| `promptCacheRetention` | `'in-memory' \| '24h' \| null`                                  | Controls provider prompt-cache retention when supported.                  |
-| `reasoning.effort`     | `'none' \| 'minimal' \| 'low' \| 'medium' \| 'high' \| 'xhigh'` | Reasoning effort for gpt-5.x models.                                      |
-| `reasoning.summary`    | `'auto' \| 'concise' \| 'detailed'`                             | Controls how much reasoning summary the model returns.                    |
-| `text.verbosity`       | `'low' \| 'medium' \| 'high'`                                   | Text verbosity for gpt-5.x etc.                                           |
-| `providerData`         | `Record<string, any>`                                           | Provider-specific passthrough options forwarded to the underlying model.  |
+| Field | Type | Notes |
+| --- | --- | --- |
+| `temperature` | `number` | Creativity vs. determinism. |
+| `topP` | `number` | Nucleus sampling. |
+| `frequencyPenalty` | `number` | Penalise repeated tokens. |
+| `presencePenalty` | `number` | Encourage new tokens. |
+| `toolChoice` | `'auto' \| 'required' \| 'none' \| string` | See [forcing tool use](/openai-agents-js/guides/agents#forcing-tool-use). |
+| `parallelToolCalls` | `boolean` | Allow parallel function calls where supported. |
+| `truncation` | `'auto' \| 'disabled'` | Token truncation strategy. |
+| `maxTokens` | `number` | Maximum tokens in the response. |
+| `store` | `boolean` | Persist the response for retrieval / RAG workflows. |
+| `promptCacheRetention` | `'in-memory' \| '24h' \| null` | Controls provider prompt-cache retention when supported. |
+| `reasoning.effort` | `'none' \| 'minimal' \| 'low' \| 'medium' \| 'high' \| 'xhigh'` | Reasoning effort for gpt-5.x models. |
+| `reasoning.summary` | `'auto' \| 'concise' \| 'detailed'` | Controls how much reasoning summary the model returns. |
+| `text.verbosity` | `'low' \| 'medium' \| 'high'` | Text verbosity for gpt-5.x etc. |
+| `providerData` | `Record<string, any>` | Provider-specific passthrough options forwarded to the underlying model. |
 
 Attach settings at either level:
 
@@ -154,24 +152,19 @@ Attach settings at either level:
 
 ### Prompt
 
-Agents can be configured with a `prompt` parameter, indicating a server-stored
-prompt configuration that should be used to control the Agent's behavior. Currently,
-this option is only supported when you use the OpenAI
-[Responses API](https://platform.openai.com/docs/api-reference/responses).
+Agents can be configured with a `prompt` parameter, indicating a server-stored prompt configuration that should be used to control the Agent's behavior. Currently, this option is only supported when you use the OpenAI [Responses API](https://platform.openai.com/docs/api-reference/responses).
 
-`prompt` can be either a static object or a function that returns one at runtime. For the callback
-shape, see [Dynamic prompts](/openai-agents-js/guides/agents#dynamic-prompts).
+`prompt` can be either a static object or a function that returns one at runtime. For the callback shape, see [Dynamic prompts](/openai-agents-js/guides/agents#dynamic-prompts).
 
-| Field       | Type     | Notes                                                                                                                                  |
-| ----------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `promptId`  | `string` | Unique identifier for a prompt.                                                                                                        |
-| `version`   | `string` | Version of the prompt you wish to use.                                                                                                 |
+| Field | Type | Notes |
+| --- | --- | --- |
+| `promptId` | `string` | Unique identifier for a prompt. |
+| `version` | `string` | Version of the prompt you wish to use. |
 | `variables` | `object` | A key/value pair of variables to substitute into the prompt. Values can be strings or content input types like text, images, or files. |
 
 <Code lang="typescript" code={promptIdExample} title="Agent with prompt" />
 
-Any additional agent configuration, like tools or instructions, will override the
-values you may have configured in your stored prompt.
+Any additional agent configuration, like tools or instructions, will override the values you may have configured in your stored prompt.
 
 ---
 
@@ -179,8 +172,7 @@ values you may have configured in your stored prompt.
 
 ### Custom model providers
 
-Implementing your own provider is straightforward – implement `ModelProvider` and `Model` and
-pass the provider to the `Runner` constructor:
+Implementing your own provider is straightforward – implement `ModelProvider` and `Model` and pass the provider to the `Runner` constructor:
 
 <Code
   lang="typescript"
@@ -188,8 +180,7 @@ pass the provider to the `Runner` constructor:
   title="Minimal custom provider"
 />
 
-If you want every `run()` call and every newly constructed `Runner` to use the same provider by
-default, set it once during app startup:
+If you want every `run()` call and every newly constructed `Runner` to use the same provider by default, set it once during app startup:
 
 <Code
   lang="typescript"
@@ -197,25 +188,17 @@ default, set it once during app startup:
   title="Set a default model provider"
 />
 
-This is useful when your app standardizes on a non-OpenAI provider and you do not want to pass a
-custom `Runner` everywhere.
+This is useful when your app standardizes on a non-OpenAI provider and you do not want to pass a custom `Runner` everywhere.
 
 #### AI SDK integration
 
-If you want to use non-OpenAI models without implementing `ModelProvider` yourself, see [Using any
-model with Vercel's AI SDK](/openai-agents-js/extensions/ai-sdk). That adapter lets you plug an AI
-SDK model into the Agents runtime directly, which is useful when your app already standardizes on
-AI SDK providers or you want access to the wider provider ecosystem. It also documents how Agents
-SDK `providerData` maps to AI SDK `providerMetadata`, plus the stream helpers available for AI SDK
-UI routes.
+If you want to use non-OpenAI models without implementing `ModelProvider` yourself, see [Using any model with Vercel's AI SDK](/openai-agents-js/extensions/ai-sdk). That adapter lets you plug an AI SDK model into the Agents runtime directly, which is useful when your app already standardizes on AI SDK providers or you want access to the wider provider ecosystem. It also documents how Agents SDK `providerData` maps to AI SDK `providerMetadata`, plus the stream helpers available for AI SDK UI routes.
 
 ---
 
 ### Tracing credentials
 
-Tracing is already enabled by default in supported server runtimes. Use
-`setTracingExportApiKey()` only when trace export should use a different credential than the
-default OpenAI API key:
+Tracing is already enabled by default in supported server runtimes. Use `setTracingExportApiKey()` only when trace export should use a different credential than the default OpenAI API key:
 
 <Code
   lang="typescript"
@@ -223,9 +206,7 @@ default OpenAI API key:
   title="Set tracing export API key"
 />
 
-This sends traces to the [OpenAI dashboard](https://platform.openai.com/traces) using that
-credential. For exporter customization such as custom ingest endpoints or retry tuning, see the
-[Tracing guide](/openai-agents-js/guides/tracing#openai-tracing-exporter).
+This sends traces to the [OpenAI dashboard](https://platform.openai.com/traces) using that credential. For exporter customization such as custom ingest endpoints or retry tuning, see the [Tracing guide](/openai-agents-js/guides/tracing#openai-tracing-exporter).
 
 ---
 

--- a/docs/src/content/docs/guides/voice-agents/build.mdx
+++ b/docs/src/content/docs/guides/voice-agents/build.mdx
@@ -165,7 +165,7 @@ Similarly to regular agents, you can use handoffs to break your agent into multi
 
 Unlike regular agents, handoffs behave slightly differently for Realtime Agents. When a handoff is performed, the ongoing session is updated with the new agent configuration in place. Because of this, the new agent automatically has access to the ongoing conversation history and input filters are currently not applied.
 
-Because the session stays live, the model for that session does not change during a handoff. Voice changes follow the underlying Realtime API rule: they only work before the session has produced audio output. Realtime handoffs are primarily for swapping between `RealtimeAgent` configurations on the same session; if you need to use a different model, for example a reasoning model like `gpt-5.2`, or delegate to a non-realtime backend agent, use [delegation through tools](#delegation-through-tools).
+Because the session stays live, the model for that session does not change during a handoff. Voice changes follow the underlying Realtime API rule: they only work before the session has produced audio output. Realtime handoffs are primarily for swapping between `RealtimeAgent` configurations on the same session; if you need to use a different model, for example a reasoning model like `gpt-5.4`, or delegate to a non-realtime backend agent, use [delegation through tools](#delegation-through-tools).
 
 ### Tools
 

--- a/examples/agent-patterns/agents-as-tools.ts
+++ b/examples/agent-patterns/agents-as-tools.ts
@@ -31,7 +31,7 @@ const orchestratorAgent = new Agent({
       toolDescription: "Translate the user's message to Spanish",
       // You can customize both runner init options and additional options for its execution
       runConfig: {
-        model: 'gpt-5.2',
+        model: 'gpt-5.4',
         modelSettings: {
           reasoning: { effort: 'low' },
           text: { verbosity: 'low' },

--- a/examples/ai-sdk-ui/src/app/api/chat/agents.ts
+++ b/examples/ai-sdk-ui/src/app/api/chat/agents.ts
@@ -15,7 +15,7 @@ export const getWeather = tool({
 export const customerSupportAgent = new Agent({
   name: 'Customer Support Agent',
   handoffDescription: 'Handles billing, refunds, and account access issues.',
-  model: 'gpt-5.2',
+  model: 'gpt-5.4',
   modelSettings: {
     reasoning: { effort: 'low', summary: 'concise' },
     text: { verbosity: 'low' },
@@ -27,7 +27,7 @@ export const customerSupportAgent = new Agent({
 
 export const agent = new Agent({
   name: 'Sky Guide',
-  model: 'gpt-5.2',
+  model: 'gpt-5.4',
   modelSettings: {
     reasoning: { effort: 'none' },
     text: { verbosity: 'low' },

--- a/examples/ai-sdk-ui/src/app/api/chat/text/route.ts
+++ b/examples/ai-sdk-ui/src/app/api/chat/text/route.ts
@@ -7,7 +7,7 @@ import { findOrCreateSession } from '@/app/lib/session';
 
 const textAgent = new Agent({
   name: 'Sky Guide',
-  model: 'gpt-5.2',
+  model: 'gpt-5.4',
   modelSettings: {
     reasoning: { effort: 'high', summary: 'auto' },
     text: { verbosity: 'medium' },

--- a/examples/ai-sdk/README.md
+++ b/examples/ai-sdk/README.md
@@ -7,7 +7,7 @@ These examples show how to wrap models from the [AI SDK](https://www.npmjs.com/p
 | Script | Command | Provider | Description |
 | --- | --- | --- | --- |
 | [index.ts](./index.ts) | `pnpm -F ai-sdk start` | OpenRouter (`OPENROUTER_API_KEY`) | Runs a parent agent that hands off a weather question to a child agent equipped with a `get_weather` tool. |
-| [gpt-5.ts](./gpt-5.ts) | `pnpm -F ai-sdk start:gpt-5` | OpenAI (`OPENAI_API_KEY`) | Shows a single agent that must call the `get_weather` tool using `gpt-5.2` with custom provider options. |
+| [gpt-5.ts](./gpt-5.ts) | `pnpm -F ai-sdk start:gpt-5` | OpenAI (`OPENAI_API_KEY`) | Shows a single agent that must call the `get_weather` tool using `gpt-5.4` with custom provider options. |
 | [stream.ts](./stream.ts) | `pnpm -F ai-sdk start:stream` | OpenAI (`OPENAI_API_KEY`) | Demonstrates streaming text output from an AI SDK model wrapped with `aisdk()`. |
 | [image-tool-output.ts](./image-tool-output.ts) | `pnpm -F ai-sdk start:image-tool-output` | OpenRouter (`OPENROUTER_API_KEY`) | Returns a `ToolOutputImage` from a tool call and asks the model to describe the image. |
 

--- a/examples/ai-sdk/gpt-5.ts
+++ b/examples/ai-sdk/gpt-5.ts
@@ -15,7 +15,7 @@ export async function main() {
     instructions:
       'You are a helpful assistant. When you need to get the weather, you must use tools.',
     tools: [getWeatherTool],
-    model: aisdk(openai('gpt-5.2')),
+    model: aisdk(openai('gpt-5.4')),
     modelSettings: {
       providerData: {
         providerOptions: {

--- a/examples/ai-sdk/index.ts
+++ b/examples/ai-sdk/index.ts
@@ -61,7 +61,7 @@ import { google } from '@ai-sdk/google';
     apiKey: process.env.OPENROUTER_API_KEY,
   });
   const _gptOSS = aisdk(openRouter('openai/gpt-oss-120b'));
-  const _gpt = aisdk(openai('gpt-5.2'));
+  const _gpt = aisdk(openai('gpt-5.4'));
   const _claude = aisdk(anthropic('claude-sonnet-4-5'));
   const _gemini = aisdk(google('gemini-3-flash-preview'));
   void _gptOSS;

--- a/examples/basic/hello-world-gpt-5.ts
+++ b/examples/basic/hello-world-gpt-5.ts
@@ -13,13 +13,13 @@ const output = z.object({
 });
 
 async function main() {
-  withTrace('GPT-5.2 Assistant', async () => {
+  withTrace('GPT-5.4 Assistant', async () => {
     const prompt =
       'Tell me about recursion in programming in a few sentences. Quickly responding with a single answer is fine.';
 
     const agent = new Agent({
-      name: 'GPT-5.2 Assistant',
-      model: 'gpt-5.2',
+      name: 'GPT-5.4 Assistant',
+      model: 'gpt-5.4',
       instructions: "You're a helpful assistant.",
       modelSettings: {
         reasoning: { effort: 'none' },
@@ -44,8 +44,8 @@ async function main() {
     // console.log(result2.finalOutput);
 
     const completionsAgent = new Agent({
-      name: 'GPT-5.2 Assistant',
-      model: new OpenAIChatCompletionsModel(new OpenAI(), 'gpt-5.2'),
+      name: 'GPT-5.4 Assistant',
+      model: new OpenAIChatCompletionsModel(new OpenAI(), 'gpt-5.4'),
       instructions: "You're a helpful assistant.",
       modelSettings: {
         reasoning: { effort: 'none' },

--- a/examples/basic/reasoning.ts
+++ b/examples/basic/reasoning.ts
@@ -7,7 +7,7 @@ const THINKING_PREFIX = styleText(['bgGray', 'black'], 'Thought');
 async function main() {
   const agent = new Agent({
     name: 'Agent',
-    model: process.env.REASONING_MODEL_NAME || 'gpt-5.2',
+    model: process.env.REASONING_MODEL_NAME || 'gpt-5.4',
     modelSettings: {
       reasoning: { effort: 'high', summary: 'auto' },
       text: { verbosity: 'high' },

--- a/examples/basic/stream-ws.ts
+++ b/examples/basic/stream-ws.ts
@@ -12,7 +12,7 @@
  * - `OPENAI_API_KEY`.
  *
  * Optional environment variables:
- * - `OPENAI_MODEL` (defaults to `gpt-5.2-codex`).
+ * - `OPENAI_MODEL` (defaults to `gpt-5.4`).
  * - `OPENAI_BASE_URL`.
  * - `OPENAI_WEBSOCKET_BASE_URL`.
  * - `EXAMPLES_INTERACTIVE_MODE=auto` (auto-approve HITL prompts for scripted runs).
@@ -213,7 +213,7 @@ async function runStreamedTurn(
 }
 
 async function main() {
-  const model = process.env.OPENAI_MODEL ?? 'gpt-5.2-codex';
+  const model = process.env.OPENAI_MODEL ?? 'gpt-5.4';
 
   const policyAgent = new Agent({
     name: 'RefundPolicySpecialist',

--- a/examples/docs/agents/agentCloning.ts
+++ b/examples/docs/agents/agentCloning.ts
@@ -3,7 +3,7 @@ import { Agent } from '@openai/agents';
 const pirateAgent = new Agent({
   name: 'Pirate',
   instructions: 'Respond like a pirate – lots of “Arrr!”',
-  model: 'gpt-5.2',
+  model: 'gpt-5.4',
 });
 
 const robotAgent = pirateAgent.clone({

--- a/examples/docs/agents/simpleAgent.ts
+++ b/examples/docs/agents/simpleAgent.ts
@@ -3,5 +3,5 @@ import { Agent } from '@openai/agents';
 const agent = new Agent({
   name: 'Haiku Agent',
   instructions: 'Always respond in haiku form.',
-  model: 'gpt-5.2', // optional – falls back to the default model
+  model: 'gpt-5.4', // optional – falls back to the default model
 });

--- a/examples/docs/extensions/ai-sdk-model.ts
+++ b/examples/docs/extensions/ai-sdk-model.ts
@@ -1,4 +1,4 @@
 import { openai } from '@ai-sdk/openai';
 import { aisdk } from '@openai/agents-extensions/ai-sdk';
 
-const model = aisdk(openai('gpt-5.2'));
+const model = aisdk(openai('gpt-5.4'));

--- a/examples/docs/extensions/ai-sdk-setup.ts
+++ b/examples/docs/extensions/ai-sdk-setup.ts
@@ -7,7 +7,7 @@ import { openai } from '@ai-sdk/openai';
 import { aisdk } from '@openai/agents-extensions/ai-sdk';
 
 // Create a model instance to be used by the agent
-const model = aisdk(openai('gpt-5.2'));
+const model = aisdk(openai('gpt-5.4'));
 
 // Create an agent with the model
 const agent = new Agent({

--- a/examples/docs/extensions/ai-sdk-transform-output-text.ts
+++ b/examples/docs/extensions/ai-sdk-transform-output-text.ts
@@ -1,7 +1,7 @@
 import { openai } from '@ai-sdk/openai';
 import { aisdk } from '@openai/agents-extensions/ai-sdk';
 
-const model = aisdk(openai('gpt-5.2'), {
+const model = aisdk(openai('gpt-5.4'), {
   transformOutputText(text) {
     return text.match(/```(?:json)?\s*([\s\S]*?)\s*```/)?.[1]?.trim() ?? text;
   },

--- a/examples/docs/models/agentWithModel.ts
+++ b/examples/docs/models/agentWithModel.ts
@@ -2,5 +2,5 @@ import { Agent } from '@openai/agents';
 
 const agent = new Agent({
   name: 'Creative writer',
-  model: 'gpt-5.2',
+  model: 'gpt-5.4',
 });

--- a/examples/docs/models/gpt5DefaultModelSettings.ts
+++ b/examples/docs/models/gpt5DefaultModelSettings.ts
@@ -3,9 +3,9 @@ import { Agent } from '@openai/agents';
 const myAgent = new Agent({
   name: 'My Agent',
   instructions: "You're a helpful agent.",
-  // If OPENAI_DEFAULT_MODEL=gpt-5.2 is set, passing only modelSettings works.
+  // If OPENAI_DEFAULT_MODEL=gpt-5.4 is set, passing only modelSettings works.
   // It's also fine to pass a GPT-5.x model name explicitly:
-  model: 'gpt-5.2',
+  model: 'gpt-5.4',
   modelSettings: {
     reasoning: { effort: 'high' },
     text: { verbosity: 'low' },

--- a/examples/docs/sessions/responsesCompactionManualSession.ts
+++ b/examples/docs/sessions/responsesCompactionManualSession.ts
@@ -8,7 +8,7 @@ import {
 const agent = new Agent({
   name: 'Support',
   instructions: 'Answer briefly and keep track of prior context.',
-  model: 'gpt-5.2',
+  model: 'gpt-5.4',
 });
 
 // Disable auto-compaction to avoid delaying stream completion.

--- a/examples/docs/sessions/responsesCompactionSession.ts
+++ b/examples/docs/sessions/responsesCompactionSession.ts
@@ -8,7 +8,7 @@ import {
 const agent = new Agent({
   name: 'Support',
   instructions: 'Answer briefly and keep track of prior context.',
-  model: 'gpt-5.2',
+  model: 'gpt-5.4',
 });
 
 // Wrap any Session to trigger responses.compact once history grows beyond your threshold.
@@ -16,7 +16,7 @@ const session = new OpenAIResponsesCompactionSession({
   // You can pass any Session implementation except OpenAIConversationsSession
   underlyingSession: new MemorySession(),
   // (optional) The model used for calling responses.compact API
-  model: 'gpt-5.2',
+  model: 'gpt-5.4',
   // (optional) your custom logic here
   shouldTriggerCompaction: ({ compactionCandidateItems }) => {
     return compactionCandidateItems.length >= 12;

--- a/examples/docs/tools/codexRunContextThread.ts
+++ b/examples/docs/tools/codexRunContextThread.ts
@@ -19,7 +19,7 @@ const agent = new Agent<ExampleContext>({
       sandboxMode: 'workspace-write',
       workingDirectory: '/path/to/repo',
       defaultThreadOptions: {
-        model: 'gpt-5.2-codex',
+        model: 'gpt-5.4',
         approvalPolicy: 'never',
       },
     }),

--- a/examples/docs/tools/codexTool.ts
+++ b/examples/docs/tools/codexTool.ts
@@ -10,7 +10,7 @@ export const codexAgent = new Agent({
       sandboxMode: 'workspace-write',
       workingDirectory: '/path/to/repo',
       defaultThreadOptions: {
-        model: 'gpt-5.2-codex',
+        model: 'gpt-5.4',
         networkAccessEnabled: true,
         webSearchEnabled: false,
       },

--- a/examples/docs/voice-agents/serverAgent.ts
+++ b/examples/docs/voice-agents/serverAgent.ts
@@ -9,7 +9,7 @@ const agent = new Agent({
   name: 'Refund Expert',
   instructions:
     'You are a refund expert. You are given a request to process a refund and you need to determine if the request is valid.',
-  model: 'gpt-5.2',
+  model: 'gpt-5.4',
   outputType: z.object({
     reasong: z.string(),
     refundApproved: z.boolean(),

--- a/examples/financial-research-agent/agents.ts
+++ b/examples/financial-research-agent/agents.ts
@@ -46,7 +46,7 @@ export type FinancialSearchPlan = z.infer<typeof FinancialSearchPlan>;
 export const plannerAgent = new Agent({
   name: 'FinancialPlannerAgent',
   instructions: plannerPrompt,
-  model: 'gpt-5.2',
+  model: 'gpt-5.4',
   outputType: FinancialSearchPlan,
 });
 
@@ -69,7 +69,7 @@ Focus on key numbers, events, or quotes that will be useful to a financial analy
 export const searchAgent = new Agent({
   name: 'FinancialSearchAgent',
   instructions: searchAgentPrompt,
-  model: 'gpt-5.2',
+  model: 'gpt-5.4',
   tools: [webSearchTool()],
 });
 
@@ -92,7 +92,7 @@ export type VerificationResult = z.infer<typeof VerificationResult>;
 export const verifierAgent = new Agent({
   name: 'VerificationAgent',
   instructions: verifierPrompt,
-  model: 'gpt-5.2',
+  model: 'gpt-5.4',
   outputType: VerificationResult,
 });
 
@@ -115,6 +115,6 @@ export type FinancialReportData = z.infer<typeof FinancialReportData>;
 export const writerAgent = new Agent({
   name: 'FinancialWriterAgent',
   instructions: writerPrompt,
-  model: 'gpt-5.2',
+  model: 'gpt-5.4',
   outputType: FinancialReportData,
 });

--- a/examples/memory/hitl-session-scenario.ts
+++ b/examples/memory/hitl-session-scenario.ts
@@ -430,7 +430,7 @@ async function main() {
     process.exit(1);
   }
 
-  const modelOverride = process.env.HITL_MODEL ?? 'gpt-5.2';
+  const modelOverride = process.env.HITL_MODEL ?? 'gpt-5.4';
   await runFileSessionScenario(modelOverride);
   await runOpenAISessionScenario(modelOverride);
 }

--- a/examples/memory/oai-compact-stateless.ts
+++ b/examples/memory/oai-compact-stateless.ts
@@ -9,7 +9,7 @@ import { fetchImageData } from './tools';
 
 async function main() {
   const session = new OpenAIResponsesCompactionSession({
-    model: 'gpt-5.2',
+    model: 'gpt-5.4',
     // If store: false in modelSettings, auto switches to input mode.
     // compactionMode: 'input',
     // Use a local session store because the server is stateless when store is false.
@@ -22,7 +22,7 @@ async function main() {
 
   const agent = new Agent({
     name: 'Assistant',
-    model: 'gpt-5.2',
+    model: 'gpt-5.4',
     instructions:
       'Keep answers short. This example demonstrates responses.compact with input mode and store=false. For every user turn, call fetch_image_data with the provided label. Do not include raw image bytes or data URLs in your final answer.',
     modelSettings: {

--- a/examples/memory/oai-compact.ts
+++ b/examples/memory/oai-compact.ts
@@ -9,7 +9,7 @@ import { FileSession } from './sessions';
 
 async function main() {
   const session = new OpenAIResponsesCompactionSession({
-    model: 'gpt-5.2',
+    model: 'gpt-5.4',
     // This compaction decorator handles only compaction logic.
     // The underlying session is responsible for storing the history.
     underlyingSession: new FileSession(),
@@ -24,7 +24,7 @@ async function main() {
 
   const agent = new Agent({
     name: 'Assistant',
-    model: 'gpt-5.2',
+    model: 'gpt-5.4',
     instructions:
       'Keep answers short. This example demonstrates responses.compact with a custom session. For every user turn, call fetch_image_data with the provided label. Do not include raw image bytes or data URLs in your final answer.',
     modelSettings: { toolChoice: 'required' },

--- a/examples/model-providers/custom-example-agent.ts
+++ b/examples/model-providers/custom-example-agent.ts
@@ -21,7 +21,7 @@ const getWeatherTool = tool({
 const client = new OpenAI();
 const agent = new Agent({
   name: 'Assistant',
-  model: new OpenAIChatCompletionsModel(client, 'gpt-5.2'),
+  model: new OpenAIChatCompletionsModel(client, 'gpt-5.4'),
   instructions: 'You only respond in haikus.',
   tools: [getWeatherTool],
 });

--- a/examples/realtime-next/src/app/server/backendAgent.action.tsx
+++ b/examples/realtime-next/src/app/server/backendAgent.action.tsx
@@ -8,7 +8,7 @@ const backendAgent = new Agent({
   name: 'Refund Agent',
   instructions:
     'You are a specialist on handling refund requests and detect fraud. You are given a request and you need to determine if the request is valid and if it is, you need to handle it.',
-  model: 'gpt-5.2',
+  model: 'gpt-5.4',
   outputType: z.object({
     refundApproved: z.boolean(),
     refundReason: z.string(),

--- a/examples/research-bot/agents.ts
+++ b/examples/research-bot/agents.ts
@@ -27,7 +27,7 @@ export type WebSearchPlan = z.infer<typeof webSearchPlan>;
 export const plannerAgent = new Agent({
   name: 'PlannerAgent',
   instructions: plannerPrompt,
-  model: 'gpt-5.2',
+  model: 'gpt-5.4',
   outputType: webSearchPlan,
 });
 

--- a/examples/tools/apply-patch.ts
+++ b/examples/tools/apply-patch.ts
@@ -112,7 +112,10 @@ async function main() {
 
   const agent = new Agent({
     name: 'Patch Assistant',
-    model: 'gpt-5.2',
+    model: 'gpt-5.4',
+    modelSettings: {
+      reasoning: { effort: 'low' },
+    },
     instructions: `You can edit files inside ${workspaceRoot} using the apply_patch tool.`,
     tools: [
       applyPatchTool({
@@ -150,7 +153,7 @@ async function main() {
       );
       const result2 = await run(
         agent,
-        `<BEGIN_FILES>\n===== tasks.md\n${updatedNotes}\n\n<END_FILES>\nCheck off the last two items from the file.`,
+        `<BEGIN_FILES>\n===== tasks.md\n${updatedNotes}\n\n<END_FILES>\nUse the apply_patch tool to update tasks.md in place. Preserve the existing Markdown structure exactly, keep the \`- [ ]\` checklist prefix style consistent, and check off only the last two items.`,
       );
       console.log(`${chalk.bold('Agent:')} ${chalk.cyan(result2.finalOutput)}`);
     });

--- a/examples/tools/codex-same-thread.ts
+++ b/examples/tools/codex-same-thread.ts
@@ -87,7 +87,7 @@ async function main(): Promise<void> {
             name: 'codex_engineer',
             sandboxMode: 'workspace-write',
             defaultThreadOptions: {
-              model: 'gpt-5.2-codex',
+              model: 'gpt-5.4',
               modelReasoningEffort: 'low',
               networkAccessEnabled: true,
               webSearchEnabled: false,

--- a/examples/tools/codex.ts
+++ b/examples/tools/codex.ts
@@ -116,7 +116,7 @@ async function main(): Promise<void> {
       const codex = codexTool({
         sandboxMode: 'workspace-write',
         defaultThreadOptions: {
-          model: 'gpt-5.2-codex',
+          model: 'gpt-5.4',
           modelReasoningEffort: 'low',
           networkAccessEnabled: true,
           webSearchEnabled: false,

--- a/examples/tools/container-shell-inline-skill.ts
+++ b/examples/tools/container-shell-inline-skill.ts
@@ -26,7 +26,7 @@ async function main() {
   await withTrace('container-shell-inline-skill-example', async () => {
     const agent1 = new Agent({
       name: 'Container Shell Agent (Inline Skill)',
-      model: 'gpt-5.2',
+      model: 'gpt-5.4',
       modelSettings: { reasoning: { effort: 'low' } },
       instructions:
         'Use the available container skill to answer user requests.',
@@ -52,7 +52,7 @@ async function main() {
 
     const agent2 = new Agent({
       name: 'Container Reference Shell Agent',
-      model: 'gpt-5.2-codex',
+      model: 'gpt-5.4',
       modelSettings: { reasoning: { effort: 'low' } },
       instructions: 'Reuse the existing shell container and answer concisely.',
       tools: [

--- a/examples/tools/container-shell-skill-ref.ts
+++ b/examples/tools/container-shell-skill-ref.ts
@@ -22,7 +22,7 @@ async function main() {
   await withTrace('container-shell-tool-example', async () => {
     const agent1 = new Agent({
       name: 'Container Shell Agent',
-      model: 'gpt-5.2',
+      model: 'gpt-5.4',
       modelSettings: { reasoning: { effort: 'low' } },
       instructions: 'Use the available container to answer user requests.',
       tools: [
@@ -52,7 +52,7 @@ async function main() {
 
     const agent2 = new Agent({
       name: 'Container Reference Shell Agent',
-      model: 'gpt-5.2-codex',
+      model: 'gpt-5.4',
       modelSettings: { reasoning: { effort: 'low' } },
       instructions: 'Reuse the existing shell container and answer concisely.',
       tools: [
@@ -196,7 +196,7 @@ async function assertSkillUsableInResponses(
   reference: ShellToolSkillReference,
 ): Promise<void> {
   await client.responses.create({
-    model: 'gpt-5.2',
+    model: 'gpt-5.4',
     reasoning: { effort: 'none' },
     input: 'Reply with exactly "ready".',
     max_output_tokens: 16,

--- a/examples/tools/local-shell.ts
+++ b/examples/tools/local-shell.ts
@@ -97,7 +97,7 @@ async function main() {
 
   const agent = new Agent({
     name: 'Shell Assistant',
-    model: 'gpt-5.2',
+    model: 'gpt-5.4',
     instructions:
       'You can execute shell commands to inspect the repository. Keep responses concise and include command output when helpful.',
     tools: [

--- a/examples/tools/web-search-filters.ts
+++ b/examples/tools/web-search-filters.ts
@@ -3,7 +3,7 @@ import { Agent, run, webSearchTool, withTrace } from '@openai/agents';
 async function main() {
   const agent = new Agent({
     name: 'OAI website searcher',
-    model: 'gpt-5.2',
+    model: 'gpt-5.4',
     instructions:
       'You are a helpful agent that can search openai.com resources.',
     tools: [


### PR DESCRIPTION
This pull request updates English docs and user-facing examples to prefer `gpt-5.4` over older `gpt-5.2` references across guides, AI SDK samples, basic examples, memory samples, and tool examples.

It keeps stable example filenames such as `gpt-5.ts` while refreshing the underlying model names and accompanying prose in the models and voice-agents guides. It also tightens the `apply-patch` example for `gpt-5.4` by adding low reasoning effort and a more explicit in-place edit prompt after live validation showed malformed patch context without that extra guidance.