### PR TITLE
docs(readme): fix subpackage install commands

### DIFF
--- a/.changeset/green-steaks-mix.md
+++ b/.changeset/green-steaks-mix.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+'@openai/agents-realtime': patch
+---
+
+fix: correct subpackage README install commands

--- a/packages/agents-core/README.md
+++ b/packages/agents-core/README.md
@@ -5,7 +5,7 @@ The OpenAI Agents SDK is a lightweight yet powerful framework for building multi
 ## Installation
 
 ```bash
-npm install @openai/agents
+npm install @openai/agents-core zod
 ```
 
 ## License

--- a/packages/agents-openai/README.md
+++ b/packages/agents-openai/README.md
@@ -5,7 +5,7 @@ The OpenAI Agents SDK is a lightweight yet powerful framework for building multi
 ## Installation
 
 ```bash
-npm install @openai/agents
+npm install @openai/agents-openai zod
 ```
 
 ## License

--- a/packages/agents-realtime/README.md
+++ b/packages/agents-realtime/README.md
@@ -5,7 +5,7 @@ The OpenAI Agents SDK is a lightweight yet powerful framework for building multi
 ## Installation
 
 ```bash
-npm install @openai/agents
+npm install @openai/agents-realtime zod
 ```
 
 ## License


### PR DESCRIPTION
## Summary

This pull request fixes incorrect installation snippets in the published subpackage READMEs for `@openai/agents-core`, `@openai/agents-openai`, and `@openai/agents-realtime`.

## Background

Each of these READMEs currently tells users to install `@openai/agents`, which is the umbrella package rather than the package documented on that page. That is misleading for consumers who intentionally want the lower-level packages directly, and it also omits `zod` from the install snippets.

## Changes

- update `packages/agents-core/README.md` to install `@openai/agents-core zod`
- update `packages/agents-openai/README.md` to install `@openai/agents-openai zod`
- update `packages/agents-realtime/README.md` to install `@openai/agents-realtime zod`
- add a patch changeset covering the three affected packages

## Impact

- aligns each subpackage README with the actual published package name
- reduces installation confusion for users consuming lower-level packages directly
- ensures the next release notes capture this package-level documentation correction

## Validation

- ran `pnpm changeset:validate-prompt`
- did not run the full verification stack because this is a docs-only README change
