### PR TITLE
docs: add SDK maintainer knowledge assets

### DIFF
--- a/.agents/references/README.md
+++ b/.agents/references/README.md
@@ -1,0 +1,41 @@
+# SDK Maintainer References
+
+This directory captures long-lived implementation contracts of the OpenAI Agents TypeScript SDK that are not replaceable by OpenAI API facts from `$openai-knowledge` or by user-facing docs alone. Use these references to preserve ownership, ordering, compatibility, failure, and cross-runtime semantics while changing or reviewing the SDK.
+
+## Usage
+
+Start with the map below and open only the references relevant to the affected boundary. Treat every reference as background, not as proof that a current issue is valid or a current patch is correct. Verify the claim against the current remote change, source, tests, docs, latest release boundary, and focused runtime evidence.
+
+During implementation or dedicated repository-maintenance work, update the narrowest owning reference when a reusable invariant is established or ownership moves. During ordinary issue or PR review, keep this directory read-only and recommend a separate reference update unless the user explicitly includes it in scope.
+
+## Inclusion Criteria
+
+Keep knowledge here only when it is SDK-specific, stable across multiple tasks or releases, easy to violate from one local path, and expensive to reconstruct repeatedly. Prefer state owners, lifecycle order, compatibility boundaries, and required cross-path parity over module summaries.
+
+Do not store current issue or PR status, one-off fixes, generic review methodology, release notes, translated documentation, or OpenAI platform facts available from `$openai-knowledge`. History is discovery evidence; each retained rule must still be supported by current source, tests, docs, or a released contract.
+
+## Reference Map
+
+| Reference | Read before changing or reviewing |
+| --- | --- |
+| [Public API, package, and runtime boundaries](public-api-package-and-runtime-boundaries.md) | Package exports, convenience re-exports, ESM/CJS/types, optional dependencies, import side effects, or Node/browser/workerd shims |
+| [Agent definition and run context](agent-definition-and-run-context.md) | Agent configuration, cloning, dynamic instructions, enabled tools/handoffs, nested agent tools, context forks, or usage |
+| [Runner lifecycle](runner-lifecycle.md) | Turns, guardrails, handoffs, interruption, cancellation, hooks, final output, or streaming parity |
+| [Run item and stream lifecycle](run-item-and-stream-lifecycle.md) | New item types, model output processing, stream events, result extraction, replay, persistence, or custom data |
+| [Schema and Zod boundaries](schema-and-zod-boundaries.md) | Function-tool schemas, structured outputs, strict conversion, Zod v3/v4, or provider schema conversion |
+| [Conversation state ownership](conversation-state-ownership.md) | Explicit replay, `conversationId`, `previousResponseId`, filtering, continuation, compaction strategy, retries, or resume |
+| [Session persistence](session-persistence.md) | Session callbacks, stored input, history mutation, per-turn writes, rollback, or compaction replacement |
+| [RunState schema and resume](runstate-schema-and-resume.md) | Serialized state, schema versions, approvals, agent/tool reconstruction, traces, or interrupted-run resume |
+| [Tool identity and routing](tool-identity-and-routing.md) | Names, namespaces, lookup, call IDs, approvals, collisions, deferred tools, MCP names, or trace labels |
+| [Tool execution and approval lifecycle](tool-execution-and-approval-lifecycle.md) | Planning, approval, guardrails, concurrency, aborts, timeouts, hooks, failure conversion, or tool-choice reset |
+| [MCP transport, cache, and shims](mcp-transport-cache-and-shims.md) | Local MCP connections, stdio/SSE/streamable HTTP, requests, cache/filtering, retries, cancellation, or cleanup |
+| [Model, provider, and conversion boundaries](model-provider-and-conversion-boundaries.md) | Model resolution, settings merge, Responses/Chat Completions, provider data, raw events, retries, or WebSocket Responses |
+| [Tracing and runtime context](tracing-and-runtime-context.md) | Trace/span context, processors, export, flush, shutdown, resume, runtime storage, usage, or sensitive data |
+| [Realtime session lifecycle](realtime-session-lifecycle.md) | Realtime agent/session state, response sequencing, tools, guardrails, history, handoffs, listeners, or cleanup |
+| [Realtime transport, audio, and events](realtime-transport-audio-and-events.md) | WebRTC, WebSocket, SIP, Twilio, Cloudflare, connection state, audio formats, transcripts, or event payloads |
+| [Sandbox runtime and provider boundaries](sandbox-runtime-and-provider-boundaries.md) | Sandbox preparation, sessions, manifests, mounts, path grants, snapshots, credentials, timeout, resume, or cleanup |
+| [Extension adapter boundaries](extension-adapter-boundaries.md) | AI SDK model/UI adapters, provider metadata, usage, reasoning, tool-call translation, aborts, or stream completion |
+
+## Maintenance Rules
+
+Keep each detailed rule in one owning reference and cross-link adjacent documents instead of copying it. Describe current architecture, not the chronology of a bug. Use repository-relative current source, test, and English-doc paths as anchors. Remove or rewrite guidance when ownership moves, and compare compatibility claims with the latest release tag rather than unreleased branch-local churn.

--- a/.agents/references/agent-definition-and-run-context.md
+++ b/.agents/references/agent-definition-and-run-context.md
@@ -1,0 +1,46 @@
+# Agent Definition and Run Context
+
+Use this reference for `Agent` configuration, cloning, dynamic instructions, enabled tools and handoffs, nested agent tools, `RunContext`, usage, or public-versus-prepared agent identity.
+
+## Agent Definition and Resolution
+
+- Resolve dynamic instructions, callable tool enablement, and callable handoff enablement with the current `RunContext` for each turn. Do not cache one run's resolved set on a reusable `Agent`.
+- Use the same resolved tool and handoff view for model exposure, collision checks, dispatch, approvals, tracing, and Realtime updates. Resolving independently can expose one set and execute another.
+- `Agent.clone()` copies configuration into a new agent but does not make contained tools, hooks, handoffs, models, or caller objects deeply independent. Do not promise mutation isolation that the implementation does not provide.
+- Prepared sandbox agents and other internal wrappers may add runtime tools or instructions, but hooks, filters, results, and public identity should continue to identify the public agent unless an internal identity is explicitly part of the contract.
+- The effective output type follows the agent and handoff path that produced the final candidate. Preserve the output union across typed handoffs instead of assuming the starting agent's output type.
+
+## Context Ownership
+
+- `RunContext.context` is application-local state and is not model input unless user code adds it explicitly. `RunContext.usage` is the run-wide mutable usage accumulator; merge each model attempt exactly once.
+- Context forks share the application object, usage, and approval state while allowing scoped `toolInput`. Use `withToolInput()` and `withoutToolInput()` so nested agent tools do not leak stale structured input into unrelated calls.
+- Preserve custom `RunContext` subclasses only through `_createFork()`; the base implementation cannot reconstruct subclass behavior automatically.
+- Nested `Agent.asTool()` runs have their own runner state, interruption scope, and model/tool settings merge. They may share application state and usage, but must not reuse parent approvals merely because a call ID or tool name matches.
+
+## Usage
+
+- Aggregate totals and `requestUsageEntries` must stay consistent across streaming, retries, handoffs, nested agents, resume, and adapters. Preserve authoritative request entries rather than synthesizing duplicates from totals.
+- A streamed response's usage is incomplete until its terminal event and stream driver complete. Do not finalize result or trace usage from an intermediate text delta.
+- Treat zero-token failed attempts, snake_case provider fields, and endpoint metadata explicitly; do not convert missing provider data into invented token counts.
+
+## Review Checklist
+
+1. Resolve dynamic agent surfaces against the current context and public identity.
+2. Verify clone and nested-tool behavior without assuming deep copies or shared approvals.
+3. Test scoped `toolInput`, custom context subclasses, and nested resume behavior.
+4. Check handoff output typing and prepared-agent identity.
+5. Compare aggregate and per-request usage after streaming, retry, handoff, nested runs, and resume.
+
+## Sources
+
+- `packages/agents-core/src/agent.ts`
+- `packages/agents-core/src/agentToolInput.ts`
+- `packages/agents-core/src/agentToolRunConfig.ts`
+- `packages/agents-core/src/runContext.ts`
+- `packages/agents-core/src/usage.ts`
+- `packages/agents-core/test/agent.test.ts`
+- `packages/agents-core/test/agentScenarios.test.ts`
+- `packages/agents-core/test/runContext.test.ts`
+- `packages/agents-core/test/usage.test.ts`
+- `docs/src/content/docs/guides/agents.mdx`
+- `docs/src/content/docs/guides/context.mdx`

--- a/.agents/references/conversation-state-ownership.md
+++ b/.agents/references/conversation-state-ownership.md
@@ -1,0 +1,56 @@
+# Conversation State Ownership
+
+Use this reference for explicit history replay, SDK sessions, `conversationId`, `previousResponseId`, model-input filtering, compaction strategy, retry, or interrupted-run resume.
+
+## Choose the State Owner
+
+| Strategy | Owner | Next model input |
+| --- | --- | --- |
+| Explicit `result.history` replay | Application | Full replay-ready history plus new input |
+| SDK `Session` | Application storage plus runner | Stored history combined with new input |
+| `conversationId` | OpenAI Conversations/Responses | Conversation ID plus new delta |
+| `previousResponseId` | OpenAI Responses | Previous response ID plus new delta |
+| `RunState` resume | Serialized SDK run | Continue the same interrupted run; this is not a new conversation strategy |
+
+Do not create two authoritative histories accidentally. When server-managed continuation is active, the runner excludes prior SDK-session history from model input and limits local persistence to new process-local items.
+
+## Server Conversation Tracker
+
+- `ServerConversationTracker` owns which original and generated items have already reached or come from the server. Use object identity in one live process and stable item/call/content keys when clones, filters, or serialization break identity.
+- Capture the latest response that actually has a response ID. Do not erase a valid `previousResponseId` because an adjacent provider response lacks one.
+- Mark prepared input as sent only when the request has crossed the relevant success boundary. Streaming abort before the first event and abort after partial tool-call events require different reconciliation.
+- Skip approval placeholders and server-echoed output when calculating the next delta. Preserve unsent tool outputs and filtered replacements that the server has not acknowledged.
+
+## Filters, Sessions, and Resume
+
+- `callModelInputFilter` receives a deep-cloned prepared payload and must return an input array. Persist filtered clones so session history reflects redaction or truncation rather than the unfiltered source.
+- Track filtered items back to their originals so delta bookkeeping marks the items the model actually received. Rewind or preserve that mapping according to whether a failed attempt may have advanced server state.
+- `RunState` persists conversation identifiers and primes tracker state from prior model responses. Resume must not resend acknowledged input, lose unsent outputs, or increment the turn count without a model call.
+- Conversation continuation carries context into a new turn. RunState resume continues a paused turn. Do not substitute one for the other.
+
+## Compaction
+
+- `previous_response_id` compaction requires a usable stored response chain. `input` compaction rebuilds from client-held items and is the safe path when the chain is unavailable or `store` prevents later lookup.
+- Normalize compacted output before destructive session replacement. If replacement fails after mutation, restore the prior history or surface both replacement and restore failures explicitly.
+
+## Review Checklist
+
+1. Name the single authoritative state owner and whether each request receives full history or a delta.
+2. Test first turn, follow-up, filter, retry, streaming abort, interruption, serialized resume, and compaction.
+3. Test tool calls and outputs separately; item IDs and call IDs serve different dedupe roles.
+4. Confirm local sessions do not introduce duplicate server-owned history.
+5. Recheck OpenAI platform semantics with `$openai-knowledge`; keep this file limited to SDK behavior.
+
+## Sources
+
+- `packages/agents-core/src/runner/conversation.ts`
+- `packages/agents-core/src/runner/turnPreparation.ts`
+- `packages/agents-core/src/run.ts`
+- `packages/agents-core/src/runState.ts`
+- `packages/agents-openai/src/memory/openaiConversationsSession.ts`
+- `packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts`
+- `packages/agents-core/test/runner/conversation.test.ts`
+- `packages/agents-core/test/agentScenarios.test.ts`
+- `packages/agents-openai/test/openaiResponsesCompactionSession.test.ts`
+- `docs/src/content/docs/guides/running-agents.mdx`
+- `docs/src/content/docs/guides/sessions.mdx`

--- a/.agents/references/extension-adapter-boundaries.md
+++ b/.agents/references/extension-adapter-boundaries.md
@@ -1,0 +1,48 @@
+# Extension Adapter Boundaries
+
+Use this reference for AI SDK model/UI adapters, provider metadata, usage translation, reasoning, tool-call conversion, abort propagation, stream completion, or optional integration behavior.
+
+## Adapter Ownership
+
+- Adapters translate between two public protocols; they do not redefine the core runner contract. Preserve the source model/item semantics and reject unsupported constructs explicitly rather than fabricating a lossy equivalent.
+- Keep optional adapter dependencies and entrypoints behind `@openai/agents-extensions` subpaths. Importing unrelated extension or SDK roots must not require the adapter dependency.
+- Support declared external protocol versions through shape-based compatibility where necessary, with tests for each supported version. Do not assume one dependency's private class identity is stable across versions.
+
+## Model and Message Conversion
+
+- Preserve system instructions, structured output, tool choice, qualified tool names, tool call/result pairing, provider metadata, images, reasoning, usage, and abort signals across generate and stream paths.
+- Reject core tool/item types the target adapter cannot represent. Unknown provider items may pass through only through the documented provider-data escape hatch.
+- Per-tool-call provider metadata such as reasoning signatures must stay attached to the matching call across multi-turn replay. Do not duplicate one reasoning block across parallel calls.
+- Normalize empty string tool input only when the target object schema makes the intended empty object unambiguous.
+
+## Streaming and UI Messages
+
+- Stream adapters must propagate source errors and cancellation to the underlying iterator. A terminal response event can arrive before delayed run-item events; emit finish only after owned item/tool output work is drained.
+- Deduplicate text when both deltas and final message items carry the same content, but synthesize message output when no deltas were emitted.
+- Preserve tool-search call IDs and replacement outputs exactly as core routing does. Server tool-search outputs without a call ID must not consume pending client calls.
+- Emit approval, reasoning, tool input/output, step, and finish chunks in an order accepted by the target UI protocol.
+
+## Usage and Errors
+
+- Translate numeric and object-shaped usage, cache/read-write details, and provider metadata without producing `NaN` or double-counting requests.
+- Preserve explicit provider retry guidance and rich error fields while keeping core replay-safety policy in control. Abort remains terminal unless the owning contract says otherwise.
+
+## Review Checklist
+
+1. Test every declared external protocol version and optional-dependency import path.
+2. Compare generate and stream conversion for instructions, tools, structured output, metadata, reasoning, usage, and errors.
+3. Exercise parallel/out-of-order tool calls and repeated tool-search output updates.
+4. Cancel the consumer and prove the source iterator or model request is aborted.
+5. Verify finish ordering after early terminal events and late run-item outputs.
+
+## Sources
+
+- `packages/agents-extensions/src/ai-sdk/index.ts`
+- `packages/agents-extensions/src/ai-sdk-ui/textStream.ts`
+- `packages/agents-extensions/src/ai-sdk-ui/uiMessageStream.ts`
+- `packages/agents-extensions/package.json`
+- `packages/agents-extensions/test/ai-sdk/index.test.ts`
+- `packages/agents-extensions/test/ai-sdk/GoogleFormat.test.ts`
+- `packages/agents-extensions/test/ai-sdk-ui/textStream.test.ts`
+- `packages/agents-extensions/test/ai-sdk-ui/uiMessageStream.test.ts`
+- `docs/src/content/docs/extensions/ai-sdk.mdx`

--- a/.agents/references/mcp-transport-cache-and-shims.md
+++ b/.agents/references/mcp-transport-cache-and-shims.md
@@ -1,0 +1,45 @@
+# MCP Transport, Cache, and Shims
+
+Use this reference for local MCP connection ownership, stdio/SSE/streamable HTTP transports, requests, tool cache/filtering, retries, cancellation, timeout, or cleanup.
+
+## Connection and Request Ownership
+
+- Each MCP server owns its client session and transport. Connect before listing/calling tools and close the owning transport once; do not let a cached function-tool wrapper outlive or invoke a prior server instance.
+- `MCPServers` coordinates serial or parallel connect/close and tracks failed servers. Strict connect failure must clean up both successfully connected and currently failing servers before returning.
+- A timeout or abort is not proof that remote cleanup finished. Reject new manager commands while close remains in flight, observe late failures, and allow a failed close to be retried.
+- Preserve runtime-specific transport construction in `shims/mcp-server/`. Node supports local process transports; browser/workerd surfaces must fail clearly or use their supported transport rather than importing Node-only code.
+
+## Cache and Filtering
+
+- Tool-list caching assumes schemas are stable until invalidation. `invalidateToolsCache()` and `invalidateServerToolsCache()` must clear every relevant agent/server key.
+- Cache the server tool description, not a wrapper permanently bound to one connection. Rebind executable wrappers to the current server instance after reconnect.
+- Static and callable filters run against the current agent/run context. Their output must not leak between agents, and a callable filter or custom cache key can make a globally shared entry invalid.
+- Apply strict-schema conversion, error functions, metadata/custom-data resolvers, server-name prefixing, and collision allocation consistently when rebuilding cached tools.
+
+## Calls and Failures
+
+- Preserve the original MCP tool name for `callTool` even when the model-visible wrapper name is overridden or prefixed.
+- Keep legacy content output as the default unless structured output/full result is explicitly enabled. Preserve error content and full serializable results according to the selected contract.
+- Normalize abort-like failures into the configured tool error only when an error function owns conversion. `errorFunction: null` means rethrow, including abort-like errors.
+- Trace list/call operations without requiring an ambient trace and without leaking headers, authorization, or sensitive tool payloads.
+
+## Review Checklist
+
+1. Test connect, partial failure, reconnect failed-only, close timeout, close retry, and abort.
+2. Invalidate and reconnect while caching is enabled; prove wrappers use the current server.
+3. Test static/callable filters and custom cache keys across multiple agents.
+4. Cover Node and non-Node shim conditions and ensure imports remain safe.
+5. Verify original tool names, normalized wrapper names, errors, structured content, and full-result serialization.
+
+## Sources
+
+- `packages/agents-core/src/mcp.ts`
+- `packages/agents-core/src/mcpServers.ts`
+- `packages/agents-core/src/mcpUtil.ts`
+- `packages/agents-core/src/shims/mcp-server/`
+- `packages/agents-core/test/mcpServers.test.ts`
+- `packages/agents-core/test/mcpCache.test.ts`
+- `packages/agents-core/test/mcpToolFilter.test.ts`
+- `packages/agents-core/test/mcpToFunctionTool.test.ts`
+- `packages/agents-core/test/shims/mcp-server/`
+- `docs/src/content/docs/guides/mcp.mdx`

--- a/.agents/references/model-provider-and-conversion-boundaries.md
+++ b/.agents/references/model-provider-and-conversion-boundaries.md
@@ -1,0 +1,54 @@
+# Model, Provider, and Conversion Boundaries
+
+Use this reference for model/provider resolution, settings merge, Responses versus Chat Completions conversion, provider data, raw events, retries, transport reuse, or Responses WebSocket sessions.
+
+## Core Boundary
+
+- `Model` normalizes provider behavior into `getResponse()` and `getStreamedResponse()` outputs consumed by the runner. Preserve provider raw events and provider data needed by public narrowing helpers without making the runner depend on one provider shape.
+- `ModelProvider` resolves names and owns model-instance caches or persistent transports. Close provider/model resources only when that implementation created and owns them.
+- Agent model configuration takes precedence when explicitly set; the runner/default provider fills only the placeholder. Per-run settings override runner/agent defaults through the established merge helpers.
+
+## Settings and Capability
+
+- Merge nested reasoning, text, retry/backoff, and provider-data maps deliberately. Shallow replacement can silently discard sibling configuration; uncontrolled deep merge can retain incompatible provider options.
+- Strip implicit default-model-only settings when a run resolves to a different model, but preserve explicit caller settings. Do not mutate agent-owned settings while preparing a request.
+- Responses and Chat Completions differ in structured output, tool/message shapes, reasoning, hosted tools, conversation state, terminal events, and usage. Enforce unsupported combinations in the owning converter rather than pretending feature parity.
+- Preserve absent versus `null` versus empty values because providers use them differently. Do not pass empty tools, empty tool outputs, or text response formats when the target path rejects them.
+
+## Provider Data and Raw Events
+
+- Treat `providerData` as namespaced provider extension data. Remove SDK-reserved keys before forwarding unknown options, preserve per-tool-call metadata through replay, and do not drop values needed by third-party providers.
+- Raw model stream events must carry their source discriminator so consumers can narrow Responses and Chat Completions events safely.
+- Keep response IDs, request IDs, usage, refusal, and terminal status available through normalized responses even when providers surface them in different chunks.
+
+## Retry and Persistent Transports
+
+- Model retries are opt-in. Apply abort and replay-safety vetoes before user policy, preserve failed-attempt usage, and do not retry a stateful request unless the provider indicates replay is safe or the request boundary proves it.
+- Responses WebSocket mode reuses a persistent connection and chains requests with connection-local state. Serialize access per session, propagate terminal errors, and close only the session-owned socket.
+- Compare HTTP and WebSocket Responses behavior for input, continuation, raw events, terminal items, and errors; transport choice must not change runner semantics.
+
+## Review Checklist
+
+1. Identify provider capability and the exact converter/transport that owns it.
+2. Compare agent, runner, per-run, model-default, and provider-data precedence without mutation.
+3. Test Responses and Chat Completions plus streaming/non-streaming when both are supported.
+4. Preserve IDs, usage, raw events, metadata, terminal status, and absent/null distinctions.
+5. Test retry replay safety and persistent transport ownership with abort and close failures.
+
+## Sources
+
+- `packages/agents-core/src/model.ts`
+- `packages/agents-core/src/providers.ts`
+- `packages/agents-core/src/runner/modelSettings.ts`
+- `packages/agents-core/src/runner/modelSettingsMerge.ts`
+- `packages/agents-core/src/runner/modelRetry.ts`
+- `packages/agents-openai/src/openaiProvider.ts`
+- `packages/agents-openai/src/openaiResponsesModel.ts`
+- `packages/agents-openai/src/openaiChatCompletionsModel.ts`
+- `packages/agents-openai/src/openaiChatCompletionsConverter.ts`
+- `packages/agents-openai/src/responsesWebSocketSession.ts`
+- `packages/agents-openai/test/openaiResponsesModel.test.ts`
+- `packages/agents-openai/test/openaiChatCompletionsModel.test.ts`
+- `packages/agents-openai/test/responsesWebSocketSession.test.ts`
+- `packages/agents-core/test/retryPolicy.test.ts`
+- `docs/src/content/docs/guides/models.mdx`

--- a/.agents/references/public-api-package-and-runtime-boundaries.md
+++ b/.agents/references/public-api-package-and-runtime-boundaries.md
@@ -1,0 +1,46 @@
+# Public API, Package, and Runtime Boundaries
+
+Use this reference for package export maps, convenience-package re-exports, ESM/CJS/type declarations, optional dependencies, import side effects, and Node/browser/workerd runtime shims.
+
+## Package Ownership
+
+- `@openai/agents-core` owns provider-neutral runtime APIs. `@openai/agents-openai` owns OpenAI-specific models, sessions, tools, and tracing export. `@openai/agents-realtime` owns Realtime sessions and transports. `@openai/agents-extensions` owns optional integrations. `@openai/agents` is a convenience bundle, not a second implementation.
+- Add a public symbol to its owning package first. Re-export it from `@openai/agents` or a subpath only when that route is intentionally supported, then cover both the owning and convenience imports.
+- Treat package `exports`, root/subpath `src/index.ts` files, and emitted declarations as one compatibility surface. A source export that is missing from `package.json` or `dist` is not a working public API.
+- Keep optional integrations behind `@openai/agents-extensions` subpaths. Importing a package root must not eagerly require unrelated optional provider SDKs.
+
+## Import-Time Behavior
+
+- Importing `@openai/agents` intentionally installs the default OpenAI model provider and tracing exporter. Provider-neutral consumers should import `@openai/agents-core` to avoid those defaults.
+- Keep package roots free of browser-incompatible imports unless their export conditions route to a compatible shim. A type-only public surface must not cause a runtime import of a Node-only dependency.
+- Validate current source through `src` imports and packaged behavior through a completed build and `dist` imports. Do not use a stale `dist` probe to decide what the current branch source does.
+
+## Runtime Conditions and Shims
+
+- Core and Realtime expose `_shims` conditionally for Node, browser, and workerd. Preserve the same interface across implementations even when context storage, event emitters, crypto, fetch, or MCP transports differ.
+- Browser event-emitter removal must remove the intended listener without collapsing duplicate registrations unexpectedly. Context-storage shims must keep trace context active across awaited and streamed work even when true `AsyncLocalStorage` is unavailable.
+- Keep workerd/browser package conditions aligned with bundler resolution. Test the condition that users actually import; a Node-only test does not validate a browser export.
+
+## Review Checklist
+
+1. Identify the owning package and every intended re-export path.
+2. Check `package.json` export conditions, emitted declarations, and optional dependency loading.
+3. Test the relevant Node, browser, or workerd condition and both ESM and CJS when the export map changes.
+4. Confirm package-root imports do not add unintended initialization or optional-provider requirements.
+5. Compare removed or moved exports with the latest release tag and add a compatibility path when a released import is affected.
+
+## Sources
+
+- `packages/agents-core/package.json`
+- `packages/agents-openai/package.json`
+- `packages/agents-realtime/package.json`
+- `packages/agents-extensions/package.json`
+- `packages/agents/package.json`
+- `packages/agents-core/src/index.ts`
+- `packages/agents-realtime/src/index.ts`
+- `packages/agents/src/index.ts`
+- `packages/agents-core/src/shims/`
+- `packages/agents-realtime/src/shims/`
+- `packages/agents-core/test/index.test.ts`
+- `packages/agents/test/index.test.ts`
+- `integration-tests/`

--- a/.agents/references/realtime-session-lifecycle.md
+++ b/.agents/references/realtime-session-lifecycle.md
@@ -1,0 +1,51 @@
+# Realtime Session Lifecycle
+
+Use this reference for `RealtimeSession` state, agent updates, response sequencing, tools, guardrails, history, handoffs, listeners, or cleanup.
+
+## Session Ownership
+
+- `RealtimeSession` owns the active agent, local history, available MCP tools, response sequencing, tool executions, guardrails, and subscriptions to one transport. The transport owns the network/media connection.
+- Resolve dynamic instructions, tools, and handoffs before sending a session update. Preserve the complete last session configuration and overwrite only intended dynamic fields so agent handoff does not drop audio formats, modalities, speed, turn detection, or other caller settings.
+- A Realtime agent shares the session/model conversation. Handoff updates active instructions/tools/voice constraints; it does not start an independent text-runner loop.
+- Once an agent has spoken, changing to an incompatible voice can fail. Validate or preserve voice across handoff rather than issuing an invalid session update.
+
+## Response Sequencing and History
+
+- `ResponseCreateSequencer` serializes create/cancel transitions. Do not send a new `response.create` while the previous turn is active or cancellation is unresolved.
+- Associate create errors with the request event that caused them. A stale error or terminal event must not release or fail a newer queued request.
+- Local history is a projection of Realtime events. Add items before later transcript/audio updates, preserve stable item IDs, and emit `history_added` and `history_updated` with their documented timing.
+- Audio storage is opt-in to limit client memory. Omitting local audio bytes must not discard transcript, format, status, or item identity.
+
+## Tools, Guardrails, and Handoffs
+
+- Recompute enabled local, handoff, hosted, and MCP tool exposure when the active agent changes. Filter MCP tools by the active agent's server labels.
+- Keep approval and input/output guardrail order aligned with the text runner where contracts overlap. An undecided call emits `tool_approval_requested`; rejected or guarded calls return model-visible output without invocation.
+- Emit agent/tool start and end events once. Tool errors, guardrail trips, and handoffs must not leave the response sequencer or available-tool set stale.
+- Output guardrails can interrupt audio generation after partial output. Emit the interruption and prevent guarded content from continuing to the client.
+
+## Entry, Exit, and Failure
+
+- Attach transport listeners once per session and detach them on close or reconnect. Repeated close must be safe and must not duplicate transport close or leave event iterators waiting.
+- Resolve lazy API keys at connection time and do not persist or log them. A failed connect must reset session/transport state enough for a controlled retry.
+- Surface transport and tool failures through the session error event while preserving the original failure for diagnostics.
+
+## Review Checklist
+
+1. Test connect, failed connect, reconnect, repeated close, and listener cleanup.
+2. Test agent updates and handoffs with custom audio/session settings and voice constraints.
+3. Exercise response create/cancel races and stale terminal/error events.
+4. Verify history item/transcript ordering with and without stored audio.
+5. Compare tool approvals, guardrails, hooks, and failure cleanup with the text runner where intended.
+
+## Sources
+
+- `packages/agents-realtime/src/realtimeSession.ts`
+- `packages/agents-realtime/src/realtimeAgent.ts`
+- `packages/agents-realtime/src/responseCreateSequencer.ts`
+- `packages/agents-realtime/src/realtimeSessionEvents.ts`
+- `packages/agents-realtime/src/items.ts`
+- `packages/agents-realtime/test/realtimeSession.test.ts`
+- `packages/agents-realtime/test/realtimeAgentHandoffs.test.ts`
+- `packages/agents-realtime/test/guardrail.test.ts`
+- `docs/src/content/docs/guides/voice-agents.mdx`
+- `docs/src/content/docs/guides/voice-agents/build.mdx`

--- a/.agents/references/realtime-transport-audio-and-events.md
+++ b/.agents/references/realtime-transport-audio-and-events.md
@@ -1,0 +1,47 @@
+# Realtime Transport, Audio, and Events
+
+Use this reference for WebRTC, WebSocket, SIP, Twilio, Cloudflare, connection states, audio formats, transcripts, or Realtime event payloads.
+
+## Transport Boundary
+
+- `RealtimeTransportLayer` is the session/transport contract. WebRTC, WebSocket, SIP, Twilio, and Cloudflare implementations must normalize connection, audio, transcript, tool-call, response, and error events without erasing transport-specific data needed by consumers.
+- Use WebRTC for browser/client media and WebSocket-style transports for server media pipelines according to the supported runtime. SIP attaches to an existing call and has different connection inputs from a fresh client session.
+- Keep transport state machines explicit. Distinguish connecting, connected, transient disconnect, terminal disconnect, closing, and closed; a brief WebRTC peer state change is not always proof the session should close.
+- A failed connection attempt must reset state and media resources so retry does not reuse a rejected promise, stale peer connection, data channel, socket, or microphone track.
+
+## Audio and Transcript State
+
+- Preserve negotiated input/output audio formats across session updates and handoffs. Twilio commonly uses telephony formats that must not revert to default PCM.
+- Treat base64, `ArrayBuffer`, and typed-array conversion as binary operations. Encode large buffers without argument-spread limits and preserve exact bytes and channel/sample metadata.
+- Audio delta, transcript delta/completion, and output-item completion are separate signals. Merge transcript updates into the correct item and use terminal item events as a fallback when a provider omits status.
+- Store local audio bytes only when requested. Cleanup must stop owned microphone tracks and detach handlers without closing caller-owned media or peer connections unexpectedly.
+
+## Events and Compatibility
+
+- Validate known Realtime server events while preserving unknown/generic event payloads for forward compatibility. Do not drop provider fields merely because the SDK has no typed interpretation yet.
+- Preserve call IDs, item IDs, event IDs, and provider error details. Round numeric timing fields only where the API requires integer values.
+- Cloudflare/workerd and browser event APIs differ from Node event emitters. Use the runtime shim contract and test listener removal, fetch-based WebSocket upgrade, and unavailable WebRTC behavior in their target environments.
+
+## Review Checklist
+
+1. Test the relevant WebRTC, WebSocket, SIP, Twilio, or Cloudflare state machine through connect, transient failure, terminal failure, retry, and close.
+2. Verify audio bytes and formats across handoff and session update.
+3. Reconcile transcript, audio, item, and response events with missing or reordered terminal signals.
+4. Confirm owned media/listeners are cleaned up without closing caller-owned resources.
+5. Preserve unknown events and stable IDs across runtime-specific shims.
+
+## Sources
+
+- `packages/agents-realtime/src/transportLayer.ts`
+- `packages/agents-realtime/src/transportLayerEvents.ts`
+- `packages/agents-realtime/src/openaiRealtimeBase.ts`
+- `packages/agents-realtime/src/openaiRealtimeWebRtc.ts`
+- `packages/agents-realtime/src/openaiRealtimeWebsocket.ts`
+- `packages/agents-realtime/src/openaiRealtimeSip.ts`
+- `packages/agents-extensions/src/CloudflareRealtimeTransport.ts`
+- `packages/agents-extensions/src/TwilioRealtimeTransport.ts`
+- `packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts`
+- `packages/agents-realtime/test/openaiRealtimeWebsocket.test.ts`
+- `packages/agents-extensions/test/CloudflareRealtimeTransport.test.ts`
+- `packages/agents-extensions/test/TwilioRealtimeTransport.test.ts`
+- `docs/src/content/docs/guides/voice-agents/transport.mdx`

--- a/.agents/references/run-item-and-stream-lifecycle.md
+++ b/.agents/references/run-item-and-stream-lifecycle.md
@@ -1,0 +1,47 @@
+# Run Item and Stream Lifecycle
+
+Use this reference for new model output types, run items, stream events, result extraction, history replay, persistence coordination, or SDK-only custom data.
+
+## Coordinated Item Surfaces
+
+- A new model output or tool-call variant normally needs coordinated handling in protocol types, model conversion, `processModelResponse()`, actionable tool metadata, `RunItem` wrappers, stream events, result history, session conversion, RunState serialization, tracing, and adapters.
+- Keep raw provider items and SDK wrappers distinct. `rawItem` is replay/persistence data; wrapper fields carry SDK identity, agent attribution, and SDK-only metadata.
+- Separate a tool call item from its output item in stream events and history. Consumers must be able to order calls and results and match them by stable identity.
+- Tool-search outputs can update an earlier call and can arrive out of order. Prefer provider call IDs, then stable item IDs, and do not let server-executed outputs consume pending client-executed call IDs.
+
+## Replay and Persistence
+
+- Convert only replay-safe items into later model input. Drop pending hosted calls that lack a matching output and remove reasoning items whose owned call was dropped.
+- Avoid replaying provider persistence metadata such as assistant conversation item IDs when the next request expects fresh input. Preserve reasoning identity only where the target persistence API supports it.
+- `RunResult` history and session history have different consumers. Apply public-history cleanup and session normalization deliberately rather than assuming one conversion is correct for both.
+- SDK-only `customData` belongs on wrappers and serialized SDK state, not in provider-visible model input. Extract it from a cloned execution value so custom extractors cannot mutate the actual tool result.
+
+## Streaming Events
+
+- Raw model events preserve provider source information. Run-item events represent SDK lifecycle milestones; do not infer one from the other when a provider omits a delta or emits a terminal item directly.
+- Reconcile streamed text and item events without duplicating content when a final item repeats already emitted deltas. Delay synthetic final events until tool and side-effect completion makes their order truthful.
+
+## Review Checklist
+
+1. List every protocol, processing, execution, event, replay, persistence, serialization, tracing, and adapter surface for a new item.
+2. Verify stable call/output matching with missing IDs, out-of-order outputs, and repeated updates.
+3. Test streaming and non-streaming extraction and public/session history separately.
+4. Confirm pending or orphan calls cannot be replayed without results.
+5. Ensure SDK-only metadata never leaks into provider payloads or mutates caller-owned values.
+
+## Sources
+
+- `packages/agents-core/src/items.ts`
+- `packages/agents-core/src/events.ts`
+- `packages/agents-core/src/result.ts`
+- `packages/agents-core/src/runner/items.ts`
+- `packages/agents-core/src/runner/modelOutputs.ts`
+- `packages/agents-core/src/runner/streamReconciliation.ts`
+- `packages/agents-core/src/runState.ts`
+- `packages/agents-core/test/items.test.ts`
+- `packages/agents-core/test/events.test.ts`
+- `packages/agents-core/test/result.test.ts`
+- `packages/agents-core/test/runner/modelOutputs.test.ts`
+- `packages/agents-core/test/runner/items.helpers.test.ts`
+- `packages/agents-extensions/test/ai-sdk-ui/uiMessageStream.test.ts`
+- `docs/src/content/docs/guides/results.mdx`

--- a/.agents/references/runner-lifecycle.md
+++ b/.agents/references/runner-lifecycle.md
@@ -1,0 +1,48 @@
+# Runner Lifecycle
+
+Use this reference for turn accounting, guardrail order, handoffs, interruption, cancellation, hooks, final-output selection, or streaming/non-streaming behavior.
+
+## Turn and Guardrail Order
+
+- Count a turn when a model call starts. Resuming a tool or MCP approval in an in-progress turn must not consume another turn before the next model call.
+- Run input guardrails only for the starting agent and initial run input. Parallel input guardrails may overlap model work, but the run must await and surface their result before committing a successful turn or exposing guarded output.
+- An interruption returns before output guardrails. On resume, reuse the serialized current step and pending tool state rather than rebuilding a fresh model turn.
+- Run output guardrails only on the selected final output. A handoff or tool continuation is not final output, and streamed candidate output must remain hidden if a guardrail later fails.
+
+## Streaming Parity and Cancellation
+
+- Keep streaming and non-streaming paths aligned for model preparation, approvals, tool execution, handoffs, persistence, usage, tracing, and final-output resolution. Streaming may emit earlier observations, but it must not change the eventual state transition.
+- A streamed result owns a background run loop. Cancellation must abort promptly, resolve completion, detach abort listeners, and avoid leaving a locked `ReadableStream` or unobserved promise rejection.
+- When a server-managed streamed request aborts after function-call fragments arrive, reconcile enough terminal tool-call state to resume safely without replaying incomplete or duplicate calls.
+- Delay end-of-run lifecycle and trace completion until tools, guardrails, persistence, and the stream loop have settled. Do not emit a successful end event before a later failure path is known.
+
+## Handoffs and Final Output
+
+- A handoff updates the current agent, emits the agent-update lifecycle, applies the selected handoff input filter, and continues the same run state. Keep explicit and runner-level filters consistent and do not expose approval placeholders as normal history.
+- Tool-use behavior can stop on a tool result or run the model again. If a named stop tool is not called, continue normally; do not treat an unmatched name as final output.
+- Final output must wait for all selected tool actions that belong to the turn. Preserve segmented assistant text and prefer an explicitly handled error result when an error handler resolves the run.
+
+## Review Checklist
+
+1. Trace first turn, second turn, handoff, interruption, resume, max-turn, and cancellation paths.
+2. Compare streaming and non-streaming state, events, persistence, usage, and trace completion.
+3. Verify parallel guardrails cannot leak output or persist input after failure.
+4. Confirm hooks and end events fire once and only after their owned work settles.
+5. Test the negative path that can leave a listener, promise, stream lock, or pending tool state behind.
+
+## Sources
+
+- `packages/agents-core/src/run.ts`
+- `packages/agents-core/src/runner/runLoop.ts`
+- `packages/agents-core/src/runner/turnPreparation.ts`
+- `packages/agents-core/src/runner/turnResolution.ts`
+- `packages/agents-core/src/runner/guardrails.ts`
+- `packages/agents-core/src/runner/streaming.ts`
+- `packages/agents-core/src/runner/streamReconciliation.ts`
+- `packages/agents-core/src/lifecycle.ts`
+- `packages/agents-core/test/run.test.ts`
+- `packages/agents-core/test/run.stream.test.ts`
+- `packages/agents-core/test/agentScenarios.test.ts`
+- `packages/agents-core/test/lifecycle.test.ts`
+- `docs/src/content/docs/guides/running-agents.mdx`
+- `docs/src/content/docs/guides/streaming.mdx`

--- a/.agents/references/runstate-schema-and-resume.md
+++ b/.agents/references/runstate-schema-and-resume.md
@@ -1,0 +1,50 @@
+# RunState Schema and Resume
+
+Use this reference for serialized `RunState`, schema versions, approvals, agent/tool reconstruction, traces, conversation identifiers, sandbox state, or interrupted-run resume.
+
+## Compatibility Boundary
+
+- `RunState` is a versioned durable SDK snapshot. `serialize()` emits `CURRENT_SCHEMA_VERSION`; deserialization must continue to accept every version listed in `SUPPORTED_SCHEMA_VERSIONS`.
+- Bump the schema when a released snapshot changes meaning or requires new durable data. Unreleased versions on `main` may be folded into the same next version when no supported snapshot consumer exists.
+- Optional/defaulted fields preserve old readers' meaning. A new item or action type also needs Zod schema support, serialization, deserialization, runtime rehydration, and a prior-version decision.
+- Reject missing or unsupported versions with a user-facing error. Do not guess which historical layout an unversioned payload used.
+
+## Identity and Rehydration
+
+- Rebuild agents from the graph reachable from the starting agent. Distinct agents with the same name are ambiguous unless serialized agent identity disambiguates them; reject or preserve identity instead of silently choosing one.
+- Rehydrate function, deferred/tool-search, MCP, computer, shell, apply-patch, and sandbox-injected tools through the current agent/tool set. Preserve declared names, namespaces, call IDs, approval attribution, and enabled-state checks.
+- Adding MCP servers or runtime tools after serialization must not make an otherwise valid snapshot unreadable. Conversely, do not execute a resumed tool that is disabled or cannot be resolved under the replacement context.
+- Rehydrate interruption items as their public `RunItem` subclasses so approval APIs and result history behave like a live interruption.
+
+## Resume State
+
+- Preserve `_currentTurnInProgress`, current step, generated items, last processed response, pending nested agent runs, persisted-item count, conversation IDs, reasoning-item policy, and rejection messages needed to continue without replay or duplicated side effects.
+- Approval and rejection decisions are scoped by tool identity and call ID. Preserve sticky `alwaysReject` messages and qualified names across serialization.
+- Runtime callbacks, provider clients, retry policies, and other executable objects are not made durable merely by serializing surrounding settings. Rebind them from current configuration on resume.
+- Serialized context can contain application data; custom data must be JSON-compatible and must not include secrets unless the application explicitly accepts that durability boundary.
+
+## Tracing and Sandbox State
+
+- Restore trace/span identity only when the snapshot carries it, then apply current per-run tracing overrides. Clearing resumed trace state must prevent accidental parentage without corrupting the rest of the run.
+- Sandbox session state is versioned inside RunState. Treat it as untrusted persisted input and recreate live clients, credentials, and tools from current trusted configuration.
+
+## Review Checklist
+
+1. Compare the change with the latest released schema and decide bump, backward read, or unreleased fold-in.
+2. Round-trip every new field and test the oldest supported version.
+3. Resume before model call, pending approval, nested agent tool, and partially persisted streaming turn.
+4. Test duplicate agent/tool names, missing tools, newly added MCP servers, and disabled tools.
+5. Confirm traces, conversation IDs, context, and sandbox state restore without serializing live clients or secrets.
+
+## Sources
+
+- `packages/agents-core/src/runState.ts`
+- `packages/agents-core/src/run.ts`
+- `packages/agents-core/src/result.ts`
+- `packages/agents-core/src/agentToolSourceRegistry.ts`
+- `packages/agents-core/src/runner/modelOutputs.ts`
+- `packages/agents-core/test/runState.test.ts`
+- `packages/agents-core/test/agentScenarios.test.ts`
+- `packages/agents-core/test/hitlMemorySessionScenario.test.ts`
+- `packages/agents-core/test/sandboxRuntime.test.ts`
+- `docs/src/content/docs/guides/human-in-the-loop.mdx`

--- a/.agents/references/sandbox-runtime-and-provider-boundaries.md
+++ b/.agents/references/sandbox-runtime-and-provider-boundaries.md
@@ -1,0 +1,51 @@
+# Sandbox Runtime and Provider Boundaries
+
+Use this reference for sandbox preparation, sessions, capabilities, manifests, mounts, path grants, snapshots, credentials, timeout, resume, process execution, or cleanup.
+
+## Trusted Configuration and Persisted State
+
+- Treat serialized sandbox session state, manifests, mount metadata, and provider values as untrusted. Recreate clients, credentials, policy, and executable tools from current trusted configuration.
+- Persist only the state needed to find or recreate a session. Never serialize live provider clients, resolved secrets, API keys, or host capabilities into RunState.
+- A prepared internal sandbox agent can add tools and prompts, but filters, hooks, handoffs, and results should keep the public source agent identity.
+- Merge provided and restored manifests by owned field. Preserve current environment resolvers and trusted configuration instead of allowing stale persisted fields to override them.
+
+## Paths, Mounts, and Materialization
+
+- Validate real host paths, normalized sandbox paths, traversal, symlinks, Git subpaths, archive entries, and extraction limits before materialization. A lexical prefix check is not a filesystem trust boundary.
+- Path grants must be enforced by every materialization route they claim to cover. Do not document a grant for local files, directories, archives, or Git sources unless that path actually consults it.
+- Keep remote mount commands allowlisted and separate command arguments from shell text. Validate privileged command environment and user selection.
+- Mount secrets and temporary archives must be cleaned on every failure path, including provider create, upload, extract, and late timeout completion.
+
+## Session and Process Lifecycle
+
+- Distinguish preserve from cleanup. A resumable session may survive a run, while disposable sessions must be destroyed; provider close and remote destroy are not interchangeable.
+- Remote timeout does not guarantee the remote operation stopped. Track late create/exec/cleanup completion and clean resources that appear after the local timeout.
+- Refresh provider credentials before expiry and on resume according to provider behavior. Prefer provider SDK state over assumptions from docs alone when units, lifecycle defaults, or generated types differ.
+- PTY and non-PTY process execution have different signal, buffering, exit, resize, and terminal-default behavior. Preserve output/status metadata and observe child failures during cleanup.
+
+## Provider Adapters
+
+- Keep shared archive, path, mount, process, session, and snapshot semantics in `sandbox/shared/`. Provider adapters should translate those contracts rather than fork validation rules.
+- Preserve structured provider error details and retryability without exposing credentials. Cleanup failure can be significant even when execution already failed; retain both causes.
+
+## Review Checklist
+
+1. Trace create, prepare, mount/materialize, execute, snapshot, preserve/destroy, resume, and failure cleanup.
+2. Validate host real paths, remote paths, archives, Git subpaths, symlinks, and command allowlists.
+3. Test timeout with a remote operation that completes late.
+4. Resume with stale or missing credentials and untrusted persisted state.
+5. Compare provider adapters with shared contracts and preserve structured errors without secrets.
+
+## Sources
+
+- `packages/agents-core/src/sandbox/`
+- `packages/agents-extensions/src/sandbox/`
+- `packages/agents-core/src/runner/sandbox.ts`
+- `packages/agents-core/src/runState.ts`
+- `packages/agents-core/test/sandboxRuntime.test.ts`
+- `packages/agents-core/test/sandboxManifest.test.ts`
+- `packages/agents-core/test/sandboxes/`
+- `packages/agents-extensions/test/sandbox/`
+- `docs/src/content/docs/guides/sandbox-agents.mdx`
+- `docs/src/content/docs/guides/sandbox-agents/concepts.mdx`
+- `docs/src/content/docs/guides/sandbox-agents/clients.mdx`

--- a/.agents/references/schema-and-zod-boundaries.md
+++ b/.agents/references/schema-and-zod-boundaries.md
@@ -1,0 +1,46 @@
+# Schema and Zod Boundaries
+
+Use this reference for function-tool parameters, structured agent output, strict JSON Schema conversion, Zod v3/v4 compatibility, or provider schema conversion.
+
+## Schema Ownership
+
+- Keep the runtime validator, model-visible JSON Schema, strictness flag, and invocation arguments aligned. A schema that a model can satisfy but the local validator rejects is not compatible.
+- `tool()` accepts Zod schemas and plain JSON Schema. Preserve explicit names, descriptions, aliases, required properties, defaults, and refinements where the supported conversion can represent them.
+- Structured agent output belongs to the effective agent/model call. Pass it through Responses and Chat Completions using each API's expected request shape without changing the local final-output validation contract.
+- Reject unsupported or ambiguous schema shapes at the earliest boundary with enough information to identify the tool or output type.
+
+## Zod v3/v4 Compatibility
+
+- Do not depend on one Zod version's private layout without a guarded compatibility helper. Use `zodCompat.ts` and `zodJsonSchemaCompat.ts` for object detection, parsing, descriptions, decorated fields, unions, enums, records, and fallback behavior.
+- Preserve descriptions while unwrapping optional, nullable, defaulted, refined, piped, or transformed schemas. Return an explicit unsupported result when introspection cannot be reliable.
+- Reject Zod types that cannot be produced by JSON parsing rather than advertising an impossible model schema.
+
+## Strict Conversion
+
+- Strict function schemas close objects and align required fields with provider expectations. Do not silently make an explicitly open schema mean something narrower without a deliberate contract.
+- Copy caller-owned plain schemas before normalization when conversion can mutate nested objects. Reusing a shared schema object must not accumulate provider-specific edits across runs.
+- Chat Completions and Responses have different structured-output and tool shapes. Test both converters instead of assuming a strict schema accepted by one path is accepted by the other.
+
+## Review Checklist
+
+1. Test Zod v3, Zod v4, and plain JSON Schema where the public API accepts all three.
+2. Compare runtime parsing with the exact schema sent to each provider path.
+3. Cover nested objects, unions, enums, optional/nullable fields, descriptions, and unsupported types.
+4. Verify strict conversion does not mutate caller-owned schemas or drop definitions.
+5. Test tool parameters and structured final output separately in streaming and non-streaming paths.
+
+## Sources
+
+- `packages/agents-core/src/tool.ts`
+- `packages/agents-core/src/agent.ts`
+- `packages/agents-core/src/utils/strictToolSchema.ts`
+- `packages/agents-core/src/utils/zodCompat.ts`
+- `packages/agents-core/src/utils/zodJsonSchemaCompat.ts`
+- `packages/agents-openai/src/openaiResponsesModel.ts`
+- `packages/agents-openai/src/openaiChatCompletionsConverter.ts`
+- `packages/agents-core/test/tool.test.ts`
+- `packages/agents-core/test/agent.test.ts`
+- `packages/agents-core/test/utils/zodJsonSchemaCompat.test.ts`
+- `packages/agents-openai/test/openaiResponsesModel.test.ts`
+- `packages/agents-openai/test/openaiChatCompletionsConverter.test.ts`
+- `docs/src/content/docs/guides/tools.mdx`

--- a/.agents/references/session-persistence.md
+++ b/.agents/references/session-persistence.md
@@ -1,0 +1,50 @@
+# Session Persistence
+
+Use this reference for `Session`, session-input callbacks, stored input, history mutation, per-turn writes, failure rollback, or compaction replacement.
+
+## Session Contract
+
+- `getItems(limit)` returns the latest limited window in chronological order. `addItems()` appends, `popItem()` removes the newest item, and `clearSession()` clears the boundary. Backends must preserve these semantics even when their storage API orders or paginates differently.
+- Return clones or otherwise prevent caller mutation from silently rewriting stored history. Normalize external records and skip or surface corrupt records according to the backend's documented recovery policy.
+- `rewriteHistory()` is an optional stronger contract for atomic mutations such as replacing approved function-call arguments. Do not emulate atomic rewrite with a partial clear-and-rebuild unless failure restoration is defined.
+
+## Preparing and Persisting Input
+
+- `sessionInputCallback` controls how stored history combines with current input for model preparation. Model-input filtering happens after preparation and filtered clones become the persistence candidates.
+- Keep prepared model input and persisted session input distinct. Server-managed conversations may use a session callback or session identity while intentionally omitting prior session history and writes.
+- Sanitize generated items before storage. Persist complete call/output pairs and remove provider-only replay metadata only at the boundary that requires it.
+
+## Per-Turn Writes and Resume
+
+- Streaming can persist input before the run finishes and append generated items incrementally. Use the one-shot persistence helper and persisted-item count so cancellation, retry, and resume do not duplicate records.
+- Preserve `_currentTurnPersistedItemCount` across RunState resume for an in-progress turn. Count post-conversion items that were actually written, not raw generated items.
+- A failed input guardrail must not leave new input committed as a successful turn. An aborted model request may need input preserved for retry; decide from the request boundary rather than applying one rollback rule to every failure.
+
+## Replacement and Recovery
+
+- Validate and normalize compacted replacement items before clearing history. Capture prior history before a destructive replacement.
+- If clear or append fails after storage changed, clean partial replacement state and restore the old history. If restoration also fails, preserve the primary failure and expose the restore failure rather than reporting success.
+- OpenAI Conversations conversion is a persistence boundary: preserve supported reasoning identity and encrypted content, drop unpersistable items deliberately, and skip empty writes.
+
+## Review Checklist
+
+1. Test ordering, limits, clone isolation, append, pop, clear, and optional rewrite semantics.
+2. Compare model input with exactly what the session stores after callbacks and filters.
+3. Test streaming cancellation, retry, interrupted resume, and partial per-turn persistence.
+4. Inject failures before and after destructive replacement and verify restoration.
+5. Confirm server-managed continuation does not produce a second authoritative transcript.
+
+## Sources
+
+- `packages/agents-core/src/memory/session.ts`
+- `packages/agents-core/src/memory/memorySession.ts`
+- `packages/agents-core/src/memory/historyMutations.ts`
+- `packages/agents-core/src/runner/sessionPersistence.ts`
+- `packages/agents-openai/src/memory/openaiConversationsSession.ts`
+- `packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts`
+- `packages/agents-core/test/memorySession.test.ts`
+- `packages/agents-core/test/runner/sessionPersistence.test.ts`
+- `packages/agents-core/test/runner/sessionPersistence.extended.test.ts`
+- `packages/agents-openai/test/openaiConversationsSession.test.ts`
+- `packages/agents-openai/test/openaiResponsesCompactionSession.test.ts`
+- `docs/src/content/docs/guides/sessions.mdx`

--- a/.agents/references/session-persistence.md
+++ b/.agents/references/session-persistence.md
@@ -6,7 +6,7 @@ Use this reference for `Session`, session-input callbacks, stored input, history
 
 - `getItems(limit)` returns the latest limited window in chronological order. `addItems()` appends, `popItem()` removes the newest item, and `clearSession()` clears the boundary. Backends must preserve these semantics even when their storage API orders or paginates differently.
 - Return clones or otherwise prevent caller mutation from silently rewriting stored history. Normalize external records and skip or surface corrupt records according to the backend's documented recovery policy.
-- `rewriteHistory()` is an optional stronger contract for atomic mutations such as replacing approved function-call arguments. Do not emulate atomic rewrite with a partial clear-and-rebuild unless failure restoration is defined.
+- `SessionHistoryRewriteAwareSession.applyHistoryMutations(...)` lets a session backend apply history mutations such as replacing approved function-call arguments. Do not emulate this contract with a partial clear-and-rebuild unless failure restoration is defined.
 
 ## Preparing and Persisting Input
 

--- a/.agents/references/tool-execution-and-approval-lifecycle.md
+++ b/.agents/references/tool-execution-and-approval-lifecycle.md
@@ -1,0 +1,50 @@
+# Tool Execution and Approval Lifecycle
+
+Use this reference for tool planning, approvals, guardrails, concurrency, aborts, timeouts, hooks, failure conversion, nested agent tools, or tool-choice reset.
+
+## Plan Before Side Effects
+
+- Normalize model output into an execution plan before invoking tools. Separate function, hosted, computer, shell, apply-patch, MCP approval, handoff, and tool-search actions so each lifecycle can enforce its own contract.
+- Parse and validate arguments before approval decisions that depend on input. Convert malformed JSON into the configured model-visible error path instead of crashing the runner without state.
+- Start all function calls by default or honor the configured concurrency cap while preserving output order. After the first fatal capped failure, do not start queued calls whose side effects have not begun.
+
+## Approval and Guardrail Order
+
+- Approval decisions are scoped by tool identity and call ID. An undecided call becomes a public interruption item; a decided call must not request approval again after resume.
+- Input guardrails run immediately before execution. `preApprovalInputGuardrails` optionally runs them before exposing a pending approval, but successful guardrails run again after approval because context or arguments may have changed.
+- Rejection returns the tool-specific or formatted model-visible result without running the tool. Preserve explicit rejection reasons and redact them from traces when sensitive tracing data is disabled.
+- Apply argument overrides to the executed call and canonical persisted history together. Do not execute one argument set while replaying another.
+
+## Invocation, Timeout, and Failure
+
+- Pass the current `RunContext`, stable call identity, abort signal, and tool-scoped metadata to invocation. Do not expose internal parent run configuration through public callback details.
+- A timeout can become an error result or a `ToolTimeoutError` carrying run state. Preserve the selected behavior across function and provider-backed tool paths.
+- Emit start/end hooks and spans exactly once, including error paths. A custom-data extractor failure must not emit a successful end event after the tool itself succeeded.
+- Tool input/output guardrail `rejectContent` replaces model-visible content; `throwException` surfaces a typed tool-call error. Stop evaluating later guardrails after a terminal behavior.
+- A nested agent tool has its own run state and can return an interruption. Rejecting it must clear the pending nested run so it cannot resume accidentally.
+
+## Tool Choice
+
+- Track use per agent identity. When `resetToolChoice` is enabled, clear a forced or named choice after that agent uses a tool, but preserve explicit `none` and do not mutate reusable agent settings.
+
+## Review Checklist
+
+1. Trace parse, guardrail, approval, invocation, output guardrail, custom data, hooks, spans, and persistence in order.
+2. Test approved, rejected, undecided, overridden, timed out, aborted, and throwing calls.
+3. Test uncapped and capped concurrency with a failure before queued work starts.
+4. Verify sensitive data redaction and one start/end event on every exit path.
+5. Resume function, hosted MCP, computer, shell, apply-patch, and nested-agent approvals.
+
+## Sources
+
+- `packages/agents-core/src/runner/toolExecution.ts`
+- `packages/agents-core/src/runner/mcpApprovals.ts`
+- `packages/agents-core/src/runner/approvalRejection.ts`
+- `packages/agents-core/src/runner/toolUseTracker.ts`
+- `packages/agents-core/src/toolGuardrail.ts`
+- `packages/agents-core/src/runContext.ts`
+- `packages/agents-core/test/runner/toolExecution.test.ts`
+- `packages/agents-core/test/runner/mcpApprovals.test.ts`
+- `packages/agents-core/test/agentScenarios.test.ts`
+- `docs/src/content/docs/guides/human-in-the-loop.mdx`
+- `docs/src/content/docs/guides/guardrails.mdx`

--- a/.agents/references/tool-identity-and-routing.md
+++ b/.agents/references/tool-identity-and-routing.md
@@ -1,0 +1,44 @@
+# Tool Identity and Routing
+
+Use this reference for tool names, namespaces, lookup, approvals, call IDs, collisions, deferred tools, MCP names, handoff routing, or trace labels.
+
+## Identity Layers
+
+- Keep declared name, optional namespace, qualified lookup name, model-visible name, display name, provider call ID, and item ID distinct. One string is not a safe substitute for every layer.
+- Use `toolQualifiedName()` and the helpers in `toolIdentity.ts` and `tooling.ts`. Do not add local concatenation or fallback rules in converters, approvals, traces, or adapters.
+- A normal namespaced function tool resolves by qualified name. A top-level deferred tool can be self-namespaced on the wire; preserve the special bare-name preference so it does not collide with a real namespace group.
+- Collision checks must use the same enabled tool and handoff set exposed to the model. Disabled handoffs do not reserve names; local functions and already allocated normalized MCP names do.
+
+## MCP and Handoffs
+
+- Prefixing local MCP tool names with a server name changes the model-visible collision-safe wrapper name, not the original name sent back to the MCP server.
+- Sanitize and length-limit generated MCP names deterministically, including a stable collision suffix. Cache entries must rebind wrappers to the current server instance.
+- Handoff tool names are routing identities. Keep text-runner and Realtime handoff conversion aligned and preserve explicit clone overrides.
+
+## Call IDs and Tool Search
+
+- Match tool calls and outputs with provider call IDs when available, then stable item IDs, then a controlled generated fallback. Do not consume a pending client call ID for a server-executed tool-search output.
+- Repeated tool-search output with the same call ID is a replacement/update, not necessarily a duplicate to drop. Out-of-order results must find the correct pending call.
+- Persist qualified names and approval IDs in RunState so resume routes to the same tool even when bare names repeat across namespaces or agents.
+
+## Review Checklist
+
+1. Name every identity layer used by the change and the helper that owns it.
+2. Test bare, namespaced, self-namespaced deferred, MCP-prefixed, handoff, and duplicate-name cases.
+3. Verify the model exposure set and dispatch/approval maps use the same enabled tools.
+4. Test missing, camelCase, snake_case, out-of-order, and repeated call IDs.
+5. Round-trip identity through stream events, sessions, adapters, tracing, and RunState.
+
+## Sources
+
+- `packages/agents-core/src/toolIdentity.ts`
+- `packages/agents-core/src/tooling.ts`
+- `packages/agents-core/src/tool.ts`
+- `packages/agents-core/src/handoff.ts`
+- `packages/agents-core/src/mcp.ts`
+- `packages/agents-core/src/runner/modelOutputs.ts`
+- `packages/agents-core/src/runState.ts`
+- `packages/agents-core/test/toolIdentity.test.ts`
+- `packages/agents-core/test/tooling.test.ts`
+- `packages/agents-core/test/mcpCache.test.ts`
+- `packages/agents-core/test/runState.test.ts`

--- a/.agents/references/tracing-and-runtime-context.md
+++ b/.agents/references/tracing-and-runtime-context.md
@@ -1,0 +1,47 @@
+# Tracing and Runtime Context
+
+Use this reference for trace/span context, processors, export, flush, shutdown, resume, runtime storage, usage, or sensitive data.
+
+## Context and Lifecycle
+
+- A trace owns spans; the active context determines implicit parentage. Start/end processor callbacks must occur once and restore the previous span stack after success or failure.
+- Node can use `AsyncLocalStorage`; browser/workerd shims use a compatible storage contract. Keep context active through awaited callbacks and until streamed results settle, not merely until a function returns the stream object.
+- Captured trace context can be restored around a callback. Clearing context must restore the prior ambient value afterward and must not allow new spans on an ended trace.
+- A resumed RunState may restore a trace and current agent span, then apply current run overrides. Do not attach a new run to stale ambient context accidentally.
+
+## Processors and Shutdown
+
+- Processors receive trace/span start and end events independently. Completed external trace/span dispatch must not rewrite source timestamps or dispatch no-op objects.
+- Batch processors keep exporting after an exporter failure, honor buffer and trigger limits, and serialize flush/shutdown with in-flight export.
+- Deduplicate shutdown. `beforeExit` cleanup is one-shot and best-effort; a timeout must not force process exit. Abort active export on timed shutdown and observe late failures.
+- Replacing processors must shut down the old set without losing the new provider's lifecycle.
+
+## Data and Export
+
+- `traceIncludeSensitiveData` controls model/tool input and output on spans. Redact exception payloads and formatted rejection text as well as normal fields; hiding a top-level field is insufficient if the original error remains attached.
+- Core spans retain provider-neutral usage. The OpenAI exporter maps required token totals and moves supported extra fields into `usage.details` without inventing values.
+- Sanitize and byte-limit exported payloads while preserving list positions and useful structured shape. Omit unserializable or getter-throwing values safely.
+- Per-run tracing API keys and metadata propagate to child spans but are serialized only when explicitly allowed.
+
+## Review Checklist
+
+1. Test parentage and restoration across await, throw, stream completion, nested runs, and resume.
+2. Exercise Node and browser-style context storage.
+3. Test exporter error, scheduled retry, flush, shutdown timeout, active abort, and duplicate shutdown.
+4. Verify sensitive input/output, errors, metadata, and usage are redacted or mapped at the correct layer.
+5. Confirm no-op traces/spans never reach processors or exporters.
+
+## Sources
+
+- `packages/agents-core/src/tracing/context.ts`
+- `packages/agents-core/src/tracing/provider.ts`
+- `packages/agents-core/src/tracing/processor.ts`
+- `packages/agents-core/src/tracing/traces.ts`
+- `packages/agents-core/src/tracing/spans.ts`
+- `packages/agents-core/src/tracing/createSpans.ts`
+- `packages/agents-core/src/runner/tracing.ts`
+- `packages/agents-openai/src/openaiTracingExporter.ts`
+- `packages/agents-core/test/tracing.test.ts`
+- `packages/agents-core/test/runner/tracing.test.ts`
+- `packages/agents-openai/test/openaiTracingExporter.test.ts`
+- `docs/src/content/docs/guides/tracing.mdx`

--- a/.agents/skills/maintainer-review/SKILL.md
+++ b/.agents/skills/maintainer-review/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: maintainer-review
+description: Review a GitHub issue or pull request URL as an openai-agents-js maintainer, with a verdict on whether the claim is real, practically important, correctly scoped, and worth maintainer and contributor effort. Use when assessing issue validity or severity, deciding whether an issue should be prioritized or closed, judging whether a PR meets a real need and is worth bringing to mergeable quality, comparing open PRs that address the same issue, separating code quality from repository readiness, comparing a proposed fix with simpler alternatives, or drafting a concise maintainer assessment. When closure, additional evidence, or code changes should be requested, also produce a polite, concise, complete, copy-paste-ready maintainer comment in English.
+---
+
+# Maintainer Review
+
+## Objective
+
+Make a maintainer decision, not a generic diff summary. Separate these questions:
+
+1. Is the claimed behavior real?
+2. Can supported users plausibly reach it?
+3. What happens when they do?
+4. Is it important enough to act on now?
+5. For a PR, is this solution worth merging and maintaining?
+6. If competing PRs exist, which single implementation path should maintainers pursue?
+7. What concise maintainer message should communicate closure, an evidence request, or required changes?
+
+Lead with the verdict. Use the diff, issue narrative, and contributor effort as evidence, not as proxies for impact.
+
+## Workflow
+
+### 1. Establish the exact remote target
+
+- Accept a GitHub issue or PR URL as the primary input. Resolve owner, repository, item type, and number before reviewing it.
+- For an issue, read the full report, comments, reproduction, environment, linked material, and maintainer responses.
+- For a PR, inspect the current remote base and head, full patch, commit history when relevant, tests, linked issue, and review discussion. Do not substitute the current local checkout for the remote change.
+- State the claim in one falsifiable sentence. Separate the observed symptom from the proposed cause or fix.
+- Identify the latest released boundary when compatibility or regression claims matter.
+
+Use read-only GitHub access. On this laptop, do not run `gh` unless the user explicitly asks in the same turn. A review never authorizes comments, labels, branch changes, pushes, merges, or other remote writes.
+
+### 2. Discover competing open PRs proportionally
+
+Do this before deeply evaluating a specified PR. A PR URL selects the starting point, not necessarily the entire comparison set.
+
+- Determine the primary issue from explicit closing keywords, linked issues, timeline/development links, PR body/comments, and the reproduced symptom. State when association is inferred.
+- When an issue is explicitly linked, enumerate all open PRs that address it through cross-references, closing keywords, and development links. Include drafts but label them.
+- When no issue is linked, run a bounded duplicate search using the strongest signals from the title, reproduction, violated invariant, and runtime path.
+- Exclude closed/merged PRs from the active comparison set while using them as history when relevant.
+- Require a shared issue, symptom, violated invariant, or materially overlapping path. A shared package label is not enough.
+- If repository access cannot establish completeness, say so instead of claiming every candidate was found.
+
+Compare candidates on need coverage, runtime correctness, placement, tests, compatibility, complexity, readiness, remaining maintainer work, and reusable pieces. Prefer the best maintainable solution, not the first or smallest diff by default.
+
+### 3. Find the shortest decisive evidence path
+
+Inspect the real runtime path before judging a change as trivial or meaningful. Check callers, public exports, equivalent streaming/non-streaming or provider/runtime paths, persistence, cleanup, and focused tests.
+
+Start with `.agents/references/README.md` and open only the references for the affected boundary. Treat `.agents/references/` as read-only background during review. Verify every current claim against the remote change, current source, tests, docs, release boundary, and runtime evidence. Do not infer issue status or PR correctness from a reference. Recommend a separate reference-maintenance change when review reveals a durable invariant unless the user explicitly includes that update.
+
+Use this evidence order:
+
+1. Existing tests and a complete code-path trace.
+2. A focused local reproduction of the exact claim.
+3. A comparison with the latest release, base branch, or another known-good control.
+4. A broader runtime matrix only when the decision remains uncertain.
+
+Use a focused local reproduction by default when runtime behavior materially affects the verdict. Include a base/release control for regression claims. For latency, timeout, buffering, backpressure, or cleanup, measure an observable elapsed-time or state transition where feasible.
+
+Use `$runtime-behavior-probe` only when the user explicitly invokes it or approves a proposed broader matrix. Preserve its environment-variable, live-service, cost, cleanup, and reporting gates. Ordinary maintainer review must not depend on that skill.
+
+For validation, cleanup, retries, interruption, background work, or concurrency:
+
+- Identify the earliest correct decision point after dynamic inputs are available.
+- List resources acquired before and after it: listeners, promises/tasks, streams, connections, files, locks, caches, state mutations, and telemetry.
+- Exercise failure during construction, connection, validation, execution, and cleanup where applicable.
+- Verify explicit cleanup when failure occurs before normal teardown.
+- Require a negative-path test when a listener, promise, stream, connection, process, or state can remain.
+
+Stop when additional evidence is unlikely to change validity, severity, or maintainer action.
+
+### 4. Calibrate validity and impact
+
+Read [the evaluation framework](references/evaluation-framework.md) when validity, severity, or merge value is not immediately clear.
+
+Assess claim validity, realistic reach, consequence, breadth, frequency, recoverability, compatibility, and severity. Keep observed facts separate from inference and name missing evidence that could change the result.
+
+For a PR, make `Severity` describe the underlying issue or user need. Report patch-induced regression, compatibility, lifecycle, or maintenance risk separately as `Patch risk`.
+
+Do not speculate about AI authorship or contributor intent. Identify weak reports through objective evidence: no reproduction, unsupported input, impossible path, duplicated handling, a test that does not exercise the claim, or a fix that is a runtime no-op.
+
+### 5. Apply the maintainer-effort test
+
+Use one code verdict:
+
+- **Merge-worthy as-is**: real need, sound placement, proportionate scope, and adequate tests.
+- **Merge-worthy after focused changes**: real need and viable direction with bounded corrections.
+- **Supersede with a simpler alternative**: real need, but a smaller or more coherent fix is preferable.
+- **Not worth completing**: negligible/unsupported impact, no-op behavior, wrong abstraction, or excessive completion cost.
+
+For merge-worthy verdicts, use one repository-readiness status when useful:
+
+- **Ready**
+- **CI or review pending**
+- **Rebase or conflict resolution required**
+- **Blocked**
+
+Omit readiness for supersede/not-worth-completing verdicts; CI does not change those code decisions. Do not downgrade sound code only because CI is pending, and do not call a PR ready when semantic changes remain.
+
+For competing PRs, make one portfolio recommendation: choose one, choose one after focused changes, combine exact pieces into one destination, replace all with a simpler approach, or merge none. State what should happen to every active candidate.
+
+Always consider at least one alternative: no code change, validation/error improvement, documentation, reuse of an existing helper, a narrower supported path, or enforcement at a different shared layer.
+
+### 6. Report the decision and action
+
+Choose the assessment language from the current user request and governing repository instructions. Maintainer comment drafts remain English.
+
+Use the matching compact report in the evaluation framework. Keep the report decision-oriented, put unexpected/negative evidence first, and use no more than five evidence bullets by default.
+
+When recommending closure, more evidence, focused changes, or superseding a PR, append a polite, complete, copy-paste-ready English maintainer comment. Include only merge-blocking work in its required-action paragraph. Do not produce a line-by-line review unless requested, equate passing tests with merge-worthiness, or equate a logically correct patch with practical value.
+
+## Resource
+
+- `references/evaluation-framework.md` contains the severity rubric, evidence checks, lifecycle review, issue dispositions, PR value checks, documentation threshold, competing-PR framework, maintainer-comment guidance, and compact report variants.

--- a/.agents/skills/maintainer-review/agents/openai.yaml
+++ b/.agents/skills/maintainer-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Maintainer Review"
+  short_description: "Assess SDK issues and pull requests"
+  default_prompt: "Use $maintainer-review to assess this GitHub issue or pull request and recommend the best maintainer action."

--- a/.agents/skills/maintainer-review/references/evaluation-framework.md
+++ b/.agents/skills/maintainer-review/references/evaluation-framework.md
@@ -1,0 +1,259 @@
+# Maintainer Evaluation Framework
+
+Use this reference when a claim is ambiguous, severity is disputed, or a technically correct PR may not justify permanent maintenance.
+
+## Contents
+
+- [Decision model](#decision-model)
+- [Severity](#severity)
+- [Evidence strength](#evidence-strength)
+- [Issue disposition](#issue-disposition)
+- [PR quality and value](#pr-quality-and-value)
+- [Documentation threshold](#documentation-threshold)
+- [Lifecycle and failure paths](#lifecycle-and-failure-paths)
+- [Alternatives](#alternatives)
+- [Competing pull requests](#competing-pull-requests)
+- [Maintainer comments](#maintainer-comments)
+- [Compact report variants](#compact-report-variants)
+
+## Decision Model
+
+Treat validity, severity, and merge-worthiness as separate outputs.
+
+| Dimension | Question | Strong evidence |
+| --- | --- | --- |
+| Claim validity | Does the exact behavior occur, and is the proposed cause correct? | Reproduction, failing focused test, or complete reachable path |
+| Reachability | Can supported realistic inputs reach it? | Public API trace, real configuration, user report, or release comparison |
+| Consequence | What fails, and is it silent or recoverable? | Observed output/error/state and downstream effect |
+| Breadth | Which packages, runtimes, providers, and versions are affected? | Explicit path and compatibility matrix |
+| Frequency | Is it normal, intermittent, or pathological? | Repeats, deterministic preconditions, reports, or telemetry |
+| Compatibility | Is released API, package resolution, protocol, or durable state changed? | Latest release comparison and contract inspection |
+| Solution fit | Does the fix enforce the invariant at the owning layer? | Equivalent paths remain aligned and alternatives were tested |
+| Maintenance cost | What permanent complexity and review burden is added? | New branches/configuration, changed surface, tests, and remaining work |
+
+## Severity
+
+- **Negligible**: no runtime difference, unreachable/unsupported input, cosmetic inconsistency, or harmless edge case. Usually close, document, or decline code complexity.
+- **Low**: real but narrow and recoverable behavior with a simple workaround and no data, security, or compatibility risk. Merge only when the fix is small and strengthens an invariant.
+- **Moderate**: supported use fails or produces incorrect behavior for a meaningful subset. Prioritize a bounded fix and regression test.
+- **High**: common or important use is broken, released compatibility is seriously affected, sensitive data can leak, or persistent corruption is possible. Require urgent strong validation.
+- **Critical**: broadly exploitable security impact, severe data loss, or systemic failure requiring coordinated action. Use only with concrete evidence.
+
+Severity is consequence multiplied by realistic reach and frequency, reduced by recoverability. Do not raise it because prose is alarming or lower it because a diff is small.
+
+## Evidence Strength
+
+Before calling a claim confirmed, answer:
+
+- Does the reproduction exercise the same public/internal path?
+- Does failure occur on the relevant base, latest release, or target?
+- Does the regression test fail without the patch and pass with it?
+- Are stale `dist`, wrong worktree/imports, dependency drift, proxies, caches, runtime conditions, unavailable Docker/sandbox, authentication, quota, and service failures excluded?
+- Does an equivalent streaming/non-streaming, provider, runtime, resume, or package-export path differ?
+- Is behavior prohibited by a real contract or merely surprising?
+- For latency, timeout, buffering, backpressure, or cleanup, was observable time or state measured rather than inferred only from mocks?
+
+Use `partially confirmed` when the symptom is real but cause/reach/scope is wrong. Use `unproven` when decisive evidence is missing. Use `contradicted` only when evidence directly disproves the claim.
+
+## Issue Disposition
+
+Choose one:
+
+- **Prioritize**: confirmed moderate-or-higher impact or important invariant with no safe workaround.
+- **Accept, low priority**: confirmed low impact and a proportionate fix is plausible.
+- **Narrow scope**: valid core, overstated paths or expected behavior.
+- **Needs evidence**: plausible but missing a supported reproduction or contract basis.
+- **Close**: duplicate, unsupported, unreachable, contradicted, no-op, or not worth permanent complexity.
+
+Ask only for evidence that could change the disposition.
+
+## PR Quality and Value
+
+Assess independently:
+
+1. **Need**: a real problem or user need is demonstrated.
+2. **Correctness**: the fix covers the claim and meaningful boundaries.
+3. **Placement**: the invariant is enforced once at the owning layer.
+4. **Consistency**: equivalent streaming/non-streaming, provider, runtime, serialization, resume, package, and adapter paths stay aligned.
+5. **Tests**: a regression test fails on base, passes on head, and asserts the non-happy-path value/state.
+6. **Compatibility**: released exports, package conditions, types, protocols, schemas, and error behavior are preserved or intentionally migrated.
+7. **Proportionality**: public surface and complexity match impact.
+8. **Completion cost**: remaining code, tests, docs, design, and conflict work is bounded enough to justify attention.
+
+A PR can be correct but not merge-worthy because the need is negligible, the real path is unchanged, equivalent paths remain inconsistent, the abstraction costs more than the benefit, or a simpler mechanism exists.
+
+Keep issue severity separate from `Patch risk`. A patch-induced regression, compatibility break, listener/resource leak, or maintenance hazard does not make the underlying issue more severe.
+
+## Documentation Threshold
+
+Make docs merge-blocking only when:
+
+- Existing docs become materially false, unsafe, or misleading.
+- Safe/correct use depends on a non-obvious constraint, migration, compatibility boundary, or operational warning.
+- Repository policy, accepted scope, or an explicit maintainer decision requires docs in the same PR.
+- The feature is practically unusable or undiscoverable without a user-facing entrypoint and generated/API discovery is insufficient.
+
+Keep optional discoverability/completeness non-blocking. Do not downgrade a code verdict solely for optional docs or include optional docs in a required-action paragraph.
+
+## Lifecycle and Failure Paths
+
+Apply this section when a change adds validation, fail-fast behavior, cleanup, retry, interruption, background work, streaming, or concurrency.
+
+- Identify the earliest point where all dynamic inputs required for a correct decision exist.
+- List side effects before and after that point: listeners, promises/tasks, streams, sockets, peer connections, processes, files, locks, caches, state, persistence, and telemetry.
+- Exercise failure during construction, connection, validation, execution, persistence, and teardown where those phases exist.
+- Confirm normal teardown is actually entered. If construction/connect fails, verify explicit cleanup.
+- Prefer validation after dynamic configuration is resolved but before avoidable side effects begin.
+- Require a regression test for any listener, promise, stream lock, connection, process, file, or state that can remain after failure.
+
+## Alternatives
+
+Test at least one:
+
+- What happens with no code change?
+- Can input validation or an existing helper enforce the invariant earlier?
+- Can the fix be limited to the supported failing path?
+- Would clearer error or documentation prevent misuse without runtime complexity?
+- Can a failing test reveal a smaller correct change?
+- Is a new public option compensating for an internal ownership problem?
+- Can the same result be achieved in the converter, adapter, or state owner instead of every caller?
+
+## Competing Pull Requests
+
+Require an explicit issue link, same reproduction, same violated invariant, or materially overlapping runtime path before grouping candidates.
+
+| Criterion | Question |
+| --- | --- |
+| Coverage | Whole confirmed issue, useful subset, or adjacent problem? |
+| Correctness | Real path and meaningful boundaries? |
+| Placement | Owning shared layer? |
+| Tests | Base failure reproduced and approaches distinguished? |
+| Compatibility | Released APIs, packages, state, protocols, providers, runtimes? |
+| Complexity | Permanent branches, abstractions, configuration, coupling? |
+| Readiness | Mergeable now or bounded focused work? |
+| Reuse | Exact tests or ideas worth transferring? |
+
+Choose one portfolio action:
+
+- **Prefer one PR**
+- **Prefer one after focused changes**
+- **Combine selectively** into a named destination PR
+- **Replace all** with a simpler/coherent implementation
+- **Merge none**
+
+Do not issue independent approvals for overlapping candidates. State the action for every active PR.
+
+## Maintainer Comments
+
+Write drafts in English. Produce one when recommending closure, more evidence, focused changes, superseding, or choosing among competing PRs.
+
+Keep it polite, direct, complete, and usually 60-160 words in one to three short paragraphs:
+
+1. Acknowledge the contribution/report.
+2. State the decision with decisive technical evidence.
+3. Give the exact next action or reconsideration condition.
+
+Do not include internal severity labels, speculate about authorship/intent, repeat the full review, or soften the requested action until it is unclear.
+
+### Close
+
+```text
+Thanks for taking the time to investigate this. I traced the reported case through <path or behavior>, and <decisive finding>. In the supported path, <practical result>, so the added complexity is not justified by the demonstrated impact.
+
+I am going to close this <issue/PR>. If you can provide <specific reproduction or evidence that would change the decision>, we can revisit the underlying problem with that narrower scope.
+```
+
+### Request Changes
+
+```text
+Thanks for the contribution. The underlying issue is valid, and this approach is directionally reasonable. Before we can merge it, please address the following points: <bounded required changes>.
+
+These changes are needed because <contract, lifecycle, compatibility, or test reason>. Once they are covered with a regression test that fails on the base and passes on the updated branch, the PR should be ready for another review.
+```
+
+Adapt these templates to evidence. Do not use them as filler.
+
+## Compact Report Variants
+
+### Issue
+
+```markdown
+## Verdict
+
+<Real/partial/unproven/contradicted, severity, and disposition.>
+
+## Evidence
+
+- <decisive evidence>
+- <scope or uncertainty>
+
+## Recommendation
+
+<Prioritize, accept low priority, narrow, request evidence, or close.>
+
+## Maintainer comment draft
+
+<Include for closure or an evidence request.>
+```
+
+### Pull Request
+
+```markdown
+## Verdict
+
+<Need, practical impact, and merge-worthiness.>
+
+- Code verdict: <code disposition>
+- Repository readiness: <one allowed status; only when useful for a merge-worthy verdict>
+
+## Evidence
+
+- <runtime/code-path result>
+- <test/compatibility result>
+
+## Issue impact
+
+- Validity: <claim validity>
+- Severity: <underlying issue severity>
+- Reach: <realistic reach>
+
+## Patch risk
+
+<Only meaningful patch-induced risk.>
+
+## PR quality
+
+- Solution fit: <assessment>
+- Tests: <assessment>
+- Remaining effort: <bounded/unbounded and why>
+
+## Recommendation
+
+<Merge, focused changes, simpler replacement, or close.>
+
+## Maintainer comment draft
+
+<Only when closure, evidence, or changes should be requested.>
+```
+
+### Competing Pull Requests
+
+```markdown
+## Verdict
+
+<Issue validity, severity, and preferred implementation path.>
+
+## Open PR comparison
+
+| PR   | Approach | Correctness | Tests | Compatibility/complexity | Readiness |
+| ---- | -------- | ----------- | ----- | ------------------------ | --------- |
+| #... | ...      | ...         | ...   | ...                      | ...       |
+
+## Recommendation
+
+<Select one, request focused changes, combine exact pieces, replace all, or merge none.> <State the action for every other active candidate.>
+
+## Maintainer comment drafts
+
+<One draft for each PR that should be closed, changed, or superseded.>
+```

--- a/.agents/skills/runtime-behavior-probe/references/openai-runtime-patterns.md
+++ b/.agents/skills/runtime-behavior-probe/references/openai-runtime-patterns.md
@@ -27,6 +27,18 @@ Do not read these variables automatically. Before a live probe uses any of them,
 
 If the task targets another standard integration, use that integration's expected default variable names under the same rule.
 
+## Environment False Signals
+
+Before attributing a failure to the patch under review, exclude source-selection and environment problems with a controlled base/head comparison.
+
+- Confirm the commit, worktree, working directory, Node executable/version, and imported module path. A probe of stale `dist`, another checkout, `/tmp/node_modules`, or an installed package does not prove current `src` behavior.
+- Rebuild when emitted declarations, package exports, generated metadata, or `dist` is the subject. Otherwise prefer current source imports so stale build output cannot create a false result.
+- Run base and head controls with the same Node/pnpm versions, dependency graph, runtime condition, environment-variable names, and command shape. Record intentional differences.
+- Treat proxy initialization, sandbox denials, unavailable Docker/provider infrastructure, expired remote sessions, authentication, quota, rate limits, service outages, and stale caches as environment conditions until a controlled rerun ties them to the patch.
+- Never print proxy URLs, tokens, credentials, or secret values. Change only the minimum in-scope environment or disposable state needed for the control and record variable names rather than values.
+
+In the final report, distinguish code failures, unsupported configurations, environment blockers, and inconclusive probes. Do not collapse them into one failed-test count.
+
 ## Responses API Probe Patterns
 
 For Responses API work, start from the uncertainty instead of from the full feature surface.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ The OpenAI Agents JS repository is a pnpm-managed monorepo that provides:
 - `scripts/dev.mts`: Runs concurrent build-watchers and the docs dev server (`pnpm dev`).
 - `scripts/embedMeta.ts`: Generates `src/metadata.ts` for each package before build.
 - `helpers/tests/`: Shared test utilities.
+- `.agents/references/`: Durable SDK maintainer architecture references. Start with [the reference map](.agents/references/README.md) and open only the files relevant to the affected boundary.
 - `README.md`: High-level overview and installation instructions.
 - `CONTRIBUTING.md`: Official contribution guidelines (this guide is complementary).
 - `pnpm-workspace.yaml`: Defines workspace packages.
@@ -81,15 +82,27 @@ The OpenAI Agents JS repository is a pnpm-managed monorepo that provides:
 
 ### Agents Core Runtime Guidelines
 
+- For public exports, convenience-package re-exports, ESM/CJS/types, optional dependencies, import side effects, or Node/browser/workerd shims, read [Public API, package, and runtime boundaries](.agents/references/public-api-package-and-runtime-boundaries.md).
+- For Agent configuration, cloning, dynamic instructions, enabled tools/handoffs, nested agent tools, run context, usage, or public-versus-prepared identity, read [Agent definition and run context](.agents/references/agent-definition-and-run-context.md).
 - `packages/agents-core/src/run.ts` is the runtime entrypoint; keep it small and focused on orchestration.
 - Add new runtime logic under `packages/agents-core/src/runner/`, organized by responsibility, then import into `run.ts`.
 - When `run.ts` grows, refactor helpers into `runner/` modules and leave only wiring and composition in `run.ts`.
 - Keep `packages/agents-core/src/agent.ts` focused on the Agent class and its type definitions; move helper logic into dedicated modules (for example, `agentToolInput.ts`).
-- Keep streaming and non-streaming loops behaviorally aligned; changes to one loop should be mirrored in the other.
-- Input guardrails run only on the first turn; interruption resumes should not increment the turn counter.
-- When `conversationId`/`previousResponseId` is provided, only deltas are sent; `callModelInputFilter` must return an input array and keep session persistence in sync.
-- Adding new tool/output/approval item types requires coordinated updates across model output processing, tool execution, turn resolution, streaming events, run item extraction, and RunState serialization.
-- If serialized RunState shape changes in a released or otherwise supported snapshot format, bump the schema version and update serialization/deserialization. Unreleased post-tag RunState changes on `main` may fold into the same next schema version when no supported snapshot consumer exists yet.
+- For turn accounting, guardrail order, handoffs, interruption, cancellation, hooks, final output, or streaming behavior, read [Runner lifecycle](.agents/references/runner-lifecycle.md). Keep streaming and non-streaming paths behaviorally aligned.
+- For new model output, tool call, approval, or run-item variants, read [Run item and stream lifecycle](.agents/references/run-item-and-stream-lifecycle.md) and update every applicable processing, event, replay, persistence, tracing, serialization, and adapter surface.
+- For function-tool parameters, structured output, strict JSON Schema conversion, Zod v3/v4, or provider schema conversion, read [Schema and Zod boundaries](.agents/references/schema-and-zod-boundaries.md).
+- For `conversationId`, `previousResponseId`, explicit replay, filtering, continuation, compaction strategy, retry, or resume, read [Conversation state ownership](.agents/references/conversation-state-ownership.md).
+- For session callbacks, stored input, history mutation, per-turn writes, rollback, or compaction replacement, read [Session persistence](.agents/references/session-persistence.md).
+- For serialized RunState, approvals, agent/tool reconstruction, traces, conversation IDs, or sandbox state, read [RunState schema and resume](.agents/references/runstate-schema-and-resume.md). Bump a released schema when its durable meaning changes; unreleased post-tag versions may be folded into the same next schema when no supported snapshot consumer exists.
+- For tool names, namespaces, lookup, call IDs, approvals, collisions, deferred tools, MCP names, or trace labels, read [Tool identity and routing](.agents/references/tool-identity-and-routing.md) and use the canonical helpers in `toolIdentity.ts` and `tooling.ts`.
+- For tool planning, approvals, guardrails, concurrency, aborts, timeouts, hooks, failure conversion, nested agent tools, or tool-choice reset, read [Tool execution and approval lifecycle](.agents/references/tool-execution-and-approval-lifecycle.md).
+- For local MCP connections, stdio/SSE/streamable HTTP, requests, cache/filtering, retries, cancellation, or cleanup, read [MCP transport, cache, and shims](.agents/references/mcp-transport-cache-and-shims.md).
+- For model resolution, settings merge, Responses/Chat Completions conversion, provider data, raw events, retries, transport reuse, or Responses WebSocket sessions, read [Model, provider, and conversion boundaries](.agents/references/model-provider-and-conversion-boundaries.md).
+- For trace/span context, processors, export, flush, shutdown, resume, runtime storage, usage, or sensitive data, read [Tracing and runtime context](.agents/references/tracing-and-runtime-context.md).
+- For Realtime agent/session state, response sequencing, tools, guardrails, history, handoffs, listeners, or cleanup, read [Realtime session lifecycle](.agents/references/realtime-session-lifecycle.md).
+- For WebRTC, WebSocket, SIP, Twilio, Cloudflare, connection state, audio formats, transcripts, or Realtime event payloads, read [Realtime transport, audio, and events](.agents/references/realtime-transport-audio-and-events.md).
+- For sandbox preparation, sessions, manifests, mounts, path grants, snapshots, credentials, timeout, resume, process execution, or cleanup, read [Sandbox runtime and provider boundaries](.agents/references/sandbox-runtime-and-provider-boundaries.md).
+- For AI SDK model/UI adapters, provider metadata, usage, reasoning, tool-call translation, aborts, or stream completion, read [Extension adapter boundaries](.agents/references/extension-adapter-boundaries.md).
 
 ### Runtime and Platform Review Checklist
 


### PR DESCRIPTION
This pull request adds repository-local maintainer knowledge derived from the TypeScript SDK's implementation, tests, documentation, release history, and merged pull requests.

It introduces a map of 17 SDK architecture references, a `maintainer-review` skill for evidence-based issue and pull request assessment, and TypeScript-specific guidance for excluding environment false signals during runtime investigation. `AGENTS.md` now routes work to the relevant reference while keeping current source and remote evidence authoritative.