### PR TITLE
feat: add Upstash Box sandbox provider

### DIFF
--- a/.changeset/upstash-box-sandbox-provider.md
+++ b/.changeset/upstash-box-sandbox-provider.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': minor
+---
+
+feat: add Upstash Box sandbox provider (`@openai/agents-extensions/sandbox/upstash-box`). The `UpstashBoxSandboxClient` runs sandbox agents on Upstash Box via the optional `@upstash/box` peer dependency, with support for command execution, file read/write, exposed ports through public URLs, keep-alive boxes, creating a box from an existing snapshot, and pause/resume session lifecycle.

--- a/docs/src/content/docs/guides/sandbox-agents/clients.mdx
+++ b/docs/src/content/docs/guides/sandbox-agents/clients.mdx
@@ -142,6 +142,7 @@ Install `@openai/agents-extensions` and satisfy its package-level peers. Each pr
 | `E2BSandboxClient` | `@openai/agents-extensions/sandbox/e2b` | npm peer: `e2b` or `@e2b/code-interpreter` |
 | `ModalSandboxClient` | `@openai/agents-extensions/sandbox/modal` | npm peer: `modal` |
 | `RunloopSandboxClient` | `@openai/agents-extensions/sandbox/runloop` | npm peer: `@runloop/api-client` |
+| `UpstashBoxSandboxClient` | `@openai/agents-extensions/sandbox/upstash-box` | npm peer: `@upstash/box` |
 | `VercelSandboxClient` | `@openai/agents-extensions/sandbox/vercel` | npm peer: `@vercel/sandbox` |
 
 `CloudflareSandboxClient` does not import a Cloudflare npm SDK. It talks to a deployed Cloudflare Sandbox bridge Worker over HTTP instead.
@@ -157,6 +158,7 @@ Hosted sandbox clients expose provider-specific mount strategies. Choose the bac
 | `DaytonaSandboxClient` | Supports rclone-backed mounts with `DaytonaCloudBucketMountStrategy` on S3, GCS, R2, Azure Blob, and Box mount entries. |
 | `E2BSandboxClient` | Supports rclone-backed mounts with `E2BCloudBucketMountStrategy` on S3, GCS, R2, Azure Blob, and Box mount entries. |
 | `RunloopSandboxClient` | Supports rclone-backed mounts with `RunloopCloudBucketMountStrategy` on S3, GCS, R2, Azure Blob, and Box mount entries. |
+| `UpstashBoxSandboxClient` | No hosted-specific mount strategy is currently exposed. Use manifest files, repos, snapshots, or other workspace inputs instead. |
 | `VercelSandboxClient` | No hosted-specific mount strategy is currently exposed. Use manifest files, repos, snapshots, or other workspace inputs instead. |
 
 The table below summarizes which remote storage entries each backend can mount directly:
@@ -170,6 +172,7 @@ The table below summarizes which remote storage entries each backend can mount d
 | `DaytonaSandboxClient` | yes | yes | yes | yes | yes | no |
 | `E2BSandboxClient` | yes | yes | yes | yes | yes | no |
 | `RunloopSandboxClient` | yes | yes | yes | yes | yes | no |
+| `UpstashBoxSandboxClient` | no | no | no | no | no | no |
 | `VercelSandboxClient` | no | no | no | no | no | no |
 
 ### Exposed ports

--- a/examples/sandbox/extensions/README.md
+++ b/examples/sandbox/extensions/README.md
@@ -277,3 +277,32 @@ Run:
 ```bash
 pnpm -F sandbox start:runloop -- --stream
 ```
+
+## Upstash Box
+
+Required environment variables:
+
+```bash
+export OPENAI_API_KEY=...
+export UPSTASH_BOX_API_KEY=...
+```
+
+How to get `UPSTASH_BOX_API_KEY`:
+
+1. Sign in to the Upstash Console at `https://console.upstash.com`.
+2. Open the Box section and create a Box API key.
+3. Copy the key and export it in your shell before running the example.
+
+Optional Upstash Box environment variable:
+
+```bash
+export UPSTASH_BOX_BASE_URL=...
+```
+
+Use `UPSTASH_BOX_BASE_URL` when you target a non-default Box API endpoint. The `@upstash/box` SDK reads both `UPSTASH_BOX_API_KEY` and `UPSTASH_BOX_BASE_URL` from the environment, and this example checks `UPSTASH_BOX_API_KEY` explicitly at startup, so make sure it is present in your shell environment first.
+
+Run:
+
+```bash
+pnpm -F sandbox start:upstash-box -- --stream
+```

--- a/examples/sandbox/extensions/upstash-box-runner.ts
+++ b/examples/sandbox/extensions/upstash-box-runner.ts
@@ -1,0 +1,87 @@
+import { Runner } from '@openai/agents';
+import { UpstashBoxSandboxClient } from '@openai/agents-extensions/sandbox/upstash-box';
+import { Manifest, SandboxAgent, shell } from '@openai/agents/sandbox';
+import { finished } from 'node:stream/promises';
+import {
+  DEFAULT_MODEL,
+  getStringArg,
+  hasFlag,
+  requireEnv,
+  requireOpenAIKey,
+  runExampleMain,
+} from '../support';
+
+const DEFAULT_QUESTION =
+  'Summarize this cloud sandbox workspace in 2 sentences.';
+const DEFAULT_UPSTASH_BOX_WORKSPACE_ROOT = '/workspace/home';
+
+function buildManifest(): Manifest {
+  return new Manifest({
+    root: DEFAULT_UPSTASH_BOX_WORKSPACE_ROOT,
+    entries: {
+      'README.md': {
+        type: 'file',
+        content: `# Upstash Box Demo Workspace
+
+This workspace exists to validate the Upstash Box sandbox backend manually.
+`,
+      },
+      'launch.md': {
+        type: 'file',
+        content: `# Launch
+
+- Customer: Contoso Logistics.
+- Goal: validate the remote sandbox agent path.
+- Current status: Upstash Box backend smoke and app-server connectivity are passing.
+`,
+      },
+      'tasks.md': {
+        type: 'file',
+        content: `# Tasks
+
+1. Inspect the workspace files.
+2. Summarize the setup and any notable status in two sentences.
+`,
+      },
+    },
+  });
+}
+
+async function main() {
+  requireOpenAIKey();
+  requireEnv('UPSTASH_BOX_API_KEY');
+
+  const model = getStringArg('--model', DEFAULT_MODEL);
+  const question = getStringArg('--question', DEFAULT_QUESTION);
+  const pauseOnExit = hasFlag('--pause-on-exit');
+  const stream = hasFlag('--stream');
+  const client = new UpstashBoxSandboxClient({ pauseOnExit });
+  const agent = new SandboxAgent({
+    name: 'Upstash Box Sandbox Assistant',
+    model,
+    instructions:
+      'Answer questions about the sandbox workspace. Inspect the files before answering, keep the response concise, and cite the file names you inspected.',
+    defaultManifest: buildManifest(),
+    capabilities: [shell()],
+  });
+  const runner = new Runner({
+    workflowName: 'Upstash Box sandbox example',
+    sandbox: { client },
+  });
+
+  if (!stream) {
+    const result = await runner.run(agent, question);
+    console.log(result.finalOutput);
+    return;
+  }
+
+  const result = await runner.run(agent, question, { stream: true });
+  process.stdout.write('assistant> ');
+  const textStream = result.toTextStream({ compatibleWithNodeStreams: true });
+  textStream.pipe(process.stdout);
+  await finished(textStream);
+  await result.completed;
+  process.stdout.write('\n');
+}
+
+await runExampleMain(main);

--- a/examples/sandbox/package.json
+++ b/examples/sandbox/package.json
@@ -28,6 +28,7 @@
     "start:e2b": "tsx extensions/e2b-runner.ts",
     "start:modal": "tsx extensions/modal-runner.ts",
     "start:runloop": "tsx extensions/runloop-runner.ts",
+    "start:upstash-box": "tsx extensions/upstash-box-runner.ts",
     "start:vercel": "tsx extensions/vercel-runner.ts"
   }
 }

--- a/packages/agents-extensions/package.json
+++ b/packages/agents-extensions/package.json
@@ -64,6 +64,11 @@
       "require": "./dist/sandbox/runloop/index.js",
       "import": "./dist/sandbox/runloop/index.mjs"
     },
+    "./sandbox/upstash-box": {
+      "types": "./dist/sandbox/upstash-box/index.d.ts",
+      "require": "./dist/sandbox/upstash-box/index.js",
+      "import": "./dist/sandbox/upstash-box/index.mjs"
+    },
     "./sandbox/vercel": {
       "types": "./dist/sandbox/vercel/index.d.ts",
       "require": "./dist/sandbox/vercel/index.js",
@@ -83,6 +88,7 @@
     "@openai/agents": "workspace:>=0.0.0",
     "@openai/codex-sdk": ">=0.86.0",
     "@runloop/api-client": "^1.16.2",
+    "@upstash/box": "^0.4.6",
     "@vercel/sandbox": "^1.9.3",
     "ai": "^6.0.0",
     "e2b": "^2.14.1",
@@ -118,6 +124,9 @@
     "@runloop/api-client": {
       "optional": true
     },
+    "@upstash/box": {
+      "optional": true
+    },
     "@vercel/sandbox": {
       "optional": true
     }
@@ -138,6 +147,7 @@
     "@openai/codex-sdk": "^0.86.0",
     "@runloop/api-client": "1.16.2",
     "@types/debug": "^4.1.12",
+    "@upstash/box": "0.4.8",
     "@vercel/sandbox": "1.9.3",
     "ai": "^6.0.42",
     "e2b": "^2.14.1",
@@ -168,6 +178,9 @@
       ],
       "sandbox/runloop": [
         "dist/sandbox/runloop/index.d.ts"
+      ],
+      "sandbox/upstash-box": [
+        "dist/sandbox/upstash-box/index.d.ts"
       ],
       "sandbox/vercel": [
         "dist/sandbox/vercel/index.d.ts"

--- a/packages/agents-extensions/src/sandbox/upstash-box/index.ts
+++ b/packages/agents-extensions/src/sandbox/upstash-box/index.ts
@@ -1,0 +1,1 @@
+export * from './sandbox';

--- a/packages/agents-extensions/src/sandbox/upstash-box/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/upstash-box/sandbox.ts
@@ -1,0 +1,670 @@
+import { UserError } from '@openai/agents-core';
+import {
+  Manifest,
+  SandboxProviderError,
+  normalizeSandboxClientCreateArgs,
+  type SandboxClient,
+  type SandboxClientCreateArgs,
+  type SandboxClientOptions,
+  type SandboxArchiveLimits,
+  type SandboxConcurrencyLimits,
+  type ExposedPortEndpoint,
+  type SandboxSessionLifecycleOptions,
+  type SandboxSessionState,
+} from '@openai/agents-core/sandbox';
+import {
+  assertCoreSnapshotUnsupported,
+  assertResumeRecreateAllowed,
+  assertSandboxManifestMetadataSupported,
+  closeRemoteSessionOnManifestError,
+  cloneManifestWithRoot,
+  deserializeRemoteSandboxSessionStateValues,
+  materializeEnvironment,
+  providerErrorMessage,
+  serializeRemoteSandboxSessionState,
+  shellQuote,
+  withProviderError,
+  withSandboxSpan,
+  readOptionalNumberArray,
+  readOptionalString,
+  readString,
+  RemoteSandboxSessionBase,
+  type RemoteSandboxCommandOptions,
+  type RemoteSandboxCommandResult,
+} from '../shared';
+
+const PROVIDER_NAME = 'UpstashBoxSandboxClient';
+const PROVIDER_ID = 'upstash-box';
+const BACKEND_ID = 'upstash-box';
+
+/**
+ * Upstash Box uses `/workspace/home` as the default workspace root. Remap the
+ * core default manifest root (`/workspace`) so manifests created without an
+ * explicit root materialize where the box expects them.
+ */
+const DEFAULT_WORKSPACE_ROOT = '/workspace/home';
+
+export type UpstashBoxRuntime = 'node' | 'python' | 'golang' | 'ruby' | 'rust';
+export type UpstashBoxSize = 'small' | 'medium' | 'large';
+
+export type UpstashBoxNetworkPolicy =
+  | { mode: 'allow-all' | 'deny-all' }
+  | {
+      mode: 'custom';
+      allowedDomains?: string[];
+      allowedCidrs?: string[];
+      deniedCidrs?: string[];
+    };
+
+type BoxRunLike = {
+  result: string;
+  exitCode: number | null;
+};
+
+type BoxLike = {
+  id: string;
+  exec: {
+    command(command: string): Promise<BoxRunLike>;
+  };
+  files: {
+    read(path: string, options?: { encoding?: 'base64' }): Promise<string>;
+    write(options: {
+      path: string;
+      content: string;
+      encoding?: 'base64';
+    }): Promise<void>;
+  };
+  getPublicURL(
+    port: number,
+    options?: { bearerToken?: boolean; basicAuth?: boolean },
+  ): Promise<{ url: string; port: number }>;
+  pause(): Promise<void>;
+  resume(): Promise<void>;
+  delete(): Promise<void>;
+};
+
+type BoxStatic = {
+  create(config?: Record<string, unknown>): Promise<BoxLike>;
+  get(boxId: string, options?: Record<string, unknown>): Promise<BoxLike>;
+  fromSnapshot(
+    snapshotId: string,
+    config?: Record<string, unknown>,
+  ): Promise<BoxLike>;
+};
+
+export interface UpstashBoxSandboxClientOptions extends SandboxClientOptions {
+  /** Upstash Box API key. Falls back to the `UPSTASH_BOX_API_KEY` env var. */
+  apiKey?: string;
+  /** Base URL of the Box API. Falls back to the `UPSTASH_BOX_BASE_URL` env var. */
+  baseUrl?: string;
+  /** Human-readable name for the box. */
+  name?: string;
+  /** Resource size for the box. Defaults to `"small"`. */
+  size?: UpstashBoxSize;
+  /** Runtime image to provision inside the box. */
+  runtime?: UpstashBoxRuntime;
+  /** Keep the box alive instead of allowing pause-based idle lifecycle. */
+  keepAlive?: boolean;
+  /** Network access policy for the box. */
+  networkPolicy?: UpstashBoxNetworkPolicy;
+  /** GitHub token forwarded to git operations inside the box. */
+  gitToken?: string;
+  /** Create the box from a saved snapshot instead of a fresh image. */
+  snapshotId?: string;
+  /** Ports that may be exposed through `resolveExposedPort`. */
+  exposedPorts?: number[];
+  /** Pause the box on session close instead of deleting it. */
+  pauseOnExit?: boolean;
+  /** Environment variables injected into the box. */
+  env?: Record<string, string>;
+  archiveLimits?: SandboxArchiveLimits | null;
+}
+
+export interface UpstashBoxSandboxSessionState extends SandboxSessionState {
+  boxId: string;
+  apiKey?: string;
+  baseUrl?: string;
+  name?: string;
+  size?: UpstashBoxSize;
+  runtime?: UpstashBoxRuntime;
+  keepAlive: boolean;
+  networkPolicy?: UpstashBoxNetworkPolicy;
+  gitToken?: string;
+  snapshotId?: string;
+  configuredExposedPorts?: number[];
+  pauseOnExit: boolean;
+  environment: Record<string, string>;
+}
+
+export class UpstashBoxSandboxSession extends RemoteSandboxSessionBase<UpstashBoxSandboxSessionState> {
+  private readonly box: BoxLike;
+  private pausePromise?: Promise<void>;
+  private deletePromise?: Promise<void>;
+
+  constructor(args: {
+    state: UpstashBoxSandboxSessionState;
+    box: BoxLike;
+    concurrencyLimits?: SandboxConcurrencyLimits;
+    archiveLimits?: SandboxArchiveLimits | null;
+  }) {
+    super({
+      state: args.state,
+      options: {
+        providerName: PROVIDER_NAME,
+        providerId: PROVIDER_ID,
+        concurrencyLimits: args.concurrencyLimits,
+        archiveLimits: args.archiveLimits,
+      },
+    });
+    this.box = args.box;
+  }
+
+  async prepareWorkspaceRoot(): Promise<void> {
+    const root = this.state.manifest.root;
+    const result = await this.runBoxShell(`mkdir -p -- ${shellQuote(root)}`);
+    if (result.status !== 0) {
+      throw new SandboxProviderError(
+        `${PROVIDER_NAME} failed to prepare the workspace root.`,
+        {
+          provider: PROVIDER_ID,
+          operation: 'prepare workspace root',
+          boxId: this.state.boxId,
+          root,
+          stdout: result.stdout ?? '',
+        },
+      );
+    }
+  }
+
+  /**
+   * Developer-owned close. Honors `pauseOnExit` (pause for later resume) and
+   * leaves keep-alive boxes running. The managed runtime drives cleanup through
+   * {@link shutdown}/{@link delete} instead, so this path is for code that owns
+   * the session directly.
+   */
+  async close(): Promise<void> {
+    await withSandboxSpan(
+      'sandbox.stop',
+      {
+        backend_id: BACKEND_ID,
+        sandbox_id: this.state.boxId,
+      },
+      async () => {
+        // Keep-alive boxes stay running and are reconnected to on resume.
+        if (this.state.keepAlive) {
+          return;
+        }
+        if (this.state.pauseOnExit) {
+          await this.pauseOnce();
+          return;
+        }
+        await this.deleteOnce();
+      },
+    );
+  }
+
+  async shutdown(options?: SandboxSessionLifecycleOptions): Promise<void> {
+    await this.cleanup(options);
+  }
+
+  async delete(options?: SandboxSessionLifecycleOptions): Promise<void> {
+    // An explicit delete (no managed-cleanup reason) always destroys the box,
+    // even when pauseOnExit is set.
+    if (options?.reason !== 'cleanup') {
+      await withSandboxSpan(
+        'sandbox.shutdown',
+        {
+          backend_id: BACKEND_ID,
+          sandbox_id: this.state.boxId,
+        },
+        async () => {
+          await this.deleteOnce();
+        },
+      );
+      return;
+    }
+    await this.cleanup(options);
+  }
+
+  /**
+   * Managed-cleanup teardown. The runtime calls both `shutdown` and `delete`
+   * with the same lifecycle options, so the terminal action is memoized and
+   * runs once. When the runtime is preserving owned sessions for reuse, a
+   * pausable box is paused instead of deleted; keep-alive boxes are left
+   * running for the caller to manage.
+   */
+  private async cleanup(
+    options?: SandboxSessionLifecycleOptions,
+  ): Promise<void> {
+    await withSandboxSpan(
+      'sandbox.shutdown',
+      {
+        backend_id: BACKEND_ID,
+        sandbox_id: this.state.boxId,
+      },
+      async () => {
+        if (this.state.keepAlive) {
+          return;
+        }
+        if (this.shouldPauseOnCleanup(options)) {
+          await this.pauseOnce();
+          return;
+        }
+        await this.deleteOnce();
+      },
+    );
+  }
+
+  private shouldPauseOnCleanup(
+    options?: SandboxSessionLifecycleOptions,
+  ): boolean {
+    return (
+      options?.reason === 'cleanup' &&
+      options?.preserveOwnedSessions === true &&
+      this.state.pauseOnExit
+    );
+  }
+
+  private async pauseOnce(): Promise<void> {
+    // Keep-alive boxes cannot be paused; leave them running instead.
+    if (this.state.keepAlive) {
+      return;
+    }
+    this.pausePromise ??= this.box.pause();
+    await this.pausePromise;
+  }
+
+  private async deleteOnce(): Promise<void> {
+    this.deletePromise ??= this.box.delete();
+    await this.deletePromise;
+  }
+
+  protected override exposedPortSource(): string {
+    return 'public URL';
+  }
+
+  protected override allowOnDemandExposedPorts(): boolean {
+    // Box exposes ports on demand, so callers do not have to declare them.
+    return true;
+  }
+
+  protected override async resolveRemoteExposedPort(
+    port: number,
+  ): Promise<ExposedPortEndpoint | string> {
+    let result: { url: string; port: number };
+    try {
+      result = await this.box.getPublicURL(port);
+    } catch (error) {
+      throw new SandboxProviderError(
+        `${PROVIDER_NAME} failed to resolve exposed port ${port}.`,
+        {
+          provider: PROVIDER_ID,
+          port,
+          cause: providerErrorMessage(error),
+        },
+      );
+    }
+
+    if (typeof result?.url !== 'string') {
+      throw new SandboxProviderError(
+        `${PROVIDER_NAME} exposed port resolution did not include a URL.`,
+        {
+          provider: PROVIDER_ID,
+          port,
+        },
+      );
+    }
+
+    return result.url;
+  }
+
+  protected override resolveManifestForApply(manifest: Manifest): Manifest {
+    const resolved = resolveManifestRoot(manifest);
+    if (resolved.root !== this.state.manifest.root) {
+      throw new UserError(
+        `${PROVIDER_NAME} cannot apply a manifest with a different root than the active session. Create or resume a session with the desired root instead.`,
+      );
+    }
+    return resolved;
+  }
+
+  protected override async runRemoteCommand(
+    command: string,
+    options: RemoteSandboxCommandOptions,
+  ): Promise<RemoteSandboxCommandResult> {
+    return await this.runBoxShell(
+      `cd ${shellQuote(options.workdir)} && ${command}`,
+    );
+  }
+
+  protected override async mkdirRemote(path: string): Promise<void> {
+    const result = await this.runBoxShell(`mkdir -p -- ${shellQuote(path)}`);
+    if (result.status !== 0) {
+      throw new SandboxProviderError(
+        `${PROVIDER_NAME} failed to create directory ${path}.`,
+        {
+          provider: PROVIDER_ID,
+          path,
+          stdout: result.stdout ?? '',
+        },
+      );
+    }
+  }
+
+  protected override async readRemoteText(path: string): Promise<string> {
+    return await this.box.files.read(path);
+  }
+
+  protected override async readRemoteFile(path: string): Promise<Uint8Array> {
+    const content = await this.box.files.read(path, { encoding: 'base64' });
+    return Uint8Array.from(Buffer.from(content, 'base64'));
+  }
+
+  protected override async writeRemoteFile(
+    path: string,
+    content: string | Uint8Array,
+  ): Promise<void> {
+    const buffer =
+      typeof content === 'string'
+        ? Buffer.from(content, 'utf8')
+        : Buffer.from(content);
+    await this.box.files.write({
+      path,
+      content: buffer.toString('base64'),
+      encoding: 'base64',
+    });
+  }
+
+  protected override async deleteRemotePath(path: string): Promise<void> {
+    await this.runBoxShell(`rm -rf -- ${shellQuote(path)}`);
+  }
+
+  private async runBoxShell(
+    command: string,
+  ): Promise<RemoteSandboxCommandResult> {
+    const run = await this.box.exec.command(command);
+    return {
+      status: run.exitCode ?? 1,
+      stdout: run.result ?? '',
+      stderr: '',
+    };
+  }
+}
+
+/**
+ * @see {@link https://upstash.com/docs/box | Upstash Box docs}.
+ * @see {@link https://www.npmjs.com/package/@upstash/box | `@upstash/box` SDK}.
+ */
+export class UpstashBoxSandboxClient implements SandboxClient<
+  UpstashBoxSandboxClientOptions,
+  UpstashBoxSandboxSessionState
+> {
+  readonly backendId = BACKEND_ID;
+  private readonly options: UpstashBoxSandboxClientOptions;
+
+  constructor(options: UpstashBoxSandboxClientOptions = {}) {
+    this.options = options;
+  }
+
+  async create(
+    args?: SandboxClientCreateArgs<UpstashBoxSandboxClientOptions> | Manifest,
+    manifestOptions?: UpstashBoxSandboxClientOptions,
+  ): Promise<UpstashBoxSandboxSession> {
+    const createArgs = normalizeSandboxClientCreateArgs(args, manifestOptions);
+    assertCoreSnapshotUnsupported(PROVIDER_NAME, createArgs.snapshot);
+    const resolvedOptions = {
+      ...this.options,
+      ...createArgs.options,
+    };
+    const resolvedManifest = resolveManifestRoot(createArgs.manifest);
+    assertSandboxManifestMetadataSupported(
+      PROVIDER_NAME,
+      resolvedManifest,
+      undefined,
+    );
+    const Box = await loadBox();
+
+    return await withSandboxSpan(
+      'sandbox.start',
+      {
+        backend_id: this.backendId,
+      },
+      async () => {
+        const environment = await materializeEnvironment(
+          resolvedManifest,
+          resolvedOptions.env,
+        );
+        const box = await createBox(Box, resolvedOptions, environment);
+
+        const session = new UpstashBoxSandboxSession({
+          box,
+          concurrencyLimits: createArgs.concurrencyLimits,
+          archiveLimits: createArgs.archiveLimits,
+          state: {
+            manifest: resolvedManifest,
+            boxId: box.id,
+            apiKey: resolvedOptions.apiKey,
+            baseUrl: resolvedOptions.baseUrl,
+            name: resolvedOptions.name,
+            size: resolvedOptions.size,
+            runtime: resolvedOptions.runtime,
+            keepAlive: resolvedOptions.keepAlive ?? false,
+            networkPolicy: resolvedOptions.networkPolicy,
+            gitToken: resolvedOptions.gitToken,
+            snapshotId: resolvedOptions.snapshotId,
+            configuredExposedPorts: resolvedOptions.exposedPorts,
+            pauseOnExit: resolvedOptions.pauseOnExit ?? false,
+            environment,
+          },
+        });
+
+        try {
+          await session.prepareWorkspaceRoot();
+          await session.applyManifest(resolvedManifest);
+        } catch (error) {
+          session.state.pauseOnExit = false;
+          session.state.keepAlive = false;
+          await closeRemoteSessionOnManifestError(
+            'Upstash Box',
+            session,
+            error,
+          );
+        }
+        return session;
+      },
+    );
+  }
+
+  async serializeSessionState(
+    state: UpstashBoxSandboxSessionState,
+  ): Promise<Record<string, unknown>> {
+    return serializeRemoteSandboxSessionState(state);
+  }
+
+  canPersistOwnedSessionState(state: UpstashBoxSandboxSessionState): boolean {
+    return state.pauseOnExit || state.keepAlive;
+  }
+
+  async deserializeSessionState(
+    state: Record<string, unknown>,
+  ): Promise<UpstashBoxSandboxSessionState> {
+    const baseState = deserializeRemoteSandboxSessionStateValues(
+      state,
+      this.options.env,
+    );
+    return {
+      ...state,
+      ...baseState,
+      boxId: readString(state, 'boxId'),
+      apiKey: readOptionalString(state, 'apiKey'),
+      baseUrl: readOptionalString(state, 'baseUrl'),
+      name: readOptionalString(state, 'name'),
+      size: readOptionalSize(state.size),
+      runtime: readOptionalRuntime(state.runtime),
+      keepAlive: Boolean(state.keepAlive),
+      networkPolicy: state.networkPolicy as UpstashBoxNetworkPolicy | undefined,
+      gitToken: readOptionalString(state, 'gitToken'),
+      snapshotId: readOptionalString(state, 'snapshotId'),
+      configuredExposedPorts: readOptionalNumberArray(
+        state.configuredExposedPorts,
+      ),
+      pauseOnExit: Boolean(state.pauseOnExit),
+    };
+  }
+
+  async resume(
+    state: UpstashBoxSandboxSessionState,
+  ): Promise<UpstashBoxSandboxSession> {
+    const Box = await loadBox();
+    let box: BoxLike;
+    try {
+      box = await Box.get(state.boxId, connectionOptions(state, this.options));
+      if (state.pauseOnExit) {
+        await box.resume();
+      }
+    } catch (error) {
+      assertResumeRecreateAllowed(error, {
+        providerName: PROVIDER_NAME,
+        provider: PROVIDER_ID,
+        details: { boxId: state.boxId },
+      });
+      return await this.recreateFromPersistedState(Box, state);
+    }
+
+    const session = new UpstashBoxSandboxSession({
+      state,
+      box,
+      archiveLimits: this.options.archiveLimits,
+    });
+    await session.prepareWorkspaceRoot();
+    return session;
+  }
+
+  private async recreateFromPersistedState(
+    Box: BoxStatic,
+    state: UpstashBoxSandboxSessionState,
+  ): Promise<UpstashBoxSandboxSession> {
+    const box = await createBox(
+      Box,
+      {
+        ...this.options,
+        apiKey: state.apiKey ?? this.options.apiKey,
+        baseUrl: state.baseUrl ?? this.options.baseUrl,
+        name: state.name,
+        size: state.size,
+        runtime: state.runtime,
+        keepAlive: state.keepAlive,
+        networkPolicy: state.networkPolicy,
+        gitToken: state.gitToken,
+        snapshotId: state.snapshotId,
+        exposedPorts: state.configuredExposedPorts,
+        pauseOnExit: state.pauseOnExit,
+      },
+      state.environment,
+    );
+
+    const nextState: UpstashBoxSandboxSessionState = {
+      ...state,
+      boxId: box.id,
+      environment: { ...state.environment },
+    };
+    delete nextState.exposedPorts;
+
+    const session = new UpstashBoxSandboxSession({
+      box,
+      state: nextState,
+      archiveLimits: this.options.archiveLimits,
+    });
+    try {
+      await session.prepareWorkspaceRoot();
+      await session.applyManifest(state.manifest);
+    } catch (error) {
+      session.state.pauseOnExit = false;
+      session.state.keepAlive = false;
+      await closeRemoteSessionOnManifestError('Upstash Box', session, error);
+    }
+    return session;
+  }
+}
+
+function resolveManifestRoot(manifest: Manifest): Manifest {
+  if (manifest.root === '/workspace') {
+    return cloneManifestWithRoot(manifest, DEFAULT_WORKSPACE_ROOT);
+  }
+  return manifest;
+}
+
+function connectionOptions(
+  state: UpstashBoxSandboxSessionState,
+  options: UpstashBoxSandboxClientOptions,
+): Record<string, unknown> {
+  const connection: Record<string, unknown> = {};
+  const apiKey = state.apiKey ?? options.apiKey;
+  const baseUrl = state.baseUrl ?? options.baseUrl;
+  const gitToken = state.gitToken ?? options.gitToken;
+  if (apiKey) connection.apiKey = apiKey;
+  if (baseUrl) connection.baseUrl = baseUrl;
+  if (gitToken) connection.gitToken = gitToken;
+  return connection;
+}
+
+async function createBox(
+  Box: BoxStatic,
+  options: UpstashBoxSandboxClientOptions,
+  environment: Record<string, string>,
+): Promise<BoxLike> {
+  const config: Record<string, unknown> = {};
+  if (options.apiKey) config.apiKey = options.apiKey;
+  if (options.baseUrl) config.baseUrl = options.baseUrl;
+  if (options.name) config.name = options.name;
+  if (options.size) config.size = options.size;
+  if (options.runtime) config.runtime = options.runtime;
+  if (options.keepAlive) config.keepAlive = true;
+  if (options.networkPolicy) config.networkPolicy = options.networkPolicy;
+  if (options.gitToken) config.git = { token: options.gitToken };
+  if (Object.keys(environment).length > 0) config.env = environment;
+
+  return await withProviderError(
+    PROVIDER_NAME,
+    PROVIDER_ID,
+    'create box',
+    async () =>
+      options.snapshotId
+        ? await Box.fromSnapshot(options.snapshotId, config)
+        : await Box.create(config),
+    options.snapshotId ? { snapshotId: options.snapshotId } : undefined,
+  );
+}
+
+async function loadBox(): Promise<BoxStatic> {
+  // Use a variable specifier so the optional peer dependency is resolved at
+  // runtime only and does not break builds when it is not installed.
+  const moduleName = '@upstash/box';
+  try {
+    const mod = (await import(moduleName)) as { Box?: BoxStatic };
+    if (!mod.Box) {
+      throw new Error('Missing `Box` export from `@upstash/box`.');
+    }
+    return mod.Box;
+  } catch (error) {
+    throw new UserError(
+      `Upstash Box sandbox support requires the optional \`@upstash/box\` package. Install it before using Upstash Box-backed sandbox examples. ${(error as Error).message}`,
+    );
+  }
+}
+
+function readOptionalSize(value: unknown): UpstashBoxSize | undefined {
+  return value === 'small' || value === 'medium' || value === 'large'
+    ? value
+    : undefined;
+}
+
+function readOptionalRuntime(value: unknown): UpstashBoxRuntime | undefined {
+  return value === 'node' ||
+    value === 'python' ||
+    value === 'golang' ||
+    value === 'ruby' ||
+    value === 'rust'
+    ? value
+    : undefined;
+}

--- a/packages/agents-extensions/test/sandbox/upstash-box.test.ts
+++ b/packages/agents-extensions/test/sandbox/upstash-box.test.ts
@@ -1,0 +1,396 @@
+import {
+  Manifest,
+  SandboxProviderError,
+  SandboxUnsupportedFeatureError,
+} from '@openai/agents-core/sandbox';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { UpstashBoxSandboxClient } from '../../src/sandbox/upstash-box';
+import { resolvedRemotePathFromValidationCommand } from './remotePathValidation';
+
+const createMock = vi.fn();
+const getMock = vi.fn();
+const fromSnapshotMock = vi.fn();
+const execCommandMock = vi.fn();
+const filesReadMock = vi.fn();
+const filesWriteMock = vi.fn();
+const getPublicURLMock = vi.fn();
+const pauseMock = vi.fn();
+const resumeMock = vi.fn();
+const deleteMock = vi.fn();
+const boxConstructorMock = vi.fn();
+
+vi.mock('@upstash/box', () => ({
+  Box: class Box {
+    static create = createMock;
+    static get = getMock;
+    static fromSnapshot = fromSnapshotMock;
+    constructor(options?: Record<string, unknown>) {
+      boxConstructorMock(options);
+    }
+  },
+}));
+
+function makeBox() {
+  return {
+    id: 'box-test',
+    exec: { command: execCommandMock },
+    files: { read: filesReadMock, write: filesWriteMock },
+    getPublicURL: getPublicURLMock,
+    pause: pauseMock,
+    resume: resumeMock,
+    delete: deleteMock,
+  };
+}
+
+describe('UpstashBoxSandboxClient', () => {
+  beforeEach(() => {
+    createMock.mockReset();
+    getMock.mockReset();
+    fromSnapshotMock.mockReset();
+    execCommandMock.mockReset();
+    filesReadMock.mockReset();
+    filesWriteMock.mockReset();
+    getPublicURLMock.mockReset();
+    pauseMock.mockReset();
+    resumeMock.mockReset();
+    deleteMock.mockReset();
+    boxConstructorMock.mockReset();
+
+    const box = makeBox();
+    createMock.mockResolvedValue(box);
+    getMock.mockResolvedValue(box);
+    fromSnapshotMock.mockResolvedValue(box);
+    execCommandMock.mockImplementation(async (command: string) => {
+      const resolvedPath = resolvedRemotePathFromValidationCommand(command);
+      const output = resolvedPath ? `${resolvedPath}\n` : 'README.md\n';
+      return { result: output, exitCode: 0 };
+    });
+    filesReadMock.mockResolvedValue('# Hello\n');
+    filesWriteMock.mockResolvedValue(undefined);
+    getPublicURLMock.mockResolvedValue({
+      url: 'https://3000-box.example.test/?token=abc',
+      port: 3000,
+    });
+    pauseMock.mockResolvedValue(undefined);
+    resumeMock.mockResolvedValue(undefined);
+    deleteMock.mockResolvedValue(undefined);
+  });
+
+  test('rejects unsupported core create options instead of ignoring them', async () => {
+    const client = new UpstashBoxSandboxClient();
+
+    await expect(
+      client.create({
+        manifest: new Manifest(),
+        snapshot: { type: 'remote' },
+      }),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('creates a box, remaps the default root, and materializes files', async () => {
+    const client = new UpstashBoxSandboxClient();
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          'README.md': { type: 'file', content: '# Hello\n' },
+        },
+      }),
+    );
+    const output = await session.execCommand({ cmd: 'ls' });
+
+    expect(session.state.manifest.root).toBe('/workspace/home');
+    expect(execCommandMock).toHaveBeenCalledWith(
+      "mkdir -p -- '/workspace/home'",
+    );
+    expect(execCommandMock).toHaveBeenCalledWith("cd '/workspace/home' && ls");
+    const writeCall = filesWriteMock.mock.calls.find(
+      ([opts]) => opts.path === '/workspace/home/README.md',
+    );
+    expect(writeCall).toBeDefined();
+    expect(Buffer.from(writeCall![0].content, 'base64').toString('utf8')).toBe(
+      '# Hello\n',
+    );
+    expect(output).toContain('README.md');
+  });
+
+  test('passes UPSTASH_BOX env config through to box creation', async () => {
+    const client = new UpstashBoxSandboxClient({
+      apiKey: 'box-key',
+      size: 'medium',
+      env: { CLIENT_ENV: 'client' },
+    });
+
+    await client.create(
+      new Manifest({
+        environment: { SAFE: 'manifest' },
+      }),
+    );
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'box-key',
+        size: 'medium',
+        env: { CLIENT_ENV: 'client', SAFE: 'manifest' },
+      }),
+    );
+  });
+
+  test('cleans up when workspace root preparation fails', async () => {
+    execCommandMock.mockResolvedValueOnce({
+      result: 'mkdir failed',
+      exitCode: 1,
+    });
+    const client = new UpstashBoxSandboxClient();
+
+    await expect(client.create(new Manifest())).rejects.toThrow(
+      /failed to prepare the workspace root/,
+    );
+    expect(deleteMock).toHaveBeenCalledOnce();
+  });
+
+  test('rejects unsupported manifest metadata after remapping the default root', async () => {
+    const client = new UpstashBoxSandboxClient();
+
+    await expect(
+      client.create(new Manifest({ extraPathGrants: [{ path: '/tmp/data' }] })),
+    ).rejects.toThrow();
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('remaps default manifest roots when applying manifests to sessions', async () => {
+    const client = new UpstashBoxSandboxClient();
+    const session = await client.create(new Manifest());
+    filesWriteMock.mockClear();
+
+    await session.applyManifest(
+      new Manifest({
+        entries: { 'next.txt': { type: 'file', content: 'next\n' } },
+      }),
+    );
+
+    const writeCall = filesWriteMock.mock.calls.find(
+      ([opts]) => opts.path === '/workspace/home/next.txt',
+    );
+    expect(writeCall).toBeDefined();
+    expect(session.state.manifest.root).toBe('/workspace/home');
+  });
+
+  test('rejects applyManifest roots that differ from the session root', async () => {
+    const client = new UpstashBoxSandboxClient();
+    const session = await client.create(new Manifest());
+    filesWriteMock.mockClear();
+
+    await expect(
+      session.applyManifest(
+        new Manifest({
+          root: '/tmp',
+          entries: { 'outside.txt': { type: 'file', content: 'outside\n' } },
+        }),
+      ),
+    ).rejects.toThrow(/different root than the active session/);
+    expect(filesWriteMock).not.toHaveBeenCalled();
+  });
+
+  test('uses box file APIs for editor reads and writes', async () => {
+    const client = new UpstashBoxSandboxClient();
+    const session = await client.create(new Manifest());
+    filesReadMock.mockClear();
+    filesWriteMock.mockClear();
+    filesReadMock.mockResolvedValue('# Hello\n');
+
+    await session.createEditor().updateFile({
+      type: 'update_file',
+      path: 'link.txt',
+      diff: '-# Hello\n+# Safe\n',
+    });
+
+    expect(filesReadMock).toHaveBeenCalled();
+    const writeCall = filesWriteMock.mock.calls.at(-1);
+    expect(writeCall).toBeDefined();
+    expect(
+      Buffer.from(writeCall![0].content, 'base64').toString('utf8'),
+    ).toContain('# Safe');
+  });
+
+  test('reads images through the base64 box file API', async () => {
+    const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    const client = new UpstashBoxSandboxClient();
+    const session = await client.create(new Manifest());
+    filesReadMock.mockReset();
+    filesReadMock.mockImplementation(
+      async (_path: string, options?: { encoding?: 'base64' }) =>
+        options?.encoding === 'base64'
+          ? pngBytes.toString('base64')
+          : pngBytes.toString('binary'),
+    );
+
+    const image = await session.viewImage({ path: 'image.png' });
+
+    expect(filesReadMock).toHaveBeenCalledWith('/workspace/home/image.png', {
+      encoding: 'base64',
+    });
+    if (
+      !image.image ||
+      typeof image.image !== 'object' ||
+      !('mediaType' in image.image)
+    ) {
+      throw new Error('Expected viewImage to return inline image data.');
+    }
+    expect(image.image.mediaType).toBe('image/png');
+  });
+
+  test('serializes runtime env overrides for session resume', async () => {
+    const client = new UpstashBoxSandboxClient({
+      env: { API_KEY: 'client-secret' },
+    });
+    const session = await client.create(
+      new Manifest({ environment: { SAFE: 'manifest' } }),
+    );
+
+    const serialized = await client.serializeSessionState(session.state);
+    const restored = await client.deserializeSessionState(serialized);
+
+    expect(serialized.environment).toEqual({
+      API_KEY: 'client-secret',
+      SAFE: 'manifest',
+    });
+    expect(restored.environment).toEqual({
+      SAFE: 'manifest',
+      API_KEY: 'client-secret',
+    });
+    expect(serialized.boxId).toBe('box-test');
+  });
+
+  test('pauses on close when pauseOnExit is enabled and resumes by id', async () => {
+    const client = new UpstashBoxSandboxClient();
+    const session = await client.create(new Manifest(), { pauseOnExit: true });
+
+    await session.close();
+    await client.resume(session.state);
+
+    expect(pauseMock).toHaveBeenCalledOnce();
+    expect(getMock).toHaveBeenCalledWith('box-test', expect.anything());
+    expect(resumeMock).toHaveBeenCalledOnce();
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  test('delete terminates even when pauseOnExit is enabled', async () => {
+    const client = new UpstashBoxSandboxClient();
+    const session = await client.create(new Manifest(), { pauseOnExit: true });
+
+    await session.delete();
+
+    expect(pauseMock).not.toHaveBeenCalled();
+    expect(deleteMock).toHaveBeenCalledOnce();
+  });
+
+  test('does not delete twice across shutdown and delete lifecycle hooks', async () => {
+    const client = new UpstashBoxSandboxClient();
+    const session = await client.create(new Manifest());
+
+    await session.shutdown();
+    await session.delete();
+
+    expect(deleteMock).toHaveBeenCalledOnce();
+  });
+
+  test('preserves the box on managed cleanup when preserveOwnedSessions is set', async () => {
+    const client = new UpstashBoxSandboxClient();
+    const session = await client.create(new Manifest(), { pauseOnExit: true });
+
+    const cleanupOptions = { reason: 'cleanup', preserveOwnedSessions: true };
+    await session.shutdown(cleanupOptions);
+    await session.delete(cleanupOptions);
+
+    expect(pauseMock).toHaveBeenCalledOnce();
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  test('tears the box down on managed cleanup without preservation', async () => {
+    const client = new UpstashBoxSandboxClient();
+    const session = await client.create(new Manifest(), { pauseOnExit: true });
+
+    const cleanupOptions = { reason: 'cleanup' };
+    await session.shutdown(cleanupOptions);
+    await session.delete(cleanupOptions);
+
+    expect(deleteMock).toHaveBeenCalledOnce();
+    expect(pauseMock).not.toHaveBeenCalled();
+  });
+
+  test('leaves keep-alive boxes running during managed cleanup', async () => {
+    const client = new UpstashBoxSandboxClient();
+    const session = await client.create(new Manifest(), { keepAlive: true });
+
+    const cleanupOptions = { reason: 'cleanup' };
+    await session.shutdown(cleanupOptions);
+    await session.delete(cleanupOptions);
+
+    expect(pauseMock).not.toHaveBeenCalled();
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  test('leaves keep-alive boxes running on close', async () => {
+    const client = new UpstashBoxSandboxClient();
+    const session = await client.create(new Manifest(), { keepAlive: true });
+
+    await session.close();
+
+    expect(pauseMock).not.toHaveBeenCalled();
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  test('resolves exposed ports through public URLs', async () => {
+    const client = new UpstashBoxSandboxClient();
+    const session = await client.create(new Manifest(), {
+      exposedPorts: [3000],
+    });
+
+    const endpoint = await session.resolveExposedPort(3000);
+
+    expect(getPublicURLMock).toHaveBeenCalledWith(3000);
+    expect(endpoint).toMatchObject({
+      host: '3000-box.example.test',
+      port: 443,
+      tls: true,
+      query: 'token=abc',
+    });
+  });
+
+  test('recreates the box when resume lookup reports a missing box', async () => {
+    const client = new UpstashBoxSandboxClient();
+    const session = await client.create(new Manifest(), { pauseOnExit: true });
+    createMock.mockClear();
+    getMock.mockRejectedValueOnce(
+      Object.assign(new Error('box not found'), { statusCode: 404 }),
+    );
+
+    const recreated = await client.resume(session.state);
+
+    expect(getMock).toHaveBeenCalledWith('box-test', expect.anything());
+    expect(createMock).toHaveBeenCalledOnce();
+    expect(recreated.state.boxId).toBe('box-test');
+  });
+
+  test('fails fast when resume lookup fails with a provider error', async () => {
+    const client = new UpstashBoxSandboxClient();
+    const session = await client.create(new Manifest(), { pauseOnExit: true });
+    createMock.mockClear();
+    getMock.mockRejectedValueOnce(new Error('request timeout'));
+
+    await expect(client.resume(session.state)).rejects.toBeInstanceOf(
+      SandboxProviderError,
+    );
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('creates from a snapshot when snapshotId is provided', async () => {
+    const client = new UpstashBoxSandboxClient({ snapshotId: 'snap-1' });
+
+    await client.create(new Manifest());
+
+    expect(fromSnapshotMock).toHaveBeenCalledWith('snap-1', expect.any(Object));
+    expect(createMock).not.toHaveBeenCalled();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -686,6 +686,9 @@ importers:
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
+      '@upstash/box':
+        specifier: 0.4.8
+        version: 0.4.8(zod@4.3.5)
       '@vercel/sandbox':
         specifier: 1.9.3
         version: 1.9.3
@@ -3682,6 +3685,12 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
+
+  '@upstash/box@0.4.8':
+    resolution: {integrity: sha512-DTtOOaFpdlBiAlqIW7vShpgI0Xbdu4m+M0dJ6XPrRrdzbvtktNR32HTQcFsrQEfrXBsSezTpkQyf52Bn37f+wQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
@@ -11383,6 +11392,11 @@ snapshots:
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@upstash/box@0.4.8(zod@4.3.5)':
+    dependencies:
+      zod: 4.3.5
+      zod-to-json-schema: 3.25.1(zod@4.3.5)
 
   '@vercel/oidc@3.1.0': {}
 


### PR DESCRIPTION
## Summary

Adds a new hosted sandbox provider, `UpstashBoxSandboxClient`, exported from `@openai/agents-extensions/sandbox/upstash-box` and backed by the optional `@upstash/box` peer dependency. The same `SandboxAgent` definition runs unchanged; only the sandbox client changes in the run config.

It follows the existing provider pattern, extending the shared `RemoteSandboxSessionBase` (like the e2b/blaxel/runloop/vercel providers) and mapping the sandbox contract onto the Box SDK:

- **exec** — `box.exec.command` (workdir applied via a `cd` prefix)
- **filesystem** — `box.files.read`/`box.files.write`, using base64 for binary safety
- **exposed ports** — `box.getPublicURL(port)` (resolved on demand)
- **create-from-snapshot** — `snapshotId` option → `Box.fromSnapshot`
- **lifecycle** — keep-alive boxes, pause/resume, and managed-cleanup teardown that preserves owned sessions (pauses instead of deletes) when `preserveOwnedSessions` is set, mirroring the e2b provider
- Box's default workspace root (`/workspace/home`) is remapped from the core default (`/workspace`)

Box does not expose cloud-bucket mounts or `runAs`, so those correctly fall through to the base class's unsupported handling.

## Changes

- New provider: `src/sandbox/upstash-box/{sandbox,index}.ts`
- `package.json`: `./sandbox/upstash-box` export, matching `typesVersions` entry, optional peer + dev dependency on `@upstash/box`
- Unit tests: `test/sandbox/upstash-box.test.ts` (21 tests)
- Example: `examples/sandbox/extensions/upstash-box-runner.ts` + `start:upstash-box` script + README section
- Docs: rows added to the sandbox clients page
- Changeset (minor)

## Testing

- `@openai/agents-extensions` sandbox suite: 497/497 passing (incl. 21 new)
- Dual ESM/CJS build, ESLint, and Prettier clean
- Manually smoke-tested against a live Upstash Box: create → manifest materialization → exec → editor write/read → binary round-trip → delete

## Notes for reviewers

- **Dependency age:** `@upstash/box` was published very recently, so it may not yet satisfy the repo's `minimumReleaseAge` (7 days) policy on a fresh CI install. It should be eligible shortly; happy to bump/re-pin if preferred.
- **Translations:** only the English `clients.mdx` is updated; the `ja/zh/ko` copies still need the corresponding rows (left for the translation flow — glad to add them if you'd rather they ship together).