### PR TITLE
fix: recover segmented assistant output in agent tools and finalization

### DIFF
--- a/.changeset/bright-fans-sing.md
+++ b/.changeset/bright-fans-sing.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: recover segmented assistant output in agent tools and finalization

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -5,7 +5,7 @@ import { RunItem, RunMessageOutputItem, RunToolApprovalItem } from '../items';
 import { ModelResponse } from '../model';
 import type { Runner, ToolErrorFormatter } from '../run';
 import { RunState } from '../runState';
-import { getLastTextFromOutputMessage } from '../utils/messages';
+import { getTextFromOutputMessage } from '../utils/messages';
 import { getSchemaAndParserFromInputType } from '../utils/tools';
 import { safeExecute } from '../utils/safeExecute';
 import { addErrorToCurrentSpan } from '../tracing/context';
@@ -783,9 +783,7 @@ export async function resolveTurnAfterModelResponse<TContext>(
   // we will use the last content output as the final output
   const potentialFinalOutput =
     messageItems.length > 0
-      ? getLastTextFromOutputMessage(
-          messageItems[messageItems.length - 1].rawItem,
-        )
+      ? getTextFromOutputMessage(messageItems[messageItems.length - 1].rawItem)
       : undefined;
 
   // if there is no output we just run again

--- a/packages/agents-core/src/utils/messages.ts
+++ b/packages/agents-core/src/utils/messages.ts
@@ -1,5 +1,20 @@
 import { ResponseOutputItem } from '../types';
 import { ModelResponse } from '../model';
+import type { AssistantMessageItem } from '../types/protocol';
+
+function getAssistantMessage(
+  outputMessage: ResponseOutputItem,
+): AssistantMessageItem | null {
+  if (outputMessage.type !== 'message') {
+    return null;
+  }
+
+  if (!('role' in outputMessage) || outputMessage.role !== 'assistant') {
+    return null;
+  }
+
+  return outputMessage as AssistantMessageItem;
+}
 
 /**
  * Get the last text from the output message.
@@ -9,20 +24,44 @@ import { ModelResponse } from '../model';
 export function getLastTextFromOutputMessage(
   outputMessage: ResponseOutputItem,
 ): string | undefined {
-  if (outputMessage.type !== 'message') {
+  const assistantMessage = getAssistantMessage(outputMessage);
+  if (!assistantMessage) {
     return undefined;
   }
 
-  if (outputMessage.role !== 'assistant') {
-    return undefined;
-  }
-
-  const lastItem = outputMessage.content[outputMessage.content.length - 1];
+  const lastItem =
+    assistantMessage.content[assistantMessage.content.length - 1];
   if (lastItem.type !== 'output_text') {
     return undefined;
   }
 
   return lastItem.text;
+}
+
+/**
+ * Get all text from the output message.
+ * @param outputMessage
+ * @returns
+ */
+export function getTextFromOutputMessage(
+  outputMessage: ResponseOutputItem,
+): string | undefined {
+  const assistantMessage = getAssistantMessage(outputMessage);
+  if (!assistantMessage) {
+    return undefined;
+  }
+
+  let sawText = false;
+  const text = assistantMessage.content.reduce((acc, item) => {
+    if (item.type !== 'output_text') {
+      return acc;
+    }
+
+    sawText = true;
+    return acc + item.text;
+  }, '');
+
+  return sawText ? text : undefined;
 }
 
 /**
@@ -36,6 +75,6 @@ export function getOutputText(output: ModelResponse) {
   }
 
   return (
-    getLastTextFromOutputMessage(output.output[output.output.length - 1]) || ''
+    getTextFromOutputMessage(output.output[output.output.length - 1]) || ''
   );
 }

--- a/packages/agents-core/test/agent.test.ts
+++ b/packages/agents-core/test/agent.test.ts
@@ -1303,6 +1303,83 @@ describe('Agent', () => {
     expect(runSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('returns the full concatenated assistant text from nested agent tools', async () => {
+    setDefaultModelProvider(new FakeModelProvider());
+    const agent = new Agent({
+      name: 'Segmented Streamer',
+      instructions: 'Return segmented output.',
+    });
+    const runSpy = vi.spyOn(Runner.prototype, 'run').mockResolvedValue({
+      rawResponses: [
+        {
+          output: [
+            {
+              type: 'message',
+              role: 'assistant',
+              content: [
+                { type: 'output_text', text: 'first ' },
+                { type: 'output_text', text: 'second' },
+              ],
+            },
+          ],
+        },
+      ],
+      finalOutput: 'first second',
+    } as any);
+    const tool = agent.asTool({
+      toolDescription: 'desc',
+    });
+
+    const output = await tool.invoke(
+      new RunContext(),
+      JSON.stringify({ input: 'hi' }),
+    );
+
+    expect(output).toBe('first second');
+    expect(runSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the full concatenated structured output text from nested agent tools', async () => {
+    setDefaultModelProvider(new FakeModelProvider());
+    const agent = new Agent({
+      name: 'Structured Streamer',
+      instructions: 'Return segmented structured output.',
+      outputType: z.object({
+        answer: z.string(),
+      }),
+    });
+    const runSpy = vi.spyOn(Runner.prototype, 'run').mockResolvedValue({
+      rawResponses: [
+        {
+          output: [
+            {
+              type: 'message',
+              role: 'assistant',
+              content: [
+                { type: 'output_text', text: '{"answer":"str' },
+                { type: 'output_text', text: 'uctured"}' },
+              ],
+            },
+          ],
+        },
+      ],
+      finalOutput: {
+        answer: 'structured',
+      },
+    } as any);
+    const tool = agent.asTool({
+      toolDescription: 'desc',
+    });
+
+    const output = await tool.invoke(
+      new RunContext(),
+      JSON.stringify({ input: 'hi' }),
+    );
+
+    expect(output).toBe('{"answer":"structured"}');
+    expect(runSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('streams nested agent events when onStream is provided and still returns final text', async () => {
     const agent = new Agent({
       name: 'Streamer Agent',

--- a/packages/agents-core/test/runner/turnResolution.test.ts
+++ b/packages/agents-core/test/runner/turnResolution.test.ts
@@ -431,6 +431,44 @@ describe('resolveTurnAfterModelResponse', () => {
     }
   });
 
+  it('returns concatenated final output when the last assistant message is segmented', async () => {
+    const textAgent = new Agent({ name: 'TextAgent', outputType: 'text' });
+    const segmentedMessage: protocol.AssistantMessageItem = {
+      id: 'msg-segmented',
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [
+        { type: 'output_text', text: 'first ' },
+        { type: 'output_text', text: 'second' },
+      ],
+    };
+    const response: ModelResponse = {
+      output: [segmentedMessage],
+      usage: new Usage(),
+    } as any;
+    const processedResponse = processModelResponse(response, textAgent, [], []);
+
+    expect(processedResponse.hasToolsOrApprovalsToRun()).toBe(false);
+
+    const result = await withTrace('test', () =>
+      resolveTurnAfterModelResponse(
+        textAgent,
+        'test input',
+        [],
+        response,
+        processedResponse,
+        runner,
+        state,
+      ),
+    );
+
+    expect(result.nextStep.type).toBe('next_step_final_output');
+    if (result.nextStep.type === 'next_step_final_output') {
+      expect(result.nextStep.output).toBe('first second');
+    }
+  });
+
   it('returns final output when final message text is empty', async () => {
     const textAgent = new Agent({ name: 'TextAgent', outputType: 'text' });
     const imageCall: protocol.HostedToolCallItem = {
@@ -471,6 +509,52 @@ describe('resolveTurnAfterModelResponse', () => {
     expect(result.nextStep.type).toBe('next_step_final_output');
     if (result.nextStep.type === 'next_step_final_output') {
       expect(result.nextStep.output).toBe('');
+    }
+  });
+
+  it('validates concatenated structured output types', async () => {
+    const structuredAgent = new Agent({
+      name: 'StructuredAgent',
+      outputType: z.object({
+        foo: z.string(),
+      }),
+    });
+    const segmentedStructuredMessage: protocol.AssistantMessageItem = {
+      id: 'msg-structured',
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [
+        { type: 'output_text', text: '{"foo":"ba' },
+        { type: 'output_text', text: 'r"}' },
+      ],
+    };
+    const response: ModelResponse = {
+      output: [segmentedStructuredMessage],
+      usage: new Usage(),
+    } as any;
+    const processedResponse = processModelResponse(
+      response,
+      structuredAgent,
+      [],
+      [],
+    );
+
+    const result = await withTrace('test', () =>
+      resolveTurnAfterModelResponse(
+        structuredAgent,
+        'test input',
+        [],
+        response,
+        processedResponse,
+        runner,
+        state,
+      ),
+    );
+
+    expect(result.nextStep.type).toBe('next_step_final_output');
+    if (result.nextStep.type === 'next_step_final_output') {
+      expect(result.nextStep.output).toBe('{"foo":"bar"}');
     }
   });
 

--- a/packages/agents-core/test/utils/messages.test.ts
+++ b/packages/agents-core/test/utils/messages.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   getLastTextFromOutputMessage,
   getOutputText,
+  getTextFromOutputMessage,
 } from '../../src/utils/messages';
 import type { ResponseOutputItem } from '../../src/types';
 import { Usage } from '../../src/usage';
@@ -37,7 +38,23 @@ describe('utils/messages', () => {
     expect(getLastTextFromOutputMessage(item)).toBe('b');
   });
 
-  it('getOutputText returns last assistant text', () => {
+  it('concatenates all assistant text segments', () => {
+    const item: ResponseOutputItem = {
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [
+        { type: 'output_text', text: 'part1' },
+        { type: 'refusal', refusal: 'ignored' },
+        { type: 'output_text', text: 'part2' },
+      ],
+    } as any;
+
+    expect(getTextFromOutputMessage(item)).toBe('part1part2');
+    expect(getLastTextFromOutputMessage(item)).toBe('part2');
+  });
+
+  it('getOutputText returns all assistant text', () => {
     const response: ModelResponse = {
       usage: new Usage(),
       output: [
@@ -45,11 +62,14 @@ describe('utils/messages', () => {
           type: 'message',
           role: 'assistant',
           status: 'completed',
-          content: [{ type: 'output_text', text: 'final' }],
+          content: [
+            { type: 'output_text', text: 'first ' },
+            { type: 'output_text', text: 'final' },
+          ],
         } as any,
       ],
     };
-    expect(getOutputText(response)).toBe('final');
+    expect(getOutputText(response)).toBe('first final');
   });
 
   it('getOutputText returns empty string when output is empty', () => {


### PR DESCRIPTION
This pull request fixes the JS analogue of https://github.com/openai/openai-agents-python/pull/2714. Python PR fixed a streamed nested-agent settlement bug where useful output had already been emitted, but fallback handling still lost the settled result. The JS runtime had the same user-visible failure mode for multi-segment assistant messages because `packages/agents-core/src/utils/messages.ts` and `packages/agents-core/src/runner/turnResolution.ts` only used the last `output_text` segment when deriving final output.

This change updates the shared message extraction path to concatenate all assistant `output_text` segments in order, so `Agent.asTool()` and normal turn finalization now recover the full plain-text or structured JSON string instead of returning only the last chunk. It also adds focused regressions in `packages/agents-core/test/utils/messages.test.ts`, `packages/agents-core/test/agent.test.ts`, and `packages/agents-core/test/runner/turnResolution.test.ts` to cover split plain-text output and split structured-output settlement, and adds a patch changeset for `@openai/agents-core`.

The compatibility risk is low: this does not change a released API shape or protocol, it corrects truncated final-output behavior to match the full assistant message that was already produced.