### PR TITLE
fix: #1176 normalize compacted Responses user messages before storing them

### DIFF
--- a/.changeset/silent-olives-pull.md
+++ b/.changeset/silent-olives-pull.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: normalize compacted Responses user messages before storing them

--- a/.changeset/silent-olives-pull.md
+++ b/.changeset/silent-olives-pull.md
@@ -2,4 +2,4 @@
 '@openai/agents-openai': patch
 ---
 
-fix: normalize compacted Responses user messages before storing them
+fix: #1176 normalize compacted Responses user messages before storing them

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "name": "openai-agents-js",
   "version": "0.0.1",
   "scripts": {
-    "clean": "tsc-multi --clean",
+    "clean": "node scripts/clean-package-dists.mjs && tsc-multi --clean",
     "prebuild": "pnpm -F @openai/* -r prebuild",
-    "build": "tsc-multi",
-    "build:ci": "pnpm run prebuild && tsc-multi --maxWorkers 1 && pnpm run postbuild",
+    "build": "pnpm clean && tsc-multi",
+    "build:ci": "pnpm run prebuild && pnpm clean && tsc-multi --maxWorkers 1 && pnpm run postbuild",
     "postbuild": "pnpm -r -F @openai/* bundle",
     "packages:dev": "tsc-multi --watch",
     "docs:dev": "pnpm -F docs dev",

--- a/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
+++ b/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
@@ -204,7 +204,7 @@ export class OpenAIResponsesCompactionSession
     const compacted = await this.client.responses.compact(compactRequest);
 
     await this.underlyingSession.clearSession();
-    const outputItems = (compacted.output ?? []) as AgentInputItem[];
+    const outputItems = normalizeCompactionOutputItems(compacted.output ?? []);
     if (outputItems.length > 0) {
       await this.underlyingSession.addItems(outputItems);
     }
@@ -411,6 +411,106 @@ function toRequestUsage(
     outputTokensDetails: { ...usage?.output_tokens_details },
     endpoint: 'responses.compact',
   });
+}
+
+type CompactionOutputItem =
+  | OpenAI.Responses.ResponseOutputItem
+  | OpenAI.Responses.ResponseInputMessageItem;
+
+function normalizeCompactionOutputItems(
+  items: ReadonlyArray<CompactionOutputItem>,
+): AgentInputItem[] {
+  return items.flatMap((item) => {
+    if (isCompactionInputMessage(item)) {
+      return [normalizeCompactionInputMessage(item)];
+    }
+
+    return [item as AgentInputItem];
+  });
+}
+
+function isCompactionInputMessage(
+  item: CompactionOutputItem,
+): item is OpenAI.Responses.ResponseInputMessageItem {
+  return item.type === 'message' && item.role === 'user';
+}
+
+function normalizeCompactionInputMessage(
+  item: OpenAI.Responses.ResponseInputMessageItem,
+): AgentInputItem {
+  return {
+    id: (item as { id?: string }).id,
+    type: 'message',
+    role: 'user',
+    content: item.content.map((content) => {
+      if (content.type === 'input_text') {
+        return {
+          type: 'input_text',
+          text: content.text,
+        };
+      }
+
+      if (content.type === 'input_image') {
+        if (
+          typeof content.image_url === 'string' &&
+          content.image_url.length > 0
+        ) {
+          return {
+            type: 'input_image',
+            image: content.image_url,
+            ...(content.detail ? { detail: content.detail } : {}),
+          };
+        }
+        if (typeof content.file_id === 'string' && content.file_id.length > 0) {
+          return {
+            type: 'input_image',
+            image: { id: content.file_id },
+            ...(content.detail ? { detail: content.detail } : {}),
+          };
+        }
+        throw new UserError(
+          'Compaction input_image item missing image_url or file_id.',
+        );
+      }
+
+      if (content.type === 'input_file') {
+        if (
+          typeof content.file_data === 'string' &&
+          content.file_data.length > 0
+        ) {
+          return {
+            type: 'input_file',
+            file: content.file_data,
+            ...(content.filename ? { filename: content.filename } : {}),
+          };
+        }
+        if (
+          typeof content.file_url === 'string' &&
+          content.file_url.length > 0
+        ) {
+          return {
+            type: 'input_file',
+            file: content.file_url,
+            ...(content.filename ? { filename: content.filename } : {}),
+          };
+        }
+        if (typeof content.file_id === 'string' && content.file_id.length > 0) {
+          return {
+            type: 'input_file',
+            file: { id: content.file_id },
+            ...(content.filename ? { filename: content.filename } : {}),
+          };
+        }
+        throw new UserError(
+          'Compaction input_file item missing file_data, file_url, or file_id.',
+        );
+      }
+
+      throw new UserError(
+        `Unsupported compaction message content type: ${JSON.stringify(content)}`,
+      );
+    }),
+  };
 }
 
 function isOpenAIConversationsSessionDelegate(

--- a/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
+++ b/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
@@ -203,8 +203,8 @@ export class OpenAIResponsesCompactionSession
 
     const compacted = await this.client.responses.compact(compactRequest);
 
-    await this.underlyingSession.clearSession();
     const outputItems = normalizeCompactionOutputItems(compacted.output ?? []);
+    await this.underlyingSession.clearSession();
     if (outputItems.length > 0) {
       await this.underlyingSession.addItems(outputItems);
     }

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -1691,10 +1691,13 @@ function getInputMessageContent(
       type: 'input_file',
     };
     if (typeof entry.file === 'string') {
-      if (entry.file.startsWith('data:')) {
-        fileEntry.file_data = entry.file;
-      } else if (entry.file.startsWith('https://')) {
-        fileEntry.file_url = entry.file;
+      const value = entry.file.trim();
+      if (value.startsWith('data:')) {
+        fileEntry.file_data = value;
+      } else if (value.startsWith('https://')) {
+        fileEntry.file_url = value;
+      } else if (/^[A-Za-z0-9+/=]+$/.test(value)) {
+        fileEntry.file_data = value;
       } else {
         throw new UserError(
           `Unsupported string data for file input. If you're trying to pass an uploaded file's ID, use an object with the ID property instead.`,

--- a/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
+++ b/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
@@ -543,6 +543,97 @@ describe('OpenAIResponsesCompactionSession', () => {
     expect(secondRequest.input[0].content[1].file_id).toBeUndefined();
   });
 
+  it('normalizes compacted user file_data messages before reusing them as input', async () => {
+    const base64 = Buffer.from('inline-file').toString('base64');
+    const compact = vi
+      .fn()
+      .mockResolvedValueOnce({
+        output: [
+          {
+            type: 'message',
+            role: 'user',
+            content: [
+              {
+                type: 'input_file',
+                file_data: base64,
+                filename: 'notes.txt',
+              },
+            ],
+          },
+        ],
+        usage: {
+          input_tokens: 2,
+          output_tokens: 1,
+          total_tokens: 3,
+        },
+      })
+      .mockResolvedValueOnce({
+        output: [],
+        usage: {
+          input_tokens: 1,
+          output_tokens: 0,
+          total_tokens: 1,
+        },
+      });
+    const session = new OpenAIResponsesCompactionSession({
+      client: { responses: { compact } } as any,
+      compactionMode: 'input',
+    });
+
+    await session.addItems([
+      {
+        type: 'message',
+        role: 'user',
+        content: [
+          {
+            type: 'input_file',
+            file: base64,
+            filename: 'notes.txt',
+          },
+        ],
+      },
+      {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'ready' }],
+      },
+    ] as any);
+
+    await session.runCompaction({ force: true, compactionMode: 'input' });
+
+    expect(await session.getItems()).toEqual([
+      {
+        type: 'message',
+        role: 'user',
+        content: [
+          {
+            type: 'input_file',
+            file: base64,
+            filename: 'notes.txt',
+          },
+        ],
+      },
+    ]);
+
+    await session.runCompaction({ force: true, compactionMode: 'input' });
+
+    const [secondRequest] = compact.mock.calls[1] ?? [];
+    expect(secondRequest.input).toHaveLength(1);
+    expect(secondRequest.input[0]).toMatchObject({
+      role: 'user',
+      content: [
+        {
+          type: 'input_file',
+          file_data: base64,
+          filename: 'notes.txt',
+        },
+      ],
+    });
+    expect(secondRequest.input[0].content[0].file_id).toBeUndefined();
+    expect(secondRequest.input[0].content[0].file_url).toBeUndefined();
+  });
+
   it('preserves existing history when compacted output normalization fails', async () => {
     const history = [
       {

--- a/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
+++ b/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
@@ -543,6 +543,50 @@ describe('OpenAIResponsesCompactionSession', () => {
     expect(secondRequest.input[0].content[1].file_id).toBeUndefined();
   });
 
+  it('preserves existing history when compacted output normalization fails', async () => {
+    const history = [
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'hello' }],
+      },
+      {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'world' }],
+      },
+    ] as const;
+    const compact = vi.fn().mockResolvedValue({
+      output: [
+        {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_image', detail: 'auto' }],
+        },
+      ],
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        total_tokens: 2,
+      },
+    });
+    const session = new OpenAIResponsesCompactionSession({
+      client: { responses: { compact } } as any,
+      compactionMode: 'input',
+    });
+
+    await session.addItems([...history] as any);
+
+    await expect(
+      session.runCompaction({ force: true, compactionMode: 'input' }),
+    ).rejects.toThrow(
+      'Compaction input_image item missing image_url or file_id.',
+    );
+
+    expect(await session.getItems()).toEqual(history);
+  });
+
   it('throws when runCompaction is called without a responseId in previous_response_id mode', async () => {
     const compact = vi.fn();
     const session = new OpenAIResponsesCompactionSession({

--- a/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
+++ b/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
@@ -449,6 +449,100 @@ describe('OpenAIResponsesCompactionSession', () => {
     ]);
   });
 
+  it('normalizes compacted user image messages before reusing them as input', async () => {
+    const dataUrl = 'data:image/jpeg;base64,abc123';
+    const compact = vi
+      .fn()
+      .mockResolvedValueOnce({
+        output: [
+          {
+            type: 'message',
+            role: 'user',
+            content: [
+              { type: 'input_text', text: 'analyse these images' },
+              {
+                type: 'input_image',
+                detail: 'auto',
+                file_id: null,
+                image_url: dataUrl,
+              },
+            ],
+          },
+        ],
+        usage: {
+          input_tokens: 2,
+          output_tokens: 1,
+          total_tokens: 3,
+        },
+      })
+      .mockResolvedValueOnce({
+        output: [],
+        usage: {
+          input_tokens: 1,
+          output_tokens: 0,
+          total_tokens: 1,
+        },
+      });
+    const session = new OpenAIResponsesCompactionSession({
+      client: { responses: { compact } } as any,
+      compactionMode: 'input',
+    });
+
+    await session.addItems([
+      {
+        type: 'message',
+        role: 'user',
+        content: [
+          { type: 'input_text', text: 'analyse these images' },
+          {
+            type: 'input_image',
+            image: dataUrl,
+          },
+        ],
+      },
+      {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'how can I help?' }],
+      },
+    ] as any);
+
+    await session.runCompaction({ force: true, compactionMode: 'input' });
+
+    expect(await session.getItems()).toEqual([
+      {
+        type: 'message',
+        role: 'user',
+        content: [
+          { type: 'input_text', text: 'analyse these images' },
+          {
+            type: 'input_image',
+            image: dataUrl,
+            detail: 'auto',
+          },
+        ],
+      },
+    ]);
+
+    await session.runCompaction({ force: true, compactionMode: 'input' });
+
+    const [secondRequest] = compact.mock.calls[1] ?? [];
+    expect(secondRequest.input).toHaveLength(1);
+    expect(secondRequest.input[0]).toMatchObject({
+      role: 'user',
+      content: [
+        { type: 'input_text', text: 'analyse these images' },
+        {
+          type: 'input_image',
+          image_url: dataUrl,
+          detail: 'auto',
+        },
+      ],
+    });
+    expect(secondRequest.input[0].content[1].file_id).toBeUndefined();
+  });
+
   it('throws when runCompaction is called without a responseId in previous_response_id mode', async () => {
     const compact = vi.fn();
     const session = new OpenAIResponsesCompactionSession({

--- a/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
@@ -1224,6 +1224,31 @@ describe('getInputItems', () => {
     ).toThrow(UserError);
   });
 
+  it('treats raw base64 input_file strings in messages as inline data', () => {
+    const base64 = Buffer.from('message-inline').toString('base64');
+    const items = getInputItems([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'input_file',
+            file: base64,
+            filename: 'inline.txt',
+          },
+        ],
+      },
+    ] as any);
+
+    const user = items.find((entry) => (entry as any).role === 'user') as any;
+    expect(user.content).toEqual([
+      {
+        type: 'input_file',
+        file_data: base64,
+        filename: 'inline.txt',
+      },
+    ]);
+  });
+
   it('converts legacy input_image fields in structured outputs', () => {
     const items = getInputItems([
       {

--- a/scripts/clean-package-dists.mjs
+++ b/scripts/clean-package-dists.mjs
@@ -1,0 +1,20 @@
+import { existsSync, readdirSync, rmSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '..');
+const packagesDir = join(repoRoot, 'packages');
+
+for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
+  if (!entry.isDirectory()) {
+    continue;
+  }
+
+  const distDir = join(packagesDir, entry.name, 'dist');
+  if (!existsSync(distDir)) {
+    continue;
+  }
+
+  rmSync(distDir, { force: true, recursive: true });
+}


### PR DESCRIPTION
This pull request resolves #1176 and fixes a regression where `OpenAIResponsesCompactionSession` stored raw `responses.compact` user message payloads instead of converting them back into the SDK's canonical session format. As a result, image-bearing user messages could be compacted successfully but later fail on the next `run()` because the serializer only accepts the protocol `image`/`file` shape, not raw `image_url`/`file_id`.

The change normalizes compacted user `input_image` and `input_file` content before writing session history, preserving the documented Responses API contract while keeping session storage consistent with the rest of the SDK. It also adds regression coverage for compacted image messages and updates the root build pipeline to clear stale package `dist/` artifacts before rebuilding so `dist:check` validates only current outputs.