### PR TITLE
fix(extensions): avoid duplicating reasoning across parallel tool calls

### DIFF
--- a/.changeset/avoid-reasoning-toolcall-duplicates.md
+++ b/.changeset/avoid-reasoning-toolcall-duplicates.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: avoid duplicating reasoning across parallel tool calls

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -205,20 +205,30 @@ export function itemsToLanguageV2Messages(
     | { text: string; providerOptions: Record<string, any> }
     | undefined;
   const collapsedItems = collapseReplacedToolSearchOutputs(items);
-  const flushPendingReasonerReasoningToMessages = () => {
+  const consumePendingReasonerReasoning = () => {
     if (
       !(
         shouldIncludeReasoningContent(model, modelSettings) &&
         pendingReasonerReasoning
       )
     ) {
+      return undefined;
+    }
+
+    const pending = pendingReasonerReasoning;
+    pendingReasonerReasoning = undefined;
+    return pending;
+  };
+  const flushPendingReasonerReasoningToMessages = () => {
+    const pendingReasoning = consumePendingReasonerReasoning();
+    if (!pendingReasoning) {
       return;
     }
 
     const reasoningPart: LanguageModelV2ReasoningPart = {
       type: 'reasoning',
-      text: pendingReasonerReasoning.text,
-      providerOptions: pendingReasonerReasoning.providerOptions,
+      text: pendingReasoning.text,
+      providerOptions: pendingReasoning.providerOptions,
     };
 
     if (
@@ -228,18 +238,41 @@ export function itemsToLanguageV2Messages(
     ) {
       currentAssistantMessage.content.unshift(reasoningPart);
       currentAssistantMessage.providerOptions = {
-        ...pendingReasonerReasoning.providerOptions,
+        ...pendingReasoning.providerOptions,
         ...currentAssistantMessage.providerOptions,
       };
     } else {
       messages.push({
         role: 'assistant',
         content: [reasoningPart],
-        providerOptions: pendingReasonerReasoning.providerOptions,
+        providerOptions: pendingReasoning.providerOptions,
       });
     }
+  };
+  const appendPendingReasonerReasoningToCurrentAssistant = () => {
+    if (
+      !currentAssistantMessage ||
+      !Array.isArray(currentAssistantMessage.content) ||
+      currentAssistantMessage.role !== 'assistant'
+    ) {
+      return;
+    }
 
-    pendingReasonerReasoning = undefined;
+    const pendingReasoning = consumePendingReasonerReasoning();
+    if (!pendingReasoning) {
+      return;
+    }
+
+    // Signed reasoning blocks must be attached once before parallel tool calls.
+    currentAssistantMessage.content.push({
+      type: 'reasoning',
+      text: pendingReasoning.text,
+      providerOptions: pendingReasoning.providerOptions,
+    });
+    currentAssistantMessage.providerOptions = {
+      ...pendingReasoning.providerOptions,
+      ...currentAssistantMessage.providerOptions,
+    };
   };
 
   for (const item of collapsedItems) {
@@ -387,21 +420,7 @@ export function itemsToLanguageV2Messages(
         currentAssistantMessage.role === 'assistant'
       ) {
         // Reasoner models (e.g., DeepSeek Reasoner) require reasoning_content on tool-call messages.
-        if (
-          shouldIncludeReasoningContent(model, modelSettings) &&
-          pendingReasonerReasoning
-        ) {
-          currentAssistantMessage.content.push({
-            type: 'reasoning',
-            text: pendingReasonerReasoning.text,
-            providerOptions: pendingReasonerReasoning.providerOptions,
-          });
-          currentAssistantMessage.providerOptions = {
-            ...pendingReasonerReasoning.providerOptions,
-            ...currentAssistantMessage.providerOptions,
-          };
-          pendingReasonerReasoning = undefined;
-        }
+        appendPendingReasonerReasoningToCurrentAssistant();
         const toolName = getAiSdkToolName(item);
         toolCallNamesById.set(item.callId, toolName);
         const content: LanguageModelV2ToolCallPart = {
@@ -448,21 +467,7 @@ export function itemsToLanguageV2Messages(
         Array.isArray(currentAssistantMessage.content) &&
         currentAssistantMessage.role === 'assistant'
       ) {
-        if (
-          shouldIncludeReasoningContent(model, modelSettings) &&
-          pendingReasonerReasoning
-        ) {
-          currentAssistantMessage.content.push({
-            type: 'reasoning',
-            text: pendingReasonerReasoning.text,
-            providerOptions: pendingReasonerReasoning.providerOptions,
-          });
-          currentAssistantMessage.providerOptions = {
-            ...pendingReasonerReasoning.providerOptions,
-            ...currentAssistantMessage.providerOptions,
-          };
-          pendingReasonerReasoning = undefined;
-        }
+        appendPendingReasonerReasoningToCurrentAssistant();
         const toolCallId = resolveToolSearchCallId(item, () => {
           generatedToolSearchCallId += 1;
           return `tool_search_${generatedToolSearchCallId}`;

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -3184,6 +3184,68 @@ describe('Extended thinking / Reasoning support', () => {
       });
     });
 
+    test('does not duplicate signed reasoning across parallel tool calls', () => {
+      const items: protocol.ModelItem[] = [
+        {
+          type: 'reasoning',
+          content: [{ type: 'input_text', text: 'Plan both calls.' }],
+          providerData: { anthropic: { signature: 'sig_parallel' } },
+        } as any,
+        {
+          type: 'function_call',
+          callId: 'call_1',
+          name: 'search',
+          arguments: '{}',
+        } as any,
+        {
+          type: 'function_call',
+          callId: 'call_2',
+          name: 'search',
+          arguments: '{}',
+        } as any,
+      ];
+
+      const msgs = itemsToLanguageV2Messages(stubModel({}), items);
+
+      expect(msgs).toHaveLength(2);
+      const reasoningAssistant = msgs[0];
+      const toolAssistant = msgs[1];
+      if (
+        reasoningAssistant.role !== 'assistant' ||
+        toolAssistant.role !== 'assistant'
+      ) {
+        throw new Error('Expected assistant messages');
+      }
+      const reasoningParts = [
+        ...reasoningAssistant.content,
+        ...toolAssistant.content,
+      ].filter((part) => part.type === 'reasoning');
+      expect(reasoningParts).toHaveLength(1);
+      expect(reasoningAssistant.content).toEqual([
+        {
+          type: 'reasoning',
+          text: 'Plan both calls.',
+          providerOptions: { anthropic: { signature: 'sig_parallel' } },
+        },
+      ]);
+      expect(toolAssistant.content).toEqual([
+        {
+          type: 'tool-call',
+          toolCallId: 'call_1',
+          toolName: 'search',
+          input: {},
+          providerOptions: {},
+        },
+        {
+          type: 'tool-call',
+          toolCallId: 'call_2',
+          toolName: 'search',
+          input: {},
+          providerOptions: {},
+        },
+      ]);
+    });
+
     test('omits providerOptions when providerData model does not match target model', () => {
       const items: protocol.ModelItem[] = [
         {


### PR DESCRIPTION
This pull request improves AI SDK history conversion so pending signed reasoning content is consumed exactly once before tool-call replay. This prevents reasoning metadata from being duplicated across parallel tool calls while preserving the existing representation for providers that keep reasoning as a separate assistant message.

It adds regression coverage for signed reasoning followed by multiple tool calls and includes a patch changeset for `@openai/agents-extensions`.

see also: https://github.com/openai/openai-agents-python/pull/3261