### PR TITLE
fix(agents-core): deduplicate trace provider shutdown cleanup

### DIFF
--- a/.changeset/calm-traces-shutdown.md
+++ b/.changeset/calm-traces-shutdown.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: deduplicate trace provider shutdown cleanup.

--- a/packages/agents-core/src/tracing/provider.ts
+++ b/packages/agents-core/src/tracing/provider.ts
@@ -14,10 +14,12 @@ export type CreateSpanOptions<TData extends SpanData> = Omit<
 export class TraceProvider {
   #multiProcessor: MultiTracingProcessor;
   #disabled: boolean;
+  #shutdownPromise: Promise<void> | null;
 
   constructor() {
     this.#multiProcessor = new MultiTracingProcessor();
     this.#disabled = tracing.disabled;
+    this.#shutdownPromise = null;
 
     this.#addCleanupListeners();
   }
@@ -28,6 +30,7 @@ export class TraceProvider {
    * @param processor - The processor to add.
    */
   registerProcessor(processor: TracingProcessor): void {
+    this.#shutdownPromise = null;
     this.#multiProcessor.addTraceProcessor(processor);
   }
 
@@ -37,6 +40,7 @@ export class TraceProvider {
    * @param processors - The list of processors to set.
    */
   setProcessors(processors: TracingProcessor[]): void {
+    this.#shutdownPromise = null;
     this.#multiProcessor.setProcessors(processors);
   }
 
@@ -167,12 +171,17 @@ export class TraceProvider {
   }
 
   async shutdown(timeout?: number): Promise<void> {
-    try {
-      logger.debug('Shutting down tracing provider');
-      await this.#multiProcessor.shutdown(timeout);
-    } catch (error) {
-      logger.error('Error shutting down tracing provider %o', error);
+    if (!this.#shutdownPromise) {
+      this.#shutdownPromise = (async () => {
+        try {
+          logger.debug('Shutting down tracing provider');
+          await this.#multiProcessor.shutdown(timeout);
+        } catch (error) {
+          logger.error('Error shutting down tracing provider %o', error);
+        }
+      })();
     }
+    await this.#shutdownPromise;
   }
 
   /** Adds listeners to `process` to ensure `shutdown` occurs before exit. */
@@ -193,7 +202,7 @@ export class TraceProvider {
       };
 
       // Handle normal termination
-      process.on('beforeExit', cleanup);
+      process.once('beforeExit', cleanup);
 
       // Handle CTRL+C (SIGINT)
       process.on('SIGINT', async () => {

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -329,6 +329,47 @@ describe('Trace & Span lifecycle', () => {
     }
   });
 
+  it('deduplicates provider shutdown calls', async () => {
+    const provider = new TraceProvider();
+    const processor = new TestProcessor();
+    processor.shutdown = vi.fn(async () => {});
+    provider.setProcessors([processor]);
+
+    await Promise.all([provider.shutdown(), provider.shutdown()]);
+    await provider.shutdown();
+
+    expect(processor.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers beforeExit cleanup as a one-shot listener', () => {
+    const onceSpy = vi.spyOn(process, 'once');
+    const onSpy = vi.spyOn(process, 'on');
+    new TraceProvider();
+
+    const beforeExitListener = onceSpy.mock.calls.find(
+      ([event]) => event === 'beforeExit',
+    )?.[1];
+
+    expect(beforeExitListener).toEqual(expect.any(Function));
+
+    if (typeof beforeExitListener === 'function') {
+      process.off('beforeExit', beforeExitListener);
+    }
+    for (const [event, listener] of onSpy.mock.calls) {
+      if (
+        (event === 'SIGINT' ||
+          event === 'SIGTERM' ||
+          event === 'unhandledRejection') &&
+        typeof listener === 'function'
+      ) {
+        process.off(event, listener);
+      }
+    }
+
+    onceSpy.mockRestore();
+    onSpy.mockRestore();
+  });
+
   it('falls back to module provider when global registration fails', () => {
     const symbol = Symbol.for('openai.agents.core.traceProvider');
     const globalHolder = globalThis as unknown as Record<


### PR DESCRIPTION
This pull request fixes trace provider cleanup so process-exit shutdown runs deterministically without invoking trace processor shutdown multiple times. The previous `beforeExit` cleanup could be registered as a recurring listener, and async cleanup work could cause `beforeExit` to fire again; repeated direct `shutdown()` calls could also re-run processor shutdown.

The change makes `TraceProvider.shutdown()` idempotent, resets that shutdown state when processors are changed, and registers normal process-exit cleanup with `process.once('beforeExit', ...)`. It also adds regression coverage for duplicate shutdown calls and one-shot `beforeExit` registration, plus a patch changeset for `@openai/agents-core`.
