### PR TITLE
feat: add completed tracing lifecycle dispatch helpers

### DIFF
--- a/.changeset/tracing-completed-dispatch.md
+++ b/.changeset/tracing-completed-dispatch.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+feat: add completed tracing lifecycle dispatch helpers

--- a/packages/agents-core/src/tracing/index.ts
+++ b/packages/agents-core/src/tracing/index.ts
@@ -1,6 +1,8 @@
 import { TracingProcessor } from './processor';
 import { getGlobalTraceProvider } from './provider';
 import type { TracingConfig } from './config';
+import type { Span, SpanData } from './spans';
+import type { Trace } from './traces';
 import type { TracingIdGenerator } from './utils';
 
 export {
@@ -21,6 +23,7 @@ export {
   TracingExporter,
   TracingProcessor,
   ConsoleSpanExporter,
+  MultiTracingProcessor,
 } from './processor';
 export { NoopSpan, Span } from './spans';
 export type {
@@ -87,6 +90,30 @@ export function setTracingIdGenerator(
   idGenerator?: Partial<TracingIdGenerator>,
 ): void {
   getGlobalTraceProvider().setIdGenerator(idGenerator);
+}
+
+/**
+ * Dispatch a completed trace lifecycle to all processors registered on the
+ * global tracing provider.
+ *
+ * This bypasses Trace.start() and Trace.end(), so callers can replay a
+ * completed lifecycle without mutating the trace state.
+ */
+export async function dispatchTrace(trace: Trace): Promise<void> {
+  await getGlobalTraceProvider().dispatchTrace(trace);
+}
+
+/**
+ * Dispatch a completed span lifecycle to all processors registered on the
+ * global tracing provider.
+ *
+ * This bypasses Span.start() and Span.end(), so callers can replay a completed
+ * lifecycle without mutating existing timestamps.
+ */
+export async function dispatchSpan<TSpanData extends SpanData>(
+  span: Span<TSpanData>,
+): Promise<void> {
+  await getGlobalTraceProvider().dispatchSpan(span);
 }
 
 /**

--- a/packages/agents-core/src/tracing/processor.ts
+++ b/packages/agents-core/src/tracing/processor.ts
@@ -367,6 +367,24 @@ export class MultiTracingProcessor implements TracingProcessor {
     }
   }
 
+  /**
+   * Dispatches a completed trace lifecycle to every registered processor without
+   * calling Trace.start() or Trace.end().
+   */
+  async dispatchTrace(trace: Trace): Promise<void> {
+    await this.onTraceStart(trace);
+    await this.onTraceEnd(trace);
+  }
+
+  /**
+   * Dispatches a completed span lifecycle to every registered processor without
+   * calling Span.start() or Span.end().
+   */
+  async dispatchSpan(span: Span): Promise<void> {
+    await this.onSpanStart(span);
+    await this.onSpanEnd(span);
+  }
+
   async shutdown(timeout?: number): Promise<void> {
     for (const processor of this.#processors) {
       await processor.shutdown(timeout);

--- a/packages/agents-core/src/tracing/processor.ts
+++ b/packages/agents-core/src/tracing/processor.ts
@@ -8,6 +8,7 @@ import {
 import type { Timeout, Timer } from '../shims/interface';
 import { tracing } from '../config';
 import { combineAbortSignals } from '../utils/abortSignals';
+import { NOOP_TRACE_OR_SPAN_ID } from './utils';
 
 type Span = TSpan<any>;
 
@@ -372,6 +373,10 @@ export class MultiTracingProcessor implements TracingProcessor {
    * calling Trace.start() or Trace.end().
    */
   async dispatchTrace(trace: Trace): Promise<void> {
+    if (trace.traceId === NOOP_TRACE_OR_SPAN_ID) {
+      return;
+    }
+
     await this.onTraceStart(trace);
     await this.onTraceEnd(trace);
   }
@@ -381,6 +386,13 @@ export class MultiTracingProcessor implements TracingProcessor {
    * calling Span.start() or Span.end().
    */
   async dispatchSpan(span: Span): Promise<void> {
+    if (
+      span.traceId === NOOP_TRACE_OR_SPAN_ID ||
+      span.spanId === NOOP_TRACE_OR_SPAN_ID
+    ) {
+      return;
+    }
+
     await this.onSpanStart(span);
     await this.onSpanEnd(span);
   }

--- a/packages/agents-core/src/tracing/provider.ts
+++ b/packages/agents-core/src/tracing/provider.ts
@@ -116,6 +116,11 @@ export class TraceProvider {
    * mutating the trace state.
    */
   async dispatchTrace(trace: Trace): Promise<void> {
+    if (this.#disabled) {
+      logger.debug('Tracing is disabled, Not dispatching trace %o', trace);
+      return;
+    }
+
     await this.#multiProcessor.dispatchTrace(trace);
   }
 
@@ -129,6 +134,11 @@ export class TraceProvider {
   async dispatchSpan<TSpanData extends SpanData>(
     span: Span<TSpanData>,
   ): Promise<void> {
+    if (this.#disabled) {
+      logger.debug('Tracing is disabled, Not dispatching span %o', span);
+      return;
+    }
+
     await this.#multiProcessor.dispatchSpan(span);
   }
 

--- a/packages/agents-core/src/tracing/provider.ts
+++ b/packages/agents-core/src/tracing/provider.ts
@@ -108,6 +108,30 @@ export class TraceProvider {
     this.#multiProcessor.start();
   }
 
+  /**
+   * Dispatches a completed trace lifecycle to all registered processors.
+   *
+   * This is useful when an integration receives a trace that was started and
+   * ended outside this process and needs to fan out the lifecycle without
+   * mutating the trace state.
+   */
+  async dispatchTrace(trace: Trace): Promise<void> {
+    await this.#multiProcessor.dispatchTrace(trace);
+  }
+
+  /**
+   * Dispatches a completed span lifecycle to all registered processors.
+   *
+   * This is useful when an integration receives a span that already has
+   * lifecycle timestamps and needs to fan out the lifecycle without mutating
+   * those timestamps.
+   */
+  async dispatchSpan<TSpanData extends SpanData>(
+    span: Span<TSpanData>,
+  ): Promise<void> {
+    await this.#multiProcessor.dispatchSpan(span);
+  }
+
   createTrace(traceOptions: TraceOptions): Trace {
     if (this.#disabled) {
       logger.debug('Tracing is disabled, Not creating trace %o', traceOptions);

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -36,6 +36,8 @@ import {
   getCurrentTraceContext,
   getCurrentTrace,
   getCurrentSpan,
+  dispatchSpan,
+  dispatchTrace,
   setTraceProcessors,
   setTracingDisabled,
   setTracingIdGenerator,
@@ -1515,6 +1517,121 @@ describe('MultiTracingProcessor', () => {
     await multiProcessor.forceFlush();
     expect(flush1).toHaveBeenCalledTimes(1);
     expect(flush2).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispatches completed traces to all processors without using trace lifecycle methods', async () => {
+    const processor1 = new TestProcessor();
+    const processor2 = new TestProcessor();
+    const multiProcessor = new MultiTracingProcessor();
+    multiProcessor.addTraceProcessor(processor1);
+    multiProcessor.addTraceProcessor(processor2);
+
+    const traceProcessor = new TestProcessor();
+    const trace = new Trace(
+      { name: 'completed-trace', traceId: 'trace_completed', started: true },
+      traceProcessor,
+    );
+
+    await trace.start();
+    expect(traceProcessor.tracesStarted).toHaveLength(0);
+
+    await multiProcessor.dispatchTrace(trace);
+
+    expect(processor1.tracesStarted).toEqual([trace]);
+    expect(processor1.tracesEnded).toEqual([trace]);
+    expect(processor2.tracesStarted).toEqual([trace]);
+    expect(processor2.tracesEnded).toEqual([trace]);
+  });
+
+  it('dispatches completed spans to all processors without mutating timestamps', async () => {
+    const processor1 = new TestProcessor();
+    const processor2 = new TestProcessor();
+    const multiProcessor = new MultiTracingProcessor();
+    multiProcessor.addTraceProcessor(processor1);
+    multiProcessor.addTraceProcessor(processor2);
+
+    const startedAt = '2026-05-22T00:00:00.000Z';
+    const endedAt = '2026-05-22T00:00:01.000Z';
+    const span = new Span(
+      {
+        traceId: 'trace_completed',
+        spanId: 'span_completed',
+        data: { type: 'custom', name: 'completed-span', data: {} },
+        startedAt,
+        endedAt,
+      },
+      new TestProcessor(),
+    );
+
+    await multiProcessor.dispatchSpan(span);
+
+    expect(processor1.spansStarted).toEqual([span]);
+    expect(processor1.spansEnded).toEqual([span]);
+    expect(processor2.spansStarted).toEqual([span]);
+    expect(processor2.spansEnded).toEqual([span]);
+    expect(span.startedAt).toBe(startedAt);
+    expect(span.endedAt).toBe(endedAt);
+  });
+});
+
+// -----------------------------------------------------------------------------------------
+// Tests for completed trace dispatch helpers.
+// -----------------------------------------------------------------------------------------
+
+describe('completed trace dispatch helpers', () => {
+  afterEach(() => {
+    setTraceProcessors([defaultProcessor()]);
+  });
+
+  it('dispatches completed traces and spans through TraceProvider', async () => {
+    const processor = new TestProcessor();
+    const provider = new TraceProvider();
+    provider.registerProcessor(processor);
+
+    const trace = new Trace({ name: 'completed-trace' });
+    const span = new Span(
+      {
+        traceId: trace.traceId,
+        spanId: 'span_completed',
+        data: { type: 'custom', name: 'completed-span', data: {} },
+        startedAt: '2026-05-22T00:00:00.000Z',
+        endedAt: '2026-05-22T00:00:01.000Z',
+      },
+      new TestProcessor(),
+    );
+
+    await provider.dispatchTrace(trace);
+    await provider.dispatchSpan(span);
+
+    expect(processor.tracesStarted).toEqual([trace]);
+    expect(processor.tracesEnded).toEqual([trace]);
+    expect(processor.spansStarted).toEqual([span]);
+    expect(processor.spansEnded).toEqual([span]);
+  });
+
+  it('dispatches completed traces and spans through global helpers', async () => {
+    const processor = new TestProcessor();
+    setTraceProcessors([processor]);
+
+    const trace = new Trace({ name: 'completed-trace' });
+    const span = new Span(
+      {
+        traceId: trace.traceId,
+        spanId: 'span_completed',
+        data: { type: 'custom', name: 'completed-span', data: {} },
+        startedAt: '2026-05-22T00:00:00.000Z',
+        endedAt: '2026-05-22T00:00:01.000Z',
+      },
+      new TestProcessor(),
+    );
+
+    await dispatchTrace(trace);
+    await dispatchSpan(span);
+
+    expect(processor.tracesStarted).toEqual([trace]);
+    expect(processor.tracesEnded).toEqual([trace]);
+    expect(processor.spansStarted).toEqual([span]);
+    expect(processor.spansEnded).toEqual([span]);
   });
 });
 

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -7,6 +7,7 @@ import {
   generateSpanId,
   generateGroupId,
   removePrivateFields,
+  NOOP_TRACE_OR_SPAN_ID,
 } from '../src/tracing/utils';
 
 import { Trace, NoopTrace } from '../src/tracing/traces';
@@ -1571,6 +1572,53 @@ describe('MultiTracingProcessor', () => {
     expect(processor2.spansEnded).toEqual([span]);
     expect(span.startedAt).toBe(startedAt);
     expect(span.endedAt).toBe(endedAt);
+  });
+
+  it('does not dispatch no-op traces or spans', async () => {
+    const processor = new TestProcessor();
+    const multiProcessor = new MultiTracingProcessor();
+    multiProcessor.addTraceProcessor(processor);
+
+    const noopTrace = new NoopTrace();
+    const traceWithNoopId = new Trace({
+      name: 'no-op-id',
+      traceId: NOOP_TRACE_OR_SPAN_ID,
+    });
+    const noopSpan = new NoopSpan(
+      { type: 'custom', name: 'noop-span', data: {} },
+      new TestProcessor(),
+    );
+    const spanWithNoopTraceId = new Span(
+      {
+        traceId: NOOP_TRACE_OR_SPAN_ID,
+        spanId: 'span_completed',
+        data: { type: 'custom', name: 'noop-trace-id', data: {} },
+        startedAt: '2026-05-22T00:00:00.000Z',
+        endedAt: '2026-05-22T00:00:01.000Z',
+      },
+      new TestProcessor(),
+    );
+    const spanWithNoopSpanId = new Span(
+      {
+        traceId: 'trace_completed',
+        spanId: NOOP_TRACE_OR_SPAN_ID,
+        data: { type: 'custom', name: 'noop-span-id', data: {} },
+        startedAt: '2026-05-22T00:00:00.000Z',
+        endedAt: '2026-05-22T00:00:01.000Z',
+      },
+      new TestProcessor(),
+    );
+
+    await multiProcessor.dispatchTrace(noopTrace);
+    await multiProcessor.dispatchTrace(traceWithNoopId);
+    await multiProcessor.dispatchSpan(noopSpan);
+    await multiProcessor.dispatchSpan(spanWithNoopTraceId);
+    await multiProcessor.dispatchSpan(spanWithNoopSpanId);
+
+    expect(processor.tracesStarted).toHaveLength(0);
+    expect(processor.tracesEnded).toHaveLength(0);
+    expect(processor.spansStarted).toHaveLength(0);
+    expect(processor.spansEnded).toHaveLength(0);
   });
 });
 

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -1581,11 +1581,13 @@ describe('MultiTracingProcessor', () => {
 describe('completed trace dispatch helpers', () => {
   afterEach(() => {
     setTraceProcessors([defaultProcessor()]);
+    setTracingDisabled(true);
   });
 
   it('dispatches completed traces and spans through TraceProvider', async () => {
     const processor = new TestProcessor();
     const provider = new TraceProvider();
+    provider.setDisabled(false);
     provider.registerProcessor(processor);
 
     const trace = new Trace({ name: 'completed-trace' });
@@ -1609,8 +1611,36 @@ describe('completed trace dispatch helpers', () => {
     expect(processor.spansEnded).toEqual([span]);
   });
 
+  it('does not dispatch completed traces and spans when TraceProvider tracing is disabled', async () => {
+    const processor = new TestProcessor();
+    const provider = new TraceProvider();
+    provider.setDisabled(true);
+    provider.registerProcessor(processor);
+
+    const trace = new Trace({ name: 'completed-trace' });
+    const span = new Span(
+      {
+        traceId: trace.traceId,
+        spanId: 'span_completed',
+        data: { type: 'custom', name: 'completed-span', data: {} },
+        startedAt: '2026-05-22T00:00:00.000Z',
+        endedAt: '2026-05-22T00:00:01.000Z',
+      },
+      new TestProcessor(),
+    );
+
+    await provider.dispatchTrace(trace);
+    await provider.dispatchSpan(span);
+
+    expect(processor.tracesStarted).toHaveLength(0);
+    expect(processor.tracesEnded).toHaveLength(0);
+    expect(processor.spansStarted).toHaveLength(0);
+    expect(processor.spansEnded).toHaveLength(0);
+  });
+
   it('dispatches completed traces and spans through global helpers', async () => {
     const processor = new TestProcessor();
+    setTracingDisabled(false);
     setTraceProcessors([processor]);
 
     const trace = new Trace({ name: 'completed-trace' });
@@ -1632,6 +1662,32 @@ describe('completed trace dispatch helpers', () => {
     expect(processor.tracesEnded).toEqual([trace]);
     expect(processor.spansStarted).toEqual([span]);
     expect(processor.spansEnded).toEqual([span]);
+  });
+
+  it('does not dispatch completed traces and spans through global helpers when tracing is disabled', async () => {
+    const processor = new TestProcessor();
+    setTraceProcessors([processor]);
+    setTracingDisabled(true);
+
+    const trace = new Trace({ name: 'completed-trace' });
+    const span = new Span(
+      {
+        traceId: trace.traceId,
+        spanId: 'span_completed',
+        data: { type: 'custom', name: 'completed-span', data: {} },
+        startedAt: '2026-05-22T00:00:00.000Z',
+        endedAt: '2026-05-22T00:00:01.000Z',
+      },
+      new TestProcessor(),
+    );
+
+    await dispatchTrace(trace);
+    await dispatchSpan(span);
+
+    expect(processor.tracesStarted).toHaveLength(0);
+    expect(processor.tracesEnded).toHaveLength(0);
+    expect(processor.spansStarted).toHaveLength(0);
+    expect(processor.spansEnded).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
This pull request adds public helpers for dispatching completed trace and span lifecycles to registered tracing processors without calling `Trace.start()`, `Trace.end()`, `Span.start()`, or `Span.end()`.

The change adds `dispatchTrace` and `dispatchSpan` on `MultiTracingProcessor`, `TraceProvider`, and the global tracing module. These helpers let integrations replay already-completed tracing objects across process boundaries while preserving existing lifecycle state and timestamps, avoiding private access to the provider's processor list.