### PR TITLE
feat(sandbox): add Modal provider

### DIFF
--- a/.changeset/sandbox-agents-modal.md
+++ b/.changeset/sandbox-agents-modal.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': minor
+---
+
+feat: add Modal sandbox provider

--- a/examples/sandbox/extensions/modal-runner.ts
+++ b/examples/sandbox/extensions/modal-runner.ts
@@ -1,0 +1,112 @@
+import { Runner } from '@openai/agents';
+import {
+  ModalSandboxClient,
+  type ModalWorkspacePersistence,
+} from '@openai/agents-extensions/sandbox/modal';
+import { Manifest, SandboxAgent, shell } from '@openai/agents/sandbox';
+import { finished } from 'node:stream/promises';
+import {
+  DEFAULT_MODEL,
+  getStringArg,
+  hasFlag,
+  getOptionalNumberArg,
+  getOptionalStringArg,
+  requireOpenAIKey,
+  runExampleMain,
+} from '../support';
+
+const DEFAULT_QUESTION =
+  'Summarize this cloud sandbox workspace in 2 sentences.';
+
+function parseWorkspacePersistence(
+  value: string | undefined,
+): ModalWorkspacePersistence {
+  if (!value || value === 'tar') {
+    return 'tar';
+  }
+  throw new Error('--workspace-persistence must be "tar".');
+}
+
+function buildManifest(): Manifest {
+  return new Manifest({
+    entries: {
+      'README.md': {
+        type: 'file',
+        content: `# Modal Demo Workspace
+
+This workspace exists to validate the Modal sandbox backend manually.
+`,
+      },
+      'incident.md': {
+        type: 'file',
+        content: `# Incident
+
+- Customer: Fabrikam Retail.
+- Issue: delayed reporting rollout.
+- Primary blocker: incomplete security questionnaire.
+`,
+      },
+      'plan.md': {
+        type: 'file',
+        content: `# Plan
+
+1. Close the questionnaire.
+2. Reconfirm the rollout date with the customer.
+`,
+      },
+    },
+  });
+}
+
+async function main() {
+  requireOpenAIKey();
+
+  const model = getStringArg('--model', DEFAULT_MODEL);
+  const question = getStringArg('--question', DEFAULT_QUESTION);
+  const appName =
+    getOptionalStringArg('--app-name') ?? 'openai-agents-js-sandbox-example';
+  const workspacePersistence = parseWorkspacePersistence(
+    getOptionalStringArg('--workspace-persistence'),
+  );
+  const sandboxCreateTimeoutS = getOptionalNumberArg(
+    '--sandbox-create-timeout-s',
+  );
+  const nativeCloudBucketSecretName = getOptionalStringArg(
+    '--native-cloud-bucket-secret-name',
+  );
+  const stream = hasFlag('--stream');
+  const client = new ModalSandboxClient({
+    appName,
+    workspacePersistence,
+    sandboxCreateTimeoutS,
+    nativeCloudBucketSecretName,
+  });
+  const agent = new SandboxAgent({
+    name: 'Modal Sandbox Assistant',
+    model,
+    instructions:
+      'Answer questions about the sandbox workspace. Inspect the files before answering, keep the response concise, and cite the file names you inspected.',
+    defaultManifest: buildManifest(),
+    capabilities: [shell()],
+  });
+  const runner = new Runner({
+    workflowName: 'Modal sandbox example',
+    sandbox: { client },
+  });
+
+  if (!stream) {
+    const result = await runner.run(agent, question);
+    console.log(result.finalOutput);
+    return;
+  }
+
+  const result = await runner.run(agent, question, { stream: true });
+  process.stdout.write('assistant> ');
+  const textStream = result.toTextStream({ compatibleWithNodeStreams: true });
+  textStream.pipe(process.stdout);
+  await finished(textStream);
+  await result.completed;
+  process.stdout.write('\n');
+}
+
+await runExampleMain(main);

--- a/packages/agents-extensions/src/sandbox/modal/index.ts
+++ b/packages/agents-extensions/src/sandbox/modal/index.ts
@@ -1,0 +1,2 @@
+export * from './sandbox';
+export * from './mounts';

--- a/packages/agents-extensions/src/sandbox/modal/mounts.ts
+++ b/packages/agents-extensions/src/sandbox/modal/mounts.ts
@@ -115,6 +115,11 @@ export function buildModalCloudBucketMountConfig(
     const accessId = readOptionalString(mount, 'accessId');
     const secretAccessKey = readOptionalString(mount, 'secretAccessKey');
     const endpointUrl = readOptionalString(mount, 'endpointUrl');
+    validateGcsCredentialPair({
+      accessId,
+      secretAccessKey,
+      mountType: mount.type,
+    });
     if ((!accessId || !secretAccessKey) && !options.secretName) {
       throw new SandboxMountError(
         'Modal GCS bucket mounts require accessId and secretAccessKey unless secretName is provided.',
@@ -231,6 +236,22 @@ function validateCredentialPair(args: {
   if (Boolean(args.accessKeyId) !== Boolean(args.secretAccessKey)) {
     throw new SandboxMountError(
       'Modal cloud bucket mounts require both accessKeyId and secretAccessKey when either is provided.',
+      {
+        provider: 'modal',
+        mountType: args.mountType,
+      },
+    );
+  }
+}
+
+function validateGcsCredentialPair(args: {
+  accessId?: string;
+  secretAccessKey?: string;
+  mountType: string;
+}): void {
+  if (Boolean(args.accessId) !== Boolean(args.secretAccessKey)) {
+    throw new SandboxMountError(
+      'Modal GCS bucket mounts require both accessId and secretAccessKey when either is provided.',
       {
         provider: 'modal',
         mountType: args.mountType,

--- a/packages/agents-extensions/src/sandbox/modal/mounts.ts
+++ b/packages/agents-extensions/src/sandbox/modal/mounts.ts
@@ -1,0 +1,279 @@
+import {
+  SandboxMountError,
+  SandboxUnsupportedFeatureError,
+  type Entry,
+  type GCSMount,
+  type R2Mount,
+  type S3Mount,
+  type TypedMount,
+} from '@openai/agents-core/sandbox';
+import { readOptionalString } from '../shared';
+
+export type ModalCloudBucketMountCredentials = Record<string, string>;
+
+export type ModalCloudBucketMountConfig = {
+  bucketName: string;
+  bucketEndpointUrl?: string;
+  keyPrefix?: string;
+  credentials?: ModalCloudBucketMountCredentials;
+  secretName?: string;
+  secretEnvironmentName?: string;
+  readOnly: boolean;
+};
+
+export type ModalCloudBucketMountStrategyOptions = {
+  secretName?: string;
+  secretEnvironmentName?: string;
+};
+
+export class ModalCloudBucketMountStrategy {
+  readonly [key: string]: unknown;
+  readonly type = 'modal_cloud_bucket';
+  readonly secretName?: string;
+  readonly secretEnvironmentName?: string;
+
+  constructor(options: ModalCloudBucketMountStrategyOptions = {}) {
+    this.secretName = options.secretName;
+    this.secretEnvironmentName = options.secretEnvironmentName;
+  }
+}
+
+export function buildModalCloudBucketMountConfig(
+  mount: Entry,
+  options: ModalCloudBucketMountStrategyOptions = {},
+): ModalCloudBucketMountConfig {
+  validateSecretOptions(mount, options);
+
+  if (isS3Mount(mount)) {
+    const accessKeyId = readOptionalString(mount, 'accessKeyId');
+    const secretAccessKey = readOptionalString(mount, 'secretAccessKey');
+    const sessionToken = readOptionalString(mount, 'sessionToken');
+    validateCredentialPair({
+      accessKeyId,
+      secretAccessKey,
+      mountType: mount.type,
+    });
+    validateSessionTokenCredentials({
+      accessKeyId,
+      secretAccessKey,
+      sessionToken,
+      mountType: mount.type,
+    });
+    const credentials = compactCredentials({
+      AWS_ACCESS_KEY_ID: accessKeyId,
+      AWS_SECRET_ACCESS_KEY: secretAccessKey,
+      AWS_SESSION_TOKEN: sessionToken,
+    });
+    assertNoInlineCredentialsWithSecret(mount, credentials, options.secretName);
+    return {
+      bucketName: mount.bucket,
+      bucketEndpointUrl: mount.endpointUrl,
+      keyPrefix: mount.prefix,
+      credentials,
+      secretName: options.secretName,
+      secretEnvironmentName: options.secretEnvironmentName,
+      readOnly: mount.readOnly ?? true,
+    };
+  }
+
+  if (isR2Mount(mount)) {
+    const accessKeyId = readOptionalString(mount, 'accessKeyId');
+    const secretAccessKey = readOptionalString(mount, 'secretAccessKey');
+    validateCredentialPair({
+      accessKeyId,
+      secretAccessKey,
+      mountType: mount.type,
+    });
+    const credentials = compactCredentials({
+      AWS_ACCESS_KEY_ID: accessKeyId,
+      AWS_SECRET_ACCESS_KEY: secretAccessKey,
+    });
+    assertNoInlineCredentialsWithSecret(mount, credentials, options.secretName);
+    const customDomain = readOptionalString(mount, 'customDomain');
+    if (!customDomain && !mount.accountId) {
+      throw new SandboxMountError(
+        'Modal R2 bucket mounts require accountId or customDomain.',
+        {
+          provider: 'modal',
+          mountType: mount.type,
+        },
+      );
+    }
+    return {
+      bucketName: mount.bucket,
+      bucketEndpointUrl:
+        customDomain ?? `https://${mount.accountId}.r2.cloudflarestorage.com`,
+      keyPrefix: mount.prefix,
+      credentials,
+      secretName: options.secretName,
+      secretEnvironmentName: options.secretEnvironmentName,
+      readOnly: mount.readOnly ?? true,
+    };
+  }
+
+  if (isGCSMount(mount)) {
+    const accessId = readOptionalString(mount, 'accessId');
+    const secretAccessKey = readOptionalString(mount, 'secretAccessKey');
+    const endpointUrl = readOptionalString(mount, 'endpointUrl');
+    if ((!accessId || !secretAccessKey) && !options.secretName) {
+      throw new SandboxMountError(
+        'Modal GCS bucket mounts require accessId and secretAccessKey unless secretName is provided.',
+        {
+          provider: 'modal',
+          mountType: mount.type,
+        },
+      );
+    }
+    const credentials =
+      accessId && secretAccessKey
+        ? {
+            GOOGLE_ACCESS_KEY_ID: accessId,
+            GOOGLE_ACCESS_KEY_SECRET: secretAccessKey,
+          }
+        : undefined;
+    assertNoInlineCredentialsWithSecret(mount, credentials, options.secretName);
+    return {
+      bucketName: mount.bucket,
+      bucketEndpointUrl: endpointUrl ?? 'https://storage.googleapis.com',
+      keyPrefix: mount.prefix,
+      credentials,
+      secretName: options.secretName,
+      secretEnvironmentName: options.secretEnvironmentName,
+      readOnly: mount.readOnly ?? true,
+    };
+  }
+
+  throw new SandboxUnsupportedFeatureError(
+    'Modal cloud bucket mounts are not supported for this mount type.',
+    {
+      provider: 'modal',
+      feature: 'entry.mount',
+      mountType: String((mount as { type?: unknown }).type ?? 'unknown'),
+    },
+  );
+}
+
+export function isModalCloudBucketMountEntry(
+  entry: Entry,
+): entry is TypedMount {
+  return (
+    isTypedBucketMount(entry) &&
+    entry.mountStrategy?.type === 'modal_cloud_bucket'
+  );
+}
+
+function validateSecretOptions(
+  mount: Entry,
+  options: ModalCloudBucketMountStrategyOptions,
+): void {
+  if (options.secretName !== undefined && options.secretName.trim() === '') {
+    throw new SandboxMountError(
+      'Modal cloud bucket secretName must be a non-empty string.',
+      {
+        provider: 'modal',
+        mountType: mount.type,
+      },
+    );
+  }
+  if (
+    options.secretEnvironmentName !== undefined &&
+    options.secretEnvironmentName.trim() === ''
+  ) {
+    throw new SandboxMountError(
+      'Modal cloud bucket secretEnvironmentName must be a non-empty string.',
+      {
+        provider: 'modal',
+        mountType: mount.type,
+      },
+    );
+  }
+  if (options.secretEnvironmentName !== undefined && !options.secretName) {
+    throw new SandboxMountError(
+      'Modal cloud bucket secretEnvironmentName requires secretName.',
+      {
+        provider: 'modal',
+        mountType: mount.type,
+      },
+    );
+  }
+}
+
+function assertNoInlineCredentialsWithSecret(
+  mount: Entry,
+  credentials: ModalCloudBucketMountCredentials | undefined,
+  secretName: string | undefined,
+): void {
+  if (secretName && credentials && Object.keys(credentials).length > 0) {
+    throw new SandboxMountError(
+      'Modal cloud bucket mounts do not support both inline credentials and secretName.',
+      {
+        provider: 'modal',
+        mountType: mount.type,
+      },
+    );
+  }
+}
+
+function compactCredentials(
+  credentials: Record<string, string | undefined>,
+): ModalCloudBucketMountCredentials | undefined {
+  const compact = Object.fromEntries(
+    Object.entries(credentials).filter(([, value]) => value !== undefined),
+  ) as ModalCloudBucketMountCredentials;
+  return Object.keys(compact).length > 0 ? compact : undefined;
+}
+
+function validateCredentialPair(args: {
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  mountType: string;
+}): void {
+  if (Boolean(args.accessKeyId) !== Boolean(args.secretAccessKey)) {
+    throw new SandboxMountError(
+      'Modal cloud bucket mounts require both accessKeyId and secretAccessKey when either is provided.',
+      {
+        provider: 'modal',
+        mountType: args.mountType,
+      },
+    );
+  }
+}
+
+function validateSessionTokenCredentials(args: {
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  sessionToken?: string;
+  mountType: string;
+}): void {
+  if (args.sessionToken && (!args.accessKeyId || !args.secretAccessKey)) {
+    throw new SandboxMountError(
+      'Modal S3 bucket mounts require accessKeyId and secretAccessKey when sessionToken is provided.',
+      {
+        provider: 'modal',
+        mountType: args.mountType,
+      },
+    );
+  }
+}
+
+function isTypedBucketMount(
+  entry: Entry,
+): entry is S3Mount | R2Mount | GCSMount {
+  return (
+    entry.type === 's3_mount' ||
+    entry.type === 'r2_mount' ||
+    entry.type === 'gcs_mount'
+  );
+}
+
+function isS3Mount(entry: Entry): entry is S3Mount {
+  return entry.type === 's3_mount';
+}
+
+function isR2Mount(entry: Entry): entry is R2Mount {
+  return entry.type === 'r2_mount';
+}
+
+function isGCSMount(entry: Entry): entry is GCSMount {
+  return entry.type === 'gcs_mount';
+}

--- a/packages/agents-extensions/src/sandbox/modal/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/modal/sandbox.ts
@@ -1,0 +1,2431 @@
+import { UserError, type ToolOutputImage } from '@openai/agents-core';
+import {
+  Manifest,
+  SandboxProviderError,
+  SandboxUnsupportedFeatureError,
+  normalizeSandboxClientCreateArgs,
+  type SandboxClient,
+  type SandboxClientCreateArgs,
+  type SandboxClientOptions,
+  type ExposedPortEndpoint,
+  type ExecCommandArgs,
+  type Entry,
+  isMount,
+  type MaterializeEntryArgs,
+  type Mount,
+  normalizePosixPath,
+  relativePosixPathWithinRoot,
+  type SandboxSession,
+  type SandboxSessionState,
+  type TypedMount,
+  type ViewImageArgs,
+  type WriteStdinArgs,
+  type WorkspaceArchiveData,
+} from '@openai/agents-core/sandbox';
+import { posix as pathPosix } from 'node:path';
+import {
+  assertCoreConcurrencyLimitsUnsupported,
+  assertCoreSnapshotUnsupported,
+  imageOutputFromBytes,
+  RemoteSandboxEditor,
+  assertTarWorkspacePersistence,
+  assertSandboxEntryMetadataSupported,
+  assertSandboxManifestMetadataSupported,
+  MOUNT_MANIFEST_METADATA_SUPPORT,
+  assertRunAsUnsupported,
+  closeRemoteSessionOnManifestError,
+  decodeNativeSnapshotRef,
+  deserializeRemoteSandboxSessionStateValues,
+  elapsedSeconds,
+  encodeNativeSnapshotRef,
+  formatExecResponse,
+  hydrateRemoteWorkspaceTar,
+  materializeEnvironment,
+  persistRemoteWorkspaceTar,
+  assertConfiguredExposedPort,
+  getCachedExposedPortEndpoint,
+  recordResolvedExposedPortEndpoint,
+  resolveSandboxAbsolutePath,
+  resolveSandboxRelativePath,
+  resolveSandboxWorkdir,
+  cloneManifestWithoutMountEntries,
+  serializeRemoteSandboxSessionState,
+  truncateOutput,
+  validateRemoteSandboxPathForManifest,
+  readOptionalNumber,
+  readOptionalNumberArray,
+  readOptionalString,
+  readString,
+  withProviderError,
+  withSandboxSpan,
+  type RemoteManifestWriter,
+  type RemoteSandboxPathOptions,
+  type RemoteSandboxPathResolver,
+} from '../shared';
+import {
+  applyLocalSourceManifestEntryToState,
+  applyLocalSourceManifestToState,
+} from '../shared/localSources';
+import {
+  buildModalCloudBucketMountConfig,
+  isModalCloudBucketMountEntry,
+  type ModalCloudBucketMountConfig,
+} from './mounts';
+
+const DEFAULT_MODAL_IMAGE_TAG = 'debian:bookworm-slim';
+const DEFAULT_EXEC_YIELD_TIME_MS = 10_000;
+const DEFAULT_WRITE_STDIN_YIELD_TIME_MS = 250;
+const MAX_ACTIVE_PROCESS_OUTPUT_CHARS = 1024 * 1024;
+const COMPLETED_ACTIVE_PROCESS_RETENTION_MS = 60_000;
+
+type ModalModule = {
+  ModalClient: new (params?: Record<string, unknown>) => ModalClientLike;
+  CloudBucketMount?: new (
+    bucketName: string,
+    params?: Record<string, unknown>,
+  ) => ModalCloudBucketMountLike;
+  Secret?: {
+    fromName(
+      name: string,
+      params?: { environment?: string },
+    ): ModalSecretLike | Promise<ModalSecretLike>;
+    fromObject(
+      entries: Record<string, string>,
+      params?: Record<string, unknown>,
+    ): ModalSecretLike | Promise<ModalSecretLike>;
+  };
+};
+
+type ModalCloudBucketMountLike = {
+  toProto?(mountPath: string): unknown;
+};
+
+type ModalSecretLike = unknown;
+
+type ModalClientLike = {
+  apps: {
+    fromName(
+      name: string,
+      params?: { createIfMissing?: boolean; environment?: string },
+    ): Promise<ModalAppLike>;
+  };
+  images: {
+    fromRegistry(tag: string): ModalImageLike;
+    fromId?(id: string): ModalImageLike | Promise<ModalImageLike>;
+    delete?(id: string): Promise<void>;
+  };
+  sandboxes: {
+    create(
+      app: ModalAppLike,
+      image: ModalImageLike,
+      params?: Record<string, unknown>,
+    ): Promise<ModalSandboxLike>;
+    fromId(id: string): Promise<ModalSandboxLike>;
+  };
+  imageBuilderVersion?(version?: string): string;
+};
+
+type ModalAppLike = {
+  appId?: string;
+};
+
+type ModalImageLike = {
+  imageId?: string;
+  objectId?: string;
+  cmd?(command: string[]): ModalImageLike;
+};
+
+type ModalSandboxLike = {
+  sandboxId: string;
+  objectId?: string;
+  exec(
+    command: string[],
+    params?: Record<string, unknown>,
+  ): Promise<ModalContainerProcessLike>;
+  open(path: string, mode?: string): Promise<ModalSandboxFileLike>;
+  terminate(params?: { wait?: boolean }): Promise<void | number>;
+  poll(): Promise<number | null>;
+  tunnels?(timeoutMs?: number): Promise<Record<number, ModalTunnelLike>>;
+  snapshotFilesystem?(
+    timeoutMs?: number,
+  ): Promise<string | { objectId?: string; imageId?: string; id?: string }>;
+  snapshotDirectory?(
+    path: string,
+  ): Promise<string | { objectId?: string; imageId?: string; id?: string }>;
+  mountImage?(path: string, image?: ModalImageLike): Promise<unknown>;
+};
+
+type ModalTunnelLike = {
+  host?: string;
+  port?: number;
+};
+
+type ModalSandboxFileLike = {
+  read(): Promise<Uint8Array>;
+  write(data: Uint8Array): Promise<void>;
+  flush?(): Promise<void>;
+  close(): Promise<void>;
+};
+
+type ModalContainerProcessLike = {
+  stdin?: {
+    writeText?(text: string): Promise<void>;
+    close?(): Promise<void>;
+  };
+  stdout: ReadableStream<string>;
+  stderr: ReadableStream<string>;
+  wait(): Promise<number>;
+};
+
+type ActiveModalProcess = {
+  process: ModalContainerProcessLike;
+  stdout: string;
+  stderr: string;
+  droppedStdoutChars: number;
+  droppedStderrChars: number;
+  done: boolean;
+  exitCode: number | null;
+  donePromise: Promise<void>;
+  stopOutputPumps?: () => Promise<void>;
+  cleanupTimer?: ReturnType<typeof setTimeout>;
+};
+
+type ModalCloudBucketMountsProvider = () => Promise<
+  Record<string, ModalCloudBucketMountLike> | undefined
+>;
+
+export type ModalWorkspacePersistence =
+  | 'tar'
+  | 'snapshot_filesystem'
+  | 'snapshot_directory';
+
+export type ModalImageSelectorKind = 'image' | 'id' | 'tag';
+
+export class ModalImageSelector {
+  readonly kind: ModalImageSelectorKind;
+  readonly value: ModalImageLike | string;
+
+  private constructor(
+    kind: ModalImageSelectorKind,
+    value: ModalImageLike | string,
+  ) {
+    this.kind = kind;
+    this.value = value;
+  }
+
+  static fromImage(image: ModalImageLike): ModalImageSelector {
+    return new ModalImageSelector('image', image);
+  }
+
+  static fromId(imageId: string): ModalImageSelector {
+    return new ModalImageSelector('id', imageId);
+  }
+
+  static fromTag(imageTag: string): ModalImageSelector {
+    return new ModalImageSelector('tag', imageTag);
+  }
+}
+
+export type ModalSandboxSelectorKind = 'sandbox' | 'id';
+
+export class ModalSandboxSelector {
+  readonly kind: ModalSandboxSelectorKind;
+  readonly value: ModalSandboxLike | string;
+
+  private constructor(
+    kind: ModalSandboxSelectorKind,
+    value: ModalSandboxLike | string,
+  ) {
+    this.kind = kind;
+    this.value = value;
+  }
+
+  static fromSandbox(sandbox: ModalSandboxLike): ModalSandboxSelector {
+    return new ModalSandboxSelector('sandbox', sandbox);
+  }
+
+  static fromId(sandboxId: string): ModalSandboxSelector {
+    return new ModalSandboxSelector('id', sandboxId);
+  }
+}
+
+export interface ModalSandboxClientOptions extends SandboxClientOptions {
+  appName: string;
+  image?: ModalImageSelector;
+  sandbox?: ModalSandboxSelector;
+  imageTag?: string;
+  sandboxCreateTimeoutS?: number;
+  workspacePersistence?: ModalWorkspacePersistence;
+  snapshotFilesystemTimeoutMs?: number;
+  snapshotFilesystemRestoreTimeoutMs?: number;
+  env?: Record<string, string>;
+  timeoutMs?: number;
+  idleTimeoutMs?: number;
+  gpu?: string;
+  exposedPorts?: number[];
+  environment?: string;
+  endpoint?: string;
+  tokenId?: string;
+  tokenSecret?: string;
+  imageBuilderVersion?: string;
+  nativeCloudBucketSecretName?: string;
+  useSleepCmd?: boolean;
+}
+
+export interface ModalSandboxSessionState extends SandboxSessionState {
+  sandboxId?: string;
+  ownsSandbox?: boolean;
+  appName: string;
+  imageId?: string;
+  imageTag: string;
+  sandboxCreateTimeoutS?: number;
+  workspacePersistence: ModalWorkspacePersistence;
+  snapshotFilesystemTimeoutMs?: number;
+  snapshotFilesystemRestoreTimeoutMs?: number;
+  environment: Record<string, string>;
+  timeoutMs?: number;
+  idleTimeoutMs?: number;
+  gpu?: string;
+  configuredExposedPorts?: number[];
+  modalEnvironment?: string;
+  endpoint?: string;
+  imageBuilderVersion?: string;
+  nativeCloudBucketSecretName?: string;
+  useSleepCmd: boolean;
+}
+
+export class ModalSandboxSession implements SandboxSession<ModalSandboxSessionState> {
+  readonly state: ModalSandboxSessionState;
+  private readonly modal: ModalClientLike;
+  private readonly app: ModalAppLike;
+  private readonly cloudBucketMountsProvider?: ModalCloudBucketMountsProvider;
+  private cloudBucketMounts?: Record<string, ModalCloudBucketMountLike>;
+  private cloudBucketMountsResolved = false;
+  private sandbox: ModalSandboxLike;
+  private ownsSandbox: boolean;
+  private closed = false;
+  private closePromise?: Promise<void>;
+  private readonly activeProcesses = new Map<number, ActiveModalProcess>();
+  private readonly remotePathResolver: RemoteSandboxPathResolver = async (
+    path,
+    options,
+  ) => await this.resolveRemotePath(path, options);
+  private nextProcessId = 1;
+
+  constructor(args: {
+    state: ModalSandboxSessionState;
+    modal: ModalClientLike;
+    app: ModalAppLike;
+    sandbox: ModalSandboxLike;
+    ownsSandbox?: boolean;
+    cloudBucketMounts?: Record<string, ModalCloudBucketMountLike>;
+    cloudBucketMountsProvider?: ModalCloudBucketMountsProvider;
+  }) {
+    this.state = args.state;
+    this.modal = args.modal;
+    this.app = args.app;
+    this.sandbox = args.sandbox;
+    this.ownsSandbox = args.ownsSandbox ?? args.state.ownsSandbox ?? true;
+    this.state.ownsSandbox = this.ownsSandbox;
+    this.cloudBucketMounts = args.cloudBucketMounts;
+    this.cloudBucketMountsProvider = args.cloudBucketMountsProvider;
+    this.cloudBucketMountsResolved =
+      args.cloudBucketMounts !== undefined || !args.cloudBucketMountsProvider;
+  }
+
+  createEditor(runAs?: string): RemoteSandboxEditor {
+    assertRunAsUnsupported('ModalSandboxClient', runAs);
+    return new RemoteSandboxEditor({
+      resolvePath: this.remotePathResolver,
+      pathExists: async (path) => await this.pathExists(path),
+      readText: async (path) =>
+        new TextDecoder().decode(await this.readSandboxFile(path)),
+      writeText: async (path, content) => {
+        await this.writeSandboxFile(path, content);
+      },
+      deletePath: async (path) => {
+        await this.removeSandboxPath(path);
+      },
+    });
+  }
+
+  supportsPty(): boolean {
+    return true;
+  }
+
+  async execCommand(args: ExecCommandArgs): Promise<string> {
+    assertRunAsUnsupported('ModalSandboxClient', args.runAs);
+    const start = Date.now();
+    const command = buildShellCommand(args);
+    const process = await this.sandbox.exec(command, {
+      mode: 'text',
+      workdir: this.resolveWorkdir(args.workdir),
+      env: this.state.environment,
+      pty: args.tty ?? false,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    const activeProcess = createActiveProcess(process);
+    await waitForProcessOrTimeout(
+      activeProcess,
+      args.yieldTimeMs ?? DEFAULT_EXEC_YIELD_TIME_MS,
+    );
+
+    if (activeProcess.done) {
+      const output = truncateOutput(
+        consumeCommandOutput(activeProcess),
+        args.maxOutputTokens,
+      );
+      return formatExecResponse({
+        output: output.text,
+        wallTimeSeconds: elapsedSeconds(start),
+        exitCode: activeProcess.exitCode ?? 1,
+        originalTokenCount: output.originalTokenCount,
+      });
+    }
+
+    const sessionId = this.nextProcessId++;
+    this.registerActiveProcess(sessionId, activeProcess);
+    const output = truncateOutput(
+      consumeCommandOutput(activeProcess),
+      args.maxOutputTokens,
+    );
+    return formatExecResponse({
+      output: output.text,
+      wallTimeSeconds: elapsedSeconds(start),
+      sessionId,
+      originalTokenCount: output.originalTokenCount,
+    });
+  }
+
+  async writeStdin(args: WriteStdinArgs): Promise<string> {
+    const activeProcess = this.activeProcesses.get(args.sessionId);
+    if (!activeProcess) {
+      return formatExecResponse({
+        output: `write_stdin failed: session not found: ${args.sessionId}`,
+        wallTimeSeconds: 0,
+        exitCode: 1,
+      });
+    }
+
+    const start = Date.now();
+    const chars = args.chars ?? '';
+    if (chars.length > 0) {
+      if (!activeProcess.process.stdin?.writeText) {
+        throw new UserError(
+          'Modal sandbox process does not expose stdin for write_stdin().',
+        );
+      }
+      await activeProcess.process.stdin.writeText(chars);
+    }
+
+    await waitForProcessOrTimeout(
+      activeProcess,
+      args.yieldTimeMs ?? DEFAULT_WRITE_STDIN_YIELD_TIME_MS,
+    );
+
+    const output = truncateOutput(
+      consumeCommandOutput(activeProcess),
+      args.maxOutputTokens,
+    );
+    if (activeProcess.done) {
+      this.deleteActiveProcess(args.sessionId, activeProcess);
+      return formatExecResponse({
+        output: output.text,
+        wallTimeSeconds: elapsedSeconds(start),
+        exitCode: activeProcess.exitCode ?? 1,
+      });
+    }
+
+    return formatExecResponse({
+      output: output.text,
+      wallTimeSeconds: elapsedSeconds(start),
+      sessionId: args.sessionId,
+      originalTokenCount: output.originalTokenCount,
+    });
+  }
+
+  async viewImage(args: ViewImageArgs): Promise<ToolOutputImage> {
+    assertRunAsUnsupported('ModalSandboxClient', args.runAs);
+    const absolutePath = await this.resolveRemotePath(args.path);
+    const bytes = await this.readSandboxFile(absolutePath);
+    return imageOutputFromBytes(args.path, bytes);
+  }
+
+  async pathExists(path: string, runAs?: string): Promise<boolean> {
+    assertRunAsUnsupported('ModalSandboxClient', runAs);
+    const absolutePath = await this.resolveRemotePath(path);
+    const process = await this.sandbox.exec(['test', '-e', absolutePath], {
+      mode: 'text',
+      workdir: this.state.manifest.root,
+      stdout: 'ignore',
+      stderr: 'pipe',
+    });
+    return (await process.wait()) === 0;
+  }
+
+  async running(): Promise<boolean> {
+    try {
+      return (await this.sandbox.poll()) === null;
+    } catch {
+      return false;
+    }
+  }
+
+  async resolveExposedPort(port: number): Promise<ExposedPortEndpoint> {
+    const requestedPort = assertConfiguredExposedPort({
+      providerName: 'ModalSandboxClient',
+      port,
+      configuredPorts: this.state.configuredExposedPorts,
+    });
+    const cached = getCachedExposedPortEndpoint(this.state, requestedPort);
+    if (cached) {
+      return cached;
+    }
+    if (!this.sandbox.tunnels) {
+      throw new SandboxProviderError(
+        'ModalSandboxClient exposed port resolution requires Modal sandbox tunnels support.',
+        {
+          provider: 'modal',
+          port: requestedPort,
+        },
+      );
+    }
+
+    let tunnels: Record<number, ModalTunnelLike>;
+    try {
+      tunnels = await this.sandbox.tunnels(10_000);
+    } catch (error) {
+      throw new SandboxProviderError(
+        `ModalSandboxClient failed to look up tunnels for exposed port ${requestedPort}.`,
+        {
+          provider: 'modal',
+          port: requestedPort,
+          cause: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+
+    const tunnel = tunnels[requestedPort];
+    if (
+      typeof tunnel?.host !== 'string' ||
+      tunnel.host.length === 0 ||
+      typeof tunnel.port !== 'number'
+    ) {
+      throw new SandboxProviderError(
+        `ModalSandboxClient did not expose port ${requestedPort}.`,
+        {
+          provider: 'modal',
+          port: requestedPort,
+        },
+      );
+    }
+
+    return recordResolvedExposedPortEndpoint(this.state, requestedPort, {
+      host: tunnel.host,
+      port: tunnel.port,
+      tls: true,
+      query: '',
+    });
+  }
+
+  async materializeEntry(args: MaterializeEntryArgs): Promise<void> {
+    assertRunAsUnsupported('ModalSandboxClient', args.runAs);
+    assertSandboxEntryMetadataSupported(
+      'ModalSandboxClient',
+      args.path,
+      args.entry,
+      MOUNT_MANIFEST_METADATA_SUPPORT,
+    );
+    assertModalLiveEntryMountsUnsupported(
+      args.entry,
+      args.path,
+      this.state.manifest,
+    );
+    await applyLocalSourceManifestEntryToState(
+      this.state,
+      args.path,
+      args.entry,
+      'modal',
+      this.writer(),
+      this.remotePathResolver,
+      this.manifestMaterializationOptions,
+    );
+    this.invalidateCloudBucketMounts();
+  }
+
+  async applyManifest(manifest: Manifest, runAs?: string): Promise<void> {
+    assertRunAsUnsupported('ModalSandboxClient', runAs);
+    assertSandboxManifestMetadataSupported(
+      'ModalSandboxClient',
+      manifest,
+      MOUNT_MANIFEST_METADATA_SUPPORT,
+    );
+    assertModalLiveManifestMountsUnsupported(manifest, this.state.manifest);
+    await applyLocalSourceManifestToState(
+      this.state,
+      manifest,
+      'modal',
+      this.writer(),
+      this.remotePathResolver,
+      this.manifestMaterializationOptions,
+    );
+    this.invalidateCloudBucketMounts();
+  }
+
+  async persistWorkspace(): Promise<Uint8Array> {
+    if (this.state.workspacePersistence === 'snapshot_filesystem') {
+      const archive = await this.persistSnapshotFilesystem();
+      if (archive) {
+        return archive;
+      }
+    } else if (this.state.workspacePersistence === 'snapshot_directory') {
+      const archive = await this.persistSnapshotDirectory();
+      if (archive) {
+        return archive;
+      }
+    } else {
+      assertTarWorkspacePersistence(
+        'ModalSandboxClient',
+        this.state.workspacePersistence,
+      );
+    }
+
+    return await persistRemoteWorkspaceTar({
+      providerName: 'ModalSandboxClient',
+      manifest: this.state.manifest,
+      io: this.archiveIo(),
+    });
+  }
+
+  async hydrateWorkspace(data: WorkspaceArchiveData): Promise<void> {
+    const snapshotRef = decodeNativeSnapshotRef(data);
+    if (snapshotRef?.provider === 'modal_snapshot_filesystem') {
+      this.assertExpectedSnapshotPersistence(
+        snapshotRef.workspacePersistence ?? 'snapshot_filesystem',
+        'snapshot_filesystem',
+      );
+      await this.restoreSnapshotFilesystem(snapshotRef.snapshotId);
+      return;
+    }
+    if (snapshotRef?.provider === 'modal_snapshot_directory') {
+      this.assertExpectedSnapshotPersistence(
+        snapshotRef.workspacePersistence ?? 'snapshot_directory',
+        'snapshot_directory',
+      );
+      await this.restoreSnapshotDirectory(snapshotRef.snapshotId);
+      return;
+    }
+
+    if (this.state.workspacePersistence === 'tar') {
+      assertTarWorkspacePersistence(
+        'ModalSandboxClient',
+        this.state.workspacePersistence,
+      );
+    }
+    await hydrateRemoteWorkspaceTar({
+      providerName: 'ModalSandboxClient',
+      manifest: this.state.manifest,
+      io: this.archiveIo(),
+      data,
+    });
+  }
+
+  private async persistSnapshotFilesystem(): Promise<Uint8Array | undefined> {
+    if (this.nativeSnapshotRequiresTarFallback()) {
+      return undefined;
+    }
+    if (!this.sandbox.snapshotFilesystem) {
+      return undefined;
+    }
+
+    const snapshotId = snapshotIdFromModalResult(
+      await withProviderError(
+        'ModalSandboxClient',
+        'modal',
+        'capture snapshot_filesystem',
+        async () =>
+          await this.sandbox.snapshotFilesystem!(
+            this.state.snapshotFilesystemTimeoutMs,
+          ),
+        { sandboxId: this.state.sandboxId },
+      ),
+    );
+    if (!snapshotId) {
+      throw new SandboxProviderError(
+        'Modal snapshot_filesystem persistence did not return a snapshot id.',
+        {
+          provider: 'modal',
+          sandboxId: this.state.sandboxId,
+        },
+      );
+    }
+
+    return encodeNativeSnapshotRef({
+      provider: 'modal_snapshot_filesystem',
+      snapshotId,
+      workspacePersistence: 'snapshot_filesystem',
+    });
+  }
+
+  private async persistSnapshotDirectory(): Promise<Uint8Array | undefined> {
+    if (this.nativeSnapshotRequiresTarFallback()) {
+      return undefined;
+    }
+    if (!this.sandbox.snapshotDirectory) {
+      return undefined;
+    }
+
+    const snapshotId = snapshotIdFromModalResult(
+      await withProviderError(
+        'ModalSandboxClient',
+        'modal',
+        'capture snapshot_directory',
+        async () =>
+          await withOptionalTimeoutMs(
+            this.sandbox.snapshotDirectory!(this.state.manifest.root),
+            this.state.snapshotFilesystemTimeoutMs,
+            'Modal snapshot_directory persistence timed out.',
+            async (snapshot) => {
+              await this.deleteSnapshotDirectoryImage(snapshot);
+            },
+          ),
+        { sandboxId: this.state.sandboxId },
+      ),
+    );
+    if (!snapshotId) {
+      throw new SandboxProviderError(
+        'Modal snapshot_directory persistence did not return a snapshot id.',
+        {
+          provider: 'modal',
+          sandboxId: this.state.sandboxId,
+        },
+      );
+    }
+
+    return encodeNativeSnapshotRef({
+      provider: 'modal_snapshot_directory',
+      snapshotId,
+      workspacePersistence: 'snapshot_directory',
+    });
+  }
+
+  private nativeSnapshotRequiresTarFallback(): boolean {
+    return this.state.manifest.ephemeralPersistencePaths().size > 0;
+  }
+
+  private assertExpectedSnapshotPersistence(
+    actual: string,
+    expected: ModalWorkspacePersistence,
+  ): void {
+    if (actual !== expected || this.state.workspacePersistence !== expected) {
+      throw new SandboxProviderError(
+        `Modal snapshot reference uses ${actual}, but this session expects ${this.state.workspacePersistence}.`,
+        {
+          provider: 'modal',
+          workspacePersistence: this.state.workspacePersistence,
+          snapshotWorkspacePersistence: actual,
+        },
+      );
+    }
+  }
+
+  private async restoreSnapshotFilesystem(snapshotId: string): Promise<void> {
+    const previousSandbox = this.sandbox;
+    const previousSandboxId = this.state.sandboxId;
+    const previousSandboxOwned = this.ownsSandbox;
+    const sandbox = await withProviderError(
+      'ModalSandboxClient',
+      'modal',
+      'restore snapshot_filesystem',
+      async () =>
+        await withOptionalTimeoutMs(
+          (async () => {
+            const image = maybeSetModalSandboxCmd(
+              await this.modalImageFromId(snapshotId),
+              this.state.useSleepCmd,
+            );
+            return await this.modal.sandboxes.create(
+              this.app,
+              image,
+              await this.sandboxCreateParams(),
+            );
+          })(),
+          this.state.snapshotFilesystemRestoreTimeoutMs,
+          'Modal snapshot_filesystem restore timed out.',
+          terminateModalSandboxAfterTimeout,
+        ),
+      { sandboxId: previousSandboxId, snapshotId },
+    );
+    if (previousSandboxOwned) {
+      try {
+        await previousSandbox.terminate();
+      } catch (error) {
+        let replacementTerminateCause: string | undefined;
+        try {
+          await sandbox.terminate();
+        } catch (replacementTerminateError) {
+          replacementTerminateCause = errorMessage(replacementTerminateError);
+        }
+        throw new SandboxProviderError(
+          'Modal snapshot_filesystem restore created a replacement sandbox, but terminating the previous sandbox failed.',
+          {
+            provider: 'modal',
+            sandboxId: previousSandboxId,
+            replacementSandboxId: sandbox.sandboxId,
+            cause: errorMessage(error),
+            ...(replacementTerminateCause ? { replacementTerminateCause } : {}),
+          },
+        );
+      }
+    }
+    await this.resetActiveProcesses();
+    this.sandbox = sandbox;
+    this.ownsSandbox = true;
+    this.state.sandboxId = sandbox.sandboxId;
+    this.state.ownsSandbox = true;
+    delete this.state.exposedPorts;
+  }
+
+  private async restoreSnapshotDirectory(snapshotId: string): Promise<void> {
+    if (!this.sandbox.mountImage) {
+      throw new SandboxProviderError(
+        'Modal snapshot_directory restore requires sandbox mountImage(path, image) support.',
+        {
+          provider: 'modal',
+          sandboxId: this.state.sandboxId,
+          snapshotId,
+        },
+      );
+    }
+    const sandbox = this.sandbox;
+    const ownsSandbox = this.ownsSandbox;
+    await withProviderError(
+      'ModalSandboxClient',
+      'modal',
+      'restore snapshot_directory',
+      async () =>
+        await withOptionalTimeoutMs(
+          (async () => {
+            const image = await this.modalImageFromId(snapshotId);
+            await sandbox.mountImage!(this.state.manifest.root, image);
+          })(),
+          this.state.snapshotFilesystemRestoreTimeoutMs,
+          'Modal snapshot_directory restore timed out.',
+          async () => {
+            if (ownsSandbox) {
+              await terminateModalSandboxAfterTimeout(sandbox);
+            }
+          },
+        ),
+      { sandboxId: this.state.sandboxId, snapshotId },
+    );
+  }
+
+  private async deleteSnapshotDirectoryImage(
+    snapshot: string | { objectId?: string; imageId?: string; id?: string },
+  ): Promise<void> {
+    const snapshotId = snapshotIdFromModalResult(snapshot);
+    if (!snapshotId || !this.modal.images.delete) {
+      return;
+    }
+    await this.modal.images.delete(snapshotId).catch(() => {});
+  }
+
+  private async modalImageFromId(snapshotId: string): Promise<ModalImageLike> {
+    return this.modal.images.fromId
+      ? await withProviderError(
+          'ModalSandboxClient',
+          'modal',
+          'look up image',
+          async () => await this.modal.images.fromId!(snapshotId),
+          { imageId: snapshotId },
+        )
+      : { imageId: snapshotId };
+  }
+
+  private async sandboxCreateParams(): Promise<Record<string, unknown>> {
+    const cloudBucketMounts = await this.resolveCloudBucketMounts();
+    return {
+      workdir: this.state.manifest.root,
+      env: this.state.environment,
+      ...(typeof this.state.timeoutMs === 'number'
+        ? { timeoutMs: this.state.timeoutMs }
+        : {}),
+      ...(typeof this.state.idleTimeoutMs === 'number'
+        ? { idleTimeoutMs: this.state.idleTimeoutMs }
+        : {}),
+      ...(this.state.gpu ? { gpu: this.state.gpu } : {}),
+      ...(this.state.configuredExposedPorts
+        ? { encryptedPorts: this.state.configuredExposedPorts }
+        : {}),
+      ...(cloudBucketMounts ? { cloudBucketMounts } : {}),
+    };
+  }
+
+  private async resolveCloudBucketMounts(): Promise<
+    Record<string, ModalCloudBucketMountLike> | undefined
+  > {
+    if (this.cloudBucketMountsResolved) {
+      return this.cloudBucketMounts;
+    }
+    this.cloudBucketMounts = await this.cloudBucketMountsProvider?.();
+    this.cloudBucketMountsResolved = true;
+    return this.cloudBucketMounts;
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+    if (this.closePromise) {
+      await this.closePromise;
+      return;
+    }
+    this.closePromise = this.closeOnce();
+    try {
+      await this.closePromise;
+      this.closed = true;
+    } finally {
+      if (!this.closed) {
+        this.closePromise = undefined;
+      }
+    }
+  }
+
+  private async closeOnce(): Promise<void> {
+    const processes = [...this.activeProcesses.values()];
+    const activeProcesses = processes.filter(
+      (activeProcess) => !activeProcess.done,
+    );
+    await Promise.all(
+      activeProcesses.map(async (activeProcess) => {
+        if (activeProcess.process.stdin?.close) {
+          await activeProcess.process.stdin.close().catch(() => {});
+        }
+      }),
+    );
+    if (this.ownsSandbox) {
+      await this.sandbox.terminate();
+      await Promise.all(
+        activeProcesses.map(async (activeProcess) => {
+          await activeProcess.donePromise.catch(() => {});
+        }),
+      );
+    } else {
+      await Promise.all(
+        activeProcesses.map(async (activeProcess) => {
+          await activeProcess.stopOutputPumps?.().catch(() => {});
+        }),
+      );
+    }
+    for (const process of processes) {
+      clearActiveProcessCleanup(process);
+    }
+    this.activeProcesses.clear();
+  }
+
+  private async resetActiveProcesses(): Promise<void> {
+    const processes = [...this.activeProcesses.values()];
+    this.activeProcesses.clear();
+    await Promise.all(
+      processes.map(async (activeProcess) => {
+        clearActiveProcessCleanup(activeProcess);
+        if (!activeProcess.done && activeProcess.process.stdin?.close) {
+          await activeProcess.process.stdin.close().catch(() => {});
+        }
+        if (!activeProcess.done) {
+          await activeProcess.stopOutputPumps?.().catch(() => {});
+        }
+      }),
+    );
+  }
+
+  private readonly manifestMaterializationOptions = {
+    materializeMount: async (
+      absolutePath: string,
+      _entry: Mount | TypedMount,
+    ) => {
+      throwModalLiveMountsUnsupported([absolutePath]);
+    },
+  };
+
+  private invalidateCloudBucketMounts(): void {
+    if (!this.cloudBucketMountsProvider) {
+      return;
+    }
+    this.cloudBucketMounts = undefined;
+    this.cloudBucketMountsResolved = false;
+  }
+
+  async shutdown(): Promise<void> {
+    await this.close();
+  }
+
+  async delete(): Promise<void> {
+    await this.close();
+  }
+
+  private registerActiveProcess(
+    sessionId: number,
+    activeProcess: ActiveModalProcess,
+  ): void {
+    this.activeProcesses.set(sessionId, activeProcess);
+    activeProcess.donePromise
+      .finally(() => {
+        activeProcess.cleanupTimer = setTimeout(() => {
+          if (this.activeProcesses.get(sessionId) === activeProcess) {
+            this.activeProcesses.delete(sessionId);
+          }
+        }, COMPLETED_ACTIVE_PROCESS_RETENTION_MS);
+        unrefTimer(activeProcess.cleanupTimer);
+      })
+      .catch(() => {});
+  }
+
+  private deleteActiveProcess(
+    sessionId: number,
+    activeProcess: ActiveModalProcess,
+  ): void {
+    clearActiveProcessCleanup(activeProcess);
+    if (this.activeProcesses.get(sessionId) === activeProcess) {
+      this.activeProcesses.delete(sessionId);
+    }
+  }
+
+  resolveAbsolutePath(path?: string): string {
+    return resolveSandboxAbsolutePath(this.state.manifest.root, path);
+  }
+
+  async resolveRemotePath(
+    path?: string,
+    options: RemoteSandboxPathOptions = {},
+  ): Promise<string> {
+    return await validateRemoteSandboxPathForManifest({
+      manifest: this.state.manifest,
+      path,
+      options,
+      runCommand: async (command) => {
+        const process = await this.sandbox.exec(['/bin/sh', '-lc', command], {
+          mode: 'text',
+          workdir: this.state.manifest.root,
+          stdout: 'pipe',
+          stderr: 'pipe',
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([
+          readStreamText(process.stdout),
+          readStreamText(process.stderr),
+          process.wait(),
+        ]);
+        return { status: exitCode, stdout, stderr };
+      },
+    });
+  }
+
+  resolveWorkdir(path?: string): string {
+    return resolveSandboxWorkdir(this.state.manifest.root, path);
+  }
+
+  async ensureDirectory(path: string): Promise<void> {
+    await this.runDirectCommand(['mkdir', '-p', '--', path]);
+  }
+
+  async writeSandboxFile(
+    path: string,
+    content: string | Uint8Array,
+  ): Promise<void> {
+    await this.ensureDirectory(pathPosix.dirname(path));
+    const handle = await this.sandbox.open(path, 'w');
+    try {
+      await handle.write(
+        typeof content === 'string'
+          ? new TextEncoder().encode(content)
+          : content,
+      );
+      if (handle.flush) {
+        await handle.flush();
+      }
+    } finally {
+      await handle.close();
+    }
+  }
+
+  async readSandboxFile(path: string): Promise<Uint8Array> {
+    const handle = await this.sandbox.open(path, 'r');
+    try {
+      return Uint8Array.from(await handle.read());
+    } finally {
+      await handle.close();
+    }
+  }
+
+  async removeSandboxPath(path: string): Promise<void> {
+    await this.runDirectCommand(['rm', '-f', '--', path]);
+  }
+
+  private writer(): RemoteManifestWriter {
+    return {
+      mkdir: async (path) => {
+        await this.ensureDirectory(path);
+      },
+      writeFile: async (path, content) => {
+        await this.writeSandboxFile(path, content);
+      },
+    };
+  }
+
+  private archiveIo() {
+    return {
+      runCommand: async (command: string) => {
+        const process = await this.sandbox.exec(['/bin/sh', '-lc', command], {
+          mode: 'text',
+          workdir: this.state.manifest.root,
+          env: this.state.environment,
+          stdout: 'pipe',
+          stderr: 'pipe',
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([
+          readStreamText(process.stdout),
+          readStreamText(process.stderr),
+          process.wait(),
+        ]);
+        return { status: exitCode, stdout, stderr };
+      },
+      readFile: async (path: string) => await this.readSandboxFile(path),
+      writeFile: async (path: string, content: string | Uint8Array) => {
+        await this.writeSandboxFile(path, content);
+      },
+      mkdir: async (path: string) => {
+        await this.ensureDirectory(path);
+      },
+    };
+  }
+
+  private async runDirectCommand(command: string[]): Promise<void> {
+    const process = await this.sandbox.exec(command, {
+      mode: 'text',
+      workdir: this.state.manifest.root,
+      stdout: 'ignore',
+      stderr: 'pipe',
+    });
+    const stderr = await readStreamText(process.stderr);
+    const exitCode = await process.wait();
+    if (exitCode !== 0) {
+      throw new UserError(
+        `Modal sandbox command failed (${command.join(' ')}): ${stderr || `exit ${exitCode}`}`,
+      );
+    }
+  }
+}
+
+/**
+ * @see {@link https://modal.com/docs/guide/sandboxes | Sandboxes guide}.
+ * @see {@link https://modal.com/docs/guide/sdk-javascript-go | JavaScript and Go SDK guide}.
+ * @see {@link https://modal.com/docs/reference/modal.Sandbox | Sandbox reference}.
+ */
+export class ModalSandboxClient implements SandboxClient<
+  ModalSandboxClientOptions,
+  ModalSandboxSessionState
+> {
+  readonly backendId = 'modal';
+  private readonly options: Partial<ModalSandboxClientOptions>;
+
+  constructor(options: Partial<ModalSandboxClientOptions> = {}) {
+    this.options = options;
+  }
+
+  async create(
+    args?: SandboxClientCreateArgs | Manifest,
+    manifestOptions?: SandboxClientOptions,
+  ): Promise<ModalSandboxSession> {
+    const createArgs = normalizeSandboxClientCreateArgs(
+      args,
+      manifestOptions as ModalSandboxClientOptions | undefined,
+    );
+    assertCoreSnapshotUnsupported('ModalSandboxClient', createArgs.snapshot);
+    assertCoreConcurrencyLimitsUnsupported(
+      'ModalSandboxClient',
+      createArgs.concurrencyLimits,
+    );
+    const manifest = createArgs.manifest;
+    const resolvedOptions = resolveOptions(
+      this.options,
+      createArgs.options as ModalSandboxClientOptions | undefined,
+    );
+    validateOptions(resolvedOptions);
+    const useSleepCmd = resolvedOptions.useSleepCmd ?? true;
+    assertSandboxManifestMetadataSupported(
+      'ModalSandboxClient',
+      manifest,
+      MOUNT_MANIFEST_METADATA_SUPPORT,
+    );
+    assertModalManifestMountsSupported(
+      manifest,
+      resolvedOptions.nativeCloudBucketSecretName,
+    );
+    assertModalReusableSandboxMountsSupported(
+      manifest,
+      resolvedOptions.sandbox,
+    );
+
+    return await withSandboxSpan(
+      'sandbox.start',
+      {
+        backend_id: this.backendId,
+      },
+      async () => {
+        const modalModule = await loadModalModule();
+        const modal = createModalClientFromModule(modalModule, resolvedOptions);
+        const workspacePersistence =
+          resolvedOptions.workspacePersistence ?? 'tar';
+        const app = shouldResolveModalApp({
+          ownsSandbox: !resolvedOptions.sandbox,
+          workspacePersistence,
+        })
+          ? await lookupModalApp({
+              modal,
+              appName: resolvedOptions.appName,
+              environment: resolvedOptions.environment,
+              createIfMissing: !resolvedOptions.sandbox,
+            })
+          : {};
+        const environment = await materializeEnvironment(
+          manifest,
+          resolvedOptions.env,
+        );
+        const imageState = modalImageStateFromOptions(resolvedOptions);
+        let cloudBucketMounts:
+          | Record<string, ModalCloudBucketMountLike>
+          | undefined;
+        let sandbox: ModalSandboxLike;
+        if (resolvedOptions.sandbox) {
+          sandbox = await withProviderError(
+            'ModalSandboxClient',
+            'modal',
+            'resolve sandbox selector',
+            async () =>
+              await resolveSelectedModalSandbox(
+                modal,
+                resolvedOptions.sandbox!,
+              ),
+          );
+        } else {
+          const { image, imageId, imageTag } = await resolveModalImage(
+            modal,
+            resolvedOptions,
+          );
+          imageState.imageId = imageId;
+          imageState.imageTag = imageTag;
+          const sandboxImage = maybeSetModalSandboxCmd(image, useSleepCmd);
+          cloudBucketMounts = await modalCloudBucketMountsForManifest({
+            modalModule,
+            manifest,
+            defaultSecretName: resolvedOptions.nativeCloudBucketSecretName,
+          });
+          const createParams = {
+            workdir: manifest.root,
+            env: environment,
+            ...(typeof resolvedOptions.timeoutMs === 'number'
+              ? { timeoutMs: resolvedOptions.timeoutMs }
+              : {}),
+            ...(typeof resolvedOptions.idleTimeoutMs === 'number'
+              ? { idleTimeoutMs: resolvedOptions.idleTimeoutMs }
+              : {}),
+            ...(resolvedOptions.gpu ? { gpu: resolvedOptions.gpu } : {}),
+            ...(resolvedOptions.exposedPorts
+              ? { encryptedPorts: resolvedOptions.exposedPorts }
+              : {}),
+            ...(cloudBucketMounts ? { cloudBucketMounts } : {}),
+          };
+          sandbox = await withOptionalTimeout(
+            withProviderError(
+              'ModalSandboxClient',
+              'modal',
+              'create sandbox',
+              async () =>
+                await modal.sandboxes.create(app, sandboxImage, createParams),
+              { appName: resolvedOptions.appName },
+            ),
+            resolvedOptions.sandboxCreateTimeoutS,
+            'Modal sandbox creation timed out.',
+            terminateModalSandboxAfterTimeout,
+          );
+        }
+
+        const sessionState: ModalSandboxSessionState = {
+          manifest,
+          sandboxId: sandbox.sandboxId,
+          ownsSandbox: !resolvedOptions.sandbox,
+          appName: resolvedOptions.appName,
+          imageId: imageState.imageId,
+          imageTag: imageState.imageTag,
+          sandboxCreateTimeoutS: resolvedOptions.sandboxCreateTimeoutS,
+          workspacePersistence,
+          snapshotFilesystemTimeoutMs:
+            resolvedOptions.snapshotFilesystemTimeoutMs,
+          snapshotFilesystemRestoreTimeoutMs:
+            resolvedOptions.snapshotFilesystemRestoreTimeoutMs,
+          environment,
+          timeoutMs: resolvedOptions.timeoutMs,
+          idleTimeoutMs: resolvedOptions.idleTimeoutMs,
+          gpu: resolvedOptions.gpu,
+          configuredExposedPorts: resolvedOptions.exposedPorts,
+          modalEnvironment: resolvedOptions.environment,
+          endpoint: resolvedOptions.endpoint,
+          imageBuilderVersion: resolvedOptions.imageBuilderVersion,
+          nativeCloudBucketSecretName:
+            resolvedOptions.nativeCloudBucketSecretName,
+          useSleepCmd,
+        };
+        const session = new ModalSandboxSession({
+          modal,
+          app,
+          sandbox,
+          ownsSandbox: !resolvedOptions.sandbox,
+          state: sessionState,
+          cloudBucketMounts,
+          cloudBucketMountsProvider: async () =>
+            await modalCloudBucketMountsForManifest({
+              modalModule,
+              manifest: sessionState.manifest,
+              defaultSecretName: resolvedOptions.nativeCloudBucketSecretName,
+            }),
+        });
+
+        try {
+          await session.applyManifest(
+            cloneManifestWithoutMountEntries(manifest),
+          );
+        } catch (error) {
+          if (resolvedOptions.sandbox) {
+            throw error;
+          }
+          await closeRemoteSessionOnManifestError('Modal', session, error);
+        }
+        return session;
+      },
+    );
+  }
+
+  async serializeSessionState(
+    state: ModalSandboxSessionState,
+  ): Promise<Record<string, unknown>> {
+    return serializeRemoteSandboxSessionState(state);
+  }
+
+  canPersistOwnedSessionState(): boolean {
+    return false;
+  }
+
+  async deserializeSessionState(
+    state: Record<string, unknown>,
+  ): Promise<ModalSandboxSessionState> {
+    const baseState = deserializeRemoteSandboxSessionStateValues(
+      state,
+      this.options.env,
+    );
+    return {
+      ...state,
+      ...baseState,
+      ownsSandbox: state.ownsSandbox === false ? false : true,
+      appName: readString(state, 'appName'),
+      imageId: readOptionalString(state, 'imageId'),
+      imageTag: readString(state, 'imageTag', DEFAULT_MODAL_IMAGE_TAG),
+      workspacePersistence:
+        (state.workspacePersistence as ModalWorkspacePersistence | undefined) ??
+        'tar',
+      snapshotFilesystemTimeoutMs: readOptionalNumber(
+        state,
+        'snapshotFilesystemTimeoutMs',
+      ),
+      snapshotFilesystemRestoreTimeoutMs: readOptionalNumber(
+        state,
+        'snapshotFilesystemRestoreTimeoutMs',
+      ),
+      timeoutMs: readOptionalNumber(state, 'timeoutMs'),
+      idleTimeoutMs: readOptionalNumber(state, 'idleTimeoutMs'),
+      gpu: readOptionalString(state, 'gpu'),
+      configuredExposedPorts: readOptionalNumberArray(
+        state.configuredExposedPorts,
+      ),
+      modalEnvironment: readOptionalString(state, 'modalEnvironment'),
+      endpoint: readOptionalString(state, 'endpoint'),
+      nativeCloudBucketSecretName: readOptionalString(
+        state,
+        'nativeCloudBucketSecretName',
+      ),
+      imageBuilderVersion: readOptionalString(state, 'imageBuilderVersion'),
+      useSleepCmd:
+        typeof state.useSleepCmd === 'boolean' ? state.useSleepCmd : true,
+    };
+  }
+
+  async resume(state: ModalSandboxSessionState): Promise<ModalSandboxSession> {
+    if (!state.sandboxId) {
+      throw new UserError(
+        'Modal sandbox resume requires a persisted sandboxId.',
+      );
+    }
+    const sandboxId = state.sandboxId;
+
+    const modalModule = await loadModalModule();
+    const modal = createModalClientFromModule(modalModule, {
+      ...this.options,
+      appName: state.appName,
+      image: state.imageId
+        ? ModalImageSelector.fromId(state.imageId)
+        : undefined,
+      imageTag: state.imageTag,
+      sandboxCreateTimeoutS: state.sandboxCreateTimeoutS,
+      workspacePersistence: state.workspacePersistence,
+      snapshotFilesystemTimeoutMs: state.snapshotFilesystemTimeoutMs,
+      snapshotFilesystemRestoreTimeoutMs:
+        state.snapshotFilesystemRestoreTimeoutMs,
+      timeoutMs: state.timeoutMs,
+      idleTimeoutMs: state.idleTimeoutMs,
+      gpu: state.gpu,
+      exposedPorts: state.configuredExposedPorts,
+      environment: state.modalEnvironment ?? this.options.environment,
+      endpoint: state.endpoint ?? this.options.endpoint,
+      imageBuilderVersion:
+        state.imageBuilderVersion ?? this.options.imageBuilderVersion,
+      useSleepCmd: state.useSleepCmd,
+    });
+    const sandbox = await withProviderError(
+      'ModalSandboxClient',
+      'modal',
+      'resume sandbox',
+      async () => await modal.sandboxes.fromId(sandboxId),
+      { sandboxId },
+    );
+    const ownsSandbox = state.ownsSandbox !== false;
+    const app = shouldResolveModalApp({
+      ownsSandbox,
+      workspacePersistence: state.workspacePersistence,
+    })
+      ? await lookupModalApp({
+          modal,
+          appName: state.appName,
+          environment: state.modalEnvironment,
+          createIfMissing: ownsSandbox,
+        })
+      : {};
+    const exitCode = await withProviderError(
+      'ModalSandboxClient',
+      'modal',
+      'poll sandbox',
+      async () => await sandbox.poll(),
+      { sandboxId },
+    );
+    if (exitCode !== null) {
+      throw new UserError(
+        `Modal sandbox ${state.sandboxId} is no longer running.`,
+      );
+    }
+
+    return new ModalSandboxSession({
+      state,
+      modal,
+      app,
+      sandbox,
+      ownsSandbox,
+      cloudBucketMountsProvider: async () =>
+        await modalCloudBucketMountsForManifest({
+          modalModule,
+          manifest: state.manifest,
+          defaultSecretName:
+            state.nativeCloudBucketSecretName ??
+            this.options.nativeCloudBucketSecretName,
+        }),
+    });
+  }
+}
+
+async function loadModalModule(): Promise<ModalModule> {
+  try {
+    return adaptModalModule(await import('modal'));
+  } catch (error) {
+    throw new UserError(
+      `Modal sandbox support requires the optional \`modal\` package. Install it before using Modal-backed sandbox examples. ${(error as Error).message}`,
+    );
+  }
+}
+
+async function lookupModalApp(args: {
+  modal: ModalClientLike;
+  appName: string;
+  environment?: string;
+  createIfMissing: boolean;
+}): Promise<ModalAppLike> {
+  return await withProviderError(
+    'ModalSandboxClient',
+    'modal',
+    'look up app',
+    async () =>
+      await args.modal.apps.fromName(args.appName, {
+        createIfMissing: args.createIfMissing,
+        ...(args.environment ? { environment: args.environment } : {}),
+      }),
+    { appName: args.appName },
+  );
+}
+
+function shouldResolveModalApp(args: {
+  ownsSandbox: boolean;
+  workspacePersistence: ModalWorkspacePersistence;
+}): boolean {
+  return (
+    args.ownsSandbox || args.workspacePersistence === 'snapshot_filesystem'
+  );
+}
+
+function adaptModalModule(modal: typeof import('modal')): ModalModule {
+  const secretApi: unknown = modal.Secret;
+  const usesClassSecretApi = typeof secretApi === 'function';
+  return {
+    ModalClient: modal.ModalClient,
+    CloudBucketMount: usesClassSecretApi
+      ? class implements ModalCloudBucketMountLike {
+          private readonly mount: InstanceType<typeof modal.CloudBucketMount>;
+
+          constructor(bucketName: string, params?: Record<string, unknown>) {
+            const bucketEndpointUrl = readOptionalString(
+              params,
+              'bucketEndpointUrl',
+            );
+            const keyPrefix = readOptionalString(params, 'keyPrefix');
+            this.mount = new modal.CloudBucketMount(bucketName, {
+              ...(bucketEndpointUrl ? { bucketEndpointUrl } : {}),
+              ...(keyPrefix ? { keyPrefix } : {}),
+              ...(typeof params?.readOnly === 'boolean'
+                ? { readOnly: params.readOnly }
+                : {}),
+              ...(params?.secret
+                ? { secret: params.secret as InstanceType<typeof modal.Secret> }
+                : {}),
+            });
+          }
+
+          toProto(mountPath: string): unknown {
+            return this.mount.toProto(mountPath);
+          }
+        }
+      : (modal.CloudBucketMount as ModalModule['CloudBucketMount']),
+    Secret: {
+      fromName: async (name, params) => {
+        if (usesClassSecretApi) {
+          return await modal.Secret.fromName(name, {
+            ...(params?.environment ? { environment: params.environment } : {}),
+          });
+        }
+        if (isModalSecretModule(secretApi)) {
+          return await secretApi.fromName(name, params);
+        }
+        throw new Error('Missing Secret export from modal.');
+      },
+      fromObject: async (entries, params) => {
+        if (usesClassSecretApi) {
+          const environment = readOptionalString(params, 'environment');
+          return await modal.Secret.fromObject(entries, {
+            ...(environment ? { environment } : {}),
+          });
+        }
+        if (isModalSecretModule(secretApi)) {
+          return await secretApi.fromObject(entries, params);
+        }
+        throw new Error('Missing Secret export from modal.');
+      },
+    },
+  };
+}
+
+function isModalSecretModule(
+  value: unknown,
+): value is NonNullable<ModalModule['Secret']> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'fromName' in value &&
+    'fromObject' in value
+  );
+}
+
+function createModalClientFromModule(
+  modalModule: ModalModule,
+  options: Partial<ModalSandboxClientOptions>,
+): ModalClientLike {
+  const { ModalClient } = modalModule;
+  const client = new ModalClient({
+    ...(options.tokenId ? { tokenId: options.tokenId } : {}),
+    ...(options.tokenSecret ? { tokenSecret: options.tokenSecret } : {}),
+    ...(options.environment ? { environment: options.environment } : {}),
+    ...(options.endpoint ? { endpoint: options.endpoint } : {}),
+  });
+  if (options.imageBuilderVersion !== undefined && client.imageBuilderVersion) {
+    const originalImageBuilderVersion = client.imageBuilderVersion.bind(client);
+    client.imageBuilderVersion = (version?: string) =>
+      originalImageBuilderVersion(version ?? options.imageBuilderVersion);
+  }
+  return client;
+}
+
+async function resolveModalImage(
+  modal: ModalClientLike,
+  options: Pick<ModalSandboxClientOptions, 'image' | 'imageTag'>,
+): Promise<{
+  image: ModalImageLike;
+  imageId?: string;
+  imageTag: string;
+}> {
+  const selector = modalImageSelectorFromOptions(options);
+  if (selector.kind === 'image') {
+    const image = selector.value as ModalImageLike;
+    return {
+      image,
+      imageId: modalImageId(image),
+      imageTag: options.imageTag ?? DEFAULT_MODAL_IMAGE_TAG,
+    };
+  }
+  if (selector.kind === 'id') {
+    const imageId = selector.value as string;
+    const image = modal.images.fromId
+      ? await withProviderError(
+          'ModalSandboxClient',
+          'modal',
+          'look up image',
+          async () => await modal.images.fromId!(imageId),
+          { imageId },
+        )
+      : { imageId };
+    return {
+      image,
+      imageId,
+      imageTag: options.imageTag ?? DEFAULT_MODAL_IMAGE_TAG,
+    };
+  }
+  const imageTag = selector.value as string;
+  const image = await withProviderError(
+    'ModalSandboxClient',
+    'modal',
+    'resolve image',
+    async () => modal.images.fromRegistry(imageTag),
+    { imageTag },
+  );
+  return {
+    image,
+    imageId: modalImageId(image),
+    imageTag,
+  };
+}
+
+function modalImageStateFromOptions(
+  options: Pick<ModalSandboxClientOptions, 'image' | 'imageTag'>,
+): {
+  imageId?: string;
+  imageTag: string;
+} {
+  const selector = modalImageSelectorFromOptions(options);
+  if (selector.kind === 'image') {
+    return {
+      imageId: modalImageId(selector.value as ModalImageLike),
+      imageTag: options.imageTag ?? DEFAULT_MODAL_IMAGE_TAG,
+    };
+  }
+  if (selector.kind === 'id') {
+    return {
+      imageId: selector.value as string,
+      imageTag: options.imageTag ?? DEFAULT_MODAL_IMAGE_TAG,
+    };
+  }
+  return {
+    imageTag: selector.value as string,
+  };
+}
+
+function modalImageSelectorFromOptions(
+  options: Pick<ModalSandboxClientOptions, 'image' | 'imageTag'>,
+): ModalImageSelector {
+  return (
+    options.image ??
+    ModalImageSelector.fromTag(options.imageTag ?? DEFAULT_MODAL_IMAGE_TAG)
+  );
+}
+
+async function resolveSelectedModalSandbox(
+  modal: ModalClientLike,
+  selector: ModalSandboxSelector,
+): Promise<ModalSandboxLike> {
+  if (selector.kind === 'sandbox') {
+    return selector.value as ModalSandboxLike;
+  }
+  return await withProviderError(
+    'ModalSandboxClient',
+    'modal',
+    'resolve sandbox',
+    async () => await modal.sandboxes.fromId(selector.value as string),
+    { sandboxId: selector.value as string },
+  );
+}
+
+function modalImageId(image: ModalImageLike): string | undefined {
+  return image.imageId ?? image.objectId;
+}
+
+function maybeSetModalSandboxCmd(
+  image: ModalImageLike,
+  useSleepCmd: boolean,
+): ModalImageLike {
+  if (!useSleepCmd || typeof image.cmd !== 'function') {
+    return image;
+  }
+  return image.cmd(['sleep', 'infinity']);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function modalCloudBucketMountsForManifest(args: {
+  modalModule: ModalModule;
+  manifest: Manifest;
+  defaultSecretName?: string;
+}): Promise<Record<string, ModalCloudBucketMountLike> | undefined> {
+  const mountEntries = args.manifest
+    .mountTargets()
+    .filter(({ entry }) => isModalCloudBucketMountEntry(entry));
+  if (mountEntries.length === 0) {
+    return undefined;
+  }
+  if (!args.modalModule.CloudBucketMount) {
+    throw new SandboxProviderError(
+      'Modal cloud bucket mounts require modal.CloudBucketMount support.',
+      {
+        provider: 'modal',
+      },
+    );
+  }
+
+  const cloudBucketMounts: Record<string, ModalCloudBucketMountLike> = {};
+  for (const { entry, mountPath } of mountEntries) {
+    const config = buildModalCloudBucketMountConfig(entry, {
+      secretName:
+        readOptionalString(entry.mountStrategy, 'secretName') ??
+        args.defaultSecretName,
+      secretEnvironmentName: readOptionalString(
+        entry.mountStrategy,
+        'secretEnvironmentName',
+      ),
+    });
+    cloudBucketMounts[mountPath] = new args.modalModule.CloudBucketMount(
+      config.bucketName,
+      {
+        ...(config.bucketEndpointUrl
+          ? { bucketEndpointUrl: config.bucketEndpointUrl }
+          : {}),
+        ...(config.keyPrefix ? { keyPrefix: config.keyPrefix } : {}),
+        ...(typeof config.readOnly === 'boolean'
+          ? { readOnly: config.readOnly }
+          : {}),
+        ...(await modalCloudBucketMountSecret(args.modalModule, config)),
+      },
+    );
+  }
+  return cloudBucketMounts;
+}
+
+async function modalCloudBucketMountSecret(
+  modalModule: ModalModule,
+  config: ModalCloudBucketMountConfig,
+): Promise<{ secret?: ModalSecretLike }> {
+  if (!config.secretName && !config.credentials) {
+    return {};
+  }
+  const Secret = modalModule.Secret;
+  if (!Secret) {
+    throw new SandboxProviderError(
+      'Modal cloud bucket mounts require modal.Secret support when credentials are configured.',
+      {
+        provider: 'modal',
+        bucketName: config.bucketName,
+      },
+    );
+  }
+  const secretName = config.secretName;
+  if (secretName) {
+    return {
+      secret: await withProviderError(
+        'ModalSandboxClient',
+        'modal',
+        'resolve cloud bucket secret',
+        async () =>
+          await Secret.fromName(secretName, {
+            ...(config.secretEnvironmentName
+              ? { environment: config.secretEnvironmentName }
+              : {}),
+          }),
+        {
+          bucketName: config.bucketName,
+          secretName,
+        },
+      ),
+    };
+  }
+  return {
+    secret: await withProviderError(
+      'ModalSandboxClient',
+      'modal',
+      'create cloud bucket secret',
+      async () => await Secret.fromObject(config.credentials ?? {}),
+      { bucketName: config.bucketName },
+    ),
+  };
+}
+
+function assertModalManifestMountsSupported(
+  manifest: Manifest,
+  defaultSecretName?: string,
+): void {
+  for (const { entry, mountPath } of manifest.mountTargets()) {
+    assertModalMountEntrySupported(entry, mountPath, defaultSecretName);
+  }
+}
+
+function assertModalMountEntrySupported(
+  entry: Mount | TypedMount,
+  mountPath: string,
+  defaultSecretName?: string,
+): void {
+  if (!isModalCloudBucketMountEntry(entry)) {
+    throw new SandboxUnsupportedFeatureError(
+      'ModalSandboxClient only supports ModalCloudBucketMountStrategy mount entries.',
+      {
+        provider: 'modal',
+        feature: 'entry.mountStrategy',
+        path: mountPath,
+        mountType: entry.type,
+        strategyType: entry.mountStrategy?.type,
+      },
+    );
+  }
+  buildModalCloudBucketMountConfig(entry, {
+    secretName:
+      readOptionalString(entry.mountStrategy, 'secretName') ??
+      defaultSecretName,
+    secretEnvironmentName: readOptionalString(
+      entry.mountStrategy,
+      'secretEnvironmentName',
+    ),
+  });
+}
+
+function assertModalLiveManifestMountsUnsupported(
+  manifest: Manifest,
+  currentManifest: Manifest,
+): void {
+  const mountPaths = uniqueStrings([
+    ...manifest.mountTargets().map(({ mountPath }) => mountPath),
+    ...collectExistingModalMountPathsOverlappedByPaths(
+      currentManifest,
+      collectModalManifestEntryPaths(manifest),
+    ),
+  ]);
+  if (mountPaths.length === 0) {
+    return;
+  }
+  throwModalLiveMountsUnsupported(mountPaths);
+}
+
+function assertModalLiveEntryMountsUnsupported(
+  entry: Entry,
+  path: string,
+  currentManifest: Manifest,
+): void {
+  const mountPaths = uniqueStrings([
+    ...collectModalEntryMountPaths(entry, path),
+    ...collectExistingModalMountPathsOverlappedByPaths(
+      currentManifest,
+      collectModalEntryPaths(entry, path, currentManifest.root),
+    ),
+  ]);
+  if (mountPaths.length === 0) {
+    return;
+  }
+  throwModalLiveMountsUnsupported(mountPaths);
+}
+
+function collectModalManifestEntryPaths(manifest: Manifest): string[] {
+  return [...manifest.iterEntries()].map(({ logicalPath }) => logicalPath);
+}
+
+function collectModalEntryPaths(
+  entry: Entry,
+  path: string,
+  root: string,
+): string[] {
+  const logicalPath = resolveSandboxRelativePath(root, path);
+  return collectModalEntryPathsFromRelative(entry, logicalPath);
+}
+
+function collectModalEntryPathsFromRelative(
+  entry: Entry,
+  path: string,
+): string[] {
+  if (entry.type !== 'dir' || !entry.children) {
+    return [normalizeManifestRelativePath(path)];
+  }
+  const paths = [normalizeManifestRelativePath(path)];
+  for (const [childPath, childEntry] of Object.entries(entry.children)) {
+    paths.push(
+      ...collectModalEntryPathsFromRelative(
+        childEntry,
+        pathPosix.join(path, childPath),
+      ),
+    );
+  }
+  return paths;
+}
+
+function collectModalEntryMountPaths(entry: Entry, path: string): string[] {
+  if (isMount(entry)) {
+    return [entry.mountPath ?? path];
+  }
+  if (entry.type !== 'dir' || !entry.children) {
+    return [];
+  }
+  const mountPaths: string[] = [];
+  for (const [childPath, childEntry] of Object.entries(entry.children)) {
+    mountPaths.push(
+      ...collectModalEntryMountPaths(
+        childEntry,
+        pathPosix.join(path, childPath),
+      ),
+    );
+  }
+  return mountPaths;
+}
+
+function collectExistingModalMountPathsOverlappedByPaths(
+  currentManifest: Manifest,
+  paths: string[],
+): string[] {
+  if (paths.length === 0) {
+    return [];
+  }
+  const normalizedPaths = paths.map(normalizeManifestRelativePath);
+  const mountPaths: string[] = [];
+  for (const target of currentManifest.mountTargets()) {
+    const mountedPaths = [
+      target.logicalPath,
+      existingMountPathRelativeToManifestRoot(
+        currentManifest,
+        target.mountPath,
+      ),
+    ].filter((path): path is string => path !== null);
+    if (
+      mountedPaths.some((mountedPath) =>
+        normalizedPaths.some((path) =>
+          manifestRelativePathsOverlap(path, mountedPath),
+        ),
+      )
+    ) {
+      mountPaths.push(target.mountPath);
+    }
+  }
+  return mountPaths;
+}
+
+function existingMountPathRelativeToManifestRoot(
+  manifest: Manifest,
+  mountPath: string,
+): string | null {
+  return relativePosixPathWithinRoot(
+    normalizePosixPath(manifest.root),
+    normalizePosixPath(mountPath),
+  );
+}
+
+function manifestRelativePathsOverlap(left: string, right: string): boolean {
+  const normalizedLeft = normalizeManifestRelativePath(left);
+  const normalizedRight = normalizeManifestRelativePath(right);
+  if (normalizedLeft === '' || normalizedRight === '') {
+    return true;
+  }
+  return (
+    normalizedLeft === normalizedRight ||
+    normalizedLeft.startsWith(`${normalizedRight}/`) ||
+    normalizedRight.startsWith(`${normalizedLeft}/`)
+  );
+}
+
+function normalizeManifestRelativePath(path: string): string {
+  const normalized = normalizePosixPath(path);
+  return normalized === '.' ? '' : normalized;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function throwModalLiveMountsUnsupported(mountPaths: string[]): never {
+  throw new SandboxUnsupportedFeatureError(
+    'ModalSandboxClient cannot apply mount entries to a running sandbox.',
+    {
+      provider: 'modal',
+      feature: 'manifest.mounts',
+      mountPaths,
+    },
+  );
+}
+
+function assertModalReusableSandboxMountsSupported(
+  manifest: Manifest,
+  sandbox?: ModalSandboxSelector,
+): void {
+  if (!sandbox) {
+    return;
+  }
+
+  const mountTargets = manifest.mountTargets();
+  if (mountTargets.length === 0) {
+    return;
+  }
+
+  throw new SandboxUnsupportedFeatureError(
+    'ModalSandboxClient cannot apply mount entries when reusing an existing sandbox.',
+    {
+      provider: 'modal',
+      feature: 'manifest.mounts',
+      mountPaths: mountTargets.map(({ mountPath }) => mountPath),
+    },
+  );
+}
+
+function resolveOptions(
+  defaults: Partial<ModalSandboxClientOptions>,
+  overrides?: ModalSandboxClientOptions,
+): ModalSandboxClientOptions {
+  return {
+    appName: overrides?.appName ?? defaults.appName ?? '',
+    image: overrides?.image ?? defaults.image,
+    sandbox: overrides?.sandbox ?? defaults.sandbox,
+    imageTag: overrides?.imageTag ?? defaults.imageTag,
+    sandboxCreateTimeoutS:
+      overrides?.sandboxCreateTimeoutS ?? defaults.sandboxCreateTimeoutS,
+    workspacePersistence:
+      overrides?.workspacePersistence ?? defaults.workspacePersistence ?? 'tar',
+    snapshotFilesystemTimeoutMs:
+      overrides?.snapshotFilesystemTimeoutMs ??
+      defaults.snapshotFilesystemTimeoutMs,
+    snapshotFilesystemRestoreTimeoutMs:
+      overrides?.snapshotFilesystemRestoreTimeoutMs ??
+      defaults.snapshotFilesystemRestoreTimeoutMs,
+    env: {
+      ...(defaults.env ?? {}),
+      ...(overrides?.env ?? {}),
+    },
+    timeoutMs: overrides?.timeoutMs ?? defaults.timeoutMs,
+    idleTimeoutMs: overrides?.idleTimeoutMs ?? defaults.idleTimeoutMs,
+    gpu: overrides?.gpu ?? defaults.gpu,
+    exposedPorts: overrides?.exposedPorts ?? defaults.exposedPorts,
+    environment: overrides?.environment ?? defaults.environment,
+    endpoint: overrides?.endpoint ?? defaults.endpoint,
+    tokenId: overrides?.tokenId ?? defaults.tokenId,
+    tokenSecret: overrides?.tokenSecret ?? defaults.tokenSecret,
+    imageBuilderVersion:
+      overrides?.imageBuilderVersion ?? defaults.imageBuilderVersion,
+    nativeCloudBucketSecretName:
+      overrides?.nativeCloudBucketSecretName ??
+      defaults.nativeCloudBucketSecretName,
+    useSleepCmd: overrides?.useSleepCmd ?? defaults.useSleepCmd ?? true,
+  };
+}
+
+function validateOptions(options: ModalSandboxClientOptions): void {
+  if (!options.appName || options.appName.trim().length === 0) {
+    throw new UserError('ModalSandboxClient requires a non-empty appName.');
+  }
+
+  const workspacePersistence = options.workspacePersistence ?? 'tar';
+  if (
+    !['tar', 'snapshot_filesystem', 'snapshot_directory'].includes(
+      workspacePersistence,
+    )
+  ) {
+    throw new SandboxUnsupportedFeatureError(
+      'ModalSandboxClient workspacePersistence must be "tar", "snapshot_filesystem", or "snapshot_directory".',
+      {
+        provider: 'modal',
+        feature: 'workspacePersistence',
+      },
+    );
+  }
+
+  if (
+    options.nativeCloudBucketSecretName !== undefined &&
+    options.nativeCloudBucketSecretName.trim() === ''
+  ) {
+    throw new SandboxUnsupportedFeatureError(
+      'Modal nativeCloudBucketSecretName must be a non-empty string.',
+      {
+        provider: 'modal',
+        feature: 'nativeCloudBucketSecretName',
+      },
+    );
+  }
+
+  if (options.image) {
+    validateModalImageSelector(options.image);
+  }
+  if (options.sandbox) {
+    validateModalSandboxSelector(options.sandbox);
+  }
+  for (const [name, value] of [
+    ['sandboxCreateTimeoutS', options.sandboxCreateTimeoutS],
+    ['snapshotFilesystemTimeoutMs', options.snapshotFilesystemTimeoutMs],
+    [
+      'snapshotFilesystemRestoreTimeoutMs',
+      options.snapshotFilesystemRestoreTimeoutMs,
+    ],
+    ['timeoutMs', options.timeoutMs],
+    ['idleTimeoutMs', options.idleTimeoutMs],
+  ] as const) {
+    if (
+      value !== undefined &&
+      (typeof value !== 'number' || !Number.isFinite(value) || value <= 0)
+    ) {
+      throw new UserError(
+        `ModalSandboxClient ${name} must be a positive number.`,
+      );
+    }
+  }
+}
+
+function validateModalImageSelector(selector: ModalImageSelector): void {
+  if (selector.kind === 'image') {
+    if (!selector.value || typeof selector.value !== 'object') {
+      throw new UserError(
+        'ModalSandboxClient image selector requires a Modal image object.',
+      );
+    }
+    return;
+  }
+  if (
+    (selector.kind === 'id' || selector.kind === 'tag') &&
+    (typeof selector.value !== 'string' || selector.value.trim().length === 0)
+  ) {
+    throw new UserError(
+      'ModalSandboxClient image selector requires a non-empty string value.',
+    );
+  }
+}
+
+function validateModalSandboxSelector(selector: ModalSandboxSelector): void {
+  if (selector.kind === 'sandbox') {
+    if (!selector.value || typeof selector.value !== 'object') {
+      throw new UserError(
+        'ModalSandboxClient sandbox selector requires a Modal sandbox object.',
+      );
+    }
+    return;
+  }
+  if (
+    selector.kind === 'id' &&
+    (typeof selector.value !== 'string' || selector.value.trim().length === 0)
+  ) {
+    throw new UserError(
+      'ModalSandboxClient sandbox selector requires a non-empty sandbox id.',
+    );
+  }
+}
+
+function snapshotIdFromModalResult(
+  snapshot: string | { objectId?: string; imageId?: string; id?: string },
+): string | undefined {
+  if (typeof snapshot === 'string') {
+    return snapshot || undefined;
+  }
+  return snapshot.objectId ?? snapshot.imageId ?? snapshot.id;
+}
+
+function buildShellCommand(args: ExecCommandArgs): string[] {
+  const shellPath = args.shell ?? '/bin/sh';
+  const flag = (args.login ?? true) ? '-lc' : '-c';
+  return [shellPath, flag, args.cmd];
+}
+
+function createActiveProcess(
+  process: ModalContainerProcessLike,
+): ActiveModalProcess {
+  const activeProcess: ActiveModalProcess = {
+    process,
+    stdout: '',
+    stderr: '',
+    droppedStdoutChars: 0,
+    droppedStderrChars: 0,
+    done: false,
+    exitCode: null,
+    donePromise: Promise.resolve(),
+  };
+
+  const stdoutPump = startTextStreamPump(process.stdout, (chunk) => {
+    appendActiveProcessOutput(activeProcess, chunk, 'stdout');
+  });
+  const stderrPump = startTextStreamPump(process.stderr, (chunk) => {
+    appendActiveProcessOutput(activeProcess, chunk, 'stderr');
+  });
+  activeProcess.stopOutputPumps = async () => {
+    await Promise.allSettled([stdoutPump.cancel(), stderrPump.cancel()]);
+  };
+
+  activeProcess.donePromise = (async () => {
+    try {
+      activeProcess.exitCode = await process.wait();
+      await Promise.allSettled([stdoutPump.promise, stderrPump.promise]);
+    } finally {
+      activeProcess.done = true;
+    }
+  })();
+
+  return activeProcess;
+}
+
+function startTextStreamPump(
+  stream: ReadableStream<string>,
+  onChunk: (chunk: string) => void,
+): {
+  promise: Promise<void>;
+  cancel: () => Promise<void>;
+} {
+  const reader = stream.getReader();
+  const promise = (async () => {
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          return;
+        }
+        if (typeof value === 'string') {
+          onChunk(value);
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  })();
+  return {
+    promise,
+    cancel: async () => {
+      await reader.cancel().catch(() => {});
+      await promise.catch(() => {});
+    },
+  };
+}
+
+function clearActiveProcessCleanup(activeProcess: ActiveModalProcess): void {
+  if (activeProcess.cleanupTimer) {
+    clearTimeout(activeProcess.cleanupTimer);
+    activeProcess.cleanupTimer = undefined;
+  }
+}
+
+function unrefTimer(timer: ReturnType<typeof setTimeout>): void {
+  const maybeTimer = timer as { unref?: () => void };
+  maybeTimer.unref?.();
+}
+
+async function pumpTextStream(
+  stream: ReadableStream<string>,
+  onChunk: (chunk: string) => void,
+): Promise<void> {
+  await startTextStreamPump(stream, onChunk).promise;
+}
+
+async function readStreamText(stream: ReadableStream<string>): Promise<string> {
+  let text = '';
+  await pumpTextStream(stream, (chunk) => {
+    text += chunk;
+  });
+  return text;
+}
+
+async function waitForProcessOrTimeout(
+  activeProcess: ActiveModalProcess,
+  timeoutMs: number,
+): Promise<void> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      activeProcess.donePromise,
+      new Promise<void>((resolve) => {
+        timeout = setTimeout(resolve, timeoutMs);
+        unrefTimer(timeout);
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function joinCommandOutput(activeProcess: ActiveModalProcess): string {
+  return [
+    withDroppedOutputPrefix(
+      activeProcess.stdout,
+      activeProcess.droppedStdoutChars,
+    ),
+    withDroppedOutputPrefix(
+      activeProcess.stderr,
+      activeProcess.droppedStderrChars,
+    ),
+  ]
+    .filter((value) => value.trim().length > 0)
+    .map((value) => value.trimEnd())
+    .join('\n');
+}
+
+function consumeCommandOutput(activeProcess: ActiveModalProcess): string {
+  const output = joinCommandOutput(activeProcess);
+  activeProcess.stdout = '';
+  activeProcess.stderr = '';
+  activeProcess.droppedStdoutChars = 0;
+  activeProcess.droppedStderrChars = 0;
+  return output;
+}
+
+type ActiveProcessOutputStream = 'stdout' | 'stderr';
+
+function appendActiveProcessOutput(
+  activeProcess: ActiveModalProcess,
+  chunk: string,
+  stream: ActiveProcessOutputStream,
+): void {
+  if (chunk.length === 0) {
+    return;
+  }
+
+  if (stream === 'stdout') {
+    const stdout = appendBoundedOutput(
+      activeProcess.stdout,
+      activeProcess.droppedStdoutChars,
+      chunk,
+    );
+    activeProcess.stdout = stdout.output;
+    activeProcess.droppedStdoutChars = stdout.droppedChars;
+    return;
+  }
+
+  const stderr = appendBoundedOutput(
+    activeProcess.stderr,
+    activeProcess.droppedStderrChars,
+    chunk,
+  );
+  activeProcess.stderr = stderr.output;
+  activeProcess.droppedStderrChars = stderr.droppedChars;
+}
+
+function appendBoundedOutput(
+  output: string,
+  droppedChars: number,
+  chunk: string,
+): { output: string; droppedChars: number } {
+  const nextLength = output.length + chunk.length;
+  if (nextLength <= MAX_ACTIVE_PROCESS_OUTPUT_CHARS) {
+    return {
+      output: output + chunk,
+      droppedChars,
+    };
+  }
+
+  const nextDroppedChars =
+    droppedChars + nextLength - MAX_ACTIVE_PROCESS_OUTPUT_CHARS;
+  if (chunk.length >= MAX_ACTIVE_PROCESS_OUTPUT_CHARS) {
+    return {
+      output: chunk.slice(-MAX_ACTIVE_PROCESS_OUTPUT_CHARS),
+      droppedChars: nextDroppedChars,
+    };
+  }
+
+  const existingCharsToKeep = MAX_ACTIVE_PROCESS_OUTPUT_CHARS - chunk.length;
+  return {
+    output: output.slice(-existingCharsToKeep) + chunk,
+    droppedChars: nextDroppedChars,
+  };
+}
+
+function withDroppedOutputPrefix(output: string, droppedChars: number): string {
+  if (droppedChars === 0) {
+    return output;
+  }
+
+  return `[...${droppedChars} characters truncated from process output...]\n${output}`;
+}
+
+async function withOptionalTimeout<T>(
+  promise: Promise<T>,
+  timeoutSeconds: number | undefined,
+  message: string,
+  onLateResolve?: (value: T) => Promise<void> | void,
+): Promise<T> {
+  if (typeof timeoutSeconds !== 'number') {
+    return await promise;
+  }
+  return await withOptionalTimeoutMs(
+    promise,
+    timeoutSeconds * 1000,
+    message,
+    onLateResolve,
+  );
+}
+
+async function withOptionalTimeoutMs<T>(
+  promise: Promise<T>,
+  timeoutMs: number | undefined,
+  message: string,
+  onLateResolve?: (value: T) => Promise<void> | void,
+): Promise<T> {
+  if (typeof timeoutMs !== 'number') {
+    return await promise;
+  }
+
+  let settled = false;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then(
+        (value) => {
+          settled = true;
+          return value;
+        },
+        (error: unknown) => {
+          settled = true;
+          throw error;
+        },
+      ),
+      new Promise<T>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          if (settled) {
+            return;
+          }
+          promise
+            .then(async (value) => {
+              await onLateResolve?.(value);
+            })
+            .catch(() => {});
+          reject(new UserError(message));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+async function terminateModalSandboxAfterTimeout(
+  sandbox: ModalSandboxLike,
+): Promise<void> {
+  await sandbox.terminate().catch(() => {});
+}

--- a/packages/agents-extensions/src/sandbox/modal/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/modal/sandbox.ts
@@ -1483,35 +1483,16 @@ function shouldResolveModalApp(args: {
 function adaptModalModule(modal: typeof import('modal')): ModalModule {
   const secretApi: unknown = modal.Secret;
   const usesClassSecretApi = typeof secretApi === 'function';
+  const cloudBucketMountClass =
+    typeof modal.CloudBucketMount === 'function'
+      ? (modal.CloudBucketMount as NonNullable<ModalModule['CloudBucketMount']>)
+      : undefined;
   return {
     ModalClient: modal.ModalClient,
-    CloudBucketMount: usesClassSecretApi
-      ? class implements ModalCloudBucketMountLike {
-          private readonly mount: InstanceType<typeof modal.CloudBucketMount>;
-
-          constructor(bucketName: string, params?: Record<string, unknown>) {
-            const bucketEndpointUrl = readOptionalString(
-              params,
-              'bucketEndpointUrl',
-            );
-            const keyPrefix = readOptionalString(params, 'keyPrefix');
-            this.mount = new modal.CloudBucketMount(bucketName, {
-              ...(bucketEndpointUrl ? { bucketEndpointUrl } : {}),
-              ...(keyPrefix ? { keyPrefix } : {}),
-              ...(typeof params?.readOnly === 'boolean'
-                ? { readOnly: params.readOnly }
-                : {}),
-              ...(params?.secret
-                ? { secret: params.secret as InstanceType<typeof modal.Secret> }
-                : {}),
-            });
-          }
-
-          toProto(mountPath: string): unknown {
-            return this.mount.toProto(mountPath);
-          }
-        }
-      : (modal.CloudBucketMount as ModalModule['CloudBucketMount']),
+    CloudBucketMount:
+      usesClassSecretApi && cloudBucketMountClass
+        ? adaptClassModalCloudBucketMount(cloudBucketMountClass)
+        : (modal.CloudBucketMount as ModalModule['CloudBucketMount']),
     Secret: {
       fromName: async (name, params) => {
         if (usesClassSecretApi) {
@@ -1537,6 +1518,39 @@ function adaptModalModule(modal: typeof import('modal')): ModalModule {
         throw new Error('Missing Secret export from modal.');
       },
     },
+  };
+}
+
+function adaptClassModalCloudBucketMount(
+  CloudBucketMount: NonNullable<ModalModule['CloudBucketMount']>,
+): NonNullable<ModalModule['CloudBucketMount']> {
+  return class implements ModalCloudBucketMountLike {
+    private readonly mount: ModalCloudBucketMountLike;
+
+    constructor(bucketName: string, params?: Record<string, unknown>) {
+      const bucketEndpointUrl = readOptionalString(params, 'bucketEndpointUrl');
+      const keyPrefix = readOptionalString(params, 'keyPrefix');
+      this.mount = new CloudBucketMount(bucketName, {
+        ...(bucketEndpointUrl ? { bucketEndpointUrl } : {}),
+        ...(keyPrefix ? { keyPrefix } : {}),
+        ...(typeof params?.readOnly === 'boolean'
+          ? { readOnly: params.readOnly }
+          : {}),
+        ...(params?.secret ? { secret: params.secret } : {}),
+      });
+    }
+
+    toProto(mountPath: string): unknown {
+      if (!this.mount.toProto) {
+        throw new SandboxProviderError(
+          'Modal CloudBucketMount is missing toProto support.',
+          {
+            provider: 'modal',
+          },
+        );
+      }
+      return this.mount.toProto(mountPath);
+    }
   };
 }
 

--- a/packages/agents-extensions/src/sandbox/modal/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/modal/sandbox.ts
@@ -186,6 +186,7 @@ type ActiveModalProcess = {
   done: boolean;
   exitCode: number | null;
   donePromise: Promise<void>;
+  waitError?: unknown;
   stopOutputPumps?: () => Promise<void>;
   cleanupTimer?: ReturnType<typeof setTimeout>;
 };
@@ -805,7 +806,16 @@ export class ModalSandboxSession implements SandboxSession<ModalSandboxSessionSt
       'ModalSandboxClient',
       'modal',
       'restore snapshot_directory',
-      async () =>
+      async () => {
+        if (!ownsSandbox) {
+          const image = await withOptionalTimeoutMs(
+            this.modalImageFromId(snapshotId),
+            this.state.snapshotFilesystemRestoreTimeoutMs,
+            'Modal snapshot_directory restore timed out.',
+          );
+          await sandbox.mountImage!(this.state.manifest.root, image);
+          return;
+        }
         await withOptionalTimeoutMs(
           (async () => {
             const image = await this.modalImageFromId(snapshotId);
@@ -814,11 +824,10 @@ export class ModalSandboxSession implements SandboxSession<ModalSandboxSessionSt
           this.state.snapshotFilesystemRestoreTimeoutMs,
           'Modal snapshot_directory restore timed out.',
           async () => {
-            if (ownsSandbox) {
-              await terminateModalSandboxAfterTimeout(sandbox);
-            }
+            await terminateModalSandboxAfterTimeout(sandbox);
           },
-        ),
+        );
+      },
       { sandboxId: this.state.sandboxId, snapshotId },
     );
   }
@@ -1007,7 +1016,7 @@ export class ModalSandboxSession implements SandboxSession<ModalSandboxSessionSt
       path,
       options,
       runCommand: async (command) => {
-        const process = await this.sandbox.exec(['/bin/sh', '-lc', command], {
+        const process = await this.sandbox.exec(['/bin/sh', '-c', command], {
           mode: 'text',
           workdir: this.state.manifest.root,
           stdout: 'pipe',
@@ -1078,7 +1087,7 @@ export class ModalSandboxSession implements SandboxSession<ModalSandboxSessionSt
   private archiveIo() {
     return {
       runCommand: async (command: string) => {
-        const process = await this.sandbox.exec(['/bin/sh', '-lc', command], {
+        const process = await this.sandbox.exec(['/bin/sh', '-c', command], {
           mode: 'text',
           workdir: this.state.manifest.root,
           env: this.state.environment,
@@ -2164,7 +2173,8 @@ function snapshotIdFromModalResult(
 
 function buildShellCommand(args: ExecCommandArgs): string[] {
   const shellPath = args.shell ?? '/bin/sh';
-  const flag = (args.login ?? true) ? '-lc' : '-c';
+  const login = args.shell ? (args.login ?? true) : false;
+  const flag = login ? '-lc' : '-c';
   return [shellPath, flag, args.cmd];
 }
 
@@ -2195,6 +2205,9 @@ function createActiveProcess(
   activeProcess.donePromise = (async () => {
     try {
       activeProcess.exitCode = await process.wait();
+      await Promise.allSettled([stdoutPump.promise, stderrPump.promise]);
+    } catch (error) {
+      activeProcess.waitError = error;
       await Promise.allSettled([stdoutPump.promise, stderrPump.promise]);
     } finally {
       activeProcess.done = true;
@@ -2281,6 +2294,21 @@ async function waitForProcessOrTimeout(
       clearTimeout(timeout);
     }
   }
+  if (activeProcess.waitError) {
+    await activeProcess.stopOutputPumps?.();
+    throw new SandboxProviderError(
+      'ModalSandboxClient failed to wait for process completion.',
+      {
+        provider: 'modal',
+        operation: 'wait process',
+        cause: modalErrorMessage(activeProcess.waitError),
+      },
+    );
+  }
+}
+
+function modalErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function joinCommandOutput(activeProcess: ActiveModalProcess): string {

--- a/packages/agents-extensions/test/sandbox/modal.test.ts
+++ b/packages/agents-extensions/test/sandbox/modal.test.ts
@@ -24,6 +24,10 @@ import { makeTarArchive } from './tarFixture';
 const processMocks = vi.hoisted(() => ({
   runSandboxProcess: vi.fn(),
 }));
+const modalSdkMocks = vi.hoisted(() => ({
+  cloudBucketMountAvailable: true,
+  classSecretApi: false,
+}));
 const appsFromNameMock = vi.fn();
 const imagesFromRegistryMock = vi.fn();
 const imagesFromIdMock = vi.fn();
@@ -44,40 +48,76 @@ const secretFromObjectMock = vi.fn();
 const imageBuilderVersionMock = vi.fn();
 const modalClientParams: Record<string, unknown>[] = [];
 
-vi.mock('modal', () => ({
-  CloudBucketMount: class CloudBucketMount {
+vi.mock('modal', () => {
+  class CloudBucketMount {
     constructor(
       readonly bucketName: string,
       readonly params: Record<string, unknown> = {},
     ) {}
-  },
-  ModalClient: class ModalClient {
-    readonly apps = {
-      fromName: appsFromNameMock,
-    };
 
-    readonly images = {
-      fromRegistry: imagesFromRegistryMock,
-      fromId: imagesFromIdMock,
-      delete: imagesDeleteMock,
-    };
-
-    readonly sandboxes = {
-      create: sandboxesCreateMock,
-      fromId: sandboxesFromIdMock,
-    };
-
-    imageBuilderVersion = imageBuilderVersionMock;
-
-    constructor(params?: Record<string, unknown>) {
-      modalClientParams.push(params ?? {});
+    toProto(mountPath: string): Record<string, unknown> {
+      return {
+        mountPath,
+        bucketName: this.bucketName,
+        params: this.params,
+      };
     }
-  },
-  Secret: {
-    fromName: secretFromNameMock,
-    fromObject: secretFromObjectMock,
-  },
-}));
+  }
+
+  class Secret {
+    static async fromName(
+      name: string,
+      params?: Record<string, unknown>,
+    ): Promise<unknown> {
+      return await secretFromNameMock(name, params);
+    }
+
+    static async fromObject(
+      entries: Record<string, string>,
+      params?: Record<string, unknown>,
+    ): Promise<unknown> {
+      return await secretFromObjectMock(entries, params);
+    }
+  }
+
+  return {
+    get CloudBucketMount() {
+      return modalSdkMocks.cloudBucketMountAvailable
+        ? CloudBucketMount
+        : undefined;
+    },
+    ModalClient: class ModalClient {
+      readonly apps = {
+        fromName: appsFromNameMock,
+      };
+
+      readonly images = {
+        fromRegistry: imagesFromRegistryMock,
+        fromId: imagesFromIdMock,
+        delete: imagesDeleteMock,
+      };
+
+      readonly sandboxes = {
+        create: sandboxesCreateMock,
+        fromId: sandboxesFromIdMock,
+      };
+
+      imageBuilderVersion = imageBuilderVersionMock;
+
+      constructor(params?: Record<string, unknown>) {
+        modalClientParams.push(params ?? {});
+      }
+    },
+    get Secret() {
+      return modalSdkMocks.classSecretApi
+        ? Secret
+        : {
+            fromName: secretFromNameMock,
+            fromObject: secretFromObjectMock,
+          };
+    },
+  };
+});
 
 vi.mock('../../src/sandbox/shared/process', () => ({
   runSandboxProcess: processMocks.runSandboxProcess,
@@ -151,6 +191,8 @@ describe('ModalSandboxClient', () => {
     secretFromObjectMock.mockReset();
     imageBuilderVersionMock.mockReset();
     processMocks.runSandboxProcess.mockReset();
+    modalSdkMocks.cloudBucketMountAvailable = true;
+    modalSdkMocks.classSecretApi = false;
     modalClientParams.splice(0);
 
     appsFromNameMock.mockResolvedValue({ appId: 'ap_test' });
@@ -471,6 +513,41 @@ describe('ModalSandboxClient', () => {
     );
   });
 
+  test('rejects Modal cloud bucket mounts when the SDK export is unavailable', async () => {
+    modalSdkMocks.classSecretApi = true;
+    modalSdkMocks.cloudBucketMountAvailable = false;
+    const client = new ModalSandboxClient();
+
+    const createPromise = client.create(
+      new Manifest({
+        entries: {
+          data: {
+            type: 's3_mount',
+            bucket: 'logs',
+            mountStrategy: new ModalCloudBucketMountStrategy({
+              secretName: 'modal-bucket-secret',
+            }),
+          },
+        },
+      }),
+      {
+        appName: 'sandbox-tests',
+      },
+    );
+
+    await expect(createPromise).rejects.toBeInstanceOf(SandboxProviderError);
+    await expect(createPromise).rejects.toThrow(
+      'Modal cloud bucket mounts require modal.CloudBucketMount support.',
+    );
+    await expect(createPromise).rejects.toMatchObject({
+      details: {
+        provider: 'modal',
+      },
+    });
+    expect(secretFromNameMock).not.toHaveBeenCalled();
+    expect(sandboxesCreateMock).not.toHaveBeenCalled();
+  });
+
   test('rejects partial S3 cloud bucket credentials', async () => {
     const client = new ModalSandboxClient();
 
@@ -496,6 +573,40 @@ describe('ModalSandboxClient', () => {
         mountType: 's3_mount',
       },
     });
+    expect(sandboxesCreateMock).not.toHaveBeenCalled();
+  });
+
+  test('rejects partial GCS cloud bucket credentials even with a secret name', async () => {
+    const client = new ModalSandboxClient();
+
+    const createPromise = client.create(
+      new Manifest({
+        entries: {
+          data: {
+            type: 'gcs_mount',
+            bucket: 'logs',
+            accessId: 'access-id',
+            mountStrategy: new ModalCloudBucketMountStrategy({
+              secretName: 'modal-bucket-secret',
+            }),
+          },
+        },
+      }),
+      {
+        appName: 'sandbox-tests',
+      },
+    );
+
+    await expect(createPromise).rejects.toThrow(
+      'Modal GCS bucket mounts require both accessId and secretAccessKey when either is provided.',
+    );
+    await expect(createPromise).rejects.toMatchObject({
+      details: {
+        provider: 'modal',
+        mountType: 'gcs_mount',
+      },
+    });
+    expect(secretFromNameMock).not.toHaveBeenCalled();
     expect(sandboxesCreateMock).not.toHaveBeenCalled();
   });
 

--- a/packages/agents-extensions/test/sandbox/modal.test.ts
+++ b/packages/agents-extensions/test/sandbox/modal.test.ts
@@ -1,0 +1,1946 @@
+import {
+  Manifest,
+  SandboxProviderError,
+  SandboxUnsupportedFeatureError,
+} from '@openai/agents-core/sandbox';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  ModalSandboxClient,
+  ModalCloudBucketMountStrategy,
+  ModalImageSelector,
+  ModalSandboxSelector,
+  type ModalSandboxClientOptions,
+  type ModalSandboxSessionState,
+} from '../../src/sandbox/modal';
+import {
+  decodeNativeSnapshotRef,
+  encodeNativeSnapshotRef,
+} from '../../src/sandbox/shared';
+import { resolvedRemotePathFromValidationCommand } from './remotePathValidation';
+import { makeTarArchive } from './tarFixture';
+
+const processMocks = vi.hoisted(() => ({
+  runSandboxProcess: vi.fn(),
+}));
+const appsFromNameMock = vi.fn();
+const imagesFromRegistryMock = vi.fn();
+const imagesFromIdMock = vi.fn();
+const imagesDeleteMock = vi.fn();
+const imageCmdMock = vi.fn();
+const sandboxesCreateMock = vi.fn();
+const sandboxesFromIdMock = vi.fn();
+const sandboxExecMock = vi.fn();
+const sandboxOpenMock = vi.fn();
+const sandboxTerminateMock = vi.fn();
+const sandboxPollMock = vi.fn();
+const sandboxTunnelsMock = vi.fn();
+const sandboxSnapshotFilesystemMock = vi.fn();
+const sandboxSnapshotDirectoryMock = vi.fn();
+const sandboxMountImageMock = vi.fn();
+const secretFromNameMock = vi.fn();
+const secretFromObjectMock = vi.fn();
+const imageBuilderVersionMock = vi.fn();
+const modalClientParams: Record<string, unknown>[] = [];
+
+vi.mock('modal', () => ({
+  CloudBucketMount: class CloudBucketMount {
+    constructor(
+      readonly bucketName: string,
+      readonly params: Record<string, unknown> = {},
+    ) {}
+  },
+  ModalClient: class ModalClient {
+    readonly apps = {
+      fromName: appsFromNameMock,
+    };
+
+    readonly images = {
+      fromRegistry: imagesFromRegistryMock,
+      fromId: imagesFromIdMock,
+      delete: imagesDeleteMock,
+    };
+
+    readonly sandboxes = {
+      create: sandboxesCreateMock,
+      fromId: sandboxesFromIdMock,
+    };
+
+    imageBuilderVersion = imageBuilderVersionMock;
+
+    constructor(params?: Record<string, unknown>) {
+      modalClientParams.push(params ?? {});
+    }
+  },
+  Secret: {
+    fromName: secretFromNameMock,
+    fromObject: secretFromObjectMock,
+  },
+}));
+
+vi.mock('../../src/sandbox/shared/process', () => ({
+  runSandboxProcess: processMocks.runSandboxProcess,
+  formatSandboxProcessError: (result: {
+    stderr?: string;
+    stdout?: string;
+    error?: Error;
+  }) => result.stderr || result.stdout || result.error?.message || 'failed',
+}));
+
+const processSuccess = (stdout = '') => ({
+  status: 0,
+  signal: null,
+  stdout,
+  stderr: '',
+  timedOut: false,
+});
+
+const processFailure = (stderr: string) => ({
+  status: 1,
+  signal: null,
+  stdout: '',
+  stderr,
+  timedOut: false,
+});
+
+function textStream(text: string): ReadableStream<string> {
+  return new ReadableStream<string>({
+    start(controller) {
+      controller.enqueue(text);
+      controller.close();
+    },
+  });
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('ModalSandboxClient', () => {
+  const files = new Map<string, Uint8Array>();
+
+  beforeEach(() => {
+    files.clear();
+    appsFromNameMock.mockReset();
+    imagesFromRegistryMock.mockReset();
+    imagesFromIdMock.mockReset();
+    imagesDeleteMock.mockReset();
+    imageCmdMock.mockReset();
+    sandboxesCreateMock.mockReset();
+    sandboxesFromIdMock.mockReset();
+    sandboxExecMock.mockReset();
+    sandboxOpenMock.mockReset();
+    sandboxTerminateMock.mockReset();
+    sandboxPollMock.mockReset();
+    sandboxTunnelsMock.mockReset();
+    sandboxSnapshotFilesystemMock.mockReset();
+    sandboxSnapshotDirectoryMock.mockReset();
+    sandboxMountImageMock.mockReset();
+    secretFromNameMock.mockReset();
+    secretFromObjectMock.mockReset();
+    imageBuilderVersionMock.mockReset();
+    processMocks.runSandboxProcess.mockReset();
+    modalClientParams.splice(0);
+
+    appsFromNameMock.mockResolvedValue({ appId: 'ap_test' });
+    imageCmdMock.mockImplementation((command: string[]) => ({
+      imageId: 'im_test_cmd',
+      command,
+    }));
+    imagesFromRegistryMock.mockReturnValue({
+      imageId: 'im_test',
+      cmd: imageCmdMock,
+    });
+    imagesFromIdMock.mockImplementation((id: string) => ({ imageId: id }));
+    imagesDeleteMock.mockResolvedValue(undefined);
+    sandboxPollMock.mockResolvedValue(null);
+    sandboxTerminateMock.mockResolvedValue(undefined);
+    sandboxSnapshotFilesystemMock.mockResolvedValue({
+      objectId: 'im_snapshot_fs',
+    });
+    sandboxSnapshotDirectoryMock.mockResolvedValue({
+      objectId: 'im_snapshot_dir',
+    });
+    sandboxMountImageMock.mockResolvedValue(undefined);
+    secretFromNameMock.mockResolvedValue({ secretId: 'secret-from-name' });
+    secretFromObjectMock.mockResolvedValue({ secretId: 'secret-from-object' });
+    imageBuilderVersionMock.mockImplementation(
+      (version?: string) => version ?? '2024.10',
+    );
+    sandboxTunnelsMock.mockResolvedValue({
+      3000: {
+        host: '3000-modal.example.test',
+        port: 443,
+      },
+    });
+
+    sandboxOpenMock.mockImplementation(
+      async (path: string, mode: string = 'r') => ({
+        read: async () => files.get(path) ?? new Uint8Array(),
+        write: async (data: Uint8Array) => {
+          if (mode.startsWith('w') || mode.startsWith('a')) {
+            files.set(path, data);
+          }
+        },
+        flush: async () => {},
+        close: async () => {},
+      }),
+    );
+
+    sandboxExecMock.mockImplementation(
+      async (command: string[], _params?: Record<string, unknown>) => {
+        if (command[0] === '/bin/sh' && command[1] === '-lc') {
+          const resolvedPath = resolvedRemotePathFromValidationCommand(
+            command[2] ?? '',
+          );
+          if (resolvedPath) {
+            return {
+              stdin: {
+                writeText: async (_text: string) => {},
+                close: async () => {},
+              },
+              stdout: textStream(`${resolvedPath}\n`),
+              stderr: textStream(''),
+              wait: async () => 0,
+            };
+          }
+        }
+
+        if (
+          command[0] === '/bin/sh' &&
+          command[1] === '-lc' &&
+          command[2] === 'ls'
+        ) {
+          return {
+            stdin: {
+              writeText: async (_text: string) => {},
+              close: async () => {},
+            },
+            stdout: textStream('README.md\n'),
+            stderr: textStream(''),
+            wait: async () => 0,
+          };
+        }
+
+        if (command[0] === 'test' && command[1] === '-e') {
+          const exists = files.has(command[2] ?? '');
+          return {
+            stdin: {
+              writeText: async (_text: string) => {},
+              close: async () => {},
+            },
+            stdout: textStream(''),
+            stderr: textStream(''),
+            wait: async () => (exists ? 0 : 1),
+          };
+        }
+
+        if (command[0] === 'rm' && command[1] === '-f') {
+          files.delete(command[3] ?? '');
+        }
+
+        return {
+          stdin: {
+            writeText: async (_text: string) => {},
+            close: async () => {},
+          },
+          stdout: textStream(''),
+          stderr: textStream(''),
+          wait: async () => 0,
+        };
+      },
+    );
+
+    const sandbox = {
+      sandboxId: 'sbx_test',
+      exec: sandboxExecMock,
+      open: sandboxOpenMock,
+      terminate: sandboxTerminateMock,
+      poll: sandboxPollMock,
+      tunnels: sandboxTunnelsMock,
+      snapshotFilesystem: sandboxSnapshotFilesystemMock,
+      snapshotDirectory: sandboxSnapshotDirectoryMock,
+      mountImage: sandboxMountImageMock,
+    };
+    sandboxesCreateMock.mockResolvedValue(sandbox);
+    sandboxesFromIdMock.mockResolvedValue(sandbox);
+  });
+
+  test('rejects unsupported core create options instead of ignoring them', async () => {
+    const client = new ModalSandboxClient();
+
+    await expect(
+      client.create({
+        manifest: new Manifest(),
+        snapshot: { type: 'remote' },
+      }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+    await expect(
+      client.create({
+        manifest: new Manifest(),
+        concurrencyLimits: { manifestEntries: 2 },
+      }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+    expect(sandboxesCreateMock).not.toHaveBeenCalled();
+  });
+
+  test('creates a sandbox, materializes the manifest, and executes commands', async () => {
+    const client = new ModalSandboxClient();
+    const manifest = new Manifest({
+      entries: {
+        'README.md': {
+          type: 'file',
+          content: '# Hello from Modal\n',
+        },
+      },
+      environment: {
+        SANDBOX_FLAG: 'enabled',
+      },
+    });
+
+    const session = await client.create(manifest, {
+      appName: 'sandbox-tests',
+    } satisfies ModalSandboxClientOptions);
+    const output = await session.execCommand({ cmd: 'ls' });
+
+    expect(appsFromNameMock).toHaveBeenCalledWith('sandbox-tests', {
+      createIfMissing: true,
+    });
+    expect(imagesFromRegistryMock).toHaveBeenCalledWith('debian:bookworm-slim');
+    expect(sandboxesCreateMock).toHaveBeenCalledWith(
+      { appId: 'ap_test' },
+      { imageId: 'im_test_cmd', command: ['sleep', 'infinity'] },
+      expect.objectContaining({
+        workdir: '/workspace',
+        env: { SANDBOX_FLAG: 'enabled' },
+      }),
+    );
+    expect(files.get('/workspace/README.md')).toEqual(
+      new TextEncoder().encode('# Hello from Modal\n'),
+    );
+    expect(output).toContain('Process exited with code 0');
+    expect(output).toContain('README.md');
+  });
+
+  test('clears exec yield timers when commands finish before timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const client = new ModalSandboxClient();
+      const session = await client.create(new Manifest(), {
+        appName: 'sandbox-tests',
+      } satisfies ModalSandboxClientOptions);
+
+      const output = await session.execCommand({
+        cmd: 'true',
+        yieldTimeMs: 10_000,
+      });
+
+      expect(output).toContain('Process exited with code 0');
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('allows disabling the Modal sleep command image override', async () => {
+    const client = new ModalSandboxClient();
+
+    await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+      useSleepCmd: false,
+    } satisfies ModalSandboxClientOptions);
+
+    expect(imageCmdMock).not.toHaveBeenCalled();
+    expect(sandboxesCreateMock).toHaveBeenCalledWith(
+      { appId: 'ap_test' },
+      { imageId: 'im_test', cmd: imageCmdMock },
+      expect.objectContaining({
+        workdir: '/workspace',
+      }),
+    );
+  });
+
+  test('passes Modal idleTimeoutMs through sandbox creation', async () => {
+    const client = new ModalSandboxClient();
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+      idleTimeoutMs: 60_000,
+    } satisfies ModalSandboxClientOptions);
+
+    expect(sandboxesCreateMock).toHaveBeenCalledWith(
+      { appId: 'ap_test' },
+      { imageId: 'im_test_cmd', command: ['sleep', 'infinity'] },
+      expect.objectContaining({
+        idleTimeoutMs: 60_000,
+      }),
+    );
+    expect(session.state.idleTimeoutMs).toBe(60_000);
+  });
+
+  test('materializes git_repo file subpaths as files', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === '--version') {
+          return processSuccess('git version 2.0.0');
+        }
+        if (args[0] === 'clone') {
+          const tempDir = args[args.length - 1];
+          await mkdir(join(tempDir, 'nested'), { recursive: true });
+          await writeFile(join(tempDir, 'nested', 'selected.txt'), 'selected');
+          return processSuccess();
+        }
+        return processFailure('unexpected command');
+      },
+    );
+    const client = new ModalSandboxClient();
+
+    await client.create(
+      new Manifest({
+        entries: {
+          'selected.txt': {
+            type: 'git_repo',
+            repo: 'https://example.test/repo.git',
+            subpath: 'nested/selected.txt',
+          },
+        },
+      }),
+      {
+        appName: 'sandbox-tests',
+      },
+    );
+
+    expect(Buffer.from(files.get('/workspace/selected.txt')!)).toEqual(
+      Buffer.from('selected'),
+    );
+  });
+
+  test('passes Modal cloud bucket mounts to sandbox creation', async () => {
+    const client = new ModalSandboxClient();
+
+    await client.create(
+      new Manifest({
+        entries: {
+          data: {
+            type: 's3_mount',
+            bucket: 'logs',
+            prefix: '2026/',
+            endpointUrl: 'https://s3.us-east-1.amazonaws.com',
+            mountPath: 'mounted/logs',
+            mountStrategy: new ModalCloudBucketMountStrategy({
+              secretName: 'modal-bucket-secret',
+              secretEnvironmentName: 'prod',
+            }),
+          },
+        },
+      }),
+      {
+        appName: 'sandbox-tests',
+      },
+    );
+
+    expect(secretFromNameMock).toHaveBeenCalledWith('modal-bucket-secret', {
+      environment: 'prod',
+    });
+    expect(sandboxesCreateMock).toHaveBeenCalledWith(
+      { appId: 'ap_test' },
+      { imageId: 'im_test_cmd', command: ['sleep', 'infinity'] },
+      expect.objectContaining({
+        cloudBucketMounts: {
+          '/workspace/mounted/logs': expect.objectContaining({
+            bucketName: 'logs',
+            params: {
+              bucketEndpointUrl: 'https://s3.us-east-1.amazonaws.com',
+              keyPrefix: '2026/',
+              readOnly: true,
+              secret: { secretId: 'secret-from-name' },
+            },
+          }),
+        },
+      }),
+    );
+  });
+
+  test('rejects partial S3 cloud bucket credentials', async () => {
+    const client = new ModalSandboxClient();
+
+    await expect(
+      client.create(
+        new Manifest({
+          entries: {
+            data: {
+              type: 's3_mount',
+              bucket: 'logs',
+              accessKeyId: 'access-key',
+              mountStrategy: new ModalCloudBucketMountStrategy(),
+            },
+          },
+        }),
+        {
+          appName: 'sandbox-tests',
+        },
+      ),
+    ).rejects.toMatchObject({
+      details: {
+        provider: 'modal',
+        mountType: 's3_mount',
+      },
+    });
+    expect(sandboxesCreateMock).not.toHaveBeenCalled();
+  });
+
+  test('rejects mount manifests when reusing an existing sandbox', async () => {
+    const client = new ModalSandboxClient({
+      sandbox: ModalSandboxSelector.fromId('sbx_existing'),
+    });
+
+    await expect(
+      client.create(
+        new Manifest({
+          entries: {
+            data: {
+              type: 's3_mount',
+              bucket: 'logs',
+              mountStrategy: new ModalCloudBucketMountStrategy({
+                secretName: 'modal-bucket-secret',
+              }),
+            },
+          },
+        }),
+        {
+          appName: 'sandbox-tests',
+        },
+      ),
+    ).rejects.toMatchObject({
+      details: {
+        provider: 'modal',
+        feature: 'manifest.mounts',
+        mountPaths: ['/workspace/data'],
+      },
+    });
+    expect(appsFromNameMock).not.toHaveBeenCalled();
+    expect(secretFromNameMock).not.toHaveBeenCalled();
+    expect(sandboxesCreateMock).not.toHaveBeenCalled();
+    expect(sandboxesFromIdMock).not.toHaveBeenCalled();
+  });
+
+  test('wraps Modal cloud bucket secret failures as provider errors', async () => {
+    const client = new ModalSandboxClient();
+    secretFromNameMock.mockRejectedValueOnce(new Error('secret failed'));
+
+    const createPromise = client.create(
+      new Manifest({
+        entries: {
+          data: {
+            type: 's3_mount',
+            bucket: 'logs',
+            mountStrategy: new ModalCloudBucketMountStrategy({
+              secretName: 'modal-bucket-secret',
+            }),
+          },
+        },
+      }),
+      {
+        appName: 'sandbox-tests',
+      },
+    );
+
+    await expect(createPromise).rejects.toBeInstanceOf(SandboxProviderError);
+    await expect(createPromise).rejects.toMatchObject({
+      details: {
+        provider: 'modal',
+        operation: 'resolve cloud bucket secret',
+        bucketName: 'logs',
+        secretName: 'modal-bucket-secret',
+        cause: 'secret failed',
+      },
+    });
+  });
+
+  test('supports image and sandbox selectors without snake_case aliases', async () => {
+    const existingSandbox = {
+      sandboxId: 'sbx_existing',
+      exec: sandboxExecMock,
+      open: sandboxOpenMock,
+      terminate: sandboxTerminateMock,
+      poll: sandboxPollMock,
+      tunnels: sandboxTunnelsMock,
+      snapshotFilesystem: sandboxSnapshotFilesystemMock,
+      snapshotDirectory: sandboxSnapshotDirectoryMock,
+      mountImage: sandboxMountImageMock,
+    };
+    sandboxesFromIdMock.mockResolvedValueOnce(existingSandbox);
+    imagesFromIdMock.mockRejectedValueOnce(new Error('image unavailable'));
+    const client = new ModalSandboxClient({
+      image: ModalImageSelector.fromId('im_existing'),
+      sandbox: ModalSandboxSelector.fromId('sbx_existing'),
+    });
+
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+    });
+
+    expect(imagesFromIdMock).not.toHaveBeenCalled();
+    expect(imagesFromRegistryMock).not.toHaveBeenCalled();
+    expect(appsFromNameMock).not.toHaveBeenCalled();
+    expect(sandboxesFromIdMock).toHaveBeenCalledWith('sbx_existing');
+    expect(sandboxesCreateMock).not.toHaveBeenCalled();
+    expect(session.state).toMatchObject({
+      sandboxId: 'sbx_existing',
+      ownsSandbox: false,
+      imageId: 'im_existing',
+      imageTag: 'debian:bookworm-slim',
+    });
+  });
+
+  test('looks up reused sandbox apps without creating them for snapshot filesystem restore', async () => {
+    const client = new ModalSandboxClient({
+      sandbox: ModalSandboxSelector.fromId('sbx_existing'),
+      workspacePersistence: 'snapshot_filesystem',
+    });
+
+    await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+    } satisfies ModalSandboxClientOptions);
+
+    expect(appsFromNameMock).toHaveBeenCalledWith('sandbox-tests', {
+      createIfMissing: false,
+    });
+    expect(sandboxesFromIdMock).toHaveBeenCalledWith('sbx_existing');
+    expect(sandboxesCreateMock).not.toHaveBeenCalled();
+  });
+
+  test('does not terminate reused sandboxes on close', async () => {
+    const existingSandbox = {
+      sandboxId: 'sbx_existing',
+      exec: sandboxExecMock,
+      open: sandboxOpenMock,
+      terminate: sandboxTerminateMock,
+      poll: sandboxPollMock,
+      tunnels: sandboxTunnelsMock,
+      snapshotFilesystem: sandboxSnapshotFilesystemMock,
+      snapshotDirectory: sandboxSnapshotDirectoryMock,
+      mountImage: sandboxMountImageMock,
+    };
+    sandboxesFromIdMock.mockResolvedValueOnce(existingSandbox);
+    const client = new ModalSandboxClient({
+      sandbox: ModalSandboxSelector.fromId('sbx_existing'),
+    });
+
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+    });
+    await session.close();
+
+    expect(sandboxesFromIdMock).toHaveBeenCalledWith('sbx_existing');
+    expect(sandboxesCreateMock).not.toHaveBeenCalled();
+    expect(sandboxTerminateMock).not.toHaveBeenCalled();
+  });
+
+  test('preserves reused sandbox ownership when resuming', async () => {
+    const existingSandbox = {
+      sandboxId: 'sbx_existing',
+      exec: sandboxExecMock,
+      open: sandboxOpenMock,
+      terminate: sandboxTerminateMock,
+      poll: sandboxPollMock,
+      tunnels: sandboxTunnelsMock,
+      snapshotFilesystem: sandboxSnapshotFilesystemMock,
+      snapshotDirectory: sandboxSnapshotDirectoryMock,
+      mountImage: sandboxMountImageMock,
+    };
+    sandboxesFromIdMock.mockResolvedValueOnce(existingSandbox);
+    const client = new ModalSandboxClient({
+      sandbox: ModalSandboxSelector.fromId('sbx_existing'),
+    });
+
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+    });
+    sandboxesFromIdMock.mockResolvedValueOnce(existingSandbox);
+    const resumed = await client.resume(
+      session.state as ModalSandboxSessionState,
+    );
+    await resumed.close();
+
+    expect(session.state.ownsSandbox).toBe(false);
+    expect(resumed.state.ownsSandbox).toBe(false);
+    expect(appsFromNameMock).not.toHaveBeenCalled();
+    expect(sandboxTerminateMock).not.toHaveBeenCalled();
+  });
+
+  test('does not terminate reused sandboxes when manifest setup fails', async () => {
+    const client = new ModalSandboxClient({
+      sandbox: ModalSandboxSelector.fromId('sbx_existing'),
+    });
+    sandboxOpenMock.mockRejectedValueOnce(new Error('write failed'));
+
+    await expect(
+      client.create(
+        new Manifest({
+          entries: {
+            'README.md': {
+              type: 'file',
+              content: '# Hello\n',
+            },
+          },
+        }),
+        {
+          appName: 'sandbox-tests',
+        },
+      ),
+    ).rejects.toThrow('write failed');
+
+    expect(sandboxesFromIdMock).toHaveBeenCalledWith('sbx_existing');
+    expect(sandboxesCreateMock).not.toHaveBeenCalled();
+    expect(sandboxTerminateMock).not.toHaveBeenCalled();
+  });
+
+  test('supports editor operations and live resume', async () => {
+    const client = new ModalSandboxClient();
+    const session = await client.create(
+      new Manifest({
+        remoteMountCommandAllowlist: ['cat'],
+      }),
+      {
+        appName: 'sandbox-tests',
+      },
+    );
+
+    const editor = session.createEditor?.();
+    if (!editor) {
+      throw new Error('Expected ModalSandboxSession.createEditor().');
+    }
+
+    await editor.createFile({
+      type: 'create_file',
+      path: 'notes.txt',
+      diff: '+hello\n',
+    });
+    await editor.updateFile({
+      type: 'update_file',
+      path: 'notes.txt',
+      diff: ' hello\n+world\n',
+    });
+    await session.materializeEntry?.({
+      path: '.agents/lazy/SKILL.md',
+      entry: {
+        type: 'file',
+        content: '# Lazy\n',
+      },
+    });
+
+    const resumed = await client.resume?.(
+      session.state as ModalSandboxSessionState,
+    );
+    await editor.deleteFile({
+      type: 'delete_file',
+      path: 'notes.txt',
+    });
+
+    expect(files.get('/workspace/notes.txt')).toBeUndefined();
+    expect(session.state.manifest.remoteMountCommandAllowlist).toEqual(['cat']);
+    expect(sandboxesFromIdMock).toHaveBeenCalledWith('sbx_test');
+    expect(resumed?.state.sandboxId).toBe('sbx_test');
+  });
+
+  test('wraps Modal resume SDK failures as provider errors', async () => {
+    const client = new ModalSandboxClient();
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+    });
+    sandboxesFromIdMock.mockRejectedValueOnce(new Error('resume failed'));
+
+    await expect(
+      client.resume(session.state as ModalSandboxSessionState),
+    ).rejects.toMatchObject({
+      details: {
+        provider: 'modal',
+        operation: 'resume sandbox',
+        sandboxId: 'sbx_test',
+        cause: 'resume failed',
+      },
+    });
+  });
+
+  test('accepts absolute workspace paths for filesystem helpers', async () => {
+    const client = new ModalSandboxClient();
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          'README.md': {
+            type: 'file',
+            content: '# Hello from Modal\n',
+          },
+        },
+      }),
+      {
+        appName: 'sandbox-tests',
+      },
+    );
+    const editor = session.createEditor?.();
+    if (!editor) {
+      throw new Error('Expected ModalSandboxSession.createEditor().');
+    }
+
+    await editor.updateFile({
+      type: 'update_file',
+      path: '/workspace/README.md',
+      diff: '@@\n-# Hello from Modal\n+# Updated from Modal\n',
+    });
+    const exists = await session.pathExists('/workspace/README.md');
+
+    expect(files.get('/workspace/README.md')).toEqual(
+      new TextEncoder().encode('# Updated from Modal\n'),
+    );
+    expect(exists).toBe(true);
+    await expect(
+      session.pathExists('/workspace/../tmp/README.md'),
+    ).rejects.toThrow(/escapes the workspace root/);
+  });
+
+  test('preserves configured credentials when resuming', async () => {
+    const client = new ModalSandboxClient({
+      appName: 'sandbox-tests',
+      tokenId: 'token-id',
+      tokenSecret: 'token-secret',
+    });
+    const session = await client.create(new Manifest());
+
+    await client.resume(session.state as ModalSandboxSessionState);
+
+    expect(modalClientParams.at(-1)).toMatchObject({
+      tokenId: 'token-id',
+      tokenSecret: 'token-secret',
+    });
+  });
+
+  test('defers cloud bucket mount secret resolution during plain resume', async () => {
+    const client = new ModalSandboxClient();
+    const state: ModalSandboxSessionState = {
+      sandboxId: 'sbx_test',
+      appName: 'sandbox-tests',
+      imageTag: 'debian:bookworm-slim',
+      manifest: new Manifest({
+        entries: {
+          data: {
+            type: 's3_mount',
+            bucket: 'logs',
+            mountStrategy: new ModalCloudBucketMountStrategy({
+              secretName: 'modal-bucket-secret',
+            }),
+          },
+        },
+      }),
+      workspacePersistence: 'snapshot_filesystem',
+      environment: {},
+      useSleepCmd: true,
+    };
+
+    const session = await client.resume(state);
+
+    expect(sandboxesFromIdMock).toHaveBeenCalledWith('sbx_test');
+    expect(secretFromNameMock).not.toHaveBeenCalled();
+    expect(secretFromObjectMock).not.toHaveBeenCalled();
+
+    await session.hydrateWorkspace(
+      encodeNativeSnapshotRef({
+        provider: 'modal_snapshot_filesystem',
+        snapshotId: 'im_snapshot_fs',
+        workspacePersistence: 'snapshot_filesystem',
+      }),
+    );
+
+    expect(secretFromNameMock).toHaveBeenCalledWith('modal-bucket-secret', {});
+    expect(sandboxesCreateMock).toHaveBeenCalledWith(
+      { appId: 'ap_test' },
+      { imageId: 'im_snapshot_fs' },
+      expect.objectContaining({
+        cloudBucketMounts: {
+          '/workspace/data': expect.objectContaining({
+            bucketName: 'logs',
+            params: expect.objectContaining({
+              secret: { secretId: 'secret-from-name' },
+            }),
+          }),
+        },
+      }),
+    );
+  });
+
+  test('preserves client env while manifest values take precedence', async () => {
+    const client = new ModalSandboxClient({
+      env: {
+        CLIENT_ONLY: 'override',
+        TOKEN: 'client',
+      },
+    });
+    const session = await client.create(
+      new Manifest({
+        environment: {
+          MANIFEST_FLAG: 'enabled',
+          TOKEN: 'manifest',
+        },
+      }),
+      {
+        appName: 'sandbox-tests',
+      },
+    );
+    expect(sandboxesCreateMock).toHaveBeenCalledWith(
+      { appId: 'ap_test' },
+      { imageId: 'im_test_cmd', command: ['sleep', 'infinity'] },
+      expect.objectContaining({
+        env: {
+          CLIENT_ONLY: 'override',
+          MANIFEST_FLAG: 'enabled',
+          TOKEN: 'manifest',
+        },
+      }),
+    );
+
+    await session.applyManifest(
+      new Manifest({
+        environment: {
+          MANIFEST_FLAG: 'updated',
+          EXTRA_FLAG: 'present',
+          TOKEN: 'manifest-updated',
+        },
+      }),
+    );
+    await session.execCommand({ cmd: 'ls' });
+
+    expect(session.state.environment).toEqual({
+      CLIENT_ONLY: 'override',
+      MANIFEST_FLAG: 'updated',
+      EXTRA_FLAG: 'present',
+      TOKEN: 'manifest-updated',
+    });
+    expect(sandboxExecMock).toHaveBeenLastCalledWith(
+      expect.any(Array),
+      expect.objectContaining({
+        env: {
+          CLIENT_ONLY: 'override',
+          MANIFEST_FLAG: 'updated',
+          EXTRA_FLAG: 'present',
+          TOKEN: 'manifest-updated',
+        },
+      }),
+    );
+  });
+
+  test('rejects live Modal cloud bucket mount updates', async () => {
+    const client = new ModalSandboxClient({
+      workspacePersistence: 'snapshot_filesystem',
+    });
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+    });
+    sandboxesCreateMock.mockClear();
+    secretFromNameMock.mockClear();
+
+    await expect(
+      session.applyManifest(
+        new Manifest({
+          entries: {
+            data: {
+              type: 's3_mount',
+              bucket: 'updated-logs',
+              mountPath: 'data',
+              mountStrategy: new ModalCloudBucketMountStrategy({
+                secretName: 'modal-bucket-secret',
+              }),
+            },
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      details: {
+        provider: 'modal',
+        feature: 'manifest.mounts',
+        mountPaths: ['/workspace/data'],
+      },
+    });
+
+    expect(secretFromNameMock).not.toHaveBeenCalled();
+    expect(sandboxesCreateMock).not.toHaveBeenCalled();
+  });
+
+  test('rejects live Modal updates that replace existing cloud bucket mounts', async () => {
+    const client = new ModalSandboxClient();
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          data: {
+            type: 's3_mount',
+            bucket: 'logs',
+            mountStrategy: new ModalCloudBucketMountStrategy({
+              secretName: 'modal-bucket-secret',
+            }),
+          },
+        },
+      }),
+      {
+        appName: 'sandbox-tests',
+      },
+    );
+    sandboxExecMock.mockClear();
+    sandboxOpenMock.mockClear();
+
+    await expect(
+      session.applyManifest(
+        new Manifest({
+          entries: {
+            data: {
+              type: 'file',
+              content: 'replacement',
+            },
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      details: {
+        provider: 'modal',
+        feature: 'manifest.mounts',
+        mountPaths: ['/workspace/data'],
+      },
+    });
+
+    await expect(
+      session.materializeEntry!({
+        path: 'data/notes.txt',
+        entry: {
+          type: 'file',
+          content: 'notes',
+        },
+      }),
+    ).rejects.toMatchObject({
+      details: {
+        provider: 'modal',
+        feature: 'manifest.mounts',
+        mountPaths: ['/workspace/data'],
+      },
+    });
+
+    expect(sandboxExecMock).not.toHaveBeenCalled();
+    expect(sandboxOpenMock).not.toHaveBeenCalled();
+    expect(session.state.manifest.mountTargets()).toHaveLength(1);
+  });
+
+  test('persists and hydrates snapshot_filesystem references', async () => {
+    const client = new ModalSandboxClient();
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+      workspacePersistence: 'snapshot_filesystem',
+      snapshotFilesystemTimeoutMs: 12_345,
+      snapshotFilesystemRestoreTimeoutMs: 23_456,
+      idleTimeoutMs: 60_000,
+      exposedPorts: [3000],
+    } satisfies ModalSandboxClientOptions);
+
+    const snapshotBytes = await session.persistWorkspace();
+    const ref = decodeNativeSnapshotRef(snapshotBytes);
+
+    expect(sandboxSnapshotFilesystemMock).toHaveBeenCalledWith(12_345);
+    expect(ref).toEqual({
+      provider: 'modal_snapshot_filesystem',
+      snapshotId: 'im_snapshot_fs',
+      workspacePersistence: 'snapshot_filesystem',
+    });
+
+    sandboxesCreateMock.mockClear();
+    await session.hydrateWorkspace(snapshotBytes);
+
+    expect(imagesFromIdMock).toHaveBeenCalledWith('im_snapshot_fs');
+    expect(sandboxesCreateMock).toHaveBeenCalledWith(
+      { appId: 'ap_test' },
+      { imageId: 'im_snapshot_fs' },
+      expect.objectContaining({
+        workdir: '/workspace',
+        env: {},
+        idleTimeoutMs: 60_000,
+        encryptedPorts: [3000],
+      }),
+    );
+    expect(sandboxTerminateMock).toHaveBeenCalledOnce();
+    expect(session.state.snapshotFilesystemRestoreTimeoutMs).toBe(23_456);
+    expect(session.state.idleTimeoutMs).toBe(60_000);
+  });
+
+  test('falls back to tar persistence when the workspace root is ephemeral', async () => {
+    const archive = makeTarArchive([{ name: 'keep.txt', content: 'keep' }]);
+    sandboxExecMock.mockImplementation(
+      async (command: string[], _params?: Record<string, unknown>) => {
+        if (command[0] === '/bin/sh' && command[1] === '-lc') {
+          const resolvedPath = resolvedRemotePathFromValidationCommand(
+            command[2] ?? '',
+          );
+          if (resolvedPath) {
+            return {
+              stdin: { writeText: async () => {}, close: async () => {} },
+              stdout: textStream(`${resolvedPath}\n`),
+              stderr: textStream(''),
+              wait: async () => 0,
+            };
+          }
+          const archivePath = command[2]?.match(/-cf '([^']+)'/)?.[1];
+          if (archivePath) {
+            files.set(archivePath, archive);
+          }
+        }
+        return {
+          stdin: { writeText: async () => {}, close: async () => {} },
+          stdout: textStream(''),
+          stderr: textStream(''),
+          wait: async () => 0,
+        };
+      },
+    );
+    const client = new ModalSandboxClient();
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          '': {
+            type: 'dir',
+            ephemeral: true,
+          },
+        },
+      }),
+      {
+        appName: 'sandbox-tests',
+        workspacePersistence: 'snapshot_filesystem',
+      } satisfies ModalSandboxClientOptions,
+    );
+
+    const snapshotBytes = await session.persistWorkspace();
+
+    expect(sandboxSnapshotFilesystemMock).not.toHaveBeenCalled();
+    expect(decodeNativeSnapshotRef(snapshotBytes)).toBeUndefined();
+    expect(snapshotBytes).toEqual(archive);
+  });
+
+  test('clears cached exposed ports after snapshot filesystem restore', async () => {
+    const client = new ModalSandboxClient();
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+      workspacePersistence: 'snapshot_filesystem',
+      exposedPorts: [3000],
+    } satisfies ModalSandboxClientOptions);
+    const originalEndpoint = await session.resolveExposedPort(3000);
+    const snapshotBytes = await session.persistWorkspace();
+    const replacementTunnelsMock = vi.fn().mockResolvedValue({
+      3000: {
+        host: '3000-restored-modal.example.test',
+        port: 443,
+      },
+    });
+    const replacementSandbox = {
+      sandboxId: 'sbx_restored',
+      exec: sandboxExecMock,
+      open: sandboxOpenMock,
+      terminate: vi.fn().mockResolvedValue(undefined),
+      poll: sandboxPollMock,
+      tunnels: replacementTunnelsMock,
+      snapshotFilesystem: sandboxSnapshotFilesystemMock,
+      snapshotDirectory: sandboxSnapshotDirectoryMock,
+      mountImage: sandboxMountImageMock,
+    };
+    sandboxesCreateMock.mockResolvedValueOnce(replacementSandbox);
+
+    await session.hydrateWorkspace(snapshotBytes);
+    const restoredEndpoint = await session.resolveExposedPort(3000);
+
+    expect(originalEndpoint.host).toBe('3000-modal.example.test');
+    expect(restoredEndpoint).toMatchObject({
+      host: '3000-restored-modal.example.test',
+      port: 443,
+      tls: true,
+    });
+    expect(sandboxTunnelsMock).toHaveBeenCalledOnce();
+    expect(replacementTunnelsMock).toHaveBeenCalledWith(10_000);
+    expect(session.state.exposedPorts?.['3000']).toBe(restoredEndpoint);
+  });
+
+  test('keeps caller-owned sandboxes alive when restoring snapshot filesystems', async () => {
+    const previousTerminateMock = vi.fn().mockResolvedValue(undefined);
+    const previousSandbox = {
+      sandboxId: 'sbx_existing',
+      exec: sandboxExecMock,
+      open: sandboxOpenMock,
+      terminate: previousTerminateMock,
+      poll: sandboxPollMock,
+      tunnels: sandboxTunnelsMock,
+      snapshotFilesystem: sandboxSnapshotFilesystemMock,
+      snapshotDirectory: sandboxSnapshotDirectoryMock,
+      mountImage: sandboxMountImageMock,
+    };
+    const replacementTerminateMock = vi.fn().mockResolvedValue(undefined);
+    const replacementSandbox = {
+      ...previousSandbox,
+      sandboxId: 'sbx_restored',
+      terminate: replacementTerminateMock,
+    };
+    sandboxesFromIdMock.mockResolvedValueOnce(previousSandbox);
+    sandboxesCreateMock.mockResolvedValueOnce(replacementSandbox);
+    const client = new ModalSandboxClient({
+      sandbox: ModalSandboxSelector.fromId('sbx_existing'),
+    });
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+      workspacePersistence: 'snapshot_filesystem',
+    } satisfies ModalSandboxClientOptions);
+
+    await session.hydrateWorkspace(
+      encodeNativeSnapshotRef({
+        provider: 'modal_snapshot_filesystem',
+        snapshotId: 'im_snapshot_fs',
+        workspacePersistence: 'snapshot_filesystem',
+      }),
+    );
+    await session.close();
+
+    expect(previousTerminateMock).not.toHaveBeenCalled();
+    expect(session.state).toMatchObject({
+      sandboxId: 'sbx_restored',
+      ownsSandbox: true,
+    });
+    expect(replacementTerminateMock).toHaveBeenCalledOnce();
+  });
+
+  test('drops caller-owned active processes when restoring snapshot filesystems', async () => {
+    const closeStdinMock = vi.fn().mockResolvedValue(undefined);
+    const cancelStdoutMock = vi.fn();
+    const cancelStderrMock = vi.fn();
+    sandboxExecMock.mockResolvedValueOnce({
+      stdin: {
+        writeText: async (_text: string) => {},
+        close: closeStdinMock,
+      },
+      stdout: new ReadableStream<string>({
+        cancel: cancelStdoutMock,
+      }),
+      stderr: new ReadableStream<string>({
+        cancel: cancelStderrMock,
+      }),
+      wait: async () => await new Promise<number>(() => {}),
+    });
+    const previousTerminateMock = vi.fn().mockResolvedValue(undefined);
+    const previousSandbox = {
+      sandboxId: 'sbx_existing',
+      exec: sandboxExecMock,
+      open: sandboxOpenMock,
+      terminate: previousTerminateMock,
+      poll: sandboxPollMock,
+      tunnels: sandboxTunnelsMock,
+      snapshotFilesystem: sandboxSnapshotFilesystemMock,
+      snapshotDirectory: sandboxSnapshotDirectoryMock,
+      mountImage: sandboxMountImageMock,
+    };
+    const replacementTerminateMock = vi.fn().mockResolvedValue(undefined);
+    const replacementSandbox = {
+      ...previousSandbox,
+      sandboxId: 'sbx_restored',
+      terminate: replacementTerminateMock,
+    };
+    sandboxesFromIdMock.mockResolvedValueOnce(previousSandbox);
+    sandboxesCreateMock.mockResolvedValueOnce(replacementSandbox);
+    const client = new ModalSandboxClient({
+      sandbox: ModalSandboxSelector.fromId('sbx_existing'),
+    });
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+      workspacePersistence: 'snapshot_filesystem',
+    } satisfies ModalSandboxClientOptions);
+    const started = await session.execCommand({
+      cmd: 'long-running',
+      yieldTimeMs: 0,
+    });
+    const sessionId = Number(
+      started.match(/Process running with session ID (\d+)/)?.[1],
+    );
+    const activeProcesses = (
+      session as unknown as {
+        activeProcesses: Map<number, unknown>;
+      }
+    ).activeProcesses;
+
+    expect(activeProcesses.has(sessionId)).toBe(true);
+
+    await session.hydrateWorkspace(
+      encodeNativeSnapshotRef({
+        provider: 'modal_snapshot_filesystem',
+        snapshotId: 'im_snapshot_fs',
+        workspacePersistence: 'snapshot_filesystem',
+      }),
+    );
+
+    expect(previousTerminateMock).not.toHaveBeenCalled();
+    expect(closeStdinMock).toHaveBeenCalledOnce();
+    expect(cancelStdoutMock).toHaveBeenCalledOnce();
+    expect(cancelStderrMock).toHaveBeenCalledOnce();
+    expect(activeProcesses.size).toBe(0);
+
+    await session.close();
+    expect(replacementTerminateMock).toHaveBeenCalledOnce();
+  });
+
+  test('stops active output pumps when closing external sandboxes', async () => {
+    const closeStdinMock = vi.fn().mockResolvedValue(undefined);
+    const cancelStdoutMock = vi.fn();
+    const cancelStderrMock = vi.fn();
+    sandboxExecMock.mockResolvedValueOnce({
+      stdin: {
+        writeText: async (_text: string) => {},
+        close: closeStdinMock,
+      },
+      stdout: new ReadableStream<string>({
+        cancel: cancelStdoutMock,
+      }),
+      stderr: new ReadableStream<string>({
+        cancel: cancelStderrMock,
+      }),
+      wait: async () => await new Promise<number>(() => {}),
+    });
+    const terminateMock = vi.fn().mockResolvedValue(undefined);
+    sandboxesFromIdMock.mockResolvedValueOnce({
+      sandboxId: 'sbx_existing',
+      exec: sandboxExecMock,
+      open: sandboxOpenMock,
+      terminate: terminateMock,
+      poll: sandboxPollMock,
+      tunnels: sandboxTunnelsMock,
+      snapshotFilesystem: sandboxSnapshotFilesystemMock,
+      snapshotDirectory: sandboxSnapshotDirectoryMock,
+      mountImage: sandboxMountImageMock,
+    });
+    const client = new ModalSandboxClient({
+      sandbox: ModalSandboxSelector.fromId('sbx_existing'),
+    });
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+    });
+
+    await session.execCommand({
+      cmd: 'long-running',
+      yieldTimeMs: 0,
+    });
+    await session.close();
+
+    expect(closeStdinMock).toHaveBeenCalledOnce();
+    expect(cancelStdoutMock).toHaveBeenCalledOnce();
+    expect(cancelStderrMock).toHaveBeenCalledOnce();
+    expect(terminateMock).not.toHaveBeenCalled();
+  });
+
+  test('wraps snapshot_filesystem capture failures as provider errors', async () => {
+    const client = new ModalSandboxClient();
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+      workspacePersistence: 'snapshot_filesystem',
+    } satisfies ModalSandboxClientOptions);
+    sandboxSnapshotFilesystemMock.mockRejectedValueOnce(
+      new Error('capture failed'),
+    );
+
+    await expect(session.persistWorkspace()).rejects.toMatchObject({
+      details: {
+        provider: 'modal',
+        operation: 'capture snapshot_filesystem',
+        sandboxId: 'sbx_test',
+        cause: 'capture failed',
+      },
+    });
+  });
+
+  test('terminates replacement sandboxes that resolve after restore timeouts', async () => {
+    const client = new ModalSandboxClient();
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+      workspacePersistence: 'snapshot_filesystem',
+      snapshotFilesystemRestoreTimeoutMs: 1,
+    } satisfies ModalSandboxClientOptions);
+    const snapshotBytes = await session.persistWorkspace();
+    const lateTerminateMock = vi.fn().mockResolvedValue(undefined);
+    const lateSandbox = {
+      sandboxId: 'sbx_late_restore',
+      exec: sandboxExecMock,
+      open: sandboxOpenMock,
+      terminate: lateTerminateMock,
+      poll: sandboxPollMock,
+      tunnels: sandboxTunnelsMock,
+      snapshotFilesystem: sandboxSnapshotFilesystemMock,
+      snapshotDirectory: sandboxSnapshotDirectoryMock,
+      mountImage: sandboxMountImageMock,
+    };
+    const pendingRestore = deferred<typeof lateSandbox>();
+    sandboxesCreateMock.mockReturnValueOnce(pendingRestore.promise);
+
+    await expect(session.hydrateWorkspace(snapshotBytes)).rejects.toThrow(
+      'Modal snapshot_filesystem restore timed out.',
+    );
+
+    pendingRestore.resolve(lateSandbox);
+    await vi.waitFor(() => {
+      expect(lateTerminateMock).toHaveBeenCalledOnce();
+    });
+    expect(session.state.sandboxId).toBe('sbx_test');
+    expect(sandboxTerminateMock).not.toHaveBeenCalled();
+  });
+
+  test('applies snapshot_filesystem restore timeout to image lookup', async () => {
+    const client = new ModalSandboxClient();
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+      workspacePersistence: 'snapshot_filesystem',
+      snapshotFilesystemRestoreTimeoutMs: 1,
+    } satisfies ModalSandboxClientOptions);
+    const snapshotBytes = await session.persistWorkspace();
+    const pendingImage = deferred<unknown>();
+    sandboxesCreateMock.mockClear();
+    imagesFromIdMock.mockReturnValueOnce(pendingImage.promise);
+
+    await expect(session.hydrateWorkspace(snapshotBytes)).rejects.toThrow(
+      'Modal snapshot_filesystem restore timed out.',
+    );
+
+    expect(sandboxesCreateMock).not.toHaveBeenCalled();
+  });
+
+  test('surfaces snapshot_filesystem restore failures when previous sandbox termination fails', async () => {
+    const previousTerminateMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('previous terminate failed'))
+      .mockResolvedValue(undefined);
+    const replacementTerminateMock = vi.fn().mockResolvedValue(undefined);
+    const previousSandbox = {
+      sandboxId: 'sbx_previous',
+      exec: sandboxExecMock,
+      open: sandboxOpenMock,
+      terminate: previousTerminateMock,
+      poll: sandboxPollMock,
+      tunnels: sandboxTunnelsMock,
+      snapshotFilesystem: sandboxSnapshotFilesystemMock,
+      snapshotDirectory: sandboxSnapshotDirectoryMock,
+      mountImage: sandboxMountImageMock,
+    };
+    const replacementSandbox = {
+      ...previousSandbox,
+      sandboxId: 'sbx_replacement',
+      terminate: replacementTerminateMock,
+    };
+    sandboxesCreateMock
+      .mockResolvedValueOnce(previousSandbox)
+      .mockResolvedValueOnce(replacementSandbox);
+
+    const client = new ModalSandboxClient();
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+      workspacePersistence: 'snapshot_filesystem',
+    } satisfies ModalSandboxClientOptions);
+
+    const snapshotBytes = await session.persistWorkspace();
+    let restoreError: unknown;
+    try {
+      await session.hydrateWorkspace(snapshotBytes);
+    } catch (error) {
+      restoreError = error;
+    }
+
+    expect(restoreError).toBeInstanceOf(SandboxProviderError);
+    expect(restoreError).toMatchObject({
+      code: 'provider_error',
+      details: {
+        provider: 'modal',
+        sandboxId: 'sbx_previous',
+        replacementSandboxId: 'sbx_replacement',
+        cause: 'previous terminate failed',
+      },
+    });
+    expect(session.state.sandboxId).toBe('sbx_previous');
+    expect(previousTerminateMock).toHaveBeenCalledOnce();
+    expect(replacementTerminateMock).toHaveBeenCalledOnce();
+
+    await session.close();
+    expect(previousTerminateMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('persists and hydrates snapshot_directory references', async () => {
+    const client = new ModalSandboxClient();
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+      workspacePersistence: 'snapshot_directory',
+    } satisfies ModalSandboxClientOptions);
+
+    const snapshotBytes = await session.persistWorkspace();
+    const ref = decodeNativeSnapshotRef(snapshotBytes);
+
+    expect(sandboxSnapshotDirectoryMock).toHaveBeenCalledWith('/workspace');
+    expect(ref).toEqual({
+      provider: 'modal_snapshot_directory',
+      snapshotId: 'im_snapshot_dir',
+      workspacePersistence: 'snapshot_directory',
+    });
+
+    await session.hydrateWorkspace(snapshotBytes);
+
+    expect(imagesFromIdMock).toHaveBeenCalledWith('im_snapshot_dir');
+    expect(sandboxMountImageMock).toHaveBeenCalledWith('/workspace', {
+      imageId: 'im_snapshot_dir',
+    });
+  });
+
+  test('deletes snapshot_directory images that resolve after persistence timeouts', async () => {
+    const pendingSnapshot = deferred<{ objectId: string }>();
+    sandboxSnapshotDirectoryMock.mockReturnValueOnce(pendingSnapshot.promise);
+    const client = new ModalSandboxClient();
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+      workspacePersistence: 'snapshot_directory',
+      snapshotFilesystemTimeoutMs: 1,
+    } satisfies ModalSandboxClientOptions);
+
+    await expect(session.persistWorkspace()).rejects.toThrow(
+      'Modal snapshot_directory persistence timed out.',
+    );
+
+    pendingSnapshot.resolve({ objectId: 'im_late_snapshot_dir' });
+    await vi.waitFor(() => {
+      expect(imagesDeleteMock).toHaveBeenCalledWith('im_late_snapshot_dir');
+    });
+  });
+
+  test('terminates sandboxes when snapshot_directory restores resolve after timeout', async () => {
+    const client = new ModalSandboxClient();
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+      workspacePersistence: 'snapshot_directory',
+      snapshotFilesystemRestoreTimeoutMs: 1,
+    } satisfies ModalSandboxClientOptions);
+    const snapshotBytes = encodeNativeSnapshotRef({
+      provider: 'modal_snapshot_directory',
+      snapshotId: 'im_snapshot_dir',
+      workspacePersistence: 'snapshot_directory',
+    });
+    const pendingMount = deferred<void>();
+    sandboxMountImageMock.mockReturnValueOnce(pendingMount.promise);
+
+    await expect(session.hydrateWorkspace(snapshotBytes)).rejects.toThrow(
+      'Modal snapshot_directory restore timed out.',
+    );
+
+    pendingMount.resolve();
+    await vi.waitFor(() => {
+      expect(sandboxTerminateMock).toHaveBeenCalledOnce();
+    });
+  });
+
+  test('applies snapshot_directory restore timeout to image lookup', async () => {
+    const client = new ModalSandboxClient();
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+      workspacePersistence: 'snapshot_directory',
+      snapshotFilesystemRestoreTimeoutMs: 1,
+    } satisfies ModalSandboxClientOptions);
+    const snapshotBytes = encodeNativeSnapshotRef({
+      provider: 'modal_snapshot_directory',
+      snapshotId: 'im_snapshot_dir',
+      workspacePersistence: 'snapshot_directory',
+    });
+    const pendingImage = deferred<unknown>();
+    imagesFromIdMock.mockReturnValueOnce(pendingImage.promise);
+
+    await expect(session.hydrateWorkspace(snapshotBytes)).rejects.toThrow(
+      'Modal snapshot_directory restore timed out.',
+    );
+
+    expect(sandboxMountImageMock).not.toHaveBeenCalled();
+  });
+
+  test('does not terminate reused sandboxes when snapshot_directory restores resolve after timeout', async () => {
+    const previousTerminateMock = vi.fn().mockResolvedValue(undefined);
+    const previousSandbox = {
+      sandboxId: 'sbx_existing',
+      exec: sandboxExecMock,
+      open: sandboxOpenMock,
+      terminate: previousTerminateMock,
+      poll: sandboxPollMock,
+      tunnels: sandboxTunnelsMock,
+      snapshotFilesystem: sandboxSnapshotFilesystemMock,
+      snapshotDirectory: sandboxSnapshotDirectoryMock,
+      mountImage: sandboxMountImageMock,
+    };
+    sandboxesFromIdMock.mockResolvedValueOnce(previousSandbox);
+    const client = new ModalSandboxClient({
+      sandbox: ModalSandboxSelector.fromId('sbx_existing'),
+    });
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+      workspacePersistence: 'snapshot_directory',
+      snapshotFilesystemRestoreTimeoutMs: 1,
+    } satisfies ModalSandboxClientOptions);
+    const snapshotBytes = encodeNativeSnapshotRef({
+      provider: 'modal_snapshot_directory',
+      snapshotId: 'im_snapshot_dir',
+      workspacePersistence: 'snapshot_directory',
+    });
+    const pendingMount = deferred<void>();
+    sandboxMountImageMock.mockReturnValueOnce(pendingMount.promise);
+
+    await expect(session.hydrateWorkspace(snapshotBytes)).rejects.toThrow(
+      'Modal snapshot_directory restore timed out.',
+    );
+
+    pendingMount.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(previousTerminateMock).not.toHaveBeenCalled();
+  });
+
+  test('wraps snapshot_directory restore failures as provider errors', async () => {
+    const client = new ModalSandboxClient();
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+      workspacePersistence: 'snapshot_directory',
+    } satisfies ModalSandboxClientOptions);
+    const snapshotBytes = await session.persistWorkspace();
+    sandboxMountImageMock.mockRejectedValueOnce(new Error('mount failed'));
+
+    await expect(session.hydrateWorkspace(snapshotBytes)).rejects.toMatchObject(
+      {
+        details: {
+          provider: 'modal',
+          operation: 'restore snapshot_directory',
+          sandboxId: 'sbx_test',
+          snapshotId: 'im_snapshot_dir',
+          cause: 'mount failed',
+        },
+      },
+    );
+  });
+
+  test('rejects invalid persistence modes clearly', async () => {
+    const client = new ModalSandboxClient();
+
+    await expect(
+      client.create(new Manifest(), {
+        appName: 'sandbox-tests',
+        workspacePersistence: 'native',
+      } as unknown as ModalSandboxClientOptions),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+  });
+
+  test('wraps Modal sandbox create SDK failures as provider errors', async () => {
+    const client = new ModalSandboxClient();
+    sandboxesCreateMock.mockRejectedValueOnce(new Error('modal unavailable'));
+
+    await expect(
+      client.create(new Manifest(), {
+        appName: 'sandbox-tests',
+      }),
+    ).rejects.toBeInstanceOf(SandboxProviderError);
+  });
+
+  test('terminates sandboxes that resolve after create timeouts', async () => {
+    const lateTerminateMock = vi.fn().mockResolvedValue(undefined);
+    const lateSandbox = {
+      sandboxId: 'sbx_late',
+      exec: sandboxExecMock,
+      open: sandboxOpenMock,
+      terminate: lateTerminateMock,
+      poll: sandboxPollMock,
+      tunnels: sandboxTunnelsMock,
+      snapshotFilesystem: sandboxSnapshotFilesystemMock,
+      snapshotDirectory: sandboxSnapshotDirectoryMock,
+      mountImage: sandboxMountImageMock,
+    };
+    const pendingCreate = deferred<typeof lateSandbox>();
+    sandboxesCreateMock.mockReturnValueOnce(pendingCreate.promise);
+
+    const client = new ModalSandboxClient();
+    await expect(
+      client.create(new Manifest(), {
+        appName: 'sandbox-tests',
+        sandboxCreateTimeoutS: 0.001,
+      }),
+    ).rejects.toThrow('Modal sandbox creation timed out.');
+
+    pendingCreate.resolve(lateSandbox);
+    await vi.waitFor(() => {
+      expect(lateTerminateMock).toHaveBeenCalledOnce();
+    });
+  });
+
+  test('resolves configured exposed ports through Modal tunnels', async () => {
+    const client = new ModalSandboxClient();
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+      exposedPorts: [3000],
+    } satisfies ModalSandboxClientOptions);
+
+    const endpoint = await session.resolveExposedPort(3000);
+    const cachedEndpoint = await session.resolveExposedPort(3000);
+
+    expect(sandboxesCreateMock).toHaveBeenCalledWith(
+      { appId: 'ap_test' },
+      { imageId: 'im_test_cmd', command: ['sleep', 'infinity'] },
+      expect.objectContaining({
+        encryptedPorts: [3000],
+      }),
+    );
+    expect(sandboxTunnelsMock).toHaveBeenCalledWith(10_000);
+    expect(sandboxTunnelsMock).toHaveBeenCalledOnce();
+    expect(endpoint).toMatchObject({
+      host: '3000-modal.example.test',
+      port: 443,
+      tls: true,
+    });
+    expect(cachedEndpoint).toBe(endpoint);
+    expect(session.state.exposedPorts?.['3000']).toBe(endpoint);
+  });
+
+  test('terminates active commands before waiting during close', async () => {
+    let releaseWait!: () => void;
+    sandboxExecMock.mockResolvedValueOnce({
+      stdin: {
+        writeText: async (_text: string) => {},
+        close: async () => {},
+      },
+      stdout: textStream(''),
+      stderr: textStream(''),
+      wait: async () =>
+        await new Promise<number>((resolve) => {
+          releaseWait = () => resolve(137);
+        }),
+    });
+    sandboxTerminateMock.mockImplementation(async () => {
+      releaseWait();
+    });
+
+    const client = new ModalSandboxClient();
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+    });
+    const started = await session.execCommand({
+      cmd: 'sleep 3600',
+      yieldTimeMs: 0,
+    });
+
+    await expect(session.close()).resolves.toBeUndefined();
+
+    expect(started).toContain('Process running with session ID');
+    expect(sandboxTerminateMock).toHaveBeenCalledOnce();
+  });
+
+  test('detaches from active commands without waiting for reused sandboxes', async () => {
+    const stdinCloseMock = vi.fn(async () => {});
+    sandboxExecMock.mockResolvedValueOnce({
+      stdin: {
+        writeText: async (_text: string) => {},
+        close: stdinCloseMock,
+      },
+      stdout: textStream(''),
+      stderr: textStream(''),
+      wait: async () => await new Promise<number>(() => {}),
+    });
+
+    const client = new ModalSandboxClient({
+      sandbox: ModalSandboxSelector.fromId('sbx_existing'),
+    });
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+    });
+    const started = await session.execCommand({
+      cmd: 'sleep 3600',
+      yieldTimeMs: 0,
+    });
+
+    const closeResult = await Promise.race([
+      session.close().then(() => 'closed'),
+      new Promise<string>((resolve) => {
+        setTimeout(() => resolve('timeout'), 50);
+      }),
+    ]);
+
+    expect(started).toContain('Process running with session ID');
+    expect(closeResult).toBe('closed');
+    expect(stdinCloseMock).toHaveBeenCalledOnce();
+    expect(sandboxTerminateMock).not.toHaveBeenCalled();
+  });
+
+  test('does not terminate twice when shutdown and delete both close', async () => {
+    sandboxTerminateMock
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('second terminate'));
+    const client = new ModalSandboxClient();
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+    });
+
+    await expect(session.shutdown()).resolves.toBeUndefined();
+    await expect(session.delete()).resolves.toBeUndefined();
+
+    expect(sandboxTerminateMock).toHaveBeenCalledOnce();
+  });
+
+  test('returns only unread output from active process polls', async () => {
+    let stdoutController!: ReadableStreamDefaultController<string>;
+    let resolveWait!: (code: number) => void;
+    sandboxExecMock.mockResolvedValueOnce({
+      stdin: {
+        writeText: async (text: string) => {
+          stdoutController.enqueue(`input:${text}`);
+        },
+        close: async () => {},
+      },
+      stdout: new ReadableStream<string>({
+        start(controller) {
+          stdoutController = controller;
+          controller.enqueue('ready\n');
+        },
+      }),
+      stderr: textStream(''),
+      wait: async () =>
+        await new Promise<number>((resolve) => {
+          resolveWait = resolve;
+        }),
+    });
+
+    const client = new ModalSandboxClient();
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+    });
+    const started = await session.execCommand({
+      cmd: 'long-running',
+      yieldTimeMs: 50,
+    });
+    const sessionId = Number(
+      started.match(/Process running with session ID (\d+)/)?.[1],
+    );
+    const firstPoll = await session.writeStdin({
+      sessionId,
+      yieldTimeMs: 0,
+    });
+    const secondPoll = await session.writeStdin({
+      sessionId,
+      chars: 'hello\n',
+      yieldTimeMs: 50,
+    });
+
+    stdoutController.close();
+    resolveWait(0);
+    await session.writeStdin({
+      sessionId,
+      yieldTimeMs: 50,
+    });
+
+    expect(started).toContain('ready');
+    expect(firstPoll).not.toContain('ready');
+    expect(secondPoll).toContain('input:hello');
+    expect(secondPoll).not.toContain('ready');
+  });
+
+  test('prunes completed active processes when clients stop polling', async () => {
+    let stdoutController!: ReadableStreamDefaultController<string>;
+    let resolveWait!: (code: number) => void;
+    sandboxExecMock.mockResolvedValueOnce({
+      stdin: {
+        writeText: async (_text: string) => {},
+        close: async () => {},
+      },
+      stdout: new ReadableStream<string>({
+        start(controller) {
+          stdoutController = controller;
+        },
+      }),
+      stderr: textStream(''),
+      wait: async () =>
+        await new Promise<number>((resolve) => {
+          resolveWait = resolve;
+        }),
+    });
+
+    const client = new ModalSandboxClient();
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+    });
+    const started = await session.execCommand({
+      cmd: 'long-running',
+      yieldTimeMs: 0,
+    });
+    const sessionId = Number(
+      started.match(/Process running with session ID (\d+)/)?.[1],
+    );
+    const activeProcesses = (
+      session as unknown as {
+        activeProcesses: Map<number, unknown>;
+      }
+    ).activeProcesses;
+
+    expect(activeProcesses.has(sessionId)).toBe(true);
+
+    vi.useFakeTimers();
+    try {
+      stdoutController.close();
+      resolveWait(0);
+      await vi.runAllTimersAsync();
+
+      expect(activeProcesses.has(sessionId)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('bounds unread active process output', async () => {
+    let stdoutController!: ReadableStreamDefaultController<string>;
+    let resolveWait!: (code: number) => void;
+    sandboxExecMock.mockResolvedValueOnce({
+      stdin: {
+        writeText: async (_text: string) => {},
+        close: async () => {},
+      },
+      stdout: new ReadableStream<string>({
+        start(controller) {
+          stdoutController = controller;
+          controller.enqueue('a'.repeat(1024 * 1024 + 10));
+        },
+      }),
+      stderr: textStream(''),
+      wait: async () =>
+        await new Promise<number>((resolve) => {
+          resolveWait = resolve;
+        }),
+    });
+
+    const client = new ModalSandboxClient();
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+    });
+    const started = await session.execCommand({
+      cmd: 'noisy',
+      yieldTimeMs: 50,
+      maxOutputTokens: 20,
+    });
+    const sessionId = Number(
+      started.match(/Process running with session ID (\d+)/)?.[1],
+    );
+
+    stdoutController.close();
+    resolveWait(0);
+    await session.writeStdin({
+      sessionId,
+      yieldTimeMs: 50,
+    });
+
+    expect(started).toContain('characters truncated from process output');
+    expect(started).toContain('Process running with session ID');
+    expect(started.length).toBeLessThan(5_000);
+  });
+});

--- a/packages/agents-extensions/test/sandbox/modal.test.ts
+++ b/packages/agents-extensions/test/sandbox/modal.test.ts
@@ -242,7 +242,7 @@ describe('ModalSandboxClient', () => {
 
     sandboxExecMock.mockImplementation(
       async (command: string[], _params?: Record<string, unknown>) => {
-        if (command[0] === '/bin/sh' && command[1] === '-lc') {
+        if (command[0] === '/bin/sh') {
           const resolvedPath = resolvedRemotePathFromValidationCommand(
             command[2] ?? '',
           );
@@ -259,11 +259,7 @@ describe('ModalSandboxClient', () => {
           }
         }
 
-        if (
-          command[0] === '/bin/sh' &&
-          command[1] === '-lc' &&
-          command[2] === 'ls'
-        ) {
+        if (command[0] === '/bin/sh' && command[2] === 'ls') {
           return {
             stdin: {
               writeText: async (_text: string) => {},
@@ -393,6 +389,32 @@ describe('ModalSandboxClient', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  test('wraps rejected process waits as provider errors', async () => {
+    sandboxExecMock.mockResolvedValueOnce({
+      stdin: {
+        writeText: async (_text: string) => {},
+        close: async () => {},
+      },
+      stdout: textStream('partial stdout\n'),
+      stderr: textStream('partial stderr\n'),
+      wait: async () => {
+        throw new Error('wait failed');
+      },
+    });
+    const client = new ModalSandboxClient();
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+    } satisfies ModalSandboxClientOptions);
+
+    await expect(session.execCommand({ cmd: 'false' })).rejects.toMatchObject({
+      details: {
+        provider: 'modal',
+        operation: 'wait process',
+        cause: 'wait failed',
+      },
+    });
   });
 
   test('allows disabling the Modal sleep command image override', async () => {
@@ -1191,7 +1213,7 @@ describe('ModalSandboxClient', () => {
     const archive = makeTarArchive([{ name: 'keep.txt', content: 'keep' }]);
     sandboxExecMock.mockImplementation(
       async (command: string[], _params?: Record<string, unknown>) => {
-        if (command[0] === '/bin/sh' && command[1] === '-lc') {
+        if (command[0] === '/bin/sh') {
           const resolvedPath = resolvedRemotePathFromValidationCommand(
             command[2] ?? '',
           );
@@ -1676,7 +1698,7 @@ describe('ModalSandboxClient', () => {
     expect(sandboxMountImageMock).not.toHaveBeenCalled();
   });
 
-  test('does not terminate reused sandboxes when snapshot_directory restores resolve after timeout', async () => {
+  test('waits for reused sandbox snapshot_directory mounts instead of timing out late mutations', async () => {
     const previousTerminateMock = vi.fn().mockResolvedValue(undefined);
     const previousSandbox = {
       sandboxId: 'sbx_existing',
@@ -1706,12 +1728,17 @@ describe('ModalSandboxClient', () => {
     const pendingMount = deferred<void>();
     sandboxMountImageMock.mockReturnValueOnce(pendingMount.promise);
 
-    await expect(session.hydrateWorkspace(snapshotBytes)).rejects.toThrow(
-      'Modal snapshot_directory restore timed out.',
-    );
+    let restoreCompleted = false;
+    const restorePromise = session.hydrateWorkspace(snapshotBytes).then(() => {
+      restoreCompleted = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
 
+    expect(restoreCompleted).toBe(false);
+    expect(sandboxMountImageMock).toHaveBeenCalledOnce();
     pendingMount.resolve();
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await restorePromise;
+
     expect(previousTerminateMock).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
This pull request adds a sandbox provider as part of agents-extensions package: https://developers.openai.com/api/docs/guides/agents/sandboxes

How to run:
```zsh
git clone https://github.com/openai/openai-agents-js
cd openai-agents-js/
git checkout feat/sandbox-agents-modal
pnpm i
pnpm build
pnpm -F sandbox start:modal
```