### PR TITLE
fix(core): stop resending resolved tool results across consecutive streamed approvals

### DIFF
--- a/.changeset/tidy-approvals-resume.md
+++ b/.changeset/tidy-approvals-resume.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-core': patch
+---
+
+fix(core): stop resending resolved tool results across consecutive streamed approvals
+
+When a streamed run started with `previousResponseId` was resumed through more than one tool-approval interruption, the server conversation tracker re-primed each earlier approval's `function_call_output` on every resume. Because `previousResponseId` had already advanced past those calls, the follow-up request failed with `400 No tool call found for function call output with call_id ...`. `primeFromState` now marks tool results whose function call belongs to an already resolved response as sent, so only the latest turn's pending results are replayed.

--- a/packages/agents-core/src/runner/conversation.ts
+++ b/packages/agents-core/src/runner/conversation.ts
@@ -231,16 +231,33 @@ export class ServerConversationTracker {
     const hasResponses = modelResponses.length > 0;
 
     const serverItemKeys = new Set<string>();
+    // Every function call the server has emitted so far, and the subset that
+    // belongs to the most recent (still-pending) response. Results for calls
+    // from earlier responses were already delivered on a prior resume and must
+    // not be resent. We derive the pending set from the last response rather
+    // than gating on `responseId`, so a `conversationId`-managed turn whose
+    // response omits an id still keeps its own calls marked pending.
+    const serverFunctionCallIds = new Set<string>();
+    let pendingFunctionCallIds = new Set<string>();
     let latestResponseId: string | undefined;
     for (const response of modelResponses) {
-      if (response.responseId) {
-        latestResponseId = response.responseId;
-      }
+      const responseFunctionCallIds = new Set<string>();
       for (const item of response.output) {
         if (item && typeof item === 'object') {
           this.serverItems.add(item);
           serverItemKeys.add(getAgentInputItemKey(item as AgentInputItem));
+          if (
+            item.type === 'function_call' &&
+            typeof item.callId === 'string'
+          ) {
+            serverFunctionCallIds.add(item.callId);
+            responseFunctionCallIds.add(item.callId);
+          }
         }
+      }
+      pendingFunctionCallIds = responseFunctionCallIds;
+      if (response.responseId) {
+        latestResponseId = response.responseId;
       }
     }
 
@@ -268,6 +285,20 @@ export class ServerConversationTracker {
         }
         const rawItemKey = getAgentInputItemKey(rawItem as AgentInputItem);
         if (this.serverItems.has(rawItem) || serverItemKeys.has(rawItemKey)) {
+          this.sentItems.add(rawItem);
+          continue;
+        }
+        // A tool result whose function call came from an earlier (already
+        // resolved) response was submitted on a previous resume; the current
+        // `previousResponseId` no longer points at that call, so resending it
+        // fails with "No tool call found for function call output". Only the
+        // latest response's calls are still pending, so leave those unmarked.
+        if (
+          rawItem.type === 'function_call_result' &&
+          typeof rawItem.callId === 'string' &&
+          serverFunctionCallIds.has(rawItem.callId) &&
+          !pendingFunctionCallIds.has(rawItem.callId)
+        ) {
           this.sentItems.add(rawItem);
         }
       }

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -2493,6 +2493,196 @@ describe('Runner.run (streaming)', () => {
         callId: 'call-1',
       });
     });
+
+    it('only sends the newest approval result across consecutive interruptions with previousResponseId', async () => {
+      const approvalTool = tool({
+        name: 'test',
+        description: 'approval tool',
+        parameters: z.object({ test: z.string() }),
+        needsApproval: async () => true,
+        execute: async ({ test }) => `result:${test}`,
+      });
+
+      const model = new TrackingStreamingModel([
+        buildTurn([buildToolCall('call-1', 'foo')], 'resp-1'),
+        buildTurn([buildToolCall('call-2', 'bar')], 'resp-2'),
+        buildTurn([fakeModelMessage('done')], 'resp-3'),
+      ]);
+
+      const agent = new Agent({
+        name: 'StreamConsecutiveApproval',
+        model,
+        tools: [approvalTool],
+      });
+
+      const runner = new Runner();
+
+      let result = await runner.run(agent, 'user_message', {
+        stream: true,
+        previousResponseId: 'seed-response',
+      });
+      await drain(result);
+
+      expect(result.interruptions).toHaveLength(1);
+      result.state.approve(result.interruptions[0]);
+
+      result = await runner.run(agent, result.state, { stream: true });
+      await drain(result);
+
+      expect(result.interruptions).toHaveLength(1);
+      result.state.approve(result.interruptions[0]);
+
+      result = await runner.run(agent, result.state, { stream: true });
+      await drain(result);
+
+      expect(result.finalOutput).toBe('done');
+      expect(model.requests).toHaveLength(3);
+      expect(model.requests[0].previousResponseId).toBe('seed-response');
+
+      const secondInput = model.requests[1].input as AgentInputItem[];
+      expect(model.requests[1].previousResponseId).toBe('resp-1');
+      expect(secondInput).toHaveLength(1);
+      expect(secondInput[0]).toMatchObject({
+        type: 'function_call_result',
+        callId: 'call-1',
+      });
+
+      // The third request resumes after the second approval. previousResponseId
+      // now points at resp-2, so only call-2's result is still pending; resending
+      // call-1's result triggers "400 No tool call found for function call output".
+      const thirdInput = model.requests[2].input as AgentInputItem[];
+      expect(model.requests[2].previousResponseId).toBe('resp-2');
+      expect(
+        thirdInput.some(
+          (item) =>
+            item.type === 'function_call_result' && item.callId === 'call-1',
+        ),
+      ).toBe(false);
+      expect(thirdInput).toHaveLength(1);
+      expect(thirdInput[0]).toMatchObject({
+        type: 'function_call_result',
+        callId: 'call-2',
+      });
+    });
+
+    it('only sends the newest result across consecutive interruptions with conversationId', async () => {
+      const approvalTool = tool({
+        name: 'test',
+        description: 'approval tool',
+        parameters: z.object({ test: z.string() }),
+        needsApproval: async () => true,
+        execute: async ({ test }) => `result:${test}`,
+      });
+
+      const model = new TrackingStreamingModel([
+        buildTurn([buildToolCall('call-1', 'foo')], 'resp-1'),
+        buildTurn([buildToolCall('call-2', 'bar')], 'resp-2'),
+        buildTurn([fakeModelMessage('done')], 'resp-3'),
+      ]);
+
+      const agent = new Agent({
+        name: 'StreamConsecutiveApprovalConv',
+        model,
+        tools: [approvalTool],
+      });
+
+      const runner = new Runner();
+
+      let result = await runner.run(agent, 'user_message', {
+        stream: true,
+        conversationId: 'conv-consecutive',
+      });
+      await drain(result);
+      expect(result.interruptions).toHaveLength(1);
+      result.state.approve(result.interruptions[0]);
+
+      result = await runner.run(agent, result.state, {
+        stream: true,
+        conversationId: 'conv-consecutive',
+      });
+      await drain(result);
+      expect(result.interruptions).toHaveLength(1);
+      result.state.approve(result.interruptions[0]);
+
+      result = await runner.run(agent, result.state, {
+        stream: true,
+        conversationId: 'conv-consecutive',
+      });
+      await drain(result);
+
+      expect(result.finalOutput).toBe('done');
+      expect(model.requests).toHaveLength(3);
+
+      const thirdInput = model.requests[2].input as AgentInputItem[];
+      expect(
+        thirdInput.some(
+          (item) =>
+            item.type === 'function_call_result' && item.callId === 'call-1',
+        ),
+      ).toBe(false);
+      expect(thirdInput).toHaveLength(1);
+      expect(thirdInput[0]).toMatchObject({
+        type: 'function_call_result',
+        callId: 'call-2',
+      });
+    });
+
+    it('does not resend a resolved rejection across consecutive interruptions with previousResponseId', async () => {
+      const approvalTool = tool({
+        name: 'test',
+        description: 'approval tool',
+        parameters: z.object({ test: z.string() }),
+        needsApproval: async () => true,
+        execute: async ({ test }) => `result:${test}`,
+      });
+
+      const model = new TrackingStreamingModel([
+        buildTurn([buildToolCall('call-1', 'foo')], 'resp-1'),
+        buildTurn([buildToolCall('call-2', 'bar')], 'resp-2'),
+        buildTurn([fakeModelMessage('done')], 'resp-3'),
+      ]);
+
+      const agent = new Agent({
+        name: 'StreamConsecutiveReject',
+        model,
+        tools: [approvalTool],
+      });
+
+      const runner = new Runner();
+
+      let result = await runner.run(agent, 'user_message', {
+        stream: true,
+        previousResponseId: 'seed-response',
+      });
+      await drain(result);
+      expect(result.interruptions).toHaveLength(1);
+      result.state.reject(result.interruptions[0]);
+
+      result = await runner.run(agent, result.state, { stream: true });
+      await drain(result);
+      expect(result.interruptions).toHaveLength(1);
+      result.state.reject(result.interruptions[0]);
+
+      result = await runner.run(agent, result.state, { stream: true });
+      await drain(result);
+
+      expect(result.finalOutput).toBe('done');
+      expect(model.requests).toHaveLength(3);
+
+      const thirdInput = model.requests[2].input as AgentInputItem[];
+      expect(model.requests[2].previousResponseId).toBe('resp-2');
+      expect(
+        thirdInput.some(
+          (item) =>
+            item.type === 'function_call_result' && item.callId === 'call-1',
+        ),
+      ).toBe(false);
+      expect(thirdInput).toHaveLength(1);
+      expect(thirdInput[0]).toMatchObject({
+        type: 'function_call_result',
+        callId: 'call-2',
+      });
+    });
   });
 
   it('persists streaming input only after the run completes successfully', async () => {


### PR DESCRIPTION
## Summary
- Fixes #1435: a streamed run started with `previousResponseId` fails with `400 No tool call found for function call output with call_id ...` once it is resumed through more than one tool-approval interruption.
- Root cause: on each resume `ServerConversationTracker.primeFromState` rebuilds its "already sent" set from the model responses, but it only marked server-emitted items as sent. A client-generated `function_call_output` from an earlier approval was never marked, so it was replayed on every subsequent turn. By then `previousResponseId` had advanced past that call, so re-submitting its output was rejected.
- `primeFromState` now marks a tool result as sent when its `function_call` belongs to an already-resolved (non-latest) response. Only the most recent response's calls stay pending, so a resume sends just the delta. The pending set is derived from the last response regardless of whether it carries a `responseId`, so `conversationId`-managed turns behave the same.

## Tests
- `pnpm exec vitest run packages/agents-core/test/run.stream.test.ts` (adds coverage for consecutive approvals with `previousResponseId`, the `conversationId` variant, and consecutive rejections)
- `pnpm -F @openai/agents-core build-check`
- `pnpm -F @openai/agents-core exec eslint src/runner/conversation.ts`

<!-- oss-radar:idempotency=auto-20260701-201240.w3.openai_openai-agents-js.1435 -->
