### PR TITLE
fix(extensions): clear Twilio playback on interrupt

### DIFF
--- a/.changeset/twilio-interrupt-clear.md
+++ b/.changeset/twilio-interrupt-clear.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: clear Twilio playback on public interrupts (#1173)

--- a/packages/agents-extensions/src/TwilioRealtimeTransport.ts
+++ b/packages/agents-extensions/src/TwilioRealtimeTransport.ts
@@ -59,6 +59,7 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
   #audioChunkCount: number = 0;
   #lastPlayedChunkCount: number = 0;
   #previousItemId: string | null = null;
+  #clearSentForInterrupt = false;
   #logger = getLogger('openai-agents:extensions:twilio');
 
   constructor(options: TwilioRealtimeTransportLayerOptions) {
@@ -203,17 +204,49 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
     super.updateSessionConfig(newConfig);
   }
 
-  _interrupt(_elapsedTime: number, cancelOngoingResponse: boolean = true) {
-    const elapsedTime = this.#lastPlayedChunkCount + 50; /* 50ms buffer */
-    this.#logger.debug(
-      `Interruption detected, clearing Twilio audio and truncating OpenAI audio after ${elapsedTime}ms`,
-    );
+  #sendTwilioClear(): boolean {
+    if (!this.#streamSid) {
+      this.#logger.debug(
+        'Skipping Twilio clear because no streamSid has been received.',
+      );
+      return false;
+    }
+
+    const readyState = (this.#twilioWebSocket as { readyState?: number })
+      .readyState;
+    if (typeof readyState === 'number' && readyState !== 1) {
+      this.#logger.debug(
+        'Skipping Twilio clear because the Twilio websocket is not open.',
+      );
+      return false;
+    }
+
     this.#twilioWebSocket.send(
       JSON.stringify({
         event: 'clear',
         streamSid: this.#streamSid,
       }),
     );
+    return true;
+  }
+
+  interrupt(cancelOngoingResponse: boolean = true) {
+    this.#clearSentForInterrupt = this.#sendTwilioClear();
+    try {
+      super.interrupt(cancelOngoingResponse);
+    } finally {
+      this.#clearSentForInterrupt = false;
+    }
+  }
+
+  _interrupt(_elapsedTime: number, cancelOngoingResponse: boolean = true) {
+    const elapsedTime = this.#lastPlayedChunkCount + 50; /* 50ms buffer */
+    this.#logger.debug(
+      `Interruption detected, clearing Twilio audio and truncating OpenAI audio after ${elapsedTime}ms`,
+    );
+    if (!this.#clearSentForInterrupt) {
+      this.#sendTwilioClear();
+    }
     super._interrupt(elapsedTime, cancelOngoingResponse);
   }
 

--- a/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
+++ b/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
@@ -24,6 +24,15 @@ vi.mock('@openai/agents/realtime', () => {
   ) {
     this.status = 'connected';
   });
+  FakeOpenAIRealtimeWebSocket.prototype.interrupt = vi.fn(function (
+    this: any,
+    cancelOngoingResponse = true,
+  ) {
+    if (!this.currentItemId) {
+      return;
+    }
+    this._interrupt(123, cancelOngoingResponse);
+  });
   FakeOpenAIRealtimeWebSocket.prototype.sendAudio = vi.fn();
   FakeOpenAIRealtimeWebSocket.prototype.close = vi.fn();
   FakeOpenAIRealtimeWebSocket.prototype._interrupt = vi.fn();
@@ -32,8 +41,11 @@ vi.mock('@openai/agents/realtime', () => {
 });
 
 class FakeTwilioWebSocket extends EventEmitter {
+  readyState = 1;
   send = vi.fn();
-  close = vi.fn();
+  close = vi.fn(() => {
+    this.readyState = 3;
+  });
 }
 
 // @ts-expect-error - we're making the node event emitter compatible with the browser event emitter
@@ -194,6 +206,81 @@ describe('TwilioRealtimeTransportLayer', () => {
     expect(marks[1].mark.name).toBe('a:3');
     expect(marks[2].mark.name).toBe('b:1');
     expect(audioListener).toHaveBeenCalledTimes(3);
+  });
+
+  test('interrupt sends Twilio clear when base interrupt has no audio state', async () => {
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: twilio as any,
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const interruptSpy = vi.mocked(
+      OpenAIRealtimeWebSocket.prototype._interrupt,
+    );
+
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({ event: 'start', start: { streamSid: 'sid-1' } }),
+    });
+
+    transport.interrupt();
+
+    expect(interruptSpy).not.toHaveBeenCalled();
+    expect(twilio.send).toHaveBeenCalledTimes(1);
+    expect(twilio.send).toHaveBeenCalledWith(
+      JSON.stringify({ event: 'clear', streamSid: 'sid-1' }),
+    );
+  });
+
+  test('interrupt sends one Twilio clear when base interrupt continues', async () => {
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: twilio as any,
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const interruptSpy = vi.mocked(
+      OpenAIRealtimeWebSocket.prototype._interrupt,
+    );
+
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({ event: 'start', start: { streamSid: 'sid-1' } }),
+    });
+    twilio.emit('message', {
+      toString: () => JSON.stringify({ event: 'mark', mark: { name: 'u:5' } }),
+    });
+    // @ts-expect-error - we're testing base interrupt interaction.
+    transport.currentItemId = 'u';
+
+    transport.interrupt(false);
+
+    const clearMessages = twilio.send.mock.calls.filter(
+      ([payload]) => JSON.parse(payload as string).event === 'clear',
+    );
+    expect(clearMessages).toHaveLength(1);
+    expect(interruptSpy).toHaveBeenCalledWith(55, false);
+  });
+
+  test('interrupt skips Twilio clear before start or after socket close', async () => {
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: twilio as any,
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+
+    transport.interrupt();
+    expect(twilio.send).not.toHaveBeenCalled();
+
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({ event: 'start', start: { streamSid: 'sid-1' } }),
+    });
+    twilio.close();
+    transport.interrupt();
+
+    expect(twilio.send).not.toHaveBeenCalled();
   });
 
   test('connect preserves nested audio config while defaulting Twilio formats', async () => {


### PR DESCRIPTION
## Summary

- send Twilio `clear` from the public transport `interrupt()` path, even when the base realtime interrupt returns before `_interrupt()`
- avoid duplicate clear frames when the base interrupt continues into `_interrupt()`
- skip Twilio clear before `start` or after the Twilio websocket is closed
- add focused Twilio transport regressions and a patch changeset for `@openai/agents-extensions`

Fixes #1173.

## Validation

- `pnpm exec vitest --run --project @openai/agents-extensions test/TwilioRealtimeTransport.test.ts` -> 11 passed
- `pnpm -F @openai/agents-extensions build-check` -> passed
- `pnpm exec prettier --check packages/agents-extensions/src/TwilioRealtimeTransport.ts packages/agents-extensions/test/TwilioRealtimeTransport.test.ts .changeset/twilio-interrupt-clear.md` -> passed
- `git diff --check -- packages/agents-extensions/src/TwilioRealtimeTransport.ts packages/agents-extensions/test/TwilioRealtimeTransport.test.ts .changeset/twilio-interrupt-clear.md` -> passed

A broad root test invocation was attempted during local review; it passed this Twilio test file and most of the suite, then failed two unrelated `agents-core` PTY signal tests.