### PR TITLE
feat: allow maxTurns null to disable turn limits

### DIFF
--- a/.changeset/disable-max-turns.md
+++ b/.changeset/disable-max-turns.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents': patch
+---
+
+feat: allow maxTurns null to disable turn limits

--- a/docs/src/content/docs/guides/running-agents.mdx
+++ b/docs/src/content/docs/guides/running-agents.mdx
@@ -38,7 +38,7 @@ The runner then runs a loop:
    - **Final output** → return.
    - **Handoff** → switch to the new agent, keep the accumulated conversation history, go to 1.
    - **Tool calls** → execute tools, append their results to the conversation, go to 1.
-3. Throw [`MaxTurnsExceededError`](/openai-agents-js/openai/agents-core/classes/maxturnsexceedederror) once `maxTurns` is reached.
+3. Throw [`MaxTurnsExceededError`](/openai-agents-js/openai/agents-core/classes/maxturnsexceedederror) once `maxTurns` is reached, unless `maxTurns` is `null`.
 
 <Aside type="note">
   The rule for whether the LLM output is considered as a "final output" is that
@@ -61,7 +61,7 @@ The additional options are:
 | --- | --- | --- |
 | `stream` | `false` | If `true` the call returns a `StreamedRunResult` and emits events as they arrive from the model. |
 | `context` | – | Context object forwarded to every tool / guardrail / handoff. Learn more in the [context guide](/openai-agents-js/guides/context). |
-| `maxTurns` | `10` | Safety limit – throws [`MaxTurnsExceededError`](/openai-agents-js/openai/agents-core/classes/maxturnsexceedederror) when reached. |
+| `maxTurns` | `10` | Safety limit – throws [`MaxTurnsExceededError`](/openai-agents-js/openai/agents-core/classes/maxturnsexceedederror) when reached. Pass `null` to disable the limit. |
 | `signal` | – | `AbortSignal` for cancellation. |
 | `session` | – | Session persistence implementation. See the [sessions guide](/openai-agents-js/guides/sessions). |
 | `sessionInputCallback` | – | Custom merge logic for session history and new input; runs before the model call. See [sessions](/openai-agents-js/guides/sessions). |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,7 @@ export default tseslint.config(
   globalIgnores([
     '**/dist/**',
     '**/node_modules/**',
+    '**/.tmp/**',
     '**/docs/.astro/**',
     'examples/realtime-next/**',
     'examples/realtime-demo/**',

--- a/packages/agents-core/src/result.ts
+++ b/packages/agents-core/src/result.ts
@@ -316,7 +316,7 @@ export class StreamedRunResult<
   /**
    * The maximum number of turns that can be run
    */
-  public maxTurns: number | undefined;
+  public maxTurns: number | null | undefined;
 
   #error: unknown = null;
   #combinedSignal?: AbortSignal;

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -274,7 +274,7 @@ type SharedRunOptions<
   TAgent extends Agent<any, any> = Agent<any, any>,
 > = {
   context?: TContext | RunContext<TContext>;
-  maxTurns?: number;
+  maxTurns?: number | null;
   signal?: AbortSignal;
   previousResponseId?: string;
   conversationId?: string;
@@ -712,10 +712,15 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               : new RunContext(options.context),
             input,
             startingAgent,
-            options.maxTurns ?? DEFAULT_MAX_TURNS,
+            options.maxTurns === undefined
+              ? DEFAULT_MAX_TURNS
+              : options.maxTurns,
           );
       if (isResumedState) {
         state._agentToolInvocation = undefined;
+        if (options.maxTurns !== undefined) {
+          state._maxTurns = options.maxTurns;
+        }
       }
       const sandboxRuntime = new SandboxRuntimeManager<TContext>({
         startingAgent,
@@ -1638,10 +1643,15 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               : new RunContext(options.context),
             input as string | AgentInputItem[],
             agent,
-            options.maxTurns ?? DEFAULT_MAX_TURNS,
+            options.maxTurns === undefined
+              ? DEFAULT_MAX_TURNS
+              : options.maxTurns,
           );
       if (isResumedState) {
         state._agentToolInvocation = undefined;
+        if (options.maxTurns !== undefined) {
+          state._maxTurns = options.maxTurns;
+        }
       }
       const sandboxRuntime = new SandboxRuntimeManager<TContext>({
         startingAgent: agent,
@@ -1674,7 +1684,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       };
 
       // Setup defaults
-      result.maxTurns = streamOptions.maxTurns ?? state._maxTurns;
+      result.maxTurns = state._maxTurns;
 
       // Continue the stream loop without blocking
       const streamLoopPromise = this.#runStreamLoop(

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -88,8 +88,9 @@ import {
  *   envelope for sandbox-agent resume.
  * - 1.10: Adds optional stable agent identity keys so duplicate-name agent graphs can
  *   serialize and resume without ambiguous name resolution.
+ * - 1.11: Allows null maxTurns to persist runs without a turn limit.
  */
-export const CURRENT_SCHEMA_VERSION = '1.10' as const;
+export const CURRENT_SCHEMA_VERSION = '1.11' as const;
 const SUPPORTED_SCHEMA_VERSIONS = [
   '1.0',
   '1.1',
@@ -101,6 +102,7 @@ const SUPPORTED_SCHEMA_VERSIONS = [
   '1.7',
   '1.8',
   '1.9',
+  '1.10',
   CURRENT_SCHEMA_VERSION,
 ] as const;
 type SupportedSchemaVersion = (typeof SUPPORTED_SCHEMA_VERSIONS)[number];
@@ -408,7 +410,7 @@ export const SerializedRunState = z.object({
     toolInput: z.any().optional(),
   }),
   toolUseTracker: z.record(z.string(), z.array(z.string())),
-  maxTurns: z.number(),
+  maxTurns: z.number().nullable(),
   currentAgentSpan: SerializedSpan.nullable().optional(),
   noActiveAgentRun: z.boolean(),
   inputGuardrailResults: z.array(inputGuardrailResultSchema),
@@ -543,7 +545,7 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
   /**
    * Maximum allowed turns before forcing termination.
    */
-  public _maxTurns: number;
+  public _maxTurns: number | null;
   /**
    * Whether the run has an active agent step in progress.
    */
@@ -603,7 +605,7 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     context: RunContext<TContext>,
     originalInput: string | AgentInputItem[],
     startingAgent: TAgent,
-    maxTurns: number,
+    maxTurns: number | null,
   ) {
     this._context = context;
     this._agentToolInvocation = undefined;
@@ -1045,6 +1047,7 @@ function assertSchemaVersionSupportsToolSearch(
   if (
     schemaVersion === '1.8' ||
     schemaVersion === '1.9' ||
+    schemaVersion === '1.10' ||
     schemaVersion === CURRENT_SCHEMA_VERSION
   ) {
     return;
@@ -1062,7 +1065,7 @@ function assertSchemaVersionSupportsToolSearch(
 function schemaVersionSupportsAgentIdentity(
   schemaVersion: SupportedSchemaVersion,
 ): boolean {
-  return schemaVersion === CURRENT_SCHEMA_VERSION;
+  return schemaVersion === '1.10' || schemaVersion === CURRENT_SCHEMA_VERSION;
 }
 
 function containsSerializedToolSearchState(

--- a/packages/agents-core/src/runner/turnPreparation.ts
+++ b/packages/agents-core/src/runner/turnPreparation.ts
@@ -72,7 +72,7 @@ export async function prepareTurn<
     continuingInterruptedTurn,
   });
 
-  if (state._currentTurn > state._maxTurns) {
+  if (state._maxTurns !== null && state._currentTurn > state._maxTurns) {
     state._currentAgentSpan?.setError({
       message: 'Max turns exceeded',
       data: { max_turns: state._maxTurns },

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -1222,6 +1222,83 @@ describe('Runner.run (streaming)', () => {
     );
   });
 
+  it('does not enforce maxTurns for streamed runs when maxTurns is null', async () => {
+    const testTool = tool({
+      name: 'test_tool',
+      description: 'A test tool',
+      parameters: z.object({}),
+      execute: async () => 'result',
+    });
+    const responses: ModelResponse[] = [
+      ...Array.from({ length: 12 }, (_, index) => ({
+        output: [
+          {
+            type: 'function_call' as const,
+            id: `fc_${index}`,
+            callId: `call_${index}`,
+            name: 'test_tool',
+            status: 'completed' as const,
+            arguments: '{}',
+            providerData: {},
+          } as protocol.FunctionCallItem,
+        ],
+        usage: new Usage(),
+      })),
+      {
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+      },
+    ];
+
+    class LongStreamingModel implements Model {
+      #callCount = 0;
+
+      async getResponse(_req: ModelRequest): Promise<ModelResponse> {
+        const response = responses[this.#callCount++];
+        if (!response) {
+          throw new Error('No response found');
+        }
+        return response;
+      }
+
+      async *getStreamedResponse(
+        req: ModelRequest,
+      ): AsyncIterable<StreamEvent> {
+        const response = await this.getResponse(req);
+        yield {
+          type: 'response_done',
+          response: {
+            id: `r_${this.#callCount}`,
+            usage: {
+              requests: 1,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            output: response.output,
+          },
+        } as any;
+      }
+    }
+
+    const agent = new Agent({
+      name: 'NoMaxTurnsStream',
+      model: new LongStreamingModel(),
+      tools: [testTool],
+      toolUseBehavior: 'run_llm_again',
+    });
+
+    const result = await run(agent, 'hi', { stream: true, maxTurns: null });
+    for await (const _event of result.toStream()) {
+      // Consume stream.
+    }
+    await result.completed;
+
+    expect(result.finalOutput).toBe('done');
+    expect(result.maxTurns).toBeNull();
+    expect(result.state._currentTurn).toBe(13);
+  });
+
   it('handles maxTurns errors with an error handler', async () => {
     const agent = new Agent({
       name: 'MaxTurnsHandlerStream',

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -1922,6 +1922,80 @@ describe('Runner.run', () => {
       );
     });
 
+    it('does not enforce maxTurns when maxTurns is null', async () => {
+      const toolResponses = Array.from({ length: 12 }, (_, index) => ({
+        output: [
+          {
+            ...TEST_MODEL_FUNCTION_CALL,
+            id: `fc_${index}`,
+            callId: `call_${index}`,
+            arguments: JSON.stringify({ test: 'input' }),
+          },
+        ],
+        usage: new Usage(),
+      }));
+      const agent = new Agent({
+        name: 'NoMaxTurns',
+        model: new FakeModel([
+          ...toolResponses,
+          { output: [fakeModelMessage('done')], usage: new Usage() },
+        ]),
+        tools: [TEST_TOOL],
+      });
+
+      const result = await run(agent, 'x', { maxTurns: null });
+
+      expect(result.finalOutput).toBe('done');
+      expect(result.state._maxTurns).toBeNull();
+      expect(result.state._currentTurn).toBe(13);
+    });
+
+    it('allows resumed states to disable maxTurns with null', async () => {
+      const responses = [
+        {
+          output: [
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              id: 'fc_1',
+              callId: 'call_1',
+              arguments: JSON.stringify({ test: 'first' }),
+            },
+          ],
+          usage: new Usage(),
+        },
+        {
+          output: [
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              id: 'fc_2',
+              callId: 'call_2',
+              arguments: JSON.stringify({ test: 'second' }),
+            },
+          ],
+          usage: new Usage(),
+        },
+        { output: [fakeModelMessage('done')], usage: new Usage() },
+      ];
+      const agent = new Agent({
+        name: 'NoMaxTurnsResume',
+        model: new FakeModel(responses),
+        tools: [TEST_TOOL],
+      });
+      const error = await run(agent, 'x', { maxTurns: 1 }).catch((err) => err);
+      expect(error).toBeInstanceOf(MaxTurnsExceededError);
+      const state = (error as MaxTurnsExceededError).state as RunState<
+        unknown,
+        typeof agent
+      >;
+
+      const result = await run(agent, state, {
+        maxTurns: null,
+      });
+
+      expect(result.finalOutput).toBe('done');
+      expect(result.state._maxTurns).toBeNull();
+    });
+
     it('max turn handler returns final output', async () => {
       const agent = new Agent({
         name: 'MaxSummary',

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -552,6 +552,18 @@ describe('RunState', () => {
     expect(JSON.parse(str)).toEqual(json);
   });
 
+  it('serializes null maxTurns', async () => {
+    const context = new RunContext();
+    const agent = new Agent({ name: 'NoMaxTurns' });
+    const state = new RunState(context, 'input1', agent, null);
+
+    const json = state.toJSON();
+    expect(json.maxTurns).toBeNull();
+
+    const restored = await RunState.fromString(agent, state.toString());
+    expect(restored._maxTurns).toBeNull();
+  });
+
   it('serializes duplicate-name agents with stable identities', async () => {
     const childA = new Agent({
       name: 'SharedSkill',
@@ -576,6 +588,12 @@ describe('RunState', () => {
 
     const restored = await RunState.fromString(root, JSON.stringify(json));
     expect(restored._currentAgent).toBe(childB);
+
+    const restoredFromSchema110 = await RunState.fromString(
+      root,
+      JSON.stringify({ ...json, $schemaVersion: '1.10' as const }),
+    );
+    expect(restoredFromSchema110._currentAgent).toBe(childB);
   });
 
   it('keeps literal identity suffixes from colliding with generated identities', () => {
@@ -906,7 +924,7 @@ describe('RunState', () => {
     );
   });
 
-  it('accepts schema version 1.8 payloads with tool_search items during deserialization', async () => {
+  it('accepts schema versions with tool_search support during deserialization', async () => {
     const context = new RunContext();
     const agent = new Agent({ name: 'Agent18' });
     const state = new RunState(context, 'input1', agent, 2);
@@ -939,10 +957,19 @@ describe('RunState', () => {
       ),
     );
 
-    const restored = await RunState.fromString(agent, state.toString());
+    for (const $schemaVersion of ['1.8', '1.10'] as const) {
+      const jsonVersion = state.toJSON() as any;
+      jsonVersion.$schemaVersion = $schemaVersion;
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(jsonVersion),
+      );
 
-    expect(restored._generatedItems[0]).toBeInstanceOf(RunToolSearchCallItem);
-    expect(restored._generatedItems[1]).toBeInstanceOf(RunToolSearchOutputItem);
+      expect(restored._generatedItems[0]).toBeInstanceOf(RunToolSearchCallItem);
+      expect(restored._generatedItems[1]).toBeInstanceOf(
+        RunToolSearchOutputItem,
+      );
+    }
   });
 
   it('preserves raw tool_search call_id and execution fields through RunState serialization', async () => {


### PR DESCRIPTION
This pull request adds an explicit `maxTurns: null` option to disable the run turn limit while preserving the existing default of `10` when `maxTurns` is omitted.

It updates non-streaming and streaming runs, allows resumed `RunState` executions to override the persisted limit with `null`, persists nullable `maxTurns` in RunState schema `1.11`, and documents the new option. It also adds regression coverage for non-streaming, streaming, resumed runs, and schema compatibility, plus an ESLint ignore for `.tmp/**` so ignored local verification artifacts do not break lint.

see also: https://github.com/openai/openai-agents-python/pull/3132