### PR TITLE
chore: add runtime behavior probe skill

### DIFF
--- a/.agents/skills/runtime-behavior-probe/SKILL.md
+++ b/.agents/skills/runtime-behavior-probe/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: runtime-behavior-probe
+description: Plan and execute runtime-behavior investigations with temporary TypeScript probe scripts, validation matrices, state controls, and findings-first reports. Use only when the user explicitly invokes this skill to verify actual runtime behavior beyond normal code-level checks, especially to uncover edge cases, undocumented behavior, or common failure modes in local or live integrations. A baseline smoke check is fine as an entry point, but do not stop at happy-path confirmation.
+---
+
+# Runtime Behavior Probe
+
+## Overview
+
+Use this skill to investigate real runtime behavior, not to restate code or documentation. Start by planning the investigation, then execute a case matrix, record observed behavior, and report both the findings and the method used to obtain them.
+
+## Core Rules
+
+- Treat this skill as manual-only. Do not rely on implicit invocation.
+- For `openai-agents-js`, treat this skill as a disposable-probe workflow, not a repository implementation workflow.
+- Unless the user explicitly asks for a reusable repository artifact, the allowed write scope is limited to:
+  - a temporary directory used for probe scripts or artifacts
+  - `.agents/skills/runtime-behavior-probe/**` when the user is editing this skill itself
+- For disposable probes in `openai-agents-js`, do not modify `examples/**`, `packages/**`, any `package.json`, `README.md`, workspace config, or build config.
+- If your draft plan would touch a disallowed path, stop and rewrite the plan before editing anything.
+- A baseline success or smoke case is often the right entry point, but do not stop there when the real question involves edge cases, drift, or failure behavior.
+- Plan before running anything. Write the case matrix first, then fill it in with observed results. The matrix can live in a scratch note, a temporary file, or the probe script header.
+- Default to local or read-only probes. Consider a live service only when it is clearly relevant, then apply the lightweight gates below before you run it.
+- Size the probe to the decision. Start with the smallest matrix that can disqualify or validate the current hypothesis, then expand only when uncertainty remains.
+- Before a live probe, apply three lightweight gates:
+  - Destination gate. Use only a live destination that is clearly allowed for the task.
+  - Intent gate. Run the live probe only when the user explicitly wants runtime verification on that integration, or explicitly approves it after you propose the probe.
+  - Data gate. If the probe will read environment variables, mutate remote state, incur material cost, or exercise non-public or user data, name the exact variable names or data class and get explicit approval first.
+- Classify each case as read-only, mutating, or costly before execution. For mutating or costly cases, or for any live case that will read environment variables, define cleanup or rollback before running the probe.
+- Use temporary files or a temporary directory for one-off probe scripts.
+- In `openai-agents-js`, use disposable probe files outside git-tracked paths by default. Do not add one-off probes, harnesses, benchmarks, or examples under `examples/`, `packages/`, or other repository directories unless the user explicitly asks for a checked-in artifact.
+- Keep temporary artifacts until the final response is drafted. Then delete them by default unless the user asked to keep them or they are needed for follow-up. Even when artifacts are deleted, keep a short run summary of the command shape, runtime context, and artifact status in the report.
+- Before executing a live probe that will read environment variables, tell the user the exact variable names you plan to use and why, then wait for explicit approval. Examples include `OPENAI_API_KEY` and other expected default names for the system under test.
+- Never print secrets, even when they come from standard environment variables that this skill may use.
+- For OpenAI API or OpenAI platform probes in this repository, use [$openai-knowledge](../openai-knowledge/SKILL.md) early to confirm contract-sensitive details such as supported parameters, field names, and limits. Use runtime probing to validate or challenge the documented behavior, not to skip the documentation pass entirely. If the docs MCP is unavailable, fall back to the official OpenAI docs and say that you used the fallback in the report.
+- For benchmark or comparison probes, make parity explicit before execution. Record what is held constant, what variable is under test, which response-shape constraints keep the comparison fair, and any usage or token counters that matter for interpreting latency or cost.
+- In `openai-agents-js`, default to a light local loop for probe authoring: temporary `probe.ts` plus temporary `tsconfig.json`, `pnpm exec tsc --noEmit -p <tmp-tsconfig>`, then `pnpm exec tsx <tmp-probe>`. Escalate to `pnpm build` only when the runtime question is specifically about `dist/`, emitted exports, or packaged output.
+- In `openai-agents-js`, do not treat a request for runtime verification, benchmarking, or model comparison as permission to add a reusable example, benchmark harness, package script, or checked-in sample. Those repository changes require explicit user intent.
+- For OpenAI hosted tool probes, remove setup ambiguity before attributing a negative result to runtime behavior:
+  - Force the tool path with the matching `tool_choice` when the question depends on tool invocation.
+  - Treat `container_auto` and `container_reference` as separate cases, not interchangeable setup details.
+  - Clear unsupported model or tool options first so they do not invalidate the probe.
+
+## Workflow
+
+1. Restate the investigation target in operational terms. Name the runtime surface, the key uncertainty, and the highest-risk behaviors to test.
+2. For `openai-agents-js`, declare the allowed write scope before you do any implementation work. For a normal disposable probe, that means a temporary directory only.
+3. Do a short preflight. Check the relevant code or docs first, decide whether the question needs local or live validation, and note any repo, baseline, or release boundary that matters.
+4. Create a validation matrix before executing probes. Cover both baseline behavior and the most relevant failure or drift cases. The matrix can live in a scratch note, a temporary file, or a structured header inside the probe script.
+5. For each case, choose an execution mode up front:
+   - `single-shot` for deterministic one-run checks.
+   - `repeat-N` for cache, retry, streaming, interruption, rate-limit, concurrency, or other run-to-run-sensitive behavior.
+   - `warm-up + repeat-N` when first-run cold-start effects could distort the result. Use these defaults unless the task clearly needs something else:
+   - Quick screen of a repeat-sensitive question: `repeat-3`.
+   - Decision-grade latency or release recommendation: `warm-up + repeat-10`.
+   - Costly live cases: start at `repeat-3`, then expand only if the answer remains unclear. If it is genuinely unclear whether extra runs are worth the time or cost, ask the user before expanding the probe.
+6. When the question is benchmark-like or comparative, run in phases. Start with a high-signal pilot matrix against a control, then expand only the surviving candidates or unresolved cases.
+7. If the question is about a suspected regression or behavior change, add at least one known-good control case such as `origin/main`, the latest release, or the same request without the suspected option.
+8. For comparative probes, define parity before execution. Record prompt or input shape, tool-choice setup, model-settings parity, state reuse rules, and any response-shape constraint that keeps the comparison fair. If materially different output length could bias the result, record usage or token notes too.
+9. If the question asks whether one option has the same intelligence or quality as another, decide whether the matrix supports only example-pattern parity or a broader quality claim. For broader claims, add at least one harder or more open-ended case. Otherwise say explicitly that the result is limited to the covered patterns.
+10. Plan state controls before execution when hidden state could affect the result. Record whether each case uses fresh or reused state, how cache reuse or cache busting is handled, what unique IDs isolate repeated runs, and how cleanup is verified.
+11. If any live case will read environment variables, list the exact variable names and purpose for each case, then ask the user for approval before execution. Keep the approval ask short and include destination, read-only versus mutating or costly risk, exact variable names, and cleanup or rollback if relevant.
+12. Build task-specific probe scripts in a temporary location. Keep the script small, observable, and easy to discard.
+13. If you are about to propose a checked-in script, example, benchmark, or workspace script for `openai-agents-js`, stop and verify that the user explicitly asked for a reusable repository artifact. If not, keep the probe temporary.
+14. In `openai-agents-js`, make the runtime context explicit:
+
+- Run TypeScript probes from the repository root with `pnpm exec tsx` when practical.
+- For probe authoring, create both `probe.ts` and a sibling temporary `tsconfig.json` under `mktemp -d`, then run `pnpm exec tsc --noEmit -p <tmp-tsconfig>` before the first live execution.
+- Record the current commit, working directory, Node executable, Node version, and the package or source path you imported.
+- Avoid accidental imports from a different checkout or from `/tmp/node_modules`. If the probe needs repository code, import it from a repository-relative `file://` URL rooted at `process.cwd()`.
+- Prefer current-branch `src/` imports when the question is "what does this branch do now?" and prefer `dist/` imports only when the question is specifically about packaged output after a build.
+- Do not run a repository-wide build just to typecheck a disposable probe. Reserve `pnpm build` for `dist/` probes or when emitted output is itself part of the question.
+
+15. Execute the matrix and capture evidence. Record request shape, setup, observation summary, unexpected or negative result, error details, timing, runtime context, approved environment-variable names, repeat counts, warm-up handling, variance when relevant, cleanup behavior, and for comparisons note what was held constant plus any response-shape or usage notes that affect interpretation.
+16. Update the matrix with actual outcomes, not guesses.
+17. Keep temporary artifacts until the final response is drafted. Then delete them unless the user asked to keep them or they are needed for follow-up. Benchmark and repeat-heavy probes often need follow-up, so keeping artifacts is normal when the result may be revisited. If deleted, retain and report a short run summary.
+18. Report findings first, with unexpected or negative findings first. Then summarize how the validation was performed and which cases were covered.
+19. If the probe isolates one clear defect, you may include a short implementation hypothesis or minimal repro direction. Do not expand into a larger next-step plan unless the user asked for it.
+
+## Validation Matrix
+
+Use a matrix that makes the news easy to scan. Start from the runtime question and the observation summary, not just from `expected` and `pass` or `fail`.
+
+Use a matrix with at least these columns:
+
+- `case_id`
+- `scenario`
+- `mode`
+- `question`
+- `setup`
+- `observation_summary`
+- `result_flag`
+- `evidence`
+
+Add these columns when they materially improve the investigation:
+
+- `comparison_basis`
+- `variable_under_test`
+- `held_constant`
+- `output_constraint`
+- `status`
+- `confidence`
+- `state_setup`
+- `repeats`
+- `warm_up`
+- `variance`
+- `usage_note`
+- `risk_profile`
+- `env_vars`
+- `approval`
+- `control`
+
+Treat `result_flag` as a fast scan field such as `unexpected`, `negative`, `expected`, or `blocked`. Use `status` only when there is a credible comparison basis, baseline, or documented contract to compare against.
+
+Always consider whether the matrix should include these categories:
+
+- Baseline success.
+- Control or baseline comparison when a regression is suspected.
+- Boundary input or parameter variation.
+- Invalid or unsupported input.
+- Missing or incorrect configuration.
+- Transient external failure such as timeout, network interruption, or rate limiting.
+- Retry, idempotence, or cleanup behavior.
+- Concurrency or overlapping operations when shared state or ordering may matter.
+- Open-ended quality or intelligence samples when the question is broader than pattern parity.
+
+Open [validation-matrix.md](./references/validation-matrix.md) when you need a stronger prioritization model or a reusable case template.
+
+## Temporary Probe Scripts
+
+Write one-off scripts in a temporary file or temporary directory such as one created by `mktemp -d`. Keep the script outside the repository by default, even when it imports code from the repository.
+
+For `openai-agents-js`, a disposable runtime probe should stay disposable. Do not add a package script, modify workspace config, or create a checked-in benchmark or example unless the user explicitly asks for a reusable repository artifact.
+
+For `openai-agents-js`, the default authoring loop should be:
+
+1. `tmpdir=$(mktemp -d)`
+2. Write `probe.ts` and `tsconfig.json` into `$tmpdir`
+3. From the repository root, run `pnpm exec tsc --noEmit -p "$tmpdir/tsconfig.json"`
+4. If the quick typecheck passes, run `pnpm exec tsx "$tmpdir/probe.ts"`
+5. Only run `pnpm build` if the probe intentionally imports `dist/` or validates packaged output
+
+Use a temporary `tsconfig.json` that extends the repository example settings but includes only the disposable probe, for example:
+
+```json
+{
+  "extends": "/absolute/path/to/openai-agents-js/tsconfig.examples.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["./probe.ts"]
+}
+```
+
+If the probe needs repository code:
+
+- Run it with the repository root as the working directory.
+- Use `pnpm exec tsx /tmp/probe.ts` from the repository root when practical.
+- Use `pnpm exec tsc --noEmit -p /tmp/probe-tsconfig.json` as the default quick typecheck step before executing the probe.
+- Import repository modules with a `file://` URL built from `process.cwd()` and a repo-relative path. Do not assume bare workspace imports such as `@openai/agents-core` will resolve from `/tmp`.
+- Use `src/` imports for current-branch behavior probes and `dist/` imports for packaged-output probes.
+
+Design the probe to maximize observability:
+
+- Print or log the exact scenario being exercised.
+- Capture runtime context such as git SHA, working directory, Node executable and version, relevant package versions, model or deployment name, endpoint or base URL alias, and any retry or tool options that materially affect behavior.
+- For live probes, record only the names of environment variables that were approved for use. Never print their values.
+- Capture structured outputs when possible.
+- Preserve raw error type, message, and status code.
+- For repeat-sensitive cases, capture the attempt index, warm-up status, and any stable identifiers that help compare runs.
+- For repeated or benchmark-style probes, write both raw results and a compact summary artifact when practical.
+- Keep branching minimal so each script answers a narrow question.
+
+Before deleting the temporary script or directory, keep a short run summary of the script path, command used, runtime context, and whether the evidence was kept or deleted.
+
+Open [typescript_probe.ts](./templates/typescript_probe.ts) when you want a lightweight disposable TypeScript probe scaffold. Open [repo-import-patterns.md](./references/repo-import-patterns.md) when you need to load current-branch workspace code from a temporary script.
+
+## Reporting
+
+Report in this order:
+
+1. Findings. Put unexpected or negative findings first. If there was no real news, say that explicitly.
+2. Validation approach. Summarize the code used, the runtime surface exercised, the execution modes, and the case matrix coverage.
+3. Case results. Include the matrix or a condensed version of it when the case count is large.
+4. Artifact status and brief run summary. State whether temporary artifacts were deleted or kept, and provide kept paths or the retained summary.
+5. Optional implementation note. Include this only when one clear defect was isolated and a short implementation direction would help.
+
+For comparative probes, the report should also say what was held constant, what variable was under test, and whether the result supports only pattern parity or a broader quality claim.
+
+Open [reporting-format.md](./references/reporting-format.md) for the recommended response template.
+
+## Resources
+
+- Open [validation-matrix.md](./references/validation-matrix.md) to design and prioritize the case matrix.
+- Open [error-cases.md](./references/error-cases.md) to expand common failure scenarios.
+- Open [openai-runtime-patterns.md](./references/openai-runtime-patterns.md) for recurring OpenAI and Responses API probe patterns.
+- Open [repo-import-patterns.md](./references/repo-import-patterns.md) for repository-relative TypeScript import guidance.
+- Open [reporting-format.md](./references/reporting-format.md) for the final report structure.
+- Open [typescript_probe.ts](./templates/typescript_probe.ts) for a minimal disposable TypeScript probe scaffold.

--- a/.agents/skills/runtime-behavior-probe/agents/openai.yaml
+++ b/.agents/skills/runtime-behavior-probe/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Runtime Behavior Probe"
+  short_description: "Plan and run runtime behavior probes"
+  default_prompt: "Use $runtime-behavior-probe to investigate actual runtime behavior with a validation matrix, disposable TypeScript probes outside git-tracked paths, and a findings-first report. For openai-agents-js, the default write scope is a temporary directory only. Do not modify examples/, packages/, package.json files, README.md, workspace config, or build config, and do not add checked-in examples, benchmarks, or package scripts unless the user explicitly asks for a reusable repository artifact."
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/runtime-behavior-probe/references/error-cases.md
+++ b/.agents/skills/runtime-behavior-probe/references/error-cases.md
@@ -1,0 +1,80 @@
+# Common Error Cases
+
+Use this reference to expand beyond the happy path. Favor error cases that a real user or operator is likely to hit.
+
+## Configuration Errors
+
+Check whether the runtime behaves differently for:
+
+- Missing required environment variables.
+- Present but malformed secrets or identifiers.
+- Wrong endpoint or base URL.
+- Wrong model or deployment name.
+- Incompatible local dependency versions.
+
+Look for:
+
+- Error type and status code.
+- Whether the failure is immediate or delayed.
+- Whether the message is actionable.
+- Whether retrying without fixing configuration changes anything.
+
+## Input Errors
+
+Probe common bad-input patterns such as:
+
+- Missing required fields.
+- Wrong data type.
+- Unsupported enum or option value.
+- Empty but syntactically valid input.
+- Oversized input or too many items.
+- Mutually incompatible options.
+
+Prefer realistic invalid inputs over artificial nonsense. The point is to learn how the runtime fails in practice.
+
+## Transport and Availability Errors
+
+When networked services are involved, consider:
+
+- Connection failure.
+- Read timeout.
+- Server timeout or upstream gateway error.
+- Rate limit response.
+- Partial stream interruption.
+- Reusing a connection after a failure.
+
+Capture whether the client library retries automatically, whether it surfaces retry metadata, and whether the final exception preserves the original cause.
+
+## State and Repetition Errors
+
+Many surprising bugs appear only when an operation is repeated or interrupted:
+
+- Re-submit the same request.
+- Repeat after a timeout.
+- Retry after a partial tool call or partial stream.
+- Resume after local cleanup or process restart.
+- Repeat with slightly changed inputs while reusing shared state.
+
+Observe whether the operation is idempotent, duplicated, silently ignored, or left in a partial state.
+
+## Concurrency Errors
+
+When shared state, ordering, or isolation may matter, consider:
+
+- Two overlapping requests with the same logical input.
+- Parallel runs that reuse the same cache key, session, container, or temporary resource.
+- Concurrent retries, cancellation, or cleanup racing with active work.
+- Output or event streams from one run leaking into another.
+
+Capture whether the runtime serializes, rejects, duplicates, corrupts, or cross-contaminates the work.
+
+## Investigation Heuristics
+
+Use these heuristics to pick error cases quickly:
+
+- Ask which failure a real engineer would debug first in production.
+- Ask which failure is most expensive if it is misunderstood.
+- Ask which failure would be invisible from code review alone.
+- Ask which failure path is likely to differ across environments.
+
+If the error behavior is already perfectly obvious from a local validator or type system, it is usually low priority for this skill.

--- a/.agents/skills/runtime-behavior-probe/references/openai-runtime-patterns.md
+++ b/.agents/skills/runtime-behavior-probe/references/openai-runtime-patterns.md
@@ -1,0 +1,126 @@
+# OpenAI Runtime Patterns
+
+Use this reference for recurring OpenAI investigations so you do not have to rediscover the probe strategy each time. In this repository, use [$openai-knowledge](../../openai-knowledge/SKILL.md) up front for contract-sensitive details, then use this reference to design the runtime validation. If the docs MCP is unavailable, fall back to the official OpenAI docs and say so in the report.
+
+## General Rules
+
+- Prefer small live probes over large harnesses.
+- Keep one script focused on one uncertainty.
+- For comparative or benchmark-like questions, start with a pilot and expand only when the answer is still unclear.
+- Capture both the request shape and the returned item types.
+- Preserve raw error payloads and status codes.
+- Record whether behavior differs between the first call and a repeated call.
+- When the question is about regression or contract drift, add a known-good control run before attributing the result to the change under investigation.
+- Keep comparison parity explicit. Record what was held constant, what variable changed, and whether output-shape or usage differences could bias the conclusion.
+- When the question depends on tool invocation, force the target path with the matching `tool_choice`.
+- Treat `container_auto` and `container_reference` as distinct setup modes, not interchangeable details.
+- Clear unsupported model or tool options before diagnosing runtime behavior.
+
+## Standard Environment Variables
+
+Do not read these variables automatically. Before a live probe uses any of them, tell the user the exact variable names you plan to read and why each one is needed, then wait for explicit approval. Never print their values:
+
+- `OPENAI_API_KEY`
+- `OPENAI_BASE_URL`
+- `OPENAI_ORG_ID`
+- `OPENAI_PROJECT_ID`
+
+If the task targets another standard integration, use that integration's expected default variable names under the same rule.
+
+## Responses API Probe Patterns
+
+For Responses API work, start from the uncertainty instead of from the full feature surface.
+
+### Benchmark or model-switch comparisons
+
+Use when you need to compare models, settings, transports, or providers with enough rigor to support a product or release decision.
+
+Probe suggestions:
+
+- Start with a pilot that includes one control and two or three highest-signal scenarios.
+- Keep prompt shape, tool choice, state setup, and non-tested settings aligned across candidates.
+- If the question is about speed, capture medians and, when relevant, first-token latency plus any usage note that could explain the difference.
+- If the question is about "same intelligence" or "same quality," add at least one harder or more open-ended case. Otherwise report the result as pattern parity only.
+- Expand to a larger matrix only when the pilot survives, the candidates are close, or a major runtime surface is still uncovered.
+
+### Plain response behavior
+
+Use when you need to confirm:
+
+- The shape of returned output items.
+- Whether text appears in one item or multiple items.
+- How metadata appears in the final object.
+
+Probe suggestions:
+
+- Baseline call with a minimal input.
+- Same call with a slightly different instruction shape.
+- Repeat the same call to check output stability where that matters.
+
+### Structured output behavior
+
+Use when you need to observe:
+
+- Schema rejection versus best-effort completion.
+- Handling of missing required fields.
+- Differences between model-compliant output and transport-level errors.
+
+Probe suggestions:
+
+- Valid schema and valid prompt.
+- Prompt likely to produce omitted fields.
+- Clearly incompatible schema or unsupported option when relevant.
+
+### Tool invocation behavior
+
+Use when you need to learn:
+
+- When tool calls are emitted.
+- How arguments are shaped at runtime.
+- What happens when the tool fails or returns malformed output.
+
+Probe suggestions:
+
+- Baseline tool-call success.
+- Tool failure with a realistic exception.
+- Tool result that is syntactically valid but semantically incomplete.
+
+### Hosted shell and code interpreter failure shields
+
+When probing hosted tools through the Responses API, eliminate common setup ambiguity first:
+
+- Force the tool path you want to test with the matching `tool_choice`. A text-only completion without forced tool choice is not a reliable negative result.
+- Treat `container_auto` and `container_reference` differently. Use `container_auto` when the probe needs fresh container provisioning or skill attachment, and use `container_reference` only to reuse existing container state.
+- Do not assume every environment field is accepted on every container mode. If the probe is about skills, validate that the chosen container mode actually supports skill attachment before treating an API error as a runtime defect.
+- Check model-specific option support before chasing unrelated failures. Unsupported reasoning or model settings can invalidate the probe before the tool path is exercised.
+- For hosted package installation, treat network-dependent setup as best-effort and separate install failures from the underlying tool behavior you are trying to observe.
+- For prompt cache investigations, keep model, instructions, tool configuration, and cache key effectively identical across repeated runs before interpreting `cached_tokens`.
+
+### Streaming behavior
+
+Use when the uncertainty involves:
+
+- Event ordering.
+- Partial text delivery.
+- Termination after interruption.
+- Tool-call events in streams.
+
+Probe suggestions:
+
+- Normal streamed completion.
+- Early local cancellation.
+- Network interruption if it can be reproduced safely.
+
+## What to Capture
+
+For OpenAI probes, try to record:
+
+- Request options that materially affect behavior.
+- Response item types and their order.
+- Whether fields are absent, null, empty, or transformed.
+- Server status and error payload details for failures.
+- Retry and backoff hints when present.
+- Stable identifiers that help compare repeated runs, such as request IDs, response IDs, tool call IDs, or container IDs when available.
+- Which environment-variable names were approved for the probe when live credentials were required.
+
+Do not spend time rediscovering static documentation unless the runtime result seems to contradict what you expected. The value of this skill is in the observed behavior.

--- a/.agents/skills/runtime-behavior-probe/references/repo-import-patterns.md
+++ b/.agents/skills/runtime-behavior-probe/references/repo-import-patterns.md
@@ -1,0 +1,96 @@
+# Repository Import Patterns
+
+Use this reference when a temporary probe script outside the repository needs to load code from the current branch.
+
+## Why This Exists
+
+When you run `pnpm exec tsx /tmp/probe.ts` from the repository root, `tsx` itself comes from this repository, but the probe file still lives under `/tmp`. Bare workspace imports such as `@openai/agents-core` or `@openai/agents` therefore resolve as if the script were its own package. That is often not what you want for "what does the current branch do right now?" investigations.
+
+The safe default is to build a `file://` import URL from `process.cwd()`, which should be the repository root, and a repository-relative path.
+
+## Default Rule
+
+- Use `src/` imports when the question is about current-branch behavior.
+- Use `dist/` imports when the question is about packaged output after a build.
+- Avoid bare workspace imports from `/tmp` unless the probe is explicitly testing published package resolution rather than branch-local source behavior.
+
+## Quick Typecheck Loop
+
+For disposable probes in `openai-agents-js`, the default loop should stay outside the repository and avoid a full workspace build:
+
+1. Create a temporary directory with `mktemp -d`.
+2. Write `probe.ts` there.
+3. Write a sibling `tsconfig.json` that extends the repository's `tsconfig.examples.json`.
+4. From the repository root, run `pnpm exec tsc --noEmit -p /tmp/.../tsconfig.json`.
+5. If that passes, run `pnpm exec tsx /tmp/.../probe.ts`.
+
+Example temporary `tsconfig.json`:
+
+```json
+{
+  "extends": "/absolute/path/to/openai-agents-js/tsconfig.examples.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["./probe.ts"]
+}
+```
+
+This keeps TypeScript module resolution and strictness close to the repository defaults while limiting the check surface to the disposable probe file.
+
+Do not convert this default loop into a checked-in benchmark, example, or package script unless the user explicitly asks for a reusable repository artifact.
+
+## Recommended Helper
+
+The disposable TypeScript scaffold exposes:
+
+    const module = await importRepoModule("packages/agents-core/src/index.ts");
+
+Internally, the helper should be equivalent to:
+
+    import { join } from "node:path";
+    import { pathToFileURL } from "node:url";
+
+    async function importRepoModule(repoRelativePath: string) {
+      const absolutePath = join(process.cwd(), repoRelativePath);
+      return import(pathToFileURL(absolutePath).href);
+    }
+
+This keeps the import anchored to the current checkout instead of the temporary script location.
+
+## Choosing `src/` Versus `dist/`
+
+Use `src/` when:
+
+- You are validating a bug fix or regression on the current branch.
+- You want to know how the repository behaves before packaging.
+- The question is about implementation details or internal helper behavior.
+
+Use `dist/` when:
+
+- The question is specifically about what consumers load after `pnpm build`.
+- You need to validate export maps or emitted `.mjs` and `.d.ts` output.
+- The bug only reproduces in generated output.
+
+If the probe uses `dist/`, record whether you ran a fresh build first. A stale `dist/` directory can create false positives or false negatives.
+
+Do not run `pnpm build` only to typecheck or execute a `src/`-based disposable probe. The fast path is temp `tsconfig` plus `pnpm exec tsc --noEmit`, then `pnpm exec tsx`.
+
+## Simple Smoke Targets
+
+When you only need to prove the helper works, start with a simple target that has minimal side effects, for example:
+
+- `packages/agents-core/src/index.ts`
+- `packages/agents-openai/src/index.ts`
+- another file with obvious exported symbols and no environment requirement
+
+If a chosen file pulls in more of the repo than expected, switch to a simpler target rather than weakening the import guidance.
+
+## What To Record
+
+When a probe imports repo code, report:
+
+- The repo-relative path you imported.
+- Whether it came from `src/` or `dist/`.
+- The repository root used by `process.cwd()`.
+- Any prerequisite step such as `pnpm build`.

--- a/.agents/skills/runtime-behavior-probe/references/reporting-format.md
+++ b/.agents/skills/runtime-behavior-probe/references/reporting-format.md
@@ -1,0 +1,118 @@
+# Reporting Format
+
+Lead with findings, not process. The user asked for investigation results, so the answer should start with the most important observed behaviors. Put the real news first.
+
+## Recommended Order
+
+1. Findings.
+2. Validation approach.
+3. Case matrix or condensed case summary.
+4. Artifact status and brief run summary.
+5. Optional implementation note.
+
+## Findings Section
+
+Make each finding answer one user-relevant question. Good findings usually include:
+
+- What was observed.
+- Why it matters.
+- The condition under which it happens.
+- What was held constant when the finding comes from a comparison probe.
+- `scope`: The boundary of the finding, such as commit, model, Node version, live versus local, or repeat mode.
+- `confidence`: `high`, `medium`, or `low`.
+
+Avoid burying the main result under setup details.
+
+Put `unexpected` or `negative` findings first. If there were no unexpected or negative findings in the executed cases, say that explicitly before the rest of the findings section.
+
+If the probe was comparative, say whether the result supports:
+
+- Pattern parity only.
+- A broader quality claim.
+
+Do not imply a broader quality equivalence than the executed cases justify.
+
+## Validation Approach Section
+
+Summarize:
+
+- The runtime surface you exercised.
+- The shape of the probe code, in overview only.
+- Which categories of cases you covered.
+- Which execution modes you used, including repeat counts or warm-up handling when relevant.
+- Whether live credentials or external services were used.
+- Any important state controls such as fresh state, cache reuse, cache busting, unique IDs, or cleanup verification.
+- For comparison probes, what was held constant, what was varied, and whether output-shape or usage differences could still influence the conclusion.
+- Whether the usual docs path or an official-docs fallback was used for contract-sensitive checks.
+
+Keep this concise. The user needs enough detail to trust the result, not a line-by-line replay of the script.
+
+## Case Summary
+
+Include either the full matrix or a condensed summary. At minimum, show:
+
+- Which scenarios were executed.
+- Whether the run was a quick pilot, an expanded matrix, or both.
+- Which ones produced `unexpected` or `negative` results.
+- Which ones passed or failed when a real comparison basis existed.
+- Which cases were blocked.
+- Where the supporting evidence lived, or that it was deleted.
+
+If the matrix is large, show the highest-value cases in the main response and keep the rest as a compact appendix or note.
+
+## Artifact Status And Brief Run Summary
+
+State one of these explicitly:
+
+- Temporary artifacts were kept until the final response was drafted, then deleted after validation.
+- Temporary artifacts were kept at `<path>` because the user asked to keep them.
+- Temporary artifacts were kept at `<path>` because they are needed for follow-up analysis.
+
+Even if artifacts were deleted, retain a short run summary such as:
+
+- Probe command or runner shape.
+- Runtime context summary such as commit, Node executable, Node version, or model.
+- Artifact path and final status.
+
+For benchmark or repeat-heavy probes, keeping artifacts for follow-up is often the right default even when the immediate report is done.
+
+## Optional Implementation Note
+
+Include this only when one clear defect was isolated and a short implementation hypothesis or minimal repro direction would help. Keep it brief. Do not turn the report into a broader next-step plan unless the user asked for that.
+
+## Compact Template
+
+Use this outline when you need a fast structure:
+
+    Findings:
+    - <finding 1>
+      held constant: <prompt/tool/state settings kept the same, if comparative>
+      scope: <commit/model/node/live-local/repeat-mode>
+      confidence: <high|medium|low>
+    - <finding 2>
+      held constant: <prompt/tool/state settings kept the same, if comparative>
+      scope: <commit/model/node/live-local/repeat-mode>
+      confidence: <high|medium|low>
+
+    Validation approach:
+    - Surface: <what was exercised>
+    - Probe code: <brief overview>
+    - Coverage: <success, edge, error, repeat-sensitive, and quality categories>
+    - Execution modes: <single-shot|repeat-N|warm-up + repeat-N>
+    - Comparison parity: <what was held constant and what varied, if comparative>
+    - Docs source: <MCP or official-docs fallback, if relevant>
+
+    Case summary:
+    | case_id | scenario | result_flag | status | note |
+    | --- | --- | --- | --- | --- |
+    | S1 | ... | expected | pass | ... |
+    | E1 | ... | negative | fail | ... |
+
+    Artifact status and brief run summary:
+    - Temporary artifacts were kept until the final response was drafted, then deleted.
+    - Summary: <command/runtime-context/artifact-status summary>
+
+    Optional implementation note:
+    - <brief hypothesis or minimal repro direction>
+
+Adjust the format to the task, but preserve the ordering.

--- a/.agents/skills/runtime-behavior-probe/references/validation-matrix.md
+++ b/.agents/skills/runtime-behavior-probe/references/validation-matrix.md
@@ -1,0 +1,137 @@
+# Validation Matrix
+
+Use the matrix to decide what to probe before writing scripts. The goal is not exhaustive combinatorics; the goal is high-value coverage that is visible, explainable, and likely to reveal runtime surprises. The matrix should make the real news easy to scan.
+
+## Minimum Columns
+
+Use these columns unless the task clearly needs more:
+
+- `case_id`: Stable identifier such as `S1`, `E3`, or `R2`.
+- `scenario`: Short description of the behavior under test.
+- `mode`: `single-shot`, `repeat-N`, or `warm-up + repeat-N`.
+- `question`: The concrete runtime uncertainty this case is answering.
+- `setup`: Inputs, environment, or preconditions required for the case.
+- `observation_summary`: A compact summary of what actually happened.
+- `result_flag`: `unexpected`, `negative`, `expected`, or `blocked`.
+- `evidence`: Path, log reference, or `deleted`.
+
+Add these columns when they materially improve the investigation:
+
+- `comparison_basis`: The baseline, docs, or prior behavior you are comparing against.
+- `variable_under_test`: The single factor that is intentionally changing in a comparison case.
+- `held_constant`: Prompt shape, tool setup, model settings, or state rules that were intentionally kept the same.
+- `output_constraint`: Any schema, length, or response-shape constraint used to keep the comparison fair.
+- `status`: Use `pass`, `fail`, `unexpected-pass`, `unexpected-fail`, or `blocked` only when there is a credible comparison basis or control.
+- `confidence`: `high`, `medium`, or `low`.
+- `state_setup`: Fresh or reused state, cache strategy, unique IDs, and cleanup checks.
+- `repeats`: Number of measured runs.
+- `warm_up`: Whether a warm-up run was used and why.
+- `variance`: Any useful spread or instability note across repeated runs.
+- `usage_note`: Token, usage, or output-length note when it materially affects interpretation.
+- `control`: Known-good comparison point for regression or behavior-change questions.
+- `risk_profile`: `read-only`, `mutating`, or `costly` for live probes.
+- `env_vars`: Exact environment-variable names the case plans to read.
+- `approval`: `not-needed`, `pending`, or `approved` for cases that need user permission before execution.
+
+Use `result_flag` as the fast scan field. It is what makes unexpected or negative findings jump out before the reader studies the full report.
+
+Use `status` only when you have a real comparison basis. If the case is exploratory and there is no trustworthy baseline, prefer a strong `observation_summary` plus `result_flag` and `confidence` instead of pretending the result is a clean pass or fail.
+
+## Choosing Execution Mode
+
+Pick an execution mode before you run the case:
+
+- Use `single-shot` for deterministic, one-run checks.
+- Use `repeat-N` automatically when the question involves cache behavior, retries, streaming, interruptions, rate limiting, concurrency, or other run-to-run-sensitive behavior.
+- Use `warm-up + repeat-N` when the first run is likely to include cold-start effects such as container provisioning, import caches, or prompt-cache population.
+
+Use these defaults unless the task clearly needs something else:
+
+- `repeat-3` for a quick screen of a repeat-sensitive question.
+- `warm-up + repeat-10` for decision-grade latency comparisons or release-facing recommendations.
+- For costly live probes, start at `repeat-3`, then expand only if the answer is still unclear.
+
+If it is genuinely unclear whether extra runs are worth the time or cost, ask the user before expanding the probe.
+
+## Phase The Matrix
+
+When the question is comparative or benchmark-like, do not jump straight to the largest matrix.
+
+Start with a pilot:
+
+- One control.
+- One or two highest-signal success cases.
+- The smallest repeat count that can disqualify a weak candidate quickly.
+
+Expand only when:
+
+- The candidate survives the pilot.
+- The results are close enough that more samples matter.
+- A major runtime surface is still uncovered.
+- The user explicitly wants decision-grade evidence.
+
+## Coverage Categories
+
+Try to cover at least one case from each relevant category:
+
+- `success`: Normal behavior that should work.
+- `control`: Known-good comparison such as `origin/main`, the latest release, or the same request without the suspected option.
+- `boundary`: Size, count, or parameter limits near a plausible edge.
+- `invalid`: Bad inputs or unsupported combinations.
+- `misconfig`: Missing key, wrong endpoint, bad permissions, or incompatible local setup.
+- `transient`: Timeout, temporary server issue, network breakage, or rate limiting.
+- `recovery`: Retry behavior, partial completion, duplicate submission, or cleanup.
+- `concurrency`: Overlapping operations when shared state, ordering, or isolation may matter.
+- `quality`: A harder or more open-ended sample when the user is asking about model intelligence, not just workflow parity.
+
+If time is limited, prioritize categories in this order:
+
+1. Known-good control when the question implies regression or drift.
+2. Highest-risk success case.
+3. Most plausible user-facing failure.
+4. Most likely edge case with ambiguous behavior.
+5. Cleanup or retry semantics.
+6. Lower-probability extremes.
+
+## Matrix Template
+
+Use this compact template:
+
+    | case_id | scenario | mode | question | setup | state_setup | variable_under_test | held_constant | comparison_basis | observation_summary | result_flag | status | evidence |
+    | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+    | K1 | Known-good control | single-shot | Does the baseline still show the expected behavior? | Same probe against baseline target | Fresh state | none | current probe shape | `origin/main` or latest release | pending | pending | pending | pending |
+    | S1 | Baseline success | single-shot | What does the normal success path look like at runtime? | Valid config and representative input | Fresh state | none | representative input and setup | current docs or local expectation | pending | pending | pending | pending |
+    | R1 | Cache or retry behavior | warm-up + repeat-N | Does behavior change after the first run or across retries? | Same request repeated under controlled settings | Cache key or retry setup recorded | reuse versus fresh state | prompt shape and tool setup | same request without reuse, or docs if available | pending | pending | pending | pending |
+    | C1 | Model comparison pilot | warm-up + repeat-N | Does candidate B preserve the covered behavior while improving latency? | Same scenario across two models | Fresh state and stable IDs | model name | prompt shape, tool choice, and model settings parity | control model in the same probe | pending | pending | pending | pending |
+    | E1 | Invalid input | single-shot | How does the runtime reject a realistic bad input? | Missing required field | Fresh state | invalid field value | same request with valid field | same request with valid field | pending | pending | pending | pending |
+    | X1 | Concurrent overlap | repeat-N | Do overlapping runs interfere with each other? | Two or more overlapping operations | Unique IDs plus cleanup verification | overlap timing | same logical input | same request serialized, if available | pending | pending | pending | pending |
+
+## Recording Results
+
+Keep `question` unchanged after execution. Put the actual behavior in `observation_summary`, then mark the scan-friendly `result_flag`.
+
+Use these `result_flag` values consistently:
+
+- `unexpected`: The result diverged from the best current understanding in a surprising way.
+- `negative`: The result exposed a user-relevant failure, risk, or sharp edge.
+- `expected`: The result matched the current understanding and did not reveal new risk.
+- `blocked`: The case did not produce a trustworthy observation.
+
+Only fill `status` when there is a credible comparison basis. Otherwise use `observation_summary`, `result_flag`, and `confidence` to communicate what was learned without over-claiming certainty.
+
+For comparison cases, use `observation_summary` and the final report to say whether the evidence supports pattern parity only or a broader quality claim.
+
+If a case reveals a new branch of behavior, add a follow-up case instead of overloading the original one.
+
+## Evidence Discipline
+
+Treat a case as incomplete when:
+
+- The observed output omits the key result you were testing.
+- The script mixed multiple questions and the result is ambiguous.
+- Hidden state, cache behavior, or previous runs may have influenced the result and were not controlled or documented.
+- The question is whether behavior changed, but the case has no credible control or baseline to compare against.
+- The case plans to read environment variables, but the exact variable names were not approved by the user before execution.
+- The case was repeat-sensitive, but it ran only once without a clear rationale.
+
+When this happens, narrow the probe and rerun. A smaller script with a cleaner result is better than a more complicated script that is hard to trust.

--- a/.agents/skills/runtime-behavior-probe/templates/typescript_probe.ts
+++ b/.agents/skills/runtime-behavior-probe/templates/typescript_probe.ts
@@ -1,0 +1,325 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * Disposable probe workflow for openai-agents-js:
+ * 1. Put this file in a temporary directory created with `mktemp -d`.
+ * 2. Add a sibling `tsconfig.json` that extends `${process.cwd()}/tsconfig.examples.json`
+ *    and includes only `./probe.ts`.
+ * 3. From the repository root, run `pnpm exec tsc --noEmit -p /tmp/.../tsconfig.json`.
+ * 4. If that passes, run `pnpm exec tsx /tmp/.../probe.ts`.
+ * 5. Only switch to `dist/` imports and `pnpm build` when packaged output is the thing under test.
+ */
+
+type ProbeMode = 'single-shot' | 'repeat-N' | 'warm-up + repeat-N';
+type ResultFlag = 'unexpected' | 'negative' | 'expected' | 'blocked';
+
+type CaseResult = {
+  case_id: string;
+  mode: ProbeMode;
+  is_warmup: boolean;
+  observation_summary: string;
+  result_flag: ResultFlag;
+  metrics: Record<string, unknown>;
+  error: string | null;
+  total_latency_s?: number;
+  first_token_latency_s?: number;
+};
+
+const SCENARIO = 'replace-me';
+const RUN_LABEL = 'replace-me';
+const MODE: ProbeMode = 'single-shot';
+const APPROVED_ENV_VARS: string[] = [];
+const OUTPUT_DIR_ENV = 'PROBE_OUTPUT_DIR';
+
+const RESULTS: CaseResult[] = [];
+const repoRequire = createRequire(join(process.cwd(), 'package.json'));
+
+function gitValue(...args: string[]): string {
+  const result = spawnSync('git', args, {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    return 'unknown';
+  }
+  const value = result.stdout.trim();
+  return value || 'unknown';
+}
+
+function outputDir(): string | null {
+  const value = process.env[OUTPUT_DIR_ENV];
+  return value ? resolve(value) : null;
+}
+
+function writeJson(path: string, payload: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function emit(kind: string, payload: Record<string, unknown> = {}): void {
+  console.log(
+    JSON.stringify({
+      ts: Number((Date.now() / 1000).toFixed(3)),
+      kind,
+      ...payload,
+    }),
+  );
+}
+
+function findNearestPackageJson(startPath: string): string | null {
+  let current = resolve(startPath);
+  while (true) {
+    const candidate = join(current, 'package.json');
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = resolve(current, '..');
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+
+function resolvePackageVersion(packageName: string): string | null {
+  try {
+    const packageJsonPath = repoRequire.resolve(`${packageName}/package.json`);
+    return JSON.parse(readFileSync(packageJsonPath, 'utf8')).version ?? null;
+  } catch {
+    try {
+      const entryPath = repoRequire.resolve(packageName);
+      const packageJsonPath = findNearestPackageJson(resolve(entryPath, '..'));
+      if (!packageJsonPath) {
+        return null;
+      }
+      return JSON.parse(readFileSync(packageJsonPath, 'utf8')).version ?? null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+export async function importRepoModule(
+  repoRelativePath: string,
+): Promise<Record<string, unknown>> {
+  const absolutePath = resolve(process.cwd(), repoRelativePath);
+  return import(pathToFileURL(absolutePath).href);
+}
+
+function runtimeContext(): Record<string, unknown> {
+  const approvedEnvVars = Object.fromEntries(
+    APPROVED_ENV_VARS.map((name) => [
+      name,
+      process.env[name] ? 'set' : 'unset',
+    ]),
+  );
+
+  const packageVersions = Object.fromEntries(
+    ['openai', '@openai/agents', '@openai/agents-core']
+      .map((name) => [name, resolvePackageVersion(name)])
+      .filter((entry): entry is [string, string] => Boolean(entry[1])),
+  );
+
+  return {
+    scenario: SCENARIO,
+    run_label: RUN_LABEL,
+    mode: MODE,
+    cwd: process.cwd(),
+    script_path: resolve(process.argv[1] ?? ''),
+    node_executable: process.execPath,
+    node_version: process.version,
+    platform: process.platform,
+    git_commit: gitValue('rev-parse', 'HEAD'),
+    git_branch: gitValue('rev-parse', '--abbrev-ref', 'HEAD'),
+    pnpm_execpath: process.env.npm_execpath ?? null,
+    package_versions: packageVersions,
+    approved_env_vars: approvedEnvVars,
+    output_dir: outputDir(),
+  };
+}
+
+function startCase(
+  caseId: string,
+  options: { mode?: ProbeMode; note?: string } = {},
+): void {
+  emit('case_start', {
+    case_id: caseId,
+    mode: options.mode ?? MODE,
+    note: options.note ?? null,
+  });
+}
+
+function recordCaseResult(
+  caseId: string,
+  observationSummary: string,
+  resultFlag: ResultFlag,
+  options: {
+    mode?: ProbeMode;
+    isWarmup?: boolean;
+    totalLatencyS?: number;
+    firstTokenLatencyS?: number;
+    metrics?: Record<string, unknown>;
+    error?: string | null;
+  } = {},
+): void {
+  const payload: CaseResult = {
+    case_id: caseId,
+    mode: options.mode ?? MODE,
+    is_warmup: options.isWarmup ?? false,
+    observation_summary: observationSummary,
+    result_flag: resultFlag,
+    metrics: options.metrics ?? {},
+    error: options.error ?? null,
+  };
+
+  if (options.totalLatencyS !== undefined) {
+    payload.total_latency_s = options.totalLatencyS;
+  }
+  if (options.firstTokenLatencyS !== undefined) {
+    payload.first_token_latency_s = options.firstTokenLatencyS;
+  }
+
+  RESULTS.push(payload);
+  emit('case_result', payload as Record<string, unknown>);
+}
+
+function summarizeResults(): Record<string, unknown> {
+  const cases = new Map<string, CaseResult[]>();
+  for (const result of RESULTS) {
+    const existing = cases.get(result.case_id) ?? [];
+    existing.push(result);
+    cases.set(result.case_id, existing);
+  }
+
+  const summarizedCases = Object.fromEntries(
+    [...cases.entries()].map(([caseId, items]) => {
+      const measured = items.filter((item) => !item.is_warmup);
+      const effectiveItems = measured.length > 0 ? measured : items;
+      const totalLatencies = effectiveItems
+        .map((item) => item.total_latency_s)
+        .filter((value): value is number => typeof value === 'number');
+      const firstTokenLatencies = effectiveItems
+        .map((item) => item.first_token_latency_s)
+        .filter((value): value is number => typeof value === 'number');
+      const resultFlags = Object.fromEntries(
+        [...new Set(effectiveItems.map((item) => item.result_flag))].map(
+          (flag) => [
+            flag,
+            effectiveItems.filter((item) => item.result_flag === flag).length,
+          ],
+        ),
+      );
+      const median = (values: number[]): number | null => {
+        if (values.length === 0) {
+          return null;
+        }
+        const sorted = [...values].sort((a, b) => a - b);
+        const middle = Math.floor(sorted.length / 2);
+        if (sorted.length % 2 === 1) {
+          return sorted[middle];
+        }
+        return (sorted[middle - 1] + sorted[middle]) / 2;
+      };
+
+      return [
+        caseId,
+        {
+          mode: items.at(-1)?.mode ?? MODE,
+          runs: effectiveItems.length,
+          warmups: items.length - effectiveItems.length,
+          result_flags: resultFlags,
+          median_total_latency_s: median(totalLatencies),
+          median_first_token_latency_s: median(firstTokenLatencies),
+          observations: effectiveItems
+            .slice(0, 3)
+            .map((item) => item.observation_summary),
+        },
+      ];
+    }),
+  );
+
+  const overallResultFlags = Object.fromEntries(
+    [...new Set(RESULTS.map((item) => item.result_flag))].map((flag) => [
+      flag,
+      RESULTS.filter((item) => item.result_flag === flag).length,
+    ]),
+  );
+
+  return {
+    scenario: SCENARIO,
+    run_label: RUN_LABEL,
+    mode: MODE,
+    result_count: RESULTS.length,
+    cases: summarizedCases,
+    result_flags: overallResultFlags,
+  };
+}
+
+function finalize(exitCode: number): void {
+  const metadataPayload = {
+    exit_code: exitCode,
+    runtime_context: runtimeContext(),
+  };
+  const summaryPayload = summarizeResults();
+  emit('summary', {
+    metadata: metadataPayload,
+    summary: summaryPayload,
+  });
+
+  const directory = outputDir();
+  if (!directory) {
+    return;
+  }
+
+  mkdirSync(directory, { recursive: true });
+  const metadataPath = join(directory, 'metadata.json');
+  const resultsPath = join(directory, 'results.json');
+  const summaryPath = join(directory, 'summary.json');
+  writeJson(metadataPath, metadataPayload);
+  writeJson(resultsPath, RESULTS);
+  writeJson(summaryPath, summaryPayload);
+  emit('artifact_paths', {
+    metadata_path: metadataPath,
+    results_path: resultsPath,
+    summary_path: summaryPath,
+  });
+}
+
+async function main(): Promise<number> {
+  const caseId = process.env.PROBE_CASE_ID ?? 'case-0001';
+  emit('banner', { context: runtimeContext() });
+  startCase(caseId);
+
+  // Replace this block with the narrow runtime question you want to test.
+  // Example:
+  // const core = await importRepoModule('packages/agents-core/src/index.ts');
+  // const hasRunner = typeof (core as { Runner?: unknown }).Runner === 'function';
+  // recordCaseResult(
+  //   caseId,
+  //   hasRunner
+  //     ? 'Loaded agents-core source from the repository root.'
+  //     : 'agents-core source loaded but expected exports were missing.',
+  //   hasRunner ? 'expected' : 'negative',
+  //   { metrics: { import_path: 'packages/agents-core/src/index.ts' } },
+  // );
+  recordCaseResult(
+    caseId,
+    'Template executed. Replace the placeholder block with the runtime behavior you want to observe.',
+    'expected',
+  );
+
+  finalize(0);
+  return 0;
+}
+
+void main().catch((error: unknown) => {
+  const message =
+    error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+  emit('fatal', { error: message });
+  finalize(1);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
This pull request adds a new `runtime-behavior-probe` skill bundle under `.agents/skills/runtime-behavior-probe/` to support evidence-first runtime investigations in `openai-agents-js`. It introduces the main skill guidance, an OpenAI agent config, reusable reference notes for validation and reporting, and a disposable `typescript_probe.ts` scaffold for temporary TypeScript probes.

see also: https://github.com/openai/openai-agents-python/pull/2743