### PR TITLE
fix: mark rejected tool call results as incomplete

### DIFF
--- a/.changeset/rejected-tool-call-incomplete-status.md
+++ b/.changeset/rejected-tool-call-incomplete-status.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: mark rejected tool call results as incomplete
+
+Approval rejections previously emitted `function_call_result` items with `status: 'completed'`, identical to successful tool runs. The structural status contradicted the rejection text and could cause models to claim a rejected tool actually executed. Rejected results now use `status: 'incomplete'`.

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -123,10 +123,15 @@ function getComputerTraceInputPayload(
  * @internal
  * Normalizes tool outputs once so downstream code works with fully structured protocol items.
  * Doing this here keeps API surface stable even when providers add new shapes.
+ *
+ * The optional `status` lets callers signal that a result is not a normal success.
+ * Approval rejections and similar failure paths pass `'incomplete'` so the model
+ * does not treat the synthetic output as a completed tool execution.
  */
 export function getToolCallOutputItem(
   toolCall: protocol.FunctionCallItem,
   output: string | unknown,
+  status: FunctionCallResultItem['status'] = 'completed',
 ): FunctionCallResultItem {
   const maybeStructuredOutputs = normalizeStructuredToolOutputs(output);
 
@@ -142,7 +147,7 @@ export function getToolCallOutputItem(
         ? { namespace: toolCall.namespace }
         : {}),
       callId: toolCall.callId,
-      status: 'completed',
+      status,
       output: structuredItems,
     };
   }
@@ -154,7 +159,7 @@ export function getToolCallOutputItem(
       ? { namespace: toolCall.namespace }
       : {}),
     callId: toolCall.callId,
-    status: 'completed',
+    status,
     output: {
       type: 'text',
       text: toSmartString(output),
@@ -362,7 +367,7 @@ async function buildApprovalRejectionResult<TContext>(
       tool: toolRun.tool,
       output: response,
       runItem: new RunToolCallOutputItem(
-        getToolCallOutputItem(toolRun.toolCall, response),
+        getToolCallOutputItem(toolRun.toolCall, response, 'incomplete'),
         agent,
         response,
       ),

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -193,6 +193,20 @@ describe('getToolCallOutputItem', () => {
     });
   });
 
+  it('uses the provided status on the function_call_result item', () => {
+    const output = getToolCallOutputItem(
+      TEST_MODEL_FUNCTION_CALL,
+      'Tool execution was not approved.',
+      'incomplete',
+    );
+
+    expect(output.status).toBe('incomplete');
+    expect(output.output).toEqual({
+      type: 'text',
+      text: 'Tool execution was not approved.',
+    });
+  });
+
   it('converts structured text outputs into input_text items', () => {
     const output = getToolCallOutputItem(TEST_MODEL_FUNCTION_CALL, {
       type: 'text',
@@ -2402,6 +2416,30 @@ describe('executeShellActions', () => {
       );
 
       expect(state.hasPendingAgentToolRun(t.name, toolCall.callId)).toBe(false);
+    });
+
+    it('marks rejected function_call_result items as incomplete', async () => {
+      const t = makeTool(true);
+      vi.spyOn(state._context, 'isToolApproved').mockReturnValue(false as any);
+
+      const res = await withTrace('test', () =>
+        executeFunctionToolCalls(
+          state._currentAgent,
+          [{ toolCall, tool: t }],
+          runner,
+          state,
+        ),
+      );
+
+      expect(res[0].type).toBe('function_output');
+      const rawItem = (res[0].runItem as ToolCallOutputItem)
+        .rawItem as protocol.FunctionCallResultItem;
+      expect(rawItem.type).toBe('function_call_result');
+      expect(rawItem.status).toBe('incomplete');
+      expect(rawItem.output).toEqual({
+        type: 'text',
+        text: 'Tool execution was not approved.',
+      });
     });
 
     it('runs tool and emits events on success', async () => {


### PR DESCRIPTION
Fixes #1104.

`buildApprovalRejectionResult` produced `function_call_result` items with `status: 'completed'`, identical to successful tool runs. The only signal that the tool was rejected was the text content of the output, which contradicts the `status` field. As reported in #1104, this can cause models to claim a rejected tool actually executed (e.g. approve one email, reject another, model says both were sent).

The protocol already allows `'in_progress' | 'completed' | 'incomplete'` for `FunctionCallResultItem.status`, so this changes rejected results to `status: 'incomplete'`. This gives the model a consistent structural signal alongside the rejection text.

`getToolCallOutputItem` gains an optional `status` parameter that defaults to `'completed'`, so other call sites are unchanged.

Tests added:
- `getToolCallOutputItem` accepts and uses an explicit `status`.
- Function tool approval rejections produce a `function_call_result` with `status: 'incomplete'`.

`pnpm build`, `pnpm lint`, `pnpm -r build-check`, and the full vitest suite (2826 passed) all pass locally.