### PR TITLE
chore: upgrade pnpm toolchain

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,5 +99,5 @@
     "verdaccio": "^6.7.4",
     "vitest": "^3.2.6"
   },
-  "packageManager": "pnpm@11.10.0+sha512.0b7f8b98060031904c017e3a41eb187a16d40eeb829b95c4f8cb03681761fc4ab53dd219115b9b447f4dce1a05a214764461e7d3703392a9f32f9511ce8c86c8"
+  "packageManager": "pnpm@11.13.1+sha512.b2fc7683b8a6525414e7d13e1ba28caaddde96bf66ec540bfaeb7e702b81f3e0be4d1f295edf7f9fe0396740a8dce4509c582ddf79891f4543fea32d37645f25"
 }


### PR DESCRIPTION
This pull request updates the repository pnpm toolchain from 11.10.0 to 11.13.1 and records the exact npm registry SHA-512 integrity in `packageManager`. The existing `pnpm/action-setup` workflow pins already match the latest immutable release commit, so no workflow changes are required.