### PR TITLE
feat(sandbox): add Vercel provider

### DIFF
--- a/.changeset/sandbox-agents-vercel.md
+++ b/.changeset/sandbox-agents-vercel.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': minor
+---
+
+feat: add Vercel sandbox provider

--- a/examples/sandbox/extensions/vercel-runner.ts
+++ b/examples/sandbox/extensions/vercel-runner.ts
@@ -1,0 +1,110 @@
+import { Runner } from '@openai/agents';
+import {
+  VercelSandboxClient,
+  type VercelWorkspacePersistence,
+} from '@openai/agents-extensions/sandbox/vercel';
+import { Manifest, SandboxAgent, shell } from '@openai/agents/sandbox';
+import { finished } from 'node:stream/promises';
+import {
+  DEFAULT_MODEL,
+  getStringArg,
+  hasFlag,
+  getOptionalNumberArg,
+  getOptionalStringArg,
+  requireOpenAIKey,
+  runExampleMain,
+} from '../support';
+
+const DEFAULT_QUESTION =
+  'Summarize this cloud sandbox workspace in 2 sentences.';
+
+function parseWorkspacePersistence(
+  value: string | undefined,
+): VercelWorkspacePersistence {
+  if (!value || value === 'tar') {
+    return 'tar';
+  }
+  if (value === 'snapshot') {
+    return 'snapshot';
+  }
+  throw new Error(
+    `--workspace-persistence must be "tar" or "snapshot", received ${value}.`,
+  );
+}
+
+function buildManifest(): Manifest {
+  return new Manifest({
+    entries: {
+      'README.md': {
+        type: 'file',
+        content: `# Vercel Demo Workspace
+
+This workspace exists to validate the Vercel sandbox backend manually.
+`,
+      },
+      'handoff.md': {
+        type: 'file',
+        content: `# Handoff
+
+- Customer: Northwind Traders.
+- Goal: validate Vercel sandbox exec and persistence flows.
+- Current status: non-PTY backend slice is wired and under test.
+`,
+      },
+      'todo.md': {
+        type: 'file',
+        content: `# Todo
+
+1. Inspect the workspace files.
+2. Summarize the current status in two sentences.
+`,
+      },
+    },
+  });
+}
+
+async function main() {
+  requireOpenAIKey();
+
+  const model = getStringArg('--model', DEFAULT_MODEL);
+  const question = getStringArg('--question', DEFAULT_QUESTION);
+  const runtime = getOptionalStringArg('--runtime');
+  const timeoutMs = getOptionalNumberArg('--timeout-ms');
+  const workspacePersistence = parseWorkspacePersistence(
+    getOptionalStringArg('--workspace-persistence'),
+  );
+  const stream = hasFlag('--stream');
+  const client = new VercelSandboxClient({
+    runtime,
+    timeoutMs,
+    workspacePersistence,
+  });
+  const agent = new SandboxAgent({
+    name: 'Vercel Sandbox Assistant',
+    model,
+    instructions:
+      'Answer questions about the sandbox workspace. Inspect the files before answering, keep the response concise, and cite the file names you inspected.',
+    defaultManifest: buildManifest(),
+    capabilities: [shell()],
+  });
+  const runner = new Runner({
+    workflowName: 'Vercel sandbox example',
+    sandbox: { client },
+  });
+
+  if (!stream) {
+    const result = await runner.run(agent, question);
+    console.log(result.finalOutput);
+    return;
+  }
+
+  const result = await runner.run(agent, question, { stream: true });
+  process.stdout.write('assistant> ');
+  const textStream = result.toTextStream({ compatibleWithNodeStreams: true });
+  textStream.pipe(process.stdout);
+  await finished(textStream);
+  await result.completed;
+  process.stdout.write('\n');
+}
+
+await runExampleMain(main);

--- a/packages/agents-extensions/src/sandbox/vercel/index.ts
+++ b/packages/agents-extensions/src/sandbox/vercel/index.ts
@@ -1,0 +1,1 @@
+export * from './sandbox';

--- a/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
@@ -1030,9 +1030,6 @@ function pickVercelCredentials(
   options: VercelCredentials,
 ): Record<string, string> {
   const credentials: Record<string, string> = {};
-  if (!options.token) {
-    return credentials;
-  }
   if (options.projectId) {
     credentials.projectId = options.projectId;
   }
@@ -1058,11 +1055,22 @@ async function resolveVercelCredentials(
     teamId: options.teamId ?? envOptions.teamId,
     token: options.token ?? envOptions.token,
   });
-  if (Object.keys(layeredCredentials).length > 0) {
+  if (layeredCredentials.token) {
     return (
       (await refreshLayeredVercelCliCredentials(layeredCredentials)) ??
       layeredCredentials
     );
+  }
+
+  if (Object.keys(layeredCredentials).length > 0) {
+    const cliToken = await resolveVercelCliAuthToken();
+    if (cliToken) {
+      return {
+        ...layeredCredentials,
+        token: cliToken,
+      };
+    }
+    return {};
   }
 
   if (hasAnyVercelCredentialOption(options)) {
@@ -1079,13 +1087,8 @@ function hasAnyVercelCredentialOption(options: VercelCredentials): boolean {
 async function resolveVercelCliCredentials(): Promise<
   Record<string, string> | undefined
 > {
-  const authModule = await loadVercelAuthModule();
-  if (!authModule) {
-    return undefined;
-  }
-
-  const auth = await resolveVercelCliAuth(authModule);
-  if (!auth?.token) {
+  const token = await resolveVercelCliAuthToken();
+  if (!token) {
     return undefined;
   }
 
@@ -1095,10 +1098,20 @@ async function resolveVercelCliCredentials(): Promise<
   }
 
   return {
-    token: auth.token,
+    token,
     projectId: linkedProject.projectId,
     teamId: linkedProject.teamId,
   };
+}
+
+async function resolveVercelCliAuthToken(): Promise<string | undefined> {
+  const authModule = await loadVercelAuthModule();
+  if (!authModule) {
+    return undefined;
+  }
+
+  const auth = await resolveVercelCliAuth(authModule);
+  return auth?.token;
 }
 
 async function refreshLayeredVercelCliCredentials(

--- a/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
@@ -294,7 +294,6 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
       try {
         await this.replaceSandboxFromSnapshot(snapshotId, {
           snapshotFreshAfterRestore: true,
-          stopPrevious: false,
         });
       } catch (error) {
         await this.recoverSandboxAfterSnapshotRestoreFailure(snapshotId, error);
@@ -399,7 +398,6 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
     snapshotId: string,
     options: {
       snapshotFreshAfterRestore?: boolean;
-      stopPrevious?: boolean;
     } = {},
   ): Promise<void> {
     const previousSandbox = this.sandbox;
@@ -409,27 +407,25 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
       credentials,
     );
 
-    if (options.stopPrevious ?? true) {
+    try {
+      await stopVercelSandbox(previousSandbox);
+    } catch (error) {
+      let replacementStopCause: string | undefined;
       try {
-        await stopVercelSandbox(previousSandbox);
-      } catch (error) {
-        let replacementStopCause: string | undefined;
-        try {
-          await stopVercelSandbox(sandbox);
-        } catch (replacementStopError) {
-          replacementStopCause = errorMessage(replacementStopError);
-        }
-        throw new SandboxProviderError(
-          'Vercel snapshot restore created a replacement sandbox, but stopping the previous sandbox failed.',
-          {
-            provider: 'vercel',
-            sandboxId: previousSandbox.sandboxId,
-            replacementSandboxId: sandbox.sandboxId,
-            cause: errorMessage(error),
-            ...(replacementStopCause ? { replacementStopCause } : {}),
-          },
-        );
+        await stopVercelSandbox(sandbox);
+      } catch (replacementStopError) {
+        replacementStopCause = errorMessage(replacementStopError);
       }
+      throw new SandboxProviderError(
+        'Vercel snapshot restore created a replacement sandbox, but stopping the previous sandbox failed.',
+        {
+          provider: 'vercel',
+          sandboxId: previousSandbox.sandboxId,
+          replacementSandboxId: sandbox.sandboxId,
+          cause: errorMessage(error),
+          ...(replacementStopCause ? { replacementStopCause } : {}),
+        },
+      );
     }
 
     this.bindRestoredSandbox(
@@ -444,12 +440,9 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
     restoreError: unknown,
   ): Promise<void> {
     try {
-      const credentials = await this.resolveSnapshotCredentials();
-      const sandbox = await this.createAndPrepareSandboxFromSnapshot(
-        snapshotId,
-        credentials,
-      );
-      this.bindRestoredSandbox(sandbox, snapshotId, true);
+      await this.replaceSandboxFromSnapshot(snapshotId, {
+        snapshotFreshAfterRestore: true,
+      });
     } catch (recoveryError) {
       throw new SandboxProviderError(
         'Vercel snapshot persistence captured a snapshot, but restoring the live session failed and recovery also failed.',

--- a/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
@@ -295,6 +295,7 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
       try {
         await this.replaceSandboxFromSnapshot(snapshotId, {
           snapshotFreshAfterRestore: true,
+          ignorePreviousStopFailure: true,
         });
       } catch (error) {
         await this.recoverSandboxAfterSnapshotRestoreFailure(snapshotId, error);
@@ -339,6 +340,7 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
 
   private async closeOnce(): Promise<void> {
     let snapshotError: unknown;
+    let snapshotCapturedBeforeStop = false;
     if (
       this.state.workspacePersistence === 'snapshot' &&
       this.sandbox.snapshot &&
@@ -348,6 +350,7 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
         await captureVercelSnapshot(this.state, {
           sandbox: this.sandbox,
         });
+        snapshotCapturedBeforeStop = true;
       } catch (error) {
         snapshotError = error;
       }
@@ -361,6 +364,10 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
         throw new UserError(
           `Failed to capture a Vercel sandbox snapshot and stop the sandbox. Snapshot error: ${errorMessage(snapshotError)} Stop error: ${errorMessage(stopError)}`,
         );
+      }
+      if (snapshotCapturedBeforeStop) {
+        this.closeCompleted = true;
+        return;
       }
       throw stopError;
     }
@@ -399,6 +406,7 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
     snapshotId: string,
     options: {
       snapshotFreshAfterRestore?: boolean;
+      ignorePreviousStopFailure?: boolean;
     } = {},
   ): Promise<void> {
     const previousSandbox = this.sandbox;
@@ -411,6 +419,14 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
     try {
       await stopVercelSandbox(previousSandbox);
     } catch (error) {
+      if (options.ignorePreviousStopFailure) {
+        this.bindRestoredSandbox(
+          sandbox,
+          snapshotId,
+          options.snapshotFreshAfterRestore,
+        );
+        return;
+      }
       let replacementStopCause: string | undefined;
       try {
         await stopVercelSandbox(sandbox);
@@ -443,6 +459,7 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
     try {
       await this.replaceSandboxFromSnapshot(snapshotId, {
         snapshotFreshAfterRestore: true,
+        ignorePreviousStopFailure: true,
       });
     } catch (recoveryError) {
       throw new SandboxProviderError(
@@ -1094,7 +1111,7 @@ async function resolveVercelCliCredentials(): Promise<
 
   const linkedProject = findLinkedVercelProject();
   if (!linkedProject) {
-    return undefined;
+    return { token };
   }
 
   return {

--- a/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
@@ -103,6 +103,7 @@ type VercelCredentials = Pick<
   VercelSandboxClientOptions,
   'projectId' | 'teamId' | 'token'
 >;
+type VercelAuth = NonNullable<ReturnType<VercelAuthModule['getAuth']>>;
 
 type VercelSandboxInstance = {
   sandboxId: string;
@@ -458,11 +459,13 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
   }
 
   private async resolveSnapshotCredentials(): Promise<Record<string, string>> {
-    return await resolveVercelCredentials({
+    const credentials = await resolveVercelCredentials({
       ...this.credentials,
       projectId: this.state.projectId ?? this.credentials.projectId,
       teamId: this.state.teamId ?? this.credentials.teamId,
     });
+    applyResolvedVercelCredentials(this.state, credentials);
+    return credentials;
   }
 
   private async createAndPrepareSandboxFromSnapshot(
@@ -855,6 +858,7 @@ export class VercelSandboxClient implements SandboxClient<
       teamId: state.teamId ?? this.options.teamId,
       token: state.token ?? this.options.token,
     });
+    applyResolvedVercelCredentials(state, credentials);
     const resumeFromSnapshot = hasFreshVercelSnapshot(state);
     const sandbox = resumeFromSnapshot
       ? await withProviderError(
@@ -1054,7 +1058,10 @@ async function resolveVercelCredentials(
     token: options.token ?? envOptions.token,
   });
   if (Object.keys(layeredCredentials).length > 0) {
-    return layeredCredentials;
+    return (
+      (await refreshLayeredVercelCliCredentials(layeredCredentials)) ??
+      layeredCredentials
+    );
   }
 
   if (hasAnyVercelCredentialOption(options)) {
@@ -1071,18 +1078,73 @@ function hasAnyVercelCredentialOption(options: VercelCredentials): boolean {
 async function resolveVercelCliCredentials(): Promise<
   Record<string, string> | undefined
 > {
+  const authModule = await loadVercelAuthModule();
+  if (!authModule) {
+    return undefined;
+  }
+
+  const auth = await resolveVercelCliAuth(authModule);
+  if (!auth?.token) {
+    return undefined;
+  }
+
+  const linkedProject = findLinkedVercelProject();
+  if (!linkedProject) {
+    return undefined;
+  }
+
+  return {
+    token: auth.token,
+    projectId: linkedProject.projectId,
+    teamId: linkedProject.teamId,
+  };
+}
+
+async function refreshLayeredVercelCliCredentials(
+  credentials: Record<string, string>,
+): Promise<Record<string, string> | undefined> {
+  if (!credentials.token) {
+    return undefined;
+  }
+
+  const authModule = await loadVercelAuthModule();
+  if (!authModule) {
+    return undefined;
+  }
+
+  const auth = authModule.getAuth();
+  if (!auth?.token || auth.token !== credentials.token) {
+    return undefined;
+  }
+
+  const resolvedAuth = await resolveVercelCliAuth(authModule, auth);
+  if (!resolvedAuth?.token) {
+    return undefined;
+  }
+
+  return {
+    ...credentials,
+    token: resolvedAuth.token,
+  };
+}
+
+async function loadVercelAuthModule(): Promise<VercelAuthModule | undefined> {
   if (process.env.NODE_ENV === 'test' && !process.env.VERCEL_AUTH_CONFIG_DIR) {
     return undefined;
   }
 
-  let authModule: VercelAuthModule;
   try {
-    authModule = await import('@vercel/sandbox/dist/auth/index.js');
+    return await import('@vercel/sandbox/dist/auth/index.js');
   } catch {
     return undefined;
   }
+}
 
-  let auth = authModule.getAuth();
+async function resolveVercelCliAuth(
+  authModule: VercelAuthModule,
+  initialAuth = authModule.getAuth(),
+): Promise<VercelAuth | undefined> {
+  let auth = initialAuth;
   if (!auth?.token && !auth?.refreshToken) {
     return undefined;
   }
@@ -1106,20 +1168,22 @@ async function resolveVercelCliCredentials(): Promise<
     }
   }
 
-  if (!auth?.token) {
-    return undefined;
-  }
+  return auth ?? undefined;
+}
 
-  const linkedProject = findLinkedVercelProject();
-  if (!linkedProject) {
-    return undefined;
+function applyResolvedVercelCredentials(
+  state: Pick<VercelSandboxSessionState, 'projectId' | 'teamId' | 'token'>,
+  credentials: Record<string, string>,
+): void {
+  if (credentials.projectId) {
+    state.projectId = credentials.projectId;
   }
-
-  return {
-    token: auth.token,
-    projectId: linkedProject.projectId,
-    teamId: linkedProject.teamId,
-  };
+  if (credentials.teamId) {
+    state.teamId = credentials.teamId;
+  }
+  if (credentials.token) {
+    state.token = credentials.token;
+  }
 }
 
 function findLinkedVercelProject():
@@ -1194,6 +1258,7 @@ async function captureVercelSnapshot(
       teamId: state.teamId ?? args.options?.teamId,
       token: state.token ?? args.options?.token,
     });
+    applyResolvedVercelCredentials(state, credentials);
     sandbox = await withProviderError(
       'VercelSandboxClient',
       'vercel',

--- a/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
@@ -1,0 +1,1343 @@
+import { UserError } from '@openai/agents-core';
+import { existsSync, readFileSync } from 'node:fs';
+import {
+  dirname as pathDirname,
+  join as pathJoin,
+  resolve as pathResolve,
+} from 'node:path';
+import {
+  Manifest,
+  SandboxLifecycleError,
+  SandboxProviderError,
+  SandboxUnsupportedFeatureError,
+  normalizeSandboxClientCreateArgs,
+  type SandboxClient,
+  type SandboxClientCreateArgs,
+  type SandboxClientOptions,
+  type SandboxSessionSerializationOptions,
+  type SandboxSessionState,
+  type WorkspaceArchiveData,
+} from '@openai/agents-core/sandbox';
+import {
+  assertCoreConcurrencyLimitsUnsupported,
+  assertCoreSnapshotUnsupported,
+  assertSandboxManifestMetadataSupported,
+  assertRunAsUnsupported,
+  cloneManifestWithRoot,
+  deserializeRemoteSandboxSessionStateValues,
+  decodeNativeSnapshotRef,
+  encodeNativeSnapshotRef,
+  materializeEnvironment,
+  posixDirname,
+  shellQuote,
+  serializeRemoteSandboxSessionState,
+  toUint8Array,
+  readOptionalBoolean,
+  readOptionalNumber,
+  readOptionalNumberArray,
+  readOptionalRecord,
+  readOptionalString,
+  readString,
+  withProviderError,
+  withSandboxSpan,
+  RemoteSandboxSessionBase,
+  type RemoteSandboxCommandOptions,
+  type RemoteSandboxCommandResult,
+} from '../shared';
+
+const DEFAULT_VERCEL_WORKSPACE_ROOT = '/vercel/sandbox';
+
+type VercelSdkSandboxClass = typeof import('@vercel/sandbox').Sandbox;
+type VercelSdkSandbox = import('@vercel/sandbox').Sandbox;
+type VercelSdkCreateParams = Parameters<VercelSdkSandboxClass['create']>[0];
+type VercelSdkGetParams = Parameters<VercelSdkSandboxClass['get']>[0];
+type VercelSdkRunCommandParams = Parameters<VercelSdkSandbox['runCommand']>[0];
+type VercelAuthModule = typeof import('@vercel/sandbox/dist/auth/index.js');
+
+type VercelSandboxCreateParams = Record<string, unknown> & {
+  source?:
+    | {
+        type: 'git';
+        url: string;
+        depth?: number;
+        revision?: string;
+        username?: string;
+        password?: string;
+      }
+    | {
+        type: 'tarball';
+        url: string;
+      }
+    | {
+        type: 'snapshot';
+        snapshotId: string;
+      };
+  ports?: number[];
+  timeout?: number;
+  resources?: Record<string, unknown>;
+  runtime?: string;
+  networkPolicy?: Record<string, unknown>;
+  interactive?: boolean;
+  env?: Record<string, string>;
+};
+
+type VercelSandboxGetParams = Record<string, unknown> & {
+  sandboxId: string;
+};
+
+type VercelSandboxRunCommandParams = Record<string, unknown> & {
+  cmd: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  sudo?: boolean;
+  detached?: boolean;
+};
+
+type VercelSandboxClass = {
+  create(params?: VercelSandboxCreateParams): Promise<VercelSandboxInstance>;
+  get(params: VercelSandboxGetParams): Promise<VercelSandboxInstance>;
+};
+
+type VercelCredentials = Pick<
+  VercelSandboxClientOptions,
+  'projectId' | 'teamId' | 'token'
+>;
+
+type VercelSandboxInstance = {
+  sandboxId: string;
+  runCommand(
+    params: VercelSandboxRunCommandParams,
+  ): Promise<VercelCommandFinishedLike>;
+  mkDir(path: string): Promise<void>;
+  readFileToBuffer(file: {
+    path: string;
+    cwd?: string;
+  }): Promise<Buffer | Uint8Array | null>;
+  writeFiles(
+    files: {
+      path: string;
+      content: string | Uint8Array;
+      mode?: number;
+    }[],
+  ): Promise<void>;
+  domain?(port: number): string;
+  stop?(params?: { blocking?: boolean }): Promise<unknown>;
+  snapshot?(params?: { expiration?: number }): Promise<{ snapshotId?: string }>;
+};
+
+type VercelCommandFinishedLike = {
+  exitCode: number | null;
+  output(stream?: 'stdout' | 'stderr' | 'both'): Promise<string>;
+};
+
+export type VercelWorkspacePersistence = 'tar' | 'snapshot';
+
+export interface VercelSandboxClientOptions extends SandboxClientOptions {
+  projectId?: string;
+  teamId?: string;
+  token?: string;
+  runtime?: string;
+  resources?: Record<string, unknown>;
+  exposedPorts?: number[];
+  interactive?: boolean;
+  networkPolicy?: Record<string, unknown>;
+  timeoutMs?: number;
+  workspacePersistence?: VercelWorkspacePersistence;
+  snapshotExpirationMs?: number;
+  env?: Record<string, string>;
+}
+
+export interface VercelSandboxSessionState extends SandboxSessionState {
+  sandboxId: string;
+  projectId?: string;
+  teamId?: string;
+  token?: string;
+  runtime?: string;
+  resources?: Record<string, unknown>;
+  configuredExposedPorts?: number[];
+  interactive?: boolean;
+  networkPolicy?: Record<string, unknown>;
+  timeoutMs?: number;
+  workspacePersistence: VercelWorkspacePersistence;
+  snapshotExpirationMs?: number;
+  environment: Record<string, string>;
+  snapshotId?: string;
+  snapshotSandboxId?: string;
+  snapshotSupported?: boolean;
+}
+
+export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandboxSessionState> {
+  private sandbox: VercelSandboxInstance;
+  private readonly knownDirs: Set<string>;
+  private closePromise?: Promise<void>;
+  private closeCompleted = false;
+  private readonly credentials: Pick<
+    VercelSandboxClientOptions,
+    'projectId' | 'teamId' | 'token'
+  >;
+
+  constructor(args: {
+    state: VercelSandboxSessionState;
+    sandbox: VercelSandboxInstance;
+    credentials?: Pick<
+      VercelSandboxClientOptions,
+      'projectId' | 'teamId' | 'token'
+    >;
+  }) {
+    super({
+      state: args.state,
+      options: {
+        providerName: 'VercelSandboxClient',
+        providerId: 'vercel',
+      },
+    });
+    this.sandbox = args.sandbox;
+    this.credentials = args.credentials ?? {};
+    this.knownDirs = new Set();
+    this.resetKnownDirs();
+  }
+
+  override supportsPty(): boolean {
+    return false;
+  }
+
+  protected override assertExecRunAs(runAs?: string): void {
+    assertRunAsUnsupported('VercelSandboxClient', runAs);
+  }
+
+  protected override assertFilesystemRunAs(runAs?: string): void {
+    assertFilesystemRunAs(runAs);
+  }
+
+  protected override resolveManifestForApply(manifest: Manifest): Manifest {
+    return resolveManifestRoot(manifest);
+  }
+
+  protected override async beforeFilesystemMutation(): Promise<void> {
+    this.markWorkspaceMutated();
+  }
+
+  protected override async beforeExecCommand(): Promise<void> {
+    this.markWorkspaceMutated();
+    this.resetKnownDirs();
+  }
+
+  protected override async beforeMaterializeEntry(): Promise<void> {
+    this.markWorkspaceMutated();
+  }
+
+  protected override async beforeApplyManifest(): Promise<void> {
+    this.markWorkspaceMutated();
+  }
+
+  protected override runningWorkdir(): string {
+    return '/';
+  }
+
+  protected override exposedPortSource(): string {
+    return 'domain';
+  }
+
+  protected override async resolveRemoteExposedPort(
+    requestedPort: number,
+  ): Promise<string> {
+    if (!this.sandbox.domain) {
+      throw new SandboxProviderError(
+        'VercelSandboxClient exposed port resolution requires @vercel/sandbox domain(port) support.',
+        {
+          provider: 'vercel',
+          port: requestedPort,
+        },
+      );
+    }
+
+    try {
+      return this.sandbox.domain(requestedPort);
+    } catch (error) {
+      throw new SandboxProviderError(
+        `VercelSandboxClient failed to resolve exposed port ${requestedPort}.`,
+        {
+          provider: 'vercel',
+          port: requestedPort,
+          cause: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+  }
+
+  async materializeInitialManifest(manifest: Manifest): Promise<void> {
+    this.markWorkspaceMutated();
+    await this.materializeManifestEntries(manifest);
+  }
+
+  async prepareWorkspaceRoot(): Promise<void> {
+    this.markWorkspaceMutated();
+    await this.ensureDir(this.state.manifest.root);
+  }
+
+  async persistWorkspace(): Promise<Uint8Array> {
+    if (this.state.workspacePersistence === 'snapshot') {
+      await captureVercelSnapshot(this.state, {
+        sandbox: this.sandbox,
+      });
+      const snapshotId = this.state.snapshotId;
+      if (!snapshotId) {
+        throw new SandboxProviderError(
+          'Vercel snapshot persistence did not produce a snapshot id.',
+          {
+            provider: 'vercel',
+            sandboxId: this.state.sandboxId,
+          },
+        );
+      }
+      try {
+        await this.replaceSandboxFromSnapshot(snapshotId, {
+          snapshotFreshAfterRestore: true,
+          stopPrevious: false,
+        });
+      } catch (error) {
+        await this.recoverSandboxAfterSnapshotRestoreFailure(snapshotId, error);
+      }
+      return encodeNativeSnapshotRef({
+        provider: 'vercel',
+        snapshotId,
+      });
+    }
+
+    return await this.persistWorkspaceTar();
+  }
+
+  async hydrateWorkspace(data: WorkspaceArchiveData): Promise<void> {
+    this.markWorkspaceMutated();
+    const snapshotRef =
+      this.state.workspacePersistence === 'snapshot'
+        ? decodeNativeSnapshotRef(data)
+        : undefined;
+    if (snapshotRef?.provider === 'vercel') {
+      await this.replaceSandboxFromSnapshot(snapshotRef.snapshotId);
+      return;
+    }
+
+    await this.hydrateWorkspaceTar(data);
+    this.resetKnownDirs();
+    this.knownDirs.add(this.state.manifest.root);
+  }
+
+  async close(): Promise<void> {
+    if (this.closeCompleted) {
+      return;
+    }
+    this.closePromise ??= this.closeOnce().catch((error) => {
+      if (!this.closeCompleted) {
+        this.closePromise = undefined;
+      }
+      throw error;
+    });
+    await this.closePromise;
+  }
+
+  private async closeOnce(): Promise<void> {
+    let snapshotError: unknown;
+    if (
+      this.state.workspacePersistence === 'snapshot' &&
+      this.sandbox.snapshot &&
+      this.state.snapshotSandboxId !== this.sandbox.sandboxId
+    ) {
+      try {
+        await captureVercelSnapshot(this.state, {
+          sandbox: this.sandbox,
+        });
+      } catch (error) {
+        snapshotError = error;
+      }
+    }
+
+    try {
+      await stopVercelSandbox(this.sandbox);
+      this.closeCompleted = true;
+    } catch (stopError) {
+      if (snapshotError) {
+        throw new UserError(
+          `Failed to capture a Vercel sandbox snapshot and stop the sandbox. Snapshot error: ${errorMessage(snapshotError)} Stop error: ${errorMessage(stopError)}`,
+        );
+      }
+      throw stopError;
+    }
+    if (snapshotError) {
+      throw snapshotError;
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    await this.close();
+  }
+
+  async delete(): Promise<void> {
+    await this.close();
+  }
+
+  private async execShell(
+    command: string,
+    cwd: string,
+    sudo: boolean | undefined,
+  ): Promise<{ exitCode: number; output: string }> {
+    const result = await this.sandbox.runCommand({
+      cmd: '/bin/sh',
+      args: ['-lc', command],
+      cwd,
+      env: this.state.environment,
+      ...(sudo ? { sudo: true } : {}),
+    });
+    return {
+      exitCode: result.exitCode ?? 1,
+      output: await result.output('both'),
+    };
+  }
+
+  private async replaceSandboxFromSnapshot(
+    snapshotId: string,
+    options: {
+      snapshotFreshAfterRestore?: boolean;
+      stopPrevious?: boolean;
+    } = {},
+  ): Promise<void> {
+    const previousSandbox = this.sandbox;
+    const credentials = await this.resolveSnapshotCredentials();
+    const sandbox = await this.createAndPrepareSandboxFromSnapshot(
+      snapshotId,
+      credentials,
+    );
+
+    if (options.stopPrevious ?? true) {
+      try {
+        await stopVercelSandbox(previousSandbox);
+      } catch (error) {
+        let replacementStopCause: string | undefined;
+        try {
+          await stopVercelSandbox(sandbox);
+        } catch (replacementStopError) {
+          replacementStopCause = errorMessage(replacementStopError);
+        }
+        throw new SandboxProviderError(
+          'Vercel snapshot restore created a replacement sandbox, but stopping the previous sandbox failed.',
+          {
+            provider: 'vercel',
+            sandboxId: previousSandbox.sandboxId,
+            replacementSandboxId: sandbox.sandboxId,
+            cause: errorMessage(error),
+            ...(replacementStopCause ? { replacementStopCause } : {}),
+          },
+        );
+      }
+    }
+
+    this.bindRestoredSandbox(
+      sandbox,
+      snapshotId,
+      options.snapshotFreshAfterRestore,
+    );
+  }
+
+  private async recoverSandboxAfterSnapshotRestoreFailure(
+    snapshotId: string,
+    restoreError: unknown,
+  ): Promise<void> {
+    try {
+      const credentials = await this.resolveSnapshotCredentials();
+      const sandbox = await this.createAndPrepareSandboxFromSnapshot(
+        snapshotId,
+        credentials,
+      );
+      this.bindRestoredSandbox(sandbox, snapshotId, true);
+    } catch (recoveryError) {
+      throw new SandboxProviderError(
+        'Vercel snapshot persistence captured a snapshot, but restoring the live session failed and recovery also failed.',
+        {
+          provider: 'vercel',
+          sandboxId: this.state.sandboxId,
+          snapshotId,
+          cause: errorMessage(restoreError),
+          recoveryCause: errorMessage(recoveryError),
+        },
+      );
+    }
+  }
+
+  private async resolveSnapshotCredentials(): Promise<Record<string, string>> {
+    return await resolveVercelCredentials({
+      ...this.credentials,
+      projectId: this.state.projectId ?? this.credentials.projectId,
+      teamId: this.state.teamId ?? this.credentials.teamId,
+    });
+  }
+
+  private async createAndPrepareSandboxFromSnapshot(
+    snapshotId: string,
+    credentials: Record<string, string>,
+  ): Promise<VercelSandboxInstance> {
+    const sandbox = await this.createSandboxFromSnapshot(
+      snapshotId,
+      credentials,
+    );
+
+    const replacementSession = new VercelSandboxSession({
+      credentials: { ...this.credentials, ...credentials },
+      sandbox,
+      state: {
+        ...this.state,
+        sandboxId: sandbox.sandboxId,
+        snapshotId,
+        snapshotSandboxId: undefined,
+        snapshotSupported: supportsVercelSnapshot(sandbox),
+        exposedPorts: undefined,
+      },
+    });
+    try {
+      await waitForVercelSandboxRunning(replacementSession);
+      await replacementSession.prepareWorkspaceRoot();
+    } catch (error) {
+      try {
+        await stopVercelSandbox(sandbox);
+      } catch (stopError) {
+        throw new UserError(
+          `Failed to restore a Vercel sandbox from snapshot and stop the replacement sandbox. Restore error: ${errorMessage(error)} Stop error: ${errorMessage(stopError)}`,
+        );
+      }
+      throw error;
+    }
+
+    return sandbox;
+  }
+
+  private async createSandboxFromSnapshot(
+    snapshotId: string,
+    credentials: Record<string, string>,
+  ): Promise<VercelSandboxInstance> {
+    const Sandbox = await loadVercelSandboxClass();
+    return await withProviderError(
+      'VercelSandboxClient',
+      'vercel',
+      'restore snapshot',
+      async () =>
+        await Sandbox.create({
+          ...credentials,
+          source: {
+            type: 'snapshot',
+            snapshotId,
+          },
+          ...(this.state.runtime ? { runtime: this.state.runtime } : {}),
+          ...(this.state.resources ? { resources: this.state.resources } : {}),
+          ...(this.state.configuredExposedPorts
+            ? { ports: this.state.configuredExposedPorts }
+            : {}),
+          ...(typeof this.state.interactive === 'boolean'
+            ? { interactive: this.state.interactive }
+            : {}),
+          ...(this.state.networkPolicy
+            ? { networkPolicy: this.state.networkPolicy }
+            : {}),
+          ...(typeof this.state.timeoutMs === 'number'
+            ? { timeout: this.state.timeoutMs }
+            : {}),
+          env: this.state.environment,
+        }),
+      { snapshotId },
+    );
+  }
+
+  private bindRestoredSandbox(
+    sandbox: VercelSandboxInstance,
+    snapshotId: string,
+    snapshotFreshAfterRestore?: boolean,
+  ): void {
+    this.sandbox = sandbox;
+    this.resetKnownDirs();
+    this.knownDirs.add(this.state.manifest.root);
+    this.state.sandboxId = sandbox.sandboxId;
+    this.state.snapshotId = snapshotId;
+    this.state.snapshotSandboxId = snapshotFreshAfterRestore
+      ? sandbox.sandboxId
+      : undefined;
+    this.state.snapshotSupported = supportsVercelSnapshot(sandbox);
+    this.clearExposedPortCache();
+  }
+
+  private resetKnownDirs(): void {
+    this.knownDirs.clear();
+    this.knownDirs.add(DEFAULT_VERCEL_WORKSPACE_ROOT);
+  }
+
+  private markWorkspaceMutated(): void {
+    if (this.state.workspacePersistence === 'snapshot') {
+      this.state.snapshotSandboxId = undefined;
+    }
+  }
+
+  private clearExposedPortCache(): void {
+    this.state.exposedPorts = undefined;
+  }
+
+  private async ensureDir(path: string): Promise<void> {
+    if (path === '/' || path === '.' || this.knownDirs.has(path)) {
+      return;
+    }
+
+    const parent = posixDirname(path);
+    if (parent !== path && parent !== '/' && parent !== '.') {
+      await this.ensureDir(parent);
+    }
+
+    try {
+      await this.sandbox.mkDir(path);
+    } catch (error) {
+      if (!isVercelAlreadyExistsError(error)) {
+        throw error;
+      }
+    }
+
+    this.knownDirs.add(path);
+  }
+
+  protected override async runRemoteCommand(
+    command: string,
+    options: RemoteSandboxCommandOptions,
+  ): Promise<RemoteSandboxCommandResult> {
+    const result = await this.execShell(command, options.workdir, undefined);
+    return {
+      status: result.exitCode,
+      stdout: result.output,
+      stderr: '',
+    };
+  }
+
+  protected override async mkdirRemote(path: string): Promise<void> {
+    await this.ensureDir(path);
+  }
+
+  protected override async readRemoteText(path: string): Promise<string> {
+    return new TextDecoder().decode(await this.readRemoteFile(path));
+  }
+
+  protected override async readRemoteFile(path: string): Promise<Uint8Array> {
+    const bytes = await this.sandbox.readFileToBuffer({ path });
+    if (!bytes) {
+      throw new UserError(`Sandbox path not found: ${path}`);
+    }
+    return await toUint8Array(bytes);
+  }
+
+  protected override async writeRemoteFile(
+    path: string,
+    content: string | Uint8Array,
+  ): Promise<void> {
+    await this.sandbox.writeFiles([
+      {
+        path,
+        content,
+      },
+    ]);
+  }
+
+  protected override async deleteRemotePath(path: string): Promise<void> {
+    const result = await this.runRemoteCommand(`rm -f -- ${shellQuote(path)}`, {
+      kind: 'manifest',
+      workdir: this.state.manifest.root,
+    });
+    if (result.status !== 0) {
+      throw new SandboxProviderError(
+        'VercelSandboxClient failed to delete path.',
+        {
+          provider: 'vercel',
+          operation: 'delete path',
+          sandboxId: this.state.sandboxId,
+          path,
+          exitCode: result.status,
+          output: result.stdout ?? '',
+        },
+      );
+    }
+  }
+}
+
+/**
+ * @see {@link https://vercel.com/docs/vercel-sandbox | Vercel Sandbox overview}.
+ * @see {@link https://vercel.com/docs/vercel-sandbox/sdk-reference | Sandbox SDK reference}.
+ * @see {@link https://vercel.com/docs/vercel-sandbox/working-with-sandbox | Working with Sandbox examples}.
+ */
+export class VercelSandboxClient implements SandboxClient<
+  VercelSandboxClientOptions,
+  VercelSandboxSessionState
+> {
+  readonly backendId = 'vercel';
+  private readonly options: VercelSandboxClientOptions;
+
+  constructor(options: VercelSandboxClientOptions = {}) {
+    this.options = options;
+  }
+
+  async create(
+    args?: SandboxClientCreateArgs<VercelSandboxClientOptions> | Manifest,
+    manifestOptions?: VercelSandboxClientOptions,
+  ): Promise<VercelSandboxSession> {
+    const createArgs = normalizeSandboxClientCreateArgs(args, manifestOptions);
+    assertCoreSnapshotUnsupported('VercelSandboxClient', createArgs.snapshot);
+    assertCoreConcurrencyLimitsUnsupported(
+      'VercelSandboxClient',
+      createArgs.concurrencyLimits,
+    );
+    const manifest = createArgs.manifest;
+    const resolvedOptions = {
+      ...this.options,
+      ...createArgs.options,
+    };
+    const resolvedManifest = resolveManifestRoot(manifest);
+    assertSandboxManifestMetadataSupported(
+      'VercelSandboxClient',
+      resolvedManifest,
+    );
+
+    return await withSandboxSpan(
+      'sandbox.start',
+      {
+        backend_id: this.backendId,
+      },
+      async () => {
+        const Sandbox = await loadVercelSandboxClass();
+        const environment = await materializeEnvironment(
+          resolvedManifest,
+          resolvedOptions.env,
+        );
+        const credentials = await resolveVercelCredentials(resolvedOptions);
+        const sandbox = await withProviderError(
+          'VercelSandboxClient',
+          'vercel',
+          'create sandbox',
+          async () =>
+            await Sandbox.create({
+              ...credentials,
+              ...(resolvedOptions.runtime
+                ? { runtime: resolvedOptions.runtime }
+                : {}),
+              ...(resolvedOptions.resources
+                ? { resources: resolvedOptions.resources }
+                : {}),
+              ...(resolvedOptions.exposedPorts
+                ? { ports: resolvedOptions.exposedPorts }
+                : {}),
+              ...(typeof resolvedOptions.interactive === 'boolean'
+                ? { interactive: resolvedOptions.interactive }
+                : {}),
+              ...(resolvedOptions.networkPolicy
+                ? { networkPolicy: resolvedOptions.networkPolicy }
+                : {}),
+              ...(typeof resolvedOptions.timeoutMs === 'number'
+                ? { timeout: resolvedOptions.timeoutMs }
+                : {}),
+              env: environment,
+            }),
+          { runtime: resolvedOptions.runtime },
+        );
+
+        const session = new VercelSandboxSession({
+          sandbox,
+          credentials: { ...resolvedOptions, ...credentials },
+          state: {
+            manifest: resolvedManifest,
+            sandboxId: sandbox.sandboxId,
+            projectId: resolvedOptions.projectId ?? credentials.projectId,
+            teamId: resolvedOptions.teamId ?? credentials.teamId,
+            token: resolvedOptions.token,
+            runtime: resolvedOptions.runtime,
+            resources: resolvedOptions.resources,
+            configuredExposedPorts: resolvedOptions.exposedPorts,
+            interactive: resolvedOptions.interactive,
+            networkPolicy: resolvedOptions.networkPolicy,
+            timeoutMs: resolvedOptions.timeoutMs,
+            workspacePersistence: resolvedOptions.workspacePersistence ?? 'tar',
+            snapshotExpirationMs: resolvedOptions.snapshotExpirationMs,
+            environment,
+            snapshotSupported: supportsVercelSnapshot(sandbox),
+          },
+        });
+
+        try {
+          await waitForVercelSandboxRunning(session);
+          await session.prepareWorkspaceRoot();
+          await session.materializeInitialManifest(resolvedManifest);
+        } catch (error) {
+          try {
+            await stopVercelSandbox(sandbox);
+          } catch (stopError) {
+            throw new UserError(
+              `Failed to apply a Vercel sandbox manifest and stop the sandbox. Manifest error: ${errorMessage(error)} Stop error: ${errorMessage(stopError)}`,
+            );
+          }
+          throw error;
+        }
+        return session;
+      },
+    );
+  }
+
+  async serializeSessionState(
+    state: VercelSandboxSessionState,
+    options?: SandboxSessionSerializationOptions,
+  ): Promise<Record<string, unknown>> {
+    if (
+      state.workspacePersistence === 'snapshot' &&
+      state.snapshotSupported !== false &&
+      state.snapshotSandboxId !== state.sandboxId &&
+      (options?.reuseLiveSession === false || options?.willCloseAfterSerialize)
+    ) {
+      await captureVercelSnapshot(state, {
+        options: {
+          ...this.options,
+          projectId: state.projectId ?? this.options.projectId,
+          teamId: state.teamId ?? this.options.teamId,
+          token: state.token ?? this.options.token,
+        },
+      });
+    }
+    return serializeRemoteSandboxSessionState(state);
+  }
+
+  canPersistOwnedSessionState(state: VercelSandboxSessionState): boolean {
+    return (
+      state.workspacePersistence === 'snapshot' &&
+      state.snapshotSupported !== false
+    );
+  }
+
+  canReusePreservedOwnedSession(state: VercelSandboxSessionState): boolean {
+    return (
+      state.workspacePersistence !== 'snapshot' ||
+      state.snapshotSupported === false
+    );
+  }
+
+  async deserializeSessionState(
+    state: Record<string, unknown>,
+  ): Promise<VercelSandboxSessionState> {
+    const baseState = deserializeRemoteSandboxSessionStateValues(
+      state,
+      this.options.env,
+    );
+    const manifest = resolveManifestRoot(baseState.manifest);
+    assertSandboxManifestMetadataSupported('VercelSandboxClient', manifest);
+    return {
+      ...state,
+      ...baseState,
+      manifest,
+      sandboxId: readString(state, 'sandboxId'),
+      workspacePersistence:
+        (state.workspacePersistence as
+          | VercelWorkspacePersistence
+          | undefined) ?? 'tar',
+      projectId: readOptionalString(state, 'projectId'),
+      teamId: readOptionalString(state, 'teamId'),
+      token: readOptionalString(state, 'token'),
+      runtime: readOptionalString(state, 'runtime'),
+      resources: readOptionalRecord(state.resources),
+      configuredExposedPorts: readOptionalNumberArray(
+        state.configuredExposedPorts,
+      ),
+      interactive: readOptionalBoolean(state, 'interactive'),
+      networkPolicy: readOptionalRecord(state.networkPolicy),
+      timeoutMs: readOptionalNumber(state, 'timeoutMs'),
+      snapshotExpirationMs: readOptionalNumber(state, 'snapshotExpirationMs'),
+      snapshotId: readOptionalString(state, 'snapshotId'),
+      snapshotSandboxId: readOptionalString(state, 'snapshotSandboxId'),
+      snapshotSupported: readOptionalBoolean(state, 'snapshotSupported'),
+    };
+  }
+
+  async resume(
+    state: VercelSandboxSessionState,
+  ): Promise<VercelSandboxSession> {
+    const Sandbox = await loadVercelSandboxClass();
+    const credentials = await resolveVercelCredentials({
+      ...this.options,
+      projectId: state.projectId ?? this.options.projectId,
+      teamId: state.teamId ?? this.options.teamId,
+      token: state.token ?? this.options.token,
+    });
+    const resumeFromSnapshot = hasFreshVercelSnapshot(state);
+    const sandbox = resumeFromSnapshot
+      ? await withProviderError(
+          'VercelSandboxClient',
+          'vercel',
+          'resume sandbox from snapshot',
+          async () =>
+            await Sandbox.create({
+              ...credentials,
+              source: {
+                type: 'snapshot',
+                snapshotId: state.snapshotId!,
+              },
+              ...(state.runtime ? { runtime: state.runtime } : {}),
+              ...(state.resources ? { resources: state.resources } : {}),
+              ...(state.configuredExposedPorts
+                ? { ports: state.configuredExposedPorts }
+                : {}),
+              ...(state.interactive !== undefined
+                ? { interactive: state.interactive }
+                : {}),
+              ...(state.networkPolicy
+                ? { networkPolicy: state.networkPolicy }
+                : {}),
+              ...(state.timeoutMs !== undefined
+                ? { timeout: state.timeoutMs }
+                : {}),
+              env: state.environment,
+            }),
+          { snapshotId: state.snapshotId, sandboxId: state.sandboxId },
+        )
+      : await withProviderError(
+          'VercelSandboxClient',
+          'vercel',
+          'resume sandbox',
+          async () =>
+            await Sandbox.get({
+              sandboxId: state.sandboxId,
+              ...credentials,
+            }),
+          { sandboxId: state.sandboxId },
+        );
+
+    const session = new VercelSandboxSession({
+      credentials,
+      state: resumeFromSnapshot
+        ? {
+            ...state,
+            sandboxId: sandbox.sandboxId,
+            snapshotSandboxId: undefined,
+            snapshotSupported: supportsVercelSnapshot(sandbox),
+            exposedPorts: undefined,
+          }
+        : {
+            ...state,
+            snapshotSupported: supportsVercelSnapshot(sandbox),
+          },
+      sandbox,
+    });
+    try {
+      await waitForVercelSandboxRunning(session);
+      await session.prepareWorkspaceRoot();
+    } catch (error) {
+      if (!resumeFromSnapshot) {
+        throw error;
+      }
+      try {
+        await stopVercelSandbox(sandbox);
+      } catch (stopError) {
+        throw new UserError(
+          `Failed to resume a Vercel sandbox from snapshot and stop the replacement sandbox. Resume error: ${errorMessage(error)} Stop error: ${errorMessage(stopError)}`,
+        );
+      }
+      throw error;
+    }
+    return session;
+  }
+}
+
+async function loadVercelSandboxClass(): Promise<VercelSandboxClass> {
+  try {
+    const { Sandbox } = await import('@vercel/sandbox');
+    if (!Sandbox) {
+      throw new Error('Missing Sandbox export from @vercel/sandbox.');
+    }
+    return adaptVercelSandboxClass(Sandbox);
+  } catch (error) {
+    throw new UserError(
+      `Vercel sandbox support requires the optional \`@vercel/sandbox\` package. Install it before using Vercel-backed sandbox examples. ${(error as Error).message}`,
+    );
+  }
+}
+
+function adaptVercelSandboxClass(
+  Sandbox: VercelSdkSandboxClass,
+): VercelSandboxClass {
+  return {
+    create: async (params) =>
+      adaptVercelSandbox(await Sandbox.create(params as VercelSdkCreateParams)),
+    get: async (params) =>
+      adaptVercelSandbox(await Sandbox.get(params as VercelSdkGetParams)),
+  };
+}
+
+function adaptVercelSandbox(sandbox: VercelSdkSandbox): VercelSandboxInstance {
+  const optionalSandbox = sandbox as VercelSdkSandbox & {
+    domain?: (port: number) => string;
+    stop?: (params?: { blocking?: boolean }) => Promise<unknown>;
+    snapshot?: (params?: {
+      expiration?: number;
+    }) => Promise<{ snapshotId?: string }>;
+  };
+  const adapted: VercelSandboxInstance = {
+    sandboxId: sandbox.sandboxId,
+    runCommand: async (params) =>
+      adaptVercelCommandFinished(
+        await sandbox.runCommand(params as VercelSdkRunCommandParams),
+      ),
+    mkDir: async (path) => await sandbox.mkDir(path),
+    readFileToBuffer: async (file) => await sandbox.readFileToBuffer(file),
+    writeFiles: async (files) => await sandbox.writeFiles(files),
+  };
+  if (typeof optionalSandbox.domain === 'function') {
+    const domain = optionalSandbox.domain.bind(sandbox);
+    adapted.domain = (port) => domain(port);
+  }
+  if (typeof optionalSandbox.stop === 'function') {
+    const stop = optionalSandbox.stop.bind(sandbox);
+    adapted.stop = async (params) => await stop(params);
+  }
+  if (typeof optionalSandbox.snapshot === 'function') {
+    const snapshotFn = optionalSandbox.snapshot.bind(sandbox);
+    adapted.snapshot = async (params) => {
+      const snapshot = await snapshotFn(params);
+      return { snapshotId: snapshot.snapshotId };
+    };
+  }
+  return adapted;
+}
+
+function adaptVercelCommandFinished(
+  command: import('@vercel/sandbox').CommandFinished,
+): VercelCommandFinishedLike {
+  return {
+    exitCode: command.exitCode,
+    output: async (stream) => await command.output(stream),
+  };
+}
+
+function resolveManifestRoot(manifest: Manifest): Manifest {
+  if (manifest.root === '/workspace') {
+    return cloneManifestWithRoot(manifest, DEFAULT_VERCEL_WORKSPACE_ROOT);
+  }
+
+  if (
+    manifest.root === DEFAULT_VERCEL_WORKSPACE_ROOT ||
+    manifest.root.startsWith(`${DEFAULT_VERCEL_WORKSPACE_ROOT}/`)
+  ) {
+    return manifest;
+  }
+
+  throw new UserError(
+    `Vercel sandboxes require manifest.root to stay within "${DEFAULT_VERCEL_WORKSPACE_ROOT}".`,
+  );
+}
+
+function pickVercelCredentials(
+  options: VercelCredentials,
+): Record<string, string> {
+  const credentials: Record<string, string> = {};
+  if (!options.token) {
+    return credentials;
+  }
+  if (options.projectId) {
+    credentials.projectId = options.projectId;
+  }
+  if (options.teamId) {
+    credentials.teamId = options.teamId;
+  }
+  if (options.token) {
+    credentials.token = options.token;
+  }
+  return credentials;
+}
+
+async function resolveVercelCredentials(
+  options: VercelCredentials,
+): Promise<Record<string, string>> {
+  const envOptions = {
+    projectId: process.env.VERCEL_PROJECT_ID,
+    teamId: process.env.VERCEL_TEAM_ID,
+    token: process.env.VERCEL_TOKEN,
+  };
+  const layeredCredentials = pickVercelCredentials({
+    projectId: options.projectId ?? envOptions.projectId,
+    teamId: options.teamId ?? envOptions.teamId,
+    token: options.token ?? envOptions.token,
+  });
+  if (Object.keys(layeredCredentials).length > 0) {
+    return layeredCredentials;
+  }
+
+  if (hasAnyVercelCredentialOption(options)) {
+    return {};
+  }
+
+  return (await resolveVercelCliCredentials()) ?? {};
+}
+
+function hasAnyVercelCredentialOption(options: VercelCredentials): boolean {
+  return Boolean(options.projectId || options.teamId || options.token);
+}
+
+async function resolveVercelCliCredentials(): Promise<
+  Record<string, string> | undefined
+> {
+  if (process.env.NODE_ENV === 'test' && !process.env.VERCEL_AUTH_CONFIG_DIR) {
+    return undefined;
+  }
+
+  let authModule: VercelAuthModule;
+  try {
+    authModule = await import('@vercel/sandbox/dist/auth/index.js');
+  } catch {
+    return undefined;
+  }
+
+  let auth = authModule.getAuth();
+  if (!auth?.token && !auth?.refreshToken) {
+    return undefined;
+  }
+
+  if (auth?.expiresAt && auth.expiresAt.getTime() <= Date.now()) {
+    if (!auth.refreshToken) {
+      return undefined;
+    }
+    const refreshed = await (
+      await authModule.OAuth()
+    ).refreshToken(auth.refreshToken);
+    auth = {
+      expiresAt: new Date(Date.now() + refreshed.expires_in * 1_000),
+      token: refreshed.access_token,
+      refreshToken: refreshed.refresh_token ?? auth.refreshToken,
+    };
+    try {
+      authModule.updateAuthConfig(auth);
+    } catch {
+      // The refreshed token is still usable for this process.
+    }
+  }
+
+  if (!auth?.token) {
+    return undefined;
+  }
+
+  const linkedProject = findLinkedVercelProject();
+  if (!linkedProject) {
+    return undefined;
+  }
+
+  return {
+    token: auth.token,
+    projectId: linkedProject.projectId,
+    teamId: linkedProject.teamId,
+  };
+}
+
+function findLinkedVercelProject():
+  | { projectId: string; teamId: string }
+  | undefined {
+  const candidateCwds = [
+    process.env.INIT_CWD,
+    process.env.PWD,
+    process.cwd(),
+  ].filter((value): value is string => Boolean(value));
+
+  for (const cwd of candidateCwds) {
+    const projectPath = findUpVercelProjectFile(cwd);
+    if (!projectPath) {
+      continue;
+    }
+    try {
+      const data = JSON.parse(readFileSync(projectPath, 'utf8')) as Record<
+        string,
+        unknown
+      >;
+      if (
+        typeof data.projectId === 'string' &&
+        typeof data.orgId === 'string'
+      ) {
+        return {
+          projectId: data.projectId,
+          teamId: data.orgId,
+        };
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return undefined;
+}
+
+function findUpVercelProjectFile(startDir: string): string | undefined {
+  let current = pathResolve(startDir);
+  while (true) {
+    const candidate = pathJoin(current, '.vercel', 'project.json');
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = pathDirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    current = parent;
+  }
+}
+
+async function captureVercelSnapshot(
+  state: VercelSandboxSessionState,
+  args: {
+    sandbox?: VercelSandboxInstance;
+    options?: Pick<
+      VercelSandboxClientOptions,
+      'projectId' | 'teamId' | 'token'
+    >;
+  } = {},
+): Promise<void> {
+  if (state.workspacePersistence !== 'snapshot') {
+    return;
+  }
+
+  let sandbox = args.sandbox;
+  if (!sandbox) {
+    const credentials = await resolveVercelCredentials({
+      projectId: state.projectId ?? args.options?.projectId,
+      teamId: state.teamId ?? args.options?.teamId,
+      token: state.token ?? args.options?.token,
+    });
+    sandbox = await withProviderError(
+      'VercelSandboxClient',
+      'vercel',
+      'look up sandbox for snapshot',
+      async () =>
+        await (
+          await loadVercelSandboxClass()
+        ).get({
+          sandboxId: state.sandboxId,
+          ...credentials,
+        }),
+      { sandboxId: state.sandboxId },
+    );
+  }
+  state.snapshotSupported = supportsVercelSnapshot(sandbox);
+  if (!state.snapshotSupported) {
+    throw new UserError(
+      'Vercel snapshot persistence requires @vercel/sandbox snapshot support.',
+    );
+  }
+
+  const snapshot = await withSandboxSpan(
+    'sandbox.snapshot',
+    {
+      backend_id: 'vercel',
+      sandbox_id: state.sandboxId,
+    },
+    async () =>
+      await withProviderError(
+        'VercelSandboxClient',
+        'vercel',
+        'capture snapshot',
+        async () =>
+          await sandbox.snapshot!({
+            expiration: state.snapshotExpirationMs,
+          }),
+        { sandboxId: state.sandboxId },
+      ),
+  );
+  if (!snapshot.snapshotId) {
+    throw new UserError(
+      'Vercel snapshot persistence did not return a snapshotId.',
+    );
+  }
+  state.snapshotId = snapshot.snapshotId;
+  state.snapshotSandboxId = sandbox.sandboxId;
+}
+
+function supportsVercelSnapshot(sandbox: VercelSandboxInstance): boolean {
+  return typeof sandbox.snapshot === 'function';
+}
+
+function hasFreshVercelSnapshot(state: VercelSandboxSessionState): boolean {
+  return Boolean(
+    state.snapshotId && state.snapshotSandboxId === state.sandboxId,
+  );
+}
+
+async function stopVercelSandbox(
+  sandbox: VercelSandboxInstance,
+): Promise<void> {
+  if (!sandbox.stop) {
+    return;
+  }
+
+  await withSandboxSpan(
+    'sandbox.stop',
+    {
+      backend_id: 'vercel',
+      sandbox_id: sandbox.sandboxId,
+    },
+    async () => {
+      await sandbox.stop!({ blocking: true });
+    },
+  );
+}
+
+async function waitForVercelSandboxRunning(
+  session: VercelSandboxSession,
+  timeoutMs: number = 30_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    if (await session.running()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new SandboxLifecycleError(
+    `Vercel sandbox ${session.state.sandboxId} did not become runnable within ${timeoutMs}ms.`,
+    {
+      provider: 'vercel',
+      sandboxId: session.state.sandboxId,
+      timeoutMs,
+    },
+  );
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function assertFilesystemRunAs(runAs?: string): void {
+  if (runAs && runAs !== 'root') {
+    assertRunAsUnsupported('VercelSandboxClient', runAs);
+  }
+  if (runAs === 'root') {
+    throw new SandboxUnsupportedFeatureError(
+      'VercelSandboxClient does not support runAs for filesystem operations.',
+      {
+        provider: 'vercel',
+        feature: 'runAs',
+      },
+    );
+  }
+}
+
+function isVercelAlreadyExistsError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const json = 'json' in error ? error.json : undefined;
+  if (!json || typeof json !== 'object') {
+    return false;
+  }
+
+  const payload = 'error' in json ? json.error : undefined;
+  if (!payload || typeof payload !== 'object') {
+    return false;
+  }
+
+  const code = 'code' in payload ? payload.code : undefined;
+  const message = 'message' in payload ? payload.message : undefined;
+  return (
+    code === 'file_error' &&
+    typeof message === 'string' &&
+    message.includes('File exists')
+  );
+}

--- a/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
@@ -740,7 +740,7 @@ export class VercelSandboxClient implements SandboxClient<
             sandboxId: sandbox.sandboxId,
             projectId: resolvedOptions.projectId ?? credentials.projectId,
             teamId: resolvedOptions.teamId ?? credentials.teamId,
-            token: resolvedOptions.token,
+            token: credentials.token,
             runtime: resolvedOptions.runtime,
             resources: resolvedOptions.resources,
             configuredExposedPorts: resolvedOptions.exposedPorts,

--- a/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
@@ -38,6 +38,7 @@ import {
   readOptionalRecord,
   readOptionalString,
   readString,
+  isProviderSandboxNotFoundError,
   withProviderError,
   withSandboxSpan,
   RemoteSandboxSessionBase,
@@ -419,7 +420,10 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
     try {
       await stopVercelSandbox(previousSandbox);
     } catch (error) {
-      if (options.ignorePreviousStopFailure) {
+      if (
+        options.ignorePreviousStopFailure &&
+        isVercelSandboxAlreadyStoppedError(error)
+      ) {
         this.bindRestoredSandbox(
           sandbox,
           snapshotId,
@@ -1390,6 +1394,22 @@ async function waitForVercelSandboxRunning(
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function isVercelSandboxAlreadyStoppedError(error: unknown): boolean {
+  if (isProviderSandboxNotFoundError(error)) {
+    return true;
+  }
+
+  const message = errorMessage(error);
+  return (
+    /\b(sandbox|sandbox instance|instance)\b.*\b(already\s+)?(stopped|terminated|not running)\b/iu.test(
+      message,
+    ) ||
+    /\b(already\s+)?(stopped|terminated|not running)\b.*\b(sandbox|sandbox instance|instance)\b/iu.test(
+      message,
+    )
+  );
 }
 
 function assertFilesystemRunAs(runAs?: string): void {

--- a/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
@@ -123,7 +123,7 @@ type VercelSandboxInstance = {
     }[],
   ): Promise<void>;
   domain?(port: number): string;
-  stop?(params?: { blocking?: boolean }): Promise<unknown>;
+  stop?(): Promise<unknown>;
   snapshot?(params?: { expiration?: number }): Promise<{ snapshotId?: string }>;
 };
 
@@ -984,7 +984,7 @@ function adaptVercelSandboxClass(
 function adaptVercelSandbox(sandbox: VercelSdkSandbox): VercelSandboxInstance {
   const optionalSandbox = sandbox as VercelSdkSandbox & {
     domain?: (port: number) => string;
-    stop?: (params?: { blocking?: boolean }) => Promise<unknown>;
+    stop?: () => Promise<unknown>;
     snapshot?: (params?: {
       expiration?: number;
     }) => Promise<{ snapshotId?: string }>;
@@ -1005,7 +1005,7 @@ function adaptVercelSandbox(sandbox: VercelSdkSandbox): VercelSandboxInstance {
   }
   if (typeof optionalSandbox.stop === 'function') {
     const stop = optionalSandbox.stop.bind(sandbox);
-    adapted.stop = async (params) => await stop(params);
+    adapted.stop = async () => await stop();
   }
   if (typeof optionalSandbox.snapshot === 'function') {
     const snapshotFn = optionalSandbox.snapshot.bind(sandbox);
@@ -1362,7 +1362,7 @@ async function stopVercelSandbox(
       sandbox_id: sandbox.sandboxId,
     },
     async () => {
-      await sandbox.stop!({ blocking: true });
+      await sandbox.stop!();
     },
   );
 }

--- a/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
@@ -463,6 +463,7 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
       ...this.credentials,
       projectId: this.state.projectId ?? this.credentials.projectId,
       teamId: this.state.teamId ?? this.credentials.teamId,
+      token: this.state.token ?? this.credentials.token,
     });
     applyResolvedVercelCredentials(this.state, credentials);
     return credentials;

--- a/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
@@ -1077,10 +1077,14 @@ async function resolveVercelCredentials(
     token: options.token ?? envOptions.token,
   });
   if (layeredCredentials.token) {
-    return (
-      (await refreshLayeredVercelCliCredentials(layeredCredentials)) ??
-      layeredCredentials
-    );
+    const refreshedCredentials =
+      await refreshLayeredVercelCliCredentials(layeredCredentials);
+    if (refreshedCredentials === null) {
+      const { token: _token, ...credentialsWithoutToken } = layeredCredentials;
+      void _token;
+      return credentialsWithoutToken;
+    }
+    return refreshedCredentials ?? layeredCredentials;
   }
 
   if (Object.keys(layeredCredentials).length > 0) {
@@ -1137,7 +1141,7 @@ async function resolveVercelCliAuthToken(): Promise<string | undefined> {
 
 async function refreshLayeredVercelCliCredentials(
   credentials: Record<string, string>,
-): Promise<Record<string, string> | undefined> {
+): Promise<Record<string, string> | null | undefined> {
   if (!credentials.token) {
     return undefined;
   }
@@ -1154,7 +1158,7 @@ async function refreshLayeredVercelCliCredentials(
 
   const resolvedAuth = await resolveVercelCliAuth(authModule, auth);
   if (!resolvedAuth?.token) {
-    return undefined;
+    return null;
   }
 
   return {
@@ -1218,6 +1222,8 @@ function applyResolvedVercelCredentials(
   }
   if (credentials.token) {
     state.token = credentials.token;
+  } else {
+    delete state.token;
   }
 }
 

--- a/packages/agents-extensions/test/sandbox/vercel.test.ts
+++ b/packages/agents-extensions/test/sandbox/vercel.test.ts
@@ -316,6 +316,45 @@ describe('VercelSandboxClient', () => {
     }
   });
 
+  test('uses Vercel CLI auth token without a linked project', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'vercel-cli-auth-'));
+    const authDir = join(root, 'auth');
+    const projectRoot = join(root, 'project');
+    mkdirSync(authDir, { recursive: true });
+    mkdirSync(projectRoot, { recursive: true });
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(projectRoot);
+    getAuthMock.mockReturnValue({
+      token: 'cli_access_token',
+      refreshToken: 'cli_refresh_token',
+      expiresAt: new Date(Date.now() + 3_600_000),
+    });
+    vi.stubEnv('VERCEL_AUTH_CONFIG_DIR', authDir);
+    vi.stubEnv('INIT_CWD', projectRoot);
+    vi.stubEnv('PWD', projectRoot);
+
+    try {
+      const client = new VercelSandboxClient();
+
+      await client.create(new Manifest());
+
+      expect(createMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token: 'cli_access_token',
+        }),
+      );
+      expect(createMock).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          projectId: expect.any(String),
+          teamId: expect.any(String),
+        }),
+      );
+    } finally {
+      cwdSpy.mockRestore();
+      vi.unstubAllEnvs();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test('serializes Vercel CLI credentials resolved during create', async () => {
     const root = mkdtempSync(join(tmpdir(), 'vercel-cli-auth-'));
     const authDir = join(root, 'auth');
@@ -1269,6 +1308,22 @@ describe('VercelSandboxClient', () => {
     expect(stopMock).toHaveBeenCalledOnce();
   });
 
+  test('ignores stop failures after a close snapshot already shut down the sandbox', async () => {
+    stopMock.mockRejectedValueOnce(new Error('sandbox already stopped'));
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workspacePersistence: 'snapshot',
+    });
+
+    await expect(session.close()).resolves.toBeUndefined();
+    await session.delete();
+
+    expect(snapshotMock).toHaveBeenCalledOnce();
+    expect(stopMock).toHaveBeenCalledOnce();
+    expect(session.state.snapshotId).toBe('snap_test');
+    expect(session.state.snapshotSandboxId).toBe('vercel_test');
+  });
+
   test('invalidates snapshot freshness after workspace writes', async () => {
     const client = new VercelSandboxClient();
     const session = await client.create(new Manifest(), {
@@ -1487,6 +1542,43 @@ describe('VercelSandboxClient', () => {
       args: ['-lc', 'echo after-persist'],
       cwd: '/vercel/sandbox',
       env: {},
+    });
+  });
+
+  test('keeps restored snapshot persistence when the snapshotted source is already stopped', async () => {
+    const sourceStopMock = vi
+      .fn()
+      .mockRejectedValue(new Error('sandbox already stopped'));
+    const replacementStopMock = vi.fn().mockResolvedValue(undefined);
+    createMock
+      .mockResolvedValueOnce(
+        makeSandbox('vercel_source', {
+          stop: sourceStopMock,
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeSandbox('vercel_replacement', {
+          stop: replacementStopMock,
+        }),
+      );
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workspacePersistence: 'snapshot',
+    });
+
+    await expect(session.persistWorkspace()).resolves.toEqual(
+      encodeNativeSnapshotRef({
+        provider: 'vercel',
+        snapshotId: 'snap_test',
+      }),
+    );
+
+    expect(sourceStopMock).toHaveBeenCalledOnce();
+    expect(replacementStopMock).not.toHaveBeenCalled();
+    expect(session.state).toMatchObject({
+      sandboxId: 'vercel_replacement',
+      snapshotId: 'snap_test',
+      snapshotSandboxId: 'vercel_replacement',
     });
   });
 

--- a/packages/agents-extensions/test/sandbox/vercel.test.ts
+++ b/packages/agents-extensions/test/sandbox/vercel.test.ts
@@ -1142,7 +1142,7 @@ describe('VercelSandboxClient', () => {
     await session.close();
 
     expect(snapshotMock).toHaveBeenCalledOnce();
-    expect(stopMock).toHaveBeenCalledOnce();
+    expect(stopMock).toHaveBeenCalledTimes(2);
   });
 
   test('persists and hydrates tar workspaces through safe archive helpers', async () => {
@@ -1277,12 +1277,17 @@ describe('VercelSandboxClient', () => {
   });
 
   test('rebinds live snapshot persistence to a replacement sandbox', async () => {
+    const sourceStopMock = vi.fn().mockResolvedValue(undefined);
     const replacementRunCommandMock = vi.fn(async () => ({
       exitCode: 0,
       output: vi.fn().mockResolvedValue('replacement\n'),
     }));
     createMock
-      .mockResolvedValueOnce(makeSandbox('vercel_source'))
+      .mockResolvedValueOnce(
+        makeSandbox('vercel_source', {
+          stop: sourceStopMock,
+        }),
+      )
       .mockResolvedValueOnce(
         makeSandbox('vercel_replacement', {
           runCommand: replacementRunCommandMock,
@@ -1309,6 +1314,7 @@ describe('VercelSandboxClient', () => {
         },
       }),
     );
+    expect(sourceStopMock).toHaveBeenCalledOnce();
     expect(stopMock).not.toHaveBeenCalled();
     expect(session.state).toMatchObject({
       sandboxId: 'vercel_replacement',
@@ -1330,6 +1336,45 @@ describe('VercelSandboxClient', () => {
       args: ['-lc', 'echo after-persist'],
       cwd: '/vercel/sandbox',
       env: {},
+    });
+  });
+
+  test('stops each previous sandbox during repeated snapshot persistence', async () => {
+    const sourceStopMock = vi.fn().mockResolvedValue(undefined);
+    const firstReplacementStopMock = vi.fn().mockResolvedValue(undefined);
+    const secondReplacementStopMock = vi.fn().mockResolvedValue(undefined);
+    createMock
+      .mockResolvedValueOnce(
+        makeSandbox('vercel_source', {
+          stop: sourceStopMock,
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeSandbox('vercel_replacement_1', {
+          stop: firstReplacementStopMock,
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeSandbox('vercel_replacement_2', {
+          stop: secondReplacementStopMock,
+        }),
+      );
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workspacePersistence: 'snapshot',
+    });
+
+    await session.persistWorkspace();
+    await session.persistWorkspace();
+
+    expect(sourceStopMock).toHaveBeenCalledOnce();
+    expect(firstReplacementStopMock).toHaveBeenCalledOnce();
+    expect(secondReplacementStopMock).not.toHaveBeenCalled();
+    expect(stopMock).not.toHaveBeenCalled();
+    expect(session.state).toMatchObject({
+      sandboxId: 'vercel_replacement_2',
+      snapshotId: 'snap_test',
+      snapshotSandboxId: 'vercel_replacement_2',
     });
   });
 
@@ -1359,6 +1404,7 @@ describe('VercelSandboxClient', () => {
       snapshotId: 'snap_test',
     });
     expect(createMock).toHaveBeenCalledTimes(2);
+    expect(stopMock).toHaveBeenCalledOnce();
     expect(session.state).toMatchObject({
       sandboxId: 'vercel_recovered',
       snapshotId: 'snap_test',

--- a/packages/agents-extensions/test/sandbox/vercel.test.ts
+++ b/packages/agents-extensions/test/sandbox/vercel.test.ts
@@ -278,6 +278,66 @@ describe('VercelSandboxClient', () => {
     }
   });
 
+  test('serializes Vercel CLI credentials resolved during create', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'vercel-cli-auth-'));
+    const authDir = join(root, 'auth');
+    const projectRoot = join(root, 'project');
+    mkdirSync(authDir, { recursive: true });
+    mkdirSync(join(projectRoot, '.vercel'), { recursive: true });
+    getAuthMock.mockReturnValue({
+      token: 'cli_access_token',
+      refreshToken: 'cli_refresh_token',
+      expiresAt: new Date(Date.now() + 3_600_000),
+    });
+    writeFileSync(
+      join(projectRoot, '.vercel', 'project.json'),
+      JSON.stringify({
+        projectId: 'prj_cli',
+        orgId: 'team_cli',
+        projectName: 'sandbox-tests',
+      }),
+    );
+    vi.stubEnv('VERCEL_AUTH_CONFIG_DIR', authDir);
+    vi.stubEnv('INIT_CWD', projectRoot);
+
+    let session: Awaited<ReturnType<VercelSandboxClient['create']>> | undefined;
+    try {
+      const client = new VercelSandboxClient();
+      session = await client.create(new Manifest(), {
+        workspacePersistence: 'snapshot',
+      });
+      expect(session.state.token).toBe('cli_access_token');
+    } finally {
+      vi.unstubAllEnvs();
+      rmSync(root, { recursive: true, force: true });
+    }
+    if (!session) {
+      throw new Error('Expected Vercel sandbox session.');
+    }
+
+    const client = new VercelSandboxClient();
+    getMock.mockClear();
+
+    const serialized = await client.serializeSessionState(session.state, {
+      willCloseAfterSerialize: true,
+    });
+
+    expect(getMock).toHaveBeenCalledWith({
+      sandboxId: 'vercel_test',
+      projectId: 'prj_cli',
+      teamId: 'team_cli',
+      token: 'cli_access_token',
+    });
+    expect(serialized).toMatchObject({
+      projectId: 'prj_cli',
+      teamId: 'team_cli',
+      token: 'cli_access_token',
+      sandboxId: 'vercel_test',
+      workspacePersistence: 'snapshot',
+      snapshotId: 'snap_test',
+    });
+  });
+
   test('passes complete access token credentials to Vercel', async () => {
     const client = new VercelSandboxClient({
       projectId: 'prj_access_token',

--- a/packages/agents-extensions/test/sandbox/vercel.test.ts
+++ b/packages/agents-extensions/test/sandbox/vercel.test.ts
@@ -1582,6 +1582,48 @@ describe('VercelSandboxClient', () => {
     });
   });
 
+  test('does not rebind snapshot persistence when the previous sandbox stop fails', async () => {
+    const sourceStopMock = vi
+      .fn()
+      .mockRejectedValue(new Error('network timeout'));
+    const firstReplacementStopMock = vi.fn().mockResolvedValue(undefined);
+    const secondReplacementStopMock = vi.fn().mockResolvedValue(undefined);
+    createMock
+      .mockResolvedValueOnce(
+        makeSandbox('vercel_source', {
+          stop: sourceStopMock,
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeSandbox('vercel_replacement_1', {
+          stop: firstReplacementStopMock,
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeSandbox('vercel_replacement_2', {
+          stop: secondReplacementStopMock,
+        }),
+      );
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workspacePersistence: 'snapshot',
+    });
+
+    await expect(session.persistWorkspace()).rejects.toMatchObject({
+      details: {
+        provider: 'vercel',
+        sandboxId: 'vercel_source',
+        snapshotId: 'snap_test',
+      },
+    });
+
+    expect(sourceStopMock).toHaveBeenCalledTimes(2);
+    expect(firstReplacementStopMock).toHaveBeenCalledOnce();
+    expect(secondReplacementStopMock).toHaveBeenCalledOnce();
+    expect(session.state.sandboxId).toBe('vercel_source');
+    expect(session.state.snapshotSandboxId).toBe('vercel_source');
+  });
+
   test('uses refreshed state token when restoring persisted snapshots', async () => {
     createMock
       .mockResolvedValueOnce(makeSandbox('vercel_source'))

--- a/packages/agents-extensions/test/sandbox/vercel.test.ts
+++ b/packages/agents-extensions/test/sandbox/vercel.test.ts
@@ -238,6 +238,44 @@ describe('VercelSandboxClient', () => {
     }
   });
 
+  test('merges explicit project credentials with Vercel CLI access token', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'vercel-cli-auth-'));
+    const authDir = join(root, 'auth');
+    const projectRoot = join(root, 'project');
+    mkdirSync(authDir, { recursive: true });
+    mkdirSync(projectRoot, { recursive: true });
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(projectRoot);
+    getAuthMock.mockReturnValue({
+      token: 'cli_access_token',
+      refreshToken: 'cli_refresh_token',
+      expiresAt: new Date(Date.now() + 3_600_000),
+    });
+    vi.stubEnv('VERCEL_AUTH_CONFIG_DIR', authDir);
+    vi.stubEnv('INIT_CWD', projectRoot);
+    vi.stubEnv('PWD', projectRoot);
+
+    try {
+      const client = new VercelSandboxClient({
+        projectId: 'prj_explicit',
+        teamId: 'team_explicit',
+      });
+
+      await client.create(new Manifest());
+
+      expect(createMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: 'prj_explicit',
+          teamId: 'team_explicit',
+          token: 'cli_access_token',
+        }),
+      );
+    } finally {
+      cwdSpy.mockRestore();
+      vi.unstubAllEnvs();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test('uses Vercel CLI auth and linked project when no explicit credentials are provided', async () => {
     const root = mkdtempSync(join(tmpdir(), 'vercel-cli-auth-'));
     const authDir = join(root, 'auth');

--- a/packages/agents-extensions/test/sandbox/vercel.test.ts
+++ b/packages/agents-extensions/test/sandbox/vercel.test.ts
@@ -743,6 +743,59 @@ describe('VercelSandboxClient', () => {
     );
   });
 
+  test('refreshes expired serialized CLI credentials when resuming live sandboxes', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'vercel-cli-refresh-'));
+    const authDir = join(root, 'auth');
+    mkdirSync(authDir, { recursive: true });
+    getAuthMock.mockReturnValue({
+      token: 'cli_access_token',
+      refreshToken: 'cli_refresh_token',
+      expiresAt: new Date(Date.now() - 1_000),
+    });
+    refreshTokenMock.mockResolvedValue({
+      access_token: 'cli_refreshed_token',
+      expires_in: 3_600,
+      refresh_token: 'cli_next_refresh_token',
+    });
+    vi.stubEnv('VERCEL_AUTH_CONFIG_DIR', authDir);
+
+    try {
+      const client = new VercelSandboxClient();
+      const state = await client.deserializeSessionState({
+        manifest: new Manifest(),
+        sandboxId: 'vercel_existing',
+        workspacePersistence: 'tar',
+        environment: {},
+        projectId: 'prj_serialized',
+        teamId: 'team_serialized',
+        token: 'cli_access_token',
+      });
+
+      await client.resume(state);
+
+      expect(refreshTokenMock).toHaveBeenCalledWith('cli_refresh_token');
+      expect(updateAuthConfigMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token: 'cli_refreshed_token',
+          refreshToken: 'cli_next_refresh_token',
+          expiresAt: expect.any(Date),
+        }),
+      );
+      expect(getMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sandboxId: 'vercel_existing',
+          projectId: 'prj_serialized',
+          teamId: 'team_serialized',
+          token: 'cli_refreshed_token',
+        }),
+      );
+      expect(state.token).toBe('cli_refreshed_token');
+    } finally {
+      vi.unstubAllEnvs();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test('retains serialized access token credentials when resuming snapshot sandboxes', async () => {
     createMock.mockResolvedValueOnce(makeSandbox('vercel_restored'));
     const client = new VercelSandboxClient();

--- a/packages/agents-extensions/test/sandbox/vercel.test.ts
+++ b/packages/agents-extensions/test/sandbox/vercel.test.ts
@@ -1756,6 +1756,7 @@ describe('VercelSandboxClient', () => {
     await session.delete();
 
     expect(stopMock).toHaveBeenCalledOnce();
+    expect(stopMock).toHaveBeenCalledWith();
   });
 
   test('retries close after a stop failure', async () => {

--- a/packages/agents-extensions/test/sandbox/vercel.test.ts
+++ b/packages/agents-extensions/test/sandbox/vercel.test.ts
@@ -1452,6 +1452,37 @@ describe('VercelSandboxClient', () => {
     });
   });
 
+  test('uses refreshed state token when restoring persisted snapshots', async () => {
+    createMock
+      .mockResolvedValueOnce(makeSandbox('vercel_source'))
+      .mockResolvedValueOnce(makeSandbox('vercel_replacement'));
+    const client = new VercelSandboxClient({
+      projectId: 'prj_cli',
+      teamId: 'team_cli',
+      token: 'cli_access_token',
+    });
+    const session = await client.create(new Manifest(), {
+      workspacePersistence: 'snapshot',
+    });
+    session.state.token = 'cli_refreshed_token';
+    createMock.mockClear();
+
+    await session.persistWorkspace();
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'prj_cli',
+        teamId: 'team_cli',
+        token: 'cli_refreshed_token',
+        source: {
+          type: 'snapshot',
+          snapshotId: 'snap_test',
+        },
+      }),
+    );
+    expect(session.state.token).toBe('cli_refreshed_token');
+  });
+
   test('stops each previous sandbox during repeated snapshot persistence', async () => {
     const sourceStopMock = vi.fn().mockResolvedValue(undefined);
     const firstReplacementStopMock = vi.fn().mockResolvedValue(undefined);

--- a/packages/agents-extensions/test/sandbox/vercel.test.ts
+++ b/packages/agents-extensions/test/sandbox/vercel.test.ts
@@ -1,0 +1,1563 @@
+import {
+  Manifest,
+  SandboxArchiveError,
+  SandboxLifecycleError,
+  SandboxProviderError,
+  SandboxUnsupportedFeatureError,
+} from '@openai/agents-core/sandbox';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  decodeNativeSnapshotRef,
+  encodeNativeSnapshotRef,
+} from '../../src/sandbox/shared';
+import { VercelSandboxClient } from '../../src/sandbox/vercel';
+import { resolvedRemotePathFromValidationCommand } from './remotePathValidation';
+import { makeTarArchive } from './tarFixture';
+
+const createMock = vi.fn();
+const getMock = vi.fn();
+const runCommandMock = vi.fn();
+const mkDirMock = vi.fn();
+const readFileToBufferMock = vi.fn();
+const writeFilesMock = vi.fn();
+const stopMock = vi.fn();
+const snapshotMock = vi.fn();
+const domainMock = vi.fn();
+const getAuthMock = vi.fn();
+const refreshTokenMock = vi.fn();
+const updateAuthConfigMock = vi.fn();
+const remoteFilePaths = new Set<string>();
+
+function makeSandbox(
+  sandboxId: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    sandboxId,
+    runCommand: runCommandMock,
+    mkDir: mkDirMock,
+    readFileToBuffer: readFileToBufferMock,
+    writeFiles: writeFilesMock,
+    stop: stopMock,
+    snapshot: snapshotMock,
+    domain: domainMock,
+    ...overrides,
+  };
+}
+
+function vercelAlreadyExistsError(path: string): unknown {
+  return {
+    json: {
+      error: {
+        code: 'file_error',
+        message: `error creating directory: cannot create directory '${path}': File exists`,
+      },
+    },
+  };
+}
+
+function testExistsPath(command: string): string | undefined {
+  return command.match(/^test -e '([^']+)'$/u)?.[1];
+}
+
+vi.mock('@vercel/sandbox', () => ({
+  Sandbox: {
+    create: createMock,
+    get: getMock,
+  },
+}));
+
+vi.mock('@vercel/sandbox/dist/auth/index.js', () => ({
+  getAuth: getAuthMock,
+  OAuth: async () => ({
+    refreshToken: refreshTokenMock,
+  }),
+  updateAuthConfig: updateAuthConfigMock,
+}));
+
+describe('VercelSandboxClient', () => {
+  beforeEach(() => {
+    createMock.mockReset();
+    getMock.mockReset();
+    runCommandMock.mockReset();
+    mkDirMock.mockReset();
+    readFileToBufferMock.mockReset();
+    writeFilesMock.mockReset();
+    stopMock.mockReset();
+    snapshotMock.mockReset();
+    domainMock.mockReset();
+    getAuthMock.mockReset();
+    refreshTokenMock.mockReset();
+    updateAuthConfigMock.mockReset();
+    remoteFilePaths.clear();
+
+    createMock.mockResolvedValue(makeSandbox('vercel_test'));
+    getMock.mockResolvedValue(makeSandbox('vercel_test'));
+    runCommandMock.mockImplementation(
+      async (params: { args?: string[] } = {}) => {
+        const command = params.args?.[1] ?? '';
+        const path = testExistsPath(command);
+        if (path) {
+          return {
+            exitCode: remoteFilePaths.has(path) ? 0 : 1,
+            output: vi.fn().mockResolvedValue(''),
+          };
+        }
+        const resolvedPath = resolvedRemotePathFromValidationCommand(command);
+        return {
+          exitCode: 0,
+          output: vi
+            .fn()
+            .mockResolvedValue(
+              resolvedPath ? `${resolvedPath}\n` : 'README.md\n',
+            ),
+        };
+      },
+    );
+    mkDirMock.mockResolvedValue(undefined);
+    readFileToBufferMock.mockResolvedValue(
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00]),
+    );
+    writeFilesMock.mockImplementation(
+      async (files: Array<{ path?: unknown }> = []) => {
+        for (const file of files) {
+          if (typeof file.path === 'string') {
+            remoteFilePaths.add(file.path);
+          }
+        }
+      },
+    );
+    stopMock.mockResolvedValue(undefined);
+    snapshotMock.mockResolvedValue({ snapshotId: 'snap_test' });
+    domainMock.mockReturnValue('https://3000-vercel.example.test');
+  });
+
+  test('rejects unsupported core create options instead of ignoring them', async () => {
+    const client = new VercelSandboxClient();
+
+    await expect(
+      client.create({
+        manifest: new Manifest(),
+        snapshot: { type: 'remote' },
+      }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+    await expect(
+      client.create({
+        manifest: new Manifest(),
+        concurrencyLimits: { manifestEntries: 2 },
+      }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('creates a sandbox, remaps the default root, and executes commands', async () => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          'README.md': {
+            type: 'file',
+            content: '# Hello\n',
+          },
+        },
+      }),
+    );
+    const output = await session.execCommand({ cmd: 'ls' });
+
+    expect(session.state.manifest.root).toBe('/vercel/sandbox');
+    expect(writeFilesMock).toHaveBeenCalledWith([
+      {
+        path: '/vercel/sandbox/README.md',
+        content: '# Hello\n',
+      },
+    ]);
+    expect(mkDirMock).not.toHaveBeenCalledWith('/vercel/sandbox');
+    expect(runCommandMock).toHaveBeenCalledWith({
+      cmd: '/bin/sh',
+      args: ['-lc', 'ls'],
+      cwd: '/vercel/sandbox',
+      env: {},
+    });
+    expect(output).toContain('README.md');
+  });
+
+  test('treats missing command exit codes as failures', async () => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest());
+    runCommandMock.mockResolvedValueOnce({
+      exitCode: null,
+      output: vi.fn().mockResolvedValue('lost exit\n'),
+    });
+
+    const output = await session.execCommand({ cmd: 'lost-exit' });
+
+    expect(output).toContain('Process exited with code 1');
+    expect(output).toContain('lost exit');
+  });
+
+  test('does not pass partial project credentials when using OIDC auth', async () => {
+    const client = new VercelSandboxClient({
+      projectId: 'prj_linked',
+      teamId: 'team_linked',
+    });
+
+    await client.create(new Manifest());
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        projectId: expect.any(String),
+        teamId: expect.any(String),
+      }),
+    );
+  });
+
+  test('merges explicit project credentials with env access token', async () => {
+    vi.stubEnv('VERCEL_PROJECT_ID', 'prj_env');
+    vi.stubEnv('VERCEL_TEAM_ID', 'team_env');
+    vi.stubEnv('VERCEL_TOKEN', 'env_token');
+    try {
+      const client = new VercelSandboxClient({
+        projectId: 'prj_explicit',
+        teamId: 'team_explicit',
+      });
+
+      await client.create(new Manifest());
+
+      expect(createMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: 'prj_explicit',
+          teamId: 'team_explicit',
+          token: 'env_token',
+        }),
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  test('uses Vercel CLI auth and linked project when no explicit credentials are provided', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'vercel-cli-auth-'));
+    const authDir = join(root, 'auth');
+    const projectRoot = join(root, 'project');
+    mkdirSync(authDir, { recursive: true });
+    mkdirSync(join(projectRoot, '.vercel'), { recursive: true });
+    getAuthMock.mockReturnValue({
+      token: 'cli_access_token',
+      refreshToken: 'cli_refresh_token',
+      expiresAt: new Date(Date.now() + 3_600_000),
+    });
+    writeFileSync(
+      join(projectRoot, '.vercel', 'project.json'),
+      JSON.stringify({
+        projectId: 'prj_cli',
+        orgId: 'team_cli',
+        projectName: 'sandbox-tests',
+      }),
+    );
+    vi.stubEnv('VERCEL_AUTH_CONFIG_DIR', authDir);
+    vi.stubEnv('INIT_CWD', projectRoot);
+
+    try {
+      const client = new VercelSandboxClient();
+
+      await client.create(new Manifest());
+
+      expect(createMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: 'prj_cli',
+          teamId: 'team_cli',
+          token: 'cli_access_token',
+        }),
+      );
+    } finally {
+      vi.unstubAllEnvs();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('passes complete access token credentials to Vercel', async () => {
+    const client = new VercelSandboxClient({
+      projectId: 'prj_access_token',
+      teamId: 'team_access_token',
+      token: 'vercel_test_token',
+    });
+
+    await client.create(new Manifest());
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'prj_access_token',
+        teamId: 'team_access_token',
+        token: 'vercel_test_token',
+      }),
+    );
+  });
+
+  test('preserves access token credentials when hydrating native snapshots', async () => {
+    const client = new VercelSandboxClient({
+      projectId: 'prj_access_token',
+      teamId: 'team_access_token',
+      token: 'vercel_test_token',
+    });
+    const session = await client.create(new Manifest(), {
+      workspacePersistence: 'snapshot',
+    });
+    createMock.mockClear();
+    createMock.mockResolvedValueOnce(makeSandbox('vercel_restored'));
+
+    await session.hydrateWorkspace(
+      encodeNativeSnapshotRef({
+        provider: 'vercel',
+        snapshotId: 'snap_restore',
+      }),
+    );
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'prj_access_token',
+        teamId: 'team_access_token',
+        token: 'vercel_test_token',
+        source: {
+          type: 'snapshot',
+          snapshotId: 'snap_restore',
+        },
+      }),
+    );
+  });
+
+  test('reuses resolved manifest environment values during create', async () => {
+    let tokenVersion = 0;
+    const resolveToken = vi.fn(async () => `token-${++tokenVersion}`);
+    const client = new VercelSandboxClient({
+      env: {
+        CLIENT_ENV: 'client',
+      },
+    });
+
+    const session = await client.create(
+      new Manifest({
+        environment: {
+          TOKEN: {
+            value: 'placeholder',
+            resolve: resolveToken,
+          },
+        },
+      }),
+    );
+
+    expect(resolveToken).toHaveBeenCalledOnce();
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: {
+          CLIENT_ENV: 'client',
+          TOKEN: 'token-1',
+        },
+      }),
+    );
+    expect(session.state.environment).toEqual({
+      CLIENT_ENV: 'client',
+      TOKEN: 'token-1',
+    });
+  });
+
+  test('rejects unsupported manifest metadata after remapping the default root', async () => {
+    const client = new VercelSandboxClient();
+
+    await expect(
+      client.create(
+        new Manifest({
+          extraPathGrants: [{ path: '/tmp/data' }],
+        }),
+      ),
+    ).rejects.toThrow(/does not support extra path grants yet/);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('rejects serialized sessions with roots outside the Vercel workspace', async () => {
+    const client = new VercelSandboxClient();
+
+    await expect(
+      client.deserializeSessionState({
+        manifest: new Manifest({
+          root: '/tmp',
+        }),
+        sandboxId: 'vercel_existing',
+        workspacePersistence: 'tar',
+        environment: {},
+      }),
+    ).rejects.toThrow(
+      'Vercel sandboxes require manifest.root to stay within "/vercel/sandbox".',
+    );
+  });
+
+  test('rejects serialized sessions with unsupported manifest metadata', async () => {
+    const client = new VercelSandboxClient();
+
+    await expect(
+      client.deserializeSessionState({
+        manifest: new Manifest({
+          extraPathGrants: [{ path: '/tmp/data' }],
+        }),
+        sandboxId: 'vercel_existing',
+        workspacePersistence: 'tar',
+        environment: {},
+      }),
+    ).rejects.toThrow(/does not support extra path grants yet/);
+  });
+
+  test('does not recreate an existing directory for sibling files', async () => {
+    mkDirMock.mockImplementation(async (path: string) => {
+      if (path === '/vercel/sandbox/project') {
+        const callsForPath = mkDirMock.mock.calls.filter(
+          ([calledPath]) => calledPath === path,
+        ).length;
+        if (callsForPath > 1) {
+          throw vercelAlreadyExistsError(path);
+        }
+      }
+    });
+
+    const client = new VercelSandboxClient();
+    await client.create(
+      new Manifest({
+        entries: {
+          'project/status.md': {
+            type: 'file',
+            content: '# Status\n',
+          },
+          'project/tasks.md': {
+            type: 'file',
+            content: '# Tasks\n',
+          },
+        },
+      }),
+    );
+
+    expect(
+      mkDirMock.mock.calls.filter(
+        ([path]) => path === '/vercel/sandbox/project',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('creates parent directories recursively before file writes', async () => {
+    const createdDirs = new Set(['/vercel/sandbox']);
+    mkDirMock.mockImplementation(async (path: string) => {
+      const lastSlash = path.lastIndexOf('/');
+      const parent = lastSlash > 0 ? path.slice(0, lastSlash) : '/';
+      if (!createdDirs.has(parent)) {
+        throw new Error(`missing parent: ${parent}`);
+      }
+      createdDirs.add(path);
+    });
+
+    const client = new VercelSandboxClient();
+    await client.create(
+      new Manifest({
+        entries: {
+          'a/b/file.txt': {
+            type: 'file',
+            content: 'nested\n',
+          },
+        },
+      }),
+    );
+
+    expect(mkDirMock.mock.calls.map(([path]) => path)).toEqual([
+      '/vercel/sandbox/a',
+      '/vercel/sandbox/a/b',
+    ]);
+    expect(writeFilesMock).toHaveBeenCalledWith([
+      {
+        path: '/vercel/sandbox/a/b/file.txt',
+        content: 'nested\n',
+      },
+    ]);
+  });
+
+  test('creates configured workspace roots before initial writes', async () => {
+    const createdDirs = new Set(['/vercel/sandbox']);
+    mkDirMock.mockImplementation(async (path: string) => {
+      const lastSlash = path.lastIndexOf('/');
+      const parent = lastSlash > 0 ? path.slice(0, lastSlash) : '/';
+      if (!createdDirs.has(parent)) {
+        throw new Error(`missing parent: ${parent}`);
+      }
+      createdDirs.add(path);
+    });
+
+    const client = new VercelSandboxClient();
+    await client.create(
+      new Manifest({
+        root: '/vercel/sandbox/app',
+        entries: {
+          'README.md': {
+            type: 'file',
+            content: '# App\n',
+          },
+        },
+      }),
+    );
+
+    expect(mkDirMock).toHaveBeenCalledWith('/vercel/sandbox/app');
+    expect(writeFilesMock).toHaveBeenCalledWith([
+      {
+        path: '/vercel/sandbox/app/README.md',
+        content: '# App\n',
+      },
+    ]);
+  });
+
+  test('uses idempotent editor mkdir operations', async () => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest());
+    const editor = session.createEditor?.();
+    if (!editor) {
+      throw new Error('Expected VercelSandboxSession.createEditor().');
+    }
+    mkDirMock.mockClear();
+    writeFilesMock.mockClear();
+    mkDirMock.mockImplementation(async (path: string) => {
+      if (path === '/vercel/sandbox') {
+        throw vercelAlreadyExistsError(path);
+      }
+    });
+
+    await editor.createFile({
+      type: 'create_file',
+      path: 'notes.txt',
+      diff: '+hello\n',
+    });
+
+    expect(mkDirMock).not.toHaveBeenCalledWith('/vercel/sandbox');
+    expect(writeFilesMock).toHaveBeenCalledWith([
+      {
+        path: '/vercel/sandbox/notes.txt',
+        content: 'hello',
+      },
+    ]);
+  });
+
+  test('fails editor deletes when remote rm fails', async () => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest());
+    const editor = session.createEditor?.();
+    if (!editor) {
+      throw new Error('Expected VercelSandboxSession.createEditor().');
+    }
+    runCommandMock.mockImplementation(
+      async (params: { args?: string[] } = {}) => {
+        const command = params.args?.[1] ?? '';
+        if (command.includes("rm -f -- '/vercel/sandbox/old.txt'")) {
+          return {
+            exitCode: 1,
+            output: vi.fn().mockResolvedValue('delete denied'),
+          };
+        }
+        const resolvedPath = resolvedRemotePathFromValidationCommand(command);
+        return {
+          exitCode: 0,
+          output: vi
+            .fn()
+            .mockResolvedValue(
+              resolvedPath ? `${resolvedPath}\n` : 'README.md\n',
+            ),
+        };
+      },
+    );
+
+    await expect(
+      editor.deleteFile({
+        type: 'delete_file',
+        path: 'old.txt',
+      }),
+    ).rejects.toMatchObject({
+      details: {
+        provider: 'vercel',
+        operation: 'delete path',
+        sandboxId: 'vercel_test',
+        path: '/vercel/sandbox/old.txt',
+        exitCode: 1,
+        output: 'delete denied',
+      },
+    });
+  });
+
+  test('stores materialized absolute workspace paths as relative manifest keys', async () => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest());
+
+    await session.materializeEntry({
+      path: '/vercel/sandbox/extra.txt',
+      entry: {
+        type: 'file',
+        content: 'extra\n',
+      },
+    });
+
+    expect(writeFilesMock).toHaveBeenCalledWith([
+      {
+        path: '/vercel/sandbox/extra.txt',
+        content: 'extra\n',
+      },
+    ]);
+    expect(session.state.manifest.entries).toHaveProperty('extra.txt');
+    expect(session.state.manifest.entries).not.toHaveProperty(
+      '/vercel/sandbox/extra.txt',
+    );
+  });
+
+  test('remaps default manifest roots when applying manifests to sessions', async () => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest());
+    writeFilesMock.mockClear();
+
+    await session.applyManifest(
+      new Manifest({
+        entries: {
+          'next.txt': {
+            type: 'file',
+            content: 'next\n',
+          },
+        },
+      }),
+    );
+
+    expect(writeFilesMock).toHaveBeenCalledWith([
+      {
+        path: '/vercel/sandbox/next.txt',
+        content: 'next\n',
+      },
+    ]);
+    expect(session.state.manifest.root).toBe('/vercel/sandbox');
+    expect(session.state.manifest.entries).toHaveProperty('next.txt');
+  });
+
+  test('captures snapshot ids on close and resumes from snapshots', async () => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workspacePersistence: 'snapshot',
+    });
+
+    await session.close();
+    getMock.mockRejectedValueOnce(new Error('sandbox gone'));
+    await client.resume(session.state);
+
+    expect(snapshotMock).toHaveBeenCalledOnce();
+    expect(stopMock).toHaveBeenCalledOnce();
+    expect(session.state.snapshotId).toBe('snap_test');
+    expect(createMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        source: {
+          type: 'snapshot',
+          snapshotId: 'snap_test',
+        },
+      }),
+    );
+  });
+
+  test('retains serialized access token credentials when resuming live sandboxes', async () => {
+    const client = new VercelSandboxClient();
+    const state = await client.deserializeSessionState({
+      manifest: new Manifest(),
+      sandboxId: 'vercel_existing',
+      workspacePersistence: 'tar',
+      environment: {},
+      projectId: 'prj_serialized',
+      teamId: 'team_serialized',
+      token: 'serialized_token',
+    });
+
+    await client.resume(state);
+
+    expect(getMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sandboxId: 'vercel_existing',
+        projectId: 'prj_serialized',
+        teamId: 'team_serialized',
+        token: 'serialized_token',
+      }),
+    );
+  });
+
+  test('retains serialized access token credentials when resuming snapshot sandboxes', async () => {
+    createMock.mockResolvedValueOnce(makeSandbox('vercel_restored'));
+    const client = new VercelSandboxClient();
+    const state = await client.deserializeSessionState({
+      manifest: new Manifest(),
+      sandboxId: 'vercel_original',
+      workspacePersistence: 'snapshot',
+      environment: {},
+      snapshotId: 'snap_original',
+      snapshotSandboxId: 'vercel_original',
+      projectId: 'prj_serialized',
+      teamId: 'team_serialized',
+      token: 'serialized_token',
+    });
+
+    await client.resume(state);
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'prj_serialized',
+        teamId: 'team_serialized',
+        token: 'serialized_token',
+        source: {
+          type: 'snapshot',
+          snapshotId: 'snap_original',
+        },
+      }),
+    );
+  });
+
+  test('reattaches live sandboxes when snapshot freshness was invalidated', async () => {
+    getMock.mockResolvedValueOnce(makeSandbox('vercel_live'));
+    const client = new VercelSandboxClient();
+    const state = await client.deserializeSessionState({
+      manifest: new Manifest(),
+      sandboxId: 'vercel_live',
+      workspacePersistence: 'snapshot',
+      environment: {},
+      snapshotId: 'snap_stale',
+    });
+
+    const session = await client.resume(state);
+
+    expect(createMock).not.toHaveBeenCalled();
+    expect(getMock).toHaveBeenCalledWith({
+      sandboxId: 'vercel_live',
+    });
+    expect(session.state.sandboxId).toBe('vercel_live');
+    expect(session.state.snapshotId).toBe('snap_stale');
+    expect(session.state.snapshotSandboxId).toBeUndefined();
+  });
+
+  test('wraps resume lookup provider errors', async () => {
+    getMock.mockRejectedValueOnce(new Error('auth failed'));
+    const client = new VercelSandboxClient();
+    const state = await client.deserializeSessionState({
+      manifest: new Manifest(),
+      sandboxId: 'vercel_existing',
+      workspacePersistence: 'tar',
+      environment: {},
+    });
+
+    await expect(client.resume(state)).rejects.toMatchObject({
+      details: {
+        provider: 'vercel',
+        operation: 'resume sandbox',
+        sandboxId: 'vercel_existing',
+        cause: 'auth failed',
+      },
+    });
+  });
+
+  test('wraps resume snapshot provider errors', async () => {
+    createMock.mockRejectedValueOnce(new Error('snapshot restore failed'));
+    const client = new VercelSandboxClient();
+    const state = await client.deserializeSessionState({
+      manifest: new Manifest(),
+      sandboxId: 'vercel_original',
+      workspacePersistence: 'snapshot',
+      environment: {},
+      snapshotId: 'snap_original',
+      snapshotSandboxId: 'vercel_original',
+    });
+
+    await expect(client.resume(state)).rejects.toMatchObject({
+      details: {
+        provider: 'vercel',
+        operation: 'resume sandbox from snapshot',
+        sandboxId: 'vercel_original',
+        snapshotId: 'snap_original',
+        cause: 'snapshot restore failed',
+      },
+    });
+  });
+
+  test('wraps snapshot capture provider errors during explicit persistence', async () => {
+    snapshotMock.mockRejectedValueOnce(new Error('snapshot failed'));
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workspacePersistence: 'snapshot',
+    });
+
+    await expect(session.persistWorkspace()).rejects.toMatchObject({
+      details: {
+        provider: 'vercel',
+        operation: 'capture snapshot',
+        sandboxId: 'vercel_test',
+        cause: 'snapshot failed',
+      },
+    });
+  });
+
+  test('stores the live sandbox id after resuming from a snapshot', async () => {
+    createMock.mockResolvedValueOnce(makeSandbox('vercel_resumed'));
+    const client = new VercelSandboxClient();
+    const state = await client.deserializeSessionState({
+      manifest: new Manifest(),
+      sandboxId: 'vercel_original',
+      workspacePersistence: 'snapshot',
+      environment: {},
+      snapshotId: 'snap_original',
+      snapshotSandboxId: 'vercel_original',
+    });
+
+    const session = await client.resume(state);
+
+    expect(getMock).not.toHaveBeenCalled();
+    expect(session.state.sandboxId).toBe('vercel_resumed');
+    expect(session.state.snapshotId).toBe('snap_original');
+    expect(session.state.snapshotSandboxId).toBeUndefined();
+  });
+
+  test('clears exposed port caches after resuming from a snapshot', async () => {
+    createMock.mockResolvedValueOnce(makeSandbox('vercel_resumed'));
+    const client = new VercelSandboxClient();
+    const state = await client.deserializeSessionState({
+      manifest: new Manifest(),
+      sandboxId: 'vercel_original',
+      workspacePersistence: 'snapshot',
+      configuredExposedPorts: [3000],
+      environment: {},
+      exposedPorts: {
+        '3000': {
+          host: 'old-vercel.example.test',
+          port: 443,
+          tls: true,
+          query: '',
+        },
+      },
+      snapshotId: 'snap_original',
+      snapshotSandboxId: 'vercel_original',
+    });
+
+    const session = await client.resume(state);
+    const endpoint = await session.resolveExposedPort(3000);
+
+    expect(domainMock).toHaveBeenCalledOnce();
+    expect(endpoint.host).toBe('3000-vercel.example.test');
+    expect(session.state.exposedPorts?.['3000']).toBe(endpoint);
+  });
+
+  test('stops snapshot replacements when resume readiness times out', async () => {
+    const nowSpy = vi
+      .spyOn(Date, 'now')
+      .mockReturnValueOnce(0)
+      .mockReturnValue(31_000);
+    try {
+      createMock.mockResolvedValueOnce(makeSandbox('vercel_resumed'));
+      const client = new VercelSandboxClient();
+      const state = await client.deserializeSessionState({
+        manifest: new Manifest(),
+        sandboxId: 'vercel_original',
+        workspacePersistence: 'snapshot',
+        environment: {},
+        snapshotId: 'snap_original',
+        snapshotSandboxId: 'vercel_original',
+      });
+
+      await expect(client.resume(state)).rejects.toBeInstanceOf(
+        SandboxLifecycleError,
+      );
+
+      expect(stopMock).toHaveBeenCalledOnce();
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  test('captures and stops a live sandbox resumed from a snapshot', async () => {
+    createMock.mockResolvedValueOnce(makeSandbox('vercel_resumed'));
+    snapshotMock.mockResolvedValueOnce({ snapshotId: 'snap_resumed' });
+    const client = new VercelSandboxClient();
+    const state = await client.deserializeSessionState({
+      manifest: new Manifest(),
+      sandboxId: 'vercel_original',
+      workspacePersistence: 'snapshot',
+      environment: {},
+      snapshotId: 'snap_original',
+      snapshotSandboxId: 'vercel_original',
+    });
+    const session = await client.resume(state);
+
+    await session.close();
+
+    expect(snapshotMock).toHaveBeenCalledOnce();
+    expect(stopMock).toHaveBeenCalledOnce();
+    expect(session.state.snapshotId).toBe('snap_resumed');
+    expect(session.state.snapshotSandboxId).toBe('vercel_resumed');
+  });
+
+  test('restores snapshot sessions instead of reattaching to the source sandbox', async () => {
+    createMock.mockResolvedValueOnce(makeSandbox('vercel_restored'));
+    const client = new VercelSandboxClient();
+    const state = await client.deserializeSessionState({
+      manifest: new Manifest(),
+      sandboxId: 'vercel_preserved',
+      workspacePersistence: 'snapshot',
+      environment: {},
+      snapshotId: 'snap_preserved',
+      snapshotSandboxId: 'vercel_preserved',
+    });
+
+    const session = await client.resume(state);
+
+    expect(getMock).not.toHaveBeenCalled();
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: {
+          type: 'snapshot',
+          snapshotId: 'snap_preserved',
+        },
+      }),
+    );
+    expect(session.state.sandboxId).toBe('vercel_restored');
+    expect(session.state.snapshotId).toBe('snap_preserved');
+    expect(session.state.snapshotSandboxId).toBeUndefined();
+  });
+
+  test('surfaces stop failures when replacing snapshot sandboxes', async () => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workspacePersistence: 'snapshot',
+    });
+    createMock.mockResolvedValueOnce(makeSandbox('vercel_restored'));
+    stopMock
+      .mockRejectedValueOnce(new Error('stop failed'))
+      .mockResolvedValueOnce(undefined);
+
+    let thrown: unknown;
+    try {
+      await session.hydrateWorkspace(
+        encodeNativeSnapshotRef({
+          provider: 'vercel',
+          snapshotId: 'snap_restore',
+        }),
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(SandboxProviderError);
+    expect((thrown as SandboxProviderError).details).toMatchObject({
+      provider: 'vercel',
+      sandboxId: 'vercel_test',
+      replacementSandboxId: 'vercel_restored',
+      cause: 'stop failed',
+    });
+    expect(stopMock).toHaveBeenCalledTimes(2);
+    expect(session.state.sandboxId).toBe('vercel_test');
+    expect(session.state.snapshotId).toBeUndefined();
+  });
+
+  test('stops snapshot replacements when hydrate readiness times out', async () => {
+    const replacementStopMock = vi.fn().mockResolvedValue(undefined);
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workspacePersistence: 'snapshot',
+    });
+    createMock.mockResolvedValueOnce(
+      makeSandbox('vercel_restored', {
+        stop: replacementStopMock,
+      }),
+    );
+    stopMock.mockClear();
+
+    const nowSpy = vi
+      .spyOn(Date, 'now')
+      .mockReturnValueOnce(0)
+      .mockReturnValue(31_000);
+    try {
+      await expect(
+        session.hydrateWorkspace(
+          encodeNativeSnapshotRef({
+            provider: 'vercel',
+            snapshotId: 'snap_restore',
+          }),
+        ),
+      ).rejects.toBeInstanceOf(SandboxLifecycleError);
+
+      expect(replacementStopMock).toHaveBeenCalledOnce();
+      expect(stopMock).not.toHaveBeenCalled();
+      expect(session.state.sandboxId).toBe('vercel_test');
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  test('serializes snapshot sessions without capturing new snapshots', async () => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workspacePersistence: 'snapshot',
+    });
+
+    const serialized = await client.serializeSessionState(session.state);
+
+    expect(snapshotMock).not.toHaveBeenCalled();
+    expect(stopMock).not.toHaveBeenCalled();
+    expect(serialized).toMatchObject({
+      sandboxId: 'vercel_test',
+      workspacePersistence: 'snapshot',
+    });
+  });
+
+  test('serializes snapshot state with create-time access token credentials', async () => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workspacePersistence: 'snapshot',
+      projectId: 'prj_create',
+      teamId: 'team_create',
+      token: 'create_token',
+    });
+    getMock.mockClear();
+
+    const serialized = await client.serializeSessionState(session.state);
+
+    expect(getMock).not.toHaveBeenCalled();
+    expect(snapshotMock).not.toHaveBeenCalled();
+    expect(serialized).toMatchObject({
+      projectId: 'prj_create',
+      teamId: 'team_create',
+      token: 'create_token',
+      sandboxId: 'vercel_test',
+      workspacePersistence: 'snapshot',
+    });
+  });
+
+  test('captures snapshots before serializing preserved snapshot sessions', async () => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workspacePersistence: 'snapshot',
+      projectId: 'prj_create',
+      teamId: 'team_create',
+      token: 'create_token',
+    });
+    getMock.mockClear();
+
+    const serialized = await client.serializeSessionState(session.state, {
+      preserveOwnedSession: true,
+      reuseLiveSession: false,
+    });
+
+    expect(getMock).toHaveBeenCalledWith({
+      sandboxId: 'vercel_test',
+      projectId: 'prj_create',
+      teamId: 'team_create',
+      token: 'create_token',
+    });
+    expect(snapshotMock).toHaveBeenCalledOnce();
+    expect(stopMock).not.toHaveBeenCalled();
+    expect(serialized).toMatchObject({
+      sandboxId: 'vercel_test',
+      workspacePersistence: 'snapshot',
+      snapshotId: 'snap_test',
+      snapshotSandboxId: 'vercel_test',
+    });
+  });
+
+  test('captures snapshots before serializing snapshot sessions marked for close', async () => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workspacePersistence: 'snapshot',
+      projectId: 'prj_create',
+      teamId: 'team_create',
+      token: 'create_token',
+    });
+    getMock.mockClear();
+
+    const serialized = await client.serializeSessionState(session.state, {
+      willCloseAfterSerialize: true,
+    });
+
+    expect(getMock).toHaveBeenCalledWith({
+      sandboxId: 'vercel_test',
+      projectId: 'prj_create',
+      teamId: 'team_create',
+      token: 'create_token',
+    });
+    expect(snapshotMock).toHaveBeenCalledOnce();
+    expect(serialized).toMatchObject({
+      sandboxId: 'vercel_test',
+      workspacePersistence: 'snapshot',
+      snapshotId: 'snap_test',
+      snapshotSandboxId: 'vercel_test',
+    });
+  });
+
+  test('captures snapshots during close after non-destructive serialization', async () => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workspacePersistence: 'snapshot',
+    });
+
+    await client.serializeSessionState(session.state);
+    await session.close();
+
+    expect(snapshotMock).toHaveBeenCalledOnce();
+    expect(stopMock).toHaveBeenCalledOnce();
+  });
+
+  test('captures live sandbox snapshots without resolving credentials', async () => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workspacePersistence: 'snapshot',
+    });
+    getAuthMock.mockImplementation(() => {
+      throw new Error('credential lookup should not run');
+    });
+
+    await session.close();
+
+    expect(getAuthMock).not.toHaveBeenCalled();
+    expect(snapshotMock).toHaveBeenCalledOnce();
+    expect(stopMock).toHaveBeenCalledOnce();
+  });
+
+  test('invalidates snapshot freshness after workspace writes', async () => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workspacePersistence: 'snapshot',
+    });
+    const editor = session.createEditor?.();
+    if (!editor) {
+      throw new Error('Expected VercelSandboxSession.createEditor().');
+    }
+
+    await session.persistWorkspace();
+    expect(session.state.snapshotSandboxId).toBe('vercel_test');
+    snapshotMock.mockClear();
+
+    await editor.createFile({
+      type: 'create_file',
+      path: 'notes.txt',
+      diff: '+fresh\n',
+    });
+    expect(session.state.snapshotSandboxId).toBeUndefined();
+
+    await session.close();
+
+    expect(snapshotMock).toHaveBeenCalledOnce();
+    expect(stopMock).toHaveBeenCalledOnce();
+  });
+
+  test('persists and hydrates tar workspaces through safe archive helpers', async () => {
+    const archive = makeTarArchive([
+      { name: 'keep.txt', content: 'keep' },
+      { name: 'nested/file.txt', content: 'nested' },
+    ]);
+    readFileToBufferMock.mockResolvedValue(archive);
+    const client = new VercelSandboxClient({
+      workspacePersistence: 'tar',
+    });
+    const session = await client.create(new Manifest());
+
+    await expect(session.persistWorkspace()).resolves.toEqual(archive);
+    await session.hydrateWorkspace(archive);
+
+    expect(
+      runCommandMock.mock.calls.some(([params]) =>
+        String(params.args?.[1]).includes('tar -C'),
+      ),
+    ).toBe(true);
+    expect(writeFilesMock).toHaveBeenCalledWith([
+      expect.objectContaining({
+        content: archive,
+      }),
+    ]);
+  });
+
+  test('clears cached directories after hydrating tar workspaces', async () => {
+    const archive = makeTarArchive([{ name: 'keep.txt', content: 'keep' }]);
+    const client = new VercelSandboxClient({
+      workspacePersistence: 'tar',
+    });
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          'cache/old.txt': {
+            type: 'file',
+            content: 'old\n',
+          },
+        },
+      }),
+    );
+    const editor = session.createEditor?.();
+    if (!editor) {
+      throw new Error('Expected VercelSandboxSession.createEditor().');
+    }
+
+    await session.hydrateWorkspace(archive);
+    mkDirMock.mockClear();
+    writeFilesMock.mockClear();
+
+    await editor.createFile({
+      type: 'create_file',
+      path: 'cache/new.txt',
+      diff: '+new\n',
+    });
+
+    expect(mkDirMock).toHaveBeenCalledWith('/vercel/sandbox/cache');
+    expect(writeFilesMock).toHaveBeenCalledWith([
+      {
+        path: '/vercel/sandbox/cache/new.txt',
+        content: 'new',
+      },
+    ]);
+  });
+
+  test('clears cached directories after shell commands', async () => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          'cache/old.txt': {
+            type: 'file',
+            content: 'old\n',
+          },
+        },
+      }),
+    );
+    const editor = session.createEditor?.();
+    if (!editor) {
+      throw new Error('Expected VercelSandboxSession.createEditor().');
+    }
+    mkDirMock.mockClear();
+    writeFilesMock.mockClear();
+
+    await session.execCommand({ cmd: 'rm -rf /vercel/sandbox/cache' });
+    await editor.createFile({
+      type: 'create_file',
+      path: 'cache/new.txt',
+      diff: '+new\n',
+    });
+
+    expect(mkDirMock).toHaveBeenCalledWith('/vercel/sandbox/cache');
+    expect(writeFilesMock).toHaveBeenCalledWith([
+      {
+        path: '/vercel/sandbox/cache/new.txt',
+        content: 'new',
+      },
+    ]);
+  });
+
+  test('rejects unsafe tar payloads before hydrate writes them', async () => {
+    const client = new VercelSandboxClient({
+      workspacePersistence: 'tar',
+    });
+    const session = await client.create(new Manifest());
+    writeFilesMock.mockClear();
+
+    await expect(
+      session.hydrateWorkspace(
+        makeTarArchive([{ name: '../escape.txt', content: 'bad' }]),
+      ),
+    ).rejects.toBeInstanceOf(SandboxArchiveError);
+    expect(writeFilesMock).not.toHaveBeenCalled();
+  });
+
+  test('persists Vercel snapshots as Python-compatible native refs', async () => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workspacePersistence: 'snapshot',
+    });
+
+    const ref = decodeNativeSnapshotRef(await session.persistWorkspace());
+
+    expect(snapshotMock).toHaveBeenCalledOnce();
+    expect(ref).toEqual({
+      provider: 'vercel',
+      snapshotId: 'snap_test',
+      workspacePersistence: undefined,
+    });
+  });
+
+  test('rebinds live snapshot persistence to a replacement sandbox', async () => {
+    const replacementRunCommandMock = vi.fn(async () => ({
+      exitCode: 0,
+      output: vi.fn().mockResolvedValue('replacement\n'),
+    }));
+    createMock
+      .mockResolvedValueOnce(makeSandbox('vercel_source'))
+      .mockResolvedValueOnce(
+        makeSandbox('vercel_replacement', {
+          runCommand: replacementRunCommandMock,
+        }),
+      );
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workspacePersistence: 'snapshot',
+    });
+    createMock.mockClear();
+    stopMock.mockClear();
+
+    const ref = decodeNativeSnapshotRef(await session.persistWorkspace());
+
+    expect(ref).toMatchObject({
+      provider: 'vercel',
+      snapshotId: 'snap_test',
+    });
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: {
+          type: 'snapshot',
+          snapshotId: 'snap_test',
+        },
+      }),
+    );
+    expect(stopMock).not.toHaveBeenCalled();
+    expect(session.state).toMatchObject({
+      sandboxId: 'vercel_replacement',
+      snapshotId: 'snap_test',
+      snapshotSandboxId: 'vercel_replacement',
+    });
+    expect(replacementRunCommandMock).toHaveBeenCalledWith({
+      cmd: '/bin/sh',
+      args: ['-lc', 'true'],
+      cwd: '/',
+      env: {},
+    });
+
+    replacementRunCommandMock.mockClear();
+    await session.execCommand({ cmd: 'echo after-persist' });
+
+    expect(replacementRunCommandMock).toHaveBeenCalledWith({
+      cmd: '/bin/sh',
+      args: ['-lc', 'echo after-persist'],
+      cwd: '/vercel/sandbox',
+      env: {},
+    });
+  });
+
+  test('recovers live snapshot persistence when replacement restore fails', async () => {
+    const recoveredRunCommandMock = vi.fn(async () => ({
+      exitCode: 0,
+      output: vi.fn().mockResolvedValue('recovered\n'),
+    }));
+    createMock
+      .mockResolvedValueOnce(makeSandbox('vercel_source'))
+      .mockRejectedValueOnce(new Error('restore failed'))
+      .mockResolvedValueOnce(
+        makeSandbox('vercel_recovered', {
+          runCommand: recoveredRunCommandMock,
+        }),
+      );
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workspacePersistence: 'snapshot',
+    });
+    createMock.mockClear();
+
+    const ref = decodeNativeSnapshotRef(await session.persistWorkspace());
+
+    expect(ref).toMatchObject({
+      provider: 'vercel',
+      snapshotId: 'snap_test',
+    });
+    expect(createMock).toHaveBeenCalledTimes(2);
+    expect(session.state).toMatchObject({
+      sandboxId: 'vercel_recovered',
+      snapshotId: 'snap_test',
+      snapshotSandboxId: 'vercel_recovered',
+    });
+
+    recoveredRunCommandMock.mockClear();
+    await session.execCommand({ cmd: 'echo after-recovery' });
+
+    expect(recoveredRunCommandMock).toHaveBeenCalledWith({
+      cmd: '/bin/sh',
+      args: ['-lc', 'echo after-recovery'],
+      cwd: '/vercel/sandbox',
+      env: {},
+    });
+  });
+
+  test('stops the sandbox when snapshot capture fails during close', async () => {
+    snapshotMock.mockRejectedValueOnce(new Error('snapshot failed'));
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workspacePersistence: 'snapshot',
+    });
+
+    await expect(session.close()).rejects.toMatchObject({
+      details: {
+        provider: 'vercel',
+        operation: 'capture snapshot',
+        sandboxId: 'vercel_test',
+        cause: 'snapshot failed',
+      },
+    });
+
+    expect(snapshotMock).toHaveBeenCalledOnce();
+    expect(stopMock).toHaveBeenCalledOnce();
+  });
+
+  test('stops the sandbox when manifest application fails during create', async () => {
+    writeFilesMock.mockRejectedValueOnce(new Error('write failed'));
+    const client = new VercelSandboxClient();
+
+    await expect(
+      client.create(
+        new Manifest({
+          entries: {
+            'README.md': {
+              type: 'file',
+              content: '# Hello\n',
+            },
+          },
+        }),
+      ),
+    ).rejects.toThrow('write failed');
+
+    expect(createMock).toHaveBeenCalledOnce();
+    expect(stopMock).toHaveBeenCalledOnce();
+  });
+
+  test('does not reuse preserved snapshot sessions as live handles', async () => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workspacePersistence: 'snapshot',
+    });
+
+    await client.serializeSessionState(session.state);
+
+    expect(client.canReusePreservedOwnedSession(session.state)).toBe(false);
+  });
+
+  test('does not stop a sandbox twice across shutdown and delete lifecycle hooks', async () => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest());
+
+    await session.shutdown();
+    await session.delete();
+
+    expect(stopMock).toHaveBeenCalledOnce();
+  });
+
+  test('retries close after a stop failure', async () => {
+    stopMock
+      .mockRejectedValueOnce(new Error('stop failed'))
+      .mockResolvedValueOnce(undefined);
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest());
+
+    await expect(session.close()).rejects.toThrow('stop failed');
+    await session.delete();
+
+    expect(stopMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('preserves missing optional Vercel sandbox methods', async () => {
+    createMock.mockResolvedValueOnce(
+      makeSandbox('vercel_test', {
+        domain: undefined,
+        stop: undefined,
+        snapshot: undefined,
+      }),
+    );
+    const client = new VercelSandboxClient({
+      exposedPorts: [3000],
+      workspacePersistence: 'snapshot',
+    });
+    const session = await client.create(new Manifest());
+    getMock.mockClear();
+
+    await expect(session.resolveExposedPort(3000)).rejects.toBeInstanceOf(
+      SandboxProviderError,
+    );
+    expect(session.state.snapshotSupported).toBe(false);
+    expect(client.canPersistOwnedSessionState(session.state)).toBe(false);
+    expect(client.canReusePreservedOwnedSession(session.state)).toBe(true);
+    await expect(
+      client.serializeSessionState(session.state, {
+        willCloseAfterSerialize: true,
+      }),
+    ).resolves.toMatchObject({
+      workspacePersistence: 'snapshot',
+      snapshotSupported: false,
+    });
+    expect(getMock).not.toHaveBeenCalled();
+    expect(snapshotMock).not.toHaveBeenCalled();
+    await expect(session.persistWorkspace()).rejects.toThrow(
+      'Vercel snapshot persistence requires @vercel/sandbox snapshot support.',
+    );
+    await expect(session.close()).resolves.toBeUndefined();
+    expect(stopMock).not.toHaveBeenCalled();
+  });
+
+  test('accepts absolute workspace paths for remote file checks', async () => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          'README.md': {
+            type: 'file',
+            content: '# Hello\n',
+          },
+        },
+      }),
+    );
+
+    const exists = await session.pathExists('/vercel/sandbox/README.md');
+
+    expect(exists).toBe(true);
+    expect(runCommandMock).toHaveBeenCalledWith({
+      cmd: '/bin/sh',
+      args: ['-lc', "test -e '/vercel/sandbox/README.md'"],
+      cwd: '/vercel/sandbox',
+      env: {},
+    });
+    await expect(
+      session.pathExists('/vercel/sandbox/../tmp/README.md'),
+    ).rejects.toThrow(/escapes the workspace root/);
+  });
+
+  test('resolves configured exposed ports through Vercel domains', async () => {
+    const client = new VercelSandboxClient({
+      exposedPorts: [3000],
+    });
+    const session = await client.create(new Manifest());
+
+    const endpoint = await session.resolveExposedPort(3000);
+    const cachedEndpoint = await session.resolveExposedPort(3000);
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ports: [3000],
+      }),
+    );
+    expect(domainMock).toHaveBeenCalledWith(3000);
+    expect(domainMock).toHaveBeenCalledOnce();
+    expect(endpoint).toMatchObject({
+      host: '3000-vercel.example.test',
+      port: 443,
+      tls: true,
+    });
+    expect(cachedEndpoint).toBe(endpoint);
+    expect(session.state.exposedPorts?.['3000']).toBe(endpoint);
+  });
+
+  test('rejects unsupported PTY execution with a typed error', async () => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest());
+
+    await expect(
+      session.execCommand({ cmd: 'sh', tty: true }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+  });
+
+  test('rejects command runAs instead of sudoing as root', async () => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest());
+    runCommandMock.mockClear();
+
+    await expect(
+      session.execCommand({ cmd: 'id', runAs: 'root' }),
+    ).rejects.toThrow(/does not support runAs yet/);
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agents-extensions/test/sandbox/vercel.test.ts
+++ b/packages/agents-extensions/test/sandbox/vercel.test.ts
@@ -873,6 +873,46 @@ describe('VercelSandboxClient', () => {
     }
   });
 
+  test('drops expired serialized CLI tokens when refresh cannot run', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'vercel-cli-expired-'));
+    const authDir = join(root, 'auth');
+    mkdirSync(authDir, { recursive: true });
+    getAuthMock.mockReturnValue({
+      token: 'cli_access_token',
+      expiresAt: new Date(Date.now() - 1_000),
+    });
+    vi.stubEnv('VERCEL_AUTH_CONFIG_DIR', authDir);
+
+    try {
+      const client = new VercelSandboxClient();
+      const state = await client.deserializeSessionState({
+        manifest: new Manifest(),
+        sandboxId: 'vercel_existing',
+        workspacePersistence: 'tar',
+        environment: {},
+        projectId: 'prj_serialized',
+        teamId: 'team_serialized',
+        token: 'cli_access_token',
+      });
+
+      await client.resume(state);
+
+      expect(refreshTokenMock).not.toHaveBeenCalled();
+      expect(getMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sandboxId: 'vercel_existing',
+          projectId: 'prj_serialized',
+          teamId: 'team_serialized',
+        }),
+      );
+      expect(getMock.mock.calls[0]?.[0]).not.toHaveProperty('token');
+      expect(state.token).toBeUndefined();
+    } finally {
+      vi.unstubAllEnvs();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test('retains serialized access token credentials when resuming snapshot sandboxes', async () => {
     createMock.mockResolvedValueOnce(makeSandbox('vercel_restored'));
     const client = new VercelSandboxClient();


### PR DESCRIPTION
This pull request adds a sandbox provider as part of agents-extensions package: https://developers.openai.com/api/docs/guides/agents/sandboxes

How to run:
```zsh
git clone https://github.com/openai/openai-agents-js
cd openai-agents-js/
git checkout feat/sandbox-agents-vercel
pnpm i
pnpm build
pnpm -F sandbox start:vercel
```