### PR TITLE
fix(realtime): surface provider error when /realtime/calls fails

### DIFF
--- a/.changeset/webrtc-realtime-calls-error.md
+++ b/.changeset/webrtc-realtime-calls-error.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix(realtime): surface the provider error when the WebRTC `/realtime/calls` request fails
+
+The WebRTC transport now checks `response.ok` before treating the `/realtime/calls` response as an SDP answer. On a non-2xx response it throws an error carrying the provider's message (e.g. `insufficient_quota`, invalid ephemeral key) instead of passing the error body to `setRemoteDescription`, which previously surfaced as an opaque "Failed to parse SessionDescription".

--- a/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
@@ -400,6 +400,16 @@ export class OpenAIRealtimeWebRTC
           },
         });
 
+        if (!sdpResponse.ok) {
+          // Without this the error body is passed to setRemoteDescription and
+          // surfaces as an opaque "Failed to parse SessionDescription", hiding
+          // the real cause (e.g. insufficient_quota, invalid ephemeral key).
+          const detail = await readSdpErrorDetail(sdpResponse);
+          throw new Error(
+            `Realtime call request failed with status ${sdpResponse.status}${detail}`,
+          );
+        }
+
         callId = sdpResponse.headers?.get('Location')?.split('/').pop();
         this.#state = { ...this.#state, callId };
 
@@ -592,4 +602,25 @@ export class OpenAIRealtimeWebRTC
       type: 'output_audio_buffer.clear',
     });
   }
+}
+
+async function readSdpErrorDetail(response: Response): Promise<string> {
+  try {
+    const text = await response.text();
+    if (text) {
+      try {
+        const message = JSON.parse(text)?.error?.message;
+        if (typeof message === 'string' && message) {
+          return `: ${message}`;
+        }
+      } catch {
+        // Non-JSON body — fall through to the raw text below.
+      }
+      return `: ${text}`;
+    }
+  } catch {
+    // Ignore response body read failures and use the status text below.
+  }
+
+  return response.statusText ? `: ${response.statusText}` : '';
 }

--- a/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
@@ -117,6 +117,8 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
     });
     Object.defineProperty(globalThis, 'fetch', {
       value: async () => ({
+        ok: true,
+        status: 200,
         text: async () => 'answer',
         headers: {
           get: (headerKey: string) => {
@@ -175,6 +177,33 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
     expect(JSON.parse(channel.sent[2])).toEqual({
       type: 'output_audio_buffer.clear',
     });
+  });
+
+  it('rejects with the provider error message when /realtime/calls fails', async () => {
+    Object.defineProperty(globalThis, 'fetch', {
+      value: async () => ({
+        ok: false,
+        status: 429,
+        statusText: 'Too Many Requests',
+        text: async () =>
+          JSON.stringify({
+            error: {
+              message: 'You exceeded your current quota.',
+              type: 'insufficient_quota',
+              code: 'insufficient_quota',
+            },
+          }),
+        headers: { get: () => null },
+      }),
+      configurable: true,
+      writable: true,
+    });
+
+    const rtc = new OpenAIRealtimeWebRTC();
+    rtc.on('error', () => {});
+    await expect(rtc.connect({ apiKey: 'ek_test' })).rejects.toThrow(
+      'Realtime call request failed with status 429: You exceeded your current quota.',
+    );
   });
 
   it('stops sending response.cancel once audio playback is done', async () => {
@@ -578,6 +607,8 @@ describe('OpenAIRealtimeWebRTC.connectionState', () => {
     });
     Object.defineProperty(globalThis, 'fetch', {
       value: async () => ({
+        ok: true,
+        status: 200,
         text: async () => 'answer',
         headers: {
           get: (headerKey: string) => {
@@ -738,6 +769,8 @@ describe('OpenAIRealtimeWebRTC.callId', () => {
     });
     Object.defineProperty(globalThis, 'fetch', {
       value: async () => ({
+        ok: true,
+        status: 200,
         text: async () => 'answer',
         headers: {
           get: (headerName: string) => {
@@ -908,6 +941,8 @@ describe('OpenAIRealtimeWebRTC session.updated ack', () => {
     });
     Object.defineProperty(globalThis, 'fetch', {
       value: async () => ({
+        ok: true,
+        status: 200,
         text: async () => 'answer',
         headers: {
           get: (headerKey: string) => {


### PR DESCRIPTION
### Summary

The WebRTC transport POSTs the SDP offer to `/v1/realtime/calls` but never checks `response.ok`. On a non-2xx response the error body is passed straight to `setRemoteDescription`, which throws an opaque `Failed to parse SessionDescription` and hides the real cause — quota exhaustion, an invalid/expired ephemeral key, a bad config, etc.

This adds a `response.ok` check before the body is treated as an SDP answer. On failure it throws an `Error` carrying the provider's message and the HTTP status, mirroring the existing `readHttpErrorDetail` pattern used for HTTP failures in `agents-core` (`sandbox/events.ts`). The throw lands in the existing `catch`, so it flows through `close()` / `_onError()` / reject like any other connect failure.

Before:

```
OperationError: Failed to execute 'setRemoteDescription' on 'RTCPeerConnection': Failed to parse SessionDescription. { Expect line: v=
```

After:

```
Error: Realtime call request failed with status 429: You exceeded your current quota, please check your plan and billing details.
```

### Test plan

- Added a unit test in `openaiRealtimeWebRtc.test.ts` asserting `connect()` rejects with the provider message on a 429.
- Updated the existing WebRTC fetch mocks to include `ok: true` / `status: 200` (they previously returned neither, so the new guard would otherwise treat them as failures).
- `pnpm build`, `pnpm test` (3032 passed / 2 skipped), `pnpm test:examples`, and `pnpm lint` all pass.

### Issue number

Closes #1460

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration` [(see details)](https://github.com/openai/openai-agents-js/tree/main/integration-tests)
- [x] I've made sure tests pass
- [x] I've added a changeset using `pnpm changeset` to indicate my changes
