### PR TITLE
feat: add tracing span lifecycle dispatch helpers

### DIFF
--- a/.changeset/tracing-span-lifecycle-dispatch.md
+++ b/.changeset/tracing-span-lifecycle-dispatch.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+feat: add tracing span lifecycle dispatch helpers

--- a/packages/agents-core/src/tracing/index.ts
+++ b/packages/agents-core/src/tracing/index.ts
@@ -117,6 +117,32 @@ export async function dispatchSpan<TSpanData extends SpanData>(
 }
 
 /**
+ * Dispatch a span start event to all processors registered on the global
+ * tracing provider.
+ *
+ * This bypasses Span.start(), so callers can emit a start event without
+ * mutating the span state or existing timestamps.
+ */
+export async function dispatchSpanStart<TSpanData extends SpanData>(
+  span: Span<TSpanData>,
+): Promise<void> {
+  await getGlobalTraceProvider().dispatchSpanStart(span);
+}
+
+/**
+ * Dispatch a span end event to all processors registered on the global tracing
+ * provider.
+ *
+ * This bypasses Span.end(), so callers can emit an end event without mutating
+ * the span state or existing timestamps.
+ */
+export async function dispatchSpanEnd<TSpanData extends SpanData>(
+  span: Span<TSpanData>,
+): Promise<void> {
+  await getGlobalTraceProvider().dispatchSpanEnd(span);
+}
+
+/**
  * Start the trace export loop.
  */
 export function startTraceExportLoop(): void {

--- a/packages/agents-core/src/tracing/processor.ts
+++ b/packages/agents-core/src/tracing/processor.ts
@@ -12,6 +12,13 @@ import { NOOP_TRACE_OR_SPAN_ID } from './utils';
 
 type Span = TSpan<any>;
 
+function isNoopSpan(span: Span): boolean {
+  return (
+    span.traceId === NOOP_TRACE_OR_SPAN_ID ||
+    span.spanId === NOOP_TRACE_OR_SPAN_ID
+  );
+}
+
 /**
  * Interface for processing traces
  */
@@ -386,14 +393,35 @@ export class MultiTracingProcessor implements TracingProcessor {
    * calling Span.start() or Span.end().
    */
   async dispatchSpan(span: Span): Promise<void> {
-    if (
-      span.traceId === NOOP_TRACE_OR_SPAN_ID ||
-      span.spanId === NOOP_TRACE_OR_SPAN_ID
-    ) {
+    if (isNoopSpan(span)) {
       return;
     }
 
     await this.onSpanStart(span);
+    await this.onSpanEnd(span);
+  }
+
+  /**
+   * Dispatches a span start event to every registered processor without calling
+   * Span.start().
+   */
+  async dispatchSpanStart(span: Span): Promise<void> {
+    if (isNoopSpan(span)) {
+      return;
+    }
+
+    await this.onSpanStart(span);
+  }
+
+  /**
+   * Dispatches a span end event to every registered processor without calling
+   * Span.end().
+   */
+  async dispatchSpanEnd(span: Span): Promise<void> {
+    if (isNoopSpan(span)) {
+      return;
+    }
+
     await this.onSpanEnd(span);
   }
 

--- a/packages/agents-core/src/tracing/provider.ts
+++ b/packages/agents-core/src/tracing/provider.ts
@@ -142,6 +142,40 @@ export class TraceProvider {
     await this.#multiProcessor.dispatchSpan(span);
   }
 
+  /**
+   * Dispatches a span start event to all registered processors.
+   *
+   * This is useful when an integration receives a span start outside this
+   * process and needs to fan out the start without mutating the span state.
+   */
+  async dispatchSpanStart<TSpanData extends SpanData>(
+    span: Span<TSpanData>,
+  ): Promise<void> {
+    if (this.#disabled) {
+      logger.debug('Tracing is disabled, Not dispatching span start %o', span);
+      return;
+    }
+
+    await this.#multiProcessor.dispatchSpanStart(span);
+  }
+
+  /**
+   * Dispatches a span end event to all registered processors.
+   *
+   * This is useful when an integration receives a span end outside this process
+   * and needs to fan out the end without mutating the span state.
+   */
+  async dispatchSpanEnd<TSpanData extends SpanData>(
+    span: Span<TSpanData>,
+  ): Promise<void> {
+    if (this.#disabled) {
+      logger.debug('Tracing is disabled, Not dispatching span end %o', span);
+      return;
+    }
+
+    await this.#multiProcessor.dispatchSpanEnd(span);
+  }
+
   createTrace(traceOptions: TraceOptions): Trace {
     if (this.#disabled) {
       logger.debug('Tracing is disabled, Not creating trace %o', traceOptions);

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -38,6 +38,8 @@ import {
   getCurrentTrace,
   getCurrentSpan,
   dispatchSpan,
+  dispatchSpanEnd,
+  dispatchSpanStart,
   dispatchTrace,
   setTraceProcessors,
   setTracingDisabled,
@@ -1574,6 +1576,45 @@ describe('MultiTracingProcessor', () => {
     expect(span.endedAt).toBe(endedAt);
   });
 
+  it('dispatches span starts and ends independently without mutating timestamps', async () => {
+    const processor1 = new TestProcessor();
+    const processor2 = new TestProcessor();
+    const multiProcessor = new MultiTracingProcessor();
+    multiProcessor.addTraceProcessor(processor1);
+    multiProcessor.addTraceProcessor(processor2);
+
+    const startedAt = '2026-05-22T00:00:00.000Z';
+    const endedAt = '2026-05-22T00:00:01.000Z';
+    const span = new Span(
+      {
+        traceId: 'trace_completed',
+        spanId: 'span_completed',
+        data: { type: 'custom', name: 'long-lived-span', data: {} },
+        startedAt,
+        endedAt,
+      },
+      new TestProcessor(),
+    );
+
+    await multiProcessor.dispatchSpanStart(span);
+
+    expect(processor1.spansStarted).toEqual([span]);
+    expect(processor1.spansEnded).toHaveLength(0);
+    expect(processor2.spansStarted).toEqual([span]);
+    expect(processor2.spansEnded).toHaveLength(0);
+    expect(span.startedAt).toBe(startedAt);
+    expect(span.endedAt).toBe(endedAt);
+
+    await multiProcessor.dispatchSpanEnd(span);
+
+    expect(processor1.spansStarted).toEqual([span]);
+    expect(processor1.spansEnded).toEqual([span]);
+    expect(processor2.spansStarted).toEqual([span]);
+    expect(processor2.spansEnded).toEqual([span]);
+    expect(span.startedAt).toBe(startedAt);
+    expect(span.endedAt).toBe(endedAt);
+  });
+
   it('does not dispatch no-op traces or spans', async () => {
     const processor = new TestProcessor();
     const multiProcessor = new MultiTracingProcessor();
@@ -1614,6 +1655,12 @@ describe('MultiTracingProcessor', () => {
     await multiProcessor.dispatchSpan(noopSpan);
     await multiProcessor.dispatchSpan(spanWithNoopTraceId);
     await multiProcessor.dispatchSpan(spanWithNoopSpanId);
+    await multiProcessor.dispatchSpanStart(noopSpan);
+    await multiProcessor.dispatchSpanStart(spanWithNoopTraceId);
+    await multiProcessor.dispatchSpanStart(spanWithNoopSpanId);
+    await multiProcessor.dispatchSpanEnd(noopSpan);
+    await multiProcessor.dispatchSpanEnd(spanWithNoopTraceId);
+    await multiProcessor.dispatchSpanEnd(spanWithNoopSpanId);
 
     expect(processor.tracesStarted).toHaveLength(0);
     expect(processor.tracesEnded).toHaveLength(0);
@@ -1659,6 +1706,34 @@ describe('completed trace dispatch helpers', () => {
     expect(processor.spansEnded).toEqual([span]);
   });
 
+  it('dispatches span starts and ends independently through TraceProvider', async () => {
+    const processor = new TestProcessor();
+    const provider = new TraceProvider();
+    provider.setDisabled(false);
+    provider.registerProcessor(processor);
+
+    const span = new Span(
+      {
+        traceId: 'trace_completed',
+        spanId: 'span_completed',
+        data: { type: 'custom', name: 'long-lived-span', data: {} },
+        startedAt: '2026-05-22T00:00:00.000Z',
+        endedAt: '2026-05-22T00:00:01.000Z',
+      },
+      new TestProcessor(),
+    );
+
+    await provider.dispatchSpanStart(span);
+
+    expect(processor.spansStarted).toEqual([span]);
+    expect(processor.spansEnded).toHaveLength(0);
+
+    await provider.dispatchSpanEnd(span);
+
+    expect(processor.spansStarted).toEqual([span]);
+    expect(processor.spansEnded).toEqual([span]);
+  });
+
   it('does not dispatch completed traces and spans when TraceProvider tracing is disabled', async () => {
     const processor = new TestProcessor();
     const provider = new TraceProvider();
@@ -1679,6 +1754,8 @@ describe('completed trace dispatch helpers', () => {
 
     await provider.dispatchTrace(trace);
     await provider.dispatchSpan(span);
+    await provider.dispatchSpanStart(span);
+    await provider.dispatchSpanEnd(span);
 
     expect(processor.tracesStarted).toHaveLength(0);
     expect(processor.tracesEnded).toHaveLength(0);
@@ -1712,6 +1789,33 @@ describe('completed trace dispatch helpers', () => {
     expect(processor.spansEnded).toEqual([span]);
   });
 
+  it('dispatches span starts and ends independently through global helpers', async () => {
+    const processor = new TestProcessor();
+    setTracingDisabled(false);
+    setTraceProcessors([processor]);
+
+    const span = new Span(
+      {
+        traceId: 'trace_completed',
+        spanId: 'span_completed',
+        data: { type: 'custom', name: 'long-lived-span', data: {} },
+        startedAt: '2026-05-22T00:00:00.000Z',
+        endedAt: '2026-05-22T00:00:01.000Z',
+      },
+      new TestProcessor(),
+    );
+
+    await dispatchSpanStart(span);
+
+    expect(processor.spansStarted).toEqual([span]);
+    expect(processor.spansEnded).toHaveLength(0);
+
+    await dispatchSpanEnd(span);
+
+    expect(processor.spansStarted).toEqual([span]);
+    expect(processor.spansEnded).toEqual([span]);
+  });
+
   it('does not dispatch completed traces and spans through global helpers when tracing is disabled', async () => {
     const processor = new TestProcessor();
     setTraceProcessors([processor]);
@@ -1731,6 +1835,8 @@ describe('completed trace dispatch helpers', () => {
 
     await dispatchTrace(trace);
     await dispatchSpan(span);
+    await dispatchSpanStart(span);
+    await dispatchSpanEnd(span);
 
     expect(processor.tracesStarted).toHaveLength(0);
     expect(processor.tracesEnded).toHaveLength(0);


### PR DESCRIPTION
This pull request adds public span lifecycle dispatch helpers for integrations that need to emit long-lived tracing spans as their start and end become known separately. It introduces `dispatchSpanStart` and `dispatchSpanEnd` through the global tracing module, `TraceProvider`, and `MultiTracingProcessor`, while preserving tracing-disabled and no-op span suppression.

The existing `dispatchSpan` behavior remains unchanged for completed span replay. The new helpers bypass `Span.start()` / `Span.end()` lifecycle guards so callers can fan out processor callbacks without mutating span timestamps or state.