### PR TITLE
fix(openai): add strict feature validation for chat completions

### DIFF
--- a/.changeset/chat-completions-strict-feature-validation.md
+++ b/.changeset/chat-completions-strict-feature-validation.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents': patch
+'@openai/agents-openai': patch
+---
+
+fix: add opt-in strict feature validation for Chat Completions models

--- a/packages/agents-openai/src/index.ts
+++ b/packages/agents-openai/src/index.ts
@@ -1,4 +1,4 @@
-export { OpenAIProvider } from './openaiProvider';
+export { OpenAIProvider, type OpenAIProviderOptions } from './openaiProvider';
 export {
   withResponsesWebSocketSession,
   type ResponsesWebSocketSession,
@@ -9,7 +9,10 @@ export {
   OpenAIResponsesWSModel,
   type OpenAIResponsesWebSocketOptions,
 } from './openaiResponsesModel';
-export { OpenAIChatCompletionsModel } from './openaiChatCompletionsModel';
+export {
+  OpenAIChatCompletionsModel,
+  type OpenAIChatCompletionsModelOptions,
+} from './openaiChatCompletionsModel';
 export {
   isOpenAIResponsesRawModelStreamEvent,
   isOpenAIChatCompletionsRawModelStreamEvent,

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -60,12 +60,30 @@ function hasReasoningContent(
 /**
  * A model that uses (or is compatible with) OpenAI's Chat Completions API.
  */
+export type OpenAIChatCompletionsModelOptions = {
+  /**
+   * When true, reject Responses-only features that Chat Completions cannot
+   * honor. Defaults to false, which preserves the previous ignore-and-warn
+   * behavior.
+   */
+  strictFeatureValidation?: boolean;
+};
+
 export class OpenAIChatCompletionsModel implements Model {
   #client: OpenAI;
   #model: string;
-  constructor(client: OpenAI, model: string) {
+  #strictFeatureValidation: boolean;
+  #hasWarnedUnsupportedPrompt = false;
+  #hasWarnedUnsupportedConversationState = false;
+
+  constructor(
+    client: OpenAI,
+    model: string,
+    options: OpenAIChatCompletionsModelOptions = {},
+  ) {
     this.#client = client;
     this.#model = model;
+    this.#strictFeatureValidation = options.strictFeatureValidation ?? false;
   }
 
   getRetryAdvice(args: ModelRetryAdviceRequest): ModelRetryAdvice | undefined {
@@ -73,6 +91,9 @@ export class OpenAIChatCompletionsModel implements Model {
   }
 
   async getResponse(request: ModelRequest): Promise<ModelResponse> {
+    this.#handleUnsupportedServerManagedConversationState(request);
+    this.#handleUnsupportedPrompt(request);
+
     const response = await withGenerationSpan(async (span) => {
       span.spanData.model = this.#model;
       span.spanData.model_config = request.modelSettings
@@ -202,6 +223,9 @@ export class OpenAIChatCompletionsModel implements Model {
   async *getStreamedResponse(
     request: ModelRequest,
   ): AsyncIterable<ResponseStreamEvent> {
+    this.#handleUnsupportedServerManagedConversationState(request);
+    this.#handleUnsupportedPrompt(request);
+
     const span = request.tracing ? createGenerationSpan() : undefined;
     try {
       if (span) {
@@ -272,6 +296,59 @@ export class OpenAIChatCompletionsModel implements Model {
         span.end();
         resetCurrentSpan();
       }
+    }
+  }
+
+  #handleUnsupportedServerManagedConversationState(request: ModelRequest) {
+    const unsupported: string[] = [];
+    if (request.previousResponseId) {
+      unsupported.push('previousResponseId');
+    }
+    if (request.conversationId) {
+      unsupported.push('conversationId');
+    }
+
+    if (unsupported.length === 0) {
+      return;
+    }
+
+    const message =
+      'OpenAIChatCompletionsModel does not support server-managed conversation state ' +
+      `(${unsupported.join(', ')}). Chat Completions requires callers to pass the full ` +
+      'conversation history; use a Responses API model for previousResponseId or a ' +
+      'conversation-capable model for conversationId.';
+
+    if (this.#strictFeatureValidation) {
+      throw new UserError(message);
+    }
+
+    if (!this.#hasWarnedUnsupportedConversationState) {
+      logger.warn(
+        `${message} Ignoring unsupported server-managed conversation state; ` +
+          'enable strict feature validation to raise an error instead.',
+      );
+      this.#hasWarnedUnsupportedConversationState = true;
+    }
+  }
+
+  #handleUnsupportedPrompt(request: ModelRequest) {
+    if (!request.prompt) {
+      return;
+    }
+
+    const message =
+      'Reusable prompts are only supported by the Responses API. ' +
+      'OpenAIChatCompletionsModel does not support prompt; use a Responses model instead.';
+
+    if (this.#strictFeatureValidation) {
+      throw new UserError(message);
+    }
+
+    if (!this.#hasWarnedUnsupportedPrompt) {
+      logger.warn(
+        `${message} Ignoring prompt; enable strict feature validation to raise an error instead.`,
+      );
+      this.#hasWarnedUnsupportedPrompt = true;
     }
   }
 

--- a/packages/agents-openai/src/openaiProvider.ts
+++ b/packages/agents-openai/src/openaiProvider.ts
@@ -26,6 +26,12 @@ export type OpenAIProviderOptions = {
   project?: string;
   useResponses?: boolean;
   useResponsesWebSocket?: boolean;
+  /**
+   * When false, Chat Completions models warn and ignore Responses-only
+   * features such as previousResponseId, conversationId, and prompt. When true,
+   * they raise UserError instead.
+   */
+  strictFeatureValidation?: boolean;
   responsesWebSocketOptions?: OpenAIResponsesWebSocketOptions;
   openAIClient?: OpenAI;
 };
@@ -140,7 +146,9 @@ export class OpenAIProvider implements ModelProvider {
           })
         : new OpenAIResponsesModel(client, model);
     } else {
-      resolvedModel = new OpenAIChatCompletionsModel(this.#getClient(), model);
+      resolvedModel = new OpenAIChatCompletionsModel(this.#getClient(), model, {
+        strictFeatureValidation: this.#options.strictFeatureValidation,
+      });
     }
 
     if (shouldCacheModelWrapper) {

--- a/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { withTrace, setTracingDisabled } from '@openai/agents-core';
 import { OpenAIChatCompletionsModel } from '../src/openaiChatCompletionsModel';
 import { HEADERS } from '../src/defaults';
+import logger from '../src/logger';
 
 vi.mock('../src/openaiChatCompletionsStreaming', () => {
   return {
@@ -77,6 +78,118 @@ describe('OpenAIChatCompletionsModel', () => {
         ],
       },
     ]);
+  });
+
+  it('warns and ignores server-managed conversation state by default', async () => {
+    const client = new FakeClient();
+    const response = {
+      id: 'r',
+      choices: [{ message: { content: 'hi' } }],
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    } as any;
+    client.chat.completions.create.mockResolvedValue(response);
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const req: any = {
+      input: 'u',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      previousResponseId: 'resp_123',
+      conversationId: 'conv_123',
+    };
+
+    await withTrace('t', () => model.getResponse(req));
+    await withTrace('t', () => model.getResponse(req));
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'server-managed conversation state',
+    );
+    expect(warnSpy.mock.calls[0]?.[0]).toContain('previousResponseId');
+    expect(warnSpy.mock.calls[0]?.[0]).toContain('conversationId');
+    expect(client.chat.completions.create).toHaveBeenCalledTimes(2);
+    warnSpy.mockRestore();
+  });
+
+  it('throws for server-managed conversation state in strict mode', async () => {
+    const client = new FakeClient();
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt', {
+      strictFeatureValidation: true,
+    });
+    const req: any = {
+      input: 'u',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      previousResponseId: 'resp_123',
+    };
+
+    await expect(withTrace('t', () => model.getResponse(req))).rejects.toThrow(
+      'server-managed conversation state',
+    );
+    expect(client.chat.completions.create).not.toHaveBeenCalled();
+  });
+
+  it('warns and ignores reusable prompts by default', async () => {
+    const client = new FakeClient();
+    const response = {
+      id: 'r',
+      choices: [{ message: { content: 'hi' } }],
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    } as any;
+    client.chat.completions.create.mockResolvedValue(response);
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const req: any = {
+      input: 'u',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      prompt: { promptId: 'pmpt_123' },
+    };
+
+    await withTrace('t', () => model.getResponse(req));
+    await withTrace('t', () => model.getResponse(req));
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'Reusable prompts are only supported by the Responses API',
+    );
+    expect(
+      client.chat.completions.create.mock.calls[0]?.[0],
+    ).not.toHaveProperty('prompt');
+    expect(client.chat.completions.create).toHaveBeenCalledTimes(2);
+    warnSpy.mockRestore();
+  });
+
+  it('throws for reusable prompts in strict mode', async () => {
+    const client = new FakeClient();
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt', {
+      strictFeatureValidation: true,
+    });
+    const req: any = {
+      input: 'u',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      prompt: { promptId: 'pmpt_123' },
+    };
+
+    await expect(withTrace('t', () => model.getResponse(req))).rejects.toThrow(
+      'Reusable prompts',
+    );
+    expect(client.chat.completions.create).not.toHaveBeenCalled();
   });
 
   it('preserves SDK retries for direct callers when no runner retry policy is configured', async () => {
@@ -858,6 +971,69 @@ describe('OpenAIChatCompletionsModel', () => {
     );
     expect(convertChatCompletionsStreamToResponses).toHaveBeenCalled();
     expect(events).toEqual([{ type: 'first' }, { type: 'second' }]);
+  });
+
+  it('warns and ignores unsupported stream response features by default', async () => {
+    const client = new FakeClient();
+    async function* fakeStream() {
+      yield { id: 'c' } as any;
+    }
+    client.chat.completions.create.mockResolvedValue(fakeStream());
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const req: any = {
+      input: 'hi',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      previousResponseId: 'resp_123',
+      prompt: { promptId: 'pmpt_123' },
+    };
+
+    await withTrace('t', async () => {
+      for await (const _event of model.getStreamedResponse(req)) {
+        // Consume the stream.
+      }
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'server-managed conversation state',
+    );
+    expect(warnSpy.mock.calls[1]?.[0]).toContain('Reusable prompts');
+    expect(
+      client.chat.completions.create.mock.calls[0]?.[0],
+    ).not.toHaveProperty('prompt');
+    expect(client.chat.completions.create).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  it('throws for unsupported stream response features in strict mode', async () => {
+    const client = new FakeClient();
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt', {
+      strictFeatureValidation: true,
+    });
+    const req: any = {
+      input: 'hi',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      conversationId: 'conv_123',
+    };
+
+    await expect(
+      withTrace('t', async () => {
+        for await (const _event of model.getStreamedResponse(req)) {
+          // Consume the stream.
+        }
+      }),
+    ).rejects.toThrow('server-managed conversation state');
+    expect(client.chat.completions.create).not.toHaveBeenCalled();
   });
 
   it('populates usage from response_done event when initial usage is zero', async () => {

--- a/packages/agents-openai/test/openaiProvider.test.ts
+++ b/packages/agents-openai/test/openaiProvider.test.ts
@@ -171,6 +171,28 @@ describe('OpenAIProvider', () => {
     expect(OpenAIMock).not.toHaveBeenCalled();
   });
 
+  it('passes strict feature validation to chat completions models', async () => {
+    const provider = new OpenAIProvider({
+      openAIClient: new FakeClient() as any,
+      useResponses: false,
+      strictFeatureValidation: true,
+    });
+
+    const model = await provider.getModel('gpt-4o');
+
+    await expect(
+      model.getResponse({
+        input: 'hi',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        previousResponseId: 'resp_123',
+      } as any),
+    ).rejects.toThrow('server-managed conversation state');
+  });
+
   it('caches model wrappers so websocket transport can reuse a connection', async () => {
     const provider = new OpenAIProvider({
       openAIClient: new FakeClient() as any,


### PR DESCRIPTION
This pull request fixes Chat Completions feature handling by adding opt-in strict feature validation to `OpenAIProvider` and `OpenAIChatCompletionsModel`. By default, Responses-only prompt templates and server-managed state continue to warn once and are ignored; when `strictFeatureValidation` is enabled, the model raises `UserError` before sending a Chat Completions request.

It also exports the new option types, adds non-streaming and streaming coverage for default warn-and-ignore behavior and strict failures, verifies provider wiring, and includes a patch changeset for `@openai/agents` and `@openai/agents-openai`.

see also: https://github.com/openai/openai-agents-python/pull/3298