### PR TITLE
Docs: add auditable final output receipt guidance

### DIFF
--- a/docs/src/content/docs/guides/results.mdx
+++ b/docs/src/content/docs/guides/results.mdx
@@ -180,7 +180,7 @@ contains several different claims:
 
 Those claims may need evidence from different result surfaces, such as `newItems`, tool outputs, approval metadata, guardrail results, file diffs, logs, or human review.
 
-One practical pattern is to ask the last agent to produce a small completion receipt alongside its user-facing answer:
+One practical pattern is to produce the user-facing `finalOutput` first, then have application code validate the claims against the settled `RunResult`. If you want an agent-authored receipt, pass the relevant evidence from `newItems`, guardrail results, approvals, logs, or diffs into a separate verifier agent instead of asking the producing agent to self-attest to data it cannot see after `run()` returns.
 
 ```yaml
 status_code: 412
@@ -189,13 +189,15 @@ summary: "The agent claimed completion and test success, but did not attach comm
 claims:
   - claim: "Task is complete."
     support_status: unverified
-    evidence: []
+    evidence:
+      - "newItems[3]: tool call update_customer_record completed"
     required_fix: "Attach the relevant tool output, file diff, or trace item."
   - claim: "All tests passed."
     support_status: unsupported
-    evidence: []
+    evidence:
+      - "No test command output was present in newItems, logs, or approval metadata."
     required_fix: "Attach the test command and output, or downgrade the claim."
-next_owner: ProducingAgent
+next_owner: ApplicationVerifier
 human_decision_required: false
 ```
 
@@ -207,4 +209,4 @@ A receipt should make these boundaries explicit:
 - who owns the next step
 - whether human approval is required before publishing, deploying, saving memory, or taking another external action
 
-This pattern complements tracing and guardrails. Traces show what happened during the run; guardrails can block or flag unsafe behavior; a receipt summarizes the final work state so humans and downstream systems can audit the completion claim.
+This pattern complements tracing and guardrails. Traces show what happened during the run; guardrails can block or flag unsafe behavior; an app-side or verifier-agent receipt summarizes the final work state so humans and downstream systems can audit the completion claim without relying on unsupported self-attestation.

--- a/docs/src/content/docs/guides/results.mdx
+++ b/docs/src/content/docs/guides/results.mdx
@@ -161,3 +161,50 @@ Use these arrays when you want to log guardrail decisions, inspect extra metadat
 Token usage is aggregated in `result.state.usage`, which tracks request counts and token totals for the run. The same usage object is also available through `result.runContext.usage`. For streaming runs this data updates as responses arrive.
 
 <Code lang="typescript" code={usageExample} title="Read usage from RunState" />
+
+## Auditable final output receipts
+
+For safety-sensitive workflows, treat `finalOutput` as the agent's final answer, not as proof that every claim in the answer is supported.
+
+A final answer such as:
+
+```text
+Done. All tests passed. Ready to publish.
+```
+
+contains several different claims:
+
+- the task is complete
+- tests passed
+- the result is ready for an external action
+
+Those claims may need evidence from different result surfaces, such as `newItems`, tool outputs, approval metadata, guardrail results, file diffs, logs, or human review.
+
+One practical pattern is to ask the last agent to produce a small completion receipt alongside its user-facing answer:
+
+```yaml
+status_code: 412
+status_text: missing_evidence
+summary: "The agent claimed completion and test success, but did not attach command output."
+claims:
+  - claim: "Task is complete."
+    support_status: unverified
+    evidence: []
+    required_fix: "Attach the relevant tool output, file diff, or trace item."
+  - claim: "All tests passed."
+    support_status: unsupported
+    evidence: []
+    required_fix: "Attach the test command and output, or downgrade the claim."
+next_owner: ProducingAgent
+human_decision_required: false
+```
+
+A receipt should make these boundaries explicit:
+
+- what the agent claimed
+- which evidence supports each claim
+- which claims are unsupported or need review
+- who owns the next step
+- whether human approval is required before publishing, deploying, saving memory, or taking another external action
+
+This pattern complements tracing and guardrails. Traces show what happened during the run; guardrails can block or flag unsafe behavior; a receipt summarizes the final work state so humans and downstream systems can audit the completion claim.


### PR DESCRIPTION
## Summary

Adds a docs-only section to the Results guide about auditable final output receipts.

The new section clarifies that `finalOutput` is the agent's final answer, not proof that every claim in the answer is supported. It shows a compact receipt pattern for safety-sensitive workflows where agent completion claims should be tied to evidence, next owner, and human approval boundaries.

## Motivation

Agent final answers can contain multiple operational claims, such as:

- task completed
- tests passed
- ready to publish
- memory saved

Those claims may require evidence from `newItems`, tool outputs, approval metadata, guardrail results, file diffs, logs, traces, or human review. A receipt complements tracing and guardrails by summarizing the final work state for humans and downstream systems.

## Notes

- Docs-only change.
- No SDK behavior change.
- No runtime dependency.
- Safety-oriented guidance for final output review.
