### PR TITLE
feat: add configurable tracing ID generation

### DIFF
--- a/.changeset/deterministic-trace-ids.md
+++ b/.changeset/deterministic-trace-ids.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+feat: add configurable tracing ID generation

--- a/packages/agents-core/src/tracing/index.ts
+++ b/packages/agents-core/src/tracing/index.ts
@@ -1,6 +1,7 @@
 import { TracingProcessor } from './processor';
 import { getGlobalTraceProvider } from './provider';
 import type { TracingConfig } from './config';
+import type { TracingIdGenerator } from './utils';
 
 export {
   getCurrentSpan,
@@ -36,7 +37,14 @@ export type {
   SpanError,
 } from './spans';
 export { NoopTrace, Trace } from './traces';
-export { generateGroupId, generateSpanId, generateTraceId } from './utils';
+export {
+  defaultTracingIdGenerator,
+  generateGroupId,
+  generateSpanId,
+  generateTraceId,
+} from './utils';
+export type { TracingIdGenerator } from './utils';
+export type { TraceProviderOptions } from './provider';
 export type { TracingConfig };
 
 /**
@@ -64,6 +72,17 @@ export function setTraceProcessors(processors: TracingProcessor[]): void {
  */
 export function setTracingDisabled(disabled: boolean): void {
   getGlobalTraceProvider().setDisabled(disabled);
+}
+
+/**
+ * Set the trace and span ID generator for the global tracing provider.
+ *
+ * @param idGenerator - Custom ID generator methods, or undefined to restore defaults.
+ */
+export function setTracingIdGenerator(
+  idGenerator?: Partial<TracingIdGenerator>,
+): void {
+  getGlobalTraceProvider().setIdGenerator(idGenerator);
 }
 
 /**

--- a/packages/agents-core/src/tracing/provider.ts
+++ b/packages/agents-core/src/tracing/provider.ts
@@ -4,22 +4,43 @@ import logger from '../logger';
 import { MultiTracingProcessor, TracingProcessor } from './processor';
 import { NoopSpan, Span, SpanData, SpanOptions } from './spans';
 import { NoopTrace, Trace, TraceOptions } from './traces';
-import { generateTraceId, NOOP_TRACE_OR_SPAN_ID } from './utils';
+import {
+  defaultTracingIdGenerator,
+  NOOP_TRACE_OR_SPAN_ID,
+  type TracingIdGenerator,
+} from './utils';
 
 export type CreateSpanOptions<TData extends SpanData> = Omit<
   SpanOptions<TData>,
   'traceId'
 > & { traceId?: string; disabled?: boolean };
 
+export type TraceProviderOptions = {
+  idGenerator?: Partial<TracingIdGenerator>;
+};
+
+function resolveTracingIdGenerator(
+  idGenerator?: Partial<TracingIdGenerator>,
+): TracingIdGenerator {
+  return {
+    generateTraceId:
+      idGenerator?.generateTraceId ?? defaultTracingIdGenerator.generateTraceId,
+    generateSpanId:
+      idGenerator?.generateSpanId ?? defaultTracingIdGenerator.generateSpanId,
+  };
+}
+
 export class TraceProvider {
   #multiProcessor: MultiTracingProcessor;
   #disabled: boolean;
   #shutdownPromise: Promise<void> | null;
+  #idGenerator: TracingIdGenerator;
 
-  constructor() {
+  constructor(options: TraceProviderOptions = {}) {
     this.#multiProcessor = new MultiTracingProcessor();
     this.#disabled = tracing.disabled;
     this.#shutdownPromise = null;
+    this.#idGenerator = resolveTracingIdGenerator(options.idGenerator);
 
     this.#addCleanupListeners();
   }
@@ -61,6 +82,28 @@ export class TraceProvider {
     this.#disabled = disabled;
   }
 
+  setIdGenerator(idGenerator?: Partial<TracingIdGenerator>): void {
+    this.#idGenerator = resolveTracingIdGenerator(idGenerator);
+  }
+
+  /**
+   * Generate a new trace ID.
+   *
+   * Override this in custom providers to take precedence over configured ID generators.
+   */
+  generateTraceId(): string {
+    return this.#idGenerator.generateTraceId();
+  }
+
+  /**
+   * Generate a new span ID.
+   *
+   * Override this in custom providers to take precedence over configured ID generators.
+   */
+  generateSpanId(): string {
+    return this.#idGenerator.generateSpanId();
+  }
+
   startExportLoop(): void {
     this.#multiProcessor.start();
   }
@@ -71,7 +114,7 @@ export class TraceProvider {
       return new NoopTrace();
     }
 
-    const traceId = traceOptions.traceId ?? generateTraceId();
+    const traceId = traceOptions.traceId ?? this.generateTraceId();
     const name = traceOptions.name ?? 'Agent workflow';
 
     logger.debug('Creating trace %s with name %s', traceId, name);
@@ -168,13 +211,20 @@ export class TraceProvider {
       return new NoopSpan(spanOptions.data, this.#multiProcessor);
     }
 
+    const spanId = spanOptions.spanId ?? this.generateSpanId();
+    if (spanId === NOOP_TRACE_OR_SPAN_ID) {
+      logger.debug('Span id is no-op, returning NoopSpan');
+      return new NoopSpan(spanOptions.data, this.#multiProcessor);
+    }
+
     logger.debug(
-      `Creating span ${JSON.stringify(spanOptions.data)} with id ${spanOptions.spanId ?? traceId}`,
+      `Creating span ${JSON.stringify(spanOptions.data)} with id ${spanId}`,
     );
 
     return new Span(
       {
         ...spanOptions,
+        spanId,
         traceId,
         parentId,
         traceMetadata: traceMetadata ?? spanOptions.traceMetadata,

--- a/packages/agents-core/src/tracing/utils.ts
+++ b/packages/agents-core/src/tracing/utils.ts
@@ -2,6 +2,11 @@ import { randomUUID } from '@openai/agents-core/_shims';
 
 export const NOOP_TRACE_OR_SPAN_ID = 'no-op';
 
+export type TracingIdGenerator = Readonly<{
+  generateTraceId: () => string;
+  generateSpanId: () => string;
+}>;
+
 /**
  * Generate an ISO 8601 timestamp of the current time.
  * @returns An ISO 8601 timestamp.
@@ -27,6 +32,11 @@ export function generateTraceId(): string {
 export function generateSpanId(): string {
   return `span_${randomUUID().replace(/-/g, '').slice(0, 24)}`;
 }
+
+export const defaultTracingIdGenerator: TracingIdGenerator = Object.freeze({
+  generateTraceId,
+  generateSpanId,
+});
 
 /**
  * Generate a group ID by creating a random UUID v4 and removing the dashes. This is the equivalent

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import {
   timeIso,
+  defaultTracingIdGenerator,
   generateTraceId,
   generateSpanId,
   generateGroupId,
@@ -35,6 +36,7 @@ import {
   getCurrentSpan,
   setTraceProcessors,
   setTracingDisabled,
+  setTracingIdGenerator,
   setCurrentSpan,
   resetCurrentSpan,
 } from '../src/tracing';
@@ -1232,6 +1234,147 @@ describe('TraceProvider disabled behavior', () => {
       trace,
     );
     expect(span).toBeInstanceOf(NoopSpan);
+  });
+});
+
+describe('TraceProvider ID generator behavior', () => {
+  it('keeps the default ID generator immutable', () => {
+    expect(Object.isFrozen(defaultTracingIdGenerator)).toBe(true);
+    expect(
+      Object.getOwnPropertyDescriptor(
+        defaultTracingIdGenerator,
+        'generateTraceId',
+      )?.writable,
+    ).toBe(false);
+    expect(
+      Object.getOwnPropertyDescriptor(
+        defaultTracingIdGenerator,
+        'generateSpanId',
+      )?.writable,
+    ).toBe(false);
+  });
+
+  it('uses a custom constructor ID generator for traces and spans', () => {
+    const provider = new TraceProvider({
+      idGenerator: {
+        generateTraceId: () => 'trace_custom_1',
+        generateSpanId: () => 'span_custom_1',
+      },
+    });
+    provider.setDisabled(false);
+
+    const trace = provider.createTrace({ name: 'deterministic' });
+    const span = provider.createSpan(
+      { data: { type: 'custom', name: 'deterministic', data: {} } },
+      trace,
+    );
+
+    expect(trace.traceId).toBe('trace_custom_1');
+    expect(span.spanId).toBe('span_custom_1');
+    expect(span.traceId).toBe('trace_custom_1');
+  });
+
+  it('prefers explicit trace and span IDs over the configured generator', () => {
+    const generateTraceId = vi.fn(() => 'trace_generated');
+    const generateSpanId = vi.fn(() => 'span_generated');
+    const provider = new TraceProvider({
+      idGenerator: {
+        generateTraceId,
+        generateSpanId,
+      },
+    });
+    provider.setDisabled(false);
+
+    const trace = provider.createTrace({
+      name: 'explicit',
+      traceId: 'trace_explicit',
+    });
+    const span = provider.createSpan(
+      {
+        spanId: 'span_explicit',
+        data: { type: 'custom', name: 'explicit', data: {} },
+      },
+      trace,
+    );
+
+    expect(trace.traceId).toBe('trace_explicit');
+    expect(span.spanId).toBe('span_explicit');
+    expect(generateTraceId).not.toHaveBeenCalled();
+    expect(generateSpanId).not.toHaveBeenCalled();
+  });
+
+  it('configures and resets the global provider ID generator', () => {
+    const provider = getGlobalTraceProvider();
+    provider.setDisabled(false);
+
+    try {
+      setTracingIdGenerator({
+        generateTraceId: () => 'trace_configured_global',
+        generateSpanId: () => 'span_configured_global',
+      });
+
+      const trace = provider.createTrace({ name: 'global' });
+      const span = provider.createSpan(
+        { data: { type: 'custom', name: 'global', data: {} } },
+        trace,
+      );
+
+      expect(trace.traceId).toBe('trace_configured_global');
+      expect(span.spanId).toBe('span_configured_global');
+    } finally {
+      setTracingIdGenerator();
+      provider.setDisabled(true);
+    }
+  });
+
+  it('prefers provider ID generation methods over the global ID generator', () => {
+    class DeterministicTraceProvider extends TraceProvider {
+      override generateTraceId(): string {
+        return 'trace_provider_custom';
+      }
+
+      override generateSpanId(): string {
+        return 'span_provider_custom';
+      }
+    }
+
+    const symbol = Symbol.for('openai.agents.core.traceProvider');
+    const globalHolder = globalThis as unknown as Record<
+      symbol | string,
+      TraceProvider | undefined
+    >;
+    const original = globalHolder[symbol];
+    const provider = new DeterministicTraceProvider();
+    const generateTraceId = vi.fn(() => 'trace_global_generator');
+    const generateSpanId = vi.fn(() => 'span_global_generator');
+
+    provider.setDisabled(false);
+    globalHolder[symbol] = provider;
+
+    try {
+      setTracingIdGenerator({ generateTraceId, generateSpanId });
+
+      const trace = getGlobalTraceProvider().createTrace({
+        name: 'provider-priority',
+      });
+      const span = getGlobalTraceProvider().createSpan(
+        { data: { type: 'custom', name: 'provider-priority', data: {} } },
+        trace,
+      );
+
+      expect(trace.traceId).toBe('trace_provider_custom');
+      expect(span.spanId).toBe('span_provider_custom');
+      expect(generateTraceId).not.toHaveBeenCalled();
+      expect(generateSpanId).not.toHaveBeenCalled();
+    } finally {
+      setTracingIdGenerator();
+      provider.setDisabled(true);
+      if (typeof original === 'undefined') {
+        delete globalHolder[symbol];
+      } else {
+        globalHolder[symbol] = original;
+      }
+    }
   });
 });
 


### PR DESCRIPTION
This pull request adds a supported tracing ID generation API so deterministic runtimes can provide replay-safe trace and span IDs without monkey-patching tracing internals.

It exposes overridable `TraceProvider.generateTraceId()` and `generateSpanId()` methods, adds `setTracingIdGenerator()` for the default global provider path, keeps explicit `traceId` / `spanId` values as the highest-priority inputs, and freezes `defaultTracingIdGenerator` so the exported default cannot be mutated. The tracing guide and regression tests cover the new behavior, including provider override priority over the global generator.