### PR TITLE
fix(core): exclude computer instances from provider detection

### DIFF
--- a/.changeset/exclude-computer-create-provider.md
+++ b/.changeset/exclude-computer-create-provider.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: exclude computer instances from provider detection

--- a/packages/agents-core/src/tool.ts
+++ b/packages/agents-core/src/tool.ts
@@ -366,10 +366,33 @@ export type ComputerConfig<
 function isComputerProvider<Context, TComputer extends Computer>(
   candidate: unknown,
 ): candidate is ComputerProvider<Context, TComputer> {
+  if (isComputerInstance(candidate)) {
+    return false;
+  }
+
   return (
     !!candidate &&
     typeof candidate === 'object' &&
     typeof (candidate as { create?: unknown }).create === 'function'
+  );
+}
+
+function isComputerInstance(candidate: unknown): candidate is Computer {
+  if (!candidate || typeof candidate !== 'object') {
+    return false;
+  }
+
+  const maybeComputer = candidate as Partial<Record<keyof Computer, unknown>>;
+  return (
+    typeof maybeComputer.screenshot === 'function' &&
+    typeof maybeComputer.click === 'function' &&
+    typeof maybeComputer.doubleClick === 'function' &&
+    typeof maybeComputer.drag === 'function' &&
+    typeof maybeComputer.keypress === 'function' &&
+    typeof maybeComputer.move === 'function' &&
+    typeof maybeComputer.scroll === 'function' &&
+    typeof maybeComputer.type === 'function' &&
+    typeof maybeComputer.wait === 'function'
   );
 }
 

--- a/packages/agents-core/test/tool.test.ts
+++ b/packages/agents-core/test/tool.test.ts
@@ -261,6 +261,31 @@ describe('Tool', () => {
     expect(initSpy).not.toHaveBeenCalled();
   });
 
+  it('resolveComputer treats computer instances with create methods as static instances', async () => {
+    const create = vi.fn();
+    const staticComp = {
+      environment: 'mac' as const,
+      dimensions: [1, 1] as [number, number],
+      screenshot: async () => 'img',
+      click: async () => {},
+      doubleClick: async () => {},
+      drag: async () => {},
+      keypress: async () => {},
+      move: async () => {},
+      scroll: async () => {},
+      type: async () => {},
+      wait: async () => {},
+      create,
+    };
+    const t = computerTool({ computer: staticComp });
+    const ctx = new RunContext();
+
+    const resolved = await resolveComputer({ tool: t, runContext: ctx });
+
+    expect(resolved).toBe(staticComp);
+    expect(create).not.toHaveBeenCalled();
+  });
+
   it('supports lifecycle initializers with dispose per run context', async () => {
     let counter = 0;
     const makeComputer = (label: string) =>


### PR DESCRIPTION
This pull request fixes computer tool lifecycle detection so a concrete computer instance is not treated as a provider just because it exposes a callable `create` property. The provider guard now first recognizes full computer instances by their required operation methods, then only applies provider duck-typing to non-computer objects.

It adds regression coverage for resolving a static computer instance with a `create` method and includes a patch changeset for `@openai/agents-core`.

see also: https://github.com/openai/openai-agents-python/pull/3249