### PR TITLE
fix(core): preserve empty array tool outputs

### DIFF
--- a/.changeset/warm-arrays-output.md
+++ b/.changeset/warm-arrays-output.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: preserve empty array tool outputs as text

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -1660,6 +1660,9 @@ function normalizeStructuredToolOutputs(
   output: unknown,
 ): StructuredToolOutput[] | null {
   if (Array.isArray(output)) {
+    if (output.length === 0) {
+      return null;
+    }
     const structured: StructuredToolOutput[] = [];
     for (const item of output) {
       const normalized = normalizeStructuredToolOutput(item);

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -320,6 +320,15 @@ describe('getToolCallOutputItem', () => {
       text: JSON.stringify({ type: 'unknown', value: 'x' }),
     });
   });
+
+  it('returns an empty array as plain text output', () => {
+    const result = getToolCallOutputItem(TEST_MODEL_FUNCTION_CALL, []);
+
+    expect(result.output).toEqual({
+      type: 'text',
+      text: '[]',
+    });
+  });
 });
 
 describe('checkForFinalOutputFromTools', () => {


### PR DESCRIPTION
This pull request fixes empty array function tool outputs being normalized as empty structured output, which could drop the tool result entirely.

Empty arrays now fall back to text serialization and reach the model as `"[]"`. Non-empty structured output arrays retain their existing behavior.

ref: https://github.com/openai/openai-agents-python/pull/3554