### PR TITLE
docs: add PromptLayer tracing integration link

### DIFF
--- a/docs/src/content/docs/guides/tracing.mdx
+++ b/docs/src/content/docs/guides/tracing.mdx
@@ -138,3 +138,4 @@ To customize this default setup, to send traces to alternative or additional bac
 
 - [AgentOps](https://docs.agentops.ai/v2/usage/typescript-sdk#openai-agents-integration)
 - [Keywords AI](https://docs.keywordsai.co/integration/development-frameworks/openai-agents-sdk-js)
+- [PromptLayer](https://docs.promptlayer.com/languages/integrations#openai-agents-sdk)


### PR DESCRIPTION
### Summary

Add PromptLayer to the OpenAI Agents JS tracing integrations list in the English tracing guide.

### Test plan

- Ran `pnpm build`
- Ran `pnpm docs:build`

### Issue number

N/A
