### PR TITLE
feat: add RunInbox for delivering user messages mid-run

### DIFF
--- a/.changeset/run-inbox.md
+++ b/.changeset/run-inbox.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+feat: add `RunInbox` for delivering user messages mid-run without aborting

--- a/docs/src/content/docs/guides/running-agents.mdx
+++ b/docs/src/content/docs/guides/running-agents.mdx
@@ -9,6 +9,7 @@ import helloWorldExample from '../../../../../examples/docs/hello-world.ts?raw';
 import runningAgentsExceptionExample from '../../../../../examples/docs/running-agents/exceptions1.ts?raw';
 import chatLoopExample from '../../../../../examples/docs/running-agents/chatLoop.ts?raw';
 import conversationIdExample from '../../../../../examples/docs/running-agents/conversationId.ts?raw';
+import inboxExample from '../../../../../examples/docs/running-agents/inbox.ts?raw';
 import previousResponseIdExample from '../../../../../examples/docs/running-agents/previousResponseId.ts?raw';
 
 Agents do nothing by themselves – you **run** them with the `Runner` class or the `run()` utility.
@@ -63,6 +64,7 @@ The additional options are:
 | `context` | – | Context object forwarded to every tool / guardrail / handoff. Learn more in the [context guide](/openai-agents-js/guides/context). |
 | `maxTurns` | `10` | Safety limit – throws [`MaxTurnsExceededError`](/openai-agents-js/openai/agents-core/classes/maxturnsexceedederror) when reached. Pass `null` to disable the limit. |
 | `signal` | – | `AbortSignal` for cancellation. |
+| `inbox` | – | [`RunInbox`](/openai-agents-js/openai/agents-core/classes/runinbox) for delivering user messages mid-run without aborting. See [Mid-run user input](#mid-run-user-input). |
 | `session` | – | Session persistence implementation. See the [sessions guide](/openai-agents-js/guides/sessions). |
 | `sessionInputCallback` | – | Custom merge logic for session history and new input; runs before the model call. See [sessions](/openai-agents-js/guides/sessions). |
 | `callModelInputFilter` | – | Hook to edit the model input (items + optional instructions) just before calling the model. See [Call model input filter](#call-model-input-filter). |
@@ -78,6 +80,18 @@ The additional options are:
 ### Streaming
 
 Streaming allows you to additionally receive streaming events as the LLM runs. Once the stream is started, the `StreamedRunResult` will contain the complete information about the run, including all the new outputs produces. You can iterate over the streaming events using a `for await` loop. Read more in the [streaming guide](/openai-agents-js/guides/streaming).
+
+### Mid-run user input
+
+`RunInbox` is a queue-shaped analog to `AbortSignal` – the caller holds the inbox, the runner observes it. Pass one as `inbox` in `RunOptions` and call `inbox.send(...)` from any external context (a websocket handler, an HTTP endpoint, another async task) while the run is in progress. Messages drained from the inbox are appended to the conversation history at the next turn boundary, so the next model call sees them.
+
+<Code
+  lang="typescript"
+  code={inboxExample}
+  title="Delivering a message mid-run"
+/>
+
+Messages are delivered between turns, never mid-model-call. If a message arrives while the model is producing the final output (or during output-guardrail work), the runner extends the loop by one turn so the message is incorporated rather than dropped. When streaming, each delivery emits a `user_input_received` event so consumers can react in real time. Input guardrails configured on the runner or active agent run against the drained batch before it reaches state, so inbox content cannot bypass screening.
 
 ### Run config
 

--- a/examples/agent-patterns/README.md
+++ b/examples/agent-patterns/README.md
@@ -1,7 +1,6 @@
 # Agent Pattern Examples
 
-This directory contains small scripts that demonstrate different agent patterns.
-Run them with `pnpm` using the commands shown below.
+This directory contains small scripts that demonstrate different agent patterns. Run them with `pnpm` using the commands shown below.
 
 - `agents-as-tools.ts` – Orchestrate translator agents using them as tools.
   ```bash
@@ -30,6 +29,10 @@ Run them with `pnpm` using the commands shown below.
 - `human-in-the-loop-stream.ts` – Streaming version of human approval.
   ```bash
   pnpm examples:streamed:human-in-the-loop
+  ```
+- `inbox.ts` – Deliver mid-run user messages via `RunInbox` without aborting the run.
+  ```bash
+  pnpm -F agent-patterns start:inbox
   ```
 - `input-guardrails.ts` – Reject unwanted requests with guardrails.
   ```bash

--- a/examples/agent-patterns/inbox.ts
+++ b/examples/agent-patterns/inbox.ts
@@ -1,0 +1,122 @@
+/**
+ * RunInbox demo: queues a mid-run user message into a `RunInbox` and watches the agent pick it
+ * up at the next turn boundary without aborting the run. The `plan_day` tool is intentionally
+ * slow so a human watching the demo has time to type while a tool call is in flight.
+ *
+ * Suggested demo: type "I just realized I'm bringing my dog! Make activities dog-friendly."
+ * after day 2 finishes. Days 3–5 should reflect the new constraint without any restart.
+ */
+import readline from 'node:readline';
+import { Agent, RunInbox, run, tool } from '@openai/agents';
+import chalk from 'chalk';
+import { z } from 'zod';
+
+// Slow on purpose so a human watching the demo has time to type during a tool call.
+const TOOL_LATENCY_MS = 6000;
+
+const planDay = tool({
+  name: 'plan_day',
+  description:
+    'Plan activities for one day of a trip. Call this exactly once per day, in order, before producing the final itinerary.',
+  parameters: z.object({
+    day: z.number().int().min(1).describe('Day number, starting from 1.'),
+    theme: z
+      .string()
+      .describe(
+        'Short summary of the theme/constraints for this day (e.g. "food tour", "dog-friendly outdoor", "rainy-day backup").',
+      ),
+  }),
+  execute: async ({ day, theme }) => {
+    await new Promise((resolve) => setTimeout(resolve, TOOL_LATENCY_MS));
+    return `Day ${day} (${theme}): three suggested stops with timings.`;
+  },
+});
+
+const agent = new Agent({
+  name: 'TripPlanner',
+  instructions: `
+You are planning a multi-day trip. For each day from 1 through the requested
+total, call the \`plan_day\` tool exactly once, IN ORDER, before producing any
+prose. Pass a short \`theme\` string that captures the user's current
+constraints. After all days are planned, write a brief itinerary acknowledging
+those constraints.
+
+If the user gives you new constraints partway through (you'll see them as
+fresh user messages between tool calls), incorporate them into the remaining
+days and call them out explicitly in your final itinerary. Do not redo days
+that were already planned.
+  `.trim(),
+  tools: [planDay],
+  model: 'gpt-4.1',
+});
+
+const inbox = new RunInbox();
+const rl = readline.createInterface({ input: process.stdin });
+
+rl.on('line', (line) => {
+  const text = line.trim();
+  if (!text) return;
+  inbox.send(text);
+  console.log(
+    chalk.yellow(
+      `\n>> queued for agent: "${text}" (inbox size: ${inbox.size})\n`,
+    ),
+  );
+});
+
+async function main() {
+  console.log(chalk.bgCyan('  ● RunInbox demo: trip planner  \n'));
+  console.log(
+    chalk.dim(
+      'Type any message and press Enter while the agent is working.\n' +
+        'It will be queued and delivered at the next turn boundary.\n',
+    ),
+  );
+
+  const prompt =
+    'Plan a 5-day Tokyo trip. Plan days 1 through 5 individually using plan_day, in order, then summarize.';
+
+  console.log(`${chalk.bold('Prompt:')} ${prompt}\n`);
+
+  const result = await run(agent, prompt, { stream: true, inbox });
+
+  for await (const event of result.toStream()) {
+    if (event.type !== 'run_item_stream_event') continue;
+
+    switch (event.name) {
+      case 'tool_called': {
+        const item = event.item as any;
+        const args = item.rawItem?.arguments ?? '{}';
+        console.log(chalk.cyan(`[tool] ${item.toolName}(${args})`));
+        break;
+      }
+      case 'tool_output': {
+        const item = event.item as any;
+        console.log(chalk.gray(`       → ${item.output}`));
+        break;
+      }
+      case 'user_input_received': {
+        // Fires the moment the runner drained the inbox into the turn input.
+        const item = event.item as any;
+        console.log(chalk.magenta(`[inbox delivered] "${item.content}"`));
+        break;
+      }
+      case 'message_output_created': {
+        const item = event.item as any;
+        console.log(chalk.green(`\n[assistant]\n${item.content}\n`));
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  await result.completed;
+  console.log(chalk.bgCyan('  ● run complete  '));
+  rl.close();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/agent-patterns/package.json
+++ b/examples/agent-patterns/package.json
@@ -16,6 +16,7 @@
     "start:forcing-tool-use": "tsx forcing-tool-use.ts -t default",
     "start:human-in-the-loop-stream": "tsx human-in-the-loop-stream.ts",
     "start:human-in-the-loop": "tsx human-in-the-loop.ts",
+    "start:inbox": "tsx inbox.ts",
     "start:input-guardrails": "tsx input-guardrails.ts",
     "start:llm-as-a-judge": "tsx llm-as-a-judge.ts",
     "start:output-guardrails": "tsx output-guardrails.ts",

--- a/examples/docs/running-agents/inbox.ts
+++ b/examples/docs/running-agents/inbox.ts
@@ -1,0 +1,18 @@
+import { Agent, RunInbox, run } from '@openai/agents';
+
+const agent = new Agent({
+  name: 'Planner',
+  instructions: "Plan the user's deep work session. Be thorough.",
+});
+
+// The caller holds the inbox; the runner observes it. Mirrors the AbortSignal pattern.
+const inbox = new RunInbox();
+
+const promise = run(agent, 'plan a 30-minute deep work session', { inbox });
+
+// Some time later, from another async context (a websocket handler, an HTTP endpoint, etc.):
+inbox.send('also remind me to drink water halfway through');
+
+const result = await promise;
+
+console.log(result.finalOutput);

--- a/packages/agents-core/src/events.ts
+++ b/packages/agents-core/src/events.ts
@@ -42,7 +42,8 @@ export type RunItemStreamEventName =
   | 'tool_called'
   | 'tool_output'
   | 'reasoning_item_created'
-  | 'tool_approval_requested';
+  | 'tool_approval_requested'
+  | 'user_input_received';
 
 /**
  * Streaming events that wrap a `RunItem`. As the agent processes the LLM response, it will generate

--- a/packages/agents-core/src/inbox.ts
+++ b/packages/agents-core/src/inbox.ts
@@ -1,0 +1,97 @@
+import { user } from './helpers/message';
+import * as protocol from './types/protocol';
+
+/**
+ * A `RunInbox` accepts user messages from outside the agent loop and delivers them at the next
+ * turn boundary without aborting the run.
+ *
+ * Conceptual analog to {@link AbortSignal}: the caller holds the inbox, the runner observes it.
+ * Pass an inbox via `RunOptions.inbox` and call {@link RunInbox.send} from any external context
+ * (a websocket handler, an HTTP endpoint, another async task) while the run is in progress. The
+ * runner drains pending messages at the start of each turn and inserts them into the conversation
+ * history so the next model call sees them.
+ *
+ * Delivered messages live in `state._generatedItems` and so they survive `RunState`
+ * serialization, appear in `result.history` / `result.newItems`, and flow through session
+ * persistence. **Undrained** messages live only in this `RunInbox` instance and are *not* part
+ * of the serialized state — if you snapshot a run mid-flight, drain or resend any pending
+ * content yourself.
+ *
+ * Input guardrails configured on the runner or active agent run against the drained batch
+ * before it reaches state, so inbox content cannot bypass screening. A tripwire raises
+ * `InputGuardrailTripwireTriggered` and the offending batch is dropped.
+ *
+ * Messages are delivered between turns, never mid-model-call. If a message arrives during the
+ * model response that would otherwise produce the final output (or during the output-guardrail
+ * work that follows it), the loop runs one extra turn so the message is incorporated rather
+ * than dropped.
+ *
+ * @example
+ * ```ts
+ * const inbox = new RunInbox();
+ * const promise = run(agent, 'plan a 30-minute deep work session', { inbox });
+ *
+ * // From elsewhere — e.g., a websocket handler
+ * inbox.send('also remind me to drink water halfway through');
+ *
+ * const result = await promise;
+ * ```
+ */
+export class RunInbox {
+  #pending: protocol.UserMessageItem[] = [];
+
+  /**
+   * Queue one or more user messages for delivery at the next turn boundary.
+   *
+   * Strings are wrapped in a user message via the {@link user} helper. Pass a
+   * {@link protocol.UserMessageItem} (or array of them) when you need control over content
+   * parts, attachments, or `providerData`.
+   */
+  send(
+    message:
+      | string
+      | protocol.UserMessageItem
+      | ReadonlyArray<string | protocol.UserMessageItem>,
+  ): void {
+    if (Array.isArray(message)) {
+      for (const entry of message) {
+        this.#pending.push(this.#coerce(entry));
+      }
+      return;
+    }
+    this.#pending.push(
+      this.#coerce(message as string | protocol.UserMessageItem),
+    );
+  }
+
+  /**
+   * Number of messages waiting to be delivered. Useful for callers that want to observe whether
+   * the runner has consumed everything yet.
+   */
+  get size(): number {
+    return this.#pending.length;
+  }
+
+  /**
+   * Removes and returns all queued messages. Called by the runner at turn boundaries; can be
+   * called externally to inspect or transfer the contents (for example, when migrating an inbox
+   * across runs).
+   */
+  drain(): protocol.UserMessageItem[] {
+    if (this.#pending.length === 0) {
+      return [];
+    }
+    const out = this.#pending;
+    this.#pending = [];
+    return out;
+  }
+
+  #coerce(
+    message: string | protocol.UserMessageItem,
+  ): protocol.UserMessageItem {
+    if (typeof message === 'string') {
+      return user(message);
+    }
+    return message;
+  }
+}

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -97,7 +97,9 @@ export {
   RunToolCallOutputItem,
   RunToolSearchCallItem,
   RunToolSearchOutputItem,
+  RunUserInputItem,
 } from './items';
+export { RunInbox } from './inbox';
 export { AgentHooks } from './lifecycle';
 export { getLogger } from './logger';
 export { applyDiff } from './utils/applyDiff';

--- a/packages/agents-core/src/items.ts
+++ b/packages/agents-core/src/items.ts
@@ -46,6 +46,46 @@ export class RunMessageOutputItem extends RunItemBase {
   }
 }
 
+/**
+ * A user message that was injected into a running loop via {@link RunInbox}. The runner appends
+ * one of these to `state._generatedItems` at the start of each turn for every message drained
+ * from the inbox. Treating these as run items (rather than mutating `_originalInput`) preserves
+ * chronological order in `result.history` and ensures they survive `RunState` serialization.
+ *
+ * The `agent` field records which agent was active at drain time, mirroring the pattern used by
+ * other run items.
+ */
+export class RunUserInputItem extends RunItemBase {
+  public readonly type = 'user_input_item' as const;
+
+  constructor(
+    public rawItem: protocol.UserMessageItem,
+    public agent: Agent,
+  ) {
+    super();
+  }
+
+  toJSON() {
+    return {
+      ...super.toJSON(),
+      agent: this.agent.toJSON(),
+    };
+  }
+
+  get content(): string {
+    if (typeof this.rawItem.content === 'string') {
+      return this.rawItem.content;
+    }
+    let content = '';
+    for (const part of this.rawItem.content) {
+      if (part.type === 'input_text') {
+        content += part.text;
+      }
+    }
+    return content;
+  }
+}
+
 export class RunToolCallItem extends RunItemBase {
   public readonly type = 'tool_call_item' as const;
 
@@ -283,6 +323,7 @@ function getStringProperty(item: object, key: string): string | undefined {
 
 export type RunItem =
   | RunMessageOutputItem
+  | RunUserInputItem
   | RunToolCallItem
   | RunToolSearchCallItem
   | RunToolSearchOutputItem

--- a/packages/agents-core/src/result.ts
+++ b/packages/agents-core/src/result.ts
@@ -156,10 +156,21 @@ class RunResultBase<
    *
    * It does not include information about the agents and instead represents the model data.
    *
+   * Items injected via {@link RunInbox} are user-originated input rather than model output, so
+   * they are excluded here. They remain in `newItems` and `history` for callers that need the
+   * full chronological record.
+   *
    * For the output including the agents, use the `newItems` property.
    */
   get output(): AgentOutputItem[] {
-    return getTurnInput([], this.newItems, this.state._reasoningItemIdPolicy);
+    const modelProducedItems = this.newItems.filter(
+      (item) => item.type !== 'user_input_item',
+    );
+    return getTurnInput(
+      [],
+      modelProducedItems,
+      this.state._reasoningItemIdPolicy,
+    );
   }
 
   /**

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -39,6 +39,8 @@ import type { SandboxRunConfig } from './sandbox/client';
 import { SandboxRuntimeManager } from './sandbox/runtime';
 import type { SandboxRuntimeModel } from './sandbox/runtime/agentPreparation';
 import type { AgentInputItem } from './types';
+import { RunInbox } from './inbox';
+import { drainInboxIntoState } from './runner/inbox';
 import {
   ServerConversationTracker,
   applyCallModelInputFilter,
@@ -332,6 +334,18 @@ type SharedRunOptions<
   tracing?: TracingConfig;
   sandbox?: SandboxRunConfig;
   toolExecution?: ToolExecutionConfig;
+  /**
+   * Optional message inbox for delivering user input into a running agent loop without
+   * aborting. Callers hold the {@link RunInbox} reference and call `inbox.send(...)` from
+   * outside the run; the runner drains pending messages at each turn boundary and inserts
+   * them into the conversation history so the next model call sees them.
+   *
+   * Conceptually a queue-shaped analog to {@link AbortSignal} — `signal` lets the caller stop
+   * a run, `inbox` lets the caller append to one. Messages are delivered between turns, never
+   * mid-model-call. If the model produces a final output while the inbox holds queued messages,
+   * the runner extends the loop by one extra turn so those messages are not dropped.
+   */
+  inbox?: RunInbox;
   /**
    * Error handlers keyed by error kind.
    */
@@ -883,6 +897,14 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           if (state._currentStep.type === 'next_step_run_again') {
             const wasContinuingInterruptedTurn = continuingInterruptedTurn;
             continuingInterruptedTurn = false;
+            // Drain any messages queued via the inbox into _generatedItems so prepareTurn picks
+            // them up as part of the model input for this turn. Input guardrails run inside the
+            // drain so inbox content cannot bypass screening; tripwires throw out of the loop.
+            await drainInboxIntoState(
+              state,
+              options.inbox,
+              this.inputGuardrailDefs,
+            );
             const guardrailTracker = createGuardrailTracker();
             const previousTurn = state._currentTurn;
             const previousPersistedCount = state._currentTurnPersistedItemCount;
@@ -1031,11 +1053,28 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
 
           switch (currentStep.type) {
             case 'next_step_final_output':
+              if (options.inbox && options.inbox.size > 0) {
+                // A message arrived while the model was producing the final output. Run one more
+                // turn so it is incorporated rather than dropped. Output guardrails for this step
+                // are skipped intentionally — they will run on the eventual final output.
+                state._currentStep = { type: 'next_step_run_again' };
+                state._currentTurnInProgress = false;
+                break;
+              }
               await runOutputGuardrails(
                 state,
                 this.outputGuardrailDefs,
                 currentStep.output,
               );
+              if (options.inbox && options.inbox.size > 0) {
+                // A message arrived during output-guardrail / persistence work. Roll back the
+                // final-output decision and run another turn so the message is delivered.
+                // Discarding the just-computed guardrail result is fine: the next final output
+                // will get its own pass.
+                state._currentStep = { type: 'next_step_run_again' };
+                state._currentTurnInProgress = false;
+                break;
+              }
               state._currentTurnInProgress = false;
               this.emit(
                 'agent_end',
@@ -1255,6 +1294,19 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           guardrailTracker = createGuardrailTracker();
           const wasContinuingInterruptedTurn = continuingInterruptedTurn;
           continuingInterruptedTurn = false;
+          // Drain any messages queued via the inbox into _generatedItems so prepareTurn picks
+          // them up as part of the model input for this turn. Input guardrails run inside the
+          // drain so inbox content cannot bypass screening; tripwires throw out of the loop.
+          // Stream a `user_input_received` event for each drained message so consumers can
+          // react in real time.
+          const drainedInboxItems = await drainInboxIntoState(
+            result.state,
+            options.inbox,
+            this.inputGuardrailDefs,
+          );
+          if (drainedInboxItems.length > 0) {
+            streamStepItemsToRunResult(result, drainedInboxItems);
+          }
           const previousTurn = result.state._currentTurn;
           const previousPersistedCount =
             result.state._currentTurnPersistedItemCount;
@@ -1542,6 +1594,14 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         const currentStep = result.state._currentStep;
         switch (currentStep.type) {
           case 'next_step_final_output':
+            if (options.inbox && options.inbox.size > 0) {
+              // A message arrived while the model was producing the final output. Run one more
+              // turn so it is incorporated rather than dropped. Output guardrails for this step
+              // are skipped intentionally — they will run on the eventual final output.
+              result.state._currentStep = { type: 'next_step_run_again' };
+              result.state._currentTurnInProgress = false;
+              break;
+            }
             try {
               await runOutputGuardrails(
                 result.state,
@@ -1553,6 +1613,15 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               result.state._currentStep = undefined;
               result.state._finalOutputSource = undefined;
               throw error;
+            }
+            if (options.inbox && options.inbox.size > 0) {
+              // A message arrived during output-guardrail work. Roll back the final-output
+              // decision and run another turn so the message is delivered. Discarding the
+              // just-computed guardrail result is fine: the next final output will get its
+              // own pass.
+              result.state._currentStep = { type: 'next_step_run_again' };
+              result.state._currentTurnInProgress = false;
+              break;
             }
             result.state._currentTurnInProgress = false;
             await persistStreamInputIfNeeded();

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -12,6 +12,7 @@ import {
   RunReasoningItem,
   RunHandoffCallItem,
   RunHandoffOutputItem,
+  RunUserInputItem,
 } from './items';
 import type { ModelResponse, ModelSettings } from './model';
 import { RunContext } from './runContext';
@@ -89,8 +90,9 @@ import {
  * - 1.10: Adds optional stable agent identity keys so duplicate-name agent graphs can
  *   serialize and resume without ambiguous name resolution.
  * - 1.11: Allows null maxTurns to persist runs without a turn limit.
+ * - 1.12: Adds user_input_item variant to support {@link RunInbox} message injection.
  */
-export const CURRENT_SCHEMA_VERSION = '1.11' as const;
+export const CURRENT_SCHEMA_VERSION = '1.12' as const;
 const SUPPORTED_SCHEMA_VERSIONS = [
   '1.0',
   '1.1',
@@ -103,6 +105,7 @@ const SUPPORTED_SCHEMA_VERSIONS = [
   '1.8',
   '1.9',
   '1.10',
+  '1.11',
   CURRENT_SCHEMA_VERSION,
 ] as const;
 type SupportedSchemaVersion = (typeof SUPPORTED_SCHEMA_VERSIONS)[number];
@@ -178,6 +181,11 @@ const itemSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('message_output_item'),
     rawItem: protocol.AssistantMessageItem,
+    agent: serializedAgentSchema,
+  }),
+  z.object({
+    type: z.literal('user_input_item'),
+    rawItem: protocol.UserMessageItem,
     agent: serializedAgentSchema,
   }),
   z.object({
@@ -1037,6 +1045,10 @@ async function buildRunStateFromString<
     currentSchemaVersion as SupportedSchemaVersion,
     stateJson,
   );
+  assertSchemaVersionSupportsUserInputItems(
+    currentSchemaVersion as SupportedSchemaVersion,
+    stateJson,
+  );
   return buildRunStateFromJson(initialAgent, stateJson, options);
 }
 
@@ -1048,6 +1060,7 @@ function assertSchemaVersionSupportsToolSearch(
     schemaVersion === '1.8' ||
     schemaVersion === '1.9' ||
     schemaVersion === '1.10' ||
+    schemaVersion === '1.11' ||
     schemaVersion === CURRENT_SCHEMA_VERSION
   ) {
     return;
@@ -1065,7 +1078,34 @@ function assertSchemaVersionSupportsToolSearch(
 function schemaVersionSupportsAgentIdentity(
   schemaVersion: SupportedSchemaVersion,
 ): boolean {
-  return schemaVersion === '1.10' || schemaVersion === CURRENT_SCHEMA_VERSION;
+  return (
+    schemaVersion === '1.10' ||
+    schemaVersion === '1.11' ||
+    schemaVersion === CURRENT_SCHEMA_VERSION
+  );
+}
+
+function assertSchemaVersionSupportsUserInputItems(
+  schemaVersion: SupportedSchemaVersion,
+  stateJson: z.infer<typeof SerializedRunState>,
+): void {
+  if (schemaVersion === CURRENT_SCHEMA_VERSION) {
+    return;
+  }
+
+  if (!containsUserInputRunItems(stateJson.generatedItems)) {
+    return;
+  }
+
+  throw new UserError(
+    `Run state schema version ${schemaVersion} does not support user_input_item entries. Please reserialize the run state with schema ${CURRENT_SCHEMA_VERSION}.`,
+  );
+}
+
+function containsUserInputRunItems(
+  items: z.infer<typeof itemSchema>[] | undefined,
+): boolean {
+  return Boolean(items?.some((item) => item.type === 'user_input_item'));
 }
 
 function containsSerializedToolSearchState(
@@ -2043,6 +2083,11 @@ export function deserializeItem(
       return new RunMessageOutputItem(
         serializedItem.rawItem,
         resolveSerializedAgent(serializedItem.agent, agentMap),
+      );
+    case 'user_input_item':
+      return new RunUserInputItem(
+        serializedItem.rawItem,
+        agentMap.get(serializedItem.agent.name) as Agent<any, any>,
       );
     case 'tool_search_call_item':
       return new RunToolSearchCallItem(

--- a/packages/agents-core/src/runner/guardrails.ts
+++ b/packages/agents-core/src/runner/guardrails.ts
@@ -196,13 +196,29 @@ export async function runInputGuardrails<
 >(
   state: RunState<TContext, TAgent>,
   guardrails: InputGuardrailDefinition[],
+  options: {
+    /**
+     * Override the input items the guardrails screen. Defaults to `state._originalInput`.
+     * Used by the inbox path so guardrails see the newly arrived messages, not the initial
+     * input.
+     */
+    input?: Parameters<InputGuardrailDefinition['run']>[0]['input'];
+    /**
+     * If `true` (default), decrement `state._currentTurn` before throwing
+     * `GuardrailExecutionError` so callers can retry from a clean state. Set to `false` for
+     * mid-run guardrail invocations (such as inbox drains) where rolling back the turn would
+     * leave the run in an inconsistent state.
+     */
+    rollbackTurnOnError?: boolean;
+  } = {},
 ): Promise<InputGuardrailResult[]> {
   if (guardrails.length === 0) {
     return [];
   }
+  const rollbackTurnOnError = options.rollbackTurnOnError ?? true;
   const guardrailArgs = {
     agent: state._currentAgent,
-    input: state._originalInput,
+    input: options.input ?? state._originalInput,
     context: state._context,
   };
   return await runGuardrailsWithTripwire({
@@ -220,8 +236,10 @@ export async function runInputGuardrails<
     isTripwireError: (error) =>
       error instanceof InputGuardrailTripwireTriggered,
     onError: (error) => {
-      // roll back the current turn to enable reruns
-      state._currentTurn--;
+      if (rollbackTurnOnError) {
+        // roll back the current turn to enable reruns
+        state._currentTurn--;
+      }
       throw new GuardrailExecutionError(
         `Input guardrail failed to complete: ${error}`,
         error as Error,

--- a/packages/agents-core/src/runner/inbox.ts
+++ b/packages/agents-core/src/runner/inbox.ts
@@ -1,0 +1,72 @@
+import { Agent } from '../agent';
+import type { InputGuardrailDefinition } from '../guardrail';
+import type { RunInbox } from '../inbox';
+import { RunUserInputItem } from '../items';
+import type { RunState } from '../runState';
+import {
+  buildInputGuardrailDefinitions,
+  runInputGuardrails,
+} from './guardrails';
+
+/**
+ * Moves any messages waiting in the inbox into the run's generated-items list so the next call
+ * to `prepareTurn` includes them in the model input.
+ *
+ * Called at two boundaries:
+ *  1. The top of every `next_step_run_again` iteration, so messages queued mid-run reach the
+ *     model on the next turn.
+ *  2. Just before the loop would honor `next_step_final_output`, where a non-empty inbox
+ *     converts the step into another `next_step_run_again` so messages received during the final
+ *     model call are not dropped.
+ *
+ * The chosen drain location matters: pushing onto `_generatedItems` (rather than `_originalInput`)
+ * preserves chronological order in `result.history`, and the items are picked up automatically by
+ * `prepareModelInputItems`, the `ServerConversationTracker`, and session persistence.
+ *
+ * Input guardrails configured on the runner or active agent are executed against the drained
+ * messages before they are appended to state. This keeps the screening boundary symmetric with
+ * how initial user input is handled — content arriving via the inbox cannot bypass policy
+ * checks. A tripwire throws `InputGuardrailTripwireTriggered`; a guardrail crash throws
+ * `GuardrailExecutionError`. In either case the offending batch is dropped (not partially
+ * persisted) so resumed runs do not contain unscreened content. For simplicity v1 runs all
+ * configured input guardrails as blocking against the drained batch; honoring `runInParallel`
+ * for inbox messages can be added later without changing the public surface.
+ *
+ * Returns the items appended (or `[]`) so streaming callers can emit corresponding events.
+ */
+export async function drainInboxIntoState(
+  state: RunState<any, Agent<any, any>>,
+  inbox: RunInbox | undefined,
+  runnerInputGuardrailDefs: InputGuardrailDefinition[],
+): Promise<RunUserInputItem[]> {
+  if (!inbox || inbox.size === 0) {
+    return [];
+  }
+  const messages = inbox.drain();
+  if (messages.length === 0) {
+    return [];
+  }
+  const agent = state._currentAgent as Agent<any, any>;
+
+  const guardrailDefs = buildInputGuardrailDefinitions(
+    state,
+    runnerInputGuardrailDefs,
+  );
+  if (guardrailDefs.length > 0) {
+    // Throws on tripwire / execution failure. Messages are dropped (already removed from the
+    // inbox via drain, but never appended to state) so a caller catching the exception and
+    // resuming from `state` does not see unscreened content in history.
+    await runInputGuardrails(state, guardrailDefs, {
+      input: messages,
+      rollbackTurnOnError: false,
+    });
+  }
+
+  const items: RunUserInputItem[] = [];
+  for (const message of messages) {
+    const item = new RunUserInputItem(message, agent);
+    state._generatedItems.push(item);
+    items.push(item);
+  }
+  return items;
+}

--- a/packages/agents-core/src/runner/streaming.ts
+++ b/packages/agents-core/src/runner/streaming.ts
@@ -11,6 +11,7 @@ import {
   RunToolCallOutputItem,
   RunToolSearchCallItem,
   RunToolSearchOutputItem,
+  RunUserInputItem,
 } from '../items';
 import { StreamedRunResult } from '../result';
 
@@ -38,6 +39,9 @@ function getRunItemStreamEventName(
 ): RunItemStreamEventName | undefined {
   if (item instanceof RunMessageOutputItem) {
     return 'message_output_created';
+  }
+  if (item instanceof RunUserInputItem) {
+    return 'user_input_received';
   }
   if (item instanceof RunHandoffCallItem) {
     return 'handoff_requested';

--- a/packages/agents-core/test/inbox.test.ts
+++ b/packages/agents-core/test/inbox.test.ts
@@ -3,6 +3,7 @@ import {
   Agent,
   AgentInputItem,
   InputGuardrailTripwireTriggered,
+  MaxTurnsExceededError,
   MemorySession,
   RunInbox,
   RunUserInputItem,
@@ -278,6 +279,65 @@ describe('Runner.run with inbox (non-streaming)', () => {
     expect(inboxIdx).toBeGreaterThan(callIdx);
 
     // Inbox is drained after delivery.
+    expect(inbox.size).toBe(0);
+  });
+
+  it('preserves drained inbox messages on `state` when the next turn exceeds maxTurns', async () => {
+    // Regression guard: drainInboxIntoState pushes RunUserInputItems onto state._generatedItems
+    // BEFORE prepareTurn enforces maxTurns, and MaxTurnsExceededError carries `state`. So even
+    // when the very next turn would max out, the drained content is reachable via `error.state`
+    // and the caller can resume.
+    const responses: ModelResponse[] = [
+      {
+        output: [functionCall('call_1', 'noop')],
+        usage: new Usage(),
+      },
+    ];
+
+    const inbox = new RunInbox();
+    const model = new RecordingModel(responses, {
+      onCall: (callIndex) => {
+        if (callIndex === 0) {
+          inbox.send('queued mid-run before maxTurns trips');
+        }
+      },
+    });
+
+    const agent = new Agent({
+      name: 'InboxAgent',
+      model,
+      tools: [
+        {
+          type: 'function',
+          name: 'noop',
+          description: 'no op',
+          strict: true,
+          parameters: {
+            type: 'object',
+            properties: {},
+            additionalProperties: false,
+          },
+          needsApproval: async () => false,
+          invoke: async () => 'ok',
+        } as any,
+      ],
+    });
+
+    let caught: unknown;
+    try {
+      await new Runner().run(agent, 'kick off', { inbox, maxTurns: 1 });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(MaxTurnsExceededError);
+    const error = caught as MaxTurnsExceededError;
+    expect(error.state).toBeDefined();
+    const inboxItems = error.state!._generatedItems.filter(
+      (item) => item instanceof RunUserInputItem,
+    ) as RunUserInputItem[];
+    expect(inboxItems).toHaveLength(1);
+    expect(inboxItems[0].content).toBe('queued mid-run before maxTurns trips');
     expect(inbox.size).toBe(0);
   });
 

--- a/packages/agents-core/test/inbox.test.ts
+++ b/packages/agents-core/test/inbox.test.ts
@@ -1,0 +1,755 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  Agent,
+  AgentInputItem,
+  InputGuardrailTripwireTriggered,
+  MemorySession,
+  RunInbox,
+  RunUserInputItem,
+  Runner,
+  RunState,
+  setDefaultModelProvider,
+  setTracingDisabled,
+  user,
+  withTrace,
+} from '../src';
+import { drainInboxIntoState } from '../src/runner/inbox';
+import { RunContext } from '../src/runContext';
+import {
+  FakeModel,
+  FakeModelProvider,
+  fakeModelMessage,
+  TEST_MODEL_FUNCTION_CALL,
+  TEST_MODEL_MESSAGE,
+  TEST_MODEL_RESPONSE_BASIC,
+} from './stubs';
+import { Model, ModelRequest, ModelResponse } from '../src/model';
+import * as protocol from '../src/types/protocol';
+import { Usage } from '../src/usage';
+import { tool } from '../src/tool';
+import { z } from 'zod';
+
+function getFirstTextContent(item: AgentInputItem): string | undefined {
+  if (item.type !== 'message') {
+    return undefined;
+  }
+  if (typeof item.content === 'string') {
+    return item.content;
+  }
+  if (Array.isArray(item.content)) {
+    const first = item.content[0] as { text?: string };
+    return first?.text;
+  }
+  return undefined;
+}
+
+function getRequestInputItems(request: ModelRequest): AgentInputItem[] {
+  return Array.isArray(request.input) ? request.input : [];
+}
+
+/**
+ * A model that records the input items each `getResponse` call sees and returns the
+ * pre-configured response for that call. Lets tests assert exactly what the model saw on
+ * each turn.
+ */
+class RecordingModel implements Model {
+  public readonly seenInputs: AgentInputItem[][] = [];
+
+  constructor(
+    private readonly responses: ModelResponse[],
+    private readonly hooks: { onCall?: (callIndex: number) => void } = {},
+  ) {}
+
+  async getResponse(req: ModelRequest): Promise<ModelResponse> {
+    const callIndex = this.seenInputs.length;
+    this.seenInputs.push(getRequestInputItems(req));
+    this.hooks.onCall?.(callIndex);
+    const response = this.responses[callIndex];
+    if (!response) {
+      throw new Error(`No response configured for call #${callIndex}`);
+    }
+    return response;
+  }
+
+  async *getStreamedResponse(
+    req: ModelRequest,
+  ): AsyncIterable<protocol.StreamEvent> {
+    const response = await this.getResponse(req);
+    yield {
+      type: 'response_done',
+      response: {
+        id: `r_${this.seenInputs.length}`,
+        usage: {
+          requests: 1,
+          inputTokens: response.usage.inputTokens,
+          outputTokens: response.usage.outputTokens,
+          totalTokens: response.usage.totalTokens,
+        },
+        output: response.output,
+      },
+    } as any;
+  }
+}
+
+function functionCall(
+  callId: string,
+  name = 'noop',
+): protocol.FunctionCallItem {
+  return {
+    type: 'function_call',
+    id: `fc_${callId}`,
+    callId,
+    name,
+    status: 'completed',
+    arguments: '{}',
+  } as protocol.FunctionCallItem;
+}
+
+describe('RunInbox', () => {
+  beforeAll(() => {
+    setTracingDisabled(true);
+  });
+
+  describe('queue primitives', () => {
+    it('coerces string sends to user messages', () => {
+      const inbox = new RunInbox();
+      inbox.send('hello there');
+      expect(inbox.size).toBe(1);
+      const drained = inbox.drain();
+      expect(drained).toHaveLength(1);
+      expect(drained[0].role).toBe('user');
+      expect(getFirstTextContent(drained[0])).toBe('hello there');
+    });
+
+    it('accepts pre-built UserMessageItems and arrays', () => {
+      const inbox = new RunInbox();
+      inbox.send(user('one'));
+      inbox.send([user('two'), 'three']);
+      expect(inbox.size).toBe(3);
+      const drained = inbox.drain();
+      expect(drained.map((m) => getFirstTextContent(m))).toEqual([
+        'one',
+        'two',
+        'three',
+      ]);
+    });
+
+    it('drain leaves the inbox empty and is idempotent on empty', () => {
+      const inbox = new RunInbox();
+      inbox.send('a');
+      expect(inbox.drain()).toHaveLength(1);
+      expect(inbox.size).toBe(0);
+      expect(inbox.drain()).toEqual([]);
+    });
+  });
+
+  describe('drainInboxIntoState helper', () => {
+    it('returns empty when inbox is undefined or empty', async () => {
+      const agent = new Agent({ name: 'A', model: new FakeModel() });
+      const state = new RunState(new RunContext(), 'hi', agent, 5);
+      expect(await drainInboxIntoState(state, undefined, [])).toEqual([]);
+      const inbox = new RunInbox();
+      expect(await drainInboxIntoState(state, inbox, [])).toEqual([]);
+      expect(state._generatedItems).toHaveLength(0);
+    });
+
+    it('appends RunUserInputItems to _generatedItems in order', async () => {
+      const agent = new Agent({ name: 'A', model: new FakeModel() });
+      const state = new RunState(new RunContext(), 'hi', agent, 5);
+      const inbox = new RunInbox();
+      inbox.send(['follow up one', 'follow up two']);
+      const drained = await drainInboxIntoState(state, inbox, []);
+      expect(drained).toHaveLength(2);
+      expect(state._generatedItems).toHaveLength(2);
+      expect(state._generatedItems[0]).toBeInstanceOf(RunUserInputItem);
+      expect((state._generatedItems[0] as RunUserInputItem).content).toBe(
+        'follow up one',
+      );
+      expect((state._generatedItems[1] as RunUserInputItem).content).toBe(
+        'follow up two',
+      );
+    });
+
+    it('runs configured input guardrails on the drained batch and throws on tripwire', async () => {
+      const agent = new Agent({
+        name: 'GuardedAgent',
+        model: new FakeModel(),
+        inputGuardrails: [
+          {
+            name: 'banned-word',
+            execute: async ({ input }) => {
+              const text = JSON.stringify(input);
+              return {
+                tripwireTriggered: text.includes('forbidden'),
+                outputInfo: { reason: 'banned' },
+              };
+            },
+          },
+        ],
+      });
+      const state = new RunState(new RunContext(), 'hi', agent, 5);
+      const inbox = new RunInbox();
+      inbox.send('this is forbidden content');
+      await expect(
+        withTrace('inbox-guardrail-trip', () =>
+          drainInboxIntoState(state, inbox, []),
+        ),
+      ).rejects.toThrow(/Input guardrail triggered/);
+      // Tripped batch is dropped, not partially persisted.
+      expect(state._generatedItems).toHaveLength(0);
+    });
+  });
+});
+
+describe('Runner.run with inbox (non-streaming)', () => {
+  beforeAll(() => {
+    setTracingDisabled(true);
+    setDefaultModelProvider(new FakeModelProvider());
+  });
+
+  it('delivers a queued message before the next turn and includes it in result.history', async () => {
+    // Turn 1: model calls a tool. Turn 2: model produces a final message.
+    // The inbox message is queued during turn 1's tool execution, so turn 2's input must
+    // include it positioned chronologically after turn 1's items.
+    const responses: ModelResponse[] = [
+      {
+        output: [functionCall('call_1', 'noop')],
+        usage: new Usage(),
+      },
+      {
+        output: [{ ...TEST_MODEL_MESSAGE }],
+        usage: new Usage(),
+      },
+    ];
+
+    const inbox = new RunInbox();
+    const model = new RecordingModel(responses, {
+      onCall: (callIndex) => {
+        // After the first model call returns a tool call, queue an inbox message before the
+        // tool actually executes. The drain at the top of the next turn should pick it up.
+        if (callIndex === 0) {
+          inbox.send('please also include the weather');
+        }
+      },
+    });
+
+    const agent = new Agent({
+      name: 'InboxAgent',
+      model,
+      tools: [
+        {
+          type: 'function',
+          name: 'noop',
+          description: 'no op',
+          strict: true,
+          parameters: {
+            type: 'object',
+            properties: {},
+            additionalProperties: false,
+          },
+          needsApproval: async () => false,
+          invoke: async () => 'ok',
+        } as any,
+      ],
+    });
+
+    const result = await new Runner().run(agent, 'kick off the run', { inbox });
+
+    expect(model.seenInputs).toHaveLength(2);
+    const turn2Inputs = model.seenInputs[1];
+    const userTexts = turn2Inputs
+      .filter(
+        (item) => item.type === 'message' && (item as any).role === 'user',
+      )
+      .map((item) => getFirstTextContent(item));
+    expect(userTexts).toContain('kick off the run');
+    expect(userTexts).toContain('please also include the weather');
+
+    // Inbox message must appear in history AFTER the function call and tool output, not before.
+    const history = result.history;
+    const callIdx = history.findIndex((item) => item.type === 'function_call');
+    const inboxIdx = history.findIndex(
+      (item) =>
+        item.type === 'message' &&
+        (item as any).role === 'user' &&
+        getFirstTextContent(item) === 'please also include the weather',
+    );
+    expect(callIdx).toBeGreaterThanOrEqual(0);
+    expect(inboxIdx).toBeGreaterThan(callIdx);
+
+    // Inbox is drained after delivery.
+    expect(inbox.size).toBe(0);
+  });
+
+  it('extends the loop by one turn when a message arrives during the final model call', async () => {
+    // Turn 1: model returns a final message. Without the inbox feature this would terminate.
+    // Turn 2: must run because a message was queued during turn 1.
+    const responses: ModelResponse[] = [
+      {
+        output: [fakeModelMessage('first answer')],
+        usage: new Usage(),
+      },
+      {
+        output: [fakeModelMessage('second answer with new context')],
+        usage: new Usage(),
+      },
+    ];
+
+    const inbox = new RunInbox();
+    const model = new RecordingModel(responses, {
+      onCall: (callIndex) => {
+        if (callIndex === 0) {
+          inbox.send('actually here is more info');
+        }
+      },
+    });
+
+    const agent = new Agent({ name: 'ExtendAgent', model });
+    const result = await new Runner().run(agent, 'do the thing', { inbox });
+
+    expect(model.seenInputs).toHaveLength(2);
+    expect(result.finalOutput).toBe('second answer with new context');
+    expect(inbox.size).toBe(0);
+
+    const turn2UserTexts = model.seenInputs[1]
+      .filter(
+        (item) => item.type === 'message' && (item as any).role === 'user',
+      )
+      .map((item) => getFirstTextContent(item));
+    expect(turn2UserTexts).toContain('actually here is more info');
+  });
+
+  it('does not extend the loop when the inbox is empty at final_output', async () => {
+    const model = new RecordingModel([
+      {
+        output: [{ ...TEST_MODEL_MESSAGE }],
+        usage: new Usage(),
+      },
+    ]);
+    const inbox = new RunInbox();
+    const agent = new Agent({ name: 'NoExtendAgent', model });
+    const result = await new Runner().run(agent, 'hello', { inbox });
+    expect(model.seenInputs).toHaveLength(1);
+    expect(result.finalOutput).toBeDefined();
+  });
+
+  it('runs unchanged when no inbox is provided', async () => {
+    const model = new RecordingModel([
+      {
+        output: [{ ...TEST_MODEL_MESSAGE }],
+        usage: new Usage(),
+      },
+    ]);
+    const agent = new Agent({ name: 'NoInboxAgent', model });
+    const result = await new Runner().run(agent, 'hello');
+    expect(result.finalOutput).toBeDefined();
+    expect(model.seenInputs).toHaveLength(1);
+  });
+});
+
+describe('RunInbox + RunState serialization', () => {
+  beforeAll(() => {
+    setTracingDisabled(true);
+  });
+
+  it('serializes user_input_item entries and round-trips them through fromString', async () => {
+    const agent = new Agent({ name: 'SerializeAgent', model: new FakeModel() });
+    const state = new RunState(new RunContext(), 'first prompt', agent, 5);
+    const inbox = new RunInbox();
+    inbox.send('queued before serialize');
+    await drainInboxIntoState(state, inbox, []);
+
+    const serialized = state.toString();
+    const restored = await RunState.fromString(agent, serialized);
+
+    const restoredItems = restored._generatedItems.filter(
+      (item): item is RunUserInputItem => item instanceof RunUserInputItem,
+    );
+    expect(restoredItems).toHaveLength(1);
+    expect(restoredItems[0].content).toBe('queued before serialize');
+  });
+
+  it('refuses to load older schema versions that contain user_input_item', async () => {
+    const agent = new Agent({ name: 'SerializeAgent', model: new FakeModel() });
+    const state = new RunState(new RunContext(), 'first prompt', agent, 5);
+    const inbox = new RunInbox();
+    inbox.send('queued');
+    await drainInboxIntoState(state, inbox, []);
+
+    const json = JSON.parse(state.toString());
+    json.$schemaVersion = '1.8';
+    await expect(
+      RunState.fromString(agent, JSON.stringify(json)),
+    ).rejects.toThrow(/user_input_item/);
+  });
+});
+
+describe('Runner.run with inbox (streaming)', () => {
+  beforeAll(() => {
+    setTracingDisabled(true);
+  });
+
+  it('drains queued messages between turns and emits user_input_received events', async () => {
+    const responses: ModelResponse[] = [
+      {
+        output: [functionCall('call_1', 'noop')],
+        usage: new Usage(),
+      },
+      {
+        output: [fakeModelMessage('streamed final answer')],
+        usage: new Usage(),
+      },
+    ];
+
+    const inbox = new RunInbox();
+    const model = new RecordingModel(responses, {
+      onCall: (callIndex) => {
+        if (callIndex === 0) {
+          inbox.send('mid-stream follow up');
+        }
+      },
+    });
+
+    const agent = new Agent({
+      name: 'StreamingInboxAgent',
+      model,
+      tools: [
+        {
+          type: 'function',
+          name: 'noop',
+          description: 'no op',
+          strict: true,
+          parameters: {
+            type: 'object',
+            properties: {},
+            additionalProperties: false,
+          },
+          needsApproval: async () => false,
+          invoke: async () => 'ok',
+        } as any,
+      ],
+    });
+
+    const result = await new Runner().run(agent, 'streaming kick-off', {
+      stream: true,
+      inbox,
+    });
+
+    const eventNames: string[] = [];
+    for await (const event of result.toStream()) {
+      if (event.type === 'run_item_stream_event') {
+        eventNames.push(event.name);
+      }
+    }
+    await result.completed;
+
+    expect(eventNames).toContain('user_input_received');
+    expect(model.seenInputs).toHaveLength(2);
+    expect(result.finalOutput).toBe('streamed final answer');
+    expect(inbox.size).toBe(0);
+  });
+});
+
+describe('integration with FakeModelProvider basic responses', () => {
+  beforeAll(() => {
+    setTracingDisabled(true);
+    setDefaultModelProvider(new FakeModelProvider());
+  });
+
+  it('still completes a basic single-turn run with an empty inbox attached', async () => {
+    const agent = new Agent({
+      name: 'EmptyInboxBasic',
+      model: new FakeModel([TEST_MODEL_RESPONSE_BASIC]),
+    });
+    const inbox = new RunInbox();
+    const result = await new Runner().run(agent, 'hi', { inbox });
+    expect(result.finalOutput).toBeDefined();
+  });
+});
+
+describe('RunInbox safety properties', () => {
+  beforeAll(() => {
+    setTracingDisabled(true);
+    setDefaultModelProvider(new FakeModelProvider());
+  });
+
+  it('input guardrails screen inbox messages mid-run, throwing tripwire from run()', async () => {
+    // Turn 1 returns a tool call so the run reaches turn 2 (where the inbox drain happens).
+    // The drained message contains banned content; the guardrail trips and run() rejects.
+    const responses: ModelResponse[] = [
+      {
+        output: [functionCall('call_1', 'noop')],
+        usage: new Usage(),
+      },
+      {
+        output: [{ ...TEST_MODEL_MESSAGE }],
+        usage: new Usage(),
+      },
+    ];
+
+    const inbox = new RunInbox();
+    const model = new RecordingModel(responses, {
+      onCall: (callIndex) => {
+        if (callIndex === 0) {
+          inbox.send('please discuss forbidden topic');
+        }
+      },
+    });
+
+    const agent = new Agent({
+      name: 'GuardedInboxAgent',
+      model,
+      tools: [
+        {
+          type: 'function',
+          name: 'noop',
+          description: 'no op',
+          strict: true,
+          parameters: {
+            type: 'object',
+            properties: {},
+            additionalProperties: false,
+          },
+          needsApproval: async () => false,
+          invoke: async () => 'ok',
+        } as any,
+      ],
+      inputGuardrails: [
+        {
+          name: 'banned-word',
+          execute: async ({ input }) => {
+            const text = JSON.stringify(input);
+            return {
+              tripwireTriggered: text.includes('forbidden'),
+              outputInfo: { reason: 'banned' },
+            };
+          },
+        },
+      ],
+    });
+
+    await expect(
+      new Runner().run(agent, 'kick off', { inbox }),
+    ).rejects.toBeInstanceOf(InputGuardrailTripwireTriggered);
+    // Only the first model call happened; the run terminated before turn 2.
+    expect(model.seenInputs).toHaveLength(1);
+  });
+
+  it('extends the loop when a message arrives during output guardrails', async () => {
+    // Turn 1 returns a final message. Output guardrail runs slowly and a message lands during
+    // it. The post-check inbox drain must catch this and run a second turn instead of returning.
+    const responses: ModelResponse[] = [
+      {
+        output: [fakeModelMessage('first answer')],
+        usage: new Usage(),
+      },
+      {
+        output: [fakeModelMessage('answer with the late note included')],
+        usage: new Usage(),
+      },
+    ];
+
+    const inbox = new RunInbox();
+    const model = new RecordingModel(responses);
+
+    let guardrailCalls = 0;
+    const agent = new Agent({
+      name: 'LateArrivalAgent',
+      model,
+      outputGuardrails: [
+        {
+          name: 'slow-guardrail',
+          execute: async () => {
+            guardrailCalls += 1;
+            // Simulate a guardrail that takes time, during which an external sender adds to
+            // the inbox. The runner's post-check after this guardrail must catch the message
+            // and re-loop instead of returning the current final output. Only do this on the
+            // first call so the second turn can finish cleanly.
+            if (guardrailCalls === 1) {
+              inbox.send('one more note before you finish');
+              await new Promise((resolve) => setTimeout(resolve, 5));
+            }
+            return { tripwireTriggered: false, outputInfo: { ok: true } };
+          },
+        },
+      ],
+    });
+
+    const result = await new Runner().run(agent, 'kick off', { inbox });
+
+    expect(model.seenInputs).toHaveLength(2);
+    expect(result.finalOutput).toBe('answer with the late note included');
+    expect(inbox.size).toBe(0);
+  });
+
+  it('persists inbox messages through a session', async () => {
+    const session = new MemorySession();
+    const responses: ModelResponse[] = [
+      {
+        output: [functionCall('call_1', 'noop')],
+        usage: new Usage(),
+      },
+      {
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+      },
+    ];
+
+    const inbox = new RunInbox();
+    const model = new RecordingModel(responses, {
+      onCall: (callIndex) => {
+        if (callIndex === 0) {
+          inbox.send('a follow-up that should be saved');
+        }
+      },
+    });
+
+    const agent = new Agent({
+      name: 'SessionInboxAgent',
+      model,
+      tools: [
+        {
+          type: 'function',
+          name: 'noop',
+          description: 'no op',
+          strict: true,
+          parameters: {
+            type: 'object',
+            properties: {},
+            additionalProperties: false,
+          },
+          needsApproval: async () => false,
+          invoke: async () => 'ok',
+        } as any,
+      ],
+    });
+
+    await new Runner().run(agent, 'kick off', { inbox, session });
+
+    const stored = await session.getItems();
+    const userMessages = stored
+      .filter(
+        (item) => item.type === 'message' && (item as any).role === 'user',
+      )
+      .map((item) => getFirstTextContent(item));
+    expect(userMessages).toContain('a follow-up that should be saved');
+  });
+
+  it('delivers messages queued during an interruption on the resumed turn', async () => {
+    const approvalToolDef = tool({
+      name: 'needsApproval',
+      description: 'approval required',
+      parameters: z.object({}).strict(),
+      execute: async () => 'approved-output',
+      needsApproval: true,
+    });
+
+    const approvalCall: protocol.FunctionCallItem = {
+      ...TEST_MODEL_FUNCTION_CALL,
+      name: 'needsApproval',
+      callId: 'call-approval',
+      arguments: '{}',
+    };
+
+    // Turn 1: model issues the approval-required tool call (run pauses for approval).
+    // Turn 2: after resume + drain, model sees the queued message and produces final answer.
+    const responses: ModelResponse[] = [
+      {
+        output: [approvalCall, fakeModelMessage('waiting for approval')],
+        usage: new Usage(),
+      },
+      {
+        output: [fakeModelMessage('done with the late context applied')],
+        usage: new Usage(),
+      },
+    ];
+
+    const model = new RecordingModel(responses);
+
+    const agent = new Agent({
+      name: 'ApprovalInboxAgent',
+      model,
+      tools: [approvalToolDef],
+    });
+
+    const inbox = new RunInbox();
+    const firstRun = await new Runner().run(agent, 'kick off', { inbox });
+    expect(firstRun.interruptions).toHaveLength(1);
+
+    // Queue a message *while paused for approval*. It must be delivered when the run resumes.
+    inbox.send('please consider this too');
+
+    firstRun.state._context.approveTool(firstRun.interruptions[0]);
+    const secondRun = await new Runner().run(agent, firstRun.state, { inbox });
+
+    expect(secondRun.finalOutput).toBe('done with the late context applied');
+    const turn2Inputs = model.seenInputs[1];
+    const userTexts = turn2Inputs
+      .filter(
+        (item) => item.type === 'message' && (item as any).role === 'user',
+      )
+      .map((item) => getFirstTextContent(item));
+    expect(userTexts).toContain('please consider this too');
+    expect(inbox.size).toBe(0);
+  });
+
+  it('excludes user_input_item from result.output but keeps it in newItems and history', async () => {
+    const responses: ModelResponse[] = [
+      {
+        output: [functionCall('call_1', 'noop')],
+        usage: new Usage(),
+      },
+      {
+        output: [fakeModelMessage('finished')],
+        usage: new Usage(),
+      },
+    ];
+
+    const inbox = new RunInbox();
+    const model = new RecordingModel(responses, {
+      onCall: (callIndex) => {
+        if (callIndex === 0) {
+          inbox.send('inbox content that is user input, not model output');
+        }
+      },
+    });
+
+    const agent = new Agent({
+      name: 'OutputFilterAgent',
+      model,
+      tools: [
+        {
+          type: 'function',
+          name: 'noop',
+          description: 'no op',
+          strict: true,
+          parameters: {
+            type: 'object',
+            properties: {},
+            additionalProperties: false,
+          },
+          needsApproval: async () => false,
+          invoke: async () => 'ok',
+        } as any,
+      ],
+    });
+
+    const result = await new Runner().run(agent, 'kick off', { inbox });
+
+    const outputUserMessages = result.output.filter(
+      (item) => item.type === 'message' && (item as any).role === 'user',
+    );
+    expect(outputUserMessages).toHaveLength(0);
+
+    const historyUserMessages = result.history.filter(
+      (item) => item.type === 'message' && (item as any).role === 'user',
+    );
+    // The original input plus the inbox-injected message both appear in history.
+    expect(historyUserMessages.length).toBeGreaterThanOrEqual(2);
+
+    const newItemUserInputs = result.newItems.filter(
+      (item) => item.type === 'user_input_item',
+    );
+    expect(newItemUserInputs).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
### Summary

A `inbox` to support a feature like Codex Steering. 
Adds `RunInbox`, a queue-shaped analog to `AbortSignal` that lets external code deliver user messages into a running agent loop without aborting it. Pass one as `RunOptions.inbox` and call `inbox.send(...)` from a websocket handler, HTTP endpoint, or other async context — the runner drains the inbox at the next turn boundary, runs configured input guardrails on the drained batch, appends the messages to state as a new `RunUserInputItem`, and (when streaming) emits a `user_input_received` event.

If a message arrives while the model is producing what would otherwise be the final output (or during the output-guardrail work that follows it), the runner extends the loop by one extra turn so the message is incorporated rather than dropped. Bumps the `RunState` schema to 1.9 to support serializing the new item type.

Public surface added in `@openai/agents-core`:

- `RunInbox` class with `send(...)`, `size`, `drain()`
- `RunOptions.inbox` option
- `RunUserInputItem` run item (excluded from `result.output`, included in `result.history`/`newItems`)
- `user_input_received` `RunItemStreamEvent` name

Documentation added under `docs/src/content/docs/guides/running-agents.mdx` (`inbox` row in the Run arguments table + new "Mid-run user input" subsection). A small interactive demo lives at `examples/agent-patterns/inbox.ts` (`pnpm -F agent-patterns start:inbox`).

### Test plan

- [x] New `packages/agents-core/test/inbox.test.ts` covering: turn-boundary delivery, mid-tool-call queueing, end-of-run extension when the inbox is non-empty during the final-output and output-guardrail phases, input-guardrail screening of drained batches (including tripwire and execution-failure paths), `user_input_received` stream events, `RunState` round-trip with `user_input_item`, and `result.history` / `result.output` filtering.
- [x] `pnpm build`
- [x] `pnpm -r build-check`
- [x] `CI=1 pnpm test` (1823/1823)
- [x] `pnpm lint`
- [x] `pnpm test:examples`
- [x] `pnpm -F docs build`

End to end demo - 5-day Tokyo trip planner. Agent calls plan_day(day, theme) sequentially. Mid-run I type "I just realized I'm bringing my dog!" — the message lands in a RunInbox, gets drained at the next turn boundary (no abort, no restart), and days 3–5 visibly call plan_day(theme="dog-friendly ...") while the final itinerary acknowledges the change.

https://github.com/user-attachments/assets/87737655-c827-40f4-8909-ce3529e45ac8

### Issue number

N/A

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration`
- [x] I've made sure tests pass
- [x] I've added a changeset using `pnpm changeset` to indicate my changes