### PR TITLE
fix(core): keep trace batch processing alive after exporter errors

### DIFF
--- a/.changeset/trace-exporter-exception-recovery.md
+++ b/.changeset/trace-exporter-exception-recovery.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: keep trace batch processing alive after exporter errors

--- a/packages/agents-core/src/tracing/processor.ts
+++ b/packages/agents-core/src/tracing/processor.ts
@@ -184,17 +184,24 @@ export class BatchTraceProcessor implements TracingProcessor {
       `Exporting batches. Force: ${force}. Buffer size: ${this.#buffer.length}`,
     );
 
+    const exportBatch = async (batch: Array<Trace | Span>): Promise<void> => {
+      this.#exportInProgress = true;
+      try {
+        await this.#exporter.export(batch);
+      } catch (error) {
+        logger.error('Tracing exporter failed to export batch', error);
+      } finally {
+        this.#exportInProgress = false;
+      }
+    };
+
     if (force || this.#buffer.length < this.#maxBatchSize) {
       const toExport = [...this.#buffer];
       this.#buffer = [];
-      this.#exportInProgress = true;
-      await this.#exporter.export(toExport);
-      this.#exportInProgress = false;
+      await exportBatch(toExport);
     } else if (this.#buffer.length > 0) {
       const batch = this.#buffer.splice(0, this.#maxBatchSize);
-      this.#exportInProgress = true;
-      await this.#exporter.export(batch);
-      this.#exportInProgress = false;
+      await exportBatch(batch);
     }
   }
 

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -657,6 +657,50 @@ describe('BatchTraceProcessor', () => {
     vi.useRealTimers();
   });
 
+  it('continues scheduled exports after an exporter exception', async () => {
+    vi.useFakeTimers();
+    const errorSpy = vi.spyOn(coreLogger, 'error').mockImplementation(() => {});
+    try {
+      let exportCalls = 0;
+      const exported: Array<(Trace | Span<any>)[]> = [];
+      const flakyExporter: TracingExporter = {
+        export: async (items) => {
+          exportCalls += 1;
+          if (exportCalls === 1) {
+            throw new Error('simulated exporter failure');
+          }
+          exported.push([...items]);
+        },
+      };
+      const processor = new BatchTraceProcessor(flakyExporter, {
+        maxQueueSize: 10,
+        maxBatchSize: 1,
+        scheduleDelay: 50,
+      });
+      const failed = new Trace({ name: 'failed' });
+      const recovered = new Trace({ name: 'recovered' });
+
+      await processor.onTraceStart(failed);
+      await vi.advanceTimersByTimeAsync(60);
+      expect(exportCalls).toBe(1);
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Tracing exporter failed to export batch',
+        expect.any(Error),
+      );
+
+      await processor.onTraceStart(recovered);
+      await vi.advanceTimersByTimeAsync(60);
+
+      expect(exportCalls).toBe(2);
+      expect(exported).toEqual([[recovered]]);
+
+      await processor.shutdown();
+    } finally {
+      errorSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it('waits while an export is in progress during shutdown', async () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
This pull request fixes `BatchTraceProcessor` so exporter failures no longer stop the scheduled trace export loop or leave the processor marked as exporting forever.

It wraps each trace export batch in error handling, logs exporter failures, and resets export-in-progress state in a `finally` block. It also adds regression coverage showing that a failed export batch is dropped but later scheduled batches are still exported. A patch changeset is included for `@openai/agents-core`.

see also: https://github.com/openai/openai-agents-python/pull/3216