### PR TITLE
fix: make tracing shutdown best-effort on process exit

### DIFF
--- a/.changeset/brave-traces-wait.md
+++ b/.changeset/brave-traces-wait.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+---
+
+fix: make tracing shutdown best-effort on process exit

--- a/packages/agents-core/src/tracing/processor.ts
+++ b/packages/agents-core/src/tracing/processor.ts
@@ -175,7 +175,10 @@ export class BatchTraceProcessor implements TracingProcessor {
     }
   }
 
-  async #exportBatches(force: boolean = false): Promise<void> {
+  async #exportBatches(
+    force: boolean = false,
+    signal?: AbortSignal,
+  ): Promise<void> {
     if (this.#buffer.length === 0) {
       return;
     }
@@ -187,7 +190,7 @@ export class BatchTraceProcessor implements TracingProcessor {
     const exportBatch = async (batch: Array<Trace | Span>): Promise<void> => {
       this.#exportInProgress = true;
       try {
-        await this.#exporter.export(batch);
+        await this.#exporter.export(batch, signal);
       } catch (error) {
         logger.error('Tracing exporter failed to export batch', error);
       } finally {
@@ -236,11 +239,10 @@ export class BatchTraceProcessor implements TracingProcessor {
       );
       if (!this.#exportInProgress) {
         // no current export in progress. Forcing all items to be exported
-        await this.#exportBatches(true);
+        await this.#exportBatches(true, this.#timeoutAbortController?.signal);
       }
       if (this.#timeoutAbortController?.signal.aborted) {
         logger.debug('Timeout reached, force flushing');
-        await this.#exportBatches(true);
         break;
       }
       // using setTimeout to add to the event loop and keep this alive until done

--- a/packages/agents-core/src/tracing/processor.ts
+++ b/packages/agents-core/src/tracing/processor.ts
@@ -225,33 +225,49 @@ export class BatchTraceProcessor implements TracingProcessor {
   }
 
   async shutdown(timeout?: number): Promise<void> {
+    let shutdownTimeout: Timeout | undefined;
+    const shutdownAbortController = timeout
+      ? (this.#timeoutAbortController ?? new AbortController())
+      : undefined;
+
     if (timeout) {
-      this.#timer.setTimeout(() => {
-        // force shutdown the HTTP request
-        this.#timeoutAbortController?.abort();
+      this.#timeoutAbortController = shutdownAbortController ?? null;
+      shutdownTimeout = this.#timer.setTimeout(() => {
+        // Force shutdown the HTTP request.
+        shutdownAbortController?.abort();
       }, timeout);
+
+      if (typeof shutdownTimeout.unref === 'function') {
+        shutdownTimeout.unref();
+      }
     }
 
-    logger.debug('Shutting down gracefully');
-    while (this.#buffer.length > 0) {
-      logger.debug(
-        `Waiting for buffer to empty. Items left: ${this.#buffer.length}`,
-      );
-      if (!this.#exportInProgress) {
-        // no current export in progress. Forcing all items to be exported
-        await this.#exportBatches(true, this.#timeoutAbortController?.signal);
+    try {
+      logger.debug('Shutting down gracefully');
+      while (this.#buffer.length > 0) {
+        logger.debug(
+          `Waiting for buffer to empty. Items left: ${this.#buffer.length}`,
+        );
+        if (!this.#exportInProgress) {
+          // No current export in progress. Forcing all items to be exported.
+          await this.#exportBatches(true, shutdownAbortController?.signal);
+        }
+        if (shutdownAbortController?.signal.aborted) {
+          logger.debug('Timeout reached, force flushing');
+          break;
+        }
+        // Using setTimeout to add to the event loop and keep this alive until done.
+        await new Promise((resolve) => this.#timer.setTimeout(resolve, 500));
       }
-      if (this.#timeoutAbortController?.signal.aborted) {
-        logger.debug('Timeout reached, force flushing');
-        break;
+      logger.debug('Buffer empty. Exiting');
+    } finally {
+      if (shutdownTimeout) {
+        this.#timer.clearTimeout(shutdownTimeout);
       }
-      // using setTimeout to add to the event loop and keep this alive until done
-      await new Promise((resolve) => this.#timer.setTimeout(resolve, 500));
-    }
-    logger.debug('Buffer empty. Exiting');
-    if (this.#timer && this.#timeout) {
-      // making sure there are no more requests
-      this.#timer.clearTimeout(this.#timeout);
+      if (this.#timer && this.#timeout) {
+        // Making sure there are no more requests.
+        this.#timer.clearTimeout(this.#timeout);
+      }
     }
   }
 

--- a/packages/agents-core/src/tracing/provider.ts
+++ b/packages/agents-core/src/tracing/provider.ts
@@ -203,15 +203,23 @@ export class TraceProvider {
     if (typeof process !== 'undefined' && typeof process.on === 'function') {
       // handling Node.js process termination
       const cleanup = async () => {
-        const timeout = setTimeout(() => {
-          console.warn('Cleanup timeout, forcing exit');
-          process.exit(1);
-        }, 5000);
+        const timeoutMs = 5000;
+        let timeout: ReturnType<typeof setTimeout> | undefined;
 
         try {
-          await this.shutdown();
+          await Promise.race([
+            this.shutdown(timeoutMs),
+            new Promise<void>((resolve) => {
+              timeout = setTimeout(() => {
+                console.warn('Tracing cleanup timed out; continuing exit');
+                resolve();
+              }, timeoutMs);
+            }),
+          ]);
         } finally {
-          clearTimeout(timeout);
+          if (timeout) {
+            clearTimeout(timeout);
+          }
         }
       };
 

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -428,6 +428,20 @@ describe('Trace & Span lifecycle', () => {
     }
   });
 
+  it('clears shutdown timeout when tracing buffer is empty', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const processor = new BatchTraceProcessor(new TestExporter());
+
+      await processor.shutdown(5000);
+
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('falls back to module provider when global registration fails', () => {
     const symbol = Symbol.for('openai.agents.core.traceProvider');
     const globalHolder = globalThis as unknown as Record<

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -370,6 +370,64 @@ describe('Trace & Span lifecycle', () => {
     onSpy.mockRestore();
   });
 
+  it('does not force exit when beforeExit tracing cleanup times out', async () => {
+    vi.useFakeTimers();
+    allowConsole(['warn']);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit should not be called');
+    }) as never);
+    const onceSpy = vi.spyOn(process, 'once');
+    const onSpy = vi.spyOn(process, 'on');
+
+    try {
+      const provider = new TraceProvider();
+      const processor = new TestProcessor();
+      processor.shutdown = vi.fn(
+        () => new Promise<void>(() => {}),
+      ) as TestProcessor['shutdown'];
+      provider.setProcessors([processor]);
+
+      const beforeExitListener = onceSpy.mock.calls.find(
+        ([event]) => event === 'beforeExit',
+      )?.[1];
+      expect(beforeExitListener).toEqual(expect.any(Function));
+
+      const cleanupPromise =
+        typeof beforeExitListener === 'function'
+          ? beforeExitListener(0 as never)
+          : Promise.resolve();
+      await vi.advanceTimersByTimeAsync(5000);
+      await cleanupPromise;
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Tracing cleanup timed out; continuing exit',
+      );
+      expect(processor.shutdown).toHaveBeenCalledWith(5000);
+      expect(exitSpy).not.toHaveBeenCalled();
+
+      if (typeof beforeExitListener === 'function') {
+        process.off('beforeExit', beforeExitListener);
+      }
+      for (const [event, listener] of onSpy.mock.calls) {
+        if (
+          (event === 'SIGINT' ||
+            event === 'SIGTERM' ||
+            event === 'unhandledRejection') &&
+          typeof listener === 'function'
+        ) {
+          process.off(event, listener);
+        }
+      }
+    } finally {
+      warnSpy.mockRestore();
+      exitSpy.mockRestore();
+      onceSpy.mockRestore();
+      onSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it('falls back to module provider when global registration fails', () => {
     const symbol = Symbol.for('openai.agents.core.traceProvider');
     const globalHolder = globalThis as unknown as Record<
@@ -797,6 +855,39 @@ describe('BatchTraceProcessor', () => {
 
     debugSpy.mockRestore();
     vi.useRealTimers();
+  });
+
+  it('passes an abort signal to exporter during timed shutdown', async () => {
+    vi.useFakeTimers();
+    let exportSignal: AbortSignal | undefined;
+    let resolveExport: (() => void) | undefined;
+    const exporter: TracingExporter = {
+      export: async (_items, signal) => {
+        exportSignal = signal;
+        await new Promise<void>((resolve) => {
+          resolveExport = resolve;
+        });
+      },
+    };
+    const processor = new BatchTraceProcessor(exporter, {
+      maxQueueSize: 10,
+      maxBatchSize: 5,
+      scheduleDelay: 10000,
+    });
+
+    try {
+      await processor.onTraceStart(new Trace({ name: 'abortable-export' }));
+      const shutdownPromise = processor.shutdown(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(exportSignal).toBeDefined();
+      expect(exportSignal?.aborted).toBe(true);
+
+      resolveExport?.();
+      await shutdownPromise;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/packages/agents-openai/src/openaiTracingExporter.ts
+++ b/packages/agents-openai/src/openaiTracingExporter.ts
@@ -34,6 +34,33 @@ type JsonCompatibleValue =
 const OPENAI_TRACING_MAX_FIELD_BYTES = 100_000;
 const OPENAI_TRACING_MAX_RECURSION_DEPTH = 1_000;
 const OPENAI_TRACING_STRING_TRUNCATION_SUFFIX = '... [truncated]';
+
+async function sleepWithAbort(
+  delayMs: number,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  if (signal?.aborted) {
+    return false;
+  }
+
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      resolve(true);
+    }, delayMs);
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      signal?.removeEventListener('abort', onAbort);
+    };
+    const onAbort = () => {
+      cleanup();
+      resolve(false);
+    };
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
 const UNSERIALIZABLE = Symbol('openaiTracingExporter.unserializable');
 const textEncoder = new TextEncoder();
 
@@ -765,10 +792,18 @@ export class OpenAITracingExporter implements TracingExporter {
           break;
         }
 
-        const sleepTime = delay + Math.random() * 0.1 * delay; // 10% jitter
-        await new Promise((resolve) => setTimeout(resolve, sleepTime));
-        delay = Math.min(delay * 2, this.#options.maxDelay);
         attempts++;
+        if (attempts >= this.#options.maxRetries) {
+          break;
+        }
+
+        const sleepTime = delay + Math.random() * 0.1 * delay; // 10% jitter
+        const shouldContinue = await sleepWithAbort(sleepTime, signal);
+        if (!shouldContinue) {
+          logger.error('Tracing: request aborted');
+          break;
+        }
+        delay = Math.min(delay * 2, this.#options.maxDelay);
       }
 
       if (attempts >= this.#options.maxRetries) {

--- a/packages/agents-openai/test/openaiTracingExporter.test.ts
+++ b/packages/agents-openai/test/openaiTracingExporter.test.ts
@@ -1171,6 +1171,47 @@ describe('OpenAITracingExporter', () => {
     warnSpy.mockRestore();
   });
 
+  it('stops retrying when aborted during retry backoff', async () => {
+    vi.useFakeTimers();
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    const item = fakeSpan;
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => 'err',
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    try {
+      const exporter = new OpenAITracingExporter({
+        apiKey: 'key2',
+        endpoint: 'url',
+        maxRetries: 3,
+        baseDelay: 1000,
+        maxDelay: 1000,
+      });
+      const controller = new AbortController();
+      const exportPromise = exporter.export([item], controller.signal);
+
+      await vi.waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+      controller.abort();
+      await exportPromise;
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[non-fatal] Tracing: server error 500, retrying.',
+      );
+      expect(errorSpy).toHaveBeenCalledWith('Tracing: request aborted');
+    } finally {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it('stops on client error', async () => {
     const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
     const item = fakeSpan;


### PR DESCRIPTION
This pull request fixes a shutdown-path bug where tracing export retries or timeouts could cause Node processes to exit with code 1 during `beforeExit` cleanup. The change makes process-exit tracing cleanup best-effort, while preserving explicit signal and unhandled rejection exit handling.

It updates tracing shutdown to pass timeout cancellation through `BatchTraceProcessor` into `OpenAITracingExporter`, allowing in-flight requests and retry backoff waits to abort cleanly instead of holding process shutdown. It also adds regression coverage for the `beforeExit` timeout path, abort-signal propagation, and exporter retry abort behavior.