### PR TITLE
feat: add AgentAssertion auth for sandbox Responses calls

### DIFF
--- a/.changeset/verified-sandbox-agent-identity.md
+++ b/.changeset/verified-sandbox-agent-identity.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-openai': minor
+'@openai/agents': minor
+'@openai/agents-core': patch
+---
+
+feat: add verified AgentAssertion auth for sandbox Responses calls

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -123,6 +123,46 @@ export type { ReasoningItemIdPolicy } from './runner/items';
 
 // Maintenance: keep helper utilities (e.g., GuardrailTracker) in runner/* modules so run.ts stays orchestration-only.
 
+const OPENAI_AGENTS_SDK_PROVIDER_DATA_KEY = 'openai_agents_sdk';
+
+function isPlainObjectLike(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function withSandboxProviderData(
+  modelSettings: ModelSettings,
+  args: { externalTaskRef?: string },
+): ModelSettings {
+  const providerData = isPlainObjectLike(modelSettings.providerData)
+    ? modelSettings.providerData
+    : {};
+  const existingAgentsSdk = isPlainObjectLike(
+    providerData[OPENAI_AGENTS_SDK_PROVIDER_DATA_KEY],
+  )
+    ? providerData[OPENAI_AGENTS_SDK_PROVIDER_DATA_KEY]
+    : {};
+  const existingSandbox = isPlainObjectLike(existingAgentsSdk.sandbox)
+    ? existingAgentsSdk.sandbox
+    : {};
+
+  return {
+    ...modelSettings,
+    providerData: {
+      ...providerData,
+      [OPENAI_AGENTS_SDK_PROVIDER_DATA_KEY]: {
+        ...existingAgentsSdk,
+        sandbox: {
+          ...existingSandbox,
+          enabled: true,
+          ...(args.externalTaskRef
+            ? { externalTaskRef: args.externalTaskRef }
+            : {}),
+        },
+      },
+    },
+  };
+}
+
 function getImplicitModelSettingsForResolvedModel(
   explictlyModelSet: boolean,
   resolvedModelName?: string,
@@ -1855,6 +1895,11 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       state._toolUseTracker,
       modelSettings,
     );
+    if (isSandboxRuntimeAgent(state._currentAgent)) {
+      modelSettings = withSandboxProviderData(modelSettings, {
+        externalTaskRef: this.config.groupId ?? this.config.traceId,
+      });
+    }
     state._lastModelSettings = modelSettings;
 
     const systemInstructions = await executionAgent.getSystemPrompt(

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -1916,6 +1916,42 @@ describe('sandbox runner integration', () => {
     expect(sandboxModel.requests[1]?.modelSettings.toolChoice).toBeUndefined();
   });
 
+  it('marks sandbox model calls for OpenAI agent identity attribution', async () => {
+    const client = new FakeSandboxClient();
+    const sandboxModel = new RecordingFakeModel([
+      {
+        output: [fakeModelMessage('sandbox done')],
+        usage: new Usage(),
+      },
+    ]);
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model: sandboxModel,
+      defaultManifest: new Manifest({ root: '/workspace' }),
+      capabilities: [shell()],
+    });
+
+    const result = await new Runner({ groupId: 'group_123' }).run(
+      sandboxAgent,
+      'Hello',
+      {
+        sandbox: {
+          client,
+        },
+      },
+    );
+
+    expect(result.finalOutput).toBe('sandbox done');
+    expect(sandboxModel.requests[0]?.modelSettings.providerData).toMatchObject({
+      openai_agents_sdk: {
+        sandbox: {
+          enabled: true,
+          externalTaskRef: 'group_123',
+        },
+      },
+    });
+  });
+
   it('resets required tool choice after a sandbox agent uses a shell tool', async () => {
     const client = new FakeSandboxClient();
     const sandboxModel = new RecordingFakeModel([

--- a/packages/agents-openai/package.json
+++ b/packages/agents-openai/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@openai/agents-core": "workspace:*",
     "debug": "^4.4.0",
+    "libsodium-wrappers-sumo": "^0.8.4",
     "openai": "^6.35.0"
   },
   "scripts": {

--- a/packages/agents-openai/src/agentIdentity.ts
+++ b/packages/agents-openai/src/agentIdentity.ts
@@ -1,0 +1,324 @@
+import type OpenAI from 'openai';
+import sodium from 'libsodium-wrappers-sumo';
+import { METADATA } from './metadata';
+
+const AGENT_ASSERTION_AUTHORIZATION_SCHEME = 'AgentAssertion';
+const DEFAULT_TASK_CACHE_KEY = '__default__';
+const DEFAULT_AGENT_HARNESS_ID = 'openai-agents-js';
+
+type SodiumKeyPair = {
+  publicKey: Uint8Array;
+  privateKey: Uint8Array;
+};
+
+type RegisterAgentResponse = {
+  agent_runtime_id?: unknown;
+};
+
+type RegisterTaskResponse = {
+  encrypted_task_id?: unknown;
+};
+
+type RegisteredRuntime = {
+  agentRuntimeId: string;
+  keyPair: SodiumKeyPair;
+  agentPublicKey: string;
+};
+
+type RegisteredTask = {
+  taskId: string;
+};
+
+export type OpenAIAgentIdentityOptions = {
+  /**
+   * Stable identifier for the SDK/harness registering this runtime.
+   *
+   * Examples: `agents-js`, `codex-cli`, or another product-specific harness id.
+   */
+  agentHarnessId: string;
+
+  /**
+   * Version of the running agent or harness.
+   */
+  agentVersion: string;
+
+  /**
+   * Logical location where the agent is running.
+   *
+   * Examples: `local`, `docker`, `e2b`, or a hosted runtime identifier.
+   */
+  runningLocation: string;
+
+  /**
+   * Capabilities authorized for this runtime registration.
+   */
+  capabilities?: string[];
+
+  /**
+   * Optional runtime TTL in seconds.
+   */
+  ttl?: number;
+
+  /**
+   * Optional durable task reference used when no per-request external task
+   * reference is available from the runner.
+   */
+  externalTaskRef?: string;
+};
+
+export type OpenAIAgentAssertionContext = {
+  /**
+   * Optional durable task reference. When present, task registration is cached
+   * per external reference so retries/resumes can reuse the same task id.
+   */
+  externalTaskRef?: string;
+};
+
+export type OpenAIAgentIdentityInput =
+  | OpenAIAgentIdentity
+  | OpenAIAgentIdentityOptions
+  | false;
+
+function assertString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`Agent identity response missing ${field}.`);
+  }
+  return value;
+}
+
+function utf8Bytes(value: string): Uint8Array {
+  return new TextEncoder().encode(value);
+}
+
+function concatBytes(parts: Uint8Array[]): Uint8Array {
+  const totalLength = parts.reduce((sum, part) => sum + part.length, 0);
+  const output = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const part of parts) {
+    output.set(part, offset);
+    offset += part.length;
+  }
+  return output;
+}
+
+function uint32be(value: number): Uint8Array {
+  const output = new Uint8Array(4);
+  new DataView(output.buffer).setUint32(0, value, false);
+  return output;
+}
+
+function sshString(value: string | Uint8Array): Uint8Array {
+  const bytes = typeof value === 'string' ? utf8Bytes(value) : value;
+  return concatBytes([uint32be(bytes.length), bytes]);
+}
+
+function openSshEd25519PublicKey(publicKey: Uint8Array): string {
+  const keyType = 'ssh-ed25519';
+  const payload = concatBytes([sshString(keyType), sshString(publicKey)]);
+  return `${keyType} ${sodium.to_base64(
+    payload,
+    sodium.base64_variants.ORIGINAL,
+  )}`;
+}
+
+function utcTimestamp(): string {
+  return new Date().toISOString();
+}
+
+function signBase64(keyPair: SodiumKeyPair, payload: string): string {
+  return sodium.to_base64(
+    sodium.crypto_sign_detached(utf8Bytes(payload), keyPair.privateKey),
+    sodium.base64_variants.ORIGINAL,
+  );
+}
+
+function serializeAgentAssertion(params: {
+  agentRuntimeId: string;
+  taskId: string;
+  timestamp: string;
+  signature: string;
+}): string {
+  // Keep the canonical key order aligned with the server-side sorted JSON
+  // envelope used by AgentAssertion auth.
+  const payload = JSON.stringify({
+    agent_runtime_id: params.agentRuntimeId,
+    signature: params.signature,
+    task_id: params.taskId,
+    timestamp: params.timestamp,
+  });
+  return sodium.to_base64(
+    utf8Bytes(payload),
+    sodium.base64_variants.URLSAFE_NO_PADDING,
+  );
+}
+
+function decryptTaskId(
+  encryptedTaskId: string,
+  keyPair: SodiumKeyPair,
+): string {
+  const encrypted = sodium.from_base64(
+    encryptedTaskId,
+    sodium.base64_variants.ORIGINAL,
+  );
+  const publicKey = sodium.crypto_sign_ed25519_pk_to_curve25519(
+    keyPair.publicKey,
+  );
+  const privateKey = sodium.crypto_sign_ed25519_sk_to_curve25519(
+    keyPair.privateKey,
+  );
+  const decrypted = sodium.crypto_box_seal_open(
+    encrypted,
+    publicKey,
+    privateKey,
+  );
+  return sodium.to_string(decrypted);
+}
+
+function taskCacheKey(externalTaskRef: string | undefined): string {
+  return externalTaskRef ?? DEFAULT_TASK_CACHE_KEY;
+}
+
+function getDefaultRunningLocation(): string {
+  const globalValue = globalThis as { window?: unknown };
+  return typeof globalValue.window === 'undefined' ? 'node' : 'browser';
+}
+
+/**
+ * Registers an OpenAI agent runtime/task and mints verified AgentAssertion
+ * authorization headers for Responses API calls.
+ */
+export class OpenAIAgentIdentity {
+  readonly #options: OpenAIAgentIdentityOptions;
+  #runtimePromise?: Promise<RegisteredRuntime>;
+  readonly #taskPromises = new Map<string, Promise<RegisteredTask>>();
+
+  constructor(options: OpenAIAgentIdentityOptions) {
+    this.#options = { ...options };
+  }
+
+  async getAuthorizationHeader(
+    client: OpenAI,
+    context: OpenAIAgentAssertionContext = {},
+  ): Promise<string> {
+    const runtime = await this.#getRuntime(client);
+    const task = await this.#getTask(client, runtime, context.externalTaskRef);
+    const timestamp = utcTimestamp();
+    const signature = signBase64(
+      runtime.keyPair,
+      `${runtime.agentRuntimeId}:${task.taskId}:${timestamp}`,
+    );
+    const assertion = serializeAgentAssertion({
+      agentRuntimeId: runtime.agentRuntimeId,
+      taskId: task.taskId,
+      timestamp,
+      signature,
+    });
+    return `${AGENT_ASSERTION_AUTHORIZATION_SCHEME} ${assertion}`;
+  }
+
+  async #getRuntime(client: OpenAI): Promise<RegisteredRuntime> {
+    this.#runtimePromise ??= this.#registerRuntime(client);
+    return this.#runtimePromise;
+  }
+
+  async #registerRuntime(client: OpenAI): Promise<RegisteredRuntime> {
+    await sodium.ready;
+    const seed = sodium.randombytes_buf(sodium.crypto_sign_ed25519_SEEDBYTES);
+    const keyPair = sodium.crypto_sign_seed_keypair(seed);
+    const agentPublicKey = openSshEd25519PublicKey(keyPair.publicKey);
+    const response = await client.post<RegisterAgentResponse>(
+      '/agent/register',
+      {
+        body: {
+          abom: {
+            agent_harness_id: this.#options.agentHarnessId,
+            agent_version: this.#options.agentVersion,
+            running_location: this.#options.runningLocation,
+          },
+          agent_public_key: agentPublicKey,
+          capabilities: this.#options.capabilities ?? [],
+          ...(typeof this.#options.ttl === 'number'
+            ? { ttl: this.#options.ttl }
+            : {}),
+        },
+      },
+    );
+
+    return {
+      agentRuntimeId: assertString(
+        response.agent_runtime_id,
+        'agent_runtime_id',
+      ),
+      keyPair,
+      agentPublicKey,
+    };
+  }
+
+  async #getTask(
+    client: OpenAI,
+    runtime: RegisteredRuntime,
+    externalTaskRef: string | undefined,
+  ): Promise<RegisteredTask> {
+    const resolvedExternalTaskRef =
+      externalTaskRef ?? this.#options.externalTaskRef;
+    const cacheKey = taskCacheKey(resolvedExternalTaskRef);
+    let taskPromise = this.#taskPromises.get(cacheKey);
+    if (!taskPromise) {
+      taskPromise = this.#registerTask(
+        client,
+        runtime,
+        resolvedExternalTaskRef,
+      );
+      this.#taskPromises.set(cacheKey, taskPromise);
+    }
+    return taskPromise;
+  }
+
+  async #registerTask(
+    client: OpenAI,
+    runtime: RegisteredRuntime,
+    externalTaskRef: string | undefined,
+  ): Promise<RegisteredTask> {
+    const timestamp = utcTimestamp();
+    const signature = signBase64(
+      runtime.keyPair,
+      `${runtime.agentRuntimeId}:${timestamp}`,
+    );
+    const response = await client.post<RegisterTaskResponse>(
+      `/agent/${runtime.agentRuntimeId}/task/register`,
+      {
+        body: {
+          timestamp,
+          signature,
+          ...(externalTaskRef ? { external_task_ref: externalTaskRef } : {}),
+        },
+      },
+    );
+    const encryptedTaskId = assertString(
+      response.encrypted_task_id,
+      'encrypted_task_id',
+    );
+    return {
+      taskId: decryptTaskId(encryptedTaskId, runtime.keyPair),
+    };
+  }
+}
+
+export function getDefaultOpenAIAgentIdentityOptions(): OpenAIAgentIdentityOptions {
+  return {
+    agentHarnessId: DEFAULT_AGENT_HARNESS_ID,
+    agentVersion: METADATA.version,
+    runningLocation: getDefaultRunningLocation(),
+  };
+}
+
+export function resolveOpenAIAgentIdentity(
+  identity: OpenAIAgentIdentityInput | undefined,
+): OpenAIAgentIdentity | undefined {
+  if (identity === false || !identity) {
+    return undefined;
+  }
+  return identity instanceof OpenAIAgentIdentity
+    ? identity
+    : new OpenAIAgentIdentity(identity);
+}

--- a/packages/agents-openai/src/agentIdentity.ts
+++ b/packages/agents-openai/src/agentIdentity.ts
@@ -5,6 +5,8 @@ import { METADATA } from './metadata';
 const AGENT_ASSERTION_AUTHORIZATION_SCHEME = 'AgentAssertion';
 const DEFAULT_TASK_CACHE_KEY = '__default__';
 const DEFAULT_AGENT_HARNESS_ID = 'openai-agents-js';
+const DEFAULT_AGENT_REGISTRATION_BASE_URL =
+  'https://auth.openai.com/api/accounts';
 
 type SodiumKeyPair = {
   publicKey: Uint8Array;
@@ -64,6 +66,11 @@ export type OpenAIAgentIdentityOptions = {
    * reference is available from the runner.
    */
   externalTaskRef?: string;
+
+  /**
+   * Base URL for the AuthAPI agent registration surface.
+   */
+  registrationBaseURL?: string;
 };
 
 export type OpenAIAgentAssertionContext = {
@@ -183,17 +190,27 @@ function getDefaultRunningLocation(): string {
   return typeof globalValue.window === 'undefined' ? 'node' : 'browser';
 }
 
+function registrationURL(baseURL: string, path: string): string {
+  const url = new URL(baseURL);
+  const basePath = url.pathname.replace(/\/+$/, '');
+  url.pathname = `${basePath}${path}`;
+  return url.toString();
+}
+
 /**
  * Registers an OpenAI agent runtime/task and mints verified AgentAssertion
  * authorization headers for Responses API calls.
  */
 export class OpenAIAgentIdentity {
   readonly #options: OpenAIAgentIdentityOptions;
+  readonly #registrationBaseURL: string;
   #runtimePromise?: Promise<RegisteredRuntime>;
   readonly #taskPromises = new Map<string, Promise<RegisteredTask>>();
 
   constructor(options: OpenAIAgentIdentityOptions) {
     this.#options = { ...options };
+    this.#registrationBaseURL =
+      options.registrationBaseURL ?? DEFAULT_AGENT_REGISTRATION_BASE_URL;
   }
 
   async getAuthorizationHeader(
@@ -227,7 +244,7 @@ export class OpenAIAgentIdentity {
     const keyPair = sodium.crypto_sign_seed_keypair(seed);
     const agentPublicKey = openSshEd25519PublicKey(keyPair.publicKey);
     const response = await client.post<RegisterAgentResponse>(
-      '/agent/register',
+      registrationURL(this.#registrationBaseURL, '/v1/agent/register'),
       {
         body: {
           abom: {
@@ -285,7 +302,10 @@ export class OpenAIAgentIdentity {
       `${runtime.agentRuntimeId}:${timestamp}`,
     );
     const response = await client.post<RegisterTaskResponse>(
-      `/agent/${runtime.agentRuntimeId}/task/register`,
+      registrationURL(
+        this.#registrationBaseURL,
+        `/v1/agent/${runtime.agentRuntimeId}/task/register`,
+      ),
       {
         body: {
           timestamp,
@@ -309,6 +329,7 @@ export function getDefaultOpenAIAgentIdentityOptions(): OpenAIAgentIdentityOptio
     agentHarnessId: DEFAULT_AGENT_HARNESS_ID,
     agentVersion: METADATA.version,
     runningLocation: getDefaultRunningLocation(),
+    registrationBaseURL: DEFAULT_AGENT_REGISTRATION_BASE_URL,
   };
 }
 

--- a/packages/agents-openai/src/index.ts
+++ b/packages/agents-openai/src/index.ts
@@ -7,8 +7,17 @@ export {
 export {
   OpenAIResponsesModel,
   OpenAIResponsesWSModel,
+  type OpenAIAgentIdentityMode,
+  type OpenAIResponsesModelOptions,
   type OpenAIResponsesWebSocketOptions,
 } from './openaiResponsesModel';
+export {
+  OpenAIAgentIdentity,
+  getDefaultOpenAIAgentIdentityOptions,
+  type OpenAIAgentAssertionContext,
+  type OpenAIAgentIdentityInput,
+  type OpenAIAgentIdentityOptions,
+} from './agentIdentity';
 export {
   OpenAIChatCompletionsModel,
   type OpenAIChatCompletionsModelOptions,

--- a/packages/agents-openai/src/openaiProvider.ts
+++ b/packages/agents-openai/src/openaiProvider.ts
@@ -45,8 +45,11 @@ export type OpenAIProviderOptions = {
   /**
    * Optional OpenAI agent identity used to mint verified AgentAssertion auth for
    * Responses API requests. By default the provider creates an SDK runtime
-   * identity and applies it only to model calls prepared for sandbox agents.
-   * Pass `false` to disable this behavior.
+   * identity when it also creates the default OpenAI client, and applies it only
+   * to model calls prepared for sandbox agents. Explicit `baseURL` and
+   * `openAIClient` configurations do not get a default identity because they may
+   * point at OpenAI-compatible providers that do not support agent runtime
+   * registration. Pass identity options to opt in, or `false` to disable.
    */
   agentIdentity?: OpenAIAgentIdentityInput;
   agentIdentityMode?: OpenAIAgentIdentityMode;
@@ -86,9 +89,23 @@ export class OpenAIProvider implements ModelProvider {
     this.#websocketBaseURL = this.#options.websocketBaseURL;
     this.#cacheResponsesWebSocketModels =
       this.#options.cacheResponsesWebSocketModels ?? true;
-    this.#agentIdentity = resolveOpenAIAgentIdentity(
-      this.#options.agentIdentity ?? getDefaultOpenAIAgentIdentityOptions(),
-    );
+    this.#agentIdentity = this.#resolveAgentIdentity();
+  }
+
+  #resolveAgentIdentity(): OpenAIAgentIdentity | undefined {
+    if (typeof this.#options.agentIdentity !== 'undefined') {
+      return resolveOpenAIAgentIdentity(this.#options.agentIdentity);
+    }
+
+    if (
+      this.#options.openAIClient ||
+      this.#options.baseURL ||
+      getDefaultOpenAIClient()
+    ) {
+      return undefined;
+    }
+
+    return resolveOpenAIAgentIdentity(getDefaultOpenAIAgentIdentityOptions());
   }
 
   /**

--- a/packages/agents-openai/src/openaiProvider.ts
+++ b/packages/agents-openai/src/openaiProvider.ts
@@ -9,10 +9,18 @@ import {
 } from './defaults';
 import {
   OpenAIResponsesModel,
+  type OpenAIAgentIdentityMode,
+  type OpenAIResponsesModelOptions,
   type OpenAIResponsesWebSocketOptions,
   OpenAIResponsesWSModel,
 } from './openaiResponsesModel';
 import { OpenAIChatCompletionsModel } from './openaiChatCompletionsModel';
+import {
+  OpenAIAgentIdentity,
+  getDefaultOpenAIAgentIdentityOptions,
+  type OpenAIAgentIdentityInput,
+  resolveOpenAIAgentIdentity,
+} from './agentIdentity';
 
 /**
  * Options for OpenAIProvider.
@@ -34,6 +42,14 @@ export type OpenAIProviderOptions = {
   strictFeatureValidation?: boolean;
   responsesWebSocketOptions?: OpenAIResponsesWebSocketOptions;
   openAIClient?: OpenAI;
+  /**
+   * Optional OpenAI agent identity used to mint verified AgentAssertion auth for
+   * Responses API requests. By default the provider creates an SDK runtime
+   * identity and applies it only to model calls prepared for sandbox agents.
+   * Pass `false` to disable this behavior.
+   */
+  agentIdentity?: OpenAIAgentIdentityInput;
+  agentIdentityMode?: OpenAIAgentIdentityMode;
 };
 
 /**
@@ -47,6 +63,7 @@ export class OpenAIProvider implements ModelProvider {
   #cacheResponsesWebSocketModels: boolean;
   #modelCache = new Map<string, Model>();
   #options: OpenAIProviderOptions;
+  #agentIdentity?: OpenAIAgentIdentity;
 
   constructor(options: OpenAIProviderOptions = {}) {
     this.#options = options;
@@ -69,6 +86,9 @@ export class OpenAIProvider implements ModelProvider {
     this.#websocketBaseURL = this.#options.websocketBaseURL;
     this.#cacheResponsesWebSocketModels =
       this.#options.cacheResponsesWebSocketModels ?? true;
+    this.#agentIdentity = resolveOpenAIAgentIdentity(
+      this.#options.agentIdentity ?? getDefaultOpenAIAgentIdentityOptions(),
+    );
   }
 
   /**
@@ -137,14 +157,19 @@ export class OpenAIProvider implements ModelProvider {
 
     if (useResponses) {
       const client = this.#getClient();
+      const responsesModelOptions: OpenAIResponsesModelOptions = {
+        agentIdentity: this.#agentIdentity,
+        agentIdentityMode: this.#options.agentIdentityMode,
+      };
       resolvedModel = useResponsesWebSocket
         ? new OpenAIResponsesWSModel(client, model, {
+            ...responsesModelOptions,
             websocketBaseURL:
               this.#getWebSocketBaseURLForResponsesModel(client),
             reuseConnection: shouldCacheModelWrapper,
             websocketOptions: this.#options.responsesWebSocketOptions,
           })
-        : new OpenAIResponsesModel(client, model);
+        : new OpenAIResponsesModel(client, model, responsesModelOptions);
     } else {
       resolvedModel = new OpenAIChatCompletionsModel(this.#getClient(), model, {
         strictFeatureValidation: this.#options.strictFeatureValidation,

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -23,6 +23,7 @@ import type {
 } from '@openai/agents-core';
 import OpenAI from 'openai';
 import logger from './logger';
+import type { OpenAIAgentIdentity } from './agentIdentity';
 import { OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE } from './rawModelEvents';
 import { getOpenAIRetryAdvice } from './retryAdvice';
 import {
@@ -101,6 +102,24 @@ type WebSocketRequestTimeoutDeadline = {
 type EnsuredResponsesWebSocketConnection = {
   connection: ResponsesWebSocketConnection;
   reused: boolean;
+};
+
+export type OpenAIAgentIdentityMode = 'sandbox' | 'always';
+
+export type OpenAIResponsesModelOptions = {
+  agentIdentity?: OpenAIAgentIdentity;
+  /**
+   * Controls when AgentAssertion authorization is applied to Responses calls.
+   *
+   * - `sandbox`: only requests marked by the sandbox runner receive the header.
+   * - `always`: every Responses request from this model receives the header.
+   */
+  agentIdentityMode?: OpenAIAgentIdentityMode;
+};
+
+type OpenAIAgentsSdkSandboxContext = {
+  enabled: boolean;
+  externalTaskRef?: string;
 };
 
 type ResponseFunctionCallOutputListItem =
@@ -1117,6 +1136,44 @@ function normalizeLegacyFileFromOutput(value: Record<string, any>): {
 
 function isRecord(value: unknown): value is Record<string, any> {
   return typeof value === 'object' && value !== null;
+}
+
+function getAgentsSdkSandboxContext(
+  providerData: unknown,
+): OpenAIAgentsSdkSandboxContext | undefined {
+  if (!isRecord(providerData)) {
+    return undefined;
+  }
+
+  const agentsSdk = providerData.openai_agents_sdk;
+  if (!isRecord(agentsSdk)) {
+    return undefined;
+  }
+
+  const sandbox = agentsSdk.sandbox;
+  if (!isRecord(sandbox) || sandbox.enabled !== true) {
+    return undefined;
+  }
+
+  return {
+    enabled: true,
+    ...(typeof sandbox.externalTaskRef === 'string' &&
+    sandbox.externalTaskRef.length > 0
+      ? { externalTaskRef: sandbox.externalTaskRef }
+      : {}),
+  };
+}
+
+function hasAuthorizationHeader(headers: Record<string, unknown> | undefined) {
+  if (!headers) {
+    return false;
+  }
+  return Object.entries(headers).some(
+    ([name, value]) =>
+      value !== null &&
+      typeof value !== 'undefined' &&
+      name.toLowerCase() === 'authorization',
+  );
 }
 
 function getShellCallProviderDataForInput(
@@ -2862,10 +2919,18 @@ async function* withAttachedResponseRequestId(
 export class OpenAIResponsesModel implements Model {
   protected readonly _client: OpenAI;
   protected readonly _model: string;
+  protected readonly _agentIdentity?: OpenAIAgentIdentity;
+  protected readonly _agentIdentityMode: OpenAIAgentIdentityMode;
 
-  constructor(client: OpenAI, model: string) {
+  constructor(
+    client: OpenAI,
+    model: string,
+    options: OpenAIResponsesModelOptions = {},
+  ) {
     this._client = client;
     this._model = model;
+    this._agentIdentity = options.agentIdentity;
+    this._agentIdentityMode = options.agentIdentityMode ?? 'sandbox';
   }
 
   getRetryAdvice(args: ModelRetryAdviceRequest): ModelRetryAdvice | undefined {
@@ -2890,7 +2955,12 @@ export class OpenAIResponsesModel implements Model {
     | AsyncIterable<OpenAI.Responses.ResponseStreamEvent>
     | OpenAI.Responses.Response
   > {
-    const builtRequest = this._buildResponsesCreateRequest(request, stream);
+    const preparedRequest =
+      await this._prepareRequestWithAgentIdentity(request);
+    const builtRequest = this._buildResponsesCreateRequest(
+      preparedRequest,
+      stream,
+    );
     const requestOptions: {
       headers: any;
       signal: AbortSignal | undefined;
@@ -2946,6 +3016,49 @@ export class OpenAIResponsesModel implements Model {
     return response;
   }
 
+  protected async _prepareRequestWithAgentIdentity(
+    request: ModelRequest,
+  ): Promise<ModelRequest> {
+    if (!this._agentIdentity) {
+      return request;
+    }
+
+    const providerData = request.modelSettings.providerData;
+    const sandboxContext = getAgentsSdkSandboxContext(providerData);
+    if (this._agentIdentityMode === 'sandbox' && !sandboxContext) {
+      return request;
+    }
+
+    const { overrides: transportOverrides } =
+      splitResponsesTransportOverrides(providerData);
+    if (hasAuthorizationHeader(transportOverrides.extraHeaders)) {
+      throw new UserError(
+        'Cannot combine OpenAI agent identity with an explicit Authorization header.',
+      );
+    }
+
+    const authorization = await this._agentIdentity.getAuthorizationHeader(
+      this._client,
+      {
+        externalTaskRef: sandboxContext?.externalTaskRef,
+      },
+    );
+
+    return {
+      ...request,
+      modelSettings: {
+        ...request.modelSettings,
+        providerData: {
+          ...(isRecord(providerData) ? providerData : {}),
+          extra_headers: {
+            ...(transportOverrides.extraHeaders ?? {}),
+            Authorization: authorization,
+          },
+        },
+      },
+    };
+  }
+
   protected _buildResponsesCreateRequest(
     request: ModelRequest,
     stream: boolean,
@@ -2980,7 +3093,11 @@ export class OpenAIResponsesModel implements Model {
     assertSupportedToolChoice(toolChoice, toolChoiceValidationTools, {
       allowPromptSuppliedTools,
     });
-    const { text, ...restOfProviderData } = providerDataWithoutTransport;
+    const {
+      text,
+      openai_agents_sdk: _openAIAgentsSdkProviderData,
+      ...restOfProviderData
+    } = providerDataWithoutTransport;
 
     if (request.modelSettings.reasoning) {
       // Merge top-level reasoning settings with provider data.
@@ -3248,7 +3365,7 @@ export class OpenAIResponsesModel implements Model {
   }
 }
 
-export type OpenAIResponsesWSModelOptions = {
+export type OpenAIResponsesWSModelOptions = OpenAIResponsesModelOptions & {
   websocketBaseURL?: string;
   reuseConnection?: boolean;
   websocketOptions?: OpenAIResponsesWebSocketOptions;
@@ -3281,7 +3398,7 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
     model: string,
     options: OpenAIResponsesWSModelOptions = {},
   ) {
-    super(client, model);
+    super(client, model, options);
     this.#websocketBaseURL = options.websocketBaseURL;
     this.#reuseConnection = options.reuseConnection ?? true;
     this.#websocketOptions = cloneResponsesWebSocketOptions(
@@ -3331,7 +3448,12 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
   > {
     // The websocket transport always uses streamed Responses events, then callers either
     // consume the stream directly or collapse it into the final terminal response.
-    const builtRequest = this._buildResponsesCreateRequest(request, true);
+    const preparedRequest =
+      await this._prepareRequestWithAgentIdentity(request);
+    const builtRequest = this._buildResponsesCreateRequest(
+      preparedRequest,
+      true,
+    );
 
     if (stream) {
       return this.#iterWebSocketResponseEvents(builtRequest);

--- a/packages/agents-openai/test/agentIdentity.test.ts
+++ b/packages/agents-openai/test/agentIdentity.test.ts
@@ -3,6 +3,8 @@ import sodium from 'libsodium-wrappers-sumo';
 import type OpenAI from 'openai';
 import { OpenAIAgentIdentity } from '../src/agentIdentity';
 
+const DEFAULT_REGISTRATION_BASE_URL = 'https://auth.openai.com/api/accounts';
+
 function utf8Bytes(value: string): Uint8Array {
   return new TextEncoder().encode(value);
 }
@@ -44,7 +46,7 @@ describe('OpenAIAgentIdentity', () => {
 
     let runtimePublicKey: Uint8Array | undefined;
     const post = vi.fn(async (path: string, options: { body: any }) => {
-      if (path === '/agent/register') {
+      if (path === `${DEFAULT_REGISTRATION_BASE_URL}/v1/agent/register`) {
         expect(options.body.abom).toEqual({
           agent_harness_id: 'agents-js',
           agent_version: '1.2.3',
@@ -57,7 +59,10 @@ describe('OpenAIAgentIdentity', () => {
         return { agent_runtime_id: 'runtime_123' };
       }
 
-      if (path === '/agent/runtime_123/task/register') {
+      if (
+        path ===
+        `${DEFAULT_REGISTRATION_BASE_URL}/v1/agent/runtime_123/task/register`
+      ) {
         expect(runtimePublicKey).toBeDefined();
         expect(options.body.external_task_ref).toBe('run_456');
         const registrationPayload = `runtime_123:${options.body.timestamp}`;
@@ -117,6 +122,52 @@ describe('OpenAIAgentIdentity', () => {
     await identity.getAuthorizationHeader(fakeClient, {
       externalTaskRef: 'run_456',
     });
+    expect(post).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses a custom AuthAPI registration base URL when configured', async () => {
+    await sodium.ready;
+
+    let runtimePublicKey: Uint8Array | undefined;
+    const post = vi.fn(async (path: string, options: { body: any }) => {
+      if (path === 'https://auth.example.test/accounts/v1/agent/register') {
+        runtimePublicKey = parseOpenSshEd25519PublicKey(
+          options.body.agent_public_key,
+        );
+        return { agent_runtime_id: 'runtime_custom' };
+      }
+
+      if (
+        path ===
+        'https://auth.example.test/accounts/v1/agent/runtime_custom/task/register'
+      ) {
+        expect(runtimePublicKey).toBeDefined();
+        const curvePublicKey = sodium.crypto_sign_ed25519_pk_to_curve25519(
+          runtimePublicKey!,
+        );
+        return {
+          encrypted_task_id: sodium.to_base64(
+            sodium.crypto_box_seal(utf8Bytes('task_custom'), curvePublicKey),
+            sodium.base64_variants.ORIGINAL,
+          ),
+        };
+      }
+
+      throw new Error(`Unexpected path ${path}`);
+    });
+    const fakeClient = { post } as unknown as OpenAI;
+    const identity = new OpenAIAgentIdentity({
+      agentHarnessId: 'agents-js',
+      agentVersion: '1.2.3',
+      runningLocation: 'docker',
+      registrationBaseURL: 'https://auth.example.test/accounts/',
+    });
+
+    const header = await identity.getAuthorizationHeader(fakeClient);
+
+    const assertion = decodeAgentAssertion(header);
+    expect(assertion.agent_runtime_id).toBe('runtime_custom');
+    expect(assertion.task_id).toBe('task_custom');
     expect(post).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/agents-openai/test/agentIdentity.test.ts
+++ b/packages/agents-openai/test/agentIdentity.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest';
+import sodium from 'libsodium-wrappers-sumo';
+import type OpenAI from 'openai';
+import { OpenAIAgentIdentity } from '../src/agentIdentity';
+
+function utf8Bytes(value: string): Uint8Array {
+  return new TextEncoder().encode(value);
+}
+
+function readUint32be(bytes: Uint8Array, offset: number): number {
+  return new DataView(
+    bytes.buffer,
+    bytes.byteOffset,
+    bytes.byteLength,
+  ).getUint32(offset, false);
+}
+
+function parseOpenSshEd25519PublicKey(publicKey: string): Uint8Array {
+  const [, payload] = publicKey.split(' ');
+  const bytes = sodium.from_base64(payload, sodium.base64_variants.ORIGINAL);
+  let offset = 0;
+  const typeLength = readUint32be(bytes, offset);
+  offset += 4;
+  const type = sodium.to_string(bytes.slice(offset, offset + typeLength));
+  expect(type).toBe('ssh-ed25519');
+  offset += typeLength;
+  const keyLength = readUint32be(bytes, offset);
+  offset += 4;
+  return bytes.slice(offset, offset + keyLength);
+}
+
+function decodeAgentAssertion(header: string): Record<string, string> {
+  const token = header.replace(/^AgentAssertion /, '');
+  return JSON.parse(
+    sodium.to_string(
+      sodium.from_base64(token, sodium.base64_variants.URLSAFE_NO_PADDING),
+    ),
+  );
+}
+
+describe('OpenAIAgentIdentity', () => {
+  it('registers a runtime and task, decrypts the task id, and signs AgentAssertion auth', async () => {
+    await sodium.ready;
+
+    let runtimePublicKey: Uint8Array | undefined;
+    const post = vi.fn(async (path: string, options: { body: any }) => {
+      if (path === '/agent/register') {
+        expect(options.body.abom).toEqual({
+          agent_harness_id: 'agents-js',
+          agent_version: '1.2.3',
+          running_location: 'docker',
+        });
+        expect(options.body.capabilities).toEqual(['shell']);
+        runtimePublicKey = parseOpenSshEd25519PublicKey(
+          options.body.agent_public_key,
+        );
+        return { agent_runtime_id: 'runtime_123' };
+      }
+
+      if (path === '/agent/runtime_123/task/register') {
+        expect(runtimePublicKey).toBeDefined();
+        expect(options.body.external_task_ref).toBe('run_456');
+        const registrationPayload = `runtime_123:${options.body.timestamp}`;
+        expect(
+          sodium.crypto_sign_verify_detached(
+            sodium.from_base64(
+              options.body.signature,
+              sodium.base64_variants.ORIGINAL,
+            ),
+            utf8Bytes(registrationPayload),
+            runtimePublicKey!,
+          ),
+        ).toBe(true);
+
+        const curvePublicKey = sodium.crypto_sign_ed25519_pk_to_curve25519(
+          runtimePublicKey!,
+        );
+        return {
+          encrypted_task_id: sodium.to_base64(
+            sodium.crypto_box_seal(utf8Bytes('task_789'), curvePublicKey),
+            sodium.base64_variants.ORIGINAL,
+          ),
+        };
+      }
+
+      throw new Error(`Unexpected path ${path}`);
+    });
+    const fakeClient = { post } as unknown as OpenAI;
+    const identity = new OpenAIAgentIdentity({
+      agentHarnessId: 'agents-js',
+      agentVersion: '1.2.3',
+      runningLocation: 'docker',
+      capabilities: ['shell'],
+    });
+
+    const header = await identity.getAuthorizationHeader(fakeClient, {
+      externalTaskRef: 'run_456',
+    });
+
+    expect(header).toMatch(/^AgentAssertion /);
+    expect(post).toHaveBeenCalledTimes(2);
+    const assertion = decodeAgentAssertion(header);
+    expect(assertion.agent_runtime_id).toBe('runtime_123');
+    expect(assertion.task_id).toBe('task_789');
+    expect(typeof assertion.timestamp).toBe('string');
+    expect(
+      sodium.crypto_sign_verify_detached(
+        sodium.from_base64(
+          assertion.signature,
+          sodium.base64_variants.ORIGINAL,
+        ),
+        utf8Bytes(`runtime_123:task_789:${assertion.timestamp}`),
+        runtimePublicKey!,
+      ),
+    ).toBe(true);
+
+    await identity.getAuthorizationHeader(fakeClient, {
+      externalTaskRef: 'run_456',
+    });
+    expect(post).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/agents-openai/test/openaiProvider.test.ts
+++ b/packages/agents-openai/test/openaiProvider.test.ts
@@ -5,6 +5,7 @@ import {
   OpenAIResponsesWSModel,
 } from '../src/openaiResponsesModel';
 import { OpenAIChatCompletionsModel } from '../src/openaiChatCompletionsModel';
+import { OpenAIAgentIdentity } from '../src/agentIdentity';
 import * as defaultsModule from '../src/defaults';
 import {
   setDefaultOpenAIClient,
@@ -66,6 +67,62 @@ describe('OpenAIProvider', () => {
     });
     const model = await provider.getModel('m');
     expect(model).toBeInstanceOf(OpenAIResponsesModel);
+  });
+
+  it('creates a default agent identity when using the default OpenAI client path', async () => {
+    setDefaultOpenAIKey('test-key');
+    const provider = new OpenAIProvider({
+      useResponses: true,
+    });
+
+    const model = (await provider.getModel('m')) as any;
+
+    expect(model).toBeInstanceOf(OpenAIResponsesModel);
+    expect(model._agentIdentity).toBeInstanceOf(OpenAIAgentIdentity);
+  });
+
+  it('does not create a default agent identity for explicit OpenAI clients', async () => {
+    const provider = new OpenAIProvider({
+      openAIClient: new FakeClient() as any,
+      useResponses: true,
+    });
+
+    const model = (await provider.getModel('m')) as any;
+
+    expect(model).toBeInstanceOf(OpenAIResponsesModel);
+    expect(model._agentIdentity).toBeUndefined();
+  });
+
+  it('does not create a default agent identity for explicit base URLs', async () => {
+    setDefaultOpenAIKey('test-key');
+    const provider = new OpenAIProvider({
+      baseURL: 'https://proxy.example.test/v1',
+      useResponses: true,
+    });
+
+    const model = (await provider.getModel('m')) as any;
+
+    expect(model).toBeInstanceOf(OpenAIResponsesModel);
+    expect(model._agentIdentity).toBeUndefined();
+  });
+
+  it('allows explicit agent identity opt-in with explicit base URLs', async () => {
+    setDefaultOpenAIKey('test-key');
+    const agentIdentity = new OpenAIAgentIdentity({
+      agentHarnessId: 'test-harness',
+      agentVersion: '1.0.0',
+      runningLocation: 'test',
+    });
+    const provider = new OpenAIProvider({
+      agentIdentity,
+      baseURL: 'https://proxy.example.test/v1',
+      useResponses: true,
+    });
+
+    const model = (await provider.getModel('m')) as any;
+
+    expect(model).toBeInstanceOf(OpenAIResponsesModel);
+    expect(model._agentIdentity).toBe(agentIdentity);
   });
 
   it('returns websocket responses model when useResponsesWebSocket is enabled', async () => {

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -127,6 +127,179 @@ describe('OpenAIResponsesModel', () => {
     });
   });
 
+  it('adds AgentAssertion auth to sandbox-marked Responses requests', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-agent-assertion',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const agentIdentity = {
+        getAuthorizationHeader: vi.fn().mockResolvedValue('AgentAssertion jwt'),
+      };
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-test', {
+        agentIdentity: agentIdentity as any,
+      });
+
+      await model.getResponse({
+        systemInstructions: undefined,
+        input: 'hello',
+        modelSettings: {
+          providerData: {
+            openai_agents_sdk: {
+              sandbox: {
+                enabled: true,
+                externalTaskRef: 'group_123',
+              },
+            },
+            extra_headers: {
+              'X-Request-Header': 'present',
+            },
+          },
+        },
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      } as any);
+
+      expect(agentIdentity.getAuthorizationHeader).toHaveBeenCalledWith(
+        fakeClient,
+        { externalTaskRef: 'group_123' },
+      );
+      const [args, opts] = createMock.mock.calls[0];
+      expect(args.openai_agents_sdk).toBeUndefined();
+      expect(opts.headers).toMatchObject({
+        Authorization: 'AgentAssertion jwt',
+        'X-Request-Header': 'present',
+      });
+    });
+  });
+
+  it('does not add AgentAssertion auth without a sandbox marker by default', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-no-agent-assertion',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const agentIdentity = {
+        getAuthorizationHeader: vi.fn().mockResolvedValue('AgentAssertion jwt'),
+      };
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-test', {
+        agentIdentity: agentIdentity as any,
+      });
+
+      await model.getResponse({
+        systemInstructions: undefined,
+        input: 'hello',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      } as any);
+
+      expect(agentIdentity.getAuthorizationHeader).not.toHaveBeenCalled();
+      expect(createMock.mock.calls[0]?.[1]).toEqual({
+        headers: HEADERS,
+        signal: undefined,
+      });
+    });
+  });
+
+  it('can add AgentAssertion auth to every Responses request when configured', async () => {
+    await withTrace('test', async () => {
+      const fakeResponse = {
+        id: 'res-agent-assertion-always',
+        usage: {},
+        output: [],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const agentIdentity = {
+        getAuthorizationHeader: vi.fn().mockResolvedValue('AgentAssertion jwt'),
+      };
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-test', {
+        agentIdentity: agentIdentity as any,
+        agentIdentityMode: 'always',
+      });
+
+      await model.getResponse({
+        systemInstructions: undefined,
+        input: 'hello',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      } as any);
+
+      expect(agentIdentity.getAuthorizationHeader).toHaveBeenCalledWith(
+        fakeClient,
+        { externalTaskRef: undefined },
+      );
+      expect(createMock.mock.calls[0]?.[1].headers).toMatchObject({
+        Authorization: 'AgentAssertion jwt',
+      });
+    });
+  });
+
+  it('rejects explicit Authorization headers when AgentAssertion auth is enabled', async () => {
+    await withTrace('test', async () => {
+      const createMock = vi.fn();
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const agentIdentity = {
+        getAuthorizationHeader: vi.fn().mockResolvedValue('AgentAssertion jwt'),
+      };
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-test', {
+        agentIdentity: agentIdentity as any,
+      });
+
+      await expect(
+        model.getResponse({
+          systemInstructions: undefined,
+          input: 'hello',
+          modelSettings: {
+            providerData: {
+              openai_agents_sdk: {
+                sandbox: {
+                  enabled: true,
+                },
+              },
+              extra_headers: {
+                authorization: 'Bearer user-token',
+              },
+            },
+          },
+          tools: [],
+          outputType: 'text',
+          handoffs: [],
+          tracing: false,
+          signal: undefined,
+        } as any),
+      ).rejects.toThrow(/explicit Authorization header/);
+
+      expect(agentIdentity.getAuthorizationHeader).not.toHaveBeenCalled();
+      expect(createMock).not.toHaveBeenCalled();
+    });
+  });
+
   it('getRetryAdvice does not suggest retries from transport heuristics alone', () => {
     const fakeClient = {
       responses: { create: vi.fn() },

--- a/packages/agents-openai/test/openaiResponsesWSModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesWSModel.test.ts
@@ -427,6 +427,75 @@ describe('OpenAIResponsesWSModel', () => {
     expect((responseDone as any).response.id).toBe('resp_done');
   });
 
+  it('adds AgentAssertion auth to sandbox-marked websocket requests', async () => {
+    const fakeClient = createFakeClient();
+    const sentFrames: Record<string, any>[] = [];
+    const agentIdentity = {
+      getAuthorizationHeader: vi.fn().mockResolvedValue('AgentAssertion jwt'),
+    };
+
+    TestWebSocket.onCreate = (socket) => {
+      socket.onSend((rawFrame) => {
+        sentFrames.push(JSON.parse(rawFrame));
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: 'resp_init' },
+          sequence_number: 0,
+        });
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: 'resp_done',
+            output: [],
+            usage: {},
+          },
+          sequence_number: 1,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws', {
+      agentIdentity: agentIdentity as any,
+      websocketBaseURL: 'wss://proxy.example.test/v1',
+    });
+
+    const request = {
+      systemInstructions: undefined,
+      input: 'hello',
+      modelSettings: {
+        providerData: {
+          openai_agents_sdk: {
+            sandbox: {
+              enabled: true,
+              externalTaskRef: 'group_123',
+            },
+          },
+        },
+      },
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    for await (const _event of model.getStreamedResponse(request as any)) {
+      // Consume stream to trigger the websocket handshake.
+    }
+
+    expect(agentIdentity.getAuthorizationHeader).toHaveBeenCalledWith(
+      fakeClient,
+      { externalTaskRef: 'group_123' },
+    );
+    expect(TestWebSocket.instances[0]?.init).toMatchObject({
+      headers: {
+        Authorization: 'AgentAssertion jwt',
+      },
+    });
+    expect(sentFrames).toHaveLength(1);
+    expect(sentFrames[0]?.openai_agents_sdk).toBeUndefined();
+  });
+
   it('serializes websocket query array params with bracket-style encoding', async () => {
     const fakeClient = createFakeClient();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -716,6 +716,9 @@ importers:
       debug:
         specifier: ^4.4.0
         version: 4.4.1
+      libsodium-wrappers-sumo:
+        specifier: ^0.8.4
+        version: 0.8.4
       openai:
         specifier: ^6.35.0
         version: 6.35.0(ws@8.18.2)(zod@4.3.5)
@@ -5291,6 +5294,12 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libsodium-sumo@0.8.4:
+    resolution: {integrity: sha512-TMtHShQfVVsaxDygyapvUC3o7YsPgXa/hRWeIgzyFz6w5k/1hirGptCxp1U7XwW3rCskaTTYKgV10v86UiGgNw==}
+
+  libsodium-wrappers-sumo@0.8.4:
+    resolution: {integrity: sha512-ql7hcgulKZ3ekfa2DGAogcCKsWU0diA/0nArz1CFzh93WQdb46/Kj18ka/Hifq6uA3Ush34Pc6vU/6HXeRwUkg==}
 
   light-my-request@6.6.0:
     resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
@@ -13240,6 +13249,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  libsodium-sumo@0.8.4: {}
+
+  libsodium-wrappers-sumo@0.8.4:
+    dependencies:
+      libsodium-sumo: 0.8.4
 
   light-my-request@6.6.0:
     dependencies:


### PR DESCRIPTION
## Summary

Adds verified AgentAssertion auth for JavaScript Agents SDK sandbox Responses calls.

This PR wires the client-side half of sandbox attribution:

- adds an OpenAI agent identity helper that registers AuthAPI `/v1/agent/register`, registers per-run tasks, decrypts encrypted task ids, and signs `AgentAssertion` auth envelopes
- defaults registration to `https://auth.openai.com/api/accounts`, with `registrationBaseURL` available for staging/internal overrides
- marks sandbox runner model calls with private `providerData.openai_agents_sdk.sandbox` context, including a durable external task ref from `groupId`/`traceId`
- teaches HTTP and websocket Responses models to inject `Authorization: AgentAssertion ...` only for sandbox-marked calls by default
- creates a default SDK identity only when `OpenAIProvider` also creates the default OpenAI client; explicit `baseURL`, explicit `openAIClient`, and `setDefaultOpenAIClient()` do not get default runtime identity unless callers opt in via `agentIdentity`
- strips the private SDK marker before sending the Responses request body

## Why

The analytics/server-side PRs can only classify sandbox vs non-sandbox token/model usage when `/v1/responses` receives verified `agent_runtime_id` / `agent_task_id` context.

Arbitrary client attribution headers would not be trustworthy, so this uses the AgentAssertion flow instead:

1. register a runtime with SDK ABOM metadata (`agent_harness_id`, `agent_version`, `running_location`)
2. register a task signed by the runtime key
3. sign each sandbox Responses request with `runtime_id:task_id:timestamp`

That gives Responses analytics a verified runtime/task identity for sandbox Agents SDK traffic without changing ordinary non-sandbox SDK calls.

## Merge Blocker / Smoke Status

This should stay draft until the Responses API ingress auth path accepts AgentAssertion.

Live smoke results:

- AuthAPI runtime registration succeeds with a production API key at `https://auth.openai.com/api/accounts/v1/agent/register`.
- AuthAPI task registration also succeeds and returns an encrypted task id.
- A production `/v1/responses` call using raw `Authorization: AgentAssertion ...` currently fails with `401 Missing bearer or basic authentication in header`.
- Direct internal `responsesapi.gateway.unified-7` and staging `responsesapi.gateway.unified-0s` probes fail the same way.

The source issue appears to be server-side ingress config: `api/responsesapi/manage/applied_spec.py` currently uses `IdentityEdgePath.AUTHENTICATE_API_WITH_SP`, while the platform has `IdentityEdgePath.AUTHENTICATE_API_OR_AGENT_ASSERTION_WITH_SP` specifically for API credentials or AgentAssertion. After that server-side route change deploys, rerun the smoke and verify Responses analytics records `agent_runtime_id` and `agent_task_id`.

I could not complete a true staging smoke because `api.openai-staging.com` returned Cloudflare 403 from this environment and the available production API key is rejected by staging AuthAPI.

## Tables / Dashboard Impact

Once the matching server-side auth path and logging are live, this should let downstream marts and dashboards correctly populate:

- sandbox vs non-sandbox Agents SDK request/token counts
- sandbox token and model usage by customer/org/project
- model mix for sandbox Agents SDK traffic
- SDK version / runtime attribution for rollout health
- retention/adoption cohorts that depend on runtime/task registration and Responses usage alignment

## Validation

- `pnpm format:changed`
- `pnpm build`
- `pnpm -r build-check`
- `pnpm lint`
- `pnpm -F @openai/agents-openai build-check`
- `pnpm exec vitest run --project @openai/agents-openai agentIdentity openaiProvider openaiResponsesModel openaiResponsesWSModel`
- `pnpm exec pre-commit run --all-files` was attempted, but this repo does not have `.pre-commit-config.yaml`.

I also ran full `pnpm test`; it passed 2806 tests and failed one unrelated local Docker sandbox test (`test/sandboxes/docker.test.ts`) because `notes.txt` was missing inside the local Docker workspace. The targeted new coverage and repo build/lint/typecheck stack pass.
