### PR TITLE
feat: add opt-in recovery for missing function tools

### DIFF
--- a/.changeset/missing-function-tool-recovery.md
+++ b/.changeset/missing-function-tool-recovery.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+feat: add opt-in recovery for missing function tools

--- a/packages/agents-core/src/agentToolRunConfig.ts
+++ b/packages/agents-core/src/agentToolRunConfig.ts
@@ -281,6 +281,10 @@ export function getInheritedAgentToolRunConfig(
   if (typeof parentRunConfig.toolExecution !== 'undefined') {
     inheritedRunConfig.toolExecution = parentRunConfig.toolExecution;
   }
+  if (typeof parentRunConfig.toolNotFoundBehavior !== 'undefined') {
+    inheritedRunConfig.toolNotFoundBehavior =
+      parentRunConfig.toolNotFoundBehavior;
+  }
 
   return Object.keys(inheritedRunConfig).length > 0
     ? inheritedRunConfig

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -182,6 +182,8 @@ export type {
   ToolErrorFormatter,
   ToolErrorFormatterArgs,
   ToolExecutionConfig,
+  ToolNotFoundBehavior,
+  ToolErrorKind,
   ReasoningItemIdPolicy,
   RunErrorData,
   RunErrorHandler,

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -140,9 +140,11 @@ function getImplicitModelSettingsForResolvedModel(
 //  Configuration
 // --------------------------------------------------------------
 
+export type ToolErrorKind = 'approval_rejected' | 'tool_not_found';
+
 export type ToolErrorFormatterArgs<
   TContext = unknown,
-  TKind extends 'approval_rejected' = 'approval_rejected',
+  TKind extends ToolErrorKind = ToolErrorKind,
 > = {
   /**
    * The category of tool error being formatted.
@@ -185,6 +187,8 @@ export type ToolExecutionConfig = {
    */
   maxFunctionToolConcurrency?: number | null;
 };
+
+export type ToolNotFoundBehavior = 'raise_error' | 'return_error_to_model';
 
 function validateToolExecutionConfig(
   config: ToolExecutionConfig | undefined,
@@ -289,6 +293,14 @@ export type RunConfig = {
   toolExecution?: ToolExecutionConfig;
 
   /**
+   * Controls unresolved function tool calls emitted by the model.
+   *
+   * - `raise_error` preserves the default behavior and raises a `ModelBehaviorError`.
+   * - `return_error_to_model` returns a model-visible tool error and lets the run continue.
+   */
+  toolNotFoundBehavior?: ToolNotFoundBehavior;
+
+  /**
    * Customizes how session history is combined with the current turn's input.
    * When omitted, history items are appended before the new input.
    */
@@ -332,6 +344,7 @@ type SharedRunOptions<
   tracing?: TracingConfig;
   sandbox?: SandboxRunConfig;
   toolExecution?: ToolExecutionConfig;
+  toolNotFoundBehavior?: ToolNotFoundBehavior;
   /**
    * Error handlers keyed by error kind.
    */
@@ -446,6 +459,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       tracing: config.tracing,
       sandbox: config.sandbox,
       toolExecution: validateToolExecutionConfig(config.toolExecution),
+      toolNotFoundBehavior: config.toolNotFoundBehavior ?? 'raise_error',
       sessionInputCallback: config.sessionInputCallback,
       callModelInputFilter: config.callModelInputFilter,
       toolErrorFormatter: config.toolErrorFormatter,
@@ -530,6 +544,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     const toolExecution = validateToolExecutionConfig(
       resolvedOptions.toolExecution ?? this.config.toolExecution,
     );
+    const toolNotFoundBehavior =
+      resolvedOptions.toolNotFoundBehavior ?? this.config.toolNotFoundBehavior;
     const hasCallModelInputFilter = Boolean(callModelInputFilter);
     const tracingConfig = resolvedOptions.tracing ?? this.config.tracing;
     const traceOverrides = {
@@ -545,6 +561,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       toolErrorFormatter,
       reasoningItemIdPolicy,
       toolExecution,
+      toolNotFoundBehavior,
     };
     const resumingFromState = input instanceof RunState;
     const preserveTurnPersistenceOnResume =
@@ -731,7 +748,13 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     const hasSandboxOverride = typeof options.sandbox !== 'undefined';
     const hasToolExecutionOverride =
       typeof options.toolExecution !== 'undefined';
-    if (!hasSandboxOverride && !hasToolExecutionOverride) {
+    const hasToolNotFoundBehaviorOverride =
+      typeof options.toolNotFoundBehavior !== 'undefined';
+    if (
+      !hasSandboxOverride &&
+      !hasToolExecutionOverride &&
+      !hasToolNotFoundBehaviorOverride
+    ) {
       return this.config;
     }
     return {
@@ -739,6 +762,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       ...(hasSandboxOverride ? { sandbox: options.sandbox } : {}),
       ...(hasToolExecutionOverride
         ? { toolExecution: options.toolExecution }
+        : {}),
+      ...(hasToolNotFoundBehaviorOverride
+        ? { toolNotFoundBehavior: options.toolNotFoundBehavior }
         : {}),
     };
   }
@@ -998,6 +1024,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               preparedCall.handoffs,
               state,
               [...preparedCall.turnInput, ...state._generatedItems],
+              options.toolNotFoundBehavior,
             );
 
             state._lastProcessedResponse = processedResponse;
@@ -1506,6 +1533,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             preparedCall.handoffs,
             result.state,
             [...preparedCall.turnInput, ...result.state._generatedItems],
+            options.toolNotFoundBehavior,
           );
 
           result.state._lastProcessedResponse = processedResponse;

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -1058,6 +1058,7 @@ function assertSchemaVersionSupportsToolSearch(
     schemaVersion === '1.8' ||
     schemaVersion === '1.9' ||
     schemaVersion === '1.10' ||
+    schemaVersion === '1.11' ||
     schemaVersion === CURRENT_SCHEMA_VERSION
   ) {
     return;
@@ -1075,7 +1076,11 @@ function assertSchemaVersionSupportsToolSearch(
 function schemaVersionSupportsAgentIdentity(
   schemaVersion: SupportedSchemaVersion,
 ): boolean {
-  return schemaVersion === '1.10' || schemaVersion === CURRENT_SCHEMA_VERSION;
+  return (
+    schemaVersion === '1.10' ||
+    schemaVersion === '1.11' ||
+    schemaVersion === CURRENT_SCHEMA_VERSION
+  );
 }
 
 function containsSerializedToolSearchState(

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -89,8 +89,9 @@ import {
  * - 1.10: Adds optional stable agent identity keys so duplicate-name agent graphs can
  *   serialize and resume without ambiguous name resolution.
  * - 1.11: Allows null maxTurns to persist runs without a turn limit.
+ * - 1.12: Adds optional missing function tool calls to processed responses.
  */
-export const CURRENT_SCHEMA_VERSION = '1.11' as const;
+export const CURRENT_SCHEMA_VERSION = '1.12' as const;
 const SUPPORTED_SCHEMA_VERSIONS = [
   '1.0',
   '1.1',
@@ -103,6 +104,7 @@ const SUPPORTED_SCHEMA_VERSIONS = [
   '1.8',
   '1.9',
   '1.10',
+  '1.11',
   CURRENT_SCHEMA_VERSION,
 ] as const;
 type SupportedSchemaVersion = (typeof SUPPORTED_SCHEMA_VERSIONS)[number];
@@ -285,6 +287,14 @@ const serializedProcessedResponseSchema = z.object({
       tool: z.any(),
     }),
   ),
+  functionToolsNotFound: z
+    .array(
+      z.object({
+        toolCall: z.any(),
+        toolName: z.string(),
+      }),
+    )
+    .optional(),
   computerActions: z.array(
     z.object({
       toolCall: z.any(),
@@ -2305,6 +2315,8 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
         };
       }),
     ),
+    functionToolsNotFound:
+      serializedProcessedResponse.functionToolsNotFound ?? [],
     computerActions: serializedProcessedResponse.computerActions.map(
       (computerAction) => {
         const toolName = computerAction.computer.name;
@@ -2389,6 +2401,7 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
       return (
         result.handoffs.length > 0 ||
         result.functions.length > 0 ||
+        result.functionToolsNotFound.length > 0 ||
         result.mcpApprovalRequests.length > 0 ||
         result.computerActions.length > 0 ||
         result.shellActions.length > 0 ||

--- a/packages/agents-core/src/runner/modelOutputs.ts
+++ b/packages/agents-core/src/runner/modelOutputs.ts
@@ -192,8 +192,10 @@ function recordMissingFunctionTool(
   toolName: string,
   agent: Agent<any, any>,
   items: RunItem[],
+  toolsUsed: string[],
   functionToolsNotFound: ToolRunFunctionNotFound[],
 ): void {
+  toolsUsed.push(toolName);
   items.push(new RunToolCallItem(output, agent));
   functionToolsNotFound.push({
     toolCall: output,
@@ -877,6 +879,7 @@ export function processModelResponse<TContext>(
         resolved.toolName,
         agent,
         items,
+        toolsUsed,
         functionToolsNotFound,
       );
     } else if (resolved.type === 'handoff') {
@@ -1193,6 +1196,7 @@ export async function processModelResponseAsync<TContext>(
         resolved.toolName,
         agent,
         items,
+        toolsUsed,
         functionToolsNotFound,
       );
     } else if (resolved.type === 'handoff') {

--- a/packages/agents-core/src/runner/modelOutputs.ts
+++ b/packages/agents-core/src/runner/modelOutputs.ts
@@ -44,10 +44,12 @@ import type {
   ToolRunApplyPatch,
   ToolRunComputer,
   ToolRunFunction,
+  ToolRunFunctionNotFound,
   ToolRunHandoff,
   ToolRunMCPApprovalRequest,
   ToolRunShell,
 } from './types';
+import type { ToolNotFoundBehavior } from '../run';
 import * as protocol from '../types/protocol';
 import {
   addHostedMcpToolsFromToolSearchOutput,
@@ -133,7 +135,8 @@ function resolveFunctionOrHandoff(
   agent: Agent<any, any>,
 ):
   | { type: 'handoff'; handoff: Handoff<any, any> }
-  | { type: 'function'; tool: FunctionTool<any> } {
+  | { type: 'function'; tool: FunctionTool<any> }
+  | { type: 'not_found'; toolName: string } {
   const resolvedToolName =
     resolveFunctionToolCallName(toolCall, functionMap) ?? toolCall.name;
   const namespace = getToolCallNamespace(toolCall);
@@ -163,18 +166,39 @@ function resolveFunctionOrHandoff(
 
   const functionTool = functionMap.get(resolvedToolName);
   if (!functionTool) {
-    const message = `Tool ${resolvedToolName} not found in agent ${agent.name}.`;
-    addErrorToCurrentSpan({
-      message,
-      data: {
-        tool_name: resolvedToolName,
-        agent_name: agent.name,
-      },
-    });
-
-    throw new ModelBehaviorError(message);
+    return { type: 'not_found', toolName: resolvedToolName };
   }
   return { type: 'function', tool: functionTool };
+}
+
+function throwFunctionToolNotFound(
+  toolName: string,
+  agent: Agent<any, any>,
+): never {
+  const message = `Tool ${toolName} not found in agent ${agent.name}.`;
+  addErrorToCurrentSpan({
+    message,
+    data: {
+      tool_name: toolName,
+      agent_name: agent.name,
+    },
+  });
+
+  throw new ModelBehaviorError(message);
+}
+
+function recordMissingFunctionTool(
+  output: protocol.FunctionCallItem,
+  toolName: string,
+  agent: Agent<any, any>,
+  items: RunItem[],
+  functionToolsNotFound: ToolRunFunctionNotFound[],
+): void {
+  items.push(new RunToolCallItem(output, agent));
+  functionToolsNotFound.push({
+    toolCall: output,
+    toolName,
+  });
 }
 
 function normalizeFunctionToolCallForStorage(
@@ -631,10 +655,12 @@ export function processModelResponse<TContext>(
   tools: Tool<TContext>[],
   handoffs: Handoff<any, any>[],
   priorItems: Array<RunItem | AgentInputItem> = [],
+  toolNotFoundBehavior: ToolNotFoundBehavior = 'raise_error',
 ): ProcessedResponse<TContext> {
   const items: RunItem[] = [];
   const runHandoffs: ToolRunHandoff[] = [];
   const runFunctions: ToolRunFunction<TContext>[] = [];
+  const functionToolsNotFound: ToolRunFunctionNotFound[] = [];
   const runComputerActions: ToolRunComputer[] = [];
   const runShellActions: ToolRunShell[] = [];
   let hasHostedShellCall = false;
@@ -842,7 +868,18 @@ export function processModelResponse<TContext>(
       functionMap,
       agent,
     );
-    if (resolved.type === 'handoff') {
+    if (resolved.type === 'not_found') {
+      if (toolNotFoundBehavior !== 'return_error_to_model') {
+        throwFunctionToolNotFound(resolved.toolName, agent);
+      }
+      recordMissingFunctionTool(
+        output,
+        resolved.toolName,
+        agent,
+        items,
+        functionToolsNotFound,
+      );
+    } else if (resolved.type === 'handoff') {
       recordHandoffRequest(
         output,
         resolved.handoff,
@@ -877,6 +914,7 @@ export function processModelResponse<TContext>(
     newItems: items,
     handoffs: runHandoffs,
     functions: runFunctions,
+    functionToolsNotFound,
     computerActions: runComputerActions,
     shellActions: runShellActions,
     applyPatchActions: runApplyPatchActions,
@@ -886,6 +924,7 @@ export function processModelResponse<TContext>(
       return (
         runHandoffs.length > 0 ||
         runFunctions.length > 0 ||
+        functionToolsNotFound.length > 0 ||
         runMCPApprovalRequests.length > 0 ||
         runComputerActions.length > 0 ||
         runShellActions.length > 0 ||
@@ -904,6 +943,7 @@ export async function processModelResponseAsync<TContext>(
   handoffs: Handoff<any, any>[],
   state: RunState<TContext, Agent<any, any>>,
   priorItems: Array<RunItem | AgentInputItem> = [],
+  toolNotFoundBehavior: ToolNotFoundBehavior = 'raise_error',
 ): Promise<ProcessedResponse<TContext>> {
   const clientToolSearchTool = getClientToolSearchHelper(tools);
   const hasCustomClientToolSearchExecutor = Boolean(
@@ -923,12 +963,14 @@ export async function processModelResponseAsync<TContext>(
       tools,
       handoffs,
       priorItems,
+      toolNotFoundBehavior,
     );
   }
 
   const items: RunItem[] = [];
   const runHandoffs: ToolRunHandoff[] = [];
   const runFunctions: ToolRunFunction<TContext>[] = [];
+  const functionToolsNotFound: ToolRunFunctionNotFound[] = [];
   const runComputerActions: ToolRunComputer[] = [];
   const runShellActions: ToolRunShell[] = [];
   let hasHostedShellCall = false;
@@ -1142,7 +1184,18 @@ export async function processModelResponseAsync<TContext>(
       functionMap,
       agent,
     );
-    if (resolved.type === 'handoff') {
+    if (resolved.type === 'not_found') {
+      if (toolNotFoundBehavior !== 'return_error_to_model') {
+        throwFunctionToolNotFound(resolved.toolName, agent);
+      }
+      recordMissingFunctionTool(
+        output,
+        resolved.toolName,
+        agent,
+        items,
+        functionToolsNotFound,
+      );
+    } else if (resolved.type === 'handoff') {
       recordHandoffRequest(
         output,
         resolved.handoff,
@@ -1177,6 +1230,7 @@ export async function processModelResponseAsync<TContext>(
     newItems: items,
     handoffs: runHandoffs,
     functions: runFunctions,
+    functionToolsNotFound,
     computerActions: runComputerActions,
     shellActions: runShellActions,
     applyPatchActions: runApplyPatchActions,
@@ -1186,6 +1240,7 @@ export async function processModelResponseAsync<TContext>(
       return (
         runHandoffs.length > 0 ||
         runFunctions.length > 0 ||
+        functionToolsNotFound.length > 0 ||
         runMCPApprovalRequests.length > 0 ||
         runComputerActions.length > 0 ||
         runShellActions.length > 0 ||

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -727,10 +727,16 @@ export async function resolveInterruptedTurn<TContext>(
           toolErrorFormatter,
         })
       : [];
+  const pendingFunctionToolsNotFound = filterPendingActions(
+    processedResponse.functionToolsNotFound ?? [],
+    {
+      completedCallIds: completedFunctionCallIds,
+    },
+  );
   const toolNotFoundResults = await buildToolNotFoundOutputItems(
     agent,
     state,
-    processedResponse.functionToolsNotFound ?? [],
+    pendingFunctionToolsNotFound,
     toolErrorFormatter,
   );
 

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { Agent } from '../agent';
 import { ModelBehaviorError, ModelRefusalError } from '../errors';
-import { RunItem, RunMessageOutputItem, RunToolApprovalItem } from '../items';
+import {
+  RunItem,
+  RunMessageOutputItem,
+  RunToolApprovalItem,
+  RunToolCallOutputItem,
+} from '../items';
+import logger from '../logger';
 import { ModelResponse } from '../model';
 import type { RunConfig, Runner, ToolErrorFormatter } from '../run';
 import { RunState } from '../runState';
@@ -17,6 +23,7 @@ import type {
   ProcessedResponse,
   ToolRunApplyPatch,
   ToolRunHandoff,
+  ToolRunFunctionNotFound,
   ToolRunShell,
 } from './types';
 import {
@@ -27,6 +34,7 @@ import {
   executeHandoffCalls,
   executeShellActions,
   collectInterruptions,
+  getToolCallOutputItem,
 } from './toolExecution';
 import { handleHostedMcpApprovals } from './mcpApprovals';
 import * as ProviderData from '../types/providerData';
@@ -41,6 +49,71 @@ import {
   resolveRunErrorHandler,
 } from './errorHandlers';
 import { getTurnInput } from './items';
+
+const DEFAULT_TOOL_NOT_FOUND_MESSAGE = (toolName: string) =>
+  `Tool '${toolName}' not found.`;
+
+async function resolveToolNotFoundMessage<TContext>(
+  state: RunState<TContext, Agent<TContext, any>>,
+  toolRun: ToolRunFunctionNotFound,
+  toolErrorFormatter?: ToolErrorFormatter<TContext>,
+): Promise<string> {
+  const defaultMessage = DEFAULT_TOOL_NOT_FOUND_MESSAGE(toolRun.toolName);
+  if (!toolErrorFormatter) {
+    return defaultMessage;
+  }
+
+  try {
+    const formattedMessage = await toolErrorFormatter({
+      kind: 'tool_not_found',
+      toolType: 'function',
+      toolName: toolRun.toolName,
+      callId: toolRun.toolCall.callId,
+      defaultMessage,
+      runContext: state._context,
+    });
+
+    if (typeof formattedMessage === 'string') {
+      return formattedMessage;
+    }
+    if (typeof formattedMessage !== 'undefined') {
+      logger.warn(
+        'toolErrorFormatter returned a non-string value. Falling back to the default tool not found message.',
+      );
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.warn(
+      `toolErrorFormatter threw while formatting tool not found: ${message}`,
+    );
+  }
+
+  return defaultMessage;
+}
+
+async function buildToolNotFoundOutputItems<TContext>(
+  agent: Agent<TContext, any>,
+  state: RunState<TContext, Agent<TContext, any>>,
+  toolRuns: ToolRunFunctionNotFound[],
+  toolErrorFormatter?: ToolErrorFormatter<TContext>,
+): Promise<RunToolCallOutputItem[]> {
+  const items: RunToolCallOutputItem[] = [];
+  for (const toolRun of toolRuns) {
+    const message = await resolveToolNotFoundMessage(
+      state,
+      toolRun,
+      toolErrorFormatter,
+    );
+    items.push(
+      new RunToolCallOutputItem(
+        getToolCallOutputItem(toolRun.toolCall, message),
+        agent,
+        message,
+      ),
+    );
+  }
+  return items;
+}
 
 type ApprovalItemLike =
   | RunToolApprovalItem
@@ -654,6 +727,12 @@ export async function resolveInterruptedTurn<TContext>(
           toolErrorFormatter,
         })
       : [];
+  const toolNotFoundResults = await buildToolNotFoundOutputItems(
+    agent,
+    state,
+    processedResponse.functionToolsNotFound ?? [],
+    toolErrorFormatter,
+  );
 
   const newItems: RunItem[] = [];
   const appendContext = buildAppendContext(originalPreStepItems);
@@ -669,6 +748,10 @@ export async function resolveInterruptedTurn<TContext>(
       continue;
     }
     appendIfNew(result.runItem);
+  }
+
+  for (const result of toolNotFoundResults) {
+    appendIfNew(result);
   }
 
   for (const result of computerResults) {
@@ -848,6 +931,12 @@ export async function resolveTurnAfterModelResponse<
           toolErrorFormatter,
         })
       : [];
+  const toolNotFoundResults = await buildToolNotFoundOutputItems(
+    agent,
+    state,
+    processedResponse.functionToolsNotFound ?? [],
+    toolErrorFormatter,
+  );
 
   for (const result of functionResults) {
     if (
@@ -858,6 +947,9 @@ export async function resolveTurnAfterModelResponse<
       continue;
     }
     appendIfNew(result.runItem);
+  }
+  for (const item of toolNotFoundResults) {
+    appendIfNew(item);
   }
   for (const item of computerResults) {
     appendIfNew(item);

--- a/packages/agents-core/src/runner/types.ts
+++ b/packages/agents-core/src/runner/types.ts
@@ -29,6 +29,11 @@ export type ToolRunFunction<TContext = UnknownContext> = {
   tool: FunctionTool<TContext>;
 };
 
+export type ToolRunFunctionNotFound = {
+  toolCall: protocol.FunctionCallItem;
+  toolName: string;
+};
+
 export type ToolRunComputer = {
   toolCall: protocol.ComputerUseCallItem;
   computer: ComputerTool<any, any>;
@@ -53,6 +58,7 @@ export type ProcessedResponse<TContext = UnknownContext> = {
   newItems: RunItem[];
   handoffs: ToolRunHandoff[];
   functions: ToolRunFunction<TContext>[];
+  functionToolsNotFound?: ToolRunFunctionNotFound[];
   computerActions: ToolRunComputer[];
   shellActions: ToolRunShell[];
   applyPatchActions: ToolRunApplyPatch[];

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -32,6 +32,7 @@ import {
 import {
   FakeModel,
   FakeModelProvider,
+  TEST_MODEL_FUNCTION_CALL,
   fakeModelMessage,
   fakeModelRefusal,
 } from './stubs';
@@ -234,6 +235,87 @@ describe('Runner.run (streaming)', () => {
 
     await result.completed;
     expect(result.finalOutput).toBe('The package arrives tomorrow.');
+  });
+
+  it('streams through missing function tool errors when opted in', async () => {
+    class RecordingStreamingModel implements Model {
+      readonly requests: ModelRequest[] = [];
+
+      constructor(private readonly responses: ModelResponse[]) {}
+
+      async getResponse(request: ModelRequest): Promise<ModelResponse> {
+        this.requests.push(request);
+        const response = this.responses.shift();
+        if (!response) {
+          throw new Error('No response found');
+        }
+        return response;
+      }
+
+      async *getStreamedResponse(
+        request: ModelRequest,
+      ): AsyncIterable<StreamEvent> {
+        const response = await this.getResponse(request);
+        yield {
+          type: 'response_done',
+          response: {
+            id: response.responseId ?? 'resp-stream-missing-tool',
+            usage: {
+              requests: response.usage.requests,
+              inputTokens: response.usage.inputTokens,
+              outputTokens: response.usage.outputTokens,
+              totalTokens: response.usage.totalTokens,
+            },
+            output: response.output.map((item) =>
+              protocol.OutputModelItem.parse(item),
+            ),
+          },
+        } satisfies StreamEvent;
+      }
+    }
+
+    const model = new RecordingStreamingModel([
+      {
+        output: [
+          {
+            ...TEST_MODEL_FUNCTION_CALL,
+            name: 'missing_tool',
+            callId: 'call_missing',
+            arguments: '{}',
+          },
+        ],
+        usage: new Usage(),
+      },
+      {
+        output: [fakeModelMessage('stream recovered')],
+        usage: new Usage(),
+      },
+    ]);
+    const agent = new Agent({
+      name: 'StreamingMissingToolAgent',
+      model,
+      toolUseBehavior: 'run_llm_again',
+    });
+
+    const result = await run(agent, 'start', {
+      stream: true,
+      toolNotFoundBehavior: 'return_error_to_model',
+    });
+
+    await result.completed;
+    expect(result.finalOutput).toBe('stream recovered');
+    expect(model.requests).toHaveLength(2);
+    const secondInput = model.requests[1].input as AgentInputItem[];
+    expect(secondInput).toContainEqual({
+      type: 'function_call_result',
+      name: 'missing_tool',
+      callId: 'call_missing',
+      status: 'completed',
+      output: {
+        type: 'text',
+        text: "Tool 'missing_tool' not found.",
+      },
+    });
   });
 
   it('detaches abort listeners after streaming completion when signal is retained', async () => {

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -179,6 +179,7 @@ describe('Runner.run', () => {
       const agent = new Agent({
         name: 'MissingToolAgent',
         model,
+        modelSettings: { toolChoice: 'required' },
         toolUseBehavior: 'run_llm_again',
       });
 
@@ -188,6 +189,8 @@ describe('Runner.run', () => {
 
       expect(result.finalOutput).toBe('recovered');
       expect(model.requests).toHaveLength(2);
+      expect(model.requests[0].modelSettings.toolChoice).toBe('required');
+      expect(model.requests[1].modelSettings.toolChoice).toBeUndefined();
       const secondInput = model.requests[1].input as AgentInputItem[];
       expect(secondInput).toContainEqual({
         type: 'function_call_result',

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -5980,6 +5980,72 @@ describe('Runner.run', () => {
       });
     });
 
+    it('does not re-emit missing function tool results when resuming an interrupted turn', async () => {
+      const approvalTool = tool({
+        name: 'test',
+        description: 'tool that requires approval',
+        parameters: z.object({ test: z.string() }),
+        needsApproval: async () => true,
+        execute: async ({ test }) => `result:${test}`,
+      });
+      const missingToolCall: protocol.FunctionCallItem = {
+        ...buildToolCall('call-missing', 'missing'),
+        name: 'missing_tool',
+      };
+
+      const model = new TrackingModel([
+        buildResponse(
+          [buildToolCall('call-approved', 'foo'), missingToolCall],
+          'resp-mixed-missing-1',
+        ),
+        buildResponse([fakeModelMessage('done')], 'resp-mixed-missing-2'),
+      ]);
+
+      const agent = new Agent({
+        name: 'MixedMissingToolResumeAgent',
+        model,
+        tools: [approvalTool],
+      });
+
+      const runner = new Runner();
+      const firstResult = await runner.run(agent, 'user_message', {
+        conversationId: 'conv-mixed-missing',
+        toolNotFoundBehavior: 'return_error_to_model',
+      });
+
+      expect(firstResult.interruptions).toHaveLength(1);
+      const preResumeMissingResults = firstResult.state._generatedItems.filter(
+        (item) =>
+          item.rawItem.type === 'function_call_result' &&
+          item.rawItem.callId === 'call-missing',
+      );
+      expect(preResumeMissingResults).toHaveLength(1);
+
+      firstResult.state.approve(firstResult.interruptions[0]);
+      const secondResult = await runner.run(agent, firstResult.state, {
+        conversationId: 'conv-mixed-missing',
+        toolNotFoundBehavior: 'return_error_to_model',
+      });
+
+      expect(secondResult.finalOutput).toBe('done');
+      expect(model.requests).toHaveLength(2);
+
+      const allMissingResults = secondResult.state._generatedItems.filter(
+        (item) =>
+          item.rawItem.type === 'function_call_result' &&
+          item.rawItem.callId === 'call-missing',
+      );
+      expect(allMissingResults).toHaveLength(1);
+
+      const secondInput = model.requests[1].input as AgentInputItem[];
+      const missingResultsSentOnResume = secondInput.filter(
+        (item) =>
+          item.type === 'function_call_result' &&
+          item.callId === 'call-missing',
+      );
+      expect(missingResultsSentOnResume).toHaveLength(1);
+    });
+
     it('does not resend prior items when resuming with previousResponseId', async () => {
       const approvalTool = tool({
         name: 'test',

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -32,6 +32,7 @@ import {
   user,
   assistant,
   type ToolExecutionConfig,
+  type ToolNotFoundBehavior,
 } from '../src';
 import { RunStreamEvent } from '../src/events';
 import { ServerConversationTracker } from '../src/runner/conversation';
@@ -117,6 +118,18 @@ describe('Runner.run', () => {
       expect(runner.config.toolExecution).toBe(toolExecution);
     });
 
+    it('accepts public tool not found behavior config', () => {
+      const toolNotFoundBehavior =
+        'return_error_to_model' satisfies ToolNotFoundBehavior;
+
+      const runner = new Runner({
+        tracingDisabled: true,
+        toolNotFoundBehavior,
+      });
+
+      expect(runner.config.toolNotFoundBehavior).toBe('return_error_to_model');
+    });
+
     it('rejects invalid function tool concurrency config', () => {
       expect(
         () =>
@@ -134,6 +147,118 @@ describe('Runner.run', () => {
       ).toThrow(
         'toolExecution.maxFunctionToolConcurrency must be an integer greater than or equal to 1.',
       );
+    });
+
+    it('returns missing function tool errors to the model when opted in', async () => {
+      class RecordingModel extends FakeModel {
+        readonly requests: ModelRequest[] = [];
+
+        async getResponse(request: ModelRequest): Promise<ModelResponse> {
+          this.requests.push(request);
+          return super.getResponse(request);
+        }
+      }
+
+      const model = new RecordingModel([
+        {
+          output: [
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              name: 'missing_tool',
+              callId: 'call_missing',
+              arguments: '{}',
+            },
+          ],
+          usage: new Usage(),
+        },
+        {
+          output: [fakeModelMessage('recovered')],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'MissingToolAgent',
+        model,
+        toolUseBehavior: 'run_llm_again',
+      });
+
+      const result = await run(agent, 'start', {
+        toolNotFoundBehavior: 'return_error_to_model',
+      });
+
+      expect(result.finalOutput).toBe('recovered');
+      expect(model.requests).toHaveLength(2);
+      const secondInput = model.requests[1].input as AgentInputItem[];
+      expect(secondInput).toContainEqual({
+        type: 'function_call_result',
+        name: 'missing_tool',
+        callId: 'call_missing',
+        status: 'completed',
+        output: {
+          type: 'text',
+          text: "Tool 'missing_tool' not found.",
+        },
+      });
+    });
+
+    it('uses toolErrorFormatter for missing function tool errors', async () => {
+      class RecordingModel extends FakeModel {
+        readonly requests: ModelRequest[] = [];
+
+        async getResponse(request: ModelRequest): Promise<ModelResponse> {
+          this.requests.push(request);
+          return super.getResponse(request);
+        }
+      }
+
+      const model = new RecordingModel([
+        {
+          output: [
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              name: 'missing_tool',
+              callId: 'call_missing',
+              arguments: '{}',
+            },
+          ],
+          usage: new Usage(),
+        },
+        {
+          output: [fakeModelMessage('formatter recovered')],
+          usage: new Usage(),
+        },
+      ]);
+      const seenKinds: string[] = [];
+      const agent = new Agent({
+        name: 'MissingToolFormatterAgent',
+        model,
+        toolUseBehavior: 'run_llm_again',
+      });
+
+      const result = await run(agent, 'start', {
+        toolNotFoundBehavior: 'return_error_to_model',
+        toolErrorFormatter: (args) => {
+          seenKinds.push(args.kind);
+          if (args.kind !== 'tool_not_found') {
+            return undefined;
+          }
+          return `${args.toolName} unavailable for ${args.callId}`;
+        },
+      });
+
+      expect(result.finalOutput).toBe('formatter recovered');
+      expect(seenKinds).toEqual(['tool_not_found']);
+      const secondInput = model.requests[1].input as AgentInputItem[];
+      expect(secondInput).toContainEqual({
+        type: 'function_call_result',
+        name: 'missing_tool',
+        callId: 'call_missing',
+        status: 'completed',
+        output: {
+          type: 'text',
+          text: 'missing_tool unavailable for call_missing',
+        },
+      });
     });
 
     it('does not persist nested agent-tool metadata when resuming a RunState', async () => {

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -594,6 +594,12 @@ describe('RunState', () => {
       JSON.stringify({ ...json, $schemaVersion: '1.10' as const }),
     );
     expect(restoredFromSchema110._currentAgent).toBe(childB);
+
+    const restoredFromSchema111 = await RunState.fromString(
+      root,
+      JSON.stringify({ ...json, $schemaVersion: '1.11' as const }),
+    );
+    expect(restoredFromSchema111._currentAgent).toBe(childB);
   });
 
   it('keeps literal identity suffixes from colliding with generated identities', () => {
@@ -957,7 +963,7 @@ describe('RunState', () => {
       ),
     );
 
-    for (const $schemaVersion of ['1.8', '1.10'] as const) {
+    for (const $schemaVersion of ['1.8', '1.10', '1.11'] as const) {
       const jsonVersion = state.toJSON() as any;
       jsonVersion.$schemaVersion = $schemaVersion;
       const restored = await RunState.fromString(

--- a/packages/agents-core/test/runner/modelOutputs.test.ts
+++ b/packages/agents-core/test/runner/modelOutputs.test.ts
@@ -2080,6 +2080,7 @@ describe('processModelResponse edge cases', () => {
     expect(result.newItems).toHaveLength(1);
     expect(result.newItems[0]).toBeInstanceOf(ToolCallItem);
     expect(result.functions).toEqual([]);
+    expect(result.toolsUsed).toEqual(['missing_tool']);
     expect(result.functionToolsNotFound).toEqual([
       {
         toolCall: missingCall,

--- a/packages/agents-core/test/runner/modelOutputs.test.ts
+++ b/packages/agents-core/test/runner/modelOutputs.test.ts
@@ -2056,6 +2056,39 @@ describe('processModelResponse edge cases', () => {
     ).toThrow(ModelBehaviorError);
   });
 
+  it('collects unknown function tool calls when opted in', () => {
+    const missingCall: protocol.FunctionCallItem = {
+      ...TEST_MODEL_FUNCTION_CALL,
+      name: 'missing_tool',
+      callId: 'call_missing',
+      arguments: '{}',
+    };
+    const response: ModelResponse = {
+      output: [missingCall],
+      usage: new Usage(),
+    };
+
+    const result = processModelResponse(
+      response,
+      TEST_AGENT,
+      [TEST_TOOL],
+      [],
+      [],
+      'return_error_to_model',
+    );
+
+    expect(result.newItems).toHaveLength(1);
+    expect(result.newItems[0]).toBeInstanceOf(ToolCallItem);
+    expect(result.functions).toEqual([]);
+    expect(result.functionToolsNotFound).toEqual([
+      {
+        toolCall: missingCall,
+        toolName: 'missing_tool',
+      },
+    ]);
+    expect(result.hasToolsOrApprovalsToRun()).toBe(true);
+  });
+
   it('throws when computer action emitted without computer tool', () => {
     const compCall: protocol.ComputerUseCallItem = {
       id: 'c1',


### PR DESCRIPTION
This pull request adds `toolNotFoundBehavior` to `RunConfig` so callers can opt into returning missing function tool calls back to the model as tool errors instead of failing the run. The default remains `raise_error`, preserving the existing `ModelBehaviorError` behavior, while `return_error_to_model` records the missing function call, emits a model-visible tool output, and lets the agent continue.

It also extends `toolErrorFormatter` with a `tool_not_found` kind, carries missing-tool state through `RunState` serialization, updates non-streaming and streaming runner paths.

See also: https://github.com/openai/openai-agents-python/pull/3461