### PR TITLE
fix(vercel): recover legacy session authentication through the SDK

### DIFF
--- a/.changeset/vercel-legacy-auth-fallback.md
+++ b/.changeset/vercel-legacy-auth-fallback.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: recover expired credentials in legacy Vercel sandbox sessions through SDK authentication

--- a/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
@@ -26,6 +26,7 @@ import {
   encodeNativeSnapshotRef,
   materializeEnvironment,
   posixDirname,
+  providerErrorDetails,
   providerErrorMessage,
   shellQuote,
   serializeRemoteSandboxSessionState,
@@ -174,6 +175,11 @@ export interface VercelSandboxClientOptions extends SandboxClientOptions {
 
 export interface VercelSandboxSessionState extends SandboxSessionState {
   sandboxId: string;
+  /**
+   * Whether authentication is explicitly configured or delegated to the SDK.
+   * Missing values identify session state created before this field existed.
+   */
+  authenticationMode?: 'explicit' | 'sdk';
   projectId?: string;
   teamId?: string;
   token?: string;
@@ -509,23 +515,25 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
     }
   }
 
-  private async resolveSnapshotCredentials(): Promise<VercelCredentials> {
-    const credentials = selectVercelCredentials(this.state, this.credentials);
-    applyVercelCredentials(this.state, credentials);
-    return credentials;
+  private async resolveSnapshotCredentials(): Promise<NormalizedVercelCredentials> {
+    return selectVercelSessionCredentials(this.state, this.credentials);
   }
 
   private async createAndPrepareSandboxFromSnapshot(
     snapshotId: string,
-    credentials: VercelCredentials,
+    credentials: NormalizedVercelCredentials,
   ): Promise<VercelSandboxInstance> {
     const sandbox = await this.createSandboxFromSnapshot(
       snapshotId,
       credentials,
     );
+    const resolvedCredentials = selectVercelSessionCredentials(
+      this.state,
+      this.credentials,
+    );
 
     const replacementSession = new VercelSandboxSession({
-      credentials: { ...this.credentials, ...credentials },
+      credentials: resolvedCredentials,
       sandbox,
       archiveLimits: this.getArchiveLimits(),
       state: {
@@ -556,38 +564,47 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
 
   private async createSandboxFromSnapshot(
     snapshotId: string,
-    credentials: VercelCredentials,
+    credentials: NormalizedVercelCredentials,
   ): Promise<VercelSandboxInstance> {
     const Sandbox = await loadVercelSandboxClass();
-    return await withProviderError(
+    const authentication = await withProviderError(
       'VercelSandboxClient',
       'vercel',
       'restore snapshot',
       async () =>
-        await Sandbox.create({
-          ...credentials,
-          source: {
-            type: 'snapshot',
-            snapshotId,
-          },
-          ...(this.state.runtime ? { runtime: this.state.runtime } : {}),
-          ...(this.state.resources ? { resources: this.state.resources } : {}),
-          ...(this.state.configuredExposedPorts
-            ? { ports: this.state.configuredExposedPorts }
-            : {}),
-          ...(typeof this.state.interactive === 'boolean'
-            ? { interactive: this.state.interactive }
-            : {}),
-          ...(this.state.networkPolicy
-            ? { networkPolicy: this.state.networkPolicy }
-            : {}),
-          ...(typeof this.state.timeoutMs === 'number'
-            ? { timeout: this.state.timeoutMs }
-            : {}),
-          env: this.state.environment,
-        }),
+        await runWithLegacyVercelAuthenticationFallback(
+          this.state,
+          credentials,
+          async (resolvedCredentials) =>
+            await Sandbox.create({
+              ...resolvedCredentials,
+              source: {
+                type: 'snapshot',
+                snapshotId,
+              },
+              ...(this.state.runtime ? { runtime: this.state.runtime } : {}),
+              ...(this.state.resources
+                ? { resources: this.state.resources }
+                : {}),
+              ...(this.state.configuredExposedPorts
+                ? { ports: this.state.configuredExposedPorts }
+                : {}),
+              ...(typeof this.state.interactive === 'boolean'
+                ? { interactive: this.state.interactive }
+                : {}),
+              ...(this.state.networkPolicy
+                ? { networkPolicy: this.state.networkPolicy }
+                : {}),
+              ...(typeof this.state.timeoutMs === 'number'
+                ? { timeout: this.state.timeoutMs }
+                : {}),
+              env: this.state.environment,
+            }),
+        ),
       { snapshotId },
     );
+    applyVercelAuthentication(this.state, authentication);
+    return authentication.value;
   }
 
   private bindRestoredSandbox(
@@ -804,6 +821,7 @@ export class VercelSandboxClient implements SandboxClient<
           state: {
             manifest: resolvedManifest,
             sandboxId: sandbox.sandboxId,
+            authenticationMode: credentials.token ? 'explicit' : 'sdk',
             ...credentials,
             runtime: resolvedOptions.runtime,
             resources: resolvedOptions.resources,
@@ -841,7 +859,7 @@ export class VercelSandboxClient implements SandboxClient<
     state: VercelSandboxSessionState,
     options?: SandboxSessionSerializationOptions,
   ): Promise<Record<string, unknown>> {
-    const credentials = selectVercelCredentials(state, this.options);
+    const credentials = selectVercelSessionCredentials(state, this.options);
     applyVercelCredentials(state, credentials);
     if (
       state.workspacePersistence === 'snapshot' &&
@@ -886,6 +904,7 @@ export class VercelSandboxClient implements SandboxClient<
       ...baseState,
       manifest,
       sandboxId: readString(state, 'sandboxId'),
+      authenticationMode: readVercelAuthenticationMode(state),
       workspacePersistence:
         (state.workspacePersistence as
           | VercelWorkspacePersistence
@@ -917,37 +936,41 @@ export class VercelSandboxClient implements SandboxClient<
     state: VercelSandboxSessionState,
   ): Promise<VercelSandboxSession> {
     const Sandbox = await loadVercelSandboxClass();
-    const credentials = selectVercelCredentials(state, this.options);
-    applyVercelCredentials(state, credentials);
+    const credentials = selectVercelSessionCredentials(state, this.options);
     const resumeFromSnapshot = hasFreshVercelSnapshot(state);
-    const sandbox = resumeFromSnapshot
+    const authentication = resumeFromSnapshot
       ? await withProviderError(
           'VercelSandboxClient',
           'vercel',
           'resume sandbox from snapshot',
           async () =>
-            await Sandbox.create({
-              ...credentials,
-              source: {
-                type: 'snapshot',
-                snapshotId: state.snapshotId!,
-              },
-              ...(state.runtime ? { runtime: state.runtime } : {}),
-              ...(state.resources ? { resources: state.resources } : {}),
-              ...(state.configuredExposedPorts
-                ? { ports: state.configuredExposedPorts }
-                : {}),
-              ...(state.interactive !== undefined
-                ? { interactive: state.interactive }
-                : {}),
-              ...(state.networkPolicy
-                ? { networkPolicy: state.networkPolicy }
-                : {}),
-              ...(state.timeoutMs !== undefined
-                ? { timeout: state.timeoutMs }
-                : {}),
-              env: state.environment,
-            }),
+            await runWithLegacyVercelAuthenticationFallback(
+              state,
+              credentials,
+              async (resolvedCredentials) =>
+                await Sandbox.create({
+                  ...resolvedCredentials,
+                  source: {
+                    type: 'snapshot',
+                    snapshotId: state.snapshotId!,
+                  },
+                  ...(state.runtime ? { runtime: state.runtime } : {}),
+                  ...(state.resources ? { resources: state.resources } : {}),
+                  ...(state.configuredExposedPorts
+                    ? { ports: state.configuredExposedPorts }
+                    : {}),
+                  ...(state.interactive !== undefined
+                    ? { interactive: state.interactive }
+                    : {}),
+                  ...(state.networkPolicy
+                    ? { networkPolicy: state.networkPolicy }
+                    : {}),
+                  ...(state.timeoutMs !== undefined
+                    ? { timeout: state.timeoutMs }
+                    : {}),
+                  env: state.environment,
+                }),
+            ),
           { snapshotId: state.snapshotId, sandboxId: state.sandboxId },
         )
       : await withProviderError(
@@ -955,15 +978,23 @@ export class VercelSandboxClient implements SandboxClient<
           'vercel',
           'resume sandbox',
           async () =>
-            await Sandbox.get({
-              sandboxId: state.sandboxId,
-              ...credentials,
-            }),
+            await runWithLegacyVercelAuthenticationFallback(
+              state,
+              credentials,
+              async (resolvedCredentials) =>
+                await Sandbox.get({
+                  sandboxId: state.sandboxId,
+                  ...resolvedCredentials,
+                }),
+            ),
           { sandboxId: state.sandboxId },
         );
+    applyVercelAuthentication(state, authentication);
+    const sandbox = authentication.value;
+    const resolvedCredentials = authentication.credentials;
 
     const session = new VercelSandboxSession({
-      credentials,
+      credentials: resolvedCredentials,
       archiveLimits: this.options.archiveLimits,
       state: resumeFromSnapshot
         ? {
@@ -1141,6 +1172,78 @@ function selectVercelCredentials(
     : resolveVercelCredentials(...fallbackLayers);
 }
 
+function selectVercelSessionCredentials(
+  state: VercelSandboxSessionState,
+  ...fallbackLayers: VercelCredentials[]
+): NormalizedVercelCredentials {
+  if (state.authenticationMode === 'sdk') {
+    return {};
+  }
+  return selectVercelCredentials(state, ...fallbackLayers);
+}
+
+type VercelAuthenticationResult<T> = {
+  value: T;
+  credentials: NormalizedVercelCredentials;
+  authenticationMode?: VercelSandboxSessionState['authenticationMode'];
+};
+
+async function runWithLegacyVercelAuthenticationFallback<T>(
+  state: VercelSandboxSessionState,
+  credentials: NormalizedVercelCredentials,
+  operation: (credentials: NormalizedVercelCredentials) => Promise<T>,
+): Promise<VercelAuthenticationResult<T>> {
+  const serializedCredentials = normalizeVercelCredentials(state);
+  const hasLegacySerializedCredentials =
+    state.authenticationMode === undefined &&
+    serializedCredentials.token !== undefined;
+  const authenticationMode =
+    state.authenticationMode ??
+    (hasLegacySerializedCredentials
+      ? undefined
+      : credentials.token
+        ? 'explicit'
+        : 'sdk');
+
+  try {
+    return {
+      value: await operation(credentials),
+      credentials,
+      authenticationMode,
+    };
+  } catch (error) {
+    if (!hasLegacySerializedCredentials || !isVercelUnauthorizedError(error)) {
+      throw error;
+    }
+  }
+
+  const delegatedCredentials = {} satisfies NormalizedVercelCredentials;
+  return {
+    value: await operation(delegatedCredentials),
+    credentials: delegatedCredentials,
+    authenticationMode: 'sdk',
+  };
+}
+
+function isVercelUnauthorizedError(error: unknown): boolean {
+  const details = providerErrorDetails(error);
+  return [details.status, details.httpStatus, details.responseStatus].some(
+    (status) => status === 401 || status === '401',
+  );
+}
+
+function applyVercelAuthentication<T>(
+  state: VercelSandboxSessionState,
+  authentication: VercelAuthenticationResult<T>,
+): void {
+  applyVercelCredentials(state, authentication.credentials);
+  if (authentication.authenticationMode === undefined) {
+    delete state.authenticationMode;
+  } else {
+    state.authenticationMode = authentication.authenticationMode;
+  }
+}
+
 function applyVercelCredentials(
   state: Pick<VercelSandboxSessionState, 'projectId' | 'teamId' | 'token'>,
   credentials: VercelCredentials,
@@ -1154,6 +1257,18 @@ function applyVercelCredentials(
     state.teamId = normalized.teamId;
     state.token = normalized.token;
   }
+}
+
+function readVercelAuthenticationMode(
+  state: Record<string, unknown>,
+): VercelSandboxSessionState['authenticationMode'] {
+  const mode = readOptionalString(state, 'authenticationMode');
+  if (mode === undefined || mode === 'explicit' || mode === 'sdk') {
+    return mode;
+  }
+  throw new UserError(
+    'Vercel sandbox session authenticationMode must be "explicit" or "sdk".',
+  );
 }
 
 async function captureVercelSnapshot(
@@ -1172,21 +1287,30 @@ async function captureVercelSnapshot(
 
   let sandbox = args.sandbox;
   if (!sandbox) {
-    const credentials = selectVercelCredentials(state, args.options ?? {});
-    applyVercelCredentials(state, credentials);
-    sandbox = await withProviderError(
+    const credentials = selectVercelSessionCredentials(
+      state,
+      args.options ?? {},
+    );
+    const authentication = await withProviderError(
       'VercelSandboxClient',
       'vercel',
       'look up sandbox for snapshot',
       async () =>
-        await (
-          await loadVercelSandboxClass()
-        ).get({
-          sandboxId: state.sandboxId,
-          ...credentials,
-        }),
+        await runWithLegacyVercelAuthenticationFallback(
+          state,
+          credentials,
+          async (resolvedCredentials) =>
+            await (
+              await loadVercelSandboxClass()
+            ).get({
+              sandboxId: state.sandboxId,
+              ...resolvedCredentials,
+            }),
+        ),
       { sandboxId: state.sandboxId },
     );
+    applyVercelAuthentication(state, authentication);
+    sandbox = authentication.value;
   }
   state.snapshotSupported = supportsVercelSnapshot(sandbox);
   if (!state.snapshotSupported) {

--- a/packages/agents-extensions/test/sandbox/vercel.test.ts
+++ b/packages/agents-extensions/test/sandbox/vercel.test.ts
@@ -53,6 +53,15 @@ function vercelAlreadyExistsError(path: string): unknown {
   };
 }
 
+function vercelHttpError(status: number): Error {
+  return Object.assign(new Error(`Vercel request failed with ${status}.`), {
+    response: {
+      status,
+      statusText: status === 401 ? 'Unauthorized' : 'Request failed',
+    },
+  });
+}
+
 function testExistsPath(command: string): string | undefined {
   return command.match(/^test -e '([^']+)'$/u)?.[1];
 }
@@ -66,6 +75,9 @@ vi.mock('@vercel/sandbox', () => ({
 
 describe('VercelSandboxClient', () => {
   beforeEach(() => {
+    vi.stubEnv('VERCEL_PROJECT_ID', '');
+    vi.stubEnv('VERCEL_TEAM_ID', '');
+    vi.stubEnv('VERCEL_TOKEN', '');
     createMock.mockReset();
     getMock.mockReset();
     runCommandMock.mockReset();
@@ -195,6 +207,7 @@ describe('VercelSandboxClient', () => {
       }),
     );
     expect(session.state).toMatchObject({
+      authenticationMode: 'explicit',
       projectId: 'prj_env',
       teamId: 'team_env',
       token: 'env_token',
@@ -253,6 +266,7 @@ describe('VercelSandboxClient', () => {
       expect(session.state).not.toHaveProperty('projectId');
       expect(session.state).not.toHaveProperty('teamId');
       expect(session.state).not.toHaveProperty('token');
+      expect(session.state.authenticationMode).toBe('sdk');
     },
   );
 
@@ -273,6 +287,7 @@ describe('VercelSandboxClient', () => {
     expect(session.state).not.toHaveProperty('projectId');
     expect(session.state).not.toHaveProperty('teamId');
     expect(session.state).not.toHaveProperty('token');
+    expect(session.state.authenticationMode).toBe('sdk');
   });
 
   test('serializes PAT environment credentials used during create and snapshot capture', async () => {
@@ -296,6 +311,7 @@ describe('VercelSandboxClient', () => {
       token: 'env_token',
     });
     expect(serialized).toMatchObject({
+      authenticationMode: 'explicit',
       projectId: 'prj_env',
       teamId: 'team_env',
       token: 'env_token',
@@ -303,6 +319,51 @@ describe('VercelSandboxClient', () => {
       workspacePersistence: 'snapshot',
       snapshotId: 'snap_test',
     });
+    await expect(
+      client.deserializeSessionState(serialized),
+    ).resolves.toMatchObject({
+      authenticationMode: 'explicit',
+      projectId: 'prj_env',
+      teamId: 'team_env',
+      token: 'env_token',
+    });
+  });
+
+  test('delegates legacy snapshot lookup authentication after a 401 response', async () => {
+    getMock
+      .mockRejectedValueOnce(vercelHttpError(401))
+      .mockResolvedValueOnce(makeSandbox('vercel_existing'));
+    const client = new VercelSandboxClient();
+    const state = await client.deserializeSessionState({
+      manifest: new Manifest(),
+      sandboxId: 'vercel_existing',
+      workspacePersistence: 'snapshot',
+      environment: {},
+      snapshotSupported: true,
+      projectId: 'prj_serialized',
+      teamId: 'team_serialized',
+      token: 'serialized_token',
+    });
+
+    const serialized = await client.serializeSessionState(state, {
+      willCloseAfterSerialize: true,
+    });
+
+    expect(getMock).toHaveBeenNthCalledWith(1, {
+      sandboxId: 'vercel_existing',
+      projectId: 'prj_serialized',
+      teamId: 'team_serialized',
+      token: 'serialized_token',
+    });
+    expect(getMock).toHaveBeenNthCalledWith(2, {
+      sandboxId: 'vercel_existing',
+    });
+    expect(snapshotMock).toHaveBeenCalledOnce();
+    expect(serialized).toMatchObject({
+      authenticationMode: 'sdk',
+      snapshotId: 'snap_test',
+    });
+    expect(serialized).not.toHaveProperty('token');
   });
 
   test('strips incomplete credentials before serializing session state', async () => {
@@ -729,6 +790,120 @@ describe('VercelSandboxClient', () => {
     );
   });
 
+  test('delegates legacy live sandbox authentication after a 401 response', async () => {
+    getMock
+      .mockRejectedValueOnce(vercelHttpError(401))
+      .mockResolvedValueOnce(makeSandbox('vercel_existing'));
+    const client = new VercelSandboxClient();
+    const state = await client.deserializeSessionState({
+      manifest: new Manifest(),
+      sandboxId: 'vercel_existing',
+      workspacePersistence: 'tar',
+      environment: {},
+      projectId: 'prj_serialized',
+      teamId: 'team_serialized',
+      token: 'serialized_token',
+    });
+
+    await client.resume(state);
+
+    expect(getMock).toHaveBeenNthCalledWith(1, {
+      sandboxId: 'vercel_existing',
+      projectId: 'prj_serialized',
+      teamId: 'team_serialized',
+      token: 'serialized_token',
+    });
+    expect(getMock).toHaveBeenNthCalledWith(2, {
+      sandboxId: 'vercel_existing',
+    });
+    expect(state.authenticationMode).toBe('sdk');
+    expect(state).not.toHaveProperty('projectId');
+    expect(state).not.toHaveProperty('teamId');
+    expect(state).not.toHaveProperty('token');
+  });
+
+  test('preserves legacy credentials when delegated authentication also fails', async () => {
+    getMock
+      .mockRejectedValueOnce(vercelHttpError(401))
+      .mockRejectedValueOnce(new Error('delegated authentication failed'));
+    const client = new VercelSandboxClient();
+    const state = await client.deserializeSessionState({
+      manifest: new Manifest(),
+      sandboxId: 'vercel_existing',
+      workspacePersistence: 'tar',
+      environment: {},
+      projectId: 'prj_serialized',
+      teamId: 'team_serialized',
+      token: 'serialized_token',
+    });
+
+    await expect(client.resume(state)).rejects.toMatchObject({
+      details: {
+        cause: 'delegated authentication failed',
+      },
+    });
+
+    expect(getMock).toHaveBeenCalledTimes(2);
+    expect(state.authenticationMode).toBeUndefined();
+    expect(state).toMatchObject({
+      projectId: 'prj_serialized',
+      teamId: 'team_serialized',
+      token: 'serialized_token',
+    });
+  });
+
+  test('does not delegate current explicit authentication after a 401 response', async () => {
+    getMock.mockRejectedValueOnce(vercelHttpError(401));
+    const client = new VercelSandboxClient();
+    const state = await client.deserializeSessionState({
+      manifest: new Manifest(),
+      sandboxId: 'vercel_existing',
+      workspacePersistence: 'tar',
+      environment: {},
+      authenticationMode: 'explicit',
+      projectId: 'prj_explicit',
+      teamId: 'team_explicit',
+      token: 'explicit_token',
+    });
+
+    await expect(client.resume(state)).rejects.toMatchObject({
+      details: {
+        responseStatus: 401,
+      },
+    });
+
+    expect(getMock).toHaveBeenCalledOnce();
+    expect(state).toMatchObject({
+      authenticationMode: 'explicit',
+      projectId: 'prj_explicit',
+      teamId: 'team_explicit',
+      token: 'explicit_token',
+    });
+  });
+
+  test('does not delegate legacy authentication after a non-401 response', async () => {
+    getMock.mockRejectedValueOnce(vercelHttpError(403));
+    const client = new VercelSandboxClient();
+    const state = await client.deserializeSessionState({
+      manifest: new Manifest(),
+      sandboxId: 'vercel_existing',
+      workspacePersistence: 'tar',
+      environment: {},
+      projectId: 'prj_serialized',
+      teamId: 'team_serialized',
+      token: 'serialized_token',
+    });
+
+    await expect(client.resume(state)).rejects.toMatchObject({
+      details: {
+        responseStatus: 403,
+      },
+    });
+
+    expect(getMock).toHaveBeenCalledOnce();
+    expect(state.authenticationMode).toBeUndefined();
+  });
+
   test('discards incomplete serialized credentials before resolving PAT environment fallback', async () => {
     vi.stubEnv('VERCEL_PROJECT_ID', 'prj_env');
     vi.stubEnv('VERCEL_TEAM_ID', 'team_env');
@@ -823,6 +998,89 @@ describe('VercelSandboxClient', () => {
         },
       }),
     );
+  });
+
+  test('delegates legacy snapshot resume authentication after a 401 response', async () => {
+    createMock
+      .mockRejectedValueOnce(vercelHttpError(401))
+      .mockResolvedValueOnce(makeSandbox('vercel_restored'));
+    const client = new VercelSandboxClient();
+    const state = await client.deserializeSessionState({
+      manifest: new Manifest(),
+      sandboxId: 'vercel_original',
+      workspacePersistence: 'snapshot',
+      environment: {},
+      snapshotId: 'snap_original',
+      snapshotSandboxId: 'vercel_original',
+      projectId: 'prj_serialized',
+      teamId: 'team_serialized',
+      token: 'serialized_token',
+    });
+
+    await client.resume(state);
+
+    expect(createMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        projectId: 'prj_serialized',
+        teamId: 'team_serialized',
+        token: 'serialized_token',
+      }),
+    );
+    expect(createMock).toHaveBeenNthCalledWith(
+      2,
+      expect.not.objectContaining({
+        projectId: expect.anything(),
+        teamId: expect.anything(),
+        token: expect.anything(),
+      }),
+    );
+    expect(state.authenticationMode).toBe('sdk');
+    expect(state).not.toHaveProperty('token');
+  });
+
+  test('delegates legacy snapshot restore authentication after a 401 response', async () => {
+    getMock.mockResolvedValueOnce(makeSandbox('vercel_live'));
+    const client = new VercelSandboxClient();
+    const state = await client.deserializeSessionState({
+      manifest: new Manifest(),
+      sandboxId: 'vercel_live',
+      workspacePersistence: 'snapshot',
+      environment: {},
+      projectId: 'prj_serialized',
+      teamId: 'team_serialized',
+      token: 'serialized_token',
+    });
+    const session = await client.resume(state);
+    createMock
+      .mockRejectedValueOnce(vercelHttpError(401))
+      .mockResolvedValueOnce(makeSandbox('vercel_restored'));
+
+    await session.hydrateWorkspace(
+      encodeNativeSnapshotRef({
+        provider: 'vercel',
+        snapshotId: 'snap_restore',
+      }),
+    );
+
+    expect(createMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        projectId: 'prj_serialized',
+        teamId: 'team_serialized',
+        token: 'serialized_token',
+      }),
+    );
+    expect(createMock).toHaveBeenNthCalledWith(
+      2,
+      expect.not.objectContaining({
+        projectId: expect.anything(),
+        teamId: expect.anything(),
+        token: expect.anything(),
+      }),
+    );
+    expect(session.state.authenticationMode).toBe('sdk');
+    expect(session.state).not.toHaveProperty('token');
   });
 
   test('reattaches live sandboxes when snapshot freshness was invalidated', async () => {


### PR DESCRIPTION
This pull request is a follow-up on https://github.com/openai/openai-agents-js/pull/1405 and it fixes Vercel sandbox sessions serialized with expiring CLI credentials before SDK-managed authentication was introduced.

Legacy session states without an authentication mode first retain their serialized credentials. If Vercel rejects those credentials with HTTP 401, the operation is retried once without explicit credentials so `@vercel/sandbox` can resolve current authentication. Successful fallback clears the stale credentials and records SDK-managed authentication for subsequent resume and snapshot operations.

New sessions record whether authentication is explicit or SDK-managed. Explicit PAT credentials never use the legacy fallback, preventing an authentication failure from silently switching identities.