### PR TITLE
fix: make Runner modelProvider optional

### DIFF
--- a/.changeset/runner-optional-model-provider.md
+++ b/.changeset/runner-optional-model-provider.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: make Runner modelProvider optional

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -487,6 +487,13 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     );
   }
 
+  #getModelProvider(): ModelProvider {
+    const modelProvider =
+      this.config.modelProvider ?? getDefaultModelProvider();
+    this.config.modelProvider = modelProvider;
+    return modelProvider;
+  }
+
   /**
    * Run a workflow starting at the given agent. The agent will run in a loop until a final
    * output is generated. The loop runs like so:
@@ -716,9 +723,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       typeof selectedModel === 'string' ? selectedModel : undefined;
     const resolvedModel =
       typeof selectedModel === 'string'
-        ? await (
-            this.config.modelProvider ?? getDefaultModelProvider()
-          ).getModel(selectedModel)
+        ? await this.#getModelProvider().getModel(selectedModel)
         : selectedModel;
     return { model: resolvedModel, explictlyModelSet, resolvedModelName };
   }

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -386,6 +386,20 @@ export type IndividualRunOptions<
   TAgent extends Agent<any, any> = Agent<any, any>,
 > = StreamRunOptions<TContext, TAgent> | NonStreamRunOptions<TContext, TAgent>;
 
+type RunnerConfig = RunConfig & {
+  modelProvider: ModelProvider;
+};
+
+class LazyDefaultModelProvider implements ModelProvider {
+  #modelProvider: ModelProvider | undefined;
+
+  getModel(modelName?: string): Promise<Model> | Model {
+    const modelProvider = this.#modelProvider ?? getDefaultModelProvider();
+    this.#modelProvider = modelProvider;
+    return modelProvider.getModel(modelName);
+  }
+}
+
 // --------------------------------------------------------------
 //  Runner
 // --------------------------------------------------------------
@@ -428,7 +442,7 @@ export async function run<TAgent extends Agent<any, any>, TContext = undefined>(
  * tracing. Reuse a `Runner` instance when you want consistent configuration across multiple runs.
  */
 export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
-  public readonly config: RunConfig;
+  public readonly config: RunnerConfig;
   private readonly traceOverrides: {
     traceId?: string;
     workflowName?: string;
@@ -445,7 +459,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
   constructor(config: Partial<RunConfig> = {}) {
     super();
     this.config = {
-      modelProvider: config.modelProvider,
+      modelProvider: config.modelProvider ?? new LazyDefaultModelProvider(),
       model: config.model,
       modelSettings: config.modelSettings,
       handoffInputFilter: config.handoffInputFilter,
@@ -485,13 +499,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     this.outputGuardrailDefs = (config.outputGuardrails ?? []).map(
       defineOutputGuardrail,
     );
-  }
-
-  #getModelProvider(): ModelProvider {
-    const modelProvider =
-      this.config.modelProvider ?? getDefaultModelProvider();
-    this.config.modelProvider = modelProvider;
-    return modelProvider;
   }
 
   /**
@@ -723,7 +730,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       typeof selectedModel === 'string' ? selectedModel : undefined;
     const resolvedModel =
       typeof selectedModel === 'string'
-        ? await this.#getModelProvider().getModel(selectedModel)
+        ? await this.config.modelProvider.getModel(selectedModel)
         : selectedModel;
     return { model: resolvedModel, explictlyModelSet, resolvedModelName };
   }

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -211,14 +211,15 @@ function validateToolExecutionConfig(
 export type RunConfig = {
   /**
    * The model to use for the entire agent run. If set, will override the model set on every
-   * agent. The modelProvider passed in below must be able to resolve this model name.
+   * agent. String model names are resolved with the configured modelProvider, or the default
+   * model provider if no explicit provider is configured.
    */
   model?: string | Model;
 
   /**
    * The model provider to use when looking up string model names. Defaults to OpenAI.
    */
-  modelProvider: ModelProvider;
+  modelProvider?: ModelProvider;
 
   /**
    * Configure global model settings. Any non-null values will override the agent-specific model
@@ -444,7 +445,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
   constructor(config: Partial<RunConfig> = {}) {
     super();
     this.config = {
-      modelProvider: config.modelProvider ?? getDefaultModelProvider(),
+      modelProvider: config.modelProvider,
       model: config.model,
       modelSettings: config.modelSettings,
       handoffInputFilter: config.handoffInputFilter,
@@ -715,7 +716,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       typeof selectedModel === 'string' ? selectedModel : undefined;
     const resolvedModel =
       typeof selectedModel === 'string'
-        ? await this.config.modelProvider.getModel(selectedModel)
+        ? await (
+            this.config.modelProvider ?? getDefaultModelProvider()
+          ).getModel(selectedModel)
         : selectedModel;
     return { model: resolvedModel, explictlyModelSet, resolvedModelName };
   }

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -130,7 +130,7 @@ describe('Runner.run', () => {
       expect(runner.config.toolNotFoundBehavior).toBe('return_error_to_model');
     });
 
-    it('keeps modelProvider unset until a string model needs the default provider', async () => {
+    it('keeps the default provider lazy until a string model needs it', async () => {
       const model = new FakeModel([TEST_MODEL_RESPONSE_BASIC]);
       const provider = {
         getModel: vi.fn(() => model),
@@ -143,11 +143,10 @@ describe('Runner.run', () => {
           tracingDisabled: true,
         });
 
-        expect(runner.config.modelProvider).toBeUndefined();
+        expect(provider.getModel).not.toHaveBeenCalled();
 
         await runner.run(new Agent({ name: 'Lazy Provider Agent' }), 'hello');
 
-        expect(runner.config.modelProvider).toBe(provider);
         expect(provider.getModel).toHaveBeenCalledWith('default-model');
       } finally {
         setDefaultModelProvider(new FakeModelProvider());
@@ -177,7 +176,6 @@ describe('Runner.run', () => {
         setDefaultModelProvider(laterProvider);
         await runner.run(new Agent({ name: 'Stable Provider Agent' }), 'hello');
 
-        expect(runner.config.modelProvider).toBe(firstProvider);
         expect(firstProvider.getModel).toHaveBeenCalledTimes(2);
         expect(laterProvider.getModel).not.toHaveBeenCalled();
       } finally {
@@ -199,8 +197,6 @@ describe('Runner.run', () => {
           model,
           tracingDisabled: true,
         });
-
-        expect(runner.config.modelProvider).toBeUndefined();
 
         await runner.run(new Agent({ name: 'Model Object Agent' }), 'hello');
 

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -130,6 +130,54 @@ describe('Runner.run', () => {
       expect(runner.config.toolNotFoundBehavior).toBe('return_error_to_model');
     });
 
+    it('keeps modelProvider unset until a string model needs the default provider', async () => {
+      const model = new FakeModel([TEST_MODEL_RESPONSE_BASIC]);
+      const provider = {
+        getModel: vi.fn(() => model),
+      } satisfies ModelProvider;
+      setDefaultModelProvider(provider);
+
+      try {
+        const runner = new Runner({
+          model: 'default-model',
+          tracingDisabled: true,
+        });
+
+        expect(runner.config.modelProvider).toBeUndefined();
+
+        await runner.run(new Agent({ name: 'Lazy Provider Agent' }), 'hello');
+
+        expect(provider.getModel).toHaveBeenCalledWith('default-model');
+      } finally {
+        setDefaultModelProvider(new FakeModelProvider());
+      }
+    });
+
+    it('does not require a modelProvider when the selected model is a Model object', async () => {
+      const model = new FakeModel([TEST_MODEL_RESPONSE_BASIC]);
+      const provider = {
+        getModel: vi.fn(() => {
+          throw new Error('default provider should not be used');
+        }),
+      } satisfies ModelProvider;
+      setDefaultModelProvider(provider);
+
+      try {
+        const runner = new Runner({
+          model,
+          tracingDisabled: true,
+        });
+
+        expect(runner.config.modelProvider).toBeUndefined();
+
+        await runner.run(new Agent({ name: 'Model Object Agent' }), 'hello');
+
+        expect(provider.getModel).not.toHaveBeenCalled();
+      } finally {
+        setDefaultModelProvider(new FakeModelProvider());
+      }
+    });
+
     it('rejects invalid function tool concurrency config', () => {
       expect(
         () =>

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -147,7 +147,39 @@ describe('Runner.run', () => {
 
         await runner.run(new Agent({ name: 'Lazy Provider Agent' }), 'hello');
 
+        expect(runner.config.modelProvider).toBe(provider);
         expect(provider.getModel).toHaveBeenCalledWith('default-model');
+      } finally {
+        setDefaultModelProvider(new FakeModelProvider());
+      }
+    });
+
+    it("keeps a runner's resolved default provider stable", async () => {
+      const firstProvider = {
+        getModel: vi.fn(
+          () => new FakeModel([{ ...TEST_MODEL_RESPONSE_BASIC }]),
+        ),
+      } satisfies ModelProvider;
+      const laterProvider = {
+        getModel: vi.fn(
+          () => new FakeModel([{ ...TEST_MODEL_RESPONSE_BASIC }]),
+        ),
+      } satisfies ModelProvider;
+      setDefaultModelProvider(firstProvider);
+
+      try {
+        const runner = new Runner({
+          model: 'default-model',
+          tracingDisabled: true,
+        });
+
+        await runner.run(new Agent({ name: 'Stable Provider Agent' }), 'hello');
+        setDefaultModelProvider(laterProvider);
+        await runner.run(new Agent({ name: 'Stable Provider Agent' }), 'hello');
+
+        expect(runner.config.modelProvider).toBe(firstProvider);
+        expect(firstProvider.getModel).toHaveBeenCalledTimes(2);
+        expect(laterProvider.getModel).not.toHaveBeenCalled();
       } finally {
         setDefaultModelProvider(new FakeModelProvider());
       }


### PR DESCRIPTION
This pull request improves the type of modelProvider argument in RunConfig to align with the actual behavior.