### PR TITLE
feat: expose Responses WebSocket keepalive options

### DIFF
--- a/.changeset/responses-websocket-keepalive.md
+++ b/.changeset/responses-websocket-keepalive.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+feat: expose Responses WebSocket keepalive options

--- a/packages/agents-openai/src/index.ts
+++ b/packages/agents-openai/src/index.ts
@@ -7,6 +7,7 @@ export {
 export {
   OpenAIResponsesModel,
   OpenAIResponsesWSModel,
+  type OpenAIResponsesWebSocketOptions,
 } from './openaiResponsesModel';
 export { OpenAIChatCompletionsModel } from './openaiChatCompletionsModel';
 export {

--- a/packages/agents-openai/src/openaiProvider.ts
+++ b/packages/agents-openai/src/openaiProvider.ts
@@ -9,6 +9,7 @@ import {
 } from './defaults';
 import {
   OpenAIResponsesModel,
+  type OpenAIResponsesWebSocketOptions,
   OpenAIResponsesWSModel,
 } from './openaiResponsesModel';
 import { OpenAIChatCompletionsModel } from './openaiChatCompletionsModel';
@@ -25,6 +26,7 @@ export type OpenAIProviderOptions = {
   project?: string;
   useResponses?: boolean;
   useResponsesWebSocket?: boolean;
+  responsesWebSocketOptions?: OpenAIResponsesWebSocketOptions;
   openAIClient?: OpenAI;
 };
 
@@ -134,6 +136,7 @@ export class OpenAIProvider implements ModelProvider {
             websocketBaseURL:
               this.#getWebSocketBaseURLForResponsesModel(client),
             reuseConnection: shouldCacheModelWrapper,
+            websocketOptions: this.#options.responsesWebSocketOptions,
           })
         : new OpenAIResponsesModel(client, model);
     } else {

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -40,6 +40,7 @@ import {
   webSocketFrameToText,
   withAbortSignal,
   withTimeout,
+  type ResponsesWebSocketKeepAliveOptions,
   type WebSocketMessageValue,
 } from './responsesWebSocketConnection';
 import {
@@ -3229,7 +3230,17 @@ export class OpenAIResponsesModel implements Model {
 export type OpenAIResponsesWSModelOptions = {
   websocketBaseURL?: string;
   reuseConnection?: boolean;
+  websocketOptions?: OpenAIResponsesWebSocketOptions;
 };
+
+export type OpenAIResponsesWebSocketOptions =
+  ResponsesWebSocketKeepAliveOptions;
+
+function cloneResponsesWebSocketOptions(
+  options: OpenAIResponsesWebSocketOptions | undefined,
+): OpenAIResponsesWebSocketOptions {
+  return { ...(options ?? {}) };
+}
 
 /**
  * Model implementation that uses the OpenAI Responses API over a websocket transport.
@@ -3239,6 +3250,7 @@ export type OpenAIResponsesWSModelOptions = {
 export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
   #websocketBaseURL?: string;
   #reuseConnection: boolean;
+  #websocketOptions: OpenAIResponsesWebSocketOptions;
   #wsConnection: ResponsesWebSocketConnection | undefined;
   #wsConnectionIdentity: string | undefined;
   #wsRequestLock: Promise<void> = Promise.resolve();
@@ -3251,6 +3263,9 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
     super(client, model);
     this.#websocketBaseURL = options.websocketBaseURL;
     this.#reuseConnection = options.reuseConnection ?? true;
+    this.#websocketOptions = cloneResponsesWebSocketOptions(
+      options.websocketOptions,
+    );
   }
 
   override getRetryAdvice(
@@ -3653,6 +3668,7 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
       signal,
       connectTimeout.timeoutMs,
       connectTimeout.errorMessage,
+      this.#websocketOptions,
     );
     this.#wsConnectionIdentity = identity;
     return { connection: this.#wsConnection, reused: false };

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -276,7 +276,8 @@ function isNeverSentWebSocketError(error: unknown): boolean {
 function isAmbiguousWebSocketReplayError(error: unknown): boolean {
   if (
     error instanceof ResponsesWebSocketInternalError &&
-    error.code === 'connection_closed_before_terminal_response_event'
+    (error.code === 'connection_closed_before_terminal_response_event' ||
+      error.code === 'pong_timeout')
   ) {
     return true;
   }
@@ -288,7 +289,8 @@ function isAmbiguousWebSocketReplayError(error: unknown): boolean {
 
   return (
     errorCause instanceof ResponsesWebSocketInternalError &&
-    errorCause.code === 'connection_closed_before_terminal_response_event'
+    (errorCause.code === 'connection_closed_before_terminal_response_event' ||
+      errorCause.code === 'pong_timeout')
   );
 }
 

--- a/packages/agents-openai/src/responsesWebSocketConnection.ts
+++ b/packages/agents-openai/src/responsesWebSocketConnection.ts
@@ -7,6 +7,21 @@ export type WebSocketMessageValue =
   | ArrayBuffer
   | ArrayBufferView;
 
+export type ResponsesWebSocketKeepAliveOptions = {
+  /**
+   * Time in milliseconds between keepalive pings sent by the client.
+   *
+   * Set to null to disable client keepalive pings.
+   */
+  pingIntervalMs?: number | null;
+  /**
+   * Time in milliseconds to wait for a pong response before closing the socket.
+   *
+   * Set to null to keep pings enabled but disable heartbeat timeouts.
+   */
+  pingTimeoutMs?: number | null;
+};
+
 export type ResponsesWebSocketInternalErrorCode =
   | 'connection_closed_before_opening'
   | 'connection_closed_before_terminal_response_event'
@@ -158,6 +173,33 @@ export function isWebSocketNotOpenError(error: unknown): boolean {
   return false;
 }
 
+type PingableWebSocket = WebSocket & {
+  ping?: () => void;
+  terminate?: () => void;
+  on?: (eventName: string, listener: (...args: any[]) => void) => unknown;
+  off?: (eventName: string, listener: (...args: any[]) => void) => unknown;
+  removeListener?: (
+    eventName: string,
+    listener: (...args: any[]) => void,
+  ) => unknown;
+};
+
+function normalizeKeepAliveDurationMs(
+  value: number | null | undefined,
+  fieldName: string,
+): number | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  if (Number.isFinite(value) && value > 0) {
+    return value;
+  }
+
+  throw new UserError(
+    `Responses websocket ${fieldName} must be a positive number of milliseconds or null.`,
+  );
+}
+
 export class ResponsesWebSocketConnection {
   #socket: WebSocket;
   #messages: WebSocketMessageValue[] = [];
@@ -169,9 +211,25 @@ export class ResponsesWebSocketConnection {
   #error: Error | undefined;
   #closedPromise: Promise<void>;
   #resolveClosed!: () => void;
+  #pingIntervalMs: number | undefined;
+  #pingTimeoutMs: number | undefined;
+  #pingIntervalTimer: ReturnType<typeof setInterval> | undefined;
+  #pingTimeoutTimer: ReturnType<typeof setTimeout> | undefined;
+  #removePongListener: (() => void) | undefined;
 
-  constructor(socket: WebSocket) {
+  constructor(
+    socket: WebSocket,
+    keepAliveOptions: ResponsesWebSocketKeepAliveOptions = {},
+  ) {
     this.#socket = socket;
+    this.#pingIntervalMs = normalizeKeepAliveDurationMs(
+      keepAliveOptions.pingIntervalMs,
+      'pingIntervalMs',
+    );
+    this.#pingTimeoutMs = normalizeKeepAliveDurationMs(
+      keepAliveOptions.pingTimeoutMs,
+      'pingTimeoutMs',
+    );
     this.#closedPromise = new Promise<void>((resolve) => {
       this.#resolveClosed = resolve;
     });
@@ -179,6 +237,7 @@ export class ResponsesWebSocketConnection {
     this.#socket.addEventListener('message', this.#onMessage as any);
     this.#socket.addEventListener('error', this.#onError as any);
     this.#socket.addEventListener('close', this.#onClose as any);
+    this.#removePongListener = this.#addPongListener();
   }
 
   static async connect(
@@ -187,6 +246,7 @@ export class ResponsesWebSocketConnection {
     signal: AbortSignal | undefined,
     timeoutMs?: number,
     timeoutErrorMessage?: string,
+    keepAliveOptions: ResponsesWebSocketKeepAliveOptions = {},
   ): Promise<ResponsesWebSocketConnection> {
     const WebSocketCtor = (globalThis as any).WebSocket as
       | (new (url: string, init?: unknown) => WebSocket)
@@ -209,9 +269,13 @@ export class ResponsesWebSocketConnection {
       throw wrappedError;
     }
 
-    const connection = new ResponsesWebSocketConnection(socket);
+    const connection = new ResponsesWebSocketConnection(
+      socket,
+      keepAliveOptions,
+    );
     try {
       await connection.waitForOpen(signal, timeoutMs, timeoutErrorMessage);
+      connection.#startKeepAlive();
     } catch (error) {
       await connection.close();
       throw error;
@@ -315,6 +379,7 @@ export class ResponsesWebSocketConnection {
   }
 
   async close(): Promise<void> {
+    this.#stopKeepAlive();
     if (!this.#closed) {
       try {
         this.#socket.close();
@@ -346,6 +411,99 @@ export class ResponsesWebSocketConnection {
     );
   }
 
+  #addPongListener(): (() => void) | undefined {
+    const socket = this.#socket as PingableWebSocket;
+    if (typeof socket.on === 'function') {
+      socket.on('pong', this.#onPong);
+      return () => {
+        if (typeof socket.off === 'function') {
+          socket.off('pong', this.#onPong);
+        } else if (typeof socket.removeListener === 'function') {
+          socket.removeListener('pong', this.#onPong);
+        }
+      };
+    }
+
+    if (typeof socket.addEventListener === 'function') {
+      socket.addEventListener('pong' as any, this.#onPong as any);
+      return () => {
+        socket.removeEventListener('pong' as any, this.#onPong as any);
+      };
+    }
+
+    return undefined;
+  }
+
+  #startKeepAlive(): void {
+    if (typeof this.#pingIntervalMs !== 'number') {
+      return;
+    }
+
+    this.#pingIntervalTimer = setInterval(() => {
+      this.#sendKeepAlivePing();
+    }, this.#pingIntervalMs);
+  }
+
+  #stopKeepAlive(): void {
+    if (this.#pingIntervalTimer) {
+      clearInterval(this.#pingIntervalTimer);
+      this.#pingIntervalTimer = undefined;
+    }
+    this.#clearKeepAliveTimeout();
+    this.#removePongListener?.();
+    this.#removePongListener = undefined;
+  }
+
+  #clearKeepAliveTimeout(): void {
+    if (this.#pingTimeoutTimer) {
+      clearTimeout(this.#pingTimeoutTimer);
+      this.#pingTimeoutTimer = undefined;
+    }
+  }
+
+  #sendKeepAlivePing(): void {
+    if (this.#closed || this.#socket.readyState !== this.#socket.OPEN) {
+      return;
+    }
+
+    const socket = this.#socket as PingableWebSocket;
+    if (typeof socket.ping !== 'function') {
+      return;
+    }
+
+    if (typeof this.#pingTimeoutMs === 'number') {
+      this.#clearKeepAliveTimeout();
+      this.#pingTimeoutTimer = setTimeout(() => {
+        this.#error = new ResponsesWebSocketInternalError(
+          'socket_not_open',
+          'Responses websocket pong timeout.',
+        );
+        try {
+          if (typeof socket.terminate === 'function') {
+            socket.terminate();
+          } else {
+            socket.close();
+          }
+        } catch {
+          // Ignore close errors; waiters will be rejected by the stored error.
+        }
+      }, this.#pingTimeoutMs);
+    }
+
+    try {
+      socket.ping();
+    } catch (error) {
+      this.#clearKeepAliveTimeout();
+      this.#error = error instanceof Error ? error : new Error(String(error));
+      try {
+        socket.close();
+      } catch {
+        // Ignore close errors; waiters will be rejected by the stored error.
+      }
+      return;
+    }
+  }
+
   #onMessage = (event: MessageEvent) => {
     const data = event.data as WebSocketMessageValue;
 
@@ -356,6 +514,10 @@ export class ResponsesWebSocketConnection {
     }
 
     this.#messages.push(data);
+  };
+
+  #onPong = () => {
+    this.#clearKeepAliveTimeout();
   };
 
   #onError = (event: any) => {
@@ -377,6 +539,7 @@ export class ResponsesWebSocketConnection {
   };
 
   #onClose = () => {
+    this.#stopKeepAlive();
     this.#closed = true;
     this.#resolveClosed();
 

--- a/packages/agents-openai/src/responsesWebSocketConnection.ts
+++ b/packages/agents-openai/src/responsesWebSocketConnection.ts
@@ -25,6 +25,7 @@ export type ResponsesWebSocketKeepAliveOptions = {
 export type ResponsesWebSocketInternalErrorCode =
   | 'connection_closed_before_opening'
   | 'connection_closed_before_terminal_response_event'
+  | 'pong_timeout'
   | 'socket_not_open';
 
 export class ResponsesWebSocketInternalError extends Error {
@@ -472,10 +473,13 @@ export class ResponsesWebSocketConnection {
     }
 
     if (typeof this.#pingTimeoutMs === 'number') {
-      this.#clearKeepAliveTimeout();
+      if (this.#pingTimeoutTimer) {
+        return;
+      }
       this.#pingTimeoutTimer = setTimeout(() => {
+        this.#pingTimeoutTimer = undefined;
         this.#error = new ResponsesWebSocketInternalError(
-          'socket_not_open',
+          'pong_timeout',
           'Responses websocket pong timeout.',
         );
         try {

--- a/packages/agents-openai/src/responsesWebSocketConnection.ts
+++ b/packages/agents-openai/src/responsesWebSocketConnection.ts
@@ -270,10 +270,18 @@ export class ResponsesWebSocketConnection {
       throw wrappedError;
     }
 
-    const connection = new ResponsesWebSocketConnection(
-      socket,
-      keepAliveOptions,
-    );
+    let connection: ResponsesWebSocketConnection;
+    try {
+      connection = new ResponsesWebSocketConnection(socket, keepAliveOptions);
+    } catch (error) {
+      try {
+        socket.close();
+      } catch {
+        // Ignore close errors for sockets that failed option validation.
+      }
+      throw error;
+    }
+
     try {
       await connection.waitForOpen(signal, timeoutMs, timeoutErrorMessage);
       connection.#startKeepAlive();

--- a/packages/agents-openai/src/responsesWebSocketSession.ts
+++ b/packages/agents-openai/src/responsesWebSocketSession.ts
@@ -1,11 +1,16 @@
 import { Runner, type RunConfig } from '@openai/agents-core';
 import { OpenAIProvider, type OpenAIProviderOptions } from './openaiProvider';
+import type { OpenAIResponsesWebSocketOptions } from './openaiResponsesModel';
 
 export type ResponsesWebSocketSessionOptions = {
   /**
    * Options used to construct the session-scoped OpenAI provider.
    */
   providerOptions?: OpenAIProviderOptions;
+  /**
+   * Low-level keepalive options for the session-scoped Responses WebSocket transport.
+   */
+  responsesWebSocketOptions?: OpenAIResponsesWebSocketOptions;
   /**
    * Runner configuration for the session. modelProvider is controlled by this helper.
    */
@@ -51,6 +56,9 @@ export async function withResponsesWebSocketSession<T>(
     ...(options.providerOptions ?? {}),
     useResponses: true,
     useResponsesWebSocket: true,
+    responsesWebSocketOptions:
+      options.responsesWebSocketOptions ??
+      options.providerOptions?.responsesWebSocketOptions,
   });
   const runner = new Runner({
     ...(options.runnerConfig ?? {}),

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -772,6 +772,36 @@ describe('OpenAIResponsesModel', () => {
     });
   });
 
+  it('getRetryAdvice marks websocket pong timeouts as unsafe', () => {
+    const fakeClient = {
+      responses: { create: vi.fn() },
+    } as unknown as OpenAI;
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-test');
+
+    expect(
+      model.getRetryAdvice({
+        error: new ResponsesWebSocketInternalError(
+          'pong_timeout',
+          'Responses websocket pong timeout.',
+        ),
+        request: {
+          input: 'hello',
+          modelSettings: {},
+          tools: [],
+          outputType: 'text',
+          handoffs: [],
+          tracing: false,
+        } as any,
+        stream: true,
+        attempt: 1,
+      }),
+    ).toEqual({
+      suggested: false,
+      replaySafety: 'unsafe',
+      reason: 'Responses websocket pong timeout.',
+    });
+  });
+
   it('getRetryAdvice allows non-streaming websocket retries when the request never left the client', () => {
     const fakeClient = {
       responses: { create: vi.fn() },

--- a/packages/agents-openai/test/openaiResponsesWSModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesWSModel.test.ts
@@ -36,6 +36,8 @@ class TestWebSocket {
   readonly init: any;
   readyState = TestWebSocket.CONNECTING;
   sent: string[] = [];
+  pings = 0;
+  autoPong = true;
   private listeners = new Map<string, Set<Listener>>();
 
   constructor(url: string, init?: unknown) {
@@ -73,6 +75,13 @@ class TestWebSocket {
     this.emit('send', { data: String(data) });
   }
 
+  ping() {
+    this.pings += 1;
+    if (this.autoPong) {
+      this.emit('pong', { type: 'pong' });
+    }
+  }
+
   close() {
     if (this.readyState === TestWebSocket.CLOSED) {
       return;
@@ -80,6 +89,10 @@ class TestWebSocket {
 
     this.readyState = TestWebSocket.CLOSED;
     this.emit('close', { type: 'close' });
+  }
+
+  terminate() {
+    this.close();
   }
 
   queueJSON(payload: unknown) {
@@ -140,6 +153,111 @@ describe('OpenAIResponsesWSModel', () => {
       (globalThis as any).WebSocket = originalWebSocket;
     }
     TestWebSocket.reset();
+  });
+
+  it('sends keepalive pings and clears heartbeat timeouts on pong', async () => {
+    vi.useFakeTimers();
+    try {
+      const connection = await ResponsesWebSocketConnection.connect(
+        'wss://proxy.example.test/v1/responses',
+        { Authorization: 'Bearer sk-test' },
+        undefined,
+        undefined,
+        undefined,
+        { pingIntervalMs: 1000, pingTimeoutMs: 500 },
+      );
+
+      await vi.advanceTimersByTimeAsync(2500);
+
+      expect(TestWebSocket.instances).toHaveLength(1);
+      expect(TestWebSocket.instances[0]?.pings).toBe(2);
+
+      await connection.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('closes the websocket when a keepalive pong times out', async () => {
+    vi.useFakeTimers();
+    try {
+      TestWebSocket.onCreate = (socket) => {
+        socket.autoPong = false;
+      };
+
+      const connection = await ResponsesWebSocketConnection.connect(
+        'wss://proxy.example.test/v1/responses',
+        { Authorization: 'Bearer sk-test' },
+        undefined,
+        undefined,
+        undefined,
+        { pingIntervalMs: 1000, pingTimeoutMs: 500 },
+      );
+
+      await vi.advanceTimersByTimeAsync(1500);
+
+      expect(TestWebSocket.instances[0]?.pings).toBe(1);
+      await expect(connection.nextFrame(undefined)).rejects.toThrow(
+        'Responses websocket pong timeout.',
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('passes model keepalive options to websocket connections', async () => {
+    vi.useFakeTimers();
+    const fakeClient = createFakeClient();
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws', {
+      websocketOptions: { pingIntervalMs: 1000, pingTimeoutMs: null },
+    });
+
+    try {
+      TestWebSocket.onCreate = (socket) => {
+        socket.onSend(() => {
+          socket.queueJSON({
+            type: 'response.created',
+            response: { id: 'resp_init' },
+            sequence_number: 0,
+          });
+        });
+      };
+
+      const request = {
+        systemInstructions: undefined,
+        input: 'hello',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+      const consumePromise = (async () => {
+        for await (const _event of model.getStreamedResponse(request as any)) {
+          // Consume stream until the test sends the terminal response.
+        }
+      })();
+
+      await vi.advanceTimersByTimeAsync(2500);
+
+      expect(TestWebSocket.instances).toHaveLength(1);
+      expect(TestWebSocket.instances[0]?.pings).toBe(2);
+
+      TestWebSocket.instances[0]?.queueJSON({
+        type: 'response.completed',
+        response: {
+          id: 'resp_done',
+          output: [],
+          usage: {},
+        },
+        sequence_number: 1,
+      });
+      await consumePromise;
+    } finally {
+      await model.close();
+      vi.useRealTimers();
+    }
   });
 
   it('streams responses over websocket and maps events', async () => {

--- a/packages/agents-openai/test/openaiResponsesWSModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesWSModel.test.ts
@@ -205,6 +205,36 @@ describe('OpenAIResponsesWSModel', () => {
     }
   });
 
+  it('does not reset an outstanding keepalive timeout before pong arrives', async () => {
+    vi.useFakeTimers();
+    try {
+      TestWebSocket.onCreate = (socket) => {
+        socket.autoPong = false;
+      };
+
+      const connection = await ResponsesWebSocketConnection.connect(
+        'wss://proxy.example.test/v1/responses',
+        { Authorization: 'Bearer sk-test' },
+        undefined,
+        undefined,
+        undefined,
+        { pingIntervalMs: 500, pingTimeoutMs: 1000 },
+      );
+
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(TestWebSocket.instances[0]?.pings).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(500);
+
+      await expect(connection.nextFrame(undefined)).rejects.toThrow(
+        'Responses websocket pong timeout.',
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('passes model keepalive options to websocket connections', async () => {
     vi.useFakeTimers();
     const fakeClient = createFakeClient();

--- a/packages/agents-openai/test/openaiResponsesWSModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesWSModel.test.ts
@@ -235,6 +235,24 @@ describe('OpenAIResponsesWSModel', () => {
     }
   });
 
+  it('closes the websocket when keepalive options are invalid', async () => {
+    await expect(
+      ResponsesWebSocketConnection.connect(
+        'wss://proxy.example.test/v1/responses',
+        { Authorization: 'Bearer sk-test' },
+        undefined,
+        undefined,
+        undefined,
+        { pingIntervalMs: 0 },
+      ),
+    ).rejects.toThrow(
+      'Responses websocket pingIntervalMs must be a positive number of milliseconds or null.',
+    );
+
+    expect(TestWebSocket.instances).toHaveLength(1);
+    expect(TestWebSocket.instances[0]?.readyState).toBe(TestWebSocket.CLOSED);
+  });
+
   it('passes model keepalive options to websocket connections', async () => {
     vi.useFakeTimers();
     const fakeClient = createFakeClient();


### PR DESCRIPTION
This pull request adds configurable keepalive options for the OpenAI Responses WebSocket transport in `@openai/agents-openai`.

It introduces `OpenAIResponsesWebSocketOptions` with `pingIntervalMs` and `pingTimeoutMs`, threads those settings through `OpenAIProvider`, `OpenAIResponsesWSModel`, and `withResponsesWebSocketSession`, and applies them in the Responses WebSocket connection wrapper for WebSocket implementations that expose ping/pong support. It also adds regression coverage for ping scheduling, pong timeout cleanup, timeout-triggered close behavior, and model-to-connection option propagation.

See also: https://github.com/openai/openai-agents-python/pull/3080