### PR TITLE
feat(ai-sdk): support provider-executed tool search

### DIFF
--- a/.changeset/ai-sdk-provider-tool-search.md
+++ b/.changeset/ai-sdk-provider-tool-search.md
@@ -3,4 +3,4 @@
 '@openai/agents-extensions': patch
 ---
 
-feat: add AI SDK provider-executed tool search support
+feat: add AI SDK provider-executed tool search support (#1479)

--- a/.changeset/ai-sdk-provider-tool-search.md
+++ b/.changeset/ai-sdk-provider-tool-search.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-extensions': patch
+---
+
+feat: add AI SDK provider-executed tool search support

--- a/packages/agents-core/src/model.ts
+++ b/packages/agents-core/src/model.ts
@@ -392,6 +392,11 @@ export type SerializedFunctionTool = {
   deferLoading?: FunctionTool['deferLoading'];
 
   /**
+   * Additional provider-specific metadata forwarded with the function tool definition.
+   */
+  providerData?: FunctionTool['providerData'];
+
+  /**
    * Responses API only. Explicit namespace used to group related function tools.
    */
   namespace?: string;

--- a/packages/agents-core/src/runner/toolSearch.ts
+++ b/packages/agents-core/src/runner/toolSearch.ts
@@ -160,16 +160,18 @@ function serializeFunctionToolForToolSearchOutput(
 ): protocol.ToolSearchOutputTool {
   const serialized = serializeTool(tool) as Record<string, unknown>;
   const namespace = getExplicitFunctionToolNamespace(tool);
+  const { providerData: _providerData, ...toolSearchPayload } = serialized;
+  void _providerData;
 
   if (!namespace) {
-    return serialized as protocol.ToolSearchOutputTool;
+    return toolSearchPayload as protocol.ToolSearchOutputTool;
   }
 
   const {
     namespace: _namespace,
     namespaceDescription,
     ...toolPayload
-  } = serialized;
+  } = toolSearchPayload;
   void namespaceDescription;
   return toolPayload as protocol.ToolSearchOutputTool;
 }

--- a/packages/agents-core/src/tool.ts
+++ b/packages/agents-core/src/tool.ts
@@ -174,8 +174,7 @@ export type ShellToolInlineSkill = {
 };
 
 export type ShellToolContainerSkill =
-  | ShellToolSkillReference
-  | ShellToolInlineSkill;
+  ShellToolSkillReference | ShellToolInlineSkill;
 
 export type ShellToolContainerNetworkPolicyDomainSecret = {
   domain: string;
@@ -216,12 +215,10 @@ export type ShellToolContainerReferenceEnvironment = {
 };
 
 export type ShellToolHostedEnvironment =
-  | ShellToolContainerAutoEnvironment
-  | ShellToolContainerReferenceEnvironment;
+  ShellToolContainerAutoEnvironment | ShellToolContainerReferenceEnvironment;
 
 export type ShellToolEnvironment =
-  | ShellToolLocalEnvironment
-  | ShellToolHostedEnvironment;
+  ShellToolLocalEnvironment | ShellToolHostedEnvironment;
 
 export type ApplyPatchApprovalFunction = (
   runContext: RunContext,
@@ -270,8 +267,7 @@ type ToolEnabledPredicate<Context = UnknownContext> = (args: {
 }) => boolean | Promise<boolean>;
 
 type ToolEnabledOption<Context = UnknownContext> =
-  | boolean
-  | ToolEnabledPredicate<Context>;
+  boolean | ToolEnabledPredicate<Context>;
 
 /**
  * Exposes a function to the agent as a tool to be called
@@ -306,6 +302,11 @@ export type FunctionTool<
    * Responses API only. Hides a top-level function tool definition until tool search loads it.
    */
   deferLoading?: boolean;
+
+  /**
+   * Additional provider-specific metadata forwarded with the function tool definition.
+   */
+  providerData?: Record<string, any>;
 
   /**
    * The function to invoke when the tool is called.
@@ -1004,7 +1005,8 @@ export function hostedMcpTool<Context = UnknownContext>(
     serverDescription?: string;
   } &
     // MCP server
-    (| {
+    (
+      | {
           serverLabel: string;
           serverUrl?: string;
           authorization?: string;
@@ -1160,10 +1162,7 @@ export type ClientToolSearchExecutorArgs<Context = UnknownContext> = {
 };
 
 export type ClientToolSearchExecutorResult<Context = UnknownContext> =
-  | Tool<Context>
-  | Tool<Context>[]
-  | null
-  | undefined;
+  Tool<Context> | Tool<Context>[] | null | undefined;
 
 export type ClientToolSearchExecutor<Context = UnknownContext> = (
   args: ClientToolSearchExecutorArgs<Context>,
@@ -1310,9 +1309,7 @@ export type FunctionToolResult<
  * If undefined is provided, the arguments to the tool will be passed as a string.
  */
 export type ToolInputParameters =
-  | undefined
-  | ZodObjectLike
-  | JsonObjectSchema<any>;
+  undefined | ZodObjectLike | JsonObjectSchema<any>;
 
 /**
  * The parameters of a tool that has strict mode enabled.
@@ -1327,9 +1324,7 @@ export type ToolInputParameters =
  * If undefined is provided, the arguments to the tool will be passed as a string.
  */
 export type ToolInputParametersStrict =
-  | undefined
-  | ZodObjectLike
-  | JsonObjectSchemaStrict<any>;
+  undefined | ZodObjectLike | JsonObjectSchemaStrict<any>;
 
 /**
  * The parameters of a tool that has strict mode disabled.
@@ -1339,8 +1334,7 @@ export type ToolInputParametersStrict =
  * Zod schemas are not supported without strict: true.
  */
 export type ToolInputParametersNonStrict =
-  | undefined
-  | JsonObjectSchemaNonStrict<any>;
+  undefined | JsonObjectSchemaNonStrict<any>;
 
 /**
  * The arguments to a tool.
@@ -1474,6 +1468,11 @@ type StrictToolOptions<
   deferLoading?: boolean;
 
   /**
+   * Additional provider-specific metadata forwarded with the function tool definition.
+   */
+  providerData?: Record<string, any>;
+
+  /**
    * The function to invoke when the tool is called.
    */
   execute: ToolExecuteFunction<TParameters, Context>;
@@ -1550,6 +1549,11 @@ type NonStrictToolOptions<
    * Responses API only. Hides a top-level function tool definition until tool search loads it.
    */
   deferLoading?: boolean;
+
+  /**
+   * Additional provider-specific metadata forwarded with the function tool definition.
+   */
+  providerData?: Record<string, any>;
 
   /**
    * The function to invoke when the tool is called.
@@ -1972,8 +1976,7 @@ export function tool<
     details?: ToolCallDetails,
   ): Promise<string | Result> {
     const detailsWithFlag = details as
-      | ToolCallDetailsWithTimeoutFlag
-      | undefined;
+      ToolCallDetailsWithTimeoutFlag | undefined;
     if (detailsWithFlag?.[FUNCTION_TOOL_TIMEOUT_ALREADY_ENFORCED]) {
       return invokeWithoutTimeout(runContext, input, details);
     }
@@ -2015,6 +2018,7 @@ export function tool<
     parameters,
     strict: strictMode,
     deferLoading: options.deferLoading ?? false,
+    providerData: options.providerData,
     invoke,
     needsApproval,
     timeoutMs,

--- a/packages/agents-core/src/utils/serialize.ts
+++ b/packages/agents-core/src/utils/serialize.ts
@@ -57,6 +57,7 @@ export function serializeTool(tool: Tool<any>): SerializedTool {
       parameters: tool.parameters as JsonObjectSchema<any>,
       strict: tool.strict,
       deferLoading: tool.deferLoading,
+      providerData: tool.providerData,
       ...(namespace ? { namespace } : {}),
       ...(namespace
         ? {

--- a/packages/agents-core/test/runner/modelOutputs.test.ts
+++ b/packages/agents-core/test/runner/modelOutputs.test.ts
@@ -143,6 +143,9 @@ describe('processModelResponse', () => {
         trackingNumber: z.string(),
       }),
       deferLoading: true,
+      providerData: {
+        anthropic: { deferLoading: true },
+      },
       execute: async () => 'tomorrow',
     });
     const shippingCredit = tool({
@@ -198,6 +201,9 @@ describe('processModelResponse', () => {
         execution: 'client',
       },
     });
+    expect(
+      (result.newItems[1] as ToolSearchOutputItem).rawItem.tools[0],
+    ).not.toHaveProperty('providerData');
     expect(result.hasToolsOrApprovalsToRun()).toBe(true);
   });
 

--- a/packages/agents-core/test/tool.test.ts
+++ b/packages/agents-core/test/tool.test.ts
@@ -54,6 +54,24 @@ describe('Tool', () => {
     expect(t.deferLoading).toBe(true);
   });
 
+  it('records provider data when requested', () => {
+    const t = tool({
+      name: 'provider_lookup',
+      description: 'Provider-specific lookup tool.',
+      parameters: z.object({
+        query: z.string(),
+      }),
+      providerData: {
+        anthropic: { deferLoading: true },
+      },
+      execute: async () => ({ bar: 'ok' }),
+    });
+
+    expect(t.providerData).toEqual({
+      anthropic: { deferLoading: true },
+    });
+  });
+
   it('toolNamespace returns shallow-cloned function tools', () => {
     const t = tool({
       name: 'lookup_account',

--- a/packages/agents-core/test/utils/serialize.test.ts
+++ b/packages/agents-core/test/utils/serialize.test.ts
@@ -196,6 +196,28 @@ describe('serialize utilities', () => {
     });
   });
 
+  it('serializes function tool provider data', () => {
+    const providerLookup = tool({
+      name: 'provider_lookup',
+      description: 'Provider-specific lookup tool.',
+      parameters: z.object({
+        query: z.string(),
+      }),
+      providerData: {
+        anthropic: { deferLoading: true },
+      },
+      execute: async () => 'ok',
+    });
+
+    expect(serializeTool(providerLookup)).toMatchObject({
+      type: 'function',
+      name: 'provider_lookup',
+      providerData: {
+        anthropic: { deferLoading: true },
+      },
+    });
+  });
+
   it('serializeHandoff', () => {
     const h: any = {
       toolName: 'hn',

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -31,6 +31,7 @@ import {
   withGenerationSpan,
   getLogger,
   ModelSettingsToolChoice,
+  HostedTool,
 } from '@openai/agents';
 import {
   getToolSearchProviderCallId,
@@ -77,8 +78,67 @@ type LanguageModelV2ProviderTool = {
 };
 
 type LanguageModelV2ProviderToolCompat =
-  | LanguageModelV2ProviderDefinedTool
-  | LanguageModelV2ProviderTool;
+  LanguageModelV2ProviderDefinedTool | LanguageModelV2ProviderTool;
+
+/**
+ * Provider tool definition returned by an AI SDK provider tool factory.
+ */
+export type AiSdkProviderTool = {
+  type?: string;
+  id?: string;
+  args?: Record<string, any>;
+};
+
+type AiSdkProviderToolConfig = {
+  id: string;
+  args: Record<string, any>;
+};
+
+const AI_SDK_PROVIDER_TOOL_KEY = 'aiSdkProviderTool';
+
+/**
+ * Adapts an AI SDK provider's server-executed tool-search definition for use
+ * with an Agents SDK agent.
+ *
+ * @param providerTool - A provider tool returned by an AI SDK tool factory.
+ * @returns A hosted tool-search tool understood by the AI SDK adapter.
+ */
+export function aiSdkToolSearchTool(
+  providerTool: AiSdkProviderTool,
+): HostedTool {
+  if (
+    !providerTool ||
+    (providerTool.type !== 'provider' &&
+      providerTool.type !== 'provider-defined')
+  ) {
+    throw new UserError(
+      'aiSdkToolSearchTool() requires an AI SDK provider tool definition.',
+    );
+  }
+  if (typeof providerTool.id !== 'string' || providerTool.id.trim() === '') {
+    throw new UserError(
+      'aiSdkToolSearchTool() requires a provider tool with a non-empty id.',
+    );
+  }
+  if (providerTool.args !== undefined && !isRecord(providerTool.args)) {
+    throw new UserError(
+      'aiSdkToolSearchTool() requires provider tool args to be an object.',
+    );
+  }
+
+  return {
+    type: 'hosted_tool',
+    name: 'tool_search',
+    providerData: {
+      type: 'tool_search',
+      execution: 'server',
+      [AI_SDK_PROVIDER_TOOL_KEY]: {
+        id: providerTool.id,
+        args: providerTool.args ?? {},
+      } satisfies AiSdkProviderToolConfig,
+    },
+  };
+}
 
 type LanguageModelV2CallOptionsCompat = Omit<
   LanguageModelV2CallOptions,
@@ -105,8 +165,7 @@ type LanguageModelV2Compat = Omit<
 };
 
 type LanguageModelCompatible =
-  | LanguageModelV2Compat
-  | LanguageModelV3Compatible;
+  LanguageModelV2Compat | LanguageModelV3Compatible;
 
 type SerializedComputerTool = Extract<SerializedTool, { type: 'computer' }>;
 
@@ -203,19 +262,17 @@ export function itemsToLanguageV2Messages(
   const toolCallNamesById = new Map<string, string>();
   const pendingToolSearchCallIds: string[] = [];
   const pendingServerToolSearchCallIds: string[] = [];
+  const serverToolSearchCallIds = new Set<string>();
   let generatedToolSearchCallId = 0;
   let currentAssistantMessage: LanguageModelV2Message | undefined;
   let pendingReasonerReasoning:
-    | { text: string; providerOptions: Record<string, any> }
-    | undefined;
+    { text: string; providerOptions: Record<string, any> } | undefined;
   const collapsedItems = collapseReplacedToolSearchOutputs(items);
   const consumePendingReasonerReasoning = () => {
-    if (
-      !(
-        shouldIncludeReasoningContent(model, modelSettings) &&
-        pendingReasonerReasoning
-      )
-    ) {
+    if (!(
+      shouldIncludeReasoningContent(model, modelSettings) &&
+      pendingReasonerReasoning
+    )) {
       return undefined;
     }
 
@@ -480,6 +537,7 @@ export function itemsToLanguageV2Messages(
           pendingToolSearchCallIds.push(toolCallId);
         } else {
           pendingServerToolSearchCallIds.push(toolCallId);
+          serverToolSearchCallIds.add(toolCallId);
         }
         toolCallNamesById.set(toolCallId, 'tool_search');
         const content: LanguageModelV2ToolCallPart = {
@@ -487,25 +545,16 @@ export function itemsToLanguageV2Messages(
           toolCallId,
           toolName: 'tool_search',
           input: item.arguments,
+          ...(getToolSearchExecution(item) === 'server'
+            ? { providerExecuted: true }
+            : {}),
           providerOptions: toProviderOptions(item.providerData, model),
         };
         currentAssistantMessage.content.push(content);
       }
       continue;
     } else if (item.type === 'tool_search_output') {
-      flushPendingReasonerReasoningToMessages();
-      if (currentAssistantMessage) {
-        messages.push(currentAssistantMessage);
-        currentAssistantMessage = undefined;
-      }
-      const rawToolSearchExecution =
-        (item as { execution?: unknown }).execution ??
-        item.providerData?.execution;
-      const toolSearchExecution =
-        rawToolSearchExecution === 'client' ||
-        rawToolSearchExecution === 'server'
-          ? rawToolSearchExecution
-          : undefined;
+      const toolSearchExecution = getToolSearchExecution(item);
       const toolCallId =
         toolSearchExecution === 'server'
           ? takeQueuedToolSearchResultCallId(
@@ -521,23 +570,59 @@ export function itemsToLanguageV2Messages(
               return `tool_search_${generatedToolSearchCallId}`;
             });
       const toolName = toolCallNamesById.get(toolCallId) ?? 'tool_search';
+      const isMatchedServerToolSearchResult =
+        toolSearchExecution === 'server' &&
+        serverToolSearchCallIds.has(toolCallId);
+      const providerOptions = toProviderOptions(item.providerData, model);
       const toolResult: LanguageModelV2ToolResultPart = {
         type: 'tool-result',
         toolCallId,
         toolName,
         output: {
           type: 'json',
-          value: {
-            ...(typeof item.status === 'string' ? { status: item.status } : {}),
-            tools: item.tools,
-          },
+          value: isMatchedServerToolSearchResult
+            ? item.tools
+            : {
+                ...(typeof item.status === 'string'
+                  ? { status: item.status }
+                  : {}),
+                tools: item.tools,
+              },
         },
-        providerOptions: toProviderOptions(item.providerData, model),
+        providerOptions,
       };
+
+      if (isMatchedServerToolSearchResult) {
+        if (!currentAssistantMessage) {
+          currentAssistantMessage = {
+            role: 'assistant',
+            content: [],
+            providerOptions,
+          };
+        }
+        if (
+          Array.isArray(currentAssistantMessage.content) &&
+          currentAssistantMessage.role === 'assistant'
+        ) {
+          appendPendingReasonerReasoningToCurrentAssistant();
+          currentAssistantMessage.content.push(toolResult);
+          currentAssistantMessage.providerOptions = {
+            ...currentAssistantMessage.providerOptions,
+            ...providerOptions,
+          };
+        }
+        continue;
+      }
+
+      flushPendingReasonerReasoningToMessages();
+      if (currentAssistantMessage) {
+        messages.push(currentAssistantMessage);
+        currentAssistantMessage = undefined;
+      }
       messages.push({
         role: 'tool',
         content: [toolResult],
-        providerOptions: toProviderOptions(item.providerData, model),
+        providerOptions,
       });
       continue;
     }
@@ -810,6 +895,28 @@ function isHostedToolSearchTool(
   );
 }
 
+function getAiSdkProviderToolConfig(
+  tool: SerializedTool | SerializedHandoff | undefined,
+): AiSdkProviderToolConfig | undefined {
+  if (!isHostedToolSearchTool(tool)) {
+    return undefined;
+  }
+
+  const config = tool.providerData?.[AI_SDK_PROVIDER_TOOL_KEY];
+  if (
+    !isRecord(config) ||
+    typeof config.id !== 'string' ||
+    !isRecord(config.args)
+  ) {
+    return undefined;
+  }
+
+  return {
+    id: config.id,
+    args: config.args,
+  };
+}
+
 function normalizeToolSearchArguments(value: unknown): unknown {
   if (typeof value !== 'string') {
     return value ?? {};
@@ -825,6 +932,19 @@ function normalizeToolSearchArguments(value: unknown): unknown {
   } catch {
     return value;
   }
+}
+
+function getToolSearchExecution(value: {
+  execution?: unknown;
+  providerData?: unknown;
+}): 'client' | 'server' | undefined {
+  const providerExecution = isRecord(value.providerData)
+    ? value.providerData.execution
+    : undefined;
+  const execution = value.execution ?? providerExecution;
+  return execution === 'client' || execution === 'server'
+    ? execution
+    : undefined;
 }
 
 function takeQueuedToolSearchResultCallId(
@@ -902,13 +1022,26 @@ function createProtocolToolCallItem(args: {
   toolName: string;
   input: unknown;
   providerData: Record<string, any> | undefined;
+  providerExecuted?: boolean;
 }): protocol.FunctionCallItem | protocol.ToolSearchCallItem {
-  const { requestedTool, toolCallId, toolName, input, providerData } = args;
+  const {
+    requestedTool,
+    toolCallId,
+    toolName,
+    input,
+    providerData,
+    providerExecuted,
+  } = args;
 
   if (isHostedToolSearchTool(requestedTool)) {
+    const execution =
+      providerExecuted || getToolSearchExecution(requestedTool) === 'server'
+        ? 'server'
+        : 'client';
     return {
       type: 'tool_search_call',
       id: toolCallId,
+      ...(execution === 'server' ? { execution } : {}),
       arguments: normalizeToolSearchArguments(input),
       status: 'completed',
       providerData,
@@ -931,6 +1064,50 @@ function createProtocolToolCallItem(args: {
     name: toolName,
     arguments: toolCallArguments,
     status: 'completed',
+    providerData,
+  };
+}
+
+function getAiSdkToolResultValue(part: any): unknown {
+  if ('result' in part) {
+    return part.result;
+  }
+
+  if (isRecord(part.output) && part.output.type === 'json') {
+    return part.output.value;
+  }
+
+  return undefined;
+}
+
+function createProtocolToolSearchOutputItem(args: {
+  requestedTool: SerializedTool | SerializedHandoff | undefined;
+  toolCallId: string;
+  part: any;
+  providerData: Record<string, any> | undefined;
+}): protocol.ToolSearchOutputItem | undefined {
+  const { requestedTool, toolCallId, part, providerData } = args;
+  if (!getAiSdkProviderToolConfig(requestedTool)) {
+    return undefined;
+  }
+
+  const result = getAiSdkToolResultValue(part);
+  if (
+    part.isError === true ||
+    !Array.isArray(result) ||
+    !result.every(isRecord)
+  ) {
+    throw new UserError(
+      `AI SDK provider tool_search returned an invalid result for call "${toolCallId}". Expected an array of tool references.`,
+    );
+  }
+
+  return {
+    type: 'tool_search_output',
+    callId: toolCallId,
+    execution: 'server',
+    status: 'completed',
+    tools: result,
     providerData,
   };
 }
@@ -1228,11 +1405,13 @@ export function toolToLanguageV2Tool(
         'The AI SDK adapter does not support deferred Responses function tools (`toolNamespace()` or `deferLoading: true`). Use a Responses API model directly.',
       );
     }
+    const providerOptions = toProviderOptions(tool.providerData, model);
     return {
       type: 'function',
       name: getSerializedFunctionToolName(tool),
       description: tool.description,
       inputSchema: tool.parameters as JSONSchema7,
+      ...(Object.keys(providerOptions).length > 0 ? { providerOptions } : {}),
     };
   }
 
@@ -1241,6 +1420,16 @@ export function toolToLanguageV2Tool(
   const providerToolPrefix = getProviderToolPrefix(model);
 
   if (tool.type === 'hosted_tool') {
+    const providerToolConfig = getAiSdkProviderToolConfig(tool);
+    if (providerToolConfig) {
+      return {
+        type: providerToolType,
+        id: providerToolConfig.id,
+        name: tool.name,
+        args: providerToolConfig.args,
+      };
+    }
+
     return {
       type: providerToolType,
       id: `${providerToolPrefix}.${tool.name}`,
@@ -1518,35 +1707,66 @@ export class AiSdkModel implements Model {
           });
         }
 
-        const toolCalls = resultContent.filter(
+        const hasToolCalls = resultContent.some(
           (c: any) => c && c.type === 'tool-call',
         );
-        const hasToolCalls = toolCalls.length > 0;
-        for (const toolCall of toolCalls) {
-          const requestedTool =
-            typeof toolCall.toolName === 'string'
-              ? requestedToolsByName.get(toolCall.toolName)
-              : undefined;
-
-          if (!requestedTool && toolCall.toolName) {
-            this.#logger.warn(
-              `Received tool call for unknown tool '${toolCall.toolName}'.`,
-            );
+        const requestedToolsByCallId = new Map<
+          string,
+          SerializedTool | SerializedHandoff
+        >();
+        for (const part of resultContent) {
+          if (
+            !part ||
+            (part.type !== 'tool-call' && part.type !== 'tool-result')
+          ) {
+            continue;
           }
 
-          output.push(
-            createProtocolToolCallItem({
-              requestedTool,
-              toolCallId: toolCall.toolCallId,
-              toolName: toolCall.toolName,
-              input: toolCall.input,
-              providerData: mergeProviderData(
-                baseProviderData,
-                toolCall.providerMetadata ??
-                  (hasToolCalls ? result.providerMetadata : undefined),
-              ),
-            }),
-          );
+          const requestedTool =
+            typeof part.toolName === 'string'
+              ? (requestedToolsByName.get(part.toolName) ??
+                requestedToolsByCallId.get(part.toolCallId))
+              : requestedToolsByCallId.get(part.toolCallId);
+
+          if (part.type === 'tool-call') {
+            if (!requestedTool && part.toolName) {
+              this.#logger.warn(
+                `Received tool call for unknown tool '${part.toolName}'.`,
+              );
+            }
+            if (requestedTool && typeof part.toolCallId === 'string') {
+              requestedToolsByCallId.set(part.toolCallId, requestedTool);
+            }
+
+            output.push(
+              createProtocolToolCallItem({
+                requestedTool,
+                toolCallId: part.toolCallId,
+                toolName: part.toolName,
+                input: part.input,
+                providerExecuted: part.providerExecuted,
+                providerData: mergeProviderData(
+                  baseProviderData,
+                  part.providerMetadata ??
+                    (hasToolCalls ? result.providerMetadata : undefined),
+                ),
+              }),
+            );
+            continue;
+          }
+
+          const toolSearchOutput = createProtocolToolSearchOutputItem({
+            requestedTool,
+            toolCallId: part.toolCallId,
+            part,
+            providerData: mergeProviderData(
+              baseProviderData,
+              part.providerMetadata ?? result.providerMetadata,
+            ),
+          });
+          if (toolSearchOutput) {
+            output.push(toolSearchOutput);
+          }
         }
 
         // Some of other platforms may return both tool calls and text.
@@ -1742,10 +1962,16 @@ export class AiSdkModel implements Model {
       let usageCompletionTokens = 0;
       let usageInputTokensDetails: Record<string, number> | undefined;
       let usageOutputTokensDetails: Record<string, number> | undefined;
-      const functionCalls: Record<
+      const toolItems: Array<
+        | protocol.FunctionCallItem
+        | protocol.ToolSearchCallItem
+        | protocol.ToolSearchOutputItem
+      > = [];
+      const toolCallItemIndexById = new Map<string, number>();
+      const requestedToolsByCallId = new Map<
         string,
-        protocol.FunctionCallItem | protocol.ToolSearchCallItem
-      > = {};
+        SerializedTool | SerializedHandoff
+      >();
       let textOutput: protocol.OutputText | undefined;
 
       // State for tracking reasoning blocks (for Anthropic extended thinking):
@@ -1816,16 +2042,51 @@ export class AiSdkModel implements Model {
                 typeof (part as any).toolName === 'string'
                   ? requestedToolsByName.get((part as any).toolName)
                   : undefined;
-              functionCalls[toolCallId] = createProtocolToolCallItem({
+              if (requestedTool) {
+                requestedToolsByCallId.set(toolCallId, requestedTool);
+              }
+              const toolCallItem = createProtocolToolCallItem({
                 requestedTool,
                 toolCallId,
                 toolName: (part as any).toolName,
                 input: (part as any).input,
+                providerExecuted: (part as any).providerExecuted,
                 providerData: mergeProviderData(
                   baseProviderData,
                   (part as any).providerMetadata,
                 ),
               });
+              const existingIndex = toolCallItemIndexById.get(toolCallId);
+              if (existingIndex === undefined) {
+                toolCallItemIndexById.set(toolCallId, toolItems.length);
+                toolItems.push(toolCallItem);
+              } else {
+                toolItems[existingIndex] = toolCallItem;
+              }
+            }
+            break;
+          }
+          case 'tool-result': {
+            const toolCallId = (part as any).toolCallId;
+            if (!toolCallId) {
+              break;
+            }
+            const requestedTool =
+              typeof (part as any).toolName === 'string'
+                ? (requestedToolsByName.get((part as any).toolName) ??
+                  requestedToolsByCallId.get(toolCallId))
+                : requestedToolsByCallId.get(toolCallId);
+            const toolSearchOutput = createProtocolToolSearchOutputItem({
+              requestedTool,
+              toolCallId,
+              part,
+              providerData: mergeProviderData(
+                baseProviderData,
+                (part as any).providerMetadata,
+              ),
+            });
+            if (toolSearchOutput) {
+              toolItems.push(toolSearchOutput);
             }
             break;
           }
@@ -1891,12 +2152,12 @@ export class AiSdkModel implements Model {
           ),
         });
       }
-      for (const fc of Object.values(functionCalls)) {
+      for (const toolItem of toolItems) {
         outputs.push({
-          ...fc,
+          ...toolItem,
           providerData: mergeProviderData(
             baseProviderData,
-            fc.providerData,
+            toolItem.providerData,
             responseId ? { responseId } : undefined,
           ),
         });

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -608,7 +608,39 @@ export function itemsToLanguageV2Messages(
           currentAssistantMessage.role === 'assistant'
         ) {
           appendPendingReasonerReasoningToCurrentAssistant();
-          currentAssistantMessage.content.push(toolResult);
+          const serverToolCallIndex = currentAssistantMessage.content.findIndex(
+            (part) =>
+              part.type === 'tool-call' && part.toolCallId === toolCallId,
+          );
+          const firstPendingClientToolCallIndex =
+            currentAssistantMessage.content.findIndex(
+              (part) => part.type === 'tool-call' && !part.providerExecuted,
+            );
+
+          if (
+            serverToolCallIndex >= 0 &&
+            firstPendingClientToolCallIndex >= 0 &&
+            firstPendingClientToolCallIndex < serverToolCallIndex
+          ) {
+            const [serverToolCall] = currentAssistantMessage.content.splice(
+              serverToolCallIndex,
+              1,
+            );
+            currentAssistantMessage.content.splice(
+              firstPendingClientToolCallIndex,
+              0,
+              serverToolCall,
+              toolResult,
+            );
+          } else if (serverToolCallIndex >= 0) {
+            currentAssistantMessage.content.splice(
+              serverToolCallIndex + 1,
+              0,
+              toolResult,
+            );
+          } else {
+            currentAssistantMessage.content.push(toolResult);
+          }
           currentAssistantMessage.providerOptions = {
             ...currentAssistantMessage.providerOptions,
             ...providerOptions,

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -574,14 +574,17 @@ export function itemsToLanguageV2Messages(
         toolSearchExecution === 'server' &&
         serverToolSearchCallIds.has(toolCallId);
       const providerOptions = toProviderOptions(item.providerData, model);
+      const isError = item.status === 'failed';
       const toolResult: LanguageModelV2ToolResultPart = {
         type: 'tool-result',
         toolCallId,
         toolName,
         output: {
-          type: 'json',
+          type: isError ? 'error-json' : 'json',
           value: isMatchedServerToolSearchResult
-            ? item.tools
+            ? isError && item.tools.length === 1
+              ? item.tools[0]
+              : item.tools
             : {
                 ...(typeof item.status === 'string'
                   ? { status: item.status }
@@ -1092,13 +1095,15 @@ function createProtocolToolSearchOutputItem(args: {
   }
 
   const result = getAiSdkToolResultValue(part);
-  if (
-    part.isError === true ||
-    !Array.isArray(result) ||
-    !result.every(isRecord)
-  ) {
+  const isError = part.isError === true;
+  let tools: protocol.ToolSearchOutputTool[];
+  if (isError && isRecord(result)) {
+    tools = [result];
+  } else if (!isError && Array.isArray(result) && result.every(isRecord)) {
+    tools = result;
+  } else {
     throw new UserError(
-      `AI SDK provider tool_search returned an invalid result for call "${toolCallId}". Expected an array of tool references.`,
+      `AI SDK provider tool_search returned an invalid result for call "${toolCallId}". Expected an array of tool references or an error object.`,
     );
   }
 
@@ -1106,8 +1111,8 @@ function createProtocolToolSearchOutputItem(args: {
     type: 'tool_search_output',
     callId: toolCallId,
     execution: 'server',
-    status: 'completed',
-    tools: result,
+    status: isError ? 'failed' : 'completed',
+    tools,
     providerData,
   };
 }

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -876,6 +876,53 @@ describe('itemsToLanguageV2Messages', () => {
     ]);
   });
 
+  test('replays provider-executed tool search errors as error results', () => {
+    const errorResult = {
+      type: 'tool_search_tool_result_error',
+      errorCode: 'invalid_pattern',
+    };
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'tool_search_call',
+        id: 'search_1',
+        execution: 'server',
+        arguments: { query: '[' },
+        status: 'completed',
+      },
+      {
+        type: 'tool_search_output',
+        callId: 'search_1',
+        execution: 'server',
+        status: 'failed',
+        tools: [errorResult],
+      },
+    ];
+
+    expect(itemsToLanguageV2Messages(stubModel({}), items)).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'search_1',
+            toolName: 'tool_search',
+            input: { query: '[' },
+            providerExecuted: true,
+            providerOptions: {},
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'search_1',
+            toolName: 'tool_search',
+            output: { type: 'error-json', value: errorResult },
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+    ]);
+  });
+
   test('does not queue hosted tool_search calls as pending client searches', () => {
     const items: protocol.ModelItem[] = [
       {
@@ -1994,7 +2041,104 @@ describe('AiSdkModel.getResponse', () => {
     });
   });
 
-  test('rejects malformed provider-executed tool search results', async () => {
+  test('preserves provider-executed tool search errors and continues the run', async () => {
+    const prompts: any[] = [];
+    const errorResult = {
+      type: 'tool_search_tool_result_error',
+      errorCode: 'invalid_pattern',
+    };
+    const model = new AiSdkModel(
+      stubModel(
+        {
+          async doGenerate(options) {
+            prompts.push(options.prompt);
+            if (prompts.length > 1) {
+              return {
+                content: [
+                  {
+                    type: 'text',
+                    text: 'The tool search failed, so I used a fallback.',
+                  },
+                ],
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                response: { id: 'response_2' },
+                finishReason: 'stop',
+                warnings: [],
+              } as any;
+            }
+
+            return {
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'search_1',
+                  toolName: 'tool_search',
+                  input: {},
+                  providerExecuted: true,
+                },
+                {
+                  type: 'tool-result',
+                  toolCallId: 'search_1',
+                  toolName: 'tool_search',
+                  isError: true,
+                  result: errorResult,
+                },
+              ],
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              response: { id: 'response_1' },
+              finishReason: 'error',
+              warnings: [],
+            } as any;
+          },
+        },
+        { provider: 'anthropic.messages', specificationVersion: 'v3' },
+      ),
+    );
+
+    const result = await run(
+      new Agent({
+        name: 'Tool search agent',
+        model,
+        tools: [
+          aiSdkToolSearchTool({
+            type: 'provider',
+            id: 'anthropic.tool_search_regex_20251119',
+          }),
+        ],
+      }),
+      'Find a tool.',
+    );
+
+    expect(result.finalOutput).toBe(
+      'The tool search failed, so I used a fallback.',
+    );
+    expect(result.history).toContainEqual(
+      expect.objectContaining({
+        type: 'tool_search_output',
+        callId: 'search_1',
+        execution: 'server',
+        status: 'failed',
+        tools: [errorResult],
+      }),
+    );
+    expect(prompts).toHaveLength(2);
+    expect(prompts[1]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: 'assistant',
+          content: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'tool-result',
+              toolCallId: 'search_1',
+              output: { type: 'error-json', value: errorResult },
+            }),
+          ]),
+        }),
+      ]),
+    );
+  });
+
+  test('rejects malformed successful provider-executed tool search results', async () => {
     const model = new AiSdkModel(
       stubModel(
         {
@@ -2012,13 +2156,12 @@ describe('AiSdkModel.getResponse', () => {
                   type: 'tool-result',
                   toolCallId: 'search_1',
                   toolName: 'tool_search',
-                  isError: true,
-                  result: { errorCode: 'invalid_tool_catalog' },
+                  result: { type: 'unexpected_success_shape' },
                 },
               ],
               usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
               response: { id: 'response_1' },
-              finishReason: 'error',
+              finishReason: 'tool-calls',
               warnings: [],
             } as any;
           },
@@ -2043,7 +2186,9 @@ describe('AiSdkModel.getResponse', () => {
           tracing: false,
         } as any),
       ),
-    ).rejects.toThrow(/Expected an array of tool references/);
+    ).rejects.toThrow(
+      /Expected an array of tool references or an error object/,
+    );
   });
 
   test('rejects ambiguous hosted and custom tool_search names in doGenerate', async () => {

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi } from 'vitest';
 import {
   AiSdkModel,
+  aiSdkToolSearchTool,
   aisdk,
   getResponseFormat,
   itemsToLanguageV2Messages,
@@ -824,31 +825,35 @@ describe('itemsToLanguageV2Messages', () => {
         ],
         providerData: { execution: 'server' },
       } as any,
+      {
+        type: 'function_call',
+        callId: 'weather_1',
+        name: 'get_weather',
+        arguments: '{"city":"Tokyo"}',
+        status: 'completed',
+      },
     ];
 
     const msgs = itemsToLanguageV2Messages(stubModel({}), items);
-    expect(msgs[0]).toMatchObject({
-      role: 'assistant',
-      content: [
-        {
-          type: 'tool-call',
-          toolCallId: 'ts_call_server',
-          toolName: 'tool_search',
-        },
-      ],
-    });
-    expect(msgs[1]).toEqual({
-      role: 'tool',
-      content: [
-        {
-          type: 'tool-result',
-          toolCallId: 'ts_call_server',
-          toolName: 'tool_search',
-          output: {
-            type: 'json',
-            value: {
-              status: 'completed',
-              tools: [
+    expect(msgs).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'ts_call_server',
+            toolName: 'tool_search',
+            input: { paths: ['billing'], query: 'lookup invoice' },
+            providerExecuted: true,
+            providerOptions: { execution: 'server' },
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'ts_call_server',
+            toolName: 'tool_search',
+            output: {
+              type: 'json',
+              value: [
                 {
                   type: 'tool_reference',
                   functionName: 'lookup_invoice',
@@ -856,12 +861,19 @@ describe('itemsToLanguageV2Messages', () => {
                 },
               ],
             },
+            providerOptions: { execution: 'server' },
           },
-          providerOptions: { execution: 'server' },
-        },
-      ],
-      providerOptions: { execution: 'server' },
-    });
+          {
+            type: 'tool-call',
+            toolCallId: 'weather_1',
+            toolName: 'get_weather',
+            input: { city: 'Tokyo' },
+            providerOptions: {},
+          },
+        ],
+        providerOptions: { execution: 'server' },
+      },
+    ]);
   });
 
   test('does not queue hosted tool_search calls as pending client searches', () => {
@@ -915,7 +927,7 @@ describe('itemsToLanguageV2Messages', () => {
     ];
 
     const msgs = itemsToLanguageV2Messages(stubModel({}), items);
-    expect(msgs[3]).toEqual({
+    expect(msgs[1]).toEqual({
       role: 'tool',
       content: [
         {
@@ -1359,6 +1371,32 @@ describe('toolToLanguageV2Tool', () => {
     });
   });
 
+  test('maps provider data on function tools to provider options', () => {
+    const anthropicModel = stubModel(
+      {},
+      { provider: 'anthropic.messages', specificationVersion: 'v3' },
+    );
+    const tool = {
+      type: 'function',
+      name: 'get_weather',
+      description: 'Get the weather.',
+      parameters: {} as any,
+      providerData: {
+        anthropic: { deferLoading: true },
+      },
+    } as any;
+
+    expect(toolToLanguageV2Tool(anthropicModel, tool)).toEqual({
+      type: 'function',
+      name: 'get_weather',
+      description: 'Get the weather.',
+      inputSchema: {},
+      providerOptions: {
+        anthropic: { deferLoading: true },
+      },
+    });
+  });
+
   test('maps same-name namespaces to qualified names', () => {
     const tool = {
       type: 'function',
@@ -1433,6 +1471,32 @@ describe('toolToLanguageV2Tool', () => {
           },
         },
       },
+    });
+  });
+
+  test('preserves AI SDK provider tool ids for v2 and v3 models', () => {
+    const tool = aiSdkToolSearchTool({
+      type: 'provider',
+      id: 'anthropic.tool_search_regex_20251119',
+      args: { maxUses: 2 },
+    });
+
+    expect(toolToLanguageV2Tool(model, tool)).toEqual({
+      type: 'provider-defined',
+      id: 'anthropic.tool_search_regex_20251119',
+      name: 'tool_search',
+      args: { maxUses: 2 },
+    });
+
+    const v3Model = stubModel(
+      {},
+      { provider: 'anthropic.messages', specificationVersion: 'v3' },
+    );
+    expect(toolToLanguageV2Tool(v3Model, tool)).toEqual({
+      type: 'provider',
+      id: 'anthropic.tool_search_regex_20251119',
+      name: 'tool_search',
+      args: { maxUses: 2 },
     });
   });
 
@@ -1841,6 +1905,145 @@ describe('AiSdkModel.getResponse', () => {
     ]);
     expect(warnSpy).not.toHaveBeenCalled();
     warnSpy.mockRestore();
+  });
+
+  test('preserves provider-executed tool search call and result order in doGenerate', async () => {
+    const model = new AiSdkModel(
+      stubModel(
+        {
+          async doGenerate() {
+            return {
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'search_1',
+                  toolName: 'tool_search',
+                  input: { query: 'weather' },
+                  providerExecuted: true,
+                },
+                {
+                  type: 'tool-result',
+                  toolCallId: 'search_1',
+                  toolName: 'tool_search',
+                  result: [{ type: 'tool_reference', toolName: 'get_weather' }],
+                },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'weather_1',
+                  toolName: 'get_weather',
+                  input: { city: 'Tokyo' },
+                },
+              ],
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              providerMetadata: {},
+              response: { id: 'response_1' },
+              finishReason: 'tool-calls',
+              warnings: [],
+            } as any;
+          },
+        },
+        { provider: 'anthropic.messages', specificationVersion: 'v3' },
+      ),
+    );
+
+    const result = await withTrace('t', () =>
+      model.getResponse({
+        input: 'Find the weather tool and use it.',
+        tools: [
+          aiSdkToolSearchTool({
+            type: 'provider',
+            id: 'anthropic.tool_search_regex_20251119',
+          }),
+          {
+            type: 'function',
+            name: 'get_weather',
+            description: 'Get the weather.',
+            parameters: { type: 'object', properties: {} },
+            strict: true,
+            providerData: { anthropic: { deferLoading: true } },
+          } as any,
+        ],
+        handoffs: [],
+        modelSettings: {},
+        outputType: 'text',
+        tracing: false,
+      } as any),
+    );
+
+    expect(result.output.map((item) => item.type)).toEqual([
+      'tool_search_call',
+      'tool_search_output',
+      'function_call',
+    ]);
+    expect(result.output[0]).toMatchObject({
+      type: 'tool_search_call',
+      id: 'search_1',
+      execution: 'server',
+      arguments: { query: 'weather' },
+    });
+    expect(result.output[1]).toMatchObject({
+      type: 'tool_search_output',
+      callId: 'search_1',
+      execution: 'server',
+      tools: [{ type: 'tool_reference', toolName: 'get_weather' }],
+    });
+    expect(result.output[2]).toMatchObject({
+      type: 'function_call',
+      callId: 'weather_1',
+      name: 'get_weather',
+    });
+  });
+
+  test('rejects malformed provider-executed tool search results', async () => {
+    const model = new AiSdkModel(
+      stubModel(
+        {
+          async doGenerate() {
+            return {
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'search_1',
+                  toolName: 'tool_search',
+                  input: {},
+                  providerExecuted: true,
+                },
+                {
+                  type: 'tool-result',
+                  toolCallId: 'search_1',
+                  toolName: 'tool_search',
+                  isError: true,
+                  result: { errorCode: 'invalid_tool_catalog' },
+                },
+              ],
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              response: { id: 'response_1' },
+              finishReason: 'error',
+              warnings: [],
+            } as any;
+          },
+        },
+        { provider: 'anthropic.messages', specificationVersion: 'v3' },
+      ),
+    );
+
+    await expect(
+      withTrace('t', () =>
+        model.getResponse({
+          input: 'Find a tool.',
+          tools: [
+            aiSdkToolSearchTool({
+              type: 'provider',
+              id: 'anthropic.tool_search_regex_20251119',
+            }),
+          ],
+          handoffs: [],
+          modelSettings: {},
+          outputType: 'text',
+          tracing: false,
+        } as any),
+      ),
+    ).rejects.toThrow(/Expected an array of tool references/);
   });
 
   test('rejects ambiguous hosted and custom tool_search names in doGenerate', async () => {
@@ -2658,6 +2861,91 @@ describe('AiSdkModel.getStreamedResponse', () => {
     ]);
     expect(warnSpy).not.toHaveBeenCalled();
     warnSpy.mockRestore();
+  });
+
+  test('preserves provider-executed tool search call and result order in streaming mode', async () => {
+    const parts = [
+      {
+        type: 'tool-call',
+        toolCallId: 'search_1',
+        toolName: 'tool_search',
+        input: { query: 'weather' },
+        providerExecuted: true,
+      },
+      {
+        type: 'tool-result',
+        toolCallId: 'search_1',
+        toolName: 'tool_search',
+        result: [{ type: 'tool_reference', toolName: 'get_weather' }],
+      },
+      {
+        type: 'tool-call',
+        toolCallId: 'weather_1',
+        toolName: 'get_weather',
+        input: { city: 'Tokyo' },
+      },
+      { type: 'response-metadata', id: 'response_stream_1' },
+      {
+        type: 'finish',
+        finishReason: 'tool-calls',
+        usage: { inputTokens: 3, outputTokens: 4 },
+      },
+    ];
+    const model = new AiSdkModel(
+      stubModel(
+        {
+          async doStream() {
+            return { stream: partsStream(parts) } as any;
+          },
+        },
+        { provider: 'anthropic.messages', specificationVersion: 'v3' },
+      ),
+    );
+
+    const events: any[] = [];
+    for await (const event of model.getStreamedResponse({
+      input: 'Find the weather tool and use it.',
+      tools: [
+        aiSdkToolSearchTool({
+          type: 'provider',
+          id: 'anthropic.tool_search_regex_20251119',
+        }),
+        {
+          type: 'function',
+          name: 'get_weather',
+          description: 'Get the weather.',
+          parameters: { type: 'object', properties: {} },
+          strict: true,
+          providerData: { anthropic: { deferLoading: true } },
+        } as any,
+      ],
+      handoffs: [],
+      modelSettings: {},
+      outputType: 'text',
+      tracing: false,
+    } as any)) {
+      events.push(event);
+    }
+
+    const final = events.at(-1);
+    expect(final.response.output.map((item: any) => item.type)).toEqual([
+      'tool_search_call',
+      'tool_search_output',
+      'function_call',
+    ]);
+    expect(final.response.output[0]).toMatchObject({
+      id: 'search_1',
+      execution: 'server',
+    });
+    expect(final.response.output[1]).toMatchObject({
+      callId: 'search_1',
+      execution: 'server',
+      tools: [{ type: 'tool_reference', toolName: 'get_weather' }],
+    });
+    expect(final.response.output[2]).toMatchObject({
+      callId: 'weather_1',
+      name: 'get_weather',
+    });
   });
 
   test('includes base providerData in streaming mode even when providerMetadata is not present', async () => {

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -876,6 +876,96 @@ describe('itemsToLanguageV2Messages', () => {
     ]);
   });
 
+  test('orders provider-executed tool searches before pending client calls', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call',
+        callId: 'weather_1',
+        name: 'get_weather',
+        arguments: '{"city":"Tokyo"}',
+        status: 'completed',
+      },
+      {
+        type: 'tool_search_call',
+        id: 'search_1',
+        execution: 'server',
+        arguments: { query: 'weather tools' },
+        status: 'completed',
+      },
+      {
+        type: 'tool_search_output',
+        callId: 'search_1',
+        execution: 'server',
+        status: 'completed',
+        tools: [
+          {
+            type: 'tool_reference',
+            toolName: 'get_forecast',
+          },
+        ],
+      },
+      {
+        type: 'function_call_result',
+        callId: 'weather_1',
+        name: 'get_weather',
+        status: 'completed',
+        output: 'sunny',
+      },
+    ];
+
+    expect(itemsToLanguageV2Messages(stubModel({}), items)).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'search_1',
+            toolName: 'tool_search',
+            input: { query: 'weather tools' },
+            providerExecuted: true,
+            providerOptions: {},
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'search_1',
+            toolName: 'tool_search',
+            output: {
+              type: 'json',
+              value: [
+                {
+                  type: 'tool_reference',
+                  toolName: 'get_forecast',
+                },
+              ],
+            },
+            providerOptions: {},
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'weather_1',
+            toolName: 'get_weather',
+            input: { city: 'Tokyo' },
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'weather_1',
+            toolName: 'get_weather',
+            output: { type: 'text', value: 'sunny' },
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+    ]);
+  });
+
   test('replays provider-executed tool search errors as error results', () => {
     const errorResult = {
       type: 'tool_search_tool_result_error',


### PR DESCRIPTION
This pull request adds provider-executed tool search support to the AI SDK adapter.

It introduces provider-specific metadata for function tools and an `aiSdkToolSearchTool()` adapter that preserves provider tool IDs, server-executed search calls and results, streaming order, and replay semantics.

This pull request resolves https://github.com/openai/openai-agents-js/issues/1479