### PR TITLE
chore: add package bugs metadata

### DIFF
--- a/.changeset/solid-loops-hang.md
+++ b/.changeset/solid-loops-hang.md
@@ -1,0 +1,8 @@
+---
+"@openai/agents-core": patch
+"@openai/agents-openai": patch
+"@openai/agents-realtime": patch
+"@openai/agents": patch
+---
+
+Add npm bugs metadata.

--- a/.changeset/solid-loops-hang.md
+++ b/.changeset/solid-loops-hang.md
@@ -1,5 +1,6 @@
 ---
 "@openai/agents-core": patch
+"@openai/agents-extensions": patch
 "@openai/agents-openai": patch
 "@openai/agents-realtime": patch
 "@openai/agents": patch

--- a/packages/agents-core/package.json
+++ b/packages/agents-core/package.json
@@ -2,6 +2,9 @@
   "name": "@openai/agents-core",
   "repository": "https://github.com/openai/openai-agents-js",
   "homepage": "https://openai.github.io/openai-agents-js/",
+  "bugs": {
+    "url": "https://github.com/openai/openai-agents-js/issues"
+  },
   "version": "0.11.6",
   "description": "The OpenAI Agents SDK is a lightweight yet powerful framework for building multi-agent workflows.",
   "author": "OpenAI <support@openai.com>",

--- a/packages/agents-extensions/package.json
+++ b/packages/agents-extensions/package.json
@@ -2,6 +2,9 @@
   "name": "@openai/agents-extensions",
   "repository": "https://github.com/openai/openai-agents-js",
   "homepage": "https://openai.github.io/openai-agents-js/",
+  "bugs": {
+    "url": "https://github.com/openai/openai-agents-js/issues"
+  },
   "version": "0.11.6",
   "description": "Extensions for the OpenAI Agents SDK",
   "author": "OpenAI <support@openai.com>",

--- a/packages/agents-openai/package.json
+++ b/packages/agents-openai/package.json
@@ -2,6 +2,9 @@
   "name": "@openai/agents-openai",
   "repository": "https://github.com/openai/openai-agents-js",
   "homepage": "https://openai.github.io/openai-agents-js/",
+  "bugs": {
+    "url": "https://github.com/openai/openai-agents-js/issues"
+  },
   "version": "0.11.6",
   "description": "The OpenAI Agents SDK is a lightweight yet powerful framework for building multi-agent workflows.",
   "author": "OpenAI <support@openai.com>",

--- a/packages/agents-realtime/package.json
+++ b/packages/agents-realtime/package.json
@@ -2,6 +2,9 @@
   "name": "@openai/agents-realtime",
   "repository": "https://github.com/openai/openai-agents-js",
   "homepage": "https://openai.github.io/openai-agents-js/",
+  "bugs": {
+    "url": "https://github.com/openai/openai-agents-js/issues"
+  },
   "version": "0.11.6",
   "description": "The OpenAI Agents SDK is a lightweight yet powerful framework for building multi-agent workflows. This package contains the logic for building realtime voice agents on the server or in the browser.",
   "author": "OpenAI <support@openai.com>",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -2,6 +2,9 @@
   "name": "@openai/agents",
   "repository": "https://github.com/openai/openai-agents-js",
   "homepage": "https://openai.github.io/openai-agents-js/",
+  "bugs": {
+    "url": "https://github.com/openai/openai-agents-js/issues"
+  },
   "version": "0.11.6",
   "description": "The OpenAI Agents SDK is a lightweight yet powerful framework for building multi-agent workflows.",
   "author": "OpenAI <support@openai.com>",


### PR DESCRIPTION
## Summary

Adds npm `bugs.url` metadata for the published Agents SDK packages.

## Why

The packages already include `repository` and `homepage` fields. Adding `bugs.url` points npm users and package tooling to the repository issue tracker for support and bug reports.

## Testing

- Parsed all updated package manifests with Node `JSON.parse`.
- Ran `git diff --check`.
