### PR TITLE
feat: add Tensorlake sandbox provider

### DIFF
--- a/.changeset/tensorlake-sandbox.md
+++ b/.changeset/tensorlake-sandbox.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': minor
+---
+
+feat: add Tensorlake sandbox provider under `@openai/agents-extensions/sandbox/tensorlake`

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ The OpenAI Agents SDK is a lightweight yet powerful framework for building multi
 
 <img src="https://cdn.openai.com/API/docs/images/orchestration.png" alt="Image of the Agents Tracing UI" style="max-height: 803px;">
 
-> [!NOTE] 
-> Looking for the Python version? Check out [OpenAI Agents SDK Python](https://github.com/openai/openai-agents-python).
+> [!NOTE] Looking for the Python version? Check out [OpenAI Agents SDK Python](https://github.com/openai/openai-agents-python).
 
 ## Core concepts
 

--- a/docs/src/content/docs/guides/sandbox-agents/clients.mdx
+++ b/docs/src/content/docs/guides/sandbox-agents/clients.mdx
@@ -142,6 +142,7 @@ Install `@openai/agents-extensions` and satisfy its package-level peers. Each pr
 | `E2BSandboxClient` | `@openai/agents-extensions/sandbox/e2b` | npm peer: `e2b` or `@e2b/code-interpreter` |
 | `ModalSandboxClient` | `@openai/agents-extensions/sandbox/modal` | npm peer: `modal` |
 | `RunloopSandboxClient` | `@openai/agents-extensions/sandbox/runloop` | npm peer: `@runloop/api-client` |
+| `TensorlakeSandboxClient` | `@openai/agents-extensions/sandbox/tensorlake` | npm peer: `tensorlake` |
 | `VercelSandboxClient` | `@openai/agents-extensions/sandbox/vercel` | npm peer: `@vercel/sandbox` |
 
 `CloudflareSandboxClient` does not import a Cloudflare npm SDK. It talks to a deployed Cloudflare Sandbox bridge Worker over HTTP instead.
@@ -157,6 +158,7 @@ Hosted sandbox clients expose provider-specific mount strategies. Choose the bac
 | `DaytonaSandboxClient` | Supports rclone-backed mounts with `DaytonaCloudBucketMountStrategy` on S3, GCS, R2, Azure Blob, and Box mount entries. |
 | `E2BSandboxClient` | Supports rclone-backed mounts with `E2BCloudBucketMountStrategy` on S3, GCS, R2, Azure Blob, and Box mount entries. |
 | `RunloopSandboxClient` | Supports rclone-backed mounts with `RunloopCloudBucketMountStrategy` on S3, GCS, R2, Azure Blob, and Box mount entries. |
+| `TensorlakeSandboxClient` | No hosted-specific mount strategy is currently exposed. Use manifest files, repos, or other workspace inputs instead. The default manifest root is `DEFAULT_TENSORLAKE_WORKSPACE_ROOT` (`/home/tl-user/workspace`), which is writable by the default image's non-root user and persisted across native checkpoints; override it only when targeting a custom image. Tensorlake's native sandbox checkpoint API is available via `workspacePersistence: 'snapshot'`; prefer this over external bucket mounts for between-run persistence. |
 | `VercelSandboxClient` | No hosted-specific mount strategy is currently exposed. Use manifest files, repos, snapshots, or other workspace inputs instead. |
 
 The table below summarizes which remote storage entries each backend can mount directly:
@@ -170,6 +172,7 @@ The table below summarizes which remote storage entries each backend can mount d
 | `DaytonaSandboxClient` | yes | yes | yes | yes | yes | no |
 | `E2BSandboxClient` | yes | yes | yes | yes | yes | no |
 | `RunloopSandboxClient` | yes | yes | yes | yes | yes | no |
+| `TensorlakeSandboxClient` | no | no | no | no | no | no |
 | `VercelSandboxClient` | no | no | no | no | no | no |
 
 ### Exposed ports

--- a/examples/sandbox/extensions/README.md
+++ b/examples/sandbox/extensions/README.md
@@ -277,3 +277,44 @@ Run:
 ```bash
 pnpm -F sandbox start:runloop -- --stream
 ```
+
+## Tensorlake
+
+Required environment variables:
+
+```bash
+export OPENAI_API_KEY=...
+export TENSORLAKE_API_KEY=...
+```
+
+How to get `TENSORLAKE_API_KEY`:
+
+1. Sign in to the Tensorlake console at `https://cloud.tensorlake.ai`.
+2. Create an API key in `Profile > API keys` (or run `tl login` and use `tl tokens create` from the CLI).
+3. Export it in your shell before running the example.
+
+Tensorlake creates ephemeral sandboxes by default. To exercise the suspend/resume path, pass `--name <unique-name>` together with `--suspend-on-exit`, which keeps the named sandbox alive between runs:
+
+```bash
+pnpm -F sandbox start:tensorlake -- --stream --name demo --suspend-on-exit
+```
+
+To use a native Tensorlake checkpoint for workspace persistence, add `--workspace-persistence snapshot`:
+
+```bash
+pnpm -F sandbox start:tensorlake -- --workspace-persistence snapshot
+```
+
+Run:
+
+```bash
+pnpm -F sandbox start:tensorlake -- --stream
+```
+
+Useful flags:
+
+- `--image <name>` to pin a specific Tensorlake registered image.
+- `--cpus <n>` to set the sandbox CPU allocation.
+- `--memory-mb <n>` to set the sandbox memory allocation, in megabytes. Must be between 1024 and 8192 MB **per CPU core**, so scale this up alongside `--cpus` (for example, `--cpus 2` requires at least `--memory-mb 2048`).
+- `--disk-mb <n>` to set the sandbox ephemeral root filesystem size, in MiB. Must be between **10240 (10 GiB)** and **102400 (100 GiB)** inclusive. Defaults to 10240 MiB when omitted.
+- `--timeout-secs <n>` to bound the sandbox lifetime in seconds.

--- a/examples/sandbox/extensions/tensorlake-runner.ts
+++ b/examples/sandbox/extensions/tensorlake-runner.ts
@@ -1,0 +1,132 @@
+import { Runner } from '@openai/agents';
+import {
+  TensorlakeSandboxClient,
+  type TensorlakeWorkspacePersistence,
+} from '@openai/agents-extensions/sandbox/tensorlake';
+import { Manifest, SandboxAgent, shell } from '@openai/agents/sandbox';
+import { finished } from 'node:stream/promises';
+import {
+  DEFAULT_MODEL,
+  getStringArg,
+  hasFlag,
+  getOptionalNumberArg,
+  getOptionalStringArg,
+  requireEnv,
+  requireOpenAIKey,
+  runExampleMain,
+} from '../support';
+
+const DEFAULT_QUESTION =
+  'Summarize this cloud sandbox workspace in 2 sentences.';
+
+function parseWorkspacePersistence(
+  value: string | undefined,
+): TensorlakeWorkspacePersistence | undefined {
+  if (!value) return undefined;
+  if (value === 'tar' || value === 'snapshot') return value;
+  throw new Error(
+    `--workspace-persistence must be "tar" or "snapshot", received ${value}.`,
+  );
+}
+
+const DISK_MB_MIN = 10240;
+const DISK_MB_MAX = 102400;
+
+function validateDiskMb(value: number | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  if (!Number.isInteger(value) || value < DISK_MB_MIN || value > DISK_MB_MAX) {
+    throw new Error(
+      `--disk-mb must be an integer between ${DISK_MB_MIN} (10 GiB) and ${DISK_MB_MAX} (100 GiB) inclusive, received ${value}.`,
+    );
+  }
+  return value;
+}
+
+function buildManifest(): Manifest {
+  return new Manifest({
+    entries: {
+      'README.md': {
+        type: 'file',
+        content: `# Tensorlake Demo Workspace
+
+This workspace exists to validate the Tensorlake sandbox backend manually.
+`,
+      },
+      'customer.md': {
+        type: 'file',
+        content: `# Customer
+
+- Name: Acme Robotics.
+- Renewal date: 2026-04-15.
+- Risk: unfinished SSO migration.
+`,
+      },
+      'next_steps.md': {
+        type: 'file',
+        content: `# Next steps
+
+1. Finish the SSO migration.
+2. Confirm legal language before procurement review.
+`,
+      },
+    },
+  });
+}
+
+async function main() {
+  requireOpenAIKey();
+  requireEnv('TENSORLAKE_API_KEY');
+
+  const model = getStringArg('--model', DEFAULT_MODEL);
+  const question = getStringArg('--question', DEFAULT_QUESTION);
+  const name = getOptionalStringArg('--name');
+  const image = getOptionalStringArg('--image');
+  const cpus = getOptionalNumberArg('--cpus');
+  const memoryMb = getOptionalNumberArg('--memory-mb');
+  const diskMb = validateDiskMb(getOptionalNumberArg('--disk-mb'));
+  const timeoutSecs = getOptionalNumberArg('--timeout-secs');
+  const suspendOnExit = hasFlag('--suspend-on-exit');
+  const workspacePersistence = parseWorkspacePersistence(
+    getOptionalStringArg('--workspace-persistence'),
+  );
+  const stream = hasFlag('--stream');
+
+  const client = new TensorlakeSandboxClient({
+    name,
+    image,
+    cpus,
+    memoryMb,
+    diskMb,
+    timeoutSecs,
+    suspendOnExit,
+    workspacePersistence,
+  });
+  const agent = new SandboxAgent({
+    name: 'Tensorlake Sandbox Assistant',
+    model,
+    instructions:
+      'Answer questions about the sandbox workspace. Inspect the files before answering, keep the response concise, and cite the file names you inspected.',
+    defaultManifest: buildManifest(),
+    capabilities: [shell()],
+  });
+  const runner = new Runner({
+    workflowName: 'Tensorlake sandbox example',
+    sandbox: { client },
+  });
+
+  if (!stream) {
+    const result = await runner.run(agent, question);
+    console.log(result.finalOutput);
+    return;
+  }
+
+  const result = await runner.run(agent, question, { stream: true });
+  process.stdout.write('assistant> ');
+  const textStream = result.toTextStream({ compatibleWithNodeStreams: true });
+  textStream.pipe(process.stdout);
+  await finished(textStream);
+  await result.completed;
+  process.stdout.write('\n');
+}
+
+await runExampleMain(main);

--- a/examples/sandbox/package.json
+++ b/examples/sandbox/package.json
@@ -28,6 +28,7 @@
     "start:e2b": "tsx extensions/e2b-runner.ts",
     "start:modal": "tsx extensions/modal-runner.ts",
     "start:runloop": "tsx extensions/runloop-runner.ts",
+    "start:tensorlake": "tsx extensions/tensorlake-runner.ts",
     "start:vercel": "tsx extensions/vercel-runner.ts"
   }
 }

--- a/packages/agents-extensions/package.json
+++ b/packages/agents-extensions/package.json
@@ -64,6 +64,11 @@
       "require": "./dist/sandbox/runloop/index.js",
       "import": "./dist/sandbox/runloop/index.mjs"
     },
+    "./sandbox/tensorlake": {
+      "types": "./dist/sandbox/tensorlake/index.d.ts",
+      "require": "./dist/sandbox/tensorlake/index.js",
+      "import": "./dist/sandbox/tensorlake/index.mjs"
+    },
     "./sandbox/vercel": {
       "types": "./dist/sandbox/vercel/index.d.ts",
       "require": "./dist/sandbox/vercel/index.js",
@@ -87,6 +92,7 @@
     "ai": "^6.0.0",
     "e2b": "^2.14.1",
     "modal": "^0.7.4",
+    "tensorlake": "^0.5.14",
     "ws": "^8.18.1",
     "zod": "^4.0.0"
   },
@@ -118,6 +124,9 @@
     "@runloop/api-client": {
       "optional": true
     },
+    "tensorlake": {
+      "optional": true
+    },
     "@vercel/sandbox": {
       "optional": true
     }
@@ -142,6 +151,7 @@
     "ai": "^6.0.42",
     "e2b": "^2.14.1",
     "modal": "0.7.4",
+    "tensorlake": "0.5.14",
     "undici-types": "6.21.0",
     "ws": "^8.18.1",
     "zod": "^4.0.0"
@@ -168,6 +178,9 @@
       ],
       "sandbox/runloop": [
         "dist/sandbox/runloop/index.d.ts"
+      ],
+      "sandbox/tensorlake": [
+        "dist/sandbox/tensorlake/index.d.ts"
       ],
       "sandbox/vercel": [
         "dist/sandbox/vercel/index.d.ts"

--- a/packages/agents-extensions/src/sandbox/shared/index.ts
+++ b/packages/agents-extensions/src/sandbox/shared/index.ts
@@ -115,6 +115,7 @@ export {
   readOptionalRecord,
   readOptionalRecordArray,
   readOptionalString,
+  readOptionalStringArray,
   readOptionalStringRecord,
   readString,
 } from './typeGuards';

--- a/packages/agents-extensions/src/sandbox/shared/sessionBase.ts
+++ b/packages/agents-extensions/src/sandbox/shared/sessionBase.ts
@@ -356,6 +356,37 @@ export abstract class RemoteSandboxSessionBase<
 
   protected async beforeApplyManifest(_manifest: Manifest): Promise<void> {}
 
+  /**
+   * When true, `applyManifest()` skips the `groupadd`/`useradd`/`usermod`
+   * round-trips because the backend filesystem already carries the manifest's
+   * accounts. Used by providers that restore a sandbox from a native
+   * filesystem snapshot whose image captures `/etc/passwd` and `/etc/group`,
+   * so re-running provisioning is wasted work and can fail if accounts are
+   * partially present.
+   *
+   * Default is `false`, which preserves the existing behavior for every other
+   * provider — only opt-in overrides change anything. Introduced for the
+   * Tensorlake provider, whose default image both pre-bakes accounts in its
+   * snapshot path and has no usable root for `useradd`-style commands.
+   */
+  protected manifestAccountsAlreadyProvisioned(): boolean {
+    return false;
+  }
+
+  /**
+   * When false, `applyManifestEntryMetadata` skips the `chown`/`chgrp`
+   * commands (still applies `chmod`). For providers whose runtime image has
+   * no usable root account, where ownership commands would fail.
+   *
+   * Default is `true`, which preserves the existing behavior for every other
+   * provider — only opt-in overrides change anything. Introduced for the
+   * Tensorlake provider, whose default image only ships a non-root `tl-user`
+   * account, so ownership commands cannot be executed but file modes can.
+   */
+  protected shouldApplyManifestEntryOwnership(): boolean {
+    return true;
+  }
+
   protected resolveManifestForApply(
     manifest: Manifest,
   ): Manifest | Promise<Manifest> {
@@ -640,6 +671,9 @@ export abstract class RemoteSandboxSessionBase<
     if (!support?.users && !support?.groups) {
       return;
     }
+    if (this.manifestAccountsAlreadyProvisioned()) {
+      return;
+    }
 
     const users = new Set(manifest.users.map((user) => user.name));
     for (const group of manifest.groups) {
@@ -697,13 +731,14 @@ export abstract class RemoteSandboxSessionBase<
     runAs?: string,
   ): Promise<void> {
     const support = this.manifestMetadataSupport();
+    const applyOwnership = this.shouldApplyManifestEntryOwnership();
     const commands: string[] = [];
-    if (runAs) {
+    if (applyOwnership && runAs) {
       commands.push(
         `chown ${shellQuote(runAs)}:${shellQuote(runAs)} -- ${shellQuote(absolutePath)}`,
       );
     }
-    if (support?.entryGroups && entry.group) {
+    if (applyOwnership && support?.entryGroups && entry.group) {
       commands.push(
         `chgrp ${shellQuote(entry.group.name)} -- ${shellQuote(absolutePath)}`,
       );

--- a/packages/agents-extensions/src/sandbox/shared/snapshots.ts
+++ b/packages/agents-extensions/src/sandbox/shared/snapshots.ts
@@ -6,6 +6,7 @@ export type NativeSnapshotProvider =
   | 'modal_snapshot_directory'
   | 'modal_snapshot_filesystem'
   | 'runloop'
+  | 'tensorlake'
   | 'vercel';
 
 export type NativeSnapshotRef = {
@@ -19,6 +20,7 @@ const NATIVE_SNAPSHOT_PREFIXES: Record<NativeSnapshotProvider, string> = {
   modal_snapshot_directory: 'MODAL_SANDBOX_DIR_SNAPSHOT_V1\n',
   modal_snapshot_filesystem: 'MODAL_SANDBOX_FS_SNAPSHOT_V1\n',
   runloop: 'RUNLOOP_SANDBOX_SNAPSHOT_V1\n',
+  tensorlake: 'TENSORLAKE_SANDBOX_SNAPSHOT_V1\n',
   vercel: 'UC_VERCEL_SNAPSHOT_V1\n',
 };
 

--- a/packages/agents-extensions/src/sandbox/shared/typeGuards.ts
+++ b/packages/agents-extensions/src/sandbox/shared/typeGuards.ts
@@ -56,6 +56,16 @@ export function readOptionalNumberArray(value: unknown): number[] | undefined {
     : undefined;
 }
 
+export function readOptionalStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const result: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== 'string') return undefined;
+    result.push(entry);
+  }
+  return result;
+}
+
 export function readOptionalRecordArray(
   value: unknown,
 ): Array<Record<string, unknown>> | undefined {

--- a/packages/agents-extensions/src/sandbox/tensorlake/index.ts
+++ b/packages/agents-extensions/src/sandbox/tensorlake/index.ts
@@ -1,0 +1,1 @@
+export * from './sandbox';

--- a/packages/agents-extensions/src/sandbox/tensorlake/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/tensorlake/sandbox.ts
@@ -1,0 +1,1992 @@
+import { UserError, getLogger } from '@openai/agents-core';
+import { randomUUID } from 'node:crypto';
+import {
+  Manifest,
+  SandboxProviderError,
+  SandboxUnsupportedFeatureError,
+  type ExecCommandArgs,
+  type ExposedPortEndpoint,
+  type SandboxArchiveLimits,
+  type SandboxClient,
+  type SandboxClientCreateArgs,
+  type SandboxClientOptions,
+  type SandboxConcurrencyLimits,
+  type SandboxSessionLifecycleOptions,
+  type SandboxSessionState,
+  type WorkspaceArchiveData,
+  type WorkspaceArchiveOptions,
+  type WriteStdinArgs,
+  normalizeSandboxClientCreateArgs,
+} from '@openai/agents-core/sandbox';
+import {
+  appendPtyOutput,
+  assertCoreSnapshotUnsupported,
+  assertResumeRecreateAllowed,
+  assertSandboxManifestMetadataSupported,
+  assertTarWorkspacePersistence,
+  cloneManifestWithRoot,
+  closeRemoteSessionOnManifestError,
+  createPtyProcessEntry,
+  decodeNativeSnapshotRef,
+  deserializeRemoteSandboxSessionStateValues,
+  encodeNativeSnapshotRef,
+  formatPtyExecUpdate,
+  isRecord,
+  markPtyDone,
+  materializeEnvironment,
+  parseExposedPortEndpoint,
+  persistRemoteWorkspaceTar,
+  providerErrorDetails,
+  providerErrorMessage,
+  PtyProcessRegistry,
+  readOptionalBoolean,
+  readOptionalNumber,
+  readOptionalNumberArray,
+  readOptionalString,
+  readOptionalStringArray,
+  readString,
+  RemoteSandboxSessionBase,
+  serializeRemoteSandboxSessionState,
+  shellCommandForPty,
+  shellQuote,
+  watchPtyProcess,
+  withProviderError,
+  withSandboxSpan,
+  writePtyStdin,
+  type RemoteSandboxCommandOptions,
+  type RemoteSandboxCommandResult,
+  type RemoteWorkspaceTarIo,
+} from '../shared';
+
+const PROVIDER_NAME = 'TensorlakeSandboxClient';
+const PROVIDER_ID = 'tensorlake';
+
+const logger = getLogger('openai-agents:sandbox:tensorlake');
+
+/** Default manifest root. The image runs as non-root tl-user; /workspace is
+ *  not writable by that account, but /home/tl-user/workspace is and survives
+ *  Tensorlake snapshots. */
+export const DEFAULT_TENSORLAKE_WORKSPACE_ROOT = '/home/tl-user/workspace';
+
+const TENSORLAKE_DEFAULT_PROXY_URL = 'https://sandbox.tensorlake.ai';
+
+function resolveProxyBase(): { protocol: string; host: string } {
+  const explicit = process.env.TENSORLAKE_SANDBOX_PROXY_URL;
+  if (explicit) {
+    try {
+      const parsed = new URL(explicit);
+      return { protocol: parsed.protocol, host: parsed.host };
+    } catch {
+      // Fall through to the trusted default.
+    }
+  }
+  const parsed = new URL(TENSORLAKE_DEFAULT_PROXY_URL);
+  return { protocol: parsed.protocol, host: parsed.host };
+}
+
+type TensorlakeRunOptions = {
+  args?: string[];
+  env?: Record<string, string>;
+  workingDir?: string;
+  timeout?: number;
+  user?: string;
+};
+
+type TensorlakeRunResult = {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number | null;
+};
+
+type TensorlakeListEntry = {
+  name?: string;
+  path?: string;
+  isDir?: boolean;
+};
+
+type TensorlakeUpdateOptions = {
+  name?: string;
+  exposedPorts?: number[];
+  allowUnauthenticatedAccess?: boolean;
+};
+
+type TensorlakeCheckpointType = 'memory' | 'filesystem';
+
+type TensorlakeCheckpointWaitUntil = 'completed' | 'local_ready';
+
+type TensorlakeCheckpointOptions = {
+  checkpointType?: TensorlakeCheckpointType;
+  waitUntil?: TensorlakeCheckpointWaitUntil;
+  timeout?: number;
+};
+
+type TensorlakePtyOptions = {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  workingDir?: string;
+  cols?: number;
+  rows?: number;
+  onData?: (data: Uint8Array | string) => void | Promise<void>;
+  onExit?: (exitCode: number | null) => void | Promise<void>;
+};
+
+type TensorlakePtyHandle = {
+  sessionId?: string;
+  token?: string;
+  sendInput(data: string | Uint8Array): Promise<void>;
+  resize?(cols: number, rows: number): Promise<void>;
+  wait?(): Promise<number | null>;
+  disconnect?(): void | Promise<void>;
+  kill?(): Promise<void>;
+};
+
+type TensorlakeSandboxInfo = {
+  sandboxId?: string;
+  sandbox_id?: string;
+  sandboxUrl?: string;
+  sandbox_url?: string;
+};
+
+type TensorlakeSandboxInstance = {
+  sandboxId: string;
+  name?: string | null;
+  run(command: string, options?: TensorlakeRunOptions): Promise<TensorlakeRunResult>;
+  writeFile(path: string, content: string | Uint8Array): Promise<void>;
+  readFile(path: string): Promise<Uint8Array>;
+  deleteFile?(path: string): Promise<void>;
+  listDirectory?(path: string): Promise<TensorlakeListEntry[]>;
+  createPty?(options: TensorlakePtyOptions): Promise<TensorlakePtyHandle>;
+  update?(options: TensorlakeUpdateOptions): Promise<unknown>;
+  suspend?(): Promise<unknown>;
+  resume?(): Promise<unknown>;
+  terminate(): Promise<unknown>;
+  info?(): Promise<TensorlakeSandboxInfo | undefined>;
+  status?(): Promise<unknown>;
+  checkpoint?(options?: TensorlakeCheckpointOptions): Promise<{ snapshotId?: string }>;
+};
+
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
+
+// Tensorlake only supports suspend/resume on named sandboxes, so when
+// suspendOnExit is requested without a name we mint a stable one.
+const GENERATED_TENSORLAKE_NAME_PREFIX = 'openai-agents-';
+
+// `mounts` is disabled because the session does not implement materializeMount.
+// `users`/`groups`/`entry*` are advertised so manifests validate, but in the
+// default 'collapse' mode the session skips account provisioning and ownership
+// commands (which need root); `chmod` still runs.
+const TENSORLAKE_MANIFEST_METADATA_SUPPORT = {
+  users: true,
+  groups: true,
+  entryPermissions: true,
+  entryGroups: true,
+  mounts: false,
+} as const;
+
+// Mirrors Tensorlake SDK's default sandbox.checkpoint() poll timeout (300s).
+const TENSORLAKE_SDK_DEFAULT_CHECKPOINT_TIMEOUT_SECS = 300;
+
+const TRANSIENT_HTTP_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
+const TRANSIENT_HTTP_RETRY_ATTEMPTS = 3;
+const TRANSIENT_HTTP_RETRY_BACKOFF_MS = 250;
+
+/**
+ * Per-operation timeouts (seconds).
+ * - execTimeoutUnboundedSecs: safety cap for exec() calls without explicit timeout (24h default).
+ * - fastOpSecs: short backend ops like mkdir, deleteFile, port updates (30s default).
+ * - snapshotTarSecs: tar persist/hydrate (300s default).
+ */
+export type TensorlakeSandboxTimeouts = {
+  execTimeoutUnboundedSecs?: number;
+  fastOpSecs?: number;
+  snapshotTarSecs?: number;
+};
+
+const DEFAULT_TENSORLAKE_TIMEOUTS = {
+  execTimeoutUnboundedSecs: 24 * 60 * 60,
+  fastOpSecs: 30,
+  snapshotTarSecs: 300,
+} as const satisfies Required<TensorlakeSandboxTimeouts>;
+
+type ResolvedTensorlakeTimeouts = Required<TensorlakeSandboxTimeouts>;
+
+const TIMEOUT_KEYS = Object.keys(
+  DEFAULT_TENSORLAKE_TIMEOUTS,
+) as (keyof TensorlakeSandboxTimeouts)[];
+
+function resolveTimeouts(
+  input: TensorlakeSandboxTimeouts | undefined,
+): ResolvedTensorlakeTimeouts {
+  const resolved = { ...DEFAULT_TENSORLAKE_TIMEOUTS } as ResolvedTensorlakeTimeouts;
+  for (const key of TIMEOUT_KEYS) {
+    if (input?.[key] !== undefined) resolved[key] = input[key]!;
+    if (!Number.isFinite(resolved[key]) || resolved[key] <= 0) {
+      throw new UserError(
+        `${PROVIDER_NAME} timeouts.${key} must be a positive finite number.`,
+      );
+    }
+  }
+  return resolved;
+}
+
+function extractHttpStatus(error: unknown): number | undefined {
+  // providerErrorDetails walks cause/response chains but skips
+  // SandboxProviderError.details where wrapped re-throws stash upstream status.
+  const wrapped = isRecord(error) ? error.details : undefined;
+  for (const bag of [providerErrorDetails(error), isRecord(wrapped) ? wrapped : undefined]) {
+    if (!bag) continue;
+    for (const key of ['status', 'httpStatus', 'responseStatus']) {
+      const value = bag[key];
+      if (typeof value === 'number' && Number.isInteger(value)) return value;
+    }
+  }
+  return undefined;
+}
+
+async function retryTransientHttp<T>(operation: () => Promise<T>): Promise<T> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      const status = extractHttpStatus(error);
+      const transient =
+        status !== undefined && TRANSIENT_HTTP_STATUS_CODES.has(status);
+      if (!transient || attempt === TRANSIENT_HTTP_RETRY_ATTEMPTS - 1) throw error;
+      await new Promise((resolve) =>
+        setTimeout(resolve, TRANSIENT_HTTP_RETRY_BACKOFF_MS * 2 ** attempt),
+      );
+    }
+  }
+}
+
+type TensorlakeSandboxClass = {
+  create(options?: Record<string, unknown>): Promise<TensorlakeSandboxInstance>;
+  connect(options: { sandboxId: string } & Record<string, unknown>): Promise<TensorlakeSandboxInstance>;
+};
+
+export type TensorlakeWorkspacePersistence = true | 'tar' | 'snapshot';
+
+/**
+ * How the provider handles manifest identity declarations (users/groups/entry
+ * ownership). The default Tensorlake image only ships non-root `tl-user`.
+ *
+ * - `'collapse'` (default): skip account provisioning and ownership commands;
+ *   everything runs as `tl-user`. `chmod` still runs. A single warning is
+ *   logged per `applyManifest()` when anything is dropped.
+ * - `'provision'`: run `groupadd`/`useradd`/`usermod`/`chown`/`chgrp` as usual.
+ *   Requires a custom Tensorlake image that exposes root.
+ */
+export type TensorlakeManifestIdentitiesMode = 'collapse' | 'provision';
+
+export interface TensorlakeSandboxClientOptions extends SandboxClientOptions {
+  /** Sandbox name. Required for suspend/resume; auto-generated when suspendOnExit is true. */
+  name?: string;
+  /** Sandbox image name or ID. Defaults to the platform default image. */
+  image?: string;
+  cpus?: number;
+  memoryMb?: number;
+  /** Root disk size in MB. Uses the SDK default when unset. */
+  diskMb?: number;
+  /** Auto-suspend (named) or auto-terminate (ephemeral) after this many seconds of idleness. */
+  timeoutSecs?: number;
+  /** Max seconds to wait for the sandbox to reach Running after create. */
+  startupTimeout?: number;
+  /** Names of secrets to inject as environment variables. */
+  secretNames?: string[];
+  entrypoint?: string[];
+  allowInternetAccess?: boolean;
+  allowOut?: string[];
+  denyOut?: string[];
+  /** User ports to expose at create-time. Listed entries skip late update. */
+  exposedPorts?: number[];
+  allowUnauthenticatedAccess?: boolean;
+  /** API key override; defaults to process.env.TENSORLAKE_API_KEY. */
+  apiKey?: string;
+  /** Pool id for pre-warmed sandbox. Mutually exclusive with snapshot restore (snapshot wins). */
+  poolId?: string;
+  /** Override the sandbox proxy URL (self-hosted/dev). Forwarded to Sandbox.create/connect. */
+  proxyUrl?: string;
+  /** Override the control-plane API URL. */
+  apiUrl?: string;
+  /** Tensorlake namespace selector. */
+  namespace?: string;
+  /** Tensorlake organization id. */
+  organizationId?: string;
+  /** Tensorlake project id. */
+  projectId?: string;
+  /** Routing hint for Sandbox.connect on resume. Not used at create time. */
+  routingHint?: string;
+  /** Per-command default timeout in seconds. */
+  commandTimeoutSecs?: number;
+  /** Fine-grained per-op timeouts. Defaults: 24h exec cap, 30s fast ops, 300s tar persist. */
+  timeouts?: TensorlakeSandboxTimeouts;
+  /** Workspace persist mode: 'tar' (default) or 'snapshot' (uses sandbox.checkpoint). */
+  workspacePersistence?: TensorlakeWorkspacePersistence;
+  /** How to apply manifest identities. 'collapse' (default) skips root-only commands. */
+  manifestIdentities?: TensorlakeManifestIdentitiesMode;
+  /** Workspace tar archive caps. Defaults from DEFAULT_SANDBOX_ARCHIVE_LIMITS; null disables. */
+  archiveLimits?: SandboxArchiveLimits | null;
+  /** Checkpoint type used when workspacePersistence === 'snapshot'. */
+  snapshotCheckpointType?: TensorlakeCheckpointType;
+  /** Timeout (s) forwarded to sandbox.checkpoint() when persistence is 'snapshot'. */
+  checkpointTimeoutSecs?: number;
+  /**
+   * Native checkpoint wait mode. 'local_ready' (default) returns once locally
+   * resumable on the same backend; 'completed' additionally blocks for durable
+   * remote-storage upload (use only when a durable snapshot_uri is required).
+   */
+  checkpointWaitUntil?: TensorlakeCheckpointWaitUntil;
+  /** Suspend named sandboxes on close instead of terminating. Auto-mints a name when unset. */
+  suspendOnExit?: boolean;
+  /** Materialized environment variables for sandbox commands. */
+  env?: Record<string, string>;
+}
+
+type TensorlakeControlPlaneOptions = Pick<
+  TensorlakeSandboxClientOptions,
+  | 'apiKey'
+  | 'proxyUrl'
+  | 'apiUrl'
+  | 'namespace'
+  | 'organizationId'
+  | 'projectId'
+  | 'routingHint'
+>;
+
+// Constructor-supplied options that override session state on resume —
+// persisted state may have been tampered with, so trusted in-process options
+// win for security-sensitive fields (routing, image, egress, ports). Applied
+// at the resume() boundary via withTrustedRecreateOverrides.
+type TensorlakeTrustedRecreateOptions = TensorlakeControlPlaneOptions &
+  Pick<
+    TensorlakeSandboxClientOptions,
+    | 'image'
+    | 'entrypoint'
+    | 'secretNames'
+    | 'allowInternetAccess'
+    | 'allowOut'
+    | 'denyOut'
+    | 'exposedPorts'
+    | 'allowUnauthenticatedAccess'
+  >;
+
+export interface TensorlakeSandboxSessionState extends SandboxSessionState {
+  sandboxId: string;
+  name?: string;
+  image?: string;
+  cpus?: number;
+  memoryMb?: number;
+  diskMb?: number;
+  timeoutSecs?: number;
+  startupTimeout?: number;
+  secretNames?: string[];
+  entrypoint?: string[];
+  allowInternetAccess?: boolean;
+  allowOut?: string[];
+  denyOut?: string[];
+  configuredExposedPorts?: number[];
+  allowUnauthenticatedAccess?: boolean;
+  commandTimeoutSecs?: number;
+  timeouts?: TensorlakeSandboxTimeouts;
+  poolId?: string;
+  proxyUrl?: string;
+  apiUrl?: string;
+  namespace?: string;
+  organizationId?: string;
+  projectId?: string;
+  routingHint?: string;
+  workspacePersistence?: TensorlakeWorkspacePersistence;
+  manifestIdentities?: TensorlakeManifestIdentitiesMode;
+  snapshotCheckpointType?: TensorlakeCheckpointType;
+  checkpointTimeoutSecs?: number;
+  checkpointWaitUntil?: TensorlakeCheckpointWaitUntil;
+  suspendOnExit: boolean;
+  environment: Record<string, string>;
+  /**
+   * Snapshot id from persistWorkspace() that still matches the live workspace
+   * — cleared by any mutation (exec, writeFile, deleteFile, mkdir, PTY,
+   * hydrate-tar, persist-tar) so resume()'s fast-path never silently restores
+   * a stale checkpoint. When unset, resume falls through to a clean recreate
+   * from the manifest; callers who stored the persistWorkspace() archive can
+   * still call hydrateWorkspace(archive) on the new session for best-effort
+   * recovery from the previous snapshot.
+   */
+  snapshotId?: string;
+  /** Workspace root already exists on the backend; skip mkdir -p. */
+  workspaceRootProvisioned?: boolean;
+  /** Manifest user/group accounts already present (e.g. from snapshot image); skip provisioning. */
+  systemSetupPreserved?: boolean;
+}
+
+export class TensorlakeSandboxSession extends RemoteSandboxSessionBase<TensorlakeSandboxSessionState> {
+  private sandbox: TensorlakeSandboxInstance;
+  private readonly ptyProcesses = new PtyProcessRegistry();
+  private readonly exposedPortConfigured = new Set<number>();
+  private readonly trustedRecreateOptions: TensorlakeTrustedRecreateOptions;
+  private cachedProxyHostname: string | null | undefined = undefined;
+  private hasWarnedAboutMissingSandboxUrl = false;
+  private readonly resolvedTimeouts: ResolvedTensorlakeTimeouts;
+
+  constructor(args: {
+    state: TensorlakeSandboxSessionState;
+    sandbox: TensorlakeSandboxInstance;
+    concurrencyLimits?: SandboxConcurrencyLimits;
+    archiveLimits?: SandboxArchiveLimits | null;
+    trustedRecreateOptions?: TensorlakeTrustedRecreateOptions;
+  }) {
+    super({
+      state: args.state,
+      options: {
+        providerName: PROVIDER_NAME,
+        providerId: PROVIDER_ID,
+        concurrencyLimits: args.concurrencyLimits,
+        archiveLimits: args.archiveLimits,
+      },
+    });
+    this.sandbox = args.sandbox;
+    this.trustedRecreateOptions = args.trustedRecreateOptions ?? {};
+    this.resolvedTimeouts = resolveTimeouts(this.state.timeouts);
+    for (const port of this.state.configuredExposedPorts ?? []) {
+      this.exposedPortConfigured.add(port);
+    }
+  }
+
+  override supportsPty(): boolean {
+    return typeof this.sandbox.createPty === 'function';
+  }
+
+  // tensorlake >=0.5.14 supports per-command user override on run(); PTY
+  // runAs is checked separately because createPty() does not expose it.
+  protected override assertExecRunAs(_runAs?: string): void {}
+
+  async writeStdin(args: WriteStdinArgs): Promise<string> {
+    // PTY keystrokes can mutate the workspace; invalidate so a later resume
+    // after sandbox death doesn't fast-restore a pre-keystroke snapshot.
+    this.invalidateCachedSnapshot();
+    return await writePtyStdin({
+      providerName: PROVIDER_NAME,
+      registry: this.ptyProcesses,
+      sessionId: args.sessionId,
+      chars: args.chars,
+      yieldTimeMs: args.yieldTimeMs,
+      maxOutputTokens: args.maxOutputTokens,
+    });
+  }
+
+  protected override manifestMetadataSupport() {
+    return TENSORLAKE_MANIFEST_METADATA_SUPPORT;
+  }
+
+  protected override exposedPortSource(): string {
+    return 'host';
+  }
+
+  protected override allowOnDemandExposedPorts(): boolean {
+    return true;
+  }
+
+  protected override async resolveRemoteExposedPort(
+    requestedPort: number,
+  ): Promise<ExposedPortEndpoint> {
+    if (!this.exposedPortConfigured.has(requestedPort)) {
+      const desired = new Set(this.exposedPortConfigured);
+      desired.add(requestedPort);
+      await updateExposedPorts(this.sandbox, {
+        exposedPorts: Array.from(desired),
+        allowUnauthenticatedAccess: this.state.allowUnauthenticatedAccess,
+        fastOpSecs: this.resolvedTimeouts.fastOpSecs,
+        onDemandPort: requestedPort,
+      });
+      this.exposedPortConfigured.add(requestedPort);
+      this.state.configuredExposedPorts = Array.from(
+        this.exposedPortConfigured,
+      );
+    }
+
+    const resolvedHostname = await this.getProxyHostname();
+    if (resolvedHostname) {
+      return parseExposedPortEndpoint(
+        `https://${requestedPort}-${resolvedHostname}`,
+        { providerName: PROVIDER_NAME, source: 'host' },
+      );
+    }
+    const base = resolveProxyBase();
+    const fallbackHost = `${requestedPort}-${this.state.name ?? this.state.sandboxId}.${base.host}`;
+    return parseExposedPortEndpoint(`${base.protocol}//${fallbackHost}`, {
+      providerName: PROVIDER_NAME,
+      source: 'host',
+    });
+  }
+
+  private async getProxyHostname(): Promise<string | null> {
+    if (this.cachedProxyHostname !== undefined) return this.cachedProxyHostname;
+    const sandboxUrl = await this.fetchSandboxUrl();
+    const hostname = parseProxyHostname(sandboxUrl);
+    this.cachedProxyHostname = hostname;
+    if (
+      hostname === null &&
+      this.usesCustomControlPlane() &&
+      !this.hasWarnedAboutMissingSandboxUrl
+    ) {
+      this.hasWarnedAboutMissingSandboxUrl = true;
+      logger.warn(
+        'TensorlakeSandboxClient could not resolve a sandbox URL from sandbox.info(); ' +
+          "falling back to the public '<port>-<name>.sandbox.tensorlake.ai' template, " +
+          'which will not route correctly for this custom proxyUrl/apiUrl deployment.',
+      );
+    }
+    return hostname;
+  }
+
+  private usesCustomControlPlane(): boolean {
+    const t = this.trustedRecreateOptions;
+    return Boolean(t.proxyUrl || t.apiUrl || this.state.proxyUrl || this.state.apiUrl);
+  }
+
+  private async fetchSandboxUrl(): Promise<string | undefined> {
+    if (!this.sandbox.info) return undefined;
+    // Tensorlake's create-time info cache can omit sandbox_url; a status()
+    // round-trip forces the SDK to refresh before info() is read. Result is
+    // cached by the caller, so the extra round-trip happens at most once.
+    if (typeof this.sandbox.status === 'function') {
+      try {
+        await this.sandbox.status();
+      } catch {
+        return undefined;
+      }
+    }
+    return await readInfoSandboxUrl(this.sandbox);
+  }
+
+  protected override async execPtyCommand(
+    args: ExecCommandArgs,
+  ): Promise<string> {
+    if (args.runAs) {
+      throw new SandboxUnsupportedFeatureError(
+        `${PROVIDER_NAME} tty=true does not support runAs because the Tensorlake SDK PTY API does not expose a user option.`,
+        { provider: PROVIDER_ID, feature: 'tty.runAs' },
+      );
+    }
+    if (!this.sandbox.createPty) {
+      throw new SandboxUnsupportedFeatureError(
+        `${PROVIDER_NAME} tty=true requires Tensorlake SDK PTY support.`,
+        { provider: PROVIDER_ID, feature: 'tty' },
+      );
+    }
+
+    // An interactive shell can mutate the workspace at any point during its
+    // lifetime, so invalidate up front rather than trying to track per-keystroke.
+    this.invalidateCachedSnapshot();
+    const start = Date.now();
+    const command = shellCommandForPty(args);
+    const entry = createPtyProcessEntry({ tty: true });
+    const handle = await this.sandbox.createPty({
+      command: '/bin/bash',
+      args: ['-l'],
+      cols: 80,
+      rows: 24,
+      env: this.state.environment,
+      workingDir: this.resolveWorkdir(args.workdir),
+      onData: (data) => appendPtyOutput(entry, data),
+      onExit: (exitCode) => markPtyDone(entry, exitCode ?? null),
+    });
+    entry.sendInput = async (chars) => {
+      await handle.sendInput(chars);
+    };
+    entry.terminate = async () => {
+      try {
+        if (handle.kill) {
+          await handle.kill();
+        } else if (handle.disconnect) {
+          await handle.disconnect();
+        }
+      } catch {
+        // best-effort
+      }
+    };
+    if (handle.wait) {
+      watchPtyProcess(
+        entry,
+        async () => await handle.wait!(),
+        (result) => (typeof result === 'number' ? result : null),
+      );
+    }
+    try {
+      await entry.sendInput(`${command}\n`);
+    } catch (error) {
+      await entry.terminate?.().catch(() => {});
+      throw error;
+    }
+
+    const { sessionId, pruned } = this.ptyProcesses.register(entry);
+    if (pruned) {
+      await pruned.terminate?.().catch(() => {});
+    }
+
+    return await formatPtyExecUpdate({
+      registry: this.ptyProcesses,
+      sessionId,
+      entry,
+      startTime: start,
+      yieldTimeMs: args.yieldTimeMs,
+      maxOutputTokens: args.maxOutputTokens,
+    });
+  }
+
+  async prepareWorkspaceRoot(): Promise<void> {
+    if (this.state.workspaceRootProvisioned) return;
+    await this.mkdirRemote(this.state.manifest.root);
+    this.state.workspaceRootProvisioned = true;
+  }
+
+  // 'collapse' (default) skips user/group provisioning and ownership commands
+  // because the default Tensorlake image ships only tl-user and no root;
+  // chmod still runs. 'provision' opts into base-class behavior on custom
+  // images with root. Per-process exec `runAs` is independently supported via
+  // the SDK's `user:` option (see assertExecRunAs).
+  private collapseManifestIdentities(): boolean {
+    return (this.state.manifestIdentities ?? 'collapse') === 'collapse';
+  }
+
+  protected override manifestAccountsAlreadyProvisioned(): boolean {
+    return (
+      this.collapseManifestIdentities() ||
+      Boolean(this.state.systemSetupPreserved)
+    );
+  }
+
+  protected override shouldApplyManifestEntryOwnership(): boolean {
+    return !this.collapseManifestIdentities();
+  }
+
+  protected override async beforeApplyManifest(
+    manifest: Manifest,
+  ): Promise<void> {
+    if (!this.collapseManifestIdentities()) return;
+    const dropped: string[] = [];
+    if (manifest.users.length > 0) dropped.push(`${manifest.users.length} user(s)`);
+    if (manifest.groups.length > 0) dropped.push(`${manifest.groups.length} group(s)`);
+    const entriesWithGroup = Object.values(manifest.entries).filter(
+      (entry) => entry.group !== undefined,
+    ).length;
+    if (entriesWithGroup > 0) dropped.push(`${entriesWithGroup} entry ownership setting(s)`);
+    if (dropped.length === 0) return;
+    logger.warn(
+      `${PROVIDER_NAME} is collapsing manifest identities to the default 'tl-user' account because the base image does not expose root; dropping: ${dropped.join(', ')}. File modes (chmod) are still applied. Set manifestIdentities: 'provision' on a custom image with root to enable full provisioning.`,
+    );
+  }
+
+  // Mark the session as resuming from a backend image that already carries
+  // the workspace root and account database (reconnect or snapshot restore).
+  markPreservedFromSnapshot(): void {
+    this.state.workspaceRootProvisioned = true;
+    this.state.systemSetupPreserved = true;
+  }
+
+  // Any operation that may have mutated the workspace invalidates the cached
+  // snapshotId, because resume()'s fast-path would otherwise silently restore
+  // a pre-mutation checkpoint after the sandbox dies. Callers wanting partial
+  // recovery can still pass a stored archive to hydrateWorkspace() explicitly.
+  private invalidateCachedSnapshot(): void {
+    if (this.state.snapshotId !== undefined) {
+      this.state.snapshotId = undefined;
+    }
+  }
+
+  async persistWorkspace(): Promise<Uint8Array> {
+    if (this.state.workspacePersistence === 'snapshot') {
+      const archive = await this.persistWorkspaceViaNativeSnapshot();
+      if (archive) {
+        return archive;
+      }
+    } else {
+      assertTarWorkspacePersistence(
+        PROVIDER_NAME,
+        this.state.workspacePersistence,
+      );
+    }
+
+    return await this.persistWorkspaceTar();
+  }
+
+  async hydrateWorkspace(
+    data: WorkspaceArchiveData,
+    options: WorkspaceArchiveOptions = {},
+  ): Promise<void> {
+    const snapshotRef = decodeNativeSnapshotRef(data);
+    if (snapshotRef?.provider === 'tensorlake') {
+      await this.replaceSandboxFromSnapshot(snapshotRef.snapshotId);
+      return;
+    }
+    // Snapshot-mode sessions intentionally accept a tar archive here so a
+    // session created before snapshot mode was enabled can still be hydrated;
+    // the assertion only fires for unknown future persistence modes.
+    if (this.state.workspacePersistence !== 'snapshot') {
+      assertTarWorkspacePersistence(
+        PROVIDER_NAME,
+        this.state.workspacePersistence,
+      );
+    }
+    await this.hydrateWorkspaceTar(data, options);
+    // Workspace contents now diverge from any snapshot we still hold, so the
+    // cached snapshotId is no longer a valid resume target.
+    this.state.snapshotId = undefined;
+  }
+
+  private async persistWorkspaceViaNativeSnapshot(): Promise<
+    Uint8Array | undefined
+  > {
+    if (this.state.manifest.ephemeralPersistencePaths().size > 0) return undefined;
+    if (!this.sandbox.checkpoint) return undefined;
+
+    // waitUntil='local_ready' is sufficient for same-backend restore via
+    // Sandbox.create({ snapshotId }); use 'completed' only when a durable
+    // snapshot_uri is required (e.g. cross-host restore).
+    const checkpointOptions: TensorlakeCheckpointOptions = {
+      waitUntil: this.state.checkpointWaitUntil ?? 'local_ready',
+    };
+    if (this.state.snapshotCheckpointType) {
+      checkpointOptions.checkpointType = this.state.snapshotCheckpointType;
+    }
+    if (typeof this.state.checkpointTimeoutSecs === 'number') {
+      checkpointOptions.timeout = this.state.checkpointTimeoutSecs;
+    }
+    let snapshot: { snapshotId?: string };
+    try {
+      snapshot = await this.sandbox.checkpoint(checkpointOptions);
+    } catch (error) {
+      throw new SandboxProviderError(
+        `${PROVIDER_NAME} failed to capture a native workspace snapshot.`,
+        {
+          provider: PROVIDER_ID,
+          sandboxId: this.state.sandboxId,
+          cause: providerErrorMessage(error),
+        },
+      );
+    }
+    if (!snapshot.snapshotId) {
+      throw new SandboxProviderError(
+        `${PROVIDER_NAME} native snapshot persistence did not return a snapshot id.`,
+        { provider: PROVIDER_ID, sandboxId: this.state.sandboxId },
+      );
+    }
+    // Cache so resume() can fast-path via Sandbox.create({ snapshotId }).
+    this.state.snapshotId = snapshot.snapshotId;
+    return encodeNativeSnapshotRef({
+      provider: PROVIDER_ID,
+      snapshotId: snapshot.snapshotId,
+    });
+  }
+
+  private async replaceSandboxFromSnapshot(snapshotId: string): Promise<void> {
+    // Tensorlake names are unique per namespace; we can't create a new named
+    // sandbox while the previous is alive. When update() is available we
+    // create unnamed → terminate → rename (non-destructive on create failure).
+    // Without update() we must terminate first (destructive on create failure).
+    const previousSandbox = this.sandbox;
+    const desiredName = this.state.name;
+    const canRenameAfterCreate =
+      Boolean(desiredName) && typeof previousSandbox.update === 'function';
+    if (desiredName && !canRenameAfterCreate) {
+      await previousSandbox.terminate().catch(() => {});
+    }
+    const { sandbox, sandboxId: newSandboxId } =
+      await restoreSandboxFromSnapshot({
+        state: this.state,
+        snapshotId,
+        apiKey: this.trustedRecreateOptions.apiKey,
+        fastOpSecs: this.resolvedTimeouts.fastOpSecs,
+        omitName: canRenameAfterCreate,
+        wrapCreateErrorMessage: `${PROVIDER_NAME} failed to restore a native workspace snapshot.`,
+      });
+    try {
+      if (canRenameAfterCreate || !desiredName) {
+        await previousSandbox.terminate().catch(() => {});
+      }
+      const renameFailed = canRenameAfterCreate
+        ? await this.renameRestoredSandbox(sandbox, desiredName!)
+        : false;
+      this.adoptRestoredSandbox(sandbox, {
+        sandboxId: newSandboxId,
+        name: renameFailed ? undefined : (sandbox.name ?? desiredName),
+        snapshotId,
+      });
+    } catch (error) {
+      await sandbox.terminate().catch(() => {});
+      throw error;
+    }
+  }
+
+  /**
+   * Swap the live sandbox for a restored one and reset session state that is
+   * tied to the previous sandbox's identity (URL cache, exposed-port cache,
+   * cached snapshot id).
+   */
+  private adoptRestoredSandbox(
+    sandbox: TensorlakeSandboxInstance,
+    args: RestoredSandboxIdentity,
+  ): void {
+    this.sandbox = sandbox;
+    applyRestoredSandboxIdentity(this.state, args);
+    // Restored sandbox has a new sandbox_url.
+    this.cachedProxyHostname = undefined;
+    this.exposedPortConfigured.clear();
+    for (const port of this.state.configuredExposedPorts ?? []) {
+      this.exposedPortConfigured.add(port);
+    }
+  }
+
+  /**
+   * Issue the post-create rename for a restored sandbox. Returns `true` when
+   * the rename failed (caller treats the session as ephemeral and disables
+   * suspend/resume); `false` on success.
+   */
+  private async renameRestoredSandbox(
+    sandbox: TensorlakeSandboxInstance,
+    desiredName: string,
+  ): Promise<boolean> {
+    try {
+      await sandbox.update!({ name: desiredName });
+      return false;
+    } catch (renameError) {
+      // Previous sandbox is already gone, so we can't roll back to it. The
+      // new sandbox is functional but ephemeral — log loudly and disable
+      // suspendOnExit so the broken named lifecycle is visible rather than
+      // silently degrading on close().
+      this.state.suspendOnExit = false;
+      logger.error(
+        `${PROVIDER_NAME} could not rename the restored sandbox to '${desiredName}'; suspend/resume is unavailable for this session. ${providerErrorMessage(renameError)}`,
+      );
+      return true;
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.stopSession('sandbox.stop', true);
+  }
+
+  async shutdown(_options?: SandboxSessionLifecycleOptions): Promise<void> {
+    await withSandboxSpan(
+      'sandbox.shutdown',
+      { backend_id: PROVIDER_ID, sandbox_id: this.state.sandboxId },
+      async () => {
+        await this.ptyProcesses.terminateAll();
+      },
+    );
+  }
+
+  async delete(options?: SandboxSessionLifecycleOptions): Promise<void> {
+    await this.stopSession('sandbox.shutdown', this.shouldSuspend(options));
+  }
+
+  private async stopSession(span: string, suspend: boolean): Promise<void> {
+    await withSandboxSpan(
+      span,
+      { backend_id: PROVIDER_ID, sandbox_id: this.state.sandboxId },
+      async () => {
+        await this.ptyProcesses.terminateAll();
+        if (suspend && this.canSuspend()) {
+          await this.suspendOrTerminateAfterFailure();
+          return;
+        }
+        await this.sandbox.terminate();
+      },
+    );
+  }
+
+  private canSuspend(): boolean {
+    return (
+      this.state.suspendOnExit &&
+      Boolean(this.state.name) &&
+      typeof this.sandbox.suspend === 'function'
+    );
+  }
+
+  private shouldSuspend(options?: SandboxSessionLifecycleOptions): boolean {
+    return options?.reason === 'cleanup' && options.preserveOwnedSessions === true;
+  }
+
+  private async suspendOrTerminateAfterFailure(): Promise<void> {
+    try {
+      await this.sandbox.suspend!();
+    } catch (suspendError) {
+      try {
+        await this.sandbox.terminate();
+      } catch (terminateError) {
+        throw new SandboxProviderError(
+          `${PROVIDER_NAME} failed to suspend and then terminate the sandbox.`,
+          {
+            provider: PROVIDER_ID,
+            sandboxId: this.state.sandboxId,
+            suspendCause: providerErrorMessage(suspendError),
+            terminateCause: providerErrorMessage(terminateError),
+          },
+        );
+      }
+      this.state.suspendOnExit = false;
+    }
+  }
+
+  protected override async runRemoteCommand(
+    command: string,
+    options: RemoteSandboxCommandOptions,
+  ): Promise<RemoteSandboxCommandResult> {
+    // exec is opaque (could be a read or a write), so treat every command as
+    // potentially mutating and invalidate the cached snapshot pre-emptively.
+    this.invalidateCachedSnapshot();
+    let result: TensorlakeRunResult;
+    try {
+      // Pass `user` natively so we can skip the `sudo -u <name> --` wrap; the
+      // default Tensorlake image often lacks sudo, and the SDK already accepts
+      // a per-call user override.
+      result = await this.sandbox.run('/bin/bash', {
+        args: ['-lc', command],
+        env: this.state.environment,
+        workingDir: options.workdir,
+        timeout: this.commandTimeoutSecs(options),
+        ...(options.runAs ? { user: options.runAs } : {}),
+      });
+    } catch (error) {
+      // Preserve upstream HTTP status so the tar-persist retry can still
+      // see transient failures after we wrap into SandboxProviderError.
+      const status = extractHttpStatus(error);
+      throw new SandboxProviderError(`${PROVIDER_NAME} command execution failed.`, {
+        provider: PROVIDER_ID,
+        sandboxId: this.state.sandboxId,
+        command,
+        cause: providerErrorMessage(error),
+        ...(typeof status === 'number' ? { status } : {}),
+      });
+    }
+    return {
+      status: result.exitCode ?? 1,
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+    };
+  }
+
+  protected override async mkdirRemote(path: string): Promise<void> {
+    this.invalidateCachedSnapshot();
+    // Pass argv directly to avoid /bin/bash -lc quoting for unusual paths.
+    let result: TensorlakeRunResult;
+    try {
+      result = await this.sandbox.run('mkdir', {
+        args: ['-p', '--', path],
+        env: this.state.environment,
+        timeout: this.resolvedTimeouts.fastOpSecs,
+      });
+    } catch (error) {
+      throw new SandboxProviderError(`${PROVIDER_NAME} failed to create directory.`, {
+        provider: PROVIDER_ID,
+        path,
+        cause: providerErrorMessage(error),
+      });
+    }
+    if ((result.exitCode ?? 1) !== 0) {
+      throw new SandboxProviderError(`${PROVIDER_NAME} failed to create directory.`, {
+        provider: PROVIDER_ID,
+        path,
+        stderr: result.stderr ?? '',
+        stdout: result.stdout ?? '',
+      });
+    }
+  }
+
+  protected override async readRemoteText(path: string): Promise<string> {
+    return new TextDecoder().decode(await this.readRemoteFile(path));
+  }
+
+  protected override async readRemoteFile(path: string): Promise<Uint8Array> {
+    try {
+      const bytes = await this.sandbox.readFile(path);
+      return bytes instanceof Uint8Array
+        ? bytes
+        : Uint8Array.from(bytes as ArrayLike<number>);
+    } catch (error) {
+      throw new UserError(
+        `Sandbox path not found: ${path} (${providerErrorMessage(error)})`,
+      );
+    }
+  }
+
+  protected override async writeRemoteFile(
+    path: string,
+    content: string | Uint8Array,
+  ): Promise<void> {
+    this.invalidateCachedSnapshot();
+    const bytes =
+      typeof content === 'string' ? new TextEncoder().encode(content) : content;
+    await this.sandbox.writeFile(path, bytes);
+  }
+
+  protected override async deleteRemotePath(path: string): Promise<void> {
+    this.invalidateCachedSnapshot();
+    if (this.sandbox.deleteFile) {
+      try {
+        await withTimeout(
+          this.sandbox.deleteFile(path),
+          this.resolvedTimeouts.fastOpSecs * 1000,
+          `${PROVIDER_NAME} deleteFile(${path}) timed out`,
+        );
+        return;
+      } catch {
+        // Fall through to shell rm in case the path doesn't exist.
+      }
+    }
+    const result = await this.runRemoteCommand(`rm -rf -- ${shellQuote(path)}`, {
+      kind: 'manifest',
+      workdir: '/',
+    });
+    if (result.status !== 0) {
+      throw new SandboxProviderError(`${PROVIDER_NAME} failed to delete path.`, {
+        provider: PROVIDER_ID,
+        path,
+        stderr: result.stderr ?? '',
+        stdout: result.stdout ?? '',
+      });
+    }
+  }
+
+  // Tar uploads see frequent transient HTTP failures (typically 5xx during
+  // large-file streaming), so wrap the shared persist with a bounded retry.
+  protected override async persistWorkspaceTar(): Promise<Uint8Array> {
+    const baseIo = this.archiveIo();
+    const retriedIo: RemoteWorkspaceTarIo = {
+      ...baseIo,
+      runCommand: async (command) =>
+        await retryTransientHttp(async () => await baseIo.runCommand(command)),
+    };
+    const archive = await persistRemoteWorkspaceTar({
+      providerName: PROVIDER_NAME,
+      manifest: this.state.manifest,
+      io: retriedIo,
+    });
+    // A tar persist supersedes any prior native snapshot — clear the cached
+    // snapshotId so the resume fast-path doesn't restore stale state.
+    this.state.snapshotId = undefined;
+    return archive;
+  }
+
+  private commandTimeoutSecs(
+    options: RemoteSandboxCommandOptions,
+  ): number | undefined {
+    if (typeof options.timeoutMs === 'number') {
+      return Math.max(1, Math.ceil(options.timeoutMs / 1000));
+    }
+    switch (options.kind) {
+      case 'exec':
+        // Per-call commandTimeoutSecs wins; otherwise apply the 24h unbounded
+        // safety cap so a runaway command can't hold the sandbox indefinitely.
+        return (
+          this.state.commandTimeoutSecs ??
+          this.resolvedTimeouts.execTimeoutUnboundedSecs
+        );
+      case 'archive':
+        return this.resolvedTimeouts.snapshotTarSecs;
+      case 'manifest':
+      case 'path':
+      case 'running':
+        return this.resolvedTimeouts.fastOpSecs;
+    }
+  }
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return promise;
+  return new Promise<T>((resolve, reject) => {
+    const handle = setTimeout(
+      () => reject(new Error(`${message} after ${Math.round(timeoutMs)}ms`)),
+      timeoutMs,
+    );
+    promise.then(
+      (value) => { clearTimeout(handle); resolve(value); },
+      (error) => { clearTimeout(handle); reject(error); },
+    );
+  });
+}
+
+/**
+ * Tensorlake sandbox provider.
+ *
+ * @see {@link https://docs.tensorlake.ai/sandboxes/sdk-reference | Tensorlake SDK reference}
+ * @see {@link https://docs.tensorlake.ai/sandboxes/introduction | Sandboxes overview}
+ */
+export class TensorlakeSandboxClient implements SandboxClient<
+  TensorlakeSandboxClientOptions,
+  TensorlakeSandboxSessionState
+> {
+  readonly backendId = 'tensorlake';
+  private readonly options: TensorlakeSandboxClientOptions;
+
+  constructor(options: TensorlakeSandboxClientOptions = {}) {
+    this.options = options;
+  }
+
+  async create(
+    args?: SandboxClientCreateArgs<TensorlakeSandboxClientOptions> | Manifest,
+    manifestOptions?: TensorlakeSandboxClientOptions,
+  ): Promise<TensorlakeSandboxSession> {
+    const createArgs = normalizeSandboxClientCreateArgs(args, manifestOptions);
+    assertCoreSnapshotUnsupported(PROVIDER_NAME, createArgs.snapshot);
+    const manifest = resolveManifestRoot(createArgs.manifest);
+    return await withSandboxSpan(
+      'sandbox.start',
+      { backend_id: this.backendId },
+      async () => {
+        const merged: TensorlakeSandboxClientOptions = {
+          ...this.options,
+          ...createArgs.options,
+        };
+        // Auto-mint a name when suspendOnExit lacks one (suspend/resume is named-only).
+        const resolvedOptions: TensorlakeSandboxClientOptions = {
+          ...merged,
+          name: resolveLifecycleSandboxName({
+            name: merged.name,
+            suspendOnExit: merged.suspendOnExit ?? false,
+          }),
+        };
+        validateOptions(resolvedOptions);
+        const resolvedTimeouts = resolveTimeouts(resolvedOptions.timeouts);
+        assertSandboxManifestMetadataSupported(
+          PROVIDER_NAME,
+          manifest,
+          TENSORLAKE_MANIFEST_METADATA_SUPPORT,
+        );
+
+        const Sandbox = await loadTensorlakeSandboxClass();
+        const environment = await materializeEnvironment(
+          manifest,
+          resolvedOptions.env,
+        );
+        const lifecycleCfg = buildLifecycleConfig(
+          resolvedOptions,
+          environment,
+          resolvedOptions.apiKey,
+        );
+        const sandbox = await withProviderError(
+          PROVIDER_NAME,
+          PROVIDER_ID,
+          'create sandbox',
+          async () => await Sandbox.create(buildCreateKwargs(lifecycleCfg)),
+        );
+
+        const sandboxId = await resolveSandboxId(sandbox).catch(
+          async (error) => {
+            await sandbox.terminate().catch(() => {});
+            throw error;
+          },
+        );
+
+        try {
+          await applyPortConfiguration(
+            sandbox,
+            resolvedOptions,
+            resolvedTimeouts.fastOpSecs,
+          );
+        } catch (error) {
+          await sandbox.terminate().catch(() => {});
+          throw error;
+        }
+
+        const session = new TensorlakeSandboxSession({
+          sandbox,
+          concurrencyLimits: createArgs.concurrencyLimits,
+          archiveLimits: createArgs.archiveLimits,
+          trustedRecreateOptions: pickTrustedRecreateOptions(resolvedOptions),
+          state: buildSessionStateFromCreate({
+            manifest,
+            sandboxId,
+            sandboxName: sandbox.name ?? resolvedOptions.name,
+            environment,
+            options: resolvedOptions,
+          }),
+        });
+
+        try {
+          await session.prepareWorkspaceRoot();
+          await session.applyManifest(manifest);
+        } catch (error) {
+          session.state.suspendOnExit = false;
+          await closeRemoteSessionOnManifestError('Tensorlake', session, error);
+        }
+        return session;
+      },
+    );
+  }
+
+  async serializeSessionState(
+    state: TensorlakeSandboxSessionState,
+  ): Promise<Record<string, unknown>> {
+    return serializeRemoteSandboxSessionState(state);
+  }
+
+  canPersistOwnedSessionState(state: TensorlakeSandboxSessionState): boolean {
+    return state.suspendOnExit && Boolean(state.name);
+  }
+
+  async deserializeSessionState(
+    state: Record<string, unknown>,
+  ): Promise<TensorlakeSandboxSessionState> {
+    const out: Record<string, unknown> = {
+      ...state,
+      ...deserializeRemoteSandboxSessionStateValues(state, this.options.env),
+      sandboxId: readString(state, 'sandboxId'),
+      configuredExposedPorts: readOptionalNumberArray(state.configuredExposedPorts),
+      timeouts: readTimeouts(state.timeouts),
+      workspacePersistence: readWorkspacePersistence(state.workspacePersistence),
+      manifestIdentities: readManifestIdentities(state.manifestIdentities),
+      snapshotCheckpointType: readCheckpointType(state.snapshotCheckpointType),
+      checkpointWaitUntil: readCheckpointWaitUntil(state.checkpointWaitUntil),
+      suspendOnExit: Boolean(state.suspendOnExit),
+    };
+    for (const f of ['name', 'image', 'poolId', 'proxyUrl', 'apiUrl', 'namespace',
+      'organizationId', 'projectId', 'routingHint', 'snapshotId'] as const) {
+      out[f] = readOptionalString(state, f);
+    }
+    for (const f of ['cpus', 'memoryMb', 'diskMb', 'timeoutSecs', 'startupTimeout',
+      'commandTimeoutSecs', 'checkpointTimeoutSecs'] as const) {
+      out[f] = readOptionalNumber(state, f);
+    }
+    for (const f of ['allowInternetAccess', 'allowUnauthenticatedAccess',
+      'workspaceRootProvisioned', 'systemSetupPreserved'] as const) {
+      out[f] = readOptionalBoolean(state, f);
+    }
+    for (const f of ['secretNames', 'entrypoint', 'allowOut', 'denyOut'] as const) {
+      out[f] = readOptionalStringArray(state[f]);
+    }
+    return out as TensorlakeSandboxSessionState;
+  }
+
+  async resume(
+    state: TensorlakeSandboxSessionState,
+  ): Promise<TensorlakeSandboxSession> {
+    const Sandbox = await loadTensorlakeSandboxClass();
+    // Normalize state at the resume boundary so downstream code can trust it.
+    const trustedRecreateOptions = this.trustedRecreateOptions();
+    state = withTrustedRecreateOverrides(state, trustedRecreateOptions);
+    try {
+      // Sandbox.connect() doesn't contact the server, so probe status() first
+      // to convert a `terminated` sandbox into a synthetic 404 (the SDK's
+      // resume() would otherwise throw a non-404 that skips the fallback).
+      const connectCfg = lifecycleConfigFromState(state, trustedRecreateOptions.apiKey);
+      const sandbox = await Sandbox.connect(buildConnectKwargs(connectCfg, state.sandboxId));
+      await probeSandboxAlive(sandbox);
+      if (state.name && typeof sandbox.resume === 'function') {
+        await sandbox.resume();
+      }
+      const session = new TensorlakeSandboxSession({
+        state,
+        sandbox,
+        archiveLimits: this.options.archiveLimits,
+        trustedRecreateOptions,
+      });
+      session.markPreservedFromSnapshot();
+      return session;
+    } catch (error) {
+      assertResumeRecreateAllowed(error, {
+        providerName: PROVIDER_NAME,
+        provider: PROVIDER_ID,
+        details: { sandboxId: state.sandboxId, name: state.name },
+      });
+    }
+
+    // Snapshot fast-path: recreate via Sandbox.create({ snapshotId }) directly
+    // when the previous session cached one; falls through on missing snapshot.
+    if (
+      state.workspacePersistence === 'snapshot' &&
+      typeof state.snapshotId === 'string' &&
+      state.snapshotId.length > 0
+    ) {
+      const session = await this.recreateFromSnapshotId(state, state.snapshotId);
+      if (session) return session;
+    }
+
+    return await this.create(state.manifest, {
+      ...stateToCreateOptions(state, state.environment),
+      env: state.environment,
+    });
+  }
+
+  private async recreateFromSnapshotId(
+    state: TensorlakeSandboxSessionState,
+    snapshotId: string,
+  ): Promise<TensorlakeSandboxSession | null> {
+    const resolvedTimeouts = resolveTimeouts(state.timeouts);
+    let result;
+    try {
+      result = await restoreSandboxFromSnapshot({
+        state,
+        snapshotId,
+        apiKey: this.options.apiKey,
+        fastOpSecs: resolvedTimeouts.fastOpSecs,
+      });
+    } catch (error) {
+      // A missing/expired snapshot is recoverable: log and let the caller
+      // recreate from scratch. Any other failure (network, auth) must
+      // surface so the caller sees the real cause rather than a silent
+      // fresh sandbox.
+      try {
+        assertResumeRecreateAllowed(error, {
+          providerName: PROVIDER_NAME,
+          provider: PROVIDER_ID,
+          details: { snapshotId, sandboxId: state.sandboxId },
+        });
+      } catch {
+        throw error;
+      }
+      logger.warn(
+        `${PROVIDER_NAME} could not restore snapshot '${snapshotId}'; recreating sandbox from scratch.`,
+      );
+      return null;
+    }
+
+    const { sandbox, sandboxId } = result;
+    const nextState = { ...state };
+    applyRestoredSandboxIdentity(nextState, {
+      sandboxId,
+      name: sandbox.name ?? state.name,
+      snapshotId,
+    });
+    return new TensorlakeSandboxSession({
+      state: nextState,
+      sandbox,
+      archiveLimits: this.options.archiveLimits,
+      trustedRecreateOptions: this.trustedRecreateOptions(),
+    });
+  }
+
+  private trustedRecreateOptions(): TensorlakeTrustedRecreateOptions {
+    return pickTrustedRecreateOptions(this.options);
+  }
+}
+
+type RestoredSandboxIdentity = {
+  sandboxId: string;
+  name: string | undefined;
+  snapshotId: string;
+};
+
+// Mutate state for a snapshot-restored replacement sandbox: swap identity,
+// cache new snapshotId, mark workspace/accounts preserved, drop cached ports.
+function applyRestoredSandboxIdentity(
+  state: TensorlakeSandboxSessionState,
+  args: RestoredSandboxIdentity,
+): void {
+  state.sandboxId = args.sandboxId;
+  state.name = args.name;
+  state.snapshotId = args.snapshotId;
+  state.workspaceRootProvisioned = true;
+  state.systemSetupPreserved = true;
+  delete state.exposedPorts;
+}
+
+async function readInfoSandboxUrl(
+  sandbox: TensorlakeSandboxInstance,
+): Promise<string | undefined> {
+  if (!sandbox.info) return undefined;
+  try {
+    const info = await sandbox.info();
+    return info?.sandboxUrl ?? info?.sandbox_url;
+  } catch {
+    return undefined;
+  }
+}
+
+// Forces a backend round-trip so a stale/deleted sandbox surfaces inside
+// resume()'s try block. Prefers status() — it always hits the API — and
+// falls back to info() when the SDK only exposes the latter. The Tensorlake
+// SDK returns a SandboxStatus enum (running/terminated/...) rather than
+// throwing for a terminated sandbox, so the dead-state check must inspect
+// the returned value and raise an error tagged with `code: 'not_found'`,
+// which isProviderSandboxNotFoundError recognizes as a recreate signal.
+async function probeSandboxAlive(
+  sandbox: TensorlakeSandboxInstance,
+): Promise<void> {
+  let raw: unknown;
+  if (typeof sandbox.status === 'function') {
+    raw = await sandbox.status();
+  } else if (typeof sandbox.info === 'function') {
+    const info = await sandbox.info();
+    raw = isRecord(info) ? (info as Record<string, unknown>).status : undefined;
+  } else {
+    return;
+  }
+  const status = extractStatusString(raw);
+  if (status && status.toLowerCase() === 'terminated') {
+    throw Object.assign(new Error('sandbox terminated'), { code: 'not_found' });
+  }
+}
+
+function extractStatusString(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (!isRecord(value)) return undefined;
+  if (typeof value.value === 'string') return value.value;
+  if (typeof value.status === 'string') return value.status;
+  return undefined;
+}
+
+function parseProxyHostname(sandboxUrl: string | undefined): string | null {
+  if (!sandboxUrl) return null;
+  try {
+    const parsed = new URL(sandboxUrl);
+    if (!parsed.hostname || LOOPBACK_HOSTNAMES.has(parsed.hostname))
+      return null;
+    return parsed.hostname;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveSandboxId(
+  sandbox: TensorlakeSandboxInstance,
+): Promise<string> {
+  // After Sandbox.create({ snapshotId }) the sandboxId property may not be
+  // populated until info() seeds the SDK's internal cache.
+  if (typeof sandbox.sandboxId === 'string' && sandbox.sandboxId.length > 0) {
+    return sandbox.sandboxId;
+  }
+  if (sandbox.info) {
+    try {
+      const info = await sandbox.info();
+      const id = info?.sandboxId ?? info?.sandbox_id;
+      if (typeof id === 'string' && id.length > 0) return id;
+    } catch {
+      // fall through to error
+    }
+  }
+  throw new SandboxProviderError(
+    'TensorlakeSandboxClient could not resolve a sandbox id after create.',
+    { provider: PROVIDER_ID },
+  );
+}
+
+function resolveManifestRoot(manifest: Manifest): Manifest {
+  if (manifest.root === '/workspace') {
+    return cloneManifestWithRoot(manifest, DEFAULT_TENSORLAKE_WORKSPACE_ROOT);
+  }
+  return manifest;
+}
+
+function validateOptions(options: TensorlakeSandboxClientOptions): void {
+  readWorkspacePersistence(options.workspacePersistence);
+  readManifestIdentities(options.manifestIdentities);
+  readCheckpointType(options.snapshotCheckpointType);
+  readCheckpointWaitUntil(options.checkpointWaitUntil);
+  for (const field of [
+    'cpus',
+    'memoryMb',
+    'diskMb',
+    'startupTimeout',
+    'commandTimeoutSecs',
+    'checkpointTimeoutSecs',
+  ] as const) {
+    assertPositive(field, options[field]);
+  }
+  resolveTimeouts(options.timeouts);
+
+  // `timeoutSecs` is an idle threshold on sandbox-proxy traffic, not a
+  // wall-clock lifetime. `sandbox.checkpoint()` polling goes through the
+  // control-plane client (no proxied traffic), so if the idle threshold is
+  // smaller than the checkpoint poll budget the sandbox can idle-time out
+  // mid-poll and orphan the snapshot. `timeoutSecs === 0` requests the plan
+  // maximum and is exempt alongside undefined.
+  if (
+    options.workspacePersistence === 'snapshot' &&
+    typeof options.timeoutSecs === 'number' &&
+    options.timeoutSecs > 0
+  ) {
+    const explicitBudget = typeof options.checkpointTimeoutSecs === 'number';
+    const budget = explicitBudget
+      ? options.checkpointTimeoutSecs!
+      : TENSORLAKE_SDK_DEFAULT_CHECKPOINT_TIMEOUT_SECS;
+    if (options.timeoutSecs <= budget) {
+      const source = explicitBudget
+        ? `checkpointTimeoutSecs=${budget}`
+        : `the Tensorlake SDK default checkpoint timeout (${budget}s)`;
+      throw new UserError(
+        `${PROVIDER_NAME} timeoutSecs must be strictly greater than the effective checkpoint poll budget when workspacePersistence='snapshot'; otherwise the sandbox can be auto-terminated during checkpoint polling, orphaning the snapshot. Got timeoutSecs=${options.timeoutSecs}, ${source}.`,
+      );
+    }
+  }
+}
+
+function assertPositive(name: string, value: number | undefined): void {
+  if (value === undefined) return;
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new UserError(`${PROVIDER_NAME} ${name} must be positive.`);
+  }
+}
+
+function readTimeouts(value: unknown): TensorlakeSandboxTimeouts | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!isRecord(value)) {
+    throw new UserError(`${PROVIDER_NAME} timeouts must be an object of positive numbers.`);
+  }
+  const result: TensorlakeSandboxTimeouts = {};
+  for (const key of TIMEOUT_KEYS) {
+    const raw = value[key];
+    if (raw === undefined || raw === null) continue;
+    if (typeof raw !== 'number') {
+      throw new UserError(`${PROVIDER_NAME} timeouts.${key} must be a positive finite number.`);
+    }
+    result[key] = raw;
+  }
+  if (Object.keys(result).length === 0) return undefined;
+  resolveTimeouts(result); // delegates positivity validation
+  return result;
+}
+
+function resolveLifecycleSandboxName(args: {
+  name: string | undefined;
+  suspendOnExit: boolean;
+}): string | undefined {
+  const trimmed = args.name?.trim();
+  if (trimmed) return trimmed;
+  if (!args.suspendOnExit) return undefined;
+  return `${GENERATED_TENSORLAKE_NAME_PREFIX}${randomUUID().replace(/-/g, '')}`;
+}
+
+const TRUSTED_RECREATE_KEYS = [
+  'apiKey',
+  'proxyUrl',
+  'apiUrl',
+  'namespace',
+  'organizationId',
+  'projectId',
+  'routingHint',
+  'image',
+  'entrypoint',
+  'secretNames',
+  'allowInternetAccess',
+  'allowOut',
+  'denyOut',
+  'exposedPorts',
+  'allowUnauthenticatedAccess',
+] as const satisfies readonly (keyof TensorlakeTrustedRecreateOptions)[];
+
+function pickTrustedRecreateOptions(
+  options: TensorlakeSandboxClientOptions,
+): TensorlakeTrustedRecreateOptions {
+  const picked: Record<string, unknown> = {};
+  for (const key of TRUSTED_RECREATE_KEYS) {
+    if (options[key] !== undefined) picked[key] = options[key];
+  }
+  return picked as TensorlakeTrustedRecreateOptions;
+}
+
+// Single security boundary for deserialized session state: fold trusted
+// in-process options over sensitive fields once at the resume() entry so
+// downstream code can read `state` as authoritative.
+function withTrustedRecreateOverrides(
+  state: TensorlakeSandboxSessionState,
+  trusted: TensorlakeTrustedRecreateOptions,
+): TensorlakeSandboxSessionState {
+  // Keys match state 1:1 except `exposedPorts` → `configuredExposedPorts`.
+  const next = { ...state };
+  for (const key of TRUSTED_RECREATE_KEYS) {
+    if (key === 'apiKey' || key === 'exposedPorts') continue;
+    const value = trusted[key];
+    if (value !== undefined) (next as Record<string, unknown>)[key] = value;
+  }
+  if (trusted.exposedPorts !== undefined) {
+    next.configuredExposedPorts = trusted.exposedPorts;
+  }
+  return next;
+}
+
+// Normalized lifecycle config shared by Sandbox.create and Sandbox.connect.
+type TensorlakeLifecycleConfig = Pick<
+  TensorlakeSandboxClientOptions,
+  | 'image' | 'cpus' | 'memoryMb' | 'diskMb' | 'timeoutSecs' | 'name'
+  | 'startupTimeout' | 'proxyUrl' | 'apiUrl' | 'namespace' | 'organizationId'
+  | 'projectId' | 'routingHint' | 'secretNames' | 'allowOut' | 'denyOut'
+  | 'entrypoint' | 'apiKey' | 'poolId'
+> & {
+  allowInternetAccess: boolean;
+  env: Record<string, string>;
+};
+
+// Building blocks. routingHint is connect-only; poolId/apiKey/env are inlined
+// in buildCreateKwargs because of mutex/empty semantics.
+const SANDBOX_CONFIG_SCALAR_FIELDS = [
+  'image', 'cpus', 'memoryMb', 'diskMb', 'timeoutSecs', 'name', 'startupTimeout',
+] as const satisfies readonly (keyof TensorlakeLifecycleConfig)[];
+const CONTROL_PLANE_SCALAR_FIELDS = [
+  'proxyUrl', 'apiUrl', 'namespace', 'organizationId', 'projectId',
+] as const satisfies readonly (keyof TensorlakeLifecycleConfig)[];
+const LIFECYCLE_LIST_FIELDS = [
+  'secretNames', 'allowOut', 'denyOut', 'entrypoint',
+] as const satisfies readonly (keyof TensorlakeLifecycleConfig)[];
+const CREATE_SCALAR_FIELDS = [...SANDBOX_CONFIG_SCALAR_FIELDS, ...CONTROL_PLANE_SCALAR_FIELDS] as const;
+const CREATE_LIST_FIELDS = LIFECYCLE_LIST_FIELDS;
+const CONNECT_FIELDS = [
+  ...CONTROL_PLANE_SCALAR_FIELDS, 'routingHint',
+] as const satisfies readonly (keyof TensorlakeLifecycleConfig)[];
+
+// Memory snapshots restore image/resources/entrypoint/secrets from the
+// snapshot; passing them at restore is rejected by the backend.
+// See https://docs.tensorlake.ai/sandboxes/snapshots.
+const MEMORY_SNAPSHOT_RESTORE_EXCLUDED_SCALARS: ReadonlySet<string> = new Set([
+  'image', 'cpus', 'memoryMb', 'diskMb',
+]);
+const MEMORY_SNAPSHOT_RESTORE_EXCLUDED_LISTS: ReadonlySet<string> = new Set([
+  'entrypoint', 'secretNames',
+]);
+
+// Fields shared by options/state/lifecycle config.
+const LIFECYCLE_COMMON_FIELDS = [
+  ...SANDBOX_CONFIG_SCALAR_FIELDS, ...CONTROL_PLANE_SCALAR_FIELDS,
+  'routingHint', ...LIFECYCLE_LIST_FIELDS, 'poolId',
+] as const satisfies readonly (keyof TensorlakeLifecycleConfig)[];
+
+type LifecycleCommonField = (typeof LIFECYCLE_COMMON_FIELDS)[number];
+
+type LifecycleSource = {
+  [K in LifecycleCommonField]?: TensorlakeLifecycleConfig[K];
+} & { allowInternetAccess?: boolean };
+
+function buildLifecycleConfig(
+  source: LifecycleSource,
+  env: Record<string, string>,
+  apiKey: string | undefined,
+): TensorlakeLifecycleConfig {
+  const cfg: TensorlakeLifecycleConfig = {
+    allowInternetAccess: source.allowInternetAccess ?? true,
+    env,
+  };
+  for (const field of LIFECYCLE_COMMON_FIELDS) {
+    const value = source[field];
+    if (value !== undefined) {
+      (cfg as Record<string, unknown>)[field] = value;
+    }
+  }
+  if (apiKey !== undefined) cfg.apiKey = apiKey;
+  return cfg;
+}
+
+// Callers passing state must ensure trusted overrides are already applied
+// (see withTrustedRecreateOverrides). apiKey is passed separately because it
+// is intentionally never carried on persisted state.
+function lifecycleConfigFromState(
+  state: TensorlakeSandboxSessionState,
+  apiKey?: string,
+): TensorlakeLifecycleConfig {
+  return buildLifecycleConfig(state, state.environment, apiKey);
+}
+
+// Derive Sandbox.create(...) kwargs from a lifecycle config. Only includes
+// optional fields when set so the SDK can apply its own defaults.
+function buildCreateKwargs(
+  cfg: TensorlakeLifecycleConfig,
+  opts: { snapshotId?: string; memorySnapshot?: boolean } = {},
+): Record<string, unknown> {
+  // Memory-snapshot restores reject image/resources/entrypoint/secrets.
+  const skip = opts.snapshotId && opts.memorySnapshot;
+  const skipScalar = (name: string) =>
+    !!skip && MEMORY_SNAPSHOT_RESTORE_EXCLUDED_SCALARS.has(name);
+  const skipList = (name: string) =>
+    !!skip && MEMORY_SNAPSHOT_RESTORE_EXCLUDED_LISTS.has(name);
+  const kwargs: Record<string, unknown> = {
+    allowInternetAccess: cfg.allowInternetAccess,
+  };
+  for (const name of CREATE_SCALAR_FIELDS) {
+    const value = cfg[name];
+    if (skipScalar(name) || value === undefined || value === null || value === '') continue;
+    kwargs[name] = value;
+  }
+  for (const name of CREATE_LIST_FIELDS) {
+    const value = cfg[name];
+    if (skipList(name) || !Array.isArray(value) || value.length === 0) continue;
+    kwargs[name] = value;
+  }
+  // Sandbox.create() treats snapshotId and poolId as mutually exclusive: when
+  // both are set it claims from the pool and silently ignores snapshotId.
+  if (opts.snapshotId) {
+    kwargs.snapshotId = opts.snapshotId;
+    if (cfg.poolId) {
+      logger.warn(
+        `${PROVIDER_NAME}: ignoring poolId='${cfg.poolId}' because a snapshotId is set; snapshot restore takes precedence.`,
+      );
+    }
+  } else if (cfg.poolId) {
+    kwargs.poolId = cfg.poolId;
+  }
+  if (cfg.apiKey) kwargs.apiKey = cfg.apiKey;
+  if (Object.keys(cfg.env).length > 0) kwargs.env = cfg.env;
+  return kwargs;
+}
+
+function buildConnectKwargs(
+  cfg: TensorlakeLifecycleConfig,
+  sandboxId: string,
+): { sandboxId: string } & Record<string, unknown> {
+  const kwargs: { sandboxId: string } & Record<string, unknown> = { sandboxId };
+  if (cfg.apiKey) kwargs.apiKey = cfg.apiKey;
+  for (const name of CONNECT_FIELDS) {
+    const value = cfg[name];
+    if (value !== undefined && value !== null && value !== '') {
+      kwargs[name] = value;
+    }
+  }
+  return kwargs;
+}
+
+// Shared scaffolding for `Sandbox.create({ snapshotId })` used by resume's
+// fast-path and in-place hydrate. Errors from create() propagate raw so
+// callers can inspect status/code (e.g. for the snapshot-missing fallback),
+// unless `wrapCreateErrorMessage` is set, in which case they're wrapped.
+async function restoreSandboxFromSnapshot(args: {
+  state: TensorlakeSandboxSessionState;
+  snapshotId: string;
+  apiKey: string | undefined;
+  fastOpSecs: number;
+  /** When true, omit `name` from create so a later `update({name})` runs. */
+  omitName?: boolean;
+  /** When set, wrap create() failures into a SandboxProviderError with this message. */
+  wrapCreateErrorMessage?: string;
+}): Promise<{ sandbox: TensorlakeSandboxInstance; sandboxId: string }> {
+  const Sandbox = await loadTensorlakeSandboxClass();
+  const cfg = lifecycleConfigFromState(args.state, args.apiKey);
+  const createCfg = args.omitName ? { ...cfg, name: undefined } : cfg;
+  const createOptions = buildCreateKwargs(createCfg, {
+    snapshotId: args.snapshotId,
+    memorySnapshot: args.state.snapshotCheckpointType === 'memory',
+  });
+
+  let sandbox: TensorlakeSandboxInstance;
+  try {
+    sandbox = await Sandbox.create(createOptions);
+  } catch (error) {
+    if (!args.wrapCreateErrorMessage) throw error;
+    throw new SandboxProviderError(args.wrapCreateErrorMessage, {
+      provider: PROVIDER_ID,
+      snapshotId: args.snapshotId,
+      cause: providerErrorMessage(error),
+    });
+  }
+
+  // Tensorlake does not expose ports via Sandbox.create(); restored sandboxes
+  // start with no proxy routes. resolveSandboxId() must run first because it
+  // seeds the SDK's info() cache that applyPortConfiguration relies on for
+  // snapshot-restored sandboxes — so these run in order, not in parallel.
+  try {
+    const sandboxId = await resolveSandboxId(sandbox);
+    await applyPortConfiguration(
+      sandbox,
+      {
+        exposedPorts: args.state.configuredExposedPorts,
+        allowUnauthenticatedAccess: args.state.allowUnauthenticatedAccess,
+      },
+      args.fastOpSecs,
+    );
+    return { sandbox, sandboxId };
+  } catch (error) {
+    await sandbox.terminate().catch(() => {});
+    throw error;
+  }
+}
+
+async function applyPortConfiguration(
+  sandbox: TensorlakeSandboxInstance,
+  options: Pick<
+    TensorlakeSandboxClientOptions,
+    'exposedPorts' | 'allowUnauthenticatedAccess'
+  >,
+  fastOpSecs: number,
+): Promise<void> {
+  const hasExposedPorts = (options.exposedPorts?.length ?? 0) > 0;
+  const hasAccessOverride =
+    typeof options.allowUnauthenticatedAccess === 'boolean';
+  if (!hasExposedPorts && !hasAccessOverride) return;
+  await updateExposedPorts(sandbox, {
+    exposedPorts: hasExposedPorts ? options.exposedPorts : undefined,
+    allowUnauthenticatedAccess: options.allowUnauthenticatedAccess,
+    fastOpSecs,
+  });
+}
+
+// Single entry point for sandbox.update() calls that change exposed ports or
+// allowUnauthenticatedAccess. Handles support check, timeout, and error map.
+async function updateExposedPorts(
+  sandbox: TensorlakeSandboxInstance,
+  args: {
+    exposedPorts?: number[];
+    allowUnauthenticatedAccess?: boolean;
+    fastOpSecs: number;
+    /** Set when invoked from on-demand `resolveRemoteExposedPort`. */
+    onDemandPort?: number;
+  },
+): Promise<void> {
+  const onDemand = args.onDemandPort !== undefined;
+  const purpose = onDemand ? 'exposed ports' : 'initial exposed ports';
+  if (!sandbox.update) {
+    throw new SandboxUnsupportedFeatureError(
+      `${PROVIDER_NAME} sandbox.update is required to ${onDemand ? 'expose ports on demand' : 'configure exposed ports'}.`,
+      {
+        provider: PROVIDER_ID,
+        feature: 'exposedPorts',
+        ...(onDemand ? { port: args.onDemandPort } : {}),
+      },
+    );
+  }
+  const payload: TensorlakeUpdateOptions = {};
+  if (args.exposedPorts !== undefined) payload.exposedPorts = args.exposedPorts;
+  if (typeof args.allowUnauthenticatedAccess === 'boolean') {
+    payload.allowUnauthenticatedAccess = args.allowUnauthenticatedAccess;
+  }
+  try {
+    await withTimeout(
+      sandbox.update(payload),
+      args.fastOpSecs * 1000,
+      `${PROVIDER_NAME} update() (${purpose}) timed out`,
+    );
+  } catch (error) {
+    throw new SandboxProviderError(
+      onDemand
+        ? `${PROVIDER_NAME} failed to expose port ${args.onDemandPort}.`
+        : `${PROVIDER_NAME} failed to configure exposed ports.`,
+      {
+        provider: PROVIDER_ID,
+        cause: providerErrorMessage(error),
+        ...(onDemand ? { port: args.onDemandPort } : {}),
+        ...(sandbox.sandboxId ? { sandboxId: sandbox.sandboxId } : {}),
+      },
+    );
+  }
+}
+
+// Fields shared 1:1 between options and state. `name`, `suspendOnExit`, and
+// the renamed pairs (configuredExposedPorts/exposedPorts, environment/env)
+// are handled inline by buildSessionStateFromCreate and stateToCreateOptions.
+const OPTION_STATE_COMMON_FIELDS = [
+  'image',
+  'cpus',
+  'memoryMb',
+  'diskMb',
+  'timeoutSecs',
+  'startupTimeout',
+  'secretNames',
+  'entrypoint',
+  'allowInternetAccess',
+  'allowOut',
+  'denyOut',
+  'allowUnauthenticatedAccess',
+  'commandTimeoutSecs',
+  'timeouts',
+  'poolId',
+  'proxyUrl',
+  'apiUrl',
+  'namespace',
+  'organizationId',
+  'projectId',
+  'routingHint',
+  'workspacePersistence',
+  'manifestIdentities',
+  'snapshotCheckpointType',
+  'checkpointTimeoutSecs',
+  'checkpointWaitUntil',
+] as const satisfies readonly (keyof TensorlakeSandboxClientOptions &
+  keyof TensorlakeSandboxSessionState)[];
+
+function buildSessionStateFromCreate(args: {
+  manifest: Manifest;
+  sandboxId: string;
+  sandboxName: string | undefined;
+  environment: Record<string, string>;
+  options: TensorlakeSandboxClientOptions;
+}): TensorlakeSandboxSessionState {
+  const state: TensorlakeSandboxSessionState = {
+    manifest: args.manifest,
+    sandboxId: args.sandboxId,
+    name: args.sandboxName,
+    environment: args.environment,
+    configuredExposedPorts: args.options.exposedPorts,
+    suspendOnExit: args.options.suspendOnExit ?? false,
+  };
+  for (const field of OPTION_STATE_COMMON_FIELDS) {
+    (state as Record<string, unknown>)[field] = args.options[field];
+  }
+  return state;
+}
+
+// Callers must pass state with trusted overrides already applied.
+function stateToCreateOptions(
+  state: TensorlakeSandboxSessionState,
+  environment: Record<string, string>,
+): TensorlakeSandboxClientOptions {
+  const options: TensorlakeSandboxClientOptions = {
+    exposedPorts: state.configuredExposedPorts,
+    env: environment,
+    suspendOnExit: state.suspendOnExit,
+  };
+  if (state.name !== undefined) options.name = state.name;
+  for (const field of OPTION_STATE_COMMON_FIELDS) {
+    const value = state[field];
+    if (value !== undefined) (options as Record<string, unknown>)[field] = value;
+  }
+  return options;
+}
+
+function parseEnum<T extends string | boolean>(
+  feature: string,
+  value: unknown,
+  allowed: readonly T[],
+): T | undefined {
+  if (value === undefined) return undefined;
+  if ((allowed as readonly unknown[]).includes(value)) return value as T;
+  const tokens = allowed.map((v) => (typeof v === 'string' ? `"${v}"` : String(v)));
+  const display =
+    tokens.length <= 2
+      ? tokens.join(' or ')
+      : `${tokens.slice(0, -1).join(', ')}, or ${tokens[tokens.length - 1]}`;
+  throw new SandboxUnsupportedFeatureError(
+    `${PROVIDER_NAME} ${feature} must be ${display}.`,
+    { provider: PROVIDER_ID, feature, [feature]: value },
+  );
+}
+
+const readManifestIdentities = (v: unknown) =>
+  parseEnum<TensorlakeManifestIdentitiesMode>('manifestIdentities', v, [
+    'collapse',
+    'provision',
+  ]);
+const readWorkspacePersistence = (v: unknown) =>
+  parseEnum<TensorlakeWorkspacePersistence>('workspacePersistence', v, [
+    true,
+    'tar',
+    'snapshot',
+  ]);
+const readCheckpointType = (v: unknown) =>
+  parseEnum<TensorlakeCheckpointType>('snapshotCheckpointType', v, [
+    'memory',
+    'filesystem',
+  ]);
+const readCheckpointWaitUntil = (v: unknown) =>
+  parseEnum<TensorlakeCheckpointWaitUntil>('checkpointWaitUntil', v, [
+    'local_ready',
+    'completed',
+  ]);
+
+async function loadTensorlakeSandboxClass(): Promise<TensorlakeSandboxClass> {
+  try {
+    const mod = (await import('tensorlake')) as Record<string, unknown>;
+    const Sandbox = mod.Sandbox as TensorlakeSandboxClass | undefined;
+    if (
+      !Sandbox ||
+      typeof Sandbox.create !== 'function' ||
+      typeof Sandbox.connect !== 'function'
+    ) {
+      throw new Error('Missing Sandbox export from tensorlake.');
+    }
+    return Sandbox;
+  } catch (error) {
+    throw new UserError(
+      `Tensorlake sandbox support requires the optional \`tensorlake\` package. Install it before using Tensorlake-backed sandbox examples. ${(error as Error).message}`,
+    );
+  }
+}

--- a/packages/agents-extensions/src/sandbox/tensorlake/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/tensorlake/sandbox.ts
@@ -69,19 +69,49 @@ const logger = getLogger('openai-agents:sandbox:tensorlake');
 export const DEFAULT_TENSORLAKE_WORKSPACE_ROOT = '/home/tl-user/workspace';
 
 const TENSORLAKE_DEFAULT_PROXY_URL = 'https://sandbox.tensorlake.ai';
+const TENSORLAKE_LOCALHOST_PROXY_URL = 'http://localhost:9443';
 
-function resolveProxyBase(): { protocol: string; host: string } {
-  const explicit = process.env.TENSORLAKE_SANDBOX_PROXY_URL;
+// Mirrors the Tensorlake SDK's resolveProxyUrl() so exposed-port fallback links
+// target the same proxy the SDK actually routes through when sandbox.info()
+// yields no usable sandbox_url. Precedence: an explicit (trusted) proxyUrl wins,
+// then TENSORLAKE_SANDBOX_PROXY_URL, then a host derived from a custom apiUrl
+// (localhost → :9443, api.X → sandbox.X), then the public default. Without this,
+// a self-hosted deployment created with a custom proxyUrl/apiUrl would emit a
+// public *.sandbox.tensorlake.ai link that does not route.
+function resolveProxyBase(overrides?: { proxyUrl?: string; apiUrl?: string }): {
+  protocol: string;
+  host: string;
+} {
+  const fromUrl = (raw: string) => {
+    const parsed = new URL(raw);
+    return { protocol: parsed.protocol, host: parsed.host };
+  };
+  const explicit =
+    overrides?.proxyUrl ?? process.env.TENSORLAKE_SANDBOX_PROXY_URL;
   if (explicit) {
     try {
-      const parsed = new URL(explicit);
-      return { protocol: parsed.protocol, host: parsed.host };
+      return fromUrl(explicit);
     } catch {
-      // Fall through to the trusted default.
+      // Fall through to apiUrl-derived / default base.
     }
   }
-  const parsed = new URL(TENSORLAKE_DEFAULT_PROXY_URL);
-  return { protocol: parsed.protocol, host: parsed.host };
+  if (overrides?.apiUrl) {
+    try {
+      const parsed = new URL(overrides.apiUrl);
+      if (LOOPBACK_HOSTNAMES.has(parsed.hostname)) {
+        return fromUrl(TENSORLAKE_LOCALHOST_PROXY_URL);
+      }
+      if (parsed.hostname.startsWith('api.')) {
+        return {
+          protocol: parsed.protocol,
+          host: `sandbox.${parsed.hostname.slice(4)}`,
+        };
+      }
+    } catch {
+      // Fall through to the public default.
+    }
+  }
+  return fromUrl(TENSORLAKE_DEFAULT_PROXY_URL);
 }
 
 type TensorlakeRunOptions = {
@@ -524,7 +554,10 @@ export class TensorlakeSandboxSession extends RemoteSandboxSessionBase<Tensorlak
         { providerName: PROVIDER_NAME, source: 'host' },
       );
     }
-    const base = resolveProxyBase();
+    const base = resolveProxyBase({
+      proxyUrl: this.trustedRecreateOptions.proxyUrl ?? this.state.proxyUrl,
+      apiUrl: this.trustedRecreateOptions.apiUrl ?? this.state.apiUrl,
+    });
     const fallbackHost = `${requestedPort}-${this.state.name ?? this.state.sandboxId}.${base.host}`;
     return parseExposedPortEndpoint(`${base.protocol}//${fallbackHost}`, {
       providerName: PROVIDER_NAME,
@@ -545,8 +578,9 @@ export class TensorlakeSandboxSession extends RemoteSandboxSessionBase<Tensorlak
       this.hasWarnedAboutMissingSandboxUrl = true;
       logger.warn(
         'TensorlakeSandboxClient could not resolve a sandbox URL from sandbox.info(); ' +
-          "falling back to the public '<port>-<name>.sandbox.tensorlake.ai' template, " +
-          'which will not route correctly for this custom proxyUrl/apiUrl deployment.',
+          "falling back to the '<port>-<name>.<proxy-host>' template using the configured " +
+          'proxyUrl/apiUrl. Exposed-port links may not route if this custom deployment does ' +
+          'not use subdomain-based proxy routing.',
       );
     }
     return hostname;

--- a/packages/agents-extensions/src/sandbox/tensorlake/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/tensorlake/sandbox.ts
@@ -151,7 +151,10 @@ type TensorlakeSandboxInfo = {
 type TensorlakeSandboxInstance = {
   sandboxId: string;
   name?: string | null;
-  run(command: string, options?: TensorlakeRunOptions): Promise<TensorlakeRunResult>;
+  run(
+    command: string,
+    options?: TensorlakeRunOptions,
+  ): Promise<TensorlakeRunResult>;
   writeFile(path: string, content: string | Uint8Array): Promise<void>;
   readFile(path: string): Promise<Uint8Array>;
   deleteFile?(path: string): Promise<void>;
@@ -163,7 +166,9 @@ type TensorlakeSandboxInstance = {
   terminate(): Promise<unknown>;
   info?(): Promise<TensorlakeSandboxInfo | undefined>;
   status?(): Promise<unknown>;
-  checkpoint?(options?: TensorlakeCheckpointOptions): Promise<{ snapshotId?: string }>;
+  checkpoint?(
+    options?: TensorlakeCheckpointOptions,
+  ): Promise<{ snapshotId?: string }>;
 };
 
 const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
@@ -218,7 +223,9 @@ const TIMEOUT_KEYS = Object.keys(
 function resolveTimeouts(
   input: TensorlakeSandboxTimeouts | undefined,
 ): ResolvedTensorlakeTimeouts {
-  const resolved = { ...DEFAULT_TENSORLAKE_TIMEOUTS } as ResolvedTensorlakeTimeouts;
+  const resolved = {
+    ...DEFAULT_TENSORLAKE_TIMEOUTS,
+  } as ResolvedTensorlakeTimeouts;
   for (const key of TIMEOUT_KEYS) {
     if (input?.[key] !== undefined) resolved[key] = input[key]!;
     if (!Number.isFinite(resolved[key]) || resolved[key] <= 0) {
@@ -234,7 +241,10 @@ function extractHttpStatus(error: unknown): number | undefined {
   // providerErrorDetails walks cause/response chains but skips
   // SandboxProviderError.details where wrapped re-throws stash upstream status.
   const wrapped = isRecord(error) ? error.details : undefined;
-  for (const bag of [providerErrorDetails(error), isRecord(wrapped) ? wrapped : undefined]) {
+  for (const bag of [
+    providerErrorDetails(error),
+    isRecord(wrapped) ? wrapped : undefined,
+  ]) {
     if (!bag) continue;
     for (const key of ['status', 'httpStatus', 'responseStatus']) {
       const value = bag[key];
@@ -252,7 +262,8 @@ async function retryTransientHttp<T>(operation: () => Promise<T>): Promise<T> {
       const status = extractHttpStatus(error);
       const transient =
         status !== undefined && TRANSIENT_HTTP_STATUS_CODES.has(status);
-      if (!transient || attempt === TRANSIENT_HTTP_RETRY_ATTEMPTS - 1) throw error;
+      if (!transient || attempt === TRANSIENT_HTTP_RETRY_ATTEMPTS - 1)
+        throw error;
       await new Promise((resolve) =>
         setTimeout(resolve, TRANSIENT_HTTP_RETRY_BACKOFF_MS * 2 ** attempt),
       );
@@ -262,7 +273,9 @@ async function retryTransientHttp<T>(operation: () => Promise<T>): Promise<T> {
 
 type TensorlakeSandboxClass = {
   create(options?: Record<string, unknown>): Promise<TensorlakeSandboxInstance>;
-  connect(options: { sandboxId: string } & Record<string, unknown>): Promise<TensorlakeSandboxInstance>;
+  connect(
+    options: { sandboxId: string } & Record<string, unknown>,
+  ): Promise<TensorlakeSandboxInstance>;
 };
 
 export type TensorlakeWorkspacePersistence = true | 'tar' | 'snapshot';
@@ -541,7 +554,9 @@ export class TensorlakeSandboxSession extends RemoteSandboxSessionBase<Tensorlak
 
   private usesCustomControlPlane(): boolean {
     const t = this.trustedRecreateOptions;
-    return Boolean(t.proxyUrl || t.apiUrl || this.state.proxyUrl || this.state.apiUrl);
+    return Boolean(
+      t.proxyUrl || t.apiUrl || this.state.proxyUrl || this.state.apiUrl,
+    );
   }
 
   private async fetchSandboxUrl(): Promise<string | undefined> {
@@ -665,12 +680,15 @@ export class TensorlakeSandboxSession extends RemoteSandboxSessionBase<Tensorlak
   ): Promise<void> {
     if (!this.collapseManifestIdentities()) return;
     const dropped: string[] = [];
-    if (manifest.users.length > 0) dropped.push(`${manifest.users.length} user(s)`);
-    if (manifest.groups.length > 0) dropped.push(`${manifest.groups.length} group(s)`);
+    if (manifest.users.length > 0)
+      dropped.push(`${manifest.users.length} user(s)`);
+    if (manifest.groups.length > 0)
+      dropped.push(`${manifest.groups.length} group(s)`);
     const entriesWithGroup = Object.values(manifest.entries).filter(
       (entry) => entry.group !== undefined,
     ).length;
-    if (entriesWithGroup > 0) dropped.push(`${entriesWithGroup} entry ownership setting(s)`);
+    if (entriesWithGroup > 0)
+      dropped.push(`${entriesWithGroup} entry ownership setting(s)`);
     if (dropped.length === 0) return;
     logger.warn(
       `${PROVIDER_NAME} is collapsing manifest identities to the default 'tl-user' account because the base image does not expose root; dropping: ${dropped.join(', ')}. File modes (chmod) are still applied. Set manifestIdentities: 'provision' on a custom image with root to enable full provisioning.`,
@@ -737,7 +755,8 @@ export class TensorlakeSandboxSession extends RemoteSandboxSessionBase<Tensorlak
   private async persistWorkspaceViaNativeSnapshot(): Promise<
     Uint8Array | undefined
   > {
-    if (this.state.manifest.ephemeralPersistencePaths().size > 0) return undefined;
+    if (this.state.manifest.ephemeralPersistencePaths().size > 0)
+      return undefined;
     if (!this.sandbox.checkpoint) return undefined;
 
     // waitUntil='local_ready' is sufficient for same-backend restore via
@@ -904,7 +923,9 @@ export class TensorlakeSandboxSession extends RemoteSandboxSessionBase<Tensorlak
   }
 
   private shouldSuspend(options?: SandboxSessionLifecycleOptions): boolean {
-    return options?.reason === 'cleanup' && options.preserveOwnedSessions === true;
+    return (
+      options?.reason === 'cleanup' && options.preserveOwnedSessions === true
+    );
   }
 
   private async suspendOrTerminateAfterFailure(): Promise<void> {
@@ -932,9 +953,14 @@ export class TensorlakeSandboxSession extends RemoteSandboxSessionBase<Tensorlak
     command: string,
     options: RemoteSandboxCommandOptions,
   ): Promise<RemoteSandboxCommandResult> {
-    // exec is opaque (could be a read or a write), so treat every command as
-    // potentially mutating and invalidate the cached snapshot pre-emptively.
-    this.invalidateCachedSnapshot();
+    // `running` (liveness probe — `true`) and `path` (`test -e`) are
+    // read-only. Other kinds (`exec`, `manifest`, `archive`) are opaque or
+    // mutating, so invalidate pre-emptively. Without this carve-out a health
+    // check against a snapshot-backed session would drop the cached snapshot
+    // and force a clean recreate on later resume.
+    if (options.kind !== 'running' && options.kind !== 'path') {
+      this.invalidateCachedSnapshot();
+    }
     let result: TensorlakeRunResult;
     try {
       // Pass `user` natively so we can skip the `sudo -u <name> --` wrap; the
@@ -951,13 +977,16 @@ export class TensorlakeSandboxSession extends RemoteSandboxSessionBase<Tensorlak
       // Preserve upstream HTTP status so the tar-persist retry can still
       // see transient failures after we wrap into SandboxProviderError.
       const status = extractHttpStatus(error);
-      throw new SandboxProviderError(`${PROVIDER_NAME} command execution failed.`, {
-        provider: PROVIDER_ID,
-        sandboxId: this.state.sandboxId,
-        command,
-        cause: providerErrorMessage(error),
-        ...(typeof status === 'number' ? { status } : {}),
-      });
+      throw new SandboxProviderError(
+        `${PROVIDER_NAME} command execution failed.`,
+        {
+          provider: PROVIDER_ID,
+          sandboxId: this.state.sandboxId,
+          command,
+          cause: providerErrorMessage(error),
+          ...(typeof status === 'number' ? { status } : {}),
+        },
+      );
     }
     return {
       status: result.exitCode ?? 1,
@@ -977,19 +1006,25 @@ export class TensorlakeSandboxSession extends RemoteSandboxSessionBase<Tensorlak
         timeout: this.resolvedTimeouts.fastOpSecs,
       });
     } catch (error) {
-      throw new SandboxProviderError(`${PROVIDER_NAME} failed to create directory.`, {
-        provider: PROVIDER_ID,
-        path,
-        cause: providerErrorMessage(error),
-      });
+      throw new SandboxProviderError(
+        `${PROVIDER_NAME} failed to create directory.`,
+        {
+          provider: PROVIDER_ID,
+          path,
+          cause: providerErrorMessage(error),
+        },
+      );
     }
     if ((result.exitCode ?? 1) !== 0) {
-      throw new SandboxProviderError(`${PROVIDER_NAME} failed to create directory.`, {
-        provider: PROVIDER_ID,
-        path,
-        stderr: result.stderr ?? '',
-        stdout: result.stdout ?? '',
-      });
+      throw new SandboxProviderError(
+        `${PROVIDER_NAME} failed to create directory.`,
+        {
+          provider: PROVIDER_ID,
+          path,
+          stderr: result.stderr ?? '',
+          stdout: result.stdout ?? '',
+        },
+      );
     }
   }
 
@@ -1034,17 +1069,23 @@ export class TensorlakeSandboxSession extends RemoteSandboxSessionBase<Tensorlak
         // Fall through to shell rm in case the path doesn't exist.
       }
     }
-    const result = await this.runRemoteCommand(`rm -rf -- ${shellQuote(path)}`, {
-      kind: 'manifest',
-      workdir: '/',
-    });
+    const result = await this.runRemoteCommand(
+      `rm -rf -- ${shellQuote(path)}`,
+      {
+        kind: 'manifest',
+        workdir: '/',
+      },
+    );
     if (result.status !== 0) {
-      throw new SandboxProviderError(`${PROVIDER_NAME} failed to delete path.`, {
-        provider: PROVIDER_ID,
-        path,
-        stderr: result.stderr ?? '',
-        stdout: result.stdout ?? '',
-      });
+      throw new SandboxProviderError(
+        `${PROVIDER_NAME} failed to delete path.`,
+        {
+          provider: PROVIDER_ID,
+          path,
+          stderr: result.stderr ?? '',
+          stdout: result.stdout ?? '',
+        },
+      );
     }
   }
 
@@ -1104,8 +1145,14 @@ function withTimeout<T>(
       timeoutMs,
     );
     promise.then(
-      (value) => { clearTimeout(handle); resolve(value); },
-      (error) => { clearTimeout(handle); reject(error); },
+      (value) => {
+        clearTimeout(handle);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(handle);
+        reject(error);
+      },
     );
   });
 }
@@ -1236,27 +1283,60 @@ export class TensorlakeSandboxClient implements SandboxClient<
       ...state,
       ...deserializeRemoteSandboxSessionStateValues(state, this.options.env),
       sandboxId: readString(state, 'sandboxId'),
-      configuredExposedPorts: readOptionalNumberArray(state.configuredExposedPorts),
+      // Resolved-endpoint cache is untrusted on deserialize; clear it.
+      // This prevents tampered state from redirecting resolveExposedPort().
+      exposedPorts: undefined,
+      configuredExposedPorts: readOptionalNumberArray(
+        state.configuredExposedPorts,
+      ),
       timeouts: readTimeouts(state.timeouts),
-      workspacePersistence: readWorkspacePersistence(state.workspacePersistence),
+      workspacePersistence: readWorkspacePersistence(
+        state.workspacePersistence,
+      ),
       manifestIdentities: readManifestIdentities(state.manifestIdentities),
       snapshotCheckpointType: readCheckpointType(state.snapshotCheckpointType),
       checkpointWaitUntil: readCheckpointWaitUntil(state.checkpointWaitUntil),
       suspendOnExit: Boolean(state.suspendOnExit),
     };
-    for (const f of ['name', 'image', 'poolId', 'proxyUrl', 'apiUrl', 'namespace',
-      'organizationId', 'projectId', 'routingHint', 'snapshotId'] as const) {
+    for (const f of [
+      'name',
+      'image',
+      'poolId',
+      'proxyUrl',
+      'apiUrl',
+      'namespace',
+      'organizationId',
+      'projectId',
+      'routingHint',
+      'snapshotId',
+    ] as const) {
       out[f] = readOptionalString(state, f);
     }
-    for (const f of ['cpus', 'memoryMb', 'diskMb', 'timeoutSecs', 'startupTimeout',
-      'commandTimeoutSecs', 'checkpointTimeoutSecs'] as const) {
+    for (const f of [
+      'cpus',
+      'memoryMb',
+      'diskMb',
+      'timeoutSecs',
+      'startupTimeout',
+      'commandTimeoutSecs',
+      'checkpointTimeoutSecs',
+    ] as const) {
       out[f] = readOptionalNumber(state, f);
     }
-    for (const f of ['allowInternetAccess', 'allowUnauthenticatedAccess',
-      'workspaceRootProvisioned', 'systemSetupPreserved'] as const) {
+    for (const f of [
+      'allowInternetAccess',
+      'allowUnauthenticatedAccess',
+      'workspaceRootProvisioned',
+      'systemSetupPreserved',
+    ] as const) {
       out[f] = readOptionalBoolean(state, f);
     }
-    for (const f of ['secretNames', 'entrypoint', 'allowOut', 'denyOut'] as const) {
+    for (const f of [
+      'secretNames',
+      'entrypoint',
+      'allowOut',
+      'denyOut',
+    ] as const) {
       out[f] = readOptionalStringArray(state[f]);
     }
     return out as TensorlakeSandboxSessionState;
@@ -1273,8 +1353,13 @@ export class TensorlakeSandboxClient implements SandboxClient<
       // Sandbox.connect() doesn't contact the server, so probe status() first
       // to convert a `terminated` sandbox into a synthetic 404 (the SDK's
       // resume() would otherwise throw a non-404 that skips the fallback).
-      const connectCfg = lifecycleConfigFromState(state, trustedRecreateOptions.apiKey);
-      const sandbox = await Sandbox.connect(buildConnectKwargs(connectCfg, state.sandboxId));
+      const connectCfg = lifecycleConfigFromState(
+        state,
+        trustedRecreateOptions.apiKey,
+      );
+      const sandbox = await Sandbox.connect(
+        buildConnectKwargs(connectCfg, state.sandboxId),
+      );
       await probeSandboxAlive(sandbox);
       if (state.name && typeof sandbox.resume === 'function') {
         await sandbox.resume();
@@ -1302,7 +1387,10 @@ export class TensorlakeSandboxClient implements SandboxClient<
       typeof state.snapshotId === 'string' &&
       state.snapshotId.length > 0
     ) {
-      const session = await this.recreateFromSnapshotId(state, state.snapshotId);
+      const session = await this.recreateFromSnapshotId(
+        state,
+        state.snapshotId,
+      );
       if (session) return session;
     }
 
@@ -1525,14 +1613,18 @@ function assertPositive(name: string, value: number | undefined): void {
 function readTimeouts(value: unknown): TensorlakeSandboxTimeouts | undefined {
   if (value === undefined || value === null) return undefined;
   if (!isRecord(value)) {
-    throw new UserError(`${PROVIDER_NAME} timeouts must be an object of positive numbers.`);
+    throw new UserError(
+      `${PROVIDER_NAME} timeouts must be an object of positive numbers.`,
+    );
   }
   const result: TensorlakeSandboxTimeouts = {};
   for (const key of TIMEOUT_KEYS) {
     const raw = value[key];
     if (raw === undefined || raw === null) continue;
     if (typeof raw !== 'number') {
-      throw new UserError(`${PROVIDER_NAME} timeouts.${key} must be a positive finite number.`);
+      throw new UserError(
+        `${PROVIDER_NAME} timeouts.${key} must be a positive finite number.`,
+      );
     }
     result[key] = raw;
   }
@@ -1596,16 +1688,32 @@ function withTrustedRecreateOverrides(
   if (trusted.exposedPorts !== undefined) {
     next.configuredExposedPorts = trusted.exposedPorts;
   }
+  delete next.exposedPorts;
   return next;
 }
 
 // Normalized lifecycle config shared by Sandbox.create and Sandbox.connect.
 type TensorlakeLifecycleConfig = Pick<
   TensorlakeSandboxClientOptions,
-  | 'image' | 'cpus' | 'memoryMb' | 'diskMb' | 'timeoutSecs' | 'name'
-  | 'startupTimeout' | 'proxyUrl' | 'apiUrl' | 'namespace' | 'organizationId'
-  | 'projectId' | 'routingHint' | 'secretNames' | 'allowOut' | 'denyOut'
-  | 'entrypoint' | 'apiKey' | 'poolId'
+  | 'image'
+  | 'cpus'
+  | 'memoryMb'
+  | 'diskMb'
+  | 'timeoutSecs'
+  | 'name'
+  | 'startupTimeout'
+  | 'proxyUrl'
+  | 'apiUrl'
+  | 'namespace'
+  | 'organizationId'
+  | 'projectId'
+  | 'routingHint'
+  | 'secretNames'
+  | 'allowOut'
+  | 'denyOut'
+  | 'entrypoint'
+  | 'apiKey'
+  | 'poolId'
 > & {
   allowInternetAccess: boolean;
   env: Record<string, string>;
@@ -1614,34 +1722,58 @@ type TensorlakeLifecycleConfig = Pick<
 // Building blocks. routingHint is connect-only; poolId/apiKey/env are inlined
 // in buildCreateKwargs because of mutex/empty semantics.
 const SANDBOX_CONFIG_SCALAR_FIELDS = [
-  'image', 'cpus', 'memoryMb', 'diskMb', 'timeoutSecs', 'name', 'startupTimeout',
+  'image',
+  'cpus',
+  'memoryMb',
+  'diskMb',
+  'timeoutSecs',
+  'name',
+  'startupTimeout',
 ] as const satisfies readonly (keyof TensorlakeLifecycleConfig)[];
 const CONTROL_PLANE_SCALAR_FIELDS = [
-  'proxyUrl', 'apiUrl', 'namespace', 'organizationId', 'projectId',
+  'proxyUrl',
+  'apiUrl',
+  'namespace',
+  'organizationId',
+  'projectId',
 ] as const satisfies readonly (keyof TensorlakeLifecycleConfig)[];
 const LIFECYCLE_LIST_FIELDS = [
-  'secretNames', 'allowOut', 'denyOut', 'entrypoint',
+  'secretNames',
+  'allowOut',
+  'denyOut',
+  'entrypoint',
 ] as const satisfies readonly (keyof TensorlakeLifecycleConfig)[];
-const CREATE_SCALAR_FIELDS = [...SANDBOX_CONFIG_SCALAR_FIELDS, ...CONTROL_PLANE_SCALAR_FIELDS] as const;
+const CREATE_SCALAR_FIELDS = [
+  ...SANDBOX_CONFIG_SCALAR_FIELDS,
+  ...CONTROL_PLANE_SCALAR_FIELDS,
+] as const;
 const CREATE_LIST_FIELDS = LIFECYCLE_LIST_FIELDS;
 const CONNECT_FIELDS = [
-  ...CONTROL_PLANE_SCALAR_FIELDS, 'routingHint',
+  ...CONTROL_PLANE_SCALAR_FIELDS,
+  'routingHint',
 ] as const satisfies readonly (keyof TensorlakeLifecycleConfig)[];
 
 // Memory snapshots restore image/resources/entrypoint/secrets from the
 // snapshot; passing them at restore is rejected by the backend.
 // See https://docs.tensorlake.ai/sandboxes/snapshots.
 const MEMORY_SNAPSHOT_RESTORE_EXCLUDED_SCALARS: ReadonlySet<string> = new Set([
-  'image', 'cpus', 'memoryMb', 'diskMb',
+  'image',
+  'cpus',
+  'memoryMb',
+  'diskMb',
 ]);
 const MEMORY_SNAPSHOT_RESTORE_EXCLUDED_LISTS: ReadonlySet<string> = new Set([
-  'entrypoint', 'secretNames',
+  'entrypoint',
+  'secretNames',
 ]);
 
 // Fields shared by options/state/lifecycle config.
 const LIFECYCLE_COMMON_FIELDS = [
-  ...SANDBOX_CONFIG_SCALAR_FIELDS, ...CONTROL_PLANE_SCALAR_FIELDS,
-  'routingHint', ...LIFECYCLE_LIST_FIELDS, 'poolId',
+  ...SANDBOX_CONFIG_SCALAR_FIELDS,
+  ...CONTROL_PLANE_SCALAR_FIELDS,
+  'routingHint',
+  ...LIFECYCLE_LIST_FIELDS,
+  'poolId',
 ] as const satisfies readonly (keyof TensorlakeLifecycleConfig)[];
 
 type LifecycleCommonField = (typeof LIFECYCLE_COMMON_FIELDS)[number];
@@ -1696,7 +1828,13 @@ function buildCreateKwargs(
   };
   for (const name of CREATE_SCALAR_FIELDS) {
     const value = cfg[name];
-    if (skipScalar(name) || value === undefined || value === null || value === '') continue;
+    if (
+      skipScalar(name) ||
+      value === undefined ||
+      value === null ||
+      value === ''
+    )
+      continue;
     kwargs[name] = value;
   }
   for (const name of CREATE_LIST_FIELDS) {
@@ -1927,7 +2065,8 @@ function stateToCreateOptions(
   if (state.name !== undefined) options.name = state.name;
   for (const field of OPTION_STATE_COMMON_FIELDS) {
     const value = state[field];
-    if (value !== undefined) (options as Record<string, unknown>)[field] = value;
+    if (value !== undefined)
+      (options as Record<string, unknown>)[field] = value;
   }
   return options;
 }
@@ -1939,7 +2078,9 @@ function parseEnum<T extends string | boolean>(
 ): T | undefined {
   if (value === undefined) return undefined;
   if ((allowed as readonly unknown[]).includes(value)) return value as T;
-  const tokens = allowed.map((v) => (typeof v === 'string' ? `"${v}"` : String(v)));
+  const tokens = allowed.map((v) =>
+    typeof v === 'string' ? `"${v}"` : String(v),
+  );
   const display =
     tokens.length <= 2
       ? tokens.join(' or ')

--- a/packages/agents-extensions/src/sandbox/tensorlake/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/tensorlake/sandbox.ts
@@ -1286,6 +1286,12 @@ export class TensorlakeSandboxClient implements SandboxClient<
       // Resolved-endpoint cache is untrusted on deserialize; clear it.
       // This prevents tampered state from redirecting resolveExposedPort().
       exposedPorts: undefined,
+      // Control-plane routing URLs are untrusted on deserialize; clear them so
+      // a tampered resume can't redirect Sandbox.connect()/create() to an
+      // attacker host and exfiltrate the trusted apiKey. Like apiKey, they are
+      // restored only from constructor options via withTrustedRecreateOverrides.
+      proxyUrl: undefined,
+      apiUrl: undefined,
       configuredExposedPorts: readOptionalNumberArray(
         state.configuredExposedPorts,
       ),
@@ -1302,8 +1308,7 @@ export class TensorlakeSandboxClient implements SandboxClient<
       'name',
       'image',
       'poolId',
-      'proxyUrl',
-      'apiUrl',
+      // proxyUrl/apiUrl intentionally omitted — see clearing above.
       'namespace',
       'organizationId',
       'projectId',

--- a/packages/agents-extensions/test/sandbox/tensorlake.test.ts
+++ b/packages/agents-extensions/test/sandbox/tensorlake.test.ts
@@ -1,0 +1,1871 @@
+import { UserError } from '@openai/agents-core';
+import {
+  Manifest,
+  SandboxArchiveError,
+  SandboxProviderError,
+  SandboxUnsupportedFeatureError,
+} from '@openai/agents-core/sandbox';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { allowConsole } from '../../../../helpers/tests/console-guard';
+import { decodeNativeSnapshotRef } from '../../src/sandbox/shared';
+import {
+  TensorlakeSandboxClient,
+  type TensorlakeSandboxClientOptions,
+} from '../../src/sandbox/tensorlake';
+import { resolvedRemotePathFromValidationCommand } from './remotePathValidation';
+import { makeTarArchive } from './tarFixture';
+
+const createMock = vi.fn();
+const connectMock = vi.fn();
+const runMock = vi.fn();
+const writeFileMock = vi.fn();
+const readFileMock = vi.fn();
+const deleteFileMock = vi.fn();
+const updateMock = vi.fn();
+const suspendMock = vi.fn();
+const resumeMock = vi.fn();
+const terminateMock = vi.fn();
+const checkpointMock = vi.fn();
+
+const remoteFiles = new Map<string, Uint8Array>();
+
+vi.mock('tensorlake', () => ({
+  Sandbox: {
+    create: createMock,
+    connect: connectMock,
+  },
+}));
+
+function makeSandboxInstance(
+  sandboxId: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    sandboxId,
+    name: null,
+    run: runMock,
+    writeFile: writeFileMock,
+    readFile: readFileMock,
+    deleteFile: deleteFileMock,
+    update: updateMock,
+    suspend: suspendMock,
+    resume: resumeMock,
+    terminate: terminateMock,
+    checkpoint: checkpointMock,
+    ...overrides,
+  };
+}
+
+describe('TensorlakeSandboxClient', () => {
+  beforeEach(() => {
+    remoteFiles.clear();
+    createMock.mockReset();
+    connectMock.mockReset();
+    runMock.mockReset();
+    writeFileMock.mockReset();
+    readFileMock.mockReset();
+    deleteFileMock.mockReset();
+    updateMock.mockReset();
+    suspendMock.mockReset();
+    resumeMock.mockReset();
+    terminateMock.mockReset();
+    checkpointMock.mockReset();
+
+    createMock.mockResolvedValue(makeSandboxInstance('sbx_test'));
+    connectMock.mockResolvedValue(makeSandboxInstance('sbx_test'));
+    writeFileMock.mockImplementation(
+      async (path: string, content: string | Uint8Array) => {
+        const bytes =
+          typeof content === 'string'
+            ? new TextEncoder().encode(content)
+            : content;
+        remoteFiles.set(path, bytes);
+      },
+    );
+    readFileMock.mockImplementation(async (path: string) => {
+      const value = remoteFiles.get(path);
+      if (!value) {
+        throw new Error(`not found: ${path}`);
+      }
+      return value;
+    });
+    deleteFileMock.mockImplementation(async (path: string) => {
+      remoteFiles.delete(path);
+    });
+    runMock.mockImplementation(
+      async (command: string, options?: { args?: string[] }) => {
+        const shellCommand = options?.args?.[1] ?? '';
+        const resolvedPath =
+          resolvedRemotePathFromValidationCommand(shellCommand);
+        if (resolvedPath) {
+          return {
+            stdout: `${resolvedPath}\n`,
+            stderr: '',
+            exitCode: 0,
+          };
+        }
+        if (shellCommand === 'ls') {
+          return {
+            stdout: 'README.md\n',
+            stderr: '',
+            exitCode: 0,
+          };
+        }
+        if (shellCommand.startsWith('test -e ')) {
+          const path = shellCommand.match(/^test -e '(.+)'$/)?.[1] ?? '';
+          return {
+            stdout: '',
+            stderr: '',
+            exitCode: remoteFiles.has(path) ? 0 : 1,
+          };
+        }
+        if (shellCommand.startsWith('mkdir -p -- ')) {
+          return { stdout: '', stderr: '', exitCode: 0 };
+        }
+        return { stdout: '', stderr: '', exitCode: 0 };
+      },
+    );
+    updateMock.mockResolvedValue({});
+    suspendMock.mockResolvedValue(undefined);
+    resumeMock.mockResolvedValue(undefined);
+    terminateMock.mockResolvedValue(undefined);
+    checkpointMock.mockResolvedValue({ snapshotId: 'snap_test' });
+  });
+
+  test('rejects unsupported core snapshot create options', async () => {
+    const client = new TensorlakeSandboxClient();
+
+    await expect(
+      client.create({
+        manifest: new Manifest(),
+        snapshot: { type: 'remote' },
+      }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('rejects manifests with mount entries before allocating a sandbox', async () => {
+    const client = new TensorlakeSandboxClient();
+    const manifest = new Manifest({
+      entries: {
+        data: {
+          type: 's3_mount',
+          bucket: 'agent-logs',
+          accessKeyId: 'access-key',
+          secretAccessKey: 'secret-key',
+          mountPath: 'mounted/logs',
+        },
+      },
+    });
+
+    await expect(client.create(manifest)).rejects.toBeInstanceOf(
+      SandboxUnsupportedFeatureError,
+    );
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test("collapses manifest identities to tl-user by default and warns once", async () => {
+    // Default Tensorlake image only ships `tl-user` and no root; the provider
+    // accepts user/group declarations at validation time but skips the
+    // privileged commands at apply time. The caller should hear about it via
+    // a single warn() summarizing what got dropped, and chmod for entry
+    // permissions should still run.
+    allowConsole(['warn']);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const client = new TensorlakeSandboxClient();
+    const manifest = new Manifest({
+      users: [{ name: 'alice' }, { name: 'bob' }],
+      groups: [{ name: 'staff' }],
+      entries: {
+        'config.json': {
+          type: 'file',
+          content: '{}',
+          permissions: {
+            owner: 7,
+            group: 4,
+            other: 4,
+          },
+          group: { name: 'staff' },
+        },
+      },
+    });
+
+    await client.create(manifest);
+
+    const shellCommands = runMock.mock.calls
+      .map(([, opts]) => (opts as { args?: string[] })?.args?.[1] ?? '')
+      .filter((s) => s.length > 0);
+
+    expect(shellCommands.some((c) => c.includes('groupadd'))).toBe(false);
+    expect(shellCommands.some((c) => c.includes('useradd'))).toBe(false);
+    expect(shellCommands.some((c) => c.includes('usermod'))).toBe(false);
+    expect(shellCommands.some((c) => c.includes('chown'))).toBe(false);
+    expect(shellCommands.some((c) => c.includes('chgrp'))).toBe(false);
+    expect(
+      shellCommands.some((c) =>
+        c.startsWith(`chmod `) &&
+        c.includes(`/home/tl-user/workspace/config.json`),
+      ),
+    ).toBe(true);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const warnMessage = String(warnSpy.mock.calls[0]?.[0] ?? '');
+    expect(warnMessage).toContain('2 user(s)');
+    expect(warnMessage).toContain('1 group(s)');
+    expect(warnMessage).toContain('1 entry ownership setting(s)');
+    expect(warnMessage).toContain('tl-user');
+    expect(warnMessage).not.toContain('entr(y/ies)');
+    warnSpy.mockRestore();
+  });
+
+  test("manifestIdentities: 'provision' runs account provisioning and entry chgrp", async () => {
+    // Opt-in mode for custom images that expose root: the provider should
+    // emit the original groupadd/useradd/usermod and chgrp commands. Note
+    // that `chown` is only emitted when `applyManifest(manifest, runAs)` is
+    // called, and Tensorlake currently rejects manifest `runAs` at the base
+    // class (see the `rejects manifest runAs even in 'provision' mode` test
+    // below), so this test deliberately does not assert `chown`.
+    const client = new TensorlakeSandboxClient({
+      manifestIdentities: 'provision',
+    } satisfies TensorlakeSandboxClientOptions);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const manifest = new Manifest({
+      users: [{ name: 'alice' }],
+      groups: [{ name: 'staff', users: [{ name: 'alice' }] }],
+      entries: {
+        'config.json': {
+          type: 'file',
+          content: '{}',
+          group: { name: 'staff' },
+        },
+      },
+    });
+
+    await client.create(manifest);
+
+    const shellCommands = runMock.mock.calls
+      .map(([, opts]) => (opts as { args?: string[] })?.args?.[1] ?? '')
+      .filter((s) => s.length > 0);
+
+    expect(shellCommands.some((c) => c.includes('groupadd'))).toBe(true);
+    expect(shellCommands.some((c) => c.includes('useradd'))).toBe(true);
+    expect(shellCommands.some((c) => c.includes('usermod'))).toBe(true);
+    expect(shellCommands.some((c) => c.includes('chgrp'))).toBe(true);
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  test("rejects manifest runAs even in 'provision' mode (not silently dropped)", async () => {
+    // Manifest materialization `runAs` is the only path that would trigger
+    // `chown` in the base class. Tensorlake does not override
+    // `assertFilesystemRunAs`/`assertManifestRunAs`, so a caller asking for
+    // manifest-time ownership via `runAs` gets a loud
+    // `SandboxUnsupportedFeatureError` — never a silent collapse. This holds
+    // in both 'collapse' and 'provision' modes.
+    for (const manifestIdentities of ['collapse', 'provision'] as const) {
+      const client = new TensorlakeSandboxClient({
+        manifestIdentities,
+      } satisfies TensorlakeSandboxClientOptions);
+      const session = await client.create(new Manifest());
+      await expect(session.applyManifest(new Manifest(), 'alice')).rejects.toBeInstanceOf(
+        SandboxUnsupportedFeatureError,
+      );
+    }
+  });
+
+  test('rejects an unknown manifestIdentities value at create-time', async () => {
+    const client = new TensorlakeSandboxClient({
+      manifestIdentities: 'bogus' as unknown as 'collapse',
+    } satisfies TensorlakeSandboxClientOptions);
+    await expect(client.create(new Manifest())).rejects.toBeInstanceOf(
+      SandboxUnsupportedFeatureError,
+    );
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('rejects snapshot persistence when timeoutSecs is below the SDK default checkpoint budget', async () => {
+    // Caller omits checkpointTimeoutSecs, so the effective poll budget is the
+    // SDK default (300s). timeoutSecs=60 would let the sandbox idle out
+    // mid-checkpoint and orphan the snapshot.
+    const client = new TensorlakeSandboxClient({
+      workspacePersistence: 'snapshot',
+      timeoutSecs: 60,
+    });
+
+    await expect(client.create(new Manifest())).rejects.toBeInstanceOf(
+      UserError,
+    );
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('rejects snapshot persistence when timeoutSecs is below an explicit checkpoint budget', async () => {
+    const client = new TensorlakeSandboxClient({
+      workspacePersistence: 'snapshot',
+      timeoutSecs: 60,
+      checkpointTimeoutSecs: 120,
+    });
+
+    await expect(client.create(new Manifest())).rejects.toBeInstanceOf(
+      UserError,
+    );
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('accepts snapshot persistence when timeoutSecs exceeds the SDK default checkpoint budget', async () => {
+    const client = new TensorlakeSandboxClient({
+      workspacePersistence: 'snapshot',
+      timeoutSecs: 600,
+    });
+
+    await expect(client.create(new Manifest())).resolves.toBeDefined();
+  });
+
+  test('creates a sandbox, materializes the manifest, and executes commands', async () => {
+    const client = new TensorlakeSandboxClient();
+    const manifest = new Manifest({
+      entries: {
+        'README.md': {
+          type: 'file',
+          content: '# Hello\n',
+        },
+      },
+    });
+
+    const session = await client.create(manifest);
+    const output = await session.execCommand({ cmd: 'ls' });
+
+    expect(createMock).toHaveBeenCalledOnce();
+    expect(writeFileMock).toHaveBeenCalledWith(
+      '/home/tl-user/workspace/README.md',
+      expect.any(Uint8Array),
+    );
+    expect(runMock).toHaveBeenCalledWith('/bin/bash', {
+      args: ['-lc', 'ls'],
+      env: {},
+      workingDir: '/home/tl-user/workspace',
+      // Default unbounded-exec safety cap is 24h (86400s).
+      timeout: 86400,
+    });
+    expect(output).toContain('Process exited with code 0');
+    expect(output).toContain('README.md');
+    expect(session.state.sandboxId).toBe('sbx_test');
+  });
+
+  test('passes name, image, and resource options through to Sandbox.create', async () => {
+    const client = new TensorlakeSandboxClient({
+      name: 'demo',
+      image: 'tensorlake/python',
+      cpus: 2,
+      memoryMb: 4096,
+      timeoutSecs: 600,
+      secretNames: ['OPENAI_API_KEY'],
+      allowInternetAccess: true,
+    } satisfies TensorlakeSandboxClientOptions);
+    createMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_named', { name: 'demo' }),
+    );
+
+    await client.create(new Manifest());
+
+    expect(createMock).toHaveBeenCalledWith({
+      name: 'demo',
+      image: 'tensorlake/python',
+      cpus: 2,
+      memoryMb: 4096,
+      timeoutSecs: 600,
+      secretNames: ['OPENAI_API_KEY'],
+      allowInternetAccess: true,
+    });
+  });
+
+  test('treats missing exit codes as failures', async () => {
+    const client = new TensorlakeSandboxClient();
+    const session = await client.create(new Manifest());
+    runMock.mockResolvedValueOnce({
+      stdout: 'lost exit\n',
+      stderr: '',
+      exitCode: null,
+    });
+
+    const output = await session.execCommand({ cmd: 'lost-exit' });
+
+    expect(output).toContain('Process exited with code 1');
+    expect(output).toContain('lost exit');
+  });
+
+  test('writes manifest entries through the SDK and reads them back', async () => {
+    const client = new TensorlakeSandboxClient();
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          'notes.txt': { type: 'file', content: 'hello' },
+        },
+      }),
+    );
+
+    expect(writeFileMock).toHaveBeenCalledWith(
+      '/home/tl-user/workspace/notes.txt',
+      expect.any(Uint8Array),
+    );
+
+    const bytes = await session.readFile({
+      path: '/home/tl-user/workspace/notes.txt',
+    });
+    expect(new TextDecoder().decode(bytes)).toBe('hello');
+  });
+
+  test('resolves exposed ports through update() and the proxy hostname', async () => {
+    const client = new TensorlakeSandboxClient({
+      exposedPorts: [8080],
+    } satisfies TensorlakeSandboxClientOptions);
+    createMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_ports', { name: null }),
+    );
+    const session = await client.create(new Manifest());
+
+    expect(updateMock).toHaveBeenCalledWith({ exposedPorts: [8080] });
+    updateMock.mockClear();
+
+    const endpoint = await session.resolveExposedPort(8080);
+    expect(endpoint.url).toContain(
+      'https://8080-sbx_ports.sandbox.tensorlake.ai',
+    );
+    expect(updateMock).not.toHaveBeenCalled();
+
+    const onDemand = await session.resolveExposedPort(9090);
+    expect(onDemand.url).toContain(
+      'https://9090-sbx_ports.sandbox.tensorlake.ai',
+    );
+    expect(updateMock).toHaveBeenCalledWith({ exposedPorts: [8080, 9090] });
+  });
+
+  test('resolves exposed port hostname from sandbox.info() sandbox_url', async () => {
+    const infoMock = vi.fn().mockResolvedValue({
+      sandboxId: 'sbx_dev',
+      sandbox_url: 'https://sbx-dev-instance.tensorlake.dev',
+    });
+    createMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_dev', { name: 'demo', info: infoMock }),
+    );
+    const client = new TensorlakeSandboxClient({
+      exposedPorts: [8080],
+    } satisfies TensorlakeSandboxClientOptions);
+    const session = await client.create(new Manifest());
+
+    const endpoint = await session.resolveExposedPort(8080);
+    // The host comes from info().sandbox_url, not the public template.
+    expect(endpoint.url).toContain(
+      'https://8080-sbx-dev-instance.tensorlake.dev',
+    );
+  });
+
+  test('falls back to the public template when sandbox.info() returns no URL', async () => {
+    const infoMock = vi.fn().mockResolvedValue({ sandboxId: 'sbx_fallback' });
+    createMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_fallback', {
+        name: 'demo',
+        info: infoMock,
+      }),
+    );
+    const client = new TensorlakeSandboxClient({
+      exposedPorts: [8080],
+    } satisfies TensorlakeSandboxClientOptions);
+    const session = await client.create(new Manifest());
+
+    const endpoint = await session.resolveExposedPort(8080);
+    expect(endpoint.url).toContain('https://8080-demo.sandbox.tensorlake.ai');
+  });
+
+  test('seeds sandbox id via info() when create returns it unpopulated', async () => {
+    const infoMock = vi.fn().mockResolvedValue({ sandboxId: 'sbx_from_info' });
+    // Empty sandboxId from create simulates the snapshot-restore lazy-id path.
+    createMock.mockResolvedValueOnce(
+      makeSandboxInstance('', { info: infoMock }),
+    );
+    const client = new TensorlakeSandboxClient();
+    const session = await client.create(new Manifest());
+
+    expect(infoMock).toHaveBeenCalled();
+    expect(session.state.sandboxId).toBe('sbx_from_info');
+  });
+
+  test('captures and restores native snapshots through checkpoint()', async () => {
+    const client = new TensorlakeSandboxClient({
+      workspacePersistence: 'snapshot',
+    } satisfies TensorlakeSandboxClientOptions);
+    const session = await client.create(new Manifest());
+
+    const archive = await session.persistWorkspace();
+    expect(checkpointMock).toHaveBeenCalledOnce();
+    // Default waitUntil mirrors Python's `'local_ready'` — sufficient for
+    // `Sandbox.create({ snapshotId })` restore on the same backend and
+    // avoids blocking on remote-storage upload.
+    expect(checkpointMock).toHaveBeenCalledWith(
+      expect.objectContaining({ waitUntil: 'local_ready' }),
+    );
+
+    const ref = decodeNativeSnapshotRef(archive);
+    expect(ref?.provider).toBe('tensorlake');
+    expect(ref?.snapshotId).toBe('snap_test');
+
+    // Hydrating with the same archive should call Sandbox.create with the
+    // recorded snapshot id.
+    createMock.mockClear();
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_restored'));
+    await session.hydrateWorkspace(archive);
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ snapshotId: 'snap_test' }),
+    );
+    expect(session.state.sandboxId).toBe('sbx_restored');
+  });
+
+  test('suspendOnExit close suspends named sandboxes', async () => {
+    const client = new TensorlakeSandboxClient({
+      name: 'demo',
+      suspendOnExit: true,
+    } satisfies TensorlakeSandboxClientOptions);
+    createMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_named', { name: 'demo' }),
+    );
+    const session = await client.create(new Manifest());
+
+    await session.close();
+
+    expect(suspendMock).toHaveBeenCalledOnce();
+    expect(terminateMock).not.toHaveBeenCalled();
+    expect(client.canPersistOwnedSessionState(session.state)).toBe(true);
+  });
+
+  test('falls back to terminate when suspend fails on close', async () => {
+    suspendMock.mockRejectedValueOnce(new Error('cannot suspend'));
+    const client = new TensorlakeSandboxClient({
+      name: 'demo',
+      suspendOnExit: true,
+    } satisfies TensorlakeSandboxClientOptions);
+    createMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_named', { name: 'demo' }),
+    );
+    const session = await client.create(new Manifest());
+
+    await session.close();
+
+    expect(suspendMock).toHaveBeenCalledOnce();
+    expect(terminateMock).toHaveBeenCalledOnce();
+    expect(session.state.suspendOnExit).toBe(false);
+  });
+
+  test('ephemeral sandboxes always terminate on close', async () => {
+    const client = new TensorlakeSandboxClient();
+    const session = await client.create(new Manifest());
+
+    await session.close();
+
+    expect(suspendMock).not.toHaveBeenCalled();
+    expect(terminateMock).toHaveBeenCalledOnce();
+  });
+
+  test('cleanup lifecycle suspends persistable sessions only once', async () => {
+    const client = new TensorlakeSandboxClient({
+      name: 'demo',
+      suspendOnExit: true,
+    } satisfies TensorlakeSandboxClientOptions);
+    createMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_named', { name: 'demo' }),
+    );
+    const session = await client.create(new Manifest());
+
+    await session.shutdown!({
+      reason: 'cleanup',
+      preserveOwnedSessions: true,
+    });
+    await session.delete!({
+      reason: 'cleanup',
+      preserveOwnedSessions: true,
+    });
+
+    expect(suspendMock).toHaveBeenCalledOnce();
+    expect(terminateMock).not.toHaveBeenCalled();
+  });
+
+  test('cleanup lifecycle terminates ephemeral sessions only once', async () => {
+    const client = new TensorlakeSandboxClient();
+    const session = await client.create(new Manifest());
+
+    await session.shutdown!({ reason: 'cleanup' });
+    await session.delete!({ reason: 'cleanup' });
+
+    expect(suspendMock).not.toHaveBeenCalled();
+    expect(terminateMock).toHaveBeenCalledOnce();
+  });
+
+  test('resume reconnects to a named sandbox by sandboxId', async () => {
+    const client = new TensorlakeSandboxClient();
+    const session = await client.create(new Manifest());
+    session.state.name = 'demo';
+    const serialized = await client.serializeSessionState(session.state);
+    const state = await client.deserializeSessionState(serialized);
+
+    connectMock.mockClear();
+    connectMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_test', { name: 'demo' }),
+    );
+
+    const resumed = await client.resume(state);
+    expect(connectMock).toHaveBeenCalledWith({ sandboxId: 'sbx_test' });
+    expect(resumeMock).toHaveBeenCalledOnce();
+    expect(resumed.state.sandboxId).toBe('sbx_test');
+  });
+
+  test('resume recreates the sandbox when the original is gone', async () => {
+    const client = new TensorlakeSandboxClient();
+    const session = await client.create(new Manifest());
+    session.state.name = 'demo';
+    const state = await client.deserializeSessionState(
+      await client.serializeSessionState(session.state),
+    );
+
+    connectMock.mockClear();
+    createMock.mockClear();
+    const notFound = Object.assign(new Error('sandbox not found'), {
+      status: 404,
+    });
+    connectMock.mockRejectedValueOnce(notFound);
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_recreated'));
+
+    const resumed = await client.resume(state);
+
+    expect(connectMock).toHaveBeenCalledOnce();
+    expect(createMock).toHaveBeenCalledOnce();
+    expect(resumed.state.sandboxId).toBe('sbx_recreated');
+  });
+
+  test('resume recreates when sandbox.resume() reports the sandbox is gone', async () => {
+    const client = new TensorlakeSandboxClient();
+    const session = await client.create(new Manifest());
+    session.state.name = 'demo';
+    const state = await client.deserializeSessionState(
+      await client.serializeSessionState(session.state),
+    );
+
+    connectMock.mockClear();
+    createMock.mockClear();
+    resumeMock.mockReset();
+    const notFound = Object.assign(new Error('sandbox not found'), {
+      status: 404,
+    });
+    connectMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_test', { name: 'demo' }),
+    );
+    resumeMock.mockRejectedValueOnce(notFound);
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_recreated'));
+
+    const resumed = await client.resume(state);
+
+    expect(connectMock).toHaveBeenCalledOnce();
+    expect(resumeMock).toHaveBeenCalledOnce();
+    expect(createMock).toHaveBeenCalledOnce();
+    expect(resumed.state.sandboxId).toBe('sbx_recreated');
+  });
+
+  test('resume probes unnamed sandboxes via status() so a stale session triggers recreate', async () => {
+    const client = new TensorlakeSandboxClient();
+    const session = await client.create(new Manifest());
+    // Leave the session unnamed so resume() cannot use sandbox.resume().
+    const state = await client.deserializeSessionState(
+      await client.serializeSessionState(session.state),
+    );
+
+    connectMock.mockClear();
+    createMock.mockClear();
+    const statusMock = vi.fn().mockResolvedValue(undefined);
+    connectMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_test', { status: statusMock }),
+    );
+
+    const resumed = await client.resume(state);
+
+    expect(connectMock).toHaveBeenCalledOnce();
+    expect(statusMock).toHaveBeenCalledOnce();
+    expect(resumeMock).not.toHaveBeenCalled();
+    expect(createMock).not.toHaveBeenCalled();
+    expect(resumed.state.sandboxId).toBe('sbx_test');
+  });
+
+  test('resume recreates an unnamed sandbox when the status probe reports 404', async () => {
+    const client = new TensorlakeSandboxClient();
+    const session = await client.create(new Manifest());
+    const state = await client.deserializeSessionState(
+      await client.serializeSessionState(session.state),
+    );
+
+    connectMock.mockClear();
+    createMock.mockClear();
+    const notFound = Object.assign(new Error('sandbox not found'), {
+      status: 404,
+    });
+    const statusMock = vi.fn().mockRejectedValueOnce(notFound);
+    connectMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_test', { status: statusMock }),
+    );
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_recreated'));
+
+    const resumed = await client.resume(state);
+
+    expect(connectMock).toHaveBeenCalledOnce();
+    expect(statusMock).toHaveBeenCalledOnce();
+    expect(resumeMock).not.toHaveBeenCalled();
+    expect(createMock).toHaveBeenCalledOnce();
+    expect(resumed.state.sandboxId).toBe('sbx_recreated');
+  });
+
+  test('resume recreates an unnamed sandbox when status() returns "terminated"', async () => {
+    // Tensorlake's SDK does not throw for a terminated sandbox; status()
+    // returns the SandboxStatus enum value. The probe must treat that as
+    // dead so the recreate path runs.
+    const client = new TensorlakeSandboxClient();
+    const session = await client.create(new Manifest());
+    const state = await client.deserializeSessionState(
+      await client.serializeSessionState(session.state),
+    );
+
+    connectMock.mockClear();
+    createMock.mockClear();
+    const statusMock = vi.fn().mockResolvedValueOnce('terminated');
+    connectMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_test', { status: statusMock }),
+    );
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_recreated'));
+
+    const resumed = await client.resume(state);
+
+    expect(connectMock).toHaveBeenCalledOnce();
+    expect(statusMock).toHaveBeenCalledOnce();
+    expect(resumeMock).not.toHaveBeenCalled();
+    expect(createMock).toHaveBeenCalledOnce();
+    expect(resumed.state.sandboxId).toBe('sbx_recreated');
+  });
+
+  test('resume recreates a named sandbox when status() returns "terminated"', async () => {
+    // The SDK's resume() polls and throws SandboxError (not 404) when a
+    // sandbox reaches a terminated state, which would skip the recreate
+    // fallback. Probing status() first converts that into a tagged
+    // not-found error so the named-sandbox path also reaches recreate.
+    const client = new TensorlakeSandboxClient();
+    const session = await client.create(new Manifest());
+    session.state.name = 'demo';
+    const state = await client.deserializeSessionState(
+      await client.serializeSessionState(session.state),
+    );
+
+    connectMock.mockClear();
+    createMock.mockClear();
+    resumeMock.mockReset();
+    const statusMock = vi.fn().mockResolvedValueOnce('terminated');
+    connectMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_test', { name: 'demo', status: statusMock }),
+    );
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_recreated'));
+
+    const resumed = await client.resume(state);
+
+    expect(connectMock).toHaveBeenCalledOnce();
+    expect(statusMock).toHaveBeenCalledOnce();
+    expect(resumeMock).not.toHaveBeenCalled();
+    expect(createMock).toHaveBeenCalledOnce();
+    expect(resumed.state.sandboxId).toBe('sbx_recreated');
+  });
+
+  test('resume forwards configured apiKey to Sandbox.connect', async () => {
+    const client = new TensorlakeSandboxClient({
+      apiKey: 'secret-key',
+    } satisfies TensorlakeSandboxClientOptions);
+    const session = await client.create(new Manifest());
+    session.state.name = 'demo';
+    const state = await client.deserializeSessionState(
+      await client.serializeSessionState(session.state),
+    );
+
+    connectMock.mockClear();
+    connectMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_test', { name: 'demo' }),
+    );
+
+    await client.resume(state);
+
+    expect(connectMock).toHaveBeenCalledWith({
+      sandboxId: 'sbx_test',
+      apiKey: 'secret-key',
+    });
+  });
+
+  test('snapshot restore re-applies configured exposed ports via update()', async () => {
+    const client = new TensorlakeSandboxClient({
+      workspacePersistence: 'snapshot',
+      exposedPorts: [8080],
+    } satisfies TensorlakeSandboxClientOptions);
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_orig'));
+    const session = await client.create(new Manifest());
+
+    const archive = await session.persistWorkspace();
+
+    createMock.mockClear();
+    updateMock.mockClear();
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_restored'));
+
+    await session.hydrateWorkspace(archive);
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ snapshotId: 'snap_test' }),
+    );
+    // Sandbox.create does not accept exposedPorts.
+    expect(createMock.mock.calls[0]?.[0]).not.toHaveProperty('exposedPorts');
+    // The restored sandbox must have its ports re-applied via update().
+    expect(updateMock).toHaveBeenCalledWith({ exposedPorts: [8080] });
+  });
+
+  test('snapshot restore seeds sandbox id via info() before applying ports', async () => {
+    // Regression: Sandbox.create({ snapshotId }) can return an instance with
+    // an unpopulated sandboxId; info() seeds the SDK's internal cache that
+    // sandbox.update() relies on. resolveSandboxId() must run before
+    // applyPortConfiguration() so the port update has a usable id.
+    const client = new TensorlakeSandboxClient({
+      workspacePersistence: 'snapshot',
+      exposedPorts: [8080],
+    } satisfies TensorlakeSandboxClientOptions);
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_orig'));
+    const session = await client.create(new Manifest());
+
+    const archive = await session.persistWorkspace();
+
+    const callOrder: string[] = [];
+    const infoMock = vi.fn().mockImplementation(async () => {
+      callOrder.push('info');
+      return { sandboxId: 'sbx_restored' };
+    });
+    updateMock.mockClear();
+    updateMock.mockImplementation(async () => {
+      callOrder.push('update');
+    });
+    createMock.mockClear();
+    createMock.mockResolvedValueOnce(
+      makeSandboxInstance('', { info: infoMock }),
+    );
+
+    await session.hydrateWorkspace(archive);
+
+    expect(infoMock).toHaveBeenCalled();
+    expect(updateMock).toHaveBeenCalledWith({ exposedPorts: [8080] });
+    expect(callOrder).toEqual(['info', 'update']);
+    expect(session.state.sandboxId).toBe('sbx_restored');
+  });
+
+  test('snapshot restore terminates the previous unnamed sandbox', async () => {
+    // Unnamed sessions don't have a rename path, so the previous sandbox is
+    // still reachable on the backend after replaceSandboxFromSnapshot swaps
+    // in the new one. It must be terminated or it leaks quota.
+    const client = new TensorlakeSandboxClient({
+      workspacePersistence: 'snapshot',
+    } satisfies TensorlakeSandboxClientOptions);
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_orig'));
+    const session = await client.create(new Manifest());
+
+    const archive = await session.persistWorkspace();
+
+    createMock.mockClear();
+    terminateMock.mockClear();
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_restored'));
+
+    await session.hydrateWorkspace(archive);
+
+    expect(session.state.sandboxId).toBe('sbx_restored');
+    expect(terminateMock).toHaveBeenCalledOnce();
+  });
+
+  test('snapshot restore failure preserves the previous sandbox', async () => {
+    const client = new TensorlakeSandboxClient({
+      workspacePersistence: 'snapshot',
+    } satisfies TensorlakeSandboxClientOptions);
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_orig'));
+    const session = await client.create(new Manifest());
+
+    const archive = await session.persistWorkspace();
+
+    createMock.mockClear();
+    terminateMock.mockClear();
+    createMock.mockRejectedValueOnce(new Error('capacity exhausted'));
+
+    await expect(session.hydrateWorkspace(archive)).rejects.toBeInstanceOf(
+      SandboxProviderError,
+    );
+    // Previous sandbox must not be torn down when the restore fails — the
+    // session is still pointing at it and can keep running.
+    expect(terminateMock).not.toHaveBeenCalled();
+    expect(session.state.sandboxId).toBe('sbx_orig');
+  });
+
+  test('snapshot restore preserves the configured name via update()', async () => {
+    const client = new TensorlakeSandboxClient({
+      name: 'demo',
+      workspacePersistence: 'snapshot',
+      suspendOnExit: true,
+    } satisfies TensorlakeSandboxClientOptions);
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_orig'));
+    const session = await client.create(new Manifest());
+
+    const archive = await session.persistWorkspace();
+
+    createMock.mockClear();
+    updateMock.mockClear();
+    terminateMock.mockClear();
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_restored'));
+
+    await session.hydrateWorkspace(archive);
+
+    // Sandbox.create() must NOT pass the name (otherwise it would collide
+    // with the still-live previous sandbox).
+    expect(createMock.mock.calls[0]?.[0]).not.toHaveProperty('name');
+    // After create succeeds, the previous sandbox is terminated and the new
+    // one is renamed back to the configured name to preserve suspend/resume.
+    expect(terminateMock).toHaveBeenCalled();
+    expect(updateMock).toHaveBeenCalledWith({ name: 'demo' });
+    expect(session.state.name).toBe('demo');
+    // Named-lifecycle preserved → suspendOnExit stays true.
+    expect(session.state.suspendOnExit).toBe(true);
+  });
+
+  test('snapshot restore degrades to ephemeral when rename fails', async () => {
+    // logger.error is expected on this codepath.
+    allowConsole(['error']);
+    const client = new TensorlakeSandboxClient({
+      name: 'demo',
+      workspacePersistence: 'snapshot',
+      suspendOnExit: true,
+    } satisfies TensorlakeSandboxClientOptions);
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_orig'));
+    const session = await client.create(new Manifest());
+
+    const archive = await session.persistWorkspace();
+
+    createMock.mockClear();
+    updateMock.mockClear();
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_restored'));
+    // First update() is the rename; subsequent update() (e.g. port config)
+    // should still succeed.
+    updateMock.mockRejectedValueOnce(new Error('rename forbidden'));
+
+    await session.hydrateWorkspace(archive);
+
+    // Session adopts the ephemeral sandbox so the workspace isn't lost, but
+    // marks suspendOnExit false and clears the name so the broken named
+    // lifecycle is visible rather than silently degrading on close().
+    expect(session.state.sandboxId).toBe('sbx_restored');
+    expect(session.state.name).toBeUndefined();
+    expect(session.state.suspendOnExit).toBe(false);
+  });
+
+  test('throws SandboxProviderError when run() rejects unexpectedly', async () => {
+    const client = new TensorlakeSandboxClient();
+    const session = await client.create(new Manifest());
+    runMock.mockRejectedValueOnce(new Error('network down'));
+
+    await expect(
+      session.execCommand({ cmd: 'never-runs' }),
+    ).rejects.toBeInstanceOf(SandboxProviderError);
+  });
+
+  test('forwards control-plane and resource options to Sandbox.create', async () => {
+    const client = new TensorlakeSandboxClient({
+      diskMb: 8192,
+      startupTimeout: 120,
+      proxyUrl: 'https://proxy.tensorlake.dev',
+      apiUrl: 'https://api.tensorlake.dev',
+      namespace: 'default',
+      organizationId: 'org_123',
+      projectId: 'proj_456',
+      poolId: 'pool_warm',
+    } satisfies TensorlakeSandboxClientOptions);
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_cp'));
+
+    await client.create(new Manifest());
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        diskMb: 8192,
+        startupTimeout: 120,
+        proxyUrl: 'https://proxy.tensorlake.dev',
+        apiUrl: 'https://api.tensorlake.dev',
+        namespace: 'default',
+        organizationId: 'org_123',
+        projectId: 'proj_456',
+        poolId: 'pool_warm',
+      }),
+    );
+  });
+
+  test('snapshot restore drops poolId (snapshot takes precedence)', async () => {
+    // buildCreateOptions warns when poolId is dropped for snapshot restore.
+    allowConsole(['warn']);
+    const client = new TensorlakeSandboxClient({
+      workspacePersistence: 'snapshot',
+      poolId: 'pool_warm',
+    } satisfies TensorlakeSandboxClientOptions);
+    const session = await client.create(new Manifest());
+
+    const archive = await session.persistWorkspace();
+
+    createMock.mockClear();
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_restored'));
+    await session.hydrateWorkspace(archive);
+
+    const callArg = createMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(callArg.snapshotId).toBe('snap_test');
+    expect(callArg).not.toHaveProperty('poolId');
+  });
+
+  test('auto-generates a name when suspendOnExit is set without one', async () => {
+    const client = new TensorlakeSandboxClient({
+      suspendOnExit: true,
+    } satisfies TensorlakeSandboxClientOptions);
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_auto'));
+
+    const session = await client.create(new Manifest());
+
+    const callArg = createMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    const passedName = callArg.name as string | undefined;
+    expect(passedName).toBeTypeOf('string');
+    expect(passedName!.startsWith('openai-agents-')).toBe(true);
+    expect(session.state.name).toBe(passedName);
+  });
+
+  test('does not auto-name ephemeral sandboxes', async () => {
+    const client = new TensorlakeSandboxClient();
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_eph'));
+
+    await client.create(new Manifest());
+
+    const callArg = createMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(callArg).not.toHaveProperty('name');
+  });
+
+  test('forwards routingHint to Sandbox.connect on resume', async () => {
+    const client = new TensorlakeSandboxClient();
+    const session = await client.create(new Manifest());
+    session.state.name = 'demo';
+    session.state.routingHint = 'host-42';
+    const state = await client.deserializeSessionState(
+      await client.serializeSessionState(session.state),
+    );
+
+    connectMock.mockClear();
+    connectMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_test', { name: 'demo' }),
+    );
+
+    await client.resume(state);
+
+    expect(connectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sandboxId: 'sbx_test',
+        routingHint: 'host-42',
+      }),
+    );
+  });
+
+  test('respects custom timeouts on exec and manifest commands', async () => {
+    const client = new TensorlakeSandboxClient({
+      timeouts: {
+        execTimeoutUnboundedSecs: 60,
+        fastOpSecs: 5,
+        snapshotTarSecs: 120,
+      },
+    } satisfies TensorlakeSandboxClientOptions);
+
+    const session = await client.create(new Manifest());
+    runMock.mockClear();
+    await session.execCommand({ cmd: 'ls' });
+    expect(runMock).toHaveBeenLastCalledWith(
+      '/bin/bash',
+      expect.objectContaining({ timeout: 60 }),
+    );
+
+    // mkdir-style call (kind: 'manifest') should use fastOpSecs.
+    await session
+      .readFile({ path: '/home/tl-user/workspace/README.md' })
+      .catch(() => undefined);
+    // Confirm at least one previous call ran with timeout: 5.
+    const fastCalls = runMock.mock.calls.filter(
+      ([, opts]) => (opts as { timeout?: number }).timeout === 5,
+    );
+    expect(fastCalls.length).toBeGreaterThan(0);
+  });
+
+  test('rejects invalid timeouts at create()', async () => {
+    const client = new TensorlakeSandboxClient({
+      timeouts: { fastOpSecs: -1 },
+    } satisfies TensorlakeSandboxClientOptions);
+    await expect(client.create(new Manifest())).rejects.toThrow(/positive/);
+  });
+
+  test('retries the tar persist command on transient HTTP errors', async () => {
+    const client = new TensorlakeSandboxClient();
+    const session = await client.create(new Manifest());
+
+    // Pre-seed an empty (valid) tar archive at the path the persist flow uses,
+    // so that the post-tar readFile() succeeds.
+    const emptyTar = new Uint8Array(1024); // two zero blocks
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('.tar')) return emptyTar;
+      const value = remoteFiles.get(path);
+      if (!value) throw new Error(`not found: ${path}`);
+      return value;
+    });
+
+    let tarCalls = 0;
+    const baseRunMock = runMock.getMockImplementation()!;
+    runMock.mockImplementation(async (command, options) => {
+      const shellCommand = (options as { args?: string[] })?.args?.[1] ?? '';
+      // The shared persist combines `mkdir -p -- ... && tar ...` into one call.
+      if (
+        shellCommand.startsWith('mkdir -p -- ') &&
+        shellCommand.includes('tar ')
+      ) {
+        tarCalls += 1;
+        if (tarCalls === 1) {
+          throw Object.assign(new Error('upstream 503'), { status: 503 });
+        }
+      }
+      return await baseRunMock(command, options);
+    });
+
+    await session.persistWorkspace();
+    expect(tarCalls).toBeGreaterThanOrEqual(2);
+  });
+
+  test('hydrateWorkspace forwards per-call archiveLimits override to tar restore', async () => {
+    // Regression: the override used to be dropped, so per-call stricter
+    // limits and `archiveLimits: null` were both silently ignored.
+    const client = new TensorlakeSandboxClient();
+    const session = await client.create(new Manifest());
+
+    const archive = makeTarArchive([
+      { name: 'one.txt', content: '1' },
+      { name: 'two.txt', content: '22' },
+    ]);
+
+    await expect(
+      session.hydrateWorkspace(archive, {
+        archiveLimits: {
+          maxInputBytes: null,
+          maxExtractedBytes: null,
+          maxMembers: 1,
+        },
+      }),
+    ).rejects.toBeInstanceOf(SandboxArchiveError);
+  });
+
+  test('forwards runAs through to sandbox.run() for exec', async () => {
+    const client = new TensorlakeSandboxClient();
+    const session = await client.create(new Manifest());
+    runMock.mockClear();
+
+    await session.execCommand({ cmd: 'whoami', runAs: 'app' });
+
+    expect(runMock).toHaveBeenLastCalledWith(
+      '/bin/bash',
+      expect.objectContaining({
+        args: ['-lc', 'whoami'],
+        user: 'app',
+      }),
+    );
+  });
+
+  test('tty exec runAs is unsupported because the Tensorlake SDK has no user option', async () => {
+    const createPtyMock = vi.fn();
+    createMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_pty', { createPty: createPtyMock }),
+    );
+    const client = new TensorlakeSandboxClient();
+    const session = await client.create(new Manifest());
+
+    await expect(
+      session.execCommand({ cmd: 'ls', tty: true, runAs: 'app' }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+    expect(createPtyMock).not.toHaveBeenCalled();
+  });
+
+  test('resume prefers trusted constructor control-plane options over serialized state', async () => {
+    const createClient = new TensorlakeSandboxClient({
+      proxyUrl: 'https://create-proxy.tensorlake.dev',
+      apiUrl: 'https://create-api.tensorlake.dev',
+      namespace: 'create-namespace',
+      organizationId: 'org_create',
+      projectId: 'proj_create',
+      routingHint: 'create-host',
+    } satisfies TensorlakeSandboxClientOptions);
+    const session = await createClient.create(new Manifest());
+    session.state.name = 'demo';
+    const serialized = await createClient.serializeSessionState(session.state);
+
+    const resumeClient = new TensorlakeSandboxClient({
+      proxyUrl: 'https://trusted-proxy.tensorlake.dev',
+      apiUrl: 'https://trusted-api.tensorlake.dev',
+      namespace: 'trusted-namespace',
+      organizationId: 'org_trusted',
+      projectId: 'proj_trusted',
+      routingHint: 'trusted-host',
+      apiKey: 'trusted-key',
+    } satisfies TensorlakeSandboxClientOptions);
+    const state = await resumeClient.deserializeSessionState({
+      ...serialized,
+      proxyUrl: 'https://serialized-proxy.tensorlake.dev',
+      apiUrl: 'https://serialized-api.tensorlake.dev',
+      namespace: 'serialized-namespace',
+      organizationId: 'org_serialized',
+      projectId: 'proj_serialized',
+      routingHint: 'serialized-host',
+    });
+
+    connectMock.mockClear();
+    connectMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_test', { name: 'demo' }),
+    );
+
+    await resumeClient.resume(state);
+
+    expect(connectMock).toHaveBeenCalledWith({
+      sandboxId: 'sbx_test',
+      proxyUrl: 'https://trusted-proxy.tensorlake.dev',
+      apiUrl: 'https://trusted-api.tensorlake.dev',
+      namespace: 'trusted-namespace',
+      organizationId: 'org_trusted',
+      projectId: 'proj_trusted',
+      routingHint: 'trusted-host',
+      apiKey: 'trusted-key',
+    });
+  });
+
+  test('snapshot resume recreate prefers trusted constructor control-plane options', async () => {
+    allowConsole(['warn']);
+    const createClient = new TensorlakeSandboxClient({
+      workspacePersistence: 'snapshot',
+      poolId: 'serialized-pool',
+      proxyUrl: 'https://create-proxy.tensorlake.dev',
+    } satisfies TensorlakeSandboxClientOptions);
+    const session = await createClient.create(new Manifest());
+    session.state.name = 'demo';
+    await session.persistWorkspace();
+    const serialized = await createClient.serializeSessionState(session.state);
+
+    const resumeClient = new TensorlakeSandboxClient({
+      proxyUrl: 'https://trusted-proxy.tensorlake.dev',
+      apiUrl: 'https://trusted-api.tensorlake.dev',
+      namespace: 'trusted-namespace',
+      organizationId: 'org_trusted',
+      projectId: 'proj_trusted',
+      routingHint: 'trusted-host',
+      apiKey: 'trusted-key',
+    } satisfies TensorlakeSandboxClientOptions);
+    const state = await resumeClient.deserializeSessionState({
+      ...serialized,
+      proxyUrl: 'https://serialized-proxy.tensorlake.dev',
+      apiUrl: 'https://serialized-api.tensorlake.dev',
+      namespace: 'serialized-namespace',
+      organizationId: 'org_serialized',
+      projectId: 'proj_serialized',
+      routingHint: 'serialized-host',
+    });
+
+    connectMock.mockClear();
+    createMock.mockClear();
+    connectMock.mockRejectedValueOnce(
+      Object.assign(new Error('sandbox not found'), { status: 404 }),
+    );
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_from_snapshot'));
+
+    await resumeClient.resume(state);
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshotId: 'snap_test',
+        proxyUrl: 'https://trusted-proxy.tensorlake.dev',
+        apiUrl: 'https://trusted-api.tensorlake.dev',
+        namespace: 'trusted-namespace',
+        organizationId: 'org_trusted',
+        projectId: 'proj_trusted',
+        apiKey: 'trusted-key',
+      }),
+    );
+  });
+
+  test('resume recreate prefers trusted constructor sensitive fields over tampered state', async () => {
+    const createClient = new TensorlakeSandboxClient({
+      secretNames: ['SAFE_SECRET'],
+      allowInternetAccess: false,
+      allowOut: ['allowlist.example.com'],
+      denyOut: ['blocked.example.com'],
+      image: 'trusted/image:1.0',
+      entrypoint: ['/safe/entrypoint'],
+      exposedPorts: [8080],
+      allowUnauthenticatedAccess: false,
+    } satisfies TensorlakeSandboxClientOptions);
+    const session = await createClient.create(new Manifest());
+    session.state.name = 'demo';
+    const serialized = await createClient.serializeSessionState(session.state);
+
+    // Simulate a tampered/persisted payload that swaps every sensitive
+    // sandbox-config field for something the attacker would prefer.
+    const tampered = {
+      ...serialized,
+      secretNames: ['ATTACKER_SECRET', 'AWS_ACCESS_KEY_ID'],
+      allowInternetAccess: true,
+      allowOut: [],
+      denyOut: [],
+      image: 'attacker/image:latest',
+      entrypoint: ['/attacker/entrypoint'],
+      configuredExposedPorts: [22, 9999],
+      allowUnauthenticatedAccess: true,
+    };
+
+    const resumeClient = new TensorlakeSandboxClient({
+      secretNames: ['SAFE_SECRET'],
+      allowInternetAccess: false,
+      allowOut: ['allowlist.example.com'],
+      denyOut: ['blocked.example.com'],
+      image: 'trusted/image:1.0',
+      entrypoint: ['/safe/entrypoint'],
+      exposedPorts: [8080],
+      allowUnauthenticatedAccess: false,
+    } satisfies TensorlakeSandboxClientOptions);
+    const state = await resumeClient.deserializeSessionState(tampered);
+
+    connectMock.mockClear();
+    createMock.mockClear();
+    connectMock.mockRejectedValueOnce(
+      Object.assign(new Error('sandbox not found'), { status: 404 }),
+    );
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_recreated'));
+
+    await resumeClient.resume(state);
+
+    expect(createMock).toHaveBeenCalledOnce();
+    const passed = createMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(passed).toEqual(
+      expect.objectContaining({
+        secretNames: ['SAFE_SECRET'],
+        allowInternetAccess: false,
+        allowOut: ['allowlist.example.com'],
+        denyOut: ['blocked.example.com'],
+        image: 'trusted/image:1.0',
+        entrypoint: ['/safe/entrypoint'],
+      }),
+    );
+  });
+
+  test('snapshot resume recreate prefers trusted exposed-port / unauthenticated-access over tampered state', async () => {
+    allowConsole(['warn']);
+    const createClient = new TensorlakeSandboxClient({
+      workspacePersistence: 'snapshot',
+      exposedPorts: [8080],
+      allowUnauthenticatedAccess: false,
+    } satisfies TensorlakeSandboxClientOptions);
+    const session = await createClient.create(new Manifest());
+    session.state.name = 'demo';
+    await session.persistWorkspace();
+    const serialized = await createClient.serializeSessionState(session.state);
+
+    // Tamper the persisted port config so a resume that picks up this state
+    // would re-expose attacker-controlled ports / disable auth — unless the
+    // trusted in-process options win.
+    const tampered = {
+      ...serialized,
+      configuredExposedPorts: [22, 9999],
+      allowUnauthenticatedAccess: true,
+    };
+
+    const resumeClient = new TensorlakeSandboxClient({
+      workspacePersistence: 'snapshot',
+      exposedPorts: [8080],
+      allowUnauthenticatedAccess: false,
+    } satisfies TensorlakeSandboxClientOptions);
+    const state = await resumeClient.deserializeSessionState(tampered);
+
+    connectMock.mockClear();
+    createMock.mockClear();
+    updateMock.mockClear();
+    connectMock.mockRejectedValueOnce(
+      Object.assign(new Error('sandbox not found'), { status: 404 }),
+    );
+    const restored = makeSandboxInstance('sbx_resumed');
+    createMock.mockResolvedValueOnce(restored);
+
+    const resumed = await resumeClient.resume(state);
+
+    // Live sandbox must be configured from trusted options, not tampered
+    // state — port 22 / 9999 / allowUnauthenticatedAccess:true must not leak
+    // through into the update() call against the restored sandbox.
+    expect(updateMock).toHaveBeenCalledWith({
+      exposedPorts: [8080],
+      allowUnauthenticatedAccess: false,
+    });
+    expect(updateMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ exposedPorts: [22, 9999] }),
+    );
+    // The session's port cache must also reflect trusted values so a later
+    // resolveExposedPort() doesn't trust the tampered set.
+    expect(resumed.state.configuredExposedPorts).toEqual([8080]);
+    expect(resumed.state.allowUnauthenticatedAccess).toBe(false);
+  });
+
+  test('resume connect normalizes tampered exposed-port cache against trusted options', async () => {
+    // Even on the connect path the live sandbox is not reconfigured, but the
+    // session's port-cache must reflect trusted values — otherwise a later
+    // on-demand resolveExposedPort() would push the attacker's ports through
+    // sandbox.update() under the cover of a user-requested port change.
+    const createClient = new TensorlakeSandboxClient({
+      exposedPorts: [8080],
+    } satisfies TensorlakeSandboxClientOptions);
+    const session = await createClient.create(new Manifest());
+    session.state.name = 'demo';
+    const serialized = await createClient.serializeSessionState(session.state);
+
+    const tampered = {
+      ...serialized,
+      configuredExposedPorts: [22, 9999],
+    };
+
+    const resumeClient = new TensorlakeSandboxClient({
+      exposedPorts: [8080],
+    } satisfies TensorlakeSandboxClientOptions);
+    const state = await resumeClient.deserializeSessionState(tampered);
+
+    connectMock.mockClear();
+    updateMock.mockClear();
+    connectMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_test', { name: 'demo' }),
+    );
+
+    const resumed = await resumeClient.resume(state);
+
+    expect(resumed.state.configuredExposedPorts).toEqual([8080]);
+    // Asking for a new port should merge against the trusted set, not the
+    // tampered one.
+    await resumed.resolveExposedPort(7000);
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ exposedPorts: [8080, 7000] }),
+    );
+  });
+
+  test('resume recreate falls back to state sensitive fields when constructor leaves them unset', async () => {
+    const createClient = new TensorlakeSandboxClient({
+      secretNames: ['LEGIT_SECRET'],
+      allowOut: ['legit.example.com'],
+    } satisfies TensorlakeSandboxClientOptions);
+    const session = await createClient.create(new Manifest());
+    session.state.name = 'demo';
+    const serialized = await createClient.serializeSessionState(session.state);
+
+    // resumeClient supplies no sensitive options, so state values must
+    // flow through to the recreate.
+    const resumeClient = new TensorlakeSandboxClient();
+    const state = await resumeClient.deserializeSessionState(serialized);
+
+    connectMock.mockClear();
+    createMock.mockClear();
+    connectMock.mockRejectedValueOnce(
+      Object.assign(new Error('sandbox not found'), { status: 404 }),
+    );
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_recreated'));
+
+    await resumeClient.resume(state);
+
+    const passed = createMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(passed).toEqual(
+      expect.objectContaining({
+        secretNames: ['LEGIT_SECRET'],
+        allowOut: ['legit.example.com'],
+      }),
+    );
+  });
+
+  test("resume recreate preserves manifestIdentities: 'provision' from state", async () => {
+    // A session created in 'provision' mode and then resumed by a fresh
+    // client (which did not repeat the option) must still recreate in
+    // 'provision' mode — otherwise manifest application silently drops back
+    // to 'collapse' and skips account provisioning on the custom image.
+    const manifest = new Manifest({
+      users: [{ name: 'alice' }],
+      groups: [{ name: 'staff', users: [{ name: 'alice' }] }],
+    });
+    const createClient = new TensorlakeSandboxClient({
+      manifestIdentities: 'provision',
+    } satisfies TensorlakeSandboxClientOptions);
+    const session = await createClient.create(manifest);
+    session.state.name = 'demo';
+
+    const resumeClient = new TensorlakeSandboxClient();
+    const state = await resumeClient.deserializeSessionState(
+      await createClient.serializeSessionState(session.state),
+    );
+
+    // Force the fallback recreate path and discard create-time shell calls
+    // so the assertions below only count what fired during resume.
+    connectMock.mockClear();
+    createMock.mockClear();
+    runMock.mockClear();
+    connectMock.mockRejectedValueOnce(
+      Object.assign(new Error('sandbox not found'), { status: 404 }),
+    );
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_recreated'));
+
+    const resumed = await resumeClient.resume(state);
+    expect(resumed.state.manifestIdentities).toBe('provision');
+
+    const shellCommands = runMock.mock.calls
+      .map(([, opts]) => (opts as { args?: string[] })?.args?.[1] ?? '')
+      .filter((s) => s.length > 0);
+    expect(shellCommands.some((c) => c.includes('groupadd'))).toBe(true);
+    expect(shellCommands.some((c) => c.includes('useradd'))).toBe(true);
+  });
+
+  test('uses native sandbox.run for mkdir on prepareWorkspaceRoot', async () => {
+    const client = new TensorlakeSandboxClient();
+    runMock.mockClear();
+
+    await client.create(new Manifest());
+
+    // The first mkdir matches the manifest root; assert it goes through
+    // sandbox.run('mkdir', { args: ['-p', '--', root] }) not a shell wrap.
+    const mkdirCalls = runMock.mock.calls.filter(([cmd]) => cmd === 'mkdir');
+    expect(mkdirCalls.length).toBeGreaterThanOrEqual(1);
+    expect(mkdirCalls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        args: ['-p', '--', '/home/tl-user/workspace'],
+      }),
+    );
+  });
+
+  test('persistWorkspace caches snapshotId on state for resume fast-path', async () => {
+    const client = new TensorlakeSandboxClient({
+      workspacePersistence: 'snapshot',
+    } satisfies TensorlakeSandboxClientOptions);
+    const session = await client.create(new Manifest());
+
+    expect(session.state.snapshotId).toBeUndefined();
+    await session.persistWorkspace();
+    expect(session.state.snapshotId).toBe('snap_test');
+  });
+
+  test('persistWorkspaceTar invalidates a cached snapshotId', async () => {
+    // Mixing snapshot + tar persistence within a single session is unusual,
+    // but the cached snapshotId must not survive a tar persist — otherwise
+    // resume would restore stale state.
+    const client = new TensorlakeSandboxClient({
+      workspacePersistence: 'snapshot',
+    } satisfies TensorlakeSandboxClientOptions);
+    const session = await client.create(new Manifest());
+    await session.persistWorkspace();
+    expect(session.state.snapshotId).toBe('snap_test');
+
+    // Switch to tar mode and persist again.
+    session.state.workspacePersistence = 'tar';
+    const emptyTar = new Uint8Array(1024);
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('.tar')) return emptyTar;
+      const value = remoteFiles.get(path);
+      if (!value) throw new Error(`not found: ${path}`);
+      return value;
+    });
+
+    await session.persistWorkspace();
+    expect(session.state.snapshotId).toBeUndefined();
+  });
+
+  test('execCommand invalidates cached snapshotId post-snapshot', async () => {
+    // After persistWorkspace caches a snapshotId, an exec that may have
+    // mutated the workspace must clear the cache. Otherwise resume()'s
+    // fast-path would silently restore the pre-mutation snapshot if the live
+    // sandbox dies. Callers wanting partial recovery can still pass the
+    // archive bytes to hydrateWorkspace() on the new session.
+    const client = new TensorlakeSandboxClient({
+      workspacePersistence: 'snapshot',
+    } satisfies TensorlakeSandboxClientOptions);
+    const session = await client.create(new Manifest());
+    await session.persistWorkspace();
+    expect(session.state.snapshotId).toBe('snap_test');
+
+    await session.execCommand({ cmd: 'ls' });
+    expect(session.state.snapshotId).toBeUndefined();
+  });
+
+  test('resume recreates from cached snapshotId without applyManifest', async () => {
+    // The fast-path: when reconnect fails on a snapshot-persisted session,
+    // resume() should create directly with snapshotId rather than building a
+    // fresh sandbox and then having hydrateWorkspace tear it down. Confirm
+    // that (a) Sandbox.create receives snapshotId, (b) no shell `groupadd`
+    // or `useradd` round-trip fires (system preserved), and (c) the session
+    // does not redo the workspace-root mkdir on later prepareWorkspaceRoot.
+    const client = new TensorlakeSandboxClient({
+      workspacePersistence: 'snapshot',
+    } satisfies TensorlakeSandboxClientOptions);
+    const session = await client.create(new Manifest());
+    session.state.name = 'demo';
+    await session.persistWorkspace();
+    const state = await client.deserializeSessionState(
+      await client.serializeSessionState(session.state),
+    );
+    expect(state.snapshotId).toBe('snap_test');
+
+    connectMock.mockClear();
+    createMock.mockClear();
+    runMock.mockClear();
+    const notFound = Object.assign(new Error('sandbox not found'), {
+      status: 404,
+    });
+    connectMock.mockRejectedValueOnce(notFound);
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_from_snapshot'));
+
+    const resumed = await client.resume(state);
+
+    expect(createMock).toHaveBeenCalledOnce();
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ snapshotId: 'snap_test' }),
+    );
+    expect(resumed.state.sandboxId).toBe('sbx_from_snapshot');
+    // The snapshot image carries the workspace root + manifest accounts.
+    expect(resumed.state.workspaceRootProvisioned).toBe(true);
+    expect(resumed.state.systemSetupPreserved).toBe(true);
+
+    // A follow-up prepareWorkspaceRoot must not re-issue mkdir.
+    runMock.mockClear();
+    await resumed.prepareWorkspaceRoot();
+    const mkdirAfter = runMock.mock.calls.filter(([cmd]) => cmd === 'mkdir');
+    expect(mkdirAfter).toHaveLength(0);
+  });
+
+  test('resume falls back to fresh create when the cached snapshotId is gone', async () => {
+    // If the stored snapshot has been pruned on the backend, the fast-path
+    // surfaces a 404 from Sandbox.create({ snapshotId }). The resume should
+    // then continue with a normal fresh recreate rather than throwing.
+    allowConsole(['warn']);
+    const client = new TensorlakeSandboxClient({
+      workspacePersistence: 'snapshot',
+    } satisfies TensorlakeSandboxClientOptions);
+    const session = await client.create(new Manifest());
+    session.state.name = 'demo';
+    await session.persistWorkspace();
+    const state = await client.deserializeSessionState(
+      await client.serializeSessionState(session.state),
+    );
+
+    connectMock.mockClear();
+    createMock.mockClear();
+    const notFound = Object.assign(new Error('sandbox not found'), {
+      status: 404,
+    });
+    connectMock.mockRejectedValueOnce(notFound);
+    createMock.mockRejectedValueOnce(
+      Object.assign(new Error('snapshot expired'), { status: 404 }),
+    );
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_fresh'));
+
+    const resumed = await client.resume(state);
+
+    expect(createMock).toHaveBeenCalledTimes(2);
+    // First create attempt used snapshotId; second was a fresh recreate.
+    expect(createMock.mock.calls[0]?.[0]).toHaveProperty(
+      'snapshotId',
+      'snap_test',
+    );
+    expect(createMock.mock.calls[1]?.[0]).not.toHaveProperty('snapshotId');
+    expect(resumed.state.sandboxId).toBe('sbx_fresh');
+  });
+
+  test('snapshot-resume fast-path drops the previous sandbox exposed-port cache', async () => {
+    // Regression: resolveExposedPort caches the resolved URL on
+    // state.exposedPorts (keyed by port). The snapshot fast-path used to
+    // spread the prior state verbatim into the resumed session, so a port
+    // resolved on the old sandbox would return the deleted sandbox's URL
+    // forever — useCachedExposedPortEndpoint() returns true by default.
+    const client = new TensorlakeSandboxClient({
+      workspacePersistence: 'snapshot',
+      exposedPorts: [8080],
+    } satisfies TensorlakeSandboxClientOptions);
+    const session = await client.create(new Manifest());
+    // Unnamed: the fallback URL template embeds sandboxId, so a stale cache
+    // is observable without depending on info().sandbox_url plumbing.
+    const originalEndpoint = await session.resolveExposedPort(8080);
+    expect(originalEndpoint.url).toContain('sbx_test');
+    expect(session.state.exposedPorts).toBeDefined();
+
+    await session.persistWorkspace();
+    const state = await client.deserializeSessionState(
+      await client.serializeSessionState(session.state),
+    );
+    // The bug premise: the stale cache survives serialization.
+    expect(state.exposedPorts).toBeDefined();
+    expect(state.snapshotId).toBe('snap_test');
+
+    connectMock.mockClear();
+    createMock.mockClear();
+    updateMock.mockClear();
+    const notFound = Object.assign(new Error('sandbox not found'), {
+      status: 404,
+    });
+    connectMock.mockRejectedValueOnce(notFound);
+    createMock.mockResolvedValueOnce(makeSandboxInstance('sbx_resumed'));
+
+    const resumed = await client.resume(state);
+
+    expect(resumed.state.sandboxId).toBe('sbx_resumed');
+    // The cache for the deleted sandbox must be cleared so the next
+    // resolveExposedPort() re-resolves against the restored sandbox.
+    expect(resumed.state.exposedPorts).toBeUndefined();
+    const newEndpoint = await resumed.resolveExposedPort(8080);
+    expect(newEndpoint.url).toContain('sbx_resumed');
+    expect(newEndpoint.url).not.toContain('sbx_test');
+  });
+
+  test('reconnect marks workspace + system state preserved', async () => {
+    const client = new TensorlakeSandboxClient();
+    const session = await client.create(new Manifest());
+    session.state.name = 'demo';
+    const state = await client.deserializeSessionState(
+      await client.serializeSessionState(session.state),
+    );
+
+    connectMock.mockClear();
+    connectMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_test', { name: 'demo' }),
+    );
+
+    const resumed = await client.resume(state);
+    expect(resumed.state.workspaceRootProvisioned).toBe(true);
+    expect(resumed.state.systemSetupPreserved).toBe(true);
+  });
+
+  test('falls back to public template (with warning) when custom proxyUrl deployment lacks sandbox_url', async () => {
+    // The fallback emits a warn so callers know the public template likely
+    // won't route to their custom deployment.
+    allowConsole(['warn']);
+    const infoMock = vi.fn().mockResolvedValue({ sandboxId: 'sbx_custom' });
+    createMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_custom', {
+        name: 'demo',
+        info: infoMock,
+      }),
+    );
+    const client = new TensorlakeSandboxClient({
+      proxyUrl: 'https://proxy.tensorlake.dev',
+      exposedPorts: [8080],
+    } satisfies TensorlakeSandboxClientOptions);
+    const session = await client.create(new Manifest());
+    const endpoint = await session.resolveExposedPort(8080);
+    expect(endpoint.url).toContain('https://8080-demo.sandbox.tensorlake.ai');
+  });
+
+  test('deserializeSessionState rejects an invalid workspacePersistence value', async () => {
+    const client = new TensorlakeSandboxClient();
+    await expect(
+      client.deserializeSessionState({
+        sandboxId: 'sbx_test',
+        workspacePersistence: 'bogus',
+      }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+  });
+
+  test('deserializeSessionState rejects an invalid snapshotCheckpointType value', async () => {
+    const client = new TensorlakeSandboxClient();
+    await expect(
+      client.deserializeSessionState({
+        sandboxId: 'sbx_test',
+        snapshotCheckpointType: 'bogus',
+      }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+  });
+
+  test('tty exec without SDK PTY support throws SandboxUnsupportedFeatureError', async () => {
+    const client = new TensorlakeSandboxClient();
+    const session = await client.create(new Manifest());
+    await expect(
+      session.execCommand({ cmd: 'ls', tty: true }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+  });
+
+  test('on-demand exposed port without sandbox.update throws SandboxUnsupportedFeatureError', async () => {
+    createMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_no_update', { update: undefined }),
+    );
+    const client = new TensorlakeSandboxClient();
+    const session = await client.create(new Manifest());
+
+    await expect(session.resolveExposedPort(9090)).rejects.toBeInstanceOf(
+      SandboxUnsupportedFeatureError,
+    );
+  });
+
+  test('on-demand exposed port wraps update() errors in SandboxProviderError', async () => {
+    const client = new TensorlakeSandboxClient();
+    const session = await client.create(new Manifest());
+    updateMock.mockRejectedValueOnce(new Error('rate limited'));
+
+    await expect(session.resolveExposedPort(9090)).rejects.toBeInstanceOf(
+      SandboxProviderError,
+    );
+  });
+
+  test('suspend + terminate both failing during close raises SandboxProviderError', async () => {
+    suspendMock.mockRejectedValueOnce(new Error('suspend boom'));
+    terminateMock.mockRejectedValueOnce(new Error('terminate boom'));
+    const client = new TensorlakeSandboxClient({
+      name: 'demo',
+      suspendOnExit: true,
+    } satisfies TensorlakeSandboxClientOptions);
+    const session = await client.create(new Manifest());
+
+    await expect(session.close()).rejects.toBeInstanceOf(SandboxProviderError);
+    expect(suspendMock).toHaveBeenCalledOnce();
+    expect(terminateMock).toHaveBeenCalledOnce();
+  });
+
+  test.each([
+    {
+      label: 'SDK rejection',
+      outcome: () => Promise.reject(new Error('disk full')),
+    },
+    {
+      label: 'non-zero exit',
+      outcome: () =>
+        Promise.resolve({
+          stdout: '',
+          stderr: 'mkdir: permission denied',
+          exitCode: 1,
+        }),
+    },
+  ])(
+    'create() surfaces mkdir $label as SandboxProviderError',
+    async ({ outcome }) => {
+      const client = new TensorlakeSandboxClient();
+      runMock.mockImplementation(async (command: string) =>
+        command === 'mkdir'
+          ? await outcome()
+          : { stdout: '', stderr: '', exitCode: 0 },
+      );
+
+      await expect(client.create(new Manifest())).rejects.toBeInstanceOf(
+        SandboxProviderError,
+      );
+    },
+  );
+
+  test('readFile surfaces missing remote files as UserError', async () => {
+    const client = new TensorlakeSandboxClient();
+    const session = await client.create(new Manifest());
+    readFileMock.mockRejectedValueOnce(new Error('not found'));
+
+    await expect(
+      session.readFile({ path: '/home/tl-user/workspace/missing.txt' }),
+    ).rejects.toBeInstanceOf(UserError);
+  });
+});

--- a/packages/agents-extensions/test/sandbox/tensorlake.test.ts
+++ b/packages/agents-extensions/test/sandbox/tensorlake.test.ts
@@ -479,6 +479,27 @@ describe('TensorlakeSandboxClient', () => {
     expect(endpoint.url).toContain('https://8080-demo.sandbox.tensorlake.ai');
   });
 
+  test('fallback derives the proxy host from a custom apiUrl (api.X -> sandbox.X)', async () => {
+    // No explicit proxyUrl: the SDK derives the proxy host from apiUrl, so the
+    // fallback must mirror that instead of emitting the public default.
+    allowConsole(['warn']);
+    const infoMock = vi.fn().mockResolvedValue({ sandboxId: 'sbx_api' });
+    createMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_api', {
+        name: 'demo',
+        info: infoMock,
+      }),
+    );
+    const client = new TensorlakeSandboxClient({
+      exposedPorts: [8080],
+      apiUrl: 'https://api.mycorp.example',
+    } satisfies TensorlakeSandboxClientOptions);
+    const session = await client.create(new Manifest());
+
+    const endpoint = await session.resolveExposedPort(8080);
+    expect(endpoint.url).toContain('https://8080-demo.sandbox.mycorp.example');
+  });
+
   test('seeds sandbox id via info() when create returns it unpopulated', async () => {
     const infoMock = vi.fn().mockResolvedValue({ sandboxId: 'sbx_from_info' });
     // Empty sandboxId from create simulates the snapshot-restore lazy-id path.
@@ -1852,9 +1873,9 @@ describe('TensorlakeSandboxClient', () => {
     expect(resumed.state.systemSetupPreserved).toBe(true);
   });
 
-  test('falls back to public template (with warning) when custom proxyUrl deployment lacks sandbox_url', async () => {
-    // The fallback emits a warn so callers know the public template likely
-    // won't route to their custom deployment.
+  test('falls back to the configured proxy host (with warning) when custom proxyUrl deployment lacks sandbox_url', async () => {
+    // The fallback uses the configured proxyUrl host and emits a warn so callers
+    // know the subdomain template may not route to their custom deployment.
     allowConsole(['warn']);
     const infoMock = vi.fn().mockResolvedValue({ sandboxId: 'sbx_custom' });
     createMock.mockResolvedValueOnce(
@@ -1869,7 +1890,7 @@ describe('TensorlakeSandboxClient', () => {
     } satisfies TensorlakeSandboxClientOptions);
     const session = await client.create(new Manifest());
     const endpoint = await session.resolveExposedPort(8080);
-    expect(endpoint.url).toContain('https://8080-demo.sandbox.tensorlake.ai');
+    expect(endpoint.url).toContain('https://8080-demo.proxy.tensorlake.dev');
   });
 
   test('deserializeSessionState rejects an invalid workspacePersistence value', async () => {

--- a/packages/agents-extensions/test/sandbox/tensorlake.test.ts
+++ b/packages/agents-extensions/test/sandbox/tensorlake.test.ts
@@ -164,7 +164,7 @@ describe('TensorlakeSandboxClient', () => {
     expect(createMock).not.toHaveBeenCalled();
   });
 
-  test("collapses manifest identities to tl-user by default and warns once", async () => {
+  test('collapses manifest identities to tl-user by default and warns once', async () => {
     // Default Tensorlake image only ships `tl-user` and no root; the provider
     // accepts user/group declarations at validation time but skips the
     // privileged commands at apply time. The caller should hear about it via
@@ -203,9 +203,10 @@ describe('TensorlakeSandboxClient', () => {
     expect(shellCommands.some((c) => c.includes('chown'))).toBe(false);
     expect(shellCommands.some((c) => c.includes('chgrp'))).toBe(false);
     expect(
-      shellCommands.some((c) =>
-        c.startsWith(`chmod `) &&
-        c.includes(`/home/tl-user/workspace/config.json`),
+      shellCommands.some(
+        (c) =>
+          c.startsWith(`chmod `) &&
+          c.includes(`/home/tl-user/workspace/config.json`),
       ),
     ).toBe(true);
 
@@ -269,9 +270,9 @@ describe('TensorlakeSandboxClient', () => {
         manifestIdentities,
       } satisfies TensorlakeSandboxClientOptions);
       const session = await client.create(new Manifest());
-      await expect(session.applyManifest(new Manifest(), 'alice')).rejects.toBeInstanceOf(
-        SandboxUnsupportedFeatureError,
-      );
+      await expect(
+        session.applyManifest(new Manifest(), 'alice'),
+      ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
     }
   });
 
@@ -1457,6 +1458,49 @@ describe('TensorlakeSandboxClient', () => {
     );
   });
 
+  test('deserialize drops tampered exposed-port endpoint cache before resume', async () => {
+    const createClient = new TensorlakeSandboxClient({
+      exposedPorts: [8080],
+    } satisfies TensorlakeSandboxClientOptions);
+    const session = await createClient.create(new Manifest());
+    session.state.name = 'demo';
+    const serialized = await createClient.serializeSessionState(session.state);
+
+    const tampered = {
+      ...serialized,
+      exposedPorts: {
+        '8080': {
+          host: 'attacker.example.com',
+          port: 8080,
+          tls: true,
+          url: 'https://attacker.example.com',
+        },
+      },
+    };
+
+    const resumeClient = new TensorlakeSandboxClient({
+      exposedPorts: [8080],
+    } satisfies TensorlakeSandboxClientOptions);
+    const state = await resumeClient.deserializeSessionState(tampered);
+
+    expect(state.exposedPorts).toBeUndefined();
+
+    const infoMock = vi.fn().mockResolvedValue({
+      sandbox_url: 'https://trusted-proxy.tensorlake.dev',
+    });
+    connectMock.mockClear();
+    connectMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_test', { name: 'demo', info: infoMock }),
+    );
+
+    const resumed = await resumeClient.resume(state);
+    const endpoint = await resumed.resolveExposedPort(8080);
+
+    expect(endpoint.url).toContain('https://8080-trusted-proxy.tensorlake.dev');
+    expect(endpoint.url).not.toContain('attacker.example.com');
+    expect(resumed.state.exposedPorts?.['8080']).toBe(endpoint);
+  });
+
   test('resume recreate falls back to state sensitive fields when constructor leaves them unset', async () => {
     const createClient = new TensorlakeSandboxClient({
       secretNames: ['LEGIT_SECRET'],
@@ -1599,6 +1643,25 @@ describe('TensorlakeSandboxClient', () => {
     expect(session.state.snapshotId).toBeUndefined();
   });
 
+  test('running() liveness probe preserves cached snapshotId', async () => {
+    // running() / pathExists() are read-only probes (`true` / `test -e`),
+    // so they must not invalidate the cached snapshot — otherwise a routine
+    // health check on a snapshot-backed session would force a clean recreate
+    // on later resume and silently drop persisted workspace state.
+    const client = new TensorlakeSandboxClient({
+      workspacePersistence: 'snapshot',
+    } satisfies TensorlakeSandboxClientOptions);
+    const session = await client.create(new Manifest());
+    await session.persistWorkspace();
+    expect(session.state.snapshotId).toBe('snap_test');
+
+    await session.running();
+    expect(session.state.snapshotId).toBe('snap_test');
+
+    await session.pathExists('/home/tl-user/workspace');
+    expect(session.state.snapshotId).toBe('snap_test');
+  });
+
   test('resume recreates from cached snapshotId without applyManifest', async () => {
     // The fast-path: when reconnect fails on a snapshot-persisted session,
     // resume() should create directly with snapshotId rather than building a
@@ -1703,8 +1766,15 @@ describe('TensorlakeSandboxClient', () => {
     const state = await client.deserializeSessionState(
       await client.serializeSessionState(session.state),
     );
-    // The bug premise: the stale cache survives serialization.
-    expect(state.exposedPorts).toBeDefined();
+    expect(state.exposedPorts).toBeUndefined();
+    state.exposedPorts = {
+      '8080': {
+        host: 'sbx_test.sandbox.tensorlake.ai',
+        port: 8080,
+        tls: true,
+        url: originalEndpoint.url,
+      },
+    };
     expect(state.snapshotId).toBe('snap_test');
 
     connectMock.mockClear();

--- a/packages/agents-extensions/test/sandbox/tensorlake.test.ts
+++ b/packages/agents-extensions/test/sandbox/tensorlake.test.ts
@@ -1247,6 +1247,43 @@ describe('TensorlakeSandboxClient', () => {
     });
   });
 
+  test('resume drops tampered control-plane URLs from state when constructor leaves them unset', async () => {
+    // Routing URLs are control-plane endpoints: a tampered resume must not be
+    // able to redirect connect() to an attacker host and pair it with the
+    // trusted apiKey. Unlike namespace/org/project (scoping within the same
+    // endpoint), proxyUrl/apiUrl change the destination, so — like apiKey —
+    // they are never trusted from persisted state and only restored from
+    // constructor options.
+    const createClient = new TensorlakeSandboxClient();
+    const session = await createClient.create(new Manifest());
+    session.state.name = 'demo';
+    const serialized = await createClient.serializeSessionState(session.state);
+
+    // resumeClient supplies a trusted apiKey but no routing URLs.
+    const resumeClient = new TensorlakeSandboxClient({ apiKey: 'trusted-key' });
+    const state = await resumeClient.deserializeSessionState({
+      ...serialized,
+      proxyUrl: 'https://attacker-proxy.example.com',
+      apiUrl: 'https://attacker-api.example.com',
+    });
+
+    // Cleared at the deserialize boundary, before resume even runs.
+    expect(state.proxyUrl).toBeUndefined();
+    expect(state.apiUrl).toBeUndefined();
+
+    connectMock.mockClear();
+    connectMock.mockResolvedValueOnce(
+      makeSandboxInstance('sbx_test', { name: 'demo' }),
+    );
+
+    await resumeClient.resume(state);
+
+    const passed = connectMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(passed).not.toHaveProperty('proxyUrl');
+    expect(passed).not.toHaveProperty('apiUrl');
+    expect(passed.apiKey).toBe('trusted-key');
+  });
+
   test('snapshot resume recreate prefers trusted constructor control-plane options', async () => {
     allowConsole(['warn']);
     const createClient = new TensorlakeSandboxClient({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,10 +226,10 @@ importers:
         version: 1.1.3
       '@openai/agents':
         specifier: 0.3.9
-        version: 0.3.9(ws@8.18.2)(zod@3.25.76)
+        version: 0.3.9(ws@8.20.1)(zod@3.25.76)
       '@openai/agents-extensions':
         specifier: 0.3.9
-        version: 0.3.9(@openai/agents@0.3.9(ws@8.18.2)(zod@3.25.76))(@openai/codex-sdk@0.86.0)(ws@8.18.2)(zod@3.25.76)
+        version: 0.3.9(@openai/agents@0.3.9(ws@8.20.1)(zod@3.25.76))(@openai/codex-sdk@0.86.0)(ws@8.20.1)(zod@3.25.76)
       hono:
         specifier: ^4.12.16
         version: 4.12.16
@@ -244,7 +244,7 @@ importers:
         version: link:../../packages/agents
       openai:
         specifier: ^6.35.0
-        version: 6.35.0(ws@8.18.2)(zod@4.3.5)
+        version: 6.35.0(ws@8.20.1)(zod@4.3.5)
       zod:
         specifier: ^4.0.0
         version: 4.3.5
@@ -289,7 +289,7 @@ importers:
         version: link:../../packages/agents-realtime
       openai:
         specifier: ^6.35.0
-        version: 6.35.0(ws@8.18.2)(zod@4.3.5)
+        version: 6.35.0(ws@8.20.1)(zod@4.3.5)
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
@@ -357,7 +357,7 @@ importers:
         version: link:../../packages/agents
       openai:
         specifier: ^6.35.0
-        version: 6.35.0(ws@8.18.2)(zod@4.3.5)
+        version: 6.35.0(ws@8.20.1)(zod@4.3.5)
       zod:
         specifier: ^4.0.0
         version: 4.3.5
@@ -436,7 +436,7 @@ importers:
         version: 4.1.10(vite@6.4.2(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.8.3))
       openai:
         specifier: ^6.35.0
-        version: 6.35.0(ws@8.18.2)(zod@4.3.5)
+        version: 6.35.0(ws@8.20.1)(zod@4.3.5)
       tailwindcss:
         specifier: ^4.1.7
         version: 4.1.10
@@ -552,7 +552,7 @@ importers:
         version: 5.0.0
       openai:
         specifier: ^6.35.0
-        version: 6.35.0(ws@8.18.2)(zod@4.3.5)
+        version: 6.35.0(ws@8.20.1)(zod@4.3.5)
       zod:
         specifier: ^4.0.0
         version: 4.3.5
@@ -597,7 +597,7 @@ importers:
         version: 5.6.2
       openai:
         specifier: ^6.35.0
-        version: 6.35.0(ws@8.18.2)(zod@4.3.5)
+        version: 6.35.0(ws@8.20.1)(zod@4.3.5)
       playwright:
         specifier: ^1.55.1
         version: 1.57.0
@@ -621,7 +621,7 @@ importers:
         version: 4.4.1
       openai:
         specifier: ^6.35.0
-        version: 6.35.0(ws@8.18.2)(zod@4.3.5)
+        version: 6.35.0(ws@8.20.1)(zod@4.3.5)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -637,7 +637,7 @@ importers:
         version: 4.4.1
       openai:
         specifier: ^6.35.0
-        version: 6.35.0(ws@8.18.2)(zod@4.3.5)
+        version: 6.35.0(ws@8.20.1)(zod@4.3.5)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -698,6 +698,9 @@ importers:
       modal:
         specifier: 0.7.4
         version: 0.7.4
+      tensorlake:
+        specifier: 0.5.14
+        version: 0.5.14
       undici-types:
         specifier: 6.21.0
         version: 6.21.0
@@ -718,7 +721,7 @@ importers:
         version: 4.4.1
       openai:
         specifier: ^6.35.0
-        version: 6.35.0(ws@8.18.2)(zod@4.3.5)
+        version: 6.35.0(ws@8.20.1)(zod@4.3.5)
     devDependencies:
       '@ai-sdk/provider':
         specifier: ^1.1.3
@@ -7341,6 +7344,11 @@ packages:
     resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
     engines: {node: '>=18'}
 
+  tensorlake@0.5.14:
+    resolution: {integrity: sha512-qeipeiNxoAv/7jks2XgI9q8AyFv36hv2YVOEUqdWo+ZjQmKpUZWFzDxZ+v0KBlkBsRpL/9RDvSZQgUjJfn9dFw==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
@@ -7582,6 +7590,10 @@ packages:
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
+
+  undici@8.3.0:
+    resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
+    engines: {node: '>=22.19.0'}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -8004,6 +8016,18 @@ packages:
 
   ws@8.18.2:
     resolution: {integrity: sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -9842,14 +9866,26 @@ snapshots:
       - supports-color
       - ws
 
-  '@openai/agents-extensions@0.3.9(@openai/agents@0.3.9(ws@8.18.2)(zod@3.25.76))(@openai/codex-sdk@0.86.0)(ws@8.18.2)(zod@3.25.76)':
+  '@openai/agents-core@0.3.9(ws@8.20.1)(zod@3.25.76)':
+    dependencies:
+      debug: 4.4.3
+      openai: 6.35.0(ws@8.20.1)(zod@3.25.76)
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.26.0(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+      - ws
+
+  '@openai/agents-extensions@0.3.9(@openai/agents@0.3.9(ws@8.20.1)(zod@3.25.76))(@openai/codex-sdk@0.86.0)(ws@8.20.1)(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@openai/agents': 0.3.9(ws@8.18.2)(zod@3.25.76)
-      '@openai/agents-core': 0.3.9(ws@8.18.2)(zod@3.25.76)
+      '@openai/agents': 0.3.9(ws@8.20.1)(zod@3.25.76)
+      '@openai/agents-core': 0.3.9(ws@8.20.1)(zod@3.25.76)
       '@types/ws': 8.18.1
       debug: 4.4.3
-      ws: 8.18.2
+      ws: 8.20.1
       zod: 3.25.76
     optionalDependencies:
       '@openai/codex-sdk': 0.86.0
@@ -9857,11 +9893,11 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@openai/agents-openai@0.3.9(ws@8.18.2)(zod@3.25.76)':
+  '@openai/agents-openai@0.3.9(ws@8.20.1)(zod@3.25.76)':
     dependencies:
-      '@openai/agents-core': 0.3.9(ws@8.18.2)(zod@3.25.76)
+      '@openai/agents-core': 0.3.9(ws@8.20.1)(zod@3.25.76)
       debug: 4.4.3
-      openai: 6.35.0(ws@8.18.2)(zod@3.25.76)
+      openai: 6.35.0(ws@8.20.1)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -9881,13 +9917,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@openai/agents@0.3.9(ws@8.18.2)(zod@3.25.76)':
+  '@openai/agents@0.3.9(ws@8.20.1)(zod@3.25.76)':
     dependencies:
-      '@openai/agents-core': 0.3.9(ws@8.18.2)(zod@3.25.76)
-      '@openai/agents-openai': 0.3.9(ws@8.18.2)(zod@3.25.76)
+      '@openai/agents-core': 0.3.9(ws@8.20.1)(zod@3.25.76)
+      '@openai/agents-openai': 0.3.9(ws@8.20.1)(zod@3.25.76)
       '@openai/agents-realtime': 0.3.9(zod@3.25.76)
       debug: 4.4.3
-      openai: 6.26.0(ws@8.18.2)(zod@3.25.76)
+      openai: 6.26.0(ws@8.20.1)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -14764,9 +14800,9 @@ snapshots:
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
 
-  openai@6.26.0(ws@8.18.2)(zod@3.25.76):
+  openai@6.26.0(ws@8.20.1)(zod@3.25.76):
     optionalDependencies:
-      ws: 8.18.2
+      ws: 8.20.1
       zod: 3.25.76
 
   openai@6.35.0(ws@8.18.2)(zod@3.25.76):
@@ -14774,9 +14810,14 @@ snapshots:
       ws: 8.18.2
       zod: 3.25.76
 
-  openai@6.35.0(ws@8.18.2)(zod@4.3.5):
+  openai@6.35.0(ws@8.20.1)(zod@3.25.76):
     optionalDependencies:
-      ws: 8.18.2
+      ws: 8.20.1
+      zod: 3.25.76
+
+  openai@6.35.0(ws@8.20.1)(zod@4.3.5):
+    optionalDependencies:
+      ws: 8.20.1
       zod: 4.3.5
 
   openapi-fetch@0.14.1:
@@ -16051,6 +16092,14 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
+  tensorlake@0.5.14:
+    dependencies:
+      undici: 8.3.0
+      ws: 8.20.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   term-size@2.2.1: {}
 
   test-exclude@7.0.2:
@@ -16263,6 +16312,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici@7.25.0: {}
+
+  undici@8.3.0: {}
 
   unicorn-magic@0.3.0: {}
 
@@ -16658,6 +16709,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.18.2: {}
+
+  ws@8.20.1: {}
 
   wsl-utils@0.3.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,5 +19,7 @@ overrides:
 
 publishBranch: main
 minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - tensorlake
 blockExoticSubdeps: true
 strictDepBuilds: true


### PR DESCRIPTION
 ### Summary
  Add `TensorlakeSandboxClient` under `@openai/agents-extensions/sandbox/tensorlake`, matching the existing sandbox-provider pattern. Supports suspend/resume via
  named sandboxes and native checkpoint-based workspace persistence (`workspacePersistence: 'snapshot'`).

  Includes shared additions: `tensorlake` native snapshot prefix, `readOptionalStringArray` type guard, and a `manifestAccountsAlreadyProvisioned()` hook on
  `RemoteSandboxSessionBase` so providers restoring from a filesystem snapshot can skip user/group re-provisioning.

  #### Demo

  ```js
  import { run } from '@openai/agents';
  import { gitRepo, SandboxAgent } from '@openai/agents/sandbox';
  import { TensorlakeSandboxClient } from '@openai/agents-extensions/sandbox/tensorlake';

  const agent = new SandboxAgent({
    name: 'Workspace Assistant',
    instructions: 'Inspect the sandbox workspace before answering.',
    defaultManifest: {
      entries: {
        repo: gitRepo({
          repo: 'openai/openai-agents-js',
          ref: 'main',
        }),
      },
    },
  });

  const result = await run(
    agent,
    'Inspect repo/README.md and summarize what this project does.',
    {
      sandbox: {
        client: new TensorlakeSandboxClient(),
      },
    },
  );

  console.log(result.finalOutput);
  // This project provides a JavaScript/TypeScript SDK for building agent workflows.
```
  Set both OPENAI_API_KEY and TENSORLAKE_API_KEY in your environment, and install the tensorlake peer:

  `npm install @openai/agents @openai/agents-extensions tensorlake`
  

 ### Test plan
  - pnpm -F @openai/agents-extensions vitest run test/sandbox/tensorlake.test.ts — 47 tests pass
  - pnpm test
  - pnpm test:examples
  - pnpm test:integration
  - Manual: pnpm -F sandbox start:tensorlake -- --stream (and --workspace-persistence snapshot)

  ### Checks
  - [x] Added new tests
  - [x] Updated docs (`clients.mdx`, example README)
  - [x] Ran `pnpm test` and `pnpm test:examples`
  - [x] Ran `pnpm test:integration`
  - [x] Added changeset
