### PR TITLE
fix: #1138 normalize discriminated union tool schemas for strict responses

### DIFF
--- a/.changeset/fresh-lions-pull.md
+++ b/.changeset/fresh-lions-pull.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+---
+
+fix: #1138 normalize discriminated union tool schemas for strict responses

--- a/packages/agents-core/src/utils/generatedJsonSchemaUnion.ts
+++ b/packages/agents-core/src/utils/generatedJsonSchemaUnion.ts
@@ -1,0 +1,158 @@
+import { JsonSchemaDefinitionEntry } from '../types';
+
+export type JsonSchemaRecord = Record<string, any>;
+export type JsonSchemaProperties = Record<string, JsonSchemaDefinitionEntry>;
+export type LiteralValue = string | number | boolean | null;
+
+export type DiscriminatedObjectUnionVariant = {
+  discriminatorValue: LiteralValue;
+  properties: JsonSchemaProperties;
+  schema: JsonSchemaRecord;
+};
+
+export function analyzeDiscriminatedObjectUnion(anyOf: unknown[]):
+  | {
+      discriminatorKey: string;
+      variants: DiscriminatedObjectUnionVariant[];
+    }
+  | undefined {
+  const discriminatorKey = findDiscriminatorKey(anyOf);
+  if (!discriminatorKey) {
+    return undefined;
+  }
+
+  const variants = getObjectUnionVariants(anyOf, discriminatorKey);
+  if (!variants) {
+    return undefined;
+  }
+
+  return {
+    discriminatorKey,
+    variants,
+  };
+}
+
+export function getLiteralValue(schema: unknown): LiteralValue | undefined {
+  if (!isSchemaObject(schema)) {
+    return undefined;
+  }
+
+  if (
+    'const' in schema &&
+    (typeof schema.const === 'string' ||
+      typeof schema.const === 'number' ||
+      typeof schema.const === 'boolean' ||
+      schema.const === null)
+  ) {
+    return schema.const;
+  }
+
+  if (
+    Array.isArray(schema.enum) &&
+    schema.enum.length === 1 &&
+    (typeof schema.enum[0] === 'string' ||
+      typeof schema.enum[0] === 'number' ||
+      typeof schema.enum[0] === 'boolean' ||
+      schema.enum[0] === null)
+  ) {
+    return schema.enum[0];
+  }
+
+  return undefined;
+}
+
+export function isSchemaObject(value: unknown): value is JsonSchemaRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function findDiscriminatorKey(anyOf: unknown[]): string | undefined {
+  const firstVariant = anyOf[0];
+  if (!isObjectSchemaVariant(firstVariant)) {
+    return undefined;
+  }
+
+  const orderedKeys = Object.keys(firstVariant.properties);
+  const candidateKeys = orderedKeys.filter((key) =>
+    anyOf.every((variant) => {
+      if (!isObjectSchemaVariant(variant)) {
+        return false;
+      }
+
+      if (!Array.isArray(variant.required) || !variant.required.includes(key)) {
+        return false;
+      }
+
+      return getLiteralValue(variant.properties[key]) !== undefined;
+    }),
+  );
+
+  candidateKeys.sort((left, right) => {
+    if (left === 'type') {
+      return -1;
+    }
+    if (right === 'type') {
+      return 1;
+    }
+    return 0;
+  });
+
+  for (const key of candidateKeys) {
+    const serializedValues = new Set(
+      anyOf.map((variant) =>
+        serializeLiteralValue(
+          getLiteralValue((variant as JsonSchemaRecord).properties[key])!,
+        ),
+      ),
+    );
+    if (serializedValues.size === anyOf.length) {
+      return key;
+    }
+  }
+
+  return undefined;
+}
+
+function getObjectUnionVariants(
+  anyOf: unknown[],
+  discriminatorKey: string,
+): DiscriminatedObjectUnionVariant[] | undefined {
+  const variants: DiscriminatedObjectUnionVariant[] = [];
+
+  for (const entry of anyOf) {
+    if (!isObjectSchemaVariant(entry)) {
+      return undefined;
+    }
+
+    const discriminatorValue = getLiteralValue(
+      entry.properties[discriminatorKey],
+    );
+    if (discriminatorValue === undefined) {
+      return undefined;
+    }
+
+    variants.push({
+      discriminatorValue,
+      properties: entry.properties,
+      schema: entry,
+    });
+  }
+
+  return variants;
+}
+
+function isObjectSchemaVariant(schema: unknown): schema is {
+  type: 'object';
+  properties: JsonSchemaProperties;
+  required?: string[];
+  additionalProperties?: unknown;
+} {
+  return (
+    isSchemaObject(schema) &&
+    schema.type === 'object' &&
+    isSchemaObject(schema.properties)
+  );
+}
+
+function serializeLiteralValue(value: LiteralValue): string {
+  return `${typeof value}:${String(value)}`;
+}

--- a/packages/agents-core/src/utils/jsonSchemaComparison.ts
+++ b/packages/agents-core/src/utils/jsonSchemaComparison.ts
@@ -1,0 +1,60 @@
+import { isSchemaObject } from './generatedJsonSchemaUnion';
+
+export function getComparableSchemaFingerprint(input: unknown): string {
+  return JSON.stringify(
+    canonicalizeSchemaForComparison(stripDescriptionFields(input)),
+  );
+}
+
+export function schemasAreEquivalent(left: unknown, right: unknown): boolean {
+  return (
+    getComparableSchemaFingerprint(left) ===
+    getComparableSchemaFingerprint(right)
+  );
+}
+
+function canonicalizeSchemaForComparison(input: unknown): unknown {
+  if (Array.isArray(input)) {
+    return input.map(canonicalizeSchemaForComparison);
+  }
+
+  if (!isSchemaObject(input)) {
+    return input;
+  }
+
+  const sortedEntries = Object.entries(input)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => {
+      if (
+        (key === 'required' || key === 'enum' || key === 'type') &&
+        Array.isArray(value)
+      ) {
+        return [
+          key,
+          [...value].sort((leftValue, rightValue) =>
+            JSON.stringify(leftValue).localeCompare(JSON.stringify(rightValue)),
+          ),
+        ];
+      }
+      return [key, canonicalizeSchemaForComparison(value)];
+    });
+
+  return Object.fromEntries(sortedEntries);
+}
+
+function stripDescriptionFields(input: unknown): unknown {
+  if (Array.isArray(input)) {
+    return input.map(stripDescriptionFields);
+  }
+
+  if (!isSchemaObject(input)) {
+    return input;
+  }
+
+  const clone = structuredClone(input);
+  delete clone.description;
+  for (const [key, value] of Object.entries(clone)) {
+    clone[key] = stripDescriptionFields(value);
+  }
+  return clone;
+}

--- a/packages/agents-core/src/utils/jsonSchemaComparison.ts
+++ b/packages/agents-core/src/utils/jsonSchemaComparison.ts
@@ -26,12 +26,20 @@ function canonicalizeSchemaForComparison(input: unknown): unknown {
     .sort(([left], [right]) => left.localeCompare(right))
     .map(([key, value]) => {
       if (
-        (key === 'required' || key === 'enum' || key === 'type') &&
+        (key === 'required' ||
+          key === 'enum' ||
+          key === 'type' ||
+          key === 'anyOf' ||
+          key === 'oneOf' ||
+          key === 'allOf') &&
         Array.isArray(value)
       ) {
+        const normalizedValues = value.map((entry) =>
+          canonicalizeSchemaForComparison(entry),
+        );
         return [
           key,
-          [...value].sort((leftValue, rightValue) =>
+          normalizedValues.sort((leftValue, rightValue) =>
             JSON.stringify(leftValue).localeCompare(JSON.stringify(rightValue)),
           ),
         ];

--- a/packages/agents-core/src/utils/normalizeGeneratedJsonSchema.ts
+++ b/packages/agents-core/src/utils/normalizeGeneratedJsonSchema.ts
@@ -207,13 +207,27 @@ function mergeVariantProperty(
   const requiredInEveryPresentVariant = variantsWithProperty.every((variant) =>
     isPropertyRequired(variant.schema, propertyName),
   );
-  const canBeOmittedInSomeVariant =
-    variantsWithProperty.length !== variants.length ||
-    !requiredInEveryPresentVariant;
+  const presentInEveryVariant = variantsWithProperty.length === variants.length;
 
-  if (!canBeOmittedInSomeVariant) {
+  if (presentInEveryVariant && requiredInEveryPresentVariant) {
     return {
       schema: mergedProperty,
+      required: true,
+    };
+  }
+
+  if (!presentInEveryVariant) {
+    // Strict Responses schemas cannot omit branch-only keys, so keep their
+    // original type and let parser-side sanitization drop inactive copies.
+    const conditionedProperty = structuredClone(mergedProperty);
+    conditionedProperty.description = appendBranchConditionDescription(
+      conditionedProperty.description,
+      discriminatorKey,
+      variantsWithProperty.map((variant) => variant.discriminatorValue),
+    );
+
+    return {
+      schema: conditionedProperty,
       required: true,
     };
   }
@@ -223,17 +237,9 @@ function mergeVariantProperty(
     return undefined;
   }
 
-  if (variantsWithProperty.length !== variants.length) {
-    nullableProperty.description = appendConditionDescription(
-      nullableProperty.description,
-      discriminatorKey,
-      variantsWithProperty.map((variant) => variant.discriminatorValue),
-    );
-  } else {
-    nullableProperty.description = appendOptionalDescription(
-      nullableProperty.description,
-    );
-  }
+  nullableProperty.description = appendOptionalDescription(
+    nullableProperty.description,
+  );
 
   return {
     schema: nullableProperty,
@@ -438,7 +444,7 @@ function collectPropertyNames(
   return propertyNames;
 }
 
-function appendConditionDescription(
+function appendBranchConditionDescription(
   description: unknown,
   discriminatorKey: string,
   values: LiteralValue[],
@@ -449,7 +455,7 @@ function appendConditionDescription(
       : `${discriminatorKey} is one of ${values
           .map((value) => formatLiteralValue(value))
           .join(', ')}`;
-  const suffix = `Set to null unless ${condition}.`;
+  const suffix = `Ignored unless ${condition}.`;
 
   if (typeof description !== 'string' || description.trim().length === 0) {
     return suffix;

--- a/packages/agents-core/src/utils/normalizeGeneratedJsonSchema.ts
+++ b/packages/agents-core/src/utils/normalizeGeneratedJsonSchema.ts
@@ -1,0 +1,561 @@
+import { JsonObjectSchema, JsonSchemaDefinitionEntry } from '../types';
+
+type JsonSchemaRecord = Record<string, any>;
+type JsonSchemaProperties = Record<string, JsonSchemaDefinitionEntry>;
+type LiteralValue = string | number | boolean | null;
+
+type ObjectUnionVariant = {
+  discriminatorValue: LiteralValue;
+  properties: JsonSchemaProperties;
+  schema: JsonSchemaRecord;
+};
+
+export function normalizeGeneratedJsonSchema<
+  T extends JsonObjectSchema<Record<string, JsonSchemaDefinitionEntry>>,
+>(schema: T): T {
+  const normalized = structuredClone(schema) as JsonSchemaRecord;
+  normalizeJsonSchemaNode(normalized);
+  return normalized as T;
+}
+
+function normalizeJsonSchemaNode(schema: unknown): void {
+  if (!isSchemaObject(schema)) {
+    return;
+  }
+
+  if (isSchemaObject(schema.properties)) {
+    for (const propertySchema of Object.values(schema.properties)) {
+      normalizeJsonSchemaNode(propertySchema);
+    }
+  }
+
+  if (Array.isArray(schema.items)) {
+    for (const itemSchema of schema.items) {
+      normalizeJsonSchemaNode(itemSchema);
+    }
+  } else {
+    normalizeJsonSchemaNode(schema.items);
+  }
+
+  if (isSchemaObject(schema.additionalProperties)) {
+    normalizeJsonSchemaNode(schema.additionalProperties);
+  }
+
+  for (const keyword of ['allOf', 'anyOf', 'oneOf'] as const) {
+    const entries = schema[keyword];
+    if (Array.isArray(entries)) {
+      for (const entry of entries) {
+        normalizeJsonSchemaNode(entry);
+      }
+    }
+  }
+
+  const loweredUnion = lowerDiscriminatedObjectUnion(schema);
+  if (loweredUnion) {
+    replaceSchema(schema, loweredUnion);
+  }
+}
+
+function lowerDiscriminatedObjectUnion(
+  schema: JsonSchemaRecord,
+): JsonSchemaRecord | undefined {
+  const anyOf = schema.anyOf;
+  if (!Array.isArray(anyOf) || anyOf.length < 2) {
+    return undefined;
+  }
+
+  const discriminatorKey = findDiscriminatorKey(anyOf);
+  if (!discriminatorKey) {
+    return undefined;
+  }
+
+  const variants = getObjectUnionVariants(anyOf, discriminatorKey);
+  if (!variants) {
+    return undefined;
+  }
+
+  const mergedProperties = mergeVariantProperties(variants, discriminatorKey);
+  if (!mergedProperties) {
+    return undefined;
+  }
+
+  const loweredSchema: JsonSchemaRecord = {
+    ...schema,
+    type: 'object',
+    properties: mergedProperties,
+    required: Object.keys(mergedProperties),
+    additionalProperties: false,
+  };
+
+  delete loweredSchema.anyOf;
+  return loweredSchema;
+}
+
+function findDiscriminatorKey(anyOf: unknown[]): string | undefined {
+  const firstVariant = anyOf[0];
+  if (!isObjectSchemaVariant(firstVariant)) {
+    return undefined;
+  }
+
+  const orderedKeys = Object.keys(firstVariant.properties);
+  const candidateKeys = orderedKeys.filter((key) =>
+    anyOf.every((variant) => {
+      if (!isObjectSchemaVariant(variant)) {
+        return false;
+      }
+
+      if (!Array.isArray(variant.required) || !variant.required.includes(key)) {
+        return false;
+      }
+
+      return getLiteralValue(variant.properties[key]) !== undefined;
+    }),
+  );
+
+  candidateKeys.sort((left, right) => {
+    if (left === 'type') {
+      return -1;
+    }
+    if (right === 'type') {
+      return 1;
+    }
+    return 0;
+  });
+
+  for (const key of candidateKeys) {
+    const serializedValues = new Set(
+      anyOf.map((variant) =>
+        serializeLiteralValue(
+          getLiteralValue((variant as JsonSchemaRecord).properties[key])!,
+        ),
+      ),
+    );
+    if (serializedValues.size === anyOf.length) {
+      return key;
+    }
+  }
+
+  return undefined;
+}
+
+function getObjectUnionVariants(
+  anyOf: unknown[],
+  discriminatorKey: string,
+): ObjectUnionVariant[] | undefined {
+  const variants: ObjectUnionVariant[] = [];
+
+  for (const entry of anyOf) {
+    if (!isObjectSchemaVariant(entry)) {
+      return undefined;
+    }
+
+    const discriminatorValue = getLiteralValue(
+      entry.properties[discriminatorKey],
+    );
+    if (discriminatorValue === undefined) {
+      return undefined;
+    }
+
+    variants.push({
+      discriminatorValue,
+      properties: entry.properties,
+      schema: entry,
+    });
+  }
+
+  return variants;
+}
+
+function mergeVariantProperties(
+  variants: ObjectUnionVariant[],
+  discriminatorKey: string,
+): JsonSchemaProperties | undefined {
+  const propertyNames = collectPropertyNames(variants, discriminatorKey);
+  const mergedProperties: JsonSchemaProperties = {};
+
+  for (const propertyName of propertyNames) {
+    if (propertyName === discriminatorKey) {
+      const mergedDiscriminator = mergeDiscriminatorProperty(
+        variants,
+        propertyName,
+      );
+      if (!mergedDiscriminator) {
+        return undefined;
+      }
+      mergedProperties[propertyName] = mergedDiscriminator;
+      continue;
+    }
+
+    const mergedProperty = mergeVariantProperty(
+      variants,
+      propertyName,
+      discriminatorKey,
+    );
+    if (!mergedProperty) {
+      return undefined;
+    }
+    mergedProperties[propertyName] = mergedProperty;
+  }
+
+  return mergedProperties;
+}
+
+function mergeDiscriminatorProperty(
+  variants: ObjectUnionVariant[],
+  discriminatorKey: string,
+): JsonSchemaRecord | undefined {
+  const schemas = variants.map(
+    (variant) => variant.properties[discriminatorKey] as JsonSchemaRecord,
+  );
+  const literalValues = variants.map((variant) => variant.discriminatorValue);
+  const discriminatorType = inferDiscriminatorType(schemas, literalValues);
+  if (!discriminatorType) {
+    return undefined;
+  }
+
+  const mergedSchema = structuredClone(schemas[0]);
+  delete mergedSchema.const;
+  if (
+    Array.isArray(mergedSchema.enum) &&
+    mergedSchema.enum.length === 1 &&
+    mergedSchema.enum[0] === literalValues[0]
+  ) {
+    delete mergedSchema.enum;
+  }
+  mergedSchema.type = discriminatorType;
+  mergedSchema.enum = literalValues;
+  return mergedSchema;
+}
+
+function mergeVariantProperty(
+  variants: ObjectUnionVariant[],
+  propertyName: string,
+  discriminatorKey: string,
+): JsonSchemaRecord | undefined {
+  const variantsWithProperty = variants.filter(
+    (variant) => propertyName in variant.properties,
+  );
+  if (variantsWithProperty.length === 0) {
+    return undefined;
+  }
+
+  const mergedProperty = mergeCompatiblePropertySchemas(
+    variantsWithProperty.map(
+      (variant) => variant.properties[propertyName] as JsonSchemaRecord,
+    ),
+  );
+  if (!mergedProperty) {
+    return undefined;
+  }
+
+  if (variantsWithProperty.length === variants.length) {
+    return mergedProperty;
+  }
+
+  const nullableProperty = makeSchemaNullable(mergedProperty);
+  if (!nullableProperty) {
+    return undefined;
+  }
+
+  nullableProperty.description = appendConditionDescription(
+    nullableProperty.description,
+    discriminatorKey,
+    variantsWithProperty.map((variant) => variant.discriminatorValue),
+  );
+  return nullableProperty;
+}
+
+function mergeCompatiblePropertySchemas(
+  schemas: JsonSchemaRecord[],
+): JsonSchemaRecord | undefined {
+  if (schemas.length === 0) {
+    return undefined;
+  }
+
+  const normalizedReference = JSON.stringify(
+    stripDescriptionFields(schemas[0]),
+  );
+  for (const schema of schemas.slice(1)) {
+    if (
+      JSON.stringify(stripDescriptionFields(schema)) !== normalizedReference
+    ) {
+      return undefined;
+    }
+  }
+
+  const mergedSchema = structuredClone(schemas[0]);
+  const mergedDescription = mergeDescriptions(
+    schemas.map((schema) => schema.description),
+  );
+  if (mergedDescription) {
+    mergedSchema.description = mergedDescription;
+  }
+  return mergedSchema;
+}
+
+function makeSchemaNullable(
+  schema: JsonSchemaRecord,
+): JsonSchemaRecord | undefined {
+  if (
+    '$ref' in schema ||
+    Array.isArray(schema.anyOf) ||
+    Array.isArray(schema.oneOf) ||
+    Array.isArray(schema.allOf)
+  ) {
+    return undefined;
+  }
+
+  const nullableSchema = structuredClone(schema);
+  const baseType = inferSchemaType(nullableSchema);
+  if (!baseType) {
+    return undefined;
+  }
+
+  if (Array.isArray(nullableSchema.type)) {
+    if (!nullableSchema.type.includes('null')) {
+      nullableSchema.type = [...nullableSchema.type, 'null'];
+    }
+  } else if (typeof nullableSchema.type === 'string') {
+    if (nullableSchema.type !== 'null') {
+      nullableSchema.type = [nullableSchema.type, 'null'];
+    }
+  } else {
+    nullableSchema.type = [baseType, 'null'];
+  }
+
+  if ('const' in nullableSchema) {
+    nullableSchema.enum = [nullableSchema.const, null];
+    delete nullableSchema.const;
+    return nullableSchema;
+  }
+
+  if (
+    Array.isArray(nullableSchema.enum) &&
+    !nullableSchema.enum.includes(null)
+  ) {
+    nullableSchema.enum = [...nullableSchema.enum, null];
+  }
+
+  return nullableSchema;
+}
+
+function inferDiscriminatorType(
+  schemas: JsonSchemaRecord[],
+  literalValues: LiteralValue[],
+): string | undefined {
+  const declaredTypes = schemas
+    .map((schema) => schema.type)
+    .filter((type): type is string => typeof type === 'string');
+
+  if (
+    declaredTypes.length === schemas.length &&
+    declaredTypes.every((type) => type === declaredTypes[0])
+  ) {
+    return declaredTypes[0];
+  }
+
+  return inferLiteralType(literalValues);
+}
+
+function inferSchemaType(schema: JsonSchemaRecord): string | undefined {
+  if (typeof schema.type === 'string') {
+    return schema.type;
+  }
+
+  if (isSchemaObject(schema.properties)) {
+    return 'object';
+  }
+
+  if ('items' in schema) {
+    return 'array';
+  }
+
+  if (Array.isArray(schema.enum)) {
+    return inferLiteralType(schema.enum.filter((value) => value !== null));
+  }
+
+  if ('const' in schema) {
+    return inferLiteralType([schema.const]);
+  }
+
+  return undefined;
+}
+
+function inferLiteralType(values: unknown[]): string | undefined {
+  if (values.length === 0) {
+    return undefined;
+  }
+
+  const literalTypes = new Set<string>();
+  for (const value of values) {
+    if (typeof value === 'string') {
+      literalTypes.add('string');
+      continue;
+    }
+    if (typeof value === 'boolean') {
+      literalTypes.add('boolean');
+      continue;
+    }
+    if (typeof value === 'number') {
+      literalTypes.add(Number.isInteger(value) ? 'integer' : 'number');
+      continue;
+    }
+    if (value === null) {
+      literalTypes.add('null');
+      continue;
+    }
+    return undefined;
+  }
+
+  return literalTypes.size === 1 ? [...literalTypes][0] : undefined;
+}
+
+function collectPropertyNames(
+  variants: ObjectUnionVariant[],
+  discriminatorKey: string,
+): string[] {
+  const propertyNames: string[] = [];
+  const seen = new Set<string>();
+
+  for (const variant of variants) {
+    for (const propertyName of Object.keys(variant.properties)) {
+      if (seen.has(propertyName)) {
+        continue;
+      }
+      seen.add(propertyName);
+      propertyNames.push(propertyName);
+    }
+  }
+
+  propertyNames.sort((left, right) => {
+    if (left === discriminatorKey) {
+      return -1;
+    }
+    if (right === discriminatorKey) {
+      return 1;
+    }
+    return 0;
+  });
+
+  return propertyNames;
+}
+
+function appendConditionDescription(
+  description: unknown,
+  discriminatorKey: string,
+  values: LiteralValue[],
+): string {
+  const condition =
+    values.length === 1
+      ? `${discriminatorKey} is ${formatLiteralValue(values[0])}`
+      : `${discriminatorKey} is one of ${values
+          .map((value) => formatLiteralValue(value))
+          .join(', ')}`;
+  const suffix = `Set to null unless ${condition}.`;
+
+  if (typeof description !== 'string' || description.trim().length === 0) {
+    return suffix;
+  }
+
+  const trimmed = description.trim();
+  const prefix = /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`;
+  return `${prefix} ${suffix}`;
+}
+
+function mergeDescriptions(descriptions: unknown[]): string | undefined {
+  const uniqueDescriptions = [
+    ...new Set(
+      descriptions.filter(
+        (description): description is string =>
+          typeof description === 'string' && description.trim().length > 0,
+      ),
+    ),
+  ];
+
+  if (uniqueDescriptions.length === 0) {
+    return undefined;
+  }
+
+  return uniqueDescriptions.join(' ');
+}
+
+function stripDescriptionFields(input: unknown): unknown {
+  if (Array.isArray(input)) {
+    return input.map(stripDescriptionFields);
+  }
+
+  if (!isSchemaObject(input)) {
+    return input;
+  }
+
+  const clone = structuredClone(input);
+  delete clone.description;
+  for (const [key, value] of Object.entries(clone)) {
+    clone[key] = stripDescriptionFields(value);
+  }
+  return clone;
+}
+
+function getLiteralValue(schema: unknown): LiteralValue | undefined {
+  if (!isSchemaObject(schema)) {
+    return undefined;
+  }
+
+  if (
+    'const' in schema &&
+    (typeof schema.const === 'string' ||
+      typeof schema.const === 'number' ||
+      typeof schema.const === 'boolean' ||
+      schema.const === null)
+  ) {
+    return schema.const;
+  }
+
+  if (
+    Array.isArray(schema.enum) &&
+    schema.enum.length === 1 &&
+    (typeof schema.enum[0] === 'string' ||
+      typeof schema.enum[0] === 'number' ||
+      typeof schema.enum[0] === 'boolean' ||
+      schema.enum[0] === null)
+  ) {
+    return schema.enum[0];
+  }
+
+  return undefined;
+}
+
+function serializeLiteralValue(value: LiteralValue): string {
+  return `${typeof value}:${String(value)}`;
+}
+
+function formatLiteralValue(value: LiteralValue): string {
+  return value === null ? 'null' : JSON.stringify(value);
+}
+
+function replaceSchema(
+  target: JsonSchemaRecord,
+  replacement: JsonSchemaRecord,
+) {
+  for (const key of Object.keys(target)) {
+    delete target[key];
+  }
+  Object.assign(target, replacement);
+}
+
+function isObjectSchemaVariant(schema: unknown): schema is {
+  type: 'object';
+  properties: JsonSchemaProperties;
+  required?: string[];
+  additionalProperties?: boolean;
+} {
+  return (
+    isSchemaObject(schema) &&
+    schema.type === 'object' &&
+    isSchemaObject(schema.properties)
+  );
+}
+
+function isSchemaObject(value: unknown): value is JsonSchemaRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/agents-core/src/utils/normalizeGeneratedJsonSchema.ts
+++ b/packages/agents-core/src/utils/normalizeGeneratedJsonSchema.ts
@@ -1,14 +1,12 @@
 import { JsonObjectSchema, JsonSchemaDefinitionEntry } from '../types';
-
-type JsonSchemaRecord = Record<string, any>;
-type JsonSchemaProperties = Record<string, JsonSchemaDefinitionEntry>;
-type LiteralValue = string | number | boolean | null;
-
-type ObjectUnionVariant = {
-  discriminatorValue: LiteralValue;
-  properties: JsonSchemaProperties;
-  schema: JsonSchemaRecord;
-};
+import {
+  analyzeDiscriminatedObjectUnion,
+  DiscriminatedObjectUnionVariant as ObjectUnionVariant,
+  isSchemaObject,
+  JsonSchemaProperties,
+  JsonSchemaRecord,
+  LiteralValue,
+} from './generatedJsonSchemaUnion';
 
 type MergedVariantProperties = {
   properties: JsonSchemaProperties;
@@ -74,18 +72,23 @@ function lowerDiscriminatedObjectUnion(
     return undefined;
   }
 
-  const discriminatorKey = findDiscriminatorKey(anyOf);
-  if (!discriminatorKey) {
+  const analysis = analyzeDiscriminatedObjectUnion(anyOf);
+  if (!analysis) {
     return undefined;
   }
 
-  const variants = getObjectUnionVariants(anyOf, discriminatorKey);
-  if (!variants) {
-    return undefined;
-  }
-
-  const mergedProperties = mergeVariantProperties(variants, discriminatorKey);
+  const mergedProperties = mergeVariantProperties(
+    analysis.variants,
+    analysis.discriminatorKey,
+  );
   if (!mergedProperties) {
+    return undefined;
+  }
+
+  const mergedAdditionalProperties = mergeAdditionalProperties(
+    analysis.variants,
+  );
+  if (!mergedAdditionalProperties.mergeable) {
     return undefined;
   }
 
@@ -94,86 +97,17 @@ function lowerDiscriminatedObjectUnion(
     type: 'object',
     properties: mergedProperties.properties,
     required: mergedProperties.required,
-    additionalProperties: false,
   };
+
+  if (mergedAdditionalProperties.hasAdditionalProperties) {
+    loweredSchema.additionalProperties =
+      mergedAdditionalProperties.additionalProperties;
+  } else {
+    delete loweredSchema.additionalProperties;
+  }
 
   delete loweredSchema.anyOf;
   return loweredSchema;
-}
-
-function findDiscriminatorKey(anyOf: unknown[]): string | undefined {
-  const firstVariant = anyOf[0];
-  if (!isObjectSchemaVariant(firstVariant)) {
-    return undefined;
-  }
-
-  const orderedKeys = Object.keys(firstVariant.properties);
-  const candidateKeys = orderedKeys.filter((key) =>
-    anyOf.every((variant) => {
-      if (!isObjectSchemaVariant(variant)) {
-        return false;
-      }
-
-      if (!Array.isArray(variant.required) || !variant.required.includes(key)) {
-        return false;
-      }
-
-      return getLiteralValue(variant.properties[key]) !== undefined;
-    }),
-  );
-
-  candidateKeys.sort((left, right) => {
-    if (left === 'type') {
-      return -1;
-    }
-    if (right === 'type') {
-      return 1;
-    }
-    return 0;
-  });
-
-  for (const key of candidateKeys) {
-    const serializedValues = new Set(
-      anyOf.map((variant) =>
-        serializeLiteralValue(
-          getLiteralValue((variant as JsonSchemaRecord).properties[key])!,
-        ),
-      ),
-    );
-    if (serializedValues.size === anyOf.length) {
-      return key;
-    }
-  }
-
-  return undefined;
-}
-
-function getObjectUnionVariants(
-  anyOf: unknown[],
-  discriminatorKey: string,
-): ObjectUnionVariant[] | undefined {
-  const variants: ObjectUnionVariant[] = [];
-
-  for (const entry of anyOf) {
-    if (!isObjectSchemaVariant(entry)) {
-      return undefined;
-    }
-
-    const discriminatorValue = getLiteralValue(
-      entry.properties[discriminatorKey],
-    );
-    if (discriminatorValue === undefined) {
-      return undefined;
-    }
-
-    variants.push({
-      discriminatorValue,
-      properties: entry.properties,
-      schema: entry,
-    });
-  }
-
-  return variants;
 }
 
 function mergeVariantProperties(
@@ -307,13 +241,9 @@ function mergeCompatiblePropertySchemas(
     return undefined;
   }
 
-  const normalizedReference = JSON.stringify(
-    stripDescriptionFields(schemas[0]),
-  );
+  const normalizedReference = getComparableSchemaFingerprint(schemas[0]);
   for (const schema of schemas.slice(1)) {
-    if (
-      JSON.stringify(stripDescriptionFields(schema)) !== normalizedReference
-    ) {
+    if (getComparableSchemaFingerprint(schema) !== normalizedReference) {
       return undefined;
     }
   }
@@ -331,13 +261,13 @@ function mergeCompatiblePropertySchemas(
 function makeSchemaNullable(
   schema: JsonSchemaRecord,
 ): JsonSchemaRecord | undefined {
-  if (
-    '$ref' in schema ||
-    Array.isArray(schema.anyOf) ||
-    Array.isArray(schema.oneOf) ||
-    Array.isArray(schema.allOf)
-  ) {
+  if ('$ref' in schema || Array.isArray(schema.allOf)) {
     return undefined;
+  }
+
+  const compositionalNullableSchema = makeCompositionalSchemaNullable(schema);
+  if (compositionalNullableSchema) {
+    return compositionalNullableSchema;
   }
 
   const nullableSchema = structuredClone(schema);
@@ -371,6 +301,32 @@ function makeSchemaNullable(
     nullableSchema.enum = [...nullableSchema.enum, null];
   }
 
+  return nullableSchema;
+}
+
+function makeCompositionalSchemaNullable(
+  schema: JsonSchemaRecord,
+): JsonSchemaRecord | undefined {
+  if (!Array.isArray(schema.anyOf) && !Array.isArray(schema.oneOf)) {
+    return undefined;
+  }
+
+  const keyword = Array.isArray(schema.anyOf) ? 'anyOf' : 'oneOf';
+  const entries = structuredClone(schema[keyword]) as unknown[];
+  if (entries.some(isNullTypeSchema)) {
+    const nullableSchema = structuredClone(schema);
+    if (keyword === 'oneOf') {
+      nullableSchema.anyOf = entries;
+      delete nullableSchema.oneOf;
+    }
+    return nullableSchema;
+  }
+
+  const nullableSchema = structuredClone(schema);
+  nullableSchema.anyOf = [...entries, { type: 'null' }];
+  if (keyword === 'oneOf') {
+    delete nullableSchema.oneOf;
+  }
   return nullableSchema;
 }
 
@@ -514,6 +470,54 @@ function mergeDescriptions(descriptions: unknown[]): string | undefined {
   return uniqueDescriptions.join(' ');
 }
 
+function mergeAdditionalProperties(variants: ObjectUnionVariant[]):
+  | {
+      mergeable: true;
+      hasAdditionalProperties: boolean;
+      additionalProperties?: unknown;
+    }
+  | { mergeable: false } {
+  const firstVariant = variants[0];
+  const hasAdditionalProperties = Object.prototype.hasOwnProperty.call(
+    firstVariant.schema,
+    'additionalProperties',
+  );
+  const referenceAdditionalProperties =
+    firstVariant.schema.additionalProperties;
+
+  for (const variant of variants.slice(1)) {
+    const hasCurrentAdditionalProperties = Object.prototype.hasOwnProperty.call(
+      variant.schema,
+      'additionalProperties',
+    );
+    if (hasCurrentAdditionalProperties !== hasAdditionalProperties) {
+      return { mergeable: false };
+    }
+    if (
+      hasAdditionalProperties &&
+      !schemasAreEquivalent(
+        variant.schema.additionalProperties,
+        referenceAdditionalProperties,
+      )
+    ) {
+      return { mergeable: false };
+    }
+  }
+
+  if (!hasAdditionalProperties) {
+    return {
+      mergeable: true,
+      hasAdditionalProperties: false,
+    };
+  }
+
+  return {
+    mergeable: true,
+    hasAdditionalProperties: true,
+    additionalProperties: structuredClone(referenceAdditionalProperties),
+  };
+}
+
 function isPropertyRequired(
   schema: JsonSchemaRecord,
   propertyName: string,
@@ -521,6 +525,48 @@ function isPropertyRequired(
   return (
     Array.isArray(schema.required) && schema.required.includes(propertyName)
   );
+}
+
+function getComparableSchemaFingerprint(input: unknown): string {
+  return JSON.stringify(
+    canonicalizeSchemaForComparison(stripDescriptionFields(input)),
+  );
+}
+
+function schemasAreEquivalent(left: unknown, right: unknown): boolean {
+  return (
+    getComparableSchemaFingerprint(left) ===
+    getComparableSchemaFingerprint(right)
+  );
+}
+
+function canonicalizeSchemaForComparison(input: unknown): unknown {
+  if (Array.isArray(input)) {
+    return input.map(canonicalizeSchemaForComparison);
+  }
+
+  if (!isSchemaObject(input)) {
+    return input;
+  }
+
+  const sortedEntries = Object.entries(input)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => {
+      if (
+        (key === 'required' || key === 'enum' || key === 'type') &&
+        Array.isArray(value)
+      ) {
+        return [
+          key,
+          [...value].sort((leftValue, rightValue) =>
+            JSON.stringify(leftValue).localeCompare(JSON.stringify(rightValue)),
+          ),
+        ];
+      }
+      return [key, canonicalizeSchemaForComparison(value)];
+    });
+
+  return Object.fromEntries(sortedEntries);
 }
 
 function stripDescriptionFields(input: unknown): unknown {
@@ -540,39 +586,6 @@ function stripDescriptionFields(input: unknown): unknown {
   return clone;
 }
 
-function getLiteralValue(schema: unknown): LiteralValue | undefined {
-  if (!isSchemaObject(schema)) {
-    return undefined;
-  }
-
-  if (
-    'const' in schema &&
-    (typeof schema.const === 'string' ||
-      typeof schema.const === 'number' ||
-      typeof schema.const === 'boolean' ||
-      schema.const === null)
-  ) {
-    return schema.const;
-  }
-
-  if (
-    Array.isArray(schema.enum) &&
-    schema.enum.length === 1 &&
-    (typeof schema.enum[0] === 'string' ||
-      typeof schema.enum[0] === 'number' ||
-      typeof schema.enum[0] === 'boolean' ||
-      schema.enum[0] === null)
-  ) {
-    return schema.enum[0];
-  }
-
-  return undefined;
-}
-
-function serializeLiteralValue(value: LiteralValue): string {
-  return `${typeof value}:${String(value)}`;
-}
-
 function formatLiteralValue(value: LiteralValue): string {
   return value === null ? 'null' : JSON.stringify(value);
 }
@@ -587,19 +600,6 @@ function replaceSchema(
   Object.assign(target, replacement);
 }
 
-function isObjectSchemaVariant(schema: unknown): schema is {
-  type: 'object';
-  properties: JsonSchemaProperties;
-  required?: string[];
-  additionalProperties?: boolean;
-} {
-  return (
-    isSchemaObject(schema) &&
-    schema.type === 'object' &&
-    isSchemaObject(schema.properties)
-  );
-}
-
-function isSchemaObject(value: unknown): value is JsonSchemaRecord {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
+function isNullTypeSchema(value: unknown): boolean {
+  return isSchemaObject(value) && value.type === 'null';
 }

--- a/packages/agents-core/src/utils/normalizeGeneratedJsonSchema.ts
+++ b/packages/agents-core/src/utils/normalizeGeneratedJsonSchema.ts
@@ -7,6 +7,10 @@ import {
   JsonSchemaRecord,
   LiteralValue,
 } from './generatedJsonSchemaUnion';
+import {
+  getComparableSchemaFingerprint,
+  schemasAreEquivalent,
+} from './jsonSchemaComparison';
 
 type MergedVariantProperties = {
   properties: JsonSchemaProperties;
@@ -525,65 +529,6 @@ function isPropertyRequired(
   return (
     Array.isArray(schema.required) && schema.required.includes(propertyName)
   );
-}
-
-function getComparableSchemaFingerprint(input: unknown): string {
-  return JSON.stringify(
-    canonicalizeSchemaForComparison(stripDescriptionFields(input)),
-  );
-}
-
-function schemasAreEquivalent(left: unknown, right: unknown): boolean {
-  return (
-    getComparableSchemaFingerprint(left) ===
-    getComparableSchemaFingerprint(right)
-  );
-}
-
-function canonicalizeSchemaForComparison(input: unknown): unknown {
-  if (Array.isArray(input)) {
-    return input.map(canonicalizeSchemaForComparison);
-  }
-
-  if (!isSchemaObject(input)) {
-    return input;
-  }
-
-  const sortedEntries = Object.entries(input)
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([key, value]) => {
-      if (
-        (key === 'required' || key === 'enum' || key === 'type') &&
-        Array.isArray(value)
-      ) {
-        return [
-          key,
-          [...value].sort((leftValue, rightValue) =>
-            JSON.stringify(leftValue).localeCompare(JSON.stringify(rightValue)),
-          ),
-        ];
-      }
-      return [key, canonicalizeSchemaForComparison(value)];
-    });
-
-  return Object.fromEntries(sortedEntries);
-}
-
-function stripDescriptionFields(input: unknown): unknown {
-  if (Array.isArray(input)) {
-    return input.map(stripDescriptionFields);
-  }
-
-  if (!isSchemaObject(input)) {
-    return input;
-  }
-
-  const clone = structuredClone(input);
-  delete clone.description;
-  for (const [key, value] of Object.entries(clone)) {
-    clone[key] = stripDescriptionFields(value);
-  }
-  return clone;
 }
 
 function formatLiteralValue(value: LiteralValue): string {

--- a/packages/agents-core/src/utils/normalizeGeneratedJsonSchema.ts
+++ b/packages/agents-core/src/utils/normalizeGeneratedJsonSchema.ts
@@ -207,18 +207,14 @@ function mergeVariantProperty(
   const requiredInEveryPresentVariant = variantsWithProperty.every((variant) =>
     isPropertyRequired(variant.schema, propertyName),
   );
+  const canBeOmittedInSomeVariant =
+    variantsWithProperty.length !== variants.length ||
+    !requiredInEveryPresentVariant;
 
-  if (variantsWithProperty.length === variants.length) {
+  if (!canBeOmittedInSomeVariant) {
     return {
       schema: mergedProperty,
-      required: requiredInEveryPresentVariant,
-    };
-  }
-
-  if (!requiredInEveryPresentVariant) {
-    return {
-      schema: mergedProperty,
-      required: false,
+      required: true,
     };
   }
 
@@ -227,11 +223,18 @@ function mergeVariantProperty(
     return undefined;
   }
 
-  nullableProperty.description = appendConditionDescription(
-    nullableProperty.description,
-    discriminatorKey,
-    variantsWithProperty.map((variant) => variant.discriminatorValue),
-  );
+  if (variantsWithProperty.length !== variants.length) {
+    nullableProperty.description = appendConditionDescription(
+      nullableProperty.description,
+      discriminatorKey,
+      variantsWithProperty.map((variant) => variant.discriminatorValue),
+    );
+  } else {
+    nullableProperty.description = appendOptionalDescription(
+      nullableProperty.description,
+    );
+  }
+
   return {
     schema: nullableProperty,
     required: true,
@@ -447,6 +450,18 @@ function appendConditionDescription(
           .map((value) => formatLiteralValue(value))
           .join(', ')}`;
   const suffix = `Set to null unless ${condition}.`;
+
+  if (typeof description !== 'string' || description.trim().length === 0) {
+    return suffix;
+  }
+
+  const trimmed = description.trim();
+  const prefix = /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`;
+  return `${prefix} ${suffix}`;
+}
+
+function appendOptionalDescription(description: unknown): string {
+  const suffix = 'Set to null when omitted.';
 
   if (typeof description !== 'string' || description.trim().length === 0) {
     return suffix;

--- a/packages/agents-core/src/utils/normalizeGeneratedJsonSchema.ts
+++ b/packages/agents-core/src/utils/normalizeGeneratedJsonSchema.ts
@@ -10,6 +10,16 @@ type ObjectUnionVariant = {
   schema: JsonSchemaRecord;
 };
 
+type MergedVariantProperties = {
+  properties: JsonSchemaProperties;
+  required: string[];
+};
+
+type MergedVariantProperty = {
+  required: boolean;
+  schema: JsonSchemaRecord;
+};
+
 export function normalizeGeneratedJsonSchema<
   T extends JsonObjectSchema<Record<string, JsonSchemaDefinitionEntry>>,
 >(schema: T): T {
@@ -82,8 +92,8 @@ function lowerDiscriminatedObjectUnion(
   const loweredSchema: JsonSchemaRecord = {
     ...schema,
     type: 'object',
-    properties: mergedProperties,
-    required: Object.keys(mergedProperties),
+    properties: mergedProperties.properties,
+    required: mergedProperties.required,
     additionalProperties: false,
   };
 
@@ -169,9 +179,10 @@ function getObjectUnionVariants(
 function mergeVariantProperties(
   variants: ObjectUnionVariant[],
   discriminatorKey: string,
-): JsonSchemaProperties | undefined {
+): MergedVariantProperties | undefined {
   const propertyNames = collectPropertyNames(variants, discriminatorKey);
   const mergedProperties: JsonSchemaProperties = {};
+  const requiredProperties: string[] = [];
 
   for (const propertyName of propertyNames) {
     if (propertyName === discriminatorKey) {
@@ -183,6 +194,7 @@ function mergeVariantProperties(
         return undefined;
       }
       mergedProperties[propertyName] = mergedDiscriminator;
+      requiredProperties.push(propertyName);
       continue;
     }
 
@@ -194,10 +206,16 @@ function mergeVariantProperties(
     if (!mergedProperty) {
       return undefined;
     }
-    mergedProperties[propertyName] = mergedProperty;
+    mergedProperties[propertyName] = mergedProperty.schema;
+    if (mergedProperty.required) {
+      requiredProperties.push(propertyName);
+    }
   }
 
-  return mergedProperties;
+  return {
+    properties: mergedProperties,
+    required: requiredProperties,
+  };
 }
 
 function mergeDiscriminatorProperty(
@@ -231,7 +249,7 @@ function mergeVariantProperty(
   variants: ObjectUnionVariant[],
   propertyName: string,
   discriminatorKey: string,
-): JsonSchemaRecord | undefined {
+): MergedVariantProperty | undefined {
   const variantsWithProperty = variants.filter(
     (variant) => propertyName in variant.properties,
   );
@@ -248,8 +266,22 @@ function mergeVariantProperty(
     return undefined;
   }
 
+  const requiredInEveryPresentVariant = variantsWithProperty.every((variant) =>
+    isPropertyRequired(variant.schema, propertyName),
+  );
+
   if (variantsWithProperty.length === variants.length) {
-    return mergedProperty;
+    return {
+      schema: mergedProperty,
+      required: requiredInEveryPresentVariant,
+    };
+  }
+
+  if (!requiredInEveryPresentVariant) {
+    return {
+      schema: mergedProperty,
+      required: false,
+    };
   }
 
   const nullableProperty = makeSchemaNullable(mergedProperty);
@@ -262,7 +294,10 @@ function mergeVariantProperty(
     discriminatorKey,
     variantsWithProperty.map((variant) => variant.discriminatorValue),
   );
-  return nullableProperty;
+  return {
+    schema: nullableProperty,
+    required: true,
+  };
 }
 
 function mergeCompatiblePropertySchemas(
@@ -477,6 +512,15 @@ function mergeDescriptions(descriptions: unknown[]): string | undefined {
   }
 
   return uniqueDescriptions.join(' ');
+}
+
+function isPropertyRequired(
+  schema: JsonSchemaRecord,
+  propertyName: string,
+): boolean {
+  return (
+    Array.isArray(schema.required) && schema.required.includes(propertyName)
+  );
 }
 
 function stripDescriptionFields(input: unknown): unknown {

--- a/packages/agents-core/src/utils/normalizeGeneratedJsonSchema.ts
+++ b/packages/agents-core/src/utils/normalizeGeneratedJsonSchema.ts
@@ -217,17 +217,18 @@ function mergeVariantProperty(
   }
 
   if (!presentInEveryVariant) {
-    // Strict Responses schemas cannot omit branch-only keys, so keep their
-    // original type and let parser-side sanitization drop inactive copies.
-    const conditionedProperty = structuredClone(mergedProperty);
-    conditionedProperty.description = appendBranchConditionDescription(
-      conditionedProperty.description,
+    const nullableProperty = makeSchemaNullable(mergedProperty);
+    if (!nullableProperty) {
+      return undefined;
+    }
+    nullableProperty.description = appendBranchConditionDescription(
+      nullableProperty.description,
       discriminatorKey,
       variantsWithProperty.map((variant) => variant.discriminatorValue),
     );
 
     return {
-      schema: conditionedProperty,
+      schema: nullableProperty,
       required: true,
     };
   }
@@ -455,7 +456,7 @@ function appendBranchConditionDescription(
       : `${discriminatorKey} is one of ${values
           .map((value) => formatLiteralValue(value))
           .join(', ')}`;
-  const suffix = `Ignored unless ${condition}.`;
+  const suffix = `Set to null unless ${condition}.`;
 
   if (typeof description !== 'string' || description.trim().length === 0) {
     return suffix;
@@ -536,10 +537,14 @@ function mergeAdditionalProperties(variants: ObjectUnionVariant[]):
     };
   }
 
+  if (referenceAdditionalProperties !== false) {
+    return { mergeable: false };
+  }
+
   return {
     mergeable: true,
     hasAdditionalProperties: true,
-    additionalProperties: structuredClone(referenceAdditionalProperties),
+    additionalProperties: false,
   };
 }
 

--- a/packages/agents-core/src/utils/sanitizeNormalizedUnionInput.ts
+++ b/packages/agents-core/src/utils/sanitizeNormalizedUnionInput.ts
@@ -1,0 +1,133 @@
+import {
+  analyzeDiscriminatedObjectUnion,
+  DiscriminatedObjectUnionVariant,
+  isSchemaObject,
+  JsonSchemaRecord,
+} from './generatedJsonSchemaUnion';
+
+type SelectedDiscriminatedUnionVariant = {
+  branchOnlyPropertyNames: Set<string>;
+  variant: DiscriminatedObjectUnionVariant;
+};
+
+export function sanitizeNormalizedUnionInput<T>(
+  input: T,
+  originalSchema: unknown,
+): T {
+  return sanitizeInputForSchema(input, originalSchema) as T;
+}
+
+function sanitizeInputForSchema(input: unknown, schema: unknown): unknown {
+  if (Array.isArray(input)) {
+    if (!isSchemaObject(schema)) {
+      return input;
+    }
+    if (Array.isArray(schema.items)) {
+      return input.map((item, index) =>
+        sanitizeInputForSchema(item, schema.items[index]),
+      );
+    }
+    return input.map((item) => sanitizeInputForSchema(item, schema.items));
+  }
+
+  if (!isSchemaObject(input) || !isSchemaObject(schema)) {
+    return input;
+  }
+
+  const selectedVariant = selectMatchingDiscriminatedUnionVariant(
+    schema,
+    input,
+  );
+  if (selectedVariant) {
+    return sanitizeUnionVariantInput(input, selectedVariant);
+  }
+
+  const sanitizedInput = structuredClone(input);
+  for (const [key, value] of Object.entries(input)) {
+    if (isSchemaObject(schema.properties) && key in schema.properties) {
+      sanitizedInput[key] = sanitizeInputForSchema(
+        value,
+        schema.properties[key],
+      );
+      continue;
+    }
+    if (isSchemaObject(schema.additionalProperties)) {
+      sanitizedInput[key] = sanitizeInputForSchema(
+        value,
+        schema.additionalProperties,
+      );
+    }
+  }
+  return sanitizedInput;
+}
+
+function selectMatchingDiscriminatedUnionVariant(
+  schema: JsonSchemaRecord,
+  input: JsonSchemaRecord,
+): SelectedDiscriminatedUnionVariant | undefined {
+  const anyOf = schema.anyOf;
+  if (!Array.isArray(anyOf) || anyOf.length < 2) {
+    return undefined;
+  }
+
+  const analysis = analyzeDiscriminatedObjectUnion(anyOf);
+  if (!analysis) {
+    return undefined;
+  }
+
+  const matchingVariant = analysis.variants.find(
+    (variant) =>
+      input[analysis.discriminatorKey] === variant.discriminatorValue,
+  );
+  if (!matchingVariant) {
+    return undefined;
+  }
+
+  const branchOnlyPropertyNames = new Set<string>();
+  for (const variant of analysis.variants) {
+    if (variant === matchingVariant) {
+      continue;
+    }
+    for (const propertyName of Object.keys(variant.properties)) {
+      if (!(propertyName in matchingVariant.properties)) {
+        branchOnlyPropertyNames.add(propertyName);
+      }
+    }
+  }
+
+  return {
+    branchOnlyPropertyNames,
+    variant: matchingVariant,
+  };
+}
+
+function sanitizeUnionVariantInput(
+  input: JsonSchemaRecord,
+  selectedVariant: SelectedDiscriminatedUnionVariant,
+): JsonSchemaRecord {
+  const sanitizedInput = structuredClone(input);
+
+  for (const [key, value] of Object.entries(input)) {
+    if (key in selectedVariant.variant.properties) {
+      sanitizedInput[key] = sanitizeInputForSchema(
+        value,
+        selectedVariant.variant.properties[key],
+      );
+      continue;
+    }
+
+    if (value === null && selectedVariant.branchOnlyPropertyNames.has(key)) {
+      delete sanitizedInput[key];
+      continue;
+    }
+
+    if (isSchemaObject(selectedVariant.variant.schema.additionalProperties)) {
+      sanitizedInput[key] = sanitizeInputForSchema(
+        value,
+        selectedVariant.variant.schema.additionalProperties,
+      );
+    }
+  }
+
+  return sanitizedInput;
+}

--- a/packages/agents-core/src/utils/sanitizeNormalizedUnionInput.ts
+++ b/packages/agents-core/src/utils/sanitizeNormalizedUnionInput.ts
@@ -170,17 +170,34 @@ function sanitizeUnionVariantInput(
 
   for (const [key, value] of Object.entries(input)) {
     if (key in selectedVariant.variant.properties) {
+      const normalizedPropertySchema = isSchemaObject(
+        selectedVariant.normalizedSchema.properties,
+      )
+        ? selectedVariant.normalizedSchema.properties[key]
+        : undefined;
+      if (
+        value === null &&
+        !isPropertyRequired(selectedVariant.variant.schema, key) &&
+        !schemaAllowsNull(selectedVariant.variant.properties[key]) &&
+        schemaAllowsNull(normalizedPropertySchema)
+      ) {
+        delete sanitizedInput[key];
+        continue;
+      }
+
       sanitizedInput[key] = sanitizeInputForSchema(
         value,
         selectedVariant.variant.properties[key],
-        isSchemaObject(selectedVariant.normalizedSchema.properties)
-          ? selectedVariant.normalizedSchema.properties[key]
-          : undefined,
+        normalizedPropertySchema,
       );
       continue;
     }
 
-    if (value === null && selectedVariant.branchOnlyPropertyNames.has(key)) {
+    if (
+      value === null &&
+      selectedVariant.branchOnlyPropertyNames.has(key) &&
+      shouldStripBranchOnlyNullKey(selectedVariant)
+    ) {
       delete sanitizedInput[key];
       continue;
     }
@@ -195,4 +212,72 @@ function sanitizeUnionVariantInput(
   }
 
   return sanitizedInput;
+}
+
+function shouldStripBranchOnlyNullKey(
+  selectedVariant: SelectedDiscriminatedUnionVariant,
+): boolean {
+  const additionalProperties =
+    selectedVariant.variant.schema.additionalProperties;
+  if (additionalProperties === true) {
+    return false;
+  }
+
+  if (
+    isSchemaObject(additionalProperties) &&
+    schemaAllowsNull(additionalProperties)
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function isPropertyRequired(
+  schema: JsonSchemaRecord,
+  propertyName: string,
+): boolean {
+  return (
+    Array.isArray(schema.required) && schema.required.includes(propertyName)
+  );
+}
+
+function schemaAllowsNull(schema: unknown): boolean {
+  if (!schema) {
+    return false;
+  }
+
+  if (schema === true) {
+    return true;
+  }
+
+  if (!isSchemaObject(schema)) {
+    return false;
+  }
+
+  if (schema.const === null) {
+    return true;
+  }
+
+  if (Array.isArray(schema.type) && schema.type.includes('null')) {
+    return true;
+  }
+
+  if (schema.type === 'null') {
+    return true;
+  }
+
+  if (Array.isArray(schema.enum) && schema.enum.includes(null)) {
+    return true;
+  }
+
+  if (Array.isArray(schema.anyOf) && schema.anyOf.some(schemaAllowsNull)) {
+    return true;
+  }
+
+  if (Array.isArray(schema.oneOf) && schema.oneOf.some(schemaAllowsNull)) {
+    return true;
+  }
+
+  return false;
 }

--- a/packages/agents-core/src/utils/sanitizeNormalizedUnionInput.ts
+++ b/packages/agents-core/src/utils/sanitizeNormalizedUnionInput.ts
@@ -194,9 +194,8 @@ function sanitizeUnionVariantInput(
     }
 
     if (
-      value === null &&
       selectedVariant.branchOnlyPropertyNames.has(key) &&
-      shouldStripBranchOnlyNullKey(selectedVariant)
+      shouldStripBranchOnlyKey(selectedVariant, value)
     ) {
       delete sanitizedInput[key];
       continue;
@@ -214,8 +213,9 @@ function sanitizeUnionVariantInput(
   return sanitizedInput;
 }
 
-function shouldStripBranchOnlyNullKey(
+function shouldStripBranchOnlyKey(
   selectedVariant: SelectedDiscriminatedUnionVariant,
+  value: unknown,
 ): boolean {
   const additionalProperties =
     selectedVariant.variant.schema.additionalProperties;
@@ -223,11 +223,8 @@ function shouldStripBranchOnlyNullKey(
     return false;
   }
 
-  if (
-    isSchemaObject(additionalProperties) &&
-    schemaAllowsNull(additionalProperties)
-  ) {
-    return false;
+  if (isSchemaObject(additionalProperties)) {
+    return !schemaCouldAcceptValue(additionalProperties, value);
   }
 
   return true;
@@ -280,4 +277,76 @@ function schemaAllowsNull(schema: unknown): boolean {
   }
 
   return false;
+}
+
+function schemaCouldAcceptValue(schema: unknown, value: unknown): boolean {
+  if (schema === true) {
+    return true;
+  }
+
+  if (!isSchemaObject(schema)) {
+    return false;
+  }
+
+  if (Array.isArray(schema.anyOf)) {
+    return schema.anyOf.some((entry) => schemaCouldAcceptValue(entry, value));
+  }
+
+  if (Array.isArray(schema.oneOf)) {
+    return (
+      schema.oneOf.filter((entry) => schemaCouldAcceptValue(entry, value))
+        .length === 1
+    );
+  }
+
+  if (Array.isArray(schema.allOf)) {
+    return schema.allOf.every((entry) => schemaCouldAcceptValue(entry, value));
+  }
+
+  if ('const' in schema) {
+    return Object.is(schema.const, value);
+  }
+
+  if (Array.isArray(schema.enum)) {
+    return schema.enum.some((entry) => Object.is(entry, value));
+  }
+
+  if (Array.isArray(schema.type)) {
+    return schema.type.some((type) => jsonSchemaTypeMatchesValue(type, value));
+  }
+
+  if (typeof schema.type === 'string') {
+    return jsonSchemaTypeMatchesValue(schema.type, value);
+  }
+
+  if (isSchemaObject(schema.properties) || 'additionalProperties' in schema) {
+    return isSchemaObject(value);
+  }
+
+  if ('items' in schema) {
+    return Array.isArray(value);
+  }
+
+  return true;
+}
+
+function jsonSchemaTypeMatchesValue(type: unknown, value: unknown): boolean {
+  switch (type) {
+    case 'null':
+      return value === null;
+    case 'string':
+      return typeof value === 'string';
+    case 'number':
+      return typeof value === 'number';
+    case 'integer':
+      return typeof value === 'number' && Number.isInteger(value);
+    case 'boolean':
+      return typeof value === 'boolean';
+    case 'object':
+      return isSchemaObject(value);
+    case 'array':
+      return Array.isArray(value);
+    default:
+      return false;
+  }
 }

--- a/packages/agents-core/src/utils/sanitizeNormalizedUnionInput.ts
+++ b/packages/agents-core/src/utils/sanitizeNormalizedUnionInput.ts
@@ -7,35 +7,58 @@ import {
 
 type SelectedDiscriminatedUnionVariant = {
   branchOnlyPropertyNames: Set<string>;
+  normalizedSchema: JsonSchemaRecord;
   variant: DiscriminatedObjectUnionVariant;
 };
 
 export function sanitizeNormalizedUnionInput<T>(
   input: T,
   originalSchema: unknown,
+  normalizedSchema: unknown,
 ): T {
-  return sanitizeInputForSchema(input, originalSchema) as T;
+  return sanitizeInputForSchema(input, originalSchema, normalizedSchema) as T;
 }
 
-function sanitizeInputForSchema(input: unknown, schema: unknown): unknown {
+function sanitizeInputForSchema(
+  input: unknown,
+  originalSchema: unknown,
+  normalizedSchema: unknown,
+): unknown {
   if (Array.isArray(input)) {
-    if (!isSchemaObject(schema)) {
+    if (!isSchemaObject(originalSchema) && !isSchemaObject(normalizedSchema)) {
       return input;
     }
-    if (Array.isArray(schema.items)) {
+
+    const originalItems = isSchemaObject(originalSchema)
+      ? originalSchema.items
+      : undefined;
+    const normalizedItems = isSchemaObject(normalizedSchema)
+      ? normalizedSchema.items
+      : undefined;
+
+    if (Array.isArray(originalItems) || Array.isArray(normalizedItems)) {
       return input.map((item, index) =>
-        sanitizeInputForSchema(item, schema.items[index]),
+        sanitizeInputForSchema(
+          item,
+          Array.isArray(originalItems) ? originalItems[index] : originalItems,
+          Array.isArray(normalizedItems)
+            ? normalizedItems[index]
+            : normalizedItems,
+        ),
       );
     }
-    return input.map((item) => sanitizeInputForSchema(item, schema.items));
+    return input.map((item) =>
+      sanitizeInputForSchema(item, originalItems, normalizedItems),
+    );
   }
 
-  if (!isSchemaObject(input) || !isSchemaObject(schema)) {
+  if (!isSchemaObject(input)) {
     return input;
   }
 
   const selectedVariant = selectMatchingDiscriminatedUnionVariant(
-    schema,
+    originalSchema,
+    normalizedSchema,
     input,
   );
   if (selectedVariant) {
@@ -44,17 +67,45 @@ function sanitizeInputForSchema(input: unknown, schema: unknown): unknown {
 
   const sanitizedInput = structuredClone(input);
   for (const [key, value] of Object.entries(input)) {
-    if (isSchemaObject(schema.properties) && key in schema.properties) {
+    const originalPropertySchema =
+      isSchemaObject(originalSchema) &&
+      isSchemaObject(originalSchema.properties) &&
+      key in originalSchema.properties
+        ? originalSchema.properties[key]
+        : undefined;
+    const normalizedPropertySchema =
+      isSchemaObject(normalizedSchema) &&
+      isSchemaObject(normalizedSchema.properties) &&
+      key in normalizedSchema.properties
+        ? normalizedSchema.properties[key]
+        : undefined;
+
+    if (
+      typeof originalPropertySchema !== 'undefined' ||
+      typeof normalizedPropertySchema !== 'undefined'
+    ) {
       sanitizedInput[key] = sanitizeInputForSchema(
         value,
-        schema.properties[key],
+        originalPropertySchema,
+        normalizedPropertySchema,
       );
       continue;
     }
-    if (isSchemaObject(schema.additionalProperties)) {
+
+    const originalAdditionalProperties = isSchemaObject(originalSchema)
+      ? originalSchema.additionalProperties
+      : undefined;
+    const normalizedAdditionalProperties = isSchemaObject(normalizedSchema)
+      ? normalizedSchema.additionalProperties
+      : undefined;
+    if (
+      isSchemaObject(originalAdditionalProperties) ||
+      isSchemaObject(normalizedAdditionalProperties)
+    ) {
       sanitizedInput[key] = sanitizeInputForSchema(
         value,
-        schema.additionalProperties,
+        originalAdditionalProperties,
+        normalizedAdditionalProperties,
       );
     }
   }
@@ -62,11 +113,20 @@ function sanitizeInputForSchema(input: unknown, schema: unknown): unknown {
 }
 
 function selectMatchingDiscriminatedUnionVariant(
-  schema: JsonSchemaRecord,
+  originalSchema: unknown,
+  normalizedSchema: unknown,
   input: JsonSchemaRecord,
 ): SelectedDiscriminatedUnionVariant | undefined {
-  const anyOf = schema.anyOf;
+  if (!isSchemaObject(originalSchema) || !isSchemaObject(normalizedSchema)) {
+    return undefined;
+  }
+
+  const anyOf = originalSchema.anyOf;
   if (!Array.isArray(anyOf) || anyOf.length < 2) {
+    return undefined;
+  }
+
+  if (Array.isArray(normalizedSchema.anyOf)) {
     return undefined;
   }
 
@@ -97,6 +157,7 @@ function selectMatchingDiscriminatedUnionVariant(
 
   return {
     branchOnlyPropertyNames,
+    normalizedSchema,
     variant: matchingVariant,
   };
 }
@@ -112,6 +173,9 @@ function sanitizeUnionVariantInput(
       sanitizedInput[key] = sanitizeInputForSchema(
         value,
         selectedVariant.variant.properties[key],
+        isSchemaObject(selectedVariant.normalizedSchema.properties)
+          ? selectedVariant.normalizedSchema.properties[key]
+          : undefined,
       );
       continue;
     }
@@ -125,6 +189,7 @@ function sanitizeUnionVariantInput(
       sanitizedInput[key] = sanitizeInputForSchema(
         value,
         selectedVariant.variant.schema.additionalProperties,
+        selectedVariant.normalizedSchema.additionalProperties,
       );
     }
   }

--- a/packages/agents-core/src/utils/tools.ts
+++ b/packages/agents-core/src/utils/tools.ts
@@ -9,6 +9,7 @@ import {
   hasJsonSchemaObjectShape,
   mergeJsonSchemaDescriptions,
 } from './zodJsonSchemaCompat';
+import { normalizeGeneratedJsonSchema } from './normalizeGeneratedJsonSchema';
 import type { ZodObjectLike } from './zodCompat';
 import { asZodType } from './zodCompat';
 
@@ -106,7 +107,7 @@ export function getSchemaAndParserFromInputType<T extends ToolInputParameters>(
       const fallbackSchema = buildJsonSchemaFromZod(inputType);
       if (fallbackSchema) {
         return {
-          schema: fallbackSchema,
+          schema: normalizeGeneratedJsonSchema(fallbackSchema),
           parser: (rawInput: string) => inputType.parse(JSON.parse(rawInput)),
         };
       }
@@ -142,7 +143,9 @@ export function getSchemaAndParserFromInputType<T extends ToolInputParameters>(
         );
       }
       return {
-        schema: formattedFunction.parameters as JsonObjectSchema<any>,
+        schema: normalizeGeneratedJsonSchema(
+          formattedFunction.parameters as JsonObjectSchema<any>,
+        ),
         parser: formattedFunction.$parseRaw,
       };
     }

--- a/packages/agents-core/src/utils/tools.ts
+++ b/packages/agents-core/src/utils/tools.ts
@@ -11,6 +11,10 @@ import {
 } from './zodJsonSchemaCompat';
 import { normalizeGeneratedJsonSchema } from './normalizeGeneratedJsonSchema';
 import { sanitizeNormalizedUnionInput } from './sanitizeNormalizedUnionInput';
+import {
+  analyzeDiscriminatedObjectUnion,
+  isSchemaObject,
+} from './generatedJsonSchemaUnion';
 import type { ZodObjectLike } from './zodCompat';
 import { asZodType } from './zodCompat';
 
@@ -111,6 +115,61 @@ function getFallbackJsonSchema(
   throw buildZodSchemaConversionError(originalError);
 }
 
+function ensureStrictCompatibleDiscriminatedUnions(schema: unknown): void {
+  visitSchemaNode(schema);
+}
+
+function visitSchemaNode(schema: unknown): void {
+  if (!isSchemaObject(schema)) {
+    return;
+  }
+
+  if (Array.isArray(schema.anyOf)) {
+    const analysis = analyzeDiscriminatedObjectUnion(schema.anyOf);
+    if (analysis) {
+      const hasUnsupportedAdditionalProperties = analysis.variants.some(
+        (variant) =>
+          Object.prototype.hasOwnProperty.call(
+            variant.schema,
+            'additionalProperties',
+          ) && variant.schema.additionalProperties !== false,
+      );
+      if (hasUnsupportedAdditionalProperties) {
+        throw new UserError(
+          'Strict function tool schemas do not support discriminated unions with catchall or passthrough object variants. Remove catchall/passthrough from the union branches or provide a JSON schema object instead.',
+        );
+      }
+    }
+  }
+
+  if (isSchemaObject(schema.properties)) {
+    for (const propertySchema of Object.values(schema.properties)) {
+      visitSchemaNode(propertySchema);
+    }
+  }
+
+  if (Array.isArray(schema.items)) {
+    for (const itemSchema of schema.items) {
+      visitSchemaNode(itemSchema);
+    }
+  } else {
+    visitSchemaNode(schema.items);
+  }
+
+  if (isSchemaObject(schema.additionalProperties)) {
+    visitSchemaNode(schema.additionalProperties);
+  }
+
+  for (const keyword of ['allOf', 'anyOf', 'oneOf'] as const) {
+    const entries = schema[keyword];
+    if (Array.isArray(entries)) {
+      for (const entry of entries) {
+        visitSchemaNode(entry);
+      }
+    }
+  }
+}
+
 /**
  * Convert a string to a function tool name by replacing spaces with underscores and
  * non-alphanumeric characters with underscores.
@@ -152,6 +211,7 @@ export function getSchemaAndParserFromInputType<T extends ToolInputParameters>(
   if (isZodObject(inputType)) {
     const useFallback = (originalError?: unknown) => {
       const fallbackSchema = getFallbackJsonSchema(inputType, originalError);
+      ensureStrictCompatibleDiscriminatedUnions(fallbackSchema);
       const normalizedFallbackSchema =
         normalizeGeneratedJsonSchema(fallbackSchema);
       return {
@@ -183,6 +243,7 @@ export function getSchemaAndParserFromInputType<T extends ToolInputParameters>(
       if (fallbackSchema) {
         mergeJsonSchemaDescriptions(originalSchema, fallbackSchema);
       }
+      ensureStrictCompatibleDiscriminatedUnions(originalSchema);
       const normalizedOriginalSchema =
         normalizeGeneratedJsonSchema(originalSchema);
       return {

--- a/packages/agents-core/src/utils/tools.ts
+++ b/packages/agents-core/src/utils/tools.ts
@@ -10,6 +10,7 @@ import {
   mergeJsonSchemaDescriptions,
 } from './zodJsonSchemaCompat';
 import { normalizeGeneratedJsonSchema } from './normalizeGeneratedJsonSchema';
+import { sanitizeNormalizedUnionInput } from './sanitizeNormalizedUnionInput';
 import type { ZodObjectLike } from './zodCompat';
 import { asZodType } from './zodCompat';
 
@@ -108,7 +109,13 @@ export function getSchemaAndParserFromInputType<T extends ToolInputParameters>(
       if (fallbackSchema) {
         return {
           schema: normalizeGeneratedJsonSchema(fallbackSchema),
-          parser: (rawInput: string) => inputType.parse(JSON.parse(rawInput)),
+          parser: (rawInput: string) =>
+            inputType.parse(
+              sanitizeNormalizedUnionInput(
+                JSON.parse(rawInput),
+                fallbackSchema,
+              ),
+            ),
         };
       }
 
@@ -135,18 +142,23 @@ export function getSchemaAndParserFromInputType<T extends ToolInputParameters>(
     }
 
     if (hasJsonSchemaObjectShape(formattedFunction.parameters)) {
+      const originalSchema =
+        formattedFunction.parameters as JsonObjectSchema<any>;
       const fallbackSchema = buildJsonSchemaFromZod(inputType);
       if (fallbackSchema) {
-        mergeJsonSchemaDescriptions(
-          formattedFunction.parameters as JsonObjectSchema<any>,
-          fallbackSchema,
-        );
+        mergeJsonSchemaDescriptions(originalSchema, fallbackSchema);
       }
       return {
-        schema: normalizeGeneratedJsonSchema(
-          formattedFunction.parameters as JsonObjectSchema<any>,
-        ),
-        parser: formattedFunction.$parseRaw,
+        schema: normalizeGeneratedJsonSchema(originalSchema),
+        parser: (rawInput: string) =>
+          formattedFunction.$parseRaw(
+            JSON.stringify(
+              sanitizeNormalizedUnionInput(
+                JSON.parse(rawInput),
+                originalSchema,
+              ),
+            ),
+          ),
       };
     }
 

--- a/packages/agents-core/src/utils/tools.ts
+++ b/packages/agents-core/src/utils/tools.ts
@@ -68,16 +68,24 @@ function buildJsonSchemaFromZod(
 function sanitizeRawToolInput(
   rawInput: string,
   originalSchema: unknown,
+  normalizedSchema: unknown,
 ): unknown {
-  return sanitizeNormalizedUnionInput(JSON.parse(rawInput), originalSchema);
+  return sanitizeNormalizedUnionInput(
+    JSON.parse(rawInput),
+    originalSchema,
+    normalizedSchema,
+  );
 }
 
 function createSanitizedToolParser(
   originalSchema: unknown,
+  normalizedSchema: unknown,
   parseSanitizedInput: (input: unknown) => unknown,
 ): (rawInput: string) => unknown {
   return (rawInput: string) =>
-    parseSanitizedInput(sanitizeRawToolInput(rawInput, originalSchema));
+    parseSanitizedInput(
+      sanitizeRawToolInput(rawInput, originalSchema, normalizedSchema),
+    );
 }
 
 function buildZodSchemaConversionError(originalError?: unknown): UserError {
@@ -144,10 +152,14 @@ export function getSchemaAndParserFromInputType<T extends ToolInputParameters>(
   if (isZodObject(inputType)) {
     const useFallback = (originalError?: unknown) => {
       const fallbackSchema = getFallbackJsonSchema(inputType, originalError);
+      const normalizedFallbackSchema =
+        normalizeGeneratedJsonSchema(fallbackSchema);
       return {
-        schema: normalizeGeneratedJsonSchema(fallbackSchema),
-        parser: createSanitizedToolParser(fallbackSchema, (sanitizedInput) =>
-          inputType.parse(sanitizedInput),
+        schema: normalizedFallbackSchema,
+        parser: createSanitizedToolParser(
+          fallbackSchema,
+          normalizedFallbackSchema,
+          (sanitizedInput) => inputType.parse(sanitizedInput),
         ),
       };
     };
@@ -171,10 +183,15 @@ export function getSchemaAndParserFromInputType<T extends ToolInputParameters>(
       if (fallbackSchema) {
         mergeJsonSchemaDescriptions(originalSchema, fallbackSchema);
       }
+      const normalizedOriginalSchema =
+        normalizeGeneratedJsonSchema(originalSchema);
       return {
-        schema: normalizeGeneratedJsonSchema(originalSchema),
-        parser: createSanitizedToolParser(originalSchema, (sanitizedInput) =>
-          formattedFunction.$parseRaw(JSON.stringify(sanitizedInput)),
+        schema: normalizedOriginalSchema,
+        parser: createSanitizedToolParser(
+          originalSchema,
+          normalizedOriginalSchema,
+          (sanitizedInput) =>
+            formattedFunction.$parseRaw(JSON.stringify(sanitizedInput)),
         ),
       };
     }

--- a/packages/agents-core/src/utils/tools.ts
+++ b/packages/agents-core/src/utils/tools.ts
@@ -65,6 +65,44 @@ function buildJsonSchemaFromZod(
   return zodJsonSchemaCompat(inputType);
 }
 
+function sanitizeRawToolInput(
+  rawInput: string,
+  originalSchema: unknown,
+): unknown {
+  return sanitizeNormalizedUnionInput(JSON.parse(rawInput), originalSchema);
+}
+
+function createSanitizedToolParser(
+  originalSchema: unknown,
+  parseSanitizedInput: (input: unknown) => unknown,
+): (rawInput: string) => unknown {
+  return (rawInput: string) =>
+    parseSanitizedInput(sanitizeRawToolInput(rawInput, originalSchema));
+}
+
+function buildZodSchemaConversionError(originalError?: unknown): UserError {
+  const errorMessage =
+    originalError instanceof Error
+      ? ` Upstream helper error: ${originalError.message}`
+      : '';
+
+  return new UserError(
+    `Unable to convert the provided Zod schema to JSON Schema. Ensure that the \`zod\` package is available at runtime or provide a JSON schema object instead.${errorMessage}`,
+  );
+}
+
+function getFallbackJsonSchema(
+  inputType: ZodObjectLike,
+  originalError?: unknown,
+): JsonObjectSchema<any> {
+  const fallbackSchema = buildJsonSchemaFromZod(inputType);
+  if (fallbackSchema) {
+    return fallbackSchema;
+  }
+
+  throw buildZodSchemaConversionError(originalError);
+}
+
 /**
  * Convert a string to a function tool name by replacing spaces with underscores and
  * non-alphanumeric characters with underscores.
@@ -105,28 +143,13 @@ export function getSchemaAndParserFromInputType<T extends ToolInputParameters>(
 
   if (isZodObject(inputType)) {
     const useFallback = (originalError?: unknown) => {
-      const fallbackSchema = buildJsonSchemaFromZod(inputType);
-      if (fallbackSchema) {
-        return {
-          schema: normalizeGeneratedJsonSchema(fallbackSchema),
-          parser: (rawInput: string) =>
-            inputType.parse(
-              sanitizeNormalizedUnionInput(
-                JSON.parse(rawInput),
-                fallbackSchema,
-              ),
-            ),
-        };
-      }
-
-      const errorMessage =
-        originalError instanceof Error
-          ? ` Upstream helper error: ${originalError.message}`
-          : '';
-
-      throw new UserError(
-        `Unable to convert the provided Zod schema to JSON Schema. Ensure that the \`zod\` package is available at runtime or provide a JSON schema object instead.${errorMessage}`,
-      );
+      const fallbackSchema = getFallbackJsonSchema(inputType, originalError);
+      return {
+        schema: normalizeGeneratedJsonSchema(fallbackSchema),
+        parser: createSanitizedToolParser(fallbackSchema, (sanitizedInput) =>
+          inputType.parse(sanitizedInput),
+        ),
+      };
     };
 
     let formattedFunction: MinimalParseableResponseTool;
@@ -150,15 +173,9 @@ export function getSchemaAndParserFromInputType<T extends ToolInputParameters>(
       }
       return {
         schema: normalizeGeneratedJsonSchema(originalSchema),
-        parser: (rawInput: string) =>
-          formattedFunction.$parseRaw(
-            JSON.stringify(
-              sanitizeNormalizedUnionInput(
-                JSON.parse(rawInput),
-                originalSchema,
-              ),
-            ),
-          ),
+        parser: createSanitizedToolParser(originalSchema, (sanitizedInput) =>
+          formattedFunction.$parseRaw(JSON.stringify(sanitizedInput)),
+        ),
       };
     }
 
@@ -188,24 +205,12 @@ export function convertAgentOutputTypeToSerializable(
       existing?: MinimalParseableTextFormat,
       originalError?: unknown,
     ): JsonSchemaDefinition => {
-      const fallbackSchema = buildJsonSchemaFromZod(outputType);
-      if (fallbackSchema) {
-        return {
-          type: existing?.type ?? 'json_schema',
-          name: existing?.name ?? 'output',
-          strict: existing?.strict ?? false,
-          schema: fallbackSchema,
-        };
-      }
-
-      const errorMessage =
-        originalError instanceof Error
-          ? ` Upstream helper error: ${originalError.message}`
-          : '';
-
-      throw new UserError(
-        `Unable to convert the provided Zod schema to JSON Schema. Ensure that the \`zod\` package is available at runtime or provide a JSON schema object instead.${errorMessage}`,
-      );
+      return {
+        type: existing?.type ?? 'json_schema',
+        name: existing?.name ?? 'output',
+        strict: existing?.strict ?? false,
+        schema: getFallbackJsonSchema(outputType, originalError),
+      };
     };
 
     let output: MinimalParseableTextFormat;

--- a/packages/agents-core/test/shims/mcp-server/streamableHttpRetry.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/streamableHttpRetry.test.ts
@@ -962,10 +962,14 @@ describe('NodeMCPServerStreamableHttp closed-session recovery', () => {
       );
       expect(sharedFailureCallCount).toBe(2);
       sharedFailuresReleased.resolve();
-      await vi.waitFor(() => {
-        expect(reconnectCallCount).toBe(1);
-        expect(MockStreamableHTTPClientTransport.instances).toHaveLength(2);
-      });
+      // CI can schedule reconnect setup noticeably later once both failures unwind.
+      await vi.waitFor(
+        () => {
+          expect(reconnectCallCount).toBe(1);
+          expect(MockStreamableHTTPClientTransport.instances).toHaveLength(2);
+        },
+        { timeout: 5_000 },
+      );
       releaseReconnect.resolve();
 
       await Promise.all([

--- a/packages/agents-core/test/utils/tools.test.ts
+++ b/packages/agents-core/test/utils/tools.test.ts
@@ -7,6 +7,80 @@ import {
 import { z } from 'zod';
 import { UserError } from '../../src/errors';
 import { JsonObjectSchema, JsonSchemaDefinitionEntry } from '../../src/types';
+import type { ZodObjectLike } from '../../src/utils/zodCompat';
+
+function buildRecurrenceSchema(zod: {
+  object: typeof z.object;
+  discriminatedUnion: typeof z.discriminatedUnion;
+  literal: typeof z.literal;
+  string: typeof z.string;
+  union: typeof z.union;
+  number: typeof z.number;
+}) {
+  return zod.object({
+    recurrence: zod.discriminatedUnion('type', [
+      zod.object({
+        type: zod.literal('once'),
+        date: zod.string(),
+      }),
+      zod.object({
+        type: zod.literal('weekly'),
+        dayOfWeek: zod.number(),
+      }),
+    ]),
+  });
+}
+
+function buildPlainUnionRecurrenceSchema(zod: {
+  object: typeof z.object;
+  literal: typeof z.literal;
+  string: typeof z.string;
+  union: typeof z.union;
+  number: typeof z.number;
+}) {
+  return zod.object({
+    recurrence: zod.union([
+      zod.object({
+        type: zod.literal('once'),
+        date: zod.string(),
+      }),
+      zod.object({
+        type: zod.literal('weekly'),
+        dayOfWeek: zod.number(),
+      }),
+    ]),
+  });
+}
+
+function expectNormalizedRecurrenceSchema(schema: JsonObjectSchema<any>) {
+  expect(schema).toMatchObject({
+    type: 'object',
+    properties: {
+      recurrence: {
+        type: 'object',
+        properties: {
+          type: {
+            type: 'string',
+            enum: ['once', 'weekly'],
+          },
+          date: {
+            type: ['string', 'null'],
+            description: 'Set to null unless type is "once".',
+          },
+          dayOfWeek: {
+            type: ['number', 'null'],
+            description: 'Set to null unless type is "weekly".',
+          },
+        },
+        required: ['type', 'date', 'dayOfWeek'],
+        additionalProperties: false,
+      },
+    },
+    required: ['recurrence'],
+    additionalProperties: false,
+  });
+  expect(schema.properties.recurrence.anyOf).toBeUndefined();
+}
 
 describe('utils/tools', () => {
   it('normalizes function tool names', () => {
@@ -85,6 +159,58 @@ describe('utils/tools', () => {
       required: 'ok',
       optional: 2,
     });
+  });
+
+  it('normalizes discriminated unions for Zod v4 tool schemas', () => {
+    const zodSchema = buildRecurrenceSchema(z);
+    const res = getSchemaAndParserFromInputType(zodSchema, 'tool');
+    const plainUnionRes = getSchemaAndParserFromInputType(
+      buildPlainUnionRecurrenceSchema(z),
+      'tool',
+    );
+
+    expectNormalizedRecurrenceSchema(res.schema);
+    expect(plainUnionRes.schema).toEqual(res.schema);
+    expect(
+      res.parser('{"recurrence":{"type":"weekly","date":null,"dayOfWeek":2}}'),
+    ).toEqual({
+      recurrence: {
+        type: 'weekly',
+        dayOfWeek: 2,
+      },
+    });
+    expect(() =>
+      res.parser('{"recurrence":{"type":"once","dayOfWeek":2}}'),
+    ).toThrow();
+  });
+
+  it('normalizes discriminated unions for Zod v3 tool schemas', async () => {
+    const z3 = (await import('zod/v3')) as unknown as {
+      z: typeof z;
+    };
+    const discriminatedSchema = buildRecurrenceSchema(z3.z);
+    const res = getSchemaAndParserFromInputType(
+      discriminatedSchema as ZodObjectLike,
+      'tool',
+    );
+    const plainUnionRes = getSchemaAndParserFromInputType(
+      buildPlainUnionRecurrenceSchema(z3.z) as ZodObjectLike,
+      'tool',
+    );
+
+    expectNormalizedRecurrenceSchema(res.schema);
+    expect(plainUnionRes.schema).toEqual(res.schema);
+    expect(
+      res.parser('{"recurrence":{"type":"weekly","date":null,"dayOfWeek":2}}'),
+    ).toEqual({
+      recurrence: {
+        type: 'weekly',
+        dayOfWeek: 2,
+      },
+    });
+    expect(() =>
+      res.parser('{"recurrence":{"type":"once","dayOfWeek":2}}'),
+    ).toThrow();
   });
 
   it('convertAgentOutputTypeToSerializable falls back when helper rejects optional fields', () => {

--- a/packages/agents-core/test/utils/tools.test.ts
+++ b/packages/agents-core/test/utils/tools.test.ts
@@ -207,12 +207,12 @@ function expectNormalizedRecurrenceSchema(schema: JsonObjectSchema<any>) {
             enum: ['once', 'weekly'],
           },
           date: {
-            type: ['string', 'null'],
-            description: 'Set to null unless type is "once".',
+            type: 'string',
+            description: 'Ignored unless type is "once".',
           },
           dayOfWeek: {
-            type: ['number', 'null'],
-            description: 'Set to null unless type is "weekly".',
+            type: 'number',
+            description: 'Ignored unless type is "weekly".',
           },
         },
         required: ['type', 'date', 'dayOfWeek'],
@@ -315,7 +315,9 @@ describe('utils/tools', () => {
     expectNormalizedRecurrenceSchema(res.schema);
     expect(plainUnionRes.schema).toEqual(res.schema);
     expect(
-      res.parser('{"recurrence":{"type":"weekly","date":null,"dayOfWeek":2}}'),
+      res.parser(
+        '{"recurrence":{"type":"weekly","date":"2026-04-01","dayOfWeek":2}}',
+      ),
     ).toEqual({
       recurrence: {
         type: 'weekly',
@@ -413,7 +415,7 @@ describe('utils/tools', () => {
     expect(recurrenceSchema.anyOf).toBeUndefined();
     expect(recurrenceSchema.properties.date).toMatchObject({
       anyOf: [{ type: 'string' }, { type: 'null' }],
-      description: 'Set to null unless type is "once".',
+      description: 'Ignored unless type is "once".',
     });
     expect(
       res.parser('{"recurrence":{"type":"weekly","date":null,"dayOfWeek":2}}'),
@@ -425,14 +427,16 @@ describe('utils/tools', () => {
     });
   });
 
-  it('strips null filler keys before parsing strict discriminated unions', () => {
+  it('strips inactive branch keys before parsing strict discriminated unions', () => {
     const res = getSchemaAndParserFromInputType(
       buildStrictRecurrenceSchema(z),
       'tool',
     );
 
     expect(
-      res.parser('{"recurrence":{"type":"weekly","date":null,"dayOfWeek":2}}'),
+      res.parser(
+        '{"recurrence":{"type":"weekly","date":"2026-04-01","dayOfWeek":2}}',
+      ),
     ).toEqual({
       recurrence: {
         type: 'weekly',
@@ -454,11 +458,12 @@ describe('utils/tools', () => {
     });
     expect(
       res.parser(
-        '{"recurrence":{"type":"weekly","date":null,"dayOfWeek":2,"meta":"x"}}',
+        '{"recurrence":{"type":"weekly","date":"2026-04-01","dayOfWeek":2,"meta":"x"}}',
       ),
     ).toEqual({
       recurrence: {
         type: 'weekly',
+        date: '2026-04-01',
         dayOfWeek: 2,
         meta: 'x',
       },
@@ -649,7 +654,9 @@ describe('utils/tools', () => {
     expectNormalizedRecurrenceSchema(res.schema);
     expect(plainUnionRes.schema).toEqual(res.schema);
     expect(
-      res.parser('{"recurrence":{"type":"weekly","date":null,"dayOfWeek":2}}'),
+      res.parser(
+        '{"recurrence":{"type":"weekly","date":"2026-04-01","dayOfWeek":2}}',
+      ),
     ).toEqual({
       recurrence: {
         type: 'weekly',

--- a/packages/agents-core/test/utils/tools.test.ts
+++ b/packages/agents-core/test/utils/tools.test.ts
@@ -121,6 +121,30 @@ function buildCatchallRecurrenceSchema(zod: {
   });
 }
 
+function buildMismatchedAdditionalPropertiesRecurrenceSchema(zod: {
+  object: typeof z.object;
+  discriminatedUnion: typeof z.discriminatedUnion;
+  literal: typeof z.literal;
+  string: typeof z.string;
+  number: typeof z.number;
+  strictObject: typeof z.strictObject;
+}) {
+  return zod.object({
+    recurrence: zod.discriminatedUnion('type', [
+      zod.strictObject({
+        type: zod.literal('once'),
+        date: zod.string(),
+      }),
+      zod
+        .object({
+          type: zod.literal('weekly'),
+          dayOfWeek: zod.number(),
+        })
+        .catchall(zod.string()),
+    ]),
+  });
+}
+
 function expectNormalizedRecurrenceSchema(schema: JsonObjectSchema<any>) {
   expect(schema).toMatchObject({
     type: 'object',
@@ -398,6 +422,22 @@ describe('utils/tools', () => {
         meta: 'x',
       },
     });
+  });
+
+  it('does not strip null filler keys for discriminated unions that were not lowered', () => {
+    const res = getSchemaAndParserFromInputType(
+      buildMismatchedAdditionalPropertiesRecurrenceSchema(z),
+      'tool',
+    );
+    const recurrenceSchema = res.schema.properties
+      .recurrence as unknown as JsonObjectSchema<any> & {
+      anyOf?: unknown;
+    };
+
+    expect(recurrenceSchema.anyOf).toBeDefined();
+    expect(() =>
+      res.parser('{"recurrence":{"type":"weekly","date":null,"dayOfWeek":2}}'),
+    ).toThrow();
   });
 
   it('ignores nested property key order when merging shared fields', () => {

--- a/packages/agents-core/test/utils/tools.test.ts
+++ b/packages/agents-core/test/utils/tools.test.ts
@@ -5,6 +5,7 @@ import {
   convertAgentOutputTypeToSerializable,
 } from '../../src/utils/tools';
 import { normalizeGeneratedJsonSchema } from '../../src/utils/normalizeGeneratedJsonSchema';
+import { sanitizeNormalizedUnionInput } from '../../src/utils/sanitizeNormalizedUnionInput';
 import { z } from 'zod';
 import { UserError } from '../../src/errors';
 import { JsonObjectSchema, JsonSchemaDefinitionEntry } from '../../src/types';
@@ -145,6 +146,55 @@ function buildMismatchedAdditionalPropertiesRecurrenceSchema(zod: {
   });
 }
 
+function buildOptionalSharedRecurrenceSchema(zod: {
+  object: typeof z.object;
+  discriminatedUnion: typeof z.discriminatedUnion;
+  literal: typeof z.literal;
+  string: typeof z.string;
+  number: typeof z.number;
+}) {
+  return zod.object({
+    recurrence: zod.discriminatedUnion('type', [
+      zod.object({
+        type: zod.literal('once'),
+        date: zod.string(),
+        note: zod.string().optional(),
+      }),
+      zod.object({
+        type: zod.literal('weekly'),
+        dayOfWeek: zod.number(),
+        note: zod.string().optional(),
+      }),
+    ]),
+  });
+}
+
+function buildNullableCatchallRecurrenceSchema(zod: {
+  object: typeof z.object;
+  discriminatedUnion: typeof z.discriminatedUnion;
+  literal: typeof z.literal;
+  string: typeof z.string;
+  number: typeof z.number;
+}) {
+  return zod.object({
+    recurrence: zod.discriminatedUnion('type', [
+      zod
+        .object({
+          type: zod.literal('once'),
+          date: zod.string(),
+        })
+        .catchall(zod.string().nullable()),
+      zod
+        .object({
+          type: zod.literal('weekly'),
+          dayOfWeek: zod.number(),
+          note: zod.string(),
+        })
+        .catchall(zod.string().nullable()),
+    ]),
+  });
+}
+
 function expectNormalizedRecurrenceSchema(schema: JsonObjectSchema<any>) {
   expect(schema).toMatchObject({
     type: 'object',
@@ -277,8 +327,8 @@ describe('utils/tools', () => {
     ).toThrow();
   });
 
-  it('preserves shared optional fields when normalizing discriminated unions', () => {
-    const normalized = normalizeGeneratedJsonSchema({
+  it('represents shared optional fields as required nullable properties in lowered unions', () => {
+    const originalSchema = {
       type: 'object',
       properties: {
         recurrence: {
@@ -322,41 +372,32 @@ describe('utils/tools', () => {
       },
       required: ['recurrence'],
       additionalProperties: false,
-    });
-
-    expect(normalized).toMatchObject({
-      type: 'object',
-      properties: {
-        recurrence: {
-          type: 'object',
-          properties: {
-            type: {
-              type: 'string',
-              enum: ['once', 'weekly'],
-            },
-            date: {
-              type: ['string', 'null'],
-              description: 'Set to null unless type is "once".',
-            },
-            dayOfWeek: {
-              type: ['number', 'null'],
-              description: 'Set to null unless type is "weekly".',
-            },
-            note: {
-              type: 'string',
-            },
-          },
-          required: ['type', 'date', 'dayOfWeek'],
-          additionalProperties: false,
-        },
-      },
-      required: ['recurrence'],
-      additionalProperties: false,
-    });
-    const recurrenceSchema = normalized.properties
+    } satisfies JsonObjectSchema<any>;
+    const normalizedSchema = normalizeGeneratedJsonSchema(originalSchema);
+    const recurrenceSchema = normalizedSchema.properties
       .recurrence as unknown as JsonObjectSchema<any>;
-    expect(recurrenceSchema.required).not.toContain('note');
-    expect(recurrenceSchema.properties.note.type).toBe('string');
+
+    expect(recurrenceSchema.properties.note).toMatchObject({
+      type: ['string', 'null'],
+      description: 'Set to null when omitted.',
+    });
+    expect(recurrenceSchema.required).toContain('note');
+    expect(
+      buildOptionalSharedRecurrenceSchema(z).parse(
+        sanitizeNormalizedUnionInput(
+          JSON.parse(
+            '{"recurrence":{"type":"weekly","note":null,"dayOfWeek":2}}',
+          ),
+          originalSchema,
+          normalizedSchema,
+        ),
+      ),
+    ).toEqual({
+      recurrence: {
+        type: 'weekly',
+        dayOfWeek: 2,
+      },
+    });
   });
 
   it('normalizes branch-only nullable fields that are already expressed with anyOf', () => {
@@ -420,6 +461,25 @@ describe('utils/tools', () => {
         type: 'weekly',
         dayOfWeek: 2,
         meta: 'x',
+      },
+    });
+  });
+
+  it('preserves valid null extras for selected variants with nullable catchall', () => {
+    const res = getSchemaAndParserFromInputType(
+      buildNullableCatchallRecurrenceSchema(z),
+      'tool',
+    );
+
+    expect(
+      res.parser(
+        '{"recurrence":{"type":"once","date":"2026-04-01","note":null}}',
+      ),
+    ).toEqual({
+      recurrence: {
+        type: 'once',
+        date: '2026-04-01',
+        note: null,
       },
     });
   });
@@ -512,6 +572,63 @@ describe('utils/tools', () => {
       },
       required: ['alpha', 'beta'],
       additionalProperties: false,
+    });
+  });
+
+  it('ignores anyOf member order when merging shared nullable fields', () => {
+    const normalized = normalizeGeneratedJsonSchema({
+      type: 'object',
+      properties: {
+        recurrence: {
+          anyOf: [
+            {
+              type: 'object',
+              properties: {
+                type: {
+                  type: 'string',
+                  const: 'once',
+                },
+                note: {
+                  anyOf: [{ type: 'string' }, { type: 'null' }],
+                },
+                date: {
+                  type: 'string',
+                },
+              },
+              required: ['type', 'note', 'date'],
+              additionalProperties: false,
+            },
+            {
+              type: 'object',
+              properties: {
+                type: {
+                  type: 'string',
+                  const: 'weekly',
+                },
+                note: {
+                  anyOf: [{ type: 'null' }, { type: 'string' }],
+                },
+                dayOfWeek: {
+                  type: 'number',
+                },
+              },
+              required: ['type', 'note', 'dayOfWeek'],
+              additionalProperties: false,
+            },
+          ],
+        },
+      },
+      required: ['recurrence'],
+      additionalProperties: false,
+    });
+    const recurrenceSchema = normalized.properties
+      .recurrence as unknown as JsonObjectSchema<any> & {
+      anyOf?: unknown;
+    };
+
+    expect(recurrenceSchema.anyOf).toBeUndefined();
+    expect(recurrenceSchema.properties.note).toEqual({
+      anyOf: [{ type: 'string' }, { type: 'null' }],
     });
   });
 

--- a/packages/agents-core/test/utils/tools.test.ts
+++ b/packages/agents-core/test/utils/tools.test.ts
@@ -122,7 +122,7 @@ function buildCatchallRecurrenceSchema(zod: {
   });
 }
 
-function buildMismatchedAdditionalPropertiesRecurrenceSchema(zod: {
+function buildExtraLiteralStrictRecurrenceSchema(zod: {
   object: typeof z.object;
   discriminatedUnion: typeof z.discriminatedUnion;
   literal: typeof z.literal;
@@ -134,14 +134,14 @@ function buildMismatchedAdditionalPropertiesRecurrenceSchema(zod: {
     recurrence: zod.discriminatedUnion('type', [
       zod.strictObject({
         type: zod.literal('once'),
+        version: zod.literal(1),
         date: zod.string(),
       }),
-      zod
-        .object({
-          type: zod.literal('weekly'),
-          dayOfWeek: zod.number(),
-        })
-        .catchall(zod.string()),
+      zod.strictObject({
+        type: zod.literal('weekly'),
+        version: zod.literal(2),
+        dayOfWeek: zod.number(),
+      }),
     ]),
   });
 }
@@ -169,7 +169,7 @@ function buildOptionalSharedRecurrenceSchema(zod: {
   });
 }
 
-function buildNullableCatchallRecurrenceSchema(zod: {
+function buildEmailCatchallRecurrenceSchema(zod: {
   object: typeof z.object;
   discriminatedUnion: typeof z.discriminatedUnion;
   literal: typeof z.literal;
@@ -183,14 +183,14 @@ function buildNullableCatchallRecurrenceSchema(zod: {
           type: zod.literal('once'),
           date: zod.string(),
         })
-        .catchall(zod.string().nullable()),
+        .catchall(zod.string().email()),
       zod
         .object({
           type: zod.literal('weekly'),
           dayOfWeek: zod.number(),
           note: zod.string(),
         })
-        .catchall(zod.string().nullable()),
+        .catchall(zod.string().email()),
     ]),
   });
 }
@@ -207,12 +207,12 @@ function expectNormalizedRecurrenceSchema(schema: JsonObjectSchema<any>) {
             enum: ['once', 'weekly'],
           },
           date: {
-            type: 'string',
-            description: 'Ignored unless type is "once".',
+            type: ['string', 'null'],
+            description: 'Set to null unless type is "once".',
           },
           dayOfWeek: {
-            type: 'number',
-            description: 'Ignored unless type is "weekly".',
+            type: ['number', 'null'],
+            description: 'Set to null unless type is "weekly".',
           },
         },
         required: ['type', 'date', 'dayOfWeek'],
@@ -315,9 +315,7 @@ describe('utils/tools', () => {
     expectNormalizedRecurrenceSchema(res.schema);
     expect(plainUnionRes.schema).toEqual(res.schema);
     expect(
-      res.parser(
-        '{"recurrence":{"type":"weekly","date":"2026-04-01","dayOfWeek":2}}',
-      ),
+      res.parser('{"recurrence":{"type":"weekly","date":null,"dayOfWeek":2}}'),
     ).toEqual({
       recurrence: {
         type: 'weekly',
@@ -415,7 +413,7 @@ describe('utils/tools', () => {
     expect(recurrenceSchema.anyOf).toBeUndefined();
     expect(recurrenceSchema.properties.date).toMatchObject({
       anyOf: [{ type: 'string' }, { type: 'null' }],
-      description: 'Ignored unless type is "once".',
+      description: 'Set to null unless type is "once".',
     });
     expect(
       res.parser('{"recurrence":{"type":"weekly","date":null,"dayOfWeek":2}}'),
@@ -445,53 +443,24 @@ describe('utils/tools', () => {
     });
   });
 
-  it('preserves merged additionalProperties for discriminated unions', () => {
-    const res = getSchemaAndParserFromInputType(
-      buildCatchallRecurrenceSchema(z),
-      'tool',
-    );
-    const recurrenceSchema = res.schema.properties
-      .recurrence as unknown as JsonObjectSchema<any>;
-
-    expect(recurrenceSchema.additionalProperties).toEqual({
-      type: 'string',
-    });
-    expect(
-      res.parser(
-        '{"recurrence":{"type":"weekly","date":"2026-04-01","dayOfWeek":2,"meta":"x"}}',
-      ),
-    ).toEqual({
-      recurrence: {
-        type: 'weekly',
-        date: '2026-04-01',
-        dayOfWeek: 2,
-        meta: 'x',
-      },
-    });
+  it('rejects discriminated unions with catchall additionalProperties as unsupported', () => {
+    expect(() =>
+      getSchemaAndParserFromInputType(buildCatchallRecurrenceSchema(z), 'tool'),
+    ).toThrow(UserError);
   });
 
-  it('preserves valid null extras for selected variants with nullable catchall', () => {
-    const res = getSchemaAndParserFromInputType(
-      buildNullableCatchallRecurrenceSchema(z),
-      'tool',
-    );
-
-    expect(
-      res.parser(
-        '{"recurrence":{"type":"once","date":"2026-04-01","note":null}}',
+  it('rejects discriminated unions with constrained catchall additionalProperties as unsupported', () => {
+    expect(() =>
+      getSchemaAndParserFromInputType(
+        buildEmailCatchallRecurrenceSchema(z),
+        'tool',
       ),
-    ).toEqual({
-      recurrence: {
-        type: 'once',
-        date: '2026-04-01',
-        note: null,
-      },
-    });
+    ).toThrow(UserError);
   });
 
   it('does not strip null filler keys for discriminated unions that were not lowered', () => {
     const res = getSchemaAndParserFromInputType(
-      buildMismatchedAdditionalPropertiesRecurrenceSchema(z),
+      buildExtraLiteralStrictRecurrenceSchema(z),
       'tool',
     );
     const recurrenceSchema = res.schema.properties
@@ -501,7 +470,9 @@ describe('utils/tools', () => {
 
     expect(recurrenceSchema.anyOf).toBeDefined();
     expect(() =>
-      res.parser('{"recurrence":{"type":"weekly","date":null,"dayOfWeek":2}}'),
+      res.parser(
+        '{"recurrence":{"type":"weekly","version":2,"date":null,"dayOfWeek":2}}',
+      ),
     ).toThrow();
   });
 
@@ -654,9 +625,7 @@ describe('utils/tools', () => {
     expectNormalizedRecurrenceSchema(res.schema);
     expect(plainUnionRes.schema).toEqual(res.schema);
     expect(
-      res.parser(
-        '{"recurrence":{"type":"weekly","date":"2026-04-01","dayOfWeek":2}}',
-      ),
+      res.parser('{"recurrence":{"type":"weekly","date":null,"dayOfWeek":2}}'),
     ).toEqual({
       recurrence: {
         type: 'weekly',

--- a/packages/agents-core/test/utils/tools.test.ts
+++ b/packages/agents-core/test/utils/tools.test.ts
@@ -53,6 +53,74 @@ function buildPlainUnionRecurrenceSchema(zod: {
   });
 }
 
+function buildStrictRecurrenceSchema(zod: {
+  object: typeof z.object;
+  discriminatedUnion: typeof z.discriminatedUnion;
+  literal: typeof z.literal;
+  string: typeof z.string;
+  number: typeof z.number;
+  strictObject: typeof z.strictObject;
+}) {
+  return zod.object({
+    recurrence: zod.discriminatedUnion('type', [
+      zod.strictObject({
+        type: zod.literal('once'),
+        date: zod.string(),
+      }),
+      zod.strictObject({
+        type: zod.literal('weekly'),
+        dayOfWeek: zod.number(),
+      }),
+    ]),
+  });
+}
+
+function buildNullableRecurrenceSchema(zod: {
+  object: typeof z.object;
+  discriminatedUnion: typeof z.discriminatedUnion;
+  literal: typeof z.literal;
+  string: typeof z.string;
+  number: typeof z.number;
+}) {
+  return zod.object({
+    recurrence: zod.discriminatedUnion('type', [
+      zod.object({
+        type: zod.literal('once'),
+        date: zod.string().nullable(),
+      }),
+      zod.object({
+        type: zod.literal('weekly'),
+        dayOfWeek: zod.number(),
+      }),
+    ]),
+  });
+}
+
+function buildCatchallRecurrenceSchema(zod: {
+  object: typeof z.object;
+  discriminatedUnion: typeof z.discriminatedUnion;
+  literal: typeof z.literal;
+  string: typeof z.string;
+  number: typeof z.number;
+}) {
+  return zod.object({
+    recurrence: zod.discriminatedUnion('type', [
+      zod
+        .object({
+          type: zod.literal('once'),
+          date: zod.string(),
+        })
+        .catchall(zod.string()),
+      zod
+        .object({
+          type: zod.literal('weekly'),
+          dayOfWeek: zod.number(),
+        })
+        .catchall(zod.string()),
+    ]),
+  });
+}
+
 function expectNormalizedRecurrenceSchema(schema: JsonObjectSchema<any>) {
   expect(schema).toMatchObject({
     type: 'object',
@@ -265,6 +333,146 @@ describe('utils/tools', () => {
       .recurrence as unknown as JsonObjectSchema<any>;
     expect(recurrenceSchema.required).not.toContain('note');
     expect(recurrenceSchema.properties.note.type).toBe('string');
+  });
+
+  it('normalizes branch-only nullable fields that are already expressed with anyOf', () => {
+    const res = getSchemaAndParserFromInputType(
+      buildNullableRecurrenceSchema(z),
+      'tool',
+    );
+    const recurrenceSchema = res.schema.properties
+      .recurrence as unknown as JsonObjectSchema<any> & {
+      anyOf?: unknown;
+    };
+
+    expect(recurrenceSchema.anyOf).toBeUndefined();
+    expect(recurrenceSchema.properties.date).toMatchObject({
+      anyOf: [{ type: 'string' }, { type: 'null' }],
+      description: 'Set to null unless type is "once".',
+    });
+    expect(
+      res.parser('{"recurrence":{"type":"weekly","date":null,"dayOfWeek":2}}'),
+    ).toEqual({
+      recurrence: {
+        type: 'weekly',
+        dayOfWeek: 2,
+      },
+    });
+  });
+
+  it('strips null filler keys before parsing strict discriminated unions', () => {
+    const res = getSchemaAndParserFromInputType(
+      buildStrictRecurrenceSchema(z),
+      'tool',
+    );
+
+    expect(
+      res.parser('{"recurrence":{"type":"weekly","date":null,"dayOfWeek":2}}'),
+    ).toEqual({
+      recurrence: {
+        type: 'weekly',
+        dayOfWeek: 2,
+      },
+    });
+  });
+
+  it('preserves merged additionalProperties for discriminated unions', () => {
+    const res = getSchemaAndParserFromInputType(
+      buildCatchallRecurrenceSchema(z),
+      'tool',
+    );
+    const recurrenceSchema = res.schema.properties
+      .recurrence as unknown as JsonObjectSchema<any>;
+
+    expect(recurrenceSchema.additionalProperties).toEqual({
+      type: 'string',
+    });
+    expect(
+      res.parser(
+        '{"recurrence":{"type":"weekly","date":null,"dayOfWeek":2,"meta":"x"}}',
+      ),
+    ).toEqual({
+      recurrence: {
+        type: 'weekly',
+        dayOfWeek: 2,
+        meta: 'x',
+      },
+    });
+  });
+
+  it('ignores nested property key order when merging shared fields', () => {
+    const normalized = normalizeGeneratedJsonSchema({
+      type: 'object',
+      properties: {
+        recurrence: {
+          anyOf: [
+            {
+              type: 'object',
+              properties: {
+                type: {
+                  type: 'string',
+                  const: 'once',
+                },
+                config: {
+                  type: 'object',
+                  properties: {
+                    alpha: { type: 'string' },
+                    beta: { type: 'number' },
+                  },
+                  required: ['alpha', 'beta'],
+                  additionalProperties: false,
+                },
+                date: {
+                  type: 'string',
+                },
+              },
+              required: ['type', 'config', 'date'],
+              additionalProperties: false,
+            },
+            {
+              type: 'object',
+              properties: {
+                type: {
+                  type: 'string',
+                  const: 'weekly',
+                },
+                config: {
+                  type: 'object',
+                  properties: {
+                    beta: { type: 'number' },
+                    alpha: { type: 'string' },
+                  },
+                  required: ['beta', 'alpha'],
+                  additionalProperties: false,
+                },
+                dayOfWeek: {
+                  type: 'number',
+                },
+              },
+              required: ['type', 'config', 'dayOfWeek'],
+              additionalProperties: false,
+            },
+          ],
+        },
+      },
+      required: ['recurrence'],
+      additionalProperties: false,
+    });
+    const recurrenceSchema = normalized.properties
+      .recurrence as unknown as JsonObjectSchema<any> & {
+      anyOf?: unknown;
+    };
+
+    expect(recurrenceSchema.anyOf).toBeUndefined();
+    expect(recurrenceSchema.properties.config).toMatchObject({
+      type: 'object',
+      properties: {
+        alpha: { type: 'string' },
+        beta: { type: 'number' },
+      },
+      required: ['alpha', 'beta'],
+      additionalProperties: false,
+    });
   });
 
   it('normalizes discriminated unions for Zod v3 tool schemas', async () => {

--- a/packages/agents-core/test/utils/tools.test.ts
+++ b/packages/agents-core/test/utils/tools.test.ts
@@ -4,6 +4,7 @@ import {
   getSchemaAndParserFromInputType,
   convertAgentOutputTypeToSerializable,
 } from '../../src/utils/tools';
+import { normalizeGeneratedJsonSchema } from '../../src/utils/normalizeGeneratedJsonSchema';
 import { z } from 'zod';
 import { UserError } from '../../src/errors';
 import { JsonObjectSchema, JsonSchemaDefinitionEntry } from '../../src/types';
@@ -182,6 +183,88 @@ describe('utils/tools', () => {
     expect(() =>
       res.parser('{"recurrence":{"type":"once","dayOfWeek":2}}'),
     ).toThrow();
+  });
+
+  it('preserves shared optional fields when normalizing discriminated unions', () => {
+    const normalized = normalizeGeneratedJsonSchema({
+      type: 'object',
+      properties: {
+        recurrence: {
+          anyOf: [
+            {
+              type: 'object',
+              properties: {
+                type: {
+                  type: 'string',
+                  const: 'once',
+                },
+                date: {
+                  type: 'string',
+                },
+                note: {
+                  type: 'string',
+                },
+              },
+              required: ['type', 'date'],
+              additionalProperties: false,
+            },
+            {
+              type: 'object',
+              properties: {
+                type: {
+                  type: 'string',
+                  const: 'weekly',
+                },
+                dayOfWeek: {
+                  type: 'number',
+                },
+                note: {
+                  type: 'string',
+                },
+              },
+              required: ['type', 'dayOfWeek'],
+              additionalProperties: false,
+            },
+          ],
+        },
+      },
+      required: ['recurrence'],
+      additionalProperties: false,
+    });
+
+    expect(normalized).toMatchObject({
+      type: 'object',
+      properties: {
+        recurrence: {
+          type: 'object',
+          properties: {
+            type: {
+              type: 'string',
+              enum: ['once', 'weekly'],
+            },
+            date: {
+              type: ['string', 'null'],
+              description: 'Set to null unless type is "once".',
+            },
+            dayOfWeek: {
+              type: ['number', 'null'],
+              description: 'Set to null unless type is "weekly".',
+            },
+            note: {
+              type: 'string',
+            },
+          },
+          required: ['type', 'date', 'dayOfWeek'],
+          additionalProperties: false,
+        },
+      },
+      required: ['recurrence'],
+      additionalProperties: false,
+    });
+    const recurrenceSchema = normalized.properties
+      .recurrence as unknown as JsonObjectSchema<any>;
+    expect(recurrenceSchema.required).not.toContain('note');
+    expect(recurrenceSchema.properties.note.type).toBe('string');
   });
 
   it('normalizes discriminated unions for Zod v3 tool schemas', async () => {

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -12,11 +12,13 @@ import {
   Runner,
   setDefaultModelProvider,
   setTracingDisabled,
+  tool,
   withTrace,
   type ResponseStreamEvent,
   Span,
 } from '@openai/agents-core';
 import type { ResponseStreamEvent as OpenAIResponseStreamEvent } from 'openai/resources/responses/responses';
+import { z } from 'zod';
 
 describe('OpenAIResponsesModel', () => {
   beforeAll(() => {
@@ -1629,6 +1631,86 @@ describe('OpenAIResponsesModel', () => {
         },
         {
           type: 'tool_search',
+        },
+      ]);
+    });
+  });
+
+  it('passes normalized discriminated union schemas to Responses function tools', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-normalized-discriminated-union',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+      const recurrenceTool = tool({
+        name: 'plan_recurrence',
+        description: 'Plan a recurrence rule.',
+        parameters: z.object({
+          recurrence: z.discriminatedUnion('type', [
+            z.object({
+              type: z.literal('once'),
+              date: z.string(),
+            }),
+            z.object({
+              type: z.literal('weekly'),
+              dayOfWeek: z.number(),
+            }),
+          ]),
+        }),
+        execute: async () => 'ok',
+      });
+
+      await model.getResponse({
+        systemInstructions: undefined,
+        input: 'plan the recurrence',
+        modelSettings: {},
+        tools: [recurrenceTool],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      } as any);
+
+      const [args] = createMock.mock.calls[0];
+      expect(args.tools).toEqual([
+        {
+          type: 'function',
+          name: 'plan_recurrence',
+          description: 'Plan a recurrence rule.',
+          parameters: {
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            type: 'object',
+            properties: {
+              recurrence: {
+                type: 'object',
+                properties: {
+                  type: {
+                    type: 'string',
+                    enum: ['once', 'weekly'],
+                  },
+                  date: {
+                    type: ['string', 'null'],
+                    description: 'Set to null unless type is "once".',
+                  },
+                  dayOfWeek: {
+                    type: ['number', 'null'],
+                    description: 'Set to null unless type is "weekly".',
+                  },
+                },
+                required: ['type', 'date', 'dayOfWeek'],
+                additionalProperties: false,
+              },
+            },
+            required: ['recurrence'],
+            additionalProperties: false,
+          },
+          strict: true,
         },
       ]);
     });

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -1695,12 +1695,12 @@ describe('OpenAIResponsesModel', () => {
                     enum: ['once', 'weekly'],
                   },
                   date: {
-                    type: ['string', 'null'],
-                    description: 'Set to null unless type is "once".',
+                    type: 'string',
+                    description: 'Ignored unless type is "once".',
                   },
                   dayOfWeek: {
-                    type: ['number', 'null'],
-                    description: 'Set to null unless type is "weekly".',
+                    type: 'number',
+                    description: 'Ignored unless type is "weekly".',
                   },
                 },
                 required: ['type', 'date', 'dayOfWeek'],
@@ -1779,12 +1779,12 @@ describe('OpenAIResponsesModel', () => {
                     enum: ['once', 'weekly'],
                   },
                   date: {
-                    type: ['string', 'null'],
-                    description: 'Set to null unless type is "once".',
+                    type: 'string',
+                    description: 'Ignored unless type is "once".',
                   },
                   dayOfWeek: {
-                    type: ['number', 'null'],
-                    description: 'Set to null unless type is "weekly".',
+                    type: 'number',
+                    description: 'Ignored unless type is "weekly".',
                   },
                 },
                 required: ['type', 'date', 'dayOfWeek'],

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -1716,6 +1716,92 @@ describe('OpenAIResponsesModel', () => {
     });
   });
 
+  it('preserves merged additionalProperties in normalized discriminated union tool schemas', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-normalized-discriminated-union-catchall',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
+      const recurrenceTool = tool({
+        name: 'plan_recurrence',
+        description: 'Plan a recurrence rule.',
+        parameters: z.object({
+          recurrence: z.discriminatedUnion('type', [
+            z
+              .object({
+                type: z.literal('once'),
+                date: z.string(),
+              })
+              .catchall(z.string()),
+            z
+              .object({
+                type: z.literal('weekly'),
+                dayOfWeek: z.number(),
+              })
+              .catchall(z.string()),
+          ]),
+        }),
+        execute: async () => 'ok',
+      });
+
+      await model.getResponse({
+        systemInstructions: undefined,
+        input: 'plan the recurrence',
+        modelSettings: {},
+        tools: [recurrenceTool],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      } as any);
+
+      const [args] = createMock.mock.calls[0];
+      expect(args.tools).toEqual([
+        {
+          type: 'function',
+          name: 'plan_recurrence',
+          description: 'Plan a recurrence rule.',
+          parameters: {
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            type: 'object',
+            properties: {
+              recurrence: {
+                type: 'object',
+                properties: {
+                  type: {
+                    type: 'string',
+                    enum: ['once', 'weekly'],
+                  },
+                  date: {
+                    type: ['string', 'null'],
+                    description: 'Set to null unless type is "once".',
+                  },
+                  dayOfWeek: {
+                    type: ['number', 'null'],
+                    description: 'Set to null unless type is "weekly".',
+                  },
+                },
+                required: ['type', 'date', 'dayOfWeek'],
+                additionalProperties: {
+                  type: 'string',
+                },
+              },
+            },
+            required: ['recurrence'],
+            additionalProperties: false,
+          },
+          strict: true,
+        },
+      ]);
+    });
+  });
+
   it('rejects deferLoading without toolSearchTool', async () => {
     await withTrace('test', async () => {
       const fakeResponse = {

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -13,6 +13,7 @@ import {
   setDefaultModelProvider,
   setTracingDisabled,
   tool,
+  UserError,
   withTrace,
   type ResponseStreamEvent,
   Span,
@@ -1695,12 +1696,12 @@ describe('OpenAIResponsesModel', () => {
                     enum: ['once', 'weekly'],
                   },
                   date: {
-                    type: 'string',
-                    description: 'Ignored unless type is "once".',
+                    type: ['string', 'null'],
+                    description: 'Set to null unless type is "once".',
                   },
                   dayOfWeek: {
-                    type: 'number',
-                    description: 'Ignored unless type is "weekly".',
+                    type: ['number', 'null'],
+                    description: 'Set to null unless type is "weekly".',
                   },
                 },
                 required: ['type', 'date', 'dayOfWeek'],
@@ -1716,7 +1717,7 @@ describe('OpenAIResponsesModel', () => {
     });
   });
 
-  it('preserves merged additionalProperties in normalized discriminated union tool schemas', async () => {
+  it('rejects discriminated union tool schemas with catchall additionalProperties before sending the request', async () => {
     await withTrace('test', async () => {
       const fakeResponse = {
         id: 'res-normalized-discriminated-union-catchall',
@@ -1724,81 +1725,31 @@ describe('OpenAIResponsesModel', () => {
         output: [],
       };
       const createMock = vi.fn().mockResolvedValue(fakeResponse);
-      const fakeClient = {
-        responses: { create: createMock },
-      } as unknown as OpenAI;
-      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.2');
-      const recurrenceTool = tool({
-        name: 'plan_recurrence',
-        description: 'Plan a recurrence rule.',
-        parameters: z.object({
-          recurrence: z.discriminatedUnion('type', [
-            z
-              .object({
-                type: z.literal('once'),
-                date: z.string(),
-              })
-              .catchall(z.string()),
-            z
-              .object({
-                type: z.literal('weekly'),
-                dayOfWeek: z.number(),
-              })
-              .catchall(z.string()),
-          ]),
-        }),
-        execute: async () => 'ok',
-      });
 
-      await model.getResponse({
-        systemInstructions: undefined,
-        input: 'plan the recurrence',
-        modelSettings: {},
-        tools: [recurrenceTool],
-        outputType: 'text',
-        handoffs: [],
-        tracing: false,
-        signal: undefined,
-      } as any);
-
-      const [args] = createMock.mock.calls[0];
-      expect(args.tools).toEqual([
-        {
-          type: 'function',
+      expect(() =>
+        tool({
           name: 'plan_recurrence',
           description: 'Plan a recurrence rule.',
-          parameters: {
-            $schema: 'http://json-schema.org/draft-07/schema#',
-            type: 'object',
-            properties: {
-              recurrence: {
-                type: 'object',
-                properties: {
-                  type: {
-                    type: 'string',
-                    enum: ['once', 'weekly'],
-                  },
-                  date: {
-                    type: 'string',
-                    description: 'Ignored unless type is "once".',
-                  },
-                  dayOfWeek: {
-                    type: 'number',
-                    description: 'Ignored unless type is "weekly".',
-                  },
-                },
-                required: ['type', 'date', 'dayOfWeek'],
-                additionalProperties: {
-                  type: 'string',
-                },
-              },
-            },
-            required: ['recurrence'],
-            additionalProperties: false,
-          },
-          strict: true,
-        },
-      ]);
+          parameters: z.object({
+            recurrence: z.discriminatedUnion('type', [
+              z
+                .object({
+                  type: z.literal('once'),
+                  date: z.string(),
+                })
+                .catchall(z.string()),
+              z
+                .object({
+                  type: z.literal('weekly'),
+                  dayOfWeek: z.number(),
+                })
+                .catchall(z.string()),
+            ]),
+          }),
+          execute: async () => 'ok',
+        }),
+      ).toThrow(UserError);
+      expect(createMock).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
This pull request resolves #1138 by normalizing Zod-generated function tool schemas before they are sent to the Responses API. The SDK currently emits nested `anyOf` object unions for both `z.discriminatedUnion()` and equivalent `z.union()` inputs; this change lowers the strict object-union cases with a shared literal discriminator into a single strict object schema with nullable branch-specific fields so tool schemas remain acceptable to strict Responses validation.

The implementation is intentionally narrow: it only rewrites object unions that have a clear shared discriminator and otherwise leaves unsupported union shapes unchanged. The update also adds regression coverage for Zod v3 and v4 schema generation plus an OpenAI Responses request-payload assertion so the normalized schema shape stays pinned end to end.