### PR TITLE
fix: add public Usage JSON restoration helpers

### DIFF
--- a/.changeset/usage-from-json.md
+++ b/.changeset/usage-from-json.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: add public Usage JSON restoration helpers

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -293,6 +293,7 @@ export type {
   StreamEventGenericItem,
 } from './types';
 export { RequestUsage, Usage } from './usage';
+export type { RequestUsageInput, UsageInput } from './usage';
 export type {
   Session,
   SessionInputCallback,

--- a/packages/agents-core/src/usage.ts
+++ b/packages/agents-core/src/usage.ts
@@ -1,6 +1,6 @@
 import { RequestUsageData, UsageData } from './types/protocol';
 
-type RequestUsageInput = Partial<
+export type RequestUsageInput = Partial<
   RequestUsageData & {
     input_tokens: number;
     output_tokens: number;
@@ -11,7 +11,7 @@ type RequestUsageInput = Partial<
   }
 >;
 
-type UsageInput = Partial<
+export type UsageInput = Partial<
   UsageData & {
     input_tokens: number;
     output_tokens: number;
@@ -82,6 +82,13 @@ export class RequestUsage {
     if (typeof input?.endpoint !== 'undefined') {
       this.endpoint = input.endpoint;
     }
+  }
+
+  /**
+   * Reconstructs a RequestUsage instance from a JSON-compatible wire value.
+   */
+  static fromJSON(input?: RequestUsageInput): RequestUsage {
+    return new RequestUsage(input);
   }
 }
 
@@ -177,6 +184,13 @@ export class Usage {
           ? normalizedRequestUsageEntries
           : undefined;
     }
+  }
+
+  /**
+   * Reconstructs a Usage instance from a JSON-compatible wire value.
+   */
+  static fromJSON(input?: UsageInput): Usage {
+    return new Usage(input);
   }
 
   add(newUsage: Usage) {

--- a/packages/agents-core/test/usage.test.ts
+++ b/packages/agents-core/test/usage.test.ts
@@ -64,6 +64,85 @@ describe('Usage', () => {
     ]);
   });
 
+  it('reconstructs RequestUsage instances from JSON-compatible values', () => {
+    const wireValue = JSON.parse(
+      JSON.stringify(
+        new RequestUsage({
+          inputTokens: 7,
+          outputTokens: 3,
+          totalTokens: 10,
+          inputTokensDetails: { cached_tokens: 1 },
+          outputTokensDetails: { reasoning_tokens: 2 },
+          endpoint: 'responses.create',
+        }),
+      ),
+    );
+
+    const usage = RequestUsage.fromJSON(wireValue);
+
+    expect(usage).toBeInstanceOf(RequestUsage);
+    expect(usage).toEqual(
+      new RequestUsage({
+        inputTokens: 7,
+        outputTokens: 3,
+        totalTokens: 10,
+        inputTokensDetails: { cached_tokens: 1 },
+        outputTokensDetails: { reasoning_tokens: 2 },
+        endpoint: 'responses.create',
+      }),
+    );
+  });
+
+  it('reconstructs Usage and nested RequestUsage instances from JSON-compatible values', () => {
+    const wireValue = JSON.parse(
+      JSON.stringify(
+        new Usage({
+          requests: 1,
+          inputTokens: 7,
+          outputTokens: 3,
+          totalTokens: 10,
+          inputTokensDetails: [{ cached_tokens: 1 }],
+          outputTokensDetails: [{ reasoning_tokens: 2 }],
+          requestUsageEntries: [
+            new RequestUsage({
+              inputTokens: 7,
+              outputTokens: 3,
+              totalTokens: 10,
+              inputTokensDetails: { cached_tokens: 1 },
+              outputTokensDetails: { reasoning_tokens: 2 },
+              endpoint: 'responses.create',
+            }),
+          ],
+        }),
+      ),
+    );
+
+    const usage = Usage.fromJSON(wireValue);
+
+    expect(usage).toBeInstanceOf(Usage);
+    expect(usage.requestUsageEntries?.[0]).toBeInstanceOf(RequestUsage);
+    expect(usage).toEqual(
+      new Usage({
+        requests: 1,
+        inputTokens: 7,
+        outputTokens: 3,
+        totalTokens: 10,
+        inputTokensDetails: [{ cached_tokens: 1 }],
+        outputTokensDetails: [{ reasoning_tokens: 2 }],
+        requestUsageEntries: [
+          new RequestUsage({
+            inputTokens: 7,
+            outputTokens: 3,
+            totalTokens: 10,
+            inputTokensDetails: { cached_tokens: 1 },
+            outputTokensDetails: { reasoning_tokens: 2 },
+            endpoint: 'responses.create',
+          }),
+        ],
+      }),
+    );
+  });
+
   it('adds other Usage instances correctly', () => {
     const usageA = new Usage({
       inputTokens: 1,


### PR DESCRIPTION
This pull request adds public JSON restoration helpers for usage objects that cross serialization boundaries. It exports `UsageInput` and `RequestUsageInput`, adds `Usage.fromJSON()` and `RequestUsage.fromJSON()`, and verifies that JSON-compatible usage payloads reconstruct `Usage` and nested `RequestUsage` instances so downstream `instanceof` checks continue to work.