### PR TITLE
feat(sandbox): add Cloudflare provider

### DIFF
--- a/.changeset/sandbox-agents-cloudflare.md
+++ b/.changeset/sandbox-agents-cloudflare.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': minor
+---
+
+feat: add Cloudflare sandbox provider

--- a/examples/sandbox/extensions/cloudflare-runner.ts
+++ b/examples/sandbox/extensions/cloudflare-runner.ts
@@ -1,0 +1,93 @@
+import { Runner } from '@openai/agents';
+import { CloudflareSandboxClient } from '@openai/agents-extensions/sandbox/cloudflare';
+import { Manifest, SandboxAgent, shell } from '@openai/agents/sandbox';
+import { finished } from 'node:stream/promises';
+import {
+  DEFAULT_MODEL,
+  getStringArg,
+  hasFlag,
+  getOptionalStringArg,
+  requireEnv,
+  requireOpenAIKey,
+  runExampleMain,
+} from '../support';
+
+const DEFAULT_QUESTION =
+  'Summarize this cloud sandbox workspace in 2 sentences.';
+
+// This example expects a worker created from the Cloudflare Sandbox bridge template:
+// `npm create cloudflare@latest -- my-sandbox --template=cloudflare/sandbox-sdk/bridge/worker`
+// A generic Worker URL will not expose the sandbox bridge endpoints this client needs.
+
+function buildManifest(): Manifest {
+  return new Manifest({
+    entries: {
+      'README.md': {
+        type: 'file',
+        content: `# Cloudflare Demo Workspace
+
+This workspace exists to validate the Cloudflare sandbox backend manually.
+`,
+      },
+      'incident.md': {
+        type: 'file',
+        content: `# Incident
+
+- Customer: Fabrikam Retail.
+- Issue: delayed reporting rollout.
+- Primary blocker: incomplete security questionnaire.
+`,
+      },
+      'plan.md': {
+        type: 'file',
+        content: `# Plan
+
+1. Close the questionnaire.
+2. Reconfirm the rollout date with the customer.
+`,
+      },
+    },
+  });
+}
+
+async function main() {
+  requireOpenAIKey();
+
+  const model = getStringArg('--model', DEFAULT_MODEL);
+  const question = getStringArg('--question', DEFAULT_QUESTION);
+  const workerUrl =
+    getOptionalStringArg('--worker-url') ??
+    requireEnv('CLOUDFLARE_SANDBOX_WORKER_URL');
+  const apiKey =
+    getOptionalStringArg('--api-key') ?? process.env.CLOUDFLARE_SANDBOX_API_KEY;
+  const stream = hasFlag('--stream');
+  const client = new CloudflareSandboxClient({ workerUrl, apiKey });
+  const agent = new SandboxAgent({
+    name: 'Cloudflare Sandbox Assistant',
+    model,
+    instructions:
+      'Answer questions about the sandbox workspace. Inspect the files before answering, keep the response concise, and cite the file names you inspected.',
+    defaultManifest: buildManifest(),
+    capabilities: [shell()],
+  });
+  const runner = new Runner({
+    workflowName: 'Cloudflare sandbox example',
+    sandbox: { client },
+  });
+
+  if (!stream) {
+    const result = await runner.run(agent, question);
+    console.log(result.finalOutput);
+    return;
+  }
+
+  const result = await runner.run(agent, question, { stream: true });
+  process.stdout.write('assistant> ');
+  const textStream = result.toTextStream({ compatibleWithNodeStreams: true });
+  textStream.pipe(process.stdout);
+  await finished(textStream);
+  await result.completed;
+  process.stdout.write('\n');
+}
+
+await runExampleMain(main);

--- a/packages/agents-extensions/src/sandbox/cloudflare/index.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/index.ts
@@ -1,0 +1,2 @@
+export * from './sandbox';
+export * from './mounts';

--- a/packages/agents-extensions/src/sandbox/cloudflare/mounts.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/mounts.ts
@@ -191,11 +191,7 @@ function isGCSMount(entry: Entry): entry is GCSMount {
 }
 
 function normalizePrefix(prefix: string | undefined): string | undefined {
-  if (prefix === undefined) {
-    return undefined;
-  }
-  const trimmed = prefix.replace(/^\/+|\/+$/gu, '');
-  return trimmed ? `/${trimmed}/` : '/';
+  return prefix;
 }
 
 function buildCredentials(args: {

--- a/packages/agents-extensions/src/sandbox/cloudflare/mounts.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/mounts.ts
@@ -1,0 +1,230 @@
+import {
+  SandboxMountError,
+  SandboxUnsupportedFeatureError,
+  type Entry,
+  type GCSMount,
+  type R2Mount,
+  type S3Mount,
+  type TypedMount,
+} from '@openai/agents-core/sandbox';
+import { readOptionalString } from '../shared/typeGuards';
+
+export type CloudflareBucketProvider = 'r2' | 's3' | 'gcs';
+
+export type CloudflareBucketMountCredentials = {
+  accessKeyId: string;
+  secretAccessKey: string;
+};
+
+export type CloudflareBucketMountConfig = {
+  bucketName: string;
+  bucketEndpointUrl: string;
+  provider: CloudflareBucketProvider;
+  keyPrefix?: string;
+  credentials?: CloudflareBucketMountCredentials;
+  readOnly: boolean;
+};
+
+export type CloudflareBucketMountRequestOptions = {
+  endpoint: string;
+  provider: CloudflareBucketProvider;
+  readOnly: boolean;
+  prefix?: string;
+  credentials?: CloudflareBucketMountCredentials;
+};
+
+export class CloudflareBucketMountStrategy {
+  readonly [key: string]: unknown;
+  readonly type = 'cloudflare_bucket_mount';
+}
+
+export function buildCloudflareBucketMountConfig(
+  mount: Entry,
+): CloudflareBucketMountConfig {
+  if (isS3Mount(mount)) {
+    const accessKeyId = readOptionalString(mount, 'accessKeyId');
+    const secretAccessKey = readOptionalString(mount, 'secretAccessKey');
+    const sessionToken = readOptionalString(mount, 'sessionToken');
+    validateCredentialPair({
+      accessKeyId,
+      secretAccessKey,
+      mountType: mount.type,
+    });
+    if (sessionToken) {
+      throw new SandboxUnsupportedFeatureError(
+        'Cloudflare bucket mounts do not support S3 sessionToken credentials.',
+        {
+          provider: 'cloudflare',
+          feature: 's3.sessionToken',
+          mountType: mount.type,
+        },
+      );
+    }
+    return {
+      bucketName: mount.bucket,
+      bucketEndpointUrl:
+        mount.endpointUrl ??
+        (mount.region
+          ? `https://s3.${mount.region}.amazonaws.com`
+          : 'https://s3.amazonaws.com'),
+      provider: 's3',
+      keyPrefix: normalizePrefix(mount.prefix),
+      credentials: buildCredentials({
+        accessKeyId,
+        secretAccessKey,
+        mountType: mount.type,
+      }),
+      readOnly: mount.readOnly ?? true,
+    };
+  }
+
+  if (isR2Mount(mount)) {
+    const accessKeyId = readOptionalString(mount, 'accessKeyId');
+    const secretAccessKey = readOptionalString(mount, 'secretAccessKey');
+    const customDomain = readOptionalString(mount, 'customDomain');
+    validateCredentialPair({
+      accessKeyId,
+      secretAccessKey,
+      mountType: mount.type,
+    });
+    if (!customDomain && !mount.accountId) {
+      throw new SandboxMountError(
+        'Cloudflare R2 bucket mounts require accountId or customDomain.',
+        {
+          provider: 'cloudflare',
+          mountType: mount.type,
+        },
+      );
+    }
+    return {
+      bucketName: mount.bucket,
+      bucketEndpointUrl:
+        customDomain ?? `https://${mount.accountId}.r2.cloudflarestorage.com`,
+      provider: 'r2',
+      keyPrefix: normalizePrefix(mount.prefix),
+      credentials: buildCredentials({
+        accessKeyId,
+        secretAccessKey,
+        mountType: mount.type,
+      }),
+      readOnly: mount.readOnly ?? true,
+    };
+  }
+
+  if (isGCSMount(mount)) {
+    const accessId = readOptionalString(mount, 'accessId');
+    const secretAccessKey = readOptionalString(mount, 'secretAccessKey');
+    const endpointUrl = readOptionalString(mount, 'endpointUrl');
+    if (!accessId || !secretAccessKey) {
+      throw new SandboxMountError(
+        'Cloudflare GCS bucket mounts require accessId and secretAccessKey.',
+        {
+          provider: 'cloudflare',
+          mountType: mount.type,
+        },
+      );
+    }
+    return {
+      bucketName: mount.bucket,
+      bucketEndpointUrl: endpointUrl ?? 'https://storage.googleapis.com',
+      provider: 'gcs',
+      keyPrefix: normalizePrefix(mount.prefix),
+      credentials: {
+        accessKeyId: accessId,
+        secretAccessKey,
+      },
+      readOnly: mount.readOnly ?? true,
+    };
+  }
+
+  throw new SandboxUnsupportedFeatureError(
+    'Cloudflare bucket mounts are not supported for this mount type.',
+    {
+      provider: 'cloudflare',
+      feature: 'entry.mount',
+      mountType: String((mount as { type?: unknown }).type ?? 'unknown'),
+    },
+  );
+}
+
+export function cloudflareBucketMountRequestOptions(
+  config: CloudflareBucketMountConfig,
+): CloudflareBucketMountRequestOptions {
+  return {
+    endpoint: config.bucketEndpointUrl,
+    provider: config.provider,
+    readOnly: config.readOnly,
+    ...(config.keyPrefix ? { prefix: config.keyPrefix } : {}),
+    ...(config.credentials ? { credentials: config.credentials } : {}),
+  };
+}
+
+export function isCloudflareBucketMountEntry(
+  entry: Entry,
+): entry is TypedMount {
+  return (
+    isTypedBucketMount(entry) &&
+    entry.mountStrategy?.type === 'cloudflare_bucket_mount'
+  );
+}
+
+function isTypedBucketMount(
+  entry: Entry,
+): entry is S3Mount | R2Mount | GCSMount {
+  return (
+    entry.type === 's3_mount' ||
+    entry.type === 'r2_mount' ||
+    entry.type === 'gcs_mount'
+  );
+}
+
+function isS3Mount(entry: Entry): entry is S3Mount {
+  return entry.type === 's3_mount';
+}
+
+function isR2Mount(entry: Entry): entry is R2Mount {
+  return entry.type === 'r2_mount';
+}
+
+function isGCSMount(entry: Entry): entry is GCSMount {
+  return entry.type === 'gcs_mount';
+}
+
+function normalizePrefix(prefix: string | undefined): string | undefined {
+  if (prefix === undefined) {
+    return undefined;
+  }
+  const trimmed = prefix.replace(/^\/+|\/+$/gu, '');
+  return trimmed ? `/${trimmed}/` : '/';
+}
+
+function buildCredentials(args: {
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  mountType: string;
+}): CloudflareBucketMountCredentials | undefined {
+  validateCredentialPair(args);
+  if (!args.accessKeyId || !args.secretAccessKey) {
+    return undefined;
+  }
+  return {
+    accessKeyId: args.accessKeyId,
+    secretAccessKey: args.secretAccessKey,
+  };
+}
+
+function validateCredentialPair(args: {
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  mountType: string;
+}): void {
+  if (Boolean(args.accessKeyId) !== Boolean(args.secretAccessKey)) {
+    throw new SandboxMountError(
+      'Cloudflare bucket mounts require both accessKeyId and secretAccessKey when either is provided.',
+      {
+        provider: 'cloudflare',
+        mountType: args.mountType,
+      },
+    );
+  }
+}

--- a/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
@@ -1,0 +1,1574 @@
+import { UserError, type ToolOutputImage } from '@openai/agents-core';
+import { loadEnv } from '@openai/agents-core/_shims';
+import {
+  Manifest,
+  SandboxArchiveError,
+  SandboxMountError,
+  SandboxProviderError,
+  SandboxUnsupportedFeatureError,
+  SandboxWorkspaceReadNotFoundError,
+  normalizeSandboxClientCreateArgs,
+  type SandboxClient,
+  type SandboxClientCreateArgs,
+  type SandboxClientOptions,
+  type ExposedPortEndpoint,
+  type ExecCommandArgs,
+  type MaterializeEntryArgs,
+  type Mount,
+  type SandboxSession,
+  type SandboxSessionState,
+  type TypedMount,
+  type ViewImageArgs,
+  type WriteStdinArgs,
+  type WorkspaceArchiveData,
+} from '@openai/agents-core/sandbox';
+import {
+  assertTarWorkspacePersistence,
+  toWorkspaceArchiveBytes,
+  validateWorkspaceTarArchive,
+} from '../shared/archive';
+import { RemoteSandboxEditor } from '../shared/editor';
+import {
+  assertShellEnvironmentName,
+  materializeEnvironment,
+} from '../shared/environment';
+import {
+  applyInlineManifestEntryToState,
+  applyInlineManifestToState,
+  entryContainsLocalSource,
+  manifestContainsLocalSource,
+} from '../shared/manifest';
+import { imageOutputFromBytes } from '../shared/media';
+import {
+  assertSandboxEntryMetadataSupported,
+  assertSandboxManifestMetadataSupported,
+  MOUNT_MANIFEST_METADATA_SUPPORT,
+} from '../shared/metadata';
+import {
+  elapsedSeconds,
+  formatExecResponse,
+  truncateOutput,
+} from '../shared/output';
+import { assertConfiguredExposedPort } from '../shared/ports';
+import {
+  addPtyWebSocketListener,
+  appendPtyOutput,
+  createPtyProcessEntry,
+  formatPtyExecUpdate,
+  markPtyDone,
+  openPtyWebSocket,
+  PtyProcessRegistry,
+  shellCommandForPty,
+  writePtyStdin,
+  type PtyProcessEntry,
+  type PtyWebSocket,
+} from '../shared/pty';
+import {
+  posixDirname,
+  resolveSandboxWorkdir,
+  shellQuote,
+  validateRemoteSandboxPathForManifest,
+} from '../shared/paths';
+import {
+  assertCoreConcurrencyLimitsUnsupported,
+  assertCoreSnapshotUnsupported,
+  assertRunAsUnsupported,
+  closeRemoteSessionOnManifestError,
+  withProviderError,
+  withSandboxSpan,
+} from '../shared/session';
+import {
+  deserializeRemoteSandboxSessionStateValues,
+  serializeRemoteSandboxSessionState,
+} from '../shared/sessionState';
+import {
+  isRecord,
+  readOptionalNumber,
+  readOptionalNumberArray,
+  readOptionalRecordArray,
+  readString,
+} from '../shared/typeGuards';
+import {
+  type RemoteManifestWriter,
+  type RemoteSandboxPathOptions,
+  type RemoteSandboxPathResolver,
+} from '../shared/types';
+import {
+  buildCloudflareBucketMountConfig,
+  cloudflareBucketMountRequestOptions,
+  isCloudflareBucketMountEntry,
+  type CloudflareBucketMountRequestOptions,
+} from './mounts';
+
+export interface CloudflareSandboxClientOptions extends SandboxClientOptions {
+  workerUrl: string;
+  apiKey?: string;
+  exposedPorts?: number[];
+  timeoutMs?: number;
+  createTimeoutMs?: number;
+  requestTimeoutMs?: number;
+  timeouts?: CloudflareSandboxTimeouts;
+  mounts?: Array<Record<string, unknown>>;
+}
+
+export interface CloudflareSandboxTimeouts {
+  execTimeoutMs?: number;
+  createTimeoutMs?: number;
+  requestTimeoutMs?: number;
+}
+
+export interface CloudflareSandboxSessionState extends SandboxSessionState {
+  workerUrl: string;
+  sandboxId: string;
+  configuredExposedPorts?: number[];
+  timeoutMs?: number;
+  createTimeoutMs?: number;
+  requestTimeoutMs?: number;
+  timeouts?: CloudflareSandboxTimeouts;
+  mounts?: Array<Record<string, unknown>>;
+  environment: Record<string, string>;
+}
+
+export class CloudflareSandboxSession implements SandboxSession<CloudflareSandboxSessionState> {
+  readonly state: CloudflareSandboxSessionState;
+  private readonly apiKey?: string;
+  private readonly ptyProcesses = new PtyProcessRegistry();
+  private readonly remotePathResolver: RemoteSandboxPathResolver = async (
+    path,
+    options,
+  ) => await this.resolveRemotePath(path, options);
+
+  constructor(args: { state: CloudflareSandboxSessionState; apiKey?: string }) {
+    this.state = {
+      ...args.state,
+      sandboxId: normalizeCloudflarePersistedSandboxId(args.state.sandboxId),
+    };
+    this.apiKey = args.apiKey;
+  }
+
+  createEditor(runAs?: string): RemoteSandboxEditor {
+    assertRunAsUnsupported('CloudflareSandboxClient', runAs);
+    return new RemoteSandboxEditor({
+      resolvePath: this.remotePathResolver,
+      pathExists: async (path) => await this.pathExists(path),
+      mkdir: async (path) => {
+        await this.mkdirPath(path, 'create directory');
+      },
+      readText: async (path) =>
+        new TextDecoder().decode(await this.readFileBytes(path)),
+      writeText: async (path, content) => {
+        await this.ensureParentDir(path);
+        await this.writeFile(path, new TextEncoder().encode(content));
+      },
+      deletePath: async (path) => {
+        const result = await this.execShell(`rm -f -- ${shellQuote(path)}`);
+        if (result.exitCode !== 0) {
+          throw new SandboxProviderError(
+            'CloudflareSandboxClient failed to delete path.',
+            {
+              provider: 'cloudflare',
+              operation: 'delete path',
+              sandboxId: this.state.sandboxId,
+              path,
+              exitCode: result.exitCode,
+              output: result.output,
+            },
+          );
+        }
+      },
+    });
+  }
+
+  supportsPty(): boolean {
+    return true;
+  }
+
+  async execCommand(args: ExecCommandArgs): Promise<string> {
+    if (args.tty) {
+      return await this.execPtyCommand(args);
+    }
+    assertRunAsUnsupported('CloudflareSandboxClient', args.runAs);
+
+    const start = Date.now();
+    const wrapped = buildShellCommand(
+      args.cmd,
+      this.state.environment,
+      resolveSandboxWorkdir(this.state.manifest.root, args.workdir),
+    );
+    const result = await this.execShell(wrapped);
+    const output = truncateOutput(result.output, args.maxOutputTokens);
+
+    return formatExecResponse({
+      output: output.text,
+      wallTimeSeconds: elapsedSeconds(start),
+      exitCode: result.exitCode,
+      originalTokenCount: output.originalTokenCount,
+    });
+  }
+
+  async writeStdin(args: WriteStdinArgs): Promise<string> {
+    return await writePtyStdin({
+      providerName: 'CloudflareSandboxClient',
+      registry: this.ptyProcesses,
+      sessionId: args.sessionId,
+      chars: args.chars,
+      yieldTimeMs: args.yieldTimeMs,
+      maxOutputTokens: args.maxOutputTokens,
+    });
+  }
+
+  private async execPtyCommand(args: ExecCommandArgs): Promise<string> {
+    assertRunAsUnsupported('CloudflareSandboxClient', args.runAs);
+    const start = Date.now();
+    const entry = createPtyProcessEntry({ tty: true });
+    let readyPromise: Promise<void> = Promise.resolve();
+    let removeMessageListener = () => {};
+    const socket = await openPtyWebSocket({
+      url: buildCloudflarePtyWebSocketUrl(this.state),
+      providerName: 'CloudflareSandboxClient',
+      headers: buildCloudflarePtyWebSocketHeaders(this.apiKey),
+      configure: (pendingSocket) => {
+        removeMessageListener = addPtyWebSocketListener(
+          pendingSocket,
+          'message',
+          (event) => handleCloudflarePtyMessage(entry, event),
+        );
+        readyPromise = waitForCloudflarePtyReady(pendingSocket);
+        readyPromise.catch(() => {});
+      },
+    });
+    const removeCloseListener = addPtyWebSocketListener(socket, 'close', () => {
+      if (!entry.done) {
+        markPtyDone(entry);
+      }
+    });
+    const removeErrorListener = addPtyWebSocketListener(socket, 'error', () => {
+      if (!entry.done) {
+        markPtyDone(entry, 1);
+      }
+    });
+
+    try {
+      await readyPromise;
+    } catch (error) {
+      socket.close();
+      throw error;
+    }
+
+    entry.sendInput = async (chars) => {
+      socket.send(new TextEncoder().encode(chars));
+    };
+    entry.terminate = async () => {
+      removeMessageListener();
+      removeCloseListener();
+      removeErrorListener();
+      socket.close();
+    };
+    let registered = false;
+    let sessionId: number;
+    try {
+      const command = shellCommandForPty({
+        ...args,
+        cmd: buildShellCommand(
+          args.cmd,
+          this.state.environment,
+          resolveSandboxWorkdir(this.state.manifest.root, args.workdir),
+        ),
+      });
+      await entry.sendInput(`${command}\n`);
+
+      const registeredProcess = this.ptyProcesses.register(entry);
+      registered = true;
+      sessionId = registeredProcess.sessionId;
+      if (registeredProcess.pruned) {
+        await registeredProcess.pruned.terminate?.().catch(() => {});
+      }
+    } catch (error) {
+      if (!registered) {
+        await entry.terminate?.().catch(() => {});
+      }
+      throw error;
+    }
+
+    return await formatPtyExecUpdate({
+      registry: this.ptyProcesses,
+      sessionId,
+      entry,
+      startTime: start,
+      yieldTimeMs: args.yieldTimeMs,
+      maxOutputTokens: args.maxOutputTokens,
+    });
+  }
+
+  async viewImage(args: ViewImageArgs): Promise<ToolOutputImage> {
+    assertRunAsUnsupported('CloudflareSandboxClient', args.runAs);
+    const absolutePath = await this.resolveRemotePath(args.path);
+    const bytes = await this.readFileBytes(absolutePath);
+    return imageOutputFromBytes(args.path, bytes);
+  }
+
+  async pathExists(path: string, runAs?: string): Promise<boolean> {
+    assertRunAsUnsupported('CloudflareSandboxClient', runAs);
+    const absolutePath = await this.resolveRemotePath(path);
+    const result = await this.execShell(`test -e ${shellQuote(absolutePath)}`);
+    return result.exitCode === 0;
+  }
+
+  async running(): Promise<boolean> {
+    const response = await this.fetch(
+      `/v1/sandbox/${this.state.sandboxId}/running`,
+      {
+        method: 'GET',
+      },
+    );
+    if (response.status === 404) {
+      return false;
+    }
+    if (!response.ok) {
+      throw cloudflareProviderHttpError('check running state', response, {
+        sandboxId: this.state.sandboxId,
+      });
+    }
+    const payload = (await response.json().catch(() => ({}))) as {
+      running?: unknown;
+    };
+    return Boolean(payload.running);
+  }
+
+  async resolveExposedPort(port: number): Promise<ExposedPortEndpoint> {
+    const requestedPort = assertConfiguredExposedPort({
+      providerName: 'CloudflareSandboxClient',
+      port,
+      configuredPorts: this.state.configuredExposedPorts,
+    });
+    throw new SandboxUnsupportedFeatureError(
+      'CloudflareSandboxClient does not support exposed port resolution until the worker deployment exposes a port-resolution endpoint.',
+      {
+        provider: 'cloudflare',
+        port: requestedPort,
+      },
+    );
+  }
+
+  async materializeEntry(args: MaterializeEntryArgs): Promise<void> {
+    assertRunAsUnsupported('CloudflareSandboxClient', args.runAs);
+    assertSandboxEntryMetadataSupported(
+      'CloudflareSandboxClient',
+      args.path,
+      args.entry,
+      MOUNT_MANIFEST_METADATA_SUPPORT,
+    );
+    if (entryContainsLocalSource(args.entry)) {
+      const { applyLocalSourceManifestEntryToState } =
+        await import('../shared/localSources');
+      await applyLocalSourceManifestEntryToState(
+        this.state,
+        args.path,
+        args.entry,
+        'cloudflare',
+        this.writer(),
+        this.remotePathResolver,
+        this.manifestMaterializationOptions,
+      );
+      return;
+    }
+
+    await applyInlineManifestEntryToState(
+      this.state,
+      args.path,
+      args.entry,
+      'cloudflare',
+      this.writer(),
+      this.remotePathResolver,
+      this.manifestMaterializationOptions,
+    );
+  }
+
+  async applyManifest(manifest: Manifest, runAs?: string): Promise<void> {
+    assertRunAsUnsupported('CloudflareSandboxClient', runAs);
+    assertCloudflareManifestRoot(manifest);
+    assertSandboxManifestMetadataSupported(
+      'CloudflareSandboxClient',
+      manifest,
+      MOUNT_MANIFEST_METADATA_SUPPORT,
+    );
+    assertCloudflareManifestMountsSupported(manifest);
+    if (manifestContainsLocalSource(manifest)) {
+      const { applyLocalSourceManifestToState } =
+        await import('../shared/localSources');
+      await applyLocalSourceManifestToState(
+        this.state,
+        manifest,
+        'cloudflare',
+        this.writer(),
+        this.remotePathResolver,
+        this.manifestMaterializationOptions,
+      );
+      return;
+    }
+
+    await applyInlineManifestToState(
+      this.state,
+      manifest,
+      'cloudflare',
+      this.writer(),
+      this.remotePathResolver,
+      this.manifestMaterializationOptions,
+    );
+  }
+
+  async mountBucket(args: {
+    bucket: string;
+    mountPath: string;
+    options: CloudflareBucketMountRequestOptions;
+  }): Promise<void> {
+    const mountPath = await this.resolveRemotePath(args.mountPath, {
+      forWrite: true,
+    });
+    const response = await this.fetch(
+      `/v1/sandbox/${this.state.sandboxId}/mount`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          bucket: args.bucket,
+          mountPath,
+          options: args.options,
+        }),
+      },
+    );
+    if (!response.ok) {
+      throw await cloudflareMountError({
+        response,
+        message: 'Cloudflare bucket mount failed.',
+        mountPath,
+        bucket: args.bucket,
+      });
+    }
+  }
+
+  async unmountBucket(mountPath: string): Promise<void> {
+    const resolvedMountPath = await this.resolveRemotePath(mountPath, {
+      forWrite: true,
+    });
+    const response = await this.fetch(
+      `/v1/sandbox/${this.state.sandboxId}/unmount`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          mountPath: resolvedMountPath,
+        }),
+      },
+    );
+    if (!response.ok) {
+      throw await cloudflareMountError({
+        response,
+        message: 'Cloudflare bucket unmount failed.',
+        mountPath: resolvedMountPath,
+      });
+    }
+  }
+
+  async persistWorkspace(): Promise<Uint8Array> {
+    assertTarWorkspacePersistence('CloudflareSandboxClient', 'tar');
+    const excludes = [...this.state.manifest.ephemeralPersistencePaths()]
+      .filter((path) => path.length > 0)
+      .sort((left, right) => left.localeCompare(right))
+      .join(',');
+    const response = await this.fetch(
+      `/v1/sandbox/${this.state.sandboxId}/persist${
+        excludes ? `?excludes=${encodeURIComponent(excludes)}` : ''
+      }`,
+      {
+        method: 'POST',
+      },
+    );
+    if (!response.ok) {
+      throw new SandboxArchiveError(
+        `Cloudflare sandbox persist failed with HTTP ${response.status}.`,
+        {
+          provider: 'cloudflare',
+          sandboxId: this.state.sandboxId,
+          status: response.status,
+        },
+      );
+    }
+    const archive = decodeStreamedPayload(
+      new Uint8Array(await response.arrayBuffer()),
+      response.headers,
+    );
+    validateWorkspaceTarArchive(archive);
+    return archive;
+  }
+
+  async hydrateWorkspace(data: WorkspaceArchiveData): Promise<void> {
+    assertTarWorkspacePersistence('CloudflareSandboxClient', 'tar');
+    const archive = toWorkspaceArchiveBytes(data);
+    validateWorkspaceTarArchive(archive);
+    const response = await this.fetch(
+      `/v1/sandbox/${this.state.sandboxId}/hydrate`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/octet-stream',
+        },
+        body: toArrayBuffer(archive),
+      },
+    );
+    if (!response.ok) {
+      throw new SandboxArchiveError(
+        `Cloudflare sandbox hydrate failed with HTTP ${response.status}.`,
+        {
+          provider: 'cloudflare',
+          sandboxId: this.state.sandboxId,
+          status: response.status,
+        },
+      );
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.ptyProcesses.terminateAll();
+    await withSandboxSpan(
+      'sandbox.stop',
+      {
+        backend_id: 'cloudflare',
+        sandbox_id: this.state.sandboxId,
+      },
+      async () => {
+        const response = await this.fetch(
+          `/v1/sandbox/${this.state.sandboxId}`,
+          {
+            method: 'DELETE',
+          },
+        );
+        if (!response.ok && response.status !== 404) {
+          throw cloudflareProviderHttpError('delete sandbox', response, {
+            sandboxId: this.state.sandboxId,
+          });
+        }
+      },
+    );
+  }
+
+  async shutdown(): Promise<void> {
+    await this.close();
+  }
+
+  async delete(): Promise<void> {
+    await this.close();
+  }
+
+  private writer(): RemoteManifestWriter {
+    return {
+      mkdir: async (path) => {
+        await this.mkdirPath(path, 'create directory');
+      },
+      writeFile: async (path, content) => {
+        await this.ensureParentDir(path);
+        await this.writeFile(
+          path,
+          typeof content === 'string'
+            ? new TextEncoder().encode(content)
+            : content,
+        );
+      },
+    };
+  }
+
+  private readonly manifestMaterializationOptions = {
+    materializeMount: this.materializeMountEntry.bind(this),
+  };
+
+  private async materializeMountEntry(
+    absolutePath: string,
+    entry: Mount | TypedMount,
+  ): Promise<void> {
+    if (!isCloudflareBucketMountEntry(entry)) {
+      throw new SandboxUnsupportedFeatureError(
+        'CloudflareSandboxClient only supports CloudflareBucketMountStrategy mount entries.',
+        {
+          provider: 'cloudflare',
+          feature: 'entry.mountStrategy',
+          path: absolutePath,
+          mountType: entry.type,
+          strategyType: entry.mountStrategy?.type,
+        },
+      );
+    }
+    const config = buildCloudflareBucketMountConfig(entry);
+    await this.mountBucket({
+      bucket: config.bucketName,
+      mountPath: entry.mountPath ?? absolutePath,
+      options: cloudflareBucketMountRequestOptions(config),
+    });
+  }
+
+  private async execShell(
+    shellCommand: string,
+  ): Promise<{ exitCode: number; output: string }> {
+    const response = await this.fetch(
+      `/v1/sandbox/${this.state.sandboxId}/exec`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          argv: ['/bin/sh', '-lc', shellCommand],
+          ...(typeof this.state.timeouts?.execTimeoutMs === 'number' ||
+          typeof this.state.timeoutMs === 'number'
+            ? {
+                timeoutMs:
+                  this.state.timeouts?.execTimeoutMs ?? this.state.timeoutMs,
+              }
+            : {}),
+        }),
+      },
+    );
+    if (!response.ok) {
+      throw cloudflareProviderHttpError('execute command', response, {
+        sandboxId: this.state.sandboxId,
+      });
+    }
+    if (!response.body) {
+      throw new SandboxProviderError(
+        'CloudflareSandboxClient failed to execute command.',
+        {
+          provider: 'cloudflare',
+          operation: 'execute command',
+          sandboxId: this.state.sandboxId,
+          cause: 'missing response body',
+        },
+      );
+    }
+
+    const decoder = new TextDecoder();
+    const reader = response.body.getReader();
+    let buffer = '';
+    let stdout = '';
+    let stderr = '';
+    let exitCode: number | undefined;
+    const processEvent = (event: { event: string; data: string }): void => {
+      if (event.event === 'stdout') {
+        stdout += decodeBase64Text(event.data);
+        return;
+      }
+      if (event.event === 'stderr') {
+        stderr += decodeBase64Text(event.data);
+        return;
+      }
+      if (event.event === 'exit') {
+        try {
+          const payload = JSON.parse(event.data) as { exit_code?: number };
+          exitCode =
+            typeof payload.exit_code === 'number' &&
+            Number.isFinite(payload.exit_code)
+              ? Math.trunc(payload.exit_code)
+              : 1;
+        } catch {
+          exitCode = 1;
+        }
+        return;
+      }
+      if (event.event === 'error') {
+        throw new SandboxProviderError(
+          'CloudflareSandboxClient failed to execute command.',
+          {
+            provider: 'cloudflare',
+            operation: 'execute command',
+            sandboxId: this.state.sandboxId,
+            cause: event.data || 'unknown error',
+          },
+        );
+      }
+    };
+
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) {
+        break;
+      }
+      buffer += decoder.decode(chunk.value, { stream: true });
+      const { events, remaining } = splitCompleteSseEvents(buffer);
+      buffer = remaining;
+      for (const part of events) {
+        const event = parseSseEvent(part);
+        if (!event) {
+          continue;
+        }
+        processEvent(event);
+      }
+    }
+    buffer += decoder.decode();
+    for (const part of collectSseEvents(buffer)) {
+      const event = parseSseEvent(part);
+      if (event) {
+        processEvent(event);
+      }
+    }
+
+    return {
+      exitCode: exitCode ?? 1,
+      output: [stdout.trimEnd(), stderr.trimEnd()]
+        .filter((value) => value.length > 0)
+        .join('\n'),
+    };
+  }
+
+  private async readFileBytes(path: string): Promise<Uint8Array> {
+    const response = await this.fetch(
+      `/v1/sandbox/${this.state.sandboxId}/file/${encodeSandboxPath(path)}`,
+      {
+        method: 'GET',
+      },
+    );
+    if (response.status === 404) {
+      throw new SandboxWorkspaceReadNotFoundError(
+        `Cloudflare sandbox path not found: ${path}.`,
+        {
+          provider: 'cloudflare',
+          sandboxId: this.state.sandboxId,
+          path,
+          status: response.status,
+        },
+      );
+    }
+    if (!response.ok) {
+      throw cloudflareProviderHttpError('read file', response, {
+        sandboxId: this.state.sandboxId,
+        path,
+      });
+    }
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    return decodeStreamedPayload(bytes, response.headers);
+  }
+
+  private async writeFile(path: string, content: Uint8Array): Promise<void> {
+    const response = await this.fetch(
+      `/v1/sandbox/${this.state.sandboxId}/file/${encodeSandboxPath(path)}`,
+      {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/octet-stream',
+        },
+        body: toArrayBuffer(content),
+      },
+    );
+    if (!response.ok) {
+      throw cloudflareProviderHttpError('write file', response, {
+        sandboxId: this.state.sandboxId,
+        path,
+      });
+    }
+  }
+
+  private async ensureParentDir(path: string): Promise<void> {
+    const parent = posixDirname(path);
+    if (parent !== '.' && parent !== '/') {
+      await this.mkdirPath(parent, 'create parent directory');
+    }
+  }
+
+  private async mkdirPath(path: string, operation: string): Promise<void> {
+    const result = await this.execShell(`mkdir -p -- ${shellQuote(path)}`);
+    if (result.exitCode !== 0) {
+      throw new SandboxProviderError(
+        'CloudflareSandboxClient failed to create directory.',
+        {
+          provider: 'cloudflare',
+          operation,
+          sandboxId: this.state.sandboxId,
+          path,
+          exitCode: result.exitCode,
+          output: result.output,
+        },
+      );
+    }
+  }
+
+  private async fetch(
+    path: string,
+    init: RequestInit,
+    timeoutMs?: number,
+  ): Promise<Response> {
+    const headers = new Headers(init.headers ?? {});
+    const apiKey = this.apiKey ?? loadEnv().CLOUDFLARE_SANDBOX_API_KEY;
+    if (apiKey) {
+      headers.set('Authorization', `Bearer ${apiKey}`);
+    }
+    const requestTimeoutMs =
+      timeoutMs ??
+      this.state.timeouts?.requestTimeoutMs ??
+      this.state.requestTimeoutMs;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    let controller: AbortController | undefined;
+    if (typeof requestTimeoutMs === 'number' && !init.signal) {
+      controller = new AbortController();
+      timeoutId = setTimeout(() => {
+        controller?.abort();
+      }, requestTimeoutMs);
+    }
+    try {
+      return await withProviderError(
+        'CloudflareSandboxClient',
+        'cloudflare',
+        'request worker',
+        async () =>
+          await fetch(`${this.state.workerUrl}${path}`, {
+            ...init,
+            headers,
+            ...(controller ? { signal: controller.signal } : {}),
+          }),
+        {
+          sandboxId: this.state.sandboxId,
+          path,
+          method: init.method ?? 'GET',
+        },
+      );
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    }
+  }
+
+  private async resolveRemotePath(
+    path?: string,
+    options: RemoteSandboxPathOptions = {},
+  ): Promise<string> {
+    return await validateRemoteSandboxPathForManifest({
+      manifest: this.state.manifest,
+      path,
+      options,
+      runCommand: async (command) => {
+        const result = await this.execShell(command);
+        return {
+          status: result.exitCode,
+          stdout: result.output,
+          stderr: '',
+        };
+      },
+    });
+  }
+}
+
+/**
+ * @see {@link https://developers.cloudflare.com/sandbox/ | Sandbox SDK overview}.
+ * @see {@link https://developers.cloudflare.com/sandbox/get-started/ | Getting started}.
+ * @see {@link https://developers.cloudflare.com/sandbox/concepts/architecture/ | Sandbox architecture}.
+ */
+export class CloudflareSandboxClient implements SandboxClient<
+  CloudflareSandboxClientOptions,
+  CloudflareSandboxSessionState
+> {
+  readonly backendId = 'cloudflare';
+  private readonly options: Partial<CloudflareSandboxClientOptions>;
+
+  constructor(options: Partial<CloudflareSandboxClientOptions> = {}) {
+    this.options = options;
+  }
+
+  async create(
+    args?: SandboxClientCreateArgs | Manifest,
+    manifestOptions?: SandboxClientOptions,
+  ): Promise<CloudflareSandboxSession> {
+    const createArgs = normalizeSandboxClientCreateArgs(
+      args,
+      manifestOptions as CloudflareSandboxClientOptions | undefined,
+    );
+    assertCoreSnapshotUnsupported(
+      'CloudflareSandboxClient',
+      createArgs.snapshot,
+    );
+    assertCoreConcurrencyLimitsUnsupported(
+      'CloudflareSandboxClient',
+      createArgs.concurrencyLimits,
+    );
+    const manifest = createArgs.manifest;
+    const resolvedOptions = {
+      ...this.options,
+      ...(createArgs.options as Partial<CloudflareSandboxClientOptions>),
+    };
+    const timeouts = resolveCloudflareTimeouts(resolvedOptions);
+    const workerUrl = resolvedOptions.workerUrl;
+    if (!workerUrl) {
+      throw new UserError(
+        'CloudflareSandboxClient requires options.workerUrl.',
+      );
+    }
+    assertCloudflareManifestRoot(manifest);
+    assertSandboxManifestMetadataSupported(
+      'CloudflareSandboxClient',
+      manifest,
+      MOUNT_MANIFEST_METADATA_SUPPORT,
+    );
+    assertCloudflareManifestMountsSupported(manifest);
+
+    return await withSandboxSpan(
+      'sandbox.start',
+      {
+        backend_id: this.backendId,
+      },
+      async () => {
+        const environment = await materializeEnvironment(manifest);
+        const headers = new Headers();
+        headers.set('Content-Type', 'application/json');
+        const apiKey =
+          resolvedOptions.apiKey ?? loadEnv().CLOUDFLARE_SANDBOX_API_KEY;
+        if (apiKey) {
+          headers.set('Authorization', `Bearer ${apiKey}`);
+        }
+
+        const normalizedWorkerUrl = normalizeCloudflareWorkerUrl(
+          workerUrl,
+          'options.workerUrl',
+        );
+        const response = await withProviderError(
+          'CloudflareSandboxClient',
+          'cloudflare',
+          'create sandbox',
+          async () =>
+            await fetchWithOptionalTimeout(
+              `${normalizedWorkerUrl}/v1/sandbox`,
+              {
+                method: 'POST',
+                headers,
+                body: JSON.stringify({
+                  ...(resolvedOptions.exposedPorts
+                    ? { exposedPorts: resolvedOptions.exposedPorts }
+                    : {}),
+                  ...(typeof timeouts.execTimeoutMs === 'number'
+                    ? { timeoutMs: timeouts.execTimeoutMs }
+                    : {}),
+                  ...(typeof timeouts.createTimeoutMs === 'number'
+                    ? { createTimeoutMs: timeouts.createTimeoutMs }
+                    : {}),
+                  ...(resolvedOptions.mounts
+                    ? { mounts: resolvedOptions.mounts }
+                    : {}),
+                }),
+              },
+              timeouts.createTimeoutMs ?? timeouts.requestTimeoutMs,
+            ),
+          { workerUrl: normalizedWorkerUrl },
+        );
+        if (!response.ok) {
+          throw cloudflareProviderHttpError('create sandbox', response, {
+            workerUrl: normalizedWorkerUrl,
+          });
+        }
+        const payload = await withProviderError(
+          'CloudflareSandboxClient',
+          'cloudflare',
+          'parse create response',
+          async () => (await response.json()) as { id?: unknown },
+          { workerUrl: normalizedWorkerUrl },
+        );
+        const sandboxId = normalizeCloudflareCreatedSandboxId(
+          payload.id,
+          normalizedWorkerUrl,
+        );
+
+        const session = new CloudflareSandboxSession({
+          apiKey,
+          state: {
+            manifest,
+            workerUrl: normalizedWorkerUrl,
+            sandboxId,
+            configuredExposedPorts: resolvedOptions.exposedPorts,
+            timeoutMs: resolvedOptions.timeoutMs,
+            createTimeoutMs: timeouts.createTimeoutMs,
+            requestTimeoutMs: timeouts.requestTimeoutMs,
+            timeouts,
+            mounts: resolvedOptions.mounts,
+            environment,
+          },
+        });
+        try {
+          await session.applyManifest(manifest);
+        } catch (error) {
+          await closeRemoteSessionOnManifestError('Cloudflare', session, error);
+        }
+        return session;
+      },
+    );
+  }
+
+  async serializeSessionState(
+    state: CloudflareSandboxSessionState,
+  ): Promise<Record<string, unknown>> {
+    return serializeRemoteSandboxSessionState(state);
+  }
+
+  canPersistOwnedSessionState(): boolean {
+    return false;
+  }
+
+  async deserializeSessionState(
+    state: Record<string, unknown>,
+  ): Promise<CloudflareSandboxSessionState> {
+    const baseState = deserializeRemoteSandboxSessionStateValues(state);
+    return {
+      ...state,
+      ...baseState,
+      workerUrl: readString(state, 'workerUrl'),
+      sandboxId: readString(state, 'sandboxId'),
+      configuredExposedPorts: readOptionalNumberArray(
+        state.configuredExposedPorts,
+      ),
+      timeoutMs: readOptionalNumber(state, 'timeoutMs'),
+      createTimeoutMs: readOptionalNumber(state, 'createTimeoutMs'),
+      requestTimeoutMs: readOptionalNumber(state, 'requestTimeoutMs'),
+      timeouts: resolveCloudflareTimeouts({
+        timeoutMs: readOptionalNumber(state, 'timeoutMs'),
+        createTimeoutMs: readOptionalNumber(state, 'createTimeoutMs'),
+        requestTimeoutMs: readOptionalNumber(state, 'requestTimeoutMs'),
+        timeouts: isRecord(state.timeouts)
+          ? (state.timeouts as CloudflareSandboxTimeouts)
+          : undefined,
+      }),
+      mounts: readOptionalRecordArray(state.mounts),
+    };
+  }
+
+  async resume(
+    state: CloudflareSandboxSessionState,
+  ): Promise<CloudflareSandboxSession> {
+    const sandboxId = normalizeCloudflarePersistedSandboxId(
+      (state as Record<string, unknown>).sandboxId,
+    );
+    const workerUrl = normalizeCloudflareWorkerUrl(
+      state.workerUrl,
+      'persisted workerUrl',
+    );
+    assertCloudflareManifestRoot(state.manifest);
+    assertSandboxManifestMetadataSupported(
+      'CloudflareSandboxClient',
+      state.manifest,
+      MOUNT_MANIFEST_METADATA_SUPPORT,
+    );
+    assertCloudflareManifestMountsSupported(state.manifest);
+
+    const session = new CloudflareSandboxSession({
+      state: {
+        ...state,
+        sandboxId,
+        workerUrl,
+      },
+      apiKey: this.options.apiKey ?? loadEnv().CLOUDFLARE_SANDBOX_API_KEY,
+    });
+    if (!(await session.running())) {
+      throw new UserError(
+        `Cloudflare sandbox ${sandboxId} is no longer running.`,
+      );
+    }
+    return session;
+  }
+}
+
+function buildShellCommand(
+  command: string,
+  environment: Record<string, string>,
+  cwd: string,
+): string {
+  const exports = Object.entries(environment).map(([key, value]) => {
+    assertShellEnvironmentName(key);
+    return `export ${key}=${shellQuote(value)}`;
+  });
+  return [`cd ${shellQuote(cwd)}`, ...exports, command].join(' && ');
+}
+
+function encodeSandboxPath(path: string): string {
+  return path.replace(/^\//, '').split('/').map(encodeURIComponent).join('/');
+}
+
+function resolveCloudflareTimeouts(
+  options: Pick<
+    CloudflareSandboxClientOptions,
+    'timeoutMs' | 'createTimeoutMs' | 'requestTimeoutMs' | 'timeouts'
+  >,
+): CloudflareSandboxTimeouts {
+  return {
+    ...options.timeouts,
+    execTimeoutMs: options.timeouts?.execTimeoutMs ?? options.timeoutMs,
+    createTimeoutMs:
+      options.timeouts?.createTimeoutMs ?? options.createTimeoutMs,
+    requestTimeoutMs:
+      options.timeouts?.requestTimeoutMs ?? options.requestTimeoutMs,
+  };
+}
+
+function normalizeCloudflareWorkerUrl(
+  workerUrl: string,
+  source: string,
+): string {
+  let url: URL;
+  try {
+    url = new URL(workerUrl);
+  } catch {
+    throw new UserError(
+      `Cloudflare sandbox ${source} must be an absolute http(s) URL.`,
+    );
+  }
+  if (
+    (url.protocol !== 'https:' && url.protocol !== 'http:') ||
+    url.search ||
+    url.hash
+  ) {
+    throw new UserError(
+      `Cloudflare sandbox ${source} must be an absolute http(s) URL.`,
+    );
+  }
+  return url.href.replace(/\/$/u, '');
+}
+
+const CLOUDFLARE_SANDBOX_ID_PATTERN = /^[A-Za-z0-9_-]+$/u;
+
+function normalizeCloudflareCreatedSandboxId(
+  sandboxId: unknown,
+  workerUrl: string,
+): string {
+  if (isValidCloudflareSandboxId(sandboxId)) {
+    return sandboxId;
+  }
+  throw new SandboxProviderError(
+    'CloudflareSandboxClient failed to create sandbox.',
+    {
+      provider: 'cloudflare',
+      operation: 'create sandbox',
+      workerUrl,
+      cause: 'invalid sandbox id',
+    },
+  );
+}
+
+function normalizeCloudflarePersistedSandboxId(sandboxId: unknown): string {
+  if (sandboxId === undefined || sandboxId === null || sandboxId === '') {
+    throw new UserError(
+      'Cloudflare sandbox resume requires a persisted sandboxId.',
+    );
+  }
+  if (isValidCloudflareSandboxId(sandboxId)) {
+    return sandboxId;
+  }
+  throw new UserError(
+    'Cloudflare sandbox persisted sandboxId must be a safe path segment.',
+  );
+}
+
+function isValidCloudflareSandboxId(sandboxId: unknown): sandboxId is string {
+  return (
+    typeof sandboxId === 'string' &&
+    CLOUDFLARE_SANDBOX_ID_PATTERN.test(sandboxId)
+  );
+}
+
+async function fetchWithOptionalTimeout(
+  input: string,
+  init: RequestInit,
+  timeoutMs: number | undefined,
+): Promise<Response> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let controller: AbortController | undefined;
+  if (typeof timeoutMs === 'number' && !init.signal) {
+    controller = new AbortController();
+    timeoutId = setTimeout(() => {
+      controller?.abort();
+    }, timeoutMs);
+  }
+  try {
+    return await fetch(input, {
+      ...init,
+      ...(controller ? { signal: controller.signal } : {}),
+    });
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+function buildCloudflarePtyWebSocketUrl(
+  state: CloudflareSandboxSessionState,
+): string {
+  const base = state.workerUrl.replace(/\/$/u, '');
+  const wsBase = base.replace(/^https:/u, 'wss:').replace(/^http:/u, 'ws:');
+  const url = new URL(`${wsBase}/v1/sandbox/${state.sandboxId}/pty`);
+  url.searchParams.set('cols', '80');
+  url.searchParams.set('rows', '24');
+  return url.toString();
+}
+
+function buildCloudflarePtyWebSocketHeaders(
+  apiKey?: string,
+): Record<string, string> | undefined {
+  if (apiKey) {
+    return {
+      Authorization: `Bearer ${apiKey}`,
+    };
+  }
+  return undefined;
+}
+
+function assertCloudflareManifestRoot(manifest: Manifest): void {
+  if (manifest.root !== '/workspace') {
+    throw new UserError(
+      'Cloudflare sandboxes currently require manifest.root="/workspace".',
+    );
+  }
+}
+
+function assertCloudflareManifestMountsSupported(manifest: Manifest): void {
+  for (const { entry, mountPath } of manifest.mountTargets()) {
+    if (!isCloudflareBucketMountEntry(entry)) {
+      throw new SandboxUnsupportedFeatureError(
+        'CloudflareSandboxClient only supports CloudflareBucketMountStrategy mount entries.',
+        {
+          provider: 'cloudflare',
+          feature: 'entry.mountStrategy',
+          path: mountPath,
+          mountType: entry.type,
+          strategyType: entry.mountStrategy?.type,
+        },
+      );
+    }
+    buildCloudflareBucketMountConfig(entry);
+  }
+}
+
+async function cloudflareMountError(args: {
+  response: Response;
+  message: string;
+  mountPath: string;
+  bucket?: string;
+}): Promise<SandboxMountError> {
+  const payload = (await args.response.json().catch(() => ({}))) as {
+    error?: unknown;
+  };
+  return new SandboxMountError(args.message, {
+    provider: 'cloudflare',
+    mountPath: args.mountPath,
+    ...(args.bucket ? { bucket: args.bucket } : {}),
+    status: args.response.status,
+    reason:
+      typeof payload.error === 'string'
+        ? payload.error
+        : `HTTP ${args.response.status}`,
+  });
+}
+
+function cloudflareProviderHttpError(
+  operation: string,
+  response: Response,
+  context: Record<string, unknown> = {},
+): SandboxProviderError {
+  return new SandboxProviderError(
+    `CloudflareSandboxClient failed to ${operation}.`,
+    {
+      provider: 'cloudflare',
+      operation,
+      status: response.status,
+      ...context,
+    },
+  );
+}
+
+function waitForCloudflarePtyReady(socket: PtyWebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let removeMessage = () => {};
+    let removeClose = () => {};
+    let removeError = () => {};
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new UserError('CloudflareSandboxClient PTY ready timed out.'));
+    }, 30_000);
+    const cleanup = () => {
+      clearTimeout(timer);
+      removeMessage();
+      removeClose();
+      removeError();
+    };
+    removeMessage = addPtyWebSocketListener(socket, 'message', (event) => {
+      const payload = parseCloudflarePtyControlPayload(event);
+      if (isRecord(payload)) {
+        if (payload.type === 'ready') {
+          cleanup();
+          resolve();
+          return;
+        }
+        if (payload.type === 'error') {
+          cleanup();
+          reject(new UserError(cloudflarePtyReadyErrorMessage(payload)));
+        }
+      }
+    });
+    removeClose = addPtyWebSocketListener(socket, 'close', () => {
+      cleanup();
+      reject(
+        new UserError(
+          'CloudflareSandboxClient PTY WebSocket closed before ready.',
+        ),
+      );
+    });
+    removeError = addPtyWebSocketListener(socket, 'error', () => {
+      cleanup();
+      reject(new UserError('CloudflareSandboxClient PTY WebSocket failed.'));
+    });
+  });
+}
+
+function cloudflarePtyReadyErrorMessage(
+  payload: Record<string, unknown>,
+): string {
+  const message = payload.message;
+  return typeof message === 'string' && message.length > 0
+    ? `CloudflareSandboxClient PTY failed before ready: ${message}`
+    : 'CloudflareSandboxClient PTY failed before ready.';
+}
+
+function handleCloudflarePtyMessage(
+  entry: PtyProcessEntry,
+  event: unknown,
+): void {
+  const payload = parseCloudflarePtyControlPayload(event);
+  if (isRecord(payload)) {
+    if (payload.type === 'ready') {
+      return;
+    }
+    if (payload.type === 'exit') {
+      markPtyDone(
+        entry,
+        typeof payload.code === 'number' ? payload.code : null,
+      );
+      return;
+    }
+    if (payload.type === 'error') {
+      const message = payload.message;
+      if (typeof message === 'string') {
+        appendPtyOutput(entry, message);
+      }
+      if (!entry.done) {
+        markPtyDone(entry, 1);
+      }
+      return;
+    }
+  }
+
+  const data = webSocketEventData(event);
+  if (typeof data === 'string') {
+    appendPtyOutput(entry, data);
+    return;
+  }
+  if (data instanceof ArrayBuffer) {
+    appendPtyOutput(entry, data);
+    return;
+  }
+  if (ArrayBuffer.isView(data)) {
+    appendPtyOutput(
+      entry,
+      new Uint8Array(data.buffer, data.byteOffset, data.byteLength),
+    );
+  }
+}
+
+function parseCloudflarePtyControlPayload(event: unknown): unknown {
+  const text = webSocketEventText(event);
+  if (!text) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseSseEvent(chunk: string): { event: string; data: string } | null {
+  const lines = chunk
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0);
+  if (lines.length === 0) {
+    return null;
+  }
+
+  let event = 'message';
+  const data: string[] = [];
+  for (const line of lines) {
+    if (line.startsWith('event:')) {
+      event = line.slice('event:'.length).trim();
+      continue;
+    }
+    if (line.startsWith('data:')) {
+      data.push(line.slice('data:'.length).trim());
+    }
+  }
+  return {
+    event,
+    data: data.join('\n'),
+  };
+}
+
+function splitCompleteSseEvents(buffer: string): {
+  events: string[];
+  remaining: string;
+} {
+  const events: string[] = [];
+  const delimiterPattern = /\r\n\r\n|\n\n|\r\r/gu;
+  let start = 0;
+  let match: RegExpExecArray | null;
+  while ((match = delimiterPattern.exec(buffer))) {
+    events.push(buffer.slice(start, match.index));
+    start = match.index + match[0].length;
+  }
+  return {
+    events,
+    remaining: buffer.slice(start),
+  };
+}
+
+function collectSseEvents(text: string): string[] {
+  const { events, remaining } = splitCompleteSseEvents(text);
+  if (remaining.trim().length > 0) {
+    events.push(remaining);
+  }
+  return events;
+}
+
+function decodeBase64Text(value: string): string {
+  return new TextDecoder().decode(decodeBase64Bytes(value));
+}
+
+const STREAMED_PAYLOAD_SSE_SNIFF_BYTES = 256;
+
+function decodeStreamedPayload(
+  body: Uint8Array,
+  headers?: Headers,
+): Uint8Array {
+  if (!shouldParseStreamedPayloadAsSse(body, headers)) {
+    return body;
+  }
+
+  const text = new TextDecoder().decode(body);
+  if (!startsWithSseFrame(text)) {
+    return body;
+  }
+  const events = collectSseEvents(text);
+  const chunkData: string[] = [];
+  let isBinary = false;
+
+  for (const rawEvent of events) {
+    const event = parseSseEvent(rawEvent);
+    if (!event) {
+      continue;
+    }
+    if (event.event === 'metadata') {
+      try {
+        const payload = JSON.parse(event.data) as { isBinary?: boolean };
+        isBinary = Boolean(payload.isBinary);
+      } catch {
+        // Ignore malformed metadata and fall back to treating the payload as text.
+      }
+      continue;
+    }
+    if (event.event === 'chunk') {
+      chunkData.push(event.data);
+    }
+  }
+
+  if (!isBinary || chunkData.length === 0) {
+    return body;
+  }
+
+  let chunks: Uint8Array[];
+  try {
+    chunks = chunkData.map((data) => decodeBase64Bytes(data));
+  } catch (error) {
+    throw new SandboxProviderError(
+      'CloudflareSandboxClient received an invalid binary stream payload.',
+      {
+        provider: 'cloudflare',
+        operation: 'decode streamed payload',
+        cause: error instanceof Error ? error.message : String(error),
+      },
+    );
+  }
+
+  const size = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+  const merged = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return merged;
+}
+
+function shouldParseStreamedPayloadAsSse(
+  body: Uint8Array,
+  headers?: Headers,
+): boolean {
+  const contentType = headers?.get('Content-Type')?.toLowerCase() ?? '';
+  if (contentType.split(';', 1)[0]?.trim() === 'text/event-stream') {
+    return true;
+  }
+  const prefix = body.subarray(
+    0,
+    Math.min(body.byteLength, STREAMED_PAYLOAD_SSE_SNIFF_BYTES),
+  );
+  return startsWithSseFrame(new TextDecoder().decode(prefix));
+}
+
+function startsWithSseFrame(text: string): boolean {
+  const trimmed = text.trimStart();
+  return (
+    trimmed.startsWith(':') ||
+    trimmed.startsWith('data:') ||
+    trimmed.startsWith('event:') ||
+    trimmed.startsWith('id:') ||
+    trimmed.startsWith('retry:')
+  );
+}
+
+function decodeBase64Bytes(value: string): Uint8Array {
+  const binary = atob(value.replace(/\s+/gu, ''));
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+function webSocketEventData(event: unknown): unknown {
+  return event && typeof event === 'object' && 'data' in event
+    ? (event as { data?: unknown }).data
+    : event;
+}
+
+function webSocketEventText(event: unknown): string | undefined {
+  const data = webSocketEventData(event);
+  if (typeof data === 'string') {
+    return data;
+  }
+  if (data instanceof ArrayBuffer) {
+    return new TextDecoder().decode(data);
+  }
+  if (ArrayBuffer.isView(data)) {
+    return new TextDecoder().decode(
+      new Uint8Array(data.buffer, data.byteOffset, data.byteLength),
+    );
+  }
+  return undefined;
+}

--- a/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
@@ -628,7 +628,7 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
           ...(typeof this.state.timeouts?.execTimeoutMs === 'number' ||
           typeof this.state.timeoutMs === 'number'
             ? {
-                timeoutMs:
+                timeout_ms:
                   this.state.timeouts?.execTimeoutMs ?? this.state.timeoutMs,
               }
             : {}),

--- a/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
@@ -227,6 +227,10 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
       url: buildCloudflarePtyWebSocketUrl(this.state),
       providerName: 'CloudflareSandboxClient',
       headers: buildCloudflarePtyWebSocketHeaders(this.apiKey),
+      headersUnsupportedUrl: buildCloudflarePtyWebSocketUrl(
+        this.state,
+        this.apiKey,
+      ),
       configure: (pendingSocket) => {
         removeMessageListener = addPtyWebSocketListener(
           pendingSocket,
@@ -1196,12 +1200,16 @@ async function fetchWithOptionalTimeout(
 
 function buildCloudflarePtyWebSocketUrl(
   state: CloudflareSandboxSessionState,
+  apiKey?: string,
 ): string {
   const base = state.workerUrl.replace(/\/$/u, '');
   const wsBase = base.replace(/^https:/u, 'wss:').replace(/^http:/u, 'ws:');
   const url = new URL(`${wsBase}/v1/sandbox/${state.sandboxId}/pty`);
   url.searchParams.set('cols', '80');
   url.searchParams.set('rows', '24');
+  if (apiKey) {
+    url.searchParams.set('authorization', `Bearer ${apiKey}`);
+  }
   return url.toString();
 }
 

--- a/packages/agents-extensions/src/sandbox/shared/paths.ts
+++ b/packages/agents-extensions/src/sandbox/shared/paths.ts
@@ -1,5 +1,4 @@
 import { UserError } from '@openai/agents-core';
-import { randomUUID } from 'node:crypto';
 import {
   type Manifest,
   normalizeRelativePath,
@@ -12,6 +11,11 @@ import {
 import type { RemoteSandboxPathOptions } from './types';
 
 export { posixDirname, shellQuote };
+
+type RuntimeCrypto = {
+  randomUUID?: () => string;
+  getRandomValues?: (array: Uint32Array) => Uint32Array;
+};
 
 export type RemotePathCommandResult = {
   status: number;
@@ -182,6 +186,20 @@ fi
 printf 'workspace escape: %s\n' "$resolved_candidate" >&2
 exit 111`;
 
+function createRemotePathHelperId(): string {
+  const crypto = (globalThis as typeof globalThis & { crypto?: RuntimeCrypto })
+    .crypto;
+  if (typeof crypto?.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  if (typeof crypto?.getRandomValues === 'function') {
+    return Array.from(crypto.getRandomValues(new Uint32Array(4)), (value) =>
+      value.toString(36),
+    ).join('-');
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
 export function resolveSandboxAbsolutePath(
   root: string,
   path?: string,
@@ -200,7 +218,7 @@ export async function validateRemoteSandboxPath({
   runCommand,
 }: ValidateRemoteSandboxPathArgs): Promise<string> {
   const candidate = resolveSandboxAbsolutePath(root, path, options);
-  const helperDir = `/tmp/openai-agents-resolve-path-${randomUUID()}`;
+  const helperDir = `/tmp/openai-agents-resolve-path-${createRemotePathHelperId()}`;
   const helperArgs = [
     root,
     candidate,

--- a/packages/agents-extensions/src/sandbox/shared/pty.ts
+++ b/packages/agents-extensions/src/sandbox/shared/pty.ts
@@ -99,6 +99,7 @@ export async function openPtyWebSocket(args: {
   url: string;
   providerName: string;
   headers?: Record<string, string>;
+  headersUnsupportedUrl?: string;
   timeoutMs?: number;
   configure?: (socket: PtyWebSocket) => void | Promise<void>;
 }): Promise<PtyWebSocket> {
@@ -221,11 +222,13 @@ async function createWebSocket(args: {
   url: string;
   providerName: string;
   headers?: Record<string, string>;
+  headersUnsupportedUrl?: string;
 }): Promise<PtyWebSocket> {
   if (!args.headers && typeof globalThis.WebSocket === 'function') {
     return new globalThis.WebSocket(args.url) as unknown as PtyWebSocket;
   }
 
+  let wsImportError: unknown;
   try {
     const mod = (await import('ws')) as {
       WebSocket?: new (
@@ -245,15 +248,25 @@ async function createWebSocket(args: {
       );
     }
   } catch (error) {
-    if (args.headers) {
-      throw new UserError(
-        `${args.providerName} PTY WebSocket support requires the optional \`ws\` package when headers are needed. ${(error as Error).message}`,
-      );
-    }
+    wsImportError = error;
   }
 
   if (typeof globalThis.WebSocket === 'function') {
-    return new globalThis.WebSocket(args.url) as unknown as PtyWebSocket;
+    if (!args.headers || args.headersUnsupportedUrl) {
+      return new globalThis.WebSocket(
+        args.headersUnsupportedUrl ?? args.url,
+      ) as unknown as PtyWebSocket;
+    }
+  }
+
+  if (args.headers) {
+    const reason =
+      wsImportError instanceof Error
+        ? wsImportError.message
+        : 'custom WebSocket headers are unavailable';
+    throw new UserError(
+      `${args.providerName} PTY WebSocket support requires the optional \`ws\` package when headers are needed. ${reason}`,
+    );
   }
 
   throw new UserError(

--- a/packages/agents-extensions/test/sandbox/cloudflare.test.ts
+++ b/packages/agents-extensions/test/sandbox/cloudflare.test.ts
@@ -1,0 +1,1734 @@
+import {
+  Manifest,
+  SandboxProviderError,
+  SandboxUnsupportedFeatureError,
+} from '@openai/agents-core/sandbox';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { CloudflareSandboxClient } from '../../src/sandbox/cloudflare';
+import { CloudflareBucketMountStrategy } from '../../src/sandbox/cloudflare/mounts';
+import { resolvedRemotePathFromValidationCommand } from './remotePathValidation';
+import { makeTarArchive } from './tarFixture';
+
+const originalFetch = global.fetch;
+const originalWebSocket = globalThis.WebSocket;
+
+function jsonResponse(body: unknown, status: number = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
+function sseExecResponse(
+  events: Array<{ event: string; data: string }>,
+  options: { trailingDelimiter?: boolean; lineEnding?: '\n' | '\r\n' } = {},
+): Response {
+  const lineEnding = options.lineEnding ?? '\n';
+  const delimiter = `${lineEnding}${lineEnding}`;
+  let body = events
+    .map(
+      ({ event, data }) =>
+        `event: ${event}${lineEnding}data: ${data}${delimiter}`,
+    )
+    .join('');
+  if (options.trailingDelimiter === false) {
+    body = body.endsWith(delimiter) ? body.slice(0, -delimiter.length) : body;
+  }
+  return new Response(body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/event-stream',
+    },
+  });
+}
+
+test('Cloudflare workerd-facing source avoids static Node-only imports', async () => {
+  const cloudflareSource = await readFile(
+    new URL('../../src/sandbox/cloudflare/sandbox.ts', import.meta.url),
+    'utf8',
+  );
+  const sharedIndexSource = await readFile(
+    new URL('../../src/sandbox/shared/index.ts', import.meta.url),
+    'utf8',
+  );
+
+  expect(cloudflareSource).not.toMatch(/from ['"]node:/u);
+  expect(cloudflareSource).not.toMatch(/\bBuffer\b/u);
+  expect(cloudflareSource).not.toMatch(/\bprocess\.env\b/u);
+  expect(cloudflareSource).not.toMatch(
+    /from ['"]\.\.\/shared\/localSources['"]/u,
+  );
+  expect(cloudflareSource).toMatch(
+    /import\(['"]\.\.\/shared\/localSources['"]\)/u,
+  );
+  expect(sharedIndexSource).not.toMatch(/from ['"]node:/u);
+  expect(sharedIndexSource).not.toMatch(/\bBuffer\b/u);
+  expect(sharedIndexSource).not.toMatch(/\bprocess\.env\b/u);
+  expect(sharedIndexSource).not.toContain('localSources');
+});
+
+describe('CloudflareSandboxClient', () => {
+  beforeEach(() => {
+    vi.doMock('ws', () => ({ WebSocket: TestWebSocket }));
+    global.fetch = vi.fn(async (input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+
+      if (url.endsWith('/v1/sandbox') && method === 'POST') {
+        return jsonResponse({ id: 'cf_test' });
+      }
+
+      if (url.includes('/exec') && method === 'POST') {
+        const payload = JSON.parse(String(init?.body)) as {
+          argv?: string[];
+        };
+        const shellCommand = payload.argv?.[2] ?? '';
+        const resolvedPath =
+          resolvedRemotePathFromValidationCommand(shellCommand);
+
+        if (resolvedPath) {
+          return sseExecResponse([
+            {
+              event: 'stdout',
+              data: Buffer.from(`${resolvedPath}\n`).toString('base64'),
+            },
+            { event: 'exit', data: JSON.stringify({ exit_code: 0 }) },
+          ]);
+        }
+
+        if (shellCommand.includes('mkdir -p')) {
+          return sseExecResponse([
+            { event: 'exit', data: JSON.stringify({ exit_code: 0 }) },
+          ]);
+        }
+
+        if (shellCommand.includes('ls')) {
+          return sseExecResponse([
+            {
+              event: 'stdout',
+              data: Buffer.from('README.md\n').toString('base64'),
+            },
+            { event: 'exit', data: JSON.stringify({ exit_code: 0 }) },
+          ]);
+        }
+
+        if (shellCommand.includes('unterminated-failure')) {
+          return sseExecResponse(
+            [
+              {
+                event: 'stderr',
+                data: Buffer.from('tail output\n').toString('base64'),
+              },
+              { event: 'exit', data: JSON.stringify({ exit_code: 7 }) },
+            ],
+            { trailingDelimiter: false },
+          );
+        }
+
+        return sseExecResponse([
+          { event: 'exit', data: JSON.stringify({ exit_code: 0 }) },
+        ]);
+      }
+
+      if (url.includes('/file/workspace/README.md') && method === 'PUT') {
+        return new Response(null, { status: 200 });
+      }
+
+      if (url.includes('/file/workspace/local.txt') && method === 'PUT') {
+        return new Response(null, { status: 200 });
+      }
+
+      if (url.includes('/file/tmp/data/note.txt') && method === 'GET') {
+        return new Response('old\n', { status: 200 });
+      }
+
+      if (url.includes('/file/tmp/data/note.txt') && method === 'PUT') {
+        return new Response(null, { status: 200 });
+      }
+
+      if (url.includes('/file/workspace/README.md') && method === 'GET') {
+        return new Response('# Hello\n', { status: 200 });
+      }
+
+      if (url.includes('/file/workspace/pixel.png') && method === 'GET') {
+        return sseExecResponse([
+          {
+            event: 'metadata',
+            data: JSON.stringify({ isBinary: true }),
+          },
+          {
+            event: 'chunk',
+            data: Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString('base64'),
+          },
+        ]);
+      }
+
+      if (url.includes('/file/workspace/commented.png') && method === 'GET') {
+        return new Response(
+          [
+            ': keepalive',
+            '',
+            'event: metadata',
+            `data: ${JSON.stringify({ isBinary: true })}`,
+            '',
+            'event: chunk',
+            `data: ${Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString('base64')}`,
+            '',
+          ].join('\n'),
+          {
+            status: 200,
+            headers: {
+              'Content-Type': 'text/event-stream',
+            },
+          },
+        );
+      }
+
+      if (url.includes('/v1/sandbox/cf_test/persist') && method === 'POST') {
+        return new Response(
+          makeTarArchive([{ name: 'README.md', content: '# Hello\n' }]),
+          { status: 200 },
+        );
+      }
+
+      if (url.includes('/v1/sandbox/cf_test/hydrate') && method === 'POST') {
+        return new Response(null, { status: 200 });
+      }
+
+      if (url.includes('/v1/sandbox/cf_test/mount') && method === 'POST') {
+        return new Response(null, { status: 200 });
+      }
+
+      if (url.includes('/v1/sandbox/cf_test/unmount') && method === 'POST') {
+        return new Response(null, { status: 200 });
+      }
+
+      if (url.includes('/v1/sandbox/cf_test/running') && method === 'GET') {
+        return jsonResponse({ running: true });
+      }
+
+      if (url.includes('/v1/sandbox/cf_test') && method === 'GET') {
+        return jsonResponse({ id: 'cf_test', status: 'running' });
+      }
+
+      if (url.includes('/v1/sandbox/cf_test') && method === 'DELETE') {
+        return new Response(null, { status: 200 });
+      }
+
+      return new Response(null, { status: 404 });
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.doUnmock('ws');
+    global.fetch = originalFetch;
+    globalThis.WebSocket = originalWebSocket;
+    TestWebSocket.instances = [];
+  });
+
+  test('rejects unsupported core create options instead of ignoring them', async () => {
+    const client = new CloudflareSandboxClient();
+
+    await expect(
+      client.create({
+        manifest: new Manifest(),
+        snapshot: { type: 'remote' },
+      }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+    await expect(
+      client.create({
+        manifest: new Manifest(),
+        concurrencyLimits: { manifestEntries: 2 },
+      }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+  });
+
+  test('wraps Cloudflare create worker failures as provider errors', async () => {
+    const client = new CloudflareSandboxClient();
+    vi.mocked(global.fetch).mockRejectedValueOnce(
+      new TypeError('network down'),
+    );
+
+    const createPromise = client.create(new Manifest(), {
+      workerUrl: 'https://worker.example.com',
+    });
+
+    await expect(createPromise).rejects.toBeInstanceOf(SandboxProviderError);
+    await expect(createPromise).rejects.toMatchObject({
+      details: {
+        provider: 'cloudflare',
+        operation: 'create sandbox',
+        workerUrl: 'https://worker.example.com',
+        cause: 'network down',
+      },
+    });
+  });
+
+  test('creates a sandbox, materializes the manifest, and executes commands', async () => {
+    const client = new CloudflareSandboxClient();
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          'README.md': {
+            type: 'file',
+            content: '# Hello\n',
+          },
+        },
+      }),
+      {
+        workerUrl: 'https://worker.example.com',
+      },
+    );
+
+    const output = await session.execCommand({ cmd: 'ls' });
+
+    expect(output).toContain('README.md');
+    expect(session.state.sandboxId).toBe('cf_test');
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://worker.example.com/v1/sandbox',
+      expect.objectContaining({
+        method: 'POST',
+      }),
+    );
+  });
+
+  test('rejects invalid sandbox ids returned by create', async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse({ id: '../cf_test' }),
+    );
+    const client = new CloudflareSandboxClient();
+
+    await expect(
+      client.create(new Manifest(), {
+        workerUrl: 'https://worker.example.com',
+      }),
+    ).rejects.toThrow(SandboxProviderError);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('rejects non-string sandbox ids returned by create', async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ id: 123 }));
+    const client = new CloudflareSandboxClient();
+
+    await expect(
+      client.create(new Manifest(), {
+        workerUrl: 'https://worker.example.com',
+      }),
+    ).rejects.toThrow(SandboxProviderError);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('treats missing command exit events as failures', async () => {
+    const client = new CloudflareSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workerUrl: 'https://worker.example.com',
+    });
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      sseExecResponse([
+        {
+          event: 'stdout',
+          data: Buffer.from('lost exit\n').toString('base64'),
+        },
+      ]),
+    );
+
+    const output = await session.execCommand({ cmd: 'lost-exit' });
+
+    expect(output).toContain('Process exited with code 1');
+    expect(output).toContain('lost exit');
+  });
+
+  test('applies provider timeout bundles to Cloudflare requests', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+      timeouts: {
+        execTimeoutMs: 101,
+        createTimeoutMs: 202,
+        requestTimeoutMs: 303,
+      },
+    });
+    const session = await client.create(new Manifest());
+
+    const createCall = vi
+      .mocked(global.fetch)
+      .mock.calls.find(([input]) => String(input).endsWith('/v1/sandbox'));
+    const createInit = createCall?.[1] as RequestInit | undefined;
+    expect(JSON.parse(String(createInit?.body))).toMatchObject({
+      timeoutMs: 101,
+      createTimeoutMs: 202,
+    });
+    expect(createInit?.signal).toBeInstanceOf(AbortSignal);
+
+    await session.execCommand({ cmd: 'ls' });
+    const execCall = vi
+      .mocked(global.fetch)
+      .mock.calls.find(([input]) => String(input).includes('/exec'));
+    const execInit = execCall?.[1] as RequestInit | undefined;
+    expect(JSON.parse(String(execInit?.body))).toMatchObject({
+      timeoutMs: 101,
+    });
+    expect(execInit?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test('materializes local file entries through the Node local source path', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'agents-cloudflare-test-'));
+    const sourceFile = join(tempDir, 'local.txt');
+    await writeFile(sourceFile, 'local source\n');
+    try {
+      const client = new CloudflareSandboxClient();
+      await client.create(
+        new Manifest({
+          entries: {
+            'local.txt': {
+              type: 'local_file',
+              src: sourceFile,
+            },
+          },
+        }),
+        {
+          workerUrl: 'https://worker.example.com',
+        },
+      );
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://worker.example.com/v1/sandbox/cf_test/file/workspace/local.txt',
+        expect.objectContaining({
+          method: 'PUT',
+          body: new TextEncoder().encode('local source\n').buffer,
+        }),
+      );
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test('deletes the sandbox when manifest application fails during create', async () => {
+    global.fetch = vi.fn(async (input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+
+      if (url.endsWith('/v1/sandbox') && method === 'POST') {
+        return jsonResponse({ id: 'cf_test' });
+      }
+
+      if (url.includes('/exec') && method === 'POST') {
+        const payload = JSON.parse(String(init?.body)) as {
+          argv?: string[];
+        };
+        const resolvedPath = resolvedRemotePathFromValidationCommand(
+          payload.argv?.[2] ?? '',
+        );
+        if (resolvedPath) {
+          return sseExecResponse([
+            {
+              event: 'stdout',
+              data: Buffer.from(`${resolvedPath}\n`).toString('base64'),
+            },
+            { event: 'exit', data: JSON.stringify({ exit_code: 0 }) },
+          ]);
+        }
+        return sseExecResponse([
+          { event: 'exit', data: JSON.stringify({ exit_code: 0 }) },
+        ]);
+      }
+
+      if (url.includes('/file/workspace/README.md') && method === 'PUT') {
+        return new Response('write failed', { status: 500 });
+      }
+
+      if (url.includes('/v1/sandbox/cf_test') && method === 'DELETE') {
+        return new Response(null, { status: 200 });
+      }
+
+      return new Response(null, { status: 404 });
+    }) as typeof fetch;
+    const client = new CloudflareSandboxClient();
+
+    await expect(
+      client.create(
+        new Manifest({
+          entries: {
+            'README.md': {
+              type: 'file',
+              content: '# Hello\n',
+            },
+          },
+        }),
+        {
+          workerUrl: 'https://worker.example.com',
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: 'provider_error',
+      details: {
+        provider: 'cloudflare',
+        operation: 'write file',
+        status: 500,
+        path: '/workspace/README.md',
+      },
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://worker.example.com/v1/sandbox/cf_test',
+      expect.objectContaining({
+        method: 'DELETE',
+      }),
+    );
+  });
+
+  test('resolves environment before creating the remote sandbox', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+
+    await expect(
+      client.create(
+        new Manifest({
+          environment: {
+            SECRET: {
+              value: 'placeholder',
+              resolve: async () => {
+                throw new Error('env failed');
+              },
+            },
+          },
+        }),
+      ),
+    ).rejects.toThrow('env failed');
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('wraps Cloudflare exec, read, and delete failures as provider errors', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+    const session = await client.create(new Manifest());
+
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response('unavailable', { status: 503 }),
+    );
+    await expect(session.execCommand({ cmd: 'ls' })).rejects.toMatchObject({
+      code: 'provider_error',
+      details: {
+        provider: 'cloudflare',
+        operation: 'execute command',
+        status: 503,
+        sandboxId: 'cf_test',
+      },
+    });
+
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(
+        sseExecResponse([
+          {
+            event: 'stdout',
+            data: Buffer.from('/workspace/missing.png\n').toString('base64'),
+          },
+          { event: 'exit', data: JSON.stringify({ exit_code: 0 }) },
+        ]),
+      )
+      .mockResolvedValueOnce(new Response('missing', { status: 404 }));
+    await expect(
+      session.viewImage({ path: 'missing.png' }),
+    ).rejects.toMatchObject({
+      code: 'workspace_read_not_found',
+      details: {
+        provider: 'cloudflare',
+        status: 404,
+        sandboxId: 'cf_test',
+        path: '/workspace/missing.png',
+      },
+    });
+
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response('delete failed', { status: 500 }),
+    );
+    await expect(session.delete()).rejects.toMatchObject({
+      code: 'provider_error',
+      details: {
+        provider: 'cloudflare',
+        operation: 'delete sandbox',
+        status: 500,
+        sandboxId: 'cf_test',
+      },
+    });
+  });
+
+  test('rejects non-workspace roots when applying manifests to sessions', async () => {
+    const client = new CloudflareSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workerUrl: 'https://worker.example.com',
+    });
+    vi.mocked(global.fetch).mockClear();
+
+    await expect(
+      session.applyManifest(
+        new Manifest({
+          root: '/tmp',
+          entries: {
+            'next.txt': {
+              type: 'file',
+              content: 'next\n',
+            },
+          },
+        }),
+      ),
+    ).rejects.toThrow(
+      'Cloudflare sandboxes currently require manifest.root="/workspace".',
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('fails fast when manifest directory creation exits non-zero', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+    const session = await client.resume({
+      manifest: new Manifest(),
+      workerUrl: 'https://worker.example.com',
+      sandboxId: 'cf_test',
+      environment: {},
+    });
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(
+        sseExecResponse([
+          {
+            event: 'stdout',
+            data: Buffer.from('/workspace/new-dir\n').toString('base64'),
+          },
+          { event: 'exit', data: JSON.stringify({ exit_code: 0 }) },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        sseExecResponse([
+          {
+            event: 'stderr',
+            data: Buffer.from('permission denied\n').toString('base64'),
+          },
+          { event: 'exit', data: JSON.stringify({ exit_code: 13 }) },
+        ]),
+      );
+
+    await expect(
+      session.applyManifest(
+        new Manifest({
+          entries: {
+            'new-dir': {
+              type: 'dir',
+            },
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: 'provider_error',
+      details: {
+        provider: 'cloudflare',
+        operation: 'create directory',
+        path: '/workspace/new-dir',
+        exitCode: 13,
+        output: 'permission denied',
+      },
+    });
+  });
+
+  test('fails fast when file materialization parent mkdir exits non-zero', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+    const session = await client.resume({
+      manifest: new Manifest(),
+      workerUrl: 'https://worker.example.com',
+      sandboxId: 'cf_test',
+      environment: {},
+    });
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(
+        sseExecResponse([
+          {
+            event: 'stdout',
+            data: Buffer.from('/workspace/nested/file.txt\n').toString(
+              'base64',
+            ),
+          },
+          { event: 'exit', data: JSON.stringify({ exit_code: 0 }) },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        sseExecResponse([
+          {
+            event: 'stderr',
+            data: Buffer.from('read-only filesystem\n').toString('base64'),
+          },
+          { event: 'exit', data: JSON.stringify({ exit_code: 30 }) },
+        ]),
+      );
+
+    await expect(
+      session.applyManifest(
+        new Manifest({
+          entries: {
+            'nested/file.txt': {
+              type: 'file',
+              content: 'hello\n',
+            },
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: 'provider_error',
+      details: {
+        provider: 'cloudflare',
+        operation: 'create parent directory',
+        path: '/workspace/nested',
+        exitCode: 30,
+        output: 'read-only filesystem',
+      },
+    });
+  });
+
+  test('fails fast when editor mkdir exits non-zero', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+    const session = await client.resume({
+      manifest: new Manifest(),
+      workerUrl: 'https://worker.example.com',
+      sandboxId: 'cf_test',
+      environment: {},
+    });
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(
+        sseExecResponse([
+          {
+            event: 'stdout',
+            data: Buffer.from('/workspace/nested/file.txt\n').toString(
+              'base64',
+            ),
+          },
+          { event: 'exit', data: JSON.stringify({ exit_code: 0 }) },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        sseExecResponse([
+          {
+            event: 'stdout',
+            data: Buffer.from('/workspace/nested/file.txt\n').toString(
+              'base64',
+            ),
+          },
+          { event: 'exit', data: JSON.stringify({ exit_code: 0 }) },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        sseExecResponse([
+          { event: 'exit', data: JSON.stringify({ exit_code: 1 }) },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        sseExecResponse([
+          {
+            event: 'stderr',
+            data: Buffer.from('mkdir failed\n').toString('base64'),
+          },
+          { event: 'exit', data: JSON.stringify({ exit_code: 1 }) },
+        ]),
+      );
+
+    await expect(
+      session.createEditor().createFile({
+        type: 'create_file',
+        path: 'nested/file.txt',
+        diff: '+hello\n',
+      }),
+    ).rejects.toMatchObject({
+      code: 'provider_error',
+      details: {
+        provider: 'cloudflare',
+        operation: 'create directory',
+        path: '/workspace/nested',
+        exitCode: 1,
+        output: 'mkdir failed',
+      },
+    });
+  });
+
+  test('parses the trailing SSE frame before returning exec output', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+    const session = await client.resume({
+      manifest: new Manifest(),
+      workerUrl: 'https://worker.example.com',
+      sandboxId: 'cf_test',
+      environment: {},
+    });
+
+    const output = await session.execCommand({ cmd: 'unterminated-failure' });
+
+    expect(output).toContain('tail output');
+    expect(output).toContain('Process exited with code 7');
+  });
+
+  test('parses CRLF-delimited SSE command output', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+    const session = await client.resume({
+      manifest: new Manifest(),
+      workerUrl: 'https://worker.example.com',
+      sandboxId: 'cf_test',
+      environment: {},
+    });
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      sseExecResponse(
+        [
+          {
+            event: 'stdout',
+            data: Buffer.from('crlf output\n').toString('base64'),
+          },
+          { event: 'exit', data: JSON.stringify({ exit_code: 0 }) },
+        ],
+        { lineEnding: '\r\n' },
+      ),
+    );
+
+    const output = await session.execCommand({ cmd: 'crlf-output' });
+
+    expect(output).toContain('crlf output');
+    expect(output).not.toContain('Process exited with code 1');
+  });
+
+  test('decodes binary file SSE that starts with a metadata event', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+    const session = await client.resume({
+      manifest: new Manifest(),
+      workerUrl: 'https://worker.example.com',
+      sandboxId: 'cf_test',
+      environment: {},
+    });
+
+    const image = await session.viewImage({ path: 'pixel.png' });
+    const payload = image.image as { data: Uint8Array; mediaType?: string };
+
+    expect(payload.mediaType).toBe('image/png');
+    expect([...payload.data.slice(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
+  });
+
+  test('decodes multiline base64 SSE binary payloads', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+    const session = await client.resume({
+      manifest: new Manifest(),
+      workerUrl: 'https://worker.example.com',
+      sandboxId: 'cf_test',
+      environment: {},
+    });
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(
+        sseExecResponse([
+          {
+            event: 'stdout',
+            data: Buffer.from('/workspace/multiline.png\n').toString('base64'),
+          },
+          { event: 'exit', data: JSON.stringify({ exit_code: 0 }) },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          [
+            'event: metadata',
+            `data: ${JSON.stringify({ isBinary: true })}`,
+            '',
+            'event: chunk',
+            'data: iVBO',
+            'data: Rw==',
+            '',
+          ].join('\n'),
+          {
+            status: 200,
+            headers: {
+              'Content-Type': 'text/event-stream',
+            },
+          },
+        ),
+      );
+
+    const image = await session.viewImage({ path: 'multiline.png' });
+    const payload = image.image as { data: Uint8Array; mediaType?: string };
+
+    expect(payload.mediaType).toBe('image/png');
+    expect([...payload.data.slice(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
+  });
+
+  test('returns raw SSE-like file payloads without binary metadata', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+    const session = await client.resume({
+      manifest: new Manifest(),
+      workerUrl: 'https://worker.example.com',
+      sandboxId: 'cf_test',
+      environment: {},
+    });
+    const rawText = ['event: chunk', 'data: not base64', ''].join('\n');
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response(rawText, {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/plain',
+        },
+      }),
+    );
+    const readFileBytes = (
+      session as unknown as {
+        readFileBytes(path: string): Promise<Uint8Array>;
+      }
+    ).readFileBytes.bind(session);
+
+    const bytes = await readFileBytes('/workspace/sse-like.txt');
+
+    expect(new TextDecoder().decode(bytes)).toBe(rawText);
+  });
+
+  test('decodes binary file SSE that starts with a comment frame', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+    const session = await client.resume({
+      manifest: new Manifest(),
+      workerUrl: 'https://worker.example.com',
+      sandboxId: 'cf_test',
+      environment: {},
+    });
+
+    const image = await session.viewImage({ path: 'commented.png' });
+    const payload = image.image as { data: Uint8Array; mediaType?: string };
+
+    expect(payload.mediaType).toBe('image/png');
+    expect([...payload.data.slice(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
+  });
+
+  test('decodes CRLF-delimited binary file SSE', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+    const session = await client.resume({
+      manifest: new Manifest(),
+      workerUrl: 'https://worker.example.com',
+      sandboxId: 'cf_test',
+      environment: {},
+    });
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(
+        sseExecResponse([
+          {
+            event: 'stdout',
+            data: Buffer.from('/workspace/crlf.png\n').toString('base64'),
+          },
+          { event: 'exit', data: JSON.stringify({ exit_code: 0 }) },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        sseExecResponse(
+          [
+            {
+              event: 'metadata',
+              data: JSON.stringify({ isBinary: true }),
+            },
+            {
+              event: 'chunk',
+              data: Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString('base64'),
+            },
+          ],
+          { lineEnding: '\r\n' },
+        ),
+      );
+
+    const image = await session.viewImage({ path: 'crlf.png' });
+    const payload = image.image as { data: Uint8Array; mediaType?: string };
+
+    expect(payload.mediaType).toBe('image/png');
+    expect([...payload.data.slice(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
+  });
+
+  test('rejects unsafe environment names before building shell commands', async () => {
+    const client = new CloudflareSandboxClient();
+    const session = await client.create(
+      new Manifest({
+        environment: {
+          'X; touch /tmp/pwned; #': 'bad',
+        },
+      }),
+      {
+        workerUrl: 'https://worker.example.com',
+      },
+    );
+
+    await expect(session.execCommand({ cmd: 'ls' })).rejects.toThrow(
+      'Invalid environment variable name',
+    );
+  });
+
+  test('closes PTY sockets when command building fails before registration', async () => {
+    globalThis.WebSocket =
+      TestWebSocket as unknown as typeof globalThis.WebSocket;
+    const client = new CloudflareSandboxClient();
+    const session = await client.create(
+      new Manifest({
+        environment: {
+          'X; touch /tmp/pwned; #': 'bad',
+        },
+      }),
+      {
+        workerUrl: 'https://worker.example.com',
+      },
+    );
+
+    const startedPromise = session.execCommand({
+      cmd: 'ls',
+      tty: true,
+      yieldTimeMs: 250,
+    });
+    const socket = await TestWebSocket.nextInstance();
+    socket.open();
+    socket.message(JSON.stringify({ type: 'ready' }));
+
+    await expect(startedPromise).rejects.toThrow(
+      'Invalid environment variable name',
+    );
+    expect(socket.readyState).toBe(3);
+    expect(socket.sent).toHaveLength(0);
+  });
+
+  test('closes PTY sockets when initial command send fails before registration', async () => {
+    globalThis.WebSocket =
+      TestWebSocket as unknown as typeof globalThis.WebSocket;
+    const client = new CloudflareSandboxClient({ apiKey: '' });
+    const session = await client.create(new Manifest(), {
+      workerUrl: 'https://worker.example.com',
+    });
+
+    const startedPromise = session.execCommand({
+      cmd: 'echo ready',
+      tty: true,
+      yieldTimeMs: 250,
+    });
+    const socket = await TestWebSocket.nextInstance();
+    socket.send = vi.fn(() => {
+      throw new Error('send failed');
+    });
+    socket.open();
+    socket.message(JSON.stringify({ type: 'ready' }));
+
+    await expect(startedPromise).rejects.toThrow('send failed');
+    expect(socket.readyState).toBe(3);
+  });
+
+  test('supports PTY execution and stdin through the worker websocket', async () => {
+    globalThis.WebSocket =
+      TestWebSocket as unknown as typeof globalThis.WebSocket;
+    const client = new CloudflareSandboxClient({ apiKey: '' });
+    const session = await client.create(new Manifest(), {
+      workerUrl: 'https://worker.example.com',
+    });
+
+    const startedPromise = session.execCommand({
+      cmd: 'echo ready',
+      tty: true,
+      yieldTimeMs: 250,
+    });
+    const socket = await TestWebSocket.nextInstance();
+    const firstSend = socket.nextSend();
+    socket.open();
+    socket.message(JSON.stringify({ type: 'ready' }));
+    await firstSend;
+    socket.message(new TextEncoder().encode('ready\n'));
+    const started = await startedPromise;
+    const sessionId = Number(
+      started.match(/Process running with session ID (\d+)/)?.[1],
+    );
+
+    const secondSend = socket.nextSend();
+    const writePromise = session.writeStdin({
+      sessionId,
+      chars: 'echo next\n',
+      yieldTimeMs: 250,
+    });
+    await secondSend;
+    socket.message(new TextEncoder().encode('next\n'));
+    socket.message(JSON.stringify({ type: 'exit', code: 0 }));
+    const next = await writePromise;
+
+    expect(socket.url).toBe(
+      'wss://worker.example.com/v1/sandbox/cf_test/pty?cols=80&rows=24',
+    );
+    expect(new TextDecoder().decode(socket.sent[0] as Uint8Array)).toBe(
+      "/bin/sh -c 'cd '\\''/workspace'\\'' && echo ready'\n",
+    );
+    expect(new TextDecoder().decode(socket.sent[1] as Uint8Array)).toBe(
+      'echo next\n',
+    );
+    expect(started).toContain('ready');
+    expect(next).toContain('next');
+    expect(next).toContain('Process exited with code 0');
+  });
+
+  test('preserves plain-text PTY websocket frames as output', async () => {
+    globalThis.WebSocket =
+      TestWebSocket as unknown as typeof globalThis.WebSocket;
+    const client = new CloudflareSandboxClient({ apiKey: '' });
+    const session = await client.create(new Manifest(), {
+      workerUrl: 'https://worker.example.com',
+    });
+
+    const startedPromise = session.execCommand({
+      cmd: 'echo ready',
+      tty: true,
+      yieldTimeMs: 250,
+    });
+    const socket = await TestWebSocket.nextInstance();
+    const firstSend = socket.nextSend();
+    socket.open();
+    socket.message(JSON.stringify({ type: 'ready' }));
+    await firstSend;
+    socket.message('plain text output\n');
+    const started = await startedPromise;
+
+    expect(started).toContain('plain text output');
+    expect(started).toContain('Process running with session ID');
+  });
+
+  test('rejects PTY error control frames before ready', async () => {
+    globalThis.WebSocket =
+      TestWebSocket as unknown as typeof globalThis.WebSocket;
+    const client = new CloudflareSandboxClient({ apiKey: '' });
+    const session = await client.create(new Manifest(), {
+      workerUrl: 'https://worker.example.com',
+    });
+
+    const startedPromise = session.execCommand({
+      cmd: 'echo ready',
+      tty: true,
+      yieldTimeMs: 250,
+    });
+    const socket = await TestWebSocket.nextInstance();
+    socket.open();
+    socket.message(JSON.stringify({ type: 'error', message: 'pty disabled' }));
+
+    await expect(startedPromise).rejects.toThrow(
+      'CloudflareSandboxClient PTY failed before ready: pty disabled',
+    );
+    expect(socket.sent).toHaveLength(0);
+  });
+
+  test('captures binary PTY frames before the ready handshake completes', async () => {
+    globalThis.WebSocket =
+      TestWebSocket as unknown as typeof globalThis.WebSocket;
+    const client = new CloudflareSandboxClient({ apiKey: '' });
+    const session = await client.create(new Manifest(), {
+      workerUrl: 'https://worker.example.com',
+    });
+
+    const startedPromise = session.execCommand({
+      cmd: 'echo ready',
+      tty: true,
+      yieldTimeMs: 250,
+    });
+    const socket = await TestWebSocket.nextInstance();
+    const firstSend = socket.nextSend();
+    socket.open();
+    socket.message(new TextEncoder().encode('boot output\n'));
+    socket.message(JSON.stringify({ type: 'ready' }));
+    await firstSend;
+    const started = await startedPromise;
+
+    expect(started).toContain('boot output');
+    expect(started).toContain('Process running with session ID');
+  });
+
+  test('parses PTY control messages delivered as binary websocket frames', async () => {
+    globalThis.WebSocket =
+      TestWebSocket as unknown as typeof globalThis.WebSocket;
+    const client = new CloudflareSandboxClient({ apiKey: '' });
+    const session = await client.create(new Manifest(), {
+      workerUrl: 'https://worker.example.com',
+    });
+
+    const startedPromise = session.execCommand({
+      cmd: 'exit 7',
+      tty: true,
+      yieldTimeMs: 250,
+    });
+    const socket = await TestWebSocket.nextInstance();
+    const firstSend = socket.nextSend();
+    socket.open();
+    socket.message(JSON.stringify({ type: 'ready' }));
+    await firstSend;
+    socket.message(Buffer.from(JSON.stringify({ type: 'exit', code: 7 })));
+    const started = await startedPromise;
+
+    expect(started).toContain('Process exited with code 7');
+  });
+
+  test('passes PTY auth through WebSocket headers for native runtimes', async () => {
+    globalThis.WebSocket =
+      TestWebSocket as unknown as typeof globalThis.WebSocket;
+    const client = new CloudflareSandboxClient({ apiKey: 'secret-token' });
+    const session = await client.create(new Manifest(), {
+      workerUrl: 'https://worker.example.com',
+    });
+
+    const startedPromise = session.execCommand({
+      cmd: 'echo ready',
+      tty: true,
+      yieldTimeMs: 250,
+    });
+    const socket = await TestWebSocket.nextInstance();
+    const firstSend = socket.nextSend();
+    socket.open();
+    socket.message(JSON.stringify({ type: 'ready' }));
+    await firstSend;
+    socket.message(JSON.stringify({ type: 'exit', code: 0 }));
+    const started = await startedPromise;
+    const socketUrl = new URL(socket.url);
+
+    expect(socketUrl.searchParams.has('authorization')).toBe(false);
+    expect(socketUrl.searchParams.get('cols')).toBe('80');
+    expect(socketUrl.searchParams.get('rows')).toBe('24');
+    expect(socket.options?.headers).toEqual({
+      Authorization: 'Bearer secret-token',
+    });
+    expect(started).toContain('Process exited with code 0');
+  });
+
+  test('preserves PTY exit codes after the worker websocket closes', async () => {
+    globalThis.WebSocket =
+      TestWebSocket as unknown as typeof globalThis.WebSocket;
+    const client = new CloudflareSandboxClient({ apiKey: '' });
+    const session = await client.create(new Manifest(), {
+      workerUrl: 'https://worker.example.com',
+    });
+
+    const startedPromise = session.execCommand({
+      cmd: 'echo ready',
+      tty: true,
+      yieldTimeMs: 250,
+    });
+    const socket = await TestWebSocket.nextInstance();
+    const firstSend = socket.nextSend();
+    socket.open();
+    socket.message(JSON.stringify({ type: 'ready' }));
+    await firstSend;
+    socket.message(JSON.stringify({ type: 'exit', code: 0 }));
+    socket.close();
+    const started = await startedPromise;
+
+    expect(started).toContain('Process exited with code 0');
+    expect(started).not.toContain('Process exited with code 1');
+  });
+
+  test('does not clobber PTY exit codes on websocket errors after exit', async () => {
+    globalThis.WebSocket =
+      TestWebSocket as unknown as typeof globalThis.WebSocket;
+    const client = new CloudflareSandboxClient({ apiKey: '' });
+    const session = await client.create(new Manifest(), {
+      workerUrl: 'https://worker.example.com',
+    });
+
+    const startedPromise = session.execCommand({
+      cmd: 'echo ready',
+      tty: true,
+      yieldTimeMs: 250,
+    });
+    const socket = await TestWebSocket.nextInstance();
+    const firstSend = socket.nextSend();
+    socket.open();
+    socket.message(JSON.stringify({ type: 'ready' }));
+    await firstSend;
+    socket.message(JSON.stringify({ type: 'exit', code: 0 }));
+    socket.error();
+    const started = await startedPromise;
+
+    expect(started).toContain('Process exited with code 0');
+    expect(started).not.toContain('Process exited with code 1');
+  });
+
+  test('honors workdir and environment for PTY execution', async () => {
+    globalThis.WebSocket =
+      TestWebSocket as unknown as typeof globalThis.WebSocket;
+    const client = new CloudflareSandboxClient({ apiKey: '' });
+    const session = await client.create(
+      new Manifest({
+        environment: {
+          NODE_ENV: 'test',
+        },
+      }),
+      {
+        workerUrl: 'https://worker.example.com',
+      },
+    );
+
+    const startedPromise = session.execCommand({
+      cmd: 'npm test',
+      workdir: 'app',
+      tty: true,
+      yieldTimeMs: 250,
+    });
+    const socket = await TestWebSocket.nextInstance();
+    const firstSend = socket.nextSend();
+    socket.open();
+    socket.message(JSON.stringify({ type: 'ready' }));
+    await firstSend;
+    socket.message(JSON.stringify({ type: 'exit', code: 0 }));
+    await startedPromise;
+
+    expect(new TextDecoder().decode(socket.sent[0] as Uint8Array)).toBe(
+      "/bin/sh -c 'cd '\\''/workspace/app'\\'' && export NODE_ENV='\\''test'\\'' && npm test'\n",
+    );
+  });
+
+  test('resumes from serialized state and deletes on close', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+    const session = await client.resume({
+      manifest: new Manifest(),
+      workerUrl: 'https://worker.example.com',
+      sandboxId: 'cf_test',
+      environment: {},
+    });
+
+    await session.close();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://worker.example.com/v1/sandbox/cf_test',
+      expect.objectContaining({
+        method: 'DELETE',
+      }),
+    );
+  });
+
+  test('requires a sandbox id when resuming from serialized state', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+
+    await expect(
+      client.resume({
+        manifest: new Manifest(),
+        workerUrl: 'https://worker.example.com',
+        sandboxId: '',
+        environment: {},
+      }),
+    ).rejects.toThrow(
+      'Cloudflare sandbox resume requires a persisted sandboxId.',
+    );
+  });
+
+  test('requires a safe sandbox id when resuming from serialized state', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+
+    await expect(
+      client.resume({
+        manifest: new Manifest(),
+        workerUrl: 'https://worker.example.com',
+        sandboxId: '../cf_test',
+        environment: {},
+      }),
+    ).rejects.toThrow(
+      'Cloudflare sandbox persisted sandboxId must be a safe path segment.',
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('requires a string sandbox id when resuming from serialized state', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+
+    await expect(
+      client.resume({
+        manifest: new Manifest(),
+        workerUrl: 'https://worker.example.com',
+        sandboxId: 123 as unknown as string,
+        environment: {},
+      }),
+    ).rejects.toThrow(
+      'Cloudflare sandbox persisted sandboxId must be a safe path segment.',
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('requires an absolute worker URL when resuming serialized state', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+
+    await expect(
+      client.resume({
+        manifest: new Manifest(),
+        workerUrl: '/relative-worker',
+        sandboxId: 'cf_test',
+        environment: {},
+      }),
+    ).rejects.toThrow(
+      'Cloudflare sandbox persisted workerUrl must be an absolute http(s) URL.',
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('rejects invalid manifests when resuming serialized state', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+
+    await expect(
+      client.resume({
+        manifest: new Manifest({ root: '/tmp' }),
+        workerUrl: 'https://worker.example.com',
+        sandboxId: 'cf_test',
+        environment: {},
+      }),
+    ).rejects.toThrow(
+      'Cloudflare sandboxes currently require manifest.root="/workspace".',
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+
+    await expect(
+      client.resume({
+        manifest: new Manifest({
+          entries: {
+            data: {
+              type: 's3_mount',
+              bucket: 'logs',
+              region: 'us-east-1',
+              accessKeyId: 'access-key',
+              secretAccessKey: 'secret-key',
+            },
+          },
+        }),
+        workerUrl: 'https://worker.example.com',
+        sandboxId: 'cf_test',
+        environment: {},
+      }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('rejects stale sandboxes during resume before commands run', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+
+    await expect(
+      client.resume({
+        manifest: new Manifest(),
+        workerUrl: 'https://worker.example.com',
+        sandboxId: 'cf_stale',
+        environment: {},
+      }),
+    ).rejects.toThrow('Cloudflare sandbox cf_stale is no longer running.');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://worker.example.com/v1/sandbox/cf_stale/running',
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+    expect(global.fetch).not.toHaveBeenCalledWith(
+      expect.stringContaining('/v1/sandbox/cf_stale/exec'),
+      expect.anything(),
+    );
+  });
+
+  test('wraps Cloudflare running lookup failures during resume as provider errors', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response(null, { status: 503 }),
+    );
+
+    const resumePromise = client.resume({
+      manifest: new Manifest(),
+      workerUrl: 'https://worker.example.com',
+      sandboxId: 'cf_test',
+      environment: {},
+    });
+
+    await expect(resumePromise).rejects.toBeInstanceOf(SandboxProviderError);
+    await expect(resumePromise).rejects.toMatchObject({
+      details: {
+        provider: 'cloudflare',
+        operation: 'check running state',
+        sandboxId: 'cf_test',
+        status: 503,
+      },
+    });
+  });
+
+  test('checks running state through the worker status endpoint', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+    const session = await client.resume({
+      manifest: new Manifest(),
+      workerUrl: 'https://worker.example.com',
+      sandboxId: 'cf_test',
+      environment: {},
+    });
+
+    await expect(session.running()).resolves.toBe(true);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://worker.example.com/v1/sandbox/cf_test/running',
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+  });
+
+  test('persists and hydrates workspaces through worker archive endpoints', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+    const session = await client.resume({
+      manifest: new Manifest({
+        entries: {
+          'tmp.txt': {
+            type: 'file',
+            content: 'tmp',
+            ephemeral: true,
+          },
+        },
+      }),
+      workerUrl: 'https://worker.example.com',
+      sandboxId: 'cf_test',
+      environment: {},
+    });
+
+    const archive = await session.persistWorkspace();
+    await session.hydrateWorkspace(archive);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://worker.example.com/v1/sandbox/cf_test/persist?excludes=tmp.txt',
+      expect.objectContaining({
+        method: 'POST',
+      }),
+    );
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://worker.example.com/v1/sandbox/cf_test/hydrate',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.any(ArrayBuffer),
+      }),
+    );
+  });
+
+  test('rejects unsupported manifest metadata during resume', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+
+    await expect(
+      client.resume({
+        manifest: new Manifest({
+          extraPathGrants: [{ path: '/tmp/data' }],
+        }),
+        workerUrl: 'https://worker.example.com',
+        sandboxId: 'cf_test',
+        environment: {},
+      }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('reports configured exposed ports as unsupported until worker resolution exists', async () => {
+    const client = new CloudflareSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workerUrl: 'https://worker.example.com',
+      exposedPorts: [3000],
+    });
+
+    await expect(session.resolveExposedPort(3000)).rejects.toBeInstanceOf(
+      SandboxUnsupportedFeatureError,
+    );
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://worker.example.com/v1/sandbox',
+      expect.objectContaining({
+        body: JSON.stringify({ exposedPorts: [3000] }),
+      }),
+    );
+  });
+
+  test('mounts Cloudflare bucket entries through worker endpoints', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+    await client.create(
+      new Manifest({
+        entries: {
+          data: {
+            type: 's3_mount',
+            bucket: 'logs',
+            prefix: '2026/04',
+            region: 'us-east-1',
+            accessKeyId: 'access-key',
+            secretAccessKey: 'secret-key',
+            mountPath: 'mounted/logs',
+            mountStrategy: new CloudflareBucketMountStrategy(),
+          },
+        },
+      }),
+    );
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://worker.example.com/v1/sandbox/cf_test/mount',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          bucket: 'logs',
+          mountPath: '/workspace/mounted/logs',
+          options: {
+            endpoint: 'https://s3.us-east-1.amazonaws.com',
+            provider: 's3',
+            readOnly: true,
+            prefix: '/2026/04/',
+            credentials: {
+              accessKeyId: 'access-key',
+              secretAccessKey: 'secret-key',
+            },
+          },
+        }),
+      }),
+    );
+  });
+
+  test('forwards Cloudflare bucket provider hints for R2 custom domains', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+    await client.create(
+      new Manifest({
+        entries: {
+          data: {
+            type: 'r2_mount',
+            bucket: 'logs',
+            customDomain: 'https://logs.example.com',
+            mountPath: 'mounted/logs',
+            mountStrategy: new CloudflareBucketMountStrategy(),
+          },
+        },
+      }),
+    );
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://worker.example.com/v1/sandbox/cf_test/mount',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          bucket: 'logs',
+          mountPath: '/workspace/mounted/logs',
+          options: {
+            endpoint: 'https://logs.example.com',
+            provider: 'r2',
+            readOnly: true,
+          },
+        }),
+      }),
+    );
+  });
+});
+
+class TestWebSocket {
+  static instances: TestWebSocket[] = [];
+  private static instanceWaiters: Array<(socket: TestWebSocket) => void> = [];
+  readonly sent: Array<string | Uint8Array | ArrayBuffer> = [];
+  readyState = 0;
+  binaryType = '';
+  private readonly listeners = new Map<string, Set<(event: unknown) => void>>();
+  private sendWaiters: Array<
+    (data: string | Uint8Array | ArrayBuffer) => void
+  > = [];
+
+  constructor(
+    readonly url: string,
+    readonly options?: { headers?: Record<string, string> },
+  ) {
+    TestWebSocket.instances.push(this);
+    const waiter = TestWebSocket.instanceWaiters.shift();
+    waiter?.(this);
+  }
+
+  static async nextInstance(): Promise<TestWebSocket> {
+    const existing = TestWebSocket.instances.at(-1);
+    if (existing) {
+      return existing;
+    }
+    return await new Promise((resolve) => {
+      TestWebSocket.instanceWaiters.push(resolve);
+    });
+  }
+
+  addEventListener(type: string, listener: (event: unknown) => void): void {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: (event: unknown) => void): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  send(data: string | Uint8Array | ArrayBuffer): void {
+    this.sent.push(data);
+    const waiter = this.sendWaiters.shift();
+    waiter?.(data);
+  }
+
+  close(): void {
+    if (this.readyState === 3) {
+      return;
+    }
+    this.readyState = 3;
+    this.dispatch('close', {});
+  }
+
+  error(): void {
+    this.dispatch('error', {});
+  }
+
+  open(): void {
+    this.readyState = 1;
+    this.dispatch('open', {});
+  }
+
+  message(data: unknown): void {
+    this.dispatch('message', { data });
+  }
+
+  async nextSend(): Promise<string | Uint8Array | ArrayBuffer> {
+    return await new Promise((resolve) => {
+      this.sendWaiters.push(resolve);
+    });
+  }
+
+  private dispatch(type: string, event: unknown): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}

--- a/packages/agents-extensions/test/sandbox/cloudflare.test.ts
+++ b/packages/agents-extensions/test/sandbox/cloudflare.test.ts
@@ -1181,6 +1181,40 @@ describe('CloudflareSandboxClient', () => {
     expect(started).toContain('Process exited with code 7');
   });
 
+  test('passes PTY auth through the URL when WebSocket headers are unavailable', async () => {
+    vi.doMock('ws', () => {
+      throw new Error('ws unavailable');
+    });
+    globalThis.WebSocket =
+      TestWebSocket as unknown as typeof globalThis.WebSocket;
+    const client = new CloudflareSandboxClient({ apiKey: 'secret-token' });
+    const session = await client.create(new Manifest(), {
+      workerUrl: 'https://worker.example.com',
+    });
+
+    const startedPromise = session.execCommand({
+      cmd: 'echo ready',
+      tty: true,
+      yieldTimeMs: 250,
+    });
+    const socket = await TestWebSocket.nextInstance();
+    const firstSend = socket.nextSend();
+    socket.open();
+    socket.message(JSON.stringify({ type: 'ready' }));
+    await firstSend;
+    socket.message(JSON.stringify({ type: 'exit', code: 0 }));
+    const started = await startedPromise;
+    const socketUrl = new URL(socket.url);
+
+    expect(socketUrl.searchParams.get('authorization')).toBe(
+      'Bearer secret-token',
+    );
+    expect(socketUrl.searchParams.get('cols')).toBe('80');
+    expect(socketUrl.searchParams.get('rows')).toBe('24');
+    expect(socket.options).toBeUndefined();
+    expect(started).toContain('Process exited with code 0');
+  });
+
   test('passes PTY auth through WebSocket headers for native runtimes', async () => {
     globalThis.WebSocket =
       TestWebSocket as unknown as typeof globalThis.WebSocket;

--- a/packages/agents-extensions/test/sandbox/cloudflare.test.ts
+++ b/packages/agents-extensions/test/sandbox/cloudflare.test.ts
@@ -371,9 +371,12 @@ describe('CloudflareSandboxClient', () => {
       .mocked(global.fetch)
       .mock.calls.find(([input]) => String(input).includes('/exec'));
     const execInit = execCall?.[1] as RequestInit | undefined;
-    expect(JSON.parse(String(execInit?.body))).toMatchObject({
-      timeoutMs: 101,
-    });
+    const execBody = JSON.parse(String(execInit?.body)) as Record<
+      string,
+      unknown
+    >;
+    expect(execBody).toMatchObject({ timeout_ms: 101 });
+    expect(execBody).not.toHaveProperty('timeoutMs');
     expect(execInit?.signal).toBeInstanceOf(AbortSignal);
   });
 
@@ -1640,7 +1643,7 @@ describe('CloudflareSandboxClient', () => {
             endpoint: 'https://s3.us-east-1.amazonaws.com',
             provider: 's3',
             readOnly: true,
-            prefix: '/2026/04/',
+            prefix: '2026/04',
             credentials: {
               accessKeyId: 'access-key',
               secretAccessKey: 'secret-key',


### PR DESCRIPTION
This pull request adds a sandbox provider as part of agents-extensions package: https://developers.openai.com/api/docs/guides/agents/sandboxes

How to run:
```zsh
git clone https://github.com/openai/openai-agents-js
cd openai-agents-js/
git checkout feat/sandbox-agents-cloudflare
pnpm i
pnpm build
pnpm -F sandbox start:cloudflare
```