### PR TITLE
fix: restore session history when responses compaction replacement fails

### DIFF
--- a/.changeset/quiet-lamps-restore.md
+++ b/.changeset/quiet-lamps-restore.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: restore session history when responses compaction replacement fails

--- a/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
+++ b/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
@@ -204,10 +204,11 @@ export class OpenAIResponsesCompactionSession
     const compacted = await this.client.responses.compact(compactRequest);
 
     const outputItems = normalizeCompactionOutputItems(compacted.output ?? []);
-    await this.underlyingSession.clearSession();
-    if (outputItems.length > 0) {
-      await this.underlyingSession.addItems(outputItems);
-    }
+    const previousItems = await this.getAllUnderlyingSessionItems();
+    await this.replaceUnderlyingSessionItems({
+      outputItems,
+      previousItems,
+    });
     this.compactionCandidateItems = selectCompactionCandidateItems(outputItems);
     this.sessionItems = outputItems;
 
@@ -285,6 +286,87 @@ export class OpenAIResponsesCompactionSession
     await this.underlyingSession.clearSession();
     this.compactionCandidateItems = [];
     this.sessionItems = [];
+  }
+
+  private async getAllUnderlyingSessionItems(): Promise<AgentInputItem[]> {
+    return this.underlyingSession.getItems();
+  }
+
+  private async replaceUnderlyingSessionItems({
+    outputItems,
+    previousItems,
+  }: {
+    outputItems: AgentInputItem[];
+    previousItems: AgentInputItem[];
+  }): Promise<void> {
+    try {
+      await this.underlyingSession.clearSession();
+    } catch (error) {
+      await this.restoreUnderlyingSessionItemsAfterFailedClear(
+        previousItems,
+        error,
+      );
+      throw error;
+    }
+
+    try {
+      if (outputItems.length > 0) {
+        await this.underlyingSession.addItems(outputItems);
+      }
+    } catch (error) {
+      await this.restoreUnderlyingSessionItems(previousItems, error);
+      throw error;
+    }
+  }
+
+  private async restoreUnderlyingSessionItemsAfterFailedClear(
+    previousItems: AgentInputItem[],
+    error: unknown,
+  ): Promise<void> {
+    let currentItems: AgentInputItem[];
+    try {
+      currentItems = await this.getAllUnderlyingSessionItems();
+    } catch (inspectionError) {
+      logger.warn(
+        'Failed to inspect session history after compaction replacement clear failed.',
+        inspectionError,
+      );
+      return;
+    }
+
+    if (areAgentItemsEqual(currentItems, previousItems)) {
+      return;
+    }
+
+    await this.restoreUnderlyingSessionItems(previousItems, error, {
+      clearExistingItems: false,
+    });
+  }
+
+  private async restoreUnderlyingSessionItems(
+    previousItems: AgentInputItem[],
+    error: unknown,
+    options: { clearExistingItems?: boolean } = {},
+  ): Promise<void> {
+    try {
+      if (options.clearExistingItems !== false) {
+        await this.underlyingSession.clearSession();
+      }
+      if (previousItems.length > 0) {
+        await this.underlyingSession.addItems(previousItems);
+      }
+    } catch (restoreError) {
+      logger.warn(
+        'Failed to restore session history after compaction replacement failed.',
+        restoreError,
+      );
+      return;
+    }
+
+    logger.warn(
+      'Restored previous session history after compaction replacement failed.',
+      error,
+    );
   }
 
   private async ensureCompactionCandidates(): Promise<{
@@ -524,4 +606,11 @@ function isOpenAIConversationsSessionDelegate(
       OPENAI_SESSION_API
     ] === 'conversations'
   );
+}
+
+function areAgentItemsEqual(
+  left: AgentInputItem[],
+  right: AgentInputItem[],
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
 }

--- a/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
+++ b/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
@@ -339,17 +339,27 @@ export class OpenAIResponsesCompactionSession
     }
 
     await this.restoreUnderlyingSessionItems(previousItems, error, {
-      clearExistingItems: false,
+      popExistingItemCount: currentItems.length,
     });
   }
 
   private async restoreUnderlyingSessionItems(
     previousItems: AgentInputItem[],
     error: unknown,
-    options: { clearExistingItems?: boolean } = {},
+    options: {
+      clearExistingItems?: boolean;
+      popExistingItemCount?: number;
+    } = {},
   ): Promise<void> {
     try {
-      if (options.clearExistingItems !== false) {
+      if (options.popExistingItemCount !== undefined) {
+        for (let i = 0; i < options.popExistingItemCount; i += 1) {
+          const popped = await this.underlyingSession.popItem();
+          if (!popped) {
+            break;
+          }
+        }
+      } else if (options.clearExistingItems !== false) {
         await this.underlyingSession.clearSession();
       }
       if (previousItems.length > 0) {

--- a/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
+++ b/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
@@ -46,10 +46,16 @@ class FailingClearBeforeMutationSession extends MemorySession {
 class FailingClearAfterMutationSession extends MemorySession {
   addCalls = 0;
   clearCalls = 0;
+  popCalls = 0;
 
   async addItems(items: AgentInputItem[]): Promise<void> {
     this.addCalls += 1;
     await super.addItems(items);
+  }
+
+  async popItem(): Promise<AgentInputItem | undefined> {
+    this.popCalls += 1;
+    return super.popItem();
   }
 
   async clearSession(): Promise<void> {
@@ -664,6 +670,87 @@ describe('OpenAIResponsesCompactionSession', () => {
 
       expect(await underlyingSession.getItems()).toEqual(history);
       expect(underlyingSession.clearCalls).toBe(1);
+      expect(underlyingSession.addCalls).toBe(1);
+      expect(underlyingSession.popCalls).toBe(0);
+      expect(warn).toHaveBeenCalledWith(
+        'Restored previous session history after compaction replacement failed.',
+        expect.any(Error),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('clears partial history before restoring after clearSession fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const history = [
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'survived clear' }],
+      },
+      {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'removed by partial clear' }],
+      },
+    ] as AgentInputItem[];
+
+    class PartiallyFailingClearSession extends MemorySession {
+      addCalls = 0;
+      clearCalls = 0;
+      popCalls = 0;
+
+      async addItems(items: AgentInputItem[]): Promise<void> {
+        this.addCalls += 1;
+        await super.addItems(items);
+      }
+
+      async popItem(): Promise<AgentInputItem | undefined> {
+        this.popCalls += 1;
+        return super.popItem();
+      }
+
+      async clearSession(): Promise<void> {
+        this.clearCalls += 1;
+        await super.popItem();
+        throw new Error('clear failed');
+      }
+    }
+
+    const underlyingSession = new PartiallyFailingClearSession({
+      initialItems: history,
+    });
+    const compact = vi.fn().mockResolvedValue({
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'compacted' }],
+        },
+      ],
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        total_tokens: 2,
+      },
+    });
+    const session = new OpenAIResponsesCompactionSession({
+      client: { responses: { compact } } as any,
+      underlyingSession,
+      compactionMode: 'input',
+    });
+
+    try {
+      await expect(
+        session.runCompaction({ force: true, compactionMode: 'input' }),
+      ).rejects.toThrow('clear failed');
+
+      expect(await underlyingSession.getItems()).toEqual(history);
+      expect(underlyingSession.clearCalls).toBe(1);
+      expect(underlyingSession.popCalls).toBe(1);
       expect(underlyingSession.addCalls).toBe(1);
       expect(warn).toHaveBeenCalledWith(
         'Restored previous session history after compaction replacement failed.',

--- a/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
+++ b/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
@@ -1,10 +1,82 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { MemorySession } from '@openai/agents-core';
-import { UserError } from '@openai/agents-core';
+import {
+  MemorySession,
+  UserError,
+  type AgentInputItem,
+} from '@openai/agents-core';
 
 import { OpenAIResponsesCompactionSession } from '../src';
 import { OPENAI_SESSION_API } from '../src/memory/openaiSessionApi';
+
+class PartiallyFailingReplacementSession extends MemorySession {
+  addCalls = 0;
+  clearCalls = 0;
+
+  async addItems(items: AgentInputItem[]): Promise<void> {
+    this.addCalls += 1;
+    if (this.addCalls === 1) {
+      await super.addItems(items.slice(0, 1));
+      throw new Error('replacement failed');
+    }
+    await super.addItems(items);
+  }
+
+  async clearSession(): Promise<void> {
+    this.clearCalls += 1;
+    await super.clearSession();
+  }
+}
+
+class FailingClearBeforeMutationSession extends MemorySession {
+  addCalls = 0;
+  clearCalls = 0;
+
+  async addItems(items: AgentInputItem[]): Promise<void> {
+    this.addCalls += 1;
+    await super.addItems(items);
+  }
+
+  async clearSession(): Promise<void> {
+    this.clearCalls += 1;
+    throw new Error('clear failed');
+  }
+}
+
+class FailingClearAfterMutationSession extends MemorySession {
+  addCalls = 0;
+  clearCalls = 0;
+
+  async addItems(items: AgentInputItem[]): Promise<void> {
+    this.addCalls += 1;
+    await super.addItems(items);
+  }
+
+  async clearSession(): Promise<void> {
+    this.clearCalls += 1;
+    await super.clearSession();
+    throw new Error('clear failed');
+  }
+}
+
+class FailingRestoreSession extends MemorySession {
+  addCalls = 0;
+  clearCalls = 0;
+
+  async addItems(items: AgentInputItem[]): Promise<void> {
+    this.addCalls += 1;
+    if (this.addCalls === 1) {
+      await super.addItems(items.slice(0, 1));
+      throw new Error('replacement failed');
+    }
+    throw new Error('restore failed');
+  }
+
+  async clearSession(): Promise<void> {
+    this.clearCalls += 1;
+    await super.clearSession();
+  }
+}
 
 describe('OpenAIResponsesCompactionSession', () => {
   it('rejects non-OpenAI model names', () => {
@@ -447,6 +519,213 @@ describe('OpenAIResponsesCompactionSession', () => {
         content: [{ type: 'output_text', text: 'second pass' }],
       },
     ]);
+  });
+
+  it('restores history when replacement addItems fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const history = [
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'original' }],
+      },
+      {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'private records' }],
+      },
+    ] as AgentInputItem[];
+    const underlyingSession = new PartiallyFailingReplacementSession({
+      initialItems: history,
+    });
+    const compact = vi.fn().mockResolvedValue({
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'compacted one' }],
+        },
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'compacted two' }],
+        },
+      ],
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        total_tokens: 2,
+      },
+    });
+    const session = new OpenAIResponsesCompactionSession({
+      client: { responses: { compact } } as any,
+      underlyingSession,
+      compactionMode: 'input',
+    });
+
+    try {
+      await expect(
+        session.runCompaction({ force: true, compactionMode: 'input' }),
+      ).rejects.toThrow('replacement failed');
+
+      expect(await underlyingSession.getItems()).toEqual(history);
+      expect(underlyingSession.clearCalls).toBe(2);
+      expect(underlyingSession.addCalls).toBe(2);
+      expect(warn).toHaveBeenCalledWith(
+        'Restored previous session history after compaction replacement failed.',
+        expect.any(Error),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('does not restore when clearSession fails without mutation', async () => {
+    const history = [
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'original' }],
+      },
+    ] as AgentInputItem[];
+    const underlyingSession = new FailingClearBeforeMutationSession({
+      initialItems: history,
+    });
+    const compact = vi.fn().mockResolvedValue({
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'compacted' }],
+        },
+      ],
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        total_tokens: 2,
+      },
+    });
+    const session = new OpenAIResponsesCompactionSession({
+      client: { responses: { compact } } as any,
+      underlyingSession,
+      compactionMode: 'input',
+    });
+
+    await expect(
+      session.runCompaction({ force: true, compactionMode: 'input' }),
+    ).rejects.toThrow('clear failed');
+
+    expect(await underlyingSession.getItems()).toEqual(history);
+    expect(underlyingSession.clearCalls).toBe(1);
+    expect(underlyingSession.addCalls).toBe(0);
+  });
+
+  it('restores history when clearSession fails after mutation', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const history = [
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'original' }],
+      },
+    ] as AgentInputItem[];
+    const underlyingSession = new FailingClearAfterMutationSession({
+      initialItems: history,
+    });
+    const compact = vi.fn().mockResolvedValue({
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'compacted' }],
+        },
+      ],
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        total_tokens: 2,
+      },
+    });
+    const session = new OpenAIResponsesCompactionSession({
+      client: { responses: { compact } } as any,
+      underlyingSession,
+      compactionMode: 'input',
+    });
+
+    try {
+      await expect(
+        session.runCompaction({ force: true, compactionMode: 'input' }),
+      ).rejects.toThrow('clear failed');
+
+      expect(await underlyingSession.getItems()).toEqual(history);
+      expect(underlyingSession.clearCalls).toBe(1);
+      expect(underlyingSession.addCalls).toBe(1);
+      expect(warn).toHaveBeenCalledWith(
+        'Restored previous session history after compaction replacement failed.',
+        expect.any(Error),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('reraises replacement errors when restore fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const history = [
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'original' }],
+      },
+    ] as AgentInputItem[];
+    const underlyingSession = new FailingRestoreSession({
+      initialItems: history,
+    });
+    const compact = vi.fn().mockResolvedValue({
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'compacted one' }],
+        },
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'compacted two' }],
+        },
+      ],
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        total_tokens: 2,
+      },
+    });
+    const session = new OpenAIResponsesCompactionSession({
+      client: { responses: { compact } } as any,
+      underlyingSession,
+      compactionMode: 'input',
+    });
+
+    try {
+      await expect(
+        session.runCompaction({ force: true, compactionMode: 'input' }),
+      ).rejects.toThrow('replacement failed');
+      expect(warn).toHaveBeenCalledWith(
+        'Failed to restore session history after compaction replacement failed.',
+        expect.any(Error),
+      );
+      expect(underlyingSession.clearCalls).toBe(2);
+      expect(underlyingSession.addCalls).toBe(2);
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it('normalizes compacted user image messages before reusing them as input', async () => {


### PR DESCRIPTION
This pull request fixes a data-loss edge case in `OpenAIResponsesCompactionSession` when replacing stored history after `responses.compact`.

The previous flow cleared the underlying session before writing compacted output, so a failing `addItems()` call could leave the session empty or partially replaced. The new flow snapshots the previous session items, restores them when replacement fails, and preserves the original replacement error when restore itself fails.

This mirrors the safety fix from the Python SDK: https://github.com/openai/openai-agents-python/pull/3117