### PR TITLE
feat: add compatible defaults for GPT-5.6 model families

### DIFF
--- a/.changeset/gpt-56-model-families.md
+++ b/.changeset/gpt-56-model-families.md
@@ -4,4 +4,4 @@
 '@openai/agents-openai': patch
 ---
 
-feat: add compatible defaults for the gpt-5.6 alias, sol, terra, and luna
+feat: add GPT-5.6 model defaults, reasoning, and sandbox compaction support

--- a/.changeset/gpt-56-model-families.md
+++ b/.changeset/gpt-56-model-families.md
@@ -4,4 +4,4 @@
 '@openai/agents-openai': patch
 ---
 
-feat: add compatible defaults for gpt-5.6 sol, terra, and luna
+feat: add compatible defaults for the gpt-5.6 alias, sol, terra, and luna

--- a/.changeset/gpt-56-model-families.md
+++ b/.changeset/gpt-56-model-families.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents': patch
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+---
+
+feat: add compatible defaults for gpt-5.6 sol, terra, and luna

--- a/docs/src/content/docs/guides/models.mdx
+++ b/docs/src/content/docs/guides/models.mdx
@@ -34,12 +34,12 @@ In day‑to‑day work you normally only interact with model **names** and occas
 
 When you don't specify a model when initializing an `Agent`, the default model will be used. The default is currently [`gpt-5.4-mini`](https://developers.openai.com/api/docs/models/gpt-5.4-mini) with `reasoning.effort: "none"` and `text.verbosity: "low"` for a balance of quality and latency.
 
-If you want to switch to another model like [`gpt-5.5`](https://developers.openai.com/api/docs/models/gpt-5.5), there are two ways to configure your agents.
+If you want to switch to another model like `gpt-5.6-sol`, there are two ways to configure your agents.
 
 First, if you want to consistently use a specific model for all agents that do not set a custom model, set the `OPENAI_DEFAULT_MODEL` environment variable before running your agents.
 
 ```bash
-export OPENAI_DEFAULT_MODEL=gpt-5.5
+export OPENAI_DEFAULT_MODEL=gpt-5.6-sol
 node my-awesome-agent.js
 ```
 

--- a/docs/src/content/docs/guides/models.mdx
+++ b/docs/src/content/docs/guides/models.mdx
@@ -164,7 +164,7 @@ When a run includes deferred tools, add `toolSearchTool()` to the same agent and
 | `store` | `boolean` | Persist the response for retrieval / RAG workflows. |
 | `promptCacheRetention` | `'in-memory' \| '24h' \| null` | Controls provider prompt-cache retention when supported. |
 | `contextManagement` | `ModelSettingsContextManagement` | Controls provider context management, such as server-side compaction. |
-| `reasoning.effort` | `'none' \| 'minimal' \| 'low' \| 'medium' \| 'high' \| 'xhigh'` | Reasoning effort for gpt-5.x models. |
+| `reasoning.effort` | `'none' \| 'minimal' \| 'low' \| 'medium' \| 'high' \| 'xhigh' \| 'max'` | Reasoning effort for supported gpt-5.x models. `max` is supported by GPT-5.6. |
 | `reasoning.summary` | `'auto' \| 'concise' \| 'detailed'` | Controls how much reasoning summary the model returns. |
 | `text.verbosity` | `'low' \| 'medium' \| 'high'` | Text verbosity for gpt-5.x etc. |
 | `providerData` | `Record<string, any>` | Provider-specific passthrough options forwarded to the underlying model. |

--- a/docs/src/scripts/translate.ts
+++ b/docs/src/scripts/translate.ts
@@ -135,7 +135,7 @@ const languages: Record<string, string> = {
   zh: 'Chinese',
   // Add more languages here
 };
-const OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-5.5';
+const OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-5.6-sol';
 setDefaultOpenAIKey(process.env.OPENAI_API_KEY || '');
 const ENABLE_CODE_SNIPPET_EXCLUSION = true;
 

--- a/examples/basic/chat.ts
+++ b/examples/basic/chat.ts
@@ -29,6 +29,9 @@ const weatherAgent = new Agent({
   instructions:
     'You answer weather questions. Always call get_weather before answering.',
   handoffDescription: 'Knows everything about the weather but nothing else.',
+  modelSettings: {
+    toolChoice: 'required',
+  },
   tools: [getWeatherTool],
 });
 

--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -14,6 +14,9 @@ const dataAgentTwo = new Agent({
   name: 'Data agent',
   instructions: 'You are a data agent',
   handoffDescription: 'You know everything about the weather',
+  modelSettings: {
+    toolChoice: 'required',
+  },
   tools: [getWeatherTool],
 });
 

--- a/examples/docs/sandbox-agents/basic.ts
+++ b/examples/docs/sandbox-agents/basic.ts
@@ -25,7 +25,7 @@ const manifest = new Manifest({
 
 const agent = new SandboxAgent({
   name: 'Sandbox engineer',
-  model: 'gpt-5.5',
+  model: 'gpt-5.6-sol',
   instructions:
     'Read `repo/task.md` before editing files. Load the `$invoice-total-fixer` skill before changing code. Stay grounded in the repository, preserve existing behavior, and mention the exact verification command you ran. If you edit files with apply_patch, paths are relative to the sandbox workspace root.',
   defaultManifest: manifest,

--- a/examples/docs/sandbox-agents/conversation-identity.ts
+++ b/examples/docs/sandbox-agents/conversation-identity.ts
@@ -11,7 +11,7 @@ import { UnixLocalSandboxClient } from '@openai/agents/sandbox/local';
 const manifest = new Manifest();
 const agent = new SandboxAgent({
   name: 'Memory-enabled reviewer',
-  model: 'gpt-5.5',
+  model: 'gpt-5.6-sol',
   instructions: 'Inspect the workspace before answering.',
   capabilities: [filesystem(), shell(), memory()],
 });

--- a/examples/docs/sandbox-agents/developer-owned-lifecycle.ts
+++ b/examples/docs/sandbox-agents/developer-owned-lifecycle.ts
@@ -5,7 +5,7 @@ import { UnixLocalSandboxClient } from '@openai/agents/sandbox/local';
 const manifest = new Manifest();
 const agent = new SandboxAgent({
   name: 'Workspace reviewer',
-  model: 'gpt-5.5',
+  model: 'gpt-5.6-sol',
   instructions: 'Inspect the sandbox workspace before answering.',
 });
 

--- a/examples/docs/sandbox-agents/developer-owned-session.ts
+++ b/examples/docs/sandbox-agents/developer-owned-session.ts
@@ -5,7 +5,7 @@ import { UnixLocalSandboxClient } from '@openai/agents/sandbox/local';
 const manifest = new Manifest();
 const agent = new SandboxAgent({
   name: 'Workspace reviewer',
-  model: 'gpt-5.5',
+  model: 'gpt-5.6-sol',
   instructions: 'Inspect the sandbox workspace before answering.',
 });
 

--- a/examples/docs/sandbox-agents/docker-client.ts
+++ b/examples/docs/sandbox-agents/docker-client.ts
@@ -4,7 +4,7 @@ import { DockerSandboxClient } from '@openai/agents/sandbox/local';
 
 const agent = new SandboxAgent({
   name: 'Workspace reviewer',
-  model: 'gpt-5.5',
+  model: 'gpt-5.6-sol',
   instructions: 'Inspect the sandbox workspace before answering.',
 });
 

--- a/examples/docs/sandbox-agents/enable-memory.ts
+++ b/examples/docs/sandbox-agents/enable-memory.ts
@@ -17,7 +17,7 @@ const manifest = new Manifest({
 
 const agent = new SandboxAgent({
   name: 'Memory-enabled reviewer',
-  model: 'gpt-5.5',
+  model: 'gpt-5.6-sol',
   instructions:
     'Inspect the workspace, verify important claims, and preserve useful lessons for follow-up runs.',
   defaultManifest: manifest,

--- a/examples/docs/sandbox-agents/manifest-concurrency.ts
+++ b/examples/docs/sandbox-agents/manifest-concurrency.ts
@@ -4,7 +4,7 @@ import { UnixLocalSandboxClient } from '@openai/agents/sandbox/local';
 
 const agent = new SandboxAgent({
   name: 'Repository inspector',
-  model: 'gpt-5.5',
+  model: 'gpt-5.6-sol',
   instructions: 'Inspect the repository before answering.',
 });
 

--- a/examples/docs/sandbox-agents/sdk-owned-lifecycle.ts
+++ b/examples/docs/sandbox-agents/sdk-owned-lifecycle.ts
@@ -4,7 +4,7 @@ import { UnixLocalSandboxClient } from '@openai/agents/sandbox/local';
 
 const agent = new SandboxAgent({
   name: 'Workspace reviewer',
-  model: 'gpt-5.5',
+  model: 'gpt-5.6-sol',
   instructions: 'Inspect the sandbox workspace before answering.',
 });
 

--- a/examples/docs/toppage/sandboxAgent.ts
+++ b/examples/docs/toppage/sandboxAgent.ts
@@ -4,7 +4,7 @@ import { UnixLocalSandboxClient } from '@openai/agents/sandbox/local';
 
 const agent = new SandboxAgent({
   name: 'Workspace Assistant',
-  model: 'gpt-5.5',
+  model: 'gpt-5.6-sol',
   instructions: 'Inspect the repo before changing files.',
   defaultManifest: {
     entries: { repo: gitRepo({ repo: 'openai/openai-agents-js' }) },

--- a/packages/agents-core/src/defaultModel.ts
+++ b/packages/agents-core/src/defaultModel.ts
@@ -24,7 +24,7 @@ export function gpt5ReasoningSettingsRequired(modelName: string): boolean {
 const DEFAULT_REASONING_EFFORT_PATTERNS: Array<
   readonly [
     RegExp,
-    Exclude<ModelSettingsReasoningEffort, 'minimal' | 'xhigh' | null>,
+    Exclude<ModelSettingsReasoningEffort, 'minimal' | 'xhigh' | 'max' | null>,
   ]
 > = [
   [/^gpt-5(?:-\d{4}-\d{2}-\d{2})?$/, 'low'],
@@ -47,7 +47,7 @@ const DEFAULT_REASONING_EFFORT_PATTERNS: Array<
 function getDefaultReasoningEffort(
   modelName: string,
 ):
-  | Exclude<ModelSettingsReasoningEffort, 'minimal' | 'xhigh' | null>
+  | Exclude<ModelSettingsReasoningEffort, 'minimal' | 'xhigh' | 'max' | null>
   | undefined {
   for (const [pattern, effort] of DEFAULT_REASONING_EFFORT_PATTERNS) {
     if (pattern.test(modelName)) {

--- a/packages/agents-core/src/defaultModel.ts
+++ b/packages/agents-core/src/defaultModel.ts
@@ -38,6 +38,9 @@ const DEFAULT_REASONING_EFFORT_PATTERNS: Array<
   [/^gpt-5\.4-mini(?:-\d{4}-\d{2}-\d{2})?$/, 'none'],
   [/^gpt-5\.4-nano(?:-\d{4}-\d{2}-\d{2})?$/, 'none'],
   [/^gpt-5\.5(?:-\d{4}-\d{2}-\d{2})?$/, 'none'],
+  [/^gpt-5\.6-sol(?:-\d{4}-\d{2}-\d{2})?$/, 'none'],
+  [/^gpt-5\.6-terra(?:-\d{4}-\d{2}-\d{2})?$/, 'none'],
+  [/^gpt-5\.6-luna(?:-\d{4}-\d{2}-\d{2})?$/, 'none'],
 ];
 
 function getDefaultReasoningEffort(

--- a/packages/agents-core/src/defaultModel.ts
+++ b/packages/agents-core/src/defaultModel.ts
@@ -38,6 +38,7 @@ const DEFAULT_REASONING_EFFORT_PATTERNS: Array<
   [/^gpt-5\.4-mini(?:-\d{4}-\d{2}-\d{2})?$/, 'none'],
   [/^gpt-5\.4-nano(?:-\d{4}-\d{2}-\d{2})?$/, 'none'],
   [/^gpt-5\.5(?:-\d{4}-\d{2}-\d{2})?$/, 'none'],
+  [/^gpt-5\.6$/, 'none'],
   [/^gpt-5\.6-sol(?:-\d{4}-\d{2}-\d{2})?$/, 'none'],
   [/^gpt-5\.6-terra(?:-\d{4}-\d{2}-\d{2})?$/, 'none'],
   [/^gpt-5\.6-luna(?:-\d{4}-\d{2}-\d{2})?$/, 'none'],

--- a/packages/agents-core/src/model.ts
+++ b/packages/agents-core/src/model.ts
@@ -514,6 +514,7 @@ export type ModelRequest = {
    */
   _internal?: {
     runnerManagedRetry?: boolean;
+    reasoningEffortImplicit?: boolean;
   };
 };
 

--- a/packages/agents-core/src/model.ts
+++ b/packages/agents-core/src/model.ts
@@ -20,14 +20,11 @@ import {
 } from './types';
 
 export type ModelSettingsToolChoice =
-  | 'auto'
-  | 'required'
-  | 'none'
-  | (string & {});
+  'auto' | 'required' | 'none' | (string & {});
 
 /**
  * Constrains effort on reasoning for [reasoning models](https://platform.openai.com/docs/guides/reasoning).
- * Currently supported values are `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`.
+ * Currently supported values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.
  * Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
  */
 export type ModelSettingsReasoningEffort =
@@ -37,6 +34,7 @@ export type ModelSettingsReasoningEffort =
   | 'medium'
   | 'high'
   | 'xhigh'
+  | 'max'
   | null;
 
 /**
@@ -45,7 +43,7 @@ export type ModelSettingsReasoningEffort =
 export type ModelSettingsReasoning = {
   /**
    * Constrains effort on reasoning for [reasoning models](https://platform.openai.com/docs/guides/reasoning).
-   * Currently supported values are `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`.
+   * Currently supported values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.
    * Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
    */
   effort?: ModelSettingsReasoningEffort | null;

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -971,6 +971,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 previousResponseId: preparedCall.previousResponseId,
                 conversationId: preparedCall.conversationId,
                 modelSettings: preparedCall.modelSettings,
+                _internal: preparedCall.modelRequestInternal,
                 tools: preparedCall.serializedTools,
                 toolsExplicitlyProvided: preparedCall.toolsExplicitlyProvided,
                 outputType: convertAgentOutputTypeToSerializable(
@@ -1389,6 +1390,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                   ),
                   conversationId: preparedCall.conversationId,
                   modelSettings: preparedCall.modelSettings,
+                  _internal: preparedCall.modelRequestInternal,
                   tools: preparedCall.serializedTools,
                   toolsExplicitlyProvided: preparedCall.toolsExplicitlyProvided,
                   handoffs: preparedCall.serializedHandoffs,
@@ -1439,6 +1441,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 previousResponseId: preparedCall.previousResponseId,
                 conversationId: preparedCall.conversationId,
                 modelSettings: preparedCall.modelSettings,
+                _internal: preparedCall.modelRequestInternal,
                 tools: preparedCall.serializedTools,
                 toolsExplicitlyProvided: preparedCall.toolsExplicitlyProvided,
                 handoffs: preparedCall.serializedHandoffs,
@@ -1829,6 +1832,12 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           explicitlyModelSet,
           resolvedModelName,
         );
+    const modelRequestInternal = {
+      reasoningEffortImplicit:
+        implicitModelSettings?.reasoning?.effort !== undefined &&
+        !hasExplicitTopLevelReasoningEffort(this.config.modelSettings) &&
+        !hasExplicitTopLevelReasoningEffort(agentModelSettings),
+    };
 
     let modelSettings = mergeModelSettings(
       implicitModelSettings,
@@ -1881,6 +1890,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       ...artifacts,
       model,
       explicitlyModelSet,
+      modelRequestInternal,
       modelSettings,
       modelInput,
       prompt,
@@ -1896,6 +1906,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
 // internal helpers and constants
 
 let defaultRunner: Runner | undefined;
+
+function hasExplicitTopLevelReasoningEffort(settings?: ModelSettings): boolean {
+  return settings?.reasoning?.effort !== undefined;
+}
 
 const getDefaultRunner = (): Runner => {
   if (!defaultRunner) {

--- a/packages/agents-core/src/runner/types.ts
+++ b/packages/agents-core/src/runner/types.ts
@@ -79,6 +79,7 @@ export type PreparedModelCall<TContext = UnknownContext> =
   AgentArtifacts<TContext> & {
     model: Model;
     explicitlyModelSet: boolean;
+    modelRequestInternal: { reasoningEffortImplicit: boolean };
     modelSettings: ModelSettings;
     modelInput: ModelInputData;
     prompt?: Prompt;

--- a/packages/agents-core/src/sandbox/capabilities/compaction.ts
+++ b/packages/agents-core/src/sandbox/capabilities/compaction.ts
@@ -148,6 +148,10 @@ function getSandboxCompactionModelCandidates(model: string): string[] {
 }
 
 const SANDBOX_CONTEXT_WINDOWS_1M = new Set([
+  'gpt-5.6',
+  'gpt-5.6-sol',
+  'gpt-5.6-terra',
+  'gpt-5.6-luna',
   'gpt-5.4',
   'gpt-5.4-2026-03-05',
   'gpt-5.4-pro',

--- a/packages/agents-core/test/agent.test.ts
+++ b/packages/agents-core/test/agent.test.ts
@@ -123,6 +123,18 @@ describe('Agent', () => {
     },
   );
 
+  it('accepts max reasoning effort for GPT-5.6 models', () => {
+    const agent = new Agent({
+      name: 'MaxReasoningAgent',
+      model: 'gpt-5.6',
+      modelSettings: { reasoning: { effort: 'max' } },
+    });
+
+    expect(agent.modelSettings).toMatchObject({
+      reasoning: { effort: 'max' },
+    });
+  });
+
   it('uses generic defaults when an explicit model is not a GPT-5 model name', () => {
     const agent = new Agent({
       name: 'ExplicitGpt4Agent',

--- a/packages/agents-core/test/agent.test.ts
+++ b/packages/agents-core/test/agent.test.ts
@@ -97,6 +97,18 @@ describe('Agent', () => {
       { reasoning: { effort: 'medium' }, text: { verbosity: 'low' } },
     ],
     ['gpt-5.5', { reasoning: { effort: 'none' }, text: { verbosity: 'low' } }],
+    [
+      'gpt-5.6-sol',
+      { reasoning: { effort: 'none' }, text: { verbosity: 'low' } },
+    ],
+    [
+      'gpt-5.6-terra',
+      { reasoning: { effort: 'none' }, text: { verbosity: 'low' } },
+    ],
+    [
+      'gpt-5.6-luna',
+      { reasoning: { effort: 'none' }, text: { verbosity: 'low' } },
+    ],
     ['gpt-5-mini', { text: { verbosity: 'low' } }],
     ['gpt-5-chat-latest', {}],
   ])(

--- a/packages/agents-core/test/defaultModel.test.ts
+++ b/packages/agents-core/test/defaultModel.test.ts
@@ -7,6 +7,7 @@ import {
   isGpt5Default,
 } from '../src/defaultModel';
 import { loadEnv } from '../src/config';
+import { Agent } from '../src/agent';
 vi.mock('../src/config', () => ({
   loadEnv: vi.fn(),
 }));
@@ -45,6 +46,21 @@ describe('getDefaultModel', () => {
     });
     expect(getDefaultModel()).toBe('gpt-5-mini');
   });
+
+  test.each(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])(
+    'lowercases the %s model family from the environment',
+    (model) => {
+      mockedLoadEnv.mockReturnValue({
+        [OPENAI_DEFAULT_MODEL_ENV_VARIABLE_NAME]: model.toUpperCase(),
+      });
+
+      expect(getDefaultModel()).toBe(model);
+      expect(new Agent({ name: 'TestAgent' }).modelSettings).toEqual({
+        reasoning: { effort: 'none' },
+        text: { verbosity: 'low' },
+      });
+    },
+  );
 });
 describe('isGpt5Default', () => {
   test('returns true for the built-in GPT-5 default model', () => {
@@ -178,6 +194,16 @@ describe('getDefaultModelSettings', () => {
       text: { verbosity: 'low' },
     });
   });
+
+  test.each(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])(
+    'returns none reasoning defaults for %s',
+    (model) => {
+      expect(getDefaultModelSettings(model)).toEqual({
+        reasoning: { effort: 'none' },
+        text: { verbosity: 'low' },
+      });
+    },
+  );
 
   test('omits reasoning defaults for GPT-5 variants without confirmed support', () => {
     expect(getDefaultModelSettings('gpt-5-mini')).toEqual({

--- a/packages/agents-core/test/defaultModel.test.ts
+++ b/packages/agents-core/test/defaultModel.test.ts
@@ -47,7 +47,7 @@ describe('getDefaultModel', () => {
     expect(getDefaultModel()).toBe('gpt-5-mini');
   });
 
-  test.each(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])(
+  test.each(['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])(
     'lowercases the %s model family from the environment',
     (model) => {
       mockedLoadEnv.mockReturnValue({
@@ -195,7 +195,7 @@ describe('getDefaultModelSettings', () => {
     });
   });
 
-  test.each(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])(
+  test.each(['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])(
     'returns none reasoning defaults for %s',
     (model) => {
       expect(getDefaultModelSettings(model)).toEqual({

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -5479,6 +5479,9 @@ describe('Runner.run', () => {
         reasoning: { effort: 'low' },
         text: { verbosity: 'low' },
       });
+      expect(
+        inspectableModel.lastRequest?._internal?.reasoningEffortImplicit,
+      ).toBe(true);
     });
 
     it('lets RunConfig modelSettings override implicit model defaults', async () => {
@@ -5505,6 +5508,9 @@ describe('Runner.run', () => {
         text: { verbosity: 'low' },
         temperature: 0.7,
       });
+      expect(
+        inspectableModel.lastRequest?._internal?.reasoningEffortImplicit,
+      ).toBe(false);
     });
   });
 

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -5460,29 +5460,35 @@ describe('Runner.run', () => {
       expect(requestSettings.text?.verbosity).toBe('medium');
     });
 
-    it('uses model-specific defaults when the RunConfig model is explicit', async () => {
-      const modelResponse: ModelResponse = {
-        output: [fakeModelMessage('Hello explicit runner GPT-5')],
-        usage: new Usage(),
-      };
-      const inspectableModel = new InspectableModel(modelResponse);
-      const runner = new Runner({
-        model: 'gpt-5',
-        modelProvider: new InspectableModelProvider(inspectableModel),
-      });
-      const agent = new Agent({ name: 'RunnerModelAgent' });
+    it.each([
+      ['gpt-5', 'low'],
+      ['gpt-5.6', 'none'],
+    ] as const)(
+      'uses model-specific defaults when the RunConfig model is %s',
+      async (modelName, reasoningEffort) => {
+        const modelResponse: ModelResponse = {
+          output: [fakeModelMessage('Hello explicit runner GPT-5')],
+          usage: new Usage(),
+        };
+        const inspectableModel = new InspectableModel(modelResponse);
+        const runner = new Runner({
+          model: modelName,
+          modelProvider: new InspectableModelProvider(inspectableModel),
+        });
+        const agent = new Agent({ name: 'RunnerModelAgent' });
 
-      const result = await runner.run(agent, 'hello');
+        const result = await runner.run(agent, 'hello');
 
-      expect(result.finalOutput).toBe('Hello explicit runner GPT-5');
-      expect(inspectableModel.lastRequest?.modelSettings).toMatchObject({
-        reasoning: { effort: 'low' },
-        text: { verbosity: 'low' },
-      });
-      expect(
-        inspectableModel.lastRequest?._internal?.reasoningEffortImplicit,
-      ).toBe(true);
-    });
+        expect(result.finalOutput).toBe('Hello explicit runner GPT-5');
+        expect(inspectableModel.lastRequest?.modelSettings).toMatchObject({
+          reasoning: { effort: reasoningEffort },
+          text: { verbosity: 'low' },
+        });
+        expect(
+          inspectableModel.lastRequest?._internal?.reasoningEffortImplicit,
+        ).toBe(true);
+      },
+    );
 
     it('lets RunConfig modelSettings override implicit model defaults', async () => {
       const modelResponse: ModelResponse = {

--- a/packages/agents-core/test/sandboxCapabilities.test.ts
+++ b/packages/agents-core/test/sandboxCapabilities.test.ts
@@ -51,6 +51,23 @@ describe('Compaction', () => {
     });
   });
 
+  it.each(['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])(
+    'uses the 1M context window for %s compaction',
+    (model) => {
+      const capability = compaction();
+
+      expect(CompactionModelInfo.forModel(model)?.contextWindow).toBe(1047576);
+      expect(capability.samplingParams({ model })).toEqual({
+        context_management: [
+          {
+            type: 'compaction',
+            compact_threshold: 942818,
+          },
+        ],
+      });
+    },
+  );
+
   it('tracks Python sandbox model context windows for compaction', () => {
     expect(CompactionModelInfo.forModel('o1-pro')?.contextWindow).toBe(200000);
     expect(CompactionModelInfo.forModel('o3-mini')?.contextWindow).toBe(200000);

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -42,7 +42,7 @@ import type { OpenAIClient } from './openaiClient';
 
 export const FAKE_ID = 'FAKE_ID';
 const GPT_56_MODEL_PATTERN =
-  /^gpt-5\.6-(?:sol|terra|luna)(?:-\d{4}-\d{2}-\d{2})?$/;
+  /^gpt-5\.6(?:-(?:sol|terra|luna)(?:-\d{4}-\d{2}-\d{2})?)?$/;
 
 // Some Chat Completions API compatible providers return a reasoning property on the message
 // If that's the case we handle them separately

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -41,6 +41,8 @@ import { normalizePromptCacheRetention } from './utils/modelSettings';
 import type { OpenAIClient } from './openaiClient';
 
 export const FAKE_ID = 'FAKE_ID';
+const GPT_56_MODEL_PATTERN =
+  /^gpt-5\.6-(?:sol|terra|luna)(?:-\d{4}-\d{2}-\d{2})?$/;
 
 // Some Chat Completions API compatible providers return a reasoning property on the message
 // If that's the case we handle them separately
@@ -444,10 +446,20 @@ export class OpenAIChatCompletionsModel implements Model {
       span.spanData.input = messages;
     }
 
-    const providerData = request.modelSettings.providerData ?? {};
+    const providerData = { ...(request.modelSettings.providerData ?? {}) };
+    const requestInternal = (
+      request as ModelRequest & {
+        _internal?: { reasoningEffortImplicit?: boolean };
+      }
+    )._internal;
+    const omitImplicitReasoningEffort =
+      requestInternal?.reasoningEffortImplicit === true &&
+      (providerData.reasoning_effort !== undefined ||
+        (tools.length > 0 && GPT_56_MODEL_PATTERN.test(this.#model)));
     if (
       request.modelSettings.reasoning &&
-      request.modelSettings.reasoning.effort
+      request.modelSettings.reasoning.effort &&
+      !omitImplicitReasoningEffort
     ) {
       // merge the top-level reasoning.effort into provider data
       providerData.reasoning_effort = request.modelSettings.reasoning.effort;

--- a/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
@@ -684,7 +684,7 @@ describe('OpenAIChatCompletionsModel', () => {
     });
   });
 
-  it.each(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])(
+  it.each(['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])(
     'omits implicit reasoning effort for %s function tools',
     async (modelName) => {
       const client = new FakeClient();
@@ -844,10 +844,10 @@ describe('OpenAIChatCompletionsModel', () => {
         usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
       });
 
-    const model = new OpenAIChatCompletionsModel(client as any, 'gpt-5.6-sol');
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt-5.6');
     const providerData = { customOption: 'keep' };
     const runner = new Runner({
-      model: 'gpt-5.6-sol',
+      model: 'gpt-5.6',
       modelProvider: { getModel: () => model },
       modelSettings: { providerData },
       tracingDisabled: true,

--- a/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { withTrace, setTracingDisabled } from '@openai/agents-core';
+import {
+  Agent,
+  Runner,
+  withTrace,
+  setTracingDisabled,
+} from '@openai/agents-core';
 import { OpenAIChatCompletionsModel } from '../src/openaiChatCompletionsModel';
 import { HEADERS } from '../src/defaults';
 import logger from '../src/logger';
@@ -677,6 +682,193 @@ describe('OpenAIChatCompletionsModel', () => {
       headers: HEADERS,
       signal: undefined,
     });
+  });
+
+  it.each(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])(
+    'omits implicit reasoning effort for %s function tools',
+    async (modelName) => {
+      const client = new FakeClient();
+      const response = {
+        id: 'gpt-5.6-tool-response',
+        choices: [{ message: { content: 'done' } }],
+        usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+      } as any;
+      client.chat.completions.create.mockResolvedValue(response);
+
+      const model = new OpenAIChatCompletionsModel(client as any, modelName);
+      const req: any = {
+        input: 'prompt',
+        modelSettings: {
+          reasoning: { effort: 'none' },
+          text: { verbosity: 'low' },
+        },
+        _internal: {
+          reasoningEffortImplicit: true,
+        },
+        tools: [
+          {
+            type: 'function',
+            name: 'lookup',
+            description: 'Look up a value.',
+            parameters: { type: 'object', properties: {}, required: [] },
+            strict: true,
+          },
+        ],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+      };
+
+      await withTrace(`${modelName} implicit reasoning`, () =>
+        model.getResponse(req),
+      );
+
+      const [args] = client.chat.completions.create.mock.calls[0];
+      expect(args.reasoning_effort).toBeUndefined();
+      expect(args.verbosity).toBe('low');
+      expect(args.tools).toHaveLength(1);
+    },
+  );
+
+  it('preserves explicit GPT-5.6 reasoning effort with function tools', async () => {
+    const client = new FakeClient();
+    const response = {
+      id: 'gpt-5.6-explicit-tool-response',
+      choices: [{ message: { content: 'done' } }],
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    } as any;
+    client.chat.completions.create.mockResolvedValue(response);
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt-5.6-sol');
+    const req: any = {
+      input: 'prompt',
+      modelSettings: {
+        reasoning: { effort: 'low' },
+      },
+      _internal: {
+        reasoningEffortImplicit: false,
+      },
+      tools: [
+        {
+          type: 'function',
+          name: 'lookup',
+          description: 'Look up a value.',
+          parameters: { type: 'object', properties: {}, required: [] },
+          strict: true,
+        },
+      ],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+    };
+
+    await withTrace('gpt-5.6 explicit reasoning', () => model.getResponse(req));
+
+    const [args] = client.chat.completions.create.mock.calls[0];
+    expect(args.reasoning_effort).toBe('low');
+  });
+
+  it('preserves explicit provider reasoning effort over implicit defaults', async () => {
+    const client = new FakeClient();
+    client.chat.completions.create.mockResolvedValue({
+      id: 'gpt-5.6-provider-reasoning-response',
+      choices: [{ message: { content: 'done' } }],
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    });
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt-5.6-sol');
+    const providerData = { reasoning_effort: 'low' };
+    const runner = new Runner({
+      model: 'gpt-5.6-sol',
+      modelProvider: { getModel: () => model },
+      modelSettings: { providerData },
+      tracingDisabled: true,
+    });
+
+    await runner.run(
+      new Agent({
+        name: 'Handoff agent',
+        handoffs: [new Agent({ name: 'Specialist' })],
+      }),
+      'delegate this',
+    );
+
+    const [request] = client.chat.completions.create.mock.calls[0];
+    expect(request.reasoning_effort).toBe('low');
+    expect(providerData).toEqual({ reasoning_effort: 'low' });
+  });
+
+  it('preserves implicit GPT-5.6 reasoning effort without tools', async () => {
+    const client = new FakeClient();
+    const response = {
+      id: 'gpt-5.6-text-response',
+      choices: [{ message: { content: 'done' } }],
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    } as any;
+    client.chat.completions.create.mockResolvedValue(response);
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt-5.6-sol');
+    const req: any = {
+      input: 'prompt',
+      modelSettings: {
+        reasoning: { effort: 'none' },
+      },
+      _internal: {
+        reasoningEffortImplicit: true,
+      },
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+    };
+
+    await withTrace('gpt-5.6 implicit text reasoning', () =>
+      model.getResponse(req),
+    );
+
+    const [args] = client.chat.completions.create.mock.calls[0];
+    expect(args.reasoning_effort).toBe('none');
+  });
+
+  it('does not persist implicit reasoning effort across runner calls', async () => {
+    const client = new FakeClient();
+    client.chat.completions.create
+      .mockResolvedValueOnce({
+        id: 'gpt-5.6-text-response',
+        choices: [{ message: { content: 'first' } }],
+        usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+      })
+      .mockResolvedValueOnce({
+        id: 'gpt-5.6-tool-response',
+        choices: [{ message: { content: 'second' } }],
+        usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+      });
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt-5.6-sol');
+    const providerData = { customOption: 'keep' };
+    const runner = new Runner({
+      model: 'gpt-5.6-sol',
+      modelProvider: { getModel: () => model },
+      modelSettings: { providerData },
+      tracingDisabled: true,
+    });
+
+    await runner.run(new Agent({ name: 'Text agent' }), 'hello');
+    await runner.run(
+      new Agent({
+        name: 'Handoff agent',
+        handoffs: [new Agent({ name: 'Specialist' })],
+      }),
+      'delegate this',
+    );
+
+    const [textRequest] = client.chat.completions.create.mock.calls[0];
+    const [toolRequest] = client.chat.completions.create.mock.calls[1];
+    expect(textRequest.reasoning_effort).toBe('none');
+    expect(toolRequest.reasoning_effort).toBeUndefined();
+    expect(textRequest.customOption).toBe('keep');
+    expect(toolRequest.customOption).toBe('keep');
+    expect(providerData).toEqual({ customOption: 'keep' });
   });
 
   it('handles function tool calls', async () => {

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -3741,42 +3741,45 @@ describe('OpenAIResponsesModel', () => {
     });
   });
 
-  it('passes none reasoning effort to the Responses API payload', async () => {
-    await withTrace('test', async () => {
-      const fakeResponse = {
-        id: 'res-none',
-        usage: {
-          input_tokens: 1,
-          output_tokens: 1,
-          total_tokens: 2,
-        },
-        output: [],
-      };
-      const createMock = vi.fn().mockResolvedValue(fakeResponse);
-      const fakeClient = {
-        responses: { create: createMock },
-      } as unknown as OpenAI;
-      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.1');
-      const request = {
-        systemInstructions: undefined,
-        input: 'hi',
-        modelSettings: {
-          reasoning: { effort: 'none' },
-        },
-        tools: [],
-        outputType: 'text',
-        handoffs: [],
-        tracing: false,
-        signal: undefined,
-      };
+  it.each(['none', 'max'] as const)(
+    'passes %s reasoning effort to the Responses API payload',
+    async (effort) => {
+      await withTrace('test', async () => {
+        const fakeResponse = {
+          id: 'res-none',
+          usage: {
+            input_tokens: 1,
+            output_tokens: 1,
+            total_tokens: 2,
+          },
+          output: [],
+        };
+        const createMock = vi.fn().mockResolvedValue(fakeResponse);
+        const fakeClient = {
+          responses: { create: createMock },
+        } as unknown as OpenAI;
+        const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.6');
+        const request = {
+          systemInstructions: undefined,
+          input: 'hi',
+          modelSettings: {
+            reasoning: { effort },
+          },
+          tools: [],
+          outputType: 'text',
+          handoffs: [],
+          tracing: false,
+          signal: undefined,
+        };
 
-      await model.getResponse(request as any);
+        await model.getResponse(request as any);
 
-      expect(createMock).toHaveBeenCalledTimes(1);
-      const [args] = createMock.mock.calls[0];
-      expect(args.reasoning).toEqual({ effort: 'none' });
-    });
-  });
+        expect(createMock).toHaveBeenCalledTimes(1);
+        const [args] = createMock.mock.calls[0];
+        expect(args.reasoning).toEqual({ effort });
+      });
+    },
+  );
 
   it('getStreamedResponse yields events and calls client with stream flag', async () => {
     await withTrace('test', async () => {


### PR DESCRIPTION
This pull request adds default model settings for `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.

It prevents implicit reasoning effort from being sent with GPT-5.6 Chat Completions function tools while preserving explicit top-level and provider-specific reasoning settings. It also avoids mutating shared provider data and updates examples and documentation for `gpt-5.6-sol`.