### PR TITLE
feat: add RunState trace clearing for resumed runs

### DIFF
--- a/.changeset/runstate-clear-trace.md
+++ b/.changeset/runstate-clear-trace.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+feat: add RunState trace clearing for resumed runs

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -23,6 +23,7 @@ import { RunResult, StreamedRunResult } from './result';
 import { RunState } from './runState';
 import { RunItem } from './items';
 import {
+  getCurrentTrace,
   getOrCreateTrace,
   resetCurrentSpan,
   setCurrentSpan,
@@ -688,14 +689,22 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         return executeRun();
       });
     }
-    return getOrCreateTrace(async () => executeRun(), {
-      traceId: this.config.traceId,
-      name: this.config.workflowName,
-      groupId: this.config.groupId,
-      metadata: this.config.traceMetadata,
-      // Per-run tracing config overrides exporter defaults such as environment API key.
-      tracingApiKey: tracingConfig?.apiKey,
-    });
+    return getOrCreateTrace(
+      async () => {
+        if (preparedInput instanceof RunState && !preparedInput._trace) {
+          preparedInput._trace = getCurrentTrace();
+        }
+        return executeRun();
+      },
+      {
+        traceId: this.config.traceId,
+        name: this.config.workflowName,
+        groupId: this.config.groupId,
+        metadata: this.config.traceMetadata,
+        // Per-run tracing config overrides exporter defaults such as environment API key.
+        tracingApiKey: tracingConfig?.apiKey,
+      },
+    );
   }
 
   // --------------------------------------------------------------

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -662,6 +662,17 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     this._currentAgentSpan = span;
   }
 
+  /**
+   * Clears the restored trace and current agent span from this run state.
+   *
+   * Use this before resuming a serialized state when the resumed run should attach
+   * to the current ambient trace instead of the trace persisted in the state.
+   */
+  public clearTrace(): void {
+    this._trace = null;
+    this._currentAgentSpan = undefined;
+  }
+
   private getOrCreateToolSearchRuntimeToolState(
     agent: Agent<any, any>,
   ): ToolSearchRuntimeToolState<TContext> {

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -29,6 +29,7 @@ import {
   setTraceProcessors,
   setTracingDisabled,
   BatchTraceProcessor,
+  withTrace,
   user,
   assistant,
   type ToolExecutionConfig,
@@ -1621,6 +1622,50 @@ describe('Runner.run', () => {
         'override-key',
       );
       setTracingDisabled(true);
+    });
+
+    it('can clear a restored RunState trace so resume uses the ambient trace', async () => {
+      setTracingDisabled(false);
+      try {
+        const provider = getGlobalTraceProvider();
+        const agent = new Agent({
+          name: 'ResumeAmbientTrace',
+          model: new FakeModel([
+            { output: [fakeModelMessage('hi')], usage: new Usage() },
+          ]),
+        });
+        const state = new RunState(new RunContext(), 'hi', agent, 1);
+        const restoredTrace = provider.createTrace({
+          traceId: 'restored-trace-id',
+          name: 'Restored workflow',
+        });
+        state._trace = restoredTrace;
+        state._currentAgentSpan = provider.createSpan(
+          { data: { type: 'agent', name: 'RestoredSpan' } },
+          restoredTrace,
+        );
+        state.clearTrace();
+
+        const ambientTrace = provider.createTrace({
+          traceId: 'ambient-trace-id',
+          name: 'Ambient workflow',
+        });
+
+        const resumed = await withTrace(ambientTrace, async () =>
+          new Runner().run(agent, state),
+        );
+
+        expect(resumed.state._trace?.traceId).toBe('ambient-trace-id');
+        expect(resumed.state._currentAgentSpan?.traceId).toBe(
+          'ambient-trace-id',
+        );
+        expect(resumed.state._trace?.traceId).not.toBe('restored-trace-id');
+        expect(resumed.state._currentAgentSpan?.traceId).not.toBe(
+          'restored-trace-id',
+        );
+      } finally {
+        setTracingDisabled(true);
+      }
     });
 
     it('input guardrail executes only once', async () => {

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -82,6 +82,37 @@ describe('RunState', () => {
     expect(state._toolOutputGuardrailResults).toEqual([]);
   });
 
+  it('clears restored trace state', () => {
+    const context = new RunContext();
+    const agent = new Agent({ name: 'TraceClearingAgent' });
+    const state = new RunState(context, 'input', agent, 1);
+    const provider = getGlobalTraceProvider();
+    provider.setDisabled(false);
+
+    try {
+      const trace = provider.createTrace({
+        traceId: 'trace_original',
+        name: 'Original workflow',
+      });
+      const span = provider.createSpan(
+        { data: { type: 'agent', name: 'OriginalSpan' } },
+        trace,
+      );
+      state._trace = trace;
+      state._currentAgentSpan = span;
+
+      state.clearTrace();
+
+      expect(state._trace).toBeNull();
+      expect(state._currentAgentSpan).toBeUndefined();
+      const json = state.toJSON();
+      expect(json.trace).toBeNull();
+      expect(json.currentAgentSpan).toBeUndefined();
+    } finally {
+      provider.setDisabled(true);
+    }
+  });
+
   it('exposes the current agent', () => {
     const context = new RunContext();
     const agent = new Agent({ name: 'CurrentAgent' });


### PR DESCRIPTION
This pull request adds a public `RunState.clearTrace()` helper for integrations that need resumed runs to attach to the current ambient trace instead of the trace persisted in serialized run state.

It clears both the restored trace and current agent span, then ensures resumed states without a trace are rebound to the active trace created or reused by `Runner.run`. This keeps trace attribution under the caller's current trace context and avoids requiring integrations to mutate private `RunState` fields directly.
