### PR TITLE
fix(agents-core): reconcile orphaned function_call items on stream abort with conversationId

### DIFF
--- a/.changeset/fix-orphaned-function-call-reconciliation.md
+++ b/.changeset/fix-orphaned-function-call-reconciliation.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: reconcile orphaned function_call items on stream abort or consumer cancel with conversationId

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -34,7 +34,11 @@ import type { TracingConfig } from './tracing';
 import { Usage } from './usage';
 import { convertAgentOutputTypeToSerializable } from './utils/tools';
 import { DEFAULT_MAX_TURNS } from './runner/constants';
-import { StreamEventResponseCompleted } from './types/protocol';
+import {
+  StreamEventResponseCompleted,
+  FunctionCallItem,
+  FunctionCallResultItem,
+} from './types/protocol';
 import type { Session, SessionInputCallback } from './memory/session';
 import type { AgentInputItem } from './types';
 import {
@@ -1149,6 +1153,12 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           guardrailTracker.throwIfError();
 
           let finalResponse: ModelResponse | undefined = undefined;
+          // Track function_call items the server has already persisted during streaming.
+          // These need synthetic outputs if we abort before tool execution.
+          const pendingFunctionCalls = new Map<
+            string,
+            Pick<FunctionCallItem, 'callId' | 'name' | 'namespace'>
+          >();
           let inputMarked = false;
           const markInputOnce = () => {
             if (inputMarked || !serverConversationTracker) {
@@ -1203,6 +1213,36 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             )) {
               guardrailTracker.throwIfError();
               markInputOnce();
+              // Track function_call items persisted server-side as they stream so we can
+              // reconcile them with synthetic outputs on abort.
+              if (
+                serverConversationTracker &&
+                event.type === 'model' &&
+                event.event &&
+                typeof event.event === 'object'
+              ) {
+                const rawEvent = event.event as Record<string, unknown>;
+                if (
+                  rawEvent['type'] === 'response.output_item.done' &&
+                  rawEvent['item'] &&
+                  typeof rawEvent['item'] === 'object'
+                ) {
+                  const item = rawEvent['item'] as Record<string, unknown>;
+                  if (
+                    item['type'] === 'function_call' &&
+                    typeof item['call_id'] === 'string'
+                  ) {
+                    pendingFunctionCalls.set(item['call_id'] as string, {
+                      callId: item['call_id'] as string,
+                      name:
+                        typeof item['name'] === 'string' ? item['name'] : '',
+                      ...(typeof item['namespace'] === 'string'
+                        ? { namespace: item['namespace'] as string }
+                        : {}),
+                    });
+                  }
+                }
+              }
               if (event.type === 'response_done') {
                 const parsed = StreamEventResponseCompleted.parse(event);
                 finalResponse = {
@@ -1212,6 +1252,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                   requestId: parsed.response.requestId,
                 };
                 result.state._context.usage.add(finalResponse.usage);
+                // All function_call items are now accounted for in the final response;
+                // tool execution will supply the corresponding outputs normally.
+                pendingFunctionCalls.clear();
               }
               if (result.cancelled) {
                 // When the user's code exits a loop to consume the stream, we need to break
@@ -1227,6 +1270,56 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 markInputOnce();
               }
               await awaitGuardrailsAndPersistInput();
+              // When using server-managed conversations (conversationId /
+              // previousResponseId), the server has already persisted any
+              // function_call items that finished streaming. Submit synthetic
+              // function_call_result outputs so the conversation stays consistent
+              // and subsequent runs against the same conversation do not fail with
+              // "No tool output found for function call".
+              if (
+                serverConversationTracker &&
+                pendingFunctionCalls.size > 0
+              ) {
+                const syntheticOutputs: FunctionCallResultItem[] = Array.from(
+                  pendingFunctionCalls.values(),
+                ).map(
+                  (fc): FunctionCallResultItem => ({
+                    type: 'function_call_result',
+                    callId: fc.callId,
+                    name: fc.name,
+                    ...(fc.namespace ? { namespace: fc.namespace } : {}),
+                    status: 'incomplete',
+                    output: { type: 'text', text: 'aborted' },
+                  }),
+                );
+                try {
+                  await getResponseWithRetry(preparedCall.model, {
+                    systemInstructions:
+                      preparedCall.modelInput.instructions,
+                    prompt: preparedCall.prompt,
+                    input: syntheticOutputs,
+                    previousResponseId: preparedCall.previousResponseId,
+                    conversationId: preparedCall.conversationId,
+                    modelSettings: preparedCall.modelSettings,
+                    tools: preparedCall.serializedTools,
+                    toolsExplicitlyProvided:
+                      preparedCall.toolsExplicitlyProvided,
+                    handoffs: preparedCall.serializedHandoffs,
+                    outputType: convertAgentOutputTypeToSerializable(
+                      currentAgent.outputType,
+                    ),
+                    tracing: getTracing(
+                      this.config.tracingDisabled,
+                      this.config.traceIncludeSensitiveData,
+                    ),
+                    // Do not forward the abort signal — this reconciliation call
+                    // must complete even though the original run was aborted.
+                  });
+                } catch {
+                  // Best-effort: ignore errors from the reconciliation call so
+                  // the original AbortError propagates cleanly.
+                }
+              }
               return;
             }
             throw error;

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1279,29 +1279,37 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                       }),
                     );
                   try {
-                    await getResponseWithRetry(preparedCall.model, {
-                      systemInstructions:
-                        preparedCall.modelInput.instructions,
-                      prompt: preparedCall.prompt,
-                      ...(preparedCall.explictlyModelSet
-                        ? { overridePromptModel: true }
-                        : {}),
-                      input: syntheticOutputs,
-                      previousResponseId: preparedCall.previousResponseId,
-                      conversationId: preparedCall.conversationId,
-                      modelSettings: preparedCall.modelSettings,
-                      tools: preparedCall.serializedTools,
-                      toolsExplicitlyProvided:
-                        preparedCall.toolsExplicitlyProvided,
-                      handoffs: preparedCall.serializedHandoffs,
-                      outputType: convertAgentOutputTypeToSerializable(
-                        currentAgent.outputType,
-                      ),
-                      tracing: getTracing(
-                        this.config.tracingDisabled,
-                        this.config.traceIncludeSensitiveData,
-                      ),
-                    });
+                    const reconciliationResponse =
+                      await getResponseWithRetry(preparedCall.model, {
+                        systemInstructions:
+                          preparedCall.modelInput.instructions,
+                        prompt: preparedCall.prompt,
+                        ...(preparedCall.explictlyModelSet
+                          ? { overridePromptModel: true }
+                          : {}),
+                        input: syntheticOutputs,
+                        previousResponseId: preparedCall.previousResponseId,
+                        conversationId: preparedCall.conversationId,
+                        modelSettings: preparedCall.modelSettings,
+                        tools: preparedCall.serializedTools,
+                        toolsExplicitlyProvided:
+                          preparedCall.toolsExplicitlyProvided,
+                        handoffs: preparedCall.serializedHandoffs,
+                        outputType: convertAgentOutputTypeToSerializable(
+                          currentAgent.outputType,
+                        ),
+                        tracing: getTracing(
+                          this.config.tracingDisabled,
+                          this.config.traceIncludeSensitiveData,
+                        ),
+                      });
+                    serverConversationTracker.trackServerItems(
+                      reconciliationResponse,
+                    );
+                    result.state.setConversationContext(
+                      serverConversationTracker.conversationId,
+                      serverConversationTracker.previousResponseId,
+                    );
                   } catch {
                     // Best-effort: ignore errors so normal cancellation flow
                     // is not disrupted.
@@ -1340,31 +1348,39 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                   }),
                 );
                 try {
-                  await getResponseWithRetry(preparedCall.model, {
-                    systemInstructions:
-                      preparedCall.modelInput.instructions,
-                    prompt: preparedCall.prompt,
-                    ...(preparedCall.explictlyModelSet
-                      ? { overridePromptModel: true }
-                      : {}),
-                    input: syntheticOutputs,
-                    previousResponseId: preparedCall.previousResponseId,
-                    conversationId: preparedCall.conversationId,
-                    modelSettings: preparedCall.modelSettings,
-                    tools: preparedCall.serializedTools,
-                    toolsExplicitlyProvided:
-                      preparedCall.toolsExplicitlyProvided,
-                    handoffs: preparedCall.serializedHandoffs,
-                    outputType: convertAgentOutputTypeToSerializable(
-                      currentAgent.outputType,
-                    ),
-                    tracing: getTracing(
-                      this.config.tracingDisabled,
-                      this.config.traceIncludeSensitiveData,
-                    ),
-                    // Do not forward the abort signal — this reconciliation call
-                    // must complete even though the original run was aborted.
-                  });
+                  const reconciliationResponse =
+                    await getResponseWithRetry(preparedCall.model, {
+                      systemInstructions:
+                        preparedCall.modelInput.instructions,
+                      prompt: preparedCall.prompt,
+                      ...(preparedCall.explictlyModelSet
+                        ? { overridePromptModel: true }
+                        : {}),
+                      input: syntheticOutputs,
+                      previousResponseId: preparedCall.previousResponseId,
+                      conversationId: preparedCall.conversationId,
+                      modelSettings: preparedCall.modelSettings,
+                      tools: preparedCall.serializedTools,
+                      toolsExplicitlyProvided:
+                        preparedCall.toolsExplicitlyProvided,
+                      handoffs: preparedCall.serializedHandoffs,
+                      outputType: convertAgentOutputTypeToSerializable(
+                        currentAgent.outputType,
+                      ),
+                      tracing: getTracing(
+                        this.config.tracingDisabled,
+                        this.config.traceIncludeSensitiveData,
+                      ),
+                      // Do not forward the abort signal — this reconciliation call
+                      // must complete even though the original run was aborted.
+                    });
+                  serverConversationTracker.trackServerItems(
+                    reconciliationResponse,
+                  );
+                  result.state.setConversationContext(
+                    serverConversationTracker.conversationId,
+                    serverConversationTracker.previousResponseId,
+                  );
                 } catch {
                   // Best-effort: ignore errors from the reconciliation call so
                   // the original AbortError propagates cleanly.

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1260,6 +1260,53 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 // When the user's code exits a loop to consume the stream, we need to break
                 // this loop to prevent internal false errors and unnecessary processing
                 await awaitGuardrailsAndPersistInput();
+                // Reconcile any persisted function_call items the same way we do on
+                // the abort-error path, so server-managed conversation state stays
+                // consistent when a consumer cancels iteration mid-stream.
+                if (
+                  serverConversationTracker &&
+                  pendingFunctionCalls.size > 0
+                ) {
+                  const syntheticOutputs: FunctionCallResultItem[] =
+                    Array.from(pendingFunctionCalls.values()).map(
+                      (fc): FunctionCallResultItem => ({
+                        type: 'function_call_result',
+                        callId: fc.callId,
+                        name: fc.name,
+                        ...(fc.namespace ? { namespace: fc.namespace } : {}),
+                        status: 'incomplete',
+                        output: { type: 'text', text: 'aborted' },
+                      }),
+                    );
+                  try {
+                    await getResponseWithRetry(preparedCall.model, {
+                      systemInstructions:
+                        preparedCall.modelInput.instructions,
+                      prompt: preparedCall.prompt,
+                      ...(preparedCall.explictlyModelSet
+                        ? { overridePromptModel: true }
+                        : {}),
+                      input: syntheticOutputs,
+                      previousResponseId: preparedCall.previousResponseId,
+                      conversationId: preparedCall.conversationId,
+                      modelSettings: preparedCall.modelSettings,
+                      tools: preparedCall.serializedTools,
+                      toolsExplicitlyProvided:
+                        preparedCall.toolsExplicitlyProvided,
+                      handoffs: preparedCall.serializedHandoffs,
+                      outputType: convertAgentOutputTypeToSerializable(
+                        currentAgent.outputType,
+                      ),
+                      tracing: getTracing(
+                        this.config.tracingDisabled,
+                        this.config.traceIncludeSensitiveData,
+                      ),
+                    });
+                  } catch {
+                    // Best-effort: ignore errors so normal cancellation flow
+                    // is not disrupted.
+                  }
+                }
                 return;
               }
               result._addItem(new RunRawModelStreamEvent(event));
@@ -1297,6 +1344,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                     systemInstructions:
                       preparedCall.modelInput.instructions,
                     prompt: preparedCall.prompt,
+                    ...(preparedCall.explictlyModelSet
+                      ? { overridePromptModel: true }
+                      : {}),
                     input: syntheticOutputs,
                     previousResponseId: preparedCall.previousResponseId,
                     conversationId: preparedCall.conversationId,


### PR DESCRIPTION
When a streaming run is aborted (e.g. via `AbortSignal` or an early loop exit) while using server-managed conversations (`conversationId` / `previousResponseId`), the Responses API has already persisted any `function_call` items that finished streaming. Subsequent runs against the same conversation then fail with "No tool output found for function call" because the server expects matching `function_call_result` outputs that were never submitted.

The fix tracks every `response.output_item.done` event that carries a `function_call` item during streaming. On an abort path in `Runner`, if any such calls are still pending (i.e. `response_done` was never received), synthetic `function_call_result` items with `status: "incomplete"` and a placeholder output are submitted to the API via a best-effort reconciliation call. This keeps the server-side conversation state consistent without surfacing errors to the caller.

The reconciliation call deliberately omits the original `AbortSignal` so it can complete even though the triggering run was cancelled, and any failure from it is silently swallowed so the original `AbortError` propagates cleanly. The tracking map is cleared on a successful `response_done` event, so the reconciliation path is a no-op for runs that complete normally.

Changes are confined to `packages/agents-core/src/run.ts`, specifically inside the streaming event loop of the `Runner` class, and reuse the already-imported `FunctionCallItem` and `FunctionCallResultItem` types from `./types/protocol`.

Fixes #1190
