### PR TITLE
test: tighten Twilio transport test fakes

### DIFF
--- a/.changeset/tidy-twilio-test-fakes.md
+++ b/.changeset/tidy-twilio-test-fakes.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+test: tighten Twilio transport test fakes

--- a/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
+++ b/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
@@ -3,7 +3,10 @@ import { EventEmitter } from 'events';
 import { TwilioRealtimeTransportLayer } from '../src/TwilioRealtimeTransport';
 import { allowConsole } from '../../../helpers/tests/console-guard';
 
-import type { MessageEvent as NodeMessageEvent } from 'ws';
+import type {
+  MessageEvent as NodeMessageEvent,
+  WebSocket as NodeWebSocket,
+} from 'ws';
 import type { MessageEvent } from 'undici-types';
 
 vi.mock('@openai/agents/realtime', () => {
@@ -34,14 +37,28 @@ vi.mock('@openai/agents/realtime', () => {
 class FakeTwilioWebSocket extends EventEmitter {
   send = vi.fn();
   close = vi.fn();
+
+  addEventListener(
+    type: string,
+    listener: (evt: MessageEvent | NodeMessageEvent) => void,
+  ) {
+    this.on(type, (evt) => listener(type === 'message' ? { data: evt } : evt));
+  }
 }
 
-// @ts-expect-error - we're making the node event emitter compatible with the browser event emitter
-FakeTwilioWebSocket.prototype.addEventListener = function (
-  type: string,
-  listener: (evt: MessageEvent | NodeMessageEvent) => void,
-) {
-  this.on(type, (evt) => listener(type === 'message' ? { data: evt } : evt));
+const asTwilioWebSocket = (
+  socket: FakeTwilioWebSocket,
+): WebSocket | NodeWebSocket => socket as unknown as WebSocket | NodeWebSocket;
+
+const setCurrentItemId = (
+  transport: TwilioRealtimeTransportLayer,
+  currentItemId: string,
+): void => {
+  (
+    transport as unknown as {
+      currentItemId: string;
+    }
+  ).currentItemId = currentItemId;
 };
 
 const base64 = (data: string) => Buffer.from(data).toString('base64');
@@ -53,7 +70,7 @@ describe('TwilioRealtimeTransportLayer', () => {
 
   test('_setInputAndOutputAudioFormat defaults g711', () => {
     const transport = new TwilioRealtimeTransportLayer({
-      twilioWebSocket: new FakeTwilioWebSocket() as any,
+      twilioWebSocket: asTwilioWebSocket(new FakeTwilioWebSocket()),
     });
     expect(transport._setInputAndOutputAudioFormat()).toEqual({
       inputAudioFormat: 'g711_ulaw',
@@ -66,7 +83,7 @@ describe('TwilioRealtimeTransportLayer', () => {
 
   test('_setInputAndOutputAudioFormat preserves nested audio config', () => {
     const transport = new TwilioRealtimeTransportLayer({
-      twilioWebSocket: new FakeTwilioWebSocket() as any,
+      twilioWebSocket: asTwilioWebSocket(new FakeTwilioWebSocket()),
     });
 
     expect(
@@ -107,7 +124,7 @@ describe('TwilioRealtimeTransportLayer', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const twilio = new FakeTwilioWebSocket();
     const transport = new TwilioRealtimeTransportLayer({
-      twilioWebSocket: twilio as any,
+      twilioWebSocket: asTwilioWebSocket(twilio),
     });
     await transport.connect({ apiKey: 'ek_test' } as any);
     const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
@@ -158,29 +175,26 @@ describe('TwilioRealtimeTransportLayer', () => {
   test('_onAudio resets chunk count and emits', async () => {
     const twilio = new FakeTwilioWebSocket();
     const transport = new TwilioRealtimeTransportLayer({
-      twilioWebSocket: twilio as any,
+      twilioWebSocket: asTwilioWebSocket(twilio),
     });
     await transport.connect({ apiKey: 'ek_test' } as any);
     const sendSpy = vi.mocked(twilio.send);
     const audioListener = vi.fn();
     transport.on('audio', audioListener);
 
-    // @ts-expect-error - we're testing protected readonly fields
-    transport.currentItemId = 'a';
+    setCurrentItemId(transport, 'a');
     transport['_onAudio']({
       responseId: 'FAKE_ID',
       type: 'audio',
       data: new Uint8Array(8).buffer,
     });
-    // @ts-expect-error - we're testing protected readonly fields
-    transport.currentItemId = 'a';
+    setCurrentItemId(transport, 'a');
     transport['_onAudio']({
       responseId: 'FAKE_ID',
       type: 'audio',
       data: new Uint8Array(16).buffer,
     });
-    // @ts-expect-error - we're testing protected readonly fields
-    transport.currentItemId = 'b';
+    setCurrentItemId(transport, 'b');
     transport['_onAudio']({
       responseId: 'FAKE_ID',
       type: 'audio',
@@ -199,7 +213,7 @@ describe('TwilioRealtimeTransportLayer', () => {
   test('connect preserves nested audio config while defaulting Twilio formats', async () => {
     const twilio = new FakeTwilioWebSocket();
     const transport = new TwilioRealtimeTransportLayer({
-      twilioWebSocket: twilio as any,
+      twilioWebSocket: asTwilioWebSocket(twilio),
     });
     const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
     const connectSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.connect);
@@ -244,7 +258,7 @@ describe('TwilioRealtimeTransportLayer', () => {
   test('updateSessionConfig keeps audio format', async () => {
     const twilio = new FakeTwilioWebSocket();
     const transport = new TwilioRealtimeTransportLayer({
-      twilioWebSocket: twilio as any,
+      twilioWebSocket: asTwilioWebSocket(twilio),
     });
     await transport.connect({ apiKey: 'ek_test' } as any);
     const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
@@ -288,7 +302,7 @@ describe('TwilioRealtimeTransportLayer', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const twilio = new FakeTwilioWebSocket();
     const transport = new TwilioRealtimeTransportLayer({
-      twilioWebSocket: twilio as any,
+      twilioWebSocket: asTwilioWebSocket(twilio),
     });
     await transport.connect({ apiKey: 'ek_test' } as any);
     const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
@@ -331,7 +345,7 @@ describe('TwilioRealtimeTransportLayer', () => {
   test('resets chunk count on done marks before interrupting', async () => {
     const twilio = new FakeTwilioWebSocket();
     const transport = new TwilioRealtimeTransportLayer({
-      twilioWebSocket: twilio as any,
+      twilioWebSocket: asTwilioWebSocket(twilio),
     });
     await transport.connect({ apiKey: 'ek_test' } as any);
     const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');

--- a/packages/agents-extensions/test/index.test.ts
+++ b/packages/agents-extensions/test/index.test.ts
@@ -1,7 +1,10 @@
 import { describe, test, expect, vi } from 'vitest';
 import { EventEmitter } from 'events';
 import { TwilioRealtimeTransportLayer } from '../src';
-import type { MessageEvent as NodeMessageEvent } from 'ws';
+import type {
+  MessageEvent as NodeMessageEvent,
+  WebSocket as NodeWebSocket,
+} from 'ws';
 
 vi.mock('ws', () => {
   class FakeWebSocket {
@@ -29,20 +32,34 @@ vi.mock('ws', () => {
 class FakeTwilioWebSocket extends EventEmitter {
   send = vi.fn();
   close = vi.fn();
+
+  addEventListener(
+    type: string,
+    listener: (evt: MessageEvent | NodeMessageEvent) => void,
+  ) {
+    this.on(type, (evt) => listener(type === 'message' ? { data: evt } : evt));
+  }
 }
 
-// @ts-expect-error - we're making the node event emitter compatible with the browser event emitter
-FakeTwilioWebSocket.prototype.addEventListener = function (
-  type: string,
-  listener: (evt: MessageEvent | NodeMessageEvent) => void,
-) {
-  this.on(type, (evt) => listener(type === 'message' ? { data: evt } : evt));
+const asTwilioWebSocket = (
+  socket: FakeTwilioWebSocket,
+): WebSocket | NodeWebSocket => socket as unknown as WebSocket | NodeWebSocket;
+
+const setAudioLengthMs = (
+  transport: TwilioRealtimeTransportLayer,
+  audioLengthMs: number,
+): void => {
+  (
+    transport as unknown as {
+      _audioLengthMs: number;
+    }
+  )._audioLengthMs = audioLengthMs;
 };
 
 describe('TwilioRealtimeTransportLayer', () => {
   test('should be available', () => {
     const transport = new TwilioRealtimeTransportLayer({
-      twilioWebSocket: {} as any,
+      twilioWebSocket: asTwilioWebSocket(new FakeTwilioWebSocket()),
     });
     expect(transport).toBeDefined();
   });
@@ -50,7 +67,7 @@ describe('TwilioRealtimeTransportLayer', () => {
   test('malformed mark name does not produce NaN', async () => {
     const twilio = new FakeTwilioWebSocket();
     const transport = new TwilioRealtimeTransportLayer({
-      twilioWebSocket: twilio as any,
+      twilioWebSocket: asTwilioWebSocket(twilio),
     });
 
     const sendEventSpy = vi.spyOn(
@@ -65,8 +82,7 @@ describe('TwilioRealtimeTransportLayer', () => {
     twilio.emit('message', { toString: () => JSON.stringify(payload) });
 
     transport._interrupt(0, false);
-    // @ts-expect-error - we're testing protected fields
-    transport._audioLengthMs = 500;
+    setAudioLengthMs(transport, 500);
     transport._interrupt(0, true);
 
     const call = sendEventSpy.mock.calls
@@ -78,7 +94,7 @@ describe('TwilioRealtimeTransportLayer', () => {
   test('interrupt clamps overshoot and emits integer audio_end_ms', async () => {
     const twilio = new FakeTwilioWebSocket();
     const transport = new TwilioRealtimeTransportLayer({
-      twilioWebSocket: twilio as any,
+      twilioWebSocket: asTwilioWebSocket(twilio),
     });
 
     const sendEventSpy = vi.spyOn(
@@ -92,8 +108,7 @@ describe('TwilioRealtimeTransportLayer', () => {
     });
     sendEventSpy.mockClear();
 
-    // @ts-expect-error - we're testing protected fields.
-    transport._audioLengthMs = 20;
+    setAudioLengthMs(transport, 20);
     transport._interrupt(0, true);
 
     const call = sendEventSpy.mock.calls


### PR DESCRIPTION
This pull request improves Twilio transport test typing by moving fake WebSocket compatibility into the fake class itself and replacing scattered protected-field suppressions with small test helpers.

It also includes the existing documentation cleanups already on the local branch: documenting missing example run commands and fixing a docs typo. A patch changeset is included for `@openai/agents-extensions` to satisfy package-change validation for the test updates.