### PR TITLE
feat: add function tool concurrency config

### DIFF
--- a/.changeset/function-tool-concurrency.md
+++ b/.changeset/function-tool-concurrency.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents': patch
+---
+
+feat: add function tool execution concurrency config

--- a/packages/agents-core/src/agentToolRunConfig.ts
+++ b/packages/agents-core/src/agentToolRunConfig.ts
@@ -278,6 +278,9 @@ export function getInheritedAgentToolRunConfig(
   if (typeof parentRunConfig.sandbox !== 'undefined') {
     inheritedRunConfig.sandbox = parentRunConfig.sandbox;
   }
+  if (typeof parentRunConfig.toolExecution !== 'undefined') {
+    inheritedRunConfig.toolExecution = parentRunConfig.toolExecution;
+  }
 
   return Object.keys(inheritedRunConfig).length > 0
     ? inheritedRunConfig

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -180,6 +180,7 @@ export type {
   CallModelInputFilterArgs,
   ToolErrorFormatter,
   ToolErrorFormatterArgs,
+  ToolExecutionConfig,
   ReasoningItemIdPolicy,
   RunErrorData,
   RunErrorHandler,

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1,6 +1,6 @@
 import { Agent, AgentOutputType } from './agent';
 import { RunAgentUpdatedStreamEvent, RunRawModelStreamEvent } from './events';
-import { ModelBehaviorError } from './errors';
+import { ModelBehaviorError, UserError } from './errors';
 import {
   defineInputGuardrail,
   defineOutputGuardrail,
@@ -175,6 +175,33 @@ export type ToolErrorFormatter<TContext = unknown> = (
 ) => Promise<string | undefined> | string | undefined;
 
 /**
+ * SDK-side execution settings for local tool calls.
+ */
+export type ToolExecutionConfig = {
+  /**
+   * Maximum number of local function tool calls to execute concurrently.
+   * Set to `null` or leave unset to start all function tool calls emitted in a turn.
+   * This does not change provider-side `parallelToolCalls` behavior.
+   */
+  maxFunctionToolConcurrency?: number | null;
+};
+
+function validateToolExecutionConfig(
+  config: ToolExecutionConfig | undefined,
+): ToolExecutionConfig | undefined {
+  const maxConcurrency = config?.maxFunctionToolConcurrency;
+  if (maxConcurrency == null) {
+    return config;
+  }
+  if (!Number.isInteger(maxConcurrency) || maxConcurrency < 1) {
+    throw new UserError(
+      'toolExecution.maxFunctionToolConcurrency must be an integer greater than or equal to 1.',
+    );
+  }
+  return config;
+}
+
+/**
  * Configures settings for the entire agent run.
  */
 export type RunConfig = {
@@ -257,6 +284,11 @@ export type RunConfig = {
   sandbox?: SandboxRunConfig;
 
   /**
+   * SDK-side execution settings for local tool calls.
+   */
+  toolExecution?: ToolExecutionConfig;
+
+  /**
    * Customizes how session history is combined with the current turn's input.
    * When omitted, history items are appended before the new input.
    */
@@ -299,6 +331,7 @@ type SharedRunOptions<
   reasoningItemIdPolicy?: ReasoningItemIdPolicy;
   tracing?: TracingConfig;
   sandbox?: SandboxRunConfig;
+  toolExecution?: ToolExecutionConfig;
   /**
    * Error handlers keyed by error kind.
    */
@@ -412,6 +445,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       traceMetadata: config.traceMetadata,
       tracing: config.tracing,
       sandbox: config.sandbox,
+      toolExecution: validateToolExecutionConfig(config.toolExecution),
       sessionInputCallback: config.sessionInputCallback,
       callModelInputFilter: config.callModelInputFilter,
       toolErrorFormatter: config.toolErrorFormatter,
@@ -491,6 +525,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     const toolErrorFormatter =
       resolvedOptions.toolErrorFormatter ?? this.config.toolErrorFormatter;
     const reasoningItemIdPolicy = resolvedOptions.reasoningItemIdPolicy;
+    const toolExecution = validateToolExecutionConfig(
+      resolvedOptions.toolExecution ?? this.config.toolExecution,
+    );
     const hasCallModelInputFilter = Boolean(callModelInputFilter);
     const tracingConfig = resolvedOptions.tracing ?? this.config.tracing;
     const traceOverrides = {
@@ -505,6 +542,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       callModelInputFilter,
       toolErrorFormatter,
       reasoningItemIdPolicy,
+      toolExecution,
     };
     const resumingFromState = input instanceof RunState;
     const preserveTurnPersistenceOnResume =
@@ -687,12 +725,19 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     TContext,
     TAgent extends Agent<TContext, AgentOutputType>,
   >(options: SharedRunOptions<TContext, TAgent>): Partial<RunConfig> {
-    return typeof options.sandbox === 'undefined'
-      ? this.config
-      : {
-          ...this.config,
-          sandbox: options.sandbox,
-        };
+    const hasSandboxOverride = typeof options.sandbox !== 'undefined';
+    const hasToolExecutionOverride =
+      typeof options.toolExecution !== 'undefined';
+    if (!hasSandboxOverride && !hasToolExecutionOverride) {
+      return this.config;
+    }
+    return {
+      ...this.config,
+      ...(hasSandboxOverride ? { sandbox: options.sandbox } : {}),
+      ...(hasToolExecutionOverride
+        ? { toolExecution: options.toolExecution }
+        : {}),
+    };
   }
 
   /**

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -183,26 +183,32 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
     agentToolParentRunConfig,
   };
 
+  const executeToolRun = async (toolRun: ToolRunFunction<TContext>) => {
+    const parseResult = parseToolArguments(toolRun);
+
+    // Handle parse errors gracefully instead of crashing.
+    if (!parseResult.success) {
+      return buildParseErrorResult(deps, toolRun, parseResult.error);
+    }
+
+    const approvalOutcome = await handleFunctionApproval(
+      deps,
+      toolRun,
+      parseResult.args,
+    );
+    if (approvalOutcome !== 'approved') {
+      return approvalOutcome;
+    }
+    return runApprovedFunctionTool(deps, toolRun);
+  };
+
   try {
-    const results = await Promise.all(
-      toolRuns.map(async (toolRun) => {
-        const parseResult = parseToolArguments(toolRun);
-
-        // Handle parse errors gracefully instead of crashing
-        if (!parseResult.success) {
-          return buildParseErrorResult(deps, toolRun, parseResult.error);
-        }
-
-        const approvalOutcome = await handleFunctionApproval(
-          deps,
-          toolRun,
-          parseResult.args,
-        );
-        if (approvalOutcome !== 'approved') {
-          return approvalOutcome;
-        }
-        return runApprovedFunctionTool(deps, toolRun);
-      }),
+    const results = await executeToolRunsWithConcurrency(
+      toolRuns,
+      getMaxFunctionToolConcurrency(
+        agentToolParentRunConfig?.toolExecution ?? runner.config.toolExecution,
+      ),
+      executeToolRun,
     );
     return results;
   } catch (e: unknown) {
@@ -217,6 +223,55 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
       state,
     );
   }
+}
+
+function getMaxFunctionToolConcurrency(
+  toolExecution: RunConfig['toolExecution'] | undefined,
+): number | undefined {
+  return toolExecution?.maxFunctionToolConcurrency ?? undefined;
+}
+
+async function executeToolRunsWithConcurrency<TContext>(
+  toolRuns: ToolRunFunction<TContext>[],
+  maxConcurrency: number | undefined,
+  executeToolRun: (
+    toolRun: ToolRunFunction<TContext>,
+  ) => Promise<FunctionToolResult<TContext>>,
+): Promise<FunctionToolResult<TContext>[]> {
+  if (
+    maxConcurrency === undefined ||
+    maxConcurrency >= toolRuns.length ||
+    toolRuns.length <= 1
+  ) {
+    return Promise.all(toolRuns.map((toolRun) => executeToolRun(toolRun)));
+  }
+
+  const results: FunctionToolResult<TContext>[] = [];
+  let nextIndex = 0;
+  let firstError: unknown;
+
+  const worker = async () => {
+    while (nextIndex < toolRuns.length && firstError === undefined) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      try {
+        results[currentIndex] = await executeToolRun(toolRuns[currentIndex]);
+      } catch (error) {
+        firstError ??= error;
+        break;
+      }
+    }
+  };
+
+  const workerCount = Math.min(maxConcurrency, toolRuns.length);
+  await Promise.allSettled(
+    Array.from({ length: workerCount }, async () => worker()),
+  );
+
+  if (firstError !== undefined) {
+    throw firstError;
+  }
+  return results;
 }
 
 function parseToolArguments<TContext>(

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -31,6 +31,7 @@ import {
   BatchTraceProcessor,
   user,
   assistant,
+  type ToolExecutionConfig,
 } from '../src';
 import { RunStreamEvent } from '../src/events';
 import { ServerConversationTracker } from '../src/runner/conversation';
@@ -103,6 +104,38 @@ describe('Runner.run', () => {
   });
 
   describe('basic', () => {
+    it('accepts public tool execution config', () => {
+      const toolExecution = {
+        maxFunctionToolConcurrency: 2,
+      } satisfies ToolExecutionConfig;
+
+      const runner = new Runner({
+        tracingDisabled: true,
+        toolExecution,
+      });
+
+      expect(runner.config.toolExecution).toBe(toolExecution);
+    });
+
+    it('rejects invalid function tool concurrency config', () => {
+      expect(
+        () =>
+          new Runner({
+            tracingDisabled: true,
+            toolExecution: { maxFunctionToolConcurrency: 0 },
+          }),
+      ).toThrow(UserError);
+      expect(
+        () =>
+          new Runner({
+            tracingDisabled: true,
+            toolExecution: { maxFunctionToolConcurrency: 1.5 },
+          }),
+      ).toThrow(
+        'toolExecution.maxFunctionToolConcurrency must be an integer greater than or equal to 1.',
+      );
+    });
+
     it('does not persist nested agent-tool metadata when resuming a RunState', async () => {
       const agent = new Agent({
         name: 'ReusedNestedStateAgent',

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -2401,6 +2401,161 @@ describe('executeShellActions', () => {
       expect(invokeSpy).toHaveBeenCalled();
     });
 
+    it('starts all function tool calls by default', async () => {
+      let activeCount = 0;
+      let maxSeenCount = 0;
+      const t = tool({
+        name: 'hi',
+        description: 'tracked tool',
+        parameters: z.object({ value: z.number() }),
+        execute: vi.fn(async ({ value }) => {
+          activeCount += 1;
+          maxSeenCount = Math.max(maxSeenCount, activeCount);
+          try {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            return `ok-${value}`;
+          } finally {
+            activeCount -= 1;
+          }
+        }),
+      }) as unknown as FunctionTool;
+
+      const res = await withTrace('test', () =>
+        executeFunctionToolCalls(
+          state._currentAgent,
+          [1, 2, 3].map((value) => ({
+            toolCall: {
+              ...toolCall,
+              callId: `c${value}`,
+              arguments: JSON.stringify({ value }),
+            },
+            tool: t,
+          })),
+          runner,
+          state,
+        ),
+      );
+
+      expect(activeCount).toBe(0);
+      expect(maxSeenCount).toBe(3);
+      expect(
+        res.map((result) => {
+          expect(result.type).toBe('function_output');
+          return result.type === 'function_output' ? result.output : undefined;
+        }),
+      ).toEqual(['ok-1', 'ok-2', 'ok-3']);
+    });
+
+    it('limits function tool concurrency and preserves output order', async () => {
+      let activeCount = 0;
+      let maxSeenCount = 0;
+      runner = new Runner({
+        tracingDisabled: true,
+        toolExecution: { maxFunctionToolConcurrency: 2 },
+      });
+      const t = tool({
+        name: 'hi',
+        description: 'tracked tool',
+        parameters: z.object({ value: z.number() }),
+        execute: vi.fn(async ({ value }) => {
+          activeCount += 1;
+          maxSeenCount = Math.max(maxSeenCount, activeCount);
+          try {
+            await new Promise((resolve) =>
+              setTimeout(resolve, value === 1 ? 30 : 1),
+            );
+            return `ok-${value}`;
+          } finally {
+            activeCount -= 1;
+          }
+        }),
+      }) as unknown as FunctionTool;
+
+      const res = await withTrace('test', () =>
+        executeFunctionToolCalls(
+          state._currentAgent,
+          [1, 2, 3].map((value) => ({
+            toolCall: {
+              ...toolCall,
+              callId: `c${value}`,
+              arguments: JSON.stringify({ value }),
+            },
+            tool: t,
+          })),
+          runner,
+          state,
+        ),
+      );
+
+      expect(activeCount).toBe(0);
+      expect(maxSeenCount).toBe(2);
+      expect(
+        res.map((result) => {
+          expect(result.type).toBe('function_output');
+          return result.type === 'function_output' ? result.output : undefined;
+        }),
+      ).toEqual(['ok-1', 'ok-2', 'ok-3']);
+    });
+
+    it('does not start queued function tool calls after a capped failure', async () => {
+      const startedTools: string[] = [];
+      runner = new Runner({
+        tracingDisabled: true,
+        toolExecution: { maxFunctionToolConcurrency: 1 },
+      });
+      const failingTool = tool({
+        name: 'failing_tool',
+        description: 'failing tool',
+        parameters: z.object({}),
+        errorFunction: null,
+        execute: vi.fn(async () => {
+          startedTools.push('failing_tool');
+          throw new Error('boom');
+        }),
+      }) as unknown as FunctionTool;
+      const queuedTool = tool({
+        name: 'queued_tool',
+        description: 'queued tool',
+        parameters: z.object({}),
+        execute: vi.fn(async () => {
+          startedTools.push('queued_tool');
+          return 'should-not-run';
+        }),
+      }) as unknown as FunctionTool;
+
+      await expect(
+        withTrace('test', () =>
+          executeFunctionToolCalls(
+            state._currentAgent,
+            [
+              {
+                toolCall: {
+                  ...toolCall,
+                  name: 'failing_tool',
+                  callId: 'c1',
+                  arguments: '{}',
+                },
+                tool: failingTool,
+              },
+              {
+                toolCall: {
+                  ...toolCall,
+                  name: 'queued_tool',
+                  callId: 'c2',
+                  arguments: '{}',
+                },
+                tool: queuedTool,
+              },
+            ],
+            runner,
+            state,
+          ),
+        ),
+      ).rejects.toThrow(/Failed to run function tools/);
+
+      expect(startedTools).toEqual(['failing_tool']);
+    });
+
     it('does not expose parentRunConfig on public tool callback details', async () => {
       const circularProvider: Record<string, unknown> = {};
       circularProvider.self = circularProvider;


### PR DESCRIPTION
This pull request adds SDK-side function tool concurrency configuration, mirroring https://github.com/openai/openai-agents-python/pull/3152 for the JS SDK.

It introduces `toolExecution.maxFunctionToolConcurrency` on `RunConfig` and per-run options, caps local function tool execution when configured, preserves the existing default full-parallel behavior, keeps output ordering stable, and carries the setting into nested `Agent.asTool()` runs. It also adds regression coverage for invalid config, default concurrency, capped concurrency/order, and queued calls after capped failures.