### PR TITLE
fix: #1396 restore system messages in conversation history

### DIFF
--- a/.changeset/late-snails-hide.md
+++ b/.changeset/late-snails-hide.md
@@ -1,0 +1,3 @@
+## "@openai/agents-openai": patch
+
+Fix `OpenAIConversationsSession.getItems()` for persisted system messages stored as `input_text` content.

--- a/.changeset/late-snails-hide.md
+++ b/.changeset/late-snails-hide.md
@@ -1,3 +1,5 @@
-## "@openai/agents-openai": patch
+---
+'@openai/agents-openai': patch
+---
 
-Fix `OpenAIConversationsSession.getItems()` for persisted system messages stored as `input_text` content.
+fix(memory): restore persisted `input_text` system messages in conversation history

--- a/packages/agents-openai/src/memory/openaiConversationsSession.ts
+++ b/packages/agents-openai/src/memory/openaiConversationsSession.ts
@@ -59,6 +59,18 @@ export class OpenAIConversationsSession
     const conversationId = await this.getSessionId();
     // Convert each API item into the Agent SDK's input shape. Some API payloads expand into multiple items.
     const toAgentItems = (item: APIConversationItem): AgentInputItem[] => {
+      if (item.type === 'message' && item.role === 'system') {
+        const message = item as APIConversationMessage;
+        return [
+          {
+            id: item.id,
+            type: 'message',
+            role: 'system',
+            content: normalizeSystemMessageContent(message.content),
+          },
+        ];
+      }
+
       if (item.type === 'message' && item.role === 'user') {
         const message = item as APIConversationMessage;
         return [
@@ -254,6 +266,23 @@ function stripProviderModelForConversationPersistence(
     }
     return rest as AgentInputItem;
   });
+}
+
+function normalizeSystemMessageContent(
+  content: APIConversationMessage['content'],
+): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+
+  if (!Array.isArray(content)) {
+    return '';
+  }
+
+  return content
+    .map((item) => (item.type === 'input_text' ? item.text : null))
+    .filter((item): item is string => item !== null)
+    .join('\n');
 }
 
 function stripConversationPersistenceMetadata(

--- a/packages/agents-openai/src/memory/openaiConversationsSession.ts
+++ b/packages/agents-openai/src/memory/openaiConversationsSession.ts
@@ -280,7 +280,9 @@ function normalizeSystemMessageContent(
   }
 
   return content
-    .map((item) => (item.type === 'input_text' ? item.text : null))
+    .map((item) =>
+      item.type === 'input_text' || item.type === 'text' ? item.text : null,
+    )
     .filter((item): item is string => item !== null)
     .join('\n');
 }

--- a/packages/agents-openai/test/openaiConversationsSession.test.ts
+++ b/packages/agents-openai/test/openaiConversationsSession.test.ts
@@ -125,6 +125,47 @@ describe('OpenAIConversationsSession', () => {
     ]);
   });
 
+  it('round-trips limited system messages with string content', async () => {
+    const list = vi.fn(() => ({
+      async *[Symbol.asyncIterator]() {
+        yield {
+          id: 'sys-1',
+          type: 'message',
+          role: 'system',
+          content: 'User info (session context): premium account',
+        } as any;
+      },
+    }));
+
+    const session = createSession({
+      client: {
+        conversations: {
+          items: {
+            list,
+            create: vi.fn(),
+            delete: vi.fn(),
+          },
+          create: vi.fn(),
+          delete: vi.fn(),
+        },
+      } as any,
+      conversationId: 'conv-123',
+    });
+
+    const result = await session.getItems(1);
+
+    expect(list).toHaveBeenCalledWith('conv-123', { limit: 1, order: 'desc' });
+    expect(convertToOutputItemMock).not.toHaveBeenCalled();
+    expect(result).toEqual([
+      {
+        id: 'sys-1',
+        type: 'message',
+        role: 'system',
+        content: 'User info (session context): premium account',
+      },
+    ]);
+  });
+
   it('wraps string function_call_output payloads before converting', async () => {
     const convertedItems = [
       {

--- a/packages/agents-openai/test/openaiConversationsSession.test.ts
+++ b/packages/agents-openai/test/openaiConversationsSession.test.ts
@@ -80,6 +80,51 @@ describe('OpenAIConversationsSession', () => {
     expect(result).toEqual(convertedItems);
   });
 
+  it('round-trips system messages without routing them through output conversion', async () => {
+    const list = vi.fn(() => ({
+      async *[Symbol.asyncIterator]() {
+        yield {
+          id: 'sys-1',
+          type: 'message',
+          role: 'system',
+          content: [
+            {
+              type: 'input_text',
+              text: 'User info (session context): premium account',
+            },
+          ],
+        } as any;
+      },
+    }));
+
+    const session = createSession({
+      client: {
+        conversations: {
+          items: {
+            list,
+            create: vi.fn(),
+            delete: vi.fn(),
+          },
+          create: vi.fn(),
+          delete: vi.fn(),
+        },
+      } as any,
+      conversationId: 'conv-123',
+    });
+
+    const result = await session.getItems();
+
+    expect(convertToOutputItemMock).not.toHaveBeenCalled();
+    expect(result).toEqual([
+      {
+        id: 'sys-1',
+        type: 'message',
+        role: 'system',
+        content: 'User info (session context): premium account',
+      },
+    ]);
+  });
+
   it('wraps string function_call_output payloads before converting', async () => {
     const convertedItems = [
       {

--- a/packages/agents-openai/test/openaiConversationsSession.test.ts
+++ b/packages/agents-openai/test/openaiConversationsSession.test.ts
@@ -80,7 +80,7 @@ describe('OpenAIConversationsSession', () => {
     expect(result).toEqual(convertedItems);
   });
 
-  it('round-trips system messages without routing them through output conversion', async () => {
+  it('round-trips system message text parts without routing them through output conversion', async () => {
     const list = vi.fn(() => ({
       async *[Symbol.asyncIterator]() {
         yield {
@@ -91,6 +91,10 @@ describe('OpenAIConversationsSession', () => {
             {
               type: 'input_text',
               text: 'User info (session context): premium account',
+            },
+            {
+              type: 'text',
+              text: 'Always respond concisely.',
             },
           ],
         } as any;
@@ -120,7 +124,8 @@ describe('OpenAIConversationsSession', () => {
         id: 'sys-1',
         type: 'message',
         role: 'system',
-        content: 'User info (session context): premium account',
+        content:
+          'User info (session context): premium account\nAlways respond concisely.',
       },
     ]);
   });


### PR DESCRIPTION
## Summary
- handle persisted Conversations API system messages directly in `OpenAIConversationsSession.getItems()`
- normalize `input_text` system-message content back into the SDK's string system-message shape
- add a regression test for the `input_text` system-message history case

## Testing
- `pnpm.cmd run prebuild`
- `pnpm.cmd -F @openai/agents-openai run build-check`
- `pnpm.cmd changeset:validate-lite -- .changeset/late-snails-hide.md`

Closes #1396.
