### PR TITLE
feat(core): add per-model-request timeouts

### DIFF
--- a/.agents/references/model-provider-and-conversion-boundaries.md
+++ b/.agents/references/model-provider-and-conversion-boundaries.md
@@ -24,7 +24,7 @@ Use this reference for model/provider resolution, settings merge, Responses vers
 ## Retry and Persistent Transports
 
 - Model retries are opt-in. Apply abort and replay-safety vetoes before user policy, preserve failed-attempt usage, and do not retry a stateful request unless the provider indicates replay is safe or the request boundary proves it.
-- Providers with ambiguous in-flight acceptance must mark the attempt replay-unsafe before a runner timeout can mask their eventual transport error. Responses WebSocket attempts become replay-unsafe after the request frame is sent; pre-send timeouts remain eligible for the configured retry policy.
+- Providers with ambiguous in-flight acceptance must mark the attempt replay-unsafe before a runner timeout can mask their eventual transport error. Responses and Hosted Multi-Agent WebSocket attempts become replay-unsafe after the request frame is sent; pre-send timeouts remain eligible for the configured retry policy.
 - Responses WebSocket mode reuses a persistent connection and chains requests with connection-local state. Serialize access per session, propagate terminal errors, and close only the session-owned socket.
 - Compare HTTP and WebSocket Responses behavior for input, continuation, raw events, terminal items, and errors; transport choice must not change runner semantics.
 

--- a/.agents/references/model-provider-and-conversion-boundaries.md
+++ b/.agents/references/model-provider-and-conversion-boundaries.md
@@ -24,6 +24,7 @@ Use this reference for model/provider resolution, settings merge, Responses vers
 ## Retry and Persistent Transports
 
 - Model retries are opt-in. Apply abort and replay-safety vetoes before user policy, preserve failed-attempt usage, and do not retry a stateful request unless the provider indicates replay is safe or the request boundary proves it.
+- Providers with ambiguous in-flight acceptance must mark the attempt replay-unsafe before a runner timeout can mask their eventual transport error. Responses WebSocket attempts become replay-unsafe after the request frame is sent; pre-send timeouts remain eligible for the configured retry policy.
 - Responses WebSocket mode reuses a persistent connection and chains requests with connection-local state. Serialize access per session, propagate terminal errors, and close only the session-owned socket.
 - Compare HTTP and WebSocket Responses behavior for input, continuation, raw events, terminal items, and errors; transport choice must not change runner semantics.
 

--- a/.changeset/calm-requests-time.md
+++ b/.changeset/calm-requests-time.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+feat(core): add per-model-request timeouts with retry policy support (#894)

--- a/.changeset/calm-requests-time.md
+++ b/.changeset/calm-requests-time.md
@@ -1,5 +1,6 @@
 ---
 '@openai/agents-core': patch
+'@openai/agents-openai': patch
 ---
 
-feat(core): add per-model-request timeouts with retry policy support (#894)
+feat(core): add replay-safe per-model-request timeouts with retry policy support (#894)

--- a/docs/src/content/docs/guides/models.mdx
+++ b/docs/src/content/docs/guides/models.mdx
@@ -272,7 +272,7 @@ const agent = new Agent({
 });
 ```
 
-When the deadline expires, the SDK aborts that attempt's request signal and throws `ModelRequestTimeoutError`. Retries remain opt-in; `retryPolicies.timeout()` matches request timeouts, and every runner-managed retry receives a fresh deadline. Existing replay-safety rules still apply, so a streamed attempt is not retried after it emits an event, and stateful requests using `previousResponseId` or `conversationId` still require replay-safe provider approval.
+When the deadline expires, the SDK aborts that attempt's request signal and throws `ModelRequestTimeoutError`. Retries remain opt-in; `retryPolicies.timeout()` matches request timeouts, and every runner-managed retry receives a fresh deadline. Existing replay-safety rules still apply, so a streamed attempt is not retried after it emits an event, a Responses WebSocket attempt is not retried after its request frame is sent, and stateful requests using `previousResponseId` or `conversationId` still require replay-safe provider approval.
 
 This setting is different from passing an `AbortSignal` to `run()`: aborting that signal cancels the overall run and is never treated as a retryable request timeout. Provider clients can also enforce their own transport timeouts; when both are configured, whichever deadline or transport failure happens first ends the attempt.
 

--- a/docs/src/content/docs/guides/models.mdx
+++ b/docs/src/content/docs/guides/models.mdx
@@ -222,6 +222,7 @@ Do not combine this model with SDK handoffs, `reasoning.summary`, or `max_tool_c
 | `parallelToolCalls` | `boolean` | Allow parallel function calls where supported. |
 | `truncation` | `'auto' \| 'disabled'` | Token truncation strategy. |
 | `maxTokens` | `number` | Maximum tokens in the response. |
+| `requestTimeoutMs` | `number` | Positive maximum duration of each model request attempt in milliseconds. See [Model request timeouts](#model-request-timeouts). |
 | `store` | `boolean` | Persist the response for retrieval / RAG workflows. |
 | `promptCacheRetention` | `'in-memory' \| '24h' \| null` | Controls the legacy maximum prompt-cache retention policy when supported. This is independent of `promptCacheOptions.ttl`. |
 | `promptCacheOptions` | `{ mode?: 'implicit' \| 'explicit'; ttl?: '30m' }` | Controls implicit or explicit prompt-cache breakpoints for GPT-5.6 and later models. |
@@ -254,6 +255,27 @@ GPT-5.6 adds request-level reasoning modes and explicit prompt-cache breakpoints
 
 Explicit breakpoints are supported on GPT-5.6 and later models. The supported content-part types and breakpoint limits vary by API; see the official [prompt cache breakpoint guide](https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints) for current details.
 
+### Model request timeouts
+
+Set `modelSettings.requestTimeoutMs` to cap each model request attempt. The timeout is provider-agnostic and covers the complete attempt: waiting for a non-streaming response or consuming a stream through its terminal event.
+
+```typescript
+const agent = new Agent({
+  name: 'Reliable agent',
+  modelSettings: {
+    requestTimeoutMs: 30_000,
+    retry: {
+      maxRetries: 2,
+      policy: retryPolicies.timeout(),
+    },
+  },
+});
+```
+
+When the deadline expires, the SDK aborts that attempt's request signal and throws `ModelRequestTimeoutError`. Retries remain opt-in; `retryPolicies.timeout()` matches request timeouts, and every runner-managed retry receives a fresh deadline. Existing replay-safety rules still apply, so a streamed attempt is not retried after it emits an event, and stateful requests using `previousResponseId` or `conversationId` still require replay-safe provider approval.
+
+This setting is different from passing an `AbortSignal` to `run()`: aborting that signal cancels the overall run and is never treated as a retryable request timeout. Provider clients can also enforce their own transport timeouts; when both are configured, whichever deadline or transport failure happens first ends the attempt.
+
 ### Model retries
 
 Retries are runtime-only and opt-in. The SDK does not retry model requests unless you configure `modelSettings.retry` and your policy returns a retry decision.
@@ -273,7 +295,7 @@ A retry policy receives a `RetryPolicyContext` with:
 - `attempt` and `maxRetries` so you can make attempt-aware decisions.
 - `stream` so you can branch between streamed and non-streamed behavior.
 - `error` for raw inspection.
-- `normalized` facts such as `statusCode`, `retryAfterMs`, `errorCode`, `isNetworkError`, and `isAbort`.
+- `normalized` facts such as `statusCode`, `retryAfterMs`, `errorCode`, `isNetworkError`, `isTimeout`, and `isAbort`.
 - `providerAdvice` when the underlying model/provider can supply retry guidance.
 
 The policy can return either:
@@ -288,6 +310,7 @@ The SDK exports ready-made helpers on `retryPolicies`:
 | `retryPolicies.never()` | Always opts out. |
 | `retryPolicies.providerSuggested()` | Follows provider retry advice when available. |
 | `retryPolicies.networkError()` | Matches transient transport/connectivity failures. |
+| `retryPolicies.timeout()` | Matches model request and provider transport timeouts. |
 | `retryPolicies.httpStatus([..])` | Matches selected HTTP status codes. |
 | `retryPolicies.retryAfter()` | Retries only when a retry-after hint is available, using that hint as an explicit delay that is not capped by `backoff.maxDelayMs`. |
 | `retryPolicies.any(...)` | Retries when any nested policy opts in. |

--- a/docs/src/content/docs/guides/models.mdx
+++ b/docs/src/content/docs/guides/models.mdx
@@ -272,7 +272,7 @@ const agent = new Agent({
 });
 ```
 
-When the deadline expires, the SDK aborts that attempt's request signal and throws `ModelRequestTimeoutError`. Retries remain opt-in; `retryPolicies.timeout()` matches request timeouts, and every runner-managed retry receives a fresh deadline. Existing replay-safety rules still apply, so a streamed attempt is not retried after it emits an event, a Responses WebSocket attempt is not retried after its request frame is sent, and stateful requests using `previousResponseId` or `conversationId` still require replay-safe provider approval.
+When the deadline expires, the SDK aborts that attempt's request signal and throws `ModelRequestTimeoutError`. Retries remain opt-in; `retryPolicies.timeout()` matches request timeouts, and every runner-managed retry receives a fresh deadline. Existing replay-safety rules still apply, so a streamed attempt is not retried after it emits an event, an OpenAI WebSocket attempt is not retried after its request frame is sent, and stateful requests using `previousResponseId` or `conversationId` still require replay-safe provider approval.
 
 This setting is different from passing an `AbortSignal` to `run()`: aborting that signal cancels the overall run and is never treated as a retryable request timeout. Provider clients can also enforce their own transport timeouts; when both are configured, whichever deadline or transport failure happens first ends the attempt.
 

--- a/packages/agents-core/src/errors.ts
+++ b/packages/agents-core/src/errors.ts
@@ -58,6 +58,24 @@ export class ModelRefusalError extends AgentsError {
 export class ModelBehaviorError extends AgentsError {}
 
 /**
+ * Error thrown when a model request attempt exceeds its timeout.
+ */
+export class ModelRequestTimeoutError extends AgentsError {
+  timeoutMs: number;
+
+  constructor({
+    timeoutMs,
+    state,
+  }: {
+    timeoutMs: number;
+    state?: RunState<any, Agent<any, any>>;
+  }) {
+    super(`Model request timed out after ${timeoutMs}ms.`, state);
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+/**
  * Context from tool invocation that failed validation.
  */
 export type ToolInvocationErrorContext = {

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -28,6 +28,7 @@ export {
   InputGuardrailTripwireTriggered,
   MaxTurnsExceededError,
   ModelBehaviorError,
+  ModelRequestTimeoutError,
   ModelRefusalError,
   OutputGuardrailTripwireTriggered,
   ToolInputGuardrailTripwireTriggered,

--- a/packages/agents-core/src/model.ts
+++ b/packages/agents-core/src/model.ts
@@ -150,6 +150,11 @@ export type ModelRetryNormalizedError = {
   isNetworkError: boolean;
 
   /**
+   * Whether the error was caused by a model request timeout.
+   */
+  isTimeout?: boolean;
+
+  /**
    * Whether the error was caused by an abort signal or abort exception.
    */
   isAbort: boolean;
@@ -310,6 +315,12 @@ export type ModelSettings = {
    * The maximum number of output tokens to generate.
    */
   maxTokens?: number;
+
+  /**
+   * Maximum duration in milliseconds for each model request attempt.
+   * Every runner-managed retry receives a fresh timeout.
+   */
+  requestTimeoutMs?: number;
 
   /**
    * Whether to store the generated model response for later retrieval.

--- a/packages/agents-core/src/model.ts
+++ b/packages/agents-core/src/model.ts
@@ -554,6 +554,8 @@ export type ModelRequest = {
   _internal?: {
     runnerManagedRetry?: boolean;
     reasoningEffortImplicit?: boolean;
+    /** Marks the current model attempt as potentially accepted by the provider. */
+    markReplayUnsafe?: () => void;
   };
 };
 

--- a/packages/agents-core/src/runner/modelRetry.ts
+++ b/packages/agents-core/src/runner/modelRetry.ts
@@ -957,7 +957,18 @@ export async function* getStreamedResponseWithRetry(
         !iteratorCompleted &&
         iterator?.return
       ) {
-        await iterator.return();
+        if (failure instanceof ModelRequestTimeoutError) {
+          try {
+            const cleanup = iterator.return();
+            // Timeout remains the primary failure. Cleanup is best-effort so
+            // a rejecting or stuck provider iterator cannot block retry.
+            void Promise.resolve(cleanup).catch(() => {});
+          } catch {
+            // Preserve the configured timeout when cleanup throws synchronously.
+          }
+        } else {
+          await iterator.return();
+        }
       }
     }
 

--- a/packages/agents-core/src/runner/modelRetry.ts
+++ b/packages/agents-core/src/runner/modelRetry.ts
@@ -12,6 +12,8 @@ import type {
 } from '../model';
 import type { StreamEvent } from '../types/protocol';
 import { RequestUsage, Usage } from '../usage';
+import { ModelRequestTimeoutError, UserError } from '../errors';
+import { combineAbortSignals } from '../utils/abortSignals';
 
 const DEFAULT_INITIAL_DELAY_MS = 250;
 const DEFAULT_MAX_DELAY_MS = 2_000;
@@ -19,6 +21,7 @@ const DEFAULT_BACKOFF_MULTIPLIER = 2;
 const DEFAULT_BACKOFF_JITTER = true;
 const RETRY_AFTER_MS_HEADER = 'retry-after-ms';
 const RETRY_AFTER_HEADER = 'retry-after';
+const MAX_REQUEST_TIMEOUT_MS = 2_147_483_647;
 
 type ResolvedRetryDecision = {
   retry: boolean;
@@ -47,6 +50,13 @@ type EvaluateRetryParams = {
   emittedVisibleEvent: boolean;
   emittedRawModelEvent: boolean;
   providerAdvice?: ModelRetryAdvice;
+};
+
+type ModelRequestAttempt = {
+  request: ModelRequest;
+  waitFor<T>(operation: () => PromiseLike<T>): Promise<T>;
+  normalizeError(error: unknown): unknown;
+  cleanup(): void;
 };
 
 function addFailedRetryAttemptsToUsage(
@@ -107,6 +117,97 @@ function shouldDisableProviderManagedRetry(
   }
 
   return attempt > 1;
+}
+
+function getRequestTimeoutMs(request: ModelRequest): number | undefined {
+  const timeoutMs = request.modelSettings.requestTimeoutMs;
+  if (timeoutMs === undefined) {
+    return undefined;
+  }
+
+  if (
+    typeof timeoutMs !== 'number' ||
+    !Number.isFinite(timeoutMs) ||
+    timeoutMs <= 0 ||
+    timeoutMs > MAX_REQUEST_TIMEOUT_MS
+  ) {
+    throw new UserError(
+      `modelSettings.requestTimeoutMs must be a finite number greater than 0 and less than or equal to ${MAX_REQUEST_TIMEOUT_MS}.`,
+    );
+  }
+
+  return timeoutMs;
+}
+
+function createModelRequestAttempt(
+  request: ModelRequest,
+  timeoutMs: number | undefined,
+): ModelRequestAttempt {
+  if (timeoutMs === undefined) {
+    return {
+      request,
+      waitFor: async <T>(operation: () => PromiseLike<T>) => await operation(),
+      normalizeError: (error) => error,
+      cleanup: () => {},
+    };
+  }
+
+  const timeoutController = new AbortController();
+  const timeoutError = new ModelRequestTimeoutError({ timeoutMs });
+  const combined = combineAbortSignals(
+    request.signal,
+    timeoutController.signal,
+  );
+  const signal = combined.signal!;
+  let timedOut = false;
+
+  const timeout = setTimeout(() => {
+    if (signal.aborted) {
+      return;
+    }
+    timedOut = true;
+    timeoutController.abort(timeoutError);
+  }, timeoutMs);
+
+  return {
+    request: { ...request, signal },
+    waitFor: async <T>(operation: () => PromiseLike<T>) => {
+      let abortListener: (() => void) | undefined;
+      const abortPromise = new Promise<never>((_, reject) => {
+        const onAbort = () => {
+          try {
+            throwAbortError(signal);
+          } catch (error) {
+            reject(error);
+          }
+        };
+
+        if (signal.aborted) {
+          onAbort();
+          return;
+        }
+
+        abortListener = onAbort;
+        signal.addEventListener('abort', onAbort, { once: true });
+      });
+
+      try {
+        return await Promise.race([
+          Promise.resolve().then(operation),
+          abortPromise,
+        ]);
+      } finally {
+        if (abortListener) {
+          signal.removeEventListener('abort', abortListener);
+        }
+      }
+    },
+    normalizeError: (error) => (timedOut ? timeoutError : error),
+    cleanup: () => {
+      clearTimeout(timeout);
+      combined.cleanup();
+    },
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -176,7 +277,34 @@ function isAbortLikeError(error: unknown): boolean {
   return cause ? isAbortLikeError(cause) : false;
 }
 
+function isTimeoutLikeError(error: unknown): boolean {
+  if (error instanceof ModelRequestTimeoutError) {
+    return true;
+  }
+
+  const name = getErrorName(error);
+  if (name === 'APIConnectionTimeoutError' || name === 'TimeoutError') {
+    return true;
+  }
+
+  const code = getErrorCode(error);
+  if (
+    code === 'ECONNABORTED' ||
+    code === 'ETIMEDOUT' ||
+    code === 'UND_ERR_CONNECT_TIMEOUT'
+  ) {
+    return true;
+  }
+
+  const cause = getNestedError(error);
+  return cause ? isTimeoutLikeError(cause) : false;
+}
+
 function isNetworkLikeError(error: unknown): boolean {
+  if (isTimeoutLikeError(error)) {
+    return true;
+  }
+
   const name = getErrorName(error);
   if (
     name === 'APIConnectionError' ||
@@ -328,6 +456,7 @@ function normalizeRetryError(
     retryAfterMs: getRetryAfterMs(headers),
     errorCode: getErrorCode(error),
     isNetworkError: isNetworkLikeError(error),
+    isTimeout: isTimeoutLikeError(error),
     isAbort: Boolean(signal?.aborted) || isAbortLikeError(error),
   };
 
@@ -574,6 +703,10 @@ export const retryPolicies = {
     return ({ normalized }) => normalized.isNetworkError;
   },
 
+  timeout(): RetryPolicy {
+    return ({ normalized }) => normalized.isTimeout === true;
+  },
+
   httpStatus(statuses: number[]): RetryPolicy {
     const allowed = new Set(statuses);
     return ({ normalized }) =>
@@ -661,6 +794,7 @@ export async function getResponseWithRetry(
   const maxRetries = request.modelSettings.retry?.maxRetries ?? 0;
   const retryPolicy = request.modelSettings.retry?.policy;
   const retryBackoff = request.modelSettings.retry?.backoff;
+  const requestTimeoutMs = getRequestTimeoutMs(request);
 
   let attempt = 1;
   const replayUnsafeRequest = isStatefulConversationRequest(request);
@@ -671,8 +805,15 @@ export async function getResponseWithRetry(
     )
       ? withRunnerManagedRetry(request)
       : request;
+    const modelRequestAttempt = createModelRequestAttempt(
+      requestForAttempt,
+      requestTimeoutMs,
+    );
+    let failure: unknown;
     try {
-      const response = await model.getResponse(requestForAttempt);
+      const response = await modelRequestAttempt.waitFor(() =>
+        model.getResponse(modelRequestAttempt.request),
+      );
       if (attempt === 1) {
         return response;
       }
@@ -681,33 +822,37 @@ export async function getResponseWithRetry(
         usage: addFailedRetryAttemptsToUsage(response.usage, attempt - 1),
       };
     } catch (error) {
-      const providerAdvice = await getRetryAdvice(model, {
-        request,
-        error,
-        stream: false,
-        attempt,
-      });
-      const decision = await evaluateRetry({
-        error,
-        attempt,
-        maxRetries,
-        retryPolicy,
-        retryBackoff,
-        signal: request.signal,
-        stream: false,
-        replayUnsafeRequest,
-        emittedVisibleEvent: false,
-        emittedRawModelEvent: false,
-        providerAdvice,
-      });
-
-      if (!decision.retry) {
-        throw error;
-      }
-
-      await waitForRetryDelay(request.signal, decision.delayMs ?? 0);
-      attempt += 1;
+      failure = modelRequestAttempt.normalizeError(error);
+    } finally {
+      modelRequestAttempt.cleanup();
     }
+
+    const providerAdvice = await getRetryAdvice(model, {
+      request,
+      error: failure,
+      stream: false,
+      attempt,
+    });
+    const decision = await evaluateRetry({
+      error: failure,
+      attempt,
+      maxRetries,
+      retryPolicy,
+      retryBackoff,
+      signal: request.signal,
+      stream: false,
+      replayUnsafeRequest,
+      emittedVisibleEvent: false,
+      emittedRawModelEvent: false,
+      providerAdvice,
+    });
+
+    if (!decision.retry) {
+      throw failure;
+    }
+
+    await waitForRetryDelay(request.signal, decision.delayMs ?? 0);
+    attempt += 1;
   }
 }
 
@@ -718,6 +863,7 @@ export async function* getStreamedResponseWithRetry(
   const maxRetries = request.modelSettings.retry?.maxRetries ?? 0;
   const retryPolicy = request.modelSettings.retry?.policy;
   const retryBackoff = request.modelSettings.retry?.backoff;
+  const requestTimeoutMs = getRequestTimeoutMs(request);
 
   let attempt = 1;
   const replayUnsafeRequest = isStatefulConversationRequest(request);
@@ -730,8 +876,28 @@ export async function* getStreamedResponseWithRetry(
     )
       ? withRunnerManagedRetry(request)
       : request;
+    const modelRequestAttempt = createModelRequestAttempt(
+      requestForAttempt,
+      requestTimeoutMs,
+    );
+    let failed = false;
+    let failure: unknown;
+    let iterator: AsyncIterator<StreamEvent> | undefined;
+    let iteratorCompleted = false;
     try {
-      for await (const event of model.getStreamedResponse(requestForAttempt)) {
+      const modelIterator = model
+        .getStreamedResponse(modelRequestAttempt.request)
+        [Symbol.asyncIterator]();
+      iterator = modelIterator;
+      while (true) {
+        const next = await modelRequestAttempt.waitFor(() =>
+          modelIterator.next(),
+        );
+        if (next.done) {
+          iteratorCompleted = true;
+          return;
+        }
+        const event = next.value;
         if (event.type === 'model') {
           emittedRawModelEvent = true;
         }
@@ -751,34 +917,41 @@ export async function* getStreamedResponseWithRetry(
         }
         yield event;
       }
-      return;
     } catch (error) {
-      const providerAdvice = await getRetryAdvice(model, {
-        request,
-        error,
-        stream: true,
-        attempt,
-      });
-      const decision = await evaluateRetry({
-        error,
-        attempt,
-        maxRetries,
-        retryPolicy,
-        retryBackoff,
-        signal: request.signal,
-        stream: true,
-        replayUnsafeRequest,
-        emittedVisibleEvent,
-        emittedRawModelEvent,
-        providerAdvice,
-      });
-
-      if (!decision.retry) {
-        throw error;
+      failed = true;
+      failure = modelRequestAttempt.normalizeError(error);
+    } finally {
+      modelRequestAttempt.cleanup();
+      if (!failed && !iteratorCompleted && iterator?.return) {
+        await iterator.return();
       }
-
-      await waitForRetryDelay(request.signal, decision.delayMs ?? 0);
-      attempt += 1;
     }
+
+    const providerAdvice = await getRetryAdvice(model, {
+      request,
+      error: failure,
+      stream: true,
+      attempt,
+    });
+    const decision = await evaluateRetry({
+      error: failure,
+      attempt,
+      maxRetries,
+      retryPolicy,
+      retryBackoff,
+      signal: request.signal,
+      stream: true,
+      replayUnsafeRequest,
+      emittedVisibleEvent,
+      emittedRawModelEvent,
+      providerAdvice,
+    });
+
+    if (!decision.retry) {
+      throw failure;
+    }
+
+    await waitForRetryDelay(request.signal, decision.delayMs ?? 0);
+    attempt += 1;
   }
 }

--- a/packages/agents-core/src/runner/modelRetry.ts
+++ b/packages/agents-core/src/runner/modelRetry.ts
@@ -56,6 +56,7 @@ type ModelRequestAttempt = {
   request: ModelRequest;
   waitFor<T>(operation: () => PromiseLike<T>): Promise<T>;
   normalizeError(error: unknown): unknown;
+  isReplayUnsafeAfterTimeout(): boolean;
   cleanup(): void;
 };
 
@@ -148,6 +149,7 @@ function createModelRequestAttempt(
       request,
       waitFor: async <T>(operation: () => PromiseLike<T>) => await operation(),
       normalizeError: (error) => error,
+      isReplayUnsafeAfterTimeout: () => false,
       cleanup: () => {},
     };
   }
@@ -160,6 +162,7 @@ function createModelRequestAttempt(
   );
   const signal = combined.signal!;
   let timedOut = false;
+  let replayUnsafe = false;
 
   const timeout = setTimeout(() => {
     if (signal.aborted) {
@@ -170,7 +173,16 @@ function createModelRequestAttempt(
   }, timeoutMs);
 
   return {
-    request: { ...request, signal },
+    request: {
+      ...request,
+      signal,
+      _internal: {
+        ...request._internal,
+        markReplayUnsafe: () => {
+          replayUnsafe = true;
+        },
+      },
+    },
     waitFor: async <T>(operation: () => PromiseLike<T>) => {
       let abortListener: (() => void) | undefined;
       const abortPromise = new Promise<never>((_, reject) => {
@@ -203,6 +215,7 @@ function createModelRequestAttempt(
       }
     },
     normalizeError: (error) => (timedOut ? timeoutError : error),
+    isReplayUnsafeAfterTimeout: () => timedOut && replayUnsafe,
     cleanup: () => {
       clearTimeout(timeout);
       combined.cleanup();
@@ -605,6 +618,20 @@ async function getRetryAdvice(
   return await getModelRetryAdvice.call(model, args);
 }
 
+function applyAttemptReplaySafety(
+  providerAdvice: ModelRetryAdvice | undefined,
+  replayUnsafeAfterTimeout: boolean,
+): ModelRetryAdvice | undefined {
+  if (!replayUnsafeAfterTimeout || providerAdvice?.replaySafety === 'safe') {
+    return providerAdvice;
+  }
+
+  return {
+    ...providerAdvice,
+    replaySafety: 'unsafe',
+  };
+}
+
 function isStatefulConversationRequest(request: ModelRequest): boolean {
   return Boolean(request.conversationId || request.previousResponseId);
 }
@@ -827,12 +854,15 @@ export async function getResponseWithRetry(
       modelRequestAttempt.cleanup();
     }
 
-    const providerAdvice = await getRetryAdvice(model, {
-      request,
-      error: failure,
-      stream: false,
-      attempt,
-    });
+    const providerAdvice = applyAttemptReplaySafety(
+      await getRetryAdvice(model, {
+        request,
+        error: failure,
+        stream: false,
+        attempt,
+      }),
+      modelRequestAttempt.isReplayUnsafeAfterTimeout(),
+    );
     const decision = await evaluateRetry({
       error: failure,
       attempt,
@@ -927,12 +957,15 @@ export async function* getStreamedResponseWithRetry(
       }
     }
 
-    const providerAdvice = await getRetryAdvice(model, {
-      request,
-      error: failure,
-      stream: true,
-      attempt,
-    });
+    const providerAdvice = applyAttemptReplaySafety(
+      await getRetryAdvice(model, {
+        request,
+        error: failure,
+        stream: true,
+        attempt,
+      }),
+      modelRequestAttempt.isReplayUnsafeAfterTimeout(),
+    );
     const decision = await evaluateRetry({
       error: failure,
       attempt,

--- a/packages/agents-core/src/runner/modelRetry.ts
+++ b/packages/agents-core/src/runner/modelRetry.ts
@@ -952,7 +952,11 @@ export async function* getStreamedResponseWithRetry(
       failure = modelRequestAttempt.normalizeError(error);
     } finally {
       modelRequestAttempt.cleanup();
-      if (!failed && !iteratorCompleted && iterator?.return) {
+      if (
+        (!failed || failure instanceof ModelRequestTimeoutError) &&
+        !iteratorCompleted &&
+        iterator?.return
+      ) {
         await iterator.return();
       }
     }

--- a/packages/agents-core/test/errors.test.ts
+++ b/packages/agents-core/test/errors.test.ts
@@ -3,6 +3,7 @@ import {
   InputGuardrailTripwireTriggered,
   MaxTurnsExceededError,
   ModelBehaviorError,
+  ModelRequestTimeoutError,
   ModelRefusalError,
   OutputGuardrailTripwireTriggered,
   UserError,
@@ -120,6 +121,14 @@ describe('errors', () => {
     expect(error.timeoutMs).toBe(1200);
     expect(error.message).toBe("Tool 'fetch' timed out after 1200ms.");
     expect(error.state).toEqual({ id: 'state' });
+  });
+
+  test('adds context to model request timeout errors', () => {
+    const error = new ModelRequestTimeoutError({ timeoutMs: 30_000 });
+
+    expect(error.timeoutMs).toBe(30_000);
+    expect(error.message).toBe('Model request timed out after 30000ms.');
+    expect(error.name).toBe('ModelRequestTimeoutError');
   });
 
   test('stores guardrail tripwire results', () => {

--- a/packages/agents-core/test/retryPolicy.test.ts
+++ b/packages/agents-core/test/retryPolicy.test.ts
@@ -1243,80 +1243,89 @@ describe('retry policies', () => {
     }
   });
 
-  it('closes a timed-out streaming iterator before retrying', async () => {
-    vi.useFakeTimers();
-    let attempts = 0;
-    let firstIteratorClosed = false;
-    let retryStartedAfterClose = false;
-    const firstIterator = {
-      next: vi.fn(
-        async () =>
-          await new Promise<IteratorResult<StreamEvent>>(() => {
-            // Intentionally ignores the aborted request signal. The runner
-            // must close this iterator explicitly before starting a retry.
-          }),
-      ),
-      return: vi.fn(async () => {
-        firstIteratorClosed = true;
-        return { done: true as const, value: undefined };
-      }),
-    };
-
-    try {
-      const model: Model = {
-        async getResponse() {
-          throw new Error('not used');
-        },
-        getStreamedResponse(): AsyncIterable<StreamEvent> {
-          attempts += 1;
-          if (attempts === 1) {
-            return {
-              [Symbol.asyncIterator]: () => firstIterator,
-            };
+  it.each(['throws synchronously', 'rejects', 'never settles'] as const)(
+    'preserves a streaming timeout when iterator cleanup %s',
+    async (cleanupBehavior) => {
+      vi.useFakeTimers();
+      let attempts = 0;
+      let firstIteratorCleanupStarted = false;
+      let retryStartedAfterCleanup = false;
+      const firstIterator = {
+        next: vi.fn(
+          async () =>
+            await new Promise<IteratorResult<StreamEvent>>(() => {
+              // Intentionally ignores the aborted request signal. The runner
+              // must close this iterator explicitly before starting a retry.
+            }),
+        ),
+        return: vi.fn(() => {
+          firstIteratorCleanupStarted = true;
+          if (cleanupBehavior === 'throws synchronously') {
+            throw new Error('iterator cleanup threw');
           }
-
-          retryStartedAfterClose = firstIteratorClosed;
-          return {
-            async *[Symbol.asyncIterator]() {
-              yield { type: 'response_started' } as const;
-              yield createDoneEvent('Streaming timeout recovered');
-            },
-          };
-        },
+          if (cleanupBehavior === 'rejects') {
+            return Promise.reject(new Error('iterator cleanup rejected'));
+          }
+          return new Promise<IteratorResult<StreamEvent>>(() => {});
+        }),
       };
 
-      const result = await run(
-        new Agent({
-          name: 'StreamingTimeoutIteratorCleanupAgent',
-          model,
-          modelSettings: {
-            requestTimeoutMs: 25,
-            retry: {
-              maxRetries: 1,
-              backoff: { initialDelayMs: 0, jitter: false },
-              policy: retryPolicies.timeout(),
-            },
+      try {
+        const model: Model = {
+          async getResponse() {
+            throw new Error('not used');
           },
-        }),
-        'hello',
-        { stream: true },
-      );
-      const consumePromise = (async () => {
-        for await (const _event of result) {
-          // Consume the stream to completion.
-        }
-      })();
+          getStreamedResponse(): AsyncIterable<StreamEvent> {
+            attempts += 1;
+            if (attempts === 1) {
+              return {
+                [Symbol.asyncIterator]: () => firstIterator,
+              };
+            }
 
-      await vi.advanceTimersByTimeAsync(25);
-      await consumePromise;
+            retryStartedAfterCleanup = firstIteratorCleanupStarted;
+            return {
+              async *[Symbol.asyncIterator]() {
+                yield { type: 'response_started' } as const;
+                yield createDoneEvent('Streaming timeout recovered');
+              },
+            };
+          },
+        };
 
-      expect(firstIterator.return).toHaveBeenCalledOnce();
-      expect(retryStartedAfterClose).toBe(true);
-      expect(result.finalOutput).toBe('Streaming timeout recovered');
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+        const result = await run(
+          new Agent({
+            name: 'StreamingTimeoutIteratorCleanupAgent',
+            model,
+            modelSettings: {
+              requestTimeoutMs: 25,
+              retry: {
+                maxRetries: 1,
+                backoff: { initialDelayMs: 0, jitter: false },
+                policy: retryPolicies.timeout(),
+              },
+            },
+          }),
+          'hello',
+          { stream: true },
+        );
+        const consumePromise = (async () => {
+          for await (const _event of result) {
+            // Consume the stream to completion.
+          }
+        })();
+
+        await vi.advanceTimersByTimeAsync(25);
+        await consumePromise;
+
+        expect(firstIterator.return).toHaveBeenCalledOnce();
+        expect(retryStartedAfterCleanup).toBe(true);
+        expect(result.finalOutput).toBe('Streaming timeout recovered');
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it('does not retry a streaming timeout after an event is emitted', async () => {
     vi.useFakeTimers();

--- a/packages/agents-core/test/retryPolicy.test.ts
+++ b/packages/agents-core/test/retryPolicy.test.ts
@@ -1,12 +1,14 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import {
   Agent,
+  ModelRequestTimeoutError,
   retryPolicies,
   run,
   Runner,
   RunStreamEvent,
   setDefaultModelProvider,
   setTracingDisabled,
+  UserError,
 } from '../src';
 import { mergeAgentToolRunConfig } from '../src/agentToolRunConfig';
 import type { Model, ModelRequest } from '../src/model';
@@ -943,6 +945,362 @@ describe('retry policies', () => {
     }
   });
 
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, 2_147_483_648])(
+    'rejects invalid model request timeout %s before calling the model',
+    async (requestTimeoutMs) => {
+      let attempts = 0;
+      const model: Model = {
+        async getResponse() {
+          attempts += 1;
+          return {
+            usage: new Usage(),
+            output: [fakeModelMessage('unexpected')],
+          };
+        },
+        async *getStreamedResponse() {
+          yield* [];
+        },
+      };
+
+      await expect(
+        run(
+          new Agent({
+            name: 'InvalidRequestTimeoutAgent',
+            model,
+            modelSettings: { requestTimeoutMs },
+          }),
+          'hello',
+        ),
+      ).rejects.toBeInstanceOf(UserError);
+      expect(attempts).toBe(0);
+    },
+  );
+
+  it('times out one non-streaming model request without retrying by default', async () => {
+    vi.useFakeTimers();
+    let attempts = 0;
+    let attemptSignal: AbortSignal | undefined;
+
+    try {
+      const model: Model = {
+        async getResponse(request) {
+          attempts += 1;
+          attemptSignal = request.signal;
+          return await new Promise<never>(() => {});
+        },
+        async *getStreamedResponse() {
+          yield* [];
+        },
+      };
+
+      const resultPromise = run(
+        new Agent({
+          name: 'TimedModelRequestAgent',
+          model,
+          modelSettings: { requestTimeoutMs: 25 },
+        }),
+        'hello',
+      );
+      const errorPromise = resultPromise.then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+
+      await vi.advanceTimersByTimeAsync(25);
+      const error = await errorPromise;
+
+      expect(error).toBeInstanceOf(ModelRequestTimeoutError);
+      expect(error).toMatchObject({ timeoutMs: 25 });
+      expect(attempts).toBe(1);
+      expect(attemptSignal?.aborted).toBe(true);
+      expect(attemptSignal?.reason).toBe(error);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('retries a timed-out model request with a fresh per-attempt deadline', async () => {
+    vi.useFakeTimers();
+    let attempts = 0;
+    const attemptSignals: AbortSignal[] = [];
+    const retryContexts: Array<{
+      isAbort: boolean;
+      isNetworkError: boolean;
+      isTimeout?: boolean;
+    }> = [];
+    const timeoutPolicy = retryPolicies.timeout();
+
+    try {
+      const model: Model = {
+        async getResponse(request) {
+          attempts += 1;
+          attemptSignals.push(request.signal!);
+          if (attempts === 1) {
+            return await new Promise<never>(() => {});
+          }
+          return {
+            usage: new Usage({ requests: 1 }),
+            output: [fakeModelMessage('Recovered after timeout')],
+          };
+        },
+        async *getStreamedResponse() {
+          yield* [];
+        },
+      };
+
+      const resultPromise = run(
+        new Agent({
+          name: 'RetryTimedModelRequestAgent',
+          model,
+          modelSettings: {
+            requestTimeoutMs: 25,
+            retry: {
+              maxRetries: 1,
+              backoff: { initialDelayMs: 0, jitter: false },
+              policy: async (context) => {
+                retryContexts.push(context.normalized);
+                return await timeoutPolicy(context);
+              },
+            },
+          },
+        }),
+        'hello',
+      );
+
+      await vi.advanceTimersByTimeAsync(25);
+      const result = await resultPromise;
+
+      expect(result.finalOutput).toBe('Recovered after timeout');
+      expect(attempts).toBe(2);
+      expect(result.state.usage.requests).toBe(2);
+      expect(attemptSignals[0]?.aborted).toBe(true);
+      expect(attemptSignals[0]?.reason).toBeInstanceOf(
+        ModelRequestTimeoutError,
+      );
+      expect(attemptSignals[1]?.aborted).toBe(false);
+      expect(retryContexts).toEqual([
+        {
+          isAbort: false,
+          isNetworkError: true,
+          isTimeout: true,
+        },
+      ]);
+
+      await vi.advanceTimersByTimeAsync(25);
+      expect(attemptSignals[1]?.aborted).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('preserves a caller abort instead of converting it to a model timeout', async () => {
+    vi.useFakeTimers();
+    let attempts = 0;
+    const controller = new AbortController();
+
+    try {
+      const model: Model = {
+        async getResponse() {
+          attempts += 1;
+          return await new Promise<never>(() => {});
+        },
+        async *getStreamedResponse() {
+          yield* [];
+        },
+      };
+
+      const resultPromise = run(
+        new Agent({
+          name: 'CallerAbortBeforeTimeoutAgent',
+          model,
+          modelSettings: {
+            requestTimeoutMs: 100,
+            retry: {
+              maxRetries: 1,
+              policy: retryPolicies.timeout(),
+            },
+          },
+        }),
+        'hello',
+        { signal: controller.signal },
+      );
+      const errorPromise = resultPromise.then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+
+      await vi.advanceTimersByTimeAsync(10);
+      controller.abort();
+      const error = await errorPromise;
+
+      expect(error).toMatchObject({ name: 'AbortError' });
+      expect(error).not.toBeInstanceOf(ModelRequestTimeoutError);
+      expect(attempts).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(attempts).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('matches provider transport timeouts with the timeout policy', async () => {
+    let attempts = 0;
+    const model: Model = {
+      async getResponse() {
+        attempts += 1;
+        if (attempts === 1) {
+          const error = new Error('Request timed out');
+          error.name = 'APIConnectionTimeoutError';
+          throw error;
+        }
+        return {
+          usage: new Usage({ requests: 1 }),
+          output: [fakeModelMessage('Recovered from provider timeout')],
+        };
+      },
+      async *getStreamedResponse() {
+        yield* [];
+      },
+    };
+
+    const result = await run(
+      new Agent({
+        name: 'ProviderTimeoutAgent',
+        model,
+        modelSettings: {
+          retry: {
+            maxRetries: 1,
+            backoff: { initialDelayMs: 0, jitter: false },
+            policy: retryPolicies.timeout(),
+          },
+        },
+      }),
+      'hello',
+    );
+
+    expect(result.finalOutput).toBe('Recovered from provider timeout');
+    expect(attempts).toBe(2);
+  });
+
+  it('retries a streaming timeout before any event is emitted', async () => {
+    vi.useFakeTimers();
+    let attempts = 0;
+    const attemptSignals: AbortSignal[] = [];
+
+    try {
+      const model: Model = {
+        async getResponse() {
+          throw new Error('not used');
+        },
+        async *getStreamedResponse(request): AsyncIterable<StreamEvent> {
+          attempts += 1;
+          attemptSignals.push(request.signal!);
+          if (attempts === 1) {
+            await new Promise<never>((_, reject) => {
+              const signal = request.signal!;
+              signal.addEventListener('abort', () => reject(signal.reason), {
+                once: true,
+              });
+            });
+          }
+          yield { type: 'response_started' };
+          yield createDoneEvent('Streaming timeout recovered');
+        },
+      };
+
+      const result = await run(
+        new Agent({
+          name: 'StreamingTimeoutRetryAgent',
+          model,
+          modelSettings: {
+            requestTimeoutMs: 25,
+            retry: {
+              maxRetries: 1,
+              backoff: { initialDelayMs: 0, jitter: false },
+              policy: retryPolicies.timeout(),
+            },
+          },
+        }),
+        'hello',
+        { stream: true },
+      );
+      const consumePromise = (async () => {
+        for await (const _event of result) {
+          // Consume the stream to completion.
+        }
+      })();
+
+      await vi.advanceTimersByTimeAsync(25);
+      await consumePromise;
+
+      expect(result.finalOutput).toBe('Streaming timeout recovered');
+      expect(attempts).toBe(2);
+      expect(attemptSignals[0]?.aborted).toBe(true);
+      expect(attemptSignals[1]?.aborted).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not retry a streaming timeout after an event is emitted', async () => {
+    vi.useFakeTimers();
+    let attempts = 0;
+    const seenEvents: RunStreamEvent[] = [];
+
+    try {
+      const model: Model = {
+        async getResponse() {
+          throw new Error('not used');
+        },
+        async *getStreamedResponse(request): AsyncIterable<StreamEvent> {
+          attempts += 1;
+          yield { type: 'response_started' };
+          await new Promise<never>((_, reject) => {
+            const signal = request.signal!;
+            signal.addEventListener('abort', () => reject(signal.reason), {
+              once: true,
+            });
+          });
+        },
+      };
+
+      const result = await run(
+        new Agent({
+          name: 'StreamingVisibleTimeoutAgent',
+          model,
+          modelSettings: {
+            requestTimeoutMs: 25,
+            retry: {
+              maxRetries: 1,
+              policy: retryPolicies.timeout(),
+            },
+          },
+        }),
+        'hello',
+        { stream: true },
+      );
+      const consumePromise = (async () => {
+        for await (const event of result) {
+          seenEvents.push(event);
+        }
+      })();
+      const errorPromise = consumePromise.then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+
+      await vi.advanceTimersByTimeAsync(25);
+      const error = await errorPromise;
+
+      expect(error).toBeInstanceOf(ModelRequestTimeoutError);
+      expect(attempts).toBe(1);
+      expect(seenEvents).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('treats websocket transport error codes as network errors', async () => {
     let attempts = 0;
     const model: Model = {
@@ -1418,8 +1776,7 @@ describe('retry policies', () => {
   it('deep merges retry settings between runner and agent configs', async () => {
     const policy = () => true;
     let capturedRetrySettings:
-      | ModelRequest['modelSettings']['retry']
-      | undefined;
+      ModelRequest['modelSettings']['retry'] | undefined;
 
     const model: Model = {
       async getResponse(request: ModelRequest) {
@@ -1474,8 +1831,7 @@ describe('retry policies', () => {
   it('inherits runner retry policy when an agent overrides only backoff', async () => {
     const policy = () => true;
     let capturedRetrySettings:
-      | ModelRequest['modelSettings']['retry']
-      | undefined;
+      ModelRequest['modelSettings']['retry'] | undefined;
 
     const model: Model = {
       async getResponse(request: ModelRequest) {

--- a/packages/agents-core/test/retryPolicy.test.ts
+++ b/packages/agents-core/test/retryPolicy.test.ts
@@ -1243,6 +1243,81 @@ describe('retry policies', () => {
     }
   });
 
+  it('closes a timed-out streaming iterator before retrying', async () => {
+    vi.useFakeTimers();
+    let attempts = 0;
+    let firstIteratorClosed = false;
+    let retryStartedAfterClose = false;
+    const firstIterator = {
+      next: vi.fn(
+        async () =>
+          await new Promise<IteratorResult<StreamEvent>>(() => {
+            // Intentionally ignores the aborted request signal. The runner
+            // must close this iterator explicitly before starting a retry.
+          }),
+      ),
+      return: vi.fn(async () => {
+        firstIteratorClosed = true;
+        return { done: true as const, value: undefined };
+      }),
+    };
+
+    try {
+      const model: Model = {
+        async getResponse() {
+          throw new Error('not used');
+        },
+        getStreamedResponse(): AsyncIterable<StreamEvent> {
+          attempts += 1;
+          if (attempts === 1) {
+            return {
+              [Symbol.asyncIterator]: () => firstIterator,
+            };
+          }
+
+          retryStartedAfterClose = firstIteratorClosed;
+          return {
+            async *[Symbol.asyncIterator]() {
+              yield { type: 'response_started' } as const;
+              yield createDoneEvent('Streaming timeout recovered');
+            },
+          };
+        },
+      };
+
+      const result = await run(
+        new Agent({
+          name: 'StreamingTimeoutIteratorCleanupAgent',
+          model,
+          modelSettings: {
+            requestTimeoutMs: 25,
+            retry: {
+              maxRetries: 1,
+              backoff: { initialDelayMs: 0, jitter: false },
+              policy: retryPolicies.timeout(),
+            },
+          },
+        }),
+        'hello',
+        { stream: true },
+      );
+      const consumePromise = (async () => {
+        for await (const _event of result) {
+          // Consume the stream to completion.
+        }
+      })();
+
+      await vi.advanceTimersByTimeAsync(25);
+      await consumePromise;
+
+      expect(firstIterator.return).toHaveBeenCalledOnce();
+      expect(retryStartedAfterClose).toBe(true);
+      expect(result.finalOutput).toBe('Streaming timeout recovered');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not retry a streaming timeout after an event is emitted', async () => {
     vi.useFakeTimers();
     let attempts = 0;

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
@@ -21,6 +21,7 @@ import {
   mergeQueryParamsIntoURL,
 } from '../../responsesTransportUtils';
 import {
+  ResponsesWebSocketTimeoutError,
   withAbortSignal,
   withTimeout,
 } from '../../responsesWebSocketConnection';
@@ -1078,7 +1079,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
       requestTimeoutDeadline.deadlineAtMs - Date.now(),
     );
     if (remainingTimeoutMs <= 0) {
-      throw new Error(errorMessage);
+      throw new ResponsesWebSocketTimeoutError(errorMessage);
     }
 
     return { timeoutMs: remainingTimeoutMs, errorMessage };

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
@@ -446,6 +446,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     let sentFrameWasReturnedUnsent = false;
     let reachedResponseBoundary = false;
     let threwError = false;
+    let markReplayUnsafe: (() => void) | undefined;
     const requestTimeoutDeadline =
       this.#createWebSocketRequestTimeoutDeadline();
     const sendWebSocketFrame = (
@@ -462,10 +463,12 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
         requestMayHaveReachedServer = true;
       }
       webSocket.send(frame as any);
+      markReplayUnsafe?.();
     };
 
     try {
       const builtRequest = this._buildResponsesCreateRequest(request, true);
+      markReplayUnsafe = builtRequest.markReplayUnsafe;
       const requestData = builtRequest.requestData;
       const webSocket = await this.#ensureWebSocket(
         {

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -3483,6 +3483,7 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
       requestTimeoutDeadline,
     );
 
+    let sentRequestFrame = false;
     let receivedAnyEvent = false;
     let sawTerminalResponseEvent = false;
     try {
@@ -3527,6 +3528,7 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
           );
           await activeConnection.send(serializedFrame);
         }
+        sentRequestFrame = true;
         builtRequest.markReplayUnsafe?.();
       };
       await sendSerializedFrame();
@@ -3583,6 +3585,13 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
         }
       }
     } catch (error) {
+      if (sentRequestFrame && error instanceof Error) {
+        (
+          error as Error & {
+            unsafeToReplay?: boolean;
+          }
+        ).unsafeToReplay = true;
+      }
       if (
         !receivedAnyEvent &&
         !(error instanceof OpenAI.APIUserAbortError) &&

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -98,6 +98,7 @@ type BuiltResponsesCreateRequest = {
   requestData: Record<string, any>;
   sdkRequestHeaders: ResponsesCreateRequestSDKHeaders;
   signal: AbortSignal | undefined;
+  markReplayUnsafe: (() => void) | undefined;
   transportExtraHeaders?: Record<string, unknown>;
   transportExtraQuery?: Record<string, unknown>;
 };
@@ -3154,6 +3155,11 @@ export class OpenAIResponsesModel implements Model {
       requestData,
       sdkRequestHeaders,
       signal: request.signal,
+      markReplayUnsafe: (
+        request as ModelRequest & {
+          _internal?: { markReplayUnsafe?: () => void };
+        }
+      )._internal?.markReplayUnsafe,
       transportExtraHeaders: transportOverrides.extraHeaders,
       transportExtraQuery: transportOverrides.extraQuery,
     };
@@ -3520,6 +3526,7 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
           );
           await activeConnection.send(serializedFrame);
         }
+        builtRequest.markReplayUnsafe?.();
       };
       await sendSerializedFrame();
 

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -34,6 +34,7 @@ import { HEADERS } from './defaults';
 import {
   ResponsesWebSocketConnection,
   ResponsesWebSocketInternalError,
+  ResponsesWebSocketTimeoutError,
   isWebSocketNotOpenError,
   shouldWrapNoEventWebSocketError,
   throwIfAborted,
@@ -3953,7 +3954,7 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
       requestTimeoutDeadline.deadlineAtMs - Date.now(),
     );
     if (remainingTimeoutMs <= 0) {
-      throw new Error(errorMessage);
+      throw new ResponsesWebSocketTimeoutError(errorMessage);
     }
 
     return { timeoutMs: remainingTimeoutMs, errorMessage };

--- a/packages/agents-openai/src/responsesWebSocketConnection.ts
+++ b/packages/agents-openai/src/responsesWebSocketConnection.ts
@@ -2,10 +2,7 @@ import { UserError } from '@openai/agents-core';
 import OpenAI from 'openai';
 
 export type WebSocketMessageValue =
-  | string
-  | Blob
-  | ArrayBuffer
-  | ArrayBufferView;
+  string | Blob | ArrayBuffer | ArrayBufferView;
 
 export type ResponsesWebSocketKeepAliveOptions = {
   /**
@@ -44,6 +41,15 @@ export class ResponsesWebSocketInternalError extends Error {
     super(message);
     this.name = 'ResponsesWebSocketInternalError';
     this.code = code;
+  }
+}
+
+export class ResponsesWebSocketTimeoutError extends Error {
+  readonly code = 'ETIMEDOUT';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'ResponsesWebSocketTimeoutError';
   }
 }
 
@@ -97,7 +103,7 @@ export async function withTimeout<T>(
 
   return await new Promise<T>((resolve, reject) => {
     const timeoutId = setTimeout(() => {
-      reject(new Error(errorMessage));
+      reject(new ResponsesWebSocketTimeoutError(errorMessage));
     }, timeoutMs);
 
     promise.then(
@@ -260,8 +266,7 @@ export class ResponsesWebSocketConnection {
     keepAliveOptions: ResponsesWebSocketKeepAliveOptions = {},
   ): Promise<ResponsesWebSocketConnection> {
     const WebSocketCtor = (globalThis as any).WebSocket as
-      | (new (url: string, init?: unknown) => WebSocket)
-      | undefined;
+      (new (url: string, init?: unknown) => WebSocket) | undefined;
 
     if (!WebSocketCtor) {
       throw new UserError(

--- a/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
+++ b/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
@@ -657,6 +657,50 @@ describe('OpenAIHostedMultiAgentModel', () => {
     },
   );
 
+  it('marks a hosted deadline exhausted between setup steps as a timeout', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const fakeWebSocket = new FakeResponsesWebSocket([]);
+      const client = new OpenAI({
+        apiKey: 'test-key',
+        timeout: 25,
+      }) as any;
+      client._callApiKey = vi.fn(
+        () =>
+          new Promise<boolean>((resolve) => {
+            // This timer is registered before the transport timeout timer, so
+            // setup advances exactly to the shared deadline before continuing.
+            setTimeout(() => resolve(false), 25);
+          }),
+      );
+      client.authHeaders = vi.fn().mockResolvedValue({
+        values: new Headers({ Authorization: 'Bearer test-key' }),
+        nulls: new Set<string>(),
+      });
+      const model = new TestHostedMultiAgentModel(
+        fakeWebSocket,
+        undefined,
+        client,
+      );
+      const errorPromise = getTestResponse(model, request(), false).then(
+        () => undefined,
+        (error: unknown) => error as Error & { code?: string },
+      );
+
+      await vi.advanceTimersByTimeAsync(25);
+      const error = await errorPromise;
+
+      expect(error).toMatchObject({ code: 'ETIMEDOUT' });
+      expect(error?.message).toBe(
+        'Hosted Multi-agent WebSocket auth header preparation timed out after 25ms.',
+      );
+      expect(fakeWebSocket.sent).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('preserves an explicit Authorization header unset', async () => {
     const fakeWebSocket = new FakeResponsesWebSocket([
       { type: 'response.created', response: emptyResponse() },

--- a/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
+++ b/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
@@ -1,6 +1,10 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import OpenAI from 'openai';
 import {
+  Agent,
+  ModelRequestTimeoutError,
+  retryPolicies,
+  run,
   setTracingDisabled,
   UserError,
   withTrace,
@@ -1723,6 +1727,77 @@ describe('OpenAIHostedMultiAgentModel', () => {
       }),
     ).toMatchObject({ suggested: false, replaySafety: 'unsafe' });
     expect(fakeWebSocket.close).toHaveBeenCalledOnce();
+  });
+
+  it('does not retry a runner timeout after sending a hosted WebSocket request', async () => {
+    vi.useFakeTimers();
+    let resolveFirstSend!: () => void;
+    const firstSend = new Promise<void>((resolve) => {
+      resolveFirstSend = resolve;
+    });
+    const firstWebSocket = new FakeResponsesWebSocket([
+      STALLED_WEBSOCKET_EVENT,
+    ]);
+    const firstSendImplementation = firstWebSocket.send.bind(firstWebSocket);
+    vi.spyOn(firstWebSocket, 'send').mockImplementation((frame) => {
+      firstSendImplementation(frame);
+      resolveFirstSend();
+    });
+    const retryWebSocket = new FakeResponsesWebSocket([
+      {
+        type: 'response.completed',
+        response: {
+          ...emptyResponse('resp_duplicate'),
+          output: [
+            {
+              id: 'msg_duplicate',
+              type: 'message',
+              status: 'completed',
+              role: 'assistant',
+              content: [
+                { type: 'output_text', text: 'duplicate request sent' },
+              ],
+            },
+          ],
+        },
+      },
+    ]);
+
+    try {
+      const model = new TestHostedMultiAgentModel([
+        firstWebSocket,
+        retryWebSocket,
+      ]);
+      const resultPromise = run(
+        new Agent({
+          name: 'HostedWebSocketTimeoutReplaySafetyAgent',
+          model,
+          modelSettings: {
+            requestTimeoutMs: 25,
+            retry: {
+              maxRetries: 1,
+              backoff: { initialDelayMs: 0, jitter: false },
+              policy: retryPolicies.timeout(),
+            },
+          },
+        }),
+        'ping',
+      );
+      const errorPromise = resultPromise.then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+
+      await firstSend;
+      await vi.advanceTimersByTimeAsync(25);
+      const error = await errorPromise;
+
+      expect(error).toBeInstanceOf(ModelRequestTimeoutError);
+      expect(firstWebSocket.sent).toHaveLength(1);
+      expect(retryWebSocket.sent).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it.each([false, true])(

--- a/packages/agents-openai/test/openaiResponsesWSModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesWSModel.test.ts
@@ -1114,6 +1114,77 @@ describe('OpenAIResponsesWSModel', () => {
     }
   });
 
+  it('does not retry a provider timeout after sending a websocket request', async () => {
+    vi.useFakeTimers();
+    let sends = 0;
+    let resolveFirstSend!: () => void;
+    const firstSend = new Promise<void>((resolve) => {
+      resolveFirstSend = resolve;
+    });
+
+    try {
+      const fakeClient = createFakeClient() as any;
+      fakeClient.timeout = 25;
+      fakeClient._options = { ...(fakeClient._options ?? {}), timeout: 25 };
+      TestWebSocket.onCreate = (socket) => {
+        socket.onSend(() => {
+          sends += 1;
+          if (sends === 1) {
+            resolveFirstSend();
+            return;
+          }
+          socket.queueJSON({
+            type: 'response.completed',
+            response: {
+              id: 'resp_provider_timeout_duplicate',
+              output: [
+                {
+                  id: 'msg_provider_timeout_duplicate',
+                  type: 'message',
+                  status: 'completed',
+                  role: 'assistant',
+                  content: [
+                    { type: 'output_text', text: 'duplicate request sent' },
+                  ],
+                },
+              ],
+              usage: {},
+            },
+            sequence_number: 0,
+          });
+        });
+      };
+
+      const resultPromise = run(
+        new Agent({
+          name: 'WebSocketProviderTimeoutReplaySafetyAgent',
+          model: new OpenAIResponsesWSModel(fakeClient, 'gpt-ws'),
+          modelSettings: {
+            retry: {
+              maxRetries: 1,
+              backoff: { initialDelayMs: 0, jitter: false },
+              policy: retryPolicies.timeout(),
+            },
+          },
+        }),
+        'ping',
+      );
+      const errorPromise = resultPromise.then(
+        () => undefined,
+        (error: unknown) => error as Error & { code?: string },
+      );
+
+      await firstSend;
+      await vi.advanceTimersByTimeAsync(25);
+      const error = await errorPromise;
+
+      expect(error).toMatchObject({ code: 'ETIMEDOUT' });
+      expect(sends).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('retries a runner timeout before sending a websocket request', async () => {
     vi.useFakeTimers();
     let authAttempts = 0;

--- a/packages/agents-openai/test/openaiResponsesWSModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesWSModel.test.ts
@@ -1190,6 +1190,87 @@ describe('OpenAIResponsesWSModel', () => {
     }
   });
 
+  it('retries a provider websocket transport timeout before sending', async () => {
+    vi.useFakeTimers();
+    let authAttempts = 0;
+    let resolveFirstAuthAttempt!: () => void;
+    const firstAuthAttempt = new Promise<void>((resolve) => {
+      resolveFirstAuthAttempt = resolve;
+    });
+
+    try {
+      const fakeClient = createFakeClient() as any;
+      fakeClient.timeout = 25;
+      fakeClient._options = { ...(fakeClient._options ?? {}), timeout: 25 };
+      fakeClient.authHeaders = vi.fn(async () => {
+        authAttempts += 1;
+        if (authAttempts === 1) {
+          resolveFirstAuthAttempt();
+          return await new Promise<never>(() => {
+            // The provider transport timeout should reject this handshake.
+          });
+        }
+        return {
+          values: new Headers({ Authorization: 'Bearer sk-test' }),
+          nulls: new Set<string>(),
+        };
+      });
+
+      TestWebSocket.onCreate = (socket) => {
+        socket.onSend(() => {
+          socket.queueJSON({
+            type: 'response.completed',
+            response: {
+              id: 'resp_transport_retry',
+              output: [
+                {
+                  id: 'msg_transport_retry',
+                  type: 'message',
+                  status: 'completed',
+                  role: 'assistant',
+                  content: [
+                    { type: 'output_text', text: 'transport retry succeeded' },
+                  ],
+                },
+              ],
+              usage: {},
+            },
+            sequence_number: 0,
+          });
+        });
+      };
+
+      const resultPromise = run(
+        new Agent({
+          name: 'WebSocketProviderTimeoutAgent',
+          model: new OpenAIResponsesWSModel(fakeClient, 'gpt-ws'),
+          modelSettings: {
+            retry: {
+              maxRetries: 1,
+              backoff: { initialDelayMs: 0, jitter: false },
+              policy: retryPolicies.timeout(),
+            },
+          },
+        }),
+        'ping',
+      ).then(
+        (result) => ({ result, error: undefined }),
+        (error: unknown) => ({ result: undefined, error }),
+      );
+
+      await firstAuthAttempt;
+      await vi.advanceTimersByTimeAsync(25);
+      const { result, error } = await resultPromise;
+
+      expect(error).toBeUndefined();
+      expect(result?.finalOutput).toBe('transport retry succeeded');
+      expect(authAttempts).toBe(2);
+      expect(TestWebSocket.instances).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('preserves local websocket setup errors before first event', async () => {
     const fakeClient = createFakeClient();
     const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws', {

--- a/packages/agents-openai/test/openaiResponsesWSModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesWSModel.test.ts
@@ -1271,6 +1271,80 @@ describe('OpenAIResponsesWSModel', () => {
     }
   });
 
+  it('retries when the websocket deadline expires between setup steps', async () => {
+    vi.useFakeTimers();
+    let apiKeyAttempts = 0;
+
+    try {
+      const fakeClient = createFakeClient() as any;
+      fakeClient.timeout = 25;
+      fakeClient._options = { ...(fakeClient._options ?? {}), timeout: 25 };
+      fakeClient._callApiKey = vi.fn(() => {
+        apiKeyAttempts += 1;
+        if (apiKeyAttempts === 1) {
+          return new Promise<boolean>((resolve) => {
+            // This timer is registered before the transport timeout timer, so
+            // setup advances exactly to the shared deadline before continuing.
+            setTimeout(() => resolve(false), 25);
+          });
+        }
+        return Promise.resolve(false);
+      });
+
+      TestWebSocket.onCreate = (socket) => {
+        socket.onSend(() => {
+          socket.queueJSON({
+            type: 'response.completed',
+            response: {
+              id: 'resp_expired_deadline_retry',
+              output: [
+                {
+                  id: 'msg_expired_deadline_retry',
+                  type: 'message',
+                  status: 'completed',
+                  role: 'assistant',
+                  content: [
+                    { type: 'output_text', text: 'deadline retry succeeded' },
+                  ],
+                },
+              ],
+              usage: {},
+            },
+            sequence_number: 0,
+          });
+        });
+      };
+
+      const resultPromise = run(
+        new Agent({
+          name: 'WebSocketExpiredProviderDeadlineAgent',
+          model: new OpenAIResponsesWSModel(fakeClient, 'gpt-ws'),
+          modelSettings: {
+            retry: {
+              maxRetries: 1,
+              backoff: { initialDelayMs: 0, jitter: false },
+              policy: retryPolicies.timeout(),
+            },
+          },
+        }),
+        'ping',
+      ).then(
+        (result) => ({ result, error: undefined }),
+        (error: unknown) => ({ result: undefined, error }),
+      );
+
+      await vi.advanceTimersByTimeAsync(25);
+      const { result, error } = await resultPromise;
+
+      expect(error).toBeUndefined();
+      expect(result?.finalOutput).toBe('deadline retry succeeded');
+      expect(apiKeyAttempts).toBe(2);
+      expect(TestWebSocket.instances).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('preserves local websocket setup errors before first event', async () => {
     const fakeClient = createFakeClient();
     const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws', {
@@ -2210,6 +2284,7 @@ describe('OpenAIResponsesWSModel', () => {
   });
 
   it('times out silent websocket frame reads and unblocks queued requests', async () => {
+    vi.useFakeTimers();
     const fakeClient = createFakeClient() as any;
     fakeClient.timeout = 25;
     fakeClient._options = { ...(fakeClient._options ?? {}), timeout: 25 };
@@ -2277,6 +2352,7 @@ describe('OpenAIResponsesWSModel', () => {
         } as any,
         false,
       );
+      void firstResponsePromise.catch(() => undefined);
       await firstFrameWaitStarted;
 
       // Keep the first request on a short frame-read timeout while allowing the
@@ -2293,6 +2369,7 @@ describe('OpenAIResponsesWSModel', () => {
       );
       void secondResponsePromise.catch(() => undefined);
 
+      await vi.advanceTimersByTimeAsync(25);
       await expect(firstResponsePromise).rejects.toThrow(
         'Responses websocket frame read timed out after 25ms.',
       );
@@ -2304,10 +2381,12 @@ describe('OpenAIResponsesWSModel', () => {
       expect(TestWebSocket.instances[1]?.sent).toHaveLength(1);
     } finally {
       nextFrameSpy.mockRestore();
+      vi.useRealTimers();
     }
   });
 
   it('bounds websocket requests by the total client timeout even while frames keep arriving', async () => {
+    vi.useFakeTimers();
     const fakeClient = createFakeClient() as any;
     fakeClient.timeout = 25;
     fakeClient._options = { ...(fakeClient._options ?? {}), timeout: 25 };
@@ -2360,21 +2439,16 @@ describe('OpenAIResponsesWSModel', () => {
       signal: undefined,
     };
 
-    const responsePromise = (model as any)._fetchResponse(
-      request as any,
-      false,
-    );
-    const outcome = await Promise.race([
-      responsePromise.then(
-        (response: any) => ({ kind: 'resolved' as const, response }),
-        (error: unknown) => ({ kind: 'rejected' as const, error }),
-      ),
-      new Promise<{ kind: 'timeout' }>((resolve) => {
-        setTimeout(() => resolve({ kind: 'timeout' }), 150);
-      }),
-    ]);
-
     try {
+      const outcomePromise = (model as any)
+        ._fetchResponse(request as any, false)
+        .then(
+          (response: any) => ({ kind: 'resolved' as const, response }),
+          (error: unknown) => ({ kind: 'rejected' as const, error }),
+        );
+      await vi.advanceTimersByTimeAsync(25);
+      const outcome = await outcomePromise;
+
       expect(outcome.kind).toBe('rejected');
       if (outcome.kind === 'rejected') {
         expect(outcome.error).toBeInstanceOf(Error);
@@ -2387,6 +2461,7 @@ describe('OpenAIResponsesWSModel', () => {
         clearInterval(deltaInterval);
       }
       await model.close();
+      vi.useRealTimers();
     }
   });
 

--- a/packages/agents-openai/test/openaiResponsesWSModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesWSModel.test.ts
@@ -10,6 +10,10 @@ import {
 import type OpenAI from 'openai';
 import type { ResponseStreamEvent as OpenAIResponseStreamEvent } from 'openai/resources/responses/responses';
 import {
+  Agent,
+  ModelRequestTimeoutError,
+  retryPolicies,
+  run,
   setTracingDisabled,
   type ResponseStreamEvent,
 } from '@openai/agents-core';
@@ -1037,6 +1041,153 @@ describe('OpenAIResponsesWSModel', () => {
       'Responses websocket connection closed before a terminal response event.',
     );
     expect(error.unsafeToReplay).toBe(true);
+  });
+
+  it('does not retry a runner timeout after sending a websocket request', async () => {
+    vi.useFakeTimers();
+    let sends = 0;
+    let resolveFirstSend!: () => void;
+    const firstSend = new Promise<void>((resolve) => {
+      resolveFirstSend = resolve;
+    });
+
+    try {
+      TestWebSocket.onCreate = (socket) => {
+        socket.onSend(() => {
+          sends += 1;
+          if (sends === 1) {
+            resolveFirstSend();
+          }
+          if (sends === 2) {
+            socket.queueJSON({
+              type: 'response.completed',
+              response: {
+                id: 'resp_duplicate',
+                output: [
+                  {
+                    id: 'msg_duplicate',
+                    type: 'message',
+                    status: 'completed',
+                    role: 'assistant',
+                    content: [
+                      { type: 'output_text', text: 'duplicate request sent' },
+                    ],
+                  },
+                ],
+                usage: {},
+              },
+              sequence_number: 0,
+            });
+          }
+        });
+      };
+
+      const model = new OpenAIResponsesWSModel(createFakeClient(), 'gpt-ws');
+      const resultPromise = run(
+        new Agent({
+          name: 'WebSocketTimeoutReplaySafetyAgent',
+          model,
+          modelSettings: {
+            requestTimeoutMs: 25,
+            retry: {
+              maxRetries: 1,
+              backoff: { initialDelayMs: 0, jitter: false },
+              policy: retryPolicies.timeout(),
+            },
+          },
+        }),
+        'ping',
+      );
+      const errorPromise = resultPromise.then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+
+      await firstSend;
+      await vi.advanceTimersByTimeAsync(25);
+      const error = await errorPromise;
+
+      expect(error).toBeInstanceOf(ModelRequestTimeoutError);
+      expect(sends).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('retries a runner timeout before sending a websocket request', async () => {
+    vi.useFakeTimers();
+    let authAttempts = 0;
+    let sends = 0;
+    let resolveFirstAuthAttempt!: () => void;
+    const firstAuthAttempt = new Promise<void>((resolve) => {
+      resolveFirstAuthAttempt = resolve;
+    });
+
+    try {
+      const fakeClient = createFakeClient() as any;
+      fakeClient.authHeaders = vi.fn(async () => {
+        authAttempts += 1;
+        if (authAttempts === 1) {
+          resolveFirstAuthAttempt();
+          return await new Promise<never>(() => {
+            // The runner timeout should abort this pre-send operation.
+          });
+        }
+        return {
+          values: new Headers({ Authorization: 'Bearer sk-test' }),
+          nulls: new Set<string>(),
+        };
+      });
+
+      TestWebSocket.onCreate = (socket) => {
+        socket.onSend(() => {
+          sends += 1;
+          socket.queueJSON({
+            type: 'response.completed',
+            response: {
+              id: 'resp_retried',
+              output: [
+                {
+                  id: 'msg_retried',
+                  type: 'message',
+                  status: 'completed',
+                  role: 'assistant',
+                  content: [{ type: 'output_text', text: 'retried safely' }],
+                },
+              ],
+              usage: {},
+            },
+            sequence_number: 0,
+          });
+        });
+      };
+
+      const resultPromise = run(
+        new Agent({
+          name: 'WebSocketPreSendTimeoutAgent',
+          model: new OpenAIResponsesWSModel(fakeClient, 'gpt-ws'),
+          modelSettings: {
+            requestTimeoutMs: 25,
+            retry: {
+              maxRetries: 1,
+              backoff: { initialDelayMs: 0, jitter: false },
+              policy: retryPolicies.timeout(),
+            },
+          },
+        }),
+        'ping',
+      );
+
+      await firstAuthAttempt;
+      await vi.advanceTimersByTimeAsync(25);
+      const result = await resultPromise;
+
+      expect(result.finalOutput).toBe('retried safely');
+      expect(authAttempts).toBe(2);
+      expect(sends).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('preserves local websocket setup errors before first event', async () => {


### PR DESCRIPTION
This pull request resolves #894.

It adds a provider-agnostic per-attempt deadline so one slow model request can time out and participate in runner-managed retry without cancelling the entire agent run.

## Changes

- Adds `ModelSettings.requestTimeoutMs` and `ModelRequestTimeoutError` for non-streaming and complete streaming attempts.
- Adds `retryPolicies.timeout()` and normalized `isTimeout` facts for SDK and provider transport timeouts.
- Preserves caller-abort precedence and current replay safety: emitted stream events and stateful requests without provider replay approval are not retried.
- Starts best-effort cleanup of timed-out streaming iterators before retry evaluation, while preserving the timeout if provider cleanup throws, rejects, or stalls.
- Prevents Responses and Hosted Multi-Agent WebSocket timeouts from replaying `response.create` or `response.inject` after send, for both runner and provider client deadlines, while keeping pre-send timeouts retryable.
- Types all OpenAI WebSocket transport deadline failures with `ETIMEDOUT`, including deadlines already exhausted between setup steps, so `retryPolicies.timeout()` handles auth, connection, queue, and frame-read deadlines consistently.
- Documents the lifecycle and includes patch changesets for `@openai/agents-core` and `@openai/agents-openai`.

## Validation

- `bash .agents/skills/code-change-verification/scripts/run.sh` (3,146 tests passed; 2 skipped)
- `pnpm -F docs build` (4,637 pages)
- `pnpm changeset:validate-lite`