### PR TITLE
fix(core): guard no-op tracing span IDs

### DIFF
--- a/.changeset/noop-tracing-span-id-guard.md
+++ b/.changeset/noop-tracing-span-id-guard.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: guard no-op tracing span ids

--- a/packages/agents-core/src/tracing/provider.ts
+++ b/packages/agents-core/src/tracing/provider.ts
@@ -4,7 +4,7 @@ import logger from '../logger';
 import { MultiTracingProcessor, TracingProcessor } from './processor';
 import { NoopSpan, Span, SpanData, SpanOptions } from './spans';
 import { NoopTrace, Trace, TraceOptions } from './traces';
-import { generateTraceId } from './utils';
+import { generateTraceId, NOOP_TRACE_OR_SPAN_ID } from './utils';
 
 export type CreateSpanOptions<TData extends SpanData> = Omit<
   SpanOptions<TData>,
@@ -88,6 +88,11 @@ export class TraceProvider {
       return new NoopSpan(spanOptions.data, this.#multiProcessor);
     }
 
+    if (spanOptions.spanId === NOOP_TRACE_OR_SPAN_ID) {
+      logger.debug('Span id is no-op, returning NoopSpan');
+      return new NoopSpan(spanOptions.data, this.#multiProcessor);
+    }
+
     let parentId;
     let traceId;
     let tracingApiKey: string | undefined;
@@ -98,7 +103,7 @@ export class TraceProvider {
       const currentSpan = getCurrentSpan();
 
       if (!currentTrace) {
-        logger.error(
+        logger.debug(
           'No active trace. Make sure to start a trace with `withTrace()` first. Returning NoopSpan.',
         );
         return new NoopSpan(spanOptions.data, this.#multiProcessor);
@@ -106,7 +111,9 @@ export class TraceProvider {
 
       if (
         currentSpan instanceof NoopSpan ||
-        currentTrace instanceof NoopTrace
+        currentSpan?.spanId === NOOP_TRACE_OR_SPAN_ID ||
+        currentTrace instanceof NoopTrace ||
+        currentTrace.traceId === NOOP_TRACE_OR_SPAN_ID
       ) {
         logger.debug(
           `Parent ${currentSpan} or ${currentTrace} is no-op, returning NoopSpan`,
@@ -127,7 +134,10 @@ export class TraceProvider {
         );
       }
     } else if (parent instanceof Trace) {
-      if (parent instanceof NoopTrace) {
+      if (
+        parent instanceof NoopTrace ||
+        parent.traceId === NOOP_TRACE_OR_SPAN_ID
+      ) {
         logger.debug('Parent trace is no-op, returning NoopSpan');
         return new NoopSpan(spanOptions.data, this.#multiProcessor);
       }
@@ -136,7 +146,11 @@ export class TraceProvider {
       tracingApiKey = parent.tracingApiKey;
       traceMetadata = parent.metadata;
     } else if (parent instanceof Span) {
-      if (parent instanceof NoopSpan) {
+      if (
+        parent instanceof NoopSpan ||
+        parent.spanId === NOOP_TRACE_OR_SPAN_ID ||
+        parent.traceId === NOOP_TRACE_OR_SPAN_ID
+      ) {
         logger.debug('Parent span is no-op, returning NoopSpan');
         return new NoopSpan(spanOptions.data, this.#multiProcessor);
       }
@@ -147,7 +161,7 @@ export class TraceProvider {
       traceMetadata = parent.traceMetadata;
     }
 
-    if (!traceId) {
+    if (!traceId || traceId === NOOP_TRACE_OR_SPAN_ID) {
       logger.error(
         'No traceId found. Make sure to start a trace with `withTrace()` first. Returning NoopSpan.',
       );

--- a/packages/agents-core/src/tracing/spans.ts
+++ b/packages/agents-core/src/tracing/spans.ts
@@ -1,6 +1,11 @@
 import logger from '../logger';
 import { TracingProcessor } from './processor';
-import { generateSpanId, removePrivateFields, timeIso } from './utils';
+import {
+  generateSpanId,
+  NOOP_TRACE_OR_SPAN_ID,
+  removePrivateFields,
+  timeIso,
+} from './utils';
 
 type SpanDataBase = {
   type: string;
@@ -271,7 +276,14 @@ export class Span<TData extends SpanData> {
 
 export class NoopSpan<TSpanData extends SpanData> extends Span<TSpanData> {
   constructor(data: TSpanData, processor: TracingProcessor) {
-    super({ traceId: 'no-op', spanId: 'no-op', data }, processor);
+    super(
+      {
+        traceId: NOOP_TRACE_OR_SPAN_ID,
+        spanId: NOOP_TRACE_OR_SPAN_ID,
+        data,
+      },
+      processor,
+    );
   }
 
   start() {

--- a/packages/agents-core/src/tracing/traces.ts
+++ b/packages/agents-core/src/tracing/traces.ts
@@ -1,5 +1,5 @@
 import { defaultProcessor, TracingProcessor } from './processor';
-import { generateTraceId } from './utils';
+import { generateTraceId, NOOP_TRACE_OR_SPAN_ID } from './utils';
 
 export type TraceOptions = {
   traceId?: string;
@@ -85,7 +85,7 @@ export class Trace {
 
 export class NoopTrace extends Trace {
   constructor() {
-    super({});
+    super({ traceId: NOOP_TRACE_OR_SPAN_ID });
   }
 
   async start(): Promise<void> {

--- a/packages/agents-core/src/tracing/utils.ts
+++ b/packages/agents-core/src/tracing/utils.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from '@openai/agents-core/_shims';
 
+export const NOOP_TRACE_OR_SPAN_ID = 'no-op';
+
 /**
  * Generate an ISO 8601 timestamp of the current time.
  * @returns An ISO 8601 timestamp.

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -1029,6 +1029,7 @@ describe('TraceProvider disabled behavior', () => {
 
     const trace = provider.createTrace({ name: 'disabled' });
     expect(trace).toBeInstanceOf(NoopTrace);
+    expect(trace.traceId).toBe('no-op');
 
     const span = provider.createSpan(
       {
@@ -1045,6 +1046,9 @@ describe('TraceProvider span creation without parents', () => {
     const loggerError = vi
       .spyOn(coreLogger, 'error')
       .mockImplementation(() => {});
+    const loggerDebug = vi
+      .spyOn(coreLogger, 'debug')
+      .mockImplementation(() => {});
     const provider = new TraceProvider();
     provider.setDisabled(false);
 
@@ -1052,6 +1056,11 @@ describe('TraceProvider span creation without parents', () => {
       data: { type: 'custom', name: 'no-trace', data: {} },
     });
     expect(span).toBeInstanceOf(NoopSpan);
+    expect(loggerDebug).toHaveBeenCalledWith(
+      'No active trace. Make sure to start a trace with `withTrace()` first. Returning NoopSpan.',
+    );
+    expect(loggerError).not.toHaveBeenCalled();
+    loggerDebug.mockRestore();
     loggerError.mockRestore();
   });
 
@@ -1082,6 +1091,16 @@ describe('TraceProvider span creation without parents', () => {
     );
     expect(fromTrace).toBeInstanceOf(NoopSpan);
 
+    const traceWithNoopId = new Trace({
+      name: 'noop-trace-id',
+      traceId: 'no-op',
+    });
+    const fromTraceId = provider.createSpan(
+      { data: { type: 'custom', name: 'noop-trace-id', data: {} } },
+      traceWithNoopId,
+    );
+    expect(fromTraceId).toBeInstanceOf(NoopSpan);
+
     const noopSpan = new NoopSpan(
       { type: 'custom', name: 'noop-span', data: {} },
       new TestProcessor(),
@@ -1091,6 +1110,52 @@ describe('TraceProvider span creation without parents', () => {
       noopSpan,
     );
     expect(fromSpan).toBeInstanceOf(NoopSpan);
+  });
+
+  it('returns NoopSpan when the span id is the no-op sentinel', async () => {
+    const provider = getGlobalTraceProvider();
+    provider.setDisabled(false);
+
+    await withTrace('active-trace', async () => {
+      const span = provider.createSpan({
+        data: { type: 'custom', name: 'noop-id', data: {} },
+        spanId: 'no-op',
+      });
+      expect(span).toBeInstanceOf(NoopSpan);
+    });
+
+    provider.setDisabled(true);
+  });
+
+  it('returns NoopSpan when the parent span id is the no-op sentinel', async () => {
+    const provider = getGlobalTraceProvider();
+    provider.setDisabled(false);
+
+    await withTrace('active-trace', async () => {
+      const currentTrace = getCurrentTrace();
+      expect(currentTrace).not.toBeNull();
+
+      const parentSpan = new Span(
+        {
+          traceId: currentTrace!.traceId,
+          spanId: 'no-op',
+          data: { type: 'custom', name: 'noop-parent-id', data: {} },
+        },
+        new TestProcessor(),
+      );
+      setCurrentSpan(parentSpan);
+
+      try {
+        const span = provider.createSpan({
+          data: { type: 'custom', name: 'child', data: {} },
+        });
+        expect(span).toBeInstanceOf(NoopSpan);
+      } finally {
+        resetCurrentSpan();
+      }
+    });
+
+    provider.setDisabled(true);
   });
 
   it('returns NoopSpan when span options are disabled', () => {


### PR DESCRIPTION
This pull request fixes tracing span creation so reserved `no-op` trace/span identifiers cannot create regular spans or become parent IDs.

It returns `NoopSpan` for explicit `spanId: "no-op"` and for parent/current trace or span contexts carrying no-op identifiers. It also downgrades missing active trace reporting to debug-level behavior while still returning a `NoopSpan`, and adds regression coverage for explicit and current-parent no-op span IDs.

A patch changeset is included for `@openai/agents-core`.

see also: https://github.com/openai/openai-agents-python/pull/3296
