### PR TITLE
fix: guard session persistence debug env access

### DIFF
--- a/.changeset/session-persistence-process-env.md
+++ b/.changeset/session-persistence-process-env.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: guard session persistence debug env access

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -272,7 +272,10 @@ export async function saveToSession(
   const alreadyPersisted = state._currentTurnPersistedItemCount ?? 0;
   const newRunItems = result.newItems.slice(alreadyPersisted);
 
-  if (process.env.OPENAI_AGENTS__DEBUG_SAVE_SESSION) {
+  if (
+    typeof process !== 'undefined' &&
+    process.env?.OPENAI_AGENTS__DEBUG_SAVE_SESSION
+  ) {
     console.debug(
       'saveToSession:newRunItems',
       newRunItems.map((item) => item.type),

--- a/packages/agents-core/test/runner/sessionPersistence.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.test.ts
@@ -1338,6 +1338,48 @@ describe('saveToSession', () => {
     }
   }
 
+  it('does not require a process global for debug session logging', async () => {
+    const processDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'process',
+    );
+    Object.defineProperty(globalThis, 'process', {
+      configurable: true,
+      value: undefined,
+      writable: true,
+    });
+
+    try {
+      const agent = new Agent<UnknownContext, 'text'>({
+        name: 'ProcesslessSessionAgent',
+        outputType: 'text',
+        instructions: 'test',
+      });
+      const session = new MemorySession();
+      const state = new RunState(new RunContext(), 'hello', agent as any, 10);
+
+      state._generatedItems = [
+        new MessageOutputItem(fakeModelMessage('saved'), agent),
+      ];
+
+      await expect(
+        saveToSession(session, [], new RunResult(state)),
+      ).resolves.toBeUndefined();
+      expect(session.items).toHaveLength(1);
+      expect(session.items[0]).toMatchObject({
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'saved' }],
+      });
+    } finally {
+      if (processDescriptor) {
+        Object.defineProperty(globalThis, 'process', processDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, 'process');
+      }
+    }
+  });
+
   it('preserves reasoning IDs for sessions that require them', async () => {
     class ReasoningPreservingSession extends MemorySession {
       preserveReasoningItemIdsForPersistence(): boolean {


### PR DESCRIPTION
This pull request fixes session persistence in runtimes that do not expose a `process` global. The debug logging path in `saveToSession` now checks for `process` before reading `process.env.OPENAI_AGENTS__DEBUG_SAVE_SESSION`, preventing a `ReferenceError` when sessions are used inside browser-like or sandboxed V8 environments.

It also adds a regression test that temporarily removes the global `process` object and verifies that `saveToSession` still persists new session items successfully.
