### PR TITLE
fix: omit acknowledged_safety_checks property in computer_call items

### DIFF
--- a/.changeset/short-seahorses-pull.md
+++ b/.changeset/short-seahorses-pull.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: omit empty computer safety check payloads

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -2057,8 +2057,12 @@ function getInputItems(
       const pendingSafetyChecks = getProviderDataField<
         OpenAI.Responses.ResponseComputerToolCall['pending_safety_checks']
       >(item.providerData, ['pendingSafetyChecks', 'pending_safety_checks']);
-      const normalizedPendingSafetyChecks: OpenAI.Responses.ResponseComputerToolCall['pending_safety_checks'] =
-        Array.isArray(pendingSafetyChecks) ? pendingSafetyChecks : [];
+      const normalizedPendingSafetyChecks:
+        | OpenAI.Responses.ResponseComputerToolCall['pending_safety_checks']
+        | undefined =
+        Array.isArray(pendingSafetyChecks) && pendingSafetyChecks.length > 0
+          ? pendingSafetyChecks
+          : undefined;
       const batchedActions = Array.isArray(
         (item as { actions?: unknown }).actions,
       )
@@ -2074,12 +2078,18 @@ function getInputItems(
           : item.action
             ? { action: item.action }
             : {};
-      const entry: OpenAI.Responses.ResponseComputerToolCall = {
+      // GA computer requests reject empty pending safety-check payloads, so we
+      // intentionally omit the field when there is nothing to acknowledge. The
+      // cast is only here to bridge the current OpenAI SDK type, which still
+      // models pending_safety_checks as required on ResponseComputerToolCall.
+      const entry = {
         type: 'computer_call',
         call_id: item.callId,
         id: item.id!,
         status: item.status,
-        pending_safety_checks: normalizedPendingSafetyChecks,
+        ...(normalizedPendingSafetyChecks
+          ? { pending_safety_checks: normalizedPendingSafetyChecks }
+          : {}),
         ...actionPayload,
         ...getSnakeCasedProviderDataWithoutReservedKeys(item.providerData, [
           'type',
@@ -2090,7 +2100,7 @@ function getInputItems(
           'status',
           'pending_safety_checks',
         ]),
-      };
+      } as OpenAI.Responses.ResponseComputerToolCall;
 
       return entry;
     }
@@ -2102,15 +2112,24 @@ function getInputItems(
         'acknowledgedSafetyChecks',
         'acknowledged_safety_checks',
       ]);
+      const normalizedAcknowledgedSafetyChecks:
+        | OpenAI.Responses.ResponseInputItem.ComputerCallOutput['acknowledged_safety_checks']
+        | undefined =
+        Array.isArray(acknowledgedSafetyChecks) &&
+        acknowledgedSafetyChecks.length > 0
+          ? acknowledgedSafetyChecks
+          : undefined;
       const entry: OpenAI.Responses.ResponseInputItem.ComputerCallOutput = {
         type: 'computer_call_output',
         id: item.id,
         call_id: item.callId,
         output: buildResponseOutput(item),
         status: item.providerData?.status,
-        acknowledged_safety_checks: Array.isArray(acknowledgedSafetyChecks)
-          ? acknowledgedSafetyChecks
-          : [],
+        ...(normalizedAcknowledgedSafetyChecks
+          ? {
+              acknowledged_safety_checks: normalizedAcknowledgedSafetyChecks,
+            }
+          : {}),
         ...getSnakeCasedProviderDataWithoutReservedKeys(item.providerData, [
           'type',
           'id',

--- a/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
@@ -751,6 +751,66 @@ describe('getInputItems', () => {
     });
   });
 
+  it('omits empty safety check fields when rebuilding computer items', () => {
+    const items = getInputItems([
+      {
+        type: 'computer_call',
+        id: 'computer-empty-checks',
+        callId: 'computer-call-empty-checks',
+        status: 'completed',
+        action: { type: 'wait' },
+        providerData: {
+          pending_safety_checks: [],
+        },
+      },
+      {
+        type: 'computer_call_result',
+        id: 'computer-result-empty-checks',
+        callId: 'computer-call-empty-checks',
+        output: { data: 'https://example.com/screenshot.png' },
+        providerData: {
+          acknowledged_safety_checks: [],
+        },
+      },
+    ] as any);
+
+    expect(items[0]).toMatchObject({
+      type: 'computer_call',
+      id: 'computer-empty-checks',
+      call_id: 'computer-call-empty-checks',
+      action: { type: 'wait' },
+    });
+    expect(items[0]).not.toHaveProperty('pending_safety_checks');
+
+    expect(items[1]).toMatchObject({
+      type: 'computer_call_output',
+      id: 'computer-result-empty-checks',
+      call_id: 'computer-call-empty-checks',
+    });
+    expect(items[1]).not.toHaveProperty('acknowledged_safety_checks');
+  });
+
+  it('omits unspecified safety check fields when rebuilding computer items', () => {
+    const items = getInputItems([
+      {
+        type: 'computer_call',
+        id: 'computer-no-checks',
+        callId: 'computer-call-no-checks',
+        status: 'completed',
+        action: { type: 'wait' },
+      },
+      {
+        type: 'computer_call_result',
+        id: 'computer-result-no-checks',
+        callId: 'computer-call-no-checks',
+        output: { data: 'https://example.com/screenshot.png' },
+      },
+    ] as any);
+
+    expect(items[0]).not.toHaveProperty('pending_safety_checks');
+    expect(items[1]).not.toHaveProperty('acknowledged_safety_checks');
+  });
+
   it('converts tool search items and namespaced function calls', () => {
     const items = getInputItems([
       {


### PR DESCRIPTION
This pull request applies the same workaround with https://github.com/openai/openai-agents-python/issues/2741 to computer using tool calls. The runtime behavioral change is on the server-side, so if the server behavior were reverted quickly, this client-side workaround may not be necessary. I am communicating with the relevant team. I will decide whether this SDK should have this later on.