### PR TITLE
feat: add invalid final output recovery handler

### DIFF
--- a/.changeset/safe-final-output-fallback.md
+++ b/.changeset/safe-final-output-fallback.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+feat: add invalid final output recovery handler

--- a/packages/agents-core/src/runner/errorHandlers.ts
+++ b/packages/agents-core/src/runner/errorHandlers.ts
@@ -1,5 +1,10 @@
 import { Agent, AgentOutputType } from '../agent';
-import { MaxTurnsExceededError, ModelRefusalError } from '../errors';
+import {
+  MaxTurnsExceededError,
+  ModelBehaviorError,
+  ModelRefusalError,
+  UserError,
+} from '../errors';
 import { assistant } from '../helpers/message';
 import { RunItem, RunMessageOutputItem } from '../items';
 import { ModelResponse } from '../model';
@@ -22,7 +27,7 @@ import { streamStepItemsToRunResult } from './streaming';
 /**
  * Error kinds supported by run error handlers.
  */
-export type RunErrorKind = 'maxTurns' | 'modelRefusal';
+export type RunErrorKind = 'maxTurns' | 'modelRefusal' | 'invalidFinalOutput';
 
 /**
  * Snapshot of run data passed to error handlers.
@@ -38,7 +43,7 @@ export type RunErrorData<TContext, TAgent extends Agent<any, any>> = {
 };
 
 export type RunErrorHandlerInput<TContext, TAgent extends Agent<any, any>> = {
-  error: MaxTurnsExceededError | ModelRefusalError;
+  error: MaxTurnsExceededError | ModelRefusalError | ModelBehaviorError;
   context: RunContext<TContext>;
   runData: RunErrorData<TContext, TAgent>;
 };
@@ -89,6 +94,7 @@ type TryHandleRunErrorArgs<TContext, TAgent extends Agent<any, any>> = {
 
 type ResolveRunErrorHandlerArgs<TContext, TAgent extends Agent<any, any>> = {
   error: unknown;
+  errorKind?: RunErrorKind;
   errorHandlers?: RunErrorHandlers<TContext, TAgent>;
   context: RunContext<TContext>;
   runData: RunErrorData<TContext, TAgent>;
@@ -126,35 +132,66 @@ const createFinalOutputItem = <TAgent extends Agent<any, any>>(
 ): RunMessageOutputItem =>
   new RunMessageOutputItem(assistant(outputText), agent);
 
+function validateRunErrorFinalOutput<TAgent extends Agent<any, any>>(
+  agent: TAgent,
+  outputText: string,
+): void {
+  try {
+    agent.processFinalOutput(outputText);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new UserError(`Invalid run error handler finalOutput: ${message}`);
+  }
+}
+
 export const formatRunErrorFinalOutput = formatFinalOutput;
 export const createRunErrorFinalOutputItem = createFinalOutputItem;
+export const validateRunErrorHandlerFinalOutput = validateRunErrorFinalOutput;
 
 export const resolveRunErrorHandler = async <
   TContext,
   TAgent extends Agent<any, any>,
 >({
   error,
+  errorKind,
   errorHandlers,
   context,
   runData,
 }: ResolveRunErrorHandlerArgs<TContext, TAgent>): Promise<
   RunErrorHandlerResult<TAgent> | undefined
 > => {
-  let handler: RunErrorHandler<TContext, TAgent> | undefined;
-  if (error instanceof MaxTurnsExceededError) {
-    handler = errorHandlers?.maxTurns ?? errorHandlers?.default;
-  } else if (error instanceof ModelRefusalError) {
-    handler = errorHandlers?.modelRefusal ?? errorHandlers?.default;
-  } else {
+  const kind =
+    errorKind ??
+    (error instanceof MaxTurnsExceededError
+      ? 'maxTurns'
+      : error instanceof ModelRefusalError
+        ? 'modelRefusal'
+        : undefined);
+
+  if (!kind) {
     return undefined;
   }
 
+  const typedError =
+    kind === 'maxTurns' && error instanceof MaxTurnsExceededError
+      ? error
+      : kind === 'modelRefusal' && error instanceof ModelRefusalError
+        ? error
+        : kind === 'invalidFinalOutput' && error instanceof ModelBehaviorError
+          ? error
+          : undefined;
+
+  if (!typedError) {
+    return undefined;
+  }
+
+  const handler = errorHandlers?.[kind] ?? errorHandlers?.default;
   if (!handler) {
     return undefined;
   }
 
   const handlerResult = await handler({
-    error,
+    error: typedError,
     context,
     runData,
   });
@@ -188,6 +225,7 @@ export const tryHandleRunError = async <
     state._currentAgent,
     handlerResult.finalOutput,
   );
+  validateRunErrorFinalOutput(state._currentAgent, outputText);
   state._lastTurnResponse = undefined;
   state._lastProcessedResponse = undefined;
   const item = createFinalOutputItem(state._currentAgent, outputText);

--- a/packages/agents-core/src/runner/runLoop.ts
+++ b/packages/agents-core/src/runner/runLoop.ts
@@ -52,7 +52,7 @@ export function applyTurnResult<
   state._currentStep = turnResult.nextStep;
   state._finalOutputSource =
     turnResult.nextStep.type === 'next_step_final_output'
-      ? 'turn_resolution'
+      ? (turnResult.finalOutputSource ?? 'turn_resolution')
       : undefined;
 }
 

--- a/packages/agents-core/src/runner/steps.ts
+++ b/packages/agents-core/src/runner/steps.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { ModelResponse } from '../model';
 import { RunItem } from '../items';
 import { AgentInputItem } from '../types';
+import type { FinalOutputSource } from '../runState';
 
 export const nextStepSchema = z.discriminatedUnion('type', [
   z.object({
@@ -30,6 +31,7 @@ export class SingleStepResult {
     public preStepItems: RunItem[],
     public newStepItems: RunItem[],
     public nextStep: NextStep,
+    public finalOutputSource?: FinalOutputSource,
   ) {}
 
   get generatedItems(): RunItem[] {

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -1150,6 +1150,7 @@ export async function resolveTurnAfterModelResponse<
         preStepItems,
         newItems,
         { type: 'next_step_final_output', output: outputText },
+        'error_handler',
       );
     }
   }
@@ -1176,6 +1177,7 @@ export async function resolveTurnAfterModelResponse<
           preStepItems,
           newItems,
           { type: 'next_step_final_output', output: handledOutput },
+          'error_handler',
         );
       }
     }
@@ -1236,6 +1238,7 @@ export async function resolveTurnAfterModelResponse<
           preStepItems,
           newItems,
           { type: 'next_step_final_output', output: handledOutput },
+          'error_handler',
         );
       }
 

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -1155,9 +1155,15 @@ export async function resolveTurnAfterModelResponse<
     }
   }
 
-  // if there is no output we just run again
-  if (typeof potentialFinalOutput === 'undefined') {
-    if (!hasPendingToolsOrApprovals && agent.outputType !== 'text') {
+  const isMissingStructuredFinalOutput =
+    agent.outputType !== 'text' && !potentialFinalOutput;
+
+  // Recover missing structured output when configured; otherwise run again.
+  if (
+    typeof potentialFinalOutput === 'undefined' ||
+    isMissingStructuredFinalOutput
+  ) {
+    if (!hasPendingToolsOrApprovals && isMissingStructuredFinalOutput) {
       const outputError = new ModelBehaviorError(
         'Model returned no final output for the structured output type.',
       );

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -47,6 +47,7 @@ import {
   createRunErrorFinalOutputItem,
   formatRunErrorFinalOutput,
   resolveRunErrorHandler,
+  validateRunErrorHandlerFinalOutput,
 } from './errorHandlers';
 import { getTurnInput } from './items';
 
@@ -547,6 +548,69 @@ function formatFinalOutputTypeError(error: unknown): string {
   }
 
   return 'Invalid output type: final assistant output did not match the expected schema.';
+}
+
+function buildTurnRunErrorData<TContext, TAgent extends Agent<TContext, any>>(
+  state: RunState<TContext, TAgent>,
+  agent: TAgent,
+  originalInput: string | AgentInputItem[],
+  preStepItems: RunItem[],
+  newItems: RunItem[],
+): RunErrorData<TContext, TAgent> {
+  const generatedItems = preStepItems.concat(newItems);
+  return {
+    input: originalInput,
+    newItems: generatedItems,
+    history: getTurnInput(
+      originalInput,
+      generatedItems,
+      state._reasoningItemIdPolicy,
+    ),
+    output: getTurnInput([], generatedItems, state._reasoningItemIdPolicy),
+    rawResponses: state._modelResponses,
+    lastAgent: agent,
+    state,
+  };
+}
+
+async function resolveInvalidFinalOutput<
+  TContext,
+  TAgent extends Agent<TContext, any>,
+>(args: {
+  error: ModelBehaviorError;
+  errorHandlers?: RunErrorHandlers<TContext, TAgent>;
+  agent: TAgent;
+  originalInput: string | AgentInputItem[];
+  preStepItems: RunItem[];
+  newItems: RunItem[];
+  state: RunState<TContext, TAgent>;
+}): Promise<string | undefined> {
+  const handlerResult = await resolveRunErrorHandler({
+    error: args.error,
+    errorKind: 'invalidFinalOutput',
+    errorHandlers: args.errorHandlers,
+    context: args.state._context,
+    runData: buildTurnRunErrorData(
+      args.state,
+      args.agent,
+      args.originalInput,
+      args.preStepItems,
+      args.newItems,
+    ),
+  });
+  if (!handlerResult) {
+    return undefined;
+  }
+
+  const outputText = formatRunErrorFinalOutput(
+    args.agent,
+    handlerResult.finalOutput,
+  );
+  validateRunErrorHandlerFinalOutput(args.agent, outputText);
+  if (handlerResult.includeInHistory !== false) {
+    args.newItems.push(createRunErrorFinalOutputItem(args.agent, outputText));
+  }
+  return outputText;
 }
 
 /**
@@ -1056,25 +1120,17 @@ export async function resolveTurnAfterModelResponse<
     );
     if (refusal && typeof potentialFinalOutput === 'undefined') {
       const refusalError = new ModelRefusalError(refusal, state);
-      const generatedItems = preStepItems.concat(newItems);
-      const runData: RunErrorData<TContext, TAgent> = {
-        input: originalInput,
-        newItems: generatedItems,
-        history: getTurnInput(
-          originalInput,
-          generatedItems,
-          state._reasoningItemIdPolicy,
-        ),
-        output: getTurnInput([], generatedItems, state._reasoningItemIdPolicy),
-        rawResponses: state._modelResponses,
-        lastAgent: agent,
-        state,
-      };
       const handlerResult = await resolveRunErrorHandler({
         error: refusalError,
         errorHandlers,
         context: state._context,
-        runData,
+        runData: buildTurnRunErrorData(
+          state,
+          agent,
+          originalInput,
+          preStepItems,
+          newItems,
+        ),
       });
       if (!handlerResult) {
         throw refusalError;
@@ -1084,6 +1140,7 @@ export async function resolveTurnAfterModelResponse<
         agent,
         handlerResult.finalOutput,
       );
+      validateRunErrorHandlerFinalOutput(agent, outputText);
       if (handlerResult.includeInHistory !== false) {
         newItems.push(createRunErrorFinalOutputItem(agent, outputText));
       }
@@ -1099,6 +1156,29 @@ export async function resolveTurnAfterModelResponse<
 
   // if there is no output we just run again
   if (typeof potentialFinalOutput === 'undefined') {
+    if (!hasPendingToolsOrApprovals && agent.outputType !== 'text') {
+      const outputError = new ModelBehaviorError(
+        'Model returned no final output for the structured output type.',
+      );
+      const handledOutput = await resolveInvalidFinalOutput({
+        error: outputError,
+        errorHandlers,
+        agent,
+        originalInput,
+        preStepItems,
+        newItems,
+        state,
+      });
+      if (typeof handledOutput !== 'undefined') {
+        return new SingleStepResult(
+          originalInput,
+          newResponse,
+          preStepItems,
+          newItems,
+          { type: 'next_step_final_output', output: handledOutput },
+        );
+      }
+    }
     return new SingleStepResult(
       originalInput,
       newResponse,
@@ -1137,7 +1217,26 @@ export async function resolveTurnAfterModelResponse<
             error: String(error),
           },
         });
-        throw new ModelBehaviorError(outputErrorMessage);
+        const outputError = new ModelBehaviorError(outputErrorMessage);
+        const handledOutput = await resolveInvalidFinalOutput({
+          error: outputError,
+          errorHandlers,
+          agent,
+          originalInput,
+          preStepItems,
+          newItems,
+          state,
+        });
+        if (typeof handledOutput === 'undefined') {
+          throw outputError;
+        }
+        return new SingleStepResult(
+          originalInput,
+          newResponse,
+          preStepItems,
+          newItems,
+          { type: 'next_step_final_output', output: handledOutput },
+        );
       }
 
       return new SingleStepResult(

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -1476,6 +1476,67 @@ describe('Runner.run (streaming)', () => {
     }
   });
 
+  it('handles invalid final output errors with an error handler', async () => {
+    class InvalidFinalOutputStreamingModel implements Model {
+      async getResponse(_req: ModelRequest): Promise<ModelResponse> {
+        return {
+          output: [fakeModelMessage('not valid json')],
+          usage: new Usage(),
+        };
+      }
+
+      async *getStreamedResponse(
+        req: ModelRequest,
+      ): AsyncIterable<StreamEvent> {
+        const response = await this.getResponse(req);
+        yield {
+          type: 'response_done',
+          response: {
+            id: 'r_invalid_final_output',
+            usage: {
+              requests: 1,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            output: response.output,
+          },
+        } as any;
+      }
+    }
+
+    const agent = new Agent({
+      name: 'InvalidFinalOutputHandlerStream',
+      outputType: z.object({ summary: z.string() }),
+      model: new InvalidFinalOutputStreamingModel(),
+    });
+    const result = await run(agent, 'x', {
+      stream: true,
+      errorHandlers: {
+        invalidFinalOutput: () => ({
+          finalOutput: { summary: 'safe fallback' },
+        }),
+      },
+    });
+    const events: RunStreamEvent[] = [];
+    for await (const event of result.toStream()) {
+      events.push(event);
+    }
+    await result.completed;
+
+    expect(result.finalOutput).toEqual({ summary: 'safe fallback' });
+    const runItemEvents = events.filter(
+      (event): event is RunItemStreamEvent =>
+        event.type === 'run_item_stream_event',
+    );
+    expect(runItemEvents).toHaveLength(2);
+    expect(runItemEvents[1].name).toBe('message_output_created');
+    expect(runItemEvents[1].item).toBeInstanceOf(RunMessageOutputItem);
+    if (runItemEvents[1].item instanceof RunMessageOutputItem) {
+      expect(runItemEvents[1].item.content).toBe('{"summary":"safe fallback"}');
+    }
+  });
+
   it('does not advance the turn for streaming runs resuming an interruption without persisted items', async () => {
     const approvalTool = tool({
       name: 'get_weather',

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -15,6 +15,7 @@ import {
   GuardrailExecutionError,
   InputGuardrailTripwireTriggered,
   MaxTurnsExceededError,
+  ModelBehaviorError,
   ModelRefusalError,
   ModelResponse,
   OutputGuardrailTripwireTriggered,
@@ -2547,6 +2548,261 @@ describe('Runner.run', () => {
         },
       });
       expect(result.finalOutput).toBe('safe fallback');
+    });
+
+    it('throws invalid structured final output without a handler', async () => {
+      const agent = new Agent({
+        name: 'InvalidStructuredOutput',
+        outputType: z.object({ summary: z.string() }),
+        model: new FakeModel([
+          {
+            output: [fakeModelMessage('not valid json')],
+            usage: new Usage(),
+          },
+        ]),
+      });
+
+      await expect(run(agent, 'x')).rejects.toBeInstanceOf(ModelBehaviorError);
+    });
+
+    it('invalid final output handler returns structured final output', async () => {
+      const agent = new Agent({
+        name: 'InvalidStructuredOutputHandler',
+        outputType: z.object({ summary: z.string() }),
+        model: new FakeModel([
+          {
+            output: [fakeModelMessage('not valid json')],
+            usage: new Usage(),
+          },
+        ]),
+      });
+
+      const result = await run(agent, 'x', {
+        errorHandlers: {
+          invalidFinalOutput: ({ error, runData }) => {
+            expect(error).toBeInstanceOf(ModelBehaviorError);
+            expect(runData.rawResponses).toHaveLength(1);
+            expect(extractAllTextOutput(runData.newItems)).toBe(
+              'not valid json',
+            );
+            return { finalOutput: { summary: 'safe fallback' } };
+          },
+        },
+      });
+
+      expect(result.finalOutput).toEqual({ summary: 'safe fallback' });
+      expect(extractAllTextOutput(result.newItems)).toBe(
+        'not valid json{"summary":"safe fallback"}',
+      );
+    });
+
+    it('invalid final output handler can skip history updates', async () => {
+      const agent = new Agent({
+        name: 'InvalidStructuredOutputNoHistory',
+        outputType: z.object({ summary: z.string() }),
+        model: new FakeModel([
+          {
+            output: [fakeModelMessage('not valid json')],
+            usage: new Usage(),
+          },
+        ]),
+      });
+
+      const result = await run(agent, 'x', {
+        errorHandlers: {
+          invalidFinalOutput: () => ({
+            finalOutput: { summary: 'safe fallback' },
+            includeInHistory: false,
+          }),
+        },
+      });
+
+      expect(result.finalOutput).toEqual({ summary: 'safe fallback' });
+      expect(extractAllTextOutput(result.newItems)).toBe('not valid json');
+    });
+
+    it('invalid final output handler can decline recovery', async () => {
+      const agent = new Agent({
+        name: 'InvalidStructuredOutputDeclined',
+        outputType: z.object({ summary: z.string() }),
+        model: new FakeModel([
+          {
+            output: [fakeModelMessage('not valid json')],
+            usage: new Usage(),
+          },
+        ]),
+      });
+
+      await expect(
+        run(agent, 'x', {
+          errorHandlers: {
+            invalidFinalOutput: () => undefined,
+          },
+        }),
+      ).rejects.toBeInstanceOf(ModelBehaviorError);
+    });
+
+    it('invalid final output handler validates fallback output', async () => {
+      const agent = new Agent({
+        name: 'InvalidStructuredOutputBadFallback',
+        outputType: z.object({ summary: z.string() }),
+        model: new FakeModel([
+          {
+            output: [fakeModelMessage('not valid json')],
+            usage: new Usage(),
+          },
+        ]),
+      });
+
+      await expect(
+        run(agent, 'x', {
+          errorHandlers: {
+            invalidFinalOutput: () => ({
+              finalOutput: { unexpected: 'value' } as any,
+            }),
+          },
+        }),
+      ).rejects.toThrow(UserError);
+    });
+
+    it('default error handler can handle invalid final output', async () => {
+      const agent = new Agent({
+        name: 'DefaultInvalidStructuredOutput',
+        outputType: z.object({ summary: z.string() }),
+        model: new FakeModel([
+          {
+            output: [fakeModelMessage('not valid json')],
+            usage: new Usage(),
+          },
+        ]),
+      });
+
+      const result = await run(agent, 'x', {
+        errorHandlers: {
+          default: ({ error }) => {
+            expect(error).toBeInstanceOf(ModelBehaviorError);
+            return { finalOutput: { summary: 'safe fallback' } };
+          },
+        },
+      });
+
+      expect(result.finalOutput).toEqual({ summary: 'safe fallback' });
+    });
+
+    it('empty structured output handler avoids another model turn', async () => {
+      class CountingModel implements Model {
+        public requests: ModelRequest[] = [];
+
+        constructor(private responses: ModelResponse[]) {}
+
+        async getResponse(request: ModelRequest): Promise<ModelResponse> {
+          this.requests.push(request);
+          const response = this.responses.shift();
+          if (!response) {
+            throw new Error('No response found');
+          }
+          return response;
+        }
+
+        getStreamedResponse(_request: ModelRequest): AsyncIterable<any> {
+          throw new Error('Not implemented');
+        }
+      }
+
+      const model = new CountingModel([
+        { output: [], usage: new Usage() },
+        {
+          output: [fakeModelMessage('{"summary":"unused"}')],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'EmptyStructuredOutputHandler',
+        outputType: z.object({ summary: z.string() }),
+        model,
+      });
+
+      const result = await run(agent, 'x', {
+        errorHandlers: {
+          invalidFinalOutput: ({ error }) => {
+            expect(error).toBeInstanceOf(ModelBehaviorError);
+            expect((error as ModelBehaviorError).message).toBe(
+              'Model returned no final output for the structured output type.',
+            );
+            return { finalOutput: { summary: 'safe fallback' } };
+          },
+        },
+      });
+
+      expect(result.finalOutput).toEqual({ summary: 'safe fallback' });
+      expect(model.requests).toHaveLength(1);
+    });
+
+    it('invalid final output fallback does not retry or replay tools', async () => {
+      const sideEffects: string[] = [];
+      const recordSideEffect = tool({
+        name: 'record_side_effect',
+        description: 'Records a side effect.',
+        parameters: z.object({ value: z.string() }),
+        execute: async ({ value }) => {
+          sideEffects.push(value);
+          return `recorded:${value}`;
+        },
+      });
+      const agent = new Agent({
+        name: 'InvalidStructuredOutputAfterTool',
+        outputType: z.object({ summary: z.string() }),
+        tools: [recordSideEffect],
+        model: new FakeModel([
+          {
+            output: [
+              {
+                type: 'function_call',
+                id: 'fc_1',
+                callId: 'call_1',
+                name: 'record_side_effect',
+                status: 'completed',
+                arguments: '{"value":"once"}',
+                providerData: {},
+              } as protocol.FunctionCallItem,
+            ],
+            usage: new Usage(),
+          },
+          {
+            output: [fakeModelMessage('not valid json')],
+            usage: new Usage(),
+          },
+          {
+            output: [
+              {
+                type: 'function_call',
+                id: 'fc_2',
+                callId: 'call_2',
+                name: 'record_side_effect',
+                status: 'completed',
+                arguments: '{"value":"replayed"}',
+                providerData: {},
+              } as protocol.FunctionCallItem,
+            ],
+            usage: new Usage(),
+          },
+          {
+            output: [fakeModelMessage('{"summary":"unexpected retry"}')],
+            usage: new Usage(),
+          },
+        ]),
+      });
+
+      const result = await run(agent, 'x', {
+        errorHandlers: {
+          invalidFinalOutput: () => ({
+            finalOutput: { summary: 'safe fallback' },
+          }),
+        },
+      });
+
+      expect(result.finalOutput).toEqual({ summary: 'safe fallback' });
+      expect(sideEffects).toEqual(['once']);
     });
 
     it('enforces maxTurns across multiple model calls', async () => {

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -2805,6 +2805,72 @@ describe('Runner.run', () => {
       expect(sideEffects).toEqual(['once']);
     });
 
+    it('nested agent tools return invalid final output fallbacks', async () => {
+      const nestedAgent = new Agent({
+        name: 'NestedRecoverer',
+        outputType: z.object({ summary: z.string() }),
+        model: new FakeModel([
+          {
+            output: [fakeModelMessage('not valid json')],
+            usage: new Usage(),
+          },
+        ]),
+      });
+      const nestedTool = nestedAgent.asTool({
+        toolName: 'recover_nested',
+        toolDescription: 'Recovers a structured nested output.',
+        runOptions: {
+          errorHandlers: {
+            invalidFinalOutput: () => ({
+              finalOutput: { summary: 'safe fallback' },
+            }),
+          },
+        },
+      });
+      const parentAgent = new Agent({
+        name: 'ParentAgent',
+        tools: [nestedTool],
+        model: new FakeModel([
+          {
+            output: [
+              {
+                type: 'function_call',
+                id: 'fc_nested',
+                callId: 'call_nested',
+                name: 'recover_nested',
+                status: 'completed',
+                arguments: '{"input":"recover"}',
+                providerData: {},
+              } as protocol.FunctionCallItem,
+            ],
+            usage: new Usage(),
+          },
+          {
+            output: [fakeModelMessage('parent done')],
+            usage: new Usage(),
+          },
+        ]),
+      });
+
+      const result = await run(parentAgent, 'x');
+      const nestedToolOutput = result.newItems.find(
+        (item): item is ToolCallOutputItem =>
+          item instanceof ToolCallOutputItem &&
+          item.rawItem.type === 'function_call_result' &&
+          item.rawItem.callId === 'call_nested',
+      );
+
+      const nestedOutput = nestedToolOutput?.rawItem.output;
+      const nestedOutputText =
+        typeof nestedOutput === 'string'
+          ? nestedOutput
+          : !Array.isArray(nestedOutput) && nestedOutput?.type === 'text'
+            ? nestedOutput.text
+            : undefined;
+      expect(nestedOutputText).toBe('{"summary":"safe fallback"}');
+      expect(result.finalOutput).toBe('parent done');
+    });
+
     it('enforces maxTurns across multiple model calls', async () => {
       // Bug: After first model call, _lastTurnResponse is set, so turn counter never advances.
       // With maxTurns=1, we should only allow 1 model call, but currently allows 2.

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -2689,54 +2689,60 @@ describe('Runner.run', () => {
       expect(result.finalOutput).toEqual({ summary: 'safe fallback' });
     });
 
-    it('empty structured output handler avoids another model turn', async () => {
-      class CountingModel implements Model {
-        public requests: ModelRequest[] = [];
+    it.each([
+      { name: 'missing message', output: [] },
+      { name: 'empty text message', output: [fakeModelMessage('')] },
+    ])(
+      'empty structured output handler avoids another model turn for $name',
+      async ({ output }) => {
+        class CountingModel implements Model {
+          public requests: ModelRequest[] = [];
 
-        constructor(private responses: ModelResponse[]) {}
+          constructor(private responses: ModelResponse[]) {}
 
-        async getResponse(request: ModelRequest): Promise<ModelResponse> {
-          this.requests.push(request);
-          const response = this.responses.shift();
-          if (!response) {
-            throw new Error('No response found');
+          async getResponse(request: ModelRequest): Promise<ModelResponse> {
+            this.requests.push(request);
+            const response = this.responses.shift();
+            if (!response) {
+              throw new Error('No response found');
+            }
+            return response;
           }
-          return response;
+
+          getStreamedResponse(_request: ModelRequest): AsyncIterable<any> {
+            throw new Error('Not implemented');
+          }
         }
 
-        getStreamedResponse(_request: ModelRequest): AsyncIterable<any> {
-          throw new Error('Not implemented');
-        }
-      }
-
-      const model = new CountingModel([
-        { output: [], usage: new Usage() },
-        {
-          output: [fakeModelMessage('{"summary":"unused"}')],
-          usage: new Usage(),
-        },
-      ]);
-      const agent = new Agent({
-        name: 'EmptyStructuredOutputHandler',
-        outputType: z.object({ summary: z.string() }),
-        model,
-      });
-
-      const result = await run(agent, 'x', {
-        errorHandlers: {
-          invalidFinalOutput: ({ error }) => {
-            expect(error).toBeInstanceOf(ModelBehaviorError);
-            expect((error as ModelBehaviorError).message).toBe(
-              'Model returned no final output for the structured output type.',
-            );
-            return { finalOutput: { summary: 'safe fallback' } };
+        const model = new CountingModel([
+          { output, usage: new Usage() },
+          {
+            output: [fakeModelMessage('{"summary":"unused"}')],
+            usage: new Usage(),
           },
-        },
-      });
+        ]);
+        const agent = new Agent({
+          name: 'EmptyStructuredOutputHandler',
+          outputType: z.object({ summary: z.string() }),
+          model,
+        });
 
-      expect(result.finalOutput).toEqual({ summary: 'safe fallback' });
-      expect(model.requests).toHaveLength(1);
-    });
+        const result = await run(agent, 'x', {
+          errorHandlers: {
+            invalidFinalOutput: ({ error }) => {
+              expect(error).toBeInstanceOf(ModelBehaviorError);
+              expect((error as ModelBehaviorError).message).toBe(
+                'Model returned no final output for the structured output type.',
+              );
+              return { finalOutput: { summary: 'safe fallback' } };
+            },
+          },
+        });
+
+        expect(result.finalOutput).toEqual({ summary: 'safe fallback' });
+        expect(model.requests).toHaveLength(1);
+      },
+    );
 
     it('invalid final output fallback does not retry or replay tools', async () => {
       const sideEffects: string[] = [];


### PR DESCRIPTION
This pull request adds an `invalidFinalOutput` run error handler for structured final output failures in `@openai/agents-core`. It lets applications recover from missing or schema-invalid structured final output by returning a validated fallback `finalOutput`, while preserving the existing default behavior when no handler is configured. The handler participates in the existing run error handler flow, supports `default` fallback handling, can opt out of history insertion with `includeInHistory: false`, and is covered across non-streaming, streaming, empty-output, invalid-fallback, and post-tool side-effect scenarios.

see also: https://github.com/openai/openai-agents-python/pull/3736