### PR TITLE
docs: clarify streaming cancellation and resume behavior

### DIFF
--- a/docs/src/content/docs/guides/results.mdx
+++ b/docs/src/content/docs/guides/results.mdx
@@ -138,6 +138,8 @@ On normal top-level `run()` results this is usually `undefined`. The metadata is
 
 If you need the settled final state of a streamed run, wait for `completed` before reading `finalOutput`, `history`, `interruptions`, or other summary properties. For event-by-event handling, see the [streaming guide](/openai-agents-js/guides/streaming).
 
+If a streamed run is cancelled, `completed` still resolves after cleanup and `cancelled` becomes `true`, but turn-end fields such as `finalOutput` can remain unset because the current turn never finished. Resume that unfinished turn with `result.state` (and the same `session`, if you use one) instead of appending a fresh user message.
+
 ## Diagnostics and advanced fields
 
 ### Run context

--- a/docs/src/content/docs/guides/streaming.mdx
+++ b/docs/src/content/docs/guides/streaming.mdx
@@ -185,6 +185,16 @@ Streaming is compatible with handoffs that pause execution (for example when a t
 
 A fuller example that interacts with the user is [`human-in-the-loop-stream.ts`](https://github.com/openai/openai-agents-js/tree/main/examples/agent-patterns/human-in-the-loop-stream.ts).
 
+## Stop a stream and continue the same turn
+
+To stop a streaming run early, abort the `signal` you passed to `run()` or cancel a reader created from `stream.toStream()`. Either way, still await `stream.completed` before treating the run as settled. The SDK may still be persisting the current turn input or finishing other cleanup after your code stops consuming events.
+
+When a stream is cancelled, `stream.cancelled` becomes `true`, and `stream.finalOutput` often remains `undefined` because the current turn never finished. If you want to continue that unfinished turn later, rerun the same agent with `stream.state` instead of appending a fresh user message. That keeps turn counting correct and reuses any `conversationId` or `previousResponseId` already stored in the `RunState`.
+
+If you are also using session persistence, pass the same `session` again on the resumed `run()` call so the conversation keeps writing to the same backing store.
+
+Approval pauses follow the same rule: resolve `stream.interruptions`, then resume from `stream.state` rather than starting a new turn.
+
 ## Tips
 
 - Remember to wait for `stream.completed` before exiting to ensure all output has been flushed.


### PR DESCRIPTION
This pull request updates the streaming and results guides to explain how cancelled streaming runs settle in the JS SDK. It documents that callers should still await `stream.completed` after aborting a stream or cancelling a reader because cleanup can continue after event consumption stops, and it clarifies that cancelled runs may leave `finalOutput` unset because the current turn never finished.

It also adds explicit guidance to resume the unfinished turn from `stream.state` or `result.state` instead of appending a fresh user message, which preserves correct turn accounting and reuses any stored `conversationId` or `previousResponseId`. For session-backed flows, the docs now call out that resumed runs should reuse the same `session` so the conversation continues writing to the same backing store.

see also: https://github.com/openai/openai-agents-python/pull/2710