### PR TITLE
fix: correlate streamed text with output items

### DIFF
--- a/.changeset/curvy-deltas-correlate.md
+++ b/.changeset/curvy-deltas-correlate.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+'@openai/agents-extensions': patch
+---
+
+fix: expose output item IDs on streamed text deltas (#1484)

--- a/packages/agents-core/src/types/protocol.ts
+++ b/packages/agents-core/src/types/protocol.ts
@@ -910,6 +910,10 @@ export type UsageData = z.infer<typeof UsageData>;
 export const StreamEventTextStream = SharedBase.extend({
   type: z.literal('output_text_delta'),
   /**
+   * The ID of the output item this delta belongs to, when provided by the model.
+   */
+  itemId: z.string().optional(),
+  /**
    * The delta text that was streamed by the modelto the user.
    */
   delta: z.string(),

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -2010,6 +2010,7 @@ export class AiSdkModel implements Model {
         SerializedTool | SerializedHandoff
       >();
       let textOutput: protocol.OutputText | undefined;
+      let textItemId: string | undefined;
 
       // State for tracking reasoning blocks (for Anthropic extended thinking):
       // Track reasoning deltas so we can preserve Anthropic signatures even when text is redacted.
@@ -2031,11 +2032,19 @@ export class AiSdkModel implements Model {
 
         switch (part.type) {
           case 'text-delta': {
+            const itemId = (part as any).id as string | undefined;
             if (!textOutput) {
               textOutput = { type: 'output_text', text: '' };
+              textItemId = itemId;
+            } else if (itemId !== textItemId) {
+              textItemId = undefined;
             }
             textOutput.text += (part as any).delta;
-            yield { type: 'output_text_delta', delta: (part as any).delta };
+            yield {
+              type: 'output_text_delta',
+              delta: (part as any).delta,
+              ...(itemId ? { itemId } : {}),
+            };
             break;
           }
           case 'reasoning-start': {
@@ -2180,6 +2189,7 @@ export class AiSdkModel implements Model {
         );
         outputs.push({
           type: 'message',
+          ...(textItemId ? { id: textItemId } : {}),
           role: 'assistant',
           content: [{ ...textOutput, text: transformedText }],
           status: 'completed',

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -189,7 +189,7 @@ describe('AiSdkModel end-to-end scenarios', () => {
 
   test('streams interleaved text and multiple tool calls with usage', async () => {
     const parts = [
-      { type: 'text-delta', delta: 'Hello ' },
+      { type: 'text-delta', id: 'text-1', delta: 'Hello ' },
       {
         type: 'tool-call',
         toolCallId: 'c1',
@@ -197,7 +197,7 @@ describe('AiSdkModel end-to-end scenarios', () => {
         input: '{"q":"a"}',
         providerMetadata: { meta: 1 },
       },
-      { type: 'text-delta', delta: 'world' },
+      { type: 'text-delta', id: 'text-1', delta: 'world' },
       {
         type: 'tool-call',
         toolCallId: 'c2',
@@ -237,10 +237,17 @@ describe('AiSdkModel end-to-end scenarios', () => {
     }
 
     const final = events.at(-1);
+    expect(
+      events.filter((event) => event.type === 'output_text_delta'),
+    ).toEqual([
+      { type: 'output_text_delta', itemId: 'text-1', delta: 'Hello ' },
+      { type: 'output_text_delta', itemId: 'text-1', delta: 'world' },
+    ]);
     expect(final.type).toBe('response_done');
     expect(final.response.output).toEqual([
       {
         type: 'message',
+        id: 'text-1',
         role: 'assistant',
         content: [{ type: 'output_text', text: 'Hello world' }],
         status: 'completed',

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -3280,8 +3280,13 @@ export class OpenAIResponsesModel implements Model {
             providerData: remainingEvent,
           };
         } else if (eventType === 'response.output_text.delta') {
-          const { delta, ...remainingEvent } = event as unknown as {
+          const {
+            delta,
+            item_id: itemId,
+            ...remainingEvent
+          } = event as unknown as {
             delta: string;
+            item_id?: string;
             output_index?: number;
           } & Record<string, any>;
           const outputItem =
@@ -3297,7 +3302,11 @@ export class OpenAIResponsesModel implements Model {
             yield {
               type: 'output_text_delta',
               delta: delta,
-              providerData: remainingEvent,
+              ...(itemId ? { itemId } : {}),
+              providerData: {
+                ...remainingEvent,
+                ...(itemId ? { item_id: itemId } : {}),
+              },
             };
           }
         }

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -4014,6 +4014,7 @@ describe('OpenAIResponsesModel', () => {
         {
           type: 'output_text_delta',
           delta: 'delta',
+          itemId: 'item-1',
           providerData: {
             content_index: 0,
             item_id: 'item-1',


### PR DESCRIPTION
This pull request resolves #1484.

Streamed `output_text_delta` events currently drop the stable output-item identifier exposed by both OpenAI Responses and AI SDK providers. Consumers that persist streamed transcripts therefore cannot reliably correlate deltas with the completed assistant message and must fall back to matching text content.

This change:

- adds an optional `itemId` to normalized text delta events;
- maps Responses `item_id` into that field while preserving it in `providerData`;
- forwards AI SDK text-part IDs and reuses a consistent ID on the completed message item; and
- adds regression coverage for both provider paths.

The field is optional, so providers that do not expose an identifier retain their existing event shape. If an AI SDK stream reports inconsistent text IDs, the completed combined message remains un-IDed rather than claiming an incorrect correlation.

Validation:

- `pnpm vitest run packages/agents-openai/test/openaiResponsesModel.test.ts packages/agents-extensions/test/ai-sdk/index.test.ts`
- `bash .agents/skills/code-change-verification/scripts/run.sh`
