### PR TITLE
fix(core): preserve GitRepo root subpath aliases

### DIFF
--- a/.changeset/preserve-git-repo-root-subpath-aliases.md
+++ b/.changeset/preserve-git-repo-root-subpath-aliases.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: preserve GitRepo root subpath aliases while validating unsafe subpaths

--- a/packages/agents-core/src/sandbox/manifest.ts
+++ b/packages/agents-core/src/sandbox/manifest.ts
@@ -362,11 +362,11 @@ function normalizeGitRepoSubpath(repo: string, subpath: string): string {
     | 'windows_path'
     | undefined;
 
-  if (subpath === '') {
+  if (subpath === '' || normalizePosixPath(trimmed) === '.') {
     return '';
   }
 
-  if (!trimmed || normalizePosixPath(trimmed) === '.') {
+  if (!trimmed) {
     reason = 'empty';
   } else if (
     hasBackslashPathSeparator(subpath) ||

--- a/packages/agents-core/test/sandboxManifest.test.ts
+++ b/packages/agents-core/test/sandboxManifest.test.ts
@@ -406,9 +406,25 @@ describe('Manifest', () => {
     expect(repo.subpath).toBe('');
   });
 
+  it.each(['.', './', './.', ' ./ '])(
+    'preserves GitRepo root subpath alias %j',
+    (subpath) => {
+      const manifest = new Manifest({
+        entries: {
+          repo: {
+            type: 'git_repo',
+            repo: 'openai/openai-agents-js',
+            subpath,
+          },
+        },
+      });
+      const repo = manifest.entries.repo as GitRepo;
+
+      expect(repo.subpath).toBe('');
+    },
+  );
+
   it.each([
-    ['.', 'empty'],
-    ['./', 'empty'],
     ['/docs', 'absolute'],
     ['../outside', 'parent_traversal'],
     ['docs/../../outside', 'parent_traversal'],


### PR DESCRIPTION
This pull request fixes a release-readiness compatibility issue in sandbox manifest GitRepo subpath validation.

The release candidate tightened `git_repo.subpath` validation to reject unsafe paths before materialization, which is correct for parent traversal, absolute paths, and Windows-style paths. However, `v0.11.1` already accepted root aliases such as `.` and `./` by normalizing them to an empty subpath, so rejecting those aliases in a patch release would break existing manifests without improving traversal safety.

This change preserves those root aliases by normalizing dot-only subpaths to `""`, keeps unsafe subpath rejection in place, and adds focused manifest coverage for both behaviors. It also adds the untracked changeset file `.changeset/preserve-git-repo-root-subpath-aliases.md` for `@openai/agents-core`.
