### PR TITLE
fix: #1340 preserve AI SDK output token details in usage tracing

### DIFF
--- a/.changeset/ai-sdk-output-token-details.md
+++ b/.changeset/ai-sdk-output-token-details.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: #1340 preserve AI SDK output token details in usage tracing

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -1751,6 +1751,7 @@ export class AiSdkModel implements Model {
       let usagePromptTokens = 0;
       let usageCompletionTokens = 0;
       let usageInputTokensDetails: Record<string, number> | undefined;
+      let usageOutputTokensDetails: Record<string, number> | undefined;
       const functionCalls: Record<
         string,
         protocol.FunctionCallItem | protocol.ToolSearchCallItem
@@ -1849,6 +1850,7 @@ export class AiSdkModel implements Model {
             usagePromptTokens = usage.inputTokens;
             usageCompletionTokens = usage.outputTokens;
             usageInputTokensDetails = usage.inputTokensDetails;
+            usageOutputTokensDetails = usage.outputTokensDetails;
             break;
           }
           case 'error': {
@@ -1923,6 +1925,11 @@ export class AiSdkModel implements Model {
                   inputTokensDetails: usageInputTokensDetails,
                 }
               : {}),
+            ...(usageOutputTokensDetails
+              ? {
+                  outputTokensDetails: usageOutputTokensDetails,
+                }
+              : {}),
           },
           output: outputs,
         },
@@ -1936,6 +1943,11 @@ export class AiSdkModel implements Model {
           ...(usageInputTokensDetails
             ? {
                 inputTokensDetails: usageInputTokensDetails,
+              }
+            : {}),
+          ...(usageOutputTokensDetails
+            ? {
+                outputTokensDetails: usageOutputTokensDetails,
               }
             : {}),
         });
@@ -2086,15 +2098,42 @@ function extractInputTokenDetails(
   };
 }
 
+function extractOutputTokenDetails(
+  usage: any,
+): Record<string, number> | undefined {
+  const outputTokens = usage?.outputTokens;
+  if (typeof outputTokens !== 'object' || outputTokens === null) {
+    return undefined;
+  }
+
+  const reasoningTokens = toUsageDetailTokenCount(
+    (outputTokens as any).reasoning,
+  );
+  const textTokens = toUsageDetailTokenCount((outputTokens as any).text);
+
+  if (typeof reasoningTokens !== 'number' && typeof textTokens !== 'number') {
+    return undefined;
+  }
+
+  return {
+    ...(typeof reasoningTokens === 'number'
+      ? { reasoning_tokens: reasoningTokens }
+      : {}),
+    ...(typeof textTokens === 'number' ? { text_tokens: textTokens } : {}),
+  };
+}
+
 function extractUsage(usage: any): {
   inputTokens: number;
   outputTokens: number;
   totalTokens: number;
   inputTokensDetails?: Record<string, number>;
+  outputTokensDetails?: Record<string, number>;
 } {
   const inputTokens = extractTokenCount(usage, 'inputTokens');
   const outputTokens = extractTokenCount(usage, 'outputTokens');
   const inputTokensDetails = extractInputTokenDetails(usage);
+  const outputTokensDetails = extractOutputTokenDetails(usage);
 
   return {
     inputTokens,
@@ -2105,6 +2144,11 @@ function extractUsage(usage: any): {
           inputTokensDetails,
         }
       : {}),
+    ...(outputTokensDetails
+      ? {
+          outputTokensDetails,
+        }
+      : {}),
   };
 }
 
@@ -2112,6 +2156,7 @@ function toTracingUsage(usage: {
   inputTokens: number;
   outputTokens: number;
   inputTokensDetails?: Record<string, number>;
+  outputTokensDetails?: Record<string, number>;
 }): GenerationUsageData {
   return {
     input_tokens: usage.inputTokens,
@@ -2119,6 +2164,11 @@ function toTracingUsage(usage: {
     ...(usage.inputTokensDetails
       ? {
           input_tokens_details: usage.inputTokensDetails,
+        }
+      : {}),
+    ...(usage.outputTokensDetails
+      ? {
+          output_tokens_details: usage.outputTokensDetails,
         }
       : {}),
   };

--- a/packages/agents-extensions/test/ai-sdk/GoogleFormat.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/GoogleFormat.test.ts
@@ -134,7 +134,7 @@ describe('AiSdkModel issue #802', () => {
                   cacheRead: 2,
                   cacheWrite: 3,
                 } as any,
-                outputTokens: { total: 20 } as any,
+                outputTokens: { total: 20, text: 17, reasoning: 3 } as any,
                 totalTokens: { total: 30 } as any,
               },
               providerMetadata: {},
@@ -160,6 +160,9 @@ describe('AiSdkModel issue #802', () => {
       expect(res.usage.inputTokensDetails).toEqual([
         { cached_tokens: 2, cache_write_tokens: 3 },
       ]);
+      expect(res.usage.outputTokensDetails).toEqual([
+        { reasoning_tokens: 3, text_tokens: 17 },
+      ]);
 
       const generationSpan = processor.spans.find(
         (span) => span.spanData.type === 'generation',
@@ -169,6 +172,7 @@ describe('AiSdkModel issue #802', () => {
         input_tokens: 10,
         output_tokens: 20,
         input_tokens_details: { cached_tokens: 2, cache_write_tokens: 3 },
+        output_tokens_details: { reasoning_tokens: 3, text_tokens: 17 },
       });
     } finally {
       setTracingDisabled(true);
@@ -185,10 +189,14 @@ describe('AiSdkModel issue #802', () => {
         // Simulating Google AI SDK behavior where tokens are objects
         usage: {
           inputTokens: { total: 5, cacheRead: 1, cacheWrite: 2 } as any,
-          outputTokens: { total: 8 } as any,
+          outputTokens: { total: 8, text: 6, reasoning: 2 } as any,
         },
       },
     ];
+    const processor = new CollectingProcessor();
+    setTracingDisabled(false);
+    setTraceProcessors([processor]);
+
     const model = new AiSdkModel(
       stubModel({
         async doStream() {
@@ -200,25 +208,44 @@ describe('AiSdkModel issue #802', () => {
     );
 
     let finalUsage: any;
-    for await (const ev of model.getStreamedResponse({
-      input: 'hi',
-      tools: [],
-      handoffs: [],
-      modelSettings: {},
-      outputType: 'text',
-      tracing: false,
-    } as any)) {
-      if (ev.type === 'response_done') {
-        finalUsage = ev.response.usage;
-      }
-    }
+    try {
+      await withTrace('t', async () => {
+        for await (const ev of model.getStreamedResponse({
+          input: 'hi',
+          tools: [],
+          handoffs: [],
+          modelSettings: {},
+          outputType: 'text',
+          tracing: true,
+        } as any)) {
+          if (ev.type === 'response_done') {
+            finalUsage = ev.response.usage;
+          }
+        }
+      });
 
-    expect(finalUsage).toEqual({
-      inputTokens: 5,
-      outputTokens: 8,
-      totalTokens: 13,
-      inputTokensDetails: { cached_tokens: 1, cache_write_tokens: 2 },
-    });
+      expect(finalUsage).toEqual({
+        inputTokens: 5,
+        outputTokens: 8,
+        totalTokens: 13,
+        inputTokensDetails: { cached_tokens: 1, cache_write_tokens: 2 },
+        outputTokensDetails: { reasoning_tokens: 2, text_tokens: 6 },
+      });
+
+      const generationSpan = processor.spans.find(
+        (span) => span.spanData.type === 'generation',
+      );
+
+      expect(generationSpan?.spanData?.usage).toEqual({
+        input_tokens: 5,
+        output_tokens: 8,
+        input_tokens_details: { cached_tokens: 1, cache_write_tokens: 2 },
+        output_tokens_details: { reasoning_tokens: 2, text_tokens: 6 },
+      });
+    } finally {
+      setTracingDisabled(true);
+      setTraceProcessors([new BatchTraceProcessor(new ConsoleSpanExporter())]);
+    }
   });
 
   test('preserves toolChoice and provider options through streaming tool calls', async () => {


### PR DESCRIPTION
This pull request resolves #1340 by preserving AI SDK output token details when extracting usage from AI SDK model responses. The AI SDK can report object-shaped output token usage with text and reasoning counts, but the adapter only propagated aggregate output tokens and input token details, so reasoning-token breakdowns were absent from Usage and generation tracing spans.

It maps outputTokens.reasoning and outputTokens.text to outputTokensDetails / output_tokens_details for both non-streaming and streaming AI SDK responses, and adds regression coverage for response usage and tracing usage.