### PR TITLE
fix: encode realtime audio buffers safely

### DIFF
--- a/.changeset/realtime-large-audio-base64.md
+++ b/.changeset/realtime-large-audio-base64.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: encode large realtime audio buffers without argument spread

--- a/packages/agents-realtime/src/utils.ts
+++ b/packages/agents-realtime/src/utils.ts
@@ -6,6 +6,7 @@ import {
 import type { InputAudioTranscriptionCompletedEvent } from './transportLayerEvents';
 import METADATA from './metadata';
 import { RunToolApprovalItem } from '@openai/agents-core';
+import { encodeUint8ArrayToBase64 } from '@openai/agents-core/utils';
 import { RealtimeAgent } from './realtimeAgent';
 
 /**
@@ -29,8 +30,7 @@ export function base64ToArrayBuffer(base64: string) {
  * @returns {string}
  */
 export function arrayBufferToBase64(arrayBuffer: ArrayBuffer) {
-  const binaryString = String.fromCharCode(...new Uint8Array(arrayBuffer));
-  return btoa(binaryString);
+  return encodeUint8ArrayToBase64(new Uint8Array(arrayBuffer));
 }
 
 /**

--- a/packages/agents-realtime/test/utils.test.ts
+++ b/packages/agents-realtime/test/utils.test.ts
@@ -25,6 +25,19 @@ describe('realtime utils', () => {
     expect(new Uint8Array(result)).toEqual(new Uint8Array(buffer));
   });
 
+  it('encodes large audio buffers safely', () => {
+    const size = 1024 * 1024;
+    const payload = new Uint8Array(size);
+    for (let i = 0; i < size; i += 1) {
+      payload[i] = i % 256;
+    }
+
+    const base64 = arrayBufferToBase64(payload.buffer);
+    const result = base64ToArrayBuffer(base64);
+
+    expect(new Uint8Array(result)).toEqual(payload);
+  });
+
   it('extracts transcript from audio output message', () => {
     const message: RealtimeMessageItem = {
       itemId: '1',


### PR DESCRIPTION
## Summary
- Reuse the shared base64 encoder for realtime ArrayBuffer conversion so large audio buffers avoid argument-spread limits.
- Add a 1 MiB regression test for realtime audio buffer base64 round trips.

## Tests
- bash .agents/skills/code-change-verification/scripts/run.sh