### PR TITLE
test: keep output guardrail tripwires behind sibling completion

### DIFF
--- a/.changeset/await-output-guardrails.md
+++ b/.changeset/await-output-guardrails.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: keep output guardrail tripwires behind sibling completion

--- a/packages/agents-core/src/runner/guardrails.ts
+++ b/packages/agents-core/src/runner/guardrails.ts
@@ -123,6 +123,8 @@ async function runGuardrailsWithTripwire<
   } = options;
 
   try {
+    // Keep tripwire handling behind this await-all barrier so sibling guardrails
+    // can finish cleanup before the tripwire error is surfaced.
     const results = await Promise.all(
       guardrails.map(async (guardrail) => {
         return withGuardrailSpan(

--- a/packages/agents-core/test/runner/guardrails.test.ts
+++ b/packages/agents-core/test/runner/guardrails.test.ts
@@ -216,6 +216,58 @@ describe('runOutputGuardrails', () => {
     expect(state._outputGuardrailResults).toHaveLength(1);
   });
 
+  it('awaits sibling output guardrails before surfacing a tripwire', async () => {
+    const agent = makeAgent({ name: 'TripOutputAwait' });
+    const state = makeState(agent);
+    let releaseSlowGuardrail!: () => void;
+    let markSlowStarted!: () => void;
+    let slowGuardrailFinished = false;
+    const slowGuardrailCanFinish = new Promise<void>((resolve) => {
+      releaseSlowGuardrail = resolve;
+    });
+    const slowGuardrailStarted = new Promise<void>((resolve) => {
+      markSlowStarted = resolve;
+    });
+    const slowGuardrail = defineOutputGuardrail({
+      name: 'slow',
+      execute: async () => {
+        markSlowStarted();
+        await slowGuardrailCanFinish;
+        slowGuardrailFinished = true;
+        return {
+          tripwireTriggered: false,
+          outputInfo: { slow: true },
+        };
+      },
+    });
+    const tripwireGuardrail = defineOutputGuardrail({
+      name: 'trip',
+      execute: async () => {
+        await slowGuardrailStarted;
+        releaseSlowGuardrail();
+        return {
+          tripwireTriggered: true,
+          outputInfo: { reason: 'bad' },
+        };
+      },
+    });
+
+    await expect(
+      withTrace('guardrails-output-trip-await-sibling', () =>
+        runOutputGuardrails(
+          state,
+          [slowGuardrail as any, tripwireGuardrail as any],
+          'ok',
+        ),
+      ),
+    ).rejects.toBeInstanceOf(OutputGuardrailTripwireTriggered);
+    expect(slowGuardrailFinished).toBe(true);
+    expect(state._outputGuardrailResults.map((r) => r.guardrail.name)).toEqual([
+      'slow',
+      'trip',
+    ]);
+  });
+
   it('wraps errors from guardrails without recording results', async () => {
     const agent = makeAgent({ name: 'OutError' });
     const state = makeState(agent);


### PR DESCRIPTION
This pull request makes the output guardrail await-all boundary explicit and adds regression coverage so an output guardrail tripwire is surfaced only after sibling output guardrails have settled.

The TypeScript SDK does not cancel sibling output guardrails in this path, so this preserves the existing `Promise.all` barrier while protecting against regressions that could leak unfinished guardrail cleanup around tripwire handling. It also adds a patch changeset for `@openai/agents-core`.

see also: https://github.com/openai/openai-agents-python/pull/3187