### PR TITLE
feat: default realtime sessions to gpt-realtime-2

### DIFF
--- a/.changeset/realtime-2-default.md
+++ b/.changeset/realtime-2-default.md
@@ -1,0 +1,8 @@
+---
+'@openai/agents': minor
+'@openai/agents-core': minor
+'@openai/agents-openai': minor
+'@openai/agents-realtime': minor
+---
+
+fix: upgrade realtime defaults and model support for gpt-realtime-2

--- a/examples/realtime-demo/token.ts
+++ b/examples/realtime-demo/token.ts
@@ -8,7 +8,7 @@ async function generateToken() {
   const session = await openai.realtime.clientSecrets.create({
     session: {
       type: 'realtime',
-      model: 'gpt-realtime-1.5',
+      model: 'gpt-realtime-2',
     },
   });
 

--- a/examples/realtime-next/src/app/page.tsx
+++ b/examples/realtime-next/src/app/page.tsx
@@ -43,15 +43,13 @@ const weatherTool = tool({
 });
 
 // To invoke this tool, you can ask a question like "What is the special number?"
-const secretTool = tool({
-  name: 'secret',
-  description: 'A secret tool to tell the special number',
+const specialNumberTool = tool({
+  name: 'special_number',
+  description: 'Retrieve the demo special number.',
   parameters: z.object({
     question: z
       .string()
-      .describe(
-        'The question to ask the secret tool; mainly about the special number.',
-      ),
+      .describe('The user question about the demo special number.'),
   }),
   execute: async ({ question }) => {
     return `The answer to ${question} is 42.`;
@@ -69,10 +67,11 @@ const weatherExpert = new RealtimeAgent({
 
 const agent = new RealtimeAgent({
   name: 'Greeter',
-  instructions: 'You are a greeter',
+  instructions:
+    'You are a greeter. If the user asks for the special number, use the special_number tool.',
   tools: [
     refundBackchannel,
-    secretTool,
+    specialNumberTool,
     hostedMcpTool({
       serverLabel: 'deepwiki',
     }),

--- a/examples/realtime-next/src/app/raw-client/page.tsx
+++ b/examples/realtime-next/src/app/raw-client/page.tsx
@@ -29,13 +29,19 @@ export default function Home() {
       const token = await getToken();
       await connection.current?.connect({
         apiKey: token,
-        model: 'gpt-4o-mini-realtime-preview',
+        model: 'gpt-realtime-2',
         initialSessionConfig: {
           instructions: 'Speak like a pirate',
           voice: 'marin',
-          modalities: ['text', 'audio'],
-          inputAudioFormat: 'pcm16',
-          outputAudioFormat: 'pcm16',
+          outputModalities: ['audio'],
+          audio: {
+            input: {
+              format: 'pcm16',
+            },
+            output: {
+              format: 'pcm16',
+            },
+          },
         },
       });
       setIsConnected(true);

--- a/examples/realtime-next/src/app/server/token.action.tsx
+++ b/examples/realtime-next/src/app/server/token.action.tsx
@@ -17,7 +17,7 @@ export async function getToken() {
       body: JSON.stringify({
         session: {
           type: 'realtime',
-          model: 'gpt-realtime-1.5',
+          model: 'gpt-realtime-2',
           tools: [
             {
               type: 'mcp',

--- a/examples/realtime-next/src/app/websocket/page.tsx
+++ b/examples/realtime-next/src/app/websocket/page.tsx
@@ -63,15 +63,13 @@ const weatherExpert = new RealtimeAgent({
 });
 
 // To invoke this tool, you can ask a question like "What is the special number?"
-const secretTool = tool({
-  name: 'secret',
-  description: 'A secret tool to tell the special number',
+const specialNumberTool = tool({
+  name: 'special_number',
+  description: 'Retrieve the demo special number.',
   parameters: z.object({
     question: z
       .string()
-      .describe(
-        'The question to ask the secret tool; mainly about the special number.',
-      ),
+      .describe('The user question about the demo special number.'),
   }),
   execute: async ({ question }) => {
     return `The answer to ${question} is 42.`;
@@ -83,7 +81,7 @@ const secretTool = tool({
 const agent = new RealtimeAgent({
   name: 'Greeter',
   instructions:
-    'You are a friendly assistant. When you use a tool always first say what you are about to do.',
+    'You are a friendly assistant. When you use a tool always first say what you are about to do. If the user asks for the special number, use the special_number tool.',
   tools: [
     hostedMcpTool({
       serverLabel: 'dnd',
@@ -91,7 +89,7 @@ const agent = new RealtimeAgent({
     hostedMcpTool({
       serverLabel: 'deepwiki',
     }),
-    secretTool,
+    specialNumberTool,
   ],
   handoffs: [weatherExpert],
 });
@@ -113,7 +111,7 @@ export default function Home() {
   useEffect(() => {
     session.current = new RealtimeSession(agent, {
       transport: 'websocket',
-      model: 'gpt-realtime',
+      model: 'gpt-realtime-2',
       outputGuardrails: guardrails,
       config: {
         audio: {

--- a/examples/realtime-twilio-sip/package.json
+++ b/examples/realtime-twilio-sip/package.json
@@ -8,7 +8,7 @@
     "dotenv": "^16.5.0",
     "fastify": "^5.8.5",
     "fastify-raw-body": "^5.0.0",
-    "openai": "^6.26.0"
+    "openai": "^6.35.0"
   },
   "scripts": {
     "build-check": "tsc --noEmit",

--- a/examples/realtime-twilio-sip/server.ts
+++ b/examples/realtime-twilio-sip/server.ts
@@ -48,7 +48,7 @@ async function main() {
   // Reuse the same session options when accepting the call and when instantiating the session so
   // the SIP payload remains in sync with the live websocket session.
   const sessionOptions: Partial<RealtimeSessionOptions> = {
-    model: 'gpt-realtime-1.5',
+    model: 'gpt-realtime-2',
     config: {
       audio: {
         input: {

--- a/examples/realtime-twilio/index.ts
+++ b/examples/realtime-twilio/index.ts
@@ -105,7 +105,7 @@ fastify.register(async (scopedFastify: FastifyInstance) => {
 
       const session = new RealtimeSession(agent, {
         transport: twilioTransportLayer,
-        model: 'gpt-realtime-1.5',
+        model: 'gpt-realtime-2',
         config: {
           audio: {
             output: {

--- a/packages/agents-core/package.json
+++ b/packages/agents-core/package.json
@@ -87,7 +87,7 @@
   },
   "dependencies": {
     "debug": "^4.4.0",
-    "openai": "^6.26.0"
+    "openai": "^6.35.0"
   },
   "peerDependencies": {
     "zod": "^4.0.0"

--- a/packages/agents-core/src/metadata.ts
+++ b/packages/agents-core/src/metadata.ts
@@ -6,7 +6,7 @@ export const METADATA = {
   "version": "0.10.1",
   "versions": {
     "@openai/agents-core": "0.10.1",
-    "openai": "^6.26.0"
+    "openai": "^6.35.0"
   }
 };
 

--- a/packages/agents-openai/package.json
+++ b/packages/agents-openai/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@openai/agents-core": "workspace:*",
     "debug": "^4.4.0",
-    "openai": "^6.26.0"
+    "openai": "^6.35.0"
   },
   "scripts": {
     "prebuild": "tsx ../../scripts/embedMeta.ts",

--- a/packages/agents-openai/src/metadata.ts
+++ b/packages/agents-openai/src/metadata.ts
@@ -7,7 +7,7 @@ export const METADATA = {
   "versions": {
     "@openai/agents-openai": "0.10.1",
     "@openai/agents-core": "workspace:*",
-    "openai": "^6.26.0"
+    "openai": "^6.35.0"
   }
 };
 

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -36,6 +36,7 @@ import {
 } from './openaiChatCompletionsConverter';
 import { protocol } from '@openai/agents-core';
 import { getOpenAIRetryAdvice } from './retryAdvice';
+import { normalizePromptCacheRetention } from './utils/modelSettings';
 
 export const FAKE_ID = 'FAKE_ID';
 
@@ -380,7 +381,9 @@ export class OpenAIChatCompletionsModel implements Model {
       stream: stream ? true : false,
       stream_options: stream ? { include_usage: true } : undefined,
       store: request.modelSettings.store,
-      prompt_cache_retention: request.modelSettings.promptCacheRetention,
+      prompt_cache_retention: normalizePromptCacheRetention(
+        request.modelSettings.promptCacheRetention,
+      ),
       ...providerData,
     };
 

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -63,6 +63,7 @@ import {
   camelOrSnakeToSnakeCase,
   getSnakeCasedProviderDataWithoutReservedKeys,
 } from './utils/providerData';
+import { normalizePromptCacheRetention } from './utils/modelSettings';
 import { ProviderData } from '@openai/agents-core/types';
 import {
   encodeUint8ArrayToBase64,
@@ -3038,7 +3039,9 @@ export class OpenAIResponsesModel implements Model {
       stream,
       text: responseFormat,
       store: request.modelSettings.store,
-      prompt_cache_retention: request.modelSettings.promptCacheRetention,
+      prompt_cache_retention: normalizePromptCacheRetention(
+        request.modelSettings.promptCacheRetention,
+      ),
       context_management: getContextManagement(
         request.modelSettings.contextManagement,
       ),

--- a/packages/agents-openai/src/utils/modelSettings.ts
+++ b/packages/agents-openai/src/utils/modelSettings.ts
@@ -1,0 +1,12 @@
+type PromptCacheRetention =
+  | 'in-memory'
+  | 'in_memory'
+  | '24h'
+  | null
+  | undefined;
+
+export function normalizePromptCacheRetention(
+  value: PromptCacheRetention,
+): 'in_memory' | '24h' | null | undefined {
+  return value === 'in-memory' ? 'in_memory' : value;
+}

--- a/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
@@ -279,7 +279,7 @@ describe('OpenAIChatCompletionsModel', () => {
     const req: any = {
       input: 'u',
       modelSettings: {
-        promptCacheRetention: '24h',
+        promptCacheRetention: 'in-memory',
       },
       tools: [],
       outputType: 'text',
@@ -291,7 +291,7 @@ describe('OpenAIChatCompletionsModel', () => {
 
     expect(client.chat.completions.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        prompt_cache_retention: '24h',
+        prompt_cache_retention: 'in_memory',
       }),
       { headers: HEADERS, signal: undefined },
     );

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -1079,7 +1079,7 @@ describe('OpenAIResponsesModel', () => {
       await model.getResponse(request as any);
 
       const [args] = createMock.mock.calls[0];
-      expect(args.prompt_cache_retention).toBe('in-memory');
+      expect(args.prompt_cache_retention).toBe('in_memory');
     });
   });
 

--- a/packages/agents-realtime/src/clientMessages.ts
+++ b/packages/agents-realtime/src/clientMessages.ts
@@ -121,12 +121,25 @@ export type RealtimeAudioConfig = {
   output?: RealtimeAudioOutputConfig;
 };
 
+export type RealtimeReasoningEffort =
+  | 'minimal'
+  | 'low'
+  | 'medium'
+  | 'high'
+  | 'xhigh';
+
+export type RealtimeReasoningConfig = {
+  effort?: RealtimeReasoningEffort;
+};
+
 // Shared/common fields across both config shapes
 export type RealtimeSessionConfigCommon = {
   model: string;
   instructions: string;
   toolChoice: ModelSettingsToolChoice;
   tools: RealtimeToolDefinition[];
+  parallelToolCalls?: boolean;
+  reasoning?: RealtimeReasoningConfig;
   tracing?: RealtimeTracingConfig | null;
   providerData?: Record<string, any>;
   prompt?: Prompt;
@@ -224,6 +237,8 @@ export function toNewSessionConfig(
       instructions: config.instructions,
       toolChoice: config.toolChoice,
       tools: config.tools,
+      parallelToolCalls: config.parallelToolCalls,
+      reasoning: config.reasoning,
       tracing: config.tracing,
       providerData: config.providerData,
       prompt: config.prompt,
@@ -243,6 +258,8 @@ export function toNewSessionConfig(
     instructions: config.instructions,
     toolChoice: config.toolChoice,
     tools: config.tools,
+    parallelToolCalls: config.parallelToolCalls,
+    reasoning: config.reasoning,
     tracing: config.tracing,
     providerData: config.providerData,
     prompt: config.prompt,

--- a/packages/agents-realtime/src/index.ts
+++ b/packages/agents-realtime/src/index.ts
@@ -25,6 +25,8 @@ export {
 export {
   RealtimeClientMessage,
   RealtimeAudioFormat,
+  RealtimeReasoningConfig,
+  RealtimeReasoningEffort,
   RealtimeSessionConfig,
 } from './clientMessages';
 

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -43,6 +43,7 @@ import { EventEmitterDelegate } from '@openai/agents-core/utils';
 export type OpenAIRealtimeModels =
   | 'gpt-realtime'
   | 'gpt-realtime-1.5'
+  | 'gpt-realtime-2'
   | 'gpt-realtime-2025-08-28'
   | 'gpt-4o-realtime-preview'
   | 'gpt-4o-realtime-preview-2024-10-01'
@@ -59,7 +60,7 @@ export type OpenAIRealtimeModels =
  * The default model that is used during the connection if no model is provided.
  */
 export const DEFAULT_OPENAI_REALTIME_MODEL: OpenAIRealtimeModels =
-  'gpt-realtime-1.5';
+  'gpt-realtime-2';
 
 /**
  * The default session config that gets send over during session connection unless overridden
@@ -603,6 +604,10 @@ export abstract class OpenAIRealtimeBase
       tool_choice:
         newConfig.toolChoice ??
         DEFAULT_OPENAI_REALTIME_SESSION_CONFIG.toolChoice,
+      ...(typeof newConfig.parallelToolCalls === 'undefined'
+        ? {}
+        : { parallel_tool_calls: newConfig.parallelToolCalls }),
+      ...(newConfig.reasoning ? { reasoning: newConfig.reasoning } : {}),
       // We don't set tracing here to make sure that we don't try to override it on every
       // session.update as it might lead to errors
       ...(newConfig.providerData ?? {}),

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -67,6 +67,26 @@ describe('OpenAIRealtimeBase helpers', () => {
     expect(config.audio?.output?.voice).toBeUndefined();
   });
 
+  it('uses gpt-realtime-2 as the default model', () => {
+    const base = new TestBase();
+    const config = (base as any)._getMergedSessionConfig({});
+
+    expect(config.model).toBe('gpt-realtime-2');
+  });
+
+  it('maps reasoning-capable realtime session settings', () => {
+    const base = new TestBase();
+    const config = (base as any)._getMergedSessionConfig({
+      model: 'gpt-realtime-2',
+      parallelToolCalls: false,
+      reasoning: { effort: 'low' },
+    });
+
+    expect(config.model).toBe('gpt-realtime-2');
+    expect(config.parallel_tool_calls).toBe(false);
+    expect(config.reasoning).toEqual({ effort: 'low' });
+  });
+
   it('preserves explicit null audio input config values', () => {
     const base = new TestBase();
     const config = (base as any)._getMergedSessionConfig({

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -45,7 +45,7 @@
     "@openai/agents-openai": "workspace:*",
     "@openai/agents-realtime": "workspace:*",
     "debug": "^4.4.0",
-    "openai": "^6.26.0"
+    "openai": "^6.35.0"
   },
   "keywords": [
     "openai",

--- a/packages/agents/src/metadata.ts
+++ b/packages/agents/src/metadata.ts
@@ -9,7 +9,7 @@ export const METADATA = {
     "@openai/agents-core": "workspace:*",
     "@openai/agents-openai": "workspace:*",
     "@openai/agents-realtime": "workspace:*",
-    "openai": "^6.26.0"
+    "openai": "^6.35.0"
   }
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -509,8 +509,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       openai:
-        specifier: ^6.26.0
-        version: 6.26.0(ws@8.18.2)(zod@4.3.6)
+        specifier: ^6.35.0
+        version: 6.35.0(ws@8.18.2)(zod@4.3.6)
 
   examples/research-bot:
     dependencies:
@@ -566,8 +566,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.1
       openai:
-        specifier: ^6.26.0
-        version: 6.26.0(ws@8.18.2)(zod@4.3.5)
+        specifier: ^6.35.0
+        version: 6.35.0(ws@8.18.2)(zod@4.3.5)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -582,8 +582,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.1
       openai:
-        specifier: ^6.26.0
-        version: 6.26.0(ws@8.18.2)(zod@4.3.5)
+        specifier: ^6.35.0
+        version: 6.35.0(ws@8.18.2)(zod@4.3.5)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -660,8 +660,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.1
       openai:
-        specifier: ^6.26.0
-        version: 6.26.0(ws@8.18.2)(zod@4.3.5)
+        specifier: ^6.35.0
+        version: 6.35.0(ws@8.18.2)(zod@4.3.5)
     devDependencies:
       '@ai-sdk/provider':
         specifier: ^1.1.3
@@ -5959,6 +5959,18 @@ packages:
       zod:
         optional: true
 
+  openai@6.35.0:
+    resolution: {integrity: sha512-L/skwIGnt5xQZHb0UfTu9uAUKbis3ehKypOuJKi20QvG7UStV6C8IC3myGYHcdiF4kms/bAvOJ9UqqNWqi8x/Q==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   openapi-fetch@0.14.1:
     resolution: {integrity: sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A==}
 
@@ -9300,7 +9312,7 @@ snapshots:
   '@openai/agents-core@0.3.9(ws@8.18.2)(zod@3.25.76)':
     dependencies:
       debug: 4.4.3
-      openai: 6.26.0(ws@8.18.2)(zod@3.25.76)
+      openai: 6.35.0(ws@8.18.2)(zod@3.25.76)
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.26.0(zod@3.25.76)
       zod: 3.25.76
@@ -9328,7 +9340,7 @@ snapshots:
     dependencies:
       '@openai/agents-core': 0.3.9(ws@8.18.2)(zod@3.25.76)
       debug: 4.4.3
-      openai: 6.26.0(ws@8.18.2)(zod@3.25.76)
+      openai: 6.35.0(ws@8.18.2)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -14127,12 +14139,17 @@ snapshots:
       ws: 8.18.2
       zod: 3.25.76
 
-  openai@6.26.0(ws@8.18.2)(zod@4.3.5):
+  openai@6.35.0(ws@8.18.2)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.18.2
+      zod: 3.25.76
+
+  openai@6.35.0(ws@8.18.2)(zod@4.3.5):
     optionalDependencies:
       ws: 8.18.2
       zod: 4.3.5
 
-  openai@6.26.0(ws@8.18.2)(zod@4.3.6):
+  openai@6.35.0(ws@8.18.2)(zod@4.3.6):
     optionalDependencies:
       ws: 8.18.2
       zod: 4.3.6


### PR DESCRIPTION
This pull request updates the staged SDK and runtime example changes for `gpt-realtime-2`. It makes `gpt-realtime-2` the default Realtime model, adds it to the SDK model autocomplete list, exposes Realtime reasoning effort and parallel tool call settings, and updates the `openai` dependency range to `^6.35.0`.

It also keeps the OpenAI package upgrade compatible by normalizing `prompt_cache_retention` from the SDK public `in-memory` value to the API `in_memory` value, updates the Realtime examples to request `gpt-realtime-2`, and fixes the `realtime-next` raw client to use a supported single output modality. Unstaged documentation changes are intentionally excluded from this draft.