### PR TITLE
fix: fail union/tuple schema conversion instead of silently dropping members

### DIFF
--- a/.changeset/tough-ducks-brake.md
+++ b/.changeset/tough-ducks-brake.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: fail zodJsonSchemaCompat union/tuple conversion instead of silently dropping unconvertible members
+
+When the fallback zod-to-JSON-schema converter met a union (or tuple) member it could not convert — for example a discriminated-union variant containing `z.preprocess` — it silently filtered the member out and emitted the remaining schema. The result looked valid but forbade outputs the Zod schema accepts: an agent whose `outputType` union lost a variant could never emit that action under structured outputs. Conversion now fails the whole union/tuple so the caller raises the existing descriptive `UserError` instead of degrading the model's output space.

--- a/packages/agents-core/src/utils/zodJsonSchemaCompat.ts
+++ b/packages/agents-core/src/utils/zodJsonSchemaCompat.ts
@@ -303,10 +303,8 @@ function buildArraySchema(
 function buildTupleSchema(
   def: Record<string, unknown> | undefined,
 ): JsonSchemaDefinitionEntry | undefined {
-  const items = coerceArray(def?.items)
-    .map((item) => convertSchema(item))
-    .filter(Boolean) as JsonSchemaDefinitionEntry[];
-  if (!items.length) {
+  const items = convertAllOrFail(coerceArray(def?.items));
+  if (!items || !items.length) {
     return undefined;
   }
   const schema: JsonSchemaDefinitionEntry = {
@@ -323,10 +321,30 @@ function buildTupleSchema(
 function buildUnionSchema(
   def: Record<string, unknown> | undefined,
 ): JsonSchemaDefinitionEntry | undefined {
-  const options = coerceArray(def?.options ?? def?.schemas)
-    .map((option) => convertSchema(option))
-    .filter(Boolean) as JsonSchemaDefinitionEntry[];
-  return options.length ? { anyOf: options } : undefined;
+  const options = convertAllOrFail(coerceArray(def?.options ?? def?.schemas));
+  return options && options.length ? { anyOf: options } : undefined;
+}
+
+/**
+ * Converts every member or fails the whole collection. Silently dropping an
+ * unconvertible member would emit a schema that looks valid but forbids
+ * outputs the Zod schema accepts — e.g. a discriminated-union action variant
+ * containing `z.preprocess` disappears from the union, so a model constrained
+ * by the emitted schema can never produce that action. Returning `undefined`
+ * propagates the failure so callers surface a descriptive error instead.
+ */
+function convertAllOrFail(
+  members: unknown[],
+): JsonSchemaDefinitionEntry[] | undefined {
+  const converted: JsonSchemaDefinitionEntry[] = [];
+  for (const member of members) {
+    const schema = convertSchema(member);
+    if (!schema) {
+      return undefined;
+    }
+    converted.push(schema);
+  }
+  return converted;
 }
 
 function buildIntersectionSchema(
@@ -432,11 +450,7 @@ function buildLiteral(
     return undefined;
   }
   const literal = extractFirst(def, 'value', 'literal') as
-    | string
-    | number
-    | boolean
-    | null
-    | undefined;
+    string | number | boolean | null | undefined;
   if (literal === undefined && Array.isArray(def.values)) {
     const values = def.values as Array<string | number | boolean | null>;
     if (values.length === 1) {

--- a/packages/agents-core/test/utils/zodJsonSchemaCompat.test.ts
+++ b/packages/agents-core/test/utils/zodJsonSchemaCompat.test.ts
@@ -228,6 +228,35 @@ describe('utils/zodJsonSchemaCompat', () => {
     });
   });
 
+  it('fails the whole union when a member cannot be converted', () => {
+    // A silently dropped union member would emit a schema that forbids
+    // outputs the Zod schema accepts: a model constrained by the emitted
+    // schema could never produce the dropped variant.
+    const schema = z.object({
+      action: z.discriminatedUnion('type', [
+        z.object({
+          type: z.literal('replace'),
+          // z.preprocess is not convertible by this fallback converter.
+          id: z.preprocess(
+            (value) => (typeof value === 'string' ? value : null),
+            z.string().nullable(),
+          ),
+        }),
+        z.object({ type: z.literal('none'), reason: z.string() }),
+      ]),
+    });
+
+    expect(zodJsonSchemaCompat(schema)).toBeUndefined();
+  });
+
+  it('fails the whole tuple when a member cannot be converted', () => {
+    const schema = z.object({
+      pair: z.tuple([z.string(), z.date()]),
+    });
+
+    expect(zodJsonSchemaCompat(schema)).toBeUndefined();
+  });
+
   it('returns undefined when schema shape cannot be introspected', () => {
     const tricky = {
       shape: () => {


### PR DESCRIPTION
## Summary

`zodJsonSchemaCompat` (the fallback converter used when `openai/helpers/zod` cannot emit a schema, e.g. for Zod v4 objects with `.optional()` fields) silently drops union and tuple members it cannot convert:

```ts
const options = coerceArray(def?.options ?? def?.schemas)
  .map((option) => convertSchema(option))
  .filter(Boolean); // <- unconvertible members vanish here
return options.length ? { anyOf: options } : undefined;
```

The emitted schema looks valid but forbids outputs the original Zod schema accepts. Under structured outputs this is silent corruption of the model's output space: the model *cannot* produce the dropped variant, and nothing fails loudly.

### Real-world impact

We hit this in production with an agent whose `outputType` is a plan object of discriminated-union actions. Several variants contain a `z.preprocess` field (not convertible by this fallback), so the serialized `text.format` schema silently lost those variants — e.g. a `sequenceAction` union of `replace | pause | abort | none` was served to the model as `pause | abort | none`. The agent spent days "refusing" to schedule work while explaining, in its reason fields, that the action wasn't available. When we force-prompted the action, the model answered: *"that executable action is not available in this response schema."*

Per the module's own doc comment, anything the converter can't cover should return `undefined`, "signalling to the caller that it should surface a user error" — that already happens for unsupported leaf nodes, but unions/tuples partially converted instead. This PR makes a failed member fail the whole union/tuple, so `convertAgentOutputTypeToSerializable`/`getSchemaAndParserFromInputType` raise their existing descriptive `UserError` instead of degrading the schema. An incomplete-but-loud failure is strictly better than a silently wrong schema: the user gets an actionable error at agent construction rather than a model that mysteriously never emits certain actions.

## Changes

- `buildUnionSchema` / `buildTupleSchema` now use `convertAllOrFail`, which returns `undefined` if any member fails to convert.
- Regression tests: a discriminated union with a `z.preprocess` variant and a tuple with a `z.date()` member both cause `zodJsonSchemaCompat` to return `undefined`.
- Changeset included (`patch` on `@openai/agents-core`).

## Test plan

- `pnpm vitest run packages/agents-core/test/utils/zodJsonSchemaCompat.test.ts` — 16 passed (14 existing + 2 new)
- Full `@openai/agents-core` project: 1723 passed; the only 2 failures (`test/sandboxes/unixLocal.signals.test.ts` PTY signal handling) also fail on a clean checkout of `main` on this machine (macOS environment issue, unrelated)
- `pnpm --filter @openai/agents-core build` and `pnpm lint` pass

Made with [Cursor](https://cursor.com)