### PR TITLE
fix(realtime): prevent ambiguous tool dispatch

### DIFF
--- a/.changeset/calm-tools-dispatch.md
+++ b/.changeset/calm-tools-dispatch.md
@@ -1,5 +1,5 @@
 ---
-'@openai/agents-realtime': patch
+'@openai/agents-realtime': minor
 ---
 
 fix: prevent ambiguous Realtime tool dispatch across agent handoffs

--- a/.changeset/calm-tools-dispatch.md
+++ b/.changeset/calm-tools-dispatch.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: prevent ambiguous Realtime tool dispatch across agent handoffs

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -456,6 +456,7 @@ export abstract class OpenAIRealtimeBase
           callId: item.call_id ?? '',
           arguments: item.arguments ?? '',
           name: item.name ?? '',
+          responseId: parsed.response_id,
         });
         return;
       }

--- a/packages/agents-realtime/src/realtimeSession.ts
+++ b/packages/agents-realtime/src/realtimeSession.ts
@@ -43,7 +43,10 @@ import { OpenAIRealtimeWebSocket } from './openaiRealtimeWebsocket';
 import { RealtimeAgent } from './realtimeAgent';
 import { RealtimeSessionEventTypes } from './realtimeSessionEvents';
 import type { ApiKey, RealtimeTransportLayer } from './transportLayer';
-import type { TransportToolCallEvent } from './transportLayerEvents';
+import type {
+  TransportLayerResponseStarted,
+  TransportToolCallEvent,
+} from './transportLayerEvents';
 import type { InputAudioTranscriptionCompletedEvent } from './transportLayerEvents';
 import {
   approvalItemToRealtimeApprovalItem,
@@ -236,6 +239,17 @@ type PendingRealtimeFunctionCall<TBaseContext> = {
   approvalItem: RunToolApprovalItem;
 };
 
+function getStartedResponseId(
+  event: TransportLayerResponseStarted,
+): string | undefined {
+  const response = event.providerData?.response;
+  if (typeof response !== 'object' || response === null) {
+    return undefined;
+  }
+  const responseId = (response as { id?: unknown }).id;
+  return typeof responseId === 'string' ? responseId : undefined;
+}
+
 function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -280,6 +294,12 @@ export class RealtimeSession<
   #currentAgent: SessionRealtimeAgent<TBaseContext>;
   #currentTools?: RealtimeToolDefinition[];
   #currentDispatchSnapshot?: RealtimeDispatchSnapshot<TBaseContext>;
+  #activeResponseDispatchSnapshot?: RealtimeDispatchSnapshot<TBaseContext>;
+  #activeResponseId?: string;
+  #responseDispatchSnapshots = new Map<
+    string,
+    RealtimeDispatchSnapshot<TBaseContext>
+  >();
   #pendingFunctionCalls = new Map<
     string,
     PendingRealtimeFunctionCall<TBaseContext>
@@ -950,8 +970,17 @@ export class RealtimeSession<
       }
       this.emit('audio', event);
     });
-    this.#transport.on('turn_started', () => {
+    this.#transport.on('turn_started', (event) => {
       this.#audioStarted = false;
+      const responseId = getStartedResponseId(event);
+      this.#activeResponseDispatchSnapshot = this.#currentDispatchSnapshot;
+      this.#activeResponseId = responseId;
+      if (responseId && this.#currentDispatchSnapshot) {
+        this.#responseDispatchSnapshots.set(
+          responseId,
+          this.#currentDispatchSnapshot,
+        );
+      }
       this.emit('agent_start', this.#context, this.#currentAgent);
       this.#currentAgent.emit('agent_start', this.#context, this.#currentAgent);
     });
@@ -981,6 +1010,14 @@ export class RealtimeSession<
       this.#currentAgent.emit('agent_end', this.#context, textOutput);
 
       this.#runOutputGuardrails(textOutput, event.response.id, itemId);
+      this.#responseDispatchSnapshots.delete(event.response.id);
+      if (
+        typeof this.#activeResponseId === 'undefined' ||
+        this.#activeResponseId === event.response.id
+      ) {
+        this.#activeResponseId = undefined;
+        this.#activeResponseDispatchSnapshot = undefined;
+      }
     });
 
     this.#transport.on('audio_done', () => {
@@ -1071,7 +1108,12 @@ export class RealtimeSession<
     });
 
     this.#transport.on('function_call', async (event) => {
-      const dispatchSnapshot = this.#currentDispatchSnapshot;
+      const dispatchSnapshot =
+        (event.responseId
+          ? this.#responseDispatchSnapshots.get(event.responseId)
+          : undefined) ??
+        this.#activeResponseDispatchSnapshot ??
+        this.#currentDispatchSnapshot;
       try {
         if (!dispatchSnapshot) {
           throw new ModelBehaviorError(
@@ -1186,6 +1228,9 @@ export class RealtimeSession<
    * @param options - The options for the connection.
    */
   async connect(options: RealtimeSessionConnectOptions) {
+    this.#responseDispatchSnapshots.clear();
+    this.#activeResponseDispatchSnapshot = undefined;
+    this.#activeResponseId = undefined;
     // makes sure the current agent is correctly set and loads the tools
     await this.#setCurrentAgent(this.initialAgent);
 
@@ -1261,6 +1306,9 @@ export class RealtimeSession<
   close() {
     this.#interruptedByGuardrail = {};
     this.#pendingFunctionCalls.clear();
+    this.#responseDispatchSnapshots.clear();
+    this.#activeResponseDispatchSnapshot = undefined;
+    this.#activeResponseId = undefined;
     this.#transport.close();
   }
 

--- a/packages/agents-realtime/src/realtimeSession.ts
+++ b/packages/agents-realtime/src/realtimeSession.ts
@@ -57,6 +57,7 @@ import {
   isBackgroundResult,
   isValidRealtimeTool,
   toRealtimeToolDefinition,
+  validateRealtimeToolNames,
 } from './tool';
 import {
   runToolInputGuardrails,
@@ -205,6 +206,36 @@ function validateRealtimeToolExecutionConfig(
 
 const TOOL_APPROVAL_REJECTION_MESSAGE = 'Tool execution was not approved.';
 
+type SessionRealtimeAgent<TBaseContext> =
+  | RealtimeAgent<TBaseContext>
+  | RealtimeAgent<RealtimeContextData<TBaseContext>>;
+
+type RealtimeFunctionTool<TBaseContext> = FunctionTool<
+  RealtimeContextData<TBaseContext>,
+  any,
+  unknown
+>;
+
+type RealtimeDispatchSnapshot<TBaseContext> = {
+  agent: SessionRealtimeAgent<TBaseContext>;
+  functionTools: RealtimeFunctionTool<TBaseContext>[];
+  handoffs: Handoff[];
+};
+
+type PreparedRealtimeAgentState<TBaseContext> = {
+  agent: SessionRealtimeAgent<TBaseContext>;
+  toolDefinitions?: RealtimeToolDefinition[];
+  dispatchSnapshot: RealtimeDispatchSnapshot<TBaseContext>;
+};
+
+type PendingRealtimeFunctionCall<TBaseContext> = {
+  toolCall: TransportToolCallEvent;
+  tool: RealtimeFunctionTool<TBaseContext>;
+  agent: SessionRealtimeAgent<TBaseContext>;
+  dispatchSnapshot: RealtimeDispatchSnapshot<TBaseContext>;
+  approvalItem: RunToolApprovalItem;
+};
+
 function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -246,10 +277,13 @@ export class RealtimeSession<
   TBaseContext = unknown,
 > extends RuntimeEventEmitter<RealtimeSessionEventTypes<TBaseContext>> {
   #transport: RealtimeTransportLayer;
-  #currentAgent:
-    | RealtimeAgent<TBaseContext>
-    | RealtimeAgent<RealtimeContextData<TBaseContext>>;
+  #currentAgent: SessionRealtimeAgent<TBaseContext>;
   #currentTools?: RealtimeToolDefinition[];
+  #currentDispatchSnapshot?: RealtimeDispatchSnapshot<TBaseContext>;
+  #pendingFunctionCalls = new Map<
+    string,
+    PendingRealtimeFunctionCall<TBaseContext>
+  >();
   #context: RunContext<RealtimeContextData<TBaseContext>>;
   #outputGuardrails: RealtimeOutputGuardrailDefinition[] = [];
   #outputGuardrailSettings: RealtimeOutputGuardrailSettings;
@@ -364,36 +398,56 @@ export class RealtimeSession<
     return this.#availableMcpTools;
   }
 
-  async #setCurrentAgent(
-    agent:
-      | RealtimeAgent<TBaseContext>
-      | RealtimeAgent<RealtimeContextData<TBaseContext>>,
-  ) {
-    this.#currentAgent = agent;
-    const handoffs = await (
-      this.#currentAgent as RealtimeAgent<TBaseContext>
-    ).getEnabledHandoffs(this.#context);
+  async #prepareAgent(
+    agent: SessionRealtimeAgent<TBaseContext>,
+  ): Promise<PreparedRealtimeAgentState<TBaseContext>> {
+    const [handoffs, agentTools] = await Promise.all([
+      (agent as RealtimeAgent<TBaseContext>).getEnabledHandoffs(this.#context),
+      (agent as RealtimeAgent<TBaseContext>).getAllTools(this.#context),
+    ]);
     const handoffTools = handoffs.map((handoff) =>
       handoff.getHandoffAsFunctionTool(),
     );
-    const allTools = (
-      await (this.#currentAgent as RealtimeAgent<TBaseContext>).getAllTools(
-        this.#context,
-      )
-    )
-      .filter(isValidRealtimeTool)
-      .map(toRealtimeToolDefinition);
+    const realtimeTools = agentTools.filter(isValidRealtimeTool);
+    const functionTools = realtimeTools.filter(
+      (tool): tool is RealtimeFunctionTool<TBaseContext> =>
+        tool.type === 'function',
+    );
+
+    validateRealtimeToolNames(functionTools, handoffs);
+
     const hasToolsDefined =
-      typeof this.#currentAgent.tools !== 'undefined' ||
-      typeof this.#currentAgent.mcpServers !== 'undefined';
+      typeof agent.tools !== 'undefined' ||
+      typeof agent.mcpServers !== 'undefined';
     const hasHandoffsDefined = handoffs.length > 0;
-    this.#currentTools =
-      hasToolsDefined || hasHandoffsDefined
-        ? [...allTools, ...handoffTools]
-        : undefined;
+    return {
+      agent,
+      toolDefinitions:
+        hasToolsDefined || hasHandoffsDefined
+          ? [...realtimeTools.map(toRealtimeToolDefinition), ...handoffTools]
+          : undefined,
+      dispatchSnapshot: {
+        agent,
+        functionTools,
+        handoffs,
+      },
+    };
+  }
+
+  #applyPreparedAgent(
+    prepared: PreparedRealtimeAgentState<TBaseContext>,
+  ): void {
+    this.#currentAgent = prepared.agent;
+    this.#currentTools = prepared.toolDefinitions;
+    this.#currentDispatchSnapshot = prepared.dispatchSnapshot;
 
     // Recompute currently available MCP tools based on the new agent's active server labels.
     this.#updateAvailableMcpTools();
+  }
+
+  async #setCurrentAgent(agent: SessionRealtimeAgent<TBaseContext>) {
+    const prepared = await this.#prepareAgent(agent);
+    this.#applyPreparedAgent(prepared);
   }
 
   async #getSessionConfig(
@@ -531,26 +585,32 @@ export class RealtimeSession<
   }
 
   async updateAgent(newAgent: RealtimeAgent<TBaseContext>) {
+    const prepared = await this.#prepareAgent(newAgent);
     this.#currentAgent.emit('agent_handoff', this.#context, newAgent);
     this.emit('agent_handoff', this.#context, this.#currentAgent, newAgent);
 
-    await this.#setCurrentAgent(newAgent);
+    this.#applyPreparedAgent(prepared);
     await this.#transport.updateSessionConfig(await this.#getSessionConfig());
 
     return newAgent;
   }
 
-  async #handleHandoff(toolCall: TransportToolCallEvent, handoff: Handoff) {
+  async #handleHandoff(
+    toolCall: TransportToolCallEvent,
+    handoff: Handoff,
+    sourceAgent: SessionRealtimeAgent<TBaseContext>,
+  ) {
     const newAgent = (await handoff.onInvokeHandoff(
       this.#context,
       toolCall.arguments,
     )) as RealtimeAgent<TBaseContext>;
+    const prepared = await this.#prepareAgent(newAgent);
 
-    this.#currentAgent.emit('agent_handoff', this.#context, newAgent);
-    this.emit('agent_handoff', this.#context, this.#currentAgent, newAgent);
+    sourceAgent.emit('agent_handoff', this.#context, newAgent);
+    this.emit('agent_handoff', this.#context, sourceAgent, newAgent);
 
     // update session with new agent
-    await this.#setCurrentAgent(newAgent);
+    this.#applyPreparedAgent(prepared);
     await this.#transport.updateSessionConfig(await this.#getSessionConfig());
     const output = getTransferMessage(newAgent);
     this.#transport.sendFunctionCallOutput(toolCall, output, true);
@@ -603,7 +663,9 @@ export class RealtimeSession<
 
   async #handleFunctionToolCall(
     toolCall: TransportToolCallEvent,
-    tool: FunctionTool<RealtimeContextData<TBaseContext>, any, unknown>,
+    tool: RealtimeFunctionTool<TBaseContext>,
+    agent: SessionRealtimeAgent<TBaseContext>,
+    dispatchSnapshot: RealtimeDispatchSnapshot<TBaseContext>,
   ) {
     this.#context.context.history = JSON.parse(JSON.stringify(this.#history)); // deep copy of the history
     let parsedArgs: any = toolCall.arguments;
@@ -625,10 +687,11 @@ export class RealtimeSession<
         callId: toolCall.callId,
       });
       if (approval === false) {
-        this.emit('agent_tool_start', this.#context, this.#currentAgent, tool, {
+        this.#pendingFunctionCalls.delete(toolCall.callId);
+        this.emit('agent_tool_start', this.#context, agent, tool, {
           toolCall,
         });
-        this.#currentAgent.emit('agent_tool_start', this.#context, tool, {
+        agent.emit('agent_tool_start', this.#context, tool, {
           toolCall,
         });
 
@@ -637,15 +700,10 @@ export class RealtimeSession<
           toolCall.callId,
         );
         this.#transport.sendFunctionCallOutput(toolCall, result, true);
-        this.emit(
-          'agent_tool_end',
-          this.#context,
-          this.#currentAgent,
-          tool,
-          result,
-          { toolCall },
-        );
-        this.#currentAgent.emit('agent_tool_end', this.#context, tool, result, {
+        this.emit('agent_tool_end', this.#context, agent, tool, result, {
+          toolCall,
+        });
+        agent.emit('agent_tool_end', this.#context, tool, result, {
           toolCall,
         });
         return;
@@ -654,7 +712,7 @@ export class RealtimeSession<
           const inputGuardrailResult = await runToolInputGuardrails({
             guardrails: tool.inputGuardrails,
             context: this.#context,
-            agent: this.#currentAgent,
+            agent,
             toolCall: toolCall as any,
           });
 
@@ -667,31 +725,36 @@ export class RealtimeSession<
             return;
           }
         }
-        this.emit(
-          'tool_approval_requested',
-          this.#context,
-          this.#currentAgent,
-          {
-            type: 'function_approval' as const,
-            tool,
-            approvalItem: new RunToolApprovalItem(toolCall, this.#currentAgent),
-          },
-        );
+        const approvalItem = new RunToolApprovalItem(toolCall, agent);
+        this.#pendingFunctionCalls.set(toolCall.callId, {
+          toolCall,
+          tool,
+          agent,
+          dispatchSnapshot,
+          approvalItem,
+        });
+        this.emit('tool_approval_requested', this.#context, agent, {
+          type: 'function_approval' as const,
+          tool,
+          approvalItem,
+        });
         return;
       }
     }
 
+    this.#pendingFunctionCalls.delete(toolCall.callId);
+
     const inputGuardrailResult = await runToolInputGuardrails({
       guardrails: tool.inputGuardrails,
       context: this.#context,
-      agent: this.#currentAgent,
+      agent,
       toolCall: toolCall as any,
     });
 
-    this.emit('agent_tool_start', this.#context, this.#currentAgent, tool, {
+    this.emit('agent_tool_start', this.#context, agent, tool, {
       toolCall,
     });
-    this.#currentAgent.emit('agent_tool_start', this.#context, tool, {
+    agent.emit('agent_tool_start', this.#context, tool, {
       toolCall,
     });
 
@@ -713,7 +776,7 @@ export class RealtimeSession<
         : await runToolOutputGuardrails({
             guardrails: tool.outputGuardrails,
             context: this.#context,
-            agent: this.#currentAgent,
+            agent,
             toolCall: toolCall as any,
             toolOutput: result,
           });
@@ -726,52 +789,81 @@ export class RealtimeSession<
       stringResult = toSmartString(guardedResult);
       this.#transport.sendFunctionCallOutput(toolCall, stringResult, true);
     }
-    this.emit(
-      'agent_tool_end',
-      this.#context,
-      this.#currentAgent,
-      tool,
-      stringResult,
-      { toolCall },
-    );
-    this.#currentAgent.emit(
-      'agent_tool_end',
-      this.#context,
-      tool,
-      stringResult,
-      { toolCall },
-    );
+    this.emit('agent_tool_end', this.#context, agent, tool, stringResult, {
+      toolCall,
+    });
+    agent.emit('agent_tool_end', this.#context, tool, stringResult, {
+      toolCall,
+    });
   }
 
-  async #handleFunctionCall(toolCall: TransportToolCallEvent) {
-    const enabledHandoffs = await (
-      this.#currentAgent as RealtimeAgent<TBaseContext>
-    ).getEnabledHandoffs(this.#context);
-    const handoffMap = new Map(
-      enabledHandoffs.map((handoff) => [handoff.toolName, handoff]),
+  async #handleFunctionCall(
+    toolCall: TransportToolCallEvent,
+    dispatchSnapshot: RealtimeDispatchSnapshot<TBaseContext>,
+  ) {
+    const [toolEnabled, handoffEnabled] = await Promise.all([
+      Promise.all(
+        dispatchSnapshot.functionTools.map((tool) =>
+          tool.isEnabled(this.#context, dispatchSnapshot.agent),
+        ),
+      ),
+      Promise.all(
+        dispatchSnapshot.handoffs.map((handoff) =>
+          handoff.isEnabled({
+            runContext: this.#context,
+            agent: dispatchSnapshot.agent,
+          }),
+        ),
+      ),
+    ]);
+    const filteredSnapshot: RealtimeDispatchSnapshot<TBaseContext> = {
+      agent: dispatchSnapshot.agent,
+      functionTools: dispatchSnapshot.functionTools.filter(
+        (_tool, index) => toolEnabled[index],
+      ),
+      handoffs: dispatchSnapshot.handoffs.filter(
+        (_handoff, index) => handoffEnabled[index],
+      ),
+    };
+    validateRealtimeToolNames(
+      filteredSnapshot.functionTools,
+      filteredSnapshot.handoffs,
     );
 
-    const allTools = await (
-      this.#currentAgent as RealtimeAgent<TBaseContext>
-    ).getAllTools(this.#context);
-    const functionToolMap = new Map(allTools.map((tool) => [tool.name, tool]));
+    const functionToolMap = new Map(
+      filteredSnapshot.functionTools.map((tool) => [tool.name, tool]),
+    );
+    const handoffMap = new Map(
+      filteredSnapshot.handoffs.map((handoff) => [handoff.toolName, handoff]),
+    );
+
+    const functionTool = functionToolMap.get(toolCall.name);
+    if (functionTool) {
+      await this.#handleFunctionToolCall(
+        toolCall,
+        functionTool,
+        filteredSnapshot.agent,
+        filteredSnapshot,
+      );
+      return;
+    }
 
     const possibleHandoff = handoffMap.get(toolCall.name);
     if (possibleHandoff) {
-      await this.#handleHandoff(toolCall, possibleHandoff);
-    } else {
-      const functionTool = functionToolMap.get(toolCall.name);
-      if (functionTool && functionTool.type === 'function') {
-        await this.#handleFunctionToolCall(toolCall, functionTool);
-      } else {
-        const message = `Tool ${toolCall.name} not found`;
-        this.#transport.sendFunctionCallOutput(toolCall, message, false);
-        this.emit('error', {
-          type: 'error',
-          error: new ModelBehaviorError(message),
-        });
-      }
+      await this.#handleHandoff(
+        toolCall,
+        possibleHandoff,
+        filteredSnapshot.agent,
+      );
+      return;
     }
+
+    const message = `Tool ${toolCall.name} not found`;
+    this.#transport.sendFunctionCallOutput(toolCall, message, false);
+    this.emit('error', {
+      type: 'error',
+      error: new ModelBehaviorError(message),
+    });
   }
 
   async #runOutputGuardrails(
@@ -979,8 +1071,14 @@ export class RealtimeSession<
     });
 
     this.#transport.on('function_call', async (event) => {
+      const dispatchSnapshot = this.#currentDispatchSnapshot;
       try {
-        await this.#handleFunctionCall(event);
+        if (!dispatchSnapshot) {
+          throw new ModelBehaviorError(
+            'Realtime tool dispatch is unavailable before the session tool configuration is resolved.',
+          );
+        }
+        await this.#handleFunctionCall(event, dispatchSnapshot);
       } catch (error) {
         logger.error('Error handling function call', error);
         this.emit('error', {
@@ -1162,6 +1260,7 @@ export class RealtimeSession<
    */
   close() {
     this.#interruptedByGuardrail = {};
+    this.#pendingFunctionCalls.clear();
     this.#transport.close();
   }
 
@@ -1183,6 +1282,44 @@ export class RealtimeSession<
     this.#transport.interrupt();
   }
 
+  #resolvePendingFunctionCall(
+    approvalItem: RunToolApprovalItem,
+  ): PendingRealtimeFunctionCall<TBaseContext> | undefined {
+    if (approvalItem.rawItem.type !== 'function_call') {
+      return undefined;
+    }
+
+    const pending = this.#pendingFunctionCalls.get(approvalItem.rawItem.callId);
+    if (pending) {
+      return pending;
+    }
+
+    const agent =
+      approvalItem.agent instanceof RealtimeAgent
+        ? (approvalItem.agent as SessionRealtimeAgent<TBaseContext>)
+        : this.#currentAgent;
+    const toolName = approvalItem.toolName ?? approvalItem.rawItem.name;
+    const tool = agent.tools.find(
+      (candidate): candidate is RealtimeFunctionTool<TBaseContext> =>
+        candidate.type === 'function' && candidate.name === toolName,
+    );
+    if (!tool) {
+      return undefined;
+    }
+
+    const dispatchSnapshot =
+      this.#currentDispatchSnapshot?.agent === agent
+        ? this.#currentDispatchSnapshot
+        : { agent, functionTools: [tool], handoffs: [] };
+    return {
+      toolCall: approvalItem.rawItem,
+      tool,
+      agent,
+      dispatchSnapshot,
+      approvalItem,
+    };
+  }
+
   /**
    * Approve a tool call. This will also trigger the tool call to the agent.
    * @param approvalItem - The approval item to approve.
@@ -1193,18 +1330,18 @@ export class RealtimeSession<
     approvalItem: RunToolApprovalItem,
     options: { alwaysApprove?: boolean } = { alwaysApprove: false },
   ) {
-    this.#context.approveTool(approvalItem, options);
+    const pending = this.#resolvePendingFunctionCall(approvalItem);
+    this.#context.approveTool(pending?.approvalItem ?? approvalItem, options);
     const toolName =
       approvalItem.toolName ?? (approvalItem.rawItem as any).name;
-    const tool = this.#currentAgent.tools.find(
-      (tool) => tool.name === toolName,
-    );
-    if (
-      tool &&
-      tool.type === 'function' &&
-      approvalItem.rawItem.type === 'function_call'
-    ) {
-      await this.#handleFunctionToolCall(approvalItem.rawItem, tool);
+    if (pending) {
+      this.#pendingFunctionCalls.delete(pending.toolCall.callId);
+      await this.#handleFunctionToolCall(
+        pending.toolCall,
+        pending.tool,
+        pending.agent,
+        pending.dispatchSnapshot,
+      );
     } else if (approvalItem.rawItem.type === 'hosted_tool_call') {
       if (options.alwaysApprove) {
         logger.warn(
@@ -1233,20 +1370,20 @@ export class RealtimeSession<
       alwaysReject: false,
     },
   ) {
-    this.#context.rejectTool(approvalItem, options);
+    const pending = this.#resolvePendingFunctionCall(approvalItem);
+    this.#context.rejectTool(pending?.approvalItem ?? approvalItem, options);
 
     // we still need to simulate a tool call to the agent to let the agent know
     const toolName =
       approvalItem.toolName ?? (approvalItem.rawItem as any).name;
-    const tool = this.#currentAgent.tools.find(
-      (tool) => tool.name === toolName,
-    );
-    if (
-      tool &&
-      tool.type === 'function' &&
-      approvalItem.rawItem.type === 'function_call'
-    ) {
-      await this.#handleFunctionToolCall(approvalItem.rawItem, tool);
+    if (pending) {
+      this.#pendingFunctionCalls.delete(pending.toolCall.callId);
+      await this.#handleFunctionToolCall(
+        pending.toolCall,
+        pending.tool,
+        pending.agent,
+        pending.dispatchSnapshot,
+      );
     } else if (approvalItem.rawItem.type === 'hosted_tool_call') {
       if (options.alwaysReject) {
         logger.warn(

--- a/packages/agents-realtime/src/realtimeSession.ts
+++ b/packages/agents-realtime/src/realtimeSession.ts
@@ -301,8 +301,6 @@ export class RealtimeSession<
   #currentAgent: SessionRealtimeAgent<TBaseContext>;
   #currentTools?: RealtimeToolDefinition[];
   #currentDispatchSnapshot?: RealtimeDispatchSnapshot<TBaseContext>;
-  #activeResponseDispatchSnapshot?: RealtimeDispatchSnapshot<TBaseContext>;
-  #activeResponseId?: string;
   #responseDispatchSnapshots = new Map<
     string,
     RealtimeDispatchSnapshot<TBaseContext>
@@ -475,6 +473,21 @@ export class RealtimeSession<
   async #setCurrentAgent(agent: SessionRealtimeAgent<TBaseContext>) {
     const prepared = await this.#prepareAgent(agent);
     this.#applyPreparedAgent(prepared);
+  }
+
+  #captureResponseDispatchSnapshot(
+    responseId: string,
+  ): RealtimeDispatchSnapshot<TBaseContext> | undefined {
+    const existingSnapshot = this.#responseDispatchSnapshots.get(responseId);
+    if (existingSnapshot) {
+      return existingSnapshot;
+    }
+
+    const snapshot = this.#currentDispatchSnapshot;
+    if (snapshot) {
+      this.#responseDispatchSnapshots.set(responseId, snapshot);
+    }
+    return snapshot;
   }
 
   async #getSessionConfig(
@@ -981,13 +994,8 @@ export class RealtimeSession<
     this.#transport.on('turn_started', (event) => {
       this.#audioStarted = false;
       const responseId = getStartedResponseId(event);
-      this.#activeResponseDispatchSnapshot = this.#currentDispatchSnapshot;
-      this.#activeResponseId = responseId;
-      if (responseId && this.#currentDispatchSnapshot) {
-        this.#responseDispatchSnapshots.set(
-          responseId,
-          this.#currentDispatchSnapshot,
-        );
+      if (responseId) {
+        this.#captureResponseDispatchSnapshot(responseId);
       }
       this.emit('agent_start', this.#context, this.#currentAgent);
       this.#currentAgent.emit('agent_start', this.#context, this.#currentAgent);
@@ -1019,13 +1027,6 @@ export class RealtimeSession<
 
       this.#runOutputGuardrails(textOutput, event.response.id, itemId);
       this.#responseDispatchSnapshots.delete(event.response.id);
-      if (
-        typeof this.#activeResponseId === 'undefined' ||
-        this.#activeResponseId === event.response.id
-      ) {
-        this.#activeResponseId = undefined;
-        this.#activeResponseDispatchSnapshot = undefined;
-      }
     });
 
     this.#transport.on('audio_done', () => {
@@ -1116,13 +1117,15 @@ export class RealtimeSession<
     });
 
     this.#transport.on('function_call', async (event) => {
-      const dispatchSnapshot =
-        (event.responseId
-          ? this.#responseDispatchSnapshots.get(event.responseId)
-          : undefined) ??
-        this.#activeResponseDispatchSnapshot ??
-        this.#currentDispatchSnapshot;
       try {
+        if (!event.responseId) {
+          throw new ModelBehaviorError(
+            'Realtime function call is missing a responseId and cannot be dispatched safely.',
+          );
+        }
+        const dispatchSnapshot = this.#captureResponseDispatchSnapshot(
+          event.responseId,
+        );
         if (!dispatchSnapshot) {
           throw new ModelBehaviorError(
             'Realtime tool dispatch is unavailable before the session tool configuration is resolved.',
@@ -1237,8 +1240,6 @@ export class RealtimeSession<
    */
   async connect(options: RealtimeSessionConnectOptions) {
     this.#responseDispatchSnapshots.clear();
-    this.#activeResponseDispatchSnapshot = undefined;
-    this.#activeResponseId = undefined;
     // makes sure the current agent is correctly set and loads the tools
     await this.#setCurrentAgent(this.initialAgent);
 
@@ -1315,8 +1316,6 @@ export class RealtimeSession<
     this.#interruptedByGuardrail = {};
     this.#pendingFunctionCalls.clear();
     this.#responseDispatchSnapshots.clear();
-    this.#activeResponseDispatchSnapshot = undefined;
-    this.#activeResponseId = undefined;
     this.#transport.close();
   }
 
@@ -1345,7 +1344,15 @@ export class RealtimeSession<
       return undefined;
     }
 
-    const toolCall = normalizeRealtimeFunctionCallId(approvalItem.rawItem);
+    const rawToolCall = approvalItem.rawItem as typeof approvalItem.rawItem & {
+      responseId?: unknown;
+    };
+    if (typeof rawToolCall.responseId !== 'string') {
+      return undefined;
+    }
+    const toolCall = normalizeRealtimeFunctionCallId(
+      rawToolCall as TransportToolCallEvent,
+    );
     const pending = this.#pendingFunctionCalls.get(toolCall.callId);
     if (pending) {
       return pending;

--- a/packages/agents-realtime/src/realtimeSession.ts
+++ b/packages/agents-realtime/src/realtimeSession.ts
@@ -239,6 +239,13 @@ type PendingRealtimeFunctionCall<TBaseContext> = {
   approvalItem: RunToolApprovalItem;
 };
 
+function normalizeRealtimeFunctionCallId(
+  toolCall: TransportToolCallEvent,
+): TransportToolCallEvent {
+  const callId = toolCall.callId || toolCall.id || '';
+  return callId === toolCall.callId ? toolCall : { ...toolCall, callId };
+}
+
 function getStartedResponseId(
   event: TransportLayerResponseStarted,
 ): string | undefined {
@@ -682,11 +689,12 @@ export class RealtimeSession<
   }
 
   async #handleFunctionToolCall(
-    toolCall: TransportToolCallEvent,
+    incomingToolCall: TransportToolCallEvent,
     tool: RealtimeFunctionTool<TBaseContext>,
     agent: SessionRealtimeAgent<TBaseContext>,
     dispatchSnapshot: RealtimeDispatchSnapshot<TBaseContext>,
   ) {
+    const toolCall = normalizeRealtimeFunctionCallId(incomingToolCall);
     this.#context.context.history = JSON.parse(JSON.stringify(this.#history)); // deep copy of the history
     let parsedArgs: any = toolCall.arguments;
     if (tool.parameters) {
@@ -1337,7 +1345,8 @@ export class RealtimeSession<
       return undefined;
     }
 
-    const pending = this.#pendingFunctionCalls.get(approvalItem.rawItem.callId);
+    const toolCall = normalizeRealtimeFunctionCallId(approvalItem.rawItem);
+    const pending = this.#pendingFunctionCalls.get(toolCall.callId);
     if (pending) {
       return pending;
     }
@@ -1360,11 +1369,18 @@ export class RealtimeSession<
         ? this.#currentDispatchSnapshot
         : { agent, functionTools: [tool], handoffs: [] };
     return {
-      toolCall: approvalItem.rawItem,
+      toolCall,
       tool,
       agent,
       dispatchSnapshot,
-      approvalItem,
+      approvalItem:
+        toolCall === approvalItem.rawItem
+          ? approvalItem
+          : new RunToolApprovalItem(
+              toolCall,
+              approvalItem.agent,
+              approvalItem.toolName,
+            ),
     };
   }
 

--- a/packages/agents-realtime/src/tool.ts
+++ b/packages/agents-realtime/src/tool.ts
@@ -1,5 +1,6 @@
 import {
   FunctionTool,
+  Handoff,
   HostedMCPTool,
   Tool,
   UserError,
@@ -38,6 +39,60 @@ export function isValidRealtimeTool(tool: Tool<any>): tool is RealtimeTool {
     tool.type === 'function' ||
     (tool.type === 'hosted_tool' && tool.name === 'hosted_mcp')
   );
+}
+
+export function validateRealtimeToolNames(
+  tools: readonly FunctionTool<any>[],
+  handoffs: readonly Handoff<any, any>[],
+): void {
+  const sourcesByName = new Map<string, string[]>();
+
+  for (const tool of tools) {
+    const sources = sourcesByName.get(tool.name) ?? [];
+    sources.push('function tool');
+    sourcesByName.set(tool.name, sources);
+  }
+
+  for (const handoff of handoffs) {
+    const sources = sourcesByName.get(handoff.toolName) ?? [];
+    sources.push('handoff');
+    sourcesByName.set(handoff.toolName, sources);
+  }
+
+  const duplicateDescriptions = [...sourcesByName.entries()]
+    .filter(([, sources]) => sources.length > 1)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(
+      ([name, sources]) => `'${name}' (${formatRealtimeToolSources(sources)})`,
+    );
+
+  if (duplicateDescriptions.length === 0) {
+    return;
+  }
+
+  const label = duplicateDescriptions.length === 1 ? 'name' : 'names';
+  throw new UserError(
+    `Duplicate Realtime tool ${label} found: ${duplicateDescriptions.join(', ')}. ` +
+      'Realtime function tool and handoff names must be unique. Rename one of them before starting the session.',
+  );
+}
+
+function formatRealtimeToolSources(sources: readonly string[]): string {
+  const counts = new Map<string, number>();
+  for (const source of sources) {
+    counts.set(source, (counts.get(source) ?? 0) + 1);
+  }
+
+  const descriptions = [...counts.entries()].map(([source, count]) =>
+    count === 1 ? source : `${count} ${source}s`,
+  );
+  if (descriptions.length === 1) {
+    return descriptions[0]!;
+  }
+  if (descriptions.length === 2) {
+    return `${descriptions[0]} and ${descriptions[1]}`;
+  }
+  return `${descriptions.slice(0, -1).join(', ')}, and ${descriptions.at(-1)}`;
 }
 
 export function toRealtimeToolDefinition(

--- a/packages/agents-realtime/src/transportLayerEvents.ts
+++ b/packages/agents-realtime/src/transportLayerEvents.ts
@@ -25,6 +25,8 @@ export type TransportToolCallEvent = {
   callId: string;
   arguments: string;
   previousItemId?: string;
+  /** The response that produced this tool call, when provided by the transport. */
+  responseId?: string;
 };
 
 /**

--- a/packages/agents-realtime/src/transportLayerEvents.ts
+++ b/packages/agents-realtime/src/transportLayerEvents.ts
@@ -25,8 +25,8 @@ export type TransportToolCallEvent = {
   callId: string;
   arguments: string;
   previousItemId?: string;
-  /** The response that produced this tool call, when provided by the transport. */
-  responseId?: string;
+  /** The response that produced this tool call. */
+  responseId: string;
 };
 
 /**

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -594,6 +594,7 @@ describe('OpenAIRealtimeBase helpers', () => {
     });
 
     expect(funcs[0]?.name).toBe('calc');
+    expect(funcs[0]?.responseId).toBe('r3');
     expect(updates.find((u) => (u as any).itemId === 'mcp1')).toBeTruthy();
   });
 

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -34,6 +34,7 @@ function createToolCall() {
     callId: 'c1',
     name: 'tool',
     arguments: '{}',
+    responseId: 'response-1',
   };
 }
 

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -1130,6 +1130,69 @@ describe('RealtimeSession', () => {
     expect(invokeSpy).not.toHaveBeenCalled();
   });
 
+  it('keeps pending approvals distinct when call IDs are missing', async () => {
+    const execute = vi.fn(async ({ request }: { request: string }) => request);
+    const needsApprovalTool = tool({
+      name: 'needs_approval',
+      description: 'Needs approval tool',
+      parameters: z.object({ request: z.string() }),
+      needsApproval: true,
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'ApprovalAgent',
+      handoffs: [],
+      tools: [needsApprovalTool],
+    });
+    const t = new FakeTransport();
+    const s = new RealtimeSession(agent, { transport: t });
+    await s.connect({ apiKey: 'test' });
+
+    const approvalRequests: any[] = [];
+    s.on('tool_approval_requested', (_context, _agent, request) => {
+      approvalRequests.push(request);
+    });
+    t.emit('function_call', {
+      id: 'item-1',
+      type: 'function_call',
+      name: 'needs_approval',
+      callId: '',
+      arguments: '{"request":"first"}',
+    });
+    t.emit('function_call', {
+      id: 'item-2',
+      type: 'function_call',
+      name: 'needs_approval',
+      callId: '',
+      arguments: '{"request":"second"}',
+    });
+
+    await vi.waitFor(() => {
+      expect(approvalRequests).toHaveLength(2);
+    });
+    await s.approve(approvalRequests[0].approvalItem);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute.mock.calls[0]?.[0]).toEqual({ request: 'first' });
+    expect(t.sendFunctionCallOutputCalls).toHaveLength(1);
+    expect(t.sendFunctionCallOutputCalls[0][0]).toMatchObject({
+      id: 'item-1',
+      callId: 'item-1',
+    });
+
+    await s.reject(approvalRequests[1].approvalItem, {
+      message: 'Second request denied',
+    });
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(t.sendFunctionCallOutputCalls).toHaveLength(2);
+    expect(t.sendFunctionCallOutputCalls[1][0]).toMatchObject({
+      id: 'item-2',
+      callId: 'item-2',
+    });
+    expect(t.sendFunctionCallOutputCalls[1][1]).toBe('Second request denied');
+  });
+
   it('does not run realtime input guardrails before pending approval by default', async () => {
     const guardrailRun = vi.fn(async () =>
       ToolGuardrailFunctionOutputFactory.allow(),

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -168,15 +168,25 @@ describe('RealtimeSession', () => {
     ).toHaveLength(1);
   });
 
-  it('dispatches sibling calls against the agent snapshot from event arrival', async () => {
-    const execute = vi.fn(async () => 'original tool output');
+  it('dispatches delayed sibling calls against the source response snapshot', async () => {
+    const sourceExecute = vi.fn(async () => 'source tool output');
+    const targetExecute = vi.fn(async () => 'target tool output');
     const originalTool = tool({
       name: 'finish_original_work',
       description: 'Finish work owned by the original agent.',
       parameters: z.object({}),
-      execute,
+      execute: sourceExecute,
     });
-    const targetAgent = new RealtimeAgent({ name: 'Billing' });
+    const targetTool = tool({
+      name: 'finish_original_work',
+      description: 'A same-named tool owned by the target agent.',
+      parameters: z.object({}),
+      execute: targetExecute,
+    });
+    const targetAgent = new RealtimeAgent({
+      name: 'Billing',
+      tools: [targetTool],
+    });
     const sourceAgent = new RealtimeAgent({
       name: 'Triage',
       tools: [originalTool],
@@ -192,17 +202,32 @@ describe('RealtimeSession', () => {
     });
     await localSession.connect({ apiKey: 'test' });
 
+    localTransport.emit('turn_started', {
+      type: 'response_started',
+      providerData: { response: { id: 'source-response' } },
+    });
     localTransport.emit('function_call', {
       type: 'function_call',
       name: 'transfer_to_Billing',
       callId: 'handoff-call',
       arguments: '{}',
+      responseId: 'source-response',
     } as any);
+
+    await vi.waitFor(() => {
+      expect(localSession.currentAgent).toBe(targetAgent);
+    });
+
+    localTransport.emit('turn_started', {
+      type: 'response_started',
+      providerData: { response: { id: 'target-response' } },
+    });
     localTransport.emit('function_call', {
       type: 'function_call',
       name: 'finish_original_work',
       callId: 'tool-call',
       arguments: '{}',
+      responseId: 'source-response',
     } as any);
 
     await vi.waitFor(() => {
@@ -210,7 +235,8 @@ describe('RealtimeSession', () => {
     });
 
     expect(localSession.currentAgent).toBe(targetAgent);
-    expect(execute).toHaveBeenCalledTimes(1);
+    expect(sourceExecute).toHaveBeenCalledTimes(1);
+    expect(targetExecute).not.toHaveBeenCalled();
     expect(sourceToolStart).toHaveBeenCalledTimes(1);
     expect(targetToolStart).not.toHaveBeenCalled();
     expect(

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -244,6 +244,29 @@ describe('RealtimeSession', () => {
         ([toolCall]) => toolCall.callId,
       ),
     ).toEqual(expect.arrayContaining(['handoff-call', 'tool-call']));
+
+    const errors: unknown[] = [];
+    localSession.on('error', (event) => errors.push(event.error));
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    localTransport.emit('function_call', {
+      type: 'function_call',
+      name: 'finish_original_work',
+      callId: 'missing-response-id-call',
+      arguments: '{}',
+    } as any);
+
+    await vi.waitFor(() => {
+      expect(errors).toHaveLength(1);
+    });
+    expect(errors[0]).toEqual(
+      new ModelBehaviorError(
+        'Realtime function call is missing a responseId and cannot be dispatched safely.',
+      ),
+    );
+    expect(sourceExecute).toHaveBeenCalledTimes(1);
+    expect(targetExecute).not.toHaveBeenCalled();
+    expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(2);
+    errorSpy.mockRestore();
   });
 
   it('resumes an approved tool call with its original agent snapshot', async () => {
@@ -276,6 +299,7 @@ describe('RealtimeSession', () => {
       name: 'approve_original_work',
       callId: 'approval-call',
       arguments: '{}',
+      responseId: 'approval-response',
     } as any);
     const [, approvalAgent, approvalPayload] = await approvalRequest;
 
@@ -285,6 +309,7 @@ describe('RealtimeSession', () => {
       name: 'transfer_to_Billing',
       callId: 'approval-handoff-call',
       arguments: '{}',
+      responseId: 'approval-response',
     } as any);
     await handoffOutput;
     expect(localSession.currentAgent).toBe(targetAgent);
@@ -621,6 +646,7 @@ describe('RealtimeSession', () => {
       name: 'echo',
       callId: 'call-1',
       arguments: JSON.stringify({ message: 'hi' }),
+      responseId: 'tool-response',
     });
 
     const [toolCall, output, startResponse] = await outputPromise;
@@ -790,6 +816,7 @@ describe('RealtimeSession', () => {
       name: 'missing',
       callId: '1',
       arguments: '{}',
+      responseId: 'unknown-tool-response',
     });
     const [toolCall, output, startResponse] = await outputEvent;
     const [error] = await errorEvent;
@@ -830,6 +857,7 @@ describe('RealtimeSession', () => {
         callId: 'c-timeout',
         status: 'completed',
         arguments: '{}',
+        responseId: 'timeout-response',
       } as any);
 
       await vi.advanceTimersByTimeAsync(5);
@@ -871,6 +899,7 @@ describe('RealtimeSession', () => {
         callId: 'c-timeout-raise',
         status: 'completed',
         arguments: '{}',
+        responseId: 'timeout-raise-response',
       } as any);
 
       await vi.advanceTimersByTimeAsync(5);
@@ -916,6 +945,7 @@ describe('RealtimeSession', () => {
       callId: 'c1',
       status: 'completed',
       arguments: '{}',
+      responseId: 'input-guardrail-response',
     } as any);
 
     const [, output] = await outputPromise;
@@ -956,6 +986,7 @@ describe('RealtimeSession', () => {
       callId: 'c2',
       status: 'completed',
       arguments: '{}',
+      responseId: 'input-guardrail-error-response',
     } as any);
 
     const [error] = await errorEvent;
@@ -1002,6 +1033,7 @@ describe('RealtimeSession', () => {
       callId: 'c3',
       status: 'completed',
       arguments: '{}',
+      responseId: 'output-guardrail-response',
     } as any);
 
     const [, output] = await outputPromise;
@@ -1042,6 +1074,7 @@ describe('RealtimeSession', () => {
       callId: 'c4',
       status: 'completed',
       arguments: '{}',
+      responseId: 'output-guardrail-error-response',
     } as any);
 
     const [error] = await errorEvent;
@@ -1069,6 +1102,7 @@ describe('RealtimeSession', () => {
       name: 'test',
       callId: '1',
       arguments: '{"test":"x"}',
+      responseId: 'direct-approval-response',
     };
     const approval = new RunToolApprovalItem(toolCall as any, agent);
     await s.approve(approval);
@@ -1121,6 +1155,7 @@ describe('RealtimeSession', () => {
       callId: 'call-1',
       arguments: '{}',
       status: 'completed',
+      responseId: 'approval-request-response',
     } as any);
 
     const [, , payload] = await approvalRequest;
@@ -1158,6 +1193,7 @@ describe('RealtimeSession', () => {
       name: 'needs_approval',
       callId: '',
       arguments: '{"request":"first"}',
+      responseId: 'missing-call-id-response',
     });
     t.emit('function_call', {
       id: 'item-2',
@@ -1165,6 +1201,7 @@ describe('RealtimeSession', () => {
       name: 'needs_approval',
       callId: '',
       arguments: '{"request":"second"}',
+      responseId: 'missing-call-id-response',
     });
 
     await vi.waitFor(() => {
@@ -1231,6 +1268,7 @@ describe('RealtimeSession', () => {
       callId: 'call-default-guardrail',
       arguments: '{}',
       status: 'completed',
+      responseId: 'default-guardrail-response',
     } as any);
 
     await approvalRequest;
@@ -1283,6 +1321,7 @@ describe('RealtimeSession', () => {
       callId: 'call-pre-approval-blocked',
       arguments: '{}',
       status: 'completed',
+      responseId: 'pre-approval-blocked-response',
     } as any);
 
     const [, output, startResponse] = await outputPromise;
@@ -1334,6 +1373,7 @@ describe('RealtimeSession', () => {
       callId: 'call-pre-approval-allow',
       arguments: '{}',
       status: 'completed',
+      responseId: 'pre-approval-allow-response',
     } as any);
 
     const [, , payload] = await approvalRequest;
@@ -1376,6 +1416,7 @@ describe('RealtimeSession', () => {
       name: 'needs_approval',
       callId: 'call-2',
       arguments: '{}',
+      responseId: 'approval-denied-response',
     };
     const approvalItem = new RunToolApprovalItem(toolCall as any, agent);
     s.context.rejectTool(approvalItem);
@@ -1421,6 +1462,7 @@ describe('RealtimeSession', () => {
       name: 'needs_approval',
       callId: 'call-2b',
       arguments: '{}',
+      responseId: 'approval-custom-message-response',
     };
     const approvalItem = new RunToolApprovalItem(toolCall as any, agent);
     s.context.rejectTool(approvalItem);
@@ -1468,6 +1510,7 @@ describe('RealtimeSession', () => {
       name: 'needs_approval',
       callId: 'call-2c',
       arguments: '{}',
+      responseId: 'approval-formatter-error-response',
     };
     const approvalItem = new RunToolApprovalItem(toolCall as any, agent);
     s.context.rejectTool(approvalItem);
@@ -1513,6 +1556,7 @@ describe('RealtimeSession', () => {
       name: 'needs_approval',
       callId: 'call-msg-1',
       arguments: '{}',
+      responseId: 'approval-reject-message-response',
     };
 
     const approvalRequest = waitForEvent<any[]>(s, 'tool_approval_requested');
@@ -1556,6 +1600,7 @@ describe('RealtimeSession', () => {
       name: 'needs_approval',
       callId: 'call-sticky-1',
       arguments: '{}',
+      responseId: 'approval-sticky-response',
     };
     const firstApprovalRequest = waitForEvent<any[]>(
       s,
@@ -1614,6 +1659,7 @@ describe('RealtimeSession', () => {
       name: 'needs_approval',
       callId: 'call-msg-2',
       arguments: '{}',
+      responseId: 'approval-message-precedence-response',
     };
     const approvalItem = new RunToolApprovalItem(toolCall as any, agent);
     s.context.rejectTool(approvalItem, { message: 'per-call message' });
@@ -1655,6 +1701,7 @@ describe('RealtimeSession', () => {
       name: 'needs_approval',
       callId: 'call-msg-3',
       arguments: '{}',
+      responseId: 'approval-empty-message-response',
     };
     const approvalItem = new RunToolApprovalItem(toolCall as any, agent);
     s.context.rejectTool(approvalItem, { message: '' });
@@ -1694,6 +1741,7 @@ describe('RealtimeSession', () => {
       callId: 'call-3',
       arguments: '{}',
       status: 'completed',
+      responseId: 'background-response',
     } as any);
 
     const [, output, startResponse] = await outputPromise;

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -10,6 +10,8 @@ import {
   ModelBehaviorError,
   RunToolApprovalItem,
   ToolTimeoutError,
+  UserError,
+  handoff,
   tool,
   defineToolInputGuardrail,
   defineToolOutputGuardrail,
@@ -79,6 +81,196 @@ describe('RealtimeSession', () => {
     const agent = new RealtimeAgent({ name: 'A', handoffs: [] });
     session = new RealtimeSession(agent, { transport });
     await session.connect({ apiKey: 'test' });
+  });
+
+  it('rejects duplicate function tool and handoff names before connecting', async () => {
+    const targetAgent = new RealtimeAgent({ name: 'Billing' });
+    const duplicateTool = tool({
+      name: 'transfer_to_Billing',
+      description: 'Conflicts with the billing handoff.',
+      parameters: z.object({}),
+      execute: async () => 'function tool',
+    });
+    const sourceAgent = new RealtimeAgent({
+      name: 'Triage',
+      tools: [duplicateTool],
+      handoffs: [targetAgent],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(sourceAgent, {
+      transport: localTransport,
+    });
+
+    await expect(localSession.connect({ apiKey: 'test' })).rejects.toThrow(
+      new UserError(
+        "Duplicate Realtime tool name found: 'transfer_to_Billing' (function tool and handoff). Realtime function tool and handoff names must be unique. Rename one of them before starting the session.",
+      ),
+    );
+    expect(localTransport.connectCalls).toHaveLength(0);
+  });
+
+  it('reports duplicate same-kind Realtime tool names deterministically', async () => {
+    const duplicateOne = tool({
+      name: 'lookup',
+      description: 'First lookup tool.',
+      parameters: z.object({}),
+      execute: async () => 'first',
+    });
+    const duplicateTwo = tool({
+      name: 'lookup',
+      description: 'Second lookup tool.',
+      parameters: z.object({}),
+      execute: async () => 'second',
+    });
+    const firstTarget = new RealtimeAgent({ name: 'First' });
+    const secondTarget = new RealtimeAgent({ name: 'Second' });
+    const sourceAgent = new RealtimeAgent({
+      name: 'Triage',
+      tools: [duplicateOne, duplicateTwo],
+      handoffs: [
+        handoff(firstTarget, { toolNameOverride: 'delegate' }),
+        handoff(secondTarget, { toolNameOverride: 'delegate' }),
+      ],
+    });
+    const localSession = new RealtimeSession(sourceAgent, {
+      transport: new FakeTransport(),
+    });
+
+    await expect(localSession.connect({ apiKey: 'test' })).rejects.toThrow(
+      "Duplicate Realtime tool names found: 'delegate' (2 handoffs), 'lookup' (2 function tools)",
+    );
+  });
+
+  it('ignores disabled tools when validating Realtime tool names', async () => {
+    const targetAgent = new RealtimeAgent({ name: 'Billing' });
+    const disabledTool = tool({
+      name: 'transfer_to_Billing',
+      description: 'Disabled conflicting tool.',
+      parameters: z.object({}),
+      isEnabled: false,
+      execute: async () => 'disabled',
+    });
+    const sourceAgent = new RealtimeAgent({
+      name: 'Triage',
+      tools: [disabledTool],
+      handoffs: [targetAgent],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(sourceAgent, {
+      transport: localTransport,
+    });
+
+    await localSession.connect({ apiKey: 'test' });
+
+    expect(localTransport.connectCalls).toHaveLength(1);
+    expect(
+      localTransport.connectCalls[0]?.initialSessionConfig?.tools,
+    ).toHaveLength(1);
+  });
+
+  it('dispatches sibling calls against the agent snapshot from event arrival', async () => {
+    const execute = vi.fn(async () => 'original tool output');
+    const originalTool = tool({
+      name: 'finish_original_work',
+      description: 'Finish work owned by the original agent.',
+      parameters: z.object({}),
+      execute,
+    });
+    const targetAgent = new RealtimeAgent({ name: 'Billing' });
+    const sourceAgent = new RealtimeAgent({
+      name: 'Triage',
+      tools: [originalTool],
+      handoffs: [targetAgent],
+    });
+    const sourceToolStart = vi.fn();
+    const targetToolStart = vi.fn();
+    sourceAgent.on('agent_tool_start', sourceToolStart);
+    targetAgent.on('agent_tool_start', targetToolStart);
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(sourceAgent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+
+    localTransport.emit('function_call', {
+      type: 'function_call',
+      name: 'transfer_to_Billing',
+      callId: 'handoff-call',
+      arguments: '{}',
+    } as any);
+    localTransport.emit('function_call', {
+      type: 'function_call',
+      name: 'finish_original_work',
+      callId: 'tool-call',
+      arguments: '{}',
+    } as any);
+
+    await vi.waitFor(() => {
+      expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(2);
+    });
+
+    expect(localSession.currentAgent).toBe(targetAgent);
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(sourceToolStart).toHaveBeenCalledTimes(1);
+    expect(targetToolStart).not.toHaveBeenCalled();
+    expect(
+      localTransport.sendFunctionCallOutputCalls.map(
+        ([toolCall]) => toolCall.callId,
+      ),
+    ).toEqual(expect.arrayContaining(['handoff-call', 'tool-call']));
+  });
+
+  it('resumes an approved tool call with its original agent snapshot', async () => {
+    const execute = vi.fn(async () => 'approved original output');
+    const approvalTool = tool({
+      name: 'approve_original_work',
+      description: 'Run work after approval.',
+      parameters: z.object({}),
+      needsApproval: true,
+      execute,
+    });
+    const targetAgent = new RealtimeAgent({ name: 'Billing' });
+    const sourceAgent = new RealtimeAgent({
+      name: 'Triage',
+      tools: [approvalTool],
+      handoffs: [targetAgent],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(sourceAgent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+
+    const approvalRequest = waitForEvent<any[]>(
+      localSession,
+      'tool_approval_requested',
+    );
+    localTransport.emit('function_call', {
+      type: 'function_call',
+      name: 'approve_original_work',
+      callId: 'approval-call',
+      arguments: '{}',
+    } as any);
+    const [, approvalAgent, approvalPayload] = await approvalRequest;
+
+    const handoffOutput = localTransport.waitForNextFunctionCallOutput();
+    localTransport.emit('function_call', {
+      type: 'function_call',
+      name: 'transfer_to_Billing',
+      callId: 'approval-handoff-call',
+      arguments: '{}',
+    } as any);
+    await handoffOutput;
+    expect(localSession.currentAgent).toBe(targetAgent);
+
+    const toolOutput = localTransport.waitForNextFunctionCallOutput();
+    await localSession.approve(approvalPayload.approvalItem);
+    const [toolCall, output] = await toolOutput;
+
+    expect(approvalAgent).toBe(sourceAgent);
+    expect(toolCall.callId).toBe('approval-call');
+    expect(output).toBe('approved original output');
+    expect(execute).toHaveBeenCalledTimes(1);
   });
 
   it('calls transport.resetHistory with correct arguments', () => {


### PR DESCRIPTION
This pull request fixes ambiguous Realtime function dispatch when function tools and handoffs share model-visible names or sibling calls race with an agent handoff.

It validates enabled tool names before connecting or updating the active agent, captures a stable dispatch snapshot when each function call arrives, and preserves the originating agent and tool while a call waits for approval. Dynamic `isEnabled` predicates can still remove candidates from the captured tool set at execution time.

ref: https://github.com/openai/openai-agents-python/pull/3441