### PR TITLE
fix: include Cloudflare sandbox exec and cleanup error details

### DIFF
--- a/.changeset/explain-cloudflare-sandbox-errors.md
+++ b/.changeset/explain-cloudflare-sandbox-errors.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: include Cloudflare sandbox exec and cleanup error details

--- a/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
@@ -629,9 +629,13 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
           },
         );
         if (!response.ok && response.status !== 404) {
-          throw cloudflareProviderHttpError('delete sandbox', response, {
-            sandboxId: this.state.sandboxId,
-          });
+          throw await cloudflareProviderHttpErrorWithBody(
+            'delete sandbox',
+            response,
+            {
+              sandboxId: this.state.sandboxId,
+            },
+          );
         }
       },
     );
@@ -723,9 +727,13 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
       },
     );
     if (!response.ok) {
-      throw cloudflareProviderHttpError('execute command', response, {
-        sandboxId: this.state.sandboxId,
-      });
+      throw await cloudflareProviderHttpErrorWithBody(
+        'execute command',
+        response,
+        {
+          sandboxId: this.state.sandboxId,
+        },
+      );
     }
     if (!response.body) {
       throw new SandboxProviderError(
@@ -742,6 +750,7 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
     const decoder = new TextDecoder();
     const reader = response.body.getReader();
     let buffer = '';
+    let rawStream = '';
     let stdout = '';
     let stderr = '';
     let exitCode: number | undefined;
@@ -785,7 +794,9 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
       if (chunk.done) {
         break;
       }
-      buffer += decoder.decode(chunk.value, { stream: true });
+      const text = decoder.decode(chunk.value, { stream: true });
+      rawStream += text;
+      buffer += text;
       const { events, remaining } = splitCompleteSseEvents(buffer);
       buffer = remaining;
       for (const part of events) {
@@ -796,7 +807,9 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
         processEvent(event);
       }
     }
-    buffer += decoder.decode();
+    const tail = decoder.decode();
+    rawStream += tail;
+    buffer += tail;
     for (const part of collectSseEvents(buffer)) {
       const event = parseSseEvent(part);
       if (event) {
@@ -804,11 +817,27 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
       }
     }
 
+    const output = [stdout.trimEnd(), stderr.trimEnd()]
+      .filter((value) => value.length > 0)
+      .join('\n');
+    if (exitCode === undefined && output.length === 0) {
+      const cause = formatCloudflareResponseBody(rawStream);
+      if (cause) {
+        throw new SandboxProviderError(
+          'CloudflareSandboxClient failed to execute command.',
+          {
+            provider: 'cloudflare',
+            operation: 'execute command',
+            sandboxId: this.state.sandboxId,
+            cause,
+          },
+        );
+      }
+    }
+
     return {
       exitCode: exitCode ?? 1,
-      output: [stdout.trimEnd(), stderr.trimEnd()]
-        .filter((value) => value.length > 0)
-        .join('\n'),
+      output,
     };
   }
 
@@ -1385,6 +1414,59 @@ function cloudflareProviderHttpError(
       ...context,
     },
   );
+}
+
+async function cloudflareProviderHttpErrorWithBody(
+  operation: string,
+  response: Response,
+  context: Record<string, unknown> = {},
+): Promise<SandboxProviderError> {
+  const cause = await readCloudflareErrorBody(response);
+  return new SandboxProviderError(
+    `CloudflareSandboxClient failed to ${operation}.`,
+    {
+      provider: 'cloudflare',
+      operation,
+      status: response.status,
+      ...context,
+      ...(cause ? { cause } : {}),
+    },
+  );
+}
+
+async function readCloudflareErrorBody(
+  response: Response,
+): Promise<string | undefined> {
+  try {
+    return formatCloudflareResponseBody(await response.text());
+  } catch (error) {
+    return `failed to read error body: ${
+      error instanceof Error ? error.message : String(error)
+    }`;
+  }
+}
+
+function formatCloudflareResponseBody(body: string): string | undefined {
+  const trimmed = body.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    const payload = JSON.parse(trimmed) as unknown;
+    if (isRecord(payload)) {
+      const error = payload.error;
+      const code = payload.code;
+      if (typeof error === 'string' && typeof code === 'string') {
+        return `${code}: ${error}`;
+      }
+      if (typeof error === 'string') {
+        return error;
+      }
+    }
+  } catch {
+    // Not a JSON error response.
+  }
+  return trimmed;
 }
 
 function waitForCloudflarePtyReady(socket: PtyWebSocket): Promise<void> {

--- a/packages/agents-extensions/src/sandbox/shared/session.ts
+++ b/packages/agents-extensions/src/sandbox/shared/session.ts
@@ -134,7 +134,19 @@ export function assertResumeRecreateAllowed(
 }
 
 function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+  const message = error instanceof Error ? error.message : String(error);
+  if (error instanceof SandboxProviderError && error.details) {
+    return `${message} Details: ${formatErrorDetails(error.details)}`;
+  }
+  return message;
+}
+
+function formatErrorDetails(details: Record<string, unknown>): string {
+  try {
+    return JSON.stringify(details);
+  } catch {
+    return String(details);
+  }
 }
 
 function isNotFoundErrorRecord(error: unknown, seen: Set<object>): boolean {

--- a/packages/agents-extensions/test/sandbox/cloudflare.test.ts
+++ b/packages/agents-extensions/test/sandbox/cloudflare.test.ts
@@ -542,6 +542,22 @@ describe('CloudflareSandboxClient', () => {
       },
     });
 
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse({
+        error: 'pool error: Failed to start container',
+        code: 'pool_error',
+      }),
+    );
+    await expect(session.execCommand({ cmd: 'ls' })).rejects.toMatchObject({
+      code: 'provider_error',
+      details: {
+        provider: 'cloudflare',
+        operation: 'execute command',
+        sandboxId: 'cf_test',
+        cause: 'pool_error: pool error: Failed to start container',
+      },
+    });
+
     vi.mocked(global.fetch)
       .mockResolvedValueOnce(
         sseExecResponse([
@@ -566,17 +582,72 @@ describe('CloudflareSandboxClient', () => {
     });
 
     vi.mocked(global.fetch).mockResolvedValueOnce(
-      new Response('delete failed', { status: 500 }),
+      jsonResponse(
+        {
+          error: 'pool error: Failed to start container',
+          code: 'pool_error',
+        },
+        502,
+      ),
     );
     await expect(session.delete()).rejects.toMatchObject({
       code: 'provider_error',
       details: {
         provider: 'cloudflare',
         operation: 'delete sandbox',
-        status: 500,
+        status: 502,
         sandboxId: 'cf_test',
+        cause: 'pool_error: pool error: Failed to start container',
       },
     });
+  });
+
+  test('keeps Cloudflare exec and cleanup details when manifest apply fails', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+    vi.mocked(global.fetch).mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+
+      if (url.endsWith('/v1/sandbox') && method === 'POST') {
+        return jsonResponse({ id: 'cf_test' });
+      }
+
+      if (url.includes('/exec') && method === 'POST') {
+        return jsonResponse({
+          error: 'pool error: Failed to start container',
+          code: 'pool_error',
+        });
+      }
+
+      if (url.includes('/v1/sandbox/cf_test') && method === 'DELETE') {
+        return jsonResponse(
+          {
+            error: 'pool error: Failed to start container',
+            code: 'pool_error',
+          },
+          502,
+        );
+      }
+
+      return new Response(null, { status: 404 });
+    });
+
+    await expect(
+      client.create(
+        new Manifest({
+          entries: {
+            'README.md': {
+              type: 'file',
+              content: '# Hello\n',
+            },
+          },
+        }),
+      ),
+    ).rejects.toThrow(
+      /Manifest error: CloudflareSandboxClient failed to execute command\. Details: .*"cause":"pool_error: pool error: Failed to start container".*Close error: CloudflareSandboxClient failed to delete sandbox\. Details: .*"status":502.*"cause":"pool_error: pool error: Failed to start container"/u,
+    );
   });
 
   test('rejects non-workspace roots when applying manifests to sessions', async () => {


### PR DESCRIPTION
This pull request fixes Cloudflare sandbox diagnostics so provider-side `/exec` and cleanup failures expose the actual response details instead of collapsing into generic command/delete errors.

It updates `packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts` and `packages/agents-extensions/src/sandbox/shared/session.ts` to include HTTP status and parsed response-body causes for Cloudflare sandbox failures, including non-SSE JSON error bodies returned from `/exec`. It also adds regression coverage in `packages/agents-extensions/test/sandbox/cloudflare.test.ts` for pool startup failures and manifest-apply cleanup errors.