### PR TITLE
fix(realtime): encode large audio buffers safely

### DIFF
--- a/.changeset/safe-realtime-audio-buffers.md
+++ b/.changeset/safe-realtime-audio-buffers.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: safely encode large realtime audio buffers

--- a/packages/agents-realtime/src/utils.ts
+++ b/packages/agents-realtime/src/utils.ts
@@ -6,6 +6,7 @@ import {
 import type { InputAudioTranscriptionCompletedEvent } from './transportLayerEvents';
 import METADATA from './metadata';
 import { RunToolApprovalItem } from '@openai/agents-core';
+import { encodeUint8ArrayToBase64 } from '@openai/agents-core/utils';
 import { RealtimeAgent } from './realtimeAgent';
 
 /**
@@ -29,8 +30,7 @@ export function base64ToArrayBuffer(base64: string) {
  * @returns {string}
  */
 export function arrayBufferToBase64(arrayBuffer: ArrayBuffer) {
-  const binaryString = String.fromCharCode(...new Uint8Array(arrayBuffer));
-  return btoa(binaryString);
+  return encodeUint8ArrayToBase64(new Uint8Array(arrayBuffer));
 }
 
 /**

--- a/packages/agents-realtime/test/utils.test.ts
+++ b/packages/agents-realtime/test/utils.test.ts
@@ -25,6 +25,20 @@ describe('realtime utils', () => {
     expect(new Uint8Array(result)).toEqual(new Uint8Array(buffer));
   });
 
+  it('converts large ArrayBuffers to base64 and back', () => {
+    const bytes = new Uint8Array(512 * 1024);
+    for (let i = 0; i < bytes.length; i += 1) {
+      bytes[i] = i % 256;
+    }
+
+    let base64 = '';
+    expect(() => {
+      base64 = arrayBufferToBase64(bytes.buffer);
+    }).not.toThrow();
+
+    expect(new Uint8Array(base64ToArrayBuffer(base64))).toEqual(bytes);
+  });
+
   it('extracts transcript from audio output message', () => {
     const message: RealtimeMessageItem = {
       itemId: '1',


### PR DESCRIPTION
## Summary
- Use the shared Uint8Array base64 encoder for realtime ArrayBuffer audio data.
- Add a regression test that round-trips a 512 KiB buffer.
- Add a patch changeset for `@openai/agents-realtime`.

Fixes #1333.

## Root cause
The previous realtime helper converted bytes with `String.fromCharCode(...new Uint8Array(arrayBuffer))`, which spreads every byte as a function argument. Large audio chunks can exceed the runtime argument limit and throw a `RangeError` during base64 encoding.

## Validation
- `pnpm exec prettier --check packages/agents-realtime/src/utils.ts packages/agents-realtime/test/utils.test.ts .changeset/safe-realtime-audio-buffers.md`
- `pnpm exec eslint packages/agents-realtime/src/utils.ts packages/agents-realtime/test/utils.test.ts`
- `pnpm -F @openai/agents-realtime build-check`
- `pnpm -F @openai/agents-realtime dist:check`
- `pnpm -F @openai/agents-realtime build`