### PR TITLE
feat: accept manifest init shorthands in sandbox configuration

### DIFF
--- a/.changeset/manifest-init-dx.md
+++ b/.changeset/manifest-init-dx.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents': patch
+'@openai/agents-core': patch
+---
+
+feat: accept manifest init shorthands in sandbox configuration

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,7 @@ export default tseslint.config(
   globalIgnores([
     '**/dist/**',
     '**/node_modules/**',
+    '**/.cache/**',
     '**/docs/.astro/**',
     'examples/realtime-next/**',
     'examples/realtime-demo/**',

--- a/packages/agents-core/src/sandbox/agent.ts
+++ b/packages/agents-core/src/sandbox/agent.ts
@@ -3,7 +3,7 @@ import type { RunContext } from '../runContext';
 import { TextOutput, UnknownContext } from '../types';
 import { SANDBOX_AGENT_BRAND } from './brand';
 import { type Capability, Capabilities } from './capabilities';
-import { cloneManifest, Manifest } from './manifest';
+import { cloneManifest, Manifest, type ManifestInput } from './manifest';
 import { normalizeUser, type SandboxUser } from './users';
 
 export type SandboxBaseInstructions<
@@ -20,7 +20,7 @@ export type SandboxAgentOptions<
   TContext = UnknownContext,
   TOutput extends AgentOutputType = TextOutput,
 > = AgentOptions<TContext, TOutput> & {
-  defaultManifest?: Manifest;
+  defaultManifest?: ManifestInput;
   baseInstructions?: SandboxBaseInstructions<TContext, TOutput>;
   capabilities?: Capability[];
   runAs?: string | SandboxUser;

--- a/packages/agents-core/src/sandbox/client.ts
+++ b/packages/agents-core/src/sandbox/client.ts
@@ -1,4 +1,4 @@
-import { Manifest } from './manifest';
+import { cloneManifest, Manifest, type ManifestInput } from './manifest';
 import type { SandboxSessionLike, SandboxSessionState } from './session';
 import { isRecord } from './shared/typeGuards';
 import type { SnapshotSpec } from './snapshot';
@@ -14,7 +14,7 @@ export type SandboxClientCreateArgs<
   TOptions extends SandboxClientOptions = SandboxClientOptions,
 > = {
   snapshot?: SnapshotSpec;
-  manifest?: Manifest;
+  manifest?: ManifestInput;
   options?: TOptions;
   concurrencyLimits?: SandboxConcurrencyLimits;
 };
@@ -82,7 +82,7 @@ export type SandboxRunConfig<
   options?: TOptions;
   session?: SandboxSessionLike<TSessionState>;
   sessionState?: TSessionState;
-  manifest?: Manifest;
+  manifest?: ManifestInput;
   snapshot?: SnapshotSpec;
   concurrencyLimits?: SandboxConcurrencyLimits;
 };
@@ -102,8 +102,14 @@ export function normalizeSandboxClientCreateArgs<
     };
   }
 
+  const manifest = args?.manifest;
+
   return {
-    manifest: args?.manifest ?? new Manifest(),
+    manifest: manifest
+      ? manifest instanceof Manifest
+        ? manifest
+        : cloneManifest(manifest)
+      : new Manifest(),
     options: args?.options,
     snapshot: args?.snapshot,
     concurrencyLimits: args?.concurrencyLimits,

--- a/packages/agents-core/src/sandbox/manifest.ts
+++ b/packages/agents-core/src/sandbox/manifest.ts
@@ -19,7 +19,9 @@ import {
   normalizeGroup,
   normalizeUser,
   type SandboxGroup,
+  type SandboxGroupInit,
   type SandboxUser,
+  type SandboxUserInit,
 } from './users';
 import { DEFAULT_REMOTE_MOUNT_COMMAND_ALLOWLIST } from './shared/remoteMountCommandAllowlist';
 import {
@@ -39,7 +41,7 @@ export type EnvValue = {
   description?: string;
 };
 
-export type EnvEntry = string | EnvValue | Environment;
+export type EnvEntry = string | EnvResolver | EnvValue | Environment;
 
 export type RenderManifestDescriptionOptions = {
   depth?: number | null;
@@ -73,6 +75,14 @@ export class Environment {
     if (typeof entry === 'string') {
       this.value = entry;
       this.resolver = undefined;
+      this.ephemeral = false;
+      this.description = undefined;
+      return;
+    }
+
+    if (typeof entry === 'function') {
+      this.value = '';
+      this.resolver = entry;
       this.ephemeral = false;
       this.description = undefined;
       return;
@@ -116,8 +126,8 @@ export type ManifestInit<
   root?: string;
   entries?: TEntries;
   environment?: TEnvironment;
-  users?: SandboxUser[];
-  groups?: SandboxGroup[];
+  users?: SandboxUserInit[];
+  groups?: SandboxGroupInit[];
   extraPathGrants?: SandboxPathGrantInit[];
   remoteMountCommandAllowlist?: string[];
 };
@@ -295,7 +305,12 @@ export class Manifest<
   }
 }
 
-export function cloneManifest(manifest: Manifest | ManifestInit): Manifest {
+export type ManifestInput<
+  TEntries extends ManifestEntries = ManifestEntries,
+  TEnvironment extends ManifestEnvironment = ManifestEnvironment,
+> = Manifest<TEntries, TEnvironment> | ManifestInit<TEntries, TEnvironment>;
+
+export function cloneManifest(manifest: ManifestInput): Manifest {
   return new Manifest({
     version: manifest.version,
     root: manifest.root,

--- a/packages/agents-core/src/sandbox/users.ts
+++ b/packages/agents-core/src/sandbox/users.ts
@@ -2,22 +2,29 @@ export type SandboxUser = {
   name: string;
 };
 
+export type SandboxUserInit = string | SandboxUser;
+
 export type SandboxGroup = {
   name: string;
   users?: SandboxUser[];
 };
 
+export type SandboxGroupInit = {
+  name: string;
+  users?: SandboxUserInit[];
+};
+
 export type SandboxEntryGroup = SandboxUser | SandboxGroup;
 
-export function normalizeUser(user: SandboxUser): SandboxUser {
-  const name = user.name.trim();
+export function normalizeUser(user: SandboxUserInit): SandboxUser {
+  const name = (typeof user === 'string' ? user : user.name).trim();
   if (!name) {
     throw new Error('Sandbox user name must be non-empty.');
   }
   return { name };
 }
 
-export function normalizeGroup(group: SandboxGroup): SandboxGroup {
+export function normalizeGroup(group: SandboxGroupInit): SandboxGroup {
   const name = group.name.trim();
   if (!name) {
     throw new Error('Sandbox group name must be non-empty.');

--- a/packages/agents-core/test/sandboxCapabilities.test.ts
+++ b/packages/agents-core/test/sandboxCapabilities.test.ts
@@ -214,6 +214,52 @@ describe('SandboxAgent', () => {
     );
   });
 
+  it('accepts default manifest instances and init objects', () => {
+    const instanceManifest = new Manifest({
+      entries: {
+        'instance.txt': {
+          type: 'file',
+          content: 'instance',
+        },
+      },
+    });
+    const initManifest = {
+      entries: {
+        'init.txt': {
+          type: 'file' as const,
+          content: 'init',
+        },
+      },
+    };
+    const instanceAgent = new SandboxAgent({
+      name: 'instance',
+      defaultManifest: instanceManifest,
+    });
+    const initAgent = new SandboxAgent({
+      name: 'init',
+      defaultManifest: initManifest,
+    });
+
+    (instanceManifest.entries['instance.txt'] as { content: string }).content =
+      'mutated-instance';
+    (initManifest.entries['init.txt'] as { content: string }).content =
+      'mutated-init';
+
+    expect(instanceAgent.defaultManifest).toBeInstanceOf(Manifest);
+    expect(initAgent.defaultManifest).toBeInstanceOf(Manifest);
+    expect(
+      (
+        instanceAgent.defaultManifest?.entries['instance.txt'] as {
+          content: string;
+        }
+      ).content,
+    ).toBe('instance');
+    expect(
+      (initAgent.defaultManifest?.entries['init.txt'] as { content: string })
+        .content,
+    ).toBe('init');
+  });
+
   it('accepts typed runAs users', () => {
     const agent = new SandboxAgent({
       name: 'sandbox',

--- a/packages/agents-core/test/sandboxManifest.test.ts
+++ b/packages/agents-core/test/sandboxManifest.test.ts
@@ -15,8 +15,12 @@ import {
   type GCSMount,
   type LocalDir,
   type ManifestEntries,
+  type ManifestInput,
   type Mount,
   type R2Mount,
+  type SandboxAgentOptions,
+  type SandboxClientCreateArgs,
+  type SandboxRunConfig,
   type S3FilesMount,
   type S3Mount,
 } from '../src/sandbox';
@@ -78,6 +82,59 @@ describe('Manifest', () => {
     expectTypeOf(inlineManifest.entries['inline.txt']).toMatchTypeOf<File>();
   });
 
+  it('accepts Manifest instances and init objects at public config surfaces', () => {
+    const manifestInstance = new Manifest({
+      entries: {
+        'instance.txt': {
+          type: 'file',
+          content: 'instance',
+        },
+      },
+    });
+    const manifestInit = {
+      entries: {
+        'init.txt': {
+          type: 'file' as const,
+          content: 'init',
+        },
+      },
+    };
+
+    expectTypeOf(manifestInstance).toMatchTypeOf<ManifestInput>();
+    expectTypeOf(manifestInit).toMatchTypeOf<ManifestInput>();
+
+    const agentOptions = [
+      {
+        name: 'instance',
+        defaultManifest: manifestInstance,
+      },
+      {
+        name: 'init',
+        defaultManifest: manifestInit,
+      },
+    ] satisfies SandboxAgentOptions[];
+    const runConfigs = [
+      {
+        manifest: manifestInstance,
+      },
+      {
+        manifest: manifestInit,
+      },
+    ] satisfies SandboxRunConfig[];
+    const createArgs = [
+      {
+        manifest: manifestInstance,
+      },
+      {
+        manifest: manifestInit,
+      },
+    ] satisfies SandboxClientCreateArgs[];
+
+    expect(agentOptions).toHaveLength(2);
+    expect(runConfigs).toHaveLength(2);
+    expect(createArgs).toHaveLength(2);
+  });
+
   it('rejects nested child paths with parent segments', () => {
     expect(
       () =>
@@ -131,6 +188,45 @@ describe('Manifest', () => {
       ephemeral: true,
       description: 'loaded at runtime',
     });
+  });
+
+  it('accepts environment resolver shorthand', async () => {
+    const manifest = new Manifest({
+      environment: {
+        TOKEN: () => 'resolved-token',
+      },
+    });
+    const cloned = cloneManifest(manifest);
+
+    await expect(manifest.resolveEnvironment()).resolves.toEqual({
+      TOKEN: 'resolved-token',
+    });
+    await expect(cloned.resolveEnvironment()).resolves.toEqual({
+      TOKEN: 'resolved-token',
+    });
+    expect(manifest.environment.TOKEN.normalized()).toEqual({
+      value: '',
+    });
+  });
+
+  it('accepts string shorthand for users and group users', () => {
+    const manifest = new Manifest({
+      users: [' sandbox-user '],
+      groups: [
+        {
+          name: ' operators ',
+          users: [' reviewer ', { name: ' maintainer ' }],
+        },
+      ],
+    });
+
+    expect(manifest.users).toEqual([{ name: 'sandbox-user' }]);
+    expect(manifest.groups).toEqual([
+      {
+        name: 'operators',
+        users: [{ name: 'reviewer' }, { name: 'maintainer' }],
+      },
+    ]);
   });
 
   it('rejects backslash-separated paths before host resolution', () => {

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -716,6 +716,115 @@ describe('sandbox runner integration', () => {
     expect(client.createCalls[0]?.manifest.root).toBe('/workspace');
   });
 
+  it('accepts manifest instances and init objects in per-run sandbox config', async () => {
+    const client = new FakeSandboxClient();
+    const manifestInstance = new Manifest({
+      entries: {
+        'instance.txt': {
+          type: 'file',
+          content: 'instance',
+        },
+      },
+    });
+    const manifestInit = {
+      entries: {
+        'init.txt': {
+          type: 'file' as const,
+          content: 'init',
+        },
+      },
+    };
+
+    for (const [name, manifest] of [
+      ['instance', manifestInstance],
+      ['init', manifestInit],
+    ] as const) {
+      const sandboxAgent = new SandboxAgent({
+        name: `SandboxWorker-${name}`,
+        model: new RecordingFakeModel([
+          {
+            output: [fakeModelMessage(`${name} sandbox done`)],
+            usage: new Usage(),
+          },
+        ]),
+      });
+
+      const result = await run(sandboxAgent, 'Hello', {
+        sandbox: {
+          client,
+          manifest,
+        },
+      });
+
+      expect(result.finalOutput).toBe(`${name} sandbox done`);
+    }
+
+    (manifestInstance.entries['instance.txt'] as { content: string }).content =
+      'mutated-instance';
+    (manifestInit.entries['init.txt'] as { content: string }).content =
+      'mutated-init';
+
+    expect(client.createCalls).toHaveLength(2);
+    expect(
+      (
+        client.createCalls[0]?.manifest.entries['instance.txt'] as {
+          content: string;
+        }
+      ).content,
+    ).toBe('instance');
+    expect(
+      (
+        client.createCalls[1]?.manifest.entries['init.txt'] as {
+          content: string;
+        }
+      ).content,
+    ).toBe('init');
+  });
+
+  it('normalizes manifest instances and init objects in sandbox client create args', () => {
+    const manifestInstance = new Manifest({
+      entries: {
+        'instance.txt': {
+          type: 'file',
+          content: 'instance',
+        },
+      },
+    });
+    const manifestInit = {
+      entries: {
+        'init.txt': {
+          type: 'file' as const,
+          content: 'init',
+        },
+      },
+    };
+
+    const normalizedInstance = normalizeSandboxClientCreateArgs({
+      manifest: manifestInstance,
+    });
+    const normalizedInit = normalizeSandboxClientCreateArgs({
+      manifest: manifestInit,
+    });
+    (manifestInstance.entries['instance.txt'] as { content: string }).content =
+      'mutated-instance';
+    (manifestInit.entries['init.txt'] as { content: string }).content =
+      'mutated-init';
+
+    expect(normalizedInstance.manifest).toBe(manifestInstance);
+    expect(normalizedInit.manifest).toBeInstanceOf(Manifest);
+    expect(
+      (
+        normalizedInstance.manifest.entries['instance.txt'] as {
+          content: string;
+        }
+      ).content,
+    ).toBe('mutated-instance');
+    expect(
+      (normalizedInit.manifest.entries['init.txt'] as { content: string })
+        .content,
+    ).toBe('init');
+  });
+
   it('passes object RunConfig model overrides into sandbox capability sampling', async () => {
     const client = new FakeSandboxClient();
     const samplingRecorder = new SamplingRecorderCapability();

--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -48,20 +48,20 @@ npm install @openai/agents zod
 
 ```js
 import { run } from '@openai/agents';
-import { gitRepo, Manifest, SandboxAgent } from '@openai/agents/sandbox';
+import { gitRepo, SandboxAgent } from '@openai/agents/sandbox';
 import { UnixLocalSandboxClient } from '@openai/agents/sandbox/local';
 
 const agent = new SandboxAgent({
   name: 'Workspace Assistant',
   instructions: 'Inspect the sandbox workspace before answering.',
-  defaultManifest: new Manifest({
+  defaultManifest: {
     entries: {
       repo: gitRepo({
         repo: 'openai/openai-agents-js',
         ref: 'main',
       }),
     },
-  }),
+  },
 });
 
 const result = await run(


### PR DESCRIPTION
This pull request adds manifest init object support across sandbox configuration surfaces so developers can pass plain manifest config to `SandboxAgent.defaultManifest`, per-run `sandbox.manifest`, and sandbox client create args without explicitly constructing `new Manifest(...)`.

It also adds small manifest authoring shorthands for environment resolvers and string user entries, updates the sandbox docs and top-level examples to show the simpler form, and adds compile-time test coverage proving both `Manifest` instances and init objects are accepted by the public TypeScript surfaces.