### PR TITLE
fix(openai): honor top-level input_image detail in the Chat Completions converter

### DIFF
--- a/.changeset/chat-completions-input-image-detail.md
+++ b/.changeset/chat-completions-input-image-detail.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix(openai): honor top-level `input_image.detail` in the Chat Completions converter
+
+The Chat Completions converter only read `detail` from `providerData.image_url.detail` and silently dropped the top-level `detail` field, even though the protocol defines it as a top-level field and both the Responses path and the Python SDK honor it. Top-level `detail` is now forwarded (with `providerData.image_url.detail` still taking precedence).

--- a/packages/agents-openai/src/openaiChatCompletionsConverter.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsConverter.ts
@@ -152,6 +152,12 @@ export function extractAllUserContent(
         type: 'image_url',
         image_url: {
           url: imageSource,
+          // Honor the top-level `detail` field, matching the Responses path
+          // (openaiResponsesModel) and the Python SDK. `providerData.image_url.detail`
+          // still takes precedence (spread last) to preserve existing behavior.
+          ...(c.detail !== undefined
+            ? { detail: c.detail as 'auto' | 'low' | 'high' }
+            : {}),
           ...imageUrl,
         },
         ...rest,

--- a/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
@@ -105,6 +105,20 @@ describe('content extraction helpers', () => {
     ]);
   });
 
+  test('extractAllUserContent honors top-level input_image detail', () => {
+    const userContent: protocol.UserMessageItem['content'] = [
+      {
+        type: 'input_image',
+        image: 'http://img',
+        detail: 'low',
+      },
+    ];
+    const converted = extractAllUserContent(userContent);
+    expect(converted).toEqual([
+      { type: 'image_url', image_url: { url: 'http://img', detail: 'low' } },
+    ]);
+  });
+
   test('extractAllUserContent preserves extras but ignores reserved providerData fields', () => {
     const userContent: protocol.UserMessageItem['content'] = [
       {


### PR DESCRIPTION
## Summary

In the Chat Completions converter, the `input_image` branch of `extractAllUserContent` (`packages/agents-openai/src/openaiChatCompletionsConverter.ts`) builds the `image_url` part from `providerData.image_url.detail` but **never reads the top-level `detail` field** — so a caller that sets `detail` at the top level of an `input_image` item has it **silently dropped**.

This is inconsistent with everything else:
- The protocol defines `detail` as a **top-level** field on `InputImage` (`packages/agents-core/src/types/protocol.ts`).
- The **Responses** path honors it: `openaiResponsesModel.ts` → `detail: entry.detail ?? 'auto'`.
- The **Python SDK** honors it: `chatcmpl_converter.py` → `detail = casted_image_param.get("detail", "auto")`.

So `detail` is respected on the Responses path but lost on the Chat Completions path.

## Fix

Forward the top-level `detail` into the `image_url` part. `providerData.image_url.detail` is spread last, so it still takes precedence — the existing `providerData` convention and its tests are unchanged. The fix is additive.

```ts
image_url: {
  url: imageSource,
  ...(c.detail !== undefined ? { detail: c.detail as 'auto' | 'low' | 'high' } : {}),
  ...imageUrl,
},
```

## Verification

Added `extractAllUserContent honors top-level input_image detail` to `packages/agents-openai/test/openaiChatCompletionsConverter.test.ts`. Verified it **fails before** the fix (the top-level `detail` is dropped) and **passes after**, with all 44 existing converter tests still green (45 total). `pnpm build`, `pnpm prettier --check`, and `eslint` are clean. Added a changeset.