### PR TITLE
fix: align Chat Completions strict validation

### DIFF
--- a/.changeset/align-chat-completions-strict-validation.md
+++ b/.changeset/align-chat-completions-strict-validation.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents': patch
+'@openai/agents-openai': patch
+---
+
+fix: align Chat Completions strict validation for unsupported stream outputs

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -204,6 +204,12 @@ export class OpenAIChatCompletionsModel implements Model {
                 ...remainingFunctionData,
               },
             });
+          } else if (tool_call.type === 'custom') {
+            if (this.#strictFeatureValidation) {
+              throw new UserError(
+                'Custom tool calls are not supported by the Chat Completions converter.',
+              );
+            }
           }
         }
       }
@@ -249,6 +255,7 @@ export class OpenAIChatCompletionsModel implements Model {
       for await (const event of convertChatCompletionsStreamToResponses(
         response,
         stream,
+        { strictFeatureValidation: this.#strictFeatureValidation },
       )) {
         if (
           event.type === 'response_done' &&

--- a/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
@@ -1,22 +1,26 @@
 import type { Stream } from 'openai/streaming';
 import type { CompletionUsage } from 'openai/resources/completions';
-import { protocol } from '@openai/agents-core';
+import { protocol, UserError } from '@openai/agents-core';
 import { ChatCompletion, ChatCompletionChunk } from 'openai/resources/chat';
 import { FAKE_ID } from './openaiChatCompletionsModel';
 import { OPENAI_CHAT_COMPLETIONS_RAW_MODEL_EVENT_SOURCE } from './rawModelEvents';
+import logger from './logger';
 
 type StreamingState = {
   started: boolean;
   text_content: protocol.OutputText | null;
   refusal_content: protocol.Refusal | null;
   function_calls: Record<number, protocol.FunctionCallItem>;
+  ignored_tool_call_indexes: Set<number>;
   reasoning: string;
   finishReason: ChatCompletion['choices'][number]['finish_reason'] | null;
+  hasWarnedUnsupportedChoice: boolean;
 };
 
 export async function* convertChatCompletionsStreamToResponses(
   response: ChatCompletion,
   stream: Stream<ChatCompletionChunk>,
+  options: { strictFeatureValidation?: boolean } = {},
 ): AsyncIterable<protocol.StreamEvent> {
   let usage: CompletionUsage | undefined = undefined;
   const state: StreamingState = {
@@ -24,9 +28,12 @@ export async function* convertChatCompletionsStreamToResponses(
     text_content: null,
     refusal_content: null,
     function_calls: {},
+    ignored_tool_call_indexes: new Set(),
     reasoning: '',
     finishReason: null,
+    hasWarnedUnsupportedChoice: false,
   };
+  const strictFeatureValidation = options.strictFeatureValidation ?? false;
 
   for await (const chunk of stream) {
     if (chunk.id && (response.id === FAKE_ID || !response.id)) {
@@ -55,7 +62,27 @@ export async function* convertChatCompletionsStreamToResponses(
     // This is always set by the OpenAI API, but not by others e.g. LiteLLM
     usage = (chunk as any).usage || undefined;
 
-    const primaryChoice = chunk.choices?.[0];
+    if (!chunk.choices || chunk.choices.length === 0) continue;
+
+    const unsupportedChoiceIndexes = chunk.choices
+      .map((choice) => choice.index)
+      .filter((index) => index !== 0);
+    if (chunk.choices.length > 1 || unsupportedChoiceIndexes.length > 0) {
+      const message =
+        'Chat Completions streaming with multiple choices or nonzero choice indexes ' +
+        'is not fully supported; only choice index 0 can be processed.';
+      if (strictFeatureValidation) {
+        throw new UserError(message);
+      }
+      if (!state.hasWarnedUnsupportedChoice) {
+        logger.warn(
+          `${message} Ignoring the other choices; enable strict feature validation to raise an error instead.`,
+        );
+        state.hasWarnedUnsupportedChoice = true;
+      }
+    }
+
+    const primaryChoice = chunk.choices.find((choice) => choice.index === 0);
     if (!primaryChoice) continue;
     if (primaryChoice.finish_reason) {
       state.finishReason = primaryChoice.finish_reason;
@@ -101,6 +128,20 @@ export async function* convertChatCompletionsStreamToResponses(
     // Handle tool calls
     if (delta.tool_calls) {
       for (const tc_delta of delta.tool_calls) {
+        if (state.ignored_tool_call_indexes.has(tc_delta.index)) {
+          continue;
+        }
+
+        if ((tc_delta as { type?: string }).type === 'custom') {
+          if (strictFeatureValidation) {
+            throw new UserError(
+              'Custom tool calls are not supported by the Chat Completions converter.',
+            );
+          }
+          state.ignored_tool_call_indexes.add(tc_delta.index);
+          continue;
+        }
+
         if (!(tc_delta.index in state.function_calls)) {
           state.function_calls[tc_delta.index] = {
             id: response.id || FAKE_ID,

--- a/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
@@ -643,6 +643,80 @@ describe('OpenAIChatCompletionsModel', () => {
     ]);
   });
 
+  it('ignores custom tool calls by default', async () => {
+    const client = new FakeClient();
+    const response = {
+      id: 'r',
+      choices: [
+        {
+          message: {
+            tool_calls: [
+              {
+                id: 'call1',
+                type: 'custom',
+                custom: { name: 'raw_tool', input: 'payload' },
+              },
+            ],
+          },
+        },
+      ],
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    } as any;
+    client.chat.completions.create.mockResolvedValue(response);
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const req: any = {
+      input: 'u',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+    };
+
+    const result = await withTrace('t', () => model.getResponse(req));
+
+    expect(result.output).toEqual([]);
+  });
+
+  it('rejects custom tool calls in strict mode', async () => {
+    const client = new FakeClient();
+    const response = {
+      id: 'r',
+      choices: [
+        {
+          message: {
+            tool_calls: [
+              {
+                id: 'call1',
+                type: 'custom',
+                custom: { name: 'raw_tool', input: 'payload' },
+              },
+            ],
+          },
+        },
+      ],
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    } as any;
+    client.chat.completions.create.mockResolvedValue(response);
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt', {
+      strictFeatureValidation: true,
+    });
+    const req: any = {
+      input: 'u',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+    };
+
+    await expect(withTrace('t', () => model.getResponse(req))).rejects.toThrow(
+      'Custom tool calls are not supported',
+    );
+  });
+
   it('rejects namespaced function tools before sending a request', async () => {
     const client = new FakeClient();
     const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
@@ -970,7 +1044,40 @@ describe('OpenAIChatCompletionsModel', () => {
       { headers: HEADERS, signal: undefined },
     );
     expect(convertChatCompletionsStreamToResponses).toHaveBeenCalled();
+    expect(
+      vi.mocked(convertChatCompletionsStreamToResponses).mock.calls[0]?.[2],
+    ).toEqual({ strictFeatureValidation: false });
     expect(events).toEqual([{ type: 'first' }, { type: 'second' }]);
+  });
+
+  it('passes strict feature validation to the stream converter', async () => {
+    const client = new FakeClient();
+    async function* fakeStream() {
+      yield { id: 'c' } as any;
+    }
+    client.chat.completions.create.mockResolvedValue(fakeStream());
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt', {
+      strictFeatureValidation: true,
+    });
+    const req: any = {
+      input: 'hi',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+    };
+
+    await withTrace('t', async () => {
+      for await (const _event of model.getStreamedResponse(req)) {
+        // Consume the stream.
+      }
+    });
+
+    expect(
+      vi.mocked(convertChatCompletionsStreamToResponses).mock.calls[0]?.[2],
+    ).toEqual({ strictFeatureValidation: true });
   });
 
   it('warns and ignores unsupported stream response features by default', async () => {

--- a/packages/agents-openai/test/openaiChatCompletionsStreaming.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsStreaming.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { UserError } from '@openai/agents-core';
 import { convertChatCompletionsStreamToResponses } from '../src/openaiChatCompletionsStreaming';
 import { FAKE_ID } from '../src/openaiChatCompletionsModel';
+import logger from '../src/logger';
 import type {
   ChatCompletion,
   ChatCompletionChunk,
@@ -12,7 +14,7 @@ function makeChunk(delta: any, usage?: any) {
     created: 0,
     model: 'm',
     object: 'chat.completion.chunk',
-    choices: [{ delta }],
+    choices: [{ index: 0, delta }],
     usage,
   } as any;
 }
@@ -271,6 +273,90 @@ describe('convertChatCompletionsStreamToResponses', () => {
     expect(deltas[0].delta).toBe('hi');
   });
 
+  it('filters multiple choices by default', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const chunks: ChatCompletionChunk[] = [
+      {
+        id: 'c',
+        created: 0,
+        model: 'm',
+        object: 'chat.completion.chunk',
+        choices: [{ index: 1, delta: { content: 'ignored-first' } }],
+      } as any,
+      {
+        id: 'c',
+        created: 0,
+        model: 'm',
+        object: 'chat.completion.chunk',
+        choices: [
+          { index: 0, delta: { content: 'kept' } },
+          { index: 1, delta: { content: 'ignored-second' } },
+        ],
+      } as any,
+      {
+        id: 'c',
+        created: 0,
+        model: 'm',
+        object: 'chat.completion.chunk',
+        choices: [{ index: 2, delta: { content: 'ignored-third' } }],
+        usage: { prompt_tokens: 2, completion_tokens: 1, total_tokens: 3 },
+      } as any,
+    ];
+
+    async function* stream() {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    }
+
+    const events: any[] = [];
+    for await (const e of convertChatCompletionsStreamToResponses(
+      { id: 'r' } as any,
+      stream() as any,
+    )) {
+      events.push(e);
+    }
+
+    expect(
+      events
+        .filter((event) => event.type === 'output_text_delta')
+        .map((event) => event.delta),
+    ).toEqual(['kept']);
+    const final = events.at(-1);
+    expect(final.response.output[0].content[0].text).toBe('kept');
+    expect(final.response.usage.totalTokens).toBe(3);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'multiple choices or nonzero choice indexes',
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('rejects multiple choices in strict mode', async () => {
+    async function* stream() {
+      yield {
+        id: 'c',
+        created: 0,
+        model: 'm',
+        object: 'chat.completion.chunk',
+        choices: [
+          { index: 0, delta: { content: 'first' } },
+          { index: 1, delta: { content: 'second' } },
+        ],
+      } as any;
+    }
+
+    await expect(async () => {
+      for await (const _event of convertChatCompletionsStreamToResponses(
+        { id: 'r' } as any,
+        stream() as any,
+        { strictFeatureValidation: true },
+      )) {
+        // Consume the stream.
+      }
+    }).rejects.toThrow(UserError);
+  });
+
   it('accumulates reasoning deltas into a reasoning item', async () => {
     const resp: ChatCompletion = {
       id: 'r1',
@@ -430,6 +516,56 @@ describe('convertChatCompletionsStreamToResponses', () => {
         },
       },
     ]);
+  });
+
+  it('ignores streamed custom tool calls by default', async () => {
+    async function* stream() {
+      yield makeChunk({
+        tool_calls: [{ index: 0, id: 'call1', type: 'custom' }],
+      });
+      yield makeChunk({
+        tool_calls: [
+          { index: 0, function: { name: 'ignored', arguments: 'x' } },
+        ],
+      });
+      yield makeChunk({ content: 'done' });
+    }
+
+    const events: any[] = [];
+    for await (const e of convertChatCompletionsStreamToResponses(
+      { id: 'r' } as any,
+      stream() as any,
+    )) {
+      events.push(e);
+    }
+
+    const final = events.at(-1);
+    expect(final.response.output).toHaveLength(1);
+    expect(final.response.output[0]).toMatchObject({
+      type: 'message',
+      content: [{ type: 'output_text', text: 'done' }],
+    });
+    expect(
+      final.response.output.some((item: any) => item.type === 'function_call'),
+    ).toBe(false);
+  });
+
+  it('rejects streamed custom tool calls in strict mode', async () => {
+    async function* stream() {
+      yield makeChunk({
+        tool_calls: [{ index: 0, id: 'call1', type: 'custom' }],
+      });
+    }
+
+    await expect(async () => {
+      for await (const _event of convertChatCompletionsStreamToResponses(
+        { id: 'r' } as any,
+        stream() as any,
+        { strictFeatureValidation: true },
+      )) {
+        // Consume the stream.
+      }
+    }).rejects.toThrow('Custom tool calls are not supported');
   });
 
   it('falls back to FAKE_ID when streaming chunks do not include an id', async () => {


### PR DESCRIPTION
This pull request fixes Chat Completions strict validation gaps in `@openai/agents-openai`. Streaming conversion now processes only choice index 0, warns once for unsupported multi-choice/nonzero-index chunks in default compatibility mode, and raises in strict mode. It also rejects unsupported custom tool calls in strict mode for both streaming and non-streaming Chat Completions while preserving the existing default behavior of ignoring them.

see also:
- https://github.com/openai/openai-agents-python/pull/3314
- https://github.com/openai/openai-agents-python/pull/3309