### PR TITLE
feat(mcp): expose serializable full tool results

### DIFF
--- a/.changeset/serializable-mcp-tool-results.md
+++ b/.changeset/serializable-mcp-tool-results.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents': patch
+---
+
+feat(mcp): expose serializable full tool results

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -107,6 +107,8 @@ export {
   invalidateServerToolsCache,
   mcpToFunctionTool,
   MCPBlobResourceContent,
+  CallToolResult,
+  CallToolResultContent,
   MCPListResourcesParams,
   MCPListResourcesResult,
   MCPListResourceTemplatesResult,

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -1195,6 +1195,7 @@ export function mcpToFunctionTool(
           };
     if (
       server.useStructuredContent === true &&
+      result.isError !== true &&
       result.structuredContent !== undefined
     ) {
       return JSON.stringify(result.structuredContent);

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -65,6 +65,11 @@ export interface MCPServer {
   toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
   toolMetaResolver?: MCPToolMetaResolver;
   /**
+   * Whether to use MCP `structuredContent` as the model-visible tool output when available.
+   * Defaults to false to preserve the existing content-based output behavior.
+   */
+  useStructuredContent?: boolean;
+  /**
    * Optional function to convert MCP tool failures into model-visible messages.
    * Set to null to rethrow errors instead of converting them.
    */
@@ -78,6 +83,14 @@ export interface MCPServer {
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
   ): Promise<CallToolResultContent>;
+  /**
+   * Invoke a tool and return the full serializable MCP result.
+   */
+  callToolResult?(
+    toolName: string,
+    args: Record<string, unknown> | null,
+    meta?: Record<string, unknown> | null,
+  ): Promise<CallToolResult>;
   invalidateToolsCache(): Promise<void>;
 }
 
@@ -184,6 +197,7 @@ export abstract class BaseMCPServerStdio implements MCPServer {
   protected _cachedTools: any[] | undefined = undefined;
   public toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
   public toolMetaResolver?: MCPToolMetaResolver;
+  public useStructuredContent?: boolean;
   public errorFunction?: MCPToolErrorFunction | null;
 
   protected logger: Logger;
@@ -193,6 +207,7 @@ export abstract class BaseMCPServerStdio implements MCPServer {
     this.cacheToolsList = options.cacheToolsList ?? false;
     this.toolFilter = options.toolFilter;
     this.toolMetaResolver = options.toolMetaResolver;
+    this.useStructuredContent = options.useStructuredContent;
     this.errorFunction = options.errorFunction;
   }
 
@@ -205,6 +220,11 @@ export abstract class BaseMCPServerStdio implements MCPServer {
     _args: Record<string, unknown> | null,
     _meta?: Record<string, unknown> | null,
   ): Promise<CallToolResultContent>;
+  abstract callToolResult(
+    _toolName: string,
+    _args: Record<string, unknown> | null,
+    _meta?: Record<string, unknown> | null,
+  ): Promise<CallToolResult>;
   abstract listResources(
     _params?: MCPListResourcesParams,
   ): Promise<MCPListResourcesResult>;
@@ -231,6 +251,7 @@ export abstract class BaseMCPServerStreamableHttp implements MCPServer {
   protected _cachedTools: any[] | undefined = undefined;
   public toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
   public toolMetaResolver?: MCPToolMetaResolver;
+  public useStructuredContent?: boolean;
   public errorFunction?: MCPToolErrorFunction | null;
 
   protected logger: Logger;
@@ -241,6 +262,7 @@ export abstract class BaseMCPServerStreamableHttp implements MCPServer {
     this.cacheToolsList = options.cacheToolsList ?? false;
     this.toolFilter = options.toolFilter;
     this.toolMetaResolver = options.toolMetaResolver;
+    this.useStructuredContent = options.useStructuredContent;
     this.errorFunction = options.errorFunction;
   }
 
@@ -253,6 +275,11 @@ export abstract class BaseMCPServerStreamableHttp implements MCPServer {
     _args: Record<string, unknown> | null,
     _meta?: Record<string, unknown> | null,
   ): Promise<CallToolResultContent>;
+  abstract callToolResult(
+    _toolName: string,
+    _args: Record<string, unknown> | null,
+    _meta?: Record<string, unknown> | null,
+  ): Promise<CallToolResult>;
   abstract listResources(
     _params?: MCPListResourcesParams,
   ): Promise<MCPListResourcesResult>;
@@ -280,6 +307,7 @@ export abstract class BaseMCPServerSSE implements MCPServer {
   protected _cachedTools: any[] | undefined = undefined;
   public toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
   public toolMetaResolver?: MCPToolMetaResolver;
+  public useStructuredContent?: boolean;
   public errorFunction?: MCPToolErrorFunction | null;
 
   protected logger: Logger;
@@ -289,6 +317,7 @@ export abstract class BaseMCPServerSSE implements MCPServer {
     this.cacheToolsList = options.cacheToolsList ?? false;
     this.toolFilter = options.toolFilter;
     this.toolMetaResolver = options.toolMetaResolver;
+    this.useStructuredContent = options.useStructuredContent;
     this.errorFunction = options.errorFunction;
   }
 
@@ -301,6 +330,11 @@ export abstract class BaseMCPServerSSE implements MCPServer {
     _args: Record<string, unknown> | null,
     _meta?: Record<string, unknown> | null,
   ): Promise<CallToolResultContent>;
+  abstract callToolResult(
+    _toolName: string,
+    _args: Record<string, unknown> | null,
+    _meta?: Record<string, unknown> | null,
+  ): Promise<CallToolResult>;
   abstract listResources(
     _params?: MCPListResourcesParams,
   ): Promise<MCPListResourcesResult>;
@@ -371,12 +405,19 @@ export class MCPServerStdio
     }
     return tools;
   }
-  callTool(
+  async callTool(
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
   ): Promise<CallToolResultContent> {
-    return this.underlying.callTool(toolName, args, meta);
+    return (await this.callToolResult(toolName, args, meta)).content;
+  }
+  callToolResult(
+    toolName: string,
+    args: Record<string, unknown> | null,
+    meta?: Record<string, unknown> | null,
+  ): Promise<CallToolResult> {
+    return this.underlying.callToolResult(toolName, args, meta);
   }
   listResources(
     params?: MCPListResourcesParams,
@@ -451,9 +492,16 @@ export class MCPServerStreamableHttp
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
   ): Promise<CallToolResultContent> {
+    return (await this.callToolResult(toolName, args, meta)).content;
+  }
+  async callToolResult(
+    toolName: string,
+    args: Record<string, unknown> | null,
+    meta?: Record<string, unknown> | null,
+  ): Promise<CallToolResult> {
     const previousSessionId = this.sessionId;
     try {
-      return await this.underlying.callTool(toolName, args, meta);
+      return await this.underlying.callToolResult(toolName, args, meta);
     } finally {
       if (previousSessionId !== this.sessionId) {
         this.clearLocalToolsCache();
@@ -507,12 +555,19 @@ export class MCPServerSSE
     }
     return tools;
   }
-  callTool(
+  async callTool(
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
   ): Promise<CallToolResultContent> {
-    return this.underlying.callTool(toolName, args, meta);
+    return (await this.callToolResult(toolName, args, meta)).content;
+  }
+  callToolResult(
+    toolName: string,
+    args: Record<string, unknown> | null,
+    meta?: Record<string, unknown> | null,
+  ): Promise<CallToolResult> {
+    return this.underlying.callToolResult(toolName, args, meta);
   }
   listResources(
     params?: MCPListResourcesParams,
@@ -1127,10 +1182,24 @@ export function mcpToFunctionTool(
     const meta = runContext
       ? await resolveMcpToolMeta(server, runContext, mcpTool.name, args)
       : undefined;
-    const content =
-      meta === undefined
-        ? await server.callTool(mcpTool.name, args)
-        : await server.callTool(mcpTool.name, args, meta);
+    const result =
+      server.useStructuredContent === true && server.callToolResult
+        ? meta === undefined
+          ? await server.callToolResult(mcpTool.name, args)
+          : await server.callToolResult(mcpTool.name, args, meta)
+        : {
+            content:
+              meta === undefined
+                ? await server.callTool(mcpTool.name, args)
+                : await server.callTool(mcpTool.name, args, meta),
+          };
+    if (
+      server.useStructuredContent === true &&
+      result.structuredContent !== undefined
+    ) {
+      return JSON.stringify(result.structuredContent);
+    }
+    const content = result.content;
     return content.length === 1 ? content[0] : content;
   }
 
@@ -1208,6 +1277,10 @@ export interface BaseMCPServerStdioOptions {
    */
   toolMetaResolver?: MCPToolMetaResolver;
   /**
+   * Whether to use MCP `structuredContent` as model-visible output when available.
+   */
+  useStructuredContent?: boolean;
+  /**
    * Optional function to convert MCP tool failures into model-visible messages.
    * Set to null to rethrow errors instead of converting them.
    */
@@ -1237,6 +1310,10 @@ export interface MCPServerStreamableHttpOptions {
    * Invoked before calling `callTool`.
    */
   toolMetaResolver?: MCPToolMetaResolver;
+  /**
+   * Whether to use MCP `structuredContent` as model-visible output when available.
+   */
+  useStructuredContent?: boolean;
   /**
    * Optional function to convert MCP tool failures into model-visible messages.
    * Set to null to rethrow errors instead of converting them.
@@ -1271,6 +1348,10 @@ export interface MCPServerSSEOptions {
    * Invoked before calling `callTool`.
    */
   toolMetaResolver?: MCPToolMetaResolver;
+  /**
+   * Whether to use MCP `structuredContent` as model-visible output when available.
+   */
+  useStructuredContent?: boolean;
   /**
    * Optional function to convert MCP tool failures into model-visible messages.
    * Set to null to rethrow errors instead of converting them.
@@ -1323,7 +1404,10 @@ export interface JsonRpcResponse {
 
 export interface CallToolResponse extends JsonRpcResponse {
   result: {
-    content: { type: string; text: string }[];
+    content: Array<{ type: string; [key: string]: unknown }>;
+    _meta?: Record<string, unknown>;
+    structuredContent?: Record<string, unknown>;
+    isError?: boolean;
   };
 }
 export type CallToolResult = CallToolResponse['result'];

--- a/packages/agents-core/src/shims/mcp-server/browser.ts
+++ b/packages/agents-core/src/shims/mcp-server/browser.ts
@@ -2,6 +2,7 @@ import {
   BaseMCPServerSSE,
   BaseMCPServerStdio,
   BaseMCPServerStreamableHttp,
+  CallToolResult,
   CallToolResultContent,
   MCPListResourcesParams,
   MCPListResourcesResult,
@@ -34,6 +35,13 @@ export class MCPServerStdio extends BaseMCPServerStdio {
     _args: Record<string, unknown> | null,
     _meta?: Record<string, unknown> | null,
   ): Promise<CallToolResultContent> {
+    throw new Error('Method not implemented.');
+  }
+  callToolResult(
+    _toolName: string,
+    _args: Record<string, unknown> | null,
+    _meta?: Record<string, unknown> | null,
+  ): Promise<CallToolResult> {
     throw new Error('Method not implemented.');
   }
   listResources(
@@ -80,6 +88,13 @@ export class MCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
   ): Promise<CallToolResultContent> {
     throw new Error('Method not implemented.');
   }
+  callToolResult(
+    _toolName: string,
+    _args: Record<string, unknown> | null,
+    _meta?: Record<string, unknown> | null,
+  ): Promise<CallToolResult> {
+    throw new Error('Method not implemented.');
+  }
   listResources(
     _params?: MCPListResourcesParams,
   ): Promise<MCPListResourcesResult> {
@@ -121,6 +136,13 @@ export class MCPServerSSE extends BaseMCPServerSSE {
     _args: Record<string, unknown> | null,
     _meta?: Record<string, unknown> | null,
   ): Promise<CallToolResultContent> {
+    throw new Error('Method not implemented.');
+  }
+  callToolResult(
+    _toolName: string,
+    _args: Record<string, unknown> | null,
+    _meta?: Record<string, unknown> | null,
+  ): Promise<CallToolResult> {
     throw new Error('Method not implemented.');
   }
   listResources(

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -7,6 +7,7 @@ import {
   BaseMCPServerStdio,
   BaseMCPServerStreamableHttp,
   BaseMCPServerSSE,
+  CallToolResult,
   CallToolResultContent,
   DefaultMCPServerStdioOptions,
   InitializeResult,
@@ -268,6 +269,14 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
   ): Promise<CallToolResultContent> {
+    return (await this.callToolResult(toolName, args, meta)).content;
+  }
+
+  async callToolResult(
+    toolName: string,
+    args: Record<string, unknown> | null,
+    meta?: Record<string, unknown> | null,
+  ): Promise<CallToolResult> {
     const { CallToolResultSchema } =
       await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
     if (!this.session) {
@@ -290,12 +299,12 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
       requestOptions,
     );
     const parsed = CallToolResultSchema.parse(response);
-    const result = parsed.content;
+    const result = parsed as CallToolResult;
     this.debugLog(
       () =>
         `Called tool ${toolName} (args: ${JSON.stringify(args)}, result: ${JSON.stringify(result)})`,
     );
-    return result as CallToolResultContent;
+    return result;
   }
 
   async listResources(
@@ -471,6 +480,14 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
   ): Promise<CallToolResultContent> {
+    return (await this.callToolResult(toolName, args, meta)).content;
+  }
+
+  async callToolResult(
+    toolName: string,
+    args: Record<string, unknown> | null,
+    meta?: Record<string, unknown> | null,
+  ): Promise<CallToolResult> {
     const { CallToolResultSchema } =
       await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
     if (!this.session) {
@@ -493,12 +510,12 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
       requestOptions,
     );
     const parsed = CallToolResultSchema.parse(response);
-    const result = parsed.content;
+    const result = parsed as CallToolResult;
     this.debugLog(
       () =>
         `Called tool ${toolName} (args: ${JSON.stringify(args)}, result: ${JSON.stringify(result)})`,
     );
-    return result as CallToolResultContent;
+    return result;
   }
 
   async listResources(
@@ -871,7 +888,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
-  ): Promise<CallToolResultContent> {
+  ): Promise<CallToolResult> {
     const { CallToolResultSchema } =
       await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
     const requestOptions = buildRequestOptions(
@@ -887,7 +904,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     };
     const response = await client.callTool(params, undefined, requestOptions);
     const parsed = CallToolResultSchema.parse(response);
-    return parsed.content as CallToolResultContent;
+    return parsed as CallToolResult;
   }
 
   private async closeStreamableHttpClient(
@@ -1252,6 +1269,14 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
   ): Promise<CallToolResultContent> {
+    return (await this.callToolResult(toolName, args, meta)).content;
+  }
+
+  async callToolResult(
+    toolName: string,
+    args: Record<string, unknown> | null,
+    meta?: Record<string, unknown> | null,
+  ): Promise<CallToolResult> {
     const client = this.session;
     if (!client) {
       throw new Error(
@@ -1259,7 +1284,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
       );
     }
     const callToolStateVersion = this.connectionStateVersion;
-    let result: CallToolResultContent;
+    let result: CallToolResult;
 
     try {
       result = await this.callToolWithClient(client, toolName, args, meta);
@@ -1301,7 +1326,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
       () =>
         `Called tool ${toolName} (args: ${JSON.stringify(args)}, result: ${JSON.stringify(result)})`,
     );
-    return result as CallToolResultContent;
+    return result;
   }
 
   async listResources(

--- a/packages/agents-core/test/mcpToFunctionTool.test.ts
+++ b/packages/agents-core/test/mcpToFunctionTool.test.ts
@@ -128,6 +128,158 @@ describe('mcpToFunctionTool', () => {
     ]);
   });
 
+  it('uses structured MCP output only when explicitly enabled', async () => {
+    const callTool = vi.fn(async () => [
+      { type: 'text', text: 'legacy output' },
+    ]);
+    const callToolResult = vi.fn(async () => ({
+      content: [{ type: 'text', text: 'legacy output' }],
+      structuredContent: { answer: 42 },
+    }));
+    const server: MCPServer = {
+      name: 'structured-output-server',
+      cacheToolsList: false,
+      useStructuredContent: true,
+      connect: async () => {},
+      close: async () => {},
+      listTools: async () => [],
+      callTool,
+      callToolResult,
+      invalidateToolsCache: async () => {},
+    };
+    const tool = mcpToFunctionTool(
+      {
+        name: 'structured',
+        description: '',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      } as any,
+      server,
+      false,
+    );
+
+    await expect(tool.invoke(new RunContext({}), '{}')).resolves.toBe(
+      '{"answer":42}',
+    );
+    expect(callToolResult).toHaveBeenCalledWith('structured', {});
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  it('keeps using legacy content output by default', async () => {
+    const callTool = vi.fn(async () => [
+      { type: 'text', text: 'legacy output' },
+    ]);
+    const callToolResult = vi.fn(async () => ({
+      content: [{ type: 'text', text: 'legacy output' }],
+      structuredContent: { answer: 42 },
+    }));
+    const server: MCPServer = {
+      name: 'legacy-output-server',
+      cacheToolsList: false,
+      connect: async () => {},
+      close: async () => {},
+      listTools: async () => [],
+      callTool,
+      callToolResult,
+      invalidateToolsCache: async () => {},
+    };
+    const tool = mcpToFunctionTool(
+      {
+        name: 'legacy',
+        description: '',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      } as any,
+      server,
+      false,
+    );
+
+    await expect(tool.invoke(new RunContext({}), '{}')).resolves.toEqual({
+      type: 'text',
+      text: 'legacy output',
+    });
+    expect(callTool).toHaveBeenCalledWith('legacy', {});
+    expect(callToolResult).not.toHaveBeenCalled();
+  });
+
+  it('uses an empty structured MCP output when explicitly enabled', async () => {
+    const callToolResult = vi.fn(async () => ({
+      content: [{ type: 'text', text: 'legacy output' }],
+      structuredContent: {},
+    }));
+    const server: MCPServer = {
+      name: 'empty-structured-output-server',
+      cacheToolsList: false,
+      useStructuredContent: true,
+      connect: async () => {},
+      close: async () => {},
+      listTools: async () => [],
+      callTool: async () => [{ type: 'text', text: 'legacy output' }],
+      callToolResult,
+      invalidateToolsCache: async () => {},
+    };
+    const tool = mcpToFunctionTool(
+      {
+        name: 'empty_structured',
+        description: '',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      } as any,
+      server,
+      false,
+    );
+
+    await expect(tool.invoke(new RunContext({}), '{}')).resolves.toBe('{}');
+  });
+
+  it('falls back to legacy content when a custom server has no full-result method', async () => {
+    const callTool = vi.fn(async () => [
+      { type: 'text', text: 'legacy output' },
+    ]);
+    const server: MCPServer = {
+      name: 'legacy-custom-server',
+      cacheToolsList: false,
+      useStructuredContent: true,
+      connect: async () => {},
+      close: async () => {},
+      listTools: async () => [],
+      callTool,
+      invalidateToolsCache: async () => {},
+    };
+    const tool = mcpToFunctionTool(
+      {
+        name: 'legacy_custom',
+        description: '',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      } as any,
+      server,
+      false,
+    );
+
+    await expect(tool.invoke(new RunContext({}), '{}')).resolves.toEqual({
+      type: 'text',
+      text: 'legacy output',
+    });
+    expect(callTool).toHaveBeenCalledWith('legacy_custom', {});
+  });
+
   it('resolves and passes MCP tool metadata', async () => {
     const callTool = vi.fn(
       async (

--- a/packages/agents-core/test/mcpToFunctionTool.test.ts
+++ b/packages/agents-core/test/mcpToFunctionTool.test.ts
@@ -244,6 +244,44 @@ describe('mcpToFunctionTool', () => {
     await expect(tool.invoke(new RunContext({}), '{}')).resolves.toBe('{}');
   });
 
+  it('preserves MCP error content when structured output is enabled', async () => {
+    const callToolResult = vi.fn(async () => ({
+      content: [{ type: 'text', text: 'tool error details' }],
+      structuredContent: { answer: 42 },
+      isError: true,
+    }));
+    const server: MCPServer = {
+      name: 'structured-error-server',
+      cacheToolsList: false,
+      useStructuredContent: true,
+      connect: async () => {},
+      close: async () => {},
+      listTools: async () => [],
+      callTool: async () => [{ type: 'text', text: 'legacy output' }],
+      callToolResult,
+      invalidateToolsCache: async () => {},
+    };
+    const tool = mcpToFunctionTool(
+      {
+        name: 'structured_error',
+        description: '',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      } as any,
+      server,
+      false,
+    );
+
+    await expect(tool.invoke(new RunContext({}), '{}')).resolves.toEqual({
+      type: 'text',
+      text: 'tool error details',
+    });
+  });
+
   it('falls back to legacy content when a custom server has no full-result method', async () => {
     const callTool = vi.fn(async () => [
       { type: 'text', text: 'legacy output' },

--- a/packages/agents-core/test/shims/mcp-server/browser.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/browser.test.ts
@@ -28,6 +28,7 @@ describe('MCPServerStreamableHttp', () => {
     expect(() => server.close()).toThrow();
     expect(() => server.listTools()).toThrow();
     expect(() => server.callTool('tool', {})).toThrow();
+    expect(() => server.callToolResult('tool', {})).toThrow();
     expect(() => server.invalidateToolsCache()).toThrow();
   });
 });
@@ -43,6 +44,7 @@ describe('MCPServerSSE', () => {
     expect(() => server.close()).toThrow();
     expect(() => server.listTools()).toThrow();
     expect(() => server.callTool('tool', {})).toThrow();
+    expect(() => server.callToolResult('tool', {})).toThrow();
     expect(() => server.invalidateToolsCache()).toThrow();
   });
 });

--- a/packages/agents-core/test/shims/mcp-server/node.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/node.test.ts
@@ -127,6 +127,28 @@ describe('NodeMCPServerStdio', () => {
     await server.close();
   });
 
+  test('should return a serializable full tool result', async () => {
+    const server = new NodeMCPServerStdio({
+      name: 'full-result-test',
+      fullCommand: 'test',
+    });
+
+    await server.connect();
+    const result = await server.callToolResult('mock-tool', {});
+
+    expect(JSON.parse(JSON.stringify(result))).toEqual({
+      content: [{ type: 'text', text: 'ok' }],
+      _meta: { renderer: 'chart' },
+      structuredContent: { answer: 42 },
+      isError: true,
+    });
+    expect(await server.callTool('mock-tool', {})).toEqual([
+      { type: 'text', text: 'ok' },
+    ]);
+
+    await server.close();
+  });
+
   test('should forward resource requests to session methods', async () => {
     const server = new NodeMCPServerStdio({
       name: 'resource-test',
@@ -228,6 +250,9 @@ class MockClient {
     lastCallToolOptions = options;
     return Promise.resolve({
       content: [{ type: 'text', text: 'ok' }],
+      _meta: { renderer: 'chart' },
+      structuredContent: { answer: 42 },
+      isError: true,
     });
   }
   listResources(params?: any, options?: any): Promise<any> {
@@ -388,6 +413,26 @@ describe('NodeMCPServerSSE', () => {
     await server.close();
   });
 
+  test('should return a serializable full tool result', async () => {
+    const server = new NodeMCPServerSSE({
+      url: 'https://example.com/sse',
+      name: 'test-sse-full-result',
+    });
+
+    await server.connect();
+
+    expect(
+      JSON.parse(JSON.stringify(await server.callToolResult('mock-tool', {}))),
+    ).toEqual({
+      content: [{ type: 'text', text: 'ok' }],
+      _meta: { renderer: 'chart' },
+      structuredContent: { answer: 42 },
+      isError: true,
+    });
+
+    await server.close();
+  });
+
   test('should forward resource requests to session methods', async () => {
     const server = new NodeMCPServerSSE({
       url: 'https://example.com/sse',
@@ -524,6 +569,26 @@ describe('NodeMCPServerStreamableHttp', () => {
     expect(lastConnectOptions?.timeout).toBe(9000);
     expect(lastListToolsOptions?.timeout).toBe(9000);
     expect(lastCallToolOptions?.timeout).toBe(DEFAULT_REQUEST_TIMEOUT_MSEC);
+
+    await server.close();
+  });
+
+  test('should return a serializable full tool result', async () => {
+    const server = new NodeMCPServerStreamableHttp({
+      url: 'https://example.com/stream',
+      name: 'test-stream-full-result',
+    });
+
+    await server.connect();
+
+    expect(
+      JSON.parse(JSON.stringify(await server.callToolResult('mock-tool', {}))),
+    ).toEqual({
+      content: [{ type: 'text', text: 'ok' }],
+      _meta: { renderer: 'chart' },
+      structuredContent: { answer: 42 },
+      isError: true,
+    });
 
     await server.close();
   });

--- a/packages/agents-core/test/shims/mcp-server/streamableHttpRetry.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/streamableHttpRetry.test.ts
@@ -557,6 +557,38 @@ describe('NodeMCPServerStreamableHttp closed-session recovery', () => {
     }
   });
 
+  it('preserves serializable full results when retrying a disconnected client', async () => {
+    MockClient.callToolHandlers = [
+      async function (this: MockClient) {
+        throwProtocolNotConnected.call(this);
+      },
+      async () => ({
+        content: [{ type: 'text', text: 'fallback' }],
+        _meta: { renderer: 'chart' },
+        structuredContent: { answer: 42 },
+        isError: false,
+      }),
+    ];
+
+    const server = createServer('full-result-retry-server');
+    await server.connect();
+
+    try {
+      const result = await server.callToolResult('mock-tool', { foo: 'bar' });
+
+      expect(JSON.parse(JSON.stringify(result))).toEqual({
+        content: [{ type: 'text', text: 'fallback' }],
+        _meta: { renderer: 'chart' },
+        structuredContent: { answer: 42 },
+        isError: false,
+      });
+      expect(MockClient.instances).toHaveLength(1);
+      expect(MockStreamableHTTPClientTransport.instances).toHaveLength(2);
+    } finally {
+      await server.close();
+    }
+  });
+
   it('does not reconnect when a healthy client hook throws Error("Not connected")', async () => {
     let firstFailure = true;
     MockClient.callToolHandlers = [


### PR DESCRIPTION
This pull request adds a serializable `callToolResult()` API for local MCP servers so integrations such as Temporal can preserve `content`, `_meta`, `structuredContent`, and `isError` across JSON serialization boundaries.

The existing `callTool()` content-array contract remains unchanged. Built-in stdio, SSE, and Streamable HTTP transports expose the new full-result method. Local MCP servers can also opt in to using JSON-stringified `structuredContent` as model-visible output with `useStructuredContent: true`.