### PR TITLE
fix(agents-core): prune orphan hosted shell calls from public history

### DIFF
--- a/.changeset/fair-clouds-flow.md
+++ b/.changeset/fair-clouds-flow.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: prune orphan hosted shell calls from public history

--- a/packages/agents-core/src/runner/items.ts
+++ b/packages/agents-core/src/runner/items.ts
@@ -200,12 +200,22 @@ export function prepareModelInputItems(
   reasoningItemIdPolicy?: ReasoningItemIdPolicy,
 ): AgentInputItem[] {
   const callerItems = toAgentInputList(originalInput);
+  const preparedGeneratedItems = getContinuationOutputItems(
+    generatedItems,
+    reasoningItemIdPolicy,
+  );
+  return [...callerItems, ...preparedGeneratedItems];
+}
+
+function getContinuationOutputItems(
+  generatedItems: RunItem[],
+  reasoningItemIdPolicy?: ReasoningItemIdPolicy,
+): AgentInputItem[] {
   const generatedOutputItems = extractOutputItemsFromRunItems(
     generatedItems,
     reasoningItemIdPolicy,
   );
-  const preparedGeneratedItems = dropOrphanToolCalls(generatedOutputItems);
-  return [...callerItems, ...preparedGeneratedItems];
+  return dropOrphanToolCalls(generatedOutputItems);
 }
 
 /**
@@ -220,7 +230,7 @@ export function getTurnInput(
   generatedItems: RunItem[],
   reasoningItemIdPolicy?: ReasoningItemIdPolicy,
 ): AgentInputItem[] {
-  const outputItems = extractOutputItemsFromRunItems(
+  const outputItems = getContinuationOutputItems(
     generatedItems,
     reasoningItemIdPolicy,
   );

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -4832,6 +4832,65 @@ describe('Runner.run', () => {
       );
     });
 
+    it('does not reintroduce orphan hosted shell calls when continuing from public history', async () => {
+      const hostedShell = shellTool({
+        environment: { type: 'container_auto' },
+      });
+      const model = new TrackingModel([
+        buildResponse(
+          [
+            {
+              type: 'shell_call',
+              callId: 'call-shell-1',
+              status: 'completed',
+              action: { commands: ['echo hi'] },
+            } satisfies protocol.ShellCallItem,
+          ],
+          'resp-shell-1',
+        ),
+        buildResponse([fakeModelMessage('done')], 'resp-shell-2'),
+        buildResponse(
+          [fakeModelMessage('continued from result')],
+          'resp-shell-3',
+        ),
+        buildResponse(
+          [fakeModelMessage('continued from state')],
+          'resp-shell-4',
+        ),
+      ]);
+
+      const agent = new Agent({
+        name: 'HostedShellAgent',
+        model,
+        tools: [hostedShell],
+      });
+      const runner = new Runner();
+      const firstResult = await runner.run(agent, 'user_message');
+
+      expect(
+        firstResult.history.some((item) => item.type === 'shell_call'),
+      ).toBe(false);
+      expect(
+        firstResult.state.history.some((item) => item.type === 'shell_call'),
+      ).toBe(false);
+
+      await runner.run(agent, firstResult.history);
+      await runner.run(agent, firstResult.state.history);
+
+      expect(model.requests).toHaveLength(4);
+      const continuedFromResult = getRequestInputItems(model.requests[2]);
+      const continuedFromState = getRequestInputItems(model.requests[3]);
+
+      expect(
+        continuedFromResult.some((item) => item.type === 'shell_call'),
+      ).toBe(false);
+      expect(
+        continuedFromState.some((item) => item.type === 'shell_call'),
+      ).toBe(false);
+      expect(continuedFromResult).toEqual(firstResult.history);
+      expect(continuedFromState).toEqual(firstResult.state.history);
+    });
+
     it('replays pending hosted shell calls in default multi-turn runs', async () => {
       const hostedShell = shellTool({
         environment: { type: 'container_auto' },

--- a/packages/agents-core/test/run.utils.test.ts
+++ b/packages/agents-core/test/run.utils.test.ts
@@ -3,9 +3,11 @@ import { getTurnInput } from '../src/run';
 import {
   RunMessageOutputItem as MessageOutputItem,
   RunReasoningItem as ReasoningItem,
+  RunToolCallItem,
 } from '../src/items';
 import { Agent } from '../src/agent';
 import { TEST_MODEL_MESSAGE } from './stubs';
+import * as protocol from '../src/types/protocol';
 
 describe('getTurnInput', () => {
   it('combines original string input with generated items', () => {
@@ -52,5 +54,28 @@ describe('getTurnInput', () => {
       content: [{ type: 'input_text', text: 'thinking' }],
     });
     expect(result[1]).not.toHaveProperty('id');
+  });
+
+  it('drops orphan hosted shell calls from generated history', () => {
+    const agent = new Agent({ name: 'A' });
+    const orphanShellCall = new RunToolCallItem(
+      {
+        type: 'shell_call',
+        callId: 'shell_123',
+        status: 'completed',
+        action: { commands: ['echo hi'] },
+      } satisfies protocol.ShellCallItem,
+      agent,
+    );
+
+    const result = getTurnInput('hello', [orphanShellCall]);
+
+    expect(result).toEqual([
+      {
+        type: 'message',
+        role: 'user',
+        content: 'hello',
+      },
+    ]);
   });
 });

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -13,6 +13,7 @@ import {
   RunToolApprovalItem as ToolApprovalItem,
   RunMessageOutputItem,
   RunReasoningItem,
+  RunToolCallItem,
   RunToolCallOutputItem,
   RunToolSearchCallItem,
   RunToolSearchOutputItem,
@@ -76,6 +77,27 @@ describe('RunState', () => {
     expect(state.history).toEqual([
       { type: 'message', role: 'user', content: 'input' },
       TEST_MODEL_MESSAGE,
+    ]);
+  });
+
+  it('drops orphan hosted shell calls from history', () => {
+    const context = new RunContext();
+    const agent = new Agent({ name: 'HistAgentShell' });
+    const state = new RunState(context, 'input', agent, 1);
+    state._generatedItems.push(
+      new RunToolCallItem(
+        {
+          type: 'shell_call',
+          callId: 'shell_orphan',
+          status: 'completed',
+          action: { commands: ['echo hi'] },
+        },
+        agent,
+      ),
+    );
+
+    expect(state.history).toEqual([
+      { type: 'message', role: 'user', content: 'input' },
     ]);
   });
 


### PR DESCRIPTION
This pull request is a follow-up for https://github.com/openai/openai-agents-js/pull/1099 and it fixes a continuation-history gap in `@openai/agents-core` where orphan hosted shell calls were pruned for internal turn assembly but could still leak through public history builders.

It updates `getTurnInput()` to reuse the same pruning path as `prepareModelInputItems()`, so `RunResult.history`, `RunState.history`, and derived continuation inputs stay replay-safe. It also adds regression coverage for direct history assembly, `RunState.history`, and follow-up runs that continue from `result.history` and `state.history`.