### PR TITLE
fix: reject invalid handoff input filters

### DIFF
--- a/.changeset/invalid-handoff-input-filter.md
+++ b/.changeset/invalid-handoff-input-filter.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: reject invalid handoff input filters before invoking handoffs

--- a/packages/agents-core/src/handoff.ts
+++ b/packages/agents-core/src/handoff.ts
@@ -434,7 +434,7 @@ export function handoff<
     handoff.toolDescription = config.toolDescriptionOverride;
   }
 
-  if (config.inputFilter) {
+  if (config.inputFilter != null) {
     handoff.inputFilter = config.inputFilter;
   }
 

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -1455,7 +1455,7 @@ export async function executeHandoffCalls<
       const handoff = actualHandoff.handoff;
       const inputFilter =
         handoff.inputFilter ?? runner.config.handoffInputFilter;
-      if (inputFilter && typeof inputFilter !== 'function') {
+      if (inputFilter != null && typeof inputFilter !== 'function') {
         handoffSpan.setError({
           message: 'Invalid input filter',
           data: {
@@ -1496,7 +1496,7 @@ export async function executeHandoffCalls<
       runner.emit('agent_handoff', runContext, agent, newAgent);
       agent.emit('agent_handoff', runContext, newAgent);
 
-      if (inputFilter) {
+      if (inputFilter != null) {
         logger.debug('Filtering inputs for handoff');
 
         const handoffInputData: HandoffInputData = {

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -1456,13 +1456,14 @@ export async function executeHandoffCalls<
       const inputFilter =
         handoff.inputFilter ?? runner.config.handoffInputFilter;
       if (inputFilter != null && typeof inputFilter !== 'function') {
-        handoffSpan.setError({
-          message: 'Invalid input filter',
-          data: {
-            details: 'not callable',
+        throw Object.assign(
+          new UserError('Invalid handoff input filter: not callable'),
+          {
+            data: {
+              details: 'not callable',
+            },
           },
-        });
-        throw new UserError('Invalid handoff input filter: not callable');
+        );
       }
 
       const newAgent = await handoff.onInvokeHandoff(

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -1453,6 +1453,17 @@ export async function executeHandoffCalls<
   return withHandoffSpan(
     async (handoffSpan) => {
       const handoff = actualHandoff.handoff;
+      const inputFilter =
+        handoff.inputFilter ?? runner.config.handoffInputFilter;
+      if (inputFilter && typeof inputFilter !== 'function') {
+        handoffSpan.setError({
+          message: 'Invalid input filter',
+          data: {
+            details: 'not callable',
+          },
+        });
+        throw new UserError('Invalid handoff input filter: not callable');
+      }
 
       const newAgent = await handoff.onInvokeHandoff(
         runContext,
@@ -1485,19 +1496,8 @@ export async function executeHandoffCalls<
       runner.emit('agent_handoff', runContext, agent, newAgent);
       agent.emit('agent_handoff', runContext, newAgent);
 
-      const inputFilter =
-        handoff.inputFilter ?? runner.config.handoffInputFilter;
       if (inputFilter) {
         logger.debug('Filtering inputs for handoff');
-
-        if (typeof inputFilter !== 'function') {
-          handoffSpan.setError({
-            message: 'Invalid input filter',
-            data: {
-              details: 'not callable',
-            },
-          });
-        }
 
         const handoffInputData: HandoffInputData = {
           inputHistory: Array.isArray(originalInput)

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -1498,8 +1498,10 @@ describe('executeHandoffCalls', () => {
     async (_label, inputFilter) => {
       const target = new Agent({ name: 'Target' });
       const onHandoff = vi.fn();
-      const h = handoff(target, { onHandoff });
-      h.inputFilter = inputFilter as any;
+      const h = handoff(target, {
+        onHandoff,
+        inputFilter: inputFilter as any,
+      });
       const runner = new Runner({ tracingDisabled: true });
       const runnerHandoffListener = vi.fn();
       const agentHandoffListener = vi.fn();

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -1480,40 +1480,48 @@ describe('executeHandoffCalls', () => {
     expect(res.originalInput).toBe('filtered');
   });
 
-  it('throws before invoking handoff if inputFilter is not callable', async () => {
-    const target = new Agent({ name: 'Target' });
-    const onHandoff = vi.fn();
-    const h = handoff(target, { onHandoff });
-    h.inputFilter = 'not callable' as any;
-    const handoffListener = vi.fn();
-    TEST_AGENT.on('agent_handoff', handoffListener);
-    const call: any = {
-      toolCall: { ...TEST_MODEL_FUNCTION_CALL, name: h.toolName },
-      handoff: h,
-    };
+  it.each([
+    ['string', 'not callable'],
+    ['false', false],
+    ['empty string', ''],
+    ['zero', 0],
+  ])(
+    'throws before invoking handoff if inputFilter is %s',
+    async (_label, inputFilter) => {
+      const target = new Agent({ name: 'Target' });
+      const onHandoff = vi.fn();
+      const h = handoff(target, { onHandoff });
+      h.inputFilter = inputFilter as any;
+      const handoffListener = vi.fn();
+      TEST_AGENT.on('agent_handoff', handoffListener);
+      const call: any = {
+        toolCall: { ...TEST_MODEL_FUNCTION_CALL, name: h.toolName },
+        handoff: h,
+      };
 
-    try {
-      await expect(
-        withTrace('test', () =>
-          executeHandoffCalls(
-            TEST_AGENT,
-            'orig',
-            [],
-            [],
-            TEST_MODEL_RESPONSE_WITH_FUNCTION,
-            [call],
-            new Runner({ tracingDisabled: true }),
-            new RunContext(),
+      try {
+        await expect(
+          withTrace('test', () =>
+            executeHandoffCalls(
+              TEST_AGENT,
+              'orig',
+              [],
+              [],
+              TEST_MODEL_RESPONSE_WITH_FUNCTION,
+              [call],
+              new Runner({ tracingDisabled: true }),
+              new RunContext(),
+            ),
           ),
-        ),
-      ).rejects.toThrow(UserError);
+        ).rejects.toThrow(UserError);
 
-      expect(onHandoff).not.toHaveBeenCalled();
-      expect(handoffListener).not.toHaveBeenCalled();
-    } finally {
-      TEST_AGENT.off('agent_handoff', handoffListener);
-    }
-  });
+        expect(onHandoff).not.toHaveBeenCalled();
+        expect(handoffListener).not.toHaveBeenCalled();
+      } finally {
+        TEST_AGENT.off('agent_handoff', handoffListener);
+      }
+    },
+  );
 });
 
 describe('checkForFinalOutputFromTools interruptions and errors', () => {

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -1479,6 +1479,41 @@ describe('executeHandoffCalls', () => {
 
     expect(res.originalInput).toBe('filtered');
   });
+
+  it('throws before invoking handoff if inputFilter is not callable', async () => {
+    const target = new Agent({ name: 'Target' });
+    const onHandoff = vi.fn();
+    const h = handoff(target, { onHandoff });
+    h.inputFilter = 'not callable' as any;
+    const handoffListener = vi.fn();
+    TEST_AGENT.on('agent_handoff', handoffListener);
+    const call: any = {
+      toolCall: { ...TEST_MODEL_FUNCTION_CALL, name: h.toolName },
+      handoff: h,
+    };
+
+    try {
+      await expect(
+        withTrace('test', () =>
+          executeHandoffCalls(
+            TEST_AGENT,
+            'orig',
+            [],
+            [],
+            TEST_MODEL_RESPONSE_WITH_FUNCTION,
+            [call],
+            new Runner({ tracingDisabled: true }),
+            new RunContext(),
+          ),
+        ),
+      ).rejects.toThrow(UserError);
+
+      expect(onHandoff).not.toHaveBeenCalled();
+      expect(handoffListener).not.toHaveBeenCalled();
+    } finally {
+      TEST_AGENT.off('agent_handoff', handoffListener);
+    }
+  });
 });
 
 describe('checkForFinalOutputFromTools interruptions and errors', () => {

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -150,6 +150,14 @@ function getEndedFunctionSpan(
   return functionSpan as Span<any>;
 }
 
+function getEndedHandoffSpan(processor: RecordingProcessor): Span<any> {
+  const handoffSpan = processor.spansEnded.find(
+    (span) => span.spanData.type === 'handoff',
+  );
+  expect(handoffSpan).toBeDefined();
+  return handoffSpan as Span<any>;
+}
+
 beforeAll(() => {
   setTracingDisabled(true);
   setDefaultModelProvider(new FakeModelProvider());
@@ -1492,8 +1500,11 @@ describe('executeHandoffCalls', () => {
       const onHandoff = vi.fn();
       const h = handoff(target, { onHandoff });
       h.inputFilter = inputFilter as any;
-      const handoffListener = vi.fn();
-      TEST_AGENT.on('agent_handoff', handoffListener);
+      const runner = new Runner({ tracingDisabled: true });
+      const runnerHandoffListener = vi.fn();
+      const agentHandoffListener = vi.fn();
+      runner.on('agent_handoff', runnerHandoffListener);
+      TEST_AGENT.on('agent_handoff', agentHandoffListener);
       const call: any = {
         toolCall: { ...TEST_MODEL_FUNCTION_CALL, name: h.toolName },
         handoff: h,
@@ -1509,19 +1520,67 @@ describe('executeHandoffCalls', () => {
               [],
               TEST_MODEL_RESPONSE_WITH_FUNCTION,
               [call],
-              new Runner({ tracingDisabled: true }),
+              runner,
               new RunContext(),
             ),
           ),
         ).rejects.toThrow(UserError);
 
         expect(onHandoff).not.toHaveBeenCalled();
-        expect(handoffListener).not.toHaveBeenCalled();
+        expect(runnerHandoffListener).not.toHaveBeenCalled();
+        expect(agentHandoffListener).not.toHaveBeenCalled();
       } finally {
-        TEST_AGENT.off('agent_handoff', handoffListener);
+        runner.off('agent_handoff', runnerHandoffListener);
+        TEST_AGENT.off('agent_handoff', agentHandoffListener);
       }
     },
   );
+
+  it('preserves structured handoff span errors for invalid inputFilter', async () => {
+    const target = new Agent({ name: 'Target' });
+    const h = handoff(target);
+    h.inputFilter = false as any;
+    const call: any = {
+      toolCall: { ...TEST_MODEL_FUNCTION_CALL, name: h.toolName },
+      handoff: h,
+    };
+
+    await withRecordingTrace(async (processor) => {
+      let caught: unknown;
+
+      try {
+        await withTrace('test', () =>
+          executeHandoffCalls(
+            TEST_AGENT,
+            'orig',
+            [],
+            [],
+            TEST_MODEL_RESPONSE_WITH_FUNCTION,
+            [call],
+            new Runner(),
+            new RunContext(),
+          ),
+        );
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBeInstanceOf(UserError);
+      expect(
+        (caught as UserError & { data?: Record<string, unknown> }).data,
+      ).toEqual({
+        details: 'not callable',
+      });
+
+      const handoffSpan = getEndedHandoffSpan(processor);
+      expect(handoffSpan.error).toEqual({
+        message: 'Invalid handoff input filter: not callable',
+        data: {
+          details: 'not callable',
+        },
+      });
+    });
+  });
 });
 
 describe('checkForFinalOutputFromTools interruptions and errors', () => {


### PR DESCRIPTION
## Summary
- Validate the selected handoff input filter before invoking the handoff so non-callable filters fail as configuration errors.
- Preserve the existing span error metadata while avoiding partial handoff side effects.
- Add regression coverage that confirms invalid filters do not invoke handoff callbacks or emit handoff events.

## Tests
- pnpm vitest run packages/agents-core/test/runner/toolExecution.test.ts
- pnpm -F @openai/agents-core build-check
- bash .agents/skills/code-change-verification/scripts/run.sh