### PR TITLE
docs: clarify usage budgeting for model calls

### DIFF
--- a/docs/src/content/docs/guides/models.mdx
+++ b/docs/src/content/docs/guides/models.mdx
@@ -200,6 +200,8 @@ The SDK exports ready-made helpers on `retryPolicies`:
 
 When you compose policies, `providerSuggested()` is the safest first building block because it preserves provider vetoes and replay-safety approvals when the provider can distinguish them.
 
+Retries are not a rate limiter or spending control. They only decide whether a failed model request should be attempted again. If your application needs per-minute request limits, token budgets, or tenant-level quotas, enforce those outside the retry policy and use `result.state.usage` after each run to decide whether more work is allowed. See the [usage section in the results guide](/openai-agents-js/guides/results#usage) for a small example.
+
 #### Safety boundaries
 
 Some failures are never retried automatically:

--- a/docs/src/content/docs/guides/results.mdx
+++ b/docs/src/content/docs/guides/results.mdx
@@ -161,3 +161,5 @@ Use these arrays when you want to log guardrail decisions, inspect extra metadat
 Token usage is aggregated in `result.state.usage`, which tracks request counts and token totals for the run. The same usage object is also available through `result.runContext.usage`. For streaming runs this data updates as responses arrive.
 
 <Code lang="typescript" code={usageExample} title="Read usage from RunState" />
+
+Usage data is also the right place to implement application-level budgets. For example, after each run you can compare `usage.requests` and `usage.totalTokens` against your own per-user, per-tenant, or per-workflow limits before allowing more work to continue.

--- a/examples/docs/results/usage.ts
+++ b/examples/docs/results/usage.ts
@@ -1,5 +1,8 @@
 import { Agent, run } from '@openai/agents';
 
+const REQUEST_BUDGET = 3;
+const TOKEN_BUDGET = 2_000;
+
 const agent = new Agent({
   name: 'Usage Tracker',
   instructions: 'Summarize the latest project update in one sentence.',
@@ -27,4 +30,10 @@ if (usage.requestUsageEntries) {
       totalTokens: entry.totalTokens,
     });
   }
+}
+
+if (usage.requests > REQUEST_BUDGET || usage.totalTokens > TOKEN_BUDGET) {
+  throw new Error(
+    `Usage budget exceeded: ${usage.requests} requests and ${usage.totalTokens} tokens`,
+  );
 }


### PR DESCRIPTION
Summary
- Clarify that model retries are not a rate limiter or spending control.
- Extend the usage example with a small request/token budget check using `result.state.usage`.
- Point readers from the retry docs to usage-based application-level budgeting.

Context
- Addresses #927 without adding a new SDK-level rate limiter API.

Verification
- `pnpm -F @openai/agents-core build`
- `pnpm -F @openai/agents-openai build`
- `pnpm -F @openai/agents-realtime build`
- `pnpm -F @openai/agents build`
- `pnpm -F @openai/agents-extensions build`
- `pnpm -F docs-code build-check`
- `pnpm docs:scripts:check`
- `pnpm docs:build`
- `pnpm exec prettier --check examples/docs/results/usage.ts docs/src/content/docs/guides/results.mdx docs/src/content/docs/guides/models.mdx`
- `git diff --check`