### PR TITLE
fix(core): preserve latest response id on resume

### DIFF
--- a/.changeset/preserve-latest-response-id.md
+++ b/.changeset/preserve-latest-response-id.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: preserve latest response id when resuming server-managed runs

--- a/packages/agents-core/src/runner/conversation.ts
+++ b/packages/agents-core/src/runner/conversation.ts
@@ -231,7 +231,11 @@ export class ServerConversationTracker {
     const hasResponses = modelResponses.length > 0;
 
     const serverItemKeys = new Set<string>();
+    let latestResponseId: string | undefined;
     for (const response of modelResponses) {
+      if (response.responseId) {
+        latestResponseId = response.responseId;
+      }
       for (const item of response.output) {
         if (item && typeof item === 'object') {
           this.serverItems.add(item);
@@ -251,9 +255,9 @@ export class ServerConversationTracker {
       this.remainingInitialInput = null;
     }
 
-    const latestResponse = modelResponses[modelResponses.length - 1];
-    if (!this.conversationId && latestResponse?.responseId) {
-      this.previousResponseId = latestResponse.responseId;
+    // Mirror live tracking by preserving the last response that actually carried an id.
+    if (!this.conversationId && latestResponseId) {
+      this.previousResponseId = latestResponseId;
     }
 
     if (hasResponses) {

--- a/packages/agents-core/test/runner/sessionPersistence.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.test.ts
@@ -87,6 +87,33 @@ describe('ServerConversationTracker', () => {
     });
   });
 
+  it('uses the latest non-empty responseId when resuming without conversationId', () => {
+    const tracker = new ServerConversationTracker({});
+
+    tracker.primeFromState({
+      originalInput: [],
+      generatedItems: [],
+      modelResponses: [
+        {
+          output: [],
+          usage: new Usage(),
+          responseId: 'resp_first',
+        },
+        {
+          output: [],
+          usage: new Usage(),
+          responseId: 'resp_second',
+        },
+        {
+          output: [],
+          usage: new Usage(),
+        },
+      ],
+    });
+
+    expect(tracker.previousResponseId).toBe('resp_second');
+  });
+
   it('applies reasoningItemIdPolicy when preparing generated reasoning items', () => {
     const tracker = new ServerConversationTracker({
       conversationId: 'conv-3',


### PR DESCRIPTION
This pull request fixes server-managed conversation resume by seeding `previousResponseId` from the most recent model response that actually carries a response id, rather than only inspecting the final model response. Without this, a resumed run could lose the response chaining cursor when a later hydrated model response had no `responseId`.

It adds regression coverage for `ServerConversationTracker.primeFromState` and a patch changeset for `@openai/agents-core`.

see also: https://github.com/openai/openai-agents-python/pull/3245