### PR TITLE
fix(twilio): send clear message on interrupt when audio is fully flushed

### DIFF
--- a/packages/agents-extensions/src/TwilioRealtimeTransport.ts
+++ b/packages/agents-extensions/src/TwilioRealtimeTransport.ts
@@ -203,6 +203,16 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
     super.updateSessionConfig(newConfig);
   }
 
+  interrupt(cancelOngoingResponse: boolean = true): void {
+    this.#twilioWebSocket.send(
+      JSON.stringify({
+        event: 'clear',
+        streamSid: this.#streamSid,
+      }),
+    );
+    super.interrupt(cancelOngoingResponse);
+  }
+
   _interrupt(_elapsedTime: number, cancelOngoingResponse: boolean = true) {
     const elapsedTime = this.#lastPlayedChunkCount + 50; /* 50ms buffer */
     this.#logger.debug(


### PR DESCRIPTION
## Problem

Fixes #1173.

When all audio chunks have already been flushed to Twilio before an interruption is triggered (e.g. the user speaks immediately after the AI finishes talking), the parent `interrupt()` method in `OpenAIRealtimeWebSocket` returns early because the audio queue is empty. This means `_interrupt()` is never called, so no Twilio `clear` message is sent — leaving Twilio actively playing audio that should have been stopped.

## Root Cause

`openaiRealtimeWebsocket.ts` `interrupt()` at line 500 guards with an early return when no audio is queued:

```ts
// parent class — simplified
interrupt(cancelOngoingResponse = true) {
  if (this.audioQueue.length === 0) return; // ← early exit, _interrupt() never fires
  this._interrupt(...);
}
```

`TwilioRealtimeTransportLayer._interrupt()` already sends the `clear` message, but it is only reached when audio is still buffered.

## Fix

Override the public `interrupt()` method in `TwilioRealtimeTransportLayer` to **always** send the Twilio `clear` message before delegating to `super.interrupt()`:

```ts
interrupt(cancelOngoingResponse: boolean = true): void {
  this.#twilioWebSocket.send(
    JSON.stringify({
      event: 'clear',
      streamSid: this.#streamSid,
    }),
  );
  super.interrupt(cancelOngoingResponse);
}
```

This guarantees active Twilio playback is stopped regardless of whether the audio queue is empty or not. The existing `_interrupt()` override is preserved unchanged and continues to handle mid-stream interruptions with the correct elapsed-time calculation.

## Testing

- LSP diagnostics on the modified file: **0 errors**
- Security scan (`codesure`): **0 findings**
- Build-check errors in the fork are pre-existing (missing `node_modules`) and unrelated to this change