### PR TITLE
docs: add W&B Weave tracing integration

### DIFF
--- a/docs/src/content/docs/guides/tracing.mdx
+++ b/docs/src/content/docs/guides/tracing.mdx
@@ -119,6 +119,7 @@ To customize this default setup, to send traces to alternative or additional bac
 
 ## External tracing processors list
 
+- [W&B Weave](https://docs.wandb.ai/weave/guides/integrations/agents/openai-agents-sdk)
 - [AgentOps](https://docs.agentops.ai/v2/usage/typescript-sdk#openai-agents-integration)
 - [Respan](https://www.respan.ai/docs/integrations/openai-agents-sdk)
 - [PromptLayer](https://docs.promptlayer.com/languages/integrations#openai-agents-sdk)


### PR DESCRIPTION
### Summary

Add W&B Weave to the external tracing processors list and link to the canonical OpenAI Agents SDK integration guide.

#### User impact

Developers can discover Weave tracing from the SDK's tracing guide. This is a documentation-only catalog addition with no runtime or API changes.

#### Privacy implications

None introduced by this PR. The linked W&B guide describes the trace data sent when users choose to enable Weave.

### Test plan

- `pnpm exec prettier --check docs/src/content/docs/guides/tracing.mdx`
- `pnpm build`
- `pnpm docs:build` (4,629 pages built)
- Repository pre-commit hook, including TruffleHog (zero secrets found)
- Confirmed the linked W&B guide returns HTTP 200

### Issue number

N/A

### Checks

- [ ] I've added new tests (not relevant; documentation-only change)
- [x] I've added/updated the relevant documentation
- [ ] I've run `pnpm test` and `pnpm test:examples` (not relevant; documentation-only change)
  - [ ] (If you made a major change) I've run `pnpm test:integration`
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh` (not relevant; no code changes)
- [x] I've confirmed all applicable verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
- [ ] I've added a changeset using `pnpm changeset` to indicate my changes (not relevant; documentation-only change)

No breaking changes.