### PR TITLE
feat: #1186 expose createAiSdkUiMessageStream

### DIFF
--- a/.changeset/ai-sdk-ui-message-stream.md
+++ b/.changeset/ai-sdk-ui-message-stream.md
@@ -1,5 +1,5 @@
 ---
-'@openai/agents-extensions': minor
+'@openai/agents-extensions': patch
 ---
 
 feat: expose createAiSdkUiMessageStream for AI SDK UI chunks

--- a/.changeset/ai-sdk-ui-message-stream.md
+++ b/.changeset/ai-sdk-ui-message-stream.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': minor
+---
+
+feat: expose createAiSdkUiMessageStream for AI SDK UI chunks

--- a/.changeset/ai-sdk-ui-message-stream.md
+++ b/.changeset/ai-sdk-ui-message-stream.md
@@ -2,4 +2,4 @@
 '@openai/agents-extensions': patch
 ---
 
-feat: expose createAiSdkUiMessageStream for AI SDK UI chunks
+feat: #1186 expose createAiSdkUiMessageStream for AI SDK UI chunks

--- a/docs/src/content/docs/extensions/ai-sdk.mdx
+++ b/docs/src/content/docs/extensions/ai-sdk.mdx
@@ -10,6 +10,7 @@ import aiSdkProviderDataExample from '../../../../../examples/docs/extensions/ai
 import aiSdkProviderMetadataExample from '../../../../../examples/docs/extensions/ai-sdk-providerMetadata.ts?raw';
 import aiSdkSetupExample from '../../../../../examples/docs/extensions/ai-sdk-setup.ts?raw';
 import aiSdkTransformOutputTextExample from '../../../../../examples/docs/extensions/ai-sdk-transform-output-text.ts?raw';
+import aiSdkUiMessageStreamExample from '../../../../../examples/docs/extensions/ai-sdk-ui-message-stream.ts?raw';
 import aiSdkUiMessageStreamResponseExample from '../../../../../examples/docs/extensions/ai-sdk-ui-message-stream-response.ts?raw';
 import aiSdkTextStreamResponseExample from '../../../../../examples/docs/extensions/ai-sdk-text-stream-response.ts?raw';
 
@@ -113,17 +114,26 @@ There are two related integrations in `@openai/agents-extensions`:
 `@openai/agents-extensions/ai-sdk-ui` provides response helpers for wiring Agents SDK streams into AI SDK UI routes:
 
 - `createAiSdkTextStreamResponse(source, options?)` for plain text streaming responses.
+- `createAiSdkUiMessageStream(source)` for a lower-level `ReadableStream<UIMessageChunk>`.
 - `createAiSdkUiMessageStreamResponse(source, options?)` for `UIMessageChunk` streaming responses.
 
-Both helpers accept a `StreamedRunResult`, stream-like source, or compatible wrapper object and return a `Response` with streaming-friendly headers.
+These helpers accept a `StreamedRunResult`, stream-like source, or compatible wrapper object. The response helpers return a `Response` with streaming-friendly headers.
 
-Use `createAiSdkUiMessageStreamResponse(...)` when your UI needs structured chunks such as tool calls or reasoning parts. Use `createAiSdkTextStreamResponse(...)` when you only want plain text.
+Use `createAiSdkUiMessageStreamResponse(...)` when your route should return the AI SDK response directly. Use `createAiSdkUiMessageStream(...)` when you want to own the response or rendering layer while still using the maintained Agents SDK to AI SDK `UIMessageChunk` translation. Use `createAiSdkTextStreamResponse(...)` when you only want plain text.
 
-Both helpers also accept optional response settings through `options`:
+The response helpers also accept optional response settings through `options`:
 
 - `headers`: additional response headers to merge into the streaming response.
 - `status`: the HTTP status code for the returned `Response`.
 - `statusText`: the HTTP status text for the returned `Response`.
+
+Example lower-level UI message stream:
+
+<Code
+  lang="typescript"
+  code={aiSdkUiMessageStreamExample}
+  title="UI message stream"
+/>
 
 Example Next.js route for UI message streaming:
 

--- a/examples/docs/extensions/ai-sdk-ui-message-stream.ts
+++ b/examples/docs/extensions/ai-sdk-ui-message-stream.ts
@@ -1,0 +1,12 @@
+import { Agent, run } from '@openai/agents';
+import { createAiSdkUiMessageStream } from '@openai/agents-extensions/ai-sdk-ui';
+
+const agent = new Agent({
+  name: 'Assistant',
+  instructions: 'Reply with a short answer.',
+});
+
+export async function createStream() {
+  const stream = await run(agent, 'Hello there.', { stream: true });
+  return createAiSdkUiMessageStream(stream);
+}

--- a/packages/agents-extensions/src/ai-sdk-ui/uiMessageStream.ts
+++ b/packages/agents-extensions/src/ai-sdk-ui/uiMessageStream.ts
@@ -483,15 +483,15 @@ async function* buildUiMessageStream(
 }
 
 /**
- * Creates a UI message stream Response compatible with the AI SDK data stream protocol.
+ * Creates a UI message stream compatible with the AI SDK data stream protocol.
  */
-export function createAiSdkUiMessageStreamResponse(
+export function createAiSdkUiMessageStream(
   source: AiSdkUiMessageStreamSource,
-  options: AiSdkUiMessageStreamResponseOptions = {},
-): Response {
+): ReadableStream<UIMessageChunk> {
   const events = resolveEventSource(source);
   const iterator = buildUiMessageStream(events)[Symbol.asyncIterator]();
-  const stream = new ReadableStream<UIMessageChunk>({
+
+  return new ReadableStream<UIMessageChunk>({
     async pull(controller) {
       const { value, done } = await iterator.next();
       if (done) {
@@ -506,6 +506,16 @@ export function createAiSdkUiMessageStreamResponse(
       }
     },
   });
+}
+
+/**
+ * Creates a UI message stream Response compatible with the AI SDK data stream protocol.
+ */
+export function createAiSdkUiMessageStreamResponse(
+  source: AiSdkUiMessageStreamSource,
+  options: AiSdkUiMessageStreamResponseOptions = {},
+): Response {
+  const stream = createAiSdkUiMessageStream(source);
 
   return createUIMessageStreamResponse({
     stream,

--- a/packages/agents-extensions/test/ai-sdk-ui/uiMessageStream.test.ts
+++ b/packages/agents-extensions/test/ai-sdk-ui/uiMessageStream.test.ts
@@ -11,8 +11,12 @@ import {
   RunToolSearchCallItem,
   RunToolSearchOutputItem,
 } from '@openai/agents';
+import type { RunStreamEvent } from '@openai/agents';
 import type { UIMessageChunk } from 'ai';
-import { createAiSdkUiMessageStreamResponse } from '../../src/ai-sdk-ui/index';
+import {
+  createAiSdkUiMessageStream,
+  createAiSdkUiMessageStreamResponse,
+} from '../../src/ai-sdk-ui/index';
 
 async function readResponseText(response: Response): Promise<string> {
   if (!response.body) {
@@ -61,7 +65,106 @@ async function readUiMessageChunks(
   return chunks;
 }
 
+async function readUiMessageStream(
+  stream: ReadableStream<UIMessageChunk>,
+): Promise<UIMessageChunk[]> {
+  const reader = stream.getReader();
+  const chunks: UIMessageChunk[] = [];
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return chunks;
+}
+
+function createRunEventStream(
+  events: RunStreamEvent[],
+): ReadableStream<RunStreamEvent> {
+  return new ReadableStream<RunStreamEvent>({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(event);
+      }
+      controller.close();
+    },
+  });
+}
+
 describe('createAiSdkUiMessageStreamResponse', () => {
+  test('creates a raw UI message chunk stream from toStream sources', async () => {
+    const agent = new Agent({ name: 'Test Agent' });
+
+    const messageOutput = new RunMessageOutputItem(
+      {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'Raw stream message' }],
+      },
+      agent,
+    );
+
+    const stream = createAiSdkUiMessageStream({
+      toStream: () =>
+        createRunEventStream([
+          new RunItemStreamEvent('message_output_created', messageOutput),
+        ]),
+    });
+
+    const chunks = await readUiMessageStream(stream);
+
+    expect(chunks.map((chunk) => chunk.type)).toEqual([
+      'start',
+      'start-step',
+      'text-start',
+      'text-delta',
+      'text-end',
+      'finish-step',
+      'finish',
+    ]);
+
+    const textDelta = chunks.find((chunk) => chunk.type === 'text-delta');
+    expect(textDelta).toMatchObject({ delta: 'Raw stream message' });
+  });
+
+  test('cancels the underlying event iterator when a raw stream is cancelled', async () => {
+    let cancelled = false;
+
+    const events = (async function* () {
+      try {
+        yield new RunRawModelStreamEvent({ type: 'response_started' });
+        yield new RunRawModelStreamEvent({
+          type: 'output_text_delta',
+          delta: 'unread',
+        });
+      } finally {
+        cancelled = true;
+      }
+    })();
+
+    const stream = createAiSdkUiMessageStream(events);
+    const reader = stream.getReader();
+
+    const first = await reader.read();
+    expect(first).toMatchObject({
+      done: false,
+      value: { type: 'start' },
+    });
+
+    await reader.cancel();
+
+    expect(cancelled).toBe(true);
+  });
+
   test('maps run stream events to UI message chunks', async () => {
     const agent = new Agent({ name: 'Test Agent' });
 

--- a/packages/agents-extensions/tsconfig.dist-check.json
+++ b/packages/agents-extensions/tsconfig.dist-check.json
@@ -4,7 +4,7 @@
     "noEmit": true,
     "skipLibCheck": false,
     "types": ["node"],
-    "lib": ["ES2018", "DOM"],
+    "lib": ["ES2018", "ES2022.Intl", "DOM"],
     "baseUrl": ".",
     "paths": {
       "@openai/agents-core/_shims": [


### PR DESCRIPTION
This pull request implements #1186 by exposing `createAiSdkUiMessageStream(...)` from `@openai/agents-extensions/ai-sdk-ui` as the lower-level `ReadableStream<UIMessageChunk>` helper that currently sits underneath `createAiSdkUiMessageStreamResponse(...)`. The response helper now delegates to the new export, so consumers can either return the built-in streaming `Response` or own the response/transport layer while still reusing the maintained Agents SDK to AI SDK UI chunk translation.

The change keeps the existing response behavior intact, adds regression coverage for direct `toStream` sources and cancellation, documents the new helper with a docs example, includes the package changeset, and updates the `agents-extensions` dist check lib target so the exported AI SDK types continue to type-check. Validation: `pnpm build`, `pnpm -r build-check`, `CI=1 pnpm test`, `pnpm lint`, `pnpm docs:build`, and `pnpm -F @openai/agents-extensions dist:check`.
