### PR TITLE
fix(ai-sdk): concatenate all text parts in non-streaming responses

### DIFF
--- a/.changeset/ai-sdk-concatenate-text-parts.md
+++ b/.changeset/ai-sdk-concatenate-text-parts.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: concatenate all text parts in AI SDK non-streaming responses instead of keeping only the first

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -1568,12 +1568,16 @@ export class AiSdkModel implements Model {
         // so adding this item only when the tool calls are empty.
         // Note that the same support is not available for streaming mode.
         if (!hasToolCalls) {
-          const textItem = resultContent.find(
+          const textParts = resultContent.filter(
             (c: any) => c && c.type === 'text' && typeof c.text === 'string',
           );
-          if (textItem) {
+          if (textParts.length > 0) {
+            // A model response may contain multiple text parts. Concatenate them
+            // to mirror the streaming path (which accumulates every text-delta
+            // into a single output_text) instead of dropping all but the first.
+            const combinedText = textParts.map((c: any) => c.text).join('');
             const transformedText = await this.#transformOutputText(
-              textItem.text,
+              combinedText,
               request,
               false,
             );

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -1528,6 +1528,51 @@ describe('AiSdkModel.getResponse', () => {
     ]);
   });
 
+  test('concatenates multiple text output parts', async () => {
+    const model = new AiSdkModel(
+      stubModel({
+        async doGenerate() {
+          return {
+            content: [
+              { type: 'text', text: 'Hello ' },
+              { type: 'text', text: 'world' },
+            ],
+            usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+            providerMetadata: { p: 1 },
+            response: { id: 'id' },
+            finishReason: 'stop',
+            warnings: [],
+          } as any;
+        },
+      }),
+    );
+
+    const res = await withTrace('t', () =>
+      model.getResponse({
+        input: 'hi',
+        tools: [],
+        handoffs: [],
+        modelSettings: {},
+        outputType: 'text',
+        tracing: false,
+      } as any),
+    );
+
+    expect(res.output).toEqual([
+      {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'Hello world' }],
+        status: 'completed',
+        providerData: {
+          model: 'stub:m',
+          responseId: 'id',
+          p: 1,
+        },
+      },
+    ]);
+  });
+
   test('applies transformOutputText to finalized assistant text', async () => {
     const transformOutputText = vi.fn((text: string, context: any) => {
       expect(context.stream).toBe(false);


### PR DESCRIPTION
### Problem

In the AI SDK extension, `AiSdkModel.getResponse` (the non-streaming path) uses `Array.prototype.find` to pick a single `text` content part out of `doGenerate().content`:

```ts
const textItem = resultContent.find(
  (c: any) => c && c.type === 'text' && typeof c.text === 'string',
);
```

A model response can legitimately contain **multiple** text parts — `doGenerate` returns `content: Array<LanguageModelV2Content>`, where `LanguageModelV2Content` includes `LanguageModelV2Text`, and the AI SDK concatenates them into the final text. With `find`, every text part after the first is silently dropped from the assistant message.

This also makes the adapter internally inconsistent with its own **streaming** path, which accumulates every `text-delta` into a single `output_text`:

```ts
case 'text-delta': {
  if (!textOutput) textOutput = { type: 'output_text', text: '' };
  textOutput.text += (part as any).delta;
  ...
}
```

So for the same model output split across multiple text parts, `run(...)` returns the full text while `run(..., { stream: false })` returns only the first segment. Note the sibling reasoning branch just above already loops over *all* reasoning parts, confirming the single-`find` for text is an oversight rather than intent.

### Fix

Collect all text parts, join them, and apply `transformOutputText` once — mirroring the streaming path:

```ts
const textParts = resultContent.filter(
  (c: any) => c && c.type === 'text' && typeof c.text === 'string',
);
if (textParts.length > 0) {
  const combinedText = textParts.map((c: any) => c.text).join('');
  const transformedText = await this.#transformOutputText(combinedText, request, false);
  ...
}
```

### Verification

- Added a regression test (`concatenates multiple text output parts`) that stubs `doGenerate` to return two text parts (`'Hello '` + `'world'`) and asserts the assistant `output_text` is `'Hello world'`.
- The test **fails on `main`** (produces `'Hello '`) and **passes** with this change.
- Full package suite green: `vitest run --project @openai/agents-extensions` → **640 passed**.
- `eslint` and `prettier --check` clean on the changed files.
- Changeset added (`@openai/agents-extensions` patch).