### PR TITLE
feat: add Programmatic Tool Calling support

### DIFF
--- a/.changeset/calm-programs-coordinate.md
+++ b/.changeset/calm-programs-coordinate.md
@@ -1,0 +1,9 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+'@openai/agents': patch
+'@openai/agents-extensions': patch
+'@openai/agents-realtime': patch
+---
+
+feat: add Programmatic Tool Calling with caller-aware replay, runtime-validated Zod outputs, configuration preflight, examples, and explicit unsupported-adapter errors

--- a/examples/docs/tools/programmaticToolCalling.ts
+++ b/examples/docs/tools/programmaticToolCalling.ts
@@ -1,0 +1,40 @@
+import { Agent, programmaticToolCallingTool, tool } from '@openai/agents';
+import { z } from 'zod';
+
+const getInventory = tool({
+  name: 'get_inventory',
+  description: 'Return inventory for a SKU.',
+  parameters: z.object({ sku: z.string() }),
+  allowedCallers: ['programmatic'],
+  outputSchema: z.object({
+    sku: z.string(),
+    availableUnits: z.number(),
+  }),
+  async execute({ sku }) {
+    return { sku, availableUnits: 42 };
+  },
+});
+
+const getDemand = tool({
+  name: 'get_demand',
+  description: 'Return requested units for a SKU.',
+  parameters: z.object({ sku: z.string() }),
+  allowedCallers: ['programmatic'],
+  outputSchema: z.object({
+    sku: z.string(),
+    requestedUnits: z.number(),
+  }),
+  async execute({ sku }) {
+    return { sku, requestedUnits: 31 };
+  },
+});
+
+const agent = new Agent({
+  name: 'Inventory planner',
+  model: 'gpt-5.6',
+  instructions: `
+Use Programmatic Tool Calling to fetch inventory and demand concurrently.
+Return the source values and the calculated shortage in the final answer.
+  `.trim(),
+  tools: [getInventory, getDemand, programmaticToolCallingTool()],
+});

--- a/examples/tools/README.md
+++ b/examples/tools/README.md
@@ -22,6 +22,12 @@ These examples demonstrate the hosted tools provided by the Agents SDK.
   pnpm examples:tools-tool-search
   ```
 
+- `programmatic-tool-calling.ts` – Uses hosted JavaScript to run read-only inventory tools concurrently and reduce their results into a replenishment plan.
+
+  ```bash
+  pnpm examples:tools-programmatic-tool-calling
+  ```
+
 - `codex.ts` – Runs the Codex CLI via the codex tool wrapper with streaming event logs and skill usage. Requires `CODEX_API_KEY` or `OPENAI_API_KEY` (Codex falls back to this unless `CODEX_API_KEY` is set). You can set `CODEX_PATH` to override the Codex CLI path.
 
   ```bash

--- a/examples/tools/package.json
+++ b/examples/tools/package.json
@@ -24,6 +24,7 @@
     "start:web-search-filters": "tsx web-search-filters.ts",
     "start:code-interpreter": "tsx code-interpreter.ts",
     "start:image-generation": "tsx image-generation.ts",
+    "start:programmatic-tool-calling": "tsx programmatic-tool-calling.ts",
     "start:shell": "tsx local-shell.ts",
     "start:local-shell": "tsx local-shell.ts",
     "start:container-shell": "tsx container-shell-skill-ref.ts",

--- a/examples/tools/programmatic-tool-calling.ts
+++ b/examples/tools/programmatic-tool-calling.ts
@@ -1,0 +1,140 @@
+import { Agent, programmaticToolCallingTool, run, tool } from '@openai/agents';
+import { z } from 'zod';
+
+const sku = z.enum(['desk-lamp', 'ergonomic-keyboard', 'usb-c-dock']);
+type Sku = z.infer<typeof sku>;
+
+const inventory: Record<Sku, number> = {
+  'desk-lamp': 12,
+  'ergonomic-keyboard': 7,
+  'usb-c-dock': 22,
+};
+
+const weeklyDemand: Record<Sku, number> = {
+  'desk-lamp': 18,
+  'ergonomic-keyboard': 16,
+  'usb-c-dock': 14,
+};
+
+const inboundUnits: Record<Sku, number> = {
+  'desk-lamp': 4,
+  'ergonomic-keyboard': 2,
+  'usb-c-dock': 0,
+};
+
+const skuParameters = z.object({
+  sku: sku.describe('The SKU to look up.'),
+});
+
+const inventoryOutput = z.object({
+  sku,
+  availableUnits: z.number(),
+});
+
+const weeklyDemandOutput = z.object({
+  sku,
+  forecastUnits: z.number(),
+});
+
+const inboundUnitsOutput = z.object({
+  sku,
+  inboundUnits: z.number(),
+});
+
+const getInventory = tool({
+  name: 'get_inventory',
+  description: 'Return the currently available units for one SKU.',
+  parameters: skuParameters,
+  allowedCallers: ['programmatic'],
+  outputSchema: inventoryOutput,
+  execute: async ({ sku }) => {
+    console.log(`[tool] get_inventory(${sku})`);
+    return { sku, availableUnits: inventory[sku] };
+  },
+});
+
+const getWeeklyDemand = tool({
+  name: 'get_weekly_demand',
+  description: 'Return forecast demand for one SKU for the next seven days.',
+  parameters: skuParameters,
+  allowedCallers: ['programmatic'],
+  outputSchema: weeklyDemandOutput,
+  execute: async ({ sku }) => {
+    console.log(`[tool] get_weekly_demand(${sku})`);
+    return { sku, forecastUnits: weeklyDemand[sku] };
+  },
+});
+
+const getInboundUnits = tool({
+  name: 'get_inbound_units',
+  description: 'Return units already scheduled to arrive for one SKU.',
+  parameters: skuParameters,
+  allowedCallers: ['programmatic'],
+  outputSchema: inboundUnitsOutput,
+  execute: async ({ sku }) => {
+    console.log(`[tool] get_inbound_units(${sku})`);
+    return { sku, inboundUnits: inboundUnits[sku] };
+  },
+});
+
+const agent = new Agent({
+  name: 'Replenishment planner',
+  model: process.env.PTC_MODEL_NAME ?? 'gpt-5.6',
+  instructions: `
+<tool_orchestration>
+Use Programmatic Tool Calling to prepare a replenishment plan for desk-lamp,
+ergonomic-keyboard, and usb-c-dock. For every SKU, call get_inventory,
+get_weekly_demand, and get_inbound_units. Create all nine tool-call promises
+before awaiting them, then run them concurrently with one Promise.all call.
+
+Use a safety stock of 5 units. Calculate reorderUnits as
+max(forecastUnits + 5 - availableUnits - inboundUnits, 0). In the program,
+return exactly one JSON object with recommendations and totalReorderUnits.
+Each recommendation must include sku, availableUnits, forecastUnits,
+inboundUnits, and reorderUnits. Include only positive reorder quantities and
+sort recommendations by reorderUnits descending.
+
+Do not call these tools directly. In the final answer, explain the plan using
+the source values returned by the program.
+</tool_orchestration>
+  `.trim(),
+  modelSettings: {
+    toolChoice: 'programmatic_tool_calling',
+  },
+  tools: [
+    getInventory,
+    getWeeklyDemand,
+    getInboundUnits,
+    programmaticToolCallingTool(),
+  ],
+});
+
+async function main() {
+  const result = await run(
+    agent,
+    'Which products should we reorder this week, and in what quantities?',
+  );
+
+  const programmaticCalls: string[] = [];
+  for (const item of result.newItems) {
+    if (item.type !== 'tool_call_item') {
+      continue;
+    }
+    if (item.rawItem.type === 'program') {
+      console.log(`\nGenerated program:\n${item.rawItem.code}\n`);
+    } else if (
+      item.rawItem.type === 'function_call' &&
+      item.rawItem.caller?.type === 'program'
+    ) {
+      programmaticCalls.push(item.rawItem.name);
+    }
+  }
+
+  console.log(`Programmatic calls: ${programmaticCalls.join(', ')}`);
+  console.log(`\nFinal answer:\n${result.finalOutput}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "examples:tools-codex": "pnpm -F tools start:codex",
     "examples:tools-codex-same-thread": "pnpm -F tools start:codex-same-thread",
     "examples:tools-file-search": "pnpm -F tools start:file-search",
+    "examples:tools-programmatic-tool-calling": "pnpm -F tools start:programmatic-tool-calling",
     "examples:tools-tool-search": "pnpm -F tools start:tool-search",
     "examples:tools-web-search": "pnpm -F tools start:web-search",
     "examples:tools-shell": "pnpm -F tools start:shell",

--- a/packages/agents-core/src/errors.ts
+++ b/packages/agents-core/src/errors.ts
@@ -101,6 +101,41 @@ export class InvalidToolInputError extends ModelBehaviorError {
 export class UserError extends AgentsError {}
 
 /**
+ * Context from a function tool output that failed runtime validation.
+ */
+export type ToolOutputErrorContext = {
+  /** The run context at the time of the error. */
+  runContext?: RunContext<any>;
+  /** The invalid value returned by the tool or one of its fallback paths. */
+  output?: unknown;
+  /** The details of the tool call made by the model. */
+  details?: ToolInvocationErrorContext['details'];
+};
+
+/**
+ * Error thrown when a function tool returns a value that does not match its
+ * runtime output schema.
+ */
+export class InvalidToolOutputError extends UserError {
+  /** The original error thrown during validation, if any. */
+  originalError?: unknown;
+
+  /** Context from the tool output that failed validation. */
+  toolOutput?: ToolOutputErrorContext;
+
+  constructor(
+    message: string,
+    state?: RunState<any, Agent<any, any>>,
+    originalError?: unknown,
+    toolOutput?: ToolOutputErrorContext,
+  ) {
+    super(message, state);
+    this.originalError = originalError;
+    this.toolOutput = toolOutput;
+  }
+}
+
+/**
  * Error thrown when a guardrail execution fails.
  */
 export class GuardrailExecutionError extends AgentsError {

--- a/packages/agents-core/src/extensions/handoffFilters.ts
+++ b/packages/agents-core/src/extensions/handoffFilters.ts
@@ -23,6 +23,8 @@ const TOOL_TYPES = new Set([
   'shell_call_output',
   'apply_patch_call',
   'apply_patch_call_output',
+  'program',
+  'program_output',
   'hosted_tool_call',
   'reasoning',
 ]);

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -26,6 +26,7 @@ export {
   AgentsError,
   GuardrailExecutionError,
   InputGuardrailTripwireTriggered,
+  InvalidToolOutputError,
   MaxTurnsExceededError,
   ModelBehaviorError,
   ModelRefusalError,
@@ -37,6 +38,7 @@ export {
   UserError,
   SystemError,
 } from './errors';
+export type { ToolOutputErrorContext } from './errors';
 export {
   RunAgentUpdatedStreamEvent,
   RunRawModelStreamEvent,
@@ -225,6 +227,8 @@ export {
   ToolExecuteArgument,
   ToolEnabledFunction,
   ToolOptionsWithGuardrails,
+  ToolAllowedCaller,
+  ToolAllowedCallers,
 } from './tool';
 export type {
   ClientToolSearchExecutor,
@@ -248,6 +252,7 @@ export type {
   ShellToolContainerNetworkPolicyDisabled,
   ShellToolContainerNetworkPolicyDomainSecret,
   ToolInputParameters,
+  ToolOutputSchema,
   ToolOptions,
   ToolNamespaceOptions,
   ToolOutputCustomData,
@@ -283,6 +288,9 @@ export type {
   ShellCallResultItem,
   ApplyPatchCallItem,
   ApplyPatchCallResultItem,
+  ProgramCallItem,
+  ProgramCallResultItem,
+  ToolCaller,
   FunctionCallItem,
   FunctionCallResultItem,
   JsonSchemaDefinition,

--- a/packages/agents-core/src/items.ts
+++ b/packages/agents-core/src/items.ts
@@ -65,6 +65,9 @@ export class RunToolCallItem extends RunItemBase {
   }
 
   get toolName(): string | undefined {
+    if (this.rawItem.type === 'program') {
+      return 'programmatic_tool_calling';
+    }
     return getStringProperty(this.rawItem, 'name');
   }
 
@@ -120,7 +123,8 @@ export class RunToolCallOutputItem extends RunItemBase {
       | protocol.FunctionCallResultItem
       | protocol.ComputerCallResultItem
       | protocol.ShellCallResultItem
-      | protocol.ApplyPatchCallResultItem,
+      | protocol.ApplyPatchCallResultItem
+      | protocol.ProgramCallResultItem,
     public agent: Agent<any, any>,
     public output: string | unknown,
     public customData?: ToolOutputCustomData,

--- a/packages/agents-core/src/model.ts
+++ b/packages/agents-core/src/model.ts
@@ -399,6 +399,16 @@ export type SerializedFunctionTool = {
   providerData?: FunctionTool['providerData'];
 
   /**
+   * Responses API only. Execution contexts allowed to invoke the function.
+   */
+  allowedCallers?: FunctionTool['allowedCallers'];
+
+  /**
+   * Responses API only. Schema for the JSON value encoded in string outputs.
+   */
+  outputSchema?: FunctionTool['outputSchema'];
+
+  /**
    * Responses API only. Explicit namespace used to group related function tools.
    */
   namespace?: string;
@@ -420,11 +430,13 @@ export type SerializedShellTool = {
   type: ShellTool['type'];
   name: ShellTool['name'];
   environment?: ShellTool['environment'];
+  allowedCallers?: ShellTool['allowedCallers'];
 };
 
 export type SerializedApplyPatchTool = {
   type: ApplyPatchTool['type'];
   name: ApplyPatchTool['name'];
+  allowedCallers?: ApplyPatchTool['allowedCallers'];
 };
 
 export type SerializedHostedTool = {

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1200,6 +1200,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               state,
               [...preparedCall.turnInput, ...state._generatedItems],
               options.toolNotFoundBehavior,
+              {
+                allowPromptSuppliedTools: preparedCall.allowPromptSuppliedTools,
+              },
             );
 
             state._lastProcessedResponse = processedResponse;
@@ -1682,7 +1685,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               );
             } catch (error) {
               logger.debug(
-                'Failed to reconcile streamed function calls after abort.',
+                'Failed to reconcile streamed tool calls after abort.',
                 error,
               );
             }
@@ -1796,6 +1799,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             result.state,
             [...preparedCall.turnInput, ...result.state._generatedItems],
             options.toolNotFoundBehavior,
+            {
+              allowPromptSuppliedTools: preparedCall.allowPromptSuppliedTools,
+            },
           );
 
           result.state._lastProcessedResponse = processedResponse;
@@ -2196,6 +2202,13 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       state._context,
     );
     const prompt = await executionAgent.getPrompt(state._context);
+    const allowPromptSuppliedTools =
+      Boolean(prompt) &&
+      !(
+        artifacts.toolsExplicitlyProvided &&
+        artifacts.serializedTools.length === 0 &&
+        artifacts.serializedHandoffs.length === 0
+      );
 
     const { modelInput, sourceItems, persistedItems, filterApplied } =
       await applyCallModelInputFilter(
@@ -2228,6 +2241,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       modelSettings,
       modelInput,
       prompt,
+      allowPromptSuppliedTools,
       previousResponseId,
       conversationId,
       sourceItems,

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -61,6 +61,7 @@ import {
   executeCustomClientToolSearch,
   getClientToolSearchHelper,
 } from './runner/toolSearch';
+import { ensureToolCallerAllowed } from './runner/toolCaller';
 import {
   getSerializedApplyPatchToolPlaceholder,
   getSerializedComputerToolPlaceholder,
@@ -93,8 +94,9 @@ import {
  * - 1.11: Allows null maxTurns to persist runs without a turn limit.
  * - 1.12: Adds optional missing function tool calls to processed responses.
  * - 1.13: Adds optional SDK-only customData on tool output run items.
+ * - 1.14: Adds Programmatic Tool Calling program items, outputs, and caller linkage.
  */
-export const CURRENT_SCHEMA_VERSION = '1.13' as const;
+export const CURRENT_SCHEMA_VERSION = '1.14' as const;
 const SUPPORTED_SCHEMA_VERSIONS = [
   '1.0',
   '1.1',
@@ -109,6 +111,7 @@ const SUPPORTED_SCHEMA_VERSIONS = [
   '1.10',
   '1.11',
   '1.12',
+  '1.13',
   CURRENT_SCHEMA_VERSION,
 ] as const;
 type SupportedSchemaVersion = (typeof SUPPORTED_SCHEMA_VERSIONS)[number];
@@ -205,7 +208,8 @@ const itemSchema = z.discriminatedUnion('type', [
     type: z.literal('tool_call_output_item'),
     rawItem: protocol.FunctionCallResultItem.or(protocol.ComputerCallResultItem)
       .or(protocol.ShellCallResultItem)
-      .or(protocol.ApplyPatchCallResultItem),
+      .or(protocol.ApplyPatchCallResultItem)
+      .or(protocol.ProgramCallResultItem),
     agent: serializedAgentSchema,
     output: z.string(),
     customData: z.record(z.string(), z.any()).optional(),
@@ -333,6 +337,7 @@ const serializedProcessedResponseSchema = z.object({
             arguments: z.string().optional(),
             status: z.string().optional(),
             output: z.string().optional(),
+            caller: protocol.ToolCaller.optional(),
             // this always exists but marked as optional for early version compatibility; when releasing 1.0, we can remove the nullable and optional
             providerData: z.record(z.string(), z.any()).nullable().optional(),
           }),
@@ -1067,6 +1072,10 @@ async function buildRunStateFromString<
     currentSchemaVersion as SupportedSchemaVersion,
     stateJson,
   );
+  assertSchemaVersionSupportsProgrammaticToolCalling(
+    currentSchemaVersion as SupportedSchemaVersion,
+    stateJson,
+  );
   return buildRunStateFromJson(initialAgent, stateJson, options);
 }
 
@@ -1080,6 +1089,7 @@ function assertSchemaVersionSupportsToolSearch(
     schemaVersion === '1.10' ||
     schemaVersion === '1.11' ||
     schemaVersion === '1.12' ||
+    schemaVersion === '1.13' ||
     schemaVersion === CURRENT_SCHEMA_VERSION
   ) {
     return;
@@ -1098,7 +1108,7 @@ function assertSchemaVersionSupportsCustomData(
   schemaVersion: SupportedSchemaVersion,
   stateJson: z.infer<typeof SerializedRunState>,
 ): void {
-  if (schemaVersion === CURRENT_SCHEMA_VERSION) {
+  if (schemaVersion === '1.13' || schemaVersion === CURRENT_SCHEMA_VERSION) {
     return;
   }
 
@@ -1118,7 +1128,122 @@ function schemaVersionSupportsAgentIdentity(
     schemaVersion === '1.10' ||
     schemaVersion === '1.11' ||
     schemaVersion === '1.12' ||
+    schemaVersion === '1.13' ||
     schemaVersion === CURRENT_SCHEMA_VERSION
+  );
+}
+
+function assertSchemaVersionSupportsProgrammaticToolCalling(
+  schemaVersion: SupportedSchemaVersion,
+  stateJson: z.infer<typeof SerializedRunState>,
+): void {
+  if (schemaVersion === CURRENT_SCHEMA_VERSION) {
+    return;
+  }
+
+  if (!containsProgrammaticToolCallingState(stateJson)) {
+    return;
+  }
+
+  throw new UserError(
+    `Run state schema version ${schemaVersion} does not support Programmatic Tool Calling items. Please reserialize the run state with schema ${CURRENT_SCHEMA_VERSION}.`,
+  );
+}
+
+function containsProgrammaticToolCallingState(
+  stateJson: z.infer<typeof SerializedRunState>,
+): boolean {
+  return (
+    containsProgrammaticToolCallingProtocolItems(stateJson.originalInput) ||
+    stateJson.modelResponses.some(
+      containsProgrammaticToolCallingInModelResponse,
+    ) ||
+    containsProgrammaticToolCallingInModelResponse(
+      stateJson.lastModelResponse,
+    ) ||
+    containsProgrammaticToolCallingRunItems(stateJson.generatedItems) ||
+    containsProgrammaticToolCallingInProcessedResponse(
+      stateJson.lastProcessedResponse,
+    )
+  );
+}
+
+function containsProgrammaticToolCallingInModelResponse(
+  modelResponse: z.infer<typeof modelResponseSchema> | undefined,
+): boolean {
+  return Boolean(
+    modelResponse?.output.some(isProgrammaticToolCallingProtocolItem),
+  );
+}
+
+function containsProgrammaticToolCallingRunItems(
+  items: z.infer<typeof itemSchema>[] | undefined,
+): boolean {
+  return Boolean(
+    items?.some((item) => isProgrammaticToolCallingProtocolItem(item.rawItem)),
+  );
+}
+
+function containsProgrammaticToolCallingProtocolItems(
+  items: string | protocol.ModelItem[],
+): boolean {
+  return Array.isArray(items)
+    ? items.some(isProgrammaticToolCallingProtocolItem)
+    : false;
+}
+
+function containsProgrammaticToolCallingInProcessedResponse(
+  processedResponse:
+    z.infer<typeof serializedProcessedResponseSchema> | undefined,
+): boolean {
+  if (!processedResponse) {
+    return false;
+  }
+
+  return (
+    containsProgrammaticToolCallingRunItems(processedResponse.newItems) ||
+    processedResponse.functions.some(({ toolCall }) =>
+      isProgrammaticToolCallingProtocolItem(toolCall),
+    ) ||
+    (processedResponse.functionToolsNotFound ?? []).some(({ toolCall }) =>
+      isProgrammaticToolCallingProtocolItem(toolCall),
+    ) ||
+    (processedResponse.shellActions ?? []).some(({ toolCall }) =>
+      isProgrammaticToolCallingProtocolItem(toolCall),
+    ) ||
+    (processedResponse.applyPatchActions ?? []).some(({ toolCall }) =>
+      isProgrammaticToolCallingProtocolItem(toolCall),
+    )
+  );
+}
+
+function isProgrammaticToolCallingProtocolItem(value: unknown): boolean {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const item = value as {
+    type?: unknown;
+    caller?: { type?: unknown; callerId?: unknown };
+  };
+  if (item.type === 'program' || item.type === 'program_output') {
+    return true;
+  }
+
+  if (
+    item.type !== 'function_call' &&
+    item.type !== 'function_call_result' &&
+    item.type !== 'shell_call' &&
+    item.type !== 'shell_call_output' &&
+    item.type !== 'apply_patch_call' &&
+    item.type !== 'apply_patch_call_output' &&
+    item.type !== 'hosted_tool_call'
+  ) {
+    return false;
+  }
+
+  return (
+    item.caller?.type === 'program' && typeof item.caller.callerId === 'string'
   );
 }
 
@@ -2104,6 +2229,16 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
       .filter((tool): tool is ApplyPatchTool => tool.type === 'apply_patch')
       .map((tool) => [tool.name, tool]),
   );
+  const mcpTools = new Map(
+    allTools
+      .filter(
+        (tool): tool is HostedMCPTool =>
+          tool.type === 'hosted_tool' &&
+          tool.name === 'hosted_mcp' &&
+          tool.providerData?.type === 'mcp',
+      )
+      .map((tool) => [tool.providerData.server_label, tool]),
+  );
   const handoffs = new Map(
     currentAgent.handoffs.map((entry) => {
       if (entry instanceof Agent) {
@@ -2124,9 +2259,17 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
         throw new UserError(`Handoff ${handoff.handoff.toolName} not found`);
       }
 
+      const resolvedHandoff = handoffs.get(handoff.handoff.toolName)!;
+      ensureToolCallerAllowed(
+        handoff.toolCall as protocol.FunctionCallItem,
+        undefined,
+        resolvedHandoff.toolName,
+        currentAgent,
+      );
+
       return {
         toolCall: handoff.toolCall,
-        handoff: handoffs.get(handoff.handoff.toolName)!,
+        handoff: resolvedHandoff,
       };
     }),
     functions: await Promise.all(
@@ -2147,6 +2290,13 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
         if (!resolvedTool) {
           throw new UserError(`Tool ${toolIdentity} not found`);
         }
+
+        ensureToolCallerAllowed(
+          functionCall.toolCall as protocol.FunctionCallItem,
+          resolvedTool.allowedCallers,
+          getFunctionToolQualifiedName(resolvedTool) ?? resolvedTool.name,
+          currentAgent,
+        );
 
         return {
           toolCall: functionCall.toolCall,
@@ -2194,6 +2344,13 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
           throw new UserError(`Shell tool ${toolName} not found`);
         }
 
+        ensureToolCallerAllowed(
+          shellAction.toolCall as protocol.ShellCallItem,
+          shellTool.allowedCallers,
+          shellTool.name,
+          currentAgent,
+        );
+
         return {
           toolCall: shellAction.toolCall,
           shell: shellTool,
@@ -2217,6 +2374,13 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
         throw new UserError(`Apply patch tool ${toolName} not found`);
       }
 
+      ensureToolCallerAllowed(
+        applyPatchAction.toolCall as protocol.ApplyPatchCallItem,
+        applyPatchTool.allowedCallers,
+        applyPatchTool.name,
+        currentAgent,
+      );
+
       return {
         toolCall: applyPatchAction.toolCall,
         applyPatch: applyPatchTool,
@@ -2224,14 +2388,39 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
     }),
     mcpApprovalRequests: (
       serializedProcessedResponse.mcpApprovalRequests ?? []
-    ).map((approvalRequest) => ({
-      requestItem: new RunToolApprovalItem(
-        approvalRequest.requestItem
-          .rawItem as unknown as protocol.HostedToolCallItem,
+    ).map((approvalRequest) => {
+      const rawItem = approvalRequest.requestItem
+        .rawItem as unknown as protocol.HostedToolCallItem;
+      const rawServerLabel = rawItem.providerData?.server_label;
+      const serializedServerLabel =
+        approvalRequest.mcpTool.providerData.server_label;
+      const serverLabel =
+        typeof rawServerLabel === 'string'
+          ? rawServerLabel
+          : typeof serializedServerLabel === 'string'
+            ? serializedServerLabel
+            : undefined;
+      if (!serverLabel) {
+        throw new UserError('MCP approval request is missing a server label');
+      }
+
+      const mcpTool = mcpTools.get(serverLabel);
+      if (!mcpTool) {
+        throw new UserError(`MCP tool ${serverLabel} not found`);
+      }
+
+      ensureToolCallerAllowed(
+        rawItem,
+        mcpTool.providerData.allowed_callers,
+        serverLabel,
         currentAgent,
-      ),
-      mcpTool: approvalRequest.mcpTool as unknown as HostedMCPTool,
-    })),
+      );
+
+      return {
+        requestItem: new RunToolApprovalItem(rawItem, currentAgent),
+        mcpTool,
+      };
+    }),
   };
 
   return {

--- a/packages/agents-core/src/runner/items.ts
+++ b/packages/agents-core/src/runner/items.ts
@@ -2,8 +2,12 @@ import { RunItem } from '../items';
 import { AgentInputItem } from '../types';
 import { serializeBinary } from '../utils/binary';
 import {
+  getToolResultCorrelationForCall,
+  getToolResultCorrelationForResult,
+  getToolResultCorrelationKey,
   getSimpleToolResultTypeForCall,
   isSimpleToolResultType,
+  type ToolResultCorrelation,
 } from './toolResultCorrelation';
 
 export type AgentInputItemPool = Map<string, AgentInputItem[]>;
@@ -172,6 +176,21 @@ function collectCompletedCallIdsByResultType(
   return completed;
 }
 
+function collectProgramCallIds(items: AgentInputItem[]): Set<string> {
+  const callIds = new Set<string>();
+
+  for (const item of items) {
+    if (!item || typeof item !== 'object' || item.type !== 'program') {
+      continue;
+    }
+    if (typeof item.callId === 'string') {
+      callIds.add(item.callId);
+    }
+  }
+
+  return callIds;
+}
+
 function isPendingHostedShellCall(item: AgentInputItem): boolean {
   if (!item || typeof item !== 'object' || item.type !== 'shell_call') {
     return false;
@@ -181,19 +200,147 @@ function isPendingHostedShellCall(item: AgentInputItem): boolean {
   return status === undefined || status === 'in_progress';
 }
 
+function getProgramCallerId(item: AgentInputItem): string | undefined {
+  if (!item || typeof item !== 'object' || !('caller' in item)) {
+    return undefined;
+  }
+  const caller = (item as { caller?: unknown }).caller;
+  if (!caller || typeof caller !== 'object') {
+    return undefined;
+  }
+  const candidate = caller as { type?: unknown; callerId?: unknown };
+  return candidate.type === 'program' && typeof candidate.callerId === 'string'
+    ? candidate.callerId
+    : undefined;
+}
+
+function getProgramOwnedCorrelationKey(
+  programCallId: string,
+  correlation: ToolResultCorrelation | undefined,
+): string | undefined {
+  return correlation
+    ? JSON.stringify([programCallId, getToolResultCorrelationKey(correlation)])
+    : undefined;
+}
+
+function collectProgramOwnedCallKeys(items: AgentInputItem[]): Set<string> {
+  const callKeys = new Set<string>();
+
+  for (const item of items) {
+    const programCallId = getProgramCallerId(item);
+    if (!programCallId) {
+      continue;
+    }
+    const key = getProgramOwnedCorrelationKey(
+      programCallId,
+      getToolResultCorrelationForCall(item),
+    );
+    if (key) {
+      callKeys.add(key);
+    }
+  }
+
+  return callKeys;
+}
+
+function hasRetainedProgramOwnedItem(
+  items: AgentInputItem[],
+  programCallId: string,
+  pruningIndexes?: Set<number>,
+): boolean {
+  const retainedCallKeys = new Set<string>();
+  const retainedResultKeys = new Set<string>();
+
+  for (const [index, item] of items.entries()) {
+    if (getProgramCallerId(item) !== programCallId) {
+      continue;
+    }
+
+    const result = getToolResultCorrelationForResult(item);
+    if (
+      !(pruningIndexes?.has(index) ?? false) &&
+      (isPendingHostedShellCall(item) ||
+        (item &&
+          typeof item === 'object' &&
+          item.type === 'hosted_tool_call' &&
+          !result))
+    ) {
+      return true;
+    }
+
+    const call = getToolResultCorrelationForCall(item);
+    if (call) {
+      retainedCallKeys.add(getToolResultCorrelationKey(call));
+    }
+    if (result) {
+      retainedResultKeys.add(getToolResultCorrelationKey(result));
+    }
+  }
+
+  return [...retainedCallKeys].some((key) => retainedResultKeys.has(key));
+}
+
 export function dropOrphanToolCalls(
   items: AgentInputItem[],
   options?: { pruningIndexes?: Set<number> },
 ): AgentInputItem[] {
   const pruningIndexes = options?.pruningIndexes;
   const completedByResultType = collectCompletedCallIdsByResultType(items);
+  const programCallIds = collectProgramCallIds(items);
+  const programOwnedCallKeys = collectProgramOwnedCallKeys(items);
   const droppedIndexes = new Set<number>();
+  const activeProgramCallIds = new Set<string>();
+  const orphanProgramCallIds = new Set<string>();
+
+  for (const [index, item] of items.entries()) {
+    if (pruningIndexes && !pruningIndexes.has(index)) {
+      continue;
+    }
+    if (!item || typeof item !== 'object' || item.type !== 'program') {
+      continue;
+    }
+    if (
+      completedByResultType.get('program_output')?.has(item.callId) ??
+      false
+    ) {
+      continue;
+    }
+
+    const hasRetainedOwnedItem = hasRetainedProgramOwnedItem(
+      items,
+      item.callId,
+      pruningIndexes,
+    );
+    if (hasRetainedOwnedItem) {
+      activeProgramCallIds.add(item.callId);
+    } else {
+      orphanProgramCallIds.add(item.callId);
+    }
+  }
 
   const filtered = items.filter((item, index) => {
-    if (pruningIndexes && !pruningIndexes.has(index)) {
+    if (!item || typeof item !== 'object') {
       return true;
     }
-    if (!item || typeof item !== 'object') {
+    const programCallerId = getProgramCallerId(item);
+    if (programCallerId) {
+      if (
+        !programCallIds.has(programCallerId) ||
+        orphanProgramCallIds.has(programCallerId)
+      ) {
+        droppedIndexes.add(index);
+        return false;
+      }
+      const resultKey = getProgramOwnedCorrelationKey(
+        programCallerId,
+        getToolResultCorrelationForResult(item),
+      );
+      if (resultKey && !programOwnedCallKeys.has(resultKey)) {
+        droppedIndexes.add(index);
+        return false;
+      }
+    }
+    if (pruningIndexes && !pruningIndexes.has(index)) {
       return true;
     }
     const type = (item as { type?: unknown }).type;
@@ -201,11 +348,18 @@ export function dropOrphanToolCalls(
     if (typeof type !== 'string' || typeof callId !== 'string') {
       return true;
     }
+    if (type === 'program_output' && !programCallIds.has(callId)) {
+      droppedIndexes.add(index);
+      return false;
+    }
     const resultType = getSimpleToolResultTypeForCall(type);
     if (!resultType) {
       return true;
     }
     if (isPendingHostedShellCall(item)) {
+      return true;
+    }
+    if (type === 'program' && activeProgramCallIds.has(callId)) {
       return true;
     }
     if (completedByResultType.get(resultType)?.has(callId) ?? false) {

--- a/packages/agents-core/src/runner/mcpApprovals.ts
+++ b/packages/agents-core/src/runner/mcpApprovals.ts
@@ -46,15 +46,13 @@ export async function handleHostedMcpApprovals<TContext>({
     }
 
     const providerData = rawItem.providerData as
-      | ProviderData.HostedMCPApprovalRequest
-      | undefined;
+      ProviderData.HostedMCPApprovalRequest | undefined;
     if (!providerData) {
       continue;
     }
 
     const toolData = approvalRequest.mcpTool.providerData as
-      | ProviderData.HostedMCPTool<TContext>
-      | undefined;
+      ProviderData.HostedMCPTool<TContext> | undefined;
     const approvalRequestId = rawItem.id ?? providerData.id;
 
     if (toolData?.on_approval) {
@@ -73,6 +71,7 @@ export async function handleHostedMcpApprovals<TContext>({
             type: 'hosted_tool_call',
             name: 'mcp_approval_response',
             providerData: approvalResponseData,
+            ...(rawItem.caller ? { caller: rawItem.caller } : {}),
           },
           agent as Agent<unknown, 'text'>,
         ),
@@ -100,6 +99,7 @@ export async function handleHostedMcpApprovals<TContext>({
             type: 'hosted_tool_call',
             name: 'mcp_approval_response',
             providerData: approvalResponseData,
+            ...(rawItem.caller ? { caller: rawItem.caller } : {}),
           },
           agent as Agent<unknown, 'text'>,
         ),

--- a/packages/agents-core/src/runner/modelOutputs.ts
+++ b/packages/agents-core/src/runner/modelOutputs.ts
@@ -20,8 +20,10 @@ import {
   ComputerTool,
   FunctionTool,
   HostedMCPTool,
+  HostedTool,
   ShellTool,
   Tool,
+  type ToolAllowedCaller,
   getClientToolSearchExecutor,
   getToolSearchRuntimeToolKey,
 } from '../tool';
@@ -58,6 +60,7 @@ import {
   executeCustomClientToolSearch,
   getClientToolSearchHelper,
 } from './toolSearch';
+import { ensureToolCallerAllowed } from './toolCaller';
 
 function ensureToolAvailable<T>(
   tool: T | undefined,
@@ -74,9 +77,117 @@ function ensureToolAvailable<T>(
   return tool;
 }
 
+function ensureProgrammaticToolCallingAvailable<TContext>(
+  output: protocol.ProgramCallItem,
+  tools: Tool<TContext>[],
+  agent: Agent<any, any>,
+  options: ModelResponseProcessingOptions,
+): void {
+  const programmaticTool = tools.find(
+    (tool) =>
+      tool.type === 'hosted_tool' &&
+      tool.providerData?.type === 'programmatic_tool_calling',
+  );
+  if (programmaticTool || options.allowPromptSuppliedTools === true) {
+    return;
+  }
+  ensureToolAvailable(
+    programmaticTool,
+    `Model produced a program item without programmaticToolCallingTool() in Agent (${agent.name}).`,
+    {
+      agent_name: agent.name,
+      tool_call_id: output.callId,
+    },
+  );
+}
+
+type ModelResponseProcessingOptions = {
+  allowPromptSuppliedTools?: boolean;
+};
+
+const MCP_HOSTED_CALL_TYPES = new Set([
+  'mcp_call',
+  'mcp_list_tools',
+  'mcp_approval_request',
+  'mcp_approval_response',
+]);
+
+function ensureHostedToolCallAllowed<TContext>(
+  output: protocol.HostedToolCallItem,
+  tools: Tool<TContext>[],
+  mcpToolMap: Map<string, HostedMCPTool>,
+  loadedToolNames: Set<string>,
+  agent: Agent<any, any>,
+): void {
+  const providerType = output.providerData?.type;
+  const isCodeInterpreterCall =
+    providerType === 'code_interpreter_call' ||
+    providerType === 'code_interpreter' ||
+    output.name === 'code_interpreter_call' ||
+    output.name === 'code_interpreter';
+  if (isCodeInterpreterCall) {
+    const codeInterpreterTool = tools.find(
+      (tool): tool is HostedTool =>
+        tool.type === 'hosted_tool' &&
+        tool.providerData?.type === 'code_interpreter',
+    );
+    if (!codeInterpreterTool) {
+      return;
+    }
+
+    ensureToolCallerAllowed(
+      output,
+      codeInterpreterTool.providerData?.allowed_callers,
+      codeInterpreterTool.name,
+      agent,
+    );
+    return;
+  }
+
+  if (
+    !MCP_HOSTED_CALL_TYPES.has(providerType) &&
+    !MCP_HOSTED_CALL_TYPES.has(output.name)
+  ) {
+    return;
+  }
+
+  const serverLabel = output.providerData?.server_label;
+  if (typeof serverLabel !== 'string') {
+    return;
+  }
+  const mcpTool = mcpToolMap.get(serverLabel);
+  if (!mcpTool) {
+    return;
+  }
+  ensureToolCallerAllowed(
+    output,
+    mcpTool.providerData.allowed_callers,
+    serverLabel,
+    agent,
+  );
+  if (
+    mcpTool.providerData.defer_loading !== true ||
+    loadedToolNames.has(serverLabel)
+  ) {
+    return;
+  }
+
+  const message = `Model produced deferred MCP call ${serverLabel} before it was loaded via tool_search.`;
+  addErrorToCurrentSpan({
+    message,
+    data: {
+      agent_name: agent.name,
+      mcp_server_label: serverLabel,
+      tool_call_id: output.id,
+    },
+  });
+  throw new ModelBehaviorError(message);
+}
+
 function handleToolCallAction<
   TTool extends {
     name: string;
+    allowedCallers?: readonly ToolAllowedCaller[];
   },
   TAction,
 >({
@@ -101,6 +212,12 @@ function handleToolCallAction<
   buildAction: (resolvedTool: TTool) => TAction;
 }) {
   const resolvedTool = ensureToolAvailable(tool, errorMessage, errorData);
+  ensureToolCallerAllowed(
+    output,
+    resolvedTool.allowedCallers,
+    resolvedTool.name,
+    agent,
+  );
   items.push(new RunToolCallItem(output, agent));
   toolsUsed.push(resolvedTool.name);
   actions.push(buildAction(resolvedTool));
@@ -658,6 +775,7 @@ export function processModelResponse<TContext>(
   handoffs: Handoff<any, any>[],
   priorItems: Array<RunItem | AgentInputItem> = [],
   toolNotFoundBehavior: ToolNotFoundBehavior = 'raise_error',
+  processingOptions: ModelResponseProcessingOptions = {},
 ): ProcessedResponse<TContext> {
   const items: RunItem[] = [];
   const runHandoffs: ToolRunHandoff[] = [];
@@ -737,7 +855,25 @@ export function processModelResponse<TContext>(
       addHostedMcpToolsFromToolSearchOutput(output, mcpToolMap, {
         preserveExistingServerLabels: originalMcpServerLabels,
       });
+    } else if (output.type === 'program') {
+      ensureProgrammaticToolCallingAvailable(
+        output,
+        tools,
+        agent,
+        processingOptions,
+      );
+      items.push(new RunToolCallItem(output, agent));
+      toolsUsed.push('programmatic_tool_calling');
+    } else if (output.type === 'program_output') {
+      items.push(new RunToolCallOutputItem(output, agent, output.output));
     } else if (output.type === 'hosted_tool_call') {
+      ensureHostedToolCallAllowed(
+        output,
+        tools,
+        mcpToolMap,
+        loadedDeferredToolState.loadedToolNames,
+        agent,
+      );
       items.push(new RunToolCallItem(output, agent));
       const toolName = output.name;
       toolsUsed.push(toolName);
@@ -760,7 +896,6 @@ export function processModelResponse<TContext>(
           });
           throw new ModelBehaviorError(message);
         }
-
         // Do this approval later:
         // We support both onApproval callback (like the Python SDK does) and HITL patterns.
         const approvalItem = new RunToolApprovalItem(
@@ -771,6 +906,7 @@ export function processModelResponse<TContext>(
             id: providerData.id,
             status: 'in_progress',
             providerData,
+            ...(output.caller ? { caller: output.caller } : {}),
           },
           agent,
         );
@@ -806,6 +942,12 @@ export function processModelResponse<TContext>(
         shellTool,
         'Model produced shell action without a shell tool.',
         { agent_name: agent.name },
+      );
+      ensureToolCallerAllowed(
+        output,
+        resolvedShellTool.allowedCallers,
+        resolvedShellTool.name,
+        agent,
       );
       items.push(new RunToolCallItem(output, agent));
       toolsUsed.push(resolvedShellTool.name);
@@ -883,6 +1025,12 @@ export function processModelResponse<TContext>(
         functionToolsNotFound,
       );
     } else if (resolved.type === 'handoff') {
+      ensureToolCallerAllowed(
+        output,
+        undefined,
+        resolved.handoff.toolName,
+        agent,
+      );
       recordHandoffRequest(
         output,
         resolved.handoff,
@@ -892,6 +1040,12 @@ export function processModelResponse<TContext>(
         runHandoffs,
       );
     } else {
+      ensureToolCallerAllowed(
+        output,
+        resolved.tool.allowedCallers,
+        getFunctionToolQualifiedName(resolved.tool) ?? resolved.tool.name,
+        agent,
+      );
       ensureDeferredFunctionToolLoaded(
         output,
         resolved.tool,
@@ -947,6 +1101,7 @@ export async function processModelResponseAsync<TContext>(
   state: RunState<TContext, Agent<any, any>>,
   priorItems: Array<RunItem | AgentInputItem> = [],
   toolNotFoundBehavior: ToolNotFoundBehavior = 'raise_error',
+  processingOptions: ModelResponseProcessingOptions = {},
 ): Promise<ProcessedResponse<TContext>> {
   const clientToolSearchTool = getClientToolSearchHelper(tools);
   const hasCustomClientToolSearchExecutor = Boolean(
@@ -967,6 +1122,7 @@ export async function processModelResponseAsync<TContext>(
       handoffs,
       priorItems,
       toolNotFoundBehavior,
+      processingOptions,
     );
   }
 
@@ -1064,7 +1220,25 @@ export async function processModelResponseAsync<TContext>(
       addHostedMcpToolsFromToolSearchOutput(output, mcpToolMap, {
         preserveExistingServerLabels: originalMcpServerLabels,
       });
+    } else if (output.type === 'program') {
+      ensureProgrammaticToolCallingAvailable(
+        output,
+        availableTools,
+        agent,
+        processingOptions,
+      );
+      items.push(new RunToolCallItem(output, agent));
+      toolsUsed.push('programmatic_tool_calling');
+    } else if (output.type === 'program_output') {
+      items.push(new RunToolCallOutputItem(output, agent, output.output));
     } else if (output.type === 'hosted_tool_call') {
+      ensureHostedToolCallAllowed(
+        output,
+        availableTools,
+        mcpToolMap,
+        loadedDeferredToolState.loadedToolNames,
+        agent,
+      );
       items.push(new RunToolCallItem(output, agent));
       const toolName = output.name;
       toolsUsed.push(toolName);
@@ -1086,7 +1260,6 @@ export async function processModelResponseAsync<TContext>(
           });
           throw new ModelBehaviorError(message);
         }
-
         const approvalItem = new RunToolApprovalItem(
           {
             type: 'hosted_tool_call',
@@ -1094,6 +1267,7 @@ export async function processModelResponseAsync<TContext>(
             id: providerData.id,
             status: 'in_progress',
             providerData,
+            ...(output.caller ? { caller: output.caller } : {}),
           },
           agent,
         );
@@ -1127,6 +1301,12 @@ export async function processModelResponseAsync<TContext>(
         shellTool,
         'Model produced shell action without a shell tool.',
         { agent_name: agent.name },
+      );
+      ensureToolCallerAllowed(
+        output,
+        resolvedShellTool.allowedCallers,
+        resolvedShellTool.name,
+        agent,
       );
       items.push(new RunToolCallItem(output, agent));
       toolsUsed.push(resolvedShellTool.name);
@@ -1200,6 +1380,12 @@ export async function processModelResponseAsync<TContext>(
         functionToolsNotFound,
       );
     } else if (resolved.type === 'handoff') {
+      ensureToolCallerAllowed(
+        output,
+        undefined,
+        resolved.handoff.toolName,
+        agent,
+      );
       recordHandoffRequest(
         output,
         resolved.handoff,
@@ -1209,6 +1395,12 @@ export async function processModelResponseAsync<TContext>(
         runHandoffs,
       );
     } else {
+      ensureToolCallerAllowed(
+        output,
+        resolved.tool.allowedCallers,
+        getFunctionToolQualifiedName(resolved.tool) ?? resolved.tool.name,
+        agent,
+      );
       ensureDeferredFunctionToolLoaded(
         output,
         resolved.tool,

--- a/packages/agents-core/src/runner/streamReconciliation.ts
+++ b/packages/agents-core/src/runner/streamReconciliation.ts
@@ -1,23 +1,40 @@
+import { randomUUID } from '@openai/agents-core/_shims';
+
 import type { ModelRequest, ModelResponse } from '../model';
 import type {
+  ApplyPatchCallResultItem,
   FunctionCallItem,
   FunctionCallResultItem,
+  ProgramCallResultItem,
+  ShellCallResultItem,
   StreamEvent,
+  ToolCaller,
 } from '../types/protocol';
 
 type PendingStreamedFunctionCall = Pick<
   FunctionCallItem,
-  'callId' | 'name' | 'namespace'
+  'callId' | 'name' | 'namespace' | 'caller'
 >;
+
+type PendingStreamedToolCall = {
+  callId: string;
+  caller?: ToolCaller;
+};
 
 export type StreamAbortReconciliationState = {
   responseId?: string;
   pendingFunctionCalls: Map<string, PendingStreamedFunctionCall>;
+  pendingShellCalls: Map<string, PendingStreamedToolCall>;
+  pendingApplyPatchCalls: Map<string, PendingStreamedToolCall>;
+  pendingProgramCalls: Map<string, string>;
 };
 
 export function createStreamAbortReconciliationState(): StreamAbortReconciliationState {
   return {
     pendingFunctionCalls: new Map(),
+    pendingShellCalls: new Map(),
+    pendingApplyPatchCalls: new Map(),
+    pendingProgramCalls: new Map(),
   };
 }
 
@@ -27,6 +44,9 @@ export function recordStreamEventForAbortReconciliation(
 ): void {
   if (event.type === 'response_done') {
     state.pendingFunctionCalls.clear();
+    state.pendingShellCalls.clear();
+    state.pendingApplyPatchCalls.clear();
+    state.pendingProgramCalls.clear();
     state.responseId = event.response.id;
     return;
   }
@@ -46,6 +66,17 @@ export function recordStreamEventForAbortReconciliation(
   }
 
   if (
+    rawEvent.type === 'response.output_item.added' &&
+    isRecord(rawEvent.item) &&
+    rawEvent.item.type === 'program_output' &&
+    typeof rawEvent.item.call_id === 'string' &&
+    typeof rawEvent.item.id === 'string'
+  ) {
+    state.pendingProgramCalls.set(rawEvent.item.call_id, rawEvent.item.id);
+    return;
+  }
+
+  if (
     rawEvent.type !== 'response.output_item.done' ||
     !isRecord(rawEvent.item)
   ) {
@@ -53,6 +84,19 @@ export function recordStreamEventForAbortReconciliation(
   }
 
   const item = rawEvent.item;
+  const caller = getToolCaller(item);
+  if (item.type === 'program' && typeof item.call_id === 'string') {
+    if (!state.pendingProgramCalls.has(item.call_id)) {
+      state.pendingProgramCalls.set(item.call_id, generateProgramOutputId());
+    }
+    return;
+  }
+
+  if (item.type === 'program_output' && typeof item.call_id === 'string') {
+    state.pendingProgramCalls.delete(item.call_id);
+    return;
+  }
+
   if (item.type === 'function_call' && typeof item.call_id === 'string') {
     state.pendingFunctionCalls.set(item.call_id, {
       callId: item.call_id,
@@ -60,6 +104,27 @@ export function recordStreamEventForAbortReconciliation(
       ...(typeof item.namespace === 'string'
         ? { namespace: item.namespace }
         : {}),
+      ...(caller ? { caller } : {}),
+    });
+    return;
+  }
+
+  if (
+    item.type === 'shell_call' &&
+    typeof item.call_id === 'string' &&
+    isClientOwnedShellCall(item)
+  ) {
+    state.pendingShellCalls.set(item.call_id, {
+      callId: item.call_id,
+      ...(caller ? { caller } : {}),
+    });
+    return;
+  }
+
+  if (item.type === 'apply_patch_call' && typeof item.call_id === 'string') {
+    state.pendingApplyPatchCalls.set(item.call_id, {
+      callId: item.call_id,
+      ...(caller ? { caller } : {}),
     });
     return;
   }
@@ -69,22 +134,87 @@ export function recordStreamEventForAbortReconciliation(
     typeof item.call_id === 'string'
   ) {
     state.pendingFunctionCalls.delete(item.call_id);
+    return;
+  }
+
+  if (item.type === 'shell_call_output' && typeof item.call_id === 'string') {
+    state.pendingShellCalls.delete(item.call_id);
+    return;
+  }
+
+  if (
+    item.type === 'apply_patch_call_output' &&
+    typeof item.call_id === 'string'
+  ) {
+    state.pendingApplyPatchCalls.delete(item.call_id);
   }
 }
 
 export function buildAbortReconciliationInput(
   state: StreamAbortReconciliationState,
-): FunctionCallResultItem[] {
-  return Array.from(state.pendingFunctionCalls.values(), (toolCall) => ({
-    type: 'function_call_result',
-    name: toolCall.name,
-    ...(typeof toolCall.namespace === 'string'
-      ? { namespace: toolCall.namespace }
-      : {}),
-    callId: toolCall.callId,
-    status: 'incomplete',
-    output: { type: 'text', text: 'aborted' },
-  }));
+): (
+  | FunctionCallResultItem
+  | ShellCallResultItem
+  | ApplyPatchCallResultItem
+  | ProgramCallResultItem
+)[] {
+  const functionOutputs = Array.from(
+    state.pendingFunctionCalls.values(),
+    (toolCall): FunctionCallResultItem => ({
+      type: 'function_call_result',
+      name: toolCall.name,
+      ...(typeof toolCall.namespace === 'string'
+        ? { namespace: toolCall.namespace }
+        : {}),
+      callId: toolCall.callId,
+      status: 'incomplete',
+      output: { type: 'text', text: 'aborted' },
+      ...(toolCall.caller ? { caller: toolCall.caller } : {}),
+    }),
+  );
+  const shellOutputs = Array.from(
+    state.pendingShellCalls.values(),
+    (toolCall): ShellCallResultItem => ({
+      type: 'shell_call_output',
+      callId: toolCall.callId,
+      status: 'incomplete',
+      output: [
+        {
+          stdout: '',
+          stderr: 'aborted',
+          outcome: { type: 'timeout' },
+        },
+      ],
+      ...(toolCall.caller ? { caller: toolCall.caller } : {}),
+    }),
+  );
+  const applyPatchOutputs = Array.from(
+    state.pendingApplyPatchCalls.values(),
+    (toolCall): ApplyPatchCallResultItem => ({
+      type: 'apply_patch_call_output',
+      callId: toolCall.callId,
+      status: 'failed',
+      output: 'aborted',
+      ...(toolCall.caller ? { caller: toolCall.caller } : {}),
+    }),
+  );
+  const programOutputs = Array.from(
+    state.pendingProgramCalls,
+    ([callId, id]): ProgramCallResultItem => ({
+      type: 'program_output',
+      id,
+      callId,
+      status: 'incomplete',
+      output: 'aborted',
+    }),
+  );
+
+  return [
+    ...functionOutputs,
+    ...shellOutputs,
+    ...applyPatchOutputs,
+    ...programOutputs,
+  ];
 }
 
 export function getAbortReconciliationPreviousResponseId(
@@ -100,7 +230,12 @@ export function getAbortReconciliationPreviousResponseId(
 export function shouldReconcileStreamAbort(
   state: StreamAbortReconciliationState,
 ): boolean {
-  return state.pendingFunctionCalls.size > 0;
+  return (
+    state.pendingFunctionCalls.size > 0 ||
+    state.pendingProgramCalls.size > 0 ||
+    state.pendingShellCalls.size > 0 ||
+    state.pendingApplyPatchCalls.size > 0
+  );
 }
 
 export function markAbortReconciliationComplete(
@@ -108,6 +243,9 @@ export function markAbortReconciliationComplete(
   response: ModelResponse | undefined,
 ): void {
   state.pendingFunctionCalls.clear();
+  state.pendingShellCalls.clear();
+  state.pendingApplyPatchCalls.clear();
+  state.pendingProgramCalls.clear();
   if (response?.responseId) {
     state.responseId = response.responseId;
   }
@@ -115,4 +253,31 @@ export function markAbortReconciliationComplete(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+function getToolCaller(item: Record<string, unknown>): ToolCaller | undefined {
+  if (!isRecord(item.caller)) {
+    return undefined;
+  }
+  if (item.caller.type === 'direct') {
+    return { type: 'direct' };
+  }
+  if (
+    item.caller.type === 'program' &&
+    typeof item.caller.caller_id === 'string'
+  ) {
+    return {
+      type: 'program',
+      callerId: item.caller.caller_id,
+    };
+  }
+  return undefined;
+}
+
+function isClientOwnedShellCall(item: Record<string, unknown>): boolean {
+  return !isRecord(item.environment) || item.environment.type === 'local';
+}
+
+function generateProgramOutputId(): string {
+  return `prog_out_${randomUUID().replace(/-/g, '')}`;
 }

--- a/packages/agents-core/src/runner/toolCaller.ts
+++ b/packages/agents-core/src/runner/toolCaller.ts
@@ -1,0 +1,33 @@
+import type { Agent } from '../agent';
+import { ModelBehaviorError } from '../errors';
+import type { ToolAllowedCaller } from '../tool';
+import type * as protocol from '../types/protocol';
+import { addErrorToCurrentSpan } from '../tracing/context';
+
+export function ensureToolCallerAllowed(
+  toolCall: protocol.ToolCallItem,
+  allowedCallers: readonly ToolAllowedCaller[] | undefined,
+  toolName: string,
+  agent: Agent<any, any>,
+): void {
+  const caller: ToolAllowedCaller =
+    'caller' in toolCall && toolCall.caller?.type === 'program'
+      ? 'programmatic'
+      : 'direct';
+  const effectiveAllowedCallers = allowedCallers ?? ['direct'];
+  if (effectiveAllowedCallers.includes(caller)) {
+    return;
+  }
+
+  const message = `Model invoked tool ${toolName} with caller ${caller}, but the tool allows only ${JSON.stringify(effectiveAllowedCallers)}.`;
+  addErrorToCurrentSpan({
+    message,
+    data: {
+      agent_name: agent.name,
+      tool_name: toolName,
+      tool_call_id: 'callId' in toolCall ? toolCall.callId : undefined,
+      tool_caller: caller,
+    },
+  });
+  throw new ModelBehaviorError(message);
+}

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -5,7 +5,13 @@ import {
   setToolCallParentSpanOnDetails,
 } from '../agentToolRunConfig';
 import { consumeAgentToolRunResult } from '../agentToolRunResults';
-import { ToolCallError, ToolTimeoutError, UserError } from '../errors';
+import {
+  InvalidToolInputError,
+  InvalidToolOutputError,
+  ToolCallError,
+  ToolTimeoutError,
+  UserError,
+} from '../errors';
 import { getTransferMessage, HandoffInputData } from '../handoff';
 import {
   RunHandoffCallItem,
@@ -22,11 +28,14 @@ import {
   ComputerSafetyCheck,
   ComputerSafetyCheckResult,
   ComputerToolCustomDataContext,
+  FunctionTool,
   FunctionToolResult,
   FunctionToolCustomDataContext,
+  ToolCallDetails,
   FUNCTION_TOOL_PARSED_INPUT_CALLBACK,
   ApplyPatchToolCustomDataContext,
   invokeFunctionTool,
+  validateFunctionToolOutput,
   resolveComputer,
   Tool,
 } from '../tool';
@@ -148,8 +157,14 @@ function getComputerTraceInputPayload(
 export function getToolCallOutputItem(
   toolCall: protocol.FunctionCallItem,
   output: string | unknown,
+  options?: {
+    outputSchema?: FunctionTool<any, any, any>['outputSchema'];
+  },
 ): FunctionCallResultItem {
-  const maybeStructuredOutputs = normalizeStructuredToolOutputs(output);
+  const hasOutputSchema = typeof options?.outputSchema !== 'undefined';
+  const maybeStructuredOutputs = hasOutputSchema
+    ? null
+    : normalizeStructuredToolOutputs(output);
 
   if (maybeStructuredOutputs) {
     const structuredItems = maybeStructuredOutputs.map(
@@ -165,7 +180,28 @@ export function getToolCallOutputItem(
       callId: toolCall.callId,
       status: 'completed',
       output: structuredItems,
+      ...(toolCall.caller ? { caller: toolCall.caller } : {}),
     };
+  }
+
+  let textOutput: string;
+  if (hasOutputSchema) {
+    try {
+      const serializedOutput = JSON.stringify(output);
+      if (typeof serializedOutput !== 'string') {
+        throw new Error('The output is not a JSON value.');
+      }
+      textOutput = serializedOutput;
+    } catch (error) {
+      throw new InvalidToolOutputError(
+        `Function tool '${toolCall.name}' outputSchema requires a JSON-serializable output.`,
+        undefined,
+        error,
+        { output },
+      );
+    }
+  } else {
+    textOutput = toSmartString(output);
   }
 
   return {
@@ -178,8 +214,9 @@ export function getToolCallOutputItem(
     status: 'completed',
     output: {
       type: 'text',
-      text: toSmartString(output),
+      text: textOutput,
     },
+    ...(toolCall.caller ? { caller: toolCall.caller } : {}),
   };
 }
 
@@ -341,29 +378,83 @@ function buildApprovalRequestResult<TContext>(
   };
 }
 
-function buildParseErrorResult<TContext>(
+function buildFunctionFailureResult<TContext>(
+  deps: FunctionToolCallDeps<TContext>,
+  toolRun: ToolRunFunction<TContext>,
+  output: unknown,
+): FunctionToolResult<TContext> {
+  return {
+    type: 'function_output' as const,
+    tool: toolRun.tool,
+    output,
+    runItem: new RunToolCallOutputItem(
+      getToolCallOutputItem(toolRun.toolCall, output, {
+        outputSchema: toolRun.tool.outputSchema,
+      }),
+      deps.agent,
+      output,
+    ),
+  };
+}
+
+async function resolveFunctionFailureOutput<TContext>(
   deps: FunctionToolCallDeps<TContext>,
   toolRun: ToolRunFunction<TContext>,
   error: Error,
-): FunctionToolResult<TContext> {
-  const errorMessage = `An error occurred while parsing tool arguments. Please try again with valid JSON. Error: ${error.message}`;
-  return {
-    type: 'function_output',
+  legacyOutput: string,
+): Promise<unknown> {
+  if (!toolRun.tool.outputSchema) {
+    return legacyOutput;
+  }
+
+  if (!toolRun.tool.errorFunction) {
+    throw error;
+  }
+
+  const details: ToolCallDetails = { toolCall: toolRun.toolCall };
+  const output = await toolRun.tool.errorFunction(
+    deps.state._context,
+    error,
+    details,
+  );
+  return validateFunctionToolOutput({
     tool: toolRun.tool,
-    output: errorMessage,
-    runItem: new RunToolCallOutputItem(
-      getToolCallOutputItem(toolRun.toolCall, errorMessage),
-      deps.agent,
-      errorMessage,
-    ),
-  };
+    output,
+    runContext: deps.state._context,
+    details,
+  });
+}
+
+async function buildParseErrorResult<TContext>(
+  deps: FunctionToolCallDeps<TContext>,
+  toolRun: ToolRunFunction<TContext>,
+  error: Error,
+): Promise<FunctionToolResult<TContext>> {
+  const errorMessage = `An error occurred while parsing tool arguments. Please try again with valid JSON. Error: ${error.message}`;
+  const parseError = new InvalidToolInputError(
+    `Invalid input for function tool '${getFunctionToolIdentity(toolRun)}'.`,
+    deps.state,
+    error,
+    {
+      runContext: deps.state._context,
+      input: toolRun.toolCall.arguments,
+      details: { toolCall: toolRun.toolCall },
+    },
+  );
+  const output = await resolveFunctionFailureOutput(
+    deps,
+    toolRun,
+    parseError,
+    errorMessage,
+  );
+  return buildFunctionFailureResult(deps, toolRun, output);
 }
 
 async function buildApprovalRejectionResult<TContext>(
   deps: FunctionToolCallDeps<TContext>,
   toolRun: ToolRunFunction<TContext>,
 ): Promise<FunctionToolResult<TContext>> {
-  const { agent, runner, state, toolErrorFormatter } = deps;
+  const { runner, state, toolErrorFormatter } = deps;
   const toolName = getFunctionToolIdentity(toolRun);
   const traceToolName = getFunctionToolTraceName(toolRun);
   return withRunStateToolFunctionSpan(deps, traceToolName, async (span) => {
@@ -386,19 +477,16 @@ async function buildApprovalRejectionResult<TContext>(
       },
     });
 
+    const output = await resolveFunctionFailureOutput(
+      deps,
+      toolRun,
+      new Error(response),
+      response,
+    );
     if (span && runner.config.traceIncludeSensitiveData) {
-      span.spanData.output = response;
+      span.spanData.output = toSmartString(output);
     }
-    return {
-      type: 'function_output' as const,
-      tool: toolRun.tool,
-      output: response,
-      runItem: new RunToolCallOutputItem(
-        getToolCallOutputItem(toolRun.toolCall, response),
-        agent,
-        response,
-      ),
-    };
+    return buildFunctionFailureResult(deps, toolRun, output);
   });
 }
 
@@ -455,21 +543,18 @@ async function handleFunctionApproval<TContext>(
   return buildApprovalRequestResult(deps, toolRun);
 }
 
-function buildInputGuardrailRejectionResult<TContext>(
+async function buildInputGuardrailRejectionResult<TContext>(
   deps: FunctionToolCallDeps<TContext>,
   toolRun: ToolRunFunction<TContext>,
   message: string,
-): FunctionToolResult<TContext> {
-  return {
-    type: 'function_output' as const,
-    tool: toolRun.tool,
-    output: message,
-    runItem: new RunToolCallOutputItem(
-      getToolCallOutputItem(toolRun.toolCall, message),
-      deps.agent,
-      message,
-    ),
-  };
+): Promise<FunctionToolResult<TContext>> {
+  const output = await resolveFunctionFailureOutput(
+    deps,
+    toolRun,
+    new Error(message),
+    message,
+  );
+  return buildFunctionFailureResult(deps, toolRun, output);
 }
 
 async function runFunctionToolInputGuardrails<TContext>({
@@ -528,14 +613,21 @@ async function runApprovedFunctionTool<TContext>(
 
       let toolOutput: unknown;
       let executedInput = parsedInput;
+      let toolDetails: ToolCallDetails = { toolCall: toolRun.toolCall };
+      let shouldValidateToolOutput = false;
       if (inputGuardrailResult.type === 'reject') {
-        toolOutput = inputGuardrailResult.message;
+        toolOutput = await resolveFunctionFailureOutput(
+          deps,
+          toolRun,
+          new Error(inputGuardrailResult.message),
+          inputGuardrailResult.message,
+        );
       } else {
         const resumeState = state.getPendingAgentToolRun(
           toolName,
           toolRun.toolCall.callId,
         );
-        const toolDetails = {
+        toolDetails = {
           toolCall: toolRun.toolCall,
           resumeState,
           [FUNCTION_TOOL_PARSED_INPUT_CALLBACK]: (input: unknown) => {
@@ -548,7 +640,7 @@ async function runApprovedFunctionTool<TContext>(
           agentToolParentRunConfig ?? runner.config,
         );
         setToolCallParentSpanOnDetails(toolDetails, span);
-        toolOutput = await invokeFunctionTool({
+        const invokedToolOutput = await invokeFunctionTool({
           tool: toolRun.tool,
           runContext: state._context,
           input: toolRun.toolCall.arguments,
@@ -559,15 +651,26 @@ async function runApprovedFunctionTool<TContext>(
           context: state._context,
           agent,
           toolCall: toolRun.toolCall,
-          toolOutput,
+          toolOutput: invokedToolOutput,
           onResult: (result) => {
             state._toolOutputGuardrailResults.push(result);
           },
         });
+        shouldValidateToolOutput = toolOutput !== invokedToolOutput;
+      }
+      if (shouldValidateToolOutput) {
+        toolOutput = validateFunctionToolOutput({
+          tool: toolRun.tool,
+          output: toolOutput,
+          runContext: state._context,
+          details: toolDetails,
+        });
       }
       const stringResult = toSmartString(toolOutput);
 
-      const rawItem = getToolCallOutputItem(toolRun.toolCall, toolOutput);
+      const rawItem = getToolCallOutputItem(toolRun.toolCall, toolOutput, {
+        outputSchema: toolRun.tool.outputSchema,
+      });
       const customData = await maybeExtractToolOutputCustomData(
         toolRun.tool.customDataExtractor,
         {
@@ -972,6 +1075,7 @@ export async function executeShellActions(
             type: 'shell_call_output',
             callId: toolCallKey,
             output: [rejectionOutput],
+            ...(toolCall.caller ? { caller: toolCall.caller } : {}),
           },
           agent,
           response,
@@ -1044,6 +1148,7 @@ export async function executeShellActions(
           type: 'shell_call_output',
           callId: toolCallKey,
           output: shellOutputs ?? [],
+          ...(toolCall.caller ? { caller: toolCall.caller } : {}),
         };
 
         if (typeof maxOutputLength === 'number') {
@@ -1111,6 +1216,7 @@ export async function executeApplyPatchOperations(
             callId: toolCallKey,
             status: 'failed',
             output: response,
+            ...(toolCall.caller ? { caller: toolCall.caller } : {}),
           },
           agent,
           response,
@@ -1189,6 +1295,7 @@ export async function executeApplyPatchOperations(
           type: 'apply_patch_call_output',
           callId: toolCallKey,
           status,
+          ...(toolCall.caller ? { caller: toolCall.caller } : {}),
         };
 
         if (output) {
@@ -1627,11 +1734,24 @@ export async function checkForFinalOutputFromTools<
     };
   }
 
+  const finalizationResults = toolResults.filter((result) => {
+    const rawItem = result.runItem.rawItem;
+    return !(
+      rawItem &&
+      'caller' in rawItem &&
+      rawItem.caller?.type === 'program'
+    );
+  });
+
+  if (finalizationResults.length === 0) {
+    return NOT_FINAL_OUTPUT;
+  }
+
   if (agent.toolUseBehavior === 'run_llm_again') {
     return NOT_FINAL_OUTPUT;
   }
 
-  const firstToolResult = toolResults[0];
+  const firstToolResult = finalizationResults[0];
   if (agent.toolUseBehavior === 'stop_on_first_tool') {
     if (firstToolResult?.type === 'function_output') {
       const stringOutput = toSmartString(firstToolResult.output);
@@ -1646,7 +1766,7 @@ export async function checkForFinalOutputFromTools<
 
   const toolUseBehavior = agent.toolUseBehavior;
   if (typeof toolUseBehavior === 'object') {
-    const stoppingTool = toolResults.find((r) => {
+    const stoppingTool = finalizationResults.find((r) => {
       return toolUseBehavior.stopAtToolNames.some((toolName) =>
         matchesFunctionToolName(r.tool, toolName),
       );
@@ -1663,7 +1783,10 @@ export async function checkForFinalOutputFromTools<
   }
 
   if (typeof toolUseBehavior === 'function') {
-    return toolUseBehavior(state._context, toolResults as FunctionToolResult[]);
+    return toolUseBehavior(
+      state._context,
+      finalizationResults as FunctionToolResult[],
+    );
   }
 
   throw new UserError(`Invalid toolUseBehavior: ${toolUseBehavior}`, state);

--- a/packages/agents-core/src/runner/toolResultCorrelation.ts
+++ b/packages/agents-core/src/runner/toolResultCorrelation.ts
@@ -6,6 +6,7 @@ import {
 import type { AgentInputItem } from '../types';
 
 const SIMPLE_TOOL_RESULT_TYPE_BY_CALL_TYPE = {
+  program: 'program_output',
   function_call: 'function_call_result',
   computer_call: 'computer_call_result',
   shell_call: 'shell_call_output',

--- a/packages/agents-core/src/runner/toolSearch.ts
+++ b/packages/agents-core/src/runner/toolSearch.ts
@@ -365,6 +365,7 @@ function normalizeHostedMcpProviderData(
     connector_id?: unknown;
     authorization?: unknown;
     allowed_tools?: unknown;
+    allowed_callers?: unknown;
     defer_loading?: unknown;
     headers?: unknown;
     require_approval?: unknown;
@@ -399,6 +400,14 @@ function normalizeHostedMcpProviderData(
   if (candidate.allowed_tools !== undefined) {
     normalized.allowed_tools =
       candidate.allowed_tools as ProviderData.HostedMCPTool<any>['allowed_tools'];
+  }
+  if (
+    Array.isArray(candidate.allowed_callers) &&
+    candidate.allowed_callers.every(
+      (caller) => caller === 'direct' || caller === 'programmatic',
+    )
+  ) {
+    normalized.allowed_callers = candidate.allowed_callers;
   }
   if (candidate.defer_loading === true) {
     normalized.defer_loading = true;

--- a/packages/agents-core/src/runner/types.ts
+++ b/packages/agents-core/src/runner/types.ts
@@ -88,6 +88,7 @@ export type PreparedModelCall<TContext = UnknownContext> =
     modelSettings: ModelSettings;
     modelInput: ModelInputData;
     prompt?: Prompt;
+    allowPromptSuppliedTools: boolean;
     previousResponseId?: string;
     conversationId?: string;
     sourceItems: (AgentInputItem | undefined)[];

--- a/packages/agents-core/src/sandbox/memory/rollouts.ts
+++ b/packages/agents-core/src/sandbox/memory/rollouts.ts
@@ -37,6 +37,8 @@ const INCLUDED_MEMORY_ITEM_TYPES = new Set([
   'mcp_approval_request',
   'mcp_approval_response',
   'mcp_call',
+  'program',
+  'program_output',
   'shell_call',
   'shell_call_output',
   'tool_search_call',

--- a/packages/agents-core/src/tool.ts
+++ b/packages/agents-core/src/tool.ts
@@ -16,7 +16,12 @@ import { combineAbortSignals } from './utils/abortSignals';
 import { RunContext } from './runContext';
 import type { RunConfig } from './run';
 import type { RunResult } from './result';
-import { InvalidToolInputError, ToolTimeoutError, UserError } from './errors';
+import {
+  InvalidToolInputError,
+  InvalidToolOutputError,
+  ToolTimeoutError,
+  UserError,
+} from './errors';
 import logger from './logger';
 import { getCurrentSpan } from './tracing';
 import { RunToolApprovalItem, RunToolCallOutputItem } from './items';
@@ -39,6 +44,15 @@ import {
   ToolOutputGuardrailFunction,
 } from './toolGuardrail';
 import type { ToolOutputCustomDataExtractor } from './utils/customData';
+import {
+  normalizeToolAllowedCallers,
+  type ToolAllowedCallers,
+} from './utils/toolCallers';
+
+export type {
+  ToolAllowedCaller,
+  ToolAllowedCallers,
+} from './utils/toolCallers';
 
 export type { ToolOutputCustomData } from './utils/customData';
 
@@ -66,6 +80,9 @@ export type ToolApprovalFunction<TParameters extends ToolInputParameters> = (
 
 export const FUNCTION_TOOL_PARSED_INPUT_CALLBACK = Symbol(
   'openai.agents.functionToolParsedInputCallback',
+);
+const FUNCTION_TOOL_OUTPUT_VALIDATOR = Symbol(
+  'openai.agents.functionToolOutputValidator',
 );
 
 export type ToolCallDetails = {
@@ -132,10 +149,14 @@ export type ApplyPatchToolCustomDataExtractor =
 
 export type FunctionToolTimeoutBehavior = 'error_as_result' | 'raise_exception';
 
-export type ToolTimeoutErrorFunction<Context = UnknownContext> = (
+export type ToolTimeoutErrorFunction<
+  Context = UnknownContext,
+  Result = string,
+> = (
   context: RunContext<Context>,
   error: ToolTimeoutError,
-) => Promise<string> | string;
+  details?: ToolCallDetails,
+) => Promise<Result> | Result;
 
 export type ShellApprovalFunction = (
   runContext: RunContext,
@@ -309,6 +330,18 @@ export type FunctionTool<
   providerData?: Record<string, any>;
 
   /**
+   * Responses API only. Controls which execution contexts can invoke the tool.
+   * When omitted, the Responses API defaults to direct calls only.
+   */
+  allowedCallers?: ToolAllowedCallers;
+
+  /**
+   * Responses API only. Describes the JSON value encoded in string outputs.
+   * Zod schemas also validate the tool result at runtime.
+   */
+  outputSchema?: JsonObjectSchema<any>;
+
+  /**
    * The function to invoke when the tool is called.
    */
   invoke: (
@@ -316,6 +349,12 @@ export type FunctionTool<
     input: string,
     details?: ToolCallDetails,
   ) => Promise<string | Result>;
+
+  /**
+   * Optional model-visible fallback for execution errors and pre-execution
+   * failures. Structured tools use this to preserve their output contract.
+   */
+  errorFunction?: ToolErrorFunction<Context, string | Result> | null;
 
   /**
    * Whether the tool needs human approval before it can be called. If this is true, the run will result in an `interruption` that the
@@ -333,13 +372,16 @@ export type FunctionTool<
    *
    * - `error_as_result`: return a model-visible timeout message.
    * - `raise_exception`: raise `ToolTimeoutError` and fail the run.
+   *
+   * Tools created with an output schema default to `raise_exception`; other
+   * function tools default to `error_as_result`.
    */
   timeoutBehavior?: FunctionToolTimeoutBehavior;
 
   /**
    * Optional formatter for timeout errors when timeoutBehavior is `error_as_result`.
    */
-  timeoutErrorFunction?: ToolTimeoutErrorFunction<Context>;
+  timeoutErrorFunction?: ToolTimeoutErrorFunction<Context, Result>;
 
   /**
    * Determines whether the tool should be made available to the model for the current run.
@@ -362,6 +404,13 @@ export type FunctionTool<
     TParameters,
     Result
   >;
+
+  /** @internal */
+  [FUNCTION_TOOL_OUTPUT_VALIDATOR]?: (
+    output: unknown,
+    runContext: RunContext<Context>,
+    details?: ToolCallDetails,
+  ) => Result;
 };
 
 /**
@@ -726,6 +775,10 @@ type ShellToolBase = {
    * If provided, it will be invoked immediately when an approval is needed.
    */
   onApproval?: ShellOnApprovalFunction;
+  /**
+   * Responses API only. Controls which execution contexts can invoke the tool.
+   */
+  allowedCallers?: ToolAllowedCallers;
 };
 
 type LocalShellTool = ShellToolBase & {
@@ -760,6 +813,7 @@ type LocalShellToolOptions = {
   shell: Shell;
   needsApproval?: boolean | ShellApprovalFunction;
   onApproval?: ShellOnApprovalFunction;
+  allowedCallers?: ToolAllowedCallers;
 };
 
 type HostedShellToolOptions = {
@@ -768,6 +822,7 @@ type HostedShellToolOptions = {
   shell?: never;
   needsApproval?: never;
   onApproval?: never;
+  allowedCallers?: ToolAllowedCallers;
 };
 
 function normalizeShellToolSkillReference(
@@ -875,6 +930,10 @@ export function shellTool(
   options: LocalShellToolOptions | HostedShellToolOptions,
 ): NormalizedLocalShellTool | HostedShellTool {
   const environment = normalizeShellToolEnvironment(options.environment);
+  const allowedCallers = normalizeToolAllowedCallers(
+    options.allowedCallers,
+    options.name ?? 'shell',
+  );
   const needsApproval: ShellApprovalFunction =
     typeof options.needsApproval === 'function'
       ? options.needsApproval
@@ -898,6 +957,7 @@ export function shellTool(
       shell: localShell,
       needsApproval,
       onApproval: options.onApproval,
+      ...(allowedCallers ? { allowedCallers } : {}),
     };
   }
 
@@ -922,6 +982,7 @@ export function shellTool(
     name: options.name ?? 'shell',
     environment,
     needsApproval,
+    ...(allowedCallers ? { allowedCallers } : {}),
   };
 }
 
@@ -945,6 +1006,11 @@ export type ApplyPatchTool = {
   onApproval?: ApplyPatchOnApprovalFunction;
 
   /**
+   * Responses API only. Controls which execution contexts can invoke the tool.
+   */
+  allowedCallers?: ToolAllowedCallers;
+
+  /**
    * Optional callback that attaches SDK-only custom data to the emitted tool output item.
    */
   customDataExtractor?: ApplyPatchToolCustomDataExtractor;
@@ -960,6 +1026,11 @@ export function applyPatchTool(
     customDataExtractor?: ApplyPatchToolCustomDataExtractor;
   },
 ): ApplyPatchTool {
+  const name = options.name ?? 'apply_patch';
+  const allowedCallers = normalizeToolAllowedCallers(
+    options.allowedCallers,
+    name,
+  );
   const needsApproval: ApplyPatchApprovalFunction =
     typeof options.needsApproval === 'function'
       ? options.needsApproval
@@ -970,10 +1041,11 @@ export function applyPatchTool(
 
   return {
     type: 'apply_patch',
-    name: options.name ?? 'apply_patch',
+    name,
     editor: options.editor,
     needsApproval,
     onApproval: options.onApproval,
+    ...(allowedCallers ? { allowedCallers } : {}),
     customDataExtractor: options.customDataExtractor,
   };
 }
@@ -1001,6 +1073,7 @@ export type HostedMCPTool<Context = UnknownContext> = HostedTool & {
 export function hostedMcpTool<Context = UnknownContext>(
   options: {
     allowedTools?: string[] | { toolNames?: string[] };
+    allowedCallers?: ToolAllowedCallers;
     deferLoading?: boolean;
     serverDescription?: string;
   } &
@@ -1034,6 +1107,13 @@ export function hostedMcpTool<Context = UnknownContext>(
         }
     ),
 ): HostedMCPTool<Context> {
+  const allowedCallers = normalizeToolAllowedCallers(
+    options.allowedCallers,
+    options.serverLabel,
+  );
+  const providerAllowedCallers = allowedCallers
+    ? [...allowedCallers]
+    : undefined;
   if ('serverUrl' in options) {
     // the MCP servers compatible with the specification
     const providerData: ProviderData.HostedMCPTool<Context> =
@@ -1046,6 +1126,7 @@ export function hostedMcpTool<Context = UnknownContext>(
             authorization: options.authorization,
             require_approval: 'never',
             allowed_tools: toMcpAllowedToolsFilter(options.allowedTools),
+            allowed_callers: providerAllowedCallers,
             defer_loading: options.deferLoading,
             headers: options.headers,
             server_description: options.serverDescription,
@@ -1056,6 +1137,7 @@ export function hostedMcpTool<Context = UnknownContext>(
             server_url: options.serverUrl,
             authorization: options.authorization,
             allowed_tools: toMcpAllowedToolsFilter(options.allowedTools),
+            allowed_callers: providerAllowedCallers,
             defer_loading: options.deferLoading,
             headers: options.headers,
             require_approval: buildRequireApproval(options.requireApproval),
@@ -1079,6 +1161,7 @@ export function hostedMcpTool<Context = UnknownContext>(
             authorization: options.authorization,
             require_approval: 'never',
             allowed_tools: toMcpAllowedToolsFilter(options.allowedTools),
+            allowed_callers: providerAllowedCallers,
             defer_loading: options.deferLoading,
             headers: options.headers,
             server_description: options.serverDescription,
@@ -1089,6 +1172,7 @@ export function hostedMcpTool<Context = UnknownContext>(
             connector_id: options.connectorId,
             authorization: options.authorization,
             allowed_tools: toMcpAllowedToolsFilter(options.allowedTools),
+            allowed_callers: providerAllowedCallers,
             defer_loading: options.deferLoading,
             headers: options.headers,
             require_approval: buildRequireApproval(options.requireApproval),
@@ -1110,6 +1194,7 @@ export function hostedMcpTool<Context = UnknownContext>(
             server_label: options.serverLabel,
             require_approval: 'never',
             allowed_tools: toMcpAllowedToolsFilter(options.allowedTools),
+            allowed_callers: providerAllowedCallers,
             defer_loading: options.deferLoading,
             server_description: options.serverDescription,
           }
@@ -1117,6 +1202,7 @@ export function hostedMcpTool<Context = UnknownContext>(
             type: 'mcp',
             server_label: options.serverLabel,
             allowed_tools: toMcpAllowedToolsFilter(options.allowedTools),
+            allowed_callers: providerAllowedCallers,
             defer_loading: options.deferLoading,
             require_approval: buildRequireApproval(options.requireApproval),
             on_approval: options.onApproval,
@@ -1337,6 +1423,28 @@ export type ToolInputParametersNonStrict =
   undefined | JsonObjectSchemaNonStrict<any>;
 
 /**
+ * A schema describing the JSON object encoded in a function tool output.
+ *
+ * Zod schemas are converted to JSON Schema when the tool is created. Plain
+ * JSON Schema objects are passed through unchanged.
+ */
+export type ToolOutputSchema = ZodObjectLike | JsonObjectSchema<any>;
+
+type ToolExecuteResult<
+  TOutputSchema extends ToolOutputSchema | undefined,
+  Result,
+> = TOutputSchema extends ZodObjectLike
+  ? ZodInfer<TOutputSchema>
+  : TOutputSchema extends JsonObjectSchema<any>
+    ? unknown
+    : Result;
+
+type ToolFallbackResult<TOutputSchema extends ToolOutputSchema | undefined> =
+  TOutputSchema extends undefined
+    ? string
+    : ToolExecuteResult<TOutputSchema, unknown>;
+
+/**
  * The arguments to a tool.
  *
  * The type of the arguments are derived from the parameters passed to the tool definition.
@@ -1360,24 +1468,56 @@ export type ToolExecuteArgument<TParameters extends ToolInputParameters> =
 type ToolExecuteFunction<
   TParameters extends ToolInputParameters,
   Context = UnknownContext,
+  Result = unknown,
 > = (
   input: ToolExecuteArgument<TParameters>,
   context?: RunContext<Context>,
   details?: ToolCallDetails,
-) => Promise<unknown> | unknown;
+) => Promise<Result> | Result;
 
 /**
- * The function to invoke when an error occurs while running the tool. This can be used to define
- * what the model should receive as tool output in case of an error. It can be used to provide
- * for example additional context or a fallback value.
+ * The function to invoke when an error or model-visible pre-execution rejection
+ * occurs. This can provide additional context or a fallback value.
  *
  * @param context An instance of the current RunContext
  * @param error The error that occurred
  */
-type ToolErrorFunction = (
-  context: RunContext,
+type ToolErrorFunction<Context = UnknownContext, Result = string> = (
+  context: RunContext<Context>,
   error: Error | unknown,
-) => Promise<string> | string;
+  details?: ToolCallDetails,
+) => Promise<Result> | Result;
+
+type ToolTimeoutOptions<
+  Context,
+  TOutputSchema extends ToolOutputSchema | undefined,
+> = [TOutputSchema] extends [undefined]
+  ? {
+      /** Optional timeout in milliseconds for each tool call. */
+      timeoutMs?: number;
+      /** Determines whether a timeout becomes a result or an exception. */
+      timeoutBehavior?: FunctionToolTimeoutBehavior;
+      /** Optional formatter for model-visible timeout results. */
+      timeoutErrorFunction?: ToolTimeoutErrorFunction<Context, string>;
+    }
+  : | {
+        /** Optional timeout in milliseconds for each tool call. */
+        timeoutMs?: number;
+        /** Structured tools raise timeout exceptions by default. */
+        timeoutBehavior?: 'raise_exception';
+        timeoutErrorFunction?: never;
+      }
+    | {
+        /** Optional timeout in milliseconds for each tool call. */
+        timeoutMs?: number;
+        /** Return a schema-compatible timeout result. */
+        timeoutBehavior: 'error_as_result';
+        /** Required formatter for schema-compatible timeout results. */
+        timeoutErrorFunction: ToolTimeoutErrorFunction<
+          Context,
+          ToolFallbackResult<TOutputSchema>
+        >;
+      };
 
 const FUNCTION_TOOL_TIMEOUT_BEHAVIORS = [
   'error_as_result',
@@ -1436,10 +1576,11 @@ const MAX_FUNCTION_TOOL_TIMEOUT_MS = 2_147_483_647;
  * @param TParameters The parameters of the tool
  * @param Context The context of the tool
  */
-type StrictToolOptions<
+type StrictToolOptionsBase<
   TParameters extends ToolInputParametersStrict,
   Context = UnknownContext,
-> = ToolGuardrailOptions<Context> & {
+  TOutputSchema extends ToolOutputSchema | undefined = undefined,
+> = {
   /**
    * The name of the tool. Must be unique within the agent.
    */
@@ -1473,14 +1614,37 @@ type StrictToolOptions<
   providerData?: Record<string, any>;
 
   /**
-   * The function to invoke when the tool is called.
+   * Responses API only. Controls which execution contexts can invoke the tool.
    */
-  execute: ToolExecuteFunction<TParameters, Context>;
+  allowedCallers?: ToolAllowedCallers;
 
   /**
-   * The function to invoke when an error occurs while running the tool.
+   * Responses API only. Describes the JSON object encoded in string outputs.
+   * Zod object schemas are converted to JSON Schema and constrain the return
+   * type of `execute` to the inferred Zod output type. They also validate the
+   * result at runtime.
    */
-  errorFunction?: ToolErrorFunction | null;
+  outputSchema?: TOutputSchema;
+
+  /**
+   * The function to invoke when the tool is called.
+   */
+  execute: ToolExecuteFunction<
+    TParameters,
+    Context,
+    ToolExecuteResult<TOutputSchema, unknown>
+  >;
+
+  /**
+   * The function to invoke when an error or model-visible pre-execution
+   * rejection occurs. Tools with an output schema rethrow by default so they
+   * cannot emit an unstructured error string. Provide this callback to return
+   * a schema-compatible fallback.
+   */
+  errorFunction?: ToolErrorFunction<
+    Context,
+    ToolFallbackResult<TOutputSchema>
+  > | null;
 
   /**
    * Whether the tool needs human approval before it can be called. If this is true, the run will result in an `interruption` that the
@@ -1494,26 +1658,22 @@ type StrictToolOptions<
   isEnabled?: ToolEnabledOption<Context>;
 
   /**
-   * Optional timeout in milliseconds for each tool call.
-   */
-  timeoutMs?: number;
-
-  /**
-   * Timeout handling mode. `error_as_result` returns a model-visible message and
-   * `raise_exception` throws `ToolTimeoutError`.
-   */
-  timeoutBehavior?: FunctionToolTimeoutBehavior;
-
-  /**
-   * Optional formatter used for timeout messages when timeoutBehavior is `error_as_result`.
-   */
-  timeoutErrorFunction?: ToolTimeoutErrorFunction<Context>;
-
-  /**
    * Optional callback that attaches SDK-only custom data to the emitted tool output item.
    */
-  customDataExtractor?: FunctionToolCustomDataExtractor<Context>;
+  customDataExtractor?: FunctionToolCustomDataExtractor<
+    Context,
+    TParameters,
+    ToolExecuteResult<TOutputSchema, unknown>
+  >;
 };
+
+type StrictToolOptions<
+  TParameters extends ToolInputParametersStrict,
+  Context = UnknownContext,
+  TOutputSchema extends ToolOutputSchema | undefined = undefined,
+> = StrictToolOptionsBase<TParameters, Context, TOutputSchema> &
+  ToolGuardrailOptions<Context> &
+  ToolTimeoutOptions<Context, TOutputSchema>;
 
 /**
  * The options for a tool that has strict mode disabled.
@@ -1521,10 +1681,11 @@ type StrictToolOptions<
  * @param TParameters The parameters of the tool
  * @param Context The context of the tool
  */
-type NonStrictToolOptions<
+type NonStrictToolOptionsBase<
   TParameters extends ToolInputParametersNonStrict,
   Context = UnknownContext,
-> = ToolGuardrailOptions<Context> & {
+  TOutputSchema extends ToolOutputSchema | undefined = undefined,
+> = {
   /**
    * The name of the tool. Must be unique within the agent.
    */
@@ -1556,14 +1717,37 @@ type NonStrictToolOptions<
   providerData?: Record<string, any>;
 
   /**
-   * The function to invoke when the tool is called.
+   * Responses API only. Controls which execution contexts can invoke the tool.
    */
-  execute: ToolExecuteFunction<TParameters, Context>;
+  allowedCallers?: ToolAllowedCallers;
 
   /**
-   * The function to invoke when an error occurs while running the tool.
+   * Responses API only. Describes the JSON object encoded in string outputs.
+   * Zod object schemas are converted to JSON Schema and constrain the return
+   * type of `execute` to the inferred Zod output type. They also validate the
+   * result at runtime.
    */
-  errorFunction?: ToolErrorFunction | null;
+  outputSchema?: TOutputSchema;
+
+  /**
+   * The function to invoke when the tool is called.
+   */
+  execute: ToolExecuteFunction<
+    TParameters,
+    Context,
+    ToolExecuteResult<TOutputSchema, unknown>
+  >;
+
+  /**
+   * The function to invoke when an error or model-visible pre-execution
+   * rejection occurs. Tools with an output schema rethrow by default so they
+   * cannot emit an unstructured error string. Provide this callback to return
+   * a schema-compatible fallback.
+   */
+  errorFunction?: ToolErrorFunction<
+    Context,
+    ToolFallbackResult<TOutputSchema>
+  > | null;
 
   /**
    * Whether the tool needs human approval before it can be called. If this is true, the run will result in an `interruption` that the
@@ -1577,26 +1761,22 @@ type NonStrictToolOptions<
   isEnabled?: ToolEnabledOption<Context>;
 
   /**
-   * Optional timeout in milliseconds for each tool call.
-   */
-  timeoutMs?: number;
-
-  /**
-   * Timeout handling mode. `error_as_result` returns a model-visible message and
-   * `raise_exception` throws `ToolTimeoutError`.
-   */
-  timeoutBehavior?: FunctionToolTimeoutBehavior;
-
-  /**
-   * Optional formatter used for timeout messages when timeoutBehavior is `error_as_result`.
-   */
-  timeoutErrorFunction?: ToolTimeoutErrorFunction<Context>;
-
-  /**
    * Optional callback that attaches SDK-only custom data to the emitted tool output item.
    */
-  customDataExtractor?: FunctionToolCustomDataExtractor<Context>;
+  customDataExtractor?: FunctionToolCustomDataExtractor<
+    Context,
+    TParameters,
+    ToolExecuteResult<TOutputSchema, unknown>
+  >;
 };
+
+type NonStrictToolOptions<
+  TParameters extends ToolInputParametersNonStrict,
+  Context = UnknownContext,
+  TOutputSchema extends ToolOutputSchema | undefined = undefined,
+> = NonStrictToolOptionsBase<TParameters, Context, TOutputSchema> &
+  ToolGuardrailOptions<Context> &
+  ToolTimeoutOptions<Context, TOutputSchema>;
 
 /**
  * The options for a tool.
@@ -1607,17 +1787,24 @@ type NonStrictToolOptions<
 export type ToolOptions<
   TParameters extends ToolInputParameters,
   Context = UnknownContext,
+  TOutputSchema extends ToolOutputSchema | undefined = undefined,
 > =
-  | StrictToolOptions<Extract<TParameters, ToolInputParametersStrict>, Context>
+  | StrictToolOptions<
+      Extract<TParameters, ToolInputParametersStrict>,
+      Context,
+      TOutputSchema
+    >
   | NonStrictToolOptions<
       Extract<TParameters, ToolInputParametersNonStrict>,
-      Context
+      Context,
+      TOutputSchema
     >;
 
 export type ToolOptionsWithGuardrails<
   TParameters extends ToolInputParameters,
   Context = UnknownContext,
-> = ToolOptions<TParameters, Context>;
+  TOutputSchema extends ToolOutputSchema | undefined = undefined,
+> = ToolOptions<TParameters, Context, TOutputSchema>;
 
 type NamespacedFunctionTool<
   Context = UnknownContext,
@@ -1668,15 +1855,18 @@ function cloneObjectWithDescriptorsAndOverrides<
   return Object.assign(clone, overrides);
 }
 
-function normalizeFunctionToolTimeoutConfig<Context = UnknownContext>(args: {
+function normalizeFunctionToolTimeoutConfig<
+  Context = UnknownContext,
+  Result = string,
+>(args: {
   toolName: string;
   timeoutMs?: number;
   timeoutBehavior?: FunctionToolTimeoutBehavior;
-  timeoutErrorFunction?: ToolTimeoutErrorFunction<Context>;
+  timeoutErrorFunction?: ToolTimeoutErrorFunction<Context, Result>;
 }): {
   timeoutMs?: number;
   timeoutBehavior: FunctionToolTimeoutBehavior;
-  timeoutErrorFunction?: ToolTimeoutErrorFunction<Context>;
+  timeoutErrorFunction?: ToolTimeoutErrorFunction<Context, Result>;
 } {
   const { toolName, timeoutMs, timeoutBehavior, timeoutErrorFunction } = args;
 
@@ -1737,7 +1927,7 @@ async function invokeFunctionToolWithTimeout<
   details?: ToolCallDetails;
   timeoutMs?: number;
   timeoutBehavior?: FunctionToolTimeoutBehavior;
-  timeoutErrorFunction?: ToolTimeoutErrorFunction<Context>;
+  timeoutErrorFunction?: ToolTimeoutErrorFunction<Context, Result>;
 }): Promise<string | Result> {
   const {
     toolName,
@@ -1802,7 +1992,7 @@ async function invokeFunctionToolWithTimeout<
     }
 
     if (timeoutErrorFunction) {
-      return timeoutErrorFunction(runContext, timeoutError);
+      return timeoutErrorFunction(runContext, timeoutError, details);
     }
 
     return defaultFunctionToolTimeoutErrorMessage({
@@ -1815,6 +2005,27 @@ async function invokeFunctionToolWithTimeout<
     }
     cleanupAbortSignals();
   }
+}
+
+/**
+ * Validate a function tool output when the tool was created with a runtime
+ * output schema.
+ */
+export function validateFunctionToolOutput<
+  Context = UnknownContext,
+  TParameters extends ToolInputParameters = ToolInputParameters,
+  Result = unknown,
+>(args: {
+  tool: FunctionTool<Context, TParameters, Result>;
+  output: unknown;
+  runContext: RunContext<Context>;
+  details?: ToolCallDetails;
+}): unknown {
+  const validator = args.tool[FUNCTION_TOOL_OUTPUT_VALIDATOR];
+  if (!validator) {
+    return args.output;
+  }
+  return validator(args.output, args.runContext, args.details);
 }
 
 /**
@@ -1865,16 +2076,17 @@ export function tool<
   TParameters extends ToolInputParameters = undefined,
   Context = UnknownContext,
   Result = string,
+  TOutputSchema extends ToolOutputSchema | undefined = undefined,
 >(
-  options: ToolOptions<TParameters, Context>,
-): FunctionTool<Context, TParameters, Result> {
+  options: ToolOptions<TParameters, Context, TOutputSchema>,
+): FunctionTool<
+  Context,
+  TParameters,
+  ToolExecuteResult<TOutputSchema, Result>
+> {
   const name = options.name
     ? toFunctionToolName(options.name)
     : toFunctionToolName(options.execute.name);
-  const toolErrorFunction: ToolErrorFunction | null =
-    typeof options.errorFunction === 'undefined'
-      ? defaultToolErrorFunction
-      : options.errorFunction;
 
   if (!name) {
     throw new Error(
@@ -1885,25 +2097,100 @@ export function tool<
   if (!strictMode && isZodObject(options.parameters)) {
     throw new UserError('Strict mode is required for Zod parameters');
   }
-  const { timeoutMs, timeoutBehavior, timeoutErrorFunction } =
-    normalizeFunctionToolTimeoutConfig({
-      toolName: name,
-      timeoutMs: options.timeoutMs,
-      timeoutBehavior: options.timeoutBehavior,
-      timeoutErrorFunction: options.timeoutErrorFunction,
-    });
+  const hasOutputSchema = typeof options.outputSchema !== 'undefined';
+  const toolErrorFunction =
+    typeof options.errorFunction === 'undefined'
+      ? hasOutputSchema
+        ? null
+        : defaultToolErrorFunction
+      : options.errorFunction;
+  const {
+    timeoutMs,
+    timeoutBehavior,
+    timeoutErrorFunction: configuredTimeoutErrorFunction,
+  } = normalizeFunctionToolTimeoutConfig<
+    Context,
+    ToolFallbackResult<TOutputSchema>
+  >({
+    toolName: name,
+    timeoutMs: options.timeoutMs,
+    timeoutBehavior:
+      options.timeoutBehavior ??
+      (hasOutputSchema ? 'raise_exception' : undefined),
+    timeoutErrorFunction: options.timeoutErrorFunction as
+      | ToolTimeoutErrorFunction<Context, ToolFallbackResult<TOutputSchema>>
+      | undefined,
+  });
+  if (
+    hasOutputSchema &&
+    timeoutBehavior === 'error_as_result' &&
+    !configuredTimeoutErrorFunction
+  ) {
+    throw new UserError(
+      `Function tool '${name}' with an output schema requires timeoutErrorFunction when timeoutBehavior is 'error_as_result'.`,
+    );
+  }
+  const allowedCallers = normalizeToolAllowedCallers(
+    options.allowedCallers,
+    name,
+  );
 
   const { parser, schema: parameters } = getSchemaAndParserFromInputType(
     options.parameters,
     name,
     { strict: strictMode },
   );
+  const zodOutputSchema = isZodObject(options.outputSchema)
+    ? options.outputSchema
+    : undefined;
+  const outputSchema: JsonObjectSchema<any> | undefined = zodOutputSchema
+    ? getSchemaAndParserFromInputType(zodOutputSchema, `${name}_output`, {
+        strict: true,
+      }).schema
+    : (options.outputSchema as JsonObjectSchema<any> | undefined);
+
+  function validateOutput(
+    output: unknown,
+    runContext: RunContext<Context>,
+    details?: ToolCallDetails,
+  ): ToolExecuteResult<TOutputSchema, Result> {
+    if (!zodOutputSchema) {
+      return output as ToolExecuteResult<TOutputSchema, Result>;
+    }
+
+    try {
+      return zodOutputSchema.parse(output) as ToolExecuteResult<
+        TOutputSchema,
+        Result
+      >;
+    } catch (error) {
+      throw new InvalidToolOutputError(
+        `Invalid output for function tool '${name}'.`,
+        undefined,
+        error,
+        { runContext, output, details },
+      );
+    }
+  }
+
+  const timeoutErrorFunction = configuredTimeoutErrorFunction
+    ? async (
+        runContext: RunContext<Context>,
+        error: ToolTimeoutError,
+        details?: ToolCallDetails,
+      ) =>
+        validateOutput(
+          await configuredTimeoutErrorFunction(runContext, error, details),
+          runContext,
+          details,
+        )
+    : undefined;
 
   async function _invoke(
     runContext: RunContext<Context>,
     input: string,
     details?: ToolCallDetails,
-  ): Promise<Result> {
+  ): Promise<ToolExecuteResult<TOutputSchema, Result>> {
     const [error, parsed] = await safeExecute(() => parser(input));
     if (error !== null) {
       if (logger.dontLogToolData) {
@@ -1929,7 +2216,11 @@ export function tool<
     }
 
     details?.[FUNCTION_TOOL_PARSED_INPUT_CALLBACK]?.(parsed);
-    const result = await options.execute(parsed, runContext, details);
+    const result = validateOutput(
+      await options.execute(parsed, runContext, details),
+      runContext,
+      details,
+    );
     const stringResult = toSmartString(result);
 
     if (logger.dontLogToolData) {
@@ -1938,15 +2229,15 @@ export function tool<
       logger.debug(`Tool ${name} returned: ${stringResult}`);
     }
 
-    return result as Result;
+    return result as ToolExecuteResult<TOutputSchema, Result>;
   }
 
   async function invokeWithoutTimeout(
     runContext: RunContext<Context>,
     input: string,
     details?: ToolCallDetails,
-  ): Promise<string | Result> {
-    return _invoke(runContext, input, details).catch<string>((error) => {
+  ): Promise<string | ToolExecuteResult<TOutputSchema, Result>> {
+    return _invoke(runContext, input, details).catch(async (error) => {
       if (
         details?.signal?.aborted &&
         details.signal.reason instanceof ToolTimeoutError
@@ -1963,7 +2254,11 @@ export function tool<
             error: error.toString(),
           },
         });
-        return toolErrorFunction(runContext, error);
+        return validateOutput(
+          await toolErrorFunction(runContext, error, details),
+          runContext,
+          details,
+        );
       }
 
       throw error;
@@ -1974,14 +2269,17 @@ export function tool<
     runContext: RunContext<Context>,
     input: string,
     details?: ToolCallDetails,
-  ): Promise<string | Result> {
+  ): Promise<string | ToolExecuteResult<TOutputSchema, Result>> {
     const detailsWithFlag = details as
       ToolCallDetailsWithTimeoutFlag | undefined;
     if (detailsWithFlag?.[FUNCTION_TOOL_TIMEOUT_ALREADY_ENFORCED]) {
       return invokeWithoutTimeout(runContext, input, details);
     }
 
-    return invokeFunctionToolWithTimeout<Context, Result>({
+    return invokeFunctionToolWithTimeout<
+      Context,
+      ToolExecuteResult<TOutputSchema, Result>
+    >({
       toolName: name,
       invoke: invokeWithoutTimeout,
       runContext,
@@ -2019,7 +2317,17 @@ export function tool<
     strict: strictMode,
     deferLoading: options.deferLoading ?? false,
     providerData: options.providerData,
+    ...(allowedCallers ? { allowedCallers } : {}),
+    ...(outputSchema ? { outputSchema } : {}),
     invoke,
+    ...(hasOutputSchema
+      ? {
+          errorFunction: toolErrorFunction as ToolErrorFunction<
+            Context,
+            string | ToolExecuteResult<TOutputSchema, Result>
+          > | null,
+        }
+      : {}),
     needsApproval,
     timeoutMs,
     timeoutBehavior,
@@ -2028,6 +2336,9 @@ export function tool<
     inputGuardrails: resolveToolInputGuardrails(options.inputGuardrails),
     outputGuardrails: resolveToolOutputGuardrails(options.outputGuardrails),
     customDataExtractor: options.customDataExtractor,
+    ...(zodOutputSchema
+      ? { [FUNCTION_TOOL_OUTPUT_VALIDATOR]: validateOutput }
+      : {}),
   };
 }
 

--- a/packages/agents-core/src/types/aliases.ts
+++ b/packages/agents-core/src/types/aliases.ts
@@ -16,6 +16,8 @@ import {
   ReasoningItem,
   CompactionItem,
   UnknownItem,
+  ProgramCallItem,
+  ProgramCallResultItem,
 } from './protocol';
 
 /**
@@ -38,6 +40,8 @@ export type AgentOutputItem =
   | ToolSearchCallItem
   | ToolSearchOutputItem
   | HostedToolCallItem
+  | ProgramCallItem
+  | ProgramCallResultItem
   | FunctionCallItem
   | ComputerUseCallItem
   | ShellCallItem
@@ -60,6 +64,8 @@ export type AgentInputItem =
   | ToolSearchCallItem
   | ToolSearchOutputItem
   | HostedToolCallItem
+  | ProgramCallItem
+  | ProgramCallResultItem
   | FunctionCallItem
   | ComputerUseCallItem
   | ShellCallItem

--- a/packages/agents-core/src/types/protocol.ts
+++ b/packages/agents-core/src/types/protocol.ts
@@ -444,6 +444,34 @@ export type MessageItem = z.infer<typeof MessageItem>;
 // Tool call types
 // ----------------------------
 
+export const ToolCaller = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('direct') }),
+  z.object({
+    type: z.literal('program'),
+    callerId: z.string(),
+  }),
+]);
+
+export type ToolCaller = z.infer<typeof ToolCaller>;
+
+export const ProgramCallItem = ItemBase.extend({
+  type: z.literal('program'),
+  callId: z.string(),
+  code: z.string(),
+  fingerprint: z.string(),
+});
+
+export type ProgramCallItem = z.infer<typeof ProgramCallItem>;
+
+export const ProgramCallResultItem = ItemBase.extend({
+  type: z.literal('program_output'),
+  callId: z.string(),
+  output: z.string(),
+  status: z.enum(['completed', 'incomplete']),
+});
+
+export type ProgramCallResultItem = z.infer<typeof ProgramCallResultItem>;
+
 export const HostedToolCallItem = ItemBase.extend({
   type: z.literal('hosted_tool_call'),
   /**
@@ -468,6 +496,11 @@ export const HostedToolCallItem = ItemBase.extend({
    * The primary output of the tool call. Additional output might be in the `providerData` field.
    */
   output: z.string().optional(),
+
+  /**
+   * The execution context that invoked the hosted tool.
+   */
+  caller: ToolCaller.optional(),
 });
 
 export type HostedToolCallItem = z.infer<typeof HostedToolCallItem>;
@@ -498,6 +531,7 @@ export const FunctionCallItem = ItemBase.extend({
    * The arguments of the function call.
    */
   arguments: z.string(),
+  caller: ToolCaller.optional(),
 });
 
 export type FunctionCallItem = z.infer<typeof FunctionCallItem>;
@@ -585,6 +619,7 @@ export const FunctionCallResultItem = ItemBase.extend({
    * The status of the tool call.
    */
   status: z.enum(['in_progress', 'completed', 'incomplete']),
+  caller: ToolCaller.optional(),
 
   /**
    * The output of the tool call.
@@ -665,6 +700,7 @@ export const ShellCallItem = ItemBase.extend({
   callId: z.string(),
   status: z.enum(['in_progress', 'completed', 'incomplete']).optional(),
   action: ShellAction,
+  caller: ToolCaller.optional(),
 });
 
 export type ShellCallItem = z.infer<typeof ShellCallItem>;
@@ -692,8 +728,10 @@ export type ShellCallOutputContent = z.infer<typeof ShellCallOutputContent>;
 export const ShellCallResultItem = ItemBase.extend({
   type: z.literal('shell_call_output'),
   callId: z.string(),
+  status: z.enum(['in_progress', 'completed', 'incomplete']).optional(),
   maxOutputLength: z.number().optional(),
   output: z.array(ShellCallOutputContent),
+  caller: ToolCaller.optional(),
 });
 
 export type ShellCallResultItem = z.infer<typeof ShellCallResultItem>;
@@ -741,6 +779,7 @@ export const ApplyPatchCallItem = ItemBase.extend({
   callId: z.string(),
   status: z.enum(['in_progress', 'completed']),
   operation: ApplyPatchOperation,
+  caller: ToolCaller.optional(),
 });
 
 export type ApplyPatchCallItem = z.infer<typeof ApplyPatchCallItem>;
@@ -750,11 +789,13 @@ export const ApplyPatchCallResultItem = ItemBase.extend({
   callId: z.string(),
   status: z.enum(['completed', 'failed']),
   output: z.string().optional(),
+  caller: ToolCaller.optional(),
 });
 
 export type ApplyPatchCallResultItem = z.infer<typeof ApplyPatchCallResultItem>;
 
 export const ToolCallItem = z.discriminatedUnion('type', [
+  ProgramCallItem,
   ComputerUseCallItem,
   ShellCallItem,
   ApplyPatchCallItem,
@@ -827,6 +868,8 @@ export const OutputModelItem = z.discriminatedUnion('type', [
   ToolSearchCallItem,
   ToolSearchOutputItem,
   HostedToolCallItem,
+  ProgramCallItem,
+  ProgramCallResultItem,
   FunctionCallItem,
   ComputerUseCallItem,
   ShellCallItem,
@@ -848,6 +891,8 @@ export const ModelItem = z.union([
   ToolSearchCallItem,
   ToolSearchOutputItem,
   HostedToolCallItem,
+  ProgramCallItem,
+  ProgramCallResultItem,
   FunctionCallItem,
   ComputerUseCallItem,
   ShellCallItem,

--- a/packages/agents-core/src/types/providerData.ts
+++ b/packages/agents-core/src/types/providerData.ts
@@ -6,12 +6,14 @@ import { UnknownContext } from './aliases';
  */
 export type HostedMCPTool<Context = UnknownContext> = {
   type: 'mcp';
+  allowed_callers?: Array<'direct' | 'programmatic'>;
   allowed_tools?: string[] | { tool_names: string[] };
   defer_loading?: boolean;
   server_description?: string;
 } &
   // MCP server
-  (| {
+  (
+    | {
         server_label: string;
         server_url?: string;
         authorization?: string;

--- a/packages/agents-core/src/utils/internal.ts
+++ b/packages/agents-core/src/utils/internal.ts
@@ -1,2 +1,3 @@
 export { formatInlineData, getInlineMediaType } from './inlineData';
 export { recordToolUsage } from '../runner/usageTracking';
+export { normalizeToolAllowedCallers } from './toolCallers';

--- a/packages/agents-core/src/utils/serialize.ts
+++ b/packages/agents-core/src/utils/serialize.ts
@@ -58,6 +58,8 @@ export function serializeTool(tool: Tool<any>): SerializedTool {
       strict: tool.strict,
       deferLoading: tool.deferLoading,
       providerData: tool.providerData,
+      ...(tool.allowedCallers ? { allowedCallers: tool.allowedCallers } : {}),
+      ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
       ...(namespace ? { namespace } : {}),
       ...(namespace
         ? {
@@ -89,12 +91,14 @@ export function serializeTool(tool: Tool<any>): SerializedTool {
       type: 'shell',
       name: tool.name,
       environment: tool.environment,
+      ...(tool.allowedCallers ? { allowedCallers: tool.allowedCallers } : {}),
     };
   }
   if (tool.type === 'apply_patch') {
     return {
       type: 'apply_patch',
       name: tool.name,
+      ...(tool.allowedCallers ? { allowedCallers: tool.allowedCallers } : {}),
     };
   }
   return {

--- a/packages/agents-core/src/utils/toolCallers.ts
+++ b/packages/agents-core/src/utils/toolCallers.ts
@@ -1,0 +1,50 @@
+import { UserError } from '../errors';
+
+/**
+ * Controls whether an eligible Responses API tool can be called directly by
+ * the model or from a Programmatic Tool Calling program.
+ */
+export type ToolAllowedCaller = 'direct' | 'programmatic';
+
+/**
+ * A non-empty set of execution contexts allowed to invoke a Responses API
+ * tool. Duplicate entries are rejected when tools are created.
+ */
+export type ToolAllowedCallers = readonly [
+  ToolAllowedCaller,
+  ...ToolAllowedCaller[],
+];
+
+export function normalizeToolAllowedCallers(
+  allowedCallers: ToolAllowedCallers | undefined,
+  toolName: string,
+): ToolAllowedCallers | undefined {
+  if (typeof allowedCallers === 'undefined') {
+    return undefined;
+  }
+
+  const callers = allowedCallers as unknown;
+  if (!Array.isArray(callers) || callers.length === 0) {
+    throw new UserError(
+      `Tool '${toolName}' allowedCallers must contain at least one caller.`,
+    );
+  }
+
+  const invalidCallerIndex = callers.findIndex(
+    (caller) => caller !== 'direct' && caller !== 'programmatic',
+  );
+  if (invalidCallerIndex !== -1) {
+    const invalidCaller = callers[invalidCallerIndex];
+    throw new UserError(
+      `Tool '${toolName}' allowedCallers contains unsupported caller '${String(invalidCaller)}'.`,
+    );
+  }
+
+  if (new Set(callers).size !== callers.length) {
+    throw new UserError(
+      `Tool '${toolName}' allowedCallers must not contain duplicate callers.`,
+    );
+  }
+
+  return [...callers] as unknown as ToolAllowedCallers;
+}

--- a/packages/agents-core/test/extensions/handoffFilters.test.ts
+++ b/packages/agents-core/test/extensions/handoffFilters.test.ts
@@ -77,6 +77,20 @@ const applyPatchCallResult: protocol.ApplyPatchCallResultItem = {
   output: 'done',
 };
 
+const programCall: protocol.ProgramCallItem = {
+  type: 'program',
+  callId: 'program-call',
+  code: 'text("done")',
+  fingerprint: 'program-fingerprint',
+};
+
+const programCallResult: protocol.ProgramCallResultItem = {
+  type: 'program_output',
+  callId: 'program-call',
+  output: 'done',
+  status: 'completed',
+};
+
 const toolSearchCall: protocol.ToolSearchCallItem = {
   type: 'tool_search_call',
   id: 'tool-search-call',
@@ -185,6 +199,8 @@ describe('removeAllTools', () => {
       shellCallResult,
       applyPatchCall,
       applyPatchCallResult,
+      programCall,
+      programCallResult,
       reasoningItem,
     ];
 
@@ -195,7 +211,7 @@ describe('removeAllTools', () => {
     });
 
     expect(result.inputHistory).toStrictEqual([userMessage]);
-    expect(history).toHaveLength(13);
+    expect(history).toHaveLength(15);
     expect((result.inputHistory as AgentInputItem[])[0]).toBe(userMessage);
   });
 });

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -109,6 +109,107 @@ class AbortAfterStreamedFunctionCallModel implements Model {
   }
 }
 
+class AbortAfterStreamedProgramModel implements Model {
+  public requests: ModelRequest[] = [];
+
+  constructor(private readonly responseId: string) {}
+
+  async getResponse(request: ModelRequest): Promise<ModelResponse> {
+    this.requests.push(request);
+    return {
+      output: [fakeModelMessage('reconciled')],
+      usage: new Usage(),
+      responseId: 'resp-reconciled',
+    };
+  }
+
+  async *getStreamedResponse(
+    request: ModelRequest,
+  ): AsyncIterable<StreamEvent> {
+    this.requests.push(request);
+    yield {
+      type: 'model',
+      event: {
+        type: 'response.created',
+        response: {
+          id: this.responseId,
+        },
+      },
+    };
+    yield {
+      type: 'model',
+      event: {
+        type: 'response.output_item.done',
+        item: {
+          type: 'program',
+          id: 'prog_abort',
+          call_id: 'call_prog_abort',
+          code: 'text("done");',
+          fingerprint: 'fingerprint:abort',
+        },
+      },
+    };
+    const error = new Error('aborted');
+    error.name = 'AbortError';
+    throw error;
+  }
+}
+
+class AbortAfterStreamedProgramToolCallsModel implements Model {
+  public requests: ModelRequest[] = [];
+
+  async getResponse(request: ModelRequest): Promise<ModelResponse> {
+    this.requests.push(request);
+    return {
+      output: [fakeModelMessage('reconciled')],
+      usage: new Usage(),
+      responseId: 'resp-reconciled',
+    };
+  }
+
+  async *getStreamedResponse(
+    request: ModelRequest,
+  ): AsyncIterable<StreamEvent> {
+    this.requests.push(request);
+    for (const item of [
+      {
+        type: 'program',
+        id: 'prog_abort',
+        call_id: 'call_prog_abort',
+        code: 'await tools.shell();',
+        fingerprint: 'fingerprint:abort',
+      },
+      {
+        type: 'shell_call',
+        id: 'shell_abort',
+        call_id: 'call_shell_abort',
+        status: 'completed',
+        action: { commands: ['sleep 10'] },
+        caller: { type: 'program', caller_id: 'call_prog_abort' },
+      },
+      {
+        type: 'apply_patch_call',
+        id: 'patch_abort',
+        call_id: 'call_patch_abort',
+        status: 'completed',
+        operation: { type: 'delete_file', path: 'temporary.txt' },
+        caller: { type: 'program', caller_id: 'call_prog_abort' },
+      },
+    ]) {
+      yield {
+        type: 'model',
+        event: {
+          type: 'response.output_item.done',
+          item,
+        },
+      };
+    }
+    const error = new Error('aborted');
+    error.name = 'AbortError';
+    throw error;
+  }
+}
+
 // Test for unhandled rejection when stream loop throws
 
 describe('Runner.run (streaming)', () => {
@@ -386,6 +487,73 @@ describe('Runner.run (streaming)', () => {
       callId: 'call_abort',
       status: 'incomplete',
     });
+  });
+
+  it('reconciles streamed programs without outputs on abort', async () => {
+    const model = new AbortAfterStreamedProgramModel('resp-aborted');
+    const agent = new Agent({ name: 'AbortProgram', model });
+
+    const result = await run(agent, 'hi', {
+      stream: true,
+      conversationId: 'conv-program-abort',
+    });
+
+    await result.completed;
+
+    expect(model.requests).toHaveLength(2);
+    expect(model.requests[1].conversationId).toBe('conv-program-abort');
+    expect(getRequestInputItems(model.requests[1])).toEqual([
+      expect.objectContaining({
+        type: 'program_output',
+        id: expect.stringMatching(/^prog_out_[0-9a-f]{32}$/),
+        callId: 'call_prog_abort',
+        status: 'incomplete',
+        output: 'aborted',
+      }),
+    ]);
+  });
+
+  it('reconciles program-owned shell and apply_patch calls on abort', async () => {
+    const model = new AbortAfterStreamedProgramToolCallsModel();
+    const agent = new Agent({ name: 'AbortProgramTools', model });
+
+    const result = await run(agent, 'hi', {
+      stream: true,
+      conversationId: 'conv-program-tools-abort',
+    });
+
+    await result.completed;
+
+    expect(model.requests).toHaveLength(2);
+    expect(model.requests[1].conversationId).toBe('conv-program-tools-abort');
+    expect(getRequestInputItems(model.requests[1])).toEqual([
+      {
+        type: 'shell_call_output',
+        callId: 'call_shell_abort',
+        status: 'incomplete',
+        output: [
+          {
+            stdout: '',
+            stderr: 'aborted',
+            outcome: { type: 'timeout' },
+          },
+        ],
+        caller: { type: 'program', callerId: 'call_prog_abort' },
+      },
+      {
+        type: 'apply_patch_call_output',
+        callId: 'call_patch_abort',
+        status: 'failed',
+        output: 'aborted',
+        caller: { type: 'program', callerId: 'call_prog_abort' },
+      },
+      expect.objectContaining({
+        type: 'program_output',
+        callId: 'call_prog_abort',
+        status: 'incomplete',
+        output: 'aborted',
+      }),
+    ]);
   });
 
   it('emits agent_updated_stream_event with new agent on handoff', async () => {
@@ -3047,8 +3215,7 @@ describe('Runner.run (streaming)', () => {
       .mockResolvedValue();
 
     let resolveGuardrail:
-      | ((value: GuardrailFunctionOutput) => void)
-      | undefined;
+      ((value: GuardrailFunctionOutput) => void) | undefined;
     const guardrail = {
       name: 'parallel-allow',
       execute: vi.fn(

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -60,6 +60,7 @@ import {
   hostedMcpTool,
   computerTool,
   shellTool,
+  type HostedTool,
 } from '../src/tool';
 import logger from '../src/logger';
 import { getGlobalTraceProvider } from '../src/tracing/provider';
@@ -82,6 +83,12 @@ import {
   ModelRequest,
   ModelSettings,
 } from '../src/model';
+
+const PROGRAMMATIC_TOOL_CALLING_TOOL: HostedTool = {
+  type: 'hosted_tool',
+  name: 'programmatic_tool_calling',
+  providerData: { type: 'programmatic_tool_calling' },
+};
 
 function getFirstTextContent(item: AgentInputItem): string | undefined {
   if (item.type !== 'message') {
@@ -1035,6 +1042,219 @@ describe('Runner.run', () => {
       expect(model.requests).toHaveLength(2);
       expect(model.requests[0]?.modelSettings.toolChoice).toBe('required');
       expect(model.requests[1]?.modelSettings.toolChoice).toBe('none');
+    });
+
+    it('continues Programmatic Tool Calling through nested calls and program output', async () => {
+      class ProgrammaticToolCallingModel implements Model {
+        requests: ModelRequest[] = [];
+
+        async getResponse(request: ModelRequest): Promise<ModelResponse> {
+          this.requests.push(request);
+          if (this.requests.length === 1) {
+            return {
+              output: [
+                {
+                  type: 'program',
+                  id: 'prog_1',
+                  callId: 'call_prog_1',
+                  code: 'const values = await Promise.all([tools.lookup({key:"a"}), tools.lookup({key:"b"})]); text(JSON.stringify(values));',
+                  fingerprint: 'fp_1',
+                },
+                {
+                  type: 'function_call',
+                  id: 'fc_1',
+                  callId: 'call_1',
+                  name: 'lookup',
+                  arguments: '{"key":"a"}',
+                  caller: { type: 'program', callerId: 'call_prog_1' },
+                },
+                {
+                  type: 'function_call',
+                  id: 'fc_2',
+                  callId: 'call_2',
+                  name: 'lookup',
+                  arguments: '{"key":"b"}',
+                  caller: { type: 'program', callerId: 'call_prog_1' },
+                },
+              ],
+              usage: new Usage(),
+            };
+          }
+          if (this.requests.length === 2) {
+            return {
+              output: [
+                {
+                  type: 'program_output',
+                  id: 'prog_out_1',
+                  callId: 'call_prog_1',
+                  output: '[{"key":"a"},{"key":"b"}]',
+                  status: 'completed',
+                },
+              ],
+              usage: new Usage(),
+            };
+          }
+          return {
+            output: [fakeModelMessage('Program completed.')],
+            usage: new Usage(),
+          };
+        }
+
+        async *getStreamedResponse(): AsyncIterable<protocol.StreamEvent> {
+          yield* [];
+          throw new Error('Not implemented');
+        }
+      }
+
+      const model = new ProgrammaticToolCallingModel();
+      const lookup = tool({
+        name: 'lookup',
+        description: 'Return the requested key.',
+        parameters: z.object({ key: z.string() }),
+        allowedCallers: ['programmatic'],
+        outputSchema: {
+          type: 'object',
+          properties: { key: { type: 'string' } },
+          required: ['key'],
+          additionalProperties: false,
+        },
+        execute: async ({ key }) => ({ key }),
+      });
+      const agent = new Agent({
+        name: 'ProgramAgent',
+        model,
+        tools: [lookup, PROGRAMMATIC_TOOL_CALLING_TOOL],
+        toolUseBehavior: 'stop_on_first_tool',
+        modelSettings: { toolChoice: 'programmatic_tool_calling' },
+      });
+
+      const result = await run(agent, 'Run the program.');
+
+      expect(result.finalOutput).toBe('Program completed.');
+      expect(model.requests).toHaveLength(3);
+      expect(model.requests[0]?.modelSettings.toolChoice).toBe(
+        'programmatic_tool_calling',
+      );
+      expect(model.requests[1]?.modelSettings.toolChoice).toBeUndefined();
+      const secondInput = model.requests[1]?.input as AgentInputItem[];
+      expect(secondInput.map((item) => item.type)).toEqual([
+        'message',
+        'program',
+        'function_call',
+        'function_call',
+        'function_call_result',
+        'function_call_result',
+      ]);
+      expect(
+        secondInput
+          .filter((item) => item.type === 'function_call_result')
+          .map((item) => item.caller),
+      ).toEqual([
+        { type: 'program', callerId: 'call_prog_1' },
+        { type: 'program', callerId: 'call_prog_1' },
+      ]);
+      const thirdInput = model.requests[2]?.input as AgentInputItem[];
+      expect(thirdInput.at(-1)).toMatchObject({
+        type: 'program_output',
+        callId: 'call_prog_1',
+        output: '[{"key":"a"},{"key":"b"}]',
+      });
+    });
+
+    it('accepts Programmatic Tool Calling supplied by a prompt template', async () => {
+      const lookup = tool({
+        name: 'prompt_lookup',
+        description: 'Return the requested key.',
+        parameters: z.object({ key: z.string() }),
+        allowedCallers: ['programmatic'],
+        outputSchema: {
+          type: 'object',
+          properties: { key: { type: 'string' } },
+          required: ['key'],
+          additionalProperties: false,
+        },
+        execute: async ({ key }) => ({ key }),
+      });
+      const agent = new Agent({
+        name: 'PromptProgramAgent',
+        model: new FakeModel([
+          {
+            output: [
+              {
+                type: 'program',
+                id: 'prog_prompt_supplied',
+                callId: 'call_prog_prompt_supplied',
+                code: 'text(await tools.prompt_lookup({key:"prompt"}))',
+                fingerprint: 'fp_prompt_supplied',
+              },
+              {
+                type: 'function_call',
+                id: 'fc_prompt_supplied',
+                callId: 'call_prompt_lookup',
+                name: 'prompt_lookup',
+                arguments: '{"key":"prompt"}',
+                caller: {
+                  type: 'program',
+                  callerId: 'call_prog_prompt_supplied',
+                },
+              },
+            ],
+            usage: new Usage(),
+          },
+          {
+            output: [
+              {
+                type: 'program_output',
+                id: 'prog_out_prompt_supplied',
+                callId: 'call_prog_prompt_supplied',
+                output: '{"key":"prompt"}',
+                status: 'completed',
+              },
+              fakeModelMessage('Prompt program completed.'),
+            ],
+            usage: new Usage(),
+          },
+        ]),
+        prompt: { promptId: 'pmpt_programmatic_tool_calling' },
+        tools: [lookup],
+      });
+
+      const result = await run(agent, 'Run the prompt program.');
+
+      expect(result.finalOutput).toBe('Prompt program completed.');
+      expect(result.newItems.map((item) => item.rawItem.type)).toEqual([
+        'program',
+        'function_call',
+        'function_call_result',
+        'program_output',
+        'message',
+      ]);
+    });
+
+    it('rejects prompt-supplied Programmatic Tool Calling when tools are explicitly disabled', async () => {
+      const agent = new Agent({
+        name: 'PromptProgramAgent',
+        model: new FakeModel([
+          {
+            output: [
+              {
+                type: 'program',
+                id: 'prog_prompt_disabled',
+                callId: 'call_prog_prompt_disabled',
+                code: 'text("blocked")',
+                fingerprint: 'fp_prompt_disabled',
+              },
+            ],
+            usage: new Usage(),
+          },
+        ]),
+        prompt: { promptId: 'pmpt_programmatic_tool_calling' },
+        tools: [],
+      });
+
+      await expect(run(agent, 'Run the prompt program.')).rejects.toThrow(
+        /without programmaticToolCallingTool\(\)/,
+      );
     });
 
     it('sholuld handle structured output', async () => {

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -25,6 +25,7 @@ import {
   attachClientToolSearchExecutor,
   applyPatchTool,
   computerTool,
+  hostedMcpTool,
   shellTool,
   tool,
   toolNamespace,
@@ -993,6 +994,293 @@ describe('RunState', () => {
     expect((restoredItem as RunToolCallOutputItem).rawItem).toEqual(
       rawShellOutput,
     );
+  });
+
+  it('round-trips Programmatic Tool Calling items in schema 1.14', async () => {
+    const context = new RunContext();
+    const agent = new Agent({ name: 'ProgramAgent' });
+    const program: protocol.ProgramCallItem = {
+      type: 'program',
+      id: 'prog_1',
+      callId: 'call_prog_1',
+      code: 'text("ok")',
+      fingerprint: 'fp_1',
+    };
+    const programOutput: protocol.ProgramCallResultItem = {
+      type: 'program_output',
+      id: 'prog_out_1',
+      callId: 'call_prog_1',
+      output: 'ok',
+      status: 'completed',
+    };
+    const state = new RunState(context, 'input', agent, 1);
+    state._generatedItems.push(
+      new RunToolCallItem(program, agent),
+      new RunToolCallOutputItem(programOutput, agent, programOutput.output),
+    );
+
+    const serialized = state.toJSON();
+    expect(serialized.$schemaVersion).toBe('1.14');
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+    expect(restored._generatedItems.map((item) => item.rawItem)).toEqual([
+      program,
+      programOutput,
+    ]);
+
+    serialized.$schemaVersion = '1.13';
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow('does not support Programmatic Tool Calling items');
+  });
+
+  it('rejects pre-1.14 state with program-owned hosted calls', async () => {
+    const agent = new Agent({ name: 'HostedProgramAgent' });
+    const hostedCall: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      id: 'ci_1',
+      name: 'code_interpreter_call',
+      status: 'completed',
+      caller: { type: 'program', callerId: 'call_prog_1' },
+      providerData: { type: 'code_interpreter_call' },
+    };
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    state._generatedItems.push(new RunToolCallItem(hostedCall, agent));
+
+    const restored = await RunState.fromString(agent, state.toString());
+    expect(restored._generatedItems[0].rawItem).toEqual(hostedCall);
+
+    const serialized = state.toJSON();
+    serialized.$schemaVersion = '1.13';
+
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow('does not support Programmatic Tool Calling items');
+  });
+
+  it('rechecks allowed callers against rebound tools during resume', async () => {
+    const caller = {
+      type: 'program' as const,
+      callerId: 'call_program',
+    };
+    const createProcessedResponse = (
+      overrides: Record<string, unknown>,
+    ): NonNullable<RunState<any, any>['_lastProcessedResponse']> =>
+      ({
+        newItems: [],
+        toolsUsed: [],
+        handoffs: [],
+        functions: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        hasToolsOrApprovalsToRun: () => true,
+        ...overrides,
+      }) as NonNullable<RunState<any, any>['_lastProcessedResponse']>;
+
+    const savedFunction = tool({
+      name: 'lookup',
+      description: 'Look up a value.',
+      parameters: z.object({}),
+      allowedCallers: ['programmatic'],
+      execute: async () => 'saved',
+    });
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'lookup',
+      callId: 'call_function',
+      arguments: '{}',
+      caller,
+    };
+    const savedFunctionAgent = new Agent({
+      name: 'FunctionResumeAgent',
+      tools: [savedFunction],
+    });
+    const functionState = new RunState(
+      new RunContext(),
+      'input',
+      savedFunctionAgent,
+      1,
+    );
+    functionState._lastProcessedResponse = createProcessedResponse({
+      functions: [{ toolCall: functionCall, tool: savedFunction }],
+    });
+
+    await expect(
+      RunState.fromString(savedFunctionAgent, functionState.toString()),
+    ).resolves.toBeInstanceOf(RunState);
+
+    const reboundFunctionAgent = new Agent({
+      name: 'FunctionResumeAgent',
+      tools: [
+        tool({
+          name: 'lookup',
+          description: 'Look up a value.',
+          parameters: z.object({}),
+          execute: async () => 'rebound',
+        }),
+      ],
+    });
+    await expect(
+      RunState.fromString(reboundFunctionAgent, functionState.toString()),
+    ).rejects.toThrow(/caller programmatic/);
+
+    const savedShell = shellTool({
+      shell: new FakeShell(),
+      allowedCallers: ['programmatic'],
+    });
+    const shellCall: protocol.ShellCallItem = {
+      type: 'shell_call',
+      callId: 'call_shell',
+      action: { commands: ['echo hi'] },
+      caller,
+    };
+    const savedShellAgent = new Agent({
+      name: 'ShellResumeAgent',
+      tools: [savedShell],
+    });
+    const shellState = new RunState(
+      new RunContext(),
+      'input',
+      savedShellAgent,
+      1,
+    );
+    shellState._lastProcessedResponse = createProcessedResponse({
+      shellActions: [{ toolCall: shellCall, shell: savedShell }],
+    });
+    const reboundShellAgent = new Agent({
+      name: 'ShellResumeAgent',
+      tools: [shellTool({ shell: new FakeShell() })],
+    });
+    await expect(
+      RunState.fromString(reboundShellAgent, shellState.toString()),
+    ).rejects.toThrow(/caller programmatic/);
+
+    const savedApplyPatch = applyPatchTool({
+      editor: new FakeEditor(),
+      allowedCallers: ['programmatic'],
+    });
+    const applyPatchCall: protocol.ApplyPatchCallItem = {
+      type: 'apply_patch_call',
+      callId: 'call_apply_patch',
+      status: 'completed',
+      operation: { type: 'delete_file', path: 'temp.txt' },
+      caller,
+    };
+    const savedApplyPatchAgent = new Agent({
+      name: 'ApplyPatchResumeAgent',
+      tools: [savedApplyPatch],
+    });
+    const applyPatchState = new RunState(
+      new RunContext(),
+      'input',
+      savedApplyPatchAgent,
+      1,
+    );
+    applyPatchState._lastProcessedResponse = createProcessedResponse({
+      applyPatchActions: [
+        { toolCall: applyPatchCall, applyPatch: savedApplyPatch },
+      ],
+    });
+    const reboundApplyPatchAgent = new Agent({
+      name: 'ApplyPatchResumeAgent',
+      tools: [applyPatchTool({ editor: new FakeEditor() })],
+    });
+    await expect(
+      RunState.fromString(reboundApplyPatchAgent, applyPatchState.toString()),
+    ).rejects.toThrow(/caller programmatic/);
+
+    const savedMcp = hostedMcpTool({
+      serverLabel: 'inventory',
+      serverUrl: 'https://inventory.example.com/mcp',
+      requireApproval: 'always',
+      allowedCallers: ['programmatic'],
+    });
+    const savedMcpAgent = new Agent({
+      name: 'McpResumeAgent',
+      tools: [savedMcp],
+    });
+    const mcpApprovalCall: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      name: 'lookup_inventory',
+      status: 'in_progress',
+      caller,
+      providerData: {
+        type: 'mcp_approval_request',
+        id: 'approval_inventory',
+        arguments: '{"sku":"sku_123"}',
+        name: 'lookup_inventory',
+        server_label: 'inventory',
+      },
+    };
+    const mcpState = new RunState(new RunContext(), 'input', savedMcpAgent, 1);
+    mcpState._lastProcessedResponse = createProcessedResponse({
+      mcpApprovalRequests: [
+        {
+          requestItem: new ToolApprovalItem(mcpApprovalCall, savedMcpAgent),
+          mcpTool: savedMcp,
+        },
+      ],
+    });
+    const reboundMcpAgent = new Agent({
+      name: 'McpResumeAgent',
+      tools: [
+        hostedMcpTool({
+          serverLabel: 'inventory',
+          serverUrl: 'https://inventory.example.com/mcp',
+          requireApproval: 'always',
+        }),
+      ],
+    });
+    await expect(
+      RunState.fromString(reboundMcpAgent, mcpState.toString()),
+    ).rejects.toThrow(/caller programmatic/);
+  });
+
+  it('accepts schema 1.13 application data that resembles PTC items', async () => {
+    const context = new RunContext({
+      nested: { type: 'program_output' },
+    });
+    context.toolInput = { type: 'program', callId: 'tool_input_program' };
+    const agent = new Agent({ name: 'ProgramLikeDataAgent' });
+    const state = new RunState(context, 'input', agent, 1);
+    const rawItem: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      name: 'lookup',
+      callId: 'call_program_like_data',
+      status: 'completed',
+      output: 'done',
+      providerData: {
+        nested: { type: 'program_output' },
+      },
+    };
+    state._generatedItems.push(
+      new RunToolCallOutputItem(rawItem, agent, 'done', {
+        nested: { type: 'program', callId: 'custom_data_program' },
+      }),
+    );
+
+    const serialized = state.toJSON();
+    serialized.$schemaVersion = '1.13';
+
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+
+    expect(restored._context.context).toEqual(context.context);
+    expect(restored._context.toolInput).toEqual(context.toolInput);
+    expect(restored._generatedItems[0].rawItem.providerData).toEqual(
+      rawItem.providerData,
+    );
+    expect(
+      (restored._generatedItems[0] as RunToolCallOutputItem).customData,
+    ).toEqual({
+      nested: { type: 'program', callId: 'custom_data_program' },
+    });
   });
 
   it('throws error if schema version is missing or invalid', async () => {
@@ -2695,7 +2983,16 @@ describe('deserialize helpers', () => {
 
   it('deserializeProcessedResponse restores currentStep', async () => {
     const tool = computerTool({ computer: new FakeComputer() });
-    const agent = new Agent({ name: 'Comp', tools: [tool] });
+    const currentMcpTool = hostedMcpTool({
+      serverLabel: 'gitmcp',
+      serverUrl: 'https://gitmcp.io/openai/codex',
+      requireApproval: 'always',
+      allowedCallers: ['programmatic'],
+    });
+    const agent = new Agent({
+      name: 'Comp',
+      tools: [tool, currentMcpTool],
+    });
     const state = new RunState(new RunContext(), '', agent, 1);
     const call: protocol.ComputerUseCallItem = {
       type: 'computer_call',
@@ -2717,6 +3014,10 @@ describe('deserialize helpers', () => {
               type: 'hosted_tool_call',
               name: 'fetch_generic_url_content',
               status: 'in_progress',
+              caller: {
+                type: 'program',
+                callerId: 'prog_approval_1',
+              },
               providerData: {
                 id: 'mcpr_685bc3c47ed88192977549b5206db77504d4306d5de6ab36',
                 type: 'mcp_approval_request',
@@ -2772,7 +3073,7 @@ describe('deserialize helpers', () => {
     }
     expect(
       restored._lastProcessedResponse?.mcpApprovalRequests[0].mcpTool,
-    ).toEqual(state._lastProcessedResponse?.mcpApprovalRequests[0].mcpTool);
+    ).toBe(currentMcpTool);
     expect(
       restored._lastProcessedResponse?.mcpApprovalRequests[0].requestItem
         .rawItem.providerData,
@@ -2780,6 +3081,17 @@ describe('deserialize helpers', () => {
       state._lastProcessedResponse?.mcpApprovalRequests[0].requestItem.rawItem
         .providerData,
     );
+    const restoredApprovalRawItem =
+      restored._lastProcessedResponse?.mcpApprovalRequests[0].requestItem
+        .rawItem;
+    expect(restoredApprovalRawItem?.type).toBe('hosted_tool_call');
+    if (restoredApprovalRawItem?.type !== 'hosted_tool_call') {
+      throw new Error('Expected a hosted MCP approval item');
+    }
+    expect(restoredApprovalRawItem.caller).toEqual({
+      type: 'program',
+      callerId: 'prog_approval_1',
+    });
   });
 
   it('rejects resumed function tools when isEnabled is false in replacement context', async () => {

--- a/packages/agents-core/test/runner/items.helpers.test.ts
+++ b/packages/agents-core/test/runner/items.helpers.test.ts
@@ -39,6 +39,106 @@ describe('prepareModelInputItems', () => {
     ]);
   });
 
+  it('drops orphan generated programs and keeps completed programs', () => {
+    const agent = new Agent({ name: 'HelperAgent' });
+    const orphanProgram = new RunToolCallItem(
+      {
+        type: 'program',
+        callId: 'program_orphan',
+        code: 'return "orphan";',
+        fingerprint: 'fingerprint:orphan',
+      } satisfies protocol.ProgramCallItem,
+      agent,
+    );
+    const completedProgram = new RunToolCallItem(
+      {
+        type: 'program',
+        callId: 'program_completed',
+        code: 'return "completed";',
+        fingerprint: 'fingerprint:completed',
+      } satisfies protocol.ProgramCallItem,
+      agent,
+    );
+    const programOutput = new RunToolCallOutputItem(
+      {
+        type: 'program_output',
+        callId: 'program_completed',
+        output: 'completed',
+        status: 'completed',
+      } satisfies protocol.ProgramCallResultItem,
+      agent,
+      'completed',
+    );
+
+    const prepared = prepareModelInputItems('hello', [
+      orphanProgram,
+      completedProgram,
+      programOutput,
+    ]);
+
+    expect(prepared).toEqual([
+      {
+        type: 'message',
+        role: 'user',
+        content: 'hello',
+      },
+      completedProgram.rawItem,
+      programOutput.rawItem,
+    ]);
+  });
+
+  it('keeps programs that are waiting on program-owned tool calls', () => {
+    const agent = new Agent({ name: 'HelperAgent' });
+    const program = new RunToolCallItem(
+      {
+        type: 'program',
+        callId: 'program_pending',
+        code: 'return await tools.lookup({ key: "value" });',
+        fingerprint: 'fingerprint:pending',
+      } satisfies protocol.ProgramCallItem,
+      agent,
+    );
+    const functionCall = new RunToolCallItem(
+      {
+        type: 'function_call',
+        callId: 'lookup_pending',
+        name: 'lookup',
+        arguments: '{"key":"value"}',
+        caller: { type: 'program', callerId: 'program_pending' },
+      } satisfies protocol.FunctionCallItem,
+      agent,
+    );
+    const functionOutput = new RunToolCallOutputItem(
+      {
+        type: 'function_call_result',
+        callId: 'lookup_pending',
+        name: 'lookup',
+        status: 'completed',
+        output: 'value',
+        caller: { type: 'program', callerId: 'program_pending' },
+      } satisfies protocol.FunctionCallResultItem,
+      agent,
+      'value',
+    );
+
+    const prepared = prepareModelInputItems('hello', [
+      program,
+      functionCall,
+      functionOutput,
+    ]);
+
+    expect(prepared).toEqual([
+      {
+        type: 'message',
+        role: 'user',
+        content: 'hello',
+      },
+      program.rawItem,
+      functionCall.rawItem,
+      functionOutput.rawItem,
+    ]);
+  });
+
   it('keeps generated pending hosted shell calls without outputs', () => {
     const agent = new Agent({ name: 'HelperAgent' });
     const shellCall = new RunToolCallItem(
@@ -252,6 +352,284 @@ describe('extractOutputItemsFromRunItems', () => {
 });
 
 describe('dropOrphanToolCalls', () => {
+  it('drops program outputs without matching program calls', () => {
+    const programOutput: protocol.ProgramCallResultItem = {
+      type: 'program_output',
+      callId: 'program_orphan',
+      output: 'done',
+      status: 'completed',
+    };
+
+    expect(dropOrphanToolCalls([programOutput])).toEqual([]);
+    expect(
+      dropOrphanToolCalls([programOutput], {
+        pruningIndexes: new Set([0]),
+      }),
+    ).toEqual([]);
+    expect(
+      dropOrphanToolCalls([programOutput], {
+        pruningIndexes: new Set(),
+      }),
+    ).toEqual([programOutput]);
+  });
+
+  it.each([
+    {
+      name: 'function',
+      call: {
+        type: 'function_call',
+        callId: 'owned_call',
+        name: 'lookup',
+        arguments: '{}',
+        caller: { type: 'program', callerId: 'program_pending' },
+      } satisfies protocol.FunctionCallItem,
+    },
+    {
+      name: 'shell',
+      call: {
+        type: 'shell_call',
+        callId: 'owned_call',
+        status: 'completed',
+        action: { commands: ['echo pending'] },
+        caller: { type: 'program', callerId: 'program_pending' },
+      } satisfies protocol.ShellCallItem,
+    },
+    {
+      name: 'apply patch',
+      call: {
+        type: 'apply_patch_call',
+        callId: 'owned_call',
+        status: 'completed',
+        operation: { type: 'delete_file', path: 'pending.txt' },
+        caller: { type: 'program', callerId: 'program_pending' },
+      } satisfies protocol.ApplyPatchCallItem,
+    },
+  ])('drops a program with an orphan program-owned $name call', ({ call }) => {
+    const program: protocol.ProgramCallItem = {
+      type: 'program',
+      callId: 'program_pending',
+      code: 'return await tools.lookup({});',
+      fingerprint: 'fingerprint:pending',
+    };
+
+    expect(dropOrphanToolCalls([program, call])).toEqual([]);
+  });
+
+  it('drops a program with a dangling program-owned result', () => {
+    const program: protocol.ProgramCallItem = {
+      type: 'program',
+      callId: 'program_pending',
+      code: 'return await tools.lookup({});',
+      fingerprint: 'fingerprint:pending',
+    };
+    const functionOutput: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      callId: 'owned_call',
+      name: 'lookup',
+      status: 'completed',
+      output: 'done',
+      caller: { type: 'program', callerId: 'program_pending' },
+    };
+
+    expect(dropOrphanToolCalls([program, functionOutput])).toEqual([]);
+    expect(
+      dropOrphanToolCalls([program, functionOutput], {
+        pruningIndexes: new Set([0]),
+      }),
+    ).toEqual([]);
+  });
+
+  it('drops a program with an orphan program-owned MCP approval response', () => {
+    const program: protocol.ProgramCallItem = {
+      type: 'program',
+      callId: 'program_pending',
+      code: 'return await tools.lookup({});',
+      fingerprint: 'fingerprint:pending',
+    };
+    const approvalResponse: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      id: 'mcpr_response',
+      name: 'mcp_approval_response',
+      status: 'completed',
+      caller: { type: 'program', callerId: 'program_pending' },
+      providerData: {
+        type: 'mcp_approval_response',
+        approval_request_id: 'mcpr_missing',
+        approve: true,
+      },
+    };
+
+    expect(dropOrphanToolCalls([program, approvalResponse])).toEqual([]);
+  });
+
+  it('keeps a program with a paired program-owned MCP approval response', () => {
+    const program: protocol.ProgramCallItem = {
+      type: 'program',
+      callId: 'program_pending',
+      code: 'return await tools.lookup({});',
+      fingerprint: 'fingerprint:pending',
+    };
+    const approvalRequest: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      id: 'mcpr_request',
+      name: 'mcp_approval_request',
+      status: 'in_progress',
+      caller: { type: 'program', callerId: 'program_pending' },
+      providerData: {
+        type: 'mcp_approval_request',
+        id: 'mcpr_request',
+      },
+    };
+    const approvalResponse: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      id: 'mcpr_response',
+      name: 'mcp_approval_response',
+      status: 'completed',
+      caller: { type: 'program', callerId: 'program_pending' },
+      providerData: {
+        type: 'mcp_approval_response',
+        approval_request_id: 'mcpr_request',
+        approve: true,
+      },
+    };
+
+    expect(
+      dropOrphanToolCalls([program, approvalRequest, approvalResponse]),
+    ).toEqual([program, approvalRequest, approvalResponse]);
+  });
+
+  it('drops program-owned items without their owning program', () => {
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      callId: 'owned_call',
+      name: 'lookup',
+      arguments: '{}',
+      caller: { type: 'program', callerId: 'program_missing' },
+    };
+    const functionOutput: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      callId: 'owned_call',
+      name: 'lookup',
+      status: 'completed',
+      output: 'done',
+      caller: { type: 'program', callerId: 'program_missing' },
+    };
+    const hostedCall: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      id: 'ci_missing',
+      name: 'code_interpreter_call',
+      status: 'completed',
+      caller: { type: 'program', callerId: 'program_missing' },
+      providerData: { type: 'code_interpreter_call' },
+    };
+
+    expect(
+      dropOrphanToolCalls([functionCall, functionOutput, hostedCall]),
+    ).toEqual([]);
+  });
+
+  it('drops dangling owned results from completed programs', () => {
+    const program: protocol.ProgramCallItem = {
+      type: 'program',
+      callId: 'program_completed',
+      code: 'return await tools.lookup({});',
+      fingerprint: 'fingerprint:completed',
+    };
+    const functionOutput: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      callId: 'owned_call',
+      name: 'lookup',
+      status: 'completed',
+      output: 'done',
+      caller: { type: 'program', callerId: 'program_completed' },
+    };
+    const programOutput: protocol.ProgramCallResultItem = {
+      type: 'program_output',
+      callId: 'program_completed',
+      output: 'done',
+      status: 'completed',
+    };
+
+    expect(
+      dropOrphanToolCalls([program, functionOutput, programOutput]),
+    ).toEqual([program, programOutput]);
+  });
+
+  it('keeps a program with a completed owned pair at pruning indexes', () => {
+    const program: protocol.ProgramCallItem = {
+      type: 'program',
+      callId: 'program_pending',
+      code: 'return await tools.lookup({});',
+      fingerprint: 'fingerprint:pending',
+    };
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      callId: 'owned_call',
+      name: 'lookup',
+      arguments: '{}',
+      caller: { type: 'program', callerId: 'program_pending' },
+    };
+    const functionOutput: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      callId: 'owned_call',
+      name: 'lookup',
+      status: 'completed',
+      output: 'done',
+      caller: { type: 'program', callerId: 'program_pending' },
+    };
+
+    expect(
+      dropOrphanToolCalls([program, functionCall, functionOutput], {
+        pruningIndexes: new Set([0, 1, 2]),
+      }),
+    ).toEqual([program, functionCall, functionOutput]);
+  });
+
+  it('keeps active programs with program-owned hosted calls', () => {
+    const program: protocol.ProgramCallItem = {
+      type: 'program',
+      callId: 'program_pending',
+      code: 'return await tools.code_interpreter({});',
+      fingerprint: 'fingerprint:pending',
+    };
+    const hostedCall: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      id: 'ci_1',
+      name: 'code_interpreter_call',
+      status: 'completed',
+      caller: { type: 'program', callerId: 'program_pending' },
+      providerData: { type: 'code_interpreter_call' },
+    };
+
+    expect(dropOrphanToolCalls([program, hostedCall])).toEqual([
+      program,
+      hostedCall,
+    ]);
+  });
+
+  it('drops program-owned hosted calls with an explicitly pruned owner', () => {
+    const program: protocol.ProgramCallItem = {
+      type: 'program',
+      callId: 'program_orphan',
+      code: 'return await tools.code_interpreter({});',
+      fingerprint: 'fingerprint:orphan',
+    };
+    const hostedCall: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      id: 'ci_1',
+      name: 'code_interpreter_call',
+      status: 'completed',
+      caller: { type: 'program', callerId: 'program_orphan' },
+      providerData: { type: 'code_interpreter_call' },
+    };
+
+    expect(
+      dropOrphanToolCalls([program, hostedCall], {
+        pruningIndexes: new Set([0, 1]),
+      }),
+    ).toEqual([]);
+  });
+
   it('prunes only the indexes explicitly marked for pruning', () => {
     const historyShell: AgentInputItem = {
       type: 'shell_call',

--- a/packages/agents-core/test/runner/mcpApprovals.test.ts
+++ b/packages/agents-core/test/runner/mcpApprovals.test.ts
@@ -30,6 +30,7 @@ const buildApprovalRequest = (id = 'mcpr_1'): ToolRunMCPApprovalRequest => {
       id: providerData.id,
       status: 'in_progress',
       providerData,
+      caller: { type: 'program', callerId: 'call_prog_1' },
     },
     TEST_AGENT,
   );
@@ -79,6 +80,10 @@ describe('handleHostedMcpApprovals', () => {
     const response = newItems[0] as RunToolCallItem;
     const raw = response.rawItem as protocol.HostedToolCallItem;
     expect(raw.name).toBe('mcp_approval_response');
+    expect(raw.caller).toEqual({
+      type: 'program',
+      callerId: 'call_prog_1',
+    });
     expect(result.pendingApprovals.size).toBe(0);
     expect(result.pendingApprovalIds.size).toBe(0);
   });
@@ -112,6 +117,10 @@ describe('handleHostedMcpApprovals', () => {
     expect(providerData).toMatchObject({
       approval_request_id: 'mcpr_approved',
       approve: true,
+    });
+    expect((response.rawItem as protocol.HostedToolCallItem).caller).toEqual({
+      type: 'program',
+      callerId: 'call_prog_1',
     });
     expect(result.pendingApprovals.size).toBe(0);
     expect(result.pendingApprovalIds.size).toBe(0);
@@ -149,6 +158,10 @@ describe('handleHostedMcpApprovals', () => {
       approval_request_id: 'mcpr_rejected',
       approve: false,
       reason: 'Denied by policy',
+    });
+    expect((response.rawItem as protocol.HostedToolCallItem).caller).toEqual({
+      type: 'program',
+      callerId: 'call_prog_1',
     });
     expect(result.pendingApprovals.size).toBe(0);
     expect(result.pendingApprovalIds.size).toBe(0);

--- a/packages/agents-core/test/runner/modelOutputs.test.ts
+++ b/packages/agents-core/test/runner/modelOutputs.test.ts
@@ -28,6 +28,7 @@ import {
   shellTool,
   tool,
   toolNamespace,
+  type HostedTool,
 } from '../../src/tool';
 import {
   FUNCTION_TOOL_NAMESPACE,
@@ -52,6 +53,12 @@ beforeAll(() => {
   setDefaultModelProvider(new FakeModelProvider());
 });
 
+const PROGRAMMATIC_TOOL_CALLING_TOOL: HostedTool = {
+  type: 'hosted_tool',
+  name: 'programmatic_tool_calling',
+  providerData: { type: 'programmatic_tool_calling' },
+};
+
 function createLegacyNamespacedTool<T extends Record<string, any>>(
   tool: T,
   namespace: string,
@@ -72,6 +79,586 @@ function createLegacyNamespacedTool<T extends Record<string, any>>(
 }
 
 describe('processModelResponse', () => {
+  it('classifies program calls and outputs as ordered run items', () => {
+    const result = processModelResponse(
+      {
+        output: [
+          {
+            type: 'program',
+            id: 'prog_1',
+            callId: 'call_prog_1',
+            code: 'text("ok")',
+            fingerprint: 'fp_1',
+          },
+          {
+            type: 'program_output',
+            id: 'prog_out_1',
+            callId: 'call_prog_1',
+            output: 'ok',
+            status: 'completed',
+          },
+        ],
+        usage: new Usage(),
+      },
+      TEST_AGENT,
+      [PROGRAMMATIC_TOOL_CALLING_TOOL],
+      [],
+    );
+
+    expect(result.newItems).toHaveLength(2);
+    expect(result.newItems[0]).toBeInstanceOf(ToolCallItem);
+    expect(result.newItems[1]).toBeInstanceOf(ToolCallOutputItem);
+    expect(result.toolsUsed).toEqual(['programmatic_tool_calling']);
+  });
+
+  it('rejects program calls when programmaticToolCallingTool is unavailable in sync and async processing', async () => {
+    const programCall: protocol.ProgramCallItem = {
+      type: 'program',
+      id: 'prog_unavailable',
+      callId: 'call_prog_unavailable',
+      code: 'text("ok")',
+      fingerprint: 'fp_unavailable',
+    };
+    const response: ModelResponse = {
+      output: [programCall],
+      usage: new Usage(),
+    };
+
+    expect(() => processModelResponse(response, TEST_AGENT, [], [])).toThrow(
+      /without programmaticToolCallingTool\(\)/,
+    );
+
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: {
+          type: 'tool_search',
+          execution: 'client',
+        },
+      },
+      async () => [],
+    );
+    const toolSearchCall: protocol.ToolSearchCallItem = {
+      type: 'tool_search_call',
+      id: 'ts_before_program',
+      status: 'completed',
+      arguments: { paths: [] },
+      providerData: {
+        call_id: 'call_ts_before_program',
+        execution: 'client',
+      },
+    };
+
+    await expect(
+      processModelResponseAsync(
+        {
+          output: [toolSearchCall, programCall],
+          usage: new Usage(),
+        },
+        TEST_AGENT,
+        [clientToolSearch],
+        [],
+        new RunState(new RunContext(), 'hello', TEST_AGENT, 1),
+        [],
+      ),
+    ).rejects.toThrow(/without programmaticToolCallingTool\(\)/);
+  });
+
+  it('accepts program calls when a prompt may supply programmaticToolCallingTool in sync and async processing', async () => {
+    const programCall: protocol.ProgramCallItem = {
+      type: 'program',
+      id: 'prog_prompt_supplied',
+      callId: 'call_prog_prompt_supplied',
+      code: 'text("ok")',
+      fingerprint: 'fp_prompt_supplied',
+    };
+    const response: ModelResponse = {
+      output: [programCall],
+      usage: new Usage(),
+    };
+    const processingOptions = { allowPromptSuppliedTools: true };
+
+    const syncResult = processModelResponse(
+      response,
+      TEST_AGENT,
+      [],
+      [],
+      [],
+      'raise_error',
+      processingOptions,
+    );
+    expect(syncResult.toolsUsed).toEqual(['programmatic_tool_calling']);
+
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: {
+          type: 'tool_search',
+          execution: 'client',
+        },
+      },
+      async () => [],
+    );
+    const toolSearchCall: protocol.ToolSearchCallItem = {
+      type: 'tool_search_call',
+      id: 'ts_before_prompt_program',
+      status: 'completed',
+      arguments: { paths: [] },
+      providerData: {
+        call_id: 'call_ts_before_prompt_program',
+        execution: 'client',
+      },
+    };
+    const asyncResult = await processModelResponseAsync(
+      {
+        output: [toolSearchCall, programCall],
+        usage: new Usage(),
+      },
+      TEST_AGENT,
+      [clientToolSearch],
+      [],
+      new RunState(new RunContext(), 'hello', TEST_AGENT, 1),
+      [],
+      'raise_error',
+      processingOptions,
+    );
+    expect(asyncResult.toolsUsed).toEqual([
+      'tool_search',
+      'programmatic_tool_calling',
+    ]);
+  });
+
+  it('rejects function and handoff calls from disallowed callers', () => {
+    const programOnlyFunction = tool({
+      name: 'program_only',
+      description: 'Program-only function.',
+      parameters: z.object({}),
+      allowedCallers: ['programmatic'],
+      execute: async () => 'ok',
+    });
+    const directFunctionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      callId: 'call_direct',
+      name: 'program_only',
+      arguments: '{}',
+    };
+    expect(() =>
+      processModelResponse(
+        { output: [directFunctionCall], usage: new Usage() },
+        TEST_AGENT,
+        [programOnlyFunction],
+        [],
+      ),
+    ).toThrow(/caller direct/);
+
+    const programFunctionCall: protocol.FunctionCallItem = {
+      ...TEST_MODEL_FUNCTION_CALL,
+      caller: { type: 'program', callerId: 'call_program' },
+    };
+    expect(() =>
+      processModelResponse(
+        { output: [programFunctionCall], usage: new Usage() },
+        TEST_AGENT,
+        [TEST_TOOL],
+        [],
+      ),
+    ).toThrow(/caller programmatic/);
+
+    const target = new Agent({ name: 'Target' });
+    const targetHandoff = handoff(target);
+    const programHandoffCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      callId: 'call_handoff',
+      name: targetHandoff.toolName,
+      arguments: '{}',
+      caller: { type: 'program', callerId: 'call_program' },
+    };
+    expect(() =>
+      processModelResponse(
+        { output: [programHandoffCall], usage: new Usage() },
+        TEST_AGENT,
+        [],
+        [targetHandoff],
+      ),
+    ).toThrow(/caller programmatic/);
+  });
+
+  it('rejects direct Code Interpreter calls for programmatic-only tools in sync and async processing', async () => {
+    const codeInterpreter: HostedTool = {
+      type: 'hosted_tool',
+      name: 'code_interpreter',
+      providerData: {
+        type: 'code_interpreter',
+        container: { type: 'auto' },
+        allowed_callers: ['programmatic'],
+      },
+    };
+    const directCodeInterpreterCall: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      id: 'ci_direct',
+      name: 'code_interpreter_call',
+      status: 'completed',
+      providerData: {
+        type: 'code_interpreter_call',
+        code: 'print("hello")',
+        outputs: [],
+      },
+    };
+    const response: ModelResponse = {
+      output: [directCodeInterpreterCall],
+      usage: new Usage(),
+    };
+
+    expect(() =>
+      processModelResponse(response, TEST_AGENT, [codeInterpreter], []),
+    ).toThrow(/caller direct/);
+
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: {
+          type: 'tool_search',
+          execution: 'client',
+        },
+      },
+      async () => [],
+    );
+    const toolSearchCall: protocol.ToolSearchCallItem = {
+      type: 'tool_search_call',
+      id: 'ts_before_ci',
+      status: 'completed',
+      arguments: { paths: [] },
+      providerData: {
+        call_id: 'call_ts_before_ci',
+        execution: 'client',
+      },
+    };
+
+    await expect(
+      processModelResponseAsync(
+        {
+          output: [toolSearchCall, directCodeInterpreterCall],
+          usage: new Usage(),
+        },
+        TEST_AGENT,
+        [clientToolSearch, codeInterpreter],
+        [],
+        new RunState(new RunContext(), 'hello', TEST_AGENT, 1),
+        [],
+      ),
+    ).rejects.toThrow(/caller direct/);
+  });
+
+  it.each(['mcp_call', 'mcp_list_tools'] as const)(
+    'rejects direct %s items for programmatic-only MCP servers in sync and async processing',
+    async (mcpCallType) => {
+      const mcpTool = hostedMcpTool({
+        serverLabel: 'server',
+        serverUrl: 'https://mcp.example.com/server',
+        requireApproval: 'never',
+        allowedCallers: ['programmatic'],
+      });
+      const directMcpCall: protocol.HostedToolCallItem = {
+        type: 'hosted_tool_call',
+        id: `${mcpCallType}_direct`,
+        name: mcpCallType,
+        status: 'completed',
+        providerData:
+          mcpCallType === 'mcp_call'
+            ? {
+                type: mcpCallType,
+                id: 'mcp_call_direct',
+                server_label: 'server',
+                name: 'lookup',
+                arguments: '{}',
+              }
+            : {
+                type: mcpCallType,
+                id: 'mcp_list_tools_direct',
+                server_label: 'server',
+                tools: [],
+              },
+      };
+
+      expect(() =>
+        processModelResponse(
+          { output: [directMcpCall], usage: new Usage() },
+          TEST_AGENT,
+          [mcpTool],
+          [],
+        ),
+      ).toThrow(/caller direct/);
+
+      const clientToolSearch = attachClientToolSearchExecutor(
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: {
+            type: 'tool_search',
+            execution: 'client',
+          },
+        },
+        async () => [],
+      );
+      const toolSearchCall: protocol.ToolSearchCallItem = {
+        type: 'tool_search_call',
+        id: `ts_before_${mcpCallType}`,
+        status: 'completed',
+        arguments: { paths: [] },
+        providerData: {
+          call_id: `call_ts_before_${mcpCallType}`,
+          execution: 'client',
+        },
+      };
+
+      await expect(
+        processModelResponseAsync(
+          {
+            output: [toolSearchCall, directMcpCall],
+            usage: new Usage(),
+          },
+          TEST_AGENT,
+          [clientToolSearch, mcpTool],
+          [],
+          new RunState(new RunContext(), 'hello', TEST_AGENT, 1),
+          [],
+        ),
+      ).rejects.toThrow(/caller direct/);
+    },
+  );
+
+  it.each(['mcp_call', 'mcp_list_tools', 'mcp_approval_request'] as const)(
+    'rejects programmatic %s items before a deferred MCP server is loaded',
+    async (mcpCallType) => {
+      const mcpTool = hostedMcpTool({
+        serverLabel: 'server',
+        serverUrl: 'https://mcp.example.com/server',
+        requireApproval: 'always',
+        deferLoading: true,
+        allowedCallers: ['programmatic'],
+      });
+      const programmaticMcpCall: protocol.HostedToolCallItem = {
+        type: 'hosted_tool_call',
+        id: `${mcpCallType}_programmatic`,
+        name: mcpCallType,
+        status: 'completed',
+        caller: { type: 'program', callerId: 'call_program' },
+        providerData:
+          mcpCallType === 'mcp_call'
+            ? {
+                type: mcpCallType,
+                id: 'mcp_call_programmatic',
+                server_label: 'server',
+                name: 'lookup',
+                arguments: '{}',
+              }
+            : mcpCallType === 'mcp_list_tools'
+              ? {
+                  type: mcpCallType,
+                  id: 'mcp_list_tools_programmatic',
+                  server_label: 'server',
+                  tools: [],
+                }
+              : {
+                  type: mcpCallType,
+                  id: 'mcp_approval_programmatic',
+                  server_label: 'server',
+                  name: 'lookup',
+                  arguments: '{}',
+                },
+      };
+
+      expect(() =>
+        processModelResponse(
+          { output: [programmaticMcpCall], usage: new Usage() },
+          TEST_AGENT,
+          [mcpTool],
+          [],
+        ),
+      ).toThrow(
+        /deferred MCP call server before it was loaded via tool_search/,
+      );
+
+      const clientToolSearch = attachClientToolSearchExecutor(
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: {
+            type: 'tool_search',
+            execution: 'client',
+          },
+        },
+        async () => [],
+      );
+      const toolSearchCall: protocol.ToolSearchCallItem = {
+        type: 'tool_search_call',
+        id: `ts_before_unloaded_${mcpCallType}`,
+        status: 'completed',
+        arguments: { paths: [] },
+        providerData: {
+          call_id: `call_ts_before_unloaded_${mcpCallType}`,
+          execution: 'client',
+        },
+      };
+
+      await expect(
+        processModelResponseAsync(
+          {
+            output: [toolSearchCall, programmaticMcpCall],
+            usage: new Usage(),
+          },
+          TEST_AGENT,
+          [clientToolSearch, mcpTool],
+          [],
+          new RunState(new RunContext(), 'hello', TEST_AGENT, 1),
+          [],
+        ),
+      ).rejects.toThrow(
+        /deferred MCP call server before it was loaded via tool_search/,
+      );
+    },
+  );
+
+  it('accepts programmatic calls after a deferred MCP server is loaded', () => {
+    const mcpTool = hostedMcpTool({
+      serverLabel: 'server',
+      serverUrl: 'https://mcp.example.com/server',
+      requireApproval: 'never',
+      deferLoading: true,
+      allowedCallers: ['programmatic'],
+    });
+    const priorItems = [
+      new ToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_server',
+          status: 'completed',
+          tools: [mcpTool.providerData],
+        },
+        TEST_AGENT,
+      ),
+    ];
+    const programmaticMcpCall: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      id: 'mcp_call_programmatic',
+      name: 'mcp_call',
+      status: 'completed',
+      caller: { type: 'program', callerId: 'call_program' },
+      providerData: {
+        type: 'mcp_call',
+        id: 'mcp_call_programmatic',
+        server_label: 'server',
+        name: 'lookup',
+        arguments: '{}',
+      },
+    };
+
+    const result = processModelResponse(
+      { output: [programmaticMcpCall], usage: new Usage() },
+      TEST_AGENT,
+      [mcpTool],
+      [],
+      priorItems,
+    );
+
+    expect(result.newItems).toHaveLength(1);
+    expect(result.newItems[0]).toBeInstanceOf(ToolCallItem);
+  });
+
+  it('rejects shell and apply_patch calls from disallowed callers', () => {
+    const programShellCall: protocol.ShellCallItem = {
+      type: 'shell_call',
+      callId: 'call_shell',
+      action: { commands: ['echo hi'] },
+      caller: { type: 'program', callerId: 'call_program' },
+    };
+    expect(() =>
+      processModelResponse(
+        { output: [programShellCall], usage: new Usage() },
+        TEST_AGENT,
+        [shellTool({ shell: new FakeShell() })],
+        [],
+      ),
+    ).toThrow(/caller programmatic/);
+
+    const directApplyPatchCall: protocol.ApplyPatchCallItem = {
+      type: 'apply_patch_call',
+      callId: 'call_patch',
+      status: 'completed',
+      operation: { type: 'delete_file', path: 'temp.txt' },
+    };
+    expect(() =>
+      processModelResponse(
+        { output: [directApplyPatchCall], usage: new Usage() },
+        TEST_AGENT,
+        [
+          applyPatchTool({
+            editor: new FakeEditor(),
+            allowedCallers: ['programmatic'],
+          }),
+        ],
+        [],
+      ),
+    ).toThrow(/caller direct/);
+  });
+
+  it('queues function, shell, and apply_patch calls from allowed program callers', () => {
+    const programFunction = tool({
+      name: 'program_function',
+      description: 'Program-callable function.',
+      parameters: z.object({}),
+      allowedCallers: ['programmatic'],
+      execute: async () => 'ok',
+    });
+    const programShell = shellTool({
+      shell: new FakeShell(),
+      allowedCallers: ['programmatic'],
+    });
+    const programApplyPatch = applyPatchTool({
+      editor: new FakeEditor(),
+      allowedCallers: ['programmatic'],
+    });
+    const caller = { type: 'program' as const, callerId: 'call_program' };
+
+    const result = processModelResponse(
+      {
+        output: [
+          {
+            type: 'function_call',
+            callId: 'call_function',
+            name: 'program_function',
+            arguments: '{}',
+            caller,
+          },
+          {
+            type: 'shell_call',
+            callId: 'call_shell',
+            action: { commands: ['echo hi'] },
+            caller,
+          },
+          {
+            type: 'apply_patch_call',
+            callId: 'call_patch',
+            status: 'completed',
+            operation: { type: 'delete_file', path: 'temp.txt' },
+            caller,
+          },
+        ],
+        usage: new Usage(),
+      },
+      TEST_AGENT,
+      [programFunction, programShell, programApplyPatch],
+      [],
+    );
+
+    expect(result.functions).toHaveLength(1);
+    expect(result.shellActions).toHaveLength(1);
+    expect(result.applyPatchActions).toHaveLength(1);
+  });
+
   it('processes message outputs and tool calls', () => {
     const modelResponse: ModelResponse = TEST_MODEL_RESPONSE_WITH_FUNCTION;
 
@@ -759,6 +1346,71 @@ describe('processModelResponse', () => {
     });
     expect(execute).toHaveBeenCalledTimes(1);
     expect(state.getToolSearchRuntimeTools(agent)).toEqual([lookupAccount]);
+  });
+
+  it('rejects disallowed callers for tools loaded by custom client tool_search', async () => {
+    const programOnlyLookup = tool({
+      name: 'lookup_account',
+      description: 'Look up an account.',
+      parameters: z.object({ accountId: z.string() }),
+      allowedCallers: ['programmatic'],
+      execute: async () => 'account',
+    });
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: {
+          type: 'tool_search',
+          execution: 'client',
+          parameters: {
+            type: 'object',
+            properties: {
+              namespaceHints: {
+                type: 'array',
+                items: { type: 'string' },
+              },
+            },
+            required: ['namespaceHints'],
+            additionalProperties: false,
+          },
+        },
+      },
+      async () => programOnlyLookup,
+    );
+    const agent = new Agent({ name: 'CustomClientToolSearchAgent' });
+    const state = new RunState(new RunContext(), 'hello', agent, 3);
+
+    await expect(
+      processModelResponseAsync(
+        {
+          output: [
+            {
+              type: 'tool_search_call',
+              id: 'ts_call_lookup',
+              status: 'completed',
+              arguments: { namespaceHints: ['crm'] },
+              providerData: {
+                call_id: 'call_tool_search_lookup',
+                execution: 'client',
+              },
+            },
+            {
+              type: 'function_call',
+              callId: 'call_lookup_account',
+              name: 'lookup_account',
+              arguments: '{"accountId":"acct_42"}',
+            },
+          ],
+          usage: new Usage(),
+        },
+        agent,
+        [clientToolSearch],
+        [],
+        state,
+        [],
+      ),
+    ).rejects.toThrow(/caller direct/);
   });
 
   it('does not auto-execute tool_search calls that explicitly request server execution', () => {
@@ -1914,6 +2566,98 @@ describe('processModelResponse', () => {
     ).toThrow(ModelBehaviorError);
   });
 
+  it('preserves callers on hosted MCP approval items in sync and async processing', async () => {
+    const mcpTool = hostedMcpTool({
+      serverLabel: 'server',
+      requireApproval: 'always',
+      allowedCallers: ['programmatic'],
+    });
+    const hostedCall: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      name: 'mcp_approval_request',
+      id: 'mcpr_program',
+      status: 'in_progress',
+      caller: { type: 'program', callerId: 'call_prog_1' },
+      providerData: {
+        type: 'mcp_approval_request',
+        server_label: 'server',
+        name: 'lookup',
+        id: 'mcpr_program',
+        arguments: '{}',
+      },
+    };
+    const response: ModelResponse = {
+      output: [hostedCall],
+      usage: new Usage(),
+    };
+
+    const syncResult = processModelResponse(
+      response,
+      TEST_AGENT,
+      [mcpTool],
+      [],
+    );
+    const asyncResult = await processModelResponseAsync(
+      response,
+      TEST_AGENT,
+      [mcpTool],
+      [],
+      new RunState(new RunContext(), 'hello', TEST_AGENT, 1),
+      [],
+    );
+
+    for (const result of [syncResult, asyncResult]) {
+      expect(
+        (
+          result.mcpApprovalRequests[0].requestItem
+            .rawItem as protocol.HostedToolCallItem
+        ).caller,
+      ).toEqual({
+        type: 'program',
+        callerId: 'call_prog_1',
+      });
+    }
+  });
+
+  it('rejects direct MCP approvals for programmatic-only servers', async () => {
+    const mcpTool = hostedMcpTool({
+      serverLabel: 'server',
+      requireApproval: 'always',
+      allowedCallers: ['programmatic'],
+    });
+    const hostedCall: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      name: 'mcp_approval_request',
+      id: 'mcpr_direct',
+      status: 'in_progress',
+      providerData: {
+        type: 'mcp_approval_request',
+        server_label: 'server',
+        name: 'lookup',
+        id: 'mcpr_direct',
+        arguments: '{}',
+      },
+    };
+    const response: ModelResponse = {
+      output: [hostedCall],
+      usage: new Usage(),
+    };
+
+    expect(() =>
+      processModelResponse(response, TEST_AGENT, [mcpTool], []),
+    ).toThrow(ModelBehaviorError);
+    await expect(
+      processModelResponseAsync(
+        response,
+        TEST_AGENT,
+        [mcpTool],
+        [],
+        new RunState(new RunContext(), 'hello', TEST_AGENT, 1),
+        [],
+      ),
+    ).rejects.toThrow(ModelBehaviorError);
+  });
+
   it('resolves hosted MCP approval requests from tool_search-loaded servers', () => {
     const toolSearchOutput: protocol.ToolSearchOutputItem = {
       type: 'tool_search_output',
@@ -1925,6 +2669,7 @@ describe('processModelResponse', () => {
           server_label: 'shopify',
           server_url: 'https://mcp.example.com/shopify',
           require_approval: 'always',
+          allowed_callers: ['programmatic'],
         },
       ],
     } as any;
@@ -1933,6 +2678,7 @@ describe('processModelResponse', () => {
       name: 'mcp_approval_request',
       id: 'mcpr_shopify',
       status: 'in_progress',
+      caller: { type: 'program', callerId: 'call_prog_1' },
       providerData: {
         type: 'mcp_approval_request',
         server_label: 'shopify',
@@ -1954,6 +2700,7 @@ describe('processModelResponse', () => {
       server_label: 'shopify',
       server_url: 'https://mcp.example.com/shopify',
       require_approval: 'always',
+      allowed_callers: ['programmatic'],
     });
   });
 

--- a/packages/agents-core/test/runner/sessionPersistence.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.test.ts
@@ -1745,6 +1745,242 @@ describe('prepareInputItemsWithSession', () => {
     expect(result.sessionItems).toEqual(toAgentInputList('fresh input'));
   });
 
+  it('keeps resumable programs when callbacks drop only the program output', async () => {
+    const program: AgentInputItem = {
+      type: 'program',
+      callId: 'program_1',
+      code: 'return "done";',
+      fingerprint: 'fingerprint:program-1',
+    };
+    const programOutput: AgentInputItem = {
+      type: 'program_output',
+      callId: 'program_1',
+      output: 'done',
+      status: 'completed',
+    };
+    const functionCall: AgentInputItem = {
+      type: 'function_call',
+      callId: 'lookup_1',
+      name: 'lookup',
+      arguments: '{}',
+      caller: { type: 'program', callerId: 'program_1' },
+    };
+    const functionOutput: AgentInputItem = {
+      type: 'function_call_result',
+      callId: 'lookup_1',
+      name: 'lookup',
+      status: 'completed',
+      output: 'done',
+      caller: { type: 'program', callerId: 'program_1' },
+    };
+    const hostedCall: AgentInputItem = {
+      type: 'hosted_tool_call',
+      id: 'ci_1',
+      name: 'code_interpreter_call',
+      status: 'completed',
+      caller: { type: 'program', callerId: 'program_1' },
+      providerData: { type: 'code_interpreter_call' },
+    };
+    const session = new StubSession([
+      program,
+      functionCall,
+      functionOutput,
+      hostedCall,
+      programOutput,
+    ]);
+
+    const result = await prepareInputItemsWithSession(
+      'fresh input',
+      session,
+      (history, newItems) => [...history.slice(0, -1), ...newItems],
+    );
+
+    expect(result.preparedInput).toEqual([
+      program,
+      functionCall,
+      functionOutput,
+      hostedCall,
+      ...toAgentInputList('fresh input'),
+    ]);
+    expect(result.sessionItems).toEqual(toAgentInputList('fresh input'));
+  });
+
+  it('drops program outputs when callbacks remove their program calls', async () => {
+    const program: AgentInputItem = {
+      type: 'program',
+      callId: 'program_orphan',
+      code: 'return "done";',
+      fingerprint: 'fingerprint:orphan',
+    };
+    const programOutput: AgentInputItem = {
+      type: 'program_output',
+      callId: 'program_orphan',
+      output: 'done',
+      status: 'completed',
+    };
+    const session = new StubSession([program, programOutput]);
+
+    const result = await prepareInputItemsWithSession(
+      'fresh input',
+      session,
+      (history, newItems) => [history[1]!, ...newItems],
+    );
+
+    expect(result.preparedInput).toEqual(toAgentInputList('fresh input'));
+    expect(result.sessionItems).toEqual(toAgentInputList('fresh input'));
+  });
+
+  it('drops program-owned pairs when callbacks remove their program calls', async () => {
+    const program: AgentInputItem = {
+      type: 'program',
+      callId: 'program_orphan',
+      code: 'return await tools.lookup({});',
+      fingerprint: 'fingerprint:orphan',
+    };
+    const functionCall: AgentInputItem = {
+      type: 'function_call',
+      callId: 'lookup_orphan',
+      name: 'lookup',
+      arguments: '{}',
+      caller: { type: 'program', callerId: 'program_orphan' },
+    };
+    const functionOutput: AgentInputItem = {
+      type: 'function_call_result',
+      callId: 'lookup_orphan',
+      name: 'lookup',
+      status: 'completed',
+      output: 'done',
+      caller: { type: 'program', callerId: 'program_orphan' },
+    };
+    const programOutput: AgentInputItem = {
+      type: 'program_output',
+      callId: 'program_orphan',
+      output: 'done',
+      status: 'completed',
+    };
+    const session = new StubSession([
+      program,
+      functionCall,
+      functionOutput,
+      programOutput,
+    ]);
+
+    const result = await prepareInputItemsWithSession(
+      'fresh input',
+      session,
+      (history, newItems) => [...history.slice(1), ...newItems],
+    );
+
+    expect(result.preparedInput).toEqual(toAgentInputList('fresh input'));
+    expect(result.sessionItems).toEqual(toAgentInputList('fresh input'));
+  });
+
+  it('drops dangling owned results from completed session programs', async () => {
+    const program: AgentInputItem = {
+      type: 'program',
+      callId: 'program_completed',
+      code: 'return await tools.lookup({});',
+      fingerprint: 'fingerprint:completed',
+    };
+    const functionCall: AgentInputItem = {
+      type: 'function_call',
+      callId: 'lookup_completed',
+      name: 'lookup',
+      arguments: '{}',
+      caller: { type: 'program', callerId: 'program_completed' },
+    };
+    const functionOutput: AgentInputItem = {
+      type: 'function_call_result',
+      callId: 'lookup_completed',
+      name: 'lookup',
+      status: 'completed',
+      output: 'done',
+      caller: { type: 'program', callerId: 'program_completed' },
+    };
+    const programOutput: AgentInputItem = {
+      type: 'program_output',
+      callId: 'program_completed',
+      output: 'done',
+      status: 'completed',
+    };
+    const session = new StubSession([
+      program,
+      functionCall,
+      functionOutput,
+      programOutput,
+    ]);
+
+    const result = await prepareInputItemsWithSession(
+      'fresh input',
+      session,
+      (history, newItems) => [history[0]!, ...history.slice(2), ...newItems],
+    );
+
+    expect(result.preparedInput).toEqual([
+      program,
+      programOutput,
+      ...toAgentInputList('fresh input'),
+    ]);
+    expect(result.sessionItems).toEqual(toAgentInputList('fresh input'));
+  });
+
+  it('drops pending programs with incomplete owned calls from session history', async () => {
+    const program: AgentInputItem = {
+      type: 'program',
+      callId: 'program_orphan',
+      code: 'return await tools.lookup({});',
+      fingerprint: 'fingerprint:orphan',
+    };
+    const functionCall: AgentInputItem = {
+      type: 'function_call',
+      callId: 'lookup_orphan',
+      name: 'lookup',
+      arguments: '{}',
+      caller: { type: 'program', callerId: 'program_orphan' },
+    };
+    const session = new StubSession([program, functionCall]);
+
+    const result = await prepareInputItemsWithSession('fresh input', session);
+
+    expect(result.preparedInput).toEqual(toAgentInputList('fresh input'));
+    expect(result.sessionItems).toEqual(toAgentInputList('fresh input'));
+  });
+
+  it('keeps pending programs with completed owned pairs in session history', async () => {
+    const program: AgentInputItem = {
+      type: 'program',
+      callId: 'program_pending',
+      code: 'return await tools.lookup({});',
+      fingerprint: 'fingerprint:pending',
+    };
+    const functionCall: AgentInputItem = {
+      type: 'function_call',
+      callId: 'lookup_1',
+      name: 'lookup',
+      arguments: '{}',
+      caller: { type: 'program', callerId: 'program_pending' },
+    };
+    const functionOutput: AgentInputItem = {
+      type: 'function_call_result',
+      callId: 'lookup_1',
+      name: 'lookup',
+      status: 'completed',
+      output: 'done',
+      caller: { type: 'program', callerId: 'program_pending' },
+    };
+    const session = new StubSession([program, functionCall, functionOutput]);
+
+    const result = await prepareInputItemsWithSession('fresh input', session);
+
+    expect(result.preparedInput).toEqual([
+      program,
+      functionCall,
+      functionOutput,
+      ...toAgentInputList('fresh input'),
+    ]);
+    expect(result.sessionItems).toEqual(toAgentInputList('fresh input'));
+  });
+
   it('preserves caller pending shell calls when callbacks also surface orphan history', async () => {
     const historyShell: AgentInputItem = {
       type: 'shell_call',

--- a/packages/agents-core/test/runner/streamReconciliation.test.ts
+++ b/packages/agents-core/test/runner/streamReconciliation.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildAbortReconciliationInput,
+  createStreamAbortReconciliationState,
+  recordStreamEventForAbortReconciliation,
+  shouldReconcileStreamAbort,
+} from '../../src/runner/streamReconciliation';
+
+describe('stream abort reconciliation', () => {
+  it('preserves Programmatic Tool Calling caller linkage', () => {
+    const state = createStreamAbortReconciliationState();
+
+    recordStreamEventForAbortReconciliation(state, {
+      type: 'model',
+      event: {
+        type: 'response.output_item.done',
+        item: {
+          type: 'function_call',
+          id: 'fc_1',
+          call_id: 'call_1',
+          name: 'lookup',
+          arguments: '{}',
+          caller: { type: 'program', caller_id: 'call_prog_1' },
+        },
+      },
+    });
+
+    expect(buildAbortReconciliationInput(state)).toEqual([
+      {
+        type: 'function_call_result',
+        name: 'lookup',
+        callId: 'call_1',
+        status: 'incomplete',
+        output: { type: 'text', text: 'aborted' },
+        caller: { type: 'program', callerId: 'call_prog_1' },
+      },
+    ]);
+  });
+
+  it('reconciles program-owned shell and apply_patch calls', () => {
+    const state = createStreamAbortReconciliationState();
+
+    for (const item of [
+      {
+        type: 'shell_call',
+        id: 'shell_1',
+        call_id: 'call_shell_1',
+        status: 'completed',
+        action: { commands: ['sleep 10'] },
+        caller: { type: 'program', caller_id: 'call_prog_1' },
+      },
+      {
+        type: 'apply_patch_call',
+        id: 'patch_1',
+        call_id: 'call_patch_1',
+        status: 'completed',
+        operation: { type: 'delete_file', path: 'temporary.txt' },
+        caller: { type: 'program', caller_id: 'call_prog_1' },
+      },
+    ]) {
+      recordStreamEventForAbortReconciliation(state, {
+        type: 'model',
+        event: {
+          type: 'response.output_item.done',
+          item,
+        },
+      });
+    }
+
+    expect(shouldReconcileStreamAbort(state)).toBe(true);
+    expect(buildAbortReconciliationInput(state)).toEqual([
+      {
+        type: 'shell_call_output',
+        callId: 'call_shell_1',
+        status: 'incomplete',
+        output: [
+          {
+            stdout: '',
+            stderr: 'aborted',
+            outcome: { type: 'timeout' },
+          },
+        ],
+        caller: { type: 'program', callerId: 'call_prog_1' },
+      },
+      {
+        type: 'apply_patch_call_output',
+        callId: 'call_patch_1',
+        status: 'failed',
+        output: 'aborted',
+        caller: { type: 'program', callerId: 'call_prog_1' },
+      },
+    ]);
+  });
+
+  it('does not reconcile shell and apply_patch calls that have outputs', () => {
+    const state = createStreamAbortReconciliationState();
+
+    for (const item of [
+      {
+        type: 'shell_call',
+        id: 'shell_1',
+        call_id: 'call_shell_1',
+        status: 'completed',
+        action: { commands: ['echo done'] },
+        caller: { type: 'program', caller_id: 'call_prog_1' },
+      },
+      {
+        type: 'apply_patch_call',
+        id: 'patch_1',
+        call_id: 'call_patch_1',
+        status: 'completed',
+        operation: { type: 'delete_file', path: 'temporary.txt' },
+        caller: { type: 'program', caller_id: 'call_prog_1' },
+      },
+      {
+        type: 'shell_call_output',
+        call_id: 'call_shell_1',
+        status: 'completed',
+        output: [
+          {
+            stdout: 'done\n',
+            stderr: '',
+            outcome: { type: 'exit', exit_code: 0 },
+          },
+        ],
+        caller: { type: 'program', caller_id: 'call_prog_1' },
+      },
+      {
+        type: 'apply_patch_call_output',
+        call_id: 'call_patch_1',
+        status: 'completed',
+        output: 'Done!',
+        caller: { type: 'program', caller_id: 'call_prog_1' },
+      },
+    ]) {
+      recordStreamEventForAbortReconciliation(state, {
+        type: 'model',
+        event: {
+          type: 'response.output_item.done',
+          item,
+        },
+      });
+    }
+
+    expect(shouldReconcileStreamAbort(state)).toBe(false);
+    expect(buildAbortReconciliationInput(state)).toEqual([]);
+  });
+
+  it('does not reconcile server-owned hosted shell calls', () => {
+    const state = createStreamAbortReconciliationState();
+
+    recordStreamEventForAbortReconciliation(state, {
+      type: 'model',
+      event: {
+        type: 'response.output_item.done',
+        item: {
+          type: 'shell_call',
+          id: 'shell_hosted',
+          call_id: 'call_shell_hosted',
+          status: 'in_progress',
+          action: { commands: ['echo hosted'] },
+          environment: {
+            type: 'container_reference',
+            container_id: 'container_123',
+          },
+          caller: { type: 'program', caller_id: 'call_prog_1' },
+        },
+      },
+    });
+
+    expect(shouldReconcileStreamAbort(state)).toBe(false);
+    expect(buildAbortReconciliationInput(state)).toEqual([]);
+  });
+
+  it('reconciles programs that have no program output', () => {
+    const state = createStreamAbortReconciliationState();
+
+    recordStreamEventForAbortReconciliation(state, {
+      type: 'model',
+      event: {
+        type: 'response.output_item.done',
+        item: {
+          type: 'program',
+          id: 'prog_1',
+          call_id: 'call_prog_1',
+          code: 'text("done");',
+          fingerprint: 'fingerprint:program-1',
+        },
+      },
+    });
+
+    expect(shouldReconcileStreamAbort(state)).toBe(true);
+    const firstInput = buildAbortReconciliationInput(state);
+    expect(firstInput).toEqual([
+      expect.objectContaining({
+        type: 'program_output',
+        id: expect.stringMatching(/^prog_out_[0-9a-f]{32}$/),
+        callId: 'call_prog_1',
+        status: 'incomplete',
+        output: 'aborted',
+      }),
+    ]);
+    expect(buildAbortReconciliationInput(state)).toEqual(firstInput);
+  });
+
+  it('preserves a streamed program output id during reconciliation', () => {
+    const state = createStreamAbortReconciliationState();
+
+    recordStreamEventForAbortReconciliation(state, {
+      type: 'model',
+      event: {
+        type: 'response.output_item.added',
+        output_index: 1,
+        item: {
+          type: 'program_output',
+          id: 'prog_out_streamed',
+          call_id: 'call_prog_1',
+          result: '',
+          status: 'in_progress',
+        },
+        sequence_number: 1,
+      },
+    });
+
+    expect(buildAbortReconciliationInput(state)).toEqual([
+      {
+        type: 'program_output',
+        id: 'prog_out_streamed',
+        callId: 'call_prog_1',
+        status: 'incomplete',
+        output: 'aborted',
+      },
+    ]);
+  });
+
+  it('does not reconcile programs that already have an output', () => {
+    const state = createStreamAbortReconciliationState();
+
+    for (const item of [
+      {
+        type: 'program',
+        id: 'prog_1',
+        call_id: 'call_prog_1',
+        code: 'text("done");',
+        fingerprint: 'fingerprint:program-1',
+      },
+      {
+        type: 'program_output',
+        id: 'prog_out_1',
+        call_id: 'call_prog_1',
+        result: 'done',
+        status: 'completed',
+      },
+    ]) {
+      recordStreamEventForAbortReconciliation(state, {
+        type: 'model',
+        event: {
+          type: 'response.output_item.done',
+          item,
+        },
+      });
+    }
+
+    expect(shouldReconcileStreamAbort(state)).toBe(false);
+    expect(buildAbortReconciliationInput(state)).toEqual([]);
+  });
+});

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -41,6 +41,8 @@ import { RunResult, StreamedRunResult } from '../../src/result';
 import { RunState } from '../../src/runState';
 import { handoff } from '../../src/handoff';
 import {
+  InvalidToolInputError,
+  InvalidToolOutputError,
   ToolCallError,
   ToolInputGuardrailTripwireTriggered,
   ToolOutputGuardrailTripwireTriggered,
@@ -90,6 +92,27 @@ const createMockLogger = (): Logger => ({
   error: vi.fn(),
   dontLogModelData: true,
   dontLogToolData: true,
+});
+
+describe('Programmatic Tool Calling outputs', () => {
+  it('copies caller linkage to function outputs', () => {
+    const output = getToolCallOutputItem(
+      {
+        type: 'function_call',
+        id: 'fc_1',
+        callId: 'call_1',
+        name: 'lookup',
+        arguments: '{}',
+        caller: { type: 'program', callerId: 'call_program_1' },
+      },
+      { value: 'ok' },
+    );
+
+    expect(output.caller).toEqual({
+      type: 'program',
+      callerId: 'call_program_1',
+    });
+  });
 });
 
 const CUSTOM_REJECTION_MESSAGE =
@@ -329,6 +352,32 @@ describe('getToolCallOutputItem', () => {
     });
   });
 
+  it('serializes schema-backed content-like objects as JSON text', () => {
+    const output = getToolCallOutputItem(
+      TEST_MODEL_FUNCTION_CALL,
+      {
+        type: 'text',
+        text: 'schema value',
+      },
+      {
+        outputSchema: {
+          type: 'object',
+          properties: {
+            type: { type: 'string' },
+            text: { type: 'string' },
+          },
+          required: ['type', 'text'],
+          additionalProperties: false,
+        },
+      },
+    );
+
+    expect(output.output).toEqual({
+      type: 'text',
+      text: JSON.stringify({ type: 'text', text: 'schema value' }),
+    });
+  });
+
   it('returns an empty array as plain text output', () => {
     const result = getToolCallOutputItem(TEST_MODEL_FUNCTION_CALL, []);
 
@@ -372,6 +421,79 @@ describe('checkForFinalOutputFromTools', () => {
     });
     const res = await checkForFinalOutputFromTools(agent, [toolResult], state);
     expect(res).toEqual({ isFinalOutput: true, finalOutput: 'sunny' });
+  });
+
+  it.each(['stop_on_first_tool' as const, { stopAtToolNames: ['weather'] }])(
+    'does not finalize program-owned tool results with %j',
+    async (behavior) => {
+      const agent = new Agent({
+        name: 'ProgramOwnedResult',
+        toolUseBehavior: behavior,
+      });
+      const programOwnedResult: FunctionToolResult = {
+        type: 'function_output',
+        tool: weatherTool,
+        output: 'sunny',
+        runItem: new ToolCallOutputItem(
+          {
+            type: 'function_call_result',
+            name: 'weather',
+            callId: 'call_weather',
+            status: 'completed',
+            output: { type: 'text', text: 'sunny' },
+            caller: { type: 'program', callerId: 'call_program' },
+          },
+          agent,
+          'sunny',
+        ),
+      };
+
+      const res = await checkForFinalOutputFromTools(
+        agent,
+        [programOwnedResult],
+        state,
+      );
+
+      expect(res.isFinalOutput).toBe(false);
+    },
+  );
+
+  it('does not pass program-owned tool results to custom finalization', async () => {
+    const finalize = vi.fn(async () => ({
+      isFinalOutput: true as const,
+      finalOutput: 'sunny',
+      isInterrupted: undefined,
+    }));
+    const agent = new Agent({
+      name: 'CustomProgramOwnedResult',
+      toolUseBehavior: finalize,
+    });
+    const programOwnedResult: FunctionToolResult = {
+      type: 'function_output',
+      tool: weatherTool,
+      output: 'sunny',
+      runItem: new ToolCallOutputItem(
+        {
+          type: 'function_call_result',
+          name: 'weather',
+          callId: 'call_weather',
+          status: 'completed',
+          output: { type: 'text', text: 'sunny' },
+          caller: { type: 'program', callerId: 'call_program' },
+        },
+        agent,
+        'sunny',
+      ),
+    };
+
+    const res = await checkForFinalOutputFromTools(
+      agent,
+      [programOwnedResult],
+      state,
+    );
+
+    expect(res.isFinalOutput).toBe(false);
+    expect(finalize).not.toHaveBeenCalled();
   });
 
   it("stop_on_first_tool returns NOT_FINAL_OUTPUT when first isn't function output", async () => {
@@ -2575,6 +2697,62 @@ describe('executeShellActions', () => {
       expect(state._toolInputGuardrailResults).toHaveLength(1);
     });
 
+    it('maps pre-approval guardrail rejection through a structured error fallback', async () => {
+      const errorFunction = vi.fn(() => ({ status: 'blocked' as const }));
+      const t = tool({
+        name: 'hi',
+        description: 'structured guarded tool',
+        parameters: z.object({}),
+        outputSchema: z.object({ status: z.literal('blocked') }),
+        needsApproval: true,
+        inputGuardrails: [
+          {
+            name: 'structured_pre_approval_blocker',
+            run: async () =>
+              ToolGuardrailFunctionOutputFactory.rejectContent(
+                'blocked before approval',
+              ),
+          },
+        ],
+        errorFunction,
+        execute: vi.fn(async () => ({ status: 'blocked' as const })),
+      }) as unknown as FunctionTool;
+      vi.spyOn(state._context, 'isToolApproved').mockReturnValue(
+        undefined as any,
+      );
+      const preApprovalRunner = new Runner({
+        tracingDisabled: true,
+        toolExecution: { preApprovalInputGuardrails: true },
+      });
+
+      const res = await withTrace('test', () =>
+        executeFunctionToolCalls(
+          state._currentAgent,
+          [{ toolCall, tool: t }],
+          preApprovalRunner,
+          state,
+        ),
+      );
+
+      expect(res[0]).toMatchObject({
+        type: 'function_output',
+        output: { status: 'blocked' },
+        runItem: {
+          rawItem: {
+            output: {
+              type: 'text',
+              text: JSON.stringify({ status: 'blocked' }),
+            },
+          },
+        },
+      });
+      expect(errorFunction).toHaveBeenCalledWith(
+        state._context,
+        expect.objectContaining({ message: 'blocked before approval' }),
+        { toolCall },
+      );
+    });
+
     it('runs input guardrails again before execution after approval', async () => {
       const guardrailRun = vi.fn(async () =>
         ToolGuardrailFunctionOutputFactory.allow(),
@@ -2647,6 +2825,49 @@ describe('executeShellActions', () => {
       expect(res[0].runItem).toBeInstanceOf(ToolCallOutputItem);
       expect(needsApproval).not.toHaveBeenCalled();
       expect(invokeSpy).not.toHaveBeenCalled();
+    });
+
+    it('maps approval rejection through a structured error fallback', async () => {
+      const errorFunction = vi.fn(() => ({ status: 'rejected' as const }));
+      const t = tool({
+        name: 'hi',
+        description: 'structured approval tool',
+        parameters: z.object({}),
+        outputSchema: z.object({ status: z.literal('rejected') }),
+        needsApproval: true,
+        errorFunction,
+        execute: vi.fn(async () => ({ status: 'rejected' as const })),
+      }) as unknown as FunctionTool;
+      vi.spyOn(state._context, 'isToolApproved').mockReturnValue(false as any);
+
+      const res = await withTrace('test', () =>
+        executeFunctionToolCalls(
+          state._currentAgent,
+          [{ toolCall, tool: t }],
+          runner,
+          state,
+        ),
+      );
+
+      expect(res[0]).toMatchObject({
+        type: 'function_output',
+        output: { status: 'rejected' },
+        runItem: {
+          rawItem: {
+            output: {
+              type: 'text',
+              text: JSON.stringify({ status: 'rejected' }),
+            },
+          },
+        },
+      });
+      expect(errorFunction).toHaveBeenCalledWith(
+        state._context,
+        expect.objectContaining({
+          message: 'Tool execution was not approved.',
+        }),
+        { toolCall },
+      );
     });
 
     it('uses toolErrorFormatter message when approval is false', async () => {
@@ -2905,6 +3126,42 @@ describe('executeShellActions', () => {
       );
       expect(res[0].runItem).toBeInstanceOf(ToolCallOutputItem);
       expect(invokeSpy).toHaveBeenCalled();
+    });
+
+    it('preserves schema-backed content-like outputs as JSON', async () => {
+      const outputSchema = z.object({
+        type: z.literal('text'),
+        text: z.string(),
+      });
+      const t = tool({
+        name: 'hi',
+        description: 'structured content-like output',
+        parameters: z.object({}),
+        outputSchema,
+        execute: async () => ({ type: 'text' as const, text: 'ok' }),
+      }) as unknown as FunctionTool;
+
+      const results = await withTrace('test', () =>
+        executeFunctionToolCalls(
+          state._currentAgent,
+          [{ toolCall, tool: t }],
+          runner,
+          state,
+        ),
+      );
+
+      expect(results[0]).toMatchObject({
+        type: 'function_output',
+        output: { type: 'text', text: 'ok' },
+        runItem: {
+          rawItem: {
+            output: {
+              type: 'text',
+              text: JSON.stringify({ type: 'text', text: 'ok' }),
+            },
+          },
+        },
+      });
     });
 
     it('passes a cloned tool call to customDataExtractor', async () => {
@@ -3368,6 +3625,118 @@ describe('executeShellActions', () => {
       expect(state._toolOutputGuardrailResults).toHaveLength(0);
     });
 
+    it('rejects input guardrail messages for Zod output schemas without a fallback', async () => {
+      const inputGuardrail = defineToolInputGuardrail({
+        name: 'block_structured_tool',
+        run: async () =>
+          ToolGuardrailFunctionOutputFactory.rejectContent('blocked'),
+      });
+      const t = tool({
+        name: 'structured_input_guardrail_tool',
+        description: 'tool with structured output',
+        parameters: z.object({}),
+        outputSchema: z.object({ value: z.string() }),
+        execute: vi.fn(async () => ({ value: 'should-not-run' })),
+        inputGuardrails: [inputGuardrail],
+      }) as unknown as FunctionTool;
+
+      const error = await withTrace('test', () =>
+        executeFunctionToolCalls(
+          state._currentAgent,
+          [{ toolCall, tool: t }],
+          runner,
+          state,
+        ).catch((caught) => caught),
+      );
+
+      expect(error).toBeInstanceOf(ToolCallError);
+      expect((error as ToolCallError).error).toMatchObject({
+        message: 'blocked',
+      });
+    });
+
+    it('rejects input guardrail messages for plain JSON output schemas without a fallback', async () => {
+      const inputGuardrail = defineToolInputGuardrail({
+        name: 'block_plain_structured_tool',
+        run: async () =>
+          ToolGuardrailFunctionOutputFactory.rejectContent('blocked'),
+      });
+      const execute = vi.fn(async () => ({ value: 'should-not-run' }));
+      const t = tool({
+        name: 'plain_structured_input_guardrail_tool',
+        description: 'tool with a plain JSON output schema',
+        parameters: z.object({}),
+        outputSchema: {
+          type: 'object',
+          properties: { value: { type: 'string' } },
+          required: ['value'],
+          additionalProperties: false,
+        },
+        execute,
+        inputGuardrails: [inputGuardrail],
+      }) as unknown as FunctionTool;
+
+      const error = await withTrace('test', () =>
+        executeFunctionToolCalls(
+          state._currentAgent,
+          [{ toolCall, tool: t }],
+          runner,
+          state,
+        ).catch((caught) => caught),
+      );
+
+      expect(error).toBeInstanceOf(ToolCallError);
+      expect((error as ToolCallError).error).toMatchObject({
+        message: 'blocked',
+      });
+      expect(execute).not.toHaveBeenCalled();
+    });
+
+    it('maps input guardrail rejection through a structured error fallback', async () => {
+      const errorFunction = vi.fn(() => ({ value: 'blocked' }));
+      const inputGuardrail = defineToolInputGuardrail({
+        name: 'map_structured_rejection',
+        run: async () =>
+          ToolGuardrailFunctionOutputFactory.rejectContent('blocked'),
+      });
+      const t = tool({
+        name: 'structured_input_guardrail_fallback_tool',
+        description: 'tool with structured output',
+        parameters: z.object({}),
+        outputSchema: z.object({ value: z.string() }),
+        errorFunction,
+        execute: vi.fn(async () => ({ value: 'should-not-run' })),
+        inputGuardrails: [inputGuardrail],
+      }) as unknown as FunctionTool;
+
+      const result = await withTrace('test', () =>
+        executeFunctionToolCalls(
+          state._currentAgent,
+          [{ toolCall, tool: t }],
+          runner,
+          state,
+        ),
+      );
+
+      expect(result[0]).toMatchObject({
+        type: 'function_output',
+        output: { value: 'blocked' },
+        runItem: {
+          rawItem: {
+            output: {
+              type: 'text',
+              text: JSON.stringify({ value: 'blocked' }),
+            },
+          },
+        },
+      });
+      expect(errorFunction).toHaveBeenCalledWith(
+        state._context,
+        expect.objectContaining({ message: 'blocked' }),
+        { toolCall },
+      );
+    });
+
     it('throws when output guardrail requests exception', async () => {
       const guardrail = defineToolOutputGuardrail({
         name: 'halt',
@@ -3554,6 +3923,67 @@ describe('executeShellActions', () => {
       expect(state._toolOutputGuardrailResults).toHaveLength(1);
     });
 
+    it('rejects guardrail replacements that violate a Zod output schema', async () => {
+      const outputGuardrail = defineToolOutputGuardrail({
+        name: 'replace_structured_output',
+        run: async () =>
+          ToolGuardrailFunctionOutputFactory.rejectContent('redacted'),
+      });
+      const t = tool({
+        name: 'structured_output_guardrail_tool',
+        description: 'tool with structured output',
+        parameters: z.object({}),
+        outputSchema: z.object({ value: z.string() }),
+        execute: vi.fn(async () => ({ value: 'ok' })),
+        outputGuardrails: [outputGuardrail],
+      }) as unknown as FunctionTool;
+
+      const error = await withTrace('test', () =>
+        executeFunctionToolCalls(
+          state._currentAgent,
+          [{ toolCall, tool: t }],
+          runner,
+          state,
+        ).catch((caught) => caught),
+      );
+
+      expect(error).toBeInstanceOf(ToolCallError);
+      expect((error as ToolCallError).error).toBeInstanceOf(
+        InvalidToolOutputError,
+      );
+    });
+
+    it('does not validate Zod outputs twice in the runner', async () => {
+      let validationCount = 0;
+      const t = tool({
+        name: 'structured_validation_tool',
+        description: 'tool with a runtime output schema',
+        parameters: z.object({}),
+        outputSchema: z.object({
+          value: z.string().refine(() => {
+            validationCount += 1;
+            return true;
+          }),
+        }),
+        execute: vi.fn(async () => ({ value: 'ok' })),
+      }) as unknown as FunctionTool;
+
+      const result = await withTrace('test', () =>
+        executeFunctionToolCalls(
+          state._currentAgent,
+          [{ toolCall, tool: t }],
+          runner,
+          state,
+        ),
+      );
+
+      expect(result[0]).toMatchObject({
+        type: 'function_output',
+        output: { value: 'ok' },
+      });
+      expect(validationCount).toBe(1);
+    });
+
     it('propagates nested run result interruptions when provided by agent tools', async () => {
       const t = makeTool(false);
       const nestedAgent = new Agent({ name: 'Nested' }) as Agent<
@@ -3631,6 +4061,79 @@ describe('executeShellActions', () => {
         );
         expect(String(firstResult.output)).toContain('valid JSON');
       }
+    });
+
+    it('maps parse failures through a structured error fallback', async () => {
+      const errorFunction = vi.fn(() => ({ status: 'invalid_input' as const }));
+      const t = tool({
+        name: 'structured_parser',
+        description: 'Parse structured input.',
+        parameters: z.object({ value: z.string() }),
+        outputSchema: z.object({ status: z.literal('invalid_input') }),
+        errorFunction,
+        execute: vi.fn(async () => ({ status: 'invalid_input' as const })),
+      }) as unknown as FunctionTool;
+      const invalidToolCall = {
+        ...toolCall,
+        name: 'structured_parser',
+        arguments: '{',
+      };
+
+      const res = await withTrace('test', () =>
+        executeFunctionToolCalls(
+          state._currentAgent,
+          [{ toolCall: invalidToolCall, tool: t }],
+          runner,
+          state,
+        ),
+      );
+
+      expect(res[0]).toMatchObject({
+        type: 'function_output',
+        output: { status: 'invalid_input' },
+        runItem: {
+          rawItem: {
+            output: {
+              type: 'text',
+              text: JSON.stringify({ status: 'invalid_input' }),
+            },
+          },
+        },
+      });
+      expect(errorFunction).toHaveBeenCalledWith(
+        state._context,
+        expect.objectContaining({ name: 'InvalidToolInputError' }),
+        { toolCall: invalidToolCall },
+      );
+    });
+
+    it('throws structured parse failures without an error fallback', async () => {
+      const t = tool({
+        name: 'structured_parser_without_fallback',
+        description: 'Parse structured input.',
+        parameters: z.object({ value: z.string() }),
+        outputSchema: z.object({ status: z.string() }),
+        execute: vi.fn(async () => ({ status: 'ok' })),
+      }) as unknown as FunctionTool;
+      const invalidToolCall = {
+        ...toolCall,
+        name: 'structured_parser_without_fallback',
+        arguments: '{',
+      };
+
+      const error = await withTrace('test', () =>
+        executeFunctionToolCalls(
+          state._currentAgent,
+          [{ toolCall: invalidToolCall, tool: t }],
+          runner,
+          state,
+        ).catch((caught) => caught),
+      );
+
+      expect(error).toBeInstanceOf(ToolCallError);
+      expect((error as ToolCallError).error).toBeInstanceOf(
+        InvalidToolInputError,
+      );
     });
   });
 

--- a/packages/agents-core/test/runner/toolResultCorrelation.test.ts
+++ b/packages/agents-core/test/runner/toolResultCorrelation.test.ts
@@ -28,6 +28,20 @@ describe('tool result correlation', () => {
   it.each<CorrelationPair>([
     {
       call: {
+        type: 'program',
+        callId: 'shared:program',
+        code: 'return "done";',
+        fingerprint: 'fingerprint:program',
+      },
+      result: {
+        type: 'program_output',
+        callId: 'shared:program',
+        output: 'done',
+        status: 'completed',
+      },
+    },
+    {
+      call: {
         type: 'function_call',
         callId: 'shared:function',
         name: 'test',
@@ -224,6 +238,19 @@ describe('tool result correlation', () => {
     expect(
       getUnresolvedToolResultCorrelationsForResponse([call, output]),
     ).toEqual([]);
+  });
+
+  it('keeps program calls unresolved until their program output arrives', () => {
+    const call: AgentInputItem = {
+      type: 'program',
+      callId: 'pending-program',
+      code: 'return "pending";',
+      fingerprint: 'fingerprint:pending-program',
+    };
+
+    expect(getUnresolvedToolResultCorrelationsForResponse([call])).toEqual([
+      getToolResultCorrelationForCall(call),
+    ]);
   });
 
   it('does not correlate unrelated hosted tool calls', () => {

--- a/packages/agents-core/test/sandboxMemoryGeneration.test.ts
+++ b/packages/agents-core/test/sandboxMemoryGeneration.test.ts
@@ -10,7 +10,7 @@ import { Agent } from '../src/agent';
 import { handoff } from '../src/handoff';
 import { run, Runner } from '../src/run';
 import { setDefaultModelProvider } from '../src';
-import { tool } from '../src/tool';
+import { tool, type HostedTool } from '../src/tool';
 import type { Model, ModelProvider } from '../src/model';
 import {
   Manifest,
@@ -39,6 +39,12 @@ import {
 import { SandboxMemoryStorage } from '../src/sandbox/memory/storage';
 import { Usage } from '../src/usage';
 import { FakeModel, FakeModelProvider, fakeModelMessage } from './stubs';
+
+const PROGRAMMATIC_TOOL_CALLING_TOOL: HostedTool = {
+  type: 'hosted_tool',
+  name: 'programmatic_tool_calling',
+  providerData: { type: 'programmatic_tool_calling' },
+};
 
 class MemoryPhaseModelProvider implements ModelProvider {
   readonly calls: string[] = [];
@@ -1035,6 +1041,64 @@ describe('Sandbox memory generation', () => {
     expect(serialized).not.toContain('UNKNOWN_SECRET');
     expect(serialized).not.toContain('REASONING_SECRET');
     expect(serialized).not.toContain('RAW_REASONING_SECRET');
+  });
+
+  it('preserves Programmatic Tool Calling items in rollout payloads', async () => {
+    const session = new MemorySession();
+    const agent = new SandboxAgent({
+      name: 'sandbox',
+      model: new FakeModel([
+        {
+          output: [
+            {
+              type: 'program',
+              id: 'prog_1',
+              callId: 'call_prog_1',
+              code: 'text("PROGRAM_RESULT")',
+              fingerprint: 'fp_1',
+            },
+            {
+              type: 'program_output',
+              id: 'prog_out_1',
+              callId: 'call_prog_1',
+              output: 'PROGRAM_RESULT',
+              status: 'completed',
+            },
+            fakeModelMessage('Program completed.'),
+          ],
+          usage: new Usage(),
+        },
+      ]),
+      tools: [PROGRAMMATIC_TOOL_CALLING_TOOL],
+      capabilities: [
+        memory({
+          read: false,
+          generate: createNoopMemoryGenerationConfig(),
+        }),
+      ],
+    });
+
+    await run(agent, 'Run the program.', { sandbox: { session } });
+
+    const rolloutFile = [...session.files.keys()].find(
+      (path) => path.startsWith('sessions/') && path.endsWith('.jsonl'),
+    );
+    expect(rolloutFile).toBeDefined();
+    const payload = JSON.parse(session.files.get(rolloutFile!) ?? '{}');
+
+    expect(payload.generated_items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'program',
+          callId: 'call_prog_1',
+        }),
+        expect.objectContaining({
+          type: 'program_output',
+          callId: 'call_prog_1',
+          output: 'PROGRAM_RESULT',
+        }),
+      ]),
+    );
   });
 
   it('clears active memory when handing off to a non-sandbox agent', async () => {

--- a/packages/agents-core/test/tool.test.ts
+++ b/packages/agents-core/test/tool.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, expectTypeOf, vi } from 'vitest';
 import {
   applyPatchTool,
   computerTool,
@@ -17,7 +17,8 @@ import { Agent } from '../src/agent';
 import { RunContext } from '../src/runContext';
 import { serializeTool } from '../src/utils/serialize';
 import { FakeEditor, FakeShell } from './stubs';
-import { ToolTimeoutError } from '../src/errors';
+import { InvalidToolOutputError, ToolTimeoutError } from '../src/errors';
+import type { JsonObjectSchema } from '../src/types';
 
 interface Bar {
   bar: string;
@@ -70,6 +71,211 @@ describe('Tool', () => {
     expect(t.providerData).toEqual({
       anthropic: { deferLoading: true },
     });
+  });
+
+  it('records Programmatic Tool Calling metadata', () => {
+    const outputSchema = {
+      type: 'object',
+      properties: { value: { type: 'string' } },
+      required: ['value'],
+      additionalProperties: false,
+    } as any;
+    const t = tool({
+      name: 'structured_lookup',
+      description: 'Return structured data.',
+      parameters: z.object({ query: z.string() }),
+      allowedCallers: ['programmatic'],
+      outputSchema,
+      execute: async ({ query }) => ({ value: query }),
+    });
+
+    expect(t.allowedCallers).toEqual(['programmatic']);
+    expect(t.outputSchema).toBe(outputSchema);
+    expect(serializeTool(t)).toMatchObject({
+      allowedCallers: ['programmatic'],
+      outputSchema,
+    });
+  });
+
+  it('uses unknown for plain JSON Schema output types', () => {
+    const outputSchema: JsonObjectSchema<{
+      value: { type: 'string' };
+    }> = {
+      type: 'object',
+      properties: { value: { type: 'string' } },
+      required: ['value'],
+      additionalProperties: false,
+    };
+    const t = tool({
+      name: 'plain_json_schema_output',
+      description: 'Return structured data.',
+      parameters: z.object({}),
+      outputSchema,
+      execute: async () => ({ value: 'ok' }),
+    });
+
+    expectTypeOf(t.invoke(new RunContext(), '{}')).toEqualTypeOf<
+      Promise<unknown>
+    >();
+  });
+
+  it('converts a Zod output schema and infers the execute result', () => {
+    const outputSchema = z.object({
+      value: z.string(),
+      count: z.number(),
+    });
+    const t = tool({
+      name: 'structured_zod_lookup',
+      description: 'Return structured data.',
+      parameters: z.object({ query: z.string() }),
+      allowedCallers: ['programmatic'],
+      outputSchema,
+      execute: async ({ query }) => ({ value: query, count: 1 }),
+    });
+
+    expect(t.outputSchema).toEqual({
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: {
+        value: { type: 'string' },
+        count: { type: 'number' },
+      },
+      required: ['value', 'count'],
+      additionalProperties: false,
+    });
+    expectTypeOf(t.invoke(new RunContext(), '{"query":"test"}')).toEqualTypeOf<
+      Promise<string | { value: string; count: number }>
+    >();
+
+    tool({
+      name: 'invalid_structured_zod_lookup',
+      description: 'Type-check an invalid structured result.',
+      parameters: z.object({ query: z.string() }),
+      outputSchema,
+      // @ts-expect-error The execute result must match the Zod output schema.
+      execute: async ({ query }) => ({ value: query, count: 'one' }),
+    });
+
+    tool({
+      name: 'invalid_structured_zod_fallback',
+      description: 'Type-check an invalid structured fallback.',
+      parameters: z.object({}),
+      outputSchema,
+      execute: async () => ({ value: 'ok', count: 1 }),
+      // @ts-expect-error The error fallback must match the Zod output schema.
+      errorFunction: () => ({ value: 'fallback', count: 'one' }),
+    });
+  });
+
+  it('validates and transforms Zod output schemas at runtime', async () => {
+    const t = tool({
+      name: 'runtime_structured_zod_lookup',
+      description: 'Return structured data.',
+      parameters: z.object({}),
+      outputSchema: z.object({ value: z.string().trim() }),
+      execute: async () => ({ value: '  ok  ' }),
+    });
+
+    await expect(t.invoke(new RunContext(), '{}')).resolves.toEqual({
+      value: 'ok',
+    });
+  });
+
+  it('rejects invalid Zod output at runtime', async () => {
+    const t = tool({
+      name: 'invalid_runtime_structured_zod_lookup',
+      description: 'Return structured data.',
+      parameters: z.object({}),
+      outputSchema: z.object({ value: z.string() }),
+      execute: async () => ({ value: 123 }) as any,
+    });
+
+    await expect(t.invoke(new RunContext(), '{}')).rejects.toMatchObject({
+      name: 'InvalidToolOutputError',
+      toolOutput: { output: { value: 123 } },
+    });
+  });
+
+  it('requires schema-compatible error fallbacks for Zod outputs', async () => {
+    const validFallback = tool({
+      name: 'valid_structured_error_fallback',
+      description: 'Return structured data.',
+      parameters: z.object({}),
+      outputSchema: z.object({ value: z.string() }),
+      execute: async () => {
+        throw new Error('boom');
+      },
+      errorFunction: () => ({ value: 'fallback' }),
+    });
+    const invalidFallback = tool({
+      name: 'invalid_structured_error_fallback',
+      description: 'Return structured data.',
+      parameters: z.object({}),
+      outputSchema: z.object({ value: z.string() }),
+      execute: async () => {
+        throw new Error('boom');
+      },
+      errorFunction: () => ({ value: 123 }) as any,
+    });
+    const noFallback = tool({
+      name: 'structured_error_without_fallback',
+      description: 'Return structured data.',
+      parameters: z.object({}),
+      outputSchema: z.object({ value: z.string() }),
+      execute: async () => {
+        throw new Error('boom');
+      },
+    });
+
+    await expect(validFallback.invoke(new RunContext(), '{}')).resolves.toEqual(
+      { value: 'fallback' },
+    );
+    await expect(
+      invalidFallback.invoke(new RunContext(), '{}'),
+    ).rejects.toBeInstanceOf(InvalidToolOutputError);
+    await expect(noFallback.invoke(new RunContext(), '{}')).rejects.toThrow(
+      'boom',
+    );
+  });
+
+  it('rejects invalid allowedCallers values at tool construction', () => {
+    expect(() =>
+      tool({
+        name: 'empty_allowed_callers',
+        description: 'Invalid configuration.',
+        parameters: z.object({}),
+        allowedCallers: [] as any,
+        execute: async () => 'ok',
+      }),
+    ).toThrow(/must contain at least one caller/);
+    expect(() =>
+      shellTool({
+        shell: new FakeShell(),
+        allowedCallers: ['programmatic', 'programmatic'] as any,
+      }),
+    ).toThrow(/must not contain duplicate callers/);
+    for (const invalidCaller of ['', 0, false, undefined, null]) {
+      expect(() =>
+        tool({
+          name: 'falsy_invalid_allowed_caller',
+          description: 'Invalid configuration.',
+          parameters: z.object({}),
+          allowedCallers: [invalidCaller] as any,
+          execute: async () => 'ok',
+        }),
+      ).toThrow(/contains unsupported caller/);
+    }
+
+    const typecheckEmptyAllowedCallers = () =>
+      tool({
+        name: 'typecheck_empty_allowed_callers',
+        description: 'Invalid configuration.',
+        parameters: z.object({}),
+        // @ts-expect-error allowedCallers must be non-empty.
+        allowedCallers: [],
+        execute: async () => 'ok',
+      });
+    expectTypeOf(typecheckEmptyAllowedCallers).toBeFunction();
   });
 
   it('toolNamespace returns shallow-cloned function tools', () => {
@@ -935,6 +1141,91 @@ describe('tool.invoke', () => {
     });
 
     expect(result).toBe("Tool 'slow' timed out after 5ms.");
+  });
+
+  it('raises timeouts by default for structured outputs', async () => {
+    const t = tool({
+      name: 'structured_slow',
+      description: 'slow structured tool',
+      parameters: z.object({}),
+      outputSchema: z.object({ status: z.string() }),
+      timeoutMs: 5,
+      execute: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        return { status: 'done' };
+      },
+    });
+
+    await expect(
+      invokeFunctionTool({
+        tool: t,
+        runContext: new RunContext(),
+        input: '{}',
+      }),
+    ).rejects.toBeInstanceOf(ToolTimeoutError);
+  });
+
+  it('validates structured timeout fallbacks', async () => {
+    const t = tool({
+      name: 'structured_timeout_fallback',
+      description: 'slow structured tool',
+      parameters: z.object({}),
+      outputSchema: z.object({ status: z.string() }),
+      timeoutMs: 5,
+      timeoutBehavior: 'error_as_result',
+      timeoutErrorFunction: (_context, _error, details) => ({
+        status: details?.toolCall?.callId ?? 'timed-out',
+      }),
+      execute: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        return { status: 'done' };
+      },
+    });
+
+    await expect(
+      invokeFunctionTool({
+        tool: t,
+        runContext: new RunContext(),
+        input: '{}',
+        details: {
+          toolCall: {
+            type: 'function_call',
+            callId: 'call-structured-timeout',
+            name: 'structured_timeout_fallback',
+            arguments: '{}',
+            status: 'completed',
+          },
+        },
+      }),
+    ).resolves.toEqual({ status: 'call-structured-timeout' });
+  });
+
+  it('requires timeout fallbacks for structured error results', () => {
+    expect(() =>
+      tool({
+        name: 'structured_timeout_without_fallback',
+        description: 'Invalid structured timeout configuration.',
+        parameters: z.object({}),
+        outputSchema: z.object({ status: z.string() }),
+        timeoutMs: 5,
+        timeoutBehavior: 'error_as_result',
+        execute: async () => ({ status: 'done' }),
+        // The cast verifies the runtime boundary in addition to the type test.
+      } as any),
+    ).toThrow(/requires timeoutErrorFunction/);
+
+    const typecheckMissingTimeoutFallback = () =>
+      // @ts-expect-error Structured error results require timeoutErrorFunction.
+      tool({
+        name: 'typecheck_structured_timeout_without_fallback',
+        description: 'Invalid structured timeout configuration.',
+        parameters: z.object({}),
+        outputSchema: z.object({ status: z.string() }),
+        timeoutMs: 5,
+        timeoutBehavior: 'error_as_result',
+        execute: async () => ({ status: 'done' }),
+      });
+    expectTypeOf(typecheckMissingTimeoutFallback).toBeFunction();
   });
 
   it('enforces timeout when invoking FunctionTool directly', async () => {

--- a/packages/agents-extensions/src/ai-sdk-ui/uiMessageStream.ts
+++ b/packages/agents-extensions/src/ai-sdk-ui/uiMessageStream.ts
@@ -99,6 +99,14 @@ function extractToolInput(item: RunToolCallItem): ToolInputPayload | null {
     };
   }
 
+  if (raw.type === 'program' && typeof raw.code === 'string') {
+    return {
+      toolCallId,
+      toolName: 'programmatic_tool_calling',
+      input: { code: raw.code },
+    };
+  }
+
   if (raw.type === 'hosted_tool_call') {
     const input =
       typeof raw.arguments === 'string' ? parseJsonArgs(raw.arguments) : {};

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -337,6 +337,12 @@ export function itemsToLanguageV2Messages(
   };
 
   for (const item of collapsedItems) {
+    if ('caller' in item && item.caller?.type === 'program') {
+      throw new UserError(
+        'The AI SDK adapter does not support Programmatic Tool Calling history. Use a Responses API model directly.',
+      );
+    }
+
     if (item.type === 'message' || typeof item.type === 'undefined') {
       const { role, content, providerData } = item;
       if (role === 'system') {
@@ -1472,6 +1478,16 @@ export function toolToLanguageV2Tool(
   model: LanguageModelCompatible,
   tool: SerializedTool,
 ): LanguageModelV2FunctionTool | LanguageModelV2ProviderToolCompat {
+  if (
+    (tool.type === 'function' ||
+      tool.type === 'shell' ||
+      tool.type === 'apply_patch') &&
+    tool.allowedCallers?.some((caller) => caller === 'programmatic')
+  ) {
+    throw new UserError(
+      'The AI SDK adapter does not support Programmatic Tool Calling. Use a Responses API model directly.',
+    );
+  }
   if (tool.type === 'function') {
     if (tool.deferLoading) {
       throw new UserError(
@@ -1479,6 +1495,11 @@ export function toolToLanguageV2Tool(
       );
     }
     const providerOptions = toProviderOptions(tool.providerData, model);
+    if (tool.outputSchema) {
+      throw new UserError(
+        'The AI SDK adapter does not support Responses function outputSchema. Use a Responses API model directly.',
+      );
+    }
     return {
       type: 'function',
       name: getSerializedFunctionToolName(tool),
@@ -1503,6 +1524,15 @@ export function toolToLanguageV2Tool(
       };
     }
 
+    if (
+      tool.providerData?.type === 'programmatic_tool_calling' ||
+      (Array.isArray(tool.providerData?.allowed_callers) &&
+        tool.providerData.allowed_callers.includes('programmatic'))
+    ) {
+      throw new UserError(
+        'The AI SDK adapter does not support Programmatic Tool Calling. Use a Responses API model directly.',
+      );
+    }
     return {
       type: providerToolType,
       id: `${providerToolPrefix}.${tool.name}`,

--- a/packages/agents-extensions/test/ai-sdk-ui/uiMessageStream.test.ts
+++ b/packages/agents-extensions/test/ai-sdk-ui/uiMessageStream.test.ts
@@ -279,6 +279,57 @@ describe('createAiSdkUiMessageStreamResponse', () => {
     expect(reasoningDelta).toMatchObject({ delta: 'Reasoning summary' });
   });
 
+  test('maps Programmatic Tool Calling to one tool lifecycle', async () => {
+    const agent = new Agent({ name: 'Test Agent' });
+    const programCall = new RunToolCallItem(
+      {
+        type: 'program',
+        callId: 'call-program-1',
+        code: 'text("done")',
+        fingerprint: 'program-fingerprint',
+      },
+      agent,
+    );
+    const programOutput = new RunToolCallOutputItem(
+      {
+        type: 'program_output',
+        callId: 'call-program-1',
+        output: 'done',
+        status: 'completed',
+      },
+      agent,
+      'done',
+    );
+    const events = (async function* () {
+      yield new RunItemStreamEvent('tool_called', programCall);
+      yield new RunItemStreamEvent('tool_output', programOutput);
+    })();
+
+    const chunks = await readUiMessageChunks(
+      createAiSdkUiMessageStreamResponse(events),
+    );
+    const programInputIndex = chunks.findIndex(
+      (chunk) => chunk.type === 'tool-input-available',
+    );
+    const programOutputIndex = chunks.findIndex(
+      (chunk) => chunk.type === 'tool-output-available',
+    );
+
+    expect(programInputIndex).toBeGreaterThan(-1);
+    expect(programOutputIndex).toBeGreaterThan(programInputIndex);
+    expect(chunks[programInputIndex]).toMatchObject({
+      toolCallId: 'call-program-1',
+      toolName: 'programmatic_tool_calling',
+      input: { code: 'text("done")' },
+      dynamic: true,
+    });
+    expect(chunks[programOutputIndex]).toMatchObject({
+      toolCallId: 'call-program-1',
+      output: 'done',
+      dynamic: true,
+    });
+  });
+
   test('emits finish after run-item events when response_done arrives early', async () => {
     const agent = new Agent({ name: 'Test Agent' });
 

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -1185,6 +1185,33 @@ describe('itemsToLanguageV2Messages', () => {
     expect(() => itemsToLanguageV2Messages(stubModel({}), items)).toThrow();
   });
 
+  test('rejects Programmatic Tool Calling caller history', () => {
+    const caller = { type: 'program' as const, callerId: 'call_program' };
+    expect(() =>
+      itemsToLanguageV2Messages(stubModel({}), [
+        {
+          type: 'function_call',
+          callId: 'call_function',
+          name: 'lookup',
+          arguments: '{}',
+          caller,
+        },
+      ]),
+    ).toThrow(/does not support Programmatic Tool Calling history/);
+    expect(() =>
+      itemsToLanguageV2Messages(stubModel({}), [
+        {
+          type: 'function_call_result',
+          callId: 'call_function',
+          name: 'lookup',
+          status: 'completed',
+          output: 'ok',
+          caller,
+        },
+      ]),
+    ).toThrow(/does not support Programmatic Tool Calling history/);
+  });
+
   test('throws on computer tool calls and results', () => {
     expect(() =>
       itemsToLanguageV2Messages(stubModel({}), [
@@ -1652,6 +1679,26 @@ describe('toolToLanguageV2Tool', () => {
     expect(() => toolToLanguageV2Tool(model, tool)).toThrow(
       /AI SDK adapter does not support deferred Responses function tools/,
     );
+  });
+
+  test('rejects Programmatic Tool Calling tools', () => {
+    expect(() =>
+      toolToLanguageV2Tool(model, {
+        type: 'function',
+        name: 'lookup',
+        description: 'd',
+        parameters: {} as any,
+        allowedCallers: ['programmatic'],
+      } as any),
+    ).toThrow(/does not support Programmatic Tool Calling/);
+
+    expect(() =>
+      toolToLanguageV2Tool(model, {
+        type: 'hosted_tool',
+        name: 'programmatic_tool_calling',
+        providerData: { type: 'programmatic_tool_calling' },
+      } as any),
+    ).toThrow(/does not support Programmatic Tool Calling/);
   });
 
   test('maps builtin tools', () => {

--- a/packages/agents-openai/src/index.ts
+++ b/packages/agents-openai/src/index.ts
@@ -42,10 +42,11 @@ export {
   webSearchTool,
   fileSearchTool,
   codeInterpreterTool,
+  programmaticToolCallingTool,
   toolSearchTool,
   imageGenerationTool,
 } from './tools';
-export type { ToolSearchTool } from './tools';
+export type { ProgrammaticToolCallingTool, ToolSearchTool } from './tools';
 export {
   OpenAIConversationsSession,
   startOpenAIConversationsSession,

--- a/packages/agents-openai/src/openaiChatCompletionsConverter.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsConverter.ts
@@ -419,6 +419,11 @@ export function itemsToMessages(
         'Tool search items are not supported for chat completions. Please use the Responses API when replaying tool search history.',
       );
     } else if (item.type === 'function_call') {
+      if (item.caller?.type === 'program') {
+        throw new UserError(
+          'Programmatic Tool Calling history is not supported for chat completions. Please use the Responses API.',
+        );
+      }
       const hasQualifiedOrInvalidName =
         typeof item.name === 'string' &&
         !CHAT_COMPLETIONS_FUNCTION_NAME_PATTERN.test(item.name);
@@ -465,6 +470,11 @@ export function itemsToMessages(
         ]),
       );
     } else if (item.type === 'function_call_result') {
+      if (item.caller?.type === 'program') {
+        throw new UserError(
+          'Programmatic Tool Calling history is not supported for chat completions. Please use the Responses API.',
+        );
+      }
       flushAssistantMessage();
       const funcOutput = item;
       const toolContent = normalizeFunctionCallOutputForChat(
@@ -489,6 +499,10 @@ export function itemsToMessages(
     } else if (item.type === 'compaction') {
       throw new UserError(
         'Compaction items are not supported for chat completions. Please use the Responses API when working with compaction.',
+      );
+    } else if (item.type === 'program' || item.type === 'program_output') {
+      throw new UserError(
+        'Programmatic Tool Calling history is not supported for chat completions. Please use the Responses API.',
       );
     } else {
       const exhaustive = item satisfies never; // ensures that the type is exhaustive

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -451,6 +451,31 @@ export class OpenAIChatCompletionsModel implements Model {
     const tools: OpenAI.Chat.Completions.ChatCompletionTool[] = [];
     if (request.tools) {
       for (const tool of request.tools) {
+        if (
+          (tool.type === 'function' ||
+            tool.type === 'shell' ||
+            tool.type === 'apply_patch') &&
+          tool.allowedCallers?.some((caller) => caller === 'programmatic')
+        ) {
+          throw new UserError(
+            'Tools callable from Programmatic Tool Calling are only supported with the Responses API.',
+          );
+        }
+        if (tool.type === 'function' && tool.outputSchema) {
+          throw new UserError(
+            'Function tool outputSchema is only supported with the Responses API.',
+          );
+        }
+        if (
+          tool.type === 'hosted_tool' &&
+          (tool.providerData?.type === 'programmatic_tool_calling' ||
+            (Array.isArray(tool.providerData?.allowed_callers) &&
+              tool.providerData.allowed_callers.includes('programmatic')))
+        ) {
+          throw new UserError(
+            'Programmatic Tool Calling is only supported with the Responses API.',
+          );
+        }
         if (tool.type === 'function') {
           if (
             typeof tool.namespace === 'string' &&

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -178,11 +178,18 @@ function toOpenAIToolSearchOutputToolPayload(
   }
 
   if (tool.type === 'function') {
-    const { deferLoading, ...rest } = tool as Record<string, any>;
+    const { deferLoading, allowedCallers, outputSchema, ...rest } =
+      tool as Record<string, any>;
     return {
       ...rest,
       ...(typeof deferLoading === 'boolean'
         ? { defer_loading: deferLoading }
+        : {}),
+      ...(Array.isArray(allowedCallers)
+        ? { allowed_callers: allowedCallers }
+        : {}),
+      ...(outputSchema && typeof outputSchema === 'object'
+        ? { output_schema: outputSchema }
         : {}),
     };
   }
@@ -221,11 +228,17 @@ function fromOpenAIToolSearchOutputToolPayload(
   }
 
   if (tool.type === 'function') {
-    const { defer_loading, ...rest } = tool;
+    const { defer_loading, allowed_callers, output_schema, ...rest } = tool;
     return {
       ...rest,
       ...(typeof defer_loading === 'boolean'
         ? { deferLoading: defer_loading }
+        : {}),
+      ...(Array.isArray(allowed_callers)
+        ? { allowedCallers: allowed_callers }
+        : {}),
+      ...(output_schema && typeof output_schema === 'object'
+        ? { outputSchema: output_schema }
         : {}),
     };
   }
@@ -338,6 +351,7 @@ const HostedToolChoice = z.enum([
   'code_interpreter',
   'image_generation',
   'mcp',
+  'programmatic_tool_calling',
   // Specialized local tools
   'shell',
   'apply_patch',
@@ -658,6 +672,110 @@ function assertSupportedToolChoice(
   ) {
     throw new UserError(
       'modelSettings.toolChoice="tool_search" is only supported for a custom function named "tool_search". Responses does not support forcing the built-in tool_search tool. Use "auto" instead.',
+    );
+  }
+}
+
+function collectProgrammaticToolConfiguration(tools: ResponsesTool[]): {
+  hasProgrammaticToolCalling: boolean;
+  hasToolSearch: boolean;
+  programmaticEligibleTools: ResponsesTool[];
+  programmaticOnlyTools: ResponsesTool[];
+} {
+  let hasProgrammaticToolCalling = false;
+  let hasToolSearch = false;
+  const programmaticEligibleTools: ResponsesTool[] = [];
+  const programmaticOnlyTools: ResponsesTool[] = [];
+
+  const visit = (tool: ResponsesTool) => {
+    if (tool.type === 'namespace' && Array.isArray(tool.tools)) {
+      for (const nestedTool of tool.tools) {
+        visit(nestedTool);
+      }
+      return;
+    }
+
+    if (tool.type === 'programmatic_tool_calling') {
+      hasProgrammaticToolCalling = true;
+      return;
+    }
+
+    if (tool.type === 'tool_search') {
+      hasToolSearch = true;
+    }
+
+    const allowedCallers = (tool as { allowed_callers?: unknown })
+      .allowed_callers;
+    if (
+      !Array.isArray(allowedCallers) ||
+      !allowedCallers.includes('programmatic')
+    ) {
+      return;
+    }
+
+    programmaticEligibleTools.push(tool);
+    if (!allowedCallers.includes('direct')) {
+      programmaticOnlyTools.push(tool);
+    }
+  };
+
+  for (const tool of tools) {
+    visit(tool);
+  }
+
+  return {
+    hasProgrammaticToolCalling,
+    hasToolSearch,
+    programmaticEligibleTools,
+    programmaticOnlyTools,
+  };
+}
+
+function describeResponsesTool(tool: ResponsesTool): string {
+  const name = (tool as { name?: unknown }).name;
+  return typeof name === 'string' ? name : String(tool.type);
+}
+
+function assertValidProgrammaticToolCallingConfiguration(
+  toolChoice: ToolChoice | undefined,
+  tools: ResponsesTool[],
+  options?: { allowPromptSuppliedTools?: boolean },
+): void {
+  const allowPromptSuppliedTools = options?.allowPromptSuppliedTools === true;
+  const {
+    hasProgrammaticToolCalling,
+    hasToolSearch,
+    programmaticEligibleTools,
+    programmaticOnlyTools,
+  } = collectProgrammaticToolConfiguration(tools);
+  const forcesProgrammaticToolCalling =
+    typeof toolChoice === 'object' &&
+    (toolChoice as { type?: unknown }).type === 'programmatic_tool_calling';
+
+  if (
+    forcesProgrammaticToolCalling &&
+    !hasProgrammaticToolCalling &&
+    !allowPromptSuppliedTools
+  ) {
+    throw new UserError(
+      'modelSettings.toolChoice="programmatic_tool_calling" requires programmaticToolCallingTool() in the agent tools.',
+    );
+  }
+
+  if (programmaticOnlyTools.length > 0 && !hasProgrammaticToolCalling) {
+    throw new UserError(
+      `Tools restricted to programmatic callers require programmaticToolCallingTool(). Affected tools: ${programmaticOnlyTools.map(describeResponsesTool).join(', ')}.`,
+    );
+  }
+
+  if (
+    hasProgrammaticToolCalling &&
+    !hasToolSearch &&
+    programmaticEligibleTools.length === 0 &&
+    !allowPromptSuppliedTools
+  ) {
+    throw new UserError(
+      'programmaticToolCallingTool() requires at least one tool whose allowedCallers includes "programmatic".',
     );
   }
 }
@@ -1476,6 +1594,10 @@ function convertTool<_TContext = unknown>(
       description: tool.description,
       parameters: tool.parameters,
       strict: tool.strict,
+      ...(tool.allowedCallers
+        ? { allowed_callers: [...tool.allowedCallers] }
+        : {}),
+      ...(tool.outputSchema ? { output_schema: tool.outputSchema } : {}),
     };
     if (tool.deferLoading) {
       openaiTool.defer_loading = true;
@@ -1514,6 +1636,9 @@ function convertTool<_TContext = unknown>(
       tool: {
         type: 'shell',
         environment: toOpenAIShellEnvironment(tool.environment),
+        ...(tool.allowedCallers
+          ? { allowed_callers: [...tool.allowedCallers] }
+          : {}),
       } as OpenAI.Responses.FunctionShellTool,
       include: undefined,
     };
@@ -1521,6 +1646,9 @@ function convertTool<_TContext = unknown>(
     return {
       tool: {
         type: 'apply_patch',
+        ...(tool.allowedCallers
+          ? { allowed_callers: [...tool.allowedCallers] }
+          : {}),
       } as OpenAI.Responses.ApplyPatchTool,
       include: undefined,
     };
@@ -1574,6 +1702,7 @@ function convertTool<_TContext = unknown>(
         tool: {
           type: 'code_interpreter',
           container: tool.providerData.container,
+          allowed_callers: tool.providerData.allowed_callers,
         },
         include: tool.providerData.include_outputs
           ? ['code_interpreter_call.outputs']
@@ -1586,6 +1715,13 @@ function convertTool<_TContext = unknown>(
           execution: tool.providerData.execution,
           description: tool.providerData.description,
           parameters: tool.providerData.parameters,
+        },
+        include: undefined,
+      };
+    } else if (tool.providerData?.type === 'programmatic_tool_calling') {
+      return {
+        tool: {
+          type: 'programmatic_tool_calling',
         },
         include: undefined,
       };
@@ -1618,6 +1754,7 @@ function convertTool<_TContext = unknown>(
         require_approval: convertMCPRequireApproval(
           tool.providerData.require_approval,
         ),
+        allowed_callers: tool.providerData.allowed_callers,
         server_description: tool.providerData.server_description,
       };
       if (tool.providerData.defer_loading === true) {
@@ -1910,6 +2047,36 @@ function isMessageItem(item: protocol.ModelItem): item is protocol.MessageItem {
   return false;
 }
 
+type OpenAIToolCaller =
+  { type: 'direct' } | { type: 'program'; caller_id: string };
+
+function toOpenAIToolCaller(
+  caller: protocol.ToolCaller | undefined,
+): OpenAIToolCaller | undefined {
+  if (!caller) {
+    return undefined;
+  }
+  if (caller.type === 'direct') {
+    return { type: 'direct' };
+  }
+  return { type: 'program', caller_id: caller.callerId };
+}
+
+function fromOpenAIToolCaller(
+  caller: unknown,
+): protocol.ToolCaller | undefined {
+  if (!isRecord(caller)) {
+    return undefined;
+  }
+  if (caller.type === 'direct') {
+    return { type: 'direct' };
+  }
+  if (caller.type === 'program' && typeof caller.caller_id === 'string') {
+    return { type: 'program', callerId: caller.caller_id };
+  }
+  return undefined;
+}
+
 function getPrompt(prompt: ModelRequest['prompt']):
   | {
       id: string;
@@ -2010,6 +2177,43 @@ function getInputItems(
       return toolSearchOutput;
     }
 
+    if (item.type === 'program') {
+      return {
+        type: 'program',
+        id: item.id!,
+        call_id: item.callId,
+        code: item.code,
+        fingerprint: item.fingerprint,
+        ...getSnakeCasedProviderDataWithoutReservedKeys(item.providerData, [
+          'type',
+          'id',
+          'call_id',
+          'callId',
+          'code',
+          'fingerprint',
+        ]),
+      } satisfies OpenAI.Responses.ResponseInputItem.Program;
+    }
+
+    if (item.type === 'program_output') {
+      return {
+        type: 'program_output',
+        id: item.id!,
+        call_id: item.callId,
+        result: item.output,
+        status: item.status,
+        ...getSnakeCasedProviderDataWithoutReservedKeys(item.providerData, [
+          'type',
+          'id',
+          'call_id',
+          'callId',
+          'output',
+          'result',
+          'status',
+        ]),
+      } satisfies OpenAI.Responses.ResponseInputItem.ProgramOutput;
+    }
+
     if (item.type === 'function_call') {
       const entry: ResponseFunctionToolCallWithNamespace = {
         id: item.id,
@@ -2018,6 +2222,7 @@ function getInputItems(
         call_id: item.callId,
         arguments: item.arguments,
         status: item.status,
+        ...(item.caller ? { caller: toOpenAIToolCaller(item.caller) } : {}),
         ...(typeof item.namespace === 'string'
           ? { namespace: item.namespace }
           : {}),
@@ -2029,6 +2234,7 @@ function getInputItems(
           'arguments',
           'status',
           'namespace',
+          'caller',
         ]),
       };
 
@@ -2046,6 +2252,7 @@ function getInputItems(
         call_id: item.callId,
         output: normalizedOutput,
         status: item.status,
+        ...(item.caller ? { caller: toOpenAIToolCaller(item.caller) } : {}),
         ...getSnakeCasedProviderDataWithoutReservedKeys(item.providerData, [
           'type',
           'id',
@@ -2053,6 +2260,7 @@ function getInputItems(
           'output',
           'status',
           'namespace',
+          'caller',
         ]),
       };
       return entry as unknown as OpenAI.Responses.ResponseInputItem.FunctionCallOutput;
@@ -2175,12 +2383,15 @@ function getInputItems(
         item.providerData,
       );
 
-      const entry: OpenAI.Responses.ResponseInputItem.ShellCall = {
+      const entry: OpenAI.Responses.ResponseInputItem.ShellCall & {
+        caller?: ReturnType<typeof toOpenAIToolCaller>;
+      } = {
         type: 'shell_call',
         id: item.id,
         call_id: item.callId,
         status: item.status ?? 'in_progress',
         action,
+        ...(item.caller ? { caller: toOpenAIToolCaller(item.caller) } : {}),
         ...shellProviderData,
       };
 
@@ -2205,11 +2416,14 @@ function getInputItems(
 
       const entry: OpenAI.Responses.ResponseInputItem.ShellCallOutput & {
         max_output_length?: number;
+        caller?: ReturnType<typeof toOpenAIToolCaller>;
       } = {
         type: 'shell_call_output',
         call_id: item.callId,
         output: sanitizedOutputs,
         id: item.id ?? undefined,
+        status: item.status ?? undefined,
+        ...(item.caller ? { caller: toOpenAIToolCaller(item.caller) } : {}),
       };
       if (typeof item.maxOutputLength === 'number') {
         entry.max_output_length = item.maxOutputLength;
@@ -2222,30 +2436,41 @@ function getInputItems(
       if (!item.operation) {
         throw new UserError('apply_patch_call missing operation');
       }
-      const entry: OpenAI.Responses.ResponseInputItem.ApplyPatchCall = {
+      const entry: OpenAI.Responses.ResponseInputItem.ApplyPatchCall & {
+        caller?: ReturnType<typeof toOpenAIToolCaller>;
+      } = {
         type: 'apply_patch_call',
         id: item.id ?? undefined,
         call_id: item.callId,
         status: item.status ?? 'in_progress',
         operation: item.operation,
+        ...(item.caller ? { caller: toOpenAIToolCaller(item.caller) } : {}),
       };
 
       return entry;
     }
 
     if (item.type === 'apply_patch_call_output') {
-      const entry: OpenAI.Responses.ResponseInputItem.ApplyPatchCallOutput = {
+      const entry: OpenAI.Responses.ResponseInputItem.ApplyPatchCallOutput & {
+        caller?: ReturnType<typeof toOpenAIToolCaller>;
+      } = {
         type: 'apply_patch_call_output',
         id: item.id ?? undefined,
         call_id: item.callId,
         status: item.status ?? 'completed',
         output: item.output ?? undefined,
+        ...(item.caller ? { caller: toOpenAIToolCaller(item.caller) } : {}),
       };
 
       return entry;
     }
 
     if (item.type === 'hosted_tool_call') {
+      const hostedCaller = (
+        item as protocol.HostedToolCallItem & {
+          caller?: protocol.ToolCaller;
+        }
+      ).caller;
       if (
         item.providerData?.type === 'web_search_call' ||
         item.providerData?.type === 'web_search' // for backward compatibility
@@ -2292,7 +2517,9 @@ function getInputItems(
         item.providerData?.type === 'code_interpreter_call' ||
         item.providerData?.type === 'code_interpreter' // for backward compatibility
       ) {
-        const entry: OpenAI.Responses.ResponseCodeInterpreterToolCall = {
+        const entry: OpenAI.Responses.ResponseCodeInterpreterToolCall & {
+          caller?: OpenAIToolCaller;
+        } = {
           ...camelOrSnakeToSnakeCase(item.providerData), // place here to prioritize the below fields
           type: 'code_interpreter_call',
           id: item.id!,
@@ -2303,6 +2530,7 @@ function getInputItems(
             item.providerData?.outputs ?? item.providerData?.results ?? [],
           status: CodeInterpreterStatus.parse(item.status ?? 'failed'),
           container_id: item.providerData?.container_id,
+          ...(hostedCaller ? { caller: toOpenAIToolCaller(hostedCaller) } : {}),
         };
 
         return entry;
@@ -2329,13 +2557,16 @@ function getInputItems(
       ) {
         const providerData =
           item.providerData as ProviderData.HostedMCPListTools;
-        const entry: OpenAI.Responses.ResponseInputItem.McpListTools = {
+        const entry: OpenAI.Responses.ResponseInputItem.McpListTools & {
+          caller?: OpenAIToolCaller;
+        } = {
           ...camelOrSnakeToSnakeCase(item.providerData),
           type: 'mcp_list_tools',
           id: item.id!,
           tools: camelOrSnakeToSnakeCase(providerData.tools) as any,
           server_label: providerData.server_label,
           error: providerData.error,
+          ...(hostedCaller ? { caller: toOpenAIToolCaller(hostedCaller) } : {}),
         };
         return entry;
       } else if (
@@ -2344,13 +2575,16 @@ function getInputItems(
       ) {
         const providerData =
           item.providerData as ProviderData.HostedMCPApprovalRequest;
-        const entry: OpenAI.Responses.ResponseInputItem.McpApprovalRequest = {
+        const entry: OpenAI.Responses.ResponseInputItem.McpApprovalRequest & {
+          caller?: OpenAIToolCaller;
+        } = {
           ...camelOrSnakeToSnakeCase(item.providerData), // place here to prioritize the below fields
           type: 'mcp_approval_request',
           id: providerData.id ?? item.id!,
           name: providerData.name,
           arguments: providerData.arguments,
           server_label: providerData.server_label,
+          ...(hostedCaller ? { caller: toOpenAIToolCaller(hostedCaller) } : {}),
         };
         return entry;
       } else if (
@@ -2359,13 +2593,16 @@ function getInputItems(
       ) {
         const providerData =
           item.providerData as ProviderData.HostedMCPApprovalResponse;
-        const entry: OpenAI.Responses.ResponseInputItem.McpApprovalResponse = {
+        const entry: OpenAI.Responses.ResponseInputItem.McpApprovalResponse & {
+          caller?: OpenAIToolCaller;
+        } = {
           ...camelOrSnakeToSnakeCase(providerData),
           type: 'mcp_approval_response',
           id: providerData.id,
           approve: providerData.approve,
           approval_request_id: providerData.approval_request_id,
           reason: providerData.reason,
+          ...(hostedCaller ? { caller: toOpenAIToolCaller(hostedCaller) } : {}),
         };
         return entry;
       } else if (
@@ -2373,7 +2610,9 @@ function getInputItems(
         item.name === 'mcp_call'
       ) {
         const providerData = item.providerData as ProviderData.HostedMCPCall;
-        const entry: OpenAI.Responses.ResponseInputItem.McpCall = {
+        const entry: OpenAI.Responses.ResponseInputItem.McpCall & {
+          caller?: OpenAIToolCaller;
+        } = {
           // output, which can be a large text string, is optional here, so we don't include it
           // output: item.output,
           ...camelOrSnakeToSnakeCase(providerData), // place here to prioritize the below fields
@@ -2383,6 +2622,7 @@ function getInputItems(
           arguments: providerData.arguments,
           server_label: providerData.server_label,
           error: providerData.error,
+          ...(hostedCaller ? { caller: toOpenAIToolCaller(hostedCaller) } : {}),
         };
         return entry;
       }
@@ -2502,6 +2742,44 @@ function convertToOutputItem(
         providerData,
       };
       return output;
+    } else if (item.type === 'program') {
+      const {
+        id,
+        call_id,
+        code,
+        fingerprint,
+        type: _type,
+        ...providerData
+      } = item as OpenAI.Responses.ResponseOutputItem.Program &
+        Record<string, unknown>;
+      const output: protocol.ProgramCallItem = {
+        type: 'program',
+        id,
+        callId: call_id,
+        code,
+        fingerprint,
+        providerData,
+      };
+      return output;
+    } else if (item.type === 'program_output') {
+      const {
+        id,
+        call_id,
+        result,
+        status,
+        type: _type,
+        ...providerData
+      } = item as OpenAI.Responses.ResponseOutputItem.ProgramOutput &
+        Record<string, unknown>;
+      const output: protocol.ProgramCallResultItem = {
+        type: 'program_output',
+        id,
+        callId: call_id,
+        output: result,
+        status,
+        providerData,
+      };
+      return output;
     } else if (
       item.type === 'file_search_call' ||
       item.type === 'web_search_call' ||
@@ -2509,6 +2787,12 @@ function convertToOutputItem(
       item.type === 'code_interpreter_call'
     ) {
       const { status, ...remainingItem } = item;
+      const caller = fromOpenAIToolCaller(
+        (remainingItem as { caller?: unknown }).caller,
+      );
+      if (caller) {
+        delete (remainingItem as { caller?: unknown }).caller;
+      }
       let outputData = undefined;
       if ('result' in remainingItem && remainingItem.result !== null) {
         // type: "image_generation_call"
@@ -2521,6 +2805,7 @@ function convertToOutputItem(
         name: item.type,
         status,
         output: outputData,
+        ...(caller ? { caller } : {}),
         providerData: remainingItem,
       };
       return output;
@@ -2530,6 +2815,7 @@ function convertToOutputItem(
         call_id,
         name,
         namespace,
+        caller,
         status,
         arguments: args,
         ...providerData
@@ -2542,6 +2828,7 @@ function convertToOutputItem(
         ...(typeof namespace === 'string' ? { namespace } : {}),
         status,
         arguments: args,
+        ...(caller ? { caller: fromOpenAIToolCaller(caller) } : {}),
         providerData,
       };
       return output;
@@ -2553,6 +2840,7 @@ function convertToOutputItem(
         name: toolName,
         function_name: functionName,
         namespace,
+        caller,
         ...providerData
       } = item as OpenAI.Responses.ResponseFunctionToolCallOutputItem & {
         name?: string;
@@ -2567,6 +2855,7 @@ function convertToOutputItem(
         ...(typeof namespace === 'string' ? { namespace } : {}),
         status: status ?? 'completed',
         output: convertFunctionCallOutputToProtocol(rawOutput),
+        ...(caller ? { caller: fromOpenAIToolCaller(caller) } : {}),
         providerData,
       };
       return output;
@@ -2590,7 +2879,7 @@ function convertToOutputItem(
       };
       return output;
     } else if (item.type === 'shell_call') {
-      const { call_id, status, action, ...providerData } = item;
+      const { call_id, status, action, caller, ...providerData } = item;
       const shellAction: protocol.ShellAction = {
         commands: Array.isArray(action?.commands) ? action.commands : [],
       };
@@ -2608,6 +2897,7 @@ function convertToOutputItem(
         callId: call_id,
         status: status ?? 'in_progress',
         action: shellAction,
+        ...(caller ? { caller: fromOpenAIToolCaller(caller) } : {}),
         providerData,
       };
       return output;
@@ -2616,6 +2906,8 @@ function convertToOutputItem(
         call_id,
         output: responseOutput,
         max_output_length,
+        status,
+        caller,
         ...providerData
       } = item as ResponseShellCallOutput;
       let normalizedOutput: protocol.ShellCallOutputContent[] = [];
@@ -2640,6 +2932,8 @@ function convertToOutputItem(
         id: item.id ?? undefined,
         callId: call_id,
         output: normalizedOutput,
+        ...(status ? { status } : {}),
+        ...(caller ? { caller: fromOpenAIToolCaller(caller) } : {}),
         providerData,
       };
       if (typeof max_output_length === 'number') {
@@ -2647,7 +2941,7 @@ function convertToOutputItem(
       }
       return output;
     } else if (item.type === 'apply_patch_call') {
-      const { call_id, status, operation, ...providerData } = item;
+      const { call_id, status, operation, caller, ...providerData } = item;
       if (!operation) {
         throw new UserError('apply_patch_call missing operation');
       }
@@ -2684,6 +2978,7 @@ function convertToOutputItem(
         callId: call_id,
         status: status ?? 'in_progress',
         operation: normalizedOperation,
+        ...(caller ? { caller: fromOpenAIToolCaller(caller) } : {}),
         providerData,
       };
       return output;
@@ -2692,6 +2987,7 @@ function convertToOutputItem(
         call_id,
         status,
         output: responseOutput,
+        caller,
         ...providerData
       } = item as unknown as ResponseApplyPatchCallOutput;
       const output: protocol.ApplyPatchCallResultItem = {
@@ -2700,40 +2996,62 @@ function convertToOutputItem(
         callId: call_id,
         status,
         output: typeof responseOutput === 'string' ? responseOutput : undefined,
+        ...(caller ? { caller: fromOpenAIToolCaller(caller) } : {}),
         providerData,
       };
       return output;
     } else if (item.type === 'mcp_list_tools') {
       const { ...providerData } = item;
+      const caller = fromOpenAIToolCaller(
+        (providerData as Record<string, unknown>).caller,
+      );
+      if (caller) {
+        delete (providerData as Record<string, unknown>).caller;
+      }
       const output: protocol.HostedToolCallItem = {
         type: 'hosted_tool_call',
         id: item.id!,
         name: item.type,
         status: 'completed',
         output: undefined,
+        ...(caller ? { caller } : {}),
         providerData,
       };
       return output;
     } else if (item.type === 'mcp_approval_request') {
       const { ...providerData } = item;
+      const caller = fromOpenAIToolCaller(
+        (providerData as Record<string, unknown>).caller,
+      );
+      if (caller) {
+        delete (providerData as Record<string, unknown>).caller;
+      }
       const output: protocol.HostedToolCallItem = {
         type: 'hosted_tool_call',
         id: item.id!,
         name: 'mcp_approval_request',
         status: 'completed',
         output: undefined,
+        ...(caller ? { caller } : {}),
         providerData,
       };
       return output;
     } else if (item.type === 'mcp_call') {
       // Avoiding to duplicate potentially large output data
       const { output: outputData, ...providerData } = item;
+      const caller = fromOpenAIToolCaller(
+        (providerData as Record<string, unknown>).caller,
+      );
+      if (caller) {
+        delete (providerData as Record<string, unknown>).caller;
+      }
       const output: protocol.HostedToolCallItem = {
         type: 'hosted_tool_call',
         id: item.id!,
         name: item.type,
         status: 'completed',
         output: outputData || undefined,
+        ...(caller ? { caller } : {}),
         providerData,
       };
       return output;
@@ -3064,6 +3382,11 @@ export class OpenAIResponsesModel implements Model {
     assertSupportedToolChoice(toolChoice, toolChoiceValidationTools, {
       allowPromptSuppliedTools,
     });
+    assertValidProgrammaticToolCallingConfiguration(
+      toolChoice,
+      toolChoiceValidationTools,
+      { allowPromptSuppliedTools },
+    );
     const { text, ...restOfProviderData } = providerDataWithoutTransport;
 
     if (request.modelSettings.reasoning) {

--- a/packages/agents-openai/src/tools.ts
+++ b/packages/agents-openai/src/tools.ts
@@ -2,10 +2,12 @@ import {
   attachClientToolSearchExecutor,
   HostedTool,
   type ClientToolSearchExecutor,
+  type ToolAllowedCallers,
   UserError,
 } from '@openai/agents-core';
 import type OpenAI from 'openai';
 import { z } from 'zod';
+import { normalizeToolAllowedCallers } from '@openai/agents-core/utils/internal';
 import * as ProviderData from './types/providerData';
 
 // -----------------------------------------------------
@@ -155,8 +157,17 @@ export type CodeInterpreterTool = {
    */
   includeOutputs?: boolean;
   container?:
-    | string
-    | OpenAI.Responses.Tool.CodeInterpreter.CodeInterpreterToolAuto;
+    string | OpenAI.Responses.Tool.CodeInterpreter.CodeInterpreterToolAuto;
+  /**
+   * Execution contexts allowed to invoke code interpreter.
+   */
+  allowedCallers?: ToolAllowedCallers;
+};
+
+export type ProgrammaticToolCallingTool = HostedTool & {
+  type: 'hosted_tool';
+  name: 'programmatic_tool_calling';
+  providerData: ProviderData.ProgrammaticToolCallingTool;
 };
 
 export type ToolSearchTool<Context = unknown> = {
@@ -176,16 +187,34 @@ export type ToolSearchTool<Context = unknown> = {
 export function codeInterpreterTool(
   options: Partial<Omit<CodeInterpreterTool, 'type'>> = {},
 ): HostedTool {
+  const allowedCallers = normalizeToolAllowedCallers(
+    options.allowedCallers,
+    options.name ?? 'code_interpreter',
+  );
   const providerData: ProviderData.CodeInterpreterTool = {
     type: 'code_interpreter',
     name: options.name ?? 'code_interpreter',
     container: options.container ?? { type: 'auto' },
     include_outputs: options.includeOutputs,
+    allowed_callers: allowedCallers ? [...allowedCallers] : undefined,
   };
   return {
     type: 'hosted_tool',
     name: options.name ?? 'code_interpreter',
     providerData,
+  };
+}
+
+/**
+ * Enables Programmatic Tool Calling for eligible Responses API tools.
+ */
+export function programmaticToolCallingTool(): ProgrammaticToolCallingTool {
+  return {
+    type: 'hosted_tool',
+    name: 'programmatic_tool_calling',
+    providerData: {
+      type: 'programmatic_tool_calling',
+    } satisfies ProviderData.ProgrammaticToolCallingTool,
   };
 }
 

--- a/packages/agents-openai/src/types/providerData.ts
+++ b/packages/agents-openai/src/types/providerData.ts
@@ -22,6 +22,10 @@ export type CodeInterpreterTool = Omit<
   include_outputs?: boolean;
 };
 
+export type ProgrammaticToolCallingTool = {
+  type: 'programmatic_tool_calling';
+};
+
 export type ToolSearchTool = Omit<OpenAI.Responses.ToolSearchTool, 'type'> & {
   type: 'tool_search';
   name: 'tool_search';

--- a/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
@@ -1001,6 +1001,20 @@ describe('itemsToMessages', () => {
 });
 
 describe('tool helpers', () => {
+  test('itemsToMessages rejects Programmatic Tool Calling history', () => {
+    expect(() =>
+      itemsToMessages([
+        {
+          type: 'program',
+          id: 'prog_1',
+          callId: 'call_prog_1',
+          code: 'text("ok")',
+          fingerprint: 'fp_1',
+        },
+      ]),
+    ).toThrow(/Programmatic Tool Calling history is not supported/);
+  });
+
   test('toolToOpenAI rejects non-function tools', () => {
     const tool: SerializedTool = { type: 'builtin' } as any;
     expect(() => toolToOpenAI(tool)).toThrow();

--- a/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
@@ -1119,6 +1119,30 @@ describe('OpenAIChatCompletionsModel', () => {
     expect(client.chat.completions.create).not.toHaveBeenCalled();
   });
 
+  it('rejects Programmatic Tool Calling before sending a request', async () => {
+    const client = new FakeClient();
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const req: any = {
+      input: 'u',
+      modelSettings: {},
+      tools: [
+        {
+          type: 'hosted_tool',
+          name: 'programmatic_tool_calling',
+          providerData: { type: 'programmatic_tool_calling' },
+        },
+      ],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+    };
+
+    await expect(withTrace('t', () => model.getResponse(req))).rejects.toThrow(
+      'Programmatic Tool Calling is only supported with the Responses API.',
+    );
+    expect(client.chat.completions.create).not.toHaveBeenCalled();
+  });
+
   it('rejects required toolChoice when no tools are available', async () => {
     const client = new FakeClient();
     const model = new OpenAIChatCompletionsModel(client as any, 'gpt');

--- a/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
@@ -29,6 +29,9 @@ describe('getToolChoice', () => {
     });
     expect(getToolChoice('shell')).toEqual({ type: 'shell' });
     expect(getToolChoice('apply_patch')).toEqual({ type: 'apply_patch' });
+    expect(getToolChoice('programmatic_tool_calling')).toEqual({
+      type: 'programmatic_tool_calling',
+    });
   });
 
   it('supports arbitrary function names', () => {
@@ -82,6 +85,41 @@ describe('getToolChoice', () => {
 });
 
 describe('convertTool', () => {
+  it('converts Programmatic Tool Calling tools and eligible metadata', () => {
+    const outputSchema = {
+      type: 'object',
+      properties: { value: { type: 'string' } },
+      required: ['value'],
+      additionalProperties: false,
+    };
+    expect(
+      convertTool({
+        type: 'function',
+        name: 'lookup',
+        description: 'Lookup a value.',
+        parameters: { type: 'object' },
+        strict: true,
+        allowedCallers: ['programmatic'],
+        outputSchema,
+      } as any).tool,
+    ).toEqual({
+      type: 'function',
+      name: 'lookup',
+      description: 'Lookup a value.',
+      parameters: { type: 'object' },
+      strict: true,
+      allowed_callers: ['programmatic'],
+      output_schema: outputSchema,
+    });
+    expect(
+      convertTool({
+        type: 'hosted_tool',
+        name: 'programmatic_tool_calling',
+        providerData: { type: 'programmatic_tool_calling' },
+      } as any).tool,
+    ).toEqual({ type: 'programmatic_tool_calling' });
+  });
+
   it('converts function tools', () => {
     const t = convertTool({
       type: 'function',
@@ -590,6 +628,107 @@ describe('convertTool', () => {
 });
 
 describe('getInputItems', () => {
+  it('replays caller linkage on MCP approval requests and responses', () => {
+    expect(
+      getInputItems([
+        {
+          type: 'hosted_tool_call',
+          id: 'mcpr_1',
+          name: 'mcp_approval_request',
+          caller: { type: 'program', callerId: 'call_prog_1' },
+          providerData: {
+            type: 'mcp_approval_request',
+            id: 'mcpr_1',
+            name: 'lookup',
+            arguments: '{}',
+            server_label: 'server',
+          },
+        },
+        {
+          type: 'hosted_tool_call',
+          name: 'mcp_approval_response',
+          caller: { type: 'program', callerId: 'call_prog_1' },
+          providerData: {
+            type: 'mcp_approval_response',
+            approve: true,
+            approval_request_id: 'mcpr_1',
+          },
+        },
+      ] as any),
+    ).toMatchObject([
+      {
+        type: 'mcp_approval_request',
+        id: 'mcpr_1',
+        caller: { type: 'program', caller_id: 'call_prog_1' },
+      },
+      {
+        type: 'mcp_approval_response',
+        approve: true,
+        approval_request_id: 'mcpr_1',
+        caller: { type: 'program', caller_id: 'call_prog_1' },
+      },
+    ]);
+  });
+
+  it('replays Programmatic Tool Calling items and caller linkage', () => {
+    expect(
+      getInputItems([
+        {
+          type: 'program',
+          id: 'prog_1',
+          callId: 'call_prog_1',
+          code: 'text("ok")',
+          fingerprint: 'fp_1',
+        },
+        {
+          type: 'function_call_result',
+          id: 'fc_out_1',
+          callId: 'call_1',
+          name: 'lookup',
+          status: 'completed',
+          output: 'ok',
+          caller: { type: 'program', callerId: 'call_prog_1' },
+        },
+        {
+          type: 'program_output',
+          id: 'prog_out_1',
+          callId: 'call_prog_1',
+          output: 'ok',
+          status: 'completed',
+          providerData: {
+            output: 'stale-output',
+            result: 'stale-result',
+            customField: 'kept',
+          },
+        },
+      ]),
+    ).toEqual([
+      {
+        type: 'program',
+        id: 'prog_1',
+        call_id: 'call_prog_1',
+        code: 'text("ok")',
+        fingerprint: 'fp_1',
+      },
+      {
+        type: 'function_call_output',
+        id: 'fc_out_1',
+        call_id: 'call_1',
+        output: 'ok',
+        status: 'completed',
+        caller: { type: 'program', caller_id: 'call_prog_1' },
+      },
+      {
+        type: 'program_output',
+        id: 'prog_out_1',
+        call_id: 'call_prog_1',
+        result: 'ok',
+        status: 'completed',
+        custom_field: 'kept',
+      },
+    ]);
+  });
+
   it('converts messages and tool calls/results', () => {
     const items = getInputItems([
       { role: 'user', content: 'hi', id: 'u1' },
@@ -641,6 +780,7 @@ describe('getInputItems', () => {
         type: 'shell_call_output',
         id: 'sh2',
         callId: 's1',
+        status: 'incomplete',
         output: [
           {
             stdout: 'hi',
@@ -692,6 +832,7 @@ describe('getInputItems', () => {
       type: 'shell_call_output',
       id: 'sh2',
       call_id: 's1',
+      status: 'incomplete',
       output: [
         {
           stdout: 'hi',
@@ -1166,9 +1307,15 @@ describe('getInputItems', () => {
   });
 
   it('handles string and fallback outputs for function_call_result', () => {
+    const schemaJson = JSON.stringify({ type: 'text', text: 'ok' });
     const items = getInputItems([
       { type: 'function_call_result', callId: 'str', output: 'ok' },
       { type: 'function_call_result', callId: 'num', output: 42 },
+      {
+        type: 'function_call_result',
+        callId: 'schema',
+        output: { type: 'text', text: schemaJson },
+      },
     ] as any);
 
     expect(items[0]).toMatchObject({
@@ -1180,6 +1327,11 @@ describe('getInputItems', () => {
       type: 'function_call_output',
       call_id: 'num',
       output: '42',
+    });
+    expect(items[2]).toMatchObject({
+      type: 'function_call_output',
+      call_id: 'schema',
+      output: schemaJson,
     });
   });
 
@@ -1697,12 +1849,35 @@ describe('getInputItems', () => {
         type: 'hosted_tool_call',
         id: 'c',
         status: 'completed',
+        caller: { type: 'program', callerId: 'call_prog_1' },
         providerData: { type: 'code_interpreter', code: 'print()' },
       },
     ] as any);
     expect(ci[0]).toMatchObject({
       type: 'code_interpreter_call',
       code: 'print()',
+      caller: { type: 'program', caller_id: 'call_prog_1' },
+    });
+
+    const mcp = getInputItems([
+      {
+        type: 'hosted_tool_call',
+        id: 'mcp_1',
+        name: 'mcp_call',
+        status: 'completed',
+        caller: { type: 'program', callerId: 'call_prog_1' },
+        providerData: {
+          type: 'mcp_call',
+          id: 'mcp_1',
+          name: 'lookup',
+          arguments: '{}',
+          server_label: 'server',
+        },
+      },
+    ] as any);
+    expect(mcp[0]).toMatchObject({
+      type: 'mcp_call',
+      caller: { type: 'program', caller_id: 'call_prog_1' },
     });
 
     const img = getInputItems([
@@ -2148,6 +2323,118 @@ describe('getInputItems', () => {
 });
 
 describe('convertToOutputItem', () => {
+  it('lifts hosted Programmatic Tool Calling caller linkage', () => {
+    expect(
+      convertToOutputItem([
+        {
+          type: 'code_interpreter_call',
+          id: 'ci_1',
+          code: 'print("ok")',
+          container_id: 'container_1',
+          outputs: [{ type: 'logs', logs: 'ok' }],
+          status: 'completed',
+          caller: { type: 'program', caller_id: 'call_prog_1' },
+        },
+      ] as any),
+    ).toEqual([
+      {
+        type: 'hosted_tool_call',
+        id: 'ci_1',
+        name: 'code_interpreter_call',
+        status: 'completed',
+        output: undefined,
+        caller: { type: 'program', callerId: 'call_prog_1' },
+        providerData: {
+          type: 'code_interpreter_call',
+          id: 'ci_1',
+          code: 'print("ok")',
+          container_id: 'container_1',
+          outputs: [{ type: 'logs', logs: 'ok' }],
+        },
+      },
+    ]);
+  });
+
+  it('lifts hosted MCP caller linkage', () => {
+    const [output] = convertToOutputItem([
+      {
+        type: 'mcp_call',
+        id: 'mcp_1',
+        name: 'lookup',
+        arguments: '{}',
+        server_label: 'server',
+        status: 'completed',
+        output: 'ok',
+        caller: { type: 'program', caller_id: 'call_prog_1' },
+      },
+    ] as any);
+
+    expect(output).toMatchObject({
+      type: 'hosted_tool_call',
+      id: 'mcp_1',
+      name: 'mcp_call',
+      caller: { type: 'program', callerId: 'call_prog_1' },
+    });
+    expect(output.providerData).not.toHaveProperty('caller');
+  });
+
+  it('converts Programmatic Tool Calling items and caller linkage', () => {
+    const out = convertToOutputItem([
+      {
+        type: 'program',
+        id: 'prog_1',
+        call_id: 'call_prog_1',
+        code: 'text("ok")',
+        fingerprint: 'fp_1',
+      },
+      {
+        type: 'function_call',
+        id: 'fc_1',
+        call_id: 'call_1',
+        name: 'lookup',
+        arguments: '{}',
+        status: 'completed',
+        caller: { type: 'program', caller_id: 'call_prog_1' },
+      },
+      {
+        type: 'program_output',
+        id: 'prog_out_1',
+        call_id: 'call_prog_1',
+        result: 'ok',
+        status: 'completed',
+      },
+    ] as any);
+
+    expect(out).toEqual([
+      {
+        type: 'program',
+        id: 'prog_1',
+        callId: 'call_prog_1',
+        code: 'text("ok")',
+        fingerprint: 'fp_1',
+        providerData: {},
+      },
+      {
+        type: 'function_call',
+        id: 'fc_1',
+        callId: 'call_1',
+        name: 'lookup',
+        status: 'completed',
+        arguments: '{}',
+        caller: { type: 'program', callerId: 'call_prog_1' },
+        providerData: { id: 'fc_1', type: 'function_call' },
+      },
+      {
+        type: 'program_output',
+        id: 'prog_out_1',
+        callId: 'call_prog_1',
+        output: 'ok',
+        status: 'completed',
+        providerData: {},
+      },
+    ]);
+  });
+
   it('converts output items', () => {
     const out = convertToOutputItem([
       {
@@ -2632,6 +2919,7 @@ describe('convertToOutputItem', () => {
         type: 'shell_call_output',
         id: 'sh2',
         call_id: 's1',
+        status: 'incomplete',
         output: [
           {
             stdout: 'hi',
@@ -2664,6 +2952,7 @@ describe('convertToOutputItem', () => {
     expect(out[1]).toMatchObject({
       type: 'shell_call_output',
       callId: 's1',
+      status: 'incomplete',
       output: [
         {
           stdout: 'hi',

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -2340,6 +2340,212 @@ describe('OpenAIResponsesModel', () => {
     });
   });
 
+  it.each([
+    {
+      name: 'forced PTC without the helper tool',
+      toolChoice: 'programmatic_tool_calling',
+      tools: [
+        {
+          type: 'function',
+          name: 'lookup_account',
+          description: 'Look up an account.',
+          parameters: { type: 'object', properties: {} },
+          strict: true,
+          allowedCallers: ['programmatic'],
+        },
+      ],
+      error: /requires programmaticToolCallingTool\(\)/,
+    },
+    {
+      name: 'programmatic-only tools without the helper tool',
+      toolChoice: undefined,
+      tools: [
+        {
+          type: 'function',
+          name: 'lookup_account',
+          description: 'Look up an account.',
+          parameters: { type: 'object', properties: {} },
+          strict: true,
+          allowedCallers: ['programmatic'],
+        },
+      ],
+      error:
+        /Tools restricted to programmatic callers require programmaticToolCallingTool\(\)/,
+    },
+    {
+      name: 'the PTC helper without an eligible tool',
+      toolChoice: undefined,
+      tools: [
+        {
+          type: 'hosted_tool',
+          name: 'programmatic_tool_calling',
+          providerData: { type: 'programmatic_tool_calling' },
+        },
+      ],
+      error:
+        /requires at least one tool whose allowedCallers includes "programmatic"/,
+    },
+  ])('rejects $name before sending a Responses request', async (testCase) => {
+    await withTrace('test', async () => {
+      const createMock = vi.fn();
+      const model = new OpenAIResponsesModel(
+        { responses: { create: createMock } } as unknown as OpenAI,
+        'gpt-5.2',
+      );
+
+      await expect(
+        model.getResponse({
+          systemInstructions: undefined,
+          input: 'look up an account',
+          modelSettings: { toolChoice: testCase.toolChoice },
+          tools: testCase.tools,
+          outputType: 'text',
+          handoffs: [],
+          tracing: false,
+          signal: undefined,
+        } as any),
+      ).rejects.toThrow(testCase.error);
+      expect(createMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('rejects programmatic-only SDK tools without the helper when a prompt may supply tools', async () => {
+    await withTrace('test', async () => {
+      const createMock = vi.fn().mockResolvedValue({
+        id: 'res-prompt-programmatic-only-tool',
+        usage: {},
+        output: [],
+      });
+      const model = new OpenAIResponsesModel(
+        { responses: { create: createMock } } as unknown as OpenAI,
+        'gpt-5.2',
+      );
+
+      await expect(
+        model.getResponse({
+          systemInstructions: undefined,
+          prompt: { promptId: 'pmpt_programmatic_tool_calling' },
+          input: 'look up an account',
+          modelSettings: {},
+          tools: [
+            {
+              type: 'function',
+              name: 'lookup_account',
+              description: 'Look up an account.',
+              parameters: { type: 'object', properties: {} },
+              strict: true,
+              allowedCallers: ['programmatic'],
+            },
+          ],
+          toolsExplicitlyProvided: false,
+          outputType: 'text',
+          handoffs: [],
+          tracing: false,
+          signal: undefined,
+        } as any),
+      ).rejects.toThrow(
+        /Tools restricted to programmatic callers require programmaticToolCallingTool\(\)/,
+      );
+      expect(createMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('allows a prompt to supply eligible tools for an SDK PTC helper', async () => {
+    await withTrace('test', async () => {
+      const createMock = vi.fn().mockResolvedValue({
+        id: 'res-prompt-eligible-tool',
+        usage: {},
+        output: [],
+      });
+      const model = new OpenAIResponsesModel(
+        { responses: { create: createMock } } as unknown as OpenAI,
+        'gpt-5.2',
+      );
+
+      await model.getResponse({
+        systemInstructions: undefined,
+        prompt: { promptId: 'pmpt_programmatic_tool_calling' },
+        input: 'look up an account',
+        modelSettings: {},
+        tools: [
+          {
+            type: 'hosted_tool',
+            name: 'programmatic_tool_calling',
+            providerData: { type: 'programmatic_tool_calling' },
+          },
+        ],
+        toolsExplicitlyProvided: false,
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      } as any);
+
+      expect(createMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it.each([
+    {
+      name: 'an explicitly eligible function',
+      tools: [
+        {
+          type: 'function',
+          name: 'lookup_account',
+          description: 'Look up an account.',
+          parameters: { type: 'object', properties: {} },
+          strict: true,
+          allowedCallers: ['programmatic'],
+        },
+        {
+          type: 'hosted_tool',
+          name: 'programmatic_tool_calling',
+          providerData: { type: 'programmatic_tool_calling' },
+        },
+      ],
+    },
+    {
+      name: 'tool search that can load an eligible tool later',
+      tools: [
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: { type: 'tool_search' },
+        },
+        {
+          type: 'hosted_tool',
+          name: 'programmatic_tool_calling',
+          providerData: { type: 'programmatic_tool_calling' },
+        },
+      ],
+    },
+  ])('accepts a complete PTC configuration with $name', async (testCase) => {
+    await withTrace('test', async () => {
+      const createMock = vi.fn().mockResolvedValue({
+        id: 'res-programmatic-tool-calling',
+        usage: {},
+        output: [],
+      });
+      const model = new OpenAIResponsesModel(
+        { responses: { create: createMock } } as unknown as OpenAI,
+        'gpt-5.2',
+      );
+
+      await model.getResponse({
+        systemInstructions: undefined,
+        input: 'look up an account',
+        modelSettings: {},
+        tools: testCase.tools,
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      } as any);
+
+      expect(createMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('allows namespaced function tool_choice values for immediate namespace tools', async () => {
     await withTrace('test', async () => {
       const fakeResponse = {

--- a/packages/agents-openai/test/tools.test.ts
+++ b/packages/agents-openai/test/tools.test.ts
@@ -1,14 +1,26 @@
 import { getClientToolSearchExecutor } from '@openai/agents-core';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, expectTypeOf } from 'vitest';
 import {
   codeInterpreterTool,
   fileSearchTool,
   imageGenerationTool,
+  programmaticToolCallingTool,
   toolSearchTool,
+  type ProgrammaticToolCallingTool,
   webSearchTool,
 } from '../src/tools';
 
 describe('Tool', () => {
+  it('programmaticToolCallingTool', () => {
+    const tool = programmaticToolCallingTool();
+    expectTypeOf(tool).toEqualTypeOf<ProgrammaticToolCallingTool>();
+    expect(tool).toEqual({
+      type: 'hosted_tool',
+      name: 'programmatic_tool_calling',
+      providerData: { type: 'programmatic_tool_calling' },
+    });
+  });
+
   it('webSearchTool', () => {
     const t = webSearchTool({
       userLocation: { type: 'approximate', city: 'Tokyo' },
@@ -58,6 +70,25 @@ describe('Tool', () => {
         include_outputs: true,
       },
     });
+  });
+
+  it('codeInterpreterTool preserves allowed callers', () => {
+    expect(
+      codeInterpreterTool({ allowedCallers: ['programmatic'] }),
+    ).toMatchObject({
+      providerData: { allowed_callers: ['programmatic'] },
+    });
+  });
+
+  it('codeInterpreterTool rejects invalid allowed callers', () => {
+    expect(() => codeInterpreterTool({ allowedCallers: [] as any })).toThrow(
+      /must contain at least one caller/,
+    );
+    expect(() =>
+      codeInterpreterTool({
+        allowedCallers: ['programmatic', 'programmatic'] as any,
+      }),
+    ).toThrow(/must not contain duplicate callers/);
   });
 
   it('imageGenerationTool with gpt-image-1', () => {

--- a/packages/agents-realtime/src/tool.ts
+++ b/packages/agents-realtime/src/tool.ts
@@ -99,9 +99,24 @@ export function toRealtimeToolDefinition(
   tool: RealtimeTool,
 ): RealtimeToolDefinition {
   if (tool.type === 'function') {
+    if (tool.allowedCallers?.includes('programmatic')) {
+      throw new UserError(
+        `Realtime does not support function tool '${tool.name}' with allowedCallers including 'programmatic'. Programmatic Tool Calling is only supported with the Responses API.`,
+      );
+    }
+    if (typeof tool.outputSchema !== 'undefined') {
+      throw new UserError(
+        `Realtime does not support function tool '${tool.name}' with outputSchema. Function tool outputSchema is only supported with the Responses API.`,
+      );
+    }
     return tool;
   }
   if (tool.type === 'hosted_tool' && tool.name === 'hosted_mcp') {
+    if (tool.providerData.allowed_callers?.includes('programmatic')) {
+      throw new UserError(
+        `Realtime does not support hosted MCP tool '${tool.providerData.server_label}' with allowedCallers including 'programmatic'. Programmatic Tool Calling is only supported with the Responses API.`,
+      );
+    }
     const serverUrl =
       tool.providerData.server_url && tool.providerData.server_url.length > 0
         ? tool.providerData.server_url

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -83,6 +83,31 @@ describe('RealtimeSession', () => {
     await session.connect({ apiKey: 'test' });
   });
 
+  it('rejects programmatic function tools before connecting', async () => {
+    const execute = vi.fn(async () => 'should not run');
+    const programmaticTool = tool({
+      name: 'program_only',
+      description: 'Only callable from a program.',
+      parameters: z.object({}),
+      allowedCallers: ['programmatic'],
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'Programmatic tool agent',
+      tools: [programmaticTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+
+    await expect(localSession.connect({ apiKey: 'test' })).rejects.toThrow(
+      "Realtime does not support function tool 'program_only' with allowedCallers including 'programmatic'. Programmatic Tool Calling is only supported with the Responses API.",
+    );
+    expect(localTransport.connectCalls).toHaveLength(0);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   it('rejects duplicate function tool and handoff names before connecting', async () => {
     const targetAgent = new RealtimeAgent({ name: 'Billing' });
     const duplicateTool = tool({

--- a/packages/agents-realtime/test/tool.test.ts
+++ b/packages/agents-realtime/test/tool.test.ts
@@ -92,6 +92,54 @@ describe('realtime tool helpers', () => {
     ).toThrowError(/Invalid tool type/);
   });
 
+  it('rejects function tools callable from programs', () => {
+    expect(() =>
+      toRealtimeToolDefinition({
+        ...functionTool,
+        allowedCallers: ['programmatic'],
+      }),
+    ).toThrowError(
+      "Realtime does not support function tool 'echo' with allowedCallers including 'programmatic'. Programmatic Tool Calling is only supported with the Responses API.",
+    );
+
+    expect(() =>
+      toRealtimeToolDefinition({
+        ...functionTool,
+        allowedCallers: ['direct', 'programmatic'],
+      }),
+    ).toThrowError(/Programmatic Tool Calling is only supported/);
+  });
+
+  it('rejects function tools with Responses output schemas', () => {
+    expect(() =>
+      toRealtimeToolDefinition({
+        ...functionTool,
+        outputSchema: {
+          type: 'object',
+          properties: { value: { type: 'string' } },
+          required: ['value'],
+          additionalProperties: false,
+        },
+      }),
+    ).toThrowError(
+      "Realtime does not support function tool 'echo' with outputSchema. Function tool outputSchema is only supported with the Responses API.",
+    );
+  });
+
+  it('rejects hosted MCP tools callable from programs', () => {
+    expect(() =>
+      toRealtimeToolDefinition({
+        ...hostedMcpTool,
+        providerData: {
+          ...hostedMcpTool.providerData,
+          allowed_callers: ['programmatic'],
+        },
+      }),
+    ).toThrowError(
+      "Realtime does not support hosted MCP tool 'my-mcp' with allowedCallers including 'programmatic'. Programmatic Tool Calling is only supported with the Responses API.",
+    );
+  });
+
   it('rejects invalid hosted MCP approval policies for realtime tools', () => {
     expect(() =>
       toRealtimeToolDefinition({

--- a/packages/agents/test/index.test.ts
+++ b/packages/agents/test/index.test.ts
@@ -46,6 +46,16 @@ describe('Tool search exports', () => {
   });
 });
 
+describe('Programmatic Tool Calling exports', () => {
+  test('programmaticToolCallingTool should be available', () => {
+    expect(Agents.programmaticToolCallingTool()).toEqual({
+      type: 'hosted_tool',
+      name: 'programmatic_tool_calling',
+      providerData: { type: 'programmatic_tool_calling' },
+    });
+  });
+});
+
 describe('Sandbox exports', () => {
   test('are only available from the sandbox subpath', () => {
     expect('SandboxAgent' in Agents).toBe(false);


### PR DESCRIPTION
This pull request adds first-class Programmatic Tool Calling support to the Agents SDK. It exposes caller and output schema configuration, preserves program and caller-linked items across runner history, streaming reconciliation, stateless replay, sessions, and RunState persistence, and explicitly rejects unsupported adapter paths.

It also adds a runnable replenishment-planning example that demonstrates nine structured read-only calls coordinated through one hosted JavaScript program and reduced into a compact result with Promise.all.