### PR TITLE
docs: add Latitude to external tracing processors list

### DIFF
--- a/docs/src/content/docs/guides/tracing.mdx
+++ b/docs/src/content/docs/guides/tracing.mdx
@@ -139,3 +139,4 @@ To customize this default setup, to send traces to alternative or additional bac
 - [AgentOps](https://docs.agentops.ai/v2/usage/typescript-sdk#openai-agents-integration)
 - [Respan](https://www.respan.ai/docs/integrations/openai-agents-sdk)
 - [PromptLayer](https://docs.promptlayer.com/languages/integrations#openai-agents-sdk)
+- [Latitude](https://docs.latitude.so/telemetry/frameworks/openai-agents)


### PR DESCRIPTION
Adds Latitude to the list of external tracing processors in the JS tracing guide.

Latitude ships SDK-level instrumentation for the OpenAI Agents SDK in TypeScript and JavaScript. Setup and a code sample live at https://docs.latitude.so/telemetry/frameworks/openai-agents.