### PR TITLE
fix(agents-extensions): reject symlink ancestors in remote local sources

### DIFF
--- a/.changeset/remote-local-source-symlink-ancestors.md
+++ b/.changeset/remote-local-source-symlink-ancestors.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: reject symlink ancestors in remote local sources

--- a/packages/agents-extensions/src/sandbox/shared/localSources.ts
+++ b/packages/agents-extensions/src/sandbox/shared/localSources.ts
@@ -15,7 +15,7 @@ import {
   rm,
 } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { normalizeGitRepository } from './git';
 import { formatSandboxProcessError, runSandboxProcess } from './process';
 import {
@@ -216,6 +216,11 @@ async function resolveStableLocalDirectorySource(
   sourceDir: string,
   expectedSourceStat?: Stats,
 ): Promise<StableLocalDirectorySource> {
+  await assertNoLocalSourceSymlinkAncestors(
+    sourceDir,
+    'local_dir',
+    localDirectoryPathChangedError,
+  );
   const sourceStat = await statStableLocalSourcePath(sourceDir);
   if (sourceStat.isSymbolicLink()) {
     throw new UserError(
@@ -289,6 +294,11 @@ async function assertStableLocalDirectoryPath(
 }
 
 async function readStableLocalFile(sourcePath: string): Promise<Uint8Array> {
+  await assertNoLocalSourceSymlinkAncestors(
+    sourcePath,
+    'local_file',
+    localFilePathChangedError,
+  );
   const sourceStat = await statStableLocalSourcePath(
     sourcePath,
     localFilePathChangedError,
@@ -319,6 +329,37 @@ async function readStableLocalFile(sourcePath: string): Promise<Uint8Array> {
     return await handle.readFile();
   } finally {
     await handle.close();
+  }
+}
+
+async function assertNoLocalSourceSymlinkAncestors(
+  sourcePath: string,
+  entryType: 'local_dir' | 'local_file',
+  pathChangedError: (sourcePath: string) => UserError,
+): Promise<void> {
+  const resolvedPath = resolve(sourcePath);
+  let current = dirname(resolvedPath);
+
+  while (current !== dirname(current)) {
+    const parent = dirname(current);
+    if (parent === dirname(parent)) {
+      break;
+    }
+    let currentStat: Stats;
+    try {
+      currentStat = await lstat(current);
+    } catch (error) {
+      if (isPathChangedError(error)) {
+        throw pathChangedError(sourcePath);
+      }
+      throw error;
+    }
+    if (currentStat.isSymbolicLink()) {
+      throw new UserError(
+        `${entryType} entries do not support symbolic link ancestors: ${sourcePath}`,
+      );
+    }
+    current = parent;
   }
 }
 

--- a/packages/agents-extensions/test/sandbox/shared.test.ts
+++ b/packages/agents-extensions/test/sandbox/shared.test.ts
@@ -1669,6 +1669,36 @@ describe('remote sandbox path helpers', () => {
     ).rejects.toThrow(/local_dir entries do not support symbolic links/);
   });
 
+  test('rejects symbolic link ancestors in local directory entries', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'agents-shared-test-'));
+    tempDirs.push(tempDir);
+    const realRoot = join(tempDir, 'real-root');
+    const linkedRoot = join(tempDir, 'linked-root');
+    const sourceDir = join(realRoot, 'source-dir');
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(join(sourceDir, 'safe.txt'), 'safe');
+    await symlink(realRoot, linkedRoot, 'dir');
+
+    const writer = {
+      mkdir: async (_path: string) => {},
+      writeFile: async (_path: string, _content: string | Uint8Array) => {},
+    };
+
+    await expect(
+      materializeLocalSourceManifestEntry(
+        writer,
+        '/workspace/project',
+        {
+          type: 'local_dir',
+          src: join(linkedRoot, 'source-dir'),
+        },
+        'test',
+      ),
+    ).rejects.toThrow(
+      /local_dir entries do not support symbolic link ancestors/,
+    );
+  });
+
   test('rejects symbolic links in local file entries', async () => {
     const tempDir = await mkdtemp(join(tmpdir(), 'agents-shared-test-'));
     tempDirs.push(tempDir);
@@ -1693,6 +1723,35 @@ describe('remote sandbox path helpers', () => {
         'test',
       ),
     ).rejects.toThrow(/local_file entries do not support symbolic links/);
+  });
+
+  test('rejects symbolic link ancestors in local file entries', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'agents-shared-test-'));
+    tempDirs.push(tempDir);
+    const realRoot = join(tempDir, 'real-root');
+    const linkedRoot = join(tempDir, 'linked-root');
+    await mkdir(realRoot);
+    await writeFile(join(realRoot, 'source.txt'), 'source');
+    await symlink(realRoot, linkedRoot, 'dir');
+
+    const writer = {
+      mkdir: async (_path: string) => {},
+      writeFile: async (_path: string, _content: string | Uint8Array) => {},
+    };
+
+    await expect(
+      materializeLocalSourceManifestEntry(
+        writer,
+        '/workspace/copied.txt',
+        {
+          type: 'local_file',
+          src: join(linkedRoot, 'source.txt'),
+        },
+        'test',
+      ),
+    ).rejects.toThrow(
+      /local_file entries do not support symbolic link ancestors/,
+    );
   });
 
   test('formats command output and truncates token output', () => {


### PR DESCRIPTION
This pull request fixes remote sandbox local source materialization so `local_file` and `local_dir` entries reject symbolic link ancestors before copying host files into remote providers.

The previous remote shared materializer rejected symbolic link leaves and symlinks inside copied directories, but paths such as `linked-root/source.txt` or `linked-root/source-dir` could still traverse a symlinked ancestor. This update brings the remote provider path checks in line with the core local materializer by walking ancestor directories before reading local sources, and adds regression coverage for both local file and local directory entries.