### PR TITLE
feat: add Handoff clone overrides

### DIFF
--- a/.changeset/handoff-clone-api.md
+++ b/.changeset/handoff-clone-api.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+feat: add Handoff clone overrides

--- a/packages/agents-core/src/handoff.ts
+++ b/packages/agents-core/src/handoff.ts
@@ -246,10 +246,15 @@ export class Handoff<
     overrides: HandoffCloneOptions<TContext, TOutput> = {},
   ): Handoff<TContext, TOutput> {
     const agent = overrides.agent ?? this.agent;
-    const cloned = new Handoff(
-      agent,
-      overrides.onInvokeHandoff ?? this.onInvokeHandoff,
-    );
+    const onInvokeHandoff =
+      overrides.onInvokeHandoff ??
+      (overrides.agent
+        ? async (context: RunContext<TContext>, args: string) => {
+            await this.onInvokeHandoff(context, args);
+            return agent;
+          }
+        : this.onInvokeHandoff);
+    const cloned = new Handoff(agent, onInvokeHandoff);
 
     cloned.agentName =
       overrides.agentName ??

--- a/packages/agents-core/src/handoff.ts
+++ b/packages/agents-core/src/handoff.ts
@@ -105,6 +105,59 @@ export type HandoffEnabledFunction<TContext = UnknownContext> = (args: {
   agent: Agent<any, any>;
 }) => Promise<boolean>;
 
+export type HandoffCloneOptions<
+  TContext = UnknownContext,
+  TOutput extends AgentOutputType = TextOutput,
+> = {
+  /**
+   * The agent that the cloned handoff should target.
+   */
+  agent?: Agent<TContext, TOutput>;
+
+  /**
+   * The callback that should run when the cloned handoff is invoked.
+   */
+  onInvokeHandoff?: (
+    context: RunContext<TContext>,
+    args: string,
+  ) => Promise<Agent<TContext, TOutput>> | Agent<TContext, TOutput>;
+
+  /**
+   * The model-facing name of the target agent.
+   */
+  agentName?: string;
+
+  /**
+   * The name of the tool that represents the cloned handoff.
+   */
+  toolName?: string;
+
+  /**
+   * The description of the tool that represents the cloned handoff.
+   */
+  toolDescription?: string;
+
+  /**
+   * The JSON schema for the cloned handoff input.
+   */
+  inputJsonSchema?: JsonObjectSchema<any>;
+
+  /**
+   * Whether the cloned handoff input schema is strict.
+   */
+  strictJsonSchema?: boolean;
+
+  /**
+   * A function that filters the inputs that are passed to the cloned handoff's agent.
+   */
+  inputFilter?: HandoffInputFilter;
+
+  /**
+   * Determines whether the cloned handoff should be available for the current run.
+   */
+  isEnabled?: HandoffEnabledFunction<TContext>;
+};
+
 export class Handoff<
   TContext = UnknownContext,
   TOutput extends AgentOutputType = TextOutput,
@@ -181,6 +234,35 @@ export class Handoff<
       parameters: this.inputJsonSchema,
       strict: this.strictJsonSchema,
     };
+  }
+
+  /**
+   * Makes a copy of this handoff, with the given fields changed.
+   *
+   * Tool name and description default to the original handoff's values so adapters can replace
+   * the runtime target without changing the model-facing tool contract.
+   */
+  clone(
+    overrides: HandoffCloneOptions<TContext, TOutput> = {},
+  ): Handoff<TContext, TOutput> {
+    const agent = overrides.agent ?? this.agent;
+    const cloned = new Handoff(
+      agent,
+      overrides.onInvokeHandoff ?? this.onInvokeHandoff,
+    );
+
+    cloned.agentName =
+      overrides.agentName ??
+      (overrides.agent ? overrides.agent.name : this.agentName);
+    cloned.toolName = overrides.toolName ?? this.toolName;
+    cloned.toolDescription = overrides.toolDescription ?? this.toolDescription;
+    cloned.inputJsonSchema = overrides.inputJsonSchema ?? this.inputJsonSchema;
+    cloned.strictJsonSchema =
+      overrides.strictJsonSchema ?? this.strictJsonSchema;
+    cloned.inputFilter = overrides.inputFilter ?? this.inputFilter;
+    cloned.isEnabled = overrides.isEnabled ?? this.isEnabled;
+
+    return cloned;
   }
 
   public isEnabled: HandoffEnabledFunction<TContext> = async () => true;

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -80,6 +80,7 @@ export {
   getHandoff,
   getTransferMessage,
   Handoff,
+  HandoffCloneOptions,
   handoff,
   HandoffInputData,
   HandoffEnabledFunction,

--- a/packages/agents-core/test/handoff.test.ts
+++ b/packages/agents-core/test/handoff.test.ts
@@ -151,16 +151,26 @@ describe('Handoff#clone', () => {
     expect(h.agentName).toBe('Original Agent');
   });
 
-  it('preserves tool metadata by default when replacing the agent', () => {
+  it('returns the replacement agent by default while preserving handoff side effects', async () => {
     const originalAgent = new Agent({ name: 'Original Agent' });
     const convertedAgent = new Agent({ name: 'Converted Agent' });
+    const onHandoff = vi.fn();
     const h = handoff(originalAgent, {
+      onHandoff,
+      inputType: z.object({ reason: z.string() }),
       toolNameOverride: 'stable_transfer',
       toolDescriptionOverride: 'Stable transfer',
     });
+    const runContext = new RunContext();
 
     const clone = h.clone({ agent: convertedAgent });
+    const result = await clone.onInvokeHandoff(
+      runContext,
+      '{"reason":"reroute"}',
+    );
 
+    expect(result).toBe(convertedAgent);
+    expect(onHandoff).toHaveBeenCalledWith(runContext, { reason: 'reroute' });
     expect(clone.agent).toBe(convertedAgent);
     expect(clone.agentName).toBe('Converted Agent');
     expect(clone.toolName).toBe('stable_transfer');

--- a/packages/agents-core/test/handoff.test.ts
+++ b/packages/agents-core/test/handoff.test.ts
@@ -4,6 +4,7 @@ import { handoff, getHandoff, Handoff } from '../src/handoff';
 import { ModelBehaviorError, UserError } from '../src/errors';
 import { z } from 'zod';
 import logger from '../src/logger';
+import { RunContext } from '../src/runContext';
 
 const agent = new Agent({ name: 'A' });
 
@@ -60,6 +61,154 @@ describe('handoff()', () => {
     expect(h.toolName).toBe('t');
     expect(h.toolDescription).toBe('d');
     expect(h.inputFilter).toBe(filter);
+  });
+});
+
+describe('Handoff#clone', () => {
+  it('returns a distinct Handoff instance and leaves the original unchanged', async () => {
+    const targetAgent = new Agent({ name: 'Target Agent' });
+    const filter = vi.fn((data) => data);
+    const h = handoff(targetAgent, {
+      inputFilter: filter,
+      isEnabled: false,
+      toolNameOverride: 'stable_transfer',
+      toolDescriptionOverride: 'Stable transfer',
+    });
+
+    const clone = h.clone();
+    clone.toolName = 'mutated_clone_transfer';
+
+    expect(clone).toBeInstanceOf(Handoff);
+    expect(clone).not.toBe(h);
+    expect(h.toolName).toBe('stable_transfer');
+    expect(h.toolDescription).toBe('Stable transfer');
+    expect(h.inputFilter).toBe(filter);
+    await expect(
+      h.isEnabled({ runContext: new RunContext(), agent: targetAgent }),
+    ).resolves.toBe(false);
+  });
+
+  it('preserves metadata and callback behavior without overrides', async () => {
+    const targetAgent = new Agent({ name: 'Target Agent' });
+    const onHandoff = vi.fn();
+    const filter = vi.fn((data) => data);
+    const h = handoff(targetAgent, {
+      onHandoff,
+      inputType: z.object({ reason: z.string() }),
+      inputFilter: filter,
+      isEnabled: true,
+      toolNameOverride: 'stable_transfer',
+      toolDescriptionOverride: 'Stable transfer',
+    });
+    const runContext = new RunContext();
+
+    const clone = h.clone();
+    const result = await clone.onInvokeHandoff(
+      runContext,
+      '{"reason":"refund"}',
+    );
+
+    expect(result).toBe(targetAgent);
+    expect(onHandoff).toHaveBeenCalledWith(runContext, { reason: 'refund' });
+    expect(clone.agent).toBe(h.agent);
+    expect(clone.agentName).toBe(h.agentName);
+    expect(clone.toolName).toBe(h.toolName);
+    expect(clone.toolDescription).toBe(h.toolDescription);
+    expect(clone.inputJsonSchema).toEqual(h.inputJsonSchema);
+    expect(clone.strictJsonSchema).toBe(h.strictJsonSchema);
+    expect(clone.inputFilter).toBe(filter);
+    expect(clone.isEnabled).toBe(h.isEnabled);
+    expect(clone.getHandoffAsFunctionTool()).toEqual(
+      h.getHandoffAsFunctionTool(),
+    );
+  });
+
+  it('supports target agent and callback overrides', async () => {
+    const originalAgent = new Agent({ name: 'Original Agent' });
+    const convertedAgent = new Agent({ name: 'Converted Agent' });
+    const originalCallback = vi.fn();
+    const overrideCallback = vi.fn(async () => convertedAgent);
+    const h = handoff(originalAgent, {
+      onHandoff: originalCallback,
+      toolNameOverride: 'stable_transfer',
+      toolDescriptionOverride: 'Stable transfer',
+    });
+
+    const clone = h.clone({
+      agent: convertedAgent,
+      onInvokeHandoff: overrideCallback,
+    });
+    const result = await clone.onInvokeHandoff(new RunContext(), '{}');
+
+    expect(result).toBe(convertedAgent);
+    expect(overrideCallback).toHaveBeenCalledOnce();
+    expect(originalCallback).not.toHaveBeenCalled();
+    expect(clone.agent).toBe(convertedAgent);
+    expect(clone.agentName).toBe('Converted Agent');
+    expect(clone.toolName).toBe('stable_transfer');
+    expect(clone.toolDescription).toBe('Stable transfer');
+    expect(h.agent).toBe(originalAgent);
+    expect(h.agentName).toBe('Original Agent');
+  });
+
+  it('preserves tool metadata by default when replacing the agent', () => {
+    const originalAgent = new Agent({ name: 'Original Agent' });
+    const convertedAgent = new Agent({ name: 'Converted Agent' });
+    const h = handoff(originalAgent, {
+      toolNameOverride: 'stable_transfer',
+      toolDescriptionOverride: 'Stable transfer',
+    });
+
+    const clone = h.clone({ agent: convertedAgent });
+
+    expect(clone.agent).toBe(convertedAgent);
+    expect(clone.agentName).toBe('Converted Agent');
+    expect(clone.toolName).toBe('stable_transfer');
+    expect(clone.toolDescription).toBe('Stable transfer');
+  });
+
+  it('uses explicit clone metadata overrides', async () => {
+    const originalAgent = new Agent({ name: 'Original Agent' });
+    const convertedAgent = new Agent({ name: 'Converted Agent' });
+    const filter = vi.fn((data) => data);
+    const isEnabled = vi.fn(async () => false);
+    const inputJsonSchema = {
+      type: 'object' as const,
+      properties: { reason: { type: 'string' } },
+      required: ['reason'],
+      additionalProperties: false,
+    };
+    const h = handoff(originalAgent);
+
+    const clone = h.clone({
+      agent: convertedAgent,
+      agentName: 'Runtime Target',
+      toolName: 'transfer_to_runtime_target',
+      toolDescription: 'Runtime target handoff',
+      inputJsonSchema,
+      strictJsonSchema: false,
+      inputFilter: filter,
+      isEnabled,
+    });
+
+    expect(clone.agent).toBe(convertedAgent);
+    expect(clone.agentName).toBe('Runtime Target');
+    expect(clone.toolName).toBe('transfer_to_runtime_target');
+    expect(clone.toolDescription).toBe('Runtime target handoff');
+    expect(clone.inputJsonSchema).toBe(inputJsonSchema);
+    expect(clone.strictJsonSchema).toBe(false);
+    expect(clone.inputFilter).toBe(filter);
+    expect(clone.isEnabled).toBe(isEnabled);
+    expect(clone.getHandoffAsFunctionTool()).toEqual({
+      type: 'function',
+      name: 'transfer_to_runtime_target',
+      description: 'Runtime target handoff',
+      parameters: inputJsonSchema,
+      strict: false,
+    });
+    await expect(
+      clone.isEnabled({ runContext: new RunContext(), agent: originalAgent }),
+    ).resolves.toBe(false);
   });
 });
 


### PR DESCRIPTION
This pull request adds a public `Handoff#clone(...)` API to `@openai/agents-core` so integrations can derive a real `Handoff` instance with a different runtime target or invocation callback without reconstructing private object internals.

The clone API preserves the model-facing tool contract by default, including tool name, description, input schema, strictness, input filter, enabled predicate, and callback behavior. It also supports explicit overrides for target agent, callback, metadata, schema, and availability.