### PR TITLE
fix: include structured sandbox provider error details

### DIFF
--- a/.changeset/informative-provider-errors.md
+++ b/.changeset/informative-provider-errors.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: include structured sandbox provider error details

--- a/packages/agents-extensions/src/sandbox/blaxel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/blaxel/sandbox.ts
@@ -37,6 +37,7 @@ import {
   openPtyWebSocket,
   parseExposedPortEndpoint,
   posixDirname,
+  providerErrorMessage,
   resolveSandboxWorkdir,
   serializeRemoteSandboxSessionState,
   shellQuote,
@@ -347,7 +348,7 @@ export class BlaxelSandboxSession extends RemoteSandboxSessionBase<BlaxelSandbox
         {
           provider: 'blaxel',
           port: requestedPort,
-          cause: error instanceof Error ? error.message : String(error),
+          cause: providerErrorMessage(error),
         },
       );
     }
@@ -554,7 +555,7 @@ export class BlaxelSandboxSession extends RemoteSandboxSessionBase<BlaxelSandbox
           {
             provider: 'blaxel',
             mountPath,
-            cause: unknownErrorMessage(error),
+            cause: providerErrorMessage(error),
           },
         );
       }
@@ -573,7 +574,7 @@ export class BlaxelSandboxSession extends RemoteSandboxSessionBase<BlaxelSandbox
           {
             provider: 'blaxel',
             mountPath,
-            cause: unknownErrorMessage(error),
+            cause: providerErrorMessage(error),
           },
         );
       }
@@ -863,7 +864,7 @@ export class BlaxelSandboxClient implements SandboxClient<
               await sandbox.delete();
             } catch (deleteError) {
               throw new UserError(
-                `Failed to materialize a Blaxel sandbox environment and delete the sandbox. Environment error: ${unknownErrorMessage(error)} Delete error: ${unknownErrorMessage(deleteError)}`,
+                `Failed to materialize a Blaxel sandbox environment and delete the sandbox. Environment error: ${providerErrorMessage(error)} Delete error: ${providerErrorMessage(deleteError)}`,
               );
             }
           }
@@ -882,7 +883,7 @@ export class BlaxelSandboxClient implements SandboxClient<
               await sandbox.delete();
             } catch (deleteError) {
               throw new UserError(
-                `Failed to verify a Blaxel sandbox identity and delete the sandbox. Identity error: ${unknownErrorMessage(error)} Delete error: ${unknownErrorMessage(deleteError)}`,
+                `Failed to verify a Blaxel sandbox identity and delete the sandbox. Identity error: ${providerErrorMessage(error)} Delete error: ${providerErrorMessage(deleteError)}`,
               );
             }
             throw error;
@@ -1187,7 +1188,7 @@ async function canonicalizeBlaxelSandboxIdentitySource(args: {
     return await args.SandboxInstance.get(args.sandboxName);
   } catch (error) {
     throw new UserError(
-      `Blaxel sandbox ${args.sandboxName} cannot be safely preserved because its identity could not be verified after create. ${unknownErrorMessage(error)}`,
+      `Blaxel sandbox ${args.sandboxName} cannot be safely preserved because its identity could not be verified after create. ${providerErrorMessage(error)}`,
     );
   }
 }
@@ -1265,7 +1266,7 @@ function isBlaxelSandboxAlreadyExistsError(error: unknown): boolean {
     }
   }
   return /\b(409|already exists|SANDBOX_ALREADY_EXISTS)\b/iu.test(
-    unknownErrorMessage(error),
+    providerErrorMessage(error),
   );
 }
 
@@ -1387,15 +1388,11 @@ function adaptBlaxelDriveApi(drives: unknown): BlaxelDriveApi | undefined {
   };
 }
 
-function unknownErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
 function blaxelReadError(path: string, error: unknown): Error {
   if (error instanceof SandboxProviderError) {
     return error;
   }
-  const cause = unknownErrorMessage(error);
+  const cause = providerErrorMessage(error);
   const details = { provider: 'blaxel', path, cause };
   if (isBlaxelReadNotFoundError(cause)) {
     return new SandboxWorkspaceReadNotFoundError(
@@ -1652,7 +1649,7 @@ async function createBlaxelPreviewTokenQuery(
       {
         provider: 'blaxel',
         port,
-        cause: error instanceof Error ? error.message : String(error),
+        cause: providerErrorMessage(error),
       },
     );
   }

--- a/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
@@ -399,9 +399,13 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
       return false;
     }
     if (!response.ok) {
-      throw cloudflareProviderHttpError('check running state', response, {
-        sandboxId: this.state.sandboxId,
-      });
+      throw await cloudflareProviderHttpErrorWithBody(
+        'check running state',
+        response,
+        {
+          sandboxId: this.state.sandboxId,
+        },
+      );
     }
     const payload = (await response.json().catch(() => ({}))) as {
       running?: unknown;
@@ -795,8 +799,8 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
         break;
       }
       const text = decoder.decode(chunk.value, { stream: true });
-      rawStream += text;
       buffer += text;
+      rawStream += text;
       const { events, remaining } = splitCompleteSseEvents(buffer);
       buffer = remaining;
       for (const part of events) {
@@ -807,14 +811,25 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
         processEvent(event);
       }
     }
-    const tail = decoder.decode();
-    rawStream += tail;
-    buffer += tail;
+    const finalText = decoder.decode();
+    buffer += finalText;
+    rawStream += finalText;
     for (const part of collectSseEvents(buffer)) {
       const event = parseSseEvent(part);
       if (event) {
         processEvent(event);
       }
+    }
+    if (exitCode === undefined && !stdout && !stderr && rawStream.trim()) {
+      throw new SandboxProviderError(
+        'CloudflareSandboxClient failed to execute command.',
+        {
+          provider: 'cloudflare',
+          operation: 'execute command',
+          sandboxId: this.state.sandboxId,
+          cause: formatCloudflareResponseBody(rawStream),
+        },
+      );
     }
 
     const output = [stdout.trimEnd(), stderr.trimEnd()]
@@ -874,7 +889,7 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
       );
     }
     if (!response.ok) {
-      throw cloudflareProviderHttpError('read file', response, {
+      throw await cloudflareProviderHttpErrorWithBody('read file', response, {
         sandboxId: this.state.sandboxId,
         path,
       });
@@ -895,7 +910,7 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
       },
     );
     if (!response.ok) {
-      throw cloudflareProviderHttpError('write file', response, {
+      throw await cloudflareProviderHttpErrorWithBody('write file', response, {
         sandboxId: this.state.sandboxId,
         path,
       });
@@ -1089,9 +1104,13 @@ export class CloudflareSandboxClient implements SandboxClient<
           { workerUrl: normalizedWorkerUrl },
         );
         if (!response.ok) {
-          throw cloudflareProviderHttpError('create sandbox', response, {
-            workerUrl: normalizedWorkerUrl,
-          });
+          throw await cloudflareProviderHttpErrorWithBody(
+            'create sandbox',
+            response,
+            {
+              workerUrl: normalizedWorkerUrl,
+            },
+          );
         }
         const payload = await withProviderError(
           'CloudflareSandboxClient',
@@ -1400,22 +1419,6 @@ async function cloudflareMountError(args: {
   });
 }
 
-function cloudflareProviderHttpError(
-  operation: string,
-  response: Response,
-  context: Record<string, unknown> = {},
-): SandboxProviderError {
-  return new SandboxProviderError(
-    `CloudflareSandboxClient failed to ${operation}.`,
-    {
-      provider: 'cloudflare',
-      operation,
-      status: response.status,
-      ...context,
-    },
-  );
-}
-
 async function cloudflareProviderHttpErrorWithBody(
   operation: string,
   response: Response,
@@ -1423,7 +1426,7 @@ async function cloudflareProviderHttpErrorWithBody(
 ): Promise<SandboxProviderError> {
   const cause = await readCloudflareErrorBody(response);
   return new SandboxProviderError(
-    `CloudflareSandboxClient failed to ${operation}.`,
+    `CloudflareSandboxClient failed to ${operation}${cause ? `: ${cause}` : ''}`,
     {
       provider: 'cloudflare',
       operation,
@@ -1437,19 +1440,20 @@ async function cloudflareProviderHttpErrorWithBody(
 async function readCloudflareErrorBody(
   response: Response,
 ): Promise<string | undefined> {
-  try {
-    return formatCloudflareResponseBody(await response.text());
-  } catch (error) {
-    return `failed to read error body: ${
-      error instanceof Error ? error.message : String(error)
-    }`;
+  const body = await response.text().catch(() => '');
+  const formatted = formatCloudflareResponseBody(body);
+  if (formatted && formatted !== 'Not a JSON error response.') {
+    return formatted;
   }
+  return body.trim()
+    ? `HTTP ${response.status}: ${truncateCloudflareErrorBody(body.trim())}`
+    : `HTTP ${response.status}`;
 }
 
-function formatCloudflareResponseBody(body: string): string | undefined {
+function formatCloudflareResponseBody(body: string): string {
   const trimmed = body.trim();
   if (!trimmed) {
-    return undefined;
+    return '';
   }
   try {
     const payload = JSON.parse(trimmed) as unknown;
@@ -1464,9 +1468,13 @@ function formatCloudflareResponseBody(body: string): string | undefined {
       }
     }
   } catch {
-    // Not a JSON error response.
+    // Fall through to raw text.
   }
-  return trimmed;
+  return truncateCloudflareErrorBody(trimmed);
+}
+
+function truncateCloudflareErrorBody(body: string): string {
+  return body.length > 500 ? `${body.slice(0, 497)}...` : body;
 }
 
 function waitForCloudflarePtyReady(socket: PtyWebSocket): Promise<void> {

--- a/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
@@ -34,6 +34,7 @@ import {
   encodeNativeSnapshotRef,
   materializeEnvironment,
   parseExposedPortEndpoint,
+  providerErrorMessage,
   shellQuote,
   shellCommandForPty,
   serializeRemoteSandboxSessionState,
@@ -358,7 +359,7 @@ export class E2BSandboxSession extends RemoteSandboxSessionBase<E2BSandboxSessio
         {
           provider: 'e2b',
           port: requestedPort,
-          cause: error instanceof Error ? error.message : String(error),
+          cause: providerErrorMessage(error),
         },
       );
     }
@@ -458,7 +459,7 @@ export class E2BSandboxSession extends RemoteSandboxSessionBase<E2BSandboxSessio
         {
           provider: 'e2b',
           sandboxId: this.state.sandboxId,
-          cause: error instanceof Error ? error.message : String(error),
+          cause: providerErrorMessage(error),
         },
       );
     }
@@ -502,7 +503,7 @@ export class E2BSandboxSession extends RemoteSandboxSessionBase<E2BSandboxSessio
         {
           provider: 'e2b',
           snapshotId,
-          cause: error instanceof Error ? error.message : String(error),
+          cause: providerErrorMessage(error),
         },
       );
     }
@@ -519,7 +520,7 @@ export class E2BSandboxSession extends RemoteSandboxSessionBase<E2BSandboxSessio
           sandboxId: previousSandbox.sandboxId,
           replacementSandboxId: sandbox.sandboxId,
           snapshotId,
-          cause: error instanceof Error ? error.message : String(error),
+          cause: providerErrorMessage(error),
         },
       );
     }
@@ -612,14 +613,8 @@ export class E2BSandboxSession extends RemoteSandboxSessionBase<E2BSandboxSessio
             provider: 'e2b',
             operation,
             sandboxId: this.state.sandboxId,
-            pauseCause:
-              pauseError instanceof Error
-                ? pauseError.message
-                : String(pauseError),
-            killCause:
-              killError instanceof Error
-                ? killError.message
-                : String(killError),
+            pauseCause: providerErrorMessage(pauseError),
+            killCause: providerErrorMessage(killError),
           },
         );
       }

--- a/packages/agents-extensions/src/sandbox/modal/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/modal/sandbox.ts
@@ -49,6 +49,7 @@ import {
   manifestMaterializationOptionsWithRunAs,
   materializeEnvironment,
   persistRemoteWorkspaceTar,
+  providerErrorMessage,
   assertConfiguredExposedPort,
   getCachedExposedPortEndpoint,
   recordResolvedExposedPortEndpoint,
@@ -566,7 +567,7 @@ export class ModalSandboxSession implements SandboxSession<ModalSandboxSessionSt
         {
           provider: 'modal',
           port: requestedPort,
-          cause: error instanceof Error ? error.message : String(error),
+          cause: providerErrorMessage(error),
         },
       );
     }
@@ -835,7 +836,9 @@ export class ModalSandboxSession implements SandboxSession<ModalSandboxSessionSt
         try {
           await sandbox.terminate();
         } catch (replacementTerminateError) {
-          replacementTerminateCause = errorMessage(replacementTerminateError);
+          replacementTerminateCause = providerErrorMessage(
+            replacementTerminateError,
+          );
         }
         throw new SandboxProviderError(
           'Modal snapshot_filesystem restore created a replacement sandbox, but terminating the previous sandbox failed.',
@@ -843,7 +846,7 @@ export class ModalSandboxSession implements SandboxSession<ModalSandboxSessionSt
             provider: 'modal',
             sandboxId: previousSandboxId,
             replacementSandboxId: sandbox.sandboxId,
-            cause: errorMessage(error),
+            cause: providerErrorMessage(error),
             ...(replacementTerminateCause ? { replacementTerminateCause } : {}),
           },
         );
@@ -1808,10 +1811,6 @@ function maybeSetModalSandboxCmd(
   return image.cmd(['sleep', 'infinity']);
 }
 
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
 async function modalCloudBucketMountsForManifest(args: {
   modalModule: ModalModule;
   manifest: Manifest;
@@ -2411,7 +2410,7 @@ async function waitForProcessOrTimeout(
 }
 
 function modalErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+  return providerErrorMessage(error);
 }
 
 function joinCommandOutput(activeProcess: ActiveModalProcess): string {

--- a/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
@@ -31,6 +31,7 @@ import {
   deserializeRemoteSandboxSessionStateValues,
   encodeNativeSnapshotRef,
   materializeEnvironment,
+  providerErrorMessage,
   serializeRemoteSandboxSessionState,
   shellQuote,
   isRecord,
@@ -781,7 +782,7 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
         {
           provider: 'runloop',
           devboxId: this.state.devboxId,
-          cause: error instanceof Error ? error.message : String(error),
+          cause: providerErrorMessage(error),
         },
       );
     }
@@ -835,7 +836,7 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
         {
           provider: 'runloop',
           snapshotId,
-          cause: error instanceof Error ? error.message : String(error),
+          cause: providerErrorMessage(error),
         },
       );
     }
@@ -852,14 +853,14 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
       try {
         await this.unmountActiveMounts();
       } catch (unmountError) {
-        replacementCleanupCause = errorMessage(unmountError);
+        replacementCleanupCause = providerErrorMessage(unmountError);
       }
       try {
         await devbox.shutdown();
       } catch (shutdownError) {
         replacementCleanupCause = replacementCleanupCause
-          ? `${replacementCleanupCause}; ${errorMessage(shutdownError)}`
-          : errorMessage(shutdownError);
+          ? `${replacementCleanupCause}; ${providerErrorMessage(shutdownError)}`
+          : providerErrorMessage(shutdownError);
       }
       this.devbox = previousDevbox;
       this.state.devboxId = previousDevboxId;
@@ -875,7 +876,7 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
           devboxId: previousDevboxId,
           replacementDevboxId: devbox.id,
           snapshotId,
-          cause: errorMessage(error),
+          cause: providerErrorMessage(error),
           ...(replacementCleanupCause ? { replacementCleanupCause } : {}),
         },
       );
@@ -888,14 +889,14 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
       try {
         await this.unmountActiveMounts();
       } catch (unmountError) {
-        replacementShutdownCause = errorMessage(unmountError);
+        replacementShutdownCause = providerErrorMessage(unmountError);
       }
       try {
         await devbox.shutdown();
       } catch (replacementShutdownError) {
         replacementShutdownCause = replacementShutdownCause
-          ? `${replacementShutdownCause}; ${errorMessage(replacementShutdownError)}`
-          : errorMessage(replacementShutdownError);
+          ? `${replacementShutdownCause}; ${providerErrorMessage(replacementShutdownError)}`
+          : providerErrorMessage(replacementShutdownError);
       }
       this.devbox = previousDevbox;
       this.state.devboxId = previousDevboxId;
@@ -911,7 +912,7 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
           devboxId: previousDevbox.id,
           replacementDevboxId: devbox.id,
           snapshotId,
-          cause: errorMessage(error),
+          cause: providerErrorMessage(error),
           ...(replacementShutdownCause ? { replacementShutdownCause } : {}),
         },
       );
@@ -1263,7 +1264,7 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
         {
           provider: 'runloop',
           port,
-          cause: error instanceof Error ? error.message : String(error),
+          cause: providerErrorMessage(error),
         },
       );
     }
@@ -1979,10 +1980,6 @@ function formatRunloopSecretErrorCause(
   return secretValue ? message.split(secretValue).join('[redacted]') : message;
 }
 
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
 async function callRunloopPlatformMethod(
   methodName: string,
   method: RunloopPlatformMethodLike | undefined,
@@ -2030,7 +2027,7 @@ function callRunloopPlatformGetter(
       {
         provider: 'runloop',
         operation: `call platform method ${methodName}`,
-        cause: error instanceof Error ? error.message : String(error),
+        cause: providerErrorMessage(error),
       },
     );
   }

--- a/packages/agents-extensions/src/sandbox/shared/index.ts
+++ b/packages/agents-extensions/src/sandbox/shared/index.ts
@@ -80,6 +80,8 @@ export {
   assertRunAsUnsupported,
   closeRemoteSessionOnManifestError,
   isProviderSandboxNotFoundError,
+  providerErrorDetails,
+  providerErrorMessage,
   withProviderError,
   withSandboxSpan,
 } from './session';

--- a/packages/agents-extensions/src/sandbox/shared/session.ts
+++ b/packages/agents-extensions/src/sandbox/shared/session.ts
@@ -19,7 +19,7 @@ export async function closeRemoteSessionOnManifestError(
     await session.close();
   } catch (closeError) {
     throw new UserError(
-      `Failed to apply a ${providerName} sandbox manifest and close the sandbox. Manifest error: ${errorMessage(manifestError)} Close error: ${errorMessage(closeError)}`,
+      `Failed to apply a ${providerName} sandbox manifest and close the sandbox. Manifest error: ${providerErrorMessage(manifestError)} Close error: ${providerErrorMessage(closeError)}`,
     );
   }
   throw manifestError;
@@ -86,12 +86,17 @@ export async function withProviderError<T>(
     if (error instanceof UserError) {
       throw error;
     }
-    throw new SandboxProviderError(`${providerName} failed to ${operation}.`, {
-      provider,
-      operation,
-      ...context,
-      cause: errorMessage(error),
-    });
+    const cause = providerErrorMessage(error);
+    throw new SandboxProviderError(
+      `${providerName} failed to ${operation}${cause ? `: ${cause}` : ''}`,
+      {
+        provider,
+        operation,
+        ...context,
+        ...providerErrorDetails(error),
+        cause,
+      },
+    );
   }
 }
 
@@ -128,9 +133,24 @@ export function assertResumeRecreateAllowed(
       provider: context.provider,
       operation: 'resume',
       ...context.details,
-      cause: errorMessage(error),
+      ...providerErrorDetails(error),
+      cause: providerErrorMessage(error),
     },
   );
+}
+
+export function providerErrorMessage(error: unknown): string {
+  const message = errorMessage(error);
+  const details = providerErrorDetails(error);
+  const detailText = formatProviderErrorDetailSummary(details);
+  if (!detailText) {
+    return message;
+  }
+  return message ? `${message} (${detailText})` : detailText;
+}
+
+export function providerErrorDetails(error: unknown): Record<string, unknown> {
+  return collectProviderErrorDetails(error, new Set<object>(), 0);
 }
 
 function errorMessage(error: unknown): string {
@@ -147,6 +167,195 @@ function formatErrorDetails(details: Record<string, unknown>): string {
   } catch {
     return String(details);
   }
+}
+
+function collectProviderErrorDetails(
+  value: unknown,
+  seen: Set<object>,
+  depth: number,
+): Record<string, unknown> {
+  if (!isRecord(value) || seen.has(value) || depth > 2) {
+    return {};
+  }
+  seen.add(value);
+
+  const details: Record<string, unknown> = {};
+  addOptionalString(
+    details,
+    'errorName',
+    value.name,
+    (name) => name !== 'Error',
+  );
+  addOptionalScalar(details, 'errorCode', value.code);
+  addOptionalScalar(
+    details,
+    'status',
+    firstDefined(value.status, value.statusCode),
+  );
+  addOptionalScalar(
+    details,
+    'httpStatus',
+    firstDefined(value.httpStatus, value.httpStatusCode),
+  );
+  addOptionalString(
+    details,
+    'requestId',
+    firstDefined(value.requestId, value.request_id, value.requestID),
+  );
+
+  const payload = firstDefined(value.json, value.data, value.body, value.error);
+  const formattedPayload = formatProviderPayload(payload, seen, depth + 1);
+  if (formattedPayload !== undefined) {
+    details.errorBody = formattedPayload;
+  }
+
+  const response = value.response;
+  if (isRecord(response)) {
+    addOptionalScalar(
+      details,
+      'responseStatus',
+      firstDefined(response.status, response.statusCode),
+    );
+    addOptionalString(details, 'responseStatusText', response.statusText);
+    addOptionalString(
+      details,
+      'responseRequestId',
+      firstDefined(response.requestId, response.request_id, response.requestID),
+    );
+    const responseBody = formatProviderPayload(
+      firstDefined(response.json, response.data, response.body, response.error),
+      seen,
+      depth + 1,
+    );
+    if (responseBody !== undefined) {
+      details.responseBody = responseBody;
+    }
+  }
+
+  const causeDetails = collectProviderErrorDetails(
+    value.cause,
+    seen,
+    depth + 1,
+  );
+  for (const [key, detail] of Object.entries(causeDetails)) {
+    details[key] ??= detail;
+  }
+
+  return details;
+}
+
+function formatProviderErrorDetailSummary(
+  details: Record<string, unknown>,
+): string {
+  const parts: string[] = [];
+  for (const key of [
+    'status',
+    'httpStatus',
+    'responseStatus',
+    'errorCode',
+    'requestId',
+    'responseRequestId',
+  ]) {
+    const value = details[key];
+    if (typeof value === 'string' || typeof value === 'number') {
+      parts.push(`${key}: ${value}`);
+    }
+  }
+  const body = details.responseBody ?? details.errorBody;
+  if (body !== undefined) {
+    parts.push(`body: ${formatSummaryValue(body)}`);
+  }
+  return parts.join(', ');
+}
+
+function formatProviderPayload(
+  value: unknown,
+  seen: Set<object>,
+  depth: number,
+): unknown {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return truncateProviderString(String(value));
+  }
+  if (Array.isArray(value)) {
+    const items = value
+      .slice(0, 3)
+      .map((item) => formatProviderPayload(item, seen, depth + 1))
+      .filter((item) => item !== undefined);
+    return items.length > 0 ? items : undefined;
+  }
+  if (!isRecord(value) || seen.has(value) || depth > 3) {
+    return undefined;
+  }
+  seen.add(value);
+
+  const summary: Record<string, unknown> = {};
+  for (const key of [
+    'code',
+    'message',
+    'error',
+    'type',
+    'name',
+    'reason',
+    'status',
+    'statusCode',
+  ]) {
+    const formatted = formatProviderPayload(value[key], seen, depth + 1);
+    if (formatted !== undefined) {
+      summary[key] = formatted;
+    }
+  }
+  return Object.keys(summary).length > 0 ? summary : undefined;
+}
+
+function formatSummaryValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return truncateProviderString(JSON.stringify(value));
+  } catch {
+    return String(value);
+  }
+}
+
+function firstDefined(...values: unknown[]): unknown {
+  return values.find((value) => value !== undefined);
+}
+
+function addOptionalScalar(
+  target: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): void {
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    target[key] = value;
+  }
+}
+
+function addOptionalString(
+  target: Record<string, unknown>,
+  key: string,
+  value: unknown,
+  predicate: (value: string) => boolean = () => true,
+): void {
+  if (typeof value === 'string' && value && predicate(value)) {
+    target[key] = truncateProviderString(value);
+  }
+}
+
+function truncateProviderString(value: string): string {
+  return value.length > 500 ? `${value.slice(0, 497)}...` : value;
 }
 
 function isNotFoundErrorRecord(error: unknown, seen: Set<object>): boolean {

--- a/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
@@ -31,6 +31,7 @@ import {
   encodeNativeSnapshotRef,
   materializeEnvironment,
   posixDirname,
+  providerErrorMessage,
   shellQuote,
   serializeRemoteSandboxSessionState,
   toUint8Array,
@@ -270,7 +271,7 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
         {
           provider: 'vercel',
           port: requestedPort,
-          cause: error instanceof Error ? error.message : String(error),
+          cause: providerErrorMessage(error),
         },
       );
     }
@@ -374,7 +375,7 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
     } catch (stopError) {
       if (snapshotError) {
         throw new UserError(
-          `Failed to capture a Vercel sandbox snapshot and stop the sandbox. Snapshot error: ${errorMessage(snapshotError)} Stop error: ${errorMessage(stopError)}`,
+          `Failed to capture a Vercel sandbox snapshot and stop the sandbox. Snapshot error: ${providerErrorMessage(snapshotError)} Stop error: ${providerErrorMessage(stopError)}`,
         );
       }
       if (snapshotCapturedBeforeStop) {
@@ -446,7 +447,7 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
       try {
         await stopVercelSandbox(sandbox);
       } catch (replacementStopError) {
-        replacementStopCause = errorMessage(replacementStopError);
+        replacementStopCause = providerErrorMessage(replacementStopError);
       }
       throw new SandboxProviderError(
         'Vercel snapshot restore created a replacement sandbox, but stopping the previous sandbox failed.',
@@ -454,7 +455,7 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
           provider: 'vercel',
           sandboxId: previousSandbox.sandboxId,
           replacementSandboxId: sandbox.sandboxId,
-          cause: errorMessage(error),
+          cause: providerErrorMessage(error),
           ...(replacementStopCause ? { replacementStopCause } : {}),
         },
       );
@@ -483,8 +484,8 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
           provider: 'vercel',
           sandboxId: this.state.sandboxId,
           snapshotId,
-          cause: errorMessage(restoreError),
-          recoveryCause: errorMessage(recoveryError),
+          cause: providerErrorMessage(restoreError),
+          recoveryCause: providerErrorMessage(recoveryError),
         },
       );
     }
@@ -531,7 +532,7 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
         await stopVercelSandbox(sandbox);
       } catch (stopError) {
         throw new UserError(
-          `Failed to restore a Vercel sandbox from snapshot and stop the replacement sandbox. Restore error: ${errorMessage(error)} Stop error: ${errorMessage(stopError)}`,
+          `Failed to restore a Vercel sandbox from snapshot and stop the replacement sandbox. Restore error: ${providerErrorMessage(error)} Stop error: ${providerErrorMessage(stopError)}`,
         );
       }
       throw error;
@@ -812,7 +813,7 @@ export class VercelSandboxClient implements SandboxClient<
             await stopVercelSandbox(sandbox);
           } catch (stopError) {
             throw new UserError(
-              `Failed to apply a Vercel sandbox manifest and stop the sandbox. Manifest error: ${errorMessage(error)} Stop error: ${errorMessage(stopError)}`,
+              `Failed to apply a Vercel sandbox manifest and stop the sandbox. Manifest error: ${providerErrorMessage(error)} Stop error: ${providerErrorMessage(stopError)}`,
             );
           }
           throw error;
@@ -976,7 +977,7 @@ export class VercelSandboxClient implements SandboxClient<
         await stopVercelSandbox(sandbox);
       } catch (stopError) {
         throw new UserError(
-          `Failed to resume a Vercel sandbox from snapshot and stop the replacement sandbox. Resume error: ${errorMessage(error)} Stop error: ${errorMessage(stopError)}`,
+          `Failed to resume a Vercel sandbox from snapshot and stop the replacement sandbox. Resume error: ${providerErrorMessage(error)} Stop error: ${providerErrorMessage(stopError)}`,
         );
       }
       throw error;
@@ -1423,16 +1424,12 @@ async function waitForVercelSandboxRunning(
   );
 }
 
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
 function isVercelSandboxAlreadyStoppedError(error: unknown): boolean {
   if (isProviderSandboxNotFoundError(error)) {
     return true;
   }
 
-  const message = errorMessage(error);
+  const message = providerErrorMessage(error);
   return (
     /\b(sandbox|sandbox instance|instance)\b.*\b(already\s+)?(stopped|terminated|not running)\b/iu.test(
       message,

--- a/packages/agents-extensions/test/sandbox/cloudflare.test.ts
+++ b/packages/agents-extensions/test/sandbox/cloudflare.test.ts
@@ -500,6 +500,71 @@ describe('CloudflareSandboxClient', () => {
     );
   });
 
+  test('keeps Cloudflare exec and cleanup details when manifest apply fails', async () => {
+    global.fetch = vi.fn(async (input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+
+      if (url.endsWith('/v1/sandbox') && method === 'POST') {
+        return jsonResponse({ id: 'cf_test' });
+      }
+
+      if (url.includes('/exec') && method === 'POST') {
+        const payload = JSON.parse(String(init?.body)) as {
+          argv?: string[];
+        };
+        const resolvedPath = resolvedRemotePathFromValidationCommand(
+          payload.argv?.[2] ?? '',
+        );
+        if (resolvedPath) {
+          return sseExecResponse([
+            {
+              event: 'stdout',
+              data: Buffer.from(`${resolvedPath}\n`).toString('base64'),
+            },
+            { event: 'exit', data: JSON.stringify({ exit_code: 0 }) },
+          ]);
+        }
+        return jsonResponse({
+          error: 'pool error: Failed to start container',
+          code: 'pool_error',
+        });
+      }
+
+      if (url.includes('/v1/sandbox/cf_test') && method === 'DELETE') {
+        return jsonResponse(
+          {
+            error: 'pool error: Failed to stop container',
+            code: 'pool_error',
+          },
+          502,
+        );
+      }
+
+      return new Response(null, { status: 404 });
+    }) as typeof fetch;
+
+    const client = new CloudflareSandboxClient();
+
+    await expect(
+      client.create(
+        new Manifest({
+          entries: {
+            'README.md': {
+              type: 'file',
+              content: '# Hello\n',
+            },
+          },
+        }),
+        {
+          workerUrl: 'https://worker.example.com',
+        },
+      ),
+    ).rejects.toThrow(
+      /Manifest error: CloudflareSandboxClient failed to execute command\..*pool_error: pool error: Failed to start container.*Close error: CloudflareSandboxClient failed to delete sandbox.*"?status"?:\s*502.*pool_error: pool error: Failed to stop container/s,
+    );
+  });
+
   test('resolves environment before creating the remote sandbox', async () => {
     const client = new CloudflareSandboxClient({
       workerUrl: 'https://worker.example.com',
@@ -539,6 +604,26 @@ describe('CloudflareSandboxClient', () => {
         operation: 'execute command',
         status: 503,
         sandboxId: 'cf_test',
+        cause: 'unavailable',
+      },
+    });
+
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse(
+        {
+          error: 'pool error: Failed to start container',
+          code: 'pool_error',
+        },
+        200,
+      ),
+    );
+    await expect(session.execCommand({ cmd: 'ls' })).rejects.toMatchObject({
+      code: 'provider_error',
+      details: {
+        provider: 'cloudflare',
+        operation: 'execute command',
+        sandboxId: 'cf_test',
+        cause: 'pool_error: pool error: Failed to start container',
       },
     });
 
@@ -584,7 +669,7 @@ describe('CloudflareSandboxClient', () => {
     vi.mocked(global.fetch).mockResolvedValueOnce(
       jsonResponse(
         {
-          error: 'pool error: Failed to start container',
+          error: 'pool error: Failed to stop container',
           code: 'pool_error',
         },
         502,
@@ -597,57 +682,9 @@ describe('CloudflareSandboxClient', () => {
         operation: 'delete sandbox',
         status: 502,
         sandboxId: 'cf_test',
-        cause: 'pool_error: pool error: Failed to start container',
+        cause: 'pool_error: pool error: Failed to stop container',
       },
     });
-  });
-
-  test('keeps Cloudflare exec and cleanup details when manifest apply fails', async () => {
-    const client = new CloudflareSandboxClient({
-      workerUrl: 'https://worker.example.com',
-    });
-    vi.mocked(global.fetch).mockImplementation(async (input, init) => {
-      const url = String(input);
-      const method = init?.method ?? 'GET';
-
-      if (url.endsWith('/v1/sandbox') && method === 'POST') {
-        return jsonResponse({ id: 'cf_test' });
-      }
-
-      if (url.includes('/exec') && method === 'POST') {
-        return jsonResponse({
-          error: 'pool error: Failed to start container',
-          code: 'pool_error',
-        });
-      }
-
-      if (url.includes('/v1/sandbox/cf_test') && method === 'DELETE') {
-        return jsonResponse(
-          {
-            error: 'pool error: Failed to start container',
-            code: 'pool_error',
-          },
-          502,
-        );
-      }
-
-      return new Response(null, { status: 404 });
-    });
-
-    await expect(
-      client.create(
-        new Manifest({
-          entries: {
-            'README.md': {
-              type: 'file',
-              content: '# Hello\n',
-            },
-          },
-        }),
-      ),
-    ).rejects.toThrow(
-      /Manifest error: CloudflareSandboxClient failed to execute command\. Details: .*"cause":"pool_error: pool error: Failed to start container".*Close error: CloudflareSandboxClient failed to delete sandbox\. Details: .*"status":502.*"cause":"pool_error: pool error: Failed to start container"/u,
-    );
   });
 
   test('rejects non-workspace roots when applying manifests to sessions', async () => {

--- a/packages/agents-extensions/test/sandbox/sharedSession.test.ts
+++ b/packages/agents-extensions/test/sandbox/sharedSession.test.ts
@@ -11,6 +11,8 @@ import {
   assertCoreSnapshotUnsupported,
   assertResumeRecreateAllowed,
   isProviderSandboxNotFoundError,
+  closeRemoteSessionOnManifestError,
+  withProviderError,
   RemoteSandboxSessionBase,
   type RemoteSandboxCommandOptions,
   type RemoteSandboxCommandResult,
@@ -223,6 +225,96 @@ describe('shared sandbox session helpers', () => {
       devboxId: 'devbox_test',
       cause: 'request timeout',
     });
+  });
+
+  test('wraps provider SDK errors with structured diagnostics', async () => {
+    const sdkError = Object.assign(new Error('request failed'), {
+      code: 'rate_limit',
+      statusCode: 429,
+      requestId: 'req_123',
+      response: {
+        status: 429,
+        statusText: 'Too Many Requests',
+        data: {
+          error: {
+            code: 'rate_limit',
+            message: 'slow down',
+          },
+        },
+      },
+    });
+
+    let thrown: unknown;
+    try {
+      await withProviderError(
+        'ProviderSandboxClient',
+        'provider',
+        'create sandbox',
+        async () => {
+          throw sdkError;
+        },
+        { sandboxId: 'sandbox_123' },
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(SandboxProviderError);
+    expect((thrown as Error).message).toContain('request failed');
+    expect((thrown as Error).message).toContain('responseStatus: 429');
+    expect((thrown as SandboxProviderError).details).toMatchObject({
+      provider: 'provider',
+      operation: 'create sandbox',
+      sandboxId: 'sandbox_123',
+      errorCode: 'rate_limit',
+      status: 429,
+      requestId: 'req_123',
+      responseStatus: 429,
+      responseStatusText: 'Too Many Requests',
+      responseBody: {
+        error: {
+          code: 'rate_limit',
+          message: 'slow down',
+        },
+      },
+      cause: expect.stringContaining('request failed'),
+    });
+  });
+
+  test('keeps provider details when manifest cleanup also fails', async () => {
+    const manifestError = new SandboxProviderError(
+      'ProviderSandboxClient failed to apply manifest.',
+      {
+        provider: 'provider',
+        operation: 'apply manifest',
+        cause: 'mkdir failed',
+      },
+    );
+    const closeError = Object.assign(new Error('delete failed'), {
+      response: {
+        status: 502,
+        data: {
+          error: {
+            code: 'pool_error',
+            message: 'failed to stop sandbox',
+          },
+        },
+      },
+    });
+
+    await expect(
+      closeRemoteSessionOnManifestError(
+        'Provider',
+        {
+          close: async () => {
+            throw closeError;
+          },
+        },
+        manifestError,
+      ),
+    ).rejects.toThrow(
+      /Manifest error: ProviderSandboxClient failed to apply manifest\..*mkdir failed.*Close error: delete failed.*responseStatus: 502.*pool_error/s,
+    );
   });
 
   test('base session handles common exec, filesystem, image, and port helpers', async () => {


### PR DESCRIPTION
This pull request fixes sandbox provider diagnostics by preserving structured SDK error details in `@openai/agents-extensions`.

It updates shared provider error handling to surface useful fields such as status codes, provider error codes, request IDs, and response error bodies, and routes E2B, Blaxel, Modal, Runloop, and Vercel error formatting through the richer shared helper. It also adds regression coverage for structured SDK errors and manifest cleanup failures, plus a patch changeset for `@openai/agents-extensions`.