### PR TITLE
docs: clarify realtime history events

### DIFF
--- a/docs/src/content/docs/extensions/twilio.mdx
+++ b/docs/src/content/docs/extensions/twilio.mdx
@@ -80,7 +80,14 @@ for more information on how to use the `RealtimeSession` with voice agents.
    `transport_event` event on your `RealtimeSession` instance. Every event from Twilio will have a
    type of `twilio_message` and a `message` property that contains the raw event data.
 
-3. **Watch debug logs.**
+3. **Use history events for transcripts.**
+
+   `RealtimeSession` does not emit a generic `message` event. To render the conversation, listen for
+   `history_updated` or `history_added`. User speech only appears as text in that history when input
+   audio transcription is enabled in the session config. If you need raw Realtime API events instead
+   of the normalized history view, listen on `session.transport`.
+
+4. **Watch debug logs.**
 
    Sometimes you may run into issues where you want more information on what's going on. Using
    a `DEBUG=openai-agents*` environment variable will show all the debug logs from the Agents SDK.

--- a/docs/src/content/docs/guides/voice-agents/build.mdx
+++ b/docs/src/content/docs/guides/voice-agents/build.mdx
@@ -14,6 +14,7 @@ import guardrailSettingsExample from '../../../../../../examples/docs/voice-agen
 import audioInterruptedExample from '../../../../../../examples/docs/voice-agents/audioInterrupted.ts?raw';
 import sessionInterruptExample from '../../../../../../examples/docs/voice-agents/sessionInterrupt.ts?raw';
 import updateHistoryExample from '../../../../../../examples/docs/voice-agents/updateHistory.ts?raw';
+import historyEventsExample from '../../../../../../examples/docs/voice-agents/historyEvents.ts?raw';
 import transportEventsExample from '../../../../../../examples/docs/voice-agents/transportEvents.ts?raw';
 import toolHistoryExample from '../../../../../../examples/docs/voice-agents/toolHistory.ts?raw';
 import sendMessageExample from '../../../../../../examples/docs/voice-agents/sendMessage.ts?raw';
@@ -259,7 +260,13 @@ Set `debounceTextLength: -1` when you only want to evaluate the fully generated 
 
 `RealtimeSession` automatically maintains a local `history` snapshot that tracks user messages, assistant output, tool calls, and truncation state. You can render it in the UI, inspect it inside tools, or update it when you need to correct or remove items.
 
-As the conversation changes the session emits `history_updated`. If you need to request history changes, use `updateHistory()`. It asks the transport to diff the current history and send the necessary delete/create events; the local `session.history` view updates as the corresponding conversation events come back.
+As the conversation changes, the session emits `history_updated`; when a new item is added, it also emits `history_added`. `RealtimeSession` does not emit a generic `message` event. Listen to the history events for the SDK's normalized conversation view, or listen to `session.transport` if you need raw Realtime API events.
+
+User audio only appears in history as text when input audio transcription is enabled. If you need to keep the raw audio data in `session.history`, set `historyStoreAudio: true`; it is disabled by default because audio payloads can be large.
+
+<Code lang="typescript" code={historyEventsExample} />
+
+If you need to request history changes, use `updateHistory()`. It asks the transport to diff the current history and send the necessary delete/create events; the local `session.history` view updates as the corresponding conversation events come back.
 
 <Code lang="typescript" code={updateHistoryExample} />
 

--- a/examples/docs/voice-agents/historyEvents.ts
+++ b/examples/docs/voice-agents/historyEvents.ts
@@ -1,0 +1,33 @@
+import { RealtimeAgent, RealtimeSession } from '@openai/agents/realtime';
+
+const agent = new RealtimeAgent({
+  name: 'Assistant',
+});
+
+const session = new RealtimeSession(agent, {
+  model: 'gpt-realtime-2',
+  config: {
+    audio: {
+      input: {
+        transcription: {
+          model: 'gpt-4o-mini-transcribe',
+        },
+      },
+    },
+  },
+  // Enable only when your app needs raw user audio in local history.
+  historyStoreAudio: false,
+});
+
+session.on('history_updated', (history) => {
+  console.log('Full conversation history:', history);
+});
+
+session.on('history_added', (item) => {
+  console.log('New conversation item:', item);
+});
+
+// For raw Realtime API events, listen to the transport instead.
+session.transport.on('*', (event) => {
+  console.log('Raw transport event:', event);
+});


### PR DESCRIPTION
## Summary

Clarifies the RealtimeSession event model for conversation history, especially for voice and Twilio users who expect a generic `message` event.

## Why

Issue #157 reports a Realtime voice session where audio works, but `session.history()` appears empty and `session.on('message', ...)` never fires. The issue discussion points to three SDK usage details that were easy to miss in the docs:

- `RealtimeSession` emits `history_updated` / `history_added`, not a generic `message` event.
- user speech appears as text in history only when input audio transcription is enabled.
- raw Realtime API events should be read from `session.transport`, while Twilio events are exposed via `transport_event`.

## Changes

- Adds a reusable voice-agent docs snippet showing `history_updated`, `history_added`, input audio transcription, and raw transport event listening.
- Updates the voice-agent conversation history section with the event-model distinction.
- Adds a Twilio docs tip for transcript rendering vs raw transport events.

## Validation

- `PATH=/tmp/codex-bin:$PATH pnpm -F '@openai/*' -r build`
- `PATH=/tmp/codex-bin:$PATH pnpm docs:scripts:check`
- `PATH=/tmp/codex-bin:$PATH pnpm test:examples`
- `PATH=/tmp/codex-bin:$PATH pnpm docs:build`
- `git diff --check`

Closes #157.
