### PR TITLE
feat: add experimental hosted multi-agent support

### DIFF
--- a/.changeset/hosted-multi-agent-beta.md
+++ b/.changeset/hosted-multi-agent-beta.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+feat: add experimental hosted Multi-agent Responses support

--- a/examples/agent-patterns/hosted-multi-agent-beta.ts
+++ b/examples/agent-patterns/hosted-multi-agent-beta.ts
@@ -1,0 +1,114 @@
+import OpenAI from 'openai';
+import {
+  Agent,
+  isOpenAIResponsesRawModelStreamEvent,
+  run,
+  tool,
+} from '@openai/agents';
+import {
+  OpenAIHostedMultiAgentModel,
+  getHostedAgentMetadata,
+} from '@openai/agents-openai/experimental/hosted-multi-agent';
+import { z } from 'zod';
+
+const records = {
+  alpha: { estimatedWeeks: 6, risk: 'medium' },
+  beta: { estimatedWeeks: 8, risk: 'low' },
+} as const;
+
+const getProposal = tool({
+  name: 'get_proposal',
+  description: 'Return deterministic details for a proposal.',
+  parameters: z.object({ proposal: z.enum(['alpha', 'beta']) }),
+  execute: async ({ proposal }, _context, details) => {
+    const metadata = getHostedAgentMetadata(details);
+    console.log(
+      `local tool caller=${metadata?.agentName ?? 'unknown'} call_id=${details?.toolCall?.callId ?? 'unknown'} proposal=${proposal}`,
+    );
+    return records[proposal];
+  },
+});
+
+const hostedItemTypes = new Set([
+  'multi_agent_call',
+  'multi_agent_call_output',
+  'agent_message',
+]);
+
+function logHostedItem(item: unknown): void {
+  if (!item || typeof item !== 'object') {
+    return;
+  }
+
+  const type = (item as { type?: unknown }).type;
+  const metadata = getHostedAgentMetadata(item);
+  const isSubagentMessage =
+    type === 'message' && metadata?.agentName !== '/root';
+  if (
+    typeof type === 'string' &&
+    (hostedItemTypes.has(type) || isSubagentMessage)
+  ) {
+    console.log(
+      `hosted item type=${type} agent=${metadata?.agentName ?? 'unknown'}`,
+    );
+  }
+}
+
+function getMode(): 'stream' | 'nonstream' {
+  const modeIndex = process.argv.indexOf('--mode');
+  const mode = modeIndex === -1 ? undefined : process.argv[modeIndex + 1];
+  if (mode === 'stream' || mode === 'nonstream') {
+    return mode;
+  }
+  if (mode !== undefined) {
+    throw new Error('Use --mode stream or --mode nonstream.');
+  }
+  return process.argv.includes('--stream') ? 'stream' : 'nonstream';
+}
+
+async function main() {
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error(
+      'Set OPENAI_API_KEY and ensure the project has hosted Multi-agent beta access.',
+    );
+  }
+
+  const model = new OpenAIHostedMultiAgentModel(new OpenAI(), 'gpt-5.6-sol');
+  try {
+    const agent = new Agent({
+      name: 'Hosted proposal coordinator',
+      model,
+      tools: [getProposal],
+      instructions:
+        'Create two subagents. Ask one to inspect proposal alpha and the other to inspect proposal beta. Each subagent must call get_proposal for its assigned proposal. Wait for both, then compare their duration and risk in one concise root final answer.',
+    });
+    const prompt = 'Compare proposal alpha with proposal beta.';
+
+    if (getMode() === 'stream') {
+      const streamed = await run(agent, prompt, { stream: true });
+      for await (const event of streamed) {
+        if (
+          isOpenAIResponsesRawModelStreamEvent(event) &&
+          event.data.event.type === 'response.output_item.done'
+        ) {
+          logHostedItem(event.data.event.item);
+        }
+      }
+      console.log(`\nFinal response:\n${streamed.finalOutput}`);
+      return;
+    }
+
+    const result = await run(agent, prompt);
+    console.log(`Final response:\n${result.finalOutput}`);
+  } finally {
+    await model.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(
+    'Hosted Multi-agent example failed. Verify beta access and the selected model.',
+  );
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/agent-patterns/package.json
+++ b/examples/agent-patterns/package.json
@@ -5,6 +5,7 @@
     "@openai/agents": "workspace:*",
     "@openai/agents-openai": "workspace:*",
     "chalk": "^5.4.1",
+    "openai": "^6.46.0",
     "zod": "^4.0.0"
   },
   "scripts": {

--- a/examples/agent-patterns/package.json
+++ b/examples/agent-patterns/package.json
@@ -3,6 +3,7 @@
   "name": "agent-patterns",
   "dependencies": {
     "@openai/agents": "workspace:*",
+    "@openai/agents-openai": "workspace:*",
     "chalk": "^5.4.1",
     "zod": "^4.0.0"
   },
@@ -16,6 +17,7 @@
     "start:forcing-tool-use": "tsx forcing-tool-use.ts -t default",
     "start:human-in-the-loop-stream": "tsx human-in-the-loop-stream.ts",
     "start:human-in-the-loop": "tsx human-in-the-loop.ts",
+    "start:hosted-multi-agent": "tsx hosted-multi-agent-beta.ts",
     "start:input-guardrails": "tsx input-guardrails.ts",
     "start:llm-as-a-judge": "tsx llm-as-a-judge.ts",
     "start:output-guardrails": "tsx output-guardrails.ts",

--- a/packages/agents-openai/package.json
+++ b/packages/agents-openai/package.json
@@ -12,6 +12,11 @@
       "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
+    },
+    "./experimental/hosted-multi-agent": {
+      "types": "./dist/experimental/hostedMultiAgent/index.d.ts",
+      "require": "./dist/experimental/hostedMultiAgent/index.js",
+      "import": "./dist/experimental/hostedMultiAgent/index.mjs"
     }
   },
   "dependencies": {
@@ -42,5 +47,12 @@
   },
   "files": [
     "dist"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "experimental/hosted-multi-agent": [
+        "dist/experimental/hostedMultiAgent/index.d.ts"
+      ]
+    }
+  }
 }

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/config.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/config.ts
@@ -1,0 +1,7 @@
+export type HostedMultiAgentConfig = Readonly<{
+  /**
+   * Maximum number of hosted subagents that may be active at once.
+   * Omit this value to use the service default.
+   */
+  maxConcurrentSubagents?: number;
+}>;

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/index.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/index.ts
@@ -1,0 +1,3 @@
+export type { HostedMultiAgentConfig } from './config';
+export { getHostedAgentMetadata, type HostedAgentMetadata } from './metadata';
+export { OpenAIHostedMultiAgentModel } from './model';

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/metadata.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/metadata.ts
@@ -1,0 +1,48 @@
+export type HostedAgentMetadata = Readonly<{
+  agentName: string;
+  phase?: string;
+}>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function unwrapHostedValue(
+  value: unknown,
+): Record<string, unknown> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  if (isRecord(value.toolCall)) {
+    return unwrapHostedValue(value.toolCall);
+  }
+
+  if (isRecord(value.providerData) && isRecord(value.providerData.agent)) {
+    return value.providerData;
+  }
+
+  return value;
+}
+
+/**
+ * Reads hosted-agent attribution without affecting local tool routing.
+ */
+export function getHostedAgentMetadata(
+  value: unknown,
+): HostedAgentMetadata | undefined {
+  const item = unwrapHostedValue(value);
+  if (!item || !isRecord(item.agent)) {
+    return undefined;
+  }
+
+  const agentName = item.agent.agent_name;
+  if (typeof agentName !== 'string' || agentName.length === 0) {
+    return undefined;
+  }
+
+  return {
+    agentName,
+    ...(typeof item.phase === 'string' ? { phase: item.phase } : {}),
+  };
+}

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
@@ -405,6 +405,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
         },
         Boolean(this.#activeResponse),
         builtRequest.signal,
+        requestTimeoutDeadline,
       );
       let pendingInjections = 0;
       const injectingCallIds = new Set<string>();
@@ -686,30 +687,31 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     transportOptions: HostedWebSocketTransportOptions,
     activeResponse: boolean,
     signal: AbortSignal | undefined,
+    requestTimeoutDeadline: WebSocketRequestTimeoutDeadline | undefined,
   ): Promise<ResponsesWebSocketLike> {
     const transportOverridesKey = getTransportOverridesKey(
       this._client,
       transportOptions,
     );
     if (activeResponse) {
-      if (
-        transportOverridesKey !== this.#webSocketTransportOverridesKey ||
-        !this.#webSocket
-      ) {
+      if (transportOverridesKey !== this.#webSocketTransportOverridesKey) {
         throw new UserError(
           'An active hosted response must be resumed with the same WebSocket transport headers and query.',
         );
       }
-      if (isReusableWebSocket(this.#webSocket)) {
-        return this.#webSocket;
+      if (this.#webSocket) {
+        if (isReusableWebSocket(this.#webSocket)) {
+          return this.#webSocket;
+        }
+        this.#dropWebSocketConnection();
+        this.#webSocketTransportOverridesKey = transportOverridesKey;
       }
-      this.#dropWebSocketConnection();
-      this.#webSocketTransportOverridesKey = transportOverridesKey;
     }
 
     const creationOptions = await this.#prepareWebSocketCreationOptions(
       transportOptions,
       signal,
+      requestTimeoutDeadline,
     );
     const connectionURL = creationOptions.client.buildURL(
       '/responses',
@@ -745,10 +747,17 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
   async #prepareWebSocketCreationOptions(
     transportOptions: HostedWebSocketTransportOptions,
     signal: AbortSignal | undefined,
+    requestTimeoutDeadline: WebSocketRequestTimeoutDeadline | undefined,
   ): Promise<HostedWebSocketCreationOptions> {
     const client = this._client as OpenAIClientInternals;
     if (typeof client._callApiKey === 'function') {
-      await withAbortSignal(client._callApiKey(), signal);
+      await this.#awaitWebSocketRequestTimedOperation(
+        client._callApiKey(),
+        signal,
+        requestTimeoutDeadline,
+        (configuredTimeoutMs) =>
+          `Hosted Multi-agent WebSocket auth header preparation timed out after ${configuredTimeoutMs}ms.`,
+      );
     }
     const websocketClient = createWebSocketClient(
       client,
@@ -762,13 +771,16 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     );
     const authHeaders =
       typeof client.authHeaders === 'function'
-        ? await withAbortSignal(
+        ? await this.#awaitWebSocketRequestTimedOperation(
             client.authHeaders({
               method: 'get',
               path: websocketURL.pathname,
               ...(authHeaderQuery ? { query: authHeaderQuery } : {}),
             }),
             signal,
+            requestTimeoutDeadline,
+            (configuredTimeoutMs) =>
+              `Hosted Multi-agent WebSocket auth header preparation timed out after ${configuredTimeoutMs}ms.`,
           )
         : undefined;
 
@@ -829,6 +841,8 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     }
     const frameReadTimeout = this.#resolveWebSocketRequestTimeout(
       requestTimeoutDeadline,
+      (configuredTimeoutMs) =>
+        `Hosted Multi-agent WebSocket frame read timed out after ${configuredTimeoutMs}ms.`,
     );
     const result = await withAbortSignal(
       withTimeout(
@@ -874,6 +888,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
 
   #resolveWebSocketRequestTimeout(
     requestTimeoutDeadline: WebSocketRequestTimeoutDeadline | undefined,
+    errorMessageForConfiguredTimeout: (configuredTimeoutMs: number) => string,
   ): { timeoutMs: number | undefined; errorMessage: string } {
     const configuredTimeoutMs =
       requestTimeoutDeadline?.configuredTimeoutMs ??
@@ -882,7 +897,9 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
       typeof configuredTimeoutMs === 'number'
         ? configuredTimeoutMs
         : OpenAI.DEFAULT_TIMEOUT;
-    const errorMessage = `Hosted Multi-agent WebSocket frame read timed out after ${safeConfiguredTimeoutMs}ms.`;
+    const errorMessage = errorMessageForConfiguredTimeout(
+      safeConfiguredTimeoutMs,
+    );
     if (!requestTimeoutDeadline) {
       return { timeoutMs: configuredTimeoutMs, errorMessage };
     }
@@ -895,5 +912,21 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     }
 
     return { timeoutMs: remainingTimeoutMs, errorMessage };
+  }
+
+  async #awaitWebSocketRequestTimedOperation<T>(
+    promise: Promise<T>,
+    signal: AbortSignal | undefined,
+    requestTimeoutDeadline: WebSocketRequestTimeoutDeadline | undefined,
+    errorMessageForConfiguredTimeout: (configuredTimeoutMs: number) => string,
+  ): Promise<T> {
+    const timeout = this.#resolveWebSocketRequestTimeout(
+      requestTimeoutDeadline,
+      errorMessageForConfiguredTimeout,
+    );
+    return await withAbortSignal(
+      withTimeout(promise, timeout.timeoutMs, timeout.errorMessage),
+      signal,
+    );
   }
 }

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
@@ -364,6 +364,9 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
       );
     }
     this.#requestInProgress = true;
+    const hadActiveResponse = Boolean(this.#activeResponse);
+    let sentWebSocketFrame = false;
+    let receivedWebSocketEvent = false;
 
     try {
       const builtRequest = this._buildResponsesCreateRequest(request, true);
@@ -396,12 +399,13 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
         }
 
         if (activeResponse.terminalEvent) {
-          this.#continueTerminalResponse(
+          const continuationFrame = this.#prepareTerminalContinuation(
             activeResponse,
             requestData,
             outputs,
-            webSocket,
           );
+          sentWebSocketFrame = true;
+          webSocket.send(continuationFrame as any);
         } else {
           if (outputs.length === 0 || !activeResponse.responseId) {
             throw new UserError(
@@ -412,6 +416,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
           for (const output of outputs) {
             injectingCallIds.add(output.call_id);
           }
+          sentWebSocketFrame = true;
           webSocket.send({
             type: 'response.inject',
             response_id: activeResponse.responseId,
@@ -426,6 +431,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
           fallbackInput: [],
           requestUsages: [],
         };
+        sentWebSocketFrame = true;
         webSocket.send(toResponseCreateFrame(requestData) as any);
       }
 
@@ -436,6 +442,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
             'Hosted Multi-agent WebSocket closed before a response boundary.',
           );
         }
+        receivedWebSocketEvent = true;
         if (message.type === 'error') {
           throw message.error;
         }
@@ -519,12 +526,13 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
 
         if (activeResponse.terminalEvent && pendingInjections === 0) {
           if (activeResponse.fallbackInput.length > 0) {
-            this.#continueTerminalResponse(
+            const continuationFrame = this.#prepareTerminalContinuation(
               activeResponse,
               requestData,
               [],
-              webSocket,
             );
+            sentWebSocketFrame = true;
+            webSocket.send(continuationFrame as any);
             injectingCallIds.clear();
             continue;
           }
@@ -551,7 +559,16 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
         }
       }
     } catch (error) {
-      await this.close();
+      if (receivedWebSocketEvent && error instanceof Error) {
+        (
+          error as Error & {
+            unsafeToReplay?: boolean;
+          }
+        ).unsafeToReplay = true;
+      }
+      if (!hadActiveResponse || sentWebSocketFrame || receivedWebSocketEvent) {
+        await this.close();
+      }
       throw error;
     } finally {
       this.#requestInProgress = false;
@@ -583,12 +600,11 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     return boundaryResponse;
   }
 
-  #continueTerminalResponse(
+  #prepareTerminalContinuation(
     activeResponse: ActiveHostedResponse,
     requestData: Record<string, any>,
     functionOutputs: Array<Record<string, any>>,
-    webSocket: ResponsesWebSocketLike,
-  ): void {
+  ): Record<string, any> {
     const terminalResponse = activeResponse.terminalEvent?.response as
       Record<string, any> | undefined;
     if (!terminalResponse?.id) {
@@ -624,7 +640,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     activeResponse.queuedFunctionCalls = [];
     activeResponse.terminalEvent = undefined;
     activeResponse.fallbackInput = [];
-    webSocket.send(fallbackFrame as any);
+    return fallbackFrame;
   }
 
   async #ensureWebSocket(

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
@@ -39,8 +39,18 @@ const HOSTED_TERMINAL_RESPONSE_EVENT_TYPES = new Set([
   'response.error',
 ]);
 
-type ResponsesWebSocketLike = Pick<ResponsesWS, 'send' | 'close'> &
+type ResponsesWebSocketLike = Pick<ResponsesWS, 'send' | 'close' | 'socket'> &
   AsyncIterable<Record<string, any>>;
+
+const WEBSOCKET_CONNECTING_READY_STATE = 0;
+const WEBSOCKET_OPEN_READY_STATE = 1;
+
+function isReusableWebSocket(webSocket: ResponsesWebSocketLike): boolean {
+  return (
+    webSocket.socket.readyState === WEBSOCKET_CONNECTING_READY_STATE ||
+    webSocket.socket.readyState === WEBSOCKET_OPEN_READY_STATE
+  );
+}
 
 type ActiveHostedResponse = {
   responseId?: string;
@@ -677,6 +687,10 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
       connectionURL,
       sortedEntries(creationOptions.headers),
     ]);
+
+    if (this.#webSocket && !isReusableWebSocket(this.#webSocket)) {
+      await this.close();
+    }
 
     if (this.#webSocket && this.#webSocketConnectionKey !== connectionKey) {
       await this.close();

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
@@ -166,6 +166,7 @@ function getTransportOverridesKey(
   return JSON.stringify([
     url,
     sortedEntries(headerAccumulatorToRecord(headerAccumulator)),
+    [...headerAccumulator.blockedLowercaseNames].sort(),
   ]);
 }
 

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
@@ -247,8 +247,12 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
 
   /** Close the persistent Responses WebSocket owned by this model. */
   async close(): Promise<void> {
-    this.#webSocketIterator = undefined;
     this.#activeResponse = undefined;
+    this.#dropWebSocketConnection();
+  }
+
+  #dropWebSocketConnection(): void {
+    this.#webSocketIterator = undefined;
     const webSocket = this.#webSocket;
     this.#webSocket = undefined;
     this.#webSocketConnectionKey = undefined;
@@ -386,6 +390,8 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     const hadActiveResponse = Boolean(this.#activeResponse);
     let sentWebSocketFrame = false;
     let receivedWebSocketEvent = false;
+    let reachedResponseBoundary = false;
+    let threwError = false;
     const requestTimeoutDeadline =
       this.#createWebSocketRequestTimeoutDeadline();
 
@@ -544,6 +550,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
         ) {
           const functionCalls = activeResponse.queuedFunctionCalls.splice(0);
           const partialResponse = this.#buildBoundaryResponse(functionCalls);
+          reachedResponseBoundary = true;
           yield { type: 'response.completed', response: partialResponse };
           return;
         }
@@ -578,11 +585,13 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
             ]),
           );
           this.#activeResponse = undefined;
+          reachedResponseBoundary = true;
           yield { ...terminalEvent, response };
           return;
         }
       }
     } catch (error) {
+      threwError = true;
       if (receivedWebSocketEvent && error instanceof Error) {
         (
           error as Error & {
@@ -595,7 +604,13 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
       }
       throw error;
     } finally {
-      this.#requestInProgress = false;
+      try {
+        if (!threwError && !reachedResponseBoundary) {
+          await this.close();
+        }
+      } finally {
+        this.#requestInProgress = false;
+      }
     }
   }
 
@@ -685,7 +700,11 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
           'An active hosted response must be resumed with the same WebSocket transport headers and query.',
         );
       }
-      return this.#webSocket;
+      if (isReusableWebSocket(this.#webSocket)) {
+        return this.#webSocket;
+      }
+      this.#dropWebSocketConnection();
+      this.#webSocketTransportOverridesKey = transportOverridesKey;
     }
 
     const creationOptions = await this.#prepareWebSocketCreationOptions(
@@ -702,7 +721,11 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
       sortedEntries(creationOptions.headers),
     ]);
 
-    if (this.#webSocket && !isReusableWebSocket(this.#webSocket)) {
+    if (
+      !activeResponse &&
+      this.#webSocket &&
+      !isReusableWebSocket(this.#webSocket)
+    ) {
       await this.close();
     }
 

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
@@ -411,7 +411,11 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     const sendWebSocketFrame = (
       webSocket: ResponsesWebSocketLike,
       frame: Record<string, any>,
+      signal: AbortSignal | undefined,
     ): void => {
+      if (signal?.aborted) {
+        throw new OpenAI.APIUserAbortError();
+      }
       sentWebSocketFrame = true;
       if (webSocket.socket.readyState === WEBSOCKET_OPEN_READY_STATE) {
         requestMayHaveReachedServer = true;
@@ -456,7 +460,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
             requestData,
             outputs,
           );
-          sendWebSocketFrame(webSocket, continuationFrame);
+          sendWebSocketFrame(webSocket, continuationFrame, builtRequest.signal);
         } else {
           if (outputs.length === 0 || !activeResponse.responseId) {
             throw new UserError(
@@ -467,11 +471,15 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
           for (const output of outputs) {
             injectingCallIds.add(output.call_id);
           }
-          sendWebSocketFrame(webSocket, {
-            type: 'response.inject',
-            response_id: activeResponse.responseId,
-            input: outputs,
-          });
+          sendWebSocketFrame(
+            webSocket,
+            {
+              type: 'response.inject',
+              response_id: activeResponse.responseId,
+              input: outputs,
+            },
+            builtRequest.signal,
+          );
         }
       } else {
         this.#activeResponse = {
@@ -489,7 +497,11 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
           fallbackInput: [],
           requestUsages: [],
         };
-        sendWebSocketFrame(webSocket, toResponseCreateFrame(requestData));
+        sendWebSocketFrame(
+          webSocket,
+          toResponseCreateFrame(requestData),
+          builtRequest.signal,
+        );
       }
 
       while (true) {
@@ -603,7 +615,11 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
               requestData,
               [],
             );
-            sendWebSocketFrame(webSocket, continuationFrame);
+            sendWebSocketFrame(
+              webSocket,
+              continuationFrame,
+              builtRequest.signal,
+            );
             injectingCallIds.clear();
             continue;
           }
@@ -760,6 +776,9 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     signal: AbortSignal | undefined,
     requestTimeoutDeadline: WebSocketRequestTimeoutDeadline | undefined,
   ): Promise<ResponsesWebSocketLike> {
+    if (signal?.aborted) {
+      throw new OpenAI.APIUserAbortError();
+    }
     const transportOverridesKey = getTransportOverridesKey(
       this._client,
       transportOptions,

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
@@ -389,11 +389,22 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     this.#requestInProgress = true;
     const hadActiveResponse = Boolean(this.#activeResponse);
     let sentWebSocketFrame = false;
-    let receivedWebSocketEvent = false;
+    let receivedServerMessage = false;
+    let requestMayHaveReachedServer = false;
     let reachedResponseBoundary = false;
     let threwError = false;
     const requestTimeoutDeadline =
       this.#createWebSocketRequestTimeoutDeadline();
+    const sendWebSocketFrame = (
+      webSocket: ResponsesWebSocketLike,
+      frame: Record<string, any>,
+    ): void => {
+      sentWebSocketFrame = true;
+      if (webSocket.socket.readyState === WEBSOCKET_OPEN_READY_STATE) {
+        requestMayHaveReachedServer = true;
+      }
+      webSocket.send(frame as any);
+    };
 
     try {
       const builtRequest = this._buildResponsesCreateRequest(request, true);
@@ -432,8 +443,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
             requestData,
             outputs,
           );
-          sentWebSocketFrame = true;
-          webSocket.send(continuationFrame as any);
+          sendWebSocketFrame(webSocket, continuationFrame);
         } else {
           if (outputs.length === 0 || !activeResponse.responseId) {
             throw new UserError(
@@ -444,12 +454,11 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
           for (const output of outputs) {
             injectingCallIds.add(output.call_id);
           }
-          sentWebSocketFrame = true;
-          webSocket.send({
+          sendWebSocketFrame(webSocket, {
             type: 'response.inject',
             response_id: activeResponse.responseId,
             input: outputs,
-          } as any);
+          });
         }
       } else {
         this.#activeResponse = {
@@ -459,8 +468,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
           fallbackInput: [],
           requestUsages: [],
         };
-        sentWebSocketFrame = true;
-        webSocket.send(toResponseCreateFrame(requestData) as any);
+        sendWebSocketFrame(webSocket, toResponseCreateFrame(requestData));
       }
 
       while (true) {
@@ -473,11 +481,20 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
             'Hosted Multi-agent WebSocket closed before a response boundary.',
           );
         }
-        receivedWebSocketEvent = true;
+        if (message.type === 'open' || message.type === 'reconnected') {
+          requestMayHaveReachedServer = true;
+        }
         if (message.type === 'error') {
           throw message.error;
         }
         if (message.type === 'close') {
+          if (
+            !receivedServerMessage &&
+            Array.isArray(message.unsent) &&
+            message.unsent.length > 0
+          ) {
+            requestMayHaveReachedServer = false;
+          }
           throw new Error(
             `Hosted Multi-agent WebSocket closed (${String(message.code)}): ${String(message.reason ?? '')}`,
           );
@@ -485,6 +502,8 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
         if (message.type !== 'message') {
           continue;
         }
+        receivedServerMessage = true;
+        requestMayHaveReachedServer = true;
 
         const event = message.message as Record<string, any>;
         const eventType = event.type;
@@ -563,8 +582,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
               requestData,
               [],
             );
-            sentWebSocketFrame = true;
-            webSocket.send(continuationFrame as any);
+            sendWebSocketFrame(webSocket, continuationFrame);
             injectingCallIds.clear();
             continue;
           }
@@ -593,14 +611,14 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
       }
     } catch (error) {
       threwError = true;
-      if (receivedWebSocketEvent && error instanceof Error) {
+      if (requestMayHaveReachedServer && error instanceof Error) {
         (
           error as Error & {
             unsafeToReplay?: boolean;
           }
         ).unsafeToReplay = true;
       }
-      if (!hadActiveResponse || sentWebSocketFrame || receivedWebSocketEvent) {
+      if (!hadActiveResponse || sentWebSocketFrame || receivedServerMessage) {
         await this.close();
       }
       throw error;

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
@@ -32,6 +32,12 @@ const HOSTED_COLLABORATION_ITEM_TYPES = new Set([
   'multi_agent_call',
   'multi_agent_call_output',
 ]);
+const HOSTED_TERMINAL_RESPONSE_EVENT_TYPES = new Set([
+  'response.completed',
+  'response.failed',
+  'response.incomplete',
+  'response.error',
+]);
 
 type ResponsesWebSocketLike = Pick<ResponsesWS, 'send' | 'close'> &
   AsyncIterable<Record<string, any>>;
@@ -42,10 +48,17 @@ type ActiveHostedResponse = {
   pendingCallIds: Set<string>;
   emittedCallIds: Set<string>;
   queuedFunctionCalls: Array<Record<string, any>>;
-  completedEvent?: Record<string, any>;
+  terminalEvent?: Record<string, any>;
   fallbackInput: Array<Record<string, any>>;
   requestUsages: Array<OpenAI.Responses.ResponseUsage | undefined>;
 };
+
+function isHostedTerminalResponseEventType(eventType: unknown): boolean {
+  return (
+    typeof eventType === 'string' &&
+    HOSTED_TERMINAL_RESPONSE_EVENT_TYPES.has(eventType)
+  );
+}
 
 type HostedWebSocketTransportOptions = {
   extraHeaders?: Record<string, unknown>;
@@ -330,7 +343,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
 
     let response: OpenAI.Responses.Response | undefined;
     for await (const event of events) {
-      if (event.type === 'response.completed') {
+      if (isHostedTerminalResponseEventType(event.type)) {
         response = event.response as OpenAI.Responses.Response;
       }
     }
@@ -382,8 +395,8 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
           );
         }
 
-        if (activeResponse.completedEvent) {
-          this.#continueCompletedResponse(
+        if (activeResponse.terminalEvent) {
+          this.#continueTerminalResponse(
             activeResponse,
             requestData,
             outputs,
@@ -482,19 +495,15 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
           for (const callId of injectingCallIds) {
             activeResponse.pendingCallIds.delete(callId);
           }
-        } else if (eventType === 'response.completed') {
-          activeResponse.completedEvent = event;
-        } else if (
-          eventType === 'error' ||
-          eventType === 'response.failed' ||
-          eventType === 'response.incomplete'
-        ) {
+        } else if (isHostedTerminalResponseEventType(eventType)) {
+          activeResponse.terminalEvent = event;
+        } else if (eventType === 'error') {
           throw new Error(
             `Hosted Multi-agent WebSocket response failed: ${JSON.stringify(event)}`,
           );
         }
 
-        if (eventType !== 'response.completed') {
+        if (!isHostedTerminalResponseEventType(eventType)) {
           yield event;
         }
 
@@ -508,9 +517,9 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
           return;
         }
 
-        if (activeResponse.completedEvent && pendingInjections === 0) {
+        if (activeResponse.terminalEvent && pendingInjections === 0) {
           if (activeResponse.fallbackInput.length > 0) {
-            this.#continueCompletedResponse(
+            this.#continueTerminalResponse(
               activeResponse,
               requestData,
               [],
@@ -520,8 +529,8 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
             continue;
           }
 
-          const completedEvent = activeResponse.completedEvent;
-          const response = completedEvent.response as Record<string, any>;
+          const terminalEvent = activeResponse.terminalEvent;
+          const response = terminalEvent.response as Record<string, any>;
           response.output = (
             Array.isArray(response.output) ? response.output : []
           ).filter(
@@ -537,7 +546,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
             ]),
           );
           this.#activeResponse = undefined;
-          yield { ...completedEvent, response };
+          yield { ...terminalEvent, response };
           return;
         }
       }
@@ -574,17 +583,17 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     return boundaryResponse;
   }
 
-  #continueCompletedResponse(
+  #continueTerminalResponse(
     activeResponse: ActiveHostedResponse,
     requestData: Record<string, any>,
     functionOutputs: Array<Record<string, any>>,
     webSocket: ResponsesWebSocketLike,
   ): void {
-    const completedResponse = activeResponse.completedEvent?.response as
+    const terminalResponse = activeResponse.terminalEvent?.response as
       Record<string, any> | undefined;
-    if (!completedResponse?.id) {
+    if (!terminalResponse?.id) {
       throw new Error(
-        'Hosted Multi-agent could not continue after a completed response.',
+        'Hosted Multi-agent could not continue after a terminal response.',
       );
     }
 
@@ -594,17 +603,17 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     ];
     if (continuationInput.length === 0) {
       throw new Error(
-        'Hosted Multi-agent completed response continuation requires function outputs.',
+        'Hosted Multi-agent terminal response continuation requires function outputs.',
       );
     }
 
     activeResponse.requestUsages.push(
-      completedResponse.usage as OpenAI.Responses.ResponseUsage | undefined,
+      terminalResponse.usage as OpenAI.Responses.ResponseUsage | undefined,
     );
     const fallbackFrame = toResponseCreateFrame(requestData);
     fallbackFrame.input = continuationInput;
     if (fallbackFrame.conversation == null) {
-      fallbackFrame.previous_response_id = completedResponse.id;
+      fallbackFrame.previous_response_id = terminalResponse.id;
     } else {
       delete fallbackFrame.previous_response_id;
     }
@@ -613,7 +622,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     activeResponse.responseTemplate = undefined;
     activeResponse.pendingCallIds.clear();
     activeResponse.queuedFunctionCalls = [];
-    activeResponse.completedEvent = undefined;
+    activeResponse.terminalEvent = undefined;
     activeResponse.fallbackInput = [];
     webSocket.send(fallbackFrame as any);
   }

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
@@ -58,6 +58,9 @@ function isReusableWebSocket(webSocket: ResponsesWebSocketLike): boolean {
 type ActiveHostedResponse = {
   responseId?: string;
   responseTemplate?: Record<string, any>;
+  responseCreateInput: Array<Record<string, any>>;
+  responseCreatePreviousResponseId?: string;
+  responseStored: boolean;
   pendingCallIds: Set<string>;
   emittedCallIds: Set<string>;
   queuedFunctionCalls: Array<Record<string, any>>;
@@ -462,6 +465,14 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
         }
       } else {
         this.#activeResponse = {
+          responseCreateInput: Array.isArray(requestData.input)
+            ? [...requestData.input]
+            : [],
+          responseCreatePreviousResponseId:
+            typeof requestData.previous_response_id === 'string'
+              ? requestData.previous_response_id
+              : undefined,
+          responseStored: requestData.store !== false,
           pendingCallIds: new Set(),
           emittedCallIds: new Set(),
           queuedFunctionCalls: [],
@@ -684,14 +695,41 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     activeResponse.requestUsages.push(
       terminalResponse.usage as OpenAI.Responses.ResponseUsage | undefined,
     );
+    const terminalResponseStored =
+      typeof terminalResponse.store === 'boolean'
+        ? terminalResponse.store
+        : activeResponse.responseStored;
     const fallbackFrame = toResponseCreateFrame(requestData);
-    fallbackFrame.input = continuationInput;
-    if (fallbackFrame.conversation == null) {
+    if (fallbackFrame.conversation != null) {
+      fallbackFrame.input = continuationInput;
+      delete fallbackFrame.previous_response_id;
+    } else if (terminalResponseStored) {
+      fallbackFrame.input = continuationInput;
       fallbackFrame.previous_response_id = terminalResponse.id;
     } else {
-      delete fallbackFrame.previous_response_id;
+      fallbackFrame.input = [
+        ...activeResponse.responseCreateInput,
+        ...(Array.isArray(terminalResponse.output)
+          ? terminalResponse.output
+          : []),
+        ...continuationInput,
+      ];
+      if (activeResponse.responseCreatePreviousResponseId) {
+        fallbackFrame.previous_response_id =
+          activeResponse.responseCreatePreviousResponseId;
+      } else {
+        delete fallbackFrame.previous_response_id;
+      }
     }
 
+    activeResponse.responseCreateInput = Array.isArray(fallbackFrame.input)
+      ? [...fallbackFrame.input]
+      : [];
+    activeResponse.responseCreatePreviousResponseId =
+      typeof fallbackFrame.previous_response_id === 'string'
+        ? fallbackFrame.previous_response_id
+        : undefined;
+    activeResponse.responseStored = fallbackFrame.store !== false;
     activeResponse.responseId = undefined;
     activeResponse.responseTemplate = undefined;
     activeResponse.pendingCallIds.clear();

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
@@ -242,6 +242,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     OpenAI.Responses.Response
   >();
   #responseUsages = new WeakMap<OpenAI.Responses.Response, Usage>();
+  #syntheticBoundaryEvents = new WeakSet<Record<string, any>>();
   #requestInProgress = false;
 
   constructor(
@@ -358,6 +359,12 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     );
   }
 
+  protected override _shouldEmitRawModelEvent(
+    event: Record<string, any>,
+  ): boolean {
+    return !this.#syntheticBoundaryEvents.has(event);
+  }
+
   protected override async _fetchResponse(
     request: ModelRequest,
     stream: true,
@@ -405,6 +412,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     let sentWebSocketFrame = false;
     let receivedServerMessage = false;
     let requestMayHaveReachedServer = false;
+    let sentFrameWasReturnedUnsent = false;
     let reachedResponseBoundary = false;
     let threwError = false;
     const requestTimeoutDeadline =
@@ -528,6 +536,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
             message.unsent.length > 0
           ) {
             requestMayHaveReachedServer = false;
+            sentFrameWasReturnedUnsent = sentWebSocketFrame;
           }
           throw new Error(
             `Hosted Multi-agent WebSocket closed (${String(message.code)}): ${String(message.reason ?? '')}`,
@@ -604,8 +613,13 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
         ) {
           const functionCalls = activeResponse.queuedFunctionCalls.splice(0);
           const partialResponse = this.#buildBoundaryResponse(functionCalls);
+          const boundaryEvent = {
+            type: 'response.completed',
+            response: partialResponse,
+          };
+          this.#syntheticBoundaryEvents.add(boundaryEvent);
           reachedResponseBoundary = true;
-          yield { type: 'response.completed', response: partialResponse };
+          yield boundaryEvent;
           return;
         }
 
@@ -661,7 +675,19 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
           }
         ).unsafeToReplay = true;
       }
-      if (!hadActiveResponse || sentWebSocketFrame || receivedServerMessage) {
+      if (
+        hadActiveResponse &&
+        sentFrameWasReturnedUnsent &&
+        !receivedServerMessage
+      ) {
+        const transportOverridesKey = this.#webSocketTransportOverridesKey;
+        this.#dropWebSocketConnection();
+        this.#webSocketTransportOverridesKey = transportOverridesKey;
+      } else if (
+        !hadActiveResponse ||
+        sentWebSocketFrame ||
+        receivedServerMessage
+      ) {
         await this.close();
       }
       throw error;

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
@@ -353,8 +353,8 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
   ): boolean {
     const agentName = event.agent?.agent_name;
     return (
-      agentName === ROOT_AGENT_NAME &&
-      Boolean(outputItem && isRootFinalMessage(outputItem))
+      Boolean(outputItem && isRootFinalMessage(outputItem)) &&
+      (typeof agentName === 'undefined' || agentName === ROOT_AGENT_NAME)
     );
   }
 

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
@@ -236,6 +236,10 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
   #webSocketConnectionKey?: string;
   #webSocketTransportOverridesKey?: string;
   #activeResponse?: ActiveHostedResponse;
+  #normalizedResponses = new WeakMap<
+    OpenAI.Responses.Response,
+    OpenAI.Responses.Response
+  >();
   #responseUsages = new WeakMap<OpenAI.Responses.Response, Usage>();
   #requestInProgress = false;
 
@@ -317,6 +321,12 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     return convertToOutputItem(
       stableItems as Parameters<typeof convertToOutputItem>[0],
     );
+  }
+
+  protected override _getResponseForSDKOutput(
+    response: OpenAI.Responses.Response,
+  ): OpenAI.Responses.Response {
+    return this.#normalizedResponses.get(response) ?? response;
   }
 
   protected override _getResponseUsage(
@@ -599,16 +609,21 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
           }
 
           const terminalEvent = activeResponse.terminalEvent;
-          const response = terminalEvent.response as Record<string, any>;
-          response.output = (
-            Array.isArray(response.output) ? response.output : []
-          ).filter(
-            (item: Record<string, any>) =>
-              item.type !== 'function_call' ||
-              !activeResponse.emittedCallIds.has(item.call_id),
-          );
+          const response = terminalEvent.response as OpenAI.Responses.Response;
+          const normalizedResponse = {
+            ...response,
+            output: (Array.isArray(response.output)
+              ? response.output
+              : []
+            ).filter(
+              (item: Record<string, any>) =>
+                item.type !== 'function_call' ||
+                !activeResponse.emittedCallIds.has(item.call_id),
+            ),
+          } as OpenAI.Responses.Response;
+          this.#normalizedResponses.set(response, normalizedResponse);
           this.#responseUsages.set(
-            response as OpenAI.Responses.Response,
+            response,
             mergeResponseUsages([
               ...activeResponse.requestUsages,
               response.usage as OpenAI.Responses.ResponseUsage | undefined,
@@ -616,7 +631,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
           );
           this.#activeResponse = undefined;
           reachedResponseBoundary = true;
-          yield { ...terminalEvent, response };
+          yield terminalEvent;
           return;
         }
       }

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
@@ -65,6 +65,7 @@ type ActiveHostedResponse = {
   emittedCallIds: Set<string>;
   queuedFunctionCalls: Array<Record<string, any>>;
   terminalEvent?: Record<string, any>;
+  pendingContinuationFrame?: Record<string, any>;
   fallbackInput: Array<Record<string, any>>;
   requestUsages: Array<OpenAI.Responses.ResponseUsage | undefined>;
 };
@@ -410,6 +411,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     this.#requestInProgress = true;
     const hadActiveResponse = Boolean(this.#activeResponse);
     let sentWebSocketFrame = false;
+    let sentWebSocketFrameType: string | undefined;
     let receivedServerMessage = false;
     let requestMayHaveReachedServer = false;
     let sentFrameWasReturnedUnsent = false;
@@ -426,6 +428,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
         throw new OpenAI.APIUserAbortError();
       }
       sentWebSocketFrame = true;
+      sentWebSocketFrameType = frame.type;
       if (webSocket.socket.readyState === WEBSOCKET_OPEN_READY_STATE) {
         requestMayHaveReachedServer = true;
       }
@@ -449,46 +452,60 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
 
       if (this.#activeResponse) {
         const activeResponse = this.#activeResponse;
-        const outputs = getFunctionCallOutputs(
-          requestData,
-          activeResponse.pendingCallIds,
-        );
-        const outputCallIds = new Set(outputs.map((output) => output.call_id));
-        const missingCallIds = Array.from(activeResponse.pendingCallIds).filter(
-          (callId) => !outputCallIds.has(callId),
-        );
-        if (missingCallIds.length > 0) {
-          throw new UserError(
-            `The hosted response is waiting for local function outputs for: ${missingCallIds.join(', ')}. Resume it with the same model instance and RunState.`,
-          );
-        }
-
-        if (activeResponse.terminalEvent) {
-          const continuationFrame = this.#prepareTerminalContinuation(
-            activeResponse,
-            requestData,
-            outputs,
-          );
-          sendWebSocketFrame(webSocket, continuationFrame, builtRequest.signal);
-        } else {
-          if (outputs.length === 0 || !activeResponse.responseId) {
-            throw new UserError(
-              'The hosted response is waiting for local function outputs. Resume it with the same model instance and RunState.',
-            );
-          }
-          pendingInjections = 1;
-          for (const output of outputs) {
-            injectingCallIds.add(output.call_id);
-          }
+        if (activeResponse.pendingContinuationFrame) {
           sendWebSocketFrame(
             webSocket,
-            {
-              type: 'response.inject',
-              response_id: activeResponse.responseId,
-              input: outputs,
-            },
+            activeResponse.pendingContinuationFrame,
             builtRequest.signal,
           );
+        } else {
+          const outputs = getFunctionCallOutputs(
+            requestData,
+            activeResponse.pendingCallIds,
+          );
+          const outputCallIds = new Set(
+            outputs.map((output) => output.call_id),
+          );
+          const missingCallIds = Array.from(
+            activeResponse.pendingCallIds,
+          ).filter((callId) => !outputCallIds.has(callId));
+          if (missingCallIds.length > 0) {
+            throw new UserError(
+              `The hosted response is waiting for local function outputs for: ${missingCallIds.join(', ')}. Resume it with the same model instance and RunState.`,
+            );
+          }
+
+          if (activeResponse.terminalEvent) {
+            const continuationFrame = this.#prepareTerminalContinuation(
+              activeResponse,
+              requestData,
+              outputs,
+            );
+            sendWebSocketFrame(
+              webSocket,
+              continuationFrame,
+              builtRequest.signal,
+            );
+          } else {
+            if (outputs.length === 0 || !activeResponse.responseId) {
+              throw new UserError(
+                'The hosted response is waiting for local function outputs. Resume it with the same model instance and RunState.',
+              );
+            }
+            pendingInjections = 1;
+            for (const output of outputs) {
+              injectingCallIds.add(output.call_id);
+            }
+            sendWebSocketFrame(
+              webSocket,
+              {
+                type: 'response.inject',
+                response_id: activeResponse.responseId,
+                input: outputs,
+              },
+              builtRequest.signal,
+            );
+          }
         }
       } else {
         this.#activeResponse = {
@@ -530,13 +547,18 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
           throw message.error;
         }
         if (message.type === 'close') {
-          if (
-            !receivedServerMessage &&
+          const currentFrameWasReturnedUnsent =
+            sentWebSocketFrame &&
+            typeof sentWebSocketFrameType === 'string' &&
             Array.isArray(message.unsent) &&
-            message.unsent.length > 0
-          ) {
+            message.unsent.some((item: Record<string, any>) => {
+              const unsentFrame =
+                item?.type === 'message' ? item.message : item;
+              return unsentFrame?.type === sentWebSocketFrameType;
+            });
+          if (currentFrameWasReturnedUnsent) {
             requestMayHaveReachedServer = false;
-            sentFrameWasReturnedUnsent = sentWebSocketFrame;
+            sentFrameWasReturnedUnsent = true;
           }
           throw new Error(
             `Hosted Multi-agent WebSocket closed (${String(message.code)}): ${String(message.reason ?? '')}`,
@@ -559,6 +581,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
         if (eventType === 'response.created') {
           activeResponse.responseId = event.response?.id;
           activeResponse.responseTemplate = event.response;
+          activeResponse.pendingContinuationFrame = undefined;
         } else if (eventType === 'response.output_item.done') {
           const item = event.item as Record<string, any> | undefined;
           if (item) {
@@ -675,11 +698,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
           }
         ).unsafeToReplay = true;
       }
-      if (
-        hadActiveResponse &&
-        sentFrameWasReturnedUnsent &&
-        !receivedServerMessage
-      ) {
+      if (hadActiveResponse && sentFrameWasReturnedUnsent) {
         const transportOverridesKey = this.#webSocketTransportOverridesKey;
         this.#dropWebSocketConnection();
         this.#webSocketTransportOverridesKey = transportOverridesKey;
@@ -794,6 +813,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     activeResponse.queuedFunctionCalls = [];
     activeResponse.terminalEvent = undefined;
     activeResponse.fallbackInput = [];
+    activeResponse.pendingContinuationFrame = fallbackFrame;
     return fallbackFrame;
   }
 

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
@@ -18,7 +18,10 @@ import {
   headerAccumulatorToRecord,
   mergeQueryParamsIntoURL,
 } from '../../responsesTransportUtils';
-import { withAbortSignal } from '../../responsesWebSocketConnection';
+import {
+  withAbortSignal,
+  withTimeout,
+} from '../../responsesWebSocketConnection';
 import {
   searchParamsToAuthHeaderQuery,
   toRequestUsageEntry,
@@ -63,6 +66,11 @@ type ActiveHostedResponse = {
   requestUsages: Array<OpenAI.Responses.ResponseUsage | undefined>;
 };
 
+type WebSocketRequestTimeoutDeadline = {
+  configuredTimeoutMs: number;
+  deadlineAtMs: number;
+};
+
 function isHostedTerminalResponseEventType(eventType: unknown): boolean {
   return (
     typeof eventType === 'string' &&
@@ -83,6 +91,7 @@ type HostedWebSocketCreationOptions = {
 type OpenAIClientInternals = OpenAI & {
   _options?: {
     defaultHeaders?: unknown;
+    timeout?: unknown;
   };
   authHeaders?: (options: Record<string, unknown>) => Promise<unknown>;
   _callApiKey?: () => Promise<boolean>;
@@ -377,6 +386,8 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     const hadActiveResponse = Boolean(this.#activeResponse);
     let sentWebSocketFrame = false;
     let receivedWebSocketEvent = false;
+    const requestTimeoutDeadline =
+      this.#createWebSocketRequestTimeoutDeadline();
 
     try {
       const builtRequest = this._buildResponsesCreateRequest(request, true);
@@ -446,7 +457,10 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
       }
 
       while (true) {
-        const message = await this.#nextWebSocketMessage(builtRequest.signal);
+        const message = await this.#nextWebSocketMessage(
+          builtRequest.signal,
+          requestTimeoutDeadline,
+        );
         if (!message) {
           throw new Error(
             'Hosted Multi-agent WebSocket closed before a response boundary.',
@@ -781,6 +795,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
 
   async #nextWebSocketMessage(
     signal: AbortSignal | undefined,
+    requestTimeoutDeadline: WebSocketRequestTimeoutDeadline | undefined,
   ): Promise<Record<string, any> | undefined> {
     if (signal?.aborted) {
       throw new OpenAI.APIUserAbortError();
@@ -789,29 +804,73 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     if (!iterator) {
       throw new Error('Hosted Multi-agent WebSocket iterator is unavailable.');
     }
-    if (!signal) {
-      const result = await iterator.next();
-      return result.done ? undefined : result.value;
+    const frameReadTimeout = this.#resolveWebSocketRequestTimeout(
+      requestTimeoutDeadline,
+    );
+    const result = await withAbortSignal(
+      withTimeout(
+        iterator.next(),
+        frameReadTimeout.timeoutMs,
+        frameReadTimeout.errorMessage,
+      ),
+      signal,
+    );
+    return result.done ? undefined : result.value;
+  }
+
+  #getWebSocketFrameReadTimeoutMs(): number | undefined {
+    const client = this._client as OpenAIClientInternals;
+    const timeoutCandidate =
+      typeof client.timeout === 'number'
+        ? client.timeout
+        : client._options?.timeout;
+
+    if (typeof timeoutCandidate === 'number') {
+      return timeoutCandidate;
     }
 
-    return await new Promise<Record<string, any> | undefined>(
-      (resolve, reject) => {
-        const onAbort = () => {
-          signal.removeEventListener('abort', onAbort);
-          reject(new OpenAI.APIUserAbortError());
-        };
-        signal.addEventListener('abort', onAbort, { once: true });
-        void iterator.next().then(
-          (result) => {
-            signal.removeEventListener('abort', onAbort);
-            resolve(result.done ? undefined : result.value);
-          },
-          (error) => {
-            signal.removeEventListener('abort', onAbort);
-            reject(error);
-          },
-        );
-      },
+    return OpenAI.DEFAULT_TIMEOUT;
+  }
+
+  #createWebSocketRequestTimeoutDeadline():
+    WebSocketRequestTimeoutDeadline | undefined {
+    const timeoutMs = this.#getWebSocketFrameReadTimeoutMs();
+    if (
+      typeof timeoutMs !== 'number' ||
+      !Number.isFinite(timeoutMs) ||
+      timeoutMs <= 0
+    ) {
+      return undefined;
+    }
+
+    return {
+      configuredTimeoutMs: timeoutMs,
+      deadlineAtMs: Date.now() + timeoutMs,
+    };
+  }
+
+  #resolveWebSocketRequestTimeout(
+    requestTimeoutDeadline: WebSocketRequestTimeoutDeadline | undefined,
+  ): { timeoutMs: number | undefined; errorMessage: string } {
+    const configuredTimeoutMs =
+      requestTimeoutDeadline?.configuredTimeoutMs ??
+      this.#getWebSocketFrameReadTimeoutMs();
+    const safeConfiguredTimeoutMs =
+      typeof configuredTimeoutMs === 'number'
+        ? configuredTimeoutMs
+        : OpenAI.DEFAULT_TIMEOUT;
+    const errorMessage = `Hosted Multi-agent WebSocket frame read timed out after ${safeConfiguredTimeoutMs}ms.`;
+    if (!requestTimeoutDeadline) {
+      return { timeoutMs: configuredTimeoutMs, errorMessage };
+    }
+
+    const remainingTimeoutMs = Math.ceil(
+      requestTimeoutDeadline.deadlineAtMs - Date.now(),
     );
+    if (remainingTimeoutMs <= 0) {
+      throw new Error(errorMessage);
+    }
+
+    return { timeoutMs: remainingTimeoutMs, errorMessage };
   }
 }

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
@@ -249,15 +249,6 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
       );
     }
 
-    if (
-      Array.isArray(requestData.context_management) &&
-      requestData.context_management.length > 0
-    ) {
-      throw new UserError(
-        'OpenAIHostedMultiAgentModel does not support explicit Responses compaction. Remove modelSettings.contextManagement.',
-      );
-    }
-
     if (requestData.max_tool_calls != null) {
       throw new UserError(
         'OpenAIHostedMultiAgentModel does not support max_tool_calls. Remove that provider setting.',
@@ -572,13 +563,15 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
       activeResponse.emittedCallIds.add(functionCall.call_id);
     }
 
-    return {
+    const boundaryResponse = {
       ...activeResponse.responseTemplate,
       id: activeResponse.responseId,
       status: 'completed',
       output: functionCalls,
       usage: undefined,
     } as unknown as OpenAI.Responses.Response;
+    this.#responseUsages.set(boundaryResponse, new Usage());
+    return boundaryResponse;
   }
 
   #continueCompletedResponse(

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
@@ -1,0 +1,785 @@
+import {
+  Usage,
+  UserError,
+  protocol,
+  type ModelRequest,
+} from '@openai/agents-core';
+import OpenAI from 'openai';
+import { ResponsesWS } from 'openai/resources/beta/responses/ws';
+import type { OpenAIClient } from '../../openaiClient';
+import { HEADERS } from '../../defaults';
+import {
+  OpenAIResponsesModel,
+  convertToOutputItem,
+} from '../../openaiResponsesModel';
+import {
+  applyHeadersToAccumulator,
+  createHeaderAccumulator,
+  headerAccumulatorToRecord,
+  mergeQueryParamsIntoURL,
+} from '../../responsesTransportUtils';
+import { withAbortSignal } from '../../responsesWebSocketConnection';
+import {
+  searchParamsToAuthHeaderQuery,
+  toRequestUsageEntry,
+} from '../../responsesUtils';
+import type { HostedMultiAgentConfig } from './config';
+
+const ROOT_AGENT_NAME = '/root';
+const MULTI_AGENT_BETA = 'responses_multi_agent=v1';
+const HOSTED_COLLABORATION_ITEM_TYPES = new Set([
+  'agent_message',
+  'multi_agent_call',
+  'multi_agent_call_output',
+]);
+
+type ResponsesWebSocketLike = Pick<ResponsesWS, 'send' | 'close'> &
+  AsyncIterable<Record<string, any>>;
+
+type ActiveHostedResponse = {
+  responseId?: string;
+  responseTemplate?: Record<string, any>;
+  pendingCallIds: Set<string>;
+  emittedCallIds: Set<string>;
+  queuedFunctionCalls: Array<Record<string, any>>;
+  completedEvent?: Record<string, any>;
+  fallbackInput: Array<Record<string, any>>;
+  requestUsages: Array<OpenAI.Responses.ResponseUsage | undefined>;
+};
+
+type HostedWebSocketTransportOptions = {
+  extraHeaders?: Record<string, unknown>;
+  extraQuery?: Record<string, unknown>;
+};
+
+type HostedWebSocketCreationOptions = {
+  client: OpenAI;
+  headers: Record<string, string>;
+};
+
+type OpenAIClientInternals = OpenAI & {
+  _options?: {
+    defaultHeaders?: unknown;
+  };
+  authHeaders?: (options: Record<string, unknown>) => Promise<unknown>;
+  _callApiKey?: () => Promise<boolean>;
+};
+
+function createWebSocketClient(
+  client: OpenAI,
+  extraQuery: Record<string, unknown> | undefined,
+): OpenAI {
+  const websocketClient = Object.create(client) as OpenAI;
+  // ResponsesWS adds client.apiKey after applying the finalized header merge.
+  // Keep authentication entirely in the explicit headers so null unsets survive.
+  websocketClient.apiKey = null;
+  websocketClient.buildURL = (path, query, defaultBaseURL) => {
+    const url = new URL(client.buildURL(path, query, defaultBaseURL));
+    mergeQueryParamsIntoURL(url, extraQuery);
+    return url.toString();
+  };
+  return websocketClient;
+}
+
+function mergeResponseUsages(
+  usages: Array<OpenAI.Responses.ResponseUsage | undefined>,
+): Usage {
+  return new Usage({
+    requests: usages.length,
+    inputTokens: usages.reduce(
+      (total, usage) => total + (usage?.input_tokens ?? 0),
+      0,
+    ),
+    outputTokens: usages.reduce(
+      (total, usage) => total + (usage?.output_tokens ?? 0),
+      0,
+    ),
+    totalTokens: usages.reduce(
+      (total, usage) => total + (usage?.total_tokens ?? 0),
+      0,
+    ),
+    inputTokensDetails: usages.map((usage) => ({
+      ...usage?.input_tokens_details,
+    })),
+    outputTokensDetails: usages.map((usage) => ({
+      ...usage?.output_tokens_details,
+    })),
+    requestUsageEntries: usages.map((usage) =>
+      toRequestUsageEntry(usage, 'responses.create'),
+    ),
+  });
+}
+
+function sortedEntries(
+  record: Record<string, string>,
+): Array<[string, string]> {
+  return Object.entries(record).sort(([left], [right]) =>
+    left.localeCompare(right),
+  );
+}
+
+function getTransportOverridesKey(
+  client: OpenAI,
+  options: HostedWebSocketTransportOptions,
+): string {
+  const websocketClient = createWebSocketClient(client, options.extraQuery);
+  const url = websocketClient.buildURL('/responses', {}, undefined);
+  const headerAccumulator = createHeaderAccumulator();
+  applyHeadersToAccumulator(headerAccumulator, options.extraHeaders, {
+    allowBlockedOverride: true,
+  });
+  return JSON.stringify([
+    url,
+    sortedEntries(headerAccumulatorToRecord(headerAccumulator)),
+  ]);
+}
+
+function validateConfig(
+  config: HostedMultiAgentConfig | undefined,
+): HostedMultiAgentConfig {
+  const maxConcurrentSubagents = config?.maxConcurrentSubagents;
+  if (
+    typeof maxConcurrentSubagents !== 'undefined' &&
+    (!Number.isInteger(maxConcurrentSubagents) || maxConcurrentSubagents <= 0)
+  ) {
+    throw new UserError(
+      'HostedMultiAgentConfig.maxConcurrentSubagents must be a positive integer.',
+    );
+  }
+
+  return Object.freeze(
+    typeof maxConcurrentSubagents === 'undefined'
+      ? {}
+      : { maxConcurrentSubagents },
+  );
+}
+
+function isRootFinalMessage(item: Record<string, any>): boolean {
+  return (
+    item.type === 'message' &&
+    item.agent?.agent_name === ROOT_AGENT_NAME &&
+    item.phase === 'final_answer'
+  );
+}
+
+function toResponseCreateFrame(
+  requestData: Record<string, any>,
+): Record<string, any> {
+  const { betas: _betas, stream: _stream, ...frame } = requestData;
+  return { ...frame, type: 'response.create' };
+}
+
+function getFunctionCallOutputs(
+  requestData: Record<string, any>,
+  pendingCallIds: Set<string>,
+): Array<Record<string, any>> {
+  if (!Array.isArray(requestData.input)) {
+    return [];
+  }
+  return requestData.input.filter(
+    (item: unknown): item is Record<string, any> =>
+      Boolean(
+        item &&
+        typeof item === 'object' &&
+        (item as Record<string, any>).type === 'function_call_output' &&
+        typeof (item as Record<string, any>).call_id === 'string' &&
+        pendingCallIds.has((item as Record<string, any>).call_id),
+      ),
+  );
+}
+
+/**
+ * Experimental OpenAI Responses model that opts into service-hosted Multi-agent orchestration.
+ *
+ * The hosted beta requires a persistent Responses WebSocket because local tool outputs must be
+ * injected into the active response. Call {@link close} when the model is no longer needed.
+ */
+export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
+  public readonly config: HostedMultiAgentConfig;
+  #webSocket?: ResponsesWebSocketLike;
+  #webSocketIterator?: AsyncIterator<Record<string, any>>;
+  #webSocketConnectionKey?: string;
+  #webSocketTransportOverridesKey?: string;
+  #activeResponse?: ActiveHostedResponse;
+  #responseUsages = new WeakMap<OpenAI.Responses.Response, Usage>();
+  #requestInProgress = false;
+
+  constructor(
+    client: OpenAIClient,
+    model: string,
+    config?: HostedMultiAgentConfig,
+  ) {
+    super(client, model);
+    this.config = validateConfig(config);
+  }
+
+  /** Close the persistent Responses WebSocket owned by this model. */
+  async close(): Promise<void> {
+    this.#webSocketIterator = undefined;
+    this.#activeResponse = undefined;
+    const webSocket = this.#webSocket;
+    this.#webSocket = undefined;
+    this.#webSocketConnectionKey = undefined;
+    this.#webSocketTransportOverridesKey = undefined;
+    webSocket?.close();
+  }
+
+  /** @internal */
+  protected _createResponsesWebSocket(
+    options: HostedWebSocketCreationOptions,
+  ): ResponsesWebSocketLike {
+    return new ResponsesWS(options.client, {
+      headers: options.headers,
+    }) as ResponsesWebSocketLike;
+  }
+
+  protected override _getResponsesCreateRequestOverrides(
+    request: ModelRequest,
+    requestData: Record<string, any>,
+  ): Record<string, any> {
+    if (request.handoffs.length > 0) {
+      throw new UserError(
+        'OpenAIHostedMultiAgentModel does not support SDK handoffs. Remove the Agent handoffs or use OpenAIResponsesModel.',
+      );
+    }
+
+    if (requestData.reasoning?.summary != null) {
+      throw new UserError(
+        'OpenAIHostedMultiAgentModel does not support reasoning.summary. Remove the reasoning summary setting.',
+      );
+    }
+
+    if (
+      Array.isArray(requestData.context_management) &&
+      requestData.context_management.length > 0
+    ) {
+      throw new UserError(
+        'OpenAIHostedMultiAgentModel does not support explicit Responses compaction. Remove modelSettings.contextManagement.',
+      );
+    }
+
+    if (requestData.max_tool_calls != null) {
+      throw new UserError(
+        'OpenAIHostedMultiAgentModel does not support max_tool_calls. Remove that provider setting.',
+      );
+    }
+
+    return {
+      multi_agent: {
+        enabled: true,
+        ...(typeof this.config.maxConcurrentSubagents === 'number'
+          ? {
+              max_concurrent_subagents: this.config.maxConcurrentSubagents,
+            }
+          : {}),
+      },
+    };
+  }
+
+  protected override _convertResponseOutputItems(
+    items: Array<Record<string, any>>,
+  ): protocol.OutputModelItem[] {
+    const stableItems = items.filter(
+      (item) =>
+        !HOSTED_COLLABORATION_ITEM_TYPES.has(item.type) &&
+        (item.type !== 'message' || isRootFinalMessage(item)),
+    );
+    return convertToOutputItem(
+      stableItems as Parameters<typeof convertToOutputItem>[0],
+    );
+  }
+
+  protected override _getResponseUsage(
+    response: OpenAI.Responses.Response,
+  ): Usage {
+    return (
+      this.#responseUsages.get(response) ?? super._getResponseUsage(response)
+    );
+  }
+
+  protected override _getStreamedResponseUsage(
+    response: OpenAI.Responses.Response,
+  ): protocol.UsageData {
+    return (
+      this.#responseUsages.get(response) ??
+      super._getStreamedResponseUsage(response)
+    );
+  }
+
+  protected override _shouldEmitOutputTextDelta(
+    event: Record<string, any>,
+    outputItem: Record<string, any> | undefined,
+  ): boolean {
+    const agentName = event.agent?.agent_name;
+    return (
+      agentName === ROOT_AGENT_NAME &&
+      Boolean(outputItem && isRootFinalMessage(outputItem))
+    );
+  }
+
+  protected override async _fetchResponse(
+    request: ModelRequest,
+    stream: true,
+  ): Promise<AsyncIterable<OpenAI.Responses.ResponseStreamEvent>>;
+  protected override async _fetchResponse(
+    request: ModelRequest,
+    stream: false,
+  ): Promise<OpenAI.Responses.Response>;
+  protected override async _fetchResponse(
+    request: ModelRequest,
+    stream: boolean,
+  ): Promise<
+    | AsyncIterable<OpenAI.Responses.ResponseStreamEvent>
+    | OpenAI.Responses.Response
+  > {
+    const events = this.#runWebSocketTurn(request);
+    if (stream) {
+      return events as AsyncIterable<OpenAI.Responses.ResponseStreamEvent>;
+    }
+
+    let response: OpenAI.Responses.Response | undefined;
+    for await (const event of events) {
+      if (event.type === 'response.completed') {
+        response = event.response as OpenAI.Responses.Response;
+      }
+    }
+    if (!response) {
+      throw new Error(
+        'Hosted Multi-agent WebSocket turn ended without a response boundary.',
+      );
+    }
+    return response;
+  }
+
+  async *#runWebSocketTurn(
+    request: ModelRequest,
+  ): AsyncIterable<Record<string, any>> {
+    if (this.#requestInProgress) {
+      throw new UserError(
+        'OpenAIHostedMultiAgentModel does not support concurrent requests on one model instance.',
+      );
+    }
+    this.#requestInProgress = true;
+
+    try {
+      const builtRequest = this._buildResponsesCreateRequest(request, true);
+      const requestData = builtRequest.requestData;
+      const webSocket = await this.#ensureWebSocket(
+        {
+          extraHeaders: builtRequest.transportExtraHeaders,
+          extraQuery: builtRequest.transportExtraQuery,
+        },
+        Boolean(this.#activeResponse),
+        builtRequest.signal,
+      );
+      let pendingInjections = 0;
+      const injectingCallIds = new Set<string>();
+
+      if (this.#activeResponse) {
+        const activeResponse = this.#activeResponse;
+        const outputs = getFunctionCallOutputs(
+          requestData,
+          activeResponse.pendingCallIds,
+        );
+        const outputCallIds = new Set(outputs.map((output) => output.call_id));
+        const missingCallIds = Array.from(activeResponse.pendingCallIds).filter(
+          (callId) => !outputCallIds.has(callId),
+        );
+        if (missingCallIds.length > 0) {
+          throw new UserError(
+            `The hosted response is waiting for local function outputs for: ${missingCallIds.join(', ')}. Resume it with the same model instance and RunState.`,
+          );
+        }
+
+        if (activeResponse.completedEvent) {
+          this.#continueCompletedResponse(
+            activeResponse,
+            requestData,
+            outputs,
+            webSocket,
+          );
+        } else {
+          if (outputs.length === 0 || !activeResponse.responseId) {
+            throw new UserError(
+              'The hosted response is waiting for local function outputs. Resume it with the same model instance and RunState.',
+            );
+          }
+          pendingInjections = 1;
+          for (const output of outputs) {
+            injectingCallIds.add(output.call_id);
+          }
+          webSocket.send({
+            type: 'response.inject',
+            response_id: activeResponse.responseId,
+            input: outputs,
+          } as any);
+        }
+      } else {
+        this.#activeResponse = {
+          pendingCallIds: new Set(),
+          emittedCallIds: new Set(),
+          queuedFunctionCalls: [],
+          fallbackInput: [],
+          requestUsages: [],
+        };
+        webSocket.send(toResponseCreateFrame(requestData) as any);
+      }
+
+      while (true) {
+        const message = await this.#nextWebSocketMessage(builtRequest.signal);
+        if (!message) {
+          throw new Error(
+            'Hosted Multi-agent WebSocket closed before a response boundary.',
+          );
+        }
+        if (message.type === 'error') {
+          throw message.error;
+        }
+        if (message.type === 'close') {
+          throw new Error(
+            `Hosted Multi-agent WebSocket closed (${String(message.code)}): ${String(message.reason ?? '')}`,
+          );
+        }
+        if (message.type !== 'message') {
+          continue;
+        }
+
+        const event = message.message as Record<string, any>;
+        const eventType = event.type;
+        const activeResponse: ActiveHostedResponse | undefined =
+          this.#activeResponse;
+        if (!activeResponse) {
+          throw new Error('Hosted Multi-agent response state was lost.');
+        }
+
+        if (eventType === 'response.created') {
+          activeResponse.responseId = event.response?.id;
+          activeResponse.responseTemplate = event.response;
+        } else if (eventType === 'response.output_item.done') {
+          const item = event.item as Record<string, any> | undefined;
+          if (item) {
+            if (
+              item.type === 'function_call' &&
+              typeof item.call_id === 'string'
+            ) {
+              activeResponse.pendingCallIds.add(item.call_id);
+              if (
+                !activeResponse.emittedCallIds.has(item.call_id) &&
+                !activeResponse.queuedFunctionCalls.some(
+                  (queued) => queued.call_id === item.call_id,
+                )
+              ) {
+                activeResponse.queuedFunctionCalls.push(item);
+              }
+            }
+          }
+        } else if (eventType === 'response.inject.created') {
+          pendingInjections = Math.max(0, pendingInjections - 1);
+          for (const callId of injectingCallIds) {
+            activeResponse.pendingCallIds.delete(callId);
+          }
+        } else if (eventType === 'response.inject.failed') {
+          pendingInjections = Math.max(0, pendingInjections - 1);
+          if (event.error?.code !== 'response_already_completed') {
+            throw new Error(
+              `Hosted Multi-agent response injection failed: ${JSON.stringify(event.error)}`,
+            );
+          }
+          if (Array.isArray(event.input)) {
+            activeResponse.fallbackInput.push(...event.input);
+          }
+          for (const callId of injectingCallIds) {
+            activeResponse.pendingCallIds.delete(callId);
+          }
+        } else if (eventType === 'response.completed') {
+          activeResponse.completedEvent = event;
+        } else if (
+          eventType === 'error' ||
+          eventType === 'response.failed' ||
+          eventType === 'response.incomplete'
+        ) {
+          throw new Error(
+            `Hosted Multi-agent WebSocket response failed: ${JSON.stringify(event)}`,
+          );
+        }
+
+        if (eventType !== 'response.completed') {
+          yield event;
+        }
+
+        if (
+          activeResponse.queuedFunctionCalls.length > 0 &&
+          pendingInjections === 0
+        ) {
+          const functionCalls = activeResponse.queuedFunctionCalls.splice(0);
+          const partialResponse = this.#buildBoundaryResponse(functionCalls);
+          yield { type: 'response.completed', response: partialResponse };
+          return;
+        }
+
+        if (activeResponse.completedEvent && pendingInjections === 0) {
+          if (activeResponse.fallbackInput.length > 0) {
+            this.#continueCompletedResponse(
+              activeResponse,
+              requestData,
+              [],
+              webSocket,
+            );
+            injectingCallIds.clear();
+            continue;
+          }
+
+          const completedEvent = activeResponse.completedEvent;
+          const response = completedEvent.response as Record<string, any>;
+          response.output = (
+            Array.isArray(response.output) ? response.output : []
+          ).filter(
+            (item: Record<string, any>) =>
+              item.type !== 'function_call' ||
+              !activeResponse.emittedCallIds.has(item.call_id),
+          );
+          this.#responseUsages.set(
+            response as OpenAI.Responses.Response,
+            mergeResponseUsages([
+              ...activeResponse.requestUsages,
+              response.usage as OpenAI.Responses.ResponseUsage | undefined,
+            ]),
+          );
+          this.#activeResponse = undefined;
+          yield { ...completedEvent, response };
+          return;
+        }
+      }
+    } catch (error) {
+      await this.close();
+      throw error;
+    } finally {
+      this.#requestInProgress = false;
+    }
+  }
+
+  #buildBoundaryResponse(
+    functionCalls: Array<Record<string, any>>,
+  ): OpenAI.Responses.Response {
+    const activeResponse = this.#activeResponse;
+    if (!activeResponse?.responseTemplate || !activeResponse.responseId) {
+      throw new Error(
+        'Hosted Multi-agent function call arrived before response.created.',
+      );
+    }
+
+    for (const functionCall of functionCalls) {
+      activeResponse.emittedCallIds.add(functionCall.call_id);
+    }
+
+    return {
+      ...activeResponse.responseTemplate,
+      id: activeResponse.responseId,
+      status: 'completed',
+      output: functionCalls,
+      usage: undefined,
+    } as unknown as OpenAI.Responses.Response;
+  }
+
+  #continueCompletedResponse(
+    activeResponse: ActiveHostedResponse,
+    requestData: Record<string, any>,
+    functionOutputs: Array<Record<string, any>>,
+    webSocket: ResponsesWebSocketLike,
+  ): void {
+    const completedResponse = activeResponse.completedEvent?.response as
+      Record<string, any> | undefined;
+    if (!completedResponse?.id) {
+      throw new Error(
+        'Hosted Multi-agent could not continue after a completed response.',
+      );
+    }
+
+    const continuationInput = [
+      ...activeResponse.fallbackInput,
+      ...functionOutputs,
+    ];
+    if (continuationInput.length === 0) {
+      throw new Error(
+        'Hosted Multi-agent completed response continuation requires function outputs.',
+      );
+    }
+
+    activeResponse.requestUsages.push(
+      completedResponse.usage as OpenAI.Responses.ResponseUsage | undefined,
+    );
+    const fallbackFrame = toResponseCreateFrame(requestData);
+    fallbackFrame.input = continuationInput;
+    if (fallbackFrame.conversation == null) {
+      fallbackFrame.previous_response_id = completedResponse.id;
+    } else {
+      delete fallbackFrame.previous_response_id;
+    }
+
+    activeResponse.responseId = undefined;
+    activeResponse.responseTemplate = undefined;
+    activeResponse.pendingCallIds.clear();
+    activeResponse.queuedFunctionCalls = [];
+    activeResponse.completedEvent = undefined;
+    activeResponse.fallbackInput = [];
+    webSocket.send(fallbackFrame as any);
+  }
+
+  async #ensureWebSocket(
+    transportOptions: HostedWebSocketTransportOptions,
+    activeResponse: boolean,
+    signal: AbortSignal | undefined,
+  ): Promise<ResponsesWebSocketLike> {
+    const transportOverridesKey = getTransportOverridesKey(
+      this._client,
+      transportOptions,
+    );
+    if (activeResponse) {
+      if (
+        transportOverridesKey !== this.#webSocketTransportOverridesKey ||
+        !this.#webSocket
+      ) {
+        throw new UserError(
+          'An active hosted response must be resumed with the same WebSocket transport headers and query.',
+        );
+      }
+      return this.#webSocket;
+    }
+
+    const creationOptions = await this.#prepareWebSocketCreationOptions(
+      transportOptions,
+      signal,
+    );
+    const connectionURL = creationOptions.client.buildURL(
+      '/responses',
+      {},
+      undefined,
+    );
+    const connectionKey = JSON.stringify([
+      connectionURL,
+      sortedEntries(creationOptions.headers),
+    ]);
+
+    if (this.#webSocket && this.#webSocketConnectionKey !== connectionKey) {
+      await this.close();
+    }
+
+    if (!this.#webSocket) {
+      this.#webSocket = this._createResponsesWebSocket(creationOptions);
+      this.#webSocketIterator = this.#webSocket[Symbol.asyncIterator]();
+      this.#webSocketConnectionKey = connectionKey;
+    }
+    this.#webSocketTransportOverridesKey = transportOverridesKey;
+    return this.#webSocket;
+  }
+
+  async #prepareWebSocketCreationOptions(
+    transportOptions: HostedWebSocketTransportOptions,
+    signal: AbortSignal | undefined,
+  ): Promise<HostedWebSocketCreationOptions> {
+    const client = this._client as OpenAIClientInternals;
+    if (typeof client._callApiKey === 'function') {
+      await withAbortSignal(client._callApiKey(), signal);
+    }
+    const websocketClient = createWebSocketClient(
+      client,
+      transportOptions.extraQuery,
+    );
+    const websocketURL = new URL(
+      websocketClient.buildURL('/responses', {}, undefined),
+    );
+    const authHeaderQuery = searchParamsToAuthHeaderQuery(
+      websocketURL.searchParams,
+    );
+    const authHeaders =
+      typeof client.authHeaders === 'function'
+        ? await withAbortSignal(
+            client.authHeaders({
+              method: 'get',
+              path: websocketURL.pathname,
+              ...(authHeaderQuery ? { query: authHeaderQuery } : {}),
+            }),
+            signal,
+          )
+        : undefined;
+
+    const headerAccumulator = createHeaderAccumulator();
+    applyHeadersToAccumulator(headerAccumulator, authHeaders);
+    if (
+      typeof client.authHeaders !== 'function' &&
+      typeof client.apiKey === 'string' &&
+      client.apiKey.length > 0 &&
+      client.apiKey !== 'Missing Key'
+    ) {
+      applyHeadersToAccumulator(headerAccumulator, {
+        Authorization: `Bearer ${client.apiKey}`,
+      });
+    }
+    if (client.organization) {
+      applyHeadersToAccumulator(headerAccumulator, {
+        'OpenAI-Organization': client.organization,
+      });
+    }
+    if (client.project) {
+      applyHeadersToAccumulator(headerAccumulator, {
+        'OpenAI-Project': client.project,
+      });
+    }
+    applyHeadersToAccumulator(
+      headerAccumulator,
+      client._options?.defaultHeaders,
+    );
+    applyHeadersToAccumulator(headerAccumulator, HEADERS);
+    applyHeadersToAccumulator(
+      headerAccumulator,
+      transportOptions.extraHeaders,
+      { allowBlockedOverride: true },
+    );
+    applyHeadersToAccumulator(
+      headerAccumulator,
+      { 'OpenAI-Beta': MULTI_AGENT_BETA },
+      { allowBlockedOverride: true },
+    );
+
+    return {
+      client: websocketClient,
+      headers: headerAccumulatorToRecord(headerAccumulator),
+    };
+  }
+
+  async #nextWebSocketMessage(
+    signal: AbortSignal | undefined,
+  ): Promise<Record<string, any> | undefined> {
+    if (signal?.aborted) {
+      throw new OpenAI.APIUserAbortError();
+    }
+    const iterator = this.#webSocketIterator;
+    if (!iterator) {
+      throw new Error('Hosted Multi-agent WebSocket iterator is unavailable.');
+    }
+    if (!signal) {
+      const result = await iterator.next();
+      return result.done ? undefined : result.value;
+    }
+
+    return await new Promise<Record<string, any> | undefined>(
+      (resolve, reject) => {
+        const onAbort = () => {
+          signal.removeEventListener('abort', onAbort);
+          reject(new OpenAI.APIUserAbortError());
+        };
+        signal.addEventListener('abort', onAbort, { once: true });
+        void iterator.next().then(
+          (result) => {
+            signal.removeEventListener('abort', onAbort);
+            resolve(result.done ? undefined : result.value);
+          },
+          (error) => {
+            signal.removeEventListener('abort', onAbort);
+            reject(error);
+          },
+        );
+      },
+    );
+  }
+}

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
@@ -2,6 +2,8 @@ import {
   Usage,
   UserError,
   protocol,
+  type ModelRetryAdvice,
+  type ModelRetryAdviceRequest,
   type ModelRequest,
 } from '@openai/agents-core';
 import OpenAI from 'openai';
@@ -91,6 +93,16 @@ type HostedWebSocketCreationOptions = {
   client: OpenAI;
   headers: Record<string, string>;
 };
+
+class HostedMultiAgentWebSocketClosedError extends Error {
+  constructor(
+    message: string,
+    readonly frameWasUnsent: boolean,
+  ) {
+    super(message);
+    this.name = 'HostedMultiAgentWebSocketClosedError';
+  }
+}
 
 type OpenAIClientInternals = OpenAI & {
   _options?: {
@@ -253,6 +265,23 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
   ) {
     super(client, model);
     this.config = validateConfig(config);
+  }
+
+  override getRetryAdvice(
+    args: ModelRetryAdviceRequest,
+  ): ModelRetryAdvice | undefined {
+    if (
+      args.error instanceof HostedMultiAgentWebSocketClosedError &&
+      args.error.frameWasUnsent
+    ) {
+      return {
+        suggested: true,
+        replaySafety: 'safe',
+        reason: args.error.message,
+      };
+    }
+
+    return super.getRetryAdvice(args);
   }
 
   /** Close the persistent Responses WebSocket owned by this model. */
@@ -560,8 +589,9 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
             requestMayHaveReachedServer = false;
             sentFrameWasReturnedUnsent = true;
           }
-          throw new Error(
+          throw new HostedMultiAgentWebSocketClosedError(
             `Hosted Multi-agent WebSocket closed (${String(message.code)}): ${String(message.reason ?? '')}`,
+            currentFrameWasReturnedUnsent,
           );
         }
         if (message.type !== 'message') {

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -2888,6 +2888,13 @@ export class OpenAIResponsesModel implements Model {
   /**
    * @internal
    */
+  protected _shouldEmitRawModelEvent(_event: Record<string, any>): boolean {
+    return true;
+  }
+
+  /**
+   * @internal
+   */
   protected _getResponsesCreateRequestOverrides(
     _request: ModelRequest,
     _requestData: Record<string, any>,
@@ -3210,6 +3217,9 @@ export class OpenAIResponsesModel implements Model {
       const outputItemsByIndex = new Map<number, Record<string, any>>();
       for await (const event of response) {
         const eventType = (event as { type?: string }).type;
+        const shouldEmitRawModelEvent = this._shouldEmitRawModelEvent(
+          event as unknown as Record<string, any>,
+        );
         if (eventType === 'response.output_item.added') {
           const outputItemAdded = event as unknown as {
             output_index?: number;
@@ -3259,7 +3269,7 @@ export class OpenAIResponsesModel implements Model {
             },
             providerData: remainingEvent,
           };
-          if (eventType === 'response.completed') {
+          if (eventType === 'response.completed' && shouldEmitRawModelEvent) {
             yield {
               type: 'model',
               event: event,
@@ -3291,13 +3301,15 @@ export class OpenAIResponsesModel implements Model {
           }
         }
 
-        yield {
-          type: 'model',
-          event: event,
-          providerData: {
-            rawModelEventSource: OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE,
-          },
-        };
+        if (shouldEmitRawModelEvent) {
+          yield {
+            type: 'model',
+            event: event,
+            providerData: {
+              rawModelEventSource: OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE,
+            },
+          };
+        }
       }
 
       if (request.tracing && span && finalResponse) {

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -2860,6 +2860,69 @@ export class OpenAIResponsesModel implements Model {
   /**
    * @internal
    */
+  protected _convertResponseOutputItems(
+    items: Array<Record<string, any>>,
+  ): protocol.OutputModelItem[] {
+    return convertToOutputItem(items as ResponseOutputItemWithFunctionResult[]);
+  }
+
+  /**
+   * @internal
+   */
+  protected _shouldEmitOutputTextDelta(
+    _event: Record<string, any>,
+    _outputItem: Record<string, any> | undefined,
+  ): boolean {
+    return true;
+  }
+
+  /**
+   * @internal
+   */
+  protected _getResponsesCreateRequestOverrides(
+    _request: ModelRequest,
+    _requestData: Record<string, any>,
+  ): Record<string, any> {
+    return {};
+  }
+
+  /**
+   * @internal
+   */
+  protected _getResponseUsage(response: OpenAI.Responses.Response): Usage {
+    return new Usage({
+      inputTokens: response.usage?.input_tokens ?? 0,
+      outputTokens: response.usage?.output_tokens ?? 0,
+      totalTokens: response.usage?.total_tokens ?? 0,
+      inputTokensDetails: { ...response.usage?.input_tokens_details },
+      outputTokensDetails: { ...response.usage?.output_tokens_details },
+      requestUsageEntries: [
+        toRequestUsageEntry(response.usage, 'responses.create'),
+      ],
+    });
+  }
+
+  /**
+   * @internal
+   */
+  protected _getStreamedResponseUsage(
+    response: OpenAI.Responses.Response,
+  ): protocol.UsageData {
+    return {
+      inputTokens: response.usage?.input_tokens ?? 0,
+      outputTokens: response.usage?.output_tokens ?? 0,
+      totalTokens: response.usage?.total_tokens ?? 0,
+      inputTokensDetails: { ...response.usage?.input_tokens_details },
+      outputTokensDetails: { ...response.usage?.output_tokens_details },
+      requestUsageEntries: [
+        toRequestUsageEntry(response.usage, 'responses.create'),
+      ],
+    };
+  }
+
+  /**
+   * @internal
+   */
   protected async _fetchResponse(
     request: ModelRequest,
     stream: true,
@@ -3040,6 +3103,11 @@ export class OpenAIResponsesModel implements Model {
       };
     }
 
+    requestData = {
+      ...requestData,
+      ...this._getResponsesCreateRequestOverrides(request, requestData),
+    };
+
     // Keep the transport mode aligned with the calling path even if extra_body includes stream.
     requestData.stream = stream;
 
@@ -3097,17 +3165,10 @@ export class OpenAIResponsesModel implements Model {
     });
 
     const output: ModelResponse = {
-      usage: new Usage({
-        inputTokens: response.usage?.input_tokens ?? 0,
-        outputTokens: response.usage?.output_tokens ?? 0,
-        totalTokens: response.usage?.total_tokens ?? 0,
-        inputTokensDetails: { ...response.usage?.input_tokens_details },
-        outputTokensDetails: { ...response.usage?.output_tokens_details },
-        requestUsageEntries: [
-          toRequestUsageEntry(response.usage, 'responses.create'),
-        ],
-      }),
-      output: convertToOutputItem(response.output),
+      usage: this._getResponseUsage(response),
+      output: this._convertResponseOutputItems(
+        response.output as Array<Record<string, any>>,
+      ),
       responseId: response.id,
       requestId: getOpenAIResponseRequestId(response),
       providerData: response,
@@ -3136,8 +3197,24 @@ export class OpenAIResponsesModel implements Model {
       const response = await this._fetchResponse(request, true);
 
       let finalResponse: OpenAI.Responses.Response | undefined;
+      const outputItemsByIndex = new Map<number, Record<string, any>>();
       for await (const event of response) {
         const eventType = (event as { type?: string }).type;
+        if (eventType === 'response.output_item.added') {
+          const outputItemAdded = event as unknown as {
+            output_index?: number;
+            item?: Record<string, any>;
+          };
+          if (
+            typeof outputItemAdded.output_index === 'number' &&
+            outputItemAdded.item
+          ) {
+            outputItemsByIndex.set(
+              outputItemAdded.output_index,
+              outputItemAdded.item,
+            );
+          }
+        }
         if (eventType === 'response.created') {
           yield {
             type: 'response_started',
@@ -3152,27 +3229,16 @@ export class OpenAIResponsesModel implements Model {
             };
           finalResponse = terminalEvent.response;
           const { response, ...remainingEvent } = terminalEvent;
-          const { output, usage, id, ...remainingResponse } = response;
+          const { output, usage: _usage, id, ...remainingResponse } = response;
           yield {
             type: 'response_done',
             response: {
               id: id,
               requestId: getOpenAIResponseRequestId(response),
-              output: convertToOutputItem(output),
-              usage: {
-                inputTokens: usage?.input_tokens ?? 0,
-                outputTokens: usage?.output_tokens ?? 0,
-                totalTokens: usage?.total_tokens ?? 0,
-                inputTokensDetails: {
-                  ...usage?.input_tokens_details,
-                },
-                outputTokensDetails: {
-                  ...usage?.output_tokens_details,
-                },
-                requestUsageEntries: [
-                  toRequestUsageEntry(usage, 'responses.create'),
-                ],
-              },
+              output: this._convertResponseOutputItems(
+                output as Array<Record<string, any>>,
+              ),
+              usage: this._getStreamedResponseUsage(response),
               providerData: remainingResponse,
             },
             providerData: remainingEvent,
@@ -3187,14 +3253,26 @@ export class OpenAIResponsesModel implements Model {
             };
           }
         } else if (eventType === 'response.output_text.delta') {
-          const { delta, ...remainingEvent } = event as {
+          const { delta, ...remainingEvent } = event as unknown as {
             delta: string;
+            output_index?: number;
           } & Record<string, any>;
-          yield {
-            type: 'output_text_delta',
-            delta: delta,
-            providerData: remainingEvent,
-          };
+          const outputItem =
+            typeof remainingEvent.output_index === 'number'
+              ? outputItemsByIndex.get(remainingEvent.output_index)
+              : undefined;
+          if (
+            this._shouldEmitOutputTextDelta(
+              event as unknown as Record<string, any>,
+              outputItem,
+            )
+          ) {
+            yield {
+              type: 'output_text_delta',
+              delta: delta,
+              providerData: remainingEvent,
+            };
+          }
         }
 
         yield {
@@ -3614,8 +3692,7 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
     mergeQueryParamsIntoURL(
       baseURL,
       clientWithInternals._options?.defaultQuery as
-        | Record<string, unknown>
-        | undefined,
+        Record<string, unknown> | undefined,
     );
     if (explicitBaseQuery && Array.from(explicitBaseQuery.keys()).length > 0) {
       const explicitTopLevelKeys = new Set<string>();
@@ -3802,8 +3879,7 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
   }
 
   #createWebSocketRequestTimeoutDeadline():
-    | WebSocketRequestTimeoutDeadline
-    | undefined {
+    WebSocketRequestTimeoutDeadline | undefined {
     const timeoutMs = this.#getWebSocketFrameReadTimeoutMs();
     if (
       typeof timeoutMs !== 'number' ||

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -3269,15 +3269,6 @@ export class OpenAIResponsesModel implements Model {
             },
             providerData: remainingEvent,
           };
-          if (eventType === 'response.completed' && shouldEmitRawModelEvent) {
-            yield {
-              type: 'model',
-              event: event,
-              providerData: {
-                rawModelEventSource: OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE,
-              },
-            };
-          }
         } else if (eventType === 'response.output_text.delta') {
           const { delta, ...remainingEvent } = event as unknown as {
             delta: string;

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -2869,6 +2869,15 @@ export class OpenAIResponsesModel implements Model {
   /**
    * @internal
    */
+  protected _getResponseForSDKOutput(
+    response: OpenAI.Responses.Response,
+  ): OpenAI.Responses.Response {
+    return response;
+  }
+
+  /**
+   * @internal
+   */
   protected _shouldEmitOutputTextDelta(
     _event: Record<string, any>,
     _outputItem: Record<string, any> | undefined,
@@ -3164,10 +3173,11 @@ export class OpenAIResponsesModel implements Model {
       return response;
     });
 
+    const responseForSDKOutput = this._getResponseForSDKOutput(response);
     const output: ModelResponse = {
       usage: this._getResponseUsage(response),
       output: this._convertResponseOutputItems(
-        response.output as Array<Record<string, any>>,
+        responseForSDKOutput.output as Array<Record<string, any>>,
       ),
       responseId: response.id,
       requestId: getOpenAIResponseRequestId(response),
@@ -3229,14 +3239,20 @@ export class OpenAIResponsesModel implements Model {
             };
           finalResponse = terminalEvent.response;
           const { response, ...remainingEvent } = terminalEvent;
-          const { output, usage: _usage, id, ...remainingResponse } = response;
+          const {
+            output: _output,
+            usage: _usage,
+            id,
+            ...remainingResponse
+          } = response;
+          const responseForSDKOutput = this._getResponseForSDKOutput(response);
           yield {
             type: 'response_done',
             response: {
               id: id,
               requestId: getOpenAIResponseRequestId(response),
               output: this._convertResponseOutputItems(
-                output as Array<Record<string, any>>,
+                responseForSDKOutput.output as Array<Record<string, any>>,
               ),
               usage: this._getStreamedResponseUsage(response),
               providerData: remainingResponse,

--- a/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
+++ b/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
@@ -214,6 +214,110 @@ describe('OpenAIHostedMultiAgentModel', () => {
     expect(secondResponse.responseId).toBe('resp_second');
   });
 
+  it('closes a hosted turn when the streaming consumer stops early', async () => {
+    const firstWebSocket = new FakeResponsesWebSocket([
+      { type: 'response.created', response: emptyResponse('resp_abandoned') },
+      {
+        type: 'response.completed',
+        response: emptyResponse('resp_abandoned'),
+      },
+    ]);
+    const secondWebSocket = new FakeResponsesWebSocket([
+      { type: 'response.created', response: emptyResponse('resp_next') },
+      { type: 'response.completed', response: emptyResponse('resp_next') },
+    ]);
+    const model = new TestHostedMultiAgentModel([
+      firstWebSocket,
+      secondWebSocket,
+    ]);
+
+    await withTestTrace(async () => {
+      for await (const _event of model.getStreamedResponse(request())) {
+        break;
+      }
+    });
+    const nextResponse = await withTestTrace(() =>
+      model.getResponse(request({ input: 'Start a clean hosted turn.' })),
+    );
+
+    expect(firstWebSocket.close).toHaveBeenCalledOnce();
+    expect(model.webSocketCreationOptions).toHaveLength(2);
+    expect(secondWebSocket.sent[0]?.type).toBe('response.create');
+    expect(nextResponse.responseId).toBe('resp_next');
+  });
+
+  it('reconnects before injecting into a closed active hosted response', async () => {
+    const functionCall = {
+      type: 'function_call',
+      id: 'fc_reconnect',
+      call_id: 'call_reconnect',
+      name: 'lookup',
+      arguments: '{}',
+      status: 'completed',
+      agent: { agent_name: '/root/researcher' },
+    };
+    const rootFinal = {
+      type: 'message',
+      id: 'msg_reconnect_final',
+      role: 'assistant',
+      status: 'completed',
+      phase: 'final_answer',
+      agent: { agent_name: '/root' },
+      content: [{ type: 'output_text', text: 'Reconnected.' }],
+    };
+    const firstWebSocket = new FakeResponsesWebSocket([
+      { type: 'response.created', response: emptyResponse('resp_reconnect') },
+      { type: 'response.output_item.done', item: functionCall },
+    ]);
+    const secondWebSocket = new FakeResponsesWebSocket([
+      { type: 'response.inject.created', response_id: 'resp_reconnect' },
+      {
+        type: 'response.completed',
+        response: {
+          ...emptyResponse('resp_reconnect'),
+          output: [functionCall, rootFinal],
+        },
+      },
+    ]);
+    const model = new TestHostedMultiAgentModel([
+      firstWebSocket,
+      secondWebSocket,
+    ]);
+
+    const boundary = await withTestTrace(() => model.getResponse(request()));
+    firstWebSocket.closeFromServer();
+    const response = await withTestTrace(() =>
+      model.getResponse(
+        request({
+          input: [
+            ...boundary.output,
+            {
+              type: 'function_call_result',
+              callId: 'call_reconnect',
+              output: 'lookup result',
+              status: 'completed',
+            },
+          ],
+        }),
+      ),
+    );
+
+    expect(model.webSocketCreationOptions).toHaveLength(2);
+    expect(firstWebSocket.close).toHaveBeenCalledOnce();
+    expect(secondWebSocket.sent[0]).toMatchObject({
+      type: 'response.inject',
+      response_id: 'resp_reconnect',
+      input: [
+        expect.objectContaining({
+          type: 'function_call_output',
+          call_id: 'call_reconnect',
+          output: 'lookup result',
+        }),
+      ],
+    });
+    expect(response.output[0]?.type).toBe('message');
+  });
+
   it.each([false, true])(
     'applies the client timeout while waiting for hosted WebSocket events (stream: %s)',
     async (stream) => {

--- a/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
+++ b/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
@@ -974,6 +974,117 @@ describe('OpenAIHostedMultiAgentModel', () => {
     },
   );
 
+  it.each([
+    { stream: false, storedBaseResponseId: undefined },
+    { stream: true, storedBaseResponseId: undefined },
+    { stream: false, storedBaseResponseId: 'resp_stored_base' },
+  ])(
+    'replays stateless history after an injection race (stream: $stream, stored base: $storedBaseResponseId)',
+    async ({ stream, storedBaseResponseId }) => {
+      const functionCall = {
+        type: 'function_call',
+        id: 'fc_stateless_race',
+        call_id: 'call_stateless_race',
+        name: 'lookup',
+        arguments: '{}',
+        status: 'completed',
+        agent: { agent_name: '/root/researcher' },
+      };
+      const failedInput = {
+        type: 'function_call_output',
+        call_id: 'call_stateless_race',
+        output: 'result',
+      };
+      const fakeWebSocket = new FakeResponsesWebSocket([
+        {
+          type: 'response.created',
+          response: { ...emptyResponse('resp_stateless_race'), store: false },
+        },
+        { type: 'response.output_item.done', item: functionCall },
+        {
+          type: 'response.completed',
+          response: {
+            ...emptyResponse('resp_stateless_race'),
+            store: false,
+            output: [functionCall],
+          },
+        },
+        {
+          type: 'response.inject.failed',
+          response_id: 'resp_stateless_race',
+          input: [failedInput],
+          error: {
+            code: 'response_already_completed',
+            message: 'Already completed.',
+          },
+        },
+        {
+          type: 'response.created',
+          response: {
+            ...emptyResponse('resp_stateless_fallback'),
+            store: false,
+          },
+        },
+        {
+          type: 'response.completed',
+          response: {
+            ...emptyResponse('resp_stateless_fallback'),
+            store: false,
+          },
+        },
+      ]);
+      const model = new TestHostedMultiAgentModel(fakeWebSocket);
+      const first = await getTestResponse(
+        model,
+        request({
+          previousResponseId: storedBaseResponseId,
+          modelSettings: { store: false },
+        }),
+        stream,
+      );
+
+      await getTestResponse(
+        model,
+        request({
+          previousResponseId: storedBaseResponseId
+            ? 'resp_stateless_race'
+            : undefined,
+          modelSettings: { store: false },
+          input: [
+            ...first.output,
+            {
+              type: 'function_call_result',
+              callId: 'call_stateless_race',
+              output: 'result',
+              status: 'completed',
+            },
+          ],
+        }),
+        stream,
+      );
+
+      expect(fakeWebSocket.sent[2]).toMatchObject({
+        type: 'response.create',
+        store: false,
+        input: [
+          ...(fakeWebSocket.sent[0].input as Array<Record<string, any>>),
+          functionCall,
+          failedInput,
+        ],
+      });
+      if (storedBaseResponseId) {
+        expect(fakeWebSocket.sent[2]).toHaveProperty(
+          'previous_response_id',
+          storedBaseResponseId,
+        );
+      } else {
+        expect(fakeWebSocket.sent[2]).not.toHaveProperty(
+          'previous_response_id',
+        );
+      }
+    },
+  );
+
   it('keeps conversation continuation mutually exclusive with previous_response_id', async () => {
     const functionCall = {
       type: 'function_call',

--- a/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
+++ b/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
@@ -860,12 +860,14 @@ describe('OpenAIHostedMultiAgentModel', () => {
       throw new Error('Stream ended without a response_done event.');
     }
     expect(done.response.output.map((item) => item.type)).toEqual(['message']);
-    const rawTerminalEvent = streamEvents.find(
+    const rawTerminalEvents = streamEvents.filter(
       (event) =>
         event.type === 'model' &&
         (event.event as any).type === 'response.completed' &&
         (event.event as any).response?.id === 'resp_raw_terminal',
     );
+    expect(rawTerminalEvents).toHaveLength(1);
+    const rawTerminalEvent = rawTerminalEvents[0];
     if (rawTerminalEvent?.type !== 'model') {
       throw new Error('Stream ended without a raw terminal model event.');
     }

--- a/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
+++ b/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
@@ -1361,6 +1361,14 @@ describe('OpenAIHostedMultiAgentModel', () => {
 
       expect(error).toBeInstanceOf(Error);
       expect(error?.unsafeToReplay).toBeUndefined();
+      expect(
+        model.getRetryAdvice({
+          error,
+          request: resumeRequest,
+          stream,
+          attempt: 1,
+        }),
+      ).toMatchObject({ suggested: true, replaySafety: 'safe' });
       const response = await getTestResponse(model, resumeRequest, stream);
 
       expect(retryWebSocket.sent[0]).toEqual(firstWebSocket.sent[2]);
@@ -1751,7 +1759,10 @@ describe('OpenAIHostedMultiAgentModel', () => {
         stream,
         attempt: 1,
       });
-      expect(retryAdvice?.replaySafety).not.toBe('unsafe');
+      expect(retryAdvice).toMatchObject({
+        suggested: true,
+        replaySafety: 'safe',
+      });
       expect(fakeWebSocket.close).toHaveBeenCalledOnce();
     },
   );
@@ -1828,6 +1839,14 @@ describe('OpenAIHostedMultiAgentModel', () => {
 
       expect(error).toBeInstanceOf(Error);
       expect(error?.unsafeToReplay).toBeUndefined();
+      expect(
+        model.getRetryAdvice({
+          error,
+          request: resumeRequest,
+          stream,
+          attempt: 1,
+        }),
+      ).toMatchObject({ suggested: true, replaySafety: 'safe' });
       const response = await getTestResponse(model, resumeRequest, stream);
 
       expect(failedResumeWebSocket.close).toHaveBeenCalledOnce();

--- a/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
+++ b/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
@@ -1684,7 +1684,6 @@ describe('OpenAIHostedMultiAgentModel', () => {
         type: 'response.output_text.delta',
         output_index: 1,
         delta: 'Root final.',
-        agent: { agent_name: '/root' },
       },
       {
         type: 'response.completed',

--- a/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
+++ b/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
@@ -36,10 +36,12 @@ function message(message: Record<string, any>) {
 class FakeResponsesWebSocket {
   readonly sent: Array<Record<string, any>> = [];
   readonly close = vi.fn();
-  #events: Array<Record<string, any>>;
+  #events: Array<Record<string, any> | Error>;
 
-  constructor(events: Array<Record<string, any>>) {
-    this.#events = events.map(message);
+  constructor(events: Array<Record<string, any> | Error>) {
+    this.#events = events.map((event) =>
+      event instanceof Error ? event : message(event),
+    );
   }
 
   send(event: Record<string, any>) {
@@ -50,6 +52,9 @@ class FakeResponsesWebSocket {
     return {
       next: async () => {
         const value = this.#events.shift();
+        if (value instanceof Error) {
+          throw value;
+        }
         return value
           ? { value, done: false as const }
           : { value: undefined, done: true as const };
@@ -342,6 +347,16 @@ describe('OpenAIHostedMultiAgentModel', () => {
       agent_name: '/root/researcher',
     });
 
+    await expect(
+      withTestTrace(() =>
+        model.getResponse(request({ input: [...first.output] })),
+      ),
+    ).rejects.toThrow(
+      'The hosted response is waiting for local function outputs for: call_lookup.',
+    );
+    expect(fakeWebSocket.sent).toHaveLength(1);
+    expect(fakeWebSocket.close).not.toHaveBeenCalled();
+
     const second = await withTestTrace(() =>
       model.getResponse(
         request({
@@ -485,6 +500,28 @@ describe('OpenAIHostedMultiAgentModel', () => {
       'call_beta',
       'call_gamma',
     ]);
+
+    await expect(
+      withTestTrace(() =>
+        model.getResponse(
+          request({
+            input: [
+              ...second.output,
+              {
+                type: 'function_call_result',
+                callId: 'call_beta',
+                output: 'beta result',
+                status: 'completed',
+              },
+            ],
+          }),
+        ),
+      ),
+    ).rejects.toThrow(
+      'The hosted response is waiting for local function outputs for: call_gamma.',
+    );
+    expect(fakeWebSocket.sent).toHaveLength(2);
+    expect(fakeWebSocket.close).not.toHaveBeenCalled();
 
     const third = await withTestTrace(() =>
       model.getResponse(
@@ -921,6 +958,34 @@ describe('OpenAIHostedMultiAgentModel', () => {
       );
     },
   );
+
+  it('marks a non-streaming turn unsafe to replay after consuming a WebSocket event', async () => {
+    const socketError = new Error('WebSocket read failed.');
+    const fakeWebSocket = new FakeResponsesWebSocket([
+      { type: 'response.created', response: emptyResponse('resp_started') },
+      socketError,
+    ]);
+    const model = new TestHostedMultiAgentModel(fakeWebSocket);
+
+    let error: (Error & { unsafeToReplay?: boolean }) | undefined;
+    try {
+      await withTestTrace(() => model.getResponse(request()));
+    } catch (caught) {
+      error = caught as Error & { unsafeToReplay?: boolean };
+    }
+
+    expect(error).toBe(socketError);
+    expect(error?.unsafeToReplay).toBe(true);
+    expect(
+      model.getRetryAdvice({
+        error,
+        request: request(),
+        stream: false,
+        attempt: 1,
+      }),
+    ).toMatchObject({ suggested: false, replaySafety: 'unsafe' });
+    expect(fakeWebSocket.close).toHaveBeenCalledOnce();
+  });
 
   it('keeps stable Responses requests free of hosted beta fields', async () => {
     const stableCreate = vi.fn().mockResolvedValue(emptyResponse());

--- a/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
+++ b/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
@@ -1,6 +1,11 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import OpenAI from 'openai';
-import { setTracingDisabled, UserError, withTrace } from '@openai/agents-core';
+import {
+  setTracingDisabled,
+  UserError,
+  withTrace,
+  type ResponseStreamEvent,
+} from '@openai/agents-core';
 import { OpenAIResponsesModel } from '../../src/openaiResponsesModel';
 import {
   OpenAIHostedMultiAgentModel,
@@ -609,6 +614,93 @@ describe('OpenAIHostedMultiAgentModel', () => {
       phase: 'final_answer',
       agent: { agent_name: '/root' },
     });
+    expect(second.providerData?.output).toEqual([
+      hostedCall,
+      functionCall,
+      rootFinal,
+    ]);
+  });
+
+  it('preserves local function calls in raw streamed terminal events', async () => {
+    const functionCall = {
+      type: 'function_call',
+      id: 'fc_raw_terminal',
+      call_id: 'call_raw_terminal',
+      name: 'lookup',
+      arguments: '{"key":"alpha"}',
+      status: 'completed',
+      agent: { agent_name: '/root/researcher' },
+    };
+    const rootFinal = {
+      type: 'message',
+      id: 'msg_raw_terminal',
+      role: 'assistant',
+      status: 'completed',
+      phase: 'final_answer',
+      agent: { agent_name: '/root' },
+      content: [{ type: 'output_text', text: 'Final answer.' }],
+    };
+    const terminalResponse = {
+      ...emptyResponse('resp_raw_terminal'),
+      output: [functionCall, rootFinal],
+    };
+    const fakeWebSocket = new FakeResponsesWebSocket([
+      {
+        type: 'response.created',
+        response: emptyResponse('resp_raw_terminal'),
+      },
+      { type: 'response.output_item.done', item: functionCall },
+      {
+        type: 'response.inject.created',
+        response_id: 'resp_raw_terminal',
+      },
+      { type: 'response.completed', response: terminalResponse },
+    ]);
+    const model = new TestHostedMultiAgentModel(fakeWebSocket);
+
+    const boundary = await getTestResponse(model, request(), true);
+    expect(boundary.output.map((item: any) => item.type)).toEqual([
+      'function_call',
+    ]);
+
+    const streamEvents: ResponseStreamEvent[] = [];
+    await withTestTrace(async () => {
+      for await (const event of model.getStreamedResponse(
+        request({
+          input: [
+            ...boundary.output,
+            {
+              type: 'function_call_result',
+              callId: 'call_raw_terminal',
+              output: 'lookup result',
+              status: 'completed',
+            },
+          ],
+        }),
+      )) {
+        streamEvents.push(event);
+      }
+    });
+
+    const done = streamEvents.find((event) => event.type === 'response_done');
+    if (done?.type !== 'response_done') {
+      throw new Error('Stream ended without a response_done event.');
+    }
+    expect(done.response.output.map((item) => item.type)).toEqual(['message']);
+    const rawTerminalEvent = streamEvents.find(
+      (event) =>
+        event.type === 'model' &&
+        (event.event as any).type === 'response.completed' &&
+        (event.event as any).response?.id === 'resp_raw_terminal',
+    );
+    if (rawTerminalEvent?.type !== 'model') {
+      throw new Error('Stream ended without a raw terminal model event.');
+    }
+    expect((rawTerminalEvent.event as any).response.output).toEqual([
+      functionCall,
+      rootFinal,
+    ]);
+    expect(terminalResponse.output).toEqual([functionCall, rootFinal]);
   });
 
   it.each([false, true])(

--- a/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
+++ b/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
@@ -460,6 +460,107 @@ describe('OpenAIHostedMultiAgentModel', () => {
   });
 
   it.each([false, true])(
+    'does not create or send on an already-aborted request (stream: %s)',
+    async (stream) => {
+      const fakeWebSocket = new FakeResponsesWebSocket([]);
+      const model = new TestHostedMultiAgentModel(fakeWebSocket);
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(
+        getTestResponse(model, request({ signal: controller.signal }), stream),
+      ).rejects.toBeInstanceOf(OpenAI.APIUserAbortError);
+
+      expect(model.webSocketCreationOptions).toHaveLength(0);
+      expect(fakeWebSocket.sent).toHaveLength(0);
+    },
+  );
+
+  it('does not send after a cached socket aborts during reuse', async () => {
+    const fakeWebSocket = new FakeResponsesWebSocket([
+      { type: 'response.created', response: emptyResponse('resp_first') },
+      { type: 'response.completed', response: emptyResponse('resp_first') },
+    ]);
+    const model = new TestHostedMultiAgentModel(fakeWebSocket);
+    await withTestTrace(() => model.getResponse(request()));
+
+    const controller = new AbortController();
+    let readyState = fakeWebSocket.socket.readyState;
+    Object.defineProperty(fakeWebSocket.socket, 'readyState', {
+      configurable: true,
+      get() {
+        controller.abort();
+        return readyState;
+      },
+      set(value: number) {
+        readyState = value;
+      },
+    });
+
+    await expect(
+      withTestTrace(() =>
+        model.getResponse(request({ signal: controller.signal })),
+      ),
+    ).rejects.toBeInstanceOf(OpenAI.APIUserAbortError);
+    expect(fakeWebSocket.sent).toHaveLength(1);
+  });
+
+  it('preserves an active response when an aborted resume sends no injection', async () => {
+    const functionCall = {
+      type: 'function_call',
+      id: 'fc_abort_resume',
+      call_id: 'call_abort_resume',
+      name: 'lookup',
+      arguments: '{}',
+      status: 'completed',
+      agent: { agent_name: '/root/researcher' },
+    };
+    const fakeWebSocket = new FakeResponsesWebSocket([
+      {
+        type: 'response.created',
+        response: emptyResponse('resp_abort_resume'),
+      },
+      { type: 'response.output_item.done', item: functionCall },
+      {
+        type: 'response.inject.created',
+        response_id: 'resp_abort_resume',
+      },
+      {
+        type: 'response.completed',
+        response: emptyResponse('resp_abort_resume'),
+      },
+    ]);
+    const model = new TestHostedMultiAgentModel(fakeWebSocket);
+    const first = await withTestTrace(() => model.getResponse(request()));
+    const resumeRequest = request({
+      input: [
+        ...first.output,
+        {
+          type: 'function_call_result',
+          callId: 'call_abort_resume',
+          output: 'result',
+          status: 'completed',
+        },
+      ],
+    });
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      withTestTrace(() =>
+        model.getResponse({ ...resumeRequest, signal: controller.signal }),
+      ),
+    ).rejects.toBeInstanceOf(OpenAI.APIUserAbortError);
+    expect(fakeWebSocket.sent).toHaveLength(1);
+
+    await withTestTrace(() => model.getResponse(resumeRequest));
+    expect(fakeWebSocket.sent[1]).toMatchObject({
+      type: 'response.inject',
+      response_id: 'resp_abort_resume',
+    });
+  });
+
+  it.each([false, true])(
     'applies the client timeout while preparing hosted WebSocket auth (stream: %s)',
     async (stream) => {
       const fakeWebSocket = new FakeResponsesWebSocket([]);

--- a/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
+++ b/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
@@ -279,27 +279,39 @@ describe('OpenAIHostedMultiAgentModel', () => {
         },
       },
     ]);
-    const model = new TestHostedMultiAgentModel([
-      firstWebSocket,
-      secondWebSocket,
-    ]);
+    const model = new TestHostedMultiAgentModel(
+      [firstWebSocket, secondWebSocket],
+      undefined,
+      new OpenAI({
+        apiKey: vi
+          .fn()
+          .mockResolvedValueOnce('initial-key')
+          .mockRejectedValueOnce(new Error('Reconnect auth failed.'))
+          .mockResolvedValue('retry-key'),
+      }),
+    );
 
     const boundary = await withTestTrace(() => model.getResponse(request()));
     firstWebSocket.closeFromServer();
+    const resumeRequest = request({
+      input: [
+        ...boundary.output,
+        {
+          type: 'function_call_result',
+          callId: 'call_reconnect',
+          output: 'lookup result',
+          status: 'completed',
+        },
+      ],
+    });
+
+    await expect(
+      withTestTrace(() => model.getResponse(resumeRequest)),
+    ).rejects.toThrow('Reconnect auth failed.');
+    expect(model.webSocketCreationOptions).toHaveLength(1);
+
     const response = await withTestTrace(() =>
-      model.getResponse(
-        request({
-          input: [
-            ...boundary.output,
-            {
-              type: 'function_call_result',
-              callId: 'call_reconnect',
-              output: 'lookup result',
-              status: 'completed',
-            },
-          ],
-        }),
-      ),
+      model.getResponse(resumeRequest),
     );
 
     expect(model.webSocketCreationOptions).toHaveLength(2);
@@ -437,6 +449,27 @@ describe('OpenAIHostedMultiAgentModel', () => {
     await expect(response).rejects.toBeInstanceOf(OpenAI.APIUserAbortError);
     expect(fakeWebSocket.sent).toHaveLength(0);
   });
+
+  it.each([false, true])(
+    'applies the client timeout while preparing hosted WebSocket auth (stream: %s)',
+    async (stream) => {
+      const fakeWebSocket = new FakeResponsesWebSocket([]);
+      const apiKey = vi.fn(async () => {
+        return await new Promise<string>(() => {});
+      });
+      const model = new TestHostedMultiAgentModel(
+        fakeWebSocket,
+        undefined,
+        new OpenAI({ apiKey, timeout: 25 }),
+      );
+
+      await expect(getTestResponse(model, request(), stream)).rejects.toThrow(
+        'Hosted Multi-agent WebSocket auth header preparation timed out after 25ms.',
+      );
+      expect(fakeWebSocket.sent).toHaveLength(0);
+      expect(model.webSocketCreationOptions).toHaveLength(0);
+    },
+  );
 
   it('preserves an explicit Authorization header unset', async () => {
     const fakeWebSocket = new FakeResponsesWebSocket([

--- a/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
+++ b/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
@@ -1275,6 +1275,103 @@ describe('OpenAIHostedMultiAgentModel', () => {
     },
   );
 
+  it.each([false, true])(
+    'retries an unsent fallback continuation after consuming server events (stream: %s)',
+    async (stream) => {
+      const functionCall = {
+        type: 'function_call',
+        id: 'fc_unsent_fallback',
+        call_id: 'call_unsent_fallback',
+        name: 'lookup',
+        arguments: '{}',
+        status: 'completed',
+        agent: { agent_name: '/root/researcher' },
+      };
+      const failedInput = {
+        type: 'function_call_output',
+        call_id: 'call_unsent_fallback',
+        output: 'result',
+      };
+      const firstWebSocket = new FakeResponsesWebSocket([
+        {
+          type: 'response.created',
+          response: emptyResponse('resp_unsent_fallback'),
+        },
+        { type: 'response.output_item.done', item: functionCall },
+        {
+          type: 'response.completed',
+          response: emptyResponse('resp_unsent_fallback'),
+        },
+        {
+          type: 'response.inject.failed',
+          response_id: 'resp_unsent_fallback',
+          input: [failedInput],
+          error: {
+            code: 'response_already_completed',
+            message: 'Already completed.',
+          },
+        },
+      ]);
+      firstWebSocket.queueTransportEvent({
+        type: 'close',
+        code: 1006,
+        reason: 'Connection failed.',
+        unsent: [
+          {
+            type: 'message',
+            message: { type: 'response.create' },
+          },
+        ],
+      });
+      const retryWebSocket = new FakeResponsesWebSocket([
+        {
+          type: 'response.created',
+          response: emptyResponse('resp_retried_fallback'),
+        },
+        {
+          type: 'response.completed',
+          response: emptyResponse('resp_retried_fallback'),
+        },
+      ]);
+      const model = new TestHostedMultiAgentModel([
+        firstWebSocket,
+        retryWebSocket,
+      ]);
+      const first = await getTestResponse(model, request(), stream);
+      const resumeRequest = request({
+        input: [
+          ...first.output,
+          {
+            type: 'function_call_result',
+            callId: 'call_unsent_fallback',
+            output: 'result',
+            status: 'completed',
+          },
+        ],
+      });
+
+      let error: (Error & { unsafeToReplay?: boolean }) | undefined;
+      try {
+        await getTestResponse(model, resumeRequest, stream);
+      } catch (caught) {
+        error = caught as Error & { unsafeToReplay?: boolean };
+      }
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error?.unsafeToReplay).toBeUndefined();
+      const response = await getTestResponse(model, resumeRequest, stream);
+
+      expect(retryWebSocket.sent[0]).toEqual(firstWebSocket.sent[2]);
+      expect(retryWebSocket.sent[0]).toMatchObject({
+        type: 'response.create',
+        previous_response_id: 'resp_unsent_fallback',
+        input: [failedInput],
+      });
+      expect(response.responseId ?? response.id).toBe('resp_retried_fallback');
+      expect(response.usage.requests).toBe(2);
+    },
+  );
+
   it.each([
     { stream: false, storedBaseResponseId: undefined },
     { stream: true, storedBaseResponseId: undefined },

--- a/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
+++ b/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
@@ -1,0 +1,932 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import OpenAI from 'openai';
+import { setTracingDisabled, UserError, withTrace } from '@openai/agents-core';
+import { OpenAIResponsesModel } from '../../src/openaiResponsesModel';
+import {
+  OpenAIHostedMultiAgentModel,
+  getHostedAgentMetadata,
+} from '../../src/experimental/hostedMultiAgent';
+
+function request(overrides: Record<string, unknown> = {}) {
+  return {
+    systemInstructions: 'Use hosted subagents when useful.',
+    input: 'Compare alpha and beta.',
+    modelSettings: {},
+    tools: [],
+    outputType: 'text',
+    handoffs: [],
+    tracing: false,
+    signal: undefined,
+    ...overrides,
+  } as any;
+}
+
+function emptyResponse(id = 'resp_empty') {
+  return {
+    id,
+    usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+    output: [],
+  };
+}
+
+function message(message: Record<string, any>) {
+  return { type: 'message', message };
+}
+
+class FakeResponsesWebSocket {
+  readonly sent: Array<Record<string, any>> = [];
+  readonly close = vi.fn();
+  #events: Array<Record<string, any>>;
+
+  constructor(events: Array<Record<string, any>>) {
+    this.#events = events.map(message);
+  }
+
+  send(event: Record<string, any>) {
+    this.sent.push(event);
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<Record<string, any>> {
+    return {
+      next: async () => {
+        const value = this.#events.shift();
+        return value
+          ? { value, done: false as const }
+          : { value: undefined, done: true as const };
+      },
+    };
+  }
+}
+
+class TestHostedMultiAgentModel extends OpenAIHostedMultiAgentModel {
+  readonly webSocketCreationOptions: Array<{
+    client: OpenAI;
+    headers: Record<string, string>;
+  }> = [];
+
+  constructor(
+    private readonly fakeWebSocket: FakeResponsesWebSocket,
+    config?: { maxConcurrentSubagents?: number },
+    client: OpenAI = new OpenAI({ apiKey: 'test-key' }),
+  ) {
+    super(client, 'gpt-5.6-sol', config);
+  }
+
+  protected override _createResponsesWebSocket(options: {
+    client: OpenAI;
+    headers: Record<string, string>;
+  }): any {
+    this.webSocketCreationOptions.push(options);
+    return this.fakeWebSocket;
+  }
+}
+
+function withTestTrace<T>(fn: () => Promise<T>): Promise<T> {
+  return withTrace('hosted-multi-agent-test', fn);
+}
+
+async function getTestResponse(
+  model: TestHostedMultiAgentModel,
+  modelRequest: ReturnType<typeof request>,
+  stream: boolean,
+): Promise<any> {
+  if (!stream) {
+    return withTestTrace(() => model.getResponse(modelRequest));
+  }
+
+  let completedResponse: any;
+  await withTestTrace(async () => {
+    for await (const event of model.getStreamedResponse(modelRequest)) {
+      if (event.type === 'response_done') {
+        completedResponse = event.response;
+      }
+    }
+  });
+  if (!completedResponse) {
+    throw new Error('Stream ended without a completed response.');
+  }
+  return completedResponse;
+}
+
+describe('OpenAIHostedMultiAgentModel', () => {
+  beforeAll(() => {
+    setTracingDisabled(true);
+  });
+
+  it('uses response.create over WebSocket with the hosted configuration', async () => {
+    const fakeWebSocket = new FakeResponsesWebSocket([
+      { type: 'response.created', response: emptyResponse('resp_ws') },
+      { type: 'response.completed', response: emptyResponse('resp_ws') },
+    ]);
+    const model = new TestHostedMultiAgentModel(fakeWebSocket, {
+      maxConcurrentSubagents: 2,
+    });
+
+    await withTestTrace(() => model.getResponse(request()));
+
+    expect(fakeWebSocket.sent).toHaveLength(1);
+    expect(fakeWebSocket.sent[0]).toMatchObject({
+      type: 'response.create',
+      model: 'gpt-5.6-sol',
+      multi_agent: {
+        enabled: true,
+        max_concurrent_subagents: 2,
+      },
+    });
+    expect(fakeWebSocket.sent[0]).not.toHaveProperty('betas');
+    expect(fakeWebSocket.sent[0]).not.toHaveProperty('stream');
+  });
+
+  it('omits max_concurrent_subagents to preserve the service default', async () => {
+    const fakeWebSocket = new FakeResponsesWebSocket([
+      { type: 'response.created', response: emptyResponse() },
+      { type: 'response.completed', response: emptyResponse() },
+    ]);
+
+    await withTestTrace(() =>
+      new TestHostedMultiAgentModel(fakeWebSocket).getResponse(request()),
+    );
+
+    expect(fakeWebSocket.sent[0]?.multi_agent).toEqual({ enabled: true });
+  });
+
+  it('preserves client and request WebSocket transport configuration', async () => {
+    const fakeWebSocket = new FakeResponsesWebSocket([
+      { type: 'response.created', response: emptyResponse() },
+      { type: 'response.completed', response: emptyResponse() },
+    ]);
+    const client = new OpenAI({
+      apiKey: 'transport-key',
+      organization: 'org_test',
+      project: 'proj_test',
+      defaultHeaders: { 'X-Default': 'default-value' },
+      defaultQuery: { api_version: 'base-version' },
+    });
+    const model = new TestHostedMultiAgentModel(
+      fakeWebSocket,
+      undefined,
+      client,
+    );
+
+    await withTestTrace(() =>
+      model.getResponse(
+        request({
+          modelSettings: {
+            providerData: {
+              extraHeaders: {
+                'OpenAI-Beta': 'wrong-beta',
+                'X-Request': 'request-value',
+              },
+              extraQuery: { region: 'test-region' },
+            },
+          },
+        }),
+      ),
+    );
+
+    const creationOptions = model.webSocketCreationOptions[0];
+    expect(creationOptions?.headers).toMatchObject({
+      'OpenAI-Beta': 'responses_multi_agent=v1',
+      'OpenAI-Organization': 'org_test',
+      'OpenAI-Project': 'proj_test',
+      'X-Default': 'default-value',
+      'X-Request': 'request-value',
+    });
+    expect(new Headers(creationOptions?.headers).get('authorization')).toBe(
+      'Bearer transport-key',
+    );
+    const websocketURL = new URL(
+      creationOptions!.client.buildURL('/responses', {}, undefined),
+    );
+    expect(websocketURL.searchParams.get('api_version')).toBe('base-version');
+    expect(websocketURL.searchParams.get('region')).toBe('test-region');
+  });
+
+  it('refreshes async API keys before creating the WebSocket', async () => {
+    const fakeWebSocket = new FakeResponsesWebSocket([
+      { type: 'response.created', response: emptyResponse() },
+      { type: 'response.completed', response: emptyResponse() },
+    ]);
+    const apiKey = vi.fn().mockResolvedValue('dynamic-key');
+    const model = new TestHostedMultiAgentModel(
+      fakeWebSocket,
+      undefined,
+      new OpenAI({ apiKey }),
+    );
+
+    await withTestTrace(() => model.getResponse(request()));
+
+    expect(apiKey).toHaveBeenCalledTimes(1);
+    expect(
+      new Headers(model.webSocketCreationOptions[0]?.headers).get(
+        'authorization',
+      ),
+    ).toBe('Bearer dynamic-key');
+  });
+
+  it('aborts while an async API key is being resolved', async () => {
+    const fakeWebSocket = new FakeResponsesWebSocket([]);
+    let markApiKeyStarted!: () => void;
+    const apiKeyStarted = new Promise<void>((resolve) => {
+      markApiKeyStarted = resolve;
+    });
+    const apiKey = vi.fn(async () => {
+      markApiKeyStarted();
+      return await new Promise<string>(() => {});
+    });
+    const model = new TestHostedMultiAgentModel(
+      fakeWebSocket,
+      undefined,
+      new OpenAI({ apiKey }),
+    );
+    const controller = new AbortController();
+
+    const response = withTestTrace(() =>
+      model.getResponse(request({ signal: controller.signal })),
+    );
+    await apiKeyStarted;
+    controller.abort();
+
+    await expect(response).rejects.toBeInstanceOf(OpenAI.APIUserAbortError);
+    expect(fakeWebSocket.sent).toHaveLength(0);
+  });
+
+  it('preserves an explicit Authorization header unset', async () => {
+    const fakeWebSocket = new FakeResponsesWebSocket([
+      { type: 'response.created', response: emptyResponse() },
+      { type: 'response.completed', response: emptyResponse() },
+    ]);
+    const model = new TestHostedMultiAgentModel(fakeWebSocket);
+
+    await withTestTrace(() =>
+      model.getResponse(
+        request({
+          modelSettings: {
+            providerData: {
+              extraHeaders: { Authorization: null },
+            },
+          },
+        }),
+      ),
+    );
+
+    const creationOptions = model.webSocketCreationOptions[0];
+    expect(new Headers(creationOptions?.headers).has('authorization')).toBe(
+      false,
+    );
+    expect(creationOptions?.client.apiKey).toBeNull();
+  });
+
+  it.each([0, -1, 1.5])(
+    'rejects invalid maxConcurrentSubagents value %s',
+    (maxConcurrentSubagents) => {
+      expect(
+        () =>
+          new TestHostedMultiAgentModel(new FakeResponsesWebSocket([]), {
+            maxConcurrentSubagents,
+          }),
+      ).toThrow(UserError);
+    },
+  );
+
+  it('returns a local function call boundary and injects its output into the active response', async () => {
+    const hostedCall = {
+      type: 'multi_agent_call',
+      id: 'mac_1',
+      call_id: 'call_spawn',
+      action: 'spawn_agent',
+      arguments: '{}',
+      agent: { agent_name: '/root' },
+    };
+    const functionCall = {
+      type: 'function_call',
+      id: 'fc_1',
+      call_id: 'call_lookup',
+      name: 'lookup',
+      arguments: '{"key":"alpha"}',
+      status: 'completed',
+      agent: { agent_name: '/root/researcher' },
+    };
+    const rootFinal = {
+      type: 'message',
+      id: 'msg_root_final',
+      role: 'assistant',
+      status: 'completed',
+      phase: 'final_answer',
+      agent: { agent_name: '/root' },
+      content: [{ type: 'output_text', text: 'Final answer.' }],
+    };
+    const fakeWebSocket = new FakeResponsesWebSocket([
+      { type: 'response.created', response: emptyResponse('resp_active') },
+      { type: 'response.output_item.done', item: hostedCall },
+      { type: 'response.output_item.done', item: functionCall },
+      {
+        type: 'response.inject.created',
+        response_id: 'resp_active',
+        sequence_number: 1,
+      },
+      {
+        type: 'response.completed',
+        response: {
+          ...emptyResponse('resp_active'),
+          output: [hostedCall, functionCall, rootFinal],
+        },
+      },
+    ]);
+    const model = new TestHostedMultiAgentModel(fakeWebSocket);
+
+    const first = await withTestTrace(() => model.getResponse(request()));
+
+    expect(first.output.map((item) => item.type)).toEqual(['function_call']);
+    expect(first.output[0]?.providerData?.agent).toEqual({
+      agent_name: '/root/researcher',
+    });
+
+    const second = await withTestTrace(() =>
+      model.getResponse(
+        request({
+          input: [
+            ...first.output,
+            {
+              type: 'function_call_result',
+              callId: 'call_lookup',
+              output: 'lookup result',
+              status: 'completed',
+            },
+          ],
+        }),
+      ),
+    );
+
+    expect(fakeWebSocket.sent[1]).toEqual({
+      type: 'response.inject',
+      response_id: 'resp_active',
+      input: [
+        expect.objectContaining({
+          type: 'function_call_output',
+          call_id: 'call_lookup',
+          output: 'lookup result',
+        }),
+      ],
+    });
+    expect(second.output).toHaveLength(1);
+    expect(second.output[0]?.type).toBe('message');
+    expect(second.output[0]?.providerData).toMatchObject({
+      phase: 'final_answer',
+      agent: { agent_name: '/root' },
+    });
+  });
+
+  it('returns every function call received before an injection acknowledgement', async () => {
+    const alphaCall = {
+      type: 'function_call',
+      id: 'fc_alpha',
+      call_id: 'call_alpha',
+      name: 'lookup',
+      arguments: '{"key":"alpha"}',
+      status: 'completed',
+      agent: { agent_name: '/root/alpha' },
+    };
+    const betaCall = {
+      type: 'function_call',
+      id: 'fc_beta',
+      call_id: 'call_beta',
+      name: 'lookup',
+      arguments: '{"key":"beta"}',
+      status: 'completed',
+      agent: { agent_name: '/root/beta' },
+    };
+    const gammaCall = {
+      type: 'function_call',
+      id: 'fc_gamma',
+      call_id: 'call_gamma',
+      name: 'lookup',
+      arguments: '{"key":"gamma"}',
+      status: 'completed',
+      agent: { agent_name: '/root/gamma' },
+    };
+    const rootFinal = {
+      type: 'message',
+      id: 'msg_parallel_final',
+      role: 'assistant',
+      status: 'completed',
+      phase: 'final_answer',
+      agent: { agent_name: '/root' },
+      content: [{ type: 'output_text', text: 'All calls completed.' }],
+    };
+    const fakeWebSocket = new FakeResponsesWebSocket([
+      { type: 'response.created', response: emptyResponse('resp_parallel') },
+      { type: 'response.output_item.done', item: alphaCall },
+      { type: 'response.output_item.done', item: betaCall },
+      { type: 'response.output_item.done', item: gammaCall },
+      { type: 'response.inject.created', response_id: 'resp_parallel' },
+      { type: 'response.inject.created', response_id: 'resp_parallel' },
+      {
+        type: 'response.completed',
+        response: {
+          ...emptyResponse('resp_parallel'),
+          output: [alphaCall, betaCall, gammaCall, rootFinal],
+        },
+      },
+    ]);
+    const model = new TestHostedMultiAgentModel(fakeWebSocket);
+
+    const first = await withTestTrace(() => model.getResponse(request()));
+    expect(first.output.map((item) => (item as any).callId)).toEqual([
+      'call_alpha',
+    ]);
+
+    const second = await withTestTrace(() =>
+      model.getResponse(
+        request({
+          input: [
+            ...first.output,
+            {
+              type: 'function_call_result',
+              callId: 'call_alpha',
+              output: 'alpha result',
+              status: 'completed',
+            },
+          ],
+        }),
+      ),
+    );
+    expect(second.output.map((item) => (item as any).callId)).toEqual([
+      'call_beta',
+      'call_gamma',
+    ]);
+
+    const third = await withTestTrace(() =>
+      model.getResponse(
+        request({
+          input: [
+            ...second.output,
+            {
+              type: 'function_call_result',
+              callId: 'call_beta',
+              output: 'beta result',
+              status: 'completed',
+            },
+            {
+              type: 'function_call_result',
+              callId: 'call_gamma',
+              output: 'gamma result',
+              status: 'completed',
+            },
+          ],
+        }),
+      ),
+    );
+
+    expect(fakeWebSocket.sent[2]?.type).toBe('response.inject');
+    expect(
+      fakeWebSocket.sent[2]?.input.map(
+        (item: Record<string, any>) => item.call_id,
+      ),
+    ).toEqual(['call_beta', 'call_gamma']);
+    expect(third.output[0]?.type).toBe('message');
+  });
+
+  it('preserves failed injection input across another function call boundary', async () => {
+    const alphaCall = {
+      type: 'function_call',
+      id: 'fc_failed_alpha',
+      call_id: 'call_failed_alpha',
+      name: 'lookup',
+      arguments: '{"key":"alpha"}',
+      status: 'completed',
+      agent: { agent_name: '/root/alpha' },
+    };
+    const betaCall = {
+      type: 'function_call',
+      id: 'fc_failed_beta',
+      call_id: 'call_failed_beta',
+      name: 'lookup',
+      arguments: '{"key":"beta"}',
+      status: 'completed',
+      agent: { agent_name: '/root/beta' },
+    };
+    const alphaOutput = {
+      type: 'function_call_output',
+      call_id: 'call_failed_alpha',
+      output: 'alpha result',
+    };
+    const rootFinal = {
+      type: 'message',
+      id: 'msg_failed_parallel_final',
+      role: 'assistant',
+      status: 'completed',
+      phase: 'final_answer',
+      agent: { agent_name: '/root' },
+      content: [{ type: 'output_text', text: 'Recovered all calls.' }],
+    };
+    const fakeWebSocket = new FakeResponsesWebSocket([
+      {
+        type: 'response.created',
+        response: emptyResponse('resp_failed_parallel'),
+      },
+      { type: 'response.output_item.done', item: alphaCall },
+      { type: 'response.output_item.done', item: betaCall },
+      {
+        type: 'response.completed',
+        response: emptyResponse('resp_failed_parallel'),
+      },
+      {
+        type: 'response.inject.failed',
+        response_id: 'resp_failed_parallel',
+        input: [alphaOutput],
+        error: {
+          code: 'response_already_completed',
+          message: 'Already completed.',
+        },
+      },
+      {
+        type: 'response.created',
+        response: emptyResponse('resp_failed_continuation'),
+      },
+      {
+        type: 'response.completed',
+        response: {
+          ...emptyResponse('resp_failed_continuation'),
+          output: [rootFinal],
+        },
+      },
+    ]);
+    const model = new TestHostedMultiAgentModel(fakeWebSocket);
+
+    const first = await withTestTrace(() => model.getResponse(request()));
+    const second = await withTestTrace(() =>
+      model.getResponse(
+        request({
+          input: [
+            ...first.output,
+            {
+              type: 'function_call_result',
+              callId: 'call_failed_alpha',
+              output: 'alpha result',
+              status: 'completed',
+            },
+          ],
+        }),
+      ),
+    );
+    expect(second.output.map((item) => (item as any).callId)).toEqual([
+      'call_failed_beta',
+    ]);
+
+    const third = await withTestTrace(() =>
+      model.getResponse(
+        request({
+          input: [
+            ...second.output,
+            {
+              type: 'function_call_result',
+              callId: 'call_failed_beta',
+              output: 'beta result',
+              status: 'completed',
+            },
+          ],
+        }),
+      ),
+    );
+
+    expect(fakeWebSocket.sent[2]).toMatchObject({
+      type: 'response.create',
+      previous_response_id: 'resp_failed_parallel',
+      input: [
+        alphaOutput,
+        expect.objectContaining({
+          type: 'function_call_output',
+          call_id: 'call_failed_beta',
+          output: 'beta result',
+        }),
+      ],
+    });
+    expect(third.output[0]?.type).toBe('message');
+  });
+
+  it.each([false, true])(
+    'continues with response.create when injection loses the completion race (stream: %s)',
+    async (stream) => {
+      const functionCall = {
+        type: 'function_call',
+        id: 'fc_race',
+        call_id: 'call_race',
+        name: 'lookup',
+        arguments: '{}',
+        status: 'completed',
+        agent: { agent_name: '/root/researcher' },
+      };
+      const rootFinal = {
+        type: 'message',
+        id: 'msg_after_race',
+        role: 'assistant',
+        status: 'completed',
+        phase: 'final_answer',
+        agent: { agent_name: '/root' },
+        content: [{ type: 'output_text', text: 'Recovered.' }],
+      };
+      const failedInput = {
+        type: 'function_call_output',
+        call_id: 'call_race',
+        output: 'result',
+      };
+      const fakeWebSocket = new FakeResponsesWebSocket([
+        { type: 'response.created', response: emptyResponse('resp_race') },
+        { type: 'response.output_item.done', item: functionCall },
+        { type: 'response.completed', response: emptyResponse('resp_race') },
+        {
+          type: 'response.inject.failed',
+          response_id: 'resp_race',
+          input: [failedInput],
+          error: {
+            code: 'response_already_completed',
+            message: 'Already completed.',
+          },
+        },
+        { type: 'response.created', response: emptyResponse('resp_fallback') },
+        {
+          type: 'response.completed',
+          response: {
+            ...emptyResponse('resp_fallback'),
+            output: [rootFinal],
+          },
+        },
+      ]);
+      const model = new TestHostedMultiAgentModel(fakeWebSocket);
+      const first = await getTestResponse(model, request(), stream);
+
+      const second = await getTestResponse(
+        model,
+        request({
+          input: [
+            ...first.output,
+            {
+              type: 'function_call_result',
+              callId: 'call_race',
+              output: 'result',
+              status: 'completed',
+            },
+          ],
+        }),
+        stream,
+      );
+
+      expect(fakeWebSocket.sent[2]).toMatchObject({
+        type: 'response.create',
+        previous_response_id: 'resp_race',
+        input: [failedInput],
+      });
+      expect(second.output[0]?.type).toBe('message');
+      expect(second.usage).toMatchObject({
+        requests: 2,
+        inputTokens: 2,
+        outputTokens: 2,
+        totalTokens: 4,
+      });
+      expect(second.usage.requestUsageEntries).toHaveLength(2);
+    },
+  );
+
+  it('keeps conversation continuation mutually exclusive with previous_response_id', async () => {
+    const functionCall = {
+      type: 'function_call',
+      id: 'fc_conversation_race',
+      call_id: 'call_conversation_race',
+      name: 'lookup',
+      arguments: '{}',
+      status: 'completed',
+      agent: { agent_name: '/root/researcher' },
+    };
+    const failedInput = {
+      type: 'function_call_output',
+      call_id: 'call_conversation_race',
+      output: 'result',
+    };
+    const fakeWebSocket = new FakeResponsesWebSocket([
+      {
+        type: 'response.created',
+        response: emptyResponse('resp_conversation_race'),
+      },
+      { type: 'response.output_item.done', item: functionCall },
+      {
+        type: 'response.completed',
+        response: emptyResponse('resp_conversation_race'),
+      },
+      {
+        type: 'response.inject.failed',
+        response_id: 'resp_conversation_race',
+        input: [failedInput],
+        error: {
+          code: 'response_already_completed',
+          message: 'Already completed.',
+        },
+      },
+      {
+        type: 'response.created',
+        response: emptyResponse('resp_conversation_fallback'),
+      },
+      {
+        type: 'response.completed',
+        response: emptyResponse('resp_conversation_fallback'),
+      },
+    ]);
+    const model = new TestHostedMultiAgentModel(fakeWebSocket);
+    const first = await withTestTrace(() =>
+      model.getResponse(request({ conversationId: 'conv_test' })),
+    );
+
+    await withTestTrace(() =>
+      model.getResponse(
+        request({
+          conversationId: 'conv_test',
+          input: [
+            ...first.output,
+            {
+              type: 'function_call_result',
+              callId: 'call_conversation_race',
+              output: 'result',
+              status: 'completed',
+            },
+          ],
+        }),
+      ),
+    );
+
+    expect(fakeWebSocket.sent[2]).toMatchObject({
+      type: 'response.create',
+      conversation: 'conv_test',
+      input: [failedInput],
+    });
+    expect(fakeWebSocket.sent[2]).not.toHaveProperty('previous_response_id');
+  });
+
+  it.each([
+    {
+      name: 'SDK handoffs',
+      override: { handoffs: [{ toolName: 'transfer' }] },
+      message: /does not support SDK handoffs/,
+    },
+    {
+      name: 'reasoning summaries',
+      override: { modelSettings: { reasoning: { summary: 'auto' } } },
+      message: /does not support reasoning\.summary/,
+    },
+    {
+      name: 'explicit compaction',
+      override: {
+        modelSettings: { contextManagement: [{ type: 'compaction' }] },
+      },
+      message: /does not support explicit Responses compaction/,
+    },
+    {
+      name: 'max tool calls',
+      override: { modelSettings: { providerData: { max_tool_calls: 2 } } },
+      message: /does not support max_tool_calls/,
+    },
+  ])('rejects $name before network I/O', async ({ override, message }) => {
+    const fakeWebSocket = new FakeResponsesWebSocket([]);
+    const model = new TestHostedMultiAgentModel(fakeWebSocket);
+
+    await expect(
+      withTestTrace(() => model.getResponse(request(override))),
+    ).rejects.toThrow(message);
+    expect(fakeWebSocket.sent).toHaveLength(0);
+  });
+
+  it('keeps stable Responses requests free of hosted beta fields', async () => {
+    const stableCreate = vi.fn().mockResolvedValue(emptyResponse());
+    const client = {
+      responses: { create: stableCreate },
+    } as unknown as OpenAI;
+
+    await withTestTrace(() =>
+      new OpenAIResponsesModel(client, 'gpt-test').getResponse(request()),
+    );
+
+    expect(stableCreate.mock.calls[0]?.[0]).not.toHaveProperty('multi_agent');
+    expect(stableCreate.mock.calls[0]?.[0]).not.toHaveProperty('betas');
+  });
+
+  it('filters streamed text to the root final message and keeps raw events', async () => {
+    const reasoning = {
+      type: 'reasoning',
+      id: 'reasoning_root',
+      summary: [],
+      encrypted_content: 'encrypted-reasoning',
+    };
+    const subagentMessage = {
+      type: 'message',
+      id: 'msg_sub',
+      role: 'assistant',
+      status: 'completed',
+      phase: 'commentary',
+      agent: { agent_name: '/root/researcher' },
+      content: [{ type: 'output_text', text: 'Hidden subagent text.' }],
+    };
+    const rootFinal = {
+      type: 'message',
+      id: 'msg_final',
+      role: 'assistant',
+      status: 'completed',
+      phase: 'final_answer',
+      agent: { agent_name: '/root' },
+      content: [{ type: 'output_text', text: 'Root final.' }],
+    };
+    const fakeWebSocket = new FakeResponsesWebSocket([
+      { type: 'response.created', response: emptyResponse('resp_stream') },
+      {
+        type: 'response.output_item.added',
+        output_index: 0,
+        item: subagentMessage,
+        agent: { agent_name: '/root/researcher' },
+      },
+      {
+        type: 'response.output_text.delta',
+        output_index: 0,
+        delta: 'Hidden subagent text.',
+        agent: { agent_name: '/root/researcher' },
+      },
+      {
+        type: 'response.output_item.added',
+        output_index: 1,
+        item: rootFinal,
+        agent: { agent_name: '/root' },
+      },
+      {
+        type: 'response.output_text.delta',
+        output_index: 1,
+        delta: 'Root final.',
+        agent: { agent_name: '/root' },
+      },
+      {
+        type: 'response.completed',
+        response: {
+          ...emptyResponse('resp_stream'),
+          output: [reasoning, subagentMessage, rootFinal],
+        },
+      },
+    ]);
+    const model = new TestHostedMultiAgentModel(fakeWebSocket);
+
+    const outputEvents = [];
+    for await (const event of model.getStreamedResponse(request())) {
+      outputEvents.push(event);
+    }
+
+    expect(
+      outputEvents
+        .filter((event) => event.type === 'output_text_delta')
+        .map((event) => event.delta),
+    ).toEqual(['Root final.']);
+    expect(
+      outputEvents.some(
+        (event) =>
+          event.type === 'model' &&
+          event.event.type === 'response.output_item.added' &&
+          event.event.item?.id === 'msg_sub',
+      ),
+    ).toBe(true);
+    const done = outputEvents.find((event) => event.type === 'response_done');
+    expect(done?.response.output.map((item) => item.type)).toEqual([
+      'reasoning',
+      'message',
+    ]);
+  });
+
+  it('closes the owned WebSocket explicitly', async () => {
+    const fakeWebSocket = new FakeResponsesWebSocket([
+      { type: 'response.created', response: emptyResponse() },
+      { type: 'response.completed', response: emptyResponse() },
+    ]);
+    const model = new TestHostedMultiAgentModel(fakeWebSocket);
+    await withTestTrace(() => model.getResponse(request()));
+
+    await model.close();
+
+    expect(fakeWebSocket.close).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getHostedAgentMetadata', () => {
+  it('reads raw and tool-call details attribution', () => {
+    expect(
+      getHostedAgentMetadata({
+        type: 'message',
+        agent: { agent_name: '/root/researcher' },
+        phase: 'commentary',
+      }),
+    ).toEqual({ agentName: '/root/researcher', phase: 'commentary' });
+
+    expect(
+      getHostedAgentMetadata({
+        toolCall: {
+          type: 'function_call',
+          providerData: {
+            agent: { agent_name: '/root/reviewer' },
+          },
+        },
+      }),
+    ).toEqual({ agentName: '/root/reviewer' });
+  });
+});

--- a/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
+++ b/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
@@ -841,6 +841,87 @@ describe('OpenAIHostedMultiAgentModel', () => {
     ]);
   });
 
+  it.each([
+    ['response.incomplete', 'incomplete', false],
+    ['response.incomplete', 'incomplete', true],
+    ['response.failed', 'failed', false],
+    ['response.failed', 'failed', true],
+    ['response.error', 'failed', false],
+    ['response.error', 'failed', true],
+  ] as const)(
+    'preserves terminal hosted response %s (status: %s, stream: %s)',
+    async (terminalEventType, expectedStatus, stream) => {
+      const rootFinal = {
+        type: 'message',
+        id: 'msg_terminal',
+        role: 'assistant',
+        status: 'completed',
+        phase: 'final_answer',
+        agent: { agent_name: '/root' },
+        content: [{ type: 'output_text', text: 'Partial answer.' }],
+      };
+      const fakeWebSocket = new FakeResponsesWebSocket([
+        {
+          type: 'response.created',
+          response: emptyResponse('resp_terminal'),
+        },
+        {
+          type: terminalEventType,
+          response: {
+            ...emptyResponse('resp_terminal'),
+            status: expectedStatus,
+            output: [rootFinal],
+            usage: {
+              input_tokens: 3,
+              output_tokens: 4,
+              total_tokens: 7,
+            },
+            ...(terminalEventType === 'response.incomplete'
+              ? { incomplete_details: { reason: 'max_output_tokens' } }
+              : {}),
+          },
+        },
+      ]);
+      const model = new TestHostedMultiAgentModel(fakeWebSocket);
+
+      const response = await getTestResponse(model, request(), stream);
+
+      expect(response.responseId ?? response.id).toBe('resp_terminal');
+      expect(response.providerData.status).toBe(expectedStatus);
+      expect(response.output).toHaveLength(1);
+      expect(response.usage).toMatchObject({
+        requests: 1,
+        inputTokens: 3,
+        outputTokens: 4,
+        totalTokens: 7,
+      });
+      if (terminalEventType === 'response.incomplete') {
+        expect(response.providerData.incomplete_details).toEqual({
+          reason: 'max_output_tokens',
+        });
+      }
+    },
+  );
+
+  it.each([false, true])(
+    'throws standalone hosted WebSocket error events (stream: %s)',
+    async (stream) => {
+      const fakeWebSocket = new FakeResponsesWebSocket([
+        {
+          type: 'error',
+          code: 'server_error',
+          message: 'Something went wrong.',
+          param: null,
+        },
+      ]);
+      const model = new TestHostedMultiAgentModel(fakeWebSocket);
+
+      await expect(getTestResponse(model, request(), stream)).rejects.toThrow(
+        /Hosted Multi-agent WebSocket response failed/,
+      );
+    },
+  );
+
   it('keeps stable Responses requests free of hosted beta fields', async () => {
     const stableCreate = vi.fn().mockResolvedValue(emptyResponse());
     const client = {

--- a/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
+++ b/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
@@ -377,6 +377,36 @@ describe('OpenAIHostedMultiAgentModel', () => {
     });
   });
 
+  it.each([false, true])(
+    'does not count a synthetic local tool boundary as an API request (stream: %s)',
+    async (stream) => {
+      const functionCall = {
+        type: 'function_call',
+        id: 'fc_usage',
+        call_id: 'call_usage',
+        name: 'lookup',
+        arguments: '{}',
+        status: 'completed',
+        agent: { agent_name: '/root/researcher' },
+      };
+      const fakeWebSocket = new FakeResponsesWebSocket([
+        { type: 'response.created', response: emptyResponse('resp_usage') },
+        { type: 'response.output_item.done', item: functionCall },
+      ]);
+      const model = new TestHostedMultiAgentModel(fakeWebSocket);
+
+      const boundary = await getTestResponse(model, request(), stream);
+
+      expect(boundary.usage).toMatchObject({
+        requests: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+      });
+      expect(boundary.usage.requestUsageEntries).toBeUndefined();
+    },
+  );
+
   it('returns every function call received before an injection acknowledgement', async () => {
     const alphaCall = {
       type: 'function_call',
@@ -773,13 +803,6 @@ describe('OpenAIHostedMultiAgentModel', () => {
       message: /does not support reasoning\.summary/,
     },
     {
-      name: 'explicit compaction',
-      override: {
-        modelSettings: { contextManagement: [{ type: 'compaction' }] },
-      },
-      message: /does not support explicit Responses compaction/,
-    },
-    {
       name: 'max tool calls',
       override: { modelSettings: { providerData: { max_tool_calls: 2 } } },
       message: /does not support max_tool_calls/,
@@ -792,6 +815,30 @@ describe('OpenAIHostedMultiAgentModel', () => {
       withTestTrace(() => model.getResponse(request(override))),
     ).rejects.toThrow(message);
     expect(fakeWebSocket.sent).toHaveLength(0);
+  });
+
+  it('allows a server-side compaction threshold over WebSocket', async () => {
+    const fakeWebSocket = new FakeResponsesWebSocket([
+      { type: 'response.created', response: emptyResponse() },
+      { type: 'response.completed', response: emptyResponse() },
+    ]);
+    const model = new TestHostedMultiAgentModel(fakeWebSocket);
+
+    await withTestTrace(() =>
+      model.getResponse(
+        request({
+          modelSettings: {
+            contextManagement: [
+              { type: 'compaction', compactThreshold: 200_000 },
+            ],
+          },
+        }),
+      ),
+    );
+
+    expect(fakeWebSocket.sent[0]?.context_management).toEqual([
+      { type: 'compaction', compact_threshold: 200_000 },
+    ]);
   });
 
   it('keeps stable Responses requests free of hosted beta fields', async () => {

--- a/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
+++ b/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
@@ -876,6 +876,42 @@ describe('OpenAIHostedMultiAgentModel', () => {
     expect(terminalResponse.output).toEqual([functionCall, rootFinal]);
   });
 
+  it('does not expose a synthetic local tool boundary as a raw model event', async () => {
+    const functionCall = {
+      type: 'function_call',
+      id: 'fc_internal_boundary',
+      call_id: 'call_internal_boundary',
+      name: 'lookup',
+      arguments: '{}',
+      status: 'completed',
+      agent: { agent_name: '/root/researcher' },
+    };
+    const fakeWebSocket = new FakeResponsesWebSocket([
+      {
+        type: 'response.created',
+        response: emptyResponse('resp_internal_boundary'),
+      },
+      { type: 'response.output_item.done', item: functionCall },
+    ]);
+    const model = new TestHostedMultiAgentModel(fakeWebSocket);
+
+    const streamEvents: ResponseStreamEvent[] = [];
+    for await (const event of model.getStreamedResponse(request())) {
+      streamEvents.push(event);
+    }
+
+    const done = streamEvents.find((event) => event.type === 'response_done');
+    expect(done?.response.output.map((item) => item.type)).toEqual([
+      'function_call',
+    ]);
+    expect(
+      streamEvents.some(
+        (event) =>
+          event.type === 'model' && event.event.type === 'response.completed',
+      ),
+    ).toBe(false);
+  });
+
   it.each([false, true])(
     'does not count a synthetic local tool boundary as an API request (stream: %s)',
     async (stream) => {
@@ -1618,6 +1654,89 @@ describe('OpenAIHostedMultiAgentModel', () => {
       });
       expect(retryAdvice?.replaySafety).not.toBe('unsafe');
       expect(fakeWebSocket.close).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each([false, true])(
+    'retries an active response when response.inject is returned unsent (stream: %s)',
+    async (stream) => {
+      const functionCall = {
+        type: 'function_call',
+        id: 'fc_unsent_inject',
+        call_id: 'call_unsent_inject',
+        name: 'lookup',
+        arguments: '{}',
+        status: 'completed',
+        agent: { agent_name: '/root/researcher' },
+      };
+      const firstWebSocket = new FakeResponsesWebSocket([
+        {
+          type: 'response.created',
+          response: emptyResponse('resp_unsent_inject'),
+        },
+        { type: 'response.output_item.done', item: functionCall },
+      ]);
+      const failedResumeWebSocket = new FakeResponsesWebSocket([]);
+      failedResumeWebSocket.socket.readyState = 0;
+      failedResumeWebSocket.queueTransportEvent({ type: 'connecting' });
+      failedResumeWebSocket.queueTransportEvent({
+        type: 'close',
+        code: 1006,
+        reason: 'Connection failed.',
+        unsent: [
+          {
+            type: 'message',
+            message: { type: 'response.inject' },
+          },
+        ],
+      });
+      const retryWebSocket = new FakeResponsesWebSocket([
+        {
+          type: 'response.inject.created',
+          response_id: 'resp_unsent_inject',
+        },
+        {
+          type: 'response.completed',
+          response: emptyResponse('resp_unsent_inject'),
+        },
+      ]);
+      const model = new TestHostedMultiAgentModel([
+        firstWebSocket,
+        failedResumeWebSocket,
+        retryWebSocket,
+      ]);
+
+      const first = await getTestResponse(model, request(), stream);
+      firstWebSocket.socket.readyState = 3;
+      const resumeRequest = request({
+        input: [
+          ...first.output,
+          {
+            type: 'function_call_result',
+            callId: 'call_unsent_inject',
+            output: 'result',
+            status: 'completed',
+          },
+        ],
+      });
+
+      let error: (Error & { unsafeToReplay?: boolean }) | undefined;
+      try {
+        await getTestResponse(model, resumeRequest, stream);
+      } catch (caught) {
+        error = caught as Error & { unsafeToReplay?: boolean };
+      }
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error?.unsafeToReplay).toBeUndefined();
+      const response = await getTestResponse(model, resumeRequest, stream);
+
+      expect(failedResumeWebSocket.close).toHaveBeenCalledOnce();
+      expect(retryWebSocket.sent[0]).toMatchObject({
+        type: 'response.inject',
+        response_id: 'resp_unsent_inject',
+      });
+      expect(response.responseId ?? response.id).toBe('resp_unsent_inject');
     },
   );
 

--- a/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
+++ b/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
@@ -35,7 +35,10 @@ function message(message: Record<string, any>) {
 
 class FakeResponsesWebSocket {
   readonly sent: Array<Record<string, any>> = [];
-  readonly close = vi.fn();
+  readonly socket = { readyState: 1 };
+  readonly close = vi.fn(() => {
+    this.socket.readyState = 3;
+  });
   #events: Array<Record<string, any> | Error>;
 
   constructor(events: Array<Record<string, any> | Error>) {
@@ -46,6 +49,15 @@ class FakeResponsesWebSocket {
 
   send(event: Record<string, any>) {
     this.sent.push(event);
+  }
+
+  closeFromServer() {
+    this.socket.readyState = 3;
+    this.#events.push({
+      type: 'close',
+      code: 1001,
+      reason: 'Idle timeout.',
+    });
   }
 
   [Symbol.asyncIterator](): AsyncIterator<Record<string, any>> {
@@ -70,7 +82,8 @@ class TestHostedMultiAgentModel extends OpenAIHostedMultiAgentModel {
   }> = [];
 
   constructor(
-    private readonly fakeWebSocket: FakeResponsesWebSocket,
+    private readonly fakeWebSocket:
+      FakeResponsesWebSocket | Array<FakeResponsesWebSocket>,
     config?: { maxConcurrentSubagents?: number },
     client: OpenAI = new OpenAI({ apiKey: 'test-key' }),
   ) {
@@ -82,7 +95,15 @@ class TestHostedMultiAgentModel extends OpenAIHostedMultiAgentModel {
     headers: Record<string, string>;
   }): any {
     this.webSocketCreationOptions.push(options);
-    return this.fakeWebSocket;
+    if (!Array.isArray(this.fakeWebSocket)) {
+      return this.fakeWebSocket;
+    }
+    const fakeWebSocket =
+      this.fakeWebSocket[this.webSocketCreationOptions.length - 1];
+    if (!fakeWebSocket) {
+      throw new Error('No fake WebSocket is available for this connection.');
+    }
+    return fakeWebSocket;
   }
 }
 
@@ -153,6 +174,33 @@ describe('OpenAIHostedMultiAgentModel', () => {
     );
 
     expect(fakeWebSocket.sent[0]?.multi_agent).toEqual({ enabled: true });
+  });
+
+  it('recreates an idle WebSocket after the server closes it', async () => {
+    const firstWebSocket = new FakeResponsesWebSocket([
+      { type: 'response.created', response: emptyResponse('resp_first') },
+      { type: 'response.completed', response: emptyResponse('resp_first') },
+    ]);
+    const secondWebSocket = new FakeResponsesWebSocket([
+      { type: 'response.created', response: emptyResponse('resp_second') },
+      { type: 'response.completed', response: emptyResponse('resp_second') },
+    ]);
+    const model = new TestHostedMultiAgentModel([
+      firstWebSocket,
+      secondWebSocket,
+    ]);
+
+    await withTestTrace(() => model.getResponse(request()));
+    firstWebSocket.closeFromServer();
+    const secondResponse = await withTestTrace(() =>
+      model.getResponse(request({ input: 'Run another hosted response.' })),
+    );
+
+    expect(model.webSocketCreationOptions).toHaveLength(2);
+    expect(firstWebSocket.close).toHaveBeenCalledOnce();
+    expect(firstWebSocket.sent).toHaveLength(1);
+    expect(secondWebSocket.sent).toHaveLength(1);
+    expect(secondResponse.responseId).toBe('resp_second');
   });
 
   it('preserves client and request WebSocket transport configuration', async () => {

--- a/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
+++ b/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
@@ -33,17 +33,23 @@ function message(message: Record<string, any>) {
   return { type: 'message', message };
 }
 
+const STALLED_WEBSOCKET_EVENT = Symbol('stalled-websocket-event');
+type FakeWebSocketEvent =
+  Record<string, any> | Error | typeof STALLED_WEBSOCKET_EVENT;
+
 class FakeResponsesWebSocket {
   readonly sent: Array<Record<string, any>> = [];
   readonly socket = { readyState: 1 };
   readonly close = vi.fn(() => {
     this.socket.readyState = 3;
   });
-  #events: Array<Record<string, any> | Error>;
+  #events: Array<FakeWebSocketEvent>;
 
-  constructor(events: Array<Record<string, any> | Error>) {
+  constructor(events: Array<FakeWebSocketEvent>) {
     this.#events = events.map((event) =>
-      event instanceof Error ? event : message(event),
+      event instanceof Error || event === STALLED_WEBSOCKET_EVENT
+        ? event
+        : message(event),
     );
   }
 
@@ -66,6 +72,11 @@ class FakeResponsesWebSocket {
         const value = this.#events.shift();
         if (value instanceof Error) {
           throw value;
+        }
+        if (value === STALLED_WEBSOCKET_EVENT) {
+          return await new Promise<IteratorResult<Record<string, any>>>(
+            () => {},
+          );
         }
         return value
           ? { value, done: false as const }
@@ -202,6 +213,25 @@ describe('OpenAIHostedMultiAgentModel', () => {
     expect(secondWebSocket.sent).toHaveLength(1);
     expect(secondResponse.responseId).toBe('resp_second');
   });
+
+  it.each([false, true])(
+    'applies the client timeout while waiting for hosted WebSocket events (stream: %s)',
+    async (stream) => {
+      const fakeWebSocket = new FakeResponsesWebSocket([
+        STALLED_WEBSOCKET_EVENT,
+      ]);
+      const model = new TestHostedMultiAgentModel(
+        fakeWebSocket,
+        undefined,
+        new OpenAI({ apiKey: 'test-key', timeout: 25 }),
+      );
+
+      await expect(getTestResponse(model, request(), stream)).rejects.toThrow(
+        'Hosted Multi-agent WebSocket frame read timed out after 25ms.',
+      );
+      expect(fakeWebSocket.close).toHaveBeenCalledOnce();
+    },
+  );
 
   it('preserves client and request WebSocket transport configuration', async () => {
     const fakeWebSocket = new FakeResponsesWebSocket([

--- a/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
+++ b/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
@@ -339,6 +339,78 @@ describe('OpenAIHostedMultiAgentModel', () => {
     expect(response.output[0]?.type).toBe('message');
   });
 
+  it('rejects a header unset when reconnecting an active response', async () => {
+    const functionCall = {
+      type: 'function_call',
+      id: 'fc_transport_unset',
+      call_id: 'call_transport_unset',
+      name: 'lookup',
+      arguments: '{}',
+      status: 'completed',
+      agent: { agent_name: '/root/researcher' },
+    };
+    const firstWebSocket = new FakeResponsesWebSocket([
+      {
+        type: 'response.created',
+        response: emptyResponse('resp_transport_unset'),
+      },
+      { type: 'response.output_item.done', item: functionCall },
+    ]);
+    const secondWebSocket = new FakeResponsesWebSocket([
+      {
+        type: 'response.inject.created',
+        response_id: 'resp_transport_unset',
+      },
+      {
+        type: 'response.completed',
+        response: emptyResponse('resp_transport_unset'),
+      },
+    ]);
+    const model = new TestHostedMultiAgentModel([
+      firstWebSocket,
+      secondWebSocket,
+    ]);
+    const boundary = await withTestTrace(() => model.getResponse(request()));
+    firstWebSocket.closeFromServer();
+    const resumeInput = [
+      ...boundary.output,
+      {
+        type: 'function_call_result',
+        callId: 'call_transport_unset',
+        output: 'lookup result',
+        status: 'completed',
+      },
+    ];
+
+    await expect(
+      withTestTrace(() =>
+        model.getResponse(
+          request({
+            input: resumeInput,
+            modelSettings: {
+              providerData: {
+                extraHeaders: { Authorization: null },
+              },
+            },
+          }),
+        ),
+      ),
+    ).rejects.toThrow(
+      'An active hosted response must be resumed with the same WebSocket transport headers and query.',
+    );
+    expect(model.webSocketCreationOptions).toHaveLength(1);
+    expect(secondWebSocket.sent).toHaveLength(0);
+
+    await withTestTrace(() =>
+      model.getResponse(request({ input: resumeInput })),
+    );
+    expect(model.webSocketCreationOptions).toHaveLength(2);
+    expect(secondWebSocket.sent[0]).toMatchObject({
+      type: 'response.inject',
+      response_id: 'resp_transport_unset',
+    });
+  });
+
   it.each([false, true])(
     'applies the client timeout while waiting for hosted WebSocket events (stream: %s)',
     async (stream) => {

--- a/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
+++ b/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
@@ -66,6 +66,10 @@ class FakeResponsesWebSocket {
     });
   }
 
+  queueTransportEvent(event: Record<string, any>) {
+    this.#events.push(event);
+  }
+
   [Symbol.asyncIterator](): AsyncIterator<Record<string, any>> {
     return {
       next: async () => {
@@ -1201,6 +1205,45 @@ describe('OpenAIHostedMultiAgentModel', () => {
     ).toMatchObject({ suggested: false, replaySafety: 'unsafe' });
     expect(fakeWebSocket.close).toHaveBeenCalledOnce();
   });
+
+  it.each([false, true])(
+    'keeps a pre-open close with an unsent request safe to retry (stream: %s)',
+    async (stream) => {
+      const fakeWebSocket = new FakeResponsesWebSocket([]);
+      fakeWebSocket.socket.readyState = 0;
+      fakeWebSocket.queueTransportEvent({ type: 'connecting' });
+      fakeWebSocket.queueTransportEvent({
+        type: 'close',
+        code: 1006,
+        reason: 'Connection failed.',
+        unsent: [
+          {
+            type: 'message',
+            message: { type: 'response.create' },
+          },
+        ],
+      });
+      const model = new TestHostedMultiAgentModel(fakeWebSocket);
+
+      let error: (Error & { unsafeToReplay?: boolean }) | undefined;
+      try {
+        await getTestResponse(model, request(), stream);
+      } catch (caught) {
+        error = caught as Error & { unsafeToReplay?: boolean };
+      }
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error?.unsafeToReplay).toBeUndefined();
+      const retryAdvice = model.getRetryAdvice({
+        error,
+        request: request(),
+        stream,
+        attempt: 1,
+      });
+      expect(retryAdvice?.replaySafety).not.toBe('unsafe');
+      expect(fakeWebSocket.close).toHaveBeenCalledOnce();
+    },
+  );
 
   it('keeps stable Responses requests free of hosted beta fields', async () => {
     const stableCreate = vi.fn().mockResolvedValue(emptyResponse());

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -3868,6 +3868,49 @@ describe('OpenAIResponsesModel', () => {
     });
   });
 
+  it('emits response.completed once as a raw model event', async () => {
+    const completedEvent: OpenAIResponseStreamEvent = {
+      type: 'response.completed',
+      response: {
+        id: 'res-completed-once',
+        output: [],
+        usage: {},
+      } as any,
+      sequence_number: 0,
+    };
+    async function* fakeStream() {
+      yield completedEvent;
+    }
+    const fakeClient = {
+      responses: { create: vi.fn().mockResolvedValue(fakeStream()) },
+    } as unknown as OpenAI;
+    const model = new OpenAIResponsesModel(fakeClient, 'model-stream');
+    const received: ResponseStreamEvent[] = [];
+
+    for await (const event of model.getStreamedResponse({
+      systemInstructions: undefined,
+      input: 'data',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    } as any)) {
+      received.push(event);
+    }
+
+    expect(
+      received.filter(
+        (event) =>
+          event.type === 'model' && event.event.type === 'response.completed',
+      ),
+    ).toHaveLength(1);
+    expect(
+      received.filter((event) => event.type === 'response_done'),
+    ).toHaveLength(1);
+  });
+
   it('prevents extra_body from overriding streamed request mode', async () => {
     await withTrace('test', async () => {
       const createdEvent: OpenAIResponseStreamEvent = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       '@openai/agents':
         specifier: workspace:*
         version: link:../../packages/agents
+      '@openai/agents-openai':
+        specifier: workspace:*
+        version: link:../../packages/agents-openai
       chalk:
         specifier: ^5.4.1
         version: 5.4.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       chalk:
         specifier: ^5.4.1
         version: 5.4.1
+      openai:
+        specifier: ^6.46.0
+        version: 6.46.0(@aws-sdk/credential-provider-node@3.972.33)(ws@8.21.0)(zod@4.3.5)
       zod:
         specifier: ^4.0.0
         version: 4.3.5


### PR DESCRIPTION
This pull request adds experimental WebSocket-only hosted multi-agent support to the OpenAI provider: https://developers.openai.com/api/docs/guides/tools-multi-agent

It supports streamed hosted collaboration events, local tool injection, concurrent hosted function calls, and continuation after completed-response injection races without losing pending outputs. It also preserves transport configuration, supports dynamic and explicitly removed authentication, makes credential preparation abortable, aggregates usage across Responses requests, and includes an executable example.