### PR TITLE
fix: resolve workspace packages from source in Vitest

### DIFF
--- a/.changeset/calm-shims-resolve.md
+++ b/.changeset/calm-shims-resolve.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: remove the MCP shim initialization cycle

--- a/helpers/vitest/workspacePackageAliases.test.ts
+++ b/helpers/vitest/workspacePackageAliases.test.ts
@@ -1,0 +1,72 @@
+import { relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  createWorkspacePackageAliases,
+  readWorkspacePackages,
+  type WorkspacePackage,
+} from './workspacePackageAliases';
+
+const rootDir = fileURLToPath(new URL('../..', import.meta.url));
+const workspacePackages = readWorkspacePackages(resolve(rootDir, 'packages'));
+const aliases = createWorkspacePackageAliases(workspacePackages);
+
+describe('workspace package aliases', () => {
+  it('maps every public package export to a source entrypoint', () => {
+    const expectedAliases = workspacePackages.flatMap((workspacePackage) =>
+      Object.keys(workspacePackage.exports).map((exportPath) => {
+        const subpath = exportPath === '.' ? '' : exportPath.slice(1);
+        return `${workspacePackage.name}${subpath}`;
+      }),
+    );
+
+    expect(Object.keys(aliases)).toEqual(
+      expect.arrayContaining(expectedAliases),
+    );
+    expect(Object.keys(aliases)).toHaveLength(expectedAliases.length);
+    for (const sourcePath of Object.values(aliases)) {
+      const relativePath = relative(resolve(rootDir, 'packages'), sourcePath);
+      const pathSegments = relativePath.split(sep);
+
+      expect(relativePath).not.toMatch(/^\.\./u);
+      expect(pathSegments).toContain('src');
+      expect(pathSegments).not.toContain('dist');
+    }
+  });
+
+  it('uses Node shims and orders subpaths before package roots', () => {
+    expect(aliases['@openai/agents-core/_shims']).toBe(
+      resolve(rootDir, 'packages/agents-core/src/shims/shims-node.ts'),
+    );
+    expect(aliases['@openai/agents-realtime/_shims']).toBe(
+      resolve(rootDir, 'packages/agents-realtime/src/shims/shims-node.ts'),
+    );
+
+    const aliasNames = Object.keys(aliases);
+    for (const workspacePackage of workspacePackages) {
+      const rootIndex = aliasNames.indexOf(workspacePackage.name);
+      expect(rootIndex).toBeGreaterThanOrEqual(0);
+      for (const aliasName of aliasNames) {
+        if (aliasName.startsWith(`${workspacePackage.name}/`)) {
+          expect(aliasNames.indexOf(aliasName)).toBeLessThan(rootIndex);
+        }
+      }
+    }
+  });
+
+  it('fails fast when a published export has no source entrypoint', () => {
+    const invalidPackage: WorkspacePackage = {
+      name: '@openai/invalid',
+      root: resolve(rootDir, 'packages/invalid'),
+      exports: {
+        '.': {
+          import: './dist/index.mjs',
+        },
+      },
+    };
+
+    expect(() => createWorkspacePackageAliases([invalidPackage])).toThrow(
+      'has no source entrypoint',
+    );
+  });
+});

--- a/helpers/vitest/workspacePackageAliases.ts
+++ b/helpers/vitest/workspacePackageAliases.ts
@@ -1,0 +1,134 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+type PackageExportTarget =
+  | string
+  | null
+  | PackageExportTarget[]
+  | { [condition: string]: PackageExportTarget };
+
+export type WorkspacePackage = {
+  name: string;
+  root: string;
+  exports: Record<string, PackageExportTarget>;
+};
+
+type WorkspacePackageJson = {
+  name?: string;
+  exports?: Record<string, PackageExportTarget>;
+};
+
+const NODE_IMPORT_CONDITIONS = [
+  'node',
+  'import',
+  'default',
+  'require',
+] as const;
+
+function selectNodeImportTarget(
+  target: PackageExportTarget,
+): string | undefined {
+  if (typeof target === 'string') {
+    return target;
+  }
+  if (target === null) {
+    return undefined;
+  }
+  if (Array.isArray(target)) {
+    for (const candidate of target) {
+      const selected = selectNodeImportTarget(candidate);
+      if (selected !== undefined) {
+        return selected;
+      }
+    }
+    return undefined;
+  }
+
+  for (const condition of NODE_IMPORT_CONDITIONS) {
+    if (condition in target) {
+      const selected = selectNodeImportTarget(target[condition]);
+      if (selected !== undefined) {
+        return selected;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function sourcePathForExport(
+  workspacePackage: WorkspacePackage,
+  exportPath: string,
+  target: PackageExportTarget,
+): string {
+  const distTarget = selectNodeImportTarget(target);
+  if (distTarget === undefined) {
+    throw new Error(
+      `Package export ${workspacePackage.name}${exportPath.slice(1)} has no Node-compatible import target.`,
+    );
+  }
+  if (!distTarget.startsWith('./dist/')) {
+    throw new Error(
+      `Package export ${workspacePackage.name}${exportPath.slice(1)} does not point into dist: ${distTarget}`,
+    );
+  }
+
+  const sourceRelativePath = distTarget
+    .slice('./dist/'.length)
+    .replace(/\.(?:mjs|js)$/u, '.ts');
+  const sourcePath = resolve(workspacePackage.root, 'src', sourceRelativePath);
+  if (!existsSync(sourcePath)) {
+    throw new Error(
+      `Package export ${workspacePackage.name}${exportPath.slice(1)} has no source entrypoint at ${sourcePath}.`,
+    );
+  }
+
+  return sourcePath;
+}
+
+export function readWorkspacePackages(packagesDir: string): WorkspacePackage[] {
+  return readdirSync(packagesDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const root = resolve(packagesDir, entry.name);
+      const packageJsonPath = resolve(root, 'package.json');
+      const packageJson = JSON.parse(
+        readFileSync(packageJsonPath, 'utf8'),
+      ) as WorkspacePackageJson;
+
+      if (!packageJson.name || !packageJson.exports) {
+        throw new Error(
+          `Workspace package ${entry.name} must define name and exports.`,
+        );
+      }
+
+      return {
+        name: packageJson.name,
+        root,
+        exports: packageJson.exports,
+      };
+    })
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+export function createWorkspacePackageAliases(
+  workspacePackages: WorkspacePackage[],
+): Record<string, string> {
+  const aliases = workspacePackages.flatMap((workspacePackage) =>
+    Object.entries(workspacePackage.exports).map(([exportPath, target]) => {
+      const subpath = exportPath === '.' ? '' : exportPath.slice(1);
+      const aliasName = `${workspacePackage.name}${subpath}`;
+      return [
+        aliasName,
+        sourcePathForExport(workspacePackage, exportPath, target),
+      ] as const;
+    }),
+  );
+
+  aliases.sort(
+    ([left], [right]) =>
+      right.length - left.length || left.localeCompare(right),
+  );
+
+  return Object.fromEntries(aliases);
+}

--- a/packages/agents-core/package.json
+++ b/packages/agents-core/package.json
@@ -83,6 +83,26 @@
       "types": "./dist/shims/shims.d.ts",
       "require": "./dist/shims/shims.js",
       "import": "./dist/shims/shims.mjs"
+    },
+    "./_shims/config": {
+      "workerd": {
+        "types": "./dist/shims/config-workerd.d.ts",
+        "require": "./dist/shims/config-workerd.js",
+        "import": "./dist/shims/config-workerd.mjs"
+      },
+      "browser": {
+        "types": "./dist/shims/config-browser.d.ts",
+        "require": "./dist/shims/config-browser.js",
+        "import": "./dist/shims/config-browser.mjs"
+      },
+      "node": {
+        "types": "./dist/shims/config-node.d.ts",
+        "require": "./dist/shims/config-node.js",
+        "import": "./dist/shims/config-node.mjs"
+      },
+      "types": "./dist/shims/config-node.d.ts",
+      "require": "./dist/shims/config-node.js",
+      "import": "./dist/shims/config-node.mjs"
     }
   },
   "keywords": [
@@ -138,6 +158,9 @@
       ],
       "_shims": [
         "dist/shims/shims-node.d.ts"
+      ],
+      "_shims/config": [
+        "dist/shims/config-node.d.ts"
       ]
     }
   },

--- a/packages/agents-core/src/config.ts
+++ b/packages/agents-core/src/config.ts
@@ -1,6 +1,4 @@
-// Use function instead of exporting the value to prevent
-// circular dependency resolution issues caused by other exports in '@openai/agents-core/_shims'
-import * as _shims from '@openai/agents-core/_shims';
+import * as _configShims from '@openai/agents-core/_shims/config';
 
 function fallbackIsBrowserEnvironment(): boolean {
   return (
@@ -12,8 +10,8 @@ function fallbackIsBrowserEnvironment(): boolean {
 
 function isBrowserEnvironment(): boolean {
   try {
-    if (typeof _shims?.isBrowserEnvironment === 'function') {
-      return _shims.isBrowserEnvironment();
+    if (typeof _configShims?.isBrowserEnvironment === 'function') {
+      return _configShims.isBrowserEnvironment();
     }
   } catch {
     // Fallback below.
@@ -28,7 +26,7 @@ function isBrowserEnvironment(): boolean {
  */
 export function loadEnv(): Record<string, string | undefined> {
   try {
-    const env = _shims?.loadEnv?.();
+    const env = _configShims?.loadEnv?.();
     return typeof env === 'object' && env != null ? env : {};
   } catch {
     return {};

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -12,9 +12,7 @@ import {
   type MCPListToolsSpanData,
   type Span,
 } from './tracing';
-import { logger as globalLogger, getLogger, Logger } from './logger';
-import debug from 'debug';
-import { z } from 'zod';
+import { logger as globalLogger, type Logger } from './logger';
 import {
   JsonObjectSchema,
   JsonObjectSchemaNonStrict,
@@ -32,15 +30,28 @@ import type {
 import type { RunContext } from './runContext';
 import type { Agent } from './agent';
 import { maybeExtractToolOutputCustomData } from './utils/customData';
+import {
+  BaseMCPServerSSE,
+  BaseMCPServerStdio,
+  BaseMCPServerStreamableHttp,
+  MCPTool,
+} from './mcpShared';
+import {
+  cachedMcpToolKeysByServer as _cachedToolKeysByServer,
+  cachedMcpTools as _cachedTools,
+} from './mcpToolCache';
 
-export const DEFAULT_STDIO_MCP_CLIENT_LOGGER_NAME =
-  'openai-agents:stdio-mcp-client';
-
-export const DEFAULT_STREAMABLE_HTTP_MCP_CLIENT_LOGGER_NAME =
-  'openai-agents:streamable-http-mcp-client';
-
-export const DEFAULT_SSE_MCP_CLIENT_LOGGER_NAME =
-  'openai-agents:sse-mcp-client';
+export {
+  BaseMCPServerSSE,
+  BaseMCPServerStdio,
+  BaseMCPServerStreamableHttp,
+  DEFAULT_SSE_MCP_CLIENT_LOGGER_NAME,
+  DEFAULT_STDIO_MCP_CLIENT_LOGGER_NAME,
+  DEFAULT_STREAMABLE_HTTP_MCP_CLIENT_LOGGER_NAME,
+  MCPTool,
+  attachCallToolResultMetadata,
+} from './mcpShared';
+export { invalidateServerToolsCache } from './mcpToolCache';
 
 export type MCPToolErrorFunction = (args: {
   context: RunContext;
@@ -195,193 +206,6 @@ export interface MCPServerWithResources extends MCPServer {
   ): Promise<MCPListResourceTemplatesResult>;
   readResource(uri: string): Promise<MCPReadResourceResult>;
 }
-
-export abstract class BaseMCPServerStdio implements MCPServer {
-  public cacheToolsList: boolean;
-  protected _cachedTools: any[] | undefined = undefined;
-  public toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
-  public toolMetaResolver?: MCPToolMetaResolver;
-  public customDataExtractor?: MCPToolCustomDataExtractor;
-  public useStructuredContent?: boolean;
-  public errorFunction?: MCPToolErrorFunction | null;
-
-  protected logger: Logger;
-  constructor(options: MCPServerStdioOptions) {
-    this.logger =
-      options.logger ?? getLogger(DEFAULT_STDIO_MCP_CLIENT_LOGGER_NAME);
-    this.cacheToolsList = options.cacheToolsList ?? false;
-    this.toolFilter = options.toolFilter;
-    this.toolMetaResolver = options.toolMetaResolver;
-    this.customDataExtractor = options.customDataExtractor;
-    this.useStructuredContent = options.useStructuredContent;
-    this.errorFunction = options.errorFunction;
-  }
-
-  abstract get name(): string;
-  abstract connect(): Promise<void>;
-  abstract close(): Promise<void>;
-  abstract listTools(): Promise<any[]>;
-  abstract callTool(
-    _toolName: string,
-    _args: Record<string, unknown> | null,
-    _meta?: Record<string, unknown> | null,
-  ): Promise<CallToolResultContent>;
-  abstract callToolResult(
-    _toolName: string,
-    _args: Record<string, unknown> | null,
-    _meta?: Record<string, unknown> | null,
-  ): Promise<CallToolResult>;
-  abstract listResources(
-    _params?: MCPListResourcesParams,
-  ): Promise<MCPListResourcesResult>;
-  abstract listResourceTemplates(
-    _params?: MCPListResourcesParams,
-  ): Promise<MCPListResourceTemplatesResult>;
-  abstract readResource(_uri: string): Promise<MCPReadResourceResult>;
-  abstract invalidateToolsCache(): Promise<void>;
-
-  /**
-   * Logs a debug message when debug logging is enabled.
-   * @param buildMessage A function that returns the message to log.
-   */
-  protected debugLog(buildMessage: () => string): void {
-    if (debug.enabled(this.logger.namespace)) {
-      // only when this is true, the function to build the string is called
-      this.logger.debug(buildMessage());
-    }
-  }
-}
-
-export abstract class BaseMCPServerStreamableHttp implements MCPServer {
-  public cacheToolsList: boolean;
-  protected _cachedTools: any[] | undefined = undefined;
-  public toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
-  public toolMetaResolver?: MCPToolMetaResolver;
-  public customDataExtractor?: MCPToolCustomDataExtractor;
-  public useStructuredContent?: boolean;
-  public errorFunction?: MCPToolErrorFunction | null;
-
-  protected logger: Logger;
-  constructor(options: MCPServerStreamableHttpOptions) {
-    this.logger =
-      options.logger ??
-      getLogger(DEFAULT_STREAMABLE_HTTP_MCP_CLIENT_LOGGER_NAME);
-    this.cacheToolsList = options.cacheToolsList ?? false;
-    this.toolFilter = options.toolFilter;
-    this.toolMetaResolver = options.toolMetaResolver;
-    this.customDataExtractor = options.customDataExtractor;
-    this.useStructuredContent = options.useStructuredContent;
-    this.errorFunction = options.errorFunction;
-  }
-
-  abstract get name(): string;
-  abstract connect(): Promise<void>;
-  abstract close(): Promise<void>;
-  abstract listTools(): Promise<any[]>;
-  abstract callTool(
-    _toolName: string,
-    _args: Record<string, unknown> | null,
-    _meta?: Record<string, unknown> | null,
-  ): Promise<CallToolResultContent>;
-  abstract callToolResult(
-    _toolName: string,
-    _args: Record<string, unknown> | null,
-    _meta?: Record<string, unknown> | null,
-  ): Promise<CallToolResult>;
-  abstract listResources(
-    _params?: MCPListResourcesParams,
-  ): Promise<MCPListResourcesResult>;
-  abstract listResourceTemplates(
-    _params?: MCPListResourcesParams,
-  ): Promise<MCPListResourceTemplatesResult>;
-  abstract readResource(_uri: string): Promise<MCPReadResourceResult>;
-  abstract get sessionId(): string | undefined;
-  abstract invalidateToolsCache(): Promise<void>;
-
-  /**
-   * Logs a debug message when debug logging is enabled.
-   * @param buildMessage A function that returns the message to log.
-   */
-  protected debugLog(buildMessage: () => string): void {
-    if (debug.enabled(this.logger.namespace)) {
-      // only when this is true, the function to build the string is called
-      this.logger.debug(buildMessage());
-    }
-  }
-}
-
-export abstract class BaseMCPServerSSE implements MCPServer {
-  public cacheToolsList: boolean;
-  protected _cachedTools: any[] | undefined = undefined;
-  public toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
-  public toolMetaResolver?: MCPToolMetaResolver;
-  public customDataExtractor?: MCPToolCustomDataExtractor;
-  public useStructuredContent?: boolean;
-  public errorFunction?: MCPToolErrorFunction | null;
-
-  protected logger: Logger;
-  constructor(options: MCPServerSSEOptions) {
-    this.logger =
-      options.logger ?? getLogger(DEFAULT_SSE_MCP_CLIENT_LOGGER_NAME);
-    this.cacheToolsList = options.cacheToolsList ?? false;
-    this.toolFilter = options.toolFilter;
-    this.toolMetaResolver = options.toolMetaResolver;
-    this.customDataExtractor = options.customDataExtractor;
-    this.useStructuredContent = options.useStructuredContent;
-    this.errorFunction = options.errorFunction;
-  }
-
-  abstract get name(): string;
-  abstract connect(): Promise<void>;
-  abstract close(): Promise<void>;
-  abstract listTools(): Promise<any[]>;
-  abstract callTool(
-    _toolName: string,
-    _args: Record<string, unknown> | null,
-    _meta?: Record<string, unknown> | null,
-  ): Promise<CallToolResultContent>;
-  abstract callToolResult(
-    _toolName: string,
-    _args: Record<string, unknown> | null,
-    _meta?: Record<string, unknown> | null,
-  ): Promise<CallToolResult>;
-  abstract listResources(
-    _params?: MCPListResourcesParams,
-  ): Promise<MCPListResourcesResult>;
-  abstract listResourceTemplates(
-    _params?: MCPListResourcesParams,
-  ): Promise<MCPListResourceTemplatesResult>;
-  abstract readResource(_uri: string): Promise<MCPReadResourceResult>;
-  abstract invalidateToolsCache(): Promise<void>;
-
-  /**
-   * Logs a debug message when debug logging is enabled.
-   * @param buildMessage A function that returns the message to log.
-   */
-  protected debugLog(buildMessage: () => string): void {
-    if (debug.enabled(this.logger.namespace)) {
-      // only when this is true, the function to build the string is called
-      this.logger.debug(buildMessage());
-    }
-  }
-}
-
-/**
- * Minimum MCP tool data definition.
- * This type definition does not intend to cover all possible properties.
- * It supports the properties that are used in this SDK.
- */
-export const MCPTool = z.object({
-  name: z.string(),
-  description: z.string().optional(),
-  inputSchema: z.object({
-    type: z.literal('object'),
-    properties: z.record(z.string(), z.any()),
-    required: z.array(z.string()),
-    additionalProperties: z.boolean(),
-  }),
-});
-export type MCPTool = z.infer<typeof MCPTool>;
 
 /**
  * Public interface of an MCP server that provides tools.
@@ -601,31 +425,6 @@ export class MCPServerSSE
  * Fetches and flattens all tools from multiple MCP servers.
  * Logs and skips any servers that fail to respond.
  */
-
-const _cachedTools: Record<string, MCPTool[]> = {};
-const _cachedToolKeysByServer: Record<string, Set<string>> = {};
-/**
- * Remove cached tools for the given server so the next lookup fetches fresh data.
- *
- * @param serverName - Name of the MCP server whose cache should be cleared.
- */
-export async function invalidateServerToolsCache(serverName: string) {
-  const cachedKeys = _cachedToolKeysByServer[serverName];
-  if (cachedKeys) {
-    for (const cacheKey of cachedKeys) {
-      delete _cachedTools[cacheKey];
-    }
-    delete _cachedToolKeysByServer[serverName];
-    return;
-  }
-
-  delete _cachedTools[serverName];
-  for (const cacheKey of Object.keys(_cachedTools)) {
-    if (cacheKey.startsWith(`${serverName}:`)) {
-      delete _cachedTools[cacheKey];
-    }
-  }
-}
 
 /**
  * Function signature for generating the MCP tool cache key.
@@ -1521,26 +1320,6 @@ export type CallToolResultMetadata = Pick<
 >;
 export type CallToolResultContent = CallToolResult['content'] &
   CallToolResultMetadata;
-
-export function attachCallToolResultMetadata(
-  content: CallToolResult['content'],
-  metadata: CallToolResultMetadata,
-): CallToolResultContent {
-  const result = content as CallToolResultContent;
-  for (const [key, value] of Object.entries(metadata) as Array<
-    [keyof CallToolResultMetadata, unknown]
-  >) {
-    if (typeof value === 'undefined') {
-      continue;
-    }
-    Object.defineProperty(result, key, {
-      value,
-      enumerable: false,
-      configurable: true,
-    });
-  }
-  return result;
-}
 
 export interface InitializeResponse extends JsonRpcResponse {
   result: {

--- a/packages/agents-core/src/mcpShared.ts
+++ b/packages/agents-core/src/mcpShared.ts
@@ -1,0 +1,239 @@
+import debug from 'debug';
+import { z } from 'zod';
+import { getLogger, type Logger } from './logger';
+import type {
+  CallToolResult,
+  CallToolResultContent,
+  CallToolResultMetadata,
+  MCPListResourcesParams,
+  MCPListResourcesResult,
+  MCPListResourceTemplatesResult,
+  MCPReadResourceResult,
+  MCPServer,
+  MCPServerSSEOptions,
+  MCPServerStdioOptions,
+  MCPServerStreamableHttpOptions,
+  MCPToolErrorFunction,
+} from './mcp';
+import type {
+  MCPToolCustomDataExtractor,
+  MCPToolFilterCallable,
+  MCPToolFilterStatic,
+  MCPToolMetaResolver,
+} from './mcpUtil';
+
+export const DEFAULT_STDIO_MCP_CLIENT_LOGGER_NAME =
+  'openai-agents:stdio-mcp-client';
+
+export const DEFAULT_STREAMABLE_HTTP_MCP_CLIENT_LOGGER_NAME =
+  'openai-agents:streamable-http-mcp-client';
+
+export const DEFAULT_SSE_MCP_CLIENT_LOGGER_NAME =
+  'openai-agents:sse-mcp-client';
+
+export abstract class BaseMCPServerStdio implements MCPServer {
+  public cacheToolsList: boolean;
+  protected _cachedTools: any[] | undefined = undefined;
+  public toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
+  public toolMetaResolver?: MCPToolMetaResolver;
+  public customDataExtractor?: MCPToolCustomDataExtractor;
+  public useStructuredContent?: boolean;
+  public errorFunction?: MCPToolErrorFunction | null;
+
+  protected logger: Logger;
+  constructor(options: MCPServerStdioOptions) {
+    this.logger =
+      options.logger ?? getLogger(DEFAULT_STDIO_MCP_CLIENT_LOGGER_NAME);
+    this.cacheToolsList = options.cacheToolsList ?? false;
+    this.toolFilter = options.toolFilter;
+    this.toolMetaResolver = options.toolMetaResolver;
+    this.customDataExtractor = options.customDataExtractor;
+    this.useStructuredContent = options.useStructuredContent;
+    this.errorFunction = options.errorFunction;
+  }
+
+  abstract get name(): string;
+  abstract connect(): Promise<void>;
+  abstract close(): Promise<void>;
+  abstract listTools(): Promise<any[]>;
+  abstract callTool(
+    _toolName: string,
+    _args: Record<string, unknown> | null,
+    _meta?: Record<string, unknown> | null,
+  ): Promise<CallToolResultContent>;
+  abstract callToolResult(
+    _toolName: string,
+    _args: Record<string, unknown> | null,
+    _meta?: Record<string, unknown> | null,
+  ): Promise<CallToolResult>;
+  abstract listResources(
+    _params?: MCPListResourcesParams,
+  ): Promise<MCPListResourcesResult>;
+  abstract listResourceTemplates(
+    _params?: MCPListResourcesParams,
+  ): Promise<MCPListResourceTemplatesResult>;
+  abstract readResource(_uri: string): Promise<MCPReadResourceResult>;
+  abstract invalidateToolsCache(): Promise<void>;
+
+  /**
+   * Logs a debug message when debug logging is enabled.
+   * @param buildMessage A function that returns the message to log.
+   */
+  protected debugLog(buildMessage: () => string): void {
+    if (debug.enabled(this.logger.namespace)) {
+      // Only build the message when debug logging is enabled.
+      this.logger.debug(buildMessage());
+    }
+  }
+}
+
+export abstract class BaseMCPServerStreamableHttp implements MCPServer {
+  public cacheToolsList: boolean;
+  protected _cachedTools: any[] | undefined = undefined;
+  public toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
+  public toolMetaResolver?: MCPToolMetaResolver;
+  public customDataExtractor?: MCPToolCustomDataExtractor;
+  public useStructuredContent?: boolean;
+  public errorFunction?: MCPToolErrorFunction | null;
+
+  protected logger: Logger;
+  constructor(options: MCPServerStreamableHttpOptions) {
+    this.logger =
+      options.logger ??
+      getLogger(DEFAULT_STREAMABLE_HTTP_MCP_CLIENT_LOGGER_NAME);
+    this.cacheToolsList = options.cacheToolsList ?? false;
+    this.toolFilter = options.toolFilter;
+    this.toolMetaResolver = options.toolMetaResolver;
+    this.customDataExtractor = options.customDataExtractor;
+    this.useStructuredContent = options.useStructuredContent;
+    this.errorFunction = options.errorFunction;
+  }
+
+  abstract get name(): string;
+  abstract connect(): Promise<void>;
+  abstract close(): Promise<void>;
+  abstract listTools(): Promise<any[]>;
+  abstract callTool(
+    _toolName: string,
+    _args: Record<string, unknown> | null,
+    _meta?: Record<string, unknown> | null,
+  ): Promise<CallToolResultContent>;
+  abstract callToolResult(
+    _toolName: string,
+    _args: Record<string, unknown> | null,
+    _meta?: Record<string, unknown> | null,
+  ): Promise<CallToolResult>;
+  abstract listResources(
+    _params?: MCPListResourcesParams,
+  ): Promise<MCPListResourcesResult>;
+  abstract listResourceTemplates(
+    _params?: MCPListResourcesParams,
+  ): Promise<MCPListResourceTemplatesResult>;
+  abstract readResource(_uri: string): Promise<MCPReadResourceResult>;
+  abstract get sessionId(): string | undefined;
+  abstract invalidateToolsCache(): Promise<void>;
+
+  /**
+   * Logs a debug message when debug logging is enabled.
+   * @param buildMessage A function that returns the message to log.
+   */
+  protected debugLog(buildMessage: () => string): void {
+    if (debug.enabled(this.logger.namespace)) {
+      // Only build the message when debug logging is enabled.
+      this.logger.debug(buildMessage());
+    }
+  }
+}
+
+export abstract class BaseMCPServerSSE implements MCPServer {
+  public cacheToolsList: boolean;
+  protected _cachedTools: any[] | undefined = undefined;
+  public toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
+  public toolMetaResolver?: MCPToolMetaResolver;
+  public customDataExtractor?: MCPToolCustomDataExtractor;
+  public useStructuredContent?: boolean;
+  public errorFunction?: MCPToolErrorFunction | null;
+
+  protected logger: Logger;
+  constructor(options: MCPServerSSEOptions) {
+    this.logger =
+      options.logger ?? getLogger(DEFAULT_SSE_MCP_CLIENT_LOGGER_NAME);
+    this.cacheToolsList = options.cacheToolsList ?? false;
+    this.toolFilter = options.toolFilter;
+    this.toolMetaResolver = options.toolMetaResolver;
+    this.customDataExtractor = options.customDataExtractor;
+    this.useStructuredContent = options.useStructuredContent;
+    this.errorFunction = options.errorFunction;
+  }
+
+  abstract get name(): string;
+  abstract connect(): Promise<void>;
+  abstract close(): Promise<void>;
+  abstract listTools(): Promise<any[]>;
+  abstract callTool(
+    _toolName: string,
+    _args: Record<string, unknown> | null,
+    _meta?: Record<string, unknown> | null,
+  ): Promise<CallToolResultContent>;
+  abstract callToolResult(
+    _toolName: string,
+    _args: Record<string, unknown> | null,
+    _meta?: Record<string, unknown> | null,
+  ): Promise<CallToolResult>;
+  abstract listResources(
+    _params?: MCPListResourcesParams,
+  ): Promise<MCPListResourcesResult>;
+  abstract listResourceTemplates(
+    _params?: MCPListResourcesParams,
+  ): Promise<MCPListResourceTemplatesResult>;
+  abstract readResource(_uri: string): Promise<MCPReadResourceResult>;
+  abstract invalidateToolsCache(): Promise<void>;
+
+  /**
+   * Logs a debug message when debug logging is enabled.
+   * @param buildMessage A function that returns the message to log.
+   */
+  protected debugLog(buildMessage: () => string): void {
+    if (debug.enabled(this.logger.namespace)) {
+      // Only build the message when debug logging is enabled.
+      this.logger.debug(buildMessage());
+    }
+  }
+}
+
+/**
+ * Minimum MCP tool data definition.
+ * This type definition does not intend to cover all possible properties.
+ * It supports the properties that are used in this SDK.
+ */
+export const MCPTool = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  inputSchema: z.object({
+    type: z.literal('object'),
+    properties: z.record(z.string(), z.any()),
+    required: z.array(z.string()),
+    additionalProperties: z.boolean(),
+  }),
+});
+export type MCPTool = z.infer<typeof MCPTool>;
+
+export function attachCallToolResultMetadata(
+  content: CallToolResult['content'],
+  metadata: CallToolResultMetadata,
+): CallToolResultContent {
+  const result = content as CallToolResultContent;
+  for (const [key, value] of Object.entries(metadata) as Array<
+    [keyof CallToolResultMetadata, unknown]
+  >) {
+    if (typeof value === 'undefined') {
+      continue;
+    }
+    Object.defineProperty(result, key, {
+      value,
+      enumerable: false,
+      configurable: true,
+    });
+  }
+  return result;
+}

--- a/packages/agents-core/src/mcpToolCache.ts
+++ b/packages/agents-core/src/mcpToolCache.ts
@@ -1,0 +1,27 @@
+import type { MCPTool } from './mcpShared';
+
+export const cachedMcpTools: Record<string, MCPTool[]> = {};
+export const cachedMcpToolKeysByServer: Record<string, Set<string>> = {};
+
+/**
+ * Remove cached tools for the given server so the next lookup fetches fresh data.
+ *
+ * @param serverName - Name of the MCP server whose cache should be cleared.
+ */
+export async function invalidateServerToolsCache(serverName: string) {
+  const cachedKeys = cachedMcpToolKeysByServer[serverName];
+  if (cachedKeys) {
+    for (const cacheKey of cachedKeys) {
+      delete cachedMcpTools[cacheKey];
+    }
+    delete cachedMcpToolKeysByServer[serverName];
+    return;
+  }
+
+  delete cachedMcpTools[serverName];
+  for (const cacheKey of Object.keys(cachedMcpTools)) {
+    if (cacheKey.startsWith(`${serverName}:`)) {
+      delete cachedMcpTools[cacheKey];
+    }
+  }
+}

--- a/packages/agents-core/src/shims/config-browser.ts
+++ b/packages/agents-core/src/shims/config-browser.ts
@@ -1,0 +1,7 @@
+export function loadEnv(): Record<string, string | undefined> {
+  return {};
+}
+
+export function isBrowserEnvironment(): boolean {
+  return true;
+}

--- a/packages/agents-core/src/shims/config-node.ts
+++ b/packages/agents-core/src/shims/config-node.ts
@@ -1,0 +1,31 @@
+import * as process from 'node:process';
+
+declare global {
+  interface ImportMeta {
+    env?: Record<string, string | undefined>;
+  }
+}
+
+export function loadEnv(): Record<string, string | undefined> {
+  if (typeof process === 'undefined' || typeof process.env === 'undefined') {
+    // In CommonJS builds, import.meta is not available, so we return empty object.
+    try {
+      // Use eval to avoid TypeScript compilation errors in CommonJS builds.
+      const importMeta = (0, eval)('import.meta');
+      if (
+        typeof importMeta === 'object' &&
+        typeof importMeta.env === 'object'
+      ) {
+        return importMeta.env as unknown as Record<string, string | undefined>;
+      }
+    } catch {
+      // import.meta is not available.
+    }
+    return {};
+  }
+  return process.env;
+}
+
+export function isBrowserEnvironment(): boolean {
+  return false;
+}

--- a/packages/agents-core/src/shims/config-workerd.ts
+++ b/packages/agents-core/src/shims/config-workerd.ts
@@ -1,0 +1,5 @@
+export { loadEnv } from './config-node';
+
+export function isBrowserEnvironment(): boolean {
+  return false;
+}

--- a/packages/agents-core/src/shims/mcp-server/browser.ts
+++ b/packages/agents-core/src/shims/mcp-server/browser.ts
@@ -2,6 +2,8 @@ import {
   BaseMCPServerSSE,
   BaseMCPServerStdio,
   BaseMCPServerStreamableHttp,
+} from '../../mcpShared';
+import type {
   CallToolResult,
   CallToolResultContent,
   MCPListResourcesParams,

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -7,6 +7,11 @@ import {
   BaseMCPServerStdio,
   BaseMCPServerStreamableHttp,
   BaseMCPServerSSE,
+  MCPTool,
+  attachCallToolResultMetadata,
+} from '../../mcpShared';
+import { invalidateServerToolsCache } from '../../mcpToolCache';
+import type {
   CallToolResult,
   CallToolResultContent,
   DefaultMCPServerStdioOptions,
@@ -18,9 +23,6 @@ import {
   MCPServerStdioOptions,
   MCPServerStreamableHttpOptions,
   MCPServerSSEOptions,
-  MCPTool,
-  attachCallToolResultMetadata,
-  invalidateServerToolsCache,
 } from '../../mcp';
 import logger from '../../logger';
 

--- a/packages/agents-core/src/shims/shims-browser.ts
+++ b/packages/agents-core/src/shims/shims-browser.ts
@@ -2,12 +2,7 @@
 
 export { EventEmitter, EventEmitterEvents } from './interface';
 import { EventEmitter, Timeout, Timer } from './interface';
-
-// Use function instead of exporting the value to prevent
-// circular dependency resolution issues caused by other exports in '@openai/agents-core/_shims'
-export function loadEnv(): Record<string, string | undefined> {
-  return {};
-}
+export { isBrowserEnvironment, loadEnv } from './config-browser';
 
 type EventMap = Record<string, any[]>;
 
@@ -210,10 +205,6 @@ export class AsyncLocalStorage<T = any> {
     }
     this.context = context;
   }
-}
-
-export function isBrowserEnvironment(): boolean {
-  return true;
 }
 
 export function isTracingLoopRunningByDefault(): boolean {

--- a/packages/agents-core/src/shims/shims-node.ts
+++ b/packages/agents-core/src/shims/shims-node.ts
@@ -1,36 +1,8 @@
-import * as process from 'node:process';
 import { Timeout, Timer } from './interface';
 
 export { EventEmitter, EventEmitterEvents } from './interface';
 export { EventEmitter as RuntimeEventEmitter } from 'node:events';
-
-declare global {
-  interface ImportMeta {
-    env?: Record<string, string | undefined>;
-  }
-}
-
-// Use function instead of exporting the value to prevent
-// circular dependency resolution issues caused by other exports in '@openai/agents-core/_shims'
-export function loadEnv(): Record<string, string | undefined> {
-  if (typeof process === 'undefined' || typeof process.env === 'undefined') {
-    // In CommonJS builds, import.meta is not available, so we return empty object
-    try {
-      // Use eval to avoid TypeScript compilation errors in CommonJS builds
-      const importMeta = (0, eval)('import.meta');
-      if (
-        typeof importMeta === 'object' &&
-        typeof importMeta.env === 'object'
-      ) {
-        return importMeta.env as unknown as Record<string, string | undefined>;
-      }
-    } catch {
-      // import.meta not available (CommonJS build)
-    }
-    return {};
-  }
-  return process.env;
-}
+export { isBrowserEnvironment, loadEnv } from './config-node';
 
 export { randomUUID } from 'node:crypto';
 export { Readable } from 'node:stream';
@@ -45,9 +17,6 @@ export function isTracingLoopRunningByDefault(): boolean {
   return true;
 }
 
-export function isBrowserEnvironment(): boolean {
-  return false;
-}
 export {
   NodeMCPServerStdio as MCPServerStdio,
   NodeMCPServerStreamableHttp as MCPServerStreamableHttp,

--- a/packages/agents-core/src/shims/shims-workerd.ts
+++ b/packages/agents-core/src/shims/shims-workerd.ts
@@ -1,37 +1,9 @@
-import * as process from 'node:process';
 import { AsyncLocalStorage as BuiltinAsyncLocalStorage } from 'node:async_hooks';
 export { EventEmitter as RuntimeEventEmitter } from 'node:events';
 
 import { Timeout, Timer } from './interface';
 export { EventEmitter, EventEmitterEvents } from './interface';
-
-declare global {
-  interface ImportMeta {
-    env?: Record<string, string | undefined>;
-  }
-}
-
-// Use function instead of exporting the value to prevent
-// circular dependency resolution issues caused by other exports in '@openai/agents-core/_shims'
-export function loadEnv(): Record<string, string | undefined> {
-  if (typeof process === 'undefined' || typeof process.env === 'undefined') {
-    // In CommonJS builds, import.meta is not available, so we return empty object
-    try {
-      // Use eval to avoid TypeScript compilation errors in CommonJS builds
-      const importMeta = (0, eval)('import.meta');
-      if (
-        typeof importMeta === 'object' &&
-        typeof importMeta.env === 'object'
-      ) {
-        return importMeta.env as unknown as Record<string, string | undefined>;
-      }
-    } catch {
-      // import.meta not available (CommonJS build)
-    }
-    return {};
-  }
-  return process.env;
-}
+export { isBrowserEnvironment, loadEnv } from './config-workerd';
 
 export { randomUUID } from 'node:crypto';
 export { Readable } from 'node:stream';
@@ -46,10 +18,6 @@ export class AsyncLocalStorage<T> extends BuiltinAsyncLocalStorage<T> {
     // Cloudflare workers does not support enterWith, so we need to use run instead
     super.run(context, () => {});
   }
-}
-
-export function isBrowserEnvironment(): boolean {
-  return false;
 }
 
 export function isTracingLoopRunningByDefault(): boolean {

--- a/packages/agents-core/tsconfig.json
+++ b/packages/agents-core/tsconfig.json
@@ -5,7 +5,8 @@
     "rootDir": "./src",
     "paths": {
       "@openai/agents-core": ["./src/index.ts"],
-      "@openai/agents-core/_shims": ["./src/shims/shims-node.ts"]
+      "@openai/agents-core/_shims": ["./src/shims/shims-node.ts"],
+      "@openai/agents-core/_shims/config": ["./src/shims/config-node.ts"]
     }
   },
   "exclude": ["dist/**", "test/**"]

--- a/packages/agents-core/tsconfig.test.json
+++ b/packages/agents-core/tsconfig.test.json
@@ -4,7 +4,8 @@
     "outDir": "./dist",
     "paths": {
       "@openai/agents-core": ["./src/index.ts"],
-      "@openai/agents-core/_shims": ["./src/shims/shims-node.ts"]
+      "@openai/agents-core/_shims": ["./src/shims/shims-node.ts"],
+      "@openai/agents-core/_shims/config": ["./src/shims/config-node.ts"]
     }
   },
   "include": ["src/**/*.ts", "test/**/*.ts"],

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -3,7 +3,8 @@
     "outDir": "./dist",
     "paths": {
       "@openai/agents-core": ["./src/index.ts"],
-      "@openai/agents-core/_shims": ["./src/shims/shims-node.ts"]
+      "@openai/agents-core/_shims": ["./src/shims/shims-node.ts"],
+      "@openai/agents-core/_shims/config": ["./src/shims/config-node.ts"]
     }
   },
   "include": ["src/**/*.ts", "test/**/*.ts"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,50 +1,22 @@
-import { readFileSync, readdirSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
+import {
+  createWorkspacePackageAliases,
+  readWorkspacePackages,
+} from './helpers/vitest/workspacePackageAliases';
 
 const rootDir = dirname(fileURLToPath(import.meta.url));
 const packagesDir = resolve(rootDir, 'packages');
-const testAliases = {
-  '@openai/agents-core/utils/internal': resolve(
-    rootDir,
-    'packages/agents-core/src/utils/internal.ts',
-  ),
-  '@openai/agents-core/sandbox/local': resolve(
-    rootDir,
-    'packages/agents-core/src/sandbox/local.ts',
-  ),
-  '@openai/agents-core/sandbox/internal/process': resolve(
-    rootDir,
-    'packages/agents-core/src/sandbox/internal/process.ts',
-  ),
-  '@openai/agents-core/sandbox/internal': resolve(
-    rootDir,
-    'packages/agents-core/src/sandbox/internal.ts',
-  ),
-  '@openai/agents-core/sandbox': resolve(
-    rootDir,
-    'packages/agents-core/src/sandbox/index.ts',
-  ),
-};
+const workspacePackages = readWorkspacePackages(packagesDir);
+const testAliases = createWorkspacePackageAliases(workspacePackages);
 
 const baseTestConfig = {
   setupFiles: [resolve(rootDir, 'helpers/tests/console-guard.ts')],
   globalSetup: resolve(rootDir, 'helpers/tests/setup.ts'),
 };
 
-const packageEntries = readdirSync(packagesDir, { withFileTypes: true }).filter(
-  (entry) => entry.isDirectory(),
-);
-
-const packageProjects = packageEntries.map((entry) => {
-  const root = resolve(packagesDir, entry.name);
-  const packageJsonPath = resolve(root, 'package.json');
-  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
-    name?: string;
-  };
-  const name = packageJson.name ?? entry.name;
-
+const packageProjects = workspacePackages.map(({ name, root }) => {
   return {
     root,
     resolve: {
@@ -60,9 +32,17 @@ const packageProjects = packageEntries.map((entry) => {
 
 export default defineConfig({
   test: {
-    alias: testAliases,
     pool: 'threads',
-    projects: packageProjects,
+    projects: [
+      {
+        root: rootDir,
+        test: {
+          name: 'workspace-test-config',
+          include: ['helpers/vitest/workspacePackageAliases.test.ts'],
+        },
+      },
+      ...packageProjects,
+    ],
     // Coverage options are global in Vitest workspaces.
     // Keep the filter at the root to avoid scanning docs/examples/dist output.
     coverage: {


### PR DESCRIPTION
This pull request fixes workspace package resolution in Vitest by deriving source aliases from each package's published exports.

It adds regression coverage for all workspace exports and separates lightweight configuration shims from MCP runtime initialization, allowing `@openai/agents-core` tests to run without prebuilt `dist` output while preserving the existing public API.