### PR TITLE
fix(core): drop reasoning items orphaned by dropped tool calls

### DIFF
--- a/.changeset/drop-orphan-reasoning-items.md
+++ b/.changeset/drop-orphan-reasoning-items.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: drop reasoning items orphaned by dropped tool calls

--- a/packages/agents-core/src/runner/items.ts
+++ b/packages/agents-core/src/runner/items.ts
@@ -181,8 +181,9 @@ export function dropOrphanToolCalls(
 ): AgentInputItem[] {
   const pruningIndexes = options?.pruningIndexes;
   const completedByResultType = collectCompletedCallIdsByResultType(items);
+  const droppedIndexes = new Set<number>();
 
-  return items.filter((item, index) => {
+  const filtered = items.filter((item, index) => {
     if (pruningIndexes && !pruningIndexes.has(index)) {
       return true;
     }
@@ -204,8 +205,66 @@ export function dropOrphanToolCalls(
     if (isPendingHostedShellCall(item)) {
       return true;
     }
-    return completedByResultType.get(resultType)?.has(callId) ?? false;
+    if (completedByResultType.get(resultType)?.has(callId) ?? false) {
+      return true;
+    }
+    droppedIndexes.add(index);
+    return false;
   });
+
+  if (droppedIndexes.size === 0) {
+    return filtered;
+  }
+
+  return dropReasoningItemsPrecedingDroppedCalls(
+    items,
+    droppedIndexes,
+    pruningIndexes,
+  );
+}
+
+function dropReasoningItemsPrecedingDroppedCalls(
+  items: AgentInputItem[],
+  droppedIndexes: Set<number>,
+  pruningIndexes?: Set<number>,
+): AgentInputItem[] {
+  const dropReasoning = new Set<number>();
+
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    if (pruningIndexes && !pruningIndexes.has(index)) {
+      continue;
+    }
+    const item = items[index];
+    if (
+      !item ||
+      typeof item !== 'object' ||
+      (item as { type?: unknown }).type !== 'reasoning' ||
+      droppedIndexes.has(index)
+    ) {
+      continue;
+    }
+
+    for (let nextIndex = index + 1; nextIndex < items.length; nextIndex += 1) {
+      if (dropReasoning.has(nextIndex)) {
+        continue;
+      }
+      const nextItem = items[nextIndex];
+      if (
+        nextItem &&
+        typeof nextItem === 'object' &&
+        (nextItem as { type?: unknown }).type === 'reasoning'
+      ) {
+        continue;
+      }
+      if (droppedIndexes.has(nextIndex)) {
+        dropReasoning.add(index);
+      }
+      break;
+    }
+  }
+
+  const excluded = new Set([...droppedIndexes, ...dropReasoning]);
+  return items.filter((_item, index) => !excluded.has(index));
 }
 
 export function prepareModelInputItems(

--- a/packages/agents-core/test/runner/items.helpers.test.ts
+++ b/packages/agents-core/test/runner/items.helpers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { Agent } from '../../src/agent';
 import {
   RunMessageOutputItem,
+  RunReasoningItem,
   RunToolCallItem,
   RunToolCallOutputItem,
 } from '../../src/items';
@@ -127,6 +128,106 @@ describe('prepareModelInputItems', () => {
       shellOutput.rawItem,
     ]);
   });
+
+  it('drops reasoning items tied to orphan generated tool calls', () => {
+    const agent = new Agent({ name: 'HelperAgent' });
+    const orphanReasoningA = new RunReasoningItem(
+      {
+        type: 'reasoning',
+        id: 'rs_orphan_a',
+        content: [],
+      },
+      agent,
+    );
+    const orphanReasoningB = new RunReasoningItem(
+      {
+        type: 'reasoning',
+        id: 'rs_orphan_b',
+        content: [],
+      },
+      agent,
+    );
+    const orphanCall = new RunToolCallItem(
+      {
+        type: 'function_call',
+        callId: 'orphan_call',
+        name: 'orphan',
+        arguments: '{}',
+      } satisfies protocol.FunctionCallItem,
+      agent,
+    );
+    const pairedReasoning = new RunReasoningItem(
+      {
+        type: 'reasoning',
+        id: 'rs_paired',
+        content: [],
+      },
+      agent,
+    );
+    const pairedCall = new RunToolCallItem(
+      {
+        type: 'function_call',
+        callId: 'paired_call',
+        name: 'paired',
+        arguments: '{}',
+      } satisfies protocol.FunctionCallItem,
+      agent,
+    );
+    const pairedOutput = new RunToolCallOutputItem(
+      {
+        type: 'function_call_result',
+        name: 'paired',
+        callId: 'paired_call',
+        status: 'completed',
+        output: 'ok',
+      } satisfies protocol.FunctionCallResultItem,
+      agent,
+      'ok',
+    );
+
+    const prepared = prepareModelInputItems('hello', [
+      orphanReasoningA,
+      orphanReasoningB,
+      orphanCall,
+      pairedReasoning,
+      pairedCall,
+      pairedOutput,
+    ]);
+
+    expect(prepared).toEqual([
+      {
+        type: 'message',
+        role: 'user',
+        content: 'hello',
+      },
+      pairedReasoning.rawItem,
+      pairedCall.rawItem,
+      pairedOutput.rawItem,
+    ]);
+  });
+
+  it('keeps generated lone reasoning when no tool calls are dropped', () => {
+    const agent = new Agent({ name: 'HelperAgent' });
+    const reasoning = new RunReasoningItem(
+      {
+        type: 'reasoning',
+        id: 'rs_lone',
+        content: [],
+      },
+      agent,
+    );
+
+    const prepared = prepareModelInputItems('hello', [reasoning]);
+
+    expect(prepared).toEqual([
+      {
+        type: 'message',
+        role: 'user',
+        content: 'hello',
+      },
+      reasoning.rawItem,
+    ]);
+  });
 });
 
 describe('extractOutputItemsFromRunItems', () => {
@@ -185,5 +286,25 @@ describe('dropOrphanToolCalls', () => {
     });
 
     expect(prepared).toEqual([pendingShell]);
+  });
+
+  it('does not drop reasoning outside the explicit pruning indexes', () => {
+    const callerReasoning: AgentInputItem = {
+      type: 'reasoning',
+      id: 'rs_caller',
+      content: [],
+    };
+    const historyShell: AgentInputItem = {
+      type: 'shell_call',
+      callId: 'history_shell',
+      status: 'completed',
+      action: { commands: ['echo old'] },
+    };
+
+    const prepared = dropOrphanToolCalls([callerReasoning, historyShell], {
+      pruningIndexes: new Set([1]),
+    });
+
+    expect(prepared).toEqual([callerReasoning]);
   });
 });


### PR DESCRIPTION
This pull request fixes continuation replay by removing reasoning items that become orphaned when their following tool call is pruned as stale history. Without this, a replay can keep a reasoning item while dropping its associated tool call, causing the Responses API to reject the input as a reasoning item without its required following item.

The change keeps lone reasoning items when no tool calls are dropped, preserves pending hosted shell calls, and respects index-scoped pruning so caller-provided items are not removed while session history is cleaned up.

see also: https://github.com/openai/openai-agents-python/pull/3207