### PR TITLE
feat: add Northflank provider

### DIFF
--- a/.changeset/northflank-sandbox-persistence.md
+++ b/.changeset/northflank-sandbox-persistence.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': minor
+---
+
+feat(extensions): add Northflank sandbox provider, tools, and shell; sandbox supports `workspacePersistence` (`'volume'` or `'tar'`) for persistent workspaces across pause/resume

--- a/examples/sandbox/extensions/northflank-runner.ts
+++ b/examples/sandbox/extensions/northflank-runner.ts
@@ -1,0 +1,115 @@
+import { Runner } from '@openai/agents';
+import { NorthflankSandboxClient } from '@openai/agents-extensions/sandbox/northflank';
+import { Manifest, SandboxAgent, shell } from '@openai/agents/sandbox';
+import { finished } from 'node:stream/promises';
+import {
+  DEFAULT_MODEL,
+  getOptionalStringArg,
+  getStringArg,
+  hasFlag,
+  requireEnv,
+  requireOpenAIKey,
+  runExampleMain,
+} from '../support';
+
+const DEFAULT_QUESTION =
+  'Summarize this cloud sandbox workspace in 2 sentences.';
+
+const DEFAULT_IMAGE = 'docker.io/library/ubuntu:24.04';
+
+function buildManifest(): Manifest {
+  return new Manifest({
+    root: '/workspace',
+    entries: {
+      'README.md': {
+        type: 'file',
+        content: `# Northflank Demo Workspace
+
+This workspace exists to validate the Northflank sandbox backend manually.
+`,
+      },
+      'release_notes.md': {
+        type: 'file',
+        content: `# Release notes
+
+- Northflank sandbox provider lives in @openai/agents-extensions/sandbox/northflank.
+- Each session runs as a single-replica deployment service; exec calls are pinned to the running pod.
+- Pod storage is ephemeral by default. Pass \`workspacePersistence: 'volume'\` to attach a Northflank volume at the workspace root, or \`'tar'\` to snapshot the workspace into session state on stop().
+`,
+      },
+      'todo.md': {
+        type: 'file',
+        content: `# Try these prompts
+
+1. List every Markdown file in this workspace and show the first heading of each.
+2. Add a new note called \`hello.md\` that greets the operator by name.
+3. Run \`uname -a\` and report what kernel the sandbox is running on.
+`,
+      },
+    },
+  });
+}
+
+async function main() {
+  requireOpenAIKey();
+  const apiToken = requireEnv('NF_API_TOKEN');
+  const projectId = requireEnv('NF_PROJECT_ID');
+
+  const model = getStringArg('--model', DEFAULT_MODEL);
+  const question = getStringArg('--question', DEFAULT_QUESTION);
+  const image = getStringArg('--image', DEFAULT_IMAGE);
+  const teamId = getOptionalStringArg('--team');
+  const pauseOnExit = hasFlag('--pause-on-exit');
+  const stream = hasFlag('--stream');
+  const persistenceArg = getOptionalStringArg('--persistence');
+  const workspacePersistence =
+    persistenceArg === 'volume' || persistenceArg === 'tar'
+      ? persistenceArg
+      : undefined;
+  if (persistenceArg && !workspacePersistence) {
+    throw new Error(
+      `--persistence must be one of: volume, tar (got "${persistenceArg}")`,
+    );
+  }
+
+  const client = new NorthflankSandboxClient({
+    apiToken,
+    projectId,
+    image,
+    teamId,
+    // Keep ubuntu alive — its default CMD exits immediately.
+    docker: { customEntrypoint: 'sleep', customCommand: 'infinity' },
+    pauseOnExit,
+    workspacePersistence,
+    readyTimeoutMs: 4 * 60 * 1000,
+  });
+
+  const agent = new SandboxAgent({
+    name: 'Northflank Sandbox Assistant',
+    model,
+    instructions:
+      'Answer questions about the sandbox workspace. Inspect the files before answering, keep the response concise, and cite the file names you inspected.',
+    defaultManifest: buildManifest(),
+    capabilities: [shell()],
+  });
+  const runner = new Runner({
+    workflowName: 'Northflank sandbox example',
+    sandbox: { client },
+  });
+
+  if (!stream) {
+    const result = await runner.run(agent, question);
+    console.log(result.finalOutput);
+    return;
+  }
+
+  const result = await runner.run(agent, question, { stream: true });
+  process.stdout.write('assistant> ');
+  const textStream = result.toTextStream({ compatibleWithNodeStreams: true });
+  textStream.pipe(process.stdout);
+  await finished(textStream);
+  await result.completed;
+  process.stdout.write('\n');
+}
+
+await runExampleMain(main);

--- a/examples/sandbox/package.json
+++ b/examples/sandbox/package.json
@@ -27,6 +27,7 @@
     "start:daytona": "tsx extensions/daytona-runner.ts",
     "start:e2b": "tsx extensions/e2b-runner.ts",
     "start:modal": "tsx extensions/modal-runner.ts",
+    "start:northflank": "tsx extensions/northflank-runner.ts",
     "start:runloop": "tsx extensions/runloop-runner.ts",
     "start:vercel": "tsx extensions/vercel-runner.ts"
   }

--- a/packages/agents-extensions/package.json
+++ b/packages/agents-extensions/package.json
@@ -54,10 +54,20 @@
       "require": "./dist/sandbox/e2b/index.js",
       "import": "./dist/sandbox/e2b/index.mjs"
     },
+    "./northflank": {
+      "types": "./dist/northflank/index.d.ts",
+      "require": "./dist/northflank/index.js",
+      "import": "./dist/northflank/index.mjs"
+    },
     "./sandbox/modal": {
       "types": "./dist/sandbox/modal/index.d.ts",
       "require": "./dist/sandbox/modal/index.js",
       "import": "./dist/sandbox/modal/index.mjs"
+    },
+    "./sandbox/northflank": {
+      "types": "./dist/sandbox/northflank/index.d.ts",
+      "require": "./dist/sandbox/northflank/index.js",
+      "import": "./dist/sandbox/northflank/index.mjs"
     },
     "./sandbox/runloop": {
       "types": "./dist/sandbox/runloop/index.d.ts",
@@ -80,6 +90,7 @@
     "@blaxel/core": "^0.2.82",
     "@daytonaio/sdk": "^0.162.0",
     "@e2b/code-interpreter": "^2.3.3",
+    "@northflank/js-client": "^0.9.0",
     "@openai/agents": "workspace:>=0.0.0",
     "@openai/codex-sdk": ">=0.86.0",
     "@runloop/api-client": "^1.16.2",
@@ -115,6 +126,9 @@
     "modal": {
       "optional": true
     },
+    "@northflank/js-client": {
+      "optional": true
+    },
     "@runloop/api-client": {
       "optional": true
     },
@@ -134,6 +148,7 @@
     "@blaxel/core": "0.2.82",
     "@daytonaio/sdk": "0.162.0",
     "@e2b/code-interpreter": "2.3.3",
+    "@northflank/js-client": "0.9.5",
     "@openai/agents": "workspace:>=0.0.0",
     "@openai/codex-sdk": "^0.86.0",
     "@runloop/api-client": "1.16.2",
@@ -163,8 +178,14 @@
       "sandbox/e2b": [
         "dist/sandbox/e2b/index.d.ts"
       ],
+      "northflank": [
+        "dist/northflank/index.d.ts"
+      ],
       "sandbox/modal": [
         "dist/sandbox/modal/index.d.ts"
+      ],
+      "sandbox/northflank": [
+        "dist/sandbox/northflank/index.d.ts"
       ],
       "sandbox/runloop": [
         "dist/sandbox/runloop/index.d.ts"

--- a/packages/agents-extensions/src/northflank/index.ts
+++ b/packages/agents-extensions/src/northflank/index.ts
@@ -1,0 +1,82 @@
+import type { ApiClient } from '@northflank/js-client';
+
+import { buildDeployTools } from './tools/deploy';
+import { buildExecTools } from './tools/exec';
+import { buildFileTools } from './tools/files';
+import { buildLogsTools } from './tools/logs';
+import { buildMetricsTools } from './tools/metrics';
+import { buildReadTools } from './tools/read';
+import { buildSecretsTools } from './tools/secrets';
+import type {
+  NorthflankTool,
+  NorthflankToolGroup,
+  NorthflankToolsOptions,
+} from './types';
+
+export type {
+  NorthflankApprovalsConfig,
+  NorthflankTool,
+  NorthflankToolGroup,
+  NorthflankToolName,
+  NorthflankToolsOptions,
+} from './types';
+
+export { NorthflankShell } from './shell';
+export type { NorthflankShellOptions, NorthflankShellTarget } from './shell';
+
+const DEFAULT_INCLUDE: NorthflankToolGroup[] = [
+  'read',
+  'deploy',
+  'exec',
+  'files',
+  'logs',
+  'metrics',
+];
+
+/**
+ * Build a curated array of OpenAI Agents `FunctionTool`s that talk to a
+ * Northflank `ApiClient`. By default 16 tools across six groups (the
+ * `secrets` group is opt-in via `include`).
+ *
+ * Pair this with `NorthflankShell` and `shellTool({ shell })` to also give
+ * the agent a hosted-shell into a Northflank container, or with
+ * `NorthflankSandboxClient` (from `@openai/agents-extensions/sandbox/northflank`)
+ * to back a full `SandboxAgent`.
+ *
+ * @example
+ * ```ts
+ * import { ApiClient, ApiClientInMemoryContextProvider } from '@northflank/js-client';
+ * import { Agent, run } from '@openai/agents';
+ * import { northflankTools } from '@openai/agents-extensions/northflank';
+ *
+ * const ctx = new ApiClientInMemoryContextProvider();
+ * await ctx.addContext({ name: 'default', token: process.env.NF_API_TOKEN! });
+ * const client = new ApiClient(ctx, { throwErrorOnHttpErrorCode: true });
+ *
+ * const agent = new Agent({
+ *   name: 'Northflank Operator',
+ *   tools: northflankTools(client, { defaultProjectId: 'my-project' }),
+ * });
+ *
+ * const result = await run(agent, 'Restart the api service.');
+ * ```
+ */
+export function northflankTools(
+  client: ApiClient,
+  options: NorthflankToolsOptions = {},
+): NorthflankTool[] {
+  const include = new Set<NorthflankToolGroup>(
+    options.include ?? DEFAULT_INCLUDE,
+  );
+
+  const tools: NorthflankTool[] = [];
+  if (include.has('read')) tools.push(...buildReadTools(client, options));
+  if (include.has('deploy')) tools.push(...buildDeployTools(client, options));
+  if (include.has('exec')) tools.push(...buildExecTools(client, options));
+  if (include.has('files')) tools.push(...buildFileTools(client, options));
+  if (include.has('logs')) tools.push(...buildLogsTools(client, options));
+  if (include.has('metrics')) tools.push(...buildMetricsTools(client, options));
+  if (include.has('secrets')) tools.push(...buildSecretsTools(client, options));
+
+  return tools;
+}

--- a/packages/agents-extensions/src/northflank/shell.ts
+++ b/packages/agents-extensions/src/northflank/shell.ts
@@ -1,0 +1,253 @@
+import type { ApiClient } from '@northflank/js-client';
+import type { Shell, ShellAction, ShellResult } from '@openai/agents-core';
+
+/**
+ * Identifies the Northflank container that a `NorthflankShell` should execute
+ * commands inside. The three variants mirror the Northflank JS-client exec API
+ * (`execServiceCommand` / `execJobCommand` / `execAddonCommand`).
+ *
+ * Common optional fields:
+ * - `teamId` — scope the API call to a team / org
+ * - `instanceName` — target a specific replica (mandatory for addons)
+ * - `containerName` — target a specific container inside the pod
+ * - `shell` — shell wrapper, e.g. `"bash -c"`. Defaults to the container default.
+ */
+export type NorthflankShellTarget =
+  | {
+      type: 'service';
+      projectId: string;
+      serviceId: string;
+      teamId?: string;
+      instanceName?: string;
+      containerName?: string;
+      shell?: string;
+    }
+  | {
+      type: 'job';
+      projectId: string;
+      jobId: string;
+      teamId?: string;
+      instanceName?: string;
+      containerName?: string;
+      shell?: string;
+    }
+  | {
+      type: 'addon';
+      projectId: string;
+      addonId: string;
+      teamId?: string;
+      /** Addons require an explicit instanceName to disambiguate replicas. */
+      instanceName: string;
+      containerName?: string;
+      shell?: string;
+    };
+
+export interface NorthflankShellOptions {
+  /** A constructed Northflank `ApiClient`. */
+  client: ApiClient;
+  /** The container the shell targets. */
+  target: NorthflankShellTarget;
+}
+
+/**
+ * Cap each captured stream at `limit` chars (default 20k). Adds a marker so
+ * the model can detect truncation and adapt.
+ */
+function clip(s: string | undefined, limit: number): string {
+  const str = s ?? '';
+  if (str.length <= limit) return str;
+  return `${str.slice(0, limit)}\n... [truncated ${str.length - limit} chars]`;
+}
+
+const DEFAULT_OUTPUT_LIMIT = 20_000;
+
+/**
+ * `Shell` implementation that proxies commands to a running Northflank
+ * container via `client.exec.execServiceCommand` / `execJobCommand` /
+ * `execAddonCommand`.
+ *
+ * Wire it into the hosted shell tool:
+ *
+ * ```ts
+ * const shell = new NorthflankShell({
+ *   client,
+ *   target: { type: 'service', projectId: 'p', serviceId: 's' },
+ * });
+ *
+ * const agent = new Agent({
+ *   name: 'Service Operator',
+ *   tools: [shellTool({ shell, needsApproval: true })],
+ * });
+ * ```
+ *
+ * Each entry in `action.commands` is forwarded as one Northflank exec call,
+ * sequentially. The Shell protocol expresses the same string commands the
+ * model would type in a terminal; we let the container's default shell parse
+ * them unless `target.shell` overrides it.
+ */
+export class NorthflankShell implements Shell {
+  constructor(private readonly options: NorthflankShellOptions) {}
+
+  async run(action: ShellAction): Promise<ShellResult> {
+    const maxOutputLength = action.maxOutputLength ?? DEFAULT_OUTPUT_LIMIT;
+    const halfLimit = Math.floor(maxOutputLength / 2);
+    const output: ShellResult['output'] = [];
+
+    for (const command of action.commands) {
+      const run = this.execOne(command);
+      const result = action.timeoutMs
+        ? await raceWithTimeout(run, action.timeoutMs)
+        : await run
+            .then((value) => ({ kind: 'done' as const, value }))
+            .catch((err) => ({
+              kind: 'error' as const,
+              err,
+            }));
+
+      if (result.kind === 'timeout') {
+        // Stop processing the rest of the batch on timeout, mirroring the
+        // Responses API local-shell contract.
+        output.push({
+          command,
+          stdout: '',
+          stderr: '',
+          outcome: { type: 'timeout' },
+        });
+        break;
+      }
+
+      if (result.kind === 'error') {
+        const message =
+          result.err instanceof Error ? result.err.message : String(result.err);
+        output.push({
+          command,
+          stdout: '',
+          stderr: message,
+          outcome: { type: 'exit', exitCode: null },
+        });
+        continue;
+      }
+
+      const { commandResult, stdOut, stdErr } = result.value;
+      output.push({
+        command,
+        stdout: clip(stdOut, halfLimit),
+        stderr: clip(stdErr, halfLimit),
+        outcome: { type: 'exit', exitCode: commandResult.exitCode },
+      });
+    }
+
+    return {
+      output,
+      maxOutputLength,
+      providerData: {
+        target: this.options.target.type,
+        projectId: this.options.target.projectId,
+      },
+    };
+  }
+
+  /**
+   * Dispatch a single command to the right Northflank exec endpoint.
+   *
+   * Northflank's exec API does NOT wrap commands in a shell by default — a
+   * raw `command: "cd /foo && ls"` string would be exec'd as a literal
+   * binary name and fail with ENOENT. We always send the command as an
+   * argv array `[<shell>, "-lc", <user_command>]` so pipes / redirects /
+   * `&&` work as the model expects.
+   */
+  private async execOne(command: string): Promise<{
+    commandResult: { exitCode: number; status: string; message?: string };
+    stdOut: string;
+    stdErr: string;
+  }> {
+    const { client, target } = this.options;
+    const teamId = target.teamId ? { teamId: target.teamId } : {};
+    const argv = buildShellArgv(command, target.shell);
+
+    const data = {
+      command: argv,
+      shell: 'none',
+      ...stripUndefined({
+        instanceName: target.instanceName,
+        containerName: target.containerName,
+      }),
+    };
+
+    switch (target.type) {
+      case 'service':
+        return client.exec.execServiceCommand(
+          {
+            projectId: target.projectId,
+            serviceId: target.serviceId,
+            ...teamId,
+          },
+          data,
+        );
+      case 'job':
+        return client.exec.execJobCommand(
+          { projectId: target.projectId, jobId: target.jobId, ...teamId },
+          data,
+        );
+      case 'addon':
+        // ExecCommandDataAddon requires instanceName — TS can narrow via the
+        // discriminant, but the spread loses that info. Cast is safe because
+        // the NorthflankShellTarget addon variant requires instanceName.
+        return client.exec.execAddonCommand(
+          { projectId: target.projectId, addonId: target.addonId, ...teamId },
+          data as typeof data & { instanceName: string },
+        );
+    }
+  }
+}
+
+function stripUndefined<T extends Record<string, unknown>>(obj: T): Partial<T> {
+  const out: Partial<T> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined) (out as Record<string, unknown>)[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Build the argv that wraps a user shell command. Defaults to `sh -c`
+ * because many minimal `/bin/sh` builds don't accept `-l`. Callers who
+ * want a login shell can opt in by passing `'bash -lc'` (or any explicit
+ * invocation ending in `-c` / `-lc`); we don't double-append the flag.
+ */
+function buildShellArgv(command: string, shell?: string): string[] {
+  const interp = (shell ?? 'sh').trim() || 'sh';
+  const shellArgv = interp.split(/\s+/);
+  const last = shellArgv[shellArgv.length - 1];
+  if (last === '-c' || last === '-lc') return [...shellArgv, command];
+  return [...shellArgv, '-c', command];
+}
+
+type RaceResult<T> =
+  | { kind: 'done'; value: T }
+  | { kind: 'error'; err: unknown }
+  | { kind: 'timeout' };
+
+/**
+ * Race a promise against a wall-clock timeout. We can't actually cancel the
+ * Northflank exec call from the client, but we can stop waiting for it so the
+ * agent run keeps moving. The orphaned exec will eventually settle on the
+ * Northflank side.
+ */
+async function raceWithTimeout<T>(
+  p: Promise<T>,
+  timeoutMs: number,
+): Promise<RaceResult<T>> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<RaceResult<T>>((resolve) => {
+    timer = setTimeout(() => resolve({ kind: 'timeout' }), timeoutMs);
+  });
+  const wrapped = p
+    .then<RaceResult<T>>((value) => ({ kind: 'done', value }))
+    .catch<RaceResult<T>>((err) => ({ kind: 'error', err }));
+  try {
+    return await Promise.race([wrapped, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/packages/agents-extensions/src/northflank/tools/deploy.ts
+++ b/packages/agents-extensions/src/northflank/tools/deploy.ts
@@ -1,0 +1,269 @@
+import type { ApiClient } from '@northflank/js-client';
+import { tool } from '@openai/agents-core';
+import { z } from 'zod';
+
+import type { NorthflankTool, NorthflankToolsOptions } from '../types';
+import {
+  buildParams,
+  jsonResult,
+  nu,
+  resolveNeedsApproval,
+  resolveProjectId,
+  runApiCall,
+} from '../util';
+
+/**
+ * Build the parameter schema for tools whose body is an open-ended JSON object
+ * (`create_service`, `update_service_deployment`, `start_service_build`). The
+ * Northflank service spec is too rich to enumerate field-by-field, so we
+ * opt out of OpenAI Structured Outputs strict mode for these three.
+ *
+ * Strict mode requires `additionalProperties: false` on every object, which
+ * forbids the catch-all `body` payload. Non-strict mode requires a JSON
+ * schema (Zod is not supported) with `additionalProperties: true`. We
+ * generate the schema by hand so it matches the JS-client request shape.
+ *
+ * `defaultProjectId` makes `projectId` non-required so the model can omit it.
+ */
+function buildBodySchema(
+  options: NorthflankToolsOptions,
+  extra: Record<string, { type: string; description: string }> = {},
+) {
+  const projectIdDescription = options.defaultProjectId
+    ? 'Northflank project ID. Optional — defaults to the configured project.'
+    : 'Northflank project ID.';
+  const properties: Record<string, unknown> = {
+    projectId: { type: 'string', description: projectIdDescription },
+    ...extra,
+    body: {
+      type: 'object',
+      description: 'Pass-through payload for the Northflank API call.',
+      additionalProperties: true,
+    },
+  };
+  const required: string[] = ['body', ...Object.keys(extra)];
+  if (!options.defaultProjectId) required.unshift('projectId');
+  return {
+    type: 'object' as const,
+    properties,
+    required,
+    additionalProperties: true as const,
+  };
+}
+
+/**
+ * Deployment / lifecycle tools — all mutating, so all default to needing approval.
+ */
+export function buildDeployTools(
+  client: ApiClient,
+  options: NorthflankToolsOptions,
+): NorthflankTool[] {
+  const projectIdSchema = options.defaultProjectId
+    ? z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          'Northflank project ID. Defaults to the configured project — pass null to use the default.',
+        )
+    : z.string().describe('Northflank project ID.');
+
+  const createService = tool({
+    name: 'northflank_create_service',
+    description:
+      'Create a new Northflank deployment service from a pre-built container image. `body` follows the Northflank `POST /projects/{projectId}/services/deployment` schema (name, billing.deploymentPlan, deployment.instances, deployment.external.imagePath, ports, runtimeEnvironment).',
+    strict: false,
+    parameters: buildBodySchema(options),
+    needsApproval: resolveNeedsApproval(
+      'northflank_create_service',
+      options.approvals,
+    ),
+    execute: async (rawInput) => {
+      const input = rawInput as {
+        projectId?: string;
+        body: Record<string, unknown>;
+      };
+      const result = await runApiCall(() =>
+        client.create.service.deployment({
+          parameters: buildParams(
+            { projectId: resolveProjectId(input.projectId, options) },
+            options,
+          ),
+          data: input.body as any,
+        } as any),
+      );
+      if (!result.ok) return `Error creating service: ${result.error}`;
+      return jsonResult(result.value, options.outputCharLimit);
+    },
+  });
+
+  const updateServiceDeployment = tool({
+    name: 'northflank_update_service_deployment',
+    description:
+      'Update the deployment of an existing service — e.g. change the container image, git source, or roll out a new tag. Mirrors `PATCH /projects/{projectId}/services/{serviceId}/deployment`. Typical body: `{ "external": { "imagePath": "registry/image:tag" } }` or `{ "internal": { "buildSHA": "<sha>" } }`.',
+    strict: false,
+    parameters: buildBodySchema(options, {
+      serviceId: { type: 'string', description: 'Service ID to update.' },
+    }),
+    needsApproval: resolveNeedsApproval(
+      'northflank_update_service_deployment',
+      options.approvals,
+    ),
+    execute: async (rawInput) => {
+      const input = rawInput as {
+        projectId?: string;
+        serviceId: string;
+        body: Record<string, unknown>;
+      };
+      const result = await runApiCall(() =>
+        client.patch.service.deployment({
+          parameters: buildParams(
+            {
+              projectId: resolveProjectId(input.projectId, options),
+              serviceId: input.serviceId,
+            },
+            options,
+          ),
+          data: input.body as any,
+        } as any),
+      );
+      if (!result.ok) return `Error updating deployment: ${result.error}`;
+      return jsonResult(result.value, options.outputCharLimit);
+    },
+  });
+
+  const startServiceBuild = tool({
+    name: 'northflank_start_service_build',
+    description:
+      'Trigger a new build for a combined or git-backed service. Optionally specify a branch, commit SHA, or extra build fields (build arguments etc.) via `buildOverrides`.',
+    strict: false,
+    parameters: {
+      type: 'object' as const,
+      properties: {
+        projectId: {
+          type: 'string',
+          description: options.defaultProjectId
+            ? 'Northflank project ID. Optional — defaults to the configured project.'
+            : 'Northflank project ID.',
+        },
+        serviceId: { type: 'string', description: 'Service ID.' },
+        branch: {
+          type: 'string',
+          description: 'Git branch to build. Omit to use the service default.',
+        },
+        commitSha: {
+          type: 'string',
+          description:
+            'Specific commit SHA to build. Omit to use the branch head.',
+        },
+        buildOverrides: {
+          type: 'object',
+          description:
+            'Additional StartServiceBuild fields (build arguments etc.). Omit when none.',
+          additionalProperties: true,
+        },
+      },
+      required: options.defaultProjectId
+        ? ['serviceId']
+        : ['projectId', 'serviceId'],
+      additionalProperties: true as const,
+    },
+    needsApproval: resolveNeedsApproval(
+      'northflank_start_service_build',
+      options.approvals,
+    ),
+    execute: async (rawInput) => {
+      const input = rawInput as {
+        projectId?: string;
+        serviceId: string;
+        branch?: string;
+        commitSha?: string;
+        buildOverrides?: Record<string, unknown>;
+      };
+      const data: Record<string, unknown> = { ...(input.buildOverrides ?? {}) };
+      if (input.branch) data.branch = input.branch;
+      if (input.commitSha) data.sha = input.commitSha;
+      const result = await runApiCall(() =>
+        client.start.service.build({
+          parameters: buildParams(
+            {
+              projectId: resolveProjectId(input.projectId, options),
+              serviceId: input.serviceId,
+            },
+            options,
+          ),
+          data: data as any,
+        } as any),
+      );
+      if (!result.ok) return `Error starting build: ${result.error}`;
+      return jsonResult(result.value, options.outputCharLimit);
+    },
+  });
+
+  const restartService = tool({
+    name: 'northflank_restart_service',
+    description:
+      'Restart a Northflank service. All running instances are recreated, rolling per the service strategy.',
+    parameters: z.object({
+      projectId: projectIdSchema,
+      serviceId: z.string().describe('Service ID to restart.'),
+    }),
+    needsApproval: resolveNeedsApproval(
+      'northflank_restart_service',
+      options.approvals,
+    ),
+    execute: async ({ projectId, serviceId }) => {
+      const result = await runApiCall(() =>
+        client.restart.service({
+          parameters: buildParams(
+            { projectId: resolveProjectId(nu(projectId), options), serviceId },
+            options,
+          ),
+        } as any),
+      );
+      if (!result.ok) return `Error restarting service: ${result.error}`;
+      return jsonResult(result.value, options.outputCharLimit);
+    },
+  });
+
+  const scaleService = tool({
+    name: 'northflank_scale_service',
+    description:
+      'Scale a service to a target instance count. Northflank will roll the new replicas according to the service strategy.',
+    parameters: z.object({
+      projectId: projectIdSchema,
+      serviceId: z.string().describe('Service ID to scale.'),
+      instances: z
+        .number()
+        .int()
+        .min(0)
+        .max(100)
+        .describe('Target replica count (0–100).'),
+    }),
+    needsApproval: resolveNeedsApproval(
+      'northflank_scale_service',
+      options.approvals,
+    ),
+    execute: async ({ projectId, serviceId, instances }) => {
+      const result = await runApiCall(() =>
+        client.scale.service({
+          parameters: buildParams(
+            { projectId: resolveProjectId(nu(projectId), options), serviceId },
+            options,
+          ),
+          data: { instances } as any,
+        } as any),
+      );
+      if (!result.ok) return `Error scaling service: ${result.error}`;
+      return jsonResult(result.value, options.outputCharLimit);
+    },
+  });
+
+  return [
+    createService,
+    updateServiceDeployment,
+    startServiceBuild,
+    restartService,
+    scaleService,
+  ];
+}

--- a/packages/agents-extensions/src/northflank/tools/exec.ts
+++ b/packages/agents-extensions/src/northflank/tools/exec.ts
@@ -1,0 +1,270 @@
+import type { ApiClient } from '@northflank/js-client';
+import { tool } from '@openai/agents-core';
+import { z } from 'zod';
+
+import type { NorthflankTool, NorthflankToolsOptions } from '../types';
+import {
+  compact,
+  DEFAULT_OUTPUT_LIMIT,
+  nu,
+  resolveNeedsApproval,
+  resolveProjectId,
+  runSafe,
+  truncate,
+} from '../util';
+
+/**
+ * Wrap a user-supplied shell command as an argv array the Northflank exec
+ * API can run reliably. The API does NOT apply a shell by default — a raw
+ * string like `cd /foo && ls` would be exec'd as a single binary name. We
+ * shell out via `<shell> -lc "<command>"` so pipes, redirects and `&&`
+ * behave as expected.
+ *
+ * `shell` defaults to `sh` (override per call: `bash`, `zsh`, etc.).
+ */
+function shellArgv(command: string, shell?: string): string[] {
+  const interp = (shell ?? 'sh').trim() || 'sh';
+  const argv = interp.split(/\s+/);
+  const last = argv[argv.length - 1];
+  // Default to `sh -c` — many minimal `/bin/sh` builds don't accept `-l`.
+  // Callers who want a login shell can pass e.g. `'bash -lc'` explicitly.
+  if (last === '-c' || last === '-lc') return [...argv, command];
+  return [...argv, '-c', command];
+}
+
+/**
+ * Format the result of a one-shot exec call into a single string the model
+ * can read. We label stdout/stderr distinctly and report the exit code on the
+ * top line so the agent can branch on success without parsing.
+ *
+ * The total budget is split evenly between stdout and stderr so a noisy
+ * stream can't blow past `outputCharLimit`. If one stream is empty the other
+ * still only gets half — keeps the contract predictable. Note that the
+ * fixed header / delimiter lines (~40 chars) are NOT counted against the
+ * budget, so total output can exceed `outputCharLimit` by that small fixed
+ * amount.
+ */
+function formatExecResult(
+  result: {
+    commandResult: { exitCode: number; status: string; message?: string };
+    stdOut: string;
+    stdErr: string;
+  },
+  totalLimit: number,
+): string {
+  const halfLimit = Math.floor(totalLimit / 2);
+  const header = `exitCode=${result.commandResult.exitCode} status=${result.commandResult.status}${
+    result.commandResult.message
+      ? ` message=${result.commandResult.message}`
+      : ''
+  }`;
+  const stdout = truncate(result.stdOut ?? '', halfLimit);
+  const stderr = truncate(result.stdErr ?? '', halfLimit);
+  return [
+    header,
+    '--- stdout ---',
+    stdout || '(empty)',
+    '--- stderr ---',
+    stderr || '(empty)',
+  ].join('\n');
+}
+
+/**
+ * One-shot exec tools for services, jobs, and addons.
+ *
+ * These are powerful — they run arbitrary shell inside a running container —
+ * so they all require approval by default. Use the `approvals` option to relax
+ * if you have an external policy engine.
+ */
+export const DEFAULT_EXEC_TIMEOUT_MS = 120_000;
+
+export function buildExecTools(
+  client: ApiClient,
+  options: NorthflankToolsOptions,
+): NorthflankTool[] {
+  const limit = options.outputCharLimit ?? DEFAULT_OUTPUT_LIMIT;
+  const timeoutMs = options.execTimeoutMs ?? DEFAULT_EXEC_TIMEOUT_MS;
+  const projectIdSchema = options.defaultProjectId
+    ? z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          'Northflank project ID. Defaults to the configured project — pass null to use the default.',
+        )
+    : z.string().describe('Northflank project ID.');
+
+  const commandSchema = z
+    .string()
+    .describe(
+      'Shell command to execute, e.g. "ls -la /app" or "node scripts/migrate.js".',
+    );
+  const shellSchema = z
+    .string()
+    .nullable()
+    .optional()
+    .describe(
+      'Shell wrapper, e.g. "bash -c". Pass null for the container default.',
+    );
+  const instanceNameSchema = z
+    .string()
+    .nullable()
+    .optional()
+    .describe(
+      'Specific pod/instance to target. Pass null to let Northflank pick.',
+    );
+  const containerNameSchema = z
+    .string()
+    .nullable()
+    .optional()
+    .describe(
+      'Container within the instance (multi-container pods). Pass null for the default.',
+    );
+
+  const execService = tool({
+    name: 'northflank_exec_service',
+    description:
+      'Run a one-shot shell command inside a running instance of a Northflank service and return stdout/stderr/exit code. Output is capped — keep commands focused.',
+    parameters: z.object({
+      projectId: projectIdSchema,
+      serviceId: z.string().describe('Service ID.'),
+      command: commandSchema,
+      shell: shellSchema,
+      instanceName: instanceNameSchema,
+      containerName: containerNameSchema,
+    }),
+    needsApproval: resolveNeedsApproval(
+      'northflank_exec_service',
+      options.approvals,
+    ),
+    timeoutMs,
+    execute: async ({
+      projectId,
+      serviceId,
+      command,
+      shell,
+      instanceName,
+      containerName,
+    }) => {
+      const result = await runSafe(() =>
+        client.exec.execServiceCommand(
+          {
+            projectId: resolveProjectId(nu(projectId), options),
+            serviceId,
+            ...(options.teamId ? { teamId: options.teamId } : {}),
+          },
+          {
+            command: shellArgv(command, nu(shell)),
+            shell: 'none',
+            ...compact({
+              instanceName: nu(instanceName),
+              containerName: nu(containerName),
+            }),
+          },
+        ),
+      );
+      if (!result.ok) return `Error executing on service: ${result.error}`;
+      return formatExecResult(result.value, limit);
+    },
+  });
+
+  const execJob = tool({
+    name: 'northflank_exec_job',
+    description:
+      'Run a one-shot shell command inside a running instance of a Northflank job (useful for cron jobs that have an active run).',
+    parameters: z.object({
+      projectId: projectIdSchema,
+      jobId: z.string().describe('Job ID.'),
+      command: commandSchema,
+      shell: shellSchema,
+      instanceName: instanceNameSchema,
+      containerName: containerNameSchema,
+    }),
+    needsApproval: resolveNeedsApproval(
+      'northflank_exec_job',
+      options.approvals,
+    ),
+    timeoutMs,
+    execute: async ({
+      projectId,
+      jobId,
+      command,
+      shell,
+      instanceName,
+      containerName,
+    }) => {
+      const result = await runSafe(() =>
+        client.exec.execJobCommand(
+          {
+            projectId: resolveProjectId(nu(projectId), options),
+            jobId,
+            ...(options.teamId ? { teamId: options.teamId } : {}),
+          },
+          {
+            command: shellArgv(command, nu(shell)),
+            shell: 'none',
+            ...compact({
+              instanceName: nu(instanceName),
+              containerName: nu(containerName),
+            }),
+          },
+        ),
+      );
+      if (!result.ok) return `Error executing on job: ${result.error}`;
+      return formatExecResult(result.value, limit);
+    },
+  });
+
+  const execAddon = tool({
+    name: 'northflank_exec_addon',
+    description:
+      'Run a one-shot shell command inside a Northflank addon instance (e.g. for running `psql` against a Postgres addon). `instanceName` is required to disambiguate replicas.',
+    parameters: z.object({
+      projectId: projectIdSchema,
+      addonId: z.string().describe('Addon ID.'),
+      command: commandSchema,
+      instanceName: z
+        .string()
+        .describe(
+          'Specific addon instance (replica) to target. Required for addons.',
+        ),
+      shell: shellSchema,
+      containerName: containerNameSchema,
+    }),
+    needsApproval: resolveNeedsApproval(
+      'northflank_exec_addon',
+      options.approvals,
+    ),
+    timeoutMs,
+    execute: async ({
+      projectId,
+      addonId,
+      command,
+      shell,
+      instanceName,
+      containerName,
+    }) => {
+      const result = await runSafe(() =>
+        client.exec.execAddonCommand(
+          {
+            projectId: resolveProjectId(nu(projectId), options),
+            addonId,
+            ...(options.teamId ? { teamId: options.teamId } : {}),
+          },
+          {
+            command: shellArgv(command, nu(shell)),
+            shell: 'none',
+            instanceName,
+            ...compact({
+              containerName: nu(containerName),
+            }),
+          },
+        ),
+      );
+      if (!result.ok) return `Error executing on addon: ${result.error}`;
+      return formatExecResult(result.value, limit);
+    },
+  });
+
+  return [execService, execJob, execAddon];
+}

--- a/packages/agents-extensions/src/northflank/tools/files.ts
+++ b/packages/agents-extensions/src/northflank/tools/files.ts
@@ -1,0 +1,168 @@
+import type { ApiClient } from '@northflank/js-client';
+import { tool } from '@openai/agents-core';
+import { z } from 'zod';
+
+import type { NorthflankTool, NorthflankToolsOptions } from '../types';
+import {
+  compact,
+  jsonResult,
+  nu,
+  resolveNeedsApproval,
+  resolveProjectId,
+  runSafe,
+} from '../util';
+
+/**
+ * File copy tools. The agent passes local + remote paths; the JS client
+ * archives/streams the files. The agent host filesystem is the source/sink,
+ * so deployments where the agent runs in a sandbox are the typical use case.
+ */
+export const DEFAULT_FILE_TIMEOUT_MS = 300_000;
+
+export function buildFileTools(
+  client: ApiClient,
+  options: NorthflankToolsOptions,
+): NorthflankTool[] {
+  const timeoutMs = options.fileTimeoutMs ?? DEFAULT_FILE_TIMEOUT_MS;
+  const projectIdSchema = options.defaultProjectId
+    ? z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          'Northflank project ID. Defaults to the configured project — pass null to use the default.',
+        )
+    : z.string().describe('Northflank project ID.');
+
+  const uploadFiles = tool({
+    name: 'northflank_upload_files',
+    description:
+      'Upload a local file or directory into a running Northflank service instance. Useful for pushing patches, fixtures, or scripts before exec.',
+    parameters: z.object({
+      projectId: projectIdSchema,
+      serviceId: z.string().describe('Target service ID.'),
+      localPath: z
+        .string()
+        .describe('Absolute path on the agent host to upload from.'),
+      remotePath: z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          'Destination path inside the container. Pass null to use the working directory.',
+        ),
+      instanceName: z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          'Specific instance to target. Pass null to let Northflank pick.',
+        ),
+      containerName: z
+        .string()
+        .nullable()
+        .optional()
+        .describe('Container in multi-container pods. Pass null for default.'),
+    }),
+    needsApproval: resolveNeedsApproval(
+      'northflank_upload_files',
+      options.approvals,
+    ),
+    timeoutMs,
+    execute: async ({
+      projectId,
+      serviceId,
+      localPath,
+      remotePath,
+      instanceName,
+      containerName,
+    }) => {
+      const result = await runSafe(() =>
+        client.fileCopy.uploadServiceFiles(
+          {
+            projectId: resolveProjectId(nu(projectId), options),
+            serviceId,
+            ...(options.teamId ? { teamId: options.teamId } : {}),
+          },
+          {
+            localPath,
+            ...compact({
+              remotePath: nu(remotePath),
+              instanceName: nu(instanceName),
+              containerName: nu(containerName),
+            }),
+          },
+        ),
+      );
+      if (!result.ok) return `Error uploading files: ${result.error}`;
+      return jsonResult(result.value, options.outputCharLimit);
+    },
+  });
+
+  const downloadFiles = tool({
+    name: 'northflank_download_files',
+    description:
+      'Download a file or directory from a running Northflank service instance to the agent host. Useful for fetching logs, dumps, or artifacts.',
+    parameters: z.object({
+      projectId: projectIdSchema,
+      serviceId: z.string().describe('Source service ID.'),
+      localPath: z
+        .string()
+        .describe('Absolute path on the agent host to download into.'),
+      remotePath: z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          'Path inside the container to copy from. Pass null for the working directory.',
+        ),
+      instanceName: z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          'Specific instance to target. Pass null to let Northflank pick.',
+        ),
+      containerName: z
+        .string()
+        .nullable()
+        .optional()
+        .describe('Container in multi-container pods. Pass null for default.'),
+    }),
+    needsApproval: resolveNeedsApproval(
+      'northflank_download_files',
+      options.approvals,
+    ),
+    timeoutMs,
+    execute: async ({
+      projectId,
+      serviceId,
+      localPath,
+      remotePath,
+      instanceName,
+      containerName,
+    }) => {
+      const result = await runSafe(() =>
+        client.fileCopy.downloadServiceFiles(
+          {
+            projectId: resolveProjectId(nu(projectId), options),
+            serviceId,
+            ...(options.teamId ? { teamId: options.teamId } : {}),
+          },
+          {
+            localPath,
+            ...compact({
+              remotePath: nu(remotePath),
+              instanceName: nu(instanceName),
+              containerName: nu(containerName),
+            }),
+          },
+        ),
+      );
+      if (!result.ok) return `Error downloading files: ${result.error}`;
+      return jsonResult(result.value, options.outputCharLimit);
+    },
+  });
+
+  return [uploadFiles, downloadFiles];
+}

--- a/packages/agents-extensions/src/northflank/tools/logs.ts
+++ b/packages/agents-extensions/src/northflank/tools/logs.ts
@@ -1,0 +1,104 @@
+import type { ApiClient } from '@northflank/js-client';
+import { tool } from '@openai/agents-core';
+import { z } from 'zod';
+
+import type { NorthflankTool, NorthflankToolsOptions } from '../types';
+import {
+  buildParams,
+  DEFAULT_OUTPUT_LIMIT,
+  nu,
+  resolveNeedsApproval,
+  resolveProjectId,
+  runApiCall,
+  truncate,
+} from '../util';
+
+/**
+ * Recent runtime-log fetch for a service. We surface a flat string so the
+ * model can scan it as if it were terminal output, with each line prefixed by
+ * the container ID and timestamp.
+ */
+export function buildLogsTools(
+  client: ApiClient,
+  options: NorthflankToolsOptions,
+): NorthflankTool[] {
+  const limit = options.outputCharLimit ?? DEFAULT_OUTPUT_LIMIT;
+  const projectIdSchema = options.defaultProjectId
+    ? z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          'Northflank project ID. Defaults to the configured project — pass null to use the default.',
+        )
+    : z.string().describe('Northflank project ID.');
+
+  const getServiceLogs = tool({
+    name: 'northflank_get_service_logs',
+    description:
+      'Fetch recent runtime logs for a Northflank service. Returns a chronological line-oriented stream. Use `durationSeconds` to look back N seconds (default 300 = 5 minutes).',
+    parameters: z.object({
+      projectId: projectIdSchema,
+      serviceId: z.string().describe('Service ID.'),
+      durationSeconds: z
+        .number()
+        .int()
+        .min(1)
+        .max(86_400)
+        .nullable()
+        .optional()
+        .describe('Lookback window. Pass null for 5 minutes (300s).'),
+      containerName: z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          'Filter to a specific container, or "all". Pass null for default.',
+        ),
+    }),
+    needsApproval: resolveNeedsApproval(
+      'northflank_get_service_logs',
+      options.approvals,
+    ),
+    execute: async ({
+      projectId,
+      serviceId,
+      durationSeconds,
+      containerName,
+    }) => {
+      const now = new Date();
+      const start = new Date(
+        now.getTime() - (nu(durationSeconds) ?? 300) * 1000,
+      );
+      const cName = nu(containerName);
+      const result = await runApiCall(() =>
+        client.get.service.logs({
+          parameters: buildParams(
+            { projectId: resolveProjectId(nu(projectId), options), serviceId },
+            options,
+          ),
+          options: {
+            startTime: start,
+            endTime: now,
+            ...(cName ? { containerName: cName } : {}),
+          } as any,
+        } as any),
+      );
+      if (!result.ok) return `Error fetching logs: ${result.error}`;
+      const lines = (result.value ?? [])
+        .map((line: any) => {
+          const ts =
+            line.ts instanceof Date
+              ? line.ts.toISOString()
+              : String(line.ts ?? '');
+          const log =
+            typeof line.log === 'string' ? line.log : JSON.stringify(line.log);
+          return `[${ts}] ${line.containerId ?? ''} ${log}`;
+        })
+        .join('\n');
+      return truncate(lines || '(no log entries in window)', limit);
+    },
+  });
+
+  return [getServiceLogs];
+}

--- a/packages/agents-extensions/src/northflank/tools/metrics.ts
+++ b/packages/agents-extensions/src/northflank/tools/metrics.ts
@@ -1,0 +1,100 @@
+import type { ApiClient } from '@northflank/js-client';
+import { tool } from '@openai/agents-core';
+import { z } from 'zod';
+
+import type { NorthflankTool, NorthflankToolsOptions } from '../types';
+import {
+  buildParams,
+  jsonResult,
+  nu,
+  resolveNeedsApproval,
+  resolveProjectId,
+  runApiCall,
+} from '../util';
+
+const METRIC_TYPES = [
+  'cpu',
+  'memory',
+  'networkIngress',
+  'networkEgress',
+  'tcpConnectionsOpen',
+  'diskUsage',
+  'requests',
+  'http4xxResponses',
+  'http5xxResponses',
+  'bandwidth',
+  'bandwidthVolume',
+] as const;
+
+export function buildMetricsTools(
+  client: ApiClient,
+  options: NorthflankToolsOptions,
+): NorthflankTool[] {
+  const projectIdSchema = options.defaultProjectId
+    ? z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          'Northflank project ID. Defaults to the configured project — pass null to use the default.',
+        )
+    : z.string().describe('Northflank project ID.');
+
+  const getServiceMetrics = tool({
+    name: 'northflank_get_service_metrics',
+    description:
+      'Fetch a metrics range for a Northflank service. Returns time-series values for each requested metric over the lookback window.',
+    parameters: z.object({
+      projectId: projectIdSchema,
+      serviceId: z.string().describe('Service ID.'),
+      durationSeconds: z
+        .number()
+        .int()
+        .min(60)
+        .max(86_400)
+        .nullable()
+        .optional()
+        .describe('Lookback window. Pass null for 15 minutes (900s).'),
+      metricTypes: z
+        .array(z.enum(METRIC_TYPES))
+        .nullable()
+        .optional()
+        .describe('Metrics to include. Pass null for ["cpu", "memory"].'),
+      containerName: z
+        .string()
+        .nullable()
+        .optional()
+        .describe('Container filter (or "all"). Pass null for default.'),
+    }),
+    needsApproval: resolveNeedsApproval(
+      'northflank_get_service_metrics',
+      options.approvals,
+    ),
+    execute: async ({
+      projectId,
+      serviceId,
+      durationSeconds,
+      metricTypes,
+      containerName,
+    }) => {
+      const cName = nu(containerName);
+      const result = await runApiCall(() =>
+        client.get.service.metricsRange({
+          parameters: buildParams(
+            { projectId: resolveProjectId(nu(projectId), options), serviceId },
+            options,
+          ),
+          options: {
+            duration: nu(durationSeconds) ?? 900,
+            metricTypes: (nu(metricTypes) ?? ['cpu', 'memory']) as any,
+            ...(cName ? { containerName: cName } : {}),
+          } as any,
+        } as any),
+      );
+      if (!result.ok) return `Error fetching metrics: ${result.error}`;
+      return jsonResult(result.value, options.outputCharLimit);
+    },
+  });
+
+  return [getServiceMetrics];
+}

--- a/packages/agents-extensions/src/northflank/tools/read.ts
+++ b/packages/agents-extensions/src/northflank/tools/read.ts
@@ -1,0 +1,148 @@
+import type { ApiClient } from '@northflank/js-client';
+import { tool } from '@openai/agents-core';
+import { z } from 'zod';
+
+import type { NorthflankTool, NorthflankToolsOptions } from '../types';
+import {
+  buildParams,
+  jsonResult,
+  nu,
+  resolveNeedsApproval,
+  resolveProjectId,
+  runApiCall,
+} from '../util';
+
+/**
+ * Read-only inspection tools. Safe to enable without approval.
+ */
+export function buildReadTools(
+  client: ApiClient,
+  options: NorthflankToolsOptions,
+): NorthflankTool[] {
+  const projectIdSchema = options.defaultProjectId
+    ? z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          'Northflank project ID. Defaults to the configured project — pass null to use the default.',
+        )
+    : z.string().describe('Northflank project ID.');
+
+  const listProjects = tool({
+    name: 'northflank_list_projects',
+    description:
+      'List Northflank projects the authenticated principal can see. Returns id, name, region, and description for each project. Supports pagination via the page argument.',
+    parameters: z.object({
+      page: z
+        .number()
+        .int()
+        .min(1)
+        .nullable()
+        .optional()
+        .describe(
+          '1-indexed page number (max 100 results per page). Pass null for the first page.',
+        ),
+    }),
+    needsApproval: resolveNeedsApproval(
+      'northflank_list_projects',
+      options.approvals,
+    ),
+    execute: async ({ page }) => {
+      const result = await runApiCall(() =>
+        client.list.projects({
+          parameters: options.teamId ? { teamId: options.teamId } : undefined,
+          options: nu(page) != null ? { page: nu(page)! } : undefined,
+        } as any),
+      );
+      if (!result.ok) return `Error listing projects: ${result.error}`;
+      return jsonResult(result.value, options.outputCharLimit);
+    },
+  });
+
+  const getProject = tool({
+    name: 'northflank_get_project',
+    description:
+      'Get the details of a single Northflank project by id (cluster, region, networking, members).',
+    parameters: z.object({
+      projectId: projectIdSchema,
+    }),
+    needsApproval: resolveNeedsApproval(
+      'northflank_get_project',
+      options.approvals,
+    ),
+    execute: async ({ projectId }) => {
+      const result = await runApiCall(() =>
+        client.get.project({
+          parameters: buildParams(
+            { projectId: resolveProjectId(nu(projectId), options) },
+            options,
+          ),
+        } as any),
+      );
+      if (!result.ok) return `Error fetching project: ${result.error}`;
+      return jsonResult(result.value, options.outputCharLimit);
+    },
+  });
+
+  const listServices = tool({
+    name: 'northflank_list_services',
+    description:
+      'List all services in a Northflank project. Returns id, name, type (deployment/combined/external), and status for each service.',
+    parameters: z.object({
+      projectId: projectIdSchema,
+      page: z
+        .number()
+        .int()
+        .min(1)
+        .nullable()
+        .optional()
+        .describe('1-indexed page number. Pass null for the first page.'),
+    }),
+    needsApproval: resolveNeedsApproval(
+      'northflank_list_services',
+      options.approvals,
+    ),
+    execute: async ({ projectId, page }) => {
+      const result = await runApiCall(() =>
+        client.list.services({
+          parameters: buildParams(
+            { projectId: resolveProjectId(nu(projectId), options) },
+            options,
+          ),
+          options: nu(page) != null ? { page: nu(page)! } : undefined,
+        } as any),
+      );
+      if (!result.ok) return `Error listing services: ${result.error}`;
+      return jsonResult(result.value, options.outputCharLimit);
+    },
+  });
+
+  const getService = tool({
+    name: 'northflank_get_service',
+    description:
+      'Get the full configuration and status of a single Northflank service: image, ports, env, deployment, replica counts.',
+    parameters: z.object({
+      projectId: projectIdSchema,
+      serviceId: z.string().describe('The service ID within the project.'),
+    }),
+    needsApproval: resolveNeedsApproval(
+      'northflank_get_service',
+      options.approvals,
+    ),
+    execute: async ({ projectId, serviceId }) => {
+      const result = await runApiCall(() =>
+        client.get.service({
+          parameters: buildParams(
+            { projectId: resolveProjectId(nu(projectId), options), serviceId },
+            options,
+          ),
+        } as any),
+      );
+      if (!result.ok) return `Error fetching service: ${result.error}`;
+      return jsonResult(result.value, options.outputCharLimit);
+    },
+  });
+
+  return [listProjects, getProject, listServices, getService];
+}

--- a/packages/agents-extensions/src/northflank/tools/secrets.ts
+++ b/packages/agents-extensions/src/northflank/tools/secrets.ts
@@ -1,0 +1,59 @@
+import type { ApiClient } from '@northflank/js-client';
+import { tool } from '@openai/agents-core';
+import { z } from 'zod';
+
+import type { NorthflankTool, NorthflankToolsOptions } from '../types';
+import {
+  buildParams,
+  jsonResult,
+  nu,
+  resolveNeedsApproval,
+  resolveProjectId,
+  runApiCall,
+} from '../util';
+
+/**
+ * Secrets group. Opt-in (not enabled in the default `include`) because even
+ * listing secret metadata can leak naming patterns.
+ */
+export function buildSecretsTools(
+  client: ApiClient,
+  options: NorthflankToolsOptions,
+): NorthflankTool[] {
+  const projectIdSchema = options.defaultProjectId
+    ? z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          'Northflank project ID. Defaults to the configured project — pass null to use the default.',
+        )
+    : z.string().describe('Northflank project ID.');
+
+  const listSecrets = tool({
+    name: 'northflank_list_secrets',
+    description:
+      'List secret groups in a Northflank project. Returns secret group names and metadata only — never the secret values themselves.',
+    parameters: z.object({
+      projectId: projectIdSchema,
+    }),
+    needsApproval: resolveNeedsApproval(
+      'northflank_list_secrets',
+      options.approvals,
+    ),
+    execute: async ({ projectId }) => {
+      const result = await runApiCall(() =>
+        client.list.secrets({
+          parameters: buildParams(
+            { projectId: resolveProjectId(nu(projectId), options) },
+            options,
+          ),
+        } as any),
+      );
+      if (!result.ok) return `Error listing secrets: ${result.error}`;
+      return jsonResult(result.value, options.outputCharLimit);
+    },
+  });
+
+  return [listSecrets];
+}

--- a/packages/agents-extensions/src/northflank/types.ts
+++ b/packages/agents-extensions/src/northflank/types.ts
@@ -1,0 +1,102 @@
+import type { FunctionTool } from '@openai/agents-core';
+
+/**
+ * Northflank tool group identifiers. Used by the `include` option on
+ * {@link NorthflankToolsOptions} to filter which tools are exposed to the agent.
+ */
+export type NorthflankToolGroup =
+  | 'read'
+  | 'deploy'
+  | 'exec'
+  | 'files'
+  | 'logs'
+  | 'metrics'
+  | 'secrets';
+
+/**
+ * Canonical names of every tool produced by {@link northflankTools}. Use these
+ * to override approval behaviour or refer to specific tools in error handling.
+ */
+export type NorthflankToolName =
+  | 'northflank_list_projects'
+  | 'northflank_get_project'
+  | 'northflank_list_services'
+  | 'northflank_get_service'
+  | 'northflank_create_service'
+  | 'northflank_update_service_deployment'
+  | 'northflank_start_service_build'
+  | 'northflank_restart_service'
+  | 'northflank_scale_service'
+  | 'northflank_exec_service'
+  | 'northflank_exec_job'
+  | 'northflank_exec_addon'
+  | 'northflank_upload_files'
+  | 'northflank_download_files'
+  | 'northflank_get_service_logs'
+  | 'northflank_get_service_metrics'
+  | 'northflank_list_secrets';
+
+/**
+ * Approval policy for the generated tools.
+ *
+ * - `'auto'` (default): mutating + exec + file-upload tools require approval; reads do not.
+ * - `'always'`: every tool requires approval.
+ * - `'never'`: no tool requires approval (use only for trusted automation).
+ * - object: per-tool override. Falls back to `'auto'` for unspecified tools.
+ */
+export type NorthflankApprovalsConfig =
+  | 'auto'
+  | 'always'
+  | 'never'
+  | Partial<Record<NorthflankToolName, boolean>>;
+
+export interface NorthflankToolsOptions {
+  /**
+   * Limit the toolset to the specified groups. Defaults to all groups except
+   * `secrets`, which is opt-in because it exposes sensitive metadata.
+   */
+  include?: NorthflankToolGroup[];
+
+  /**
+   * Approval policy. See {@link NorthflankApprovalsConfig}.
+   */
+  approvals?: NorthflankApprovalsConfig;
+
+  /**
+   * If provided, the `projectId` argument on every tool becomes optional and
+   * falls back to this value. Useful when an agent is scoped to a single project.
+   */
+  defaultProjectId?: string;
+
+  /**
+   * If provided, scopes API calls to a specific team/org. Pass-through on every
+   * request and exposed as a default for tools that accept an explicit teamId.
+   */
+  teamId?: string;
+
+  /**
+   * Hard cap on captured output per exec call, in characters. Defaults to
+   * 20,000. For exec tools the cap is split evenly between stdout and stderr
+   * (so total output is still bounded by this number, not double it). For
+   * other tools the whole JSON response is truncated to this length.
+   * Truncation is marked with `[truncated N chars]` so the model can adapt.
+   */
+  outputCharLimit?: number;
+
+  /**
+   * Timeout for exec tools (`exec_service` / `exec_job` / `exec_addon`), in
+   * milliseconds. Defaults to 120,000 (2 minutes). The OpenAI Agents runtime
+   * aborts the tool call past this point so a stuck remote command can't hang
+   * the run forever.
+   */
+  execTimeoutMs?: number;
+
+  /**
+   * Timeout for file copy tools (`upload_files` / `download_files`), in
+   * milliseconds. Defaults to 300,000 (5 minutes) to accommodate larger
+   * directory copies.
+   */
+  fileTimeoutMs?: number;
+}
+
+export type NorthflankTool = FunctionTool<any, any, any>;

--- a/packages/agents-extensions/src/northflank/util.ts
+++ b/packages/agents-extensions/src/northflank/util.ts
@@ -1,0 +1,188 @@
+import type {
+  NorthflankApprovalsConfig,
+  NorthflankToolName,
+  NorthflankToolsOptions,
+} from './types';
+
+export const DEFAULT_OUTPUT_LIMIT = 20_000;
+
+const MUTATING_TOOLS: ReadonlySet<NorthflankToolName> = new Set([
+  'northflank_create_service',
+  'northflank_update_service_deployment',
+  'northflank_start_service_build',
+  'northflank_restart_service',
+  'northflank_scale_service',
+  'northflank_exec_service',
+  'northflank_exec_job',
+  'northflank_exec_addon',
+  'northflank_upload_files',
+  // download_files writes to the agent host filesystem — treat as mutating.
+  'northflank_download_files',
+]);
+
+/**
+ * Resolve whether a given tool requires approval according to the user's
+ * config. Defaults to `'auto'` (mutating tools require approval, reads don't).
+ */
+export function resolveNeedsApproval(
+  toolName: NorthflankToolName,
+  approvals: NorthflankApprovalsConfig | undefined,
+): boolean {
+  if (approvals === 'always') return true;
+  if (approvals === 'never') return false;
+  if (approvals && typeof approvals === 'object') {
+    const override = approvals[toolName];
+    if (typeof override === 'boolean') return override;
+  }
+  return MUTATING_TOOLS.has(toolName);
+}
+
+/**
+ * Truncate a string to the configured limit. Adds a marker indicating how many
+ * characters were dropped so the model can adapt its strategy (e.g. ask for
+ * a tighter command).
+ */
+export function truncate(input: string, limit = DEFAULT_OUTPUT_LIMIT): string {
+  if (!input) return '';
+  if (input.length <= limit) return input;
+  const dropped = input.length - limit;
+  return `${input.slice(0, limit)}\n... [truncated ${dropped} chars]`;
+}
+
+/**
+ * Resolve the project ID for a tool call, falling back to the configured
+ * default. Throws a clear error if neither is present.
+ */
+export function resolveProjectId(
+  argProjectId: string | undefined,
+  options: NorthflankToolsOptions,
+): string {
+  const id = argProjectId ?? options.defaultProjectId;
+  if (!id) {
+    throw new Error(
+      'projectId is required (no defaultProjectId was configured on northflankTools).',
+    );
+  }
+  return id;
+}
+
+/**
+ * Wrap an API call so any thrown error is converted to a string. The Agents
+ * SDK passes execute results back to the model verbatim; throwing leaks
+ * internals and aborts the run. Instead we return a structured error string
+ * that the model can read and recover from.
+ *
+ * Use this for client methods that throw on failure (exec, fileCopy). For
+ * methods that return `ApiCallResponse`, use {@link runApiCall} instead so
+ * non-2xx HTTP responses are surfaced even when the client is configured with
+ * `throwErrorOnHttpErrorCode: false` (the JS-client default).
+ */
+export async function runSafe<T>(
+  fn: () => Promise<T>,
+): Promise<{ ok: true; value: T } | { ok: false; error: string }> {
+  try {
+    return { ok: true, value: await fn() };
+  } catch (err) {
+    return { ok: false, error: formatError(err) };
+  }
+}
+
+/**
+ * Shape of every Northflank `ApiCallResponse`. Reproduced here so we don't
+ * pull the runtime type into our public types — it lives in the client.
+ */
+interface ApiResponseLike<T> {
+  data: T;
+  error?: {
+    status?: number;
+    message?: string;
+    id?: string;
+    details?: unknown;
+  };
+}
+
+/**
+ * Wrap an `ApiCallResponse`-returning call. Catches thrown errors AND surfaces
+ * the `response.error` field that the JS client populates when it's running
+ * with the default `throwErrorOnHttpErrorCode: false`.
+ *
+ * Without this, a 404 / 500 from Northflank would silently return `undefined`
+ * data and look like success to the agent.
+ */
+export async function runApiCall<T>(
+  fn: () => Promise<ApiResponseLike<T>>,
+): Promise<{ ok: true; value: T } | { ok: false; error: string }> {
+  try {
+    const response = await fn();
+    if (response.error) {
+      const { status, message, id } = response.error;
+      const parts = [
+        status ? `HTTP ${status}` : null,
+        message ?? 'unknown API error',
+        id ? `(id ${id})` : null,
+      ].filter(Boolean);
+      return { ok: false, error: parts.join(' ') };
+    }
+    return { ok: true, value: response.data };
+  } catch (err) {
+    return { ok: false, error: formatError(err) };
+  }
+}
+
+function formatError(err: unknown): string {
+  if (err instanceof Error) {
+    // NorthflankApiCallError tucks the HTTP status on the instance.
+    const status = (err as Error & { status?: number }).status;
+    return status ? `HTTP ${status} ${err.message}` : err.message;
+  }
+  return String(err);
+}
+
+/**
+ * Build the params object passed to the Northflank JS client. When a `teamId`
+ * is configured we merge it in; the client tolerates an undefined teamId so we
+ * only add the key when it's set.
+ */
+export function buildParams<T extends Record<string, unknown>>(
+  params: T,
+  options: NorthflankToolsOptions,
+): T & { teamId?: string } {
+  if (options.teamId) {
+    return { ...params, teamId: options.teamId };
+  }
+  return params;
+}
+
+/**
+ * Stringify a JSON-compatible value, truncating to fit within the output cap.
+ * Tools return strings; this keeps payloads readable without blowing up the
+ * context window.
+ */
+export function jsonResult(value: unknown, limit?: number): string {
+  return truncate(
+    JSON.stringify(value, null, 2),
+    limit ?? DEFAULT_OUTPUT_LIMIT,
+  );
+}
+
+/**
+ * OpenAI Structured Outputs requires every property be `required` in the JSON
+ * schema, so optional fields use `.nullable().optional()` — the model passes
+ * `null` to "omit" them. Convert those nulls back to `undefined` before
+ * forwarding to the Northflank API, which expects missing rather than null.
+ */
+export function nu<T>(value: T | null | undefined): T | undefined {
+  return value == null ? undefined : value;
+}
+
+/**
+ * Strip null/undefined values from a record. Used to assemble pass-through
+ * payloads for the Northflank API without polluting them with explicit nulls.
+ */
+export function compact<T extends Record<string, unknown>>(obj: T): Partial<T> {
+  const out: Partial<T> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v != null) (out as Record<string, unknown>)[k] = v;
+  }
+  return out;
+}

--- a/packages/agents-extensions/src/sandbox/northflank/index.ts
+++ b/packages/agents-extensions/src/sandbox/northflank/index.ts
@@ -1,0 +1,1 @@
+export * from './sandbox';

--- a/packages/agents-extensions/src/sandbox/northflank/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/northflank/sandbox.ts
@@ -1,0 +1,1418 @@
+import { UserError } from '@openai/agents-core';
+import {
+  Manifest,
+  SandboxProviderError,
+  normalizeSandboxClientCreateArgs,
+  type SandboxClient,
+  type SandboxClientCreateArgs,
+  type SandboxClientOptions,
+  type SandboxSessionLifecycleOptions,
+  type SandboxSessionState,
+  type SandboxArchiveLimits,
+  type SandboxConcurrencyLimits,
+} from '@openai/agents-core/sandbox';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join as joinPath, posix } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import {
+  RemoteSandboxSessionBase,
+  assertCoreSnapshotUnsupported,
+  closeRemoteSessionOnManifestError,
+  deserializeRemoteSandboxSessionStateValues,
+  materializeEnvironment,
+  readOptionalBoolean,
+  readOptionalNumber,
+  readOptionalString,
+  readString,
+  serializeRemoteSandboxSessionState,
+  shellQuote,
+  withProviderError,
+  withSandboxSpan,
+  type RemoteSandboxCommandOptions,
+  type RemoteSandboxCommandResult,
+} from '../shared';
+
+/**
+ * A minimal structural view of the @northflank/js-client surface we touch.
+ * Reproduced here so we don't take a hard type dep on the SDK — it's an
+ * optional peer dependency loaded dynamically when the caller doesn't bring
+ * their own pre-constructed ApiClient.
+ */
+type NorthflankApiClient = {
+  create: {
+    service: {
+      deployment: (opts: {
+        parameters: { projectId: string; teamId?: string };
+        data: Record<string, unknown>;
+      }) => Promise<{ data?: { id?: string }; error?: NorthflankApiError }>;
+    };
+    volume: (opts: {
+      parameters: { projectId: string; teamId?: string };
+      data: {
+        name: string;
+        mounts: { containerMountPath: string; volumeMountPath?: string }[];
+        spec: {
+          accessMode: 'ReadWriteOnce' | 'ReadWriteMany';
+          storageClassName?: string;
+          storageSize: number;
+        };
+        attachedObjects?: { id: string; type: 'service' | 'job' }[];
+      };
+    }) => Promise<{ data?: { id?: string }; error?: NorthflankApiError }>;
+  };
+  get: {
+    service: ((opts: {
+      parameters: { projectId: string; serviceId: string; teamId?: string };
+    }) => Promise<{
+      data?: NorthflankServiceData;
+      error?: NorthflankApiError;
+    }>) & {
+      containers: (opts: {
+        parameters: { projectId: string; serviceId: string; teamId?: string };
+      }) => Promise<{
+        data?: NorthflankContainersData;
+        error?: NorthflankApiError;
+      }>;
+    };
+  };
+  delete: {
+    service: (opts: {
+      parameters: { projectId: string; serviceId: string; teamId?: string };
+    }) => Promise<{ data?: unknown; error?: NorthflankApiError }>;
+    volume: (opts: {
+      parameters: { projectId: string; volumeId: string; teamId?: string };
+    }) => Promise<{ data?: unknown; error?: NorthflankApiError }>;
+  };
+  attach: {
+    volume: (opts: {
+      parameters: { projectId: string; volumeId: string; teamId?: string };
+      data: { nfObject: { id: string; type: 'service' | 'job' } };
+    }) => Promise<{ data?: unknown; error?: NorthflankApiError }>;
+  };
+  detach: {
+    volume: (opts: {
+      parameters: { projectId: string; volumeId: string; teamId?: string };
+      data: { nfObject: { id: string; type: 'service' | 'job' } };
+    }) => Promise<{ data?: unknown; error?: NorthflankApiError }>;
+  };
+  pause: {
+    service: (opts: {
+      parameters: { projectId: string; serviceId: string; teamId?: string };
+    }) => Promise<{ data?: unknown; error?: NorthflankApiError }>;
+  };
+  resume: {
+    service: (opts: {
+      parameters: { projectId: string; serviceId: string; teamId?: string };
+    }) => Promise<{ data?: unknown; error?: NorthflankApiError }>;
+  };
+  exec: {
+    execServiceCommand: (
+      params: {
+        projectId: string;
+        serviceId: string;
+        teamId?: string;
+      },
+      data: {
+        command: string | string[];
+        shell?: string;
+        instanceName?: string;
+        containerName?: string;
+        user?: string | number;
+      },
+    ) => Promise<{
+      commandResult: {
+        exitCode: number | null;
+        status: string;
+        message?: string;
+      };
+      stdOut: string;
+      stdErr: string;
+    }>;
+  };
+  fileCopy: {
+    uploadServiceFiles: (
+      params: { projectId: string; serviceId: string; teamId?: string },
+      options: {
+        localPath: string;
+        remotePath?: string;
+        instanceName?: string;
+        containerName?: string;
+      },
+    ) => Promise<unknown>;
+    downloadServiceFiles: (
+      params: { projectId: string; serviceId: string; teamId?: string },
+      options: {
+        localPath: string;
+        remotePath?: string;
+        instanceName?: string;
+        containerName?: string;
+      },
+    ) => Promise<unknown>;
+  };
+};
+
+type NorthflankApiError = {
+  status?: number;
+  message?: string;
+  id?: string;
+};
+
+type NorthflankServiceData = {
+  id?: string;
+  servicePaused?: boolean;
+  status?: {
+    deployment?: {
+      status?: 'PENDING' | 'IN_PROGRESS' | 'COMPLETED' | 'FAILED';
+    };
+  };
+};
+
+type NorthflankContainersData = {
+  containers?: Array<{
+    name: string;
+    status: string;
+  }>;
+};
+
+/**
+ * Options for {@link NorthflankSandboxClient}. Two ways to authenticate:
+ *
+ * 1. Pass an `apiClient` that you've already constructed with your preferred
+ *    Northflank context provider (recommended for production).
+ * 2. Pass an `apiToken` and the SDK will lazy-construct a default ApiClient.
+ *    Convenient for examples and scripts.
+ */
+export interface NorthflankSandboxClientOptions extends SandboxClientOptions {
+  /** Northflank project ID where the sandbox service will live. */
+  projectId?: string;
+
+  /** Container image to run, e.g. `'docker.io/library/ubuntu:24.04'`. */
+  image?: string;
+
+  /** Pre-constructed `ApiClient` from `@northflank/js-client`. */
+  apiClient?: NorthflankApiClient;
+
+  /** API token (used only when `apiClient` is not supplied). */
+  apiToken?: string;
+
+  /** Northflank team / org scope. */
+  teamId?: string;
+
+  /** Northflank deployment plan. Defaults to `'nf-compute-20'`. */
+  deploymentPlan?: string;
+
+  /**
+   * Prefix for generated service IDs. Each session appends a random suffix.
+   * Defaults to `'agent-sandbox'`.
+   */
+  serviceNamePrefix?: string;
+
+  /**
+   * Optional override for the container entrypoint / command. Useful when
+   * the image's default CMD exits immediately (e.g. base ubuntu) — set
+   * `customEntrypoint: 'sleep', customCommand: 'infinity'` to keep it
+   * alive for the duration of the agent run.
+   */
+  docker?: {
+    customEntrypoint?: string;
+    customCommand?: string;
+  };
+
+  /** Environment variables to set in the container. */
+  env?: Record<string, string>;
+
+  /**
+   * If true, `close()` pauses the underlying service instead of deleting it
+   * so a later `resume(state)` can pick it back up. Defaults to false.
+   *
+   * Without `workspacePersistence`, Northflank deployment services use
+   * ephemeral pod storage — files written during a session do NOT survive
+   * a pause cycle and the manifest is re-applied on every `create()`. Set
+   * `workspacePersistence` to `'volume'` or `'tar'` to keep the workspace
+   * across pause/resume.
+   */
+  pauseOnExit?: boolean;
+
+  /**
+   * How (and whether) the workspace contents persist across pause / resume:
+   *
+   * - `undefined` (default): ephemeral pod storage. Workspace is lost on
+   *   pause; manifest is re-materialized on every `create()`.
+   * - `'volume'`: provision a Northflank volume, attach it to the service,
+   *   and mount it at `workspaceRoot`. The volume survives pause cycles
+   *   and is deleted only when `delete()` runs (and only if this client
+   *   created it).
+   * - `'tar'`: capture the workspace contents to a tar archive at `stop()`,
+   *   store it inline in the session state, and re-extract it on `resume()`.
+   *   Convenient for small workspaces; bounded by whatever your runtime is
+   *   willing to round-trip through `serializeSessionState`.
+   */
+  workspacePersistence?: 'volume' | 'tar';
+
+  /**
+   * Override the volume created in `'volume'` persistence mode. Ignored for
+   * other modes. The default is a 5 GB `ReadWriteMany` volume on the
+   * `'nf-multi-rw'` storage class.
+   */
+  volumeSpec?: {
+    /**
+     * Volume size in megabytes. Defaults to 5120 (5 GB) — the minimum the
+     * default `nf-multi-rw` storage class accepts on Northflank's standard
+     * cluster.
+     */
+    storageSize?: number;
+    /**
+     * Volume access mode. Defaults to `'ReadWriteMany'` to match the
+     * `'nf-multi-rw'` storage class used by default. Override to
+     * `'ReadWriteOnce'` when pairing with a single-attach storage class.
+     */
+    accessMode?: 'ReadWriteOnce' | 'ReadWriteMany';
+    /**
+     * Storage class. Defaults to `'nf-multi-rw'`, which is available on
+     * Northflank's standard cluster and accepts the 5 GB default size
+     * above. The cluster default (`nvme`) requires a 6 GB minimum, so we
+     * override it here for out-of-the-box compatibility.
+     */
+    storageClassName?: string;
+  };
+
+  /**
+   * Reuse an existing Northflank volume in `'volume'` persistence mode
+   * instead of provisioning a new one. The volume must already have a
+   * mount entry at `workspaceRoot` (mount paths are configured on the
+   * volume itself, not on the attach call). The volume is attached to
+   * the service on `create()` and is NOT deleted on `delete()` — the
+   * caller owns it.
+   */
+  volumeId?: string;
+
+  /**
+   * Maximum time `create()` waits for the deployment to reach `COMPLETED`.
+   * Defaults to 5 minutes.
+   */
+  readyTimeoutMs?: number;
+
+  /**
+   * Poll interval (in ms) while waiting for the deployment and
+   * container to be ready. Defaults to 100ms — Northflank's API tolerates
+   * tight polling without rate-limiting, and the fast cadence keeps cold
+   * starts snappy.
+   */
+  pollIntervalMs?: number;
+}
+
+/**
+ * Session state persisted across `serializeSessionState` /
+ * `deserializeSessionState`. Carries everything {@link NorthflankSandboxClient}
+ * needs to find and re-pin the underlying Northflank service.
+ */
+export interface NorthflankSandboxSessionState extends SandboxSessionState {
+  /** Manifest applied to the workspace at startup. */
+  manifest: Manifest;
+
+  /** Resolved environment that was passed to `runtimeEnvironment` at create. */
+  environment: Record<string, string>;
+
+  /** Northflank project ID. */
+  projectId: string;
+
+  /** Northflank service ID. */
+  serviceId: string;
+
+  /** Optional team / org scope. */
+  teamId?: string;
+
+  /** Image the service was created from (used for diagnostics + resume). */
+  image: string;
+
+  /** Northflank deployment plan ID. */
+  deploymentPlan: string;
+
+  /** Filesystem root inside the container. */
+  workspaceRoot: string;
+
+  /** Whether close() should pause vs. delete. */
+  pauseOnExit: boolean;
+
+  /**
+   * The currently-running container name (e.g. `<service>-…-abc12`). Every
+   * exec / file-copy call is pinned to this instance so successive ops share
+   * a filesystem. Re-resolved before each file operation in case the pod
+   * cycles mid-session.
+   */
+  instanceName?: string;
+
+  /**
+   * Workspace persistence mode in effect for this session. Mirrors
+   * {@link NorthflankSandboxClientOptions.workspacePersistence} and is
+   * round-tripped through `serializeSessionState` so a resumed session
+   * keeps the same restore strategy.
+   */
+  workspacePersistence?: 'volume' | 'tar';
+
+  /**
+   * ID of the volume attached to the service in `'volume'` mode. Persists
+   * across pause/resume; deleted on `delete()` only when this client
+   * provisioned it (see {@link volumeProviderCreated}).
+   */
+  volumeId?: string;
+
+  /**
+   * `true` when {@link volumeId} was created by this client and should be
+   * torn down alongside the service. `false` when the caller passed an
+   * existing `volumeId` via options — in that case the volume outlives the
+   * session.
+   */
+  volumeProviderCreated?: boolean;
+
+  /**
+   * Base64-encoded gzip tar of the workspace, captured at `stop()` in
+   * `'tar'` mode and re-extracted on `resume()`. Empty / undefined while
+   * the session is live.
+   */
+  workspaceTar?: string;
+}
+
+const DEFAULT_DEPLOYMENT_PLAN = 'nf-compute-20';
+const DEFAULT_WORKSPACE_ROOT = '/workspace';
+const DEFAULT_SERVICE_PREFIX = 'agent-sandbox';
+const DEFAULT_READY_TIMEOUT_MS = 5 * 60 * 1000;
+const DEFAULT_POLL_INTERVAL_MS = 100;
+const INSTANCE_RESOLVE_POLL_INTERVAL_MS = 100;
+const INSTANCE_RESOLVE_TIMEOUT_MS = 60_000;
+// Matches the minimum size `nf-multi-rw` accepts on Northflank's standard
+// cluster — smaller values return HTTP 409 at create time.
+const DEFAULT_VOLUME_SIZE_MB = 5120;
+const DEFAULT_VOLUME_STORAGE_CLASS = 'nf-multi-rw';
+const DEFAULT_VOLUME_ACCESS_MODE: 'ReadWriteOnce' | 'ReadWriteMany' =
+  'ReadWriteMany';
+const WORKSPACE_TAR_REMOTE_PATH = '/tmp/nf-workspace-snapshot.tar.gz';
+
+/**
+ * `RemoteSandboxSessionBase`-backed session that proxies exec + file ops
+ * to a Northflank `deployment` service. The base class handles
+ * `applyManifest`, `createEditor`, `viewImage`, `materializeEntry`, path
+ * resolution and exposed-port plumbing — we only provide the 6 primitives
+ * (exec, mkdir, read/write file, delete) plus lifecycle.
+ *
+ * **Routing pin:** Northflank's exec API can route consecutive calls to
+ * different replicas. We resolve a single running container after
+ * `create()` and pass its name as `instanceName` on every subsequent
+ * exec / file-copy call. The pin is refreshed (`refreshInstanceName`) on
+ * each file op so pod restarts mid-session don't leave us talking to a
+ * dead pod.
+ */
+export class NorthflankSandboxSession extends RemoteSandboxSessionBase<NorthflankSandboxSessionState> {
+  private readonly client: NorthflankApiClient;
+  private readonly refreshInstance?: () => Promise<string>;
+  private paused = false;
+  private deleted = false;
+
+  constructor(args: {
+    state: NorthflankSandboxSessionState;
+    client: NorthflankApiClient;
+    refreshInstance?: () => Promise<string>;
+    concurrencyLimits?: SandboxConcurrencyLimits;
+    archiveLimits?: SandboxArchiveLimits | null;
+  }) {
+    super({
+      state: args.state,
+      options: {
+        providerName: 'NorthflankSandboxClient',
+        providerId: 'northflank',
+        concurrencyLimits: args.concurrencyLimits,
+        archiveLimits: args.archiveLimits,
+      },
+    });
+    this.client = args.client;
+    this.refreshInstance = args.refreshInstance;
+  }
+
+  /**
+   * Ensure the workspace dir exists. Called by `applyManifest` / lazily
+   * before file ops; idempotent.
+   */
+  async prepareWorkspaceRoot(): Promise<void> {
+    const root = this.state.manifest.root;
+    const result = await this.runRemoteCommand(
+      `mkdir -p -- ${shellQuote(root)}`,
+      {
+        kind: 'manifest',
+        workdir: '/',
+      },
+    );
+    if (result.status !== 0) {
+      throw new SandboxProviderError(
+        'NorthflankSandboxClient failed to prepare the workspace root.',
+        {
+          provider: 'northflank',
+          operation: 'prepare workspace root',
+          serviceId: this.state.serviceId,
+          root,
+          stdout: result.stdout ?? '',
+          stderr: result.stderr ?? '',
+        },
+      );
+    }
+  }
+
+  // --- Required abstract methods --------------------------------------
+
+  protected override async runRemoteCommand(
+    command: string,
+    options: RemoteSandboxCommandOptions,
+  ): Promise<RemoteSandboxCommandResult> {
+    // Wrap as `sh -c <line>` so pipes / `&&` / redirects behave. Prefix
+    // with `cd <workdir>` to honour the manifest root the caller passed.
+    const line = `cd ${shellQuote(options.workdir)} && ${command}`;
+    const response = await this.client.exec.execServiceCommand(
+      this.serviceParams(),
+      {
+        command: ['sh', '-c', line],
+        shell: 'none',
+        ...(this.state.instanceName
+          ? { instanceName: this.state.instanceName }
+          : {}),
+        ...(options.runAs ? { user: options.runAs } : {}),
+      },
+    );
+    return {
+      status: response.commandResult.exitCode ?? 1,
+      stdout: response.stdOut ?? '',
+      stderr: response.stdErr ?? '',
+    };
+  }
+
+  protected override async mkdirRemote(path: string): Promise<void> {
+    const result = await this.runRemoteCommand(
+      `mkdir -p -- ${shellQuote(path)}`,
+      {
+        kind: 'manifest',
+        workdir: '/',
+      },
+    );
+    if (result.status !== 0) {
+      throw new SandboxProviderError(
+        `NorthflankSandboxClient failed to create directory ${path}.`,
+        {
+          provider: 'northflank',
+          operation: 'mkdir',
+          path,
+          stderr: result.stderr ?? '',
+        },
+      );
+    }
+  }
+
+  protected override async readRemoteText(path: string): Promise<string> {
+    const bytes = await this.readRemoteFile(path);
+    return new TextDecoder().decode(bytes);
+  }
+
+  protected override async readRemoteFile(path: string): Promise<Uint8Array> {
+    await this.refreshInstanceName();
+    // Northflank's downloadServiceFiles treats `localPath` as a *target
+    // directory* and extracts the remote file as `<localPath>/<basename>`.
+    // Use a fresh tmp dir to receive it.
+    const tmpDir = joinPath(tmpdir(), `nf-sandbox-${randomUUID()}`);
+    await fs.mkdir(tmpDir, { recursive: true });
+    try {
+      await this.client.fileCopy.downloadServiceFiles(this.serviceParams(), {
+        remotePath: path,
+        localPath: tmpDir,
+        ...(this.state.instanceName
+          ? { instanceName: this.state.instanceName }
+          : {}),
+      });
+      const bytes = await fs.readFile(joinPath(tmpDir, posix.basename(path)));
+      return new Uint8Array(bytes);
+    } finally {
+      await fs
+        .rm(tmpDir, { recursive: true, force: true })
+        .catch(() => undefined);
+    }
+  }
+
+  protected override async writeRemoteFile(
+    path: string,
+    content: string | Uint8Array,
+  ): Promise<void> {
+    await this.refreshInstanceName();
+    const buf =
+      typeof content === 'string'
+        ? Buffer.from(content, 'utf8')
+        : Buffer.from(content);
+    // Match the local basename to the remote basename so the tar-based
+    // copy lands the file at `dirname(remotePath)/<basename(remotePath)>`
+    // reliably (the JS client's path-rewrite hook is best-effort for
+    // arbitrary characters).
+    const remoteName = posix.basename(path);
+    const tmpDir = joinPath(tmpdir(), `nf-sandbox-${randomUUID()}`);
+    await fs.mkdir(tmpDir, { recursive: true });
+    const tmpFile = joinPath(tmpDir, remoteName);
+    await fs.writeFile(tmpFile, buf);
+    try {
+      await this.client.fileCopy.uploadServiceFiles(this.serviceParams(), {
+        localPath: tmpFile,
+        remotePath: path,
+        ...(this.state.instanceName
+          ? { instanceName: this.state.instanceName }
+          : {}),
+      });
+    } finally {
+      await fs
+        .rm(tmpDir, { recursive: true, force: true })
+        .catch(() => undefined);
+    }
+  }
+
+  protected override async deleteRemotePath(path: string): Promise<void> {
+    const result = await this.runRemoteCommand(
+      `rm -rf -- ${shellQuote(path)}`,
+      {
+        kind: 'manifest',
+        workdir: '/',
+      },
+    );
+    if (result.status !== 0) {
+      throw new SandboxProviderError(
+        `NorthflankSandboxClient failed to remove ${path}.`,
+        {
+          provider: 'northflank',
+          operation: 'delete',
+          path,
+          stderr: result.stderr ?? '',
+        },
+      );
+    }
+  }
+
+  // --- Lifecycle ------------------------------------------------------
+
+  /**
+   * Last-resort cleanup invoked when the runtime can't use the standard
+   * `stop()`/`delete()` lifecycle. Pauses if the session is configured to
+   * survive (pauseOnExit or any `workspacePersistence` mode), deletes
+   * otherwise.
+   */
+  async close(): Promise<void> {
+    if (
+      this.state.pauseOnExit ||
+      this.state.workspacePersistence !== undefined
+    ) {
+      await this.pauseSession();
+    } else {
+      await this.delete();
+    }
+  }
+
+  /**
+   * Non-destructive idle. In `'tar'` persistence mode, captures the
+   * workspace into `state.workspaceTar` first so `serializeSessionState`
+   * carries the snapshot. In `'volume'` mode (or no persistence), simply
+   * pauses the service when `pauseOnExit` is set.
+   */
+  async stop(_options?: SandboxSessionLifecycleOptions): Promise<void> {
+    if (this.deleted) return;
+    if (this.state.workspacePersistence === 'tar') {
+      this.state.workspaceTar = await this.captureWorkspaceTar();
+    }
+    if (!this.state.pauseOnExit) return;
+    await this.pauseSession();
+  }
+
+  /**
+   * Hard-delete the underlying service. Idempotent. Also tears down the
+   * attached workspace volume when this client provisioned it; volumes
+   * supplied via `options.volumeId` are left in place for the caller to
+   * manage.
+   *
+   * The Agents runtime calls `stop()` then `delete()` during cleanup with
+   * `{ reason: 'cleanup', preserveOwnedSessions: true }`. When the session
+   * is configured to survive that cycle (`pauseOnExit` or any
+   * `workspacePersistence`), `delete()` pauses instead of tearing down so
+   * the serialized state remains resumable. Direct user calls (no cleanup
+   * options) always hard-delete.
+   */
+  async delete(options?: SandboxSessionLifecycleOptions): Promise<void> {
+    if (this.deleted) return;
+    if (this.shouldPauseOnCleanup(options)) {
+      await this.pauseSession();
+      return;
+    }
+    await withSandboxSpan(
+      'sandbox.delete',
+      { backend_id: 'northflank', sandbox_id: this.state.serviceId },
+      async () => {
+        const response = await this.client.delete.service({
+          parameters: this.serviceParams(),
+        });
+        assertApiOk(response, 'delete.service');
+        this.deleted = true;
+      },
+    );
+    if (this.state.volumeId && this.state.volumeProviderCreated) {
+      // Northflank rejects `delete.volume` while it is still attached to a
+      // service. Detaching is idempotent — when the service is already gone
+      // it 404s — so swallow errors and let `delete.volume` surface the
+      // real failure if one remains.
+      await this.client.detach
+        .volume({
+          parameters: {
+            projectId: this.state.projectId,
+            volumeId: this.state.volumeId,
+            ...(this.state.teamId ? { teamId: this.state.teamId } : {}),
+          },
+          data: {
+            nfObject: { id: this.state.serviceId, type: 'service' },
+          },
+        })
+        .catch(() => undefined);
+      const volumeResponse = await this.client.delete.volume({
+        parameters: {
+          projectId: this.state.projectId,
+          volumeId: this.state.volumeId,
+          ...(this.state.teamId ? { teamId: this.state.teamId } : {}),
+        },
+      });
+      assertApiOk(volumeResponse, 'delete.volume');
+      this.state.volumeId = undefined;
+      this.state.volumeProviderCreated = undefined;
+    }
+  }
+
+  /**
+   * Tar+gzip the current workspace and return the archive base64-encoded.
+   * Used by `'tar'` persistence mode to roll the workspace into session
+   * state on stop().
+   */
+  async captureWorkspaceTar(): Promise<string> {
+    await this.refreshInstanceName();
+    const root = this.state.workspaceRoot;
+    const remotePath = WORKSPACE_TAR_REMOTE_PATH;
+    const tar = await this.runRemoteCommand(
+      `tar czf ${shellQuote(remotePath)} -C ${shellQuote(root)} .`,
+      { kind: 'manifest', workdir: '/' },
+    );
+    if (tar.status !== 0) {
+      throw new SandboxProviderError(
+        'NorthflankSandboxClient failed to archive the workspace for tar persistence.',
+        {
+          provider: 'northflank',
+          operation: 'capture workspace tar',
+          stderr: tar.stderr ?? '',
+        },
+      );
+    }
+    try {
+      const bytes = await this.readRemoteFile(remotePath);
+      return Buffer.from(bytes).toString('base64');
+    } finally {
+      await this.runRemoteCommand(`rm -f -- ${shellQuote(remotePath)}`, {
+        kind: 'manifest',
+        workdir: '/',
+      }).catch(() => undefined);
+    }
+  }
+
+  /**
+   * Reverse of {@link captureWorkspaceTar}: decode a base64 gzip tar and
+   * extract it into `state.workspaceRoot`. Called by
+   * `NorthflankSandboxClient.resume()`.
+   *
+   * Session state is round-tripped through `serializeSessionState`, so the
+   * tar may have been mutated between sessions. Before extracting, we list
+   * the archive contents and reject any entry that could escape
+   * `workspaceRoot` — absolute paths, parent-traversal components, or
+   * symlinks/hardlinks (whose targets aren't constrained to the archive).
+   */
+  async restoreWorkspaceFromTar(base64Tar: string): Promise<void> {
+    const remotePath = WORKSPACE_TAR_REMOTE_PATH;
+    const buf = Buffer.from(base64Tar, 'base64');
+    await this.writeRemoteFile(remotePath, new Uint8Array(buf));
+    try {
+      await this.assertTarSafe(remotePath);
+      const extract = await this.runRemoteCommand(
+        `tar xzf ${shellQuote(remotePath)} -C ${shellQuote(
+          this.state.workspaceRoot,
+        )}`,
+        { kind: 'manifest', workdir: '/' },
+      );
+      if (extract.status !== 0) {
+        throw new SandboxProviderError(
+          'NorthflankSandboxClient failed to extract the workspace tar on resume.',
+          {
+            provider: 'northflank',
+            operation: 'restore workspace tar',
+            stderr: extract.stderr ?? '',
+          },
+        );
+      }
+    } finally {
+      await this.runRemoteCommand(`rm -f -- ${shellQuote(remotePath)}`, {
+        kind: 'manifest',
+        workdir: '/',
+      }).catch(() => undefined);
+    }
+  }
+
+  /**
+   * Validate that a workspace tar restored from session state cannot
+   * escape `workspaceRoot`. Throws a `SandboxProviderError` on the first
+   * unsafe entry.
+   */
+  private async assertTarSafe(remoteArchive: string): Promise<void> {
+    const listing = await this.runRemoteCommand(
+      `tar -tzf ${shellQuote(remoteArchive)}`,
+      { kind: 'manifest', workdir: '/' },
+    );
+    if (listing.status !== 0) {
+      throw new SandboxProviderError(
+        'NorthflankSandboxClient failed to list workspace tar contents during the safety check.',
+        {
+          provider: 'northflank',
+          operation: 'validate workspace tar',
+          stderr: listing.stderr ?? '',
+        },
+      );
+    }
+    for (const raw of (listing.stdout ?? '').split('\n')) {
+      const entry = raw.trim();
+      if (!entry) continue;
+      if (entry.startsWith('/')) {
+        throw new SandboxProviderError(
+          `NorthflankSandboxClient rejected workspace tar: contains absolute path "${entry}".`,
+          {
+            provider: 'northflank',
+            operation: 'validate workspace tar',
+            entry,
+          },
+        );
+      }
+      const parts = entry.split('/');
+      if (parts.includes('..')) {
+        throw new SandboxProviderError(
+          `NorthflankSandboxClient rejected workspace tar: contains parent-traversal path "${entry}".`,
+          {
+            provider: 'northflank',
+            operation: 'validate workspace tar',
+            entry,
+          },
+        );
+      }
+    }
+    const verbose = await this.runRemoteCommand(
+      `tar -tvzf ${shellQuote(remoteArchive)}`,
+      { kind: 'manifest', workdir: '/' },
+    );
+    if (verbose.status !== 0) return;
+    for (const raw of (verbose.stdout ?? '').split('\n')) {
+      const line = raw.trim();
+      if (!line) continue;
+      const typeChar = line[0];
+      if (typeChar === 'l' || typeChar === 'h') {
+        throw new SandboxProviderError(
+          `NorthflankSandboxClient rejected workspace tar: contains unsupported link entry "${line}".`,
+          {
+            provider: 'northflank',
+            operation: 'validate workspace tar',
+            entry: line,
+          },
+        );
+      }
+    }
+  }
+
+  /**
+   * Returns `true` when the runtime is cleaning up an owned session it
+   * wants preserved (so `delete()` should pause instead of tearing the
+   * service down). Mirrors the contract `canPersistOwnedSessionState`
+   * advertises to the runtime.
+   */
+  private shouldPauseOnCleanup(
+    options?: SandboxSessionLifecycleOptions,
+  ): boolean {
+    if (options?.reason !== 'cleanup') return false;
+    const preserve = (options as { preserveOwnedSessions?: unknown })
+      .preserveOwnedSessions;
+    if (preserve !== true) return false;
+    return (
+      this.state.pauseOnExit === true ||
+      this.state.workspacePersistence !== undefined
+    );
+  }
+
+  private async pauseSession(): Promise<void> {
+    if (this.paused || this.deleted) return;
+    await withSandboxSpan(
+      'sandbox.pause',
+      { backend_id: 'northflank', sandbox_id: this.state.serviceId },
+      async () => {
+        const response = await this.client.pause.service({
+          parameters: this.serviceParams(),
+        });
+        assertApiOk(response, 'pause.service');
+        this.paused = true;
+      },
+    );
+  }
+
+  // --- Internals ------------------------------------------------------
+
+  private serviceParams(): {
+    projectId: string;
+    serviceId: string;
+    teamId?: string;
+  } {
+    return {
+      projectId: this.state.projectId,
+      serviceId: this.state.serviceId,
+      ...(this.state.teamId ? { teamId: this.state.teamId } : {}),
+    };
+  }
+
+  private async refreshInstanceName(): Promise<void> {
+    if (this.refreshInstance) {
+      this.state.instanceName = await this.refreshInstance();
+    }
+  }
+}
+
+/**
+ * Provisions Northflank-backed sandbox sessions. Each session spins up a
+ * dedicated `deployment`-type service running the configured container
+ * image; the manifest is materialised after the deployment reaches
+ * `COMPLETED`.
+ */
+export class NorthflankSandboxClient implements SandboxClient<
+  NorthflankSandboxClientOptions,
+  NorthflankSandboxSessionState
+> {
+  readonly backendId = 'northflank';
+  private readonly options: NorthflankSandboxClientOptions;
+  private cachedClient?: NorthflankApiClient;
+
+  constructor(options: NorthflankSandboxClientOptions = {}) {
+    this.options = options;
+  }
+
+  async create(
+    args?: SandboxClientCreateArgs<NorthflankSandboxClientOptions> | Manifest,
+    manifestOptions?: NorthflankSandboxClientOptions,
+  ): Promise<NorthflankSandboxSession> {
+    const createArgs = normalizeSandboxClientCreateArgs(args, manifestOptions);
+    assertCoreSnapshotUnsupported(
+      'NorthflankSandboxClient',
+      createArgs.snapshot,
+    );
+
+    const effective: NorthflankSandboxClientOptions = {
+      ...this.options,
+      ...(createArgs.options ?? {}),
+    };
+    const projectId = requireOption(effective.projectId, 'projectId');
+    const image = requireOption(effective.image, 'image');
+    const manifest = createArgs.manifest ?? new Manifest({});
+
+    // If both options.workspaceRoot and a non-default manifest.root are set
+    // and disagree, fail fast — silently preferring one would surprise.
+    const customWorkspaceRoot = (effective as { workspaceRoot?: string })
+      .workspaceRoot;
+    if (
+      customWorkspaceRoot &&
+      manifest.root !== DEFAULT_WORKSPACE_ROOT &&
+      manifest.root !== customWorkspaceRoot
+    ) {
+      throw new UserError(
+        `NorthflankSandboxClient: workspaceRoot conflict — options.workspaceRoot="${customWorkspaceRoot}" vs manifest.root="${manifest.root}".`,
+      );
+    }
+    const workspaceRoot =
+      customWorkspaceRoot ?? manifest.root ?? DEFAULT_WORKSPACE_ROOT;
+
+    return await withSandboxSpan(
+      'sandbox.start',
+      { backend_id: this.backendId },
+      async () => {
+        const client = await this.resolveClient(effective);
+        // materializeEnvironment() lays the manifest environment on top of
+        // the base options.env, matching the precedence the other providers
+        // rely on (manifest wins). Don't re-spread effective.env after — it
+        // would invert that.
+        const env = assertSafeEnv(
+          await materializeEnvironment(manifest, effective.env ?? {}),
+        );
+
+        const serviceId = await this.createService(
+          client,
+          effective,
+          env,
+          projectId,
+          image,
+        );
+        const state: NorthflankSandboxSessionState = {
+          manifest: new Manifest({ ...manifest, root: workspaceRoot }),
+          environment: env,
+          projectId,
+          serviceId,
+          teamId: effective.teamId,
+          image,
+          deploymentPlan: effective.deploymentPlan ?? DEFAULT_DEPLOYMENT_PLAN,
+          workspaceRoot,
+          pauseOnExit: effective.pauseOnExit ?? false,
+          workspacePersistence: effective.workspacePersistence,
+        };
+
+        const session = new NorthflankSandboxSession({
+          state,
+          client,
+          refreshInstance: () =>
+            this.resolveRunningInstance(client, state, effective),
+          concurrencyLimits: createArgs.concurrencyLimits,
+          archiveLimits: createArgs.archiveLimits,
+        });
+
+        try {
+          await this.waitUntilReady(client, state, effective);
+          if (effective.workspacePersistence === 'volume') {
+            await this.attachWorkspaceVolume(
+              client,
+              state,
+              effective,
+              workspaceRoot,
+            );
+            // Mounting a volume triggers a redeployment — wait for the
+            // service to settle and re-resolve the running container.
+            await this.waitUntilReady(client, state, effective);
+          }
+          state.instanceName = await this.resolveRunningInstance(
+            client,
+            state,
+            effective,
+          );
+          await session.prepareWorkspaceRoot();
+          await session.applyManifest(manifest);
+        } catch (error) {
+          // Best-effort cleanup of the partial service.
+          await closeRemoteSessionOnManifestError(
+            'NorthflankSandboxClient',
+            session,
+            error,
+          );
+        }
+        return session;
+      },
+    );
+  }
+
+  async resume(
+    state: NorthflankSandboxSessionState,
+  ): Promise<NorthflankSandboxSession> {
+    const client = await this.resolveClient(this.options);
+
+    const current = await client.get.service({
+      parameters: paramsFromState(state),
+    });
+    assertApiOk(current, 'get.service');
+
+    if (current.data?.servicePaused) {
+      const resumed = await client.resume.service({
+        parameters: paramsFromState(state),
+      });
+      assertApiOk(resumed, 'resume.service');
+      await this.waitUntilReady(client, state, this.options);
+    }
+
+    state.instanceName = await this.resolveRunningInstance(
+      client,
+      state,
+      this.options,
+    );
+
+    const session = new NorthflankSandboxSession({
+      state,
+      client,
+      refreshInstance: () =>
+        this.resolveRunningInstance(client, state, this.options),
+      archiveLimits: this.options.archiveLimits as
+        | SandboxArchiveLimits
+        | null
+        | undefined,
+    });
+    await session.prepareWorkspaceRoot();
+    if (state.workspacePersistence === 'tar' && state.workspaceTar) {
+      await session.restoreWorkspaceFromTar(state.workspaceTar);
+      // Snapshot consumed — clear so a fresh stop() captures the latest state.
+      state.workspaceTar = undefined;
+    }
+    return session;
+  }
+
+  async serializeSessionState(
+    state: NorthflankSandboxSessionState,
+  ): Promise<Record<string, unknown>> {
+    return serializeRemoteSandboxSessionState(state);
+  }
+
+  async deserializeSessionState(
+    state: Record<string, unknown>,
+  ): Promise<NorthflankSandboxSessionState> {
+    const { manifest, environment } =
+      deserializeRemoteSandboxSessionStateValues(state, this.options.env);
+    const persistence = readOptionalString(state, 'workspacePersistence');
+    return {
+      manifest,
+      environment,
+      projectId: readString(state, 'projectId'),
+      serviceId: readString(state, 'serviceId'),
+      teamId: readOptionalString(state, 'teamId'),
+      image: readString(state, 'image'),
+      deploymentPlan: readString(state, 'deploymentPlan'),
+      workspaceRoot: readString(state, 'workspaceRoot'),
+      pauseOnExit: readOptionalBoolean(state, 'pauseOnExit') ?? false,
+      instanceName: readOptionalString(state, 'instanceName'),
+      workspacePersistence:
+        persistence === 'volume' || persistence === 'tar'
+          ? persistence
+          : undefined,
+      volumeId: readOptionalString(state, 'volumeId'),
+      volumeProviderCreated: readOptionalBoolean(
+        state,
+        'volumeProviderCreated',
+      ),
+      workspaceTar: readOptionalString(state, 'workspaceTar'),
+      ...spreadOptionalExposedPorts(state),
+    } as NorthflankSandboxSessionState;
+  }
+
+  canPersistOwnedSessionState(state: NorthflankSandboxSessionState): boolean {
+    return state.pauseOnExit === true || state.workspacePersistence === 'tar';
+  }
+
+  // --- Internals ------------------------------------------------------
+
+  private async createService(
+    client: NorthflankApiClient,
+    options: NorthflankSandboxClientOptions,
+    env: Record<string, string>,
+    projectId: string,
+    image: string,
+  ): Promise<string> {
+    const requestedId = generateServiceId(options.serviceNamePrefix);
+    return await withProviderError(
+      'NorthflankSandboxClient',
+      'northflank',
+      'create sandbox service',
+      async () => {
+        const response = await client.create.service.deployment({
+          parameters: {
+            projectId,
+            ...(options.teamId ? { teamId: options.teamId } : {}),
+          },
+          data: {
+            name: requestedId,
+            billing: {
+              deploymentPlan: options.deploymentPlan ?? DEFAULT_DEPLOYMENT_PLAN,
+            },
+            deployment: {
+              // Pinned to 1 — multiple replicas would split exec/file
+              // ops across pods and the agent would see flapping state.
+              instances: 1,
+              external: { imagePath: image },
+              ...(options.docker
+                ? {
+                    docker: {
+                      configType: dockerConfigType(options.docker),
+                      ...options.docker,
+                    },
+                  }
+                : {}),
+            },
+            runtimeEnvironment: env,
+          },
+        });
+        assertApiOk(response, 'create.service.deployment');
+        return response.data?.id ?? requestedId;
+      },
+      { projectId, image },
+    );
+  }
+
+  /**
+   * In `'volume'` persistence mode, ensure a Northflank volume is attached
+   * to the freshly-created service at `workspaceRoot`. Reuses
+   * `options.volumeId` when provided (the caller owns it) — otherwise
+   * provisions a new volume and flags it for deletion on `delete()`.
+   */
+  private async attachWorkspaceVolume(
+    client: NorthflankApiClient,
+    state: NorthflankSandboxSessionState,
+    options: NorthflankSandboxClientOptions,
+    workspaceRoot: string,
+  ): Promise<void> {
+    if (options.volumeId) {
+      const callerVolumeId = options.volumeId;
+      state.volumeId = callerVolumeId;
+      state.volumeProviderCreated = false;
+      // The caller's volume already has its own mount configuration baked
+      // in at create time. We only attach it to the freshly-created service
+      // — Northflank then re-rolls the service with the volume mounted.
+      // Cleanup leaves the volume alone (caller owns it).
+      await withProviderError(
+        'NorthflankSandboxClient',
+        'northflank',
+        'attach workspace volume',
+        async () => {
+          const response = await client.attach.volume({
+            parameters: {
+              projectId: state.projectId,
+              volumeId: callerVolumeId,
+              ...(state.teamId ? { teamId: state.teamId } : {}),
+            },
+            data: {
+              nfObject: { id: state.serviceId, type: 'service' },
+            },
+          });
+          assertApiOk(response, 'attach.volume');
+        },
+        { volumeId: callerVolumeId },
+      );
+      return;
+    }
+    const spec = options.volumeSpec ?? {};
+    const data = {
+      name: state.serviceId,
+      mounts: [{ containerMountPath: workspaceRoot }],
+      spec: {
+        accessMode: spec.accessMode ?? DEFAULT_VOLUME_ACCESS_MODE,
+        storageSize: spec.storageSize ?? DEFAULT_VOLUME_SIZE_MB,
+        storageClassName: spec.storageClassName ?? DEFAULT_VOLUME_STORAGE_CLASS,
+      },
+      attachedObjects: [{ id: state.serviceId, type: 'service' as const }],
+    };
+    await withProviderError(
+      'NorthflankSandboxClient',
+      'northflank',
+      'create workspace volume',
+      async () => {
+        const response = await client.create.volume({
+          parameters: {
+            projectId: state.projectId,
+            ...(state.teamId ? { teamId: state.teamId } : {}),
+          },
+          data,
+        });
+        assertApiOk(response, 'create.volume');
+        const id = response.data?.id;
+        if (!id) {
+          throw new SandboxProviderError(
+            'NorthflankSandboxClient: create.volume returned without an id.',
+            { provider: 'northflank', operation: 'create.volume' },
+          );
+        }
+        state.volumeId = id;
+        state.volumeProviderCreated = true;
+      },
+      { workspaceRoot },
+    );
+  }
+
+  private async waitUntilReady(
+    client: NorthflankApiClient,
+    state: NorthflankSandboxSessionState,
+    options: NorthflankSandboxClientOptions,
+  ): Promise<void> {
+    const timeoutMs = options.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS;
+    const intervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const response = await client.get.service({
+        parameters: paramsFromState(state),
+      });
+      assertApiOk(response, 'get.service');
+      const status = response.data?.status?.deployment?.status;
+      if (status === 'COMPLETED') return;
+      if (status === 'FAILED') {
+        throw new SandboxProviderError(
+          `Northflank service ${state.serviceId} deployment failed.`,
+          { provider: 'northflank', operation: 'wait until ready', status },
+        );
+      }
+      await sleep(intervalMs);
+    }
+    throw new SandboxProviderError(
+      `Northflank service ${state.serviceId} did not become ready within ${timeoutMs}ms.`,
+      { provider: 'northflank', operation: 'wait until ready', timeoutMs },
+    );
+  }
+
+  /**
+   * Find the currently-running container so we can pin every exec /
+   * file-copy call to it. Northflank's exec API doesn't sticky-route by
+   * default — without this, two consecutive calls during a deployment roll
+   * can land on different pods.
+   */
+  private async resolveRunningInstance(
+    client: NorthflankApiClient,
+    state: NorthflankSandboxSessionState,
+    options: NorthflankSandboxClientOptions,
+  ): Promise<string> {
+    const intervalMs =
+      options.pollIntervalMs ?? INSTANCE_RESOLVE_POLL_INTERVAL_MS;
+    const deadline = Date.now() + INSTANCE_RESOLVE_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      const response = await client.get.service.containers({
+        parameters: paramsFromState(state),
+      });
+      assertApiOk(response, 'get.service.containers');
+      const running = response.data?.containers?.find(
+        (c) => c.status === 'TASK_RUNNING',
+      );
+      if (running) return running.name;
+      await sleep(intervalMs);
+    }
+    throw new SandboxProviderError(
+      `Northflank service ${state.serviceId} has no TASK_RUNNING container.`,
+      { provider: 'northflank', operation: 'resolve running instance' },
+    );
+  }
+
+  private async resolveClient(
+    options: NorthflankSandboxClientOptions,
+  ): Promise<NorthflankApiClient> {
+    if (options.apiClient) return options.apiClient;
+    if (this.cachedClient) return this.cachedClient;
+    if (!options.apiToken) {
+      throw new UserError(
+        'NorthflankSandboxClient requires either `apiClient` or `apiToken`.',
+      );
+    }
+    this.cachedClient = await buildDefaultApiClient(options.apiToken);
+    return this.cachedClient;
+  }
+}
+
+// --- helpers ----------------------------------------------------------
+
+function requireOption(value: string | undefined, name: string): string {
+  if (!value) {
+    throw new UserError(`NorthflankSandboxClient requires \`${name}\`.`);
+  }
+  return value;
+}
+
+function paramsFromState(state: NorthflankSandboxSessionState): {
+  projectId: string;
+  serviceId: string;
+  teamId?: string;
+} {
+  return {
+    projectId: state.projectId,
+    serviceId: state.serviceId,
+    ...(state.teamId ? { teamId: state.teamId } : {}),
+  };
+}
+
+function assertApiOk(
+  response: { error?: NorthflankApiError | undefined },
+  label: string,
+): void {
+  const err = response.error;
+  if (!err) return;
+  const status = err.status ? `HTTP ${err.status} ` : '';
+  throw new SandboxProviderError(
+    `NorthflankSandboxClient: ${label} failed: ${status}${err.message ?? 'unknown API error'}`,
+    {
+      provider: 'northflank',
+      operation: label,
+      status: err.status,
+      id: err.id,
+    },
+  );
+}
+
+/**
+ * Reject env keys that contain shell metacharacters. They'd flow into
+ * `export <key>=<value>` inside every exec command otherwise — a key like
+ * `FOO; rm -rf /` would be a textbook shell-injection sink.
+ */
+function assertSafeEnv(env: Record<string, string>): Record<string, string> {
+  const validKey = /^[A-Za-z_][A-Za-z0-9_]*$/;
+  for (const key of Object.keys(env)) {
+    if (!validKey.test(key)) {
+      throw new UserError(
+        `Invalid environment variable name "${key}". Names must match /^[A-Za-z_][A-Za-z0-9_]*$/.`,
+      );
+    }
+  }
+  return env;
+}
+
+function dockerConfigType(docker: {
+  customEntrypoint?: string;
+  customCommand?: string;
+}):
+  | 'default'
+  | 'customEntrypoint'
+  | 'customCommand'
+  | 'customEntrypointCustomCommand' {
+  const hasEntry = Boolean(docker.customEntrypoint);
+  const hasCommand = Boolean(docker.customCommand);
+  if (hasEntry && hasCommand) return 'customEntrypointCustomCommand';
+  if (hasEntry) return 'customEntrypoint';
+  if (hasCommand) return 'customCommand';
+  return 'default';
+}
+
+function generateServiceId(prefix?: string): string {
+  const base =
+    (prefix ?? DEFAULT_SERVICE_PREFIX)
+      .toLowerCase()
+      .replace(/[^a-z0-9-]+/g, '-')
+      .replace(/^-+|-+$/g, '') || DEFAULT_SERVICE_PREFIX;
+  const suffix = randomUUID().split('-')[0];
+  return `${base}-${suffix}`;
+}
+
+function spreadOptionalExposedPorts(
+  state: Record<string, unknown>,
+): Pick<SandboxSessionState, 'exposedPorts'> {
+  const ports = state.exposedPorts;
+  return ports !== undefined
+    ? { exposedPorts: ports as SandboxSessionState['exposedPorts'] }
+    : {};
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Lazy-load `@northflank/js-client` and construct a minimal default
+ * `ApiClient`. Used only when the caller doesn't supply their own
+ * `apiClient` instance.
+ */
+async function buildDefaultApiClient(
+  apiToken: string,
+): Promise<NorthflankApiClient> {
+  let mod: typeof import('@northflank/js-client');
+  try {
+    mod = await import('@northflank/js-client');
+  } catch (error) {
+    throw new UserError(
+      `Northflank sandbox support requires the optional \`@northflank/js-client\` package. Install it before using Northflank-backed sandbox examples. ${(error as Error).message}`,
+    );
+  }
+  const { ApiClient, ApiClientInMemoryContextProvider } = mod;
+  const ctx = new ApiClientInMemoryContextProvider();
+  await ctx.addContext({ name: 'default', token: apiToken });
+  return new ApiClient(ctx, {
+    throwErrorOnHttpErrorCode: false,
+  }) as unknown as NorthflankApiClient;
+}
+
+// readOptionalNumber is exported by shared/ for callers that want to add
+// more numeric state fields; keep the import alive even though the current
+// deserializer doesn't use it.
+void readOptionalNumber;

--- a/packages/agents-extensions/src/sandbox/northflank/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/northflank/sandbox.ts
@@ -12,6 +12,8 @@ import {
   type SandboxConcurrencyLimits,
 } from '@openai/agents-core/sandbox';
 import { promises as fs } from 'node:fs';
+import http from 'node:http';
+import https from 'node:https';
 import { tmpdir } from 'node:os';
 import { join as joinPath, posix } from 'node:path';
 import { randomUUID } from 'node:crypto';
@@ -388,6 +390,23 @@ const DEFAULT_VOLUME_STORAGE_CLASS = 'nf-multi-rw';
 const DEFAULT_VOLUME_ACCESS_MODE: 'ReadWriteOnce' | 'ReadWriteMany' =
   'ReadWriteMany';
 const WORKSPACE_TAR_REMOTE_PATH = '/tmp/nf-workspace-snapshot.tar.gz';
+const DEFAULT_NORTHFLANK_HOST = 'https://api.northflank.com';
+
+const AGENT_OPTIONS = {
+  keepAlive: true,
+  keepAliveMsecs: 10_000,
+  maxSockets: 1024,
+  maxFreeSockets: 512,
+  scheduling: 'lifo' as const,
+  timeout: 120_000,
+};
+
+const httpsAgent = new https.Agent(AGENT_OPTIONS);
+const httpAgent = new http.Agent(AGENT_OPTIONS);
+
+function agentForHost(host: string): http.Agent | https.Agent {
+  return new URL(host).protocol === 'http:' ? httpAgent : httpsAgent;
+}
 
 /**
  * `RemoteSandboxSessionBase`-backed session that proxies exec + file ops
@@ -1409,6 +1428,9 @@ async function buildDefaultApiClient(
   await ctx.addContext({ name: 'default', token: apiToken });
   return new ApiClient(ctx, {
     throwErrorOnHttpErrorCode: false,
+    // Pass a shared keepAlive Agent *instance* (not a function) — selected by
+    // protocol of the API host — so REST + ws exec calls reuse connections.
+    agent: agentForHost(DEFAULT_NORTHFLANK_HOST),
   }) as unknown as NorthflankApiClient;
 }
 

--- a/packages/agents-extensions/test/northflank/shell.test.ts
+++ b/packages/agents-extensions/test/northflank/shell.test.ts
@@ -1,0 +1,252 @@
+import type { ShellAction } from '@openai/agents';
+import { describe, expect, it, vi } from 'vitest';
+
+import { NorthflankShell } from '../../src/northflank/shell';
+
+function makeClient(overrides: Partial<Record<string, any>> = {}) {
+  // Type the mock signatures with `(...args: any[])` so vitest's call
+  // recording surfaces typed tuples on `.mock.calls`; the default
+  // `vi.fn(async () => ...)` infers a zero-arg signature.
+  const execServiceCommand = vi.fn(async (..._args: any[]) => ({
+    commandResult: { exitCode: 0, status: 'Success' as const },
+    stdOut: 'hello',
+    stdErr: '',
+  }));
+  const execJobCommand = vi.fn(async (..._args: any[]) => ({
+    commandResult: { exitCode: 0, status: 'Success' as const },
+    stdOut: 'job-out',
+    stdErr: '',
+  }));
+  const execAddonCommand = vi.fn(async (..._args: any[]) => ({
+    commandResult: { exitCode: 0, status: 'Success' as const },
+    stdOut: 'addon-out',
+    stdErr: '',
+  }));
+  const client: any = {
+    exec: {
+      execServiceCommand,
+      execJobCommand,
+      execAddonCommand,
+      ...overrides,
+    },
+  };
+  return { client, execServiceCommand, execJobCommand, execAddonCommand };
+}
+
+function action(
+  commands: string[],
+  rest: Partial<ShellAction> = {},
+): ShellAction {
+  return { commands, ...rest };
+}
+
+describe('NorthflankShell — service target', () => {
+  it('runs each command sequentially and returns one output per command', async () => {
+    const { client, execServiceCommand } = makeClient();
+    const shell = new NorthflankShell({
+      client,
+      target: { type: 'service', projectId: 'p', serviceId: 's' },
+    });
+
+    const result = await shell.run(action(['ls', 'pwd']));
+
+    expect(execServiceCommand).toHaveBeenCalledTimes(2);
+    // Commands are wrapped as argv `[sh, -c, <user>]` so Northflank's exec
+    // API actually runs them through a shell instead of treating the whole
+    // string as a binary name. We default to `sh -c` because many minimal
+    // `/bin/sh` builds don't accept `-l`.
+    expect(execServiceCommand.mock.calls[0]![1].command).toEqual([
+      'sh',
+      '-c',
+      'ls',
+    ]);
+    expect(execServiceCommand.mock.calls[0]![1].shell).toBe('none');
+    expect(execServiceCommand.mock.calls[1]![1].command).toEqual([
+      'sh',
+      '-c',
+      'pwd',
+    ]);
+
+    expect(result.output).toHaveLength(2);
+    expect(result.output[0]).toMatchObject({
+      command: 'ls',
+      stdout: 'hello',
+      stderr: '',
+      outcome: { type: 'exit', exitCode: 0 },
+    });
+  });
+
+  it('forwards instanceName, containerName, shell, teamId when configured', async () => {
+    const { client, execServiceCommand } = makeClient();
+    const shell = new NorthflankShell({
+      client,
+      target: {
+        type: 'service',
+        projectId: 'p',
+        serviceId: 's',
+        teamId: 't',
+        instanceName: 'pod-0',
+        containerName: 'main',
+        shell: 'bash -lc',
+      },
+    });
+    await shell.run(action(['echo hi']));
+
+    const [params, data] = execServiceCommand.mock.calls[0]!;
+    expect(params).toMatchObject({
+      projectId: 'p',
+      serviceId: 's',
+      teamId: 't',
+    });
+    // `target.shell: 'bash -lc'` is parsed as a full invocation — we don't
+    // append another `-lc`. `shell: 'none'` tells Northflank not to wrap
+    // again (we did our own wrapping).
+    expect(data).toMatchObject({
+      command: ['bash', '-lc', 'echo hi'],
+      shell: 'none',
+      instanceName: 'pod-0',
+      containerName: 'main',
+    });
+  });
+
+  it('omits target fields that were not configured', async () => {
+    const { client, execServiceCommand } = makeClient();
+    const shell = new NorthflankShell({
+      client,
+      target: { type: 'service', projectId: 'p', serviceId: 's' },
+    });
+    await shell.run(action(['echo hi']));
+
+    const data = execServiceCommand.mock.calls[0]![1];
+    expect(data).not.toHaveProperty('instanceName');
+    expect(data).not.toHaveProperty('containerName');
+    expect(data).not.toHaveProperty('teamId');
+    // We always set shell: 'none' to opt out of Northflank's own wrapping.
+    expect(data.shell).toBe('none');
+  });
+});
+
+describe('NorthflankShell — job + addon targets', () => {
+  it('dispatches job commands via execJobCommand', async () => {
+    const { client, execJobCommand, execServiceCommand } = makeClient();
+    const shell = new NorthflankShell({
+      client,
+      target: { type: 'job', projectId: 'p', jobId: 'j' },
+    });
+    const result = await shell.run(action(['ls']));
+
+    expect(execJobCommand).toHaveBeenCalledTimes(1);
+    expect(execServiceCommand).not.toHaveBeenCalled();
+    expect(result.output[0].stdout).toBe('job-out');
+  });
+
+  it('dispatches addon commands via execAddonCommand with required instanceName', async () => {
+    const { client, execAddonCommand } = makeClient();
+    const shell = new NorthflankShell({
+      client,
+      target: {
+        type: 'addon',
+        projectId: 'p',
+        addonId: 'a',
+        instanceName: 'replica-0',
+      },
+    });
+    await shell.run(action(['psql -c "select 1"']));
+
+    expect(execAddonCommand).toHaveBeenCalledTimes(1);
+    const data = execAddonCommand.mock.calls[0]![1];
+    expect(data.instanceName).toBe('replica-0');
+  });
+});
+
+describe('NorthflankShell — outcomes', () => {
+  it('reports non-zero exit codes as exit/exitCode outcomes', async () => {
+    const { client } = makeClient({
+      execServiceCommand: vi.fn(async () => ({
+        commandResult: {
+          exitCode: 7,
+          status: 'Failure' as const,
+          message: 'no',
+        },
+        stdOut: 'partial',
+        stdErr: 'boom',
+      })),
+    });
+    const shell = new NorthflankShell({
+      client,
+      target: { type: 'service', projectId: 'p', serviceId: 's' },
+    });
+    const result = await shell.run(action(['fail']));
+    expect(result.output[0].outcome).toEqual({ type: 'exit', exitCode: 7 });
+    expect(result.output[0].stdout).toBe('partial');
+    expect(result.output[0].stderr).toBe('boom');
+  });
+
+  it('thrown exec errors produce a null exitCode outcome with stderr=error message', async () => {
+    const { client } = makeClient({
+      execServiceCommand: vi.fn(async () => {
+        throw new Error('connection lost');
+      }),
+    });
+    const shell = new NorthflankShell({
+      client,
+      target: { type: 'service', projectId: 'p', serviceId: 's' },
+    });
+    const result = await shell.run(action(['echo hi']));
+    expect(result.output[0].outcome).toEqual({ type: 'exit', exitCode: null });
+    expect(result.output[0].stderr).toContain('connection lost');
+  });
+
+  it('honors timeoutMs and stops processing further commands', async () => {
+    const { client } = makeClient({
+      execServiceCommand: vi.fn(
+        () => new Promise(() => undefined), // never resolves
+      ),
+    });
+    const shell = new NorthflankShell({
+      client,
+      target: { type: 'service', projectId: 'p', serviceId: 's' },
+    });
+    const result = await shell.run(
+      action(['sleep 999', 'should-not-run'], { timeoutMs: 25 }),
+    );
+    expect(result.output).toHaveLength(1);
+    expect(result.output[0].outcome).toEqual({ type: 'timeout' });
+  });
+
+  it('truncates stdout/stderr per stream so total stays under maxOutputLength', async () => {
+    const { client } = makeClient({
+      execServiceCommand: vi.fn(async () => ({
+        commandResult: { exitCode: 0, status: 'Success' as const },
+        stdOut: 'o'.repeat(1000),
+        stdErr: 'e'.repeat(1000),
+      })),
+    });
+    const shell = new NorthflankShell({
+      client,
+      target: { type: 'service', projectId: 'p', serviceId: 's' },
+    });
+    const result = await shell.run(action(['big'], { maxOutputLength: 100 }));
+    const item = result.output[0];
+    // The leading run of the original character is bounded by half the budget.
+    // (Anything past that is the "[truncated N chars]" marker.)
+    expect(item.stdout.match(/^o+/)?.[0].length).toBeLessThanOrEqual(50);
+    expect(item.stderr.match(/^e+/)?.[0].length).toBeLessThanOrEqual(50);
+    expect(item.stdout).toMatch(/truncated/);
+    expect(item.stderr).toMatch(/truncated/);
+    expect(result.maxOutputLength).toBe(100);
+  });
+
+  it('includes providerData for downstream telemetry', async () => {
+    const { client } = makeClient();
+    const shell = new NorthflankShell({
+      client,
+      target: { type: 'service', projectId: 'p-1', serviceId: 's' },
+    });
+    const result = await shell.run(action(['echo hi']));
+    expect(result.providerData).toMatchObject({
+      target: 'service',
+      projectId: 'p-1',
+    });
+  });
+});

--- a/packages/agents-extensions/test/northflank/tools.test.ts
+++ b/packages/agents-extensions/test/northflank/tools.test.ts
@@ -1,0 +1,464 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { northflankTools } from '../../src/northflank/index';
+import { DEFAULT_EXEC_TIMEOUT_MS } from '../../src/northflank/tools/exec';
+import { DEFAULT_FILE_TIMEOUT_MS } from '../../src/northflank/tools/files';
+import {
+  DEFAULT_OUTPUT_LIMIT,
+  resolveNeedsApproval,
+  resolveProjectId,
+  truncate,
+} from '../../src/northflank/util';
+
+/**
+ * Build a stub ApiClient with deeply chained methods recorded as vi.fn(). The
+ * real client is generated from OpenAPI and impractical to import in tests,
+ * so we exercise the surface that our tools actually touch.
+ *
+ * Methods that return `ApiCallResponse` are stubbed to return `{ data }` (no
+ * error). To simulate an HTTP failure, override the method to return
+ * `{ data: undefined, error: { status, message } }`.
+ */
+function makeStubClient() {
+  const calls: { method: string; args: any[] }[] = [];
+  const make = (method: string, response: any = { data: { ok: true } }) =>
+    vi.fn(async (...args: any[]) => {
+      calls.push({ method, args });
+      return response;
+    });
+  const client = {
+    list: {
+      projects: make('list.projects', {
+        data: { projects: [{ id: 'p1', name: 'P1' }] },
+      }),
+      services: make('list.services', { data: { services: [{ id: 's1' }] } }),
+      secrets: make('list.secrets', { data: { secrets: [] } }),
+    },
+    get: {
+      project: make('get.project', { data: { id: 'p1', name: 'P1' } }),
+      service: Object.assign(make('get.service', { data: { id: 's1' } }), {
+        logs: make('get.service.logs', {
+          data: [{ ts: new Date(0), containerId: 'c', log: 'hello' }],
+        }),
+        metricsRange: make('get.service.metricsRange', {
+          data: { entries: [] },
+        }),
+      }),
+    },
+    create: {
+      service: {
+        deployment: make('create.service.deployment', {
+          data: { id: 'new-svc' },
+        }),
+      },
+    },
+    patch: {
+      service: {
+        deployment: make('patch.service.deployment', { data: { id: 's1' } }),
+      },
+    },
+    start: {
+      service: {
+        build: make('start.service.build', { data: { buildId: 'b1' } }),
+      },
+    },
+    restart: {
+      service: make('restart.service', { data: { ok: true } }),
+    },
+    scale: {
+      service: make('scale.service', { data: { instances: 3 } }),
+    },
+    exec: {
+      execServiceCommand: vi.fn(async () => ({
+        commandResult: { exitCode: 0, status: 'Success' as const },
+        stdOut: 'hi',
+        stdErr: '',
+      })),
+      execJobCommand: vi.fn(async () => ({
+        commandResult: { exitCode: 0, status: 'Success' as const },
+        stdOut: '',
+        stdErr: '',
+      })),
+      execAddonCommand: vi.fn(async () => ({
+        commandResult: { exitCode: 0, status: 'Success' as const },
+        stdOut: '',
+        stdErr: '',
+      })),
+    },
+    fileCopy: {
+      uploadServiceFiles: vi.fn(async () => ({
+        type: 'directory-upload',
+        sourceDirectory: '/x',
+        targetDirectory: '/y',
+      })),
+      downloadServiceFiles: vi.fn(async () => ({
+        type: 'directory-download',
+        sourceDirectory: '/y',
+        targetDirectory: '/x',
+      })),
+    },
+  };
+  return { client, calls };
+}
+
+describe('northflankTools — assembly', () => {
+  it('returns all default groups (~16 tools) when include is omitted', () => {
+    const { client } = makeStubClient();
+    const tools = northflankTools(client as any);
+    // 4 read + 5 deploy + 3 exec + 2 files + 1 logs + 1 metrics = 16
+    expect(tools).toHaveLength(16);
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toContain('northflank_list_projects');
+    expect(names).toContain('northflank_exec_service');
+    expect(names).toContain('northflank_scale_service');
+    // secrets is opt-in
+    expect(names).not.toContain('northflank_list_secrets');
+  });
+
+  it('opting into the secrets group adds the 17th tool', () => {
+    const { client } = makeStubClient();
+    const tools = northflankTools(client as any, {
+      include: [
+        'read',
+        'deploy',
+        'exec',
+        'files',
+        'logs',
+        'metrics',
+        'secrets',
+      ],
+    });
+    expect(tools).toHaveLength(17);
+    expect(tools.map((t) => t.name)).toContain('northflank_list_secrets');
+  });
+
+  it('filters groups when include is narrowed', () => {
+    const { client } = makeStubClient();
+    const tools = northflankTools(client as any, { include: ['read'] });
+    expect(tools).toHaveLength(4);
+    for (const t of tools) expect(t.name.startsWith('northflank_')).toBe(true);
+  });
+
+  it('every tool exposes name/description/parameters/needsApproval', () => {
+    const { client } = makeStubClient();
+    for (const t of northflankTools(client as any)) {
+      expect(t.type).toBe('function');
+      expect(t.name).toMatch(/^northflank_[a-z_]+$/);
+      expect(t.description.length).toBeGreaterThan(10);
+      expect(t.parameters).toBeDefined();
+      expect(typeof t.needsApproval).toBe('function');
+    }
+  });
+});
+
+describe('approvals policy', () => {
+  it("'auto' marks mutating tools as needing approval and reads as not", () => {
+    expect(resolveNeedsApproval('northflank_list_projects', 'auto')).toBe(
+      false,
+    );
+    expect(resolveNeedsApproval('northflank_get_service', 'auto')).toBe(false);
+    expect(resolveNeedsApproval('northflank_restart_service', 'auto')).toBe(
+      true,
+    );
+    expect(resolveNeedsApproval('northflank_exec_service', 'auto')).toBe(true);
+    expect(resolveNeedsApproval('northflank_upload_files', 'auto')).toBe(true);
+    // download_files writes to the agent host filesystem — also gated.
+    expect(resolveNeedsApproval('northflank_download_files', 'auto')).toBe(
+      true,
+    );
+  });
+
+  it("'always' / 'never' flip every tool uniformly", () => {
+    expect(resolveNeedsApproval('northflank_list_projects', 'always')).toBe(
+      true,
+    );
+    expect(resolveNeedsApproval('northflank_restart_service', 'never')).toBe(
+      false,
+    );
+  });
+
+  it('per-tool override beats the default', () => {
+    expect(
+      resolveNeedsApproval('northflank_restart_service', {
+        northflank_restart_service: false,
+      }),
+    ).toBe(false);
+    expect(
+      resolveNeedsApproval('northflank_get_service', {
+        northflank_get_service: true,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('defaults & helpers', () => {
+  it('resolveProjectId uses defaultProjectId when arg is missing', () => {
+    expect(resolveProjectId(undefined, { defaultProjectId: 'p-default' })).toBe(
+      'p-default',
+    );
+    expect(resolveProjectId('p-arg', { defaultProjectId: 'p-default' })).toBe(
+      'p-arg',
+    );
+  });
+
+  it('resolveProjectId throws a helpful error when nothing is set', () => {
+    expect(() => resolveProjectId(undefined, {})).toThrow(
+      /projectId is required/,
+    );
+  });
+
+  it('truncate appends a clear marker past the limit', () => {
+    const s = 'a'.repeat(100);
+    const out = truncate(s, 10);
+    expect(out.startsWith('a'.repeat(10))).toBe(true);
+    expect(out).toMatch(/truncated 90 chars/);
+  });
+
+  it('truncate is a no-op under the limit', () => {
+    expect(truncate('hi', DEFAULT_OUTPUT_LIMIT)).toBe('hi');
+  });
+});
+
+describe('tool execution wiring', () => {
+  it('list_projects calls the client and JSON-serialises the response data', async () => {
+    const { client, calls } = makeStubClient();
+    const tools = northflankTools(client as any);
+    const listProjects = tools.find(
+      (t) => t.name === 'northflank_list_projects',
+    )!;
+
+    const result = await listProjects.invoke({} as any, JSON.stringify({}));
+    expect(calls[0]?.method).toBe('list.projects');
+    expect(String(result)).toContain('P1');
+    // We're returning .data, not the whole response.
+    expect(String(result)).not.toContain('rawResponse');
+  });
+
+  it('exec_service formats stdout/stderr/exit code', async () => {
+    const { client } = makeStubClient();
+    const tools = northflankTools(client as any, { approvals: 'never' });
+    const execService = tools.find(
+      (t) => t.name === 'northflank_exec_service',
+    )!;
+    const out = String(
+      await execService.invoke(
+        {} as any,
+        JSON.stringify({ projectId: 'p', serviceId: 's', command: 'echo hi' }),
+      ),
+    );
+    expect(out).toContain('exitCode=0');
+    expect(out).toContain('--- stdout ---');
+    expect(out).toContain('hi');
+  });
+
+  it('defaultProjectId lets the model omit projectId', async () => {
+    const { client, calls } = makeStubClient();
+    const tools = northflankTools(client as any, {
+      defaultProjectId: 'p-default',
+      approvals: 'never',
+    });
+    const listServices = tools.find(
+      (t) => t.name === 'northflank_list_services',
+    )!;
+    await listServices.invoke({} as any, JSON.stringify({}));
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall?.method).toBe('list.services');
+    expect(lastCall?.args[0]?.parameters?.projectId).toBe('p-default');
+  });
+
+  it('teamId is forwarded to read endpoints', async () => {
+    const { client, calls } = makeStubClient();
+    const tools = northflankTools(client as any, {
+      teamId: 't-1',
+      defaultProjectId: 'p',
+      approvals: 'never',
+    });
+    const getService = tools.find((t) => t.name === 'northflank_get_service')!;
+    await getService.invoke({} as any, JSON.stringify({ serviceId: 's' }));
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall?.args[0]?.parameters?.teamId).toBe('t-1');
+  });
+
+  it('thrown client errors are reported back to the model, not thrown', async () => {
+    const { client } = makeStubClient();
+    client.list.projects = vi.fn(async () => {
+      throw new Error('boom');
+    }) as any;
+    const tools = northflankTools(client as any);
+    const listProjects = tools.find(
+      (t) => t.name === 'northflank_list_projects',
+    )!;
+    const out = String(
+      await listProjects.invoke({} as any, JSON.stringify({})),
+    );
+    expect(out).toMatch(/Error listing projects: boom/);
+  });
+
+  it('non-2xx response.error is detected even when the client does not throw', async () => {
+    // throwErrorOnHttpErrorCode: false (the JS client default) puts the
+    // failure in response.error rather than throwing.
+    const { client } = makeStubClient();
+    client.get.service = vi.fn(async () => ({
+      data: undefined,
+      error: { status: 404, message: 'service not found', id: 'nf-404' },
+    })) as any;
+    const tools = northflankTools(client as any, { approvals: 'never' });
+    const getService = tools.find((t) => t.name === 'northflank_get_service')!;
+    const out = String(
+      await getService.invoke(
+        {} as any,
+        JSON.stringify({ projectId: 'p', serviceId: 's' }),
+      ),
+    );
+    expect(out).toMatch(/Error fetching service/);
+    expect(out).toContain('HTTP 404');
+    expect(out).toContain('service not found');
+  });
+
+  it('start_service_build maps commitSha to the JS-client `sha` field', async () => {
+    // The JS client expects `sha`, not `buildSHA`.
+    const { client, calls } = makeStubClient();
+    const tools = northflankTools(client as any, {
+      defaultProjectId: 'p',
+      approvals: 'never',
+    });
+    const startBuild = tools.find(
+      (t) => t.name === 'northflank_start_service_build',
+    )!;
+    await startBuild.invoke(
+      {} as any,
+      JSON.stringify({ serviceId: 's', commitSha: 'deadbeef' }),
+    );
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall?.method).toBe('start.service.build');
+    expect(lastCall?.args[0]?.data?.sha).toBe('deadbeef');
+    expect(lastCall?.args[0]?.data?.buildSHA).toBeUndefined();
+  });
+
+  it('exec output splits the budget between stdout and stderr', async () => {
+    // Total output must not exceed outputCharLimit even when both streams
+    // are noisy.
+    const { client } = makeStubClient();
+    client.exec.execServiceCommand = vi.fn(async () => ({
+      commandResult: { exitCode: 0, status: 'Success' as const },
+      stdOut: 'o'.repeat(1000),
+      stdErr: 'e'.repeat(1000),
+    })) as any;
+    const tools = northflankTools(client as any, {
+      approvals: 'never',
+      outputCharLimit: 100, // tiny cap to make truncation observable
+    });
+    const exec = tools.find((t) => t.name === 'northflank_exec_service')!;
+    const out = String(
+      await exec.invoke(
+        {} as any,
+        JSON.stringify({ projectId: 'p', serviceId: 's', command: 'x' }),
+      ),
+    );
+    // Half the budget goes to each stream. Each stream of "o"/"e" should be
+    // truncated to ~50 chars + truncation marker.
+    const oRun = out.match(/o+/)?.[0] ?? '';
+    const eRun = out.match(/e+/)?.[0] ?? '';
+    expect(oRun.length).toBeLessThanOrEqual(50);
+    expect(eRun.length).toBeLessThanOrEqual(50);
+    expect(out).toMatch(/truncated/);
+  });
+});
+
+describe('strict mode', () => {
+  // Rich-body tools opt out of OpenAI Structured Outputs strict mode because
+  // the Northflank service spec is too large to enumerate — strict mode would
+  // require additionalProperties: false on every nested object.
+  it('create_service / update_service_deployment / start_service_build are non-strict', () => {
+    const { client } = makeStubClient();
+    const tools = northflankTools(client as any);
+    for (const name of [
+      'northflank_create_service',
+      'northflank_update_service_deployment',
+      'northflank_start_service_build',
+    ]) {
+      const t = tools.find((x) => x.name === name)!;
+      expect((t as any).strict).toBe(false);
+    }
+  });
+
+  it('all other tools stay in strict mode', () => {
+    const { client } = makeStubClient();
+    const tools = northflankTools(client as any, {
+      include: [
+        'read',
+        'deploy',
+        'exec',
+        'files',
+        'logs',
+        'metrics',
+        'secrets',
+      ],
+    });
+    const nonStrictNames = new Set([
+      'northflank_create_service',
+      'northflank_update_service_deployment',
+      'northflank_start_service_build',
+    ]);
+    for (const t of tools) {
+      if (nonStrictNames.has(t.name)) continue;
+      expect((t as any).strict).toBe(true);
+    }
+  });
+});
+
+describe('timeouts', () => {
+  it('exec tools inherit the default execTimeoutMs', () => {
+    const { client } = makeStubClient();
+    const tools = northflankTools(client as any);
+    const exec = tools.find((t) => t.name === 'northflank_exec_service')!;
+    expect((exec as any).timeoutMs).toBe(DEFAULT_EXEC_TIMEOUT_MS);
+  });
+
+  it('file tools inherit the default fileTimeoutMs', () => {
+    const { client } = makeStubClient();
+    const tools = northflankTools(client as any);
+    const upload = tools.find((t) => t.name === 'northflank_upload_files')!;
+    expect((upload as any).timeoutMs).toBe(DEFAULT_FILE_TIMEOUT_MS);
+  });
+
+  it('execTimeoutMs option overrides the default for all three exec tools', () => {
+    const { client } = makeStubClient();
+    const tools = northflankTools(client as any, { execTimeoutMs: 5_000 });
+    for (const name of [
+      'northflank_exec_service',
+      'northflank_exec_job',
+      'northflank_exec_addon',
+    ]) {
+      const t = tools.find((x) => x.name === name)!;
+      expect((t as any).timeoutMs).toBe(5_000);
+    }
+  });
+
+  it('fileTimeoutMs option overrides the default for both file tools', () => {
+    const { client } = makeStubClient();
+    const tools = northflankTools(client as any, { fileTimeoutMs: 10_000 });
+    for (const name of [
+      'northflank_upload_files',
+      'northflank_download_files',
+    ]) {
+      const t = tools.find((x) => x.name === name)!;
+      expect((t as any).timeoutMs).toBe(10_000);
+    }
+  });
+
+  it('read/deploy/logs/metrics tools do not impose a timeout', () => {
+    const { client } = makeStubClient();
+    const tools = northflankTools(client as any);
+    for (const name of [
+      'northflank_list_projects',
+      'northflank_get_service',
+      'northflank_restart_service',
+      'northflank_get_service_logs',
+      'northflank_get_service_metrics',
+    ]) {
+      const t = tools.find((x) => x.name === name)!;
+      expect((t as any).timeoutMs).toBeUndefined();
+    }
+  });
+});

--- a/packages/agents-extensions/test/sandbox/northflank.test.ts
+++ b/packages/agents-extensions/test/sandbox/northflank.test.ts
@@ -1,0 +1,769 @@
+import { Manifest, SandboxProviderError } from '@openai/agents-core/sandbox';
+import { promises as fs } from 'node:fs';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { NorthflankSandboxClient } from '../../src/sandbox/northflank';
+import { resolvedRemotePathFromValidationCommand } from './remotePathValidation';
+
+type StubClient = ReturnType<typeof makeStubClient>;
+
+/**
+ * In-memory stub of the @northflank/js-client surface NorthflankSandboxClient
+ * touches. Models a single deployment service with an ephemeral filesystem
+ * shared across mocked exec + file-copy calls.
+ */
+function makeStubClient() {
+  const files = new Map<string, Buffer>();
+  const dirs = new Set<string>(['/', '/workspace']);
+  const calls: { method: string; args: unknown[] }[] = [];
+
+  let createdServiceId = 'sandbox-test-abc';
+  let servicePaused = false;
+  let deploymentStatus: 'PENDING' | 'IN_PROGRESS' | 'COMPLETED' | 'FAILED' =
+    'COMPLETED';
+
+  /**
+   * Dispatch a `sh -c '<inner>'` shell line against our in-memory FS. The
+   * provider only ever sends `sh -c '<inner>'` where `<inner>` looks like
+   * `cd '<workdir>' && <user_command>`. We strip the cd prefix and match
+   * the suffix against a handful of well-known forms.
+   */
+  function dispatchExec(argv: unknown): {
+    stdOut: string;
+    stdErr: string;
+    exitCode: number;
+  } {
+    if (!Array.isArray(argv) || argv[0] !== 'sh' || argv[1] !== '-c') {
+      return { stdOut: '', stdErr: 'expected sh -c argv', exitCode: 2 };
+    }
+    const rawInner = String(argv[2] ?? '');
+    // The base class validates user-supplied paths by running an embedded
+    // resolve-workspace-path.sh helper through exec. Echo the requested
+    // path back so the validator sees an absolute resolution.
+    const resolved = resolvedRemotePathFromValidationCommand(rawInner);
+    if (resolved) {
+      return { stdOut: `${resolved}\n`, stdErr: '', exitCode: 0 };
+    }
+    const inner = rawInner.replace(/^cd '[^']*' && /, '');
+
+    const mkdir = inner.match(/^mkdir -p -- '([^']*)'$/);
+    if (mkdir) {
+      dirs.add(mkdir[1]);
+      return { stdOut: '', stdErr: '', exitCode: 0 };
+    }
+    const rmrf = inner.match(/^rm -rf -- '([^']*)'$/);
+    if (rmrf) {
+      files.delete(rmrf[1]);
+      dirs.delete(rmrf[1]);
+      return { stdOut: '', stdErr: '', exitCode: 0 };
+    }
+    const teste = inner.match(/^test -e '([^']*)'$/);
+    if (teste) {
+      const path = teste[1];
+      return {
+        stdOut: '',
+        stdErr: '',
+        exitCode: files.has(path) || dirs.has(path) ? 0 : 1,
+      };
+    }
+    const tarCreate = inner.match(/^tar czf '([^']*)' -C '([^']*)' \.$/);
+    if (tarCreate) {
+      const [, archivePath, root] = tarCreate;
+      if (!dirs.has(root)) {
+        return { stdOut: '', stdErr: 'no such dir', exitCode: 2 };
+      }
+      const prefix = root.endsWith('/') ? root : `${root}/`;
+      const captured: Record<string, string> = {};
+      for (const [fpath, content] of files) {
+        if (fpath.startsWith(prefix)) {
+          captured[fpath.slice(prefix.length)] = content.toString('utf8');
+        }
+      }
+      files.set(archivePath, Buffer.from(JSON.stringify(captured)));
+      return { stdOut: '', stdErr: '', exitCode: 0 };
+    }
+    const tarList = inner.match(/^tar -tzf '([^']*)'$/);
+    if (tarList) {
+      if (pendingTarListing !== null) {
+        return { stdOut: pendingTarListing, stdErr: '', exitCode: 0 };
+      }
+      const blob = files.get(tarList[1]);
+      if (!blob) return { stdOut: '', stdErr: 'no archive', exitCode: 2 };
+      try {
+        const obj = JSON.parse(blob.toString('utf8')) as Record<string, string>;
+        return {
+          stdOut: `${Object.keys(obj).join('\n')}\n`,
+          stdErr: '',
+          exitCode: 0,
+        };
+      } catch {
+        return { stdOut: '', stdErr: 'corrupt archive', exitCode: 2 };
+      }
+    }
+    const tarListVerbose = inner.match(/^tar -tvzf '([^']*)'$/);
+    if (tarListVerbose) {
+      if (pendingTarVerbose !== null) {
+        return { stdOut: pendingTarVerbose, stdErr: '', exitCode: 0 };
+      }
+      const blob = files.get(tarListVerbose[1]);
+      if (!blob) return { stdOut: '', stdErr: 'no archive', exitCode: 2 };
+      try {
+        const obj = JSON.parse(blob.toString('utf8')) as Record<string, string>;
+        const lines = Object.keys(obj).map(
+          (p) => `-rw-r--r-- 0/0 0 2025-01-01 00:00 ${p}`,
+        );
+        return { stdOut: `${lines.join('\n')}\n`, stdErr: '', exitCode: 0 };
+      } catch {
+        return { stdOut: '', stdErr: 'corrupt archive', exitCode: 2 };
+      }
+    }
+    const tarExtract = inner.match(/^tar xzf '([^']*)' -C '([^']*)'$/);
+    if (tarExtract) {
+      const [, archivePath, root] = tarExtract;
+      const blob = files.get(archivePath);
+      if (!blob) return { stdOut: '', stdErr: 'no archive', exitCode: 2 };
+      const prefix = root.endsWith('/') ? root : `${root}/`;
+      const restored = JSON.parse(blob.toString('utf8')) as Record<
+        string,
+        string
+      >;
+      dirs.add(root);
+      for (const [rel, content] of Object.entries(restored)) {
+        files.set(`${prefix}${rel}`, Buffer.from(content, 'utf8'));
+      }
+      return { stdOut: '', stdErr: '', exitCode: 0 };
+    }
+    const rmf = inner.match(/^rm -f -- '([^']*)'$/);
+    if (rmf) {
+      files.delete(rmf[1]);
+      return { stdOut: '', stdErr: '', exitCode: 0 };
+    }
+    const testf = inner.match(/^test -f '([^']*)'$/);
+    if (testf) {
+      return { stdOut: '', stdErr: '', exitCode: files.has(testf[1]) ? 0 : 1 };
+    }
+    const ls = inner.match(/^ls -1Ap -- '([^']*)'$/);
+    if (ls) {
+      const root = ls[1];
+      if (!dirs.has(root)) {
+        return { stdOut: '', stdErr: 'no such directory', exitCode: 2 };
+      }
+      const prefix = root.endsWith('/') ? root : `${root}/`;
+      const entries: string[] = [];
+      for (const f of files.keys()) {
+        if (f.startsWith(prefix) && !f.slice(prefix.length).includes('/')) {
+          entries.push(f.slice(prefix.length));
+        }
+      }
+      for (const d of dirs) {
+        if (d === root) continue;
+        if (d.startsWith(prefix) && !d.slice(prefix.length).includes('/')) {
+          entries.push(`${d.slice(prefix.length)}/`);
+        }
+      }
+      return { stdOut: entries.join('\n'), stdErr: '', exitCode: 0 };
+    }
+    // Generic fallback for `execCommand` calls in tests.
+    return { stdOut: 'ok', stdErr: '', exitCode: 0 };
+  }
+
+  const execServiceCommand = vi.fn(
+    async (
+      params: { projectId: string; serviceId: string; teamId?: string },
+      data: { command: string | string[]; instanceName?: string },
+    ) => {
+      calls.push({ method: 'exec.execServiceCommand', args: [params, data] });
+      const result = dispatchExec(data.command);
+      return {
+        commandResult: {
+          exitCode: result.exitCode,
+          status: result.exitCode === 0 ? 'Success' : 'Failure',
+        },
+        stdOut: result.stdOut,
+        stdErr: result.stdErr,
+      };
+    },
+  );
+
+  const uploadServiceFiles = vi.fn(
+    async (
+      _params: unknown,
+      options: { localPath: string; remotePath?: string },
+    ) => {
+      calls.push({
+        method: 'fileCopy.uploadServiceFiles',
+        args: [_params, options],
+      });
+      const buf = await fs.readFile(options.localPath);
+      files.set(options.remotePath ?? '', buf);
+      return { type: 'file-upload' };
+    },
+  );
+
+  const downloadServiceFiles = vi.fn(
+    async (
+      _params: unknown,
+      options: { localPath: string; remotePath?: string },
+    ) => {
+      calls.push({
+        method: 'fileCopy.downloadServiceFiles',
+        args: [_params, options],
+      });
+      const content = files.get(options.remotePath ?? '');
+      if (content === undefined) {
+        throw new Error(`download: no such file ${options.remotePath}`);
+      }
+      const target = `${options.localPath.replace(/\/$/, '')}/${(
+        options.remotePath ?? ''
+      )
+        .split('/')
+        .pop()}`;
+      await fs.writeFile(target, content);
+      return { type: 'file-download' };
+    },
+  );
+
+  const getService = Object.assign(
+    vi.fn(async () => ({
+      data: {
+        id: createdServiceId,
+        servicePaused,
+        status: { deployment: { status: deploymentStatus } },
+      },
+    })),
+    {
+      containers: vi.fn(async () => ({
+        data: {
+          containers: [
+            { name: `${createdServiceId}-pod-0`, status: 'TASK_RUNNING' },
+          ],
+        },
+      })),
+    },
+  );
+
+  let volumeCounter = 0;
+  const createVolume = vi.fn(async (opts: unknown) => {
+    calls.push({ method: 'create.volume', args: [opts] });
+    volumeCounter += 1;
+    return { data: { id: `vol-${volumeCounter}` } };
+  });
+  const deleteVolume = vi.fn(async (opts: unknown) => {
+    calls.push({ method: 'delete.volume', args: [opts] });
+    return { data: {} };
+  });
+  const detachVolume = vi.fn(async (opts: unknown) => {
+    calls.push({ method: 'detach.volume', args: [opts] });
+    return { data: {} };
+  });
+  const attachVolume = vi.fn(async (opts: unknown) => {
+    calls.push({ method: 'attach.volume', args: [opts] });
+    return { data: {} };
+  });
+
+  let pendingTarListing: string | null = null;
+  let pendingTarVerbose: string | null = null;
+
+  const client = {
+    create: {
+      service: {
+        deployment: vi.fn(async (...args: unknown[]) => {
+          calls.push({ method: 'create.service.deployment', args });
+          return { data: { id: createdServiceId } };
+        }),
+      },
+      volume: createVolume,
+    },
+    get: { service: getService },
+    delete: {
+      service: vi.fn(async () => ({ data: {} })),
+      volume: deleteVolume,
+    },
+    attach: { volume: attachVolume },
+    detach: { volume: detachVolume },
+    pause: { service: vi.fn(async () => ({ data: {} })) },
+    resume: { service: vi.fn(async () => ({ data: {} })) },
+    exec: { execServiceCommand },
+    fileCopy: { uploadServiceFiles, downloadServiceFiles },
+  };
+
+  return {
+    client,
+    calls,
+    files,
+    setDeploymentStatus: (status: typeof deploymentStatus) => {
+      deploymentStatus = status;
+    },
+    setServicePaused: (paused: boolean) => {
+      servicePaused = paused;
+    },
+    setCreatedServiceId: (id: string) => {
+      createdServiceId = id;
+    },
+    setTarListing: (listing: string | null) => {
+      pendingTarListing = listing;
+    },
+    setTarVerbose: (verbose: string | null) => {
+      pendingTarVerbose = verbose;
+    },
+  };
+}
+
+function makeSandbox(stub: StubClient, options: Record<string, unknown> = {}) {
+  return new NorthflankSandboxClient({
+    apiClient: stub.client as never,
+    projectId: 'p',
+    image: 'img',
+    pollIntervalMs: 1,
+    ...options,
+  });
+}
+
+describe('NorthflankSandboxClient', () => {
+  let stub: StubClient;
+
+  beforeEach(() => {
+    stub = makeStubClient();
+  });
+
+  test('requires projectId and image', () => {
+    const incomplete = new NorthflankSandboxClient({
+      apiClient: stub.client as never,
+    });
+    return expect(incomplete.create()).rejects.toThrow(/projectId/);
+  });
+
+  test('creates a deployment service and materializes the manifest', async () => {
+    const sandbox = makeSandbox(stub);
+    const manifest = new Manifest({
+      root: '/workspace',
+      entries: { 'README.md': { type: 'file', content: '# Hello\n' } },
+    });
+
+    const session = await sandbox.create(manifest);
+
+    expect(session.state.serviceId).toBeTruthy();
+    expect(session.state.workspaceRoot).toBe('/workspace');
+    // create.service.deployment was called with instances pinned to 1
+    const createCall = stub.calls.find(
+      (c) => c.method === 'create.service.deployment',
+    )!;
+    const data = (
+      createCall.args[0] as {
+        data: {
+          deployment: { instances: number; external: { imagePath: string } };
+        };
+      }
+    ).data;
+    expect(data.deployment.instances).toBe(1);
+    expect(data.deployment.external.imagePath).toBe('img');
+    // README.md ended up in the in-memory FS via uploadServiceFiles
+    expect(stub.files.get('/workspace/README.md')?.toString('utf8')).toBe(
+      '# Hello\n',
+    );
+    // Every fileCopy call is pinned to the resolved instance
+    const uploadCall = stub.calls.find(
+      (c) => c.method === 'fileCopy.uploadServiceFiles',
+    )!;
+    expect((uploadCall.args[1] as { instanceName?: string }).instanceName).toBe(
+      session.state.instanceName,
+    );
+  });
+
+  test('execCommand wraps user commands as `sh -c` and pins the instance', async () => {
+    const sandbox = makeSandbox(stub);
+    const session = await sandbox.create(new Manifest());
+    await session.execCommand({ cmd: 'echo hi' });
+    const execCall = [...stub.calls]
+      .reverse()
+      .find(
+        (c: any) =>
+          c.method === 'exec.execServiceCommand' &&
+          Array.isArray((c.args[1] as { command?: unknown }).command) &&
+          String((c.args[1] as { command: string[] }).command[2]).includes(
+            'echo hi',
+          ),
+      );
+    expect(execCall).toBeDefined();
+    const data = execCall!.args[1] as {
+      command: string[];
+      shell?: string;
+      instanceName?: string;
+    };
+    expect(data.command[0]).toBe('sh');
+    expect(data.command[1]).toBe('-c');
+    expect(data.shell).toBe('none');
+    expect(data.instanceName).toBe(session.state.instanceName);
+  });
+
+  test('writeFile + readFile round-trip via fileCopy', async () => {
+    const sandbox = makeSandbox(stub);
+    const session = await sandbox.create(new Manifest({ root: '/workspace' }));
+
+    await (
+      session as unknown as {
+        writeRemoteFile: (path: string, content: string) => Promise<void>;
+      }
+    ).writeRemoteFile('/workspace/hi.txt', 'world');
+    const bytes = await (
+      session as unknown as {
+        readRemoteFile: (path: string) => Promise<Uint8Array>;
+      }
+    ).readRemoteFile('/workspace/hi.txt');
+    expect(Buffer.from(bytes).toString('utf8')).toBe('world');
+  });
+
+  test('throws when the deployment never reaches COMPLETED', async () => {
+    stub.setDeploymentStatus('FAILED');
+    const sandbox = makeSandbox(stub);
+    await expect(sandbox.create()).rejects.toBeInstanceOf(SandboxProviderError);
+  });
+
+  test('serializeSessionState → deserializeSessionState round-trips', async () => {
+    const sandbox = makeSandbox(stub);
+    const session = await sandbox.create(
+      new Manifest({ entries: { 'a.txt': { type: 'file', content: 'A' } } }),
+    );
+    const serialized = await sandbox.serializeSessionState(session.state);
+    const round = JSON.parse(JSON.stringify(serialized));
+    const restored = await sandbox.deserializeSessionState(round);
+    expect(restored.serviceId).toBe(session.state.serviceId);
+    expect(restored.workspaceRoot).toBe(session.state.workspaceRoot);
+    expect(restored.pauseOnExit).toBe(false);
+  });
+
+  test('close() deletes by default, pauses when pauseOnExit is true', async () => {
+    const sandbox = makeSandbox(stub);
+    const ephemeral = await sandbox.create(new Manifest());
+    await ephemeral.close();
+    expect(stub.client.delete.service).toHaveBeenCalled();
+    expect(stub.client.pause.service).not.toHaveBeenCalled();
+
+    const persisted = await makeSandbox(stub, { pauseOnExit: true }).create(
+      new Manifest(),
+    );
+    await persisted.close();
+    expect(stub.client.pause.service).toHaveBeenCalled();
+  });
+
+  test('stop() is a no-op without pauseOnExit so runtime stop+delete is safe', async () => {
+    const sandbox = makeSandbox(stub);
+    const session = await sandbox.create(new Manifest());
+    await session.stop();
+    expect(stub.client.pause.service).not.toHaveBeenCalled();
+    expect(stub.client.delete.service).not.toHaveBeenCalled();
+    await session.delete();
+    expect(stub.client.delete.service).toHaveBeenCalledTimes(1);
+  });
+
+  test('delete() is idempotent', async () => {
+    const sandbox = makeSandbox(stub);
+    const session = await sandbox.create(new Manifest());
+    await session.delete();
+    await session.delete();
+    expect(stub.client.delete.service).toHaveBeenCalledTimes(1);
+  });
+
+  test('delete() pauses instead of tearing down during runtime cleanup of a persistable session', async () => {
+    // The Agents runtime calls stop(opts) then delete(opts) during cleanup
+    // with { reason: 'cleanup', preserveOwnedSessions: true }. With
+    // pauseOnExit, the session must survive that sequence so the
+    // serialized state remains resumable.
+    const sandbox = makeSandbox(stub, { pauseOnExit: true });
+    const session = await sandbox.create(new Manifest());
+    const cleanupOptions = {
+      reason: 'cleanup',
+      preserveOwnedSessions: true,
+    };
+    await session.stop(cleanupOptions);
+    await session.delete(cleanupOptions);
+    expect(stub.client.pause.service).toHaveBeenCalled();
+    expect(stub.client.delete.service).not.toHaveBeenCalled();
+
+    // After a paused cleanup, an explicit user-initiated delete() (no
+    // cleanup options) should still tear down the service.
+    await session.delete();
+    expect(stub.client.delete.service).toHaveBeenCalledTimes(1);
+  });
+
+  test('delete() preserves volume-mode sessions during cleanup so resume can reach the volume', async () => {
+    const sandbox = makeSandbox(stub, {
+      workspacePersistence: 'volume',
+      pauseOnExit: true,
+    });
+    const session = await sandbox.create(new Manifest());
+    const volumeId = session.state.volumeId!;
+    await session.delete({ reason: 'cleanup', preserveOwnedSessions: true });
+    expect(stub.client.pause.service).toHaveBeenCalled();
+    expect(stub.client.delete.service).not.toHaveBeenCalled();
+    expect(stub.client.delete.volume).not.toHaveBeenCalled();
+    expect(session.state.volumeId).toBe(volumeId);
+  });
+
+  test('delete() with cleanup options still tears down when the session is not persistable', async () => {
+    const sandbox = makeSandbox(stub);
+    const session = await sandbox.create(new Manifest());
+    await session.delete({ reason: 'cleanup', preserveOwnedSessions: true });
+    expect(stub.client.pause.service).not.toHaveBeenCalled();
+    expect(stub.client.delete.service).toHaveBeenCalledTimes(1);
+  });
+
+  test('env merge: manifest environment wins over options.env on key collision', async () => {
+    const sandbox = makeSandbox(stub, {
+      env: { SHARED: 'from-options', FROM_OPTIONS: 'opt' },
+    });
+    const session = await sandbox.create(
+      new Manifest({
+        environment: {
+          SHARED: { value: 'from-manifest' },
+          FROM_MANIFEST: { value: 'man' },
+        },
+      }),
+    );
+    expect(session.state.environment).toEqual({
+      SHARED: 'from-manifest',
+      FROM_OPTIONS: 'opt',
+      FROM_MANIFEST: 'man',
+    });
+    const createCall = stub.calls.find(
+      (c) => c.method === 'create.service.deployment',
+    )!;
+    const runtimeEnvironment = (
+      createCall.args[0] as {
+        data: { runtimeEnvironment: Record<string, string> };
+      }
+    ).data.runtimeEnvironment;
+    expect(runtimeEnvironment.SHARED).toBe('from-manifest');
+  });
+
+  test('rejects env keys with shell metacharacters', async () => {
+    const sandbox = new NorthflankSandboxClient({
+      apiClient: stub.client as never,
+      projectId: 'p',
+      image: 'img',
+      env: { 'FOO; rm -rf /': 'oops' },
+      pollIntervalMs: 1,
+    });
+    await expect(sandbox.create(new Manifest())).rejects.toThrow(
+      /Invalid environment variable/,
+    );
+  });
+
+  test('resume() un-pauses a paused service then reconnects', async () => {
+    const sandbox = makeSandbox(stub, { pauseOnExit: true });
+    const session = await sandbox.create(new Manifest());
+    stub.setServicePaused(true);
+    const resumed = await sandbox.resume(session.state);
+    expect(stub.client.resume.service).toHaveBeenCalled();
+    expect(resumed.state.serviceId).toBe(session.state.serviceId);
+  });
+
+  test('volume persistence: create attaches a provider-owned volume mounted at workspaceRoot', async () => {
+    const sandbox = makeSandbox(stub, {
+      workspacePersistence: 'volume',
+      volumeSpec: { storageSize: 2048, accessMode: 'ReadWriteOnce' },
+    });
+    const session = await sandbox.create(new Manifest({ root: '/workspace' }));
+    expect(session.state.workspacePersistence).toBe('volume');
+    expect(session.state.volumeId).toBeTruthy();
+    expect(session.state.volumeProviderCreated).toBe(true);
+
+    const volumeCall = stub.calls.find((c) => c.method === 'create.volume')!;
+    const body = (
+      volumeCall.args[0] as {
+        data: {
+          name: string;
+          mounts: { containerMountPath: string }[];
+          spec: {
+            storageSize: number;
+            accessMode: string;
+            storageClassName?: string;
+          };
+          attachedObjects: { id: string; type: string }[];
+        };
+      }
+    ).data;
+    expect(body.mounts[0].containerMountPath).toBe('/workspace');
+    expect(body.spec.storageSize).toBe(2048);
+    expect(body.spec.accessMode).toBe('ReadWriteOnce');
+    expect(body.attachedObjects[0]).toEqual({
+      id: session.state.serviceId,
+      type: 'service',
+    });
+  });
+
+  test('volume persistence: default volume is ReadWriteMany on nf-multi-rw at the cluster minimum size', async () => {
+    const sandbox = makeSandbox(stub, { workspacePersistence: 'volume' });
+    await sandbox.create(new Manifest({ root: '/workspace' }));
+    const volumeCall = stub.calls.find((c) => c.method === 'create.volume')!;
+    const spec = (
+      volumeCall.args[0] as {
+        data: {
+          spec: {
+            storageSize: number;
+            accessMode: string;
+            storageClassName?: string;
+          };
+        };
+      }
+    ).data.spec;
+    expect(spec.accessMode).toBe('ReadWriteMany');
+    expect(spec.storageClassName).toBe('nf-multi-rw');
+    expect(spec.storageSize).toBe(5120);
+  });
+
+  test('volume persistence: existing volumeId is attached to the service and not deleted on teardown', async () => {
+    const sandbox = makeSandbox(stub, {
+      workspacePersistence: 'volume',
+      volumeId: 'caller-owned-volume',
+    });
+    const session = await sandbox.create(new Manifest());
+    expect(stub.client.create.volume).not.toHaveBeenCalled();
+    expect(session.state.volumeId).toBe('caller-owned-volume');
+    expect(session.state.volumeProviderCreated).toBe(false);
+
+    // Caller-owned volumes must be attached to the freshly-created service
+    // — otherwise the service runs on ephemeral storage despite state
+    // claiming a volume is in play.
+    expect(stub.client.attach.volume).toHaveBeenCalledTimes(1);
+    const attachCall = stub.calls.find((c) => c.method === 'attach.volume')!;
+    const attachArgs = attachCall.args[0] as {
+      parameters: { projectId: string; volumeId: string };
+      data: { nfObject: { id: string; type: 'service' | 'job' } };
+    };
+    expect(attachArgs.parameters.volumeId).toBe('caller-owned-volume');
+    expect(attachArgs.data.nfObject).toEqual({
+      id: session.state.serviceId,
+      type: 'service',
+    });
+
+    await session.delete();
+    expect(stub.client.delete.volume).not.toHaveBeenCalled();
+  });
+
+  test('volume persistence: delete() detaches then removes the provider-created volume', async () => {
+    const sandbox = makeSandbox(stub, { workspacePersistence: 'volume' });
+    const session = await sandbox.create(new Manifest());
+    const volumeId = session.state.volumeId!;
+    await session.delete();
+    expect(stub.client.delete.volume).toHaveBeenCalledTimes(1);
+    expect(stub.client.detach.volume).toHaveBeenCalledTimes(1);
+    // detach.volume must run before delete.volume — Northflank rejects
+    // delete.volume while the volume is still attached.
+    const indexes = stub.calls.map((c) => c.method);
+    expect(indexes.indexOf('detach.volume')).toBeLessThan(
+      indexes.indexOf('delete.volume'),
+    );
+    const deleteCall = stub.calls.find((c) => c.method === 'delete.volume')!;
+    const params = (
+      deleteCall.args[0] as {
+        parameters: { projectId: string; volumeId: string };
+      }
+    ).parameters;
+    expect(params.volumeId).toBe(volumeId);
+    expect(session.state.volumeId).toBeUndefined();
+  });
+
+  test('tar persistence: stop() captures workspace; serialize round-trip restores it on resume()', async () => {
+    const sandbox = makeSandbox(stub, {
+      workspacePersistence: 'tar',
+      pauseOnExit: true,
+    });
+    const session = await sandbox.create(
+      new Manifest({
+        root: '/workspace',
+        entries: { 'snap.txt': { type: 'file', content: 'before' } },
+      }),
+    );
+
+    // Write a fresh file inside the live session so the captured tar must
+    // pick up state beyond the initial manifest.
+    await (
+      session as unknown as {
+        writeRemoteFile: (path: string, content: string) => Promise<void>;
+      }
+    ).writeRemoteFile('/workspace/fresh.txt', 'after');
+
+    await session.stop();
+    expect(session.state.workspaceTar).toBeTruthy();
+    expect(stub.client.pause.service).toHaveBeenCalled();
+
+    const serialized = await sandbox.serializeSessionState(session.state);
+    expect(typeof (serialized as { workspaceTar?: unknown }).workspaceTar).toBe(
+      'string',
+    );
+
+    // Simulate the workspace being wiped between pause and resume.
+    stub.files.delete('/workspace/snap.txt');
+    stub.files.delete('/workspace/fresh.txt');
+
+    stub.setServicePaused(true);
+    const restoredState = await sandbox.deserializeSessionState(
+      JSON.parse(JSON.stringify(serialized)),
+    );
+    const resumed = await sandbox.resume(restoredState);
+    expect(resumed.state.workspacePersistence).toBe('tar');
+    expect(stub.files.get('/workspace/snap.txt')?.toString('utf8')).toBe(
+      'before',
+    );
+    expect(stub.files.get('/workspace/fresh.txt')?.toString('utf8')).toBe(
+      'after',
+    );
+    // Snapshot consumed — subsequent serialize emits no workspaceTar.
+    expect(resumed.state.workspaceTar).toBeUndefined();
+  });
+
+  test('tar persistence: canPersistOwnedSessionState is true even without pauseOnExit', async () => {
+    const sandbox = makeSandbox(stub, { workspacePersistence: 'tar' });
+    const session = await sandbox.create(new Manifest());
+    expect(sandbox.canPersistOwnedSessionState(session.state)).toBe(true);
+  });
+
+  test('tar persistence: rejects archives containing absolute paths', async () => {
+    const sandbox = makeSandbox(stub, { workspacePersistence: 'tar' });
+    const session = await sandbox.create(new Manifest({ root: '/workspace' }));
+    stub.setTarListing('/etc/passwd\n');
+    stub.setTarVerbose('-rw-r--r-- 0/0 0 2025-01-01 00:00 /etc/passwd\n');
+    const restore = (
+      session as unknown as {
+        restoreWorkspaceFromTar: (b: string) => Promise<void>;
+      }
+    ).restoreWorkspaceFromTar(Buffer.from('any', 'utf8').toString('base64'));
+    await expect(restore).rejects.toMatchObject({
+      code: 'provider_error',
+      details: expect.objectContaining({
+        operation: 'validate workspace tar',
+      }),
+    });
+    await expect(restore).rejects.toThrow(/absolute path/);
+  });
+
+  test('tar persistence: rejects archives containing parent-traversal entries', async () => {
+    const sandbox = makeSandbox(stub, { workspacePersistence: 'tar' });
+    const session = await sandbox.create(new Manifest({ root: '/workspace' }));
+    stub.setTarListing('safe.txt\n../outside.txt\n');
+    stub.setTarVerbose(
+      '-rw-r--r-- 0/0 0 2025-01-01 00:00 safe.txt\n-rw-r--r-- 0/0 0 2025-01-01 00:00 ../outside.txt\n',
+    );
+    const restore = (
+      session as unknown as {
+        restoreWorkspaceFromTar: (b: string) => Promise<void>;
+      }
+    ).restoreWorkspaceFromTar(Buffer.from('any', 'utf8').toString('base64'));
+    await expect(restore).rejects.toThrow(/parent-traversal/);
+  });
+
+  test('tar persistence: rejects archives containing symlinks', async () => {
+    const sandbox = makeSandbox(stub, { workspacePersistence: 'tar' });
+    const session = await sandbox.create(new Manifest({ root: '/workspace' }));
+    stub.setTarListing('link\n');
+    stub.setTarVerbose(
+      'lrwxrwxrwx 0/0 0 2025-01-01 00:00 link -> /etc/passwd\n',
+    );
+    const restore = (
+      session as unknown as {
+        restoreWorkspaceFromTar: (b: string) => Promise<void>;
+      }
+    ).restoreWorkspaceFromTar(Buffer.from('any', 'utf8').toString('base64'));
+    await expect(restore).rejects.toThrow(/unsupported link entry/);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,10 +226,10 @@ importers:
         version: 1.1.3
       '@openai/agents':
         specifier: 0.3.9
-        version: 0.3.9(ws@8.18.2)(zod@3.25.76)
+        version: 0.3.9(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76)
       '@openai/agents-extensions':
         specifier: 0.3.9
-        version: 0.3.9(@openai/agents@0.3.9(ws@8.18.2)(zod@3.25.76))(@openai/codex-sdk@0.86.0)(ws@8.18.2)(zod@3.25.76)
+        version: 0.3.9(@openai/agents@0.3.9(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76))(@openai/codex-sdk@0.86.0)(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76)
       hono:
         specifier: ^4.12.16
         version: 4.12.16
@@ -244,7 +244,7 @@ importers:
         version: link:../../packages/agents
       openai:
         specifier: ^6.35.0
-        version: 6.35.0(ws@8.18.2)(zod@4.3.5)
+        version: 6.35.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.5)
       zod:
         specifier: ^4.0.0
         version: 4.3.5
@@ -289,7 +289,7 @@ importers:
         version: link:../../packages/agents-realtime
       openai:
         specifier: ^6.35.0
-        version: 6.35.0(ws@8.18.2)(zod@4.3.5)
+        version: 6.35.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.5)
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
@@ -357,7 +357,7 @@ importers:
         version: link:../../packages/agents
       openai:
         specifier: ^6.35.0
-        version: 6.35.0(ws@8.18.2)(zod@4.3.5)
+        version: 6.35.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.5)
       zod:
         specifier: ^4.0.0
         version: 4.3.5
@@ -436,7 +436,7 @@ importers:
         version: 4.1.10(vite@6.4.2(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       openai:
         specifier: ^6.35.0
-        version: 6.35.0(ws@8.18.2)(zod@4.3.5)
+        version: 6.35.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.5)
       tailwindcss:
         specifier: ^4.1.7
         version: 4.1.10
@@ -510,7 +510,7 @@ importers:
         version: 8.0.2
       '@fastify/websocket':
         specifier: ^11.1.0
-        version: 11.1.0
+        version: 11.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@openai/agents':
         specifier: workspace:*
         version: link:../../packages/agents
@@ -525,7 +525,7 @@ importers:
         version: 5.8.5
       ws:
         specifier: ^8.18.1
-        version: 8.18.2
+        version: 8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod:
         specifier: ^4.0.0
         version: 4.3.5
@@ -552,7 +552,7 @@ importers:
         version: 5.0.0
       openai:
         specifier: ^6.35.0
-        version: 6.35.0(ws@8.18.2)(zod@4.3.5)
+        version: 6.35.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.5)
       zod:
         specifier: ^4.0.0
         version: 4.3.5
@@ -597,7 +597,7 @@ importers:
         version: 5.6.2
       openai:
         specifier: ^6.35.0
-        version: 6.35.0(ws@8.18.2)(zod@4.3.5)
+        version: 6.35.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.5)
       playwright:
         specifier: ^1.55.1
         version: 1.57.0
@@ -621,7 +621,7 @@ importers:
         version: 4.4.1
       openai:
         specifier: ^6.35.0
-        version: 6.35.0(ws@8.18.2)(zod@4.3.5)
+        version: 6.35.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.5)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -637,7 +637,7 @@ importers:
         version: 4.4.1
       openai:
         specifier: ^6.35.0
-        version: 6.35.0(ws@8.18.2)(zod@4.3.5)
+        version: 6.35.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.5)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -667,13 +667,16 @@ importers:
         version: 3.0.2
       '@blaxel/core':
         specifier: 0.2.82
-        version: 0.2.82(@hey-api/openapi-ts@0.96.1(magicast@0.5.2)(typescript@5.9.3))(debug@4.4.1)
+        version: 0.2.82(@hey-api/openapi-ts@0.96.1(magicast@0.5.2)(typescript@5.9.3))(bufferutil@4.1.0)(debug@4.4.1)(utf-8-validate@6.0.6)
       '@daytonaio/sdk':
         specifier: 0.162.0
-        version: 0.162.0(debug@4.4.1)(ws@8.18.2)
+        version: 0.162.0(debug@4.4.1)(ws@8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@e2b/code-interpreter':
         specifier: 2.3.3
         version: 2.3.3
+      '@northflank/js-client':
+        specifier: 0.9.5
+        version: 0.9.5
       '@openai/agents':
         specifier: workspace:>=0.0.0
         version: link:../agents
@@ -703,7 +706,7 @@ importers:
         version: 6.21.0
       ws:
         specifier: ^8.18.1
-        version: 8.18.2
+        version: 8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod:
         specifier: ^4.0.0
         version: 4.3.5
@@ -718,7 +721,7 @@ importers:
         version: 4.4.1
       openai:
         specifier: ^6.35.0
-        version: 6.35.0(ws@8.18.2)(zod@4.3.5)
+        version: 6.35.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.5)
     devDependencies:
       '@ai-sdk/provider':
         specifier: ^1.1.3
@@ -743,7 +746,7 @@ importers:
         version: 4.4.1
       ws:
         specifier: ^8.18.1
-        version: 8.18.2
+        version: 8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -1964,6 +1967,10 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@northflank/js-client@0.9.5':
+    resolution: {integrity: sha512-yo8DvsuZnsQLczccYJJtQQ3KNjKeCUaQLNBIKgjDbYcRfz9qTt5E6Nb3SDvC6x0T3SsB6RZKliTjQ6iGJ/ST/g==}
+    engines: {node: '>=18.0.0'}
 
   '@openai/agents-core@0.3.9':
     resolution: {integrity: sha512-6Fr/VkA3lMaTT9EV2+OsmkMX9Yx+/PeWtlmaWNKDRG8D15IWuK13NOC9eFklTsa7otbuwbw/Xmjes+h4Z+CwSQ==}
@@ -3812,6 +3819,10 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
+  bufferutil@4.1.0:
+    resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
+    engines: {node: '>=6.14.2'}
+
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
@@ -4324,9 +4335,6 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
-
-  end-of-stream@1.4.4:
-    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -5451,6 +5459,9 @@ packages:
   lockfile@1.0.4:
     resolution: {integrity: sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
@@ -5820,21 +5831,12 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  minizlib@3.0.2:
-    resolution: {integrity: sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==}
-    engines: {node: '>= 18'}
-
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  mkdirp@3.0.1:
-    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -5934,6 +5936,10 @@ packages:
 
   node-gyp-build-optional-packages@5.1.1:
     resolution: {integrity: sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==}
+    hasBin: true
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
 
   node-mock-http@1.0.4:
@@ -6993,11 +6999,6 @@ packages:
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
-  tar@7.4.3:
-    resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
-    engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
   tar@7.5.13:
     resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
     engines: {node: '>=18'}
@@ -7095,6 +7096,10 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -7383,6 +7388,10 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  utf-8-validate@6.0.6:
+    resolution: {integrity: sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==}
+    engines: {node: '>=6.14.2'}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -7577,6 +7586,14 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
@@ -7614,6 +7631,18 @@ packages:
 
   ws@8.18.2:
     resolution: {integrity: sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -8394,7 +8423,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@blaxel/core@0.2.82(@hey-api/openapi-ts@0.96.1(magicast@0.5.2)(typescript@5.9.3))(debug@4.4.1)':
+  '@blaxel/core@0.2.82(@hey-api/openapi-ts@0.96.1(magicast@0.5.2)(typescript@5.9.3))(bufferutil@4.1.0)(debug@4.4.1)(utf-8-validate@6.0.6)':
     dependencies:
       '@hey-api/client-fetch': 0.10.2(@hey-api/openapi-ts@0.96.1(magicast@0.5.2)(typescript@5.9.3))
       '@modelcontextprotocol/sdk': 1.26.0(zod@3.25.76)
@@ -8406,7 +8435,7 @@ snapshots:
       jwt-decode: 4.0.0
       toml: 3.0.0
       uuid: 11.1.0
-      ws: 8.18.2
+      ws: 8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       yaml: 2.8.3
       zod: 3.25.76
     transitivePeerDependencies:
@@ -8642,7 +8671,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@daytonaio/sdk@0.162.0(debug@4.4.1)(ws@8.18.2)':
+  '@daytonaio/sdk@0.162.0(debug@4.4.1)(ws@8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@aws-sdk/client-s3': 3.1033.0
       '@aws-sdk/lib-storage': 3.1033.0(@aws-sdk/client-s3@3.1033.0)
@@ -8663,7 +8692,7 @@ snapshots:
       expand-tilde: 2.0.2
       fast-glob: 3.3.3
       form-data: 4.0.5
-      isomorphic-ws: 5.0.0(ws@8.18.2)
+      isomorphic-ws: 5.0.0(ws@8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       pathe: 2.0.3
       shell-quote: 1.8.3
       tar: 7.5.13
@@ -8937,11 +8966,11 @@ snapshots:
       '@fastify/forwarded': 3.0.1
       ipaddr.js: 2.3.0
 
-  '@fastify/websocket@11.1.0':
+  '@fastify/websocket@11.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       duplexify: 4.1.3
       fastify-plugin: 5.0.1
-      ws: 8.18.2
+      ws: 8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -9358,10 +9387,23 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@openai/agents-core@0.3.9(ws@8.18.2)(zod@3.25.76)':
+  '@northflank/js-client@0.9.5':
+    dependencies:
+      bufferutil: 4.1.0
+      lodash-es: 4.18.1
+      node-fetch: 2.6.7
+      pump: 3.0.4
+      tar: 7.5.13
+      utf-8-validate: 6.0.6
+      whatwg-url: 14.2.0
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - encoding
+
+  '@openai/agents-core@0.3.9(ws@8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76)':
     dependencies:
       debug: 4.4.3
-      openai: 6.35.0(ws@8.18.2)(zod@3.25.76)
+      openai: 6.35.0(ws@8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76)
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.26.0(zod@3.25.76)
       zod: 3.25.76
@@ -9370,14 +9412,26 @@ snapshots:
       - supports-color
       - ws
 
-  '@openai/agents-extensions@0.3.9(@openai/agents@0.3.9(ws@8.18.2)(zod@3.25.76))(@openai/codex-sdk@0.86.0)(ws@8.18.2)(zod@3.25.76)':
+  '@openai/agents-core@0.3.9(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76)':
+    dependencies:
+      debug: 4.4.3
+      openai: 6.35.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76)
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.26.0(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+      - ws
+
+  '@openai/agents-extensions@0.3.9(@openai/agents@0.3.9(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76))(@openai/codex-sdk@0.86.0)(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@openai/agents': 0.3.9(ws@8.18.2)(zod@3.25.76)
-      '@openai/agents-core': 0.3.9(ws@8.18.2)(zod@3.25.76)
+      '@openai/agents': 0.3.9(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@openai/agents-core': 0.3.9(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76)
       '@types/ws': 8.18.1
       debug: 4.4.3
-      ws: 8.18.2
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 3.25.76
     optionalDependencies:
       '@openai/codex-sdk': 0.86.0
@@ -9385,23 +9439,23 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@openai/agents-openai@0.3.9(ws@8.18.2)(zod@3.25.76)':
+  '@openai/agents-openai@0.3.9(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76)':
     dependencies:
-      '@openai/agents-core': 0.3.9(ws@8.18.2)(zod@3.25.76)
+      '@openai/agents-core': 0.3.9(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76)
       debug: 4.4.3
-      openai: 6.35.0(ws@8.18.2)(zod@3.25.76)
+      openai: 6.35.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
       - ws
 
-  '@openai/agents-realtime@0.3.9(zod@3.25.76)':
+  '@openai/agents-realtime@0.3.9(bufferutil@4.1.0)(utf-8-validate@6.0.6)(zod@3.25.76)':
     dependencies:
-      '@openai/agents-core': 0.3.9(ws@8.18.2)(zod@3.25.76)
+      '@openai/agents-core': 0.3.9(ws@8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76)
       '@types/ws': 8.18.1
       debug: 4.4.3
-      ws: 8.18.2
+      ws: 8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -9409,13 +9463,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@openai/agents@0.3.9(ws@8.18.2)(zod@3.25.76)':
+  '@openai/agents@0.3.9(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76)':
     dependencies:
-      '@openai/agents-core': 0.3.9(ws@8.18.2)(zod@3.25.76)
-      '@openai/agents-openai': 0.3.9(ws@8.18.2)(zod@3.25.76)
-      '@openai/agents-realtime': 0.3.9(zod@3.25.76)
+      '@openai/agents-core': 0.3.9(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@openai/agents-openai': 0.3.9(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@openai/agents-realtime': 0.3.9(bufferutil@4.1.0)(utf-8-validate@6.0.6)(zod@3.25.76)
       debug: 4.4.3
-      openai: 6.26.0(ws@8.18.2)(zod@3.25.76)
+      openai: 6.26.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -10607,7 +10661,7 @@ snapshots:
   '@tailwindcss/oxide@4.1.10':
     dependencies:
       detect-libc: 2.1.1
-      tar: 7.4.3
+      tar: 7.5.13
     optionalDependencies:
       '@tailwindcss/oxide-android-arm64': 4.1.10
       '@tailwindcss/oxide-darwin-arm64': 4.1.10
@@ -11489,6 +11543,10 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bufferutil@4.1.0:
+    dependencies:
+      node-gyp-build: 4.8.4
+
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
@@ -11924,7 +11982,7 @@ snapshots:
 
   duplexify@4.1.3:
     dependencies:
-      end-of-stream: 1.4.4
+      end-of-stream: 1.4.5
       inherits: 2.0.4
       readable-stream: 3.6.2
       stream-shift: 1.0.3
@@ -11967,10 +12025,6 @@ snapshots:
   empathic@2.0.0: {}
 
   encodeurl@2.0.0: {}
-
-  end-of-stream@1.4.4:
-    dependencies:
-      once: 1.4.0
 
   end-of-stream@1.4.5:
     dependencies:
@@ -13107,9 +13161,9 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isomorphic-ws@5.0.0(ws@8.18.2):
+  isomorphic-ws@5.0.0(ws@8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
-      ws: 8.18.2
+      ws: 8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   isstream@0.1.2: {}
 
@@ -13356,6 +13410,8 @@ snapshots:
   lockfile@1.0.4:
     dependencies:
       signal-exit: 3.0.7
+
+  lodash-es@4.18.1: {}
 
   lodash.camelcase@4.3.0: {}
 
@@ -13993,17 +14049,11 @@ snapshots:
 
   minipass@7.1.3: {}
 
-  minizlib@3.0.2:
-    dependencies:
-      minipass: 7.1.3
-
   minizlib@3.1.0:
     dependencies:
       minipass: 7.1.3
 
   mkdirp@1.0.4: {}
-
-  mkdirp@3.0.1: {}
 
   modal@0.7.4:
     dependencies:
@@ -14115,6 +14165,8 @@ snapshots:
       detect-libc: 2.1.2
     optional: true
 
+  node-gyp-build@4.8.4: {}
+
   node-mock-http@1.0.4: {}
 
   normalize-path@3.0.0: {}
@@ -14181,19 +14233,24 @@ snapshots:
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
 
-  openai@6.26.0(ws@8.18.2)(zod@3.25.76):
+  openai@6.26.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76):
     optionalDependencies:
-      ws: 8.18.2
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 3.25.76
 
-  openai@6.35.0(ws@8.18.2)(zod@3.25.76):
+  openai@6.35.0(ws@8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76):
     optionalDependencies:
-      ws: 8.18.2
+      ws: 8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 3.25.76
 
-  openai@6.35.0(ws@8.18.2)(zod@4.3.5):
+  openai@6.35.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76):
     optionalDependencies:
-      ws: 8.18.2
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      zod: 3.25.76
+
+  openai@6.35.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.5):
+    optionalDependencies:
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 4.3.5
 
   openapi-fetch@0.14.1:
@@ -15406,15 +15463,6 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  tar@7.4.3:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.3
-      minizlib: 3.0.2
-      mkdirp: 3.0.1
-      yallist: 5.0.0
-
   tar@7.5.13:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
@@ -15501,6 +15549,10 @@ snapshots:
       tldts: 6.1.86
 
   tr46@0.0.3: {}
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -15742,6 +15794,10 @@ snapshots:
     dependencies:
       react: 19.2.3
 
+  utf-8-validate@6.0.6:
+    dependencies:
+      node-gyp-build: 4.8.4
+
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
@@ -15951,6 +16007,13 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
+  webidl-conversions@7.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
@@ -15985,7 +16048,15 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.18.2: {}
+  ws@8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
+
+  ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
 
   wsl-utils@0.3.1:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,11 @@ const testAliases = {
     rootDir,
     'packages/agents-core/src/sandbox/index.ts',
   ),
+  '@openai/agents-core/_shims': resolve(
+    rootDir,
+    'packages/agents-core/src/shims/shims-node.ts',
+  ),
+  '@openai/agents-core': resolve(rootDir, 'packages/agents-core/src/index.ts'),
 };
 
 const baseTestConfig = {


### PR DESCRIPTION
This pull request adds Northflank support to the `@openai/agents-extensions` package.

## What is included

- `@openai/agents-extensions/sandbox/northflank`
  - `NorthflankSandboxClient`
  - Provisions one Northflank deployment service per sandbox session.
  - Implements the remote sandbox primitives through `RemoteSandboxSessionBase`.
  - Supports shell execution, file read/write, manifest materialization, `apply_patch`, `view_image`, pause/resume, and cleanup.
  - Pins exec and file-copy calls to the resolved running container instance.
  - Optional `workspacePersistence: 'volume' | 'tar'` keeps the workspace across pause/resume — either via a mounted Northflank volume or an in-state tar snapshot. See [Workspace persistence](#workspace-persistence).

- `@openai/agents-extensions/northflank`
  - `northflankTools(client, options)` for curated Northflank function tools.
  - `NorthflankShell` for use with `shellTool`.
  - Tools cover read, deploy, exec, file copy, logs, metrics, and optional secrets metadata.

`@northflank/js-client` is added as an optional peer dependency.

## Usage

```ts
import { Runner } from '@openai/agents';
import { Manifest, SandboxAgent, shell } from '@openai/agents/sandbox';
import { NorthflankSandboxClient } from '@openai/agents-extensions/sandbox/northflank';

const client = new NorthflankSandboxClient({
  apiToken: process.env.NF_API_TOKEN!,
  projectId: process.env.NF_PROJECT_ID!,
  image: 'docker.io/library/ubuntu:24.04',
  docker: { customEntrypoint: 'sleep', customCommand: 'infinity' },
});

const agent = new SandboxAgent({
  name: 'Northflank Sandbox Assistant',
  defaultManifest: new Manifest({
    root: '/workspace',
    entries: {
      'README.md': { type: 'file', content: '# Hello from Northflank\n' },
    },
  }),
  capabilities: [shell()],
});

const runner = new Runner({
  sandbox: { client },
});

const result = await runner.run(agent, 'Inspect the workspace.');
console.log(result.finalOutput);
```

## Workspace persistence

By default, sessions use ephemeral pod storage and the manifest is re-materialized on every `create()`. Set `workspacePersistence` on `NorthflankSandboxClient` to keep the workspace across pause/resume:

### `'volume'` — Northflank volume mounted at `workspaceRoot`

```ts
new NorthflankSandboxClient({
  apiToken: process.env.NF_API_TOKEN!,
  projectId: process.env.NF_PROJECT_ID!,
  image: 'docker.io/library/ubuntu:24.04',
  workspacePersistence: 'volume',
  // Optional — defaults shown below.
  volumeSpec: {
    storageSize: 5120,
    accessMode: 'ReadWriteMany',
    storageClassName: 'nf-multi-rw',
  },
  pauseOnExit: true,
});
```

A 5 GB `ReadWriteMany` volume on the `nf-multi-rw` storage class is provisioned by default, attached to the service, and mounted at `workspaceRoot`. (`nf-multi-rw` enforces a 5 GB minimum on Northflank's standard cluster.) Pass `volumeId` to reuse an existing volume (the caller owns it; it is never deleted). Provider-created volumes are detached then deleted by `session.delete()`.

### `'tar'` — workspace snapshotted into session state

```ts
new NorthflankSandboxClient({
  apiToken: process.env.NF_API_TOKEN!,
  projectId: process.env.NF_PROJECT_ID!,
  image: 'docker.io/library/ubuntu:24.04',
  workspacePersistence: 'tar',
  pauseOnExit: true,
});
```

`stop()` tars `workspaceRoot` and base64-encodes the archive into `state.workspaceTar`; `serializeSessionState` round-trips it; `resume()` re-extracts. Convenient for small workspaces; bounded by whatever your runtime is willing to round-trip through session state.

## Example

```zsh
git clone https://github.com/openai/openai-agents-js
cd openai-agents-js
pnpm i
pnpm build

OPENAI_API_KEY=... \
NF_API_TOKEN=... \
NF_PROJECT_ID=... \
pnpm -F sandbox start:northflank

# With workspace persistence:
OPENAI_API_KEY=... NF_API_TOKEN=... NF_PROJECT_ID=... \
  pnpm -F sandbox start:northflank --persistence volume --pause-on-exit
```

## Checks

```zsh
pnpm --filter @openai/agents-extensions build
pnpm --filter @openai/agents-extensions build-check
pnpm vitest run packages/agents-extensions/test/northflank packages/agents-extensions/test/sandbox/northflank.test.ts
pnpm vitest run packages/agents-extensions/test/sandbox/
```
