### PR TITLE
fix: preserve sandbox env resolvers across manifest merges

### DIFF
--- a/.changeset/preserve-env-resolvers.md
+++ b/.changeset/preserve-env-resolvers.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: preserve sandbox environment resolvers across manifest merges

--- a/packages/agents-core/src/sandbox/sandboxes/shared/manifestPersistence.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/manifestPersistence.ts
@@ -1,5 +1,5 @@
 import { isMount, type Entry } from '../../entries';
-import { Manifest } from '../../manifest';
+import { Manifest, type EnvValue } from '../../manifest';
 import {
   mergeNamedObjects,
   mergePathKeyedObjects,
@@ -90,8 +90,8 @@ export function mergeManifestDelta(base: Manifest, update: Manifest): Manifest {
       ...structuredClone(update.entries),
     },
     environment: {
-      ...serializeManifestEnvironment(base),
-      ...serializeManifestEnvironment(update),
+      ...cloneManifestEnvironment(base),
+      ...cloneManifestEnvironment(update),
     },
     users: mergeNamedObjects(base.users, update.users),
     groups: mergeNamedObjects(base.groups, update.groups),
@@ -103,6 +103,17 @@ export function mergeManifestDelta(base: Manifest, update: Manifest): Manifest {
       ? update.remoteMountCommandAllowlist
       : base.remoteMountCommandAllowlist,
   });
+}
+
+function cloneManifestEnvironment(
+  manifest: Manifest,
+): Record<string, EnvValue> {
+  return Object.fromEntries(
+    Object.entries(manifest.environment).map(([key, value]) => [
+      key,
+      value.init(),
+    ]),
+  );
 }
 
 export function mergeManifestEntryDelta(

--- a/packages/agents-core/test/sandboxShared.test.ts
+++ b/packages/agents-core/test/sandboxShared.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { Manifest, dir, file, mount } from '../src/sandbox';
 import {
   deserializeManifest,
@@ -362,6 +362,38 @@ describe('sandbox shared helpers', () => {
     ).toEqual({
       CLIENT_ONLY: 'client',
       TOKEN: 'next',
+    });
+  });
+
+  it('keeps resolver-backed environment values materialized after manifest merges', async () => {
+    const resolveToken = vi.fn(async () => 'resolved-token');
+    const previous = new Manifest({
+      environment: {
+        TOKEN: {
+          value: 'placeholder-token',
+          resolve: resolveToken,
+        },
+        STATIC: 'old-static',
+      },
+    });
+    const currentEnvironment = await materializeEnvironment(previous);
+    const next = mergeManifestDelta(
+      previous,
+      new Manifest({
+        environment: {
+          STATIC: 'new-static',
+        },
+      }),
+    );
+
+    await expect(
+      mergeMaterializedEnvironment(previous, next, currentEnvironment),
+    ).resolves.toEqual({
+      TOKEN: 'resolved-token',
+      STATIC: 'new-static',
+    });
+    await expect(next.resolveEnvironment()).resolves.toMatchObject({
+      TOKEN: 'resolved-token',
     });
   });
 


### PR DESCRIPTION
## Summary

- Preserve resolver-backed sandbox environment values when manifest deltas are merged.
- Keep static environment values serialized as before, while carrying `EnvValue.resolve` entries through `mergeManifestDelta`.
- Add regression coverage for a resolver-backed environment value surviving a manifest merge and resolving during materialization.

## Root cause

`mergeManifestDelta` rebuilt the merged manifest environment through the serialized environment path. That is safe for static strings, but it drops resolver functions, so a resolver-backed environment value becomes a static placeholder after a later manifest merge.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run packages/agents-core/test/sandboxShared.test.ts -t "keeps resolver-backed environment values materialized after manifest merges"`
- `pnpm -F @openai/agents-core build-check`
- `pnpm build`
- `pnpm -r build-check`
- `pnpm changeset:validate-lite`
- `pnpm lint`
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 TMPDIR=/private/tmp CI=1 pnpm test`
