### PR TITLE
fix(core): allow callback-only handoff hooks

### DIFF
--- a/.changeset/allow-callback-only-handoffs.md
+++ b/.changeset/allow-callback-only-handoffs.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: allow callback-only handoff hooks without input schemas

--- a/packages/agents-core/src/handoff.ts
+++ b/packages/agents-core/src/handoff.ts
@@ -266,13 +266,12 @@ export function handoff<
 ) {
   let parser: ((input: string) => Promise<any>) | undefined = undefined;
 
-  const hasOnHandoff = !!config.onHandoff;
-  const hasInputType = !!config.inputType;
-  const hasBothOrNeitherHandoffAndInputType = hasOnHandoff === hasInputType;
+  const inputType = config.inputType;
+  const hasInputType = inputType != null;
 
-  if (!hasBothOrNeitherHandoffAndInputType) {
+  if (hasInputType && config.onHandoff == null) {
     throw new UserError(
-      'You must provide either both `onHandoff` and `inputType` or neither.',
+      'You must provide `onHandoff` when `inputType` is provided.',
     );
   }
 
@@ -329,9 +328,9 @@ export function handoff<
     handoff.isEnabled = async () => config.isEnabled as boolean;
   }
 
-  if (config.inputType) {
+  if (hasInputType) {
     const result = getSchemaAndParserFromInputType(
-      config.inputType,
+      inputType,
       handoff.toolName,
       { strict: true },
     );

--- a/packages/agents-core/test/handoff.test.ts
+++ b/packages/agents-core/test/handoff.test.ts
@@ -8,11 +8,19 @@ import logger from '../src/logger';
 const agent = new Agent({ name: 'A' });
 
 describe('handoff()', () => {
-  it('throws UserError when only onHandoff or inputType provided', () => {
-    expect(() => handoff(agent, { onHandoff: () => {} })).toThrow(UserError);
+  it('throws UserError when inputType is provided without onHandoff', () => {
     expect(() => handoff(agent, { inputType: z.object({}) })).toThrow(
       UserError,
     );
+  });
+
+  it('allows onHandoff without inputType', async () => {
+    const onHandoff = vi.fn();
+    const h = handoff(agent, { onHandoff });
+
+    await h.onInvokeHandoff({} as any, '');
+
+    expect(onHandoff).toHaveBeenCalledWith({});
   });
 
   it('parses JSON and reports errors', async () => {


### PR DESCRIPTION
This pull request fixes handoff configuration validation so `inputType` still requires `onHandoff`, while `onHandoff` can be provided without an input schema. This matches the Python SDK behavior and lets callers attach side-effect hooks to handoffs that do not require model-provided arguments.

It updates the `handoff()` validation path, adds regression coverage for both the rejected and allowed configurations, and includes a patch changeset for `@openai/agents-core`.

see also: https://github.com/openai/openai-agents-python/pull/3248