### PR TITLE
feat(realtime): add session payload transform hook

### DIFF
--- a/.changeset/short-pianos-reflect.md
+++ b/.changeset/short-pianos-reflect.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+feat: add Realtime session payload transform hook (#466)

--- a/docs/src/content/docs/guides/voice-agents/transport.mdx
+++ b/docs/src/content/docs/guides/voice-agents/transport.mdx
@@ -41,6 +41,25 @@ To use your own media stream or audio element, provide an `OpenAIRealtimeWebRTC`
 
 For lower-level customization, `OpenAIRealtimeWebRTC` also accepts `changePeerConnection`, which lets you inspect or replace the freshly created `RTCPeerConnection` before the offer is generated.
 
+### Azure OpenAI Realtime compatibility
+
+The built-in `OpenAIRealtimeWebRTC` and `OpenAIRealtimeWebSocket` transports target the OpenAI GA Realtime API shape. Azure OpenAI Realtime endpoints may not accept the same `session.update` payload shape as OpenAI GA Realtime, so verify the Realtime event schema accepted by your Azure deployment before relying on the default OpenAI transports for Azure.
+
+If your endpoint rejects OpenAI-specific fields, create the transport yourself and use `transformSessionPayload` to rewrite SDK-managed `session.update` payloads before they are sent:
+
+```ts
+const transport = new OpenAIRealtimeWebRTC({
+  baseUrl: 'https://<region>.realtimeapi-preview.ai.azure.com/v1/realtimertc',
+  transformSessionPayload: ({ type, output_modalities, audio, ...session }) => {
+    return {
+      ...session,
+      modalities: ['audio', 'text'],
+      voice: audio?.output?.voice,
+    };
+  },
+});
+```
+
 ### WebSocket is the default server choice
 
 Pass `transport: 'websocket'` or an instance of `OpenAIRealtimeWebSocket` when creating the session to use a WebSocket connection instead of WebRTC. This works well for server-side use cases, telephony bridges, and custom audio pipelines.

--- a/packages/agents-realtime/src/index.ts
+++ b/packages/agents-realtime/src/index.ts
@@ -52,6 +52,8 @@ export {
   DEFAULT_OPENAI_REALTIME_MODEL,
   DEFAULT_OPENAI_REALTIME_SESSION_CONFIG,
   RealtimeSessionPayload,
+  RealtimeSessionPayloadTransformer,
+  RealtimeSessionUpdatePayload,
 } from './openaiRealtimeBase';
 
 export { RealtimeOutputGuardrail } from './guardrail';

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -95,6 +95,14 @@ export type OpenAIRealtimeBaseOptions = {
    * The API key to use for the connection.
    */
   apiKey?: ApiKey;
+  /**
+   * Optional hook for rewriting the raw session payload before the SDK sends
+   * a `session.update` event.
+   *
+   * This is useful when a Realtime-compatible provider expects a different
+   * session schema than the OpenAI Realtime API.
+   */
+  transformSessionPayload?: RealtimeSessionPayloadTransformer;
 };
 
 /**
@@ -117,6 +125,19 @@ export type OpenAIRealtimeEventTypes = {
  * directly into the `openai.realtime.calls.accept` helper without casts.
  */
 export type RealtimeSessionPayload = { type: 'realtime' } & Record<string, any>;
+
+/**
+ * Shape sent inside a `session.update` event after optional transport-level rewriting.
+ */
+export type RealtimeSessionUpdatePayload = Record<string, any>;
+
+/**
+ * Rewrites a normalized OpenAI Realtime session payload before it is sent in
+ * a `session.update` event.
+ */
+export type RealtimeSessionPayloadTransformer = (
+  payload: RealtimeSessionPayload,
+) => RealtimeSessionUpdatePayload;
 
 function normalizeRealtimeMessageContent(
   role: string | undefined,
@@ -147,6 +168,7 @@ export abstract class OpenAIRealtimeBase
 {
   #model: string;
   #apiKey: ApiKey | undefined;
+  #transformSessionPayload: RealtimeSessionPayloadTransformer | undefined;
   #tracingConfig: RealtimeTracingConfig | null = null;
   #rawSessionConfig: Record<string, any> | null = null;
 
@@ -157,6 +179,7 @@ export abstract class OpenAIRealtimeBase
     super();
     this.#model = options.model ?? DEFAULT_OPENAI_REALTIME_MODEL;
     this.#apiKey = options.apiKey;
+    this.#transformSessionPayload = options.transformSessionPayload;
   }
 
   /**
@@ -705,6 +728,19 @@ export abstract class OpenAIRealtimeBase
     return this._getMergedSessionConfig(config);
   }
 
+  protected _transformSessionPayload(
+    payload: RealtimeSessionPayload,
+  ): RealtimeSessionUpdatePayload {
+    return this.#transformSessionPayload?.(payload) ?? payload;
+  }
+
+  protected _sendSessionUpdate(payload: RealtimeSessionPayload): void {
+    this.sendEvent({
+      type: 'session.update',
+      session: this._transformSessionPayload(payload),
+    });
+  }
+
   private static buildTurnDetectionConfig(
     c: RealtimeTurnDetectionConfig | null | undefined,
   ): RealtimeTurnDetectionConfigAsIs | null | undefined {
@@ -773,12 +809,9 @@ export abstract class OpenAIRealtimeBase
 
     if (tracingConfig === 'auto') {
       // turn on tracing in auto mode
-      this.sendEvent({
-        type: 'session.update',
-        session: {
-          type: 'realtime',
-          tracing: 'auto',
-        },
+      this._sendSessionUpdate({
+        type: 'realtime',
+        tracing: 'auto',
       });
       return;
     }
@@ -800,12 +833,9 @@ export abstract class OpenAIRealtimeBase
         'Disabling tracing for this session. It cannot be turned on for this session from this point on.',
       );
 
-      this.sendEvent({
-        type: 'session.update',
-        session: {
-          type: 'realtime',
-          tracing: null,
-        },
+      this._sendSessionUpdate({
+        type: 'realtime',
+        tracing: null,
       });
       return;
     }
@@ -815,12 +845,9 @@ export abstract class OpenAIRealtimeBase
       typeof this.#tracingConfig === 'string'
     ) {
       // tracing is currently not set so we can set it to the new value
-      this.sendEvent({
-        type: 'session.update',
-        session: {
-          type: 'realtime',
-          tracing: tracingConfig,
-        },
+      this._sendSessionUpdate({
+        type: 'realtime',
+        tracing: tracingConfig,
       });
       return;
     }
@@ -838,12 +865,9 @@ export abstract class OpenAIRealtimeBase
       return;
     }
 
-    this.sendEvent({
-      type: 'session.update',
-      session: {
-        type: 'realtime',
-        tracing: tracingConfig,
-      },
+    this._sendSessionUpdate({
+      type: 'realtime',
+      tracing: tracingConfig,
     });
   }
 
@@ -855,11 +879,7 @@ export abstract class OpenAIRealtimeBase
    */
   updateSessionConfig(config: Partial<RealtimeSessionConfig>): void {
     const sessionData = this.buildSessionPayload(config);
-
-    this.sendEvent({
-      type: 'session.update',
-      session: sessionData,
-    });
+    this._sendSessionUpdate(sessionData);
   }
 
   /**

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -169,6 +169,49 @@ describe('OpenAIRealtimeBase helpers', () => {
     expect(session?.audio?.output?.voice).toBe('echo');
   });
 
+  it('transforms outgoing session.update payloads', () => {
+    const base = new TestBase({
+      transformSessionPayload: (payload) => {
+        const {
+          type: _type,
+          output_modalities: _modalities,
+          audio,
+          ...rest
+        } = payload;
+        return {
+          ...rest,
+          voice: audio?.output?.voice,
+        };
+      },
+    });
+
+    base.updateSessionConfig({ instructions: 'hi', voice: 'echo' });
+
+    const session = (base.events[0] as any)?.session;
+    expect(session).toMatchObject({
+      instructions: 'hi',
+      model: 'gpt-realtime-2',
+      voice: 'echo',
+    });
+    expect(session.type).toBeUndefined();
+    expect(session.output_modalities).toBeUndefined();
+    expect(session.audio).toBeUndefined();
+  });
+
+  it('keeps buildSessionPayload in the OpenAI Realtime shape', () => {
+    const base = new TestBase({
+      transformSessionPayload: (payload) => {
+        const { type: _type, ...rest } = payload;
+        return rest;
+      },
+    });
+
+    const payload = base.buildSessionPayload({ instructions: 'hi' });
+
+    expect(payload.type).toBe('realtime');
+    expect(payload.output_modalities).toEqual(['audio']);
+  });
+
   it('whitelists function tools in session payload', () => {
     const base = new TestBase();
     const payload = (base as any)._getMergedSessionConfig({
@@ -848,5 +891,18 @@ describe('OpenAIRealtimeBase helpers', () => {
 
     const sentTypes = sendSpy.mock.calls.map((c) => c[0].type);
     expect(sentTypes).toContain('session.update');
+  });
+
+  it('transforms tracing session.update payloads', () => {
+    const base = new TestBase({
+      transformSessionPayload: (payload) => {
+        const { type: _type, ...rest } = payload;
+        return rest;
+      },
+    });
+
+    (base as any)._updateTracingConfig('auto');
+
+    expect((base.events[0] as any).session).toEqual({ tracing: 'auto' });
   });
 });


### PR DESCRIPTION
## What changed

Adds a `transformSessionPayload` transport option for SDK-managed Realtime `session.update` payloads. The hook is applied to both regular session config updates and tracing updates, while `buildSessionPayload()` continues to return the OpenAI Realtime API shape for existing helper use cases.

This also exports the related payload transformer types, adds regression coverage for config and tracing updates, documents an Azure OpenAI Realtime adaptation example, and includes a patch changeset for `@openai/agents-realtime`.

## Why

Azure OpenAI Realtime-compatible endpoints can reject OpenAI GA-specific session fields such as `type` or `output_modalities`. A generic transform hook lets integrations adapt the outgoing payload shape without hardcoding Azure-specific behavior into the SDK transports.

Refs #466.

## Testing

- `env PATH=/Users/peterlee/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH PNPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS=false bash .agents/skills/code-change-verification/scripts/run.sh`