### PR TITLE
fix(core): parse special permission bits by position

### DIFF
--- a/.changeset/neat-permissions-parse.md
+++ b/.changeset/neat-permissions-parse.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: parse special filesystem permission bits by position

--- a/packages/agents-core/src/sandbox/permissions.ts
+++ b/packages/agents-core/src/sandbox/permissions.ts
@@ -88,9 +88,9 @@ export class Permissions {
 
     return new Permissions({
       directory: permissions[0] === 'd',
-      owner: parsePermissionTriplet(permissions.slice(1, 4)),
-      group: parsePermissionTriplet(permissions.slice(4, 7)),
-      other: parsePermissionTriplet(permissions.slice(7, 10)),
+      owner: parsePermissionTriplet(permissions.slice(1, 4), ['s', 'S']),
+      group: parsePermissionTriplet(permissions.slice(4, 7), ['s', 'S']),
+      other: parsePermissionTriplet(permissions.slice(7, 10), ['t', 'T']),
     });
   }
 
@@ -134,7 +134,10 @@ function normalizePermissionBits(value: number, label: string): number {
   return value;
 }
 
-function parsePermissionTriplet(value: string): number {
+function parsePermissionTriplet(
+  value: string,
+  specialExecChars: readonly [withExec: string, withoutExec: string],
+): number {
   if (value.length !== 3) {
     throw new Error(`Invalid permissions triplet: ${value}`);
   }
@@ -150,9 +153,10 @@ function parsePermissionTriplet(value: string): number {
   } else if (value[1] !== '-') {
     throw new Error(`Invalid write flag: ${value}`);
   }
-  if (value[2] === 'x') {
+  const [withExec, withoutExec] = specialExecChars;
+  if (value[2] === 'x' || value[2] === withExec) {
     mode |= FileMode.EXEC;
-  } else if (value[2] !== '-') {
+  } else if (value[2] !== '-' && value[2] !== withoutExec) {
     throw new Error(`Invalid exec flag: ${value}`);
   }
   return mode;

--- a/packages/agents-core/test/sandboxManifest.test.ts
+++ b/packages/agents-core/test/sandboxManifest.test.ts
@@ -875,6 +875,32 @@ describe('Manifest', () => {
     expect(directory.toString()).toBe('drwxr-x---');
   });
 
+  it('parses position-specific special permission bits', () => {
+    const stickyDirectory = Permissions.fromString('drwxrwxrwt');
+    const specialWithExec = Permissions.fromString('-rwsr-sr-t');
+    const specialWithoutExec = Permissions.fromString('-rwSr-Sr-T');
+
+    expect(stickyDirectory.directory).toBe(true);
+    expect(stickyDirectory.other & FileMode.EXEC).toBe(FileMode.EXEC);
+    expect(specialWithExec.owner & FileMode.EXEC).toBe(FileMode.EXEC);
+    expect(specialWithExec.group & FileMode.EXEC).toBe(FileMode.EXEC);
+    expect(specialWithExec.other & FileMode.EXEC).toBe(FileMode.EXEC);
+    expect(specialWithoutExec.owner & FileMode.EXEC).toBe(FileMode.NONE);
+    expect(specialWithoutExec.group & FileMode.EXEC).toBe(FileMode.NONE);
+    expect(specialWithoutExec.other & FileMode.EXEC).toBe(FileMode.NONE);
+  });
+
+  it.each([
+    '-rwTr--r--',
+    '-rwxrwTr--',
+    '-rwxrwxr-S',
+    '-rwtr--r--',
+    '-rwxrwtr--',
+    '-rwxrwxr-s',
+  ])('rejects special permission bits in the wrong position: %s', (value) => {
+    expect(() => Permissions.fromString(value)).toThrow('Invalid exec flag');
+  });
+
   it('rejects invalid manifest identity and permission metadata', () => {
     expect(() => new Manifest({ users: [{ name: ' ' }] })).toThrow(
       /user name must be non-empty/i,


### PR DESCRIPTION
This pull request fixes parsing of special filesystem permission bits from `ls -l` output.

Owner and group execute positions now accept `s`/`S`, while the other position accepts `t`/`T`. Lowercase variants set the modeled execute bit, uppercase variants do not, and markers in invalid positions remain rejected. Special bits are not retained because `Permissions` currently models only read, write, execute, and directory state.

ref: https://github.com/openai/openai-agents-python/pull/3420