### PR TITLE
chore: upgrade pnpm toolchain to 10.32.1

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -52,9 +52,9 @@ jobs:
             "https://github.com/${PR_HEAD_REPO}.git" \
             "${PR_HEAD_SHA}"
       - name: Install pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
         with:
-          version: 10.30.3
+          version: 10.32.1
           run_install: false
       - name: Setup Node
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,9 +25,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238
       - name: Install pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
         with:
-          version: 10.30.3
+          version: 10.32.1
           run_install: true
       - name: Run build
         run: pnpm build:ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
         with:
-          version: 10.30.3
+          version: 10.32.1
 
       - name: Setup node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,9 +107,9 @@ jobs:
           persist-credentials: false
       - name: Install pnpm
         if: ${{ needs.changes.outputs.run_ci == 'true' }}
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
         with:
-          version: 10.30.3
+          version: 10.32.1
           run_install: false
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.run_ci == 'true' }}
@@ -155,9 +155,9 @@ jobs:
           persist-credentials: false
       - name: Install pnpm
         if: ${{ needs.changes.outputs.run_ci == 'true' }}
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
         with:
-          version: 10.30.3
+          version: 10.32.1
           run_install: false
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.run_ci == 'true' }}

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -54,9 +54,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
         with:
-          version: 10.30.3
+          version: 10.32.1
           run_install: false
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238

--- a/package.json
+++ b/package.json
@@ -90,5 +90,5 @@
       "@types/node": "22.19.13"
     }
   },
-  "packageManager": "pnpm@10.30.3"
+  "packageManager": "pnpm@10.32.1"
 }


### PR DESCRIPTION
This pull request updates the repository pnpm toolchain to `10.32.1` and refreshes the pinned `pnpm/action-setup` commit used in GitHub Actions.