### PR TITLE
fix: surface model refusals during run resolution

### DIFF
--- a/.changeset/surface-model-refusals.md
+++ b/.changeset/surface-model-refusals.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: surface model refusals during run resolution

--- a/packages/agents-core/src/errors.ts
+++ b/packages/agents-core/src/errors.ts
@@ -38,6 +38,21 @@ export class SystemError extends AgentsError {}
 export class MaxTurnsExceededError extends AgentsError {}
 
 /**
+ * Error thrown when the model refuses to produce output.
+ */
+export class ModelRefusalError extends AgentsError {
+  /**
+   * The refusal text returned by the model.
+   */
+  refusal: string;
+
+  constructor(refusal: string, state?: RunState<any, Agent<any, any>>) {
+    super(`Model refused to produce output: ${refusal}`, state);
+    this.refusal = refusal;
+  }
+}
+
+/**
  * Error thrown when a model behavior is unexpected.
  */
 export class ModelBehaviorError extends AgentsError {}

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -28,6 +28,7 @@ export {
   InputGuardrailTripwireTriggered,
   MaxTurnsExceededError,
   ModelBehaviorError,
+  ModelRefusalError,
   OutputGuardrailTripwireTriggered,
   ToolInputGuardrailTripwireTriggered,
   ToolOutputGuardrailTripwireTriggered,

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -263,7 +263,7 @@ type SharedRunOptions<
   reasoningItemIdPolicy?: ReasoningItemIdPolicy;
   tracing?: TracingConfig;
   /**
-   * Error handlers keyed by error kind. Currently only maxTurns errors are supported.
+   * Error handlers keyed by error kind.
    */
   errorHandlers?: RunErrorHandlers<TContext, TAgent>;
 };
@@ -848,7 +848,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
 
             await guardrailTracker.awaitCompletion();
 
-            const turnResult = await resolveTurnAfterModelResponse<TContext>(
+            const turnResult = await resolveTurnAfterModelResponse(
               state._currentAgent,
               state._originalInput,
               state._generatedItems,
@@ -857,6 +857,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               this,
               state,
               toolErrorFormatter,
+              options.errorHandlers,
             );
 
             applyTurnResult({
@@ -1279,7 +1280,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             streamStepItemsToRunResult(result, processedResponse.newItems);
           }
 
-          const turnResult = await resolveTurnAfterModelResponse<TContext>(
+          const turnResult = await resolveTurnAfterModelResponse(
             currentAgent,
             result.state._originalInput,
             result.state._generatedItems,
@@ -1288,6 +1289,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             this,
             result.state,
             toolErrorFormatter,
+            options.errorHandlers,
           );
 
           applyTurnResult({

--- a/packages/agents-core/src/runner/errorHandlers.ts
+++ b/packages/agents-core/src/runner/errorHandlers.ts
@@ -1,5 +1,5 @@
 import { Agent, AgentOutputType } from '../agent';
-import { MaxTurnsExceededError } from '../errors';
+import { MaxTurnsExceededError, ModelRefusalError } from '../errors';
 import { assistant } from '../helpers/message';
 import { RunItem, RunMessageOutputItem } from '../items';
 import { ModelResponse } from '../model';
@@ -22,7 +22,7 @@ import { streamStepItemsToRunResult } from './streaming';
 /**
  * Error kinds supported by run error handlers.
  */
-export type RunErrorKind = 'maxTurns';
+export type RunErrorKind = 'maxTurns' | 'modelRefusal';
 
 /**
  * Snapshot of run data passed to error handlers.
@@ -38,7 +38,7 @@ export type RunErrorData<TContext, TAgent extends Agent<any, any>> = {
 };
 
 export type RunErrorHandlerInput<TContext, TAgent extends Agent<any, any>> = {
-  error: MaxTurnsExceededError;
+  error: MaxTurnsExceededError | ModelRefusalError;
   context: RunContext<TContext>;
   runData: RunErrorData<TContext, TAgent>;
 };
@@ -87,6 +87,13 @@ type TryHandleRunErrorArgs<TContext, TAgent extends Agent<any, any>> = {
   streamResult?: StreamedRunResult<TContext, TAgent>;
 };
 
+type ResolveRunErrorHandlerArgs<TContext, TAgent extends Agent<any, any>> = {
+  error: unknown;
+  errorHandlers?: RunErrorHandlers<TContext, TAgent>;
+  context: RunContext<TContext>;
+  runData: RunErrorData<TContext, TAgent>;
+};
+
 const buildRunData = <TContext, TAgent extends Agent<any, any>>(
   state: RunState<TContext, TAgent>,
 ): RunErrorData<TContext, TAgent> => ({
@@ -119,6 +126,41 @@ const createFinalOutputItem = <TAgent extends Agent<any, any>>(
 ): RunMessageOutputItem =>
   new RunMessageOutputItem(assistant(outputText), agent);
 
+export const formatRunErrorFinalOutput = formatFinalOutput;
+export const createRunErrorFinalOutputItem = createFinalOutputItem;
+
+export const resolveRunErrorHandler = async <
+  TContext,
+  TAgent extends Agent<any, any>,
+>({
+  error,
+  errorHandlers,
+  context,
+  runData,
+}: ResolveRunErrorHandlerArgs<TContext, TAgent>): Promise<
+  RunErrorHandlerResult<TAgent> | undefined
+> => {
+  let handler: RunErrorHandler<TContext, TAgent> | undefined;
+  if (error instanceof MaxTurnsExceededError) {
+    handler = errorHandlers?.maxTurns ?? errorHandlers?.default;
+  } else if (error instanceof ModelRefusalError) {
+    handler = errorHandlers?.modelRefusal ?? errorHandlers?.default;
+  } else {
+    return undefined;
+  }
+
+  if (!handler) {
+    return undefined;
+  }
+
+  const handlerResult = await handler({
+    error,
+    context,
+    runData,
+  });
+  return handlerResult || undefined;
+};
+
 export const tryHandleRunError = async <
   TContext,
   TAgent extends Agent<TContext, AgentOutputType>,
@@ -132,15 +174,9 @@ export const tryHandleRunError = async <
 }: TryHandleRunErrorArgs<TContext, TAgent>): Promise<
   RunResult<TContext, TAgent> | undefined
 > => {
-  if (!(error instanceof MaxTurnsExceededError)) {
-    return undefined;
-  }
-  const handler = errorHandlers?.maxTurns ?? errorHandlers?.default;
-  if (!handler) {
-    return undefined;
-  }
-  const handlerResult = await handler({
+  const handlerResult = await resolveRunErrorHandler({
     error,
+    errorHandlers,
     context: state._context,
     runData: buildRunData(state),
   });

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -1,11 +1,14 @@
 import { z } from 'zod';
 import { Agent } from '../agent';
-import { ModelBehaviorError } from '../errors';
+import { ModelBehaviorError, ModelRefusalError } from '../errors';
 import { RunItem, RunMessageOutputItem, RunToolApprovalItem } from '../items';
 import { ModelResponse } from '../model';
 import type { Runner, ToolErrorFormatter } from '../run';
 import { RunState } from '../runState';
-import { getTextFromOutputMessage } from '../utils/messages';
+import {
+  getRefusalFromOutputMessage,
+  getTextFromOutputMessage,
+} from '../utils/messages';
 import { getSchemaAndParserFromInputType } from '../utils/tools';
 import { safeExecute } from '../utils/safeExecute';
 import { addErrorToCurrentSpan } from '../tracing/context';
@@ -26,6 +29,13 @@ import * as protocol from '../types/protocol';
 import { AgentInputItem } from '../types';
 import type { FunctionToolResult } from '../tool';
 import { getFunctionToolQualifiedName } from '../toolIdentity';
+import type { RunErrorData, RunErrorHandlers } from './errorHandlers';
+import {
+  createRunErrorFinalOutputItem,
+  formatRunErrorFinalOutput,
+  resolveRunErrorHandler,
+} from './errorHandlers';
+import { getTurnInput } from './items';
 
 type ApprovalItemLike =
   | RunToolApprovalItem
@@ -628,15 +638,19 @@ export async function resolveInterruptedTurn<TContext>(
  * Executes every follow-up action the model requested (function tools, computer actions, MCP flows),
  * appends their outputs to the run history, and determines the next step for the agent loop.
  */
-export async function resolveTurnAfterModelResponse<TContext>(
-  agent: Agent<TContext, any>,
+export async function resolveTurnAfterModelResponse<
+  TContext,
+  TAgent extends Agent<TContext, any>,
+>(
+  agent: TAgent,
   originalInput: string | AgentInputItem[],
   originalPreStepItems: RunItem[],
   newResponse: ModelResponse,
   processedResponse: ProcessedResponse<TContext>,
   runner: Runner,
-  state: RunState<TContext, Agent<TContext, any>>,
+  state: RunState<TContext, TAgent>,
   toolErrorFormatter?: ToolErrorFormatter,
+  errorHandlers?: RunErrorHandlers<TContext, TAgent>,
 ): Promise<SingleStepResult> {
   // Reuse the same array reference so we can compare object identity when deciding whether to
   // append new items, ensuring we never double-stream existing RunItems.
@@ -786,6 +800,59 @@ export async function resolveTurnAfterModelResponse<TContext>(
       ? getTextFromOutputMessage(messageItems[messageItems.length - 1].rawItem)
       : undefined;
 
+  // Keep looping if any tool output placeholders still require an approval follow-up.
+  const hasPendingToolsOrApprovals =
+    functionResults.some(
+      (result) => result.runItem instanceof RunToolApprovalItem,
+    ) || additionalInterruptions.length > 0;
+
+  if (!hasPendingToolsOrApprovals && messageItems.length > 0) {
+    const refusal = getRefusalFromOutputMessage(
+      messageItems[messageItems.length - 1].rawItem,
+    );
+    if (refusal) {
+      const refusalError = new ModelRefusalError(refusal, state);
+      const generatedItems = preStepItems.concat(newItems);
+      const runData: RunErrorData<TContext, TAgent> = {
+        input: originalInput,
+        newItems: generatedItems,
+        history: getTurnInput(
+          originalInput,
+          generatedItems,
+          state._reasoningItemIdPolicy,
+        ),
+        output: getTurnInput([], generatedItems, state._reasoningItemIdPolicy),
+        rawResponses: state._modelResponses,
+        lastAgent: agent,
+        state,
+      };
+      const handlerResult = await resolveRunErrorHandler({
+        error: refusalError,
+        errorHandlers,
+        context: state._context,
+        runData,
+      });
+      if (!handlerResult) {
+        throw refusalError;
+      }
+
+      const outputText = formatRunErrorFinalOutput(
+        agent,
+        handlerResult.finalOutput,
+      );
+      if (handlerResult.includeInHistory !== false) {
+        newItems.push(createRunErrorFinalOutputItem(agent, outputText));
+      }
+      return new SingleStepResult(
+        originalInput,
+        newResponse,
+        preStepItems,
+        newItems,
+        { type: 'next_step_final_output', output: outputText },
+      );
+    }
+  }
+
   // if there is no output we just run again
   if (typeof potentialFinalOutput === 'undefined') {
     return new SingleStepResult(
@@ -796,12 +863,6 @@ export async function resolveTurnAfterModelResponse<TContext>(
       { type: 'next_step_run_again' },
     );
   }
-
-  // Keep looping if any tool output placeholders still require an approval follow-up.
-  const hasPendingToolsOrApprovals =
-    functionResults.some(
-      (result) => result.runItem instanceof RunToolApprovalItem,
-    ) || additionalInterruptions.length > 0;
 
   if (!hasPendingToolsOrApprovals) {
     if (agent.outputType === 'text') {

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -810,7 +810,7 @@ export async function resolveTurnAfterModelResponse<
     const refusal = getRefusalFromOutputMessage(
       messageItems[messageItems.length - 1].rawItem,
     );
-    if (refusal) {
+    if (refusal && typeof potentialFinalOutput === 'undefined') {
       const refusalError = new ModelRefusalError(refusal, state);
       const generatedItems = preStepItems.concat(newItems);
       const runData: RunErrorData<TContext, TAgent> = {

--- a/packages/agents-core/src/utils/messages.ts
+++ b/packages/agents-core/src/utils/messages.ts
@@ -65,6 +65,32 @@ export function getTextFromOutputMessage(
 }
 
 /**
+ * Get all refusal text from the output message.
+ * @param outputMessage
+ * @returns
+ */
+export function getRefusalFromOutputMessage(
+  outputMessage: ResponseOutputItem,
+): string | undefined {
+  const assistantMessage = getAssistantMessage(outputMessage);
+  if (!assistantMessage) {
+    return undefined;
+  }
+
+  let sawRefusal = false;
+  const refusal = assistantMessage.content.reduce((acc, item) => {
+    if (item.type !== 'refusal') {
+      return acc;
+    }
+
+    sawRefusal = true;
+    return acc + item.refusal;
+  }, '');
+
+  return sawRefusal ? refusal : undefined;
+}
+
+/**
  * Get the last text from the output message.
  * @param output
  * @returns

--- a/packages/agents-core/test/errors.test.ts
+++ b/packages/agents-core/test/errors.test.ts
@@ -3,6 +3,7 @@ import {
   InputGuardrailTripwireTriggered,
   MaxTurnsExceededError,
   ModelBehaviorError,
+  ModelRefusalError,
   OutputGuardrailTripwireTriggered,
   UserError,
   GuardrailExecutionError,
@@ -22,6 +23,11 @@ describe('errors', () => {
     expect(() => {
       throw new ModelBehaviorError('Test error', {} as any);
     }).toThrow('Test error');
+    const refusalError = new ModelRefusalError('No.', {} as any);
+    expect(refusalError.refusal).toBe('No.');
+    expect(() => {
+      throw refusalError;
+    }).toThrow('Model refused to produce output: No.');
     expect(() => {
       throw new UserError('Test error', {} as any);
     }).toThrow('Test error');
@@ -62,6 +68,9 @@ describe('errors', () => {
     );
     expect(new ModelBehaviorError('Test error', {} as any).name).toBe(
       'ModelBehaviorError',
+    );
+    expect(new ModelRefusalError('No.', {} as any).name).toBe(
+      'ModelRefusalError',
     );
     expect(new UserError('Test error', {} as any).name).toBe('UserError');
     expect(

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -4,6 +4,7 @@ import {
   Agent,
   AgentInputItem,
   MaxTurnsExceededError,
+  ModelRefusalError,
   run,
   Runner,
   setDefaultModelProvider,
@@ -28,7 +29,12 @@ import {
   RunState,
   shellTool,
 } from '../src';
-import { FakeModel, FakeModelProvider, fakeModelMessage } from './stubs';
+import {
+  FakeModel,
+  FakeModelProvider,
+  fakeModelMessage,
+  fakeModelRefusal,
+} from './stubs';
 import * as protocol from '../src/types/protocol';
 import * as sessionPersistence from '../src/runner/sessionPersistence';
 import type { GuardrailFunctionOutput } from '../src/guardrail';
@@ -1154,6 +1160,66 @@ describe('Runner.run (streaming)', () => {
     expect(runItemEvents[0].item).toBeInstanceOf(RunMessageOutputItem);
     if (runItemEvents[0].item instanceof RunMessageOutputItem) {
       expect(runItemEvents[0].item.content).toBe('summary');
+    }
+  });
+
+  it('handles model refusal errors with an error handler', async () => {
+    class RefusalStreamingModel implements Model {
+      async getResponse(_req: ModelRequest): Promise<ModelResponse> {
+        return {
+          output: [fakeModelRefusal('I cannot help with that request.')],
+          usage: new Usage(),
+        };
+      }
+
+      async *getStreamedResponse(
+        req: ModelRequest,
+      ): AsyncIterable<StreamEvent> {
+        const response = await this.getResponse(req);
+        yield {
+          type: 'response_done',
+          response: {
+            id: 'r_refusal',
+            usage: {
+              requests: 1,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            output: response.output,
+          },
+        } as any;
+      }
+    }
+
+    const agent = new Agent({
+      name: 'RefusalHandlerStream',
+      model: new RefusalStreamingModel(),
+    });
+    const result = await run(agent, 'x', {
+      stream: true,
+      errorHandlers: {
+        modelRefusal: ({ error }) => {
+          expect(error).toBeInstanceOf(ModelRefusalError);
+          return { finalOutput: 'safe fallback' };
+        },
+      },
+    });
+    const events: RunStreamEvent[] = [];
+    for await (const event of result.toStream()) {
+      events.push(event);
+    }
+    await result.completed;
+    expect(result.finalOutput).toBe('safe fallback');
+    const runItemEvents = events.filter(
+      (event): event is RunItemStreamEvent =>
+        event.type === 'run_item_stream_event',
+    );
+    expect(runItemEvents).toHaveLength(2);
+    expect(runItemEvents[1].name).toBe('message_output_created');
+    expect(runItemEvents[1].item).toBeInstanceOf(RunMessageOutputItem);
+    if (runItemEvents[1].item instanceof RunMessageOutputItem) {
+      expect(runItemEvents[1].item.content).toBe('safe fallback');
     }
   });
 

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -61,6 +61,7 @@ import { getGlobalTraceProvider } from '../src/tracing/provider';
 import {
   FakeModel,
   fakeModelRefusal,
+  fakeModelMessageWithRefusal,
   fakeModelMessage,
   FakeModelProvider,
   FakeTracingExporter,
@@ -1952,6 +1953,45 @@ describe('Runner.run', () => {
         ]),
       });
       await expect(run(agent, 'x')).rejects.toBeInstanceOf(ModelRefusalError);
+    });
+
+    it('uses assistant text when a message also contains refusal content', async () => {
+      const agent = new Agent({
+        name: 'MixedTextRefusal',
+        model: new FakeModel([
+          {
+            output: [
+              fakeModelMessageWithRefusal(
+                'valid answer',
+                'I cannot help with a different part.',
+              ),
+            ],
+            usage: new Usage(),
+          },
+        ]),
+      });
+      const result = await run(agent, 'x');
+      expect(result.finalOutput).toBe('valid answer');
+    });
+
+    it('parses structured assistant text when refusal content is also present', async () => {
+      const agent = new Agent({
+        name: 'MixedStructuredRefusal',
+        outputType: z.object({ summary: z.string() }),
+        model: new FakeModel([
+          {
+            output: [
+              fakeModelMessageWithRefusal(
+                '{"summary":"valid answer"}',
+                'I cannot help with a different part.',
+              ),
+            ],
+            usage: new Usage(),
+          },
+        ]),
+      });
+      const result = await run(agent, 'x');
+      expect(result.finalOutput).toEqual({ summary: 'valid answer' });
     });
 
     it('model refusal handler returns structured final output', async () => {

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -14,6 +14,7 @@ import {
   Agent,
   InputGuardrailTripwireTriggered,
   MaxTurnsExceededError,
+  ModelRefusalError,
   ModelResponse,
   OutputGuardrailTripwireTriggered,
   Session,
@@ -59,6 +60,7 @@ import logger from '../src/logger';
 import { getGlobalTraceProvider } from '../src/tracing/provider';
 import {
   FakeModel,
+  fakeModelRefusal,
   fakeModelMessage,
   FakeModelProvider,
   FakeTracingExporter,
@@ -1920,6 +1922,108 @@ describe('Runner.run', () => {
       });
       expect(result.finalOutput).toBe('summary');
       expect(result.newItems).toHaveLength(0);
+    });
+
+    it('throws model refusal errors instead of retrying refusal-only messages', async () => {
+      const agent = new Agent({
+        name: 'Refusal',
+        model: new FakeModel([
+          {
+            output: [fakeModelRefusal('I cannot help with that request.')],
+            usage: new Usage(),
+          },
+        ]),
+      });
+      await expect(run(agent, 'x', { maxTurns: 3 })).rejects.toMatchObject({
+        name: 'ModelRefusalError',
+        refusal: 'I cannot help with that request.',
+      });
+    });
+
+    it('throws model refusal errors before structured output parsing', async () => {
+      const agent = new Agent({
+        name: 'StructuredRefusalError',
+        outputType: z.object({ summary: z.string() }),
+        model: new FakeModel([
+          {
+            output: [fakeModelRefusal('I cannot help with that request.')],
+            usage: new Usage(),
+          },
+        ]),
+      });
+      await expect(run(agent, 'x')).rejects.toBeInstanceOf(ModelRefusalError);
+    });
+
+    it('model refusal handler returns structured final output', async () => {
+      const agent = new Agent({
+        name: 'StructuredRefusal',
+        outputType: z.object({ summary: z.string() }),
+        model: new FakeModel([
+          {
+            output: [fakeModelRefusal('I cannot help with that request.')],
+            usage: new Usage(),
+          },
+        ]),
+      });
+      const result = await run(agent, 'x', {
+        errorHandlers: {
+          modelRefusal: ({ error, runData }) => {
+            expect(error).toBeInstanceOf(ModelRefusalError);
+            expect((error as ModelRefusalError).refusal).toBe(
+              'I cannot help with that request.',
+            );
+            expect(runData.rawResponses).toHaveLength(1);
+            return { finalOutput: { summary: 'safe fallback' } };
+          },
+        },
+      });
+      expect(result.finalOutput).toEqual({ summary: 'safe fallback' });
+      expect(extractAllTextOutput(result.newItems)).toBe(
+        '{"summary":"safe fallback"}',
+      );
+    });
+
+    it('model refusal handler can skip history updates', async () => {
+      const agent = new Agent({
+        name: 'RefusalNoHistory',
+        model: new FakeModel([
+          {
+            output: [fakeModelRefusal('I cannot help with that request.')],
+            usage: new Usage(),
+          },
+        ]),
+      });
+      const result = await run(agent, 'x', {
+        errorHandlers: {
+          modelRefusal: () => ({
+            finalOutput: 'safe fallback',
+            includeInHistory: false,
+          }),
+        },
+      });
+      expect(result.finalOutput).toBe('safe fallback');
+      expect(extractAllTextOutput(result.newItems)).toBe('');
+    });
+
+    it('default error handler can handle model refusals', async () => {
+      const agent = new Agent({
+        name: 'DefaultRefusal',
+        model: new FakeModel([
+          {
+            output: [fakeModelRefusal('I cannot help with that request.')],
+            usage: new Usage(),
+          },
+        ]),
+      });
+      const result = await run(agent, 'x', {
+        errorHandlers: {
+          default: ({ error }) => {
+            expect(error).toBeInstanceOf(ModelRefusalError);
+            return { finalOutput: 'safe fallback' };
+          },
+        },
+      });
+      expect(result.finalOutput).toBe('safe fallback');
     });
 
     it('enforces maxTurns across multiple model calls', async () => {

--- a/packages/agents-core/test/stubs.ts
+++ b/packages/agents-core/test/stubs.ts
@@ -51,6 +51,20 @@ export function fakeModelMessage(text: string): protocol.AssistantMessageItem {
   };
 }
 
+export function fakeModelRefusal(
+  refusal: string,
+): protocol.AssistantMessageItem {
+  return {
+    ...TEST_MODEL_MESSAGE,
+    content: [
+      {
+        type: 'refusal' as const,
+        refusal,
+      },
+    ],
+  };
+}
+
 export const TEST_MODEL_FUNCTION_CALL: protocol.FunctionCallItem = {
   id: '123',
   type: 'function_call' as const,

--- a/packages/agents-core/test/stubs.ts
+++ b/packages/agents-core/test/stubs.ts
@@ -65,6 +65,28 @@ export function fakeModelRefusal(
   };
 }
 
+export function fakeModelMessageWithRefusal(
+  text: string,
+  refusal: string,
+): protocol.AssistantMessageItem {
+  return {
+    ...TEST_MODEL_MESSAGE,
+    content: [
+      {
+        type: 'output_text' as const,
+        text,
+        providerData: {
+          annotations: [],
+        },
+      },
+      {
+        type: 'refusal' as const,
+        refusal,
+      },
+    ],
+  };
+}
+
 export const TEST_MODEL_FUNCTION_CALL: protocol.FunctionCallItem = {
   id: '123',
   type: 'function_call' as const,

--- a/packages/agents-core/test/utils/messages.test.ts
+++ b/packages/agents-core/test/utils/messages.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   getLastTextFromOutputMessage,
   getOutputText,
+  getRefusalFromOutputMessage,
   getTextFromOutputMessage,
 } from '../../src/utils/messages';
 import type { ResponseOutputItem } from '../../src/types';
@@ -52,6 +53,21 @@ describe('utils/messages', () => {
 
     expect(getTextFromOutputMessage(item)).toBe('part1part2');
     expect(getLastTextFromOutputMessage(item)).toBe('part2');
+  });
+
+  it('concatenates all assistant refusal segments', () => {
+    const item: ResponseOutputItem = {
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [
+        { type: 'refusal', refusal: 'part1' },
+        { type: 'output_text', text: 'ignored' },
+        { type: 'refusal', refusal: 'part2' },
+      ],
+    } as any;
+
+    expect(getRefusalFromOutputMessage(item)).toBe('part1part2');
   });
 
   it('getOutputText returns all assistant text', () => {


### PR DESCRIPTION
This pull request fixes model refusal handling so refusal-only assistant messages are surfaced as `ModelRefusalError` instead of being treated as missing output and retried until `MaxTurnsExceededError`.

It adds `modelRefusal` support to run error handlers, preserves `default` handler fallback behavior, extracts refusal content from assistant messages, and documents the new error path. It also adds coverage for text, structured output, skipped history, default handlers, and streamed runs.

See also: https://github.com/openai/openai-agents-python/pull/3057
