### PR TITLE
fix(openai): support openai 6.46.0 usage types

### DIFF
--- a/.changeset/bright-caches-write.md
+++ b/.changeset/bright-caches-write.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: decouple Chat Completions usage from Responses types

--- a/.changeset/bright-caches-write.md
+++ b/.changeset/bright-caches-write.md
@@ -1,5 +1,7 @@
 ---
+'@openai/agents': patch
+'@openai/agents-core': patch
 '@openai/agents-openai': patch
 ---
 
-fix: decouple Chat Completions usage from Responses types
+fix: support openai-node v6.46.0 usage types

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -3,7 +3,7 @@
   "name": "basic",
   "dependencies": {
     "@openai/agents": "workspace:*",
-    "openai": "^6.42.0",
+    "openai": "^6.46.0",
     "zod": "^4.0.0"
   },
   "scripts": {

--- a/examples/docs/package.json
+++ b/examples/docs/package.json
@@ -8,7 +8,7 @@
     "@openai/agents-core": "workspace:*",
     "@openai/agents-extensions": "workspace:*",
     "@openai/agents-realtime": "workspace:*",
-    "openai": "^6.42.0",
+    "openai": "^6.46.0",
     "server-only": "^0.0.1",
     "zod": "^4.0.0"
   },

--- a/examples/model-providers/package.json
+++ b/examples/model-providers/package.json
@@ -3,7 +3,7 @@
   "name": "model-providers",
   "dependencies": {
     "@openai/agents": "workspace:*",
-    "openai": "^6.42.0",
+    "openai": "^6.46.0",
     "zod": "^4.0.0"
   },
   "scripts": {

--- a/examples/realtime-demo/package.json
+++ b/examples/realtime-demo/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@openai/agents-realtime": "workspace:*",
     "@tailwindcss/vite": "^4.1.7",
-    "openai": "^6.42.0",
+    "openai": "^6.46.0",
     "tailwindcss": "^4.1.7",
     "zod": "^4.0.0"
   }

--- a/examples/realtime-twilio-sip/package.json
+++ b/examples/realtime-twilio-sip/package.json
@@ -8,7 +8,7 @@
     "dotenv": "^16.5.0",
     "fastify": "^5.8.5",
     "fastify-raw-body": "^5.0.0",
-    "openai": "^6.42.0",
+    "openai": "^6.46.0",
     "zod": "^4.0.0"
   },
   "scripts": {

--- a/examples/tools/package.json
+++ b/examples/tools/package.json
@@ -8,7 +8,7 @@
     "@openai/agents-extensions": "workspace:*",
     "@openai/codex-sdk": "^0.86.0",
     "chalk": "^5.6.2",
-    "openai": "^6.42.0",
+    "openai": "^6.46.0",
     "playwright": "^1.55.1",
     "zod": "^4.0.0"
   },

--- a/packages/agents-core/package.json
+++ b/packages/agents-core/package.json
@@ -97,7 +97,7 @@
   },
   "dependencies": {
     "debug": "^4.4.0",
-    "openai": "^6.42.0"
+    "openai": "^6.46.0"
   },
   "peerDependencies": {
     "zod": "^4.0.0"

--- a/packages/agents-core/src/metadata.ts
+++ b/packages/agents-core/src/metadata.ts
@@ -6,7 +6,7 @@ export const METADATA = {
   "version": "0.13.0",
   "versions": {
     "@openai/agents-core": "0.13.0",
-    "openai": "^6.42.0"
+    "openai": "^6.46.0"
   }
 };
 

--- a/packages/agents-openai/package.json
+++ b/packages/agents-openai/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@openai/agents-core": "workspace:*",
     "debug": "^4.4.0",
-    "openai": "^6.42.0"
+    "openai": "^6.46.0"
   },
   "scripts": {
     "prebuild": "tsx ../../scripts/embedMeta.ts",

--- a/packages/agents-openai/src/metadata.ts
+++ b/packages/agents-openai/src/metadata.ts
@@ -7,7 +7,7 @@ export const METADATA = {
   "versions": {
     "@openai/agents-openai": "0.13.0",
     "@openai/agents-core": "workspace:*",
-    "openai": "^6.42.0"
+    "openai": "^6.46.0"
   }
 };
 

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -14,6 +14,7 @@ import type {
   ModelResponse,
   ResponseStreamEvent,
   SerializedOutputType,
+  UsageInput,
 } from '@openai/agents-core';
 import OpenAI from 'openai';
 import type { Stream } from 'openai/streaming';
@@ -559,7 +560,7 @@ function getResponseFormat(
 
 function toResponseUsage(
   usage: CompletionUsage,
-): OpenAI.Responses.ResponseUsage & { requests: number } {
+): UsageInput & { requests: number } {
   return {
     requests: 1,
     input_tokens: usage.prompt_tokens,

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -45,7 +45,7 @@
     "@openai/agents-openai": "workspace:*",
     "@openai/agents-realtime": "workspace:*",
     "debug": "^4.4.0",
-    "openai": "^6.42.0"
+    "openai": "^6.46.0"
   },
   "keywords": [
     "openai",

--- a/packages/agents/src/metadata.ts
+++ b/packages/agents/src/metadata.ts
@@ -9,7 +9,7 @@ export const METADATA = {
     "@openai/agents-core": "workspace:*",
     "@openai/agents-openai": "workspace:*",
     "@openai/agents-realtime": "workspace:*",
-    "openai": "^6.42.0"
+    "openai": "^6.46.0"
   }
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,8 +246,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/agents
       openai:
-        specifier: ^6.42.0
-        version: 6.44.0(ws@8.21.0)(zod@4.3.5)
+        specifier: ^6.46.0
+        version: 6.46.0(@aws-sdk/credential-provider-node@3.972.33)(ws@8.21.0)(zod@4.3.5)
       zod:
         specifier: ^4.0.0
         version: 4.3.5
@@ -291,8 +291,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/agents-realtime
       openai:
-        specifier: ^6.42.0
-        version: 6.44.0(ws@8.21.0)(zod@4.3.5)
+        specifier: ^6.46.0
+        version: 6.46.0(@aws-sdk/credential-provider-node@3.972.33)(ws@8.21.0)(zod@4.3.5)
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
@@ -359,8 +359,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/agents
       openai:
-        specifier: ^6.42.0
-        version: 6.44.0(ws@8.21.0)(zod@4.3.5)
+        specifier: ^6.46.0
+        version: 6.46.0(@aws-sdk/credential-provider-node@3.972.33)(ws@8.21.0)(zod@4.3.5)
       zod:
         specifier: ^4.0.0
         version: 4.3.5
@@ -438,8 +438,8 @@ importers:
         specifier: ^4.1.7
         version: 4.1.10(vite@6.4.3(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
       openai:
-        specifier: ^6.42.0
-        version: 6.44.0(ws@8.21.0)(zod@4.3.5)
+        specifier: ^6.46.0
+        version: 6.46.0(@aws-sdk/credential-provider-node@3.972.33)(ws@8.21.0)(zod@4.3.5)
       tailwindcss:
         specifier: ^4.1.7
         version: 4.1.10
@@ -554,8 +554,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       openai:
-        specifier: ^6.42.0
-        version: 6.44.0(ws@8.21.0)(zod@4.3.5)
+        specifier: ^6.46.0
+        version: 6.46.0(@aws-sdk/credential-provider-node@3.972.33)(ws@8.21.0)(zod@4.3.5)
       zod:
         specifier: ^4.0.0
         version: 4.3.5
@@ -599,8 +599,8 @@ importers:
         specifier: ^5.6.2
         version: 5.6.2
       openai:
-        specifier: ^6.42.0
-        version: 6.44.0(ws@8.21.0)(zod@4.3.5)
+        specifier: ^6.46.0
+        version: 6.46.0(@aws-sdk/credential-provider-node@3.972.33)(ws@8.21.0)(zod@4.3.5)
       playwright:
         specifier: ^1.55.1
         version: 1.57.0
@@ -623,8 +623,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.1
       openai:
-        specifier: ^6.42.0
-        version: 6.44.0(ws@8.21.0)(zod@4.3.5)
+        specifier: ^6.46.0
+        version: 6.46.0(@aws-sdk/credential-provider-node@3.972.33)(ws@8.21.0)(zod@4.3.5)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -639,8 +639,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.1
       openai:
-        specifier: ^6.42.0
-        version: 6.44.0(ws@8.21.0)(zod@4.3.5)
+        specifier: ^6.46.0
+        version: 6.46.0(@aws-sdk/credential-provider-node@3.972.33)(ws@8.21.0)(zod@4.3.5)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -720,8 +720,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.1
       openai:
-        specifier: ^6.42.0
-        version: 6.44.0(ws@8.21.0)(zod@4.3.5)
+        specifier: ^6.46.0
+        version: 6.46.0(@aws-sdk/credential-provider-node@3.972.33)(ws@8.21.0)(zod@4.3.5)
     devDependencies:
       '@ai-sdk/provider':
         specifier: ^1.1.3
@@ -6200,6 +6200,26 @@ packages:
       ws: ^8.18.0
       zod: ^3.25 || ^4.0
     peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
+  openai@6.46.0:
+    resolution: {integrity: sha512-DFg6jEPT2RO+oAyXtddeUJU8zkGy1OQ1AjGzNIJUMQG03TTqvCpy9tBpQ+2VVVnvrl3E56F8GEin2JYtWpITtA==}
+    peerDependencies:
+      '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
+      '@smithy/hash-node': '>=4.3.0 <5'
+      '@smithy/signature-v4': '>=5.4.0 <6'
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-node':
+        optional: true
+      '@smithy/hash-node':
+        optional: true
+      '@smithy/signature-v4':
+        optional: true
       ws:
         optional: true
       zod:
@@ -14574,8 +14594,9 @@ snapshots:
       ws: 8.21.0
       zod: 3.25.76
 
-  openai@6.44.0(ws@8.21.0)(zod@4.3.5):
+  openai@6.46.0(@aws-sdk/credential-provider-node@3.972.33)(ws@8.21.0)(zod@4.3.5):
     optionalDependencies:
+      '@aws-sdk/credential-provider-node': 3.972.33
       ws: 8.21.0
       zod: 4.3.5
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,5 +21,7 @@ overrides:
 
 publishBranch: main
 minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - openai@6.46.0
 blockExoticSubdeps: true
 strictDepBuilds: true


### PR DESCRIPTION
## Summary

- Type the Chat Completions usage adapter as Agents SDK `UsageInput` instead of the generated Responses API `ResponseUsage`.
- Bump the workspace's direct `openai` dependencies to `^6.46.0` across the published packages and examples, and regenerate package metadata.
- Add a version-specific `minimumReleaseAgeExclude` for `openai@6.46.0` so the just-published launch SDK can pass the repository's normal frozen install policy.
- Add patch changesets for `@openai/agents`, `@openai/agents-core`, and `@openai/agents-openai`.

## Why

[openai/openai-node#1959](https://github.com/openai/openai-node/pull/1959) shipped `openai@6.46.0` with the required `cache_write_tokens` field on `ResponseUsage.InputTokensDetails`. The downstream Agents SDK regression check failed with TS2741 because `toResponseUsage()` synthesizes an Agents usage object containing only `cached_tokens`, while its return annotation incorrectly required the full Responses API output schema.

The value is immediately passed to `new Usage(...)`, whose supported input boundary is `UsageInput`. Using that type removes the accidental coupling to generated API output fields and lets required Responses outputs remain required.

The dependency floor and workspace examples now all use 6.46 so TypeScript does not load nominally incompatible `OpenAI` classes from 6.44 and 6.46 in the same build. The cooldown exception is scoped to exactly `openai@6.46.0`, not the package generally.

## Impact

There is no runtime behavior change in the usage adapter. Published Agents packages now require `openai@^6.46.0`, and the workspace explicitly validates against the GPT-5.6 launch SDK.

## Validation

- `pnpm changeset:validate-prompt` (patch bumps validated)
- `pnpm install --frozen-lockfile` (normal supply-chain policy passed)
- `bash .agents/skills/code-change-verification/scripts/run.sh`
- Reproduced the original downstream check with the built SDK from openai/openai-node#1959 linked into a scratch checkout:
  - `pnpm build`
  - `pnpm lint`
  - `pnpm docs:scripts:check`
