### PR TITLE
fix: preflight pnpm upgrades against action setup

### DIFF
--- a/.agents/skills/pnpm-upgrade/SKILL.md
+++ b/.agents/skills/pnpm-upgrade/SKILL.md
@@ -34,7 +34,7 @@ Use these steps to update pnpm and CI pins without blunt search/replace.
 4. Preflight the release and CI installation path
    - Run `node .agents/skills/pnpm-upgrade/scripts/preflight.mjs --version "${PNPM_VERSION}" --action-ref "${ACTION_SHA}"`.
    - The script first rejects published pnpm manifests with non-empty `dependencies` or `devDependencies`. pnpm bundles its runtime dependencies, so these fields indicate a broken publication such as `pnpm@11.12.0`.
-   - It then reproduces `pnpm/action-setup` in a temporary directory: install the action's pinned bootstrap pnpm with its committed npm lockfile, set an isolated `PNPM_HOME`, and self-update from the bootstrap to `PNPM_VERSION`.
+   - It then reproduces both `pnpm/action-setup` installation paths in separate temporary directories: install the regular `pnpm` bootstrap from `pnpm-lock.json` and the standalone `@pnpm/exe` bootstrap from `exe-lock.json`, set isolated `PNPM_HOME` directories, and self-update each bootstrap to `PNPM_VERSION`.
    - Abort the upgrade on any failure. Do not bypass this check with a direct local install; the preflight exists to exercise the CI-only bootstrap path.
 
 5. Update pnpm locally

--- a/.agents/skills/pnpm-upgrade/SKILL.md
+++ b/.agents/skills/pnpm-upgrade/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pnpm-upgrade
-description: 'Keep pnpm current: run pnpm self-update/corepack prepare, align packageManager in package.json, and bump pnpm/action-setup + pinned pnpm versions in .github/workflows to the latest release. Use this when refreshing the pnpm toolchain manually or in automation.'
+description: 'Keep pnpm current: preflight the published package and pnpm/action-setup self-installer, update pnpm locally, align packageManager in package.json, and refresh CI pins. Use this when refreshing the pnpm toolchain manually or in automation.'
 ---
 
 # pnpm Upgrade
@@ -9,12 +9,10 @@ Use these steps to update pnpm and CI pins without blunt search/replace.
 
 ## Steps (run from repo root)
 
-1. Update pnpm locally
-   - Try `pnpm self-update`; if pnpm is missing or self-update fails, run `corepack prepare pnpm@latest --activate`.
-   - Capture the resulting version as `PNPM_VERSION=$(pnpm -v)`.
-
-2. Resolve pnpm package integrity
-   - Query npm registry for the exact package integrity: `curl -fsSL "https://registry.npmjs.org/pnpm/${PNPM_VERSION}" | jq -r .dist.integrity`.
+1. Resolve the target pnpm release
+   - Query the npm registry before changing the local toolchain: `PNPM_VERSION=$(curl -fsSL https://registry.npmjs.org/pnpm/latest | jq -r .version)`.
+   - Abort if the version is missing.
+   - Resolve the exact package integrity: `curl -fsSL "https://registry.npmjs.org/pnpm/${PNPM_VERSION}" | jq -r .dist.integrity`.
    - Store the result as `PNPM_INTEGRITY`.
    - Abort if the integrity is missing or does not start with `sha512-`.
    - Convert the base64 digest after `sha512-` to lowercase hex, for example:
@@ -23,38 +21,49 @@ Use these steps to update pnpm and CI pins without blunt search/replace.
      ```
    - Store the result as `PNPM_SHA512_HEX`.
 
-3. Align package.json
-   - Open `package.json` and set `packageManager` to `pnpm@${PNPM_VERSION}+sha512.${PNPM_SHA512_HEX}` (preserve trailing newline and formatting).
-
-4. Find latest pnpm/action-setup tag
+2. Find the target pnpm/action-setup release
    - Query GitHub API: `curl -fsSL https://api.github.com/repos/pnpm/action-setup/releases/latest | jq -r .tag_name`.
    - Use `GITHUB_TOKEN`/`GH_TOKEN` if available for higher rate limits.
    - Store as `ACTION_TAG` (e.g., `v4.2.0`). Abort if missing.
 
-5. Resolve the action tag to an immutable commit SHA
+3. Resolve the action tag to an immutable commit SHA
    - Run `git ls-remote https://github.com/pnpm/action-setup "refs/tags/${ACTION_TAG}^{}"` and capture the SHA as `ACTION_SHA`.
    - If the dereferenced tag is missing, fall back to `git ls-remote https://github.com/pnpm/action-setup "refs/tags/${ACTION_TAG}"`.
    - Abort if `ACTION_SHA` is empty.
 
-6. Update workflows carefully (no broad regex)
+4. Preflight the release and CI installation path
+   - Run `node .agents/skills/pnpm-upgrade/scripts/preflight.mjs --version "${PNPM_VERSION}" --action-ref "${ACTION_SHA}"`.
+   - The script first rejects published pnpm manifests with non-empty `dependencies` or `devDependencies`. pnpm bundles its runtime dependencies, so these fields indicate a broken publication such as `pnpm@11.12.0`.
+   - It then reproduces `pnpm/action-setup` in a temporary directory: install the action's pinned bootstrap pnpm with its committed npm lockfile, set an isolated `PNPM_HOME`, and self-update from the bootstrap to `PNPM_VERSION`.
+   - Abort the upgrade on any failure. Do not bypass this check with a direct local install; the preflight exists to exercise the CI-only bootstrap path.
+
+5. Update pnpm locally
+   - Run `pnpm self-update "${PNPM_VERSION}"`.
+   - If pnpm is missing or self-update fails only because the current installation cannot update itself, run `corepack prepare "pnpm@${PNPM_VERSION}" --activate`. Do not use this fallback to bypass a failed preflight.
+   - Confirm `pnpm -v` exactly matches `PNPM_VERSION`.
+
+6. Align package.json
+   - Open `package.json` and set `packageManager` to `pnpm@${PNPM_VERSION}+sha512.${PNPM_SHA512_HEX}` (preserve trailing newline and formatting).
+
+7. Update workflows carefully (no broad regex)
    - Files: everything under `.github/workflows/` that uses `pnpm/action-setup`.
    - For each file, edit by hand:
      - Set `uses: pnpm/action-setup@${ACTION_SHA}`.
      - If a `with: version:` field exists, set it to `${PNPM_VERSION}` (keep quoting style/indent).
    - Do not touch unrelated steps. Avoid multiline sed/perl one-liners.
 
-7. Verify
+8. Verify
    - Run `pnpm -v` and confirm it matches the version portion of `packageManager`.
    - Confirm `packageManager` keeps the exact `+sha512.${PNPM_SHA512_HEX}` suffix.
    - `git diff` to ensure only intended workflow/package.json changes.
 
-8. Follow-up
+9. Follow-up
    - If runtime code/build/test config was changed (not typical here), run `$code-change-verification`; otherwise, a light check is enough.
    - Commit with `chore: upgrade pnpm toolchain` and open a PR (automation may do this).
 
 ## Notes
 
-- Tools needed: `curl`, `jq`, `base64`, `xxd`, `node`, `pnpm`/`corepack`. Install if missing.
+- Tools needed: `curl`, `jq`, `base64`, `xxd`, `node`, `npm`, and `pnpm`/`corepack`. Install if missing.
 - Keep edits minimal and readable—prefer explicit file edits over global replacements.
 - GitHub Actions must stay pinned to commit SHAs, not tags. Use the latest release tag only to discover the commit SHA to pin.
 - If GitHub API is rate-limited, retry with a token or bail out rather than guessing the tag.

--- a/.agents/skills/pnpm-upgrade/agents/openai.yaml
+++ b/.agents/skills/pnpm-upgrade/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "pnpm Upgrade"
-  short_description: "Refresh local pnpm and CI workflow pins"
-  default_prompt: "Use $pnpm-upgrade to update pnpm locally, align packageManager, and refresh pinned pnpm/action-setup workflow versions."
+  short_description: "Preflight and refresh pnpm plus CI workflow pins"
+  default_prompt: "Use $pnpm-upgrade to preflight the CI installation path, update pnpm locally, align packageManager, and refresh pinned pnpm/action-setup workflow versions."

--- a/.agents/skills/pnpm-upgrade/scripts/preflight.mjs
+++ b/.agents/skills/pnpm-upgrade/scripts/preflight.mjs
@@ -29,7 +29,6 @@ function run(command, args, options) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       ...options,
-      shell: process.platform === 'win32',
       stdio: 'inherit',
     });
     child.on('error', reject);
@@ -73,7 +72,11 @@ async function runBootstrapProbe(bootstrap, targetVersion) {
       path.join(workDir, 'package-lock.json'),
       `${JSON.stringify(bootstrap.lock, null, 2)}\n`,
     );
-    await run('npm', ['ci'], { cwd: workDir, env: process.env });
+    await run('npm', ['ci'], {
+      cwd: workDir,
+      env: process.env,
+      shell: process.platform === 'win32',
+    });
 
     const pnpmHome =
       bootstrap.label === 'standalone' && process.platform === 'win32'

--- a/.agents/skills/pnpm-upgrade/scripts/preflight.mjs
+++ b/.agents/skills/pnpm-upgrade/scripts/preflight.mjs
@@ -27,7 +27,11 @@ async function fetchJson(url) {
 
 function run(command, args, options) {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { ...options, stdio: 'inherit' });
+    const child = spawn(command, args, {
+      ...options,
+      shell: process.platform === 'win32',
+      stdio: 'inherit',
+    });
     child.on('error', reject);
     child.on('close', (code, signal) => {
       if (code === 0) {
@@ -41,6 +45,73 @@ function run(command, args, options) {
       );
     });
   });
+}
+
+async function loadBootstrap(actionRef, options) {
+  const lock = await fetchJson(
+    `https://raw.githubusercontent.com/pnpm/action-setup/${actionRef}/src/install-pnpm/bootstrap/${options.lockFile}`,
+  );
+  const version = lock.packages?.[options.packageKey]?.version;
+  if (!version) {
+    throw new Error(
+      `Could not resolve the ${options.label} bootstrap version from pnpm/action-setup@${actionRef}.`,
+    );
+  }
+  return { ...options, lock, version };
+}
+
+async function runBootstrapProbe(bootstrap, targetVersion) {
+  const workDir = await mkdtemp(
+    path.join(tmpdir(), `pnpm-upgrade-preflight-${bootstrap.label}-`),
+  );
+  try {
+    await writeFile(
+      path.join(workDir, 'package.json'),
+      `${JSON.stringify({ private: true, dependencies: { [bootstrap.packageName]: bootstrap.version } }, null, 2)}\n`,
+    );
+    await writeFile(
+      path.join(workDir, 'package-lock.json'),
+      `${JSON.stringify(bootstrap.lock, null, 2)}\n`,
+    );
+    await run('npm', ['ci'], { cwd: workDir, env: process.env });
+
+    const pnpmHome =
+      bootstrap.label === 'standalone' && process.platform === 'win32'
+        ? path.join(workDir, 'node_modules', '@pnpm', 'exe')
+        : path.join(workDir, 'node_modules', '.bin');
+    const xdgDataHome = path.join(workDir, 'xdg-data');
+    await mkdir(xdgDataHome, { recursive: true });
+    const bootstrapPnpm =
+      bootstrap.label === 'standalone'
+        ? path.join(
+            workDir,
+            'node_modules',
+            '@pnpm',
+            'exe',
+            process.platform === 'win32' ? 'pnpm.exe' : 'pnpm',
+          )
+        : path.join(workDir, 'node_modules', 'pnpm', 'bin', 'pnpm.mjs');
+    const command =
+      bootstrap.label === 'standalone' ? bootstrapPnpm : process.execPath;
+    const args =
+      bootstrap.label === 'standalone'
+        ? ['self-update', targetVersion]
+        : [bootstrapPnpm, 'self-update', targetVersion];
+    await run(command, args, {
+      cwd: workDir,
+      env: {
+        ...process.env,
+        PNPM_HOME: pnpmHome,
+        XDG_DATA_HOME: xdgDataHome,
+      },
+    });
+  } finally {
+    await rm(workDir, { recursive: true, force: true });
+  }
+
+  console.log(
+    `Preflight passed for the ${bootstrap.label} pnpm/action-setup bootstrap ${bootstrap.version}.`,
+  );
 }
 
 function assertDependencyFreeManifest(manifest, version) {
@@ -79,53 +150,27 @@ async function main() {
   }
   assertDependencyFreeManifest(manifest, version);
 
-  const bootstrapLock = await fetchJson(
-    `https://raw.githubusercontent.com/pnpm/action-setup/${actionRef}/src/install-pnpm/bootstrap/pnpm-lock.json`,
-  );
-  const bootstrapVersion =
-    bootstrapLock.packages?.['node_modules/pnpm']?.version;
-  if (!bootstrapVersion) {
-    throw new Error(
-      `Could not resolve the pnpm bootstrap version from pnpm/action-setup@${actionRef}.`,
-    );
-  }
+  const bootstraps = await Promise.all([
+    loadBootstrap(actionRef, {
+      label: 'regular',
+      lockFile: 'pnpm-lock.json',
+      packageKey: 'node_modules/pnpm',
+      packageName: 'pnpm',
+    }),
+    loadBootstrap(actionRef, {
+      label: 'standalone',
+      lockFile: 'exe-lock.json',
+      packageKey: 'node_modules/@pnpm/exe',
+      packageName: '@pnpm/exe',
+    }),
+  ]);
 
-  const workDir = await mkdtemp(path.join(tmpdir(), 'pnpm-upgrade-preflight-'));
-  try {
-    await writeFile(
-      path.join(workDir, 'package.json'),
-      `${JSON.stringify({ private: true, dependencies: { pnpm: bootstrapVersion } }, null, 2)}\n`,
-    );
-    await writeFile(
-      path.join(workDir, 'package-lock.json'),
-      `${JSON.stringify(bootstrapLock, null, 2)}\n`,
-    );
-    await run('npm', ['ci'], { cwd: workDir, env: process.env });
-
-    const pnpmHome = path.join(workDir, 'node_modules', '.bin');
-    const xdgDataHome = path.join(workDir, 'xdg-data');
-    await mkdir(xdgDataHome, { recursive: true });
-    const bootstrapPnpm = path.join(
-      workDir,
-      'node_modules',
-      'pnpm',
-      'bin',
-      'pnpm.mjs',
-    );
-    await run(process.execPath, [bootstrapPnpm, 'self-update', version], {
-      cwd: workDir,
-      env: {
-        ...process.env,
-        PNPM_HOME: pnpmHome,
-        XDG_DATA_HOME: xdgDataHome,
-      },
-    });
-  } finally {
-    await rm(workDir, { recursive: true, force: true });
+  for (const bootstrap of bootstraps) {
+    await runBootstrapProbe(bootstrap, version);
   }
 
   console.log(
-    `Preflight passed: pnpm/action-setup bootstrap ${bootstrapVersion} can self-update to pnpm ${version}.`,
+    `Preflight passed: all pnpm/action-setup bootstrap paths can self-update to pnpm ${version}.`,
   );
 }
 

--- a/.agents/skills/pnpm-upgrade/scripts/preflight.mjs
+++ b/.agents/skills/pnpm-upgrade/scripts/preflight.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const { console, fetch, process } = globalThis;
+
+function readArg(name) {
+  const index = process.argv.indexOf(name);
+  if (index === -1 || !process.argv[index + 1]) {
+    throw new Error(`Missing required argument: ${name}`);
+  }
+  return process.argv[index + 1];
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url, {
+    headers: { 'user-agent': 'openai-agents-js-pnpm-upgrade-preflight' },
+  });
+  if (!response.ok) {
+    throw new Error(`Request failed (${response.status}): ${url}`);
+  }
+  return response.json();
+}
+
+function run(command, args, options) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { ...options, stdio: 'inherit' });
+    child.on('error', reject);
+    child.on('close', (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(
+        new Error(
+          `${command} exited with ${signal ? `signal ${signal}` : `code ${code}`}`,
+        ),
+      );
+    });
+  });
+}
+
+function assertDependencyFreeManifest(manifest, version) {
+  const dependencies = Object.keys(manifest.dependencies ?? {});
+  const devDependencies = Object.keys(manifest.devDependencies ?? {});
+  if (dependencies.length === 0 && devDependencies.length === 0) return;
+
+  const summarize = (names) =>
+    names.length === 0
+      ? 'none'
+      : `${names.length}: ${names.slice(0, 10).join(', ')}${names.length > 10 ? ', ...' : ''}`;
+  throw new Error(
+    [
+      `pnpm@${version} has an unexpected published manifest.`,
+      `dependencies (${summarize(dependencies)})`,
+      `devDependencies (${summarize(devDependencies)})`,
+      'pnpm bundles its runtime dependencies; aborting before the pnpm/action-setup self-installer runs.',
+    ].join('\n'),
+  );
+}
+
+async function main() {
+  const version = readArg('--version');
+  const actionRef = readArg('--action-ref');
+  if (!/^[0-9a-f]{40}$/.test(actionRef)) {
+    throw new Error('--action-ref must be a 40-character commit SHA.');
+  }
+
+  const manifest = await fetchJson(
+    `https://registry.npmjs.org/pnpm/${encodeURIComponent(version)}`,
+  );
+  if (manifest.version !== version) {
+    throw new Error(
+      `Registry returned pnpm@${manifest.version ?? 'unknown'} instead of pnpm@${version}.`,
+    );
+  }
+  assertDependencyFreeManifest(manifest, version);
+
+  const bootstrapLock = await fetchJson(
+    `https://raw.githubusercontent.com/pnpm/action-setup/${actionRef}/src/install-pnpm/bootstrap/pnpm-lock.json`,
+  );
+  const bootstrapVersion =
+    bootstrapLock.packages?.['node_modules/pnpm']?.version;
+  if (!bootstrapVersion) {
+    throw new Error(
+      `Could not resolve the pnpm bootstrap version from pnpm/action-setup@${actionRef}.`,
+    );
+  }
+
+  const workDir = await mkdtemp(path.join(tmpdir(), 'pnpm-upgrade-preflight-'));
+  try {
+    await writeFile(
+      path.join(workDir, 'package.json'),
+      `${JSON.stringify({ private: true, dependencies: { pnpm: bootstrapVersion } }, null, 2)}\n`,
+    );
+    await writeFile(
+      path.join(workDir, 'package-lock.json'),
+      `${JSON.stringify(bootstrapLock, null, 2)}\n`,
+    );
+    await run('npm', ['ci'], { cwd: workDir, env: process.env });
+
+    const pnpmHome = path.join(workDir, 'node_modules', '.bin');
+    const xdgDataHome = path.join(workDir, 'xdg-data');
+    await mkdir(xdgDataHome, { recursive: true });
+    const bootstrapPnpm = path.join(
+      workDir,
+      'node_modules',
+      'pnpm',
+      'bin',
+      'pnpm.mjs',
+    );
+    await run(process.execPath, [bootstrapPnpm, 'self-update', version], {
+      cwd: workDir,
+      env: {
+        ...process.env,
+        PNPM_HOME: pnpmHome,
+        XDG_DATA_HOME: xdgDataHome,
+      },
+    });
+  } finally {
+    await rm(workDir, { recursive: true, force: true });
+  }
+
+  console.log(
+    `Preflight passed: pnpm/action-setup bootstrap ${bootstrapVersion} can self-update to pnpm ${version}.`,
+  );
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
This pull request fixes a validation gap where a pnpm upgrade can pass local repository checks but fail during the `pnpm/action-setup` self-installer in CI.

It adds a new, currently untracked `preflight.mjs` that rejects malformed published pnpm manifests and reproduces the pinned action bootstrap-to-target self-update in an isolated environment. The upgrade workflow now runs this check before modifying the local pnpm installation or `package.json`.