### PR TITLE
fix: stabilize examples auto-run for local MCP and sandbox runs

### DIFF
--- a/.agents/skills/examples-auto-run/SKILL.md
+++ b/.agents/skills/examples-auto-run/SKILL.md
@@ -52,6 +52,7 @@ description: Run examples:start-all in auto mode with parallel execution, per-sc
 - `EXAMPLES_INTERACTIVE_MODE=auto`
 - `AUTO_APPROVE_MCP=1`, `APPLY_PATCH_AUTO_APPROVE=1`, `AUTO_APPROVE_HITL=1` (set in runner)
 - `EXAMPLES_CONCURRENCY=4`
+  - `sandbox:start:memory-generation` is still serialized by the runner because its pre-stop memory generation can contend with shared local resources. Other hosted, Unix-local, and Docker sandbox examples remain parallelized.
 - `EXAMPLES_EXECA_TIMEOUT_MS=300000` (5m)  
   `financial-research-agent` and `computer-use` use 10m inside the script.
 - Includes interactive; excludes server/audio/external by default:
@@ -61,6 +62,11 @@ description: Run examples:start-all in auto mode with parallel execution, per-sc
 - `EXAMPLES_INCLUDE_EXTERNAL=0`
   - This means `realtime-*` / `nextjs` (tagged as server/audio) are skipped unless you opt in with `--include-server` / `--include-audio` or the corresponding env flags.
 - Auto-skip list: `EXAMPLES_AUTO_SKIP` (comma/space separated) overrides the built-in defaults used by both `run.sh` and `run-example-starts.mjs`. Defaults include `agent-patterns:start:llm-as-a-judge`, `agent-patterns:start:routing`, `customer-service:start`, `connectors:start`, `mcp:start:hosted-mcp-on-approval`, `mcp:start:hosted-mcp-human-in-the-loop`.
+
+## Codex execution environment
+
+- When Codex invokes `start` or `rerun`, run the command outside the Codex sandbox by default (`sandbox_permissions=require_escalated`). Several examples start nested sandboxes, browsers, npm helpers, or local service processes; running from inside the Codex sandbox can produce environment-only failures such as Playwright browser launch permission errors, npm cache permission errors, or nested sandbox setup errors.
+- Use sandboxed execution only when the user explicitly asks for it or when running a narrow dry-run / log inspection command that does not execute examples.
 
 ## Cancellation / cleanup
 

--- a/examples/mcp/sse-example.ts
+++ b/examples/mcp/sse-example.ts
@@ -1,28 +1,148 @@
-import { Agent, run, MCPServerSSE, withTrace } from '@openai/agents';
+import http, { type IncomingMessage, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
 
-async function main() {
+import { Agent, run, MCPServerSSE, withTrace } from '@openai/agents';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+
+const SSE_HOST = process.env.SSE_HOST ?? '127.0.0.1';
+const REMOTE_SSE_URL = process.env.MCP_SSE_REMOTE_URL;
+
+type LocalSseServer = {
+  close: () => Promise<void>;
+  url: string;
+};
+
+function parseOptionalPort(): number {
+  const rawPort = process.env.SSE_PORT;
+  if (!rawPort) {
+    return 0;
+  }
+
+  const port = Number.parseInt(rawPort, 10);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error(`Invalid SSE_PORT value: ${rawPort}`);
+  }
+  return port;
+}
+
+async function startLocalSseServer(): Promise<LocalSseServer> {
+  const mcpServer = new McpServer({
+    name: 'local-sse-example',
+    version: '1.0.0',
+  });
+  mcpServer.tool('add', 'Add 7 and 22 for this example.', () => ({
+    content: [{ type: 'text', text: '29' }],
+  }));
+
+  let transport: SSEServerTransport | undefined;
+  const server = http.createServer(
+    async (req: IncomingMessage, res: ServerResponse) => {
+      try {
+        const requestUrl = new URL(
+          req.url ?? '/',
+          `http://${req.headers.host ?? SSE_HOST}`,
+        );
+
+        if (req.method === 'GET' && requestUrl.pathname === '/sse') {
+          transport = new SSEServerTransport('/messages', res);
+          await mcpServer.connect(transport);
+          return;
+        }
+
+        if (req.method === 'POST' && requestUrl.pathname === '/messages') {
+          if (
+            !transport ||
+            requestUrl.searchParams.get('sessionId') !== transport.sessionId
+          ) {
+            res.writeHead(404).end('Unknown SSE session');
+            return;
+          }
+          await transport.handlePostMessage(req, res);
+          return;
+        }
+
+        res.writeHead(404).end('Not found');
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!res.headersSent) {
+          res.writeHead(500);
+        }
+        res.end(message);
+      }
+    },
+  );
+
+  const port = await new Promise<number>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(parseOptionalPort(), SSE_HOST, () => {
+      server.off('error', reject);
+      resolve((server.address() as AddressInfo).port);
+    });
+  });
+
+  const url = `http://${SSE_HOST}:${port}/sse`;
+  console.log(`Started local SSE MCP server at ${url}`);
+
+  return {
+    url,
+    close: async () => {
+      await transport?.close();
+      await mcpServer.close();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+async function runSseExample(url: string, name: string) {
   const mcpServer = new MCPServerSSE({
-    url: 'https://gitmcp.io/openai/codex',
-    name: 'SSE MCP Server',
+    url,
+    name,
+    clientSessionTimeoutSeconds: 15,
+    timeout: 15_000,
   });
 
   const agent = new Agent({
     name: 'SSE Assistant',
-    instructions: 'Use the tools to respond to user requests.',
+    instructions: 'Use the available MCP tools to answer the user.',
     mcpServers: [mcpServer],
+    modelSettings: { toolChoice: 'required' },
   });
 
   try {
     await withTrace('SSE MCP Server Example', async () => {
       await mcpServer.connect();
-      const result = await run(
-        agent,
-        'Please help me with the available tools.',
-      );
+      const result = await run(agent, 'Use the MCP add tool to add 7 and 22.');
       console.log(result.finalOutput);
     });
   } finally {
     await mcpServer.close();
+  }
+}
+
+async function main() {
+  if (REMOTE_SSE_URL) {
+    console.log(`Connecting to remote SSE MCP server at ${REMOTE_SSE_URL}`);
+    await runSseExample(REMOTE_SSE_URL, 'Remote SSE MCP Server');
+    return;
+  }
+
+  console.log(
+    'MCP_SSE_REMOTE_URL is not set; using the bundled local SSE MCP server.',
+  );
+  const server = await startLocalSseServer();
+  try {
+    await runSseExample(server.url, 'Local SSE MCP Server');
+  } finally {
+    await server.close();
   }
 }
 

--- a/scripts/run-example-starts.mjs
+++ b/scripts/run-example-starts.mjs
@@ -127,6 +127,8 @@ const TRANSIENT_PNPM_WORKSPACE_STATE_PATTERNS = [
   /loadWorkspaceState/i,
 ];
 
+const SERIALIZED_EXAMPLE_STARTS = new Set(['sandbox:start:memory-generation']);
+
 const parseArgs = (args) => {
   let dryRun = false;
   let filter = null;
@@ -671,6 +673,26 @@ const runStarts = async (
     return start;
   };
 
+  let serializedStartTail = Promise.resolve();
+  const acquireSerializedStart = async (start) => {
+    const name = `${start.packageName}:${start.scriptName}`;
+    if (!SERIALIZED_EXAMPLE_STARTS.has(name)) {
+      return () => {};
+    }
+
+    const previous = serializedStartTail;
+    let release = () => {};
+    serializedStartTail = new Promise((resolve) => {
+      release = resolve;
+    });
+
+    await previous;
+    console.log(
+      `   [serialized] ${name} runs one at a time to avoid shared sandbox memory generation conflicts.`,
+    );
+    return release;
+  };
+
   const worker = async () => {
     while (true) {
       const start = next();
@@ -728,99 +750,149 @@ const runStarts = async (
         continue;
       }
 
-      let logFile;
-      let logStream;
-      const flushLogStream = () =>
-        new Promise((resolve) => {
-          if (!logStream) {
-            resolve();
-            return;
-          }
-          if (logStream.closed) {
-            resolve();
-            return;
-          }
-          logStream.end(() => resolve());
-        });
+      const releaseSerializedStart = await acquireSerializedStart(start);
       try {
-        const key = `${start.packageName}:${start.scriptName}`;
-        const dirKey = `${path.basename(start.dir)}:${start.scriptName}`;
-        const resolvedAutoInput =
-          DEFAULT_INTERACTIVE_INPUTS.get(key) ??
-          DEFAULT_INTERACTIVE_INPUTS.get(dirKey) ??
-          process.env.EXAMPLES_INTERACTIVE_DEFAULT_INPUT;
-        const autoInput =
-          interactiveMode === 'auto' && resolvedAutoInput
-            ? resolvedAutoInput
-            : undefined;
+        let logFile;
+        let logStream;
+        const flushLogStream = () =>
+          new Promise((resolve) => {
+            if (!logStream) {
+              resolve();
+              return;
+            }
+            if (logStream.closed) {
+              resolve();
+              return;
+            }
+            logStream.end(() => resolve());
+          });
+        try {
+          const key = `${start.packageName}:${start.scriptName}`;
+          const dirKey = `${path.basename(start.dir)}:${start.scriptName}`;
+          const resolvedAutoInput =
+            DEFAULT_INTERACTIVE_INPUTS.get(key) ??
+            DEFAULT_INTERACTIVE_INPUTS.get(dirKey) ??
+            process.env.EXAMPLES_INTERACTIVE_DEFAULT_INPUT;
+          const autoInput =
+            interactiveMode === 'auto' && resolvedAutoInput
+              ? resolvedAutoInput
+              : undefined;
 
-        if (interactiveMode === 'auto') {
-          const label =
-            autoInput && start.tags.has('interactive')
-              ? '[auto-input enabled]'
-              : start.tags.has('interactive')
-                ? '[interactive: no auto-input configured]'
-                : autoInput
-                  ? '[auto-input enabled]'
-                  : '[auto-input not found for this script]';
-          console.log(`   ${label}`);
-        }
+          if (interactiveMode === 'auto') {
+            const label =
+              autoInput && start.tags.has('interactive')
+                ? '[auto-input enabled]'
+                : start.tags.has('interactive')
+                  ? '[interactive: no auto-input configured]'
+                  : autoInput
+                    ? '[auto-input enabled]'
+                    : '[auto-input not found for this script]';
+            console.log(`   ${label}`);
+          }
 
-        const timeout =
-          start.packageName === 'financial-research-agent'
-            ? 600_000
-            : start.scriptName.includes('computer-use')
+          const timeout =
+            start.packageName === 'financial-research-agent'
               ? 600_000
-              : baseTimeoutMs;
+              : start.scriptName.includes('computer-use')
+                ? 600_000
+                : baseTimeoutMs;
 
-        const childEnv = { ...process.env };
-        if (interactiveMode === 'auto' && start.tags.has('interactive')) {
-          childEnv.AUTO_APPROVE_HITL =
-            childEnv.AUTO_APPROVE_HITL ?? (autoInput ? '1' : '1');
-        }
-        if (start.scriptName.includes('apply-patch')) {
-          childEnv.APPLY_PATCH_AUTO_APPROVE =
-            childEnv.APPLY_PATCH_AUTO_APPROVE ?? '1';
-        }
-        if (start.scriptName.includes('shell')) {
-          childEnv.SHELL_AUTO_APPROVE =
-            childEnv.SHELL_AUTO_APPROVE ?? childEnv.AUTO_APPROVE_HITL ?? '1';
-        }
-        if (start.packageName === 'mcp') {
-          childEnv.AUTO_APPROVE_MCP =
-            childEnv.AUTO_APPROVE_MCP ?? childEnv.AUTO_APPROVE_HITL ?? '1';
-        }
+          const childEnv = { ...process.env };
+          if (interactiveMode === 'auto' && start.tags.has('interactive')) {
+            childEnv.AUTO_APPROVE_HITL =
+              childEnv.AUTO_APPROVE_HITL ?? (autoInput ? '1' : '1');
+          }
+          if (start.scriptName.includes('apply-patch')) {
+            childEnv.APPLY_PATCH_AUTO_APPROVE =
+              childEnv.APPLY_PATCH_AUTO_APPROVE ?? '1';
+          }
+          if (start.scriptName.includes('shell')) {
+            childEnv.SHELL_AUTO_APPROVE =
+              childEnv.SHELL_AUTO_APPROVE ?? childEnv.AUTO_APPROVE_HITL ?? '1';
+          }
+          if (start.packageName === 'mcp') {
+            childEnv.AUTO_APPROVE_MCP =
+              childEnv.AUTO_APPROVE_MCP ?? childEnv.AUTO_APPROVE_HITL ?? '1';
+          }
 
-        logFile = path.join(
-          logsDir,
-          `${start.packageName.replace(/[^\w.-]/g, '_')}__${start.scriptName.replace(/[^\w.-]/g, '_')}.log`,
-        );
-        console.log(`   log: ${path.relative(rootDir, logFile)}`);
-
-        let attempt = 1;
-        while (true) {
-          // Truncate per-script log on each attempt so only the latest execution remains.
-          logStream = createWriteStream(logFile, { flags: 'w' });
-          const child = execa(
-            'pnpm',
-            ['-C', start.dir, 'run', start.scriptName],
-            {
-              stdio: 'pipe',
-              input: autoInput,
-              env: childEnv,
-              timeout,
-            },
+          logFile = path.join(
+            logsDir,
+            `${start.packageName.replace(/[^\w.-]/g, '_')}__${start.scriptName.replace(/[^\w.-]/g, '_')}.log`,
           );
-          if (child.stdout) {
-            child.stdout.pipe(logStream);
+          console.log(`   log: ${path.relative(rootDir, logFile)}`);
+
+          let attempt = 1;
+          while (true) {
+            // Truncate per-script log on each attempt so only the latest execution remains.
+            logStream = createWriteStream(logFile, { flags: 'w' });
+            const child = execa(
+              'pnpm',
+              ['-C', start.dir, 'run', start.scriptName],
+              {
+                stdio: 'pipe',
+                input: autoInput,
+                env: childEnv,
+                timeout,
+              },
+            );
+            if (child.stdout) {
+              child.stdout.pipe(logStream);
+            }
+            if (child.stderr) {
+              child.stderr.pipe(logStream);
+            }
+            running.add(child);
+            try {
+              await child;
+              await flushLogStream();
+              executed += 1;
+              const validation = await validateLog({
+                start,
+                logFile,
+                exitCode: 0,
+              });
+              if (validation.status === 'unexpected') {
+                unexpected += 1;
+              } else if (validation.status === 'unknown') {
+                validationUnknown += 1;
+              }
+              results.push({
+                start,
+                status: 'passed',
+                logFile,
+                usedAutoInput: Boolean(autoInput),
+                validation,
+              });
+              break;
+            } catch (error) {
+              await flushLogStream();
+              const exitCode =
+                typeof error?.exitCode === 'number'
+                  ? error.exitCode
+                  : 'unknown';
+              const shouldRetry =
+                attempt < 2 &&
+                (await shouldRetryTransientPnpmFailure({ exitCode, logFile }));
+              if (shouldRetry) {
+                console.warn(
+                  `   !! ${start.packageName}:${start.scriptName} hit transient pnpm workspace state parsing; retrying once`,
+                );
+                attempt += 1;
+                continue;
+              }
+              throw error;
+            } finally {
+              running.delete(child);
+              if (logStream && !logStream.closed) {
+                logStream.end();
+              }
+            }
           }
-          if (child.stderr) {
-            child.stderr.pipe(logStream);
-          }
-          running.add(child);
-          try {
-            await child;
-            await flushLogStream();
+        } catch (error) {
+          const exitCode =
+            typeof error?.exitCode === 'number' ? error.exitCode : 'unknown';
+          await flushLogStream();
+          if (exitCode === 0) {
             executed += 1;
             const validation = await validateLog({
               start,
@@ -836,47 +908,34 @@ const runStarts = async (
               start,
               status: 'passed',
               logFile,
-              usedAutoInput: Boolean(autoInput),
               validation,
+              usedAutoInput: Boolean(
+                interactiveMode === 'auto' &&
+                (start.tags.has('interactive') ||
+                  DEFAULT_INTERACTIVE_INPUTS.has(
+                    `${start.packageName}:${start.scriptName}`,
+                  )),
+              ),
             });
-            break;
-          } catch (error) {
-            await flushLogStream();
-            const exitCode =
-              typeof error?.exitCode === 'number' ? error.exitCode : 'unknown';
-            const shouldRetry =
-              attempt < 2 &&
-              (await shouldRetryTransientPnpmFailure({ exitCode, logFile }));
-            if (shouldRetry) {
-              console.warn(
-                `   !! ${start.packageName}:${start.scriptName} hit transient pnpm workspace state parsing; retrying once`,
-              );
-              attempt += 1;
-              continue;
-            }
-            throw error;
-          } finally {
-            running.delete(child);
-            if (logStream && !logStream.closed) {
-              logStream.end();
-            }
+            continue;
           }
-        }
-      } catch (error) {
-        const exitCode =
-          typeof error?.exitCode === 'number' ? error.exitCode : 'unknown';
-        await flushLogStream();
-        if (exitCode === 0) {
-          executed += 1;
-          const validation = await validateLog({ start, logFile, exitCode: 0 });
-          if (validation.status === 'unexpected') {
+          failed += 1;
+          console.error(
+            `   !! ${start.packageName}:${start.scriptName} exited with ${exitCode}`,
+          );
+
+          const validation = await validateLog({ start, logFile, exitCode });
+          if (validation.status === 'expected-failure') {
+            expectedFailures += 1;
+          } else if (validation.status === 'unexpected') {
             unexpected += 1;
           } else if (validation.status === 'unknown') {
             validationUnknown += 1;
           }
           results.push({
             start,
-            status: 'passed',
+            status: 'failed',
+            exitCode,
             logFile,
             validation,
             usedAutoInput: Boolean(
@@ -887,39 +946,13 @@ const runStarts = async (
                 )),
             ),
           });
-          continue;
+          if (failFast) {
+            requestCancel('fail-fast');
+            return;
+          }
         }
-        failed += 1;
-        console.error(
-          `   !! ${start.packageName}:${start.scriptName} exited with ${exitCode}`,
-        );
-
-        const validation = await validateLog({ start, logFile, exitCode });
-        if (validation.status === 'expected-failure') {
-          expectedFailures += 1;
-        } else if (validation.status === 'unexpected') {
-          unexpected += 1;
-        } else if (validation.status === 'unknown') {
-          validationUnknown += 1;
-        }
-        results.push({
-          start,
-          status: 'failed',
-          exitCode,
-          logFile,
-          validation,
-          usedAutoInput: Boolean(
-            interactiveMode === 'auto' &&
-            (start.tags.has('interactive') ||
-              DEFAULT_INTERACTIVE_INPUTS.has(
-                `${start.packageName}:${start.scriptName}`,
-              )),
-          ),
-        });
-        if (failFast) {
-          requestCancel('fail-fast');
-          return;
-        }
+      } finally {
+        releaseSerializedStart();
       }
       if (cancelled) {
         return;


### PR DESCRIPTION
This pull request fixes local `examples:start-all` reliability by making the MCP SSE example self-contained by default and narrowing sandbox serialization to only the memory-generation example that contends on shared local resources.

It updates `examples/mcp/sse-example.ts` to start a bundled local SSE MCP server unless `MCP_SSE_REMOTE_URL` is provided, so the example no longer depends on a remote SSE endpoint for normal local validation. It also updates `scripts/run-example-starts.mjs` so `sandbox:start:memory-generation` runs serially while hosted sandbox, Unix-local, and Docker sandbox examples remain eligible for parallel execution. The examples auto-run skill notes the Codex execution expectations and the targeted serialization behavior.