### PR TITLE
fix: set model metadata on generation span in streaming + chat completions

### DIFF
--- a/.changeset/fix-streaming-generation-span-model.md
+++ b/.changeset/fix-streaming-generation-span-model.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: populate model and model_config on generation span in streaming mode
+
+`getStreamedResponse()` in `OpenAIChatCompletionsModel` was not setting `span.spanData.model` or `span.spanData.model_config` on the generation span, causing downstream tracing exporters to report the model as "unknown". The non-streaming `getResponse()` path already set these fields correctly.

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -235,6 +235,17 @@ export class OpenAIChatCompletionsModel implements Model {
     const span = request.tracing ? createGenerationSpan() : undefined;
     try {
       if (span) {
+        span.spanData.model = this.#model;
+        span.spanData.model_config = request.modelSettings
+          ? {
+              temperature: request.modelSettings.temperature,
+              top_p: request.modelSettings.topP,
+              frequency_penalty: request.modelSettings.frequencyPenalty,
+              presence_penalty: request.modelSettings.presencePenalty,
+              reasoning_effort: request.modelSettings.reasoning?.effort,
+              verbosity: request.modelSettings.text?.verbosity,
+            }
+          : { base_url: this.#client.baseURL };
         span.start();
         setCurrentSpan(span);
       }

--- a/packages/agents-openai/test/openaiChatCompletionsModel.scenario.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.scenario.test.ts
@@ -265,4 +265,66 @@ describe('OpenAIChatCompletionsModel streaming scenarios', () => {
       setTracingDisabled(true);
     }
   });
+
+  it('populates model and model_config on generation span in streaming mode', async () => {
+    setTracingDisabled(false);
+    const createGenerationSpanSpy = vi.spyOn(
+      AgentsCore,
+      'createGenerationSpan',
+    );
+
+    try {
+      const stream = {
+        async *[Symbol.asyncIterator]() {
+          yield makeChunk({ content: 'hi' });
+        },
+      };
+
+      const create = vi.fn().mockResolvedValue(stream);
+      const client = {
+        chat: { completions: { create } },
+        baseURL: 'https://example.com',
+      };
+
+      const model = new OpenAIChatCompletionsModel(
+        client as any,
+        'my-model-id',
+      );
+      const request: any = {
+        input: 'hello',
+        modelSettings: {
+          temperature: 0.7,
+          topP: 0.9,
+        },
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: 'enabled_without_data',
+        signal: undefined,
+      };
+
+      await withTrace('model-trace', async () => {
+        for await (const _event of model.getStreamedResponse(request)) {
+          // Drain.
+        }
+      });
+
+      const generationSpan = createGenerationSpanSpy.mock.results
+        .map((result) => result.value as { spanData?: Record<string, any> })
+        .find((span) => span?.spanData?.type === 'generation');
+      expect(generationSpan).toBeDefined();
+      if (!generationSpan?.spanData) {
+        throw new Error('Expected generation span data to exist');
+      }
+
+      expect(generationSpan.spanData.model).toBe('my-model-id');
+      expect(generationSpan.spanData.model_config).toMatchObject({
+        temperature: 0.7,
+        top_p: 0.9,
+      });
+    } finally {
+      createGenerationSpanSpy.mockRestore();
+      setTracingDisabled(true);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

`OpenAIChatCompletionsModel.getStreamedResponse()` creates a generation span but never populates `spanData.model` or `spanData.model_config`. Downstream tracing consumers (OpenInference, OpenTelemetry exporters) then report the model name as `"unknown"`, which breaks model-level metrics and filtering in observability backends.

The non-streaming `getResponse()` path already sets these fields correctly (via `withGenerationSpan` callback). This PR brings the streaming path to parity.

## Changes

- **`packages/agents-openai/src/openaiChatCompletionsModel.ts`** — Set `span.spanData.model` and `span.spanData.model_config` in the `getStreamedResponse()` method, matching `getResponse()`.
- **`packages/agents-openai/test/openaiChatCompletionsModel.scenario.test.ts`** — Add test verifying the generation span contains model metadata when streaming with tracing enabled.

## Context

The Python SDK does not have this issue — its `generation_span(model=...)` context manager accepts `model` as a creation-time parameter that applies uniformly to both streaming and non-streaming paths.

In the JS SDK, the streaming path uses manual span lifecycle (`createGenerationSpan()` + `span.start()` / `span.end()`) instead of `withGenerationSpan(callback)`, and the metadata assignments were not carried over when this pattern was introduced in the initial commit.