### PR TITLE
fix: restore run usage when deserializing RunState

### DIFF
--- a/.changeset/restore-runstate-usage.md
+++ b/.changeset/restore-runstate-usage.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: restore run usage when deserializing RunState

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -1171,8 +1171,7 @@ function containsToolSearchProtocolItems(
 
 function containsToolSearchInProcessedResponse(
   processedResponse:
-    | z.infer<typeof serializedProcessedResponseSchema>
-    | undefined,
+    z.infer<typeof serializedProcessedResponseSchema> | undefined,
 ): boolean {
   return containsToolSearchRunItems(processedResponse?.newItems);
 }
@@ -1519,6 +1518,19 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
     typeof context.toolInput === 'undefined'
   ) {
     context.toolInput = stateJson.context.toolInput;
+  }
+
+  // Restore the aggregated run usage. toJSON serializes context.usage, but a
+  // freshly constructed RunContext starts with an empty Usage, so without this
+  // a resumed run reports zero token usage.
+  //
+  // Only restore on the no-override path. A caller-supplied RunContext is
+  // authoritative and owns its usage accounting: its counters do not reveal
+  // whether its Usage is newly owned or shared with another run (for example a
+  // nested agent-tool resume passes a context whose usage aggregate is shared
+  // with the outer run), so it is left untouched.
+  if (!contextOverride) {
+    context.usage = new Usage(stateJson.context.usage);
   }
 
   //

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -195,6 +195,129 @@ describe('RunState', () => {
     });
   });
 
+  it('restores aggregated run usage after serialization', async () => {
+    const context = new RunContext();
+    const agent = new Agent({ name: 'UsageState' });
+    const state = new RunState(context, 'input', agent, 1);
+    state._context.usage.add(
+      new Usage({
+        requests: 1,
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+      }),
+    );
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(restored.usage.requests).toBe(1);
+    expect(restored.usage.inputTokens).toBe(100);
+    expect(restored.usage.outputTokens).toBe(50);
+    expect(restored.usage.totalTokens).toBe(150);
+    expect(restored.usage.requestUsageEntries).toHaveLength(1);
+  });
+
+  it('does not double-count usage when resuming with an override context', async () => {
+    const agent = new Agent({ name: 'UsageOverrideState' });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    state._context.usage.add(
+      new Usage({
+        requests: 1,
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+      }),
+    );
+
+    // The override context is authoritative (e.g. a nested agent-tool resume
+    // passes the live outer context that already shares this usage), so its
+    // usage must be left untouched rather than added to.
+    const overrideContext = new RunContext();
+    overrideContext.usage.add(
+      new Usage({
+        requests: 1,
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+      }),
+    );
+
+    const restored = await RunState.fromStringWithContext(
+      agent,
+      state.toString(),
+      overrideContext,
+    );
+
+    expect(restored.usage.requests).toBe(1);
+    expect(restored.usage.inputTokens).toBe(100);
+    expect(restored.usage.outputTokens).toBe(50);
+    expect(restored.usage.totalTokens).toBe(150);
+  });
+
+  it('leaves a fresh override context usage untouched', async () => {
+    const agent = new Agent({ name: 'UsageFreshOverrideState' });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    state._context.usage.add(
+      new Usage({
+        requests: 1,
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+      }),
+    );
+
+    // A caller-supplied RunContext is authoritative: even a fresh one with zero
+    // usage is left untouched. Its counters do not reveal whether its Usage is
+    // newly owned or shared with another run, so it does not inherit the
+    // serialized usage.
+    const restored = await RunState.fromStringWithContext(
+      agent,
+      state.toString(),
+      new RunContext(),
+    );
+
+    expect(restored.usage.requests).toBe(0);
+    expect(restored.usage.inputTokens).toBe(0);
+    expect(restored.usage.outputTokens).toBe(0);
+    expect(restored.usage.totalTokens).toBe(0);
+  });
+
+  it('keeps a shared usage reference when resuming a forked context', async () => {
+    const agent = new Agent({ name: 'UsageSharedRefState' });
+    // A nested run that made no model call before interruption serializes zero
+    // usage.
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+
+    // A nested agent-tool resume passes a forked context that shares its usage
+    // object with the outer run.
+    const outer = new RunContext();
+    const forked = new RunContext();
+    forked.usage = outer.usage;
+
+    const restored = await RunState.fromStringWithContext(
+      agent,
+      state.toString(),
+      forked,
+    );
+
+    // The forked context's Usage must remain the very object shared with the
+    // outer run (a replace would have severed the reference).
+    expect(restored.usage).toBe(outer.usage);
+
+    // Usage recorded after resume must still reach the outer run through the
+    // shared reference (a replace would have severed it).
+    forked.usage.add(
+      new Usage({
+        requests: 1,
+        inputTokens: 20,
+        outputTokens: 10,
+        totalTokens: 30,
+      }),
+    );
+    expect(outer.usage.requests).toBe(1);
+    expect(outer.usage.totalTokens).toBe(30);
+  });
+
   it('preserves requestId on serialized model responses', async () => {
     const context = new RunContext();
     const agent = new Agent({ name: 'RequestIdState' });


### PR DESCRIPTION
## What

`RunContext.toJSON()` serializes the aggregated run usage (`usage: this.usage`), and it ends up in the serialized run state. But on deserialization, `buildRunStateFromJson` constructs a fresh `RunContext`:

```ts
const context =
  contextOverride ??
  new RunContext<TContext>(stateJson.context.context as TContext);
```

…and never restores the usage. The `RunContext` constructor sets `this.usage = new Usage()` (all zeros), so `RunState.fromString(...)` returns a run whose usage is reset to zero. Any run resumed from a serialized state then under-reports token usage (billing / observability). Approvals and `toolInput` are restored right below — usage was just missing.

## Fix

Restore `context.usage` from the serialized state on the **no-override path only**. A caller-supplied `RunContext` is authoritative and owns its usage accounting, so it is left untouched:

```ts
if (!contextOverride) {
  context.usage = new Usage(stateJson.context.usage);
}
```

A supplied context's zero counters do not establish whether its `Usage` is newly owned or shared with another run — e.g. a nested `Agent.asTool()` resume passes a context whose usage accumulator is shared with the outer run — so restoring into it could either double-count or sever the shared reference. Leaving it untouched is correct in every override case. `Usage`'s constructor faithfully reconstructs the aggregate (including `requestUsageEntries`), so nothing is lost on the default path.

## Tests

`packages/agents-core/test/runState.test.ts`:

- **default deserialization** — `fromString` round-trips a state with usage and asserts requests/tokens and per-request entries are preserved;
- **override with existing usage is not double-counted** — `fromStringWithContext` with a context that already has usage leaves it untouched;
- **fresh override is left untouched** — a fresh `RunContext` does not inherit the serialized usage;
- **shared reference preserved** — a forked context that shares its `Usage` with a parent keeps that object identity (`restored.usage === outer.usage`), so usage recorded after resume still reaches the outer run.

All pass; eslint, tsc, and the full `agents-core` suite pass.
