### PR TITLE
fix: #1176 normalize compacted multimodal session items

### DIFF
--- a/.changeset/wild-fishes-hear.md
+++ b/.changeset/wild-fishes-hear.md
@@ -2,4 +2,4 @@
 '@openai/agents-openai': patch
 ---
 
-fix: normalize compacted multimodal session items
+fix: normalize compacted multimodal session items (#1176)

--- a/.changeset/wild-fishes-hear.md
+++ b/.changeset/wild-fishes-hear.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: normalize compacted multimodal session items

--- a/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
+++ b/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
@@ -13,7 +13,10 @@ import type {
 } from '@openai/agents-core';
 import type { OpenAIResponsesCompactionResult } from '@openai/agents-core';
 import { DEFAULT_OPENAI_MODEL, getDefaultOpenAIClient } from '../defaults';
-import { getInputItems } from '../openaiResponsesModel';
+import {
+  getInputItems,
+  normalizeCompactionOutputItems,
+} from '../openaiResponsesModel';
 import {
   OPENAI_SESSION_API,
   type OpenAISessionApiTagged,
@@ -204,7 +207,7 @@ export class OpenAIResponsesCompactionSession
     const compacted = await this.client.responses.compact(compactRequest);
 
     await this.underlyingSession.clearSession();
-    const outputItems = (compacted.output ?? []) as AgentInputItem[];
+    const outputItems = normalizeCompactionOutputItems(compacted.output ?? []);
     if (outputItems.length > 0) {
       await this.underlyingSession.addItems(outputItems);
     }

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -10,6 +10,7 @@ import {
   UserError,
 } from '@openai/agents-core';
 import type {
+  AgentInputItem,
   ModelRetryAdvice,
   ModelRetryAdviceRequest,
   SerializedHandoff,
@@ -983,9 +984,11 @@ function convertStructuredOutputToRequestItem(
   );
 }
 
-function convertResponseFunctionCallOutputItemToStructured(
-  item: ResponseFunctionCallOutputListItem,
-): protocol.ToolCallStructuredOutput | null {
+function convertResponseInputContentToStructured(
+  item:
+    | ResponseFunctionCallOutputListItem
+    | OpenAI.Responses.ResponseInputContent,
+): protocol.InputText | protocol.InputImage | protocol.InputFile | null {
   if (item.type === 'input_text') {
     return {
       type: 'input_text',
@@ -1052,7 +1055,7 @@ function convertFunctionCallOutputToProtocol(
 
   if (Array.isArray(output)) {
     return output
-      .map(convertResponseFunctionCallOutputItemToStructured)
+      .map(convertResponseInputContentToStructured)
       .filter((s) => s !== null);
   }
 
@@ -1911,6 +1914,104 @@ function getPrompt(prompt: ModelRequest['prompt']):
   };
 }
 
+function normalizeCompactionMessageItem(
+  item:
+    | OpenAI.Responses.ResponseInputItem.Message
+    | OpenAI.Responses.ResponseOutputMessage,
+): AgentInputItem | null {
+  if (item.role === 'user') {
+    const {
+      id,
+      type: _type,
+      role: _role,
+      content,
+      ...providerData
+    } = item as OpenAI.Responses.ResponseInputItem.Message &
+      Record<string, any>;
+    const normalizedContent =
+      typeof content === 'string'
+        ? content
+        : Array.isArray(content)
+          ? (content
+              .map(convertResponseInputContentToStructured)
+              .filter((entry) => entry !== null) as protocol.UserContent[])
+          : [];
+
+    return {
+      id,
+      type: 'message',
+      role: 'user',
+      content: normalizedContent,
+      ...(Object.keys(providerData).length > 0 ? { providerData } : {}),
+    };
+  }
+
+  if (item.role === 'assistant') {
+    const { id, type, role, content, status, ...providerData } = item;
+    return {
+      id,
+      type,
+      role,
+      content: content.map(convertToMessageContentItem),
+      status,
+      ...(Object.keys(providerData).length > 0 ? { providerData } : {}),
+    };
+  }
+
+  return null;
+}
+
+function normalizeCompactionOutputItem(
+  item:
+    | OpenAI.Responses.ResponseOutputItem
+    | OpenAI.Responses.ResponseInputItem,
+): AgentInputItem | null {
+  if (item.type === 'message') {
+    return normalizeCompactionMessageItem(
+      item as
+        | OpenAI.Responses.ResponseInputItem.Message
+        | OpenAI.Responses.ResponseOutputMessage,
+    );
+  }
+
+  if (item.type === 'compaction') {
+    const {
+      id: _id,
+      type: _type,
+      encrypted_content,
+      created_by,
+      ...providerData
+    } = item as {
+      encrypted_content?: string;
+      created_by?: string;
+      id?: string;
+      type?: string;
+    };
+    if (typeof encrypted_content !== 'string') {
+      throw new UserError('Compaction item missing encrypted_content');
+    }
+    return {
+      type: 'compaction',
+      id: item.id ?? undefined,
+      encrypted_content,
+      created_by,
+      ...(Object.keys(providerData).length > 0 ? { providerData } : {}),
+    };
+  }
+
+  throw new UserError(
+    `Unsupported compaction output item: ${JSON.stringify(item)}`,
+  );
+}
+
+function normalizeCompactionOutputItems(
+  items: Array<OpenAI.Responses.ResponseOutputItem>,
+): AgentInputItem[] {
+  return items
+    .map(normalizeCompactionOutputItem)
+    .filter((item): item is AgentInputItem => item !== null);
+}
+
 function getInputItems(
   input: ModelRequest['input'],
 ): OpenAI.Responses.ResponseInputItem[] {
@@ -2755,7 +2856,13 @@ function convertToOutputItem(
   });
 }
 
-export { getToolChoice, converTool, getInputItems, convertToOutputItem };
+export {
+  getToolChoice,
+  converTool,
+  getInputItems,
+  convertToOutputItem,
+  normalizeCompactionOutputItems,
+};
 
 const TERMINAL_RESPONSES_STREAM_EVENT_TYPES = new Set([
   'response.completed',

--- a/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
+++ b/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
@@ -449,6 +449,163 @@ describe('OpenAIResponsesCompactionSession', () => {
     ]);
   });
 
+  it('normalizes compacted multimodal user messages before storing them', async () => {
+    const imageDataUrl = 'data:image/jpeg;base64,aW1hZ2U=';
+    const compact = vi
+      .fn()
+      .mockResolvedValueOnce({
+        output: [
+          {
+            id: 'msg_user_compacted',
+            type: 'message',
+            role: 'user',
+            content: [
+              { type: 'input_text', text: 'analyse these images' },
+              {
+                type: 'input_image',
+                image_url: imageDataUrl,
+                file_id: null,
+                detail: 'auto',
+              },
+              {
+                type: 'input_image',
+                file_id: 'file_img',
+                detail: 'high',
+              },
+              {
+                type: 'input_file',
+                file_id: 'file_doc',
+                filename: 'doc.txt',
+              },
+              {
+                type: 'input_file',
+                file_url: 'https://example.com/doc.txt',
+                filename: 'doc.txt',
+              },
+            ],
+          },
+          {
+            id: 'cmp_1',
+            type: 'compaction',
+            encrypted_content: 'enc_1',
+            created_by: 'server',
+          },
+        ],
+        usage: {
+          input_tokens: 2,
+          output_tokens: 1,
+          total_tokens: 3,
+        },
+      })
+      .mockResolvedValueOnce({
+        output: [],
+        usage: {
+          input_tokens: 1,
+          output_tokens: 1,
+          total_tokens: 2,
+        },
+      });
+    const session = new OpenAIResponsesCompactionSession({
+      client: { responses: { compact } } as any,
+      compactionMode: 'input',
+    });
+
+    await session.addItems([
+      {
+        type: 'message',
+        role: 'user',
+        content: [
+          { type: 'input_text', text: 'start' },
+          { type: 'input_image', image: imageDataUrl },
+        ],
+      },
+      {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'ack' }],
+      },
+    ] as any);
+
+    await session.runCompaction({ force: true });
+
+    expect(await session.getItems()).toEqual([
+      {
+        id: 'msg_user_compacted',
+        type: 'message',
+        role: 'user',
+        content: [
+          { type: 'input_text', text: 'analyse these images' },
+          {
+            type: 'input_image',
+            image: imageDataUrl,
+            detail: 'auto',
+          },
+          {
+            type: 'input_image',
+            image: { id: 'file_img' },
+            detail: 'high',
+          },
+          {
+            type: 'input_file',
+            file: { id: 'file_doc' },
+            filename: 'doc.txt',
+          },
+          {
+            type: 'input_file',
+            file: { url: 'https://example.com/doc.txt' },
+            filename: 'doc.txt',
+          },
+        ],
+      },
+      {
+        id: 'cmp_1',
+        type: 'compaction',
+        encrypted_content: 'enc_1',
+        created_by: 'server',
+      },
+    ]);
+
+    await session.runCompaction({ force: true });
+
+    expect(compact).toHaveBeenCalledTimes(2);
+    const [request] = compact.mock.calls[1] ?? [];
+    expect(request.input).toEqual([
+      {
+        id: 'msg_user_compacted',
+        role: 'user',
+        content: [
+          { type: 'input_text', text: 'analyse these images' },
+          {
+            type: 'input_image',
+            image_url: imageDataUrl,
+            detail: 'auto',
+          },
+          {
+            type: 'input_image',
+            file_id: 'file_img',
+            detail: 'high',
+          },
+          {
+            type: 'input_file',
+            file_id: 'file_doc',
+            filename: 'doc.txt',
+          },
+          {
+            type: 'input_file',
+            file_url: 'https://example.com/doc.txt',
+            filename: 'doc.txt',
+          },
+        ],
+      },
+      {
+        id: 'cmp_1',
+        type: 'compaction',
+        encrypted_content: 'enc_1',
+      },
+    ]);
+  });
+
   it('throws when runCompaction is called without a responseId in previous_response_id mode', async () => {
     const compact = vi.fn();
     const session = new OpenAIResponsesCompactionSession({


### PR DESCRIPTION
### Summary

- Normalize `responses.compact()` output back into Agents SDK session items before storing it in `OpenAIResponsesCompactionSession`.
- Convert compacted multimodal user content from Responses wire fields such as `image_url`, `file_id`, `file_url`, and `file_data` back into the SDK protocol shape used by session history.
- Add a regression test covering image and file prompts so a second compaction pass re-encodes valid Responses input instead of producing a 400.

### Test plan

- `pnpm exec vitest run packages/agents-openai/test/openaiResponsesCompactionSession.test.ts packages/agents-openai/test/openaiResponsesModel.helpers.test.ts`
- `bash .agents/skills/code-change-verification/scripts/run.sh`
- Manual: reran `pnpm exec vitest run packages/agents-core/test/logger.test.ts` after one unrelated timeout during an earlier full-suite run; the test passed and the final full verification run passed cleanly.

### Issue number

Closes #1176

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration` [(see details)](https://github.com/openai/openai-agents-js/tree/main/integration-tests)
- [x] I've made sure tests pass
- [x] I've added a changeset using `pnpm changeset` to indicate my changes
