### PR TITLE
fix(agents-core): type raw model stream events precisely

### DIFF
--- a/packages/agents-core/src/types/protocol.ts
+++ b/packages/agents-core/src/types/protocol.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { ResponseStreamEvent as OpenAIResponseStreamEvent } from 'openai/resources/responses/responses';
 
 // ----------------------------
 // Shared base types
@@ -941,7 +942,10 @@ export const StreamEventGenericItem = SharedBase.extend({
   type: z.literal('model'),
   event: z.any().describe('The event from the model'),
 });
-export type StreamEventGenericItem = z.infer<typeof StreamEventGenericItem>;
+export type StreamEventGenericItem = SharedBase & {
+  type: 'model';
+  event: OpenAIResponseStreamEvent;
+};
 
 export const StreamEvent = z.discriminatedUnion('type', [
   StreamEventTextStream,

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -10,6 +10,7 @@ import {
   vi,
 } from 'vitest';
 import { z } from 'zod';
+import type { ResponseStreamEvent as OpenAIResponseStreamEvent } from 'openai/resources/responses/responses';
 import {
   Agent,
   InputGuardrailTripwireTriggered,
@@ -91,6 +92,12 @@ function getRequestInputItems(request: ModelRequest): AgentInputItem[] {
 }
 
 describe('Runner.run', () => {
+  it('types raw model stream events with the OpenAI response stream union', () => {
+    expectTypeOf<
+      protocol.StreamEventGenericItem['event']
+    >().toEqualTypeOf<OpenAIResponseStreamEvent>();
+  });
+
   beforeAll(() => {
     setTracingDisabled(true);
     setDefaultModelProvider(new FakeModelProvider());


### PR DESCRIPTION
## Summary
- type `StreamEventGenericItem.event` as the OpenAI `ResponseStreamEvent` union instead of `any`
- keep the runtime schema unchanged while tightening the exported TypeScript surface for SDK consumers
- add a focused type assertion test so the contract stays locked in

## Root Cause
The current protocol schema uses `z.any()` for raw model stream events, and the inferred public TypeScript type inherits that `any`, which strips IntelliSense and type-safety from `raw_model_stream_event.data.event`.

## Why This Is Small And Safe
This patch only tightens the exported TypeScript type. It does not change runtime parsing, event shapes, or streaming behavior, so existing consumers keep the same runtime semantics while gaining more precise typings.

## Testing
- `pnpm --filter @openai/agents-core build-check`
- `pnpm exec prettier --check packages/agents-core/src/types/protocol.ts packages/agents-core/test/run.test.ts`

Closes #279.
