### PR TITLE
test: add sandbox agent integration smoke

### DIFF
--- a/integration-tests/bun.test.ts
+++ b/integration-tests/bun.test.ts
@@ -28,10 +28,28 @@ describe('Bun', () => {
     expect(stdout).toContain('[RESPONSE]Hello there![/RESPONSE]');
   });
 
-  test('aisdk runner should not lose tracing context', async () => {
-    const { stdout } = await execa`bun run aisdk.ts`;
-    expect(stdout).toContain('[AISDK_RESPONSE]hello[/AISDK_RESPONSE]');
-  });
+  test(
+    'aisdk runner should not lose tracing context',
+    { timeout: 15_000 },
+    async () => {
+      const { stdout } = await execa`bun run aisdk.ts`;
+      expect(stdout).toContain('[AISDK_RESPONSE]hello[/AISDK_RESPONSE]');
+    },
+  );
+
+  test(
+    'sandbox agent should run with unix-local',
+    { timeout: 60_000 },
+    async () => {
+      const { stdout } = await execa`bun run sandbox-unix-local.ts`;
+      expect(stdout).toMatch(
+        /\[SANDBOX_TOOLS\].*exec_command.*\[\/SANDBOX_TOOLS\]/s,
+      );
+      expect(stdout).toContain(
+        '[SANDBOX_RESPONSE]unix-local-bun:unix-local-bun-command[/SANDBOX_RESPONSE]',
+      );
+    },
+  );
 
   afterAll(async () => {
     await execa`rm -f bun.lock`;

--- a/integration-tests/bun/package.json
+++ b/integration-tests/bun/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "bun run index.ts",
     "start:aisdk": "bun run aisdk.ts",
-    "start:zod": "bun run zod.ts"
+    "start:zod": "bun run zod.ts",
+    "start:sandbox:unix-local": "bun run sandbox-unix-local.ts"
   },
   "devDependencies": {
     "@types/bun": "latest"

--- a/integration-tests/bun/sandbox-unix-local.ts
+++ b/integration-tests/bun/sandbox-unix-local.ts
@@ -1,0 +1,56 @@
+// @ts-check
+
+import { getGlobalTraceProvider, run } from '@openai/agents';
+import { Manifest, SandboxAgent, shell } from '@openai/agents/sandbox';
+import { UnixLocalSandboxClient } from '@openai/agents/sandbox/local';
+
+const manifest = new Manifest({
+  entries: {
+    'README.md': {
+      type: 'file',
+      content: '# Unix Local Sandbox\n\nmarker: unix-local-bun\n',
+    },
+    'scripts/marker.sh': {
+      type: 'file',
+      content: '#!/bin/sh\nprintf "unix-local-bun-command\\n"\n',
+      executable: true,
+    },
+  },
+});
+
+const client = new UnixLocalSandboxClient();
+const session = await client.create(manifest);
+const agent = new SandboxAgent({
+  name: 'Bun unix local sandbox smoke',
+  instructions:
+    'Inspect README.md, run scripts/marker.sh, and respond exactly with [SANDBOX_RESPONSE]unix-local-bun:unix-local-bun-command[/SANDBOX_RESPONSE].',
+  defaultManifest: manifest,
+  capabilities: [shell()],
+  modelSettings: {
+    toolChoice: 'required',
+  },
+});
+
+try {
+  const result = await run(
+    agent,
+    'Run the Bun unix-local sandbox smoke check.',
+    {
+      maxTurns: 8,
+      sandbox: { session },
+    },
+  );
+  const toolNames = result.newItems.flatMap((item) => {
+    if (item.type !== 'tool_call_item') {
+      return [];
+    }
+    const rawItem = item.rawItem as { name?: unknown };
+    return typeof rawItem.name === 'string' ? [rawItem.name] : [];
+  });
+
+  console.log(`[SANDBOX_TOOLS]${toolNames.join(',')}[/SANDBOX_TOOLS]`);
+  console.log(String(result.finalOutput));
+} finally {
+  await session.close?.().catch(() => {});
+  await getGlobalTraceProvider().shutdown();
+}

--- a/integration-tests/bun/sandbox-unix-local.ts
+++ b/integration-tests/bun/sandbox-unix-local.ts
@@ -51,6 +51,6 @@ try {
   console.log(`[SANDBOX_TOOLS]${toolNames.join(',')}[/SANDBOX_TOOLS]`);
   console.log(String(result.finalOutput));
 } finally {
-  await session.close?.().catch(() => {});
+  await session.close?.();
   await getGlobalTraceProvider().shutdown();
 }

--- a/integration-tests/deno.test.ts
+++ b/integration-tests/deno.test.ts
@@ -79,6 +79,21 @@ describe('Deno', () => {
     },
   );
 
+  test(
+    'sandbox agent should run with unix-local',
+    { timeout: 60000 },
+    async () => {
+      const { stdout } =
+        await execa`deno --allow-all --reload=npm: sandbox-unix-local.ts`;
+      expect(stdout).toMatch(
+        /\[SANDBOX_TOOLS\].*exec_command.*\[\/SANDBOX_TOOLS\]/s,
+      );
+      expect(stdout).toContain(
+        '[SANDBOX_RESPONSE]unix-local-deno:unix-local-deno-command[/SANDBOX_RESPONSE]',
+      );
+    },
+  );
+
   afterAll(async () => {
     await rm(path.join(denoCwd, 'deno.lock'), { force: true });
     await rm(denoCacheDir, { recursive: true, force: true });

--- a/integration-tests/deno/sandbox-unix-local.ts
+++ b/integration-tests/deno/sandbox-unix-local.ts
@@ -51,6 +51,6 @@ try {
   console.log(`[SANDBOX_TOOLS]${toolNames.join(',')}[/SANDBOX_TOOLS]`);
   console.log(String(result.finalOutput));
 } finally {
-  await session.close?.().catch(() => {});
+  await session.close?.();
   await getGlobalTraceProvider().shutdown();
 }

--- a/integration-tests/deno/sandbox-unix-local.ts
+++ b/integration-tests/deno/sandbox-unix-local.ts
@@ -1,0 +1,56 @@
+// @ts-check
+
+import { getGlobalTraceProvider, run } from '@openai/agents';
+import { Manifest, SandboxAgent, shell } from '@openai/agents/sandbox';
+import { UnixLocalSandboxClient } from '@openai/agents/sandbox/local';
+
+const manifest = new Manifest({
+  entries: {
+    'README.md': {
+      type: 'file',
+      content: '# Unix Local Sandbox\n\nmarker: unix-local-deno\n',
+    },
+    'scripts/marker.sh': {
+      type: 'file',
+      content: '#!/bin/sh\nprintf "unix-local-deno-command\\n"\n',
+      executable: true,
+    },
+  },
+});
+
+const client = new UnixLocalSandboxClient();
+const session = await client.create(manifest);
+const agent = new SandboxAgent({
+  name: 'Deno unix local sandbox smoke',
+  instructions:
+    'Inspect README.md, run scripts/marker.sh, and respond exactly with [SANDBOX_RESPONSE]unix-local-deno:unix-local-deno-command[/SANDBOX_RESPONSE].',
+  defaultManifest: manifest,
+  capabilities: [shell()],
+  modelSettings: {
+    toolChoice: 'required',
+  },
+});
+
+try {
+  const result = await run(
+    agent,
+    'Run the Deno unix-local sandbox smoke check.',
+    {
+      maxTurns: 8,
+      sandbox: { session },
+    },
+  );
+  const toolNames = result.newItems.flatMap((item) => {
+    if (item.type !== 'tool_call_item') {
+      return [];
+    }
+    const rawItem = item.rawItem as { name?: unknown };
+    return typeof rawItem.name === 'string' ? [rawItem.name] : [];
+  });
+
+  console.log(`[SANDBOX_TOOLS]${toolNames.join(',')}[/SANDBOX_TOOLS]`);
+  console.log(String(result.finalOutput));
+} finally {
+  await session.close?.().catch(() => {});
+  await getGlobalTraceProvider().shutdown();
+}

--- a/integration-tests/node.test.ts
+++ b/integration-tests/node.test.ts
@@ -17,7 +17,7 @@ describe('Node.js', () => {
     await execa`npm install`;
   }, 60000);
 
-  test('should be able to run using CommonJS', async () => {
+  test('should be able to run using CommonJS', { timeout: 15000 }, async () => {
     const { stdout } = await execa`npm run start:cjs`;
     expect(stdout).toContain('[RESPONSE]Hello there![/RESPONSE]');
   });
@@ -38,6 +38,40 @@ describe('Node.js', () => {
     async () => {
       const { stdout } = await execa`npm run start:codex`;
       expect(stdout).toContain('[CODEX_RESPONSE]');
+    },
+  );
+
+  test(
+    'sandbox agent should run with unix-local',
+    { timeout: 60_000 },
+    async () => {
+      const { stdout } = await execa`npm run start:sandbox:unix-local`;
+      expect(stdout).toMatch(
+        /\[SANDBOX_TOOLS\].*exec_command.*\[\/SANDBOX_TOOLS\]/s,
+      );
+      expect(stdout).toContain(
+        '[SANDBOX_RESPONSE]unix-local-node:unix-local-node-command[/SANDBOX_RESPONSE]',
+      );
+    },
+  );
+
+  test(
+    'sandbox agent should run with docker',
+    { timeout: 120_000 },
+    async (context) => {
+      try {
+        await execa`docker info`;
+      } catch {
+        context.skip();
+      }
+
+      const { stdout } = await execa`npm run start:sandbox:docker`;
+      expect(stdout).toMatch(
+        /\[SANDBOX_TOOLS\].*exec_command.*\[\/SANDBOX_TOOLS\]/s,
+      );
+      expect(stdout).toContain(
+        '[SANDBOX_RESPONSE]docker-node:docker-node-command[/SANDBOX_RESPONSE]',
+      );
     },
   );
 });

--- a/integration-tests/node/package.json
+++ b/integration-tests/node/package.json
@@ -5,7 +5,9 @@
     "start:cjs": "node --no-experimental-require-module index.cjs",
     "start:esm": "node --no-experimental-require-module index.mjs",
     "start:aisdk:cjs": "node aisdk.cjs",
-    "start:codex": "node --no-experimental-require-module codex.mjs"
+    "start:codex": "node --no-experimental-require-module codex.mjs",
+    "start:sandbox:unix-local": "node --no-experimental-require-module sandbox-unix-local.mjs",
+    "start:sandbox:docker": "node --no-experimental-require-module sandbox-docker.mjs"
   },
   "dependencies": {
     "@openai/agents": "latest",

--- a/integration-tests/node/sandbox-docker.mjs
+++ b/integration-tests/node/sandbox-docker.mjs
@@ -50,6 +50,6 @@ try {
   console.log(`[SANDBOX_TOOLS]${toolNames.join(',')}[/SANDBOX_TOOLS]`);
   console.log(String(result.finalOutput));
 } finally {
-  await session.close?.().catch(() => {});
+  await session.close?.();
   await getGlobalTraceProvider().shutdown();
 }

--- a/integration-tests/node/sandbox-docker.mjs
+++ b/integration-tests/node/sandbox-docker.mjs
@@ -1,0 +1,55 @@
+// @ts-check
+
+import { getGlobalTraceProvider, run } from '@openai/agents';
+import { Manifest, SandboxAgent, shell } from '@openai/agents/sandbox';
+import { DockerSandboxClient } from '@openai/agents/sandbox/local';
+
+const manifest = new Manifest({
+  entries: {
+    'README.md': {
+      type: 'file',
+      content: '# Docker Sandbox\n\nmarker: docker-node\n',
+    },
+    'scripts/marker.sh': {
+      type: 'file',
+      content: '#!/bin/sh\nprintf "docker-node-command\\n"\n',
+      executable: true,
+    },
+  },
+});
+
+const client = new DockerSandboxClient({
+  image:
+    process.env.SANDBOX_INTEGRATION_DOCKER_IMAGE ?? 'node:22-bookworm-slim',
+});
+const session = await client.create(manifest);
+const agent = new SandboxAgent({
+  name: 'Docker sandbox smoke',
+  instructions:
+    'Inspect README.md, run scripts/marker.sh, and respond exactly with [SANDBOX_RESPONSE]docker-node:docker-node-command[/SANDBOX_RESPONSE].',
+  defaultManifest: manifest,
+  capabilities: [shell()],
+  modelSettings: {
+    toolChoice: 'required',
+  },
+});
+
+try {
+  const result = await run(agent, 'Run the docker sandbox smoke check.', {
+    maxTurns: 8,
+    sandbox: { session },
+  });
+  const toolNames = result.newItems.flatMap((item) => {
+    if (item.type !== 'tool_call_item') {
+      return [];
+    }
+    const rawItem = /** @type {{ name?: unknown }} */ (item.rawItem);
+    return typeof rawItem.name === 'string' ? [rawItem.name] : [];
+  });
+
+  console.log(`[SANDBOX_TOOLS]${toolNames.join(',')}[/SANDBOX_TOOLS]`);
+  console.log(String(result.finalOutput));
+} finally {
+  await session.close?.().catch(() => {});
+  await getGlobalTraceProvider().shutdown();
+}

--- a/integration-tests/node/sandbox-unix-local.mjs
+++ b/integration-tests/node/sandbox-unix-local.mjs
@@ -47,6 +47,6 @@ try {
   console.log(`[SANDBOX_TOOLS]${toolNames.join(',')}[/SANDBOX_TOOLS]`);
   console.log(String(result.finalOutput));
 } finally {
-  await session.close?.().catch(() => {});
+  await session.close?.();
   await getGlobalTraceProvider().shutdown();
 }

--- a/integration-tests/node/sandbox-unix-local.mjs
+++ b/integration-tests/node/sandbox-unix-local.mjs
@@ -1,0 +1,52 @@
+// @ts-check
+
+import { getGlobalTraceProvider, run } from '@openai/agents';
+import { Manifest, SandboxAgent, shell } from '@openai/agents/sandbox';
+import { UnixLocalSandboxClient } from '@openai/agents/sandbox/local';
+
+const manifest = new Manifest({
+  entries: {
+    'README.md': {
+      type: 'file',
+      content: '# Unix Local Sandbox\n\nmarker: unix-local-node\n',
+    },
+    'scripts/marker.sh': {
+      type: 'file',
+      content: '#!/bin/sh\nprintf "unix-local-node-command\\n"\n',
+      executable: true,
+    },
+  },
+});
+
+const client = new UnixLocalSandboxClient();
+const session = await client.create(manifest);
+const agent = new SandboxAgent({
+  name: 'Unix local sandbox smoke',
+  instructions:
+    'Inspect README.md, run scripts/marker.sh, and respond exactly with [SANDBOX_RESPONSE]unix-local-node:unix-local-node-command[/SANDBOX_RESPONSE].',
+  defaultManifest: manifest,
+  capabilities: [shell()],
+  modelSettings: {
+    toolChoice: 'required',
+  },
+});
+
+try {
+  const result = await run(agent, 'Run the unix-local sandbox smoke check.', {
+    maxTurns: 8,
+    sandbox: { session },
+  });
+  const toolNames = result.newItems.flatMap((item) => {
+    if (item.type !== 'tool_call_item') {
+      return [];
+    }
+    const rawItem = /** @type {{ name?: unknown }} */ (item.rawItem);
+    return typeof rawItem.name === 'string' ? [rawItem.name] : [];
+  });
+
+  console.log(`[SANDBOX_TOOLS]${toolNames.join(',')}[/SANDBOX_TOOLS]`);
+  console.log(String(result.finalOutput));
+} finally {
+  await session.close?.().catch(() => {});
+  await getGlobalTraceProvider().shutdown();
+}


### PR DESCRIPTION
This pull request adds packaged integration smoke coverage for sandbox agents across Node, Bun, Deno, and Docker. It verifies that published sandbox subpath imports work, `SandboxAgent` can invoke `shell()` through `exec_command`, and unix-local/docker sessions clean up successfully in the integration-test fixtures.

```text
pnpm test:integration
Test Files  10 passed (10)
Tests       26 passed (26)

New coverage:
✓ Bun > sandbox agent should run with unix-local
✓ Deno > sandbox agent should run with unix-local
✓ Node.js > sandbox agent should run with unix-local
✓ Node.js > sandbox agent should run with docker
```
