### PR TITLE
fix(realtime): replay assistant audio history from transcripts

### DIFF
--- a/.changeset/audio-history-replay.md
+++ b/.changeset/audio-history-replay.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: replay assistant audio history from transcripts

--- a/docs/src/content/docs/guides/voice-agents/build.mdx
+++ b/docs/src/content/docs/guides/voice-agents/build.mdx
@@ -254,14 +254,14 @@ Set `debounceTextLength: -1` when you only want to evaluate the fully generated 
 
 `RealtimeSession` automatically maintains a local `history` snapshot that tracks user messages, assistant output, tool calls, and truncation state. You can render it in the UI, inspect it inside tools, or update it when you need to correct or remove items.
 
-As the conversation changes the session emits `history_updated`. If you need to request history changes, use `updateHistory()`. It asks the transport to diff the current history and send the necessary delete/create events; the local `session.history` view updates as the corresponding conversation events come back.
+As the conversation changes the session emits `history_updated`. If you need to request history changes, use `updateHistory()`. It asks the transport to diff the current history and send the necessary delete/create events; the local `session.history` view updates as the corresponding conversation events come back. Because the Realtime API does not currently accept assistant audio items in `conversation.item.create`, replaying assistant audio history converts transcript-backed `output_audio` entries into assistant text and skips assistant audio turns that do not have transcripts.
 
 <Code lang="typescript" code={updateHistoryExample} />
 
 #### Limitations
 
 1. You cannot currently edit function tool calls after the fact.
-2. Assistant text in history depends on available transcripts, including `output_audio.transcript`.
+2. Assistant text in history depends on available transcripts, including `output_audio.transcript`. Replaying assistant audio history also depends on those transcripts because transcript-backed audio is restored as assistant text.
 3. Responses truncated by interruption do not retain a final transcript.
 4. Input audio transcription is best treated as a rough guide to what the user said, not an exact copy of how the model interpreted the audio.
 

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -33,7 +33,11 @@ import {
   RealtimeTransportEventTypes,
   TransportToolCallEvent,
 } from './transportLayerEvents';
-import { arrayBufferToBase64, diffRealtimeHistory } from './utils';
+import {
+  arrayBufferToBase64,
+  diffRealtimeHistory,
+  realtimeMessageToConversationItemCreateMessage,
+} from './utils';
 import { EventEmitterDelegate } from '@openai/agents-core/utils';
 
 /**
@@ -921,14 +925,14 @@ export abstract class OpenAIRealtimeBase
 
     for (const addition of additionsAndUpdates) {
       if (addition.type === 'message') {
-        const itemEntry: Record<string, any> = {
-          type: 'message',
-          role: addition.role,
-          content: addition.content,
-          id: addition.itemId,
-        };
-        if (addition.role !== 'system' && addition.status) {
-          itemEntry.status = addition.status;
+        const itemEntry =
+          realtimeMessageToConversationItemCreateMessage(addition);
+        if (!itemEntry) {
+          logger.warn(
+            'Assistant audio history can only be replayed when transcripts are available. Skipping item %s.',
+            addition.itemId,
+          );
+          continue;
         }
         this.sendEvent({
           type: 'conversation.item.create',

--- a/packages/agents-realtime/src/utils.ts
+++ b/packages/agents-realtime/src/utils.ts
@@ -94,6 +94,19 @@ export type RealtimeHistoryDiff = {
   updates: RealtimeItem[];
 };
 
+type RealtimeMessageStatus = Extract<
+  RealtimeMessageItem,
+  { status: unknown }
+>['status'];
+
+export type ConversationItemCreateMessage = {
+  type: 'message';
+  role: RealtimeMessageItem['role'];
+  content: RealtimeMessageItem['content'];
+  id: string;
+  status?: RealtimeMessageStatus;
+};
+
 /**
  * Compare two conversation histories to determine the removals, additions, and updates.
  * @param oldHistory - The old history.
@@ -122,6 +135,52 @@ export function diffRealtimeHistory(
     additions,
     updates,
   };
+}
+
+/**
+ * Normalize a history message into a shape the Realtime API accepts for conversation.item.create.
+ * Assistant audio history can only be replayed from transcripts, so output_audio items are
+ * converted into output_text entries and transcript-less audio is dropped.
+ * @param item - The message item to normalize.
+ * @returns A conversation.item.create message payload or null if nothing replayable remains.
+ */
+export function realtimeMessageToConversationItemCreateMessage(
+  item: RealtimeMessageItem,
+): ConversationItemCreateMessage | null {
+  const content =
+    item.role === 'assistant'
+      ? item.content.flatMap((entry) => {
+          if (entry.type !== 'output_audio') {
+            return [entry];
+          }
+
+          if (
+            typeof entry.transcript !== 'string' ||
+            entry.transcript.length === 0
+          ) {
+            return [];
+          }
+
+          return [{ type: 'output_text' as const, text: entry.transcript }];
+        })
+      : item.content;
+
+  if (content.length === 0) {
+    return null;
+  }
+
+  const normalizedItem: ConversationItemCreateMessage = {
+    type: 'message',
+    role: item.role,
+    content: content as RealtimeMessageItem['content'],
+    id: item.itemId,
+  };
+
+  if (item.role !== 'system' && item.status) {
+    normalizedItem.status = item.status;
+  }
+
+  return normalizedItem;
 }
 
 /**

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -266,6 +266,53 @@ describe('OpenAIRealtimeBase helpers', () => {
     });
   });
 
+  it('resetHistory replays assistant audio history as transcript-backed text', () => {
+    const base = new TestBase();
+
+    base.resetHistory([], [
+      {
+        itemId: 'assistant-1',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [
+          { type: 'output_audio', audio: 'abc', transcript: 'hello there' },
+        ],
+      },
+    ] as any);
+
+    expect(base.events[0]).toEqual({
+      type: 'conversation.item.create',
+      item: {
+        id: 'assistant-1',
+        role: 'assistant',
+        type: 'message',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'hello there' }],
+      },
+    });
+  });
+
+  it('resetHistory skips assistant audio history without transcripts', () => {
+    const base = new TestBase();
+
+    base.resetHistory([], [
+      {
+        itemId: 'assistant-2',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_audio', audio: 'abc', transcript: null }],
+      },
+    ] as any);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Assistant audio history can only be replayed when transcripts are available. Skipping item %s.',
+      'assistant-2',
+    );
+    expect(base.events).toHaveLength(0);
+  });
+
   it('resetHistory warns on function call additions', () => {
     const base = new TestBase();
     const newHist = [

--- a/packages/agents-realtime/test/utils.test.ts
+++ b/packages/agents-realtime/test/utils.test.ts
@@ -7,6 +7,7 @@ import {
   updateRealtimeHistory,
   hasWebRTCSupport,
   removeAudioFromContent,
+  realtimeMessageToConversationItemCreateMessage,
   realtimeApprovalItemToApprovalItem,
   approvalItemToRealtimeApprovalItem,
 } from '../src/utils';
@@ -141,6 +142,36 @@ describe('realtime utils', () => {
     expect(diff.removals.map((i) => i.itemId)).toEqual(['2']);
     expect(diff.additions.map((i) => i.itemId)).toEqual(['3']);
     expect(diff.updates.map((i) => i.itemId)).toEqual(['1']);
+  });
+
+  it('converts assistant audio history into transcript-backed text for replay', () => {
+    const item: RealtimeMessageItem = {
+      itemId: 'assistant-1',
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [{ type: 'output_audio', audio: 'abc', transcript: 'hello' }],
+    };
+
+    expect(realtimeMessageToConversationItemCreateMessage(item)).toEqual({
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      id: 'assistant-1',
+      content: [{ type: 'output_text', text: 'hello' }],
+    });
+  });
+
+  it('returns null for assistant audio history without replayable transcripts', () => {
+    const item: RealtimeMessageItem = {
+      itemId: 'assistant-2',
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [{ type: 'output_audio', audio: 'abc', transcript: null }],
+    };
+
+    expect(realtimeMessageToConversationItemCreateMessage(item)).toBeNull();
   });
 
   it('updateRealtimeHistory inserts and strips audio', () => {


### PR DESCRIPTION
## Summary
- fix `session.updateHistory()` replay for assistant audio turns by converting transcript-backed `output_audio` history into replayable assistant text
- skip assistant audio turns that do not have transcripts instead of sending invalid `conversation.item.create` payloads
- add regression tests and document that assistant audio replay is transcript-backed rather than raw audio restoration

## Why
This pull request resolves #963.

`RealtimeSession.history` can contain assistant `output_audio` items, but feeding that history back into `session.updateHistory()` currently fails because the Realtime API does not accept assistant audio messages in `conversation.item.create`. This change preserves round-tripping for assistant turns when a transcript is available and narrows the unsupported case to transcript-less audio replay.

## What Changed
- added `realtimeMessageToConversationItemCreateMessage(...)` to normalize replayed history items into a shape accepted by `conversation.item.create`
- updated `OpenAIRealtimeBase.resetHistory()` to replay assistant audio history as `output_text` using `output_audio.transcript`
- log and skip assistant audio items that do not have transcripts instead of emitting an invalid request
- added regression coverage in the realtime utils/base tests for transcript-backed replay and transcript-missing skips
- updated the voice agents guide to explain that assistant audio history replay depends on transcripts and does not restore audio blobs

## Testing
- `pnpm vitest run packages/agents-realtime/test/utils.test.ts packages/agents-realtime/test/openaiRealtimeBase.test.ts`
- `bash .agents/skills/code-change-verification/scripts/run.sh`
- `pnpm changeset:validate-prompt`

## Risks / Follow-ups
- assistant audio turns without transcripts still cannot be replayed because the upstream Realtime API does not currently support creating assistant audio history directly
