### PR TITLE
feat: add scoped trace context helpers

### DIFF
--- a/.changeset/scoped-trace-context.md
+++ b/.changeset/scoped-trace-context.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+feat: add scoped trace context helpers

--- a/packages/agents-core/src/tracing/context.ts
+++ b/packages/agents-core/src/tracing/context.ts
@@ -60,11 +60,35 @@ function getActiveContext() {
 
 function isPromiseLike(value: unknown): value is Promise<unknown> {
   return (
-    typeof value === 'object' &&
+    (typeof value === 'object' || typeof value === 'function') &&
     value !== null &&
-    typeof (value as Promise<unknown>).then === 'function' &&
-    typeof (value as Promise<unknown>).finally === 'function'
+    typeof (value as Promise<unknown>).then === 'function'
   );
+}
+
+function deferRestoreForStreamedRunResult(
+  result: unknown,
+  restore: () => void,
+) {
+  if (!(result instanceof StreamedRunResult)) {
+    return false;
+  }
+
+  const streamLoopPromise = result._getStreamLoopPromise();
+  if (!streamLoopPromise) {
+    return false;
+  }
+
+  void streamLoopPromise.then(restore, restore);
+  return true;
+}
+
+function restoreAfterResolvedValue<T>(result: T, restore: () => void): T {
+  if (!deferRestoreForStreamedRunResult(result, restore)) {
+    restore();
+  }
+
+  return result;
 }
 
 function runWithScopedTraceContext<T>(store: ContextState, fn: () => T): T {
@@ -78,12 +102,18 @@ function runWithScopedTraceContext<T>(store: ContextState, fn: () => T): T {
     let restoreOnExit = true;
     try {
       const result = fn();
+      restoreOnExit = false;
       if (isPromiseLike(result)) {
-        restoreOnExit = false;
-        return result.finally(restore) as T;
+        return result.then(
+          (resolved) => restoreAfterResolvedValue(resolved, restore),
+          (error) => {
+            restore();
+            throw error;
+          },
+        ) as T;
       }
 
-      return result;
+      return restoreAfterResolvedValue(result, restore);
     } finally {
       if (restoreOnExit) {
         restore();
@@ -157,6 +187,7 @@ export function withTraceContext<T>(
     {
       trace: context.trace,
       span: context.span ?? undefined,
+      previousSpan: context.span?.previousSpan,
       active: true,
     },
     fn,

--- a/packages/agents-core/src/tracing/context.ts
+++ b/packages/agents-core/src/tracing/context.ts
@@ -11,6 +11,11 @@ type ContextState = {
   active: boolean;
 };
 
+export type TraceContextSnapshot = Readonly<{
+  trace: Trace;
+  span?: Span<any> | null;
+}>;
+
 const ALS_SYMBOL = Symbol.for('openai.agents.core.asyncLocalStorage');
 let localFallbackAls: AsyncLocalStorage<ContextState | undefined> | undefined;
 
@@ -78,6 +83,50 @@ export function getCurrentSpan() {
     return currentSpan.span;
   }
   return null;
+}
+
+/**
+ * Gets a public snapshot of the current trace context.
+ *
+ * This intentionally does not expose the internal async storage shape.
+ */
+export function getCurrentTraceContext(): TraceContextSnapshot | null {
+  const context = getActiveContext();
+  if (!context?.trace) {
+    return null;
+  }
+
+  if (context.span) {
+    return {
+      trace: context.trace,
+      span: context.span,
+    };
+  }
+
+  return { trace: context.trace };
+}
+
+/**
+ * Runs a callback with a previously captured trace context.
+ *
+ * Pass null or undefined to run the callback without any ambient trace context.
+ */
+export function withTraceContext<T>(
+  context: TraceContextSnapshot | null | undefined,
+  fn: () => T,
+): T {
+  if (!context) {
+    return getContextAsyncLocalStorage().run({ active: false }, fn);
+  }
+
+  return getContextAsyncLocalStorage().run(
+    {
+      trace: context.trace,
+      span: context.span ?? undefined,
+      active: true,
+    },
+    fn,
+  );
 }
 
 /**

--- a/packages/agents-core/src/tracing/context.ts
+++ b/packages/agents-core/src/tracing/context.ts
@@ -58,6 +58,40 @@ function getActiveContext() {
   return undefined;
 }
 
+function isPromiseLike(value: unknown): value is Promise<unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Promise<unknown>).then === 'function' &&
+    typeof (value as Promise<unknown>).finally === 'function'
+  );
+}
+
+function runWithScopedTraceContext<T>(store: ContextState, fn: () => T): T {
+  const asyncLocalStorage = getContextAsyncLocalStorage();
+  const previousStore = asyncLocalStorage.getStore();
+  const restore = () => {
+    asyncLocalStorage.enterWith(previousStore);
+  };
+
+  return asyncLocalStorage.run(store, () => {
+    let restoreOnExit = true;
+    try {
+      const result = fn();
+      if (isPromiseLike(result)) {
+        restoreOnExit = false;
+        return result.finally(restore) as T;
+      }
+
+      return result;
+    } finally {
+      if (restoreOnExit) {
+        restore();
+      }
+    }
+  });
+}
+
 /**
  * This function will get the current trace from the execution context.
  *
@@ -116,10 +150,10 @@ export function withTraceContext<T>(
   fn: () => T,
 ): T {
   if (!context) {
-    return getContextAsyncLocalStorage().run({ active: false }, fn);
+    return runWithScopedTraceContext({ active: false }, fn);
   }
 
-  return getContextAsyncLocalStorage().run(
+  return runWithScopedTraceContext(
     {
       trace: context.trace,
       span: context.span ?? undefined,

--- a/packages/agents-core/src/tracing/index.ts
+++ b/packages/agents-core/src/tracing/index.ts
@@ -3,13 +3,16 @@ import { getGlobalTraceProvider } from './provider';
 import type { TracingConfig } from './config';
 
 export {
+  getCurrentTraceContext,
   getCurrentSpan,
   getCurrentTrace,
   getOrCreateTrace,
   resetCurrentSpan,
   setCurrentSpan,
+  withTraceContext,
   withTrace,
 } from './context';
+export type { TraceContextSnapshot } from './context';
 export * from './createSpans';
 export {
   BatchTraceProcessor,

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -52,6 +52,7 @@ import { TraceProvider, getGlobalTraceProvider } from '../src/tracing/provider';
 
 import { Runner } from '../src/run';
 import { Agent } from '../src/agent';
+import { StreamedRunResult } from '../src/result';
 import { FakeModel, fakeModelMessage, FakeModelProvider } from './stubs';
 import { Usage } from '../src/usage';
 import * as protocol from '../src/types/protocol';
@@ -1100,6 +1101,52 @@ describe('withTrace & span helpers (integration)', () => {
     }
   });
 
+  it('withTraceContext keeps browser context until streamed results finish', async () => {
+    const globalScope = globalThis as unknown as Record<
+      symbol,
+      unknown | undefined
+    >;
+    const previousStorage = globalScope[ALS_SYMBOL];
+    const trace = new Trace({ name: 'manual-streaming-trace' });
+
+    globalScope[ALS_SYMBOL] = new BrowserAsyncLocalStorage();
+
+    try {
+      let finishStreamLoop!: () => void;
+      let traceDuringStreamLoop: Trace | null | undefined;
+      const streamLoopGate = new Promise<void>((resolve) => {
+        finishStreamLoop = resolve;
+      });
+      const streamLoopPromise = streamLoopGate.then(() => {
+        traceDuringStreamLoop = getCurrentTrace();
+      });
+
+      const resultPromise = withTraceContext({ trace }, async () => {
+        const result = new StreamedRunResult<any, any>();
+        result._setStreamLoopPromise(streamLoopPromise);
+        return result;
+      });
+
+      const result = await resultPromise;
+
+      expect(result).toBeInstanceOf(StreamedRunResult);
+      expect(getCurrentTrace()).toBe(trace);
+
+      finishStreamLoop();
+      await streamLoopPromise;
+      await Promise.resolve();
+
+      expect(traceDuringStreamLoop).toBe(trace);
+      expect(getCurrentTrace()).toBeNull();
+    } finally {
+      if (previousStorage === undefined) {
+        delete globalScope[ALS_SYMBOL];
+      } else {
+        globalScope[ALS_SYMBOL] = previousStorage;
+      }
+    }
+  });
+
   it('withTraceContext keeps context across awaits', async () => {
     const trace = new Trace({ name: 'manual-async-trace' });
 
@@ -1184,6 +1231,33 @@ describe('withTrace & span helpers (integration)', () => {
 
       resetCurrentSpan();
       expect(getCurrentSpan()).toBeNull();
+    });
+  });
+
+  it('withTraceContext preserves the captured span stack', async () => {
+    await withTrace('workflow', async () => {
+      const spanA = createAgentSpan({ data: { name: 'A' } });
+      setCurrentSpan(spanA);
+      const spanB = createAgentSpan({ data: { name: 'B' } });
+      setCurrentSpan(spanB);
+      const snapshot = getCurrentTraceContext();
+
+      expect(snapshot?.span).toBe(spanB);
+      expect(spanB.previousSpan).toBe(spanA);
+
+      withTraceContext(snapshot, () => {
+        const spanC = createAgentSpan({ data: { name: 'C' } });
+        setCurrentSpan(spanC);
+
+        expect(spanC.previousSpan).toBe(spanB);
+        resetCurrentSpan();
+        expect(getCurrentSpan()).toBe(spanB);
+        resetCurrentSpan();
+        expect(getCurrentSpan()).toBe(spanA);
+      });
+
+      expect(spanB.previousSpan).toBe(spanA);
+      expect(getCurrentSpan()).toBe(spanB);
     });
   });
 

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -31,6 +31,8 @@ import { allowConsole } from '../../../helpers/tests/console-guard';
 
 import {
   withTrace,
+  withTraceContext,
+  getCurrentTraceContext,
   getCurrentTrace,
   getCurrentSpan,
   setTraceProcessors,
@@ -38,6 +40,7 @@ import {
   setCurrentSpan,
   resetCurrentSpan,
 } from '../src/tracing';
+import type { TraceContextSnapshot } from '../src/tracing';
 
 import {
   withAgentSpan,
@@ -991,6 +994,81 @@ describe('withTrace & span helpers (integration)', () => {
     // Processor should have been notified
     expect(processor.tracesStarted.length).toBe(1);
     expect(processor.tracesEnded.length).toBe(1);
+  });
+
+  it('getCurrentTraceContext returns null outside a trace', () => {
+    expect(getCurrentTraceContext()).toBeNull();
+  });
+
+  it('getCurrentTraceContext returns the active trace snapshot', async () => {
+    await withTrace('workflow', async (trace) => {
+      const snapshot = getCurrentTraceContext();
+
+      expect(snapshot).toEqual({ trace });
+      expect(snapshot?.trace).toBe(getCurrentTrace());
+    });
+  });
+
+  it('withTraceContext restores a captured trace around a callback', async () => {
+    let snapshot: TraceContextSnapshot | null = null;
+
+    await withTrace('workflow', async () => {
+      snapshot = getCurrentTraceContext();
+    });
+
+    expect(snapshot).not.toBeNull();
+    const result = withTraceContext(snapshot, () => {
+      expect(getCurrentTrace()).toBe(snapshot?.trace);
+      return 'done';
+    });
+
+    expect(result).toBe('done');
+    expect(getCurrentTrace()).toBeNull();
+  });
+
+  it('withTraceContext restores a provided span around a callback', () => {
+    const trace = new Trace({ name: 'manual-trace' });
+    const span = new Span(
+      {
+        traceId: trace.traceId,
+        data: { type: 'custom', name: 'manual-span', data: {} },
+      },
+      processor,
+    );
+
+    withTraceContext({ trace, span }, () => {
+      expect(getCurrentTrace()).toBe(trace);
+      expect(getCurrentSpan()).toBe(span);
+    });
+
+    expect(getCurrentTrace()).toBeNull();
+    expect(getCurrentSpan()).toBeNull();
+  });
+
+  it('withTraceContext clears and restores ambient trace context', async () => {
+    await withTrace('workflow', async (trace) => {
+      const result = withTraceContext(null, () => {
+        expect(getCurrentTrace()).toBeNull();
+        expect(getCurrentTraceContext()).toBeNull();
+        return 'isolated';
+      });
+
+      expect(result).toBe('isolated');
+      expect(getCurrentTrace()).toBe(trace);
+    });
+  });
+
+  it('withTraceContext keeps context across awaits', async () => {
+    const trace = new Trace({ name: 'manual-async-trace' });
+
+    await withTraceContext({ trace }, async () => {
+      expect(getCurrentTrace()).toBe(trace);
+      await Promise.resolve();
+      expect(getCurrentTrace()).toBe(trace);
+      expect(getCurrentTraceContext()?.trace).toBe(trace);
+    });
+
+    expect(getCurrentTrace()).toBeNull();
   });
 
   it('does not allow setting spans after a trace ends', async () => {

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -56,6 +56,9 @@ import { FakeModel, fakeModelMessage, FakeModelProvider } from './stubs';
 import { Usage } from '../src/usage';
 import * as protocol from '../src/types/protocol';
 import { setDefaultModelProvider } from '../src/providers';
+import { AsyncLocalStorage as BrowserAsyncLocalStorage } from '../src/shims/shims-browser';
+
+const ALS_SYMBOL = Symbol.for('openai.agents.core.asyncLocalStorage');
 
 class TestExporter implements TracingExporter {
   public exported: Array<(Trace | Span<any>)[]> = [];
@@ -1056,6 +1059,45 @@ describe('withTrace & span helpers (integration)', () => {
       expect(result).toBe('isolated');
       expect(getCurrentTrace()).toBe(trace);
     });
+  });
+
+  it('withTraceContext restores ambient trace context with browser storage', async () => {
+    const globalScope = globalThis as unknown as Record<
+      symbol,
+      unknown | undefined
+    >;
+    const previousStorage = globalScope[ALS_SYMBOL];
+
+    globalScope[ALS_SYMBOL] = new BrowserAsyncLocalStorage();
+
+    try {
+      await withTrace('workflow', async (trace) => {
+        const overlayTrace = new Trace({ name: 'overlay-trace' });
+
+        const isolated = withTraceContext(null, () => {
+          expect(getCurrentTrace()).toBeNull();
+          expect(getCurrentTraceContext()).toBeNull();
+          return 'isolated';
+        });
+
+        expect(isolated).toBe('isolated');
+        expect(getCurrentTrace()).toBe(trace);
+
+        await withTraceContext({ trace: overlayTrace }, async () => {
+          expect(getCurrentTrace()).toBe(overlayTrace);
+          await Promise.resolve();
+          expect(getCurrentTrace()).toBe(overlayTrace);
+        });
+
+        expect(getCurrentTrace()).toBe(trace);
+      });
+    } finally {
+      if (previousStorage === undefined) {
+        delete globalScope[ALS_SYMBOL];
+      } else {
+        globalScope[ALS_SYMBOL] = previousStorage;
+      }
+    }
   });
 
   it('withTraceContext keeps context across awaits', async () => {


### PR DESCRIPTION
This pull request adds public scoped trace context helpers to `@openai/agents-core`.

It introduces `getCurrentTraceContext()` for capturing the current public `Trace` and optional `Span`, plus `withTraceContext(...)` for restoring, overlaying, or clearing trace context around a callback. This lets integrations avoid reading the SDK's private async storage shape while still preserving trace/span context across runtime boundaries.