### PR TITLE
feat(core): add MCP server logging handler

### DIFF
--- a/.changeset/loud-mcp-servers-listen.md
+++ b/.changeset/loud-mcp-servers-listen.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents': patch
+---
+
+feat(core): add MCP server logging handler option

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -29,6 +29,10 @@ import type {
 } from './mcpUtil';
 import type { RunContext } from './runContext';
 import type { Agent } from './agent';
+import type {
+  LoggingLevel,
+  LoggingMessageNotification,
+} from '@modelcontextprotocol/sdk/types.js';
 
 export const DEFAULT_STDIO_MCP_CLIENT_LOGGER_NAME =
   'openai-agents:stdio-mcp-client';
@@ -43,6 +47,24 @@ export type MCPToolErrorFunction = (args: {
   context: RunContext;
   error: Error | unknown;
 }) => Promise<string> | string;
+
+export type MCPServerLoggingHandler = (message: {
+  level: LoggingMessageNotification['params']['level'];
+  logger?: string;
+  data: unknown;
+  meta?: LoggingMessageNotification['params']['_meta'];
+}) => void | Promise<void>;
+
+export type MCPServerLoggingOptions = {
+  /**
+   * Optional minimum level requested from the MCP server.
+   */
+  level?: LoggingLevel;
+  /**
+   * Handler invoked for MCP `notifications/message` logging events.
+   */
+  handler: MCPServerLoggingHandler;
+};
 
 const MCP_FUNCTION_TOOL_NAME_MAX_LENGTH = 64;
 const MCP_FUNCTION_TOOL_HASH_LENGTH = 8;
@@ -1212,6 +1234,7 @@ export interface BaseMCPServerStdioOptions {
    * Set to null to rethrow errors instead of converting them.
    */
   errorFunction?: MCPToolErrorFunction | null;
+  serverLogging?: MCPServerLoggingOptions;
   timeout?: number;
 }
 export interface DefaultMCPServerStdioOptions extends BaseMCPServerStdioOptions {
@@ -1242,6 +1265,7 @@ export interface MCPServerStreamableHttpOptions {
    * Set to null to rethrow errors instead of converting them.
    */
   errorFunction?: MCPToolErrorFunction | null;
+  serverLogging?: MCPServerLoggingOptions;
   timeout?: number;
 
   // ----------------------------------------------------
@@ -1276,6 +1300,7 @@ export interface MCPServerSSEOptions {
    * Set to null to rethrow errors instead of converting them.
    */
   errorFunction?: MCPToolErrorFunction | null;
+  serverLogging?: MCPServerLoggingOptions;
   timeout?: number;
 
   // ----------------------------------------------------

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -29,10 +29,6 @@ import type {
 } from './mcpUtil';
 import type { RunContext } from './runContext';
 import type { Agent } from './agent';
-import type {
-  LoggingLevel,
-  LoggingMessageNotification,
-} from '@modelcontextprotocol/sdk/types.js';
 
 export const DEFAULT_STDIO_MCP_CLIENT_LOGGER_NAME =
   'openai-agents:stdio-mcp-client';
@@ -48,18 +44,28 @@ export type MCPToolErrorFunction = (args: {
   error: Error | unknown;
 }) => Promise<string> | string;
 
+export type MCPServerLoggingLevel =
+  | 'debug'
+  | 'info'
+  | 'notice'
+  | 'warning'
+  | 'error'
+  | 'critical'
+  | 'alert'
+  | 'emergency';
+
 export type MCPServerLoggingHandler = (message: {
-  level: LoggingMessageNotification['params']['level'];
+  level: MCPServerLoggingLevel;
   logger?: string;
   data: unknown;
-  meta?: LoggingMessageNotification['params']['_meta'];
+  meta?: Record<string, unknown>;
 }) => void | Promise<void>;
 
 export type MCPServerLoggingOptions = {
   /**
    * Optional minimum level requested from the MCP server.
    */
-  level?: LoggingLevel;
+  level?: MCPServerLoggingLevel;
   /**
    * Handler invoked for MCP `notifications/message` logging events.
    */

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -56,10 +56,9 @@ function buildRequestOptions(
   return Object.keys(mergedOptions).length === 0 ? undefined : mergedOptions;
 }
 
-async function configureMCPServerLogging(
+async function registerMCPServerLoggingHandler(
   client: Client,
   serverLogging: MCPServerLoggingOptions | undefined,
-  requestOptions?: RequestOptions,
 ): Promise<void> {
   if (!serverLogging) {
     return;
@@ -79,6 +78,16 @@ async function configureMCPServerLogging(
       });
     },
   );
+}
+
+async function setMCPServerLoggingLevel(
+  client: Client,
+  serverLogging: MCPServerLoggingOptions | undefined,
+  requestOptions?: RequestOptions,
+): Promise<void> {
+  if (!serverLogging) {
+    return;
+  }
 
   if (serverLogging.level) {
     await client.setLoggingLevel(serverLogging.level, requestOptions);
@@ -254,8 +263,12 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
       const requestOptions = buildRequestOptions(
         this.clientSessionTimeoutSeconds,
       );
+      await registerMCPServerLoggingHandler(
+        this.session,
+        this.params.serverLogging,
+      );
       await this.session.connect(this.transport, requestOptions);
-      await configureMCPServerLogging(
+      await setMCPServerLoggingLevel(
         this.session,
         this.params.serverLogging,
         requestOptions,
@@ -462,8 +475,12 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
       const requestOptions = buildRequestOptions(
         this.clientSessionTimeoutSeconds,
       );
+      await registerMCPServerLoggingHandler(
+        this.session,
+        this.params.serverLogging,
+      );
       await this.session.connect(this.transport, requestOptions);
-      await configureMCPServerLogging(
+      await setMCPServerLoggingLevel(
         this.session,
         this.params.serverLogging,
         requestOptions,
@@ -739,8 +756,9 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
       const requestOptions = buildRequestOptions(
         this.clientSessionTimeoutSeconds,
       );
+      await registerMCPServerLoggingHandler(client, this.params.serverLogging);
       await client.connect(transport, requestOptions);
-      await configureMCPServerLogging(
+      await setMCPServerLoggingLevel(
         client,
         this.params.serverLogging,
         requestOptions,
@@ -994,13 +1012,17 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
       const requestOptions = buildRequestOptions(
         this.clientSessionTimeoutSeconds,
       );
+      await registerMCPServerLoggingHandler(
+        args.client,
+        this.params.serverLogging,
+      );
       await args.client.connect(transport, requestOptions);
       if (args.sessionId !== undefined) {
         // Reconnecting with an existing session skips initialize(), so resend
         // initialized to reopen the shared SSE stream for async responses.
         await this.reopenSharedStreamableHttpSession(args.client);
       }
-      await configureMCPServerLogging(
+      await setMCPServerLoggingLevel(
         args.client,
         this.params.serverLogging,
         requestOptions,

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -14,6 +14,7 @@ import {
   MCPListResourcesResult,
   MCPListResourceTemplatesResult,
   MCPReadResourceResult,
+  MCPServerLoggingOptions,
   MCPServerStdioOptions,
   MCPServerStreamableHttpOptions,
   MCPServerSSEOptions,
@@ -53,6 +54,35 @@ function buildRequestOptions(
       : { timeout: clientSessionTimeoutSeconds * 1000 };
   const mergedOptions = { ...(baseOptions ?? {}), ...(overrides ?? {}) };
   return Object.keys(mergedOptions).length === 0 ? undefined : mergedOptions;
+}
+
+async function configureMCPServerLogging(
+  client: Client,
+  serverLogging: MCPServerLoggingOptions | undefined,
+  requestOptions?: RequestOptions,
+): Promise<void> {
+  if (!serverLogging) {
+    return;
+  }
+
+  const { LoggingMessageNotificationSchema } =
+    await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
+  client.setNotificationHandler(
+    LoggingMessageNotificationSchema,
+    async (notification) => {
+      const params = notification.params;
+      await serverLogging.handler({
+        level: params.level,
+        logger: params.logger,
+        data: params.data,
+        meta: params._meta,
+      });
+    },
+  );
+
+  if (serverLogging.level) {
+    await client.setLoggingLevel(serverLogging.level, requestOptions);
+  }
 }
 
 type MaybeSessionTransport = Transport & {
@@ -225,6 +255,11 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
         this.clientSessionTimeoutSeconds,
       );
       await this.session.connect(this.transport, requestOptions);
+      await configureMCPServerLogging(
+        this.session,
+        this.params.serverLogging,
+        requestOptions,
+      );
       this.serverInitializeResult = {
         serverInfo: { name: this._name, version: '1.0.0' },
       } as InitializeResult;
@@ -428,6 +463,11 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
         this.clientSessionTimeoutSeconds,
       );
       await this.session.connect(this.transport, requestOptions);
+      await configureMCPServerLogging(
+        this.session,
+        this.params.serverLogging,
+        requestOptions,
+      );
       this.serverInitializeResult = {
         serverInfo: { name: this._name, version: '1.0.0' },
       } as InitializeResult;
@@ -700,6 +740,11 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
         this.clientSessionTimeoutSeconds,
       );
       await client.connect(transport, requestOptions);
+      await configureMCPServerLogging(
+        client,
+        this.params.serverLogging,
+        requestOptions,
+      );
       return { client, transport };
     } catch (error) {
       await this.closeStreamableHttpClient(
@@ -955,6 +1000,11 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
         // initialized to reopen the shared SSE stream for async responses.
         await this.reopenSharedStreamableHttpSession(args.client);
       }
+      await configureMCPServerLogging(
+        args.client,
+        this.params.serverLogging,
+        requestOptions,
+      );
       return { client: args.client, transport };
     } catch (error) {
       await this.closeStreamableHttpClient(

--- a/packages/agents-core/test/shims/mcp-server/node.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/node.test.ts
@@ -26,6 +26,10 @@ let lastCallToolOptions: any;
 let lastCallToolParams: any;
 let lastReadResourceOptions: any;
 let lastReadResourceParams: any;
+let lastSetLoggingLevel: any;
+let lastSetLoggingLevelOptions: any;
+let lastNotificationHandlerSchema: any;
+let lastNotificationHandler: any;
 
 beforeEach(() => {
   lastConnectOptions = undefined;
@@ -38,6 +42,10 @@ beforeEach(() => {
   lastCallToolParams = undefined;
   lastReadResourceOptions = undefined;
   lastReadResourceParams = undefined;
+  lastSetLoggingLevel = undefined;
+  lastSetLoggingLevelOptions = undefined;
+  lastNotificationHandlerSchema = undefined;
+  lastNotificationHandler = undefined;
 });
 
 describe('NodeMCPServerStdio', () => {
@@ -123,6 +131,44 @@ describe('NodeMCPServerStdio', () => {
     );
 
     expect(lastCallToolParams?._meta).toEqual({ request_id: 'req-123' });
+
+    await server.close();
+  });
+
+  test('should subscribe to MCP server logging messages', async () => {
+    const handler = vi.fn();
+    const server = new NodeMCPServerStdio({
+      name: 'logging-test',
+      fullCommand: 'test',
+      clientSessionTimeoutSeconds: 11,
+      serverLogging: {
+        level: 'info',
+        handler,
+      },
+    });
+
+    await server.connect();
+    await lastNotificationHandler({
+      method: 'notifications/message',
+      params: {
+        level: 'info',
+        logger: 'mock-server',
+        data: { progress: 'halfway' },
+        _meta: { requestId: 'req-123' },
+      },
+    });
+
+    expect(lastNotificationHandlerSchema.shape.method.value).toBe(
+      'notifications/message',
+    );
+    expect(lastSetLoggingLevel).toBe('info');
+    expect(lastSetLoggingLevelOptions?.timeout).toBe(11000);
+    expect(handler).toHaveBeenCalledWith({
+      level: 'info',
+      logger: 'mock-server',
+      data: { progress: 'halfway' },
+      meta: { requestId: 'req-123' },
+    });
 
     await server.close();
   });
@@ -268,6 +314,15 @@ class MockClient {
       ],
     });
   }
+  setNotificationHandler(schema: any, handler: any): void {
+    lastNotificationHandlerSchema = schema;
+    lastNotificationHandler = handler;
+  }
+  setLoggingLevel(level: any, options?: any): Promise<any> {
+    lastSetLoggingLevel = level;
+    lastSetLoggingLevelOptions = options;
+    return Promise.resolve({});
+  }
   close(): Promise<void> {
     return Promise.resolve();
   }
@@ -384,6 +439,39 @@ describe('NodeMCPServerSSE', () => {
     expect(lastConnectOptions?.timeout).toBe(4000);
     expect(lastListToolsOptions?.timeout).toBe(4000);
     expect(lastCallToolOptions?.timeout).toBe(DEFAULT_REQUEST_TIMEOUT_MSEC);
+
+    await server.close();
+  });
+
+  test('should subscribe to MCP server logging without changing level', async () => {
+    const handler = vi.fn();
+    const server = new NodeMCPServerSSE({
+      url: 'https://example.com/sse',
+      name: 'test-sse-logging',
+      serverLogging: {
+        handler,
+      },
+    });
+
+    await server.connect();
+    await lastNotificationHandler({
+      method: 'notifications/message',
+      params: {
+        level: 'debug',
+        data: 'working',
+      },
+    });
+
+    expect(lastNotificationHandlerSchema.shape.method.value).toBe(
+      'notifications/message',
+    );
+    expect(lastSetLoggingLevel).toBeUndefined();
+    expect(handler).toHaveBeenCalledWith({
+      level: 'debug',
+      logger: undefined,
+      data: 'working',
+      meta: undefined,
+    });
 
     await server.close();
   });
@@ -543,6 +631,43 @@ describe('NodeMCPServerStreamableHttp', () => {
     await server.close();
 
     expect(server.sessionId).toBeUndefined();
+  });
+
+  test('should subscribe to streamable HTTP MCP server logging', async () => {
+    const handler = vi.fn();
+    const server = new NodeMCPServerStreamableHttp({
+      url: 'https://example.com/stream',
+      name: 'test-stream-logging',
+      clientSessionTimeoutSeconds: 3,
+      serverLogging: {
+        level: 'warning',
+        handler,
+      },
+    });
+
+    await server.connect();
+    await lastNotificationHandler({
+      method: 'notifications/message',
+      params: {
+        level: 'warning',
+        logger: 'stream-server',
+        data: ['retrying'],
+      },
+    });
+
+    expect(lastNotificationHandlerSchema.shape.method.value).toBe(
+      'notifications/message',
+    );
+    expect(lastSetLoggingLevel).toBe('warning');
+    expect(lastSetLoggingLevelOptions?.timeout).toBe(3000);
+    expect(handler).toHaveBeenCalledWith({
+      level: 'warning',
+      logger: 'stream-server',
+      data: ['retrying'],
+      meta: undefined,
+    });
+
+    await server.close();
   });
 
   test('should forward resource requests to session methods', async () => {

--- a/packages/agents-core/test/shims/mcp-server/node.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/node.test.ts
@@ -30,6 +30,7 @@ let lastSetLoggingLevel: any;
 let lastSetLoggingLevelOptions: any;
 let lastNotificationHandlerSchema: any;
 let lastNotificationHandler: any;
+let loggingOperationOrder: string[];
 
 beforeEach(() => {
   lastConnectOptions = undefined;
@@ -46,6 +47,7 @@ beforeEach(() => {
   lastSetLoggingLevelOptions = undefined;
   lastNotificationHandlerSchema = undefined;
   lastNotificationHandler = undefined;
+  loggingOperationOrder = [];
 });
 
 describe('NodeMCPServerStdio', () => {
@@ -163,6 +165,11 @@ describe('NodeMCPServerStdio', () => {
     );
     expect(lastSetLoggingLevel).toBe('info');
     expect(lastSetLoggingLevelOptions?.timeout).toBe(11000);
+    expect(loggingOperationOrder).toEqual([
+      'setNotificationHandler',
+      'connect',
+      'setLoggingLevel',
+    ]);
     expect(handler).toHaveBeenCalledWith({
       level: 'info',
       logger: 'mock-server',
@@ -252,6 +259,7 @@ class MockClient {
     this.options = options;
   }
   connect(_transport: any, options?: any): Promise<void> {
+    loggingOperationOrder.push('connect');
     lastConnectOptions = options;
     return Promise.resolve();
   }
@@ -315,10 +323,12 @@ class MockClient {
     });
   }
   setNotificationHandler(schema: any, handler: any): void {
+    loggingOperationOrder.push('setNotificationHandler');
     lastNotificationHandlerSchema = schema;
     lastNotificationHandler = handler;
   }
   setLoggingLevel(level: any, options?: any): Promise<any> {
+    loggingOperationOrder.push('setLoggingLevel');
     lastSetLoggingLevel = level;
     lastSetLoggingLevelOptions = options;
     return Promise.resolve({});
@@ -466,6 +476,10 @@ describe('NodeMCPServerSSE', () => {
       'notifications/message',
     );
     expect(lastSetLoggingLevel).toBeUndefined();
+    expect(loggingOperationOrder).toEqual([
+      'setNotificationHandler',
+      'connect',
+    ]);
     expect(handler).toHaveBeenCalledWith({
       level: 'debug',
       logger: undefined,
@@ -660,6 +674,11 @@ describe('NodeMCPServerStreamableHttp', () => {
     );
     expect(lastSetLoggingLevel).toBe('warning');
     expect(lastSetLoggingLevelOptions?.timeout).toBe(3000);
+    expect(loggingOperationOrder).toEqual([
+      'setNotificationHandler',
+      'connect',
+      'setLoggingLevel',
+    ]);
     expect(handler).toHaveBeenCalledWith({
       level: 'warning',
       logger: 'stream-server',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,10 @@ import { defineConfig } from 'vitest/config';
 const rootDir = dirname(fileURLToPath(import.meta.url));
 const packagesDir = resolve(rootDir, 'packages');
 const testAliases = {
+  '@openai/agents-core/_shims': resolve(
+    rootDir,
+    'packages/agents-core/src/shims/shims-node.ts',
+  ),
   '@openai/agents-core/sandbox/local': resolve(
     rootDir,
     'packages/agents-core/src/sandbox/local.ts',


### PR DESCRIPTION
## Summary
- Add a `serverLogging` option for MCP server wrappers so callers can subscribe to MCP `notifications/message` events.
- Support optional `level` to send `logging/setLevel` when the caller wants to request a minimum server log level.
- Cover stdio, SSE, and streamable HTTP MCP transports, including reconnect-created streamable HTTP clients.
- Add the missing Vitest alias for `@openai/agents-core/_shims` so agents-core shim tests can run from source.

Closes #793.

## Testing
- `pnpm exec prettier --check packages/agents-core/src/mcp.ts packages/agents-core/src/shims/mcp-server/node.ts packages/agents-core/test/shims/mcp-server/node.test.ts vitest.config.ts .changeset/loud-mcp-servers-listen.md`
- `pnpm -F @openai/agents-core build-check`
- `pnpm exec vitest --run --project @openai/agents-core test/shims/mcp-server/node.test.ts`
- `pnpm exec eslint packages/agents-core/src/mcp.ts packages/agents-core/src/shims/mcp-server/node.ts packages/agents-core/test/shims/mcp-server/node.test.ts vitest.config.ts`

Note: the local pre-commit hook could not complete because it lints the changeset markdown as an ignored file and `trufflehog` is not installed in this environment. The source files were checked with targeted ESLint, Prettier, typecheck, and focused tests above.