### PR TITLE
fix: validate hosted MCP approval policies

### DIFF
--- a/.changeset/strict-mcp-approval-validation.md
+++ b/.changeset/strict-mcp-approval-validation.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+'@openai/agents-realtime': patch
+---
+
+fix: validate hosted MCP approval policies

--- a/packages/agents-core/src/runner/toolSearch.ts
+++ b/packages/agents-core/src/runner/toolSearch.ts
@@ -17,6 +17,7 @@ import {
   toolQualifiedName,
 } from '../toolIdentity';
 import { serializeTool } from '../utils/serialize';
+import { normalizeHostedMcpRequireApproval } from '../utils/mcpApproval';
 import { resolveToolSearchCallId } from '../utils/toolSearch';
 
 type BuiltInClientToolSearchArguments = {
@@ -379,10 +380,9 @@ function normalizeHostedMcpProviderData(
   const normalized: Record<string, unknown> = {
     type: 'mcp',
     server_label: candidate.server_label,
-    require_approval:
-      candidate.require_approval === undefined
-        ? 'never'
-        : candidate.require_approval,
+    require_approval: normalizeHostedMcpRequireApproval(
+      candidate.require_approval,
+    ),
   };
 
   if (typeof candidate.server_url === 'string') {

--- a/packages/agents-core/src/tool.ts
+++ b/packages/agents-core/src/tool.ts
@@ -920,8 +920,8 @@ export function hostedMcpTool<Context = UnknownContext>(
           requireApproval:
             | 'always'
             | {
-                never?: { toolNames: string[] };
-                always?: { toolNames: string[] };
+                never?: { toolNames?: string[]; readOnly?: boolean };
+                always?: { toolNames?: string[]; readOnly?: boolean };
               };
           onApproval?: HostedMCPApprovalFunction<Context>;
         }
@@ -1981,8 +1981,8 @@ function buildRequireApproval(
   requireApproval:
     | 'always'
     | {
-        never?: { toolNames: string[] };
-        always?: { toolNames: string[] };
+        never?: { toolNames?: string[]; readOnly?: boolean };
+        always?: { toolNames?: string[]; readOnly?: boolean };
       },
 ): Exclude<
   ProviderData.HostedMCPTool['require_approval'],

--- a/packages/agents-core/src/tool.ts
+++ b/packages/agents-core/src/tool.ts
@@ -21,6 +21,7 @@ import logger from './logger';
 import { getCurrentSpan } from './tracing';
 import { RunToolApprovalItem, RunToolCallOutputItem } from './items';
 import { toSmartString } from './utils/smartString';
+import { normalizeHostedMcpRequireApproval } from './utils/mcpApproval';
 import * as ProviderData from './types/providerData';
 import * as protocol from './types/protocol';
 import type { ZodInfer, ZodObjectLike } from './utils/zodCompat';
@@ -950,10 +951,7 @@ export function hostedMcpTool<Context = UnknownContext>(
             allowed_tools: toMcpAllowedToolsFilter(options.allowedTools),
             defer_loading: options.deferLoading,
             headers: options.headers,
-            require_approval:
-              typeof options.requireApproval === 'string'
-                ? 'always'
-                : buildRequireApproval(options.requireApproval),
+            require_approval: buildRequireApproval(options.requireApproval),
             on_approval: options.onApproval,
             server_description: options.serverDescription,
           };
@@ -986,10 +984,7 @@ export function hostedMcpTool<Context = UnknownContext>(
             allowed_tools: toMcpAllowedToolsFilter(options.allowedTools),
             defer_loading: options.deferLoading,
             headers: options.headers,
-            require_approval:
-              typeof options.requireApproval === 'string'
-                ? 'always'
-                : buildRequireApproval(options.requireApproval),
+            require_approval: buildRequireApproval(options.requireApproval),
             on_approval: options.onApproval,
             server_description: options.serverDescription,
           };
@@ -1016,10 +1011,7 @@ export function hostedMcpTool<Context = UnknownContext>(
             server_label: options.serverLabel,
             allowed_tools: toMcpAllowedToolsFilter(options.allowedTools),
             defer_loading: options.deferLoading,
-            require_approval:
-              typeof options.requireApproval === 'string'
-                ? 'always'
-                : buildRequireApproval(options.requireApproval),
+            require_approval: buildRequireApproval(options.requireApproval),
             on_approval: options.onApproval,
             server_description: options.serverDescription,
           };
@@ -1985,21 +1977,24 @@ export function toolNamespace<TTools extends readonly AnyFunctionTool[]>(
   ) as unknown as TTools;
 }
 
-function buildRequireApproval(requireApproval: {
-  never?: { toolNames: string[] };
-  always?: { toolNames: string[] };
-}): { never?: { tool_names: string[] }; always?: { tool_names: string[] } } {
-  const result: {
-    never?: { tool_names: string[] };
-    always?: { tool_names: string[] };
-  } = {};
-  if (requireApproval.always) {
-    result.always = { tool_names: requireApproval.always.toolNames };
+function buildRequireApproval(
+  requireApproval:
+    | 'always'
+    | {
+        never?: { toolNames: string[] };
+        always?: { toolNames: string[] };
+      },
+): Exclude<
+  ProviderData.HostedMCPTool['require_approval'],
+  'never' | undefined
+> {
+  const normalized = normalizeHostedMcpRequireApproval(requireApproval);
+  if (normalized === 'never') {
+    throw new UserError(
+      'Invalid hosted MCP requireApproval: approval-required branch cannot normalize to "never".',
+    );
   }
-  if (requireApproval.never) {
-    result.never = { tool_names: requireApproval.never.toolNames };
-  }
-  return result;
+  return normalized;
 }
 
 function toMcpAllowedToolsFilter(

--- a/packages/agents-core/src/types/providerData.ts
+++ b/packages/agents-core/src/types/providerData.ts
@@ -31,8 +31,8 @@ export type HostedMCPTool<Context = UnknownContext> = {
         require_approval:
           | 'always'
           | {
-              never?: { tool_names: string[] };
-              always?: { tool_names: string[] };
+              never?: { tool_names?: string[]; read_only?: boolean };
+              always?: { tool_names?: string[]; read_only?: boolean };
             };
         on_approval?: HostedMCPApprovalFunction<Context>;
       }

--- a/packages/agents-core/src/utils/index.ts
+++ b/packages/agents-core/src/utils/index.ts
@@ -4,6 +4,7 @@ export { toFunctionToolName } from './tools';
 export { EventEmitterDelegate } from '../lifecycle';
 export { encodeUint8ArrayToBase64 } from './base64';
 export { applyDiff } from './applyDiff';
+export { normalizeHostedMcpRequireApproval } from './mcpApproval';
 export {
   getToolSearchProviderCallId,
   getToolSearchMatchKey,

--- a/packages/agents-core/src/utils/mcpApproval.ts
+++ b/packages/agents-core/src/utils/mcpApproval.ts
@@ -1,0 +1,132 @@
+import { UserError } from '../errors';
+import type * as ProviderData from '../types/providerData';
+
+type HostedMcpRequireApproval = Exclude<
+  ProviderData.HostedMCPTool['require_approval'],
+  undefined
+>;
+
+type ToolNamesFilter = { tool_names: string[] };
+
+const REQUIRE_APPROVAL_POLICY_KEYS = new Set(['always', 'never']);
+const TOOL_NAMES_KEYS = new Set(['toolNames', 'tool_names']);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function invalidRequireApproval(message: string): UserError {
+  return new UserError(`Invalid hosted MCP requireApproval: ${message}`);
+}
+
+function normalizeToolNamesFilter(
+  value: unknown,
+  path: string,
+): ToolNamesFilter {
+  if (!isRecord(value)) {
+    throw invalidRequireApproval(`${path} must be an object with toolNames.`);
+  }
+
+  const keys = Object.keys(value);
+  const unknownKeys = keys.filter((key) => !TOOL_NAMES_KEYS.has(key));
+  if (unknownKeys.length > 0) {
+    throw invalidRequireApproval(
+      `${path} has unsupported key "${unknownKeys[0]}".`,
+    );
+  }
+
+  if ('toolNames' in value && 'tool_names' in value) {
+    throw invalidRequireApproval(
+      `${path} must not specify both toolNames and tool_names.`,
+    );
+  }
+
+  const toolNames = value.toolNames ?? value.tool_names;
+  if (!Array.isArray(toolNames)) {
+    throw invalidRequireApproval(`${path}.toolNames must be an array.`);
+  }
+
+  for (const toolName of toolNames) {
+    if (typeof toolName !== 'string' || toolName.length === 0) {
+      throw invalidRequireApproval(
+        `${path}.toolNames must contain only non-empty strings.`,
+      );
+    }
+  }
+
+  return { tool_names: [...toolNames] };
+}
+
+function findOverlappingToolName(
+  always?: ToolNamesFilter,
+  never?: ToolNamesFilter,
+): string | undefined {
+  if (!always || !never) {
+    return undefined;
+  }
+
+  const neverNames = new Set(never.tool_names);
+  return always.tool_names.find((toolName) => neverNames.has(toolName));
+}
+
+/**
+ * Validates and canonicalizes hosted MCP approval policy config.
+ */
+export function normalizeHostedMcpRequireApproval(
+  requireApproval: unknown,
+): HostedMcpRequireApproval {
+  if (typeof requireApproval === 'undefined') {
+    return 'never';
+  }
+
+  if (typeof requireApproval === 'string') {
+    if (requireApproval === 'always' || requireApproval === 'never') {
+      return requireApproval;
+    }
+    throw invalidRequireApproval(
+      `string value must be "always" or "never", got "${requireApproval}".`,
+    );
+  }
+
+  if (!isRecord(requireApproval)) {
+    throw invalidRequireApproval(
+      'value must be "always", "never", or an object with always/never filters.',
+    );
+  }
+
+  const keys = Object.keys(requireApproval);
+  if (keys.length === 0) {
+    throw invalidRequireApproval(
+      'object value must include at least one of always or never.',
+    );
+  }
+
+  const unknownKeys = keys.filter(
+    (key) => !REQUIRE_APPROVAL_POLICY_KEYS.has(key),
+  );
+  if (unknownKeys.length > 0) {
+    throw invalidRequireApproval(
+      `object value has unsupported key "${unknownKeys[0]}".`,
+    );
+  }
+
+  const normalized: Exclude<HostedMcpRequireApproval, 'always' | 'never'> = {};
+  if (typeof requireApproval.always !== 'undefined') {
+    normalized.always = normalizeToolNamesFilter(
+      requireApproval.always,
+      'always',
+    );
+  }
+  if (typeof requireApproval.never !== 'undefined') {
+    normalized.never = normalizeToolNamesFilter(requireApproval.never, 'never');
+  }
+
+  const overlap = findOverlappingToolName(normalized.always, normalized.never);
+  if (overlap) {
+    throw invalidRequireApproval(
+      `tool "${overlap}" cannot be listed in both always and never.`,
+    );
+  }
+
+  return normalized;
+}

--- a/packages/agents-core/src/utils/mcpApproval.ts
+++ b/packages/agents-core/src/utils/mcpApproval.ts
@@ -6,10 +6,15 @@ type HostedMcpRequireApproval = Exclude<
   undefined
 >;
 
-type ToolNamesFilter = { tool_names: string[] };
+type McpApprovalFilter = { tool_names?: string[]; read_only?: boolean };
 
 const REQUIRE_APPROVAL_POLICY_KEYS = new Set(['always', 'never']);
 const TOOL_NAMES_KEYS = new Set(['toolNames', 'tool_names']);
+const READ_ONLY_KEYS = new Set(['readOnly', 'read_only']);
+const MCP_APPROVAL_FILTER_KEYS = new Set([
+  ...TOOL_NAMES_KEYS,
+  ...READ_ONLY_KEYS,
+]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -19,16 +24,18 @@ function invalidRequireApproval(message: string): UserError {
   return new UserError(`Invalid hosted MCP requireApproval: ${message}`);
 }
 
-function normalizeToolNamesFilter(
+function normalizeApprovalFilter(
   value: unknown,
   path: string,
-): ToolNamesFilter {
+): McpApprovalFilter {
   if (!isRecord(value)) {
-    throw invalidRequireApproval(`${path} must be an object with toolNames.`);
+    throw invalidRequireApproval(
+      `${path} must be an object with toolNames or readOnly.`,
+    );
   }
 
   const keys = Object.keys(value);
-  const unknownKeys = keys.filter((key) => !TOOL_NAMES_KEYS.has(key));
+  const unknownKeys = keys.filter((key) => !MCP_APPROVAL_FILTER_KEYS.has(key));
   if (unknownKeys.length > 0) {
     throw invalidRequireApproval(
       `${path} has unsupported key "${unknownKeys[0]}".`,
@@ -41,27 +48,52 @@ function normalizeToolNamesFilter(
     );
   }
 
+  if ('readOnly' in value && 'read_only' in value) {
+    throw invalidRequireApproval(
+      `${path} must not specify both readOnly and read_only.`,
+    );
+  }
+
+  const normalized: McpApprovalFilter = {};
   const toolNames = value.toolNames ?? value.tool_names;
-  if (!Array.isArray(toolNames)) {
+  if (typeof toolNames !== 'undefined' && !Array.isArray(toolNames)) {
     throw invalidRequireApproval(`${path}.toolNames must be an array.`);
   }
 
-  for (const toolName of toolNames) {
-    if (typeof toolName !== 'string' || toolName.length === 0) {
-      throw invalidRequireApproval(
-        `${path}.toolNames must contain only non-empty strings.`,
-      );
+  if (Array.isArray(toolNames)) {
+    for (const toolName of toolNames) {
+      if (typeof toolName !== 'string' || toolName.length === 0) {
+        throw invalidRequireApproval(
+          `${path}.toolNames must contain only non-empty strings.`,
+        );
+      }
     }
+    normalized.tool_names = [...toolNames];
   }
 
-  return { tool_names: [...toolNames] };
+  const readOnly = value.readOnly ?? value.read_only;
+  if (typeof readOnly !== 'undefined') {
+    if (typeof readOnly !== 'boolean') {
+      throw invalidRequireApproval(`${path}.readOnly must be a boolean.`);
+    }
+    normalized.read_only = readOnly;
+  }
+
+  if (
+    typeof normalized.tool_names === 'undefined' &&
+    typeof normalized.read_only === 'undefined'
+  ) {
+    throw invalidRequireApproval(`${path} must include toolNames or readOnly.`);
+  }
+
+  return normalized;
 }
 
 function findOverlappingToolName(
-  always?: ToolNamesFilter,
-  never?: ToolNamesFilter,
+  always?: McpApprovalFilter,
+  never?: McpApprovalFilter,
 ): string | undefined {
-  if (!always || !never) {
+  if (!always?.tool_names || !never?.tool_names) {
     return undefined;
   }
 
@@ -112,13 +144,13 @@ export function normalizeHostedMcpRequireApproval(
 
   const normalized: Exclude<HostedMcpRequireApproval, 'always' | 'never'> = {};
   if (typeof requireApproval.always !== 'undefined') {
-    normalized.always = normalizeToolNamesFilter(
+    normalized.always = normalizeApprovalFilter(
       requireApproval.always,
       'always',
     );
   }
   if (typeof requireApproval.never !== 'undefined') {
-    normalized.never = normalizeToolNamesFilter(requireApproval.never, 'never');
+    normalized.never = normalizeApprovalFilter(requireApproval.never, 'never');
   }
 
   const overlap = findOverlappingToolName(normalized.always, normalized.never);

--- a/packages/agents-core/test/runner/modelOutputs.test.ts
+++ b/packages/agents-core/test/runner/modelOutputs.test.ts
@@ -1951,6 +1951,33 @@ describe('processModelResponse', () => {
     });
   });
 
+  it('rejects invalid hosted MCP approval policies from tool_search output', () => {
+    const toolSearchOutput: protocol.ToolSearchOutputItem = {
+      type: 'tool_search_output',
+      id: 'ts_output_shopify',
+      status: 'completed',
+      tools: [
+        {
+          type: 'mcp',
+          server_label: 'shopify',
+          server_url: 'https://mcp.example.com/shopify',
+          require_approval: {
+            always: { tool_names: ['delete'] },
+            never: { tool_names: ['delete'] },
+          },
+        },
+      ],
+    } as any;
+    const response: ModelResponse = {
+      output: [toolSearchOutput],
+      usage: new Usage(),
+    };
+
+    expect(() => processModelResponse(response, TEST_AGENT, [], [])).toThrow(
+      UserError,
+    );
+  });
+
   it('captures reasoning items', () => {
     const reasoning: protocol.ReasoningItem = {
       id: 'r1',

--- a/packages/agents-core/test/runner/modelOutputs.test.ts
+++ b/packages/agents-core/test/runner/modelOutputs.test.ts
@@ -1978,6 +1978,54 @@ describe('processModelResponse', () => {
     );
   });
 
+  it('accepts read-only hosted MCP approval filters from tool_search output', () => {
+    const toolSearchOutput: protocol.ToolSearchOutputItem = {
+      type: 'tool_search_output',
+      id: 'ts_output_shopify',
+      status: 'completed',
+      tools: [
+        {
+          type: 'mcp',
+          server_label: 'shopify',
+          server_url: 'https://mcp.example.com/shopify',
+          require_approval: {
+            always: { read_only: false },
+            never: { tool_names: ['search'], read_only: true },
+          },
+        },
+      ],
+    } as any;
+    const hostedCall: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      name: 'mcp_approval_request',
+      id: 'mcpr_shopify',
+      status: 'in_progress',
+      providerData: {
+        type: 'mcp_approval_request',
+        server_label: 'shopify',
+        name: 'mcp_approval_request',
+        id: 'mcpr_shopify',
+        arguments: {},
+      },
+    };
+    const response: ModelResponse = {
+      output: [toolSearchOutput, hostedCall],
+      usage: new Usage(),
+    };
+
+    const result = processModelResponse(response, TEST_AGENT, [], []);
+
+    expect(result.mcpApprovalRequests[0].mcpTool.providerData).toMatchObject({
+      type: 'mcp',
+      server_label: 'shopify',
+      server_url: 'https://mcp.example.com/shopify',
+      require_approval: {
+        always: { read_only: false },
+        never: { tool_names: ['search'], read_only: true },
+      },
+    });
+  });
+
   it('captures reasoning items', () => {
     const reasoning: protocol.ReasoningItem = {
       id: 'r1',

--- a/packages/agents-core/test/tool.test.ts
+++ b/packages/agents-core/test/tool.test.ts
@@ -650,6 +650,22 @@ describe('create a tool using hostedMcpTool utility', () => {
       never: { tool_names: ['search'] },
     });
   });
+
+  it('normalizes MCP approval read-only filters', () => {
+    const t = hostedMcpTool({
+      serverLabel: 'gitmcp',
+      serverUrl: 'https://gitmcp.io/openai/codex',
+      requireApproval: {
+        always: { readOnly: false },
+        never: { toolNames: ['search'], readOnly: true },
+      },
+    });
+
+    expect(t.providerData.require_approval).toEqual({
+      always: { read_only: false },
+      never: { tool_names: ['search'], read_only: true },
+    });
+  });
 });
 
 describe('tool.invoke', () => {

--- a/packages/agents-core/test/tool.test.ts
+++ b/packages/agents-core/test/tool.test.ts
@@ -601,6 +601,55 @@ describe('create a tool using hostedMcpTool utility', () => {
     expect(t.providerData.server_description).toBe('Repository operations');
     expect(t.providerData.defer_loading).toBe(true);
   });
+
+  it('rejects invalid MCP approval string policies', () => {
+    expect(() =>
+      hostedMcpTool({
+        serverLabel: 'gitmcp',
+        serverUrl: 'https://gitmcp.io/openai/codex',
+        requireApproval: 'alwyas',
+      } as any),
+    ).toThrowError(/Invalid hosted MCP requireApproval/);
+  });
+
+  it('rejects unsupported MCP approval object keys', () => {
+    expect(() =>
+      hostedMcpTool({
+        serverLabel: 'gitmcp',
+        serverUrl: 'https://gitmcp.io/openai/codex',
+        requireApproval: { delete: 'alwyas' },
+      } as any),
+    ).toThrowError(/unsupported key "delete"/);
+  });
+
+  it('rejects MCP approval policies with overlapping tool names', () => {
+    expect(() =>
+      hostedMcpTool({
+        serverLabel: 'gitmcp',
+        serverUrl: 'https://gitmcp.io/openai/codex',
+        requireApproval: {
+          always: { toolNames: ['delete'] },
+          never: { toolNames: ['delete'] },
+        },
+      }),
+    ).toThrowError(/cannot be listed in both always and never/);
+  });
+
+  it('normalizes MCP approval tool name filters', () => {
+    const t = hostedMcpTool({
+      serverLabel: 'gitmcp',
+      serverUrl: 'https://gitmcp.io/openai/codex',
+      requireApproval: {
+        always: { toolNames: ['delete'] },
+        never: { toolNames: ['search'] },
+      },
+    });
+
+    expect(t.providerData.require_approval).toEqual({
+      always: { tool_names: ['delete'] },
+      never: { tool_names: ['search'] },
+    });
+  });
 });
 
 describe('tool.invoke', () => {

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -1654,8 +1654,8 @@ function convertMCPRequireApproval(
   }
 
   return {
-    never: { tool_names: normalized.never?.tool_names },
-    always: { tool_names: normalized.always?.tool_names },
+    never: normalized.never,
+    always: normalized.always,
   };
 }
 

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -68,6 +68,7 @@ import {
   encodeUint8ArrayToBase64,
   getToolSearchExecution,
   getToolSearchProviderCallId,
+  normalizeHostedMcpRequireApproval,
 } from '@openai/agents-core/utils';
 
 type ToolChoice =
@@ -1643,17 +1644,18 @@ function converTool<_TContext = unknown>(
 function convertMCPRequireApproval(
   requireApproval: ProviderData.HostedMCPTool['require_approval'],
 ): OpenAI.Responses.Tool.Mcp.McpToolApprovalFilter | 'always' | 'never' | null {
-  if (requireApproval === 'never' || requireApproval === undefined) {
+  const normalized = normalizeHostedMcpRequireApproval(requireApproval);
+  if (normalized === 'never') {
     return 'never';
   }
 
-  if (requireApproval === 'always') {
+  if (normalized === 'always') {
     return 'always';
   }
 
   return {
-    never: { tool_names: requireApproval.never?.tool_names },
-    always: { tool_names: requireApproval.always?.tool_names },
+    never: { tool_names: normalized.never?.tool_names },
+    always: { tool_names: normalized.always?.tool_names },
   };
 }
 

--- a/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
@@ -525,6 +525,30 @@ describe('converTool', () => {
     });
   });
 
+  it('preserves MCP approval read-only filters when converting tools', () => {
+    const scoped = converTool({
+      type: 'hosted_tool',
+      providerData: {
+        type: 'mcp',
+        server_label: 'scoped',
+        server_url: 'https://mcp.example.com',
+        require_approval: {
+          never: { tool_names: ['alpha'], read_only: true },
+          always: { read_only: false },
+        },
+      },
+    } as any);
+
+    expect(scoped.tool).toMatchObject({
+      type: 'mcp',
+      server_label: 'scoped',
+      require_approval: {
+        never: { tool_names: ['alpha'], read_only: true },
+        always: { read_only: false },
+      },
+    });
+  });
+
   it('rejects invalid MCP approval policies before converting tools', () => {
     expect(() =>
       converTool({

--- a/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
@@ -525,6 +525,23 @@ describe('converTool', () => {
     });
   });
 
+  it('rejects invalid MCP approval policies before converting tools', () => {
+    expect(() =>
+      converTool({
+        type: 'hosted_tool',
+        providerData: {
+          type: 'mcp',
+          server_label: 'scoped',
+          server_url: 'https://mcp.example.com',
+          require_approval: {
+            never: { tool_names: ['alpha'] },
+            always: { tool_names: ['alpha'] },
+          },
+        },
+      } as any),
+    ).toThrow(UserError);
+  });
+
   it('preserves explicit false external web access on web search tools', () => {
     const web = converTool({
       type: 'hosted_tool',

--- a/packages/agents-realtime/src/clientMessages.ts
+++ b/packages/agents-realtime/src/clientMessages.ts
@@ -289,6 +289,10 @@ export type HostedToolFilter = {
   tool_names?: string[];
 };
 
+export type HostedMCPApprovalFilter = HostedToolFilter & {
+  read_only?: boolean;
+};
+
 // TODO unify this with the core types
 export type HostedMCPToolDefinition = {
   type: 'mcp';
@@ -300,8 +304,8 @@ export type HostedMCPToolDefinition = {
     | 'never'
     | 'always'
     | {
-        never?: HostedToolFilter;
-        always?: HostedToolFilter;
+        never?: HostedMCPApprovalFilter;
+        always?: HostedMCPApprovalFilter;
       };
 };
 

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -636,9 +636,10 @@ export abstract class OpenAIRealtimeBase
             authorization: tool.authorization,
             headers: tool.headers,
             allowed_tools: tool.allowed_tools,
-            require_approval: normalizeHostedMcpRequireApproval(
-              tool.require_approval,
-            ),
+            require_approval:
+              typeof tool.require_approval === 'undefined'
+                ? undefined
+                : normalizeHostedMcpRequireApproval(tool.require_approval),
           });
         }
 

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -1,4 +1,5 @@
 import { RuntimeEventEmitter, Usage } from '@openai/agents-core';
+import { normalizeHostedMcpRequireApproval } from '@openai/agents-core/utils';
 import type { MessageEvent as WebSocketMessageEvent } from 'ws';
 
 import {
@@ -635,7 +636,9 @@ export abstract class OpenAIRealtimeBase
             authorization: tool.authorization,
             headers: tool.headers,
             allowed_tools: tool.allowed_tools,
-            require_approval: tool.require_approval,
+            require_approval: normalizeHostedMcpRequireApproval(
+              tool.require_approval,
+            ),
           });
         }
 

--- a/packages/agents-realtime/src/tool.ts
+++ b/packages/agents-realtime/src/tool.ts
@@ -51,15 +51,19 @@ export function toRealtimeToolDefinition(
       tool.providerData.server_url && tool.providerData.server_url.length > 0
         ? tool.providerData.server_url
         : undefined;
+    const requireApproval =
+      typeof tool.providerData.require_approval === 'undefined'
+        ? undefined
+        : normalizeHostedMcpRequireApproval(tool.providerData.require_approval);
     return {
       type: 'mcp',
       server_label: tool.providerData.server_label,
       server_url: serverUrl,
       headers: tool.providerData.headers,
       allowed_tools: tool.providerData.allowed_tools,
-      require_approval: normalizeHostedMcpRequireApproval(
-        tool.providerData.require_approval,
-      ),
+      ...(typeof requireApproval === 'undefined'
+        ? {}
+        : { require_approval: requireApproval }),
     };
   }
 

--- a/packages/agents-realtime/src/tool.ts
+++ b/packages/agents-realtime/src/tool.ts
@@ -4,6 +4,7 @@ import {
   Tool,
   UserError,
 } from '@openai/agents-core';
+import { normalizeHostedMcpRequireApproval } from '@openai/agents-core/utils';
 import { RealtimeToolDefinition } from './clientMessages';
 
 export const BACKGROUND_RESULT_SYMBOL = Symbol('backgroundResult');
@@ -56,7 +57,9 @@ export function toRealtimeToolDefinition(
       server_url: serverUrl,
       headers: tool.providerData.headers,
       allowed_tools: tool.providerData.allowed_tools,
-      require_approval: tool.providerData.require_approval,
+      require_approval: normalizeHostedMcpRequireApproval(
+        tool.providerData.require_approval,
+      ),
     };
   }
 

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -188,6 +188,29 @@ describe('OpenAIRealtimeBase helpers', () => {
     ]);
   });
 
+  it('omits mcp require_approval when realtime config leaves it undefined', () => {
+    const base = new TestBase();
+    const payload = (base as any)._getMergedSessionConfig({
+      instructions: 'hi',
+      model: 'gpt-realtime-1.5',
+      tools: [
+        {
+          type: 'mcp',
+          server_label: 'deepwiki',
+          server_url: 'https://mcp.deepwiki.com/sse',
+        },
+      ],
+    });
+
+    expect(payload.tools).toEqual([
+      {
+        type: 'mcp',
+        server_label: 'deepwiki',
+        server_url: 'https://mcp.deepwiki.com/sse',
+      },
+    ]);
+  });
+
   it('sendFunctionCallOutput emits item_update and response.create', () => {
     const base = new TestBase();
     const updates: any[] = [];

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -211,6 +211,37 @@ describe('OpenAIRealtimeBase helpers', () => {
     ]);
   });
 
+  it('preserves mcp require_approval read_only filters in realtime config', () => {
+    const base = new TestBase();
+    const payload = (base as any)._getMergedSessionConfig({
+      instructions: 'hi',
+      model: 'gpt-realtime-1.5',
+      tools: [
+        {
+          type: 'mcp',
+          server_label: 'deepwiki',
+          server_url: 'https://mcp.deepwiki.com/sse',
+          require_approval: {
+            always: { read_only: false },
+            never: { tool_names: ['search'], read_only: true },
+          },
+        },
+      ],
+    });
+
+    expect(payload.tools).toEqual([
+      {
+        type: 'mcp',
+        server_label: 'deepwiki',
+        server_url: 'https://mcp.deepwiki.com/sse',
+        require_approval: {
+          always: { read_only: false },
+          never: { tool_names: ['search'], read_only: true },
+        },
+      },
+    ]);
+  });
+
   it('sendFunctionCallOutput emits item_update and response.create', () => {
     const base = new TestBase();
     const updates: any[] = [];

--- a/packages/agents-realtime/test/tool.test.ts
+++ b/packages/agents-realtime/test/tool.test.ts
@@ -104,6 +104,21 @@ describe('realtime tool helpers', () => {
     ).toThrowError(/Invalid hosted MCP requireApproval/);
   });
 
+  it('omits hosted MCP approval policy when provider data leaves it undefined', () => {
+    const mcpDef = toRealtimeToolDefinition({
+      ...hostedMcpTool,
+      providerData: {
+        ...hostedMcpTool.providerData,
+        require_approval: undefined,
+      },
+    } as any);
+
+    if (mcpDef.type !== 'mcp') {
+      throw new Error('Expected mcp definition');
+    }
+    expect(mcpDef).not.toHaveProperty('require_approval');
+  });
+
   it('preserves read-only hosted MCP approval filters for realtime tools', () => {
     const mcpDef = toRealtimeToolDefinition({
       ...hostedMcpTool,

--- a/packages/agents-realtime/test/tool.test.ts
+++ b/packages/agents-realtime/test/tool.test.ts
@@ -91,4 +91,16 @@ describe('realtime tool helpers', () => {
       toRealtimeToolDefinition({ ...functionTool, type: 'computer' } as any),
     ).toThrowError(/Invalid tool type/);
   });
+
+  it('rejects invalid hosted MCP approval policies for realtime tools', () => {
+    expect(() =>
+      toRealtimeToolDefinition({
+        ...hostedMcpTool,
+        providerData: {
+          ...hostedMcpTool.providerData,
+          require_approval: { delete: 'alwyas' },
+        },
+      } as any),
+    ).toThrowError(/Invalid hosted MCP requireApproval/);
+  });
 });

--- a/packages/agents-realtime/test/tool.test.ts
+++ b/packages/agents-realtime/test/tool.test.ts
@@ -103,4 +103,25 @@ describe('realtime tool helpers', () => {
       } as any),
     ).toThrowError(/Invalid hosted MCP requireApproval/);
   });
+
+  it('preserves read-only hosted MCP approval filters for realtime tools', () => {
+    const mcpDef = toRealtimeToolDefinition({
+      ...hostedMcpTool,
+      providerData: {
+        ...hostedMcpTool.providerData,
+        require_approval: {
+          always: { read_only: false },
+          never: { tool_names: ['search'], read_only: true },
+        },
+      },
+    } as any);
+
+    if (mcpDef.type !== 'mcp') {
+      throw new Error('Expected mcp definition');
+    }
+    expect(mcpDef.require_approval).toEqual({
+      always: { read_only: false },
+      never: { tool_names: ['search'], read_only: true },
+    });
+  });
 });


### PR DESCRIPTION
This pull request fixes hosted MCP approval policy validation so invalid `require_approval` values cannot silently change or disable approval behavior. It adds a shared validator in `packages/agents-core/src/utils/mcpApproval.ts` and applies it through `hostedMcpTool()`, tool_search-loaded hosted MCP tools, Responses conversion, and Realtime session/tool conversion.

The change rejects unsupported policy strings, unknown object keys, malformed `toolNames` filters, and tools listed in both `always` and `never`. It also adds regression coverage across agents-core, agents-openai, and agents-realtime.

see also: https://github.com/openai/openai-agents-python/pull/3179