### PR TITLE
fix: reset turn detection timers when re-enabling server VAD

### DIFF
--- a/.changeset/realtime-vad-timer-reset.md
+++ b/.changeset/realtime-vad-timer-reset.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: #1208 reset server turn detection timers when VAD is re-enabled

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -149,6 +149,9 @@ export abstract class OpenAIRealtimeBase
   #apiKey: ApiKey | undefined;
   #tracingConfig: RealtimeTracingConfig | null = null;
   #rawSessionConfig: Record<string, any> | null = null;
+  // Tracks the last turn detection state we sent so we can reset the server's
+  // idle/turn timers when voice activity detection is toggled back on.
+  #turnDetectionEnabled: boolean | undefined = undefined;
 
   protected eventEmitter: RuntimeEventEmitter<OpenAIRealtimeEventTypes> =
     new RuntimeEventEmitter<OpenAIRealtimeEventTypes>();
@@ -860,6 +863,41 @@ export abstract class OpenAIRealtimeBase
       type: 'session.update',
       session: sessionData,
     });
+
+    this._resetTurnDetectionTimersIfReenabled(config);
+  }
+
+  /**
+   * Resets the server-side turn detection timers when voice activity detection
+   * is toggled back on.
+   *
+   * Disabling turn detection (`turnDetection: null`) leaves the previous idle
+   * timer running on the server. If detection stays off for longer than the
+   * configured idle timeout and is then re-enabled, the stale timer fires
+   * immediately and the model speaks before the user gets a chance to. Clearing
+   * the input audio buffer when detection is re-enabled resets that state so the
+   * idle timer only starts counting from fresh speech.
+   *
+   * @param config - The session config that was just applied.
+   */
+  private _resetTurnDetectionTimersIfReenabled(
+    config: Partial<RealtimeSessionConfig>,
+  ): void {
+    const turnDetection =
+      toNewSessionConfig(config).audio?.input?.turnDetection;
+    // `undefined` means this update did not touch turn detection, so leave the
+    // tracked state (and any in-flight audio) untouched.
+    if (typeof turnDetection === 'undefined') {
+      return;
+    }
+
+    const enabled = turnDetection !== null;
+    const wasDisabled = this.#turnDetectionEnabled === false;
+    this.#turnDetectionEnabled = enabled;
+
+    if (enabled && wasDisabled) {
+      this.sendEvent({ type: 'input_audio_buffer.clear' });
+    }
   }
 
   /**

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -169,6 +169,90 @@ describe('OpenAIRealtimeBase helpers', () => {
     expect(session?.audio?.output?.voice).toBe('echo');
   });
 
+  it('clears the input audio buffer when turn detection is re-enabled', () => {
+    const base = new TestBase();
+
+    // Disable turn detection (VAD off).
+    base.updateSessionConfig({
+      audio: { input: { turnDetection: null } },
+    });
+    // Re-enable turn detection (VAD on). The server keeps a stale idle timer
+    // while VAD is off, so re-enabling has to reset it to avoid an immediate
+    // idle trigger.
+    base.updateSessionConfig({
+      audio: {
+        input: {
+          turnDetection: { type: 'server_vad', idleTimeoutMs: 5000 },
+        },
+      },
+    });
+
+    const sentTypes = base.events.map((event) => event.type);
+    expect(sentTypes).toEqual([
+      'session.update',
+      'session.update',
+      'input_audio_buffer.clear',
+    ]);
+  });
+
+  it('does not clear the input audio buffer when turn detection stays enabled', () => {
+    const base = new TestBase();
+
+    base.updateSessionConfig({
+      audio: {
+        input: {
+          turnDetection: { type: 'server_vad', idleTimeoutMs: 5000 },
+        },
+      },
+    });
+    base.updateSessionConfig({
+      audio: {
+        input: {
+          turnDetection: { type: 'server_vad', idleTimeoutMs: 8000 },
+        },
+      },
+    });
+
+    const sentTypes = base.events.map((event) => event.type);
+    expect(sentTypes).not.toContain('input_audio_buffer.clear');
+  });
+
+  it('does not clear the input audio buffer when turn detection is disabled', () => {
+    const base = new TestBase();
+
+    base.updateSessionConfig({
+      audio: {
+        input: {
+          turnDetection: { type: 'server_vad', idleTimeoutMs: 5000 },
+        },
+      },
+    });
+    base.updateSessionConfig({
+      audio: { input: { turnDetection: null } },
+    });
+
+    const sentTypes = base.events.map((event) => event.type);
+    expect(sentTypes).not.toContain('input_audio_buffer.clear');
+  });
+
+  it('does not clear the input audio buffer when an update omits turn detection', () => {
+    const base = new TestBase();
+
+    base.updateSessionConfig({
+      audio: {
+        input: {
+          turnDetection: { type: 'server_vad', idleTimeoutMs: 5000 },
+        },
+      },
+    });
+    // An unrelated update that does not touch turn detection must not clear the
+    // buffer or accidentally drop the user's in-flight audio.
+    base.updateSessionConfig({ voice: 'echo' });
+
+    const sentTypes = base.events.map((event) => event.type);
+    expect(sentTypes).not.toContain('input_audio_buffer.clear');
+  });
+
   it('whitelists function tools in session payload', () => {
     const base = new TestBase();
     const payload = (base as any)._getMergedSessionConfig({


### PR DESCRIPTION
## Summary

Re-enabling server VAD after turning it off triggers an immediate idle prompt. Disabling turn detection (`turnDetection: null`) leaves the server's idle timer running, so if VAD stays off longer than `idleTimeoutMs` and is then re-enabled, the stale timer fires right away and the model speaks before the user gets a chance to.

`updateSessionConfig` now tracks the turn detection state and clears the input audio buffer when detection transitions from off to on, which resets the server-side idle/turn timers so they only start counting from fresh speech. Updates that don't touch turn detection are left untouched so in-flight audio isn't dropped.

Fixes #1208

## Test plan

- [x] `cd packages/agents-realtime && CI=1 pnpm vitest run` (new tests in `test/openaiRealtimeBase.test.ts` cover re-enable / stay-enabled / disable / untouched cases; the re-enable test fails on `main`)
- [x] `pnpm build && pnpm -r build-check && pnpm lint`

## Note

This resets the timer for the supported `transport.updateSessionConfig` path. Callers that toggle VAD by sending raw `session.update` events via `transport.sendEvent` bypass this and should send an `input_audio_buffer.clear` themselves (or switch to `updateSessionConfig`).