### PR TITLE
test: expand coverage for helper and session edge cases

### DIFF
--- a/.changeset/fresh-mugs-sit.md
+++ b/.changeset/fresh-mugs-sit.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+---
+
+test: add coverage for helper edge cases and conversation session branches

--- a/packages/agents-core/test/agentToolInput.test.ts
+++ b/packages/agents-core/test/agentToolInput.test.ts
@@ -140,4 +140,95 @@ describe('agentToolInput', () => {
     expect(result).toContain('"name": "Ada"');
     expect(result).toContain('"type": "object"');
   });
+
+  it('buildStructuredInputSchemaInfo unwraps decorated Zod fields and inner descriptions', () => {
+    const schema = z.object({
+      createdAt: z
+        .string()
+        .default('now')
+        .nullable()
+        .describe('Creation timestamp.'),
+      enabled: z
+        .boolean()
+        .catch(false)
+        .describe('Whether the flag is enabled.'),
+    });
+
+    const info = buildStructuredInputSchemaInfo(schema, 'tool', false);
+
+    expect(info.summary).toContain(
+      '- createdAt (string | null, required) - Creation timestamp.',
+    );
+    expect(info.summary).toContain(
+      '- enabled (boolean, required) - Whether the flag is enabled.',
+    );
+  });
+
+  it('buildStructuredInputSchemaInfo summarizes native enums and truncates long enum previews', () => {
+    enum Status {
+      Draft = 'draft',
+      Queued = 'queued',
+      Running = 'running',
+      Done = 'done',
+      Failed = 'failed',
+      Canceled = 'canceled',
+    }
+
+    const schema = z.object({
+      status: z.nativeEnum(Status).describe('Execution status.'),
+      mode: z.enum(['a', 'b', 'c', 'd', 'e', 'f']).describe('Preview mode.'),
+    });
+
+    const info = buildStructuredInputSchemaInfo(schema, 'tool', false);
+
+    expect(info.summary).toContain(
+      '- status (enum("draft" | "queued" | "running" | "done" | "failed" | ...), required) - Execution status.',
+    );
+    expect(info.summary).toContain(
+      '- mode (enum("a" | "b" | "c" | "d" | "e" | ...), required) - Preview mode.',
+    );
+  });
+
+  it('buildStructuredInputSchemaInfo omits summaries for unsupported Zod field shapes', () => {
+    const schema = z.object({
+      nested: z
+        .object({
+          value: z.string(),
+        })
+        .describe('Nested payload.'),
+    });
+
+    const info = buildStructuredInputSchemaInfo(schema, 'tool', false);
+
+    expect(info.summary).toBeUndefined();
+  });
+
+  it('buildStructuredInputSchemaInfo omits summaries for unsupported JSON schema fields', () => {
+    const schema: ToolInputParametersStrict = {
+      type: 'object',
+      description: 'Payload.',
+      properties: {
+        nested: {
+          type: 'object',
+          properties: {
+            value: { type: 'string' },
+          },
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    };
+
+    const info = buildStructuredInputSchemaInfo(schema, 'tool', false);
+
+    expect(info.summary).toBeUndefined();
+  });
+
+  it('resolveAgentToolInput returns null when params are undefined without schema info', async () => {
+    const result = await resolveAgentToolInput({
+      params: undefined,
+    });
+
+    expect(result).toBe('null');
+  });
 });

--- a/packages/agents-core/test/runner/mcpApprovals.test.ts
+++ b/packages/agents-core/test/runner/mcpApprovals.test.ts
@@ -215,4 +215,92 @@ describe('handleHostedMcpApprovals', () => {
     expect(result.pendingApprovals.has(approvalRequest.requestItem)).toBe(true);
     expect(result.pendingApprovalIds.has('mcpr_pending')).toBe(true);
   });
+
+  it('ignores non-hosted raw items', async () => {
+    const result = await handleHostedMcpApprovals({
+      requests: [
+        {
+          requestItem: {
+            rawItem: {
+              type: 'function_call',
+              name: 'list_files',
+            },
+          },
+          mcpTool: hostedMcpTool({
+            serverLabel: 'stub',
+            requireApproval: 'always',
+          }),
+        } as any,
+      ],
+      agent: TEST_AGENT,
+      state,
+      functionResults,
+      appendIfNew: (item) => newItems.push(item),
+    });
+
+    expect(functionResults).toHaveLength(0);
+    expect(newItems).toHaveLength(0);
+    expect(result.pendingApprovals.size).toBe(0);
+    expect(result.pendingApprovalIds.size).toBe(0);
+  });
+
+  it('ignores hosted approval items that are missing provider data', async () => {
+    const approvalRequest = buildApprovalRequest('mcpr_missing_provider_data');
+    (
+      approvalRequest.requestItem.rawItem as protocol.HostedToolCallItem
+    ).providerData = undefined as any;
+
+    const result = await handleHostedMcpApprovals({
+      requests: [approvalRequest],
+      agent: TEST_AGENT,
+      state,
+      functionResults,
+      appendIfNew: (item) => newItems.push(item),
+    });
+
+    expect(functionResults).toHaveLength(0);
+    expect(newItems).toHaveLength(0);
+    expect(result.pendingApprovals.size).toBe(0);
+    expect(result.pendingApprovalIds.size).toBe(0);
+  });
+
+  it('treats approval requests without ids as pending without tracking an id', async () => {
+    const approvalRequest = buildApprovalRequest('mcpr_missing_id');
+    const rawItem = approvalRequest.requestItem
+      .rawItem as protocol.HostedToolCallItem;
+
+    rawItem.id = undefined as any;
+    (rawItem.providerData as HostedMCPApprovalRequest).id = undefined as any;
+
+    const result = await handleHostedMcpApprovals({
+      requests: [approvalRequest],
+      agent: TEST_AGENT,
+      state,
+      functionResults,
+      appendIfNew: (item) => newItems.push(item),
+      resolveApproval: () => false,
+    });
+
+    expect(functionResults).toHaveLength(1);
+    expect(newItems).toContain(approvalRequest.requestItem);
+    expect(result.pendingApprovals.has(approvalRequest.requestItem)).toBe(true);
+    expect(result.pendingApprovalIds.size).toBe(0);
+  });
+
+  it('surfaces pending approvals when no resolver is provided', async () => {
+    const approvalRequest = buildApprovalRequest('mcpr_no_resolver');
+
+    const result = await handleHostedMcpApprovals({
+      requests: [approvalRequest],
+      agent: TEST_AGENT,
+      state,
+      functionResults,
+      appendIfNew: (item) => newItems.push(item),
+    });
+
+    expect(functionResults).toHaveLength(1);
+    expect(newItems).toContain(approvalRequest.requestItem);
+    expect(result.pendingApprovals.has(approvalRequest.requestItem)).toBe(true);
+    expect(result.pendingApprovalIds.has('mcpr_no_resolver')).toBe(true);
+  });
 });

--- a/packages/agents-core/test/tooling.test.ts
+++ b/packages/agents-core/test/tooling.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getToolCallDisplayName,
+  getToolSearchExecution,
+  getToolSearchMatchKey,
+  getToolSearchOutputReplacementKey,
+  getToolSearchProviderCallId,
+  isClientToolSearchCall,
+  resolveToolSearchCallId,
+  shouldQueuePendingToolSearchCall,
+  takePendingToolSearchCallId,
+  toolDisplayName,
+  toolQualifiedName,
+} from '../src/tooling';
+
+describe('tooling', () => {
+  it('formats qualified and display names defensively', () => {
+    expect(toolQualifiedName(undefined, 'search')).toBeUndefined();
+    expect(toolQualifiedName('lookup', 'search')).toBe('search.lookup');
+    expect(toolDisplayName('lookup', undefined)).toBe('lookup');
+    expect(toolDisplayName('lookup', 'lookup')).toBe('lookup');
+    expect(
+      getToolCallDisplayName({ name: 'lookup', namespace: 'search' }),
+    ).toBe('search.lookup');
+  });
+
+  it('prefers provider call ids over top-level ids', () => {
+    const value = {
+      id: 'item-1',
+      call_id: 'top-level',
+      providerData: {
+        call_id: 'provider-call-id',
+      },
+    };
+
+    expect(getToolSearchProviderCallId(value)).toBe('provider-call-id');
+    expect(getToolSearchMatchKey(value)).toBe('provider-call-id');
+    expect(getToolSearchOutputReplacementKey(value)).toBe(
+      'call:provider-call-id',
+    );
+  });
+
+  it('supports camelCase provider ids and falls back to the item id', () => {
+    expect(
+      getToolSearchProviderCallId({
+        providerData: {
+          callId: 'provider-call-id',
+        },
+      }),
+    ).toBe('provider-call-id');
+    expect(getToolSearchMatchKey({ id: 'item-2' })).toBe('item-2');
+    expect(getToolSearchOutputReplacementKey({ id: 'item-2' })).toBe(
+      'item:item-2',
+    );
+  });
+
+  it('derives execution mode from top-level or provider data', () => {
+    expect(getToolSearchExecution({ execution: 'client' })).toBe('client');
+    expect(
+      getToolSearchExecution({
+        providerData: { execution: 'server' },
+      }),
+    ).toBe('server');
+    expect(isClientToolSearchCall({ execution: 'client' })).toBe(true);
+    expect(shouldQueuePendingToolSearchCall({ execution: 'server' })).toBe(
+      false,
+    );
+    expect(shouldQueuePendingToolSearchCall({})).toBe(true);
+  });
+
+  it('resolves tool search call ids from explicit values or fallback generators', () => {
+    expect(
+      resolveToolSearchCallId(
+        {
+          callId: 'call-123',
+        },
+        () => 'generated-id',
+      ),
+    ).toBe('call-123');
+    expect(resolveToolSearchCallId({}, () => 'generated-id')).toBe(
+      'generated-id',
+    );
+    expect(() => resolveToolSearchCallId({})).toThrow(
+      'Tool search item is missing both call_id and id.',
+    );
+  });
+
+  it('consumes pending ids for client-side items and removes matched explicit ids', () => {
+    const pendingCallIds = ['pending-1', 'pending-2'];
+
+    expect(
+      takePendingToolSearchCallId(
+        {
+          providerData: { call_id: 'pending-2' },
+        },
+        pendingCallIds,
+      ),
+    ).toBe('pending-2');
+    expect(pendingCallIds).toEqual(['pending-1']);
+
+    expect(
+      takePendingToolSearchCallId(
+        {
+          execution: 'client',
+        },
+        pendingCallIds,
+        () => 'generated-client-id',
+      ),
+    ).toBe('pending-1');
+    expect(pendingCallIds).toEqual([]);
+  });
+
+  it('uses explicit or generated ids for server-side items without consuming the queue', () => {
+    const pendingCallIds = ['pending-1'];
+
+    expect(
+      takePendingToolSearchCallId(
+        {
+          execution: 'server',
+          id: 'server-item-id',
+        },
+        pendingCallIds,
+        () => 'generated-server-id',
+      ),
+    ).toBe('server-item-id');
+    expect(pendingCallIds).toEqual(['pending-1']);
+
+    expect(
+      takePendingToolSearchCallId(
+        {
+          execution: 'client',
+        },
+        pendingCallIds,
+        () => 'generated-client-id',
+      ),
+    ).toBe('pending-1');
+    expect(
+      takePendingToolSearchCallId(
+        {
+          execution: 'client',
+        },
+        [],
+        () => 'generated-client-id',
+      ),
+    ).toBe('generated-client-id');
+  });
+});

--- a/packages/agents-core/test/utils/abortSignals.test.ts
+++ b/packages/agents-core/test/utils/abortSignals.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+
+import {
+  combineAbortSignals,
+  combineAbortSignalsWithOptions,
+} from '../../src/utils/abortSignals';
+
+describe('utils/abortSignals', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns no signal when no signals are provided', () => {
+    const result = combineAbortSignals(undefined, undefined);
+    expect(result.signal).toBeUndefined();
+    expect(() => result.cleanup()).not.toThrow();
+  });
+
+  it('uses AbortSignal.any when it succeeds', () => {
+    const controller = new AbortController();
+    const combinedSignal = new AbortController().signal;
+    const anySpy = vi
+      .spyOn(
+        AbortSignal as typeof AbortSignal & { any: typeof AbortSignal.any },
+        'any',
+      )
+      .mockReturnValue(combinedSignal);
+
+    const result = combineAbortSignals(controller.signal);
+
+    expect(anySpy).toHaveBeenCalledWith([controller.signal]);
+    expect(result.signal).toBe(combinedSignal);
+    expect(() => result.cleanup()).not.toThrow();
+  });
+
+  it('falls back when AbortSignal.any throws and propagates abort reasons', () => {
+    const first = new AbortController();
+    const second = new AbortController();
+    const onAbortSignalAnyError = vi.fn();
+
+    vi.spyOn(
+      AbortSignal as typeof AbortSignal & { any: typeof AbortSignal.any },
+      'any',
+    ).mockImplementation(() => {
+      throw new Error('AbortSignal.any failed');
+    });
+
+    const result = combineAbortSignalsWithOptions(
+      [first.signal, second.signal],
+      { onAbortSignalAnyError },
+    );
+
+    second.abort('manual-fallback');
+
+    expect(onAbortSignalAnyError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'AbortSignal.any failed' }),
+    );
+    expect(result.signal?.aborted).toBe(true);
+    expect(result.signal?.reason).toBe('manual-fallback');
+  });
+
+  it('aborts immediately when an input signal is already aborted', () => {
+    const aborted = new AbortController();
+    const active = new AbortController();
+    aborted.abort('already-aborted');
+
+    vi.spyOn(
+      AbortSignal as typeof AbortSignal & { any: typeof AbortSignal.any },
+      'any',
+    ).mockImplementation(() => {
+      throw new Error('AbortSignal.any failed');
+    });
+
+    const result = combineAbortSignalsWithOptions([
+      aborted.signal,
+      active.signal,
+    ]);
+
+    expect(result.signal?.aborted).toBe(true);
+    expect(result.signal?.reason).toBe('already-aborted');
+  });
+
+  it('removes registered listeners during cleanup', () => {
+    const makeSignal = (reason: string) => {
+      const signal = {
+        aborted: false,
+        reason,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      };
+      return signal as unknown as AbortSignal;
+    };
+
+    const signal = makeSignal('unused');
+    const otherSignal = makeSignal('other');
+
+    vi.spyOn(
+      AbortSignal as typeof AbortSignal & { any: typeof AbortSignal.any },
+      'any',
+    ).mockImplementation(() => {
+      throw new Error('AbortSignal.any failed');
+    });
+
+    const result = combineAbortSignalsWithOptions([signal, otherSignal]);
+
+    result.cleanup();
+
+    expect((signal as any).removeEventListener).toHaveBeenCalledWith(
+      'abort',
+      expect.any(Function),
+    );
+    expect((otherSignal as any).removeEventListener).toHaveBeenCalledWith(
+      'abort',
+      expect.any(Function),
+    );
+  });
+});

--- a/packages/agents-openai/test/openaiConversationsSession.test.ts
+++ b/packages/agents-openai/test/openaiConversationsSession.test.ts
@@ -513,6 +513,211 @@ describe('OpenAIConversationsSession', () => {
     });
   });
 
+  it('returns an empty array for non-positive limits without listing items', async () => {
+    const list = vi.fn();
+
+    const session = createSession({
+      client: {
+        conversations: {
+          items: {
+            list,
+            create: vi.fn(),
+            delete: vi.fn(),
+          },
+          create: vi.fn(),
+          delete: vi.fn(),
+        },
+      } as any,
+      conversationId: 'conv-123',
+    });
+
+    await expect(session.getItems(0)).resolves.toEqual([]);
+    await expect(session.getItems(-1)).resolves.toEqual([]);
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it('skips addItems when no items are provided', async () => {
+    const createItems = vi.fn();
+    const createConversation = vi.fn();
+
+    const session = createSession({
+      client: {
+        conversations: {
+          items: {
+            list: vi.fn(),
+            create: createItems,
+            delete: vi.fn(),
+          },
+          create: createConversation,
+          delete: vi.fn(),
+        },
+      } as any,
+    });
+
+    await session.addItems([]);
+
+    expect(createItems).not.toHaveBeenCalled();
+    expect(createConversation).not.toHaveBeenCalled();
+    expect(getInputItemsMock).not.toHaveBeenCalled();
+  });
+
+  it('popItem returns undefined when no items are available', async () => {
+    const list = vi.fn(() => ({
+      async *[Symbol.asyncIterator]() {},
+    }));
+    const deleteMock = vi.fn();
+
+    const session = createSession({
+      client: {
+        conversations: {
+          items: {
+            list,
+            create: vi.fn(),
+            delete: deleteMock,
+          },
+          create: vi.fn(),
+          delete: vi.fn(),
+        },
+      } as any,
+      conversationId: 'conv-123',
+    });
+
+    await expect(session.popItem()).resolves.toBeUndefined();
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it('popItem returns the newest item even when it has no id', async () => {
+    convertToOutputItemMock.mockReturnValue([
+      {
+        type: 'message',
+        role: 'assistant',
+        content: [],
+      },
+    ] as any);
+
+    const list = vi.fn(() => ({
+      async *[Symbol.asyncIterator]() {
+        yield {
+          id: 'resp-1',
+          type: 'message',
+          role: 'assistant',
+          content: [],
+        } as any;
+      },
+    }));
+    const deleteMock = vi.fn();
+
+    const session = createSession({
+      client: {
+        conversations: {
+          items: {
+            list,
+            create: vi.fn(),
+            delete: deleteMock,
+          },
+          create: vi.fn(),
+          delete: vi.fn(),
+        },
+      } as any,
+      conversationId: 'conv-123',
+    });
+
+    const popped = await session.popItem();
+
+    expect(popped).toEqual({
+      type: 'message',
+      role: 'assistant',
+      content: [],
+    });
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it('clearSession is a no-op before a conversation is created', async () => {
+    const deleteConversation = vi.fn();
+
+    const session = createSession({
+      client: {
+        conversations: {
+          items: {
+            list: vi.fn(),
+            create: vi.fn(),
+            delete: vi.fn(),
+          },
+          create: vi.fn(),
+          delete: deleteConversation,
+        },
+      } as any,
+    });
+
+    await session.clearSession();
+
+    expect(deleteConversation).not.toHaveBeenCalled();
+  });
+
+  it('treats input_* output arrays as raw items instead of response output arrays', async () => {
+    const convertedItems = [
+      {
+        id: 'converted-raw-item',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+      },
+    ];
+
+    convertToOutputItemMock.mockReturnValue(convertedItems as any);
+
+    const items = [
+      {
+        type: 'response',
+        id: 'resp-input-content',
+        output: [
+          {
+            type: 'input_text',
+            text: 'raw input payload',
+          },
+        ],
+      },
+    ];
+
+    const list = vi.fn(() => ({
+      async *[Symbol.asyncIterator]() {
+        for (const item of items) {
+          yield item as any;
+        }
+      },
+    }));
+
+    const session = createSession({
+      client: {
+        conversations: {
+          items: {
+            list,
+            create: vi.fn(),
+            delete: vi.fn(),
+          },
+          create: vi.fn(),
+          delete: vi.fn(),
+        },
+      } as any,
+      conversationId: 'conv-123',
+    });
+
+    const result = await session.getItems();
+
+    expect(convertToOutputItemMock).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: 'resp-input-content',
+        output: [
+          {
+            type: 'input_text',
+            text: 'raw input payload',
+          },
+        ],
+      }),
+    ]);
+    expect(result).toEqual(convertedItems);
+  });
+
   it('handles a conversation lifecycle across list, add, pop, and clear', async () => {
     convertToOutputItemMock.mockReturnValueOnce([
       {


### PR DESCRIPTION
This pull request expands regression coverage for helper and session edge cases in `@openai/agents-core` and `@openai/agents-openai`. It adds new focused suites for abort signal composition and tooling identifier resolution, broadens `agentToolInput` and hosted MCP approval coverage, and exercises additional `OpenAIConversationsSession` paths such as empty inputs, non-positive limits, missing item IDs, and raw `input_*` output payload handling. It also includes a patch changeset covering both touched packages so the branch satisfies the repository's package-change workflow.