### PR TITLE
fix(extensions): force g711 audio format on Twilio session updates

### DIFF
--- a/.changeset/twilio-handoff-audio-format.md
+++ b/.changeset/twilio-handoff-audio-format.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix(extensions): force g711 audio format on Twilio session updates

--- a/packages/agents-extensions/src/TwilioRealtimeTransport.ts
+++ b/packages/agents-extensions/src/TwilioRealtimeTransport.ts
@@ -4,6 +4,7 @@ import {
   utils,
   RealtimeTransportLayerConnectOptions,
   TransportLayerAudio,
+  RealtimeAudioFormat,
   RealtimeSessionConfig,
 } from '@openai/agents/realtime';
 import { getLogger } from '@openai/agents';
@@ -14,6 +15,34 @@ import type {
 } from 'ws';
 
 import type { ErrorEvent } from 'undici-types';
+
+/**
+ * Twilio Media Streams only support G.711 audio (`g711_ulaw` / `g711_alaw`).
+ * Returns `true` when the provided audio format is already one of those, taking
+ * both the legacy string shorthands and the GA object form into account.
+ */
+function isTwilioCompatibleAudioFormat(
+  format: RealtimeAudioFormat | undefined,
+): boolean {
+  if (!format) {
+    return false;
+  }
+  if (typeof format === 'string') {
+    return format === 'g711_ulaw' || format === 'g711_alaw';
+  }
+  return format.type === 'audio/pcmu' || format.type === 'audio/pcma';
+}
+
+/**
+ * Coerces an audio format to one Twilio understands. An explicitly chosen G.711
+ * format (ulaw or alaw) is preserved; anything else, including the SDK's default
+ * PCM format, is replaced with `g711_ulaw`.
+ */
+function toTwilioAudioFormat(
+  format: RealtimeAudioFormat | undefined,
+): RealtimeAudioFormat {
+  return isTwilioCompatibleAudioFormat(format) ? format! : 'g711_ulaw';
+}
 
 /**
  * The options for the Twilio Realtime Transport Layer.
@@ -86,11 +115,11 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
           ...audioConfig,
           input: {
             ...audioConfig.input,
-            format: audioConfig.input?.format ?? 'g711_ulaw',
+            format: toTwilioAudioFormat(audioConfig.input?.format),
           },
           output: {
             ...audioConfig.output,
-            format: audioConfig.output?.format ?? 'g711_ulaw',
+            format: toTwilioAudioFormat(audioConfig.output?.format),
           },
         },
       };
@@ -99,9 +128,9 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
     return {
       ...partialConfig,
       // @ts-expect-error - this is a valid config
-      inputAudioFormat: partialConfig.inputAudioFormat ?? 'g711_ulaw',
+      inputAudioFormat: toTwilioAudioFormat(partialConfig.inputAudioFormat),
       // @ts-expect-error - this is a valid config
-      outputAudioFormat: partialConfig.outputAudioFormat ?? 'g711_ulaw',
+      outputAudioFormat: toTwilioAudioFormat(partialConfig.outputAudioFormat),
     };
   }
 

--- a/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
+++ b/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
@@ -59,9 +59,70 @@ describe('TwilioRealtimeTransportLayer', () => {
       inputAudioFormat: 'g711_ulaw',
       outputAudioFormat: 'g711_ulaw',
     });
+    // A non-G.711 legacy format is replaced with g711_ulaw so Twilio keeps
+    // receiving compatible audio.
     expect(
-      transport._setInputAndOutputAudioFormat({ inputAudioFormat: 'foo' }),
-    ).toEqual({ inputAudioFormat: 'foo', outputAudioFormat: 'g711_ulaw' });
+      transport._setInputAndOutputAudioFormat({ inputAudioFormat: 'pcm16' }),
+    ).toEqual({
+      inputAudioFormat: 'g711_ulaw',
+      outputAudioFormat: 'g711_ulaw',
+    });
+    // An explicitly selected G.711 format is preserved.
+    expect(
+      transport._setInputAndOutputAudioFormat({
+        inputAudioFormat: 'g711_alaw',
+      }),
+    ).toEqual({
+      inputAudioFormat: 'g711_alaw',
+      outputAudioFormat: 'g711_ulaw',
+    });
+  });
+
+  test('_setInputAndOutputAudioFormat overrides non-G.711 nested formats', () => {
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: new FakeTwilioWebSocket() as any,
+    });
+
+    // The session config built by RealtimeSession always carries an explicit
+    // PCM format (inherited from the SDK defaults). The transport must still
+    // force g711_ulaw so Twilio audio does not turn into static noise after a
+    // session update such as an agent handoff.
+    expect(
+      transport._setInputAndOutputAudioFormat({
+        audio: {
+          input: { format: { type: 'audio/pcm', rate: 24000 } },
+          output: {
+            format: { type: 'audio/pcm', rate: 24000 },
+            voice: 'alloy',
+          },
+        },
+      } as any),
+    ).toEqual({
+      audio: {
+        input: { format: 'g711_ulaw' },
+        output: { format: 'g711_ulaw', voice: 'alloy' },
+      },
+    });
+  });
+
+  test('_setInputAndOutputAudioFormat preserves explicit nested G.711 formats', () => {
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: new FakeTwilioWebSocket() as any,
+    });
+
+    expect(
+      transport._setInputAndOutputAudioFormat({
+        audio: {
+          input: { format: { type: 'audio/pcma' } },
+          output: { format: 'g711_alaw' },
+        },
+      } as any),
+    ).toEqual({
+      audio: {
+        input: { format: { type: 'audio/pcma' } },
+        output: { format: 'g711_alaw' },
+      },
+    });
   });
 
   test('_setInputAndOutputAudioFormat preserves nested audio config', () => {


### PR DESCRIPTION
The `TwilioRealtimeTransportLayer` forces Twilio's required `g711_ulaw` audio format onto the session config in `_setInputAndOutputAudioFormat`, but it only did so when the format was missing, using `format ?? 'g711_ulaw'`. After the GA audio config migration, `RealtimeSession` always sends a config whose `audio.input.format` and `audio.output.format` are explicitly set, because its `#lastSessionConfig` is seeded from `DEFAULT_OPENAI_REALTIME_SESSION_CONFIG`, which carries `{ type: 'audio/pcm', rate: 24000 }`. Since the format was already present, the `??` fallback never fired and the transport forwarded PCM to the Realtime API instead of G.711. The resulting `session.update` (sent on connect and again on every agent handoff) reconfigures the model to PCM while Twilio Media Streams still expect mu-law, which is heard as static noise and a model that stops responding.

The fix replaces the `??` defaults with a small `toTwilioAudioFormat` helper that preserves an explicitly chosen G.711 format (`g711_ulaw` or `g711_alaw`, in either the legacy string or the GA object form) and coerces anything else, including the leaked PCM default, to `g711_ulaw`. This restores the original intent of keeping Twilio sessions on a compatible format across session updates while still letting callers opt into `g711_alaw`. Both the nested `audio` config shape and the legacy flat keys are handled.

Coverage extends the existing transport tests with a case mirroring the real handoff config (an explicit PCM format in the nested `audio` shape, asserted to become `g711_ulaw`) and a case verifying an explicit G.711 format is left untouched; the legacy-format assertion was updated to reflect the corrected behavior. The two new assertions fail before this change and pass after.

Closes #122
Closes #168
