### PR TITLE
fix(realtime): capture user transcript when a message triggers a tool…

### DIFF
--- a/.changeset/realtime-141-transcript-on-toolcall.md
+++ b/.changeset/realtime-141-transcript-on-toolcall.md
@@ -1,0 +1,11 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: capture realtime user transcript when a message triggers a tool call (#141)
+
+When a user's spoken message triggered a tool call, the `conversation.item.added`/`.retrieved` seeding event that normally creates the user message item did not arrive, so `updateRealtimeHistory`'s `input_audio_transcription.completed` branch no-op'd and the user's transcribed message was silently dropped from `session.history()`.
+
+`updateRealtimeHistory` is now self-sufficient: if no item with the transcript's `item_id` exists it creates the user message (keyed on id-presence so no duplicate is appended), and if a matching user item has no `input_audio` entry it adds one. The session transcript handler now emits `history_added` (before `history_updated`) for items it creates, mirroring the `item_update` handler. A user-side analog of `preserveAssistantAudioTranscripts` keeps a captured transcript from being clobbered by a later `item_update` carrying a null transcript. The assistant audio-transcript path is unchanged.
+
+Note: positional ordering of a created item relative to the triggering tool call is best-effort (the transcription event carries no `previous_item_id`); the fix guarantees the message is present, not its exact position.

--- a/packages/agents-realtime/src/realtimeSession.ts
+++ b/packages/agents-realtime/src/realtimeSession.ts
@@ -779,12 +779,27 @@ export class RealtimeSession<
       ) {
         try {
           const completedEvent = event as InputAudioTranscriptionCompletedEvent;
+          // Mirror the item_update handler's history_added parity: when the
+          // transcript event creates a brand-new item (the seeding event never
+          // arrived — issue #141), emit history_added before history_updated so
+          // consumers listening only to history_added still see the user message.
+          const isNew = !this.#history.some(
+            (item) => item.itemId === completedEvent.item_id,
+          );
           this.#history = updateRealtimeHistory(
             this.#history,
             completedEvent,
             this.#shouldIncludeAudioData,
           );
           this.#context.context.history = this.#history;
+          if (isNew) {
+            const addedItem = this.#history.find(
+              (item) => item.itemId === completedEvent.item_id,
+            );
+            if (addedItem) {
+              this.emit('history_added', addedItem);
+            }
+          }
           this.emit('history_updated', this.#history);
         } catch (err) {
           this.emit('error', {

--- a/packages/agents-realtime/src/transportLayerEvents.ts
+++ b/packages/agents-realtime/src/transportLayerEvents.ts
@@ -43,6 +43,10 @@ export type TransportLayerAudio = {
 export type InputAudioTranscriptionCompletedEvent = {
   type: 'conversation.item.input_audio_transcription.completed';
   item_id: string;
+  // The index of the audio part within the item's content array. The Realtime
+  // event always carries it (see openaiRealtimeEvents schema); it is optional
+  // here for back-compat with synthetic events and defaults to 0 when absent.
+  content_index?: number;
   transcript: string;
   usage?: {
     type: 'tokens';

--- a/packages/agents-realtime/src/utils.ts
+++ b/packages/agents-realtime/src/utils.ts
@@ -225,6 +225,51 @@ function preserveAssistantAudioTranscripts(
   };
 }
 
+// User input_audio messages can be resent (e.g. a late conversation.item.added /
+// .retrieved after a transcript was already captured) with a null transcript.
+// Mirror preserveAssistantAudioTranscripts for the user role so a late null
+// transcript does not clobber a transcript already in history (issue #141).
+function preserveUserAudioTranscripts(
+  existing: RealtimeMessageItem,
+  incoming: RealtimeMessageItem,
+): RealtimeMessageItem {
+  if (existing.role !== 'user' || incoming.role !== 'user') {
+    return incoming;
+  }
+
+  const mergedContent = incoming.content.map((entry, index) => {
+    if (entry.type !== 'input_audio') {
+      return entry;
+    }
+
+    const transcriptMissing =
+      typeof entry.transcript !== 'string' || entry.transcript.length === 0;
+    if (!transcriptMissing) {
+      return entry;
+    }
+
+    const previousEntry = existing.content[index];
+    if (
+      previousEntry &&
+      previousEntry.type === 'input_audio' &&
+      typeof previousEntry.transcript === 'string' &&
+      previousEntry.transcript.length > 0
+    ) {
+      return {
+        ...entry,
+        transcript: previousEntry.transcript,
+      };
+    }
+
+    return entry;
+  });
+
+  return {
+    ...incoming,
+    content: mergedContent,
+  };
+}
+
 /**
  * Updates the realtime history array based on the incoming event and options.
  * @param history - The current history array.
@@ -239,6 +284,24 @@ export function updateRealtimeHistory(
 ): RealtimeItem[] {
   // Merge transcript into placeholder input_audio message
   if (event.type === 'conversation.item.input_audio_transcription.completed') {
+    // Key create/skip on item-id presence, NOT on the user-message predicate:
+    // when the message triggers a tool call the conversation.item.added /
+    // .retrieved event that normally seeds the user item never arrives, so the
+    // map below would no-op and the transcript would be silently dropped
+    // (issue #141). If no item with this id exists, create the user message so
+    // the transcript is captured; keying on id-presence also avoids appending a
+    // duplicate when an item with this id already exists.
+    const exists = history.some((item) => item.itemId === event.item_id);
+    if (!exists) {
+      const created = {
+        itemId: event.item_id,
+        type: 'message',
+        role: 'user',
+        status: 'completed',
+        content: [{ type: 'input_audio', transcript: event.transcript }],
+      } as unknown as RealtimeItem;
+      return [...history, created];
+    }
     return history.map((item) => {
       if (
         item.itemId === event.item_id &&
@@ -246,15 +309,23 @@ export function updateRealtimeHistory(
         'role' in item &&
         item.role === 'user'
       ) {
-        const updatedContent = item.content.map((entry: any) => {
-          if (entry.type === 'input_audio') {
-            return {
-              ...entry,
-              transcript: event.transcript,
-            };
-          }
-          return entry;
-        });
+        const hasInputAudio = item.content.some(
+          (entry: any) => entry.type === 'input_audio',
+        );
+        const updatedContent = hasInputAudio
+          ? item.content.map((entry: any) => {
+              if (entry.type === 'input_audio') {
+                return {
+                  ...entry,
+                  transcript: event.transcript,
+                };
+              }
+              return entry;
+            })
+          : [
+              ...item.content,
+              { type: 'input_audio', transcript: event.transcript },
+            ];
 
         return {
           ...item,
@@ -278,7 +349,10 @@ export function updateRealtimeHistory(
     const existingItem = history[existingIndex];
     const mergedEvent =
       newEvent.type === 'message' && existingItem.type === 'message'
-        ? preserveAssistantAudioTranscripts(existingItem, newEvent)
+        ? preserveUserAudioTranscripts(
+            existingItem,
+            preserveAssistantAudioTranscripts(existingItem, newEvent),
+          )
         : newEvent;
     // Update existing item
     return history.map((item, idx) => {

--- a/packages/agents-realtime/src/utils.ts
+++ b/packages/agents-realtime/src/utils.ts
@@ -291,14 +291,27 @@ export function updateRealtimeHistory(
     // (issue #141). If no item with this id exists, create the user message so
     // the transcript is captured; keying on id-presence also avoids appending a
     // duplicate when an item with this id already exists.
+    // The event carries the audio part's content_index; honor it so a later
+    // seed (which arrives with the real content array) reconciles the transcript
+    // by the same index instead of clobbering it. Defaults to 0 when absent.
+    const contentIndex =
+      typeof event.content_index === 'number' ? event.content_index : 0;
     const exists = history.some((item) => item.itemId === event.item_id);
     if (!exists) {
+      // Place the transcript's input_audio at contentIndex; earlier slots are
+      // unknown here, so they are minimal input_audio placeholders that a later
+      // seed (carrying the real content array) replaces.
+      const content = Array.from({ length: contentIndex + 1 }, (_, i) =>
+        i === contentIndex
+          ? { type: 'input_audio', transcript: event.transcript }
+          : { type: 'input_audio', transcript: null },
+      );
       const created = {
         itemId: event.item_id,
         type: 'message',
         role: 'user',
         status: 'completed',
-        content: [{ type: 'input_audio', transcript: event.transcript }],
+        content,
       } as unknown as RealtimeItem;
       return [...history, created];
     }
@@ -309,23 +322,32 @@ export function updateRealtimeHistory(
         'role' in item &&
         item.role === 'user'
       ) {
+        const targetIsInputAudio =
+          (item.content[contentIndex] as any)?.type === 'input_audio';
         const hasInputAudio = item.content.some(
           (entry: any) => entry.type === 'input_audio',
         );
-        const updatedContent = hasInputAudio
-          ? item.content.map((entry: any) => {
-              if (entry.type === 'input_audio') {
-                return {
-                  ...entry,
-                  transcript: event.transcript,
-                };
-              }
-              return entry;
-            })
-          : [
-              ...item.content,
-              { type: 'input_audio', transcript: event.transcript },
-            ];
+        let updatedContent;
+        if (targetIsInputAudio) {
+          // Set the transcript on the audio part at the event's content_index.
+          updatedContent = item.content.map((entry: any, i: number) =>
+            i === contentIndex
+              ? { ...entry, transcript: event.transcript }
+              : entry,
+          );
+        } else if (hasInputAudio) {
+          updatedContent = item.content.map((entry: any) => {
+            if (entry.type === 'input_audio') {
+              return { ...entry, transcript: event.transcript };
+            }
+            return entry;
+          });
+        } else {
+          updatedContent = [
+            ...item.content,
+            { type: 'input_audio', transcript: event.transcript },
+          ];
+        }
 
         return {
           ...item,

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -1630,3 +1630,139 @@ describe('RealtimeSession', () => {
     expect(msg!.status).toBe('completed'); // ensure we didn't overwrite server status
   });
 });
+
+describe('issue #141 — transcript captured when a message triggers a tool call', () => {
+  it('creates the user message + fires history_added when the seeding event never arrives (AC-01, AC-03)', async () => {
+    const transport = new FakeTransport();
+    const session = new RealtimeSession(
+      new RealtimeAgent({ name: 'Listener' }),
+      {
+        transport,
+      },
+    );
+    const added: any[] = [];
+    const updated: any[] = [];
+    session.on('history_added', (i) => added.push(i));
+    session.on('history_updated', (h) => updated.push([...h]));
+    await session.connect({ apiKey: 'test-key' });
+
+    transport.emit('*', {
+      type: 'conversation.item.input_audio_transcription.completed',
+      item_id: 'user-1',
+      transcript: 'please transfer to refund',
+    } as any);
+
+    const msg = session.history.find(
+      (i: any) => i.type === 'message' && i.role === 'user',
+    ) as any;
+    expect(msg, 'user message should be in history').toBeTruthy();
+    expect(msg.itemId).toBe('user-1');
+    expect(msg.content[0]?.transcript).toBe('please transfer to refund');
+    expect(added.filter((i) => i.itemId === 'user-1')).toHaveLength(1);
+    expect(updated.length).toBeGreaterThan(0);
+  });
+
+  it('does not duplicate or clobber the transcript on a late null-transcript item_update (AC-04, AC-06)', async () => {
+    const transport = new FakeTransport();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'L' }), {
+      transport,
+    });
+    await session.connect({ apiKey: 'test-key' });
+
+    transport.emit('*', {
+      type: 'conversation.item.input_audio_transcription.completed',
+      item_id: 'user-2',
+      transcript: 'hello world',
+    } as any);
+    // A late seeding event (conversation.item.added/.retrieved) carrying a null
+    // transcript — exactly what the existing stub emits — must not clobber it.
+    transport.emit('item_update', {
+      itemId: 'user-2',
+      type: 'message',
+      role: 'user',
+      status: 'in_progress',
+      content: [{ type: 'input_audio', audio: 'AA==', transcript: null }],
+    } as any);
+
+    const matches = session.history.filter((i: any) => i.itemId === 'user-2');
+    expect(matches).toHaveLength(1);
+    const ia = (matches[0] as any).content.find(
+      (e: any) => e.type === 'input_audio',
+    );
+    expect(ia?.transcript).toBe('hello world');
+  });
+
+  it('captures the transcript on an existing user item with no input_audio entry (AC-07)', async () => {
+    const transport = new FakeTransport();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'L' }), {
+      transport,
+    });
+    await session.connect({ apiKey: 'test-key' });
+
+    transport.emit('item_update', {
+      itemId: 'user-3',
+      type: 'message',
+      role: 'user',
+      status: 'in_progress',
+      content: [{ type: 'input_text', text: 'typed' }],
+    } as any);
+    transport.emit('*', {
+      type: 'conversation.item.input_audio_transcription.completed',
+      item_id: 'user-3',
+      transcript: 'spoken transcript',
+    } as any);
+
+    const item = session.history.find((i: any) => i.itemId === 'user-3') as any;
+    const ia = item.content.find((e: any) => e.type === 'input_audio');
+    expect(ia?.transcript).toBe('spoken transcript');
+  });
+
+  it('leaves the assistant audio-transcript merge path unchanged (AC-09)', async () => {
+    const transport = new FakeTransport();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'L' }), {
+      transport,
+      historyStoreAudio: true,
+    } as any);
+    await session.connect({ apiKey: 'test-key' });
+
+    transport.emit('item_update', {
+      itemId: 'asst-1',
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [
+        { type: 'output_audio', audio: 'AA==', transcript: 'final answer' },
+      ],
+    } as any);
+    // A late resend with a missing transcript must preserve the prior one.
+    transport.emit('item_update', {
+      itemId: 'asst-1',
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [{ type: 'output_audio', audio: 'AA==', transcript: '' }],
+    } as any);
+
+    const item = session.history.find((i: any) => i.itemId === 'asst-1') as any;
+    expect(item.content[0]?.transcript).toBe('final answer');
+  });
+
+  it('keeps the created transcript-only item under default historyStoreAudio=false (AC-05)', async () => {
+    const transport = new FakeTransport();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'L' }), {
+      transport,
+    });
+    await session.connect({ apiKey: 'test-key' });
+
+    transport.emit('*', {
+      type: 'conversation.item.input_audio_transcription.completed',
+      item_id: 'user-5',
+      transcript: 'kept transcript',
+    } as any);
+
+    const item = session.history.find((i: any) => i.itemId === 'user-5') as any;
+    expect(item, 'created item present').toBeTruthy();
+    const ia = item.content.find((e: any) => e.type === 'input_audio');
+    expect(ia?.transcript).toBe('kept transcript');
+  });
+});

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -1765,4 +1765,44 @@ describe('issue #141 — transcript captured when a message triggers a tool call
     const ia = item.content.find((e: any) => e.type === 'input_audio');
     expect(ia?.transcript).toBe('kept transcript');
   });
+
+
+  it('honors content_index so a late seed at that index does not clobber the transcript (Codex P2)', async () => {
+    const transport = new FakeTransport();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'L' }), {
+      transport,
+    });
+    await session.connect({ apiKey: 'test-key' });
+
+    // The audio part is at content_index 1 (not the first content part) and no
+    // seeding event arrives first (tool-call path).
+    transport.emit('*', {
+      type: 'conversation.item.input_audio_transcription.completed',
+      item_id: 'user-ci',
+      content_index: 1,
+      transcript: 'second-part transcript',
+    } as any);
+
+    let item = session.history.find((i: any) => i.itemId === 'user-ci') as any;
+    expect(item, 'created item present').toBeTruthy();
+    expect(item.content[1]?.transcript).toBe('second-part transcript');
+
+    // A late seed arrives with the real content array (text at 0, audio with a
+    // null transcript at 1). The captured transcript at index 1 must survive.
+    transport.emit('item_update', {
+      itemId: 'user-ci',
+      type: 'message',
+      role: 'user',
+      status: 'in_progress',
+      content: [
+        { type: 'input_text', text: 'hi' },
+        { type: 'input_audio', audio: 'AA==', transcript: null },
+      ],
+    } as any);
+
+    item = session.history.find((i: any) => i.itemId === 'user-ci') as any;
+    const matches = session.history.filter((i: any) => i.itemId === 'user-ci');
+    expect(matches).toHaveLength(1);
+    expect(item.content[1]?.transcript).toBe('second-part transcript');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #141. When a user's spoken (input-audio) message **triggers a tool call**, the user's transcribed message was silently dropped from `session.history()` — only the tool call and the assistant reply appeared.

### Root cause

`updateRealtimeHistory` (`packages/agents-realtime/src/utils.ts`) handles `conversation.item.input_audio_transcription.completed` by `history.map(...)`, **merging the transcript into an existing `role:'user'` item**. The user item is normally seeded into history by the transport's `item_update` (emitted on `conversation.item.added` / `.done` / `.retrieved`). On a transcription event the transport instead sends a best-effort `conversation.item.retrieve` and relies on the `conversation.item.retrieved` reply to seed the item.

When the message triggers a tool call, that seeding round-trip is not observed, so **no user item exists when the transcript arrives** → the `map` is a no-op → the transcript (and the user message) is dropped. The SDK was depending on a server event ordering it cannot control.

### Fix (SDK-side, at the root)

- **`updateRealtimeHistory` is now self-sufficient.** The transcription-completed branch keys create/skip on **item-id presence** (not the `role:'user'` predicate, which would append a duplicate when an item with that id already exists). If no item with the transcript's `item_id` exists, it **creates** the user message carrying the transcript; if a matching user item exists but has **no `input_audio` entry**, it appends one.
- **`history_added` parity.** The session's transcript handler now computes `isNew` before the update and emits `history_added` (before `history_updated`) for items it creates, mirroring the `item_update` handler — so consumers listening only to `history_added` also see the user message.
- **No clobber on a late seed.** A new `preserveUserAudioTranscripts` helper (the user-role analog of the existing `preserveAssistantAudioTranscripts`) prevents a later `item_update` carrying a `null`/empty transcript (exactly what the existing stub emits) from overwriting a transcript already captured. The assistant audio-transcript path is unchanged.

### Tests

New regression coverage in `packages/agents-realtime/test/realtimeSession.test.ts`:
- create-if-absent on an unseeded transcription event + `history_added`/`history_updated` fire;
- idempotency + survival: a late `item_update` with `transcript: null` does not duplicate or clobber;
- sibling: an existing user item with no `input_audio` entry captures the transcript;
- assistant path unchanged (no regression);
- created transcript-only item under default `historyStoreAudio=false`.

### Known limitation (intentional, documented)

Positional ordering of a created item relative to the triggering tool call is best-effort — the `input_audio_transcription.completed` event carries no `previous_item_id`, so the created item is appended. The fix guarantees the message is **present**, not its exact position; full positional reconciliation would require the server seeding event the SDK cannot rely on.

## Validation
pnpm build
pnpm -F @openai/agents-realtime exec vitest run test/realtimeSession.test.ts # 53 passed (48 existing + 5 new)
pnpm -r build-check # clean
pnpm lint # clean

A changeset is included (`.changeset/realtime-141-transcript-on-toolcall.md`, `@openai/agents-realtime` patch).
Closes #141