### PR TITLE
fix: restore PTY child terminal signal defaults

### DIFF
--- a/packages/agents-core/src/sandbox/sandboxes/shared/pty.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/pty.ts
@@ -10,6 +10,12 @@ import select
 import signal
 import sys
 
+PTY_CHILD_SIGNAL_DEFAULTS = (signal.SIGINT, signal.SIGQUIT)
+
+def restore_pty_child_signal_defaults():
+    for signum in PTY_CHILD_SIGNAL_DEFAULTS:
+        signal.signal(signum, signal.SIG_DFL)
+
 executable = sys.argv[1]
 argv = sys.argv[1:]
 pid, fd = pty.fork()
@@ -22,6 +28,7 @@ if pid == 0:
             os.setgid(int(gid))
         if uid:
             os.setuid(int(uid))
+        restore_pty_child_signal_defaults()
         os.execvpe(executable, argv, os.environ)
     except BaseException as exc:
         os.write(2, (str(exc) + '\n').encode())

--- a/packages/agents-core/test/sandboxes/unixLocal.test.ts
+++ b/packages/agents-core/test/sandboxes/unixLocal.test.ts
@@ -10,9 +10,10 @@ import {
   writeFile,
 } from 'node:fs/promises';
 import { execFile } from 'node:child_process';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { promisify } from 'node:util';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   Manifest,
@@ -29,6 +30,20 @@ import {
 } from '../../src/sandbox/sandboxes/shared/localWorkspace';
 
 const execFileAsync = promisify(execFile);
+const testFileDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(testFileDir, '../../..');
+const sandboxLocalModuleUrl = pathToFileURL(
+  join(testFileDir, '../../src/sandbox/local.ts'),
+).href;
+
+const PYTHON_SIGNAL_IGNORE_WRAPPER = String.raw`
+import signal
+import subprocess
+import sys
+
+signal.signal(getattr(signal, sys.argv[1]), signal.SIG_IGN)
+raise SystemExit(subprocess.run(sys.argv[2:]).returncode)
+`;
 
 const ONE_BY_ONE_PNG = Uint8Array.from(
   Buffer.from(
@@ -1270,6 +1285,120 @@ describe('UnixLocalSandboxClient', () => {
     expect(started).toContain('Process running with session ID');
     expect(interrupted).toContain('Process exited with code 130');
   });
+
+  for (const { signalName, chars, expectedExitCodes } of [
+    { signalName: 'SIGINT', chars: '\u0003', expectedExitCodes: [127, 130] },
+    { signalName: 'SIGQUIT', chars: '\u001c', expectedExitCodes: [131] },
+  ]) {
+    it(`interrupts tty commands with ${signalName} even if the parent ignores it`, async () => {
+      const scriptPath = join(rootDir, `pty-${signalName.toLowerCase()}.ts`);
+      await writeFile(
+        scriptPath,
+        `
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { Manifest, UnixLocalSandboxClient } from ${JSON.stringify(sandboxLocalModuleUrl)};
+
+const [, , chars, expectedExitCodesJson] = process.argv;
+const expectedExitCodes = JSON.parse(expectedExitCodesJson);
+
+async function main() {
+  const rootDir = await mkdtemp(join(tmpdir(), 'agents-core-pty-signal-child-'));
+  const client = new UnixLocalSandboxClient({ workspaceBaseDir: rootDir });
+  const session = await client.create(new Manifest());
+
+  try {
+    const started = await session.execCommand({
+      cmd: 'printf "ready\\\\n"; exec sleep 30',
+      shell: '/bin/sh',
+      login: false,
+      tty: true,
+      yieldTimeMs: 500,
+    });
+    const sessionId = Number(
+      started.match(/Process running with session ID (\\d+)/)?.[1],
+    );
+    if (!Number.isFinite(sessionId)) {
+      throw new Error(\`Expected active PTY session, received: \${started}\`);
+    }
+    let readyOutput = started;
+    for (
+      let attempt = 0;
+      attempt < 20 && !readyOutput.includes('ready');
+      attempt += 1
+    ) {
+      readyOutput += await session.writeStdin({
+        sessionId,
+        chars: '',
+        yieldTimeMs: 500,
+      });
+    }
+    if (!readyOutput.includes('ready')) {
+      throw new Error(\`Expected PTY command to become ready, received: \${readyOutput}\`);
+    }
+
+    let interrupted = await session.writeStdin({
+      sessionId,
+      chars,
+      yieldTimeMs: 500,
+    });
+    for (
+      let attempt = 0;
+      attempt < 20 && !interrupted.includes('Process exited with code');
+      attempt += 1
+    ) {
+      interrupted += await session.writeStdin({
+        sessionId,
+        chars: '',
+        yieldTimeMs: 500,
+      });
+    }
+    if (
+      !expectedExitCodes.some((code) =>
+        interrupted.includes(\`Process exited with code \${code}\`),
+      )
+    ) {
+      throw new Error(
+        \`Expected one of exit codes \${expectedExitCodes.join(', ')}, received: \${interrupted}\`,
+      );
+    }
+  } finally {
+    await session.close();
+    await rm(rootDir, { recursive: true, force: true });
+  }
+}
+
+void main();
+`,
+        'utf8',
+      );
+
+      await execFileAsync(
+        process.env.OPENAI_AGENTS_PYTHON ?? 'python3',
+        [
+          '-c',
+          PYTHON_SIGNAL_IGNORE_WRAPPER,
+          signalName,
+          'pnpm',
+          'exec',
+          'tsx',
+          scriptPath,
+          chars,
+          JSON.stringify(expectedExitCodes),
+        ],
+        {
+          cwd: repoRoot,
+          env: {
+            ...process.env,
+            CI: '1',
+          },
+          maxBuffer: 1024 * 1024,
+          timeout: 20_000,
+        },
+      );
+    }, 25_000);
+  }
 
   it('returns only unread output from active sessions', async () => {
     const client = new UnixLocalSandboxClient({


### PR DESCRIPTION
This pull request fixes Unix-local PTY child signal handling so terminal-generated interrupts are not affected when the parent process is temporarily ignoring terminal signals. It restores `SIGINT` and `SIGQUIT` to their default dispositions before the PTY child process execs, and adds regression coverage for Ctrl-C and Ctrl-\ behavior under ignored parent signal handlers.

see also: https://github.com/openai/openai-agents-python/pull/3082