### PR TITLE
fix(husky): disable trufflehog auto-update in pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -29,5 +29,5 @@ if [ -z "$CI" ] && [ -z "$GITHUB_ACTIONS" ]; then
     echo "Skipping secrets check due to missing trufflehog."
     exit 1
   fi
-  trufflehog git file://. --since-commit HEAD --fail
+  trufflehog --no-update git file://. --since-commit HEAD --fail
 fi


### PR DESCRIPTION
This pull request fixes a contributor workflow issue in the local `pre-commit` hook by disabling TruffleHog's automatic self-update during the secret scan.

## Background

The repository's Husky hook currently runs:

```bash
trufflehog git file://. --since-commit HEAD --fail
```

On systems where the installed `trufflehog` binary lives in a package-managed or otherwise non-writable location, the tool may try to self-update before scanning and fail while replacing its own binary. In that case, commits are blocked even though the secret scan itself would otherwise succeed.

In my local repro, the hook failed with an updater error similar to:

```text
error occurred with trufflehog updater
cannot move binary
```

## What this changes

This updates the hook to run:

```bash
trufflehog --no-update git file://. --since-commit HEAD --fail
```

That keeps the secret scan in place, but removes the runtime self-update step from the commit path.

## Why this is safe

- the hook still runs TruffleHog on every local commit
- `--no-update` only disables auto-updating during hook execution
- tool upgrades can still be handled explicitly by contributors outside the commit path
- this makes the hook more deterministic and avoids commit failures caused by local binary replacement permissions

## Validation

- reproduced the commit failure when TruffleHog attempted to self-update
- verified that `trufflehog --no-update git file://. --since-commit HEAD --fail` completes successfully in the same environment
- verified that the updated hook allows the commit to complete while still running the secret scan
