### PR TITLE
feat(sandbox): add Runloop provider

### DIFF
--- a/.changeset/sandbox-agents-runloop.md
+++ b/.changeset/sandbox-agents-runloop.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': minor
+---
+
+feat: add Runloop sandbox provider

--- a/examples/sandbox/extensions/runloop-runner.ts
+++ b/examples/sandbox/extensions/runloop-runner.ts
@@ -1,0 +1,99 @@
+import { Runner } from '@openai/agents';
+import { RunloopSandboxClient } from '@openai/agents-extensions/sandbox/runloop';
+import { Manifest, SandboxAgent, shell } from '@openai/agents/sandbox';
+import { finished } from 'node:stream/promises';
+import {
+  DEFAULT_MODEL,
+  getStringArg,
+  hasFlag,
+  getOptionalStringArg,
+  requireEnv,
+  requireOpenAIKey,
+  runExampleMain,
+} from '../support';
+
+const DEFAULT_QUESTION =
+  'Summarize this cloud sandbox workspace in 2 sentences.';
+const DEFAULT_RUNLOOP_WORKSPACE_ROOT = '/home/user';
+const DEFAULT_RUNLOOP_ROOT_WORKSPACE_ROOT = '/root';
+
+function buildManifest(root: string): Manifest {
+  return new Manifest({
+    root,
+    entries: {
+      'README.md': {
+        type: 'file',
+        content: `# Runloop Demo Workspace
+
+This workspace exists to validate the Runloop sandbox backend manually.
+`,
+      },
+      'launch.md': {
+        type: 'file',
+        content: `# Launch
+
+- Customer: Contoso Logistics.
+- Goal: validate the remote sandbox agent path.
+- Current status: Runloop backend smoke and app-server connectivity are passing.
+`,
+      },
+      'tasks.md': {
+        type: 'file',
+        content: `# Tasks
+
+1. Inspect the workspace files.
+2. Summarize the setup and any notable status in two sentences.
+`,
+      },
+    },
+  });
+}
+
+async function main() {
+  requireOpenAIKey();
+  requireEnv('RUNLOOP_API_KEY');
+
+  const model = getStringArg('--model', DEFAULT_MODEL);
+  const question = getStringArg('--question', DEFAULT_QUESTION);
+  const pauseOnExit = hasFlag('--pause-on-exit');
+  const blueprintName = getOptionalStringArg('--blueprint-name');
+  const root = hasFlag('--root');
+  const stream = hasFlag('--stream');
+  const client = new RunloopSandboxClient({
+    blueprintName,
+    pauseOnExit,
+    userParameters: root ? { username: 'root', uid: 0 } : undefined,
+  });
+  const agent = new SandboxAgent({
+    name: 'Runloop Sandbox Assistant',
+    model,
+    instructions:
+      'Answer questions about the sandbox workspace. Inspect the files before answering, keep the response concise, and cite the file names you inspected.',
+    defaultManifest: buildManifest(
+      root
+        ? DEFAULT_RUNLOOP_ROOT_WORKSPACE_ROOT
+        : DEFAULT_RUNLOOP_WORKSPACE_ROOT,
+    ),
+    capabilities: [shell()],
+  });
+  const runner = new Runner({
+    workflowName: 'Runloop sandbox example',
+    sandbox: { client },
+  });
+
+  if (!stream) {
+    const result = await runner.run(agent, question);
+    console.log(result.finalOutput);
+    return;
+  }
+
+  const result = await runner.run(agent, question, { stream: true });
+  process.stdout.write('assistant> ');
+  const textStream = result.toTextStream({ compatibleWithNodeStreams: true });
+  textStream.pipe(process.stdout);
+  await finished(textStream);
+  await result.completed;
+  process.stdout.write('\n');
+}
+
+await runExampleMain(main);

--- a/packages/agents-extensions/src/sandbox/runloop/index.ts
+++ b/packages/agents-extensions/src/sandbox/runloop/index.ts
@@ -1,0 +1,2 @@
+export * from './sandbox';
+export * from './mounts';

--- a/packages/agents-extensions/src/sandbox/runloop/mounts.ts
+++ b/packages/agents-extensions/src/sandbox/runloop/mounts.ts
@@ -1,0 +1,26 @@
+import type {
+  Entry,
+  RcloneMountPattern,
+  TypedMount,
+} from '@openai/agents-core/sandbox';
+import { isRcloneCloudBucketMountEntry } from '../shared/inContainerMounts';
+
+export type RunloopCloudBucketMountStrategyOptions = {
+  pattern?: RcloneMountPattern;
+};
+
+export class RunloopCloudBucketMountStrategy {
+  readonly [key: string]: unknown;
+  readonly type = 'runloop_cloud_bucket';
+  readonly pattern: RcloneMountPattern;
+
+  constructor(options: RunloopCloudBucketMountStrategyOptions = {}) {
+    this.pattern = options.pattern ?? { type: 'rclone', mode: 'fuse' };
+  }
+}
+
+export function isRunloopCloudBucketMountEntry(
+  entry: Entry,
+): entry is TypedMount {
+  return isRcloneCloudBucketMountEntry(entry, 'runloop_cloud_bucket');
+}

--- a/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
@@ -94,7 +94,7 @@ type RunloopClientLike = {
     ): Promise<unknown>;
   };
   blueprint?: RunloopPlatformResourceLike;
-  benchmark?: RunloopPlatformResourceLike;
+  benchmark?: RunloopBenchmarkResourceLike;
   networkPolicy?: RunloopPlatformResourceLike;
   axon?: RunloopPlatformResourceLike;
   api?: Record<string, Record<string, RunloopPlatformMethodLike>>;
@@ -106,6 +106,12 @@ type RunloopPlatformResourceLike = {
   create?: RunloopPlatformMethodLike;
   list?: RunloopPlatformMethodLike;
   fromId?: (id: string) => unknown;
+};
+
+type RunloopBenchmarkResourceLike = RunloopPlatformResourceLike & {
+  retrieve?: RunloopPlatformMethodLike;
+  update?: RunloopPlatformMethodLike;
+  startRun?: RunloopPlatformMethodLike;
 };
 
 type RunloopDevboxLike = {
@@ -323,11 +329,15 @@ export class RunloopPlatformBenchmarksClient {
   }
 
   get(benchmarkId: string): unknown {
-    return callRunloopPlatformGetter(
-      'benchmark.fromId',
-      this.sdk.benchmark?.fromId,
-      benchmarkId,
-    );
+    if (this.sdk.benchmark?.retrieve) {
+      return callRunloopPlatformMethod(
+        'benchmark.retrieve',
+        this.sdk.benchmark.retrieve,
+        benchmarkId,
+      );
+    }
+
+    return this.getBenchmarkFacade(benchmarkId);
   }
 
   async create(params: Record<string, unknown> = {}): Promise<unknown> {
@@ -342,9 +352,18 @@ export class RunloopPlatformBenchmarksClient {
     benchmarkId: string,
     params: Record<string, unknown> = {},
   ): Promise<unknown> {
+    if (this.sdk.benchmark?.update) {
+      return await callRunloopPlatformMethod(
+        'benchmark.update',
+        this.sdk.benchmark.update,
+        benchmarkId,
+        params,
+      );
+    }
+
     return await callRunloopPlatformMethod(
       'benchmark.update',
-      bindRunloopMethod(this.get(benchmarkId), 'update'),
+      bindRunloopMethod(this.getBenchmarkFacade(benchmarkId), 'update'),
       params,
     );
   }
@@ -365,9 +384,20 @@ export class RunloopPlatformBenchmarksClient {
     benchmarkId: string,
     params: Record<string, unknown> = {},
   ): Promise<unknown> {
+    if (this.sdk.benchmark?.startRun) {
+      return await callRunloopPlatformMethod(
+        'benchmark.startRun',
+        this.sdk.benchmark.startRun,
+        {
+          ...params,
+          benchmark_id: benchmarkId,
+        },
+      );
+    }
+
     return await callRunloopPlatformMethod(
       'benchmark.startRun',
-      bindRunloopMethod(this.get(benchmarkId), 'startRun'),
+      bindRunloopMethod(this.getBenchmarkFacade(benchmarkId), 'startRun'),
       params,
     );
   }
@@ -381,6 +411,14 @@ export class RunloopPlatformBenchmarksClient {
       this.sdk.api?.benchmarks?.updateScenarios,
       benchmarkId,
       params,
+    );
+  }
+
+  private getBenchmarkFacade(benchmarkId: string): unknown {
+    return callRunloopPlatformGetter(
+      'benchmark.fromId',
+      this.sdk.benchmark?.fromId,
+      benchmarkId,
     );
   }
 }
@@ -1447,21 +1485,33 @@ export class RunloopSandboxClient implements SandboxClient<
   async resume(
     state: RunloopSandboxSessionState,
   ): Promise<RunloopSandboxSession> {
+    const resumeState: RunloopSandboxSessionState = {
+      ...state,
+      manifest: resolveRunloopManifestRoot(
+        state.manifest,
+        state.userParameters,
+        true,
+      ),
+    };
     const sdk = await createRunloopClient({
       ...this.options,
-      baseUrl: state.baseUrl ?? this.options.baseUrl,
+      baseUrl: resumeState.baseUrl ?? this.options.baseUrl,
     });
     try {
-      const devbox = sdk.devbox.fromId(state.devboxId);
-      if (state.pauseOnExit) {
+      const devbox = sdk.devbox.fromId(resumeState.devboxId);
+      if (resumeState.pauseOnExit) {
         await devbox.resume(
-          runloopLongPollOptions(state.timeouts?.resumeTimeoutMs),
+          runloopLongPollOptions(resumeState.timeouts?.resumeTimeoutMs),
         );
       }
-      invalidateRunloopRuntimeCaches(state);
-      const session = new RunloopSandboxSession({ state, sdk, devbox });
+      invalidateRunloopRuntimeCaches(resumeState);
+      const session = new RunloopSandboxSession({
+        state: resumeState,
+        sdk,
+        devbox,
+      });
       try {
-        await rematerializeRunloopManifestMounts(session, state.manifest);
+        await rematerializeRunloopManifestMounts(session, resumeState.manifest);
       } catch (error) {
         await session.cleanupAfterFailedResume();
         throw error;
@@ -1471,27 +1521,27 @@ export class RunloopSandboxClient implements SandboxClient<
       assertResumeRecreateAllowed(error, {
         providerName: 'RunloopSandboxClient',
         provider: 'runloop',
-        details: { devboxId: state.devboxId },
+        details: { devboxId: resumeState.devboxId },
       });
       const recreateOptions: RunloopSandboxResolvedOptions = {
-        blueprintName: state.blueprintName,
-        blueprintId: state.blueprintId,
-        name: state.name,
-        launchParameters: state.launchParameters,
-        exposedPorts: state.configuredExposedPorts,
-        tunnel: state.tunnel,
-        gateways: state.gateways,
-        mcp: state.mcp,
-        metadata: state.metadata,
-        secretRefs: state.secretRefs,
-        pauseOnExit: state.pauseOnExit,
-        userParameters: state.userParameters,
-        env: state.environment,
-        baseUrl: state.baseUrl ?? this.options.baseUrl,
-        createTimeoutMs: state.createTimeoutMs,
-        timeouts: state.timeouts,
+        blueprintName: resumeState.blueprintName,
+        blueprintId: resumeState.blueprintId,
+        name: resumeState.name,
+        launchParameters: resumeState.launchParameters,
+        exposedPorts: resumeState.configuredExposedPorts,
+        tunnel: resumeState.tunnel,
+        gateways: resumeState.gateways,
+        mcp: resumeState.mcp,
+        metadata: resumeState.metadata,
+        secretRefs: resumeState.secretRefs,
+        pauseOnExit: resumeState.pauseOnExit,
+        userParameters: resumeState.userParameters,
+        env: resumeState.environment,
+        baseUrl: resumeState.baseUrl ?? this.options.baseUrl,
+        createTimeoutMs: resumeState.createTimeoutMs,
+        timeouts: resumeState.timeouts,
       };
-      return await this.create(state.manifest, recreateOptions);
+      return await this.create(resumeState.manifest, recreateOptions);
     }
   }
 }
@@ -1598,9 +1648,7 @@ function adaptRunloopClient(
         : {}),
     },
     blueprint: adaptRunloopPlatformResource(sdk.blueprint),
-    benchmark: adaptRunloopPlatformResource(
-      (sdk as { benchmark?: unknown }).benchmark,
-    ),
+    benchmark: adaptRunloopBenchmarkResource(sdk),
     networkPolicy: adaptRunloopPlatformResource(sdk.networkPolicy),
     axon: adaptRunloopPlatformResource(sdk.axon),
     api: adaptRunloopApi(sdk),
@@ -1716,6 +1764,38 @@ function adaptRunloopPlatformResource(
         ? (id) => fromId.call(resource, id)
         : undefined,
   };
+}
+
+function adaptRunloopBenchmarkResource(
+  sdk: import('@runloop/api-client').RunloopSDK,
+): RunloopBenchmarkResourceLike | undefined {
+  const apiBenchmarks = (sdk as { api?: { benchmarks?: unknown } }).api
+    ?.benchmarks;
+  const apiResource = adaptRunloopApiBenchmarkResource(apiBenchmarks);
+  if (apiResource) {
+    return apiResource;
+  }
+  return adaptRunloopPlatformResource(
+    (sdk as { benchmark?: unknown }).benchmark,
+  );
+}
+
+function adaptRunloopApiBenchmarkResource(
+  resource: unknown,
+): RunloopBenchmarkResourceLike | undefined {
+  if (!isRecord(resource)) {
+    return undefined;
+  }
+  const adapted: RunloopBenchmarkResourceLike = {
+    create: bindRunloopMethod(resource, 'create'),
+    list: bindRunloopMethod(resource, 'list'),
+    retrieve: bindRunloopMethod(resource, 'retrieve'),
+    update: bindRunloopMethod(resource, 'update'),
+    startRun: bindRunloopMethod(resource, 'startRun'),
+  };
+  return Object.values(adapted).some((value) => typeof value === 'function')
+    ? adapted
+    : undefined;
 }
 
 function adaptRunloopApi(

--- a/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
@@ -1,0 +1,2108 @@
+import { UserError } from '@openai/agents-core';
+import {
+  Manifest,
+  SandboxConfigurationError,
+  SandboxProviderError,
+  SandboxUnsupportedFeatureError,
+  normalizeSandboxClientCreateArgs,
+  type SandboxClient,
+  type SandboxClientCreateArgs,
+  type SandboxClientOptions,
+  type Mount,
+  type SandboxSessionState,
+  type TypedMount,
+  type WorkspaceArchiveData,
+} from '@openai/agents-core/sandbox';
+import { posix as pathPosix } from 'node:path';
+import {
+  assertCoreConcurrencyLimitsUnsupported,
+  assertCoreSnapshotUnsupported,
+  assertTarWorkspacePersistence,
+  assertResumeRecreateAllowed,
+  assertRunAsUnsupported,
+  assertSandboxManifestMetadataSupported,
+  SANDBOX_MANIFEST_METADATA_SUPPORT,
+  closeRemoteSessionOnManifestError,
+  cloneManifestWithRoot,
+  decodeNativeSnapshotRef,
+  assertShellEnvironmentName,
+  deserializeRemoteSandboxSessionStateValues,
+  encodeNativeSnapshotRef,
+  materializeEnvironment,
+  serializeRemoteSandboxSessionState,
+  shellQuote,
+  isRecord,
+  readOptionalNumber,
+  readOptionalNumberArray,
+  readOptionalRecord,
+  readOptionalString,
+  readOptionalStringRecord,
+  readString,
+  withProviderError,
+  withSandboxSpan,
+  RemoteSandboxSessionBase,
+  type RemoteSandboxCommandOptions,
+  type RemoteSandboxCommandResult,
+} from '../shared';
+import {
+  mountRcloneCloudBucket,
+  rclonePatternFromMountStrategy,
+  unmountRcloneMount,
+  type RemoteMountCommand,
+} from '../shared/inContainerMounts';
+import { isRunloopCloudBucketMountEntry } from './mounts';
+
+export const DEFAULT_RUNLOOP_WORKSPACE_ROOT = '/home/user';
+export const DEFAULT_RUNLOOP_ROOT_WORKSPACE_ROOT = '/root';
+
+type RunloopClientLike = {
+  devbox: {
+    create(
+      params?: Record<string, unknown>,
+      options?: Record<string, unknown>,
+    ): Promise<RunloopDevboxLike>;
+    createFromBlueprintName(
+      blueprintName: string,
+      params?: Record<string, unknown>,
+      options?: Record<string, unknown>,
+    ): Promise<RunloopDevboxLike>;
+    createFromSnapshot?(
+      snapshotId: string,
+      params?: Record<string, unknown>,
+      options?: Record<string, unknown>,
+    ): Promise<RunloopDevboxLike>;
+    fromId(id: string): RunloopDevboxLike;
+  };
+  secret?: {
+    create(
+      params: { name: string; value: string },
+      options?: Record<string, unknown>,
+    ): Promise<unknown>;
+    list?(
+      params?: Record<string, unknown>,
+      options?: Record<string, unknown>,
+    ): Promise<unknown>;
+    update(
+      secret: string,
+      params: { value: string },
+      options?: Record<string, unknown>,
+    ): Promise<unknown>;
+    delete?(
+      secret: string,
+      params?: Record<string, unknown>,
+      options?: Record<string, unknown>,
+    ): Promise<unknown>;
+  };
+  blueprint?: RunloopPlatformResourceLike;
+  benchmark?: RunloopPlatformResourceLike;
+  networkPolicy?: RunloopPlatformResourceLike;
+  axon?: RunloopPlatformResourceLike;
+  api?: Record<string, Record<string, RunloopPlatformMethodLike>>;
+};
+
+type RunloopPlatformMethodLike = (...args: unknown[]) => unknown;
+
+type RunloopPlatformResourceLike = {
+  create?: RunloopPlatformMethodLike;
+  list?: RunloopPlatformMethodLike;
+  fromId?: (id: string) => unknown;
+};
+
+type RunloopDevboxLike = {
+  id: string;
+  cmd: {
+    exec(
+      command: string,
+      params?: Record<string, unknown>,
+      options?: Record<string, unknown>,
+    ): Promise<RunloopExecutionResultLike>;
+  };
+  file: {
+    read(
+      params: { file_path: string },
+      options?: Record<string, unknown>,
+    ): Promise<string>;
+    write(
+      params: { path: string; contents: string },
+      options?: Record<string, unknown>,
+    ): Promise<unknown>;
+    download(
+      params: { path: string },
+      options?: Record<string, unknown>,
+    ): Promise<{
+      buffer?: () => Promise<Buffer>;
+      arrayBuffer?: () => Promise<ArrayBuffer>;
+    }>;
+    upload(
+      params: { path: string; file: File | Blob },
+      options?: Record<string, unknown>,
+    ): Promise<unknown>;
+  };
+  net?: {
+    enableTunnel?(
+      params?: Record<string, unknown>,
+      options?: Record<string, unknown>,
+    ): Promise<unknown>;
+  };
+  getTunnelUrl?(
+    port: number,
+    options?: Record<string, unknown>,
+  ): Promise<string>;
+  snapshotDisk?(
+    params?: Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ): Promise<{ id?: string }>;
+  resume(options?: Record<string, unknown>): Promise<unknown>;
+  suspend(options?: Record<string, unknown>): Promise<unknown>;
+  shutdown(options?: Record<string, unknown>): Promise<unknown>;
+};
+
+type RunloopExecutionResultLike = {
+  exitCode: number | null;
+  stdout(numLines?: number): Promise<string>;
+  stderr(numLines?: number): Promise<string>;
+};
+
+const UNKNOWN_RUNLOOP_EXIT_CODE = 1;
+const DEFAULT_RUNLOOP_TUNNEL_PARAMS = {
+  auth_mode: 'open',
+  http_keep_alive: true,
+  wake_on_http: false,
+} as const;
+
+export type RunloopUserParameters = {
+  uid: number;
+  username: string;
+};
+
+export interface RunloopSandboxTimeouts {
+  execTimeoutMs?: number;
+  createTimeoutMs?: number;
+  keepAliveTimeoutMs?: number;
+  cleanupTimeoutMs?: number;
+  fastOperationTimeoutMs?: number;
+  fileUploadTimeoutMs?: number;
+  fileDownloadTimeoutMs?: number;
+  snapshotTimeoutMs?: number;
+  suspendTimeoutMs?: number;
+  resumeTimeoutMs?: number;
+}
+
+export interface RunloopSandboxClientOptions extends SandboxClientOptions {
+  blueprintName?: string;
+  blueprintId?: string;
+  name?: string;
+  launchParameters?: Record<string, unknown>;
+  exposedPorts?: number[];
+  tunnel?: boolean | Record<string, unknown>;
+  gateways?: Record<string, unknown>;
+  mcp?: Record<string, unknown>;
+  metadata?: Record<string, string>;
+  managedSecrets?: Record<string, string>;
+  pauseOnExit?: boolean;
+  userParameters?: RunloopUserParameters;
+  env?: Record<string, string>;
+  apiKey?: string;
+  baseUrl?: string;
+  createTimeoutMs?: number;
+  timeouts?: RunloopSandboxTimeouts;
+}
+
+export interface RunloopSandboxSessionState extends SandboxSessionState {
+  devboxId: string;
+  blueprintName?: string;
+  blueprintId?: string;
+  name?: string;
+  launchParameters?: Record<string, unknown>;
+  configuredExposedPorts?: number[];
+  tunnel?: boolean | Record<string, unknown>;
+  gateways?: Record<string, unknown>;
+  mcp?: Record<string, unknown>;
+  metadata?: Record<string, string>;
+  secretRefs?: Record<string, string>;
+  pauseOnExit: boolean;
+  userParameters?: RunloopUserParameters;
+  environment: Record<string, string>;
+  baseUrl?: string;
+  createTimeoutMs?: number;
+  timeouts?: RunloopSandboxTimeouts;
+}
+
+type RunloopSandboxResolvedOptions = RunloopSandboxClientOptions & {
+  secretRefs?: Record<string, string>;
+};
+
+export class RunloopPlatformBlueprintsClient {
+  constructor(private readonly sdk: RunloopClientLike) {}
+
+  async list(params: Record<string, unknown> = {}): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'blueprint.list',
+      this.sdk.blueprint?.list,
+      params,
+    );
+  }
+
+  async listPublic(params: Record<string, unknown> = {}): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'api.blueprints.listPublic',
+      this.sdk.api?.blueprints?.listPublic,
+      params,
+    );
+  }
+
+  get(blueprintId: string): unknown {
+    return callRunloopPlatformGetter(
+      'blueprint.fromId',
+      this.sdk.blueprint?.fromId,
+      blueprintId,
+    );
+  }
+
+  async logs(
+    blueprintId: string,
+    params: Record<string, unknown> = {},
+  ): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'api.blueprints.logs',
+      this.sdk.api?.blueprints?.logs,
+      blueprintId,
+      params,
+    );
+  }
+
+  async create(params: Record<string, unknown> = {}): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'blueprint.create',
+      this.sdk.blueprint?.create,
+      params,
+    );
+  }
+
+  async awaitBuildComplete(
+    blueprintId: string,
+    params: Record<string, unknown> = {},
+  ): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'api.blueprints.awaitBuildComplete',
+      this.sdk.api?.blueprints?.awaitBuildComplete,
+      blueprintId,
+      params,
+    );
+  }
+
+  async delete(
+    blueprintId: string,
+    params: Record<string, unknown> = {},
+  ): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'blueprint.delete',
+      bindRunloopMethod(this.get(blueprintId), 'delete'),
+      params,
+    );
+  }
+}
+
+export class RunloopPlatformBenchmarksClient {
+  constructor(private readonly sdk: RunloopClientLike) {}
+
+  async list(params: Record<string, unknown> = {}): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'benchmark.list',
+      this.sdk.benchmark?.list,
+      params,
+    );
+  }
+
+  async listPublic(params: Record<string, unknown> = {}): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'api.benchmarks.listPublic',
+      this.sdk.api?.benchmarks?.listPublic,
+      params,
+    );
+  }
+
+  get(benchmarkId: string): unknown {
+    return callRunloopPlatformGetter(
+      'benchmark.fromId',
+      this.sdk.benchmark?.fromId,
+      benchmarkId,
+    );
+  }
+
+  async create(params: Record<string, unknown> = {}): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'benchmark.create',
+      this.sdk.benchmark?.create,
+      params,
+    );
+  }
+
+  async update(
+    benchmarkId: string,
+    params: Record<string, unknown> = {},
+  ): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'benchmark.update',
+      bindRunloopMethod(this.get(benchmarkId), 'update'),
+      params,
+    );
+  }
+
+  async definitions(
+    benchmarkId: string,
+    params: Record<string, unknown> = {},
+  ): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'api.benchmarks.definitions',
+      this.sdk.api?.benchmarks?.definitions,
+      benchmarkId,
+      params,
+    );
+  }
+
+  async startRun(
+    benchmarkId: string,
+    params: Record<string, unknown> = {},
+  ): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'benchmark.startRun',
+      bindRunloopMethod(this.get(benchmarkId), 'startRun'),
+      params,
+    );
+  }
+
+  async updateScenarios(
+    benchmarkId: string,
+    params: Record<string, unknown> = {},
+  ): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'api.benchmarks.updateScenarios',
+      this.sdk.api?.benchmarks?.updateScenarios,
+      benchmarkId,
+      params,
+    );
+  }
+}
+
+export class RunloopPlatformSecretsClient {
+  constructor(private readonly sdk: RunloopClientLike) {}
+
+  async create(params: { name: string; value: string }): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'secret.create',
+      this.sdk.secret?.create as RunloopPlatformMethodLike | undefined,
+      params,
+    );
+  }
+
+  async list(params: Record<string, unknown> = {}): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'secret.list',
+      (this.sdk.secret as { list?: RunloopPlatformMethodLike } | undefined)
+        ?.list,
+      params,
+    );
+  }
+
+  async get(
+    name: string,
+    params: Record<string, unknown> = {},
+  ): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'api.secrets.retrieve',
+      this.sdk.api?.secrets?.retrieve,
+      name,
+      params,
+    );
+  }
+
+  async update(params: { name: string; value: string }): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'secret.update',
+      this.sdk.secret?.update as RunloopPlatformMethodLike | undefined,
+      params.name,
+      { value: params.value },
+    );
+  }
+
+  async delete(
+    name: string,
+    params: Record<string, unknown> = {},
+  ): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'secret.delete',
+      (this.sdk.secret as { delete?: RunloopPlatformMethodLike } | undefined)
+        ?.delete,
+      name,
+      params,
+    );
+  }
+}
+
+export class RunloopPlatformNetworkPoliciesClient {
+  constructor(private readonly sdk: RunloopClientLike) {}
+
+  async create(params: Record<string, unknown> = {}): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'networkPolicy.create',
+      this.sdk.networkPolicy?.create,
+      params,
+    );
+  }
+
+  async list(params: Record<string, unknown> = {}): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'networkPolicy.list',
+      this.sdk.networkPolicy?.list,
+      params,
+    );
+  }
+
+  get(networkPolicyId: string): unknown {
+    return callRunloopPlatformGetter(
+      'networkPolicy.fromId',
+      this.sdk.networkPolicy?.fromId,
+      networkPolicyId,
+    );
+  }
+
+  async update(
+    networkPolicyId: string,
+    params: Record<string, unknown> = {},
+  ): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'networkPolicy.update',
+      bindRunloopMethod(this.get(networkPolicyId), 'update'),
+      params,
+    );
+  }
+
+  async delete(
+    networkPolicyId: string,
+    params: Record<string, unknown> = {},
+  ): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'networkPolicy.delete',
+      bindRunloopMethod(this.get(networkPolicyId), 'delete'),
+      params,
+    );
+  }
+}
+
+export class RunloopPlatformAxonsClient {
+  constructor(private readonly sdk: RunloopClientLike) {}
+
+  async create(params: Record<string, unknown> = {}): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'axon.create',
+      this.sdk.axon?.create,
+      params,
+    );
+  }
+
+  async list(params: Record<string, unknown> = {}): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'axon.list',
+      this.sdk.axon?.list,
+      params,
+    );
+  }
+
+  get(axonId: string): unknown {
+    return callRunloopPlatformGetter(
+      'axon.fromId',
+      this.sdk.axon?.fromId,
+      axonId,
+    );
+  }
+
+  async publish(
+    axonId: string,
+    params: Record<string, unknown> = {},
+  ): Promise<unknown> {
+    return await callRunloopPlatformMethod(
+      'axon.publish',
+      bindRunloopMethod(this.get(axonId), 'publish'),
+      params,
+    );
+  }
+
+  async querySql(
+    axonId: string,
+    params: Record<string, unknown> = {},
+  ): Promise<unknown> {
+    const axon = this.get(axonId) as {
+      sql?: unknown;
+    };
+    return await callRunloopPlatformMethod(
+      'axon.sql.query',
+      bindRunloopMethod(axon.sql, 'query'),
+      params,
+    );
+  }
+
+  async batchSql(
+    axonId: string,
+    params: Record<string, unknown> = {},
+  ): Promise<unknown> {
+    const axon = this.get(axonId) as {
+      sql?: unknown;
+    };
+    return await callRunloopPlatformMethod(
+      'axon.sql.batch',
+      bindRunloopMethod(axon.sql, 'batch'),
+      params,
+    );
+  }
+}
+
+export class RunloopPlatformClient {
+  constructor(private readonly sdk: RunloopClientLike) {}
+
+  get blueprints(): RunloopPlatformBlueprintsClient {
+    return new RunloopPlatformBlueprintsClient(this.sdk);
+  }
+
+  get benchmarks(): RunloopPlatformBenchmarksClient {
+    return new RunloopPlatformBenchmarksClient(this.sdk);
+  }
+
+  get secrets(): RunloopPlatformSecretsClient {
+    return new RunloopPlatformSecretsClient(this.sdk);
+  }
+
+  get networkPolicies(): RunloopPlatformNetworkPoliciesClient {
+    return new RunloopPlatformNetworkPoliciesClient(this.sdk);
+  }
+
+  get axons(): RunloopPlatformAxonsClient {
+    return new RunloopPlatformAxonsClient(this.sdk);
+  }
+}
+
+export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandboxSessionState> {
+  private readonly sdk: RunloopClientLike;
+  private devbox: RunloopDevboxLike;
+  private readonly activeMountPaths = new Set<string>();
+
+  constructor(args: {
+    state: RunloopSandboxSessionState;
+    sdk: RunloopClientLike;
+    devbox: RunloopDevboxLike;
+  }) {
+    super({
+      state: args.state,
+      options: {
+        providerName: 'RunloopSandboxClient',
+        providerId: 'runloop',
+      },
+    });
+    this.sdk = args.sdk;
+    this.devbox = args.devbox;
+  }
+
+  override supportsPty(): boolean {
+    return false;
+  }
+
+  protected override exposedPortSource(): string {
+    return 'tunnel URL';
+  }
+
+  protected override async resolveRemoteExposedPort(
+    port: number,
+  ): Promise<string> {
+    return await this.ensureTunnelUrl(port);
+  }
+
+  protected override resolveManifestForApply(manifest: Manifest): Manifest {
+    return resolveRunloopManifestRoot(
+      manifest,
+      this.state.userParameters,
+      true,
+    );
+  }
+
+  protected override async beforeApplyManifest(
+    manifest: Manifest,
+  ): Promise<void> {
+    await this.ensureManifestRoot(manifest.root);
+  }
+
+  async persistWorkspace(): Promise<Uint8Array> {
+    const snapshot = await this.persistWorkspaceViaNativeSnapshot();
+    if (snapshot) {
+      return snapshot;
+    }
+
+    assertTarWorkspacePersistence('RunloopSandboxClient', 'tar');
+    return await this.persistWorkspaceTar();
+  }
+
+  async hydrateWorkspace(data: WorkspaceArchiveData): Promise<void> {
+    const snapshotRef = decodeNativeSnapshotRef(data);
+    if (snapshotRef?.provider === 'runloop') {
+      await this.replaceDevboxFromSnapshot(snapshotRef.snapshotId);
+      return;
+    }
+
+    assertTarWorkspacePersistence('RunloopSandboxClient', 'tar');
+    await this.hydrateWorkspaceTar(data);
+  }
+
+  async close(): Promise<void> {
+    if (this.state.pauseOnExit) {
+      await withSandboxSpan(
+        'sandbox.stop',
+        {
+          backend_id: 'runloop',
+          devbox_id: this.state.devboxId,
+        },
+        async () => {
+          await this.devbox.suspend(
+            runloopRequestOptions(this.state.timeouts?.suspendTimeoutMs),
+          );
+        },
+      );
+      return;
+    }
+
+    await withSandboxSpan(
+      'sandbox.shutdown',
+      {
+        backend_id: 'runloop',
+        devbox_id: this.state.devboxId,
+      },
+      async () => {
+        await this.unmountActiveMounts();
+        await this.devbox.shutdown(
+          runloopRequestOptions(this.state.timeouts?.cleanupTimeoutMs),
+        );
+      },
+    );
+  }
+
+  async shutdown(): Promise<void> {
+    await this.close();
+  }
+
+  async delete(): Promise<void> {
+    await withSandboxSpan(
+      'sandbox.shutdown',
+      {
+        backend_id: 'runloop',
+        devbox_id: this.state.devboxId,
+      },
+      async () => {
+        await this.unmountActiveMounts();
+        await this.devbox.shutdown(
+          runloopRequestOptions(this.state.timeouts?.cleanupTimeoutMs),
+        );
+      },
+    );
+  }
+
+  private async persistWorkspaceViaNativeSnapshot(): Promise<
+    Uint8Array | undefined
+  > {
+    if (this.nativeSnapshotRequiresTarFallback()) {
+      return undefined;
+    }
+    if (!this.devbox.snapshotDisk) {
+      return undefined;
+    }
+
+    let snapshot: { id?: string };
+    try {
+      const snapshotOptions = runloopLongPollOptions(
+        this.state.timeouts?.snapshotTimeoutMs,
+      );
+      const snapshotParams = {
+        name: `sandbox-${this.state.devboxId}`,
+        metadata: {
+          openai_agents_devbox_id: this.state.devboxId,
+        },
+      };
+      snapshot = snapshotOptions
+        ? await this.devbox.snapshotDisk(snapshotParams, snapshotOptions)
+        : await this.devbox.snapshotDisk(snapshotParams);
+    } catch (error) {
+      throw new SandboxProviderError(
+        'RunloopSandboxClient failed to create a native disk snapshot.',
+        {
+          provider: 'runloop',
+          devboxId: this.state.devboxId,
+          cause: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+
+    if (!snapshot.id) {
+      throw new SandboxProviderError(
+        'RunloopSandboxClient native disk snapshot did not return a snapshot id.',
+        {
+          provider: 'runloop',
+          devboxId: this.state.devboxId,
+        },
+      );
+    }
+
+    return encodeNativeSnapshotRef({
+      provider: 'runloop',
+      snapshotId: snapshot.id,
+    });
+  }
+
+  private nativeSnapshotRequiresTarFallback(): boolean {
+    return this.state.manifest.ephemeralPersistencePaths().size > 0;
+  }
+
+  private async replaceDevboxFromSnapshot(snapshotId: string): Promise<void> {
+    if (!this.sdk.devbox.createFromSnapshot) {
+      throw new SandboxProviderError(
+        'RunloopSandboxClient native snapshot restore requires createFromSnapshot(snapshotId).',
+        {
+          provider: 'runloop',
+          snapshotId,
+        },
+      );
+    }
+
+    const previousDevbox = this.devbox;
+    let devbox: RunloopDevboxLike;
+    try {
+      devbox = await this.sdk.devbox.createFromSnapshot(
+        snapshotId,
+        createRunloopParams(this.state, this.state.environment, {
+          includeBlueprint: false,
+        }),
+        createRunloopOptions(this.state),
+      );
+    } catch (error) {
+      throw new SandboxProviderError(
+        'RunloopSandboxClient failed to restore a native disk snapshot.',
+        {
+          provider: 'runloop',
+          snapshotId,
+          cause: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+
+    const previousDevboxId = this.state.devboxId;
+    this.devbox = devbox;
+    this.state.devboxId = devbox.id;
+    this.activeMountPaths.clear();
+    invalidateRunloopRuntimeCaches(this.state);
+    try {
+      await rematerializeRunloopManifestMounts(this, this.state.manifest);
+    } catch (error) {
+      let replacementCleanupCause: string | undefined;
+      try {
+        await this.unmountActiveMounts();
+      } catch (unmountError) {
+        replacementCleanupCause = errorMessage(unmountError);
+      }
+      try {
+        await devbox.shutdown();
+      } catch (shutdownError) {
+        replacementCleanupCause = replacementCleanupCause
+          ? `${replacementCleanupCause}; ${errorMessage(shutdownError)}`
+          : errorMessage(shutdownError);
+      }
+      this.devbox = previousDevbox;
+      this.state.devboxId = previousDevboxId;
+      this.activeMountPaths.clear();
+      invalidateRunloopRuntimeCaches(this.state);
+      throw new SandboxProviderError(
+        'RunloopSandboxClient native snapshot restore failed while rematerializing mounts.',
+        {
+          provider: 'runloop',
+          devboxId: previousDevboxId,
+          replacementDevboxId: devbox.id,
+          snapshotId,
+          cause: errorMessage(error),
+          ...(replacementCleanupCause ? { replacementCleanupCause } : {}),
+        },
+      );
+    }
+
+    try {
+      await previousDevbox.shutdown();
+    } catch (error) {
+      let replacementShutdownCause: string | undefined;
+      try {
+        await this.unmountActiveMounts();
+      } catch (unmountError) {
+        replacementShutdownCause = errorMessage(unmountError);
+      }
+      try {
+        await devbox.shutdown();
+      } catch (replacementShutdownError) {
+        replacementShutdownCause = replacementShutdownCause
+          ? `${replacementShutdownCause}; ${errorMessage(replacementShutdownError)}`
+          : errorMessage(replacementShutdownError);
+      }
+      this.devbox = previousDevbox;
+      this.state.devboxId = previousDevboxId;
+      this.activeMountPaths.clear();
+      invalidateRunloopRuntimeCaches(this.state);
+      throw new SandboxProviderError(
+        'RunloopSandboxClient native snapshot restore created a replacement devbox, but shutting down the previous devbox failed.',
+        {
+          provider: 'runloop',
+          devboxId: previousDevbox.id,
+          replacementDevboxId: devbox.id,
+          snapshotId,
+          cause: errorMessage(error),
+          ...(replacementShutdownCause ? { replacementShutdownCause } : {}),
+        },
+      );
+    }
+  }
+
+  protected override manifestMetadataSupport() {
+    return SANDBOX_MANIFEST_METADATA_SUPPORT;
+  }
+
+  protected override manifestMaterializationOptions() {
+    return {
+      materializeMount: this.materializeMountEntry.bind(this),
+    };
+  }
+
+  protected override assertExecRunAs(_runAs?: string): void {
+    void _runAs;
+  }
+
+  protected override assertFilesystemRunAs(_runAs?: string): void {
+    assertRunAsUnsupported('RunloopSandboxClient', _runAs);
+  }
+
+  private async materializeMountEntry(
+    absolutePath: string,
+    entry: Mount | TypedMount,
+  ): Promise<void> {
+    if (!isRunloopCloudBucketMountEntry(entry)) {
+      throw new SandboxUnsupportedFeatureError(
+        'RunloopSandboxClient only supports RunloopCloudBucketMountStrategy mount entries.',
+        {
+          provider: 'runloop',
+          feature: 'entry.mountStrategy',
+          path: absolutePath,
+          mountType: entry.type,
+          strategyType: entry.mountStrategy?.type,
+        },
+      );
+    }
+    const mountPath = await this.resolveRemotePath(
+      entry.mountPath ?? absolutePath,
+      { forWrite: true },
+    );
+    await mountRcloneCloudBucket({
+      providerName: 'RunloopSandboxClient',
+      providerId: 'runloop',
+      strategyType: 'runloop_cloud_bucket',
+      entry,
+      mountPath,
+      pattern: rclonePatternFromMountStrategy(entry.mountStrategy),
+      runCommand: this.mountCommandRunner(),
+      packageManagers: ['apt'],
+      installRcloneViaScript: true,
+    });
+    this.activeMountPaths.add(mountPath);
+  }
+
+  async rematerializeManifestMounts(manifest: Manifest): Promise<void> {
+    for (const {
+      absolutePath,
+      entry,
+    } of manifest.mountTargetsForMaterialization()) {
+      await this.materializeMountEntry(absolutePath, structuredClone(entry));
+    }
+  }
+
+  async cleanupAfterFailedResume(): Promise<void> {
+    await this.unmountActiveMounts().catch(() => {});
+    if (this.state.pauseOnExit) {
+      await this.devbox
+        .suspend(runloopRequestOptions(this.state.timeouts?.suspendTimeoutMs))
+        .catch(() => {});
+      return;
+    }
+    await this.devbox
+      .shutdown(runloopRequestOptions(this.state.timeouts?.cleanupTimeoutMs))
+      .catch(() => {});
+  }
+
+  private async unmountActiveMounts(): Promise<void> {
+    for (const mountPath of [...this.activeMountPaths].reverse()) {
+      await unmountRcloneMount({
+        providerName: 'RunloopSandboxClient',
+        providerId: 'runloop',
+        mountPath,
+        runCommand: this.mountCommandRunner(),
+      }).catch(() => {});
+      this.activeMountPaths.delete(mountPath);
+    }
+  }
+
+  private mountCommandRunner(): RemoteMountCommand {
+    return async (command, options = {}) => {
+      const result = await this.execShell(
+        command,
+        undefined,
+        options.timeoutMs ?? this.state.timeouts?.fastOperationTimeoutMs,
+        options.user,
+      );
+      return {
+        status: runloopExitStatus(result),
+        stdout: await result.stdout(),
+        stderr: await result.stderr(),
+      };
+    };
+  }
+
+  private async ensureManifestRoot(root: string): Promise<void> {
+    const result = await this.execShellInWorkdir(
+      `mkdir -p -- ${shellQuote(root)}`,
+      effectiveRunloopHome(this.state.userParameters),
+      this.state.timeouts?.fastOperationTimeoutMs,
+      {},
+    );
+    if (!runloopSucceeded(result)) {
+      throw new SandboxProviderError(
+        'RunloopSandboxClient failed to prepare the workspace root.',
+        {
+          provider: 'runloop',
+          root,
+          exitCode: runloopExitStatus(result),
+          stderr: await result.stderr(),
+        },
+      );
+    }
+  }
+
+  private async execShell(
+    command: string,
+    workdir?: string,
+    timeoutMs?: number,
+    user?: string,
+  ): Promise<RunloopExecutionResultLike> {
+    return await this.execShellInWorkdir(
+      command,
+      this.resolveWorkdir(workdir),
+      timeoutMs,
+      this.state.environment,
+      user,
+    );
+  }
+
+  private async execShellInWorkdir(
+    command: string,
+    workdir: string,
+    timeoutMs: number | undefined,
+    environment: Record<string, string>,
+    user?: string,
+  ): Promise<RunloopExecutionResultLike> {
+    const shellCommand = buildShellCommand(
+      command,
+      environment,
+      workdir,
+      user,
+      this.state.userParameters,
+    );
+    const params = {
+      last_n: '2000',
+    };
+    const options = runloopLongPollOptions(timeoutMs);
+    return options
+      ? await this.devbox.cmd.exec(shellCommand, params, options)
+      : await this.devbox.cmd.exec(shellCommand, params);
+  }
+
+  protected override async runRemoteCommand(
+    command: string,
+    options: RemoteSandboxCommandOptions,
+  ): Promise<RemoteSandboxCommandResult> {
+    const result = await this.execShellInWorkdir(
+      command,
+      options.workdir,
+      options.timeoutMs ?? this.timeoutForCommand(options),
+      this.state.environment,
+      options.runAs,
+    );
+    return {
+      status: runloopExitStatus(result),
+      stdout: await result.stdout(),
+      stderr: await result.stderr(),
+    };
+  }
+
+  protected override async mkdirRemote(path: string): Promise<void> {
+    const result = await this.runRemoteCommand(
+      `mkdir -p -- ${shellQuote(path)}`,
+      {
+        kind: 'manifest',
+        workdir: this.state.manifest.root,
+        timeoutMs: this.state.timeouts?.fastOperationTimeoutMs,
+      },
+    );
+    this.assertRemoteCommandSucceeded(result, 'create directory', path);
+  }
+
+  protected override async readRemoteText(path: string): Promise<string> {
+    return await this.devbox.file.read({
+      file_path: path,
+    });
+  }
+
+  protected override async readRemoteFile(path: string): Promise<Uint8Array> {
+    const downloadOptions = runloopRequestOptions(
+      this.state.timeouts?.fileDownloadTimeoutMs,
+    );
+    const response = downloadOptions
+      ? await this.devbox.file.download({ path }, downloadOptions)
+      : await this.devbox.file.download({ path });
+    if (response.buffer) {
+      return Uint8Array.from(await response.buffer());
+    }
+    return new Uint8Array(await response.arrayBuffer!());
+  }
+
+  protected override async writeRemoteFile(
+    path: string,
+    content: string | Uint8Array,
+  ): Promise<void> {
+    const uploadOptions = runloopRequestOptions(
+      this.state.timeouts?.fileUploadTimeoutMs,
+    );
+    const uploadParams = {
+      path,
+      file: new File(
+        [typeof content === 'string' ? content : Uint8Array.from(content)],
+        basename(path),
+      ),
+    };
+    if (uploadOptions) {
+      await this.devbox.file.upload(uploadParams, uploadOptions);
+    } else {
+      await this.devbox.file.upload(uploadParams);
+    }
+  }
+
+  protected override async deleteRemotePath(path: string): Promise<void> {
+    const result = await this.runRemoteCommand(`rm -f -- ${shellQuote(path)}`, {
+      kind: 'manifest',
+      workdir: this.state.manifest.root,
+      timeoutMs: this.state.timeouts?.fastOperationTimeoutMs,
+    });
+    this.assertRemoteCommandSucceeded(result, 'delete path', path);
+  }
+
+  private assertRemoteCommandSucceeded(
+    result: RemoteSandboxCommandResult,
+    operation: string,
+    path: string,
+  ): void {
+    if (result.status === 0) {
+      return;
+    }
+    throw new SandboxProviderError(
+      `RunloopSandboxClient failed to ${operation}.`,
+      {
+        provider: 'runloop',
+        operation,
+        devboxId: this.state.devboxId,
+        path,
+        exitCode: result.status,
+        stdout: result.stdout ?? '',
+        stderr: result.stderr ?? '',
+      },
+    );
+  }
+
+  private timeoutForCommand(
+    options: RemoteSandboxCommandOptions,
+  ): number | undefined {
+    if (options.kind === 'exec') {
+      return this.state.timeouts?.execTimeoutMs;
+    }
+    if (options.kind === 'running') {
+      return this.state.timeouts?.keepAliveTimeoutMs;
+    }
+    if (options.kind === 'archive') {
+      return this.state.timeouts?.snapshotTimeoutMs;
+    }
+    if (options.kind === 'path' || options.kind === 'manifest') {
+      return this.state.timeouts?.fastOperationTimeoutMs;
+    }
+    return undefined;
+  }
+
+  private async ensureTunnelUrl(port: number): Promise<string> {
+    const existingUrl = await this.getTunnelUrl(port);
+    if (existingUrl) {
+      return existingUrl;
+    }
+
+    if (!this.devbox.net?.enableTunnel) {
+      throw new SandboxProviderError(
+        'RunloopSandboxClient exposed port resolution requires a Runloop tunnel API.',
+        {
+          provider: 'runloop',
+          port,
+        },
+      );
+    }
+
+    try {
+      const tunnelOptions = runloopRequestOptions(
+        this.state.timeouts?.fastOperationTimeoutMs,
+      );
+      const tunnelParams = runloopTunnelEnableParams(this.state.tunnel);
+      if (!tunnelParams) {
+        throw new SandboxProviderError(
+          `RunloopSandboxClient cannot enable a tunnel for exposed port ${port} because tunnel is disabled.`,
+          {
+            provider: 'runloop',
+            port,
+          },
+        );
+      }
+      if (tunnelOptions) {
+        await this.devbox.net.enableTunnel(tunnelParams, tunnelOptions);
+      } else {
+        await this.devbox.net.enableTunnel(tunnelParams);
+      }
+    } catch (error) {
+      throw new SandboxProviderError(
+        `RunloopSandboxClient failed to enable a tunnel for exposed port ${port}.`,
+        {
+          provider: 'runloop',
+          port,
+          cause: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+
+    const enabledUrl = await this.getTunnelUrl(port);
+    if (!enabledUrl) {
+      throw new SandboxProviderError(
+        `RunloopSandboxClient did not return a tunnel URL for exposed port ${port}.`,
+        {
+          provider: 'runloop',
+          port,
+        },
+      );
+    }
+    return enabledUrl;
+  }
+
+  private async getTunnelUrl(port: number): Promise<string | undefined> {
+    if (!this.devbox.getTunnelUrl) {
+      throw new SandboxProviderError(
+        'RunloopSandboxClient exposed port resolution requires getTunnelUrl(port).',
+        {
+          provider: 'runloop',
+          port,
+        },
+      );
+    }
+
+    try {
+      const tunnelOptions = runloopRequestOptions(
+        this.state.timeouts?.fastOperationTimeoutMs,
+      );
+      const url = tunnelOptions
+        ? await this.devbox.getTunnelUrl(port, tunnelOptions)
+        : await this.devbox.getTunnelUrl(port);
+      return typeof url === 'string' && url ? url : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+/**
+ * @see {@link https://docs.runloop.ai/docs/devboxes/overview | Devbox overview}.
+ * @see {@link https://docs.runloop.ai/docs/devboxes/start-stop | Devbox lifecycle}.
+ * @see {@link https://runloopai.github.io/api-client-ts/stable/classes/sdk.DevboxOps.html | TypeScript SDK Devbox reference}.
+ */
+export class RunloopSandboxClient implements SandboxClient<
+  RunloopSandboxClientOptions,
+  RunloopSandboxSessionState
+> {
+  readonly backendId = 'runloop';
+  private readonly options: RunloopSandboxClientOptions;
+
+  constructor(options: RunloopSandboxClientOptions = {}) {
+    this.options = options;
+  }
+
+  async platform(): Promise<RunloopPlatformClient> {
+    return new RunloopPlatformClient(await createRunloopClient(this.options));
+  }
+
+  async create(
+    args?: SandboxClientCreateArgs<RunloopSandboxClientOptions> | Manifest,
+    manifestOptions?: RunloopSandboxClientOptions,
+  ): Promise<RunloopSandboxSession> {
+    const manifestProvided =
+      args instanceof Manifest ||
+      (typeof args === 'object' &&
+        args !== null &&
+        args.manifest instanceof Manifest);
+    const createArgs = normalizeSandboxClientCreateArgs(args, manifestOptions);
+    assertCoreSnapshotUnsupported('RunloopSandboxClient', createArgs.snapshot);
+    assertCoreConcurrencyLimitsUnsupported(
+      'RunloopSandboxClient',
+      createArgs.concurrencyLimits,
+    );
+    const resolvedOptions: RunloopSandboxResolvedOptions = {
+      ...this.options,
+      ...createArgs.options,
+    };
+    const timeouts = resolveRunloopTimeouts(resolvedOptions);
+    const manifest = resolveRunloopManifestRoot(
+      createArgs.manifest,
+      resolvedOptions.userParameters,
+      manifestProvided,
+    );
+    assertSandboxManifestMetadataSupported(
+      'RunloopSandboxClient',
+      manifest,
+      SANDBOX_MANIFEST_METADATA_SUPPORT,
+    );
+    const sdk = await createRunloopClient(resolvedOptions);
+
+    return await withSandboxSpan(
+      'sandbox.start',
+      {
+        backend_id: this.backendId,
+      },
+      async () => {
+        const environment = await materializeEnvironment(
+          manifest,
+          resolvedOptions.env,
+        );
+        const createParams: Record<string, unknown> = {
+          environment_variables: environment,
+        };
+        const createBlueprintId = resolvedOptions.blueprintName
+          ? undefined
+          : resolvedOptions.blueprintId;
+        for (const key of [
+          'blueprintId',
+          'name',
+          'exposedPorts',
+          'tunnel',
+          'gateways',
+          'mcp',
+          'metadata',
+        ] as const) {
+          const value =
+            key === 'blueprintId' ? createBlueprintId : resolvedOptions[key];
+          if (value !== undefined) {
+            createParams[toSnakeCase(key)] = value;
+          }
+        }
+
+        if (
+          resolvedOptions.userParameters ||
+          resolvedOptions.launchParameters
+        ) {
+          createParams.launch_parameters = {
+            ...(resolvedOptions.launchParameters ?? {}),
+            user_parameters: resolvedOptions.userParameters,
+          };
+        }
+
+        const createOptions = runloopLongPollOptions(timeouts.createTimeoutMs);
+        const secretRefs =
+          resolvedOptions.secretRefs ??
+          (await upsertRunloopManagedSecrets(
+            sdk,
+            resolvedOptions.managedSecrets,
+            runloopRequestOptions(timeouts.fastOperationTimeoutMs) ??
+              createOptions,
+          ));
+        const persistedSecretRefs =
+          Object.keys(secretRefs).length > 0 ? secretRefs : undefined;
+        if (persistedSecretRefs) {
+          createParams.secrets = persistedSecretRefs;
+        }
+        const devbox = await withProviderError(
+          'RunloopSandboxClient',
+          'runloop',
+          'create devbox',
+          async () =>
+            resolvedOptions.blueprintName
+              ? await sdk.devbox.createFromBlueprintName(
+                  resolvedOptions.blueprintName,
+                  createParams,
+                  createOptions,
+                )
+              : await sdk.devbox.create(createParams, createOptions),
+          {
+            blueprintName: resolvedOptions.blueprintName,
+            blueprintId: createBlueprintId,
+          },
+        );
+
+        const session = new RunloopSandboxSession({
+          sdk,
+          devbox,
+          state: {
+            manifest,
+            devboxId: devbox.id,
+            blueprintName: resolvedOptions.blueprintName,
+            blueprintId: createBlueprintId,
+            name: resolvedOptions.name,
+            launchParameters: resolvedOptions.launchParameters,
+            configuredExposedPorts: resolvedOptions.exposedPorts,
+            tunnel: resolvedOptions.tunnel,
+            gateways: resolvedOptions.gateways,
+            mcp: resolvedOptions.mcp,
+            metadata: resolvedOptions.metadata,
+            secretRefs: persistedSecretRefs,
+            pauseOnExit: resolvedOptions.pauseOnExit ?? false,
+            userParameters: resolvedOptions.userParameters,
+            environment,
+            baseUrl: resolvedOptions.baseUrl,
+            createTimeoutMs: timeouts.createTimeoutMs,
+            timeouts,
+          },
+        });
+
+        try {
+          await session.applyManifest(manifest);
+        } catch (error) {
+          session.state.pauseOnExit = false;
+          await closeRemoteSessionOnManifestError('Runloop', session, error);
+        }
+        return session;
+      },
+    );
+  }
+
+  async serializeSessionState(
+    state: RunloopSandboxSessionState,
+  ): Promise<Record<string, unknown>> {
+    const { managedSecrets: _managedSecrets, ...serializableState } =
+      state as RunloopSandboxSessionState & {
+        managedSecrets?: Record<string, string>;
+      };
+    return serializeRemoteSandboxSessionState(serializableState);
+  }
+
+  canPersistOwnedSessionState(state: RunloopSandboxSessionState): boolean {
+    return state.pauseOnExit;
+  }
+
+  async deserializeSessionState(
+    state: Record<string, unknown>,
+  ): Promise<RunloopSandboxSessionState> {
+    const baseState = deserializeRemoteSandboxSessionStateValues(
+      state,
+      this.options.env,
+    );
+    const { managedSecrets: _managedSecrets, ...rest } = state;
+    return {
+      ...rest,
+      ...baseState,
+      devboxId: readString(state, 'devboxId'),
+      blueprintName: readOptionalString(state, 'blueprintName'),
+      blueprintId: readOptionalString(state, 'blueprintId'),
+      name: readOptionalString(state, 'name'),
+      launchParameters: readOptionalRecord(state.launchParameters),
+      configuredExposedPorts: readOptionalNumberArray(
+        state.configuredExposedPorts,
+      ),
+      tunnel:
+        typeof state.tunnel === 'boolean' || isRecord(state.tunnel)
+          ? (state.tunnel as boolean | Record<string, unknown>)
+          : undefined,
+      gateways: readOptionalRecord(state.gateways),
+      mcp: readOptionalRecord(state.mcp),
+      metadata: readOptionalStringRecord(state.metadata),
+      secretRefs: readOptionalStringRecord(state.secretRefs),
+      pauseOnExit: Boolean(state.pauseOnExit),
+      userParameters:
+        typeof state.userParameters === 'object' && state.userParameters
+          ? (state.userParameters as RunloopUserParameters)
+          : undefined,
+      baseUrl: readOptionalString(state, 'baseUrl'),
+      createTimeoutMs: readOptionalNumber(state, 'createTimeoutMs'),
+      timeouts: resolveRunloopTimeouts({
+        createTimeoutMs: readOptionalNumber(state, 'createTimeoutMs'),
+        timeouts: isRecord(state.timeouts)
+          ? (state.timeouts as RunloopSandboxTimeouts)
+          : undefined,
+      }),
+    };
+  }
+
+  async resume(
+    state: RunloopSandboxSessionState,
+  ): Promise<RunloopSandboxSession> {
+    const sdk = await createRunloopClient({
+      ...this.options,
+      baseUrl: state.baseUrl ?? this.options.baseUrl,
+    });
+    try {
+      const devbox = sdk.devbox.fromId(state.devboxId);
+      if (state.pauseOnExit) {
+        await devbox.resume(
+          runloopLongPollOptions(state.timeouts?.resumeTimeoutMs),
+        );
+      }
+      invalidateRunloopRuntimeCaches(state);
+      const session = new RunloopSandboxSession({ state, sdk, devbox });
+      try {
+        await rematerializeRunloopManifestMounts(session, state.manifest);
+      } catch (error) {
+        await session.cleanupAfterFailedResume();
+        throw error;
+      }
+      return session;
+    } catch (error) {
+      assertResumeRecreateAllowed(error, {
+        providerName: 'RunloopSandboxClient',
+        provider: 'runloop',
+        details: { devboxId: state.devboxId },
+      });
+      const recreateOptions: RunloopSandboxResolvedOptions = {
+        blueprintName: state.blueprintName,
+        blueprintId: state.blueprintId,
+        name: state.name,
+        launchParameters: state.launchParameters,
+        exposedPorts: state.configuredExposedPorts,
+        tunnel: state.tunnel,
+        gateways: state.gateways,
+        mcp: state.mcp,
+        metadata: state.metadata,
+        secretRefs: state.secretRefs,
+        pauseOnExit: state.pauseOnExit,
+        userParameters: state.userParameters,
+        env: state.environment,
+        baseUrl: state.baseUrl ?? this.options.baseUrl,
+        createTimeoutMs: state.createTimeoutMs,
+        timeouts: state.timeouts,
+      };
+      return await this.create(state.manifest, recreateOptions);
+    }
+  }
+}
+
+async function createRunloopClient(
+  options: Pick<RunloopSandboxClientOptions, 'apiKey' | 'baseUrl'>,
+): Promise<RunloopClientLike> {
+  try {
+    const { RunloopSDK } = await import('@runloop/api-client');
+    return adaptRunloopClient(
+      new RunloopSDK({
+        ...(options.apiKey ? { bearerToken: options.apiKey } : {}),
+        ...(options.baseUrl ? { baseURL: options.baseUrl } : {}),
+      }),
+    );
+  } catch (error) {
+    throw new UserError(
+      `Runloop sandbox support requires the optional \`@runloop/api-client\` package. Install it before using Runloop-backed sandbox examples. ${(error as Error).message}`,
+    );
+  }
+}
+
+function adaptRunloopClient(
+  sdk: import('@runloop/api-client').RunloopSDK,
+): RunloopClientLike {
+  const createFromSnapshot = bindRunloopMethod(
+    sdk.devbox,
+    'createFromSnapshot',
+  );
+  const secretList = bindRunloopMethod(sdk.secret, 'list');
+  const secretDelete = bindRunloopMethod(sdk.secret, 'delete');
+  return {
+    devbox: {
+      create: async (params, options) =>
+        adaptRunloopDevbox(
+          await sdk.devbox.create(
+            params as Parameters<typeof sdk.devbox.create>[0],
+            options as Parameters<typeof sdk.devbox.create>[1],
+          ),
+        ),
+      createFromBlueprintName: async (blueprintName, params, options) =>
+        adaptRunloopDevbox(
+          await sdk.devbox.createFromBlueprintName(
+            blueprintName,
+            params as Parameters<typeof sdk.devbox.createFromBlueprintName>[1],
+            options as Parameters<typeof sdk.devbox.createFromBlueprintName>[2],
+          ),
+        ),
+      ...(createFromSnapshot
+        ? {
+            createFromSnapshot: async (snapshotId, params, options) =>
+              adaptRunloopDevbox(
+                (await createFromSnapshot(
+                  snapshotId,
+                  params,
+                  options,
+                )) as import('@runloop/api-client').Devbox,
+              ),
+          }
+        : {}),
+      fromId: (id) => adaptRunloopDevbox(sdk.devbox.fromId(id)),
+    },
+    secret: {
+      create: async (...args) => {
+        const [params, options] = args;
+        const createParams = params as Parameters<typeof sdk.secret.create>[0];
+        return args.length > 1
+          ? await sdk.secret.create(
+              createParams,
+              options as Parameters<typeof sdk.secret.create>[1],
+            )
+          : await sdk.secret.create(createParams);
+      },
+      update: async (...args) => {
+        const [secret, params, options] = args;
+        const updateParams = params as Parameters<typeof sdk.secret.update>[1];
+        return args.length > 2
+          ? await sdk.secret.update(
+              secret,
+              updateParams,
+              options as Parameters<typeof sdk.secret.update>[2],
+            )
+          : await sdk.secret.update(secret, updateParams);
+      },
+      ...(secretList
+        ? {
+            list: async (...args) => {
+              const [params, options] = args;
+              return args.length > 1
+                ? await secretList(params, options)
+                : await secretList(params);
+            },
+          }
+        : {}),
+      ...(secretDelete
+        ? {
+            delete: async (...args) => {
+              const [secret, params, options] = args;
+              return args.length > 2
+                ? await secretDelete(secret, params, options)
+                : await secretDelete(secret, params);
+            },
+          }
+        : {}),
+    },
+    blueprint: adaptRunloopPlatformResource(sdk.blueprint),
+    benchmark: adaptRunloopPlatformResource(
+      (sdk as { benchmark?: unknown }).benchmark,
+    ),
+    networkPolicy: adaptRunloopPlatformResource(sdk.networkPolicy),
+    axon: adaptRunloopPlatformResource(sdk.axon),
+    api: adaptRunloopApi(sdk),
+  };
+}
+
+function adaptRunloopDevbox(
+  devbox: import('@runloop/api-client').Devbox,
+): RunloopDevboxLike {
+  const enableTunnel = bindRunloopMethod(
+    (devbox as { net?: unknown }).net,
+    'enableTunnel',
+  );
+  const getTunnelUrl = bindRunloopMethod(devbox, 'getTunnelUrl');
+  const snapshotDisk = bindRunloopMethod(devbox, 'snapshotDisk');
+
+  return {
+    id: devbox.id,
+    cmd: {
+      exec: async (...args) => {
+        const [command, params, options] = args;
+        if (args.length > 2) {
+          return await devbox.cmd.exec(
+            command,
+            params as Parameters<typeof devbox.cmd.exec>[1],
+            options as Parameters<typeof devbox.cmd.exec>[2],
+          );
+        }
+        return args.length > 1
+          ? await devbox.cmd.exec(
+              command,
+              params as Parameters<typeof devbox.cmd.exec>[1],
+            )
+          : await devbox.cmd.exec(command);
+      },
+    },
+    file: {
+      read: async (params, options) =>
+        await devbox.file.read(
+          params as Parameters<typeof devbox.file.read>[0],
+          options as Parameters<typeof devbox.file.read>[1],
+        ),
+      write: async (params, options) =>
+        await devbox.file.write(
+          {
+            file_path: params.path,
+            contents: params.contents,
+          },
+          options as Parameters<typeof devbox.file.write>[1],
+        ),
+      download: async (params, options) =>
+        await devbox.file.download(
+          params as Parameters<typeof devbox.file.download>[0],
+          options as Parameters<typeof devbox.file.download>[1],
+        ),
+      upload: async (params, options) => {
+        const uploadParams = params as Parameters<typeof devbox.file.upload>[0];
+        return options
+          ? await devbox.file.upload(
+              uploadParams,
+              options as Parameters<typeof devbox.file.upload>[1],
+            )
+          : await devbox.file.upload(uploadParams);
+      },
+    },
+    ...(enableTunnel
+      ? {
+          net: {
+            enableTunnel: async (params, options) =>
+              options
+                ? await enableTunnel(params, options)
+                : await enableTunnel(params),
+          },
+        }
+      : {}),
+    ...(getTunnelUrl
+      ? {
+          getTunnelUrl: async (port, options) =>
+            (options
+              ? await getTunnelUrl(port, options)
+              : await getTunnelUrl(port)) as string,
+        }
+      : {}),
+    ...(snapshotDisk
+      ? {
+          snapshotDisk: async (params, options) =>
+            (options
+              ? await snapshotDisk(params, options)
+              : await snapshotDisk(params)) as { id?: string },
+        }
+      : {}),
+    resume: async (options) =>
+      await devbox.resume(options as Parameters<typeof devbox.resume>[0]),
+    suspend: async (options) =>
+      await devbox.suspend(options as Parameters<typeof devbox.suspend>[0]),
+    shutdown: async (options) =>
+      await devbox.shutdown(options as Parameters<typeof devbox.shutdown>[0]),
+  };
+}
+
+function adaptRunloopPlatformResource(
+  resource: unknown,
+): RunloopPlatformResourceLike | undefined {
+  if (!isRecord(resource)) {
+    return undefined;
+  }
+  const fromId = resource.fromId;
+  return {
+    create: bindRunloopMethod(resource, 'create'),
+    list: bindRunloopMethod(resource, 'list'),
+    fromId:
+      typeof fromId === 'function'
+        ? (id) => fromId.call(resource, id)
+        : undefined,
+  };
+}
+
+function adaptRunloopApi(
+  sdk: import('@runloop/api-client').RunloopSDK,
+): Record<string, Record<string, RunloopPlatformMethodLike>> {
+  const apiClient = (sdk as { api?: unknown }).api;
+  if (!isRecord(apiClient)) {
+    return {};
+  }
+  const api: Record<string, Record<string, RunloopPlatformMethodLike>> = {};
+  const blueprintsResource = apiClient.blueprints;
+  const benchmarksResource = apiClient.benchmarks;
+  const secretsResource = apiClient.secrets;
+  const blueprints = runloopApiResource({
+    listPublic: bindRunloopMethod(blueprintsResource, 'listPublic'),
+    logs: bindRunloopMethod(blueprintsResource, 'logs'),
+    awaitBuildComplete: bindRunloopMethod(
+      blueprintsResource,
+      'awaitBuildComplete',
+    ),
+  });
+  if (Object.keys(blueprints).length > 0) {
+    api.blueprints = blueprints;
+  }
+
+  const benchmarks = runloopApiResource({
+    listPublic: bindRunloopMethod(benchmarksResource, 'listPublic'),
+    definitions: bindRunloopMethod(benchmarksResource, 'definitions'),
+    updateScenarios: bindRunloopMethod(benchmarksResource, 'updateScenarios'),
+  });
+  if (Object.keys(benchmarks).length > 0) {
+    api.benchmarks = benchmarks;
+  }
+
+  const secrets = runloopApiResource({
+    retrieve: bindRunloopMethod(secretsResource, 'retrieve'),
+  });
+  if (Object.keys(secrets).length > 0) {
+    api.secrets = secrets;
+  }
+
+  return api;
+}
+
+function runloopApiResource(
+  methods: Record<string, RunloopPlatformMethodLike | undefined>,
+): Record<string, RunloopPlatformMethodLike> {
+  return Object.fromEntries(
+    Object.entries(methods).filter(
+      (entry): entry is [string, RunloopPlatformMethodLike] =>
+        typeof entry[1] === 'function',
+    ),
+  );
+}
+
+function bindRunloopMethod(
+  target: unknown,
+  methodName: string,
+): RunloopPlatformMethodLike | undefined {
+  if (!isRecord(target)) {
+    return undefined;
+  }
+  const method = target[methodName];
+  return typeof method === 'function'
+    ? (method.bind(target) as RunloopPlatformMethodLike)
+    : undefined;
+}
+
+async function upsertRunloopManagedSecrets(
+  sdk: RunloopClientLike,
+  managedSecrets: Record<string, string> | undefined,
+  options: Record<string, unknown> | undefined,
+): Promise<Record<string, string>> {
+  if (!managedSecrets || Object.keys(managedSecrets).length === 0) {
+    return {};
+  }
+  if (!sdk.secret?.create || !sdk.secret.update) {
+    throw new SandboxProviderError(
+      'RunloopSandboxClient managedSecrets require the Runloop SDK secret API.',
+      {
+        provider: 'runloop',
+      },
+    );
+  }
+
+  const refs: Record<string, string> = {};
+  for (const [name, value] of Object.entries(managedSecrets).sort(
+    ([left], [right]) => left.localeCompare(right),
+  )) {
+    try {
+      await sdk.secret.create({ name, value }, options);
+    } catch (error) {
+      if (!isRunloopConflictError(error)) {
+        throw new SandboxProviderError(
+          `RunloopSandboxClient failed to create managed secret ${name}.`,
+          {
+            provider: 'runloop',
+            secretName: name,
+            cause: formatRunloopSecretErrorCause(error, value),
+          },
+        );
+      }
+      try {
+        await sdk.secret.update(name, { value }, options);
+      } catch (updateError) {
+        throw new SandboxProviderError(
+          `RunloopSandboxClient failed to update managed secret ${name}.`,
+          {
+            provider: 'runloop',
+            secretName: name,
+            cause: formatRunloopSecretErrorCause(updateError, value),
+          },
+        );
+      }
+    }
+    refs[name] = name;
+  }
+  return refs;
+}
+
+function isRunloopConflictError(error: unknown): boolean {
+  if (!isRecord(error)) {
+    return false;
+  }
+  const status = error.status ?? error.statusCode;
+  if (status === 409 || status === '409') {
+    return true;
+  }
+  const code = error.code;
+  if (code === 409 || code === '409') {
+    return true;
+  }
+  const text = `${String(error.name ?? '')} ${String(error.message ?? '')}`;
+  return /\b(conflict|already exists)\b/iu.test(text);
+}
+
+function formatRunloopSecretErrorCause(
+  error: unknown,
+  secretValue: string,
+): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return secretValue ? message.split(secretValue).join('[redacted]') : message;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function callRunloopPlatformMethod(
+  methodName: string,
+  method: RunloopPlatformMethodLike | undefined,
+  ...args: unknown[]
+): Promise<unknown> {
+  if (!method) {
+    throw new SandboxUnsupportedFeatureError(
+      `Runloop platform method ${methodName} is not available in the installed Runloop SDK.`,
+      {
+        provider: 'runloop',
+        feature: `platform.${methodName}`,
+      },
+    );
+  }
+  return await withProviderError(
+    'RunloopSandboxClient',
+    'runloop',
+    `call platform method ${methodName}`,
+    async () => await method(...args),
+  );
+}
+
+function callRunloopPlatformGetter(
+  methodName: string,
+  method: ((id: string) => unknown) | undefined,
+  id: string,
+): unknown {
+  if (!method) {
+    throw new SandboxUnsupportedFeatureError(
+      `Runloop platform method ${methodName} is not available in the installed Runloop SDK.`,
+      {
+        provider: 'runloop',
+        feature: `platform.${methodName}`,
+      },
+    );
+  }
+  try {
+    return method(id);
+  } catch (error) {
+    if (error instanceof UserError) {
+      throw error;
+    }
+    throw new SandboxProviderError(
+      `RunloopSandboxClient failed to call platform method ${methodName}.`,
+      {
+        provider: 'runloop',
+        operation: `call platform method ${methodName}`,
+        cause: error instanceof Error ? error.message : String(error),
+      },
+    );
+  }
+}
+
+function createRunloopParams(
+  state: RunloopSandboxSessionState,
+  environment: Record<string, string>,
+  options: {
+    includeBlueprint?: boolean;
+  } = {},
+): Record<string, unknown> {
+  const createParams: Record<string, unknown> = {
+    environment_variables: environment,
+  };
+  const includeBlueprint = options.includeBlueprint ?? true;
+  const values = {
+    blueprintId: includeBlueprint ? state.blueprintId : undefined,
+    name: state.name,
+    exposedPorts: state.configuredExposedPorts,
+    tunnel: state.tunnel,
+    gateways: state.gateways,
+    mcp: state.mcp,
+    metadata: state.metadata,
+    secrets: state.secretRefs,
+  };
+  for (const [key, value] of Object.entries(values)) {
+    if (value !== undefined) {
+      createParams[toSnakeCase(key)] = value;
+    }
+  }
+
+  if (state.userParameters || state.launchParameters) {
+    createParams.launch_parameters = {
+      ...(state.launchParameters ?? {}),
+      user_parameters: state.userParameters,
+    };
+  }
+
+  return createParams;
+}
+
+function resolveRunloopManifestRoot(
+  manifest: Manifest,
+  userParameters: RunloopUserParameters | undefined,
+  manifestProvided: boolean,
+): Manifest {
+  const effectiveHome = effectiveRunloopHome(userParameters);
+  const resolvedManifest =
+    manifestProvided || manifest.root !== '/workspace'
+      ? manifest
+      : cloneManifestWithRoot(manifest, effectiveHome);
+  validateRunloopManifestRoot(resolvedManifest, effectiveHome);
+  return resolvedManifest;
+}
+
+function effectiveRunloopHome(
+  userParameters: RunloopUserParameters | undefined,
+): string {
+  if (!userParameters) {
+    return DEFAULT_RUNLOOP_WORKSPACE_ROOT;
+  }
+  if (userParameters.username === 'root' && userParameters.uid === 0) {
+    return DEFAULT_RUNLOOP_ROOT_WORKSPACE_ROOT;
+  }
+  return `/home/${userParameters.username}`;
+}
+
+function validateRunloopManifestRoot(manifest: Manifest, home: string): void {
+  const root = pathPosix.normalize(manifest.root);
+  if (root === home || root.startsWith(`${home}/`)) {
+    return;
+  }
+  throw new SandboxConfigurationError(
+    `RunloopSandboxClient requires manifest.root to be the effective Runloop home (${home}) or a subdirectory of it.`,
+    {
+      provider: 'runloop',
+      root: manifest.root,
+      effectiveHome: home,
+    },
+  );
+}
+
+function createRunloopOptions(
+  state: Pick<RunloopSandboxSessionState, 'createTimeoutMs' | 'timeouts'>,
+): Record<string, unknown> | undefined {
+  return runloopLongPollOptions(
+    state.timeouts?.createTimeoutMs ?? state.createTimeoutMs,
+  );
+}
+
+function resolveRunloopTimeouts(
+  options: Pick<RunloopSandboxClientOptions, 'createTimeoutMs' | 'timeouts'>,
+): RunloopSandboxTimeouts {
+  return {
+    ...options.timeouts,
+    createTimeoutMs:
+      options.timeouts?.createTimeoutMs ?? options.createTimeoutMs,
+    fastOperationTimeoutMs:
+      options.timeouts?.fastOperationTimeoutMs ?? options.createTimeoutMs,
+  };
+}
+
+function runloopRequestOptions(
+  timeoutMs: number | undefined,
+): Record<string, unknown> | undefined {
+  return typeof timeoutMs === 'number' ? { timeout: timeoutMs } : undefined;
+}
+
+function runloopLongPollOptions(
+  timeoutMs: number | undefined,
+): Record<string, unknown> | undefined {
+  return typeof timeoutMs === 'number'
+    ? { timeout: timeoutMs, longPoll: { timeoutMs } }
+    : undefined;
+}
+
+function runloopTunnelEnableParams(
+  tunnel: boolean | Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (tunnel === false) {
+    return undefined;
+  }
+  if (isRecord(tunnel)) {
+    return {
+      ...DEFAULT_RUNLOOP_TUNNEL_PARAMS,
+      ...tunnel,
+    };
+  }
+  return { ...DEFAULT_RUNLOOP_TUNNEL_PARAMS };
+}
+
+function runloopExitStatus(result: RunloopExecutionResultLike): number {
+  return result.exitCode ?? UNKNOWN_RUNLOOP_EXIT_CODE;
+}
+
+function runloopSucceeded(result: RunloopExecutionResultLike): boolean {
+  return result.exitCode === 0;
+}
+
+function invalidateRunloopRuntimeCaches(
+  state: RunloopSandboxSessionState,
+): void {
+  delete state.exposedPorts;
+}
+
+async function rematerializeRunloopManifestMounts(
+  session: RunloopSandboxSession,
+  manifest: Manifest,
+): Promise<void> {
+  await session.rematerializeManifestMounts(manifest);
+}
+
+function buildShellCommand(
+  command: string,
+  environment: Record<string, string>,
+  cwd: string,
+  user?: string,
+  userParameters?: RunloopUserParameters,
+): string {
+  const exports = Object.entries(environment).map(([key, value]) => {
+    assertShellEnvironmentName(key);
+    return `export ${key}=${shellQuote(value)}`;
+  });
+  const shellCommand = [`cd ${shellQuote(cwd)}`, ...exports, command].join(
+    ' && ',
+  );
+  return runloopShellCommandForUser(shellCommand, user, userParameters);
+}
+
+function runloopShellCommandForUser(
+  command: string,
+  user?: string,
+  userParameters?: RunloopUserParameters,
+): string {
+  if (!user || user === effectiveRunloopUsername(userParameters)) {
+    return command;
+  }
+  return `sudo -n -u ${shellQuote(user)} -- sh -lc ${shellQuote(command)}`;
+}
+
+function effectiveRunloopUsername(
+  userParameters: RunloopUserParameters | undefined,
+): string {
+  return userParameters?.username ?? 'user';
+}
+
+function toSnakeCase(value: string): string {
+  return value.replace(/[A-Z]/gu, (match) => `_${match.toLowerCase()}`);
+}
+
+function basename(path: string): string {
+  return path.split('/').pop() || 'file';
+}

--- a/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
@@ -988,10 +988,11 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
 
   private mountCommandRunner(): RemoteMountCommand {
     return async (command, options = {}) => {
-      const result = await this.execShell(
+      const result = await this.execShellWithEnvironment(
         command,
         undefined,
         options.timeoutMs ?? this.state.timeouts?.fastOperationTimeoutMs,
+        mountCommandEnvironment(this.state.environment, options.user),
         options.user,
       );
       return {
@@ -1022,17 +1023,18 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
     }
   }
 
-  private async execShell(
+  private async execShellWithEnvironment(
     command: string,
-    workdir?: string,
-    timeoutMs?: number,
+    workdir: string | undefined,
+    timeoutMs: number | undefined,
+    environment: Record<string, string>,
     user?: string,
   ): Promise<RunloopExecutionResultLike> {
     return await this.execShellInWorkdir(
       command,
       this.resolveWorkdir(workdir),
       timeoutMs,
-      this.state.environment,
+      environment,
       user,
     );
   }
@@ -2164,6 +2166,13 @@ async function rematerializeRunloopManifestMounts(
   manifest: Manifest,
 ): Promise<void> {
   await session.rematerializeManifestMounts(manifest);
+}
+
+function mountCommandEnvironment(
+  environment: Record<string, string>,
+  user?: string,
+): Record<string, string> {
+  return user === 'root' ? {} : environment;
 }
 
 function buildShellCommand(

--- a/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
@@ -1974,10 +1974,31 @@ function effectiveRunloopHome(
   if (!userParameters) {
     return DEFAULT_RUNLOOP_WORKSPACE_ROOT;
   }
+  validateRunloopUsername(userParameters.username);
   if (userParameters.username === 'root' && userParameters.uid === 0) {
     return DEFAULT_RUNLOOP_ROOT_WORKSPACE_ROOT;
   }
   return `/home/${userParameters.username}`;
+}
+
+function validateRunloopUsername(username: string): void {
+  if (
+    username.length > 0 &&
+    username !== '.' &&
+    !username.includes('/') &&
+    !username.includes('..') &&
+    !username.includes('\0')
+  ) {
+    return;
+  }
+
+  throw new SandboxConfigurationError(
+    'RunloopSandboxClient userParameters.username must be non-empty and must not contain "/", "..", or NUL bytes.',
+    {
+      provider: 'runloop',
+      username,
+    },
+  );
 }
 
 function validateRunloopManifestRoot(manifest: Manifest, home: string): void {

--- a/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
@@ -1070,7 +1070,7 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
       command,
       options.workdir,
       options.timeoutMs ?? this.timeoutForCommand(options),
-      this.state.environment,
+      remoteCommandEnvironment(this.state.environment, options),
       options.runAs,
     );
     return {
@@ -1489,16 +1489,14 @@ export class RunloopSandboxClient implements SandboxClient<
   ): Promise<RunloopSandboxSession> {
     const resumeState: RunloopSandboxSessionState = {
       ...state,
+      baseUrl: this.options.baseUrl,
       manifest: resolveRunloopManifestRoot(
         state.manifest,
         state.userParameters,
         true,
       ),
     };
-    const sdk = await createRunloopClient({
-      ...this.options,
-      baseUrl: resumeState.baseUrl ?? this.options.baseUrl,
-    });
+    const sdk = await createRunloopClient(this.options);
     try {
       const devbox = sdk.devbox.fromId(resumeState.devboxId);
       if (resumeState.pauseOnExit) {
@@ -1525,6 +1523,7 @@ export class RunloopSandboxClient implements SandboxClient<
         provider: 'runloop',
         details: { devboxId: resumeState.devboxId },
       });
+      assertRunloopResumeRecreateSecretRefsTrusted(resumeState, this.options);
       const recreateOptions: RunloopSandboxResolvedOptions = {
         blueprintName: resumeState.blueprintName,
         blueprintId: resumeState.blueprintId,
@@ -1535,11 +1534,11 @@ export class RunloopSandboxClient implements SandboxClient<
         gateways: resumeState.gateways,
         mcp: resumeState.mcp,
         metadata: resumeState.metadata,
-        secretRefs: resumeState.secretRefs,
+        managedSecrets: this.options.managedSecrets,
         pauseOnExit: resumeState.pauseOnExit,
         userParameters: resumeState.userParameters,
         env: resumeState.environment,
-        baseUrl: resumeState.baseUrl ?? this.options.baseUrl,
+        baseUrl: this.options.baseUrl,
         createTimeoutMs: resumeState.createTimeoutMs,
         timeouts: resumeState.timeouts,
       };
@@ -2159,6 +2158,31 @@ function invalidateRunloopRuntimeCaches(
   state: RunloopSandboxSessionState,
 ): void {
   delete state.exposedPorts;
+}
+
+function remoteCommandEnvironment(
+  environment: Record<string, string>,
+  options: RemoteSandboxCommandOptions,
+): Record<string, string> {
+  return options.kind === 'exec' ? environment : {};
+}
+
+function assertRunloopResumeRecreateSecretRefsTrusted(
+  state: RunloopSandboxSessionState,
+  options: RunloopSandboxClientOptions,
+): void {
+  if (!state.secretRefs || Object.keys(state.secretRefs).length === 0) {
+    return;
+  }
+  if (
+    options.managedSecrets &&
+    Object.keys(options.managedSecrets).length > 0
+  ) {
+    return;
+  }
+  throw new UserError(
+    'RunloopSandboxClient cannot recreate a missing devbox with persisted secretRefs. Configure managedSecrets on the client to recreate secrets from trusted input.',
+  );
 }
 
 async function rematerializeRunloopManifestMounts(

--- a/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
@@ -1289,11 +1289,6 @@ export class RunloopSandboxClient implements SandboxClient<
     args?: SandboxClientCreateArgs<RunloopSandboxClientOptions> | Manifest,
     manifestOptions?: RunloopSandboxClientOptions,
   ): Promise<RunloopSandboxSession> {
-    const manifestProvided =
-      args instanceof Manifest ||
-      (typeof args === 'object' &&
-        args !== null &&
-        args.manifest instanceof Manifest);
     const createArgs = normalizeSandboxClientCreateArgs(args, manifestOptions);
     assertCoreSnapshotUnsupported('RunloopSandboxClient', createArgs.snapshot);
     assertCoreConcurrencyLimitsUnsupported(
@@ -1308,7 +1303,7 @@ export class RunloopSandboxClient implements SandboxClient<
     const manifest = resolveRunloopManifestRoot(
       createArgs.manifest,
       resolvedOptions.userParameters,
-      manifestProvided,
+      false,
     );
     assertSandboxManifestMetadataSupported(
       'RunloopSandboxClient',
@@ -2038,13 +2033,13 @@ function createRunloopParams(
 function resolveRunloopManifestRoot(
   manifest: Manifest,
   userParameters: RunloopUserParameters | undefined,
-  manifestProvided: boolean,
+  preserveDefaultRoot: boolean,
 ): Manifest {
   const effectiveHome = effectiveRunloopHome(userParameters);
   const resolvedManifest =
-    manifestProvided || manifest.root !== '/workspace'
-      ? manifest
-      : cloneManifestWithRoot(manifest, effectiveHome);
+    !preserveDefaultRoot && manifest.root === '/workspace'
+      ? cloneManifestWithRoot(manifest, effectiveHome)
+      : manifest;
   validateRunloopManifestRoot(resolvedManifest, effectiveHome);
   return resolvedManifest;
 }

--- a/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
@@ -808,6 +808,7 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
     }
 
     const previousDevbox = this.devbox;
+    const previousActiveMountPaths = new Set(this.activeMountPaths);
     let devbox: RunloopDevboxLike;
     try {
       devbox = await this.sdk.devbox.createFromSnapshot(
@@ -853,6 +854,9 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
       this.devbox = previousDevbox;
       this.state.devboxId = previousDevboxId;
       this.activeMountPaths.clear();
+      for (const mountPath of previousActiveMountPaths) {
+        this.activeMountPaths.add(mountPath);
+      }
       invalidateRunloopRuntimeCaches(this.state);
       throw new SandboxProviderError(
         'RunloopSandboxClient native snapshot restore failed while rematerializing mounts.',
@@ -886,6 +890,9 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
       this.devbox = previousDevbox;
       this.state.devboxId = previousDevboxId;
       this.activeMountPaths.clear();
+      for (const mountPath of previousActiveMountPaths) {
+        this.activeMountPaths.add(mountPath);
+      }
       invalidateRunloopRuntimeCaches(this.state);
       throw new SandboxProviderError(
         'RunloopSandboxClient native snapshot restore created a replacement devbox, but shutting down the previous devbox failed.',

--- a/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
@@ -1557,7 +1557,7 @@ export class RunloopSandboxClient implements SandboxClient<
         managedSecrets: this.options.managedSecrets,
         pauseOnExit: resumeState.pauseOnExit,
         userParameters: this.options.userParameters,
-        env: resumeState.environment,
+        env: this.options.env,
         baseUrl: this.options.baseUrl,
         createTimeoutMs: resumeState.createTimeoutMs,
         timeouts: resumeState.timeouts,

--- a/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
@@ -1508,6 +1508,7 @@ export class RunloopSandboxClient implements SandboxClient<
     const resumeState: RunloopSandboxSessionState = {
       ...state,
       baseUrl: this.options.baseUrl,
+      launchParameters: this.options.launchParameters,
       userParameters: this.options.userParameters,
       manifest: resolveRunloopManifestRoot(
         state.manifest,

--- a/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
@@ -814,6 +814,7 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
         snapshotId,
         createRunloopParams(this.state, this.state.environment, {
           includeBlueprint: false,
+          includeSecrets: false,
         }),
         createRunloopOptions(this.state),
       );
@@ -974,6 +975,10 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
       .catch(() => {});
   }
 
+  async ensureCurrentManifestRoot(): Promise<void> {
+    await this.ensureManifestRoot(this.state.manifest.root);
+  }
+
   private async unmountActiveMounts(): Promise<void> {
     for (const mountPath of [...this.activeMountPaths].reverse()) {
       await unmountRcloneMount({
@@ -992,7 +997,11 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
         command,
         undefined,
         options.timeoutMs ?? this.state.timeouts?.fastOperationTimeoutMs,
-        mountCommandEnvironment(this.state.environment, options.user),
+        mountCommandEnvironment(
+          this.state.environment,
+          options.user,
+          this.state.userParameters,
+        ),
         options.user,
       );
       return {
@@ -1004,9 +1013,22 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
   }
 
   private async ensureManifestRoot(root: string): Promise<void> {
+    const home = effectiveRunloopHome(this.state.userParameters);
+    const rootParent = root === home ? root : pathPosix.dirname(root);
     const result = await this.execShellInWorkdir(
-      `mkdir -p -- ${shellQuote(root)}`,
-      effectiveRunloopHome(this.state.userParameters),
+      [
+        `home_real=$(cd -- ${shellQuote(home)} && pwd -P)`,
+        `root_ancestor=${shellQuote(rootParent)}`,
+        'while [ ! -e "$root_ancestor" ]; do parent=$(dirname -- "$root_ancestor"); [ "$parent" = "$root_ancestor" ] && break; root_ancestor="$parent"; done',
+        'ancestor_real=$(cd -- "$root_ancestor" && pwd -P)',
+        `printf 'OPENAI_AGENTS_REALPATH_HOME=%s\\nOPENAI_AGENTS_REALPATH_ANCESTOR=%s\\n' "$home_real" "$ancestor_real"`,
+        'case "$ancestor_real" in "$home_real"|"$home_real"/*) ancestor_confined=1 ;; *) ancestor_confined=0 ;; esac',
+        `if [ "$home_real" = / ] || [ "$ancestor_confined" != 1 ]; then printf 'OPENAI_AGENTS_REALPATH_ROOT=%s\\n' ''; exit 0; fi`,
+        `mkdir -p -- ${shellQuote(root)}`,
+        `root_real=$(cd -- ${shellQuote(root)} && pwd -P)`,
+        `printf 'OPENAI_AGENTS_REALPATH_ROOT=%s\\n' "$root_real"`,
+      ].join(' && '),
+      home,
       this.state.timeouts?.fastOperationTimeoutMs,
       {},
     );
@@ -1021,6 +1043,7 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
         },
       );
     }
+    assertRunloopManifestRootRealPath(root, home, await result.stdout());
   }
 
   private async execShellWithEnvironment(
@@ -1485,9 +1508,10 @@ export class RunloopSandboxClient implements SandboxClient<
     const resumeState: RunloopSandboxSessionState = {
       ...state,
       baseUrl: this.options.baseUrl,
+      userParameters: this.options.userParameters,
       manifest: resolveRunloopManifestRoot(
         state.manifest,
-        state.userParameters,
+        this.options.userParameters,
         true,
       ),
     };
@@ -1506,6 +1530,7 @@ export class RunloopSandboxClient implements SandboxClient<
         devbox,
       });
       try {
+        await session.ensureCurrentManifestRoot();
         await rematerializeRunloopManifestMounts(session, resumeState.manifest);
       } catch (error) {
         await session.cleanupAfterFailedResume();
@@ -1520,10 +1545,10 @@ export class RunloopSandboxClient implements SandboxClient<
       });
       assertRunloopResumeRecreateSecretRefsTrusted(resumeState, this.options);
       const recreateOptions: RunloopSandboxResolvedOptions = {
-        blueprintName: resumeState.blueprintName,
-        blueprintId: resumeState.blueprintId,
+        blueprintName: this.options.blueprintName,
+        blueprintId: this.options.blueprintId,
         name: resumeState.name,
-        launchParameters: resumeState.launchParameters,
+        launchParameters: this.options.launchParameters,
         exposedPorts: resumeState.configuredExposedPorts,
         tunnel: resumeState.tunnel,
         gateways: resumeState.gateways,
@@ -1531,7 +1556,7 @@ export class RunloopSandboxClient implements SandboxClient<
         metadata: resumeState.metadata,
         managedSecrets: this.options.managedSecrets,
         pauseOnExit: resumeState.pauseOnExit,
-        userParameters: resumeState.userParameters,
+        userParameters: this.options.userParameters,
         env: resumeState.environment,
         baseUrl: this.options.baseUrl,
         createTimeoutMs: resumeState.createTimeoutMs,
@@ -1998,12 +2023,14 @@ function createRunloopParams(
   environment: Record<string, string>,
   options: {
     includeBlueprint?: boolean;
+    includeSecrets?: boolean;
   } = {},
 ): Record<string, unknown> {
   const createParams: Record<string, unknown> = {
     environment_variables: environment,
   };
   const includeBlueprint = options.includeBlueprint ?? true;
+  const includeSecrets = options.includeSecrets ?? true;
   const values = {
     blueprintId: includeBlueprint ? state.blueprintId : undefined,
     name: state.name,
@@ -2012,7 +2039,7 @@ function createRunloopParams(
     gateways: state.gateways,
     mcp: state.mcp,
     metadata: state.metadata,
-    secrets: state.secretRefs,
+    secrets: includeSecrets ? state.secretRefs : undefined,
   };
   for (const [key, value] of Object.entries(values)) {
     if (value !== undefined) {
@@ -2088,6 +2115,53 @@ function validateRunloopManifestRoot(manifest: Manifest, home: string): void {
       provider: 'runloop',
       root: manifest.root,
       effectiveHome: home,
+    },
+  );
+}
+
+function assertRunloopManifestRootRealPath(
+  root: string,
+  home: string,
+  stdout: string,
+): void {
+  const values = new Map(
+    stdout
+      .trim()
+      .split(/\r?\n/u)
+      .map((line) =>
+        line.match(/^(OPENAI_AGENTS_REALPATH_(?:ANCESTOR|HOME|ROOT))=(.*)$/u),
+      )
+      .filter((match): match is RegExpMatchArray => match !== null)
+      .map((match) => [match[1], pathPosix.normalize(match[2] ?? '')]),
+  );
+  const realHome = values.get('OPENAI_AGENTS_REALPATH_HOME');
+  const realAncestor = values.get('OPENAI_AGENTS_REALPATH_ANCESTOR');
+  const realRoot = values.get('OPENAI_AGENTS_REALPATH_ROOT');
+  const normalizedHome = pathPosix.normalize(home);
+  const realHomeIsConfined =
+    realHome &&
+    realHome !== '/' &&
+    (realHome === normalizedHome || realHome.startsWith(`${normalizedHome}/`));
+  const realAncestorIsConfined =
+    realHome &&
+    realAncestor &&
+    (realAncestor === realHome || realAncestor.startsWith(`${realHome}/`));
+  const realRootIsConfined =
+    realHome &&
+    realRoot &&
+    (realRoot === realHome || realRoot.startsWith(`${realHome}/`));
+  if (realHomeIsConfined && realAncestorIsConfined && realRootIsConfined) {
+    return;
+  }
+  throw new SandboxConfigurationError(
+    `RunloopSandboxClient requires manifest.root to resolve to the effective Runloop home (${home}) or a subdirectory of it.`,
+    {
+      provider: 'runloop',
+      root,
+      effectiveHome: home,
+      resolvedRoot: realRoot,
+      resolvedHome: realHome,
+      resolvedAncestor: realAncestor,
     },
   );
 }
@@ -2190,8 +2264,10 @@ async function rematerializeRunloopManifestMounts(
 function mountCommandEnvironment(
   environment: Record<string, string>,
   user?: string,
+  userParameters?: RunloopUserParameters,
 ): Record<string, string> {
-  return user === 'root' ? {} : environment;
+  const effectiveUser = user ?? effectiveRunloopUsername(userParameters);
+  return effectiveUser === 'root' ? {} : environment;
 }
 
 function buildShellCommand(

--- a/packages/agents-extensions/test/sandbox/runloop.test.ts
+++ b/packages/agents-extensions/test/sandbox/runloop.test.ts
@@ -602,10 +602,30 @@ describe('RunloopSandboxClient', () => {
     const defaultSession = await client.create();
 
     expect(defaultSession.state.manifest.root).toBe(RUNLOOP_HOME);
+    uploadMock.mockClear();
+
+    const defaultRootManifestSession = await client.create({
+      manifest: new Manifest({
+        root: '/workspace',
+        entries: {
+          'capability.txt': {
+            type: 'file',
+            content: 'capability\n',
+          },
+        },
+      }),
+    });
+
+    expect(defaultRootManifestSession.state.manifest.root).toBe(RUNLOOP_HOME);
+    expect(uploadMock).toHaveBeenCalledWith({
+      path: '/home/user/capability.txt',
+      file: expect.any(File),
+    });
+
     await expect(
       client.create(
         new Manifest({
-          root: '/workspace',
+          root: '/tmp',
         }),
       ),
     ).rejects.toBeInstanceOf(SandboxConfigurationError);

--- a/packages/agents-extensions/test/sandbox/runloop.test.ts
+++ b/packages/agents-extensions/test/sandbox/runloop.test.ts
@@ -16,6 +16,7 @@ import { decodeNativeSnapshotRef } from '../../src/sandbox/shared';
 import { resolvedRemotePathFromValidationCommand } from './remotePathValidation';
 import { makeTarArchive } from './tarFixture';
 
+const runloopSdkConstructorMock = vi.fn();
 const createMock = vi.fn();
 const createFromBlueprintNameMock = vi.fn();
 const createFromSnapshotMock = vi.fn();
@@ -131,6 +132,10 @@ function mockRunloopDevbox(overrides: Record<string, unknown> = {}) {
 
 vi.mock('@runloop/api-client', () => ({
   RunloopSDK: class RunloopSDK {
+    constructor(options?: Record<string, unknown>) {
+      runloopSdkConstructorMock(options);
+    }
+
     readonly devbox = {
       create: createMock,
       createFromBlueprintName: createFromBlueprintNameMock,
@@ -196,6 +201,7 @@ vi.mock('@runloop/api-client', () => ({
 
 describe('RunloopSandboxClient', () => {
   beforeEach(() => {
+    runloopSdkConstructorMock.mockReset();
     createMock.mockReset();
     createFromBlueprintNameMock.mockReset();
     createFromSnapshotMock.mockReset();
@@ -1099,6 +1105,36 @@ describe('RunloopSandboxClient', () => {
     );
   });
 
+  test('does not export manifest environment into internal path and manifest commands', async () => {
+    const client = new RunloopSandboxClient();
+    const session = await client.create(
+      runloopManifest({
+        environment: {
+          PATH: '/tmp/attacker-bin',
+        },
+      }),
+    );
+    execMock.mockClear();
+
+    await session.pathExists('README.md');
+    await session.applyManifest(
+      runloopManifest({
+        entries: {
+          logs: {
+            type: 'dir',
+          },
+        },
+      }),
+    );
+
+    const commands = execMock.mock.calls.map(([command]) => String(command));
+    expect(commands.length).toBeGreaterThan(0);
+    for (const command of commands) {
+      expect(command).not.toContain('export PATH=');
+      expect(command).not.toContain('/tmp/attacker-bin');
+    }
+  });
+
   test('rejects unsupported PTY execution with a typed error', async () => {
     const client = new RunloopSandboxClient();
     const session = await client.create(runloopManifest());
@@ -1121,6 +1157,30 @@ describe('RunloopSandboxClient', () => {
     expect(fromIdMock).toHaveBeenCalledWith('devbox_test');
     expect(resumeMock).toHaveBeenCalledOnce();
     expect(shutdownMock).not.toHaveBeenCalled();
+  });
+
+  test('ignores persisted baseUrl when resuming sessions', async () => {
+    const client = new RunloopSandboxClient({
+      apiKey: 'trusted-key',
+    });
+    const state = await client.deserializeSessionState({
+      manifest: runloopManifest(),
+      devboxId: 'devbox_test',
+      pauseOnExit: true,
+      environment: {},
+      baseUrl: 'https://attacker.example',
+    });
+    runloopSdkConstructorMock.mockClear();
+
+    const resumed = await client.resume(state);
+
+    expect(runloopSdkConstructorMock).toHaveBeenCalledWith({
+      bearerToken: 'trusted-key',
+    });
+    expect(runloopSdkConstructorMock.mock.calls[0]?.[0]).not.toHaveProperty(
+      'baseURL',
+    );
+    expect(resumed.state.baseUrl).toBeUndefined();
   });
 
   test('rejects persisted resume manifests outside the effective Runloop home', async () => {
@@ -1254,6 +1314,26 @@ describe('RunloopSandboxClient', () => {
     expect(resumeMock).toHaveBeenCalledOnce();
     expect(createMock).toHaveBeenCalledOnce();
     expect(recreated.state.devboxId).toBe('devbox_test');
+  });
+
+  test('rejects persisted secret refs when recreating missing devboxes', async () => {
+    const client = new RunloopSandboxClient();
+    const state = await client.deserializeSessionState({
+      manifest: runloopManifest(),
+      devboxId: 'devbox_test',
+      pauseOnExit: true,
+      environment: {},
+      secretRefs: {
+        API_KEY: 'attacker-secret',
+      },
+    });
+    resumeMock.mockRejectedValueOnce(new Error('devbox not found'));
+
+    await expect(client.resume(state)).rejects.toThrow(
+      'RunloopSandboxClient cannot recreate a missing devbox with persisted secretRefs.',
+    );
+
+    expect(createMock).not.toHaveBeenCalled();
   });
 
   test('fails fast when resume lookup fails with a provider error', async () => {

--- a/packages/agents-extensions/test/sandbox/runloop.test.ts
+++ b/packages/agents-extensions/test/sandbox/runloop.test.ts
@@ -31,6 +31,7 @@ const benchmarkCreateMock = vi.fn();
 const benchmarkListMock = vi.fn();
 const benchmarkListPublicMock = vi.fn();
 const benchmarkFromIdMock = vi.fn();
+const benchmarkRetrieveMock = vi.fn();
 const benchmarkUpdateMock = vi.fn();
 const benchmarkDefinitionsMock = vi.fn();
 const benchmarkStartRunMock = vi.fn();
@@ -64,6 +65,8 @@ const suspendMock = vi.fn();
 const shutdownMock = vi.fn();
 const RUNLOOP_HOME = '/home/user';
 let includeCreateFromSnapshotApi = true;
+let includeApiBenchmarks = true;
+let includeLegacyBenchmarkFacade = false;
 
 function runloopManifest(config: Record<string, unknown> = {}): Manifest {
   return new Manifest({
@@ -147,11 +150,13 @@ vi.mock('@runloop/api-client', () => ({
       list: blueprintListMock,
       fromId: blueprintFromIdMock,
     };
-    readonly benchmark = {
-      create: benchmarkCreateMock,
-      list: benchmarkListMock,
-      fromId: benchmarkFromIdMock,
-    };
+    readonly benchmark = includeLegacyBenchmarkFacade
+      ? {
+          create: benchmarkCreateMock,
+          list: benchmarkListMock,
+          fromId: benchmarkFromIdMock,
+        }
+      : undefined;
     readonly networkPolicy = {
       create: networkPolicyCreateMock,
       list: networkPolicyListMock,
@@ -168,11 +173,20 @@ vi.mock('@runloop/api-client', () => ({
         logs: blueprintLogsMock,
         awaitBuildComplete: blueprintAwaitBuildCompleteMock,
       },
-      benchmarks: {
-        listPublic: benchmarkListPublicMock,
-        definitions: benchmarkDefinitionsMock,
-        updateScenarios: benchmarkUpdateScenariosMock,
-      },
+      ...(includeApiBenchmarks
+        ? {
+            benchmarks: {
+              create: benchmarkCreateMock,
+              list: benchmarkListMock,
+              retrieve: benchmarkRetrieveMock,
+              update: benchmarkUpdateMock,
+              listPublic: benchmarkListPublicMock,
+              definitions: benchmarkDefinitionsMock,
+              startRun: benchmarkStartRunMock,
+              updateScenarios: benchmarkUpdateScenariosMock,
+            },
+          }
+        : {}),
       secrets: {
         retrieve: secretRetrieveMock,
       },
@@ -198,6 +212,7 @@ describe('RunloopSandboxClient', () => {
     benchmarkListMock.mockReset();
     benchmarkListPublicMock.mockReset();
     benchmarkFromIdMock.mockReset();
+    benchmarkRetrieveMock.mockReset();
     benchmarkUpdateMock.mockReset();
     benchmarkDefinitionsMock.mockReset();
     benchmarkStartRunMock.mockReset();
@@ -229,6 +244,8 @@ describe('RunloopSandboxClient', () => {
     resumeMock.mockReset();
     suspendMock.mockReset();
     shutdownMock.mockReset();
+    includeApiBenchmarks = true;
+    includeLegacyBenchmarkFacade = false;
 
     const devbox = mockRunloopDevbox();
 
@@ -251,6 +268,7 @@ describe('RunloopSandboxClient', () => {
     benchmarkCreateMock.mockResolvedValue({ id: 'bench_created' });
     benchmarkListMock.mockResolvedValue([{ id: 'bench_test' }]);
     benchmarkListPublicMock.mockResolvedValue([{ id: 'bench_public' }]);
+    benchmarkRetrieveMock.mockResolvedValue({ id: 'bench_test' });
     benchmarkFromIdMock.mockReturnValue({
       update: benchmarkUpdateMock,
       startRun: benchmarkStartRunMock,
@@ -850,7 +868,7 @@ describe('RunloopSandboxClient', () => {
     await platform.blueprints.delete('bp_test', { force: true });
     await platform.benchmarks.list({ limit: 5 });
     await platform.benchmarks.listPublic({ limit: 6 });
-    const benchmark = platform.benchmarks.get('bench_test');
+    const benchmark = await platform.benchmarks.get('bench_test');
     await platform.benchmarks.create({ name: 'agent-benchmark' });
     await platform.benchmarks.update('bench_test', { name: 'updated' });
     await platform.benchmarks.definitions('bench_test', { scenario: 'all' });
@@ -886,10 +904,7 @@ describe('RunloopSandboxClient', () => {
     expect(blueprint).toEqual({
       delete: blueprintDeleteMock,
     });
-    expect(benchmark).toEqual({
-      update: benchmarkUpdateMock,
-      startRun: benchmarkStartRunMock,
-    });
+    expect(benchmark).toEqual({ id: 'bench_test' });
     expect(networkPolicy).toEqual({
       update: networkPolicyUpdateMock,
       delete: networkPolicyDeleteMock,
@@ -914,15 +929,20 @@ describe('RunloopSandboxClient', () => {
     expect(blueprintDeleteMock).toHaveBeenCalledWith({ force: true });
     expect(benchmarkListMock).toHaveBeenCalledWith({ limit: 5 });
     expect(benchmarkListPublicMock).toHaveBeenCalledWith({ limit: 6 });
-    expect(benchmarkFromIdMock).toHaveBeenCalledWith('bench_test');
+    expect(benchmarkRetrieveMock).toHaveBeenCalledWith('bench_test');
     expect(benchmarkCreateMock).toHaveBeenCalledWith({
       name: 'agent-benchmark',
     });
-    expect(benchmarkUpdateMock).toHaveBeenCalledWith({ name: 'updated' });
+    expect(benchmarkUpdateMock).toHaveBeenCalledWith('bench_test', {
+      name: 'updated',
+    });
     expect(benchmarkDefinitionsMock).toHaveBeenCalledWith('bench_test', {
       scenario: 'all',
     });
-    expect(benchmarkStartRunMock).toHaveBeenCalledWith({ input: 'run' });
+    expect(benchmarkStartRunMock).toHaveBeenCalledWith({
+      benchmark_id: 'bench_test',
+      input: 'run',
+    });
     expect(benchmarkUpdateScenariosMock).toHaveBeenCalledWith('bench_test', {
       scenarios: [],
     });
@@ -968,21 +988,6 @@ describe('RunloopSandboxClient', () => {
         return blueprintDeleteMock(params);
       },
     });
-    benchmarkFromIdMock.mockReturnValue({
-      client: 'benchmark-client',
-      update: function (this: { client: string }, params: unknown) {
-        if (this.client !== 'benchmark-client') {
-          throw new Error('unbound benchmark update method');
-        }
-        return benchmarkUpdateMock(params);
-      },
-      startRun: function (this: { client: string }, params: unknown) {
-        if (this.client !== 'benchmark-client') {
-          throw new Error('unbound benchmark startRun method');
-        }
-        return benchmarkStartRunMock(params);
-      },
-    });
     networkPolicyFromIdMock.mockReturnValue({
       client: 'network-policy-client',
       update: function (this: { client: string }, params: unknown) {
@@ -1024,8 +1029,6 @@ describe('RunloopSandboxClient', () => {
     });
 
     await platform.blueprints.delete('bp_test', { force: true });
-    await platform.benchmarks.update('bench_test', { name: 'updated' });
-    await platform.benchmarks.startRun('bench_test', { input: 'run' });
     await platform.networkPolicies.update('np_test', { name: 'updated' });
     await platform.networkPolicies.delete('np_test', { force: true });
     await platform.axons.publish('axon_test', { revision: 'latest' });
@@ -1035,8 +1038,6 @@ describe('RunloopSandboxClient', () => {
     });
 
     expect(blueprintDeleteMock).toHaveBeenCalledWith({ force: true });
-    expect(benchmarkUpdateMock).toHaveBeenCalledWith({ name: 'updated' });
-    expect(benchmarkStartRunMock).toHaveBeenCalledWith({ input: 'run' });
     expect(networkPolicyUpdateMock).toHaveBeenCalledWith({ name: 'updated' });
     expect(networkPolicyDeleteMock).toHaveBeenCalledWith({ force: true });
     expect(axonPublishMock).toHaveBeenCalledWith({ revision: 'latest' });
@@ -1044,6 +1045,43 @@ describe('RunloopSandboxClient', () => {
     expect(axonBatchMock).toHaveBeenCalledWith({
       statements: ['select 1'],
     });
+  });
+
+  test('falls back to legacy Runloop benchmark facade methods', async () => {
+    includeApiBenchmarks = false;
+    includeLegacyBenchmarkFacade = true;
+    const client = new RunloopSandboxClient();
+    const platform = await client.platform();
+    benchmarkFromIdMock.mockReturnValue({
+      client: 'benchmark-client',
+      update: function (this: { client: string }, params: unknown) {
+        if (this.client !== 'benchmark-client') {
+          throw new Error('unbound benchmark update method');
+        }
+        return benchmarkUpdateMock(params);
+      },
+      startRun: function (this: { client: string }, params: unknown) {
+        if (this.client !== 'benchmark-client') {
+          throw new Error('unbound benchmark startRun method');
+        }
+        return benchmarkStartRunMock(params);
+      },
+    });
+
+    await platform.benchmarks.list({ limit: 5 });
+    const benchmark = platform.benchmarks.get('bench_test');
+    await platform.benchmarks.create({ name: 'agent-benchmark' });
+    await platform.benchmarks.update('bench_test', { name: 'updated' });
+    await platform.benchmarks.startRun('bench_test', { input: 'run' });
+
+    expect(benchmark).toMatchObject({ client: 'benchmark-client' });
+    expect(benchmarkListMock).toHaveBeenCalledWith({ limit: 5 });
+    expect(benchmarkCreateMock).toHaveBeenCalledWith({
+      name: 'agent-benchmark',
+    });
+    expect(benchmarkFromIdMock).toHaveBeenCalledWith('bench_test');
+    expect(benchmarkUpdateMock).toHaveBeenCalledWith({ name: 'updated' });
+    expect(benchmarkStartRunMock).toHaveBeenCalledWith({ input: 'run' });
   });
 
   test('rejects unsafe environment names before building shell commands', async () => {
@@ -1083,6 +1121,23 @@ describe('RunloopSandboxClient', () => {
     expect(fromIdMock).toHaveBeenCalledWith('devbox_test');
     expect(resumeMock).toHaveBeenCalledOnce();
     expect(shutdownMock).not.toHaveBeenCalled();
+  });
+
+  test('rejects persisted resume manifests outside the effective Runloop home', async () => {
+    const client = new RunloopSandboxClient();
+    const session = await client.create(runloopManifest(), {
+      pauseOnExit: true,
+    });
+    session.state.manifest = new Manifest({ root: '/tmp' });
+    fromIdMock.mockClear();
+    resumeMock.mockClear();
+
+    await expect(client.resume(session.state)).rejects.toBeInstanceOf(
+      SandboxConfigurationError,
+    );
+
+    expect(fromIdMock).not.toHaveBeenCalled();
+    expect(resumeMock).not.toHaveBeenCalled();
   });
 
   test('refreshes ports and rematerializes cloud mounts when resuming', async () => {

--- a/packages/agents-extensions/test/sandbox/runloop.test.ts
+++ b/packages/agents-extensions/test/sandbox/runloop.test.ts
@@ -1655,4 +1655,40 @@ describe('RunloopSandboxClient', () => {
       ),
     ).toBe(true);
   });
+
+  test('does not export manifest environment into root mount commands', async () => {
+    const client = new RunloopSandboxClient();
+
+    await client.create(
+      runloopManifest({
+        environment: {
+          PATH: '/tmp/attacker-bin',
+        },
+        entries: {
+          data: {
+            type: 's3_mount',
+            bucket: 'agent-logs',
+            accessKeyId: 'access-key',
+            secretAccessKey: 'secret-key',
+            mountPath: 'mounted/logs',
+            mountStrategy: new RunloopCloudBucketMountStrategy(),
+          },
+        },
+      }),
+    );
+
+    const rootMountCommands = execMock.mock.calls
+      .map(([command]) => String(command))
+      .filter(
+        (command) =>
+          command.startsWith("sudo -n -u 'root' -- sh -lc ") &&
+          command.includes('chmod a+rw /dev/fuse'),
+      );
+
+    expect(rootMountCommands.length).toBeGreaterThan(0);
+    for (const command of rootMountCommands) {
+      expect(command).not.toContain('export PATH=');
+      expect(command).not.toContain('/tmp/attacker-bin');
+    }
+  });
 });

--- a/packages/agents-extensions/test/sandbox/runloop.test.ts
+++ b/packages/agents-extensions/test/sandbox/runloop.test.ts
@@ -587,6 +587,29 @@ describe('RunloopSandboxClient', () => {
     ).rejects.toBeInstanceOf(SandboxConfigurationError);
   });
 
+  test('rejects unsafe usernames before deriving the effective home', async () => {
+    for (const username of [
+      '',
+      '.',
+      '..',
+      '../root',
+      'team/user',
+      'user/../root',
+      'team..user',
+    ]) {
+      const client = new RunloopSandboxClient({
+        userParameters: {
+          username,
+          uid: 1000,
+        },
+      });
+
+      await expect(client.create()).rejects.toThrow('userParameters.username');
+    }
+
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
   test('validates manifest roots when applying manifests to sessions', async () => {
     const client = new RunloopSandboxClient();
     const session = await client.create();

--- a/packages/agents-extensions/test/sandbox/runloop.test.ts
+++ b/packages/agents-extensions/test/sandbox/runloop.test.ts
@@ -1,0 +1,1580 @@
+import {
+  Manifest,
+  SandboxArchiveError,
+  SandboxConfigurationError,
+  SandboxMountError,
+  SandboxProviderError,
+  SandboxUnsupportedFeatureError,
+} from '@openai/agents-core/sandbox';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  RunloopCloudBucketMountStrategy,
+  RunloopSandboxClient,
+  type RunloopUserParameters,
+} from '../../src/sandbox/runloop';
+import { decodeNativeSnapshotRef } from '../../src/sandbox/shared';
+import { resolvedRemotePathFromValidationCommand } from './remotePathValidation';
+import { makeTarArchive } from './tarFixture';
+
+const createMock = vi.fn();
+const createFromBlueprintNameMock = vi.fn();
+const createFromSnapshotMock = vi.fn();
+const fromIdMock = vi.fn();
+const blueprintCreateMock = vi.fn();
+const blueprintListMock = vi.fn();
+const blueprintFromIdMock = vi.fn();
+const blueprintDeleteMock = vi.fn();
+const blueprintListPublicMock = vi.fn();
+const blueprintLogsMock = vi.fn();
+const blueprintAwaitBuildCompleteMock = vi.fn();
+const benchmarkCreateMock = vi.fn();
+const benchmarkListMock = vi.fn();
+const benchmarkListPublicMock = vi.fn();
+const benchmarkFromIdMock = vi.fn();
+const benchmarkUpdateMock = vi.fn();
+const benchmarkDefinitionsMock = vi.fn();
+const benchmarkStartRunMock = vi.fn();
+const benchmarkUpdateScenariosMock = vi.fn();
+const secretCreateMock = vi.fn();
+const secretListMock = vi.fn();
+const secretUpdateMock = vi.fn();
+const secretDeleteMock = vi.fn();
+const secretRetrieveMock = vi.fn();
+const networkPolicyCreateMock = vi.fn();
+const networkPolicyListMock = vi.fn();
+const networkPolicyFromIdMock = vi.fn();
+const networkPolicyUpdateMock = vi.fn();
+const networkPolicyDeleteMock = vi.fn();
+const axonCreateMock = vi.fn();
+const axonListMock = vi.fn();
+const axonFromIdMock = vi.fn();
+const axonPublishMock = vi.fn();
+const axonQueryMock = vi.fn();
+const axonBatchMock = vi.fn();
+const execMock = vi.fn();
+const readMock = vi.fn();
+const writeMock = vi.fn();
+const downloadMock = vi.fn();
+const uploadMock = vi.fn();
+const getTunnelUrlMock = vi.fn();
+const enableTunnelMock = vi.fn();
+const snapshotDiskMock = vi.fn();
+const resumeMock = vi.fn();
+const suspendMock = vi.fn();
+const shutdownMock = vi.fn();
+const RUNLOOP_HOME = '/home/user';
+let includeCreateFromSnapshotApi = true;
+
+function runloopManifest(config: Record<string, unknown> = {}): Manifest {
+  return new Manifest({
+    root: RUNLOOP_HOME,
+    ...config,
+  });
+}
+
+function runloopCloudBucketManifest(
+  entryOverrides: Record<string, unknown> = {},
+): Manifest {
+  return runloopManifest({
+    entries: {
+      data: {
+        type: 's3_mount',
+        bucket: 'agent-logs',
+        accessKeyId: 'access-key',
+        secretAccessKey: 'secret-key',
+        mountPath: 'mounted/logs',
+        mountStrategy: new RunloopCloudBucketMountStrategy(),
+        ...entryOverrides,
+      },
+    },
+  });
+}
+
+function execResult(args: {
+  exitCode: number | null;
+  stdout?: string;
+  stderr?: string;
+}) {
+  return {
+    exitCode: args.exitCode,
+    stdout: vi.fn().mockResolvedValue(args.stdout ?? ''),
+    stderr: vi.fn().mockResolvedValue(args.stderr ?? ''),
+  };
+}
+
+function mockRunloopDevbox(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'devbox_test',
+    cmd: {
+      exec: execMock,
+    },
+    file: {
+      read: readMock,
+      write: writeMock,
+      download: downloadMock,
+      upload: uploadMock,
+    },
+    net: {
+      enableTunnel: enableTunnelMock,
+    },
+    getTunnelUrl: getTunnelUrlMock,
+    snapshotDisk: snapshotDiskMock,
+    resume: resumeMock,
+    suspend: suspendMock,
+    shutdown: shutdownMock,
+    ...overrides,
+  };
+}
+
+vi.mock('@runloop/api-client', () => ({
+  RunloopSDK: class RunloopSDK {
+    readonly devbox = {
+      create: createMock,
+      createFromBlueprintName: createFromBlueprintNameMock,
+      ...(includeCreateFromSnapshotApi
+        ? { createFromSnapshot: createFromSnapshotMock }
+        : {}),
+      fromId: fromIdMock,
+    };
+    readonly secret = {
+      create: secretCreateMock,
+      list: secretListMock,
+      update: secretUpdateMock,
+      delete: secretDeleteMock,
+    };
+    readonly blueprint = {
+      create: blueprintCreateMock,
+      list: blueprintListMock,
+      fromId: blueprintFromIdMock,
+    };
+    readonly benchmark = {
+      create: benchmarkCreateMock,
+      list: benchmarkListMock,
+      fromId: benchmarkFromIdMock,
+    };
+    readonly networkPolicy = {
+      create: networkPolicyCreateMock,
+      list: networkPolicyListMock,
+      fromId: networkPolicyFromIdMock,
+    };
+    readonly axon = {
+      create: axonCreateMock,
+      list: axonListMock,
+      fromId: axonFromIdMock,
+    };
+    readonly api = {
+      blueprints: {
+        listPublic: blueprintListPublicMock,
+        logs: blueprintLogsMock,
+        awaitBuildComplete: blueprintAwaitBuildCompleteMock,
+      },
+      benchmarks: {
+        listPublic: benchmarkListPublicMock,
+        definitions: benchmarkDefinitionsMock,
+        updateScenarios: benchmarkUpdateScenariosMock,
+      },
+      secrets: {
+        retrieve: secretRetrieveMock,
+      },
+    };
+  },
+}));
+
+describe('RunloopSandboxClient', () => {
+  beforeEach(() => {
+    createMock.mockReset();
+    createFromBlueprintNameMock.mockReset();
+    createFromSnapshotMock.mockReset();
+    includeCreateFromSnapshotApi = true;
+    fromIdMock.mockReset();
+    blueprintCreateMock.mockReset();
+    blueprintListMock.mockReset();
+    blueprintFromIdMock.mockReset();
+    blueprintDeleteMock.mockReset();
+    blueprintListPublicMock.mockReset();
+    blueprintLogsMock.mockReset();
+    blueprintAwaitBuildCompleteMock.mockReset();
+    benchmarkCreateMock.mockReset();
+    benchmarkListMock.mockReset();
+    benchmarkListPublicMock.mockReset();
+    benchmarkFromIdMock.mockReset();
+    benchmarkUpdateMock.mockReset();
+    benchmarkDefinitionsMock.mockReset();
+    benchmarkStartRunMock.mockReset();
+    benchmarkUpdateScenariosMock.mockReset();
+    secretCreateMock.mockReset();
+    secretListMock.mockReset();
+    secretUpdateMock.mockReset();
+    secretDeleteMock.mockReset();
+    secretRetrieveMock.mockReset();
+    networkPolicyCreateMock.mockReset();
+    networkPolicyListMock.mockReset();
+    networkPolicyFromIdMock.mockReset();
+    networkPolicyUpdateMock.mockReset();
+    networkPolicyDeleteMock.mockReset();
+    axonCreateMock.mockReset();
+    axonListMock.mockReset();
+    axonFromIdMock.mockReset();
+    axonPublishMock.mockReset();
+    axonQueryMock.mockReset();
+    axonBatchMock.mockReset();
+    execMock.mockReset();
+    readMock.mockReset();
+    writeMock.mockReset();
+    downloadMock.mockReset();
+    uploadMock.mockReset();
+    getTunnelUrlMock.mockReset();
+    enableTunnelMock.mockReset();
+    snapshotDiskMock.mockReset();
+    resumeMock.mockReset();
+    suspendMock.mockReset();
+    shutdownMock.mockReset();
+
+    const devbox = mockRunloopDevbox();
+
+    createMock.mockResolvedValue(devbox);
+    createFromBlueprintNameMock.mockResolvedValue(devbox);
+    createFromSnapshotMock.mockResolvedValue({
+      ...devbox,
+      id: 'devbox_restored',
+    });
+    fromIdMock.mockReturnValue(devbox);
+    blueprintCreateMock.mockResolvedValue({ id: 'bp_created' });
+    blueprintListMock.mockResolvedValue([{ id: 'bp_test' }]);
+    blueprintListPublicMock.mockResolvedValue([{ id: 'bp_public' }]);
+    blueprintLogsMock.mockResolvedValue({ logs: [] });
+    blueprintAwaitBuildCompleteMock.mockResolvedValue({ status: 'ready' });
+    blueprintFromIdMock.mockReturnValue({
+      delete: blueprintDeleteMock,
+    });
+    blueprintDeleteMock.mockResolvedValue({});
+    benchmarkCreateMock.mockResolvedValue({ id: 'bench_created' });
+    benchmarkListMock.mockResolvedValue([{ id: 'bench_test' }]);
+    benchmarkListPublicMock.mockResolvedValue([{ id: 'bench_public' }]);
+    benchmarkFromIdMock.mockReturnValue({
+      update: benchmarkUpdateMock,
+      startRun: benchmarkStartRunMock,
+    });
+    benchmarkUpdateMock.mockResolvedValue({ id: 'bench_test' });
+    benchmarkDefinitionsMock.mockResolvedValue([{ id: 'definition' }]);
+    benchmarkStartRunMock.mockResolvedValue({ id: 'run_test' });
+    benchmarkUpdateScenariosMock.mockResolvedValue({ updated: true });
+    secretCreateMock.mockResolvedValue({});
+    secretListMock.mockResolvedValue({});
+    secretUpdateMock.mockResolvedValue({});
+    secretDeleteMock.mockResolvedValue({});
+    secretRetrieveMock.mockResolvedValue({ name: 'API_KEY' });
+    networkPolicyCreateMock.mockResolvedValue({ id: 'np_created' });
+    networkPolicyListMock.mockResolvedValue([{ id: 'np_test' }]);
+    networkPolicyFromIdMock.mockReturnValue({
+      update: networkPolicyUpdateMock,
+      delete: networkPolicyDeleteMock,
+    });
+    networkPolicyUpdateMock.mockResolvedValue({ id: 'np_test' });
+    networkPolicyDeleteMock.mockResolvedValue({});
+    axonCreateMock.mockResolvedValue({ id: 'axon_created' });
+    axonListMock.mockResolvedValue([{ id: 'axon_test' }]);
+    axonFromIdMock.mockReturnValue({
+      publish: axonPublishMock,
+      sql: {
+        query: axonQueryMock,
+        batch: axonBatchMock,
+      },
+    });
+    axonPublishMock.mockResolvedValue({ published: true });
+    axonQueryMock.mockResolvedValue({ rows: [] });
+    axonBatchMock.mockResolvedValue({ results: [] });
+    execMock.mockImplementation(async (command: string) => {
+      const resolvedPath = resolvedRemotePathFromValidationCommand(command);
+      return {
+        exitCode: 0,
+        stdout: vi
+          .fn()
+          .mockResolvedValue(
+            resolvedPath ? `${resolvedPath}\n` : 'README.md\n',
+          ),
+        stderr: vi.fn().mockResolvedValue(''),
+      };
+    });
+    readMock.mockResolvedValue('# Hello\n');
+    writeMock.mockResolvedValue(undefined);
+    downloadMock.mockResolvedValue({
+      buffer: async () => Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00]),
+    });
+    uploadMock.mockResolvedValue(undefined);
+    getTunnelUrlMock.mockResolvedValue('https://3000-devbox.tunnel.runloop.ai');
+    enableTunnelMock.mockResolvedValue(undefined);
+    snapshotDiskMock.mockResolvedValue({ id: 'snap_runloop' });
+    resumeMock.mockResolvedValue(undefined);
+    suspendMock.mockResolvedValue(undefined);
+    shutdownMock.mockResolvedValue(undefined);
+  });
+
+  test('rejects unsupported core create options instead of ignoring them', async () => {
+    const client = new RunloopSandboxClient();
+
+    await expect(
+      client.create({
+        manifest: new Manifest(),
+        snapshot: { type: 'remote' },
+      }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+    await expect(
+      client.create({
+        manifest: new Manifest(),
+        concurrencyLimits: { manifestEntries: 2 },
+      }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('creates from a blueprint, materializes files, and executes commands', async () => {
+    const client = new RunloopSandboxClient();
+    const userParameters: RunloopUserParameters = {
+      username: 'root',
+      uid: 0,
+    };
+
+    const session = await client.create(
+      new Manifest({
+        root: '/root',
+        entries: {
+          'README.md': {
+            type: 'file',
+            content: '# Hello\n',
+          },
+        },
+      }),
+      {
+        blueprintName: 'blueprint-test',
+        userParameters,
+      },
+    );
+    const output = await session.execCommand({ cmd: 'ls' });
+
+    expect(createFromBlueprintNameMock).toHaveBeenCalledWith(
+      'blueprint-test',
+      {
+        environment_variables: {},
+        launch_parameters: {
+          user_parameters: userParameters,
+        },
+      },
+      undefined,
+    );
+    expect(uploadMock).toHaveBeenCalledWith({
+      path: '/root/README.md',
+      file: expect.any(File),
+    });
+    expect(execMock).toHaveBeenCalledWith("cd '/root' && ls", {
+      last_n: '2000',
+    });
+    expect(output).toContain('README.md');
+  });
+
+  test('omits blueprint_id when creating from a blueprint name', async () => {
+    const client = new RunloopSandboxClient({
+      blueprintId: 'bp-default',
+    });
+
+    await client.create(runloopManifest(), {
+      blueprintName: 'blueprint-test',
+    });
+
+    expect(createFromBlueprintNameMock).toHaveBeenCalledWith(
+      'blueprint-test',
+      expect.not.objectContaining({
+        blueprint_id: 'bp-default',
+      }),
+      undefined,
+    );
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('creates subdirectory manifest roots before path validation', async () => {
+    let rootCreated = false;
+    execMock.mockImplementation(async (command: string) => {
+      if (command === "cd '/home/user' && mkdir -p -- '/home/user/project'") {
+        rootCreated = true;
+        return execResult({ exitCode: 0 });
+      }
+      if (command.startsWith("cd '/home/user/project' &&") && !rootCreated) {
+        return execResult({
+          exitCode: 1,
+          stderr: 'cd: /home/user/project: No such file or directory',
+        });
+      }
+      const resolvedPath = resolvedRemotePathFromValidationCommand(command);
+      return execResult({
+        exitCode: 0,
+        stdout: resolvedPath ? `${resolvedPath}\n` : 'README.md\n',
+      });
+    });
+    const client = new RunloopSandboxClient();
+
+    await client.create(
+      new Manifest({
+        root: '/home/user/project',
+        entries: {
+          'README.md': {
+            type: 'file',
+            content: '# Hello\n',
+          },
+        },
+      }),
+    );
+
+    expect(rootCreated).toBe(true);
+    expect(uploadMock).toHaveBeenCalledWith({
+      path: '/home/user/project/README.md',
+      file: expect.any(File),
+    });
+  });
+
+  test('reports unknown Runloop exec exit codes as failures', async () => {
+    const client = new RunloopSandboxClient();
+    const session = await client.create(runloopManifest());
+    execMock.mockResolvedValueOnce(
+      execResult({
+        exitCode: null,
+        stderr: 'command interrupted',
+      }),
+    );
+
+    const output = await session.execCommand({ cmd: 'ls' });
+
+    expect(output).toContain('Process exited with code 1');
+    expect(output).toContain('command interrupted');
+  });
+
+  test('treats unknown Runloop liveness exit codes as not running', async () => {
+    const client = new RunloopSandboxClient();
+    const session = await client.create(runloopManifest());
+    execMock.mockResolvedValueOnce(execResult({ exitCode: null }));
+
+    await expect(session.running()).resolves.toBe(false);
+  });
+
+  test('passes createTimeoutMs to create calls', async () => {
+    const client = new RunloopSandboxClient();
+
+    await client.create(runloopManifest(), {
+      createTimeoutMs: 12_345,
+    });
+    await client.create(runloopManifest(), {
+      blueprintName: 'blueprint-test',
+      createTimeoutMs: 23_456,
+    });
+
+    expect(createMock).toHaveBeenCalledWith(
+      {
+        environment_variables: {},
+      },
+      {
+        timeout: 12_345,
+        longPoll: { timeoutMs: 12_345 },
+      },
+    );
+    expect(createFromBlueprintNameMock).toHaveBeenCalledWith(
+      'blueprint-test',
+      {
+        environment_variables: {},
+      },
+      {
+        timeout: 23_456,
+        longPoll: { timeoutMs: 23_456 },
+      },
+    );
+  });
+
+  test('applies provider timeout bundles to Runloop operations', async () => {
+    const client = new RunloopSandboxClient({
+      timeouts: {
+        createTimeoutMs: 101,
+        execTimeoutMs: 202,
+        fileUploadTimeoutMs: 303,
+        fileDownloadTimeoutMs: 404,
+        snapshotTimeoutMs: 505,
+        cleanupTimeoutMs: 606,
+        fastOperationTimeoutMs: 707,
+      },
+    });
+
+    const session = await client.create(
+      runloopManifest({
+        entries: {
+          'README.md': {
+            type: 'file',
+            content: '# Hello\n',
+          },
+        },
+      }),
+    );
+
+    expect(createMock).toHaveBeenCalledWith(
+      {
+        environment_variables: {},
+      },
+      {
+        timeout: 101,
+        longPoll: { timeoutMs: 101 },
+      },
+    );
+    expect(uploadMock).toHaveBeenCalledWith(
+      {
+        path: '/home/user/README.md',
+        file: expect.any(File),
+      },
+      {
+        timeout: 303,
+      },
+    );
+
+    await session.execCommand({ cmd: 'ls' });
+    expect(execMock).toHaveBeenLastCalledWith(
+      "cd '/home/user' && ls",
+      {
+        last_n: '2000',
+      },
+      {
+        timeout: 202,
+        longPoll: { timeoutMs: 202 },
+      },
+    );
+
+    await session.viewImage({ path: 'pixel.png' });
+    expect(downloadMock).toHaveBeenLastCalledWith(
+      {
+        path: '/home/user/pixel.png',
+      },
+      {
+        timeout: 404,
+      },
+    );
+
+    await session.persistWorkspace();
+    expect(snapshotDiskMock).toHaveBeenCalledWith(
+      {
+        name: 'sandbox-devbox_test',
+        metadata: {
+          openai_agents_devbox_id: 'devbox_test',
+        },
+      },
+      {
+        timeout: 505,
+        longPoll: { timeoutMs: 505 },
+      },
+    );
+
+    await session.close();
+    expect(shutdownMock).toHaveBeenCalledWith({
+      timeout: 606,
+    });
+  });
+
+  test('defaults and validates manifest roots against the effective Runloop home', async () => {
+    const client = new RunloopSandboxClient();
+
+    const defaultSession = await client.create();
+
+    expect(defaultSession.state.manifest.root).toBe(RUNLOOP_HOME);
+    await expect(
+      client.create(
+        new Manifest({
+          root: '/workspace',
+        }),
+      ),
+    ).rejects.toBeInstanceOf(SandboxConfigurationError);
+  });
+
+  test('validates manifest roots when applying manifests to sessions', async () => {
+    const client = new RunloopSandboxClient();
+    const session = await client.create();
+    uploadMock.mockClear();
+
+    await expect(
+      session.applyManifest(
+        new Manifest({
+          root: '/workspace',
+          entries: {
+            'next.txt': {
+              type: 'file',
+              content: 'next\n',
+            },
+          },
+        }),
+      ),
+    ).rejects.toBeInstanceOf(SandboxConfigurationError);
+    expect(uploadMock).not.toHaveBeenCalled();
+
+    await session.applyManifest(
+      runloopManifest({
+        entries: {
+          'next.txt': {
+            type: 'file',
+            content: 'next\n',
+          },
+        },
+      }),
+    );
+
+    expect(uploadMock).toHaveBeenCalledWith({
+      path: '/home/user/next.txt',
+      file: expect.any(File),
+    });
+    expect(session.state.manifest.root).toBe('/home/user');
+    expect(session.state.manifest.entries).toHaveProperty('next.txt');
+  });
+
+  test('fails manifest directory materialization when remote mkdir fails', async () => {
+    const client = new RunloopSandboxClient();
+    const session = await client.create();
+    execMock.mockImplementation(async (command: string) => {
+      if (command.includes("mkdir -p -- '/home/user/logs'")) {
+        return execResult({
+          exitCode: 1,
+          stderr: 'mkdir denied',
+        });
+      }
+      const resolvedPath = resolvedRemotePathFromValidationCommand(command);
+      return execResult({
+        exitCode: 0,
+        stdout: resolvedPath ? `${resolvedPath}\n` : 'README.md\n',
+      });
+    });
+
+    await expect(
+      session.applyManifest(
+        runloopManifest({
+          entries: {
+            logs: {
+              type: 'dir',
+            },
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      details: {
+        provider: 'runloop',
+        operation: 'create directory',
+        devboxId: 'devbox_test',
+        path: '/home/user/logs',
+        exitCode: 1,
+        stderr: 'mkdir denied',
+      },
+    });
+  });
+
+  test('fails editor deletes when remote rm fails', async () => {
+    const client = new RunloopSandboxClient();
+    const session = await client.create();
+    execMock.mockImplementation(async (command: string) => {
+      if (command.includes("rm -f -- '/home/user/old.txt'")) {
+        return execResult({
+          exitCode: 1,
+          stderr: 'delete denied',
+        });
+      }
+      const resolvedPath = resolvedRemotePathFromValidationCommand(command);
+      return execResult({
+        exitCode: 0,
+        stdout: resolvedPath ? `${resolvedPath}\n` : 'README.md\n',
+      });
+    });
+
+    await expect(
+      session.createEditor().deleteFile({
+        type: 'delete_file',
+        path: 'old.txt',
+      }),
+    ).rejects.toMatchObject({
+      details: {
+        provider: 'runloop',
+        operation: 'delete path',
+        devboxId: 'devbox_test',
+        path: '/home/user/old.txt',
+        exitCode: 1,
+        stderr: 'delete denied',
+      },
+    });
+  });
+
+  test('rejects filesystem runAs values', async () => {
+    const client = new RunloopSandboxClient();
+    const session = await client.create();
+
+    expect(() => session.createEditor('root')).toThrow(
+      'RunloopSandboxClient does not support runAs yet.',
+    );
+    await expect(
+      session.pathExists('README.md', 'root'),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+  });
+
+  test('upserts managed secrets and stores only secret references', async () => {
+    const client = new RunloopSandboxClient();
+
+    const session = await client.create(runloopManifest(), {
+      managedSecrets: {
+        API_KEY: 'secret-value',
+      },
+      createTimeoutMs: 12_345,
+    });
+    const serialized = await client.serializeSessionState(session.state);
+
+    expect(secretCreateMock).toHaveBeenCalledWith(
+      {
+        name: 'API_KEY',
+        value: 'secret-value',
+      },
+      {
+        timeout: 12_345,
+      },
+    );
+    expect(secretUpdateMock).not.toHaveBeenCalled();
+    expect(createMock).toHaveBeenCalledWith(
+      {
+        environment_variables: {},
+        secrets: {
+          API_KEY: 'API_KEY',
+        },
+      },
+      {
+        timeout: 12_345,
+        longPoll: { timeoutMs: 12_345 },
+      },
+    );
+    expect(session.state.secretRefs).toEqual({
+      API_KEY: 'API_KEY',
+    });
+    expect(JSON.stringify(serialized)).not.toContain('secret-value');
+    expect(serialized).toMatchObject({
+      secretRefs: {
+        API_KEY: 'API_KEY',
+      },
+    });
+  });
+
+  test('updates existing Runloop managed secrets on conflict', async () => {
+    const client = new RunloopSandboxClient();
+    secretCreateMock.mockRejectedValueOnce(
+      Object.assign(new Error('already exists'), { status: 409 }),
+    );
+
+    await client.create(runloopManifest(), {
+      managedSecrets: {
+        API_KEY: 'secret-value',
+      },
+    });
+
+    expect(secretCreateMock).toHaveBeenCalledWith(
+      {
+        name: 'API_KEY',
+        value: 'secret-value',
+      },
+      undefined,
+    );
+    expect(secretUpdateMock).toHaveBeenCalledWith(
+      'API_KEY',
+      {
+        value: 'secret-value',
+      },
+      undefined,
+    );
+  });
+
+  test('wraps Runloop managed secret failures without leaking values', async () => {
+    const client = new RunloopSandboxClient();
+    secretCreateMock.mockRejectedValueOnce(
+      new Error('service unavailable for secret-value'),
+    );
+
+    let thrown: unknown;
+    try {
+      await client.create(runloopManifest(), {
+        managedSecrets: {
+          API_KEY: 'secret-value',
+        },
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(SandboxProviderError);
+    expect(String(thrown)).not.toContain('secret-value');
+    expect(JSON.stringify(thrown)).not.toContain('secret-value');
+  });
+
+  test('wraps Runloop create SDK failures as provider errors', async () => {
+    const client = new RunloopSandboxClient();
+    createMock.mockRejectedValueOnce(new Error('provider unavailable'));
+
+    await expect(client.create(runloopManifest())).rejects.toBeInstanceOf(
+      SandboxProviderError,
+    );
+  });
+
+  test('exposes Runloop platform facade with camelCase methods', async () => {
+    const client = new RunloopSandboxClient();
+    const platform = await client.platform();
+
+    await platform.blueprints.list({ limit: 1 });
+    await platform.blueprints.listPublic({ limit: 2 });
+    const blueprint = platform.blueprints.get('bp_test');
+    await platform.blueprints.create({ name: 'agent-blueprint' });
+    await platform.blueprints.logs('bp_test', { limit: 3 });
+    await platform.blueprints.awaitBuildComplete('bp_test', { timeout: 4 });
+    await platform.blueprints.delete('bp_test', { force: true });
+    await platform.benchmarks.list({ limit: 5 });
+    await platform.benchmarks.listPublic({ limit: 6 });
+    const benchmark = platform.benchmarks.get('bench_test');
+    await platform.benchmarks.create({ name: 'agent-benchmark' });
+    await platform.benchmarks.update('bench_test', { name: 'updated' });
+    await platform.benchmarks.definitions('bench_test', { scenario: 'all' });
+    await platform.benchmarks.startRun('bench_test', { input: 'run' });
+    await platform.benchmarks.updateScenarios('bench_test', {
+      scenarios: [],
+    });
+    await platform.secrets.create({
+      name: 'API_KEY',
+      value: 'secret-value',
+    });
+    await platform.secrets.list({ limit: 9 });
+    await platform.secrets.get('API_KEY', { include_metadata: true });
+    await platform.secrets.update({
+      name: 'API_KEY',
+      value: 'next-value',
+    });
+    await platform.secrets.delete('API_KEY', { force: true });
+    await platform.networkPolicies.create({ name: 'agent-policy' });
+    await platform.networkPolicies.list({ limit: 7 });
+    const networkPolicy = platform.networkPolicies.get('np_test');
+    await platform.networkPolicies.update('np_test', { name: 'updated' });
+    await platform.networkPolicies.delete('np_test', { force: true });
+    await platform.axons.create({ name: 'agent-axon' });
+    await platform.axons.list({ limit: 8 });
+    const axon = platform.axons.get('axon_test');
+    await platform.axons.publish('axon_test', { revision: 'latest' });
+    await platform.axons.querySql('axon_test', { sql: 'select 1' });
+    await platform.axons.batchSql('axon_test', {
+      statements: ['select 1'],
+    });
+
+    expect(blueprint).toEqual({
+      delete: blueprintDeleteMock,
+    });
+    expect(benchmark).toEqual({
+      update: benchmarkUpdateMock,
+      startRun: benchmarkStartRunMock,
+    });
+    expect(networkPolicy).toEqual({
+      update: networkPolicyUpdateMock,
+      delete: networkPolicyDeleteMock,
+    });
+    expect(axon).toEqual({
+      publish: axonPublishMock,
+      sql: {
+        query: axonQueryMock,
+        batch: axonBatchMock,
+      },
+    });
+    expect(blueprintCreateMock).toHaveBeenCalledWith({
+      name: 'agent-blueprint',
+    });
+    expect(blueprintListMock).toHaveBeenCalledWith({ limit: 1 });
+    expect(blueprintListPublicMock).toHaveBeenCalledWith({ limit: 2 });
+    expect(blueprintLogsMock).toHaveBeenCalledWith('bp_test', { limit: 3 });
+    expect(blueprintAwaitBuildCompleteMock).toHaveBeenCalledWith('bp_test', {
+      timeout: 4,
+    });
+    expect(blueprintFromIdMock).toHaveBeenCalledWith('bp_test');
+    expect(blueprintDeleteMock).toHaveBeenCalledWith({ force: true });
+    expect(benchmarkListMock).toHaveBeenCalledWith({ limit: 5 });
+    expect(benchmarkListPublicMock).toHaveBeenCalledWith({ limit: 6 });
+    expect(benchmarkFromIdMock).toHaveBeenCalledWith('bench_test');
+    expect(benchmarkCreateMock).toHaveBeenCalledWith({
+      name: 'agent-benchmark',
+    });
+    expect(benchmarkUpdateMock).toHaveBeenCalledWith({ name: 'updated' });
+    expect(benchmarkDefinitionsMock).toHaveBeenCalledWith('bench_test', {
+      scenario: 'all',
+    });
+    expect(benchmarkStartRunMock).toHaveBeenCalledWith({ input: 'run' });
+    expect(benchmarkUpdateScenariosMock).toHaveBeenCalledWith('bench_test', {
+      scenarios: [],
+    });
+    expect(secretCreateMock).toHaveBeenCalledWith({
+      name: 'API_KEY',
+      value: 'secret-value',
+    });
+    expect(secretListMock).toHaveBeenCalledWith({ limit: 9 });
+    expect(secretRetrieveMock).toHaveBeenCalledWith('API_KEY', {
+      include_metadata: true,
+    });
+    expect(secretUpdateMock).toHaveBeenCalledWith('API_KEY', {
+      value: 'next-value',
+    });
+    expect(secretDeleteMock).toHaveBeenCalledWith('API_KEY', { force: true });
+    expect(networkPolicyCreateMock).toHaveBeenCalledWith({
+      name: 'agent-policy',
+    });
+    expect(networkPolicyListMock).toHaveBeenCalledWith({ limit: 7 });
+    expect(networkPolicyFromIdMock).toHaveBeenCalledWith('np_test');
+    expect(networkPolicyUpdateMock).toHaveBeenCalledWith({ name: 'updated' });
+    expect(networkPolicyDeleteMock).toHaveBeenCalledWith({ force: true });
+    expect(axonCreateMock).toHaveBeenCalledWith({ name: 'agent-axon' });
+    expect(axonListMock).toHaveBeenCalledWith({ limit: 8 });
+    expect(axonFromIdMock).toHaveBeenCalledWith('axon_test');
+    expect(axonPublishMock).toHaveBeenCalledWith({ revision: 'latest' });
+    expect(axonQueryMock).toHaveBeenCalledWith({ sql: 'select 1' });
+    expect(axonBatchMock).toHaveBeenCalledWith({
+      statements: ['select 1'],
+    });
+  });
+
+  test('binds fromId platform instance methods before invoking them', async () => {
+    const client = new RunloopSandboxClient();
+    const platform = await client.platform();
+
+    blueprintFromIdMock.mockReturnValue({
+      client: 'blueprint-client',
+      delete: function (this: { client: string }, params: unknown) {
+        if (this.client !== 'blueprint-client') {
+          throw new Error('unbound blueprint method');
+        }
+        return blueprintDeleteMock(params);
+      },
+    });
+    benchmarkFromIdMock.mockReturnValue({
+      client: 'benchmark-client',
+      update: function (this: { client: string }, params: unknown) {
+        if (this.client !== 'benchmark-client') {
+          throw new Error('unbound benchmark update method');
+        }
+        return benchmarkUpdateMock(params);
+      },
+      startRun: function (this: { client: string }, params: unknown) {
+        if (this.client !== 'benchmark-client') {
+          throw new Error('unbound benchmark startRun method');
+        }
+        return benchmarkStartRunMock(params);
+      },
+    });
+    networkPolicyFromIdMock.mockReturnValue({
+      client: 'network-policy-client',
+      update: function (this: { client: string }, params: unknown) {
+        if (this.client !== 'network-policy-client') {
+          throw new Error('unbound network policy update method');
+        }
+        return networkPolicyUpdateMock(params);
+      },
+      delete: function (this: { client: string }, params: unknown) {
+        if (this.client !== 'network-policy-client') {
+          throw new Error('unbound network policy delete method');
+        }
+        return networkPolicyDeleteMock(params);
+      },
+    });
+    axonFromIdMock.mockReturnValue({
+      client: 'axon-client',
+      publish: function (this: { client: string }, params: unknown) {
+        if (this.client !== 'axon-client') {
+          throw new Error('unbound axon publish method');
+        }
+        return axonPublishMock(params);
+      },
+      sql: {
+        client: 'axon-sql-client',
+        query: function (this: { client: string }, params: unknown) {
+          if (this.client !== 'axon-sql-client') {
+            throw new Error('unbound axon sql query method');
+          }
+          return axonQueryMock(params);
+        },
+        batch: function (this: { client: string }, params: unknown) {
+          if (this.client !== 'axon-sql-client') {
+            throw new Error('unbound axon sql batch method');
+          }
+          return axonBatchMock(params);
+        },
+      },
+    });
+
+    await platform.blueprints.delete('bp_test', { force: true });
+    await platform.benchmarks.update('bench_test', { name: 'updated' });
+    await platform.benchmarks.startRun('bench_test', { input: 'run' });
+    await platform.networkPolicies.update('np_test', { name: 'updated' });
+    await platform.networkPolicies.delete('np_test', { force: true });
+    await platform.axons.publish('axon_test', { revision: 'latest' });
+    await platform.axons.querySql('axon_test', { sql: 'select 1' });
+    await platform.axons.batchSql('axon_test', {
+      statements: ['select 1'],
+    });
+
+    expect(blueprintDeleteMock).toHaveBeenCalledWith({ force: true });
+    expect(benchmarkUpdateMock).toHaveBeenCalledWith({ name: 'updated' });
+    expect(benchmarkStartRunMock).toHaveBeenCalledWith({ input: 'run' });
+    expect(networkPolicyUpdateMock).toHaveBeenCalledWith({ name: 'updated' });
+    expect(networkPolicyDeleteMock).toHaveBeenCalledWith({ force: true });
+    expect(axonPublishMock).toHaveBeenCalledWith({ revision: 'latest' });
+    expect(axonQueryMock).toHaveBeenCalledWith({ sql: 'select 1' });
+    expect(axonBatchMock).toHaveBeenCalledWith({
+      statements: ['select 1'],
+    });
+  });
+
+  test('rejects unsafe environment names before building shell commands', async () => {
+    const client = new RunloopSandboxClient();
+    const session = await client.create(
+      runloopManifest({
+        environment: {
+          'X; touch /tmp/pwned; #': 'bad',
+        },
+      }),
+    );
+
+    await expect(session.execCommand({ cmd: 'ls' })).rejects.toThrow(
+      'Invalid environment variable name',
+    );
+  });
+
+  test('rejects unsupported PTY execution with a typed error', async () => {
+    const client = new RunloopSandboxClient();
+    const session = await client.create(runloopManifest());
+
+    await expect(
+      session.execCommand({ cmd: 'sh', tty: true }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+  });
+
+  test('suspends on close when pauseOnExit is enabled and resumes by id', async () => {
+    const client = new RunloopSandboxClient();
+    const session = await client.create(runloopManifest(), {
+      pauseOnExit: true,
+    });
+
+    await session.close();
+    await client.resume(session.state);
+
+    expect(suspendMock).toHaveBeenCalledOnce();
+    expect(fromIdMock).toHaveBeenCalledWith('devbox_test');
+    expect(resumeMock).toHaveBeenCalledOnce();
+    expect(shutdownMock).not.toHaveBeenCalled();
+  });
+
+  test('refreshes ports and rematerializes cloud mounts when resuming', async () => {
+    getTunnelUrlMock.mockResolvedValueOnce(
+      'https://3000-devbox.tunnel.runloop.ai',
+    );
+    const client = new RunloopSandboxClient();
+    const session = await client.create(runloopCloudBucketManifest(), {
+      pauseOnExit: true,
+      exposedPorts: [3000],
+    });
+    await session.resolveExposedPort(3000);
+    await session.close();
+    execMock.mockClear();
+    enableTunnelMock.mockClear();
+    getTunnelUrlMock.mockReset();
+    getTunnelUrlMock
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('https://3000-resumed.tunnel.runloop.ai');
+
+    const resumed = await client.resume(session.state);
+    const endpoint = await resumed.resolveExposedPort(3000);
+
+    expect(resumeMock).toHaveBeenCalledOnce();
+    expect(
+      execMock.mock.calls.some(([command]) =>
+        String(command).includes("'rclone' 'mount'"),
+      ),
+    ).toBe(true);
+    expect(enableTunnelMock).toHaveBeenCalledWith({
+      auth_mode: 'open',
+      http_keep_alive: true,
+      wake_on_http: false,
+    });
+    expect(getTunnelUrlMock).toHaveBeenCalledTimes(2);
+    expect(endpoint.host).toBe('3000-resumed.tunnel.runloop.ai');
+    expect(resumed.state.exposedPorts?.['3000']).toBe(endpoint);
+  });
+
+  test('suspends a resumed devbox when mount rematerialization fails', async () => {
+    const client = new RunloopSandboxClient();
+    const session = await client.create(runloopCloudBucketManifest(), {
+      pauseOnExit: true,
+    });
+    await session.close();
+    createMock.mockClear();
+    suspendMock.mockClear();
+    execMock.mockRejectedValueOnce(new Error('mount failed'));
+
+    await expect(client.resume(session.state)).rejects.toBeInstanceOf(
+      SandboxProviderError,
+    );
+
+    expect(resumeMock).toHaveBeenCalledOnce();
+    expect(suspendMock).toHaveBeenCalledOnce();
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('keeps nested mount entries nested when rematerializing on resume', async () => {
+    const client = new RunloopSandboxClient();
+    const manifest = runloopManifest({
+      entries: {
+        dir: {
+          type: 'dir',
+          children: {
+            data: {
+              type: 's3_mount',
+              bucket: 'agent-logs',
+              accessKeyId: 'access-key',
+              secretAccessKey: 'secret-key',
+              mountStrategy: new RunloopCloudBucketMountStrategy(),
+            },
+          },
+        },
+      },
+    });
+    const session = await client.create(manifest, { pauseOnExit: true });
+    await session.close();
+    execMock.mockClear();
+
+    const resumed = await client.resume(session.state);
+    const dirEntry = resumed.state.manifest.entries.dir;
+
+    expect(resumed.state.manifest.entries).not.toHaveProperty('dir/data');
+    expect(dirEntry).toMatchObject({ type: 'dir' });
+    expect(
+      (dirEntry as { children?: Record<string, unknown> }).children,
+    ).toHaveProperty('data');
+  });
+
+  test('delete terminates even when pauseOnExit is enabled', async () => {
+    const client = new RunloopSandboxClient();
+    const session = await client.create(runloopManifest(), {
+      pauseOnExit: true,
+    });
+
+    await session.delete();
+
+    expect(suspendMock).not.toHaveBeenCalled();
+    expect(shutdownMock).toHaveBeenCalledOnce();
+  });
+
+  test('recreates paused devboxes when resume reports missing devbox', async () => {
+    const client = new RunloopSandboxClient();
+    const session = await client.create(runloopManifest(), {
+      pauseOnExit: true,
+    });
+    createMock.mockClear();
+    resumeMock.mockRejectedValueOnce(new Error('devbox not found'));
+
+    const recreated = await client.resume(session.state);
+
+    expect(fromIdMock).toHaveBeenCalledWith('devbox_test');
+    expect(resumeMock).toHaveBeenCalledOnce();
+    expect(createMock).toHaveBeenCalledOnce();
+    expect(recreated.state.devboxId).toBe('devbox_test');
+  });
+
+  test('fails fast when resume lookup fails with a provider error', async () => {
+    const client = new RunloopSandboxClient();
+    const session = await client.create(runloopManifest(), {
+      pauseOnExit: true,
+    });
+    createMock.mockClear();
+    fromIdMock.mockImplementationOnce(() => {
+      throw new Error('request timeout');
+    });
+
+    let thrown: unknown;
+    try {
+      await client.resume(session.state);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(SandboxProviderError);
+    expect((thrown as SandboxProviderError).details).toMatchObject({
+      provider: 'runloop',
+      operation: 'resume',
+      devboxId: 'devbox_test',
+      cause: 'request timeout',
+    });
+    expect(resumeMock).not.toHaveBeenCalled();
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('fails fast when resume fails with a provider error', async () => {
+    const client = new RunloopSandboxClient();
+    const session = await client.create(runloopManifest(), {
+      pauseOnExit: true,
+    });
+    createMock.mockClear();
+    resumeMock.mockRejectedValueOnce(new Error('request timeout'));
+
+    let thrown: unknown;
+    try {
+      await client.resume(session.state);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(SandboxProviderError);
+    expect((thrown as SandboxProviderError).details).toMatchObject({
+      provider: 'runloop',
+      operation: 'resume',
+      devboxId: 'devbox_test',
+      cause: 'request timeout',
+    });
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('persists native disk snapshots and restores from snapshot refs', async () => {
+    getTunnelUrlMock
+      .mockResolvedValueOnce('https://3000-devbox.tunnel.runloop.ai')
+      .mockResolvedValueOnce('https://3000-restored.tunnel.runloop.ai');
+    const client = new RunloopSandboxClient();
+    const session = await client.create(
+      runloopCloudBucketManifest({ ephemeral: false }),
+      {
+        name: 'agent-devbox',
+        exposedPorts: [3000],
+      },
+    );
+
+    const originalEndpoint = await session.resolveExposedPort(3000);
+    const snapshotBytes = await session.persistWorkspace();
+    const ref = decodeNativeSnapshotRef(snapshotBytes);
+
+    expect(snapshotDiskMock).toHaveBeenCalledWith({
+      name: 'sandbox-devbox_test',
+      metadata: {
+        openai_agents_devbox_id: 'devbox_test',
+      },
+    });
+    expect(ref).toEqual({
+      provider: 'runloop',
+      snapshotId: 'snap_runloop',
+      workspacePersistence: undefined,
+    });
+
+    execMock.mockClear();
+    await session.hydrateWorkspace(snapshotBytes);
+    const restoredEndpoint = await session.resolveExposedPort(3000);
+
+    expect(createFromSnapshotMock).toHaveBeenCalledWith(
+      'snap_runloop',
+      {
+        environment_variables: {},
+        name: 'agent-devbox',
+        exposed_ports: [3000],
+      },
+      undefined,
+    );
+    expect(shutdownMock).toHaveBeenCalledOnce();
+    expect(session.state.devboxId).toBe('devbox_restored');
+    expect(originalEndpoint.host).toBe('3000-devbox.tunnel.runloop.ai');
+    expect(restoredEndpoint.host).toBe('3000-restored.tunnel.runloop.ai');
+    expect(session.state.exposedPorts?.['3000']).toBe(restoredEndpoint);
+    expect(getTunnelUrlMock).toHaveBeenCalledTimes(2);
+    expect(
+      execMock.mock.calls.some(([command]) =>
+        String(command).includes("'rclone' 'mount'"),
+      ),
+    ).toBe(true);
+  });
+
+  test('shuts down replacement devboxes when snapshot mount restore fails', async () => {
+    const replacementShutdownMock = vi.fn().mockResolvedValue(undefined);
+    createFromSnapshotMock.mockResolvedValueOnce(
+      mockRunloopDevbox({
+        id: 'devbox_restored',
+        shutdown: replacementShutdownMock,
+      }),
+    );
+    const client = new RunloopSandboxClient();
+    const session = await client.create(
+      runloopCloudBucketManifest({ ephemeral: false }),
+    );
+    const snapshotBytes = await session.persistWorkspace();
+    execMock.mockRejectedValueOnce(new Error('mount failed'));
+
+    await expect(session.hydrateWorkspace(snapshotBytes)).rejects.toMatchObject(
+      {
+        details: {
+          provider: 'runloop',
+          devboxId: 'devbox_test',
+          replacementDevboxId: 'devbox_restored',
+          snapshotId: 'snap_runloop',
+          cause: 'mount failed',
+        },
+      },
+    );
+
+    expect(shutdownMock).not.toHaveBeenCalled();
+    expect(replacementShutdownMock).toHaveBeenCalledOnce();
+    expect(session.state.devboxId).toBe('devbox_test');
+  });
+
+  test('falls back to tar persistence when Runloop snapshot API is unavailable', async () => {
+    createMock.mockResolvedValueOnce(
+      mockRunloopDevbox({
+        snapshotDisk: undefined,
+      }),
+    );
+    const client = new RunloopSandboxClient();
+    const session = await client.create(runloopManifest());
+    const archive = makeTarArchive([{ name: 'keep.txt', content: 'keep' }]);
+    downloadMock.mockResolvedValueOnce({
+      buffer: async () => Buffer.from(archive),
+    });
+
+    const snapshotBytes = await session.persistWorkspace();
+
+    expect(snapshotDiskMock).not.toHaveBeenCalled();
+    expect(decodeNativeSnapshotRef(snapshotBytes)).toBeUndefined();
+    expect(downloadMock).toHaveBeenCalled();
+  });
+
+  test('falls back to tar persistence when the workspace root is ephemeral', async () => {
+    const client = new RunloopSandboxClient();
+    const session = await client.create(
+      runloopManifest({
+        entries: {
+          '': {
+            type: 'dir',
+            ephemeral: true,
+          },
+        },
+      }),
+    );
+    const archive = makeTarArchive([{ name: 'keep.txt', content: 'keep' }]);
+    downloadMock.mockResolvedValueOnce({
+      buffer: async () => Buffer.from(archive),
+    });
+
+    const snapshotBytes = await session.persistWorkspace();
+
+    expect(snapshotDiskMock).not.toHaveBeenCalled();
+    expect(decodeNativeSnapshotRef(snapshotBytes)).toBeUndefined();
+    expect(downloadMock).toHaveBeenCalled();
+  });
+
+  test('reports provider errors when native snapshot restore is unsupported', async () => {
+    includeCreateFromSnapshotApi = false;
+    const client = new RunloopSandboxClient();
+    const session = await client.create(runloopManifest());
+    const snapshotBytes = await session.persistWorkspace();
+
+    await expect(session.hydrateWorkspace(snapshotBytes)).rejects.toMatchObject(
+      {
+        details: {
+          provider: 'runloop',
+          snapshotId: 'snap_runloop',
+        },
+      },
+    );
+
+    expect(createFromSnapshotMock).not.toHaveBeenCalled();
+    expect(shutdownMock).not.toHaveBeenCalled();
+    expect(session.state.devboxId).toBe('devbox_test');
+  });
+
+  test('surfaces shutdown failures when replacing native snapshot devboxes', async () => {
+    const client = new RunloopSandboxClient();
+    const session = await client.create(runloopManifest(), {
+      name: 'agent-devbox',
+    });
+    const snapshotBytes = await session.persistWorkspace();
+    shutdownMock
+      .mockRejectedValueOnce(new Error('shutdown failed'))
+      .mockResolvedValueOnce(undefined);
+
+    let thrown: unknown;
+    try {
+      await session.hydrateWorkspace(snapshotBytes);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(SandboxProviderError);
+    expect((thrown as SandboxProviderError).details).toMatchObject({
+      provider: 'runloop',
+      devboxId: 'devbox_test',
+      replacementDevboxId: 'devbox_restored',
+      cause: 'shutdown failed',
+    });
+    expect(shutdownMock).toHaveBeenCalledTimes(2);
+    expect(session.state.devboxId).toBe('devbox_test');
+  });
+
+  test('fails tar hydration when Runloop archive command exit code is unknown', async () => {
+    const client = new RunloopSandboxClient();
+    const session = await client.create(runloopManifest());
+    const archive = makeTarArchive([{ name: 'keep.txt', content: 'keep' }]);
+    execMock.mockImplementation(async (command: string) => {
+      const resolvedPath = resolvedRemotePathFromValidationCommand(command);
+      if (resolvedPath) {
+        return execResult({
+          exitCode: 0,
+          stdout: `${resolvedPath}\n`,
+        });
+      }
+      if (command.includes(' -xf ')) {
+        return execResult({
+          exitCode: null,
+          stderr: 'hydrate interrupted',
+        });
+      }
+      return execResult({ exitCode: 0 });
+    });
+
+    await expect(session.hydrateWorkspace(archive)).rejects.toBeInstanceOf(
+      SandboxArchiveError,
+    );
+  });
+
+  test('resolves configured exposed ports through Runloop tunnels', async () => {
+    getTunnelUrlMock
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('https://3000-devbox.tunnel.runloop.ai');
+    const client = new RunloopSandboxClient();
+    const session = await client.create(runloopManifest(), {
+      exposedPorts: [3000],
+    });
+
+    const endpoint = await session.resolveExposedPort(3000);
+    const cachedEndpoint = await session.resolveExposedPort(3000);
+
+    expect(enableTunnelMock).toHaveBeenCalledWith({
+      auth_mode: 'open',
+      http_keep_alive: true,
+      wake_on_http: false,
+    });
+    expect(getTunnelUrlMock).toHaveBeenCalledWith(3000);
+    expect(getTunnelUrlMock).toHaveBeenCalledTimes(2);
+    expect(endpoint).toMatchObject({
+      host: '3000-devbox.tunnel.runloop.ai',
+      port: 443,
+      tls: true,
+    });
+    expect(cachedEndpoint).toBe(endpoint);
+    expect(session.state.exposedPorts?.['3000']).toBe(endpoint);
+  });
+
+  test('reuses configured tunnel policy when enabling missing tunnels', async () => {
+    getTunnelUrlMock
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('https://3000-private.tunnel.runloop.ai');
+    const client = new RunloopSandboxClient();
+    const session = await client.create(runloopManifest(), {
+      exposedPorts: [3000],
+      tunnel: {
+        auth_mode: 'authenticated',
+        http_keep_alive: false,
+        wake_on_http: true,
+      },
+    });
+
+    await session.resolveExposedPort(3000);
+
+    expect(enableTunnelMock).toHaveBeenCalledWith({
+      auth_mode: 'authenticated',
+      http_keep_alive: false,
+      wake_on_http: true,
+    });
+  });
+
+  test('rejects exposed ports when Runloop getTunnelUrl API is unavailable', async () => {
+    createMock.mockResolvedValueOnce(
+      mockRunloopDevbox({
+        getTunnelUrl: undefined,
+      }),
+    );
+    const client = new RunloopSandboxClient();
+    const session = await client.create(runloopManifest(), {
+      exposedPorts: [3000],
+    });
+
+    await expect(session.resolveExposedPort(3000)).rejects.toThrow(
+      /requires getTunnelUrl/,
+    );
+    expect(enableTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test('rejects exposed ports when Runloop tunnel enable API is unavailable', async () => {
+    createMock.mockResolvedValueOnce(
+      mockRunloopDevbox({
+        net: undefined,
+      }),
+    );
+    getTunnelUrlMock.mockResolvedValueOnce('');
+    const client = new RunloopSandboxClient();
+    const session = await client.create(runloopManifest(), {
+      exposedPorts: [3000],
+    });
+
+    await expect(session.resolveExposedPort(3000)).rejects.toThrow(
+      /requires a Runloop tunnel API/,
+    );
+    expect(enableTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test('fails mount commands when Runloop exit code is unknown', async () => {
+    const client = new RunloopSandboxClient();
+    execMock.mockImplementation(async (command: string) => {
+      const resolvedPath = resolvedRemotePathFromValidationCommand(command);
+      if (resolvedPath) {
+        return execResult({
+          exitCode: 0,
+          stdout: `${resolvedPath}\n`,
+        });
+      }
+      if (command.includes('test -c /dev/fuse')) {
+        return execResult({
+          exitCode: null,
+          stderr: 'mount probe interrupted',
+        });
+      }
+      return execResult({ exitCode: 0 });
+    });
+
+    await expect(
+      client.create(runloopCloudBucketManifest()),
+    ).rejects.toBeInstanceOf(SandboxMountError);
+  });
+
+  test('mounts cloud buckets with the Runloop rclone mount strategy', async () => {
+    const client = new RunloopSandboxClient();
+
+    const session = await client.create(runloopCloudBucketManifest());
+    await session.close();
+
+    expect(
+      execMock.mock.calls.some(([command]) =>
+        String(command).includes("'rclone' 'mount'"),
+      ),
+    ).toBe(true);
+    expect(
+      execMock.mock.calls.some(([command]) =>
+        String(command).includes('/home/user/mounted/logs'),
+      ),
+    ).toBe(true);
+    expect(
+      execMock.mock.calls.some(([command]) => {
+        const shellCommand = String(command);
+        return (
+          shellCommand.startsWith("sudo -n -u 'root' -- sh -lc ") &&
+          shellCommand.includes('chmod a+rw /dev/fuse')
+        );
+      }),
+    ).toBe(true);
+    expect(
+      execMock.mock.calls.some(([command]) =>
+        String(command).includes('fusermount3 -u'),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/agents-extensions/test/sandbox/runloop.test.ts
+++ b/packages/agents-extensions/test/sandbox/runloop.test.ts
@@ -106,6 +106,18 @@ function execResult(args: {
   };
 }
 
+function runloopRealpathResult(command: string) {
+  if (!command.includes('OPENAI_AGENTS_REALPATH_HOME=')) {
+    return undefined;
+  }
+  const home = command.match(/^cd '([^']+)' && /u)?.[1] ?? RUNLOOP_HOME;
+  const root = command.match(/mkdir -p -- '([^']+)'/u)?.[1] ?? home;
+  return execResult({
+    exitCode: 0,
+    stdout: `OPENAI_AGENTS_REALPATH_HOME=${home}\nOPENAI_AGENTS_REALPATH_ANCESTOR=${home}\nOPENAI_AGENTS_REALPATH_ROOT=${root}\n`,
+  });
+}
+
 function mockRunloopDevbox(overrides: Record<string, unknown> = {}) {
   return {
     id: 'devbox_test',
@@ -309,6 +321,10 @@ describe('RunloopSandboxClient', () => {
     axonQueryMock.mockResolvedValue({ rows: [] });
     axonBatchMock.mockResolvedValue({ results: [] });
     execMock.mockImplementation(async (command: string) => {
+      const realpathResult = runloopRealpathResult(command);
+      if (realpathResult) {
+        return realpathResult;
+      }
       const resolvedPath = resolvedRemotePathFromValidationCommand(command);
       return {
         exitCode: 0,
@@ -418,15 +434,20 @@ describe('RunloopSandboxClient', () => {
   test('creates subdirectory manifest roots before path validation', async () => {
     let rootCreated = false;
     execMock.mockImplementation(async (command: string) => {
-      if (command === "cd '/home/user' && mkdir -p -- '/home/user/project'") {
+      if (command.includes("mkdir -p -- '/home/user/project'")) {
         rootCreated = true;
-        return execResult({ exitCode: 0 });
+        const realpathResult = runloopRealpathResult(command);
+        return realpathResult ?? execResult({ exitCode: 0 });
       }
       if (command.startsWith("cd '/home/user/project' &&") && !rootCreated) {
         return execResult({
           exitCode: 1,
           stderr: 'cd: /home/user/project: No such file or directory',
         });
+      }
+      const realpathResult = runloopRealpathResult(command);
+      if (realpathResult) {
+        return realpathResult;
       }
       const resolvedPath = resolvedRemotePathFromValidationCommand(command);
       return execResult({
@@ -631,6 +652,80 @@ describe('RunloopSandboxClient', () => {
     ).rejects.toBeInstanceOf(SandboxConfigurationError);
   });
 
+  test('rejects manifest roots that resolve outside the effective Runloop home', async () => {
+    execMock.mockImplementation(async (command: string) => {
+      if (command.includes('OPENAI_AGENTS_REALPATH_HOME=')) {
+        return execResult({
+          exitCode: 0,
+          stdout: `OPENAI_AGENTS_REALPATH_HOME=${RUNLOOP_HOME}\nOPENAI_AGENTS_REALPATH_ANCESTOR=${RUNLOOP_HOME}\nOPENAI_AGENTS_REALPATH_ROOT=/\n`,
+        });
+      }
+      return execResult({ exitCode: 0, stdout: '' });
+    });
+    const client = new RunloopSandboxClient();
+
+    await expect(
+      client.create(
+        new Manifest({
+          root: '/home/user/link',
+        }),
+      ),
+    ).rejects.toBeInstanceOf(SandboxConfigurationError);
+
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  test('checks manifest root ancestor confinement before creating directories', async () => {
+    let prepareRootCommand = '';
+    execMock.mockImplementation(async (command: string) => {
+      if (command.includes('OPENAI_AGENTS_REALPATH_HOME=')) {
+        prepareRootCommand = command;
+        return execResult({
+          exitCode: 0,
+          stdout: `OPENAI_AGENTS_REALPATH_HOME=${RUNLOOP_HOME}\nOPENAI_AGENTS_REALPATH_ANCESTOR=/\nOPENAI_AGENTS_REALPATH_ROOT=\n`,
+        });
+      }
+      return execResult({ exitCode: 0, stdout: '' });
+    });
+    const client = new RunloopSandboxClient();
+
+    await expect(
+      client.create(
+        new Manifest({
+          root: '/home/user/link/project',
+        }),
+      ),
+    ).rejects.toBeInstanceOf(SandboxConfigurationError);
+
+    expect(prepareRootCommand.indexOf('ancestor_real=')).toBeLessThan(
+      prepareRootCommand.indexOf("mkdir -p -- '/home/user/link/project'"),
+    );
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  test('rejects effective Runloop homes that resolve to filesystem root', async () => {
+    execMock.mockImplementation(async (command: string) => {
+      if (command.includes('OPENAI_AGENTS_REALPATH_HOME=')) {
+        return execResult({
+          exitCode: 0,
+          stdout: `OPENAI_AGENTS_REALPATH_HOME=/\nOPENAI_AGENTS_REALPATH_ANCESTOR=/\nOPENAI_AGENTS_REALPATH_ROOT=/home/user/project\n`,
+        });
+      }
+      return execResult({ exitCode: 0, stdout: '' });
+    });
+    const client = new RunloopSandboxClient();
+
+    await expect(
+      client.create(
+        new Manifest({
+          root: '/home/user/project',
+        }),
+      ),
+    ).rejects.toBeInstanceOf(SandboxConfigurationError);
+
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
   test('rejects unsafe usernames before deriving the effective home', async () => {
     for (const username of [
       '',
@@ -697,6 +792,10 @@ describe('RunloopSandboxClient', () => {
     const client = new RunloopSandboxClient();
     const session = await client.create();
     execMock.mockImplementation(async (command: string) => {
+      const realpathResult = runloopRealpathResult(command);
+      if (realpathResult) {
+        return realpathResult;
+      }
       if (command.includes("mkdir -p -- '/home/user/logs'")) {
         return execResult({
           exitCode: 1,
@@ -1203,6 +1302,40 @@ describe('RunloopSandboxClient', () => {
     expect(resumed.state.baseUrl).toBeUndefined();
   });
 
+  test('uses trusted user parameters when resuming sessions', async () => {
+    const userParameters: RunloopUserParameters = {
+      username: 'root',
+      uid: 0,
+    };
+    const client = new RunloopSandboxClient({
+      userParameters,
+    });
+    const state = await client.deserializeSessionState({
+      manifest: new Manifest({
+        root: '/root',
+      }),
+      devboxId: 'devbox_test',
+      pauseOnExit: true,
+      environment: {
+        PATH: '/tmp/attacker-bin',
+      },
+      userParameters: {
+        username: 'agent',
+        uid: 1001,
+      },
+    });
+
+    const resumed = await client.resume(state);
+
+    expect(resumed.state.userParameters).toEqual(userParameters);
+    const commands = execMock.mock.calls.map(([command]) => String(command));
+    expect(commands.length).toBeGreaterThan(0);
+    for (const command of commands) {
+      expect(command).not.toContain('export PATH=');
+      expect(command).not.toContain('/tmp/attacker-bin');
+    }
+  });
+
   test('rejects persisted resume manifests outside the effective Runloop home', async () => {
     const client = new RunloopSandboxClient();
     const session = await client.create(runloopManifest(), {
@@ -1336,6 +1469,130 @@ describe('RunloopSandboxClient', () => {
     expect(recreated.state.devboxId).toBe('devbox_test');
   });
 
+  test('uses trusted launch parameters when recreating missing devboxes', async () => {
+    const client = new RunloopSandboxClient({
+      launchParameters: {
+        trusted: true,
+      },
+    });
+    const state = await client.deserializeSessionState({
+      manifest: runloopManifest(),
+      devboxId: 'devbox_test',
+      pauseOnExit: true,
+      environment: {},
+      launchParameters: {
+        attacker: true,
+      },
+    });
+    resumeMock.mockRejectedValueOnce(new Error('devbox not found'));
+
+    await client.resume(state);
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        launch_parameters: expect.objectContaining({
+          trusted: true,
+        }),
+      }),
+      undefined,
+    );
+    expect(JSON.stringify(createMock.mock.calls.at(-1)?.[0])).not.toContain(
+      'attacker',
+    );
+  });
+
+  test('uses trusted user parameters when recreating missing devboxes', async () => {
+    const userParameters: RunloopUserParameters = {
+      username: 'agent',
+      uid: 1001,
+    };
+    const client = new RunloopSandboxClient({
+      userParameters,
+    });
+    const state = await client.deserializeSessionState({
+      manifest: new Manifest({
+        root: '/home/agent',
+      }),
+      devboxId: 'devbox_test',
+      pauseOnExit: true,
+      environment: {},
+      userParameters: {
+        username: 'root',
+        uid: 0,
+      },
+    });
+    resumeMock.mockRejectedValueOnce(new Error('devbox not found'));
+
+    await client.resume(state);
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        launch_parameters: expect.objectContaining({
+          user_parameters: userParameters,
+        }),
+      }),
+      undefined,
+    );
+    expect(JSON.stringify(createMock.mock.calls.at(-1)?.[0])).not.toContain(
+      'root',
+    );
+  });
+
+  test('uses trusted blueprint settings when recreating missing devboxes', async () => {
+    const client = new RunloopSandboxClient({
+      blueprintName: 'trusted-blueprint',
+    });
+    const state = await client.deserializeSessionState({
+      manifest: runloopManifest(),
+      devboxId: 'devbox_test',
+      pauseOnExit: true,
+      environment: {},
+      blueprintName: 'attacker-blueprint',
+      blueprintId: 'bp_attacker',
+    });
+    resumeMock.mockRejectedValueOnce(new Error('devbox not found'));
+
+    await client.resume(state);
+
+    expect(createFromBlueprintNameMock).toHaveBeenCalledWith(
+      'trusted-blueprint',
+      expect.objectContaining({
+        environment_variables: {},
+      }),
+      undefined,
+    );
+    expect(createMock).not.toHaveBeenCalled();
+    expect(
+      JSON.stringify(createFromBlueprintNameMock.mock.calls.at(-1)),
+    ).not.toContain('attacker');
+  });
+
+  test('uses trusted blueprint ids when recreating missing devboxes', async () => {
+    const client = new RunloopSandboxClient({
+      blueprintId: 'bp_trusted',
+    });
+    const state = await client.deserializeSessionState({
+      manifest: runloopManifest(),
+      devboxId: 'devbox_test',
+      pauseOnExit: true,
+      environment: {},
+      blueprintId: 'bp_attacker',
+    });
+    resumeMock.mockRejectedValueOnce(new Error('devbox not found'));
+
+    await client.resume(state);
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        blueprint_id: 'bp_trusted',
+      }),
+      undefined,
+    );
+    expect(JSON.stringify(createMock.mock.calls.at(-1))).not.toContain(
+      'bp_attacker',
+    );
+  });
+
   test('rejects persisted secret refs when recreating missing devboxes', async () => {
     const client = new RunloopSandboxClient();
     const state = await client.deserializeSessionState({
@@ -1462,6 +1719,32 @@ describe('RunloopSandboxClient', () => {
         String(command).includes("'rclone' 'mount'"),
       ),
     ).toBe(true);
+  });
+
+  test('drops persisted secret refs when restoring native snapshots', async () => {
+    const client = new RunloopSandboxClient();
+    const session = await client.create(runloopManifest(), {
+      managedSecrets: {
+        API_KEY: 'secret-value',
+      },
+    });
+    const snapshotBytes = await session.persistWorkspace();
+    session.state.secretRefs = {
+      API_KEY: 'attacker-secret',
+    };
+
+    await session.hydrateWorkspace(snapshotBytes);
+
+    expect(createFromSnapshotMock).toHaveBeenCalledWith(
+      'snap_runloop',
+      {
+        environment_variables: {},
+      },
+      undefined,
+    );
+    expect(
+      JSON.stringify(createFromSnapshotMock.mock.calls.at(-1)?.[1]),
+    ).not.toContain('attacker-secret');
   });
 
   test('shuts down replacement devboxes when snapshot mount restore fails', async () => {
@@ -1703,6 +1986,10 @@ describe('RunloopSandboxClient', () => {
   test('fails mount commands when Runloop exit code is unknown', async () => {
     const client = new RunloopSandboxClient();
     execMock.mockImplementation(async (command: string) => {
+      const realpathResult = runloopRealpathResult(command);
+      if (realpathResult) {
+        return realpathResult;
+      }
       const resolvedPath = resolvedRemotePathFromValidationCommand(command);
       if (resolvedPath) {
         return execResult({
@@ -1787,6 +2074,49 @@ describe('RunloopSandboxClient', () => {
 
     expect(rootMountCommands.length).toBeGreaterThan(0);
     for (const command of rootMountCommands) {
+      expect(command).not.toContain('export PATH=');
+      expect(command).not.toContain('/tmp/attacker-bin');
+    }
+  });
+
+  test('does not export manifest environment into default root session mount commands', async () => {
+    const client = new RunloopSandboxClient({
+      userParameters: {
+        username: 'root',
+        uid: 0,
+      },
+    });
+
+    await client.create(
+      runloopManifest({
+        root: '/root',
+        environment: {
+          PATH: '/tmp/attacker-bin',
+        },
+        entries: {
+          data: {
+            type: 's3_mount',
+            bucket: 'agent-logs',
+            accessKeyId: 'access-key',
+            secretAccessKey: 'secret-key',
+            mountPath: 'mounted/logs',
+            mountStrategy: new RunloopCloudBucketMountStrategy(),
+          },
+        },
+      }),
+    );
+
+    const defaultRootMountCommands = execMock.mock.calls
+      .map(([command]) => String(command))
+      .filter(
+        (command) =>
+          !command.startsWith("sudo -n -u 'root' -- sh -lc ") &&
+          (command.includes('chmod a+rw /dev/fuse') ||
+            command.includes("'rclone' 'mount'")),
+      );
+
+    expect(defaultRootMountCommands.length).toBeGreaterThan(0);
+    for (const command of defaultRootMountCommands) {
       expect(command).not.toContain('export PATH=');
       expect(command).not.toContain('/tmp/attacker-bin');
     }

--- a/packages/agents-extensions/test/sandbox/runloop.test.ts
+++ b/packages/agents-extensions/test/sandbox/runloop.test.ts
@@ -1959,6 +1959,44 @@ describe('RunloopSandboxClient', () => {
     expect(session.state.devboxId).toBe('devbox_test');
   });
 
+  test('preserves old mount tracking when snapshot replacement rollback restores the old devbox', async () => {
+    const client = new RunloopSandboxClient();
+    const session = await client.create(
+      runloopCloudBucketManifest({ ephemeral: false }),
+    );
+    const snapshotBytes = await session.persistWorkspace();
+    execMock.mockClear();
+    shutdownMock
+      .mockRejectedValueOnce(new Error('shutdown failed'))
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined);
+
+    await expect(session.hydrateWorkspace(snapshotBytes)).rejects.toMatchObject(
+      {
+        details: {
+          provider: 'runloop',
+          devboxId: 'devbox_test',
+          replacementDevboxId: 'devbox_restored',
+          cause: 'shutdown failed',
+        },
+      },
+    );
+
+    const unmountsAfterRollback = execMock.mock.calls.filter(([command]) =>
+      String(command).includes('fusermount3 -u'),
+    ).length;
+    expect(unmountsAfterRollback).toBeGreaterThan(0);
+
+    await session.close();
+
+    expect(
+      execMock.mock.calls.filter(([command]) =>
+        String(command).includes('fusermount3 -u'),
+      ).length,
+    ).toBeGreaterThan(unmountsAfterRollback);
+    expect(session.state.devboxId).toBe('devbox_test');
+  });
+
   test('fails tar hydration when Runloop archive command exit code is unknown', async () => {
     const client = new RunloopSandboxClient();
     const session = await client.create(runloopManifest());

--- a/packages/agents-extensions/test/sandbox/runloop.test.ts
+++ b/packages/agents-extensions/test/sandbox/runloop.test.ts
@@ -1501,6 +1501,37 @@ describe('RunloopSandboxClient', () => {
     );
   });
 
+  test('uses trusted environment when recreating missing devboxes', async () => {
+    const client = new RunloopSandboxClient({
+      env: {
+        TRUSTED_ENV: 'yes',
+      },
+    });
+    const state = await client.deserializeSessionState({
+      manifest: runloopManifest(),
+      devboxId: 'devbox_test',
+      pauseOnExit: true,
+      environment: {
+        ATTACKER_ENV: 'yes',
+      },
+    });
+    resumeMock.mockRejectedValueOnce(new Error('devbox not found'));
+
+    await client.resume(state);
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        environment_variables: {
+          TRUSTED_ENV: 'yes',
+        },
+      }),
+      undefined,
+    );
+    expect(JSON.stringify(createMock.mock.calls.at(-1)?.[0])).not.toContain(
+      'ATTACKER_ENV',
+    );
+  });
+
   test('uses trusted user parameters when recreating missing devboxes', async () => {
     const userParameters: RunloopUserParameters = {
       username: 'agent',

--- a/packages/agents-extensions/test/sandbox/runloop.test.ts
+++ b/packages/agents-extensions/test/sandbox/runloop.test.ts
@@ -1336,6 +1336,29 @@ describe('RunloopSandboxClient', () => {
     }
   });
 
+  test('uses trusted launch parameters when resuming sessions', async () => {
+    const client = new RunloopSandboxClient({
+      launchParameters: {
+        trusted: true,
+      },
+    });
+    const state = await client.deserializeSessionState({
+      manifest: runloopManifest(),
+      devboxId: 'devbox_test',
+      pauseOnExit: true,
+      environment: {},
+      launchParameters: {
+        attacker: true,
+      },
+    });
+
+    const resumed = await client.resume(state);
+
+    expect(resumed.state.launchParameters).toEqual({
+      trusted: true,
+    });
+  });
+
   test('rejects persisted resume manifests outside the effective Runloop home', async () => {
     const client = new RunloopSandboxClient();
     const session = await client.create(runloopManifest(), {
@@ -1776,6 +1799,40 @@ describe('RunloopSandboxClient', () => {
     expect(
       JSON.stringify(createFromSnapshotMock.mock.calls.at(-1)?.[1]),
     ).not.toContain('attacker-secret');
+  });
+
+  test('uses trusted launch parameters when restoring resumed native snapshots', async () => {
+    const client = new RunloopSandboxClient({
+      launchParameters: {
+        trusted: true,
+      },
+    });
+    const state = await client.deserializeSessionState({
+      manifest: runloopManifest(),
+      devboxId: 'devbox_test',
+      pauseOnExit: true,
+      environment: {},
+      launchParameters: {
+        attacker: true,
+      },
+    });
+    const resumed = await client.resume(state);
+    const snapshotBytes = await resumed.persistWorkspace();
+
+    await resumed.hydrateWorkspace(snapshotBytes);
+
+    expect(createFromSnapshotMock).toHaveBeenCalledWith(
+      'snap_runloop',
+      expect.objectContaining({
+        launch_parameters: expect.objectContaining({
+          trusted: true,
+        }),
+      }),
+      undefined,
+    );
+    expect(
+      JSON.stringify(createFromSnapshotMock.mock.calls.at(-1)?.[1]),
+    ).not.toContain('attacker');
   });
 
   test('shuts down replacement devboxes when snapshot mount restore fails', async () => {


### PR DESCRIPTION
This pull request adds a sandbox provider as part of agents-extensions package: https://developers.openai.com/api/docs/guides/agents/sandboxes

How to run:
```zsh
git clone https://github.com/openai/openai-agents-js
cd openai-agents-js/
git checkout feat/sandbox-agents-runloop
pnpm i
pnpm build
pnpm -F sandbox start:runloop
```