### PR TITLE
fix: strip reasoning and approval placeholders from handoff filters

### DIFF
--- a/.changeset/five-coins-rhyme.md
+++ b/.changeset/five-coins-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: remove reasoning and approval placeholders from handoff filters

--- a/packages/agents-core/src/extensions/handoffFilters.ts
+++ b/packages/agents-core/src/extensions/handoffFilters.ts
@@ -3,6 +3,8 @@ import {
   RunHandoffCallItem,
   RunHandoffOutputItem,
   RunItem,
+  RunReasoningItem,
+  RunToolApprovalItem,
   RunToolCallItem,
   RunToolCallOutputItem,
   RunToolSearchCallItem,
@@ -22,6 +24,7 @@ const TOOL_TYPES = new Set([
   'apply_patch_call',
   'apply_patch_call_output',
   'hosted_tool_call',
+  'reasoning',
 ]);
 
 /**
@@ -59,7 +62,9 @@ function removeToolsFromItems(items: RunItem[]): RunItem[] {
       !(item instanceof RunToolSearchCallItem) &&
       !(item instanceof RunToolSearchOutputItem) &&
       !(item instanceof RunToolCallItem) &&
-      !(item instanceof RunToolCallOutputItem),
+      !(item instanceof RunToolCallOutputItem) &&
+      !(item instanceof RunReasoningItem) &&
+      !(item instanceof RunToolApprovalItem),
   );
 }
 

--- a/packages/agents-core/test/extensions/handoffFilters.test.ts
+++ b/packages/agents-core/test/extensions/handoffFilters.test.ts
@@ -4,6 +4,8 @@ import {
   RunHandoffCallItem,
   RunHandoffOutputItem,
   RunMessageOutputItem,
+  RunReasoningItem,
+  RunToolApprovalItem,
   RunToolCallItem,
   RunToolCallOutputItem,
   RunToolSearchCallItem,
@@ -98,6 +100,25 @@ const toolSearchOutput: protocol.ToolSearchOutputItem = {
   ],
 };
 
+const reasoningItem: protocol.ReasoningItem = {
+  type: 'reasoning',
+  content: [{ type: 'input_text', text: 'thinking' }],
+};
+
+const hostedMcpApprovalRequest: protocol.HostedToolCallItem = {
+  type: 'hosted_tool_call',
+  id: 'approval-1',
+  name: 'lookup_account',
+  status: 'in_progress',
+  providerData: {
+    type: 'mcp_approval_request',
+    id: 'approval-1',
+    server_label: 'crm',
+    name: 'lookup_account',
+    arguments: '{}',
+  },
+};
+
 describe('removeAllTools', () => {
   test('should be available', () => {
     const result = removeAllTools({
@@ -129,11 +150,13 @@ describe('removeAllTools', () => {
         message,
         new RunToolSearchCallItem(toolSearchCall, TEST_AGENT),
         new RunToolCallItem(TEST_MODEL_FUNCTION_CALL, TEST_AGENT),
+        new RunReasoningItem(reasoningItem, TEST_AGENT),
       ],
       newItems: [
         new RunToolSearchOutputItem(toolSearchOutput, TEST_AGENT),
         new RunToolCallOutputItem(functionCallResult, TEST_AGENT, 'ok'),
         new RunHandoffOutputItem(functionCallResult, TEST_AGENT, TEST_AGENT),
+        new RunToolApprovalItem(hostedMcpApprovalRequest, TEST_AGENT),
         anotherMessage,
       ],
     });
@@ -162,6 +185,7 @@ describe('removeAllTools', () => {
       shellCallResult,
       applyPatchCall,
       applyPatchCallResult,
+      reasoningItem,
     ];
 
     const result = removeAllTools({
@@ -171,7 +195,7 @@ describe('removeAllTools', () => {
     });
 
     expect(result.inputHistory).toStrictEqual([userMessage]);
-    expect(history).toHaveLength(12);
+    expect(history).toHaveLength(13);
     expect((result.inputHistory as AgentInputItem[])[0]).toBe(userMessage);
   });
 });


### PR DESCRIPTION
This pull request fixes `removeAllTools()` so handoff input filtering removes orphaned reasoning items and pending tool-approval placeholders in addition to tool calls, tool outputs, and tool-search items. Before this change, a handoff could still forward reasoning traces or hosted MCP approval placeholders to the next agent even when the caller explicitly opted into the "remove all tools" filter.

It updates the handoff filter in `packages/agents-core/src/extensions/handoffFilters.ts` to exclude `reasoning` input items plus `RunReasoningItem` and `RunToolApprovalItem` run items. It also expands `packages/agents-core/test/extensions/handoffFilters.test.ts` with regression coverage for reasoning items and hosted MCP approval placeholders so the helper stays aligned with the actual run-item shapes used by the JS runtime.

see also: https://github.com/openai/openai-agents-python/pull/2700