### PR TITLE
fix(realtime): treat null audio channels as unset

### DIFF
--- a/.changeset/treat-null-realtime-audio-channels.md
+++ b/.changeset/treat-null-realtime-audio-channels.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: treat null realtime audio channels as unset

--- a/packages/agents-realtime/src/clientMessages.ts
+++ b/packages/agents-realtime/src/clientMessages.ts
@@ -117,8 +117,8 @@ export type RealtimeAudioOutputConfig = {
 };
 
 export type RealtimeAudioConfig = {
-  input?: RealtimeAudioInputConfig;
-  output?: RealtimeAudioOutputConfig;
+  input?: RealtimeAudioInputConfig | null;
+  output?: RealtimeAudioOutputConfig | null;
 };
 
 export type RealtimeReasoningEffort =
@@ -213,22 +213,24 @@ export function toNewSessionConfig(
   config: Partial<RealtimeSessionConfig>,
 ): Partial<RealtimeSessionConfigDefinition> {
   if (!isDeprecatedConfig(config)) {
-    const inputConfig = config.audio?.input
+    const audioInput = config.audio?.input ?? undefined;
+    const audioOutput = config.audio?.output ?? undefined;
+    const inputConfig = audioInput
       ? {
-          format: normalizeAudioFormat(config.audio.input.format),
-          noiseReduction: config.audio.input.noiseReduction ?? null,
-          transcription: config.audio.input.transcription,
-          turnDetection: config.audio.input.turnDetection,
+          format: normalizeAudioFormat(audioInput?.format),
+          noiseReduction: audioInput?.noiseReduction ?? null,
+          transcription: audioInput?.transcription,
+          turnDetection: audioInput?.turnDetection,
         }
       : undefined;
 
-    const requestedOutputVoice = config.audio?.output?.voice ?? config.voice;
+    const requestedOutputVoice = audioOutput?.voice ?? config.voice;
     const outputConfig =
-      config.audio?.output || typeof requestedOutputVoice !== 'undefined'
+      audioOutput || typeof requestedOutputVoice !== 'undefined'
         ? {
-            format: normalizeAudioFormat(config.audio?.output?.format),
+            format: normalizeAudioFormat(audioOutput?.format),
             voice: requestedOutputVoice,
-            speed: config.audio?.output?.speed,
+            speed: audioOutput?.speed,
           }
         : undefined;
 

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { RealtimeClientMessage } from '../src/clientMessages';
-import { OpenAIRealtimeBase } from '../src/openaiRealtimeBase';
+import {
+  DEFAULT_OPENAI_REALTIME_SESSION_CONFIG,
+  OpenAIRealtimeBase,
+} from '../src/openaiRealtimeBase';
 import logger from '../src/logger';
 
 class TestBase extends OpenAIRealtimeBase {
@@ -102,6 +105,29 @@ describe('OpenAIRealtimeBase helpers', () => {
     expect(config.audio?.input?.noise_reduction).toBeNull();
     expect(config.audio?.input?.transcription).toBeNull();
     expect(config.audio?.input?.turn_detection).toBeNull();
+  });
+
+  it('treats null audio channels as unset when building config', () => {
+    const base = new TestBase();
+    const config = (base as any)._getMergedSessionConfig({
+      audio: {
+        input: null,
+        output: null,
+      },
+    });
+
+    expect(config.audio?.input?.format).toEqual(
+      DEFAULT_OPENAI_REALTIME_SESSION_CONFIG.audio?.input?.format,
+    );
+    expect(config.audio?.input?.transcription).toEqual(
+      DEFAULT_OPENAI_REALTIME_SESSION_CONFIG.audio?.input?.transcription,
+    );
+    expect(config.audio?.output?.format).toEqual(
+      DEFAULT_OPENAI_REALTIME_SESSION_CONFIG.audio?.output?.format,
+    );
+    expect(config.audio?.output?.speed).toEqual(
+      DEFAULT_OPENAI_REALTIME_SESSION_CONFIG.audio?.output?.speed,
+    );
   });
 
   it('preserves falsy turn detection values when building payload', () => {


### PR DESCRIPTION
This pull request updates Realtime session config handling so `audio.input: null` and `audio.output: null` are treated the same as omitted audio channels.

It widens the public Realtime audio config type to accept null channels and normalizes them away before building the GA session payload, so callers can explicitly opt out of one side of the audio config without losing the SDK defaults or hitting channel property access issues. A patch changeset is included for `@openai/agents-realtime`.

see also: https://github.com/openai/openai-agents-python/pull/3254