### PR TITLE
fix: support remote sandbox concurrency limits

### DIFF
--- a/.changeset/sandbox-remote-concurrency-limits.md
+++ b/.changeset/sandbox-remote-concurrency-limits.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: support remote sandbox concurrency limits

--- a/packages/agents-extensions/src/sandbox/blaxel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/blaxel/sandbox.ts
@@ -8,6 +8,7 @@ import {
   type SandboxClient,
   type SandboxClientCreateArgs,
   type SandboxClientOptions,
+  type SandboxConcurrencyLimits,
   type ExposedPortEndpoint,
   type ExecCommandArgs,
   type Mount,
@@ -18,7 +19,6 @@ import {
 import {
   addPtyWebSocketListener,
   appendPtyOutput,
-  assertCoreConcurrencyLimitsUnsupported,
   assertCoreSnapshotUnsupported,
   assertResumeRecreateAllowed,
   createPtyProcessEntry,
@@ -190,12 +190,14 @@ export class BlaxelSandboxSession extends RemoteSandboxSessionBase<BlaxelSandbox
     sandbox: BlaxelSandboxLike;
     apiKey?: string;
     ownsSandbox?: boolean;
+    concurrencyLimits?: SandboxConcurrencyLimits;
   }) {
     super({
       state: args.state,
       options: {
         providerName: 'BlaxelSandboxClient',
         providerId: 'blaxel',
+        concurrencyLimits: args.concurrencyLimits,
       },
     });
     this.sandbox = args.sandbox;
@@ -755,10 +757,6 @@ export class BlaxelSandboxClient implements SandboxClient<
   ): Promise<BlaxelSandboxSession> {
     const createArgs = normalizeSandboxClientCreateArgs(args, manifestOptions);
     assertCoreSnapshotUnsupported('BlaxelSandboxClient', createArgs.snapshot);
-    assertCoreConcurrencyLimitsUnsupported(
-      'BlaxelSandboxClient',
-      createArgs.concurrencyLimits,
-    );
     const manifest = createArgs.manifest;
     const resolvedOptions = {
       ...this.options,
@@ -841,6 +839,7 @@ export class BlaxelSandboxClient implements SandboxClient<
           sandbox,
           apiKey: resolvedOptions.apiKey ?? loadEnv().BL_API_KEY,
           ownsSandbox,
+          concurrencyLimits: createArgs.concurrencyLimits,
           state: {
             manifest,
             sandboxName,

--- a/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
@@ -11,6 +11,7 @@ import {
   type SandboxClient,
   type SandboxClientCreateArgs,
   type SandboxClientOptions,
+  type SandboxConcurrencyLimits,
   type ExposedPortEndpoint,
   type ExecCommandArgs,
   type MaterializeEntryArgs,
@@ -70,7 +71,6 @@ import {
   validateRemoteSandboxPathForManifest,
 } from '../shared/paths';
 import {
-  assertCoreConcurrencyLimitsUnsupported,
   assertCoreSnapshotUnsupported,
   assertRunAsUnsupported,
   closeRemoteSessionOnManifestError,
@@ -133,17 +133,23 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
   readonly state: CloudflareSandboxSessionState;
   private readonly apiKey?: string;
   private readonly ptyProcesses = new PtyProcessRegistry();
+  private readonly concurrencyLimits?: SandboxConcurrencyLimits;
   private readonly remotePathResolver: RemoteSandboxPathResolver = async (
     path,
     options,
   ) => await this.resolveRemotePath(path, options);
 
-  constructor(args: { state: CloudflareSandboxSessionState; apiKey?: string }) {
+  constructor(args: {
+    state: CloudflareSandboxSessionState;
+    apiKey?: string;
+    concurrencyLimits?: SandboxConcurrencyLimits;
+  }) {
     this.state = {
       ...args.state,
       sandboxId: normalizeCloudflarePersistedSandboxId(args.state.sandboxId),
     };
     this.apiKey = args.apiKey;
+    this.concurrencyLimits = args.concurrencyLimits;
   }
 
   createEditor(runAs?: string): RemoteSandboxEditor {
@@ -372,7 +378,7 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
         'cloudflare',
         this.writer(),
         this.remotePathResolver,
-        this.manifestMaterializationOptions,
+        this.manifestMaterializationOptions(),
       );
       return;
     }
@@ -384,7 +390,7 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
       'cloudflare',
       this.writer(),
       this.remotePathResolver,
-      this.manifestMaterializationOptions,
+      this.manifestMaterializationOptions(),
     );
   }
 
@@ -406,7 +412,7 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
         'cloudflare',
         this.writer(),
         this.remotePathResolver,
-        this.manifestMaterializationOptions,
+        this.manifestMaterializationOptions(),
       );
       return;
     }
@@ -417,7 +423,7 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
       'cloudflare',
       this.writer(),
       this.remotePathResolver,
-      this.manifestMaterializationOptions,
+      this.manifestMaterializationOptions(),
     );
   }
 
@@ -585,9 +591,12 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
     };
   }
 
-  private readonly manifestMaterializationOptions = {
-    materializeMount: this.materializeMountEntry.bind(this),
-  };
+  private manifestMaterializationOptions() {
+    return {
+      materializeMount: this.materializeMountEntry.bind(this),
+      concurrencyLimits: this.concurrencyLimits,
+    };
+  }
 
   private async materializeMountEntry(
     absolutePath: string,
@@ -890,10 +899,6 @@ export class CloudflareSandboxClient implements SandboxClient<
       'CloudflareSandboxClient',
       createArgs.snapshot,
     );
-    assertCoreConcurrencyLimitsUnsupported(
-      'CloudflareSandboxClient',
-      createArgs.concurrencyLimits,
-    );
     const manifest = createArgs.manifest;
     const resolvedOptions = {
       ...this.options,
@@ -981,6 +986,7 @@ export class CloudflareSandboxClient implements SandboxClient<
 
         const session = new CloudflareSandboxSession({
           apiKey,
+          concurrencyLimits: createArgs.concurrencyLimits,
           state: {
             manifest,
             workerUrl: normalizedWorkerUrl,

--- a/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
@@ -7,6 +7,7 @@ import {
   type SandboxClient,
   type SandboxClientCreateArgs,
   type SandboxClientOptions,
+  type SandboxConcurrencyLimits,
   type ExposedPortEndpoint,
   type ExecCommandArgs,
   type MaterializeEntryArgs,
@@ -20,7 +21,6 @@ import {
 } from '@openai/agents-core/sandbox';
 import {
   appendPtyOutput,
-  assertCoreConcurrencyLimitsUnsupported,
   assertCoreSnapshotUnsupported,
   assertTarWorkspacePersistence,
   createPtyProcessEntry,
@@ -196,15 +196,18 @@ export class DaytonaSandboxSession implements SandboxSession<DaytonaSandboxSessi
     options,
   ) => await this.resolveRemotePath(path, options);
   private readonly activeMountPaths = new Set<string>();
+  private readonly concurrencyLimits?: SandboxConcurrencyLimits;
   private stopPromise?: Promise<void>;
   private deletePromise?: Promise<void>;
 
   constructor(args: {
     state: DaytonaSandboxSessionState;
     sandbox: DaytonaSandboxLike;
+    concurrencyLimits?: SandboxConcurrencyLimits;
   }) {
     this.state = args.state;
     this.sandbox = args.sandbox;
+    this.concurrencyLimits = args.concurrencyLimits;
   }
 
   createEditor(runAs?: string): RemoteSandboxEditor {
@@ -463,7 +466,7 @@ export class DaytonaSandboxSession implements SandboxSession<DaytonaSandboxSessi
       'daytona',
       this.writer(),
       this.remotePathResolver,
-      this.manifestMaterializationOptions,
+      this.manifestMaterializationOptions(),
     );
   }
 
@@ -486,7 +489,7 @@ export class DaytonaSandboxSession implements SandboxSession<DaytonaSandboxSessi
       'daytona',
       this.writer(),
       this.remotePathResolver,
-      this.manifestMaterializationOptions,
+      this.manifestMaterializationOptions(),
     );
   }
 
@@ -496,7 +499,7 @@ export class DaytonaSandboxSession implements SandboxSession<DaytonaSandboxSessi
       manifest,
       'daytona',
       this.remotePathResolver,
-      this.manifestMaterializationOptions,
+      this.manifestMaterializationOptions(),
     );
   }
 
@@ -631,9 +634,12 @@ export class DaytonaSandboxSession implements SandboxSession<DaytonaSandboxSessi
     };
   }
 
-  private readonly manifestMaterializationOptions = {
-    materializeMount: this.materializeMountEntry.bind(this),
-  };
+  private manifestMaterializationOptions() {
+    return {
+      materializeMount: this.materializeMountEntry.bind(this),
+      concurrencyLimits: this.concurrencyLimits,
+    };
+  }
 
   private async materializeMountEntry(
     absolutePath: string,
@@ -933,10 +939,6 @@ export class DaytonaSandboxClient implements SandboxClient<
   ): Promise<DaytonaSandboxSession> {
     const createArgs = normalizeSandboxClientCreateArgs(args, manifestOptions);
     assertCoreSnapshotUnsupported('DaytonaSandboxClient', createArgs.snapshot);
-    assertCoreConcurrencyLimitsUnsupported(
-      'DaytonaSandboxClient',
-      createArgs.concurrencyLimits,
-    );
     const manifest = createArgs.manifest;
     const resolvedOptions = {
       ...this.options,
@@ -1003,6 +1005,7 @@ export class DaytonaSandboxClient implements SandboxClient<
 
         const session = new DaytonaSandboxSession({
           sandbox,
+          concurrencyLimits: createArgs.concurrencyLimits,
           state: {
             manifest: resolvedManifest,
             sandboxId: sandbox.id,

--- a/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
@@ -6,6 +6,7 @@ import {
   type SandboxClient,
   type SandboxClientCreateArgs,
   type SandboxClientOptions,
+  type SandboxConcurrencyLimits,
   type ExposedPortEndpoint,
   type ExecCommandArgs,
   type Mount,
@@ -18,7 +19,6 @@ import {
 } from '@openai/agents-core/sandbox';
 import {
   appendPtyOutput,
-  assertCoreConcurrencyLimitsUnsupported,
   assertCoreSnapshotUnsupported,
   assertResumeRecreateAllowed,
   assertTarWorkspacePersistence,
@@ -202,12 +202,14 @@ export class E2BSandboxSession extends RemoteSandboxSessionBase<E2BSandboxSessio
   constructor(args: {
     state: E2BSandboxSessionState;
     sandbox: E2BSandboxInstance;
+    concurrencyLimits?: SandboxConcurrencyLimits;
   }) {
     super({
       state: args.state,
       options: {
         providerName: 'E2BSandboxClient',
         providerId: 'e2b',
+        concurrencyLimits: args.concurrencyLimits,
       },
     });
     this.sandbox = args.sandbox;
@@ -845,10 +847,6 @@ export class E2BSandboxClient implements SandboxClient<
   ): Promise<E2BSandboxSession> {
     const createArgs = normalizeSandboxClientCreateArgs(args, manifestOptions);
     assertCoreSnapshotUnsupported('E2BSandboxClient', createArgs.snapshot);
-    assertCoreConcurrencyLimitsUnsupported(
-      'E2BSandboxClient',
-      createArgs.concurrencyLimits,
-    );
     const manifest = createArgs.manifest;
     return await withSandboxSpan(
       'sandbox.start',
@@ -881,6 +879,7 @@ export class E2BSandboxClient implements SandboxClient<
 
         const session = new E2BSandboxSession({
           sandbox,
+          concurrencyLimits: createArgs.concurrencyLimits,
           state: {
             manifest,
             sandboxId: sandbox.sandboxId,

--- a/packages/agents-extensions/src/sandbox/modal/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/modal/sandbox.ts
@@ -7,6 +7,7 @@ import {
   type SandboxClient,
   type SandboxClientCreateArgs,
   type SandboxClientOptions,
+  type SandboxConcurrencyLimits,
   type ExposedPortEndpoint,
   type ExecCommandArgs,
   type Entry,
@@ -24,7 +25,6 @@ import {
 } from '@openai/agents-core/sandbox';
 import { posix as pathPosix } from 'node:path';
 import {
-  assertCoreConcurrencyLimitsUnsupported,
   assertCoreSnapshotUnsupported,
   imageOutputFromBytes,
   RemoteSandboxEditor,
@@ -311,6 +311,7 @@ export class ModalSandboxSession implements SandboxSession<ModalSandboxSessionSt
     path,
     options,
   ) => await this.resolveRemotePath(path, options);
+  private readonly concurrencyLimits?: SandboxConcurrencyLimits;
   private nextProcessId = 1;
 
   constructor(args: {
@@ -321,6 +322,7 @@ export class ModalSandboxSession implements SandboxSession<ModalSandboxSessionSt
     ownsSandbox?: boolean;
     cloudBucketMounts?: Record<string, ModalCloudBucketMountLike>;
     cloudBucketMountsProvider?: ModalCloudBucketMountsProvider;
+    concurrencyLimits?: SandboxConcurrencyLimits;
   }) {
     this.state = args.state;
     this.modal = args.modal;
@@ -330,6 +332,7 @@ export class ModalSandboxSession implements SandboxSession<ModalSandboxSessionSt
     this.state.ownsSandbox = this.ownsSandbox;
     this.cloudBucketMounts = args.cloudBucketMounts;
     this.cloudBucketMountsProvider = args.cloudBucketMountsProvider;
+    this.concurrencyLimits = args.concurrencyLimits;
     this.cloudBucketMountsResolved =
       args.cloudBucketMounts !== undefined || !args.cloudBucketMountsProvider;
   }
@@ -551,7 +554,7 @@ export class ModalSandboxSession implements SandboxSession<ModalSandboxSessionSt
       'modal',
       this.writer(),
       this.remotePathResolver,
-      this.manifestMaterializationOptions,
+      this.manifestMaterializationOptions(),
     );
     this.invalidateCloudBucketMounts();
   }
@@ -570,7 +573,7 @@ export class ModalSandboxSession implements SandboxSession<ModalSandboxSessionSt
       'modal',
       this.writer(),
       this.remotePathResolver,
-      this.manifestMaterializationOptions,
+      this.manifestMaterializationOptions(),
     );
     this.invalidateCloudBucketMounts();
   }
@@ -951,14 +954,17 @@ export class ModalSandboxSession implements SandboxSession<ModalSandboxSessionSt
     );
   }
 
-  private readonly manifestMaterializationOptions = {
-    materializeMount: async (
-      absolutePath: string,
-      _entry: Mount | TypedMount,
-    ) => {
-      throwModalLiveMountsUnsupported([absolutePath]);
-    },
-  };
+  private manifestMaterializationOptions() {
+    return {
+      materializeMount: async (
+        absolutePath: string,
+        _entry: Mount | TypedMount,
+      ) => {
+        throwModalLiveMountsUnsupported([absolutePath]);
+      },
+      concurrencyLimits: this.concurrencyLimits,
+    };
+  }
 
   private invalidateCloudBucketMounts(): void {
     if (!this.cloudBucketMountsProvider) {
@@ -1153,10 +1159,6 @@ export class ModalSandboxClient implements SandboxClient<
       manifestOptions as ModalSandboxClientOptions | undefined,
     );
     assertCoreSnapshotUnsupported('ModalSandboxClient', createArgs.snapshot);
-    assertCoreConcurrencyLimitsUnsupported(
-      'ModalSandboxClient',
-      createArgs.concurrencyLimits,
-    );
     const manifest = createArgs.manifest;
     const resolvedOptions = resolveOptions(
       this.options,
@@ -1294,6 +1296,7 @@ export class ModalSandboxClient implements SandboxClient<
           ownsSandbox: !resolvedOptions.sandbox,
           state: sessionState,
           cloudBucketMounts,
+          concurrencyLimits: createArgs.concurrencyLimits,
           cloudBucketMountsProvider: async () =>
             await modalCloudBucketMountsForManifest({
               modalModule,

--- a/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
@@ -8,6 +8,7 @@ import {
   type SandboxClient,
   type SandboxClientCreateArgs,
   type SandboxClientOptions,
+  type SandboxConcurrencyLimits,
   type Mount,
   type SandboxSessionState,
   type TypedMount,
@@ -15,7 +16,6 @@ import {
 } from '@openai/agents-core/sandbox';
 import { posix as pathPosix } from 'node:path';
 import {
-  assertCoreConcurrencyLimitsUnsupported,
   assertCoreSnapshotUnsupported,
   assertTarWorkspacePersistence,
   assertResumeRecreateAllowed,
@@ -628,12 +628,14 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
     state: RunloopSandboxSessionState;
     sdk: RunloopClientLike;
     devbox: RunloopDevboxLike;
+    concurrencyLimits?: SandboxConcurrencyLimits;
   }) {
     super({
       state: args.state,
       options: {
         providerName: 'RunloopSandboxClient',
         providerId: 'runloop',
+        concurrencyLimits: args.concurrencyLimits,
       },
     });
     this.sdk = args.sdk;
@@ -1321,10 +1323,6 @@ export class RunloopSandboxClient implements SandboxClient<
   ): Promise<RunloopSandboxSession> {
     const createArgs = normalizeSandboxClientCreateArgs(args, manifestOptions);
     assertCoreSnapshotUnsupported('RunloopSandboxClient', createArgs.snapshot);
-    assertCoreConcurrencyLimitsUnsupported(
-      'RunloopSandboxClient',
-      createArgs.concurrencyLimits,
-    );
     const resolvedOptions: RunloopSandboxResolvedOptions = {
       ...this.options,
       ...createArgs.options,
@@ -1419,6 +1417,7 @@ export class RunloopSandboxClient implements SandboxClient<
         const session = new RunloopSandboxSession({
           sdk,
           devbox,
+          concurrencyLimits: createArgs.concurrencyLimits,
           state: {
             manifest,
             devboxId: devbox.id,

--- a/packages/agents-extensions/src/sandbox/shared/localSources.ts
+++ b/packages/agents-extensions/src/sandbox/shared/localSources.ts
@@ -23,7 +23,9 @@ import {
   applyMaterializedManifestToState,
   materializeInlineManifestEntry,
   materializeManifestEntries,
+  resolveLocalDirFileConcurrency,
   resolveMaterializedChildPath,
+  runLimited,
 } from './manifest';
 import type { SandboxProcessResult } from './process';
 import type {
@@ -140,7 +142,7 @@ export async function materializeLocalSourceManifestEntry(
       );
       break;
     case 'local_dir':
-      await materializeLocalDirectory(writer, absolutePath, entry.src);
+      await materializeLocalDirectory(writer, absolutePath, entry.src, options);
       break;
     case 'git_repo':
       await materializeGitRepo(
@@ -149,6 +151,7 @@ export async function materializeLocalSourceManifestEntry(
         entry,
         entry.ref,
         providerLabel,
+        options,
       );
       break;
     default:
@@ -169,6 +172,7 @@ async function materializeLocalDirectory(
   writer: RemoteManifestWriter,
   absolutePath: string,
   sourceDir: string,
+  options: ManifestMaterializationOptions,
   expectedSourceStat?: Stats,
 ): Promise<void> {
   const source = await resolveStableLocalDirectorySource(
@@ -178,38 +182,43 @@ async function materializeLocalDirectory(
   await writer.mkdir(absolutePath);
   const entries = await readStableLocalDirectoryEntries(sourceDir, source.stat);
 
-  for (const entry of entries) {
-    const sourcePath = join(sourceDir, entry.name);
-    const destinationPath = `${absolutePath}/${entry.name}`;
+  await runLimited(
+    entries,
+    resolveLocalDirFileConcurrency(options.concurrencyLimits),
+    async (entry) => {
+      const sourcePath = join(sourceDir, entry.name);
+      const destinationPath = `${absolutePath}/${entry.name}`;
 
-    if (entry.isDirectory()) {
-      const childSourceStat = await assertStableLocalDirectoryChild(
-        source.root,
-        sourcePath,
-      );
-      await materializeLocalDirectory(
-        writer,
-        destinationPath,
-        sourcePath,
-        childSourceStat,
-      );
-      continue;
-    }
+      if (entry.isDirectory()) {
+        const childSourceStat = await assertStableLocalDirectoryChild(
+          source.root,
+          sourcePath,
+        );
+        await materializeLocalDirectory(
+          writer,
+          destinationPath,
+          sourcePath,
+          options,
+          childSourceStat,
+        );
+        return;
+      }
 
-    if (entry.isFile()) {
-      await writer.writeFile(
-        destinationPath,
-        await readStableLocalDirectoryFile(source.root, sourcePath),
-      );
-      continue;
-    }
+      if (entry.isFile()) {
+        await writer.writeFile(
+          destinationPath,
+          await readStableLocalDirectoryFile(source.root, sourcePath),
+        );
+        return;
+      }
 
-    if (entry.isSymbolicLink()) {
-      throw new UserError(
-        `local_dir entries do not support symbolic links: ${sourcePath}`,
-      );
-    }
-  }
+      if (entry.isSymbolicLink()) {
+        throw new UserError(
+          `local_dir entries do not support symbolic links: ${sourcePath}`,
+        );
+      }
+    },
+  );
 }
 
 async function resolveStableLocalDirectorySource(
@@ -505,6 +514,7 @@ async function materializeGitRepo(
   repository: string | { host?: string; repo: string; subpath?: string },
   ref: string | undefined,
   providerLabel: string,
+  options: ManifestMaterializationOptions,
 ): Promise<void> {
   const gitVersion = await runSandboxProcess('git', ['--version'], {
     timeoutMs: GIT_VERSION_TIMEOUT_MS,
@@ -542,7 +552,13 @@ async function materializeGitRepo(
         `git_repo subpath escapes the cloned repository: ${subpath}`,
       );
     }
-    await materializeGitRepoSource(writer, absolutePath, sourcePath, subpath);
+    await materializeGitRepoSource(
+      writer,
+      absolutePath,
+      sourcePath,
+      options,
+      subpath,
+    );
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -627,11 +643,12 @@ async function materializeGitRepoSource(
   writer: RemoteManifestWriter,
   absolutePath: string,
   sourcePath: string,
+  options: ManifestMaterializationOptions,
   subpath?: string,
 ): Promise<void> {
   const sourceInfo = await lstat(sourcePath);
   if (sourceInfo.isDirectory()) {
-    await materializeLocalDirectory(writer, absolutePath, sourcePath);
+    await materializeLocalDirectory(writer, absolutePath, sourcePath, options);
     return;
   }
   if (sourceInfo.isFile()) {

--- a/packages/agents-extensions/src/sandbox/shared/manifest.ts
+++ b/packages/agents-extensions/src/sandbox/shared/manifest.ts
@@ -8,6 +8,7 @@ import {
   normalizeRelativePath,
   normalizePosixPath,
   relativePosixPathWithinRoot,
+  type SandboxConcurrencyLimits,
   SandboxUnsupportedFeatureError,
   serializeManifestRecord,
   type Entry,
@@ -163,6 +164,7 @@ export type ManifestMaterializationOptions = {
     entry: Mount | TypedMount,
   ) => Promise<void>;
   applyMetadata?: (absolutePath: string, entry: Entry) => Promise<void>;
+  concurrencyLimits?: SandboxConcurrencyLimits;
   resolvePath?: RemoteSandboxPathResolver;
   logicalPath?: string;
 };
@@ -313,25 +315,31 @@ export async function materializeManifestEntries<TOptions extends object>(
     skipMountEntries: true,
   } as TOptions;
 
-  for (const [path, entry] of Object.entries(manifest.entries)) {
-    if (isMount(entry)) {
-      continue;
-    }
-    const logicalPath = normalizeRelativePath(path);
-    const absolutePath = await resolvePath(logicalPath, { forWrite: true });
-    const entryOptions = {
-      ...deferredOptions,
-      resolvePath,
-      logicalPath,
-    };
-    await materializeEntry(
-      writer,
-      absolutePath,
-      entry,
-      providerLabel,
-      entryOptions as TOptions,
-    );
-  }
+  const entries = Object.entries(manifest.entries).filter(
+    ([, entry]) => !isMount(entry),
+  );
+  await runLimited(
+    entries,
+    resolveManifestEntryConcurrency(
+      (options as ManifestMaterializationOptions).concurrencyLimits,
+    ),
+    async ([path, entry]) => {
+      const logicalPath = normalizeRelativePath(path);
+      const absolutePath = await resolvePath(logicalPath, { forWrite: true });
+      const entryOptions = {
+        ...deferredOptions,
+        resolvePath,
+        logicalPath,
+      };
+      await materializeEntry(
+        writer,
+        absolutePath,
+        entry,
+        providerLabel,
+        entryOptions as TOptions,
+      );
+    },
+  );
 
   for (const {
     mountPath,
@@ -341,6 +349,53 @@ export async function materializeManifestEntries<TOptions extends object>(
     const absolutePath = await resolvePath(logicalPath, { forWrite: true });
     await materializeEntry(writer, absolutePath, entry, providerLabel, options);
   }
+}
+
+export async function runLimited<T>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<void>,
+): Promise<void> {
+  if (items.length === 0) {
+    return;
+  }
+
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(limit, items.length) },
+    async () => {
+      while (nextIndex < items.length) {
+        const item = items[nextIndex++];
+        await fn(item);
+      }
+    },
+  );
+  await Promise.all(workers);
+}
+
+export function resolveManifestEntryConcurrency(
+  limits?: SandboxConcurrencyLimits,
+): number {
+  return normalizeConcurrencyLimit(limits?.manifestEntries, 4);
+}
+
+export function resolveLocalDirFileConcurrency(
+  limits?: SandboxConcurrencyLimits,
+): number {
+  return normalizeConcurrencyLimit(limits?.localDirFiles, 4);
+}
+
+function normalizeConcurrencyLimit(
+  value: number | undefined,
+  fallback: number,
+): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  if (!Number.isFinite(value) || value < 1) {
+    throw new UserError('Sandbox concurrency limits must be positive numbers.');
+  }
+  return Math.floor(value);
 }
 
 export async function materializeInlineManifestEntry(

--- a/packages/agents-extensions/src/sandbox/shared/sessionBase.ts
+++ b/packages/agents-extensions/src/sandbox/shared/sessionBase.ts
@@ -6,6 +6,7 @@ import {
   type Manifest,
   type MaterializeEntryArgs,
   type ReadFileArgs,
+  type SandboxConcurrencyLimits,
   SandboxProviderError,
   type SandboxSession,
   type SandboxSessionState,
@@ -78,6 +79,7 @@ export type RemoteSandboxCommandResult = {
 export type RemoteSandboxSessionBaseOptions = {
   providerName: string;
   providerId: string;
+  concurrencyLimits?: SandboxConcurrencyLimits;
 };
 
 export abstract class RemoteSandboxSessionBase<
@@ -86,6 +88,7 @@ export abstract class RemoteSandboxSessionBase<
   readonly state: TState;
   protected readonly providerName: string;
   protected readonly providerId: string;
+  private readonly concurrencyLimits?: SandboxConcurrencyLimits;
   protected readonly remotePathResolver: RemoteSandboxPathResolver = async (
     path,
     options,
@@ -98,6 +101,7 @@ export abstract class RemoteSandboxSessionBase<
     this.state = args.state;
     this.providerName = args.options.providerName;
     this.providerId = args.options.providerId;
+    this.concurrencyLimits = args.options.concurrencyLimits;
   }
 
   createEditor(runAs?: string): RemoteSandboxEditor {
@@ -591,7 +595,10 @@ export abstract class RemoteSandboxSessionBase<
   private manifestMaterializationOptionsWithMetadata(
     runAs?: string,
   ): ManifestMaterializationOptions {
-    const options = this.manifestMaterializationOptions();
+    const options = {
+      ...this.manifestMaterializationOptions(),
+      concurrencyLimits: this.concurrencyLimits,
+    };
     const support = this.manifestMetadataSupport();
     if (!support?.entryGroups && !support?.entryPermissions && !runAs) {
       return options;

--- a/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
@@ -14,12 +14,12 @@ import {
   type SandboxClient,
   type SandboxClientCreateArgs,
   type SandboxClientOptions,
+  type SandboxConcurrencyLimits,
   type SandboxSessionSerializationOptions,
   type SandboxSessionState,
   type WorkspaceArchiveData,
 } from '@openai/agents-core/sandbox';
 import {
-  assertCoreConcurrencyLimitsUnsupported,
   assertCoreSnapshotUnsupported,
   assertSandboxManifestMetadataSupported,
   assertRunAsUnsupported,
@@ -172,6 +172,7 @@ export interface VercelSandboxSessionState extends SandboxSessionState {
 export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandboxSessionState> {
   private sandbox: VercelSandboxInstance;
   private readonly knownDirs: Set<string>;
+  private readonly pendingDirCreates = new Map<string, Promise<void>>();
   private closePromise?: Promise<void>;
   private closeCompleted = false;
   private readonly credentials: Pick<
@@ -186,12 +187,14 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
       VercelSandboxClientOptions,
       'projectId' | 'teamId' | 'token'
     >;
+    concurrencyLimits?: SandboxConcurrencyLimits;
   }) {
     super({
       state: args.state,
       options: {
         providerName: 'VercelSandboxClient',
         providerId: 'vercel',
+        concurrencyLimits: args.concurrencyLimits,
       },
     });
     this.sandbox = args.sandbox;
@@ -583,6 +586,7 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
 
   private resetKnownDirs(): void {
     this.knownDirs.clear();
+    this.pendingDirCreates.clear();
     this.knownDirs.add(DEFAULT_VERCEL_WORKSPACE_ROOT);
   }
 
@@ -600,21 +604,34 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
     if (path === '/' || path === '.' || this.knownDirs.has(path)) {
       return;
     }
-
-    const parent = posixDirname(path);
-    if (parent !== path && parent !== '/' && parent !== '.') {
-      await this.ensureDir(parent);
+    const pending = this.pendingDirCreates.get(path);
+    if (pending) {
+      await pending;
+      return;
     }
 
-    try {
-      await this.sandbox.mkDir(path);
-    } catch (error) {
-      if (!isVercelAlreadyExistsError(error)) {
-        throw error;
+    const create = (async () => {
+      const parent = posixDirname(path);
+      if (parent !== path && parent !== '/' && parent !== '.') {
+        await this.ensureDir(parent);
       }
-    }
 
-    this.knownDirs.add(path);
+      try {
+        await this.sandbox.mkDir(path);
+      } catch (error) {
+        if (!isVercelAlreadyExistsError(error)) {
+          throw error;
+        }
+      }
+
+      this.knownDirs.add(path);
+    })();
+    this.pendingDirCreates.set(path, create);
+    try {
+      await create;
+    } finally {
+      this.pendingDirCreates.delete(path);
+    }
   }
 
   protected override async runRemoteCommand(
@@ -700,10 +717,6 @@ export class VercelSandboxClient implements SandboxClient<
   ): Promise<VercelSandboxSession> {
     const createArgs = normalizeSandboxClientCreateArgs(args, manifestOptions);
     assertCoreSnapshotUnsupported('VercelSandboxClient', createArgs.snapshot);
-    assertCoreConcurrencyLimitsUnsupported(
-      'VercelSandboxClient',
-      createArgs.concurrencyLimits,
-    );
     const manifest = createArgs.manifest;
     const resolvedOptions = {
       ...this.options,
@@ -760,6 +773,7 @@ export class VercelSandboxClient implements SandboxClient<
         const session = new VercelSandboxSession({
           sandbox,
           credentials: { ...resolvedOptions, ...credentials },
+          concurrencyLimits: createArgs.concurrencyLimits,
           state: {
             manifest: resolvedManifest,
             sandboxId: sandbox.sandboxId,

--- a/packages/agents-extensions/test/sandbox/blaxel.test.ts
+++ b/packages/agents-extensions/test/sandbox/blaxel.test.ts
@@ -133,12 +133,6 @@ describe('BlaxelSandboxClient', () => {
         snapshot: { type: 'remote' },
       }),
     ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
-    await expect(
-      client.create({
-        manifest: new Manifest(),
-        concurrencyLimits: { manifestEntries: 2 },
-      }),
-    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
     expect(createSandboxMock).not.toHaveBeenCalled();
   });
 

--- a/packages/agents-extensions/test/sandbox/cloudflare.test.ts
+++ b/packages/agents-extensions/test/sandbox/cloudflare.test.ts
@@ -240,12 +240,6 @@ describe('CloudflareSandboxClient', () => {
         snapshot: { type: 'remote' },
       }),
     ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
-    await expect(
-      client.create({
-        manifest: new Manifest(),
-        concurrencyLimits: { manifestEntries: 2 },
-      }),
-    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
   });
 
   test('wraps Cloudflare create worker failures as provider errors', async () => {

--- a/packages/agents-extensions/test/sandbox/daytona.test.ts
+++ b/packages/agents-extensions/test/sandbox/daytona.test.ts
@@ -104,12 +104,6 @@ describe('DaytonaSandboxClient', () => {
         snapshot: { type: 'remote' },
       }),
     ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
-    await expect(
-      client.create({
-        manifest: new Manifest(),
-        concurrencyLimits: { manifestEntries: 2 },
-      }),
-    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
     expect(createMock).not.toHaveBeenCalled();
   });
 

--- a/packages/agents-extensions/test/sandbox/e2b.test.ts
+++ b/packages/agents-extensions/test/sandbox/e2b.test.ts
@@ -187,12 +187,6 @@ describe('E2BSandboxClient', () => {
         snapshot: { type: 'remote' },
       }),
     ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
-    await expect(
-      client.create({
-        manifest: new Manifest(),
-        concurrencyLimits: { manifestEntries: 2 },
-      }),
-    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
     expect(createMock).not.toHaveBeenCalled();
   });
 

--- a/packages/agents-extensions/test/sandbox/modal.test.ts
+++ b/packages/agents-extensions/test/sandbox/modal.test.ts
@@ -324,12 +324,6 @@ describe('ModalSandboxClient', () => {
         snapshot: { type: 'remote' },
       }),
     ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
-    await expect(
-      client.create({
-        manifest: new Manifest(),
-        concurrencyLimits: { manifestEntries: 2 },
-      }),
-    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
     expect(sandboxesCreateMock).not.toHaveBeenCalled();
   });
 

--- a/packages/agents-extensions/test/sandbox/runloop.test.ts
+++ b/packages/agents-extensions/test/sandbox/runloop.test.ts
@@ -359,12 +359,6 @@ describe('RunloopSandboxClient', () => {
         snapshot: { type: 'remote' },
       }),
     ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
-    await expect(
-      client.create({
-        manifest: new Manifest(),
-        concurrencyLimits: { manifestEntries: 2 },
-      }),
-    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
     expect(createMock).not.toHaveBeenCalled();
   });
 

--- a/packages/agents-extensions/test/sandbox/shared.test.ts
+++ b/packages/agents-extensions/test/sandbox/shared.test.ts
@@ -622,6 +622,85 @@ describe('remote sandbox path helpers', () => {
     });
   });
 
+  test('applies manifest entry concurrency limits to local source manifests', async () => {
+    const state = {
+      manifest: new Manifest({ root: '/workspace' }),
+      environment: {},
+    };
+    let activeWrites = 0;
+    let maxActiveWrites = 0;
+
+    await applyLocalSourceManifestToState(
+      state,
+      new Manifest({
+        entries: {
+          'a.txt': file({ content: 'a' }),
+          'b.txt': file({ content: 'b' }),
+          'c.txt': file({ content: 'c' }),
+        },
+      }),
+      'fake-provider',
+      {
+        mkdir: vi.fn(),
+        writeFile: async () => {
+          activeWrites += 1;
+          maxActiveWrites = Math.max(maxActiveWrites, activeWrites);
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          activeWrites -= 1;
+        },
+      },
+      async (path) => `/workspace/${path}`,
+      {
+        concurrencyLimits: {
+          manifestEntries: 2,
+        },
+      },
+    );
+
+    expect(maxActiveWrites).toBe(2);
+  });
+
+  test('applies local_dir file concurrency limits to local source manifests', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'agents-local-dir-'));
+    tempDirs.push(tempDir);
+    await writeFile(join(tempDir, 'a.txt'), 'a');
+    await writeFile(join(tempDir, 'b.txt'), 'b');
+    await writeFile(join(tempDir, 'c.txt'), 'c');
+    const state = {
+      manifest: new Manifest({ root: '/workspace' }),
+      environment: {},
+    };
+    let activeWrites = 0;
+    let maxActiveWrites = 0;
+
+    await applyLocalSourceManifestToState(
+      state,
+      new Manifest({
+        entries: {
+          copied: localDir({ src: tempDir }),
+        },
+      }),
+      'fake-provider',
+      {
+        mkdir: vi.fn(),
+        writeFile: async () => {
+          activeWrites += 1;
+          maxActiveWrites = Math.max(maxActiveWrites, activeWrites);
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          activeWrites -= 1;
+        },
+      },
+      async (path) => `/workspace/${path}`,
+      {
+        concurrencyLimits: {
+          localDirFiles: 2,
+        },
+      },
+    );
+
+    expect(maxActiveWrites).toBe(2);
+  });
+
   test('applies single local source entries to remote state', async () => {
     const written = new Map<string, string | Uint8Array>();
     const state = {

--- a/packages/agents-extensions/test/sandbox/vercel.test.ts
+++ b/packages/agents-extensions/test/sandbox/vercel.test.ts
@@ -144,12 +144,6 @@ describe('VercelSandboxClient', () => {
         snapshot: { type: 'remote' },
       }),
     ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
-    await expect(
-      client.create({
-        manifest: new Manifest(),
-        concurrencyLimits: { manifestEntries: 2 },
-      }),
-    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
     expect(createMock).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
This pull request fixes remote sandbox `concurrencyLimits` support so the TypeScript sandbox implementation no longer rejects options that are available in Python.

It threads `concurrencyLimits` through shared remote manifest materialization, local source handling, and provider session construction for E2B, Blaxel, Runloop, Daytona, Cloudflare, Modal, and Vercel. It also applies `manifestEntries` and `localDirFiles` limits during remote source materialization, adds regression coverage for those limits, removes outdated provider rejection assertions, and adds a Vercel directory-creation guard needed when sibling manifest writes run concurrently.