### PR TITLE
fix: map workspace package aliases in Vitest

### DIFF
--- a/.changeset/bright-walls-heal.md
+++ b/.changeset/bright-walls-heal.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: map Vitest aliases for agents-extensions public subpaths

--- a/packages/agents-extensions/test/vitest-aliases.test.ts
+++ b/packages/agents-extensions/test/vitest-aliases.test.ts
@@ -1,0 +1,47 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const packageJson = JSON.parse(
+  readFileSync(
+    resolve(rootDir, 'packages/agents-extensions/package.json'),
+    'utf8',
+  ),
+) as {
+  exports: Record<string, unknown>;
+};
+const vitestConfig = readFileSync(resolve(rootDir, 'vitest.config.ts'), 'utf8');
+
+describe('Vitest workspace package aliases', () => {
+  it('maps agents-extensions public subpaths before the package root alias', () => {
+    const rootAlias = '@openai/agents-extensions';
+    const rootAliasIndex = vitestConfig.indexOf(`'${rootAlias}': resolve(`);
+
+    expect(rootAliasIndex).toBeGreaterThanOrEqual(0);
+
+    for (const exportPath of Object.keys(packageJson.exports)) {
+      if (exportPath === '.') {
+        continue;
+      }
+
+      const subpath = exportPath.replace(/^\.\//u, '');
+      const aliasName = `${rootAlias}/${subpath}`;
+      const expectedSource = resolve(
+        rootDir,
+        'packages/agents-extensions/src',
+        subpath,
+        'index.ts',
+      );
+      const aliasIndex = vitestConfig.indexOf(`'${aliasName}': resolve(`);
+
+      expect(aliasIndex).toBeGreaterThanOrEqual(0);
+      expect(aliasIndex).toBeLessThan(rootAliasIndex);
+      expect(vitestConfig).toContain(
+        `'packages/agents-extensions/src/${subpath}/index.ts'`,
+      );
+      expect(existsSync(expectedSource)).toBe(true);
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from 'vitest/config';
 
 const rootDir = dirname(fileURLToPath(import.meta.url));
 const packagesDir = resolve(rootDir, 'packages');
-const testAliases = {
+export const testAliases = {
   '@openai/agents-core/_shims': resolve(
     rootDir,
     'packages/agents-core/src/shims/shims-node.ts',
@@ -74,6 +74,46 @@ const testAliases = {
   '@openai/agents-realtime': resolve(
     rootDir,
     'packages/agents-realtime/src/index.ts',
+  ),
+  '@openai/agents-extensions/ai-sdk': resolve(
+    rootDir,
+    'packages/agents-extensions/src/ai-sdk/index.ts',
+  ),
+  '@openai/agents-extensions/ai-sdk-ui': resolve(
+    rootDir,
+    'packages/agents-extensions/src/ai-sdk-ui/index.ts',
+  ),
+  '@openai/agents-extensions/sandbox/blaxel': resolve(
+    rootDir,
+    'packages/agents-extensions/src/sandbox/blaxel/index.ts',
+  ),
+  '@openai/agents-extensions/sandbox/cloudflare': resolve(
+    rootDir,
+    'packages/agents-extensions/src/sandbox/cloudflare/index.ts',
+  ),
+  '@openai/agents-extensions/sandbox/daytona': resolve(
+    rootDir,
+    'packages/agents-extensions/src/sandbox/daytona/index.ts',
+  ),
+  '@openai/agents-extensions/sandbox/e2b': resolve(
+    rootDir,
+    'packages/agents-extensions/src/sandbox/e2b/index.ts',
+  ),
+  '@openai/agents-extensions/sandbox/modal': resolve(
+    rootDir,
+    'packages/agents-extensions/src/sandbox/modal/index.ts',
+  ),
+  '@openai/agents-extensions/sandbox/runloop': resolve(
+    rootDir,
+    'packages/agents-extensions/src/sandbox/runloop/index.ts',
+  ),
+  '@openai/agents-extensions/sandbox/vercel': resolve(
+    rootDir,
+    'packages/agents-extensions/src/sandbox/vercel/index.ts',
+  ),
+  '@openai/agents-extensions/experimental/codex': resolve(
+    rootDir,
+    'packages/agents-extensions/src/experimental/codex/index.ts',
   ),
   '@openai/agents-extensions': resolve(
     rootDir,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,9 +6,29 @@ import { defineConfig } from 'vitest/config';
 const rootDir = dirname(fileURLToPath(import.meta.url));
 const packagesDir = resolve(rootDir, 'packages');
 const testAliases = {
+  '@openai/agents-core/_shims': resolve(
+    rootDir,
+    'packages/agents-core/src/shims/shims-node.ts',
+  ),
+  '@openai/agents-realtime/_shims': resolve(
+    rootDir,
+    'packages/agents-realtime/src/shims/shims-node.ts',
+  ),
+  '@openai/agents-core/model': resolve(
+    rootDir,
+    'packages/agents-core/src/model.ts',
+  ),
   '@openai/agents-core/utils/internal': resolve(
     rootDir,
     'packages/agents-core/src/utils/internal.ts',
+  ),
+  '@openai/agents-core/utils': resolve(
+    rootDir,
+    'packages/agents-core/src/utils/index.ts',
+  ),
+  '@openai/agents-core/extensions': resolve(
+    rootDir,
+    'packages/agents-core/src/extensions/index.ts',
   ),
   '@openai/agents-core/sandbox/local': resolve(
     rootDir,
@@ -26,6 +46,40 @@ const testAliases = {
     rootDir,
     'packages/agents-core/src/sandbox/index.ts',
   ),
+  '@openai/agents-core/types': resolve(
+    rootDir,
+    'packages/agents-core/src/types/index.ts',
+  ),
+  '@openai/agents/sandbox/local': resolve(
+    rootDir,
+    'packages/agents/src/sandbox/local.ts',
+  ),
+  '@openai/agents/sandbox': resolve(
+    rootDir,
+    'packages/agents/src/sandbox/index.ts',
+  ),
+  '@openai/agents/realtime': resolve(
+    rootDir,
+    'packages/agents/src/realtime/index.ts',
+  ),
+  '@openai/agents/utils': resolve(
+    rootDir,
+    'packages/agents/src/utils/index.ts',
+  ),
+  '@openai/agents-core': resolve(rootDir, 'packages/agents-core/src/index.ts'),
+  '@openai/agents-openai': resolve(
+    rootDir,
+    'packages/agents-openai/src/index.ts',
+  ),
+  '@openai/agents-realtime': resolve(
+    rootDir,
+    'packages/agents-realtime/src/index.ts',
+  ),
+  '@openai/agents-extensions': resolve(
+    rootDir,
+    'packages/agents-extensions/src/index.ts',
+  ),
+  '@openai/agents': resolve(rootDir, 'packages/agents/src/index.ts'),
 };
 
 const baseTestConfig = {


### PR DESCRIPTION
## Summary
- Map Vitest workspace package imports to source entrypoints for package roots and public subpaths.
- Cover shim exports such as @openai/agents-core/_shims so tests do not depend on prebuilt dist package exports.

## Validation
- Reproduced before the fix: pnpm exec vitest --run --project @openai/agents-extensions test/ai-sdk/index.test.ts --reporter=verbose failed during collection on @openai/agents-core/_shims.
- pnpm exec vitest --run --project @openai/agents-extensions test/ai-sdk/index.test.ts
- pnpm -F @openai/agents-extensions build-check
- pnpm run build:ci
- pnpm lint
- pnpm format:changed --check
- git diff --check

Note: pnpm exec vitest --run --project @openai/agents-extensions now gets past collection and runs the project suite on Windows; it reports 674 passing tests and 5 existing Windows path expectation failures in test/sandbox/shared.test.ts.