### PR TITLE
fix(agents-extensions): #1163 preserve nested audio config

### DIFF
--- a/.changeset/twilio-audio-config.md
+++ b/.changeset/twilio-audio-config.md
@@ -1,0 +1,5 @@
+---
+"@openai/agents-extensions": patch
+---
+
+fix: preserve nested audio config in Twilio transport

--- a/packages/agents-extensions/src/TwilioRealtimeTransport.ts
+++ b/packages/agents-extensions/src/TwilioRealtimeTransport.ts
@@ -68,23 +68,41 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
 
   _setInputAndOutputAudioFormat(
     partialConfig?: Partial<RealtimeSessionConfig>,
-  ) {
-    let newConfig: Partial<RealtimeSessionConfig> = {};
+  ): Partial<RealtimeSessionConfig> {
     if (!partialConfig) {
+      const newConfig: Partial<RealtimeSessionConfig> = {};
       // @ts-expect-error - this is a valid config
       newConfig.inputAudioFormat = 'g711_ulaw';
       // @ts-expect-error - this is a valid config
       newConfig.outputAudioFormat = 'g711_ulaw';
-    } else {
-      newConfig = {
+      return newConfig;
+    }
+
+    const audioConfig = 'audio' in partialConfig ? partialConfig.audio : null;
+    if (audioConfig) {
+      return {
         ...partialConfig,
-        // @ts-expect-error - this is a valid config
-        inputAudioFormat: partialConfig.inputAudioFormat ?? 'g711_ulaw',
-        // @ts-expect-error - this is a valid config
-        outputAudioFormat: partialConfig.outputAudioFormat ?? 'g711_ulaw',
+        audio: {
+          ...audioConfig,
+          input: {
+            ...audioConfig.input,
+            format: audioConfig.input?.format ?? 'g711_ulaw',
+          },
+          output: {
+            ...audioConfig.output,
+            format: audioConfig.output?.format ?? 'g711_ulaw',
+          },
+        },
       };
     }
-    return newConfig;
+
+    return {
+      ...partialConfig,
+      // @ts-expect-error - this is a valid config
+      inputAudioFormat: partialConfig.inputAudioFormat ?? 'g711_ulaw',
+      // @ts-expect-error - this is a valid config
+      outputAudioFormat: partialConfig.outputAudioFormat ?? 'g711_ulaw',
+    };
   }
 
   async connect(options: RealtimeTransportLayerConnectOptions) {

--- a/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
+++ b/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
@@ -64,6 +64,44 @@ describe('TwilioRealtimeTransportLayer', () => {
     ).toEqual({ inputAudioFormat: 'foo', outputAudioFormat: 'g711_ulaw' });
   });
 
+  test('_setInputAndOutputAudioFormat preserves nested audio config', () => {
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: new FakeTwilioWebSocket() as any,
+    });
+
+    expect(
+      transport._setInputAndOutputAudioFormat({
+        instructions: 'hi',
+        audio: {
+          input: {
+            turnDetection: {
+              type: 'server_vad',
+              silenceDurationMs: 300,
+            },
+          },
+          output: {
+            voice: 'alloy',
+          },
+        },
+      } as any),
+    ).toEqual({
+      instructions: 'hi',
+      audio: {
+        input: {
+          format: 'g711_ulaw',
+          turnDetection: {
+            type: 'server_vad',
+            silenceDurationMs: 300,
+          },
+        },
+        output: {
+          format: 'g711_ulaw',
+          voice: 'alloy',
+        },
+      },
+    });
+  });
+
   test('connect handles messages and events', async () => {
     allowConsole(['error']);
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -158,6 +196,51 @@ describe('TwilioRealtimeTransportLayer', () => {
     expect(audioListener).toHaveBeenCalledTimes(3);
   });
 
+  test('connect preserves nested audio config while defaulting Twilio formats', async () => {
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: twilio as any,
+    });
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const connectSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.connect);
+
+    await transport.connect({
+      apiKey: 'ek_test',
+      initialSessionConfig: {
+        audio: {
+          input: {
+            turnDetection: {
+              type: 'server_vad',
+              silenceDurationMs: 300,
+            },
+          },
+          output: {
+            voice: 'alloy',
+          },
+        },
+      },
+    } as any);
+
+    expect(connectSpy).toHaveBeenCalledWith({
+      apiKey: 'ek_test',
+      initialSessionConfig: {
+        audio: {
+          input: {
+            format: 'g711_ulaw',
+            turnDetection: {
+              type: 'server_vad',
+              silenceDurationMs: 300,
+            },
+          },
+          output: {
+            format: 'g711_ulaw',
+            voice: 'alloy',
+          },
+        },
+      },
+    });
+  });
+
   test('updateSessionConfig keeps audio format', async () => {
     const twilio = new FakeTwilioWebSocket();
     const transport = new TwilioRealtimeTransportLayer({
@@ -168,11 +251,35 @@ describe('TwilioRealtimeTransportLayer', () => {
     const spy = vi.mocked(
       OpenAIRealtimeWebSocket.prototype.updateSessionConfig,
     );
-    transport.updateSessionConfig({ instructions: 'hi' });
+    transport.updateSessionConfig({
+      instructions: 'hi',
+      audio: {
+        input: {
+          turnDetection: {
+            type: 'server_vad',
+            silenceDurationMs: 300,
+          },
+        },
+        output: {
+          voice: 'alloy',
+        },
+      },
+    } as any);
     expect(spy).toHaveBeenCalledWith({
       instructions: 'hi',
-      inputAudioFormat: 'g711_ulaw',
-      outputAudioFormat: 'g711_ulaw',
+      audio: {
+        input: {
+          format: 'g711_ulaw',
+          turnDetection: {
+            type: 'server_vad',
+            silenceDurationMs: 300,
+          },
+        },
+        output: {
+          format: 'g711_ulaw',
+          voice: 'alloy',
+        },
+      },
     });
   });
 


### PR DESCRIPTION
This pull request resolves #1163.

TwilioRealtimeTransportLayer was forcing legacy `inputAudioFormat` and `outputAudioFormat` fields even when callers used the GA `audio.input` and `audio.output` session shape. That caused session config normalization to drop nested settings like `audio.input.turnDetection` and `audio.output.voice`.

This change preserves nested audio config when the caller already uses the GA `audio` structure and only fills in the Twilio-required `g711_ulaw` defaults. The legacy and empty-config paths stay unchanged.

The regression coverage now verifies:
- nested `audio.input.turnDetection` survives `_setInputAndOutputAudioFormat()`
- `connect()` preserves nested `audio` config in `initialSessionConfig`
- `updateSessionConfig()` preserves nested `audio` config while defaulting Twilio formats

Validation:
- `pnpm changeset:validate-prompt` (`required_bump: patch`)
- `bash .agents/skills/code-change-verification/scripts/run.sh`
