### PR TITLE
 docs(agents-extensions): sync AI SDK docs and examples

### DIFF
--- a/docs/src/content/docs/extensions/ai-sdk.mdx
+++ b/docs/src/content/docs/extensions/ai-sdk.mdx
@@ -105,6 +105,7 @@ There are two related integrations in `@openai/agents-extensions`:
 - The `@openai/agents-extensions/ai-sdk` adapter is still in beta, so it is worth testing carefully with your chosen provider, especially smaller ones.
 - If you are using OpenAI models, prefer the default OpenAI model provider instead of this adapter.
 - Supported AI SDK providers must expose `specificationVersion` `v2` or `v3`. If you need the older v1 provider style, copy the module from [examples/ai-sdk-v1](https://github.com/openai/openai-agents-js/tree/main/examples/ai-sdk-v1) into your project.
+- Computer tools require display metadata when used through this adapter. Make sure the tool includes both `environment` and `dimensions` metadata.
 - Deferred Responses tool-loading flows are not supported here. That includes `toolNamespace()`, function tools with `deferLoading: true`, and `toolSearchTool()`. If you need tool search, use an OpenAI Responses model directly. See the [Tools guide](/openai-agents-js/guides/tools#deferred-tool-loading-with-tool-search) and [Models guide](/openai-agents-js/guides/models#responses-only-deferred-tool-loading).
 
 ## AI SDK UI stream helpers
@@ -117,6 +118,12 @@ There are two related integrations in `@openai/agents-extensions`:
 Both helpers accept a `StreamedRunResult`, stream-like source, or compatible wrapper object and return a `Response` with streaming-friendly headers.
 
 Use `createAiSdkUiMessageStreamResponse(...)` when your UI needs structured chunks such as tool calls or reasoning parts. Use `createAiSdkTextStreamResponse(...)` when you only want plain text.
+
+Both helpers also accept optional response settings through `options`:
+
+- `headers`: additional response headers to merge into the streaming response.
+- `status`: the HTTP status code for the returned `Response`.
+- `statusText`: the HTTP status text for the returned `Response`.
 
 Example Next.js route for UI message streaming:
 

--- a/examples/ai-sdk-ui/README.md
+++ b/examples/ai-sdk-ui/README.md
@@ -1,7 +1,6 @@
 # AI SDK UI Stream Example
 
-This example shows how to convert an Agents SDK streaming run into responses that
-are compatible with the AI SDK UI data stream and text stream protocols.
+This example shows how to convert an Agents SDK streaming run into responses that are compatible with the AI SDK UI data stream and text stream protocols.
 
 ## Run the Next.js chat UI
 
@@ -9,8 +8,7 @@ are compatible with the AI SDK UI data stream and text stream protocols.
 pnpm -F ai-sdk-ui dev
 ```
 
-Open http://localhost:3000 for the UI message stream (tool calls and reasoning
-parts are rendered). Open http://localhost:3000/text for the text-only stream.
+Open http://localhost:3000 for the UI message stream (tool calls and reasoning parts are rendered). Open http://localhost:3000/text for the text-only stream.
 
 ## Run the Node.js text stream samples
 
@@ -19,14 +17,13 @@ pnpm -F ai-sdk-ui start:script-ai-sdk
 pnpm -F ai-sdk-ui start:script-simple
 ```
 
-`ai-sdk.ts` uses `streamText` from the AI SDK, while `simple.ts` streams an
-Agents SDK run through `createAiSdkTextStreamResponse`.
+`ai-sdk.ts` uses `streamText` from the AI SDK, while `simple.ts` streams an Agents SDK run through `createAiSdkTextStreamResponse`.
 
 ## Next.js route examples
 
 ```ts
 import { Agent, run } from '@openai/agents';
-import { createAiSdkUiMessageStreamResponse } from '@openai/agents-extensions';
+import { createAiSdkUiMessageStreamResponse } from '@openai/agents-extensions/ai-sdk-ui';
 
 export async function POST() {
   const agent = new Agent({
@@ -41,7 +38,7 @@ export async function POST() {
 
 ```ts
 import { Agent, run } from '@openai/agents';
-import { createAiSdkTextStreamResponse } from '@openai/agents-extensions';
+import { createAiSdkTextStreamResponse } from '@openai/agents-extensions/ai-sdk-ui';
 
 export async function POST() {
   const agent = new Agent({

--- a/examples/ai-sdk-v1/README.md
+++ b/examples/ai-sdk-v1/README.md
@@ -2,9 +2,14 @@
 
 This example shows how to run the Agents SDK with a model provided by the [AI SDK](https://www.npmjs.com/package/@ai-sdk/openai).
 
-The [ai-sdk-model.ts](./ai-sdk-model.ts) script:
+This example contains:
 
-- Wraps the AI SDK `openai` provider with `aisdk` from `@openai/agents-extensions`.
+- [`index.ts`](./index.ts), the runnable example entrypoint.
+- [`ai-sdk-v1.ts`](./ai-sdk-v1.ts), the local AI SDK v1 adapter implementation that you can copy into your own project if you still need the older provider interface.
+
+The example:
+
+- Wraps the AI SDK `openai` provider with `aisdk` from `./ai-sdk-v1`.
 - Creates a simple `get_weather` tool that returns a mock weather string.
 - Defines a data agent that uses this model and tool.
 - Runs a parent agent that hands off to the data agent to answer a weather question.

--- a/examples/tools/README.md
+++ b/examples/tools/README.md
@@ -43,13 +43,13 @@ These examples demonstrate the hosted tools provided by the Agents SDK.
 - `code-interpreter.ts` – Demonstrates `codeInterpreterTool` for code execution.
 
   ```bash
-  pnpm examples:tools-code-interpreter
+  pnpm -F tools start:code-interpreter
   ```
 
 - `image-generation.ts` – Demonstrates `imageGenerationTool` for image generation.
 
   ```bash
-  pnpm examples:tools-image-generation
+  pnpm -F tools start:image-generation
   ```
 
 - `local-shell.ts` – Demonstrates `shellTool` with a local shell environment.


### PR DESCRIPTION
 ## Summary

  Sync the AI SDK / AI SDK UI documentation and example READMEs in `agents-extensions` with the current
  package exports and adapter behavior.

  ## Changes

  - fix outdated top-level `@openai/agents-extensions` imports in `examples/ai-sdk-ui/README.md`
  - fix the incorrect file reference in `examples/ai-sdk-v1/README.md`
  - document `headers`, `status`, and `statusText` for AI SDK UI stream helpers
  - document the computer tool metadata requirement for the AI SDK adapter

  ## Validation

  - ran `pnpm -F docs-code build-check`
  - ran the full verification stack:
    - `pnpm i`
    - `pnpm build`
    - `pnpm -r build-check`
    - `pnpm -r -F "@openai/*" dist:check`
    - `pnpm lint`
    - `pnpm test`
