### PR TITLE
feat: support file inputs (e.g. PDF) in the AI SDK adapter

### DIFF
--- a/.changeset/ai-sdk-input-file-support.md
+++ b/.changeset/ai-sdk-input-file-support.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+feat: support file inputs (e.g. PDF documents) in the AI SDK adapter

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -148,24 +148,22 @@ function ensureSupportedModel(model: LanguageModelCompatible): void {
   }
 }
 
-type ParsedInlineImageData = {
+type ParsedInlineData = {
   data: string;
   mediaType: string;
 };
 
-function parseBase64ImageDataUrl(
-  imageSource: string,
-): ParsedInlineImageData | undefined {
-  if (!imageSource.startsWith('data:')) {
+function parseBase64DataUrl(source: string): ParsedInlineData | undefined {
+  if (!source.startsWith('data:')) {
     return undefined;
   }
 
-  const commaIndex = imageSource.indexOf(',');
+  const commaIndex = source.indexOf(',');
   if (commaIndex === -1) {
     return undefined;
   }
 
-  const metadata = imageSource.slice('data:'.length, commaIndex);
+  const metadata = source.slice('data:'.length, commaIndex);
   if (!metadata.includes('base64')) {
     return undefined;
   }
@@ -177,9 +175,56 @@ function parseBase64ImageDataUrl(
   }
 
   return {
-    data: imageSource.slice(commaIndex + 1),
+    data: source.slice(commaIndex + 1),
     mediaType,
   };
+}
+
+// Strings that contain only base64 characters are treated as inline file data
+// rather than a URL, mirroring how the Responses API model resolves them.
+const BASE64_FILE_DATA_PATTERN = /^[A-Za-z0-9+/=]+$/;
+
+const FILE_EXTENSION_MEDIA_TYPES: Record<string, string> = {
+  pdf: 'application/pdf',
+  txt: 'text/plain',
+  md: 'text/markdown',
+  csv: 'text/csv',
+  json: 'application/json',
+  html: 'text/html',
+};
+
+const FILE_MEDIA_TYPE_ERROR_MESSAGE =
+  'Unable to determine the media type for file input. Set providerData.mediaType (e.g. "application/pdf") or provide a filename with a known extension.';
+
+function getFileExtension(name: string | undefined): string | undefined {
+  if (!name) {
+    return undefined;
+  }
+  const basename = name.slice(name.lastIndexOf('/') + 1);
+  const dotIndex = basename.lastIndexOf('.');
+  if (dotIndex <= 0 || dotIndex === basename.length - 1) {
+    return undefined;
+  }
+  return basename.slice(dotIndex + 1).toLowerCase();
+}
+
+function resolveFileMediaType(options: {
+  explicit?: string;
+  filename?: string;
+  url?: URL;
+}): string | undefined {
+  if (options.explicit) {
+    return options.explicit;
+  }
+  const filenameExtension = getFileExtension(options.filename);
+  if (filenameExtension && FILE_EXTENSION_MEDIA_TYPES[filenameExtension]) {
+    return FILE_EXTENSION_MEDIA_TYPES[filenameExtension];
+  }
+  const urlExtension = getFileExtension(options.url?.pathname);
+  if (urlExtension && FILE_EXTENSION_MEDIA_TYPES[urlExtension]) {
+    return FILE_EXTENSION_MEDIA_TYPES[urlExtension];
+  }
+  return undefined;
 }
 
 /**
@@ -321,7 +366,7 @@ export function itemsToLanguageV2Messages(
                       );
                     }
 
-                    const inlineImage = parseBase64ImageDataUrl(imageSource);
+                    const inlineImage = parseBase64DataUrl(imageSource);
                     if (inlineImage) {
                       return {
                         type: 'file',
@@ -346,7 +391,97 @@ export function itemsToLanguageV2Messages(
                     };
                   }
                   if (c.type === 'input_file') {
-                    throw new UserError('File inputs are not supported.');
+                    const providerOptions = toProviderOptions(
+                      contentProviderData,
+                      model,
+                    );
+                    const filename =
+                      c.filename ??
+                      (typeof contentProviderData?.filename === 'string'
+                        ? contentProviderData.filename
+                        : undefined);
+                    const explicitMediaType =
+                      typeof contentProviderData?.mediaType === 'string'
+                        ? contentProviderData.mediaType
+                        : undefined;
+
+                    const toFileUrlPart = (urlValue: string) => {
+                      let url: URL;
+                      try {
+                        url = new URL(urlValue);
+                      } catch {
+                        throw new UserError(
+                          `File input must be a base64-encoded data URL, base64 data, or a valid URL: ${JSON.stringify(c)}`,
+                        );
+                      }
+                      const mediaType = resolveFileMediaType({
+                        explicit: explicitMediaType,
+                        filename,
+                        url,
+                      });
+                      if (!mediaType) {
+                        throw new UserError(FILE_MEDIA_TYPE_ERROR_MESSAGE);
+                      }
+                      return {
+                        type: 'file' as const,
+                        data: url,
+                        mediaType,
+                        ...(filename ? { filename } : {}),
+                        providerOptions,
+                      };
+                    };
+
+                    if (typeof c.file === 'string') {
+                      const value = c.file.trim();
+                      if (value.startsWith('data:')) {
+                        const inlineFile = parseBase64DataUrl(value);
+                        if (!inlineFile) {
+                          throw new UserError(
+                            'File data URLs must be base64-encoded, e.g. data:application/pdf;base64,<data>.',
+                          );
+                        }
+                        // The media type embedded in the data URL takes precedence.
+                        return {
+                          type: 'file' as const,
+                          data: inlineFile.data,
+                          mediaType: inlineFile.mediaType,
+                          ...(filename ? { filename } : {}),
+                          providerOptions,
+                        };
+                      }
+                      if (BASE64_FILE_DATA_PATTERN.test(value)) {
+                        const mediaType = resolveFileMediaType({
+                          explicit: explicitMediaType,
+                          filename,
+                        });
+                        if (!mediaType) {
+                          throw new UserError(FILE_MEDIA_TYPE_ERROR_MESSAGE);
+                        }
+                        return {
+                          type: 'file' as const,
+                          data: value,
+                          mediaType,
+                          ...(filename ? { filename } : {}),
+                          providerOptions,
+                        };
+                      }
+                      return toFileUrlPart(value);
+                    }
+                    if (
+                      isRecord(c.file) &&
+                      'url' in c.file &&
+                      typeof c.file.url === 'string'
+                    ) {
+                      return toFileUrlPart(c.file.url);
+                    }
+                    if (isRecord(c.file) && 'id' in c.file) {
+                      throw new UserError(
+                        'File IDs are OpenAI-specific and not supported by the AI SDK adapter. Pass a publicly accessible URL or inline data (a base64 string or data URL) instead.',
+                      );
+                    }
+                    throw new UserError(
+                      `File input requires inline data (a base64 string or data URL) or a file URL: ${JSON.stringify(c)}`,
+                    );
                   }
                   throw new UserError(`Unknown content type: ${c.type}`);
                 }),
@@ -967,7 +1102,7 @@ function convertStructuredOutputsToAiSdkOutput(
         textParts.push('[image]');
         continue;
       }
-      const inlineImage = parseBase64ImageDataUrl(imageValue);
+      const inlineImage = parseBase64DataUrl(imageValue);
       if (inlineImage) {
         mediaParts.push({
           type: 'media',

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -1298,22 +1298,244 @@ describe('itemsToLanguageV2Messages', () => {
     );
   });
 
-  test('rejects input_file content', () => {
-    const items: protocol.ModelItem[] = [
+  describe('input_file conversion', () => {
+    const userFileItems = (
+      content: Record<string, any>,
+    ): protocol.ModelItem[] => [
       {
         role: 'user',
-        content: [
-          {
-            type: 'input_file',
-            file: 'file_123',
-          },
-        ],
+        content: [{ type: 'input_file', ...content }],
       } as any,
     ];
 
-    expect(() => itemsToLanguageV2Messages(stubModel({}), items)).toThrow(
-      /File inputs are not supported/,
-    );
+    test('converts file data URLs to raw base64 alongside text content', () => {
+      const items: protocol.ModelItem[] = [
+        {
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'summarize this' },
+            {
+              type: 'input_file',
+              file: 'data:application/pdf;base64,JVBERi0xLjQK',
+            },
+          ],
+        } as any,
+      ];
+      const msgs = itemsToLanguageV2Messages(stubModel({}), items);
+      expect(msgs).toEqual([
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'summarize this', providerOptions: {} },
+            {
+              type: 'file',
+              data: 'JVBERi0xLjQK',
+              mediaType: 'application/pdf',
+              providerOptions: {},
+            },
+          ],
+          providerOptions: {},
+        },
+      ]);
+    });
+
+    test('passes filename through for file inputs', () => {
+      const msgs = itemsToLanguageV2Messages(
+        stubModel({}),
+        userFileItems({
+          file: 'data:application/pdf;base64,JVBERi0xLjQK',
+          filename: 'report.pdf',
+        }),
+      );
+      expect((msgs[0] as any).content[0]).toEqual({
+        type: 'file',
+        data: 'JVBERi0xLjQK',
+        mediaType: 'application/pdf',
+        filename: 'report.pdf',
+        providerOptions: {},
+      });
+    });
+
+    test('falls back to providerData.filename when filename is absent', () => {
+      const msgs = itemsToLanguageV2Messages(
+        stubModel({}),
+        userFileItems({
+          file: 'data:application/pdf;base64,JVBERi0xLjQK',
+          providerData: { filename: 'fallback.pdf' },
+        }),
+      );
+      expect((msgs[0] as any).content[0]).toEqual({
+        type: 'file',
+        data: 'JVBERi0xLjQK',
+        mediaType: 'application/pdf',
+        filename: 'fallback.pdf',
+        providerOptions: { filename: 'fallback.pdf' },
+      });
+    });
+
+    test('prefers the mediaType embedded in a data URL over providerData', () => {
+      const msgs = itemsToLanguageV2Messages(
+        stubModel({}),
+        userFileItems({
+          file: 'data:application/pdf;base64,JVBERi0xLjQK',
+          providerData: { mediaType: 'text/plain' },
+        }),
+      );
+      expect((msgs[0] as any).content[0]).toEqual({
+        type: 'file',
+        data: 'JVBERi0xLjQK',
+        mediaType: 'application/pdf',
+        providerOptions: { mediaType: 'text/plain' },
+      });
+    });
+
+    test('converts file URL strings and infers mediaType from the URL path', () => {
+      const msgs = itemsToLanguageV2Messages(
+        stubModel({}),
+        userFileItems({ file: 'https://example.com/docs/report.pdf' }),
+      );
+      expect((msgs[0] as any).content[0]).toEqual({
+        type: 'file',
+        data: new URL('https://example.com/docs/report.pdf'),
+        mediaType: 'application/pdf',
+        providerOptions: {},
+      });
+    });
+
+    test('accepts http URLs', () => {
+      const msgs = itemsToLanguageV2Messages(
+        stubModel({}),
+        userFileItems({ file: 'http://example.com/report.pdf' }),
+      );
+      expect((msgs[0] as any).content[0]).toEqual({
+        type: 'file',
+        data: new URL('http://example.com/report.pdf'),
+        mediaType: 'application/pdf',
+        providerOptions: {},
+      });
+    });
+
+    test('converts { url } file objects', () => {
+      const msgs = itemsToLanguageV2Messages(
+        stubModel({}),
+        userFileItems({ file: { url: 'https://example.com/report.pdf' } }),
+      );
+      expect((msgs[0] as any).content[0]).toEqual({
+        type: 'file',
+        data: new URL('https://example.com/report.pdf'),
+        mediaType: 'application/pdf',
+        providerOptions: {},
+      });
+    });
+
+    test('converts raw base64 file data with providerData.mediaType', () => {
+      const msgs = itemsToLanguageV2Messages(
+        stubModel({}),
+        userFileItems({
+          file: 'JVBERi0xLjQK',
+          providerData: { mediaType: 'application/pdf' },
+        }),
+      );
+      expect((msgs[0] as any).content[0]).toEqual({
+        type: 'file',
+        data: 'JVBERi0xLjQK',
+        mediaType: 'application/pdf',
+        providerOptions: { mediaType: 'application/pdf' },
+      });
+    });
+
+    test('prefers filename extension over URL path extension for mediaType', () => {
+      const msgs = itemsToLanguageV2Messages(
+        stubModel({}),
+        userFileItems({
+          file: 'https://example.com/notes.txt',
+          filename: 'actual.pdf',
+        }),
+      );
+      expect((msgs[0] as any).content[0]).toEqual({
+        type: 'file',
+        data: new URL('https://example.com/notes.txt'),
+        mediaType: 'application/pdf',
+        filename: 'actual.pdf',
+        providerOptions: {},
+      });
+    });
+
+    test('rejects file URLs whose mediaType cannot be determined', () => {
+      expect(() =>
+        itemsToLanguageV2Messages(
+          stubModel({}),
+          userFileItems({ file: 'https://example.com/document' }),
+        ),
+      ).toThrow(/Unable to determine the media type/);
+    });
+
+    test('rejects OpenAI file IDs', () => {
+      expect(() =>
+        itemsToLanguageV2Messages(
+          stubModel({}),
+          userFileItems({ file: { id: 'file_123' } }),
+        ),
+      ).toThrow(/File IDs are OpenAI-specific/);
+    });
+
+    test('rejects strings that are neither data URLs, base64, nor URLs', () => {
+      expect(() =>
+        itemsToLanguageV2Messages(
+          stubModel({}),
+          userFileItems({ file: 'file_123' }),
+        ),
+      ).toThrow(/File input must be a base64-encoded data URL/);
+    });
+
+    test('rejects missing or empty file values', () => {
+      expect(() =>
+        itemsToLanguageV2Messages(stubModel({}), userFileItems({})),
+      ).toThrow(/File input requires inline data/);
+      expect(() =>
+        itemsToLanguageV2Messages(stubModel({}), userFileItems({ file: '' })),
+      ).toThrow(/File input must be a base64-encoded data URL/);
+      expect(() =>
+        itemsToLanguageV2Messages(
+          stubModel({}),
+          userFileItems({ file: { url: '' } }),
+        ),
+      ).toThrow(/File input must be a base64-encoded data URL/);
+    });
+
+    test('keeps skipping file outputs in tool results', () => {
+      const items: protocol.ModelItem[] = [
+        {
+          type: 'function_call',
+          callId: 'f1',
+          name: 'fetch_doc',
+          arguments: '{}',
+        } as any,
+        {
+          type: 'function_call_result',
+          callId: 'f1',
+          name: 'fetch_doc',
+          output: [
+            { type: 'input_text', text: 'done' },
+            { type: 'input_file', file: 'data:application/pdf;base64,AAAA' },
+          ],
+        } as any,
+      ];
+      const msgs = itemsToLanguageV2Messages(stubModel({}), items);
+      expect(msgs[1]).toEqual({
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'f1',
+            toolName: 'fetch_doc',
+            output: { type: 'text', value: 'done[file output skipped]' },
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      });
+    });
   });
 
   test('passes through unknown items via providerData', () => {


### PR DESCRIPTION
## Motivation

Resolves #630

Today the AI SDK adapter rejects every `input_file` content part with `File inputs are not supported.`, so models that natively accept documents (e.g. Claude or Gemini via `aiSdk()`) cannot receive PDFs at all, even though the AI SDK protocol has a first-class file part for this.

Following the direction suggested in the issue:

> Enabling to pass publicly accessible URL and data URL would be useful if other models also support the same protocol.

this PR converts `input_file` user content into AI SDK `file` parts for URLs and inline data, and rejects OpenAI-specific file IDs with an actionable error.

## What this changes

`itemsToLanguageV2Messages` now maps `input_file` user content as follows:

| `file` value | Result |
|---|---|
| `data:<mediaType>;base64,<data>` | `{ type: 'file', data: <raw base64>, mediaType: <from data URL> }` |
| raw base64 string | `{ type: 'file', data, mediaType: <resolved> }` |
| URL string / `{ url }` | `{ type: 'file', data: new URL(...), mediaType: <resolved> }` |
| `{ id }` | `UserError` — file IDs are OpenAI-specific (per the issue discussion), the error says what to pass instead |
| missing / unparsable | `UserError` with the accepted formats |

- `mediaType` resolution (required by the AI SDK spec but absent from the protocol type): explicit `providerData.mediaType` → `filename` extension → URL path extension (small built-in map: pdf, txt, md, csv, json, html). For data URLs the embedded media type wins.
- If the media type cannot be determined, the adapter fails fast with `UserError` telling the caller to set `providerData.mediaType`, instead of deferring to a provider-specific error later (providers validate file media types client-side, e.g. `@ai-sdk/anthropic` only accepts images/PDF/plain text).
- `filename` is passed through from `c.filename` or `providerData.filename` (same lookup as the Chat Completions converter, #735).
- `parseBase64ImageDataUrl` was renamed to `parseBase64DataUrl` (it was already media-type agnostic); no behavior change for images.

## Notes for reviewers

- **URL strictness:** string parsing mirrors the Responses model's resolution order (`data:` → base64 → URL), but accepts any scheme `new URL()` can parse — same as the image branch right above it — whereas the Responses user-input converter only accepts `https://`. Happy to restrict this to http(s) if you prefer consistency with that path.
- **Tool results are intentionally untouched:** `input_file` items in tool outputs keep the existing `[file output skipped]` placeholder, since provider support for documents in tool results is inconsistent and replacing the placeholder could turn today's graceful degradation into a hard request failure. Can follow up separately if there is interest.
- No legacy aliases (`fileData` / `fileUrl`) are handled: the adapter never accepted files, so there is no existing usage to stay compatible with.
- Happy to add a short docs section (e.g. under "Notes for AI SDK models") if useful.

## Testing

- New unit tests cover: data URL (with/without filename, mediaType precedence), raw base64 + `providerData.mediaType`, URL string / `{ url }` object, http URLs, filename-vs-URL extension priority, undeterminable media type, `{ id }` rejection, malformed strings, missing/empty values, and a regression test pinning the unchanged tool-output behavior.
- `pnpm build`, `pnpm -r build-check`, `pnpm test`, `pnpm lint` all pass locally (Node 22).

