### PR TITLE
fix: align sandbox mounts with Python and protect rclone credentials

### DIFF
--- a/.changeset/docker-in-container-mounts.md
+++ b/.changeset/docker-in-container-mounts.md
@@ -1,7 +1,7 @@
 ---
-'@openai/agents-core': patch
-'@openai/agents': patch
-'@openai/agents-extensions': patch
+'@openai/agents-core': minor
+'@openai/agents': minor
+'@openai/agents-extensions': minor
 ---
 
 fix: align sandbox mounts with Python and protect rclone credentials

--- a/.changeset/docker-in-container-mounts.md
+++ b/.changeset/docker-in-container-mounts.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-core': patch
+'@openai/agents': patch
+'@openai/agents-extensions': patch
+---
+
+fix: align sandbox mounts with Python and protect rclone credentials

--- a/packages/agents-core/src/sandbox/entries/types.ts
+++ b/packages/agents-core/src/sandbox/entries/types.ts
@@ -44,6 +44,9 @@ export type MountPattern = {
 export type RcloneMountPattern = MountPattern & {
   type: 'rclone';
   mode?: 'fuse' | 'nfs' | (string & {});
+  remoteName?: string;
+  extraArgs?: string[];
+  configFilePath?: string;
   remote?: string;
   args?: string[];
   nfsAddr?: string;
@@ -53,16 +56,38 @@ export type RcloneMountPattern = MountPattern & {
 export type FuseMountPattern = MountPattern & {
   type: 'fuse';
   command?: string | string[];
+  allowOther?: boolean;
+  logType?: string;
+  logLevel?: string;
+  cacheType?: 'block_cache' | 'file_cache' | (string & {});
+  cachePath?: string;
+  cacheSizeMb?: number;
+  blockCacheBlockSizeMb?: number;
+  blockCacheDiskTimeoutSec?: number;
+  fileCacheTimeoutSec?: number;
+  fileCacheMaxSizeMb?: number;
+  attrCacheTimeoutSec?: number;
+  entryCacheTimeoutSec?: number;
+  negativeEntryCacheTimeoutSec?: number;
 };
 
 export type MountpointMountPattern = MountPattern & {
   type: 'mountpoint';
-  args?: string[];
+  options?: {
+    prefix?: string;
+    region?: string;
+    endpointUrl?: string;
+  };
 };
 
 export type S3FilesMountPattern = MountPattern & {
-  type: 's3_files';
-  args?: string[];
+  type: 's3files';
+  options?: {
+    mountTargetIp?: string;
+    accessPoint?: string;
+    region?: string;
+    extraOptions?: Record<string, string | null>;
+  };
 };
 
 export type InContainerMountStrategy = {
@@ -118,6 +143,7 @@ export type S3Mount = MountBase & {
   prefix?: string;
   region?: string;
   endpointUrl?: string;
+  s3Provider?: string;
   accessKeyId?: string;
   secretAccessKey?: string;
   sessionToken?: string;
@@ -140,7 +166,7 @@ export type R2Mount = MountBase & {
   type: 'r2_mount';
   bucket: string;
   prefix?: string;
-  accountId?: string;
+  accountId: string;
   customDomain?: string;
   accessKeyId?: string;
   secretAccessKey?: string;
@@ -152,6 +178,7 @@ export type AzureBlobMount = MountBase & {
   prefix?: string;
   account?: string;
   accountName?: string;
+  endpoint?: string;
   endpointUrl?: string;
   identityClientId?: string;
   accountKey?: string;
@@ -174,9 +201,12 @@ export type BoxMount = MountBase & {
 
 export type S3FilesMount = MountBase & {
   type: 's3_files_mount';
-  bucket: string;
-  prefix?: string;
+  fileSystemId: string;
+  subpath?: string;
+  mountTargetIp?: string;
+  accessPoint?: string;
   region?: string;
+  extraOptions?: Record<string, string | null>;
 };
 
 export type TypedMount =

--- a/packages/agents-core/src/sandbox/manifest.ts
+++ b/packages/agents-core/src/sandbox/manifest.ts
@@ -635,6 +635,39 @@ function normalizeMountStrategy(strategy: unknown): MountStrategy {
     type: strategy.type.trim(),
   };
   rejectKnownSnakeCaseKeys(normalized, ['driver_options'], 'mount strategy');
+  if (isRecord(normalized.pattern)) {
+    rejectKnownSnakeCaseKeys(
+      normalized.pattern,
+      [
+        'remote_name',
+        'extra_args',
+        'config_file_path',
+        'nfs_addr',
+        'nfs_mount_options',
+        'allow_other',
+        'log_type',
+        'log_level',
+        'cache_type',
+        'cache_path',
+        'cache_size_mb',
+        'block_cache_block_size_mb',
+        'block_cache_disk_timeout_sec',
+        'file_cache_timeout_sec',
+        'file_cache_max_size_mb',
+        'attr_cache_timeout_sec',
+        'entry_cache_timeout_sec',
+        'negative_entry_cache_timeout_sec',
+      ],
+      'mount strategy pattern',
+    );
+    if (isRecord(normalized.pattern.options)) {
+      rejectKnownSnakeCaseKeys(
+        normalized.pattern.options,
+        ['endpoint_url', 'mount_target_ip', 'access_point', 'extra_options'],
+        'mount strategy pattern options',
+      );
+    }
+  }
 
   return normalized as MountStrategy;
 }
@@ -655,6 +688,7 @@ function normalizeTypedMountProvider(entry: Entry): void {
             prefix: entry.prefix,
             region: entry.region,
             endpointUrl: entry.endpointUrl,
+            s3Provider: entry.s3Provider,
           },
         ),
       );
@@ -697,6 +731,7 @@ function normalizeTypedMountProvider(entry: Entry): void {
             prefix: entry.prefix,
             account: entry.account,
             accountName: entry.accountName,
+            endpoint: entry.endpoint,
             endpointUrl: entry.endpointUrl,
           },
         ),
@@ -723,10 +758,13 @@ function normalizeTypedMountProvider(entry: Entry): void {
         entry,
         's3_files',
         typedMountConfig(
-          { bucket: entry.bucket },
+          { fileSystemId: entry.fileSystemId },
           {
-            prefix: entry.prefix,
+            subpath: entry.subpath,
+            mountTargetIp: entry.mountTargetIp,
+            accessPoint: entry.accessPoint,
             region: entry.region,
+            extraOptions: entry.extraOptions,
           },
         ),
       );
@@ -750,11 +788,11 @@ function setTypedMountProviderConfig(
 
 function typedMountConfig(
   required: Record<string, string>,
-  optional: Record<string, string | undefined> = {},
+  optional: Record<string, unknown | undefined> = {},
 ): Record<string, unknown> {
   const config: Record<string, unknown> = { ...required };
   for (const [key, value] of Object.entries(optional)) {
-    if (value) {
+    if (value !== undefined) {
       config[key] = value;
     }
   }
@@ -770,10 +808,24 @@ function rejectKnownSnakeCaseMountKeys(entry: Entry): void {
       'mount_strategy',
       'client_id',
       'client_secret',
+      'access_id',
+      'access_key_id',
       'access_token',
+      'secret_access_key',
+      'session_token',
+      'service_account_credentials',
+      'service_account_file',
       'endpoint_url',
       'account_id',
       'account_name',
+      'account_key',
+      'custom_domain',
+      'file_system_id',
+      'mount_target_ip',
+      'access_point',
+      'extra_options',
+      's3_provider',
+      'identity_client_id',
       'box_config_file',
       'config_credentials',
       'box_sub_type',

--- a/packages/agents-core/src/sandbox/sandboxes/docker.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/docker.ts
@@ -8,9 +8,10 @@ import type { ToolOutputImage } from '../../tool';
 import { applyDiff } from '../../utils/applyDiff';
 import {
   SandboxConfigurationError,
+  SandboxMountError,
   SandboxUnsupportedFeatureError,
 } from '../errors';
-import { chmod, mkdir, mkdtemp } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { createHash, randomUUID } from 'node:crypto';
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { isAbsolute, join, resolve } from 'node:path';
@@ -18,11 +19,19 @@ import { tmpdir } from 'node:os';
 import {
   type AzureBlobMount,
   type BoxMount,
+  type Entry,
+  type FuseMountPattern,
   type GCSMount,
   type Mount,
+  type MountPattern,
+  type MountpointMountPattern,
   type R2Mount,
+  type RcloneMountPattern,
+  type S3FilesMount,
+  type S3FilesMountPattern,
   type S3Mount,
   type TypedMount,
+  isMount,
 } from '../entries';
 import type {
   SandboxClient,
@@ -113,6 +122,7 @@ export interface DockerSandboxSessionState extends UnixLocalSandboxSessionState 
   defaultUser?: string;
   configuredExposedPorts?: number[];
   dockerVolumeNames?: string[];
+  snapshotExcludedPaths?: string[];
 }
 
 export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxSessionState> {
@@ -146,7 +156,7 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
   }
 
   override async pathExists(path: string, runAs?: string): Promise<boolean> {
-    if (!runAs) {
+    if (!runAs && !this.pathRequiresDockerFilesystem(path)) {
       return await super.pathExists(path);
     }
     const result = await this.runDockerFilesystemCommand(
@@ -157,7 +167,7 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
   }
 
   override async readFile(args: ReadFileArgs): Promise<Uint8Array> {
-    if (!args.runAs) {
+    if (!args.runAs && !this.pathRequiresDockerFilesystem(args.path)) {
       return await super.readFile(args);
     }
     const bytes = await this.readDockerFileAs(
@@ -173,7 +183,7 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
   override async listDir(
     args: ListDirectoryArgs,
   ): Promise<SandboxDirectoryEntry[]> {
-    if (!args.runAs) {
+    if (!args.runAs && !this.pathRequiresDockerFilesystem(args.path)) {
       return await super.listDir(args);
     }
     const absolutePath = this.resolveContainerFilesystemPath(args.path);
@@ -200,7 +210,60 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
       });
   }
 
+  private pathRequiresDockerFilesystem(path?: string): boolean {
+    return Boolean(
+      dockerInContainerMountContainingPath(this.state.manifest, path),
+    );
+  }
+
   override async materializeEntry(args: MaterializeEntryArgs): Promise<void> {
+    if (isMount(args.entry) && isDockerInContainerMount(args.entry)) {
+      const logicalPath = this.resolveLogicalPath(args.path);
+      assertDockerCanApplyInContainerMounts(
+        this.state.manifest,
+        new Manifest({
+          entries: {
+            [logicalPath]: args.entry,
+          },
+        }),
+      );
+      assertLocalWorkspaceManifestMetadataSupported(
+        'DockerSandboxClient',
+        new Manifest({
+          entries: {
+            [logicalPath]: args.entry,
+          },
+        }),
+        {
+          allowLocalBindMounts: false,
+          allowIdentityMetadata: true,
+          supportsMount: isSupportedDockerApplyMount,
+        },
+      );
+      await materializeDockerMountPoint(
+        this.state.workspaceRootPath,
+        this.state.manifest.root,
+        logicalPath,
+        args.entry,
+      );
+      if (args.runAs) {
+        const mountPath = resolveDockerMountPath(
+          this.state.manifest.root,
+          logicalPath,
+          args.entry,
+        );
+        await this.mkdirDockerPathAs(mountPath, 'root');
+        await this.chownContainerPath(mountPath, args.runAs);
+      }
+      await applyDockerInContainerMount(this, logicalPath, args.entry);
+      this.state.manifest = mergeManifestEntryDelta(
+        this.state.manifest,
+        logicalPath,
+        args.entry,
+      );
+      return;
+    }
+
     if (!args.runAs) {
       await super.materializeEntry(args);
       return;
@@ -240,20 +303,61 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
     runAs?: string,
   ): Promise<void> {
     assertDockerManifestDeltaSupported(manifest);
-    await provisionDockerAccounts(this.state.containerId, manifest);
-    await super.applyManifest(stripDockerIdentityMetadata(manifest));
-    if (runAs) {
-      for (const path of Object.keys(manifest.entries)) {
-        await this.chownContainerPath(
-          this.resolveContainerFilesystemPath(path),
-          runAs,
-        );
+    assertDockerCanApplyInContainerMounts(this.state.manifest, manifest);
+    const environment = await manifest.resolveEnvironment();
+    const previousEnvironment = this.state.environment;
+    const nextEnvironment = {
+      ...this.state.environment,
+      ...environment,
+    };
+    this.state.environment = nextEnvironment;
+    try {
+      await provisionDockerAccounts(this.state.containerId, manifest);
+      const materializedManifest = stripDockerIdentityMetadata(manifest);
+      await materializeLocalWorkspaceManifest(
+        materializedManifest,
+        this.state.workspaceRootPath,
+        {
+          allowLocalBindMounts: false,
+          allowIdentityMetadata: true,
+          supportsMount: isSupportedDockerApplyMount,
+          materializeMount: async ({ logicalPath, entry }) => {
+            await materializeDockerMountPoint(
+              this.state.workspaceRootPath,
+              this.state.manifest.root,
+              logicalPath,
+              entry,
+            );
+          },
+        },
+      );
+      if (runAs) {
+        for (const [path, entry] of Object.entries(manifest.entries)) {
+          if (isMount(entry)) {
+            const mountPath = resolveDockerMountPath(
+              this.state.manifest.root,
+              path,
+              entry,
+            );
+            await this.mkdirDockerPathAs(mountPath, 'root');
+            await this.chownContainerPath(mountPath, runAs);
+          } else {
+            await this.chownContainerPath(
+              this.resolveContainerFilesystemPath(path),
+              runAs,
+            );
+          }
+        }
       }
+      await applyDockerInContainerMounts(this, manifest);
+      this.state.manifest = mergeDockerIdentityMetadata(
+        mergeManifestDelta(this.state.manifest, materializedManifest),
+        manifest,
+      );
+    } catch (error) {
+      this.state.environment = previousEnvironment;
+      throw error;
     }
-    this.state.manifest = mergeDockerIdentityMetadata(
-      this.state.manifest,
-      manifest,
-    );
   }
 
   override async resolveExposedPort(
@@ -376,6 +480,7 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
         },
       },
     );
+    await applyDockerInContainerMounts(this, this.state.manifest);
   }
 
   override resolveSandboxPath(
@@ -389,6 +494,15 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
     if (mountPath) {
       throw new UserError(
         `DockerSandboxClient filesystem operations cannot access Docker volume mount path "${path ?? mountPath}". Use execCommand for container-visible paths under "${mountPath}".`,
+      );
+    }
+    const inContainerMountPath = dockerInContainerMountContainingPath(
+      this.state.manifest,
+      path,
+    );
+    if (inContainerMountPath) {
+      throw new UserError(
+        `DockerSandboxClient host filesystem operations cannot access in-container mount path "${path ?? inContainerMountPath}". Use execCommand for container-visible paths under "${inContainerMountPath}".`,
       );
     }
     return super.resolveSandboxPath(path, options);
@@ -405,7 +519,7 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
     return resolved.path;
   }
 
-  async readDockerFileAs(path: string, runAs: string): Promise<Uint8Array> {
+  async readDockerFileAs(path: string, runAs?: string): Promise<Uint8Array> {
     const output = await this.runCheckedDockerFilesystemCommand(
       `base64 -- ${shellQuote(path)}`,
       { runAs },
@@ -442,6 +556,18 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
       `mkdir -p -- ${shellQuote(path)}`,
       { runAs },
       `create directory ${path}`,
+    );
+  }
+
+  async runDockerMountCommand(
+    command: string,
+    action: string,
+    options: { input?: string | Uint8Array } = {},
+  ): Promise<string> {
+    return await this.runCheckedDockerFilesystemCommand(
+      command,
+      { runAs: 'root', input: options.input },
+      action,
     );
   }
 
@@ -644,9 +770,7 @@ export class DockerSandboxClient implements SandboxClient<
       defaultUser,
       exposedPorts: configuredExposedPorts,
     });
-    await provisionDockerAccounts(container.containerId, manifest);
-
-    return new DockerSandboxSession({
+    const session = new DockerSandboxSession({
       state: {
         manifest,
         workspaceRootPath,
@@ -661,6 +785,20 @@ export class DockerSandboxClient implements SandboxClient<
         dockerVolumeNames: container.volumeNames,
       },
     });
+    try {
+      await provisionDockerAccounts(container.containerId, manifest);
+      await applyDockerInContainerMounts(session, manifest);
+    } catch (error) {
+      await cleanupStartedDockerContainer({
+        containerId: container.containerId,
+        volumeNames: container.volumeNames,
+        workspaceRootPath,
+        removeWorkspace: true,
+      });
+      throw error;
+    }
+
+    return session;
   }
 
   async resume(
@@ -679,6 +817,7 @@ export class DockerSandboxClient implements SandboxClient<
     state: DockerSandboxSessionState,
   ): Promise<Record<string, unknown>> {
     const snapshotSpec = state.snapshotSpec ?? this.options.snapshot ?? null;
+    attachDockerSnapshotExcludedPaths(state);
     const snapshot = await persistLocalSnapshot(
       'DockerSandboxClient',
       state,
@@ -724,6 +863,7 @@ export class DockerSandboxClient implements SandboxClient<
   private async restoreIfNeeded(
     state: DockerSandboxSessionState,
   ): Promise<DockerSandboxSessionState> {
+    attachDockerSnapshotExcludedPaths(state);
     const containerRunning = await inspectContainerRunning(state.containerId);
     const workspaceExists = await pathExists(state.workspaceRootPath);
 
@@ -811,14 +951,44 @@ export class DockerSandboxClient implements SandboxClient<
       defaultUser: state.defaultUser,
       exposedPorts: state.configuredExposedPorts,
     });
-    await provisionDockerAccounts(container.containerId, state.manifest);
-    return {
+    const nextState = {
       ...state,
       workspaceRootPath,
       containerId: container.containerId,
       dockerVolumeNames: container.volumeNames,
       exposedPorts: undefined,
     };
+    const session = new DockerSandboxSession({ state: nextState });
+    try {
+      await provisionDockerAccounts(container.containerId, state.manifest);
+      await applyDockerInContainerMounts(session, state.manifest);
+    } catch (error) {
+      await cleanupStartedDockerContainer({
+        containerId: container.containerId,
+        volumeNames: container.volumeNames,
+        workspaceRootPath,
+        removeWorkspace: false,
+      });
+      throw error;
+    }
+    return nextState;
+  }
+}
+
+async function cleanupStartedDockerContainer(args: {
+  containerId: string;
+  volumeNames: string[];
+  workspaceRootPath: string;
+  removeWorkspace: boolean;
+}): Promise<void> {
+  await removeDockerContainer(args.containerId, { ignoreMissing: true }).catch(
+    () => undefined,
+  );
+  await removeDockerVolumes(args.volumeNames);
+  if (args.removeWorkspace) {
+    await rm(args.workspaceRootPath, { recursive: true, force: true }).catch(
+      () => undefined,
+    );
   }
 }
 
@@ -1066,6 +1236,7 @@ async function startDockerContainer(args: {
     args.manifest,
     containerName,
   );
+  const privilegeArgs = dockerInContainerMountPrivilegeArgs(args.manifest);
   const result = await runSandboxProcess(
     'docker',
     [
@@ -1079,6 +1250,7 @@ async function startDockerContainer(args: {
       `${args.workspaceRootPath}:${args.manifestRoot}`,
       ...dockerExtraPathGrantMountArgs(args.manifest),
       ...mountArgs,
+      ...privilegeArgs,
       '-w',
       args.manifestRoot,
       ...portArgs,
@@ -1124,11 +1296,15 @@ async function materializeDockerMountPoint(
 }
 
 function isSupportedDockerCreateMount(entry: Mount | TypedMount): boolean {
-  return isDockerBindMount(entry) || isDockerVolumeMount(entry);
+  return (
+    isDockerBindMount(entry) ||
+    isDockerVolumeMount(entry) ||
+    isSupportedDockerInContainerMount(entry)
+  );
 }
 
-function isSupportedDockerApplyMount(_entry: Mount | TypedMount): boolean {
-  return false;
+function isSupportedDockerApplyMount(entry: Mount | TypedMount): boolean {
+  return isSupportedDockerInContainerMount(entry);
 }
 
 function isDockerBindMount(
@@ -1147,9 +1323,83 @@ function isDockerVolumeMount(entry: Mount | TypedMount): boolean {
   return Boolean(dockerVolumeDriverConfig(entry));
 }
 
+function isDockerInContainerMount(
+  entry: Mount | TypedMount,
+): entry is Mount | TypedMount {
+  return entry.mountStrategy?.type === 'in_container';
+}
+
+function isSupportedDockerInContainerMount(entry: Mount | TypedMount): boolean {
+  if (!isDockerInContainerMount(entry)) {
+    return false;
+  }
+  let pattern: MountPattern;
+  try {
+    pattern = dockerInContainerMountPattern(entry);
+  } catch {
+    return false;
+  }
+  switch (pattern.type) {
+    case 'rclone':
+      return dockerRcloneMountTypes.has(entry.type);
+    case 'mountpoint':
+      return entry.type === 's3_mount' || entry.type === 'gcs_mount';
+    case 's3files':
+      return entry.type === 's3_files_mount';
+    case 'fuse':
+      return entry.type === 'azure_blob_mount' || Boolean(pattern.command);
+    default:
+      return false;
+  }
+}
+
+function assertDockerCanApplyInContainerMounts(
+  currentManifest: Manifest,
+  deltaManifest: Manifest,
+): void {
+  const currentPrivilege = dockerInContainerMountPrivilege(currentManifest);
+  const requiredPrivilege = dockerInContainerMountPrivilege(deltaManifest);
+  if (dockerPrivilegeSatisfies(currentPrivilege, requiredPrivilege)) {
+    return;
+  }
+  throw new SandboxUnsupportedFeatureError(
+    'DockerSandboxClient cannot add this in-container mount to an already-running container because it requires Docker privileges that were not granted at container start.',
+    {
+      provider: 'DockerSandboxClient',
+      currentPrivilege,
+      requiredPrivilege,
+    },
+  );
+}
+
+function dockerPrivilegeSatisfies(
+  current: 'none' | 'fuse' | 'sys_admin',
+  required: 'none' | 'fuse' | 'sys_admin',
+): boolean {
+  if (required === 'none' || current === required) {
+    return true;
+  }
+  return current === 'fuse' && required === 'sys_admin';
+}
+
 function dockerVolumeMountContainingPath(
   manifest: Manifest,
   path?: string,
+): string | undefined {
+  return dockerMountContainingPath(manifest, path, isDockerVolumeMount);
+}
+
+function dockerInContainerMountContainingPath(
+  manifest: Manifest,
+  path?: string,
+): string | undefined {
+  return dockerMountContainingPath(manifest, path, isDockerInContainerMount);
+}
+
+function dockerMountContainingPath(
+  manifest: Manifest,
+  path: string | undefined,
+  predicate: (entry: Mount | TypedMount) => boolean,
 ): string | undefined {
   const resolved = new WorkspacePathPolicy({
     root: manifest.root,
@@ -1157,7 +1407,7 @@ function dockerVolumeMountContainingPath(
   }).resolve(path);
 
   for (const { entry, mountPath } of manifest.mountTargets()) {
-    if (!isDockerVolumeMount(entry)) {
+    if (!predicate(entry)) {
       continue;
     }
     if (pathWithinDockerMount(resolved.path, mountPath)) {
@@ -1172,6 +1422,754 @@ function pathWithinDockerMount(path: string, mountPath: string): boolean {
     return true;
   }
   return path === mountPath || path.startsWith(`${mountPath}/`);
+}
+
+async function applyDockerInContainerMounts(
+  session: DockerSandboxSession,
+  manifest: Manifest,
+): Promise<void> {
+  const appliedMountPaths: string[] = [];
+  for (const {
+    logicalPath,
+    entry,
+  } of manifest.mountTargetsForMaterialization()) {
+    if (!isDockerInContainerMount(entry)) {
+      continue;
+    }
+    try {
+      appliedMountPaths.push(
+        await applyDockerInContainerMount(session, logicalPath, entry),
+      );
+    } catch (error) {
+      await cleanupDockerAppliedMounts(session, appliedMountPaths);
+      throw error;
+    }
+  }
+}
+
+async function applyDockerInContainerMount(
+  session: DockerSandboxSession,
+  logicalPath: string,
+  entry: Mount | TypedMount,
+): Promise<string> {
+  const mountPath = resolveDockerMountPath(
+    session.state.manifest.root,
+    logicalPath,
+    entry,
+  );
+  const pattern = dockerInContainerMountPattern(entry);
+  try {
+    switch (pattern.type) {
+      case 'rclone':
+        await applyDockerRcloneMount(
+          session,
+          entry,
+          mountPath,
+          pattern as RcloneMountPattern,
+        );
+        return mountPath;
+      case 'mountpoint':
+        await applyDockerMountpointMount(
+          session,
+          entry,
+          mountPath,
+          pattern as MountpointMountPattern,
+        );
+        return mountPath;
+      case 's3files':
+        await applyDockerS3FilesMount(
+          session,
+          entry,
+          mountPath,
+          pattern as S3FilesMountPattern,
+        );
+        return mountPath;
+      case 'fuse':
+        await applyDockerFuseMount(
+          session,
+          entry,
+          mountPath,
+          pattern as FuseMountPattern,
+        );
+        return mountPath;
+      default:
+        throw new SandboxUnsupportedFeatureError(
+          'DockerSandboxClient does not support this in-container mount pattern.',
+          {
+            provider: 'DockerSandboxClient',
+            feature: 'entry.mountStrategy.pattern',
+            mountType: entry.type,
+            patternType: pattern.type,
+          },
+        );
+    }
+  } catch (error) {
+    await cleanupDockerAppliedMounts(session, [mountPath]);
+    throw error;
+  }
+}
+
+async function cleanupDockerAppliedMounts(
+  session: DockerSandboxSession,
+  mountPaths: string[],
+): Promise<void> {
+  for (const mountPath of [...mountPaths].reverse()) {
+    await session
+      .runDockerMountCommand(
+        [
+          `fusermount3 -u ${shellQuote(mountPath)} >/dev/null 2>&1 || true`,
+          `fusermount -u ${shellQuote(mountPath)} >/dev/null 2>&1 || true`,
+          `umount ${shellQuote(mountPath)} >/dev/null 2>&1 || true`,
+          `umount -l ${shellQuote(mountPath)} >/dev/null 2>&1 || true`,
+          dockerSafeKillRcloneNfsPidFileCommand(
+            dockerRcloneNfsPidPath(session, mountPath),
+          ),
+        ].join(' ; '),
+        `cleanup Docker mount ${mountPath}`,
+      )
+      .catch(() => undefined);
+  }
+}
+
+function dockerInContainerMountPattern(
+  entry: Mount | TypedMount,
+): MountPattern {
+  const pattern = (
+    entry.mountStrategy as { pattern?: MountPattern } | undefined
+  )?.pattern;
+  if (pattern) {
+    return pattern;
+  }
+  if (entry.type === 's3_files_mount') {
+    return { type: 's3files' } satisfies S3FilesMountPattern;
+  }
+  if (dockerRcloneMountTypes.has(entry.type)) {
+    return { type: 'rclone', mode: 'fuse' } satisfies RcloneMountPattern;
+  }
+  throw new SandboxUnsupportedFeatureError(
+    'DockerSandboxClient in-container mounts require a mount strategy pattern for this mount type.',
+    {
+      provider: 'DockerSandboxClient',
+      feature: 'entry.mountStrategy.pattern',
+      mountType: entry.type,
+    },
+  );
+}
+
+function attachDockerSnapshotExcludedPaths(
+  state: DockerSandboxSessionState,
+): void {
+  state.snapshotExcludedPaths = dockerInternalSnapshotExcludedPaths(
+    state.manifest,
+  );
+}
+
+function dockerInternalSnapshotExcludedPaths(manifest: Manifest): string[] {
+  const paths = new Set<string>();
+  for (const { entry } of manifest.mountTargetsForMaterialization()) {
+    if (!isDockerInContainerMount(entry)) {
+      continue;
+    }
+    const pattern = dockerInContainerMountPattern(entry);
+    if (entry.type === 'azure_blob_mount' && pattern.type === 'fuse') {
+      paths.add('.sandbox-blobfuse-config');
+      paths.add('.sandbox-blobfuse-cache');
+      const cachePath = dockerBlobfuseWorkspaceCachePath(
+        pattern as FuseMountPattern,
+      );
+      if (cachePath) {
+        paths.add(cachePath);
+      }
+    }
+  }
+  return [...paths];
+}
+
+async function applyDockerRcloneMount(
+  session: DockerSandboxSession,
+  entry: Mount | TypedMount,
+  mountPath: string,
+  pattern: RcloneMountPattern,
+): Promise<void> {
+  const mode = pattern.mode ?? 'fuse';
+  if (mode !== 'fuse' && mode !== 'nfs') {
+    throw new SandboxUnsupportedFeatureError(
+      'DockerSandboxClient rclone mounts support fuse and nfs modes only.',
+      {
+        provider: 'DockerSandboxClient',
+        feature: 'entry.mountStrategy.pattern.mode',
+        mode,
+      },
+    );
+  }
+  const config = await dockerRcloneMountConfig(
+    session,
+    entry,
+    pattern,
+    mountPath,
+  );
+  const configDir = `/tmp/openai-agents-docker-mounts-${dockerPathHash(
+    `${session.state.containerId}:${mountPath}`,
+  )}`;
+  const configPath = `${configDir}/${config.remoteName}.conf`;
+  const baseCommand = [
+    `mkdir -p -- ${shellQuote(mountPath)}`,
+    `rm -rf -- ${shellQuote(configDir)}`,
+    `trap ${shellQuote(`rm -rf -- ${shellQuote(configDir)}`)} EXIT`,
+    `install -d -m 700 -- ${shellQuote(configDir)}`,
+    `(umask 077 && cat > ${shellQuote(configPath)})`,
+  ];
+  if (mode === 'nfs') {
+    const nfsAddr = rclonePatternString(pattern, 'nfsAddr') ?? '127.0.0.1:2049';
+    const pidPath = dockerRcloneNfsPidPath(session, mountPath);
+    const [host, port] = splitDockerNfsAddr(nfsAddr);
+    const serverArgs = [
+      'rclone',
+      'serve',
+      'nfs',
+      `${config.remoteName}:${config.remotePath}`,
+      '--addr',
+      nfsAddr,
+      '--config',
+      configPath,
+      ...(config.readOnly ? ['--read-only'] : []),
+      ...dockerRclonePatternArgs(pattern),
+    ];
+    const mountOptions = rclonePatternStringArray(
+      pattern,
+      'nfsMountOptions',
+    ) ?? ['vers=4.1', 'tcp', `port=${port}`, 'soft', 'timeo=50', 'retrans=1'];
+    const mountCommand = [
+      '{ mounted=0',
+      `for i in 1 2 3; do if mount -v -t nfs -o ${shellQuote(mountOptions.join(','))} ${shellQuote(`${host}:/`)} ${shellQuote(mountPath)}; then mounted=1; break; fi; sleep 1; done`,
+      `if [ "$mounted" = 1 ]; then rm -rf -- ${shellQuote(configDir)}; exit 0; fi`,
+      dockerSafeKillRcloneNfsPidFileCommand(pidPath),
+      `rm -rf -- ${shellQuote(configDir)}`,
+      'exit 1',
+      '}',
+    ].join('; ');
+    await session.runDockerMountCommand(
+      [
+        ...baseCommand,
+        `(${shellCommand(serverArgs)} & printf %s "$!" > ${shellQuote(pidPath)}) && ${mountCommand}`,
+      ].join(' && '),
+      `mount rclone ${entry.type}`,
+      { input: config.configText },
+    );
+    return;
+  }
+
+  const mountArgs = [
+    'rclone',
+    'mount',
+    `${config.remoteName}:${config.remotePath}`,
+    mountPath,
+    ...(config.readOnly ? ['--read-only'] : []),
+    ...dockerRcloneFuseAccessArgs(session),
+    '--config',
+    configPath,
+    '--daemon',
+    ...dockerRclonePatternArgs(pattern),
+  ];
+  await session.runDockerMountCommand(
+    [
+      ...baseCommand,
+      dockerEnableFuseAllowOtherCommand(),
+      shellCommand(mountArgs),
+      `rm -rf -- ${shellQuote(configDir)}`,
+    ].join(' && '),
+    `mount rclone ${entry.type}`,
+    { input: config.configText },
+  );
+}
+
+function dockerRcloneNfsPidPath(
+  session: DockerSandboxSession,
+  mountPath: string,
+): string {
+  return `/tmp/openai-agents-rclone-nfs-${dockerPathHash(
+    `${session.state.containerId}:${mountPath}`,
+  )}.pid`;
+}
+
+function dockerSafeKillRcloneNfsPidFileCommand(pidPath: string): string {
+  return [
+    `pid=$(cat ${shellQuote(pidPath)} 2>/dev/null || true)`,
+    `case "$pid" in ''|0|*[!0-9]*) ;; *) cmdline=$(tr '\\000' ' ' < "/proc/$pid/cmdline" 2>/dev/null || true); case "$cmdline" in *rclone*serve\\ nfs*) kill "$pid" >/dev/null 2>&1 || true ;; esac ;; esac`,
+    `rm -f -- ${shellQuote(pidPath)}`,
+  ].join('; ');
+}
+
+function dockerEnableFuseAllowOtherCommand(): string {
+  return "touch /etc/fuse.conf && (grep -qxF user_allow_other /etc/fuse.conf || printf '\\nuser_allow_other\\n' >> /etc/fuse.conf)";
+}
+
+function dockerRcloneFuseAccessArgs(session: DockerSandboxSession): string[] {
+  const user = session.state.defaultUser;
+  const match = /^(\d+):(\d+)$/u.exec(user ?? '');
+  return [
+    '--allow-other',
+    ...(match ? ['--uid', match[1], '--gid', match[2]] : []),
+  ];
+}
+
+async function applyDockerMountpointMount(
+  session: DockerSandboxSession,
+  entry: Mount | TypedMount,
+  mountPath: string,
+  pattern: MountpointMountPattern,
+): Promise<void> {
+  if (entry.type !== 's3_mount' && entry.type !== 'gcs_mount') {
+    throw new SandboxUnsupportedFeatureError(
+      'DockerSandboxClient mountpoint mounts support S3 and GCS mount entries only.',
+      {
+        provider: 'DockerSandboxClient',
+        mountType: entry.type,
+      },
+    );
+  }
+  const options = dockerMountpointPatternOptions(pattern);
+  const endpointUrl =
+    entry.endpointUrl ??
+    options.endpointUrl ??
+    (entry.type === 'gcs_mount' ? 'https://storage.googleapis.com' : undefined);
+  const mountArgs = [
+    'mount-s3',
+    ...((entry.readOnly ?? true)
+      ? ['--read-only']
+      : ['--allow-overwrite', '--allow-delete']),
+    ...((entry.region ?? options.region)
+      ? ['--region', entry.region ?? options.region!]
+      : []),
+    ...(endpointUrl ? ['--endpoint-url', endpointUrl] : []),
+    ...(entry.type === 'gcs_mount' ? ['--upload-checksums', 'off'] : []),
+    ...((entry.prefix ?? options.prefix)
+      ? ['--prefix', entry.prefix ?? options.prefix!]
+      : []),
+    entry.bucket,
+    mountPath,
+  ];
+  const envText =
+    entry.type === 's3_mount'
+      ? dockerMountpointAwsEnv(
+          entry.accessKeyId,
+          entry.secretAccessKey,
+          entry.sessionToken,
+        )
+      : dockerMountpointAwsEnv(
+          readOptionalString(entry, 'accessId'),
+          readOptionalString(entry, 'secretAccessKey'),
+        );
+  const envDir = `/tmp/openai-agents-mountpoint-env-${dockerPathHash(
+    `${session.state.containerId}:${mountPath}`,
+  )}`;
+  const envPath = `${envDir}/credentials.env`;
+  const command = envText
+    ? [
+        `rm -rf -- ${shellQuote(envDir)}`,
+        `install -d -m 700 -- ${shellQuote(envDir)}`,
+        `(umask 077 && cat > ${shellQuote(envPath)})`,
+        `set -a && . ${shellQuote(envPath)} && set +a`,
+        `rm -rf -- ${shellQuote(envDir)}`,
+        shellCommand(mountArgs),
+      ].join(' && ')
+    : shellCommand(mountArgs);
+  await session.runDockerMountCommand(
+    [`mkdir -p -- ${shellQuote(mountPath)}`, command].join(' && '),
+    `mount mountpoint ${entry.type}`,
+    envText ? { input: envText } : {},
+  );
+}
+
+async function applyDockerS3FilesMount(
+  session: DockerSandboxSession,
+  entry: Mount | TypedMount,
+  mountPath: string,
+  pattern: S3FilesMountPattern,
+): Promise<void> {
+  if (entry.type !== 's3_files_mount') {
+    throw new SandboxUnsupportedFeatureError(
+      'DockerSandboxClient s3files mounts require an s3FilesMount() entry.',
+      {
+        provider: 'DockerSandboxClient',
+        mountType: entry.type,
+      },
+    );
+  }
+  const s3Files = entry as S3FilesMount;
+  if (!s3Files.fileSystemId) {
+    throw new SandboxMountError(
+      's3FilesMount() requires fileSystemId for Docker in-container mounts.',
+      { mountType: entry.type },
+      'mount_config_invalid',
+    );
+  }
+  const patternOptions = dockerS3FilesPatternOptions(pattern);
+  const options: Record<string, string | null> = {
+    ...readStringNullRecord(patternOptions.extraOptions),
+    ...readStringNullRecord(s3Files.extraOptions),
+  };
+  if (entry.readOnly ?? true) {
+    options.ro = null;
+  }
+  const mountTargetIp = s3Files.mountTargetIp ?? patternOptions.mountTargetIp;
+  const accessPoint = s3Files.accessPoint ?? patternOptions.accessPoint;
+  const region = s3Files.region ?? patternOptions.region;
+  if (mountTargetIp) {
+    options.mounttargetip = mountTargetIp;
+  }
+  if (accessPoint) {
+    options.accesspoint = accessPoint;
+  }
+  if (region) {
+    options.region = region;
+  }
+  const device = s3Files.subpath
+    ? `${s3Files.fileSystemId}:${s3Files.subpath}`
+    : s3Files.fileSystemId;
+  const mountArgs = [
+    'mount',
+    '-t',
+    's3files',
+    ...(Object.keys(options).length > 0
+      ? ['-o', dockerMountOptions(options)]
+      : []),
+    device,
+    mountPath,
+  ];
+  await session.runDockerMountCommand(
+    [`mkdir -p -- ${shellQuote(mountPath)}`, shellCommand(mountArgs)].join(
+      ' && ',
+    ),
+    `mount s3files ${entry.type}`,
+  );
+}
+
+async function applyDockerFuseMount(
+  session: DockerSandboxSession,
+  entry: Mount | TypedMount,
+  mountPath: string,
+  pattern: FuseMountPattern,
+): Promise<void> {
+  if (entry.type === 'azure_blob_mount') {
+    await applyDockerAzureBlobFuseMount(session, entry, mountPath, pattern);
+    return;
+  }
+  if (!pattern.command) {
+    throw new SandboxUnsupportedFeatureError(
+      'DockerSandboxClient fuse command mounts require pattern.command.',
+      {
+        provider: 'DockerSandboxClient',
+        mountType: entry.type,
+      },
+    );
+  }
+  const command = Array.isArray(pattern.command)
+    ? shellCommand(pattern.command)
+    : pattern.command;
+  await session.runDockerMountCommand(
+    [
+      `mkdir -p -- ${shellQuote(mountPath)}`,
+      [
+        `export OPENAI_AGENTS_MOUNT_PATH=${shellQuote(mountPath)}`,
+        ...(entry.source
+          ? [`export OPENAI_AGENTS_MOUNT_SOURCE=${shellQuote(entry.source)}`]
+          : []),
+        command,
+      ].join('; '),
+    ].join(' && '),
+    `mount fuse command ${entry.type}`,
+  );
+}
+
+async function applyDockerAzureBlobFuseMount(
+  session: DockerSandboxSession,
+  entry: AzureBlobMount,
+  mountPath: string,
+  pattern: FuseMountPattern,
+): Promise<void> {
+  const account = entry.account ?? entry.accountName;
+  if (!account) {
+    throw new SandboxMountError(
+      'azureBlobMount() requires account or accountName for Docker fuse mounts.',
+      { mountType: entry.type },
+      'mount_config_invalid',
+    );
+  }
+  if (entry.prefix) {
+    throw new SandboxUnsupportedFeatureError(
+      'DockerSandboxClient blobfuse mounts do not support azureBlobMount().prefix. Use an rclone mount pattern for prefix-scoped Azure Blob mounts.',
+      {
+        provider: 'DockerSandboxClient',
+        mountType: entry.type,
+      },
+    );
+  }
+
+  const cacheType = dockerFusePatternString(
+    pattern,
+    'cacheType',
+    'block_cache',
+  );
+  if (cacheType !== 'block_cache' && cacheType !== 'file_cache') {
+    throw new SandboxMountError(
+      'blobfuse cacheType must be "block_cache" or "file_cache".',
+      { mountType: entry.type, cacheType },
+      'mount_config_invalid',
+    );
+  }
+  const workspaceRoot = session.state.manifest.root;
+  const cacheDir = resolveDockerBlobfuseCacheDir(
+    workspaceRoot,
+    pattern,
+    session.state.containerId,
+    account,
+    entry.container,
+  );
+  if (pathWithinDockerMount(cacheDir, mountPath)) {
+    throw new SandboxMountError(
+      'blobfuse cachePath must be outside the mount path.',
+      {
+        mountPath,
+        cachePath: cacheDir,
+      },
+      'mount_config_invalid',
+    );
+  }
+  const configDir = `/tmp/openai-agents-blobfuse-config-${dockerPathHash(
+    `${session.state.containerId}:${mountPath}`,
+  )}`;
+  const configName = `${sanitizeDockerMountName(account)}_${sanitizeDockerMountName(entry.container)}.yaml`;
+  const configPath = `${configDir}/${configName}`;
+  const configText = dockerBlobfuseConfigText({
+    account,
+    container: entry.container,
+    endpoint:
+      azureBlobEndpoint(entry) ?? `https://${account}.blob.core.windows.net`,
+    cacheType,
+    cacheSizeMb:
+      dockerFusePatternNumber(pattern, 'cacheSizeMb') ??
+      (cacheType === 'block_cache' ? 50_000 : 4_096),
+    blockCacheBlockSizeMb:
+      dockerFusePatternNumber(pattern, 'blockCacheBlockSizeMb') ?? 16,
+    blockCacheDiskTimeoutSec:
+      dockerFusePatternNumber(pattern, 'blockCacheDiskTimeoutSec') ?? 3600,
+    fileCacheTimeoutSec:
+      dockerFusePatternNumber(pattern, 'fileCacheTimeoutSec') ?? 120,
+    fileCacheMaxSizeMb: dockerFusePatternNumber(pattern, 'fileCacheMaxSizeMb'),
+    cacheDir,
+    allowOther: dockerFusePatternBoolean(pattern, 'allowOther', true),
+    logType: dockerFusePatternString(pattern, 'logType', 'syslog'),
+    logLevel: dockerFusePatternString(pattern, 'logLevel', 'log_debug'),
+    entryCacheTimeoutSec: dockerFusePatternNumber(
+      pattern,
+      'entryCacheTimeoutSec',
+    ),
+    negativeEntryCacheTimeoutSec: dockerFusePatternNumber(
+      pattern,
+      'negativeEntryCacheTimeoutSec',
+    ),
+    attrCacheTimeoutSec: dockerFusePatternNumber(
+      pattern,
+      'attrCacheTimeoutSec',
+    ),
+    identityClientId: entry.identityClientId,
+    accountKey: entry.accountKey,
+  });
+  const mountArgs = [
+    'blobfuse2',
+    'mount',
+    ...((entry.readOnly ?? true) ? ['--read-only'] : []),
+    '--config-file',
+    configPath,
+    mountPath,
+  ];
+  await session.runDockerMountCommand(
+    [
+      'command -v blobfuse2 >/dev/null 2>&1',
+      `mkdir -p -- ${shellQuote(mountPath)} ${shellQuote(cacheDir)}`,
+      `rm -rf -- ${shellQuote(configDir)}`,
+      `trap ${shellQuote(`rm -rf -- ${shellQuote(configDir)}`)} EXIT`,
+      `install -d -m 700 -- ${shellQuote(configDir)}`,
+      `(umask 077 && cat > ${shellQuote(configPath)})`,
+      dockerEnableFuseAllowOtherCommand(),
+      shellCommand(mountArgs),
+      `rm -rf -- ${shellQuote(configDir)}`,
+    ].join(' && '),
+    `mount blobfuse ${entry.type}`,
+    { input: configText },
+  );
+}
+
+function resolveDockerBlobfuseCacheDir(
+  workspaceRoot: string,
+  pattern: FuseMountPattern,
+  containerId: string,
+  account: string,
+  container: string,
+): string {
+  const configuredCachePath = dockerFusePatternString(pattern, 'cachePath');
+  if (configuredCachePath) {
+    return joinSandboxLogicalPath(
+      workspaceRoot,
+      normalizeDockerBlobfuseCachePath(configuredCachePath),
+    );
+  }
+  return joinSandboxLogicalPath(
+    workspaceRoot,
+    [
+      '.sandbox-blobfuse-cache',
+      dockerPathHash(containerId),
+      sanitizeDockerMountName(account),
+      sanitizeDockerMountName(container),
+    ].join('/'),
+  );
+}
+
+function dockerBlobfuseWorkspaceCachePath(
+  pattern: FuseMountPattern,
+): string | undefined {
+  const configuredCachePath = dockerFusePatternString(pattern, 'cachePath');
+  return configuredCachePath
+    ? normalizeDockerBlobfuseCachePath(configuredCachePath)
+    : undefined;
+}
+
+function normalizeDockerBlobfuseCachePath(cachePath: string): string {
+  const normalized = cachePath.replace(/\\/gu, '/');
+  const parts = normalized.split('/').filter((part) => part.length > 0);
+  if (
+    normalized.startsWith('/') ||
+    /^[A-Za-z]:\//u.test(normalized) ||
+    normalized === '.' ||
+    parts.includes('..')
+  ) {
+    throw new SandboxMountError(
+      'blobfuse cachePath must be relative to the workspace root.',
+      { cachePath },
+      'mount_config_invalid',
+    );
+  }
+  return normalized.replace(/^\.\/+/u, '');
+}
+
+function dockerBlobfuseConfigText(args: {
+  account: string;
+  container: string;
+  endpoint: string;
+  cacheType: 'block_cache' | 'file_cache';
+  cacheSizeMb: number;
+  blockCacheBlockSizeMb: number;
+  blockCacheDiskTimeoutSec: number;
+  fileCacheTimeoutSec: number;
+  fileCacheMaxSizeMb?: number;
+  cacheDir: string;
+  allowOther: boolean;
+  logType: string;
+  logLevel: string;
+  entryCacheTimeoutSec?: number;
+  negativeEntryCacheTimeoutSec?: number;
+  attrCacheTimeoutSec?: number;
+  identityClientId?: string;
+  accountKey?: string;
+}): string {
+  const lines: string[] = [];
+  if (args.allowOther) {
+    lines.push('allow-other: true', '');
+  }
+  lines.push(
+    'logging:',
+    `  type: ${args.logType}`,
+    `  level: ${args.logLevel}`,
+    '',
+    'components:',
+    '  - libfuse',
+    `  - ${args.cacheType}`,
+    '  - attr_cache',
+    '  - azstorage',
+    '',
+  );
+
+  const libfuseLines: string[] = [];
+  if (args.entryCacheTimeoutSec !== undefined) {
+    libfuseLines.push(`  entry-expiration-sec: ${args.entryCacheTimeoutSec}`);
+  }
+  if (args.negativeEntryCacheTimeoutSec !== undefined) {
+    libfuseLines.push(
+      `  negative-entry-expiration-sec: ${args.negativeEntryCacheTimeoutSec}`,
+    );
+  }
+  if (libfuseLines.length > 0) {
+    lines.push('libfuse:', ...libfuseLines, '');
+  }
+
+  if (args.cacheType === 'block_cache') {
+    lines.push(
+      'block_cache:',
+      `  block-size-mb: ${args.blockCacheBlockSizeMb}`,
+      `  mem-size-mb: ${args.cacheSizeMb}`,
+      `  path: ${args.cacheDir}`,
+      `  disk-size-mb: ${args.cacheSizeMb}`,
+      `  disk-timeout-sec: ${args.blockCacheDiskTimeoutSec}`,
+      '',
+    );
+  } else {
+    lines.push(
+      'file_cache:',
+      `  path: ${args.cacheDir}`,
+      `  timeout-sec: ${args.fileCacheTimeoutSec}`,
+      `  max-size-mb: ${args.fileCacheMaxSizeMb ?? args.cacheSizeMb}`,
+      '',
+    );
+  }
+
+  lines.push(
+    'attr_cache:',
+    `  timeout-sec: ${args.attrCacheTimeoutSec ?? 7200}`,
+    '',
+    'azstorage:',
+    '  type: block',
+    `  account-name: ${args.account}`,
+    `  container: ${args.container}`,
+    `  endpoint: ${args.endpoint}`,
+  );
+  if (args.accountKey) {
+    lines.push('  auth-type: key', `  account-key: ${args.accountKey}`);
+  } else {
+    lines.push('  mode: msi');
+  }
+  if (args.identityClientId) {
+    lines.push(`  identity-client-id: ${args.identityClientId}`);
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+function dockerFusePatternString(
+  pattern: FuseMountPattern,
+  key: string,
+  fallback?: string,
+): string {
+  const value = pattern[key];
+  return typeof value === 'string' ? value : (fallback ?? '');
+}
+
+function dockerFusePatternNumber(
+  pattern: FuseMountPattern,
+  key: string,
+  fallback?: number,
+): number | undefined {
+  const value = pattern[key];
+  return typeof value === 'number' ? value : fallback;
+}
+
+function dockerFusePatternBoolean(
+  pattern: FuseMountPattern,
+  key: string,
+  fallback: boolean,
+): boolean {
+  const value = pattern[key];
+  return typeof value === 'boolean' ? value : fallback;
 }
 
 function dockerMountArgsForManifest(
@@ -1311,6 +2309,504 @@ function dockerVolumeDriverConfig(
   }
 }
 
+const dockerRcloneMountTypes = new Set<string>([
+  's3_mount',
+  'r2_mount',
+  'gcs_mount',
+  'azure_blob_mount',
+  'box_mount',
+]);
+
+type DockerRcloneMountConfig = {
+  remoteName: string;
+  remotePath: string;
+  configText: string;
+  readOnly: boolean;
+};
+
+async function dockerRcloneMountConfig(
+  session: DockerSandboxSession,
+  entry: Mount | TypedMount,
+  pattern: RcloneMountPattern,
+  mountPath: string,
+): Promise<DockerRcloneMountConfig> {
+  const remoteName = dockerRcloneRemoteName(entry, pattern, mountPath);
+  const withConfigText = async (
+    config: DockerRcloneMountConfig,
+  ): Promise<DockerRcloneMountConfig> => {
+    const configFilePath = rclonePatternString(pattern, 'configFilePath');
+    if (!configFilePath) {
+      return config;
+    }
+    const sourcePath = resolveDockerRcloneConfigPath(
+      session.state.manifest,
+      configFilePath,
+    );
+    const encodedConfig = await session.runDockerMountCommand(
+      `base64 -- ${shellQuote(sourcePath)}`,
+      `read rclone config ${sourcePath}`,
+    );
+    const sourceConfigText = Buffer.from(
+      encodedConfig.replace(/\s+/gu, ''),
+      'base64',
+    ).toString('utf8');
+    return {
+      ...config,
+      configText: supplementDockerRcloneConfigText(
+        sourceConfigText,
+        remoteName,
+        config.configText,
+        entry.type,
+      ),
+    };
+  };
+  switch (entry.type) {
+    case 's3_mount':
+      return await withConfigText({
+        remoteName,
+        remotePath: joinRemotePath(entry.bucket, entry.prefix),
+        configText: [
+          `[${remoteName}]`,
+          'type = s3',
+          `provider = ${entry.s3Provider ?? 'AWS'}`,
+          ...(entry.endpointUrl ? [`endpoint = ${entry.endpointUrl}`] : []),
+          ...(entry.region ? [`region = ${entry.region}`] : []),
+          ...s3CredentialLines(entry),
+          '',
+        ].join('\n'),
+        readOnly: entry.readOnly ?? true,
+      });
+    case 'r2_mount':
+      validateCredentialPair(
+        'R2',
+        entry.type,
+        entry.accessKeyId,
+        entry.secretAccessKey,
+      );
+      if (!entry.accountId) {
+        throw new SandboxMountError(
+          'R2 mounts require accountId.',
+          { mountType: entry.type },
+          'mount_config_invalid',
+        );
+      }
+      return await withConfigText({
+        remoteName,
+        remotePath: joinRemotePath(entry.bucket, entry.prefix),
+        configText: [
+          `[${remoteName}]`,
+          'type = s3',
+          'provider = Cloudflare',
+          `endpoint = ${entry.customDomain ?? `https://${entry.accountId}.r2.cloudflarestorage.com`}`,
+          'acl = private',
+          ...(entry.accessKeyId && entry.secretAccessKey
+            ? [
+                'env_auth = false',
+                `access_key_id = ${entry.accessKeyId}`,
+                `secret_access_key = ${entry.secretAccessKey}`,
+              ]
+            : ['env_auth = true']),
+          '',
+        ].join('\n'),
+        readOnly: entry.readOnly ?? true,
+      });
+    case 'gcs_mount':
+      return await withConfigText(
+        dockerGcsRcloneMountConfig(entry, remoteName),
+      );
+    case 'azure_blob_mount':
+      return await withConfigText(
+        dockerAzureBlobRcloneMountConfig(entry, remoteName),
+      );
+    case 'box_mount':
+      return await withConfigText({
+        remoteName,
+        remotePath: normalizeBoxRemotePath(entry.path),
+        configText: [
+          `[${remoteName}]`,
+          'type = box',
+          ...(entry.clientId ? [`client_id = ${entry.clientId}`] : []),
+          ...(entry.clientSecret
+            ? [`client_secret = ${entry.clientSecret}`]
+            : []),
+          ...(entry.accessToken ? [`access_token = ${entry.accessToken}`] : []),
+          ...(entry.token ? [`token = ${entry.token}`] : []),
+          ...(entry.boxConfigFile
+            ? [`box_config_file = ${entry.boxConfigFile}`]
+            : []),
+          ...(entry.configCredentials
+            ? [`config_credentials = ${entry.configCredentials}`]
+            : []),
+          ...(entry.boxSubType && entry.boxSubType !== 'user'
+            ? [`box_sub_type = ${entry.boxSubType}`]
+            : []),
+          ...(entry.rootFolderId
+            ? [`root_folder_id = ${entry.rootFolderId}`]
+            : []),
+          ...(entry.impersonate ? [`impersonate = ${entry.impersonate}`] : []),
+          ...(entry.ownedBy ? [`owned_by = ${entry.ownedBy}`] : []),
+          '',
+        ].join('\n'),
+        readOnly: entry.readOnly ?? true,
+      });
+    default:
+      throw new SandboxUnsupportedFeatureError(
+        'DockerSandboxClient rclone mounts do not support this mount entry.',
+        {
+          provider: 'DockerSandboxClient',
+          mountType: (entry as Entry).type,
+        },
+      );
+  }
+}
+
+function dockerAzureBlobRcloneMountConfig(
+  entry: AzureBlobMount,
+  remoteName: string,
+): DockerRcloneMountConfig {
+  const account = entry.account ?? entry.accountName;
+  if (!account) {
+    throw new SandboxMountError(
+      'Azure Blob mounts require account or accountName.',
+      { mountType: entry.type },
+      'mount_config_invalid',
+    );
+  }
+  return {
+    remoteName,
+    remotePath: joinRemotePath(entry.container, entry.prefix),
+    configText: [
+      `[${remoteName}]`,
+      'type = azureblob',
+      `account = ${account}`,
+      ...(azureBlobEndpoint(entry)
+        ? [`endpoint = ${azureBlobEndpoint(entry)}`]
+        : []),
+      ...(entry.accountKey
+        ? [`key = ${entry.accountKey}`]
+        : [
+            'use_msi = true',
+            ...(entry.identityClientId
+              ? [`msi_client_id = ${entry.identityClientId}`]
+              : []),
+          ]),
+      '',
+    ].join('\n'),
+    readOnly: entry.readOnly ?? true,
+  };
+}
+
+function azureBlobEndpoint(entry: AzureBlobMount): string | undefined {
+  return entry.endpointUrl ?? entry.endpoint;
+}
+
+function dockerGcsRcloneMountConfig(
+  entry: GCSMount,
+  remoteName: string,
+): DockerRcloneMountConfig {
+  const accessId = readOptionalString(entry, 'accessId');
+  const secretAccessKey = readOptionalString(entry, 'secretAccessKey');
+  if (accessId && secretAccessKey) {
+    return {
+      remoteName,
+      remotePath: joinRemotePath(entry.bucket, entry.prefix),
+      configText: [
+        `[${remoteName}]`,
+        'type = s3',
+        'provider = GCS',
+        'env_auth = false',
+        `access_key_id = ${accessId}`,
+        `secret_access_key = ${secretAccessKey}`,
+        `endpoint = ${entry.endpointUrl ?? 'https://storage.googleapis.com'}`,
+        ...(entry.region ? [`region = ${entry.region}`] : []),
+        '',
+      ].join('\n'),
+      readOnly: entry.readOnly ?? true,
+    };
+  }
+  return {
+    remoteName,
+    remotePath: joinRemotePath(entry.bucket, entry.prefix),
+    configText: [
+      `[${remoteName}]`,
+      'type = google cloud storage',
+      ...(entry.serviceAccountFile
+        ? [`service_account_file = ${entry.serviceAccountFile}`]
+        : []),
+      ...(entry.serviceAccountCredentials
+        ? [`service_account_credentials = ${entry.serviceAccountCredentials}`]
+        : []),
+      ...(entry.accessToken ? [`access_token = ${entry.accessToken}`] : []),
+      entry.serviceAccountFile ||
+      entry.serviceAccountCredentials ||
+      entry.accessToken
+        ? 'env_auth = false'
+        : 'env_auth = true',
+      '',
+    ].join('\n'),
+    readOnly: entry.readOnly ?? true,
+  };
+}
+
+function dockerInContainerMountPrivilegeArgs(manifest: Manifest): string[] {
+  const privilege = dockerInContainerMountPrivilege(manifest);
+  if (privilege === 'fuse') {
+    return [
+      '--device',
+      '/dev/fuse',
+      '--cap-add',
+      'SYS_ADMIN',
+      '--security-opt',
+      'apparmor:unconfined',
+    ];
+  }
+  if (privilege === 'sys_admin') {
+    return ['--cap-add', 'SYS_ADMIN', '--security-opt', 'apparmor:unconfined'];
+  }
+  return [];
+}
+
+function dockerInContainerMountPrivilege(
+  manifest: Manifest,
+): 'none' | 'fuse' | 'sys_admin' {
+  let needsSysAdmin = false;
+  for (const { entry } of manifest.mountTargetsForMaterialization()) {
+    if (!isDockerInContainerMount(entry)) {
+      continue;
+    }
+    const pattern = dockerInContainerMountPattern(entry);
+    if (
+      pattern.type === 'fuse' ||
+      pattern.type === 'mountpoint' ||
+      (pattern.type === 'rclone' && (pattern.mode ?? 'fuse') === 'fuse')
+    ) {
+      return 'fuse';
+    }
+    if (
+      pattern.type === 's3files' ||
+      (pattern.type === 'rclone' && pattern.mode === 'nfs')
+    ) {
+      needsSysAdmin = true;
+    }
+  }
+  return needsSysAdmin ? 'sys_admin' : 'none';
+}
+
+function s3CredentialLines(entry: S3Mount): string[] {
+  const lines: string[] = [];
+  if (entry.accessKeyId && entry.secretAccessKey) {
+    lines.push('env_auth = false');
+    lines.push(`access_key_id = ${entry.accessKeyId}`);
+    lines.push(`secret_access_key = ${entry.secretAccessKey}`);
+    if (entry.sessionToken) {
+      lines.push(`session_token = ${entry.sessionToken}`);
+    }
+  } else {
+    lines.push('env_auth = true');
+  }
+  return lines;
+}
+
+function validateCredentialPair(
+  provider: string,
+  mountType: string,
+  accessKeyId?: string,
+  secretAccessKey?: string,
+): void {
+  if (Boolean(accessKeyId) !== Boolean(secretAccessKey)) {
+    throw new SandboxMountError(
+      `${provider} mounts require both accessKeyId and secretAccessKey when either is provided.`,
+      { mountType },
+      'mount_config_invalid',
+    );
+  }
+}
+
+function dockerMountpointAwsEnv(
+  accessKeyId?: string,
+  secretAccessKey?: string,
+  sessionToken?: string,
+): string {
+  if (!accessKeyId || !secretAccessKey) {
+    return '';
+  }
+  return [
+    `AWS_ACCESS_KEY_ID=${shellQuote(accessKeyId)}`,
+    `AWS_SECRET_ACCESS_KEY=${shellQuote(secretAccessKey)}`,
+    ...(sessionToken ? [`AWS_SESSION_TOKEN=${shellQuote(sessionToken)}`] : []),
+    '',
+  ].join('\n');
+}
+
+function splitDockerNfsAddr(value: string): [string, string] {
+  const index = value.lastIndexOf(':');
+  if (index < 0) {
+    return [
+      value === '0.0.0.0' || value === '::' ? '127.0.0.1' : value,
+      '2049',
+    ];
+  }
+  const host = value.slice(0, index);
+  return [
+    host === '0.0.0.0' || host === '::' ? '127.0.0.1' : host,
+    value.slice(index + 1),
+  ];
+}
+
+function dockerMountpointPatternOptions(pattern: MountpointMountPattern): {
+  prefix?: string;
+  region?: string;
+  endpointUrl?: string;
+} {
+  const options = readRecord(pattern.options);
+  return {
+    prefix: readOptionalString(options, 'prefix'),
+    region: readOptionalString(options, 'region'),
+    endpointUrl: readOptionalString(options, 'endpointUrl'),
+  };
+}
+
+function dockerS3FilesPatternOptions(pattern: S3FilesMountPattern): {
+  mountTargetIp?: string;
+  accessPoint?: string;
+  region?: string;
+  extraOptions?: Record<string, string | null>;
+} {
+  const options = readRecord(pattern.options);
+  return {
+    mountTargetIp: readOptionalString(options, 'mountTargetIp'),
+    accessPoint: readOptionalString(options, 'accessPoint'),
+    region: readOptionalString(options, 'region'),
+    extraOptions: readStringNullRecord(options.extraOptions),
+  };
+}
+
+function dockerRcloneRemoteName(
+  entry: Mount | TypedMount,
+  pattern: RcloneMountPattern,
+  mountPath: string,
+): string {
+  const remoteName =
+    rclonePatternString(pattern, 'remoteName') ??
+    rclonePatternString(pattern, 'remote');
+  if (!remoteName) {
+    return `sandbox_${sanitizeDockerMountName(entry.type)}_${dockerPathHash(mountPath)}`;
+  }
+  if (!/^[A-Za-z0-9_-]+$/u.test(remoteName)) {
+    throw new SandboxMountError(
+      'DockerSandboxClient rclone mounts require remoteName to contain only letters, numbers, underscores, and hyphens.',
+      {
+        mountType: entry.type,
+        remoteName,
+      },
+      'mount_config_invalid',
+    );
+  }
+  return remoteName;
+}
+
+function resolveDockerRcloneConfigPath(
+  manifest: Manifest,
+  configFilePath: string,
+): string {
+  return new WorkspacePathPolicy({
+    root: manifest.root,
+    extraPathGrants: manifest.extraPathGrants,
+  }).resolve(configFilePath).path;
+}
+
+function supplementDockerRcloneConfigText(
+  configText: string,
+  remoteName: string,
+  requiredConfigText: string,
+  mountType: string,
+): string {
+  const escapedRemote = remoteName.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+  const sectionPattern = new RegExp(`^\\s*\\[${escapedRemote}\\]\\s*$`, 'mu');
+  const match = sectionPattern.exec(configText);
+  if (!match) {
+    throw new SandboxMountError(
+      'DockerSandboxClient rclone config file is missing the required remote section.',
+      {
+        mountType,
+        remoteName,
+      },
+      'mount_config_invalid',
+    );
+  }
+  const sectionStart = match.index;
+  const sectionEnd = match.index + match[0].length;
+  const nextSection = /^\s*\[.+\]\s*$/mu.exec(configText.slice(sectionEnd));
+  const sectionBodyEnd = nextSection
+    ? sectionEnd + nextSection.index
+    : configText.length;
+  const before = configText.slice(0, sectionStart);
+  const sectionBody = configText.slice(sectionStart, sectionBodyEnd).trimEnd();
+  const after = configText.slice(sectionBodyEnd);
+  const requiredLines = requiredConfigText.trimEnd().split('\n').slice(1);
+  const supplement =
+    requiredLines.length > 0 ? `\n${requiredLines.join('\n')}` : '';
+  return `${before}${sectionBody}${supplement}\n${after}`;
+}
+
+function dockerRclonePatternArgs(pattern: RcloneMountPattern): string[] {
+  return [
+    ...(rclonePatternStringArray(pattern, 'args') ?? []),
+    ...(rclonePatternStringArray(pattern, 'extraArgs') ?? []),
+  ];
+}
+
+function rclonePatternString(
+  pattern: RcloneMountPattern,
+  key: string,
+): string | undefined {
+  return readOptionalString(pattern, key);
+}
+
+function rclonePatternStringArray(
+  pattern: RcloneMountPattern,
+  key: string,
+): string[] | undefined {
+  const value = readStringArray(pattern[key]);
+  return value.length > 0 ? value : undefined;
+}
+
+function readRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function readStringNullRecord(value: unknown): Record<string, string | null> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, string | null] =>
+        typeof entry[1] === 'string' || entry[1] === null,
+    ),
+  );
+}
+
+function dockerMountOptions(options: Record<string, string | null>): string {
+  return Object.entries(options)
+    .map(([key, value]) => (value === null ? key : `${key}=${value}`))
+    .join(',');
+}
+
+function shellCommand(parts: string[]): string {
+  return parts.map((part) => shellQuote(part)).join(' ');
+}
+
+function sanitizeDockerMountName(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]/gu, '_');
+}
+
+function dockerPathHash(path: string): string {
+  return createHash('sha256').update(path).digest('hex').slice(0, 12);
+}
+
 function dockerPosixDirname(path: string): string {
   const index = path.lastIndexOf('/');
   if (index <= 0) {
@@ -1410,7 +2906,7 @@ async function removeDockerVolumes(volumeNames: string[]): Promise<void> {
 function dockerRcloneS3Options(entry: S3Mount): Record<string, string> {
   return withDefinedStringValues({
     type: 's3',
-    's3-provider': 'AWS',
+    's3-provider': entry.s3Provider ?? 'AWS',
     path: joinRemotePath(entry.bucket, entry.prefix),
     's3-access-key-id': entry.accessKeyId,
     's3-secret-access-key': entry.secretAccessKey,
@@ -1465,15 +2961,26 @@ function dockerMountpointGcsOptions(entry: GCSMount): Record<string, string> {
 }
 
 function dockerRcloneR2Options(entry: R2Mount): Record<string, string> {
+  validateCredentialPair(
+    'R2',
+    entry.type,
+    entry.accessKeyId,
+    entry.secretAccessKey,
+  );
+  if (!entry.accountId) {
+    throw new SandboxMountError(
+      'R2 Docker volume mounts require accountId.',
+      { mountType: entry.type },
+      'mount_config_invalid',
+    );
+  }
   return withDefinedStringValues({
     type: 's3',
     path: joinRemotePath(entry.bucket, entry.prefix),
     's3-provider': 'Cloudflare',
     's3-endpoint':
       entry.customDomain ??
-      (entry.accountId
-        ? `https://${entry.accountId}.r2.cloudflarestorage.com`
-        : undefined),
+      `https://${entry.accountId}.r2.cloudflarestorage.com`,
     's3-access-key-id': entry.accessKeyId,
     's3-secret-access-key': entry.secretAccessKey,
   });
@@ -1486,7 +2993,7 @@ function dockerRcloneAzureBlobOptions(
     type: 'azureblob',
     path: joinRemotePath(entry.container, entry.prefix),
     'azureblob-account': entry.account ?? entry.accountName,
-    'azureblob-endpoint': entry.endpointUrl,
+    'azureblob-endpoint': azureBlobEndpoint(entry),
     'azureblob-msi-client-id': entry.identityClientId,
     'azureblob-key': entry.accountKey,
   });

--- a/packages/agents-core/src/sandbox/sandboxes/shared/localSnapshots.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/localSnapshots.ts
@@ -52,6 +52,7 @@ export type LocalSnapshotFingerprint = {
 type LocalSnapshotState = {
   workspaceRootPath: string;
   manifest: Manifest;
+  snapshotExcludedPaths?: Iterable<string>;
   snapshotSpec?: SnapshotSpec | null;
   snapshot?: LocalSandboxSnapshot | null;
   snapshotFingerprint?: string | null;
@@ -66,7 +67,7 @@ export async function createLocalSnapshot(
   await copyDirectory(
     state.workspaceRootPath,
     snapshotPath,
-    state.manifest.ephemeralPersistencePaths(),
+    localSnapshotExcludedPaths(state),
   );
   return {
     id: randomUUID(),
@@ -81,7 +82,7 @@ export async function createRemoteSnapshot(
 ): Promise<RemoteSnapshot> {
   const data = await createWorkspaceArchive(
     state.workspaceRootPath,
-    state.manifest.ephemeralPersistencePaths(),
+    localSnapshotExcludedPaths(state),
   );
   const saved = await spec.store.save({
     id: spec.id,
@@ -285,12 +286,20 @@ export async function computeLocalSnapshotFingerprint(
   await hashDirectory(
     hash,
     state.workspaceRootPath,
-    state.manifest.ephemeralPersistencePaths(),
+    localSnapshotExcludedPaths(state),
   );
   return {
     fingerprint: hash.digest('hex'),
     version: LOCAL_SNAPSHOT_FINGERPRINT_VERSION,
   };
+}
+
+function localSnapshotExcludedPaths(state: LocalSnapshotState): Set<string> {
+  const paths = state.manifest.ephemeralPersistencePaths();
+  for (const path of state.snapshotExcludedPaths ?? []) {
+    paths.add(path);
+  }
+  return paths;
 }
 
 export async function copyDirectory(

--- a/packages/agents-core/test/sandboxEntries.test.ts
+++ b/packages/agents-core/test/sandboxEntries.test.ts
@@ -143,9 +143,9 @@ describe('sandbox entry helpers', () => {
       boxSubType: 'enterprise',
     });
     expectTypeOf(boxMount()).toMatchTypeOf<BoxMount>();
-    expect(s3FilesMount({ bucket: 'bucket' })).toMatchObject({
+    expect(s3FilesMount({ fileSystemId: 'fs-123' })).toMatchObject({
       type: 's3_files_mount',
-      bucket: 'bucket',
+      fileSystemId: 'fs-123',
     });
     expect(inContainerMountStrategy()).toEqual({ type: 'in_container' });
     expect(

--- a/packages/agents-core/test/sandboxManifest.test.ts
+++ b/packages/agents-core/test/sandboxManifest.test.ts
@@ -17,6 +17,7 @@ import {
   type ManifestEntries,
   type Mount,
   type R2Mount,
+  type S3FilesMount,
   type S3Mount,
 } from '../src/sandbox';
 
@@ -338,6 +339,17 @@ describe('Manifest', () => {
           ownedBy: 'owner@example.com',
           accessToken: 'secret-token',
         },
+        s3files: {
+          type: 's3_files_mount',
+          fileSystemId: 'fs-123',
+          subpath: '/reports',
+          mountTargetIp: '10.0.0.5',
+          accessPoint: 'ap-123',
+          region: 'us-east-1',
+          extraOptions: {
+            allow_other: null,
+          },
+        },
       },
     });
     const data = manifest.entries.data as S3Mount;
@@ -384,6 +396,16 @@ describe('Manifest', () => {
     expect((manifest.entries.box as BoxMount).config).not.toHaveProperty(
       'accessToken',
     );
+    expect((manifest.entries.s3files as S3FilesMount).config).toMatchObject({
+      fileSystemId: 'fs-123',
+      subpath: '/reports',
+      mountTargetIp: '10.0.0.5',
+      accessPoint: 'ap-123',
+      region: 'us-east-1',
+      extraOptions: {
+        allow_other: null,
+      },
+    });
   });
 
   it('clones manifests without sharing entries or environment values', () => {
@@ -568,6 +590,70 @@ describe('Manifest', () => {
           },
         }),
     ).toThrow('snake_case key "driver_options" is not supported');
+
+    expect(
+      () =>
+        new Manifest({
+          entries: {
+            data: {
+              type: 'mount',
+              mountStrategy: {
+                type: 'in_container',
+                pattern: {
+                  type: 'rclone',
+                  remote_name: 'custom',
+                },
+              },
+            } as any,
+          },
+        }),
+    ).toThrow('snake_case key "remote_name" is not supported');
+
+    expect(
+      () =>
+        new Manifest({
+          entries: {
+            data: {
+              type: 's3_mount',
+              bucket: 'bucket',
+              mountStrategy: {
+                type: 'in_container',
+                pattern: {
+                  type: 'mountpoint',
+                  options: {
+                    endpoint_url: 'https://s3.example.test',
+                  },
+                },
+              },
+            } as any,
+          },
+        }),
+    ).toThrow('snake_case key "endpoint_url" is not supported');
+
+    expect(
+      () =>
+        new Manifest({
+          entries: {
+            data: {
+              type: 's3_files_mount',
+              file_system_id: 'fs-123',
+            } as any,
+          },
+        }),
+    ).toThrow('snake_case key "file_system_id" is not supported');
+
+    expect(
+      () =>
+        new Manifest({
+          entries: {
+            data: {
+              type: 's3_mount',
+              bucket: 'bucket',
+              s3_provider: 'Minio',
+            } as any,
+          },
+        }),
+    ).toThrow('snake_case key "s3_provider" is not supported');
 
     expect(
       () =>

--- a/packages/agents-core/test/sandboxes/docker.test.ts
+++ b/packages/agents-core/test/sandboxes/docker.test.ts
@@ -3,7 +3,11 @@ import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { afterEach, beforeAll, describe, expect, it } from 'vitest';
-import { DockerSandboxClient, Manifest } from '../../src/sandbox/local';
+import {
+  DockerSandboxClient,
+  inContainerMountStrategy,
+  Manifest,
+} from '../../src/sandbox/local';
 
 const ONE_BY_ONE_PNG = Uint8Array.from(
   Buffer.from(
@@ -103,6 +107,66 @@ describe('DockerSandboxClient', () => {
       expect(envOutput).toContain('updated:present');
       expect(ttyOutput).toContain('tty yes');
       expect(ttyOutput).not.toContain('tty no');
+    },
+    DOCKER_TEST_TIMEOUT_MS,
+  );
+
+  itIfDocker(
+    'applies in-container command mounts inside Docker',
+    async () => {
+      rootDir = await mkdtemp(
+        join(tmpdir(), 'agents-core-docker-sandbox-test-'),
+      );
+      const client = new DockerSandboxClient({
+        workspaceBaseDir: rootDir,
+        image: DOCKER_TEST_IMAGE,
+      });
+      const session = await client.create(
+        new Manifest({
+          entries: {
+            mounted: {
+              type: 'mount',
+              source: 'memory://initial',
+              mountStrategy: inContainerMountStrategy({
+                pattern: {
+                  type: 'fuse',
+                  command:
+                    'printf initial > "$OPENAI_AGENTS_MOUNT_PATH/marker.txt"',
+                },
+              }),
+            },
+          },
+        }),
+      );
+      cleanupContainerIds.add(session.state.containerId);
+
+      const initialOutput = await session.execCommand({
+        cmd: 'cat mounted/marker.txt',
+      });
+      expect(initialOutput).toContain('initial');
+
+      await session.applyManifest(
+        new Manifest({
+          entries: {
+            applied: {
+              type: 'mount',
+              source: 'memory://applied',
+              mountStrategy: inContainerMountStrategy({
+                pattern: {
+                  type: 'fuse',
+                  command:
+                    'printf applied > "$OPENAI_AGENTS_MOUNT_PATH/marker.txt"',
+                },
+              }),
+            },
+          },
+        }),
+      );
+
+      const appliedOutput = await session.execCommand({
+        cmd: 'cat applied/marker.txt',
+      });
+      expect(appliedOutput).toContain('applied');
     },
     DOCKER_TEST_TIMEOUT_MS,
   );

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -1,6 +1,8 @@
 import {
   lstat,
+  mkdir,
   mkdtemp,
+  readdir,
   readFile,
   rm,
   stat,
@@ -14,6 +16,7 @@ import { PassThrough } from 'node:stream';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SandboxProcessResult } from '../../src/sandbox/sandboxes/shared/runProcess';
 
+const dockerStdinWrites: Array<string | Uint8Array> = [];
 const processMocks = vi.hoisted(() => ({
   runSandboxProcess: vi.fn(),
 }));
@@ -37,6 +40,7 @@ vi.mock('node:child_process', async (importOriginal) => {
 import {
   dockerVolumeMountStrategy,
   DockerSandboxClient,
+  inContainerMountStrategy,
   Manifest,
   NoopSnapshotSpec,
 } from '../../src/sandbox/local';
@@ -70,7 +74,9 @@ function dockerSpawnResult(args: {
   child.stdout = new PassThrough();
   child.stderr = new PassThrough();
   child.stdin = {
-    write: vi.fn(),
+    write: vi.fn((chunk: string | Uint8Array) => {
+      dockerStdinWrites.push(chunk);
+    }),
     end: vi.fn(),
   };
   queueMicrotask(() => {
@@ -92,6 +98,7 @@ describe('DockerSandboxClient unit behavior', () => {
 
   beforeEach(async () => {
     rootDir = await mkdtemp(join(tmpdir(), 'agents-core-docker-unit-test-'));
+    dockerStdinWrites.length = 0;
     processMocks.runSandboxProcess.mockReset();
     childProcessMocks.spawn.mockReset();
   });
@@ -390,6 +397,963 @@ describe('DockerSandboxClient unit behavior', () => {
       ['volume', 'rm', '-f', expect.stringContaining('logs')],
       { timeoutMs: 10_000 },
     );
+  });
+
+  it('starts Docker with fuse privileges and applies in-container command mounts', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
+      expect(args).toEqual(
+        expect.arrayContaining(['exec', '-i', '-w', '/', '-u', 'root']),
+      );
+      expect(args.join(' ')).toContain('OPENAI_AGENTS_MOUNT_PATH=');
+      expect(args.join(' ')).toContain('OPENAI_AGENTS_MOUNT_SOURCE=');
+      return dockerSpawnResult({ status: 0 });
+    });
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+
+    await client.create(
+      new Manifest({
+        entries: {
+          mounted: {
+            type: 'mount',
+            source: 'memory://fixture',
+            mountStrategy: inContainerMountStrategy({
+              pattern: {
+                type: 'fuse',
+                command:
+                  'printf mounted > "$OPENAI_AGENTS_MOUNT_PATH/marker.txt"',
+              },
+            }),
+          },
+        },
+      }),
+    );
+
+    const runCall = processMocks.runSandboxProcess.mock.calls.find(
+      ([, args]) => args[0] === 'run',
+    );
+    expect(runCall?.[1]).toEqual(
+      expect.arrayContaining([
+        '--device',
+        '/dev/fuse',
+        '--cap-add',
+        'SYS_ADMIN',
+        '--security-opt',
+        'apparmor:unconfined',
+      ]),
+    );
+    expect(childProcessMocks.spawn).toHaveBeenCalledOnce();
+  });
+
+  it('routes filesystem reads in in-container mounts through Docker', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
+      const command = args.join(' ');
+      if (command.includes('test -e')) {
+        return dockerSpawnResult({ status: 0 });
+      }
+      if (command.includes('base64 --')) {
+        return dockerSpawnResult({
+          stdout: Buffer.from('container-data').toString('base64'),
+          status: 0,
+        });
+      }
+      if (command.includes('find ')) {
+        return dockerSpawnResult({
+          stdout: 'f\tfile.txt\nd\tnested\nl\tlink\n',
+          status: 0,
+        });
+      }
+      return dockerSpawnResult({ status: 0 });
+    });
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          mounted: {
+            type: 'mount',
+            source: 'memory://fixture',
+            mountStrategy: inContainerMountStrategy({
+              pattern: {
+                type: 'fuse',
+                command: 'true',
+              },
+            }),
+          },
+        },
+      }),
+    );
+
+    await expect(session.pathExists('mounted/file.txt')).resolves.toBe(true);
+    await expect(
+      session.readFile({ path: 'mounted/file.txt' }),
+    ).resolves.toEqual(Buffer.from('container-data'));
+    await expect(session.listDir({ path: 'mounted' })).resolves.toEqual([
+      { name: 'file.txt', path: 'mounted/file.txt', type: 'file' },
+      { name: 'nested', path: 'mounted/nested', type: 'dir' },
+      { name: 'link', path: 'mounted/link', type: 'other' },
+    ]);
+    await expect(
+      session.createEditor().createFile({
+        type: 'create_file',
+        path: 'mounted/host-only.txt',
+        diff: '+hidden\n',
+      }),
+    ).rejects.toThrow(/in-container mount path/);
+
+    const filesystemCommands = childProcessMocks.spawn.mock.calls
+      .map(([, args]) => (args as string[]).join(' '))
+      .filter(
+        (command) =>
+          command.includes('test -e') ||
+          command.includes('base64 --') ||
+          command.includes('find '),
+      );
+    expect(filesystemCommands).toHaveLength(3);
+    for (const command of filesystemCommands) {
+      expect(command).toContain('exec -i');
+      expect(command).toContain('container-123');
+    }
+
+    await session.close();
+  });
+
+  it('removes the container and workspace when in-container mount application fails during create', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation(() =>
+      dockerSpawnResult({ stderr: 'mount failed', status: 1 }),
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+
+    await expect(
+      client.create(
+        new Manifest({
+          entries: {
+            mounted: {
+              type: 'mount',
+              source: 'memory://fixture',
+              mountStrategy: inContainerMountStrategy({
+                pattern: {
+                  type: 'fuse',
+                  command: 'false',
+                },
+              }),
+            },
+          },
+        }),
+      ),
+    ).rejects.toThrow(/mount failed/);
+
+    expect(processMocks.runSandboxProcess).toHaveBeenCalledWith(
+      'docker',
+      ['rm', '-f', 'container-123'],
+      { timeoutMs: 30_000 },
+    );
+    expect(
+      (await readdir(rootDir)).filter((name) =>
+        name.startsWith('openai-agents-docker-sandbox-'),
+      ),
+    ).toEqual([]);
+  });
+
+  it('applies Azure Blob blobfuse options for Docker in-container mounts', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
+      const command = args.join(' ');
+      expect(command).toContain('blobfuse2');
+      expect(command).toContain('--read-only');
+      expect(command).toContain('trap');
+      expect(command).toContain('rm -rf');
+      expect(command).not.toContain('account-key');
+      return dockerSpawnResult({ status: 0 });
+    });
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+
+    await client.create(
+      new Manifest({
+        entries: {
+          azure: {
+            type: 'azure_blob_mount',
+            account: 'account-name',
+            container: 'container-name',
+            endpointUrl: 'https://blob.example.test',
+            accountKey: 'account-key',
+            mountStrategy: inContainerMountStrategy({
+              pattern: {
+                type: 'fuse',
+                cacheType: 'file_cache',
+                cachePath: 'cache/blobfuse',
+                cacheSizeMb: 123,
+                fileCacheTimeoutSec: 77,
+                attrCacheTimeoutSec: 42,
+                entryCacheTimeoutSec: 9,
+                negativeEntryCacheTimeoutSec: 3,
+                logLevel: 'log_warning',
+              },
+            }),
+          },
+        },
+      }),
+    );
+
+    const configInput = dockerStdinWrites.join('\n');
+    expect(configInput).toContain('allow-other: true');
+    expect(configInput).toContain('- file_cache');
+    expect(configInput).toContain('level: log_warning');
+    expect(configInput).toContain('entry-expiration-sec: 9');
+    expect(configInput).toContain('negative-entry-expiration-sec: 3');
+    expect(configInput).toContain('timeout-sec: 42');
+    expect(configInput).toContain('path: /workspace/cache/blobfuse');
+    expect(configInput).toContain('timeout-sec: 77');
+    expect(configInput).toContain('max-size-mb: 123');
+    expect(configInput).toContain('account-name: account-name');
+    expect(configInput).toContain('container: container-name');
+    expect(configInput).toContain('endpoint: https://blob.example.test');
+    expect(configInput).toContain('auth-type: key');
+    expect(configInput).toContain('account-key: account-key');
+
+    const runCall = processMocks.runSandboxProcess.mock.calls.find(
+      ([, args]) => args[0] === 'run',
+    );
+    expect(runCall?.[1]).toEqual(
+      expect.arrayContaining([
+        '--device',
+        '/dev/fuse',
+        '--cap-add',
+        'SYS_ADMIN',
+        '--security-opt',
+        'apparmor:unconfined',
+      ]),
+    );
+    expect(childProcessMocks.spawn).toHaveBeenCalledOnce();
+  });
+
+  it('rejects blobfuse cache paths inside the mount path', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+
+    await expect(
+      client.create(
+        new Manifest({
+          entries: {
+            azure: {
+              type: 'azure_blob_mount',
+              account: 'account-name',
+              container: 'container-name',
+              mountPath: 'azure',
+              mountStrategy: inContainerMountStrategy({
+                pattern: {
+                  type: 'fuse',
+                  cachePath: 'azure/cache',
+                },
+              }),
+            },
+          },
+        }),
+      ),
+    ).rejects.toThrow(/cachePath must be outside the mount path/);
+    expect(
+      childProcessMocks.spawn.mock.calls.every(([, args]) =>
+        (args as string[]).join(' ').includes('fusermount3'),
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects blobfuse cache paths with parent segments', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+
+    await expect(
+      client.create(
+        new Manifest({
+          entries: {
+            azure: {
+              type: 'azure_blob_mount',
+              account: 'account-name',
+              container: 'container-name',
+              mountStrategy: inContainerMountStrategy({
+                pattern: {
+                  type: 'fuse',
+                  cachePath: 'cache/..',
+                },
+              }),
+            },
+          },
+        }),
+      ),
+    ).rejects.toThrow(/cachePath must be relative/);
+    expect(
+      childProcessMocks.spawn.mock.calls.every(([, args]) =>
+        (args as string[]).join(' ').includes('fusermount3'),
+      ),
+    ).toBe(true);
+  });
+
+  it('starts Docker with sysadmin privileges and applies S3 Files mounts', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
+      const command = args.join(' ');
+      expect(command).toContain('mount');
+      expect(command).toContain('s3files');
+      expect(command).toContain('fs-123:/reports');
+      expect(command).toContain('mounttargetip=10.0.0.5');
+      expect(command).toContain('accesspoint=ap-123');
+      expect(command).toContain('region=us-east-1');
+      return dockerSpawnResult({ status: 0 });
+    });
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+
+    await client.create(
+      new Manifest({
+        entries: {
+          s3files: {
+            type: 's3_files_mount',
+            fileSystemId: 'fs-123',
+            subpath: '/reports',
+            mountStrategy: inContainerMountStrategy({
+              pattern: {
+                type: 's3files',
+                options: {
+                  mountTargetIp: '10.0.0.5',
+                  accessPoint: 'ap-123',
+                  region: 'us-east-1',
+                },
+              },
+            }),
+          },
+        },
+      }),
+    );
+
+    const runCall = processMocks.runSandboxProcess.mock.calls.find(
+      ([, args]) => args[0] === 'run',
+    );
+    expect(runCall?.[1]).toEqual(
+      expect.arrayContaining([
+        '--cap-add',
+        'SYS_ADMIN',
+        '--security-opt',
+        'apparmor:unconfined',
+      ]),
+    );
+    expect(runCall?.[1]).not.toContain('/dev/fuse');
+    expect(childProcessMocks.spawn).toHaveBeenCalledOnce();
+  });
+
+  it('applies mountpoint options for Docker in-container mounts', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
+      const command = args.join(' ');
+      expect(command).toContain('mount-s3');
+      expect(command).toContain('--prefix');
+      expect(command).toContain('reports');
+      expect(command).toContain('--region');
+      expect(command).toContain('us-west-2');
+      expect(command).toContain('--endpoint-url');
+      expect(command).toContain('https://s3.example.test');
+      expect(command).not.toContain('secret-key');
+      return dockerSpawnResult({ status: 0 });
+    });
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+
+    await client.create(
+      new Manifest({
+        entries: {
+          s3: {
+            type: 's3_mount',
+            bucket: 'agent-logs',
+            accessKeyId: 'access-key',
+            secretAccessKey: 'secret-key',
+            mountStrategy: inContainerMountStrategy({
+              pattern: {
+                type: 'mountpoint',
+                options: {
+                  prefix: 'reports',
+                  region: 'us-west-2',
+                  endpointUrl: 'https://s3.example.test',
+                },
+              },
+            }),
+          },
+        },
+      }),
+    );
+
+    const runCall = processMocks.runSandboxProcess.mock.calls.find(
+      ([, args]) => args[0] === 'run',
+    );
+    expect(runCall?.[1]).toEqual(
+      expect.arrayContaining([
+        '--device',
+        '/dev/fuse',
+        '--cap-add',
+        'SYS_ADMIN',
+        '--security-opt',
+        'apparmor:unconfined',
+      ]),
+    );
+    expect(childProcessMocks.spawn).toHaveBeenCalledOnce();
+    const envInput = dockerStdinWrites.join('\n');
+    expect(envInput).toContain('AWS_ACCESS_KEY_ID');
+    expect(envInput).toContain('secret-key');
+  });
+
+  it('uses the GCS endpoint default for Docker mountpoint mounts', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
+      const command = args.join(' ');
+      expect(command).toContain('mount-s3');
+      expect(command).toContain('--endpoint-url');
+      expect(command).toContain('https://storage.googleapis.com');
+      expect(command).toContain('--upload-checksums');
+      return dockerSpawnResult({ status: 0 });
+    });
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+
+    await client.create(
+      new Manifest({
+        entries: {
+          gcs: {
+            type: 'gcs_mount',
+            bucket: 'gcs-logs',
+            mountStrategy: inContainerMountStrategy({
+              pattern: {
+                type: 'mountpoint',
+              },
+            }),
+          },
+        },
+      }),
+    );
+
+    expect(childProcessMocks.spawn).toHaveBeenCalledOnce();
+  });
+
+  it('reads rclone config files and applies remoteName and extraArgs for Docker mounts', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
+      const command = args.join(' ');
+      if (command.includes('base64')) {
+        expect(command).toContain('/workspace/rclone.conf');
+        return dockerSpawnResult({
+          stdout: Buffer.from('[custom]\ncustom_option = true\n').toString(
+            'base64',
+          ),
+          status: 0,
+        });
+      }
+      expect(command).toContain('--allow-other');
+      expect(command).toContain('--vfs-cache-mode');
+      expect(command).toContain('writes');
+      expect(command).toContain('trap');
+      expect(command).toContain('rm -rf');
+      expect(command).not.toContain('/tmp/openai-agents-docker-custom.conf');
+      return dockerSpawnResult({ status: 0 });
+    });
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+
+    await client.create(
+      new Manifest({
+        entries: {
+          'rclone.conf': {
+            type: 'file',
+            content: '[custom]\ncustom_option = true\n',
+          },
+          s3: {
+            type: 's3_mount',
+            bucket: 'agent-logs',
+            mountStrategy: inContainerMountStrategy({
+              pattern: {
+                type: 'rclone',
+                remoteName: 'custom',
+                configFilePath: 'rclone.conf',
+                extraArgs: ['--vfs-cache-mode', 'writes'],
+              },
+            }),
+          },
+        },
+      }),
+    );
+
+    expect(childProcessMocks.spawn).toHaveBeenCalledTimes(2);
+    const configInput = dockerStdinWrites.join('\n');
+    expect(configInput).toContain('[custom]');
+    expect(configInput).toContain('custom_option = true');
+    expect(configInput).toContain('provider = AWS');
+  });
+
+  it('honors R2 prefixes in Docker in-container rclone mounts', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
+      const command = args.join(' ');
+      expect(command).toContain('rclone');
+      expect(command).toContain('r2remote:r2-logs/2026/04');
+      return dockerSpawnResult({ status: 0 });
+    });
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          r2logs: {
+            type: 'r2_mount',
+            bucket: 'r2-logs',
+            prefix: '/2026/04/',
+            accountId: 'account-id',
+            accessKeyId: 'access-key',
+            secretAccessKey: 'secret-key',
+            mountStrategy: inContainerMountStrategy({
+              pattern: {
+                type: 'rclone',
+                remoteName: 'r2remote',
+              },
+            }),
+          },
+        },
+      }),
+    );
+
+    expect(childProcessMocks.spawn).toHaveBeenCalledOnce();
+    await session.close();
+  });
+
+  it('rejects rclone config files outside the Docker workspace policy', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+
+    await expect(
+      client.create(
+        new Manifest({
+          entries: {
+            s3: {
+              type: 's3_mount',
+              bucket: 'agent-logs',
+              mountStrategy: inContainerMountStrategy({
+                pattern: {
+                  type: 'rclone',
+                  remoteName: 'custom',
+                  configFilePath: '/etc/rclone.conf',
+                },
+              }),
+            },
+          },
+        }),
+      ),
+    ).rejects.toThrow(/escapes the workspace root/);
+  });
+
+  it('builds syntactically valid Docker rclone NFS mount commands', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
+      const command = args.join(' ');
+      expect(command).toContain('rclone');
+      expect(command).toContain('serve');
+      expect(command).toContain('nfs');
+      expect(command).toContain('& printf %s "$!" >');
+      expect(command).toContain('{ mounted=0; for i in 1 2 3; do if');
+      expect(command).toContain('openai-agents-rclone-nfs');
+      expect(command).not.toContain('pkill -f');
+      expect(command).not.toContain('do; if');
+      expect(command).not.toContain('& &&');
+      return dockerSpawnResult({ status: 0 });
+    });
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+
+    await client.create(
+      new Manifest({
+        entries: {
+          s3: {
+            type: 's3_mount',
+            bucket: 'agent-logs',
+            mountStrategy: inContainerMountStrategy({
+              pattern: {
+                type: 'rclone',
+                mode: 'nfs',
+              },
+            }),
+          },
+        },
+      }),
+    );
+
+    expect(childProcessMocks.spawn).toHaveBeenCalledOnce();
+  });
+
+  it('applies Azure Blob prefix when building Docker rclone mounts', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
+      const command = args.join(' ');
+      expect(command).toContain(':container-name/prefix/path');
+      return dockerSpawnResult({ status: 0 });
+    });
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+
+    await client.create(
+      new Manifest({
+        entries: {
+          azure: {
+            type: 'azure_blob_mount',
+            accountName: 'account-name',
+            container: 'container-name',
+            endpoint: 'https://blob.alias.example.test',
+            prefix: '/prefix/path/',
+            mountStrategy: inContainerMountStrategy({
+              pattern: {
+                type: 'rclone',
+              },
+            }),
+          },
+        },
+      }),
+    );
+
+    expect(childProcessMocks.spawn).toHaveBeenCalledOnce();
+    const configInput = dockerStdinWrites.join('\n');
+    expect(configInput).toContain('type = azureblob');
+    expect(configInput).toContain('account = account-name');
+    expect(configInput).toContain('endpoint = https://blob.alias.example.test');
+  });
+
+  it('passes custom S3 providers through Docker rclone mounts', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation(() =>
+      dockerSpawnResult({ status: 0 }),
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+
+    await client.create(
+      new Manifest({
+        entries: {
+          s3: {
+            type: 's3_mount',
+            bucket: 'agent-logs',
+            s3Provider: 'Minio',
+            mountStrategy: inContainerMountStrategy({
+              pattern: {
+                type: 'rclone',
+              },
+            }),
+          },
+        },
+      }),
+    );
+
+    const configInput = dockerStdinWrites.join('\n');
+    expect(configInput).toContain('type = s3');
+    expect(configInput).toContain('provider = Minio');
+  });
+
+  it('falls back to native Docker GCS rclone config for partial HMAC credentials', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
+      const command = args.join(' ');
+      expect(command).toContain('rclone');
+      return dockerSpawnResult({ status: 0 });
+    });
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+
+    await client.create(
+      new Manifest({
+        entries: {
+          gcs: {
+            type: 'gcs_mount',
+            bucket: 'gcs-logs',
+            accessId: 'gcs-access-id',
+            mountStrategy: inContainerMountStrategy({
+              pattern: {
+                type: 'rclone',
+              },
+            }),
+          },
+        },
+      }),
+    );
+
+    expect(childProcessMocks.spawn).toHaveBeenCalledOnce();
+    const configInput = dockerStdinWrites.join('\n');
+    expect(configInput).toContain('type = google cloud storage');
+    expect(configInput).toContain('env_auth = true');
+    expect(configInput).not.toContain('access_key_id = gcs-access-id');
+  });
+
+  it('rejects R2 Docker rclone mounts without accountId even with customDomain', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+
+    await expect(
+      client.create(
+        new Manifest({
+          entries: {
+            r2: {
+              type: 'r2_mount',
+              bucket: 'r2-logs',
+              customDomain: 'https://r2.example.test',
+              mountStrategy: inContainerMountStrategy({
+                pattern: {
+                  type: 'rclone',
+                },
+              }),
+            } as any,
+          },
+        }),
+      ),
+    ).rejects.toThrow(/accountId/);
   });
 
   it('hydrates workspace archives with Docker volume mount entries', async () => {
@@ -696,6 +1660,285 @@ describe('DockerSandboxClient unit behavior', () => {
     await expect(session.pathExists(rootDir)).resolves.toBe(true);
   });
 
+  it('rejects applying in-container mounts that need missing Docker privileges', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(new Manifest());
+
+    await expect(
+      session.applyManifest(
+        new Manifest({
+          entries: {
+            s3files: {
+              type: 's3_files_mount',
+              fileSystemId: 'fs-123',
+              mountStrategy: inContainerMountStrategy({
+                pattern: {
+                  type: 's3files',
+                },
+              }),
+            },
+          },
+        }),
+      ),
+    ).rejects.toThrow(/requires Docker privileges/);
+  });
+
+  it('creates and chowns absolute in-container mount paths before runAs apply', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation(() =>
+      dockerSpawnResult({ status: 0 }),
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          bootstrap: {
+            type: 'mount',
+            source: 'memory://fixture',
+            mountStrategy: inContainerMountStrategy({
+              pattern: {
+                type: 'fuse',
+                command: 'true',
+              },
+            }),
+          },
+        },
+      }),
+    );
+    childProcessMocks.spawn.mockClear();
+    childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
+      const command = (args as string[]).join(' ');
+      if (command.includes("OPENAI_AGENTS_MOUNT_PATH='/workspace/failed'")) {
+        return dockerSpawnResult({ stderr: 'mount failed', status: 1 });
+      }
+      return dockerSpawnResult({ status: 0 });
+    });
+
+    await session.applyManifest(
+      new Manifest({
+        entries: {
+          mounted: {
+            type: 'mount',
+            source: 'memory://fixture',
+            mountPath: '/mnt/absolute',
+            mountStrategy: inContainerMountStrategy({
+              pattern: {
+                type: 'fuse',
+                command: 'true',
+              },
+            }),
+          },
+        },
+      }),
+      'node',
+    );
+
+    const commands = childProcessMocks.spawn.mock.calls.map(([, args]) =>
+      (args as string[]).join(' '),
+    );
+    const mkdirIndex = commands.findIndex((command) =>
+      command.includes("mkdir -p -- '/mnt/absolute'"),
+    );
+    const chownIndex = commands.findIndex((command) =>
+      command.includes("chown -R 'node':'node' -- '/mnt/absolute'"),
+    );
+    const mountIndex = commands.findIndex((command) =>
+      command.includes("OPENAI_AGENTS_MOUNT_PATH='/mnt/absolute'"),
+    );
+    expect(mkdirIndex).toBeGreaterThanOrEqual(0);
+    expect(chownIndex).toBeGreaterThan(mkdirIndex);
+    expect(mountIndex).toBeGreaterThan(chownIndex);
+  });
+
+  it('unmounts applied in-container mounts when applyManifest later fails', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
+      const command = args.join(' ');
+      if (command.includes("OPENAI_AGENTS_MOUNT_PATH='/workspace/second'")) {
+        return dockerSpawnResult({ stderr: 'second failed', status: 1 });
+      }
+      return dockerSpawnResult({ status: 0 });
+    });
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          bootstrap: {
+            type: 'mount',
+            source: 'memory://fixture',
+            mountStrategy: inContainerMountStrategy({
+              pattern: {
+                type: 'fuse',
+                command: 'true',
+              },
+            }),
+          },
+        },
+      }),
+    );
+    childProcessMocks.spawn.mockClear();
+
+    await expect(
+      session.applyManifest(
+        new Manifest({
+          entries: {
+            first: {
+              type: 'mount',
+              source: 'memory://fixture',
+              mountStrategy: inContainerMountStrategy({
+                pattern: {
+                  type: 'fuse',
+                  command: 'true',
+                },
+              }),
+            },
+            second: {
+              type: 'mount',
+              source: 'memory://fixture',
+              mountStrategy: inContainerMountStrategy({
+                pattern: {
+                  type: 'fuse',
+                  command: 'false',
+                },
+              }),
+            },
+          },
+        }),
+      ),
+    ).rejects.toThrow(/second failed/);
+
+    const commands = childProcessMocks.spawn.mock.calls.map(([, args]) =>
+      (args as string[]).join(' '),
+    );
+    expect(
+      commands.some(
+        (command) =>
+          command.includes("umount -l '/workspace/second'") &&
+          command.includes('fusermount3'),
+      ),
+    ).toBe(true);
+    expect(
+      commands.some(
+        (command) =>
+          command.includes("umount -l '/workspace/first'") &&
+          command.includes('fusermount3'),
+      ),
+    ).toBe(true);
+  });
+
+  it('rolls back environment state when applyManifest fails', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation(() =>
+      dockerSpawnResult({ status: 0 }),
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(
+      new Manifest({
+        environment: {
+          KEEP: 'old',
+        },
+        entries: {
+          bootstrap: {
+            type: 'mount',
+            source: 'memory://fixture',
+            mountStrategy: inContainerMountStrategy({
+              pattern: {
+                type: 'fuse',
+                command: 'true',
+              },
+            }),
+          },
+        },
+      }),
+    );
+    childProcessMocks.spawn.mockClear();
+    childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
+      const command = (args as string[]).join(' ');
+      if (command.includes("OPENAI_AGENTS_MOUNT_PATH='/workspace/failed'")) {
+        return dockerSpawnResult({ stderr: 'mount failed', status: 1 });
+      }
+      return dockerSpawnResult({ status: 0 });
+    });
+
+    await expect(
+      session.applyManifest(
+        new Manifest({
+          environment: {
+            SECRET: {
+              value: 'new-secret',
+              ephemeral: true,
+            },
+          },
+          entries: {
+            failed: {
+              type: 'mount',
+              source: 'memory://fixture',
+              mountStrategy: inContainerMountStrategy({
+                pattern: {
+                  type: 'fuse',
+                  command: 'false',
+                },
+              }),
+            },
+          },
+        }),
+      ),
+    ).rejects.toThrow(/mount failed/);
+
+    expect(session.state.environment).toEqual({
+      KEEP: 'old',
+    });
+  });
+
   it('starts a new container when resumed container state is stopped', async () => {
     const workspaceRootPath = await mkdtemp(join(rootDir, 'workspace-'));
     processMocks.runSandboxProcess.mockImplementation(
@@ -801,6 +2044,97 @@ describe('DockerSandboxClient unit behavior', () => {
     await expect(lstat(join(secondSnapshot.path, 'link'))).rejects.toThrow();
     await expect(
       readFile(join(secondSnapshot.path, 'link'), 'utf8'),
+    ).rejects.toThrow();
+  });
+
+  it('excludes blobfuse cache and config directories from Docker snapshots', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation(() =>
+      dockerSpawnResult({ status: 0 }),
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: {
+        type: 'local',
+        baseDir: rootDir,
+      },
+    });
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          azure: {
+            type: 'azure_blob_mount',
+            account: 'account-name',
+            container: 'container-name',
+            mountStrategy: inContainerMountStrategy({
+              pattern: {
+                type: 'fuse',
+                cachePath: 'cache/blobfuse',
+              },
+            }),
+          },
+        },
+      }),
+    );
+    await mkdir(
+      join(session.state.workspaceRootPath, '.sandbox-blobfuse-config'),
+      {
+        recursive: true,
+      },
+    );
+    await writeFile(
+      join(
+        session.state.workspaceRootPath,
+        '.sandbox-blobfuse-config',
+        'secret.yaml',
+      ),
+      'account-key: secret\n',
+      'utf8',
+    );
+    await mkdir(
+      join(session.state.workspaceRootPath, '.sandbox-blobfuse-cache'),
+      {
+        recursive: true,
+      },
+    );
+    await writeFile(
+      join(session.state.workspaceRootPath, '.sandbox-blobfuse-cache', 'data'),
+      'cache\n',
+      'utf8',
+    );
+    await mkdir(join(session.state.workspaceRootPath, 'cache', 'blobfuse'), {
+      recursive: true,
+    });
+    await writeFile(
+      join(session.state.workspaceRootPath, 'cache', 'blobfuse', 'data'),
+      'custom cache\n',
+      'utf8',
+    );
+
+    const serialized = await client.serializeSessionState(session.state);
+    const snapshot = serialized.snapshot as {
+      type: 'local';
+      path: string;
+    };
+
+    await expect(
+      stat(join(snapshot.path, '.sandbox-blobfuse-config')),
+    ).rejects.toThrow();
+    await expect(
+      stat(join(snapshot.path, '.sandbox-blobfuse-cache')),
+    ).rejects.toThrow();
+    await expect(
+      stat(join(snapshot.path, 'cache', 'blobfuse')),
     ).rejects.toThrow();
   });
 

--- a/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
@@ -712,6 +712,10 @@ export class DaytonaSandboxSession implements SandboxSession<DaytonaSandboxSessi
       mountPath,
       pattern: rclonePatternFromMountStrategy(entry.mountStrategy),
       runCommand: this.mountCommandRunner(),
+      writeFile: async (path, content) => {
+        await this.ensureParentDir(path);
+        await this.sandbox.fs.uploadFile(Buffer.from(content), path);
+      },
       packageManagers: ['apt', 'apk'],
     });
     this.activeMountPaths.add(mountPath);

--- a/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
@@ -767,6 +767,7 @@ export class E2BSandboxSession extends RemoteSandboxSessionBase<E2BSandboxSessio
       mountPath,
       pattern: rclonePatternFromMountStrategy(entry.mountStrategy),
       runCommand: this.mountCommandRunner(),
+      writeFile: this.writeRemoteFile.bind(this),
       packageManagers: ['apt'],
       installRcloneViaScript: true,
     });

--- a/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
@@ -956,6 +956,7 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
       mountPath,
       pattern: rclonePatternFromMountStrategy(entry.mountStrategy),
       runCommand: this.mountCommandRunner(),
+      writeFile: this.writeRemoteFile.bind(this),
       packageManagers: ['apt'],
       installRcloneViaScript: true,
     });

--- a/packages/agents-extensions/src/sandbox/shared/inContainerMounts.ts
+++ b/packages/agents-extensions/src/sandbox/shared/inContainerMounts.ts
@@ -29,6 +29,11 @@ export type RemoteMountCommand = (
   options?: RemoteMountCommandOptions,
 ) => Promise<RemoteMountCommandResult>;
 
+export type RemoteMountFileWriter = (
+  path: string,
+  content: string | Uint8Array,
+) => Promise<void>;
+
 export type RcloneCloudBucketMountOptions = {
   providerName: string;
   providerId: string;
@@ -37,6 +42,7 @@ export type RcloneCloudBucketMountOptions = {
   mountPath: string;
   pattern?: RcloneMountPattern;
   runCommand: RemoteMountCommand;
+  writeFile: RemoteMountFileWriter;
   packageManagers?: Array<'apt' | 'apk'>;
   installRcloneViaScript?: boolean;
 };
@@ -139,18 +145,23 @@ export async function mountRcloneCloudBucket(
     await ensureFuseSupport(options);
   }
   await ensureRclone(options);
-  const config = buildRcloneMountConfig(options.entry, {
-    remoteName,
-  });
+  const config = await resolveRcloneMountConfig(options, pattern, remoteName);
   const configPath = `/tmp/openai-agents-${options.providerId}-${config.remoteName}.conf`;
 
   await runRequiredMountCommand(options, {
-    label: 'write rclone config',
+    label: 'prepare rclone config',
     command: [
       `mkdir -p -- ${shellQuote(options.mountPath)}`,
-      `printf %s ${shellQuote(config.configText)} > ${shellQuote(configPath)}`,
+      `rm -f -- ${shellQuote(configPath)}`,
+      `touch ${shellQuote(configPath)}`,
       `chmod 600 ${shellQuote(configPath)}`,
     ].join(' && '),
+    timeoutMs: 30_000,
+  });
+  await options.writeFile(configPath, config.configText);
+  await runRequiredMountCommand(options, {
+    label: 'protect rclone config',
+    command: `chmod 600 ${shellQuote(configPath)}`,
     timeoutMs: 30_000,
   });
 
@@ -224,7 +235,7 @@ async function mountRcloneFuse(
     '--allow-other',
     ...(userIds ? ['--uid', userIds.uid, '--gid', userIds.gid] : []),
     ...(config.readOnly ? ['--read-only'] : []),
-    ...(pattern.args ?? []),
+    ...rclonePatternArgs(pattern),
   ];
 
   try {
@@ -270,7 +281,7 @@ async function mountRcloneNfs(
     '--config',
     configPath,
     ...(config.readOnly ? ['--read-only'] : []),
-    ...(pattern.args ?? []),
+    ...rclonePatternArgs(pattern),
   ];
   await runRequiredMountCommand(options, {
     label: 'start rclone nfs server',
@@ -323,7 +334,7 @@ function buildRcloneMountConfig(
         configText: [
           `[${options.remoteName}]`,
           'type = s3',
-          'provider = AWS',
+          `provider = ${entry.s3Provider ?? 'AWS'}`,
           ...(entry.endpointUrl ? [`endpoint = ${entry.endpointUrl}`] : []),
           ...(entry.region ? [`region = ${entry.region}`] : []),
           ...s3CredentialLines(entry),
@@ -339,9 +350,9 @@ function buildRcloneMountConfig(
         accessKeyId: readOptionalString(entry, 'accessKeyId'),
         secretAccessKey: readOptionalString(entry, 'secretAccessKey'),
       });
-      if (!entry.accountId && !readOptionalString(entry, 'customDomain')) {
+      if (!entry.accountId) {
         throw new SandboxMountError(
-          'R2 cloud bucket mounts require accountId or customDomain.',
+          'R2 cloud bucket mounts require accountId.',
           {
             mountType: entry.type,
           },
@@ -381,18 +392,88 @@ function buildRcloneMountConfig(
   }
 }
 
+async function resolveRcloneMountConfig(
+  options: RcloneCloudBucketMountOptions,
+  pattern: RcloneMountPattern,
+  remoteName: string,
+): Promise<RcloneMountConfig> {
+  const config = buildRcloneMountConfig(options.entry as RcloneBucketMount, {
+    remoteName,
+  });
+  const configFilePath = rclonePatternString(pattern, 'configFilePath');
+  if (!configFilePath) {
+    return config;
+  }
+  const result = await options.runCommand(
+    `cat -- ${shellQuote(configFilePath)}`,
+    {
+      timeoutMs: 30_000,
+    },
+  );
+  if (result.status !== 0) {
+    throw new SandboxMountError(
+      `${options.providerName} failed to read rclone config file.`,
+      {
+        provider: options.providerId,
+        mountType: config.mountType,
+        path: configFilePath,
+        stderr: result.stderr,
+      },
+    );
+  }
+  return {
+    ...config,
+    configText: supplementRcloneConfigText(
+      result.stdout ?? '',
+      remoteName,
+      config.configText,
+      config.mountType,
+      options,
+    ),
+  };
+}
+
+function supplementRcloneConfigText(
+  configText: string,
+  remoteName: string,
+  requiredConfigText: string,
+  mountType: string,
+  options: RcloneCloudBucketMountOptions,
+): string {
+  const escapedRemote = remoteName.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+  const sectionPattern = new RegExp(`^\\s*\\[${escapedRemote}\\]\\s*$`, 'mu');
+  const match = sectionPattern.exec(configText);
+  if (!match) {
+    throw new SandboxMountError(
+      `${options.providerName} rclone config file is missing the required remote section.`,
+      {
+        provider: options.providerId,
+        mountType,
+        remoteName,
+      },
+    );
+  }
+  const sectionStart = match.index;
+  const sectionEnd = match.index + match[0].length;
+  const nextSection = /^\s*\[.+\]\s*$/mu.exec(configText.slice(sectionEnd));
+  const sectionBodyEnd = nextSection
+    ? sectionEnd + nextSection.index
+    : configText.length;
+  const before = configText.slice(0, sectionStart);
+  const sectionBody = configText.slice(sectionStart, sectionBodyEnd).trimEnd();
+  const after = configText.slice(sectionBodyEnd);
+  const requiredLines = requiredConfigText.trimEnd().split('\n').slice(1);
+  const supplement =
+    requiredLines.length > 0 ? `\n${requiredLines.join('\n')}` : '';
+  return `${before}${sectionBody}${supplement}\n${after}`;
+}
+
 function buildGcsRcloneMountConfig(
   entry: GCSMount,
   remoteName: string,
 ): RcloneMountConfig {
   const accessId = readOptionalString(entry, 'accessId');
   const secretAccessKey = readOptionalString(entry, 'secretAccessKey');
-  validateCredentialPair({
-    provider: 'GCS',
-    mountType: entry.type,
-    accessKeyId: accessId,
-    secretAccessKey,
-  });
   if (accessId && secretAccessKey) {
     return {
       remoteName,
@@ -458,7 +539,9 @@ function buildAzureBlobRcloneMountConfig(
       `[${remoteName}]`,
       'type = azureblob',
       `account = ${account}`,
-      ...(entry.endpointUrl ? [`endpoint = ${entry.endpointUrl}`] : []),
+      ...(azureBlobEndpoint(entry)
+        ? [`endpoint = ${azureBlobEndpoint(entry)}`]
+        : []),
       ...(entry.accountKey
         ? [`key = ${entry.accountKey}`]
         : [
@@ -472,6 +555,10 @@ function buildAzureBlobRcloneMountConfig(
     readOnly: entry.readOnly ?? true,
     mountType: entry.type,
   };
+}
+
+function azureBlobEndpoint(entry: AzureBlobMount): string | undefined {
+  return entry.endpointUrl ?? entry.endpoint;
 }
 
 function buildBoxRcloneMountConfig(
@@ -501,12 +588,6 @@ function buildBoxRcloneMountConfig(
 function s3CredentialLines(entry: S3Mount): string[] {
   const accessKeyId = readOptionalString(entry, 'accessKeyId');
   const secretAccessKey = readOptionalString(entry, 'secretAccessKey');
-  validateCredentialPair({
-    provider: 'S3',
-    mountType: entry.type,
-    accessKeyId,
-    secretAccessKey,
-  });
   if (!accessKeyId || !secretAccessKey) {
     return ['env_auth = true'];
   }
@@ -728,20 +809,23 @@ function resolveRcloneRemoteName(
   pattern: RcloneMountPattern,
   options: RcloneCloudBucketMountOptions,
 ): string {
-  if (typeof pattern.remote !== 'undefined') {
+  const remoteName =
+    rclonePatternString(pattern, 'remoteName') ??
+    rclonePatternString(pattern, 'remote');
+  if (typeof remoteName !== 'undefined') {
     if (
-      typeof pattern.remote !== 'string' ||
-      !/^[A-Za-z0-9_-]+$/u.test(pattern.remote)
+      typeof remoteName !== 'string' ||
+      !/^[A-Za-z0-9_-]+$/u.test(remoteName)
     ) {
       throw new SandboxMountError(
-        `${options.providerName} cloud bucket mounts require pattern.remote to contain only letters, numbers, underscores, and hyphens.`,
+        `${options.providerName} cloud bucket mounts require remoteName to contain only letters, numbers, underscores, and hyphens.`,
         {
           provider: options.providerId,
-          remoteName: pattern.remote,
+          remoteName,
         },
       );
     }
-    return pattern.remote;
+    return remoteName;
   }
 
   return `sandbox_${sanitizeRemoteName(options.providerId)}_${sanitizeRemoteName(options.mountPath)}`;
@@ -796,6 +880,13 @@ function rclonePatternStringArray(
     value.every((item): item is string => typeof item === 'string')
     ? value
     : undefined;
+}
+
+function rclonePatternArgs(pattern: RcloneMountPattern): string[] {
+  return [
+    ...(rclonePatternStringArray(pattern, 'args') ?? []),
+    ...(rclonePatternStringArray(pattern, 'extraArgs') ?? []),
+  ];
 }
 
 function isRcloneBucketMount(entry: Entry): entry is RcloneBucketMount {

--- a/packages/agents-extensions/test/sandbox/cloudflare.test.ts
+++ b/packages/agents-extensions/test/sandbox/cloudflare.test.ts
@@ -1677,6 +1677,7 @@ describe('CloudflareSandboxClient', () => {
           data: {
             type: 'r2_mount',
             bucket: 'logs',
+            accountId: 'account-id',
             customDomain: 'https://logs.example.com',
             mountPath: 'mounted/logs',
             mountStrategy: new CloudflareBucketMountStrategy(),

--- a/packages/agents-extensions/test/sandbox/shared.test.ts
+++ b/packages/agents-extensions/test/sandbox/shared.test.ts
@@ -80,6 +80,9 @@ import {
   mount,
   relativeHostPathEscapesRoot,
   relativeHostPathEscapesRootOrSelf,
+  type AzureBlobMount,
+  type GCSMount,
+  type R2Mount,
   type S3Mount,
 } from '@openai/agents-core/sandbox';
 
@@ -95,9 +98,24 @@ afterEach(async () => {
   );
 });
 
+function recordMountWrite(writes: Map<string, string>) {
+  return async (path: string, content: string | Uint8Array) => {
+    writes.set(
+      path,
+      typeof content === 'string' ? content : Buffer.from(content).toString(),
+    );
+  };
+}
+
+function onlyMountWrite(writes: Map<string, string>): string {
+  expect(writes.size).toBe(1);
+  return [...writes.values()][0]!;
+}
+
 describe('remote sandbox path helpers', () => {
   test('mounts Box entries through the shared rclone helper', async () => {
     const commands: string[] = [];
+    const writes = new Map<string, string>();
     const entry = boxMount({
       path: '/Shared/Docs',
       clientId: 'box-client-id',
@@ -116,8 +134,9 @@ describe('remote sandbox path helpers', () => {
         pattern: {
           type: 'rclone',
           mode: 'fuse',
-          remote: 'boxremote',
-          args: ['--vfs-cache-mode', 'writes'],
+          remoteName: 'boxremote',
+          configFilePath: '/workspace/rclone.conf',
+          extraArgs: ['--vfs-cache-mode', 'writes'],
         },
       },
     });
@@ -135,39 +154,45 @@ describe('remote sandbox path helpers', () => {
       pattern: {
         type: 'rclone',
         mode: 'fuse',
-        remote: 'boxremote',
-        args: ['--vfs-cache-mode', 'writes'],
+        remoteName: 'boxremote',
+        configFilePath: '/workspace/rclone.conf',
+        extraArgs: ['--vfs-cache-mode', 'writes'],
       },
       runCommand: async (command) => {
         commands.push(command);
         if (command === 'id -u; id -g') {
           return { status: 0, stdout: '1000\n1000\n' };
         }
+        if (command === "cat -- '/workspace/rclone.conf'") {
+          return { status: 0, stdout: '[boxremote]\nexisting = true\n' };
+        }
         return { status: 0 };
       },
+      writeFile: recordMountWrite(writes),
     });
 
-    const configCommand = commands.find((command) =>
-      command.includes('printf %s'),
-    );
+    const configText = onlyMountWrite(writes);
     const mountCommand = commands.find((command) =>
       command.startsWith("'rclone' 'mount'"),
     );
+    const commandText = commands.join('\n');
 
-    expect(configCommand).toContain('[boxremote]');
-    expect(configCommand).toContain('type = box');
-    expect(configCommand).toContain('client_id = box-client-id');
-    expect(configCommand).toContain('client_secret = box-client-secret');
-    expect(configCommand).toContain('box_config_file = /run/secrets/box.json');
-    expect(configCommand).toContain(
-      'config_credentials = {"boxAppSettings":{}}',
-    );
-    expect(configCommand).toContain('access_token = box-access-token');
-    expect(configCommand).toContain('token = {"access_token":"token"}');
-    expect(configCommand).toContain('box_sub_type = enterprise');
-    expect(configCommand).toContain('root_folder_id = root-id');
-    expect(configCommand).toContain('impersonate = 123456');
-    expect(configCommand).toContain('owned_by = owner@example.com');
+    expect(configText).toContain('[boxremote]');
+    expect(configText).toContain('existing = true');
+    expect(configText).toContain('type = box');
+    expect(configText).toContain('client_id = box-client-id');
+    expect(configText).toContain('client_secret = box-client-secret');
+    expect(configText).toContain('box_config_file = /run/secrets/box.json');
+    expect(configText).toContain('config_credentials = {"boxAppSettings":{}}');
+    expect(configText).toContain('access_token = box-access-token');
+    expect(configText).toContain('token = {"access_token":"token"}');
+    expect(configText).toContain('box_sub_type = enterprise');
+    expect(configText).toContain('root_folder_id = root-id');
+    expect(configText).toContain('impersonate = 123456');
+    expect(configText).toContain('owned_by = owner@example.com');
+    expect(commandText).not.toContain('client_secret = box-client-secret');
+    expect(commandText).not.toContain('access_token = box-access-token');
+    expect(commandText).not.toContain('token = {"access_token":"token"}');
     expect(mountCommand).toContain("'boxremote:Shared/Docs'");
     expect(mountCommand).toContain("'/workspace/box docs'");
     expect(mountCommand).toContain("'--uid' '1000' '--gid' '1000'");
@@ -198,6 +223,184 @@ describe('remote sandbox path helpers', () => {
       "openai_agents_kill_pidfile $pidfile 'rclone' 'serve' 'nfs'",
     );
     expect(commands[0]).not.toContain('kill "$(cat "$pidfile")"');
+  });
+
+  test('passes S3 provider through the shared rclone helper', async () => {
+    const commands: string[] = [];
+    const writes = new Map<string, string>();
+    const entry: S3Mount = {
+      type: 's3_mount',
+      bucket: 'agent-logs',
+      s3Provider: 'Minio',
+      mountStrategy: {
+        type: 'test_cloud_bucket',
+        pattern: {
+          type: 'rclone',
+          remoteName: 'logs',
+        },
+      },
+    };
+
+    await mountRcloneCloudBucket({
+      providerName: 'TestSandboxClient',
+      providerId: 'test',
+      strategyType: 'test_cloud_bucket',
+      entry,
+      mountPath: '/workspace/logs',
+      runCommand: async (command) => {
+        commands.push(command);
+        if (command === 'id -u; id -g') {
+          return { status: 0, stdout: '1000\n1000\n' };
+        }
+        return { status: 0, stdout: '' };
+      },
+      writeFile: recordMountWrite(writes),
+    });
+
+    const configText = onlyMountWrite(writes);
+    expect(configText).toContain('type = s3');
+    expect(configText).toContain('provider = Minio');
+  });
+
+  test('falls back to S3 env auth for partial credentials in the shared rclone helper', async () => {
+    const commands: string[] = [];
+    const writes = new Map<string, string>();
+    const entry: S3Mount = {
+      type: 's3_mount',
+      bucket: 'agent-logs',
+      accessKeyId: 'access-key',
+      mountStrategy: {
+        type: 'test_cloud_bucket',
+        pattern: {
+          type: 'rclone',
+          remoteName: 'logs',
+        },
+      },
+    };
+
+    await mountRcloneCloudBucket({
+      providerName: 'TestSandboxClient',
+      providerId: 'test',
+      strategyType: 'test_cloud_bucket',
+      entry,
+      mountPath: '/workspace/logs',
+      runCommand: async (command) => {
+        commands.push(command);
+        if (command === 'id -u; id -g') {
+          return { status: 0, stdout: '1000\n1000\n' };
+        }
+        return { status: 0, stdout: '' };
+      },
+      writeFile: recordMountWrite(writes),
+    });
+
+    const configText = onlyMountWrite(writes);
+    expect(configText).toContain('env_auth = true');
+    expect(configText).not.toContain('access_key_id = access-key');
+  });
+
+  test('falls back to native GCS rclone config for partial HMAC credentials in the shared helper', async () => {
+    const commands: string[] = [];
+    const writes = new Map<string, string>();
+    const entry: GCSMount = {
+      type: 'gcs_mount',
+      bucket: 'agent-logs',
+      accessId: 'gcs-access-id',
+      mountStrategy: {
+        type: 'test_cloud_bucket',
+        pattern: {
+          type: 'rclone',
+          remoteName: 'logs',
+        },
+      },
+    };
+
+    await mountRcloneCloudBucket({
+      providerName: 'TestSandboxClient',
+      providerId: 'test',
+      strategyType: 'test_cloud_bucket',
+      entry,
+      mountPath: '/workspace/logs',
+      runCommand: async (command) => {
+        commands.push(command);
+        if (command === 'id -u; id -g') {
+          return { status: 0, stdout: '1000\n1000\n' };
+        }
+        return { status: 0, stdout: '' };
+      },
+      writeFile: recordMountWrite(writes),
+    });
+
+    const configText = onlyMountWrite(writes);
+    expect(configText).toContain('type = google cloud storage');
+    expect(configText).toContain('env_auth = true');
+    expect(configText).not.toContain('access_key_id = gcs-access-id');
+  });
+
+  test('rejects shared R2 rclone mounts without accountId even with customDomain', async () => {
+    const entry: R2Mount = {
+      type: 'r2_mount',
+      bucket: 'agent-logs',
+      customDomain: 'https://r2.example.test',
+      mountStrategy: {
+        type: 'test_cloud_bucket',
+        pattern: {
+          type: 'rclone',
+          remoteName: 'logs',
+        },
+      },
+    } as any;
+
+    await expect(
+      mountRcloneCloudBucket({
+        providerName: 'TestSandboxClient',
+        providerId: 'test',
+        strategyType: 'test_cloud_bucket',
+        entry,
+        mountPath: '/workspace/logs',
+        runCommand: async () => ({ status: 0, stdout: '' }),
+        writeFile: recordMountWrite(new Map<string, string>()),
+      }),
+    ).rejects.toThrow(/accountId/);
+  });
+
+  test('accepts Azure Blob endpoint aliases in the shared rclone helper', async () => {
+    const commands: string[] = [];
+    const writes = new Map<string, string>();
+    const entry: AzureBlobMount = {
+      type: 'azure_blob_mount',
+      account: 'account-name',
+      container: 'container-name',
+      endpoint: 'https://blob.alias.example.test',
+      mountStrategy: {
+        type: 'test_cloud_bucket',
+        pattern: {
+          type: 'rclone',
+          remoteName: 'azure',
+        },
+      },
+    };
+
+    await mountRcloneCloudBucket({
+      providerName: 'TestSandboxClient',
+      providerId: 'test',
+      strategyType: 'test_cloud_bucket',
+      entry,
+      mountPath: '/workspace/azure',
+      runCommand: async (command) => {
+        commands.push(command);
+        if (command === 'id -u; id -g') {
+          return { status: 0, stdout: '1000\n1000\n' };
+        }
+        return { status: 0, stdout: '' };
+      },
+      writeFile: recordMountWrite(writes),
+    });
+
+    const configText = onlyMountWrite(writes);
+    expect(configText).toContain('type = azureblob');
+    expect(configText).toContain('account = account-name');
+    expect(configText).toContain('endpoint = https://blob.alias.example.test');
   });
 
   test('validates rclone NFS pidfiles during failed mount cleanup', async () => {
@@ -234,6 +437,7 @@ describe('remote sandbox path helpers', () => {
           }
           return { status: 0, stdout: '' };
         },
+        writeFile: recordMountWrite(new Map<string, string>()),
       }),
     ).rejects.toThrow(
       'TestSandboxClient cloud bucket mount failed while trying to mount rclone nfs client.',


### PR DESCRIPTION
This pull request fixes sandbox mount support so this TS SDK matches the Python SDK’s current in-container mount behavior and option shapes. It adds Docker in-container mount handling for rclone, mountpoint, s3files, and Azure Blob FUSE patterns, including the Docker privileges, manifest application path, resume/rematerialization behavior, snapshot exclusions, rollback, and cleanup needed for those mounts to work reliably.