### PR TITLE
test: preserve tracing in real-model integration fixtures

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -12,6 +12,7 @@ It is intentionally not part of the `pnpm` workspace and instead installs the pa
 - Have an `OPENAI_API_KEY` environment variable configured
 - Run `pnpm exec playwright install` to install playwright
 - `pnpm test:integration` will create temporary `integration-tests/cloudflare-workers/worker/.dev.vars` and `integration-tests/vite-react/.env` files from `OPENAI_API_KEY` and restore any pre-existing files during cleanup
+- Integration test fixture subprocesses run with `NODE_ENV=development` so real-model SDK examples keep the normal server-runtime tracing behavior even though Vitest itself runs with `NODE_ENV=test`
 
 2. **Local npm registry**
 

--- a/integration-tests/_helpers/env.ts
+++ b/integration-tests/_helpers/env.ts
@@ -1,0 +1,17 @@
+export function createIntegrationSubprocessEnv(
+  overrides: Record<string, string | undefined> = {},
+): Record<string, string | undefined> {
+  const env = { ...process.env };
+  delete env.CODEX_CI;
+  delete env.CODEX_THREAD_ID;
+
+  return {
+    ...env,
+    // The Vitest parent runs with NODE_ENV=test, where SDK tracing is disabled by default.
+    NODE_ENV: 'development',
+    NODE_OPTIONS: '',
+    TS_NODE_PROJECT: '',
+    TS_NODE_COMPILER_OPTIONS: '',
+    ...overrides,
+  };
+}

--- a/integration-tests/bun.test.ts
+++ b/integration-tests/bun.test.ts
@@ -1,11 +1,16 @@
 import { describe, test, expect, beforeAll, afterAll } from 'vitest';
 import { execa as execaBase } from 'execa';
 
-const execa = execaBase({ cwd: './integration-tests/bun' });
+import { createIntegrationSubprocessEnv } from './_helpers/env';
+
+const execa = execaBase({
+  cwd: './integration-tests/bun',
+  env: createIntegrationSubprocessEnv(),
+});
 
 describe('Bun', () => {
   beforeAll(async () => {
-    // remove lock file to avoid errors
+    // Remove lock file to avoid errors.
     await execa`rm -f bun.lock`;
     console.log('[bun] Removing node_modules');
     await execa`rm -rf node_modules`;
@@ -13,12 +18,12 @@ describe('Bun', () => {
     await execa`bun install`;
   }, 60000);
 
-  test('should be able to run', async () => {
+  test('should be able to run', { timeout: 15_000 }, async () => {
     const { stdout } = await execa`bun run index.ts`;
     expect(stdout).toContain('[RESPONSE]Hello there![/RESPONSE]');
   });
 
-  test('should be able to run with zod', async () => {
+  test('should be able to run with zod', { timeout: 15_000 }, async () => {
     const { stdout } = await execa`bun run zod.ts`;
     expect(stdout).toContain('[RESPONSE]Hello there![/RESPONSE]');
   });

--- a/integration-tests/bun/index.ts
+++ b/integration-tests/bun/index.ts
@@ -1,14 +1,6 @@
 // @ts-check
 
-import {
-  Agent,
-  run,
-  setTraceProcessors,
-  ConsoleSpanExporter,
-  BatchTraceProcessor,
-} from '@openai/agents';
-
-setTraceProcessors([new BatchTraceProcessor(new ConsoleSpanExporter())]);
+import { Agent, getGlobalTraceProvider, run } from '@openai/agents';
 
 const agent = new Agent({
   name: 'Test Agent',
@@ -16,5 +8,9 @@ const agent = new Agent({
     'You will always only respond with "Hello there!". Not more not less.',
 });
 
-const result = await run(agent, 'Hey there!');
-console.log(`[RESPONSE]${result.finalOutput}[/RESPONSE]`);
+try {
+  const result = await run(agent, 'Hey there!');
+  console.log(`[RESPONSE]${result.finalOutput}[/RESPONSE]`);
+} finally {
+  await getGlobalTraceProvider().shutdown();
+}

--- a/integration-tests/bun/zod.ts
+++ b/integration-tests/bun/zod.ts
@@ -2,16 +2,7 @@
 
 import { z } from 'zod';
 
-import {
-  Agent,
-  run,
-  tool,
-  setTraceProcessors,
-  ConsoleSpanExporter,
-  BatchTraceProcessor,
-} from '@openai/agents';
-
-setTraceProcessors([new BatchTraceProcessor(new ConsoleSpanExporter())]);
+import { Agent, getGlobalTraceProvider, run, tool } from '@openai/agents';
 
 const getWeatherTool = tool({
   name: 'get_weather',
@@ -29,5 +20,9 @@ const agent = new Agent({
   tools: [getWeatherTool],
 });
 
-const result = await run(agent, 'What is the weather in San Francisco?');
-console.log(`[RESPONSE]${result.finalOutput}[/RESPONSE]`);
+try {
+  const result = await run(agent, 'What is the weather in San Francisco?');
+  console.log(`[RESPONSE]${result.finalOutput}[/RESPONSE]`);
+} finally {
+  await getGlobalTraceProvider().shutdown();
+}

--- a/integration-tests/cloudflare-workers/worker/src/index.ts
+++ b/integration-tests/cloudflare-workers/worker/src/index.ts
@@ -17,14 +17,11 @@ export interface Env {
 
 import {
   Agent,
-  BatchTraceProcessor,
-  ConsoleSpanExporter,
   getGlobalTraceProvider,
   getCurrentTrace,
   run,
   Runner,
   setDefaultOpenAIKey,
-  setTraceProcessors,
   withTrace,
 } from '@openai/agents';
 import { aisdk } from '@openai/agents-extensions/ai-sdk';
@@ -33,7 +30,6 @@ export default {
   async fetch(request, env, ctx): Promise<Response> {
     try {
       setDefaultOpenAIKey(env.OPENAI_API_KEY!);
-      setTraceProcessors([new BatchTraceProcessor(new ConsoleSpanExporter())]);
       const url = new URL(request.url);
 
       if (url.pathname === '/aisdk') {

--- a/integration-tests/cloudflare.test.ts
+++ b/integration-tests/cloudflare.test.ts
@@ -2,10 +2,12 @@ import { describe, test, expect, beforeAll, afterAll } from 'vitest';
 import { execa as execaBase, ResultPromise } from 'execa';
 import path from 'node:path';
 
+import { createIntegrationSubprocessEnv } from './_helpers/env';
 import { requireEnvVar, withManagedFile } from './_helpers/prereqs';
 
 const execa = execaBase({
   cwd: './integration-tests/cloudflare-workers/worker',
+  env: createIntegrationSubprocessEnv(),
 });
 
 let server: ResultPromise;
@@ -20,7 +22,7 @@ let cleanupDevVars: (() => Promise<void>) | undefined;
 
 describe('Cloudflare Workers', () => {
   beforeAll(async () => {
-    // Remove lock file to avoid errors
+    // Remove lock file to avoid errors.
     await execa`rm -f package-lock.json`;
     console.log('[cloudflare] Removing node_modules');
     await execa`rm -rf node_modules`;

--- a/integration-tests/deno.test.ts
+++ b/integration-tests/deno.test.ts
@@ -4,6 +4,8 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
+import { createIntegrationSubprocessEnv } from './_helpers/env';
+
 const denoCwd = './integration-tests/deno';
 const denoNpmrcPath = path.resolve(denoCwd, '.npmrc');
 let denoCacheDir = '';
@@ -15,11 +17,10 @@ describe('Deno', () => {
     denoCacheDir = await mkdtemp(path.join(tmpdir(), 'openai-agents-js-deno-'));
     execa = execaBase({
       cwd: denoCwd,
-      env: {
-        ...process.env,
+      env: createIntegrationSubprocessEnv({
         DENO_DIR: denoCacheDir,
         NPM_CONFIG_USERCONFIG: denoNpmrcPath,
-      },
+      }),
     });
 
     await rm(path.join(denoCwd, 'deno.lock'), { force: true });

--- a/integration-tests/deno/main.ts
+++ b/integration-tests/deno/main.ts
@@ -1,14 +1,6 @@
 // @ts-check
 
-import {
-  Agent,
-  run,
-  setTraceProcessors,
-  ConsoleSpanExporter,
-  BatchTraceProcessor,
-} from '@openai/agents';
-
-setTraceProcessors([new BatchTraceProcessor(new ConsoleSpanExporter())]);
+import { Agent, getGlobalTraceProvider, run } from '@openai/agents';
 
 const agent = new Agent({
   name: 'Test Agent',
@@ -16,5 +8,9 @@ const agent = new Agent({
     'You will always only respond with "Hello there!". Not more not less.',
 });
 
-const result = await run(agent, 'Hey there!');
-console.log(`[RESPONSE]${result.finalOutput}[/RESPONSE]`);
+try {
+  const result = await run(agent, 'Hey there!');
+  console.log(`[RESPONSE]${result.finalOutput}[/RESPONSE]`);
+} finally {
+  await getGlobalTraceProvider().shutdown();
+}

--- a/integration-tests/deno/zod.ts
+++ b/integration-tests/deno/zod.ts
@@ -2,16 +2,7 @@
 
 import { z } from 'zod';
 
-import {
-  Agent,
-  run,
-  tool,
-  setTraceProcessors,
-  ConsoleSpanExporter,
-  BatchTraceProcessor,
-} from '@openai/agents';
-
-setTraceProcessors([new BatchTraceProcessor(new ConsoleSpanExporter())]);
+import { Agent, getGlobalTraceProvider, run, tool } from '@openai/agents';
 
 const getWeatherTool = tool({
   name: 'get_weather',
@@ -29,5 +20,9 @@ const agent = new Agent({
   tools: [getWeatherTool],
 });
 
-const result = await run(agent, 'What is the weather in San Francisco?');
-console.log(`[RESPONSE]${result.finalOutput}[/RESPONSE]`);
+try {
+  const result = await run(agent, 'What is the weather in San Francisco?');
+  console.log(`[RESPONSE]${result.finalOutput}[/RESPONSE]`);
+} finally {
+  await getGlobalTraceProvider().shutdown();
+}

--- a/integration-tests/node-ai-sdk-v2-ts.test.ts
+++ b/integration-tests/node-ai-sdk-v2-ts.test.ts
@@ -1,14 +1,11 @@
 import { describe, test, expect, beforeAll } from 'vitest';
 import { execa as execaBase } from 'execa';
 
+import { createIntegrationSubprocessEnv } from './_helpers/env';
+
 const execa = execaBase({
   cwd: './integration-tests/node-ai-sdk-v2-ts',
-  env: {
-    ...process.env,
-    NODE_OPTIONS: '',
-    TS_NODE_PROJECT: '',
-    TS_NODE_COMPILER_OPTIONS: '',
-  },
+  env: createIntegrationSubprocessEnv(),
 });
 
 describe('Node.js (TypeScript + AI SDK v2)', () => {

--- a/integration-tests/node-ai-sdk-v2-ts/src/index.ts
+++ b/integration-tests/node-ai-sdk-v2-ts/src/index.ts
@@ -1,4 +1,4 @@
-import { Agent, run, tool } from '@openai/agents';
+import { Agent, getGlobalTraceProvider, run, tool } from '@openai/agents';
 import { aisdk } from '@openai/agents-extensions/ai-sdk';
 import { z } from 'zod';
 import { openai } from '@ai-sdk/openai';
@@ -29,11 +29,15 @@ export async function main() {
     },
   });
 
-  const result = await run(
-    agent,
-    'Hello what is the weather in San Francisco?',
-  );
-  console.log(`[AISDK_V2_RESPONSE]${result.finalOutput}[/AISDK_V2_RESPONSE]`);
+  try {
+    const result = await run(
+      agent,
+      'Hello what is the weather in San Francisco?',
+    );
+    console.log(`[AISDK_V2_RESPONSE]${result.finalOutput}[/AISDK_V2_RESPONSE]`);
+  } finally {
+    await getGlobalTraceProvider().shutdown();
+  }
 }
 
 main().catch((error) => {

--- a/integration-tests/node-ai-sdk-v3-ts.test.ts
+++ b/integration-tests/node-ai-sdk-v3-ts.test.ts
@@ -1,14 +1,11 @@
 import { describe, test, expect, beforeAll } from 'vitest';
 import { execa as execaBase } from 'execa';
 
+import { createIntegrationSubprocessEnv } from './_helpers/env';
+
 const execa = execaBase({
   cwd: './integration-tests/node-ai-sdk-v3-ts',
-  env: {
-    ...process.env,
-    NODE_OPTIONS: '',
-    TS_NODE_PROJECT: '',
-    TS_NODE_COMPILER_OPTIONS: '',
-  },
+  env: createIntegrationSubprocessEnv(),
 });
 
 describe('Node.js (TypeScript + AI SDK v3)', () => {

--- a/integration-tests/node-ai-sdk-v3-ts/src/index.ts
+++ b/integration-tests/node-ai-sdk-v3-ts/src/index.ts
@@ -1,4 +1,4 @@
-import { Agent, run, tool } from '@openai/agents';
+import { Agent, getGlobalTraceProvider, run, tool } from '@openai/agents';
 import { aisdk } from '@openai/agents-extensions/ai-sdk';
 import { z } from 'zod';
 import { openai } from '@ai-sdk/openai';
@@ -29,11 +29,15 @@ export async function main() {
     },
   });
 
-  const result = await run(
-    agent,
-    'Hello what is the weather in San Francisco?',
-  );
-  console.log(`[AISDK_V3_RESPONSE]${result.finalOutput}[/AISDK_V3_RESPONSE]`);
+  try {
+    const result = await run(
+      agent,
+      'Hello what is the weather in San Francisco?',
+    );
+    console.log(`[AISDK_V3_RESPONSE]${result.finalOutput}[/AISDK_V3_RESPONSE]`);
+  } finally {
+    await getGlobalTraceProvider().shutdown();
+  }
 }
 
 main().catch((error) => {

--- a/integration-tests/node-zod3.test.ts
+++ b/integration-tests/node-zod3.test.ts
@@ -1,31 +1,32 @@
 import { describe, test, expect, beforeAll } from 'vitest';
 import { execa as execaBase } from 'execa';
 
+import { createIntegrationSubprocessEnv } from './_helpers/env';
+
 const execa = execaBase({
   cwd: './integration-tests/node-zod3',
-  env: {
-    ...process.env,
-    NODE_OPTIONS: '',
-    TS_NODE_PROJECT: '',
-    TS_NODE_COMPILER_OPTIONS: '',
-  },
+  env: createIntegrationSubprocessEnv(),
 });
 
 describe('Node.js', () => {
   beforeAll(async () => {
-    // remove lock file to avoid errors
+    // Remove lock file to avoid errors.
     console.log('[node] Removing node_modules');
     await execa`rm -rf node_modules`;
     console.log('[node] Installing dependencies');
     await execa`npm install`;
   }, 60000);
 
-  test('should be able to run using CommonJS', async () => {
-    const { stdout } = await execa`npm run start:cjs`;
-    expect(stdout).toContain('[RESPONSE]Hello there![/RESPONSE]');
-  });
+  test(
+    'should be able to run using CommonJS',
+    { timeout: 15_000 },
+    async () => {
+      const { stdout } = await execa`npm run start:cjs`;
+      expect(stdout).toContain('[RESPONSE]Hello there![/RESPONSE]');
+    },
+  );
 
-  test('should be able to run using ESM', async () => {
+  test('should be able to run using ESM', { timeout: 15_000 }, async () => {
     const { stdout } = await execa`npm run start:esm`;
     expect(stdout).toContain('[RESPONSE]Hello there![/RESPONSE]');
   });

--- a/integration-tests/node-zod3/index.cjs
+++ b/integration-tests/node-zod3/index.cjs
@@ -1,17 +1,8 @@
 // @ts-check
 
-const {
-  Agent,
-  run,
-  tool,
-  setTraceProcessors,
-  ConsoleSpanExporter,
-  BatchTraceProcessor,
-} = require('@openai/agents');
+const { Agent, getGlobalTraceProvider, run, tool } = require('@openai/agents');
 
 const { z } = require('zod/v3');
-
-setTraceProcessors([new BatchTraceProcessor(new ConsoleSpanExporter())]);
 
 const getWeatherTool = tool({
   name: 'get_weather',
@@ -30,8 +21,12 @@ const agent = new Agent({
 });
 
 async function main() {
-  const result = await run(agent, 'Hey there!');
-  console.log(`[RESPONSE]${result.finalOutput}[/RESPONSE]`);
+  try {
+    const result = await run(agent, 'Hey there!');
+    console.log(`[RESPONSE]${result.finalOutput}[/RESPONSE]`);
+  } finally {
+    await getGlobalTraceProvider().shutdown();
+  }
 }
 
 main().catch(console.error);

--- a/integration-tests/node-zod3/index.mjs
+++ b/integration-tests/node-zod3/index.mjs
@@ -2,16 +2,7 @@
 
 import { z } from 'zod/v3';
 
-import {
-  Agent,
-  run,
-  tool,
-  setTraceProcessors,
-  ConsoleSpanExporter,
-  BatchTraceProcessor,
-} from '@openai/agents';
-
-setTraceProcessors([new BatchTraceProcessor(new ConsoleSpanExporter())]);
+import { Agent, getGlobalTraceProvider, run, tool } from '@openai/agents';
 
 const getWeatherTool = tool({
   name: 'get_weather',
@@ -29,5 +20,9 @@ const agent = new Agent({
   tools: [getWeatherTool],
 });
 
-const result = await run(agent, 'What is the weather in San Francisco?');
-console.log(`[RESPONSE]${result.finalOutput}[/RESPONSE]`);
+try {
+  const result = await run(agent, 'What is the weather in San Francisco?');
+  console.log(`[RESPONSE]${result.finalOutput}[/RESPONSE]`);
+} finally {
+  await getGlobalTraceProvider().shutdown();
+}

--- a/integration-tests/node-zod4-ts.test.ts
+++ b/integration-tests/node-zod4-ts.test.ts
@@ -1,14 +1,11 @@
 import { describe, test, expect, beforeAll } from 'vitest';
 import { execa as execaBase } from 'execa';
 
+import { createIntegrationSubprocessEnv } from './_helpers/env';
+
 const execa = execaBase({
   cwd: './integration-tests/node-zod4-ts',
-  env: {
-    ...process.env,
-    NODE_OPTIONS: '',
-    TS_NODE_PROJECT: '',
-    TS_NODE_COMPILER_OPTIONS: '',
-  },
+  env: createIntegrationSubprocessEnv(),
 });
 
 describe('Node.js (TypeScript + Zod v4)', () => {

--- a/integration-tests/node-zod4-ts/src/index.ts
+++ b/integration-tests/node-zod4-ts/src/index.ts
@@ -1,15 +1,6 @@
 import { z } from 'zod';
 
-import {
-  Agent,
-  run,
-  tool,
-  setTraceProcessors,
-  ConsoleSpanExporter,
-  BatchTraceProcessor,
-} from '@openai/agents';
-
-setTraceProcessors([new BatchTraceProcessor(new ConsoleSpanExporter())]);
+import { Agent, getGlobalTraceProvider, run, tool } from '@openai/agents';
 
 const getWeatherTool = tool({
   name: 'get_weather',
@@ -28,8 +19,12 @@ const agent = new Agent({
 });
 
 async function main() {
-  const result = await run(agent, 'What is the weather in San Francisco?');
-  console.log(`[RESPONSE]${result.finalOutput}[/RESPONSE]`);
+  try {
+    const result = await run(agent, 'What is the weather in San Francisco?');
+    console.log(`[RESPONSE]${result.finalOutput}[/RESPONSE]`);
+  } finally {
+    await getGlobalTraceProvider().shutdown();
+  }
 }
 
 main().catch((error) => {

--- a/integration-tests/node-zod4.test.ts
+++ b/integration-tests/node-zod4.test.ts
@@ -1,31 +1,32 @@
 import { describe, test, expect, beforeAll } from 'vitest';
 import { execa as execaBase } from 'execa';
 
+import { createIntegrationSubprocessEnv } from './_helpers/env';
+
 const execa = execaBase({
   cwd: './integration-tests/node-zod4',
-  env: {
-    ...process.env,
-    NODE_OPTIONS: '',
-    TS_NODE_PROJECT: '',
-    TS_NODE_COMPILER_OPTIONS: '',
-  },
+  env: createIntegrationSubprocessEnv(),
 });
 
 describe('Node.js', () => {
   beforeAll(async () => {
-    // remove lock file to avoid errors
+    // Remove lock file to avoid errors.
     console.log('[node] Removing node_modules');
     await execa`rm -rf node_modules`;
     console.log('[node] Installing dependencies');
     await execa`npm install`;
   }, 60000);
 
-  test('should be able to run using CommonJS', async () => {
-    const { stdout } = await execa`npm run start:cjs`;
-    expect(stdout).toContain('[RESPONSE]Hello there![/RESPONSE]');
-  });
+  test(
+    'should be able to run using CommonJS',
+    { timeout: 15_000 },
+    async () => {
+      const { stdout } = await execa`npm run start:cjs`;
+      expect(stdout).toContain('[RESPONSE]Hello there![/RESPONSE]');
+    },
+  );
 
-  test('should be able to run using ESM', { timeout: 15000 }, async () => {
+  test('should be able to run using ESM', { timeout: 15_000 }, async () => {
     const { stdout } = await execa`npm run start:esm`;
     expect(stdout).toContain('[RESPONSE]Hello there![/RESPONSE]');
   });

--- a/integration-tests/node-zod4/index.cjs
+++ b/integration-tests/node-zod4/index.cjs
@@ -1,17 +1,8 @@
 // @ts-check
 
-const {
-  Agent,
-  run,
-  tool,
-  setTraceProcessors,
-  ConsoleSpanExporter,
-  BatchTraceProcessor,
-} = require('@openai/agents');
+const { Agent, getGlobalTraceProvider, run, tool } = require('@openai/agents');
 
 const { z } = require('zod');
-
-setTraceProcessors([new BatchTraceProcessor(new ConsoleSpanExporter())]);
 
 const getWeatherTool = tool({
   name: 'get_weather',
@@ -30,8 +21,12 @@ const agent = new Agent({
 });
 
 async function main() {
-  const result = await run(agent, 'Hey there!');
-  console.log(`[RESPONSE]${result.finalOutput}[/RESPONSE]`);
+  try {
+    const result = await run(agent, 'Hey there!');
+    console.log(`[RESPONSE]${result.finalOutput}[/RESPONSE]`);
+  } finally {
+    await getGlobalTraceProvider().shutdown();
+  }
 }
 
 main().catch(console.error);

--- a/integration-tests/node-zod4/index.mjs
+++ b/integration-tests/node-zod4/index.mjs
@@ -2,16 +2,7 @@
 
 import { z } from 'zod';
 
-import {
-  Agent,
-  run,
-  tool,
-  setTraceProcessors,
-  ConsoleSpanExporter,
-  BatchTraceProcessor,
-} from '@openai/agents';
-
-setTraceProcessors([new BatchTraceProcessor(new ConsoleSpanExporter())]);
+import { Agent, getGlobalTraceProvider, run, tool } from '@openai/agents';
 
 const getWeatherTool = tool({
   name: 'get_weather',
@@ -29,5 +20,9 @@ const agent = new Agent({
   tools: [getWeatherTool],
 });
 
-const result = await run(agent, 'What is the weather in San Francisco?');
-console.log(`[RESPONSE]${result.finalOutput}[/RESPONSE]`);
+try {
+  const result = await run(agent, 'What is the weather in San Francisco?');
+  console.log(`[RESPONSE]${result.finalOutput}[/RESPONSE]`);
+} finally {
+  await getGlobalTraceProvider().shutdown();
+}

--- a/integration-tests/node.test.ts
+++ b/integration-tests/node.test.ts
@@ -1,25 +1,16 @@
 import { describe, test, expect, beforeAll } from 'vitest';
 import { execa as execaBase } from 'execa';
 
-const {
-  CODEX_CI: _codexCi,
-  CODEX_THREAD_ID: _codexThreadId,
-  ...integrationEnv
-} = process.env;
+import { createIntegrationSubprocessEnv } from './_helpers/env';
 
 const execa = execaBase({
   cwd: './integration-tests/node',
-  env: {
-    ...integrationEnv,
-    NODE_OPTIONS: '',
-    TS_NODE_PROJECT: '',
-    TS_NODE_COMPILER_OPTIONS: '',
-  },
+  env: createIntegrationSubprocessEnv(),
 });
 
 describe('Node.js', () => {
   beforeAll(async () => {
-    // remove lock file to avoid errors
+    // Remove lock file to avoid errors.
     console.log('[node] Removing node_modules');
     await execa`rm -rf node_modules`;
     console.log('[node] Installing dependencies');

--- a/integration-tests/node/codex.mjs
+++ b/integration-tests/node/codex.mjs
@@ -2,7 +2,7 @@
 
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { Agent, run } from '@openai/agents';
+import { Agent, getGlobalTraceProvider, run } from '@openai/agents';
 import { codexTool } from '@openai/agents-extensions/experimental/codex';
 
 const fixtureDirectory = path.dirname(fileURLToPath(import.meta.url));
@@ -122,11 +122,15 @@ async function main() {
     ].join(' '),
     tools: [codex],
   });
-  const result = await run(
-    agent,
-    'Use the codex tool to inspect package.json in the current workspace and tell me the version of @openai/codex-sdk.',
-  );
-  console.log(`[CODEX_RESPONSE]${result.finalOutput}[/CODEX_RESPONSE]`);
+  try {
+    const result = await run(
+      agent,
+      'Use the codex tool to inspect package.json in the current workspace and tell me the version of @openai/codex-sdk.',
+    );
+    console.log(`[CODEX_RESPONSE]${result.finalOutput}[/CODEX_RESPONSE]`);
+  } finally {
+    await getGlobalTraceProvider().shutdown();
+  }
 }
 
 main().catch((error) => {

--- a/integration-tests/node/index.cjs
+++ b/integration-tests/node/index.cjs
@@ -1,14 +1,6 @@
 // @ts-check
 
-const {
-  Agent,
-  run,
-  setTraceProcessors,
-  ConsoleSpanExporter,
-  BatchTraceProcessor,
-} = require('@openai/agents');
-
-setTraceProcessors([new BatchTraceProcessor(new ConsoleSpanExporter())]);
+const { Agent, getGlobalTraceProvider, run } = require('@openai/agents');
 
 const agent = new Agent({
   name: 'Test Agent',
@@ -17,8 +9,12 @@ const agent = new Agent({
 });
 
 async function main() {
-  const result = await run(agent, 'Hey there!');
-  console.log(`[RESPONSE]${result.finalOutput}[/RESPONSE]`);
+  try {
+    const result = await run(agent, 'Hey there!');
+    console.log(`[RESPONSE]${result.finalOutput}[/RESPONSE]`);
+  } finally {
+    await getGlobalTraceProvider().shutdown();
+  }
 }
 
 main().catch(console.error);

--- a/integration-tests/node/index.mjs
+++ b/integration-tests/node/index.mjs
@@ -1,14 +1,6 @@
 // @ts-check
 
-import {
-  Agent,
-  run,
-  setTraceProcessors,
-  ConsoleSpanExporter,
-  BatchTraceProcessor,
-} from '@openai/agents';
-
-setTraceProcessors([new BatchTraceProcessor(new ConsoleSpanExporter())]);
+import { Agent, getGlobalTraceProvider, run } from '@openai/agents';
 
 const agent = new Agent({
   name: 'Test Agent',
@@ -16,5 +8,9 @@ const agent = new Agent({
     'You will always only respond with "Hello there!". Not more not less.',
 });
 
-const result = await run(agent, 'Hey there!');
-console.log(`[RESPONSE]${result.finalOutput}[/RESPONSE]`);
+try {
+  const result = await run(agent, 'Hey there!');
+  console.log(`[RESPONSE]${result.finalOutput}[/RESPONSE]`);
+} finally {
+  await getGlobalTraceProvider().shutdown();
+}

--- a/integration-tests/vite-react.test.ts
+++ b/integration-tests/vite-react.test.ts
@@ -3,6 +3,7 @@ import { chromium } from 'playwright';
 import { execa as execaBase, ResultPromise } from 'execa';
 import path from 'node:path';
 
+import { createIntegrationSubprocessEnv } from './_helpers/env';
 import {
   assertPathExists,
   requireEnvVar,
@@ -11,6 +12,7 @@ import {
 
 const execa = execaBase({
   cwd: './integration-tests/vite-react',
+  env: createIntegrationSubprocessEnv(),
 });
 
 let server: ResultPromise;
@@ -24,7 +26,7 @@ let cleanupEnvFile: (() => Promise<void>) | undefined;
 
 describe('Vite React', () => {
   beforeAll(async () => {
-    // Remove lock file to avoid errors
+    // Remove lock file to avoid errors.
     await execa`rm -f package-lock.json`;
     console.log('[vite-react] Removing node_modules');
     await execa`rm -rf node_modules`;


### PR DESCRIPTION
This pull request updates integration test fixtures so real-model subprocesses keep the SDK's normal server-runtime tracing behavior even though Vitest itself runs with `NODE_ENV=test`.

It adds a shared integration subprocess environment helper, removes fixture-level `ConsoleSpanExporter` overrides so the default OpenAI tracing exporter is used, explicitly shuts down the global trace provider in short-lived fixture processes to flush traces before exit, and documents the integration fixture environment behavior.