### PR TITLE
feat: update realtime default model to gpt-realtime-2.1

### DIFF
--- a/.changeset/realtime-21-default.md
+++ b/.changeset/realtime-21-default.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents': minor
+'@openai/agents-realtime': minor
+---
+
+feat: update realtime model support and default to gpt-realtime-2.1

--- a/examples/realtime-demo/token.ts
+++ b/examples/realtime-demo/token.ts
@@ -8,7 +8,7 @@ async function generateToken() {
   const session = await openai.realtime.clientSecrets.create({
     session: {
       type: 'realtime',
-      model: 'gpt-realtime-2',
+      model: 'gpt-realtime-2.1',
     },
   });
 

--- a/examples/realtime-next/src/app/raw-client/page.tsx
+++ b/examples/realtime-next/src/app/raw-client/page.tsx
@@ -29,7 +29,7 @@ export default function Home() {
       const token = await getToken();
       await connection.current?.connect({
         apiKey: token,
-        model: 'gpt-realtime-2',
+        model: 'gpt-realtime-2.1',
         initialSessionConfig: {
           instructions: 'Speak like a pirate',
           voice: 'marin',

--- a/examples/realtime-next/src/app/server/token.action.tsx
+++ b/examples/realtime-next/src/app/server/token.action.tsx
@@ -17,7 +17,7 @@ export async function getToken() {
       body: JSON.stringify({
         session: {
           type: 'realtime',
-          model: 'gpt-realtime-2',
+          model: 'gpt-realtime-2.1',
           tools: [
             {
               type: 'mcp',

--- a/examples/realtime-next/src/app/websocket/page.tsx
+++ b/examples/realtime-next/src/app/websocket/page.tsx
@@ -111,7 +111,7 @@ export default function Home() {
   useEffect(() => {
     session.current = new RealtimeSession(agent, {
       transport: 'websocket',
-      model: 'gpt-realtime-2',
+      model: 'gpt-realtime-2.1',
       outputGuardrails: guardrails,
       config: {
         audio: {

--- a/examples/realtime-twilio-sip/server.ts
+++ b/examples/realtime-twilio-sip/server.ts
@@ -48,7 +48,7 @@ async function main() {
   // Reuse the same session options when accepting the call and when instantiating the session so
   // the SIP payload remains in sync with the live websocket session.
   const sessionOptions: Partial<RealtimeSessionOptions> = {
-    model: 'gpt-realtime-2',
+    model: 'gpt-realtime-2.1',
     config: {
       audio: {
         input: {

--- a/examples/realtime-twilio/index.ts
+++ b/examples/realtime-twilio/index.ts
@@ -105,7 +105,7 @@ fastify.register(async (scopedFastify: FastifyInstance) => {
 
       const session = new RealtimeSession(agent, {
         transport: twilioTransportLayer,
-        model: 'gpt-realtime-2',
+        model: 'gpt-realtime-2.1',
         config: {
           audio: {
             output: {

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -44,6 +44,8 @@ export type OpenAIRealtimeModels =
   | 'gpt-realtime'
   | 'gpt-realtime-1.5'
   | 'gpt-realtime-2'
+  | 'gpt-realtime-2.1'
+  | 'gpt-realtime-2.1-mini'
   | 'gpt-realtime-2025-08-28'
   | 'gpt-4o-realtime-preview'
   | 'gpt-4o-realtime-preview-2024-10-01'
@@ -60,7 +62,7 @@ export type OpenAIRealtimeModels =
  * The default model that is used during the connection if no model is provided.
  */
 export const DEFAULT_OPENAI_REALTIME_MODEL: OpenAIRealtimeModels =
-  'gpt-realtime-2';
+  'gpt-realtime-2.1';
 
 /**
  * The default session config that gets send over during session connection unless overridden

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -95,22 +95,22 @@ describe('OpenAIRealtimeBase helpers', () => {
     expect(config.audio?.output?.voice).toBeUndefined();
   });
 
-  it('uses gpt-realtime-2 as the default model', () => {
+  it('uses gpt-realtime-2.1 as the default model', () => {
     const base = new TestBase();
     const config = (base as any)._getMergedSessionConfig({});
 
-    expect(config.model).toBe('gpt-realtime-2');
+    expect(config.model).toBe('gpt-realtime-2.1');
   });
 
   it('maps reasoning-capable realtime session settings', () => {
     const base = new TestBase();
     const config = (base as any)._getMergedSessionConfig({
-      model: 'gpt-realtime-2',
+      model: 'gpt-realtime-2.1',
       parallelToolCalls: false,
       reasoning: { effort: 'low' },
     });
 
-    expect(config.model).toBe('gpt-realtime-2');
+    expect(config.model).toBe('gpt-realtime-2.1');
     expect(config.parallel_tool_calls).toBe(false);
     expect(config.reasoning).toEqual({ effort: 'low' });
   });


### PR DESCRIPTION
This pull request adds support for gpt-realtime-2.1 and gpt-realtime-2.1-mini, and changes the default Realtime model to gpt-realtime-2.1.