### PR TITLE
fix: correct agents realtime browser bundle path

### DIFF
--- a/.changeset/agents-realtime-browser-bundle.md
+++ b/.changeset/agents-realtime-browser-bundle.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+Fix the package browser field to point at the generated UMD bundle.

--- a/packages/agents-realtime/package.json
+++ b/packages/agents-realtime/package.json
@@ -7,7 +7,7 @@
   "author": "OpenAI <support@openai.com>",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "./dist/bundle/openai-realtime-agents.umd.cjs",
+  "browser": "./dist/bundle/openai-realtime-agents.umd.js",
   "exports": {
     ".": {
       "browser": {


### PR DESCRIPTION
### Summary

Fixes the `@openai/agents-realtime` package `browser` field so it points at the generated UMD bundle that is actually published.

The current package metadata points to `./dist/bundle/openai-realtime-agents.umd.cjs`, but the published tarball and Vite library build output use `openai-realtime-agents.umd.js`.

### Test plan

- `npm pack @openai/agents-realtime@0.11.6 --dry-run --json --ignore-scripts` plus a Node assertion that:
  - `dist/bundle/openai-realtime-agents.umd.cjs` is absent
  - `dist/bundle/openai-realtime-agents.umd.js` is present
  - the patched `browser` field resolves to the present file
- `npx --yes prettier@3.8.3 --check packages/agents-realtime/package.json .changeset/agents-realtime-browser-bundle.md`
- `git diff --check`

I did not run the full `pnpm test` / `pnpm test:examples` suite because this is a package metadata pointer fix and this checkout only fetched the package plus release metadata needed for the change.

### Issue number

N/A

### Checks

- [ ] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [ ] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration` [(see details)](https://github.com/openai/openai-agents-js/tree/main/integration-tests)
- [ ] I've made sure tests pass
- [x] I've added a changeset using `pnpm changeset` to indicate my changes