### PR TITLE
fix(realtime): encode large audio buffers without crashing

### DIFF
--- a/.changeset/realtime-large-audio-base64.md
+++ b/.changeset/realtime-large-audio-base64.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+Encode realtime audio buffers safely so large chunks no longer crash. The realtime `arrayBufferToBase64` helper now uses the shared `encodeUint8ArrayToBase64` encoder instead of spreading every byte into `String.fromCharCode`, which threw a RangeError for larger audio buffers.

--- a/packages/agents-realtime/src/utils.ts
+++ b/packages/agents-realtime/src/utils.ts
@@ -6,6 +6,7 @@ import {
 import type { InputAudioTranscriptionCompletedEvent } from './transportLayerEvents';
 import METADATA from './metadata';
 import { RunToolApprovalItem } from '@openai/agents-core';
+import { encodeUint8ArrayToBase64 } from '@openai/agents-core/utils';
 import { RealtimeAgent } from './realtimeAgent';
 
 /**
@@ -29,8 +30,7 @@ export function base64ToArrayBuffer(base64: string) {
  * @returns {string}
  */
 export function arrayBufferToBase64(arrayBuffer: ArrayBuffer) {
-  const binaryString = String.fromCharCode(...new Uint8Array(arrayBuffer));
-  return btoa(binaryString);
+  return encodeUint8ArrayToBase64(new Uint8Array(arrayBuffer));
 }
 
 /**

--- a/packages/agents-realtime/test/utils.test.ts
+++ b/packages/agents-realtime/test/utils.test.ts
@@ -25,6 +25,23 @@ describe('realtime utils', () => {
     expect(new Uint8Array(result)).toEqual(new Uint8Array(buffer));
   });
 
+  it('encodes a large audio buffer without throwing and round-trips it', () => {
+    const size = 1024 * 1024;
+    const bytes = new Uint8Array(size);
+    for (let i = 0; i < size; i++) {
+      bytes[i] = i % 256;
+    }
+
+    let base64 = '';
+    expect(() => {
+      base64 = arrayBufferToBase64(bytes.buffer);
+    }).not.toThrow();
+
+    const result = new Uint8Array(base64ToArrayBuffer(base64));
+    expect(result.length).toBe(size);
+    expect(result).toEqual(bytes);
+  });
+
   it('extracts transcript from audio output message', () => {
     const message: RealtimeMessageItem = {
       itemId: '1',


### PR DESCRIPTION
### Summary

The realtime `arrayBufferToBase64` helper in `packages/agents-realtime/src/utils.ts` converts audio bytes with `String.fromCharCode(...new Uint8Array(arrayBuffer))`. Spreading the byte array passes every byte as a separate function argument, so once an audio chunk is large enough it exceeds the runtime argument limit and throws a `RangeError: Maximum call stack size exceeded` before the audio can be encoded. This helper is on the live send path, it is called from `openaiRealtimeBase.sendAudio`, so a large enough chunk crashes audio sending.

The fix routes the conversion through the shared `encodeUint8ArrayToBase64` encoder from `@openai/agents-core/utils`. That encoder uses `Buffer` when available and otherwise iterates the bytes one at a time, so it handles buffers of any size and never spreads the array into a call. The inline-data call sites in the OpenAI and AI SDK packages already use this same encoder, so this brings the realtime path in line with them. The public signature of `arrayBufferToBase64` is unchanged.

### Test plan

Added a regression test in `packages/agents-realtime/test/utils.test.ts` that builds a 1 MiB buffer with deterministic byte content, asserts that `arrayBufferToBase64` does not throw, and round-trips the result back through `base64ToArrayBuffer` to confirm the bytes match. On `main` this test fails with the `RangeError`. With this change the realtime utils suite passes (17 tests), and the full `@openai/agents-realtime` suite passes (179 tests). I also ran prettier and eslint on the changed files and the package `build-check` and `dist:check`, all clean.

An earlier attempt at this fix in #1322 went stale from inactivity and was closed, not closed on the merits. This implementation differs by importing the shared encoder through the public `@openai/agents-core/utils` entry point and by covering a larger 1 MiB buffer with an explicit does-not-throw assertion.

### Issue number

Closes #1333

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `pnpm test` and `pnpm test:examples`
- [x] I've made sure tests pass
- [x] I've added a changeset using `pnpm changeset` to indicate my changes