### PR TITLE
docs(nextjs): fix README source path

### DIFF
--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -19,7 +19,7 @@ Open [http://localhost:3000](http://localhost:3000) in your browser and ask `Wha
 ## Endpoints
 
 - **`/`** – The basic example that actually handles receiving the approval requests and sending messages to the API. Code in `src/app/page.tsx`.
-- **`/api/basic`** – The endpoint that gets triggered to run the agent. Code in `src/app/websocket/page.tsx`.
+- **`/api/basic`** – The endpoint that gets triggered to run the agent. Code in `src/app/api/basic/route.ts`.
 
 ## Other files
 


### PR DESCRIPTION
This pull request updates the `examples/nextjs` README so the documented source path for the `/api/basic` endpoint matches the actual implementation in the example.

The README currently points readers to `src/app/websocket/page.tsx` for the `/api/basic` endpoint. That path does not belong to this example's API route and can send contributors to the wrong part of the codebase when they try to inspect how the endpoint works.

This change fixes the endpoint reference to `src/app/api/basic/route.ts`, which is the real file that handles the `POST /api/basic` request in the Next.js example.

Scope of this pull request:

- updates documentation only
- corrects the broken source-path reference in `examples/nextjs/README.md`
- does not change runtime behavior, build output, or example logic
