### PR TITLE
fix: constrain local sandbox artifact sources to source base directory

### DIFF
--- a/.changeset/friendly-sandboxes-guard.md
+++ b/.changeset/friendly-sandboxes-guard.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': minor
+'@openai/agents-extensions': minor
+---
+
+fix: constrain local sandbox artifact sources to the source base directory by default

--- a/.changeset/friendly-sandboxes-guard.md
+++ b/.changeset/friendly-sandboxes-guard.md
@@ -3,4 +3,4 @@
 '@openai/agents-extensions': minor
 ---
 
-fix: constrain local sandbox artifact sources to the source base directory by default
+fix: require extra path grants for local sandbox sources outside the base directory

--- a/examples/docs/sandbox-agents/basic.ts
+++ b/examples/docs/sandbox-agents/basic.ts
@@ -19,7 +19,7 @@ const hostSkillsDir = join(exampleDir, 'skills');
 
 const manifest = new Manifest({
   entries: {
-    repo: localDir({ src: hostRepoDir }),
+    repo: localDir({ src: hostRepoDir, allowOutsideBaseDir: true }),
   },
 });
 
@@ -32,7 +32,10 @@ const agent = new SandboxAgent({
   capabilities: [
     ...Capabilities.default(),
     skills({
-      lazyFrom: localDirLazySkillSource(hostSkillsDir),
+      lazyFrom: localDirLazySkillSource({
+        src: hostSkillsDir,
+        allowOutsideBaseDir: true,
+      }),
     }),
   ],
 });

--- a/examples/docs/sandbox-agents/basic.ts
+++ b/examples/docs/sandbox-agents/basic.ts
@@ -19,7 +19,7 @@ const hostSkillsDir = join(exampleDir, 'skills');
 
 const manifest = new Manifest({
   entries: {
-    repo: localDir({ src: hostRepoDir, allowOutsideBaseDir: true }),
+    repo: localDir({ src: hostRepoDir }),
   },
 });
 
@@ -34,7 +34,6 @@ const agent = new SandboxAgent({
     skills({
       lazyFrom: localDirLazySkillSource({
         src: hostSkillsDir,
-        allowOutsideBaseDir: true,
       }),
     }),
   ],

--- a/examples/sandbox/coding-task.ts
+++ b/examples/sandbox/coding-task.ts
@@ -115,7 +115,6 @@ async function main() {
         repo: {
           type: 'local_dir',
           src: REPO_DIR,
-          allowOutsideBaseDir: true,
         },
       },
     }),
@@ -126,7 +125,6 @@ async function main() {
           source: {
             type: 'local_dir',
             src: SKILLS_DIR,
-            allowOutsideBaseDir: true,
           },
           index: [
             {

--- a/examples/sandbox/coding-task.ts
+++ b/examples/sandbox/coding-task.ts
@@ -112,14 +112,22 @@ async function main() {
       'Inspect the repo, make the smallest correct change, run the most relevant checks, and summarize the file changes and risks. Read `repo/task.md` before editing files, stay grounded in the repository, use the `$credit-note-fixer` skill before editing files, prefer apply_patch for file edits when available, remember that apply_patch paths are relative to the sandbox workspace root, and use relative shell paths because the shell already starts in the workspace root.',
     defaultManifest: new Manifest({
       entries: {
-        repo: { type: 'local_dir', src: REPO_DIR },
+        repo: {
+          type: 'local_dir',
+          src: REPO_DIR,
+          allowOutsideBaseDir: true,
+        },
       },
     }),
     capabilities: [
       ...Capabilities.default(),
       skills({
         lazyFrom: {
-          source: { type: 'local_dir', src: SKILLS_DIR },
+          source: {
+            type: 'local_dir',
+            src: SKILLS_DIR,
+            allowOutsideBaseDir: true,
+          },
           index: [
             {
               name: 'credit-note-fixer',

--- a/examples/sandbox/sandbox-agent-capabilities.ts
+++ b/examples/sandbox/sandbox-agent-capabilities.ts
@@ -111,7 +111,11 @@ Use relative paths because the shell starts in the workspace root.`,
       ...Capabilities.default(),
       skills({
         lazyFrom: {
-          source: { type: 'local_dir', src: skillsRoot },
+          source: {
+            type: 'local_dir',
+            src: skillsRoot,
+            allowOutsideBaseDir: true,
+          },
           index: [
             {
               name: 'capability-proof',

--- a/examples/sandbox/sandbox-agent-capabilities.ts
+++ b/examples/sandbox/sandbox-agent-capabilities.ts
@@ -60,8 +60,9 @@ When loaded, use these exact verification values:
   );
 }
 
-function buildManifest() {
+function buildManifest(skillsRoot: string) {
   return new Manifest({
+    extraPathGrants: [{ path: skillsRoot, readOnly: true }],
     entries: {
       'README.md': {
         type: 'file',
@@ -91,7 +92,7 @@ async function main() {
   const skillsRoot = join(tempDir, 'skills');
   await writeSkill(skillsRoot);
 
-  const manifest = buildManifest();
+  const manifest = buildManifest(skillsRoot);
   const client = new UnixLocalSandboxClient();
   const session = await client.create(manifest);
   const agent = new SandboxAgent({
@@ -114,7 +115,6 @@ Use relative paths because the shell starts in the workspace root.`,
           source: {
             type: 'local_dir',
             src: skillsRoot,
-            allowOutsideBaseDir: true,
           },
           index: [
             {

--- a/packages/agents-core/src/sandbox/capabilities/skills.ts
+++ b/packages/agents-core/src/sandbox/capabilities/skills.ts
@@ -27,6 +27,7 @@ export type SkillIndexEntry = {
 export type LocalDirLazySkillSource = {
   source: Dir | LocalDir | GitRepo;
   index?: SkillIndexEntry[];
+  getIndex?: (manifest: Manifest, skillsPath: string) => SkillIndexEntry[];
 };
 
 export type SkillDescriptor = {
@@ -99,7 +100,11 @@ class SkillsCapability extends Capability {
           skill_name: string;
           path: string;
         }> => {
-          const match = resolveLazySkillMatch(this, skill_name);
+          const match = resolveLazySkillMatch(
+            this,
+            skill_name,
+            session.state.manifest,
+          );
           const relativeSkillPath = normalizeRelativePath(
             match.path ?? match.name,
           );
@@ -190,6 +195,7 @@ class SkillsCapability extends Capability {
     const metadata = resolveSkillsMetadata(
       this,
       await this.resolveRuntimeMetadata(manifest),
+      manifest,
     );
     if (metadata.length === 0 && this.from) {
       return renderSkillsDiscoveryInstructions(this.skillsPath);
@@ -378,6 +384,7 @@ function normalizeSkillContent(
 function resolveSkillsMetadata(
   capability: SkillsCapability,
   runtimeMetadata: SkillIndexEntry[] = [],
+  manifest?: Manifest,
 ): SkillIndexEntry[] {
   if (capability.skills.length > 0) {
     return capability.skills
@@ -390,7 +397,11 @@ function resolveSkillsMetadata(
   }
 
   const configuredIndex =
-    resolveLazySkillIndex(capability.lazyFrom) ??
+    resolveLazySkillIndex(
+      capability.lazyFrom,
+      manifest,
+      capability.skillsPath,
+    ) ??
     capability.index ??
     (runtimeMetadata.length > 0 ? runtimeMetadata : undefined) ??
     deriveIndexFromDirEntry(capability.from);
@@ -453,12 +464,18 @@ function unquoteFrontmatterValue(value: string): string {
 
 function resolveLazySkillIndex(
   lazySource: LocalDirLazySkillSource | undefined,
+  manifest?: Manifest,
+  skillsPath: string = '.agents',
 ): SkillIndexEntry[] | undefined {
   if (!lazySource) {
     return undefined;
   }
   if (lazySource.index) {
     return lazySource.index;
+  }
+  if (lazySource.getIndex && manifest) {
+    const derivedIndex = lazySource.getIndex(manifest, skillsPath);
+    return derivedIndex.length > 0 ? derivedIndex : undefined;
   }
 
   const derivedIndex = deriveIndexFromDirEntry(lazySource.source);
@@ -529,9 +546,16 @@ ${lazyLoadingSection}${usageInstructions}
 function resolveLazySkillMatch(
   capability: SkillsCapability,
   skillName: string,
+  manifest: Manifest,
 ): SkillIndexEntry {
   const index =
-    resolveLazySkillIndex(capability.lazyFrom) ?? capability.index ?? [];
+    resolveLazySkillIndex(
+      capability.lazyFrom,
+      manifest,
+      capability.skillsPath,
+    ) ??
+    capability.index ??
+    [];
   const matches = index.filter((skill) => {
     const relativePath = normalizeRelativePath(skill.path ?? skill.name);
     const pathBaseName = relativePath.split('/').pop() ?? relativePath;

--- a/packages/agents-core/src/sandbox/entries/types.ts
+++ b/packages/agents-core/src/sandbox/entries/types.ts
@@ -21,19 +21,11 @@ export type File = EntryBase & {
 export type LocalFile = EntryBase & {
   type: 'local_file';
   src: string;
-  /**
-   * Allow reading a host source path outside the local source base directory.
-   */
-  allowOutsideBaseDir?: boolean;
 };
 
 export type LocalDir = EntryBase & {
   type: 'local_dir';
   src: string;
-  /**
-   * Allow reading a host source path outside the local source base directory.
-   */
-  allowOutsideBaseDir?: boolean;
 };
 
 export type GitRepo = EntryBase & {

--- a/packages/agents-core/src/sandbox/entries/types.ts
+++ b/packages/agents-core/src/sandbox/entries/types.ts
@@ -21,11 +21,19 @@ export type File = EntryBase & {
 export type LocalFile = EntryBase & {
   type: 'local_file';
   src: string;
+  /**
+   * Allow reading a host source path outside the local source base directory.
+   */
+  allowOutsideBaseDir?: boolean;
 };
 
 export type LocalDir = EntryBase & {
   type: 'local_dir';
   src: string;
+  /**
+   * Allow reading a host source path outside the local source base directory.
+   */
+  allowOutsideBaseDir?: boolean;
 };
 
 export type GitRepo = EntryBase & {

--- a/packages/agents-core/src/sandbox/localSkills.ts
+++ b/packages/agents-core/src/sandbox/localSkills.ts
@@ -1,17 +1,13 @@
-import {
-  lstatSync,
-  readdirSync,
-  readFileSync,
-  realpathSync,
-  statSync,
-} from 'node:fs';
-import { join, resolve } from 'node:path';
+import { lstatSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import {
   parseSkillFrontmatter,
   type LocalDirLazySkillSource,
   type SkillIndexEntry,
 } from './capabilities/skills';
 import { localDir } from './entries';
+import type { Manifest } from './manifest';
+import type { SandboxPathGrant } from './pathGrants';
 import { isHostPathWithinRoot } from './shared/hostPath';
 
 export type LocalDirLazySkillSourceOptions = {
@@ -24,10 +20,6 @@ export type LocalDirLazySkillSourceOptions = {
    * Defaults to the current working directory.
    */
   baseDir?: string;
-  /**
-   * Allow reading skill metadata and materializing skills outside the local source base directory.
-   */
-  allowOutsideBaseDir?: boolean;
 };
 
 export function localDirLazySkillSource(
@@ -37,27 +29,24 @@ export function localDirLazySkillSource(
     typeof srcOrOptions === 'string' ? { src: srcOrOptions } : srcOrOptions;
   const sourceRoot = resolve(options.baseDir ?? process.cwd(), options.src);
   return {
-    source: localDir({
-      src: sourceRoot,
-      ...(options.allowOutsideBaseDir ? { allowOutsideBaseDir: true } : {}),
-    }),
-    index: discoverLocalDirSkillIndex(options),
+    source: localDir({ src: sourceRoot }),
+    getIndex: (manifest: Manifest) =>
+      discoverLocalDirSkillIndex(options, manifest.extraPathGrants),
   };
 }
 
 function discoverLocalDirSkillIndex(
   options: LocalDirLazySkillSourceOptions,
+  sourceGrants: SandboxPathGrant[] = [],
 ): SkillIndexEntry[] {
   const base = resolve(options.baseDir ?? process.cwd());
-  const root = resolve(base, options.src);
-  if (
-    !options.allowOutsideBaseDir &&
-    (!isHostPathWithinRoot(base, root) ||
-      !isResolvedLocalSourceWithinBase(base, root))
-  ) {
+  let root: string;
+  try {
+    root = resolveLocalSkillSourcePath(options.src, base, sourceGrants);
+  } catch {
     return [];
   }
-  if (!isDirectory(root)) {
+  if (hasLocalSourceSymlinkAncestor(root) || !isDirectory(root)) {
     return [];
   }
 
@@ -88,20 +77,50 @@ function discoverLocalDirSkillIndex(
     });
 }
 
-function isResolvedLocalSourceWithinBase(base: string, root: string): boolean {
+function resolveLocalSkillSourcePath(
+  sourcePath: string,
+  base: string,
+  sourceGrants: SandboxPathGrant[],
+): string {
+  const resolvedSourcePath = resolve(base, sourcePath);
+  if (
+    isHostPathWithinRoot(base, resolvedSourcePath) ||
+    sourceGrants.some((grant) =>
+      isHostPathWithinRoot(resolve(grant.path), resolvedSourcePath),
+    )
+  ) {
+    return resolvedSourcePath;
+  }
+  throw new Error('local skill source is outside base directory');
+}
+
+function isDirectory(path: string): boolean {
   try {
-    return isHostPathWithinRoot(realpathSync(base), realpathSync(root));
+    return lstatSync(path).isDirectory();
   } catch {
     return false;
   }
 }
 
-function isDirectory(path: string): boolean {
-  try {
-    return statSync(path).isDirectory();
-  } catch {
-    return false;
+function hasLocalSourceSymlinkAncestor(path: string): boolean {
+  const resolvedPath = resolve(path);
+  let current = dirname(resolvedPath);
+
+  while (current !== dirname(current)) {
+    const parent = dirname(current);
+    if (parent === dirname(parent)) {
+      break;
+    }
+    try {
+      if (lstatSync(current).isSymbolicLink()) {
+        return true;
+      }
+    } catch {
+      return false;
+    }
+    current = parent;
   }
+  return false;
 }
 
 function isRegularFileWithoutSymlink(path: string): boolean {

--- a/packages/agents-core/src/sandbox/localSkills.ts
+++ b/packages/agents-core/src/sandbox/localSkills.ts
@@ -6,6 +6,7 @@ import {
   type SkillIndexEntry,
 } from './capabilities/skills';
 import { localDir } from './entries';
+import { isHostPathWithinRoot } from './shared/hostPath';
 
 export type LocalDirLazySkillSourceOptions = {
   /**
@@ -17,6 +18,10 @@ export type LocalDirLazySkillSourceOptions = {
    * Defaults to the current working directory.
    */
   baseDir?: string;
+  /**
+   * Allow reading skill metadata and materializing skills outside the local source base directory.
+   */
+  allowOutsideBaseDir?: boolean;
 };
 
 export function localDirLazySkillSource(
@@ -26,7 +31,10 @@ export function localDirLazySkillSource(
     typeof srcOrOptions === 'string' ? { src: srcOrOptions } : srcOrOptions;
   const sourceRoot = resolve(options.baseDir ?? process.cwd(), options.src);
   return {
-    source: localDir({ src: sourceRoot }),
+    source: localDir({
+      src: sourceRoot,
+      ...(options.allowOutsideBaseDir ? { allowOutsideBaseDir: true } : {}),
+    }),
     index: discoverLocalDirSkillIndex(options),
   };
 }
@@ -34,7 +42,11 @@ export function localDirLazySkillSource(
 function discoverLocalDirSkillIndex(
   options: LocalDirLazySkillSourceOptions,
 ): SkillIndexEntry[] {
-  const root = resolve(options.baseDir ?? process.cwd(), options.src);
+  const base = resolve(options.baseDir ?? process.cwd());
+  const root = resolve(base, options.src);
+  if (!options.allowOutsideBaseDir && !isHostPathWithinRoot(base, root)) {
+    return [];
+  }
   if (!isDirectory(root)) {
     return [];
   }

--- a/packages/agents-core/src/sandbox/localSkills.ts
+++ b/packages/agents-core/src/sandbox/localSkills.ts
@@ -1,4 +1,10 @@
-import { readdirSync, readFileSync, statSync } from 'node:fs';
+import {
+  lstatSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from 'node:fs';
 import { join, resolve } from 'node:path';
 import {
   parseSkillFrontmatter,
@@ -44,7 +50,11 @@ function discoverLocalDirSkillIndex(
 ): SkillIndexEntry[] {
   const base = resolve(options.baseDir ?? process.cwd());
   const root = resolve(base, options.src);
-  if (!options.allowOutsideBaseDir && !isHostPathWithinRoot(base, root)) {
+  if (
+    !options.allowOutsideBaseDir &&
+    (!isHostPathWithinRoot(base, root) ||
+      !isResolvedLocalSourceWithinBase(base, root))
+  ) {
     return [];
   }
   if (!isDirectory(root)) {
@@ -56,7 +66,7 @@ function discoverLocalDirSkillIndex(
     .sort((left, right) => left.name.localeCompare(right.name))
     .flatMap((entry) => {
       const skillMarkdownPath = join(root, entry.name, 'SKILL.md');
-      if (!isFile(skillMarkdownPath)) {
+      if (!isRegularFileWithoutSymlink(skillMarkdownPath)) {
         return [];
       }
 
@@ -78,6 +88,14 @@ function discoverLocalDirSkillIndex(
     });
 }
 
+function isResolvedLocalSourceWithinBase(base: string, root: string): boolean {
+  try {
+    return isHostPathWithinRoot(realpathSync(base), realpathSync(root));
+  } catch {
+    return false;
+  }
+}
+
 function isDirectory(path: string): boolean {
   try {
     return statSync(path).isDirectory();
@@ -86,9 +104,9 @@ function isDirectory(path: string): boolean {
   }
 }
 
-function isFile(path: string): boolean {
+function isRegularFileWithoutSymlink(path: string): boolean {
   try {
-    return statSync(path).isFile();
+    return lstatSync(path).isFile();
   } catch {
     return false;
   }

--- a/packages/agents-core/src/sandbox/sandboxes/docker.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/docker.ts
@@ -286,6 +286,9 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
       this.state.workspaceRootPath,
       logicalPath,
       args.entry,
+      {
+        localSourceGrants: this.state.manifest.extraPathGrants,
+      },
     );
     await this.chownContainerPath(
       this.resolveContainerFilesystemPath(args.path),

--- a/packages/agents-core/src/sandbox/sandboxes/shared/localWorkspace.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/localWorkspace.ts
@@ -55,6 +55,7 @@ const LOCAL_SOURCE_DIRECTORY_READ_FLAGS =
 type MaterializeLocalWorkspaceOptions = {
   concurrencyLimits?: SandboxConcurrencyLimits;
   manifestRoot?: string;
+  localSourceBaseDir?: string;
   allowLocalBindMounts?: boolean;
   allowIdentityMetadata?: boolean;
   supportsMount?: (entry: Mount | TypedMount) => boolean;
@@ -189,6 +190,7 @@ export async function materializeLocalWorkspaceManifestEntry(
         destination,
         entry,
         logicalPath,
+        options,
       );
       break;
     case 'local_dir':
@@ -573,6 +575,7 @@ async function materializeLocalFileEntry(
   destination: string,
   entry: LocalFile,
   logicalPath: string,
+  options: MaterializeLocalWorkspaceOptions,
 ): Promise<void> {
   await createMaterializationParentDirectory(
     workspaceRootPath,
@@ -583,7 +586,14 @@ async function materializeLocalFileEntry(
     workspaceRootPath,
     destination,
     logicalPath,
-    await readStableLocalFile(entry.src),
+    await readStableLocalFile(
+      resolveLocalSourcePath(
+        'local_file',
+        entry.src,
+        Boolean(entry.allowOutsideBaseDir),
+        options.localSourceBaseDir,
+      ),
+    ),
   );
 }
 
@@ -595,12 +605,33 @@ async function materializeLocalDirEntry(
   options: MaterializeLocalWorkspaceOptions,
 ): Promise<void> {
   await copyLocalDirectory(
-    entry.src,
+    resolveLocalSourcePath(
+      'local_dir',
+      entry.src,
+      Boolean(entry.allowOutsideBaseDir),
+      options.localSourceBaseDir,
+    ),
     destination,
     options,
     workspaceRootPath,
     logicalPath,
   );
+}
+
+function resolveLocalSourcePath(
+  entryType: 'local_dir' | 'local_file',
+  sourcePath: string,
+  allowOutsideBaseDir: boolean,
+  baseDir: string = process.cwd(),
+): string {
+  const base = resolve(baseDir);
+  const resolvedSourcePath = resolve(base, sourcePath);
+  if (!allowOutsideBaseDir && !isHostPathWithinRoot(base, resolvedSourcePath)) {
+    throw new UserError(
+      `${entryType} source must stay within the local source base directory: ${resolvedSourcePath} (base: ${base})`,
+    );
+  }
+  return resolvedSourcePath;
 }
 
 async function copyLocalDirectory(

--- a/packages/agents-core/src/sandbox/sandboxes/shared/localWorkspace.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/localWorkspace.ts
@@ -13,6 +13,7 @@ import type {
 } from '../../entries';
 import { isMount } from '../../entries';
 import { Manifest, normalizeRelativePath } from '../../manifest';
+import type { SandboxPathGrant } from '../../pathGrants';
 import { permissionsForSandboxEntry } from '../../permissions';
 import { WorkspacePathPolicy } from '../../workspacePaths';
 import { formatSandboxProcessError, runSandboxProcess } from './runProcess';
@@ -56,6 +57,7 @@ type MaterializeLocalWorkspaceOptions = {
   concurrencyLimits?: SandboxConcurrencyLimits;
   manifestRoot?: string;
   localSourceBaseDir?: string;
+  localSourceGrants?: SandboxPathGrant[];
   allowLocalBindMounts?: boolean;
   allowIdentityMetadata?: boolean;
   supportsMount?: (entry: Mount | TypedMount) => boolean;
@@ -98,6 +100,7 @@ export async function materializeLocalWorkspaceManifest(
   await materializeEntries(workspaceRootPath, manifest.entries, '', {
     ...options,
     manifestRoot: manifest.root,
+    localSourceGrants: manifest.extraPathGrants,
     skipMountEntries: true,
   });
   await materializeLocalWorkspaceManifestMounts(
@@ -249,6 +252,7 @@ export async function materializeLocalWorkspaceManifestMounts(
       {
         ...options,
         manifestRoot: manifest.root,
+        localSourceGrants: manifest.extraPathGrants,
       },
     );
   }
@@ -587,12 +591,7 @@ async function materializeLocalFileEntry(
     destination,
     logicalPath,
     await readStableLocalFile(
-      resolveLocalSourcePath(
-        'local_file',
-        entry.src,
-        Boolean(entry.allowOutsideBaseDir),
-        options.localSourceBaseDir,
-      ),
+      resolveLocalSourcePath('local_file', entry.src, options),
     ),
   );
 }
@@ -605,12 +604,7 @@ async function materializeLocalDirEntry(
   options: MaterializeLocalWorkspaceOptions,
 ): Promise<void> {
   await copyLocalDirectory(
-    resolveLocalSourcePath(
-      'local_dir',
-      entry.src,
-      Boolean(entry.allowOutsideBaseDir),
-      options.localSourceBaseDir,
-    ),
+    resolveLocalSourcePath('local_dir', entry.src, options),
     destination,
     options,
     workspaceRootPath,
@@ -621,17 +615,22 @@ async function materializeLocalDirEntry(
 function resolveLocalSourcePath(
   entryType: 'local_dir' | 'local_file',
   sourcePath: string,
-  allowOutsideBaseDir: boolean,
-  baseDir: string = process.cwd(),
+  options: MaterializeLocalWorkspaceOptions,
 ): string {
-  const base = resolve(baseDir);
+  const base = resolve(options.localSourceBaseDir ?? process.cwd());
   const resolvedSourcePath = resolve(base, sourcePath);
-  if (!allowOutsideBaseDir && !isHostPathWithinRoot(base, resolvedSourcePath)) {
-    throw new UserError(
-      `${entryType} source must stay within the local source base directory: ${resolvedSourcePath} (base: ${base})`,
-    );
+  if (
+    isHostPathWithinRoot(base, resolvedSourcePath) ||
+    (options.localSourceGrants ?? []).some((grant) =>
+      isHostPathWithinRoot(resolve(grant.path), resolvedSourcePath),
+    )
+  ) {
+    return resolvedSourcePath;
   }
-  return resolvedSourcePath;
+
+  throw new UserError(
+    `${entryType} source must stay within the local source base directory or manifest.extraPathGrants: ${resolvedSourcePath} (base: ${base})`,
+  );
 }
 
 async function copyLocalDirectory(

--- a/packages/agents-core/src/sandbox/sandboxes/unixLocal.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/unixLocal.ts
@@ -380,6 +380,9 @@ export class UnixLocalSandboxSession<
       this.state.workspaceRootPath,
       logicalPath,
       args.entry,
+      {
+        localSourceGrants: this.state.manifest.extraPathGrants,
+      },
     );
     if (runAs) {
       await applyOwnershipRecursive(

--- a/packages/agents-core/test/sandboxSkills.test.ts
+++ b/packages/agents-core/test/sandboxSkills.test.ts
@@ -340,18 +340,18 @@ describe('Skills', () => {
       );
 
       const capability = skills({
-        lazyFrom: localDirLazySkillSource({
-          src: skillsRoot,
-          allowOutsideBaseDir: true,
-        }),
+        lazyFrom: localDirLazySkillSource(skillsRoot),
       });
-      const instructions = await capability.instructions(new Manifest());
+      const manifest = new Manifest({
+        extraPathGrants: [{ path: skillsRoot, readOnly: true }],
+      });
+      const instructions = await capability.instructions(manifest);
 
       expect(instructions).toContain(
         '- spreadsheet-review: Review spreadsheets quickly (file: .agents/sheet-tools)',
       );
 
-      const session = new FakeSkillsSession();
+      const session = new FakeSkillsSession(manifest);
       capability.bind(session);
       const [tool] = capability.tools();
 
@@ -371,7 +371,6 @@ describe('Skills', () => {
           entry: {
             type: 'local_dir',
             src: `${skillsRoot}/sheet-tools`,
-            allowOutsideBaseDir: true,
           },
           runAs: undefined,
         },
@@ -381,7 +380,7 @@ describe('Skills', () => {
     }
   });
 
-  it('does not discover lazy local directory metadata outside the base directory by default', async () => {
+  it('does not discover lazy local directory metadata outside the base directory without a grant', async () => {
     const root = mkdtempSync(join(tmpdir(), 'agents-skills-outside-'));
     try {
       const skillsRoot = join(root, 'skills');
@@ -405,6 +404,41 @@ describe('Skills', () => {
       const instructions = await capability.instructions(new Manifest());
 
       expect(instructions).toBeNull();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('discovers lazy local directory metadata outside the base directory with a grant', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agents-skills-granted-'));
+    try {
+      const skillsRoot = join(root, 'skills');
+      const skillDir = join(skillsRoot, 'hidden-skill');
+      mkdirSync(skillDir, { recursive: true });
+      writeFileSync(
+        join(skillDir, 'SKILL.md'),
+        [
+          '---',
+          'name: hidden-skill',
+          'description: Outside the base directory',
+          '---',
+          '# Hidden skill',
+        ].join('\n'),
+        'utf8',
+      );
+
+      const capability = skills({
+        lazyFrom: localDirLazySkillSource(skillsRoot),
+      });
+      const instructions = await capability.instructions(
+        new Manifest({
+          extraPathGrants: [{ path: skillsRoot, readOnly: true }],
+        }),
+      );
+
+      expect(instructions).toContain(
+        '- hidden-skill: Outside the base directory (file: .agents/hidden-skill)',
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -501,7 +535,6 @@ describe('Skills', () => {
         lazyFrom: localDirLazySkillSource({
           src: 'skills',
           baseDir: root,
-          allowOutsideBaseDir: true,
         }),
       });
       const session = new FakeSkillsSession();
@@ -524,7 +557,6 @@ describe('Skills', () => {
           entry: {
             type: 'local_dir',
             src: `${root}/skills/relative-skill`,
-            allowOutsideBaseDir: true,
           },
           runAs: undefined,
         },

--- a/packages/agents-core/test/sandboxSkills.test.ts
+++ b/packages/agents-core/test/sandboxSkills.test.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -395,6 +401,76 @@ describe('Skills', () => {
 
       const capability = skills({
         lazyFrom: localDirLazySkillSource(skillsRoot),
+      });
+      const instructions = await capability.instructions(new Manifest());
+
+      expect(instructions).toBeNull();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not discover lazy local directory metadata through a symlinked source', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agents-skills-symlink-'));
+    try {
+      const base = join(root, 'base');
+      const outsideSkillsRoot = join(root, 'outside-skills');
+      const outsideSkillDir = join(outsideSkillsRoot, 'hidden-skill');
+      mkdirSync(base);
+      mkdirSync(outsideSkillDir, { recursive: true });
+      writeFileSync(
+        join(outsideSkillDir, 'SKILL.md'),
+        [
+          '---',
+          'name: hidden-skill',
+          'description: Outside the base directory',
+          '---',
+          '# Hidden skill',
+        ].join('\n'),
+        'utf8',
+      );
+      symlinkSync(outsideSkillsRoot, join(base, 'skills'), 'dir');
+
+      const capability = skills({
+        lazyFrom: localDirLazySkillSource({
+          src: 'skills',
+          baseDir: base,
+        }),
+      });
+      const instructions = await capability.instructions(new Manifest());
+
+      expect(instructions).toBeNull();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not discover lazy local directory metadata through a symlinked SKILL.md', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agents-skills-file-symlink-'));
+    try {
+      const base = join(root, 'base');
+      const skillDir = join(base, 'skills', 'hidden-skill');
+      const outside = join(root, 'outside');
+      mkdirSync(skillDir, { recursive: true });
+      mkdirSync(outside);
+      writeFileSync(
+        join(outside, 'SKILL.md'),
+        [
+          '---',
+          'name: hidden-skill',
+          'description: Outside the base directory',
+          '---',
+          '# Hidden skill',
+        ].join('\n'),
+        'utf8',
+      );
+      symlinkSync(join(outside, 'SKILL.md'), join(skillDir, 'SKILL.md'));
+
+      const capability = skills({
+        lazyFrom: localDirLazySkillSource({
+          src: 'skills',
+          baseDir: base,
+        }),
       });
       const instructions = await capability.instructions(new Manifest());
 

--- a/packages/agents-core/test/sandboxSkills.test.ts
+++ b/packages/agents-core/test/sandboxSkills.test.ts
@@ -334,7 +334,10 @@ describe('Skills', () => {
       );
 
       const capability = skills({
-        lazyFrom: localDirLazySkillSource(skillsRoot),
+        lazyFrom: localDirLazySkillSource({
+          src: skillsRoot,
+          allowOutsideBaseDir: true,
+        }),
       });
       const instructions = await capability.instructions(new Manifest());
 
@@ -362,10 +365,40 @@ describe('Skills', () => {
           entry: {
             type: 'local_dir',
             src: `${skillsRoot}/sheet-tools`,
+            allowOutsideBaseDir: true,
           },
           runAs: undefined,
         },
       ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not discover lazy local directory metadata outside the base directory by default', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agents-skills-outside-'));
+    try {
+      const skillsRoot = join(root, 'skills');
+      const skillDir = join(skillsRoot, 'hidden-skill');
+      mkdirSync(skillDir, { recursive: true });
+      writeFileSync(
+        join(skillDir, 'SKILL.md'),
+        [
+          '---',
+          'name: hidden-skill',
+          'description: Outside the base directory',
+          '---',
+          '# Hidden skill',
+        ].join('\n'),
+        'utf8',
+      );
+
+      const capability = skills({
+        lazyFrom: localDirLazySkillSource(skillsRoot),
+      });
+      const instructions = await capability.instructions(new Manifest());
+
+      expect(instructions).toBeNull();
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -392,6 +425,7 @@ describe('Skills', () => {
         lazyFrom: localDirLazySkillSource({
           src: 'skills',
           baseDir: root,
+          allowOutsideBaseDir: true,
         }),
       });
       const session = new FakeSkillsSession();
@@ -414,6 +448,7 @@ describe('Skills', () => {
           entry: {
             type: 'local_dir',
             src: `${root}/skills/relative-skill`,
+            allowOutsideBaseDir: true,
           },
           runAs: undefined,
         },

--- a/packages/agents-core/test/sandboxes/unixLocal.test.ts
+++ b/packages/agents-core/test/sandboxes/unixLocal.test.ts
@@ -283,11 +283,11 @@ describe('UnixLocalSandboxClient', () => {
     await expect(
       client.create(
         new Manifest({
+          extraPathGrants: [{ path: sourceDir, readOnly: true }],
           entries: {
             data: {
               type: 'local_dir',
               src: sourceDir,
-              allowOutsideBaseDir: true,
             },
           },
         }),
@@ -308,11 +308,11 @@ describe('UnixLocalSandboxClient', () => {
     await expect(
       client.create(
         new Manifest({
+          extraPathGrants: [{ path: rootDir, readOnly: true }],
           entries: {
             copied: {
               type: 'local_file',
               src: linkFile,
-              allowOutsideBaseDir: true,
             },
           },
         }),
@@ -333,11 +333,11 @@ describe('UnixLocalSandboxClient', () => {
     await expect(
       client.create(
         new Manifest({
+          extraPathGrants: [{ path: rootDir, readOnly: true }],
           entries: {
             copied: {
               type: 'local_file',
               src: join(rootDir, 'link', 'sub', 'secret.txt'),
-              allowOutsideBaseDir: true,
             },
           },
         }),
@@ -360,11 +360,11 @@ describe('UnixLocalSandboxClient', () => {
     await expect(
       client.create(
         new Manifest({
+          extraPathGrants: [{ path: rootDir, readOnly: true }],
           entries: {
             data: {
               type: 'local_dir',
               src: join(rootDir, 'link', 'sub'),
-              allowOutsideBaseDir: true,
             },
           },
         }),
@@ -411,11 +411,9 @@ describe('UnixLocalSandboxClient', () => {
     ).rejects.toThrow(/Sandbox concurrency limits must be positive numbers/);
   });
 
-  it('rejects local_file sources outside the local source base directory', async () => {
-    const base = join(rootDir, 'base');
+  it('rejects local_file sources outside the local source base directory without a grant', async () => {
     const outside = join(rootDir, 'outside');
     const workspaceRootPath = join(rootDir, 'workspace');
-    await mkdir(base);
     await mkdir(outside);
     await writeFile(join(outside, 'secret.txt'), 'secret');
 
@@ -430,9 +428,6 @@ describe('UnixLocalSandboxClient', () => {
           },
         }),
         workspaceRootPath,
-        {
-          localSourceBaseDir: base,
-        },
       ),
     ).rejects.toThrow(/local_file source must stay within/);
 
@@ -441,51 +436,43 @@ describe('UnixLocalSandboxClient', () => {
     ).rejects.toThrow();
   });
 
-  it('rejects relative local_dir sources that escape the local source base directory', async () => {
-    const base = join(rootDir, 'base');
-    const outside = join(rootDir, 'outside');
+  it('allows local_file sources outside the local source base directory with a grant', async () => {
+    const outside = join(rootDir, 'outside-granted');
     const workspaceRootPath = join(rootDir, 'workspace');
-    await mkdir(base);
     await mkdir(outside);
     await writeFile(join(outside, 'secret.txt'), 'secret');
 
-    await expect(
-      materializeLocalWorkspaceManifest(
-        new Manifest({
-          entries: {
-            copied: {
-              type: 'local_dir',
-              src: '../outside',
-            },
+    await materializeLocalWorkspaceManifest(
+      new Manifest({
+        extraPathGrants: [{ path: outside, readOnly: true }],
+        entries: {
+          copied: {
+            type: 'local_file',
+            src: join(outside, 'secret.txt'),
           },
-        }),
-        workspaceRootPath,
-        {
-          localSourceBaseDir: base,
         },
-      ),
-    ).rejects.toThrow(/local_dir source must stay within/);
+      }),
+      workspaceRootPath,
+    );
 
     await expect(
-      readFile(join(workspaceRootPath, 'copied', 'secret.txt'), 'utf8'),
-    ).rejects.toThrow();
+      readFile(join(workspaceRootPath, 'copied'), 'utf8'),
+    ).resolves.toBe('secret');
   });
 
-  it('allows explicit local_dir sources outside the local source base directory', async () => {
+  it('allows local_dir sources inside the local source base directory without a grant', async () => {
     const base = join(rootDir, 'base');
-    const outside = join(rootDir, 'outside');
+    const source = join(base, 'source');
     const workspaceRootPath = join(rootDir, 'workspace');
-    await mkdir(base);
-    await mkdir(outside);
-    await writeFile(join(outside, 'secret.txt'), 'secret');
+    await mkdir(source, { recursive: true });
+    await writeFile(join(source, 'safe.txt'), 'safe');
 
     await materializeLocalWorkspaceManifest(
       new Manifest({
         entries: {
           copied: {
             type: 'local_dir',
-            src: outside,
-            allowOutsideBaseDir: true,
+            src: source,
           },
         },
       }),
@@ -493,6 +480,30 @@ describe('UnixLocalSandboxClient', () => {
       {
         localSourceBaseDir: base,
       },
+    );
+
+    await expect(
+      readFile(join(workspaceRootPath, 'copied', 'safe.txt'), 'utf8'),
+    ).resolves.toBe('safe');
+  });
+
+  it('allows local_dir sources outside the local source base directory with a grant', async () => {
+    const outside = join(rootDir, 'absolute-outside');
+    const workspaceRootPath = join(rootDir, 'workspace');
+    await mkdir(outside);
+    await writeFile(join(outside, 'secret.txt'), 'secret');
+
+    await materializeLocalWorkspaceManifest(
+      new Manifest({
+        extraPathGrants: [{ path: outside, readOnly: true }],
+        entries: {
+          copied: {
+            type: 'local_dir',
+            src: outside,
+          },
+        },
+      }),
+      workspaceRootPath,
     );
 
     await expect(
@@ -2252,13 +2263,16 @@ void main();
     const client = new UnixLocalSandboxClient({
       workspaceBaseDir: rootDir,
     });
-    const session = await client.create(new Manifest());
+    const session = await client.create(
+      new Manifest({
+        extraPathGrants: [{ path: skillsRoot, readOnly: true }],
+      }),
+    );
     const capability = skills({
       lazyFrom: {
         source: {
           type: 'local_dir',
           src: skillsRoot,
-          allowOutsideBaseDir: true,
         },
         index: [
           {

--- a/packages/agents-core/test/sandboxes/unixLocal.test.ts
+++ b/packages/agents-core/test/sandboxes/unixLocal.test.ts
@@ -287,6 +287,7 @@ describe('UnixLocalSandboxClient', () => {
             data: {
               type: 'local_dir',
               src: sourceDir,
+              allowOutsideBaseDir: true,
             },
           },
         }),
@@ -311,6 +312,7 @@ describe('UnixLocalSandboxClient', () => {
             copied: {
               type: 'local_file',
               src: linkFile,
+              allowOutsideBaseDir: true,
             },
           },
         }),
@@ -335,6 +337,7 @@ describe('UnixLocalSandboxClient', () => {
             copied: {
               type: 'local_file',
               src: join(rootDir, 'link', 'sub', 'secret.txt'),
+              allowOutsideBaseDir: true,
             },
           },
         }),
@@ -361,6 +364,7 @@ describe('UnixLocalSandboxClient', () => {
             data: {
               type: 'local_dir',
               src: join(rootDir, 'link', 'sub'),
+              allowOutsideBaseDir: true,
             },
           },
         }),
@@ -405,6 +409,95 @@ describe('UnixLocalSandboxClient', () => {
         }),
       ),
     ).rejects.toThrow(/Sandbox concurrency limits must be positive numbers/);
+  });
+
+  it('rejects local_file sources outside the local source base directory', async () => {
+    const base = join(rootDir, 'base');
+    const outside = join(rootDir, 'outside');
+    const workspaceRootPath = join(rootDir, 'workspace');
+    await mkdir(base);
+    await mkdir(outside);
+    await writeFile(join(outside, 'secret.txt'), 'secret');
+
+    await expect(
+      materializeLocalWorkspaceManifest(
+        new Manifest({
+          entries: {
+            copied: {
+              type: 'local_file',
+              src: join(outside, 'secret.txt'),
+            },
+          },
+        }),
+        workspaceRootPath,
+        {
+          localSourceBaseDir: base,
+        },
+      ),
+    ).rejects.toThrow(/local_file source must stay within/);
+
+    await expect(
+      readFile(join(workspaceRootPath, 'copied'), 'utf8'),
+    ).rejects.toThrow();
+  });
+
+  it('rejects relative local_dir sources that escape the local source base directory', async () => {
+    const base = join(rootDir, 'base');
+    const outside = join(rootDir, 'outside');
+    const workspaceRootPath = join(rootDir, 'workspace');
+    await mkdir(base);
+    await mkdir(outside);
+    await writeFile(join(outside, 'secret.txt'), 'secret');
+
+    await expect(
+      materializeLocalWorkspaceManifest(
+        new Manifest({
+          entries: {
+            copied: {
+              type: 'local_dir',
+              src: '../outside',
+            },
+          },
+        }),
+        workspaceRootPath,
+        {
+          localSourceBaseDir: base,
+        },
+      ),
+    ).rejects.toThrow(/local_dir source must stay within/);
+
+    await expect(
+      readFile(join(workspaceRootPath, 'copied', 'secret.txt'), 'utf8'),
+    ).rejects.toThrow();
+  });
+
+  it('allows explicit local_dir sources outside the local source base directory', async () => {
+    const base = join(rootDir, 'base');
+    const outside = join(rootDir, 'outside');
+    const workspaceRootPath = join(rootDir, 'workspace');
+    await mkdir(base);
+    await mkdir(outside);
+    await writeFile(join(outside, 'secret.txt'), 'secret');
+
+    await materializeLocalWorkspaceManifest(
+      new Manifest({
+        entries: {
+          copied: {
+            type: 'local_dir',
+            src: outside,
+            allowOutsideBaseDir: true,
+          },
+        },
+      }),
+      workspaceRootPath,
+      {
+        localSourceBaseDir: base,
+      },
+    );
+
+    await expect(
+      readFile(join(workspaceRootPath, 'copied', 'secret.txt'), 'utf8'),
+    ).resolves.toBe('secret');
   });
 
   it('applies explicit entry permissions during materialization', async () => {
@@ -2165,6 +2258,7 @@ void main();
         source: {
           type: 'local_dir',
           src: skillsRoot,
+          allowOutsideBaseDir: true,
         },
         index: [
           {

--- a/packages/agents-extensions/src/sandbox/shared/localSources.ts
+++ b/packages/agents-extensions/src/sandbox/shared/localSources.ts
@@ -23,6 +23,7 @@ import {
   applyMaterializedManifestToState,
   materializeInlineManifestEntry,
   materializeManifestEntries,
+  mergeManifestDelta,
   resolveLocalDirFileConcurrency,
   resolveMaterializedChildPath,
   runLimited,
@@ -65,7 +66,10 @@ export async function applyLocalSourceManifestEntryToState(
     writer,
     resolvePath,
     materializeLocalSourceManifestEntry,
-    options,
+    {
+      ...options,
+      localSourceGrants: state.manifest.extraPathGrants,
+    },
   );
 }
 
@@ -77,6 +81,7 @@ export async function applyLocalSourceManifestToState(
   resolvePath: RemoteSandboxPathResolver,
   options: ManifestMaterializationOptions = {},
 ): Promise<void> {
+  const sourceManifest = mergeManifestDelta(state.manifest, manifest);
   await applyMaterializedManifestToState(
     state,
     manifest,
@@ -84,7 +89,10 @@ export async function applyLocalSourceManifestToState(
     writer,
     resolvePath,
     materializeLocalSourceManifestEntry,
-    options,
+    {
+      ...options,
+      localSourceGrants: sourceManifest.extraPathGrants,
+    },
   );
 }
 
@@ -101,7 +109,10 @@ export async function materializeLocalSourceManifest(
     providerLabel,
     resolvePath,
     materializeLocalSourceManifestEntry,
-    options,
+    {
+      ...options,
+      localSourceGrants: manifest.extraPathGrants,
+    },
   );
 }
 
@@ -139,12 +150,7 @@ export async function materializeLocalSourceManifestEntry(
       await writer.writeFile(
         absolutePath,
         await readStableLocalFile(
-          resolveLocalSourcePath(
-            'local_file',
-            entry.src,
-            Boolean(entry.allowOutsideBaseDir),
-            options.localSourceBaseDir,
-          ),
+          resolveLocalSourcePath('local_file', entry.src, options),
         ),
       );
       break;
@@ -152,12 +158,7 @@ export async function materializeLocalSourceManifestEntry(
       await materializeLocalDirectory(
         writer,
         absolutePath,
-        resolveLocalSourcePath(
-          'local_dir',
-          entry.src,
-          Boolean(entry.allowOutsideBaseDir),
-          options.localSourceBaseDir,
-        ),
+        resolveLocalSourcePath('local_dir', entry.src, options),
         options,
       );
       break;
@@ -188,17 +189,22 @@ export async function materializeLocalSourceManifestEntry(
 function resolveLocalSourcePath(
   entryType: 'local_dir' | 'local_file',
   sourcePath: string,
-  allowOutsideBaseDir: boolean,
-  baseDir: string = process.cwd(),
+  options: ManifestMaterializationOptions,
 ): string {
-  const base = resolve(baseDir);
+  const base = resolve(options.localSourceBaseDir ?? process.cwd());
   const resolvedSourcePath = resolve(base, sourcePath);
-  if (!allowOutsideBaseDir && !isHostPathWithinRoot(base, resolvedSourcePath)) {
-    throw new UserError(
-      `${entryType} source must stay within the local source base directory: ${resolvedSourcePath} (base: ${base})`,
-    );
+  if (
+    isHostPathWithinRoot(base, resolvedSourcePath) ||
+    (options.localSourceGrants ?? []).some((grant) =>
+      isHostPathWithinRoot(resolve(grant.path), resolvedSourcePath),
+    )
+  ) {
+    return resolvedSourcePath;
   }
-  return resolvedSourcePath;
+
+  throw new UserError(
+    `${entryType} source must stay within the local source base directory or manifest.extraPathGrants: ${resolvedSourcePath} (base: ${base})`,
+  );
 }
 
 async function materializeLocalDirectory(

--- a/packages/agents-extensions/src/sandbox/shared/localSources.ts
+++ b/packages/agents-extensions/src/sandbox/shared/localSources.ts
@@ -1,6 +1,9 @@
 import { UserError } from '@openai/agents-core';
 import { type Entry, type Manifest } from '@openai/agents-core/sandbox';
-import { isHostPathStrictlyWithinRoot } from '@openai/agents-core/sandbox/internal';
+import {
+  isHostPathStrictlyWithinRoot,
+  isHostPathWithinRoot,
+} from '@openai/agents-core/sandbox/internal';
 import { constants, type Dirent, type Stats } from 'node:fs';
 import {
   lstat,
@@ -135,11 +138,28 @@ export async function materializeLocalSourceManifestEntry(
     case 'local_file':
       await writer.writeFile(
         absolutePath,
-        await readStableLocalFile(entry.src),
+        await readStableLocalFile(
+          resolveLocalSourcePath(
+            'local_file',
+            entry.src,
+            Boolean(entry.allowOutsideBaseDir),
+            options.localSourceBaseDir,
+          ),
+        ),
       );
       break;
     case 'local_dir':
-      await materializeLocalDirectory(writer, absolutePath, entry.src, options);
+      await materializeLocalDirectory(
+        writer,
+        absolutePath,
+        resolveLocalSourcePath(
+          'local_dir',
+          entry.src,
+          Boolean(entry.allowOutsideBaseDir),
+          options.localSourceBaseDir,
+        ),
+        options,
+      );
       break;
     case 'git_repo':
       await materializeGitRepo(
@@ -163,6 +183,22 @@ export async function materializeLocalSourceManifestEntry(
   }
 
   await options.applyMetadata?.(absolutePath, entry);
+}
+
+function resolveLocalSourcePath(
+  entryType: 'local_dir' | 'local_file',
+  sourcePath: string,
+  allowOutsideBaseDir: boolean,
+  baseDir: string = process.cwd(),
+): string {
+  const base = resolve(baseDir);
+  const resolvedSourcePath = resolve(base, sourcePath);
+  if (!allowOutsideBaseDir && !isHostPathWithinRoot(base, resolvedSourcePath)) {
+    throw new UserError(
+      `${entryType} source must stay within the local source base directory: ${resolvedSourcePath} (base: ${base})`,
+    );
+  }
+  return resolvedSourcePath;
 }
 
 async function materializeLocalDirectory(

--- a/packages/agents-extensions/src/sandbox/shared/manifest.ts
+++ b/packages/agents-extensions/src/sandbox/shared/manifest.ts
@@ -167,6 +167,7 @@ export type ManifestMaterializationOptions = {
   ) => Promise<void>;
   applyMetadata?: (absolutePath: string, entry: Entry) => Promise<void>;
   concurrencyLimits?: SandboxConcurrencyLimits;
+  localSourceBaseDir?: string;
   resolvePath?: RemoteSandboxPathResolver;
   logicalPath?: string;
 };

--- a/packages/agents-extensions/src/sandbox/shared/manifest.ts
+++ b/packages/agents-extensions/src/sandbox/shared/manifest.ts
@@ -168,6 +168,7 @@ export type ManifestMaterializationOptions = {
   applyMetadata?: (absolutePath: string, entry: Entry) => Promise<void>;
   concurrencyLimits?: SandboxConcurrencyLimits;
   localSourceBaseDir?: string;
+  localSourceGrants?: Manifest['extraPathGrants'];
   resolvePath?: RemoteSandboxPathResolver;
   logicalPath?: string;
 };

--- a/packages/agents-extensions/test/sandbox/cloudflare.test.ts
+++ b/packages/agents-extensions/test/sandbox/cloudflare.test.ts
@@ -405,6 +405,7 @@ describe('CloudflareSandboxClient', () => {
             'local.txt': {
               type: 'local_file',
               src: sourceFile,
+              allowOutsideBaseDir: true,
             },
           },
         }),

--- a/packages/agents-extensions/test/sandbox/cloudflare.test.ts
+++ b/packages/agents-extensions/test/sandbox/cloudflare.test.ts
@@ -4,7 +4,6 @@ import {
   SandboxUnsupportedFeatureError,
 } from '@openai/agents-core/sandbox';
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { CloudflareSandboxClient } from '../../src/sandbox/cloudflare';
@@ -394,7 +393,9 @@ describe('CloudflareSandboxClient', () => {
   });
 
   test('materializes local file entries through the Node local source path', async () => {
-    const tempDir = await mkdtemp(join(tmpdir(), 'agents-cloudflare-test-'));
+    const tempDir = await mkdtemp(
+      join(process.cwd(), '.tmp-agents-cloudflare-test-'),
+    );
     const sourceFile = join(tempDir, 'local.txt');
     await writeFile(sourceFile, 'local source\n');
     try {
@@ -405,7 +406,6 @@ describe('CloudflareSandboxClient', () => {
             'local.txt': {
               type: 'local_file',
               src: sourceFile,
-              allowOutsideBaseDir: true,
             },
           },
         }),

--- a/packages/agents-extensions/test/sandbox/shared.test.ts
+++ b/packages/agents-extensions/test/sandbox/shared.test.ts
@@ -8,7 +8,7 @@ import {
 } from 'node:fs/promises';
 import { execFile } from 'node:child_process';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { promisify } from 'node:util';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import {
@@ -884,8 +884,9 @@ describe('remote sandbox path helpers', () => {
     await applyLocalSourceManifestToState(
       state,
       new Manifest({
+        extraPathGrants: [{ path: tempDir, readOnly: true }],
         entries: {
-          copied: localDir({ src: tempDir, allowOutsideBaseDir: true }),
+          copied: localDir({ src: tempDir }),
         },
       }),
       'fake-provider',
@@ -1718,11 +1719,11 @@ describe('remote sandbox path helpers', () => {
     await materializeLocalSourceManifest(
       writer,
       new Manifest({
+        extraPathGrants: [{ path: dirname(sourceFile), readOnly: true }],
         entries: {
           ' ./copied//source.txt ': {
             type: 'local_file',
             src: sourceFile,
-            allowOutsideBaseDir: true,
           },
         },
       }),
@@ -1870,6 +1871,7 @@ describe('remote sandbox path helpers', () => {
     await materializeLocalSourceManifest(
       writer,
       new Manifest({
+        extraPathGrants: [{ path: dirname(sourceFile), readOnly: true }],
         entries: {
           child: mount({
             source: 's3://bucket/child',
@@ -1879,7 +1881,6 @@ describe('remote sandbox path helpers', () => {
           'copied/source.txt': {
             type: 'local_file',
             src: sourceFile,
-            allowOutsideBaseDir: true,
           },
           parent: mount({
             source: 's3://bucket/parent',
@@ -2013,16 +2014,20 @@ describe('remote sandbox path helpers', () => {
           'local.txt': {
             type: 'local_file',
             src: sourceFile,
-            allowOutsideBaseDir: true,
           },
           data: {
             type: 'local_dir',
             src: sourceDir,
-            allowOutsideBaseDir: true,
           },
         },
       },
       'test',
+      {
+        localSourceGrants: [
+          { path: dirname(sourceFile), readOnly: true },
+          { path: sourceDir, readOnly: true },
+        ],
+      },
     );
 
     expect(directories).toContain('/workspace/project');
@@ -2047,12 +2052,10 @@ describe('remote sandbox path helpers', () => {
     ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
   });
 
-  test('rejects local source entries outside the local source base directory', async () => {
+  test('rejects local source entries outside the local source base directory without a grant', async () => {
     const tempDir = await mkdtemp(join(tmpdir(), 'agents-shared-test-'));
     tempDirs.push(tempDir);
-    const base = join(tempDir, 'base');
     const outside = join(tempDir, 'outside');
-    await mkdir(base);
     await mkdir(outside);
     await writeFile(join(outside, 'secret.txt'), 'secret');
 
@@ -2073,21 +2076,16 @@ describe('remote sandbox path helpers', () => {
           src: join(outside, 'secret.txt'),
         },
         'test',
-        {
-          localSourceBaseDir: base,
-        },
       ),
     ).rejects.toThrow(/local_file source must stay within/);
 
     expect(files.size).toBe(0);
   });
 
-  test('allows explicit local source entries outside the local source base directory', async () => {
+  test('allows local source entries outside the local source base directory with a grant', async () => {
     const tempDir = await mkdtemp(join(tmpdir(), 'agents-shared-test-'));
     tempDirs.push(tempDir);
-    const base = join(tempDir, 'base');
     const outside = join(tempDir, 'outside');
-    await mkdir(base);
     await mkdir(outside);
     await writeFile(join(outside, 'secret.txt'), 'secret');
 
@@ -2105,11 +2103,10 @@ describe('remote sandbox path helpers', () => {
       {
         type: 'local_file',
         src: join(outside, 'secret.txt'),
-        allowOutsideBaseDir: true,
       },
       'test',
       {
-        localSourceBaseDir: base,
+        localSourceGrants: [{ path: outside, readOnly: true }],
       },
     );
 
@@ -2140,9 +2137,11 @@ describe('remote sandbox path helpers', () => {
         {
           type: 'local_dir',
           src: sourceDir,
-          allowOutsideBaseDir: true,
         },
         'test',
+        {
+          localSourceGrants: [{ path: sourceDir, readOnly: true }],
+        },
       ),
     ).rejects.toThrow(/local_dir entries do not support symbolic links/);
   });
@@ -2169,9 +2168,11 @@ describe('remote sandbox path helpers', () => {
         {
           type: 'local_dir',
           src: join(linkedRoot, 'source-dir'),
-          allowOutsideBaseDir: true,
         },
         'test',
+        {
+          localSourceGrants: [{ path: linkedRoot, readOnly: true }],
+        },
       ),
     ).rejects.toThrow(
       /local_dir entries do not support symbolic link ancestors/,
@@ -2198,9 +2199,11 @@ describe('remote sandbox path helpers', () => {
         {
           type: 'local_file',
           src: linkFile,
-          allowOutsideBaseDir: true,
         },
         'test',
+        {
+          localSourceGrants: [{ path: tempDir, readOnly: true }],
+        },
       ),
     ).rejects.toThrow(/local_file entries do not support symbolic links/);
   });
@@ -2226,9 +2229,11 @@ describe('remote sandbox path helpers', () => {
         {
           type: 'local_file',
           src: join(linkedRoot, 'source.txt'),
-          allowOutsideBaseDir: true,
         },
         'test',
+        {
+          localSourceGrants: [{ path: linkedRoot, readOnly: true }],
+        },
       ),
     ).rejects.toThrow(
       /local_file entries do not support symbolic link ancestors/,

--- a/packages/agents-extensions/test/sandbox/shared.test.ts
+++ b/packages/agents-extensions/test/sandbox/shared.test.ts
@@ -885,7 +885,7 @@ describe('remote sandbox path helpers', () => {
       state,
       new Manifest({
         entries: {
-          copied: localDir({ src: tempDir }),
+          copied: localDir({ src: tempDir, allowOutsideBaseDir: true }),
         },
       }),
       'fake-provider',
@@ -1722,6 +1722,7 @@ describe('remote sandbox path helpers', () => {
           ' ./copied//source.txt ': {
             type: 'local_file',
             src: sourceFile,
+            allowOutsideBaseDir: true,
           },
         },
       }),
@@ -1878,6 +1879,7 @@ describe('remote sandbox path helpers', () => {
           'copied/source.txt': {
             type: 'local_file',
             src: sourceFile,
+            allowOutsideBaseDir: true,
           },
           parent: mount({
             source: 's3://bucket/parent',
@@ -2011,10 +2013,12 @@ describe('remote sandbox path helpers', () => {
           'local.txt': {
             type: 'local_file',
             src: sourceFile,
+            allowOutsideBaseDir: true,
           },
           data: {
             type: 'local_dir',
             src: sourceDir,
+            allowOutsideBaseDir: true,
           },
         },
       },
@@ -2043,6 +2047,77 @@ describe('remote sandbox path helpers', () => {
     ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
   });
 
+  test('rejects local source entries outside the local source base directory', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'agents-shared-test-'));
+    tempDirs.push(tempDir);
+    const base = join(tempDir, 'base');
+    const outside = join(tempDir, 'outside');
+    await mkdir(base);
+    await mkdir(outside);
+    await writeFile(join(outside, 'secret.txt'), 'secret');
+
+    const files = new Map<string, string | Uint8Array>();
+    const writer = {
+      mkdir: async (_path: string) => {},
+      writeFile: async (path: string, content: string | Uint8Array) => {
+        files.set(path, content);
+      },
+    };
+
+    await expect(
+      materializeLocalSourceManifestEntry(
+        writer,
+        '/workspace/copied.txt',
+        {
+          type: 'local_file',
+          src: join(outside, 'secret.txt'),
+        },
+        'test',
+        {
+          localSourceBaseDir: base,
+        },
+      ),
+    ).rejects.toThrow(/local_file source must stay within/);
+
+    expect(files.size).toBe(0);
+  });
+
+  test('allows explicit local source entries outside the local source base directory', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'agents-shared-test-'));
+    tempDirs.push(tempDir);
+    const base = join(tempDir, 'base');
+    const outside = join(tempDir, 'outside');
+    await mkdir(base);
+    await mkdir(outside);
+    await writeFile(join(outside, 'secret.txt'), 'secret');
+
+    const files = new Map<string, string | Uint8Array>();
+    const writer = {
+      mkdir: async (_path: string) => {},
+      writeFile: async (path: string, content: string | Uint8Array) => {
+        files.set(path, content);
+      },
+    };
+
+    await materializeLocalSourceManifestEntry(
+      writer,
+      '/workspace/copied.txt',
+      {
+        type: 'local_file',
+        src: join(outside, 'secret.txt'),
+        allowOutsideBaseDir: true,
+      },
+      'test',
+      {
+        localSourceBaseDir: base,
+      },
+    );
+
+    expect(Buffer.from(files.get('/workspace/copied.txt')!)).toEqual(
+      Buffer.from('secret'),
+    );
+  });
+
   test('rejects symbolic links inside local directory entries', async () => {
     const tempDir = await mkdtemp(join(tmpdir(), 'agents-shared-test-'));
     tempDirs.push(tempDir);
@@ -2065,6 +2140,7 @@ describe('remote sandbox path helpers', () => {
         {
           type: 'local_dir',
           src: sourceDir,
+          allowOutsideBaseDir: true,
         },
         'test',
       ),
@@ -2093,6 +2169,7 @@ describe('remote sandbox path helpers', () => {
         {
           type: 'local_dir',
           src: join(linkedRoot, 'source-dir'),
+          allowOutsideBaseDir: true,
         },
         'test',
       ),
@@ -2121,6 +2198,7 @@ describe('remote sandbox path helpers', () => {
         {
           type: 'local_file',
           src: linkFile,
+          allowOutsideBaseDir: true,
         },
         'test',
       ),
@@ -2148,6 +2226,7 @@ describe('remote sandbox path helpers', () => {
         {
           type: 'local_file',
           src: join(linkedRoot, 'source.txt'),
+          allowOutsideBaseDir: true,
         },
         'test',
       ),


### PR DESCRIPTION
This pull request fixes local sandbox artifact materialization so `local_file` and `local_dir` entries only read host paths within the local source base directory by default.

~~The change adds an explicit `allowOutsideBaseDir` opt-in for trusted callers that intentionally need to materialize host files from outside that boundary~~, 

The final behavior is:
- `LocalFile.src` and `LocalDir.src` stay constrained to the SDK process `baseDir` by default.
- A source outside `base_dir` is allowed only when its host path is under an explicit `manifest.extraPathGrants` entry.
- `readOnly=true` grants are accepted for local source materialization because this path only reads from the host source before copying into the sandbox.
- Lazy local skill discovery and `loadSkill` use the same grant boundary.
- Symlink protections remain in place, including for lazy skill metadata discovery.

applies the same rule to lazy local skill metadata discovery and loading, and covers both core local workspace materialization and extensions remote local-source materialization. It also adds regression coverage for rejected outside paths, relative escapes, explicit opt-in behavior, and existing symlink protections.

see also: https://github.com/openai/openai-agents-python/pull/3177