### PR TITLE
fix(extensions): clear Twilio playback on interrupt

### DIFF
--- a/.changeset/clear-twilio-playback.md
+++ b/.changeset/clear-twilio-playback.md
@@ -2,4 +2,4 @@
 '@openai/agents-extensions': patch
 ---
 
-fix: clear Twilio playback on manual interrupt (#1173)
+fix: clear buffered Twilio playback and preserve Realtime truncation on interrupt (#1173)

--- a/.changeset/clear-twilio-playback.md
+++ b/.changeset/clear-twilio-playback.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: clear Twilio playback on manual interrupt (#1173)

--- a/packages/agents-extensions/src/TwilioRealtimeTransport.ts
+++ b/packages/agents-extensions/src/TwilioRealtimeTransport.ts
@@ -59,6 +59,7 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
   #audioChunkCount: number = 0;
   #lastPlayedChunkCount: number = 0;
   #previousItemId: string | null = null;
+  #shouldClearOnInterrupt: boolean = true;
   #logger = getLogger('openai-agents:extensions:twilio');
 
   constructor(options: TwilioRealtimeTransportLayerOptions) {
@@ -203,17 +204,44 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
     super.updateSessionConfig(newConfig);
   }
 
-  _interrupt(_elapsedTime: number, cancelOngoingResponse: boolean = true) {
-    const elapsedTime = this.#lastPlayedChunkCount + 50; /* 50ms buffer */
-    this.#logger.debug(
-      `Interruption detected, clearing Twilio audio and truncating OpenAI audio after ${elapsedTime}ms`,
-    );
+  #clearTwilioAudio() {
+    if (this.#streamSid == null) {
+      this.#logger.debug('Skipping Twilio clear before streamSid is set');
+      return;
+    }
+    this.#logger.debug('Clearing Twilio audio');
     this.#twilioWebSocket.send(
       JSON.stringify({
         event: 'clear',
         streamSid: this.#streamSid,
       }),
     );
+  }
+
+  interrupt(cancelOngoingResponse: boolean = true) {
+    // Twilio may still be playing buffered audio after the OpenAI response has
+    // finished streaming and the base transport has reset its audio state.
+    // Always clear Twilio playback first, then let the base transport truncate
+    // the OpenAI conversation item if it still has one to truncate.
+    this.#clearTwilioAudio();
+    // Avoid sending a duplicate Twilio `clear` when super.interrupt() calls
+    // this transport's overridden _interrupt().
+    this.#shouldClearOnInterrupt = false;
+    try {
+      super.interrupt(cancelOngoingResponse);
+    } finally {
+      this.#shouldClearOnInterrupt = true;
+    }
+  }
+
+  _interrupt(_elapsedTime: number, cancelOngoingResponse: boolean = true) {
+    const elapsedTime = this.#lastPlayedChunkCount + 50; /* 50ms buffer */
+    this.#logger.debug(
+      `Interruption detected, truncating OpenAI audio after ${elapsedTime}ms`,
+    );
+    if (this.#shouldClearOnInterrupt) {
+      this.#clearTwilioAudio();
+    }
     super._interrupt(elapsedTime, cancelOngoingResponse);
   }
 

--- a/packages/agents-extensions/src/TwilioRealtimeTransport.ts
+++ b/packages/agents-extensions/src/TwilioRealtimeTransport.ts
@@ -59,6 +59,7 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
   #audioChunkCount: number = 0;
   #lastPlayedChunkCount: number = 0;
   #previousItemId: string | null = null;
+  #pendingPlaybackItemId: string | null = null;
   #shouldClearOnInterrupt: boolean = true;
   #logger = getLogger('openai-agents:extensions:twilio');
 
@@ -147,11 +148,24 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
                   );
                 }
               } else if (data.mark.name.startsWith('done:')) {
-                this.#lastPlayedChunkCount = 0;
+                const itemId = data.mark.name.slice('done:'.length);
+                if (itemId === this.#pendingPlaybackItemId) {
+                  this.#pendingPlaybackItemId = null;
+                  if (itemId === this.currentItemId) {
+                    this.#audioChunkCount = 0;
+                    this.#lastPlayedChunkCount = 0;
+                    this.#previousItemId = null;
+                    super._afterAudioDoneEvent();
+                  }
+                }
               }
               break;
             case 'start':
               this.#streamSid = data.start.streamSid;
+              this.#audioChunkCount = 0;
+              this.#lastPlayedChunkCount = 0;
+              this.#previousItemId = null;
+              this.#pendingPlaybackItemId = null;
               break;
             default:
               break;
@@ -186,17 +200,33 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
       },
     );
     this.on('audio_done', () => {
+      const itemId = this.currentItemId;
+      if (this.#streamSid == null || itemId == null) {
+        this.#pendingPlaybackItemId = null;
+        return;
+      }
+      this.#pendingPlaybackItemId = itemId;
       this.#twilioWebSocket.send(
         JSON.stringify({
           event: 'mark',
           mark: {
-            name: `done:${this.currentItemId}`,
+            name: `done:${itemId}`,
           },
           streamSid: this.#streamSid,
         }),
       );
     });
     await super.connect(options);
+  }
+
+  protected override _afterAudioDoneEvent() {
+    // OpenAI can finish streaming before Twilio has played its buffered audio.
+    // Retain the base transport's item and timing state until Twilio acknowledges
+    // the matching done mark so a later interrupt can still truncate unheard audio.
+    if (this.#pendingPlaybackItemId === this.currentItemId) {
+      return;
+    }
+    super._afterAudioDoneEvent();
   }
 
   updateSessionConfig(config: Partial<RealtimeSessionConfig>): void {
@@ -220,9 +250,8 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
 
   interrupt(cancelOngoingResponse: boolean = true) {
     // Twilio may still be playing buffered audio after the OpenAI response has
-    // finished streaming and the base transport has reset its audio state.
-    // Always clear Twilio playback first, then let the base transport truncate
-    // the OpenAI conversation item if it still has one to truncate.
+    // finished streaming. Clear Twilio playback first, then let the retained
+    // base transport state truncate any audio the caller did not hear.
     this.#clearTwilioAudio();
     // Avoid sending a duplicate Twilio `clear` when super.interrupt() calls
     // this transport's overridden _interrupt().
@@ -231,6 +260,10 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
       super.interrupt(cancelOngoingResponse);
     } finally {
       this.#shouldClearOnInterrupt = true;
+      this.#pendingPlaybackItemId = null;
+      this.#audioChunkCount = 0;
+      this.#lastPlayedChunkCount = 0;
+      this.#previousItemId = null;
     }
   }
 

--- a/packages/agents-extensions/src/TwilioRealtimeTransport.ts
+++ b/packages/agents-extensions/src/TwilioRealtimeTransport.ts
@@ -75,6 +75,7 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
   #audioChunkCount: number = 0;
   #lastPlayedChunkCount: number = 0;
   #previousItemId: string | null = null;
+  #pendingPlaybackItemId: string | null = null;
   #shouldClearOnInterrupt: boolean = true;
   #logger = getLogger('openai-agents:extensions:twilio');
 
@@ -162,11 +163,24 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
                   }
                 }
               } else if (data.mark.name.startsWith('done:')) {
-                this.#lastPlayedChunkCount = 0;
+                const itemId = data.mark.name.slice('done:'.length);
+                if (itemId === this.#pendingPlaybackItemId) {
+                  this.#pendingPlaybackItemId = null;
+                  if (itemId === this.currentItemId) {
+                    this.#audioChunkCount = 0;
+                    this.#lastPlayedChunkCount = 0;
+                    this.#previousItemId = null;
+                    super._afterAudioDoneEvent();
+                  }
+                }
               }
               break;
             case 'start':
               this.#streamSid = data.start.streamSid;
+              this.#audioChunkCount = 0;
+              this.#lastPlayedChunkCount = 0;
+              this.#previousItemId = null;
+              this.#pendingPlaybackItemId = null;
               break;
             default:
               break;
@@ -202,17 +216,33 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
       },
     );
     this.on('audio_done', () => {
+      const itemId = this.currentItemId;
+      if (this.#streamSid == null || itemId == null) {
+        this.#pendingPlaybackItemId = null;
+        return;
+      }
+      this.#pendingPlaybackItemId = itemId;
       this.#twilioWebSocket.send(
         JSON.stringify({
           event: 'mark',
           mark: {
-            name: `done:${this.currentItemId}`,
+            name: `done:${itemId}`,
           },
           streamSid: this.#streamSid,
         }),
       );
     });
     await super.connect(options);
+  }
+
+  protected override _afterAudioDoneEvent() {
+    // OpenAI can finish streaming before Twilio has played its buffered audio.
+    // Retain the base transport's item and timing state until Twilio acknowledges
+    // the matching done mark so a later interrupt can still truncate unheard audio.
+    if (this.#pendingPlaybackItemId === this.currentItemId) {
+      return;
+    }
+    super._afterAudioDoneEvent();
   }
 
   updateSessionConfig(config: Partial<RealtimeSessionConfig>): void {
@@ -236,9 +266,8 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
 
   interrupt(cancelOngoingResponse: boolean = true) {
     // Twilio may still be playing buffered audio after the OpenAI response has
-    // finished streaming and the base transport has reset its audio state.
-    // Always clear Twilio playback first, then let the base transport truncate
-    // the OpenAI conversation item if it still has one to truncate.
+    // finished streaming. Clear Twilio playback first, then let the retained
+    // base transport state truncate any audio the caller did not hear.
     this.#clearTwilioAudio();
     // Avoid sending a duplicate Twilio `clear` when super.interrupt() calls
     // this transport's overridden _interrupt().
@@ -247,6 +276,10 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
       super.interrupt(cancelOngoingResponse);
     } finally {
       this.#shouldClearOnInterrupt = true;
+      this.#pendingPlaybackItemId = null;
+      this.#audioChunkCount = 0;
+      this.#lastPlayedChunkCount = 0;
+      this.#previousItemId = null;
     }
   }
 

--- a/packages/agents-extensions/src/TwilioRealtimeTransport.ts
+++ b/packages/agents-extensions/src/TwilioRealtimeTransport.ts
@@ -75,6 +75,7 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
   #audioChunkCount: number = 0;
   #lastPlayedChunkCount: number = 0;
   #previousItemId: string | null = null;
+  #shouldClearOnInterrupt: boolean = true;
   #logger = getLogger('openai-agents:extensions:twilio');
 
   constructor(options: TwilioRealtimeTransportLayerOptions) {
@@ -219,17 +220,44 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
     super.updateSessionConfig(newConfig);
   }
 
-  _interrupt(_elapsedTime: number, cancelOngoingResponse: boolean = true) {
-    const elapsedTime = this.#lastPlayedChunkCount + 50; /* 50ms buffer */
-    this.#logger.debug(
-      `Interruption detected, clearing Twilio audio and truncating OpenAI audio after ${elapsedTime}ms`,
-    );
+  #clearTwilioAudio() {
+    if (this.#streamSid == null) {
+      this.#logger.debug('Skipping Twilio clear before streamSid is set');
+      return;
+    }
+    this.#logger.debug('Clearing Twilio audio');
     this.#twilioWebSocket.send(
       JSON.stringify({
         event: 'clear',
         streamSid: this.#streamSid,
       }),
     );
+  }
+
+  interrupt(cancelOngoingResponse: boolean = true) {
+    // Twilio may still be playing buffered audio after the OpenAI response has
+    // finished streaming and the base transport has reset its audio state.
+    // Always clear Twilio playback first, then let the base transport truncate
+    // the OpenAI conversation item if it still has one to truncate.
+    this.#clearTwilioAudio();
+    // Avoid sending a duplicate Twilio `clear` when super.interrupt() calls
+    // this transport's overridden _interrupt().
+    this.#shouldClearOnInterrupt = false;
+    try {
+      super.interrupt(cancelOngoingResponse);
+    } finally {
+      this.#shouldClearOnInterrupt = true;
+    }
+  }
+
+  _interrupt(_elapsedTime: number, cancelOngoingResponse: boolean = true) {
+    const elapsedTime = this.#lastPlayedChunkCount + 50; /* 50ms buffer */
+    this.#logger.debug(
+      `Interruption detected, truncating OpenAI audio after ${elapsedTime}ms`,
+    );
+    if (this.#shouldClearOnInterrupt) {
+      this.#clearTwilioAudio();
+    }
     super._interrupt(elapsedTime, cancelOngoingResponse);
   }
 

--- a/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
+++ b/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
@@ -26,6 +26,7 @@ vi.mock('@openai/agents/realtime', () => {
   });
   FakeOpenAIRealtimeWebSocket.prototype.sendAudio = vi.fn();
   FakeOpenAIRealtimeWebSocket.prototype.close = vi.fn();
+  FakeOpenAIRealtimeWebSocket.prototype.interrupt = vi.fn();
   FakeOpenAIRealtimeWebSocket.prototype._interrupt = vi.fn();
   FakeOpenAIRealtimeWebSocket.prototype.updateSessionConfig = vi.fn();
   return { OpenAIRealtimeWebSocket: FakeOpenAIRealtimeWebSocket, utils };
@@ -153,6 +154,79 @@ describe('TwilioRealtimeTransportLayer', () => {
     expect(closeSpy).toHaveBeenCalled();
     twilio.emit('error', new Error('boom'));
     expect(closeSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test('interrupt skips Twilio clear before stream start', async () => {
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: twilio as any,
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const interruptSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.interrupt);
+
+    transport.interrupt();
+
+    const clearCalls = twilio.send.mock.calls
+      .map((call) => JSON.parse(call[0]))
+      .filter((message: any) => message.event === 'clear');
+    expect(clearCalls).toEqual([]);
+    expect(interruptSpy).toHaveBeenCalledWith(true);
+  });
+
+  test('interrupt clears Twilio playback even when base transport has no active audio state', async () => {
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: twilio as any,
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const interruptSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.interrupt);
+
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({ event: 'start', start: { streamSid: 'sid' } }),
+    });
+
+    transport.interrupt();
+
+    expect(twilio.send).toHaveBeenCalledWith(
+      JSON.stringify({ event: 'clear', streamSid: 'sid' }),
+    );
+    expect(interruptSpy).toHaveBeenCalledWith(true);
+  });
+
+  test('interrupt clears Twilio playback once when base interrupt truncates audio', async () => {
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: twilio as any,
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const interruptSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.interrupt);
+    const truncateSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype._interrupt);
+    interruptSpy.mockImplementationOnce(function (
+      this: any,
+      cancelOngoingResponse = true,
+    ) {
+      this._interrupt(0, cancelOngoingResponse);
+    });
+
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({ event: 'start', start: { streamSid: 'sid' } }),
+    });
+    twilio.emit('message', {
+      toString: () => JSON.stringify({ event: 'mark', mark: { name: 'u:5' } }),
+    });
+
+    transport.interrupt(false);
+
+    const clearCalls = twilio.send.mock.calls
+      .map((call) => JSON.parse(call[0]))
+      .filter((message: any) => message.event === 'clear');
+    expect(clearCalls).toEqual([{ event: 'clear', streamSid: 'sid' }]);
+    expect(truncateSpy).toHaveBeenCalledWith(55, false);
   });
 
   test('_onAudio resets chunk count and emits', async () => {

--- a/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
+++ b/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
@@ -28,6 +28,11 @@ vi.mock('@openai/agents/realtime', () => {
   FakeOpenAIRealtimeWebSocket.prototype.close = vi.fn();
   FakeOpenAIRealtimeWebSocket.prototype.interrupt = vi.fn();
   FakeOpenAIRealtimeWebSocket.prototype._interrupt = vi.fn();
+  FakeOpenAIRealtimeWebSocket.prototype._afterAudioDoneEvent = vi.fn(function (
+    this: any,
+  ) {
+    this.currentItemId = null;
+  });
   FakeOpenAIRealtimeWebSocket.prototype.updateSessionConfig = vi.fn();
   return { OpenAIRealtimeWebSocket: FakeOpenAIRealtimeWebSocket, utils };
 });
@@ -229,6 +234,108 @@ describe('TwilioRealtimeTransportLayer', () => {
     expect(truncateSpy).toHaveBeenCalledWith(55, false);
   });
 
+  test('interrupt truncates an item while Twilio is still playing completed audio', async () => {
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: twilio as any,
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const interruptSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.interrupt);
+    const truncateSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype._interrupt);
+    const resetSpy = vi.mocked(
+      (OpenAIRealtimeWebSocket.prototype as any)._afterAudioDoneEvent,
+    );
+    interruptSpy.mockImplementationOnce(function (
+      this: any,
+      cancelOngoingResponse = true,
+    ) {
+      if (this.currentItemId == null) {
+        return;
+      }
+      this._interrupt(0, cancelOngoingResponse);
+      this.currentItemId = null;
+    });
+
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({ event: 'start', start: { streamSid: 'sid' } }),
+    });
+    // @ts-expect-error - we're testing protected readonly fields
+    transport.currentItemId = 'item-1';
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({
+          event: 'mark',
+          mark: { name: 'item-1:5' },
+        }),
+    });
+
+    transport.emit('audio_done');
+    transport['_afterAudioDoneEvent']();
+
+    expect(resetSpy).not.toHaveBeenCalled();
+    // @ts-expect-error - we're testing protected readonly fields
+    expect(transport.currentItemId).toBe('item-1');
+
+    transport.interrupt(false);
+
+    expect(twilio.send).toHaveBeenCalledWith(
+      JSON.stringify({ event: 'clear', streamSid: 'sid' }),
+    );
+    expect(truncateSpy).toHaveBeenCalledWith(55, false);
+  });
+
+  test('resets retained audio state only for the matching Twilio done mark', async () => {
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: twilio as any,
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const resetSpy = vi.mocked(
+      (OpenAIRealtimeWebSocket.prototype as any)._afterAudioDoneEvent,
+    );
+
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({ event: 'start', start: { streamSid: 'sid' } }),
+    });
+    // @ts-expect-error - we're testing protected readonly fields
+    transport.currentItemId = 'item-1';
+    transport.emit('audio_done');
+    transport['_afterAudioDoneEvent']();
+
+    // A new response can start before Twilio acknowledges the previous done mark.
+    // @ts-expect-error - we're testing protected readonly fields
+    transport.currentItemId = 'item-2';
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({
+          event: 'mark',
+          mark: { name: 'done:item-1' },
+        }),
+    });
+
+    expect(resetSpy).not.toHaveBeenCalled();
+    // @ts-expect-error - we're testing protected readonly fields
+    expect(transport.currentItemId).toBe('item-2');
+
+    transport.emit('audio_done');
+    transport['_afterAudioDoneEvent']();
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({
+          event: 'mark',
+          mark: { name: 'done:item-2' },
+        }),
+    });
+
+    expect(resetSpy).toHaveBeenCalledTimes(1);
+    // @ts-expect-error - we're testing protected readonly fields
+    expect(transport.currentItemId).toBeNull();
+  });
+
   test('_onAudio resets chunk count and emits', async () => {
     const twilio = new FakeTwilioWebSocket();
     const transport = new TwilioRealtimeTransportLayer({
@@ -420,6 +527,10 @@ describe('TwilioRealtimeTransportLayer', () => {
     twilio.emit('message', {
       toString: () => JSON.stringify({ event: 'mark', mark: { name: 'u:7' } }),
     });
+    // @ts-expect-error - we're testing protected readonly fields
+    transport.currentItemId = 'u';
+    transport.emit('audio_done');
+    transport['_afterAudioDoneEvent']();
     twilio.emit('message', {
       toString: () =>
         JSON.stringify({ event: 'mark', mark: { name: 'done:u' } }),

--- a/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
+++ b/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
@@ -31,6 +31,11 @@ vi.mock('@openai/agents/realtime', () => {
   FakeOpenAIRealtimeWebSocket.prototype.close = vi.fn();
   FakeOpenAIRealtimeWebSocket.prototype.interrupt = vi.fn();
   FakeOpenAIRealtimeWebSocket.prototype._interrupt = vi.fn();
+  FakeOpenAIRealtimeWebSocket.prototype._afterAudioDoneEvent = vi.fn(function (
+    this: any,
+  ) {
+    this.currentItemId = null;
+  });
   FakeOpenAIRealtimeWebSocket.prototype.updateSessionConfig = vi.fn();
   return { OpenAIRealtimeWebSocket: FakeOpenAIRealtimeWebSocket, utils };
 });
@@ -282,6 +287,108 @@ describe('TwilioRealtimeTransportLayer', () => {
     expect(truncateSpy).toHaveBeenCalledWith(55, false);
   });
 
+  test('interrupt truncates an item while Twilio is still playing completed audio', async () => {
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: twilio as any,
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const interruptSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.interrupt);
+    const truncateSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype._interrupt);
+    const resetSpy = vi.mocked(
+      (OpenAIRealtimeWebSocket.prototype as any)._afterAudioDoneEvent,
+    );
+    interruptSpy.mockImplementationOnce(function (
+      this: any,
+      cancelOngoingResponse = true,
+    ) {
+      if (this.currentItemId == null) {
+        return;
+      }
+      this._interrupt(0, cancelOngoingResponse);
+      this.currentItemId = null;
+    });
+
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({ event: 'start', start: { streamSid: 'sid' } }),
+    });
+    // @ts-expect-error - we're testing protected readonly fields
+    transport.currentItemId = 'item-1';
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({
+          event: 'mark',
+          mark: { name: 'item-1:5' },
+        }),
+    });
+
+    transport.emit('audio_done');
+    transport['_afterAudioDoneEvent']();
+
+    expect(resetSpy).not.toHaveBeenCalled();
+    // @ts-expect-error - we're testing protected readonly fields
+    expect(transport.currentItemId).toBe('item-1');
+
+    transport.interrupt(false);
+
+    expect(twilio.send).toHaveBeenCalledWith(
+      JSON.stringify({ event: 'clear', streamSid: 'sid' }),
+    );
+    expect(truncateSpy).toHaveBeenCalledWith(55, false);
+  });
+
+  test('resets retained audio state only for the matching Twilio done mark', async () => {
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: twilio as any,
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const resetSpy = vi.mocked(
+      (OpenAIRealtimeWebSocket.prototype as any)._afterAudioDoneEvent,
+    );
+
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({ event: 'start', start: { streamSid: 'sid' } }),
+    });
+    // @ts-expect-error - we're testing protected readonly fields
+    transport.currentItemId = 'item-1';
+    transport.emit('audio_done');
+    transport['_afterAudioDoneEvent']();
+
+    // A new response can start before Twilio acknowledges the previous done mark.
+    // @ts-expect-error - we're testing protected readonly fields
+    transport.currentItemId = 'item-2';
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({
+          event: 'mark',
+          mark: { name: 'done:item-1' },
+        }),
+    });
+
+    expect(resetSpy).not.toHaveBeenCalled();
+    // @ts-expect-error - we're testing protected readonly fields
+    expect(transport.currentItemId).toBe('item-2');
+
+    transport.emit('audio_done');
+    transport['_afterAudioDoneEvent']();
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({
+          event: 'mark',
+          mark: { name: 'done:item-2' },
+        }),
+    });
+
+    expect(resetSpy).toHaveBeenCalledTimes(1);
+    // @ts-expect-error - we're testing protected readonly fields
+    expect(transport.currentItemId).toBeNull();
+  });
+
   test('_onAudio resets chunk count and emits', async () => {
     const twilio = new FakeTwilioWebSocket();
     const transport = new TwilioRealtimeTransportLayer({
@@ -472,6 +579,10 @@ describe('TwilioRealtimeTransportLayer', () => {
     twilio.emit('message', {
       toString: () => JSON.stringify({ event: 'mark', mark: { name: 'u:7' } }),
     });
+    // @ts-expect-error - we're testing protected readonly fields
+    transport.currentItemId = 'u';
+    transport.emit('audio_done');
+    transport['_afterAudioDoneEvent']();
     twilio.emit('message', {
       toString: () =>
         JSON.stringify({ event: 'mark', mark: { name: 'done:u' } }),

--- a/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
+++ b/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
@@ -29,6 +29,7 @@ vi.mock('@openai/agents/realtime', () => {
   });
   FakeOpenAIRealtimeWebSocket.prototype.sendAudio = vi.fn();
   FakeOpenAIRealtimeWebSocket.prototype.close = vi.fn();
+  FakeOpenAIRealtimeWebSocket.prototype.interrupt = vi.fn();
   FakeOpenAIRealtimeWebSocket.prototype._interrupt = vi.fn();
   FakeOpenAIRealtimeWebSocket.prototype.updateSessionConfig = vi.fn();
   return { OpenAIRealtimeWebSocket: FakeOpenAIRealtimeWebSocket, utils };
@@ -208,6 +209,77 @@ describe('TwilioRealtimeTransportLayer', () => {
         process.env.OPENAI_AGENTS_DONT_LOG_MODEL_DATA = original;
       }
     }
+  test('interrupt skips Twilio clear before stream start', async () => {
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: twilio as any,
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const interruptSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.interrupt);
+
+    transport.interrupt();
+
+    const clearCalls = twilio.send.mock.calls
+      .map((call) => JSON.parse(call[0]))
+      .filter((message: any) => message.event === 'clear');
+    expect(clearCalls).toEqual([]);
+    expect(interruptSpy).toHaveBeenCalledWith(true);
+  });
+
+  test('interrupt clears Twilio playback even when base transport has no active audio state', async () => {
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: twilio as any,
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const interruptSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.interrupt);
+
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({ event: 'start', start: { streamSid: 'sid' } }),
+    });
+
+    transport.interrupt();
+
+    expect(twilio.send).toHaveBeenCalledWith(
+      JSON.stringify({ event: 'clear', streamSid: 'sid' }),
+    );
+    expect(interruptSpy).toHaveBeenCalledWith(true);
+  });
+
+  test('interrupt clears Twilio playback once when base interrupt truncates audio', async () => {
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: twilio as any,
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const interruptSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.interrupt);
+    const truncateSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype._interrupt);
+    interruptSpy.mockImplementationOnce(function (
+      this: any,
+      cancelOngoingResponse = true,
+    ) {
+      this._interrupt(0, cancelOngoingResponse);
+    });
+
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({ event: 'start', start: { streamSid: 'sid' } }),
+    });
+    twilio.emit('message', {
+      toString: () => JSON.stringify({ event: 'mark', mark: { name: 'u:5' } }),
+    });
+
+    transport.interrupt(false);
+
+    const clearCalls = twilio.send.mock.calls
+      .map((call) => JSON.parse(call[0]))
+      .filter((message: any) => message.event === 'clear');
+    expect(clearCalls).toEqual([{ event: 'clear', streamSid: 'sid' }]);
+    expect(truncateSpy).toHaveBeenCalledWith(55, false);
   });
 
   test('_onAudio resets chunk count and emits', async () => {

--- a/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
+++ b/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
@@ -214,6 +214,7 @@ describe('TwilioRealtimeTransportLayer', () => {
         process.env.OPENAI_AGENTS_DONT_LOG_MODEL_DATA = original;
       }
     }
+  });
   test('interrupt skips Twilio clear before stream start', async () => {
     const twilio = new FakeTwilioWebSocket();
     const transport = new TwilioRealtimeTransportLayer({


### PR DESCRIPTION
## Summary
- Clear Twilio playback from the public `TwilioRealtimeTransportLayer.interrupt()` path before delegating to the base transport.
- Keep `_interrupt()` responsible for OpenAI item truncation while avoiding duplicate Twilio `clear` events when the base interrupt path dispatches to it.
- Add regression coverage for both the base-transport early-return case and the active-audio truncation case.

## Test Plan
- `CI=1 PATH=/tmp/corepack-pnpm-shim:$PATH bash .agents/skills/code-change-verification/scripts/run.sh`
- `PATH=/tmp/corepack-pnpm-shim:$PATH pnpm exec vitest run --project @openai/agents-extensions test/TwilioRealtimeTransport.test.ts`
- `PATH=/tmp/corepack-pnpm-shim:$PATH pnpm -F @openai/agents-extensions build-check`
- `CI=1 PATH=/tmp/corepack-pnpm-shim:$PATH pnpm changeset:validate-result -- /tmp/changeset-validation-result.json`
- `CI=1 PATH=/tmp/corepack-pnpm-shim:$PATH pnpm changeset:validate-lite -- --base origin/main --head HEAD`

Closes #1173
