### PR TITLE
fix(core): allow sync MCP tool filters

### DIFF
--- a/.changeset/sync-mcp-tool-filters.md
+++ b/.changeset/sync-mcp-tool-filters.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+Allow MCP tool filter callbacks to return a synchronous boolean.

--- a/packages/agents-core/src/mcpUtil.ts
+++ b/packages/agents-core/src/mcpUtil.ts
@@ -38,7 +38,7 @@ export type MCPToolMetaResolver<TContext = UnknownContext> = (
 export type MCPToolFilterCallable<TContext = UnknownContext> = (
   context: MCPToolFilterContext<TContext>,
   tool: MCPTool,
-) => Promise<boolean>;
+) => boolean | Promise<boolean>;
 
 /** Static tool filter configuration using allow and block lists. */
 export interface MCPToolFilterStatic {

--- a/packages/agents-core/test/mcpToolFilter.test.ts
+++ b/packages/agents-core/test/mcpToolFilter.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { withTrace } from '../src/tracing';
 import { NodeMCPServerStdio } from '../src/shims/mcp-server/node';
 import { createMCPToolStaticFilter } from '../src/mcpUtil';
+import type { MCPToolFilterCallable } from '../src/mcpUtil';
 
 class StubServer extends NodeMCPServerStdio {
   public toolList: any[];
@@ -83,6 +84,14 @@ describe('MCP tool filtering', () => {
       const result = await server.listTools();
       expect(result.map((t) => t.name)).toEqual(['good', 'bad']);
     });
+  });
+
+  it('accepts sync callable filter types', async () => {
+    const filter: MCPToolFilterCallable = (_ctx, tool) => {
+      return tool.name !== 'blocked';
+    };
+
+    expect(filter).toBeTypeOf('function');
   });
 
   it('hierarchy across multiple servers', async () => {


### PR DESCRIPTION
## Summary
- allow `MCPToolFilterCallable` implementations to return `boolean` as well as `Promise<boolean>`
- add a typechecked regression case for synchronous callable filters

## Context
The runtime already awaits callable MCP filters, so synchronous boolean returns work at runtime. The public type currently requires `Promise<boolean>`, which unnecessarily rejects deterministic sync allow/deny filters.

## Verification
- `pnpm exec prettier --check packages/agents-core/src/mcpUtil.ts packages/agents-core/test/mcpToolFilter.test.ts`
- `pnpm -F @openai/agents-core build-check`
- `pnpm -F @openai/agents-core build`
- `git diff --check`

## Note
- `pnpm vitest run packages/agents-core/test/mcpToolFilter.test.ts` currently fails in this checkout before running tests because Vite cannot resolve `@openai/agents-core/_shims`; the typecheck/build gates above pass.