### PR TITLE
fix: avoid auto responses for unknown realtime tools

### DIFF
--- a/.changeset/real-cycles-thank.md
+++ b/.changeset/real-cycles-thank.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: avoid auto responses for unknown realtime tools

--- a/packages/agents-realtime/src/realtimeSession.ts
+++ b/packages/agents-realtime/src/realtimeSession.ts
@@ -715,7 +715,12 @@ export class RealtimeSession<
       if (functionTool && functionTool.type === 'function') {
         await this.#handleFunctionToolCall(toolCall, functionTool);
       } else {
-        throw new ModelBehaviorError(`Tool ${toolCall.name} not found`);
+        const message = `Tool ${toolCall.name} not found`;
+        this.#transport.sendFunctionCallOutput(toolCall, message, false);
+        this.emit('error', {
+          type: 'error',
+          error: new ModelBehaviorError(message),
+        });
       }
     }
   }

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -502,21 +502,24 @@ describe('RealtimeSession', () => {
     filterSpy.mockRestore();
   });
 
-  it('propagates errors from handleFunctionCall', async () => {
+  it('returns an error output without starting a response for unknown tools', async () => {
     const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
     const errorEvent = waitForEvent<any[]>(session, 'error');
+    const outputEvent = transport.waitForNextFunctionCallOutput();
     transport.emit('function_call', {
       type: 'function_call',
       name: 'missing',
       callId: '1',
       arguments: '{}',
     });
+    const [toolCall, output, startResponse] = await outputEvent;
     const [error] = await errorEvent;
+    expect(toolCall.name).toBe('missing');
+    expect(output).toBe('Tool missing not found');
+    expect(startResponse).toBe(false);
     expect(error.error).toBeInstanceOf(ModelBehaviorError);
-    expect(errorSpy).toHaveBeenCalledWith(
-      'Error handling function call',
-      expect.any(Error),
-    );
+    expect(error.error.message).toBe('Tool missing not found');
+    expect(errorSpy).not.toHaveBeenCalled();
     errorSpy.mockRestore();
   });
 


### PR DESCRIPTION
This pull request fixes Realtime sessions when the model calls a tool that is not registered on the current agent. Instead of throwing through the transport handler and only surfacing an SDK-side error, the session now completes the model-visible function call with `Tool <name> not found` and `startResponse: false`.

This keeps SDK observability by emitting a `ModelBehaviorError` error event, while avoiding an automatic follow-up response for an unknown tool. The change updates `packages/agents-realtime/src/realtimeSession.ts`, adjusts the Realtime session test coverage, and includes the untracked changeset file `.changeset/real-cycles-thank.md` for `@openai/agents-realtime`.