### PR TITLE
docs: add Traccia to external tracing processors list

### DIFF
--- a/docs/src/content/docs/guides/tracing.mdx
+++ b/docs/src/content/docs/guides/tracing.mdx
@@ -140,3 +140,4 @@ To customize this default setup, to send traces to alternative or additional bac
 - [Respan](https://www.respan.ai/docs/integrations/openai-agents-sdk)
 - [PromptLayer](https://docs.promptlayer.com/languages/integrations#openai-agents-sdk)
 - [Latitude](https://docs.latitude.so/telemetry/frameworks/openai-agents)
+- [Traccia](https://traccia.ai/docs/integrations/openai-agents)

--- a/docs/src/content/docs/ja/guides/tracing.mdx
+++ b/docs/src/content/docs/ja/guides/tracing.mdx
@@ -123,3 +123,4 @@ Agents SDK には組み込みのトレーシングが含まれており、エー
 - [Respan](https://www.respan.ai/docs/integrations/openai-agents-sdk)
 - [PromptLayer](https://docs.promptlayer.com/languages/integrations#openai-agents-sdk)
 - [Latitude](https://docs.latitude.so/telemetry/frameworks/openai-agents)
+- [Traccia](https://traccia.ai/docs/integrations/openai-agents)

--- a/docs/src/content/docs/ko/guides/tracing.mdx
+++ b/docs/src/content/docs/ko/guides/tracing.mdx
@@ -123,3 +123,4 @@ Agents SDK에는 내장 트레이싱이 포함되어 있어 에이전트 실행 
 - [Respan](https://www.respan.ai/docs/integrations/openai-agents-sdk)
 - [PromptLayer](https://docs.promptlayer.com/languages/integrations#openai-agents-sdk)
 - [Latitude](https://docs.latitude.so/telemetry/frameworks/openai-agents)
+- [Traccia](https://traccia.ai/docs/integrations/openai-agents)

--- a/docs/src/content/docs/zh/guides/tracing.mdx
+++ b/docs/src/content/docs/zh/guides/tracing.mdx
@@ -123,3 +123,4 @@ Span 会自动成为当前 Trace 的一部分，并嵌套在最近的当前 Span
 - [Respan](https://www.respan.ai/docs/integrations/openai-agents-sdk)
 - [PromptLayer](https://docs.promptlayer.com/languages/integrations#openai-agents-sdk)
 - [Latitude](https://docs.latitude.so/telemetry/frameworks/openai-agents)
+- [Traccia](https://traccia.ai/docs/integrations/openai-agents)


### PR DESCRIPTION
Hello from Traccia!

Traccia now supports tracing agents made with OpenAI Agents SDK - [Documentation](https://traccia.ai/docs/integrations/openai-agents)

[Traccia Release v0.1.3](https://github.com/traccia-ai/traccia-node/releases/tag/v0.1.3)
[Traccia NPM v0.1.3](https://www.npmjs.com/package/@traccia/sdk/v/0.1.3)