### PR TITLE
feat(sandbox): add Daytona provider

### DIFF
--- a/.changeset/sandbox-agents-daytona.md
+++ b/.changeset/sandbox-agents-daytona.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': minor
+---
+
+feat: add Daytona sandbox provider

--- a/examples/sandbox/extensions/daytona-runner.ts
+++ b/examples/sandbox/extensions/daytona-runner.ts
@@ -1,0 +1,87 @@
+import { Runner } from '@openai/agents';
+import { DaytonaSandboxClient } from '@openai/agents-extensions/sandbox/daytona';
+import { Manifest, SandboxAgent, shell } from '@openai/agents/sandbox';
+import { finished } from 'node:stream/promises';
+import {
+  DEFAULT_MODEL,
+  getStringArg,
+  hasFlag,
+  requireEnv,
+  requireOpenAIKey,
+  runExampleMain,
+} from '../support';
+
+const DEFAULT_QUESTION =
+  'Summarize this cloud sandbox workspace in 2 sentences.';
+const DEFAULT_DAYTONA_WORKSPACE_ROOT = '/home/daytona/workspace';
+
+function buildManifest(): Manifest {
+  return new Manifest({
+    root: DEFAULT_DAYTONA_WORKSPACE_ROOT,
+    entries: {
+      'README.md': {
+        type: 'file',
+        content: `# Daytona Demo Workspace
+
+This workspace exists to validate the Daytona sandbox backend manually.
+`,
+      },
+      'launch.md': {
+        type: 'file',
+        content: `# Launch
+
+- Customer: Contoso Logistics.
+- Goal: validate the remote sandbox agent path.
+- Current status: Daytona backend smoke and app-server connectivity are passing.
+`,
+      },
+      'tasks.md': {
+        type: 'file',
+        content: `# Tasks
+
+1. Inspect the workspace files.
+2. Summarize the setup and any notable status in two sentences.
+`,
+      },
+    },
+  });
+}
+
+async function main() {
+  requireOpenAIKey();
+  requireEnv('DAYTONA_API_KEY');
+
+  const model = getStringArg('--model', DEFAULT_MODEL);
+  const question = getStringArg('--question', DEFAULT_QUESTION);
+  const pauseOnExit = hasFlag('--pause-on-exit');
+  const stream = hasFlag('--stream');
+  const client = new DaytonaSandboxClient({ pauseOnExit });
+  const agent = new SandboxAgent({
+    name: 'Daytona Sandbox Assistant',
+    model,
+    instructions:
+      'Answer questions about the sandbox workspace. Inspect the files before answering, keep the response concise, and cite the file names you inspected.',
+    defaultManifest: buildManifest(),
+    capabilities: [shell()],
+  });
+  const runner = new Runner({
+    workflowName: 'Daytona sandbox example',
+    sandbox: { client },
+  });
+
+  if (!stream) {
+    const result = await runner.run(agent, question);
+    console.log(result.finalOutput);
+    return;
+  }
+
+  const result = await runner.run(agent, question, { stream: true });
+  process.stdout.write('assistant> ');
+  const textStream = result.toTextStream({ compatibleWithNodeStreams: true });
+  textStream.pipe(process.stdout);
+  await finished(textStream);
+  await result.completed;
+  process.stdout.write('\n');
+}
+
+await runExampleMain(main);

--- a/packages/agents-extensions/src/sandbox/daytona/index.ts
+++ b/packages/agents-extensions/src/sandbox/daytona/index.ts
@@ -1,0 +1,2 @@
+export * from './sandbox';
+export * from './mounts';

--- a/packages/agents-extensions/src/sandbox/daytona/mounts.ts
+++ b/packages/agents-extensions/src/sandbox/daytona/mounts.ts
@@ -1,0 +1,26 @@
+import type {
+  Entry,
+  RcloneMountPattern,
+  TypedMount,
+} from '@openai/agents-core/sandbox';
+import { isRcloneCloudBucketMountEntry } from '../shared/inContainerMounts';
+
+export type DaytonaCloudBucketMountStrategyOptions = {
+  pattern?: RcloneMountPattern;
+};
+
+export class DaytonaCloudBucketMountStrategy {
+  readonly [key: string]: unknown;
+  readonly type = 'daytona_cloud_bucket';
+  readonly pattern: RcloneMountPattern;
+
+  constructor(options: DaytonaCloudBucketMountStrategyOptions = {}) {
+    this.pattern = options.pattern ?? { type: 'rclone', mode: 'fuse' };
+  }
+}
+
+export function isDaytonaCloudBucketMountEntry(
+  entry: Entry,
+): entry is TypedMount {
+  return isRcloneCloudBucketMountEntry(entry, 'daytona_cloud_bucket');
+}

--- a/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
@@ -1,0 +1,1358 @@
+import { UserError, type ToolOutputImage } from '@openai/agents-core';
+import {
+  Manifest,
+  SandboxProviderError,
+  SandboxUnsupportedFeatureError,
+  normalizeSandboxClientCreateArgs,
+  type SandboxClient,
+  type SandboxClientCreateArgs,
+  type SandboxClientOptions,
+  type ExposedPortEndpoint,
+  type ExecCommandArgs,
+  type MaterializeEntryArgs,
+  type Mount,
+  type SandboxSession,
+  type SandboxSessionState,
+  type TypedMount,
+  type ViewImageArgs,
+  type WriteStdinArgs,
+  type WorkspaceArchiveData,
+} from '@openai/agents-core/sandbox';
+import {
+  appendPtyOutput,
+  assertCoreConcurrencyLimitsUnsupported,
+  assertCoreSnapshotUnsupported,
+  assertTarWorkspacePersistence,
+  createPtyProcessEntry,
+  imageOutputFromBytes,
+  RemoteSandboxEditor,
+  assertSandboxEntryMetadataSupported,
+  assertSandboxManifestMetadataSupported,
+  MOUNT_MANIFEST_METADATA_SUPPORT,
+  assertRunAsUnsupported,
+  closeRemoteSessionOnManifestError,
+  cloneManifestWithRoot,
+  deserializeRemoteSandboxSessionStateValues,
+  elapsedSeconds,
+  formatExecResponse,
+  formatPtyExecUpdate,
+  hydrateRemoteWorkspaceTar,
+  assertResumeRecreateAllowed,
+  materializeEnvironment,
+  persistRemoteWorkspaceTar,
+  assertConfiguredExposedPort,
+  getCachedExposedPortEndpoint,
+  parseExposedPortEndpoint,
+  recordResolvedExposedPortEndpoint,
+  resolveSandboxAbsolutePath,
+  resolveSandboxWorkdir,
+  posixDirname,
+  shellQuote,
+  shellCommandForPty,
+  serializeRemoteSandboxSessionState,
+  truncateOutput,
+  validateRemoteSandboxPathForManifest,
+  watchPtyProcess,
+  readOptionalNumber,
+  readOptionalNumberArray,
+  readOptionalRecord,
+  readOptionalString,
+  readString,
+  withProviderError,
+  withSandboxSpan,
+  writePtyStdin,
+  PtyProcessRegistry,
+  type RemoteManifestWriter,
+  type RemoteSandboxPathOptions,
+  type RemoteSandboxPathResolver,
+} from '../shared';
+import {
+  mountRcloneCloudBucket,
+  rclonePatternFromMountStrategy,
+  unmountRcloneMount,
+  type RemoteMountCommand,
+} from '../shared/inContainerMounts';
+import { isDaytonaCloudBucketMountEntry } from './mounts';
+import {
+  applyLocalSourceManifestEntryToState,
+  applyLocalSourceManifestToState,
+  materializeLocalSourceManifest,
+} from '../shared/localSources';
+
+const DEFAULT_WORKSPACE_ROOT = '/home/daytona/workspace';
+const DEFAULT_EXPOSED_PORT_URL_TTL_S = 60;
+const DAYTONA_DELETE_RETRY_DELAYS_MS = [1_000, 2_000, 4_000];
+
+type DaytonaClientLike = {
+  create(
+    params?: Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ): Promise<DaytonaSandboxLike>;
+  get(idOrName: string): Promise<DaytonaSandboxLike>;
+};
+
+type DaytonaSandboxLike = {
+  id: string;
+  start(timeout?: number): Promise<void>;
+  stop(timeout?: number, force?: boolean): Promise<void>;
+  delete(timeout?: number): Promise<void>;
+  fs: {
+    createFolder(path: string, mode: string): Promise<void>;
+    uploadFile(
+      source: Buffer | string,
+      remotePath: string,
+      timeout?: number,
+    ): Promise<void>;
+    downloadFile(remotePath: string, timeout?: number): Promise<Buffer>;
+    deleteFile(path: string, recursive?: boolean): Promise<void>;
+  };
+  process: {
+    executeCommand(
+      command: string,
+      cwd?: string,
+      env?: Record<string, string>,
+      timeout?: number,
+    ): Promise<DaytonaExecuteResponse>;
+    createPty?(options?: {
+      id?: string;
+      cwd?: string;
+      envs?: Record<string, string>;
+      cols?: number;
+      rows?: number;
+      onData?: (data: Uint8Array | string) => void | Promise<void>;
+    }): Promise<DaytonaPtyHandle>;
+    killPtySession?(id: string): Promise<void>;
+  };
+  getSignedPreviewUrl?(
+    port: number,
+    expiresInSeconds?: number,
+  ): Promise<DaytonaPreviewUrlLike>;
+};
+
+type DaytonaExecuteResponse = {
+  exitCode: number;
+  result: string;
+  artifacts?: {
+    stdout?: string;
+  };
+};
+
+type DaytonaPreviewUrlLike = string | { url?: string };
+
+type DaytonaPtyHandle = {
+  sessionId?: string;
+  waitForConnection?(): Promise<void>;
+  sendInput?(data: string | Uint8Array): Promise<void>;
+  wait?(): Promise<{ exitCode?: number; error?: string }>;
+  kill?(): Promise<void>;
+  disconnect?(): Promise<void>;
+  exitCode?: number;
+  error?: string;
+};
+
+export interface DaytonaSandboxClientOptions extends SandboxClientOptions {
+  image?: string;
+  resources?: Record<string, unknown>;
+  env?: Record<string, string>;
+  pauseOnExit?: boolean;
+  createTimeoutSec?: number;
+  startTimeoutSec?: number;
+  timeoutSec?: number;
+  sandboxSnapshotName?: string;
+  exposedPorts?: number[];
+  exposedPortUrlTtlS?: number;
+  name?: string;
+  autoStopInterval?: number;
+  apiKey?: string;
+  apiUrl?: string;
+  target?: string;
+}
+
+export interface DaytonaSandboxSessionState extends SandboxSessionState {
+  sandboxId: string;
+  image?: string;
+  resources?: Record<string, unknown>;
+  pauseOnExit: boolean;
+  createTimeoutSec?: number;
+  startTimeoutSec?: number;
+  timeoutSec?: number;
+  sandboxSnapshotName?: string;
+  configuredExposedPorts?: number[];
+  exposedPortUrlTtlS?: number;
+  name?: string;
+  autoStopInterval?: number;
+  environment: Record<string, string>;
+  apiKey?: string;
+  apiUrl?: string;
+  target?: string;
+}
+
+export class DaytonaSandboxSession implements SandboxSession<DaytonaSandboxSessionState> {
+  readonly state: DaytonaSandboxSessionState;
+  private readonly sandbox: DaytonaSandboxLike;
+  private readonly ptyProcesses = new PtyProcessRegistry();
+  private readonly remotePathResolver: RemoteSandboxPathResolver = async (
+    path,
+    options,
+  ) => await this.resolveRemotePath(path, options);
+  private readonly activeMountPaths = new Set<string>();
+  private stopPromise?: Promise<void>;
+  private deletePromise?: Promise<void>;
+
+  constructor(args: {
+    state: DaytonaSandboxSessionState;
+    sandbox: DaytonaSandboxLike;
+  }) {
+    this.state = args.state;
+    this.sandbox = args.sandbox;
+  }
+
+  createEditor(runAs?: string): RemoteSandboxEditor {
+    assertRunAsUnsupported('DaytonaSandboxClient', runAs);
+    return new RemoteSandboxEditor({
+      resolvePath: this.remotePathResolver,
+      pathExists: async (path) => await this.pathExists(path),
+      mkdir: async (path) => {
+        await this.mkdirEditorPath(path);
+      },
+      readText: async (path) => {
+        return await this.readEditorText(path);
+      },
+      writeText: async (path, content) => {
+        await this.writeEditorText(path, content);
+      },
+      deletePath: async (path) => {
+        await this.deleteEditorPath(path);
+      },
+    });
+  }
+
+  supportsPty(): boolean {
+    return typeof this.sandbox.process.createPty === 'function';
+  }
+
+  async execCommand(args: ExecCommandArgs): Promise<string> {
+    if (args.tty) {
+      return await this.execPtyCommand(args);
+    }
+    assertRunAsUnsupported('DaytonaSandboxClient', args.runAs);
+
+    const start = Date.now();
+    const result = await this.sandbox.process.executeCommand(
+      args.cmd,
+      resolveSandboxWorkdir(this.state.manifest.root, args.workdir),
+      this.state.environment,
+    );
+    const combinedOutput = result.artifacts?.stdout ?? result.result ?? '';
+    const output = truncateOutput(combinedOutput, args.maxOutputTokens);
+
+    return formatExecResponse({
+      output: output.text,
+      wallTimeSeconds: elapsedSeconds(start),
+      exitCode: result.exitCode,
+      originalTokenCount: output.originalTokenCount,
+    });
+  }
+
+  async writeStdin(args: WriteStdinArgs): Promise<string> {
+    return await writePtyStdin({
+      providerName: 'DaytonaSandboxClient',
+      registry: this.ptyProcesses,
+      sessionId: args.sessionId,
+      chars: args.chars,
+      yieldTimeMs: args.yieldTimeMs,
+      maxOutputTokens: args.maxOutputTokens,
+    });
+  }
+
+  private async execPtyCommand(args: ExecCommandArgs): Promise<string> {
+    assertRunAsUnsupported('DaytonaSandboxClient', args.runAs);
+    if (!this.sandbox.process.createPty) {
+      throw new SandboxUnsupportedFeatureError(
+        'DaytonaSandboxClient tty=true requires Daytona SDK PTY support.',
+        {
+          provider: 'daytona',
+          feature: 'tty',
+        },
+      );
+    }
+
+    const start = Date.now();
+    const command = shellCommandForPty(args);
+    const entry = createPtyProcessEntry({ tty: true });
+    const providerSessionId = `sandbox-${Math.random().toString(16).slice(2, 14)}`;
+    const handle = await this.sandbox.process.createPty({
+      id: providerSessionId,
+      cwd: resolveSandboxWorkdir(this.state.manifest.root, args.workdir),
+      envs: this.state.environment,
+      cols: 80,
+      rows: 24,
+      onData: (data: Uint8Array | string) => appendPtyOutput(entry, data),
+    });
+    if (handle.waitForConnection) {
+      await handle.waitForConnection();
+    }
+
+    if (!handle.sendInput) {
+      await this.terminatePtyHandle(handle, providerSessionId);
+      throw new SandboxUnsupportedFeatureError(
+        'DaytonaSandboxClient tty=true requires Daytona SDK PTY stdin support.',
+        {
+          provider: 'daytona',
+          feature: 'tty.stdin',
+        },
+      );
+    }
+    if (!handle.wait) {
+      await this.terminatePtyHandle(handle, providerSessionId);
+      throw new SandboxUnsupportedFeatureError(
+        'DaytonaSandboxClient tty=true requires Daytona SDK PTY wait support.',
+        {
+          provider: 'daytona',
+          feature: 'tty.wait',
+        },
+      );
+    }
+    const waitForExit = handle.wait.bind(handle);
+    entry.sendInput = async (chars) => {
+      await handle.sendInput!(chars);
+    };
+    entry.terminate = async () => {
+      if (handle.kill) {
+        await handle.kill();
+      } else {
+        await this.sandbox.process.killPtySession?.(
+          handle.sessionId ?? providerSessionId,
+        );
+      }
+      await handle.disconnect?.();
+    };
+    const { sessionId, pruned } = this.ptyProcesses.register(entry);
+    if (pruned) {
+      await pruned.terminate?.().catch(() => {});
+    }
+    watchPtyProcess(
+      entry,
+      async () => await waitForExit(),
+      (result, error) =>
+        exitCodeFromDaytonaResult(result) ??
+        exitCodeFromDaytonaResult(error) ??
+        exitCodeFromDaytonaResult(handle),
+    );
+    await entry.sendInput(`${command}\n`);
+
+    return await formatPtyExecUpdate({
+      registry: this.ptyProcesses,
+      sessionId,
+      entry,
+      startTime: start,
+      yieldTimeMs: args.yieldTimeMs,
+      maxOutputTokens: args.maxOutputTokens,
+    });
+  }
+
+  private async terminatePtyHandle(
+    handle: DaytonaPtyHandle,
+    providerSessionId: string,
+  ): Promise<void> {
+    if (handle.kill) {
+      try {
+        await handle.kill();
+      } catch {
+        // Ignore best-effort PTY cleanup failures.
+      }
+    } else {
+      try {
+        await this.sandbox.process.killPtySession?.(
+          handle.sessionId ?? providerSessionId,
+        );
+      } catch {
+        // Ignore best-effort PTY cleanup failures.
+      }
+    }
+    try {
+      await handle.disconnect?.();
+    } catch {
+      // Ignore best-effort PTY cleanup failures.
+    }
+  }
+
+  async viewImage(args: ViewImageArgs): Promise<ToolOutputImage> {
+    assertRunAsUnsupported('DaytonaSandboxClient', args.runAs);
+    const bytes = await this.readFileBytes(args.path);
+    return imageOutputFromBytes(args.path, bytes);
+  }
+
+  async pathExists(path: string, runAs?: string): Promise<boolean> {
+    assertRunAsUnsupported('DaytonaSandboxClient', runAs);
+    const absolutePath = await this.resolveRemotePath(path);
+    const result = await this.sandbox.process.executeCommand(
+      `test -e ${shellQuote(absolutePath)}`,
+      this.state.manifest.root,
+      this.state.environment,
+      5,
+    );
+    return result.exitCode === 0;
+  }
+
+  async running(): Promise<boolean> {
+    try {
+      const result = await this.sandbox.process.executeCommand(
+        'true',
+        this.state.manifest.root,
+        this.state.environment,
+        5,
+      );
+      return result.exitCode === 0;
+    } catch {
+      return false;
+    }
+  }
+
+  async resolveExposedPort(port: number): Promise<ExposedPortEndpoint> {
+    const requestedPort = assertConfiguredExposedPort({
+      providerName: 'DaytonaSandboxClient',
+      port,
+      configuredPorts: this.state.configuredExposedPorts,
+    });
+    const cached = getUsableDaytonaCachedExposedPortEndpoint(
+      this.state,
+      requestedPort,
+    );
+    if (cached) {
+      return cached;
+    }
+
+    const preview = await this.createSignedPreviewUrl(requestedPort);
+    const url = typeof preview === 'string' ? preview : preview.url;
+    if (typeof url !== 'string') {
+      throw new SandboxProviderError(
+        'DaytonaSandboxClient exposed port preview did not include a URL.',
+        {
+          provider: 'daytona',
+          port: requestedPort,
+        },
+      );
+    }
+
+    return recordResolvedExposedPortEndpoint(
+      this.state,
+      requestedPort,
+      withDaytonaPreviewExpiration(
+        parseExposedPortEndpoint(url, {
+          providerName: 'DaytonaSandboxClient',
+          source: 'preview URL',
+        }),
+        this.state.exposedPortUrlTtlS,
+      ),
+    );
+  }
+
+  async materializeEntry(args: MaterializeEntryArgs): Promise<void> {
+    assertRunAsUnsupported('DaytonaSandboxClient', args.runAs);
+    assertSandboxEntryMetadataSupported(
+      'DaytonaSandboxClient',
+      args.path,
+      args.entry,
+      MOUNT_MANIFEST_METADATA_SUPPORT,
+    );
+    await applyLocalSourceManifestEntryToState(
+      this.state,
+      args.path,
+      args.entry,
+      'daytona',
+      this.writer(),
+      this.remotePathResolver,
+      this.manifestMaterializationOptions,
+    );
+  }
+
+  async applyManifest(manifest: Manifest, runAs?: string): Promise<void> {
+    assertRunAsUnsupported('DaytonaSandboxClient', runAs);
+    const resolvedManifest = resolveManifestRoot(manifest);
+    if (resolvedManifest.root !== this.state.manifest.root) {
+      throw new UserError(
+        'DaytonaSandboxClient cannot apply a manifest with a different root than the active session. Create or resume a session with the desired root instead.',
+      );
+    }
+    assertSandboxManifestMetadataSupported(
+      'DaytonaSandboxClient',
+      resolvedManifest,
+      MOUNT_MANIFEST_METADATA_SUPPORT,
+    );
+    await applyLocalSourceManifestToState(
+      this.state,
+      resolvedManifest,
+      'daytona',
+      this.writer(),
+      this.remotePathResolver,
+      this.manifestMaterializationOptions,
+    );
+  }
+
+  async materializeInitialManifest(manifest: Manifest): Promise<void> {
+    await materializeLocalSourceManifest(
+      this.writer(),
+      manifest,
+      'daytona',
+      this.remotePathResolver,
+      this.manifestMaterializationOptions,
+    );
+  }
+
+  async rematerializeMountEntries(): Promise<void> {
+    const targets: Array<{
+      mountPath: string;
+      entry: Mount | TypedMount;
+      resolvedMountPath: string;
+    }> = [];
+    for (const target of this.state.manifest.mountTargetsForMaterialization()) {
+      targets.push({
+        ...target,
+        resolvedMountPath: await this.resolveMountEntryPath(
+          target.mountPath,
+          target.entry,
+        ),
+      });
+    }
+
+    for (const { resolvedMountPath } of [...targets].reverse()) {
+      await this.unmountMountPath(resolvedMountPath);
+    }
+    this.activeMountPaths.clear();
+
+    for (const { mountPath, entry } of targets) {
+      await this.materializeMountEntry(mountPath, entry);
+    }
+  }
+
+  async prepareWorkspaceRoot(): Promise<void> {
+    const root = this.state.manifest.root;
+    const result = await this.sandbox.process.executeCommand(
+      `mkdir -p -- ${shellQuote(root)}`,
+      '/',
+      this.state.environment,
+    );
+    if (result.exitCode !== 0) {
+      throw new SandboxProviderError(
+        'DaytonaSandboxClient failed to prepare the workspace root.',
+        {
+          provider: 'daytona',
+          operation: 'prepare workspace root',
+          sandboxId: this.state.sandboxId,
+          root,
+          stdout: result.artifacts?.stdout ?? result.result ?? '',
+        },
+      );
+    }
+  }
+
+  async persistWorkspace(): Promise<Uint8Array> {
+    assertTarWorkspacePersistence('DaytonaSandboxClient', 'tar');
+    return await persistRemoteWorkspaceTar({
+      providerName: 'DaytonaSandboxClient',
+      manifest: this.state.manifest,
+      io: this.archiveIo(),
+    });
+  }
+
+  async hydrateWorkspace(data: WorkspaceArchiveData): Promise<void> {
+    assertTarWorkspacePersistence('DaytonaSandboxClient', 'tar');
+    await hydrateRemoteWorkspaceTar({
+      providerName: 'DaytonaSandboxClient',
+      manifest: this.state.manifest,
+      io: this.archiveIo(),
+      data,
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.state.pauseOnExit) {
+      await this.stopOnce();
+      return;
+    }
+    await this.deleteOnce();
+  }
+
+  async shutdown(): Promise<void> {
+    await this.close();
+  }
+
+  async delete(): Promise<void> {
+    await this.deleteOnce();
+  }
+
+  private async stopOnce(): Promise<void> {
+    this.stopPromise ??= (async () => {
+      await this.ptyProcesses.terminateAll();
+      await withSandboxSpan(
+        'sandbox.stop',
+        {
+          backend_id: 'daytona',
+          sandbox_id: this.state.sandboxId,
+        },
+        async () => {
+          await this.sandbox.stop();
+        },
+      );
+    })();
+    await this.stopPromise;
+  }
+
+  private async deleteOnce(): Promise<void> {
+    this.deletePromise ??= (async () => {
+      await this.ptyProcesses.terminateAll();
+      await withSandboxSpan(
+        'sandbox.shutdown',
+        {
+          backend_id: 'daytona',
+          sandbox_id: this.state.sandboxId,
+        },
+        async () => {
+          await this.unmountActiveMounts();
+          await deleteDaytonaSandboxWithRetry(async () => {
+            await this.sandbox.delete();
+          });
+        },
+      );
+    })();
+    await this.deletePromise;
+  }
+
+  private writer(): RemoteManifestWriter {
+    return {
+      mkdir: async (path) => {
+        await this.sandbox.fs.createFolder(path, '755');
+      },
+      writeFile: async (path, content) => {
+        await this.ensureParentDir(path);
+        await this.sandbox.fs.uploadFile(Buffer.from(content), path);
+      },
+    };
+  }
+
+  private readonly manifestMaterializationOptions = {
+    materializeMount: this.materializeMountEntry.bind(this),
+  };
+
+  private async materializeMountEntry(
+    absolutePath: string,
+    entry: Mount | TypedMount,
+  ): Promise<void> {
+    if (!isDaytonaCloudBucketMountEntry(entry)) {
+      throw new SandboxUnsupportedFeatureError(
+        'DaytonaSandboxClient only supports DaytonaCloudBucketMountStrategy mount entries.',
+        {
+          provider: 'daytona',
+          feature: 'entry.mountStrategy',
+          path: absolutePath,
+          mountType: entry.type,
+          strategyType: entry.mountStrategy?.type,
+        },
+      );
+    }
+    const mountPath = await this.resolveMountEntryPath(absolutePath, entry);
+    await mountRcloneCloudBucket({
+      providerName: 'DaytonaSandboxClient',
+      providerId: 'daytona',
+      strategyType: 'daytona_cloud_bucket',
+      entry,
+      mountPath,
+      pattern: rclonePatternFromMountStrategy(entry.mountStrategy),
+      runCommand: this.mountCommandRunner(),
+      packageManagers: ['apt', 'apk'],
+    });
+    this.activeMountPaths.add(mountPath);
+  }
+
+  private async unmountActiveMounts(): Promise<void> {
+    for (const mountPath of [...this.activeMountPaths].reverse()) {
+      await this.unmountMountPath(mountPath);
+    }
+  }
+
+  private async unmountMountPath(mountPath: string): Promise<void> {
+    await unmountRcloneMount({
+      providerName: 'DaytonaSandboxClient',
+      providerId: 'daytona',
+      mountPath,
+      runCommand: this.mountCommandRunner(),
+    }).catch(() => {});
+    this.activeMountPaths.delete(mountPath);
+  }
+
+  private async resolveMountEntryPath(
+    absolutePath: string,
+    entry: Mount | TypedMount,
+  ): Promise<string> {
+    return await this.resolveRemotePath(entry.mountPath ?? absolutePath, {
+      forWrite: true,
+    });
+  }
+
+  private mountCommandRunner(): RemoteMountCommand {
+    return async (command, options = {}) => {
+      const commandToRun = commandForDaytonaUser(command, options.user);
+      const result = await this.sandbox.process.executeCommand(
+        commandToRun,
+        this.state.manifest.root,
+        this.state.environment,
+        options.timeoutMs ? Math.ceil(options.timeoutMs / 1000) : undefined,
+      );
+      return {
+        status: result.exitCode,
+        stdout: result.artifacts?.stdout ?? result.result ?? '',
+        stderr: '',
+      };
+    };
+  }
+
+  private archiveIo() {
+    return {
+      runCommand: async (command: string) => {
+        const result = await this.sandbox.process.executeCommand(
+          command,
+          this.state.manifest.root,
+          this.state.environment,
+          this.state.timeoutSec,
+        );
+        return {
+          status: result.exitCode,
+          stdout: result.artifacts?.stdout ?? result.result ?? '',
+          stderr: '',
+        };
+      },
+      readFile: async (path: string) =>
+        Uint8Array.from(await this.sandbox.fs.downloadFile(path)),
+      writeFile: async (path: string, content: string | Uint8Array) => {
+        await this.ensureParentDir(path);
+        await this.sandbox.fs.uploadFile(Buffer.from(content), path);
+      },
+      mkdir: async (path: string) => {
+        await this.sandbox.fs.createFolder(path, '755');
+      },
+    };
+  }
+
+  private async readFileBytes(path: string): Promise<Uint8Array> {
+    const absolutePath = this.resolveEditorPath(path);
+    const output = await this.runEditorFileCommand(
+      [
+        'set -eu',
+        `root=${shellQuote(this.state.manifest.root)}`,
+        `path=${shellQuote(absolutePath)}`,
+        'resolved_root=$(realpath -m -- "$root")',
+        'resolved=$(readlink -f -- "$path")',
+        'case "$resolved" in "$resolved_root"|"$resolved_root"/*) ;; *) printf "workspace escape: %s\\n" "$resolved" >&2; exit 111 ;; esac',
+        '[ -f "$resolved" ] || { printf "not a regular file: %s\\n" "$resolved" >&2; exit 112; }',
+        'exec 3< "$resolved"',
+        'resolved=$(readlink -f "/proc/$$/fd/3")',
+        'case "$resolved" in "$resolved_root"|"$resolved_root"/*) ;; *) printf "workspace escape: %s\\n" "$resolved" >&2; exit 111 ;; esac',
+        'base64 <&3',
+      ].join('\n'),
+    );
+    return Buffer.from(output.replace(/\s+/gu, ''), 'base64');
+  }
+
+  private async readEditorText(path: string): Promise<string> {
+    return new TextDecoder().decode(await this.readFileBytes(path));
+  }
+
+  private async mkdirEditorPath(path: string): Promise<void> {
+    const absolutePath = this.resolveEditorPath(path, { forWrite: true });
+    await this.runEditorFileCommand(
+      [
+        'set -eu',
+        `root=${shellQuote(this.state.manifest.root)}`,
+        `path=${shellQuote(absolutePath)}`,
+        'resolved_root=$(realpath -m -- "$root")',
+        'resolved_path=$(realpath -m -- "$path")',
+        'case "$resolved_path" in "$resolved_root"|"$resolved_root"/*) ;; *) printf "workspace escape: %s\\n" "$resolved_path" >&2; exit 111 ;; esac',
+        'mkdir -p -- "$resolved_path"',
+        'resolved_created=$(realpath -m -- "$resolved_path")',
+        'case "$resolved_created" in "$resolved_root"|"$resolved_root"/*) ;; *) printf "workspace escape: %s\\n" "$resolved_created" >&2; exit 111 ;; esac',
+        '[ -d "$resolved_created" ] || { printf "not a directory: %s\\n" "$resolved_created" >&2; exit 112; }',
+      ].join('\n'),
+    );
+  }
+
+  private async writeEditorText(path: string, content: string): Promise<void> {
+    const absolutePath = this.resolveEditorPath(path, { forWrite: true });
+    const encoded = Buffer.from(content, 'utf8').toString('base64');
+    await this.runEditorFileCommand(
+      [
+        'set -eu',
+        `root=${shellQuote(this.state.manifest.root)}`,
+        `path=${shellQuote(absolutePath)}`,
+        'resolved_root=$(realpath -m -- "$root")',
+        'parent=$(dirname -- "$path")',
+        'base=$(basename -- "$path")',
+        'resolved_parent=$(realpath -m -- "$parent")',
+        'case "$resolved_parent" in "$resolved_root"|"$resolved_root"/*) ;; *) printf "workspace escape: %s\\n" "$resolved_parent" >&2; exit 111 ;; esac',
+        'target="$resolved_parent/$base"',
+        'if [ -d "$target" ]; then printf "directory target: %s\\n" "$target" >&2; exit 112; fi',
+        'tmp=$(mktemp "$resolved_parent/.openai-agents-write.XXXXXX")',
+        'cleanup() { rm -f -- "$tmp"; }',
+        'trap cleanup EXIT HUP INT TERM',
+        'base64 -d > "$tmp" <<\'OPENAI_AGENTS_CONTENT\'',
+        encoded,
+        'OPENAI_AGENTS_CONTENT',
+        'chmod 644 "$tmp"',
+        'mv -f -- "$tmp" "$target"',
+        'trap - EXIT',
+      ].join('\n'),
+    );
+  }
+
+  private async deleteEditorPath(path: string): Promise<void> {
+    const absolutePath = this.resolveEditorPath(path, { forWrite: true });
+    await this.runEditorFileCommand(
+      [
+        'set -eu',
+        `root=${shellQuote(this.state.manifest.root)}`,
+        `path=${shellQuote(absolutePath)}`,
+        'resolved_root=$(realpath -m -- "$root")',
+        'parent=$(dirname -- "$path")',
+        'base=$(basename -- "$path")',
+        'resolved_parent=$(realpath -m -- "$parent")',
+        'case "$resolved_parent" in "$resolved_root"|"$resolved_root"/*) ;; *) printf "workspace escape: %s\\n" "$resolved_parent" >&2; exit 111 ;; esac',
+        'rm -f -- "$resolved_parent/$base"',
+      ].join('\n'),
+    );
+  }
+
+  private async runEditorFileCommand(command: string): Promise<string> {
+    const result = await this.sandbox.process.executeCommand(
+      command,
+      this.state.manifest.root,
+      this.state.environment,
+      this.state.timeoutSec,
+    );
+    if (result.exitCode !== 0) {
+      throw new UserError(
+        (
+          result.artifacts?.stdout ||
+          result.result ||
+          'remote editor operation failed'
+        )
+          .trim()
+          .split(/\r?\n/u)
+          .join('; '),
+      );
+    }
+    return result.artifacts?.stdout ?? result.result ?? '';
+  }
+
+  private resolveEditorPath(
+    path?: string,
+    options: RemoteSandboxPathOptions = {},
+  ): string {
+    return resolveSandboxAbsolutePath(this.state.manifest.root, path, options);
+  }
+
+  private async ensureParentDir(path: string): Promise<void> {
+    const parent = posixDirname(path);
+    if (parent !== '.' && parent !== '/') {
+      await this.sandbox.fs.createFolder(parent, '755');
+    }
+  }
+
+  private async resolveRemotePath(
+    path?: string,
+    options: RemoteSandboxPathOptions = {},
+  ): Promise<string> {
+    return await validateRemoteSandboxPathForManifest({
+      manifest: this.state.manifest,
+      path,
+      options,
+      runCommand: async (command) => {
+        const result = await this.sandbox.process.executeCommand(
+          command,
+          this.state.manifest.root,
+          this.state.environment,
+        );
+        return {
+          status: result.exitCode,
+          stdout: result.artifacts?.stdout ?? result.result ?? '',
+          stderr: '',
+        };
+      },
+    });
+  }
+
+  private async createSignedPreviewUrl(
+    port: number,
+  ): Promise<DaytonaPreviewUrlLike> {
+    try {
+      if (this.sandbox.getSignedPreviewUrl) {
+        return await this.sandbox.getSignedPreviewUrl(
+          port,
+          this.state.exposedPortUrlTtlS,
+        );
+      }
+    } catch (error) {
+      throw new SandboxProviderError(
+        `DaytonaSandboxClient failed to resolve exposed port ${port}.`,
+        {
+          provider: 'daytona',
+          port,
+          cause: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+
+    throw new SandboxProviderError(
+      'DaytonaSandboxClient exposed port resolution requires a Daytona signed preview URL API.',
+      {
+        provider: 'daytona',
+        port,
+      },
+    );
+  }
+}
+
+/**
+ * @see {@link https://www.daytona.io/docs/ | Daytona docs}.
+ * @see {@link https://www.daytona.io/docs/en/getting-started/ | Getting started}.
+ * @see {@link https://www.daytona.io/docs/en/typescript-sdk/sandbox/ | TypeScript SDK Sandbox reference}.
+ */
+export class DaytonaSandboxClient implements SandboxClient<
+  DaytonaSandboxClientOptions,
+  DaytonaSandboxSessionState
+> {
+  readonly backendId = 'daytona';
+  private readonly options: DaytonaSandboxClientOptions;
+
+  constructor(options: DaytonaSandboxClientOptions = {}) {
+    this.options = options;
+  }
+
+  async create(
+    args?: SandboxClientCreateArgs<DaytonaSandboxClientOptions> | Manifest,
+    manifestOptions?: DaytonaSandboxClientOptions,
+  ): Promise<DaytonaSandboxSession> {
+    const createArgs = normalizeSandboxClientCreateArgs(args, manifestOptions);
+    assertCoreSnapshotUnsupported('DaytonaSandboxClient', createArgs.snapshot);
+    assertCoreConcurrencyLimitsUnsupported(
+      'DaytonaSandboxClient',
+      createArgs.concurrencyLimits,
+    );
+    const manifest = createArgs.manifest;
+    const resolvedOptions = {
+      ...this.options,
+      ...createArgs.options,
+    };
+    const resolvedManifest = resolveManifestRoot(manifest);
+    assertSandboxManifestMetadataSupported(
+      'DaytonaSandboxClient',
+      resolvedManifest,
+      MOUNT_MANIFEST_METADATA_SUPPORT,
+    );
+    const client = await createDaytonaClient(resolvedOptions);
+
+    return await withSandboxSpan(
+      'sandbox.start',
+      {
+        backend_id: this.backendId,
+      },
+      async () => {
+        const environment = await materializeEnvironment(
+          resolvedManifest,
+          resolvedOptions.env,
+        );
+        const sandbox = await withProviderError(
+          'DaytonaSandboxClient',
+          'daytona',
+          'create sandbox',
+          async () =>
+            await client.create(
+              {
+                ...(resolvedOptions.sandboxSnapshotName
+                  ? { snapshot: resolvedOptions.sandboxSnapshotName }
+                  : { image: resolvedOptions.image ?? 'debian:12.9' }),
+                ...(!resolvedOptions.sandboxSnapshotName &&
+                resolvedOptions.resources
+                  ? { resources: resolvedOptions.resources }
+                  : {}),
+                ...(resolvedOptions.name ? { name: resolvedOptions.name } : {}),
+                ...(typeof resolvedOptions.autoStopInterval === 'number'
+                  ? { autoStopInterval: resolvedOptions.autoStopInterval }
+                  : {}),
+                ...(typeof resolvedOptions.startTimeoutSec === 'number'
+                  ? { startTimeoutSec: resolvedOptions.startTimeoutSec }
+                  : {}),
+                ...(typeof resolvedOptions.timeoutSec === 'number'
+                  ? { timeoutSec: resolvedOptions.timeoutSec }
+                  : {}),
+                ...(resolvedOptions.exposedPorts
+                  ? { exposedPorts: resolvedOptions.exposedPorts }
+                  : {}),
+                ...(typeof resolvedOptions.exposedPortUrlTtlS === 'number'
+                  ? { exposedPortUrlTtlS: resolvedOptions.exposedPortUrlTtlS }
+                  : {}),
+                envVars: environment,
+              },
+              ...(typeof resolvedOptions.createTimeoutSec === 'number'
+                ? [{ timeout: resolvedOptions.createTimeoutSec }]
+                : []),
+            ),
+          resolvedOptions.sandboxSnapshotName
+            ? { snapshot: resolvedOptions.sandboxSnapshotName }
+            : { image: resolvedOptions.image ?? 'debian:12.9' },
+        );
+
+        const session = new DaytonaSandboxSession({
+          sandbox,
+          state: {
+            manifest: resolvedManifest,
+            sandboxId: sandbox.id,
+            image: resolvedOptions.image,
+            resources: resolvedOptions.resources,
+            pauseOnExit: resolvedOptions.pauseOnExit ?? false,
+            createTimeoutSec: resolvedOptions.createTimeoutSec,
+            startTimeoutSec: resolvedOptions.startTimeoutSec,
+            timeoutSec: resolvedOptions.timeoutSec,
+            sandboxSnapshotName: resolvedOptions.sandboxSnapshotName,
+            configuredExposedPorts: resolvedOptions.exposedPorts,
+            exposedPortUrlTtlS: resolvedOptions.exposedPortUrlTtlS,
+            name: resolvedOptions.name,
+            autoStopInterval: resolvedOptions.autoStopInterval,
+            environment,
+            apiKey: resolvedOptions.apiKey,
+            apiUrl: resolvedOptions.apiUrl,
+            target: resolvedOptions.target,
+          },
+        });
+
+        try {
+          await session.prepareWorkspaceRoot();
+          await session.materializeInitialManifest(resolvedManifest);
+        } catch (error) {
+          session.state.pauseOnExit = false;
+          await closeRemoteSessionOnManifestError('Daytona', session, error);
+        }
+        return session;
+      },
+    );
+  }
+
+  async serializeSessionState(
+    state: DaytonaSandboxSessionState,
+  ): Promise<Record<string, unknown>> {
+    return serializeRemoteSandboxSessionState(state);
+  }
+
+  canPersistOwnedSessionState(state: DaytonaSandboxSessionState): boolean {
+    return state.pauseOnExit;
+  }
+
+  async deserializeSessionState(
+    state: Record<string, unknown>,
+  ): Promise<DaytonaSandboxSessionState> {
+    const baseState = deserializeRemoteSandboxSessionStateValues(
+      state,
+      this.options.env,
+    );
+    return {
+      ...state,
+      ...baseState,
+      sandboxId: readString(state, 'sandboxId'),
+      pauseOnExit: Boolean(state.pauseOnExit),
+      image: readOptionalString(state, 'image'),
+      resources: readOptionalRecord(state.resources),
+      createTimeoutSec: readOptionalNumber(state, 'createTimeoutSec'),
+      startTimeoutSec: readOptionalNumber(state, 'startTimeoutSec'),
+      timeoutSec: readOptionalNumber(state, 'timeoutSec'),
+      sandboxSnapshotName: readOptionalString(state, 'sandboxSnapshotName'),
+      configuredExposedPorts: readOptionalNumberArray(
+        state.configuredExposedPorts,
+      ),
+      exposedPortUrlTtlS: readOptionalNumber(state, 'exposedPortUrlTtlS'),
+      name: readOptionalString(state, 'name'),
+      autoStopInterval: readOptionalNumber(state, 'autoStopInterval'),
+      apiKey: readOptionalString(state, 'apiKey'),
+      apiUrl: readOptionalString(state, 'apiUrl'),
+      target: readOptionalString(state, 'target'),
+    };
+  }
+
+  async resume(
+    state: DaytonaSandboxSessionState,
+  ): Promise<DaytonaSandboxSession> {
+    const client = await createDaytonaClient({
+      ...this.options,
+      apiKey: state.apiKey ?? this.options.apiKey,
+      apiUrl: state.apiUrl ?? this.options.apiUrl,
+      target: state.target ?? this.options.target,
+    });
+    let sandbox: DaytonaSandboxLike;
+    try {
+      sandbox = await client.get(state.sandboxId);
+      await sandbox.start(state.startTimeoutSec);
+    } catch (error) {
+      assertResumeRecreateAllowed(error, {
+        providerName: 'DaytonaSandboxClient',
+        provider: 'daytona',
+        details: { sandboxId: state.sandboxId },
+      });
+      return await this.recreateFromPersistedState(client, state);
+    }
+    const session = new DaytonaSandboxSession({ state, sandbox });
+    await session.prepareWorkspaceRoot();
+    await session.rematerializeMountEntries();
+    return session;
+  }
+
+  private async recreateFromPersistedState(
+    client: DaytonaClientLike,
+    state: DaytonaSandboxSessionState,
+  ): Promise<DaytonaSandboxSession> {
+    const sandbox = await withProviderError(
+      'DaytonaSandboxClient',
+      'daytona',
+      'create sandbox',
+      async () =>
+        await client.create(
+          {
+            ...(state.sandboxSnapshotName
+              ? { snapshot: state.sandboxSnapshotName }
+              : { image: state.image ?? 'debian:12.9' }),
+            ...(!state.sandboxSnapshotName && state.resources
+              ? { resources: state.resources }
+              : {}),
+            ...(state.name ? { name: state.name } : {}),
+            ...(typeof state.autoStopInterval === 'number'
+              ? { autoStopInterval: state.autoStopInterval }
+              : {}),
+            ...(typeof state.startTimeoutSec === 'number'
+              ? { startTimeoutSec: state.startTimeoutSec }
+              : {}),
+            ...(typeof state.timeoutSec === 'number'
+              ? { timeoutSec: state.timeoutSec }
+              : {}),
+            ...(state.configuredExposedPorts
+              ? { exposedPorts: state.configuredExposedPorts }
+              : {}),
+            ...(typeof state.exposedPortUrlTtlS === 'number'
+              ? { exposedPortUrlTtlS: state.exposedPortUrlTtlS }
+              : {}),
+            envVars: state.environment,
+          },
+          ...(typeof state.createTimeoutSec === 'number'
+            ? [{ timeout: state.createTimeoutSec }]
+            : []),
+        ),
+      state.sandboxSnapshotName
+        ? { snapshot: state.sandboxSnapshotName }
+        : { image: state.image ?? 'debian:12.9' },
+    );
+    const nextState: DaytonaSandboxSessionState = {
+      ...state,
+      sandboxId: sandbox.id,
+      environment: { ...state.environment },
+    };
+    delete nextState.exposedPorts;
+    const session = new DaytonaSandboxSession({
+      sandbox,
+      state: nextState,
+    });
+    try {
+      await session.prepareWorkspaceRoot();
+      await session.materializeInitialManifest(state.manifest);
+    } catch (error) {
+      session.state.pauseOnExit = false;
+      await closeRemoteSessionOnManifestError('Daytona', session, error);
+    }
+    return session;
+  }
+}
+
+function getUsableDaytonaCachedExposedPortEndpoint(
+  state: DaytonaSandboxSessionState,
+  requestedPort: number,
+): ExposedPortEndpoint | undefined {
+  const cached = getCachedExposedPortEndpoint(state, requestedPort);
+  if (!cached) {
+    return undefined;
+  }
+
+  const expiresAtMs = cached.daytonaExpiresAtMs;
+  return typeof expiresAtMs === 'number' &&
+    Number.isFinite(expiresAtMs) &&
+    expiresAtMs > Date.now()
+    ? cached
+    : undefined;
+}
+
+function withDaytonaPreviewExpiration(
+  endpoint: ExposedPortEndpoint,
+  ttlS: number | undefined,
+): ExposedPortEndpoint {
+  const resolvedTtlS =
+    typeof ttlS === 'number' ? ttlS : DEFAULT_EXPOSED_PORT_URL_TTL_S;
+  if (!Number.isFinite(resolvedTtlS) || resolvedTtlS <= 0) {
+    return endpoint;
+  }
+  return {
+    ...endpoint,
+    daytonaExpiresAtMs: Date.now() + resolvedTtlS * 1000,
+  };
+}
+
+async function createDaytonaClient(
+  options: Pick<DaytonaSandboxClientOptions, 'apiKey' | 'apiUrl' | 'target'>,
+): Promise<DaytonaClientLike> {
+  try {
+    const { Daytona } = await import('@daytonaio/sdk');
+    return adaptDaytonaClient(
+      new Daytona({
+        ...(options.apiKey ? { apiKey: options.apiKey } : {}),
+        ...(options.apiUrl ? { apiUrl: options.apiUrl } : {}),
+        ...(options.target ? { target: options.target } : {}),
+      }),
+    );
+  } catch (error) {
+    throw new UserError(
+      `Daytona sandbox support requires the optional \`@daytonaio/sdk\` package. Install it before using Daytona-backed sandbox examples. ${(error as Error).message}`,
+    );
+  }
+}
+
+function adaptDaytonaClient(
+  client: import('@daytonaio/sdk').Daytona,
+): DaytonaClientLike {
+  return {
+    create: async (params, options) =>
+      adaptDaytonaSandbox(
+        await client.create(
+          params as Parameters<typeof client.create>[0],
+          options as Parameters<typeof client.create>[1],
+        ),
+      ),
+    get: async (idOrName) => adaptDaytonaSandbox(await client.get(idOrName)),
+  };
+}
+
+function adaptDaytonaSandbox(
+  sandbox: import('@daytonaio/sdk').Sandbox,
+): DaytonaSandboxLike {
+  return {
+    id: sandbox.id,
+    start: async (timeout) => await sandbox.start(timeout),
+    stop: async (timeout, force) => await sandbox.stop(timeout, force),
+    delete: async (timeout) => await sandbox.delete(timeout),
+    fs: {
+      createFolder: async (path, mode) =>
+        await sandbox.fs.createFolder(path, mode),
+      uploadFile: async (source, remotePath, timeout) => {
+        if (typeof source === 'string') {
+          if (typeof timeout === 'number') {
+            await sandbox.fs.uploadFile(source, remotePath, timeout);
+          } else {
+            await sandbox.fs.uploadFile(source, remotePath);
+          }
+          return;
+        }
+        if (typeof timeout === 'number') {
+          await sandbox.fs.uploadFile(source, remotePath, timeout);
+        } else {
+          await sandbox.fs.uploadFile(source, remotePath);
+        }
+      },
+      downloadFile: async (remotePath, timeout) =>
+        await sandbox.fs.downloadFile(remotePath, timeout),
+      deleteFile: async (path, recursive) =>
+        await sandbox.fs.deleteFile(path, recursive),
+    },
+    process: {
+      executeCommand: async (command, cwd, env, timeout) =>
+        typeof timeout === 'number'
+          ? await sandbox.process.executeCommand(command, cwd, env, timeout)
+          : await sandbox.process.executeCommand(command, cwd, env),
+      ...(typeof sandbox.process.createPty === 'function'
+        ? {
+            createPty: async (options) =>
+              await sandbox.process.createPty(
+                options as Parameters<typeof sandbox.process.createPty>[0],
+              ),
+          }
+        : {}),
+      ...(typeof sandbox.process.killPtySession === 'function'
+        ? {
+            killPtySession: async (id) =>
+              await sandbox.process.killPtySession(id),
+          }
+        : {}),
+    },
+    getSignedPreviewUrl: async (port, expiresInSeconds) =>
+      await sandbox.getSignedPreviewUrl(port, expiresInSeconds),
+  };
+}
+
+function resolveManifestRoot(manifest: Manifest): Manifest {
+  if (manifest.root === '/workspace') {
+    return cloneManifestWithRoot(manifest, DEFAULT_WORKSPACE_ROOT);
+  }
+
+  return manifest;
+}
+
+function commandForDaytonaUser(command: string, user?: string): string {
+  if (!user) {
+    return command;
+  }
+  return [
+    `target_user=${shellQuote(user)}`,
+    'current_uid="$(id -u)"',
+    'current_user="$(id -un 2>/dev/null || id -u)"',
+    'if [ "$current_uid" = "$target_user" ] || [ "$current_user" = "$target_user" ]; then',
+    `  sh -lc ${shellQuote(command)}`,
+    'elif [ "$current_uid" -eq 0 ]; then',
+    `  su -s /bin/sh "$target_user" -c ${shellQuote(command)}`,
+    'else',
+    `  sudo -n -u "$target_user" -- sh -lc ${shellQuote(command)}`,
+    'fi',
+  ].join('\n');
+}
+
+async function deleteDaytonaSandboxWithRetry(
+  deleteSandbox: () => Promise<void>,
+): Promise<void> {
+  let attempt = 0;
+  while (true) {
+    try {
+      await deleteSandbox();
+      return;
+    } catch (error) {
+      const delayMs = DAYTONA_DELETE_RETRY_DELAYS_MS[attempt];
+      if (
+        !isDaytonaStateChangeInProgressError(error) ||
+        delayMs === undefined
+      ) {
+        throw error;
+      }
+      attempt += 1;
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+}
+
+function isDaytonaStateChangeInProgressError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+  const record = error as Record<string, unknown>;
+  return (
+    record.statusCode === 409 &&
+    error instanceof Error &&
+    /state change in progress/i.test(error.message)
+  );
+}
+
+function exitCodeFromDaytonaResult(value: unknown): number | null | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  return typeof record.exitCode === 'number' ? record.exitCode : undefined;
+}

--- a/packages/agents-extensions/test/sandbox/daytona.test.ts
+++ b/packages/agents-extensions/test/sandbox/daytona.test.ts
@@ -1,0 +1,1099 @@
+import {
+  Manifest,
+  SandboxProviderError,
+  SandboxUnsupportedFeatureError,
+} from '@openai/agents-core/sandbox';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  DaytonaCloudBucketMountStrategy,
+  DaytonaSandboxClient,
+} from '../../src/sandbox/daytona';
+import { resolvedRemotePathFromValidationCommand } from './remotePathValidation';
+
+const createMock = vi.fn();
+const getMock = vi.fn();
+const executeCommandMock = vi.fn();
+const createPtyMock = vi.fn();
+const createFolderMock = vi.fn();
+const uploadFileMock = vi.fn();
+const downloadFileMock = vi.fn();
+const deleteFileMock = vi.fn();
+const getSignedPreviewUrlMock = vi.fn();
+const startMock = vi.fn();
+const stopMock = vi.fn();
+const deleteMock = vi.fn();
+const daytonaConstructorMock = vi.fn();
+
+vi.mock('@daytonaio/sdk', () => ({
+  Daytona: class Daytona {
+    constructor(options?: Record<string, unknown>) {
+      daytonaConstructorMock(options);
+    }
+
+    create = createMock;
+    get = getMock;
+  },
+}));
+
+describe('DaytonaSandboxClient', () => {
+  beforeEach(() => {
+    createMock.mockReset();
+    getMock.mockReset();
+    executeCommandMock.mockReset();
+    createPtyMock.mockReset();
+    createFolderMock.mockReset();
+    uploadFileMock.mockReset();
+    downloadFileMock.mockReset();
+    deleteFileMock.mockReset();
+    getSignedPreviewUrlMock.mockReset();
+    startMock.mockReset();
+    stopMock.mockReset();
+    deleteMock.mockReset();
+    daytonaConstructorMock.mockReset();
+
+    const sandbox = {
+      id: 'daytona-test',
+      start: startMock,
+      stop: stopMock,
+      delete: deleteMock,
+      fs: {
+        createFolder: createFolderMock,
+        uploadFile: uploadFileMock,
+        downloadFile: downloadFileMock,
+        deleteFile: deleteFileMock,
+      },
+      process: {
+        executeCommand: executeCommandMock,
+        createPty: createPtyMock,
+      },
+      getSignedPreviewUrl: getSignedPreviewUrlMock,
+    };
+
+    createMock.mockResolvedValue(sandbox);
+    getMock.mockResolvedValue(sandbox);
+    executeCommandMock.mockImplementation(async (command: string) => {
+      const resolvedPath = resolvedRemotePathFromValidationCommand(command);
+      const stdout = resolvedPath ? `${resolvedPath}\n` : 'README.md\n';
+      return {
+        exitCode: 0,
+        result: stdout,
+        artifacts: { stdout },
+      };
+    });
+    createPtyMock.mockImplementation(async () => {
+      throw new Error('PTY not configured for this test.');
+    });
+    createFolderMock.mockResolvedValue(undefined);
+    uploadFileMock.mockResolvedValue(undefined);
+    downloadFileMock.mockResolvedValue(Buffer.from('# Hello\n', 'utf8'));
+    deleteFileMock.mockResolvedValue(undefined);
+    getSignedPreviewUrlMock.mockResolvedValue({
+      url: 'https://3000-daytona.example.test/signed?token=abc',
+    });
+    startMock.mockResolvedValue(undefined);
+    stopMock.mockResolvedValue(undefined);
+    deleteMock.mockResolvedValue(undefined);
+  });
+
+  test('rejects unsupported core create options instead of ignoring them', async () => {
+    const client = new DaytonaSandboxClient();
+
+    await expect(
+      client.create({
+        manifest: new Manifest(),
+        snapshot: { type: 'remote' },
+      }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+    await expect(
+      client.create({
+        manifest: new Manifest(),
+        concurrencyLimits: { manifestEntries: 2 },
+      }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('creates a sandbox, remaps the default root, and executes commands', async () => {
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          'README.md': {
+            type: 'file',
+            content: '# Hello\n',
+          },
+        },
+      }),
+    );
+    const output = await session.execCommand({ cmd: 'ls' });
+
+    expect(session.state.manifest.root).toBe('/home/daytona/workspace');
+    expect(executeCommandMock).toHaveBeenNthCalledWith(
+      1,
+      "mkdir -p -- '/home/daytona/workspace'",
+      '/',
+      {},
+    );
+    expect(uploadFileMock).toHaveBeenCalledWith(
+      Buffer.from('# Hello\n'),
+      '/home/daytona/workspace/README.md',
+    );
+    expect(executeCommandMock).toHaveBeenCalledWith(
+      'ls',
+      '/home/daytona/workspace',
+      {},
+    );
+    expect(output).toContain('README.md');
+  });
+
+  test('cleans up when workspace root preparation fails', async () => {
+    executeCommandMock.mockResolvedValueOnce({
+      exitCode: 1,
+      result: 'mkdir failed',
+      artifacts: { stdout: 'mkdir failed' },
+    });
+    const client = new DaytonaSandboxClient();
+
+    await expect(client.create(new Manifest())).rejects.toThrow(
+      /failed to prepare the workspace root/,
+    );
+
+    expect(deleteMock).toHaveBeenCalledOnce();
+  });
+
+  test('rejects unsupported manifest metadata after remapping the default root', async () => {
+    const client = new DaytonaSandboxClient();
+
+    await expect(
+      client.create(
+        new Manifest({
+          extraPathGrants: [{ path: '/tmp/data' }],
+        }),
+      ),
+    ).rejects.toThrow(/does not support extra path grants yet/);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('remaps default manifest roots when applying manifests to sessions', async () => {
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest());
+    uploadFileMock.mockClear();
+
+    await session.applyManifest(
+      new Manifest({
+        entries: {
+          'next.txt': {
+            type: 'file',
+            content: 'next\n',
+          },
+        },
+      }),
+    );
+
+    expect(uploadFileMock).toHaveBeenCalledWith(
+      Buffer.from('next\n'),
+      '/home/daytona/workspace/next.txt',
+    );
+    expect(session.state.manifest.root).toBe('/home/daytona/workspace');
+    expect(session.state.manifest.entries).toHaveProperty('next.txt');
+  });
+
+  test('rejects applyManifest roots that differ from the session root', async () => {
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest());
+    uploadFileMock.mockClear();
+
+    await expect(
+      session.applyManifest(
+        new Manifest({
+          root: '/tmp',
+          entries: {
+            'outside.txt': {
+              type: 'file',
+              content: 'outside\n',
+            },
+          },
+        }),
+      ),
+    ).rejects.toThrow(/different root than the active session/);
+
+    expect(uploadFileMock).not.toHaveBeenCalled();
+    expect(session.state.manifest.root).toBe('/home/daytona/workspace');
+    expect(session.state.manifest.entries).not.toHaveProperty('outside.txt');
+  });
+
+  test('does not pass yield_time_ms as the provider command timeout', async () => {
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest());
+
+    await session.execCommand({ cmd: 'sleep 30', yieldTimeMs: 10_000 });
+
+    expect(executeCommandMock).toHaveBeenLastCalledWith(
+      'sleep 30',
+      '/home/daytona/workspace',
+      {},
+    );
+  });
+
+  test('uses remote shell file operations for editor reads and writes', async () => {
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest());
+    executeCommandMock.mockClear();
+    downloadFileMock.mockClear();
+    uploadFileMock.mockClear();
+
+    executeCommandMock.mockImplementation(async (command: string) => {
+      if (command.includes('resolve-workspace-path.sh')) {
+        return {
+          exitCode: 0,
+          result: '/home/daytona/workspace/link.txt\n',
+          artifacts: { stdout: '/home/daytona/workspace/link.txt\n' },
+        };
+      }
+
+      if (command.includes('base64 <&3')) {
+        const stdout = Buffer.from('# Hello\n', 'utf8').toString('base64');
+        return {
+          exitCode: 0,
+          result: stdout,
+          artifacts: { stdout },
+        };
+      }
+
+      return {
+        exitCode: 0,
+        result: '',
+        artifacts: { stdout: '' },
+      };
+    });
+
+    await session.createEditor().updateFile({
+      type: 'update_file',
+      path: 'link.txt',
+      diff: '-# Hello\n+# Safe\n',
+    });
+
+    expect(
+      executeCommandMock.mock.calls.some(([command]) =>
+        String(command).includes('/proc/$$/fd/3'),
+      ),
+    ).toBe(true);
+    expect(
+      executeCommandMock.mock.calls.some(([command]) =>
+        String(command).includes('mktemp "$resolved_parent'),
+      ),
+    ).toBe(true);
+    expect(
+      executeCommandMock.mock.calls.some(([command]) =>
+        String(command).includes('if [ -d "$target" ]'),
+      ),
+    ).toBe(true);
+    expect(
+      executeCommandMock.mock.calls.some(([command]) =>
+        String(command).includes('mv -f -- "$tmp" "$target"'),
+      ),
+    ).toBe(true);
+    expect(downloadFileMock).not.toHaveBeenCalled();
+    expect(uploadFileMock).not.toHaveBeenCalled();
+  });
+
+  test('uses remote shell directory creation for nested editor writes', async () => {
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest());
+    executeCommandMock.mockClear();
+    createFolderMock.mockClear();
+    uploadFileMock.mockClear();
+
+    executeCommandMock.mockImplementation(async (command: string) => {
+      if (command.includes('test -e ')) {
+        return {
+          exitCode: 1,
+          result: '',
+          artifacts: { stdout: '' },
+        };
+      }
+      const resolvedPath = resolvedRemotePathFromValidationCommand(command);
+      if (resolvedPath) {
+        return {
+          exitCode: 0,
+          result: `${resolvedPath}\n`,
+          artifacts: { stdout: `${resolvedPath}\n` },
+        };
+      }
+
+      return {
+        exitCode: 0,
+        result: '',
+        artifacts: { stdout: '' },
+      };
+    });
+
+    await session.createEditor().createFile({
+      type: 'create_file',
+      path: 'nested/new.txt',
+      diff: '+hello',
+    });
+
+    expect(
+      executeCommandMock.mock.calls.some(([command]) =>
+        String(command).includes('mkdir -p -- "$resolved_path"'),
+      ),
+    ).toBe(true);
+    expect(createFolderMock).not.toHaveBeenCalled();
+    expect(uploadFileMock).not.toHaveBeenCalled();
+  });
+
+  test('uses remote shell file operation for image reads', async () => {
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest());
+    const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    executeCommandMock.mockClear();
+    downloadFileMock.mockClear();
+
+    executeCommandMock.mockImplementation(async (command: string) => {
+      if (command.includes('base64 <&3')) {
+        const stdout = pngBytes.toString('base64');
+        return {
+          exitCode: 0,
+          result: stdout,
+          artifacts: { stdout },
+        };
+      }
+
+      return {
+        exitCode: 0,
+        result: '',
+        artifacts: { stdout: '' },
+      };
+    });
+
+    const image = await session.viewImage({ path: 'image.png' });
+
+    const readCommand = executeCommandMock.mock.calls
+      .map(([command]) => String(command))
+      .find((command) => command.includes('base64 <&3'));
+    expect(readCommand).toContain('resolved=$(readlink -f -- "$path")');
+    expect(readCommand).toContain('exec 3< "$resolved"');
+    expect(readCommand).toContain('[ -f "$resolved" ]');
+    expect(
+      readCommand?.indexOf('resolved=$(readlink -f -- "$path")'),
+    ).toBeLessThan(readCommand?.indexOf('exec 3< "$resolved"') ?? -1);
+    expect(
+      executeCommandMock.mock.calls.some(([command]) =>
+        String(command).includes('/proc/$$/fd/3'),
+      ),
+    ).toBe(true);
+    expect(downloadFileMock).not.toHaveBeenCalled();
+    if (
+      !image.image ||
+      typeof image.image !== 'object' ||
+      !('mediaType' in image.image)
+    ) {
+      throw new Error('Expected viewImage to return inline image data.');
+    }
+    expect(image.image.mediaType).toBe('image/png');
+  });
+
+  test('reuses resolved manifest environment values during create', async () => {
+    let tokenVersion = 0;
+    const resolveToken = vi.fn(async () => `token-${++tokenVersion}`);
+    const client = new DaytonaSandboxClient({
+      env: {
+        CLIENT_ENV: 'client',
+      },
+    });
+
+    const session = await client.create(
+      new Manifest({
+        environment: {
+          TOKEN: {
+            value: 'placeholder',
+            resolve: resolveToken,
+          },
+        },
+      }),
+    );
+
+    expect(resolveToken).toHaveBeenCalledOnce();
+    expect(createMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        envVars: {
+          CLIENT_ENV: 'client',
+          TOKEN: 'token-1',
+        },
+      }),
+    );
+    expect(session.state.environment).toEqual({
+      CLIENT_ENV: 'client',
+      TOKEN: 'token-1',
+    });
+  });
+
+  test('maps sandboxSnapshotName to the Daytona snapshot create field', async () => {
+    const client = new DaytonaSandboxClient({
+      image: 'node:22',
+      resources: { cpu: 2 },
+      sandboxSnapshotName: 'snapshot-test',
+    });
+
+    await client.create(new Manifest());
+
+    const createParams = createMock.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(createParams).toEqual(
+      expect.objectContaining({
+        snapshot: 'snapshot-test',
+      }),
+    );
+    expect(createParams).not.toHaveProperty('sandboxSnapshotName');
+    expect(createParams).not.toHaveProperty('image');
+    expect(createParams).not.toHaveProperty('resources');
+  });
+
+  test('rejects PTY execution when the SDK PTY API is unavailable', async () => {
+    createMock.mockResolvedValueOnce({
+      id: 'daytona-test',
+      start: startMock,
+      stop: stopMock,
+      delete: deleteMock,
+      fs: {
+        createFolder: createFolderMock,
+        uploadFile: uploadFileMock,
+        downloadFile: downloadFileMock,
+        deleteFile: deleteFileMock,
+      },
+      process: {
+        executeCommand: executeCommandMock,
+      },
+      getSignedPreviewUrl: getSignedPreviewUrlMock,
+    });
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest());
+
+    await expect(
+      session.execCommand({ cmd: 'sh', tty: true }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+  });
+
+  test('supports PTY execution and stdin through the Daytona SDK', async () => {
+    let onData!: (data: Uint8Array | string) => void;
+    let finishWait!: (result: { exitCode: number }) => void;
+    createPtyMock.mockImplementationOnce(
+      async (options: Record<string, unknown>) => {
+        onData = options.onData as (data: Uint8Array | string) => void;
+        return {
+          sessionId: options.id,
+          waitForConnection: async () => {},
+          sendInput: async (data: string | Uint8Array) => {
+            onData(
+              typeof data === 'string' ? data : new TextDecoder().decode(data),
+            );
+          },
+          wait: async () =>
+            await new Promise<{ exitCode: number }>((resolve) => {
+              finishWait = resolve;
+            }),
+          kill: async () => {},
+          disconnect: async () => {},
+        };
+      },
+    );
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest());
+
+    const started = await session.execCommand({
+      cmd: 'echo ready',
+      tty: true,
+      yieldTimeMs: 250,
+    });
+    const sessionId = Number(
+      started.match(/Process running with session ID (\d+)/)?.[1],
+    );
+    const next = await session.writeStdin({
+      sessionId,
+      chars: 'echo next\n',
+      yieldTimeMs: 250,
+    });
+    finishWait({ exitCode: 0 });
+    const done = await session.writeStdin({
+      sessionId,
+      yieldTimeMs: 250,
+    });
+
+    expect(next).toContain('echo next');
+    expect(done).toContain('Process exited with code 0');
+    expect(createPtyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: '/home/daytona/workspace',
+        envs: {},
+        cols: 80,
+        rows: 24,
+      }),
+    );
+    expect(started).toContain('Process running with session ID');
+  });
+
+  test('rejects PTY handles without wait support', async () => {
+    const killMock = vi.fn();
+    const disconnectMock = vi.fn();
+    createPtyMock.mockResolvedValueOnce({
+      sendInput: async () => {},
+      kill: killMock,
+      disconnect: disconnectMock,
+    });
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest());
+
+    await expect(
+      session.execCommand({ cmd: 'sh', tty: true }),
+    ).rejects.toMatchObject({
+      details: {
+        provider: 'daytona',
+        feature: 'tty.wait',
+      },
+    });
+
+    expect(killMock).toHaveBeenCalledOnce();
+    expect(disconnectMock).toHaveBeenCalledOnce();
+  });
+
+  test('registers PTY handles before sending the initial command', async () => {
+    const killMock = vi.fn();
+    const disconnectMock = vi.fn();
+    createPtyMock.mockResolvedValueOnce({
+      waitForConnection: async () => {},
+      sendInput: async () => {
+        throw new Error('stdin failed');
+      },
+      wait: async () => await new Promise(() => {}),
+      kill: killMock,
+      disconnect: disconnectMock,
+    });
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest());
+
+    await expect(session.execCommand({ cmd: 'sh', tty: true })).rejects.toThrow(
+      'stdin failed',
+    );
+    await session.close();
+
+    expect(killMock).toHaveBeenCalledOnce();
+    expect(disconnectMock).toHaveBeenCalledOnce();
+  });
+
+  test('serializes runtime env overrides for session resume', async () => {
+    const client = new DaytonaSandboxClient({
+      env: { API_KEY: 'client-secret' },
+    });
+    const session = await client.create(
+      new Manifest({
+        environment: {
+          SAFE: 'manifest',
+        },
+      }),
+    );
+
+    const serialized = await client.serializeSessionState(session.state);
+    const restored = await client.deserializeSessionState(serialized);
+
+    expect(serialized.environment).toEqual({
+      API_KEY: 'client-secret',
+      SAFE: 'manifest',
+    });
+    expect(restored.environment).toEqual({
+      SAFE: 'manifest',
+      API_KEY: 'client-secret',
+    });
+  });
+
+  test('stops on close when pauseOnExit is enabled and resumes by id', async () => {
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest(), {
+      pauseOnExit: true,
+    });
+
+    await session.close();
+    await client.resume(session.state);
+
+    expect(stopMock).toHaveBeenCalledOnce();
+    expect(getMock).toHaveBeenCalledWith('daytona-test');
+    expect(startMock).toHaveBeenCalledOnce();
+    expect(executeCommandMock).toHaveBeenLastCalledWith(
+      "mkdir -p -- '/home/daytona/workspace'",
+      '/',
+      {},
+    );
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  test('starts sandboxes during resume even when pauseOnExit is false', async () => {
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest(), {
+      autoStopInterval: 10,
+    });
+
+    await client.resume(session.state);
+
+    expect(getMock).toHaveBeenCalledWith('daytona-test');
+    expect(startMock).toHaveBeenCalledOnce();
+  });
+
+  test('rematerializes cloud bucket mounts when resuming auto-stopped sandboxes', async () => {
+    const client = new DaytonaSandboxClient();
+    const manifest = new Manifest({
+      entries: {
+        data: {
+          type: 's3_mount',
+          bucket: 'agent-logs',
+          accessKeyId: 'access-key',
+          secretAccessKey: 'secret-key',
+          mountPath: 'mounted/logs',
+          mountStrategy: new DaytonaCloudBucketMountStrategy(),
+        },
+      },
+    });
+    const session = await client.create(manifest, {
+      autoStopInterval: 10,
+    });
+    executeCommandMock.mockClear();
+
+    await client.resume(session.state);
+
+    expect(startMock).toHaveBeenCalledOnce();
+    expect(
+      executeCommandMock.mock.calls.some(([command]) =>
+        String(command).includes('fusermount3 -u'),
+      ),
+    ).toBe(true);
+    expect(
+      executeCommandMock.mock.calls.some(([command]) =>
+        String(command).includes("'rclone' 'mount'"),
+      ),
+    ).toBe(true);
+    expect(
+      executeCommandMock.mock.calls.some(([command]) =>
+        String(command).includes('/home/daytona/workspace/mounted/logs'),
+      ),
+    ).toBe(true);
+  });
+
+  test('persists create-time client auth options for serialized resume', async () => {
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest(), {
+      apiKey: 'daytona-create-key',
+      apiUrl: 'https://daytona.example.test',
+      target: 'us',
+      pauseOnExit: true,
+    });
+    const serialized = await client.serializeSessionState(session.state);
+    const restoredClient = new DaytonaSandboxClient();
+    const restored = await restoredClient.deserializeSessionState(serialized);
+    daytonaConstructorMock.mockClear();
+
+    await restoredClient.resume(restored);
+
+    expect(serialized).toMatchObject({
+      apiKey: 'daytona-create-key',
+      apiUrl: 'https://daytona.example.test',
+      target: 'us',
+    });
+    expect(restored).toMatchObject({
+      apiKey: 'daytona-create-key',
+      apiUrl: 'https://daytona.example.test',
+      target: 'us',
+    });
+    expect(daytonaConstructorMock).toHaveBeenCalledWith({
+      apiKey: 'daytona-create-key',
+      apiUrl: 'https://daytona.example.test',
+      target: 'us',
+    });
+  });
+
+  test('delete terminates even when pauseOnExit is enabled', async () => {
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest(), {
+      pauseOnExit: true,
+    });
+
+    await session.delete();
+
+    expect(stopMock).not.toHaveBeenCalled();
+    expect(deleteMock).toHaveBeenCalledOnce();
+  });
+
+  test('does not delete twice across shutdown and delete lifecycle hooks', async () => {
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest());
+
+    await session.shutdown();
+    await session.delete();
+
+    expect(deleteMock).toHaveBeenCalledOnce();
+  });
+
+  test('deletes after pause shutdown when delete lifecycle hook runs', async () => {
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest(), {
+      pauseOnExit: true,
+    });
+
+    await session.shutdown();
+    await session.delete();
+
+    expect(stopMock).toHaveBeenCalledOnce();
+    expect(deleteMock).toHaveBeenCalledOnce();
+  });
+
+  test('retries delete while Daytona reports a state change in progress', async () => {
+    vi.useFakeTimers();
+    try {
+      const client = new DaytonaSandboxClient();
+      const session = await client.create(new Manifest());
+      const stateChangeError = Object.assign(
+        new Error('Sandbox state change in progress'),
+        { statusCode: 409 },
+      );
+      deleteMock
+        .mockRejectedValueOnce(stateChangeError)
+        .mockResolvedValueOnce(undefined);
+
+      const deletePromise = session.delete();
+      await vi.advanceTimersByTimeAsync(1_000);
+      await deletePromise;
+
+      expect(deleteMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('recreates paused sandboxes when resume start reports missing sandbox', async () => {
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest(), {
+      pauseOnExit: true,
+    });
+    createMock.mockClear();
+    startMock.mockRejectedValueOnce(new Error('sandbox not found'));
+
+    const recreated = await client.resume(session.state);
+
+    expect(getMock).toHaveBeenCalledWith('daytona-test');
+    expect(startMock).toHaveBeenCalledOnce();
+    expect(createMock).toHaveBeenCalledOnce();
+    expect(recreated.state.sandboxId).toBe('daytona-test');
+  });
+
+  test('preserves persisted environment when recreating resumed sandboxes', async () => {
+    let tokenVersion = 0;
+    const resolveToken = vi.fn(async () => `token-${++tokenVersion}`);
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(
+      new Manifest({
+        environment: {
+          TOKEN: {
+            value: 'placeholder',
+            resolve: resolveToken,
+          },
+        },
+      }),
+      { pauseOnExit: true },
+    );
+    createMock.mockClear();
+    startMock.mockRejectedValueOnce(new Error('sandbox not found'));
+
+    const recreated = await client.resume(session.state);
+
+    expect(resolveToken).toHaveBeenCalledOnce();
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        envVars: {
+          TOKEN: 'token-1',
+        },
+      }),
+      undefined,
+    );
+    expect(recreated.state.environment).toEqual({
+      TOKEN: 'token-1',
+    });
+  });
+
+  test('recreates sandboxes when resume lookup reports missing sandbox', async () => {
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest(), {
+      pauseOnExit: true,
+    });
+    createMock.mockClear();
+    getMock.mockRejectedValueOnce(new Error('sandbox missing'));
+
+    const recreated = await client.resume(session.state);
+
+    expect(getMock).toHaveBeenCalledWith('daytona-test');
+    expect(startMock).not.toHaveBeenCalled();
+    expect(createMock).toHaveBeenCalledOnce();
+    expect(recreated.state.sandboxId).toBe('daytona-test');
+  });
+
+  test('fails fast when resume lookup fails with a provider error', async () => {
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest(), {
+      pauseOnExit: true,
+    });
+    createMock.mockClear();
+    getMock.mockRejectedValueOnce(new Error('request timeout'));
+
+    let thrown: unknown;
+    try {
+      await client.resume(session.state);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(SandboxProviderError);
+    expect((thrown as SandboxProviderError).details).toMatchObject({
+      provider: 'daytona',
+      operation: 'resume',
+      sandboxId: 'daytona-test',
+      cause: 'request timeout',
+    });
+    expect(startMock).not.toHaveBeenCalled();
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('fails fast when resume start fails with a provider error', async () => {
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest(), {
+      pauseOnExit: true,
+    });
+    createMock.mockClear();
+    startMock.mockRejectedValueOnce(new Error('request timeout'));
+
+    let thrown: unknown;
+    try {
+      await client.resume(session.state);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(SandboxProviderError);
+    expect((thrown as SandboxProviderError).details).toMatchObject({
+      provider: 'daytona',
+      operation: 'resume',
+      sandboxId: 'daytona-test',
+      cause: 'request timeout',
+    });
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('fails fast when resume workspace root preparation fails', async () => {
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest(), {
+      pauseOnExit: true,
+    });
+    createMock.mockClear();
+    executeCommandMock.mockResolvedValueOnce({
+      exitCode: 1,
+      result: 'mkdir failed',
+      artifacts: { stdout: 'mkdir failed' },
+    });
+
+    let thrown: unknown;
+    try {
+      await client.resume(session.state);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(SandboxProviderError);
+    expect((thrown as SandboxProviderError).details).toMatchObject({
+      provider: 'daytona',
+      operation: 'prepare workspace root',
+      sandboxId: 'daytona-test',
+      root: '/home/daytona/workspace',
+      stdout: 'mkdir failed',
+    });
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('resolves configured exposed ports through signed preview URLs', async () => {
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest(), {
+      exposedPorts: [3000],
+      exposedPortUrlTtlS: 120,
+    });
+
+    const endpoint = await session.resolveExposedPort(3000);
+    const cachedEndpoint = await session.resolveExposedPort(3000);
+
+    expect(getSignedPreviewUrlMock).toHaveBeenCalledWith(3000, 120);
+    expect(getSignedPreviewUrlMock).toHaveBeenCalledOnce();
+    expect(endpoint).toMatchObject({
+      host: '3000-daytona.example.test',
+      port: 443,
+      tls: true,
+      query: 'token=abc',
+    });
+    expect(endpoint.daytonaExpiresAtMs).toEqual(expect.any(Number));
+    expect(cachedEndpoint).toBe(endpoint);
+    expect(session.state.exposedPorts?.['3000']).toBe(endpoint);
+  });
+
+  test('refreshes expired Daytona signed preview URLs', async () => {
+    getSignedPreviewUrlMock
+      .mockResolvedValueOnce({
+        url: 'https://3000-daytona.example.test/signed?token=first',
+      })
+      .mockResolvedValueOnce({
+        url: 'https://3000-daytona.example.test/signed?token=second',
+      });
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest(), {
+      exposedPorts: [3000],
+      exposedPortUrlTtlS: 120,
+    });
+
+    const firstEndpoint = await session.resolveExposedPort(3000);
+    session.state.exposedPorts!['3000']!.daytonaExpiresAtMs = Date.now() - 1;
+    const secondEndpoint = await session.resolveExposedPort(3000);
+
+    expect(getSignedPreviewUrlMock).toHaveBeenCalledTimes(2);
+    expect(firstEndpoint.query).toBe('token=first');
+    expect(secondEndpoint.query).toBe('token=second');
+    expect(secondEndpoint).not.toBe(firstEndpoint);
+    expect(session.state.exposedPorts?.['3000']).toBe(secondEndpoint);
+  });
+
+  test('clears cached signed preview URLs when recreating a sandbox', async () => {
+    getSignedPreviewUrlMock
+      .mockResolvedValueOnce({
+        url: 'https://3000-daytona.example.test/signed?token=first',
+      })
+      .mockResolvedValueOnce({
+        url: 'https://3000-daytona.example.test/signed?token=second',
+      });
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest(), {
+      exposedPorts: [3000],
+      exposedPortUrlTtlS: 120,
+      pauseOnExit: true,
+    });
+    const firstEndpoint = await session.resolveExposedPort(3000);
+    createMock.mockClear();
+    startMock.mockRejectedValueOnce(new Error('sandbox not found'));
+
+    const recreated = await client.resume(session.state);
+    const secondEndpoint = await recreated.resolveExposedPort(3000);
+
+    expect(createMock).toHaveBeenCalledOnce();
+    expect(getSignedPreviewUrlMock).toHaveBeenCalledTimes(2);
+    expect(firstEndpoint.query).toBe('token=first');
+    expect(secondEndpoint.query).toBe('token=second');
+    expect(recreated.state.exposedPorts?.['3000']).toBe(secondEndpoint);
+  });
+
+  test('expires Daytona signed preview URL cache when TTL is implicit', async () => {
+    getSignedPreviewUrlMock
+      .mockResolvedValueOnce({
+        url: 'https://3000-daytona.example.test/signed?token=first',
+      })
+      .mockResolvedValueOnce({
+        url: 'https://3000-daytona.example.test/signed?token=second',
+      });
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest(), {
+      exposedPorts: [3000],
+    });
+
+    const firstEndpoint = await session.resolveExposedPort(3000);
+    session.state.exposedPorts!['3000']!.daytonaExpiresAtMs = Date.now() - 1;
+    const secondEndpoint = await session.resolveExposedPort(3000);
+
+    expect(getSignedPreviewUrlMock).toHaveBeenCalledWith(3000, undefined);
+    expect(getSignedPreviewUrlMock).toHaveBeenCalledTimes(2);
+    expect(firstEndpoint.daytonaExpiresAtMs).toEqual(expect.any(Number));
+    expect(firstEndpoint.query).toBe('token=first');
+    expect(secondEndpoint.query).toBe('token=second');
+    expect(secondEndpoint).not.toBe(firstEndpoint);
+  });
+
+  test('mounts cloud buckets with the Daytona rclone mount strategy', async () => {
+    const client = new DaytonaSandboxClient();
+
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          data: {
+            type: 's3_mount',
+            bucket: 'agent-logs',
+            accessKeyId: 'access-key',
+            secretAccessKey: 'secret-key',
+            mountPath: 'mounted/logs',
+            mountStrategy: new DaytonaCloudBucketMountStrategy(),
+          },
+        },
+      }),
+    );
+    await session.close();
+
+    expect(
+      executeCommandMock.mock.calls.some(([command]) =>
+        String(command).includes("'rclone' 'mount'"),
+      ),
+    ).toBe(true);
+    expect(
+      executeCommandMock.mock.calls.some(([command]) =>
+        String(command).includes('/home/daytona/workspace/mounted/logs'),
+      ),
+    ).toBe(true);
+    expect(
+      executeCommandMock.mock.calls.some(([command]) =>
+        String(command).includes('fusermount3 -u'),
+      ),
+    ).toBe(true);
+    const privilegedFuseCommand = executeCommandMock.mock.calls
+      .map(([command]) => String(command))
+      .find((command) => command.includes('chmod a+rw /dev/fuse'));
+    expect(privilegedFuseCommand).toContain("target_user='root'");
+    expect(privilegedFuseCommand).toContain(
+      'sudo -n -u "$target_user" -- sh -lc',
+    );
+  });
+
+  test('rematerializes cloud bucket mounts when resuming paused sandboxes', async () => {
+    const client = new DaytonaSandboxClient();
+    const manifest = new Manifest({
+      entries: {
+        data: {
+          type: 's3_mount',
+          bucket: 'agent-logs',
+          accessKeyId: 'access-key',
+          secretAccessKey: 'secret-key',
+          mountPath: 'mounted/logs',
+          mountStrategy: new DaytonaCloudBucketMountStrategy(),
+        },
+      },
+    });
+
+    const session = await client.create(manifest, {
+      pauseOnExit: true,
+    });
+    await session.close();
+    executeCommandMock.mockClear();
+
+    await client.resume(session.state);
+
+    expect(startMock).toHaveBeenCalledOnce();
+    expect(
+      executeCommandMock.mock.calls.some(([command]) =>
+        String(command).includes("'rclone' 'mount'"),
+      ),
+    ).toBe(true);
+    expect(
+      executeCommandMock.mock.calls.some(([command]) =>
+        String(command).includes('/home/daytona/workspace/mounted/logs'),
+      ),
+    ).toBe(true);
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This pull request adds a sandbox provider as part of agents-extensions package: https://developers.openai.com/api/docs/guides/agents/sandboxes
How to run:
```zsh
git clone https://github.com/openai/openai-agents-js
cd openai-agents-js/
git checkout feat/sandbox-agents-daytona
pnpm i
pnpm build
pnpm -F sandbox start:daytona
```