### PR TITLE
fix: reject external symlink targets during Cloudflare workspace hydrate

### DIFF
--- a/.changeset/cloudflare-symlink-hydrate.md
+++ b/.changeset/cloudflare-symlink-hydrate.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: reject external symlink targets during Cloudflare workspace hydrate

--- a/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
@@ -569,7 +569,9 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
   async hydrateWorkspace(data: WorkspaceArchiveData): Promise<void> {
     assertTarWorkspacePersistence('CloudflareSandboxClient', 'tar');
     const archive = toWorkspaceArchiveBytes(data);
-    validateWorkspaceTarArchive(archive);
+    validateWorkspaceTarArchive(archive, {
+      allowExternalSymlinkTargets: false,
+    });
     const response = await this.fetch(
       `/v1/sandbox/${this.state.sandboxId}/hydrate`,
       {

--- a/packages/agents-extensions/src/sandbox/shared/archive.ts
+++ b/packages/agents-extensions/src/sandbox/shared/archive.ts
@@ -23,6 +23,7 @@ export type RemoteWorkspaceTarIo = RemoteManifestWriter & {
 
 export type WorkspaceTarValidationOptions = {
   allowSymlinks?: boolean;
+  allowExternalSymlinkTargets?: boolean;
   rejectSymlinkRelPaths?: Iterable<string>;
   skipRelPaths?: Iterable<string>;
   rootName?: string;
@@ -250,6 +251,7 @@ export function validateWorkspaceTarArchive(
           readTarString(header, 0, 100),
           readTarString(header, 345, 155),
         );
+      const linkName = pendingPax?.linkpath ?? readTarString(header, 157, 100);
       pendingPax = undefined;
       pendingLongName = undefined;
 
@@ -262,7 +264,7 @@ export function validateWorkspaceTarArchive(
         continue;
       }
 
-      const member = validateTarMember(name, rawType, options);
+      const member = validateTarMember(name, rawType, options, linkName);
       if (!member) {
         continue;
       }
@@ -343,6 +345,7 @@ function validateTarMember(
   name: string,
   typeFlag: string,
   options: WorkspaceTarValidationOptions,
+  linkName: string,
 ): TarMember | null {
   const relPath = safeTarMemberRelPath(name);
   if (relPath === null) {
@@ -368,6 +371,7 @@ function validateTarMember(
     ) {
       throw tarError(name, `symlink member not allowed: ${relPath}`);
     }
+    validateSymlinkTarget(name, relPath, linkName, options);
     return { rawName: name, path: relPath, type: 'symlink' };
   }
   if (typeFlag === '5') {
@@ -378,6 +382,28 @@ function validateTarMember(
   }
 
   throw tarError(name, 'unsupported member type');
+}
+
+function validateSymlinkTarget(
+  name: string,
+  relPath: string,
+  linkName: string,
+  options: WorkspaceTarValidationOptions,
+): void {
+  if (options.allowExternalSymlinkTargets !== false) {
+    return;
+  }
+  if (linkName.startsWith('/')) {
+    throw tarError(name, `absolute symlink target not allowed: ${linkName}`);
+  }
+
+  const parent = parentPath(relPath);
+  if (
+    normalizePosixPathWithoutRoot(parent ? `${parent}/${linkName}` : linkName)
+  ) {
+    return;
+  }
+  throw tarError(name, `symlink target escapes archive root: ${linkName}`);
 }
 
 function safeTarMemberRelPath(name: string): string | null {
@@ -449,6 +475,29 @@ function parentPaths(path: string): string[] {
     parents.push(parts.slice(0, index).join('/'));
   }
   return parents;
+}
+
+function parentPath(path: string): string {
+  const index = path.lastIndexOf('/');
+  return index < 0 ? '' : path.slice(0, index);
+}
+
+function normalizePosixPathWithoutRoot(path: string): string[] | null {
+  const normalized: string[] = [];
+  for (const part of path.split('/')) {
+    if (part === '' || part === '.') {
+      continue;
+    }
+    if (part === '..') {
+      if (normalized.length === 0) {
+        return null;
+      }
+      normalized.pop();
+      continue;
+    }
+    normalized.push(part);
+  }
+  return normalized;
 }
 
 function parsePaxPayload(payload: Uint8Array): Record<string, string> {

--- a/packages/agents-extensions/test/sandbox/cloudflare.test.ts
+++ b/packages/agents-extensions/test/sandbox/cloudflare.test.ts
@@ -1588,6 +1588,27 @@ describe('CloudflareSandboxClient', () => {
     );
   });
 
+  test('rejects external symlink targets before hydrating workspace archives', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+    const session = await client.resume({
+      manifest: new Manifest(),
+      workerUrl: 'https://worker.example.com',
+      sandboxId: 'cf_test',
+      environment: {},
+    });
+    vi.mocked(global.fetch).mockClear();
+
+    await expect(
+      session.hydrateWorkspace(
+        makeTarArchive([{ name: 'link', type: '2', linkName: '/tmp/outside' }]),
+      ),
+    ).rejects.toThrow(/absolute symlink target not allowed/);
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
   test('rejects unsupported manifest metadata during resume', async () => {
     const client = new CloudflareSandboxClient({
       workerUrl: 'https://worker.example.com',

--- a/packages/agents-extensions/test/sandbox/shared.test.ts
+++ b/packages/agents-extensions/test/sandbox/shared.test.ts
@@ -1312,6 +1312,41 @@ describe('remote sandbox path helpers', () => {
     expect(() =>
       validateWorkspaceTarArchive(symlinkArchive, { allowSymlinks: false }),
     ).toThrow(SandboxArchiveError);
+    expect(() =>
+      validateWorkspaceTarArchive(symlinkArchive, {
+        allowExternalSymlinkTargets: false,
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      validateWorkspaceTarArchive(
+        makeTarArchive([{ name: 'link', type: '2', linkName: '/tmp/outside' }]),
+      ),
+    ).not.toThrow();
+    expect(() =>
+      validateWorkspaceTarArchive(
+        makeTarArchive([{ name: 'link', type: '2', linkName: '/tmp/outside' }]),
+        { allowExternalSymlinkTargets: false },
+      ),
+    ).toThrow(/absolute symlink target not allowed/);
+    expect(() =>
+      validateWorkspaceTarArchive(
+        makeTarArchive([
+          { name: 'nested', type: '5' },
+          { name: 'nested/link', type: '2', linkName: '../../outside' },
+        ]),
+        { allowExternalSymlinkTargets: false },
+      ),
+    ).toThrow(/symlink target escapes archive root/);
+    expect(() =>
+      validateWorkspaceTarArchive(
+        makeTarArchive([
+          { name: 'nested', type: '5' },
+          { name: 'nested/link', type: '2', linkName: '../safe/file.txt' },
+        ]),
+        { allowExternalSymlinkTargets: false },
+      ),
+    ).not.toThrow();
   });
 
   test('rejects symbolic links before hydrating tar archives', async () => {


### PR DESCRIPTION
This pull request fixes Cloudflare workspace hydrate archive validation so tar archives with symlinks pointing outside the archive root are rejected before upload. It adds a shared tar validation option for external symlink targets, enables that stricter mode for Cloudflare hydrate, and covers absolute, escaping, and internal symlink target cases with tests.

The change preserves existing default tar validation behavior while tightening the Cloudflare hydrate path that hands user-provided archives to the remote worker.

see also: https://github.com/openai/openai-agents-python/pull/3094