### PR TITLE
feat: #279 add OpenAI raw model stream event narrowing helpers

### DIFF
--- a/.changeset/openai-raw-model-event-helpers.md
+++ b/.changeset/openai-raw-model-event-helpers.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents': patch
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+---
+
+feat: #279 add OpenAI raw model stream event narrowing helpers

--- a/examples/basic/stream-ws.ts
+++ b/examples/basic/stream-ws.ts
@@ -22,6 +22,7 @@ import readline from 'node:readline/promises';
 import { stdin, stdout } from 'node:process';
 import {
   Agent,
+  isOpenAIResponsesRawModelStreamEvent,
   Runner,
   tool,
   withResponsesWebSocketSession,
@@ -132,18 +133,14 @@ async function runStreamedTurn(
     let printedOutput = false;
 
     for await (const event of streamedResult.toStream()) {
-      if (event.type === 'raw_model_stream_event') {
-        if (event.data.type !== 'model') {
-          continue;
-        }
-
-        const raw = event.data.event as { type?: string; delta?: string };
+      if (isOpenAIResponsesRawModelStreamEvent(event)) {
+        const raw = event.data.event;
         if (raw.type === 'response.reasoning_summary_text.delta') {
           if (!printedReasoning) {
             console.log('Reasoning:');
             printedReasoning = true;
           }
-          process.stdout.write(raw.delta ?? '');
+          process.stdout.write(raw.delta);
         } else if (raw.type === 'response.output_text.delta') {
           if (printedReasoning && !printedOutput) {
             process.stdout.write('\n\n');
@@ -152,7 +149,7 @@ async function runStreamedTurn(
             console.log('Assistant:');
             printedOutput = true;
           }
-          process.stdout.write(raw.delta ?? '');
+          process.stdout.write(raw.delta);
         }
         continue;
       }

--- a/examples/connectors/index.ts
+++ b/examples/connectors/index.ts
@@ -1,4 +1,9 @@
-import { Agent, run, hostedMcpTool } from '@openai/agents';
+import {
+  Agent,
+  hostedMcpTool,
+  isOpenAIResponsesRawModelStreamEvent,
+  run,
+} from '@openai/agents';
 
 async function main(verbose: boolean, stream: boolean): Promise<void> {
   // 1. Visit https://developers.google.com/oauthplayground/
@@ -31,8 +36,7 @@ async function main(verbose: boolean, stream: boolean): Promise<void> {
     const result = await run(agent, input, { stream: true });
     for await (const event of result) {
       if (
-        event.type === 'raw_model_stream_event' &&
-        event.data.type === 'model' &&
+        isOpenAIResponsesRawModelStreamEvent(event) &&
         event.data.event.type !== 'response.mcp_call_arguments.delta' &&
         event.data.event.type !== 'response.output_text.delta'
       ) {

--- a/examples/tools/code-interpreter.ts
+++ b/examples/tools/code-interpreter.ts
@@ -1,5 +1,10 @@
-import { Agent, run, codeInterpreterTool, withTrace } from '@openai/agents';
-import OpenAI from 'openai';
+import {
+  Agent,
+  codeInterpreterTool,
+  isOpenAIResponsesRawModelStreamEvent,
+  run,
+  withTrace,
+} from '@openai/agents';
 
 async function main() {
   const agent = new Agent({
@@ -18,20 +23,12 @@ async function main() {
     );
     for await (const event of result) {
       if (
-        event.type === 'raw_model_stream_event' &&
-        event.data.type === 'model'
+        isOpenAIResponsesRawModelStreamEvent(event) &&
+        event.data.event.type === 'response.output_item.done' &&
+        event.data.event.item.type === 'code_interpreter_call'
       ) {
-        const modelEvent = event.data.event as
-          | OpenAI.Responses.ResponseStreamEvent
-          | undefined;
-        if (
-          modelEvent &&
-          modelEvent.type === 'response.output_item.done' &&
-          modelEvent.item.type === 'code_interpreter_call'
-        ) {
-          const code = modelEvent.item.code;
-          console.log(`Code interpreter code:\n\`\`\`\n${code}\n\`\`\``);
-        }
+        const code = event.data.event.item.code;
+        console.log(`Code interpreter code:\n\`\`\`\n${code}\n\`\`\``);
       }
     }
     console.log(`Final output: ${result.finalOutput}`);

--- a/packages/agents-core/src/events.ts
+++ b/packages/agents-core/src/events.ts
@@ -2,6 +2,15 @@ import { Agent } from './agent';
 import { RunItem } from './items';
 import { ResponseStreamEvent } from './types';
 
+function getRawModelEventSource(data: ResponseStreamEvent): string | undefined {
+  if (data.type !== 'model') {
+    return undefined;
+  }
+
+  const source = data.providerData?.rawModelEventSource;
+  return typeof source === 'string' ? source : undefined;
+}
+
 /**
  * Streaming event from the LLM. These are `raw` events, i.e. they are directly passed through from
  * the LLM.
@@ -15,7 +24,10 @@ export class RunRawModelStreamEvent {
   /**
    * @param data The raw responses stream events from the LLM.
    */
-  constructor(public data: ResponseStreamEvent) {}
+  constructor(
+    public data: ResponseStreamEvent,
+    public readonly source: string | undefined = getRawModelEventSource(data),
+  ) {}
 }
 
 /**

--- a/packages/agents-core/test/events.test.ts
+++ b/packages/agents-core/test/events.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { RunRawModelStreamEvent } from '../src/events';
+
+describe('RunRawModelStreamEvent', () => {
+  it('derives source from raw model event providerData', () => {
+    const event = new RunRawModelStreamEvent({
+      type: 'model',
+      event: { type: 'response.created' } as any,
+      providerData: {
+        rawModelEventSource: 'openai-responses',
+      },
+    });
+
+    expect(event.source).toBe('openai-responses');
+  });
+
+  it('leaves source undefined for non-model protocol events', () => {
+    const event = new RunRawModelStreamEvent({
+      type: 'output_text_delta',
+      delta: 'hello',
+    });
+
+    expect(event.source).toBeUndefined();
+  });
+});

--- a/packages/agents-openai/src/index.ts
+++ b/packages/agents-openai/src/index.ts
@@ -10,6 +10,17 @@ export {
 } from './openaiResponsesModel';
 export { OpenAIChatCompletionsModel } from './openaiChatCompletionsModel';
 export {
+  isOpenAIResponsesRawModelStreamEvent,
+  isOpenAIChatCompletionsRawModelStreamEvent,
+  OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE,
+  OPENAI_CHAT_COMPLETIONS_RAW_MODEL_EVENT_SOURCE,
+} from './rawModelEvents';
+export type {
+  OpenAIRawModelEventSource,
+  OpenAIResponsesRawModelStreamEvent,
+  OpenAIChatCompletionsRawModelStreamEvent,
+} from './rawModelEvents';
+export {
   setDefaultOpenAIClient,
   setOpenAIAPI,
   setOpenAIResponsesTransport,

--- a/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
@@ -3,6 +3,7 @@ import type { CompletionUsage } from 'openai/resources/completions';
 import { protocol } from '@openai/agents-core';
 import { ChatCompletion, ChatCompletionChunk } from 'openai/resources/chat';
 import { FAKE_ID } from './openaiChatCompletionsModel';
+import { OPENAI_CHAT_COMPLETIONS_RAW_MODEL_EVENT_SOURCE } from './rawModelEvents';
 
 type StreamingState = {
   started: boolean;
@@ -46,6 +47,9 @@ export async function* convertChatCompletionsStreamToResponses(
     yield {
       type: 'model',
       event: chunk,
+      providerData: {
+        rawModelEventSource: OPENAI_CHAT_COMPLETIONS_RAW_MODEL_EVENT_SOURCE,
+      },
     };
 
     // This is always set by the OpenAI API, but not by others e.g. LiteLLM

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -22,6 +22,7 @@ import type {
 } from '@openai/agents-core';
 import OpenAI from 'openai';
 import logger from './logger';
+import { OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE } from './rawModelEvents';
 import { getOpenAIRetryAdvice } from './retryAdvice';
 import {
   ToolChoiceFunction,
@@ -3159,6 +3160,9 @@ export class OpenAIResponsesModel implements Model {
             yield {
               type: 'model',
               event: event,
+              providerData: {
+                rawModelEventSource: OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE,
+              },
             };
           }
         } else if (eventType === 'response.output_text.delta') {
@@ -3175,6 +3179,9 @@ export class OpenAIResponsesModel implements Model {
         yield {
           type: 'model',
           event: event,
+          providerData: {
+            rawModelEventSource: OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE,
+          },
         };
       }
 

--- a/packages/agents-openai/src/rawModelEvents.ts
+++ b/packages/agents-openai/src/rawModelEvents.ts
@@ -1,0 +1,68 @@
+import type {
+  RunRawModelStreamEvent,
+  RunStreamEvent,
+  StreamEventGenericItem,
+} from '@openai/agents-core';
+import type { ChatCompletionChunk } from 'openai/resources/chat';
+import type { ResponseStreamEvent as OpenAIResponseStreamEvent } from 'openai/resources/responses/responses';
+
+export const OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE = 'openai-responses';
+export const OPENAI_CHAT_COMPLETIONS_RAW_MODEL_EVENT_SOURCE =
+  'openai-chat-completions';
+
+export type OpenAIRawModelEventSource =
+  | typeof OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE
+  | typeof OPENAI_CHAT_COMPLETIONS_RAW_MODEL_EVENT_SOURCE;
+
+type OpenAIRawModelEventData<
+  TSource extends OpenAIRawModelEventSource,
+  TEvent,
+> = Omit<StreamEventGenericItem, 'event' | 'providerData'> & {
+  type: 'model';
+  event: TEvent;
+  providerData: NonNullable<StreamEventGenericItem['providerData']> & {
+    rawModelEventSource: TSource;
+  };
+};
+
+export type OpenAIResponsesRawModelStreamEvent = Omit<
+  RunRawModelStreamEvent,
+  'data' | 'source'
+> & {
+  source: typeof OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE;
+  data: OpenAIRawModelEventData<
+    typeof OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE,
+    OpenAIResponseStreamEvent
+  >;
+};
+
+export type OpenAIChatCompletionsRawModelStreamEvent = Omit<
+  RunRawModelStreamEvent,
+  'data' | 'source'
+> & {
+  source: typeof OPENAI_CHAT_COMPLETIONS_RAW_MODEL_EVENT_SOURCE;
+  data: OpenAIRawModelEventData<
+    typeof OPENAI_CHAT_COMPLETIONS_RAW_MODEL_EVENT_SOURCE,
+    ChatCompletionChunk
+  >;
+};
+
+export function isOpenAIResponsesRawModelStreamEvent(
+  event: RunStreamEvent,
+): event is OpenAIResponsesRawModelStreamEvent {
+  return (
+    event.type === 'raw_model_stream_event' &&
+    event.data.type === 'model' &&
+    event.source === OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE
+  );
+}
+
+export function isOpenAIChatCompletionsRawModelStreamEvent(
+  event: RunStreamEvent,
+): event is OpenAIChatCompletionsRawModelStreamEvent {
+  return (
+    event.type === 'raw_model_stream_event' &&
+    event.data.type === 'model' &&
+    event.source === OPENAI_CHAT_COMPLETIONS_RAW_MODEL_EVENT_SOURCE
+  );
+}

--- a/packages/agents-openai/test/openaiChatCompletionsStreaming.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsStreaming.test.ts
@@ -94,14 +94,26 @@ describe('convertChatCompletionsStreamToResponses', () => {
       type: 'response_started',
       providerData: { ...chunk1 },
     });
-    expect(events[1]).toEqual({ type: 'model', event: chunk1 });
+    expect(events[1]).toEqual({
+      type: 'model',
+      event: chunk1,
+      providerData: { rawModelEventSource: 'openai-chat-completions' },
+    });
     expect(events[2]).toEqual({
       type: 'output_text_delta',
       delta: 'hello',
       providerData: { ...chunk1 },
     });
-    expect(events[3]).toEqual({ type: 'model', event: chunk2 });
-    expect(events[4]).toEqual({ type: 'model', event: chunk3 });
+    expect(events[3]).toEqual({
+      type: 'model',
+      event: chunk2,
+      providerData: { rawModelEventSource: 'openai-chat-completions' },
+    });
+    expect(events[4]).toEqual({
+      type: 'model',
+      event: chunk3,
+      providerData: { rawModelEventSource: 'openai-chat-completions' },
+    });
 
     expect(events[5]).toEqual({
       type: 'response_done',

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -3774,6 +3774,9 @@ describe('OpenAIResponsesModel', () => {
         {
           type: 'model',
           event: events[0],
+          providerData: {
+            rawModelEventSource: 'openai-responses',
+          },
         },
         {
           type: 'output_text_delta',
@@ -3790,6 +3793,9 @@ describe('OpenAIResponsesModel', () => {
         {
           type: 'model',
           event: events[1],
+          providerData: {
+            rawModelEventSource: 'openai-responses',
+          },
         },
       ]);
     });

--- a/packages/agents-openai/test/rawModelEvents.test.ts
+++ b/packages/agents-openai/test/rawModelEvents.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { RunRawModelStreamEvent } from '@openai/agents-core';
+import type { ChatCompletionChunk } from 'openai/resources/chat';
+import type { ResponseStreamEvent as OpenAIResponseStreamEvent } from 'openai/resources/responses/responses';
+import {
+  isOpenAIChatCompletionsRawModelStreamEvent,
+  isOpenAIResponsesRawModelStreamEvent,
+  OPENAI_CHAT_COMPLETIONS_RAW_MODEL_EVENT_SOURCE,
+  OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE,
+  type OpenAIChatCompletionsRawModelStreamEvent,
+  type OpenAIResponsesRawModelStreamEvent,
+} from '../src';
+
+describe('raw model event helpers', () => {
+  it('narrows OpenAI Responses raw model events', () => {
+    const event = new RunRawModelStreamEvent({
+      type: 'model',
+      event: {
+        type: 'response.created',
+        response: { id: 'resp_123' } as any,
+        sequence_number: 0,
+      } as OpenAIResponseStreamEvent,
+      providerData: {
+        rawModelEventSource: OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE,
+      },
+    });
+
+    expect(isOpenAIResponsesRawModelStreamEvent(event)).toBe(true);
+    expect(isOpenAIChatCompletionsRawModelStreamEvent(event)).toBe(false);
+
+    if (isOpenAIResponsesRawModelStreamEvent(event)) {
+      expect(event.data.event.type).toBe('response.created');
+    }
+
+    expectTypeOf<
+      OpenAIResponsesRawModelStreamEvent['data']['event']
+    >().toMatchTypeOf<OpenAIResponseStreamEvent>();
+  });
+
+  it('narrows Chat Completions raw model events', () => {
+    const chunk = {
+      id: 'chatcmpl_123',
+      created: 0,
+      model: 'gpt-4.1',
+      object: 'chat.completion.chunk',
+      choices: [],
+    } as ChatCompletionChunk;
+
+    const event = new RunRawModelStreamEvent({
+      type: 'model',
+      event: chunk,
+      providerData: {
+        rawModelEventSource: OPENAI_CHAT_COMPLETIONS_RAW_MODEL_EVENT_SOURCE,
+      },
+    });
+
+    expect(isOpenAIChatCompletionsRawModelStreamEvent(event)).toBe(true);
+    expect(isOpenAIResponsesRawModelStreamEvent(event)).toBe(false);
+
+    if (isOpenAIChatCompletionsRawModelStreamEvent(event)) {
+      expect(event.data.event.object).toBe('chat.completion.chunk');
+    }
+
+    expectTypeOf<
+      OpenAIChatCompletionsRawModelStreamEvent['data']['event']
+    >().toMatchTypeOf<ChatCompletionChunk>();
+  });
+
+  it('does not narrow generic raw model events without an OpenAI source marker', () => {
+    const event = new RunRawModelStreamEvent({
+      type: 'model',
+      event: {
+        type: 'text-delta',
+        delta: 'hello',
+      } as any,
+    });
+
+    expect(isOpenAIResponsesRawModelStreamEvent(event)).toBe(false);
+    expect(isOpenAIChatCompletionsRawModelStreamEvent(event)).toBe(false);
+  });
+});


### PR DESCRIPTION
This pull request resolves #279.

This pull request fixes the lack of precise typing for OpenAI raw model stream events while preserving the released generic stream surface in `@openai/agents-core`. It adds OpenAI-specific narrowing helpers in `@openai/agents-openai`, threads a lightweight source marker through raw model events, and updates examples/docs to use the new guards instead of hand-written `raw_model_stream_event` checks and unsafe casts.

The main changes are:
- add `source` derivation to raw model stream events in `packages/agents-core/src/events.ts`
- add `isOpenAIResponsesRawModelStreamEvent(...)` and `isOpenAIChatCompletionsRawModelStreamEvent(...)` plus typed aliases in `packages/agents-openai/src/rawModelEvents.ts`, and export them through `@openai/agents-openai` and `@openai/agents`
- tag OpenAI Responses and Chat Completions raw `model` events with an explicit source in `packages/agents-openai/src/openaiResponsesModel.ts` and `packages/agents-openai/src/openaiChatCompletionsStreaming.ts`
- add regression coverage in `packages/agents-core/test/events.test.ts` and `packages/agents-openai/test/rawModelEvents.test.ts`, plus update existing OpenAI streaming tests
- update user-facing examples in `examples/basic/stream-ws.ts`, `examples/connectors/index.ts`, `examples/tools/code-interpreter.ts`, and `examples/docs/mcp/hostedStream.ts` to use the new helpers
- update the streaming guide in `docs/src/content/docs/guides/streaming.mdx`
- include an untracked new docs example file: `examples/docs/streaming/openaiResponsesRawModelStreamEvent.ts`

This change is additive rather than breaking: generic consumers can keep using `RunRawModelStreamEvent`, while OpenAI-specific consumers now get a sound way to recover the precise Responses or Chat Completions event unions.