### PR TITLE
fix(examples): skip corrupt Prisma session records

### DIFF
--- a/examples/memory/sessions/prisma.test.ts
+++ b/examples/memory/sessions/prisma.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AgentInputItem } from '@openai/agents';
+import { PrismaSession } from './prisma';
+
+type StoredSessionItem = {
+  id: string;
+  sessionId: string;
+  position: number;
+  item: unknown;
+};
+
+class FakePrismaClient {
+  items: StoredSessionItem[] = [];
+  #nextId = 1;
+
+  session = {
+    upsert: async () => ({}),
+    delete: async () => ({}),
+  };
+
+  sessionItem = {
+    findMany: async (args: {
+      where: { sessionId: string };
+      orderBy: { position: 'asc' | 'desc' };
+      take?: number;
+    }) => {
+      const sorted = this.#query(args.where.sessionId, args.orderBy.position);
+      return typeof args.take === 'number'
+        ? sorted.slice(0, args.take)
+        : sorted;
+    },
+    findFirst: async (args: {
+      where: { sessionId: string };
+      orderBy: { position: 'asc' | 'desc' };
+    }) => this.#query(args.where.sessionId, args.orderBy.position)[0] ?? null,
+    createMany: async (args: {
+      data: Array<{ sessionId: string; position: number; item: string }>;
+    }) => {
+      for (const item of args.data) {
+        this.items.push({ id: String(this.#nextId++), ...item });
+      }
+    },
+    delete: async (args: { where: { id: string } }) => {
+      this.items = this.items.filter((item) => item.id !== args.where.id);
+    },
+  };
+
+  $transaction = async <T>(fn: (client: FakePrismaClient) => Promise<T>) =>
+    await fn(this);
+
+  $disconnect = async () => {};
+
+  #query(sessionId: string, order: 'asc' | 'desc') {
+    return this.items
+      .filter((item) => item.sessionId === sessionId)
+      .sort((a, b) =>
+        order === 'desc' ? b.position - a.position : a.position - b.position,
+      );
+  }
+}
+
+const userItem = (content: string) =>
+  ({ role: 'user', content }) as AgentInputItem;
+
+describe('PrismaSession', () => {
+  it('skips corrupt records when reading items', async () => {
+    const client = new FakePrismaClient();
+    const session = new PrismaSession({
+      client: client as any,
+      sessionId: 's1',
+    });
+    await session.addItems([userItem('valid')]);
+    client.items.push({
+      id: 'bad',
+      sessionId: 's1',
+      position: 2,
+      item: 'not valid json {{{',
+    });
+
+    const items = await session.getItems();
+
+    expect(items.map((item) => (item as any).content)).toEqual(['valid']);
+  });
+
+  it('skips corrupt most-recent records when popping items', async () => {
+    const client = new FakePrismaClient();
+    const session = new PrismaSession({
+      client: client as any,
+      sessionId: 's1',
+    });
+    await session.addItems([userItem('valid')]);
+    client.items.push({
+      id: 'bad',
+      sessionId: 's1',
+      position: 999,
+      item: 'not valid json {{{',
+    });
+
+    const popped = await session.popItem();
+
+    expect((popped as any)?.content).toBe('valid');
+    expect(client.items).toEqual([]);
+  });
+
+  it('drops every corrupt record before returning undefined', async () => {
+    const client = new FakePrismaClient();
+    const session = new PrismaSession({
+      client: client as any,
+      sessionId: 's1',
+    });
+    client.items.push(
+      {
+        id: 'bad1',
+        sessionId: 's1',
+        position: 1,
+        item: 'garbage',
+      },
+      {
+        id: 'bad2',
+        sessionId: 's1',
+        position: 2,
+        item: 42,
+      },
+    );
+
+    await expect(session.popItem()).resolves.toBeUndefined();
+    expect(client.items).toEqual([]);
+  });
+});

--- a/examples/memory/sessions/prisma.ts
+++ b/examples/memory/sessions/prisma.ts
@@ -46,9 +46,7 @@ export class PrismaSession implements Session {
     const ordered = take ? [...records].reverse() : records;
     const result: AgentInputItem[] = [];
     for (const record of ordered) {
-      const raw =
-        typeof record.item === 'string' ? JSON.parse(record.item) : record.item;
-      const item = coerceAgentItem(raw);
+      const item = parseStoredAgentItem(record.item);
       if (item) {
         result.push(item);
       }
@@ -89,18 +87,21 @@ export class PrismaSession implements Session {
   async popItem(): Promise<AgentInputItem | undefined> {
     const sessionId = await this.getSessionId();
     return await this.#withClient(async (client) => {
-      const latest = await client.sessionItem.findFirst({
-        where: { sessionId },
-        select: { id: true, item: true },
-        orderBy: { position: 'desc' },
-      });
-      if (!latest?.id) {
-        return undefined;
+      while (true) {
+        const latest = await client.sessionItem.findFirst({
+          where: { sessionId },
+          select: { id: true, item: true },
+          orderBy: { position: 'desc' },
+        });
+        if (!latest?.id) {
+          return undefined;
+        }
+        await client.sessionItem.delete({ where: { id: latest.id } });
+        const item = parseStoredAgentItem(latest.item);
+        if (item) {
+          return item;
+        }
       }
-      await client.sessionItem.delete({ where: { id: latest.id } });
-      const raw =
-        typeof latest.item === 'string' ? JSON.parse(latest.item) : latest.item;
-      return coerceAgentItem(raw) ?? undefined;
     });
   }
 
@@ -163,6 +164,17 @@ function coerceAgentItem(raw: unknown): AgentInputItem | undefined {
     return undefined;
   }
   return parsed.data as AgentInputItem;
+}
+
+function parseStoredAgentItem(raw: unknown): AgentInputItem | undefined {
+  if (typeof raw !== 'string') {
+    return coerceAgentItem(raw);
+  }
+  try {
+    return coerceAgentItem(JSON.parse(raw));
+  } catch {
+    return undefined;
+  }
 }
 
 export type { PrismaClient } from '@prisma/client';


### PR DESCRIPTION
This pull request fixes the Prisma-backed memory session example so corrupt stored records do not make session reads or `popItem()` fail.

`getItems()` now skips records that cannot be parsed or coerced into SDK input items. `popItem()` now deletes corrupt most-recent records and continues to the next record, returning the newest valid item or `undefined` when only corrupt records remain. This mirrors the Python MongoDB session hardening while keeping the change scoped to the TypeScript Prisma example backend.

No changeset is included because this only changes example code, not a published package.

see also: https://github.com/openai/openai-agents-python/pull/3247