### PR TITLE
fix(core): validate sandbox GitRepo subpaths

### DIFF
--- a/.changeset/validate-git-repo-subpaths.md
+++ b/.changeset/validate-git-repo-subpaths.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: validate sandbox GitRepo subpaths before materialization

--- a/packages/agents-core/src/sandbox/errors.ts
+++ b/packages/agents-core/src/sandbox/errors.ts
@@ -35,6 +35,7 @@ export type SandboxErrorCode =
   | 'local_checksum_error'
   | 'git_missing_in_image'
   | 'git_clone_error'
+  | 'git_subpath_error'
   | 'git_copy_error'
   | 'mount_missing_tool'
   | 'mount_failed'
@@ -342,7 +343,10 @@ export class SandboxGitArtifactError extends SandboxArtifactError {
     message: string,
     code: Extract<
       SandboxErrorCode,
-      'git_missing_in_image' | 'git_clone_error' | 'git_copy_error'
+      | 'git_missing_in_image'
+      | 'git_clone_error'
+      | 'git_subpath_error'
+      | 'git_copy_error'
     >,
     details?: Record<string, unknown>,
   ) {
@@ -359,6 +363,12 @@ export class SandboxGitMissingInImageError extends SandboxGitArtifactError {
 export class SandboxGitCloneError extends SandboxGitArtifactError {
   constructor(message: string, details?: Record<string, unknown>) {
     super(message, 'git_clone_error', details);
+  }
+}
+
+export class SandboxGitSubpathError extends SandboxGitArtifactError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super(message, 'git_subpath_error', details);
   }
 }
 

--- a/packages/agents-core/src/sandbox/manifest.ts
+++ b/packages/agents-core/src/sandbox/manifest.ts
@@ -31,6 +31,7 @@ import {
   relativePosixPathWithinRoot,
 } from './shared/posixPath';
 import { isRecord } from './shared/typeGuards';
+import { SandboxGitSubpathError } from './errors';
 
 export type EnvResolver = () => string | Promise<string>;
 
@@ -352,6 +353,42 @@ export function normalizeRelativePath(path: string): string {
   return normalized === '.' ? '' : normalized;
 }
 
+function normalizeGitRepoSubpath(repo: string, subpath: string): string {
+  const trimmed = subpath.trim();
+  let reason:
+    | 'absolute'
+    | 'empty'
+    | 'parent_traversal'
+    | 'windows_path'
+    | undefined;
+
+  if (subpath === '') {
+    return '';
+  }
+
+  if (!trimmed || normalizePosixPath(trimmed) === '.') {
+    reason = 'empty';
+  } else if (
+    hasBackslashPathSeparator(subpath) ||
+    /^[A-Za-z]:($|\/)/.test(trimmed)
+  ) {
+    reason = 'windows_path';
+  } else if (trimmed.startsWith('/')) {
+    reason = 'absolute';
+  } else if (hasParentPathSegment(subpath)) {
+    reason = 'parent_traversal';
+  }
+
+  if (reason) {
+    throw new SandboxGitSubpathError(
+      `git_repo subpath must be a relative path inside the repository: ${subpath}`,
+      { repo, subpath, reason },
+    );
+  }
+
+  return normalizePosixPath(trimmed);
+}
+
 export function renderManifestDescription(
   manifest: Manifest,
   options: RenderManifestDescriptionOptions = {},
@@ -592,7 +629,10 @@ function normalizeEntry(
     normalized.repo = repo.trim();
     normalized.host = normalizeGitHost(normalized.host);
     if (normalized.subpath !== undefined) {
-      normalized.subpath = normalizeRelativePath(normalized.subpath);
+      normalized.subpath = normalizeGitRepoSubpath(
+        normalized.repo,
+        normalized.subpath,
+      );
     }
   }
   if (isMount(normalized)) {

--- a/packages/agents-core/test/sandboxManifest.test.ts
+++ b/packages/agents-core/test/sandboxManifest.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeRelativePath,
   Permissions,
   renderManifestDescription,
+  SandboxGitSubpathError,
   type Dir,
   type File,
   type GitRepo,
@@ -389,6 +390,64 @@ describe('Manifest', () => {
     expect(repo.repo).toBe('openai/openai-agents-js');
     expect(repo.subpath).toBe('packages/agents-core');
   });
+
+  it('allows an empty GitRepo subpath as the repository root', () => {
+    const manifest = new Manifest({
+      entries: {
+        repo: {
+          type: 'git_repo',
+          repo: 'openai/openai-agents-js',
+          subpath: '',
+        },
+      },
+    });
+    const repo = manifest.entries.repo as GitRepo;
+
+    expect(repo.subpath).toBe('');
+  });
+
+  it.each([
+    ['.', 'empty'],
+    ['./', 'empty'],
+    ['/docs', 'absolute'],
+    ['../outside', 'parent_traversal'],
+    ['docs/../../outside', 'parent_traversal'],
+    ['C:/repo', 'windows_path'],
+    ['docs\\outside', 'windows_path'],
+  ])(
+    'rejects invalid GitRepo subpath %j before materialization',
+    (subpath, reason) => {
+      expect(() => {
+        new Manifest({
+          entries: {
+            repo: {
+              type: 'git_repo',
+              repo: 'openai/openai-agents-js',
+              subpath,
+            },
+          },
+        });
+      }).toThrow(SandboxGitSubpathError);
+
+      try {
+        new Manifest({
+          entries: {
+            repo: {
+              type: 'git_repo',
+              repo: 'openai/openai-agents-js',
+              subpath,
+            },
+          },
+        });
+      } catch (error) {
+        expect(error).toBeInstanceOf(SandboxGitSubpathError);
+        expect((error as SandboxGitSubpathError).details).toMatchObject({
+          subpath,
+          reason,
+        });
+      }
+    },
+  );
 
   it('normalizes typed mount config and defaults', () => {
     const manifest = new Manifest({

--- a/packages/agents-core/test/sandboxes/unixLocal.test.ts
+++ b/packages/agents-core/test/sandboxes/unixLocal.test.ts
@@ -1298,6 +1298,44 @@ describe('UnixLocalSandboxClient', () => {
     expect(await session.pathExists('deps/app/README.md')).toBe(true);
   }, 10_000);
 
+  it('treats empty git repository subpaths as the repository root', async () => {
+    const repository = join(rootDir, 'empty-subpath-repo');
+    await mkdir(repository, { recursive: true });
+    await execFileAsync('git', ['init'], { cwd: repository });
+    await execFileAsync('git', ['config', 'user.email', 'test@example.com'], {
+      cwd: repository,
+    });
+    await execFileAsync('git', ['config', 'user.name', 'Test User'], {
+      cwd: repository,
+    });
+    await writeFile(join(repository, 'README.md'), 'repo root\n', 'utf8');
+    await execFileAsync('git', ['add', 'README.md'], { cwd: repository });
+    await execFileAsync('git', ['commit', '-m', 'init'], { cwd: repository });
+
+    const client = new UnixLocalSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          app: {
+            type: 'git_repo',
+            repo: `file://${repository}`,
+            subpath: '',
+          },
+        },
+      }),
+    );
+
+    const output = await session.execCommand({
+      cmd: 'cat /workspace/app/README.md',
+      shell: '/bin/sh',
+      login: false,
+      yieldTimeMs: 2_000,
+    });
+    expect(output).toContain('repo root');
+  }, 10_000);
+
   it('checks out commit SHA refs when cloning git repositories', async () => {
     const repository = join(rootDir, 'commit-repo');
     await mkdir(repository, { recursive: true });


### PR DESCRIPTION
This pull request fixes sandbox `git_repo` subpath validation so unsafe subpaths are rejected before materialization while preserving `subpath: ""` as a valid repository-root selection.

It adds a typed `SandboxGitSubpathError` with reason metadata for empty dot paths, absolute paths, parent traversal, and Windows-style paths. It also adds regression coverage for manifest normalization and Unix local materialization so `subpath: ""` continues to clone/copy the repository root. A patch changeset is included for `@openai/agents-core`.

see also: https://github.com/openai/openai-agents-python/pull/3276, https://github.com/openai/openai-agents-python/pull/3299