### PR TITLE
fix: avoid tracing process lifecycle listeners in workerd

### DIFF
--- a/.changeset/calm-workers-trace.md
+++ b/.changeset/calm-workers-trace.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: avoid installing tracing process-lifecycle listeners in workerd and browsers

--- a/packages/agents-core/src/shims/shims-browser.ts
+++ b/packages/agents-core/src/shims/shims-browser.ts
@@ -211,6 +211,10 @@ export function isTracingLoopRunningByDefault(): boolean {
   return false;
 }
 
+export function supportsProcessLifecycleEvents(): boolean {
+  return false;
+}
+
 export {
   MCPServerStdio,
   MCPServerStreamableHttp,

--- a/packages/agents-core/src/shims/shims-node.ts
+++ b/packages/agents-core/src/shims/shims-node.ts
@@ -17,6 +17,10 @@ export function isTracingLoopRunningByDefault(): boolean {
   return true;
 }
 
+export function supportsProcessLifecycleEvents(): boolean {
+  return true;
+}
+
 export {
   NodeMCPServerStdio as MCPServerStdio,
   NodeMCPServerStreamableHttp as MCPServerStreamableHttp,

--- a/packages/agents-core/src/shims/shims-workerd.ts
+++ b/packages/agents-core/src/shims/shims-workerd.ts
@@ -26,6 +26,10 @@ export function isTracingLoopRunningByDefault(): boolean {
   return false;
 }
 
+export function supportsProcessLifecycleEvents(): boolean {
+  return false;
+}
+
 /**
  * Use the Node versions of MCP helpers
  */

--- a/packages/agents-core/src/tracing/provider.ts
+++ b/packages/agents-core/src/tracing/provider.ts
@@ -1,4 +1,5 @@
 import { getCurrentSpan, getCurrentTrace } from './context';
+import { supportsProcessLifecycleEvents } from '@openai/agents-core/_shims';
 import { tracing } from '../config';
 import logger from '../logger';
 import { MultiTracingProcessor, TracingProcessor } from './processor';
@@ -318,7 +319,11 @@ export class TraceProvider {
 
   /** Adds listeners to `process` to ensure `shutdown` occurs before exit. */
   #addCleanupListeners(): void {
-    if (typeof process !== 'undefined' && typeof process.on === 'function') {
+    if (
+      supportsProcessLifecycleEvents() &&
+      typeof process !== 'undefined' &&
+      typeof process.on === 'function'
+    ) {
       // handling Node.js process termination
       const cleanup = async () => {
         const timeoutMs = 5000;

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -71,6 +71,7 @@ import { Usage } from '../src/usage';
 import * as protocol from '../src/types/protocol';
 import { setDefaultModelProvider } from '../src/providers';
 import { AsyncLocalStorage as BrowserAsyncLocalStorage } from '../src/shims/shims-browser';
+import { supportsProcessLifecycleEvents as workerdSupportsProcessLifecycleEvents } from '../src/shims/shims-workerd';
 
 const ALS_SYMBOL = Symbol.for('openai.agents.core.asyncLocalStorage');
 
@@ -436,6 +437,45 @@ describe('Trace & Span lifecycle', () => {
 
     onceSpy.mockRestore();
     onSpy.mockRestore();
+  });
+
+  it('does not register process cleanup listeners in workerd', async () => {
+    const onceSpy = vi.spyOn(process, 'once');
+    const onSpy = vi.spyOn(process, 'on');
+
+    vi.resetModules();
+    vi.doMock('@openai/agents-core/_shims', async () => {
+      const actual = await vi.importActual('@openai/agents-core/_shims');
+      return {
+        ...(actual as Record<string, unknown>),
+        supportsProcessLifecycleEvents: workerdSupportsProcessLifecycleEvents,
+      };
+    });
+
+    try {
+      const { TraceProvider: WorkerdTraceProvider } =
+        await import('../src/tracing/provider');
+      new WorkerdTraceProvider();
+
+      expect(workerdSupportsProcessLifecycleEvents()).toBe(false);
+      expect(onceSpy).not.toHaveBeenCalledWith(
+        'beforeExit',
+        expect.any(Function),
+      );
+      expect(
+        onSpy.mock.calls.filter(
+          ([event]) =>
+            event === 'SIGINT' ||
+            event === 'SIGTERM' ||
+            event === 'unhandledRejection',
+        ),
+      ).toEqual([]);
+    } finally {
+      onceSpy.mockRestore();
+      onSpy.mockRestore();
+      vi.resetModules();
+      vi.unmock('@openai/agents-core/_shims');
+    }
   });
 
   it('does not force exit when beforeExit tracing cleanup times out', async () => {


### PR DESCRIPTION
## Summary

Prevent the tracing provider from registering process-lifecycle listeners in workerd and browser runtimes. `@openai/agents-core` initializes its global trace provider during import; in workerd, its `unhandledRejection` listener can call `process.exit(1)`, cancel the active request, and mask the original retryable error even after `setTracingDisabled(true)`.

- Add a runtime-shim capability for process lifecycle events: enabled for Node, disabled for workerd and browsers.
- Preserve the existing Node cleanup behavior while skipping all four listeners (`beforeExit`, `SIGINT`, `SIGTERM`, and `unhandledRejection`) in unsupported runtimes.
- Add a regression test and a patch changeset for `@openai/agents-core`.

## Why workerd needs different handling

Workerd exposes `process.on()` under `nodejs_compat` and can emit `unhandledRejection`, so checking for the presence of the Node process-event API does **not** establish that Node-equivalent process-lifecycle semantics are available.

- `beforeExit`, `SIGINT`, and `SIGTERM` assume an application owns an OS process. A Worker runs in a shared V8 isolate and does not own that lifecycle, so these are not appropriate Worker shutdown hooks.
- `unhandledRejection` can still fire for an unrelated Worker operation, allowing an import-time SDK listener to intercept errors even when no Agents SDK run is active.
- `process.exit(1)` exists, but in workerd it aborts the current request and terminates its JavaScript execution instead of exiting an application-owned Node process. This can replace a retryable application error with the terminal `process.exit` error. See the [workerd implementation](https://github.com/cloudflare/workerd/blob/v1.20260401.1/src/workerd/api/node/process.c++#L90-L111).

The underlying issue is therefore an invalid assumption: **the presence of Node's `process` event API does not imply Node process-lifecycle behavior**. The runtime-shim capability preserves lifecycle cleanup for actual Node.js while avoiding these hooks in workerd and browsers.

## Reproduction

Using workerd/Miniflare with `nodejs_compat` and compatibility date `2026-04-07`, importing the SDK and disabling tracing previously installed all four listeners. Triggering a retryable rejection produced an HTTP 500 with `The Node.js process.exit(1) API was called. Canceling the request.`, masking the original error.

With this change, the same probe returns HTTP 200 and:

```json
{"tracingDisabled":true,"listeners":{"beforeExit":0,"SIGINT":0,"SIGTERM":0,"unhandledRejection":0}}
```

## Validation

- `@openai/agents-core`: 97 test files and 1,723 tests passed.
- Core source and test TypeScript checks passed.
- ESLint and Prettier checks passed for all changed files.
- Verified the bundled source in real workerd/Miniflare with `nodejs_compat`.

The managed local Socket registry currently blocks the lockfile-pinned `openai@6.46.0` as recently published, so local validation used the already-installed `openai@6.44.0` only as a test substitute; the lockfile and dependency declarations are unchanged.
