### PR TITLE
chore: upgrade GitHub Actions workflow pins

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Resolve PR context
         id: pr
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -56,7 +56,7 @@ jobs:
         with:
           run_install: false
       - name: Setup Node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 22
 
@@ -84,12 +84,13 @@ jobs:
       - name: Run Codex changeset validation
         id: run_codex
         if: ${{ github.actor != 'dependabot[bot]' && steps.pr.outputs.is_fork != 'true' }}
-        uses: openai/codex-action@c25d10f3f498316d4b2496cc4c6dd58057a7b031
+        uses: openai/codex-action@e0fdf01220eb9a88167c4898839d273e3f2609d1
         with:
           openai-api-key: ${{ secrets.PROD_OPENAI_API_KEY }}
           prompt-file: .github/codex/prompts/changeset-validation.generated.md
           output-file: .github/codex/outputs/changeset-validation.json
           output-schema-file: .github/codex/schemas/changeset-validation.json
+          allow-bots: true
           # Keep the legacy Linux sandbox path until the default bubblewrap path
           # works reliably on GitHub-hosted Ubuntu runners.
           codex-args: '["--full-auto","--enable","use_legacy_landlock"]'
@@ -109,7 +110,7 @@ jobs:
 
       - name: Sync package labels
         if: ${{ steps.run_codex.conclusion == 'success' || github.actor == 'dependabot[bot]' || steps.pr.outputs.is_fork == 'true' }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         env:
           BASE_SHA: ${{ steps.pr.outputs.base_sha }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       - name: Install pnpm
         uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d
         with:
@@ -31,7 +31,7 @@ jobs:
       - name: Run build
         run: pnpm build:ci
       - name: Install, build, and upload your site
-        uses: withastro/action@44706356b4eb735f8b9035699eb4796241a040c4
+        uses: withastro/action@b7d53628f8b666036b0238aadb0b984a2a489f26
         with:
           path: docs
           # with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d
 
       - name: Setup node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: '24.x'
           cache: 'pnpm'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Determine whether CI should run
         id: filter
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           script: |
             const IGNORED_PREFIXES = [
@@ -112,7 +112,7 @@ jobs:
           run_install: false
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.run_ci == 'true' }}
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
@@ -160,7 +160,7 @@ jobs:
           run_install: false
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.run_ci == 'true' }}
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 22
           cache: 'pnpm'
@@ -200,7 +200,7 @@ jobs:
           run_install: false
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.run_ci == 'true' }}
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 22
           cache: 'pnpm'

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           run_install: false
       - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 22
           cache: 'pnpm'
@@ -92,7 +92,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.commit.outputs.committed == 'true'
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "docs: update translated document pages"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow pins across the repo to current immutable SHAs for `actions/github-script`, `actions/setup-node`, `openai/codex-action`, `withastro/action`, and `peter-evans/create-pull-request`.

It also preserves the automated translated-docs PR flow after the `openai/codex-action` v1.8 bot permission change by explicitly allowing the trusted `github-actions[bot]` actor in the changeset validation Codex step. No package changes are included, so no changeset is required.