### PR TITLE
fix: accept OpenAI clients across module resolution modes

### DIFF
--- a/.changeset/wise-pandas-smile.md
+++ b/.changeset/wise-pandas-smile.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: accept ESM and CommonJS OpenAI clients in public APIs (#1432)

--- a/integration-tests/node-openai-client-types.test.ts
+++ b/integration-tests/node-openai-client-types.test.ts
@@ -1,0 +1,22 @@
+import { beforeAll, describe, test } from 'vitest';
+import { execa as execaBase } from 'execa';
+
+import { createIntegrationSubprocessEnv } from './_helpers/env';
+
+const execa = execaBase({
+  cwd: './integration-tests/node-openai-client-types',
+  env: createIntegrationSubprocessEnv(),
+});
+
+describe('Node.js (NodeNext OpenAI client types)', () => {
+  beforeAll(async () => {
+    console.log('[node-openai-client-types] Removing node_modules');
+    await execa`rm -rf node_modules`;
+    console.log('[node-openai-client-types] Installing dependencies');
+    await execa`npm install`;
+  }, 60_000);
+
+  test('accepts an ESM OpenAI client across TypeScript versions', async () => {
+    await execa`npm run build-check`;
+  });
+});

--- a/integration-tests/node-openai-client-types.test.ts
+++ b/integration-tests/node-openai-client-types.test.ts
@@ -18,5 +18,5 @@ describe('Node.js (NodeNext OpenAI client types)', () => {
 
   test('accepts an ESM OpenAI client across TypeScript versions', async () => {
     await execa`npm run build-check`;
-  });
+  }, 15_000);
 });

--- a/integration-tests/node-openai-client-types/.npmrc
+++ b/integration-tests/node-openai-client-types/.npmrc
@@ -1,0 +1,2 @@
+@openai:registry=http://localhost:4873
+package-lock=false

--- a/integration-tests/node-openai-client-types/package.json
+++ b/integration-tests/node-openai-client-types/package.json
@@ -1,0 +1,18 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build-check": "npm run build-check:typescript-5-2 && npm run build-check:typescript-6",
+    "build-check:typescript-5-2": "node ./node_modules/typescript-5-2/bin/tsc --noEmit",
+    "build-check:typescript-6": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@openai/agents": "latest",
+    "openai": "6.45.0",
+    "zod": "^4"
+  },
+  "devDependencies": {
+    "typescript": "6.0.3",
+    "typescript-5-2": "npm:typescript@5.2.2"
+  }
+}

--- a/integration-tests/node-openai-client-types/src/index.ts
+++ b/integration-tests/node-openai-client-types/src/index.ts
@@ -1,6 +1,14 @@
-import { OpenAIResponsesModel } from '@openai/agents';
+import {
+  getDefaultOpenAIClient,
+  OpenAIResponsesModel,
+  setDefaultOpenAIClient,
+} from '@openai/agents';
 import { OpenAI } from 'openai';
 
 const client = new OpenAI({ apiKey: 'test' });
 
 new OpenAIResponsesModel(client, 'gpt-5.5');
+setDefaultOpenAIClient(client);
+
+const defaultClient: OpenAI | undefined = getDefaultOpenAIClient();
+void defaultClient;

--- a/integration-tests/node-openai-client-types/src/index.ts
+++ b/integration-tests/node-openai-client-types/src/index.ts
@@ -1,0 +1,6 @@
+import { OpenAIResponsesModel } from '@openai/agents';
+import { OpenAI } from 'openai';
+
+const client = new OpenAI({ apiKey: 'test' });
+
+new OpenAIResponsesModel(client, 'gpt-5.5');

--- a/integration-tests/node-openai-client-types/tsconfig.json
+++ b/integration-tests/node-openai-client-types/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/packages/agents-openai/src/defaults.ts
+++ b/packages/agents-openai/src/defaults.ts
@@ -1,6 +1,7 @@
 import { OpenAI } from 'openai';
 import { loadEnv } from '@openai/agents-core/_shims';
 import METADATA from './metadata';
+import type { OpenAIClient } from './openaiClient';
 
 export const DEFAULT_OPENAI_API = 'responses';
 export const DEFAULT_OPENAI_MODEL = 'gpt-5.4-mini';
@@ -36,8 +37,8 @@ export function setOpenAIResponsesTransport(value: 'http' | 'websocket') {
   _defaultOpenAIResponsesTransport = value;
 }
 
-export function setDefaultOpenAIClient(client: OpenAI) {
-  _defaultOpenAIClient = client;
+export function setDefaultOpenAIClient(client: OpenAIClient) {
+  _defaultOpenAIClient = client as OpenAI;
 }
 
 export function getDefaultOpenAIClient(): OpenAI | undefined {

--- a/packages/agents-openai/src/defaults.ts
+++ b/packages/agents-openai/src/defaults.ts
@@ -1,4 +1,3 @@
-import { OpenAI } from 'openai';
 import { loadEnv } from '@openai/agents-core/_shims';
 import METADATA from './metadata';
 import type { OpenAIClient } from './openaiClient';
@@ -9,7 +8,7 @@ export const DEFAULT_OPENAI_RESPONSES_TRANSPORT = 'http';
 
 let _defaultOpenAIAPI = DEFAULT_OPENAI_API;
 let _defaultOpenAIResponsesTransport = DEFAULT_OPENAI_RESPONSES_TRANSPORT;
-let _defaultOpenAIClient: OpenAI | undefined;
+let _defaultOpenAIClient: OpenAIClient | undefined;
 let _defaultOpenAIKey: string | undefined = undefined;
 let _defaultTracingApiKey: string | undefined = undefined;
 
@@ -38,11 +37,13 @@ export function setOpenAIResponsesTransport(value: 'http' | 'websocket') {
 }
 
 export function setDefaultOpenAIClient(client: OpenAIClient) {
-  _defaultOpenAIClient = client as OpenAI;
+  _defaultOpenAIClient = client;
 }
 
-export function getDefaultOpenAIClient(): OpenAI | undefined {
-  return _defaultOpenAIClient;
+export function getDefaultOpenAIClient<
+  TClient extends OpenAIClient = OpenAIClient,
+>(): TClient | undefined {
+  return _defaultOpenAIClient as TClient | undefined;
 }
 
 export function setDefaultOpenAIKey(key: string) {

--- a/packages/agents-openai/src/index.ts
+++ b/packages/agents-openai/src/index.ts
@@ -1,4 +1,5 @@
 export { OpenAIProvider, type OpenAIProviderOptions } from './openaiProvider';
+export type { OpenAIClient } from './openaiClient';
 export {
   withResponsesWebSocketSession,
   type ResponsesWebSocketSession,

--- a/packages/agents-openai/src/index.ts
+++ b/packages/agents-openai/src/index.ts
@@ -26,6 +26,7 @@ export type {
   OpenAIChatCompletionsRawModelStreamEvent,
 } from './rawModelEvents';
 export {
+  getDefaultOpenAIClient,
   setDefaultOpenAIClient,
   setOpenAIAPI,
   setOpenAIResponsesTransport,

--- a/packages/agents-openai/src/memory/openaiConversationsSession.ts
+++ b/packages/agents-openai/src/memory/openaiConversationsSession.ts
@@ -381,7 +381,7 @@ function resolveClient(options: OpenAIConversationsSessionOptions): OpenAI {
   }
 
   return (
-    getDefaultOpenAIClient() ??
+    (getDefaultOpenAIClient() as OpenAI | undefined) ??
     new OpenAI({
       apiKey: options.apiKey ?? getDefaultOpenAIKey(),
       baseURL: options.baseURL,

--- a/packages/agents-openai/src/memory/openaiConversationsSession.ts
+++ b/packages/agents-openai/src/memory/openaiConversationsSession.ts
@@ -9,10 +9,11 @@ import {
   OPENAI_SESSION_API,
   type OpenAISessionApiTagged,
 } from './openaiSessionApi';
+import type { OpenAIClient } from '../openaiClient';
 
 export type OpenAIConversationsSessionOptions = {
   conversationId?: string;
-  client?: OpenAI;
+  client?: OpenAIClient;
   apiKey?: string;
   baseURL?: string;
   organization?: string;
@@ -20,9 +21,9 @@ export type OpenAIConversationsSessionOptions = {
 };
 
 export async function startOpenAIConversationsSession(
-  client?: OpenAI,
+  client?: OpenAIClient,
 ): Promise<string> {
-  const resolvedClient = client ?? resolveClient({});
+  const resolvedClient = client ? (client as OpenAI) : resolveClient({});
   const response = await resolvedClient.conversations.create({ items: [] });
   return response.id;
 }
@@ -376,7 +377,7 @@ function isResponseOutputItemArray(
 
 function resolveClient(options: OpenAIConversationsSessionOptions): OpenAI {
   if (options.client) {
-    return options.client;
+    return options.client as OpenAI;
   }
 
   return (

--- a/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
+++ b/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
@@ -18,6 +18,7 @@ import {
   OPENAI_SESSION_API,
   type OpenAISessionApiTagged,
 } from './openaiSessionApi';
+import type { OpenAIClient } from '../openaiClient';
 
 const DEFAULT_COMPACTION_THRESHOLD = 10;
 const logger = getLogger('openai-agents:openai:compaction');
@@ -56,7 +57,7 @@ export type OpenAIResponsesCompactionSessionOptions = {
    * When omitted, the session will use `getDefaultOpenAIClient()` if configured. Otherwise it
    * creates a new `OpenAI()` instance via `new OpenAI()`.
    */
-  client?: OpenAI;
+  client?: OpenAIClient;
   /**
    * Session store that receives items and holds the compacted history.
    *
@@ -431,7 +432,7 @@ function resolveClient(
   options: OpenAIResponsesCompactionSessionOptions,
 ): OpenAI {
   if (options.client) {
-    return options.client;
+    return options.client as OpenAI;
   }
 
   const defaultClient = getDefaultOpenAIClient();

--- a/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
+++ b/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
@@ -437,7 +437,7 @@ function resolveClient(
 
   const defaultClient = getDefaultOpenAIClient();
   if (defaultClient) {
-    return defaultClient;
+    return defaultClient as OpenAI;
   }
 
   return new OpenAI();

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -37,6 +37,7 @@ import {
 import { protocol } from '@openai/agents-core';
 import { getOpenAIRetryAdvice } from './retryAdvice';
 import { normalizePromptCacheRetention } from './utils/modelSettings';
+import type { OpenAIClient } from './openaiClient';
 
 export const FAKE_ID = 'FAKE_ID';
 
@@ -77,11 +78,11 @@ export class OpenAIChatCompletionsModel implements Model {
   #hasWarnedUnsupportedConversationState = false;
 
   constructor(
-    client: OpenAI,
+    client: OpenAIClient,
     model: string,
     options: OpenAIChatCompletionsModelOptions = {},
   ) {
-    this.#client = client;
+    this.#client = client as OpenAI;
     this.#model = model;
     this.#strictFeatureValidation = options.strictFeatureValidation ?? false;
   }

--- a/packages/agents-openai/src/openaiClient.ts
+++ b/packages/agents-openai/src/openaiClient.ts
@@ -1,0 +1,11 @@
+/**
+ * An OpenAI client resolved through either the ESM or CommonJS declaration graph.
+ *
+ * The `openai` package publishes separate declarations for its `import` and
+ * `require` conditions. Because the client class has private members, TypeScript
+ * treats those declarations as nominally distinct even though they represent the
+ * same runtime client.
+ */
+export type OpenAIClient =
+  | import('openai/index.mjs').OpenAI
+  | import('openai').OpenAI;

--- a/packages/agents-openai/src/openaiProvider.ts
+++ b/packages/agents-openai/src/openaiProvider.ts
@@ -13,6 +13,7 @@ import {
   OpenAIResponsesWSModel,
 } from './openaiResponsesModel';
 import { OpenAIChatCompletionsModel } from './openaiChatCompletionsModel';
+import type { OpenAIClient } from './openaiClient';
 
 /**
  * Options for OpenAIProvider.
@@ -33,7 +34,7 @@ export type OpenAIProviderOptions = {
    */
   strictFeatureValidation?: boolean;
   responsesWebSocketOptions?: OpenAIResponsesWebSocketOptions;
-  openAIClient?: OpenAI;
+  openAIClient?: OpenAIClient;
 };
 
 /**
@@ -62,7 +63,7 @@ export class OpenAIProvider implements ModelProvider {
           'Cannot provide both websocketBaseURL and openAIClient',
         );
       }
-      this.#client = this.#options.openAIClient;
+      this.#client = this.#options.openAIClient as OpenAI;
     }
     this.#useResponses = this.#options.useResponses;
     this.#useResponsesWebSocket = this.#options.useResponsesWebSocket;

--- a/packages/agents-openai/src/openaiProvider.ts
+++ b/packages/agents-openai/src/openaiProvider.ts
@@ -81,7 +81,7 @@ export class OpenAIProvider implements ModelProvider {
     if (!this.#client) {
       this.#client =
         // this provider checks if there is the default client first,
-        getDefaultOpenAIClient() ??
+        (getDefaultOpenAIClient() as OpenAI | undefined) ??
         // and then manually creates a new one.
         new OpenAI({
           apiKey: this.#options.apiKey ?? getDefaultOpenAIKey(),

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -53,6 +53,7 @@ import {
   mergeQueryParamsIntoURL,
   splitResponsesTransportOverrides,
 } from './responsesTransportUtils';
+import type { OpenAIClient } from './openaiClient';
 import {
   CodeInterpreterStatus,
   FileSearchStatus,
@@ -2863,8 +2864,8 @@ export class OpenAIResponsesModel implements Model {
   protected readonly _client: OpenAI;
   protected readonly _model: string;
 
-  constructor(client: OpenAI, model: string) {
-    this._client = client;
+  constructor(client: OpenAIClient, model: string) {
+    this._client = client as OpenAI;
     this._model = model;
   }
 
@@ -3277,7 +3278,7 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
   #wsRequestLock: Promise<void> = Promise.resolve();
 
   constructor(
-    client: OpenAI,
+    client: OpenAIClient,
     model: string,
     options: OpenAIResponsesWSModelOptions = {},
   ) {


### PR DESCRIPTION
This pull request resolves #1432

It fixes TypeScript NodeNext ESM consumers being rejected when passing an `OpenAI` client to public SDK APIs. The SDK exposes an `OpenAIClient` union using standard package subpaths for the ESM and CommonJS declaration graphs, preserving compatibility with older TypeScript compilers.

The expanded type applies consistently across model constructors, provider configuration, default-client configuration, and OpenAI-backed sessions. A local-registry integration fixture verifies the published package with TypeScript 5.2.2 and 6.0.3.