### PR TITLE
chore: add npm bugs metadata to all published packages

### DIFF
--- a/packages/agents-core/package.json
+++ b/packages/agents-core/package.json
@@ -132,4 +132,8 @@
   "files": [
     "dist"
   ]
+,
+  "bugs": {
+    "url": "https://github.com/openai/openai-agents-js/issues"
+  }
 }

--- a/packages/agents-extensions/package.json
+++ b/packages/agents-extensions/package.json
@@ -183,4 +183,8 @@
       ]
     }
   }
+,
+  "bugs": {
+    "url": "https://github.com/openai/openai-agents-js/issues"
+  }
 }

--- a/packages/agents-openai/package.json
+++ b/packages/agents-openai/package.json
@@ -43,4 +43,8 @@
   "files": [
     "dist"
   ]
+,
+  "bugs": {
+    "url": "https://github.com/openai/openai-agents-js/issues"
+  }
 }

--- a/packages/agents-realtime/package.json
+++ b/packages/agents-realtime/package.json
@@ -78,4 +78,8 @@
   "files": [
     "dist"
   ]
+,
+  "bugs": {
+    "url": "https://github.com/openai/openai-agents-js/issues"
+  }
 }

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -80,4 +80,8 @@
       ]
     }
   }
+,
+  "bugs": {
+    "url": "https://github.com/openai/openai-agents-js/issues"
+  }
 }


### PR DESCRIPTION
All 5 `@openai/agents-*` packages are missing the `bugs` field in their npm metadata. This adds `bugs.url` pointing to the GitHub issue tracker.

No runtime code, dependencies, tests, or build configuration are changed.