### PR TITLE
fix(agents-realtime): fail fast on unsupported SIP VAD fields

### DIFF
--- a/.changeset/green-drinks-ring.md
+++ b/.changeset/green-drinks-ring.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: fail fast on unsupported SIP VAD fields

--- a/.changeset/green-drinks-ring.md
+++ b/.changeset/green-drinks-ring.md
@@ -2,4 +2,4 @@
 '@openai/agents-realtime': patch
 ---
 
-fix: fail fast on unsupported SIP VAD fields
+fix: fail fast on unsupported SIP VAD fields (#741)

--- a/docs/src/content/docs/guides/voice-agents/transport.mdx
+++ b/docs/src/content/docs/guides/voice-agents/transport.mdx
@@ -61,6 +61,14 @@ Use `OpenAIRealtimeSIP` when you want a `RealtimeSession` to attach to an existi
 2. Attach a `RealtimeSession` that uses the `OpenAIRealtimeSIP` transport and connect with the `callId` issued by the provider webhook.
 3. If you need provider-specific media forwarding or event bridging, use an integration transport such as the Twilio extension.
 
+<Aside type="caution">
+  SIP call acceptance only supports a subset of Realtime turn-detection fields.
+  `OpenAIRealtimeSIP.buildInitialConfig()` throws locally if your config
+  includes `threshold`, `prefixPaddingMs`, or `silenceDurationMs` (or their
+  snake_case equivalents) because the Realtime Calls API rejects those
+  `session.audio.input.turn_detection` properties for SIP sessions.
+</Aside>
+
 <Code lang="typescript" code={sipTransportExample} />
 
 ### Cloudflare Workers and workerd

--- a/packages/agents-realtime/src/openaiRealtimeSip.ts
+++ b/packages/agents-realtime/src/openaiRealtimeSip.ts
@@ -13,6 +13,24 @@ import {
 } from './realtimeSession';
 import { RealtimeAgent } from './realtimeAgent';
 
+const SIP_UNSUPPORTED_TURN_DETECTION_FIELDS = [
+  ['threshold', 'threshold'],
+  ['prefix_padding_ms', 'prefixPaddingMs/prefix_padding_ms'],
+  ['silence_duration_ms', 'silenceDurationMs/silence_duration_ms'],
+] as const;
+
+function formatFieldList(fields: string[]): string {
+  if (fields.length <= 1) {
+    return fields[0] ?? '';
+  }
+
+  if (fields.length === 2) {
+    return `${fields[0]} and ${fields[1]}`;
+  }
+
+  return `${fields.slice(0, -1).join(', ')}, and ${fields.at(-1)}`;
+}
+
 /**
  * Transport layer that connects to an existing SIP-initiated Realtime call via call ID.
  */
@@ -47,7 +65,9 @@ export class OpenAIRealtimeSIP extends OpenAIRealtimeWebSocket {
       overrides,
     );
     const transport = new OpenAIRealtimeSIP();
-    return transport.buildSessionPayload(sessionConfig);
+    const payload = transport.buildSessionPayload(sessionConfig);
+    OpenAIRealtimeSIP.assertSupportedInitialConfigPayload(payload);
+    return payload;
   }
 
   override sendAudio(
@@ -69,5 +89,31 @@ export class OpenAIRealtimeSIP extends OpenAIRealtimeWebSocket {
     }
 
     await super.connect(options);
+  }
+
+  private static assertSupportedInitialConfigPayload(
+    payload: RealtimeSessionPayload,
+  ): void {
+    const turnDetection = payload.audio?.input?.turn_detection as
+      | Record<string, unknown>
+      | null
+      | undefined;
+
+    if (!turnDetection || typeof turnDetection !== 'object') {
+      return;
+    }
+
+    const unsupportedFields = SIP_UNSUPPORTED_TURN_DETECTION_FIELDS.flatMap(
+      ([key, label]) =>
+        typeof turnDetection[key] === 'undefined' ? [] : [label],
+    );
+
+    if (unsupportedFields.length === 0) {
+      return;
+    }
+
+    throw new UserError(
+      `OpenAIRealtimeSIP.buildInitialConfig() does not support SIP turn-detection fields ${formatFieldList(unsupportedFields)}. The Realtime Calls API rejects these session.audio.input.turn_detection properties for SIP sessions, so remove them before accepting the call.`,
+    );
   }
 }

--- a/packages/agents-realtime/test/openaiRealtimeSip.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeSip.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { OpenAIRealtimeSIP } from '../src/openaiRealtimeSip';
 import { RealtimeAgent } from '../src/realtimeAgent';
 import { RealtimeSession } from '../src/realtimeSession';
@@ -31,6 +31,10 @@ vi.mock('ws', () => {
 });
 
 describe('OpenAIRealtimeSIP', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('requires callId on connect', async () => {
     const sip = new OpenAIRealtimeSIP();
     await expect(
@@ -64,6 +68,75 @@ describe('OpenAIRealtimeSIP', () => {
     expect(computeSpy).toHaveBeenCalled();
     expect(payload.instructions).toBe('hi');
     expect(payload.audio?.output?.voice).toBe('alloy');
+  });
+
+  it('buildInitialConfig fails fast on unsupported SIP VAD tuning fields', async () => {
+    const agent = new RealtimeAgent({ name: 'SIP Agent' });
+
+    await expect(
+      OpenAIRealtimeSIP.buildInitialConfig(agent, {
+        config: {
+          audio: {
+            input: {
+              turnDetection: {
+                type: 'server_vad',
+                threshold: 0.4,
+                prefixPaddingMs: 150,
+                silenceDurationMs: 600,
+              },
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow(
+      /threshold, prefixPaddingMs\/prefix_padding_ms, and silenceDurationMs\/silence_duration_ms/,
+    );
+  });
+
+  it('buildInitialConfig rejects snake_case SIP VAD tuning fields', async () => {
+    const agent = new RealtimeAgent({ name: 'SIP Agent' });
+
+    await expect(
+      OpenAIRealtimeSIP.buildInitialConfig(agent, {
+        config: {
+          audio: {
+            input: {
+              turnDetection: {
+                type: 'server_vad',
+                prefix_padding_ms: 150,
+                silence_duration_ms: 600,
+              },
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow(
+      /prefixPaddingMs\/prefix_padding_ms and silenceDurationMs\/silence_duration_ms/,
+    );
+  });
+
+  it('buildInitialConfig still allows supported SIP turn detection fields', async () => {
+    const agent = new RealtimeAgent({ name: 'SIP Agent' });
+
+    const payload = await OpenAIRealtimeSIP.buildInitialConfig(agent, {
+      config: {
+        audio: {
+          input: {
+            turnDetection: {
+              type: 'server_vad',
+              idleTimeoutMs: 900,
+              interruptResponse: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect(payload.audio?.input?.turn_detection).toMatchObject({
+      type: 'server_vad',
+      idle_timeout_ms: 900,
+      interrupt_response: true,
+    });
   });
 
   it('sendAudio is explicitly unsupported', async () => {


### PR DESCRIPTION
This pull request resolves #741.

## Background

`OpenAIRealtimeSIP.buildInitialConfig()` currently reuses the generic realtime session config path and forwards the resulting payload into SIP call acceptance. That is the right starting point for keeping SIP acceptance and the later SDK-attached session in sync, but it also means SIP inherits turn-detection fields that the Realtime Calls API does not currently accept for SIP sessions.

In practice, this shows up in telephony deployments as a late server-side failure during call acceptance:

- `session.audio.input.turn_detection.threshold`
- `session.audio.input.turn_detection.prefix_padding_ms`
- `session.audio.input.turn_detection.silence_duration_ms`

The result is an opaque 400 from the Calls API even though the configuration originated from SDK-managed session config. For SIP users this is primarily a DX bug: the SDK accepts a shape that the SIP accept path cannot actually use, and the failure only becomes visible once the call is already in flight.

## Why this approach

This change intentionally does **not** try to broaden SIP support for additional VAD tuning fields. The issue and current API behavior both point to a transport-specific limitation rather than a missing SDK mapping.

Because of that, the safest and most reviewer-friendly fix is to fail fast at the SIP helper boundary:

- preserve the existing generic realtime config behavior for WebRTC and WebSocket flows
- keep `OpenAIRealtimeSIP.buildInitialConfig()` as the single place where SIP-specific initial payload constraints are enforced
- surface a local, actionable SDK error before the application makes the `calls.accept(...)` request
- document the limitation where the SIP transport is introduced so users do not infer that all generic `turnDetection` options are valid for SIP

This keeps the change narrowly scoped to the transport that actually has the constraint, avoids adding compatibility shims, and does not reframe an API limitation as new SIP functionality.

## What changed

### Runtime behavior

`OpenAIRealtimeSIP.buildInitialConfig()` now validates the normalized SIP initial payload and throws a `UserError` when the payload contains unsupported SIP turn-detection fields:

- `threshold`
- `prefixPaddingMs` / `prefix_padding_ms`
- `silenceDurationMs` / `silence_duration_ms`

The validation happens **after** the config is normalized into the payload shape. That is important because it means the guard covers both camelCase and snake_case inputs without duplicating normalization logic or changing behavior in the generic realtime transport code.

### Tests

Added focused SIP tests that verify:

- fail-fast behavior for unsupported camelCase VAD tuning fields
- fail-fast behavior for unsupported snake_case VAD tuning fields
- supported SIP turn-detection fields such as `idleTimeoutMs` and `interruptResponse` continue to pass through

This keeps the regression coverage on the exact SDK helper that telephony integrations rely on.

### Docs

Updated the voice transport guide to call out that SIP call acceptance only supports a subset of the generic realtime turn-detection configuration, and that the SDK now throws locally for the unsupported fields above.

## Behavior impact

This is a patch-level DX fix for `@openai/agents-realtime`.

Before this change:
- unsupported SIP VAD tuning fields could survive SDK config generation and fail later as a server-side 400 during call acceptance

After this change:
- the SDK throws a local, transport-specific error before the `calls.accept(...)` request is sent

The WebRTC and WebSocket realtime paths are unchanged.

## Risk and scope

The change is intentionally narrow:

- it only affects `OpenAIRealtimeSIP.buildInitialConfig()`
- it only rejects fields that the current Realtime Calls API already rejects for SIP sessions
- it leaves supported SIP turn-detection options intact
- it avoids touching shared realtime session normalization logic outside the SIP entrypoint

That should make the behavior easier to reason about for users and easier to review/accept, because the SDK is becoming stricter only where the transport contract is already stricter.

## Validation

- Ran the full repository verification stack via `$code-change-verification`
- Verified the changeset scope and bump via `$changeset-validation` (`required_bump: patch`)
