### PR TITLE
fix: allow GA computer tools without display metadata

### DIFF
--- a/.changeset/ga-computer-metadata-optional.md
+++ b/.changeset/ga-computer-metadata-optional.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+'@openai/agents-extensions': patch
+---
+
+fix: allow GA computer tools without display metadata

--- a/packages/agents-core/src/computer.ts
+++ b/packages/agents-core/src/computer.ts
@@ -11,8 +11,16 @@ type Promisable<T> = T | Promise<T>;
  * Interface to implement for a computer environment to be used by the agent.
  */
 interface ComputerBase {
-  environment: Environment;
-  dimensions: [number, number];
+  /**
+   * Optional display environment metadata.
+   * Required when targeting preview computer tool wire formats.
+   */
+  environment?: Environment;
+  /**
+   * Optional display dimensions metadata.
+   * Required when targeting preview computer tool wire formats.
+   */
+  dimensions?: [number, number];
 
   initRun?(runContext?: RunContext): Promisable<void>;
 

--- a/packages/agents-core/src/model.ts
+++ b/packages/agents-core/src/model.ts
@@ -195,8 +195,8 @@ export type SerializedFunctionTool = {
 export type SerializedComputerTool = {
   type: ComputerTool['type'];
   name: ComputerTool['name'];
-  environment: Computer['environment'];
-  dimensions: Computer['dimensions'];
+  environment?: Computer['environment'];
+  dimensions?: Computer['dimensions'];
 };
 
 export type SerializedShellTool = {

--- a/packages/agents-core/src/utils/serialize.ts
+++ b/packages/agents-core/src/utils/serialize.ts
@@ -10,12 +10,40 @@ import {
   getFunctionToolNamespaceDescription,
 } from '../toolIdentity';
 
+const REQUIRED_COMPUTER_METHODS = [
+  'screenshot',
+  'click',
+  'doubleClick',
+  'drag',
+  'keypress',
+  'move',
+  'scroll',
+  'type',
+  'wait',
+] as const;
+
 function isComputerInstance(value: unknown): value is Computer {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return REQUIRED_COMPUTER_METHODS.every(
+    (methodName) => typeof record[methodName] === 'function',
+  );
+}
+
+function hasComputerDisplayMetadata(
+  computer: Computer,
+): computer is Computer & {
+  environment: NonNullable<Computer['environment']>;
+  dimensions: NonNullable<Computer['dimensions']>;
+} {
   return (
-    !!value &&
-    typeof value === 'object' &&
-    'environment' in (value as Record<string, unknown>) &&
-    'dimensions' in (value as Record<string, unknown>)
+    typeof computer.environment === 'string' &&
+    Array.isArray(computer.dimensions) &&
+    computer.dimensions.length === 2 &&
+    computer.dimensions.every((value) => typeof value === 'number')
   );
 }
 
@@ -47,8 +75,12 @@ export function serializeTool(tool: Tool<any>): SerializedTool {
     return {
       type: 'computer',
       name: tool.name,
-      environment: tool.computer.environment,
-      dimensions: tool.computer.dimensions,
+      ...(hasComputerDisplayMetadata(tool.computer)
+        ? {
+            environment: tool.computer.environment,
+            dimensions: tool.computer.dimensions,
+          }
+        : {}),
     };
   }
   if (tool.type === 'shell') {

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -942,6 +942,58 @@ describe('Runner.run', () => {
       expect(capturingModel.lastRequest?.overridePromptModel).toBe(true);
     });
 
+    it('serializes GA computer tools without requiring display metadata', async () => {
+      class CapturingModel implements Model {
+        lastRequest?: ModelRequest;
+
+        async getResponse(request: ModelRequest): Promise<ModelResponse> {
+          this.lastRequest = request;
+          return {
+            output: [fakeModelMessage('computer ok')],
+            usage: new Usage(),
+          };
+        }
+
+        async *getStreamedResponse(
+          _request: ModelRequest,
+        ): AsyncIterable<protocol.StreamEvent> {
+          yield* [];
+          throw new Error('Not implemented');
+        }
+      }
+
+      const capturingModel = new CapturingModel();
+      const agent = new Agent({
+        name: 'ComputerPrompted',
+        model: capturingModel,
+        tools: [
+          computerTool({
+            computer: {
+              screenshot: async () => 'img',
+              click: async () => {},
+              doubleClick: async () => {},
+              drag: async () => {},
+              keypress: async () => {},
+              move: async () => {},
+              scroll: async () => {},
+              type: async () => {},
+              wait: async () => {},
+            } as any,
+          }),
+        ],
+      });
+
+      const result = await run(agent, 'hello');
+
+      expect(result.finalOutput).toBe('computer ok');
+      expect(capturingModel.lastRequest?.tools).toEqual([
+        {
+          type: 'computer',
+          name: 'computer_use_preview',
+        },
+      ]);
+    });
+
     it('emits agent_end lifecycle event for non-streaming agents', async () => {
       const agent = new Agent({
         name: 'TestAgent',

--- a/packages/agents-core/test/utils/serialize.test.ts
+++ b/packages/agents-core/test/utils/serialize.test.ts
@@ -30,13 +30,47 @@ describe('serialize utilities', () => {
     const t: any = {
       type: 'computer',
       name: 'comp',
-      computer: { environment: 'node', dimensions: { width: 1, height: 2 } },
+      computer: {
+        environment: 'browser',
+        dimensions: [1, 2],
+        screenshot: async () => 'img',
+        click: async () => {},
+        doubleClick: async () => {},
+        drag: async () => {},
+        keypress: async () => {},
+        move: async () => {},
+        scroll: async () => {},
+        type: async () => {},
+        wait: async () => {},
+      },
     };
     expect(serializeTool(t)).toEqual({
       type: 'computer',
       name: 'comp',
-      environment: 'node',
-      dimensions: { width: 1, height: 2 },
+      environment: 'browser',
+      dimensions: [1, 2],
+    });
+  });
+
+  it('serializes GA computer tools without display metadata', () => {
+    const t: any = {
+      type: 'computer',
+      name: 'comp',
+      computer: {
+        screenshot: async () => 'img',
+        click: async () => {},
+        doubleClick: async () => {},
+        drag: async () => {},
+        keypress: async () => {},
+        move: async () => {},
+        scroll: async () => {},
+        type: async () => {},
+        wait: async () => {},
+      },
+    };
+    expect(serializeTool(t)).toEqual({
+      type: 'computer',
+      name: 'comp',
     });
   });
 
@@ -45,8 +79,8 @@ describe('serialize utilities', () => {
       type: 'computer',
       name: 'comp',
       computer: async () => ({
-        environment: 'node',
-        dimensions: { width: 1, height: 2 },
+        environment: 'browser',
+        dimensions: [1, 2],
       }),
     };
     expect(() => serializeTool(t)).toThrow(

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -102,6 +102,22 @@ type LanguageModelCompatible =
   | LanguageModelV2Compat
   | LanguageModelV3Compatible;
 
+type SerializedComputerTool = Extract<SerializedTool, { type: 'computer' }>;
+
+function hasComputerDisplayMetadata(
+  tool: SerializedComputerTool,
+): tool is SerializedComputerTool & {
+  environment: NonNullable<SerializedComputerTool['environment']>;
+  dimensions: NonNullable<SerializedComputerTool['dimensions']>;
+} {
+  return (
+    typeof tool.environment === 'string' &&
+    Array.isArray(tool.dimensions) &&
+    tool.dimensions.length === 2 &&
+    tool.dimensions.every((value) => typeof value === 'number')
+  );
+}
+
 function getSpecVersion(
   model: LanguageModelCompatible,
 ): 'v2' | 'v3' | 'unknown' {
@@ -1241,6 +1257,12 @@ export function toolToLanguageV2Tool(
   }
 
   if (tool.type === 'computer') {
+    if (!hasComputerDisplayMetadata(tool)) {
+      throw new UserError(
+        'The AI SDK adapter requires computer tools to include environment and dimensions metadata.',
+      );
+    }
+
     return {
       type: providerToolType,
       id: `${providerToolPrefix}.${tool.name}`,

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -1465,6 +1465,16 @@ describe('toolToLanguageV2Tool', () => {
     });
   });
 
+  test('rejects computer tools without display metadata', () => {
+    const tool = {
+      type: 'computer',
+      name: 'comp',
+    } as any;
+    expect(() => toolToLanguageV2Tool(model, tool)).toThrow(
+      'The AI SDK adapter requires computer tools to include environment and dimensions metadata.',
+    );
+  });
+
   test('throws on unknown type', () => {
     const tool = { type: 'x', name: 'u' } as any;
     expect(() => toolToLanguageV2Tool(model, tool)).toThrow();

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -217,6 +217,7 @@ type ResponseShellCallOutputContent =
   OpenAI.Responses.ResponseFunctionShellCallOutputContent;
 type ResponseApplyPatchCallOutput =
   OpenAI.Responses.ResponseInputItem.ApplyPatchCallOutput;
+type SerializedComputerTool = Extract<SerializedTool, { type: 'computer' }>;
 type SerializedShellTool = Extract<SerializedTool, { type: 'shell' }>;
 type SerializedShellEnvironment = NonNullable<
   SerializedShellTool['environment']
@@ -239,6 +240,20 @@ type SerializedShellContainerSkill = NonNullable<
 >[number];
 type SerializedShellContainerNetworkPolicy =
   SerializedShellContainerAutoEnvironment['networkPolicy'];
+
+function hasSerializedComputerDisplayMetadata(
+  tool: SerializedComputerTool,
+): tool is SerializedComputerTool & {
+  environment: NonNullable<SerializedComputerTool['environment']>;
+  dimensions: NonNullable<SerializedComputerTool['dimensions']>;
+} {
+  return (
+    typeof tool.environment === 'string' &&
+    Array.isArray(tool.dimensions) &&
+    tool.dimensions.length === 2 &&
+    tool.dimensions.every((value) => typeof value === 'number')
+  );
+}
 
 const HostedToolChoice = z.enum([
   'file_search',
@@ -1409,6 +1424,12 @@ function converTool<_TContext = unknown>(
     };
   } else if (tool.type === 'computer') {
     if (options?.usePreviewComputerTool) {
+      if (!hasSerializedComputerDisplayMetadata(tool)) {
+        throw new UserError(
+          'Preview computer tools require environment and dimensions. Provide them on your Computer implementation or target a GA computer model such as gpt-5.4.',
+        );
+      }
+
       return {
         tool: {
           type: 'computer_use_preview',

--- a/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
@@ -55,8 +55,6 @@ describe('getToolChoice', () => {
       {
         type: 'computer',
         name: 'computer_use_preview',
-        environment: 'browser',
-        dimensions: [1024, 768],
       },
     ] as any;
 
@@ -121,8 +119,6 @@ describe('converTool', () => {
   it('converts computer tools', () => {
     const t = converTool({
       type: 'computer',
-      environment: 'mac',
-      dimensions: [100, 200],
     } as any);
     expect(t.tool).toEqual({
       type: 'computer',
@@ -146,6 +142,19 @@ describe('converTool', () => {
       display_width: 100,
       display_height: 200,
     });
+  });
+
+  it('rejects preview computer tools without display metadata', () => {
+    expect(() =>
+      converTool(
+        {
+          type: 'computer',
+        } as any,
+        {
+          usePreviewComputerTool: true,
+        },
+      ),
+    ).toThrow('Preview computer tools require environment and dimensions.');
   });
 
   it('converts shell tools', () => {

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -2368,8 +2368,6 @@ describe('OpenAIResponsesModel', () => {
           {
             type: 'computer',
             name: 'computer_use_preview',
-            environment: 'browser',
-            dimensions: [1024, 768],
           },
         ],
         outputType: 'text',
@@ -2384,6 +2382,39 @@ describe('OpenAIResponsesModel', () => {
       const [args] = createMock.mock.calls[0];
       expect(args.model).toBe('gpt-5.4');
       expect(args.tools).toEqual([{ type: 'computer' }]);
+    });
+  });
+
+  it('rejects preview computer fallback without display metadata before sending the request', async () => {
+    await withTrace('test', async () => {
+      const createMock = vi.fn();
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.4');
+
+      const request = {
+        systemInstructions: undefined,
+        prompt: { promptId: 'pmpt_computer_preview_missing_display' },
+        input: 'hello',
+        modelSettings: {},
+        tools: [
+          {
+            type: 'computer',
+            name: 'computer_use_preview',
+          },
+        ],
+        toolsExplicitlyProvided: false,
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      await expect(model.getResponse(request as any)).rejects.toThrow(
+        'Preview computer tools require environment and dimensions.',
+      );
+      expect(createMock).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
This pull request fixes a runtime mismatch introduced by the GA computer tool shape. The core SDK now allows local `Computer` implementations to omit `environment` and `dimensions` when the request is targeting the GA `{"type":"computer"}` wire format, while keeping preview-only validation in the OpenAI Responses adapter. It also makes the AI SDK adapter fail explicitly when preview-style computer metadata is missing, rather than relying on implicit type assumptions.