### PR TITLE
chore: correct explicit model flag spelling

### DIFF
--- a/.changeset/correct-explicit-model-flag-spelling.md
+++ b/.changeset/correct-explicit-model-flag-spelling.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+chore: correct explicit model flag spelling

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -694,10 +694,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     agent: Agent<TContext, AgentOutputType>,
   ): Promise<{
     model: Model;
-    explictlyModelSet: boolean;
+    explicitlyModelSet: boolean;
     resolvedModelName?: string;
   }> {
-    const explictlyModelSet =
+    const explicitlyModelSet =
       (agent.model !== undefined &&
         agent.model !== Agent.DEFAULT_MODEL_PLACEHOLDER) ||
       (this.config.model !== undefined &&
@@ -709,7 +709,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       typeof selectedModel === 'string'
         ? await this.config.modelProvider.getModel(selectedModel)
         : selectedModel;
-    return { model: resolvedModel, explictlyModelSet, resolvedModelName };
+    return { model: resolvedModel, explicitlyModelSet, resolvedModelName };
   }
 
   async #resolveSandboxRuntimeModelForAgent<TContext>(
@@ -964,7 +964,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 systemInstructions: preparedCall.modelInput.instructions,
                 prompt: preparedCall.prompt,
                 // Explicit agent/run config models should take precedence over prompt defaults.
-                ...(preparedCall.explictlyModelSet
+                ...(preparedCall.explicitlyModelSet
                   ? { overridePromptModel: true }
                   : {}),
                 input: preparedCall.modelInput.input,
@@ -1379,7 +1379,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 {
                   systemInstructions: preparedCall.modelInput.instructions,
                   prompt: preparedCall.prompt,
-                  ...(preparedCall.explictlyModelSet
+                  ...(preparedCall.explicitlyModelSet
                     ? { overridePromptModel: true }
                     : {}),
                   input: reconciliationInput,
@@ -1432,7 +1432,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 systemInstructions: preparedCall.modelInput.instructions,
                 prompt: preparedCall.prompt,
                 // Streaming requests should also honor explicitly chosen models.
-                ...(preparedCall.explictlyModelSet
+                ...(preparedCall.explicitlyModelSet
                   ? { overridePromptModel: true }
                   : {}),
                 input: preparedCall.modelInput.input,
@@ -1815,7 +1815,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       filteredItems?: AgentInputItem[],
     ) => void,
   ): Promise<PreparedModelCall<TContext>> {
-    const { model, explictlyModelSet, resolvedModelName } =
+    const { model, explicitlyModelSet, resolvedModelName } =
       await this.#resolveModelForAgent(executionAgent);
 
     const hasExplicitAgentModelSettings =
@@ -1826,7 +1826,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     const implicitModelSettings = hasExplicitAgentModelSettings
       ? undefined
       : getImplicitModelSettingsForResolvedModel(
-          explictlyModelSet,
+          explicitlyModelSet,
           resolvedModelName,
         );
 
@@ -1836,7 +1836,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     );
     modelSettings = mergeModelSettings(modelSettings, agentModelSettings);
     modelSettings = adjustModelSettingsForNonGPT5RunnerModel(
-      explictlyModelSet,
+      explicitlyModelSet,
       agentModelSettings ?? implicitModelSettings ?? {},
       model,
       modelSettings,
@@ -1880,7 +1880,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     return {
       ...artifacts,
       model,
-      explictlyModelSet,
+      explicitlyModelSet,
       modelSettings,
       modelInput,
       prompt,

--- a/packages/agents-core/src/runner/modelSettings.ts
+++ b/packages/agents-core/src/runner/modelSettings.ts
@@ -64,7 +64,7 @@ export function maybeResetToolChoice(
  * are incompatible and should be stripped to avoid runtime errors.
  */
 export function adjustModelSettingsForNonGPT5RunnerModel(
-  explictlyModelSet: boolean,
+  explicitlyModelSet: boolean,
   agentModelSettings: ModelSettings,
   runnerModel: string | Model,
   modelSettings: ModelSettings,
@@ -86,7 +86,7 @@ export function adjustModelSettingsForNonGPT5RunnerModel(
 
   if (
     isGpt5Default() &&
-    explictlyModelSet &&
+    explicitlyModelSet &&
     isNonGpt5RunnerModel &&
     hasGpt5Defaults
   ) {

--- a/packages/agents-core/src/runner/types.ts
+++ b/packages/agents-core/src/runner/types.ts
@@ -78,7 +78,7 @@ export type AgentArtifacts<TContext = UnknownContext> = {
 export type PreparedModelCall<TContext = UnknownContext> =
   AgentArtifacts<TContext> & {
     model: Model;
-    explictlyModelSet: boolean;
+    explicitlyModelSet: boolean;
     modelSettings: ModelSettings;
     modelInput: ModelInputData;
     prompt?: Prompt;


### PR DESCRIPTION
This pull request updates an internal `agents-core` runner flag name from `explictlyModelSet` to `explicitlyModelSet` across the model-call preparation path. The change is a behavior-preserving source cleanup that makes the existing explicit-model precedence logic easier to read, and includes the required patch changeset for `@openai/agents-core`.
