### PR TITLE
fix: delay WebRTC close for transient peer disconnects

### DIFF
--- a/.changeset/sweet-webrtc-disconnect.md
+++ b/.changeset/sweet-webrtc-disconnect.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: delay WebRTC close for transient peer disconnects

--- a/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
@@ -17,6 +17,8 @@ import { parseRealtimeEvent } from './openaiRealtimeEvents';
 import { ResponseCreateSequencer } from './responseCreateSequencer';
 import { HEADERS } from './utils';
 
+const PEER_CONNECTION_DISCONNECTED_GRACE_MS = 5000;
+
 /**
  * The connection state of the WebRTC connection.
  */
@@ -99,6 +101,7 @@ export class OpenAIRealtimeWebRTC
   #muted = false;
   #connectPromise: Promise<void> | undefined;
   #connectAttemptId = 0;
+  #peerConnectionDisconnectedTimeout: ReturnType<typeof setTimeout> | undefined;
   #responseCreateSequencer = new ResponseCreateSequencer(
     (event) => this.#sendEventNow(event),
     (error) => this._onError(error),
@@ -197,15 +200,7 @@ export class OpenAIRealtimeWebRTC
           connection: RTCPeerConnection,
         ) => {
           connection.onconnectionstatechange = () => {
-            switch (connection.connectionState) {
-              case 'disconnected':
-              case 'failed':
-              case 'closed':
-                this.close();
-                break;
-              // 'connected' state is handled by dataChannel.onopen. So we don't need to handle it here.
-              // 'new' and 'connecting' are intermediate states and do not require action here.
-            }
+            this.#handlePeerConnectionStateChange(connection);
           };
         };
         attachConnectionStateHandler(peerConnection);
@@ -449,6 +444,50 @@ export class OpenAIRealtimeWebRTC
     this.#state.dataChannel!.send(JSON.stringify(event));
   }
 
+  #handlePeerConnectionStateChange(connection: RTCPeerConnection): void {
+    if (this.#state.peerConnection !== connection) {
+      return;
+    }
+
+    switch (connection.connectionState) {
+      case 'connected':
+        this.#clearPeerConnectionDisconnectedTimeout();
+        break;
+      case 'disconnected':
+        this.#schedulePeerConnectionDisconnectedClose(connection);
+        break;
+      case 'failed':
+      case 'closed':
+        this.#clearPeerConnectionDisconnectedTimeout();
+        this.close();
+        break;
+      // 'new' and 'connecting' are intermediate states and do not require action here.
+    }
+  }
+
+  #schedulePeerConnectionDisconnectedClose(
+    connection: RTCPeerConnection,
+  ): void {
+    this.#clearPeerConnectionDisconnectedTimeout();
+    this.#peerConnectionDisconnectedTimeout = setTimeout(() => {
+      if (
+        this.#state.peerConnection === connection &&
+        connection.connectionState === 'disconnected'
+      ) {
+        this.close();
+      }
+    }, PEER_CONNECTION_DISCONNECTED_GRACE_MS);
+  }
+
+  #clearPeerConnectionDisconnectedTimeout(): void {
+    if (this.#peerConnectionDisconnectedTimeout === undefined) {
+      return;
+    }
+
+    clearTimeout(this.#peerConnectionDisconnectedTimeout);
+    this.#peerConnectionDisconnectedTimeout = undefined;
+  }
+
   /**
    * Mute or unmute the session.
    * @param muted - Whether to mute the session.
@@ -473,6 +512,7 @@ export class OpenAIRealtimeWebRTC
    * Close the connection to the Realtime API and disconnects the underlying WebRTC connection.
    */
   close() {
+    this.#clearPeerConnectionDisconnectedTimeout();
     this.#responseCreateSequencer.releaseWaiters();
     this.#cancelOngoingResponse = false;
     if (this.#state.dataChannel) {

--- a/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
@@ -520,6 +520,8 @@ describe('OpenAIRealtimeWebRTC.connectionState', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
     (global as any).RTCPeerConnection = originals.RTCPeerConnection;
     Object.defineProperty(globalThis, 'navigator', {
       value: originals.navigator,
@@ -551,6 +553,57 @@ describe('OpenAIRealtimeWebRTC.connectionState', () => {
     expect(pc).toBeInstanceOf(FakeRTCPeerConnection);
     pc._simulateStateChange('failed');
     await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(rtc.status).toBe('disconnected');
+    expect(events).toEqual(['connecting', 'connected', 'disconnected']);
+  });
+
+  it('keeps the connection open when peer connection disconnection recovers', async () => {
+    const rtc = new OpenAIRealtimeWebRTC();
+    const closeSpy = vi.spyOn(rtc, 'close');
+    const events: string[] = [];
+    rtc.on('connection_change', (status) => events.push(status));
+    await rtc.connect({ apiKey: 'ek_test' });
+    expect(rtc.status).toBe('connected');
+
+    const pc = rtc.connectionState
+      .peerConnection as unknown as FakeRTCPeerConnection;
+
+    vi.useFakeTimers();
+    pc._simulateStateChange('disconnected');
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(closeSpy).not.toHaveBeenCalled();
+    expect(rtc.status).toBe('connected');
+
+    pc._simulateStateChange('connected');
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(closeSpy).not.toHaveBeenCalled();
+    expect(rtc.status).toBe('connected');
+    expect(events).toEqual(['connecting', 'connected']);
+  });
+
+  it('closes when peer connection disconnection exceeds the grace period', async () => {
+    const rtc = new OpenAIRealtimeWebRTC();
+    const closeSpy = vi.spyOn(rtc, 'close');
+    const events: string[] = [];
+    rtc.on('connection_change', (status) => events.push(status));
+    await rtc.connect({ apiKey: 'ek_test' });
+
+    const pc = rtc.connectionState
+      .peerConnection as unknown as FakeRTCPeerConnection;
+
+    vi.useFakeTimers();
+    pc._simulateStateChange('disconnected');
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(closeSpy).not.toHaveBeenCalled();
+    expect(rtc.status).toBe('connected');
+
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(closeSpy).toHaveBeenCalledTimes(1);
     expect(rtc.status).toBe('disconnected');
     expect(events).toEqual(['connecting', 'connected', 'disconnected']);
   });


### PR DESCRIPTION
This pull request addresses the SDK-side WebRTC disconnect handling discussed in https://github.com/openai/openai-agents-js/issues/1353.

It updates `OpenAIRealtimeWebRTC` so `RTCPeerConnection.connectionState === "disconnected"` no longer immediately tears down the transport. Instead, the SDK keeps the active connection open for a short grace period, clears the pending close if the peer connection returns to `connected`, and still closes immediately for `failed` or `closed`.

The change adds regression coverage for transient disconnect recovery and for the grace-period close path in `packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts`. It also adds `.changeset/sweet-webrtc-disconnect.md` with a patch changeset for `@openai/agents-realtime`.