### PR TITLE
feat: align local MCP config with the Python SDK

### DIFF
--- a/.changeset/server-prefixed-mcp-tools.md
+++ b/.changeset/server-prefixed-mcp-tools.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents': patch
+---
+
+feat: align local MCP config with the Python SDK

--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -1,6 +1,10 @@
 import type { InputGuardrail, OutputGuardrail } from './guardrail';
 import { AgentHooks } from './lifecycle';
-import { getAllMcpTools, type MCPServer } from './mcp';
+import {
+  getAllMcpTools,
+  type MCPServer,
+  type MCPToolErrorFunction,
+} from './mcp';
 import type { Model, ModelSettings, Prompt } from './model';
 import {
   getDefaultModelSettings,
@@ -348,6 +352,27 @@ export interface AgentConfiguration<
   mcpServers: MCPServer[];
 
   /**
+   * Configuration for MCP servers used by this agent.
+   */
+  mcpConfig: {
+    /**
+     * Try to convert MCP tool schemas to strict JSON schema.
+     */
+    convertSchemasToStrict?: boolean;
+    /**
+     * Optional function to convert MCP tool failures into model-visible messages.
+     * Set to null to rethrow errors instead of converting them.
+     * Server-level errorFunction values take precedence.
+     */
+    errorFunction?: MCPToolErrorFunction | null;
+    /**
+     * Prefix local MCP tool names with their server name before exposing them to the model.
+     * The SDK still invokes the original MCP tool name on the original server.
+     */
+    includeServerInToolNames?: boolean;
+  };
+
+  /**
    * A list of checks that run in parallel to the agent by default; set `runInParallel` to false to
    * block LLM/tool calls until the guardrail completes. Runs only if the agent is the first agent
    * in the chain.
@@ -500,6 +525,7 @@ export class Agent<
   modelSettings: ModelSettings;
   tools: Tool<TContext>[];
   mcpServers: MCPServer[];
+  mcpConfig: AgentConfiguration<TContext, TOutput>['mcpConfig'];
   inputGuardrails: InputGuardrail[];
   outputGuardrails: OutputGuardrail<AgentOutputType, TContext>[];
   outputType: TOutput = 'text' as TOutput;
@@ -527,6 +553,7 @@ export class Agent<
     this.tools = config.tools ?? [];
     this._toolsExplicitlyConfigured = config.tools !== undefined;
     this.mcpServers = config.mcpServers ?? [];
+    this.mcpConfig = config.mcpConfig ?? {};
     this.inputGuardrails = config.inputGuardrails ?? [];
     this.outputGuardrails = config.outputGuardrails ?? [];
     if (config.outputType) {
@@ -966,15 +993,41 @@ export class Agent<
     runContext: RunContext<TContext>,
   ): Promise<Tool<TContext>[]> {
     if (this.mcpServers.length > 0) {
+      const includeServerInToolNames =
+        this.mcpConfig.includeServerInToolNames === true;
       return getAllMcpTools({
         mcpServers: this.mcpServers,
         runContext,
         agent: this,
-        convertSchemasToStrict: false,
+        convertSchemasToStrict: this.mcpConfig.convertSchemasToStrict === true,
+        errorFunction: this.mcpConfig.errorFunction,
+        includeServerInToolNames,
+        reservedToolNames: includeServerInToolNames
+          ? await this.getMcpToolReservedNames(runContext)
+          : undefined,
       });
     }
 
     return [];
+  }
+
+  private async getMcpToolReservedNames(
+    runContext: RunContext<TContext>,
+  ): Promise<Set<string>> {
+    const reservedToolNames = new Set(
+      this.tools
+        .filter(
+          (tool): tool is FunctionTool<TContext> => tool.type === 'function',
+        )
+        .map((tool) => tool.name),
+    );
+
+    const enabledHandoffs = await this.getEnabledHandoffs(runContext);
+    for (const handoff of enabledHandoffs) {
+      reservedToolNames.add(handoff.toolName);
+    }
+
+    return reservedToolNames;
   }
 
   /**

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -121,6 +121,7 @@ export {
   MCPTextResourceContent,
   GetAllMcpToolsOptions,
   MCPToolCacheKeyGenerator,
+  MCPToolErrorFunction,
 } from './mcp';
 export {
   MCPServers,

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -39,10 +39,22 @@ export const DEFAULT_STREAMABLE_HTTP_MCP_CLIENT_LOGGER_NAME =
 export const DEFAULT_SSE_MCP_CLIENT_LOGGER_NAME =
   'openai-agents:sse-mcp-client';
 
-type MCPToolErrorFunction = (args: {
+export type MCPToolErrorFunction = (args: {
   context: RunContext;
   error: Error | unknown;
 }) => Promise<string> | string;
+
+const MCP_FUNCTION_TOOL_NAME_MAX_LENGTH = 64;
+const MCP_FUNCTION_TOOL_HASH_LENGTH = 8;
+
+type PrefixedToolNameCandidate = {
+  batchKey: string;
+  baseName: string;
+  seed: string;
+  initialName: string;
+  serverIndex: number;
+  toolIndex: number;
+};
 
 /**
  * Interface for MCP server implementations.
@@ -575,21 +587,19 @@ export const defaultMCPToolCacheKey: MCPToolCacheKeyGenerator = ({
 };
 
 /**
- * Fetches all function tools from a single MCP server.
+ * Fetches and filters raw MCP tools from a single MCP server.
  */
-async function getFunctionToolsFromServer<TContext = UnknownContext>({
+async function getMcpToolsFromServer<TContext = UnknownContext>({
   server,
-  convertSchemasToStrict,
   runContext,
   agent,
   generateMCPToolCacheKey,
 }: {
   server: MCPServer;
-  convertSchemasToStrict: boolean;
   runContext?: RunContext<TContext>;
   agent?: Agent<any, any>;
   generateMCPToolCacheKey?: MCPToolCacheKeyGenerator;
-}): Promise<FunctionTool<TContext, any, unknown>[]> {
+}): Promise<MCPTool[]> {
   const cacheKey = (generateMCPToolCacheKey || defaultMCPToolCacheKey)({
     server,
     agent,
@@ -597,14 +607,12 @@ async function getFunctionToolsFromServer<TContext = UnknownContext>({
   });
   // Use cache key generator injected from the outside, or the default if absent.
   if (server.cacheToolsList && _cachedTools[cacheKey]) {
-    return _cachedTools[cacheKey].map((t) =>
-      mcpToFunctionTool(t, server, convertSchemasToStrict),
-    );
+    return _cachedTools[cacheKey];
   }
 
   const listToolsForServer = async (
     span?: Span<MCPListToolsSpanData>,
-  ): Promise<FunctionTool<TContext, any, unknown>[]> => {
+  ): Promise<MCPTool[]> => {
     const fetchedMcpTools = await server.listTools();
     let mcpTools: MCPTool[] = fetchedMcpTools;
 
@@ -657,9 +665,6 @@ async function getFunctionToolsFromServer<TContext = UnknownContext>({
     if (span) {
       span.spanData.result = mcpTools.map((t) => t.name);
     }
-    const tools: FunctionTool<TContext, any, string>[] = mcpTools.map((t) =>
-      mcpToFunctionTool(t, server, convertSchemasToStrict),
-    );
     // Cache store
     if (server.cacheToolsList) {
       _cachedTools[cacheKey] = mcpTools;
@@ -668,7 +673,7 @@ async function getFunctionToolsFromServer<TContext = UnknownContext>({
       }
       _cachedToolKeysByServer[server.name].add(cacheKey);
     }
-    return tools;
+    return mcpTools;
   };
 
   if (!getCurrentTrace()) {
@@ -677,6 +682,59 @@ async function getFunctionToolsFromServer<TContext = UnknownContext>({
 
   return withMCPListToolsSpan(listToolsForServer, {
     data: { server: server.name },
+  });
+}
+
+function convertMcpToolsToFunctionTools<TContext = UnknownContext>({
+  mcpTools,
+  server,
+  convertSchemasToStrict,
+  toolNameOverrides,
+  errorFunction,
+}: {
+  mcpTools: MCPTool[];
+  server: MCPServer;
+  convertSchemasToStrict: boolean;
+  toolNameOverrides?: Array<string | undefined>;
+  errorFunction?: MCPToolErrorFunction | null;
+}): FunctionTool<TContext, any, unknown>[] {
+  return mcpTools.map((mcpTool, index) =>
+    mcpToFunctionTool(mcpTool, server, convertSchemasToStrict, {
+      toolNameOverride: toolNameOverrides?.[index],
+      errorFunction,
+    }),
+  );
+}
+
+/**
+ * Fetches all function tools from a single MCP server.
+ */
+async function getFunctionToolsFromServer<TContext = UnknownContext>({
+  server,
+  convertSchemasToStrict,
+  runContext,
+  agent,
+  generateMCPToolCacheKey,
+  errorFunction,
+}: {
+  server: MCPServer;
+  convertSchemasToStrict: boolean;
+  runContext?: RunContext<TContext>;
+  agent?: Agent<any, any>;
+  generateMCPToolCacheKey?: MCPToolCacheKeyGenerator;
+  errorFunction?: MCPToolErrorFunction | null;
+}): Promise<FunctionTool<TContext, any, unknown>[]> {
+  const mcpTools = await getMcpToolsFromServer({
+    server,
+    runContext,
+    agent,
+    generateMCPToolCacheKey,
+  });
+  return convertMcpToolsToFunctionTools({
+    mcpTools,
+    server,
+    convertSchemasToStrict,
+    errorFunction,
   });
 }
 
@@ -689,6 +747,9 @@ export type GetAllMcpToolsOptions<TContext> = {
   runContext?: RunContext<TContext>;
   agent?: Agent<TContext, any>;
   generateMCPToolCacheKey?: MCPToolCacheKeyGenerator;
+  errorFunction?: MCPToolErrorFunction | null;
+  includeServerInToolNames?: boolean;
+  reservedToolNames?: Set<string>;
 };
 
 /**
@@ -716,9 +777,57 @@ export async function getAllMcpTools<TContext = UnknownContext>(
     runContext: runContextFromOpts,
     agent: agentFromOpts,
     generateMCPToolCacheKey,
+    errorFunction,
+    includeServerInToolNames = false,
+    reservedToolNames,
   } = opts;
   const allTools: Tool<TContext>[] = [];
   const toolNames = new Set<string>();
+
+  if (includeServerInToolNames) {
+    const serverToolBatches = await Promise.all(
+      mcpServers.map(async (server, serverIndex) => ({
+        server,
+        serverIndex,
+        mcpTools: await getMcpToolsFromServer({
+          server,
+          runContext: runContextFromOpts,
+          agent: agentFromOpts,
+          generateMCPToolCacheKey,
+        }),
+      })),
+    );
+    const toolNameOverrides = buildPrefixedToolNameOverrides(
+      serverToolBatches,
+      new Set(reservedToolNames ?? []),
+    );
+
+    for (const { server, serverIndex, mcpTools } of serverToolBatches) {
+      const serverTools = convertMcpToolsToFunctionTools<TContext>({
+        mcpTools,
+        server,
+        convertSchemasToStrict: convertSchemasToStrictFromOpts,
+        errorFunction,
+        toolNameOverrides: mcpTools.map((_, toolIndex) =>
+          toolNameOverrides.get(getToolNameOverrideKey(serverIndex, toolIndex)),
+        ),
+      });
+      const serverToolNames = new Set(serverTools.map((t) => t.name));
+      const intersection = [...serverToolNames]
+        .filter((n) => toolNames.has(n))
+        .sort();
+      if (intersection.length > 0) {
+        throw new UserError(
+          `Duplicate tool names found across MCP servers: ${intersection.join(', ')}`,
+        );
+      }
+      for (const t of serverTools) {
+        toolNames.add(t.name);
+        allTools.push(t);
+      }
+    }
+    return allTools;
+  }
 
   for (const server of mcpServers) {
     const serverTools = await getFunctionToolsFromServer({
@@ -727,9 +836,12 @@ export async function getAllMcpTools<TContext = UnknownContext>(
       runContext: runContextFromOpts,
       agent: agentFromOpts,
       generateMCPToolCacheKey,
+      errorFunction,
     });
     const serverToolNames = new Set(serverTools.map((t) => t.name));
-    const intersection = [...serverToolNames].filter((n) => toolNames.has(n));
+    const intersection = [...serverToolNames]
+      .filter((n) => toolNames.has(n))
+      .sort();
     if (intersection.length > 0) {
       throw new UserError(
         `Duplicate tool names found across MCP servers: ${intersection.join(', ')}`,
@@ -741,6 +853,209 @@ export async function getAllMcpTools<TContext = UnknownContext>(
     }
   }
   return allTools;
+}
+
+function getToolNameOverrideKey(
+  serverIndex: number,
+  toolIndex: number,
+): string {
+  return `${serverIndex}:${toolIndex}`;
+}
+
+function getSafeToolNamePart(value: string, fallback: string): string {
+  const safe = Array.from(value)
+    .map((char) => {
+      const code = char.charCodeAt(0);
+      return code <= 127 && /[A-Za-z0-9_-]/.test(char) ? char : '_';
+    })
+    .join('')
+    .replace(/^[_-]+|[_-]+$/g, '');
+  return safe || fallback;
+}
+
+function getUtf8Bytes(value: string): number[] {
+  const encoded = encodeURIComponent(value);
+  const bytes: number[] = [];
+  for (let index = 0; index < encoded.length; index += 1) {
+    if (encoded[index] === '%') {
+      bytes.push(Number.parseInt(encoded.slice(index + 1, index + 3), 16));
+      index += 2;
+    } else {
+      bytes.push(encoded.charCodeAt(index));
+    }
+  }
+  return bytes;
+}
+
+function rotateLeft(value: number, bits: number): number {
+  return ((value << bits) | (value >>> (32 - bits))) >>> 0;
+}
+
+function getSha1Hex(value: string): string {
+  const bytes = getUtf8Bytes(value);
+  const bitLength = bytes.length * 8;
+  bytes.push(0x80);
+  while (bytes.length % 64 !== 56) {
+    bytes.push(0);
+  }
+
+  for (let shift = 56; shift >= 0; shift -= 8) {
+    bytes.push(Math.floor(bitLength / 2 ** shift) & 0xff);
+  }
+
+  let h0 = 0x67452301;
+  let h1 = 0xefcdab89;
+  let h2 = 0x98badcfe;
+  let h3 = 0x10325476;
+  let h4 = 0xc3d2e1f0;
+
+  for (let offset = 0; offset < bytes.length; offset += 64) {
+    const words = new Array<number>(80).fill(0);
+    for (let index = 0; index < 16; index += 1) {
+      const byteOffset = offset + index * 4;
+      words[index] =
+        ((bytes[byteOffset] ?? 0) << 24) |
+        ((bytes[byteOffset + 1] ?? 0) << 16) |
+        ((bytes[byteOffset + 2] ?? 0) << 8) |
+        (bytes[byteOffset + 3] ?? 0);
+    }
+    for (let index = 16; index < 80; index += 1) {
+      words[index] = rotateLeft(
+        words[index - 3] ^
+          words[index - 8] ^
+          words[index - 14] ^
+          words[index - 16],
+        1,
+      );
+    }
+
+    let a = h0;
+    let b = h1;
+    let c = h2;
+    let d = h3;
+    let e = h4;
+
+    for (let index = 0; index < 80; index += 1) {
+      let f: number;
+      let k: number;
+      if (index < 20) {
+        f = (b & c) | (~b & d);
+        k = 0x5a827999;
+      } else if (index < 40) {
+        f = b ^ c ^ d;
+        k = 0x6ed9eba1;
+      } else if (index < 60) {
+        f = (b & c) | (b & d) | (c & d);
+        k = 0x8f1bbcdc;
+      } else {
+        f = b ^ c ^ d;
+        k = 0xca62c1d6;
+      }
+      const temp = (rotateLeft(a, 5) + f + e + k + (words[index] ?? 0)) >>> 0;
+      e = d;
+      d = c;
+      c = rotateLeft(b, 30);
+      b = a;
+      a = temp;
+    }
+
+    h0 = (h0 + a) >>> 0;
+    h1 = (h1 + b) >>> 0;
+    h2 = (h2 + c) >>> 0;
+    h3 = (h3 + d) >>> 0;
+    h4 = (h4 + e) >>> 0;
+  }
+
+  return [h0, h1, h2, h3, h4]
+    .map((word) => word.toString(16).padStart(8, '0'))
+    .join('');
+}
+
+function shortenToolName(
+  baseName: string,
+  seed: string,
+  forceHash = false,
+): string {
+  if (!forceHash && baseName.length <= MCP_FUNCTION_TOOL_NAME_MAX_LENGTH) {
+    return baseName;
+  }
+
+  const hashSuffix = getSha1Hex(seed).slice(0, MCP_FUNCTION_TOOL_HASH_LENGTH);
+  const suffix = `_${hashSuffix}`;
+  const stemLength = MCP_FUNCTION_TOOL_NAME_MAX_LENGTH - suffix.length;
+  const stem = baseName.slice(0, stemLength).replace(/[_-]+$/g, '') || 'mcp';
+  return `${stem}${suffix}`;
+}
+
+function buildPrefixedToolBaseName(
+  serverName: string,
+  toolName: string,
+): string {
+  const serverPart = getSafeToolNamePart(serverName, 'server');
+  const toolPart = getSafeToolNamePart(toolName, 'tool');
+  return `mcp_${serverPart}__${toolPart}`;
+}
+
+function buildPrefixedToolNameOverrides(
+  serverToolBatches: Array<{
+    server: MCPServer;
+    serverIndex: number;
+    mcpTools: MCPTool[];
+  }>,
+  reservedNames: Set<string>,
+): Map<string, string> {
+  const baseNameCounts = new Map<string, number>();
+  for (const { server, mcpTools } of serverToolBatches) {
+    for (const mcpTool of mcpTools) {
+      const baseName = buildPrefixedToolBaseName(server.name, mcpTool.name);
+      baseNameCounts.set(baseName, (baseNameCounts.get(baseName) ?? 0) + 1);
+    }
+  }
+
+  const candidates: PrefixedToolNameCandidate[] = [];
+  for (const { server, serverIndex, mcpTools } of serverToolBatches) {
+    mcpTools.forEach((mcpTool, toolIndex) => {
+      const baseName = buildPrefixedToolBaseName(server.name, mcpTool.name);
+      const seed = `${server.name}\0${mcpTool.name}`;
+      const forceHash =
+        (baseNameCounts.get(baseName) ?? 0) > 1 || reservedNames.has(baseName);
+      candidates.push({
+        batchKey: getToolNameOverrideKey(serverIndex, toolIndex),
+        baseName,
+        seed,
+        initialName: shortenToolName(baseName, seed, forceHash),
+        serverIndex,
+        toolIndex,
+      });
+    });
+  }
+
+  const usedNames = new Set(reservedNames);
+  const overrides = new Map<string, string>();
+  for (const candidate of candidates.sort((left, right) => {
+    return (
+      left.initialName.localeCompare(right.initialName) ||
+      left.seed.localeCompare(right.seed) ||
+      left.serverIndex - right.serverIndex ||
+      left.toolIndex - right.toolIndex
+    );
+  })) {
+    let publicName = candidate.initialName;
+    let collisionIndex = 1;
+    while (usedNames.has(publicName)) {
+      publicName = shortenToolName(
+        candidate.baseName,
+        `${candidate.seed}\0${collisionIndex}`,
+        true,
+      );
+      collisionIndex += 1;
+    }
+
+    usedNames.add(publicName);
+    overrides.set(candidate.batchKey, publicName);
+  }
+
+  return overrides;
 }
 
 async function resolveMcpToolMeta<TContext>(
@@ -776,17 +1091,28 @@ async function resolveMcpToolMeta<TContext>(
 /**
  * Converts an MCP tool definition to a function tool for the Agents SDK.
  */
+export type MCPFunctionToolConversionOptions = {
+  toolNameOverride?: string;
+  errorFunction?: MCPToolErrorFunction | null;
+};
+
 export function mcpToFunctionTool(
   mcpTool: MCPTool,
   server: MCPServer,
   convertSchemasToStrict: boolean,
+  options: MCPFunctionToolConversionOptions = {},
 ) {
+  const toolName = options.toolNameOverride ?? mcpTool.name;
   const serverErrorFunction = server.errorFunction;
+  const mcpErrorFunction =
+    serverErrorFunction !== undefined
+      ? serverErrorFunction
+      : options.errorFunction;
   const errorFunction =
-    typeof serverErrorFunction === 'function'
+    typeof mcpErrorFunction === 'function'
       ? (context: RunContext, error: Error | unknown) =>
-          serverErrorFunction({ context, error })
-      : serverErrorFunction;
+          mcpErrorFunction({ context, error })
+      : mcpErrorFunction;
   async function invoke(input: any, runContext?: RunContext<any>) {
     let args = {};
     if (typeof input === 'string' && input) {
@@ -820,7 +1146,7 @@ export function mcpToFunctionTool(
     try {
       const strictSchema = ensureStrictJsonSchema(schema);
       return tool({
-        name: mcpTool.name,
+        name: toolName,
         description: mcpTool.description || '',
         parameters: strictSchema,
         strict: true,
@@ -837,7 +1163,7 @@ export function mcpToFunctionTool(
     additionalProperties: true,
   };
   return tool({
-    name: mcpTool.name,
+    name: toolName,
     description: mcpTool.description || '',
     parameters: nonStrictSchema,
     strict: false,

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -1771,6 +1771,7 @@ function getAgentIdentitySignature(agent: Agent<any, any>): string {
           },
     ),
     mcpServers: agent.mcpServers.map(summarizeIdentityValue),
+    mcpConfig: summarizeIdentityValue(agent.mcpConfig),
     inputGuardrails: agent.inputGuardrails.map(summarizeIdentityValue),
     outputGuardrails: agent.outputGuardrails.map(summarizeIdentityValue),
     outputType: summarizeIdentityValue(agent.outputType),

--- a/packages/agents-core/src/sandbox/agent.ts
+++ b/packages/agents-core/src/sandbox/agent.ts
@@ -70,6 +70,7 @@ export class SandboxAgent<
       modelSettings: config.modelSettings ?? this.modelSettings,
       tools: config.tools ?? this.tools,
       mcpServers: config.mcpServers ?? this.mcpServers,
+      mcpConfig: config.mcpConfig ?? this.mcpConfig,
       inputGuardrails: config.inputGuardrails ?? this.inputGuardrails,
       outputGuardrails: config.outputGuardrails ?? this.outputGuardrails,
       outputType: config.outputType ?? this.outputType,

--- a/packages/agents-core/test/mcpCache.test.ts
+++ b/packages/agents-core/test/mcpCache.test.ts
@@ -1,12 +1,14 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { getAllMcpTools, invalidateServerToolsCache } from '../src/mcp';
 import { UserError } from '../src/errors';
-import type { FunctionTool } from '../src/tool';
+import { tool, type FunctionTool } from '../src/tool';
 import { withTrace } from '../src/tracing';
 import { NodeMCPServerStdio } from '../src/shims/mcp-server/node';
 import type { CallToolResultContent, MCPServer } from '../src/mcp';
 import { RunContext } from '../src/runContext';
 import { Agent } from '../src/agent';
+import { handoff } from '../src/handoff';
+import { z } from 'zod';
 
 class StubServer extends NodeMCPServerStdio {
   public toolList: any[];
@@ -311,6 +313,375 @@ describe('MCP tools uniqueness', () => {
           agent: new Agent({ name: 'AgentOne' }),
         }),
       ).rejects.toBeInstanceOf(UserError);
+    });
+  });
+
+  it('prefixes local MCP tool names with server names when requested', async () => {
+    await withTrace('test', async () => {
+      const serverA = new StubServer('docs', [
+        {
+          name: 'search',
+          description: '',
+          inputSchema: { type: 'object', properties: {} },
+        },
+        {
+          name: 'fetch',
+          description: '',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ]);
+      const serverB = new StubServer('calendar', [
+        {
+          name: 'search',
+          description: '',
+          inputSchema: { type: 'object', properties: {} },
+        },
+        {
+          name: 'update',
+          description: '',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ]);
+      serverA.cacheToolsList = false;
+      serverB.cacheToolsList = false;
+
+      const tools = await getAllMcpTools({
+        mcpServers: [serverA, serverB],
+        runContext: new RunContext({}),
+        agent: new Agent({ name: 'AgentOne' }),
+        includeServerInToolNames: true,
+      });
+
+      expect(tools.map((t) => t.name)).toEqual([
+        'mcp_docs__search',
+        'mcp_docs__fetch',
+        'mcp_calendar__search',
+        'mcp_calendar__update',
+      ]);
+    });
+  });
+
+  it('sanitizes non-ASCII MCP server and tool names before prefixing', async () => {
+    await withTrace('test', async () => {
+      const server = new StubServer('天気サーバー', [
+        {
+          name: '検索',
+          description: '',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ]);
+      server.cacheToolsList = false;
+
+      const tools = await getAllMcpTools({
+        mcpServers: [server],
+        runContext: new RunContext({}),
+        agent: new Agent({ name: 'AgentOne' }),
+        includeServerInToolNames: true,
+      });
+
+      expect(tools.map((t) => t.name)).toEqual(['mcp_server__tool']);
+      expect(tools[0].name.length).toBeLessThanOrEqual(64);
+      expect(/^[A-Za-z0-9_-]+$/.test(tools[0].name)).toBe(true);
+    });
+  });
+
+  it('shortens long prefixed MCP names with deterministic hashes', async () => {
+    await withTrace('test', async () => {
+      const longServerName = `server_${'a'.repeat(100)}`;
+      const longToolName = `tool_${'b'.repeat(100)}`;
+      const serverA = new StubServer(longServerName, [
+        {
+          name: longToolName,
+          description: '',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ]);
+      const serverB = new StubServer(longServerName, [
+        {
+          name: longToolName,
+          description: '',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ]);
+      serverA.cacheToolsList = false;
+      serverB.cacheToolsList = false;
+
+      const tools = await getAllMcpTools({
+        mcpServers: [serverA, serverB],
+        runContext: new RunContext({}),
+        agent: new Agent({ name: 'AgentOne' }),
+        includeServerInToolNames: true,
+      });
+      const names = tools.map((t) => t.name);
+
+      expect(new Set(names).size).toBe(2);
+      expect(names.every((name) => name.length <= 64)).toBe(true);
+      expect(names.every((name) => /^[A-Za-z0-9_-]+$/.test(name))).toBe(true);
+    });
+  });
+
+  it('allocates normalized MCP tool name collisions stably', async () => {
+    async function publicNamesByOriginalTool(
+      toolNames: string[],
+    ): Promise<Record<string, string>> {
+      const server = new StubServer(
+        'docs',
+        toolNames.map((name) => ({
+          name,
+          description: '',
+          inputSchema: { type: 'object', properties: {} },
+        })),
+      );
+      server.cacheToolsList = false;
+
+      const tools = await getAllMcpTools({
+        mcpServers: [server],
+        runContext: new RunContext({}),
+        agent: new Agent({ name: 'AgentOne' }),
+        includeServerInToolNames: true,
+      });
+
+      return Object.fromEntries(
+        server.toolList.map((mcpTool, index) => {
+          const tool = tools[index];
+          if (!tool) {
+            throw new Error(`Missing function tool at index ${index}`);
+          }
+          return [String(mcpTool.name), tool.name];
+        }),
+      );
+    }
+
+    await withTrace('test', async () => {
+      const firstOrder = await publicNamesByOriginalTool(['search', 'search!']);
+      const reversedOrder = await publicNamesByOriginalTool([
+        'search!',
+        'search',
+      ]);
+
+      expect(firstOrder).toEqual(reversedOrder);
+      expect(Object.values(firstOrder)).not.toContain('mcp_docs__search');
+      expect(new Set(Object.values(firstOrder)).size).toBe(2);
+      expect(
+        Object.values(firstOrder).every((name) =>
+          name.startsWith('mcp_docs__search_'),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it('reserves existing local function tool names when prefixing MCP tools', async () => {
+    await withTrace('test', async () => {
+      const server = new StubServer('docs', [
+        {
+          name: 'search',
+          description: '',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ]);
+      server.cacheToolsList = false;
+      const reservedTool = tool({
+        name: 'mcp_docs__search',
+        description: 'Reserved local tool.',
+        parameters: z.object({}),
+        execute: async () => 'ok',
+      });
+      const agent = new Agent({
+        name: 'AgentOne',
+        tools: [reservedTool],
+        mcpServers: [server],
+        mcpConfig: { includeServerInToolNames: true },
+      });
+
+      const tools = await agent.getMcpTools(new RunContext({}));
+
+      expect(tools[0].name).not.toBe('mcp_docs__search');
+      expect(tools[0].name.startsWith('mcp_docs__search_')).toBe(true);
+      expect(tools[0].name.length).toBeLessThanOrEqual(64);
+    });
+  });
+
+  it('reserves enabled handoff tool names when prefixing MCP tools', async () => {
+    await withTrace('test', async () => {
+      const server = new StubServer('calendar', [
+        {
+          name: 'search',
+          description: '',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ]);
+      server.cacheToolsList = false;
+      const handoffAgent = new Agent({ name: 'CalendarAgent' });
+      const agent = new Agent({
+        name: 'AgentOne',
+        handoffs: [
+          handoff(handoffAgent, {
+            toolNameOverride: 'mcp_calendar__search',
+          }),
+        ],
+        mcpServers: [server],
+        mcpConfig: { includeServerInToolNames: true },
+      });
+
+      const tools = await agent.getMcpTools(new RunContext({}));
+
+      expect(tools[0].name).not.toBe('mcp_calendar__search');
+      expect(tools[0].name.startsWith('mcp_calendar__search_')).toBe(true);
+    });
+  });
+
+  it('ignores disabled handoff tool names when prefixing MCP tools', async () => {
+    await withTrace('test', async () => {
+      const server = new StubServer('calendar', [
+        {
+          name: 'search',
+          description: '',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ]);
+      server.cacheToolsList = false;
+      const handoffAgent = new Agent({ name: 'CalendarAgent' });
+      const agent = new Agent({
+        name: 'AgentOne',
+        handoffs: [
+          handoff(handoffAgent, {
+            toolNameOverride: 'mcp_calendar__search',
+            isEnabled: false,
+          }),
+        ],
+        mcpServers: [server],
+        mcpConfig: { includeServerInToolNames: true },
+      });
+
+      const tools = await agent.getMcpTools(new RunContext({}));
+
+      expect(tools[0].name).toBe('mcp_calendar__search');
+    });
+  });
+
+  it('uses agent MCP config to force strict MCP tool schemas', async () => {
+    await withTrace('test', async () => {
+      const server = new StubServer('docs', [
+        {
+          name: 'search',
+          description: '',
+          inputSchema: {
+            type: 'object',
+            properties: { foo: { type: 'string' } },
+          },
+        },
+      ]);
+      server.cacheToolsList = false;
+      const agent = new Agent({
+        name: 'AgentOne',
+        mcpServers: [server],
+        mcpConfig: { convertSchemasToStrict: true },
+      });
+
+      const mcpTools = (await agent.getMcpTools(
+        new RunContext({}),
+      )) as FunctionTool[];
+      const mcpTool = mcpTools[0]!;
+
+      expect(mcpTool.strict).toBe(true);
+      expect(mcpTool.parameters.additionalProperties).toBe(false);
+      expect(mcpTool.parameters.required).toEqual(['foo']);
+    });
+  });
+
+  it('uses agent MCP config errorFunction for MCP tool failures', async () => {
+    await withTrace('test', async () => {
+      const server = new StubServer('docs', [
+        {
+          name: 'search',
+          description: '',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ]);
+      server.cacheToolsList = false;
+      const callTool = vi.fn(async () => {
+        throw new Error('boom');
+      });
+      server.callTool = callTool;
+      const errorFunction = vi.fn(() => 'agent failure');
+      const agent = new Agent({
+        name: 'AgentOne',
+        mcpServers: [server],
+        mcpConfig: { errorFunction },
+      });
+
+      const mcpTools = (await agent.getMcpTools(
+        new RunContext({}),
+      )) as FunctionTool[];
+      const mcpTool = mcpTools[0]!;
+      const result = await mcpTool.invoke(new RunContext({}), '{}');
+
+      expect(result).toBe('agent failure');
+      expect(errorFunction).toHaveBeenCalledTimes(1);
+      expect(callTool).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('lets server MCP errorFunction override agent MCP config', async () => {
+    await withTrace('test', async () => {
+      const server = new StubServer('docs', [
+        {
+          name: 'search',
+          description: '',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ]);
+      server.cacheToolsList = false;
+      server.callTool = vi.fn(async () => {
+        throw new Error('boom');
+      });
+      server.errorFunction = vi.fn(() => 'server failure');
+      const agentErrorFunction = vi.fn(() => 'agent failure');
+      const agent = new Agent({
+        name: 'AgentOne',
+        mcpServers: [server],
+        mcpConfig: { errorFunction: agentErrorFunction },
+      });
+
+      const mcpTools = (await agent.getMcpTools(
+        new RunContext({}),
+      )) as FunctionTool[];
+      const mcpTool = mcpTools[0]!;
+      const result = await mcpTool.invoke(new RunContext({}), '{}');
+
+      expect(result).toBe('server failure');
+      expect(server.errorFunction).toHaveBeenCalledTimes(1);
+      expect(agentErrorFunction).not.toHaveBeenCalled();
+    });
+  });
+
+  it('rethrows MCP tool failures when agent MCP config errorFunction is null', async () => {
+    await withTrace('test', async () => {
+      const server = new StubServer('docs', [
+        {
+          name: 'search',
+          description: '',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ]);
+      server.cacheToolsList = false;
+      server.callTool = vi.fn(async () => {
+        throw new Error('boom');
+      });
+      const agent = new Agent({
+        name: 'AgentOne',
+        mcpServers: [server],
+        mcpConfig: { errorFunction: null },
+      });
+
+      const mcpTools = (await agent.getMcpTools(
+        new RunContext({}),
+      )) as FunctionTool[];
+      const mcpTool = mcpTools[0]!;
+
+      await expect(mcpTool.invoke(new RunContext({}), '{}')).rejects.toThrow(
+        'boom',
+      );
     });
   });
 });

--- a/packages/agents-core/test/mcpToFunctionTool.test.ts
+++ b/packages/agents-core/test/mcpToFunctionTool.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { mcpToFunctionTool, MCPServer } from '../src/mcp';
+import type { MCPToolMetaContext } from '../src/mcpUtil';
 import { RunContext } from '../src/runContext';
 import { withTrace } from '../src/tracing';
 import { withCustomSpan } from '../src/tracing/createSpans';
@@ -184,6 +185,57 @@ describe('mcpToFunctionTool', () => {
     expect(metaContext.serverName).toBe('stub');
     expect(metaContext.toolName).toBe('meta');
     expect(metaContext.arguments).toEqual({ foo: 'bar' });
+  });
+
+  it('can expose an override name while invoking the original MCP tool name', async () => {
+    const callTool = vi.fn(
+      async (
+        _toolName: string,
+        _args: Record<string, unknown> | null,
+        _meta?: Record<string, unknown> | null,
+      ) => [{ type: 'text', text: 'ok' }],
+    );
+
+    const toolMetaResolver = vi.fn((_context: MCPToolMetaContext) => ({
+      request_id: 'req-123',
+    }));
+
+    const server: MCPServer = {
+      name: 'docs',
+      cacheToolsList: false,
+      toolMetaResolver,
+      connect: async () => {},
+      close: async () => {},
+      listTools: async () => [],
+      callTool,
+      invalidateToolsCache: async () => {},
+    };
+
+    const tool = mcpToFunctionTool(
+      {
+        name: 'search',
+        description: '',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      } as any,
+      server,
+      false,
+      { toolNameOverride: 'mcp_docs__search' },
+    );
+
+    expect(tool.name).toBe('mcp_docs__search');
+    await tool.invoke(new RunContext({}), '{}');
+
+    expect(callTool).toHaveBeenCalledWith(
+      'search',
+      {},
+      { request_id: 'req-123' },
+    );
+    expect(toolMetaResolver.mock.calls[0][0].toolName).toBe('search');
   });
 
   it('uses server errorFunction for tool failures', async () => {


### PR DESCRIPTION
This pull request adds Python SDK feature parity for local MCP agent configuration in the TypeScript SDK. It extends `Agent.mcpConfig` with strict schema conversion, custom MCP tool error handling, and server-prefixed local MCP tool names.

The change wires `convertSchemasToStrict`, `errorFunction`, and `includeServerInToolNames` through MCP tool conversion, with server-level error functions continuing to override agent-level defaults. It also keeps generated MCP tool names deterministic and collision-safe while preserving original MCP tool names for server invocation and metadata resolution.