### PR TITLE
fix: add tracing context storage injection

### DIFF
--- a/.changeset/tracing-context-storage.md
+++ b/.changeset/tracing-context-storage.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: restore browser tracing context and add context storage injection

--- a/packages/agents-core/src/shims/shims-browser.ts
+++ b/packages/agents-core/src/shims/shims-browser.ts
@@ -119,17 +119,57 @@ export const ReadableStreamController =
   globalThis.ReadableStreamDefaultController;
 export const TransformStream = globalThis.TransformStream;
 
-export class AsyncLocalStorage {
-  context = null;
+function isPromiseLike(value: unknown): value is Promise<unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Promise<unknown>).finally === 'function'
+  );
+}
+
+export class AsyncLocalStorage<T = any> {
+  context: T | undefined = undefined;
+  #stack: Array<{ context: T }> = [];
+
   constructor() {}
-  run(context: any, fn: () => any) {
+
+  run<TResult>(context: T, fn: () => TResult): TResult {
+    const entry = { context };
+    this.#stack.push(entry);
     this.context = context;
-    return fn();
+
+    const restore = () => {
+      const index = this.#stack.indexOf(entry);
+      if (index !== -1) {
+        this.#stack.splice(index, 1);
+      }
+      this.context = this.#stack.at(-1)?.context;
+    };
+
+    try {
+      const result = fn();
+      if (isPromiseLike(result)) {
+        return result.finally(restore) as TResult;
+      }
+      restore();
+      return result;
+    } catch (error) {
+      restore();
+      throw error;
+    }
   }
+
   getStore() {
     return this.context;
   }
-  enterWith(context: any) {
+
+  enterWith(context: T) {
+    const current = this.#stack.at(-1);
+    if (current) {
+      current.context = context;
+    } else {
+      this.#stack.push({ context });
+    }
     this.context = context;
   }
 }

--- a/packages/agents-core/src/shims/shims-browser.ts
+++ b/packages/agents-core/src/shims/shims-browser.ts
@@ -123,8 +123,29 @@ function isPromiseLike(value: unknown): value is Promise<unknown> {
   return (
     typeof value === 'object' &&
     value !== null &&
+    typeof (value as Promise<unknown>).then === 'function' &&
     typeof (value as Promise<unknown>).finally === 'function'
   );
+}
+
+function getDeferredRestorePromise(
+  value: unknown,
+): Promise<unknown> | undefined {
+  if (typeof value !== 'object' || value === null) {
+    return undefined;
+  }
+
+  const streamLoopPromise = (
+    value as {
+      _getStreamLoopPromise?: () => unknown;
+    }
+  )._getStreamLoopPromise?.();
+
+  if (isPromiseLike(streamLoopPromise)) {
+    return streamLoopPromise;
+  }
+
+  return undefined;
 }
 
 export class AsyncLocalStorage<T = any> {
@@ -149,7 +170,21 @@ export class AsyncLocalStorage<T = any> {
     try {
       const result = fn();
       if (isPromiseLike(result)) {
-        return result.finally(restore) as TResult;
+        return result.then(
+          (value) => {
+            const deferredRestore = getDeferredRestorePromise(value);
+            if (deferredRestore) {
+              void deferredRestore.then(restore, restore);
+            } else {
+              restore();
+            }
+            return value;
+          },
+          (error) => {
+            restore();
+            throw error;
+          },
+        ) as TResult;
       }
       restore();
       return result;
@@ -167,8 +202,11 @@ export class AsyncLocalStorage<T = any> {
     const current = this.#stack.at(-1);
     if (current) {
       current.context = context;
-    } else {
+    } else if (context !== undefined) {
       this.#stack.push({ context });
+    } else {
+      this.context = context;
+      return;
     }
     this.context = context;
   }

--- a/packages/agents-core/src/tracing/context.ts
+++ b/packages/agents-core/src/tracing/context.ts
@@ -16,18 +16,40 @@ export type TraceContextSnapshot = Readonly<{
   span?: Span<any> | null;
 }>;
 
+export type TracingContextStorage<TStore = any> = {
+  /**
+   * Runs the callback with the provided store as the active tracing context.
+   */
+  run<TResult>(store: TStore, callback: () => TResult): TResult;
+
+  /**
+   * Returns the active tracing context store, if one exists.
+   */
+  getStore(): TStore | undefined;
+
+  /**
+   * Replaces the active tracing context store. The store is undefined when
+   * tracing clears the current scope.
+   */
+  enterWith(store: TStore | undefined): void;
+};
+
 const ALS_SYMBOL = Symbol.for('openai.agents.core.asyncLocalStorage');
-let localFallbackAls: AsyncLocalStorage<ContextState | undefined> | undefined;
+let localFallbackAls:
+  | TracingContextStorage<ContextState | undefined>
+  | undefined;
 
 // Global symbols ensure that if multiple copies of agents-core are loaded
 // (e.g., via different npm resolution paths or bundlers), they all share the
 // same AsyncLocalStorage instance. This prevents losing trace/span state when a
 // downstream package pulls in a duplicate copy.
-function getContextAsyncLocalStorage() {
+function getContextAsyncLocalStorage(): TracingContextStorage<
+  ContextState | undefined
+> {
   try {
     const globalScope = globalThis as unknown as Record<
       symbol | string,
-      AsyncLocalStorage<ContextState | undefined> | undefined
+      TracingContextStorage<ContextState | undefined> | undefined
     >;
 
     const globalALS = globalScope[ALS_SYMBOL];
@@ -37,7 +59,11 @@ function getContextAsyncLocalStorage() {
     }
 
     const newALS = new AsyncLocalStorage<ContextState | undefined>();
-    globalScope[ALS_SYMBOL] = newALS;
+    Object.defineProperty(globalScope, ALS_SYMBOL, {
+      value: newALS,
+      writable: true,
+      configurable: true,
+    });
     return newALS;
   } catch {
     // As a defensive fallback (e.g., if globalThis is locked down or ALS
@@ -50,8 +76,41 @@ function getContextAsyncLocalStorage() {
   }
 }
 
+/**
+ * Sets the context storage implementation used for tracing.
+ *
+ * Use this before starting traces in runtimes that cannot rely on the SDK's default
+ * AsyncLocalStorage implementation. Pass undefined to restore the default storage.
+ */
+export function setTracingContextStorage(
+  storage?: TracingContextStorage,
+): void {
+  try {
+    const globalScope = globalThis as unknown as Record<
+      symbol | string,
+      TracingContextStorage<ContextState | undefined> | undefined
+    >;
+
+    if (storage) {
+      Object.defineProperty(globalScope, ALS_SYMBOL, {
+        value: storage,
+        writable: true,
+        configurable: true,
+      });
+    } else {
+      delete globalScope[ALS_SYMBOL];
+    }
+
+    localFallbackAls = undefined;
+  } catch {
+    localFallbackAls = storage;
+  }
+}
+
 function getActiveContext() {
-  const store = getContextAsyncLocalStorage().getStore();
+  const store = getContextAsyncLocalStorage().getStore() as
+    | ContextState
+    | undefined;
   if (store?.active === true) {
     return store;
   }
@@ -289,7 +348,9 @@ export async function withTrace<T>(
     trace: newTrace,
     active: true,
   };
-  const previousAlsStore = getContextAsyncLocalStorage().getStore();
+  const previousAlsStore = getContextAsyncLocalStorage().getStore() as
+    | ContextState
+    | undefined;
 
   return getContextAsyncLocalStorage().run(
     context,
@@ -319,7 +380,9 @@ export async function getOrCreateTrace<T>(
     trace: newTrace,
     active: true,
   };
-  const previousAlsStore = getContextAsyncLocalStorage().getStore();
+  const previousAlsStore = getContextAsyncLocalStorage().getStore() as
+    | ContextState
+    | undefined;
   return getContextAsyncLocalStorage().run(
     newContext,
     _wrapFunctionWithTraceLifecycle(fn, newContext, previousAlsStore),

--- a/packages/agents-core/src/tracing/index.ts
+++ b/packages/agents-core/src/tracing/index.ts
@@ -10,10 +10,11 @@ export {
   getOrCreateTrace,
   resetCurrentSpan,
   setCurrentSpan,
+  setTracingContextStorage,
   withTraceContext,
   withTrace,
 } from './context';
-export type { TraceContextSnapshot } from './context';
+export type { TraceContextSnapshot, TracingContextStorage } from './context';
 export * from './createSpans';
 export {
   BatchTraceProcessor,

--- a/packages/agents-core/test/shims/browser-shims.test.ts
+++ b/packages/agents-core/test/shims/browser-shims.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test, vi } from 'vitest';
 
-import { BrowserEventEmitter, randomUUID } from '../../src/shims/shims-browser';
+import {
+  AsyncLocalStorage,
+  BrowserEventEmitter,
+  randomUUID,
+} from '../../src/shims/shims-browser';
 
 describe('BrowserEventEmitter', () => {
   test('off removes previously registered listener', () => {
@@ -116,5 +120,60 @@ describe('randomUUID', () => {
       value: originalCrypto,
       configurable: true,
     });
+  });
+});
+
+describe('AsyncLocalStorage browser shim', () => {
+  test('restores the previous context after a synchronous run', () => {
+    const storage = new AsyncLocalStorage<string>();
+
+    storage.enterWith('outer');
+    const result = storage.run('inner', () => {
+      expect(storage.getStore()).toBe('inner');
+      return 'done';
+    });
+
+    expect(result).toBe('done');
+    expect(storage.getStore()).toBe('outer');
+  });
+
+  test('restores the previous context after an asynchronous run settles', async () => {
+    const storage = new AsyncLocalStorage<string>();
+
+    storage.enterWith('outer');
+    const result = await storage.run('inner', async () => {
+      expect(storage.getStore()).toBe('inner');
+      await Promise.resolve();
+      expect(storage.getStore()).toBe('inner');
+      return 'done';
+    });
+
+    expect(result).toBe('done');
+    expect(storage.getStore()).toBe('outer');
+  });
+
+  test('keeps the active context when overlapping runs settle out of order', async () => {
+    const storage = new AsyncLocalStorage<string>();
+    let resolveFirst!: () => void;
+    let resolveSecond!: () => void;
+
+    const first = storage.run(
+      'first',
+      () => new Promise<void>((resolve) => (resolveFirst = resolve)),
+    );
+    const second = storage.run(
+      'second',
+      () => new Promise<void>((resolve) => (resolveSecond = resolve)),
+    );
+
+    expect(storage.getStore()).toBe('second');
+
+    resolveFirst();
+    await first;
+    expect(storage.getStore()).toBe('second');
+
+    resolveSecond();
+    await second;
+    expect(storage.getStore()).toBeUndefined();
   });
 });

--- a/packages/agents-core/test/shims/browser-shims.test.ts
+++ b/packages/agents-core/test/shims/browser-shims.test.ts
@@ -176,4 +176,27 @@ describe('AsyncLocalStorage browser shim', () => {
     await second;
     expect(storage.getStore()).toBeUndefined();
   });
+
+  test('keeps context until a streamed result loop settles', async () => {
+    const storage = new AsyncLocalStorage<string>();
+    let resolveStream!: () => void;
+    const streamLoopPromise = new Promise<void>((resolve) => {
+      resolveStream = resolve;
+    });
+    const streamedResult = {
+      _getStreamLoopPromise: () => streamLoopPromise,
+    };
+
+    storage.enterWith('outer');
+    const result = await storage.run('inner', async () => streamedResult);
+
+    expect(result).toBe(streamedResult);
+    expect(storage.getStore()).toBe('inner');
+
+    resolveStream();
+    await streamLoopPromise;
+    await Promise.resolve();
+
+    expect(storage.getStore()).toBe('outer');
+  });
 });

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -39,10 +39,11 @@ import {
   setTraceProcessors,
   setTracingDisabled,
   setTracingIdGenerator,
+  setTracingContextStorage,
   setCurrentSpan,
   resetCurrentSpan,
 } from '../src/tracing';
-import type { TraceContextSnapshot } from '../src/tracing';
+import type { TraceContextSnapshot, TracingContextStorage } from '../src/tracing';
 
 import {
   withAgentSpan,
@@ -95,6 +96,54 @@ class TestProcessor implements TracingProcessor {
   }
   async forceFlush(): Promise<void> {
     /* noop */
+  }
+}
+
+function isPromiseLike(value: unknown): value is Promise<unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Promise<unknown>).finally === 'function'
+  );
+}
+
+class StackTracingContextStorage implements TracingContextStorage {
+  runCalls = 0;
+  enterWithCalls = 0;
+  #stack: any[] = [];
+
+  run<TResult>(store: any, callback: () => TResult): TResult {
+    this.runCalls += 1;
+    this.#stack.push(store);
+
+    const restore = () => {
+      this.#stack.pop();
+    };
+
+    try {
+      const result = callback();
+      if (isPromiseLike(result)) {
+        return result.finally(restore) as TResult;
+      }
+      restore();
+      return result;
+    } catch (error) {
+      restore();
+      throw error;
+    }
+  }
+
+  getStore() {
+    return this.#stack.at(-1);
+  }
+
+  enterWith(store: any) {
+    this.enterWithCalls += 1;
+    if (this.#stack.length > 0) {
+      this.#stack[this.#stack.length - 1] = store;
+    } else {
+      this.#stack.push(store);
+    }
   }
 }
 
@@ -983,6 +1032,7 @@ describe('withTrace & span helpers (integration)', () => {
     // Restore original default processor so other test suites are unaffected
     // restore the global processor so subsequent tests are unaffected
     setTraceProcessors([defaultProcessor()]);
+    setTracingContextStorage();
   });
 
   it('withTrace creates a trace that is accessible via getCurrentTrace()', async () => {
@@ -1000,6 +1050,28 @@ describe('withTrace & span helpers (integration)', () => {
     // Processor should have been notified
     expect(processor.tracesStarted.length).toBe(1);
     expect(processor.tracesEnded.length).toBe(1);
+  });
+
+  it('uses a supplied tracing context storage implementation', async () => {
+    const storage = new StackTracingContextStorage();
+    const observed: Array<string | null> = [];
+
+    setTracingContextStorage(storage);
+
+    await withTrace('outer', async () => {
+      observed.push(getCurrentTrace()?.name ?? null);
+
+      await withTrace('inner', async () => {
+        observed.push(getCurrentTrace()?.name ?? null);
+      });
+
+      observed.push(getCurrentTrace()?.name ?? null);
+    });
+
+    expect(observed).toEqual(['outer', 'inner', 'outer']);
+    expect(storage.runCalls).toBe(2);
+    expect(storage.enterWithCalls).toBeGreaterThan(0);
+    expect(getCurrentTrace()).toBeNull();
   });
 
   it('getCurrentTraceContext returns null outside a trace', () => {

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -43,7 +43,10 @@ import {
   setCurrentSpan,
   resetCurrentSpan,
 } from '../src/tracing';
-import type { TraceContextSnapshot, TracingContextStorage } from '../src/tracing';
+import type {
+  TraceContextSnapshot,
+  TracingContextStorage,
+} from '../src/tracing';
 
 import {
   withAgentSpan,
@@ -56,6 +59,8 @@ import { TraceProvider, getGlobalTraceProvider } from '../src/tracing/provider';
 import { Runner } from '../src/run';
 import { Agent } from '../src/agent';
 import { StreamedRunResult } from '../src/result';
+import { RunContext } from '../src/runContext';
+import { RunState } from '../src/runState';
 import { FakeModel, fakeModelMessage, FakeModelProvider } from './stubs';
 import { Usage } from '../src/usage';
 import * as protocol from '../src/types/protocol';
@@ -1074,6 +1079,40 @@ describe('withTrace & span helpers (integration)', () => {
     expect(getCurrentTrace()).toBeNull();
   });
 
+  it('keeps browser shim context active until a streamed result settles', async () => {
+    const storage = new BrowserAsyncLocalStorage<any>();
+    let resolveStream!: () => void;
+    const streamLoopPromise = new Promise<void>((resolve) => {
+      resolveStream = resolve;
+    });
+    let activeTrace: Trace | null = null;
+
+    setTracingContextStorage(storage);
+
+    await withTrace('streaming-workflow', async (trace) => {
+      activeTrace = trace;
+      const agent = new Agent({ name: 'stream-agent' });
+      const state: RunState<unknown, Agent<any, any>> = new RunState(
+        new RunContext(),
+        [],
+        agent,
+        1,
+      );
+      const result = new StreamedRunResult({ state });
+      result._setStreamLoopPromise(streamLoopPromise);
+      return result;
+    });
+
+    expect(getCurrentTrace()).toBe(activeTrace);
+
+    resolveStream();
+    await streamLoopPromise;
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(getCurrentTrace()).toBeNull();
+  });
+
   it('getCurrentTraceContext returns null outside a trace', () => {
     expect(getCurrentTraceContext()).toBeNull();
   });
@@ -1230,7 +1269,6 @@ describe('withTrace & span helpers (integration)', () => {
       expect(getCurrentTrace()).toBe(trace);
       expect(getCurrentTraceContext()?.trace).toBe(trace);
     });
-
     expect(getCurrentTrace()).toBeNull();
   });
 


### PR DESCRIPTION
This pull request fixes tracing context handling in non-Node runtimes by adding a public tracing context storage injection API and making the browser `AsyncLocalStorage` shim restore scope on exit.

It documents that shared-isolate runtimes should provide runtime-scoped storage rather than relying on the browser shim for true async context propagation, and adds regressions for injected tracing storage plus browser shim restoration behavior.