### PR TITLE
fix(openai): forward external web access for web search tools

### DIFF
--- a/.changeset/bright-donuts-hang.md
+++ b/.changeset/bright-donuts-hang.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+feat: add external web access control for web search tools

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -1514,13 +1514,20 @@ function converTool<_TContext = unknown>(
     };
   } else if (tool.type === 'hosted_tool') {
     if (tool.providerData?.type === 'web_search') {
+      const webSearchTool: OpenAI.Responses.WebSearchTool & {
+        external_web_access?: boolean;
+      } = {
+        type: 'web_search',
+        user_location: tool.providerData.user_location,
+        filters: tool.providerData.filters,
+        search_context_size: tool.providerData.search_context_size,
+      };
+      if (tool.providerData.external_web_access !== undefined) {
+        webSearchTool.external_web_access =
+          tool.providerData.external_web_access;
+      }
       return {
-        tool: {
-          type: 'web_search',
-          user_location: tool.providerData.user_location,
-          filters: tool.providerData.filters,
-          search_context_size: tool.providerData.search_context_size,
-        },
+        tool: webSearchTool,
         include: undefined,
       };
     } else if (tool.providerData?.type === 'web_search_preview') {

--- a/packages/agents-openai/src/tools.ts
+++ b/packages/agents-openai/src/tools.ts
@@ -55,6 +55,12 @@ export type WebSearchTool = {
    * search. One of `low`, `medium`, or `high`. `medium` is the default.
    */
   searchContextSize: 'low' | 'medium' | 'high';
+
+  /**
+   * Whether the tool may fetch live internet content. When omitted, the API
+   * default is used.
+   */
+  externalWebAccess?: boolean;
 };
 
 /**
@@ -74,6 +80,9 @@ export function webSearchTool(
       : undefined,
     search_context_size: options.searchContextSize ?? 'medium',
   };
+  if (options.externalWebAccess !== undefined) {
+    providerData.external_web_access = options.externalWebAccess;
+  }
   return {
     type: 'hosted_tool',
     name: options.name ?? 'web_search',

--- a/packages/agents-openai/src/types/providerData.ts
+++ b/packages/agents-openai/src/types/providerData.ts
@@ -3,6 +3,8 @@ import OpenAI from 'openai';
 export type WebSearchTool = Omit<OpenAI.Responses.WebSearchTool, 'type'> & {
   type: 'web_search';
   name: 'web_search' | 'web_search_preview' | (string & {});
+  // The Responses API supports this field, but openai-node typings do not expose it yet.
+  external_web_access?: boolean;
 };
 
 export type FileSearchTool = Omit<OpenAI.Responses.FileSearchTool, 'type'> & {

--- a/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
@@ -511,6 +511,24 @@ describe('converTool', () => {
     });
   });
 
+  it('preserves explicit false external web access on web search tools', () => {
+    const web = converTool({
+      type: 'hosted_tool',
+      providerData: {
+        type: 'web_search',
+        search_context_size: 'medium',
+        external_web_access: false,
+      },
+    } as any);
+    expect(web.tool).toEqual({
+      type: 'web_search',
+      user_location: undefined,
+      filters: undefined,
+      search_context_size: 'medium',
+      external_web_access: false,
+    });
+  });
+
   it('throws on unsupported tool', () => {
     expect(() => converTool({ type: 'other' } as any)).toThrow();
   });

--- a/packages/agents-openai/test/tools.test.ts
+++ b/packages/agents-openai/test/tools.test.ts
@@ -17,6 +17,22 @@ describe('Tool', () => {
     expect(t.name).toBe('web_search');
   });
 
+  it('webSearchTool preserves explicit false external web access', () => {
+    const t = webSearchTool({
+      externalWebAccess: false,
+    });
+    expect(t).toMatchObject({
+      type: 'hosted_tool',
+      name: 'web_search',
+      providerData: {
+        type: 'web_search',
+        name: 'web_search',
+        search_context_size: 'medium',
+        external_web_access: false,
+      },
+    });
+  });
+
   it('fileSearchTool', () => {
     const t = fileSearchTool(['test'], {});
     expect(t).toBeDefined();


### PR DESCRIPTION
This pull request fixes a gap in the web search tool wiring where `external_web_access` could not be configured or forwarded to the Responses API. It adds `externalWebAccess` to `webSearchTool`, preserves explicit `false` values through provider data and Responses tool conversion, and adds regression tests for the public helper and conversion path. The current `openai` npm typings do not expose this field yet, so the SDK keeps the extension localized to the internal provider-data type until upstream typings catch up.

see also: https://github.com/openai/openai-agents-python/pull/2786