### PR TITLE
fix: clean up Twilio realtime listeners

### DIFF
--- a/.changeset/twilio-reconnect-listeners.md
+++ b/.changeset/twilio-reconnect-listeners.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: clean up Twilio realtime listeners on reconnect and failed connect

--- a/packages/agents-extensions/src/TwilioRealtimeTransport.ts
+++ b/packages/agents-extensions/src/TwilioRealtimeTransport.ts
@@ -60,6 +60,82 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
   #lastPlayedChunkCount: number = 0;
   #previousItemId: string | null = null;
   #logger = getLogger('openai-agents:extensions:twilio');
+  #twilioListenersAttached = false;
+
+  #handleTwilioMessage = (message: MessageEvent | NodeMessageEvent) => {
+    try {
+      const data = JSON.parse(message.data.toString());
+      if (this.#logger.dontLogModelData) {
+        this.#logger.debug('Twilio message:', data.event);
+      } else {
+        this.#logger.debug('Twilio message:', data);
+      }
+      this.emit('*', {
+        type: 'twilio_message',
+        message: data,
+      });
+      switch (data.event) {
+        case 'media':
+          if (this.status === 'connected') {
+            this.sendAudio(utils.base64ToArrayBuffer(data.media.payload));
+          }
+          break;
+        case 'mark':
+          if (
+            !data.mark.name.startsWith('done:') &&
+            data.mark.name.includes(':')
+          ) {
+            // keeping track of what the last chunk was that the user heard fully
+            const count = Number(data.mark.name.split(':')[1]);
+            if (Number.isFinite(count)) {
+              this.#lastPlayedChunkCount = count;
+            } else {
+              this.#logger.warn('Invalid mark name received:', data.mark.name);
+            }
+          } else if (data.mark.name.startsWith('done:')) {
+            this.#lastPlayedChunkCount = 0;
+          }
+          break;
+        case 'start':
+          this.#streamSid = data.start.streamSid;
+          break;
+        default:
+          break;
+      }
+    } catch (error) {
+      this.#logger.error('Error parsing message:', error, 'Message:', message);
+      this.emit('error', {
+        type: 'error',
+        error,
+      });
+    }
+  };
+
+  #handleTwilioClose = () => {
+    if (this.status !== 'disconnected') {
+      this.close();
+    }
+  };
+
+  #handleTwilioError = (error: ErrorEvent | NodeErrorEvent) => {
+    this.emit('error', {
+      type: 'error',
+      error,
+    });
+    this.close();
+  };
+
+  #handleAudioDone = () => {
+    this.#twilioWebSocket.send(
+      JSON.stringify({
+        event: 'mark',
+        mark: {
+          name: `done:${this.currentItemId}`,
+        },
+        streamSid: this.#streamSid,
+      }),
+    );
+  };
 
   constructor(options: TwilioRealtimeTransportLayerOptions) {
     super(options);
@@ -105,97 +181,50 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
     };
   }
 
+  #addTwilioListeners() {
+    this.#removeTwilioListeners();
+    this.#twilioWebSocket.addEventListener(
+      'message',
+      this.#handleTwilioMessage,
+    );
+    this.#twilioWebSocket.addEventListener('close', this.#handleTwilioClose);
+    this.#twilioWebSocket.addEventListener('error', this.#handleTwilioError);
+    this.on('audio_done', this.#handleAudioDone);
+    this.#twilioListenersAttached = true;
+  }
+
+  #removeTwilioListeners() {
+    if (!this.#twilioListenersAttached) {
+      return;
+    }
+
+    this.#twilioWebSocket.removeEventListener(
+      'message',
+      this.#handleTwilioMessage,
+    );
+    this.#twilioWebSocket.removeEventListener('close', this.#handleTwilioClose);
+    this.#twilioWebSocket.removeEventListener('error', this.#handleTwilioError);
+    this.off('audio_done', this.#handleAudioDone);
+    this.#twilioListenersAttached = false;
+  }
+
   async connect(options: RealtimeTransportLayerConnectOptions) {
     options.initialSessionConfig = this._setInputAndOutputAudioFormat(
       options.initialSessionConfig,
     );
     // listen to Twilio messages as quickly as possible
-    this.#twilioWebSocket.addEventListener(
-      'message',
-      (message: MessageEvent | NodeMessageEvent) => {
-        try {
-          const data = JSON.parse(message.data.toString());
-          if (this.#logger.dontLogModelData) {
-            this.#logger.debug('Twilio message:', data.event);
-          } else {
-            this.#logger.debug('Twilio message:', data);
-          }
-          this.emit('*', {
-            type: 'twilio_message',
-            message: data,
-          });
-          switch (data.event) {
-            case 'media':
-              if (this.status === 'connected') {
-                this.sendAudio(utils.base64ToArrayBuffer(data.media.payload));
-              }
-              break;
-            case 'mark':
-              if (
-                !data.mark.name.startsWith('done:') &&
-                data.mark.name.includes(':')
-              ) {
-                // keeping track of what the last chunk was that the user heard fully
-                const count = Number(data.mark.name.split(':')[1]);
-                if (Number.isFinite(count)) {
-                  this.#lastPlayedChunkCount = count;
-                } else {
-                  this.#logger.warn(
-                    'Invalid mark name received:',
-                    data.mark.name,
-                  );
-                }
-              } else if (data.mark.name.startsWith('done:')) {
-                this.#lastPlayedChunkCount = 0;
-              }
-              break;
-            case 'start':
-              this.#streamSid = data.start.streamSid;
-              break;
-            default:
-              break;
-          }
-        } catch (error) {
-          this.#logger.error(
-            'Error parsing message:',
-            error,
-            'Message:',
-            message,
-          );
-          this.emit('error', {
-            type: 'error',
-            error,
-          });
-        }
-      },
-    );
-    this.#twilioWebSocket.addEventListener('close', () => {
-      if (this.status !== 'disconnected') {
-        this.close();
-      }
-    });
-    this.#twilioWebSocket.addEventListener(
-      'error',
-      (error: ErrorEvent | NodeErrorEvent) => {
-        this.emit('error', {
-          type: 'error',
-          error,
-        });
-        this.close();
-      },
-    );
-    this.on('audio_done', () => {
-      this.#twilioWebSocket.send(
-        JSON.stringify({
-          event: 'mark',
-          mark: {
-            name: `done:${this.currentItemId}`,
-          },
-          streamSid: this.#streamSid,
-        }),
-      );
-    });
-    await super.connect(options);
+    this.#addTwilioListeners();
+    try {
+      await super.connect(options);
+    } catch (error) {
+      this.#removeTwilioListeners();
+      throw error;
+    }
+  }
+
+  close() {
+    this.#removeTwilioListeners();
+    super.close();
   }
 
   updateSessionConfig(config: Partial<RealtimeSessionConfig>): void {

--- a/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
+++ b/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
@@ -3,9 +3,6 @@ import { EventEmitter } from 'events';
 import { TwilioRealtimeTransportLayer } from '../src/TwilioRealtimeTransport';
 import { allowConsole } from '../../../helpers/tests/console-guard';
 
-import type { MessageEvent as NodeMessageEvent } from 'ws';
-import type { MessageEvent } from 'undici-types';
-
 vi.mock('@openai/agents/realtime', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { EventEmitter } = require('events');
@@ -34,15 +31,38 @@ vi.mock('@openai/agents/realtime', () => {
 class FakeTwilioWebSocket extends EventEmitter {
   send = vi.fn();
   close = vi.fn();
-}
+  listenerWrappers = new Map<
+    string,
+    Map<(evt: any) => void, (evt: any) => void>
+  >();
 
-// @ts-expect-error - we're making the node event emitter compatible with the browser event emitter
-FakeTwilioWebSocket.prototype.addEventListener = function (
-  type: string,
-  listener: (evt: MessageEvent | NodeMessageEvent) => void,
-) {
-  this.on(type, (evt) => listener(type === 'message' ? { data: evt } : evt));
-};
+  addEventListener(type: string, listener: (evt: any) => void) {
+    const wrapped = (evt: any) =>
+      listener(type === 'message' ? { data: evt } : evt);
+    const wrappers = this.listenerWrappers.get(type) ?? new Map();
+    wrappers.set(listener, wrapped);
+    this.listenerWrappers.set(type, wrappers);
+    this.on(type, wrapped);
+  }
+
+  removeEventListener(type: string, listener: (evt: any) => void) {
+    const wrappers = this.listenerWrappers.get(type);
+    if (!wrappers) {
+      return;
+    }
+
+    const wrapped = wrappers.get(listener);
+    if (!wrapped) {
+      return;
+    }
+
+    this.off(type, wrapped);
+    wrappers.delete(listener);
+    if (wrappers.size === 0) {
+      this.listenerWrappers.delete(type);
+    }
+  }
+}
 
 const base64 = (data: string) => Buffer.from(data).toString('base64');
 
@@ -151,8 +171,80 @@ describe('TwilioRealtimeTransportLayer', () => {
 
     twilio.emit('close');
     expect(closeSpy).toHaveBeenCalled();
-    twilio.emit('error', new Error('boom'));
+
+    const twilioError = new FakeTwilioWebSocket();
+    const transportError = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: twilioError as any,
+    });
+    transportError.on('error', vi.fn());
+    await transportError.connect({ apiKey: 'ek_test' } as any);
+    twilioError.emit('error', new Error('boom'));
     expect(closeSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test('connect does not duplicate Twilio listeners on reconnect', async () => {
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: twilio as any,
+    });
+
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    await transport.connect({ apiKey: 'ek_test' } as any);
+
+    expect(twilio.listenerCount('message')).toBe(1);
+    expect(twilio.listenerCount('close')).toBe(1);
+    expect(twilio.listenerCount('error')).toBe(1);
+
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const sendAudioSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.sendAudio);
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({ event: 'media', media: { payload: base64('a') } }),
+    });
+
+    expect(sendAudioSpy).toHaveBeenCalledTimes(1);
+
+    transport.emit('audio_done' as any);
+    expect(twilio.send).toHaveBeenCalledTimes(1);
+  });
+
+  test('connect removes Twilio listeners when OpenAI connect fails', async () => {
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: twilio as any,
+    });
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    vi.mocked(OpenAIRealtimeWebSocket.prototype.connect).mockRejectedValueOnce(
+      new Error('connect failed'),
+    );
+
+    await expect(
+      transport.connect({ apiKey: 'ek_test' } as any),
+    ).rejects.toThrow('connect failed');
+
+    expect(twilio.listenerCount('message')).toBe(0);
+    expect(twilio.listenerCount('close')).toBe(0);
+    expect(twilio.listenerCount('error')).toBe(0);
+
+    transport.emit('audio_done' as any);
+    expect(twilio.send).not.toHaveBeenCalled();
+  });
+
+  test('close removes Twilio listeners', async () => {
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: twilio as any,
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+
+    transport.close();
+
+    expect(twilio.listenerCount('message')).toBe(0);
+    expect(twilio.listenerCount('close')).toBe(0);
+    expect(twilio.listenerCount('error')).toBe(0);
+
+    transport.emit('audio_done' as any);
+    expect(twilio.send).not.toHaveBeenCalled();
   });
 
   test('_onAudio resets chunk count and emits', async () => {


### PR DESCRIPTION
## Summary
- Store Twilio websocket and internal audio_done listener references so reconnects replace old handlers instead of stacking duplicates.
- Remove Twilio listeners when close() is called or when the OpenAI realtime connect step fails after early listener attachment.
- Add regression coverage for reconnect, failed connect, and close cleanup.

## Tests
- pnpm vitest run packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
- pnpm -F @openai/agents-extensions build-check
- bash .agents/skills/code-change-verification/scripts/run.sh