### PR TITLE
fix: avoid empty chat completions tool outputs

### DIFF
--- a/.changeset/cyan-pears-train.md
+++ b/.changeset/cyan-pears-train.md
@@ -2,4 +2,4 @@
 '@openai/agents-openai': patch
 ---
 
-fix: avoid empty chat completions tool outputs
+fix: handle unsupported chat completions tool outputs safely

--- a/.changeset/cyan-pears-train.md
+++ b/.changeset/cyan-pears-train.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: avoid empty chat completions tool outputs

--- a/packages/agents-openai/src/openaiChatCompletionsConverter.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsConverter.ts
@@ -490,6 +490,13 @@ function normalizeFunctionCallOutputForChat(
       return handleEmptyOrNonTextToolOutput(options);
     }
 
+    if (options.strictFeatureValidation && textItems.length !== output.length) {
+      throw new UserError(
+        'Only text tool outputs are supported for chat completions. Got item: ' +
+          JSON.stringify(output),
+      );
+    }
+
     return textItems.map((item) => item.text).join('');
   }
 

--- a/packages/agents-openai/src/openaiChatCompletionsConverter.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsConverter.ts
@@ -14,8 +14,14 @@ import {
   UserError,
 } from '@openai/agents-core';
 import { getProviderDataWithoutReservedKeys } from './utils/providerData';
+import logger from './logger';
 
 const CHAT_COMPLETIONS_FUNCTION_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const OMITTED_TOOL_OUTPUT_PLACEHOLDER = '[tool output omitted]';
+
+type ItemsToMessagesOptions = {
+  strictFeatureValidation?: boolean;
+};
 
 export function convertToolChoice(
   toolChoice: 'auto' | 'required' | 'none' | (string & {}) | undefined | null,
@@ -246,6 +252,7 @@ function isMessageItem(item: protocol.ModelItem): item is protocol.MessageItem {
 
 export function itemsToMessages(
   items: ModelRequest['input'],
+  options: ItemsToMessagesOptions = {},
 ): ChatCompletionMessageParam[] {
   if (typeof items === 'string') {
     return [{ role: 'user', content: items }];
@@ -436,7 +443,10 @@ export function itemsToMessages(
     } else if (item.type === 'function_call_result') {
       flushAssistantMessage();
       const funcOutput = item;
-      const toolContent = normalizeFunctionCallOutputForChat(funcOutput.output);
+      const toolContent = normalizeFunctionCallOutputForChat(
+        funcOutput.output,
+        options,
+      );
 
       result.push({
         role: 'tool',
@@ -467,19 +477,20 @@ export function itemsToMessages(
 
 function normalizeFunctionCallOutputForChat(
   output: protocol.FunctionCallResultItem['output'],
+  options: ItemsToMessagesOptions,
 ): string {
   if (typeof output === 'string') {
     return output;
   }
 
   if (Array.isArray(output)) {
-    const textOnly = output.every((item) => item.type === 'input_text');
-    if (!textOnly) {
-      throw new UserError(
-        'Only text tool outputs are supported for chat completions.',
-      );
+    const textItems = output.filter((item) => item.type === 'input_text');
+
+    if (textItems.length === 0) {
+      return handleEmptyOrNonTextToolOutput(options);
     }
-    return output.map((item) => item.text).join('');
+
+    return textItems.map((item) => item.text).join('');
   }
 
   if (
@@ -490,10 +501,30 @@ function normalizeFunctionCallOutputForChat(
     return output.text;
   }
 
+  if (isRecord(output) && (output.type === 'image' || output.type === 'file')) {
+    return handleEmptyOrNonTextToolOutput(options);
+  }
+
   throw new UserError(
     'Only text tool outputs are supported for chat completions. Got item: ' +
       JSON.stringify(output),
   );
+}
+
+function handleEmptyOrNonTextToolOutput(
+  options: ItemsToMessagesOptions,
+): string {
+  const message =
+    'Chat Completions tool outputs cannot be empty or contain only non-text content.';
+
+  if (options.strictFeatureValidation) {
+    throw new UserError(message);
+  }
+
+  logger.warn(
+    `${message} Replacing the tool output with a placeholder; enable strict feature validation to raise an error instead.`,
+  );
+  return OMITTED_TOOL_OUTPUT_PLACEHOLDER;
 }
 
 function isRecord(value: unknown): value is Record<string, any> {

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -417,7 +417,9 @@ export class OpenAIChatCompletionsModel implements Model {
       parallelToolCalls = request.modelSettings.parallelToolCalls;
     }
 
-    const messages = itemsToMessages(request.input);
+    const messages = itemsToMessages(request.input, {
+      strictFeatureValidation: this.#strictFeatureValidation,
+    });
     if (request.systemInstructions) {
       messages.unshift({
         content: request.systemInstructions,

--- a/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, vi } from 'vitest';
 import {
   convertToolChoice,
   extractAllAssistantContent,
@@ -14,6 +14,7 @@ import type {
   SerializedHandoff,
   SerializedTool,
 } from '@openai/agents-core/model';
+import logger from '../src/logger';
 
 /**
  * Tests around the helpers converting internal protocol structures to the
@@ -455,6 +456,164 @@ describe('itemsToMessages', () => {
       },
       { role: 'tool', tool_call_id: 'call1', content: 'res' },
     ]);
+  });
+
+  test('uses placeholder for empty structured function output by default', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call_result',
+        id: '2',
+        callId: 'call1',
+        name: 'f',
+        status: 'completed',
+        output: [],
+      } as protocol.FunctionCallResultItem,
+    ];
+
+    expect(itemsToMessages(items)).toEqual([
+      {
+        role: 'tool',
+        tool_call_id: 'call1',
+        content: '[tool output omitted]',
+      },
+    ]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Replacing the tool output with a placeholder'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  test('uses placeholder for non-text-only structured function output by default', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call_result',
+        id: '2',
+        callId: 'call1',
+        name: 'f',
+        status: 'completed',
+        output: [
+          {
+            type: 'input_image',
+            image: 'https://example.com/image.png',
+          },
+        ],
+      } as protocol.FunctionCallResultItem,
+    ];
+
+    expect(itemsToMessages(items)).toEqual([
+      {
+        role: 'tool',
+        tool_call_id: 'call1',
+        content: '[tool output omitted]',
+      },
+    ]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Replacing the tool output with a placeholder'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  test('keeps text from mixed structured function output by default', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call_result',
+        id: '2',
+        callId: 'call1',
+        name: 'f',
+        status: 'completed',
+        output: [
+          {
+            type: 'input_text',
+            text: 'visible',
+          },
+          {
+            type: 'input_image',
+            image: 'https://example.com/image.png',
+          },
+        ],
+      } as protocol.FunctionCallResultItem,
+    ];
+
+    expect(itemsToMessages(items)).toEqual([
+      {
+        role: 'tool',
+        tool_call_id: 'call1',
+        content: 'visible',
+      },
+    ]);
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  test('keeps explicit empty text from structured function output', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call_result',
+        id: '2',
+        callId: 'call1',
+        name: 'f',
+        status: 'completed',
+        output: [
+          {
+            type: 'input_text',
+            text: '',
+          },
+        ],
+      } as protocol.FunctionCallResultItem,
+    ];
+
+    expect(itemsToMessages(items)).toEqual([
+      {
+        role: 'tool',
+        tool_call_id: 'call1',
+        content: '',
+      },
+    ]);
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  test('throws for empty structured function output in strict mode', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call_result',
+        id: '2',
+        callId: 'call1',
+        name: 'f',
+        status: 'completed',
+        output: [],
+      } as protocol.FunctionCallResultItem,
+    ];
+
+    expect(() =>
+      itemsToMessages(items, { strictFeatureValidation: true }),
+    ).toThrow(/cannot be empty or contain only non-text content/);
+  });
+
+  test('throws for non-text-only structured function output in strict mode', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call_result',
+        id: '2',
+        callId: 'call1',
+        name: 'f',
+        status: 'completed',
+        output: [
+          {
+            type: 'input_image',
+            image: 'https://example.com/image.png',
+          },
+        ],
+      } as protocol.FunctionCallResultItem,
+    ];
+
+    expect(() =>
+      itemsToMessages(items, { strictFeatureValidation: true }),
+    ).toThrow(/cannot be empty or contain only non-text content/);
   });
 
   test('rejects namespaced function call history', () => {

--- a/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
@@ -616,6 +616,32 @@ describe('itemsToMessages', () => {
     ).toThrow(/cannot be empty or contain only non-text content/);
   });
 
+  test('throws for mixed structured function output in strict mode', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call_result',
+        id: '2',
+        callId: 'call1',
+        name: 'f',
+        status: 'completed',
+        output: [
+          {
+            type: 'input_text',
+            text: 'visible',
+          },
+          {
+            type: 'input_image',
+            image: 'https://example.com/image.png',
+          },
+        ],
+      } as protocol.FunctionCallResultItem,
+    ];
+
+    expect(() =>
+      itemsToMessages(items, { strictFeatureValidation: true }),
+    ).toThrow(/Only text tool outputs are supported for chat completions/);
+  });
+
   test('rejects namespaced function call history', () => {
     const items: protocol.ModelItem[] = [
       {

--- a/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
@@ -80,6 +80,94 @@ describe('OpenAIChatCompletionsModel', () => {
     ]);
   });
 
+  it('sends placeholder for non-text-only tool output by default', async () => {
+    const client = new FakeClient();
+    const response = {
+      id: 'r',
+      choices: [{ message: { content: 'ok' } }],
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    } as any;
+    client.chat.completions.create.mockResolvedValue(response);
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const req: any = {
+      input: [
+        {
+          type: 'function_call_result',
+          id: '2',
+          callId: 'call_image',
+          name: 'f',
+          status: 'completed',
+          output: [
+            {
+              type: 'input_image',
+              image: 'https://example.com/image.png',
+            },
+          ],
+        },
+      ],
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+    };
+
+    await withTrace('t', () => model.getResponse(req));
+
+    expect(client.chat.completions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [
+          {
+            role: 'tool',
+            tool_call_id: 'call_image',
+            content: '[tool output omitted]',
+          },
+        ],
+      }),
+      { headers: HEADERS, signal: undefined },
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Replacing the tool output with a placeholder'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('rejects non-text-only tool output in strict mode before sending a request', async () => {
+    const client = new FakeClient();
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt', {
+      strictFeatureValidation: true,
+    });
+    const req: any = {
+      input: [
+        {
+          type: 'function_call_result',
+          id: '2',
+          callId: 'call_image',
+          name: 'f',
+          status: 'completed',
+          output: [
+            {
+              type: 'input_image',
+              image: 'https://example.com/image.png',
+            },
+          ],
+        },
+      ],
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+    };
+
+    await expect(withTrace('t', () => model.getResponse(req))).rejects.toThrow(
+      /cannot be empty or contain only non-text content/,
+    );
+    expect(client.chat.completions.create).not.toHaveBeenCalled();
+  });
+
   it('warns and ignores server-managed conversation state by default', async () => {
     const client = new FakeClient();
     const response = {


### PR DESCRIPTION
This pull request fixes Chat Completions history conversion when function tool outputs are empty or contain only non-text structured content. Instead of sending an empty tool message by default, the converter now sends `"[tool output omitted]"` with a warning, while strict feature validation raises a `UserError` before the request is sent.

It also preserves explicit text outputs, including empty text strings, and keeps text parts from mixed structured outputs. The change updates `packages/agents-openai/src/openaiChatCompletionsConverter.ts`, passes strict validation through `OpenAIChatCompletionsModel`, adds converter/model coverage, and includes the untracked changeset file `.changeset/cyan-pears-train.md` for `@openai/agents-openai`.