### PR TITLE
fix: #1122 hide ignored handoffs without breaking managed continuations

### DIFF
--- a/.changeset/tasty-falcons-drum.md
+++ b/.changeset/tasty-falcons-drum.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: #1122 hide ignored handoffs without breaking managed continuations

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1261,7 +1261,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             );
           }
           result.state._modelResponses.push(result.state._lastTurnResponse);
-
           const processedResponse = await processModelResponseAsync(
             result.state._lastTurnResponse,
             currentAgent,

--- a/packages/agents-core/src/runner/conversation.ts
+++ b/packages/agents-core/src/runner/conversation.ts
@@ -296,6 +296,7 @@ export class ServerConversationTracker {
   prepareInput(
     originalInput: string | AgentInputItem[],
     generatedItems: RunItem[],
+    supplementalGeneratedItems: AgentInputItem[] = [],
   ): AgentInputItem[] {
     const inputItems: AgentInputItem[] = [];
     const generatedItemsForInput: RunItem[] = [];
@@ -348,6 +349,16 @@ export class ServerConversationTracker {
       this.registerPreparedItemSource(preparedItem, sourceItem);
     }
     inputItems.push(...preparedGeneratedItems);
+    const filteredSupplementalItems = filterSupplementalGeneratedItems(
+      supplementalGeneratedItems,
+      preparedGeneratedItems,
+      this.sentItems,
+      this.serverItems,
+    );
+    for (const item of filteredSupplementalItems) {
+      this.registerPreparedItemSource(item);
+    }
+    inputItems.push(...filteredSupplementalItems);
 
     return inputItems;
   }
@@ -444,4 +455,41 @@ export class ServerConversationTracker {
       this.remainingInitialInput = null;
     }
   }
+}
+
+function filterSupplementalGeneratedItems(
+  supplementalGeneratedItems: AgentInputItem[],
+  preparedGeneratedItems: AgentInputItem[],
+  sentItems: WeakSet<object>,
+  serverItems: WeakSet<object>,
+): AgentInputItem[] {
+  const preparedFunctionResultCallIds = new Set(
+    preparedGeneratedItems.flatMap((item) => {
+      if (
+        !item ||
+        typeof item !== 'object' ||
+        item.type !== 'function_call_result' ||
+        typeof item.callId !== 'string'
+      ) {
+        return [];
+      }
+      return [item.callId];
+    }),
+  );
+
+  return supplementalGeneratedItems.filter((item) => {
+    if (!item || typeof item !== 'object') {
+      return true;
+    }
+    if (sentItems.has(item) || serverItems.has(item)) {
+      return false;
+    }
+    if (
+      item.type !== 'function_call_result' ||
+      typeof item.callId !== 'string'
+    ) {
+      return true;
+    }
+    return !preparedFunctionResultCallIds.has(item.callId);
+  });
 }

--- a/packages/agents-core/src/runner/modelOutputs.ts
+++ b/packages/agents-core/src/runner/modelOutputs.ts
@@ -104,6 +104,28 @@ function handleToolCallAction<
   actions.push(buildAction(resolvedTool));
 }
 
+function recordHandoffRequest(
+  output: protocol.FunctionCallItem,
+  handoff: Handoff<any, any>,
+  agent: Agent<any, any>,
+  items: RunItem[],
+  toolsUsed: string[],
+  handoffs: ToolRunHandoff[],
+): void {
+  toolsUsed.push(output.name);
+  const isPrimaryHandoff = handoffs.length === 0;
+  handoffs.push({
+    toolCall: output,
+    handoff,
+  });
+  if (!isPrimaryHandoff) {
+    return;
+  }
+  // Only persist the first handoff request. Later handoffs are SDK-ignored and
+  // would otherwise bias future turns against valid delegation targets.
+  items.push(new RunHandoffCallItem(output, agent));
+}
+
 function resolveFunctionOrHandoff(
   toolCall: protocol.FunctionCallItem,
   handoffMap: Map<string, Handoff<any, any>>,
@@ -821,12 +843,14 @@ export function processModelResponse<TContext>(
       agent,
     );
     if (resolved.type === 'handoff') {
-      toolsUsed.push(output.name);
-      items.push(new RunHandoffCallItem(output, agent));
-      runHandoffs.push({
-        toolCall: output,
-        handoff: resolved.handoff,
-      });
+      recordHandoffRequest(
+        output,
+        resolved.handoff,
+        agent,
+        items,
+        toolsUsed,
+        runHandoffs,
+      );
     } else {
       ensureDeferredFunctionToolLoaded(
         output,
@@ -1119,12 +1143,14 @@ export async function processModelResponseAsync<TContext>(
       agent,
     );
     if (resolved.type === 'handoff') {
-      toolsUsed.push(output.name);
-      items.push(new RunHandoffCallItem(output, agent));
-      runHandoffs.push({
-        toolCall: output,
-        handoff: resolved.handoff,
-      });
+      recordHandoffRequest(
+        output,
+        resolved.handoff,
+        agent,
+        items,
+        toolsUsed,
+        runHandoffs,
+      );
     } else {
       ensureDeferredFunctionToolLoaded(
         output,

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -11,6 +11,7 @@ import { consumeAgentToolRunResult } from '../agentToolRunResults';
 import { ToolCallError, ToolTimeoutError, UserError } from '../errors';
 import { getTransferMessage, HandoffInputData } from '../handoff';
 import {
+  RunHandoffCallItem,
   RunHandoffOutputItem,
   RunItem,
   RunMessageOutputItem,
@@ -1210,17 +1211,17 @@ export async function executeHandoffCalls<
   }
 
   if (runHandoffs.length > 1) {
-    // multiple handoffs. Ignoring all but the first one by adding reject responses for those
-    const outputMessage = 'Multiple handoffs detected, ignoring this one.';
-    for (let i = 1; i < runHandoffs.length; i++) {
-      newStepItems.push(
-        new RunToolCallOutputItem(
-          getToolCallOutputItem(runHandoffs[i].toolCall, outputMessage),
-          agent,
-          outputMessage,
+    const ignoredCallIds = new Set(
+      runHandoffs.slice(1).map((handoff) => handoff.toolCall.callId),
+    );
+    // Drop ignored handoff requests from the step so they never persist to history.
+    newStepItems = newStepItems.filter(
+      (item) =>
+        !(
+          item instanceof RunHandoffCallItem &&
+          ignoredCallIds.has(item.rawItem.callId)
         ),
-      );
-    }
+    );
   }
 
   const actualHandoff = runHandoffs[0];

--- a/packages/agents-core/src/runner/turnPreparation.ts
+++ b/packages/agents-core/src/runner/turnPreparation.ts
@@ -1,6 +1,6 @@
 import { Agent, AgentOutputType } from '../agent';
 import { MaxTurnsExceededError } from '../errors';
-import { RunItem } from '../items';
+import { RunHandoffOutputItem, RunItem } from '../items';
 import logger from '../logger';
 import { RunState } from '../runState';
 import type { AgentInputItem } from '../types';
@@ -16,7 +16,8 @@ import {
 } from './guardrails';
 import { prepareModelInputItems } from './items';
 import { prepareAgentArtifacts } from './modelPreparation';
-import type { AgentArtifacts } from './types';
+import { getToolCallOutputItem } from './toolExecution';
+import type { AgentArtifacts, ProcessedResponse } from './types';
 
 type GuardrailHandlers = {
   onParallelStart?: () => void;
@@ -99,7 +100,11 @@ export async function prepareTurn<
   );
 
   const turnInput = serverConversationTracker
-    ? serverConversationTracker.prepareInput(input, generatedItems)
+    ? serverConversationTracker.prepareInput(
+        input,
+        generatedItems,
+        getManagedConversationSupplementalItems(state),
+      )
     : prepareModelInputItems(
         input,
         generatedItems,
@@ -121,6 +126,54 @@ export async function prepareTurn<
     turnInput,
     parallelGuardrailPromise,
   };
+}
+
+const IGNORED_HANDOFF_OUTPUT_MESSAGE =
+  'Multiple handoffs detected, ignoring this one.';
+
+const managedConversationSupplementalItemsCache = new WeakMap<
+  ProcessedResponse<any>,
+  AgentInputItem[]
+>();
+
+export function getManagedConversationSupplementalItems<
+  TContext,
+  TAgent extends Agent<TContext, AgentOutputType>,
+>(state: RunState<TContext, TAgent>): AgentInputItem[] {
+  const processedResponse = state._lastProcessedResponse;
+  const handoffs = processedResponse?.handoffs;
+  if (!handoffs || handoffs.length <= 1) {
+    return [];
+  }
+
+  const acceptedCallId = handoffs[0]?.toolCall.callId;
+  // Respect handoff input filters that removed the accepted handoff output from the next turn.
+  const acceptedHandoffOutputStillPresent =
+    typeof acceptedCallId === 'string' &&
+    state._generatedItems.some(
+      (item) =>
+        item instanceof RunHandoffOutputItem &&
+        item.rawItem.callId === acceptedCallId,
+    );
+  if (!acceptedHandoffOutputStillPresent) {
+    return [];
+  }
+
+  const cached =
+    managedConversationSupplementalItemsCache.get(processedResponse);
+  if (cached) {
+    return cached;
+  }
+
+  // Server-managed transcripts still contain ignored handoff calls from the last response.
+  // Add synthetic results only to the continuation request so the provider transcript stays balanced.
+  const items = handoffs
+    .slice(1)
+    .map(({ toolCall }) =>
+      getToolCallOutputItem(toolCall, IGNORED_HANDOFF_OUTPUT_MESSAGE),
+    );
+  managedConversationSupplementalItemsCache.set(processedResponse, items);
+  return items;
 }
 
 async function runInputGuardrailsForTurn<

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -269,6 +269,102 @@ describe('Runner.run (streaming)', () => {
     expect(update?.agent).toBe(agentB);
   });
 
+  it('streams only the accepted handoff when multiple handoffs are emitted', async () => {
+    class SimpleStreamingModel implements Model {
+      constructor(private resp: ModelResponse) {}
+      async getResponse(_req: ModelRequest): Promise<ModelResponse> {
+        return this.resp;
+      }
+      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
+        yield {
+          type: 'response_done',
+          response: {
+            id: 'r',
+            usage: {
+              requests: 1,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            output: this.resp.output,
+          },
+        } as any;
+      }
+    }
+
+    const agentB = new Agent({
+      name: 'B',
+      model: new SimpleStreamingModel({
+        output: [fakeModelMessage('done B')],
+        usage: new Usage(),
+      }),
+    });
+    const agentC = new Agent({
+      name: 'C',
+      model: new SimpleStreamingModel({
+        output: [fakeModelMessage('done C')],
+        usage: new Usage(),
+      }),
+    });
+    const handoffToB = handoff(agentB);
+    const handoffToC = handoff(agentC);
+    const acceptedCall: FunctionCallItem = {
+      id: 'h1',
+      type: 'function_call',
+      name: handoffToB.toolName,
+      callId: 'c1',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const ignoredCall: FunctionCallItem = {
+      id: 'h2',
+      type: 'function_call',
+      name: handoffToC.toolName,
+      callId: 'c2',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const agentA = new Agent({
+      name: 'A',
+      model: new SimpleStreamingModel({
+        output: [acceptedCall, ignoredCall],
+        usage: new Usage(),
+      }),
+      handoffs: [handoffToB, handoffToC],
+    });
+
+    const result = await run(agentA, 'hi', { stream: true });
+    const events: RunStreamEvent[] = [];
+    for await (const event of result.toStream()) {
+      events.push(event);
+    }
+    await result.completed;
+
+    const handoffRequested = events.filter(
+      (event): event is RunItemStreamEvent =>
+        event.type === 'run_item_stream_event' &&
+        event.name === 'handoff_requested',
+    );
+
+    expect(handoffRequested).toHaveLength(1);
+    expect((handoffRequested[0].item as any).rawItem.callId).toBe(
+      acceptedCall.callId,
+    );
+    expect(
+      events.some(
+        (event) =>
+          event.type === 'run_item_stream_event' &&
+          event.name === 'tool_output' &&
+          (event.item as any).rawItem.callId === ignoredCall.callId,
+      ),
+    ).toBe(false);
+    expect(
+      result.history.some(
+        (item) => (item as { callId?: string }).callId === ignoredCall.callId,
+      ),
+    ).toBe(false);
+  });
+
   it('emits agent_end lifecycle event for streaming agents', async () => {
     class SimpleStreamingModel implements Model {
       constructor(private resp: ModelResponse) {}
@@ -1548,6 +1644,295 @@ describe('Runner.run (streaming)', () => {
         type: 'function_call_result',
         callId: 'call-1',
       });
+    });
+
+    it('acknowledges ignored handoffs when continuing a managed conversationId stream', async () => {
+      const agentBModel = new TrackingStreamingModel([
+        buildTurn([fakeModelMessage('done B')], 'resp-b'),
+      ]);
+      const agentCModel = new TrackingStreamingModel([
+        buildTurn([fakeModelMessage('done C')], 'resp-c'),
+      ]);
+      const agentB = new Agent({
+        name: 'ManagedStreamB',
+        model: agentBModel,
+      });
+      const agentC = new Agent({
+        name: 'ManagedStreamC',
+        model: agentCModel,
+      });
+      const handoffToB = handoff(agentB);
+      const handoffToC = handoff(agentC);
+      const acceptedCall: FunctionCallItem = {
+        id: 'h1',
+        type: 'function_call',
+        name: handoffToB.toolName,
+        callId: 'c1',
+        status: 'completed',
+        arguments: '{}',
+      };
+      const ignoredCall: FunctionCallItem = {
+        id: 'h2',
+        type: 'function_call',
+        name: handoffToC.toolName,
+        callId: 'c2',
+        status: 'completed',
+        arguments: '{}',
+      };
+      const agentA = new Agent({
+        name: 'ManagedStreamA',
+        model: new TrackingStreamingModel([
+          buildTurn([acceptedCall, ignoredCall], 'resp-a'),
+        ]),
+        handoffs: [handoffToB, handoffToC],
+      });
+      const runner = new Runner();
+
+      const result = await runner.run(agentA, 'hi', {
+        stream: true,
+        conversationId: 'conv-managed-handoff',
+      });
+
+      await drain(result);
+
+      expect(result.finalOutput).toBe('done B');
+      expect(agentBModel.requests).toHaveLength(1);
+      expect(agentCModel.requests).toHaveLength(0);
+      expect(agentBModel.requests[0].conversationId).toBe(
+        'conv-managed-handoff',
+      );
+      expect(agentBModel.requests[0].input).toEqual([
+        expect.objectContaining({
+          type: 'function_call_result',
+          callId: acceptedCall.callId,
+        }),
+        expect.objectContaining({
+          type: 'function_call_result',
+          callId: ignoredCall.callId,
+        }),
+      ]);
+      expect(
+        result.history.some(
+          (item) => (item as { callId?: string }).callId === ignoredCall.callId,
+        ),
+      ).toBe(false);
+    });
+
+    it('acknowledges ignored handoffs when streaming after a reused callId from an earlier turn', async () => {
+      const agentBModel = new TrackingStreamingModel([
+        buildTurn([fakeModelMessage('done B')], 'resp-b'),
+      ]);
+      const agentCModel = new TrackingStreamingModel([
+        buildTurn([fakeModelMessage('done C')], 'resp-c'),
+      ]);
+      const agentB = new Agent({
+        name: 'ManagedReuseStreamB',
+        model: agentBModel,
+      });
+      const agentC = new Agent({
+        name: 'ManagedReuseStreamC',
+        model: agentCModel,
+      });
+      const handoffToB = handoff(agentB);
+      const handoffToC = handoff(agentC);
+      const reusedCallId = 'reused-call-id';
+      const acceptedCall: FunctionCallItem = {
+        id: 'handoff-accepted',
+        type: 'function_call',
+        name: handoffToB.toolName,
+        callId: 'handoff-accepted-id',
+        status: 'completed',
+        arguments: '{}',
+      };
+      const ignoredCall: FunctionCallItem = {
+        id: 'handoff-ignored',
+        type: 'function_call',
+        name: handoffToC.toolName,
+        callId: reusedCallId,
+        status: 'completed',
+        arguments: '{}',
+      };
+      const agentA = new Agent({
+        name: 'ManagedReuseStreamA',
+        model: new TrackingStreamingModel([
+          buildTurn([buildToolCall(reusedCallId, 'warmup')], 'resp-tool'),
+          buildTurn([acceptedCall, ignoredCall], 'resp-handoff'),
+        ]),
+        tools: [serverTool],
+        handoffs: [handoffToB, handoffToC],
+      });
+      const runner = new Runner();
+
+      const result = await runner.run(agentA, 'hi', {
+        stream: true,
+        conversationId: 'conv-managed-reused-call-id',
+      });
+
+      await drain(result);
+
+      expect(result.finalOutput).toBe('done B');
+      expect(agentBModel.requests).toHaveLength(1);
+      expect(agentCModel.requests).toHaveLength(0);
+      expect(agentBModel.requests[0].conversationId).toBe(
+        'conv-managed-reused-call-id',
+      );
+      expect(agentBModel.requests[0].input).toEqual([
+        expect.objectContaining({
+          type: 'function_call_result',
+          callId: acceptedCall.callId,
+        }),
+        expect.objectContaining({
+          type: 'function_call_result',
+          callId: ignoredCall.callId,
+        }),
+      ]);
+    });
+
+    it('replays managed handoff acknowledgements when resuming before streamed response completion', async () => {
+      class AbortAfterAckStreamingModel implements Model {
+        public requests: ModelRequest[] = [];
+        private attempt = 0;
+
+        async getResponse(): Promise<ModelResponse> {
+          throw new Error('not used');
+        }
+
+        async *getStreamedResponse(
+          request: ModelRequest,
+        ): AsyncIterable<StreamEvent> {
+          this.requests.push({
+            ...request,
+            input: Array.isArray(request.input)
+              ? (JSON.parse(JSON.stringify(request.input)) as AgentInputItem[])
+              : request.input,
+          });
+          this.attempt += 1;
+
+          if (this.attempt === 1) {
+            yield { type: 'output_text_delta', delta: 'ack' } as any;
+            const abortError = new Error('aborted');
+            (abortError as Error & { name: string }).name = 'AbortError';
+            const signal = request.signal as AbortSignal | undefined;
+            await new Promise((_resolve, reject) => {
+              if (signal?.aborted) {
+                reject(abortError);
+                return;
+              }
+              const onAbort = () => {
+                signal?.removeEventListener('abort', onAbort);
+                reject(abortError);
+              };
+              signal?.addEventListener('abort', onAbort, { once: true });
+            });
+            yield* [] as any;
+            return;
+          }
+
+          yield {
+            type: 'response_done',
+            response: {
+              id: 'resp-b-final',
+              usage: {
+                requests: 1,
+                inputTokens: 0,
+                outputTokens: 0,
+                totalTokens: 0,
+              },
+              output: [fakeModelMessage('done B')],
+            },
+          } as any;
+        }
+      }
+
+      const agentBModel = new AbortAfterAckStreamingModel();
+      const agentB = new Agent({
+        name: 'ManagedResumeB',
+        model: agentBModel,
+      });
+      const agentC = new Agent({
+        name: 'ManagedResumeC',
+        model: new TrackingStreamingModel([
+          buildTurn([fakeModelMessage('done C')], 'resp-c'),
+        ]),
+      });
+      const handoffToB = handoff(agentB);
+      const handoffToC = handoff(agentC);
+      const acceptedCall: FunctionCallItem = {
+        id: 'handoff-accepted',
+        type: 'function_call',
+        name: handoffToB.toolName,
+        callId: 'c1',
+        status: 'completed',
+        arguments: '{}',
+      };
+      const ignoredCall: FunctionCallItem = {
+        id: 'handoff-ignored',
+        type: 'function_call',
+        name: handoffToC.toolName,
+        callId: 'c2',
+        status: 'completed',
+        arguments: '{}',
+      };
+      const agentA = new Agent({
+        name: 'ManagedResumeA',
+        model: new TrackingStreamingModel([
+          buildTurn([acceptedCall, ignoredCall], 'resp-a'),
+        ]),
+        handoffs: [handoffToB, handoffToC],
+      });
+      const runner = new Runner();
+
+      const firstRun = await runner.run(agentA, 'hi', {
+        stream: true,
+        conversationId: 'conv-managed-handoff-resume',
+      });
+      const reader = (firstRun.toStream() as any).getReader();
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        if (
+          value?.type === 'raw_model_stream_event' &&
+          value.data?.type === 'output_text_delta'
+        ) {
+          await reader.cancel('stop');
+          break;
+        }
+      }
+      await firstRun.completed;
+
+      expect(agentBModel.requests).toHaveLength(1);
+      expect(agentBModel.requests[0].input).toEqual([
+        expect.objectContaining({
+          type: 'function_call_result',
+          callId: acceptedCall.callId,
+        }),
+        expect.objectContaining({
+          type: 'function_call_result',
+          callId: ignoredCall.callId,
+        }),
+      ]);
+
+      const resumed = await runner.run(agentA, firstRun.state, {
+        stream: true,
+        conversationId: 'conv-managed-handoff-resume',
+      });
+      await drain(resumed);
+
+      expect(resumed.finalOutput).toBe('done B');
+      expect(agentBModel.requests).toHaveLength(2);
+      expect(agentBModel.requests[1]?.input).toEqual([
+        expect.objectContaining({
+          type: 'function_call_result',
+          callId: acceptedCall.callId,
+        }),
+        expect.objectContaining({
+          type: 'function_call_result',
+          callId: ignoredCall.callId,
+        }),
+      ]);
     });
 
     it('does not replay orphan hosted shell calls in default streamed multi-turn runs', async () => {

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -33,8 +33,10 @@ import {
 } from '../src';
 import { RunStreamEvent } from '../src/events';
 import { ServerConversationTracker } from '../src/runner/conversation';
+import { removeAllTools } from '../src/extensions';
 import { handoff } from '../src/handoff';
 import {
+  RunHandoffOutputItem,
   RunMessageOutputItem as MessageOutputItem,
   RunToolApprovalItem as ToolApprovalItem,
   RunToolCallOutputItem as ToolCallOutputItem,
@@ -1677,6 +1679,92 @@ describe('Runner.run', () => {
       const result = await runner.run(agentA, 'hi');
       expect(result.finalOutput).toBe('done B');
       expect(result.state._currentAgent).toBe(agentB);
+    });
+
+    it('does not keep ignored handoffs in history or session state', async () => {
+      class RecordingSession implements Session {
+        items: AgentInputItem[] = [];
+
+        async getSessionId(): Promise<string> {
+          return 'session';
+        }
+
+        async getItems(): Promise<AgentInputItem[]> {
+          return [...this.items];
+        }
+
+        async addItems(items: AgentInputItem[]): Promise<void> {
+          this.items.push(...items);
+        }
+
+        async popItem(): Promise<AgentInputItem | undefined> {
+          return this.items.pop();
+        }
+
+        async clearSession(): Promise<void> {
+          this.items = [];
+        }
+      }
+
+      const agentB = new Agent({
+        name: 'B',
+        model: new FakeModel([
+          { output: [fakeModelMessage('done B')], usage: new Usage() },
+        ]),
+      });
+      const agentC = new Agent({
+        name: 'C',
+        model: new FakeModel([
+          { output: [fakeModelMessage('done C')], usage: new Usage() },
+        ]),
+      });
+      const handoffToB = handoff(agentB);
+      const handoffToC = handoff(agentC);
+      const acceptedCall: protocol.FunctionCallItem = {
+        id: 'h1',
+        type: 'function_call',
+        name: handoffToB.toolName,
+        callId: 'c1',
+        status: 'completed',
+        arguments: '{}',
+      };
+      const ignoredCall: protocol.FunctionCallItem = {
+        id: 'h2',
+        type: 'function_call',
+        name: handoffToC.toolName,
+        callId: 'c2',
+        status: 'completed',
+        arguments: '{}',
+      };
+      const session = new RecordingSession();
+      const agentA = new Agent({
+        name: 'A',
+        model: new FakeModel([
+          { output: [acceptedCall, ignoredCall], usage: new Usage() },
+        ]),
+        handoffs: [handoffToB, handoffToC],
+      });
+
+      const result = await new Runner().run(agentA, 'hi', { session });
+      const persistedItems = await session.getItems();
+
+      expect(result.finalOutput).toBe('done B');
+      expect(
+        result.history.some(
+          (item) => (item as { callId?: string }).callId === ignoredCall.callId,
+        ),
+      ).toBe(false);
+      expect(
+        persistedItems.some(
+          (item) => (item as { callId?: string }).callId === ignoredCall.callId,
+        ),
+      ).toBe(false);
+      expect(
+        persistedItems.some(
+          (item) =>
+            (item as { callId?: string }).callId === acceptedCall.callId,
+        ),
+      ).toBe(true);
     });
 
     it('streamed run produces same final output', async () => {
@@ -4788,6 +4876,293 @@ describe('Runner.run', () => {
         type: 'function_call_result',
         callId: 'call-1',
       });
+    });
+
+    it('acknowledges ignored handoffs when continuing a managed previousResponseId run', async () => {
+      const agentBModel = new TrackingModel([
+        buildResponse([fakeModelMessage('done B')], 'resp-b'),
+      ]);
+      const agentCModel = new TrackingModel([
+        buildResponse([fakeModelMessage('done C')], 'resp-c'),
+      ]);
+      const agentB = new Agent({
+        name: 'ManagedB',
+        model: agentBModel,
+      });
+      const agentC = new Agent({
+        name: 'ManagedC',
+        model: agentCModel,
+      });
+      const handoffToB = handoff(agentB);
+      const handoffToC = handoff(agentC);
+      const acceptedCall: protocol.FunctionCallItem = {
+        id: 'h1',
+        type: 'function_call',
+        name: handoffToB.toolName,
+        callId: 'c1',
+        status: 'completed',
+        arguments: '{}',
+      };
+      const ignoredCall: protocol.FunctionCallItem = {
+        id: 'h2',
+        type: 'function_call',
+        name: handoffToC.toolName,
+        callId: 'c2',
+        status: 'completed',
+        arguments: '{}',
+      };
+      const agentA = new Agent({
+        name: 'ManagedA',
+        model: new TrackingModel([
+          buildResponse([acceptedCall, ignoredCall], 'resp-a'),
+        ]),
+        handoffs: [handoffToB, handoffToC],
+      });
+
+      const result = await new Runner().run(agentA, 'hi', {
+        previousResponseId: 'initial-response',
+      });
+
+      expect(result.finalOutput).toBe('done B');
+      expect(agentBModel.requests).toHaveLength(1);
+      expect(agentCModel.requests).toHaveLength(0);
+      expect(agentBModel.requests[0].previousResponseId).toBe('resp-a');
+      expect(agentBModel.requests[0].input).toEqual([
+        expect.objectContaining({
+          type: 'function_call_result',
+          callId: acceptedCall.callId,
+        }),
+        expect.objectContaining({
+          type: 'function_call_result',
+          callId: ignoredCall.callId,
+        }),
+      ]);
+      expect(
+        result.history.some(
+          (item) => (item as { callId?: string }).callId === ignoredCall.callId,
+        ),
+      ).toBe(false);
+    });
+
+    it('acknowledges ignored handoffs even when callIds were reused in earlier turns', async () => {
+      const agentBModel = new TrackingModel([
+        buildResponse([fakeModelMessage('done B')], 'resp-b'),
+      ]);
+      const agentCModel = new TrackingModel([
+        buildResponse([fakeModelMessage('done C')], 'resp-c'),
+      ]);
+      const agentB = new Agent({
+        name: 'ManagedReuseB',
+        model: agentBModel,
+      });
+      const agentC = new Agent({
+        name: 'ManagedReuseC',
+        model: agentCModel,
+      });
+      const handoffToB = handoff(agentB);
+      const handoffToC = handoff(agentC);
+      const reusedCallId = 'reused-call-id';
+      const acceptedCall: protocol.FunctionCallItem = {
+        id: 'handoff-accepted',
+        type: 'function_call',
+        name: handoffToB.toolName,
+        callId: 'handoff-accepted-id',
+        status: 'completed',
+        arguments: '{}',
+      };
+      const ignoredCall: protocol.FunctionCallItem = {
+        id: 'handoff-ignored',
+        type: 'function_call',
+        name: handoffToC.toolName,
+        callId: reusedCallId,
+        status: 'completed',
+        arguments: '{}',
+      };
+      const agentA = new Agent({
+        name: 'ManagedReuseA',
+        model: new TrackingModel([
+          buildResponse([buildToolCall(reusedCallId, 'warmup')], 'resp-tool'),
+          buildResponse([acceptedCall, ignoredCall], 'resp-handoff'),
+        ]),
+        tools: [serverTool],
+        handoffs: [handoffToB, handoffToC],
+      });
+
+      const result = await new Runner().run(agentA, 'hi', {
+        previousResponseId: 'initial-response',
+      });
+
+      expect(result.finalOutput).toBe('done B');
+      expect(agentBModel.requests).toHaveLength(1);
+      expect(agentCModel.requests).toHaveLength(0);
+      expect(agentBModel.requests[0].previousResponseId).toBe('resp-handoff');
+      expect(agentBModel.requests[0].input).toEqual([
+        expect.objectContaining({
+          type: 'function_call_result',
+          callId: acceptedCall.callId,
+        }),
+        expect.objectContaining({
+          type: 'function_call_result',
+          callId: ignoredCall.callId,
+        }),
+      ]);
+    });
+
+    it('replays pending managed handoff acknowledgements when resuming in non-stream mode', async () => {
+      const agentBModel = new TrackingModel([
+        buildResponse([fakeModelMessage('done B')], 'resp-b'),
+      ]);
+      const agentB = new Agent({
+        name: 'ManagedResumeNonStreamB',
+        model: agentBModel,
+      });
+      const agentC = new Agent({
+        name: 'ManagedResumeNonStreamC',
+        model: new TrackingModel([
+          buildResponse([fakeModelMessage('done C')], 'resp-c'),
+        ]),
+      });
+      const handoffToB = handoff(agentB);
+      const handoffToC = handoff(agentC);
+      const acceptedCall: protocol.FunctionCallItem = {
+        id: 'handoff-accepted',
+        type: 'function_call',
+        name: handoffToB.toolName,
+        callId: 'c1',
+        status: 'completed',
+        arguments: '{}',
+      };
+      const ignoredCall: protocol.FunctionCallItem = {
+        id: 'handoff-ignored',
+        type: 'function_call',
+        name: handoffToC.toolName,
+        callId: 'c2',
+        status: 'completed',
+        arguments: '{}',
+      };
+      const agentA = new Agent({
+        name: 'ManagedResumeNonStreamA',
+        model: new TrackingModel([]),
+        handoffs: [handoffToB, handoffToC],
+      });
+      const state = new RunState(new RunContext(), 'hi', agentA, 3);
+
+      state._currentAgent = agentB;
+      state._currentTurn = 1;
+      state._currentTurnInProgress = true;
+      state._currentStep = { type: 'next_step_run_again' } as const;
+      state._noActiveAgentRun = true;
+      state._modelResponses = [
+        buildResponse([acceptedCall, ignoredCall], 'resp-a'),
+      ];
+      state._generatedItems = [
+        new RunHandoffOutputItem(
+          {
+            type: 'function_call_result',
+            name: acceptedCall.name,
+            callId: acceptedCall.callId,
+            status: 'completed',
+            output: {
+              type: 'text',
+              text: 'Transferred to ManagedResumeNonStreamB',
+            },
+          },
+          agentA,
+          agentB,
+        ),
+      ];
+      state._lastProcessedResponse = {
+        newItems: [],
+        handoffs: [
+          { toolCall: acceptedCall, handoff: handoffToB },
+          { toolCall: ignoredCall, handoff: handoffToC },
+        ],
+        functions: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: [],
+        hasToolsOrApprovalsToRun: () => true,
+      } as any;
+      state.setConversationContext(
+        'conv-managed-handoff-resume-non-stream',
+        undefined,
+      );
+
+      const result = await new Runner().run(agentA, state, {
+        conversationId: 'conv-managed-handoff-resume-non-stream',
+      });
+
+      expect(result.finalOutput).toBe('done B');
+      expect(agentBModel.requests).toHaveLength(1);
+      expect(agentBModel.requests[0].conversationId).toBe(
+        'conv-managed-handoff-resume-non-stream',
+      );
+      expect(agentBModel.requests[0].input).toEqual([
+        expect.objectContaining({
+          type: 'function_call_result',
+          callId: acceptedCall.callId,
+        }),
+        expect.objectContaining({
+          type: 'function_call_result',
+          callId: ignoredCall.callId,
+        }),
+      ]);
+    });
+
+    it('does not append ignored handoff acknowledgements after removeAllTools filters the handoff input', async () => {
+      const agentBModel = new TrackingModel([
+        buildResponse([fakeModelMessage('done B')], 'resp-b'),
+      ]);
+      const agentCModel = new TrackingModel([
+        buildResponse([fakeModelMessage('done C')], 'resp-c'),
+      ]);
+      const agentB = new Agent({
+        name: 'ManagedFilteredB',
+        model: agentBModel,
+      });
+      const agentC = new Agent({
+        name: 'ManagedFilteredC',
+        model: agentCModel,
+      });
+      const handoffToB = handoff(agentB, {
+        inputFilter: removeAllTools,
+      });
+      const handoffToC = handoff(agentC);
+      const acceptedCall: protocol.FunctionCallItem = {
+        id: 'handoff-filtered-accepted',
+        type: 'function_call',
+        name: handoffToB.toolName,
+        callId: 'filtered-c1',
+        status: 'completed',
+        arguments: '{}',
+      };
+      const ignoredCall: protocol.FunctionCallItem = {
+        id: 'handoff-filtered-ignored',
+        type: 'function_call',
+        name: handoffToC.toolName,
+        callId: 'filtered-c2',
+        status: 'completed',
+        arguments: '{}',
+      };
+      const agentA = new Agent({
+        name: 'ManagedFilteredA',
+        model: new TrackingModel([
+          buildResponse([acceptedCall, ignoredCall], 'resp-a'),
+        ]),
+        handoffs: [handoffToB, handoffToC],
+      });
+
+      const result = await new Runner().run(agentA, 'hi', {
+        previousResponseId: 'initial-response',
+      });
+
+      expect(result.finalOutput).toBe('done B');
+      expect(agentBModel.requests).toHaveLength(1);
+      expect(agentCModel.requests).toHaveLength(0);
+      expect(agentBModel.requests[0].previousResponseId).toBe('resp-a');
+      expect(agentBModel.requests[0].input).toEqual([]);
     });
 
     it('does not replay orphan hosted shell calls in default multi-turn runs', async () => {

--- a/packages/agents-core/test/runner/modelOutputs.test.ts
+++ b/packages/agents-core/test/runner/modelOutputs.test.ts
@@ -5,6 +5,7 @@ import { Agent } from '../../src/agent';
 import { ModelBehaviorError, UserError } from '../../src/errors';
 import { handoff } from '../../src/handoff';
 import {
+  RunHandoffCallItem as HandoffCallItem,
   RunMessageOutputItem as MessageOutputItem,
   RunReasoningItem as ReasoningItem,
   RunToolCallItem as ToolCallItem,
@@ -2048,6 +2049,46 @@ describe('processModelResponse edge cases', () => {
     expect(result.toolsUsed).toEqual(['test', computer.name, h.toolName]);
     expect(result.hasToolsOrApprovalsToRun()).toBe(true);
     expect(result.newItems[3]).toBeInstanceOf(MessageOutputItem);
+  });
+
+  it('only serializes the first handoff when multiple handoffs are requested', () => {
+    const targetB = new Agent({ name: 'B' });
+    const targetC = new Agent({ name: 'C' });
+    const handoffToB = handoff(targetB);
+    const handoffToC = handoff(targetC);
+    const handoffCallB: protocol.FunctionCallItem = {
+      ...TEST_MODEL_FUNCTION_CALL,
+      id: 'h1',
+      name: handoffToB.toolName,
+      callId: 'hb1',
+    };
+    const handoffCallC: protocol.FunctionCallItem = {
+      ...TEST_MODEL_FUNCTION_CALL,
+      id: 'h2',
+      name: handoffToC.toolName,
+      callId: 'hc1',
+    };
+    const response: ModelResponse = {
+      output: [handoffCallB, handoffCallC],
+      usage: new Usage(),
+    } as any;
+
+    const result = processModelResponse(
+      response,
+      TEST_AGENT,
+      [],
+      [handoffToB, handoffToC],
+    );
+
+    expect(result.handoffs).toEqual([
+      { toolCall: handoffCallB, handoff: handoffToB },
+      { toolCall: handoffCallC, handoff: handoffToC },
+    ]);
+    expect(result.newItems).toHaveLength(1);
+    expect(result.newItems[0]).toBeInstanceOf(HandoffCallItem);
+    expect((result.newItems[0] as HandoffCallItem).rawItem.callId).toBe(
+      handoffCallB.callId,
+    );
   });
 });
 

--- a/packages/agents-core/test/runner/sessionPersistence.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../../src';
 import { Agent, AgentOutputType } from '../../src/agent';
 import {
+  RunHandoffOutputItem as HandoffOutputItem,
   RunMessageOutputItem as MessageOutputItem,
   RunReasoningItem as ReasoningItem,
   RunToolApprovalItem as ToolApprovalItem,
@@ -23,6 +24,7 @@ import {
 } from '../../src/runner/sessionPersistence';
 import { ServerConversationTracker } from '../../src/runner/conversation';
 import { getToolCallOutputItem } from '../../src/runner/toolExecution';
+import { getManagedConversationSupplementalItems } from '../../src/runner/turnPreparation';
 import { Runner } from '../../src/run';
 import { RunContext } from '../../src/runContext';
 import { RunResult, StreamedRunResult } from '../../src/result';
@@ -406,6 +408,186 @@ describe('ServerConversationTracker', () => {
 
     const nextTurnInput = tracker.prepareInput(initialInput, generatedItems);
     expect(nextTurnInput).toHaveLength(0);
+  });
+
+  it('does not resend supplemental generated items after they were marked sent', () => {
+    const tracker = new ServerConversationTracker({
+      conversationId: 'conv_supplemental_sent',
+    });
+    const supplementalResult: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      name: 'transfer_to_managed_c',
+      callId: 'handoff-ignored',
+      status: 'completed',
+      output: {
+        type: 'text',
+        text: 'Multiple handoffs detected, ignoring this one.',
+      },
+    };
+
+    const firstPrepared = tracker.prepareInput([], [], [supplementalResult]);
+    expect(firstPrepared).toEqual([supplementalResult]);
+
+    tracker.markInputAsSent(firstPrepared);
+
+    const secondPrepared = tracker.prepareInput([], [], [supplementalResult]);
+    expect(secondPrepared).toEqual([]);
+  });
+
+  it('preserves current-turn supplemental items when resuming before they were sent', () => {
+    const tracker = new ServerConversationTracker({
+      conversationId: 'conv_supplemental_resume',
+    });
+    const initialInput = toAgentInputList('hello');
+    const supplementalResult: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      name: 'transfer_to_managed_c',
+      callId: 'handoff-ignored',
+      status: 'completed',
+      output: {
+        type: 'text',
+        text: 'Multiple handoffs detected, ignoring this one.',
+      },
+    };
+
+    tracker.primeFromState({
+      originalInput: initialInput,
+      generatedItems: [],
+      modelResponses: [
+        {
+          output: [fakeModelMessage('handoff')],
+          usage: new Usage(),
+        },
+      ],
+    });
+
+    const nextTurnInput = tracker.prepareInput([], [], [supplementalResult]);
+    expect(nextTurnInput).toEqual([supplementalResult]);
+  });
+
+  it('creates fresh supplemental items for later responses with the same ignored handoff signature', () => {
+    const tracker = new ServerConversationTracker({
+      conversationId: 'conv_supplemental_later_response',
+    });
+    const state = new RunState(
+      new RunContext<UnknownContext>(undefined as UnknownContext),
+      'hello',
+      TEST_AGENT as Agent<UnknownContext, AgentOutputType>,
+      3,
+    );
+    const makeProcessedResponse = (): ProcessedResponse<UnknownContext> => ({
+      newItems: [],
+      handoffs: [
+        {
+          toolCall: {
+            type: 'function_call',
+            id: 'handoff-accepted',
+            name: 'transfer_to_managed_b',
+            callId: 'handoff-accepted',
+            status: 'completed',
+            arguments: '{}',
+          },
+          handoff: {} as any,
+        },
+        {
+          toolCall: {
+            type: 'function_call',
+            id: 'handoff-ignored',
+            name: 'transfer_to_managed_c',
+            callId: 'handoff-ignored',
+            status: 'completed',
+            arguments: '{}',
+          },
+          handoff: {} as any,
+        },
+      ],
+      functions: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: [],
+      hasToolsOrApprovalsToRun: () => true,
+    });
+    state._generatedItems = [
+      new HandoffOutputItem(
+        {
+          type: 'function_call_result',
+          name: 'transfer_to_managed_b',
+          callId: 'handoff-accepted',
+          status: 'completed',
+          output: {
+            type: 'text',
+            text: 'Transferred to ManagedB',
+          },
+        },
+        TEST_AGENT as Agent<UnknownContext, AgentOutputType>,
+        TEST_AGENT as Agent<UnknownContext, AgentOutputType>,
+      ),
+    ];
+
+    state._lastProcessedResponse = makeProcessedResponse();
+    const firstSupplementalItems =
+      getManagedConversationSupplementalItems(state);
+    tracker.markInputAsSent(
+      tracker.prepareInput([], [], firstSupplementalItems),
+    );
+
+    state._lastProcessedResponse = makeProcessedResponse();
+    const secondSupplementalItems =
+      getManagedConversationSupplementalItems(state);
+
+    expect(secondSupplementalItems).not.toBe(firstSupplementalItems);
+    expect(secondSupplementalItems[0]).not.toBe(firstSupplementalItems[0]);
+    expect(tracker.prepareInput([], [], secondSupplementalItems)).toEqual(
+      secondSupplementalItems,
+    );
+  });
+
+  it('does not create supplemental items when the accepted handoff output was filtered out', () => {
+    const state = new RunState(
+      new RunContext<UnknownContext>(undefined as UnknownContext),
+      'hello',
+      TEST_AGENT as Agent<UnknownContext, AgentOutputType>,
+      3,
+    );
+
+    state._lastProcessedResponse = {
+      newItems: [],
+      handoffs: [
+        {
+          toolCall: {
+            type: 'function_call',
+            id: 'handoff-accepted',
+            name: 'transfer_to_managed_b',
+            callId: 'handoff-accepted',
+            status: 'completed',
+            arguments: '{}',
+          },
+          handoff: {} as any,
+        },
+        {
+          toolCall: {
+            type: 'function_call',
+            id: 'handoff-ignored',
+            name: 'transfer_to_managed_c',
+            callId: 'handoff-ignored',
+            status: 'completed',
+            arguments: '{}',
+          },
+          handoff: {} as any,
+        },
+      ],
+      functions: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: [],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+
+    expect(getManagedConversationSupplementalItems(state)).toEqual([]);
   });
 
   it('requeues initial inputs when resuming a server-managed conversation without responses', () => {

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -1297,7 +1297,7 @@ describe('executeHandoffCalls', () => {
     }
   });
 
-  it('handles multiple handoffs by rejecting extras', async () => {
+  it('drops ignored handoffs from the step items', async () => {
     const target = new Agent({ name: 'Target' });
     const h = handoff(target);
     const call1: any = {
@@ -1314,7 +1314,10 @@ describe('executeHandoffCalls', () => {
         TEST_AGENT,
         '',
         [],
-        [],
+        [
+          new HandoffCallItem(call1.toolCall, TEST_AGENT),
+          new HandoffCallItem(call2.toolCall, TEST_AGENT),
+        ],
         TEST_MODEL_RESPONSE_WITH_FUNCTION,
         [call1, call2],
         new Runner({ tracingDisabled: true }),
@@ -1323,11 +1326,18 @@ describe('executeHandoffCalls', () => {
     );
 
     expect(
-      res.newStepItems.some(
-        (i) =>
-          i instanceof ToolCallOutputItem && (i.rawItem as any).callId === '2',
-      ),
-    ).toBe(true);
+      res.newStepItems.filter((item) => item instanceof HandoffCallItem),
+    ).toHaveLength(1);
+    expect(
+      (
+        res.newStepItems.find(
+          (item) => item instanceof HandoffCallItem,
+        ) as HandoffCallItem
+      ).rawItem.callId,
+    ).toBe('1');
+    expect(
+      res.newStepItems.some((item) => item instanceof ToolCallOutputItem),
+    ).toBe(false);
   });
 
   it('filters input when inputFilter provided', async () => {


### PR DESCRIPTION
This pull request resolves #1122 by narrowing the managed-resume fix to the actual streaming failure boundary. For Responses API managed conversations, request inputs are only added to the server-side conversation after the response completes, so a streamed run that is interrupted after an early SSE but before `response_done` must resend the accepted handoff output and any supplemental ignored-handoff acknowledgements on resume.

The change removes the streaming-only logic that treated an in-progress managed turn as already committed during `primeFromState()`. Non-stream resumes still keep their existing suppression behavior, while streamed resumes now replay the current turn inputs until a completed response has actually been observed. Regression coverage now locks in that pre-`response_done` cancellation path so the resumed managed request includes the required handoff acknowledgements again.