### PR TITLE
fix(examples): implement forcing-tool-use calculator

### DIFF
--- a/examples/docs/agents/agentForcingToolUse.ts
+++ b/examples/docs/agents/agentForcingToolUse.ts
@@ -1,12 +1,49 @@
 import { Agent, tool } from '@openai/agents';
 import { z } from 'zod';
 
-const calculatorTool = tool({
-  name: 'Calculator',
+const basicExpressionPattern =
+  /(-?\d+(?:\.\d+)?)\s*([+\-*/x])\s*(-?\d+(?:\.\d+)?)/;
+
+function evaluateBasicExpression(question: string): string {
+  const match = question.match(basicExpressionPattern);
+  if (!match) {
+    return 'I can only solve a single arithmetic expression such as "2 + 2".';
+  }
+
+  const left = Number(match[1]);
+  const operator = match[2].toLowerCase();
+  const right = Number(match[3]);
+
+  if (operator === '/' && right === 0) {
+    return 'Division by zero is undefined.';
+  }
+
+  let result: number;
+  switch (operator) {
+    case '+':
+      result = left + right;
+      break;
+    case '-':
+      result = left - right;
+      break;
+    case '*':
+    case 'x':
+      result = left * right;
+      break;
+    default:
+      result = left / right;
+      break;
+  }
+
+  return `${left} ${operator} ${right} = ${result}`;
+}
+
+export const calculatorTool = tool({
+  name: 'calculator',
   description: 'Use this tool to answer questions about math problems.',
   parameters: z.object({ question: z.string() }),
-  execute: async (input) => {
-    throw new Error('TODO: implement this');
+  execute: async ({ question }) => {
+    return evaluateBasicExpression(question);
   },
 });
 


### PR DESCRIPTION
### Summary

- Replace the `TODO: implement this` error in the official "Forcing tool use" docs example with a working local calculator implementation.
- Keep the example deterministic by parsing a single arithmetic expression locally, with explicit handling for unsupported input and division by zero.
- Export the example tool so the snippet can be smoke-checked directly.

### Test plan

- `pnpm -F docs-code build-check`
- Manual smoke: invoked `calculatorTool` directly with `what is 6 * 7?` and verified the result was `6 * 7 = 42`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

- N/A

### Checks

- [ ] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration` [(see details)](https://github.com/openai/openai-agents-js/tree/main/integration-tests)
- [x] I've made sure tests pass
- [ ] I've added a changeset using `pnpm changeset` to indicate my changes

No changeset was added because this PR only updates a docs example under `examples/docs/` and does not change a published package.
