### PR TITLE
fix: add configurable sandbox archive extraction limits

### DIFF
--- a/.changeset/limit-sandbox-archive-extraction.md
+++ b/.changeset/limit-sandbox-archive-extraction.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-extensions': patch
+---
+
+fix: add configurable sandbox archive extraction limits

--- a/packages/agents-core/src/sandbox/client.ts
+++ b/packages/agents-core/src/sandbox/client.ts
@@ -2,10 +2,29 @@ import { cloneManifest, Manifest, type ManifestInput } from './manifest';
 import type { SandboxSessionLike, SandboxSessionState } from './session';
 import { isRecord } from './shared/typeGuards';
 import type { SnapshotSpec } from './snapshot';
+import { UserError } from '../errors';
 
 export type SandboxConcurrencyLimits = {
   manifestEntries?: number;
   localDirFiles?: number;
+};
+
+export type SandboxArchiveLimits = {
+  maxInputBytes?: number | null;
+  maxExtractedBytes?: number | null;
+  maxMembers?: number | null;
+};
+
+export type ResolvedSandboxArchiveLimits = {
+  maxInputBytes: number | null;
+  maxExtractedBytes: number | null;
+  maxMembers: number | null;
+};
+
+export const DEFAULT_SANDBOX_ARCHIVE_LIMITS: ResolvedSandboxArchiveLimits = {
+  maxInputBytes: 1024 * 1024 * 1024,
+  maxExtractedBytes: 4 * 1024 * 1024 * 1024,
+  maxMembers: 100_000,
 };
 
 export type SandboxClientOptions = Record<string, unknown>;
@@ -17,6 +36,7 @@ export type SandboxClientCreateArgs<
   manifest?: ManifestInput;
   options?: TOptions;
   concurrencyLimits?: SandboxConcurrencyLimits;
+  archiveLimits?: SandboxArchiveLimits | null;
 };
 
 export type NormalizedSandboxClientCreateArgs<
@@ -26,6 +46,7 @@ export type NormalizedSandboxClientCreateArgs<
   manifest: Manifest;
   options?: TOptions;
   concurrencyLimits?: SandboxConcurrencyLimits;
+  archiveLimits?: SandboxArchiveLimits | null;
 };
 
 export type SandboxClientCreate<
@@ -85,6 +106,7 @@ export type SandboxRunConfig<
   manifest?: ManifestInput;
   snapshot?: SnapshotSpec;
   concurrencyLimits?: SandboxConcurrencyLimits;
+  archiveLimits?: SandboxArchiveLimits | null;
 };
 
 export function normalizeSandboxClientCreateArgs<
@@ -99,6 +121,7 @@ export function normalizeSandboxClientCreateArgs<
       options: manifestOptions,
       snapshot: readSnapshotOption(manifestOptions),
       concurrencyLimits: readConcurrencyLimitsOption(manifestOptions),
+      archiveLimits: readArchiveLimitsOption(manifestOptions),
     };
   }
 
@@ -113,7 +136,54 @@ export function normalizeSandboxClientCreateArgs<
     options: args?.options,
     snapshot: args?.snapshot,
     concurrencyLimits: args?.concurrencyLimits,
+    archiveLimits: args?.archiveLimits,
   };
+}
+
+export function resolveSandboxArchiveLimits(
+  limits?: SandboxArchiveLimits | null,
+): ResolvedSandboxArchiveLimits | null {
+  if (limits == null) {
+    return null;
+  }
+  validateSandboxArchiveLimits(limits);
+  return {
+    maxInputBytes:
+      limits.maxInputBytes === undefined
+        ? DEFAULT_SANDBOX_ARCHIVE_LIMITS.maxInputBytes
+        : limits.maxInputBytes,
+    maxExtractedBytes:
+      limits.maxExtractedBytes === undefined
+        ? DEFAULT_SANDBOX_ARCHIVE_LIMITS.maxExtractedBytes
+        : limits.maxExtractedBytes,
+    maxMembers:
+      limits.maxMembers === undefined
+        ? DEFAULT_SANDBOX_ARCHIVE_LIMITS.maxMembers
+        : limits.maxMembers,
+  };
+}
+
+export function validateSandboxArchiveLimits(
+  limits?: SandboxArchiveLimits | null,
+): void {
+  if (limits == null) {
+    return;
+  }
+  validatePositiveArchiveLimit('maxInputBytes', limits.maxInputBytes);
+  validatePositiveArchiveLimit('maxExtractedBytes', limits.maxExtractedBytes);
+  validatePositiveArchiveLimit('maxMembers', limits.maxMembers);
+}
+
+function validatePositiveArchiveLimit(
+  name: keyof SandboxArchiveLimits,
+  value: number | null | undefined,
+): void {
+  if (value == null) {
+    return;
+  }
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new UserError(`archiveLimits.${name} must be at least 1.`);
+  }
 }
 
 function readSnapshotOption(options: unknown): SnapshotSpec | undefined {
@@ -130,4 +200,13 @@ function readConcurrencyLimitsOption(
     return undefined;
   }
   return options.concurrencyLimits as SandboxConcurrencyLimits | undefined;
+}
+
+function readArchiveLimitsOption(
+  options: unknown,
+): SandboxArchiveLimits | null | undefined {
+  if (!isRecord(options)) {
+    return undefined;
+  }
+  return options.archiveLimits as SandboxArchiveLimits | null | undefined;
 }

--- a/packages/agents-core/src/sandbox/client.ts
+++ b/packages/agents-core/src/sandbox/client.ts
@@ -49,6 +49,10 @@ export type NormalizedSandboxClientCreateArgs<
   archiveLimits?: SandboxArchiveLimits | null;
 };
 
+export type SandboxClientResumeOptions = {
+  archiveLimits?: SandboxArchiveLimits | null;
+};
+
 export type SandboxClientCreate<
   TOptions extends SandboxClientOptions = SandboxClientOptions,
   TSessionState extends SandboxSessionState = SandboxSessionState,
@@ -92,7 +96,10 @@ export interface SandboxClient<
   deserializeSessionState?(
     state: Record<string, unknown>,
   ): Promise<TSessionState>;
-  resume?(state: TSessionState): Promise<SandboxSessionLike<TSessionState>>;
+  resume?(
+    state: TSessionState,
+    options?: SandboxClientResumeOptions,
+  ): Promise<SandboxSessionLike<TSessionState>>;
 }
 
 export type SandboxRunConfig<

--- a/packages/agents-core/src/sandbox/runtime/manager.ts
+++ b/packages/agents-core/src/sandbox/runtime/manager.ts
@@ -568,8 +568,12 @@ export class SandboxRuntimeManager<TContext> {
           agent_name: entry.currentAgentName,
           backend_id: client.backendId,
         },
-        async () => await client.resume!(serializedState),
+        async () =>
+          await client.resume!(serializedState, {
+            archiveLimits: this.sandboxConfig?.archiveLimits,
+          }),
       );
+      this.applyArchiveLimits(session);
       this.sessionsByAgentKey.set(agentKey, session);
       this.sessionAgentNamesByKey.set(agentKey, entry.currentAgentName);
       this.ownedSessionAgentKeys.add(agentKey);

--- a/packages/agents-core/src/sandbox/runtime/manager.ts
+++ b/packages/agents-core/src/sandbox/runtime/manager.ts
@@ -599,6 +599,7 @@ export class SandboxRuntimeManager<TContext> {
     }
     const existingByKey = this.sessionsByAgentKey.get(agentKey);
     if (existingByKey) {
+      this.applyArchiveLimits(existingByKey);
       await this.ensureSessionStarted(existingByKey, agent, 'resume', {
         oncePerSession: true,
       });
@@ -610,6 +611,7 @@ export class SandboxRuntimeManager<TContext> {
 
     if (this.sandboxConfig?.session) {
       const session = this.sandboxConfig.session;
+      this.applyArchiveLimits(session);
       const configuredManifest = this.resolveConfiguredManifest(agent, {
         providedSession: session,
       });
@@ -632,6 +634,7 @@ export class SandboxRuntimeManager<TContext> {
     const client = this.requireClient();
     const resumed = await this.resumeSessionForAgent(client, agent);
     if (resumed) {
+      this.applyArchiveLimits(resumed);
       await this.ensureSessionStarted(resumed, agent, 'resume');
       this.registerSessionForAgent(agent, resumed, { owned: true });
       return resumed;
@@ -647,6 +650,7 @@ export class SandboxRuntimeManager<TContext> {
       snapshot: this.resolveSnapshotSpec(client),
       options: this.sandboxConfig?.options,
       concurrencyLimits: this.sandboxConfig?.concurrencyLimits,
+      archiveLimits: this.sandboxConfig?.archiveLimits,
     };
     if (configuredManifest.passToCreate) {
       createArgs.manifest = configuredManifest.manifest;
@@ -660,9 +664,19 @@ export class SandboxRuntimeManager<TContext> {
       },
       async () => await createSession(createArgs),
     );
+    this.applyArchiveLimits(session);
     await this.ensureSessionStarted(session, agent, 'create');
     this.registerSessionForAgent(agent, session, { owned: true });
     return session;
+  }
+
+  private applyArchiveLimits(
+    session: SandboxSessionLike<SandboxSessionState>,
+  ): void {
+    if (this.sandboxConfig?.archiveLimits === undefined) {
+      return;
+    }
+    session.setArchiveLimits?.(this.sandboxConfig.archiveLimits);
   }
 
   private registerSessionForAgent(

--- a/packages/agents-core/src/sandbox/runtime/manager.ts
+++ b/packages/agents-core/src/sandbox/runtime/manager.ts
@@ -811,7 +811,10 @@ export class SandboxRuntimeManager<TContext> {
           agent_name: agent.name,
           backend_id: client.backendId,
         },
-        async () => await client.resume!(this.sandboxConfig!.sessionState!),
+        async () =>
+          await client.resume!(this.sandboxConfig!.sessionState!, {
+            archiveLimits: this.sandboxConfig?.archiveLimits,
+          }),
       );
     }
 
@@ -829,7 +832,10 @@ export class SandboxRuntimeManager<TContext> {
         agent_name: agent.name,
         backend_id: client.backendId,
       },
-      async () => await client.resume!(serializedState),
+      async () =>
+        await client.resume!(serializedState, {
+          archiveLimits: this.sandboxConfig?.archiveLimits,
+        }),
     );
   }
 

--- a/packages/agents-core/src/sandbox/sandboxes/docker.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/docker.ts
@@ -37,6 +37,7 @@ import type {
   SandboxClient,
   SandboxClientOptions,
   SandboxClientCreateArgs,
+  SandboxArchiveLimits,
   SandboxConcurrencyLimits,
 } from '../client';
 import { normalizeSandboxClientCreateArgs } from '../client';
@@ -114,6 +115,7 @@ export interface DockerSandboxClientOptions extends SandboxClientOptions {
   workspaceBaseDir?: string;
   snapshot?: LocalSandboxSnapshotSpec;
   concurrencyLimits?: SandboxConcurrencyLimits;
+  archiveLimits?: SandboxArchiveLimits | null;
 }
 
 export interface DockerSandboxSessionState extends UnixLocalSandboxSessionState {
@@ -735,6 +737,9 @@ export class DockerSandboxClient implements SandboxClient<
       ...(createArgs.concurrencyLimits
         ? { concurrencyLimits: createArgs.concurrencyLimits }
         : {}),
+      ...(createArgs.archiveLimits !== undefined
+        ? { archiveLimits: createArgs.archiveLimits }
+        : {}),
     };
     const workspaceRootPath = await mkdtemp(
       join(
@@ -787,6 +792,7 @@ export class DockerSandboxClient implements SandboxClient<
         configuredExposedPorts,
         dockerVolumeNames: container.volumeNames,
       },
+      archiveLimits: resolvedOptions.archiveLimits,
     });
     try {
       await provisionDockerAccounts(container.containerId, manifest);
@@ -813,6 +819,7 @@ export class DockerSandboxClient implements SandboxClient<
 
     return new DockerSandboxSession({
       state: restoredState,
+      archiveLimits: this.options.archiveLimits,
     });
   }
 
@@ -961,7 +968,10 @@ export class DockerSandboxClient implements SandboxClient<
       dockerVolumeNames: container.volumeNames,
       exposedPorts: undefined,
     };
-    const session = new DockerSandboxSession({ state: nextState });
+    const session = new DockerSandboxSession({
+      state: nextState,
+      archiveLimits: this.options.archiveLimits,
+    });
     try {
       await provisionDockerAccounts(container.containerId, state.manifest);
       await applyDockerInContainerMounts(session, state.manifest);

--- a/packages/agents-core/src/sandbox/sandboxes/docker.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/docker.ts
@@ -38,6 +38,7 @@ import type {
   SandboxClientOptions,
   SandboxClientCreateArgs,
   SandboxArchiveLimits,
+  SandboxClientResumeOptions,
   SandboxConcurrencyLimits,
 } from '../client';
 import { normalizeSandboxClientCreateArgs } from '../client';
@@ -812,14 +813,19 @@ export class DockerSandboxClient implements SandboxClient<
 
   async resume(
     state: DockerSandboxSessionState,
+    options: SandboxClientResumeOptions = {},
   ): Promise<DockerSandboxSession> {
     assertDockerManifestSupported(state.manifest);
     await ensureDockerAvailable();
-    const restoredState = await this.restoreIfNeeded(state);
+    const archiveLimits =
+      options.archiveLimits === undefined
+        ? this.options.archiveLimits
+        : options.archiveLimits;
+    const restoredState = await this.restoreIfNeeded(state, archiveLimits);
 
     return new DockerSandboxSession({
       state: restoredState,
-      archiveLimits: this.options.archiveLimits,
+      archiveLimits,
     });
   }
 
@@ -872,6 +878,7 @@ export class DockerSandboxClient implements SandboxClient<
 
   private async restoreIfNeeded(
     state: DockerSandboxSessionState,
+    archiveLimits?: SandboxArchiveLimits | null,
   ): Promise<DockerSandboxSessionState> {
     attachDockerSnapshotExcludedPaths(state);
     const containerRunning = await inspectContainerRunning(state.containerId);
@@ -883,17 +890,23 @@ export class DockerSandboxClient implements SandboxClient<
       }
       if (await canReuseLocalSnapshotWorkspace(state)) {
         await this.cleanupDockerResources(state);
-        return await this.restartContainer(state, state.workspaceRootPath);
+        return await this.restartContainer(
+          state,
+          state.workspaceRootPath,
+          archiveLimits,
+        );
       }
       if (await localSnapshotIsRestorable(state)) {
         const restoredState = await restoreLocalSnapshotToWorkspace(
           state,
           state.workspaceRootPath,
+          { archiveLimits },
         );
         await this.cleanupDockerResources(state);
         return await this.restartContainer(
           restoredState,
           restoredState.workspaceRootPath,
+          archiveLimits,
         );
       }
     }
@@ -918,9 +931,14 @@ export class DockerSandboxClient implements SandboxClient<
         workspaceRootOwned: true,
       },
       workspaceRootPath,
+      { archiveLimits },
     );
 
-    return await this.restartContainer(restoredState, workspaceRootPath);
+    return await this.restartContainer(
+      restoredState,
+      workspaceRootPath,
+      archiveLimits,
+    );
   }
 
   private async cleanupDockerResources(
@@ -933,6 +951,7 @@ export class DockerSandboxClient implements SandboxClient<
   private async restartContainer(
     state: DockerSandboxSessionState,
     workspaceRootPath: string,
+    archiveLimits?: SandboxArchiveLimits | null,
   ): Promise<DockerSandboxSessionState> {
     await materializeLocalWorkspaceManifestMounts(
       state.manifest,
@@ -970,7 +989,7 @@ export class DockerSandboxClient implements SandboxClient<
     };
     const session = new DockerSandboxSession({
       state: nextState,
-      archiveLimits: this.options.archiveLimits,
+      archiveLimits,
     });
     try {
       await provisionDockerAccounts(container.containerId, state.manifest);

--- a/packages/agents-core/src/sandbox/sandboxes/shared/localSnapshots.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/localSnapshots.ts
@@ -1,4 +1,5 @@
 import { UserError } from '../../../errors';
+import { SandboxArchiveError } from '../../errors';
 import {
   isNoopSnapshotSpec,
   type RemoteSnapshot,
@@ -26,6 +27,10 @@ import { createHash, randomUUID } from 'node:crypto';
 import { dirname, join, relative, sep } from 'node:path';
 import type { Manifest } from '../../manifest';
 import type { WorkspaceArchiveData } from '../../session';
+import {
+  resolveSandboxArchiveLimits,
+  type SandboxArchiveLimits,
+} from '../../client';
 import { stableJsonStringify } from '../../shared/stableJson';
 import { isRecord } from '../../shared/typeGuards';
 import {
@@ -441,15 +446,22 @@ async function appendWorkspaceArchiveEntries(
 export async function restoreWorkspaceArchive(
   data: WorkspaceArchiveData,
   destinationRoot: string,
+  options: { archiveLimits?: SandboxArchiveLimits | null } = {},
 ): Promise<void> {
-  const archive = JSON.parse(
+  const bytes =
     typeof data === 'string'
-      ? data
-      : new TextDecoder().decode(workspaceArchiveDataToUint8Array(data)),
+      ? new TextEncoder().encode(data)
+      : workspaceArchiveDataToUint8Array(data);
+  const archiveLimits = resolveSandboxArchiveLimits(options.archiveLimits);
+  checkWorkspaceArchiveInputBytes(bytes.byteLength, archiveLimits);
+
+  const archive = JSON.parse(
+    new TextDecoder().decode(bytes),
   ) as WorkspaceArchiveV1;
   if (archive.version !== 1) {
     throw new UserError('Unsupported remote snapshot archive version.');
   }
+  validateWorkspaceArchiveLimits(archive, archiveLimits);
 
   await mkdir(destinationRoot, { recursive: true });
   await clearDirectory(destinationRoot);
@@ -468,6 +480,84 @@ function workspaceArchiveDataToUint8Array(
     return data;
   }
   return new Uint8Array(data);
+}
+
+function checkWorkspaceArchiveInputBytes(
+  actual: number,
+  limits: ReturnType<typeof resolveSandboxArchiveLimits>,
+): void {
+  const limit = limits?.maxInputBytes;
+  if (limit != null && actual > limit) {
+    throw new SandboxArchiveError(
+      'Workspace archive input size exceeds limit.',
+      {
+        reason: 'archive input size exceeds limit',
+        limit,
+        actual,
+      },
+    );
+  }
+}
+
+function validateWorkspaceArchiveLimits(
+  archive: WorkspaceArchiveV1,
+  limits: ReturnType<typeof resolveSandboxArchiveLimits>,
+): void {
+  if (limits == null) {
+    return;
+  }
+
+  let memberCount = 0;
+  for (const directory of archive.directories) {
+    memberCount += 1;
+    checkWorkspaceArchiveMemberCount(memberCount, directory, limits);
+  }
+
+  let extractedBytes = 0;
+  for (const file of archive.files) {
+    memberCount += 1;
+    checkWorkspaceArchiveMemberCount(memberCount, file.path, limits);
+    extractedBytes += Buffer.byteLength(file.data, 'base64');
+    checkWorkspaceArchiveExtractedBytes(extractedBytes, file.path, limits);
+  }
+}
+
+function checkWorkspaceArchiveMemberCount(
+  actual: number,
+  member: string,
+  limits: ReturnType<typeof resolveSandboxArchiveLimits>,
+): void {
+  const limit = limits?.maxMembers;
+  if (limit != null && actual > limit) {
+    throw new SandboxArchiveError(
+      'Workspace archive member count exceeds limit.',
+      {
+        reason: 'archive member count exceeds limit',
+        limit,
+        actual,
+        member,
+      },
+    );
+  }
+}
+
+function checkWorkspaceArchiveExtractedBytes(
+  actual: number,
+  member: string,
+  limits: ReturnType<typeof resolveSandboxArchiveLimits>,
+): void {
+  const limit = limits?.maxExtractedBytes;
+  if (limit != null && actual > limit) {
+    throw new SandboxArchiveError(
+      'Workspace archive extracted size exceeds limit.',
+      {
+        reason: 'archive extracted size exceeds limit',
+        limit,
+        actual,
+        member,
+      },
+    );
+  }
 }
 
 async function writeSafeArchiveDirectory(

--- a/packages/agents-core/src/sandbox/sandboxes/shared/localSnapshots.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/localSnapshots.ts
@@ -1,4 +1,8 @@
 import { UserError } from '../../../errors';
+import {
+  resolveSandboxArchiveLimits,
+  type SandboxArchiveLimits,
+} from '../../client';
 import { SandboxArchiveError } from '../../errors';
 import {
   isNoopSnapshotSpec,
@@ -27,10 +31,6 @@ import { createHash, randomUUID } from 'node:crypto';
 import { dirname, join, relative, sep } from 'node:path';
 import type { Manifest } from '../../manifest';
 import type { WorkspaceArchiveData } from '../../session';
-import {
-  resolveSandboxArchiveLimits,
-  type SandboxArchiveLimits,
-} from '../../client';
 import { stableJsonStringify } from '../../shared/stableJson';
 import { isRecord } from '../../shared/typeGuards';
 import {
@@ -249,7 +249,11 @@ export async function localSnapshotIsRestorable(
 
 export async function restoreLocalSnapshotToWorkspace<
   TState extends LocalSnapshotState,
->(state: TState, workspaceRootPath: string): Promise<TState> {
+>(
+  state: TState,
+  workspaceRootPath: string,
+  options: { archiveLimits?: SandboxArchiveLimits | null } = {},
+): Promise<TState> {
   if (!(await localSnapshotIsRestorable(state))) {
     throw new UserError('No local snapshot is available to restore.');
   }
@@ -260,7 +264,7 @@ export async function restoreLocalSnapshotToWorkspace<
       throw new UserError('No remote snapshot store is available to restore.');
     }
     const restored = await store.load({ id: state.snapshot.id });
-    await restoreWorkspaceArchive(restored.data, workspaceRootPath);
+    await restoreWorkspaceArchive(restored.data, workspaceRootPath, options);
   } else {
     await replaceDirectoryContents(state.snapshot!.path, workspaceRootPath);
   }

--- a/packages/agents-core/src/sandbox/sandboxes/unixLocal.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/unixLocal.ts
@@ -24,9 +24,13 @@ import type {
   SandboxClient,
   SandboxClientOptions,
   SandboxClientCreateArgs,
+  SandboxArchiveLimits,
   SandboxConcurrencyLimits,
 } from '../client';
-import { normalizeSandboxClientCreateArgs } from '../client';
+import {
+  normalizeSandboxClientCreateArgs,
+  validateSandboxArchiveLimits,
+} from '../client';
 import {
   normalizeExposedPort,
   recordExposedPortEndpoint,
@@ -41,6 +45,7 @@ import {
   type SandboxSessionState,
   type ViewImageArgs,
   type WriteStdinArgs,
+  type WorkspaceArchiveOptions,
 } from '../session';
 import { Manifest, normalizeRelativePath } from '../manifest';
 import { SandboxConfigurationError } from '../errors';
@@ -107,6 +112,7 @@ export interface UnixLocalSandboxClientOptions extends SandboxClientOptions {
   defaultShell?: string;
   exposedPorts?: number[];
   concurrencyLimits?: SandboxConcurrencyLimits;
+  archiveLimits?: SandboxArchiveLimits | null;
 }
 
 export interface UnixLocalSandboxSessionState extends SandboxSessionState {
@@ -149,13 +155,24 @@ export class UnixLocalSandboxSession<
 > implements SandboxSession<TState> {
   readonly state: TState;
   protected readonly defaultShell?: string;
+  private archiveLimits?: SandboxArchiveLimits | null;
   private readonly activeProcesses = new Map<number, ActiveProcess>();
   private nextSessionId = 1;
   private closed = false;
 
-  constructor(args: { state: TState; defaultShell?: string }) {
+  constructor(args: {
+    state: TState;
+    defaultShell?: string;
+    archiveLimits?: SandboxArchiveLimits | null;
+  }) {
     this.state = args.state;
     this.defaultShell = args.defaultShell;
+    this.setArchiveLimits(args.archiveLimits);
+  }
+
+  setArchiveLimits(limits?: SandboxArchiveLimits | null): void {
+    validateSandboxArchiveLimits(limits);
+    this.archiveLimits = limits;
   }
 
   createEditor(runAs?: string): Editor {
@@ -434,8 +451,14 @@ export class UnixLocalSandboxSession<
 
   async hydrateWorkspace(
     data: string | ArrayBuffer | Uint8Array,
+    options: WorkspaceArchiveOptions = {},
   ): Promise<void> {
-    await restoreWorkspaceArchive(data, this.state.workspaceRootPath);
+    await restoreWorkspaceArchive(data, this.state.workspaceRootPath, {
+      archiveLimits:
+        options.archiveLimits === undefined
+          ? this.archiveLimits
+          : options.archiveLimits,
+    });
     await this.materializeRestoredWorkspaceMounts();
   }
 
@@ -875,6 +898,9 @@ export class UnixLocalSandboxClient implements SandboxClient<
       ...(createArgs.concurrencyLimits
         ? { concurrencyLimits: createArgs.concurrencyLimits }
         : {}),
+      ...(createArgs.archiveLimits !== undefined
+        ? { archiveLimits: createArgs.archiveLimits }
+        : {}),
     };
     assertLocalWorkspaceManifestMetadataSupported(
       'UnixLocalSandboxClient',
@@ -906,6 +932,7 @@ export class UnixLocalSandboxClient implements SandboxClient<
         configuredExposedPorts,
       },
       defaultShell: resolvedOptions.defaultShell,
+      archiveLimits: resolvedOptions.archiveLimits,
     });
   }
 
@@ -916,6 +943,7 @@ export class UnixLocalSandboxClient implements SandboxClient<
     return new UnixLocalSandboxSession({
       state: restoredState,
       defaultShell: this.options.defaultShell,
+      archiveLimits: this.options.archiveLimits,
     });
   }
 

--- a/packages/agents-core/src/sandbox/sandboxes/unixLocal.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/unixLocal.ts
@@ -25,6 +25,7 @@ import type {
   SandboxClientOptions,
   SandboxClientCreateArgs,
   SandboxArchiveLimits,
+  SandboxClientResumeOptions,
   SandboxConcurrencyLimits,
 } from '../client';
 import {
@@ -938,12 +939,17 @@ export class UnixLocalSandboxClient implements SandboxClient<
 
   async resume(
     state: UnixLocalSandboxSessionState,
+    options: SandboxClientResumeOptions = {},
   ): Promise<UnixLocalSandboxSession> {
-    const restoredState = await this.restoreIfNeeded(state);
+    const archiveLimits =
+      options.archiveLimits === undefined
+        ? this.options.archiveLimits
+        : options.archiveLimits;
+    const restoredState = await this.restoreIfNeeded(state, archiveLimits);
     return new UnixLocalSandboxSession({
       state: restoredState,
       defaultShell: this.options.defaultShell,
-      archiveLimits: this.options.archiveLimits,
+      archiveLimits,
     });
   }
 
@@ -983,13 +989,18 @@ export class UnixLocalSandboxClient implements SandboxClient<
 
   private async restoreIfNeeded(
     state: UnixLocalSandboxSessionState,
+    archiveLimits?: SandboxArchiveLimits | null,
   ): Promise<UnixLocalSandboxSessionState> {
     if (await pathExists(state.workspaceRootPath)) {
       if (await canReuseLocalSnapshotWorkspace(state)) {
         return state;
       }
       if (await localSnapshotIsRestorable(state)) {
-        return await restoreSnapshotAndMounts(state, state.workspaceRootPath);
+        return await restoreSnapshotAndMounts(
+          state,
+          state.workspaceRootPath,
+          archiveLimits,
+        );
       }
       return state;
     }
@@ -1011,6 +1022,7 @@ export class UnixLocalSandboxClient implements SandboxClient<
         workspaceRootOwned: true,
       },
       workspaceRootPath,
+      archiveLimits,
     );
   }
 }
@@ -1018,10 +1030,12 @@ export class UnixLocalSandboxClient implements SandboxClient<
 async function restoreSnapshotAndMounts(
   state: UnixLocalSandboxSessionState,
   workspaceRootPath: string,
+  archiveLimits?: SandboxArchiveLimits | null,
 ): Promise<UnixLocalSandboxSessionState> {
   const restoredState = await restoreLocalSnapshotToWorkspace(
     state,
     workspaceRootPath,
+    { archiveLimits },
   );
   await materializeLocalWorkspaceManifestMounts(
     restoredState.manifest,

--- a/packages/agents-core/src/sandbox/session.ts
+++ b/packages/agents-core/src/sandbox/session.ts
@@ -1,6 +1,7 @@
 import type { Editor } from '../editor';
 import { UserError } from '../errors';
 import type { ToolOutputImage } from '../tool';
+import type { SandboxArchiveLimits } from './client';
 import type { Entry } from './entries';
 import type { Manifest } from './manifest';
 import type { Snapshot } from './snapshot';
@@ -100,6 +101,10 @@ export type MaterializeEntryArgs = {
 
 export type WorkspaceArchiveData = string | ArrayBuffer | Uint8Array;
 
+export type WorkspaceArchiveOptions = {
+  archiveLimits?: SandboxArchiveLimits | null;
+};
+
 export type SandboxSessionLifecycleOptions = {
   reason?: string;
   [key: string]: unknown;
@@ -194,7 +199,11 @@ export interface SandboxSession<
   materializeEntry?(args: MaterializeEntryArgs): Promise<void>;
   applyManifest?(manifest: Manifest, runAs?: string): Promise<void>;
   persistWorkspace?(): Promise<Uint8Array>;
-  hydrateWorkspace?(data: WorkspaceArchiveData): Promise<void>;
+  hydrateWorkspace?(
+    data: WorkspaceArchiveData,
+    options?: WorkspaceArchiveOptions,
+  ): Promise<void>;
+  setArchiveLimits?(limits?: SandboxArchiveLimits | null): void;
   resolveExposedPort?(port: number): Promise<ExposedPortEndpoint>;
   supportsPty?(): boolean;
   close?(): Promise<void>;

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -2498,6 +2498,11 @@ describe('sandbox runner integration', () => {
 
   it('starts adopted preserved sandbox sessions before agent execution', async () => {
     const client = new StartableFakeSandboxClient();
+    const archiveLimits = {
+      maxInputBytes: 10,
+      maxExtractedBytes: 20,
+      maxMembers: 30,
+    };
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
       model: new RecordingFakeModel([]),
@@ -2534,6 +2539,7 @@ describe('sandbox runner integration', () => {
       startingAgent: sandboxAgent as Agent<unknown, any>,
       sandboxConfig: {
         client,
+        archiveLimits,
       },
       runState: state,
     });
@@ -2550,6 +2556,7 @@ describe('sandbox runner integration', () => {
     expect(client.resumeCalls.map((call) => call.state.sessionId)).toEqual([
       'resumed-session',
     ]);
+    expect(client.resumeCalls[0]?.archiveLimits).toEqual(archiveLimits);
     expect(client.startCalls).toEqual([
       {
         sessionId: 'resumed-session',

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -254,7 +254,10 @@ class FakeSandboxClient implements SandboxClient<
   readonly rawCreateCalls: Array<
     SandboxClientCreateArgs<SandboxClientOptions> | Manifest | undefined
   > = [];
-  readonly resumeCalls: Array<{ state: FakeSandboxSessionState }> = [];
+  readonly resumeCalls: Array<{
+    state: FakeSandboxSessionState;
+    archiveLimits?: SandboxClientCreateArgs['archiveLimits'];
+  }> = [];
   readonly serializedStates: Array<FakeSandboxSessionState> = [];
   readonly serializedOptions: SandboxSessionSerializationOptions[] = [];
   readonly closeCalls: string[] = [];
@@ -296,8 +299,9 @@ class FakeSandboxClient implements SandboxClient<
 
   async resume(
     state: FakeSandboxSessionState,
+    options: { archiveLimits?: SandboxClientCreateArgs['archiveLimits'] } = {},
   ): Promise<SandboxSessionLike<FakeSandboxSessionState>> {
-    this.resumeCalls.push({ state });
+    this.resumeCalls.push({ state, archiveLimits: options.archiveLimits });
     const session = this.makeSession(state);
     this.resumedSessions.push(session);
     return session;
@@ -1473,12 +1477,25 @@ describe('sandbox runner integration', () => {
     const secondResult = await runner.run(sandboxAgent, resumedState, {
       sandbox: {
         client,
+        archiveLimits: {
+          maxInputBytes: 10,
+          maxExtractedBytes: 20,
+          maxMembers: 30,
+        },
       },
     });
 
     expect(secondResult.finalOutput).toBe('turn two');
     expect(client.createCalls).toHaveLength(1);
-    expect(client.resumeCalls).toHaveLength(1);
+    expect(client.resumeCalls).toMatchObject([
+      {
+        archiveLimits: {
+          maxInputBytes: 10,
+          maxExtractedBytes: 20,
+          maxMembers: 30,
+        },
+      },
+    ]);
   });
 
   it('sanitizes manifest data in serialized sandbox state envelopes', async () => {

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -249,6 +249,7 @@ class FakeSandboxClient implements SandboxClient<
     options?: SandboxClientOptions;
     snapshot?: SandboxClientCreateArgs['snapshot'];
     concurrencyLimits?: SandboxClientCreateArgs['concurrencyLimits'];
+    archiveLimits?: SandboxClientCreateArgs['archiveLimits'];
   }> = [];
   readonly rawCreateCalls: Array<
     SandboxClientCreateArgs<SandboxClientOptions> | Manifest | undefined
@@ -276,13 +277,14 @@ class FakeSandboxClient implements SandboxClient<
     manifestOptions?: SandboxClientOptions,
   ): Promise<SandboxSessionLike<FakeSandboxSessionState>> {
     this.rawCreateCalls.push(args);
-    const { manifest, options, snapshot, concurrencyLimits } =
+    const { manifest, options, snapshot, concurrencyLimits, archiveLimits } =
       normalizeSandboxClientCreateArgs(args, manifestOptions);
     this.createCalls.push({
       manifest,
       options,
       snapshot,
       concurrencyLimits,
+      archiveLimits,
     });
     const session = this.makeSession({
       manifest,
@@ -1270,7 +1272,7 @@ describe('sandbox runner integration', () => {
     ]);
   });
 
-  it('passes run-level snapshot and concurrency settings through sandbox client options', async () => {
+  it('passes run-level snapshot and resource settings through sandbox client options', async () => {
     const client = new FakeSandboxClient();
     const sandboxModel = new RecordingFakeModel([
       {
@@ -1294,6 +1296,11 @@ describe('sandbox runner integration', () => {
           manifestEntries: 2,
           localDirFiles: 3,
         },
+        archiveLimits: {
+          maxInputBytes: 4,
+          maxExtractedBytes: 5,
+          maxMembers: 6,
+        },
       },
     });
 
@@ -1304,6 +1311,11 @@ describe('sandbox runner integration', () => {
     expect(client.createCalls[0]?.concurrencyLimits).toMatchObject({
       manifestEntries: 2,
       localDirFiles: 3,
+    });
+    expect(client.createCalls[0]?.archiveLimits).toMatchObject({
+      maxInputBytes: 4,
+      maxExtractedBytes: 5,
+      maxMembers: 6,
     });
   });
 

--- a/packages/agents-core/test/sandboxes/unixLocal.test.ts
+++ b/packages/agents-core/test/sandboxes/unixLocal.test.ts
@@ -739,6 +739,54 @@ describe('UnixLocalSandboxClient', () => {
     await session.close();
   });
 
+  it('rejects local workspace archive hydration over resource limits', async () => {
+    const client = new UnixLocalSandboxClient();
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          'one.txt': {
+            type: 'file',
+            content: '1',
+          },
+          'two.txt': {
+            type: 'file',
+            content: '2',
+          },
+        },
+      }),
+    );
+
+    const archive = await session.persistWorkspace();
+
+    await expect(
+      session.hydrateWorkspace(archive, {
+        archiveLimits: {
+          maxInputBytes: null,
+          maxExtractedBytes: null,
+          maxMembers: 1,
+        },
+      }),
+    ).rejects.toMatchObject({
+      details: {
+        reason: 'archive member count exceeds limit',
+        limit: 1,
+        actual: 2,
+        member: 'two.txt',
+      },
+    });
+    await expect(
+      session.hydrateWorkspace(archive, {
+        archiveLimits: {
+          maxInputBytes: null,
+          maxExtractedBytes: null,
+          maxMembers: 2,
+        },
+      }),
+    ).resolves.toBeUndefined();
+
+    await session.close();
+  });
+
   it('rejects read-only local bind mounts because host symlinks cannot enforce them', async () => {
     const sourceDir = join(rootDir, 'bind-source');
     await mkdir(sourceDir);

--- a/packages/agents-core/test/sandboxes/unixLocal.test.ts
+++ b/packages/agents-core/test/sandboxes/unixLocal.test.ts
@@ -740,7 +740,9 @@ describe('UnixLocalSandboxClient', () => {
   });
 
   it('rejects local workspace archive hydration over resource limits', async () => {
-    const client = new UnixLocalSandboxClient();
+    const client = new UnixLocalSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
     const session = await client.create(
       new Manifest({
         entries: {
@@ -2280,6 +2282,49 @@ void main();
     await expect(
       readFile(join(restored.state.workspaceRootPath, 'skip.txt'), 'utf8'),
     ).rejects.toThrow();
+  });
+
+  it('applies archive limits before restoring remote snapshots', async () => {
+    const store = new InMemoryRemoteSnapshotStore();
+    const client = new UnixLocalSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: {
+        type: 'remote',
+        id: 'remote-snapshot',
+        store,
+      },
+      archiveLimits: {
+        maxInputBytes: null,
+        maxExtractedBytes: 4,
+        maxMembers: null,
+      },
+    });
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          'keep.txt': {
+            type: 'file',
+            content: 'keep\n',
+          },
+        },
+      }),
+    );
+
+    const serialized = JSON.parse(
+      JSON.stringify(await client.serializeSessionState(session.state)),
+    ) as Record<string, unknown>;
+    await rm(session.state.workspaceRootPath, { recursive: true, force: true });
+
+    await expect(
+      client.resume(await client.deserializeSessionState(serialized)),
+    ).rejects.toMatchObject({
+      details: {
+        reason: 'archive extracted size exceeds limit',
+        limit: 4,
+        actual: 5,
+        member: 'keep.txt',
+      },
+    });
   });
 
   it('rejects restoring remote snapshots into a symlinked workspace root', async () => {

--- a/packages/agents-extensions/src/sandbox/blaxel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/blaxel/sandbox.ts
@@ -10,6 +10,7 @@ import {
   type SandboxClient,
   type SandboxClientCreateArgs,
   type SandboxClientOptions,
+  type SandboxArchiveLimits,
   type SandboxConcurrencyLimits,
   type ExposedPortEndpoint,
   type ExecCommandArgs,
@@ -156,6 +157,7 @@ export interface BlaxelSandboxClientOptions extends SandboxClientOptions {
   ttl?: string;
   name?: string;
   pauseOnExit?: boolean;
+  archiveLimits?: SandboxArchiveLimits | null;
 }
 
 export interface BlaxelSandboxSessionState extends SandboxSessionState {
@@ -194,6 +196,7 @@ export class BlaxelSandboxSession extends RemoteSandboxSessionBase<BlaxelSandbox
     apiKey?: string;
     ownsSandbox?: boolean;
     concurrencyLimits?: SandboxConcurrencyLimits;
+    archiveLimits?: SandboxArchiveLimits | null;
   }) {
     super({
       state: args.state,
@@ -201,6 +204,7 @@ export class BlaxelSandboxSession extends RemoteSandboxSessionBase<BlaxelSandbox
         providerName: 'BlaxelSandboxClient',
         providerId: 'blaxel',
         concurrencyLimits: args.concurrencyLimits,
+        archiveLimits: args.archiveLimits,
       },
     });
     this.sandbox = args.sandbox;
@@ -893,6 +897,7 @@ export class BlaxelSandboxClient implements SandboxClient<
           apiKey: resolvedOptions.apiKey ?? loadEnv().BL_API_KEY,
           ownsSandbox,
           concurrencyLimits: createArgs.concurrencyLimits,
+          archiveLimits: createArgs.archiveLimits,
           state: {
             manifest,
             sandboxName,
@@ -1008,6 +1013,7 @@ export class BlaxelSandboxClient implements SandboxClient<
       sandbox,
       apiKey: this.options.apiKey ?? loadEnv().BL_API_KEY,
       ownsSandbox: state.ownsSandbox,
+      archiveLimits: this.options.archiveLimits,
     });
     await session.rehydrateActiveMountPathsFromManifest();
     return session;

--- a/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
@@ -11,6 +11,7 @@ import {
   type SandboxClient,
   type SandboxClientCreateArgs,
   type SandboxClientOptions,
+  type SandboxArchiveLimits,
   type SandboxConcurrencyLimits,
   type ExposedPortEndpoint,
   type ExecCommandArgs,
@@ -23,6 +24,8 @@ import {
   type ViewImageArgs,
   type WriteStdinArgs,
   type WorkspaceArchiveData,
+  type WorkspaceArchiveOptions,
+  validateSandboxArchiveLimits,
 } from '@openai/agents-core/sandbox';
 import {
   assertTarWorkspacePersistence,
@@ -116,6 +119,7 @@ export interface CloudflareSandboxClientOptions extends SandboxClientOptions {
   requestTimeoutMs?: number;
   timeouts?: CloudflareSandboxTimeouts;
   mounts?: Array<Record<string, unknown>>;
+  archiveLimits?: SandboxArchiveLimits | null;
 }
 
 export interface CloudflareSandboxTimeouts {
@@ -141,6 +145,7 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
   private readonly apiKey?: string;
   private readonly ptyProcesses = new PtyProcessRegistry();
   private readonly concurrencyLimits?: SandboxConcurrencyLimits;
+  private archiveLimits?: SandboxArchiveLimits | null;
   private readonly remotePathResolver: RemoteSandboxPathResolver = async (
     path,
     options,
@@ -150,6 +155,7 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
     state: CloudflareSandboxSessionState;
     apiKey?: string;
     concurrencyLimits?: SandboxConcurrencyLimits;
+    archiveLimits?: SandboxArchiveLimits | null;
   }) {
     this.state = {
       ...args.state,
@@ -157,6 +163,12 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
     };
     this.apiKey = args.apiKey;
     this.concurrencyLimits = args.concurrencyLimits;
+    this.setArchiveLimits(args.archiveLimits);
+  }
+
+  setArchiveLimits(limits?: SandboxArchiveLimits | null): void {
+    validateSandboxArchiveLimits(limits);
+    this.archiveLimits = limits;
   }
 
   createEditor(runAs?: string): RemoteSandboxEditor {
@@ -566,11 +578,18 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
     return archive;
   }
 
-  async hydrateWorkspace(data: WorkspaceArchiveData): Promise<void> {
+  async hydrateWorkspace(
+    data: WorkspaceArchiveData,
+    options: WorkspaceArchiveOptions = {},
+  ): Promise<void> {
     assertTarWorkspacePersistence('CloudflareSandboxClient', 'tar');
     const archive = toWorkspaceArchiveBytes(data);
     validateWorkspaceTarArchive(archive, {
       allowExternalSymlinkTargets: false,
+      archiveLimits:
+        options.archiveLimits === undefined
+          ? this.archiveLimits
+          : options.archiveLimits,
     });
     const response = await this.fetch(
       `/v1/sandbox/${this.state.sandboxId}/hydrate`,
@@ -1060,6 +1079,7 @@ export class CloudflareSandboxClient implements SandboxClient<
         const session = new CloudflareSandboxSession({
           apiKey,
           concurrencyLimits: createArgs.concurrencyLimits,
+          archiveLimits: createArgs.archiveLimits,
           state: {
             manifest,
             workerUrl: normalizedWorkerUrl,
@@ -1139,6 +1159,7 @@ export class CloudflareSandboxClient implements SandboxClient<
     assertCloudflareManifestMountsSupported(state.manifest);
 
     const session = new CloudflareSandboxSession({
+      archiveLimits: this.options.archiveLimits,
       state: {
         ...state,
         sandboxId,

--- a/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
@@ -7,6 +7,7 @@ import {
   type SandboxClient,
   type SandboxClientCreateArgs,
   type SandboxClientOptions,
+  type SandboxArchiveLimits,
   type SandboxConcurrencyLimits,
   type ExposedPortEndpoint,
   type ExecCommandArgs,
@@ -19,6 +20,8 @@ import {
   type ViewImageArgs,
   type WriteStdinArgs,
   type WorkspaceArchiveData,
+  type WorkspaceArchiveOptions,
+  validateSandboxArchiveLimits,
 } from '@openai/agents-core/sandbox';
 import {
   appendPtyOutput,
@@ -171,6 +174,7 @@ export interface DaytonaSandboxClientOptions extends SandboxClientOptions {
   apiKey?: string;
   apiUrl?: string;
   target?: string;
+  archiveLimits?: SandboxArchiveLimits | null;
 }
 
 export interface DaytonaSandboxSessionState extends SandboxSessionState {
@@ -202,6 +206,7 @@ export class DaytonaSandboxSession implements SandboxSession<DaytonaSandboxSessi
   ) => await this.resolveRemotePath(path, options);
   private readonly activeMountPaths = new Set<string>();
   private readonly concurrencyLimits?: SandboxConcurrencyLimits;
+  private archiveLimits?: SandboxArchiveLimits | null;
   private stopPromise?: Promise<void>;
   private deletePromise?: Promise<void>;
 
@@ -209,10 +214,17 @@ export class DaytonaSandboxSession implements SandboxSession<DaytonaSandboxSessi
     state: DaytonaSandboxSessionState;
     sandbox: DaytonaSandboxLike;
     concurrencyLimits?: SandboxConcurrencyLimits;
+    archiveLimits?: SandboxArchiveLimits | null;
   }) {
     this.state = args.state;
     this.sandbox = args.sandbox;
     this.concurrencyLimits = args.concurrencyLimits;
+    this.setArchiveLimits(args.archiveLimits);
+  }
+
+  setArchiveLimits(limits?: SandboxArchiveLimits | null): void {
+    validateSandboxArchiveLimits(limits);
+    this.archiveLimits = limits;
   }
 
   createEditor(runAs?: string): RemoteSandboxEditor {
@@ -598,13 +610,20 @@ export class DaytonaSandboxSession implements SandboxSession<DaytonaSandboxSessi
     });
   }
 
-  async hydrateWorkspace(data: WorkspaceArchiveData): Promise<void> {
+  async hydrateWorkspace(
+    data: WorkspaceArchiveData,
+    options: WorkspaceArchiveOptions = {},
+  ): Promise<void> {
     assertTarWorkspacePersistence('DaytonaSandboxClient', 'tar');
     await hydrateRemoteWorkspaceTar({
       providerName: 'DaytonaSandboxClient',
       manifest: this.state.manifest,
       io: this.archiveIo(),
       data,
+      archiveLimits:
+        options.archiveLimits === undefined
+          ? this.archiveLimits
+          : options.archiveLimits,
     });
   }
 
@@ -1073,6 +1092,7 @@ export class DaytonaSandboxClient implements SandboxClient<
         const session = new DaytonaSandboxSession({
           sandbox,
           concurrencyLimits: createArgs.concurrencyLimits,
+          archiveLimits: createArgs.archiveLimits,
           state: {
             manifest: resolvedManifest,
             sandboxId: sandbox.id,
@@ -1167,7 +1187,11 @@ export class DaytonaSandboxClient implements SandboxClient<
       });
       return await this.recreateFromPersistedState(client, state);
     }
-    const session = new DaytonaSandboxSession({ state, sandbox });
+    const session = new DaytonaSandboxSession({
+      state,
+      sandbox,
+      archiveLimits: this.options.archiveLimits,
+    });
     await session.prepareWorkspaceRoot();
     await session.rematerializeMountEntries();
     return session;
@@ -1225,6 +1249,7 @@ export class DaytonaSandboxClient implements SandboxClient<
     const session = new DaytonaSandboxSession({
       sandbox,
       state: nextState,
+      archiveLimits: this.options.archiveLimits,
     });
     try {
       await session.prepareWorkspaceRoot();

--- a/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
@@ -6,6 +6,7 @@ import {
   type SandboxClient,
   type SandboxClientCreateArgs,
   type SandboxClientOptions,
+  type SandboxArchiveLimits,
   type SandboxConcurrencyLimits,
   type ExposedPortEndpoint,
   type ExecCommandArgs,
@@ -15,6 +16,7 @@ import {
   type TypedMount,
   type WriteStdinArgs,
   type WorkspaceArchiveData,
+  type WorkspaceArchiveOptions,
   normalizeSandboxClientCreateArgs,
 } from '@openai/agents-core/sandbox';
 import {
@@ -167,6 +169,7 @@ export interface E2BSandboxClientOptions extends SandboxClientOptions {
   allowInternetAccess?: boolean;
   exposedPorts?: number[];
   workspacePersistence?: E2BWorkspacePersistence;
+  archiveLimits?: SandboxArchiveLimits | null;
   mcp?: Record<string, unknown>;
   pauseOnExit?: boolean;
   env?: Record<string, string>;
@@ -203,6 +206,7 @@ export class E2BSandboxSession extends RemoteSandboxSessionBase<E2BSandboxSessio
     state: E2BSandboxSessionState;
     sandbox: E2BSandboxInstance;
     concurrencyLimits?: SandboxConcurrencyLimits;
+    archiveLimits?: SandboxArchiveLimits | null;
   }) {
     super({
       state: args.state,
@@ -210,6 +214,7 @@ export class E2BSandboxSession extends RemoteSandboxSessionBase<E2BSandboxSessio
         providerName: 'E2BSandboxClient',
         providerId: 'e2b',
         concurrencyLimits: args.concurrencyLimits,
+        archiveLimits: args.archiveLimits,
       },
     });
     this.sandbox = args.sandbox;
@@ -415,7 +420,10 @@ export class E2BSandboxSession extends RemoteSandboxSessionBase<E2BSandboxSessio
     return await this.persistWorkspaceTar();
   }
 
-  async hydrateWorkspace(data: WorkspaceArchiveData): Promise<void> {
+  async hydrateWorkspace(
+    data: WorkspaceArchiveData,
+    options: WorkspaceArchiveOptions = {},
+  ): Promise<void> {
     const snapshotRef = decodeNativeSnapshotRef(data);
     if (snapshotRef?.provider === 'e2b') {
       await this.replaceSandboxFromSnapshot(snapshotRef.snapshotId);
@@ -428,7 +436,7 @@ export class E2BSandboxSession extends RemoteSandboxSessionBase<E2BSandboxSessio
         this.state.workspacePersistence,
       );
     }
-    await this.hydrateWorkspaceTar(data);
+    await this.hydrateWorkspaceTar(data, options);
   }
 
   private async persistWorkspaceViaNativeSnapshot(): Promise<
@@ -881,6 +889,7 @@ export class E2BSandboxClient implements SandboxClient<
         const session = new E2BSandboxSession({
           sandbox,
           concurrencyLimits: createArgs.concurrencyLimits,
+          archiveLimits: createArgs.archiveLimits,
           state: {
             manifest,
             sandboxId: sandbox.sandboxId,
@@ -980,7 +989,11 @@ export class E2BSandboxClient implements SandboxClient<
           state.sandboxId,
           e2bReconnectOptions(state),
         );
-        return new E2BSandboxSession({ state, sandbox });
+        return new E2BSandboxSession({
+          state,
+          sandbox,
+          archiveLimits: this.options.archiveLimits,
+        });
       } catch (error) {
         assertResumeRecreateAllowed(error, {
           providerName: 'E2BSandboxClient',

--- a/packages/agents-extensions/src/sandbox/modal/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/modal/sandbox.ts
@@ -7,6 +7,7 @@ import {
   type SandboxClient,
   type SandboxClientCreateArgs,
   type SandboxClientOptions,
+  type SandboxArchiveLimits,
   type SandboxConcurrencyLimits,
   type ExposedPortEndpoint,
   type ExecCommandArgs,
@@ -21,6 +22,8 @@ import {
   type ViewImageArgs,
   type WriteStdinArgs,
   type WorkspaceArchiveData,
+  type WorkspaceArchiveOptions,
+  validateSandboxArchiveLimits,
 } from '@openai/agents-core/sandbox';
 import {
   normalizePosixPath,
@@ -278,6 +281,7 @@ export interface ModalSandboxClientOptions extends SandboxClientOptions {
   imageBuilderVersion?: string;
   nativeCloudBucketSecretName?: string;
   useSleepCmd?: boolean;
+  archiveLimits?: SandboxArchiveLimits | null;
 }
 
 export interface ModalSandboxSessionState extends SandboxSessionState {
@@ -319,6 +323,7 @@ export class ModalSandboxSession implements SandboxSession<ModalSandboxSessionSt
     options,
   ) => await this.resolveRemotePath(path, options);
   private readonly concurrencyLimits?: SandboxConcurrencyLimits;
+  private archiveLimits?: SandboxArchiveLimits | null;
   private nextProcessId = 1;
 
   constructor(args: {
@@ -330,6 +335,7 @@ export class ModalSandboxSession implements SandboxSession<ModalSandboxSessionSt
     cloudBucketMounts?: Record<string, ModalCloudBucketMountLike>;
     cloudBucketMountsProvider?: ModalCloudBucketMountsProvider;
     concurrencyLimits?: SandboxConcurrencyLimits;
+    archiveLimits?: SandboxArchiveLimits | null;
   }) {
     this.state = args.state;
     this.modal = args.modal;
@@ -340,8 +346,14 @@ export class ModalSandboxSession implements SandboxSession<ModalSandboxSessionSt
     this.cloudBucketMounts = args.cloudBucketMounts;
     this.cloudBucketMountsProvider = args.cloudBucketMountsProvider;
     this.concurrencyLimits = args.concurrencyLimits;
+    this.setArchiveLimits(args.archiveLimits);
     this.cloudBucketMountsResolved =
       args.cloudBucketMounts !== undefined || !args.cloudBucketMountsProvider;
+  }
+
+  setArchiveLimits(limits?: SandboxArchiveLimits | null): void {
+    validateSandboxArchiveLimits(limits);
+    this.archiveLimits = limits;
   }
 
   createEditor(runAs?: string): RemoteSandboxEditor {
@@ -649,7 +661,10 @@ export class ModalSandboxSession implements SandboxSession<ModalSandboxSessionSt
     });
   }
 
-  async hydrateWorkspace(data: WorkspaceArchiveData): Promise<void> {
+  async hydrateWorkspace(
+    data: WorkspaceArchiveData,
+    options: WorkspaceArchiveOptions = {},
+  ): Promise<void> {
     const snapshotRef = decodeNativeSnapshotRef(data);
     if (snapshotRef?.provider === 'modal_snapshot_filesystem') {
       this.assertExpectedSnapshotPersistence(
@@ -679,6 +694,10 @@ export class ModalSandboxSession implements SandboxSession<ModalSandboxSessionSt
       manifest: this.state.manifest,
       io: this.archiveIo(),
       data,
+      archiveLimits:
+        options.archiveLimits === undefined
+          ? this.archiveLimits
+          : options.archiveLimits,
     });
   }
 
@@ -1376,6 +1395,7 @@ export class ModalSandboxClient implements SandboxClient<
           state: sessionState,
           cloudBucketMounts,
           concurrencyLimits: createArgs.concurrencyLimits,
+          archiveLimits: createArgs.archiveLimits,
           cloudBucketMountsProvider: async () =>
             await modalCloudBucketMountsForManifest({
               modalModule,
@@ -1529,6 +1549,7 @@ export class ModalSandboxClient implements SandboxClient<
             state.nativeCloudBucketSecretName ??
             this.options.nativeCloudBucketSecretName,
         }),
+      archiveLimits: this.options.archiveLimits,
     });
   }
 }

--- a/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
@@ -8,11 +8,13 @@ import {
   type SandboxClient,
   type SandboxClientCreateArgs,
   type SandboxClientOptions,
+  type SandboxArchiveLimits,
   type SandboxConcurrencyLimits,
   type Mount,
   type SandboxSessionState,
   type TypedMount,
   type WorkspaceArchiveData,
+  type WorkspaceArchiveOptions,
 } from '@openai/agents-core/sandbox';
 import { posix as pathPosix } from 'node:path';
 import {
@@ -206,6 +208,7 @@ export interface RunloopSandboxClientOptions extends SandboxClientOptions {
   metadata?: Record<string, string>;
   managedSecrets?: Record<string, string>;
   pauseOnExit?: boolean;
+  archiveLimits?: SandboxArchiveLimits | null;
   userParameters?: RunloopUserParameters;
   env?: Record<string, string>;
   apiKey?: string;
@@ -629,6 +632,7 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
     sdk: RunloopClientLike;
     devbox: RunloopDevboxLike;
     concurrencyLimits?: SandboxConcurrencyLimits;
+    archiveLimits?: SandboxArchiveLimits | null;
   }) {
     super({
       state: args.state,
@@ -636,6 +640,7 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
         providerName: 'RunloopSandboxClient',
         providerId: 'runloop',
         concurrencyLimits: args.concurrencyLimits,
+        archiveLimits: args.archiveLimits,
       },
     });
     this.sdk = args.sdk;
@@ -680,7 +685,10 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
     return await this.persistWorkspaceTar();
   }
 
-  async hydrateWorkspace(data: WorkspaceArchiveData): Promise<void> {
+  async hydrateWorkspace(
+    data: WorkspaceArchiveData,
+    options: WorkspaceArchiveOptions = {},
+  ): Promise<void> {
     const snapshotRef = decodeNativeSnapshotRef(data);
     if (snapshotRef?.provider === 'runloop') {
       await this.replaceDevboxFromSnapshot(snapshotRef.snapshotId);
@@ -688,7 +696,7 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
     }
 
     assertTarWorkspacePersistence('RunloopSandboxClient', 'tar');
-    await this.hydrateWorkspaceTar(data);
+    await this.hydrateWorkspaceTar(data, options);
   }
 
   async close(): Promise<void> {
@@ -1419,6 +1427,7 @@ export class RunloopSandboxClient implements SandboxClient<
           sdk,
           devbox,
           concurrencyLimits: createArgs.concurrencyLimits,
+          archiveLimits: createArgs.archiveLimits,
           state: {
             manifest,
             devboxId: devbox.id,
@@ -1536,6 +1545,7 @@ export class RunloopSandboxClient implements SandboxClient<
         state: resumeState,
         sdk,
         devbox,
+        archiveLimits: this.options.archiveLimits,
       });
       try {
         await session.ensureCurrentManifestRoot();

--- a/packages/agents-extensions/src/sandbox/shared/archive.ts
+++ b/packages/agents-extensions/src/sandbox/shared/archive.ts
@@ -2,6 +2,9 @@ import {
   Manifest,
   SandboxArchiveError,
   SandboxUnsupportedFeatureError,
+  resolveSandboxArchiveLimits,
+  type ResolvedSandboxArchiveLimits,
+  type SandboxArchiveLimits,
   type WorkspaceArchiveData,
 } from '@openai/agents-core/sandbox';
 import { shellQuote, validateRemoteSandboxPathForManifest } from './paths';
@@ -27,6 +30,7 @@ export type WorkspaceTarValidationOptions = {
   rejectSymlinkRelPaths?: Iterable<string>;
   skipRelPaths?: Iterable<string>;
   rootName?: string;
+  archiveLimits?: SandboxArchiveLimits | null;
 };
 
 export function assertTarWorkspacePersistence(
@@ -126,10 +130,14 @@ export async function hydrateRemoteWorkspaceTar(args: {
   io: RemoteWorkspaceTarIo;
   data: WorkspaceArchiveData;
   archivePath?: string;
+  archiveLimits?: SandboxArchiveLimits | null;
 }): Promise<void> {
   const root = args.manifest.root;
   const archive = toWorkspaceArchiveBytes(args.data);
-  validateWorkspaceTarArchive(archive, { allowSymlinks: false });
+  validateWorkspaceTarArchive(archive, {
+    allowSymlinks: false,
+    archiveLimits: args.archiveLimits,
+  });
 
   const archivePath = args.archivePath ?? remoteArchivePath(args.providerName);
   assertRemoteWorkspaceTarRoot(args.providerName, root, archivePath, 'hydrate');
@@ -206,9 +214,12 @@ export function validateWorkspaceTarArchive(
   options: WorkspaceTarValidationOptions = {},
 ): void {
   const bytes = toWorkspaceArchiveBytes(data);
+  const archiveLimits = resolveSandboxArchiveLimits(options.archiveLimits);
+  checkArchiveInputBytes(bytes.byteLength, archiveLimits);
   const membersByPath = new Map<string, TarMember>();
   const symlinkPaths = new Set<string>();
   const members: TarMember[] = [];
+  let extractedBytes = 0;
   let pendingLongName: string | undefined;
   let pendingPax: Record<string, string> | undefined;
 
@@ -267,6 +278,11 @@ export function validateWorkspaceTarArchive(
       const member = validateTarMember(name, rawType, options, linkName);
       if (!member) {
         continue;
+      }
+      checkArchiveMemberCount(members.length + 1, name, archiveLimits);
+      if (member.type === 'file') {
+        extractedBytes += size;
+        checkArchiveExtractedBytes(extractedBytes, name, archiveLimits);
       }
 
       const previous = membersByPath.get(member.path);
@@ -404,6 +420,66 @@ function validateSymlinkTarget(
     return;
   }
   throw tarError(name, `symlink target escapes archive root: ${linkName}`);
+}
+
+function checkArchiveInputBytes(
+  actual: number,
+  limits: ResolvedSandboxArchiveLimits | null,
+): void {
+  const limit = limits?.maxInputBytes;
+  if (limit != null && actual > limit) {
+    throw archiveResourceLimitError(
+      'archive input size exceeds limit',
+      limit,
+      actual,
+    );
+  }
+}
+
+function checkArchiveMemberCount(
+  actual: number,
+  member: string,
+  limits: ResolvedSandboxArchiveLimits | null,
+): void {
+  const limit = limits?.maxMembers;
+  if (limit != null && actual > limit) {
+    throw archiveResourceLimitError(
+      'archive member count exceeds limit',
+      limit,
+      actual,
+      member,
+    );
+  }
+}
+
+function checkArchiveExtractedBytes(
+  actual: number,
+  member: string,
+  limits: ResolvedSandboxArchiveLimits | null,
+): void {
+  const limit = limits?.maxExtractedBytes;
+  if (limit != null && actual > limit) {
+    throw archiveResourceLimitError(
+      'archive extracted size exceeds limit',
+      limit,
+      actual,
+      member,
+    );
+  }
+}
+
+function archiveResourceLimitError(
+  reason: string,
+  limit: number,
+  actual: number,
+  member?: string,
+): SandboxArchiveError {
+  return new SandboxArchiveError(`Workspace ${reason}.`, {
+    reason,
+    limit,
+    actual,
+    ...(member !== undefined ? { member } : {}),
+  });
 }
 
 function safeTarMemberRelPath(name: string): string | null {

--- a/packages/agents-extensions/src/sandbox/shared/sessionBase.ts
+++ b/packages/agents-extensions/src/sandbox/shared/sessionBase.ts
@@ -6,6 +6,7 @@ import {
   type Manifest,
   type MaterializeEntryArgs,
   type ReadFileArgs,
+  type SandboxArchiveLimits,
   type SandboxConcurrencyLimits,
   SandboxProviderError,
   type SandboxSession,
@@ -13,6 +14,8 @@ import {
   SandboxUnsupportedFeatureError,
   type ViewImageArgs,
   type WorkspaceArchiveData,
+  type WorkspaceArchiveOptions,
+  validateSandboxArchiveLimits,
 } from '@openai/agents-core/sandbox';
 import { randomUUID } from 'node:crypto';
 import {
@@ -80,6 +83,7 @@ export type RemoteSandboxSessionBaseOptions = {
   providerName: string;
   providerId: string;
   concurrencyLimits?: SandboxConcurrencyLimits;
+  archiveLimits?: SandboxArchiveLimits | null;
 };
 
 export abstract class RemoteSandboxSessionBase<
@@ -89,6 +93,7 @@ export abstract class RemoteSandboxSessionBase<
   protected readonly providerName: string;
   protected readonly providerId: string;
   private readonly concurrencyLimits?: SandboxConcurrencyLimits;
+  private archiveLimits?: SandboxArchiveLimits | null;
   protected readonly remotePathResolver: RemoteSandboxPathResolver = async (
     path,
     options,
@@ -102,6 +107,16 @@ export abstract class RemoteSandboxSessionBase<
     this.providerName = args.options.providerName;
     this.providerId = args.options.providerId;
     this.concurrencyLimits = args.options.concurrencyLimits;
+    this.setArchiveLimits(args.options.archiveLimits);
+  }
+
+  setArchiveLimits(limits?: SandboxArchiveLimits | null): void {
+    validateSandboxArchiveLimits(limits);
+    this.archiveLimits = limits;
+  }
+
+  protected getArchiveLimits(): SandboxArchiveLimits | null | undefined {
+    return this.archiveLimits;
   }
 
   createEditor(runAs?: string): RemoteSandboxEditor {
@@ -280,12 +295,15 @@ export abstract class RemoteSandboxSessionBase<
     return await this.persistWorkspaceTar();
   }
 
-  async hydrateWorkspace(data: WorkspaceArchiveData): Promise<void> {
+  async hydrateWorkspace(
+    data: WorkspaceArchiveData,
+    options: WorkspaceArchiveOptions = {},
+  ): Promise<void> {
     assertTarWorkspacePersistence(
       this.providerName,
       this.workspacePersistence(),
     );
-    await this.hydrateWorkspaceTar(data);
+    await this.hydrateWorkspaceTar(data, options);
   }
 
   protected abstract runRemoteCommand(
@@ -432,12 +450,17 @@ export abstract class RemoteSandboxSessionBase<
 
   protected async hydrateWorkspaceTar(
     data: WorkspaceArchiveData,
+    options: WorkspaceArchiveOptions = {},
   ): Promise<void> {
     await hydrateRemoteWorkspaceTar({
       providerName: this.providerName,
       manifest: this.state.manifest,
       io: this.archiveIo(),
       data,
+      archiveLimits:
+        options.archiveLimits === undefined
+          ? this.archiveLimits
+          : options.archiveLimits,
     });
   }
 

--- a/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
@@ -14,10 +14,12 @@ import {
   type SandboxClient,
   type SandboxClientCreateArgs,
   type SandboxClientOptions,
+  type SandboxArchiveLimits,
   type SandboxConcurrencyLimits,
   type SandboxSessionSerializationOptions,
   type SandboxSessionState,
   type WorkspaceArchiveData,
+  type WorkspaceArchiveOptions,
 } from '@openai/agents-core/sandbox';
 import {
   assertCoreSnapshotUnsupported,
@@ -146,6 +148,7 @@ export interface VercelSandboxClientOptions extends SandboxClientOptions {
   networkPolicy?: Record<string, unknown>;
   timeoutMs?: number;
   workspacePersistence?: VercelWorkspacePersistence;
+  archiveLimits?: SandboxArchiveLimits | null;
   snapshotExpirationMs?: number;
   env?: Record<string, string>;
 }
@@ -188,6 +191,7 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
       'projectId' | 'teamId' | 'token'
     >;
     concurrencyLimits?: SandboxConcurrencyLimits;
+    archiveLimits?: SandboxArchiveLimits | null;
   }) {
     super({
       state: args.state,
@@ -195,6 +199,7 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
         providerName: 'VercelSandboxClient',
         providerId: 'vercel',
         concurrencyLimits: args.concurrencyLimits,
+        archiveLimits: args.archiveLimits,
       },
     });
     this.sandbox = args.sandbox;
@@ -313,7 +318,10 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
     return await this.persistWorkspaceTar();
   }
 
-  async hydrateWorkspace(data: WorkspaceArchiveData): Promise<void> {
+  async hydrateWorkspace(
+    data: WorkspaceArchiveData,
+    options: WorkspaceArchiveOptions = {},
+  ): Promise<void> {
     this.markWorkspaceMutated();
     const snapshotRef =
       this.state.workspacePersistence === 'snapshot'
@@ -324,7 +332,7 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
       return;
     }
 
-    await this.hydrateWorkspaceTar(data);
+    await this.hydrateWorkspaceTar(data, options);
     this.resetKnownDirs();
     this.knownDirs.add(this.state.manifest.root);
   }
@@ -505,6 +513,7 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
     const replacementSession = new VercelSandboxSession({
       credentials: { ...this.credentials, ...credentials },
       sandbox,
+      archiveLimits: this.getArchiveLimits(),
       state: {
         ...this.state,
         sandboxId: sandbox.sandboxId,
@@ -774,6 +783,7 @@ export class VercelSandboxClient implements SandboxClient<
           sandbox,
           credentials: { ...resolvedOptions, ...credentials },
           concurrencyLimits: createArgs.concurrencyLimits,
+          archiveLimits: createArgs.archiveLimits,
           state: {
             manifest: resolvedManifest,
             sandboxId: sandbox.sandboxId,
@@ -940,6 +950,7 @@ export class VercelSandboxClient implements SandboxClient<
 
     const session = new VercelSandboxSession({
       credentials,
+      archiveLimits: this.options.archiveLimits,
       state: resumeFromSnapshot
         ? {
             ...state,

--- a/packages/agents-extensions/test/sandbox/shared.test.ts
+++ b/packages/agents-extensions/test/sandbox/shared.test.ts
@@ -1350,6 +1350,50 @@ describe('remote sandbox path helpers', () => {
     ).not.toThrow();
   });
 
+  test('rejects workspace tar archives over resource limits', () => {
+    const archive = makeTarArchive([
+      { name: 'one.txt', content: '1' },
+      { name: 'two.txt', content: '22' },
+    ]);
+
+    expect(() =>
+      validateWorkspaceTarArchive(archive, {
+        archiveLimits: {
+          maxInputBytes: 4,
+          maxExtractedBytes: null,
+          maxMembers: null,
+        },
+      }),
+    ).toThrow(SandboxArchiveError);
+    expect(() =>
+      validateWorkspaceTarArchive(archive, {
+        archiveLimits: {
+          maxInputBytes: null,
+          maxExtractedBytes: 2,
+          maxMembers: null,
+        },
+      }),
+    ).toThrow(/archive extracted size exceeds limit/);
+    expect(() =>
+      validateWorkspaceTarArchive(archive, {
+        archiveLimits: {
+          maxInputBytes: null,
+          maxExtractedBytes: null,
+          maxMembers: 1,
+        },
+      }),
+    ).toThrow(/archive member count exceeds limit/);
+    expect(() =>
+      validateWorkspaceTarArchive(archive, {
+        archiveLimits: {
+          maxInputBytes: null,
+          maxExtractedBytes: null,
+          maxMembers: null,
+        },
+      }),
+    ).not.toThrow();
+  });
+
   test('rejects symbolic links before hydrating tar archives', async () => {
     const writeFile = vi.fn();
 


### PR DESCRIPTION
This pull request fixes a sandbox archive extraction resource-risk by adding configurable `archiveLimits` across core sandbox run config, local sandbox restore paths, and extension-backed remote tar hydration.

It preserves existing behavior when `archiveLimits` is omitted, enables SDK default thresholds when the option is provided, and supports per-limit `null` values to disable input-size, extracted-byte, or member-count checks selectively. The change also adds regression coverage for run-config propagation, local workspace archive hydration limits, remote tar validation, and includes a patch changeset for `@openai/agents-core` and `@openai/agents-extensions`.

see also: https://github.com/openai/openai-agents-python/pull/3278
