### PR TITLE
feat(sandbox): add E2B provider

### DIFF
--- a/.changeset/sandbox-agents-e2b.md
+++ b/.changeset/sandbox-agents-e2b.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': minor
+---
+
+feat: add E2B sandbox provider

--- a/examples/sandbox/extensions/e2b-runner.ts
+++ b/examples/sandbox/extensions/e2b-runner.ts
@@ -1,0 +1,117 @@
+import { Runner } from '@openai/agents';
+import {
+  E2BSandboxClient,
+  type E2BSandboxType,
+} from '@openai/agents-extensions/sandbox/e2b';
+import { Manifest, SandboxAgent, shell } from '@openai/agents/sandbox';
+import { finished } from 'node:stream/promises';
+import {
+  DEFAULT_MODEL,
+  getStringArg,
+  hasFlag,
+  getOptionalNumberArg,
+  getOptionalStringArg,
+  requireEnv,
+  requireOpenAIKey,
+  runExampleMain,
+} from '../support';
+
+const DEFAULT_QUESTION =
+  'Summarize this cloud sandbox workspace in 2 sentences.';
+
+function parseSandboxType(
+  value: string | undefined,
+): E2BSandboxType | undefined {
+  if (!value) {
+    return undefined;
+  }
+  if (value === 'e2b' || value === 'e2b_code_interpreter') {
+    return value;
+  }
+  throw new Error(
+    `--sandbox-type must be "e2b" or "e2b_code_interpreter", received ${value}.`,
+  );
+}
+
+function buildManifest(): Manifest {
+  return new Manifest({
+    entries: {
+      'README.md': {
+        type: 'file',
+        content: `# Renewal Notes
+
+This workspace contains a tiny account review packet for manual sandbox testing.
+`,
+      },
+      'customer.md': {
+        type: 'file',
+        content: `# Customer
+
+- Name: Northwind Health.
+- Renewal date: 2026-04-15.
+- Risk: unresolved SSO setup.
+`,
+      },
+      'next_steps.md': {
+        type: 'file',
+        content: `# Next steps
+
+1. Finish the SSO fix.
+2. Confirm legal language before procurement review.
+`,
+      },
+    },
+  });
+}
+
+async function main() {
+  requireOpenAIKey();
+  requireEnv('E2B_API_KEY');
+
+  const model = getStringArg('--model', DEFAULT_MODEL);
+  const question = getStringArg('--question', DEFAULT_QUESTION);
+  const sandboxType = parseSandboxType(getOptionalStringArg('--sandbox-type'));
+  const template = getOptionalStringArg('--template');
+  const timeout = getOptionalNumberArg('--timeout');
+  const pauseOnExit = hasFlag('--pause-on-exit');
+  if (hasFlag('--workspace-persistence')) {
+    throw new Error(
+      'E2B sandbox examples do not support --workspace-persistence yet.',
+    );
+  }
+  const stream = hasFlag('--stream');
+  const client = new E2BSandboxClient({
+    sandboxType,
+    template,
+    timeout,
+    pauseOnExit,
+  });
+  const agent = new SandboxAgent({
+    name: 'E2B Sandbox Assistant',
+    model,
+    instructions:
+      'Answer questions about the sandbox workspace. Inspect the files before answering, keep the response concise, and cite the file names you inspected.',
+    defaultManifest: buildManifest(),
+    capabilities: [shell()],
+  });
+  const runner = new Runner({
+    workflowName: 'E2B sandbox example',
+    sandbox: { client },
+  });
+
+  if (!stream) {
+    const result = await runner.run(agent, question);
+    console.log(result.finalOutput);
+    return;
+  }
+
+  const result = await runner.run(agent, question, { stream: true });
+  process.stdout.write('assistant> ');
+  const textStream = result.toTextStream({ compatibleWithNodeStreams: true });
+  textStream.pipe(process.stdout);
+  await finished(textStream);
+  await result.completed;
+  process.stdout.write('\n');
+}
+
+await runExampleMain(main);

--- a/packages/agents-extensions/src/sandbox/e2b/index.ts
+++ b/packages/agents-extensions/src/sandbox/e2b/index.ts
@@ -1,0 +1,2 @@
+export * from './sandbox';
+export * from './mounts';

--- a/packages/agents-extensions/src/sandbox/e2b/mounts.ts
+++ b/packages/agents-extensions/src/sandbox/e2b/mounts.ts
@@ -1,0 +1,24 @@
+import type {
+  Entry,
+  RcloneMountPattern,
+  TypedMount,
+} from '@openai/agents-core/sandbox';
+import { isRcloneCloudBucketMountEntry } from '../shared/inContainerMounts';
+
+export type E2BCloudBucketMountStrategyOptions = {
+  pattern?: RcloneMountPattern;
+};
+
+export class E2BCloudBucketMountStrategy {
+  readonly [key: string]: unknown;
+  readonly type = 'e2b_cloud_bucket';
+  readonly pattern: RcloneMountPattern;
+
+  constructor(options: E2BCloudBucketMountStrategyOptions = {}) {
+    this.pattern = options.pattern ?? { type: 'rclone', mode: 'fuse' };
+  }
+}
+
+export function isE2BCloudBucketMountEntry(entry: Entry): entry is TypedMount {
+  return isRcloneCloudBucketMountEntry(entry, 'e2b_cloud_bucket');
+}

--- a/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
@@ -581,6 +581,7 @@ export class E2BSandboxSession extends RemoteSandboxSessionBase<E2BSandboxSessio
   ): boolean {
     return (
       options?.reason === 'cleanup' &&
+      options.preserveOwnedSessions === true &&
       this.state.pauseOnExit &&
       canPauseE2BSandbox(this.sandbox)
     );
@@ -590,7 +591,10 @@ export class E2BSandboxSession extends RemoteSandboxSessionBase<E2BSandboxSessio
     operation: 'close' | 'cleanup',
   ): Promise<boolean> {
     try {
-      await this.sandbox.pause!();
+      const paused = await this.sandbox.pause!();
+      if (!paused) {
+        throw new Error('E2B sandbox pause returned false.');
+      }
       return true;
     } catch (pauseError) {
       try {

--- a/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
@@ -180,7 +180,7 @@ export interface E2BSandboxSessionState extends SandboxSessionState {
   commandTimeoutMs?: number;
   requestTimeoutMs?: number;
   connectionTimeoutMs?: number;
-  onTimeout: E2BTimeoutAction;
+  onTimeout?: E2BTimeoutAction;
   timeoutAction?: E2BTimeoutAction;
   autoResume?: boolean;
   metadata?: Record<string, string>;
@@ -891,7 +891,7 @@ export class E2BSandboxClient implements SandboxClient<
             connectionTimeoutMs: resolvedOptions.connectionTimeoutMs,
             onTimeout: resolveE2BOnTimeout(resolvedOptions),
             timeoutAction: resolvedOptions.timeoutAction,
-            autoResume: resolveE2BAutoResume(resolvedOptions),
+            autoResume: resolvedOptions.autoResume,
             metadata: resolvedOptions.metadata,
             secure: resolvedOptions.secure,
             allowInternetAccess: resolvedOptions.allowInternetAccess,
@@ -945,14 +945,14 @@ export class E2BSandboxClient implements SandboxClient<
       commandTimeoutMs: readOptionalNumber(state, 'commandTimeoutMs'),
       requestTimeoutMs: readOptionalNumber(state, 'requestTimeoutMs'),
       connectionTimeoutMs: readOptionalNumber(state, 'connectionTimeoutMs'),
-      onTimeout: readE2BTimeoutAction(
+      onTimeout: readOptionalE2BTimeoutAction(
         readOptionalString(state, 'onTimeout') ??
           readOptionalString(state, 'timeoutAction'),
       ),
       timeoutAction: readOptionalE2BTimeoutAction(
         readOptionalString(state, 'timeoutAction'),
       ),
-      autoResume: readOptionalBoolean(state, 'autoResume') ?? true,
+      autoResume: readOptionalBoolean(state, 'autoResume'),
       metadata: readOptionalStringRecord(state.metadata),
       secure: readOptionalBoolean(state, 'secure'),
       allowInternetAccess: readOptionalBoolean(state, 'allowInternetAccess'),
@@ -1004,19 +1004,10 @@ function validateOptions(options: E2BSandboxClientOptions): void {
 
 function resolveE2BOnTimeout(
   options: Pick<E2BSandboxClientOptions, 'onTimeout' | 'timeoutAction'>,
-): E2BTimeoutAction {
-  return readE2BTimeoutAction(options.onTimeout ?? options.timeoutAction);
-}
-
-function resolveE2BAutoResume(
-  options: Pick<E2BSandboxClientOptions, 'autoResume'>,
-): boolean {
-  return options.autoResume ?? true;
-}
-
-function readE2BTimeoutAction(value: unknown): E2BTimeoutAction {
-  const action = readOptionalE2BTimeoutAction(value);
-  return action ?? 'pause';
+): E2BTimeoutAction | undefined {
+  return readOptionalE2BTimeoutAction(
+    options.onTimeout ?? options.timeoutAction,
+  );
 }
 
 function readOptionalE2BTimeoutAction(
@@ -1085,6 +1076,9 @@ function e2bReconnectOptions(
   state: E2BSandboxSessionState,
 ): Record<string, unknown> | undefined {
   const options: Record<string, unknown> = {};
+  if (state.timeout !== undefined) {
+    options.timeoutMs = Math.max(1, Math.trunc(state.timeout * 1000));
+  }
   if (state.requestTimeoutMs !== undefined) {
     options.requestTimeoutMs = state.requestTimeoutMs;
   }
@@ -1153,12 +1147,16 @@ async function createSandboxInstance(
     createOptions.timeoutMs = Math.max(1, Math.trunc(options.timeout * 1000));
   }
   const onTimeout = resolveE2BOnTimeout(options);
-  createOptions.lifecycle = {
-    onTimeout,
-    ...(onTimeout === 'pause'
-      ? { autoResume: resolveE2BAutoResume(options) }
-      : {}),
-  };
+  const lifecycle: Record<string, unknown> = {};
+  if (onTimeout !== undefined) {
+    lifecycle.onTimeout = onTimeout;
+  }
+  if (options.autoResume !== undefined && onTimeout === 'pause') {
+    lifecycle.autoResume = options.autoResume;
+  }
+  if (Object.keys(lifecycle).length > 0) {
+    createOptions.lifecycle = lifecycle;
+  }
   for (const key of [
     'commandTimeoutMs',
     'requestTimeoutMs',

--- a/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
@@ -529,9 +529,8 @@ export class E2BSandboxSession extends RemoteSandboxSessionBase<E2BSandboxSessio
       async () => {
         await this.ptyProcesses.terminateAll();
         if (this.state.pauseOnExit && canPauseE2BSandbox(this.sandbox)) {
-          if (await this.pauseOrKillAfterPauseFailure('close')) {
-            return;
-          }
+          await this.pauseOrKillAfterPauseFailure('close');
+          return;
         }
         await this.unmountActiveMounts();
         await this.sandbox.kill();
@@ -566,9 +565,8 @@ export class E2BSandboxSession extends RemoteSandboxSessionBase<E2BSandboxSessio
       async () => {
         await this.ptyProcesses.terminateAll();
         if (this.shouldPauseOnCleanup(options)) {
-          if (await this.pauseOrKillAfterPauseFailure('cleanup')) {
-            return;
-          }
+          await this.pauseOrKillAfterPauseFailure('cleanup');
+          return;
         }
         await this.unmountActiveMounts();
         await this.sandbox.kill();
@@ -591,10 +589,7 @@ export class E2BSandboxSession extends RemoteSandboxSessionBase<E2BSandboxSessio
     operation: 'close' | 'cleanup',
   ): Promise<boolean> {
     try {
-      const paused = await this.sandbox.pause!();
-      if (!paused) {
-        throw new Error('E2B sandbox pause returned false.');
-      }
+      await this.sandbox.pause!();
       return true;
     } catch (pauseError) {
       try {
@@ -618,7 +613,9 @@ export class E2BSandboxSession extends RemoteSandboxSessionBase<E2BSandboxSessio
           },
         );
       }
-      return true;
+      this.state.pauseOnExit = false;
+      this.state.pauseOnExitSupported = false;
+      return false;
     }
   }
 

--- a/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
@@ -1,0 +1,1271 @@
+import { UserError } from '@openai/agents-core';
+import {
+  Manifest,
+  SandboxProviderError,
+  SandboxUnsupportedFeatureError,
+  type SandboxClient,
+  type SandboxClientCreateArgs,
+  type SandboxClientOptions,
+  type ExposedPortEndpoint,
+  type ExecCommandArgs,
+  type Mount,
+  type SandboxSessionLifecycleOptions,
+  type SandboxSessionState,
+  type TypedMount,
+  type WriteStdinArgs,
+  type WorkspaceArchiveData,
+  normalizeSandboxClientCreateArgs,
+} from '@openai/agents-core/sandbox';
+import {
+  appendPtyOutput,
+  assertCoreConcurrencyLimitsUnsupported,
+  assertCoreSnapshotUnsupported,
+  assertResumeRecreateAllowed,
+  assertTarWorkspacePersistence,
+  createPtyProcessEntry,
+  deserializeRemoteSandboxSessionStateValues,
+  formatPtyExecUpdate,
+  assertSandboxManifestMetadataSupported,
+  SANDBOX_MANIFEST_METADATA_SUPPORT,
+  closeRemoteSessionOnManifestError,
+  decodeNativeSnapshotRef,
+  encodeNativeSnapshotRef,
+  materializeEnvironment,
+  parseExposedPortEndpoint,
+  shellQuote,
+  shellCommandForPty,
+  serializeRemoteSandboxSessionState,
+  watchPtyProcess,
+  isRecord,
+  readOptionalBoolean,
+  readOptionalNumber,
+  readOptionalNumberArray,
+  readOptionalRecord,
+  readOptionalString,
+  readOptionalStringRecord,
+  readString,
+  withProviderError,
+  withSandboxSpan,
+  writePtyStdin,
+  PtyProcessRegistry,
+  RemoteSandboxSessionBase,
+  type RemoteSandboxCommandOptions,
+  type RemoteSandboxCommandResult,
+} from '../shared';
+import {
+  mountRcloneCloudBucket,
+  rclonePatternFromMountStrategy,
+  unmountRcloneMount,
+  type RemoteMountCommand,
+} from '../shared/inContainerMounts';
+import { isE2BCloudBucketMountEntry } from './mounts';
+
+type E2BSandboxClass = {
+  create(
+    templateOrOpts?: string | Record<string, unknown>,
+    opts?: Record<string, unknown>,
+  ): Promise<E2BSandboxInstance>;
+  connect?(
+    sandboxId: string,
+    opts?: Record<string, unknown>,
+  ): Promise<E2BSandboxInstance>;
+  resume?(
+    sandboxId: string,
+    opts?: Record<string, unknown>,
+  ): Promise<E2BSandboxInstance>;
+};
+
+type E2BSandboxInstance = {
+  sandboxId: string;
+  files: E2BFilesystemApi;
+  commands: E2BCommandsApi;
+  pty?: E2BPtyApi;
+  getHost?(port: number): string | Promise<string>;
+  createSnapshot?(): Promise<{ snapshotId?: string }>;
+  kill(): Promise<void>;
+  pause?(): Promise<boolean>;
+};
+
+type E2BFilesystemApi = {
+  write(
+    path: string | { path: string; data: string | Uint8Array }[],
+    data?: string | Uint8Array,
+  ): Promise<unknown>;
+  read?(
+    path: string,
+    opts?: { format?: 'text' | 'bytes' },
+  ): Promise<string | Uint8Array>;
+  remove?(path: string): Promise<unknown>;
+  makeDir?(path: string): Promise<unknown>;
+};
+
+type E2BCommandResult = {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number | null;
+  error?: string;
+};
+
+type E2BCommandHandle = E2BCommandResult & {
+  pid: number;
+  wait?(): Promise<E2BCommandResult>;
+  kill?(): Promise<boolean>;
+  disconnect?(): Promise<void>;
+};
+
+type E2BCommandsApi = {
+  run(
+    command: string,
+    opts?: {
+      background?: boolean;
+      cwd?: string;
+      envs?: Record<string, string>;
+      user?: string;
+      timeoutMs?: number;
+      onStdout?: (data: string) => void | Promise<void>;
+      onStderr?: (data: string) => void | Promise<void>;
+      stdin?: boolean;
+    },
+  ): Promise<E2BCommandResult | E2BCommandHandle>;
+};
+type E2BCommandRunOptions = Parameters<E2BCommandsApi['run']>[1];
+
+type E2BPtyApi = {
+  create(opts: {
+    cols?: number;
+    rows?: number;
+    size?: { cols: number; rows: number };
+    cwd?: string;
+    envs?: Record<string, string>;
+    timeoutMs?: number;
+    onData?: (data: Uint8Array) => void | Promise<void>;
+  }): Promise<E2BCommandHandle>;
+  sendInput?(
+    pid: number,
+    data: Uint8Array,
+    opts?: Record<string, unknown>,
+  ): Promise<void>;
+  kill?(pid: number, opts?: Record<string, unknown>): Promise<boolean>;
+};
+
+export type E2BSandboxType = 'e2b' | 'e2b_code_interpreter';
+export type E2BWorkspacePersistence = true | 'tar' | 'snapshot';
+export type E2BTimeoutAction = 'pause' | 'kill';
+
+export interface E2BSandboxClientOptions extends SandboxClientOptions {
+  sandboxType?: E2BSandboxType;
+  template?: string;
+  timeout?: number;
+  commandTimeoutMs?: number;
+  requestTimeoutMs?: number;
+  connectionTimeoutMs?: number;
+  onTimeout?: E2BTimeoutAction;
+  timeoutAction?: E2BTimeoutAction;
+  autoResume?: boolean;
+  metadata?: Record<string, string>;
+  secure?: boolean;
+  allowInternetAccess?: boolean;
+  exposedPorts?: number[];
+  workspacePersistence?: E2BWorkspacePersistence;
+  mcp?: Record<string, unknown>;
+  pauseOnExit?: boolean;
+  env?: Record<string, string>;
+}
+
+export interface E2BSandboxSessionState extends SandboxSessionState {
+  sandboxId: string;
+  template?: string;
+  sandboxType: E2BSandboxType;
+  timeout?: number;
+  commandTimeoutMs?: number;
+  requestTimeoutMs?: number;
+  connectionTimeoutMs?: number;
+  onTimeout: E2BTimeoutAction;
+  timeoutAction?: E2BTimeoutAction;
+  autoResume?: boolean;
+  metadata?: Record<string, string>;
+  secure?: boolean;
+  allowInternetAccess?: boolean;
+  configuredExposedPorts?: number[];
+  workspacePersistence?: E2BWorkspacePersistence;
+  mcp?: Record<string, unknown>;
+  pauseOnExit: boolean;
+  pauseOnExitSupported?: boolean;
+  environment: Record<string, string>;
+}
+
+export class E2BSandboxSession extends RemoteSandboxSessionBase<E2BSandboxSessionState> {
+  private sandbox: E2BSandboxInstance;
+  private readonly ptyProcesses = new PtyProcessRegistry();
+  private readonly activeMountPaths = new Set<string>();
+
+  constructor(args: {
+    state: E2BSandboxSessionState;
+    sandbox: E2BSandboxInstance;
+  }) {
+    super({
+      state: args.state,
+      options: {
+        providerName: 'E2BSandboxClient',
+        providerId: 'e2b',
+      },
+    });
+    this.sandbox = args.sandbox;
+    this.state.pauseOnExitSupported = canPauseE2BSandbox(args.sandbox);
+  }
+
+  override supportsPty(): boolean {
+    return typeof this.sandbox.pty?.create === 'function';
+  }
+
+  async writeStdin(args: WriteStdinArgs): Promise<string> {
+    return await writePtyStdin({
+      providerName: 'E2BSandboxClient',
+      registry: this.ptyProcesses,
+      sessionId: args.sessionId,
+      chars: args.chars,
+      yieldTimeMs: args.yieldTimeMs,
+      maxOutputTokens: args.maxOutputTokens,
+    });
+  }
+
+  protected override async execPtyCommand(
+    args: ExecCommandArgs,
+  ): Promise<string> {
+    if (args.runAs) {
+      throw new SandboxUnsupportedFeatureError(
+        'E2BSandboxClient tty=true does not support runAs because the E2B SDK PTY API does not expose a user option.',
+        {
+          provider: 'e2b',
+          feature: 'tty.runAs',
+        },
+      );
+    }
+
+    const pty = this.sandbox.pty;
+    if (!pty?.create) {
+      throw new SandboxUnsupportedFeatureError(
+        'E2BSandboxClient tty=true requires E2B SDK PTY support.',
+        {
+          provider: 'e2b',
+          feature: 'tty',
+        },
+      );
+    }
+
+    const start = Date.now();
+    const command = shellCommandForPty(args);
+    const entry = createPtyProcessEntry({ tty: true });
+    const timeoutMs =
+      typeof this.state.commandTimeoutMs === 'number'
+        ? this.state.commandTimeoutMs
+        : typeof this.state.timeout === 'number'
+          ? Math.max(1, Math.trunc(this.state.timeout * 1000))
+          : undefined;
+    const handle = await pty.create({
+      cols: 80,
+      rows: 24,
+      size: { cols: 80, rows: 24 },
+      cwd: this.resolveWorkdir(args.workdir),
+      envs: this.state.environment,
+      timeoutMs,
+      onData: (data) => appendPtyOutput(entry, data),
+    });
+    entry.terminate = async () => {
+      if (handle.kill) {
+        await handle.kill();
+      } else if (pty.kill) {
+        await pty.kill(handle.pid, {
+          requestTimeoutMs: this.state.requestTimeoutMs,
+        });
+      }
+    };
+    if (!pty.sendInput) {
+      await entry.terminate().catch(() => {});
+      throw new SandboxUnsupportedFeatureError(
+        'E2BSandboxClient tty=true requires E2B SDK PTY stdin support.',
+        {
+          provider: 'e2b',
+          feature: 'tty.stdin',
+        },
+      );
+    }
+    entry.sendInput = async (chars) => {
+      await pty.sendInput!(handle.pid, new TextEncoder().encode(chars), {
+        requestTimeoutMs: this.state.requestTimeoutMs,
+      });
+    };
+    watchPtyProcess(
+      entry,
+      async () => (handle.wait ? await handle.wait() : undefined),
+      (result, error) =>
+        exitCodeFromE2BResult(result) ??
+        exitCodeFromE2BResult(error) ??
+        exitCodeFromE2BResult(handle),
+    );
+    try {
+      await entry.sendInput(`${command}\n`);
+    } catch (error) {
+      await entry.terminate().catch(() => {});
+      throw error;
+    }
+
+    const { sessionId, pruned } = this.ptyProcesses.register(entry);
+    if (pruned) {
+      await pruned.terminate?.().catch(() => {});
+    }
+
+    return await formatPtyExecUpdate({
+      registry: this.ptyProcesses,
+      sessionId,
+      entry,
+      startTime: start,
+      yieldTimeMs: args.yieldTimeMs,
+      maxOutputTokens: args.maxOutputTokens,
+    });
+  }
+
+  protected override exposedPortSource(): string {
+    return 'host';
+  }
+
+  protected override async resolveRemoteExposedPort(
+    requestedPort: number,
+  ): Promise<ExposedPortEndpoint> {
+    if (!this.sandbox.getHost) {
+      throw new SandboxProviderError(
+        'E2BSandboxClient exposed port resolution requires an E2B SDK getHost(port) API.',
+        {
+          provider: 'e2b',
+          port: requestedPort,
+        },
+      );
+    }
+
+    let host: unknown;
+    try {
+      host = await this.sandbox.getHost(requestedPort);
+    } catch (error) {
+      throw new SandboxProviderError(
+        `E2BSandboxClient failed to resolve exposed port ${requestedPort}.`,
+        {
+          provider: 'e2b',
+          port: requestedPort,
+          cause: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+
+    if (typeof host !== 'string') {
+      throw new SandboxProviderError(
+        'E2BSandboxClient exposed port resolution returned a non-string host.',
+        {
+          provider: 'e2b',
+          port: requestedPort,
+        },
+      );
+    }
+
+    return parseExposedPortEndpoint(host, {
+      providerName: 'E2BSandboxClient',
+      source: 'host',
+    });
+  }
+
+  async prepareWorkspaceRoot(): Promise<void> {
+    const root = this.state.manifest.root;
+    await this.ensureDirectory(root);
+    const result = await this.sandbox.commands.run(
+      `mkdir -p -- ${shellQuote(root)}`,
+      {
+        cwd: '/',
+        envs: this.state.environment,
+      },
+    );
+    if ((result.exitCode ?? 1) !== 0) {
+      throw new SandboxProviderError(
+        'E2BSandboxClient failed to prepare the workspace root.',
+        {
+          provider: 'e2b',
+          operation: 'prepare workspace root',
+          sandboxId: this.state.sandboxId,
+          root,
+          stderr: result.stderr ?? '',
+          stdout: result.stdout ?? '',
+        },
+      );
+    }
+  }
+
+  async persistWorkspace(): Promise<Uint8Array> {
+    if (this.state.workspacePersistence === 'snapshot') {
+      const archive = await this.persistWorkspaceViaNativeSnapshot();
+      if (archive) {
+        return archive;
+      }
+    } else {
+      assertTarWorkspacePersistence(
+        'E2BSandboxClient',
+        this.state.workspacePersistence,
+      );
+    }
+
+    return await this.persistWorkspaceTar();
+  }
+
+  async hydrateWorkspace(data: WorkspaceArchiveData): Promise<void> {
+    const snapshotRef = decodeNativeSnapshotRef(data);
+    if (snapshotRef?.provider === 'e2b') {
+      await this.replaceSandboxFromSnapshot(snapshotRef.snapshotId);
+      return;
+    }
+
+    if (this.state.workspacePersistence !== 'snapshot') {
+      assertTarWorkspacePersistence(
+        'E2BSandboxClient',
+        this.state.workspacePersistence,
+      );
+    }
+    await this.hydrateWorkspaceTar(data);
+  }
+
+  private async persistWorkspaceViaNativeSnapshot(): Promise<
+    Uint8Array | undefined
+  > {
+    if (this.nativeSnapshotRequiresTarFallback()) {
+      return undefined;
+    }
+    if (!this.sandbox.createSnapshot) {
+      return undefined;
+    }
+
+    let snapshot: { snapshotId?: string };
+    try {
+      snapshot = await this.sandbox.createSnapshot();
+    } catch (error) {
+      throw new SandboxProviderError(
+        'E2BSandboxClient failed to create a native workspace snapshot.',
+        {
+          provider: 'e2b',
+          sandboxId: this.state.sandboxId,
+          cause: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+
+    if (!snapshot.snapshotId) {
+      throw new SandboxProviderError(
+        'E2BSandboxClient native snapshot persistence did not return a snapshot id.',
+        {
+          provider: 'e2b',
+          sandboxId: this.state.sandboxId,
+        },
+      );
+    }
+
+    return encodeNativeSnapshotRef({
+      provider: 'e2b',
+      snapshotId: snapshot.snapshotId,
+    });
+  }
+
+  private nativeSnapshotRequiresTarFallback(): boolean {
+    return this.state.manifest.ephemeralPersistencePaths().size > 0;
+  }
+
+  private async replaceSandboxFromSnapshot(snapshotId: string): Promise<void> {
+    const Sandbox = await loadE2BSandboxClass(this.state.sandboxType);
+    const previousSandbox = this.sandbox;
+    let sandbox: E2BSandboxInstance;
+    try {
+      sandbox = await createSandboxInstance(
+        Sandbox,
+        {
+          ...stateToCreateOptions(this.state),
+          template: snapshotId,
+        },
+        this.state.environment,
+      );
+    } catch (error) {
+      throw new SandboxProviderError(
+        'E2BSandboxClient failed to restore a native workspace snapshot.',
+        {
+          provider: 'e2b',
+          snapshotId,
+          cause: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+
+    try {
+      await previousSandbox.kill();
+    } catch (error) {
+      await sandbox.kill().catch(() => {});
+      throw new SandboxProviderError(
+        'E2BSandboxClient failed to terminate the previous sandbox while restoring a native workspace snapshot.',
+        {
+          provider: 'e2b',
+          operation: 'restore snapshot',
+          sandboxId: previousSandbox.sandboxId,
+          replacementSandboxId: sandbox.sandboxId,
+          snapshotId,
+          cause: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+
+    this.sandbox = sandbox;
+    this.state.sandboxId = sandbox.sandboxId;
+    delete this.state.exposedPorts;
+  }
+
+  async close(): Promise<void> {
+    await withSandboxSpan(
+      'sandbox.stop',
+      {
+        backend_id: 'e2b',
+        sandbox_id: this.state.sandboxId,
+      },
+      async () => {
+        await this.ptyProcesses.terminateAll();
+        if (this.state.pauseOnExit && canPauseE2BSandbox(this.sandbox)) {
+          if (await this.pauseOrKillAfterPauseFailure('close')) {
+            return;
+          }
+        }
+        await this.unmountActiveMounts();
+        await this.sandbox.kill();
+      },
+    );
+  }
+
+  async shutdown(options?: SandboxSessionLifecycleOptions): Promise<void> {
+    await withSandboxSpan(
+      'sandbox.shutdown',
+      {
+        backend_id: 'e2b',
+        sandbox_id: this.state.sandboxId,
+      },
+      async () => {
+        await this.ptyProcesses.terminateAll();
+        if (this.shouldPauseOnCleanup(options)) {
+          return;
+        }
+        await this.unmountActiveMounts();
+      },
+    );
+  }
+
+  async delete(options?: SandboxSessionLifecycleOptions): Promise<void> {
+    await withSandboxSpan(
+      'sandbox.shutdown',
+      {
+        backend_id: 'e2b',
+        sandbox_id: this.state.sandboxId,
+      },
+      async () => {
+        await this.ptyProcesses.terminateAll();
+        if (this.shouldPauseOnCleanup(options)) {
+          if (await this.pauseOrKillAfterPauseFailure('cleanup')) {
+            return;
+          }
+        }
+        await this.unmountActiveMounts();
+        await this.sandbox.kill();
+      },
+    );
+  }
+
+  private shouldPauseOnCleanup(
+    options?: SandboxSessionLifecycleOptions,
+  ): boolean {
+    return (
+      options?.reason === 'cleanup' &&
+      this.state.pauseOnExit &&
+      canPauseE2BSandbox(this.sandbox)
+    );
+  }
+
+  private async pauseOrKillAfterPauseFailure(
+    operation: 'close' | 'cleanup',
+  ): Promise<boolean> {
+    try {
+      await this.sandbox.pause!();
+      return true;
+    } catch (pauseError) {
+      try {
+        await this.unmountActiveMounts();
+        await this.sandbox.kill();
+      } catch (killError) {
+        throw new SandboxProviderError(
+          'E2BSandboxClient failed to pause and then terminate the sandbox.',
+          {
+            provider: 'e2b',
+            operation,
+            sandboxId: this.state.sandboxId,
+            pauseCause:
+              pauseError instanceof Error
+                ? pauseError.message
+                : String(pauseError),
+            killCause:
+              killError instanceof Error
+                ? killError.message
+                : String(killError),
+          },
+        );
+      }
+      return true;
+    }
+  }
+
+  protected override assertExecRunAs(_runAs?: string): void {
+    void _runAs;
+  }
+
+  protected override assertFilesystemRunAs(_runAs?: string): void {
+    void _runAs;
+  }
+
+  protected override manifestMetadataSupport() {
+    return SANDBOX_MANIFEST_METADATA_SUPPORT;
+  }
+
+  protected override manifestMaterializationOptions() {
+    return {
+      materializeMount: this.materializeMountEntry.bind(this),
+    };
+  }
+
+  protected override async runRemoteCommand(
+    command: string,
+    options: RemoteSandboxCommandOptions,
+  ): Promise<RemoteSandboxCommandResult> {
+    const result = await this.runCommandForStatus(command, {
+      cwd: options.workdir,
+      envs: this.state.environment,
+      timeoutMs:
+        options.timeoutMs ??
+        (options.kind === 'exec' ? this.commandTimeoutMs() : undefined),
+      user: options.runAs,
+    });
+    return {
+      status: result.exitCode ?? 1,
+      stdout: result.stdout ?? '',
+      stderr: [result.stderr ?? '', result.error ?? '']
+        .filter((value) => value.trim().length > 0)
+        .join('\n'),
+    };
+  }
+
+  protected override async mkdirRemote(path: string): Promise<void> {
+    await this.ensureDirectory(path);
+  }
+
+  protected override async readRemoteText(path: string): Promise<string> {
+    if (this.sandbox.files.read) {
+      const result = await this.sandbox.files.read(path);
+      return typeof result === 'string'
+        ? result
+        : new TextDecoder().decode(result);
+    }
+
+    const result = await this.runRemoteCommand(`cat ${shellQuote(path)}`, {
+      kind: 'path',
+      workdir: this.state.manifest.root,
+    });
+    if (result.status !== 0) {
+      throw new UserError(`Sandbox path not found: ${path}`);
+    }
+    return result.stdout ?? '';
+  }
+
+  protected override async readRemoteFile(path: string): Promise<Uint8Array> {
+    if (this.sandbox.files.read) {
+      const result = await this.sandbox.files.read(path, { format: 'bytes' });
+      return typeof result === 'string'
+        ? new TextEncoder().encode(result)
+        : Uint8Array.from(result);
+    }
+
+    const encoded = await this.sandbox.commands.run(
+      `base64 ${shellQuote(path)}`,
+      {
+        cwd: this.state.manifest.root,
+        envs: this.state.environment,
+      },
+    );
+    if ((encoded.exitCode ?? 1) !== 0 || !encoded.stdout) {
+      throw new UserError(`Sandbox path not found: ${path}`);
+    }
+
+    return Uint8Array.from(
+      Buffer.from(encoded.stdout.replace(/\s+/g, ''), 'base64'),
+    );
+  }
+
+  protected override async writeRemoteFile(
+    path: string,
+    content: string | Uint8Array,
+  ): Promise<void> {
+    await this.sandbox.files.write(path, content);
+  }
+
+  protected override async deleteRemotePath(path: string): Promise<void> {
+    await this.removeSandboxPath(path);
+  }
+
+  private async ensureDirectory(path: string): Promise<void> {
+    if (this.sandbox.files.makeDir) {
+      await this.sandbox.files.makeDir(path);
+      return;
+    }
+    await this.sandbox.commands.run(`mkdir -p -- ${shellQuote(path)}`, {
+      cwd: '/',
+      envs: this.state.environment,
+    });
+  }
+
+  private async removeSandboxPath(path: string): Promise<void> {
+    if (this.sandbox.files.remove) {
+      await this.sandbox.files.remove(path);
+      return;
+    }
+    await this.sandbox.commands.run(`rm -f -- ${shellQuote(path)}`, {
+      cwd: this.state.manifest.root,
+      envs: this.state.environment,
+    });
+  }
+
+  private async materializeMountEntry(
+    absolutePath: string,
+    entry: Mount | TypedMount,
+  ): Promise<void> {
+    if (!isE2BCloudBucketMountEntry(entry)) {
+      throw new SandboxUnsupportedFeatureError(
+        'E2BSandboxClient only supports E2BCloudBucketMountStrategy mount entries.',
+        {
+          provider: 'e2b',
+          feature: 'entry.mountStrategy',
+          path: absolutePath,
+          mountType: entry.type,
+          strategyType: entry.mountStrategy?.type,
+        },
+      );
+    }
+    const mountPath = await this.resolveRemotePath(
+      entry.mountPath ?? absolutePath,
+      { forWrite: true },
+    );
+    await mountRcloneCloudBucket({
+      providerName: 'E2BSandboxClient',
+      providerId: 'e2b',
+      strategyType: 'e2b_cloud_bucket',
+      entry,
+      mountPath,
+      pattern: rclonePatternFromMountStrategy(entry.mountStrategy),
+      runCommand: this.mountCommandRunner(),
+      packageManagers: ['apt'],
+      installRcloneViaScript: true,
+    });
+    this.activeMountPaths.add(mountPath);
+  }
+
+  private async unmountActiveMounts(): Promise<void> {
+    for (const mountPath of [...this.activeMountPaths].reverse()) {
+      await unmountRcloneMount({
+        providerName: 'E2BSandboxClient',
+        providerId: 'e2b',
+        mountPath,
+        runCommand: this.mountCommandRunner(),
+      }).catch(() => {});
+      this.activeMountPaths.delete(mountPath);
+    }
+  }
+
+  private mountCommandRunner(): RemoteMountCommand {
+    return async (command, options = {}) => {
+      const result = await this.runCommandForStatus(command, {
+        cwd: this.state.manifest.root,
+        envs: this.state.environment,
+        timeoutMs: options.timeoutMs,
+        user: options.user,
+      });
+      return {
+        status: result.exitCode ?? 1,
+        stdout: result.stdout ?? '',
+        stderr: result.stderr ?? result.error ?? '',
+      };
+    };
+  }
+
+  private async runCommandForStatus(
+    command: string,
+    options?: E2BCommandRunOptions,
+  ): Promise<E2BCommandResult> {
+    try {
+      return await this.sandbox.commands.run(command, options);
+    } catch (error) {
+      const result = commandResultFromE2BError(error);
+      if (!result) {
+        throw error;
+      }
+      return result;
+    }
+  }
+
+  private commandTimeoutMs(): number | undefined {
+    return typeof this.state.commandTimeoutMs === 'number'
+      ? this.state.commandTimeoutMs
+      : typeof this.state.timeout === 'number'
+        ? Math.max(1, Math.trunc(this.state.timeout * 1000))
+        : undefined;
+  }
+}
+
+/**
+ * @see {@link https://e2b.dev/docs | E2B docs}.
+ * @see {@link https://e2b.dev/docs/sdk-reference/js-sdk/v2.8.0/sandbox | JavaScript SDK Sandbox reference}.
+ * @see {@link https://e2b.dev/docs/sdk-reference/code-interpreter-js-sdk/v2.3.2/sandbox | Code Interpreter JavaScript SDK Sandbox reference}.
+ */
+export class E2BSandboxClient implements SandboxClient<
+  E2BSandboxClientOptions,
+  E2BSandboxSessionState
+> {
+  readonly backendId = 'e2b';
+  private readonly options: E2BSandboxClientOptions;
+
+  constructor(options: E2BSandboxClientOptions = {}) {
+    this.options = options;
+  }
+
+  async create(
+    args?: SandboxClientCreateArgs<E2BSandboxClientOptions> | Manifest,
+    manifestOptions?: E2BSandboxClientOptions,
+  ): Promise<E2BSandboxSession> {
+    const createArgs = normalizeSandboxClientCreateArgs(args, manifestOptions);
+    assertCoreSnapshotUnsupported('E2BSandboxClient', createArgs.snapshot);
+    assertCoreConcurrencyLimitsUnsupported(
+      'E2BSandboxClient',
+      createArgs.concurrencyLimits,
+    );
+    const manifest = createArgs.manifest;
+    return await withSandboxSpan(
+      'sandbox.start',
+      {
+        backend_id: this.backendId,
+      },
+      async () => {
+        const resolvedOptions = {
+          ...this.options,
+          ...createArgs.options,
+        };
+        validateOptions(resolvedOptions);
+        assertSandboxManifestMetadataSupported(
+          'E2BSandboxClient',
+          manifest,
+          SANDBOX_MANIFEST_METADATA_SUPPORT,
+        );
+        const Sandbox = await loadE2BSandboxClass(
+          resolvedOptions.sandboxType ?? 'e2b',
+        );
+        const environment = await materializeEnvironment(
+          manifest,
+          resolvedOptions.env,
+        );
+        const sandbox = await createSandboxInstance(
+          Sandbox,
+          resolvedOptions,
+          environment,
+        );
+
+        const session = new E2BSandboxSession({
+          sandbox,
+          state: {
+            manifest,
+            sandboxId: sandbox.sandboxId,
+            template: resolvedOptions.template,
+            sandboxType: resolvedOptions.sandboxType ?? 'e2b',
+            timeout: resolvedOptions.timeout,
+            commandTimeoutMs: resolvedOptions.commandTimeoutMs,
+            requestTimeoutMs: resolvedOptions.requestTimeoutMs,
+            connectionTimeoutMs: resolvedOptions.connectionTimeoutMs,
+            onTimeout: resolveE2BOnTimeout(resolvedOptions),
+            timeoutAction: resolvedOptions.timeoutAction,
+            autoResume: resolveE2BAutoResume(resolvedOptions),
+            metadata: resolvedOptions.metadata,
+            secure: resolvedOptions.secure,
+            allowInternetAccess: resolvedOptions.allowInternetAccess,
+            configuredExposedPorts: resolvedOptions.exposedPorts,
+            workspacePersistence: resolvedOptions.workspacePersistence,
+            mcp: resolvedOptions.mcp,
+            pauseOnExit: resolvedOptions.pauseOnExit ?? false,
+            environment,
+          },
+        });
+
+        try {
+          await session.prepareWorkspaceRoot();
+          await session.applyManifest(manifest);
+        } catch (error) {
+          session.state.pauseOnExit = false;
+          await closeRemoteSessionOnManifestError('E2B', session, error);
+        }
+        return session;
+      },
+    );
+  }
+
+  async serializeSessionState(
+    state: E2BSandboxSessionState,
+  ): Promise<Record<string, unknown>> {
+    return serializeRemoteSandboxSessionState(state);
+  }
+
+  canPersistOwnedSessionState(state: E2BSandboxSessionState): boolean {
+    return state.pauseOnExit && state.pauseOnExitSupported === true;
+  }
+
+  async deserializeSessionState(
+    state: Record<string, unknown>,
+  ): Promise<E2BSandboxSessionState> {
+    const baseState = deserializeRemoteSandboxSessionStateValues(
+      state,
+      this.options.env,
+    );
+    return {
+      ...state,
+      ...baseState,
+      sandboxId: readString(state, 'sandboxId'),
+      template: readOptionalString(state, 'template'),
+      sandboxType:
+        state.sandboxType === 'e2b_code_interpreter'
+          ? 'e2b_code_interpreter'
+          : 'e2b',
+      timeout: readOptionalNumber(state, 'timeout'),
+      commandTimeoutMs: readOptionalNumber(state, 'commandTimeoutMs'),
+      requestTimeoutMs: readOptionalNumber(state, 'requestTimeoutMs'),
+      connectionTimeoutMs: readOptionalNumber(state, 'connectionTimeoutMs'),
+      onTimeout: readE2BTimeoutAction(
+        readOptionalString(state, 'onTimeout') ??
+          readOptionalString(state, 'timeoutAction'),
+      ),
+      timeoutAction: readOptionalE2BTimeoutAction(
+        readOptionalString(state, 'timeoutAction'),
+      ),
+      autoResume: readOptionalBoolean(state, 'autoResume') ?? true,
+      metadata: readOptionalStringRecord(state.metadata),
+      secure: readOptionalBoolean(state, 'secure'),
+      allowInternetAccess: readOptionalBoolean(state, 'allowInternetAccess'),
+      configuredExposedPorts: readOptionalNumberArray(
+        state.configuredExposedPorts,
+      ),
+      workspacePersistence: readE2BWorkspacePersistence(
+        state.workspacePersistence,
+      ),
+      mcp: readOptionalRecord(state.mcp),
+      pauseOnExit: Boolean(state.pauseOnExit),
+      pauseOnExitSupported:
+        readOptionalBoolean(state, 'pauseOnExitSupported') ?? false,
+    };
+  }
+
+  async resume(state: E2BSandboxSessionState): Promise<E2BSandboxSession> {
+    const Sandbox = await loadE2BSandboxClass(state.sandboxType);
+    const connect = Sandbox.connect ?? Sandbox.resume;
+    if (connect) {
+      try {
+        const sandbox = await connect.call(
+          Sandbox,
+          state.sandboxId,
+          e2bReconnectOptions(state),
+        );
+        return new E2BSandboxSession({ state, sandbox });
+      } catch (error) {
+        assertResumeRecreateAllowed(error, {
+          providerName: 'E2BSandboxClient',
+          provider: 'e2b',
+          details: { sandboxId: state.sandboxId },
+        });
+        // Fall through to recreate from serialized state.
+      }
+    }
+
+    return await this.create(state.manifest, {
+      ...stateToCreateOptions(state),
+      env: state.environment,
+    });
+  }
+}
+
+function validateOptions(options: E2BSandboxClientOptions): void {
+  readE2BWorkspacePersistence(options.workspacePersistence);
+  resolveE2BOnTimeout(options);
+}
+
+function resolveE2BOnTimeout(
+  options: Pick<E2BSandboxClientOptions, 'onTimeout' | 'timeoutAction'>,
+): E2BTimeoutAction {
+  return readE2BTimeoutAction(options.onTimeout ?? options.timeoutAction);
+}
+
+function resolveE2BAutoResume(
+  options: Pick<E2BSandboxClientOptions, 'autoResume'>,
+): boolean {
+  return options.autoResume ?? true;
+}
+
+function readE2BTimeoutAction(value: unknown): E2BTimeoutAction {
+  const action = readOptionalE2BTimeoutAction(value);
+  return action ?? 'pause';
+}
+
+function readOptionalE2BTimeoutAction(
+  value: unknown,
+): E2BTimeoutAction | undefined {
+  if (value === undefined || value === 'pause' || value === 'kill') {
+    return value;
+  }
+
+  throw new SandboxUnsupportedFeatureError(
+    'E2BSandboxClient onTimeout must be "pause" or "kill".',
+    {
+      provider: 'E2BSandboxClient',
+      feature: 'onTimeout',
+      onTimeout: value,
+    },
+  );
+}
+
+function readE2BWorkspacePersistence(
+  value: unknown,
+): E2BWorkspacePersistence | undefined {
+  if (
+    value === undefined ||
+    value === true ||
+    value === 'tar' ||
+    value === 'snapshot'
+  ) {
+    return value;
+  }
+
+  throw new SandboxUnsupportedFeatureError(
+    'E2BSandboxClient workspacePersistence must be true, "tar", or "snapshot".',
+    {
+      provider: 'E2BSandboxClient',
+      feature: 'workspacePersistence',
+      workspacePersistence: value,
+    },
+  );
+}
+
+function stateToCreateOptions(
+  state: E2BSandboxSessionState,
+): E2BSandboxClientOptions {
+  return {
+    sandboxType: state.sandboxType,
+    template: state.template,
+    timeout: state.timeout,
+    commandTimeoutMs: state.commandTimeoutMs,
+    requestTimeoutMs: state.requestTimeoutMs,
+    connectionTimeoutMs: state.connectionTimeoutMs,
+    onTimeout: state.onTimeout,
+    timeoutAction: state.timeoutAction,
+    autoResume: state.autoResume,
+    metadata: state.metadata,
+    secure: state.secure,
+    allowInternetAccess: state.allowInternetAccess,
+    exposedPorts: state.configuredExposedPorts,
+    workspacePersistence: state.workspacePersistence,
+    mcp: state.mcp,
+    pauseOnExit: state.pauseOnExit,
+  };
+}
+
+function e2bReconnectOptions(
+  state: E2BSandboxSessionState,
+): Record<string, unknown> | undefined {
+  const options: Record<string, unknown> = {};
+  if (state.requestTimeoutMs !== undefined) {
+    options.requestTimeoutMs = state.requestTimeoutMs;
+  }
+  if (state.connectionTimeoutMs !== undefined) {
+    options.connectionTimeoutMs = state.connectionTimeoutMs;
+  }
+  return Object.keys(options).length > 0 ? options : undefined;
+}
+
+function canPauseE2BSandbox(
+  sandbox: E2BSandboxInstance,
+): sandbox is E2BSandboxInstance & { pause: () => Promise<boolean> } {
+  return typeof sandbox.pause === 'function';
+}
+
+async function loadE2BSandboxClass(
+  sandboxType: E2BSandboxType,
+): Promise<E2BSandboxClass> {
+  const moduleName =
+    sandboxType === 'e2b_code_interpreter' ? '@e2b/code-interpreter' : 'e2b';
+
+  try {
+    const Sandbox =
+      sandboxType === 'e2b_code_interpreter'
+        ? (await import('@e2b/code-interpreter')).Sandbox
+        : (await import('e2b')).Sandbox;
+    if (!Sandbox) {
+      throw new Error(`Missing Sandbox export from ${moduleName}.`);
+    }
+    return adaptE2BSandboxClass(Sandbox);
+  } catch (error) {
+    throw new UserError(
+      `E2B sandbox support requires the optional \`${moduleName}\` package. Install it before using E2B-backed sandbox examples. ${(error as Error).message}`,
+    );
+  }
+}
+
+function adaptE2BSandboxClass(
+  Sandbox:
+    | typeof import('e2b').Sandbox
+    | typeof import('@e2b/code-interpreter').Sandbox,
+): E2BSandboxClass {
+  const sdkSandbox = Sandbox as typeof Sandbox & {
+    connect?: E2BSandboxClass['connect'];
+    resume?: E2BSandboxClass['resume'];
+  };
+  const adapted: E2BSandboxClass = {
+    create: Sandbox.create.bind(Sandbox) as E2BSandboxClass['create'],
+  };
+  if (typeof sdkSandbox.connect === 'function') {
+    adapted.connect = sdkSandbox.connect.bind(Sandbox);
+  }
+  if (typeof sdkSandbox.resume === 'function') {
+    adapted.resume = sdkSandbox.resume.bind(Sandbox);
+  }
+  return adapted;
+}
+
+async function createSandboxInstance(
+  Sandbox: E2BSandboxClass,
+  options: E2BSandboxClientOptions,
+  environment: Record<string, string>,
+): Promise<E2BSandboxInstance> {
+  const createOptions: Record<string, unknown> = {};
+  if (typeof options.timeout === 'number') {
+    createOptions.timeoutMs = Math.max(1, Math.trunc(options.timeout * 1000));
+  }
+  const onTimeout = resolveE2BOnTimeout(options);
+  createOptions.lifecycle = {
+    onTimeout,
+    ...(onTimeout === 'pause'
+      ? { autoResume: resolveE2BAutoResume(options) }
+      : {}),
+  };
+  for (const key of [
+    'commandTimeoutMs',
+    'requestTimeoutMs',
+    'connectionTimeoutMs',
+    'metadata',
+    'secure',
+    'allowInternetAccess',
+    'mcp',
+  ] as const) {
+    if (options[key] !== undefined) {
+      createOptions[key] = options[key];
+    }
+  }
+  if (options.exposedPorts?.length) {
+    createOptions.network = {
+      allowPublicTraffic: true,
+    };
+  }
+  if (Object.keys(environment).length > 0) {
+    createOptions.envs = environment;
+  }
+
+  if (options.template) {
+    return await withProviderError(
+      'E2BSandboxClient',
+      'e2b',
+      'create sandbox',
+      async () => await Sandbox.create(options.template, createOptions),
+      { template: options.template },
+    );
+  }
+
+  if (Object.keys(createOptions).length > 0) {
+    return await withProviderError(
+      'E2BSandboxClient',
+      'e2b',
+      'create sandbox',
+      async () => await Sandbox.create(createOptions),
+    );
+  }
+
+  return await withProviderError(
+    'E2BSandboxClient',
+    'e2b',
+    'create sandbox',
+    async () => await Sandbox.create(),
+  );
+}
+
+function commandResultFromE2BError(
+  error: unknown,
+): E2BCommandResult | undefined {
+  return commandResultFromE2BErrorValue(error, new Set<unknown>());
+}
+
+function commandResultFromE2BErrorValue(
+  value: unknown,
+  seen: Set<unknown>,
+): E2BCommandResult | undefined {
+  if (!isRecord(value) || seen.has(value)) {
+    return undefined;
+  }
+  seen.add(value);
+
+  const directResult = commandResultFromRecord(value);
+  if (directResult) {
+    return directResult;
+  }
+
+  for (const key of ['result', 'context', 'data', 'details', 'cause']) {
+    const nestedResult = commandResultFromE2BErrorValue(value[key], seen);
+    if (nestedResult) {
+      return nestedResult;
+    }
+  }
+
+  return undefined;
+}
+
+function commandResultFromRecord(
+  value: Record<string, unknown>,
+): E2BCommandResult | undefined {
+  const exitCode =
+    typeof value.exitCode === 'number' ? value.exitCode : undefined;
+  const stdout = typeof value.stdout === 'string' ? value.stdout : undefined;
+  const stderr =
+    typeof value.stderr === 'string'
+      ? value.stderr
+      : typeof value.error === 'string'
+        ? value.error
+        : exitCode !== undefined && typeof value.message === 'string'
+          ? value.message
+          : undefined;
+  if (exitCode === undefined && stdout === undefined && stderr === undefined) {
+    return undefined;
+  }
+
+  return {
+    exitCode: exitCode ?? 1,
+    stdout,
+    stderr,
+  };
+}
+
+function exitCodeFromE2BResult(value: unknown): number | null | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  return typeof value.exitCode === 'number' ? value.exitCode : undefined;
+}

--- a/packages/agents-extensions/test/sandbox/e2b.test.ts
+++ b/packages/agents-extensions/test/sandbox/e2b.test.ts
@@ -227,6 +227,16 @@ describe('E2BSandboxClient', () => {
     expect(output).toContain('README.md');
   });
 
+  test('omits E2B lifecycle defaults when lifecycle options are omitted', async () => {
+    const client = new E2BSandboxClient();
+
+    const session = await client.create(new Manifest());
+
+    expect(createMock.mock.calls[0]).toEqual([]);
+    expect(session.state.onTimeout).toBeUndefined();
+    expect(session.state.autoResume).toBeUndefined();
+  });
+
   test('treats missing command exit codes as failures', async () => {
     const client = new E2BSandboxClient();
     const session = await client.create(new Manifest());
@@ -307,10 +317,6 @@ describe('E2BSandboxClient', () => {
 
     expect(createMock).toHaveBeenCalledWith('base', {
       timeoutMs: 30000,
-      lifecycle: {
-        onTimeout: 'pause',
-        autoResume: true,
-      },
     });
     expect(pauseMock).toHaveBeenCalledOnce();
     expect(killMock).not.toHaveBeenCalled();
@@ -460,6 +466,18 @@ describe('E2BSandboxClient', () => {
         onTimeout: 'kill',
       },
     });
+  });
+
+  test('does not force an onTimeout default for autoResume without pause', async () => {
+    const client = new E2BSandboxClient({
+      autoResume: true,
+    } satisfies E2BSandboxClientOptions);
+
+    const session = await client.create(new Manifest());
+
+    expect(createMock.mock.calls[0]).toEqual([]);
+    expect(session.state.onTimeout).toBeUndefined();
+    expect(session.state.autoResume).toBe(true);
   });
 
   test('rejects invalid workspace persistence before creating a sandbox', async () => {
@@ -616,6 +634,9 @@ describe('E2BSandboxClient', () => {
   test('serializes state and reconnects paused sandboxes by id', async () => {
     const client = new E2BSandboxClient({
       pauseOnExit: true,
+      timeout: 30,
+      requestTimeoutMs: 1000,
+      connectionTimeoutMs: 2000,
       env: {
         CLIENT_ONLY: 'override',
       },
@@ -634,7 +655,11 @@ describe('E2BSandboxClient', () => {
 
     expect(client.canPersistOwnedSessionState(session.state)).toBe(true);
     expect(restored.pauseOnExitSupported).toBe(true);
-    expect(connectMock).toHaveBeenCalledWith('sbx_test', undefined);
+    expect(connectMock).toHaveBeenCalledWith('sbx_test', {
+      timeoutMs: 30000,
+      requestTimeoutMs: 1000,
+      connectionTimeoutMs: 2000,
+    });
     expect(resumed.state.environment).toEqual({
       CLIENT_ONLY: 'override',
       MANIFEST_FLAG: 'enabled',
@@ -653,12 +678,7 @@ describe('E2BSandboxClient', () => {
     const recreated = await client.resume(session.state);
 
     expect(connectMock).toHaveBeenCalledWith('sbx_test', undefined);
-    expect(createMock).toHaveBeenCalledWith('base', {
-      lifecycle: {
-        onTimeout: 'pause',
-        autoResume: true,
-      },
-    });
+    expect(createMock).toHaveBeenCalledWith('base', {});
     expect(recreated.state.sandboxId).toBe('sbx_test');
   });
 
@@ -764,12 +784,7 @@ describe('E2BSandboxClient', () => {
 
     await session.hydrateWorkspace(await session.persistWorkspace());
 
-    expect(createMock).toHaveBeenLastCalledWith('snap_test', {
-      lifecycle: {
-        onTimeout: 'pause',
-        autoResume: true,
-      },
-    });
+    expect(createMock).toHaveBeenLastCalledWith('snap_test', {});
     expect(session.state.sandboxId).toBe('sbx_restored');
     expect(killMock).toHaveBeenCalledOnce();
   });
@@ -949,10 +964,6 @@ describe('E2BSandboxClient', () => {
     const cachedEndpoint = await session.resolveExposedPort(3000);
 
     expect(createMock).toHaveBeenCalledWith({
-      lifecycle: {
-        onTimeout: 'pause',
-        autoResume: true,
-      },
       network: { allowPublicTraffic: true },
     });
     expect(getHostMock).toHaveBeenCalledWith(3000);
@@ -1032,10 +1043,6 @@ describe('E2BSandboxClient', () => {
 
     const session = await client.create(manifest);
     expect(createMock).toHaveBeenCalledWith({
-      lifecycle: {
-        onTimeout: 'pause',
-        autoResume: true,
-      },
       envs: {
         CLIENT_ONLY: 'override',
         MANIFEST_FLAG: 'enabled',

--- a/packages/agents-extensions/test/sandbox/e2b.test.ts
+++ b/packages/agents-extensions/test/sandbox/e2b.test.ts
@@ -340,15 +340,47 @@ describe('E2BSandboxClient', () => {
     } satisfies E2BSandboxClientOptions);
     const session = await client.create(new Manifest());
 
-    await session.shutdown({ reason: 'cleanup' });
-    await session.delete({ reason: 'cleanup' });
+    await session.shutdown({
+      reason: 'cleanup',
+      preserveOwnedSessions: true,
+    });
+    await session.delete({
+      reason: 'cleanup',
+      preserveOwnedSessions: true,
+    });
 
     expect(pauseMock).toHaveBeenCalledOnce();
     expect(killMock).not.toHaveBeenCalled();
   });
 
+  test('cleanup lifecycle kills pauseOnExit sessions unless preservation is requested', async () => {
+    const client = new E2BSandboxClient({
+      pauseOnExit: true,
+    } satisfies E2BSandboxClientOptions);
+    const session = await client.create(new Manifest());
+
+    await session.shutdown({ reason: 'cleanup' });
+    await session.delete({ reason: 'cleanup' });
+
+    expect(pauseMock).not.toHaveBeenCalled();
+    expect(killMock).toHaveBeenCalledOnce();
+  });
+
   test('kills the sandbox when close cannot pause a persistable session', async () => {
     pauseMock.mockRejectedValueOnce(new Error('pause failed'));
+    const client = new E2BSandboxClient({
+      pauseOnExit: true,
+    } satisfies E2BSandboxClientOptions);
+    const session = await client.create(new Manifest());
+
+    await session.close();
+
+    expect(pauseMock).toHaveBeenCalledOnce();
+    expect(killMock).toHaveBeenCalledOnce();
+  });
+
+  test('kills the sandbox when close reports an unpaused persistable session', async () => {
+    pauseMock.mockResolvedValueOnce(false);
     const client = new E2BSandboxClient({
       pauseOnExit: true,
     } satisfies E2BSandboxClientOptions);
@@ -367,7 +399,26 @@ describe('E2BSandboxClient', () => {
     } satisfies E2BSandboxClientOptions);
     const session = await client.create(new Manifest());
 
-    await session.delete({ reason: 'cleanup' });
+    await session.delete({
+      reason: 'cleanup',
+      preserveOwnedSessions: true,
+    });
+
+    expect(pauseMock).toHaveBeenCalledOnce();
+    expect(killMock).toHaveBeenCalledOnce();
+  });
+
+  test('kills the sandbox when cleanup delete reports an unpaused persistable session', async () => {
+    pauseMock.mockResolvedValueOnce(false);
+    const client = new E2BSandboxClient({
+      pauseOnExit: true,
+    } satisfies E2BSandboxClientOptions);
+    const session = await client.create(new Manifest());
+
+    await session.delete({
+      reason: 'cleanup',
+      preserveOwnedSessions: true,
+    });
 
     expect(pauseMock).toHaveBeenCalledOnce();
     expect(killMock).toHaveBeenCalledOnce();

--- a/packages/agents-extensions/test/sandbox/e2b.test.ts
+++ b/packages/agents-extensions/test/sandbox/e2b.test.ts
@@ -1,0 +1,1338 @@
+import {
+  Manifest,
+  SandboxProviderError,
+  SandboxUnsupportedFeatureError,
+} from '@openai/agents-core/sandbox';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  E2BCloudBucketMountStrategy,
+  E2BSandboxClient,
+  type E2BSandboxClientOptions,
+} from '../../src/sandbox/e2b';
+import { decodeNativeSnapshotRef } from '../../src/sandbox/shared';
+import { resolvedRemotePathFromValidationCommand } from './remotePathValidation';
+import { makeTarArchive } from './tarFixture';
+
+const processMocks = vi.hoisted(() => ({
+  runSandboxProcess: vi.fn(),
+}));
+const createMock = vi.fn();
+const connectMock = vi.fn();
+const runMock = vi.fn();
+const writeMock = vi.fn();
+const readMock = vi.fn();
+const removeMock = vi.fn();
+const makeDirMock = vi.fn();
+const getHostMock = vi.fn();
+const createSnapshotMock = vi.fn();
+const killMock = vi.fn();
+const pauseMock = vi.fn();
+const files = new Map<string, string | Uint8Array>();
+
+vi.mock('e2b', () => ({
+  Sandbox: {
+    create: createMock,
+    connect: connectMock,
+  },
+}));
+
+vi.mock('../../src/sandbox/shared/process', () => ({
+  runSandboxProcess: processMocks.runSandboxProcess,
+  formatSandboxProcessError: (result: {
+    stderr?: string;
+    stdout?: string;
+    error?: Error;
+  }) => result.stderr || result.stdout || result.error?.message || 'failed',
+}));
+
+const processSuccess = (stdout = '') => ({
+  status: 0,
+  signal: null,
+  stdout,
+  stderr: '',
+  timedOut: false,
+});
+
+const processFailure = (stderr: string) => ({
+  status: 1,
+  signal: null,
+  stdout: '',
+  stderr,
+  timedOut: false,
+});
+
+describe('E2BSandboxClient', () => {
+  beforeEach(() => {
+    files.clear();
+    createMock.mockReset();
+    connectMock.mockReset();
+    runMock.mockReset();
+    writeMock.mockReset();
+    readMock.mockReset();
+    removeMock.mockReset();
+    makeDirMock.mockReset();
+    getHostMock.mockReset();
+    createSnapshotMock.mockReset();
+    killMock.mockReset();
+    pauseMock.mockReset();
+    processMocks.runSandboxProcess.mockReset();
+
+    writeMock.mockImplementation(
+      async (path: string, data: string | Uint8Array) => {
+        files.set(path, data);
+      },
+    );
+    readMock.mockImplementation(
+      async (path: string, opts?: { format?: 'text' | 'bytes' }) => {
+        const value = files.get(path) ?? '';
+        if (opts?.format === 'bytes') {
+          return typeof value === 'string'
+            ? new TextEncoder().encode(value)
+            : value;
+        }
+        return typeof value === 'string'
+          ? value
+          : new TextDecoder().decode(value);
+      },
+    );
+    removeMock.mockImplementation(async (path: string) => {
+      files.delete(path);
+    });
+    createMock.mockResolvedValue({
+      sandboxId: 'sbx_test',
+      commands: {
+        run: runMock,
+      },
+      files: {
+        write: writeMock,
+        read: readMock,
+        remove: removeMock,
+        makeDir: makeDirMock,
+      },
+      getHost: getHostMock,
+      createSnapshot: createSnapshotMock,
+      kill: killMock,
+      pause: pauseMock,
+    });
+    connectMock.mockResolvedValue({
+      sandboxId: 'sbx_test',
+      commands: {
+        run: runMock,
+      },
+      files: {
+        write: writeMock,
+        read: readMock,
+        remove: removeMock,
+        makeDir: makeDirMock,
+      },
+      getHost: getHostMock,
+      createSnapshot: createSnapshotMock,
+      kill: killMock,
+      pause: pauseMock,
+    });
+    runMock.mockImplementation(async (command: string) => {
+      const resolvedPath = resolvedRemotePathFromValidationCommand(command);
+      if (resolvedPath) {
+        return {
+          stdout: `${resolvedPath}\n`,
+          stderr: '',
+          exitCode: 0,
+        };
+      }
+      if (command === 'ls') {
+        return {
+          stdout: 'README.md\n',
+          stderr: '',
+          exitCode: 0,
+        };
+      }
+      if (command.startsWith('test -e ')) {
+        const path = command.match(/^test -e '(.+)'$/)?.[1] ?? '';
+        return {
+          stdout: '',
+          stderr: '',
+          exitCode: files.has(path) ? 0 : 1,
+        };
+      }
+      if (command.startsWith('base64 -- ')) {
+        const path = command.match(/^base64 -- '(.+)'$/)?.[1] ?? '';
+        const value = files.get(path) ?? new Uint8Array();
+        const bytes =
+          typeof value === 'string' ? new TextEncoder().encode(value) : value;
+        return {
+          stdout: `${Buffer.from(bytes).toString('base64')}\n`,
+          stderr: '',
+          exitCode: 0,
+        };
+      }
+      return {
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+      };
+    });
+    pauseMock.mockResolvedValue(true);
+    createSnapshotMock.mockResolvedValue({ snapshotId: 'snap_test' });
+    killMock.mockResolvedValue(undefined);
+  });
+
+  test('rejects unsupported core create options instead of ignoring them', async () => {
+    const client = new E2BSandboxClient();
+
+    await expect(
+      client.create({
+        manifest: new Manifest(),
+        snapshot: { type: 'remote' },
+      }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+    await expect(
+      client.create({
+        manifest: new Manifest(),
+        concurrencyLimits: { manifestEntries: 2 },
+      }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('creates a sandbox, materializes the manifest, and executes commands', async () => {
+    const client = new E2BSandboxClient();
+    const manifest = new Manifest({
+      entries: {
+        'README.md': {
+          type: 'file',
+          content: '# Hello\n',
+        },
+      },
+    });
+
+    const session = await client.create(manifest);
+    const output = await session.execCommand({ cmd: 'ls' });
+
+    expect(createMock).toHaveBeenCalledOnce();
+    expect(makeDirMock).toHaveBeenCalledWith('/workspace');
+    expect(runMock).toHaveBeenCalledWith("mkdir -p -- '/workspace'", {
+      cwd: '/',
+      envs: {},
+    });
+    expect(writeMock).toHaveBeenCalledWith('/workspace/README.md', '# Hello\n');
+    expect(runMock).toHaveBeenCalledWith('ls', {
+      cwd: '/workspace',
+      envs: {},
+      timeoutMs: undefined,
+      user: undefined,
+    });
+    expect(output).toContain('Process exited with code 0');
+    expect(output).toContain('README.md');
+  });
+
+  test('treats missing command exit codes as failures', async () => {
+    const client = new E2BSandboxClient();
+    const session = await client.create(new Manifest());
+    runMock.mockResolvedValueOnce({
+      stdout: 'lost exit\n',
+      stderr: '',
+      exitCode: null,
+    });
+
+    const output = await session.execCommand({ cmd: 'lost-exit' });
+
+    expect(output).toContain('Process exited with code 1');
+    expect(output).toContain('lost exit');
+  });
+
+  test('formats non-zero command errors returned by the E2B SDK', async () => {
+    const client = new E2BSandboxClient();
+    const session = await client.create(new Manifest());
+    runMock.mockRejectedValueOnce(
+      Object.assign(new Error('command failed'), {
+        stdout: 'partial\n',
+        stderr: 'boom\n',
+        exitCode: 2,
+      }),
+    );
+
+    const output = await session.execCommand({ cmd: 'bad-command' });
+
+    expect(output).toContain('Process exited with code 2');
+    expect(output).toContain('partial');
+    expect(output).toContain('boom');
+  });
+
+  test('materializes git_repo file subpaths as files', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === '--version') {
+          return processSuccess('git version 2.0.0');
+        }
+        if (args[0] === 'clone') {
+          const tempDir = args[args.length - 1];
+          await mkdir(join(tempDir, 'nested'), { recursive: true });
+          await writeFile(join(tempDir, 'nested', 'selected.txt'), 'selected');
+          return processSuccess();
+        }
+        return processFailure('unexpected command');
+      },
+    );
+    const client = new E2BSandboxClient();
+
+    await client.create(
+      new Manifest({
+        entries: {
+          'selected.txt': {
+            type: 'git_repo',
+            repo: 'https://example.test/repo.git',
+            subpath: 'nested/selected.txt',
+          },
+        },
+      }),
+    );
+
+    expect(Buffer.from(files.get('/workspace/selected.txt')!)).toEqual(
+      Buffer.from('selected'),
+    );
+  });
+
+  test('passes template, timeout, and pauseOnExit options through', async () => {
+    const client = new E2BSandboxClient({
+      template: 'base',
+      timeout: 30,
+      pauseOnExit: true,
+    } satisfies E2BSandboxClientOptions);
+    const manifest = new Manifest();
+
+    const session = await client.create(manifest);
+    await session.close();
+
+    expect(createMock).toHaveBeenCalledWith('base', {
+      timeoutMs: 30000,
+      lifecycle: {
+        onTimeout: 'pause',
+        autoResume: true,
+      },
+    });
+    expect(pauseMock).toHaveBeenCalledOnce();
+    expect(killMock).not.toHaveBeenCalled();
+  });
+
+  test('delete terminates even when pauseOnExit is enabled', async () => {
+    const client = new E2BSandboxClient({
+      pauseOnExit: true,
+    } satisfies E2BSandboxClientOptions);
+    const session = await client.create(new Manifest());
+
+    await session.delete();
+
+    expect(pauseMock).not.toHaveBeenCalled();
+    expect(killMock).toHaveBeenCalledOnce();
+  });
+
+  test('cleanup lifecycle pauses persistable sessions instead of killing them', async () => {
+    const client = new E2BSandboxClient({
+      pauseOnExit: true,
+    } satisfies E2BSandboxClientOptions);
+    const session = await client.create(new Manifest());
+
+    await session.shutdown({ reason: 'cleanup' });
+    await session.delete({ reason: 'cleanup' });
+
+    expect(pauseMock).toHaveBeenCalledOnce();
+    expect(killMock).not.toHaveBeenCalled();
+  });
+
+  test('kills the sandbox when close cannot pause a persistable session', async () => {
+    pauseMock.mockRejectedValueOnce(new Error('pause failed'));
+    const client = new E2BSandboxClient({
+      pauseOnExit: true,
+    } satisfies E2BSandboxClientOptions);
+    const session = await client.create(new Manifest());
+
+    await session.close();
+
+    expect(pauseMock).toHaveBeenCalledOnce();
+    expect(killMock).toHaveBeenCalledOnce();
+  });
+
+  test('kills the sandbox when cleanup delete cannot pause a persistable session', async () => {
+    pauseMock.mockRejectedValueOnce(new Error('pause failed'));
+    const client = new E2BSandboxClient({
+      pauseOnExit: true,
+    } satisfies E2BSandboxClientOptions);
+    const session = await client.create(new Manifest());
+
+    await session.delete({ reason: 'cleanup' });
+
+    expect(pauseMock).toHaveBeenCalledOnce();
+    expect(killMock).toHaveBeenCalledOnce();
+  });
+
+  test('does not persist owned state when pauseOnExit is unsupported', async () => {
+    createMock.mockResolvedValueOnce({
+      sandboxId: 'sbx_test',
+      commands: {
+        run: runMock,
+      },
+      files: {
+        write: writeMock,
+        read: readMock,
+        remove: removeMock,
+        makeDir: makeDirMock,
+      },
+      getHost: getHostMock,
+      createSnapshot: createSnapshotMock,
+      kill: killMock,
+    });
+    const client = new E2BSandboxClient({
+      pauseOnExit: true,
+    } satisfies E2BSandboxClientOptions);
+    const session = await client.create(new Manifest());
+
+    expect(session.state.pauseOnExitSupported).toBe(false);
+    expect(client.canPersistOwnedSessionState(session.state)).toBe(false);
+
+    await session.close();
+
+    expect(pauseMock).not.toHaveBeenCalled();
+    expect(killMock).toHaveBeenCalledOnce();
+  });
+
+  test('does not terminate twice across shutdown and delete lifecycle', async () => {
+    const client = new E2BSandboxClient();
+    const session = await client.create(new Manifest());
+
+    await session.shutdown();
+    await session.delete();
+
+    expect(killMock).toHaveBeenCalledOnce();
+  });
+
+  test('passes SDK create options through without forwarding workspace persistence', async () => {
+    const client = new E2BSandboxClient({
+      workspacePersistence: 'tar',
+      metadata: { owner: 'tests' },
+      secure: true,
+      allowInternetAccess: false,
+      exposedPorts: [3000],
+      onTimeout: 'pause',
+      autoResume: true,
+      mcp: { servers: [] },
+      requestTimeoutMs: 1000,
+      connectionTimeoutMs: 2000,
+      commandTimeoutMs: 3000,
+    } satisfies E2BSandboxClientOptions);
+
+    const session = await client.create(new Manifest());
+    await session.execCommand({ cmd: 'ls' });
+
+    expect(createMock).toHaveBeenCalledWith({
+      metadata: { owner: 'tests' },
+      secure: true,
+      allowInternetAccess: false,
+      network: { allowPublicTraffic: true },
+      lifecycle: {
+        onTimeout: 'pause',
+        autoResume: true,
+      },
+      mcp: { servers: [] },
+      requestTimeoutMs: 1000,
+      connectionTimeoutMs: 2000,
+      commandTimeoutMs: 3000,
+    });
+    expect(runMock).toHaveBeenLastCalledWith('ls', {
+      cwd: '/workspace',
+      envs: {},
+      timeoutMs: 3000,
+      user: undefined,
+    });
+  });
+
+  test('maps legacy timeoutAction to lifecycle and omits autoResume for kill', async () => {
+    const client = new E2BSandboxClient({
+      timeoutAction: 'kill',
+      autoResume: true,
+    } satisfies E2BSandboxClientOptions);
+
+    await client.create(new Manifest());
+
+    expect(createMock).toHaveBeenCalledWith({
+      lifecycle: {
+        onTimeout: 'kill',
+      },
+    });
+  });
+
+  test('rejects invalid workspace persistence before creating a sandbox', async () => {
+    const client = new E2BSandboxClient({
+      workspacePersistence: 'native',
+    } as unknown as E2BSandboxClientOptions);
+
+    await expect(client.create(new Manifest())).rejects.toBeInstanceOf(
+      SandboxUnsupportedFeatureError,
+    );
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('rejects unsupported PTY execution with a typed error', async () => {
+    const client = new E2BSandboxClient();
+    const session = await client.create(new Manifest());
+
+    await expect(
+      session.execCommand({ cmd: 'sh', tty: true }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+  });
+
+  test('supports PTY execution and stdin when the E2B SDK exposes PTY APIs', async () => {
+    let onData!: (data: Uint8Array) => void;
+    let finishWait!: (result: { exitCode: number }) => void;
+    const ptyCreateMock = vi.fn(async (options: Record<string, unknown>) => {
+      onData = options.onData as (data: Uint8Array) => void;
+      return {
+        pid: 42,
+        wait: async () =>
+          await new Promise<{ exitCode: number }>((resolve) => {
+            finishWait = resolve;
+          }),
+        kill: async () => true,
+      };
+    });
+    const ptySendInputMock = vi.fn(async (_pid: number, data: Uint8Array) => {
+      onData(new TextEncoder().encode(new TextDecoder().decode(data)));
+    });
+    createMock.mockResolvedValueOnce({
+      sandboxId: 'sbx_test',
+      commands: {
+        run: runMock,
+      },
+      files: {
+        write: writeMock,
+        read: readMock,
+        remove: removeMock,
+        makeDir: makeDirMock,
+      },
+      pty: {
+        create: ptyCreateMock,
+        sendInput: ptySendInputMock,
+      },
+      getHost: getHostMock,
+      createSnapshot: createSnapshotMock,
+      kill: killMock,
+      pause: pauseMock,
+    });
+    const client = new E2BSandboxClient();
+    const session = await client.create(new Manifest());
+
+    const started = await session.execCommand({
+      cmd: 'echo ready',
+      tty: true,
+      yieldTimeMs: 250,
+    });
+    const sessionId = Number(
+      started.match(/Process running with session ID (\d+)/)?.[1],
+    );
+    const next = await session.writeStdin({
+      sessionId,
+      chars: 'echo next\n',
+      yieldTimeMs: 250,
+    });
+    finishWait({ exitCode: 0 });
+    const done = await session.writeStdin({
+      sessionId,
+      yieldTimeMs: 250,
+    });
+
+    expect(next).toContain('echo next');
+    expect(done).toContain('Process exited with code 0');
+    expect(ptyCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: '/workspace',
+        envs: {},
+      }),
+    );
+    expect(ptySendInputMock).toHaveBeenCalledWith(
+      42,
+      new TextEncoder().encode("/bin/sh -c 'echo ready'\n"),
+      expect.objectContaining({
+        requestTimeoutMs: undefined,
+      }),
+    );
+  });
+
+  test('terminates PTY execution when the initial stdin write fails', async () => {
+    const handleKillMock = vi.fn(async () => true);
+    const ptyCreateMock = vi.fn(async () => ({
+      pid: 42,
+      wait: async () => ({ exitCode: 1 }),
+      kill: handleKillMock,
+    }));
+    const ptySendInputMock = vi.fn(async () => {
+      throw new Error('stdin unavailable');
+    });
+    createMock.mockResolvedValueOnce({
+      sandboxId: 'sbx_test',
+      commands: {
+        run: runMock,
+      },
+      files: {
+        write: writeMock,
+        read: readMock,
+        remove: removeMock,
+        makeDir: makeDirMock,
+      },
+      pty: {
+        create: ptyCreateMock,
+        sendInput: ptySendInputMock,
+      },
+      getHost: getHostMock,
+      createSnapshot: createSnapshotMock,
+      kill: killMock,
+      pause: pauseMock,
+    });
+    const client = new E2BSandboxClient();
+    const session = await client.create(new Manifest());
+
+    await expect(
+      session.execCommand({ cmd: 'echo ready', tty: true }),
+    ).rejects.toThrow('stdin unavailable');
+
+    expect(ptySendInputMock).toHaveBeenCalledOnce();
+    expect(handleKillMock).toHaveBeenCalledOnce();
+  });
+
+  test('rejects runAs for PTY execution', async () => {
+    const client = new E2BSandboxClient();
+    const session = await client.create(new Manifest());
+
+    await expect(
+      session.execCommand({ cmd: 'id', tty: true, runAs: 'root' }),
+    ).rejects.toMatchObject({
+      details: {
+        provider: 'e2b',
+        feature: 'tty.runAs',
+      },
+    });
+  });
+
+  test('serializes state and reconnects paused sandboxes by id', async () => {
+    const client = new E2BSandboxClient({
+      pauseOnExit: true,
+      env: {
+        CLIENT_ONLY: 'override',
+      },
+    });
+    const session = await client.create(
+      new Manifest({
+        environment: {
+          MANIFEST_FLAG: 'enabled',
+        },
+      }),
+    );
+
+    const serialized = await client.serializeSessionState(session.state);
+    const restored = await client.deserializeSessionState(serialized);
+    const resumed = await client.resume(restored);
+
+    expect(client.canPersistOwnedSessionState(session.state)).toBe(true);
+    expect(restored.pauseOnExitSupported).toBe(true);
+    expect(connectMock).toHaveBeenCalledWith('sbx_test', undefined);
+    expect(resumed.state.environment).toEqual({
+      CLIENT_ONLY: 'override',
+      MANIFEST_FLAG: 'enabled',
+    });
+  });
+
+  test('recreates sandboxes when reconnect reports missing sandbox', async () => {
+    const client = new E2BSandboxClient({
+      pauseOnExit: true,
+      template: 'base',
+    });
+    const session = await client.create(new Manifest());
+    createMock.mockClear();
+    connectMock.mockRejectedValueOnce(new Error('not found'));
+
+    const recreated = await client.resume(session.state);
+
+    expect(connectMock).toHaveBeenCalledWith('sbx_test', undefined);
+    expect(createMock).toHaveBeenCalledWith('base', {
+      lifecycle: {
+        onTimeout: 'pause',
+        autoResume: true,
+      },
+    });
+    expect(recreated.state.sandboxId).toBe('sbx_test');
+  });
+
+  test('fails fast when reconnect fails with a provider error', async () => {
+    const client = new E2BSandboxClient({
+      pauseOnExit: true,
+      template: 'base',
+    });
+    const session = await client.create(new Manifest());
+    createMock.mockClear();
+    connectMock.mockRejectedValueOnce(new Error('request timeout'));
+
+    let thrown: unknown;
+    try {
+      await client.resume(session.state);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(SandboxProviderError);
+    expect((thrown as SandboxProviderError).details).toMatchObject({
+      provider: 'e2b',
+      operation: 'resume',
+      sandboxId: 'sbx_test',
+      cause: 'request timeout',
+    });
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('persists and hydrates tar workspaces', async () => {
+    const archive = makeTarArchive([{ name: 'keep.txt', content: 'keep' }]);
+    runMock.mockImplementation(async (command: string) => {
+      const resolvedPath = resolvedRemotePathFromValidationCommand(command);
+      if (resolvedPath) {
+        return {
+          stdout: `${resolvedPath}\n`,
+          stderr: '',
+          exitCode: 0,
+        };
+      }
+      const archivePath = command.match(/-cf '([^']+)'/)?.[1];
+      if (archivePath) {
+        files.set(archivePath, archive);
+      }
+      return {
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+      };
+    });
+    const client = new E2BSandboxClient({
+      workspacePersistence: 'tar',
+    });
+    const session = await client.create(new Manifest());
+
+    await expect(session.persistWorkspace()).resolves.toEqual(archive);
+    await session.hydrateWorkspace(archive);
+
+    expect(readMock).toHaveBeenCalledWith(expect.any(String), {
+      format: 'bytes',
+    });
+    expect(writeMock).toHaveBeenCalledWith(
+      expect.stringContaining('/tmp/openai-agents-e2bsandboxclient-'),
+      archive,
+    );
+    expect(
+      runMock.mock.calls.some(([command]) =>
+        String(command).includes('tar -C'),
+      ),
+    ).toBe(true);
+  });
+
+  test('persists native snapshots and restores them through E2B templates', async () => {
+    const client = new E2BSandboxClient({
+      workspacePersistence: 'snapshot',
+    });
+    const session = await client.create(new Manifest());
+
+    const ref = decodeNativeSnapshotRef(await session.persistWorkspace());
+
+    expect(ref).toEqual({
+      provider: 'e2b',
+      snapshotId: 'snap_test',
+      workspacePersistence: undefined,
+    });
+
+    createMock.mockResolvedValueOnce({
+      sandboxId: 'sbx_restored',
+      commands: {
+        run: runMock,
+      },
+      files: {
+        write: writeMock,
+        read: readMock,
+        remove: removeMock,
+        makeDir: makeDirMock,
+      },
+      getHost: getHostMock,
+      createSnapshot: createSnapshotMock,
+      kill: killMock,
+      pause: pauseMock,
+    });
+
+    await session.hydrateWorkspace(await session.persistWorkspace());
+
+    expect(createMock).toHaveBeenLastCalledWith('snap_test', {
+      lifecycle: {
+        onTimeout: 'pause',
+        autoResume: true,
+      },
+    });
+    expect(session.state.sandboxId).toBe('sbx_restored');
+    expect(killMock).toHaveBeenCalledOnce();
+  });
+
+  test('clears cached exposed ports after restoring a native snapshot sandbox', async () => {
+    getHostMock
+      .mockReturnValueOnce('3000-sbx-test.e2b.dev')
+      .mockReturnValueOnce('3000-sbx-restored.e2b.dev');
+    const client = new E2BSandboxClient({
+      exposedPorts: [3000],
+      workspacePersistence: 'snapshot',
+    });
+    const session = await client.create(new Manifest());
+    const initialEndpoint = await session.resolveExposedPort(3000);
+    const snapshot = await session.persistWorkspace();
+    createMock.mockResolvedValueOnce({
+      sandboxId: 'sbx_restored',
+      commands: {
+        run: runMock,
+      },
+      files: {
+        write: writeMock,
+        read: readMock,
+        remove: removeMock,
+        makeDir: makeDirMock,
+      },
+      getHost: getHostMock,
+      createSnapshot: createSnapshotMock,
+      kill: killMock,
+      pause: pauseMock,
+    });
+
+    await session.hydrateWorkspace(snapshot);
+    const restoredEndpoint = await session.resolveExposedPort(3000);
+
+    expect(initialEndpoint.host).toBe('3000-sbx-test.e2b.dev');
+    expect(session.state.sandboxId).toBe('sbx_restored');
+    expect(restoredEndpoint.host).toBe('3000-sbx-restored.e2b.dev');
+    expect(getHostMock).toHaveBeenCalledTimes(2);
+    expect(session.state.exposedPorts?.['3000']).toBe(restoredEndpoint);
+  });
+
+  test('keeps previous sandbox state when native snapshot restore cannot kill the old sandbox', async () => {
+    const client = new E2BSandboxClient({
+      workspacePersistence: 'snapshot',
+    });
+    const session = await client.create(new Manifest());
+    const snapshot = await session.persistWorkspace();
+    const restoredKillMock = vi.fn().mockResolvedValue(undefined);
+    createMock.mockResolvedValueOnce({
+      sandboxId: 'sbx_restored',
+      commands: {
+        run: runMock,
+      },
+      files: {
+        write: writeMock,
+        read: readMock,
+        remove: removeMock,
+        makeDir: makeDirMock,
+      },
+      getHost: getHostMock,
+      createSnapshot: createSnapshotMock,
+      kill: restoredKillMock,
+      pause: pauseMock,
+    });
+    killMock.mockRejectedValueOnce(new Error('kill failed'));
+
+    await expect(session.hydrateWorkspace(snapshot)).rejects.toMatchObject({
+      details: {
+        provider: 'e2b',
+        operation: 'restore snapshot',
+        sandboxId: 'sbx_test',
+        replacementSandboxId: 'sbx_restored',
+        snapshotId: 'snap_test',
+        cause: 'kill failed',
+      },
+    });
+
+    expect(restoredKillMock).toHaveBeenCalledOnce();
+    expect(session.state.sandboxId).toBe('sbx_test');
+    await session.execCommand({ cmd: 'ls' });
+    expect(runMock).toHaveBeenLastCalledWith('ls', {
+      cwd: '/workspace',
+      envs: {},
+      timeoutMs: undefined,
+      user: undefined,
+    });
+  });
+
+  test('falls back to tar snapshots when native snapshots cannot exclude ephemeral paths', async () => {
+    const archive = makeTarArchive([{ name: 'keep.txt', content: 'keep' }]);
+    runMock.mockImplementation(async (command: string) => {
+      const resolvedPath = resolvedRemotePathFromValidationCommand(command);
+      if (resolvedPath) {
+        return {
+          stdout: `${resolvedPath}\n`,
+          stderr: '',
+          exitCode: 0,
+        };
+      }
+      const archivePath = command.match(/-cf '([^']+)'/)?.[1];
+      if (archivePath) {
+        files.set(archivePath, archive);
+      }
+      return {
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+      };
+    });
+    const client = new E2BSandboxClient({
+      workspacePersistence: 'snapshot',
+    });
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          'tmp.txt': {
+            type: 'file',
+            content: 'tmp',
+            ephemeral: true,
+          },
+        },
+      }),
+    );
+
+    await expect(session.persistWorkspace()).resolves.toEqual(archive);
+    expect(createSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  test('falls back to tar snapshots when the workspace root is ephemeral', async () => {
+    const archive = makeTarArchive([{ name: 'keep.txt', content: 'keep' }]);
+    runMock.mockImplementation(async (command: string) => {
+      const resolvedPath = resolvedRemotePathFromValidationCommand(command);
+      if (resolvedPath) {
+        return {
+          stdout: `${resolvedPath}\n`,
+          stderr: '',
+          exitCode: 0,
+        };
+      }
+      const archivePath = command.match(/-cf '([^']+)'/)?.[1];
+      if (archivePath) {
+        files.set(archivePath, archive);
+      }
+      return {
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+      };
+    });
+    const client = new E2BSandboxClient({
+      workspacePersistence: 'snapshot',
+    });
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          '': {
+            type: 'dir',
+            ephemeral: true,
+          },
+        },
+      }),
+    );
+
+    await expect(session.persistWorkspace()).resolves.toEqual(archive);
+    expect(createSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  test('resolves configured exposed ports through E2B hosts', async () => {
+    getHostMock.mockReturnValue('3000-sbx-test.e2b.dev');
+    const client = new E2BSandboxClient({
+      exposedPorts: [3000],
+    });
+
+    const session = await client.create(new Manifest());
+    const endpoint = await session.resolveExposedPort(3000);
+    const cachedEndpoint = await session.resolveExposedPort(3000);
+
+    expect(createMock).toHaveBeenCalledWith({
+      lifecycle: {
+        onTimeout: 'pause',
+        autoResume: true,
+      },
+      network: { allowPublicTraffic: true },
+    });
+    expect(getHostMock).toHaveBeenCalledWith(3000);
+    expect(getHostMock).toHaveBeenCalledOnce();
+    expect(endpoint).toMatchObject({
+      host: '3000-sbx-test.e2b.dev',
+      port: 443,
+      tls: true,
+    });
+    expect(cachedEndpoint).toBe(endpoint);
+    expect(session.state.exposedPorts?.['3000']).toBe(endpoint);
+  });
+
+  test('rejects unsupported manifest metadata before creating a sandbox', async () => {
+    const client = new E2BSandboxClient();
+
+    await expect(
+      client.create(
+        new Manifest({
+          extraPathGrants: [{ path: '/tmp/data' }],
+        }),
+      ),
+    ).rejects.toThrow(/does not support extra path grants yet/);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('provisions manifest accounts and applies entry metadata', async () => {
+    const client = new E2BSandboxClient();
+
+    await client.create(
+      new Manifest({
+        users: [{ name: 'sandbox-user' }],
+        groups: [
+          {
+            name: 'sandbox-group',
+            users: [{ name: 'sandbox-user' }],
+          },
+        ],
+        entries: {
+          'notes.txt': {
+            type: 'file',
+            content: 'hello\n',
+            group: { name: 'sandbox-group' },
+            permissions: '-rw-r-----',
+          },
+        },
+      }),
+    );
+
+    const commands = runMock.mock.calls.map(([command]) => String(command));
+    expect(commands.some((command) => command.includes('groupadd'))).toBe(true);
+    expect(commands.some((command) => command.includes('useradd'))).toBe(true);
+    expect(commands.some((command) => command.includes('usermod'))).toBe(true);
+    expect(
+      commands.some(
+        (command) =>
+          command.includes("chgrp 'sandbox-group'") &&
+          command.includes("chmod 0640 -- '/workspace/notes.txt'"),
+      ),
+    ).toBe(true);
+    expect(writeMock).toHaveBeenCalledWith('/workspace/notes.txt', 'hello\n');
+  });
+
+  test('preserves client env while manifest values take precedence', async () => {
+    const client = new E2BSandboxClient({
+      env: {
+        CLIENT_ONLY: 'override',
+        TOKEN: 'client',
+      },
+    });
+    const manifest = new Manifest({
+      environment: {
+        MANIFEST_FLAG: 'enabled',
+        TOKEN: 'manifest',
+      },
+    });
+
+    const session = await client.create(manifest);
+    expect(createMock).toHaveBeenCalledWith({
+      lifecycle: {
+        onTimeout: 'pause',
+        autoResume: true,
+      },
+      envs: {
+        CLIENT_ONLY: 'override',
+        MANIFEST_FLAG: 'enabled',
+        TOKEN: 'manifest',
+      },
+    });
+
+    await session.applyManifest(
+      new Manifest({
+        environment: {
+          MANIFEST_FLAG: 'updated',
+          EXTRA_FLAG: 'present',
+          TOKEN: 'manifest-updated',
+        },
+      }),
+    );
+    await session.execCommand({ cmd: 'ls' });
+
+    expect(runMock).toHaveBeenCalledWith('ls', {
+      cwd: '/workspace',
+      envs: {
+        CLIENT_ONLY: 'override',
+        MANIFEST_FLAG: 'updated',
+        EXTRA_FLAG: 'present',
+        TOKEN: 'manifest-updated',
+      },
+      timeoutMs: undefined,
+      user: undefined,
+    });
+  });
+
+  test('materializes a single lazy skill entry', async () => {
+    const client = new E2BSandboxClient();
+    const session = await client.create(
+      new Manifest({
+        remoteMountCommandAllowlist: ['cat'],
+      }),
+    );
+
+    await session.materializeEntry?.({
+      path: '.agents/lazy/SKILL.md',
+      entry: {
+        type: 'file',
+        content: '# Lazy\n',
+      },
+    });
+
+    expect(writeMock).toHaveBeenLastCalledWith(
+      '/workspace/.agents/lazy/SKILL.md',
+      '# Lazy\n',
+    );
+    expect(await session.pathExists('.agents/lazy/SKILL.md')).toBe(true);
+    expect(session.state.manifest.remoteMountCommandAllowlist).toEqual(['cat']);
+  });
+
+  test('returns false when E2B throws for missing path existence checks', async () => {
+    const client = new E2BSandboxClient();
+    const session = await client.create(new Manifest());
+    runMock.mockImplementation(async (command: string) => {
+      const resolvedPath = resolvedRemotePathFromValidationCommand(command);
+      if (resolvedPath) {
+        return {
+          stdout: `${resolvedPath}\n`,
+          stderr: '',
+          exitCode: 0,
+        };
+      }
+      if (command.startsWith('test -e ')) {
+        throw Object.assign(new Error('missing path'), {
+          exitCode: 1,
+          stderr: 'missing path',
+        });
+      }
+      return {
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+      };
+    });
+
+    await expect(session.pathExists('missing.txt')).resolves.toBe(false);
+  });
+
+  test('mounts cloud buckets with the E2B rclone mount strategy', async () => {
+    const client = new E2BSandboxClient();
+
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          data: {
+            type: 's3_mount',
+            bucket: 'agent-logs',
+            accessKeyId: 'access-key',
+            secretAccessKey: 'secret-key',
+            mountPath: 'mounted/logs',
+            mountStrategy: new E2BCloudBucketMountStrategy(),
+          },
+        },
+      }),
+    );
+    await session.close();
+
+    expect(
+      runMock.mock.calls.some(([command]) =>
+        String(command).includes("'rclone' 'mount'"),
+      ),
+    ).toBe(true);
+    expect(
+      runMock.mock.calls.some(([command]) =>
+        String(command).includes('/workspace/mounted/logs'),
+      ),
+    ).toBe(true);
+    expect(
+      runMock.mock.calls.some(([command]) =>
+        String(command).includes('fusermount3 -u'),
+      ),
+    ).toBe(true);
+  });
+
+  test('continues mount setup when E2B throws for install probes', async () => {
+    let rcloneProbeFailures = 0;
+    runMock.mockImplementation(async (command: string) => {
+      const resolvedPath = resolvedRemotePathFromValidationCommand(command);
+      if (resolvedPath) {
+        return {
+          stdout: `${resolvedPath}\n`,
+          stderr: '',
+          exitCode: 0,
+        };
+      }
+      if (
+        command.includes('command -v rclone') &&
+        rcloneProbeFailures++ === 0
+      ) {
+        throw Object.assign(new Error('rclone missing'), {
+          exitCode: 1,
+          stderr: 'rclone missing',
+        });
+      }
+      return {
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+      };
+    });
+    const client = new E2BSandboxClient();
+
+    await client.create(
+      new Manifest({
+        entries: {
+          data: {
+            type: 's3_mount',
+            bucket: 'agent-logs',
+            accessKeyId: 'access-key',
+            secretAccessKey: 'secret-key',
+            mountPath: 'mounted/logs',
+            mountStrategy: new E2BCloudBucketMountStrategy(),
+          },
+        },
+      }),
+    );
+
+    expect(
+      runMock.mock.calls.some(([command]) =>
+        String(command).includes('command -v apt-get'),
+      ),
+    ).toBe(true);
+    expect(
+      runMock.mock.calls.some(([command]) =>
+        String(command).includes("'rclone' 'mount'"),
+      ),
+    ).toBe(true);
+  });
+
+  test('reads images with runAs through remote commands', async () => {
+    const client = new E2BSandboxClient();
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          'pixel.png': {
+            type: 'file',
+            content: '',
+          },
+        },
+      }),
+    );
+    const png = Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x00]);
+    files.set('/workspace/pixel.png', png);
+    runMock.mockClear();
+
+    const image = await session.viewImage({
+      path: 'pixel.png',
+      runAs: 'sandbox-user',
+    });
+
+    expect((image.image as { data: Uint8Array }).data).toEqual(png);
+    expect(runMock).toHaveBeenCalledWith("base64 -- '/workspace/pixel.png'", {
+      cwd: '/',
+      envs: {},
+      timeoutMs: undefined,
+      user: 'sandbox-user',
+    });
+    expect(readMock).not.toHaveBeenCalled();
+  });
+
+  test('reads images through the E2B byte file format', async () => {
+    const client = new E2BSandboxClient();
+    const session = await client.create(new Manifest());
+    const pngHeader = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ]);
+    files.set('/workspace/pixel.png', pngHeader);
+    readMock.mockClear();
+
+    const image = await session.viewImage({ path: 'pixel.png' });
+    const payload = image.image as { data: Uint8Array; mediaType?: string };
+
+    expect(readMock).toHaveBeenCalledWith('/workspace/pixel.png', {
+      format: 'bytes',
+    });
+    expect(payload.mediaType).toBe('image/png');
+    expect([...payload.data]).toEqual([...pngHeader]);
+  });
+
+  test('supports filesystem editor hooks with absolute workspace paths', async () => {
+    const client = new E2BSandboxClient();
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          'README.md': {
+            type: 'file',
+            content: '# Hello\n',
+          },
+        },
+      }),
+    );
+    const editor = session.createEditor?.();
+    if (!editor) {
+      throw new Error('Expected E2BSandboxSession.createEditor().');
+    }
+
+    await editor.updateFile({
+      type: 'update_file',
+      path: '/workspace/README.md',
+      diff: '@@\n-# Hello\n+# Updated\n',
+    });
+    const exists = await session.pathExists?.('/workspace/README.md');
+
+    expect(readMock).toHaveBeenCalledWith('/workspace/README.md');
+    expect(writeMock).toHaveBeenLastCalledWith(
+      '/workspace/README.md',
+      '# Updated\n',
+    );
+    expect(exists).toBe(true);
+    await expect(
+      session.pathExists('/workspace/../tmp/README.md'),
+    ).rejects.toThrow(/escapes the workspace root/);
+  });
+
+  test('supports filesystem and command runAs', async () => {
+    const client = new E2BSandboxClient();
+    const session = await client.create(new Manifest());
+
+    expect(() => session.createEditor?.('sandbox-user')).not.toThrow();
+    await expect(
+      session.pathExists?.('/workspace/README.md', 'sandbox-user'),
+    ).resolves.toBe(false);
+    await expect(
+      session.applyManifest?.(
+        new Manifest({
+          entries: {
+            'owned.txt': {
+              type: 'file',
+              content: 'owned\n',
+            },
+          },
+        }),
+        'sandbox-user',
+      ),
+    ).resolves.toBeUndefined();
+    expect(writeMock).toHaveBeenCalledWith('/workspace/owned.txt', 'owned\n');
+    expect(runMock).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "chown 'sandbox-user':'sandbox-user' -- '/workspace/owned.txt'",
+      ),
+      expect.objectContaining({
+        cwd: '/',
+        user: undefined,
+      }),
+    );
+
+    await session.execCommand({ cmd: 'ls', runAs: 'sandbox-user' });
+    expect(runMock).toHaveBeenLastCalledWith('ls', {
+      cwd: '/workspace',
+      envs: {},
+      timeoutMs: undefined,
+      user: 'sandbox-user',
+    });
+  });
+});

--- a/packages/agents-extensions/test/sandbox/e2b.test.ts
+++ b/packages/agents-extensions/test/sandbox/e2b.test.ts
@@ -377,9 +377,12 @@ describe('E2BSandboxClient', () => {
 
     expect(pauseMock).toHaveBeenCalledOnce();
     expect(killMock).toHaveBeenCalledOnce();
+    expect(session.state.pauseOnExit).toBe(false);
+    expect(session.state.pauseOnExitSupported).toBe(false);
+    expect(client.canPersistOwnedSessionState(session.state)).toBe(false);
   });
 
-  test('kills the sandbox when close reports an unpaused persistable session', async () => {
+  test('treats false pause results as already-paused close success', async () => {
     pauseMock.mockResolvedValueOnce(false);
     const client = new E2BSandboxClient({
       pauseOnExit: true,
@@ -389,7 +392,8 @@ describe('E2BSandboxClient', () => {
     await session.close();
 
     expect(pauseMock).toHaveBeenCalledOnce();
-    expect(killMock).toHaveBeenCalledOnce();
+    expect(killMock).not.toHaveBeenCalled();
+    expect(client.canPersistOwnedSessionState(session.state)).toBe(true);
   });
 
   test('kills the sandbox when cleanup delete cannot pause a persistable session', async () => {
@@ -406,9 +410,12 @@ describe('E2BSandboxClient', () => {
 
     expect(pauseMock).toHaveBeenCalledOnce();
     expect(killMock).toHaveBeenCalledOnce();
+    expect(session.state.pauseOnExit).toBe(false);
+    expect(session.state.pauseOnExitSupported).toBe(false);
+    expect(client.canPersistOwnedSessionState(session.state)).toBe(false);
   });
 
-  test('kills the sandbox when cleanup delete reports an unpaused persistable session', async () => {
+  test('treats false pause results as already-paused cleanup success', async () => {
     pauseMock.mockResolvedValueOnce(false);
     const client = new E2BSandboxClient({
       pauseOnExit: true,
@@ -421,7 +428,8 @@ describe('E2BSandboxClient', () => {
     });
 
     expect(pauseMock).toHaveBeenCalledOnce();
-    expect(killMock).toHaveBeenCalledOnce();
+    expect(killMock).not.toHaveBeenCalled();
+    expect(client.canPersistOwnedSessionState(session.state)).toBe(true);
   });
 
   test('does not persist owned state when pauseOnExit is unsupported', async () => {


### PR DESCRIPTION
This pull request adds a sandbox provider as part of agents-extensions package: https://developers.openai.com/api/docs/guides/agents/sandboxes

How to run:
```zsh
git clone https://github.com/openai/openai-agents-js
cd openai-agents-js/
git checkout feat/sandbox-agents-e2b
pnpm i
pnpm build
pnpm -F sandbox start:e2b
```