### PR TITLE
fix: #1212 add code interpreter output include option

### DIFF
--- a/.changeset/sharp-cameras-jam.md
+++ b/.changeset/sharp-cameras-jam.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: #1212 add code interpreter output include option

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -1563,7 +1563,9 @@ function converTool<_TContext = unknown>(
           type: 'code_interpreter',
           container: tool.providerData.container,
         },
-        include: undefined,
+        include: tool.providerData.include_outputs
+          ? ['code_interpreter_call.outputs']
+          : undefined,
       };
     } else if (tool.providerData?.type === 'tool_search') {
       return {

--- a/packages/agents-openai/src/tools.ts
+++ b/packages/agents-openai/src/tools.ts
@@ -150,6 +150,10 @@ export function fileSearchTool(
 export type CodeInterpreterTool = {
   type: 'code_interpreter';
   name?: 'code_interpreter' | (string & {});
+  /**
+   * Whether to include code interpreter outputs in the response.
+   */
+  includeOutputs?: boolean;
   container?:
     | string
     | OpenAI.Responses.Tool.CodeInterpreter.CodeInterpreterToolAuto;
@@ -176,6 +180,7 @@ export function codeInterpreterTool(
     type: 'code_interpreter',
     name: options.name ?? 'code_interpreter',
     container: options.container ?? { type: 'auto' },
+    include_outputs: options.includeOutputs,
   };
   return {
     type: 'hosted_tool',

--- a/packages/agents-openai/src/types/providerData.ts
+++ b/packages/agents-openai/src/types/providerData.ts
@@ -19,6 +19,7 @@ export type CodeInterpreterTool = Omit<
 > & {
   type: 'code_interpreter';
   name: 'code_interpreter' | (string & {});
+  include_outputs?: boolean;
 };
 
 export type ToolSearchTool = Omit<OpenAI.Responses.ToolSearchTool, 'type'> & {

--- a/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
@@ -394,6 +394,20 @@ describe('converTool', () => {
       container: 'python',
     });
 
+    const codeWithOutputs = converTool({
+      type: 'hosted_tool',
+      providerData: {
+        type: 'code_interpreter',
+        container: 'python',
+        include_outputs: true,
+      },
+    } as any);
+    expect(codeWithOutputs.tool).toEqual({
+      type: 'code_interpreter',
+      container: 'python',
+    });
+    expect(codeWithOutputs.include).toEqual(['code_interpreter_call.outputs']);
+
     const toolSearch = converTool({
       type: 'hosted_tool',
       providerData: { type: 'tool_search' },

--- a/packages/agents-openai/test/tools.test.ts
+++ b/packages/agents-openai/test/tools.test.ts
@@ -1,6 +1,7 @@
 import { getClientToolSearchExecutor } from '@openai/agents-core';
 import { describe, it, expect } from 'vitest';
 import {
+  codeInterpreterTool,
   fileSearchTool,
   imageGenerationTool,
   toolSearchTool,
@@ -43,6 +44,20 @@ describe('Tool', () => {
     expect(t2).toBeDefined();
     expect(t2.type).toBe('hosted_tool');
     expect(t2.name).toBe('file_search');
+  });
+
+  it('codeInterpreterTool preserves include outputs option', () => {
+    const t = codeInterpreterTool({ includeOutputs: true });
+    expect(t).toMatchObject({
+      type: 'hosted_tool',
+      name: 'code_interpreter',
+      providerData: {
+        type: 'code_interpreter',
+        name: 'code_interpreter',
+        container: { type: 'auto' },
+        include_outputs: true,
+      },
+    });
   });
 
   it('imageGenerationTool with gpt-image-1', () => {


### PR DESCRIPTION
This pull request resolves https://github.com/openai/openai-agents-js/issues/1212 by adding an `includeOutputs` option to `codeInterpreterTool()`.

When enabled, the OpenAI Responses model conversion now sends `code_interpreter_call.outputs` in the request `include` array, matching the existing `includeSearchResults` behavior for file search. The default remains unchanged because the include is only sent when `includeOutputs` is truthy.
