### PR TITLE
fix(realtime): preserve output audio content from output item events

### DIFF
--- a/.changeset/preserve-realtime-output-audio.md
+++ b/.changeset/preserve-realtime-output-audio.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: preserve realtime output audio content from output item events

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -118,6 +118,29 @@ export type OpenAIRealtimeEventTypes = {
  */
 export type RealtimeSessionPayload = { type: 'realtime' } & Record<string, any>;
 
+function normalizeRealtimeMessageContent(
+  role: string | undefined,
+  content: unknown,
+): unknown {
+  if (role !== 'assistant' || !Array.isArray(content)) {
+    return content;
+  }
+  return content.map((part) => {
+    if (
+      part &&
+      typeof part === 'object' &&
+      'type' in part &&
+      part.type === 'audio'
+    ) {
+      return {
+        ...part,
+        type: 'output_audio',
+      };
+    }
+    return part;
+  });
+}
+
 export abstract class OpenAIRealtimeBase
   extends EventEmitterDelegate<OpenAIRealtimeEventTypes>
   implements RealtimeTransportLayer
@@ -340,7 +363,10 @@ export abstract class OpenAIRealtimeBase
           previousItemId,
           type: parsed.item.type,
           role: parsed.item.role,
-          content: parsed.item.content,
+          content: normalizeRealtimeMessageContent(
+            parsed.item.role,
+            parsed.item.content,
+          ),
           status: parsed.item.status,
         });
         this.emit('item_update', item);
@@ -455,7 +481,10 @@ export abstract class OpenAIRealtimeBase
           itemId: parsed.item.id,
           type: parsed.item.type,
           role: parsed.item.role,
-          content: parsed.item.content,
+          content: normalizeRealtimeMessageContent(
+            parsed.item.role,
+            parsed.item.content,
+          ),
           status:
             parsed.type === 'response.output_item.done'
               ? (item.status ?? 'completed')

--- a/packages/agents-realtime/src/openaiRealtimeEvents.ts
+++ b/packages/agents-realtime/src/openaiRealtimeEvents.ts
@@ -54,6 +54,7 @@ export const conversationItemContentSchema = z.object({
     z.literal('input_audio'),
     z.literal('item_reference'),
     z.literal('output_text'),
+    z.literal('audio'),
     z.literal('output_audio'),
   ]),
 });

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -571,6 +571,89 @@ describe('OpenAIRealtimeBase helpers', () => {
     expect(updates.find((u) => (u as any).itemId === 'mcp1')).toBeTruthy();
   });
 
+  it('preserves GA output_audio content on output item messages', () => {
+    const base = new TestBase();
+    const updates: any[] = [];
+    base.on('item_update', (i) => updates.push(i));
+
+    (base as any)._onMessage({
+      data: JSON.stringify({
+        type: 'response.output_item.added',
+        event_id: 'o3',
+        response_id: 'r5',
+        output_index: 0,
+        item: {
+          id: 'audio1',
+          type: 'message',
+          role: 'assistant',
+          content: [
+            {
+              type: 'output_audio',
+              audio: 'base64data',
+              transcript: 'hi',
+            },
+          ],
+        },
+      }),
+    });
+
+    expect(updates[0]).toMatchObject({
+      itemId: 'audio1',
+      type: 'message',
+      role: 'assistant',
+      status: 'in_progress',
+      content: [
+        {
+          type: 'output_audio',
+          audio: 'base64data',
+          transcript: 'hi',
+        },
+      ],
+    });
+  });
+
+  it('normalizes legacy audio content on output item messages', () => {
+    const base = new TestBase();
+    const updates: any[] = [];
+    base.on('item_update', (i) => updates.push(i));
+
+    (base as any)._onMessage({
+      data: JSON.stringify({
+        type: 'response.output_item.done',
+        event_id: 'o4',
+        response_id: 'r6',
+        output_index: 0,
+        item: {
+          id: 'audio2',
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [
+            {
+              type: 'audio',
+              audio: 'legacydata',
+              transcript: 'hello',
+            },
+          ],
+        },
+      }),
+    });
+
+    expect(updates[0]).toMatchObject({
+      itemId: 'audio2',
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [
+        {
+          type: 'output_audio',
+          audio: 'legacydata',
+          transcript: 'hello',
+        },
+      ],
+    });
+  });
+
   it('retrieves MCP tool call items on in-progress signals', () => {
     const base = new TestBase();
 


### PR DESCRIPTION
This pull request fixes Realtime output item handling so assistant message content from `response.output_item.added` and `response.output_item.done` preserves GA-style `output_audio` parts.

It also accepts legacy `audio` content parts from output item events and normalizes them to the SDK's internal `output_audio` message content shape, so audio payloads and transcripts continue reaching `item_update` listeners. A patch changeset is included for `@openai/agents-realtime`.

see also: https://github.com/openai/openai-agents-python/pull/3230