### PR TITLE
feat: add SDK-only custom data for tool outputs

### DIFF
--- a/.changeset/tool-output-custom-data.md
+++ b/.changeset/tool-output-custom-data.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents': patch
+---
+
+feat: add SDK-only custom data for tool outputs

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -136,6 +136,8 @@ export {
   MCPToolFilterCallable,
   MCPToolFilterContext,
   MCPToolFilterStatic,
+  MCPToolCustomDataContext,
+  MCPToolCustomDataExtractor,
   MCPToolMetaContext,
   MCPToolMetaResolver,
   createMCPToolStaticFilter,
@@ -248,6 +250,13 @@ export type {
   ToolInputParameters,
   ToolOptions,
   ToolNamespaceOptions,
+  ToolOutputCustomData,
+  FunctionToolCustomDataContext,
+  FunctionToolCustomDataExtractor,
+  ComputerToolCustomDataContext,
+  ComputerToolCustomDataExtractor,
+  ApplyPatchToolCustomDataContext,
+  ApplyPatchToolCustomDataExtractor,
 } from './tool';
 export type {
   ToolOutputText,

--- a/packages/agents-core/src/items.ts
+++ b/packages/agents-core/src/items.ts
@@ -5,6 +5,7 @@ import {
   getFunctionToolQualifiedName,
   resolveFunctionToolCallName,
 } from './toolIdentity';
+import type { ToolOutputCustomData } from './utils/customData';
 
 export class RunItemBase {
   public readonly type: string = 'base_item' as const;
@@ -122,6 +123,7 @@ export class RunToolCallOutputItem extends RunItemBase {
       | protocol.ApplyPatchCallResultItem,
     public agent: Agent<any, any>,
     public output: string | unknown,
+    public customData?: ToolOutputCustomData,
   ) {
     super();
   }
@@ -131,6 +133,7 @@ export class RunToolCallOutputItem extends RunItemBase {
       ...super.toJSON(),
       agent: this.agent.toJSON(),
       output: toSmartString(this.output),
+      customData: this.customData,
     };
   }
 

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -1,4 +1,4 @@
-import { FunctionTool, tool, Tool } from './tool';
+import { FunctionTool, tool, Tool, type ToolCallDetails } from './tool';
 import { UserError } from './errors';
 import {
   MCPServerStdio as UnderlyingMCPServerStdio,
@@ -22,6 +22,8 @@ import {
   UnknownContext,
 } from './types';
 import type {
+  MCPToolCustomDataContext,
+  MCPToolCustomDataExtractor,
   MCPToolFilterCallable,
   MCPToolFilterStatic,
   MCPToolMetaContext,
@@ -29,6 +31,7 @@ import type {
 } from './mcpUtil';
 import type { RunContext } from './runContext';
 import type { Agent } from './agent';
+import { maybeExtractToolOutputCustomData } from './utils/customData';
 
 export const DEFAULT_STDIO_MCP_CLIENT_LOGGER_NAME =
   'openai-agents:stdio-mcp-client';
@@ -64,6 +67,7 @@ export interface MCPServer {
   cacheToolsList: boolean;
   toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
   toolMetaResolver?: MCPToolMetaResolver;
+  customDataExtractor?: MCPToolCustomDataExtractor;
   /**
    * Whether to use MCP `structuredContent` as the model-visible tool output when available.
    * Defaults to false to preserve the existing content-based output behavior.
@@ -197,6 +201,7 @@ export abstract class BaseMCPServerStdio implements MCPServer {
   protected _cachedTools: any[] | undefined = undefined;
   public toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
   public toolMetaResolver?: MCPToolMetaResolver;
+  public customDataExtractor?: MCPToolCustomDataExtractor;
   public useStructuredContent?: boolean;
   public errorFunction?: MCPToolErrorFunction | null;
 
@@ -207,6 +212,7 @@ export abstract class BaseMCPServerStdio implements MCPServer {
     this.cacheToolsList = options.cacheToolsList ?? false;
     this.toolFilter = options.toolFilter;
     this.toolMetaResolver = options.toolMetaResolver;
+    this.customDataExtractor = options.customDataExtractor;
     this.useStructuredContent = options.useStructuredContent;
     this.errorFunction = options.errorFunction;
   }
@@ -251,6 +257,7 @@ export abstract class BaseMCPServerStreamableHttp implements MCPServer {
   protected _cachedTools: any[] | undefined = undefined;
   public toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
   public toolMetaResolver?: MCPToolMetaResolver;
+  public customDataExtractor?: MCPToolCustomDataExtractor;
   public useStructuredContent?: boolean;
   public errorFunction?: MCPToolErrorFunction | null;
 
@@ -262,6 +269,7 @@ export abstract class BaseMCPServerStreamableHttp implements MCPServer {
     this.cacheToolsList = options.cacheToolsList ?? false;
     this.toolFilter = options.toolFilter;
     this.toolMetaResolver = options.toolMetaResolver;
+    this.customDataExtractor = options.customDataExtractor;
     this.useStructuredContent = options.useStructuredContent;
     this.errorFunction = options.errorFunction;
   }
@@ -307,6 +315,7 @@ export abstract class BaseMCPServerSSE implements MCPServer {
   protected _cachedTools: any[] | undefined = undefined;
   public toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
   public toolMetaResolver?: MCPToolMetaResolver;
+  public customDataExtractor?: MCPToolCustomDataExtractor;
   public useStructuredContent?: boolean;
   public errorFunction?: MCPToolErrorFunction | null;
 
@@ -317,6 +326,7 @@ export abstract class BaseMCPServerSSE implements MCPServer {
     this.cacheToolsList = options.cacheToolsList ?? false;
     this.toolFilter = options.toolFilter;
     this.toolMetaResolver = options.toolMetaResolver;
+    this.customDataExtractor = options.customDataExtractor;
     this.useStructuredContent = options.useStructuredContent;
     this.errorFunction = options.errorFunction;
   }
@@ -1158,6 +1168,10 @@ export function mcpToFunctionTool(
   options: MCPFunctionToolConversionOptions = {},
 ) {
   const toolName = options.toolNameOverride ?? mcpTool.name;
+  const customDataByCall = new WeakMap<
+    RunContext<any>,
+    Map<string, MCPToolCustomDataContext<any>>
+  >();
   const serverErrorFunction = server.errorFunction;
   const mcpErrorFunction =
     serverErrorFunction !== undefined
@@ -1168,7 +1182,11 @@ export function mcpToFunctionTool(
       ? (context: RunContext, error: Error | unknown) =>
           mcpErrorFunction({ context, error })
       : mcpErrorFunction;
-  async function invoke(input: any, runContext?: RunContext<any>) {
+  async function invoke(
+    input: any,
+    runContext?: RunContext<any>,
+    details?: ToolCallDetails,
+  ) {
     let args = {};
     if (typeof input === 'string' && input) {
       args = JSON.parse(input);
@@ -1182,7 +1200,7 @@ export function mcpToFunctionTool(
     const meta = runContext
       ? await resolveMcpToolMeta(server, runContext, mcpTool.name, args)
       : undefined;
-    const result =
+    const result: CallToolResult =
       server.useStructuredContent === true && server.callToolResult
         ? meta === undefined
           ? await server.callToolResult(mcpTool.name, args)
@@ -1193,15 +1211,42 @@ export function mcpToFunctionTool(
                 ? await server.callTool(mcpTool.name, args)
                 : await server.callTool(mcpTool.name, args, meta),
           };
-    if (
+    const content = result.content as CallToolResultContent;
+    const resultMeta = result._meta ?? content._meta;
+    const structuredContent =
+      result.structuredContent ?? content.structuredContent;
+    const isError = result.isError ?? content.isError;
+    const toolOutput =
       server.useStructuredContent === true &&
-      result.isError !== true &&
-      result.structuredContent !== undefined
+      isError !== true &&
+      structuredContent !== undefined
+        ? JSON.stringify(structuredContent)
+        : content.length === 1
+          ? content[0]
+          : content;
+    if (
+      runContext &&
+      details?.toolCall?.callId &&
+      server.customDataExtractor
     ) {
-      return JSON.stringify(result.structuredContent);
+      let byCall = customDataByCall.get(runContext);
+      if (!byCall) {
+        byCall = new Map();
+        customDataByCall.set(runContext, byCall);
+      }
+      byCall.set(details.toolCall.callId, {
+        runContext,
+        serverName: server.name,
+        toolName: mcpTool.name,
+        toolDisplayName: toolName,
+        arguments: cloneMcpCustomDataContextValue(args),
+        resultMeta: cloneMcpCustomDataContextValue(resultMeta),
+        structuredContent: cloneMcpCustomDataContextValue(structuredContent),
+        isError,
+        toolOutput: cloneMcpCustomDataContextValue(toolOutput),
+      });
     }
-    const content = result.content;
-    return content.length === 1 ? content[0] : content;
+    return toolOutput;
   }
 
   const schema: JsonObjectSchema<any> = {
@@ -1222,6 +1267,19 @@ export function mcpToFunctionTool(
         strict: true,
         execute: invoke,
         errorFunction,
+        customDataExtractor: async (context) => {
+          const mcpContext = getMcpCustomDataContext(
+            customDataByCall,
+            context.runContext,
+            context.toolCall.callId,
+          );
+          return mcpContext
+            ? maybeExtractToolOutputCustomData(
+                server.customDataExtractor,
+                mcpContext,
+              )
+            : undefined;
+        },
       });
     } catch (e) {
       globalLogger.warn(`Error converting MCP schema to strict mode: ${e}`);
@@ -1239,7 +1297,42 @@ export function mcpToFunctionTool(
     strict: false,
     execute: invoke,
     errorFunction,
+    customDataExtractor: async (context) => {
+      const mcpContext = getMcpCustomDataContext(
+        customDataByCall,
+        context.runContext,
+        context.toolCall.callId,
+      );
+      return mcpContext
+        ? maybeExtractToolOutputCustomData(
+            server.customDataExtractor,
+            mcpContext,
+          )
+        : undefined;
+    },
   });
+}
+
+function getMcpCustomDataContext(
+  contexts: WeakMap<
+    RunContext<any>,
+    Map<string, MCPToolCustomDataContext<any>>
+  >,
+  runContext: RunContext<any>,
+  callId: string,
+): MCPToolCustomDataContext<any> | undefined {
+  const byCall = contexts.get(runContext);
+  const context = byCall?.get(callId);
+  byCall?.delete(callId);
+  return context;
+}
+
+function cloneMcpCustomDataContextValue<T>(value: T): T {
+  try {
+    return structuredClone(value);
+  } catch {
+    return value;
+  }
 }
 
 /**
@@ -1282,6 +1375,10 @@ export interface BaseMCPServerStdioOptions {
    */
   useStructuredContent?: boolean;
   /**
+   * Optional callback that attaches SDK-only custom data to local MCP tool output items.
+   */
+  customDataExtractor?: MCPToolCustomDataExtractor;
+  /**
    * Optional function to convert MCP tool failures into model-visible messages.
    * Set to null to rethrow errors instead of converting them.
    */
@@ -1315,6 +1412,10 @@ export interface MCPServerStreamableHttpOptions {
    * Whether to use MCP `structuredContent` as model-visible output when available.
    */
   useStructuredContent?: boolean;
+  /**
+   * Optional callback that attaches SDK-only custom data to local MCP tool output items.
+   */
+  customDataExtractor?: MCPToolCustomDataExtractor;
   /**
    * Optional function to convert MCP tool failures into model-visible messages.
    * Set to null to rethrow errors instead of converting them.
@@ -1353,6 +1454,10 @@ export interface MCPServerSSEOptions {
    * Whether to use MCP `structuredContent` as model-visible output when available.
    */
   useStructuredContent?: boolean;
+  /**
+   * Optional callback that attaches SDK-only custom data to local MCP tool output items.
+   */
+  customDataExtractor?: MCPToolCustomDataExtractor;
   /**
    * Optional function to convert MCP tool failures into model-visible messages.
    * Set to null to rethrow errors instead of converting them.
@@ -1412,7 +1517,32 @@ export interface CallToolResponse extends JsonRpcResponse {
   };
 }
 export type CallToolResult = CallToolResponse['result'];
-export type CallToolResultContent = CallToolResult['content'];
+export type CallToolResultMetadata = Pick<
+  CallToolResult,
+  '_meta' | 'structuredContent' | 'isError'
+>;
+export type CallToolResultContent = CallToolResult['content'] &
+  CallToolResultMetadata;
+
+export function attachCallToolResultMetadata(
+  content: CallToolResult['content'],
+  metadata: CallToolResultMetadata,
+): CallToolResultContent {
+  const result = content as CallToolResultContent;
+  for (const [key, value] of Object.entries(metadata) as Array<
+    [keyof CallToolResultMetadata, unknown]
+  >) {
+    if (typeof value === 'undefined') {
+      continue;
+    }
+    Object.defineProperty(result, key, {
+      value,
+      enumerable: false,
+      configurable: true,
+    });
+  }
+  return result;
+}
 
 export interface InitializeResponse extends JsonRpcResponse {
   result: {

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -1201,7 +1201,9 @@ export function mcpToFunctionTool(
       ? await resolveMcpToolMeta(server, runContext, mcpTool.name, args)
       : undefined;
     const result: CallToolResult =
-      server.useStructuredContent === true && server.callToolResult
+      (server.useStructuredContent === true ||
+        server.customDataExtractor !== undefined) &&
+      server.callToolResult
         ? meta === undefined
           ? await server.callToolResult(mcpTool.name, args)
           : await server.callToolResult(mcpTool.name, args, meta)
@@ -1224,11 +1226,7 @@ export function mcpToFunctionTool(
         : content.length === 1
           ? content[0]
           : content;
-    if (
-      runContext &&
-      details?.toolCall?.callId &&
-      server.customDataExtractor
-    ) {
+    if (runContext && details?.toolCall?.callId && server.customDataExtractor) {
       let byCall = customDataByCall.get(runContext);
       if (!byCall) {
         byCall = new Map();

--- a/packages/agents-core/src/mcpUtil.ts
+++ b/packages/agents-core/src/mcpUtil.ts
@@ -2,6 +2,7 @@ import type { Agent } from './agent';
 import type { RunContext } from './runContext';
 import type { MCPTool } from './mcp';
 import type { UnknownContext } from './types';
+import type { ToolOutputCustomDataExtractor } from './utils/customData';
 
 /** Context information available to tool filter functions. */
 export interface MCPToolFilterContext<TContext = UnknownContext> {
@@ -33,6 +34,32 @@ export type MCPToolMetaResolver<TContext = UnknownContext> = (
   | Record<string, unknown>
   | null
   | undefined;
+
+/** Context information available to MCP tool custom data extractors. */
+export interface MCPToolCustomDataContext<TContext = UnknownContext> {
+  /** The current run context. */
+  runContext: RunContext<TContext>;
+  /** Name of the MCP server. */
+  serverName: string;
+  /** Original name of the tool on the MCP server. */
+  toolName: string;
+  /** Public function-tool name exposed through the Agents SDK. */
+  toolDisplayName: string;
+  /** Parsed tool arguments. */
+  arguments: Record<string, unknown> | null;
+  /** MCP tool result `_meta`, if present. */
+  resultMeta?: Record<string, unknown>;
+  /** MCP tool result `structuredContent`, if present. */
+  structuredContent?: Record<string, unknown>;
+  /** MCP tool result `isError`, if present. */
+  isError?: boolean;
+  /** The model-visible output produced from the MCP tool result. */
+  toolOutput: unknown;
+}
+
+/** A function that produces SDK-only custom data for MCP tool output items. */
+export type MCPToolCustomDataExtractor<TContext = UnknownContext> =
+  ToolOutputCustomDataExtractor<MCPToolCustomDataContext<TContext>>;
 
 /** A function that determines whether a tool should be available. */
 export type MCPToolFilterCallable<TContext = UnknownContext> = (

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -89,7 +89,8 @@ import {
  * - 1.10: Adds optional stable agent identity keys so duplicate-name agent graphs can
  *   serialize and resume without ambiguous name resolution.
  * - 1.11: Allows null maxTurns to persist runs without a turn limit.
- * - 1.12: Adds optional missing function tool calls to processed responses.
+ * - 1.12: Adds optional missing function tool calls to processed responses and optional
+ *   SDK-only customData on tool output run items.
  */
 export const CURRENT_SCHEMA_VERSION = '1.12' as const;
 const SUPPORTED_SCHEMA_VERSIONS = [
@@ -204,6 +205,7 @@ const itemSchema = z.discriminatedUnion('type', [
       .or(protocol.ApplyPatchCallResultItem),
     agent: serializedAgentSchema,
     output: z.string(),
+    customData: z.record(z.string(), z.any()).optional(),
   }),
   z.object({
     type: z.literal('reasoning_item'),
@@ -2090,6 +2092,7 @@ export function deserializeItem(
         serializedItem.rawItem,
         resolveSerializedAgent(serializedItem.agent, agentMap),
         serializedItem.output,
+        serializedItem.customData,
       );
     case 'reasoning_item':
       return new RunReasoningItem(

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -89,10 +89,10 @@ import {
  * - 1.10: Adds optional stable agent identity keys so duplicate-name agent graphs can
  *   serialize and resume without ambiguous name resolution.
  * - 1.11: Allows null maxTurns to persist runs without a turn limit.
- * - 1.12: Adds optional missing function tool calls to processed responses and optional
- *   SDK-only customData on tool output run items.
+ * - 1.12: Adds optional missing function tool calls to processed responses.
+ * - 1.13: Adds optional SDK-only customData on tool output run items.
  */
-export const CURRENT_SCHEMA_VERSION = '1.12' as const;
+export const CURRENT_SCHEMA_VERSION = '1.13' as const;
 const SUPPORTED_SCHEMA_VERSIONS = [
   '1.0',
   '1.1',
@@ -106,6 +106,7 @@ const SUPPORTED_SCHEMA_VERSIONS = [
   '1.9',
   '1.10',
   '1.11',
+  '1.12',
   CURRENT_SCHEMA_VERSION,
 ] as const;
 type SupportedSchemaVersion = (typeof SUPPORTED_SCHEMA_VERSIONS)[number];
@@ -1060,6 +1061,10 @@ async function buildRunStateFromString<
     currentSchemaVersion as SupportedSchemaVersion,
     stateJson,
   );
+  assertSchemaVersionSupportsCustomData(
+    currentSchemaVersion as SupportedSchemaVersion,
+    stateJson,
+  );
   return buildRunStateFromJson(initialAgent, stateJson, options);
 }
 
@@ -1072,6 +1077,7 @@ function assertSchemaVersionSupportsToolSearch(
     schemaVersion === '1.9' ||
     schemaVersion === '1.10' ||
     schemaVersion === '1.11' ||
+    schemaVersion === '1.12' ||
     schemaVersion === CURRENT_SCHEMA_VERSION
   ) {
     return;
@@ -1086,12 +1092,30 @@ function assertSchemaVersionSupportsToolSearch(
   );
 }
 
+function assertSchemaVersionSupportsCustomData(
+  schemaVersion: SupportedSchemaVersion,
+  stateJson: z.infer<typeof SerializedRunState>,
+): void {
+  if (schemaVersion === CURRENT_SCHEMA_VERSION) {
+    return;
+  }
+
+  if (!containsSerializedToolOutputCustomData(stateJson)) {
+    return;
+  }
+
+  throw new UserError(
+    `Run state schema version ${schemaVersion} does not support tool output customData. Please reserialize the run state with schema ${CURRENT_SCHEMA_VERSION}.`,
+  );
+}
+
 function schemaVersionSupportsAgentIdentity(
   schemaVersion: SupportedSchemaVersion,
 ): boolean {
   return (
     schemaVersion === '1.10' ||
     schemaVersion === '1.11' ||
+    schemaVersion === '1.12' ||
     schemaVersion === CURRENT_SCHEMA_VERSION
   );
 }
@@ -1149,6 +1173,29 @@ function containsToolSearchInProcessedResponse(
     | undefined,
 ): boolean {
   return containsToolSearchRunItems(processedResponse?.newItems);
+}
+
+function containsSerializedToolOutputCustomData(
+  stateJson: z.infer<typeof SerializedRunState>,
+): boolean {
+  return (
+    containsToolOutputCustomDataRunItems(stateJson.generatedItems) ||
+    containsToolOutputCustomDataRunItems(
+      stateJson.lastProcessedResponse?.newItems,
+    )
+  );
+}
+
+function containsToolOutputCustomDataRunItems(
+  items: z.infer<typeof itemSchema>[] | undefined,
+): boolean {
+  return Boolean(
+    items?.some(
+      (item) =>
+        item.type === 'tool_call_output_item' &&
+        Object.prototype.hasOwnProperty.call(item, 'customData'),
+    ),
+  );
 }
 
 function isToolSearchProtocolType(type: unknown): boolean {

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -24,7 +24,11 @@ import { ModelResponse } from '../model';
 import {
   ComputerSafetyCheck,
   ComputerSafetyCheckResult,
+  ComputerToolCustomDataContext,
   FunctionToolResult,
+  FunctionToolCustomDataContext,
+  FUNCTION_TOOL_PARSED_INPUT_CALLBACK,
+  ApplyPatchToolCustomDataContext,
   invokeFunctionTool,
   resolveComputer,
   Tool,
@@ -53,6 +57,7 @@ import {
   runToolOutputGuardrails,
 } from '../utils/toolGuardrails';
 import type { ToolInputGuardrailResult } from '../toolGuardrail';
+import { maybeExtractToolOutputCustomData } from '../utils/customData';
 import {
   resolveApprovalRejectionMessage,
   TOOL_APPROVAL_REJECTION_MESSAGE,
@@ -92,6 +97,14 @@ function getFunctionToolIdentity<TContext>(
   toolRun: ToolRunFunction<TContext>,
 ): string {
   return getFunctionToolQualifiedName(toolRun.tool) ?? toolRun.tool.name;
+}
+
+function cloneForCustomDataContext<T>(value: T): T {
+  try {
+    return structuredClone(value);
+  } catch {
+    return value;
+  }
 }
 
 function getFunctionToolTraceName<TContext>(
@@ -204,7 +217,7 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
     if (approvalOutcome !== 'approved') {
       return approvalOutcome;
     }
-    return runApprovedFunctionTool(deps, toolRun);
+    return runApprovedFunctionTool(deps, toolRun, parseResult.args);
   };
 
   try {
@@ -481,6 +494,7 @@ async function runFunctionToolInputGuardrails<TContext>({
 async function runApprovedFunctionTool<TContext>(
   deps: FunctionToolCallDeps<TContext>,
   toolRun: ToolRunFunction<TContext>,
+  parsedInput: unknown,
 ): Promise<FunctionToolResult<TContext>> {
   const { agent, runner, state, agentToolParentRunConfig } = deps;
   const toolName = getFunctionToolIdentity(toolRun);
@@ -510,6 +524,7 @@ async function runApprovedFunctionTool<TContext>(
       );
 
       let toolOutput: unknown;
+      let executedInput = parsedInput;
       if (inputGuardrailResult.type === 'reject') {
         toolOutput = inputGuardrailResult.message;
       } else {
@@ -520,6 +535,9 @@ async function runApprovedFunctionTool<TContext>(
         const toolDetails = {
           toolCall: toolRun.toolCall,
           resumeState,
+          [FUNCTION_TOOL_PARSED_INPUT_CALLBACK]: (input: unknown) => {
+            executedInput = cloneForCustomDataContext(input);
+          },
         };
         setAgentToolParentRunConfigOnDetails(
           toolDetails,
@@ -544,6 +562,19 @@ async function runApprovedFunctionTool<TContext>(
       }
       const stringResult = toSmartString(toolOutput);
 
+      const rawItem = getToolCallOutputItem(toolRun.toolCall, toolOutput);
+      const customData = await maybeExtractToolOutputCustomData(
+        toolRun.tool.customDataExtractor,
+        {
+          runContext: state._context,
+          tool: toolRun.tool,
+          toolCall: cloneForCustomDataContext(toolRun.toolCall),
+          input: cloneForCustomDataContext(executedInput),
+          output: cloneForCustomDataContext(toolOutput),
+          rawItem: cloneForCustomDataContext(rawItem),
+        } satisfies FunctionToolCustomDataContext<TContext>,
+      );
+
       emitToolEnd(
         runner,
         state._context,
@@ -562,9 +593,10 @@ async function runApprovedFunctionTool<TContext>(
         tool: toolRun.tool,
         output: toolOutput,
         runItem: new RunToolCallOutputItem(
-          getToolCallOutputItem(toolRun.toolCall, toolOutput),
+          rawItem,
           agent,
           toolOutput,
+          customData,
         ),
       };
 
@@ -1122,6 +1154,28 @@ export async function executeApplyPatchOperations(
           _logger.error('Failed to execute apply_patch operation:', err);
         }
 
+        const rawItem: protocol.ApplyPatchCallResultItem = {
+          type: 'apply_patch_call_output',
+          callId: toolCallKey,
+          status,
+        };
+
+        if (output) {
+          rawItem.output = output;
+        }
+
+        const customData = await maybeExtractToolOutputCustomData(
+          applyPatchTool.customDataExtractor,
+          {
+            runContext,
+            tool: applyPatchTool,
+            operation: cloneForCustomDataContext(toolCall.operation),
+            output,
+            status,
+            rawItem: cloneForCustomDataContext(rawItem),
+          } satisfies ApplyPatchToolCustomDataContext,
+        );
+
         emitToolEnd(
           runner,
           runContext,
@@ -1135,17 +1189,7 @@ export async function executeApplyPatchOperations(
           span.spanData.output = output;
         }
 
-        const rawItem: protocol.ApplyPatchCallResultItem = {
-          type: 'apply_patch_call_output',
-          callId: toolCallKey,
-          status,
-        };
-
-        if (output) {
-          rawItem.output = output;
-        }
-
-        return new RunToolCallOutputItem(rawItem, agent, output);
+        return new RunToolCallOutputItem(rawItem, agent, output, customData);
       },
     );
 
@@ -1309,14 +1353,8 @@ export async function executeComputerActions(
           });
         }
 
-        // Hooks: on_tool_end (global + agent)
-        emitToolEnd(runner, runContext, agent, computerTool, output, toolCall);
-
         // Return the screenshot as a data URL when available; fall back to an empty string on failures.
         const imageUrl = output ? `data:image/png;base64,${output}` : '';
-        if (span && runner.config.traceIncludeSensitiveData) {
-          span.spanData.output = imageUrl;
-        }
         const rawItem: protocol.ComputerCallResultItem = {
           type: 'computer_call_result',
           callId: toolCall.callId,
@@ -1327,7 +1365,25 @@ export async function executeComputerActions(
             acknowledgedSafetyChecks,
           };
         }
-        return new RunToolCallOutputItem(rawItem, agent, imageUrl);
+        const customData = await maybeExtractToolOutputCustomData(
+          computerTool.customDataExtractor,
+          {
+            runContext,
+            tool: computerTool,
+            toolCall: cloneForCustomDataContext(toolCall),
+            output: imageUrl,
+            rawItem: cloneForCustomDataContext(rawItem),
+          } satisfies ComputerToolCustomDataContext,
+        );
+
+        // Hooks: on_tool_end (global + agent)
+        emitToolEnd(runner, runContext, agent, computerTool, output, toolCall);
+
+        if (span && runner.config.traceIncludeSensitiveData) {
+          span.spanData.output = imageUrl;
+        }
+
+        return new RunToolCallOutputItem(rawItem, agent, imageUrl, customData);
       },
     );
 

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -19,6 +19,7 @@ import {
   MCPServerStreamableHttpOptions,
   MCPServerSSEOptions,
   MCPTool,
+  attachCallToolResultMetadata,
   invalidateServerToolsCache,
 } from '../../mcp';
 import logger from '../../logger';
@@ -42,6 +43,17 @@ npm install @modelcontextprotocol/sdk
     `.trim(),
   );
   throw error;
+}
+
+function attachParsedCallToolResultMetadata(
+  result: CallToolResult,
+): CallToolResult {
+  result.content = attachCallToolResultMetadata(result.content, {
+    _meta: result._meta,
+    structuredContent: result.structuredContent,
+    isError: result.isError,
+  });
+  return result;
 }
 
 function buildRequestOptions(
@@ -299,7 +311,7 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
       requestOptions,
     );
     const parsed = CallToolResultSchema.parse(response);
-    const result = parsed as CallToolResult;
+    const result = attachParsedCallToolResultMetadata(parsed as CallToolResult);
     this.debugLog(
       () =>
         `Called tool ${toolName} (args: ${JSON.stringify(args)}, result: ${JSON.stringify(result)})`,
@@ -510,7 +522,7 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
       requestOptions,
     );
     const parsed = CallToolResultSchema.parse(response);
-    const result = parsed as CallToolResult;
+    const result = attachParsedCallToolResultMetadata(parsed as CallToolResult);
     this.debugLog(
       () =>
         `Called tool ${toolName} (args: ${JSON.stringify(args)}, result: ${JSON.stringify(result)})`,
@@ -904,7 +916,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     };
     const response = await client.callTool(params, undefined, requestOptions);
     const parsed = CallToolResultSchema.parse(response);
-    return parsed as CallToolResult;
+    return attachParsedCallToolResultMetadata(parsed as CallToolResult);
   }
 
   private async closeStreamableHttpClient(

--- a/packages/agents-core/src/tool.ts
+++ b/packages/agents-core/src/tool.ts
@@ -38,6 +38,9 @@ import {
   ToolInputGuardrailFunction,
   ToolOutputGuardrailFunction,
 } from './toolGuardrail';
+import type { ToolOutputCustomDataExtractor } from './utils/customData';
+
+export type { ToolOutputCustomData } from './utils/customData';
 
 export type {
   ToolOutputText,
@@ -61,15 +64,71 @@ export type ToolApprovalFunction<TParameters extends ToolInputParameters> = (
   callId?: string,
 ) => Promise<boolean>;
 
+export const FUNCTION_TOOL_PARSED_INPUT_CALLBACK = Symbol(
+  'openai.agents.functionToolParsedInputCallback',
+);
+
 export type ToolCallDetails = {
   toolCall?: protocol.FunctionCallItem;
   resumeState?: string;
   signal?: AbortSignal;
+  [FUNCTION_TOOL_PARSED_INPUT_CALLBACK]?: (input: unknown) => void;
   /**
    * Internal: parent runner config for nested agent-tool runs (Agent.asTool).
    */
   parentRunConfig?: Partial<RunConfig>;
 };
+
+export type FunctionToolCustomDataContext<
+  Context = UnknownContext,
+  TParameters extends ToolInputParameters = ToolInputParameters,
+  Result = unknown,
+> = {
+  runContext: RunContext<Context>;
+  tool: FunctionTool<Context, TParameters, Result>;
+  toolCall: protocol.FunctionCallItem;
+  input: unknown;
+  output: unknown;
+  rawItem: protocol.FunctionCallResultItem;
+};
+
+export type FunctionToolCustomDataExtractor<
+  Context = UnknownContext,
+  TParameters extends ToolInputParameters = ToolInputParameters,
+  Result = unknown,
+> = ToolOutputCustomDataExtractor<
+  FunctionToolCustomDataContext<Context, TParameters, Result>
+>;
+
+export type ComputerToolCustomDataContext<
+  Context = UnknownContext,
+  TComputer extends Computer = Computer,
+> = {
+  runContext: RunContext<Context>;
+  tool: ComputerTool<Context, TComputer>;
+  toolCall: protocol.ComputerUseCallItem;
+  output: string;
+  rawItem: protocol.ComputerCallResultItem;
+};
+
+export type ComputerToolCustomDataExtractor<
+  Context = UnknownContext,
+  TComputer extends Computer = Computer,
+> = ToolOutputCustomDataExtractor<
+  ComputerToolCustomDataContext<Context, TComputer>
+>;
+
+export type ApplyPatchToolCustomDataContext = {
+  runContext: RunContext;
+  tool: ApplyPatchTool;
+  operation: ApplyPatchOperation;
+  output: string;
+  status: protocol.ApplyPatchCallResultItem['status'];
+  rawItem: protocol.ApplyPatchCallResultItem;
+};
+
+export type ApplyPatchToolCustomDataExtractor =
+  ToolOutputCustomDataExtractor<ApplyPatchToolCustomDataContext>;
 
 export type FunctionToolTimeoutBehavior = 'error_as_result' | 'raise_exception';
 
@@ -293,6 +352,15 @@ export type FunctionTool<
    * Guardrails that run after the tool executes.
    */
   outputGuardrails?: ToolOutputGuardrailDefinition<Context>[];
+
+  /**
+   * Optional callback that attaches SDK-only custom data to the emitted tool output item.
+   */
+  customDataExtractor?: FunctionToolCustomDataExtractor<
+    Context,
+    TParameters,
+    Result
+  >;
 };
 
 /**
@@ -426,6 +494,11 @@ export type ComputerTool<
    * Optional handler to acknowledge pending safety checks.
    */
   onSafetyCheck?: ComputerOnSafetyCheckFunction;
+
+  /**
+   * Optional callback that attaches SDK-only custom data to the emitted tool output item.
+   */
+  customDataExtractor?: ComputerToolCustomDataExtractor<Context, TComputer>;
 };
 
 /**
@@ -442,6 +515,7 @@ export function computerTool<
   computer: ComputerConfig<Context, TComputer>;
   needsApproval?: boolean | ComputerApprovalFunction;
   onSafetyCheck?: ComputerOnSafetyCheckFunction;
+  customDataExtractor?: ComputerToolCustomDataExtractor<Context, TComputer>;
 }): ComputerTool<Context, TComputer> {
   if (!options.computer) {
     throw new UserError(
@@ -463,6 +537,7 @@ export function computerTool<
     computer: options.computer,
     needsApproval,
     onSafetyCheck: options.onSafetyCheck,
+    customDataExtractor: options.customDataExtractor,
   };
 
   if (
@@ -867,6 +942,11 @@ export type ApplyPatchTool = {
    * Optional handler to auto-approve or reject when approval is required.
    */
   onApproval?: ApplyPatchOnApprovalFunction;
+
+  /**
+   * Optional callback that attaches SDK-only custom data to the emitted tool output item.
+   */
+  customDataExtractor?: ApplyPatchToolCustomDataExtractor;
 };
 
 export function applyPatchTool(
@@ -876,6 +956,7 @@ export function applyPatchTool(
     editor: Editor;
     needsApproval?: boolean | ApplyPatchApprovalFunction;
     onApproval?: ApplyPatchOnApprovalFunction;
+    customDataExtractor?: ApplyPatchToolCustomDataExtractor;
   },
 ): ApplyPatchTool {
   const needsApproval: ApplyPatchApprovalFunction =
@@ -892,6 +973,7 @@ export function applyPatchTool(
     editor: options.editor,
     needsApproval,
     onApproval: options.onApproval,
+    customDataExtractor: options.customDataExtractor,
   };
 }
 
@@ -1427,6 +1509,11 @@ type StrictToolOptions<
    * Optional formatter used for timeout messages when timeoutBehavior is `error_as_result`.
    */
   timeoutErrorFunction?: ToolTimeoutErrorFunction<Context>;
+
+  /**
+   * Optional callback that attaches SDK-only custom data to the emitted tool output item.
+   */
+  customDataExtractor?: FunctionToolCustomDataExtractor<Context>;
 };
 
 /**
@@ -1500,6 +1587,11 @@ type NonStrictToolOptions<
    * Optional formatter used for timeout messages when timeoutBehavior is `error_as_result`.
    */
   timeoutErrorFunction?: ToolTimeoutErrorFunction<Context>;
+
+  /**
+   * Optional callback that attaches SDK-only custom data to the emitted tool output item.
+   */
+  customDataExtractor?: FunctionToolCustomDataExtractor<Context>;
 };
 
 /**
@@ -1832,6 +1924,7 @@ export function tool<
       logger.debug(`Invoking tool ${name} with input ${input}`);
     }
 
+    details?.[FUNCTION_TOOL_PARSED_INPUT_CALLBACK]?.(parsed);
     const result = await options.execute(parsed, runContext, details);
     const stringResult = toSmartString(result);
 
@@ -1930,6 +2023,7 @@ export function tool<
     isEnabled,
     inputGuardrails: resolveToolInputGuardrails(options.inputGuardrails),
     outputGuardrails: resolveToolOutputGuardrails(options.outputGuardrails),
+    customDataExtractor: options.customDataExtractor,
   };
 }
 

--- a/packages/agents-core/src/utils/customData.ts
+++ b/packages/agents-core/src/utils/customData.ts
@@ -1,0 +1,106 @@
+import { UserError } from '../errors';
+
+export type ToolOutputCustomData = Record<string, unknown>;
+
+export type MaybePromise<T> = T | Promise<T>;
+
+export type ToolOutputCustomDataExtractor<TContext> = (
+  context: TContext,
+) => MaybePromise<ToolOutputCustomData | null | undefined>;
+
+export function normalizeToolOutputCustomData(
+  value: ToolOutputCustomData | null | undefined,
+): ToolOutputCustomData | undefined {
+  if (value == null) {
+    return undefined;
+  }
+
+  if (!isRecord(value)) {
+    throw new UserError('customDataExtractor must return an object or null.');
+  }
+
+  if (Reflect.ownKeys(value).some((key) => typeof key !== 'string')) {
+    throw new UserError(
+      'customDataExtractor must return an object with string keys.',
+    );
+  }
+
+  if (Object.keys(value).length === 0) {
+    return undefined;
+  }
+
+  assertJsonCompatible(value, 'customDataExtractor result');
+  return JSON.parse(JSON.stringify(value)) as ToolOutputCustomData;
+}
+
+export async function maybeExtractToolOutputCustomData<TContext>(
+  extractor: ToolOutputCustomDataExtractor<TContext> | undefined,
+  context: TContext,
+): Promise<ToolOutputCustomData | undefined> {
+  if (!extractor) {
+    return undefined;
+  }
+
+  return normalizeToolOutputCustomData(await extractor(context));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    (Object.getPrototypeOf(value) === Object.prototype ||
+      Object.getPrototypeOf(value) === null)
+  );
+}
+
+function assertJsonCompatible(value: unknown, path: string): void {
+  if (value == null) {
+    return;
+  }
+
+  const valueType = typeof value;
+  if (valueType === 'string' || valueType === 'boolean') {
+    return;
+  }
+  if (valueType === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new UserError(
+        'customDataExtractor must return JSON-compatible data.',
+      );
+    }
+    return;
+  }
+  if (
+    valueType === 'undefined' ||
+    valueType === 'function' ||
+    valueType === 'symbol' ||
+    valueType === 'bigint'
+  ) {
+    throw new UserError(
+      'customDataExtractor must return JSON-compatible data.',
+    );
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) =>
+      assertJsonCompatible(entry, `${path}[${index}]`),
+    );
+    return;
+  }
+
+  if (!isRecord(value)) {
+    throw new UserError(
+      'customDataExtractor must return JSON-compatible data.',
+    );
+  }
+
+  for (const key of Reflect.ownKeys(value)) {
+    if (typeof key !== 'string') {
+      throw new UserError(
+        'customDataExtractor must return JSON-compatible data.',
+      );
+    }
+    assertJsonCompatible(value[key], `${path}.${key}`);
+  }
+}

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -892,6 +892,34 @@ describe('RunState', () => {
     );
   });
 
+  it('rejects schema version 1.12 payloads with tool output customData', async () => {
+    const context = new RunContext();
+    const agent = new Agent({ name: 'CustomDataVersionAgent' });
+    const state = new RunState(context, 'input1', agent, 2);
+    const rawItem: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      name: 'lookup',
+      callId: 'call_custom_data',
+      status: 'completed',
+      output: 'done',
+    };
+    state._generatedItems.push(
+      new RunToolCallOutputItem(rawItem, agent, 'done', {
+        auditId: 'audit_123',
+      }),
+    );
+
+    const jsonVersion = state.toJSON() as any;
+    expect(jsonVersion.$schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+    jsonVersion.$schemaVersion = '1.12';
+
+    await expect(() =>
+      RunState.fromString(agent, JSON.stringify(jsonVersion)),
+    ).rejects.toThrow(
+      'Run state schema version 1.12 does not support tool output customData.',
+    );
+  });
+
   it('accepts schema version 1.6 payloads during deserialization', async () => {
     const context = new RunContext();
     const agent = new Agent({ name: 'Agent16' });

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -699,6 +699,104 @@ describe('executeComputerActions', () => {
     expect((items[0] as any).output).toBe('data:image/png;base64,img');
   });
 
+  it('does not emit a success end event when computer customDataExtractor fails', async () => {
+    const fakeComputer = {
+      environment: 'mac',
+      dimensions: [1, 1] as [number, number],
+      screenshot: vi.fn().mockResolvedValue('img'),
+      click: vi.fn(),
+      doubleClick: vi.fn(),
+      drag: vi.fn(),
+      keypress: vi.fn(),
+      move: vi.fn(),
+      scroll: vi.fn(),
+      type: vi.fn(),
+      wait: vi.fn(),
+    } as any;
+    const tool = computerTool({
+      computer: fakeComputer,
+      customDataExtractor: () => ({ bad: BigInt(1) }) as any,
+    });
+    const call: protocol.ComputerUseCallItem = {
+      type: 'computer_call',
+      callId: 'c1_bad_custom_data',
+      status: 'completed',
+      action: { type: 'screenshot' } as any,
+    };
+    const runner = new Runner();
+    const end = vi.fn();
+    runner.on('agent_tool_end', end);
+
+    await expect(
+      executeComputerActions(
+        new Agent({ name: 'Comp' }),
+        [{ toolCall: call, computer: tool }],
+        runner,
+        new RunContext(),
+      ),
+    ).rejects.toThrow(/customDataExtractor must return JSON-compatible data/);
+
+    expect(end).not.toHaveBeenCalled();
+  });
+
+  it('passes a cloned computer tool call to customDataExtractor', async () => {
+    const fakeComputer = {
+      environment: 'mac',
+      dimensions: [1, 1] as [number, number],
+      screenshot: vi.fn().mockResolvedValue('img'),
+      click: vi.fn(),
+      doubleClick: vi.fn(),
+      drag: vi.fn(),
+      keypress: vi.fn(),
+      move: vi.fn(),
+      scroll: vi.fn(),
+      type: vi.fn(),
+      wait: vi.fn(),
+    } as any;
+    const tool = computerTool({
+      computer: fakeComputer,
+      customDataExtractor: (context) => {
+        (context.toolCall as any).sdkOnly = { traceId: 'sdk-only' };
+        context.toolCall.action = {
+          type: 'click',
+          button: 'left',
+          x: 1,
+          y: 2,
+        } as any;
+        return { annotatedCall: context.toolCall };
+      },
+    });
+    const call: protocol.ComputerUseCallItem = {
+      type: 'computer_call',
+      callId: 'c1_cloned_custom_data',
+      status: 'completed',
+      action: { type: 'screenshot' } as any,
+    };
+
+    const items = await executeComputerActions(
+      new Agent({ name: 'Comp' }),
+      [{ toolCall: call, computer: tool }],
+      new Runner(),
+      new RunContext(),
+    );
+
+    expect((call as any).sdkOnly).toBeUndefined();
+    expect(call.action).toEqual({ type: 'screenshot' });
+    expect(items[0]).toBeInstanceOf(ToolCallOutputItem);
+    expect((items[0] as ToolCallOutputItem).customData).toEqual({
+      annotatedCall: {
+        ...call,
+        action: {
+          type: 'click',
+          button: 'left',
+          x: 1,
+          y: 2,
+        },
+        sdkOnly: { traceId: 'sdk-only' },
+      },
+    });
+  });
+
   it('emits a function span for computer actions', async () => {
     const fakeComputer = {
       environment: 'mac',
@@ -1748,6 +1846,41 @@ describe('executeShellActions', () => {
       expect(editor.operations).toHaveLength(1);
     });
 
+    it('does not emit a success end event when apply_patch customDataExtractor fails', async () => {
+      const editor = new FakeEditor();
+      const applyPatch = applyPatchTool({
+        editor,
+        customDataExtractor: () => ({ bad: BigInt(1) }) as any,
+      });
+      const agent = new Agent({ name: 'EditorAgent' });
+      const runContext = new RunContext();
+      const runner = new Runner({ tracingDisabled: true });
+      const end = vi.fn();
+      runner.on('agent_tool_end', end);
+      const toolCall: protocol.ApplyPatchCallItem = {
+        type: 'apply_patch_call',
+        callId: 'call_patch_bad_custom_data',
+        status: 'completed',
+        operation: {
+          type: 'update_file',
+          path: 'README.md',
+          diff: 'diff --git',
+        },
+      };
+
+      await expect(
+        executeApplyPatchOperations(
+          agent,
+          [{ toolCall, applyPatch } as any],
+          runner,
+          runContext,
+        ),
+      ).rejects.toThrow(/customDataExtractor must return JSON-compatible data/);
+
+      expect(end).not.toHaveBeenCalled();
+      expect(editor.operations).toHaveLength(1);
+    });
+
     it('passes RunContext to apply_patch editor operations', async () => {
       const editor = new FakeEditor();
       const applyPatch = applyPatchTool({ editor });
@@ -2609,6 +2742,140 @@ describe('executeShellActions', () => {
       );
       expect(res[0].runItem).toBeInstanceOf(ToolCallOutputItem);
       expect(invokeSpy).toHaveBeenCalled();
+    });
+
+    it('passes a cloned tool call to customDataExtractor', async () => {
+      const localToolCall = {
+        ...toolCall,
+        callId: 'c_cloned_tool_call',
+        arguments: '{}',
+      };
+      const t = tool({
+        name: 'hi',
+        description: 't',
+        parameters: z.object({}),
+        execute: vi.fn(async () => 'ok'),
+        customDataExtractor: (context) => {
+          (context.toolCall as any).sdkOnly = { traceId: 'sdk-only' };
+          context.toolCall.arguments = '{"leaked":true}';
+          return { annotatedCall: context.toolCall };
+        },
+      }) as unknown as FunctionTool;
+
+      const res = await withTrace('test', () =>
+        executeFunctionToolCalls(
+          state._currentAgent,
+          [{ toolCall: localToolCall, tool: t }],
+          runner,
+          state,
+        ),
+      );
+
+      expect(res[0].type).toBe('function_output');
+      expect((localToolCall as any).sdkOnly).toBeUndefined();
+      expect(localToolCall.arguments).toBe('{}');
+      if (res[0].type === 'function_output') {
+        expect(res[0].runItem.customData).toEqual({
+          annotatedCall: {
+            ...localToolCall,
+            arguments: '{"leaked":true}',
+            sdkOnly: { traceId: 'sdk-only' },
+          },
+        });
+      }
+    });
+
+    it('passes the executed tool input to customDataExtractor', async () => {
+      const executedInputs: unknown[] = [];
+      const t = tool({
+        name: 'hi',
+        description: 't',
+        parameters: z.object({
+          name: z.string(),
+          optional: z.string().optional(),
+          withDefault: z.string().default('default-value'),
+        }),
+        execute: vi.fn(async (input) => {
+          executedInputs.push(input);
+          return 'ok';
+        }),
+        customDataExtractor: (context) => ({
+          input: context.input,
+        }),
+      }) as unknown as FunctionTool;
+      const localToolCall = {
+        ...toolCall,
+        callId: 'c_executed_input_custom_data',
+        arguments: JSON.stringify({
+          name: 'alice',
+          optional: null,
+        }),
+      };
+
+      const res = await withTrace('test', () =>
+        executeFunctionToolCalls(
+          state._currentAgent,
+          [{ toolCall: localToolCall, tool: t }],
+          runner,
+          state,
+        ),
+      );
+
+      const expectedInput = {
+        name: 'alice',
+        withDefault: 'default-value',
+      };
+      expect(executedInputs).toEqual([expectedInput]);
+      expect(res[0].type).toBe('function_output');
+      if (res[0].type === 'function_output') {
+        expect(res[0].runItem.customData).toEqual({
+          input: expectedInput,
+        });
+      }
+    });
+
+    it('emits a single error end event when customDataExtractor fails', async () => {
+      const t = tool({
+        name: 'hi',
+        description: 't',
+        parameters: z.object({}),
+        execute: vi.fn(async () => 'ok'),
+        customDataExtractor: () => ({ bad: BigInt(1) }) as any,
+      }) as unknown as FunctionTool;
+      const start = vi.fn();
+      const end = vi.fn();
+      runner.on('agent_tool_start', start);
+      runner.on('agent_tool_end', end);
+
+      await expect(
+        withTrace('test', () =>
+          executeFunctionToolCalls(
+            state._currentAgent,
+            [{ toolCall, tool: t }],
+            runner,
+            state,
+          ),
+        ),
+      ).rejects.toThrow(/customDataExtractor must return JSON-compatible data/);
+
+      expect(start).toHaveBeenCalledTimes(1);
+      expect(end).toHaveBeenCalledTimes(1);
+      expect(end).toHaveBeenCalledWith(
+        state._context,
+        state._currentAgent,
+        t,
+        expect.stringContaining(
+          'customDataExtractor must return JSON-compatible data',
+        ),
+        { toolCall },
+      );
+      expect(end).not.toHaveBeenCalledWith(
+        state._context,
+        state._currentAgent,
+        t,
+        'ok',
+        { toolCall },
+      );
     });
 
     it('starts all function tool calls by default', async () => {

--- a/packages/agents-core/test/toolCustomData.test.ts
+++ b/packages/agents-core/test/toolCustomData.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { Agent } from '../src/agent';
+import { RunToolCallOutputItem } from '../src/items';
+import type { ModelRequest, ModelResponse } from '../src/model';
+import type { MCPServer, MCPTool } from '../src/mcp';
+import { attachCallToolResultMetadata, mcpToFunctionTool } from '../src/mcp';
+import { run, Runner } from '../src/run';
+import { RunContext } from '../src/runContext';
+import { RunState } from '../src/runState';
+import { applyPatchTool, computerTool, tool } from '../src/tool';
+import {
+  executeApplyPatchOperations,
+  executeComputerActions,
+} from '../src/runner/toolExecution';
+import * as protocol from '../src/types/protocol';
+import { ToolCallError, UserError } from '../src/errors';
+import { Usage } from '../src/usage';
+import { FakeComputer, FakeEditor, FakeModel, fakeModelMessage } from './stubs';
+
+class RecordingModel extends FakeModel {
+  readonly requests: ModelRequest[] = [];
+
+  async getResponse(request: ModelRequest): Promise<ModelResponse> {
+    this.requests.push(request);
+    return super.getResponse(request);
+  }
+}
+
+function toolOutputItem(items: unknown[]): RunToolCallOutputItem {
+  const item = items.find(
+    (candidate) => candidate instanceof RunToolCallOutputItem,
+  );
+  expect(item).toBeDefined();
+  return item as RunToolCallOutputItem;
+}
+
+describe('tool output customData', () => {
+  it('attaches function tool customData without replaying it to the model', async () => {
+    const model = new RecordingModel([
+      {
+        output: [
+          {
+            type: 'function_call',
+            name: 'get_data',
+            callId: 'call_custom_data',
+            status: 'completed',
+            arguments: '{"key":"alpha"}',
+          },
+        ],
+        usage: new Usage(),
+      },
+      {
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+      },
+    ]);
+    const getData = tool({
+      name: 'get_data',
+      description: 'Get data.',
+      parameters: z.object({ key: z.string() }),
+      execute: ({ key }) => `tool result for ${key}`,
+      customDataExtractor: (context) => {
+        (context.rawItem as any).providerData = { leaked: true };
+        return {
+          callId: context.rawItem.callId,
+          output: context.output,
+        };
+      },
+    });
+    const agent = new Agent({
+      name: 'CustomDataAgent',
+      model,
+      tools: [getData],
+      toolUseBehavior: 'run_llm_again',
+    });
+
+    const result = await run(agent, 'start');
+
+    const outputItem = toolOutputItem(result.newItems);
+    expect(outputItem.customData).toEqual({
+      callId: 'call_custom_data',
+      output: 'tool result for alpha',
+    });
+    expect(outputItem.rawItem.providerData).toBeUndefined();
+
+    const secondInput = model.requests[1].input as protocol.ModelItem[];
+    expect(JSON.stringify(secondInput)).not.toContain('customData');
+    expect(JSON.stringify(secondInput)).not.toContain('leaked');
+
+    const restored = await RunState.fromString(agent, result.state.toString());
+    const restoredOutput = toolOutputItem(restored._generatedItems);
+    expect(restoredOutput.customData).toEqual(outputItem.customData);
+    expect(JSON.stringify(restored.history)).not.toContain('customData');
+  });
+
+  it('rejects non-JSON-compatible customData', async () => {
+    const model = new RecordingModel([
+      {
+        output: [
+          {
+            type: 'function_call',
+            name: 'bad_data',
+            callId: 'call_bad_data',
+            status: 'completed',
+            arguments: '{}',
+          },
+        ],
+        usage: new Usage(),
+      },
+    ]);
+    const badData = tool({
+      name: 'bad_data',
+      description: 'Return invalid custom data.',
+      parameters: z.object({}),
+      execute: () => 'ok',
+      customDataExtractor: () => ({ bad: BigInt(1) }) as any,
+    });
+    const agent = new Agent({
+      name: 'BadCustomDataAgent',
+      model,
+      tools: [badData],
+    });
+
+    const runPromise = run(agent, 'start');
+
+    await expect(runPromise).rejects.toThrow(ToolCallError);
+    await expect(runPromise).rejects.toThrow(
+      'customDataExtractor must return JSON-compatible data.',
+    );
+    await runPromise.catch((error) => {
+      expect(error).toBeInstanceOf(ToolCallError);
+      expect((error as ToolCallError).error).toBeInstanceOf(UserError);
+    });
+  });
+
+  it('maps local MCP result metadata to tool output customData', async () => {
+    const model = new RecordingModel([
+      {
+        output: [
+          {
+            type: 'function_call',
+            name: 'meta_tool',
+            callId: 'call_mcp_meta',
+            status: 'completed',
+            arguments: '{}',
+          },
+        ],
+        usage: new Usage(),
+      },
+      {
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+      },
+    ]);
+    const server: MCPServer = {
+      name: 'meta-server',
+      cacheToolsList: false,
+      customDataExtractor: (context) => ({
+        responseMeta: context.resultMeta,
+        structuredContent: context.structuredContent,
+        isError: context.isError,
+        output: context.toolOutput,
+      }),
+      connect: async () => {},
+      close: async () => {},
+      listTools: async () => [],
+      callTool: async () =>
+        attachCallToolResultMetadata([{ type: 'text', text: 'mcp result' }], {
+          _meta: { renderer: { type: 'chart' } },
+          structuredContent: { rows: [{ x: 1, y: 2 }] },
+          isError: false,
+        }),
+      invalidateToolsCache: async () => {},
+    };
+    const mcpTool = mcpToFunctionTool(
+      {
+        name: 'meta_tool',
+        description: 'Returns metadata.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      } satisfies MCPTool,
+      server,
+      false,
+    );
+    const agent = new Agent({
+      name: 'McpCustomDataAgent',
+      model,
+      tools: [mcpTool],
+      toolUseBehavior: 'run_llm_again',
+    });
+
+    const result = await run(agent, 'start');
+
+    const outputItem = toolOutputItem(result.newItems);
+    expect(outputItem.customData).toEqual({
+      responseMeta: { renderer: { type: 'chart' } },
+      structuredContent: { rows: [{ x: 1, y: 2 }] },
+      isError: false,
+      output: { type: 'text', text: 'mcp result' },
+    });
+    expect(JSON.stringify(model.requests[1].input)).not.toContain('customData');
+  });
+
+  it('attaches computer tool customData', async () => {
+    const computer = computerTool({
+      computer: new FakeComputer(),
+      customDataExtractor: (context) => ({
+        callId: context.toolCall.callId,
+        output: context.output,
+      }),
+    });
+    const agent = new Agent({ name: 'ComputerAgent', tools: [computer] });
+    const toolCall: protocol.ComputerUseCallItem = {
+      type: 'computer_call',
+      callId: 'call_computer',
+      status: 'completed',
+      action: { type: 'screenshot' },
+    };
+
+    const [item] = await executeComputerActions(
+      agent,
+      [{ toolCall, computer }],
+      new Runner({ tracingDisabled: true }),
+      new RunContext(),
+    );
+
+    expect(item).toBeInstanceOf(RunToolCallOutputItem);
+    expect((item as RunToolCallOutputItem).customData).toEqual({
+      callId: 'call_computer',
+      output: 'data:image/png;base64,img',
+    });
+  });
+
+  it('attaches apply_patch tool customData', async () => {
+    const patchTool = applyPatchTool({
+      editor: new FakeEditor(),
+      customDataExtractor: (context) => {
+        (context.rawItem as any).status = 'failed';
+        return {
+          status: context.status,
+          path: context.operation.path,
+        };
+      },
+    });
+    const agent = new Agent({ name: 'PatchAgent', tools: [patchTool] });
+    const toolCall: protocol.ApplyPatchCallItem = {
+      type: 'apply_patch_call',
+      callId: 'call_patch',
+      status: 'completed',
+      operation: {
+        type: 'create_file',
+        path: 'tasks.md',
+        diff: '+hello\n',
+      },
+    };
+
+    const [item] = await executeApplyPatchOperations(
+      agent,
+      [{ toolCall, applyPatch: patchTool }],
+      new Runner({ tracingDisabled: true }),
+      new RunContext(),
+    );
+
+    expect(item).toBeInstanceOf(RunToolCallOutputItem);
+    expect((item as RunToolCallOutputItem).customData).toEqual({
+      status: 'completed',
+      path: 'tasks.md',
+    });
+    expect(
+      (
+        (item as RunToolCallOutputItem)
+          .rawItem as protocol.ApplyPatchCallResultItem
+      ).status,
+    ).toBe('completed');
+  });
+});

--- a/packages/agents-core/test/toolCustomData.test.ts
+++ b/packages/agents-core/test/toolCustomData.test.ts
@@ -5,7 +5,7 @@ import { Agent } from '../src/agent';
 import { RunToolCallOutputItem } from '../src/items';
 import type { ModelRequest, ModelResponse } from '../src/model';
 import type { MCPServer, MCPTool } from '../src/mcp';
-import { attachCallToolResultMetadata, mcpToFunctionTool } from '../src/mcp';
+import { mcpToFunctionTool } from '../src/mcp';
 import { run, Runner } from '../src/run';
 import { RunContext } from '../src/runContext';
 import { RunState } from '../src/runState';
@@ -166,12 +166,17 @@ describe('tool output customData', () => {
       connect: async () => {},
       close: async () => {},
       listTools: async () => [],
-      callTool: async () =>
-        attachCallToolResultMetadata([{ type: 'text', text: 'mcp result' }], {
-          _meta: { renderer: { type: 'chart' } },
-          structuredContent: { rows: [{ x: 1, y: 2 }] },
-          isError: false,
-        }),
+      callTool: async () => {
+        throw new Error(
+          'callTool should not be used when extracting metadata.',
+        );
+      },
+      callToolResult: async () => ({
+        content: [{ type: 'text', text: 'mcp result' }],
+        _meta: { renderer: { type: 'chart' } },
+        structuredContent: { rows: [{ x: 1, y: 2 }] },
+        isError: false,
+      }),
       invalidateToolsCache: async () => {},
     };
     const mcpTool = mcpToFunctionTool(
@@ -204,7 +209,10 @@ describe('tool output customData', () => {
       isError: false,
       output: { type: 'text', text: 'mcp result' },
     });
-    expect(JSON.stringify(model.requests[1].input)).not.toContain('customData');
+    const modelInput = JSON.stringify(model.requests[1].input);
+    expect(modelInput).toContain('mcp result');
+    expect(modelInput).not.toContain('rows');
+    expect(modelInput).not.toContain('customData');
   });
 
   it('attaches computer tool customData', async () => {


### PR DESCRIPTION
This pull request adds SDK-only custom data support for tool output items. It introduces `RunToolCallOutputItem.customData`, validates extractor output as JSON-compatible data, and preserves that metadata through `RunState` without replaying it to the model.

The change adds `customDataExtractor` hooks for function tools, local MCP tools, computer tools, and apply_patch tools. Local MCP extraction can read result `_meta`, `structuredContent`, `isError`, and the model-visible tool output. Shell tools are left unchanged.

see also: https://github.com/openai/openai-agents-python/pull/3486