### PR TITLE
fix: decode base64 without host globals

### DIFF
--- a/.changeset/tidy-cats-decode.md
+++ b/.changeset/tidy-cats-decode.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: decode persisted binary sandbox manifest content without host base64 globals

--- a/packages/agents-core/src/sandbox/sandboxes/shared/manifestPersistence.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/manifestPersistence.ts
@@ -9,7 +9,10 @@ import {
   serializeManifestEnvironment,
   type SerializedManifestEnvironment,
 } from '../../shared/environment';
-import { encodeUint8ArrayToBase64 } from '../../../utils/base64';
+import {
+  decodeBase64ToUint8Array,
+  encodeUint8ArrayToBase64,
+} from '../../../utils/base64';
 
 type ManifestPersistenceState = {
   manifest: Manifest;
@@ -276,22 +279,4 @@ function isSerializedFileContent(
     (value as { type?: unknown }).type === 'base64' &&
     typeof (value as { data?: unknown }).data === 'string'
   );
-}
-
-function decodeBase64ToUint8Array(value: string): Uint8Array {
-  const bufferCtor = (
-    globalThis as {
-      Buffer?: { from(input: string, encoding: string): Uint8Array };
-    }
-  ).Buffer;
-  if (bufferCtor) {
-    return Uint8Array.from(bufferCtor.from(value, 'base64'));
-  }
-
-  const binary = atob(value);
-  const bytes = new Uint8Array(binary.length);
-  for (let index = 0; index < binary.length; index += 1) {
-    bytes[index] = binary.charCodeAt(index);
-  }
-  return bytes;
 }

--- a/packages/agents-core/src/utils/base64.ts
+++ b/packages/agents-core/src/utils/base64.ts
@@ -48,3 +48,76 @@ export function encodeUint8ArrayToBase64(data: Uint8Array): string {
 
   return result;
 }
+
+/**
+ * Decode a base64 string into a Uint8Array in both Node and browser environments.
+ */
+export function decodeBase64ToUint8Array(value: string): Uint8Array {
+  if (value.length === 0) {
+    return new Uint8Array();
+  }
+
+  const globalBuffer =
+    typeof globalThis !== 'undefined' && (globalThis as any).Buffer
+      ? (globalThis as any).Buffer
+      : undefined;
+
+  if (globalBuffer) {
+    return Uint8Array.from(globalBuffer.from(value, 'base64'));
+  }
+
+  if (typeof (globalThis as any).atob === 'function') {
+    const binary = (globalThis as any).atob(value);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) {
+      bytes[index] = binary.charCodeAt(index);
+    }
+    return bytes;
+  }
+
+  const chars =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+  const normalized = value.replace(/[\t\n\f\r ]/g, '');
+  if (normalized.length % 4 === 1) {
+    throw new TypeError('Invalid base64 string.');
+  }
+
+  const padded = normalized.padEnd(
+    normalized.length + ((4 - (normalized.length % 4)) % 4),
+    '=',
+  );
+  const padding = padded.endsWith('==') ? 2 : padded.endsWith('=') ? 1 : 0;
+  const bytes = new Uint8Array((padded.length / 4) * 3 - padding);
+  let outputIndex = 0;
+
+  for (let index = 0; index < padded.length; index += 4) {
+    const enc1 = chars.indexOf(padded[index]);
+    const enc2 = chars.indexOf(padded[index + 1]);
+    const enc3 =
+      padded[index + 2] === '=' ? 64 : chars.indexOf(padded[index + 2]);
+    const enc4 =
+      padded[index + 3] === '=' ? 64 : chars.indexOf(padded[index + 3]);
+    const isFinalGroup = index + 4 === padded.length;
+
+    if (
+      enc1 < 0 ||
+      enc2 < 0 ||
+      enc3 < 0 ||
+      enc4 < 0 ||
+      (!isFinalGroup && (enc3 === 64 || enc4 === 64)) ||
+      (enc3 === 64 && enc4 !== 64)
+    ) {
+      throw new TypeError('Invalid base64 string.');
+    }
+
+    bytes[outputIndex++] = (enc1 << 2) | (enc2 >> 4);
+    if (enc3 !== 64) {
+      bytes[outputIndex++] = ((enc2 & 0xf) << 4) | (enc3 >> 2);
+    }
+    if (enc4 !== 64) {
+      bytes[outputIndex++] = ((enc3 & 0x3) << 6) | enc4;
+    }
+  }
+
+  return bytes;
+}

--- a/packages/agents-core/test/sandboxShared.test.ts
+++ b/packages/agents-core/test/sandboxShared.test.ts
@@ -39,6 +39,7 @@ const processPlatformDescriptor = Object.getOwnPropertyDescriptor(
 afterEach(() => {
   vi.doUnmock('node:os');
   vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
   vi.resetModules();
   if (processPlatformDescriptor) {
     Object.defineProperty(process, 'platform', processPlatformDescriptor);
@@ -302,6 +303,23 @@ describe('sandbox shared helpers', () => {
     expect(
       (restored.entries.nested as any).children['payload.bin'].content,
     ).toEqual(bytes);
+  });
+
+  it('restores binary manifest files without host base64 globals', () => {
+    const bytes = Uint8Array.from([0, 255, 34, 17, 128]);
+    const serialized = serializeManifestRecord(
+      new Manifest({
+        entries: {
+          'payload.bin': file({ content: bytes }),
+        },
+      }),
+    );
+    vi.stubGlobal('Buffer', undefined);
+    vi.stubGlobal('atob', undefined);
+
+    const restored = deserializeManifest(serialized);
+
+    expect((restored.entries['payload.bin'] as any).content).toEqual(bytes);
   });
 
   it('materializes manifest environment values and preserves runtime overrides', async () => {

--- a/packages/agents-core/test/utils/base64.test.ts
+++ b/packages/agents-core/test/utils/base64.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 
-import { encodeUint8ArrayToBase64 } from '../../src/utils/base64';
+import {
+  decodeBase64ToUint8Array,
+  encodeUint8ArrayToBase64,
+} from '../../src/utils/base64';
 
 describe('encodeUint8ArrayToBase64', () => {
   const originalBuffer = (globalThis as any).Buffer;
@@ -51,5 +54,60 @@ describe('encodeUint8ArrayToBase64', () => {
     expect(result).toBe(
       (originalBuffer as typeof Buffer).from(bytes).toString('base64'),
     );
+  });
+});
+
+describe('decodeBase64ToUint8Array', () => {
+  const originalBuffer = (globalThis as any).Buffer;
+  const originalAtob = (globalThis as any).atob;
+
+  afterEach(() => {
+    (globalThis as any).Buffer = originalBuffer;
+    (globalThis as any).atob = originalAtob;
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(decodeBase64ToUint8Array('')).toEqual(new Uint8Array());
+  });
+
+  it('decodes ASCII data from base64', () => {
+    expect(decodeBase64ToUint8Array('aGVsbG8gd29ybGQ=')).toEqual(
+      new TextEncoder().encode('hello world'),
+    );
+  });
+
+  it('decodes arbitrary binary data', () => {
+    expect(decodeBase64ToUint8Array('AP8iEYBA')).toEqual(
+      new Uint8Array([0, 255, 34, 17, 128, 64]),
+    );
+  });
+
+  it('uses atob when Buffer is unavailable', () => {
+    (globalThis as any).Buffer = undefined;
+    const atobSpy = vi.fn((input: string) =>
+      (originalBuffer as typeof Buffer)
+        .from(input, 'base64')
+        .toString('binary'),
+    );
+    (globalThis as any).atob = atobSpy;
+
+    expect(decodeBase64ToUint8Array('AQID')).toEqual(new Uint8Array([1, 2, 3]));
+    expect(atobSpy).toHaveBeenCalledWith('AQID');
+  });
+
+  it('falls back to manual decoding when Buffer and atob are unavailable', () => {
+    (globalThis as any).Buffer = undefined;
+    (globalThis as any).atob = undefined;
+
+    const cases: Array<[string, number[]]> = [
+      ['AA==', [0]],
+      ['AP8=', [0, 255]],
+      ['AP8i', [0, 255, 34]],
+      ['AP8iEQ==', [0, 255, 34, 17]],
+    ];
+
+    for (const [value, expected] of cases) {
+      expect(decodeBase64ToUint8Array(value)).toEqual(new Uint8Array(expected));
+    }
   });
 });


### PR DESCRIPTION
This pull request fixes binary sandbox manifest restoration in pure ECMAScript environments such as Temporal workflow isolates, where neither Node `Buffer` nor host `atob` is available.

It adds a pure JavaScript fallback to the shared base64 decoder and uses it when restoring persisted binary manifest file content. The existing serialized manifest format and Node/browser decoding paths remain unchanged.