### PR TITLE
fix(core): await sibling guardrails after failures

### DIFF
--- a/.changeset/quiet-guards-settle.md
+++ b/.changeset/quiet-guards-settle.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: await sibling guardrails after execution failures

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1003,7 +1003,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               sessionInputUpdate,
             );
 
-            guardrailTracker.throwIfError();
+            await guardrailTracker.throwIfError();
 
             state._lastTurnResponse = await getResponseWithRetry(
               preparedCall.model,
@@ -1385,7 +1385,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             sessionInputUpdate,
           );
 
-          guardrailTracker.throwIfError();
+          await guardrailTracker.throwIfError();
 
           let finalResponse: ModelResponse | undefined = undefined;
           const abortReconciliationState =
@@ -1499,7 +1499,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 signal: options.signal,
               },
             )) {
-              guardrailTracker.throwIfError();
+              await guardrailTracker.throwIfError();
               markInputOnce();
               recordStreamEventForAbortReconciliation(
                 abortReconciliationState,

--- a/packages/agents-core/src/runner/guardrails.ts
+++ b/packages/agents-core/src/runner/guardrails.ts
@@ -110,7 +110,8 @@ async function runGuardrailsWithTripwire<
   resultsTarget: TResult[];
   onTripwire: (result: TResult) => never;
   isTripwireError: (error: unknown) => boolean;
-  onError: (error: unknown) => never;
+  onError: (error: unknown) => unknown;
+  onErrorObserved?: (error: unknown) => void;
 }): Promise<TResult[]> {
   const {
     state,
@@ -120,6 +121,7 @@ async function runGuardrailsWithTripwire<
     onTripwire,
     isTripwireError,
     onError,
+    onErrorObserved,
   } = options;
 
   const guardrailPromises = guardrails.map(async (guardrail) => {
@@ -150,14 +152,12 @@ async function runGuardrailsWithTripwire<
     }
     return results;
   } catch (error) {
+    const finalError = isTripwireError(error) ? error : onError(error);
+    onErrorObserved?.(finalError);
     // Promise.all rejects immediately, so drain the full batch before the
     // failure is surfaced to prevent sibling guardrails from outliving the run.
     await Promise.allSettled(guardrailPromises);
-    if (isTripwireError(error)) {
-      throw error;
-    }
-    onError(error);
-    return [];
+    throw finalError;
   }
 }
 
@@ -197,6 +197,7 @@ export async function runInputGuardrails<
 >(
   state: RunState<TContext, TAgent>,
   guardrails: InputGuardrailDefinition[],
+  options: { onErrorObserved?: (error: unknown) => void } = {},
 ): Promise<InputGuardrailResult[]> {
   if (guardrails.length === 0) {
     return [];
@@ -223,12 +224,13 @@ export async function runInputGuardrails<
     onError: (error) => {
       // roll back the current turn to enable reruns
       state._currentTurn--;
-      throw new GuardrailExecutionError(
+      return new GuardrailExecutionError(
         `Input guardrail failed to complete: ${error}`,
         error as Error,
         state,
       );
     },
+    onErrorObserved: options.onErrorObserved,
   });
 }
 
@@ -286,7 +288,7 @@ export async function runOutputGuardrails<
     isTripwireError: (error) =>
       error instanceof OutputGuardrailTripwireTriggered,
     onError: (error) => {
-      throw new GuardrailExecutionError(
+      return new GuardrailExecutionError(
         `Output guardrail failed to complete: ${error}`,
         error as Error,
         state,

--- a/packages/agents-core/src/runner/guardrails.ts
+++ b/packages/agents-core/src/runner/guardrails.ts
@@ -25,7 +25,7 @@ export type GuardrailTracker = {
   markPending: () => void;
   setPromise: (promise?: Promise<InputGuardrailResult[]>) => void;
   setError: (err: unknown) => void;
-  throwIfError: () => void;
+  throwIfError: () => Promise<void>;
   awaitCompletion: (options?: { suppressErrors?: boolean }) => Promise<void>;
 };
 
@@ -38,7 +38,6 @@ export const createGuardrailTracker = (): GuardrailTracker => {
   const setError = (err: unknown) => {
     failed = true;
     error = err;
-    pending = false;
   };
 
   const setPromise = (incoming?: Promise<InputGuardrailResult[]>) => {
@@ -58,8 +57,11 @@ export const createGuardrailTracker = (): GuardrailTracker => {
       });
   };
 
-  const throwIfError = () => {
+  const throwIfError = async () => {
     if (error) {
+      if (promise) {
+        await promise;
+      }
       throw error;
     }
   };

--- a/packages/agents-core/src/runner/guardrails.ts
+++ b/packages/agents-core/src/runner/guardrails.ts
@@ -122,22 +122,20 @@ async function runGuardrailsWithTripwire<
     onError,
   } = options;
 
-  try {
-    // Keep tripwire handling behind this await-all barrier so sibling guardrails
-    // can finish cleanup before the tripwire error is surfaced.
-    const results = await Promise.all(
-      guardrails.map(async (guardrail) => {
-        return withGuardrailSpan(
-          async (span) => {
-            const result = await guardrail.run(guardrailArgs);
-            span.spanData.triggered = result.output.tripwireTriggered;
-            return result;
-          },
-          { data: { name: guardrail.name } },
-          state._currentAgentSpan,
-        );
-      }),
+  const guardrailPromises = guardrails.map(async (guardrail) => {
+    return withGuardrailSpan(
+      async (span) => {
+        const result = await guardrail.run(guardrailArgs);
+        span.spanData.triggered = result.output.tripwireTriggered;
+        return result;
+      },
+      { data: { name: guardrail.name } },
+      state._currentAgentSpan,
     );
+  });
+
+  try {
+    const results = await Promise.all(guardrailPromises);
     resultsTarget.push(...results);
     for (const result of results) {
       if (result.output.tripwireTriggered) {
@@ -152,6 +150,9 @@ async function runGuardrailsWithTripwire<
     }
     return results;
   } catch (error) {
+    // Promise.all rejects immediately, so drain the full batch before the
+    // failure is surfaced to prevent sibling guardrails from outliving the run.
+    await Promise.allSettled(guardrailPromises);
     if (isTripwireError(error)) {
       throw error;
     }

--- a/packages/agents-core/src/runner/turnPreparation.ts
+++ b/packages/agents-core/src/runner/turnPreparation.ts
@@ -199,11 +199,11 @@ async function runInputGuardrailsForTurn<
   }
   if (guardrails.parallel.length > 0) {
     handlers.onParallelStart?.();
-    const promise = runInputGuardrails(state, guardrails.parallel);
-    const parallelGuardrailPromise = promise.catch((err) => {
-      handlers.onParallelError?.(err);
-      return [];
-    });
+    const parallelGuardrailPromise = runInputGuardrails(
+      state,
+      guardrails.parallel,
+      { onErrorObserved: handlers.onParallelError },
+    ).catch(() => []);
     return { parallelGuardrailPromise };
   }
 

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import {
   Agent,
   AgentInputItem,
+  GuardrailExecutionError,
   MaxTurnsExceededError,
   ModelRefusalError,
   run,
@@ -2750,6 +2751,85 @@ describe('Runner.run (streaming)', () => {
     expect(saveInputSpy).not.toHaveBeenCalled();
     expect(saveResultSpy).not.toHaveBeenCalled();
     expect(guardrail.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start streaming while sibling parallel guardrails drain after a failure', async () => {
+    let releaseSlowGuardrail!: () => void;
+    let markSlowStarted!: () => void;
+    let markErrorThrown!: () => void;
+    const slowGuardrailCanFinish = new Promise<void>((resolve) => {
+      releaseSlowGuardrail = resolve;
+    });
+    const slowGuardrailStarted = new Promise<void>((resolve) => {
+      markSlowStarted = resolve;
+    });
+    const errorThrown = new Promise<void>((resolve) => {
+      markErrorThrown = resolve;
+    });
+    const slowGuardrail = {
+      name: 'slow-parallel-guardrail',
+      execute: async () => {
+        markSlowStarted();
+        await slowGuardrailCanFinish;
+        return { tripwireTriggered: false, outputInfo: {} };
+      },
+    };
+    const errorGuardrail = {
+      name: 'failing-parallel-guardrail',
+      execute: async () => {
+        await slowGuardrailStarted;
+        markErrorThrown();
+        throw new Error('boom');
+      },
+    };
+
+    class TrackingStreamingModel implements Model {
+      calls = 0;
+
+      async getResponse(_request: ModelRequest): Promise<ModelResponse> {
+        throw new Error('not implemented');
+      }
+
+      async *getStreamedResponse(
+        _request: ModelRequest,
+      ): AsyncIterable<StreamEvent> {
+        this.calls++;
+        yield {
+          type: 'response_done',
+          response: {
+            id: 'stream-response',
+            usage: {
+              requests: 1,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            output: [protocol.OutputModelItem.parse(fakeModelMessage('done'))],
+          },
+        } satisfies StreamEvent;
+      }
+    }
+
+    const model = new TrackingStreamingModel();
+    const agent = new Agent({
+      name: 'StreamingParallelGuardrailFailure',
+      model,
+      inputGuardrails: [slowGuardrail, errorGuardrail],
+    });
+    const runner = new Runner();
+
+    const result = await runner.run(agent, 'hello', { stream: true });
+    void result.completed.catch(() => {});
+    await errorThrown;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const callsBeforeSiblingFinished = model.calls;
+    releaseSlowGuardrail();
+
+    await expect(result.completed).rejects.toBeInstanceOf(
+      GuardrailExecutionError,
+    );
+    expect(callsBeforeSiblingFinished).toBe(0);
+    expect(model.calls).toBe(0);
   });
 
   it('persists streaming input but drops the result when an output guardrail trips', async () => {

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -2819,16 +2819,26 @@ describe('Runner.run (streaming)', () => {
     const runner = new Runner();
 
     const result = await runner.run(agent, 'hello', { stream: true });
-    void result.completed.catch(() => {});
+    let completionSettled = false;
+    void result.completed.then(
+      () => {
+        completionSettled = true;
+      },
+      () => {
+        completionSettled = true;
+      },
+    );
     await errorThrown;
     await new Promise((resolve) => setTimeout(resolve, 0));
     const callsBeforeSiblingFinished = model.calls;
+    const settledBeforeSiblingFinished = completionSettled;
     releaseSlowGuardrail();
 
     await expect(result.completed).rejects.toBeInstanceOf(
       GuardrailExecutionError,
     );
     expect(callsBeforeSiblingFinished).toBe(0);
+    expect(settledBeforeSiblingFinished).toBe(false);
     expect(model.calls).toBe(0);
   });
 

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -1816,14 +1816,24 @@ describe('Runner.run', () => {
       });
 
       const runPromise = run(agent, 'hello');
-      void runPromise.catch(() => {});
+      let runSettled = false;
+      void runPromise.then(
+        () => {
+          runSettled = true;
+        },
+        () => {
+          runSettled = true;
+        },
+      );
       await errorThrown;
       await new Promise((resolve) => setTimeout(resolve, 0));
       const callsBeforeSiblingFinished = model.calls;
+      const settledBeforeSiblingFinished = runSettled;
       releaseSlowGuardrail();
 
       await expect(runPromise).rejects.toBeInstanceOf(GuardrailExecutionError);
       expect(callsBeforeSiblingFinished).toBe(0);
+      expect(settledBeforeSiblingFinished).toBe(false);
       expect(model.calls).toBe(0);
     });
 

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -12,6 +12,7 @@ import {
 import { z } from 'zod';
 import {
   Agent,
+  GuardrailExecutionError,
   InputGuardrailTripwireTriggered,
   MaxTurnsExceededError,
   ModelRefusalError,
@@ -1757,6 +1758,73 @@ describe('Runner.run', () => {
       expect(result.finalOutput).toBe('done');
       expect(result.inputGuardrailResults).toHaveLength(1);
       expect(blockingGuardrail.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call the model while sibling parallel guardrails drain after a failure', async () => {
+      let releaseSlowGuardrail!: () => void;
+      let markSlowStarted!: () => void;
+      let markErrorThrown!: () => void;
+      const slowGuardrailCanFinish = new Promise<void>((resolve) => {
+        releaseSlowGuardrail = resolve;
+      });
+      const slowGuardrailStarted = new Promise<void>((resolve) => {
+        markSlowStarted = resolve;
+      });
+      const errorThrown = new Promise<void>((resolve) => {
+        markErrorThrown = resolve;
+      });
+      const slowGuardrail = {
+        name: 'slow-parallel-guardrail',
+        execute: async () => {
+          markSlowStarted();
+          await slowGuardrailCanFinish;
+          return { tripwireTriggered: false, outputInfo: {} };
+        },
+      };
+      const errorGuardrail = {
+        name: 'failing-parallel-guardrail',
+        execute: async () => {
+          await slowGuardrailStarted;
+          markErrorThrown();
+          throw new Error('boom');
+        },
+      };
+
+      class TrackingModel implements Model {
+        calls = 0;
+
+        async getResponse(_request: ModelRequest): Promise<ModelResponse> {
+          this.calls++;
+          return {
+            output: [fakeModelMessage('should not run')],
+            usage: new Usage(),
+          };
+        }
+
+        /* eslint-disable require-yield */
+        async *getStreamedResponse(_request: ModelRequest) {
+          throw new Error('not implemented');
+        }
+        /* eslint-enable require-yield */
+      }
+
+      const model = new TrackingModel();
+      const agent = new Agent({
+        name: 'ParallelGuardrailFailure',
+        model,
+        inputGuardrails: [slowGuardrail, errorGuardrail],
+      });
+
+      const runPromise = run(agent, 'hello');
+      void runPromise.catch(() => {});
+      await errorThrown;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      const callsBeforeSiblingFinished = model.calls;
+      releaseSlowGuardrail();
+
+      await expect(runPromise).rejects.toBeInstanceOf(GuardrailExecutionError);
+      expect(callsBeforeSiblingFinished).toBe(0);
+      expect(model.calls).toBe(0);
     });
 
     it('throws InputGuardrailTripwireTriggered when parallel guardrail trips with structured output and model returns non-JSON', async () => {

--- a/packages/agents-core/test/runner/guardrails.test.ts
+++ b/packages/agents-core/test/runner/guardrails.test.ts
@@ -151,6 +151,66 @@ describe('runInputGuardrails', () => {
     expect(state._inputGuardrailResults).toHaveLength(0);
     expect(state._currentTurn).toBe(1);
   });
+
+  it('awaits sibling input guardrails before surfacing execution failures', async () => {
+    const agent = makeAgent({ name: 'InputErrorAwait' });
+    const state = makeState(agent);
+    let releaseSlowGuardrail!: () => void;
+    let markSlowStarted!: () => void;
+    let markErrorThrown!: () => void;
+    let slowGuardrailFinished = false;
+    const slowGuardrailCanFinish = new Promise<void>((resolve) => {
+      releaseSlowGuardrail = resolve;
+    });
+    const slowGuardrailStarted = new Promise<void>((resolve) => {
+      markSlowStarted = resolve;
+    });
+    const errorThrown = new Promise<void>((resolve) => {
+      markErrorThrown = resolve;
+    });
+    const slowGuardrail = defineInputGuardrail({
+      name: 'slow',
+      execute: async () => {
+        markSlowStarted();
+        await slowGuardrailCanFinish;
+        slowGuardrailFinished = true;
+        return {
+          tripwireTriggered: false,
+          outputInfo: { slow: true },
+        };
+      },
+    });
+    const errorGuardrail = defineInputGuardrail({
+      name: 'error',
+      execute: async () => {
+        await slowGuardrailStarted;
+        markErrorThrown();
+        throw new Error('boom');
+      },
+    });
+
+    const runPromise = withTrace('guardrails-input-error-await-sibling', () =>
+      runInputGuardrails(state, [slowGuardrail, errorGuardrail]),
+    );
+    let settled = false;
+    void runPromise.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+
+    await errorThrown;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const settledBeforeSiblingFinished = settled;
+    releaseSlowGuardrail();
+
+    await expect(runPromise).rejects.toBeInstanceOf(GuardrailExecutionError);
+    expect(settledBeforeSiblingFinished).toBe(false);
+    expect(slowGuardrailFinished).toBe(true);
+  });
 });
 
 describe('runOutputGuardrails', () => {
@@ -284,5 +344,69 @@ describe('runOutputGuardrails', () => {
       ),
     ).rejects.toBeInstanceOf(GuardrailExecutionError);
     expect(state._outputGuardrailResults).toHaveLength(0);
+  });
+
+  it('awaits sibling output guardrails before surfacing execution failures', async () => {
+    const agent = makeAgent({ name: 'OutputErrorAwait' });
+    const state = makeState(agent);
+    let releaseSlowGuardrail!: () => void;
+    let markSlowStarted!: () => void;
+    let markErrorThrown!: () => void;
+    let slowGuardrailFinished = false;
+    const slowGuardrailCanFinish = new Promise<void>((resolve) => {
+      releaseSlowGuardrail = resolve;
+    });
+    const slowGuardrailStarted = new Promise<void>((resolve) => {
+      markSlowStarted = resolve;
+    });
+    const errorThrown = new Promise<void>((resolve) => {
+      markErrorThrown = resolve;
+    });
+    const slowGuardrail = defineOutputGuardrail({
+      name: 'slow',
+      execute: async () => {
+        markSlowStarted();
+        await slowGuardrailCanFinish;
+        slowGuardrailFinished = true;
+        return {
+          tripwireTriggered: false,
+          outputInfo: { slow: true },
+        };
+      },
+    });
+    const errorGuardrail = defineOutputGuardrail({
+      name: 'error',
+      execute: async () => {
+        await slowGuardrailStarted;
+        markErrorThrown();
+        throw new Error('boom');
+      },
+    });
+
+    const runPromise = withTrace('guardrails-output-error-await-sibling', () =>
+      runOutputGuardrails(
+        state,
+        [slowGuardrail as any, errorGuardrail as any],
+        'ok',
+      ),
+    );
+    let settled = false;
+    void runPromise.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+
+    await errorThrown;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const settledBeforeSiblingFinished = settled;
+    releaseSlowGuardrail();
+
+    await expect(runPromise).rejects.toBeInstanceOf(GuardrailExecutionError);
+    expect(settledBeforeSiblingFinished).toBe(false);
+    expect(slowGuardrailFinished).toBe(true);
   });
 });


### PR DESCRIPTION
This pull request fixes parallel input and output guardrails so an execution failure is not surfaced until every sibling guardrail promise has settled.

It preserves the original first failure and existing tripwire semantics while preventing sibling work from continuing past the runner's error boundary. Forced cancellation is intentionally excluded because guardrails do not currently receive a cooperative `AbortSignal`.

ref: https://github.com/openai/openai-agents-python/pull/3239