### PR TITLE
fix: use V3 file-data/file-url format for tool result images in aisdk adapter

### DIFF
--- a/.changeset/olive-glasses-cry.md
+++ b/.changeset/olive-glasses-cry.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+Fix tool result image format for AI SDK V3 models. convertStructuredOutputsToAiSdkOutput now uses file-data/file-url content parts for V3 models instead of the V2-only media format, fixing 400 errors with V3 providers like Vercel AI Gateway

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -426,7 +426,7 @@ export function itemsToLanguageV2Messages(
         type: 'tool-result',
         toolCallId: item.callId,
         toolName,
-        output: convertToAiSdkOutput(item.output),
+        output: convertToAiSdkOutput(item.output, getSpecVersion(model)),
         providerOptions: toProviderOptions(item.providerData, model),
       };
       messages.push({
@@ -631,12 +631,13 @@ function handoffToLanguageV2Tool(
 
 function convertToAiSdkOutput(
   output: protocol.FunctionCallResultItem['output'],
+  specVersion: 'v2' | 'v3' | 'unknown',
 ): LanguageModelV2ToolResultPart['output'] {
   if (typeof output === 'string') {
     return { type: 'text', value: output };
   }
   if (Array.isArray(output)) {
-    return convertStructuredOutputsToAiSdkOutput(output);
+    return convertStructuredOutputsToAiSdkOutput(output, specVersion);
   }
   if (isRecord(output) && typeof output.type === 'string') {
     if (output.type === 'text' && typeof output.text === 'string') {
@@ -646,7 +647,10 @@ function convertToAiSdkOutput(
       const structuredOutputs = convertLegacyToolOutputContent(
         output as protocol.ToolCallOutputContent,
       );
-      return convertStructuredOutputsToAiSdkOutput(structuredOutputs);
+      return convertStructuredOutputsToAiSdkOutput(
+        structuredOutputs,
+        specVersion,
+      );
     }
   }
   return { type: 'text', value: String(output) };
@@ -927,16 +931,42 @@ function createProtocolToolCallItem(args: {
 }
 
 /**
- * Maps the protocol-level structured outputs into the Language Model V2 result primitives.
- * The AI SDK expects either plain text or content parts (text + media), so we merge multiple
- * items accordingly.
+ * Maps the protocol-level structured outputs into AI SDK result primitives,
+ * using the appropriate content part format for the model's spec version.
  */
 function convertStructuredOutputsToAiSdkOutput(
   outputs: protocol.ToolCallStructuredOutput[],
+  specVersion: 'v2' | 'v3' | 'unknown',
 ): LanguageModelV2ToolResultPart['output'] {
+  const isV3 = specVersion === 'v3';
+
+  type MediaPart =
+    | { type: 'media'; data: string; mediaType: string }
+    | { type: 'file-data'; data: string; mediaType: string }
+    | { type: 'file-url'; url: string };
+
+  const makeDataPart = isV3
+    ? (data: string, mediaType: string): MediaPart => ({
+        type: 'file-data',
+        data,
+        mediaType,
+      })
+    : (data: string, mediaType: string): MediaPart => ({
+        type: 'media',
+        data,
+        mediaType,
+      });
+
+  const makeUrlPart = isV3
+    ? (url: string): MediaPart => ({ type: 'file-url', url })
+    : (url: string): MediaPart => ({
+        type: 'media',
+        data: url,
+        mediaType: 'image/*',
+      });
+
   const textParts: string[] = [];
-  const mediaParts: Array<{ type: 'media'; data: string; mediaType: string }> =
-    [];
+  const mediaParts: MediaPart[] = [];
 
   for (const item of outputs) {
     if (item.type === 'input_text') {
@@ -964,20 +994,12 @@ function convertStructuredOutputsToAiSdkOutput(
       }
       const inlineImage = parseBase64ImageDataUrl(imageValue);
       if (inlineImage) {
-        mediaParts.push({
-          type: 'media',
-          data: inlineImage.data,
-          mediaType: inlineImage.mediaType,
-        });
+        mediaParts.push(makeDataPart(inlineImage.data, inlineImage.mediaType));
         continue;
       }
       try {
         const url = new URL(imageValue);
-        mediaParts.push({
-          type: 'media',
-          data: url.toString(),
-          mediaType: 'image/*',
-        });
+        mediaParts.push(makeUrlPart(url.toString()));
       } catch {
         textParts.push(imageValue);
       }
@@ -994,16 +1016,13 @@ function convertStructuredOutputsToAiSdkOutput(
     return { type: 'text', value: textParts.join('') };
   }
 
-  const value: Array<
-    | { type: 'text'; text: string }
-    | { type: 'media'; data: string; mediaType: string }
-  > = [];
+  const value: Array<{ type: 'text'; text: string } | MediaPart> = [];
 
   if (textParts.length > 0) {
     value.push({ type: 'text', text: textParts.join('') });
   }
   value.push(...mediaParts);
-  return { type: 'content', value };
+  return { type: 'content', value } as LanguageModelV2ToolResultPart['output'];
 }
 
 function isRecord(value: unknown): value is Record<string, any> {

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -1265,6 +1265,80 @@ describe('itemsToLanguageV2Messages', () => {
     ]);
   });
 
+  test('converts structured tool output lists using V3 file-data/file-url format', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call',
+        callId: 'tool-1',
+        name: 'describe_image',
+        arguments: '{}',
+      } as any,
+      {
+        type: 'function_call_result',
+        callId: 'tool-1',
+        name: 'describe_image',
+        output: [
+          { type: 'input_text', text: 'A scenic view.' },
+          {
+            type: 'input_image',
+            image: 'https://example.com/image.png',
+          },
+          {
+            type: 'input_image',
+            image: 'data:image/png;base64,aGVsbG8=',
+          },
+        ],
+      } as any,
+    ];
+
+    const msgs = itemsToLanguageV2Messages(
+      stubModel({}, { specificationVersion: 'v3' }),
+      items,
+    );
+    expect(msgs).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'tool-1',
+            toolName: 'describe_image',
+            input: {},
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'tool-1',
+            toolName: 'describe_image',
+            output: {
+              type: 'content',
+              value: [
+                { type: 'text', text: 'A scenic view.' },
+                {
+                  type: 'file-url',
+                  url: 'https://example.com/image.png',
+                },
+                {
+                  type: 'file-data',
+                  data: 'aGVsbG8=',
+                  mediaType: 'image/png',
+                },
+              ],
+            },
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+    ]);
+  });
+
   test('handles undefined providerData without throwing', () => {
     const items: protocol.ModelItem[] = [
       {


### PR DESCRIPTION
## Problem

When using `aisdk()` with a V3 provider (e.g. Vercel AI Gateway), tool results containing images fail with a `400 Invalid input` error. This happens because `convertStructuredOutputsToAiSdkOutput` always emits V2 `{type:'media'}` content parts, even when the model's `specificationVersion` is `v3`.

The `getSpecVersion()` helper already exists and is used elsewhere (e.g. `toolToLanguageV2Tool`), but was not wired into the tool result conversion path.

## Fix

Thread the spec version into `convertToAiSdkOutput` → `convertStructuredOutputsToAiSdkOutput` and emit the correct content part format per version:

| | Base64 image | URL image |
|---|---|---|
| **V2** | `{type:'media', data, mediaType}` | `{type:'media', data, mediaType:'image/*'}` |
| **V3** | `{type:'file-data', data, mediaType}` | `{type:'file-url', url}` |

## Test plan

- Existing V2 test passes unchanged
- New V3 test validates `file-data`/`file-url` output
- All 1677 tests pass
- `pnpm build && pnpm -r build-check && pnpm test && pnpm lint` all green