### PR TITLE
fix: correlate streamed text with output items

### DIFF
--- a/.changeset/curvy-deltas-correlate.md
+++ b/.changeset/curvy-deltas-correlate.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+'@openai/agents-extensions': patch
+---
+
+fix: correlate streamed text deltas with completed output items (#1484)

--- a/packages/agents-core/src/types/protocol.ts
+++ b/packages/agents-core/src/types/protocol.ts
@@ -910,6 +910,10 @@ export type UsageData = z.infer<typeof UsageData>;
 export const StreamEventTextStream = SharedBase.extend({
   type: z.literal('output_text_delta'),
   /**
+   * The ID of the output item this delta belongs to, when provided by the model.
+   */
+  itemId: z.string().optional(),
+  /**
    * The delta text that was streamed by the modelto the user.
    */
   delta: z.string(),

--- a/packages/agents-extensions/src/ai-sdk-ui/uiMessageStream.ts
+++ b/packages/agents-extensions/src/ai-sdk-ui/uiMessageStream.ts
@@ -27,9 +27,7 @@ export type AiSdkUiMessageStreamSource =
   | { toStream: () => ReadableStream<RunStreamEvent> };
 
 export type AiSdkUiMessageStreamHeaders =
-  | Headers
-  | Record<string, string>
-  | Array<[string, string]>;
+  Headers | Record<string, string> | Array<[string, string]>;
 
 export type AiSdkUiMessageStreamResponseOptions = {
   headers?: AiSdkUiMessageStreamHeaders;
@@ -215,9 +213,11 @@ async function* buildUiMessageStream(
   let stepOpen = false;
   let pendingStepClose = false;
   let responseHasText = false;
+  let responseHasUnkeyedText = false;
   let stepHasTextOutput = false;
   let textOpen = false;
   let currentTextId = '';
+  const streamedTextItemIds = new Set<string>();
   const startedToolCalls = new Set<string>();
   const emittedToolOutputs = new Set<string>();
   // FIFO fallback for tool_search outputs that do not carry an explicit call_id.
@@ -258,6 +258,9 @@ async function* buildUiMessageStream(
       if (data.type === 'response_started') {
         yield* ensureMessageStart();
         responseHasText = false;
+        responseHasUnkeyedText = false;
+        streamedTextItemIds.clear();
+        currentTextId = '';
         yield* ensureStepStart();
       }
 
@@ -266,8 +269,18 @@ async function* buildUiMessageStream(
         yield* ensureStepStart();
         responseHasText = true;
         stepHasTextOutput = true;
+        if (data.itemId) {
+          streamedTextItemIds.add(data.itemId);
+        } else {
+          responseHasUnkeyedText = true;
+        }
+        const nextTextId = data.itemId ?? (currentTextId || createId('text'));
+        if (textOpen && currentTextId !== nextTextId) {
+          yield { type: 'text-end', id: currentTextId };
+          textOpen = false;
+        }
         if (!textOpen) {
-          currentTextId = createId('text');
+          currentTextId = nextTextId;
           textOpen = true;
           yield { type: 'text-start', id: currentTextId };
         }
@@ -296,14 +309,18 @@ async function* buildUiMessageStream(
     if (event.type === 'run_item_stream_event') {
       if (event.name === 'message_output_created') {
         yield* ensureMessageStart();
-        if (!responseHasText) {
+        const item = event.item as RunMessageOutputItem;
+        const itemId = item.rawItem.id;
+        const alreadyStreamed =
+          responseHasUnkeyedText ||
+          (typeof itemId === 'string' && streamedTextItemIds.has(itemId));
+        if (!responseHasText || !alreadyStreamed) {
           if (!stepOpen) {
             yield* ensureStepStart();
           }
-          const item = event.item as RunMessageOutputItem;
           const content = item.content;
           if (content) {
-            const textId = createId('text');
+            const textId = itemId ?? createId('text');
             yield { type: 'text-start', id: textId };
             yield { type: 'text-delta', id: textId, delta: content };
             yield { type: 'text-end', id: textId };

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -2010,6 +2010,7 @@ export class AiSdkModel implements Model {
         SerializedTool | SerializedHandoff
       >();
       let textOutput: protocol.OutputText | undefined;
+      let textItemId: string | undefined;
 
       // State for tracking reasoning blocks (for Anthropic extended thinking):
       // Track reasoning deltas so we can preserve Anthropic signatures even when text is redacted.
@@ -2033,9 +2034,19 @@ export class AiSdkModel implements Model {
           case 'text-delta': {
             if (!textOutput) {
               textOutput = { type: 'output_text', text: '' };
+              // The adapter combines all AI SDK text blocks into one output
+              // message, so every normalized delta must use that message ID.
+              textItemId =
+                typeof (part as any).id === 'string'
+                  ? (part as any).id
+                  : undefined;
             }
             textOutput.text += (part as any).delta;
-            yield { type: 'output_text_delta', delta: (part as any).delta };
+            yield {
+              type: 'output_text_delta',
+              delta: (part as any).delta,
+              ...(textItemId ? { itemId: textItemId } : {}),
+            };
             break;
           }
           case 'reasoning-start': {
@@ -2180,6 +2191,7 @@ export class AiSdkModel implements Model {
         );
         outputs.push({
           type: 'message',
+          ...(textItemId ? { id: textItemId } : {}),
           role: 'assistant',
           content: [{ ...textOutput, text: transformedText }],
           status: 'completed',

--- a/packages/agents-extensions/test/ai-sdk-ui/uiMessageStream.test.ts
+++ b/packages/agents-extensions/test/ai-sdk-ui/uiMessageStream.test.ts
@@ -243,8 +243,7 @@ describe('createAiSdkUiMessageStreamResponse', () => {
     ]);
 
     const textStart = chunks.find((chunk) => chunk.type === 'text-start') as
-      | { id: string }
-      | undefined;
+      { id: string } | undefined;
     const textEnd = chunks.find((chunk) => chunk.type === 'text-end');
     const textDelta = chunks.find((chunk) => chunk.type === 'text-delta');
     const textStartId = textStart?.id;
@@ -1053,6 +1052,7 @@ describe('createAiSdkUiMessageStreamResponse', () => {
 
     const messageOutput = new RunMessageOutputItem(
       {
+        id: 'message-1',
         type: 'message',
         role: 'assistant',
         status: 'completed',
@@ -1066,6 +1066,7 @@ describe('createAiSdkUiMessageStreamResponse', () => {
       yield new RunRawModelStreamEvent({
         type: 'output_text_delta',
         delta: 'Hello again',
+        itemId: 'message-1',
       });
       yield new RunRawModelStreamEvent({
         type: 'response_done',
@@ -1087,7 +1088,55 @@ describe('createAiSdkUiMessageStreamResponse', () => {
     const deltas = chunks.filter((chunk) => chunk.type === 'text-delta');
 
     expect(deltas).toHaveLength(1);
-    expect(deltas[0]).toMatchObject({ delta: 'Hello again' });
+    expect(deltas[0]).toMatchObject({
+      id: 'message-1',
+      delta: 'Hello again',
+    });
+  });
+
+  test('emits a completed message with a different item ID', async () => {
+    const agent = new Agent({ name: 'Test Agent' });
+    const messageOutput = new RunMessageOutputItem(
+      {
+        id: 'message-2',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'Separate message' }],
+      },
+      agent,
+    );
+
+    const events = (async function* () {
+      yield new RunRawModelStreamEvent({ type: 'response_started' });
+      yield new RunRawModelStreamEvent({
+        type: 'output_text_delta',
+        delta: 'Streamed message',
+        itemId: 'message-1',
+      });
+      yield new RunRawModelStreamEvent({
+        type: 'response_done',
+        response: {
+          id: 'resp-distinct',
+          usage: {
+            inputTokens: 1,
+            outputTokens: 2,
+            totalTokens: 3,
+          },
+          output: [{ type: 'unknown' }],
+        },
+      });
+      yield new RunItemStreamEvent('message_output_created', messageOutput);
+    })();
+
+    const response = createAiSdkUiMessageStreamResponse(events);
+    const chunks = await readUiMessageChunks(response);
+    const deltas = chunks.filter((chunk) => chunk.type === 'text-delta');
+
+    expect(deltas).toEqual([
+      { type: 'text-delta', id: 'message-1', delta: 'Streamed message' },
+      { type: 'text-delta', id: 'message-2', delta: 'Separate message' },
+    ]);
   });
 
   test('falls back for invalid JSON arguments and maps non-function tool inputs', async () => {

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -187,9 +187,9 @@ describe('AiSdkModel end-to-end scenarios', () => {
     expect(result.finalOutput).toEqual({ content: 'structured' });
   });
 
-  test('streams interleaved text and multiple tool calls with usage', async () => {
+  test('streams text blocks and tool calls with a stable message ID', async () => {
     const parts = [
-      { type: 'text-delta', delta: 'Hello ' },
+      { type: 'text-delta', id: 'text-1', delta: 'Hello ' },
       {
         type: 'tool-call',
         toolCallId: 'c1',
@@ -197,7 +197,7 @@ describe('AiSdkModel end-to-end scenarios', () => {
         input: '{"q":"a"}',
         providerMetadata: { meta: 1 },
       },
-      { type: 'text-delta', delta: 'world' },
+      { type: 'text-delta', id: 'text-2', delta: 'world' },
       {
         type: 'tool-call',
         toolCallId: 'c2',
@@ -237,10 +237,17 @@ describe('AiSdkModel end-to-end scenarios', () => {
     }
 
     const final = events.at(-1);
+    expect(
+      events.filter((event) => event.type === 'output_text_delta'),
+    ).toEqual([
+      { type: 'output_text_delta', itemId: 'text-1', delta: 'Hello ' },
+      { type: 'output_text_delta', itemId: 'text-1', delta: 'world' },
+    ]);
     expect(final.type).toBe('response_done');
     expect(final.response.output).toEqual([
       {
         type: 'message',
+        id: 'text-1',
         role: 'assistant',
         content: [{ type: 'output_text', text: 'Hello world' }],
         status: 'completed',

--- a/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
@@ -9,6 +9,7 @@ import logger from './logger';
 type StreamingState = {
   started: boolean;
   text_content: protocol.OutputText | null;
+  messageItemId: string | undefined;
   refusal_content: protocol.Refusal | null;
   function_calls: Record<number, protocol.FunctionCallItem>;
   ignored_tool_call_indexes: Set<number>;
@@ -26,6 +27,7 @@ export async function* convertChatCompletionsStreamToResponses(
   const state: StreamingState = {
     started: false,
     text_content: null,
+    messageItemId: undefined,
     refusal_content: null,
     function_calls: {},
     ignored_tool_call_indexes: new Set(),
@@ -103,10 +105,12 @@ export async function* convertChatCompletionsStreamToResponses(
           type: 'output_text',
           providerData: { annotations: [] },
         };
+        state.messageItemId = response.id || FAKE_ID;
       }
       yield {
         type: 'output_text_delta',
         delta: delta.content,
+        itemId: state.messageItemId,
         providerData: {
           ...chunk,
         },
@@ -188,7 +192,7 @@ export async function* convertChatCompletionsStreamToResponses(
       content.push(state.refusal_content);
     }
     outputs.push({
-      id: outputItemId,
+      id: state.messageItemId ?? outputItemId,
       content,
       role: 'assistant',
       type: 'message',

--- a/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
@@ -105,12 +105,13 @@ export async function* convertChatCompletionsStreamToResponses(
           type: 'output_text',
           providerData: { annotations: [] },
         };
-        state.messageItemId = response.id || FAKE_ID;
+        state.messageItemId =
+          response.id && response.id !== FAKE_ID ? response.id : undefined;
       }
       yield {
         type: 'output_text_delta',
         delta: delta.content,
-        itemId: state.messageItemId,
+        ...(state.messageItemId ? { itemId: state.messageItemId } : {}),
         providerData: {
           ...chunk,
         },

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -3282,8 +3282,10 @@ export class OpenAIResponsesModel implements Model {
         } else if (eventType === 'response.output_text.delta') {
           const { delta, ...remainingEvent } = event as unknown as {
             delta: string;
+            item_id?: string;
             output_index?: number;
           } & Record<string, any>;
+          const itemId = remainingEvent.item_id;
           const outputItem =
             typeof remainingEvent.output_index === 'number'
               ? outputItemsByIndex.get(remainingEvent.output_index)
@@ -3297,6 +3299,7 @@ export class OpenAIResponsesModel implements Model {
             yield {
               type: 'output_text_delta',
               delta: delta,
+              ...(typeof itemId === 'string' ? { itemId } : {}),
               providerData: remainingEvent,
             };
           }

--- a/packages/agents-openai/test/openaiChatCompletionsStreaming.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsStreaming.test.ts
@@ -104,6 +104,7 @@ describe('convertChatCompletionsStreamToResponses', () => {
     expect(events[2]).toEqual({
       type: 'output_text_delta',
       delta: 'hello',
+      itemId: 'res1',
       providerData: { ...chunk1 },
     });
     expect(events[3]).toEqual({

--- a/packages/agents-openai/test/openaiChatCompletionsStreaming.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsStreaming.test.ts
@@ -244,6 +244,46 @@ describe('convertChatCompletionsStreamToResponses', () => {
     expect(final.response.usage.totalTokens).toBe(3);
   });
 
+  it('uses a response ID received after the first text chunk for the final message', async () => {
+    const firstChunk = {
+      ...makeChunk({ content: 'hello' }),
+      id: '',
+    } as ChatCompletionChunk;
+    const finalChunk = {
+      ...makeChunk({}),
+      id: 'late-response-id',
+      choices: [],
+    } as ChatCompletionChunk;
+
+    async function* stream(): AsyncGenerator<
+      ChatCompletionChunk,
+      void,
+      unknown
+    > {
+      yield firstChunk;
+      yield finalChunk;
+    }
+
+    const response = { id: FAKE_ID } as ChatCompletion;
+    const events: any[] = [];
+    for await (const event of convertChatCompletionsStreamToResponses(
+      response,
+      stream() as any,
+    )) {
+      events.push(event);
+    }
+
+    expect(events[2]).toEqual({
+      type: 'output_text_delta',
+      delta: 'hello',
+      providerData: firstChunk,
+    });
+    expect(events.at(-1).response.output[0]).toMatchObject({
+      id: 'late-response-id',
+      type: 'message',
+    });
+  });
+
   it('preserves usage reported on an earlier chunk when the final chunk has no usage', async () => {
     async function* stream(): AsyncGenerator<
       ChatCompletionChunk,

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -3965,6 +3965,23 @@ describe('OpenAIResponsesModel', () => {
           output_index: 0,
           sequence_number: 1,
         } as any,
+        {
+          type: 'response.completed',
+          response: {
+            id: 'res2',
+            output: [
+              {
+                id: 'item-1',
+                type: 'message',
+                status: 'completed',
+                content: [{ type: 'output_text', text: 'delta' }],
+                role: 'assistant',
+              },
+            ],
+            usage: {},
+          },
+          sequence_number: 2,
+        } as any,
       ];
       async function* fakeStream() {
         yield* events;
@@ -3999,7 +4016,7 @@ describe('OpenAIResponsesModel', () => {
         headers: HEADERS,
         signal: abort.signal,
       });
-      expect(received).toEqual([
+      expect(received.slice(0, 4)).toEqual([
         {
           type: 'response_started',
           providerData: events[0],
@@ -4014,6 +4031,7 @@ describe('OpenAIResponsesModel', () => {
         {
           type: 'output_text_delta',
           delta: 'delta',
+          itemId: 'item-1',
           providerData: {
             content_index: 0,
             item_id: 'item-1',
@@ -4031,6 +4049,19 @@ describe('OpenAIResponsesModel', () => {
           },
         },
       ]);
+      const textDelta = received.find(
+        (event) => event.type === 'output_text_delta',
+      );
+      const completed = received.find(
+        (event) => event.type === 'response_done',
+      );
+
+      expect(textDelta).toMatchObject({ itemId: 'item-1' });
+      expect(completed).toMatchObject({
+        response: {
+          output: [expect.objectContaining({ type: 'message', id: 'item-1' })],
+        },
+      });
     });
   });
 


### PR DESCRIPTION
This pull request resolves #1484.

Normalized output_text_delta events now expose an optional itemId that matches the completed message item across Responses, Chat Completions, and AI SDK-backed models. The AI SDK adapter preserves one message identity when multiple source text blocks are combined into a single output message.

The AI SDK UI bridge now reuses these IDs and suppresses only the matching completed item, preserving genuinely distinct messages. The change includes regression coverage and patch changesets for the affected packages.