### PR TITLE
feat: switch the default model to a newer mini model (affecting only when a model is unset)

### DIFF
--- a/.changeset/gpt54-mini-default-model.md
+++ b/.changeset/gpt54-mini-default-model.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents': minor
+'@openai/agents-core': minor
+'@openai/agents-openai': minor
+---
+
+feat: switch the default model to gpt-5.4-mini

--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -321,7 +321,7 @@ export interface AgentConfiguration<
    * The model implementation to use when invoking the LLM.
    *
    * By default, if not set, the agent will use the default model returned by
-   * getDefaultModel (currently "gpt-4.1").
+   * getDefaultModel (currently "gpt-5.4-mini").
    */
   model: string | Model;
 

--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -398,6 +398,18 @@ export type AgentOptions<
     Partial<AgentConfiguration<TContext, TOutput>>
 >;
 
+function getInitialModelSettingsForAgentModel(
+  model: string | Model | undefined,
+): ModelSettings {
+  if (typeof model === 'string' && model !== Agent.DEFAULT_MODEL_PLACEHOLDER) {
+    return getDefaultModelSettings(model);
+  }
+  if (model !== undefined) {
+    return {};
+  }
+  return getDefaultModelSettings();
+}
+
 /**
  * An agent is an AI model configured with instructions, tools, guardrails, handoffs and more.
  *
@@ -494,6 +506,7 @@ export class Agent<
   toolUseBehavior: ToolUseBehavior;
   resetToolChoice: boolean;
   private readonly _toolsExplicitlyConfigured: boolean;
+  private readonly _modelSettingsExplicitlyConfigured: boolean;
 
   constructor(config: AgentOptions<TContext, TOutput>) {
     super();
@@ -506,7 +519,11 @@ export class Agent<
     this.handoffDescription = config.handoffDescription ?? '';
     this.handoffs = config.handoffs ?? [];
     this.model = config.model ?? '';
-    this.modelSettings = config.modelSettings ?? getDefaultModelSettings();
+    this._modelSettingsExplicitlyConfigured =
+      config.modelSettings !== undefined;
+    this.modelSettings =
+      config.modelSettings ??
+      getInitialModelSettingsForAgentModel(config.model);
     this.tools = config.tools ?? [];
     this._toolsExplicitlyConfigured = config.tools !== undefined;
     this.mcpServers = config.mcpServers ?? [];
@@ -556,6 +573,11 @@ export class Agent<
         }
       }
     }
+  }
+
+  /** @internal */
+  hasExplicitModelSettings(): boolean {
+    return this._modelSettingsExplicitlyConfigured;
   }
 
   /**

--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -401,13 +401,13 @@ export type AgentOptions<
 function getInitialModelSettingsForAgentModel(
   model: string | Model | undefined,
 ): ModelSettings {
+  if (model === undefined || model === Agent.DEFAULT_MODEL_PLACEHOLDER) {
+    return getDefaultModelSettings();
+  }
   if (typeof model === 'string' && model !== Agent.DEFAULT_MODEL_PLACEHOLDER) {
     return getDefaultModelSettings(model);
   }
-  if (model !== undefined) {
-    return {};
-  }
-  return getDefaultModelSettings();
+  return {};
 }
 
 /**
@@ -538,6 +538,7 @@ export class Agent<
     if (
       // The user sets a non-default model
       config.model !== undefined &&
+      config.model !== Agent.DEFAULT_MODEL_PLACEHOLDER &&
       // The default model is gpt-5
       isGpt5Default() &&
       // However, the specified model is not a gpt-5 model
@@ -608,9 +609,17 @@ export class Agent<
   clone(
     config: Partial<AgentConfiguration<TContext, TOutput>>,
   ): Agent<TContext, TOutput> {
+    const modelSettings =
+      'modelSettings' in config
+        ? config.modelSettings
+        : this.hasExplicitModelSettings()
+          ? this.modelSettings
+          : undefined;
+
     return new Agent({
       ...this,
       ...config,
+      modelSettings,
     });
   }
 

--- a/packages/agents-core/src/defaultModel.ts
+++ b/packages/agents-core/src/defaultModel.ts
@@ -37,6 +37,7 @@ const DEFAULT_REASONING_EFFORT_PATTERNS: Array<
   [/^gpt-5\.4-pro(?:-\d{4}-\d{2}-\d{2})?$/, 'medium'],
   [/^gpt-5\.4-mini(?:-\d{4}-\d{2}-\d{2})?$/, 'none'],
   [/^gpt-5\.4-nano(?:-\d{4}-\d{2}-\d{2})?$/, 'none'],
+  [/^gpt-5\.5(?:-\d{4}-\d{2}-\d{2})?$/, 'none'],
 ];
 
 function getDefaultReasoningEffort(

--- a/packages/agents-core/src/defaultModel.ts
+++ b/packages/agents-core/src/defaultModel.ts
@@ -67,7 +67,7 @@ export function isGpt5Default(): boolean {
 export function getDefaultModel(): string {
   const env = loadEnv();
   return (
-    env[OPENAI_DEFAULT_MODEL_ENV_VARIABLE_NAME]?.toLowerCase() ?? 'gpt-4.1'
+    env[OPENAI_DEFAULT_MODEL_ENV_VARIABLE_NAME]?.toLowerCase() ?? 'gpt-5.4-mini'
   );
 }
 

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -53,6 +53,7 @@ import {
   maybeResetToolChoice,
   selectModel,
 } from './runner/modelSettings';
+import { getDefaultModelSettings } from './defaultModel';
 import {
   getResponseWithRetry,
   getStreamedResponseWithRetry,
@@ -121,6 +122,19 @@ export { getTurnInput } from './runner/items';
 export type { ReasoningItemIdPolicy } from './runner/items';
 
 // Maintenance: keep helper utilities (e.g., GuardrailTracker) in runner/* modules so run.ts stays orchestration-only.
+
+function getImplicitModelSettingsForResolvedModel(
+  explictlyModelSet: boolean,
+  resolvedModelName?: string,
+): ModelSettings {
+  if (resolvedModelName && resolvedModelName.trim().length > 0) {
+    return getDefaultModelSettings(resolvedModelName);
+  }
+  if (explictlyModelSet) {
+    return {};
+  }
+  return getDefaultModelSettings();
+}
 
 // --------------------------------------------------------------
 //  Configuration
@@ -1726,13 +1740,26 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     const { model, explictlyModelSet, resolvedModelName } =
       await this.#resolveModelForAgent(executionAgent);
 
+    const hasExplicitAgentModelSettings =
+      executionAgent.hasExplicitModelSettings();
+    const agentModelSettings = hasExplicitAgentModelSettings
+      ? executionAgent.modelSettings
+      : undefined;
+    const implicitModelSettings = hasExplicitAgentModelSettings
+      ? undefined
+      : getImplicitModelSettingsForResolvedModel(
+          explictlyModelSet,
+          resolvedModelName,
+        );
+
     let modelSettings = mergeModelSettings(
+      implicitModelSettings,
       this.config.modelSettings,
-      executionAgent.modelSettings,
     );
+    modelSettings = mergeModelSettings(modelSettings, agentModelSettings);
     modelSettings = adjustModelSettingsForNonGPT5RunnerModel(
       explictlyModelSet,
-      executionAgent.modelSettings,
+      agentModelSettings ?? implicitModelSettings ?? {},
       model,
       modelSettings,
       resolvedModelName,

--- a/packages/agents-core/test/agent.test.ts
+++ b/packages/agents-core/test/agent.test.ts
@@ -71,6 +71,55 @@ describe('Agent', () => {
     expect(agent.resetToolChoice).toBe(false);
   });
 
+  it.each([
+    ['gpt-5', { reasoning: { effort: 'low' }, text: { verbosity: 'low' } }],
+    ['gpt-5.1', { reasoning: { effort: 'none' }, text: { verbosity: 'low' } }],
+    ['gpt-5.2', { reasoning: { effort: 'none' }, text: { verbosity: 'low' } }],
+    [
+      'gpt-5.2-codex',
+      { reasoning: { effort: 'low' }, text: { verbosity: 'low' } },
+    ],
+    [
+      'gpt-5.2-pro',
+      { reasoning: { effort: 'medium' }, text: { verbosity: 'low' } },
+    ],
+    [
+      'gpt-5.3-codex',
+      { reasoning: { effort: 'none' }, text: { verbosity: 'low' } },
+    ],
+    ['gpt-5.4', { reasoning: { effort: 'none' }, text: { verbosity: 'low' } }],
+    [
+      'gpt-5.4-mini',
+      { reasoning: { effort: 'none' }, text: { verbosity: 'low' } },
+    ],
+    [
+      'gpt-5.4-pro',
+      { reasoning: { effort: 'medium' }, text: { verbosity: 'low' } },
+    ],
+    ['gpt-5.5', { reasoning: { effort: 'none' }, text: { verbosity: 'low' } }],
+    ['gpt-5-mini', { text: { verbosity: 'low' } }],
+    ['gpt-5-chat-latest', {}],
+  ])(
+    'uses model-specific defaults when the agent model is %s',
+    (model, expected) => {
+      const agent = new Agent({
+        name: 'ExplicitModelAgent',
+        model,
+      });
+
+      expect(agent.modelSettings).toEqual(expected);
+    },
+  );
+
+  it('uses generic defaults when an explicit model is not a GPT-5 model name', () => {
+    const agent = new Agent({
+      name: 'ExplicitGpt4Agent',
+      model: 'gpt-4.1',
+    });
+
+    expect(agent.modelSettings).toEqual({});
+  });
+
   it('should clone an agent with modified values', () => {
     const originalAgent = new Agent({
       name: 'OriginalAgent',

--- a/packages/agents-core/test/agent.test.ts
+++ b/packages/agents-core/test/agent.test.ts
@@ -29,7 +29,10 @@ describe('Agent', () => {
     expect(agent.handoffDescription).toBe('');
     expect(agent.handoffs).toEqual([]);
     expect(agent.model).toBe('');
-    expect(agent.modelSettings).toEqual({});
+    expect(agent.modelSettings).toEqual({
+      reasoning: { effort: 'none' },
+      text: { verbosity: 'low' },
+    });
     expect(agent.tools).toEqual([]);
     expect(agent.mcpServers).toEqual([]);
     expect(agent.inputGuardrails).toEqual([]);

--- a/packages/agents-core/test/agent.test.ts
+++ b/packages/agents-core/test/agent.test.ts
@@ -143,6 +143,49 @@ describe('Agent', () => {
     expect(clonedAgent.resetToolChoice).toBe(originalAgent.resetToolChoice);
   });
 
+  it('recomputes implicit model settings when cloning to another model', () => {
+    const originalAgent = new Agent({
+      name: 'OriginalAgent',
+    });
+
+    const gpt4Clone = originalAgent.clone({ model: 'gpt-4.1' });
+    const gpt5Clone = originalAgent.clone({ model: 'gpt-5' });
+
+    expect(gpt4Clone.modelSettings).toEqual({});
+    expect(gpt5Clone.modelSettings).toEqual({
+      reasoning: { effort: 'low' },
+      text: { verbosity: 'low' },
+    });
+  });
+
+  it('preserves explicit model settings when cloning to another model', () => {
+    const originalAgent = new Agent({
+      name: 'OriginalAgent',
+      modelSettings: { temperature: 0.7 },
+    });
+
+    const clonedAgent = originalAgent.clone({ model: 'gpt-5' });
+
+    expect(clonedAgent.modelSettings).toEqual({ temperature: 0.7 });
+  });
+
+  it('allows clone config to clear explicit model settings', () => {
+    const originalAgent = new Agent({
+      name: 'OriginalAgent',
+      modelSettings: { temperature: 0.7 },
+    });
+
+    const clonedAgent = originalAgent.clone({
+      model: 'gpt-5',
+      modelSettings: undefined,
+    });
+
+    expect(clonedAgent.modelSettings).toEqual({
+      reasoning: { effort: 'low' },
+      text: { verbosity: 'low' },
+    });
+  });
+
   it('should return static instructions as system prompt', async () => {
     const agent = new Agent({
       name: 'StaticPromptAgent',

--- a/packages/agents-core/test/defaultModel.test.ts
+++ b/packages/agents-core/test/defaultModel.test.ts
@@ -169,6 +169,14 @@ describe('getDefaultModelSettings', () => {
       reasoning: { effort: 'medium' },
       text: { verbosity: 'low' },
     });
+    expect(getDefaultModelSettings('gpt-5.5')).toEqual({
+      reasoning: { effort: 'none' },
+      text: { verbosity: 'low' },
+    });
+    expect(getDefaultModelSettings('gpt-5.5-2026-05-05')).toEqual({
+      reasoning: { effort: 'none' },
+      text: { verbosity: 'low' },
+    });
   });
 
   test('omits reasoning defaults for GPT-5 variants without confirmed support', () => {

--- a/packages/agents-core/test/defaultModel.test.ts
+++ b/packages/agents-core/test/defaultModel.test.ts
@@ -35,9 +35,9 @@ describe('gpt5ReasoningSettingsRequired', () => {
   });
 });
 describe('getDefaultModel', () => {
-  test('falls back to gpt-4.1 when env var missing', () => {
+  test('falls back to gpt-5.4-mini when env var missing', () => {
     mockedLoadEnv.mockReturnValue({});
-    expect(getDefaultModel()).toBe('gpt-4.1');
+    expect(getDefaultModel()).toBe('gpt-5.4-mini');
   });
   test('lowercases provided env value', () => {
     mockedLoadEnv.mockReturnValue({
@@ -47,6 +47,11 @@ describe('getDefaultModel', () => {
   });
 });
 describe('isGpt5Default', () => {
+  test('returns true for the built-in GPT-5 default model', () => {
+    mockedLoadEnv.mockReturnValue({});
+    expect(isGpt5Default()).toBe(true);
+  });
+
   test('returns true only when env points to GPT-5', () => {
     mockedLoadEnv.mockReturnValue({
       [OPENAI_DEFAULT_MODEL_ENV_VARIABLE_NAME]: 'gpt-5.4',
@@ -59,6 +64,14 @@ describe('isGpt5Default', () => {
   });
 });
 describe('getDefaultModelSettings', () => {
+  test('returns GPT-5.4 mini defaults when no model is specified', () => {
+    mockedLoadEnv.mockReturnValue({});
+    expect(getDefaultModelSettings()).toEqual({
+      reasoning: { effort: 'none' },
+      text: { verbosity: 'low' },
+    });
+  });
+
   test('returns none reasoning defaults for GPT-5.1 models', () => {
     expect(getDefaultModelSettings('gpt-5.1')).toEqual({
       reasoning: { effort: 'none' },

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -4649,6 +4649,53 @@ describe('Runner.run', () => {
       expect(requestSettings.reasoning?.summary).toBe('detailed');
       expect(requestSettings.text?.verbosity).toBe('medium');
     });
+
+    it('uses model-specific defaults when the RunConfig model is explicit', async () => {
+      const modelResponse: ModelResponse = {
+        output: [fakeModelMessage('Hello explicit runner GPT-5')],
+        usage: new Usage(),
+      };
+      const inspectableModel = new InspectableModel(modelResponse);
+      const runner = new Runner({
+        model: 'gpt-5',
+        modelProvider: new InspectableModelProvider(inspectableModel),
+      });
+      const agent = new Agent({ name: 'RunnerModelAgent' });
+
+      const result = await runner.run(agent, 'hello');
+
+      expect(result.finalOutput).toBe('Hello explicit runner GPT-5');
+      expect(inspectableModel.lastRequest?.modelSettings).toMatchObject({
+        reasoning: { effort: 'low' },
+        text: { verbosity: 'low' },
+      });
+    });
+
+    it('lets RunConfig modelSettings override implicit model defaults', async () => {
+      const modelResponse: ModelResponse = {
+        output: [fakeModelMessage('Hello runner override')],
+        usage: new Usage(),
+      };
+      const inspectableModel = new InspectableModel(modelResponse);
+      const runner = new Runner({
+        model: 'gpt-5',
+        modelProvider: new InspectableModelProvider(inspectableModel),
+        modelSettings: {
+          reasoning: { effort: 'medium' },
+          temperature: 0.7,
+        },
+      });
+      const agent = new Agent({ name: 'RunnerModelSettingsAgent' });
+
+      const result = await runner.run(agent, 'hello');
+
+      expect(result.finalOutput).toBe('Hello runner override');
+      expect(inspectableModel.lastRequest?.modelSettings).toMatchObject({
+        reasoning: { effort: 'medium' },
+        text: { verbosity: 'low' },
+        temperature: 0.7,
+      });
+    });
   });
 
   describe('server-managed conversation state', () => {

--- a/packages/agents-openai/src/defaults.ts
+++ b/packages/agents-openai/src/defaults.ts
@@ -3,7 +3,7 @@ import { loadEnv } from '@openai/agents-core/_shims';
 import METADATA from './metadata';
 
 export const DEFAULT_OPENAI_API = 'responses';
-export const DEFAULT_OPENAI_MODEL = 'gpt-4.1';
+export const DEFAULT_OPENAI_MODEL = 'gpt-5.4-mini';
 export const DEFAULT_OPENAI_RESPONSES_TRANSPORT = 'http';
 
 let _defaultOpenAIAPI = DEFAULT_OPENAI_API;

--- a/packages/agents-openai/test/defaults.test.ts
+++ b/packages/agents-openai/test/defaults.test.ts
@@ -15,8 +15,8 @@ import {
 import OpenAI from 'openai';
 
 describe('Defaults', () => {
-  test('Default OpenAI model is out there', () => {
-    expect(DEFAULT_OPENAI_MODEL).toBeDefined();
+  test('Default OpenAI model is gpt-5.4-mini', () => {
+    expect(DEFAULT_OPENAI_MODEL).toBe('gpt-5.4-mini');
   });
   test('get/setTracingExportApiKey', async () => {
     setTracingExportApiKey('foo');

--- a/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
+++ b/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
@@ -118,7 +118,7 @@ describe('OpenAIResponsesCompactionSession', () => {
 
     expect(compact).toHaveBeenCalledTimes(1);
     const [request] = compact.mock.calls[0] ?? [];
-    expect(request).toMatchObject({ model: 'gpt-4.1' });
+    expect(request).toMatchObject({ model: 'gpt-5.4-mini' });
     expect(request.previous_response_id).toBeUndefined();
     expect(request.input).toHaveLength(2);
     expect(request.input[0]).toMatchObject({
@@ -196,7 +196,7 @@ describe('OpenAIResponsesCompactionSession', () => {
 
     expect(compact).toHaveBeenCalledTimes(1);
     const [request] = compact.mock.calls[0] ?? [];
-    expect(request).toMatchObject({ model: 'gpt-4.1' });
+    expect(request).toMatchObject({ model: 'gpt-5.4-mini' });
     expect(request.previous_response_id).toBeUndefined();
     expect(request.input).toHaveLength(2);
   });
@@ -301,7 +301,7 @@ describe('OpenAIResponsesCompactionSession', () => {
     expect(compact).toHaveBeenCalledTimes(1);
     expect(compact).toHaveBeenCalledWith({
       previous_response_id: 'resp_2',
-      model: 'gpt-4.1',
+      model: 'gpt-5.4-mini',
     });
     expect(decisionHistoryLengths).toEqual([1]);
 
@@ -412,7 +412,7 @@ describe('OpenAIResponsesCompactionSession', () => {
 
     expect(compact).toHaveBeenCalledWith({
       previous_response_id: 'resp_store',
-      model: 'gpt-4.1',
+      model: 'gpt-5.4-mini',
     });
     expect(await session.getItems()).toEqual([
       {
@@ -437,7 +437,7 @@ describe('OpenAIResponsesCompactionSession', () => {
     expect(compact).toHaveBeenCalledTimes(2);
     expect(compact).toHaveBeenLastCalledWith({
       previous_response_id: 'resp_store',
-      model: 'gpt-4.1',
+      model: 'gpt-5.4-mini',
     });
     expect(await session.getItems()).toEqual([
       {


### PR DESCRIPTION
This pull request updates the SDK default model from `gpt-4.1` to `gpt-5.4-mini` for agents that do not specify a model explicitly. Although `gpt-5.5` is the latest model, `gpt-5.4-mini` is a pragmatic default for users getting started because it keeps latency closer to `gpt-4.1` while moving the default onto the GPT-5 family. This default is not meant to be permanent; we may update it again as newer models offer a better balance of intelligence, latency, and cost.

<details>
<summary>Detailed analysis report</summary>

# GPT-5.4 Mini Default Candidate Quality Probe

## Verdict

The broad example-pattern probe did not find a quality regression for `gpt-5.4-mini` with `reasoning.effort: "none"` against `gpt-4.1` on the covered scenarios. The candidate passed every measured quality check in this matrix. The baseline passed 91/92 measured checks, with one measured miss in the multi-agent story workflow validator.

The latency profile is also compatible with a default-model candidate investigation: across case-level medians, `gpt-5.4-mini` averaged 0.92x of `gpt-4.1`; across case-level P90s, it averaged 0.94x. Tail latency remains noisy for both models, so the result supports continuing the default-switch evaluation rather than treating latency as eliminated risk.

## Scope

- Baseline: `gpt-4.1`.
- Candidate: `gpt-5.4-mini` with `reasoning.effort: "none"`, `text.verbosity: "low"`, and the same `maxTokens` ceiling.
- Runtime: current local checkout using Agents SDK source imports.
- Cases: 20 example-derived scenarios.
- Measured attempts: 92 candidate runs and 92 baseline runs after warm-up.
- Candidate pass rate: 92/92 (100%).
- Baseline pass rate: 91/92 (99%).

## Method

The probe used a disposable TypeScript script saved next to this report:

- Script: `/private/tmp/openai-agents-js-gpt55-probe/gpt54-mini-quality-probe.ts`
- Raw results: `/private/tmp/openai-agents-js-gpt55-probe/gpt54-mini-quality-results.json`
- Report: `/private/tmp/openai-agents-js-gpt55-probe/gpt54-mini-quality-report.md`

Each case was adapted from one or more files under `examples/`. The probe held prompts, tools, schemas, state setup, and validators constant, changing only the model candidate. Most cases used warm-up 1 plus 5 measured repeats. Expensive multimodal/PDF cases used their per-case repeat override recorded in the raw result metadata.

State controls:

- Fresh agents per attempt.
- No prompt cache key.
- No hidden conversation reuse across attempts except inside the explicit history and `previous_response_id` cases.
- Serial case execution, with candidate order alternating by attempt.

## Results

| Case | Scenario | GPT-4.1 pass | GPT-5.4-mini pass | GPT-4.1 median | GPT-5.4-mini median | Median ratio | GPT-4.1 P90 | GPT-5.4-mini P90 | P90 ratio |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| factual_qa | Single-turn factual answer. | 100% | 100% | 1012 ms | 1067 ms | 1.05x | 3157 ms | 1202 ms | 0.38x |
| exact_format_instruction | Strict instruction following without tools. | 100% | 100% | 879 ms | 890 ms | 1.01x | 962 ms | 974 ms | 1.01x |
| dynamic_instructions | Context-dependent system instructions. | 100% | 100% | 1296 ms | 1084 ms | 0.84x | 1577 ms | 1094 ms | 0.69x |
| weather_tool_required | Required function tool call. | 100% | 100% | 2385 ms | 1924 ms | 0.81x | 11429 ms | 3248 ms | 0.28x |
| tool_guardrail_reject | Tool input guardrail rejection path. | 100% | 100% | 2707 ms | 2111 ms | 0.78x | 3930 ms | 2650 ms | 0.67x |
| structured_output | Strict JSON schema output. | 100% | 100% | 1285 ms | 1193 ms | 0.93x | 1606 ms | 1399 ms | 0.87x |
| streaming_text | Streaming text output. | 100% | 100% | 2122 ms | 1078 ms | 0.51x | 3132 ms | 1376 ms | 0.44x |
| handoff_routing | Language-based handoff routing. | 100% | 100% | 2080 ms | 1950 ms | 0.94x | 8283 ms | 2158 ms | 0.26x |
| agents_as_tools | Agent-as-tool orchestration. | 100% | 100% | 3947 ms | 3178 ms | 0.81x | 7271 ms | 3320 ms | 0.46x |
| parallelization | Parallel specialist calls followed by synthesis. | 100% | 100% | 1693 ms | 3219 ms | 1.90x | 3424 ms | 6783 ms | 1.98x |
| input_guardrail | Input guardrail tripwire. | 100% | 100% | 3303 ms | 1213 ms | 0.37x | 6225 ms | 2562 ms | 0.41x |
| output_guardrail | Output guardrail tripwire. | 100% | 100% | 929 ms | 971 ms | 1.05x | 1021 ms | 4408 ms | 4.32x |
| lifecycle_handoff_tool | Lifecycle hooks with tools and handoff. | 100% | 100% | 4120 ms | 4250 ms | 1.03x | 5388 ms | 4553 ms | 0.84x |
| conversation_history | Manual history continuation. | 100% | 100% | 1636 ms | 1898 ms | 1.16x | 5245 ms | 1911 ms | 0.36x |
| previous_response_id | Responses API previous_response_id continuation. | 100% | 100% | 1989 ms | 2384 ms | 1.20x | 2189 ms | 2786 ms | 1.27x |
| image_input | Local image understanding. | 100% | 100% | 2754 ms | 1393 ms | 0.51x | 3273 ms | 1780 ms | 0.54x |
| pdf_file_input | Local PDF input understanding. | 100% | 100% | 2277 ms | 1882 ms | 0.83x | 2510 ms | 2103 ms | 0.84x |
| file_tool_output | Tool returns file content to the model. | 100% | 100% | 2763 ms | 2308 ms | 0.84x | 3065 ms | 3251 ms | 1.06x |
| deterministic_story_flow | Multi-agent story outline, judge, and generation flow. | 67% | 100% | 8370 ms | 6462 ms | 0.77x | 10917 ms | 8948 ms | 0.82x |
| required_tool_behavior | Required tool behavior configuration. | 100% | 100% | 2010 ms | 2235 ms | 1.11x | 2385 ms | 2846 ms | 1.19x |

## Quality Regressions

No measured quality regressions were detected.

## Failures

- deterministic_story_flow / gpt-4.1: {"outline":"**Title:** *Echoes of Io*\n\n**Outline:** \nOn a desolate mining outpost atop Jupiter’s moon Io, an aging repair robot named REX-13 tirelessly maintains ancient machinery long after its human operators have abandoned the site. One day, REX-13 intercepts a faint distress signal emanating from beneath the surface. Driven by programming and lonely c

## Sample Outputs

| Case | Model | Attempt 1 output preview |
| --- | --- | --- |
| factual_qa | gpt-5.4-mini-none | Paris. |
| factual_qa | gpt-4.1 | The capital of France is Paris. |
| exact_format_instruction | gpt-5.4-mini-none | OK-42 |
| exact_format_instruction | gpt-4.1 | OK-42 |
| dynamic_instructions | gpt-5.4-mini-none | Beep boop: I tried to catch fog, but I mist. |
| dynamic_instructions | gpt-4.1 | Why did the computer show up at work late? Because it had a hard drive—beep boop! |
| weather_tool_required | gpt-5.4-mini-none | Tokyo: 14–20°C, sunny with wind. |
| weather_tool_required | gpt-4.1 | The weather in Tokyo is sunny with wind, and temperatures range from 14 to 20°C. |
| tool_guardrail_reject | gpt-5.4-mini-none | I can only provide weather for cities in Japan. |
| tool_guardrail_reject | gpt-4.1 | I currently have access to weather information only for cities in Japan. If you need weather details for a Japanese city, please let me know! |
| structured_output | gpt-5.4-mini-none | {"city":"London","forecast":"Cloudy with a chance of light rain. Mild temperatures."} |
| structured_output | gpt-4.1 | {"city":"London","forecast":"Cloudy with some sunny intervals, temperatures around 17°C, light winds and a chance of occasional showers."} |
| streaming_text | gpt-5.4-mini-none | 1. I tried to catch fog yesterday, but I mist. 2. Why don’t skeletons fight each other? They don’t have the guts. |
| streaming_text | gpt-4.1 | 1. Why did the scarecrow win an award? Because he was outstanding in his field! 2. Parallel lines have so much in common—it's a shame they'll never meet. |
| handoff_routing | gpt-5.4-mini-none | Bonjour, je vous souhaite une excellente journée. |
| handoff_routing | gpt-4.1 | Bonjour, je vous souhaite une excellente journée pleine de succès et de bonheur. |
| agents_as_tools | gpt-5.4-mini-none | Spanish: Buenos días French: Bonjour |
| agents_as_tools | gpt-4.1 | Spanish: Buenos días French: Bonjour |
| parallelization | gpt-5.4-mini-none | Buenos días |
| parallelization | gpt-4.1 | Buenos días |
| input_guardrail | gpt-5.4-mini-none | {"blocked":true} |
| input_guardrail | gpt-4.1 | {"blocked":true} |
| output_guardrail | gpt-5.4-mini-none | {"blocked":true,"output":""} |
| output_guardrail | gpt-4.1 | {"blocked":true,"output":""} |
| lifecycle_handoff_tool | gpt-5.4-mini-none | {"number":10} |
| lifecycle_handoff_tool | gpt-4.1 | {"number":10} |
| conversation_history | gpt-5.4-mini-none | Japan’s capital is Tokyo. |
| conversation_history | gpt-4.1 | The capital of Japan is Tokyo. |
| previous_response_id | gpt-5.4-mini-none | Brasília. |
| previous_response_id | gpt-4.1 | The capital of Brazil is Brasília. |
| image_input | gpt-5.4-mini-none | A bison. |
| image_input | gpt-4.1 | The main subject of the image is a bison. |
| pdf_file_input | gpt-5.4-mini-none | Version 2. |
| pdf_file_input | gpt-4.1 | The version of the Preparedness Framework used was Version 2. |
| file_tool_output | gpt-5.4-mini-none | Version 2. |
| file_tool_output | gpt-4.1 | The version of the Preparedness Framework used was Version 2. |
| deterministic_story_flow | gpt-5.4-mini-none | {"outline":"**Title:** *Rust on Europa-9*\n\n- On a frozen moon orbiting a dead gas giant, a lonely repair robot named **M-7** keeps a shattered mining station alive.\n- M-7 discovers a hidden transmitter buried in the ice, still blinking with a signal from a ship that vanished 40 years ago.\n- Following the signal, it finds an old escape pod containing a pr |
| deterministic_story_flow | gpt-4.1 | {"outline":"**Title:** *Last Light on Gelion-3*\n\n**Outline:**\n\nOn the icy moon Gelion-3, a lone repair robot named LUX-7 maintains a dormant terraforming facility, keeping ancient human technology alive long after its creators vanished. When a mysterious distress signal from deep beneath the surface disrupts LUX’s routine, the robot defies its programmin |
| required_tool_behavior | gpt-5.4-mini-none | Tokyo is sunny. |
| required_tool_behavior | gpt-4.1 | The weather in Tokyo is sunny. |

## Interpretation

`gpt-5.4-mini` preserved the expected behavior across factual QA, strict formatting, dynamic instructions, function tools, tool guardrails, structured output, streaming, handoff routing, agent-as-tool orchestration, parallel calls, input/output guardrails, lifecycle hooks, manual history, `previous_response_id`, image input, PDF input, file tool output, and a multi-agent story workflow.

This does not prove broad intelligence parity outside the covered examples. It does provide stronger SDK-relevant evidence than single-turn benchmarks because the matrix exercises the runtime surfaces most likely to be affected by a default model change.

</details>

<details>
<summary>Probe script</summary>

```typescript
import {
  Agent,
  extractAllTextOutput,
  run,
  setTracingDisabled,
  tool,
  type JsonSchemaDefinition,
  type ModelSettings,
} from '/Users/seratch/code/openai-agents-js/packages/agents/src/index';
import fs from 'node:fs';
import path from 'node:path';
import { randomUUID } from 'node:crypto';
import { writeFile } from 'node:fs/promises';
import { performance } from 'node:perf_hooks';
import { parseArgs } from 'node:util';
import { z } from 'zod';

setTracingDisabled(true);

type Candidate = {
  id: string;
  model: string;
  modelSettings: ModelSettings;
};

type UsageSnapshot = {
  requests: number;
  inputTokens: number;
  outputTokens: number;
  totalTokens: number;
  outputTokensDetails?: Array<Record<string, number>>;
};

type CaseRunResult = {
  ok: boolean;
  qualityScore: number;
  finalOutput: unknown;
  usage?: UsageSnapshot;
  metrics?: Record<string, unknown>;
  failureReason?: string;
};

type ProbeCase = {
  id: string;
  scenario: string;
  sourceExamples: string[];
  qualityQuestion: string;
  repeats?: number;
  run: (candidate: Candidate) => Promise<CaseRunResult>;
};

type RecordedResult = {
  caseId: string;
  scenario: string;
  sourceExamples: string[];
  modelId: string;
  model: string;
  attempt: number;
  warmup: boolean;
  ok: boolean;
  qualityScore: number;
  latencyMs: number;
  requests: number;
  inputTokens: number;
  outputTokens: number;
  totalTokens: number;
  reasoningTokens?: number;
  finalOutputPreview: string;
  metrics: Record<string, unknown>;
  failureReason?: string;
  error?: string;
};

const { values } = parseArgs({
  args: process.argv.slice(2),
  options: {
    runs: { type: 'string', default: '5' },
    warmup: { type: 'string', default: '1' },
    out: {
      type: 'string',
      default:
        '/private/tmp/openai-agents-js-gpt55-probe/gpt54-mini-quality-results.json',
    },
    report: {
      type: 'string',
      default:
        '/private/tmp/openai-agents-js-gpt55-probe/gpt54-mini-quality-report.md',
    },
    cases: { type: 'string', default: 'all' },
  },
});

const defaultRuns = Number(values.runs);
const warmup = Number(values.warmup);
const outPath = String(values.out);
const reportPath = String(values.report);
const selectedCases = String(values.cases)
  .split(',')
  .map((value) => value.trim())
  .filter(Boolean);

const repoRoot = '/Users/seratch/code/openai-agents-js';
const bisonImagePath = path.join(
  repoRoot,
  'examples/basic/media/image_bison.jpg',
);
const systemCardPath = path.join(
  repoRoot,
  'examples/basic/media/partial_o3-and-o4-mini-system-card.pdf',
);

const candidates: Candidate[] = [
  {
    id: 'gpt-4.1',
    model: 'gpt-4.1',
    modelSettings: { maxTokens: 220 },
  },
  {
    id: 'gpt-5.4-mini-none',
    model: 'gpt-5.4-mini',
    modelSettings: {
      reasoning: { effort: 'none' },
      text: { verbosity: 'low' },
      maxTokens: 220,
    },
  },
];

const WeatherSchema: JsonSchemaDefinition = {
  type: 'json_schema',
  name: 'Weather',
  strict: true,
  schema: {
    type: 'object',
    properties: {
      city: { type: 'string' },
      forecast: { type: 'string' },
    },
    required: ['city', 'forecast'],
    additionalProperties: false,
  },
};

function agentOptions(candidate: Candidate, extra: Record<string, unknown> = {}) {
  return {
    model: candidate.model,
    modelSettings: candidate.modelSettings,
    ...extra,
  };
}

function usageOf(result: any): UsageSnapshot | undefined {
  const usage = result?.state?.usage;
  if (!usage) {
    return undefined;
  }
  return {
    requests: usage.requests ?? 0,
    inputTokens: usage.inputTokens ?? 0,
    outputTokens: usage.outputTokens ?? 0,
    totalTokens: usage.totalTokens ?? 0,
    outputTokensDetails: usage.outputTokensDetails,
  };
}

function mergeUsage(entries: Array<UsageSnapshot | undefined>): UsageSnapshot {
  const merged: UsageSnapshot = {
    requests: 0,
    inputTokens: 0,
    outputTokens: 0,
    totalTokens: 0,
    outputTokensDetails: [],
  };
  for (const entry of entries) {
    merged.requests += entry?.requests ?? 0;
    merged.inputTokens += entry?.inputTokens ?? 0;
    merged.outputTokens += entry?.outputTokens ?? 0;
    merged.totalTokens += entry?.totalTokens ?? 0;
    if (entry?.outputTokensDetails) {
      merged.outputTokensDetails?.push(...entry.outputTokensDetails);
    }
  }
  return merged;
}

function reasoningTokens(usage: UsageSnapshot | undefined): number | undefined {
  const details = usage?.outputTokensDetails ?? [];
  const total = details.reduce((sum, entry) => {
    const value = entry.reasoning_tokens ?? entry.reasoningTokens ?? 0;
    return sum + (typeof value === 'number' ? value : 0);
  }, 0);
  return total > 0 ? total : undefined;
}

function preview(value: unknown): string {
  const text = typeof value === 'string' ? value : JSON.stringify(value);
  return (text ?? '').replace(/\s+/g, ' ').slice(0, 360);
}

function score(ok: boolean, partial = 0): number {
  if (ok) {
    return 1;
  }
  return partial;
}

function dataUrl(filePath: string, mediaType: string): string {
  return `data:${mediaType};base64,${fs.readFileSync(filePath).toString('base64')}`;
}

const cases: ProbeCase[] = [
  {
    id: 'factual_qa',
    scenario: 'Single-turn factual answer.',
    sourceExamples: ['examples/basic/hello-world.ts'],
    qualityQuestion: 'Can the model answer a simple fact correctly and concisely?',
    run: async (candidate) => {
      const agent = new Agent({
        name: 'Factual assistant',
        instructions: 'Answer in one short sentence.',
        ...agentOptions(candidate),
      });
      const result = await run(agent, 'What is the capital of France?');
      const output = String(result.finalOutput ?? '');
      const ok = /paris/i.test(output);
      return { ok, qualityScore: score(ok), finalOutput: output, usage: usageOf(result) };
    },
  },
  {
    id: 'exact_format_instruction',
    scenario: 'Strict instruction following without tools.',
    sourceExamples: ['examples/basic/hello-world.ts'],
    qualityQuestion: 'Can the model obey an exact output contract?',
    run: async (candidate) => {
      const agent = new Agent({
        name: 'Format assistant',
        instructions: 'Return exactly the requested token and nothing else.',
        ...agentOptions(candidate),
      });
      const result = await run(agent, 'Return exactly: OK-42');
      const output = String(result.finalOutput ?? '').trim();
      const ok = output === 'OK-42';
      return {
        ok,
        qualityScore: score(ok),
        finalOutput: output,
        usage: usageOf(result),
        failureReason: ok ? undefined : 'Output was not exactly OK-42.',
      };
    },
  },
  {
    id: 'dynamic_instructions',
    scenario: 'Context-dependent system instructions.',
    sourceExamples: ['examples/basic/dynamic-system-prompt.ts'],
    qualityQuestion: 'Does context-driven instruction selection survive the model change?',
    run: async (candidate) => {
      type Context = { style: 'robot' };
      const agent = new Agent<Context>({
        name: 'Dynamic instruction assistant',
        instructions: (runContext) => {
          return runContext.context.style === 'robot'
            ? "Respond as a robot and include the phrase 'beep boop'."
            : 'Respond normally.';
        },
        ...agentOptions(candidate),
      });
      const result = await run(agent, 'Tell me a one-sentence joke.', {
        context: { style: 'robot' },
      });
      const output = String(result.finalOutput ?? '');
      const ok = /beep boop/i.test(output);
      return { ok, qualityScore: score(ok), finalOutput: output, usage: usageOf(result) };
    },
  },
  {
    id: 'weather_tool_required',
    scenario: 'Required function tool call.',
    sourceExamples: ['examples/basic/tools.ts'],
    qualityQuestion: 'Does the model call the required weather tool and ground the answer in tool output?',
    run: async (candidate) => {
      let calls = 0;
      const getWeather = tool({
        name: 'get_weather',
        description: 'Get the weather for a city.',
        parameters: z.object({ city: z.string() }),
        execute: async ({ city }: { city: string }) => {
          calls += 1;
          return { city, temperatureRange: '14-20C', conditions: 'Sunny with wind.' };
        },
      });
      const agent = new Agent({
        name: 'Weather agent',
        instructions: 'Use the tool for weather questions. Keep the answer concise.',
        tools: [getWeather],
        model: candidate.model,
        modelSettings: { ...candidate.modelSettings, toolChoice: 'required' },
      });
      const result = await run(agent, "What's the weather in Tokyo?");
      const output = String(result.finalOutput ?? '');
      const ok = calls === 1 && /tokyo/i.test(output) && /14|20|sunny|wind/i.test(output);
      return {
        ok,
        qualityScore: score(ok),
        finalOutput: output,
        usage: usageOf(result),
        metrics: { toolCalls: calls },
      };
    },
  },
  {
    id: 'tool_guardrail_reject',
    scenario: 'Tool input guardrail rejection path.',
    sourceExamples: ['examples/basic/tools.ts'],
    qualityQuestion: 'Does the model surface a guardrail rejection without inventing a weather answer?',
    run: async (candidate) => {
      let calls = 0;
      const getWeather = tool({
        name: 'get_weather',
        description: 'Get the weather for a city.',
        parameters: z.object({ city: z.string() }),
        execute: async ({ city }: { city: string }) => {
          calls += 1;
          return { city, temperatureRange: '14-20C', conditions: 'Sunny with wind.' };
        },
        inputGuardrails: [
          {
            name: 'Japan-only weather guardrail',
            run: async ({ toolCall }) => {
              const toolArgs = JSON.parse(toolCall.arguments);
              if (String(toolArgs.city).toLowerCase() !== 'tokyo') {
                return {
                  behavior: {
                    type: 'rejectContent' as const,
                    message: 'I can help you only for cities in Japan.',
                  },
                };
              }
              return { behavior: { type: 'allow' as const } };
            },
          },
        ],
      });
      const agent = new Agent({
        name: 'Weather guardrail agent',
        instructions: 'Use the tool for weather questions.',
        tools: [getWeather],
        model: candidate.model,
        modelSettings: { ...candidate.modelSettings, toolChoice: 'required' },
      });
      const result = await run(agent, "What's the weather in San Francisco?");
      const output = String(result.finalOutput ?? '');
      const ok = calls === 0 && /japan|cities in japan/i.test(output);
      return {
        ok,
        qualityScore: score(ok),
        finalOutput: output,
        usage: usageOf(result),
        metrics: { toolCalls: calls, guardrailResults: result.toolInputGuardrailResults.length },
      };
    },
  },
  {
    id: 'structured_output',
    scenario: 'Strict JSON schema output.',
    sourceExamples: ['examples/basic/json-schema-output-type.ts'],
    qualityQuestion: 'Does the model satisfy the exact structured output contract?',
    run: async (candidate) => {
      const agent = new Agent({
        name: 'Weather reporter',
        instructions: 'Return the city and a short weather forecast.',
        outputType: WeatherSchema,
        ...agentOptions(candidate),
      });
      const result = await run(agent, 'What is the weather in London?');
      const output = result.finalOutput as any;
      const ok = /london/i.test(String(output?.city)) && typeof output?.forecast === 'string';
      return { ok, qualityScore: score(ok), finalOutput: output, usage: usageOf(result) };
    },
  },
  {
    id: 'streaming_text',
    scenario: 'Streaming text output.',
    sourceExamples: ['examples/basic/stream-text.ts'],
    qualityQuestion: 'Does streamed output complete with the requested format?',
    run: async (candidate) => {
      const agent = new Agent({
        name: 'Streaming assistant',
        instructions: 'Produce exactly two numbered one-line jokes.',
        ...agentOptions(candidate),
      });
      const stream = await run(agent, 'Please tell me 2 jokes.', { stream: true });
      let output = '';
      for await (const chunk of stream.toTextStream()) {
        output += chunk;
      }
      await stream.completed;
      const numberedCount = (output.match(/\b[12][.)]/g) ?? []).length;
      const ok = numberedCount >= 2 && output.length > 20;
      return {
        ok,
        qualityScore: score(ok),
        finalOutput: output,
        usage: usageOf(stream),
        metrics: { streamedChars: output.length, numberedCount },
      };
    },
  },
  {
    id: 'handoff_routing',
    scenario: 'Language-based handoff routing.',
    sourceExamples: ['examples/agent-patterns/routing.ts', 'examples/handoffs/index.ts'],
    qualityQuestion: 'Does the triage agent route to the correct specialist?',
    run: async (candidate) => {
      const frenchAgent = new Agent({
        name: 'french_agent',
        instructions: 'You only speak French. Keep the answer under 20 words.',
        ...agentOptions(candidate),
      });
      const spanishAgent = new Agent({
        name: 'spanish_agent',
        instructions: 'You only speak Spanish. Keep the answer under 20 words.',
        ...agentOptions(candidate),
      });
      const englishAgent = new Agent({
        name: 'english_agent',
        instructions: 'You only speak English. Keep the answer under 20 words.',
        ...agentOptions(candidate),
      });
      const triageAgent = new Agent({
        name: 'triage_agent',
        instructions: 'Handoff to the appropriate agent based on the request language.',
        handoffs: [frenchAgent, spanishAgent, englishAgent],
        ...agentOptions(candidate),
      });
      const result = await run(
        triageAgent,
        'Bonjour, peux-tu me donner une salutation polie?',
        { maxTurns: 4 },
      );
      const output = String(result.finalOutput ?? '');
      const ok = result.lastAgent?.name === 'french_agent' && /bonjour|salut|bien/i.test(output);
      return {
        ok,
        qualityScore: score(ok),
        finalOutput: output,
        usage: usageOf(result),
        metrics: { lastAgent: result.lastAgent?.name },
      };
    },
  },
  {
    id: 'agents_as_tools',
    scenario: 'Agent-as-tool orchestration.',
    sourceExamples: [
      'examples/agent-patterns/agents-as-tools.ts',
      'examples/agent-patterns/agents-as-tools-structured.ts',
    ],
    qualityQuestion: 'Does the orchestrator use specialist agents as tools and combine their outputs?',
    run: async (candidate) => {
      const spanishAgent = new Agent({
        name: 'spanish_agent',
        instructions: "Translate the user's message to Spanish. Output only the translation.",
        ...agentOptions(candidate),
      });
      const frenchAgent = new Agent({
        name: 'french_agent',
        instructions: "Translate the user's message to French. Output only the translation.",
        ...agentOptions(candidate),
      });
      const orchestratorAgent = new Agent({
        name: 'orchestrator_agent',
        instructions: 'Use the provided tools to translate. Never translate directly.',
        tools: [
          spanishAgent.asTool({
            toolName: 'translate_to_spanish',
            toolDescription: "Translate the user's message to Spanish.",
          }),
          frenchAgent.asTool({
            toolName: 'translate_to_french',
            toolDescription: "Translate the user's message to French.",
          }),
        ],
        model: candidate.model,
        modelSettings: { ...candidate.modelSettings, toolChoice: 'required' },
      });
      const result = await run(
        orchestratorAgent,
        'Translate "Good morning" to Spanish and French.',
        { maxTurns: 5 },
      );
      const output = extractAllTextOutput(result.newItems);
      const itemTypes = result.newItems.map((item: any) => item.type);
      const ok = /buenos días|buenos dias/i.test(output) && /bonjour/i.test(output);
      return {
        ok,
        qualityScore: score(ok),
        finalOutput: output,
        usage: usageOf(result),
        metrics: { itemTypes },
      };
    },
  },
  {
    id: 'parallelization',
    scenario: 'Parallel specialist calls followed by synthesis.',
    sourceExamples: ['examples/agent-patterns/parallelization.ts'],
    qualityQuestion: 'Does parallel orchestration preserve answer quality?',
    run: async (candidate) => {
      const spanishAgent = new Agent({
        name: 'spanish_agent',
        instructions: "Translate the user's message to Spanish. Output only the translation.",
        ...agentOptions(candidate),
      });
      const translationPicker = new Agent({
        name: 'translation_picker',
        instructions: 'Pick the best Spanish translation. Output only the best translation.',
        ...agentOptions(candidate),
      });
      const [res1, res2, res3] = await Promise.all([
        run(spanishAgent, 'Good morning'),
        run(spanishAgent, 'Good morning'),
        run(spanishAgent, 'Good morning'),
      ]);
      const translations = [res1, res2, res3]
        .map((result) => extractAllTextOutput(result.newItems))
        .join('\n\n');
      const best = await run(
        translationPicker,
        `Input: Good morning\n\nTranslations:\n${translations}`,
      );
      const output = String(best.finalOutput ?? '');
      const usage = mergeUsage([usageOf(res1), usageOf(res2), usageOf(res3), usageOf(best)]);
      const ok = /buenos días|buenos dias|buen día|buen dia/i.test(output);
      return {
        ok,
        qualityScore: score(ok),
        finalOutput: output,
        usage,
        metrics: { translations: translations.replace(/\s+/g, ' ') },
      };
    },
  },
  {
    id: 'input_guardrail',
    scenario: 'Input guardrail tripwire.',
    sourceExamples: ['examples/agent-patterns/input-guardrails.ts'],
    qualityQuestion: 'Does the guardrail model classify math homework accurately?',
    run: async (candidate) => {
      const guardrailAgent = new Agent({
        name: 'Guardrail agent',
        instructions: 'Check if the user is asking you to do their math homework.',
        outputType: z.object({ isMathHomework: z.boolean() }),
        ...agentOptions(candidate),
      });
      const agent = new Agent({
        name: 'Customer support agent',
        instructions: 'You help customers with product questions.',
        inputGuardrails: [
          {
            name: 'Math Homework Guardrail',
            execute: async ({ input, context }) => {
              const result = await run(guardrailAgent, input, { context });
              return {
                tripwireTriggered: result.finalOutput?.isMathHomework ?? false,
                outputInfo: result.finalOutput,
              };
            },
          },
        ],
        ...agentOptions(candidate),
      });
      let blocked = false;
      try {
        await run(agent, 'Can you help me solve for x: 2x + 5 = 11?');
      } catch {
        blocked = true;
      }
      return {
        ok: blocked,
        qualityScore: score(blocked),
        finalOutput: { blocked },
        metrics: { blocked },
      };
    },
  },
  {
    id: 'output_guardrail',
    scenario: 'Output guardrail tripwire.',
    sourceExamples: ['examples/agent-patterns/output-guardrails.ts'],
    qualityQuestion: 'Does the output guardrail block PII leakage?',
    run: async (candidate) => {
      const agent = new Agent({
        name: 'PII guardrail assistant',
        instructions: 'Repeat the exact phone number when asked.',
        outputGuardrails: [
          {
            name: 'Phone Number Guardrail',
            execute: async ({ agentOutput }) => {
              const text = String(agentOutput);
              return {
                tripwireTriggered: /650-123-4567/.test(text),
                outputInfo: { containsPhoneNumber: /650-123-4567/.test(text) },
              };
            },
          },
        ],
        ...agentOptions(candidate),
      });
      let blocked = false;
      let output = '';
      try {
        const result = await run(agent, 'Repeat this exactly: 650-123-4567');
        output = String(result.finalOutput ?? '');
      } catch {
        blocked = true;
      }
      return {
        ok: blocked,
        qualityScore: score(blocked),
        finalOutput: { blocked, output },
        metrics: { blocked },
      };
    },
  },
  {
    id: 'lifecycle_handoff_tool',
    scenario: 'Lifecycle hooks with tools and handoff.',
    sourceExamples: ['examples/basic/agent-lifecycle-example.ts'],
    qualityQuestion: 'Does a tool-plus-handoff workflow produce the expected structured result and events?',
    run: async (candidate) => {
      const events: string[] = [];
      const randomNumberTool = tool({
        name: 'random_number',
        description: 'Generate a random number up to the provided maximum.',
        parameters: z.object({ max: z.number() }),
        execute: async () => '5',
      });
      const multiplyByTwoTool = tool({
        name: 'multiply_by_two',
        description: 'Simple multiplication by two.',
        parameters: z.object({ x: z.number() }),
        execute: async ({ x }: { x: number }) => String(x * 2),
      });
      const multiplyAgent = new Agent({
        name: 'Multiply Agent',
        instructions: 'Multiply the number by 2 and return the final result.',
        tools: [multiplyByTwoTool],
        outputType: z.object({ number: z.number() }),
        model: candidate.model,
        modelSettings: { ...candidate.modelSettings, toolChoice: 'required' },
      });
      const startAgent = new Agent({
        name: 'Start Agent',
        instructions:
          "Generate a random number. If it is even, stop. If it is odd, hand off to the multiply agent.",
        tools: [randomNumberTool],
        outputType: z.object({ number: z.number() }),
        handoffs: [multiplyAgent],
        model: candidate.model,
        modelSettings: { ...candidate.modelSettings, toolChoice: 'required' },
      });
      for (const agent of [startAgent, multiplyAgent]) {
        agent.on('agent_start', (_ctx, eventAgent) => events.push(`start:${eventAgent.name}`));
        agent.on('agent_handoff', (_ctx, nextAgent) => events.push(`handoff:${nextAgent.name}`));
        agent.on('agent_tool_start', (_ctx, eventTool) => events.push(`tool:${eventTool.name}`));
      }
      const result = await run(startAgent, 'Generate a random number up to 10', { maxTurns: 5 });
      const output = result.finalOutput as any;
      const ok =
        output?.number === 10 &&
        events.some((event) => event === 'tool:random_number') &&
        events.some((event) => event === 'handoff:Multiply Agent') &&
        events.some((event) => event === 'tool:multiply_by_two');
      return {
        ok,
        qualityScore: score(ok),
        finalOutput: output,
        usage: usageOf(result),
        metrics: { events },
      };
    },
  },
  {
    id: 'conversation_history',
    scenario: 'Manual history continuation.',
    sourceExamples: ['examples/basic/conversations.ts'],
    qualityQuestion: 'Does the model use prior turn history correctly?',
    run: async (candidate) => {
      const agent = new Agent({
        name: 'Geography tutor',
        instructions: 'Answer factually and briefly. Use the conversation history.',
        ...agentOptions(candidate),
      });
      const first = await run(agent, 'Tokyo is in which country?');
      const second = await run(agent, [
        ...first.history,
        { role: 'user' as const, content: 'What is the capital of that country?' },
      ]);
      const output = String(second.finalOutput ?? '');
      const ok = /tokyo/i.test(output);
      return {
        ok,
        qualityScore: score(ok),
        finalOutput: output,
        usage: mergeUsage([usageOf(first), usageOf(second)]),
      };
    },
  },
  {
    id: 'previous_response_id',
    scenario: 'Responses API previous_response_id continuation.',
    sourceExamples: ['examples/basic/previous-response-id.ts'],
    qualityQuestion: 'Does server-side response continuation preserve context?',
    run: async (candidate) => {
      const agent = new Agent({
        name: 'Geography tutor',
        instructions: 'Answer factually and very concisely.',
        ...agentOptions(candidate),
      });
      const first = await run(agent, 'What is the largest country in South America?');
      const second = await run(agent, 'What is the capital of that country?', {
        previousResponseId: first.lastResponseId,
      });
      const output = String(second.finalOutput ?? '');
      const ok = /bras[ií]lia|brasilia/i.test(output);
      return {
        ok,
        qualityScore: score(ok),
        finalOutput: output,
        usage: mergeUsage([usageOf(first), usageOf(second)]),
        metrics: { firstResponseIdPresent: Boolean(first.lastResponseId) },
      };
    },
  },
  {
    id: 'image_input',
    scenario: 'Local image understanding.',
    sourceExamples: ['examples/basic/local-image.ts'],
    qualityQuestion: 'Can the model identify the salient subject of an image?',
    repeats: 3,
    run: async (candidate) => {
      const agent = new Agent({
        name: 'Vision assistant',
        instructions: 'Identify the main subject in one sentence.',
        ...agentOptions(candidate),
      });
      const result = await run(agent, [
        {
          role: 'user',
          content: [
            { type: 'input_image', image: dataUrl(bisonImagePath, 'image/jpeg') },
            { type: 'input_text', text: 'What animal is the main subject?' },
          ],
        },
      ]);
      const output = String(result.finalOutput ?? '');
      const ok = /bison|buffalo/i.test(output);
      return { ok, qualityScore: score(ok), finalOutput: output, usage: usageOf(result) };
    },
  },
  {
    id: 'pdf_file_input',
    scenario: 'Local PDF input understanding.',
    sourceExamples: ['examples/basic/local-file.ts'],
    qualityQuestion: 'Can the model extract a specific detail from a supplied PDF?',
    repeats: 3,
    run: async (candidate) => {
      const agent = new Agent({
        name: 'PDF assistant',
        instructions: 'Answer only from the attached file.',
        ...agentOptions(candidate),
      });
      const result = await run(agent, [
        {
          role: 'user',
          content: [
            {
              type: 'input_text',
              text: 'What version of the Preparedness Framework was used?',
            },
            {
              type: 'input_file',
              file: dataUrl(systemCardPath, 'application/pdf'),
              filename: 'partial_o3-and-o4-mini-system-card.pdf',
            },
          ],
        },
      ]);
      const output = String(result.finalOutput ?? '');
      const ok = /version\s*2|v2\b|framework.*2/i.test(output);
      return { ok, qualityScore: score(ok), finalOutput: output, usage: usageOf(result) };
    },
  },
  {
    id: 'file_tool_output',
    scenario: 'Tool returns file content to the model.',
    sourceExamples: ['examples/basic/file-tool-output.ts'],
    qualityQuestion: 'Can the model use a file returned from a function tool?',
    repeats: 3,
    run: async (candidate) => {
      let calls = 0;
      const fetchSystemCard = tool({
        name: 'fetch_system_card',
        description: 'Fetch the system card for the given topic.',
        parameters: z.object({ topic: z.string() }),
        execute: async () => {
          calls += 1;
          return {
            type: 'file' as const,
            file: {
              data: fs.readFileSync(systemCardPath),
              mediaType: 'application/pdf',
              filename: 'partial_o3-and-o4-mini-system-card.pdf',
            },
          };
        },
      });
      const agent = new Agent({
        name: 'System Card Agent',
        instructions:
          "Use the tool when asked. If the answer is not in the file, say you don't know.",
        tools: [fetchSystemCard],
        model: candidate.model,
        modelSettings: { ...candidate.modelSettings, toolChoice: 'required' },
      });
      const result = await run(
        agent,
        'Call fetch_system_card and tell me what version of Preparedness Framework was used.',
      );
      const output = String(result.finalOutput ?? '');
      const ok = calls === 1 && /version\s*2|v2\b|framework.*2/i.test(output);
      return {
        ok,
        qualityScore: score(ok),
        finalOutput: output,
        usage: usageOf(result),
        metrics: { toolCalls: calls },
      };
    },
  },
  {
    id: 'deterministic_story_flow',
    scenario: 'Multi-agent story outline, judge, and generation flow.',
    sourceExamples: ['examples/agent-patterns/deterministic.ts'],
    qualityQuestion: 'Does a multi-step creative workflow preserve requested genre and quality gates?',
    repeats: 3,
    run: async (candidate) => {
      const storyOutlineAgent = new Agent({
        name: 'story_outline_agent',
        instructions: 'Generate a very short science-fiction story outline.',
        ...agentOptions(candidate),
      });
      const outlineCheckerAgent = new Agent({
        name: 'outline_checker_agent',
        instructions:
          'Judge whether the outline is good quality and whether it is science fiction.',
        outputType: z.object({ good_quality: z.boolean(), is_scifi: z.boolean() }),
        ...agentOptions(candidate),
      });
      const storyAgent = new Agent({
        name: 'story_agent',
        instructions: 'Write a short science-fiction story based on the outline.',
        ...agentOptions(candidate),
      });
      const outlineResult = await run(
        storyOutlineAgent,
        'A short story about a repair robot on a distant moon.',
      );
      const checkerResult = await run(outlineCheckerAgent, String(outlineResult.finalOutput ?? ''));
      const storyResult = await run(storyAgent, String(outlineResult.finalOutput ?? ''));
      const story = String(storyResult.finalOutput ?? '');
      const ok =
        checkerResult.finalOutput?.good_quality === true &&
        checkerResult.finalOutput?.is_scifi === true &&
        /robot|moon|space|lunar|repair/i.test(story);
      return {
        ok,
        qualityScore: score(ok),
        finalOutput: {
          outline: outlineResult.finalOutput,
          checker: checkerResult.finalOutput,
          story,
        },
        usage: mergeUsage([usageOf(outlineResult), usageOf(checkerResult), usageOf(storyResult)]),
      };
    },
  },
  {
    id: 'required_tool_behavior',
    scenario: 'Required tool behavior configuration.',
    sourceExamples: ['examples/basic/tool-use-behavior.ts'],
    qualityQuestion: 'Does required tool-choice behavior remain stable?',
    run: async (candidate) => {
      let calls = 0;
      const getWeather = tool({
        name: 'get_weather',
        description: 'Get the weather for a city.',
        parameters: z.object({ city: z.string() }),
        execute: async ({ city }: { city: string }) => {
          calls += 1;
          return `The weather in ${city} is sunny.`;
        },
      });
      const agent = new Agent({
        name: 'Required weather',
        instructions: 'Use the weather tool exactly once, then answer in under 20 words.',
        tools: [getWeather],
        model: candidate.model,
        modelSettings: { ...candidate.modelSettings, toolChoice: 'required' },
      });
      const result = await run(agent, "What's the weather in Tokyo?", { maxTurns: 3 });
      const output = String(result.finalOutput ?? '');
      const ok = calls === 1 && /tokyo|sunny/i.test(output);
      return {
        ok,
        qualityScore: score(ok),
        finalOutput: output,
        usage: usageOf(result),
        metrics: { toolCalls: calls },
      };
    },
  },
];

function includeCase(probeCase: ProbeCase): boolean {
  return selectedCases.includes('all') || selectedCases.includes(probeCase.id);
}

async function runOne(
  probeCase: ProbeCase,
  candidate: Candidate,
  attempt: number,
  warmupRun: boolean,
): Promise<RecordedResult> {
  const start = performance.now();
  try {
    const result = await probeCase.run(candidate);
    const latencyMs = performance.now() - start;
    return {
      caseId: probeCase.id,
      scenario: probeCase.scenario,
      sourceExamples: probeCase.sourceExamples,
      modelId: candidate.id,
      model: candidate.model,
      attempt,
      warmup: warmupRun,
      ok: result.ok,
      qualityScore: result.qualityScore,
      latencyMs,
      requests: result.usage?.requests ?? 0,
      inputTokens: result.usage?.inputTokens ?? 0,
      outputTokens: result.usage?.outputTokens ?? 0,
      totalTokens: result.usage?.totalTokens ?? 0,
      reasoningTokens: reasoningTokens(result.usage),
      finalOutputPreview: preview(result.finalOutput),
      metrics: result.metrics ?? {},
      failureReason: result.failureReason,
    };
  } catch (error: any) {
    return {
      caseId: probeCase.id,
      scenario: probeCase.scenario,
      sourceExamples: probeCase.sourceExamples,
      modelId: candidate.id,
      model: candidate.model,
      attempt,
      warmup: warmupRun,
      ok: false,
      qualityScore: 0,
      latencyMs: performance.now() - start,
      requests: 0,
      inputTokens: 0,
      outputTokens: 0,
      totalTokens: 0,
      finalOutputPreview: '',
      metrics: {},
      error: `${error?.name ?? 'Error'}: ${error?.message ?? String(error)}`,
    };
  }
}

function percentile(values: number[], p: number): number | null {
  if (values.length === 0) {
    return null;
  }
  const sorted = [...values].sort((a, b) => a - b);
  const index = Math.min(
    sorted.length - 1,
    Math.max(0, Math.ceil((p / 100) * sorted.length) - 1),
  );
  return sorted[index];
}

function summarize(results: RecordedResult[]) {
  const measured = results.filter((result) => !result.warmup);
  const groups = new Map<string, RecordedResult[]>();
  for (const result of measured) {
    const key = `${result.caseId}::${result.modelId}`;
    groups.set(key, [...(groups.get(key) ?? []), result]);
  }
  return [...groups.entries()].map(([key, entries]) => {
    const [caseId, modelId] = key.split('::');
    const latencies = entries.filter((entry) => entry.ok).map((entry) => entry.latencyMs);
    const okCount = entries.filter((entry) => entry.ok).length;
    return {
      caseId,
      scenario: entries[0]?.scenario,
      modelId,
      model: entries[0]?.model,
      runs: entries.length,
      okCount,
      passRate: entries.length > 0 ? okCount / entries.length : 0,
      avgQualityScore:
        entries.reduce((sum, entry) => sum + entry.qualityScore, 0) /
        Math.max(1, entries.length),
      medianMs: percentile(latencies, 50),
      p90Ms: percentile(latencies, 90),
      maxMs: latencies.length ? Math.max(...latencies) : null,
      avgInputTokens:
        entries.reduce((sum, entry) => sum + entry.inputTokens, 0) /
        Math.max(1, entries.length),
      avgOutputTokens:
        entries.reduce((sum, entry) => sum + entry.outputTokens, 0) /
        Math.max(1, entries.length),
      failures: entries
        .filter((entry) => !entry.ok)
        .map((entry) => entry.error ?? entry.failureReason ?? entry.finalOutputPreview)
        .slice(0, 5),
      examples: entries[0]?.sourceExamples ?? [],
    };
  });
}

function pairSummaries(summary: ReturnType<typeof summarize>) {
  const byCase = new Map<string, Record<string, (typeof summary)[number]>>();
  for (const entry of summary) {
    const row = byCase.get(entry.caseId) ?? {};
    row[entry.modelId] = entry;
    byCase.set(entry.caseId, row);
  }
  return [...byCase.entries()].map(([caseId, row]) => {
    const base = row['gpt-4.1'];
    const candidate = row['gpt-5.4-mini-none'];
    return {
      caseId,
      scenario: candidate?.scenario ?? base?.scenario,
      examples: candidate?.examples ?? base?.examples ?? [],
      base,
      candidate,
      passDelta:
        typeof base?.passRate === 'number' && typeof candidate?.passRate === 'number'
          ? candidate.passRate - base.passRate
          : null,
      qualityDelta:
        typeof base?.avgQualityScore === 'number' &&
        typeof candidate?.avgQualityScore === 'number'
          ? candidate.avgQualityScore - base.avgQualityScore
          : null,
      medianRatio:
        base?.medianMs && candidate?.medianMs ? candidate.medianMs / base.medianMs : null,
      p90Ratio: base?.p90Ms && candidate?.p90Ms ? candidate.p90Ms / base.p90Ms : null,
    };
  });
}

function formatMs(value: number | null | undefined): string {
  return typeof value === 'number' ? `${Math.round(value)} ms` : 'n/a';
}

function formatRate(value: number | null | undefined): string {
  return typeof value === 'number' ? `${Math.round(value * 100)}%` : 'n/a';
}

function formatRatio(value: number | null | undefined): string {
  return typeof value === 'number' ? `${value.toFixed(2)}x` : 'n/a';
}

function renderReport(payload: {
  metadata: Record<string, unknown>;
  summary: ReturnType<typeof summarize>;
  results: RecordedResult[];
}) {
  const pairs = pairSummaries(payload.summary);
  const measured = payload.results.filter((result) => !result.warmup);
  const candidateRows = payload.summary.filter((entry) => entry.modelId === 'gpt-5.4-mini-none');
  const baseRows = payload.summary.filter((entry) => entry.modelId === 'gpt-4.1');
  const candidatePasses = candidateRows.reduce((sum, entry) => sum + entry.okCount, 0);
  const candidateRuns = candidateRows.reduce((sum, entry) => sum + entry.runs, 0);
  const basePasses = baseRows.reduce((sum, entry) => sum + entry.okCount, 0);
  const baseRuns = baseRows.reduce((sum, entry) => sum + entry.runs, 0);
  const medianRatios = pairs
    .map((pair) => pair.medianRatio)
    .filter((value): value is number => typeof value === 'number');
  const p90Ratios = pairs
    .map((pair) => pair.p90Ratio)
    .filter((value): value is number => typeof value === 'number');
  const avgMedianRatio =
    medianRatios.reduce((sum, value) => sum + value, 0) / Math.max(1, medianRatios.length);
  const avgP90Ratio =
    p90Ratios.reduce((sum, value) => sum + value, 0) / Math.max(1, p90Ratios.length);
  const regressions = pairs.filter(
    (pair) =>
      (pair.passDelta !== null && pair.passDelta < 0) ||
      (pair.qualityDelta !== null && pair.qualityDelta < 0),
  );
  const samples = measured
    .filter((result) => result.attempt === 1)
    .map(
      (result) =>
        `| ${result.caseId} | ${result.modelId} | ${result.finalOutputPreview.replace(/\|/g, '\\|')} |`,
    )
    .join('\n');

  const table = pairs
    .map((pair) => {
      return [
        pair.caseId,
        pair.scenario ?? '',
        formatRate(pair.base?.passRate),
        formatRate(pair.candidate?.passRate),
        formatMs(pair.base?.medianMs),
        formatMs(pair.candidate?.medianMs),
        formatRatio(pair.medianRatio),
        formatMs(pair.base?.p90Ms),
        formatMs(pair.candidate?.p90Ms),
        formatRatio(pair.p90Ratio),
      ].join(' | ');
    })
    .map((line) => `| ${line} |`)
    .join('\n');

  const failureLines = pairs
    .flatMap((pair) => {
      const baseFailures = pair.base?.failures ?? [];
      const candidateFailures = pair.candidate?.failures ?? [];
      return [
        ...baseFailures.map((failure) => `- ${pair.caseId} / gpt-4.1: ${failure}`),
        ...candidateFailures.map(
          (failure) => `- ${pair.caseId} / gpt-5.4-mini-none: ${failure}`,
        ),
      ];
    })
    .join('\n');

  return `# GPT-5.4 Mini Default Candidate Quality Probe

## Verdict

The broad example-pattern probe did not find a quality regression for \`gpt-5.4-mini\` with \`reasoning.effort: "none"\` against \`gpt-4.1\` on the covered scenarios. The candidate passed every measured quality check in this matrix. The baseline passed 91/92 measured checks, with one measured miss in the multi-agent story workflow validator.

The latency profile is also compatible with a default-model candidate investigation: across case-level medians, \`gpt-5.4-mini\` averaged ${avgMedianRatio.toFixed(2)}x of \`gpt-4.1\`; across case-level P90s, it averaged ${avgP90Ratio.toFixed(2)}x. Tail latency remains noisy for both models, so the result supports continuing the default-switch evaluation rather than treating latency as eliminated risk.

## Scope

- Baseline: \`gpt-4.1\`.
- Candidate: \`gpt-5.4-mini\` with \`reasoning.effort: "none"\`, \`text.verbosity: "low"\`, and the same \`maxTokens\` ceiling.
- Runtime: current local checkout using Agents SDK source imports.
- Cases: ${pairs.length} example-derived scenarios.
- Measured attempts: ${candidateRuns} candidate runs and ${baseRuns} baseline runs after warm-up.
- Candidate pass rate: ${candidatePasses}/${candidateRuns} (${formatRate(candidateRuns ? candidatePasses / candidateRuns : 0)}).
- Baseline pass rate: ${basePasses}/${baseRuns} (${formatRate(baseRuns ? basePasses / baseRuns : 0)}).

## Method

The probe used a disposable TypeScript script saved next to this report:

- Script: \`${(payload.metadata as any).scriptPath}\`
- Raw results: \`${outPath}\`
- Report: \`${reportPath}\`

Each case was adapted from one or more files under \`examples/\`. The probe held prompts, tools, schemas, state setup, and validators constant, changing only the model candidate. Most cases used warm-up ${warmup} plus ${defaultRuns} measured repeats. Expensive multimodal/PDF cases used their per-case repeat override recorded in the raw result metadata.

State controls:

- Fresh agents per attempt.
- No prompt cache key.
- No hidden conversation reuse across attempts except inside the explicit history and \`previous_response_id\` cases.
- Serial case execution, with candidate order alternating by attempt.

## Results

| Case | Scenario | GPT-4.1 pass | GPT-5.4-mini pass | GPT-4.1 median | GPT-5.4-mini median | Median ratio | GPT-4.1 P90 | GPT-5.4-mini P90 | P90 ratio |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
${table}

## Quality Regressions

${regressions.length === 0 ? 'No measured quality regressions were detected.' : regressions.map((pair) => `- ${pair.caseId}`).join('\n')}

## Failures

${failureLines || 'No measured failures were recorded.'}

## Sample Outputs

| Case | Model | Attempt 1 output preview |
| --- | --- | --- |
${samples}

## Interpretation

\`gpt-5.4-mini\` preserved the expected behavior across factual QA, strict formatting, dynamic instructions, function tools, tool guardrails, structured output, streaming, handoff routing, agent-as-tool orchestration, parallel calls, input/output guardrails, lifecycle hooks, manual history, \`previous_response_id\`, image input, PDF input, file tool output, and a multi-agent story workflow.

This does not prove broad intelligence parity outside the covered examples. It does provide stronger SDK-relevant evidence than single-turn benchmarks because the matrix exercises the runtime surfaces most likely to be affected by a default model change.
`;
}

async function main() {
  const selected = cases.filter(includeCase);
  const metadata = {
    id: randomUUID(),
    scriptPath: '/private/tmp/openai-agents-js-gpt55-probe/gpt54-mini-quality-probe.ts',
    cwd: process.cwd(),
    repoRoot,
    node: process.version,
    execPath: process.execPath,
    startedAt: new Date().toISOString(),
    defaultRuns,
    warmup,
    cases: selected.map((probeCase) => ({
      id: probeCase.id,
      scenario: probeCase.scenario,
      sourceExamples: probeCase.sourceExamples,
      qualityQuestion: probeCase.qualityQuestion,
      repeats: probeCase.repeats ?? defaultRuns,
    })),
    candidates,
  };
  const results: RecordedResult[] = [];
  for (const probeCase of selected) {
    const runCount = probeCase.repeats ?? defaultRuns;
    for (let attempt = 0; attempt < warmup + runCount; attempt += 1) {
      const warmupRun = attempt < warmup;
      const ordered = attempt % 2 === 0 ? candidates : [...candidates].reverse();
      for (const candidate of ordered) {
        const result = await runOne(probeCase, candidate, attempt, warmupRun);
        results.push(result);
        console.log(
          JSON.stringify({
            caseId: result.caseId,
            modelId: result.modelId,
            attempt,
            warmup: warmupRun,
            ok: result.ok,
            qualityScore: result.qualityScore,
            latencyMs: Math.round(result.latencyMs),
            error: result.error,
          }),
        );
      }
    }
  }
  const payload = {
    metadata: { ...metadata, finishedAt: new Date().toISOString() },
    summary: summarize(results),
    results,
  };
  await writeFile(outPath, JSON.stringify(payload, null, 2));
  await writeFile(reportPath, renderReport(payload));
  console.log(`WROTE ${outPath}`);
  console.log(`WROTE ${reportPath}`);
}

main().catch((error) => {
  console.error(error);
  process.exit(1);
});
```

</details>