### PR TITLE
fix: surface partial usage when streaming run is aborted before response_done (fix #995)

### DIFF
--- a/.changeset/stream-abort-usage.md
+++ b/.changeset/stream-abort-usage.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: surface partial token usage when a streaming run is aborted before `response_done`

--- a/packages/agents-core/src/result.ts
+++ b/packages/agents-core/src/result.ts
@@ -18,6 +18,7 @@ import { ReadableStream } from './shims/interface';
 import { RunStreamEvent } from './events';
 import { getTurnInput } from './runner/items';
 import { RunState } from './runState';
+import type { Usage } from './usage';
 import { RunContext } from './runContext';
 import type { AgentToolInvocation } from './agentToolInvocation';
 import type { InputGuardrailResult, OutputGuardrailResult } from './guardrail';
@@ -332,6 +333,11 @@ export class StreamedRunResult<
   #abortHandler: (() => void) | undefined;
   #abortHandlerRef: AbortHandlerRef<() => void> | undefined;
   #combinedSignalCleanup: () => void = () => {};
+  // #995: the latest running token usage observed on intermediate stream
+  // events (e.g. `response.in_progress` from the Responses API), waiting to
+  // be folded into `state.usage` if the stream is aborted before the
+  // terminal `response_done` arrives.
+  #pendingStreamAbortUsage: Usage | undefined;
 
   constructor(
     result: {
@@ -526,6 +532,32 @@ export class StreamedRunResult<
     return this.#abortSignalSnapshot ?? this.#combinedSignal;
   }
 
+  /**
+   * @internal
+   * Stash the latest running token usage observed on an intermediate stream
+   * event. The run loop calls this every time it sees usage on a non-terminal
+   * Responses API event (e.g. `response.in_progress`), and clears it once a
+   * terminal `response_done` arrives with authoritative usage.
+   */
+  _setPendingStreamAbortUsage(usage: Usage | undefined): void {
+    this.#pendingStreamAbortUsage = usage;
+  }
+
+  /**
+   * @internal
+   * Fold any pending intermediate usage into `state.usage`. Idempotent so the
+   * run loop's abort/cancellation paths can call it without coordinating with
+   * the synchronous abort handler.
+   */
+  _drainPendingStreamAbortUsage(): void {
+    if (!this.#pendingStreamAbortUsage) {
+      return;
+    }
+    const pending = this.#pendingStreamAbortUsage;
+    this.#pendingStreamAbortUsage = undefined;
+    this.state._context.usage.add(pending);
+  }
+
   #handleAbort() {
     if (this.#cancelled) {
       this.#detachAbortHandler();
@@ -533,6 +565,11 @@ export class StreamedRunResult<
     }
 
     this.#cancelled = true;
+
+    // Drain pending intermediate usage BEFORE resolving `completed`, so any
+    // caller awaiting `result.completed` then reading `state.usage` sees the
+    // best-effort token totals from the partially streamed turn (#995).
+    this._drainPendingStreamAbortUsage();
 
     const controller = this.#readableController;
     this.#readableController = undefined;

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -98,6 +98,7 @@ import {
 import {
   buildAbortReconciliationInput,
   createStreamAbortReconciliationState,
+  extractRunningUsageFromStreamEvent,
   getAbortReconciliationPreviousResponseId,
   markAbortReconciliationComplete,
   recordStreamEventForAbortReconciliation,
@@ -1490,6 +1491,15 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 abortReconciliationState,
                 event,
               );
+              const runningUsage = extractRunningUsageFromStreamEvent(event);
+              if (runningUsage) {
+                // Stash on the result so #handleAbort can drain it
+                // synchronously when the consumer aborts. The stream loop's
+                // own catch/cancelled branches also drain it below
+                // (idempotent), in case the abort never fires through the
+                // result signal.
+                result._setPendingStreamAbortUsage(runningUsage);
+              }
               if (event.type === 'response_done') {
                 const parsed = StreamEventResponseCompleted.parse(event);
                 finalResponse = {
@@ -1499,10 +1509,14 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                   requestId: parsed.response.requestId,
                 };
                 result.state._context.usage.add(finalResponse.usage);
+                // Authoritative usage from response_done subsumes the
+                // running totals we'd otherwise add on abort.
+                result._setPendingStreamAbortUsage(undefined);
               }
               if (result.cancelled) {
                 // When the user's code exits a loop to consume the stream, we need to break
                 // this loop to prevent internal false errors and unnecessary processing
+                result._drainPendingStreamAbortUsage();
                 await awaitGuardrailsAndPersistInput();
                 await reconcileStreamAbortIfNeeded();
                 return;
@@ -1514,6 +1528,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               if (sentInputToModel) {
                 markInputOnce();
               }
+              result._drainPendingStreamAbortUsage();
               await awaitGuardrailsAndPersistInput();
               await reconcileStreamAbortIfNeeded();
               return;

--- a/packages/agents-core/src/runner/streamReconciliation.ts
+++ b/packages/agents-core/src/runner/streamReconciliation.ts
@@ -4,6 +4,7 @@ import type {
   FunctionCallResultItem,
   StreamEvent,
 } from '../types/protocol';
+import { Usage } from '../usage';
 
 type PendingStreamedFunctionCall = Pick<
   FunctionCallItem,
@@ -115,4 +116,64 @@ export function markAbortReconciliationComplete(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Extract the running cumulative usage carried on intermediate Responses API
+ * stream events. The OpenAI Responses API emits `response.created` and
+ * `response.in_progress` events whose `response.usage` is populated with the
+ * running totals seen so far. When a streaming run is aborted before the
+ * terminal `response.completed` event arrives, the SDK never gets a
+ * `response_done`, so callers see `result.state.usage` stuck at zero (see
+ * #995). Snapshotting these intermediate usages lets the run loop surface a
+ * best-effort token count on abort.
+ *
+ * Returns `undefined` if the event does not carry usage data or all values
+ * are zero (the very first `response.created` typically arrives with a
+ * usage shell of zeros before any prompt tokens are accounted for).
+ */
+export function extractRunningUsageFromStreamEvent(
+  event: StreamEvent,
+): Usage | undefined {
+  if (event.type !== 'model' || !isRecord(event.event)) {
+    return undefined;
+  }
+  const rawEvent = event.event;
+  const type = rawEvent.type;
+  // Only intermediate events. Terminal events are already handled by the
+  // `response_done` branch in the stream loop.
+  if (type !== 'response.created' && type !== 'response.in_progress') {
+    return undefined;
+  }
+  const response = rawEvent.response;
+  if (!isRecord(response)) {
+    return undefined;
+  }
+  const usage = response.usage;
+  if (!isRecord(usage)) {
+    return undefined;
+  }
+  const inputTokens =
+    typeof usage.input_tokens === 'number' ? usage.input_tokens : 0;
+  const outputTokens =
+    typeof usage.output_tokens === 'number' ? usage.output_tokens : 0;
+  if (inputTokens === 0 && outputTokens === 0) {
+    return undefined;
+  }
+  const totalTokens =
+    typeof usage.total_tokens === 'number'
+      ? usage.total_tokens
+      : inputTokens + outputTokens;
+  return new Usage({
+    requests: 1,
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    inputTokensDetails: isRecord(usage.input_tokens_details)
+      ? (usage.input_tokens_details as Record<string, number>)
+      : undefined,
+    outputTokensDetails: isRecord(usage.output_tokens_details)
+      ? (usage.output_tokens_details as Record<string, number>)
+      : undefined,
+  });
 }

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -1017,6 +1017,110 @@ describe('Runner.run (streaming)', () => {
     expect(result.error).toBe(null);
   });
 
+  it('surfaces running usage from intermediate stream events when aborted before response_done (#995)', async () => {
+    // The OpenAI Responses API ships running usage totals on
+    // `response.in_progress` events. When AbortSignal fires before the
+    // terminal `response.completed`, the SDK previously dropped that on the
+    // floor and reported `usage.totalTokens === 0`. The run loop now
+    // snapshots the last intermediate usage and adds it on abort.
+
+    class UsageBeforeAbortStreamingModel implements Model {
+      async getResponse(): Promise<ModelResponse> {
+        throw new Error('not used');
+      }
+
+      async *getStreamedResponse(
+        request: ModelRequest,
+      ): AsyncIterable<StreamEvent> {
+        yield {
+          type: 'model',
+          event: {
+            type: 'response.created',
+            sequence_number: 0,
+            response: {
+              id: 'resp_partial',
+              // First-event zeros should be ignored — they would otherwise
+              // clobber later running totals with zero.
+              usage: {
+                input_tokens: 0,
+                output_tokens: 0,
+                total_tokens: 0,
+              },
+            },
+          },
+        } as any;
+        yield {
+          type: 'model',
+          event: {
+            type: 'response.in_progress',
+            sequence_number: 1,
+            response: {
+              id: 'resp_partial',
+              usage: {
+                input_tokens: 17,
+                output_tokens: 5,
+                total_tokens: 22,
+              },
+            },
+          },
+        } as any;
+        yield { type: 'output_text_delta', delta: 'hello' } as any;
+        // Wait until the consumer aborts.
+        await new Promise<void>((_, reject) => {
+          const handler = () => {
+            const err = new Error('Aborted');
+            err.name = 'AbortError';
+            reject(err);
+          };
+          if (request.signal?.aborted) {
+            handler();
+            return;
+          }
+          request.signal?.addEventListener('abort', handler, { once: true });
+        });
+        // Unreachable — abort always wins above.
+        yield {
+          type: 'response_done',
+          response: {
+            id: 'resp_partial',
+            usage: {
+              requests: 1,
+              inputTokens: 50,
+              outputTokens: 50,
+              totalTokens: 100,
+            },
+            output: [fakeModelMessage('never')],
+          },
+        } as any;
+      }
+    }
+
+    const agent = new Agent({
+      name: 'PartialUsageAbort',
+      model: new UsageBeforeAbortStreamingModel(),
+    });
+    const controller = new AbortController();
+    const result = await run(agent, 'go', {
+      stream: true,
+      signal: controller.signal,
+    });
+
+    for await (const event of result.toStream()) {
+      if (
+        event.type === 'raw_model_stream_event' &&
+        event.data.type === 'output_text_delta'
+      ) {
+        controller.abort();
+        break;
+      }
+    }
+    await result.completed;
+
+    expect(result.state.usage.totalTokens).toBe(22);
+    expect(result.state.usage.inputTokens).toBe(17);
+    expect(result.state.usage.outputTokens).toBe(5);
+  });
+
   it('marks inputs as sent when aborted before first stream event in server-managed conversations', async () => {
     const waitWithAbort = (ms: number, signal?: AbortSignal) =>
       new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
Fixes #995.

## Problem

The Responses API streams running token totals on intermediate `response.in_progress` events, but the run loop only folded them into `state.usage` on the terminal `response_done`. When `AbortSignal` fired mid-stream, `#handleAbort` on `StreamedRunResult` resolved `result.completed` synchronously, while the model's eventual `AbortError` arrived later through the run loop's `catch`. Callers awaiting `result.completed` then read `result.state.usage.totalTokens === 0` even though the server had already metered tokens.

The repro from the issue (`Write a long essay`, abort after 100 chars) ends up with `usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 }` — useless for billing/quota tracking.

## Fix

- Add `_setPendingStreamAbortUsage` / `_drainPendingStreamAbortUsage` on `StreamedRunResult`. The run loop stashes the running `Usage` (parsed from `event.event.response.usage` on `response.created` / `response.in_progress`) every time it sees it, and clears it once `response_done` arrives with authoritative totals.
- `#handleAbort` drains the pending usage into `state.usage` **before** resolving `completedPromise`, so a caller awaiting `result.completed` then reading `state.usage` sees the partial totals.
- The run loop's own abort/cancellation branches (`catch (isAbortError)` and `if (result.cancelled)`) also call `_drainPendingStreamAbortUsage` — idempotent, so they're safe whether or not the abort handler ran first.
- A new helper `extractRunningUsageFromStreamEvent` in `streamReconciliation.ts` parses the OpenAI Responses raw event shape. Zero-valued shells (the typical first `response.created`) are ignored so they don't clobber later running totals.

## Test

Added `surfaces running usage from intermediate stream events when aborted before response_done (#995)` in `run.stream.test.ts`. The model emits `response.created` (zeros, ignored), then `response.in_progress` with `{ input: 17, output: 5, total: 22 }`, then an `output_text_delta`, then waits on the request signal. The consumer breaks + aborts on the delta. After `await result.completed` the test asserts `state.usage.totalTokens === 22`.

```
$ pnpm --filter @openai/agents-core exec vitest run test/run.stream.test.ts
 Test Files  1 passed (1)
      Tests  50 passed (50)

$ pnpm --filter @openai/agents-core exec vitest run
 Test Files  144 passed | 1 skipped (145)
      Tests  2836 passed | 2 skipped (2838)
```

## Out of scope

- Chat Completions adapter doesn't emit running usage on intermediate chunks (only at the terminal event), so its abort path still returns zero. That can be added later with `include_usage: true` + per-chunk parsing.
- This only changes `state.usage`; the existing `usage` field on `RunResult` / per-call `RequestUsage` are unaffected.