### PR TITLE
test: add optional sandbox storage mount integrations

### DIFF
--- a/.agents/skills/integration-tests/SKILL.md
+++ b/.agents/skills/integration-tests/SKILL.md
@@ -22,10 +22,11 @@ Run integration tests that require a local npm registry by starting `pnpm local-
 Run this exact sequence in the main process and capture the output:
 
 ```bash
-pnpm i && pnpm build:ci && pnpm local-npm:reset && pnpm local-npm:publish && pnpm test:integration
+pnpm i && pnpm build:ci && pnpm local-npm:reset && pnpm local-npm:publish && OPENAI_AGENTS_RUN_STORAGE_MOUNT_INTEGRATION=1 pnpm test:integration
 ```
 
 - Use `pnpm build:ci` here so the skill validates the same serialized build path that GitHub Actions now uses, while still running the normal `prebuild` and `postbuild` lifecycle steps.
+- Run `pnpm test:integration` with `OPENAI_AGENTS_RUN_STORAGE_MOUNT_INTEGRATION=1` so the optional sandbox storage mount coverage runs by default when this skill is used. This enables the local Azurite and MinIO smoke tests without changing the repository's plain `pnpm test:integration` default.
 
 - Return the full success/failure outcome and a concise summary of the results.
 - Always capture the stdout/stderr from `pnpm test:integration` and include it in the final response (trim obvious noise if extremely long) inside a fenced code block.

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -13,6 +13,7 @@ It is intentionally not part of the `pnpm` workspace and instead installs the pa
 - Run `pnpm exec playwright install` to install playwright
 - `pnpm test:integration` will create temporary `integration-tests/cloudflare-workers/worker/.dev.vars` and `integration-tests/vite-react/.env` files from `OPENAI_API_KEY` and restore any pre-existing files during cleanup
 - Integration test fixture subprocesses run with `NODE_ENV=development` so real-model SDK examples keep the normal server-runtime tracing behavior even though Vitest itself runs with `NODE_ENV=test`
+- Optional sandbox storage mount coverage requires Docker with FUSE support and is skipped unless `OPENAI_AGENTS_RUN_STORAGE_MOUNT_INTEGRATION=1` is set. It starts local Azurite and MinIO containers and removes them after the test.
 
 2. **Local npm registry**
 

--- a/integration-tests/node.test.ts
+++ b/integration-tests/node.test.ts
@@ -74,4 +74,28 @@ describe('Node.js', () => {
       );
     },
   );
+
+  test(
+    'sandbox storage mounts should run against local emulators',
+    { timeout: 300_000 },
+    async (context) => {
+      if (process.env.OPENAI_AGENTS_RUN_STORAGE_MOUNT_INTEGRATION !== '1') {
+        context.skip();
+      }
+
+      try {
+        await execa`docker info`;
+      } catch {
+        context.skip();
+      }
+
+      const { stdout } = await execa`npm run start:sandbox:storage-mounts`;
+      expect(stdout).toContain(
+        '[STORAGE_MOUNT_RESPONSE]azure:ok[/STORAGE_MOUNT_RESPONSE]',
+      );
+      expect(stdout).toContain(
+        '[STORAGE_MOUNT_RESPONSE]s3:ok[/STORAGE_MOUNT_RESPONSE]',
+      );
+    },
+  );
 });

--- a/integration-tests/node/package.json
+++ b/integration-tests/node/package.json
@@ -7,7 +7,8 @@
     "start:aisdk:cjs": "node aisdk.cjs",
     "start:codex": "node --no-experimental-require-module codex.mjs",
     "start:sandbox:unix-local": "node --no-experimental-require-module sandbox-unix-local.mjs",
-    "start:sandbox:docker": "node --no-experimental-require-module sandbox-docker.mjs"
+    "start:sandbox:docker": "node --no-experimental-require-module sandbox-docker.mjs",
+    "start:sandbox:storage-mounts": "node --no-experimental-require-module sandbox-storage-mounts.mjs"
   },
   "dependencies": {
     "@openai/agents": "latest",

--- a/integration-tests/node/sandbox-storage-mounts.Dockerfile
+++ b/integration-tests/node/sandbox-storage-mounts.Dockerfile
@@ -1,0 +1,5 @@
+FROM node:22-bookworm-slim
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates fuse3 rclone \
+  && rm -rf /var/lib/apt/lists/*

--- a/integration-tests/node/sandbox-storage-mounts.mjs
+++ b/integration-tests/node/sandbox-storage-mounts.mjs
@@ -1,0 +1,382 @@
+// @ts-check
+
+import {
+  Manifest,
+  azureBlobMount,
+  inContainerMountStrategy,
+  mountPattern,
+  s3Mount,
+} from '@openai/agents/sandbox';
+import { DockerSandboxClient } from '@openai/agents/sandbox/local';
+import { spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+
+const mountImage =
+  process.env.SANDBOX_STORAGE_MOUNT_IMAGE ??
+  'openai-agents-js-storage-mount-smoke:local';
+const azuriteImage =
+  process.env.SANDBOX_STORAGE_AZURITE_IMAGE ??
+  'mcr.microsoft.com/azure-storage/azurite';
+const minioImage =
+  process.env.SANDBOX_STORAGE_MINIO_IMAGE ?? 'minio/minio:latest';
+
+const azureAccountName = 'devstoreaccount1';
+const azureAccountKey =
+  'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==';
+const azureContainer = 'azurite-smoke';
+
+const s3Bucket = 'minio-smoke';
+const s3AccessKeyId = 'minioadmin';
+const s3SecretAccessKey = 'minioadmin';
+
+const startedContainers = new Set();
+
+function runCommand(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    input: options.input,
+    encoding: 'utf8',
+    stdio: options.capture
+      ? ['pipe', 'pipe', 'pipe']
+      : ['pipe', 'inherit', 'inherit'],
+    env: process.env,
+    timeout: options.timeoutMs,
+  });
+  if (result.status !== 0 && !options.allowFailure) {
+    const detail = options.capture ? `\n${result.stderr}` : '';
+    throw new Error(`${command} ${args.join(' ')} failed.${detail}`);
+  }
+  return result.stdout ?? '';
+}
+
+function ensureMountImage() {
+  const inspect = spawnSync('docker', ['image', 'inspect', mountImage], {
+    stdio: 'ignore',
+  });
+  if (inspect.status === 0) {
+    return;
+  }
+  runCommand('docker', [
+    'build',
+    '-t',
+    mountImage,
+    '-f',
+    'sandbox-storage-mounts.Dockerfile',
+    '.',
+  ]);
+}
+
+function startContainer(args) {
+  const name = args.namePrefix + randomUUID().slice(0, 8);
+  runCommand('docker', ['run', '-d', '--name', name, ...args.runArgs], {
+    timeoutMs: 120_000,
+  });
+  startedContainers.add(name);
+  const ipAddress = runCommand(
+    'docker',
+    [
+      'inspect',
+      '-f',
+      '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}',
+      name,
+    ],
+    { capture: true },
+  ).trim();
+  if (!ipAddress) {
+    throw new Error(`Could not resolve container IP address for ${name}.`);
+  }
+  return { name, ipAddress };
+}
+
+function cleanupContainers() {
+  for (const name of [...startedContainers].reverse()) {
+    runCommand('docker', ['rm', '-f', name], { allowFailure: true });
+    startedContainers.delete(name);
+  }
+}
+
+function runRclone(args, options = {}) {
+  return runCommand(
+    'docker',
+    ['run', '--rm', '-i', mountImage, 'rclone', ...args],
+    {
+      ...options,
+      timeoutMs: options.timeoutMs ?? 30_000,
+    },
+  );
+}
+
+function azureRcloneArgs(endpoint, args) {
+  return [
+    '--contimeout',
+    '5s',
+    '--timeout',
+    '10s',
+    '--retries',
+    '1',
+    '--low-level-retries',
+    '1',
+    ...args,
+    '--azureblob-account',
+    azureAccountName,
+    '--azureblob-key',
+    azureAccountKey,
+    '--azureblob-endpoint',
+    endpoint,
+    '--azureblob-use-emulator',
+  ];
+}
+
+function s3RcloneArgs(endpoint, args) {
+  return [
+    '--contimeout',
+    '5s',
+    '--timeout',
+    '10s',
+    '--retries',
+    '1',
+    '--low-level-retries',
+    '1',
+    ...args,
+    '--s3-provider',
+    'Minio',
+    '--s3-access-key-id',
+    s3AccessKeyId,
+    '--s3-secret-access-key',
+    s3SecretAccessKey,
+    '--s3-endpoint',
+    endpoint,
+    '--s3-region',
+    'us-east-1',
+  ];
+}
+
+async function waitForRclone(args) {
+  for (let attempt = 1; attempt <= 30; attempt += 1) {
+    const result = spawnSync(
+      'docker',
+      ['run', '--rm', mountImage, 'rclone', ...args],
+      {
+        stdio: 'ignore',
+        timeout: 10_000,
+      },
+    );
+    if (result.status === 0) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error('Storage emulator did not become ready.');
+}
+
+async function startAzurite() {
+  const container = startContainer({
+    namePrefix: 'oaajs-azurite-',
+    runArgs: [azuriteImage, 'azurite-blob', '--blobHost', '0.0.0.0'],
+  });
+  const endpoint = `http://${container.ipAddress}:10000/${azureAccountName}`;
+  await waitForRclone(
+    azureRcloneArgs(endpoint, ['mkdir', `:azureblob:${azureContainer}`]),
+  );
+  return endpoint;
+}
+
+async function startMinio() {
+  const container = startContainer({
+    namePrefix: 'oaajs-minio-',
+    runArgs: [
+      '-e',
+      `MINIO_ROOT_USER=${s3AccessKeyId}`,
+      '-e',
+      `MINIO_ROOT_PASSWORD=${s3SecretAccessKey}`,
+      minioImage,
+      'server',
+      '/data',
+      '--address',
+      ':9000',
+      '--console-address',
+      ':9001',
+    ],
+  });
+  const endpoint = `http://${container.ipAddress}:9000`;
+  await waitForRclone(s3RcloneArgs(endpoint, ['mkdir', `:s3:${s3Bucket}`]));
+  return endpoint;
+}
+
+async function smokeAzureBlobMount() {
+  const endpoint = await startAzurite();
+  runRclone(
+    azureRcloneArgs(endpoint, [
+      'rcat',
+      `:azureblob:${azureContainer}/from-host.txt`,
+    ]),
+    { input: 'hello from host\n' },
+  );
+  const prepared = runRclone(
+    azureRcloneArgs(endpoint, [
+      'cat',
+      `:azureblob:${azureContainer}/from-host.txt`,
+    ]),
+    { capture: true },
+  );
+  if (prepared !== 'hello from host\n') {
+    throw new Error(`Azurite preparation readback failed: ${prepared}`);
+  }
+
+  const manifest = new Manifest({
+    entries: {
+      azure: azureBlobMount({
+        container: azureContainer,
+        accountName: azureAccountName,
+        accountKey: azureAccountKey,
+        endpointUrl: endpoint,
+        readOnly: false,
+        mountStrategy: inContainerMountStrategy({
+          pattern: mountPattern({
+            type: 'rclone',
+            mode: 'fuse',
+            args: [
+              '--azureblob-use-emulator',
+              '--contimeout',
+              '5s',
+              '--timeout',
+              '10s',
+              '--retries',
+              '1',
+              '--low-level-retries',
+              '1',
+            ],
+          }),
+        }),
+      }),
+    },
+  });
+
+  const client = new DockerSandboxClient({ image: mountImage });
+  const session = await client.create(manifest);
+  try {
+    const result = await session.execCommand?.({
+      cmd: [
+        'set -e',
+        'cat azure/from-host.txt',
+        'printf "hello from sandbox\\n" > azure/from-sandbox.txt',
+        'sync',
+        'sleep 2',
+        'cat azure/from-sandbox.txt',
+      ].join(' && '),
+      shell: '/bin/sh',
+      login: false,
+      yieldTimeMs: 20_000,
+      maxOutputTokens: 4000,
+    });
+    const output = typeof result === 'string' ? result : result?.output;
+    if (
+      !output?.includes('hello from host') ||
+      !output.includes('hello from sandbox')
+    ) {
+      throw new Error(`Unexpected Azure Blob mount output: ${String(output)}`);
+    }
+  } finally {
+    await session.close?.();
+  }
+
+  const downloaded = runRclone(
+    azureRcloneArgs(endpoint, [
+      'cat',
+      `:azureblob:${azureContainer}/from-sandbox.txt`,
+    ]),
+    { capture: true },
+  );
+  if (downloaded !== 'hello from sandbox\n') {
+    throw new Error(`Azurite sandbox write readback failed: ${downloaded}`);
+  }
+}
+
+async function smokeS3Mount() {
+  const endpoint = await startMinio();
+  runRclone(s3RcloneArgs(endpoint, ['rcat', `:s3:${s3Bucket}/from-host.txt`]), {
+    input: 'hello from host\n',
+  });
+  const prepared = runRclone(
+    s3RcloneArgs(endpoint, ['cat', `:s3:${s3Bucket}/from-host.txt`]),
+    { capture: true },
+  );
+  if (prepared !== 'hello from host\n') {
+    throw new Error(`MinIO preparation readback failed: ${prepared}`);
+  }
+
+  const manifest = new Manifest({
+    entries: {
+      s3: s3Mount({
+        bucket: s3Bucket,
+        endpointUrl: endpoint,
+        s3Provider: 'Minio',
+        region: 'us-east-1',
+        accessKeyId: s3AccessKeyId,
+        secretAccessKey: s3SecretAccessKey,
+        readOnly: false,
+        mountStrategy: inContainerMountStrategy({
+          pattern: mountPattern({
+            type: 'rclone',
+            mode: 'fuse',
+            args: [
+              '--contimeout',
+              '5s',
+              '--timeout',
+              '10s',
+              '--retries',
+              '1',
+              '--low-level-retries',
+              '1',
+            ],
+          }),
+        }),
+      }),
+    },
+  });
+
+  const client = new DockerSandboxClient({ image: mountImage });
+  const session = await client.create(manifest);
+  try {
+    const result = await session.execCommand?.({
+      cmd: [
+        'set -e',
+        'cat s3/from-host.txt',
+        'printf "hello from sandbox\\n" > s3/from-sandbox.txt',
+        'sync',
+        'sleep 2',
+        'cat s3/from-sandbox.txt',
+      ].join(' && '),
+      shell: '/bin/sh',
+      login: false,
+      yieldTimeMs: 20_000,
+      maxOutputTokens: 4000,
+    });
+    const output = typeof result === 'string' ? result : result?.output;
+    if (
+      !output?.includes('hello from host') ||
+      !output.includes('hello from sandbox')
+    ) {
+      throw new Error(`Unexpected S3 mount output: ${String(output)}`);
+    }
+  } finally {
+    await session.close?.();
+  }
+
+  const downloaded = runRclone(
+    s3RcloneArgs(endpoint, ['cat', `:s3:${s3Bucket}/from-sandbox.txt`]),
+    { capture: true },
+  );
+  if (downloaded !== 'hello from sandbox\n') {
+    throw new Error(`MinIO sandbox write readback failed: ${downloaded}`);
+  }
+}
+
+try {
+  ensureMountImage();
+  await smokeAzureBlobMount();
+  console.log('[STORAGE_MOUNT_RESPONSE]azure:ok[/STORAGE_MOUNT_RESPONSE]');
+  await smokeS3Mount();
+  console.log('[STORAGE_MOUNT_RESPONSE]s3:ok[/STORAGE_MOUNT_RESPONSE]');
+} finally {
+  cleanupContainers();
+}


### PR DESCRIPTION
This pull request adds optional integration coverage for sandbox storage mounts against local emulators. It introduces a Node integration fixture that validates `azureBlobMount()` with Azurite and `s3Mount()` with MinIO through Docker-backed sandbox sessions, gated behind `OPENAI_AGENTS_RUN_STORAGE_MOUNT_INTEGRATION=1` so the default integration suite remains lightweight.