### PR TITLE
fix: preserve server-side compaction items across turns

### DIFF
--- a/.changeset/stateless-compaction-history.md
+++ b/.changeset/stateless-compaction-history.md
@@ -3,4 +3,4 @@
 '@openai/agents': patch
 ---
 
-fix: preserve server-side compaction items across turns
+fix: preserve server-side compaction history and deferred tool state

--- a/.changeset/stateless-compaction-history.md
+++ b/.changeset/stateless-compaction-history.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents': patch
+---
+
+fix: preserve server-side compaction items across turns

--- a/docs/src/content/docs/guides/results.mdx
+++ b/docs/src/content/docs/guides/results.mdx
@@ -83,6 +83,7 @@ In practice:
 
 - [`RunMessageOutputItem`](/openai-agents-js/openai/agents/classes/runmessageoutputitem) for assistant messages.
 - [`RunReasoningItem`](/openai-agents-js/openai/agents/classes/runreasoningitem) for reasoning items.
+- [`RunCompactionItem`](/openai-agents-js/openai/agents/classes/runcompactionitem) for encrypted Responses compaction items.
 - [`RunToolSearchCallItem`](/openai-agents-js/openai/agents/classes/runtoolsearchcallitem) and [`RunToolSearchOutputItem`](/openai-agents-js/openai/agents/classes/runtoolsearchoutputitem) for Responses tool-search requests and the loaded tool definitions they return.
 - [`RunToolCallItem`](/openai-agents-js/openai/agents/classes/runtoolcallitem) and [`RunToolCallOutputItem`](/openai-agents-js/openai/agents/classes/runtoolcalloutputitem) for tool calls and their results.
 - [`RunToolApprovalItem`](/openai-agents-js/openai/agents/classes/runtoolapprovalitem) for tool calls that paused for approval.

--- a/docs/src/content/docs/guides/results.mdx
+++ b/docs/src/content/docs/guides/results.mdx
@@ -22,7 +22,7 @@ Most applications only need a few properties:
 | If you need... | Use |
 | --- | --- |
 | The final answer to show the user | `finalOutput` |
-| A replay-ready next-turn input with the full local transcript | `history` |
+| A replay-ready next-turn input with the local transcript | `history` |
 | Only the newly generated model-shaped items from this run | `output` |
 | Rich run items with agent/tool/handoff metadata | `newItems` |
 | The agent that should usually handle the next user turn | `lastAgent` or `activeAgent` |
@@ -64,7 +64,7 @@ These properties answer different questions:
 | `input` | The base input for this run. If a handoff input filter rewrote the history, this reflects the filtered input the run continued with. | Auditing what this run actually used as input |
 | `output` | Only the model-shaped items generated in this run, without agent metadata. | Storing or replaying just the new model delta |
 | `newItems` | Rich [`RunItem`](/openai-agents-js/openai/agents/type-aliases/runitem) wrappers with agent/tool/handoff metadata. | Logs, UIs, audits, and debugging |
-| `history` | A replay-ready next-turn input built from `input + newItems`. | Manual chat loops and client-managed conversation state |
+| `history` | A replay-ready next-turn input built from `input + newItems`. Items before the latest Responses compaction item are omitted. | Manual chat loops and client-managed conversation state |
 
 In practice:
 

--- a/docs/src/content/docs/guides/streaming.mdx
+++ b/docs/src/content/docs/guides/streaming.mdx
@@ -135,6 +135,7 @@ See [`examples/basic/stream-ws.ts`](https://github.com/openai/openai-agents-js/t
 | `tool_called` | A tool call item was emitted. |
 | `tool_output` | A tool result item was emitted. |
 | `reasoning_item_created` | A reasoning item was emitted. |
+| `compaction_item_created` | An encrypted Responses compaction item was emitted. |
 | `tool_approval_requested` | A tool call paused for human approval. |
 
 The `tool_search_*` events only appear on Responses runs that use `toolSearchTool()` to load deferred tools during the run.

--- a/packages/agents-core/src/events.ts
+++ b/packages/agents-core/src/events.ts
@@ -42,6 +42,7 @@ export type RunItemStreamEventName =
   | 'tool_called'
   | 'tool_output'
   | 'reasoning_item_created'
+  | 'compaction_item_created'
   | 'tool_approval_requested';
 
 /**

--- a/packages/agents-core/src/extensions/handoffFilters.ts
+++ b/packages/agents-core/src/extensions/handoffFilters.ts
@@ -1,5 +1,6 @@
 import { HandoffInputData } from '../handoff';
 import {
+  RunCompactionItem,
   RunHandoffCallItem,
   RunHandoffOutputItem,
   RunItem,
@@ -25,13 +26,14 @@ const TOOL_TYPES = new Set([
   'apply_patch_call_output',
   'hosted_tool_call',
   'reasoning',
+  'compaction',
 ]);
 
 /**
  * Filters out tool-related history and run items before a handoff.
  *
  * @param handoffInputData The collected handoff input to sanitize.
- * @returns Handoff input without tool calls, tool outputs, or tool search items.
+ * @returns Handoff input without tool, reasoning, or compaction items.
  */
 export function removeAllTools(
   handoffInputData: HandoffInputData,
@@ -57,6 +59,7 @@ export function removeAllTools(
 function removeToolsFromItems(items: RunItem[]): RunItem[] {
   return items.filter(
     (item) =>
+      !(item instanceof RunCompactionItem) &&
       !(item instanceof RunHandoffCallItem) &&
       !(item instanceof RunHandoffOutputItem) &&
       !(item instanceof RunToolSearchCallItem) &&

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -88,6 +88,7 @@ export {
 export { assistant, system, user } from './helpers/message';
 export {
   extractAllTextOutput,
+  RunCompactionItem,
   RunHandoffCallItem,
   RunHandoffOutputItem,
   RunItem,

--- a/packages/agents-core/src/items.ts
+++ b/packages/agents-core/src/items.ts
@@ -160,6 +160,24 @@ export class RunReasoningItem extends RunItemBase {
   }
 }
 
+export class RunCompactionItem extends RunItemBase {
+  public readonly type = 'compaction_item' as const;
+
+  constructor(
+    public rawItem: protocol.CompactionItem,
+    public agent: Agent,
+  ) {
+    super();
+  }
+
+  toJSON() {
+    return {
+      ...super.toJSON(),
+      agent: this.agent.toJSON(),
+    };
+  }
+}
+
 export class RunHandoffCallItem extends RunItemBase {
   public readonly type = 'handoff_call_item' as const;
 
@@ -287,6 +305,7 @@ export type RunItem =
   | RunToolSearchCallItem
   | RunToolSearchOutputItem
   | RunReasoningItem
+  | RunCompactionItem
   | RunHandoffCallItem
   | RunToolCallOutputItem
   | RunHandoffOutputItem

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { Agent } from './agent';
 import { getAgentToolSourceAgent } from './agentToolSourceRegistry';
 import {
+  RunCompactionItem,
   RunMessageOutputItem,
   RunItem,
   RunToolApprovalItem,
@@ -90,8 +91,9 @@ import {
  *   serialize and resume without ambiguous name resolution.
  * - 1.11: Allows null maxTurns to persist runs without a turn limit.
  * - 1.12: Adds optional missing function tool calls to processed responses.
+ * - 1.13: Adds compaction items to serialized run state payloads.
  */
-export const CURRENT_SCHEMA_VERSION = '1.12' as const;
+export const CURRENT_SCHEMA_VERSION = '1.13' as const;
 const SUPPORTED_SCHEMA_VERSIONS = [
   '1.0',
   '1.1',
@@ -105,6 +107,7 @@ const SUPPORTED_SCHEMA_VERSIONS = [
   '1.9',
   '1.10',
   '1.11',
+  '1.12',
   CURRENT_SCHEMA_VERSION,
 ] as const;
 type SupportedSchemaVersion = (typeof SUPPORTED_SCHEMA_VERSIONS)[number];
@@ -208,6 +211,11 @@ const itemSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('reasoning_item'),
     rawItem: protocol.ReasoningItem,
+    agent: serializedAgentSchema,
+  }),
+  z.object({
+    type: z.literal('compaction_item'),
+    rawItem: protocol.CompactionItem,
     agent: serializedAgentSchema,
   }),
   z.object({
@@ -2093,6 +2101,11 @@ export function deserializeItem(
       );
     case 'reasoning_item':
       return new RunReasoningItem(
+        serializedItem.rawItem,
+        resolveSerializedAgent(serializedItem.agent, agentMap),
+      );
+    case 'compaction_item':
+      return new RunCompactionItem(
         serializedItem.rawItem,
         resolveSerializedAgent(serializedItem.agent, agentMap),
       );

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -1066,7 +1066,33 @@ async function buildRunStateFromString<
     currentSchemaVersion as SupportedSchemaVersion,
     stateJson,
   );
+  assertSchemaVersionSupportsCompactionOutputs(
+    currentSchemaVersion as SupportedSchemaVersion,
+    stateJson,
+  );
   return buildRunStateFromJson(initialAgent, stateJson, options);
+}
+
+function assertSchemaVersionSupportsCompactionOutputs(
+  schemaVersion: SupportedSchemaVersion,
+  stateJson: z.infer<typeof SerializedRunState>,
+): void {
+  if (schemaVersion === CURRENT_SCHEMA_VERSION) {
+    return;
+  }
+
+  const responses = stateJson.lastModelResponse
+    ? [...stateJson.modelResponses, stateJson.lastModelResponse]
+    : stateJson.modelResponses;
+  if (
+    responses.some((response) =>
+      response.output.some((item) => item.type === 'compaction'),
+    )
+  ) {
+    throw new UserError(
+      `Run state schema version ${schemaVersion} cannot safely resume Responses compaction outputs because compaction run items were added in schema ${CURRENT_SCHEMA_VERSION}. Restart the run from its original input.`,
+    );
+  }
 }
 
 function assertSchemaVersionSupportsToolSearch(

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -1077,7 +1077,11 @@ function assertSchemaVersionSupportsCompactionOutputs(
   schemaVersion: SupportedSchemaVersion,
   stateJson: z.infer<typeof SerializedRunState>,
 ): void {
-  if (schemaVersion === CURRENT_SCHEMA_VERSION) {
+  if (
+    schemaVersion === CURRENT_SCHEMA_VERSION ||
+    stateJson.conversationId ||
+    stateJson.previousResponseId
+  ) {
     return;
   }
 

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -1078,6 +1078,7 @@ function assertSchemaVersionSupportsToolSearch(
     schemaVersion === '1.9' ||
     schemaVersion === '1.10' ||
     schemaVersion === '1.11' ||
+    schemaVersion === '1.12' ||
     schemaVersion === CURRENT_SCHEMA_VERSION
   ) {
     return;
@@ -1098,6 +1099,7 @@ function schemaVersionSupportsAgentIdentity(
   return (
     schemaVersion === '1.10' ||
     schemaVersion === '1.11' ||
+    schemaVersion === '1.12' ||
     schemaVersion === CURRENT_SCHEMA_VERSION
   );
 }

--- a/packages/agents-core/src/runner/items.ts
+++ b/packages/agents-core/src/runner/items.ts
@@ -1,6 +1,8 @@
 import { RunItem } from '../items';
 import { AgentInputItem } from '../types';
+import * as protocol from '../types/protocol';
 import { serializeBinary } from '../utils/binary';
+import { getToolSearchOutputReplacementKey } from '../utils';
 
 export type AgentInputItemPool = Map<string, AgentInputItem[]>;
 
@@ -10,6 +12,13 @@ const TOOL_CALL_RESULT_TYPE_BY_CALL_TYPE = {
   shell_call: 'shell_call_output',
   apply_patch_call: 'apply_patch_call_output',
 } as const;
+
+const COMPACTION_TOOL_SEARCH_STATE_KEY = '__openai_agents_tool_search_state';
+
+type CompactionToolSearchStateEntry = {
+  agentName?: string;
+  output: protocol.ToolSearchOutputItem;
+};
 
 // Normalizes user-provided input into the structure the model expects. Strings become user messages,
 // arrays are kept as-is so downstream loops can treat both scenarios uniformly.
@@ -288,7 +297,11 @@ export function prepareModelInputItems(
     generatedItems,
     reasoningItemIdPolicy,
   );
-  return combineWithGeneratedCompaction(callerItems, preparedGeneratedItems);
+  return combineWithGeneratedCompaction(
+    callerItems,
+    preparedGeneratedItems,
+    generatedItems,
+  );
 }
 
 function getContinuationOutputItems(
@@ -321,17 +334,161 @@ export function getTurnInput(
   return combineWithGeneratedCompaction(
     toAgentInputList(originalInput),
     outputItems,
+    generatedItems,
   );
 }
 
-function combineWithGeneratedCompaction(
+export function combineWithGeneratedCompaction(
   callerItems: AgentInputItem[],
   generatedItems: AgentInputItem[],
+  generatedRunItems: RunItem[],
 ): AgentInputItem[] {
   for (let index = generatedItems.length - 1; index >= 0; index -= 1) {
     if (generatedItems[index]?.type === 'compaction') {
-      return generatedItems.slice(index);
+      const compactedItems = generatedItems.slice(index);
+      const toolSearchState = compactToolSearchStateEntries([
+        ...collectToolSearchStateFromInputItems(callerItems),
+        ...collectToolSearchStateFromRunItems(generatedRunItems),
+      ]);
+      if (toolSearchState.length === 0) {
+        return compactedItems;
+      }
+
+      const compaction = compactedItems[0] as protocol.CompactionItem;
+      return [
+        {
+          ...compaction,
+          providerData: {
+            ...compaction.providerData,
+            [COMPACTION_TOOL_SEARCH_STATE_KEY]: toolSearchState,
+          },
+        },
+        ...compactedItems.slice(1),
+      ];
     }
   }
   return [...callerItems, ...generatedItems];
+}
+
+export function getCompactionToolSearchOutputs(
+  item: AgentInputItem,
+  agentName: string,
+): protocol.ToolSearchOutputItem[] {
+  if (item.type !== 'compaction') {
+    return [];
+  }
+
+  return getCompactionToolSearchStateEntries(item)
+    .filter(
+      (entry) => entry.agentName === undefined || entry.agentName === agentName,
+    )
+    .map((entry) => entry.output);
+}
+
+function collectToolSearchStateFromInputItems(
+  items: AgentInputItem[],
+): CompactionToolSearchStateEntry[] {
+  const entries: CompactionToolSearchStateEntry[] = [];
+  for (const item of items) {
+    if (item.type === 'tool_search_output') {
+      entries.push({ output: item });
+    } else if (item.type === 'compaction') {
+      replaceWithCompactionToolSearchState(entries, item);
+    }
+  }
+  return entries;
+}
+
+function collectToolSearchStateFromRunItems(
+  items: RunItem[],
+): CompactionToolSearchStateEntry[] {
+  const entries: CompactionToolSearchStateEntry[] = [];
+  let latestCompactionIndex = -1;
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    if (items[index]?.type === 'compaction_item') {
+      latestCompactionIndex = index;
+      break;
+    }
+  }
+
+  for (const item of items.slice(0, latestCompactionIndex + 1)) {
+    if (item.type === 'tool_search_output_item') {
+      entries.push({
+        agentName: item.agent.name,
+        output: item.rawItem,
+      });
+    } else if (item.type === 'compaction_item') {
+      replaceWithCompactionToolSearchState(entries, item.rawItem);
+    }
+  }
+  return entries;
+}
+
+function replaceWithCompactionToolSearchState(
+  entries: CompactionToolSearchStateEntry[],
+  item: protocol.CompactionItem,
+): void {
+  const compactedEntries = getCompactionToolSearchStateEntries(item);
+  if (compactedEntries.length === 0) {
+    return;
+  }
+  entries.splice(0, entries.length, ...compactedEntries);
+}
+
+function getCompactionToolSearchStateEntries(
+  item: protocol.CompactionItem,
+): CompactionToolSearchStateEntry[] {
+  const storedState = item.providerData?.[COMPACTION_TOOL_SEARCH_STATE_KEY];
+  if (!Array.isArray(storedState)) {
+    return [];
+  }
+
+  const entries: CompactionToolSearchStateEntry[] = [];
+  for (const value of storedState) {
+    if (!value || typeof value !== 'object' || !('output' in value)) {
+      continue;
+    }
+    const agentName = (value as { agentName?: unknown }).agentName;
+    if (agentName !== undefined && typeof agentName !== 'string') {
+      continue;
+    }
+    const parsedOutput = protocol.ToolSearchOutputItem.safeParse(
+      (value as { output: unknown }).output,
+    );
+    if (!parsedOutput.success) {
+      continue;
+    }
+    entries.push({
+      ...(agentName === undefined ? {} : { agentName }),
+      output: parsedOutput.data,
+    });
+  }
+  return entries;
+}
+
+function compactToolSearchStateEntries(
+  entries: CompactionToolSearchStateEntry[],
+): CompactionToolSearchStateEntry[] {
+  const compacted: Array<CompactionToolSearchStateEntry | undefined> = [];
+  const replacementIndexes = new Map<string, number>();
+
+  for (const entry of entries) {
+    const replacementKey = getToolSearchOutputReplacementKey(entry.output);
+    if (replacementKey) {
+      const scopedKey = JSON.stringify([
+        entry.agentName ?? null,
+        replacementKey,
+      ]);
+      const previousIndex = replacementIndexes.get(scopedKey);
+      if (previousIndex !== undefined) {
+        compacted[previousIndex] = undefined;
+      }
+      replacementIndexes.set(scopedKey, compacted.length);
+    }
+    compacted.push(entry);
+  }
+
+  return compacted.filter(
+    (entry): entry is CompactionToolSearchStateEntry => entry !== undefined,
+  );
 }

--- a/packages/agents-core/src/runner/items.ts
+++ b/packages/agents-core/src/runner/items.ts
@@ -288,10 +288,7 @@ export function prepareModelInputItems(
     generatedItems,
     reasoningItemIdPolicy,
   );
-  return pruneBeforeLatestCompaction([
-    ...callerItems,
-    ...preparedGeneratedItems,
-  ]);
+  return combineWithGeneratedCompaction(callerItems, preparedGeneratedItems);
 }
 
 function getContinuationOutputItems(
@@ -321,19 +318,20 @@ export function getTurnInput(
     generatedItems,
     reasoningItemIdPolicy,
   );
-  return pruneBeforeLatestCompaction([
-    ...toAgentInputList(originalInput),
-    ...outputItems,
-  ]);
+  return combineWithGeneratedCompaction(
+    toAgentInputList(originalInput),
+    outputItems,
+  );
 }
 
-function pruneBeforeLatestCompaction(
-  items: AgentInputItem[],
+function combineWithGeneratedCompaction(
+  callerItems: AgentInputItem[],
+  generatedItems: AgentInputItem[],
 ): AgentInputItem[] {
-  for (let index = items.length - 1; index >= 0; index -= 1) {
-    if (items[index]?.type === 'compaction') {
-      return items.slice(index);
+  for (let index = generatedItems.length - 1; index >= 0; index -= 1) {
+    if (generatedItems[index]?.type === 'compaction') {
+      return generatedItems.slice(index);
     }
   }
-  return items;
+  return [...callerItems, ...generatedItems];
 }

--- a/packages/agents-core/src/runner/items.ts
+++ b/packages/agents-core/src/runner/items.ts
@@ -288,7 +288,10 @@ export function prepareModelInputItems(
     generatedItems,
     reasoningItemIdPolicy,
   );
-  return [...callerItems, ...preparedGeneratedItems];
+  return pruneBeforeLatestCompaction([
+    ...callerItems,
+    ...preparedGeneratedItems,
+  ]);
 }
 
 function getContinuationOutputItems(
@@ -318,5 +321,19 @@ export function getTurnInput(
     generatedItems,
     reasoningItemIdPolicy,
   );
-  return [...toAgentInputList(originalInput), ...outputItems];
+  return pruneBeforeLatestCompaction([
+    ...toAgentInputList(originalInput),
+    ...outputItems,
+  ]);
+}
+
+function pruneBeforeLatestCompaction(
+  items: AgentInputItem[],
+): AgentInputItem[] {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    if (items[index]?.type === 'compaction') {
+      return items.slice(index);
+    }
+  }
+  return items;
 }

--- a/packages/agents-core/src/runner/modelOutputs.ts
+++ b/packages/agents-core/src/runner/modelOutputs.ts
@@ -2,6 +2,7 @@ import { Agent } from '../agent';
 import { ModelBehaviorError } from '../errors';
 import { Handoff } from '../handoff';
 import {
+  RunCompactionItem,
   RunHandoffCallItem,
   RunItem,
   RunMessageOutputItem,
@@ -786,6 +787,8 @@ export function processModelResponse<TContext>(
       }
     } else if (output.type === 'reasoning') {
       items.push(new RunReasoningItem(output, agent));
+    } else if (output.type === 'compaction') {
+      items.push(new RunCompactionItem(output, agent));
     } else if (output.type === 'computer_call') {
       handleToolCallAction({
         output,
@@ -1107,6 +1110,8 @@ export async function processModelResponseAsync<TContext>(
       }
     } else if (output.type === 'reasoning') {
       items.push(new RunReasoningItem(output, agent));
+    } else if (output.type === 'compaction') {
+      items.push(new RunCompactionItem(output, agent));
     } else if (output.type === 'computer_call') {
       handleToolCallAction({
         output,

--- a/packages/agents-core/src/runner/modelOutputs.ts
+++ b/packages/agents-core/src/runner/modelOutputs.ts
@@ -59,6 +59,7 @@ import {
   executeCustomClientToolSearch,
   getClientToolSearchHelper,
 } from './toolSearch';
+import { getCompactionToolSearchOutputs } from './items';
 
 function ensureToolAvailable<T>(
   tool: T | undefined,
@@ -301,6 +302,15 @@ function collectLoadedDeferredToolStateFromHistory(
     }
 
     const rawItem = getRawAgentInputItem(item);
+    if (rawItem?.type === 'compaction') {
+      for (const toolSearchOutput of getCompactionToolSearchOutputs(
+        rawItem,
+        agent.name,
+      )) {
+        recordLoadedToolSearchOutput(state, toolSearchOutput);
+      }
+      continue;
+    }
     if (rawItem?.type !== 'tool_search_output') {
       continue;
     }

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -640,15 +640,23 @@ async function persistRunItemsToSession(options: {
     return;
   }
 
-  const itemsToSave = [
-    ...extraInputItems,
-    ...extractOutputItemsFromRunItems(
-      newRunItems,
-      session.preserveReasoningItemIdsForPersistence?.() === true
-        ? undefined
-        : state._reasoningItemIdPolicy,
-    ),
-  ];
+  const generatedItemsToSave = extractOutputItemsFromRunItems(
+    newRunItems,
+    session.preserveReasoningItemIdsForPersistence?.() === true
+      ? undefined
+      : state._reasoningItemIdPolicy,
+  );
+  let latestCompactionIndex = -1;
+  for (let index = generatedItemsToSave.length - 1; index >= 0; index -= 1) {
+    if (generatedItemsToSave[index]?.type === 'compaction') {
+      latestCompactionIndex = index;
+      break;
+    }
+  }
+  const replacesSessionHistory = latestCompactionIndex !== -1;
+  const itemsToSave = replacesSessionHistory
+    ? generatedItemsToSave.slice(latestCompactionIndex)
+    : [...extraInputItems, ...generatedItemsToSave];
 
   if (itemsToSave.length === 0) {
     state._currentTurnPersistedItemCount =
@@ -658,10 +666,54 @@ async function persistRunItemsToSession(options: {
   }
 
   const sanitizedItems = normalizeItemsForSessionPersistence(itemsToSave);
-  await session.addItems(sanitizedItems);
+  if (replacesSessionHistory) {
+    await replaceSessionHistory(session, sanitizedItems);
+  } else {
+    await session.addItems(sanitizedItems);
+  }
   await runCompactionOnSession(session, lastResponseId, state);
   state._currentTurnPersistedItemCount =
     alreadyPersistedCount + newRunItems.length;
+}
+
+async function replaceSessionHistory(
+  session: Session,
+  replacementItems: AgentInputItem[],
+): Promise<void> {
+  const previousItems = await session.getItems();
+  try {
+    await session.clearSession();
+    await session.addItems(replacementItems);
+  } catch (error) {
+    try {
+      const currentItems = await session.getItems();
+      const unchanged =
+        currentItems.length === previousItems.length &&
+        currentItems.every(
+          (item, index) =>
+            getAgentInputItemKey(item) ===
+            getAgentInputItemKey(previousItems[index]),
+        );
+      if (!unchanged) {
+        for (let index = 0; index < currentItems.length; index += 1) {
+          if (!(await session.popItem())) {
+            break;
+          }
+        }
+        await session.addItems(previousItems);
+        logger.warn(
+          'Restored previous session history after compaction replacement failed.',
+          error,
+        );
+      }
+    } catch (restoreError) {
+      logger.warn(
+        'Failed to restore session history after compaction replacement failed.',
+        restoreError,
+      );
+    }
+    throw error;
+  }
 }
 
 async function runCompactionOnSession(

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -13,6 +13,7 @@ import { encodeUint8ArrayToBase64 } from '../utils/base64';
 import { toUint8ArrayFromBinary } from '../utils/binary';
 import {
   buildAgentInputPool,
+  combineWithGeneratedCompaction,
   dropOrphanToolCalls,
   extractOutputItemsFromRunItems,
   toAgentInputList,
@@ -654,8 +655,15 @@ async function persistRunItemsToSession(options: {
     }
   }
   const replacesSessionHistory = latestCompactionIndex !== -1;
+  const previousItems = replacesSessionHistory
+    ? await session.getItems()
+    : undefined;
   const itemsToSave = replacesSessionHistory
-    ? generatedItemsToSave.slice(latestCompactionIndex)
+    ? combineWithGeneratedCompaction(
+        [...(previousItems ?? []), ...extraInputItems],
+        generatedItemsToSave,
+        newRunItems,
+      )
     : [...extraInputItems, ...generatedItemsToSave];
 
   if (itemsToSave.length === 0) {
@@ -667,7 +675,7 @@ async function persistRunItemsToSession(options: {
 
   const sanitizedItems = normalizeItemsForSessionPersistence(itemsToSave);
   if (replacesSessionHistory) {
-    await replaceSessionHistory(session, sanitizedItems);
+    await replaceSessionHistory(session, sanitizedItems, previousItems);
   } else {
     await session.addItems(sanitizedItems);
   }
@@ -679,8 +687,9 @@ async function persistRunItemsToSession(options: {
 async function replaceSessionHistory(
   session: Session,
   replacementItems: AgentInputItem[],
+  previousItems?: AgentInputItem[],
 ): Promise<void> {
-  const previousItems = await session.getItems();
+  const previousItemsSnapshot = previousItems ?? (await session.getItems());
   try {
     await session.clearSession();
     await session.addItems(replacementItems);
@@ -688,11 +697,11 @@ async function replaceSessionHistory(
     try {
       const currentItems = await session.getItems();
       const unchanged =
-        currentItems.length === previousItems.length &&
+        currentItems.length === previousItemsSnapshot.length &&
         currentItems.every(
           (item, index) =>
             getAgentInputItemKey(item) ===
-            getAgentInputItemKey(previousItems[index]),
+            getAgentInputItemKey(previousItemsSnapshot[index]),
         );
       if (!unchanged) {
         for (let index = 0; index < currentItems.length; index += 1) {
@@ -700,7 +709,7 @@ async function replaceSessionHistory(
             break;
           }
         }
-        await session.addItems(previousItems);
+        await session.addItems(previousItemsSnapshot);
         logger.warn(
           'Restored previous session history after compaction replacement failed.',
           error,

--- a/packages/agents-core/src/runner/streaming.ts
+++ b/packages/agents-core/src/runner/streaming.ts
@@ -1,6 +1,7 @@
 import logger from '../logger';
 import { RunItemStreamEvent, RunItemStreamEventName } from '../events';
 import {
+  RunCompactionItem,
   RunHandoffCallItem,
   RunHandoffOutputItem,
   RunItem,
@@ -61,6 +62,9 @@ function getRunItemStreamEventName(
   }
   if (item instanceof RunReasoningItem) {
     return 'reasoning_item_created';
+  }
+  if (item instanceof RunCompactionItem) {
+    return 'compaction_item_created';
   }
   if (item instanceof RunToolApprovalItem) {
     return 'tool_approval_requested';

--- a/packages/agents-core/test/extensions/handoffFilters.test.ts
+++ b/packages/agents-core/test/extensions/handoffFilters.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from 'vitest';
 import { removeAllTools } from '../../src/extensions';
 import {
+  RunCompactionItem,
   RunHandoffCallItem,
   RunHandoffOutputItem,
   RunMessageOutputItem,
@@ -105,6 +106,11 @@ const reasoningItem: protocol.ReasoningItem = {
   content: [{ type: 'input_text', text: 'thinking' }],
 };
 
+const compactionItem: protocol.CompactionItem = {
+  type: 'compaction',
+  encrypted_content: 'opaque-history',
+};
+
 const hostedMcpApprovalRequest: protocol.HostedToolCallItem = {
   type: 'hosted_tool_call',
   id: 'approval-1',
@@ -146,6 +152,7 @@ describe('removeAllTools', () => {
     const result = removeAllTools({
       inputHistory: 'keep me',
       preHandoffItems: [
+        new RunCompactionItem(compactionItem, TEST_AGENT),
         new RunHandoffCallItem(TEST_MODEL_FUNCTION_CALL, TEST_AGENT),
         message,
         new RunToolSearchCallItem(toolSearchCall, TEST_AGENT),
@@ -186,6 +193,7 @@ describe('removeAllTools', () => {
       applyPatchCall,
       applyPatchCallResult,
       reasoningItem,
+      compactionItem,
     ];
 
     const result = removeAllTools({
@@ -195,7 +203,7 @@ describe('removeAllTools', () => {
     });
 
     expect(result.inputHistory).toStrictEqual([userMessage]);
-    expect(history).toHaveLength(13);
+    expect(history).toHaveLength(14);
     expect((result.inputHistory as AgentInputItem[])[0]).toBe(userMessage);
   });
 });

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -2739,6 +2739,51 @@ describe('Runner.run', () => {
       expect(historyReasoning).not.toHaveProperty('id');
     });
 
+    it('sends compaction outputs unchanged on the next turn', async () => {
+      const compaction: protocol.CompactionItem = {
+        type: 'compaction',
+        id: 'cmp_follow_up',
+        encrypted_content: 'opaque-follow-up-payload',
+        created_by: 'server',
+      };
+      class RequestRecordingModel extends FakeModel {
+        readonly requests: ModelRequest[] = [];
+
+        override async getResponse(
+          request: ModelRequest,
+        ): Promise<ModelResponse> {
+          this.requests.push(request);
+          return super.getResponse(request);
+        }
+      }
+
+      const model = new RequestRecordingModel([
+        {
+          output: [compaction, TEST_MODEL_FUNCTION_CALL],
+          usage: new Usage(),
+        },
+        {
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'CompactionContinuationAgent',
+        model,
+        tools: [TEST_TOOL],
+      });
+
+      const result = await run(agent, 'hello');
+
+      expect(result.finalOutput).toBe('done');
+      expect(model.requests).toHaveLength(2);
+      expect(
+        getRequestInputItems(model.requests[1]).find(
+          (item) => item.type === 'compaction',
+        ),
+      ).toEqual(compaction);
+    });
+
     it('allows per-run reasoningItemIdPolicy to override runner defaults', async () => {
       class RequestRecordingModel implements Model {
         readonly requests: ModelRequest[] = [];

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -2777,11 +2777,8 @@ describe('Runner.run', () => {
 
       expect(result.finalOutput).toBe('done');
       expect(model.requests).toHaveLength(2);
-      expect(
-        getRequestInputItems(model.requests[1]).find(
-          (item) => item.type === 'compaction',
-        ),
-      ).toEqual(compaction);
+      expect(getRequestInputItems(model.requests[1])[0]).toEqual(compaction);
+      expect(result.history[0]).toEqual(compaction);
     });
 
     it('allows per-run reasoningItemIdPolicy to override runner defaults', async () => {

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -184,10 +184,7 @@ describe('RunState', () => {
 
     expect(restored._generatedItems[0]).toBeInstanceOf(RunCompactionItem);
     expect(restored._generatedItems[0].rawItem).toEqual(rawItem);
-    expect(restored.history).toEqual([
-      { type: 'message', role: 'user', content: 'input' },
-      rawItem,
-    ]);
+    expect(restored.history).toEqual([rawItem]);
   });
 
   it('preserves reasoningItemIdPolicy after serialization', async () => {

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -957,6 +957,36 @@ describe('RunState', () => {
     expect(restored._currentAgent).toBe(agent);
   });
 
+  it.each(['modelResponses', 'lastModelResponse'] as const)(
+    'rejects schema version 1.12 compaction in %s',
+    async (responseField) => {
+      const agent = new Agent({ name: 'LegacyCompactionAgent' });
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      const response = {
+        usage: new Usage(),
+        output: [
+          {
+            type: 'compaction',
+            encrypted_content: 'opaque-history',
+          } satisfies protocol.CompactionItem,
+        ],
+      };
+      if (responseField === 'modelResponses') {
+        state._modelResponses = [response];
+      } else {
+        state._lastTurnResponse = response;
+      }
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.12';
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow(
+        'Run state schema version 1.12 cannot safely resume Responses compaction outputs',
+      );
+    },
+  );
+
   it('rejects schema version 1.7 payloads with tool_search items during deserialization', async () => {
     const context = new RunContext();
     const agent = new Agent({ name: 'Agent18' });

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -653,6 +653,12 @@ describe('RunState', () => {
       JSON.stringify({ ...json, $schemaVersion: '1.11' as const }),
     );
     expect(restoredFromSchema111._currentAgent).toBe(childB);
+
+    const restoredFromSchema112 = await RunState.fromString(
+      root,
+      JSON.stringify({ ...json, $schemaVersion: '1.12' as const }),
+    );
+    expect(restoredFromSchema112._currentAgent).toBe(childB);
   });
 
   it('keeps literal identity suffixes from colliding with generated identities', () => {
@@ -1030,7 +1036,7 @@ describe('RunState', () => {
       ),
     );
 
-    for (const $schemaVersion of ['1.8', '1.10', '1.11'] as const) {
+    for (const $schemaVersion of ['1.8', '1.10', '1.11', '1.12'] as const) {
       const jsonVersion = state.toJSON() as any;
       jsonVersion.$schemaVersion = $schemaVersion;
       const restored = await RunState.fromString(

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -987,6 +987,39 @@ describe('RunState', () => {
     },
   );
 
+  it.each(['conversationId', 'previousResponseId'] as const)(
+    'accepts schema version 1.12 compaction with %s',
+    async (serverContextField) => {
+      const agent = new Agent({ name: 'ManagedLegacyCompactionAgent' });
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._modelResponses = [
+        {
+          usage: new Usage(),
+          output: [
+            {
+              type: 'compaction',
+              encrypted_content: 'opaque-history',
+            } satisfies protocol.CompactionItem,
+          ],
+        },
+      ];
+      state.setConversationContext(
+        serverContextField === 'conversationId' ? 'conv-legacy' : undefined,
+        serverContextField === 'previousResponseId' ? 'resp-legacy' : undefined,
+      );
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.12';
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._conversationId).toBe(state._conversationId);
+      expect(restored._previousResponseId).toBe(state._previousResponseId);
+    },
+  );
+
   it('rejects schema version 1.7 payloads with tool_search items during deserialization', async () => {
     const context = new RunContext();
     const agent = new Agent({ name: 'Agent18' });

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -12,6 +12,7 @@ import { RunContext } from '../src/runContext';
 import { Agent } from '../src/agent';
 import { Usage } from '../src/usage';
 import {
+  RunCompactionItem,
   RunToolApprovalItem as ToolApprovalItem,
   RunMessageOutputItem,
   RunReasoningItem,
@@ -166,6 +167,27 @@ describe('RunState', () => {
 
     const restored = await RunState.fromString(agent, state.toString());
     expect(restored.history).toEqual(state.history);
+  });
+
+  it('preserves compaction items after serialization', async () => {
+    const agent = new Agent({ name: 'CompactionState' });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    const rawItem: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_state',
+      encrypted_content: 'opaque-state-payload',
+      created_by: 'server',
+    };
+    state._generatedItems.push(new RunCompactionItem(rawItem, agent));
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(restored._generatedItems[0]).toBeInstanceOf(RunCompactionItem);
+    expect(restored._generatedItems[0].rawItem).toEqual(rawItem);
+    expect(restored.history).toEqual([
+      { type: 'message', role: 'user', content: 'input' },
+      rawItem,
+    ]);
   });
 
   it('preserves reasoningItemIdPolicy after serialization', async () => {
@@ -916,6 +938,20 @@ describe('RunState', () => {
 
     expect(restored._lastTurnResponse?.responseId).toBe('resp_16');
     expect(restored._lastTurnResponse?.requestId).toBe('req_16');
+  });
+
+  it('accepts schema version 1.12 payloads during deserialization', async () => {
+    const agent = new Agent({ name: 'Agent112' });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const jsonVersion = state.toJSON() as any;
+    jsonVersion.$schemaVersion = '1.12';
+
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(jsonVersion),
+    );
+
+    expect(restored._currentAgent).toBe(agent);
   });
 
   it('rejects schema version 1.7 payloads with tool_search items during deserialization', async () => {

--- a/packages/agents-core/test/runner/items.helpers.test.ts
+++ b/packages/agents-core/test/runner/items.helpers.test.ts
@@ -16,6 +16,23 @@ import type { AgentInputItem } from '../../src/types';
 import * as protocol from '../../src/types/protocol';
 
 describe('prepareModelInputItems', () => {
+  it('preserves caller-provided compacted windows', () => {
+    const retainedMessage = {
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'output_text', text: 'retained' }],
+    } as AgentInputItem;
+    const compaction = {
+      type: 'compaction',
+      encrypted_content: 'opaque-history',
+    } as AgentInputItem;
+
+    expect(prepareModelInputItems([retainedMessage, compaction], [])).toEqual([
+      retainedMessage,
+      compaction,
+    ]);
+  });
+
   it('drops orphan generated hosted shell calls', () => {
     const agent = new Agent({ name: 'HelperAgent' });
     const shellCall = new RunToolCallItem(

--- a/packages/agents-core/test/runner/items.helpers.test.ts
+++ b/packages/agents-core/test/runner/items.helpers.test.ts
@@ -2,14 +2,18 @@ import { describe, expect, it } from 'vitest';
 
 import { Agent } from '../../src/agent';
 import {
+  RunCompactionItem,
   RunMessageOutputItem,
   RunReasoningItem,
   RunToolCallItem,
   RunToolCallOutputItem,
+  RunToolSearchOutputItem,
 } from '../../src/items';
 import {
   dropOrphanToolCalls,
   extractOutputItemsFromRunItems,
+  getCompactionToolSearchOutputs,
+  getTurnInput,
   prepareModelInputItems,
 } from '../../src/runner/items';
 import type { AgentInputItem } from '../../src/types';
@@ -30,6 +34,60 @@ describe('prepareModelInputItems', () => {
     expect(prepareModelInputItems([retainedMessage, compaction], [])).toEqual([
       retainedMessage,
       compaction,
+    ]);
+  });
+
+  it('carries loaded deferred tool state in generated compaction metadata', () => {
+    const agent = new Agent({ name: 'ToolSearchAgent' });
+    const toolSearchOutput = new RunToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        id: 'ts_output',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'get_shipping_eta',
+          },
+        ],
+      },
+      agent,
+    );
+    const compaction = new RunCompactionItem(
+      {
+        type: 'compaction',
+        encrypted_content: 'opaque-history',
+      },
+      agent,
+    );
+
+    const generatedItems = [toolSearchOutput, compaction];
+    const prepared = prepareModelInputItems('hello', generatedItems);
+    const history = getTurnInput('hello', generatedItems);
+
+    expect(prepared).toEqual(history);
+    expect(prepared).toHaveLength(1);
+    expect(prepared[0]?.type).toBe('compaction');
+    expect(getCompactionToolSearchOutputs(prepared[0]!, agent.name)).toEqual([
+      toolSearchOutput.rawItem,
+    ]);
+    expect(getCompactionToolSearchOutputs(prepared[0]!, 'OtherAgent')).toEqual(
+      [],
+    );
+
+    const nextCompaction = new RunCompactionItem(
+      {
+        type: 'compaction',
+        encrypted_content: 'next-opaque-history',
+      },
+      agent,
+    );
+    const repeated = getTurnInput(
+      [toolSearchOutput.rawItem, ...history],
+      [nextCompaction],
+    );
+    expect(getCompactionToolSearchOutputs(repeated[0]!, agent.name)).toEqual([
+      toolSearchOutput.rawItem,
     ]);
   });
 

--- a/packages/agents-core/test/runner/modelOutputs.test.ts
+++ b/packages/agents-core/test/runner/modelOutputs.test.ts
@@ -5,6 +5,7 @@ import { Agent } from '../../src/agent';
 import { ModelBehaviorError, UserError } from '../../src/errors';
 import { handoff } from '../../src/handoff';
 import {
+  RunCompactionItem as CompactionItem,
   RunHandoffCallItem as HandoffCallItem,
   RunMessageOutputItem as MessageOutputItem,
   RunReasoningItem as ReasoningItem,
@@ -72,6 +73,29 @@ function createLegacyNamespacedTool<T extends Record<string, any>>(
 }
 
 describe('processModelResponse', () => {
+  it('preserves compaction outputs as run items', () => {
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_1',
+      encrypted_content: 'opaque-payload',
+      created_by: 'server',
+    };
+
+    const result = processModelResponse(
+      {
+        output: [compaction],
+        usage: new Usage(),
+      },
+      TEST_AGENT,
+      [],
+      [],
+    );
+
+    expect(result.newItems).toHaveLength(1);
+    expect(result.newItems[0]).toBeInstanceOf(CompactionItem);
+    expect(result.newItems[0].rawItem).toBe(compaction);
+  });
+
   it('processes message outputs and tool calls', () => {
     const modelResponse: ModelResponse = TEST_MODEL_RESPONSE_WITH_FUNCTION;
 
@@ -709,8 +733,13 @@ describe('processModelResponse', () => {
       status: 'completed',
       arguments: '{"accountId":"acct_42"}',
     };
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_async',
+      encrypted_content: 'opaque-async-payload',
+    };
     const modelResponse: ModelResponse = {
-      output: [toolSearchCall, functionCall],
+      output: [compaction, toolSearchCall, functionCall],
       usage: new Usage(),
     };
     const agent = new Agent({
@@ -728,17 +757,20 @@ describe('processModelResponse', () => {
     );
 
     expect(result.newItems.map((item) => item.type)).toEqual([
+      'compaction_item',
       'tool_search_call_item',
       'tool_search_output_item',
       'tool_call_item',
     ]);
+    expect(result.newItems[0]).toBeInstanceOf(CompactionItem);
+    expect(result.newItems[0].rawItem).toBe(compaction);
     expect(result.functions).toEqual([
       {
         toolCall: functionCall,
         tool: lookupAccount,
       },
     ]);
-    expect((result.newItems[1] as ToolSearchOutputItem).rawItem).toMatchObject({
+    expect((result.newItems[2] as ToolSearchOutputItem).rawItem).toMatchObject({
       type: 'tool_search_output',
       providerData: {
         call_id: 'call_tool_search_lookup',

--- a/packages/agents-core/test/runner/modelOutputs.test.ts
+++ b/packages/agents-core/test/runner/modelOutputs.test.ts
@@ -19,6 +19,7 @@ import {
   processModelResponse,
   processModelResponseAsync,
 } from '../../src/runner/modelOutputs';
+import { getTurnInput } from '../../src/runner/items';
 import { RunContext } from '../../src/runContext';
 import { RunState } from '../../src/runState';
 import {
@@ -1113,6 +1114,68 @@ describe('processModelResponse', () => {
       tool: shippingEta,
     });
     expect(result.toolsUsed).toEqual(['get_shipping_eta']);
+  });
+
+  it('restores deferred tool state from compacted history', () => {
+    const shippingEta = tool({
+      name: 'get_shipping_eta',
+      description: 'Look up a shipping ETA.',
+      parameters: z.object({
+        trackingNumber: z.string(),
+      }),
+      deferLoading: true,
+      execute: async () => 'tomorrow',
+    });
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_shipping_eta',
+      callId: 'call_shipping_eta',
+      name: 'get_shipping_eta',
+      namespace: 'get_shipping_eta',
+      status: 'completed',
+      arguments: '{"trackingNumber":"ZX-123"}',
+    };
+    const toolSearchOutput = new ToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        id: 'ts_output_shipping_eta',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            functionName: 'get_shipping_eta',
+            namespace: 'get_shipping_eta',
+          },
+        ],
+      },
+      TEST_AGENT,
+    );
+    const compaction = new CompactionItem(
+      {
+        type: 'compaction',
+        encrypted_content: 'opaque-tool-search-history',
+      },
+      TEST_AGENT,
+    );
+    const priorItems = getTurnInput('', [toolSearchOutput, compaction]);
+
+    const result = processModelResponse(
+      {
+        output: [functionCall],
+        usage: new Usage(),
+      },
+      TEST_AGENT,
+      [shippingEta],
+      [],
+      priorItems,
+    );
+
+    expect(result.functions).toEqual([
+      {
+        toolCall: functionCall,
+        tool: shippingEta,
+      },
+    ]);
   });
 
   it('does not treat tool_search outputs from other agents as loaded for the current agent', () => {

--- a/packages/agents-core/test/runner/sessionPersistence.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.test.ts
@@ -37,7 +37,10 @@ import type {
   OpenAIResponsesCompactionResult,
   Session,
 } from '../../src/memory/session';
-import { toAgentInputList } from '../../src/runner/items';
+import {
+  getCompactionToolSearchOutputs,
+  toAgentInputList,
+} from '../../src/runner/items';
 import { tool } from '../../src/tool';
 import type { FunctionTool } from '../../src/tool';
 import { Usage, RequestUsage } from '../../src/usage';
@@ -1390,6 +1393,60 @@ describe('saveToSession', () => {
         { type: 'message', role: 'user', content: 'next input' },
       ],
     });
+  });
+
+  it('preserves deferred tool state when compaction replaces session history', async () => {
+    const textAgent = new Agent<UnknownContext, 'text'>({
+      name: 'ToolSearchCompactionSessionAgent',
+      outputType: 'text',
+      instructions: 'test',
+    });
+    const agent = textAgent as unknown as Agent<
+      UnknownContext,
+      AgentOutputType
+    >;
+    const toolSearchOutput: protocol.ToolSearchOutputItem = {
+      type: 'tool_search_output',
+      id: 'ts_output_shipping_eta',
+      status: 'completed',
+      tools: [
+        {
+          type: 'tool_reference',
+          functionName: 'get_shipping_eta',
+        },
+      ],
+    };
+    const session = new MemorySession();
+    session.items = [toolSearchOutput];
+    const state = new RunState<
+      UnknownContext,
+      Agent<UnknownContext, AgentOutputType>
+    >(
+      new RunContext<UnknownContext>(undefined as UnknownContext),
+      'current input',
+      agent,
+      10,
+    );
+    state._generatedItems = [
+      new CompactionItem(
+        {
+          type: 'compaction',
+          encrypted_content: 'opaque-tool-search-history',
+        },
+        textAgent,
+      ),
+    ];
+
+    await saveToSession(
+      session,
+      toAgentInputList(state._originalInput),
+      new RunResult(state),
+    );
+
+    expect(session.items).toHaveLength(1);
+    expect(
+      getCompactionToolSearchOutputs(session.items[0]!, textAgent.name),
+    ).toEqual([toolSearchOutput]);
   });
 
   it('restores persisted history when compaction replacement fails', async () => {

--- a/packages/agents-core/test/runner/sessionPersistence.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../../src';
 import { Agent, AgentOutputType } from '../../src/agent';
 import {
+  RunCompactionItem as CompactionItem,
   RunHandoffOutputItem as HandoffOutputItem,
   RunMessageOutputItem as MessageOutputItem,
   RunReasoningItem as ReasoningItem,
@@ -45,6 +46,7 @@ import type { AgentInputItem, UnknownContext } from '../../src/types';
 import * as protocol from '../../src/types/protocol';
 import { FakeModelProvider, TEST_AGENT, fakeModelMessage } from '../stubs';
 import logger from '../../src/logger';
+import { allowConsole } from '../../../../helpers/tests/console-guard';
 
 beforeAll(() => {
   setTracingDisabled(true);
@@ -1337,6 +1339,115 @@ describe('saveToSession', () => {
       this.items = [];
     }
   }
+
+  it('replaces persisted history after generated compaction', async () => {
+    const textAgent = new Agent<UnknownContext, 'text'>({
+      name: 'CompactionSessionAgent',
+      outputType: 'text',
+      instructions: 'test',
+    });
+    const agent = textAgent as unknown as Agent<
+      UnknownContext,
+      AgentOutputType
+    >;
+    const session = new MemorySession();
+    session.items = [
+      { type: 'message', role: 'user', content: 'old input' },
+      fakeModelMessage('old output'),
+    ];
+    const state = new RunState<
+      UnknownContext,
+      Agent<UnknownContext, AgentOutputType>
+    >(
+      new RunContext<UnknownContext>(undefined as UnknownContext),
+      'current input',
+      agent,
+      10,
+    );
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      encrypted_content: 'opaque-history',
+    };
+    const afterCompaction = fakeModelMessage('after compaction');
+    state._generatedItems = [
+      new CompactionItem(compaction, textAgent),
+      new MessageOutputItem(afterCompaction, textAgent),
+    ];
+
+    await saveToSession(
+      session,
+      toAgentInputList(state._originalInput),
+      new RunResult(state),
+    );
+
+    expect(session.items).toEqual([compaction, afterCompaction]);
+    await expect(
+      prepareInputItemsWithSession('next input', session),
+    ).resolves.toMatchObject({
+      preparedInput: [
+        compaction,
+        afterCompaction,
+        { type: 'message', role: 'user', content: 'next input' },
+      ],
+    });
+  });
+
+  it('restores persisted history when compaction replacement fails', async () => {
+    allowConsole(['warn']);
+
+    class FailingReplacementSession extends MemorySession {
+      failNextAdd = true;
+
+      override async addItems(items: AgentInputItem[]): Promise<void> {
+        if (this.failNextAdd) {
+          this.failNextAdd = false;
+          this.items.push(items[0]);
+          throw new Error('replacement failed');
+        }
+        await super.addItems(items);
+      }
+    }
+
+    const textAgent = new Agent<UnknownContext, 'text'>({
+      name: 'FailingCompactionSessionAgent',
+      outputType: 'text',
+      instructions: 'test',
+    });
+    const agent = textAgent as unknown as Agent<
+      UnknownContext,
+      AgentOutputType
+    >;
+    const session = new FailingReplacementSession();
+    const previousItems = [
+      { type: 'message', role: 'user', content: 'old input' },
+      fakeModelMessage('old output'),
+    ] satisfies AgentInputItem[];
+    session.items = structuredClone(previousItems);
+    const state = new RunState<
+      UnknownContext,
+      Agent<UnknownContext, AgentOutputType>
+    >(
+      new RunContext<UnknownContext>(undefined as UnknownContext),
+      'current input',
+      agent,
+      10,
+    );
+    state._generatedItems = [
+      new CompactionItem(
+        { type: 'compaction', encrypted_content: 'opaque-history' },
+        textAgent,
+      ),
+    ];
+
+    await expect(
+      saveToSession(
+        session,
+        toAgentInputList(state._originalInput),
+        new RunResult(state),
+      ),
+    ).rejects.toThrow('replacement failed');
+    expect(session.items).toEqual(previousItems);
+  });
 
   it('does not require a process global for debug session logging', async () => {
     const processDescriptor = Object.getOwnPropertyDescriptor(

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -11,6 +11,7 @@ import { Agent, AgentOutputType } from '../../src/agent';
 import { saveAgentToolRunResult } from '../../src/agentToolRunResults';
 import { getAgentToolParentRunConfigFromDetails } from '../../src/agentToolRunConfig';
 import {
+  RunCompactionItem as CompactionItem,
   RunHandoffCallItem as HandoffCallItem,
   RunHandoffOutputItem as HandoffOutputItem,
   RunMessageOutputItem as MessageOutputItem,
@@ -548,6 +549,14 @@ describe('addStepToRunResult', () => {
       } as any,
       agent,
     );
+    const compactionItem = new CompactionItem(
+      {
+        type: 'compaction',
+        id: 'cmp_event',
+        encrypted_content: 'opaque-event-payload',
+      },
+      agent,
+    );
 
     const step: any = {
       newStepItems: [
@@ -559,6 +568,7 @@ describe('addStepToRunResult', () => {
         toolCallItem,
         toolOutputItem,
         reasoningItem,
+        compactionItem,
       ],
     };
 
@@ -580,6 +590,7 @@ describe('addStepToRunResult', () => {
       'tool_called',
       'tool_output',
       'reasoning_item_created',
+      'compaction_item_created',
     ]);
   });
 


### PR DESCRIPTION
## Summary

  Fixes stateless Responses API runs dropping encrypted server-side compaction items.

  ## Problem

  `processModelResponse()` accepted `compaction` protocol outputs but did not convert them into run items. As a result, compaction outputs were omitted from subsequent model input, potentially triggering repeated compaction of the same history.
  
  This causes a problem when users have ZDR enabled and cannot rely on remote responses API state.

  ## Changes

  - Add and export `RunCompactionItem`.
  - Preserve compaction outputs across synchronous and asynchronous response processing.
  - Persist compaction items in RunState schema `1.13`.
  - Emit `compaction_item_created` streaming events.
  - Document the new run item and event.
  - Add regression coverage for continuation, serialization, and streaming.

  The encrypted compaction payload remains opaque and unchanged.