### PR TITLE
fix: use locked MCP filesystem server in examples

### DIFF
--- a/examples/docs/mcp/stdio.ts
+++ b/examples/docs/mcp/stdio.ts
@@ -4,8 +4,8 @@ import * as path from 'node:path';
 async function main() {
   const samplesDir = path.join(__dirname, 'sample_files');
   const mcpServer = new MCPServerStdio({
-    name: 'Filesystem MCP Server, via npx',
-    fullCommand: `npx -y @modelcontextprotocol/server-filesystem ${samplesDir}`,
+    name: 'Filesystem MCP Server, via local package',
+    fullCommand: `pnpm exec mcp-server-filesystem ${samplesDir}`,
   });
   await mcpServer.connect();
   try {

--- a/examples/docs/package.json
+++ b/examples/docs/package.json
@@ -3,6 +3,7 @@
   "name": "docs-code",
   "dependencies": {
     "@ai-sdk/openai": "^2.0.15",
+    "@modelcontextprotocol/server-filesystem": "^2026.1.14",
     "@openai/agents": "workspace:*",
     "@openai/agents-core": "workspace:*",
     "@openai/agents-extensions": "workspace:*",

--- a/examples/docs/tools/mcpLocalServer.ts
+++ b/examples/docs/tools/mcpLocalServer.ts
@@ -1,7 +1,7 @@
 import { Agent, MCPServerStdio } from '@openai/agents';
 
 const server = new MCPServerStdio({
-  fullCommand: 'npx -y @modelcontextprotocol/server-filesystem ./sample_files',
+  fullCommand: 'pnpm exec mcp-server-filesystem ./sample_files',
 });
 
 await server.connect();

--- a/examples/mcp/filesystem-example.ts
+++ b/examples/mcp/filesystem-example.ts
@@ -4,11 +4,11 @@ import * as path from 'node:path';
 async function main() {
   const samplesDir = path.join(__dirname, 'sample_files');
   const mcpServer = new MCPServerStdio({
-    name: 'Filesystem Server, via npx',
-    fullCommand: `npx -y @modelcontextprotocol/server-filesystem ${samplesDir}`,
-    // Or passing command and args
-    // command: 'npx',
-    // args: ['-y', '@modelcontextprotocol/server-filesystem', samplesDir],
+    name: 'Filesystem Server, via local package',
+    fullCommand: `pnpm exec mcp-server-filesystem ${samplesDir}`,
+    // Or passing command and args.
+    // command: 'pnpm',
+    // args: ['exec', 'mcp-server-filesystem', samplesDir],
   });
 
   await mcpServer.connect();

--- a/examples/mcp/get-all-mcp-tools-example.ts
+++ b/examples/mcp/get-all-mcp-tools-example.ts
@@ -14,7 +14,7 @@ async function main() {
   // Create multiple MCP servers to demonstrate getAllMcpTools
   const filesystemServer = new MCPServerStdio({
     name: 'Filesystem Server',
-    fullCommand: `npx -y @modelcontextprotocol/server-filesystem ${samplesDir}`,
+    fullCommand: `pnpm exec mcp-server-filesystem ${samplesDir}`,
   });
 
   // Note: This example shows how to use multiple servers

--- a/examples/mcp/package.json
+++ b/examples/mcp/package.json
@@ -3,6 +3,7 @@
   "name": "mcp",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
+    "@modelcontextprotocol/server-filesystem": "^2026.1.14",
     "@openai/agents": "workspace:*"
   },
   "scripts": {

--- a/examples/mcp/tool-filter-example.ts
+++ b/examples/mcp/tool-filter-example.ts
@@ -24,7 +24,7 @@ async function main() {
   const samplesDir = path.join(__dirname, 'sample_files');
   const mcpServer = new MCPServerStdio({
     name: 'Filesystem Server with filter',
-    fullCommand: `npx -y @modelcontextprotocol/server-filesystem ${samplesDir}`,
+    fullCommand: `pnpm exec mcp-server-filesystem ${samplesDir}`,
     toolFilter: createMCPToolStaticFilter({
       allowed: ['read_file', 'list_directory'],
       blocked: ['write_file'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,6 +260,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^2.0.15
         version: 2.0.15(zod@4.3.5)
+      '@modelcontextprotocol/server-filesystem':
+        specifier: ^2026.1.14
+        version: 2026.1.14(zod@4.3.5)
       '@openai/agents':
         specifier: workspace:*
         version: link:../../packages/agents
@@ -303,6 +306,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.26.0
         version: 1.26.0(zod@4.3.6)
+      '@modelcontextprotocol/server-filesystem':
+        specifier: ^2026.1.14
+        version: 2026.1.14(zod@4.3.6)
       '@openai/agents':
         specifier: workspace:*
         version: link:../../packages/agents
@@ -1693,6 +1699,10 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@modelcontextprotocol/server-filesystem@2026.1.14':
+    resolution: {integrity: sha512-bGAfu3fWRVeF10NxvPhFBDlRen6ExSx6YkKJzoVgQMNrbdVVV4okfGGQ3KBRu9ygXYfw5/N9ermHAJXA0uys+g==}
+    hasBin: true
 
   '@next/env@16.2.3':
     resolution: {integrity: sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==}
@@ -3334,6 +3344,10 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  diff@5.2.2:
+    resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
+    engines: {node: '>=0.3.1'}
+
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
@@ -4817,10 +4831,6 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-
-  minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
-    engines: {node: '>=16 || 14 >=14.17'}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
@@ -7537,7 +7547,7 @@ snapshots:
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   '@istanbuljs/schema@0.1.3': {}
 
@@ -7650,7 +7660,6 @@ snapshots:
       zod-to-json-schema: 3.25.1(zod@4.3.5)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@modelcontextprotocol/sdk@1.26.0(zod@4.3.6)':
     dependencies:
@@ -7673,6 +7682,30 @@ snapshots:
       zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
+
+  '@modelcontextprotocol/server-filesystem@2026.1.14(zod@4.3.5)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.26.0(zod@4.3.5)
+      diff: 5.2.2
+      glob: 10.5.0
+      minimatch: 10.2.4
+      zod-to-json-schema: 3.25.1(zod@4.3.5)
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+      - zod
+
+  '@modelcontextprotocol/server-filesystem@2026.1.14(zod@4.3.6)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.26.0(zod@4.3.6)
+      diff: 5.2.2
+      glob: 10.5.0
+      minimatch: 10.2.4
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+      - zod
 
   '@next/env@16.2.3': {}
 
@@ -9348,6 +9381,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  diff@5.2.2: {}
 
   diff@8.0.4: {}
 
@@ -11398,13 +11433,11 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minipass@7.1.2: {}
-
   minipass@7.1.3: {}
 
   minizlib@3.0.2:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   mkdirp@1.0.4: {}
 
@@ -12678,7 +12711,7 @@ snapshots:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
-      minipass: 7.1.2
+      minipass: 7.1.3
       minizlib: 3.0.2
       mkdirp: 3.0.1
       yallist: 5.0.0


### PR DESCRIPTION
## What changed

- Replaced the MCP filesystem examples' `npx -y @modelcontextprotocol/server-filesystem` commands with `pnpm exec mcp-server-filesystem`.
- Added `@modelcontextprotocol/server-filesystem` as a dependency for the docs-code and MCP example workspaces.
- Updated `pnpm-lock.yaml` so the filesystem MCP server resolves through the repo-managed dependency graph.

## Why

This is package-manager security hardening that reduces package-compromise risk. The previous example commands could resolve and execute the freshest published npm package at runtime, bypassing the repository's pnpm `minimumReleaseAge` policy. Resolving the server through workspace dependencies keeps installs under the repo lockfile and pnpm age gate.

## Verification

- `bash .agents/skills/code-change-verification/scripts/run.sh`
- Repo-wide package-manager audit confirmed the original `npx -y @modelcontextprotocol/server-filesystem` bypass is no longer present in the MCP examples.