### PR TITLE
feat: run output guardrails during streaming

### DIFF
--- a/.changeset/streaming-output-guardrails.md
+++ b/.changeset/streaming-output-guardrails.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-core': minor
+---
+
+feat: run output guardrails during streaming via `streamingOutputGuardrailCheckpoint`
+
+Adds a runner option that decides, per streamed delta, when output guardrails run against the accumulated partial output. Streamed output is held back until a checkpoint passes, so unsafe content never reaches the consumer; if a guardrail trips, streaming stops and `OutputGuardrailTripwireTriggered` is thrown. The existing behavior is unchanged when the option is not set.

--- a/docs/src/content/docs/guides/guardrails.mdx
+++ b/docs/src/content/docs/guides/guardrails.mdx
@@ -6,6 +6,7 @@ description: Validate or transform agent input and output
 import { Code } from '@astrojs/starlight/components';
 import inputGuardrailExample from '../../../../../examples/docs/guardrails/guardrails-input.ts?raw';
 import outputGuardrailExample from '../../../../../examples/docs/guardrails/guardrails-output.ts?raw';
+import streamingGuardrailExample from '../../../../../examples/docs/guardrails/guardrails-streaming.ts?raw';
 import toolGuardrailsExample from '../../../../../examples/docs/guardrails/toolGuardrails.ts?raw';
 
 Guardrails can run alongside your agents or block execution until they complete, allowing you to perform checks and validations on user input or agent output. For example, you may run a lightweight model as a guardrail before invoking an expensive model. If the guardrail detects malicious usage, it can trigger an error and stop the costly model from running.
@@ -51,6 +52,26 @@ Output guardrails run in 3 steps:
 > **Note** Output guardrails only run if the agent is the _last_ agent in the workflow. For realtime voice interactions see [the voice agents guide](/openai-agents-js/guides/voice-agents/build#guardrails).
 
 Output guardrail functions also receive an optional `details` object with the underlying `modelResponse` and the generated output items for the turn. Use this when the final output alone is not enough to decide whether the response should pass, for example when you want to inspect the full generated item list or provider response metadata before tripping the guardrail.
+
+### Streaming output guardrails
+
+By default, output guardrails only run once the full output has been generated. In streaming runs this means the model's text has already reached the consumer before the guardrail had a chance to inspect it.
+
+Set `streamingOutputGuardrailCheckpoint` on the runner (or per run) to run your output guardrails **while the model is still streaming**:
+
+- The runner holds streamed output back from the consumer and invokes your checkpoint predicate for each streamed text delta. It receives the latest `delta`, the `accumulatedText` so far, the `agent`, and the run `context`, and returns a `boolean`.
+- When the predicate returns `true`, the configured output guardrails run against the accumulated partial output. If a guardrail trips, streaming stops and an `OutputGuardrailTripwireTriggered` error is raised; otherwise the buffered output is released to the consumer and streaming continues.
+- Because output is held until a checkpoint passes, unsafe content never reaches the consumer. With a checkpoint configured, streamed text therefore arrives in blocks (one per passing checkpoint) instead of token by token.
+
+The same guardrail `execute` runs both mid-stream and on the final output. During streaming, `agentOutput` is the raw accumulated text and `details.partial` is `true`; on the final check, `agentOutput` is the parsed output and `details.partial` is unset. For agents with a structured `outputType`, mid-stream guardrails therefore receive partial **text** (which may not be valid JSON yet) rather than a parsed object.
+
+This is useful for cadence-based checks, for example running the guardrail every 200 characters, or in a quiz builder each time a question in a list is fully generated.
+
+<Code
+  lang="typescript"
+  code={streamingGuardrailExample}
+  title="Streaming output guardrail example"
+/>
 
 ## Tool guardrails
 

--- a/docs/src/content/docs/guides/streaming.mdx
+++ b/docs/src/content/docs/guides/streaming.mdx
@@ -195,6 +195,10 @@ If you are also using session persistence, pass the same `session` again on the 
 
 Approval pauses follow the same rule: resolve `stream.interruptions`, then resume from `stream.state` rather than starting a new turn.
 
+## Validating streamed output with guardrails
+
+By default output guardrails run only on the final output, after every streamed delta has already reached the consumer. To validate output **while it streams** — and hold it back until it passes a check — configure `streamingOutputGuardrailCheckpoint`. See [Streaming output guardrails](/openai-agents-js/guides/guardrails#streaming-output-guardrails) for details. Note that, when configured, streamed text is released in blocks (one per passing checkpoint) rather than token by token.
+
 ## Tips
 
 - Remember to wait for `stream.completed` before exiting to ensure all output has been flushed.

--- a/examples/agent-patterns/streaming-guardrails.ts
+++ b/examples/agent-patterns/streaming-guardrails.ts
@@ -1,13 +1,12 @@
-import { Agent, run } from '@openai/agents';
+import {
+  Agent,
+  run,
+  OutputGuardrail,
+  OutputGuardrailTripwireTriggered,
+} from '@openai/agents';
 import { z } from 'zod';
 
 async function main() {
-  const agent = new Agent({
-    name: 'Assistnt',
-    instructions:
-      'You are a helpful assistant. You ALWAYS write long responses, making sure to be verbose and detailed.',
-  });
-
   const GuardrailOutput = z.object({
     reasoning: z.string(),
     isReadableByTenYearOld: z.boolean(),
@@ -21,45 +20,72 @@ async function main() {
     outputType: GuardrailOutput,
   });
 
-  async function runGuardrail(text: string) {
-    const result = await run(guardrailAgent, text);
-    return result.finalOutput;
-  }
+  // A single output guardrail. The runner runs it on the partial output while the
+  // model streams (see `streamingOutputGuardrailCheckpoint` below) and again on the
+  // final output. `agentOutput` is the accumulated text so far for streaming checks.
+  const readabilityGuardrail: OutputGuardrail = {
+    name: 'Readable by a ten-year-old',
+    async execute({ agentOutput }) {
+      const result = await run(guardrailAgent, String(agentOutput));
+      const output = result.finalOutput;
+      return {
+        outputInfo: output,
+        tripwireTriggered: output ? !output.isReadableByTenYearOld : false,
+      };
+    },
+  };
 
-  let currentText = '';
-  let nextGuardrailCheckLen = 300;
-  const result = await run(
-    agent,
-    'What is a black hole, and how does it behave?',
-    { stream: true },
-  );
-  for await (const event of result) {
-    if (
-      event.type === 'raw_model_stream_event' &&
-      event.data.type === 'output_text_delta'
-    ) {
-      process.stdout.write(event.data.delta);
-      currentText += event.data.delta;
-      if (currentText.length > nextGuardrailCheckLen) {
-        const guardrailResult = await runGuardrail(currentText);
-        if (guardrailResult && !guardrailResult.isReadableByTenYearOld) {
-          console.log(
-            `\n\nGuardrail tripped. Reasoning: ${guardrailResult.reasoning}`,
-          );
-          return;
-        }
-        nextGuardrailCheckLen += 300;
+  const agent = new Agent({
+    name: 'Assistant',
+    instructions:
+      'You are a helpful assistant. You ALWAYS write long responses, making sure to be verbose and detailed.',
+    outputGuardrails: [readabilityGuardrail],
+  });
+
+  // Decide when to run the guardrail while streaming: here, every ~300 characters.
+  // Until a checkpoint passes, the streamed output is held back, so unsafe content
+  // never reaches the consumer.
+  let lastCheckpoint = 0;
+
+  try {
+    const result = await run(
+      agent,
+      'What is a black hole, and how does it behave?',
+      {
+        stream: true,
+        streamingOutputGuardrailCheckpoint: ({ accumulatedText }) => {
+          if (accumulatedText.length - lastCheckpoint >= 300) {
+            lastCheckpoint = accumulatedText.length;
+            return true;
+          }
+          return false;
+        },
+      },
+    );
+
+    for await (const event of result) {
+      if (
+        event.type === 'raw_model_stream_event' &&
+        event.data.type === 'output_text_delta'
+      ) {
+        process.stdout.write(event.data.delta);
       }
     }
+    await result.completed;
+
+    console.log(`\n\n${result.finalOutput}`);
+  } catch (error) {
+    if (error instanceof OutputGuardrailTripwireTriggered) {
+      const info = error.result.output.outputInfo as
+        | z.infer<typeof GuardrailOutput>
+        | undefined;
+      console.log(
+        `\n\nGuardrail tripped. Reasoning: ${info?.reasoning ?? 'not readable'}`,
+      );
+      return;
+    }
+    throw error;
   }
-  const guardrailResult = await runGuardrail(currentText);
-  if (guardrailResult && !guardrailResult.isReadableByTenYearOld) {
-    console.log(
-      `\n\nGuardrail tripped. Reasoning: ${guardrailResult.reasoning}`,
-    );
-    return;
-  }
-  console.log(`\n\n${result.finalOutput}`);
 }
 
 main().catch((error) => {

--- a/examples/docs/guardrails/guardrails-streaming.ts
+++ b/examples/docs/guardrails/guardrails-streaming.ts
@@ -1,0 +1,74 @@
+import {
+  Agent,
+  run,
+  OutputGuardrail,
+  OutputGuardrailTripwireTriggered,
+} from '@openai/agents';
+import { z } from 'zod';
+
+const GuardrailOutput = z.object({
+  reasoning: z.string(),
+  isReadableByTenYearOld: z.boolean(),
+});
+
+const guardrailAgent = new Agent({
+  name: 'Checker',
+  instructions:
+    'Judge whether the response is simple enough to be understood by a ten year old.',
+  outputType: GuardrailOutput,
+});
+
+// Runs both mid-stream (against the accumulated partial text) and on the final output.
+const readabilityGuardrail: OutputGuardrail = {
+  name: 'Readable by a ten-year-old',
+  async execute({ agentOutput }) {
+    const result = await run(guardrailAgent, String(agentOutput));
+    const output = result.finalOutput;
+    return {
+      outputInfo: output,
+      tripwireTriggered: output ? !output.isReadableByTenYearOld : false,
+    };
+  },
+};
+
+const agent = new Agent({
+  name: 'Assistant',
+  instructions: 'You are a helpful assistant. Always write long responses.',
+  outputGuardrails: [readabilityGuardrail],
+});
+
+async function main() {
+  // Run the guardrail every ~300 streamed characters.
+  let lastCheckpoint = 0;
+
+  try {
+    const result = await run(agent, 'What is a black hole?', {
+      stream: true,
+      streamingOutputGuardrailCheckpoint: ({ accumulatedText }) => {
+        if (accumulatedText.length - lastCheckpoint >= 300) {
+          lastCheckpoint = accumulatedText.length;
+          return true;
+        }
+        return false;
+      },
+    });
+
+    // Output is released only after each checkpoint passes, so unsafe content
+    // never reaches the consumer.
+    for await (const event of result) {
+      if (
+        event.type === 'raw_model_stream_event' &&
+        event.data.type === 'output_text_delta'
+      ) {
+        process.stdout.write(event.data.delta);
+      }
+    }
+    await result.completed;
+  } catch (e) {
+    if (e instanceof OutputGuardrailTripwireTriggered) {
+      console.log('\n\nStreaming output guardrail tripped');
+    }
+  }
+}
+
+main().catch(console.error);

--- a/packages/agents-core/src/guardrail.ts
+++ b/packages/agents-core/src/guardrail.ts
@@ -173,6 +173,13 @@ export interface OutputGuardrailFunctionArgs<
     modelResponse?: ModelResponse;
     /** Model output items generated during the run (excluding approvals). */
     output?: AgentOutputItem[];
+    /**
+     * True when the guardrail is invoked mid-stream against the partial output
+     * accumulated so far, rather than against the final output. When this is set,
+     * `agentOutput` is the raw accumulated text and has not been parsed against the
+     * agent's `outputType`.
+     */
+    partial?: boolean;
   };
 }
 /**
@@ -213,6 +220,37 @@ export type OutputGuardrailFunction<
 > = (
   args: OutputGuardrailFunctionArgs<TContext, TOutput>,
 ) => Promise<GuardrailFunctionOutput>;
+
+/**
+ * Arguments passed to a streaming output guardrail checkpoint. The checkpoint is
+ * invoked for each streamed text delta to decide whether the output guardrails
+ * should run against the partial output accumulated so far.
+ */
+export interface StreamingOutputGuardrailCheckpointArgs<
+  TContext = UnknownContext,
+> {
+  /** The agent currently producing the output. */
+  agent: Agent<any, any>;
+  /** The latest text delta streamed by the model. */
+  delta: string;
+  /**
+   * All of the output text accumulated for the current turn so far, including
+   * `delta`.
+   */
+  accumulatedText: string;
+  /** The context of the agent run. */
+  context: RunContext<TContext>;
+}
+
+/**
+ * Decides whether the configured output guardrails should run at a given point
+ * while the model is still streaming. Returning `true` runs the output guardrails
+ * against the accumulated partial output before any of the buffered output reaches
+ * the consumer; returning `false` keeps buffering and streaming.
+ */
+export type StreamingOutputGuardrailCheckpoint<TContext = UnknownContext> = (
+  args: StreamingOutputGuardrailCheckpointArgs<TContext>,
+) => boolean | Promise<boolean>;
 
 /**
  * A guardrail that checks the output of the agent.

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -57,6 +57,8 @@ export {
   OutputGuardrailFunctionArgs,
   OutputGuardrailMetadata,
   OutputGuardrailResult,
+  StreamingOutputGuardrailCheckpoint,
+  StreamingOutputGuardrailCheckpointArgs,
 } from './guardrail';
 export {
   ToolGuardrailBehavior,

--- a/packages/agents-core/src/result.ts
+++ b/packages/agents-core/src/result.ts
@@ -423,6 +423,18 @@ export class StreamedRunResult<
 
   /**
    * @internal
+   * Disables the output hold and flushes any buffered events to the consumer, so
+   * subsequent events stream through directly. Used by the runner when a turn has no
+   * streaming output guardrails to enforce (e.g. after a handoff to an unguarded
+   * agent), so that turn is not needlessly buffered into a burst.
+   */
+  _disableOutputHold() {
+    this.#outputHoldActive = false;
+    this._releaseHeldOutput();
+  }
+
+  /**
+   * @internal
    * Releases any events held in the output buffer to the consumer, in order, and
    * keeps the hold active for subsequent events. Called after a guardrail
    * checkpoint passes.

--- a/packages/agents-core/src/result.ts
+++ b/packages/agents-core/src/result.ts
@@ -328,6 +328,8 @@ export class StreamedRunResult<
   #completedPromiseResolve: (() => void) | undefined;
   #completedPromiseReject: ((err: unknown) => void) | undefined;
   #cancelled: boolean = false;
+  #outputHoldActive: boolean = false;
+  #outputHoldBuffer: RunStreamEvent[] = [];
   #streamLoopPromise: Promise<void> | undefined;
   #abortHandler: (() => void) | undefined;
   #abortHandlerRef: AbortHandlerRef<() => void> | undefined;
@@ -392,12 +394,61 @@ export class StreamedRunResult<
 
   /**
    * @internal
-   * Adds an item to the stream of output items
+   * Adds an item to the stream of output items.
+   *
+   * When an output hold is active (i.e. streaming output guardrails are
+   * configured), items are buffered instead of being emitted so that nothing
+   * reaches the consumer before passing a guardrail checkpoint.
    */
   _addItem(item: RunStreamEvent) {
-    if (!this.cancelled) {
+    if (this.cancelled) {
+      return;
+    }
+    if (this.#outputHoldActive) {
+      this.#outputHoldBuffer.push(item);
+      return;
+    }
+    this.#readableController?.enqueue(item);
+  }
+
+  /**
+   * @internal
+   * Enables holding streamed events in an internal buffer until they are explicitly
+   * released. Used by the runner when streaming output guardrails are configured so
+   * that output never reaches the consumer before passing a guardrail checkpoint.
+   */
+  _enableOutputHold() {
+    this.#outputHoldActive = true;
+  }
+
+  /**
+   * @internal
+   * Releases any events held in the output buffer to the consumer, in order, and
+   * keeps the hold active for subsequent events. Called after a guardrail
+   * checkpoint passes.
+   */
+  _releaseHeldOutput() {
+    if (this.#outputHoldBuffer.length === 0) {
+      return;
+    }
+    const buffered = this.#outputHoldBuffer;
+    this.#outputHoldBuffer = [];
+    if (this.cancelled) {
+      return;
+    }
+    for (const item of buffered) {
       this.#readableController?.enqueue(item);
     }
+  }
+
+  /**
+   * @internal
+   * Discards any events held in the output buffer without emitting them. Called when
+   * a guardrail tripwire triggers (so unsafe output never reaches the consumer) or
+   * when the stream is aborted.
+   */
+  _discardHeldOutput() {
+    this.#outputHoldBuffer = [];
   }
 
   /**
@@ -533,6 +584,8 @@ export class StreamedRunResult<
     }
 
     this.#cancelled = true;
+    // Drop any output held back for guardrail checkpoints so it cannot leak after abort.
+    this.#outputHoldBuffer = [];
 
     const controller = this.#readableController;
     this.#readableController = undefined;

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -12,6 +12,7 @@ import type {
   InputGuardrailResult,
   OutputGuardrailDefinition,
   OutputGuardrailMetadata,
+  StreamingOutputGuardrailCheckpoint,
 } from './guardrail';
 import { Handoff, HandoffInputFilter } from './handoff';
 import { RunHooks } from './lifecycle';
@@ -47,6 +48,7 @@ import {
 import {
   createGuardrailTracker,
   runOutputGuardrails,
+  runStreamingOutputGuardrails,
 } from './runner/guardrails';
 import {
   adjustModelSettingsForNonGPT5RunnerModel,
@@ -246,6 +248,22 @@ export type RunConfig = {
   outputGuardrails?: OutputGuardrail<AgentOutputType<unknown>>[];
 
   /**
+   * Controls when output guardrails run while the model is still streaming.
+   *
+   * When set, the runner holds streamed output back from the consumer and invokes
+   * this predicate for each streamed text delta. Returning `true` runs the
+   * configured output guardrails (both runner-level and agent-level) against the
+   * accumulated partial output before that output is released to the consumer. If a
+   * guardrail trips, streaming stops and an `OutputGuardrailTripwireTriggered` error
+   * is raised; otherwise the buffered output is released and streaming continues.
+   *
+   * This only affects streaming runs and only when at least one output guardrail is
+   * configured. When omitted, output guardrails run solely on the final output
+   * (the default behavior).
+   */
+  streamingOutputGuardrailCheckpoint?: StreamingOutputGuardrailCheckpoint;
+
+  /**
    * Whether tracing is disabled for the agent run. If disabled, we will not trace the agent run.
    */
   tracingDisabled: boolean;
@@ -342,6 +360,7 @@ type SharedRunOptions<
   sessionInputCallback?: SessionInputCallback;
   callModelInputFilter?: CallModelInputFilter;
   toolErrorFormatter?: ToolErrorFormatter;
+  streamingOutputGuardrailCheckpoint?: StreamingOutputGuardrailCheckpoint;
   reasoningItemIdPolicy?: ReasoningItemIdPolicy;
   tracing?: TracingConfig;
   sandbox?: SandboxRunConfig;
@@ -479,6 +498,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       sessionInputCallback: config.sessionInputCallback,
       callModelInputFilter: config.callModelInputFilter,
       toolErrorFormatter: config.toolErrorFormatter,
+      streamingOutputGuardrailCheckpoint:
+        config.streamingOutputGuardrailCheckpoint,
       reasoningItemIdPolicy: config.reasoningItemIdPolicy,
     };
     this.traceOverrides = {
@@ -1253,6 +1274,18 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       options.toolErrorFormatter ?? this.config.toolErrorFormatter;
     const agentToolParentRunConfig = this.#getAgentToolParentRunConfig(options);
 
+    // When configured, output guardrails run against partial output while streaming.
+    // Streamed events are held back from the consumer until a checkpoint passes, so
+    // unsafe content never reaches the user.
+    const streamingOutputGuardrailCheckpoint =
+      options.streamingOutputGuardrailCheckpoint ??
+      this.config.streamingOutputGuardrailCheckpoint;
+    const hasOutputGuardrailsFor = (agent: Agent<TContext, AgentOutputType>) =>
+      this.outputGuardrailDefs.length > 0 || agent.outputGuardrails.length > 0;
+    let outputHoldEnabled = false;
+    // Accumulated assistant text for the current turn, used to feed partial guardrails.
+    let accumulatedStreamText = '';
+
     // Tracks when we resume an approval interruption so the next run-again step stays in the same turn.
     let continuingInterruptedTurn = false;
     let runError: unknown;
@@ -1457,6 +1490,17 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             await persistStreamInputIfNeeded();
           }
 
+          // Reset per-turn streaming guardrail state and start holding output when
+          // streaming output guardrails are configured for this agent.
+          accumulatedStreamText = '';
+          const turnHoldActive =
+            Boolean(streamingOutputGuardrailCheckpoint) &&
+            hasOutputGuardrailsFor(currentAgent);
+          if (turnHoldActive && !outputHoldEnabled) {
+            result._enableOutputHold();
+            outputHoldEnabled = true;
+          }
+
           try {
             for await (const event of getStreamedResponseWithRetry(
               preparedCall.model,
@@ -1508,6 +1552,31 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 return;
               }
               result._addItem(new RunRawModelStreamEvent(event));
+
+              if (
+                turnHoldActive &&
+                streamingOutputGuardrailCheckpoint &&
+                event.type === 'output_text_delta'
+              ) {
+                accumulatedStreamText += event.delta;
+                const shouldCheck = await streamingOutputGuardrailCheckpoint({
+                  agent: currentAgent,
+                  delta: event.delta,
+                  accumulatedText: accumulatedStreamText,
+                  context: result.state._context,
+                });
+                if (shouldCheck) {
+                  // Throws OutputGuardrailTripwireTriggered if a guardrail trips,
+                  // which is handled below by discarding the held (unsafe) output.
+                  await runStreamingOutputGuardrails(
+                    result.state,
+                    this.outputGuardrailDefs,
+                    accumulatedStreamText,
+                  );
+                  // Checkpoint passed: the buffered output is safe to release.
+                  result._releaseHeldOutput();
+                }
+              }
             }
           } catch (error) {
             if (isAbortError(error)) {
@@ -1518,6 +1587,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               await reconcileStreamAbortIfNeeded();
               return;
             }
+            // A streaming guardrail tripped (or another error occurred): never leak
+            // output that has not passed a checkpoint.
+            result._discardHeldOutput();
             throw error;
           }
 
@@ -1607,8 +1679,12 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               // Do not leave blocked output visible through StreamedRunResult.finalOutput.
               result.state._currentStep = undefined;
               result.state._finalOutputSource = undefined;
+              // Drop any output still held back so the blocked content never reaches the consumer.
+              result._discardHeldOutput();
               throw error;
             }
+            // Final guardrails passed: release any output held since the last checkpoint.
+            result._releaseHeldOutput();
             result.state._currentTurnInProgress = false;
             await persistStreamInputIfNeeded();
             // Guardrails must succeed before persisting session memory to avoid storing blocked outputs.
@@ -1629,6 +1705,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             return;
           case 'next_step_interruption':
             // We are done for now. Don't run any output guardrails.
+            // Non-final turns have no final-output guardrail; release held items so
+            // the consumer sees everything streamed up to the interruption.
+            result._releaseHeldOutput();
             await persistStreamInputIfNeeded();
             if (!serverManagesConversation) {
               await saveStreamResultToSession(options.session, result);
@@ -1647,6 +1726,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             result.state._noActiveAgentRun = true;
             result.state._currentTurnInProgress = false;
 
+            // Non-final turn: release held items so handoff events are not delayed.
+            result._releaseHeldOutput();
+
             // We've processed the handoff, so we need to run the loop again.
             result.state._currentStep = {
               type: 'next_step_run_again',
@@ -1654,6 +1736,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             break;
           case 'next_step_run_again':
             result.state._currentTurnInProgress = false;
+            // Non-final turn: release held items (e.g. tool call events) in order.
+            result._releaseHeldOutput();
             logger.debug('Running next loop');
             break;
           default:
@@ -1662,6 +1746,11 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       }
     } catch (error) {
       result.state._currentTurnInProgress = false;
+      // Drop any partial output held back from the failed turn: it never passed a
+      // guardrail checkpoint, so it must not reach the consumer. Recovered output
+      // emitted by an error handler below is buffered after this point and released
+      // once it passes its own guardrails.
+      result._discardHeldOutput();
       if (guardrailTracker.pending) {
         await guardrailTracker.awaitCompletion({ suppressErrors: true });
       }
@@ -1684,6 +1773,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         streamResult: result,
       });
       if (handledResult) {
+        // The recovered output passed its guardrails; release it to the consumer.
+        result._releaseHeldOutput();
         await persistStreamInputIfNeeded();
         if (!serverManagesConversation) {
           await saveStreamResultToSession(options.session, result);

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1285,6 +1285,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     let outputHoldEnabled = false;
     // Accumulated assistant text for the current turn, used to feed partial guardrails.
     let accumulatedStreamText = '';
+    // Length of accumulated text already verified by a streaming guardrail run, so
+    // turn-boundary checks don't redundantly re-run guardrails on unchanged text.
+    let lastVerifiedStreamTextLength = 0;
 
     // Tracks when we resume an approval interruption so the next run-again step stays in the same turn.
     let continuingInterruptedTurn = false;
@@ -1493,6 +1496,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           // Reset per-turn streaming guardrail state and start holding output when
           // streaming output guardrails are configured for this agent.
           accumulatedStreamText = '';
+          lastVerifiedStreamTextLength = 0;
           const turnHoldActive =
             Boolean(streamingOutputGuardrailCheckpoint) &&
             hasOutputGuardrailsFor(currentAgent);
@@ -1579,6 +1583,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                     this.outputGuardrailDefs,
                     accumulatedStreamText,
                   );
+                  lastVerifiedStreamTextLength = accumulatedStreamText.length;
                   // Checkpoint passed: the buffered output is safe to release.
                   result._releaseHeldOutput();
                 }
@@ -1673,6 +1678,32 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         }
 
         const currentStep = result.state._currentStep;
+        // Non-final turns have no final-output guardrail, yet a response can contain
+        // assistant text alongside the tool calls that force the turn to be non-final.
+        // Verify any accumulated text that has not already passed a streaming
+        // checkpoint before its buffer is released, so unverified content never leaks.
+        // A trip discards the held output and propagates as usual. Uses the streaming
+        // agent's guardrails, so it must run before a handoff swaps the current agent.
+        const verifyNonFinalHeldOutput = async () => {
+          if (
+            !streamingOutputGuardrailCheckpoint ||
+            !hasOutputGuardrailsFor(currentAgent) ||
+            accumulatedStreamText.length <= lastVerifiedStreamTextLength
+          ) {
+            return;
+          }
+          try {
+            await runStreamingOutputGuardrails(
+              result.state,
+              this.outputGuardrailDefs,
+              accumulatedStreamText,
+            );
+          } catch (error) {
+            result._discardHeldOutput();
+            throw error;
+          }
+          lastVerifiedStreamTextLength = accumulatedStreamText.length;
+        };
         switch (currentStep.type) {
           case 'next_step_final_output':
             try {
@@ -1710,9 +1741,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             );
             return;
           case 'next_step_interruption':
-            // We are done for now. Don't run any output guardrails.
-            // Non-final turns have no final-output guardrail; release held items so
-            // the consumer sees everything streamed up to the interruption.
+            // We are done for now. Verify any unchecked streamed text before releasing
+            // the held items so the consumer sees everything streamed up to the
+            // interruption (but never unverified content).
+            await verifyNonFinalHeldOutput();
             result._releaseHeldOutput();
             await persistStreamInputIfNeeded();
             if (!serverManagesConversation) {
@@ -1720,6 +1752,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             }
             return;
           case 'next_step_handoff':
+            // Verify the handing-off agent's unchecked streamed text before swapping
+            // agents, so its guardrails (not the target agent's) run on its output.
+            await verifyNonFinalHeldOutput();
             result.state.setCurrentAgent(currentStep.newAgent as TAgent);
             if (result.state._currentAgentSpan) {
               result.state._currentAgentSpan.end();
@@ -1742,7 +1777,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             break;
           case 'next_step_run_again':
             result.state._currentTurnInProgress = false;
-            // Non-final turn: release held items (e.g. tool call events) in order.
+            // Non-final turn: verify any unchecked streamed text (a response may carry
+            // assistant text alongside the tool calls), then release held items in order.
+            await verifyNonFinalHeldOutput();
             result._releaseHeldOutput();
             logger.debug('Running next loop');
             break;

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1499,6 +1499,12 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           if (turnHoldActive && !outputHoldEnabled) {
             result._enableOutputHold();
             outputHoldEnabled = true;
+          } else if (!turnHoldActive && outputHoldEnabled) {
+            // This turn has no streaming output guardrails to enforce (e.g. a handoff
+            // to an unguarded agent). Disable the hold so its events stream through
+            // directly instead of being buffered into a burst at turn completion.
+            result._disableOutputHold();
+            outputHoldEnabled = false;
           }
 
           try {

--- a/packages/agents-core/src/runner/guardrails.ts
+++ b/packages/agents-core/src/runner/guardrails.ts
@@ -339,7 +339,10 @@ export async function runStreamingOutputGuardrails<
     agentOutput: partialText as ResolvedAgentOutput<TOutput>,
     context: state._context,
     details: {
-      modelResponse: state._lastTurnResponse,
+      // The current turn's response is not finalized while the model is still
+      // streaming (`state._lastTurnResponse` is only set once the stream completes),
+      // so passing it here would surface a stale, previous-turn response. Omit it for
+      // partial checks; it is provided on the final guardrail run.
       partial: true,
     },
   };

--- a/packages/agents-core/src/runner/guardrails.ts
+++ b/packages/agents-core/src/runner/guardrails.ts
@@ -17,6 +17,7 @@ import { RunState } from '../runState';
 import { getTurnInput } from './items';
 import { withGuardrailSpan } from '../tracing';
 import type { GuardrailFunctionOutput } from '../guardrail';
+import type { ResolvedAgentOutput } from '../types';
 
 export type GuardrailTracker = {
   readonly pending: boolean;
@@ -268,6 +269,78 @@ export async function runOutputGuardrails<
     details: {
       modelResponse: state._lastTurnResponse,
       output: runOutput,
+    },
+  };
+  await runGuardrailsWithTripwire({
+    state,
+    guardrails,
+    guardrailArgs,
+    resultsTarget: state._outputGuardrailResults,
+    onTripwire: (result) => {
+      throw new OutputGuardrailTripwireTriggered(
+        `Output guardrail triggered: ${JSON.stringify(result.output.outputInfo)}`,
+        result,
+        state,
+      );
+    },
+    isTripwireError: (error) =>
+      error instanceof OutputGuardrailTripwireTriggered,
+    onError: (error) => {
+      throw new GuardrailExecutionError(
+        `Output guardrail failed to complete: ${error}`,
+        error as Error,
+        state,
+      );
+    },
+  });
+}
+
+/**
+ * Runs output guardrails against the partial output accumulated while the model is
+ * still streaming. This is invoked by the runner only after the configured
+ * streaming checkpoint predicate has decided that a check should happen, so this
+ * function is solely responsible for executing the guardrails and surfacing any
+ * tripwire.
+ *
+ * Unlike {@link runOutputGuardrails}, the partial text is passed through verbatim
+ * and is NOT parsed via `Agent.processFinalOutput`, because partial output (for
+ * example incomplete JSON) is not guaranteed to be parseable yet. Guardrails are
+ * informed of this via `details.partial`.
+ */
+export async function runStreamingOutputGuardrails<
+  TContext,
+  TOutput extends AgentOutputType,
+  TAgent extends Agent<TContext, TOutput>,
+>(
+  state: RunState<TContext, TAgent>,
+  runnerOutputGuardrails: OutputGuardrailDefinition<
+    OutputGuardrailMetadata,
+    AgentOutputType<unknown>
+  >[],
+  partialText: string,
+) {
+  // Runner-level output guardrails are context-agnostic, so align them with the active run context type.
+  const runnerGuardrails = runnerOutputGuardrails as OutputGuardrailDefinition<
+    OutputGuardrailMetadata,
+    AgentOutputType<unknown>,
+    TContext
+  >[];
+  // Run the same guardrails as the final check (runner-level + agent-level). The
+  // configured checkpoint predicate decides the cadence; this function decides the trip.
+  const guardrails = runnerGuardrails.concat(
+    state._currentAgent.outputGuardrails.map(defineOutputGuardrail),
+  );
+  if (guardrails.length === 0) {
+    return;
+  }
+  const guardrailArgs: OutputGuardrailFunctionArgs<TContext, TOutput> = {
+    agent: state._currentAgent,
+    // Pass the raw partial text; do not call processFinalOutput on incomplete output.
+    agentOutput: partialText as ResolvedAgentOutput<TOutput>,
+    context: state._context,
+    details: {
+      modelResponse: state._lastTurnResponse,
+      partial: true,
     },
   };
   await runGuardrailsWithTripwire({

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -3570,6 +3570,169 @@ describe('Runner.run (streaming output guardrails)', () => {
     expect(received).toEqual(['B1', 'B2']);
     expect(result.finalOutput).toBe('B1B2');
   });
+
+  // A response can carry assistant text alongside the tool calls that force a
+  // non-final (run-again) turn. If the checkpoint predicate hasn't fired yet, that
+  // text must still be verified before the held buffer is released.
+  it('verifies buffered text before releasing it on a non-final tool turn', async () => {
+    const guardrail = {
+      name: 'blocks-unsafe',
+      execute: vi.fn(async ({ agentOutput }: any) => ({
+        tripwireTriggered: String(agentOutput).includes('UNSAFE'),
+        outputInfo: { reason: 'unsafe' },
+      })),
+    };
+    const noopTool = tool({
+      name: 'noop',
+      description: 'noop',
+      parameters: z.object({}),
+      execute: async () => 'ok',
+    });
+    const toolCall: FunctionCallItem = {
+      id: 'call-1',
+      type: 'function_call',
+      name: noopTool.name,
+      callId: 'c1',
+      status: 'completed',
+      arguments: '{}',
+    };
+
+    class TextPlusToolModel implements Model {
+      async getResponse(): Promise<ModelResponse> {
+        return { output: [fakeModelMessage('UNSAFE')], usage: new Usage() };
+      }
+      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
+        yield { type: 'output_text_delta', delta: 'UN' } as any;
+        yield { type: 'output_text_delta', delta: 'SAFE' } as any;
+        // Text + tool call in the same response forces a non-final (run-again) turn.
+        yield {
+          type: 'response_done',
+          response: {
+            id: 'resp-tool',
+            usage: {
+              requests: 1,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            output: [fakeModelMessage('UNSAFE'), toolCall],
+          },
+        } as any;
+      }
+    }
+
+    const agent = new Agent({
+      name: 'StreamGuard',
+      model: new TextPlusToolModel(),
+      tools: [noopTool],
+      outputGuardrails: [guardrail],
+    });
+    const runner = new Runner({
+      // Never checks mid-stream, so the text would otherwise reach the consumer
+      // unverified when the tool turn's buffer is released.
+      streamingOutputGuardrailCheckpoint: () => false,
+    });
+
+    const result = await runner.run(agent, 'go', { stream: true });
+    const received: string[] = [];
+    await expect(
+      (async () => {
+        for await (const event of result) {
+          if (
+            event.type === 'raw_model_stream_event' &&
+            event.data.type === 'output_text_delta'
+          ) {
+            received.push(event.data.delta);
+          }
+        }
+      })(),
+    ).rejects.toBeInstanceOf(OutputGuardrailTripwireTriggered);
+
+    // The unsafe text was caught at the tool-turn boundary and never released.
+    expect(received.join('')).toBe('');
+    expect(guardrail.execute).toHaveBeenCalled();
+  });
+
+  it('releases safe buffered text on a non-final tool turn and continues', async () => {
+    const guardrail = {
+      name: 'blocks-unsafe',
+      execute: vi.fn(async ({ agentOutput }: any) => ({
+        tripwireTriggered: String(agentOutput).includes('UNSAFE'),
+        outputInfo: {},
+      })),
+    };
+    const noopTool = tool({
+      name: 'noop',
+      description: 'noop',
+      parameters: z.object({}),
+      execute: async () => 'ok',
+    });
+    const toolCall: FunctionCallItem = {
+      id: 'call-1',
+      type: 'function_call',
+      name: noopTool.name,
+      callId: 'c1',
+      status: 'completed',
+      arguments: '{}',
+    };
+
+    class SafeTextThenToolThenFinalModel implements Model {
+      #callCount = 0;
+      async getResponse(): Promise<ModelResponse> {
+        return { output: [fakeModelMessage('done')], usage: new Usage() };
+      }
+      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
+        const turn = this.#callCount++;
+        if (turn === 0) {
+          yield { type: 'output_text_delta', delta: 'safe-pre' } as any;
+          yield {
+            type: 'response_done',
+            response: {
+              id: 'resp-tool',
+              usage: {
+                requests: 1,
+                inputTokens: 0,
+                outputTokens: 0,
+                totalTokens: 0,
+              },
+              output: [fakeModelMessage('safe-pre'), toolCall],
+            },
+          } as any;
+          return;
+        }
+        yield { type: 'output_text_delta', delta: 'done' } as any;
+        yield {
+          type: 'response_done',
+          response: {
+            id: 'resp-final',
+            usage: {
+              requests: 1,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            output: [fakeModelMessage('done')],
+          },
+        } as any;
+      }
+    }
+
+    const agent = new Agent({
+      name: 'StreamGuard',
+      model: new SafeTextThenToolThenFinalModel(),
+      tools: [noopTool],
+      outputGuardrails: [guardrail],
+    });
+    const runner = new Runner({
+      streamingOutputGuardrailCheckpoint: () => false,
+    });
+
+    const result = await runner.run(agent, 'go', { stream: true });
+    const received = await collectDeltas(result);
+
+    expect(received).toEqual(['safe-pre', 'done']);
+    expect(result.finalOutput).toBe('done');
+  });
 });
 
 class ImmediateStreamingModel implements Model {

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -3046,6 +3046,311 @@ describe('Runner.run (streaming)', () => {
   });
 });
 
+describe('Runner.run (streaming output guardrails)', () => {
+  beforeAll(() => {
+    setTracingDisabled(true);
+    setDefaultModelProvider(new FakeModelProvider());
+  });
+
+  // Streams the provided text in chunks, then completes with the joined text
+  // (or an explicit final text) as the assistant message.
+  class TextDeltaStreamingModel implements Model {
+    constructor(
+      private readonly chunks: string[],
+      private readonly finalText?: string,
+    ) {}
+
+    async getResponse(): Promise<ModelResponse> {
+      return {
+        output: [fakeModelMessage(this.finalText ?? this.chunks.join(''))],
+        usage: new Usage(),
+      };
+    }
+
+    async *getStreamedResponse(): AsyncIterable<StreamEvent> {
+      for (const chunk of this.chunks) {
+        yield { type: 'output_text_delta', delta: chunk } as any;
+      }
+      const text = this.finalText ?? this.chunks.join('');
+      yield {
+        type: 'response_done',
+        response: {
+          id: 'resp-stream-guardrail',
+          usage: {
+            requests: 1,
+            inputTokens: 0,
+            outputTokens: 0,
+            totalTokens: 0,
+          },
+          output: [fakeModelMessage(text)],
+        },
+      } as any;
+    }
+  }
+
+  async function collectDeltas(
+    result: StreamedRunResult<any, any>,
+  ): Promise<string[]> {
+    const received: string[] = [];
+    for await (const event of result) {
+      if (
+        event.type === 'raw_model_stream_event' &&
+        event.data.type === 'output_text_delta'
+      ) {
+        received.push(event.data.delta);
+      }
+    }
+    await result.completed;
+    return received;
+  }
+
+  it('releases buffered output only after each checkpoint passes', async () => {
+    const checkpointTexts: string[] = [];
+    const guardrail = {
+      name: 'never-trips',
+      execute: vi.fn(async () => ({
+        tripwireTriggered: false,
+        outputInfo: {},
+      })),
+    };
+    const agent = new Agent({
+      name: 'StreamGuard',
+      model: new TextDeltaStreamingModel(['aaa', 'bbb', 'ccc']),
+    });
+    const runner = new Runner({
+      outputGuardrails: [guardrail],
+      streamingOutputGuardrailCheckpoint: ({ accumulatedText }) => {
+        checkpointTexts.push(accumulatedText);
+        return true;
+      },
+    });
+
+    const result = await runner.run(agent, 'go', { stream: true });
+    const received = await collectDeltas(result);
+
+    expect(received).toEqual(['aaa', 'bbb', 'ccc']);
+    // Checkpoint sees accumulated text on every delta.
+    expect(checkpointTexts).toEqual(['aaa', 'aaabbb', 'aaabbbccc']);
+    // Guardrail runs once per checkpoint plus once on the final output.
+    expect(guardrail.execute).toHaveBeenCalledTimes(4);
+    expect(result.finalOutput).toBe('aaabbbccc');
+  });
+
+  it('stops the stream and never leaks unsafe content when a checkpoint trips', async () => {
+    const guardrail = {
+      name: 'blocks-unsafe',
+      execute: vi.fn(async ({ agentOutput }: any) => ({
+        tripwireTriggered: String(agentOutput).includes('UNSAFE'),
+        outputInfo: { reason: 'unsafe' },
+      })),
+    };
+    const agent = new Agent({
+      name: 'StreamGuard',
+      model: new TextDeltaStreamingModel(['safe1', 'safe2', 'UNSAFE', 'more']),
+    });
+    const runner = new Runner({
+      outputGuardrails: [guardrail],
+      streamingOutputGuardrailCheckpoint: () => true,
+    });
+
+    const result = await runner.run(agent, 'go', { stream: true });
+    const received: string[] = [];
+    await expect(
+      (async () => {
+        for await (const event of result) {
+          if (
+            event.type === 'raw_model_stream_event' &&
+            event.data.type === 'output_text_delta'
+          ) {
+            received.push(event.data.delta);
+          }
+        }
+      })(),
+    ).rejects.toBeInstanceOf(OutputGuardrailTripwireTriggered);
+
+    // Only the deltas covered by passing checkpoints reached the consumer.
+    expect(received.join('')).toBe('safe1safe2');
+    expect(received).not.toContain('UNSAFE');
+    expect(received).not.toContain('more');
+  });
+
+  it('holds trailing output until the final guardrails pass', async () => {
+    const guardrail = {
+      name: 'final-only',
+      execute: vi.fn(async (_args: any) => ({
+        tripwireTriggered: false,
+        outputInfo: {},
+      })),
+    };
+    const agent = new Agent({
+      name: 'StreamGuard',
+      model: new TextDeltaStreamingModel(['part1', 'part2']),
+    });
+    const runner = new Runner({
+      outputGuardrails: [guardrail],
+      // Never run mid-stream: the trailing buffer is released by the final guardrails.
+      streamingOutputGuardrailCheckpoint: () => false,
+    });
+
+    const result = await runner.run(agent, 'go', { stream: true });
+    const received = await collectDeltas(result);
+
+    expect(received).toEqual(['part1', 'part2']);
+    // Only the final output check runs because no checkpoint fired.
+    expect(guardrail.execute).toHaveBeenCalledTimes(1);
+    expect(guardrail.execute.mock.calls[0][0].details?.partial).toBeUndefined();
+    expect(result.finalOutput).toBe('part1part2');
+  });
+
+  it('discards trailing output when the final guardrails trip', async () => {
+    const guardrail = {
+      name: 'final-trips',
+      execute: vi.fn(async () => ({
+        tripwireTriggered: true,
+        outputInfo: { reason: 'final' },
+      })),
+    };
+    const agent = new Agent({
+      name: 'StreamGuard',
+      model: new TextDeltaStreamingModel(['hello', 'world']),
+    });
+    const runner = new Runner({
+      outputGuardrails: [guardrail],
+      streamingOutputGuardrailCheckpoint: () => false,
+    });
+
+    const result = await runner.run(agent, 'go', { stream: true });
+    const received: string[] = [];
+    await expect(
+      (async () => {
+        for await (const event of result) {
+          if (
+            event.type === 'raw_model_stream_event' &&
+            event.data.type === 'output_text_delta'
+          ) {
+            received.push(event.data.delta);
+          }
+        }
+      })(),
+    ).rejects.toBeInstanceOf(OutputGuardrailTripwireTriggered);
+
+    // Nothing was released because the only checkpoint (the final output) tripped.
+    expect(received).toEqual([]);
+  });
+
+  it('does not change behavior when no streaming checkpoint is configured', async () => {
+    const guardrail = {
+      name: 'final-default',
+      execute: vi.fn(async () => ({
+        tripwireTriggered: false,
+        outputInfo: {},
+      })),
+    };
+    const agent = new Agent({
+      name: 'StreamGuard',
+      model: new TextDeltaStreamingModel(['x', 'y', 'z']),
+    });
+    const runner = new Runner({ outputGuardrails: [guardrail] });
+
+    const result = await runner.run(agent, 'go', { stream: true });
+    const received = await collectDeltas(result);
+
+    expect(received).toEqual(['x', 'y', 'z']);
+    // Default behavior: the guardrail runs only once, on the final output.
+    expect(guardrail.execute).toHaveBeenCalledTimes(1);
+    expect(result.finalOutput).toBe('xyz');
+  });
+
+  it('supports asynchronous checkpoint predicates', async () => {
+    const guardrail = {
+      name: 'async-checkpoint',
+      execute: vi.fn(async () => ({
+        tripwireTriggered: false,
+        outputInfo: {},
+      })),
+    };
+    const agent = new Agent({
+      name: 'StreamGuard',
+      model: new TextDeltaStreamingModel(['one', 'two']),
+    });
+    const runner = new Runner({
+      outputGuardrails: [guardrail],
+      streamingOutputGuardrailCheckpoint: async ({ accumulatedText }) =>
+        Promise.resolve(accumulatedText.length >= 6),
+    });
+
+    const result = await runner.run(agent, 'go', { stream: true });
+    const received = await collectDeltas(result);
+
+    expect(received).toEqual(['one', 'two']);
+    // Fires once mid-stream (after 'onetwo') plus the final output check.
+    expect(guardrail.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes raw partial text mid-stream and the parsed object on the final check', async () => {
+    const seen: Array<{ partial: boolean | undefined; output: unknown }> = [];
+    const guardrail = {
+      name: 'structured',
+      execute: vi.fn(async ({ agentOutput, details }: any) => {
+        seen.push({ partial: details?.partial, output: agentOutput });
+        return { tripwireTriggered: false, outputInfo: {} };
+      }),
+    };
+    const finalJson = '{"value":"hello"}';
+    const agent = new Agent({
+      name: 'StructuredStreamGuard',
+      outputType: z.object({ value: z.string() }),
+      model: new TextDeltaStreamingModel(['{"value":', '"hello"}'], finalJson),
+    });
+    const runner = new Runner({
+      outputGuardrails: [guardrail],
+      streamingOutputGuardrailCheckpoint: ({ accumulatedText }) =>
+        accumulatedText === '{"value":',
+    });
+
+    const result = await runner.run(agent, 'go', { stream: true });
+    await collectDeltas(result);
+
+    // First call is the mid-stream partial check (raw text), second is the final parsed object.
+    expect(seen[0]).toEqual({ partial: true, output: '{"value":' });
+    expect(seen[seen.length - 1].partial).toBeUndefined();
+    expect(seen[seen.length - 1].output).toEqual({ value: 'hello' });
+    expect(result.finalOutput).toEqual({ value: 'hello' });
+  });
+
+  it('consults multiple output guardrails at a checkpoint', async () => {
+    const passing = {
+      name: 'passes',
+      execute: vi.fn(async () => ({
+        tripwireTriggered: false,
+        outputInfo: {},
+      })),
+    };
+    const tripping = {
+      name: 'trips',
+      execute: vi.fn(async ({ agentOutput }: any) => ({
+        tripwireTriggered: String(agentOutput).includes('bad'),
+        outputInfo: {},
+      })),
+    };
+    const agent = new Agent({
+      name: 'StreamGuard',
+      model: new TextDeltaStreamingModel(['good', 'bad']),
+    });
+    const runner = new Runner({
+      outputGuardrails: [passing, tripping],
+      streamingOutputGuardrailCheckpoint: () => true,
+    });
+
+    const result = await runner.run(agent, 'go', { stream: true });
+    await expect(collectDeltas(result)).rejects.toBeInstanceOf(
+      OutputGuardrailTripwireTriggered,
+    );
+    expect(passing.execute).toHaveBeenCalled();
+    expect(tripping.execute).toHaveBeenCalled();
+  });
+});
+
 class ImmediateStreamingModel implements Model {
   constructor(private readonly response: ModelResponse) {}
 

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -3349,6 +3349,227 @@ describe('Runner.run (streaming output guardrails)', () => {
     expect(passing.execute).toHaveBeenCalled();
     expect(tripping.execute).toHaveBeenCalled();
   });
+
+  it('does not surface a previous turn response to mid-stream partial checks', async () => {
+    // Turn 1 is a tool call (which sets the last-turn response), turn 2 streams the
+    // final text. The partial check fires during turn 2, before that turn's response
+    // is finalized, so it must not receive the stale turn-1 response.
+    const seen: Array<{
+      partial: boolean | undefined;
+      modelResponse: any;
+    }> = [];
+    const guardrail = {
+      name: 'records-details',
+      execute: vi.fn(async ({ details }: any) => {
+        seen.push({
+          partial: details?.partial,
+          modelResponse: details?.modelResponse,
+        });
+        return { tripwireTriggered: false, outputInfo: {} };
+      }),
+    };
+
+    const echoTool = tool({
+      name: 'echo',
+      description: 'echo',
+      parameters: z.object({}),
+      execute: async () => 'tool-result',
+    });
+    const toolCall: FunctionCallItem = {
+      id: 'call-1',
+      type: 'function_call',
+      name: echoTool.name,
+      callId: 'c1',
+      status: 'completed',
+      arguments: '{}',
+    };
+
+    class ToolThenTextModel implements Model {
+      #callCount = 0;
+      async getResponse(): Promise<ModelResponse> {
+        return { output: [fakeModelMessage('final')], usage: new Usage() };
+      }
+      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
+        const turn = this.#callCount++;
+        if (turn === 0) {
+          yield {
+            type: 'response_done',
+            response: {
+              id: 'resp-tool-turn',
+              usage: {
+                requests: 1,
+                inputTokens: 0,
+                outputTokens: 0,
+                totalTokens: 0,
+              },
+              output: [toolCall],
+            },
+          } as any;
+          return;
+        }
+        yield { type: 'output_text_delta', delta: 'fin' } as any;
+        yield { type: 'output_text_delta', delta: 'al' } as any;
+        yield {
+          type: 'response_done',
+          response: {
+            id: 'resp-text-turn',
+            usage: {
+              requests: 1,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            output: [fakeModelMessage('final')],
+          },
+        } as any;
+      }
+    }
+
+    const agent = new Agent({
+      name: 'StreamGuard',
+      model: new ToolThenTextModel(),
+      tools: [echoTool],
+    });
+    const runner = new Runner({
+      outputGuardrails: [guardrail],
+      streamingOutputGuardrailCheckpoint: () => true,
+    });
+
+    const result = await runner.run(agent, 'go', { stream: true });
+    await collectDeltas(result);
+
+    const partialCalls = seen.filter((s) => s.partial);
+    const finalCalls = seen.filter((s) => !s.partial);
+    expect(partialCalls.length).toBeGreaterThan(0);
+    // No response at all (let alone the stale turn-1 response) is surfaced mid-stream.
+    expect(partialCalls.every((c) => c.modelResponse === undefined)).toBe(true);
+    expect(
+      partialCalls.some(
+        (c) => c.modelResponse?.responseId === 'resp-tool-turn',
+      ),
+    ).toBe(false);
+    // The final check still receives the completed turn-2 response.
+    expect(finalCalls[finalCalls.length - 1].modelResponse?.responseId).toBe(
+      'resp-text-turn',
+    );
+  });
+
+  it('streams an unguarded agent directly after a handoff from a guarded agent', async () => {
+    // Gate the unguarded agent's turn so it cannot complete until released. If its
+    // output were still held back, the first delta could only arrive as a burst at
+    // turn completion, which the gate prevents until after the assertion below.
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    let resolveSawFirstDelta!: () => void;
+    const sawFirstDelta = new Promise<void>((resolve) => {
+      resolveSawFirstDelta = resolve;
+    });
+
+    class GatedDeltaModel implements Model {
+      async getResponse(): Promise<ModelResponse> {
+        return { output: [fakeModelMessage('B1B2')], usage: new Usage() };
+      }
+      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
+        yield { type: 'output_text_delta', delta: 'B1' } as any;
+        await gate;
+        yield { type: 'output_text_delta', delta: 'B2' } as any;
+        yield {
+          type: 'response_done',
+          response: {
+            id: 'resp-b',
+            usage: {
+              requests: 1,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            output: [fakeModelMessage('B1B2')],
+          },
+        } as any;
+      }
+    }
+
+    class HandoffStreamingModel implements Model {
+      constructor(private readonly resp: ModelResponse) {}
+      async getResponse(): Promise<ModelResponse> {
+        return this.resp;
+      }
+      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
+        yield {
+          type: 'response_done',
+          response: {
+            id: 'resp-a',
+            usage: {
+              requests: 1,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            output: this.resp.output,
+          },
+        } as any;
+      }
+    }
+
+    const agentB = new Agent({ name: 'B', model: new GatedDeltaModel() });
+    const handoffToB = handoff(agentB);
+    const handoffCall: FunctionCallItem = {
+      id: 'h1',
+      type: 'function_call',
+      name: handoffToB.toolName,
+      callId: 'c1',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const agentA = new Agent({
+      name: 'A',
+      model: new HandoffStreamingModel({
+        output: [handoffCall],
+        usage: new Usage(),
+      }),
+      handoffs: [handoffToB],
+      // Agent-level guardrail makes A's turn buffered, activating the output hold.
+      outputGuardrails: [
+        {
+          name: 'a-guard',
+          execute: async () => ({ tripwireTriggered: false, outputInfo: {} }),
+        },
+      ],
+    });
+    const runner = new Runner({
+      streamingOutputGuardrailCheckpoint: () => true,
+    });
+
+    const result = await runner.run(agentA, 'go', { stream: true });
+    const received: string[] = [];
+    const consume = (async () => {
+      for await (const event of result) {
+        if (
+          event.type === 'raw_model_stream_event' &&
+          event.data.type === 'output_text_delta'
+        ) {
+          received.push(event.data.delta);
+          if (event.data.delta === 'B1') {
+            resolveSawFirstDelta();
+          }
+        }
+      }
+    })();
+
+    // The unguarded agent streams through directly: its first delta reaches the
+    // consumer before its (gated) turn can complete.
+    await sawFirstDelta;
+    expect(received).toContain('B1');
+
+    releaseGate();
+    await consume;
+    await result.completed;
+
+    expect(received).toEqual(['B1', 'B2']);
+    expect(result.finalOutput).toBe('B1B2');
+  });
 });
 
 class ImmediateStreamingModel implements Model {

--- a/packages/agents-core/test/runner/guardrails.test.ts
+++ b/packages/agents-core/test/runner/guardrails.test.ts
@@ -7,6 +7,7 @@ import {
   buildInputGuardrailDefinitions,
   runInputGuardrails,
   runOutputGuardrails,
+  runStreamingOutputGuardrails,
   splitInputGuardrails,
 } from '../../src/runner/guardrails';
 import {
@@ -283,6 +284,67 @@ describe('runOutputGuardrails', () => {
         runOutputGuardrails(state, [runnerGuardrail as any], 'ok'),
       ),
     ).rejects.toBeInstanceOf(GuardrailExecutionError);
+    expect(state._outputGuardrailResults).toHaveLength(0);
+  });
+});
+
+describe('runStreamingOutputGuardrails', () => {
+  it('passes the raw partial text and a partial flag to guardrails', async () => {
+    const agent = makeAgent({ name: 'PartialOutput' });
+    const state = makeState(agent);
+    state._lastTurnResponse = { output: [], usage: new Usage() };
+    let received: { agentOutput: unknown; partial: boolean | undefined } = {
+      agentOutput: undefined,
+      partial: undefined,
+    };
+    const runnerGuardrail = defineOutputGuardrail({
+      name: 'partial',
+      execute: async ({ agentOutput, details }) => {
+        received = { agentOutput, partial: details?.partial };
+        return { tripwireTriggered: false, outputInfo: {} };
+      },
+    });
+
+    await withTrace('streaming-guardrails-partial', () =>
+      runStreamingOutputGuardrails(
+        state,
+        [runnerGuardrail as any],
+        'partial te',
+      ),
+    );
+
+    expect(received.agentOutput).toBe('partial te');
+    expect(received.partial).toBe(true);
+    expect(state._outputGuardrailResults).toHaveLength(1);
+  });
+
+  it('throws when a streaming guardrail trips', async () => {
+    const agent = makeAgent({ name: 'PartialTrip' });
+    const state = makeState(agent);
+    const runnerGuardrail = defineOutputGuardrail({
+      name: 'trip',
+      execute: async () => ({
+        tripwireTriggered: true,
+        outputInfo: { reason: 'bad' },
+      }),
+    });
+
+    await expect(
+      withTrace('streaming-guardrails-trip', () =>
+        runStreamingOutputGuardrails(state, [runnerGuardrail as any], 'oops'),
+      ),
+    ).rejects.toBeInstanceOf(OutputGuardrailTripwireTriggered);
+    expect(state._outputGuardrailResults).toHaveLength(1);
+  });
+
+  it('is a no-op when there are no output guardrails', async () => {
+    const agent = makeAgent({ name: 'NoGuards' });
+    const state = makeState(agent);
+
+    await withTrace('streaming-guardrails-noop', () =>
+      runStreamingOutputGuardrails(state, [], 'anything'),
+    );
+
     expect(state._outputGuardrailResults).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

Output guardrails currently run only on the final output. In streaming runs this is awkward: every text delta has already reached the consumer before the guardrail gets a chance to inspect it.

This adds a runner option, `streamingOutputGuardrailCheckpoint`, that lets output guardrails run **while the model is still streaming**, and holds streamed output back until it passes a check.

## How it works

- Set `streamingOutputGuardrailCheckpoint` on the `Runner` (or per run). It receives `{ agent, delta, accumulatedText, context }` for each streamed text delta and returns a `boolean` (sync or async).
- When the predicate returns `true`, the configured output guardrails (runner-level + agent-level) run against the accumulated partial output.
  - **Pass** → the buffered output is released to the consumer and streaming continues.
  - **Trip** → streaming stops and `OutputGuardrailTripwireTriggered` is raised.
- While a checkpoint has not passed, streamed events are held back, so unsafe content never reaches the consumer. With a checkpoint configured, streamed text therefore arrives in blocks (one per passing checkpoint) instead of token by token.
- The same guardrail `execute` runs both mid-stream (with the raw accumulated text and `details.partial = true`) and on the final output (parsed object). For structured `outputType` agents, mid-stream guardrails receive partial text.

Useful for cadence-based checks: run the guardrail every 200 characters, or in a quiz builder each time a question in a list is fully generated.

## Backward compatibility

When `streamingOutputGuardrailCheckpoint` is not set, nothing changes: no buffering, identical emission timing, and output guardrails run solely on the final output as before.

## Changes

- `streamingOutputGuardrailCheckpoint` option on `RunConfig` / run options (`run.ts`).
- New `StreamingOutputGuardrailCheckpoint` / `StreamingOutputGuardrailCheckpointArgs` types and a `details.partial` flag (`guardrail.ts`).
- New `runStreamingOutputGuardrails` helper that checks partial text without parsing it (`runner/guardrails.ts`).
- Hold/release/discard buffer in `StreamedRunResult` (`result.ts`), gating the single `_addItem` emission point.
- Stream-loop integration: per-turn accumulation, checkpoint evaluation, and buffer flush/discard around the existing final guardrails, turn boundaries, abort, and error handlers (`run.ts`).
- Tests (`run.stream.test.ts`, `runner/guardrails.test.ts`), docs, an updated example, and a changeset.

## Testing

- `pnpm -r build-check` passes for all packages and examples.
- New tests pass; full `agents-core` suite has no regressions.
- `pnpm lint` is clean.
