### PR TITLE
fix: expose sandbox error retryability metadata

### DIFF
--- a/.changeset/sandbox-error-retryability.md
+++ b/.changeset/sandbox-error-retryability.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-extensions': patch
+---
+
+fix: expose sandbox error retryability metadata

--- a/packages/agents-core/src/sandbox/errors.ts
+++ b/packages/agents-core/src/sandbox/errors.ts
@@ -49,6 +49,7 @@ export type SandboxErrorCode =
 export class SandboxError extends UserError {
   readonly code: SandboxErrorCode;
   readonly details?: Record<string, unknown>;
+  readonly retryable: boolean | null;
 
   constructor(
     message: string,
@@ -58,6 +59,7 @@ export class SandboxError extends UserError {
     super(message);
     this.code = code;
     this.details = details;
+    this.retryable = inferSandboxErrorRetryability(code, details);
   }
 }
 
@@ -424,4 +426,100 @@ export class SandboxSnapshotNotRestorableError extends SandboxSnapshotError {
   constructor(message: string, details?: Record<string, unknown>) {
     super(message, details, 'snapshot_not_restorable');
   }
+}
+
+function inferSandboxErrorRetryability(
+  code: SandboxErrorCode,
+  details?: Record<string, unknown>,
+): boolean | null {
+  const retryable = details?.retryable;
+  if (typeof retryable === 'boolean') {
+    return retryable;
+  }
+
+  const cause = details?.cause;
+  if (cause instanceof SandboxError) {
+    return cause.retryable;
+  }
+
+  const providerRetryability = inferProviderDetailsRetryability(details);
+  if (providerRetryability !== null) {
+    return providerRetryability;
+  }
+
+  switch (code) {
+    case 'configuration_error':
+    case 'unsupported_feature':
+    case 'path_resolution_error':
+    case 'invalid_manifest_path':
+    case 'invalid_compression_scheme':
+    case 'exposed_port_unavailable':
+    case 'exec_nonzero':
+    case 'exec_timeout':
+    case 'pty_session_not_found':
+    case 'apply_patch_invalid_path':
+    case 'apply_patch_invalid_diff':
+    case 'apply_patch_file_not_found':
+    case 'apply_patch_decode_error':
+    case 'workspace_read_not_found':
+    case 'workspace_write_type_error':
+    case 'workspace_root_not_found':
+    case 'git_missing_in_image':
+    case 'git_subpath_error':
+    case 'mount_missing_tool':
+    case 'mount_config_invalid':
+    case 'skills_config_invalid':
+    case 'sandbox_config_invalid':
+    case 'snapshot_not_restorable':
+      return false;
+    default:
+      return null;
+  }
+}
+
+function inferProviderDetailsRetryability(
+  details?: Record<string, unknown>,
+): boolean | null {
+  const status = readStatus(details);
+  if (status !== undefined) {
+    if ([408, 425, 429, 500, 502, 503, 504].includes(status)) {
+      return true;
+    }
+    if ([400, 401, 403, 404, 409, 422].includes(status)) {
+      return false;
+    }
+  }
+
+  const code = details?.errorCode ?? details?.providerErrorCode;
+  if (typeof code === 'string') {
+    const normalized = code.toLowerCase();
+    if (/(rate.?limit|timeout|connection|unavailable)/u.test(normalized)) {
+      return true;
+    }
+    if (
+      /(authentication|authorization|permission|forbidden|not.?found|validation|bad.?request|conflict|unprocessable)/u.test(
+        normalized,
+      )
+    ) {
+      return false;
+    }
+  }
+
+  return null;
+}
+
+function readStatus(details?: Record<string, unknown>): number | undefined {
+  if (!details) {
+    return undefined;
+  }
+  for (const key of ['status', 'httpStatus', 'responseStatus']) {
+    const value = details[key];
+    if (typeof value === 'number' && Number.isInteger(value)) {
+      return value;
+    }
+    if (typeof value === 'string' && /^\d+$/u.test(value)) {
+      return Number(value);
+    }
+  }
+  return undefined;
 }

--- a/packages/agents-core/src/sandbox/events.ts
+++ b/packages/agents-core/src/sandbox/events.ts
@@ -4,6 +4,7 @@ export type SandboxEventError = {
   name?: string;
   message: string;
   code?: string;
+  retryable?: boolean | null;
 };
 
 export type SandboxOperationEvent = {
@@ -132,10 +133,12 @@ export function createChainedSandboxEventSink(
 export function serializeSandboxEventError(error: unknown): SandboxEventError {
   if (error instanceof Error) {
     const code = readErrorCode(error);
+    const retryable = readErrorRetryability(error);
     return {
       name: error.name,
       message: error.message,
       ...(code ? { code } : {}),
+      ...(retryable !== undefined ? { retryable } : {}),
     };
   }
 
@@ -147,6 +150,13 @@ export function serializeSandboxEventError(error: unknown): SandboxEventError {
 function readErrorCode(error: Error): string | undefined {
   const code = (error as { code?: unknown }).code;
   return typeof code === 'string' ? code : undefined;
+}
+
+function readErrorRetryability(error: Error): boolean | null | undefined {
+  const retryable = (error as { retryable?: unknown }).retryable;
+  return typeof retryable === 'boolean' || retryable === null
+    ? retryable
+    : undefined;
 }
 
 function readGlobalFetch(): SandboxHttpEventFetch | undefined {

--- a/packages/agents-core/src/sandbox/runtime/spans.ts
+++ b/packages/agents-core/src/sandbox/runtime/spans.ts
@@ -1,4 +1,6 @@
 import { getCurrentTrace, withCustomSpan } from '../../tracing';
+import type { Span } from '../../tracing';
+import type { CustomSpanData } from '../../tracing/spans';
 import { emitSandboxEvent, serializeSandboxEventError } from '../events';
 
 export async function withSandboxSpan<T>(
@@ -15,7 +17,7 @@ export async function withSandboxSpan<T>(
     data: { ...data },
   });
 
-  const runWithEvents = async (): Promise<T> => {
+  const runWithEvents = async (span?: Span<CustomSpanData>): Promise<T> => {
     try {
       const result = await fn();
       await emitSandboxEvent({
@@ -28,6 +30,8 @@ export async function withSandboxSpan<T>(
       });
       return result;
     } catch (error) {
+      const serializedError = serializeSandboxEventError(error);
+      recordSandboxSpanError(span, serializedError);
       await emitSandboxEvent({
         type: 'sandbox_operation',
         name,
@@ -35,7 +39,7 @@ export async function withSandboxSpan<T>(
         timestamp: new Date().toISOString(),
         data: { ...data },
         durationMs: Date.now() - startedAt,
-        error: serializeSandboxEventError(error),
+        error: serializedError,
       });
       throw error;
     }
@@ -45,10 +49,24 @@ export async function withSandboxSpan<T>(
     return await runWithEvents();
   }
 
-  return await withCustomSpan(async () => await runWithEvents(), {
+  return await withCustomSpan(async (span) => await runWithEvents(span), {
     data: {
       name,
       data,
     },
   });
+}
+
+function recordSandboxSpanError(
+  span: Span<CustomSpanData> | undefined,
+  error: ReturnType<typeof serializeSandboxEventError>,
+): void {
+  if (!span) {
+    return;
+  }
+  span.spanData.data = {
+    ...span.spanData.data,
+    error,
+    error_retryable: error.retryable ?? null,
+  };
 }

--- a/packages/agents-core/test/sandboxErrors.test.ts
+++ b/packages/agents-core/test/sandboxErrors.test.ts
@@ -44,6 +44,58 @@ describe('sandbox errors', () => {
     expect(error.name).toBe('SandboxError');
     expect(error.code).toBe('runtime_error');
     expect(error.details).toEqual({ provider: 'fake' });
+    expect(error.retryable).toBeNull();
+  });
+
+  it('exposes explicit retryability metadata', () => {
+    const error = new SandboxExecTransportError('backend unavailable', {
+      provider: 'fake',
+      retryable: true,
+    });
+
+    expect(error.retryable).toBe(true);
+  });
+
+  it('inherits retryability from wrapped sandbox causes', () => {
+    const cause = new SandboxWorkspaceArchiveReadError('archive failed', {
+      retryable: false,
+    });
+    const error = new SandboxWorkspaceStopError('stop failed', { cause });
+
+    expect(error.retryable).toBe(false);
+  });
+
+  it('marks deterministic sandbox errors as non-retryable', () => {
+    expect(new SandboxWorkspaceReadNotFoundError('missing').retryable).toBe(
+      false,
+    );
+    expect(new SandboxWorkspaceWriteTypeError('bad write').retryable).toBe(
+      false,
+    );
+    expect(new SandboxExecTimeoutError('timeout').retryable).toBe(false);
+  });
+
+  it('keeps broad archive and snapshot failures as unknown by default', () => {
+    expect(
+      new SandboxWorkspaceArchiveReadError('archive read').retryable,
+    ).toBeNull();
+    expect(new SandboxGitCloneError('clone failed').retryable).toBeNull();
+    expect(new SandboxGitCopyError('copy failed').retryable).toBeNull();
+    expect(
+      new SandboxSnapshotPersistError('persist failed').retryable,
+    ).toBeNull();
+    expect(
+      new SandboxSnapshotRestoreError('restore failed').retryable,
+    ).toBeNull();
+  });
+
+  it('infers provider retryability from status details', () => {
+    expect(
+      new SandboxExecTransportError('rate limited', { status: 429 }).retryable,
+    ).toBe(true);
+    expect(
+      new SandboxExecTransportError('bad request', { status: 400 }).retryable,
+    ).toBe(false);
   });
 
   it('exposes Python-parity error codes for concrete sandbox failures', () => {

--- a/packages/agents-core/test/sandboxEvents.test.ts
+++ b/packages/agents-core/test/sandboxEvents.test.ts
@@ -10,10 +10,33 @@ import {
   type SandboxHttpEventFetch,
   withSandboxSpan,
 } from '../src/sandbox';
+import {
+  setTraceProcessors,
+  setTracingDisabled,
+  withTrace,
+  type Span,
+  type Trace,
+  type TracingProcessor,
+} from '../src/tracing';
+
+class RecordingProcessor implements TracingProcessor {
+  spansEnded: Span<any>[] = [];
+
+  async onTraceStart(_trace: Trace): Promise<void> {}
+  async onTraceEnd(_trace: Trace): Promise<void> {}
+  async onSpanStart(_span: Span<any>): Promise<void> {}
+  async onSpanEnd(span: Span<any>): Promise<void> {
+    this.spansEnded.push(span);
+  }
+  async shutdown(): Promise<void> {}
+  async forceFlush(): Promise<void> {}
+}
 
 describe('sandbox events', () => {
   afterEach(() => {
     clearSandboxEventSinks();
+    setTracingDisabled(true);
+    setTraceProcessors([]);
   });
 
   it('emits operation start and end events without exposing operation output', async () => {
@@ -209,6 +232,55 @@ describe('sandbox events', () => {
         name: 'SandboxProviderError',
         message: 'provider unavailable',
         code: 'provider_error',
+        retryable: null,
+      },
+    });
+  });
+
+  it('emits sandbox retryability in error events and traces', async () => {
+    const events: SandboxEvent[] = [];
+    const processor = new RecordingProcessor();
+    addSandboxEventSink((event) => {
+      events.push(event);
+    });
+    setTraceProcessors([processor]);
+    setTracingDisabled(false);
+
+    await expect(
+      withTrace('sandbox retryability', async () => {
+        await withSandboxSpan(
+          'sandbox.read',
+          { path: 'missing.txt' },
+          async () => {
+            throw new SandboxProviderError('missing path', {
+              status: 404,
+            });
+          },
+        );
+      }),
+    ).rejects.toThrow('missing path');
+
+    expect(events[1]).toMatchObject({
+      type: 'sandbox_operation',
+      name: 'sandbox.read',
+      phase: 'error',
+      error: {
+        code: 'provider_error',
+        retryable: false,
+      },
+    });
+
+    const sandboxSpan = processor.spansEnded.find(
+      (span) =>
+        span.spanData.type === 'custom' &&
+        span.spanData.name === 'sandbox.read',
+    );
+    expect(sandboxSpan?.spanData.data).toMatchObject({
+      path: 'missing.txt',
+      error_retryable: false,
+      error: {
+        code: 'provider_error',
+        retryable: false,
       },
     });
   });

--- a/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
@@ -1431,10 +1431,21 @@ async function cloudflareProviderHttpErrorWithBody(
       provider: 'cloudflare',
       operation,
       status: response.status,
+      retryable: cloudflareRetryabilityForStatus(response.status),
       ...context,
       ...(cause ? { cause } : {}),
     },
   );
+}
+
+function cloudflareRetryabilityForStatus(status: number): boolean | null {
+  if (status === 503) {
+    return true;
+  }
+  if (status === 400 || status === 500) {
+    return false;
+  }
+  return null;
 }
 
 async function readCloudflareErrorBody(

--- a/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
@@ -1439,10 +1439,10 @@ async function cloudflareProviderHttpErrorWithBody(
 }
 
 function cloudflareRetryabilityForStatus(status: number): boolean | null {
-  if (status === 503) {
+  if (status === 500 || status === 503) {
     return true;
   }
-  if (status === 400 || status === 500) {
+  if (status === 400) {
     return false;
   }
   return null;

--- a/packages/agents-extensions/src/sandbox/shared/index.ts
+++ b/packages/agents-extensions/src/sandbox/shared/index.ts
@@ -82,6 +82,7 @@ export {
   isProviderSandboxNotFoundError,
   providerErrorDetails,
   providerErrorMessage,
+  providerErrorRetryability,
   withProviderError,
   withSandboxSpan,
 } from './session';

--- a/packages/agents-extensions/src/sandbox/shared/session.ts
+++ b/packages/agents-extensions/src/sandbox/shared/session.ts
@@ -87,6 +87,7 @@ export async function withProviderError<T>(
       throw error;
     }
     const cause = providerErrorMessage(error);
+    const retryable = providerErrorRetryability(error);
     throw new SandboxProviderError(
       `${providerName} failed to ${operation}${cause ? `: ${cause}` : ''}`,
       {
@@ -94,6 +95,7 @@ export async function withProviderError<T>(
         operation,
         ...context,
         ...providerErrorDetails(error),
+        retryable,
         cause,
       },
     );
@@ -134,6 +136,7 @@ export function assertResumeRecreateAllowed(
       operation: 'resume',
       ...context.details,
       ...providerErrorDetails(error),
+      retryable: providerErrorRetryability(error),
       cause: providerErrorMessage(error),
     },
   );
@@ -151,6 +154,10 @@ export function providerErrorMessage(error: unknown): string {
 
 export function providerErrorDetails(error: unknown): Record<string, unknown> {
   return collectProviderErrorDetails(error, new Set<object>(), 0);
+}
+
+export function providerErrorRetryability(error: unknown): boolean | null {
+  return readProviderErrorRetryability(error, new Set<object>(), 0);
 }
 
 function errorMessage(error: unknown): string {
@@ -242,6 +249,130 @@ function collectProviderErrorDetails(
   }
 
   return details;
+}
+
+function readProviderErrorRetryability(
+  value: unknown,
+  seen: Set<object>,
+  depth: number,
+): boolean | null {
+  if (!isRecord(value) || seen.has(value) || depth > 3) {
+    return null;
+  }
+  seen.add(value);
+
+  const explicit = readExplicitRetryability(value);
+  if (explicit !== null) {
+    return explicit;
+  }
+
+  const typed = retryabilityForErrorType(value);
+  if (typed !== null) {
+    return typed;
+  }
+
+  const status = readProviderStatus(value);
+  if (status !== undefined) {
+    const retryable = retryabilityForHttpStatus(status);
+    if (retryable !== null) {
+      return retryable;
+    }
+  }
+
+  const response = value.response;
+  if (isRecord(response)) {
+    const responseExplicit = readExplicitRetryability(response);
+    if (responseExplicit !== null) {
+      return responseExplicit;
+    }
+    const responseStatus = readProviderStatus(response);
+    if (responseStatus !== undefined) {
+      const retryable = retryabilityForHttpStatus(responseStatus);
+      if (retryable !== null) {
+        return retryable;
+      }
+    }
+    const responsePayloadRetryable = readPayloadRetryability(
+      firstDefined(response.json, response.data, response.body, response.error),
+    );
+    if (responsePayloadRetryable !== null) {
+      return responsePayloadRetryable;
+    }
+  }
+
+  const payload = firstDefined(value.json, value.data, value.body, value.error);
+  const payloadRetryable = readPayloadRetryability(payload);
+  if (payloadRetryable !== null) {
+    return payloadRetryable;
+  }
+
+  return readProviderErrorRetryability(value.cause, seen, depth + 1);
+}
+
+function readExplicitRetryability(
+  value: Record<string, unknown>,
+): boolean | null {
+  return typeof value.retryable === 'boolean' ? value.retryable : null;
+}
+
+function readPayloadRetryability(value: unknown): boolean | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const explicit = readExplicitRetryability(value);
+  if (explicit !== null) {
+    return explicit;
+  }
+  const nested = value.error;
+  return isRecord(nested) ? readExplicitRetryability(nested) : null;
+}
+
+function retryabilityForErrorType(
+  value: Record<string, unknown>,
+): boolean | null {
+  const text = [value.name, value.code, value.errorCode]
+    .filter((item): item is string => typeof item === 'string')
+    .join(' ')
+    .toLowerCase();
+  if (!text) {
+    return null;
+  }
+  if (/(rate.?limit|timeout|connection|unavailable)/u.test(text)) {
+    return true;
+  }
+  if (
+    /(authentication|authorization|permission|forbidden|not.?found|validation|bad.?request|conflict|unprocessable)/u.test(
+      text,
+    )
+  ) {
+    return false;
+  }
+  return null;
+}
+
+function readProviderStatus(
+  value: Record<string, unknown>,
+): number | undefined {
+  for (const key of ['status', 'statusCode', 'httpStatus', 'httpStatusCode']) {
+    const status = value[key];
+    if (typeof status === 'number' && Number.isInteger(status)) {
+      return status;
+    }
+    if (typeof status === 'string' && /^\d+$/u.test(status)) {
+      return Number(status);
+    }
+  }
+  return undefined;
+}
+
+function retryabilityForHttpStatus(status: number): boolean | null {
+  if ([408, 425, 429, 500, 502, 503, 504].includes(status)) {
+    return true;
+  }
+  if ([400, 401, 403, 404, 409, 422].includes(status)) {
+    return false;
+  }
+  return null;
 }
 
 function formatProviderErrorDetailSummary(

--- a/packages/agents-extensions/test/sandbox/cloudflare.test.ts
+++ b/packages/agents-extensions/test/sandbox/cloudflare.test.ts
@@ -484,10 +484,12 @@ describe('CloudflareSandboxClient', () => {
       ),
     ).rejects.toMatchObject({
       code: 'provider_error',
+      retryable: true,
       details: {
         provider: 'cloudflare',
         operation: 'write file',
         status: 500,
+        retryable: true,
         path: '/workspace/README.md',
       },
     });

--- a/packages/agents-extensions/test/sandbox/sharedSession.test.ts
+++ b/packages/agents-extensions/test/sandbox/sharedSession.test.ts
@@ -13,6 +13,7 @@ import {
   isProviderSandboxNotFoundError,
   closeRemoteSessionOnManifestError,
   withProviderError,
+  providerErrorRetryability,
   RemoteSandboxSessionBase,
   type RemoteSandboxCommandOptions,
   type RemoteSandboxCommandResult,
@@ -277,8 +278,35 @@ describe('shared sandbox session helpers', () => {
           message: 'slow down',
         },
       },
+      retryable: true,
       cause: expect.stringContaining('request failed'),
     });
+    expect((thrown as SandboxProviderError).retryable).toBe(true);
+  });
+
+  test('classifies provider retryability from statuses and typed errors', () => {
+    expect(providerErrorRetryability({ status: 400 })).toBe(false);
+    expect(providerErrorRetryability({ status: 404 })).toBe(false);
+    expect(providerErrorRetryability({ status: 408 })).toBe(true);
+    expect(providerErrorRetryability({ status: 429 })).toBe(true);
+    expect(providerErrorRetryability({ status: 503 })).toBe(true);
+    expect(providerErrorRetryability({ name: 'ProviderValidationError' })).toBe(
+      false,
+    );
+    expect(providerErrorRetryability({ name: 'ProviderTimeoutError' })).toBe(
+      true,
+    );
+    expect(
+      providerErrorRetryability({
+        response: {
+          data: {
+            error: {
+              retryable: false,
+            },
+          },
+        },
+      }),
+    ).toBe(false);
   });
 
   test('keeps provider details when manifest cleanup also fails', async () => {


### PR DESCRIPTION
This pull request fixes sandbox error metadata parity by exposing retryability on sandbox errors, emitted sandbox error events, and sandbox tracing spans. It also adds provider-side retryability inference for extension sandbox clients so provider failures can surface whether retrying is likely useful, including Cloudflare-specific HTTP status handling.

The change is additive: existing sandbox errors keep their current codes and details, with a new `retryable` value of `true`, `false`, or `null` when the SDK cannot infer the answer.

ref: https://github.com/openai/openai-agents-python/pull/3581