### PR TITLE
test(agents-extensions): add AI SDK UI boundary coverage

### DIFF
--- a/.changeset/old-camels-fly.md
+++ b/.changeset/old-camels-fly.md
@@ -1,0 +1,3 @@
+"@openai/agents-extensions": patch
+
+test: add AI SDK UI boundary coverage

--- a/.changeset/old-camels-fly.md
+++ b/.changeset/old-camels-fly.md
@@ -1,3 +1,5 @@
+---
 "@openai/agents-extensions": patch
+---
 
 test: add AI SDK UI boundary coverage

--- a/packages/agents-extensions/test/ai-sdk-ui/textStream.test.ts
+++ b/packages/agents-extensions/test/ai-sdk-ui/textStream.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { ReadableStream as NodeReadableStream } from 'node:stream/web';
 import { createAiSdkTextStreamResponse } from '../../src/ai-sdk-ui/index';
 
@@ -33,6 +33,10 @@ async function readResponseText(response: Response): Promise<string> {
   return output;
 }
 
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 describe('createAiSdkTextStreamResponse', () => {
   test('streams text and applies default headers', async () => {
     const response = createAiSdkTextStreamResponse(
@@ -62,5 +66,23 @@ describe('createAiSdkTextStreamResponse', () => {
     expect(response.status).toBe(201);
     expect(response.headers.get('cache-control')).toBe('no-store');
     await expect(readResponseText(response)).resolves.toBe('One more');
+  });
+
+  test('preserves explicit headers and encodes without TextEncoderStream', async () => {
+    vi.stubGlobal('TextEncoderStream', undefined);
+
+    const response = createAiSdkTextStreamResponse(
+      stringStream(['Edge case']),
+      {
+        headers: [
+          ['Content-Type', 'text/custom'],
+          ['cache-control', 'max-age=60'],
+        ],
+      },
+    );
+
+    expect(response.headers.get('content-type')).toBe('text/custom');
+    expect(response.headers.get('cache-control')).toBe('max-age=60');
+    await expect(readResponseText(response)).resolves.toBe('Edge case');
   });
 });

--- a/packages/agents-extensions/test/ai-sdk-ui/uiMessageStream.test.ts
+++ b/packages/agents-extensions/test/ai-sdk-ui/uiMessageStream.test.ts
@@ -5,6 +5,7 @@ import {
   RunRawModelStreamEvent,
   RunMessageOutputItem,
   RunReasoningItem,
+  RunToolApprovalItem,
   RunToolCallItem,
   RunToolCallOutputItem,
   RunToolSearchCallItem,
@@ -984,5 +985,162 @@ describe('createAiSdkUiMessageStreamResponse', () => {
 
     expect(deltas).toHaveLength(1);
     expect(deltas[0]).toMatchObject({ delta: 'Hello again' });
+  });
+
+  test('falls back for invalid JSON arguments and maps non-function tool inputs', async () => {
+    const agent = new Agent({ name: 'Test Agent' });
+
+    const invalidFunctionCall = new RunToolCallItem(
+      {
+        type: 'function_call',
+        name: 'broken_json',
+        arguments: '{not valid json',
+      } as any,
+      agent,
+    );
+    const computerCall = new RunToolCallItem(
+      {
+        type: 'computer_call',
+        callId: 'computer-call-1',
+        action: { type: 'click', x: 1, y: 2, button: 'left' },
+      } as any,
+      agent,
+    );
+    const shellCall = new RunToolCallItem(
+      {
+        type: 'shell_call',
+        callId: 'shell-call-1',
+        action: {
+          command: 'pwd',
+          cwd: '/tmp',
+        },
+      } as any,
+      agent,
+    );
+    const applyPatchCall = new RunToolCallItem(
+      {
+        type: 'apply_patch_call',
+        callId: 'apply-patch-call-1',
+        operation: '*** Begin Patch\n*** End Patch\n',
+      } as any,
+      agent,
+    );
+
+    const events = (async function* () {
+      yield new RunItemStreamEvent('tool_called', invalidFunctionCall);
+      yield new RunItemStreamEvent('tool_called', computerCall);
+      yield new RunItemStreamEvent('tool_called', shellCall);
+      yield new RunItemStreamEvent('tool_called', applyPatchCall);
+    })();
+
+    const response = createAiSdkUiMessageStreamResponse(events);
+    const chunks = await readUiMessageChunks(response);
+
+    expect(
+      chunks.filter((chunk) => chunk.type === 'tool-input-available'),
+    ).toMatchObject([
+      {
+        toolCallId: expect.stringMatching(/^broken_json-call-/),
+        toolName: 'broken_json',
+        input: { raw: '{not valid json' },
+        dynamic: true,
+      },
+      {
+        toolCallId: 'computer-call-1',
+        toolName: 'computer_call',
+        input: { type: 'click', x: 1, y: 2, button: 'left' },
+        dynamic: true,
+      },
+      {
+        toolCallId: 'shell-call-1',
+        toolName: 'shell_call',
+        input: {
+          command: 'pwd',
+          cwd: '/tmp',
+        },
+        dynamic: true,
+      },
+      {
+        toolCallId: 'apply-patch-call-1',
+        toolName: 'apply_patch_call',
+        input: '*** Begin Patch\n*** End Patch\n',
+        dynamic: true,
+      },
+    ]);
+  });
+
+  test('emits approval requests with generated fallback ids', async () => {
+    const agent = new Agent({ name: 'Test Agent' });
+
+    const approvalItem = new RunToolApprovalItem(
+      {
+        type: 'shell_call',
+        action: {
+          command: 'rm -rf /tmp/nope',
+        },
+      } as any,
+      agent,
+      'shell',
+    );
+
+    const events = (async function* () {
+      yield new RunItemStreamEvent('tool_approval_requested', approvalItem);
+    })();
+
+    const response = createAiSdkUiMessageStreamResponse(events);
+    const chunks = await readUiMessageChunks(response);
+    const approvalRequest = chunks.find(
+      (chunk) => chunk.type === 'tool-approval-request',
+    );
+
+    expect(approvalRequest).toMatchObject({
+      type: 'tool-approval-request',
+      toolCallId: expect.stringMatching(/^shell-call-/),
+      approvalId: expect.stringMatching(/^shell-call-/),
+    });
+  });
+
+  test('closes pending empty steps when response_done arrives before empty message output', async () => {
+    const agent = new Agent({ name: 'Test Agent' });
+
+    const emptyMessageOutput = new RunMessageOutputItem(
+      {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [],
+      },
+      agent,
+    );
+
+    const events = (async function* () {
+      yield new RunRawModelStreamEvent({ type: 'response_started' });
+      yield new RunRawModelStreamEvent({
+        type: 'response_done',
+        response: {
+          id: 'resp-empty',
+          usage: {
+            inputTokens: 1,
+            outputTokens: 0,
+            totalTokens: 1,
+          },
+          output: [],
+        },
+      });
+      yield new RunItemStreamEvent(
+        'message_output_created',
+        emptyMessageOutput,
+      );
+    })();
+
+    const response = createAiSdkUiMessageStreamResponse(events);
+    const chunks = await readUiMessageChunks(response);
+
+    expect(chunks.map((chunk) => chunk.type)).toEqual([
+      'start',
+      'start-step',
+      'finish-step',
+      'finish',
+    ]);
   });
 });


### PR DESCRIPTION
Summary

Add boundary coverage for the agents-extensions AI SDK UI helpers so the tests pin down fallback behavior that is easy to regress but not covered by the happy-path cases.

What changed

- Added a text stream test that exercises the TextEncoderStream fallback path and verifies explicit headers are preserved.
- Added UI message stream coverage for invalid JSON argument fallback.
- Added UI message stream coverage for computer, shell, and apply_patch input mapping.
- Added UI message stream coverage for approval requests that need a generated fallback id.
- Added UI message stream coverage for the empty-message case where a pending step must still close after response_done.
- Added a patch changeset for @openai/agents-extensions.

Test plan

- Passed `pnpm vitest run packages/agents-extensions/test/ai-sdk-ui/textStream.test.ts`.
- Passed `pnpm vitest run packages/agents-extensions/test/ai-sdk-ui/uiMessageStream.test.ts`.
- Passed `$code-change-verification` via `bash .agents/skills/code-change-verification/scripts/run.sh`.
- Passed `$changeset-validation` via `pnpm changeset:validate-prompt` with an `ok: true` / `required_bump: "patch"` verdict.
