### PR TITLE
feat: support GPT-5.6 request controls

### DIFF
--- a/.changeset/gpt-56-request-controls.md
+++ b/.changeset/gpt-56-request-controls.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+---
+
+feat: support GPT-5.6 reasoning and prompt-cache request controls

--- a/packages/agents-core/src/model.ts
+++ b/packages/agents-core/src/model.ts
@@ -42,6 +42,11 @@ export type ModelSettingsReasoningEffort =
  */
 export type ModelSettingsReasoning = {
   /**
+   * Controls which reasoning items are rendered back to the model on later turns.
+   */
+  context?: 'auto' | 'current_turn' | 'all_turns' | null;
+
+  /**
    * Constrains effort on reasoning for [reasoning models](https://platform.openai.com/docs/guides/reasoning).
    * Currently supported values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.
    * Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
@@ -49,11 +54,31 @@ export type ModelSettingsReasoning = {
   effort?: ModelSettingsReasoningEffort | null;
 
   /**
+   * Controls the reasoning execution mode for the request.
+   */
+  mode?: 'standard' | 'pro' | (string & {});
+
+  /**
    * A summary of the reasoning performed by the model.
    * This can be useful for debugging and understanding the model's reasoning process.
    * One of `auto`, `concise`, or `detailed`.
    */
   summary?: 'auto' | 'concise' | 'detailed' | null;
+};
+
+/**
+ * Prompt-cache configuration for supported model providers.
+ */
+export type ModelSettingsPromptCacheOptions = {
+  /**
+   * Controls whether the provider creates an implicit cache breakpoint.
+   */
+  mode?: 'implicit' | 'explicit';
+
+  /**
+   * The minimum lifetime applied to cache breakpoints written by the request.
+   */
+  ttl?: '30m';
 };
 
 export interface ModelSettingsText {
@@ -297,6 +322,11 @@ export type ModelSettings = {
    * See https://platform.openai.com/docs/guides/prompt-caching#prompt-cache-retention for the available options.
    */
   promptCacheRetention?: 'in-memory' | '24h' | null;
+
+  /**
+   * Controls implicit and explicit prompt caching for supported model providers.
+   */
+  promptCacheOptions?: ModelSettingsPromptCacheOptions;
 
   /**
    * Context-management strategies to apply when calling the model.

--- a/packages/agents-core/src/runner/modelSettingsMerge.ts
+++ b/packages/agents-core/src/runner/modelSettingsMerge.ts
@@ -1,6 +1,10 @@
 import { ModelSettings } from '../model';
 
-const NESTED_MODEL_SETTINGS_MERGE_KEYS = ['reasoning', 'text'] as const;
+const NESTED_MODEL_SETTINGS_MERGE_KEYS = [
+  'reasoning',
+  'text',
+  'promptCacheOptions',
+] as const;
 
 function isPlainObjectLike(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/packages/agents-core/src/types/protocol.ts
+++ b/packages/agents-core/src/types/protocol.ts
@@ -55,12 +55,26 @@ export const OutputText = SharedBase.extend({
 
 export type OutputText = z.infer<typeof OutputText>;
 
+export const PromptCacheBreakpoint = z.object({
+  /**
+   * The breakpoint mode. Always `explicit`.
+   */
+  mode: z.literal('explicit'),
+});
+
+export type PromptCacheBreakpoint = z.infer<typeof PromptCacheBreakpoint>;
+
 export const InputText = SharedBase.extend({
   type: z.literal('input_text'),
   /**
    * A text input for example a message from a user
    */
   text: z.string(),
+
+  /**
+   * Marks the exact end of a reusable prompt prefix.
+   */
+  promptCacheBreakpoint: PromptCacheBreakpoint.optional(),
 });
 
 export type InputText = z.infer<typeof InputText>;
@@ -97,6 +111,11 @@ export const InputImage = SharedBase.extend({
    * Future models may add new values, therefore this accepts any string.
    */
   detail: z.string().optional(),
+
+  /**
+   * Marks the exact end of a reusable prompt prefix.
+   */
+  promptCacheBreakpoint: PromptCacheBreakpoint.optional(),
 });
 
 export type InputImage = z.infer<typeof InputImage>;
@@ -125,6 +144,11 @@ export const InputFile = SharedBase.extend({
    * Optional filename metadata when uploading file data inline.
    */
   filename: z.string().optional(),
+
+  /**
+   * Marks the exact end of a reusable prompt prefix.
+   */
+  promptCacheBreakpoint: PromptCacheBreakpoint.optional(),
 });
 
 export type InputFile = z.infer<typeof InputFile>;
@@ -153,6 +177,11 @@ export const AudioContent = SharedBase.extend({
    * The transcript of the audio.
    */
   transcript: z.string().nullable().optional(),
+
+  /**
+   * Marks the exact end of a reusable prompt prefix.
+   */
+  promptCacheBreakpoint: PromptCacheBreakpoint.optional(),
 });
 
 export type AudioContent = z.infer<typeof AudioContent>;

--- a/packages/agents-core/test/runner/modelSettings.test.ts
+++ b/packages/agents-core/test/runner/modelSettings.test.ts
@@ -152,6 +152,24 @@ describe('adjustModelSettingsForNonGPT5RunnerModel', () => {
 });
 
 describe('mergeModelSettings', () => {
+  it('merges GPT-5.6 reasoning and prompt-cache options', () => {
+    expect(
+      mergeModelSettings(
+        {
+          reasoning: { effort: 'max', context: 'all_turns' },
+          promptCacheOptions: { mode: 'explicit', ttl: '30m' },
+        },
+        {
+          reasoning: { mode: 'pro' },
+          promptCacheOptions: { mode: 'implicit' },
+        },
+      ),
+    ).toEqual({
+      reasoning: { effort: 'max', context: 'all_turns', mode: 'pro' },
+      promptCacheOptions: { mode: 'implicit', ttl: '30m' },
+    });
+  });
+
   it('deep merges retry settings and nested backoff overrides', () => {
     const policy = () => true;
 

--- a/packages/agents-openai/src/openaiChatCompletionsConverter.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsConverter.ts
@@ -128,6 +128,9 @@ export function extractAllUserContent(
       out.push({
         type: 'text',
         text: c.text,
+        ...(c.promptCacheBreakpoint
+          ? { prompt_cache_breakpoint: c.promptCacheBreakpoint }
+          : {}),
         ...getProviderDataWithoutReservedKeys(c.providerData, ['type', 'text']),
       });
     } else if (c.type === 'input_image') {
@@ -165,6 +168,9 @@ export function extractAllUserContent(
             : {}),
           ...imageUrl,
         },
+        ...(c.promptCacheBreakpoint
+          ? { prompt_cache_breakpoint: c.promptCacheBreakpoint }
+          : {}),
         ...rest,
       });
     } else if (c.type === 'input_file') {
@@ -204,6 +210,9 @@ export function extractAllUserContent(
       out.push({
         type: 'file',
         file,
+        ...(c.promptCacheBreakpoint
+          ? { prompt_cache_breakpoint: c.promptCacheBreakpoint }
+          : {}),
         ...rest,
       });
     } else if (c.type === 'audio') {
@@ -239,6 +248,9 @@ export function extractAllUserContent(
           format: inputAudioFormat,
           ...inputAudio,
         } as ChatCompletionContentPartInputAudio['input_audio'],
+        ...(c.promptCacheBreakpoint
+          ? { prompt_cache_breakpoint: c.promptCacheBreakpoint }
+          : {}),
         ...rest,
       });
     } else {

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -79,6 +79,7 @@ export class OpenAIChatCompletionsModel implements Model {
   #strictFeatureValidation: boolean;
   #hasWarnedUnsupportedPrompt = false;
   #hasWarnedUnsupportedConversationState = false;
+  #hasWarnedUnsupportedReasoningSettings = false;
 
   constructor(
     client: OpenAIClient,
@@ -97,6 +98,7 @@ export class OpenAIChatCompletionsModel implements Model {
   async getResponse(request: ModelRequest): Promise<ModelResponse> {
     this.#handleUnsupportedServerManagedConversationState(request);
     this.#handleUnsupportedPrompt(request);
+    this.#handleUnsupportedReasoningSettings(request);
 
     const response = await withGenerationSpan(async (span) => {
       span.spanData.model = this.#model;
@@ -235,6 +237,7 @@ export class OpenAIChatCompletionsModel implements Model {
   ): AsyncIterable<ResponseStreamEvent> {
     this.#handleUnsupportedServerManagedConversationState(request);
     this.#handleUnsupportedPrompt(request);
+    this.#handleUnsupportedReasoningSettings(request);
 
     const span = request.tracing ? createGenerationSpan() : undefined;
     try {
@@ -374,6 +377,39 @@ export class OpenAIChatCompletionsModel implements Model {
     }
   }
 
+  #handleUnsupportedReasoningSettings(request: ModelRequest) {
+    const reasoning = request.modelSettings.reasoning;
+    if (!reasoning) {
+      return;
+    }
+
+    const unsupported = (['mode', 'context'] as const).filter(
+      (name) => reasoning[name] !== undefined && reasoning[name] !== null,
+    );
+    if (unsupported.length === 0) {
+      return;
+    }
+
+    const unsupportedParams = unsupported
+      .map((name) => `reasoning.${name}`)
+      .join(', ');
+    const message =
+      `OpenAIChatCompletionsModel does not support ${unsupportedParams}. ` +
+      'These reasoning settings require the Responses API; Chat Completions only uses reasoning.effort.';
+
+    if (this.#strictFeatureValidation) {
+      throw new UserError(message);
+    }
+
+    if (!this.#hasWarnedUnsupportedReasoningSettings) {
+      logger.warn(
+        `${message} Ignoring unsupported reasoning settings; ` +
+          'enable strict feature validation to raise an error instead.',
+      );
+      this.#hasWarnedUnsupportedReasoningSettings = true;
+    }
+  }
+
   /**
    * @internal
    */
@@ -495,6 +531,7 @@ export class OpenAIChatCompletionsModel implements Model {
       prompt_cache_retention: normalizePromptCacheRetention(
         request.modelSettings.promptCacheRetention,
       ),
+      prompt_cache_options: request.modelSettings.promptCacheOptions,
       ...providerData,
     };
 

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -1662,6 +1662,9 @@ function getInputMessageContent(
     return {
       type: 'input_text',
       text: entry.text,
+      ...(entry.promptCacheBreakpoint
+        ? { prompt_cache_breakpoint: entry.promptCacheBreakpoint }
+        : {}),
       ...getSnakeCasedProviderDataWithoutReservedKeys(entry.providerData, [
         'type',
         'text',
@@ -1683,6 +1686,9 @@ function getInputMessageContent(
     }
     return {
       ...imageEntry,
+      ...(entry.promptCacheBreakpoint
+        ? { prompt_cache_breakpoint: entry.promptCacheBreakpoint }
+        : {}),
       ...getSnakeCasedProviderDataWithoutReservedKeys(entry.providerData, [
         'type',
         'detail',
@@ -1738,6 +1744,9 @@ function getInputMessageContent(
     }
     return {
       ...fileEntry,
+      ...(entry.promptCacheBreakpoint
+        ? { prompt_cache_breakpoint: entry.promptCacheBreakpoint }
+        : {}),
       ...getSnakeCasedProviderDataWithoutReservedKeys(entry.providerData, [
         'type',
         'file_data',
@@ -3106,6 +3115,7 @@ export class OpenAIResponsesModel implements Model {
       prompt_cache_retention: normalizePromptCacheRetention(
         request.modelSettings.promptCacheRetention,
       ),
+      prompt_cache_options: request.modelSettings.promptCacheOptions,
       context_management: getContextManagement(
         request.modelSettings.contextManagement,
       ),

--- a/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
@@ -119,6 +119,60 @@ describe('content extraction helpers', () => {
     ]);
   });
 
+  test('extractAllUserContent preserves prompt-cache breakpoints', () => {
+    const promptCacheBreakpoint = { mode: 'explicit' } as const;
+    const userContent: protocol.UserMessageItem['content'] = [
+      {
+        type: 'input_text',
+        text: 'one',
+        promptCacheBreakpoint,
+      },
+      {
+        type: 'input_image',
+        image: 'http://img',
+        promptCacheBreakpoint,
+      },
+      {
+        type: 'input_file',
+        file: 'data:text/plain;base64,SGVsbG8=',
+        filename: 'hello.txt',
+        promptCacheBreakpoint,
+      },
+      {
+        type: 'audio',
+        audio: 'AAA=',
+        format: 'wav',
+        promptCacheBreakpoint,
+      },
+    ];
+
+    expect(extractAllUserContent(userContent)).toEqual([
+      {
+        type: 'text',
+        text: 'one',
+        prompt_cache_breakpoint: promptCacheBreakpoint,
+      },
+      {
+        type: 'image_url',
+        image_url: { url: 'http://img' },
+        prompt_cache_breakpoint: promptCacheBreakpoint,
+      },
+      {
+        type: 'file',
+        file: {
+          file_data: 'data:text/plain;base64,SGVsbG8=',
+          filename: 'hello.txt',
+        },
+        prompt_cache_breakpoint: promptCacheBreakpoint,
+      },
+      {
+        type: 'input_audio',
+        input_audio: { data: 'AAA=', format: 'wav' },
+        prompt_cache_breakpoint: promptCacheBreakpoint,
+      },
+    ]);
+  });
+
   test('extractAllUserContent preserves extras but ignores reserved providerData fields', () => {
     const userContent: protocol.UserMessageItem['content'] = [
       {

--- a/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
@@ -472,7 +472,7 @@ describe('OpenAIChatCompletionsModel', () => {
     ]);
   });
 
-  it('sends prompt cache retention when provided', async () => {
+  it('sends prompt cache controls when provided', async () => {
     const client = new FakeClient();
     const response = {
       id: 'r',
@@ -486,6 +486,7 @@ describe('OpenAIChatCompletionsModel', () => {
       input: 'u',
       modelSettings: {
         promptCacheRetention: 'in-memory',
+        promptCacheOptions: { mode: 'explicit', ttl: '30m' },
       },
       tools: [],
       outputType: 'text',
@@ -498,9 +499,66 @@ describe('OpenAIChatCompletionsModel', () => {
     expect(client.chat.completions.create).toHaveBeenCalledWith(
       expect.objectContaining({
         prompt_cache_retention: 'in_memory',
+        prompt_cache_options: { mode: 'explicit', ttl: '30m' },
       }),
       { headers: HEADERS, signal: undefined },
     );
+  });
+
+  it('warns once for Responses-only reasoning settings', async () => {
+    const client = new FakeClient();
+    const response = {
+      id: 'r',
+      choices: [{ message: { content: 'hi' } }],
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    } as any;
+    client.chat.completions.create.mockResolvedValue(response);
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt-5.6');
+    const req: any = {
+      input: 'u',
+      modelSettings: {
+        reasoning: { mode: 'pro', effort: 'max', context: 'all_turns' },
+      },
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+    };
+
+    await withTrace('t', () => model.getResponse(req));
+    await withTrace('t', () => model.getResponse(req));
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain('reasoning.mode');
+    expect(warnSpy.mock.calls[0]?.[0]).toContain('reasoning.context');
+    expect(client.chat.completions.create.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ reasoning_effort: 'max' }),
+    );
+    expect(
+      client.chat.completions.create.mock.calls[0]?.[0],
+    ).not.toHaveProperty('reasoning');
+    warnSpy.mockRestore();
+  });
+
+  it('rejects Responses-only reasoning settings in strict mode', async () => {
+    const client = new FakeClient();
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt-5.6', {
+      strictFeatureValidation: true,
+    });
+    const req: any = {
+      input: 'u',
+      modelSettings: { reasoning: { mode: 'pro', context: 'all_turns' } },
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+    };
+
+    await expect(withTrace('t', () => model.getResponse(req))).rejects.toThrow(
+      /reasoning\.mode.*reasoning\.context/,
+    );
+    expect(client.chat.completions.create).not.toHaveBeenCalled();
   });
 
   it('handles refusal message', async () => {

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -1056,7 +1056,7 @@ describe('OpenAIResponsesModel', () => {
     });
   });
 
-  it('sends prompt cache retention setting to the Responses API', async () => {
+  it('sends GPT-5.6 reasoning and prompt-cache controls to the Responses API', async () => {
     await withTrace('test', async () => {
       const fakeResponse = { id: 'res-cache', usage: {}, output: [] };
       const createMock = vi.fn().mockResolvedValue(fakeResponse);
@@ -1068,7 +1068,11 @@ describe('OpenAIResponsesModel', () => {
       const request = {
         systemInstructions: undefined,
         input: 'hello',
-        modelSettings: { promptCacheRetention: 'in-memory' },
+        modelSettings: {
+          promptCacheRetention: 'in-memory',
+          promptCacheOptions: { mode: 'explicit', ttl: '30m' },
+          reasoning: { mode: 'pro', effort: 'max', context: 'all_turns' },
+        },
         tools: [],
         outputType: 'text',
         handoffs: [],
@@ -1080,6 +1084,81 @@ describe('OpenAIResponsesModel', () => {
 
       const [args] = createMock.mock.calls[0];
       expect(args.prompt_cache_retention).toBe('in_memory');
+      expect(args.prompt_cache_options).toEqual({
+        mode: 'explicit',
+        ttl: '30m',
+      });
+      expect(args.reasoning).toEqual({
+        mode: 'pro',
+        effort: 'max',
+        context: 'all_turns',
+      });
+    });
+  });
+
+  it('preserves prompt-cache breakpoints in Responses input content', async () => {
+    await withTrace('test', async () => {
+      const createMock = vi
+        .fn()
+        .mockResolvedValue({ id: 'res-breakpoints', usage: {}, output: [] });
+      const fakeClient = {
+        responses: { create: createMock },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(fakeClient, 'gpt-5.6');
+      const promptCacheBreakpoint = { mode: 'explicit' } as const;
+
+      await model.getResponse({
+        systemInstructions: undefined,
+        input: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'input_text',
+                text: 'one',
+                promptCacheBreakpoint,
+              },
+              {
+                type: 'input_image',
+                image: 'https://example.com/image.png',
+                promptCacheBreakpoint,
+              },
+              {
+                type: 'input_file',
+                file: 'data:text/plain;base64,SGVsbG8=',
+                filename: 'hello.txt',
+                promptCacheBreakpoint,
+              },
+            ],
+          },
+        ],
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      } as any);
+
+      expect(createMock.mock.calls[0]?.[0].input[0].content).toEqual([
+        {
+          type: 'input_text',
+          text: 'one',
+          prompt_cache_breakpoint: promptCacheBreakpoint,
+        },
+        {
+          type: 'input_image',
+          detail: 'auto',
+          image_url: 'https://example.com/image.png',
+          prompt_cache_breakpoint: promptCacheBreakpoint,
+        },
+        {
+          type: 'input_file',
+          file_data: 'data:text/plain;base64,SGVsbG8=',
+          filename: 'hello.txt',
+          prompt_cache_breakpoint: promptCacheBreakpoint,
+        },
+      ]);
     });
   });
 


### PR DESCRIPTION
This pull request adds GPT-5.6 reasoning mode and context controls, explicit prompt-cache options, and content-part cache breakpoints across the Responses and Chat Completions model paths.

It preserves provider-data precedence, forwards the controls through Responses HTTP and WebSocket transports, and warns or raises under strict validation when Responses-only reasoning settings are supplied to Chat Completions. It also documents model and API-surface differences observed during live API validation.