### PR TITLE
fix: preserve reasoning identities for OpenAI Conversations persistence

### DIFF
--- a/.changeset/calm-clouds-reason.md
+++ b/.changeset/calm-clouds-reason.md
@@ -3,4 +3,4 @@
 '@openai/agents-openai': patch
 ---
 
-fix: preserve reasoning identities for OpenAI Conversations persistence
+fix: preserve Conversations reasoning identities without replaying omitted IDs

--- a/.changeset/calm-clouds-reason.md
+++ b/.changeset/calm-clouds-reason.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+---
+
+fix: preserve reasoning identities for OpenAI Conversations persistence

--- a/packages/agents-core/src/memory/session.ts
+++ b/packages/agents-core/src/memory/session.ts
@@ -47,6 +47,14 @@ export interface Session {
   prepareHistoryItemForModelInput?(item: AgentInputItem): AgentInputItem;
 
   /**
+   * Optionally preserve reasoning item IDs when persisting generated output.
+   *
+   * Some remote session stores require provider-assigned reasoning identities to accept stored
+   * reasoning items, even when model replay should omit those IDs.
+   */
+  preserveReasoningItemIdsForPersistence?(): boolean;
+
+  /**
    * Append new items to the conversation history.
    *
    * @param items - Items to add to the session history.

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -524,7 +524,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     // Per-run callback can override runner-level tool error formatting defaults.
     const toolErrorFormatter =
       resolvedOptions.toolErrorFormatter ?? this.config.toolErrorFormatter;
-    const reasoningItemIdPolicy = resolvedOptions.reasoningItemIdPolicy;
+    const reasoningItemIdPolicy =
+      resolvedOptions.reasoningItemIdPolicy ??
+      this.config.reasoningItemIdPolicy;
     const toolExecution = validateToolExecutionConfig(
       resolvedOptions.toolExecution ?? this.config.toolExecution,
     );
@@ -578,6 +580,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           // previous messages are recovered via conversationId/previousResponseId.
           includeHistoryInPreparedInput: !serverManagesConversation,
           preserveDroppedNewItems: serverManagesConversation,
+          reasoningItemIdPolicy,
         },
       );
       if (serverManagesConversation && session) {

--- a/packages/agents-core/src/runner/items.ts
+++ b/packages/agents-core/src/runner/items.ts
@@ -99,26 +99,37 @@ function shouldOmitReasoningItemIds(
   return reasoningItemIdPolicy === 'omit';
 }
 
+export function stripReasoningItemIdForPolicy(
+  item: AgentInputItem,
+  reasoningItemIdPolicy?: ReasoningItemIdPolicy,
+): AgentInputItem {
+  if (
+    !shouldOmitReasoningItemIds(reasoningItemIdPolicy) ||
+    !item ||
+    typeof item !== 'object' ||
+    item.type !== 'reasoning' ||
+    !('id' in item)
+  ) {
+    return item;
+  }
+
+  const { id: _id, ...withoutId } = item as Record<string, unknown>;
+  return withoutId as AgentInputItem;
+}
+
 // Extracts model-ready output items from run items, excluding approval placeholders.
 export function extractOutputItemsFromRunItems(
   items: RunItem[],
   reasoningItemIdPolicy?: ReasoningItemIdPolicy,
 ): AgentInputItem[] {
-  const omitReasoningItemIds = shouldOmitReasoningItemIds(
-    reasoningItemIdPolicy,
-  );
   return items
     .filter((item) => item.type !== 'tool_approval_item')
     .map((item) => {
       const rawItem = withoutNullStatus(item.rawItem as AgentInputItem);
-      if (!omitReasoningItemIds || item.type !== 'reasoning_item') {
+      if (item.type !== 'reasoning_item') {
         return rawItem;
       }
-      if (!rawItem || typeof rawItem !== 'object' || !('id' in rawItem)) {
-        return rawItem;
-      }
-      const { id: _id, ...withoutId } = rawItem as Record<string, unknown>;
-      return withoutId as AgentInputItem;
+      return stripReasoningItemIdForPolicy(rawItem, reasoningItemIdPolicy);
     });
 }
 

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -18,6 +18,8 @@ import {
   toAgentInputList,
   getAgentInputItemKey,
   removeAgentInputFromPool,
+  stripReasoningItemIdForPolicy,
+  type ReasoningItemIdPolicy,
 } from './items';
 import logger from '../logger';
 
@@ -325,6 +327,7 @@ export async function prepareInputItemsWithSession(
   options?: {
     includeHistoryInPreparedInput?: boolean;
     preserveDroppedNewItems?: boolean;
+    reasoningItemIdPolicy?: ReasoningItemIdPolicy;
   },
 ): Promise<PreparedInputWithSessionResult> {
   if (!session) {
@@ -337,13 +340,14 @@ export async function prepareInputItemsWithSession(
   const includeHistoryInPreparedInput =
     options?.includeHistoryInPreparedInput ?? true;
   const preserveDroppedNewItems = options?.preserveDroppedNewItems ?? false;
+  const reasoningItemIdPolicy = options?.reasoningItemIdPolicy;
 
   const history = await session.getItems();
   const newInputItems = toAgentInputList(input);
 
   if (!sessionInputCallback) {
     const historyForModelInput = history.map((item) =>
-      prepareHistoryItemForModelInput(session, item),
+      prepareHistoryItemForModelInput(session, item, reasoningItemIdPolicy),
     );
     const preparedInput = includeHistoryInPreparedInput
       ? dropOrphanToolCalls([...historyForModelInput, ...newInputItems], {
@@ -369,6 +373,7 @@ export async function prepareInputItemsWithSession(
   const historyCounts = buildItemFrequencyMap(historySnapshot, {
     session,
     prepareForModelInput: true,
+    reasoningItemIdPolicy,
   });
   const newInputCounts = buildItemFrequencyMap(newInputSnapshot);
   const historyRefs = buildAgentInputPool(historySnapshot);
@@ -433,6 +438,7 @@ export async function prepareInputItemsWithSession(
           session,
           preparedItems,
           historyIndexes,
+          reasoningItemIdPolicy,
         ),
         { pruningIndexes: historyIndexes },
       )
@@ -448,13 +454,14 @@ function prepareHistoryItemsForModelInput(
   session: Session,
   items: AgentInputItem[],
   historyIndexes: Set<number>,
+  reasoningItemIdPolicy?: ReasoningItemIdPolicy,
 ): AgentInputItem[] {
-  if (!session.prepareHistoryItemForModelInput || historyIndexes.size === 0) {
+  if (historyIndexes.size === 0) {
     return items;
   }
   return items.map((item, index) =>
     historyIndexes.has(index)
-      ? prepareHistoryItemForModelInput(session, item)
+      ? prepareHistoryItemForModelInput(session, item, reasoningItemIdPolicy)
       : item,
   );
 }
@@ -462,15 +469,20 @@ function prepareHistoryItemsForModelInput(
 function prepareHistoryItemForModelInput(
   session: Session,
   item: AgentInputItem,
+  reasoningItemIdPolicy?: ReasoningItemIdPolicy,
 ): AgentInputItem {
-  return session.prepareHistoryItemForModelInput?.(item) ?? item;
+  const prepared = session.prepareHistoryItemForModelInput?.(item) ?? item;
+  return stripReasoningItemIdForPolicy(prepared, reasoningItemIdPolicy);
 }
 
 function getHistoryItemModelInputKey(
   session: Session,
   item: AgentInputItem,
+  reasoningItemIdPolicy?: ReasoningItemIdPolicy,
 ): string {
-  return getAgentInputItemKey(prepareHistoryItemForModelInput(session, item));
+  return getAgentInputItemKey(
+    prepareHistoryItemForModelInput(session, item, reasoningItemIdPolicy),
+  );
 }
 
 function normalizeItemsForSessionPersistence(
@@ -682,13 +694,21 @@ async function runCompactionOnSession(
 
 function buildItemFrequencyMap(
   items: AgentInputItem[],
-  options?: { session?: Session; prepareForModelInput?: boolean },
+  options?: {
+    session?: Session;
+    prepareForModelInput?: boolean;
+    reasoningItemIdPolicy?: ReasoningItemIdPolicy;
+  },
 ): Map<string, number> {
   const counts = new Map<string, number>();
   for (const item of items) {
     const key =
       options?.prepareForModelInput && options.session
-        ? getHistoryItemModelInputKey(options.session, item)
+        ? getHistoryItemModelInputKey(
+            options.session,
+            item,
+            options.reasoningItemIdPolicy,
+          )
         : getAgentInputItemKey(item);
     counts.set(key, (counts.get(key) ?? 0) + 1);
   }

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -625,7 +625,9 @@ async function persistRunItemsToSession(options: {
     ...extraInputItems,
     ...extractOutputItemsFromRunItems(
       newRunItems,
-      state._reasoningItemIdPolicy,
+      session.preserveReasoningItemIdsForPersistence?.() === true
+        ? undefined
+        : state._reasoningItemIdPolicy,
     ),
   ];
 

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -382,7 +382,11 @@ export async function prepareInputItemsWithSession(
 
   const appended: AgentInputItem[] = [];
   for (const [index, item] of combined.entries()) {
-    const historyKey = getHistoryItemModelInputKey(session, item);
+    const historyKey = getHistoryItemModelInputKey(
+      session,
+      item,
+      reasoningItemIdPolicy,
+    );
     const newInputKey = getAgentInputItemKey(item);
     if (removeAgentInputFromPool(newInputRefs, item)) {
       decrementCount(newInputCounts, newInputKey);

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -2800,6 +2800,41 @@ describe('Runner.run', () => {
         expect(firstPart?.providerData).toEqual({ annotations: [] });
       });
 
+      it('applies runner-level reasoningItemIdPolicy to replayed session history', async () => {
+        class ReasoningPreservingSession extends MemorySession {
+          preserveReasoningItemIdsForPersistence(): boolean {
+            return true;
+          }
+        }
+
+        const model = new RecordingModel([
+          {
+            ...TEST_MODEL_RESPONSE_BASIC,
+            output: [fakeModelMessage('response')],
+          },
+        ]);
+        const agent = new Agent({ name: 'SessionReasoningAgent', model });
+        const session = new ReasoningPreservingSession([
+          {
+            id: 'rs_persisted',
+            type: 'reasoning',
+            content: [{ type: 'input_text', text: 'stored reasoning' }],
+          },
+        ]);
+        const runner = new Runner({ reasoningItemIdPolicy: 'omit' });
+
+        await runner.run(agent, 'new input', { session });
+
+        expect(model.lastRequest).toBeDefined();
+        const reasoningItem = getRequestInputItems(model.lastRequest!).find(
+          (item): item is protocol.ReasoningItem => item.type === 'reasoning',
+        );
+        expect(reasoningItem).toEqual({
+          type: 'reasoning',
+          content: [{ type: 'input_text', text: 'stored reasoning' }],
+        });
+      });
+
       it('allows list inputs with session history and no session input callback', async () => {
         const model = new RecordingModel([
           {

--- a/packages/agents-core/test/runner/sessionPersistence.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.test.ts
@@ -307,6 +307,61 @@ describe('saveStreamResultToSession', () => {
     ]);
   });
 
+  it('preserves streamed reasoning IDs when the session requires them', async () => {
+    class ReasoningPreservingSession extends TrackingSession {
+      preserveReasoningItemIdsForPersistence(): boolean {
+        return true;
+      }
+    }
+
+    const textAgent = new Agent<UnknownContext, 'text'>({
+      name: 'StreamerReasoningPreserve',
+      outputType: 'text',
+      instructions: 'stream reasoning test',
+    });
+    const agent = textAgent as unknown as Agent<
+      UnknownContext,
+      AgentOutputType
+    >;
+    const session = new ReasoningPreservingSession();
+    const context = new RunContext<UnknownContext>(undefined as UnknownContext);
+    const state = new RunState<
+      UnknownContext,
+      Agent<UnknownContext, AgentOutputType>
+    >(context, 'hello', agent, 10);
+    state.setReasoningItemIdPolicy('omit');
+
+    state._modelResponses.push({
+      output: [],
+      usage: new Usage(),
+      responseId: 'resp_reasoning',
+    });
+    state._generatedItems = [
+      new ReasoningItem(
+        {
+          type: 'reasoning',
+          id: 'rs_stream',
+          content: [{ type: 'input_text', text: 'thinking' }],
+        },
+        textAgent,
+      ),
+    ];
+
+    const streamedResult = new StreamedRunResult({
+      state,
+    });
+
+    await saveStreamResultToSession(session, streamedResult);
+
+    expect(session.items).toEqual([
+      {
+        type: 'reasoning',
+        id: 'rs_stream',
+        content: [{ type: 'input_text', text: 'thinking' }],
+      },
+    ]);
+  });
+
   it('skips writes when there is no new streamed output but still runs compaction', async () => {
     const textAgent = new Agent<UnknownContext, 'text'>({
       name: 'StreamerNoDelta',
@@ -1185,6 +1240,44 @@ describe('saveToSession', () => {
       this.items = [];
     }
   }
+
+  it('preserves reasoning IDs for sessions that require them', async () => {
+    class ReasoningPreservingSession extends MemorySession {
+      preserveReasoningItemIdsForPersistence(): boolean {
+        return true;
+      }
+    }
+
+    const agent = new Agent<UnknownContext, 'text'>({
+      name: 'ReasoningSessionAgent',
+      outputType: 'text',
+      instructions: 'test',
+    });
+    const session = new ReasoningPreservingSession();
+    const state = new RunState(new RunContext(), 'hello', agent as any, 10);
+    state.setReasoningItemIdPolicy('omit');
+
+    state._generatedItems = [
+      new ReasoningItem(
+        {
+          type: 'reasoning',
+          id: 'rs_session',
+          content: [{ type: 'input_text', text: 'thinking' }],
+        },
+        agent,
+      ),
+    ];
+
+    await saveToSession(session, [], new RunResult(state));
+
+    expect(session.items).toEqual([
+      {
+        type: 'reasoning',
+        id: 'rs_session',
+        content: [{ type: 'input_text', text: 'thinking' }],
+      },
+    ]);
+  });
 
   it('keeps tool_search ids when persisting session history without call ids', async () => {
     const agent = new Agent<UnknownContext, 'text'>({

--- a/packages/agents-core/test/runner/sessionPersistence.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.test.ts
@@ -1026,6 +1026,38 @@ describe('prepareInputItemsWithSession', () => {
     expect(result.sessionItems).toEqual([newItem]);
   });
 
+  it('matches cloned callback reasoning history with persisted ids when policy omits them', async () => {
+    const reasoningHistoryItem: AgentInputItem = {
+      id: 'rs_persisted',
+      type: 'reasoning',
+      content: [{ type: 'input_text', text: 'thinking' }],
+    };
+    const newItem: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'new',
+    };
+    const session = new StubSession([reasoningHistoryItem]);
+
+    const result = await prepareInputItemsWithSession(
+      [newItem],
+      session,
+      (history, newItems) => [{ ...history[0] }, { ...newItems[0] }],
+      {
+        reasoningItemIdPolicy: 'omit',
+      },
+    );
+
+    expect(result.preparedInput).toEqual([
+      {
+        type: 'reasoning',
+        content: [{ type: 'input_text', text: 'thinking' }],
+      },
+      newItem,
+    ]);
+    expect(result.sessionItems).toEqual([newItem]);
+  });
+
   it('keeps sanitized user history distinct when callbacks remove its id', async () => {
     const userHistoryItem: AgentInputItem = {
       id: 'conv-user',

--- a/packages/agents-core/test/runner/sessionPersistence.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.test.ts
@@ -908,6 +908,33 @@ describe('prepareInputItemsWithSession', () => {
     expect(result.sessionItems).toEqual(toAgentInputList('new'));
   });
 
+  it('strips persisted reasoning IDs from model input when policy omits them', async () => {
+    const reasoningHistoryItem: AgentInputItem = {
+      id: 'rs_persisted',
+      type: 'reasoning',
+      content: [{ type: 'input_text', text: 'thinking' }],
+    };
+    const session = new StubSession([reasoningHistoryItem]);
+
+    const result = await prepareInputItemsWithSession(
+      'new',
+      session,
+      undefined,
+      {
+        reasoningItemIdPolicy: 'omit',
+      },
+    );
+
+    expect(result.preparedInput).toEqual([
+      {
+        type: 'reasoning',
+        content: [{ type: 'input_text', text: 'thinking' }],
+      },
+      ...toAgentInputList('new'),
+    ]);
+    expect(result.sessionItems).toEqual(toAgentInputList('new'));
+  });
+
   it('matches sanitized assistant history returned by callbacks without re-persisting it', async () => {
     const assistantHistoryItem: AgentInputItem = {
       id: 'conv-assistant',
@@ -955,6 +982,44 @@ describe('prepareInputItemsWithSession', () => {
             text: 'assistant history',
           },
         ],
+      },
+      newItem,
+    ]);
+    expect(result.sessionItems).toEqual([newItem]);
+  });
+
+  it('matches callback-returned reasoning history after policy-based id stripping', async () => {
+    const reasoningHistoryItem: AgentInputItem = {
+      id: 'rs_persisted',
+      type: 'reasoning',
+      content: [{ type: 'input_text', text: 'thinking' }],
+    };
+    const newItem: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'new',
+    };
+    const session = new StubSession([reasoningHistoryItem]);
+
+    const result = await prepareInputItemsWithSession(
+      [newItem],
+      session,
+      (history, newItems) => {
+        const { id: _id, ...historyWithoutId } = history[0] as Record<
+          string,
+          unknown
+        >;
+        return [historyWithoutId as AgentInputItem, { ...newItems[0] }];
+      },
+      {
+        reasoningItemIdPolicy: 'omit',
+      },
+    );
+
+    expect(result.preparedInput).toEqual([
+      {
+        type: 'reasoning',
+        content: [{ type: 'input_text', text: 'thinking' }],
       },
       newItem,
     ]);

--- a/packages/agents-openai/src/memory/openaiConversationsSession.ts
+++ b/packages/agents-openai/src/memory/openaiConversationsSession.ts
@@ -178,6 +178,10 @@ export class OpenAIConversationsSession
     return stripAssistantReplayMetadata(item);
   }
 
+  preserveReasoningItemIdsForPersistence(): boolean {
+    return true;
+  }
+
   async addItems(items: AgentInputItem[]): Promise<void> {
     if (!items.length) {
       return;
@@ -188,6 +192,9 @@ export class OpenAIConversationsSession
     const sanitizedItems = stripConversationPersistenceMetadata(
       getInputItems(normalizedItems),
     );
+    if (!sanitizedItems.length) {
+      return;
+    }
     await this.#client.conversations.items.create(conversationId, {
       items: sanitizedItems,
     });
@@ -252,19 +259,32 @@ function stripProviderModelForConversationPersistence(
 function stripConversationPersistenceMetadata(
   items: OpenAI.Responses.ResponseInputItem[],
 ): OpenAI.Responses.ResponseInputItem[] {
-  return items.map((item) => {
+  return items.flatMap((item) => {
     if (Array.isArray(item) || item === null || typeof item !== 'object') {
-      return item;
+      return [item];
     }
     const record = item as unknown as Record<string, unknown>;
+    if (isUnpersistableReasoningItem(record)) {
+      return [];
+    }
     const {
-      id: _id,
       providerData: _providerData,
       provider_data: _provider_data,
       ...rest
     } = record;
-    return rest as unknown as OpenAI.Responses.ResponseInputItem;
+    if (rest.type !== 'reasoning') {
+      delete rest.id;
+    }
+    return [rest as unknown as OpenAI.Responses.ResponseInputItem];
   });
+}
+
+function isUnpersistableReasoningItem(item: Record<string, unknown>): boolean {
+  return (
+    item.type === 'reasoning' &&
+    typeof item.id !== 'string' &&
+    typeof item.encrypted_content !== 'string'
+  );
 }
 
 function stripAssistantReplayMetadata(item: AgentInputItem): AgentInputItem {

--- a/packages/agents-openai/test/openaiConversationsSession.test.ts
+++ b/packages/agents-openai/test/openaiConversationsSession.test.ts
@@ -514,6 +514,146 @@ describe('OpenAIConversationsSession', () => {
     });
   });
 
+  it('preserves reasoning identity and encrypted content when adding items', async () => {
+    const createMock = vi.fn();
+    const inputItems = [
+      {
+        id: 'rs-input',
+        type: 'reasoning',
+        content: [],
+        providerData: { model: 'some-model' },
+      },
+    ];
+    const converted = [
+      {
+        id: 'rs-output',
+        type: 'reasoning',
+        summary: [],
+        encrypted_content: 'encrypted',
+        providerData: { server: 'metadata' },
+        provider_data: { server: 'snake' },
+      },
+    ];
+
+    getInputItemsMock.mockReturnValue(converted as any);
+
+    const session = createSession({
+      client: {
+        conversations: {
+          items: {
+            list: vi.fn(),
+            create: createMock,
+            delete: vi.fn(),
+          },
+          create: vi.fn(),
+          delete: vi.fn(),
+        },
+      } as any,
+      conversationId: 'conv-123',
+    });
+
+    await session.addItems(inputItems as any);
+
+    expect(createMock).toHaveBeenCalledWith('conv-123', {
+      items: [
+        {
+          id: 'rs-output',
+          type: 'reasoning',
+          summary: [],
+          encrypted_content: 'encrypted',
+        },
+      ],
+    });
+  });
+
+  it('drops reasoning items that Conversations cannot persist', async () => {
+    const createMock = vi.fn();
+    const inputItems = [
+      { type: 'message', role: 'user', content: 'hello' },
+      { type: 'reasoning', id: 'rs-input', content: [] },
+      { type: 'message', role: 'assistant', content: [] },
+    ];
+    const converted = [
+      {
+        id: 'msg-user',
+        type: 'message',
+        role: 'user',
+        content: 'hello',
+      },
+      {
+        type: 'reasoning',
+        summary: [],
+      },
+      {
+        id: 'msg-assistant',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+      },
+    ];
+
+    getInputItemsMock.mockReturnValue(converted as any);
+
+    const session = createSession({
+      client: {
+        conversations: {
+          items: {
+            list: vi.fn(),
+            create: createMock,
+            delete: vi.fn(),
+          },
+          create: vi.fn(),
+          delete: vi.fn(),
+        },
+      } as any,
+      conversationId: 'conv-123',
+    });
+
+    await session.addItems(inputItems as any);
+
+    expect(createMock).toHaveBeenCalledWith('conv-123', {
+      items: [
+        {
+          type: 'message',
+          role: 'user',
+          content: 'hello',
+        },
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [],
+        },
+      ],
+    });
+  });
+
+  it('skips the Conversations write when every item is unpersistable', async () => {
+    const createMock = vi.fn();
+    const inputItems = [{ type: 'reasoning', id: 'rs-input', content: [] }];
+    const converted = [{ type: 'reasoning', summary: [] }];
+
+    getInputItemsMock.mockReturnValue(converted as any);
+
+    const session = createSession({
+      client: {
+        conversations: {
+          items: {
+            list: vi.fn(),
+            create: createMock,
+            delete: vi.fn(),
+          },
+          create: vi.fn(),
+          delete: vi.fn(),
+        },
+      } as any,
+      conversationId: 'conv-123',
+    });
+
+    await session.addItems(inputItems as any);
+
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
   it('strips persistence metadata after converting hosted tool calls', async () => {
     const createMock = vi.fn();
     const inputItems = [


### PR DESCRIPTION
This pull request fixes OpenAI Conversations session persistence for reasoning model outputs. Previously, `OpenAIConversationsSession` could strip provider-assigned reasoning item IDs before calling `conversations.items.create`, producing invalid `{"type":"reasoning","summary":[]}` payloads and causing `400 invalid_item` failures.

The change adds a narrow session persistence hook so Conversations-backed sessions can preserve reasoning IDs even when model replay uses `reasoningItemIdPolicy: "omit"`. It also updates Conversations payload sanitization to keep reasoning `id` and `encrypted_content`, continue stripping stale optional IDs from other item types, and drop only reasoning items that have neither `id` nor `encrypted_content`.

see also: https://github.com/openai/openai-agents-python/pull/3352