### PR TITLE
fix: preserve stream usage reported on non-final chunks

### DIFF
--- a/.changeset/fix-stream-usage-earlier-chunk.md
+++ b/.changeset/fix-stream-usage-earlier-chunk.md
@@ -4,4 +4,4 @@
 
 fix: preserve token usage reported on earlier Chat Completions stream chunks
 
-When streaming Chat Completions, usage was overwritten on every chunk, so a trailing chunk without usage reset the previously reported totals to zero. Some providers (e.g. xAI/Grok via LiteLLM) attach usage to an earlier chunk rather than the final one, which caused `response_done` to report `inputTokens`/`outputTokens`/`totalTokens` as 0. Usage is now retained when a later chunk omits it, while the normal OpenAI path (usage on the final chunk) is unchanged.
+When streaming Chat Completions, usage was overwritten on every chunk, so a trailing chunk without usage reset the previously reported totals to zero. Some OpenAI-compatible providers or gateways may emit a later chunk without usage after reporting usage on an earlier chunk, which caused `response_done` to report `inputTokens`/`outputTokens`/`totalTokens` as 0. Usage is now retained when a later chunk omits it, while the normal OpenAI path (usage on the final chunk) is unchanged.

--- a/.changeset/fix-stream-usage-earlier-chunk.md
+++ b/.changeset/fix-stream-usage-earlier-chunk.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: preserve token usage reported on earlier Chat Completions stream chunks
+
+When streaming Chat Completions, usage was overwritten on every chunk, so a trailing chunk without usage reset the previously reported totals to zero. Some providers (e.g. xAI/Grok via LiteLLM) attach usage to an earlier chunk rather than the final one, which caused `response_done` to report `inputTokens`/`outputTokens`/`totalTokens` as 0. Usage is now retained when a later chunk omits it, while the normal OpenAI path (usage on the final chunk) is unchanged.

--- a/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
@@ -59,8 +59,13 @@ export async function* convertChatCompletionsStreamToResponses(
       },
     };
 
-    // This is always set by the OpenAI API, but not by others e.g. LiteLLM
-    usage = (chunk as any).usage || undefined;
+    // This is always set by the OpenAI API, but not by others e.g. LiteLLM.
+    // Usage is not always reported on the final chunk (some providers such as
+    // xAI/Grok via LiteLLM attach it to an earlier chunk), so only overwrite
+    // it when the current chunk actually carries usage data.
+    if ((chunk as any).usage) {
+      usage = (chunk as any).usage;
+    }
 
     if (!chunk.choices || chunk.choices.length === 0) continue;
 

--- a/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
@@ -59,10 +59,10 @@ export async function* convertChatCompletionsStreamToResponses(
       },
     };
 
-    // This is always set by the OpenAI API, but not by others e.g. LiteLLM.
-    // Usage is not always reported on the final chunk (some providers such as
-    // xAI/Grok via LiteLLM attach it to an earlier chunk), so only overwrite
-    // it when the current chunk actually carries usage data.
+    // Usage is not always reported on the final chunk: some OpenAI-compatible
+    // providers or gateways may emit a later chunk without usage after
+    // reporting usage, so only overwrite it when the current chunk actually
+    // carries usage data.
     if ((chunk as any).usage) {
       usage = (chunk as any).usage;
     }

--- a/packages/agents-openai/test/openaiChatCompletionsModel.scenario.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.scenario.test.ts
@@ -143,6 +143,76 @@ describe('OpenAIChatCompletionsModel streaming scenarios', () => {
     });
   });
 
+  it('preserves usage reported on a non-final chunk when the terminal chunk has no usage', async () => {
+    // Some OpenAI-compatible providers reachable through a custom baseURL
+    // (e.g. xAI/Grok, or a LiteLLM gateway in front of it) attach usage to a
+    // non-final chunk and then emit a terminal chunk that carries no usage.
+    const stream = {
+      async *[Symbol.asyncIterator]() {
+        yield makeChunk({ content: 'Hello' });
+        yield makeChunk(
+          { content: ' world' },
+          {
+            prompt_tokens: 17,
+            completion_tokens: 4,
+            total_tokens: 21,
+          },
+        );
+        // Terminal chunk: finish_reason is set but there is no usage field.
+        yield {
+          id: 'res-stream',
+          created: 0,
+          model: 'gpt-stream',
+          object: 'chat.completion.chunk',
+          choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+        } as any;
+      },
+    };
+
+    const create = vi.fn().mockResolvedValue(stream);
+    const client = {
+      chat: { completions: { create } },
+      baseURL: 'https://openai-compatible.example/v1',
+    };
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt-stream');
+    const events: any[] = [];
+
+    const request: any = {
+      input: 'hi there',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    for await (const event of model.getStreamedResponse(request)) {
+      events.push(event);
+    }
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: true,
+        stream_options: { include_usage: true },
+      }),
+      { headers: HEADERS, signal: undefined },
+    );
+
+    const finalEvent = events.find((ev) => ev.type === 'response_done');
+    expect(finalEvent).toBeDefined();
+    // The usage reported mid-stream must survive the terminal usage-less
+    // chunk instead of being reset to zero.
+    expect(finalEvent.response.usage).toEqual({
+      inputTokens: 17,
+      outputTokens: 4,
+      totalTokens: 21,
+      inputTokensDetails: { cached_tokens: 0 },
+      outputTokensDetails: { reasoning_tokens: 0 },
+    });
+  });
+
   it('stores a chat-completion shaped choice in generation spans for streaming traces', async () => {
     setTracingDisabled(false);
     const createGenerationSpanSpy = vi.spyOn(

--- a/packages/agents-openai/test/openaiChatCompletionsModel.scenario.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.scenario.test.ts
@@ -144,9 +144,9 @@ describe('OpenAIChatCompletionsModel streaming scenarios', () => {
   });
 
   it('preserves usage reported on a non-final chunk when the terminal chunk has no usage', async () => {
-    // Some OpenAI-compatible providers reachable through a custom baseURL
-    // (e.g. xAI/Grok, or a LiteLLM gateway in front of it) attach usage to a
-    // non-final chunk and then emit a terminal chunk that carries no usage.
+    // Some OpenAI-compatible providers or gateways may emit a later chunk
+    // without usage after reporting usage: usage arrives on a non-final
+    // chunk and the terminal chunk carries no usage of its own.
     const stream = {
       async *[Symbol.asyncIterator]() {
         yield makeChunk({ content: 'Hello' });

--- a/packages/agents-openai/test/openaiChatCompletionsStreaming.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsStreaming.test.ts
@@ -249,8 +249,9 @@ describe('convertChatCompletionsStreamToResponses', () => {
       void,
       unknown
     > {
-      // usage is delivered on an early chunk (as some providers such as
-      // xAI/Grok via LiteLLM do)...
+      // usage is delivered on an early chunk (some OpenAI-compatible
+      // providers or gateways may emit a later chunk without usage after
+      // reporting usage)...
       yield makeChunk(
         { content: 'Hello' },
         { prompt_tokens: 100, completion_tokens: 5, total_tokens: 105 },

--- a/packages/agents-openai/test/openaiChatCompletionsStreaming.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsStreaming.test.ts
@@ -238,7 +238,54 @@ describe('convertChatCompletionsStreamToResponses', () => {
         arguments: 'a',
       },
     ]);
-    expect(final.response.usage.totalTokens).toBe(0);
+    // The usage reported on the middle chunk must be retained even though the
+    // trailing tool_calls chunk carries no usage of its own.
+    expect(final.response.usage.totalTokens).toBe(3);
+  });
+
+  it('preserves usage reported on an earlier chunk when the final chunk has no usage', async () => {
+    async function* stream(): AsyncGenerator<
+      ChatCompletionChunk,
+      void,
+      unknown
+    > {
+      // usage is delivered on an early chunk (as some providers such as
+      // xAI/Grok via LiteLLM do)...
+      yield makeChunk(
+        { content: 'Hello' },
+        { prompt_tokens: 100, completion_tokens: 5, total_tokens: 105 },
+      );
+      // ...and the terminal chunk carries no usage at all.
+      yield {
+        id: 'c',
+        created: 0,
+        model: 'm',
+        object: 'chat.completion.chunk',
+        choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+      } as any;
+    }
+
+    const resp = { id: 'r' } as any;
+    const events: any[] = [];
+    for await (const e of convertChatCompletionsStreamToResponses(
+      resp,
+      stream() as any,
+    )) {
+      events.push(e);
+    }
+
+    const final = events[events.length - 1];
+    expect(final.type).toBe('response_done');
+    expect(final.response.usage).toMatchObject({
+      inputTokens: 100,
+      outputTokens: 5,
+      totalTokens: 105,
+    });
+    expect(resp.usage).toMatchObject({
+      prompt_tokens: 100,
+      completion_tokens: 5,
+      total_tokens: 105,
+    });
   });
 
   it('ignores chunks with empty choices', async () => {


### PR DESCRIPTION
### Summary

When converting a streamed Chat Completions response, token usage is silently lost whenever a provider reports usage on a non-final chunk.

In `convertChatCompletionsStreamToResponses` (`packages/agents-openai/src/openaiChatCompletionsStreaming.ts`), the streaming loop ran on every chunk:

```ts
// This is always set by the OpenAI API, but not by others e.g. LiteLLM
usage = (chunk as any).usage || undefined;
```

Because this overwrites `usage` unconditionally, the **last-seen** chunk is treated as authoritative. That is fine for the standard OpenAI path, where usage arrives on the final chunk. But some OpenAI-compatible providers or gateways may emit a later chunk without usage after reporting usage on an **earlier** chunk. On that final iteration `usage` is reset to `undefined`, so the terminal `response_done` event serializes usage via `usage?.prompt_tokens ?? 0` (and friends) and reports `inputTokens`, `outputTokens` and `totalTokens` all as `0` — silently corrupting cost/usage accounting.

The fix only overwrites `usage` when the current chunk actually carries usage data, so a value reported anywhere in the stream is retained:

```ts
if ((chunk as any).usage) {
  usage = (chunk as any).usage;
}
```

The normal OpenAI path is unchanged: when usage is on the final chunk, that chunk's usage still wins.

This is the direct JS counterpart of the merged Python fix openai/openai-agents-python#2126 ("Fix: usage from earlier stream chunks when later chunks have none"), which was never ported to the JS SDK.

### Test plan

Added and updated tests in `packages/agents-openai/test/openaiChatCompletionsStreaming.test.ts`:

- **New regression test** — `preserves usage reported on an earlier chunk when the final chunk has no usage`: streams a first chunk carrying `{prompt_tokens: 100, completion_tokens: 5, total_tokens: 105}`, followed by a terminal chunk with `finish_reason: 'stop'` and no usage. It asserts the final `response_done` usage is `{inputTokens: 100, outputTokens: 5, totalTokens: 105}` and that the raw `ChatCompletion.usage` matches. Before the fix this failed with all-zero usage; after the fix it passes.
- **Updated existing assertion** — in `converts chunks to protocol events`, the stream places usage `{1, 2, 3}` on a middle chunk with a trailing tool-call chunk that has no usage. The old assertion `expect(final.response.usage.totalTokens).toBe(0)` had codified the bug (mid-stream usage was discarded); it now asserts `.toBe(3)`, matching the corrected behavior. Same rationale as openai/openai-agents-python#2126.

The normal-path tests that report usage on the **last** chunk (`emits protocol events for streamed chat completions`, asserting `totalTokens: 7`, and `filters multiple choices by default`, asserting `totalTokens: 3`) are intentionally left unchanged and still pass as regression guards.

Verification (from repo root):

- `pnpm build && pnpm -r build-check` — pass
- `CI=1 pnpm test` — 3126 passed, 2 skipped
- `pnpm lint` — clean
- `.agents/skills/code-change-verification/scripts/run.sh` — all commands passed
- Added a changeset (`.changeset/fix-stream-usage-earlier-chunk.md`, patch bump for `@openai/agents-openai`)

### Issue number

No existing issue; the reproduction and root cause are described above.

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration` [(see details)](https://github.com/openai/openai-agents-js/tree/main/integration-tests)
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
- [x] I've added a changeset using `pnpm changeset` to indicate my changes

