### PR TITLE
feat: add task and turn tracing spans

### DIFF
--- a/.changeset/brave-traces-turn.md
+++ b/.changeset/brave-traces-turn.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-core': minor
+'@openai/agents-extensions': patch
+'@openai/agents-openai': patch
+---
+
+feat: add default task and turn tracing with a per-run opt-out

--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -51,6 +51,7 @@ import {
   type StructuredToolInputBuilder,
 } from './agentToolInput';
 import {
+  getToolCallParentSpanFromDetails,
   getAgentToolParentRunConfigFromDetails,
   getInheritedAgentToolRunConfig,
   mergeAgentToolRunConfig,
@@ -59,10 +60,15 @@ import type { ZodObjectLike } from './utils/zodCompat';
 import { saveAgentToolRunResult } from './agentToolRunResults';
 import { registerAgentToolSourceAgent } from './agentToolSourceRegistry';
 import type { AgentToolInvocation } from './agentToolInvocation';
+import {
+  getToolUsageRecorder,
+  setRunnerParentUsageRecorder,
+} from './runner/usageTracking';
+import { setRunnerInvocationSpanParent } from './runner/invocationContext';
+import type { Span } from './tracing';
 
 type CompletedRunResult<TContext, TAgent extends Agent<TContext, any>> = (
-  | RunResult<TContext, TAgent>
-  | StreamedRunResult<TContext, TAgent>
+  RunResult<TContext, TAgent> | StreamedRunResult<TContext, TAgent>
 ) & {
   finalOutput: ResolvedAgentOutput<TAgent['outputType']>;
 };
@@ -451,8 +457,7 @@ type ExtractHandoffOutput<T> = T extends Handoff<any, infer O> ? O : never;
 export type HandoffsOutputUnion<
   Handoffs extends readonly (Agent<any, any> | Handoff<any, any>)[],
 > =
-  | ExtractAgentOutput<Handoffs[number]>
-  | ExtractHandoffOutput<Handoffs[number]>;
+  ExtractAgentOutput<Handoffs[number]> | ExtractHandoffOutput<Handoffs[number]>;
 
 /**
  * Helper type for config with handoffs
@@ -739,8 +744,7 @@ export class Agent<
       parameters: toolParameters,
       strict: true,
       needsApproval: needsApproval as
-        | boolean
-        | ToolApprovalFunction<ToolInputParametersStrict>,
+        boolean | ToolApprovalFunction<ToolInputParametersStrict>,
       isEnabled,
       execute: async (
         params: ToolExecuteArgument<ToolInputParametersStrict>,
@@ -794,6 +798,11 @@ export class Agent<
           runConfig,
         );
         const runner = new Runner(nestedRunConfig);
+        setRunnerParentUsageRecorder(runner, getToolUsageRecorder(details));
+        setRunnerInvocationSpanParent(
+          runner,
+          getToolCallParentSpanFromDetails(details),
+        );
         const resumeContextStrategy = resumeState?.contextStrategy ?? 'merge';
         const resumeContext =
           resumeContextStrategy === 'preferSerialized' ? undefined : runContext;
@@ -991,6 +1000,7 @@ export class Agent<
    */
   async getMcpTools(
     runContext: RunContext<TContext>,
+    tracingParent?: Span<any>,
   ): Promise<Tool<TContext>[]> {
     if (this.mcpServers.length > 0) {
       const includeServerInToolNames =
@@ -1005,6 +1015,7 @@ export class Agent<
         reservedToolNames: includeServerInToolNames
           ? await this.getMcpToolReservedNames(runContext)
           : undefined,
+        tracingParent,
       });
     }
 
@@ -1037,8 +1048,9 @@ export class Agent<
    */
   async getAllTools(
     runContext: RunContext<TContext>,
+    tracingParent?: Span<any>,
   ): Promise<Tool<TContext>[]> {
-    const mcpTools = await this.getMcpTools(runContext);
+    const mcpTools = await this.getMcpTools(runContext, tracingParent);
     const enabledTools: Tool<TContext>[] = [];
 
     for (const candidate of this.tools) {

--- a/packages/agents-core/src/agentToolRunConfig.ts
+++ b/packages/agents-core/src/agentToolRunConfig.ts
@@ -1,5 +1,7 @@
 import type { RunConfig } from './run';
 import { mergeModelSettings } from './runner/modelSettingsMerge';
+import { mergeTracingConfig } from './tracing/config';
+import type { Span } from './tracing/spans';
 
 const TRANSPORT_OVERRIDE_PROVIDER_DATA_ALIAS_KEYS = [
   ['extra_headers', 'extraHeaders'],
@@ -9,6 +11,7 @@ const TRANSPORT_OVERRIDE_PROVIDER_DATA_ALIAS_KEYS = [
 const AGENT_TOOL_PARENT_RUN_CONFIG_SYMBOL = Symbol(
   'openai.agents.agentToolParentRunConfig',
 );
+const TOOL_CALL_PARENT_SPAN_SYMBOL = Symbol('openai.agents.toolCallParentSpan');
 
 function isPlainObjectLike(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -57,6 +60,32 @@ export function getAgentToolParentRunConfigFromDetails(
   return isPlainObjectLike(legacyParentRunConfig)
     ? (legacyParentRunConfig as Partial<RunConfig>)
     : undefined;
+}
+
+export function setToolCallParentSpanOnDetails(
+  details: object,
+  parent: Span<any> | undefined,
+): void {
+  if (!parent) {
+    return;
+  }
+  Object.defineProperty(details, TOOL_CALL_PARENT_SPAN_SYMBOL, {
+    value: parent,
+    enumerable: false,
+    configurable: true,
+    writable: false,
+  });
+}
+
+export function getToolCallParentSpanFromDetails(
+  details: unknown,
+): Span<any> | undefined {
+  if (!details || typeof details !== 'object') {
+    return undefined;
+  }
+  return (details as Record<PropertyKey, unknown>)[
+    TOOL_CALL_PARENT_SPAN_SYMBOL
+  ] as Span<any> | undefined;
 }
 
 function getSafeInheritedAgentToolModelSettings(
@@ -285,6 +314,15 @@ export function getInheritedAgentToolRunConfig(
     inheritedRunConfig.toolNotFoundBehavior =
       parentRunConfig.toolNotFoundBehavior;
   }
+  if (typeof parentRunConfig.tracing !== 'undefined') {
+    inheritedRunConfig.tracing = parentRunConfig.tracing;
+  }
+  if (
+    typeof parentRunConfig.tracingDisabled !== 'undefined' &&
+    typeof toolRunConfigOverride?.tracingDisabled === 'undefined'
+  ) {
+    inheritedRunConfig.tracingDisabled = parentRunConfig.tracingDisabled;
+  }
 
   return Object.keys(inheritedRunConfig).length > 0
     ? inheritedRunConfig
@@ -312,6 +350,13 @@ export function mergeAgentToolRunConfig(
   );
   if (typeof mergedModelSettings !== 'undefined') {
     mergedRunConfig.modelSettings = mergedModelSettings;
+  }
+  const mergedTracing = mergeTracingConfig(
+    inheritedRunConfig.tracing,
+    toolRunConfigOverride.tracing,
+  );
+  if (typeof mergedTracing !== 'undefined') {
+    mergedRunConfig.tracing = mergedTracing;
   }
 
   return mergedRunConfig;

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -40,6 +40,7 @@ import {
   cachedMcpToolKeysByServer as _cachedToolKeysByServer,
   cachedMcpTools as _cachedTools,
 } from './mcpToolCache';
+import { getToolCallParentSpanFromDetails } from './agentToolRunConfig';
 
 export {
   BaseMCPServerSSE,
@@ -165,8 +166,7 @@ export interface MCPBlobResourceContent {
 }
 
 export type MCPResourceContent =
-  | MCPTextResourceContent
-  | MCPBlobResourceContent;
+  MCPTextResourceContent | MCPBlobResourceContent;
 
 /**
  * Result returned by `listResources`.
@@ -458,11 +458,13 @@ async function getMcpToolsFromServer<TContext = UnknownContext>({
   runContext,
   agent,
   generateMCPToolCacheKey,
+  tracingParent,
 }: {
   server: MCPServer;
   runContext?: RunContext<TContext>;
   agent?: Agent<any, any>;
   generateMCPToolCacheKey?: MCPToolCacheKeyGenerator;
+  tracingParent?: Span<any>;
 }): Promise<MCPTool[]> {
   const cacheKey = (generateMCPToolCacheKey || defaultMCPToolCacheKey)({
     server,
@@ -540,13 +542,17 @@ async function getMcpToolsFromServer<TContext = UnknownContext>({
     return mcpTools;
   };
 
-  if (!getCurrentTrace()) {
+  if (!tracingParent && !getCurrentTrace()) {
     return listToolsForServer();
   }
 
-  return withMCPListToolsSpan(listToolsForServer, {
-    data: { server: server.name },
-  });
+  return withMCPListToolsSpan(
+    listToolsForServer,
+    {
+      data: { server: server.name },
+    },
+    tracingParent,
+  );
 }
 
 function convertMcpToolsToFunctionTools<TContext = UnknownContext>({
@@ -580,6 +586,7 @@ async function getFunctionToolsFromServer<TContext = UnknownContext>({
   agent,
   generateMCPToolCacheKey,
   errorFunction,
+  tracingParent,
 }: {
   server: MCPServer;
   convertSchemasToStrict: boolean;
@@ -587,12 +594,14 @@ async function getFunctionToolsFromServer<TContext = UnknownContext>({
   agent?: Agent<any, any>;
   generateMCPToolCacheKey?: MCPToolCacheKeyGenerator;
   errorFunction?: MCPToolErrorFunction | null;
+  tracingParent?: Span<any>;
 }): Promise<FunctionTool<TContext, any, unknown>[]> {
   const mcpTools = await getMcpToolsFromServer({
     server,
     runContext,
     agent,
     generateMCPToolCacheKey,
+    tracingParent,
   });
   return convertMcpToolsToFunctionTools({
     mcpTools,
@@ -614,6 +623,7 @@ export type GetAllMcpToolsOptions<TContext> = {
   errorFunction?: MCPToolErrorFunction | null;
   includeServerInToolNames?: boolean;
   reservedToolNames?: Set<string>;
+  tracingParent?: Span<any>;
 };
 
 /**
@@ -644,6 +654,7 @@ export async function getAllMcpTools<TContext = UnknownContext>(
     errorFunction,
     includeServerInToolNames = false,
     reservedToolNames,
+    tracingParent,
   } = opts;
   const allTools: Tool<TContext>[] = [];
   const toolNames = new Set<string>();
@@ -658,6 +669,7 @@ export async function getAllMcpTools<TContext = UnknownContext>(
           runContext: runContextFromOpts,
           agent: agentFromOpts,
           generateMCPToolCacheKey,
+          tracingParent,
         }),
       })),
     );
@@ -701,6 +713,7 @@ export async function getAllMcpTools<TContext = UnknownContext>(
       agent: agentFromOpts,
       generateMCPToolCacheKey,
       errorFunction,
+      tracingParent,
     });
     const serverToolNames = new Set(serverTools.map((t) => t.name));
     const intersection = [...serverToolNames]
@@ -992,7 +1005,8 @@ export function mcpToFunctionTool(
     } else if (typeof input === 'object' && input != null) {
       args = input;
     }
-    const currentSpan = getCurrentSpan();
+    const currentSpan =
+      getToolCallParentSpanFromDetails(details) ?? getCurrentSpan();
     if (currentSpan) {
       currentSpan.spanData['mcp_data'] = { server: server.name };
     }
@@ -1190,8 +1204,7 @@ export interface FullCommandMCPServerStdioOptions extends BaseMCPServerStdioOpti
   fullCommand: string;
 }
 export type MCPServerStdioOptions =
-  | DefaultMCPServerStdioOptions
-  | FullCommandMCPServerStdioOptions;
+  DefaultMCPServerStdioOptions | FullCommandMCPServerStdioOptions;
 
 export interface MCPServerStreamableHttpOptions {
   url: string;

--- a/packages/agents-core/src/model.ts
+++ b/packages/agents-core/src/model.ts
@@ -9,6 +9,8 @@ import {
 } from './tool';
 import { Computer } from './computer';
 import { Handoff } from './handoff';
+import type { Span } from './tracing/spans';
+import type { Trace } from './tracing/traces';
 import {
   AgentInputItem,
   AgentOutputItem,
@@ -548,6 +550,7 @@ export type ModelRequest = {
   _internal?: {
     runnerManagedRetry?: boolean;
     reasoningEffortImplicit?: boolean;
+    tracingParent?: Span<any> | Trace;
   };
 };
 

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1,6 +1,6 @@
 import { Agent, AgentOutputType } from './agent';
 import { RunAgentUpdatedStreamEvent, RunRawModelStreamEvent } from './events';
-import { ModelBehaviorError } from './errors';
+import { AgentsError, ModelBehaviorError } from './errors';
 import {
   defineInputGuardrail,
   defineOutputGuardrail,
@@ -24,13 +24,15 @@ import { RunState } from './runState';
 import { RunItem } from './items';
 import {
   getCurrentTrace,
-  getOrCreateTrace,
+  getCurrentTraceContext,
   resetCurrentSpan,
   setCurrentSpan,
   withNewSpanContext,
   withTrace,
+  withTraceContext,
 } from './tracing/context';
 import type { TracingConfig } from './tracing';
+import { includeTaskAndTurnSpans, mergeTracingConfig } from './tracing/config';
 import { Usage } from './usage';
 import { convertAgentOutputTypeToSerializable } from './utils/tools';
 import { DEFAULT_MAX_TURNS } from './runner/constants';
@@ -79,7 +81,30 @@ import {
   handleInterruptedOutcome,
   resumeInterruptedTurn,
 } from './runner/runLoop';
-import { applyTraceOverrides, getTracing } from './runner/tracing';
+import {
+  applyTraceOverrides,
+  ensureActiveAgentSpanForInterruptedResume,
+  ensureTurnSpan,
+  finishRunnerSpan,
+  getTracing,
+  setRunnerSpanError,
+  startRunnerInvocationSpans,
+  startTurnSpan,
+  recordRunnerSpanUsage,
+  type RunnerSpanLifecycle,
+} from './runner/tracing';
+import {
+  getRunnerParentUsageRecorder,
+  setRunStateUsageRecorder,
+} from './runner/usageTracking';
+import {
+  getRunnerInvocationSpanParent,
+  getRunStateTurnSpanParent,
+  setRunStateTurnSpanParent,
+} from './runner/invocationContext';
+import type { Span, TaskSpanData } from './tracing/spans';
+import { NoopTrace, type Trace } from './tracing/traces';
+import { NOOP_TRACE_OR_SPAN_ID } from './tracing/utils';
 import type { ReasoningItemIdPolicy } from './runner/items';
 import type {
   AgentArtifacts,
@@ -369,6 +394,10 @@ class LazyDefaultModelProvider implements ModelProvider {
   }
 }
 
+function isNoopTrace(trace: Trace | null | undefined): boolean {
+  return trace instanceof NoopTrace || trace?.traceId === NOOP_TRACE_OR_SPAN_ID;
+}
+
 // --------------------------------------------------------------
 //  Runner
 // --------------------------------------------------------------
@@ -395,8 +424,7 @@ export async function run<TAgent extends Agent<any, any>, TContext = undefined>(
   agent: TAgent,
   input: string | AgentInputItem[] | RunState<TContext, TAgent>,
   options?:
-    | StreamRunOptions<TContext, TAgent>
-    | NonStreamRunOptions<TContext, TAgent>,
+    StreamRunOptions<TContext, TAgent> | NonStreamRunOptions<TContext, TAgent>,
 ): Promise<RunResult<TContext, TAgent> | StreamedRunResult<TContext, TAgent>> {
   const runner = getDefaultRunner();
   if (options?.stream) {
@@ -512,6 +540,26 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
   ): Promise<
     RunResult<TContext, TAgent> | StreamedRunResult<TContext, TAgent>
   > {
+    if (input instanceof RunState) {
+      if (isNoopTrace(input._trace)) {
+        input._trace = null;
+      }
+      if (input._currentAgentSpan?.spanId === NOOP_TRACE_OR_SPAN_ID) {
+        input.setCurrentAgentSpan(undefined);
+      }
+    }
+    const capturedInvocationTraceContext = getCurrentTraceContext();
+    const invocationTraceContext = isNoopTrace(
+      capturedInvocationTraceContext?.trace,
+    )
+      ? undefined
+      : capturedInvocationTraceContext;
+    const configuredInvocationSpanParent = getRunnerInvocationSpanParent(this);
+    const invocationSpanParent: Span<any> | Trace | undefined =
+      configuredInvocationSpanParent ??
+      (input instanceof RunState && input._trace
+        ? input._trace
+        : (invocationTraceContext?.span ?? invocationTraceContext?.trace));
     const resolvedOptions = options ?? { stream: false, context: undefined };
     // Per-run options take precedence over runner defaults for session memory behavior.
     const sessionInputCallback =
@@ -531,7 +579,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     const toolNotFoundBehavior =
       resolvedOptions.toolNotFoundBehavior ?? this.config.toolNotFoundBehavior;
     const hasCallModelInputFilter = Boolean(callModelInputFilter);
-    const tracingConfig = resolvedOptions.tracing ?? this.config.tracing;
+    const tracingConfig = mergeTracingConfig(
+      this.config.tracing,
+      resolvedOptions.tracing,
+    );
     const traceOverrides = {
       ...this.traceOverrides,
       ...(resolvedOptions.tracing?.apiKey !== undefined
@@ -546,7 +597,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       reasoningItemIdPolicy,
       toolExecution,
       toolNotFoundBehavior,
+      tracing: tracingConfig,
     };
+    const useTaskAndTurnSpans =
+      !this.config.tracingDisabled && includeTaskAndTurnSpans(tracingConfig);
     const resumingFromState = input instanceof RunState;
     const preserveTurnPersistenceOnResume =
       resumingFromState &&
@@ -603,7 +657,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     const ensureStreamInputPersisted =
       sessionPersistence?.buildPersistInputOnce(serverManagesConversation);
 
-    const executeRun = async () => {
+    const executeRun = async (
+      effectiveInvocationSpanParent = invocationSpanParent,
+    ) => {
       if (effectiveOptions.stream) {
         const streamResult = await this.#runIndividualStream(
           agent,
@@ -616,6 +672,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             sdkSessionId: async () => await session?.getSessionId(),
             inputOverride: () => sessionPersistence?.getItemsForPersistence(),
           },
+          effectiveInvocationSpanParent,
         );
         return streamResult;
       }
@@ -629,18 +686,52 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           sdkSessionId: async () => await session?.getSessionId(),
           inputOverride: () => sessionPersistence?.getItemsForPersistence(),
         },
+        effectiveInvocationSpanParent,
+        sessionPersistence && !serverManagesConversation
+          ? async (result) => {
+              await saveToSession(
+                session,
+                sessionPersistence.getItemsForPersistence(),
+                result,
+              );
+            }
+          : undefined,
       );
-      // See note above: allow sessions to run for callbacks/state but skip writes when the server
-      // is the source of truth for transcript history.
-      if (sessionPersistence && !serverManagesConversation) {
-        await saveToSession(
-          session,
-          sessionPersistence.getItemsForPersistence(),
-          runResult,
-        );
-      }
       return runResult;
     };
+
+    if (this.config.tracingDisabled) {
+      const disabledTrace = new NoopTrace();
+      if (preparedInput instanceof RunState) {
+        preparedInput._currentAgentSpan?.end();
+        preparedInput._trace = null;
+        preparedInput.setCurrentAgentSpan(undefined);
+      }
+      return withTrace(disabledTrace, async () => {
+        try {
+          const result = await executeRun(disabledTrace);
+          const clearDisabledTraceState = () => {
+            result.state._trace = null;
+            result.state.setCurrentAgentSpan(undefined);
+          };
+          if (result instanceof StreamedRunResult) {
+            void result.completed.then(
+              clearDisabledTraceState,
+              clearDisabledTraceState,
+            );
+          } else {
+            clearDisabledTraceState();
+          }
+          return result;
+        } catch (error) {
+          if (error instanceof AgentsError && error.state) {
+            error.state._trace = null;
+            error.state.setCurrentAgentSpan(undefined);
+          }
+          throw error;
+        }
+      });
+    }
 
     if (preparedInput instanceof RunState && preparedInput._trace) {
       const applied = applyTraceOverrides(
@@ -651,22 +742,28 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       preparedInput._trace = applied.trace;
       preparedInput._currentAgentSpan = applied.currentSpan;
       return withTrace(preparedInput._trace, async () => {
-        if (preparedInput._currentAgentSpan) {
+        if (preparedInput._currentAgentSpan && !useTaskAndTurnSpans) {
           setCurrentSpan(preparedInput._currentAgentSpan);
         }
         return executeRun();
       });
     }
-    return getOrCreateTrace(
-      async () => {
-        if (preparedInput instanceof RunState && !preparedInput._trace) {
-          preparedInput._trace = getCurrentTrace();
-        }
-        return executeRun();
-      },
+    const executeInInvocationTrace = async (
+      effectiveInvocationSpanParent = invocationSpanParent,
+    ) => {
+      if (preparedInput instanceof RunState && !preparedInput._trace) {
+        preparedInput._trace = getCurrentTrace();
+      }
+      return executeRun(effectiveInvocationSpanParent);
+    };
+    if (invocationTraceContext) {
+      return withTraceContext(invocationTraceContext, executeInInvocationTrace);
+    }
+    return withTrace(
+      this.config.workflowName ?? 'Agent workflow',
+      async (trace) => executeInInvocationTrace(trace),
       {
         traceId: this.config.traceId,
-        name: this.config.workflowName,
         groupId: this.config.groupId,
         metadata: this.config.traceMetadata,
         // Per-run tracing config overrides exporter defaults such as environment API key.
@@ -742,10 +839,12 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       typeof options.toolExecution !== 'undefined';
     const hasToolNotFoundBehaviorOverride =
       typeof options.toolNotFoundBehavior !== 'undefined';
+    const hasTracingOverride = typeof options.tracing !== 'undefined';
     if (
       !hasSandboxOverride &&
       !hasToolExecutionOverride &&
-      !hasToolNotFoundBehaviorOverride
+      !hasToolNotFoundBehaviorOverride &&
+      !hasTracingOverride
     ) {
       return this.config;
     }
@@ -758,6 +857,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       ...(hasToolNotFoundBehaviorOverride
         ? { toolNotFoundBehavior: options.toolNotFoundBehavior }
         : {}),
+      ...(hasTracingOverride ? { tracing: options.tracing } : {}),
     };
   }
 
@@ -780,6 +880,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     ) => void,
     preserveTurnPersistenceOnResume?: boolean,
     sandboxMemoryRunContext?: SandboxMemoryPersistenceContext,
+    invocationSpanParent?: Span<any> | Trace,
+    persistResult?: (result: RunResult<TContext, TAgent>) => Promise<void>,
   ): Promise<RunResult<TContext, TAgent>> {
     return withNewSpanContext(async () => {
       // if we have a saved state we use that one, otherwise we create a new one
@@ -854,9 +956,58 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       const toolErrorFormatter =
         options.toolErrorFormatter ?? this.config.toolErrorFormatter;
 
+      const useTaskAndTurnSpans =
+        !this.config.tracingDisabled &&
+        includeTaskAndTurnSpans(options.tracing);
+      const resumingInterruptedTurn =
+        isResumedState && state._currentStep?.type === 'next_step_interruption';
+      const invocationSpans = useTaskAndTurnSpans
+        ? startRunnerInvocationSpans({
+            name:
+              getCurrentTrace()?.name ??
+              this.config.workflowName ??
+              'Agent workflow',
+            agent: state._currentAgent,
+            restoredAgentSpan: isResumedState
+              ? state._currentAgentSpan
+              : undefined,
+            resumeInterruptedTurn: resumingInterruptedTurn,
+            parent: invocationSpanParent,
+          })
+        : undefined;
+      const taskSpan = invocationSpans?.taskSpan;
+      const optOutResumeAgentSpan =
+        resumingInterruptedTurn && !useTaskAndTurnSpans
+          ? ensureActiveAgentSpanForInterruptedResume({
+              agent: state._currentAgent,
+              restoredAgentSpan: isResumedState
+                ? state._currentAgentSpan
+                : undefined,
+              parent: invocationSpanParent ?? getCurrentTrace() ?? undefined,
+            })
+          : undefined;
+      if (useTaskAndTurnSpans && isResumedState) {
+        state.setCurrentAgentSpan(invocationSpans?.agentSpan);
+      } else if (optOutResumeAgentSpan) {
+        state.setCurrentAgentSpan(optOutResumeAgentSpan);
+      }
+
       // Tracks when we resume an approval interruption so the next run-again step stays in the same turn.
       let continuingInterruptedTurn = false;
       let runError: unknown;
+      let currentTurnSpan: ReturnType<typeof startTurnSpan> | undefined;
+      const parentUsageRecorder = getRunnerParentUsageRecorder(this);
+      const recordUsage = (usage: Usage) => {
+        recordRunnerSpanUsage(taskSpan, usage);
+        recordRunnerSpanUsage(currentTurnSpan, usage);
+        parentUsageRecorder?.(usage);
+      };
+      setRunStateUsageRecorder(state, recordUsage);
+      let completedResult: RunResult<TContext, TAgent> | undefined;
+      const completeResult = (result: RunResult<TContext, TAgent>) => {
+        completedResult = result;
+        return result;
+      };
 
       try {
         while (true) {
@@ -873,7 +1024,19 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               runConfigModel: await this.#resolveSandboxRuntimeModelForAgent(
                 state._currentAgent,
               ),
+              tracingParent:
+                getRunStateTurnSpanParent(state) ?? state._currentAgentSpan,
             });
+
+            if (useTaskAndTurnSpans) {
+              currentTurnSpan = ensureTurnSpan(
+                currentTurnSpan,
+                state._currentTurn,
+                state._currentAgent.name,
+                state._currentAgentSpan,
+              );
+              setRunStateTurnSpanParent(state, currentTurnSpan.span);
+            }
 
             const interruptedOutcome = await resumeInterruptedTurn({
               state,
@@ -892,9 +1055,14 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 continuingInterruptedTurn = value;
               },
             });
+            if (!shouldContinue) {
+              finishRunnerSpan(currentTurnSpan);
+              setRunStateTurnSpanParent(state, undefined);
+              currentTurnSpan = undefined;
+            }
             if (shouldReturn) {
               // we are still in an interruption, so we need to avoid an infinite loop
-              return new RunResult<TContext, TAgent>(state);
+              return completeResult(new RunResult<TContext, TAgent>(state));
             }
             if (shouldContinue) {
               continue;
@@ -924,6 +1092,18 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               emitAgentStart: (context, agent, inputItems) => {
                 this.emit('agent_start', context, agent, inputItems);
               },
+              onAgentSpanReady: useTaskAndTurnSpans
+                ? (turn, agentName) => {
+                    currentTurnSpan = ensureTurnSpan(
+                      currentTurnSpan,
+                      turn,
+                      agentName,
+                      state._currentAgentSpan,
+                    );
+                    setRunStateTurnSpanParent(state, currentTurnSpan.span);
+                  }
+                : undefined,
+              agentSpanParent: taskSpan?.span ?? invocationSpanParent,
             });
             if (
               preserveTurnPersistenceOnResume &&
@@ -941,6 +1121,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               runConfigModel: await this.#resolveSandboxRuntimeModelForAgent(
                 state._currentAgent,
               ),
+              tracingParent: currentTurnSpan?.span ?? state._currentAgentSpan,
             });
             const artifacts = await prepareAgentArtifacts(
               state,
@@ -996,6 +1177,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             }
             state._modelResponses.push(state._lastTurnResponse);
             state._context.usage.add(state._lastTurnResponse.usage);
+            recordUsage(state._lastTurnResponse.usage);
             state._noActiveAgentRun = false;
 
             // After each turn record the items echoed by the server so future requests only
@@ -1044,6 +1226,11 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               toolsUsed: state._lastProcessedResponse?.toolsUsed ?? [],
               resetTurnPersistence: !isResumedState,
             });
+            if (turnResult.nextStep.type !== 'next_step_final_output') {
+              finishRunnerSpan(currentTurnSpan);
+              setRunStateTurnSpanParent(state, undefined);
+              currentTurnSpan = undefined;
+            }
           }
 
           const currentStep = state._currentStep;
@@ -1059,6 +1246,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 this.outputGuardrailDefs,
                 currentStep.output,
               );
+              finishRunnerSpan(currentTurnSpan);
+              setRunStateTurnSpanParent(state, undefined);
+              currentTurnSpan = undefined;
               state._currentTurnInProgress = false;
               this.emit(
                 'agent_end',
@@ -1071,7 +1261,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 state._context,
                 currentStep.output,
               );
-              return new RunResult<TContext, TAgent>(state);
+              return completeResult(new RunResult<TContext, TAgent>(state));
             case 'next_step_handoff':
               state.setCurrentAgent(currentStep.newAgent as TAgent);
               if (state._currentAgentSpan) {
@@ -1087,7 +1277,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               break;
             case 'next_step_interruption':
               // Interrupted. Don't run any guardrails.
-              return new RunResult<TContext, TAgent>(state);
+              return completeResult(new RunResult<TContext, TAgent>(state));
             case 'next_step_run_again':
               state._currentTurnInProgress = false;
               logger.debug('Running next loop');
@@ -1109,7 +1299,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           },
         });
         if (handledResult) {
-          return handledResult;
+          return completeResult(handledResult);
         }
         if (state._currentAgentSpan) {
           state._currentAgentSpan.setError({
@@ -1117,21 +1307,51 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             data: { error: String(err) },
           });
         }
+        setRunnerSpanError(currentTurnSpan, err);
+        setRunnerSpanError(taskSpan, err);
         runError = err;
         throw err;
       } finally {
+        finishRunnerSpan(currentTurnSpan);
+        setRunStateTurnSpanParent(state, undefined);
         const preserveSandboxSessions =
           state._currentStep?.type === 'next_step_interruption';
-        await finalizeSandboxRuntime({
-          state: state as RunState<TContext, Agent<TContext, AgentOutputType>>,
-          sandboxRuntime,
-          preserveSessionsForInterruption: preserveSandboxSessions,
-          runError,
-          groupId: this.config.groupId,
-          memoryContext: sandboxMemoryRunContext,
-          runAgent: async (agent, input, runOptions) =>
-            await this.run(agent, input, runOptions),
-        });
+        try {
+          try {
+            await finalizeSandboxRuntime({
+              state: state as RunState<
+                TContext,
+                Agent<TContext, AgentOutputType>
+              >,
+              sandboxRuntime,
+              preserveSessionsForInterruption: preserveSandboxSessions,
+              finishAgentSpanForInterruption:
+                Boolean(taskSpan) || runError !== undefined,
+              runError,
+              groupId: this.config.groupId,
+              memoryContext: sandboxMemoryRunContext,
+              runAgent: async (agent, input, runOptions) =>
+                await this.run(agent, input, runOptions),
+              tracingParent:
+                taskSpan?.span ??
+                state._currentAgentSpan ??
+                invocationSpanParent,
+            });
+          } catch (error) {
+            setRunnerSpanError(taskSpan, error);
+            await Promise.reject(error);
+          }
+          if (completedResult) {
+            try {
+              await persistResult?.(completedResult);
+            } catch (error) {
+              setRunnerSpanError(taskSpan, error);
+              await Promise.reject(error);
+            }
+          }
+        } finally {
+          finishRunnerSpan(taskSpan);
+        }
       }
     });
   }
@@ -1155,6 +1375,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     ) => void,
     preserveTurnPersistenceOnResume?: boolean,
     sandboxMemoryRunContext?: SandboxMemoryPersistenceContext,
+    taskSpan?: RunnerSpanLifecycle<TaskSpanData>,
+    invocationSpanParent?: Span<any> | Trace,
   ): Promise<void> {
     const resolvedReasoningItemIdPolicy =
       options.reasoningItemIdPolicy ??
@@ -1221,10 +1443,20 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     const toolErrorFormatter =
       options.toolErrorFormatter ?? this.config.toolErrorFormatter;
     const agentToolParentRunConfig = this.#getAgentToolParentRunConfig(options);
+    const useTaskAndTurnSpans =
+      !this.config.tracingDisabled && includeTaskAndTurnSpans(options.tracing);
 
     // Tracks when we resume an approval interruption so the next run-again step stays in the same turn.
     let continuingInterruptedTurn = false;
     let runError: unknown;
+    let currentTurnSpan: ReturnType<typeof startTurnSpan> | undefined;
+    const parentUsageRecorder = getRunnerParentUsageRecorder(this);
+    const recordUsage = (usage: Usage) => {
+      recordRunnerSpanUsage(taskSpan, usage);
+      recordRunnerSpanUsage(currentTurnSpan, usage);
+      parentUsageRecorder?.(usage);
+    };
+    setRunStateUsageRecorder(result.state, recordUsage);
 
     try {
       while (true) {
@@ -1242,7 +1474,20 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             runConfigModel: await this.#resolveSandboxRuntimeModelForAgent(
               result.state._currentAgent,
             ),
+            tracingParent:
+              getRunStateTurnSpanParent(result.state) ??
+              result.state._currentAgentSpan,
           });
+
+          if (useTaskAndTurnSpans) {
+            currentTurnSpan = ensureTurnSpan(
+              currentTurnSpan,
+              result.state._currentTurn,
+              result.state._currentAgent.name,
+              result.state._currentAgentSpan,
+            );
+            setRunStateTurnSpanParent(result.state, currentTurnSpan.span);
+          }
 
           const interruptedOutcome = await resumeInterruptedTurn({
             state: result.state,
@@ -1264,6 +1509,11 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               continuingInterruptedTurn = value;
             },
           });
+          if (!shouldContinue) {
+            finishRunnerSpan(currentTurnSpan);
+            setRunStateTurnSpanParent(result.state, undefined);
+            currentTurnSpan = undefined;
+          }
           if (shouldReturn) {
             // we are still in an interruption, so we need to avoid an infinite loop
             return;
@@ -1302,6 +1552,18 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             emitAgentStart: (context, agent, inputItems) => {
               this.emit('agent_start', context, agent, inputItems);
             },
+            onAgentSpanReady: useTaskAndTurnSpans
+              ? (turn, agentName) => {
+                  currentTurnSpan = ensureTurnSpan(
+                    currentTurnSpan,
+                    turn,
+                    agentName,
+                    result.state._currentAgentSpan,
+                  );
+                  setRunStateTurnSpanParent(result.state, currentTurnSpan.span);
+                }
+              : undefined,
+            agentSpanParent: taskSpan?.span ?? invocationSpanParent,
           });
           if (
             preserveTurnPersistenceOnResume &&
@@ -1323,6 +1585,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             runConfigModel: await this.#resolveSandboxRuntimeModelForAgent(
               result.state._currentAgent,
             ),
+            tracingParent:
+              currentTurnSpan?.span ?? result.state._currentAgentSpan,
           });
           const artifacts = await prepareAgentArtifacts(
             result.state,
@@ -1407,6 +1671,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 abortReconciliationState,
                 reconciliationResponse,
               );
+              result.state._context.usage.add(reconciliationResponse.usage);
+              recordUsage(reconciliationResponse.usage);
               serverConversationTracker.trackServerItems(
                 reconciliationResponse,
               );
@@ -1470,6 +1736,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                   requestId: parsed.response.requestId,
                 };
                 result.state._context.usage.add(finalResponse.usage);
+                recordUsage(finalResponse.usage);
               }
               if (result.cancelled) {
                 // When the user's code exits a loop to consume the stream, we need to break
@@ -1563,6 +1830,11 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               addStepToRunResult(result, step, { skipItems: preToolItems });
             },
           });
+          if (turnResult.nextStep.type !== 'next_step_final_output') {
+            finishRunnerSpan(currentTurnSpan);
+            setRunStateTurnSpanParent(result.state, undefined);
+            currentTurnSpan = undefined;
+          }
         }
 
         const currentStep = result.state._currentStep;
@@ -1574,6 +1846,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 this.outputGuardrailDefs,
                 currentStep.output,
               );
+              finishRunnerSpan(currentTurnSpan);
+              setRunStateTurnSpanParent(result.state, undefined);
+              currentTurnSpan = undefined;
             } catch (error) {
               // Do not leave blocked output visible through StreamedRunResult.finalOutput.
               result.state._currentStep = undefined;
@@ -1667,9 +1942,13 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           data: { error: String(error) },
         });
       }
+      setRunnerSpanError(currentTurnSpan, error);
+      setRunnerSpanError(taskSpan, error);
       runError = error;
       throw error;
     } finally {
+      finishRunnerSpan(currentTurnSpan);
+      setRunStateTurnSpanParent(result.state, undefined);
       if (guardrailTracker.pending) {
         await guardrailTracker.awaitCompletion({ suppressErrors: true });
       }
@@ -1682,19 +1961,34 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       }
       const preserveSandboxSessions =
         result.state._currentStep?.type === 'next_step_interruption';
-      await finalizeSandboxRuntime({
-        state: result.state as RunState<
-          TContext,
-          Agent<TContext, AgentOutputType>
-        >,
-        sandboxRuntime,
-        preserveSessionsForInterruption: preserveSandboxSessions,
-        runError,
-        groupId: this.config.groupId,
-        memoryContext: sandboxMemoryRunContext,
-        runAgent: async (agent, input, runOptions) =>
-          await this.run(agent, input, runOptions),
-      });
+      try {
+        try {
+          await finalizeSandboxRuntime({
+            state: result.state as RunState<
+              TContext,
+              Agent<TContext, AgentOutputType>
+            >,
+            sandboxRuntime,
+            preserveSessionsForInterruption: preserveSandboxSessions,
+            finishAgentSpanForInterruption:
+              Boolean(taskSpan) || runError !== undefined,
+            runError,
+            groupId: this.config.groupId,
+            memoryContext: sandboxMemoryRunContext,
+            runAgent: async (agent, input, runOptions) =>
+              await this.run(agent, input, runOptions),
+            tracingParent:
+              taskSpan?.span ??
+              result.state._currentAgentSpan ??
+              invocationSpanParent,
+          });
+        } catch (error) {
+          setRunnerSpanError(taskSpan, error);
+          await Promise.reject(error);
+        }
+      } finally {
+        finishRunnerSpan(taskSpan);
+      }
     }
   }
 
@@ -1715,6 +2009,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     ) => void,
     preserveTurnPersistenceOnResume?: boolean,
     sandboxMemoryRunContext?: SandboxMemoryPersistenceContext,
+    invocationSpanParent?: Span<any> | Trace,
   ): Promise<StreamedRunResult<TContext, TAgent>> {
     options = options ?? ({} as StreamRunOptions<TContext>);
     return withNewSpanContext(async () => {
@@ -1737,6 +2032,41 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         if (options.maxTurns !== undefined) {
           state._maxTurns = options.maxTurns;
         }
+      }
+      const useTaskAndTurnSpans =
+        !this.config.tracingDisabled &&
+        includeTaskAndTurnSpans(options.tracing);
+      const resumingInterruptedTurn =
+        isResumedState && state._currentStep?.type === 'next_step_interruption';
+      const invocationSpans = useTaskAndTurnSpans
+        ? startRunnerInvocationSpans({
+            name:
+              getCurrentTrace()?.name ??
+              this.config.workflowName ??
+              'Agent workflow',
+            agent: state._currentAgent,
+            restoredAgentSpan: isResumedState
+              ? state._currentAgentSpan
+              : undefined,
+            resumeInterruptedTurn: resumingInterruptedTurn,
+            parent: invocationSpanParent,
+          })
+        : undefined;
+      const taskSpan = invocationSpans?.taskSpan;
+      const optOutResumeAgentSpan =
+        resumingInterruptedTurn && !useTaskAndTurnSpans
+          ? ensureActiveAgentSpanForInterruptedResume({
+              agent: state._currentAgent,
+              restoredAgentSpan: isResumedState
+                ? state._currentAgentSpan
+                : undefined,
+              parent: invocationSpanParent ?? getCurrentTrace() ?? undefined,
+            })
+          : undefined;
+      if (useTaskAndTurnSpans && isResumedState) {
+        state.setCurrentAgentSpan(invocationSpans?.agentSpan);
+      } else if (optOutResumeAgentSpan) {
+        state.setCurrentAgentSpan(optOutResumeAgentSpan);
       }
       const sandboxRuntime = new SandboxRuntimeManager<TContext>({
         startingAgent: agent,
@@ -1782,6 +2112,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         sessionInputUpdate,
         preserveTurnPersistenceOnResume,
         sandboxMemoryRunContext,
+        taskSpan,
+        invocationSpanParent,
       ).then(
         () => {
           result._done();
@@ -1837,6 +2169,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         implicitModelSettings?.reasoning?.effort !== undefined &&
         !hasExplicitTopLevelReasoningEffort(this.config.modelSettings) &&
         !hasExplicitTopLevelReasoningEffort(agentModelSettings),
+      tracingParent:
+        getRunStateTurnSpanParent(state) ?? state._currentAgentSpan,
     };
 
     let modelSettings = mergeModelSettings(

--- a/packages/agents-core/src/runner/invocationContext.ts
+++ b/packages/agents-core/src/runner/invocationContext.ts
@@ -1,0 +1,38 @@
+import type { Span } from '../tracing/spans';
+
+const runnerInvocationSpanParents = new WeakMap<object, Span<any>>();
+const runStateTurnSpanParents = new WeakMap<object, Span<any>>();
+
+export function setRunnerInvocationSpanParent(
+  runner: object,
+  parent: Span<any> | undefined,
+): void {
+  if (parent) {
+    runnerInvocationSpanParents.set(runner, parent);
+  } else {
+    runnerInvocationSpanParents.delete(runner);
+  }
+}
+
+export function getRunnerInvocationSpanParent(
+  runner: object,
+): Span<any> | undefined {
+  return runnerInvocationSpanParents.get(runner);
+}
+
+export function setRunStateTurnSpanParent(
+  state: object,
+  parent: Span<any> | undefined,
+): void {
+  if (parent) {
+    runStateTurnSpanParents.set(state, parent);
+  } else {
+    runStateTurnSpanParents.delete(state);
+  }
+}
+
+export function getRunStateTurnSpanParent(
+  state: object,
+): Span<any> | undefined {
+  return runStateTurnSpanParents.get(state);
+}

--- a/packages/agents-core/src/runner/modelPreparation.ts
+++ b/packages/agents-core/src/runner/modelPreparation.ts
@@ -93,6 +93,7 @@ async function collectAgentCapabilities<TContext>(
   const handoffs = await executionAgent.getEnabledHandoffs(state._context);
   const configuredTools = (await executionAgent.getAllTools(
     state._context,
+    state._currentAgentSpan,
   )) as Tool<TContext>[];
   const runtimeLoadedTools = state.getToolSearchRuntimeTools(
     state._currentAgent,

--- a/packages/agents-core/src/runner/sandbox.ts
+++ b/packages/agents-core/src/runner/sandbox.ts
@@ -9,6 +9,8 @@ import { isSandboxAgent } from '../sandbox/runtime/agentKeys';
 import { processedResponseRequiresExecutionToolRehydration } from '../sandbox/runtime/toolRehydration';
 import { disposeResolvedComputers } from '../tool';
 import { resetCurrentSpan } from '../tracing/context';
+import type { Span } from '../tracing/spans';
+import type { Trace } from '../tracing/traces';
 import type { AgentInputItem } from '../types';
 import { prepareAgentArtifacts } from './modelPreparation';
 
@@ -25,8 +27,15 @@ export async function prepareSandboxInterruptedTurnResume<
   state: RunState<TContext, TAgent>;
   sandboxRuntime: SandboxRuntimeManager<TContext>;
   runConfigModel?: SandboxRuntimeModel;
+  tracingParent?: Span<any> | Trace;
 }): Promise<void> {
-  const { startingAgent, state, sandboxRuntime, runConfigModel } = args;
+  const {
+    startingAgent,
+    state,
+    sandboxRuntime,
+    runConfigModel,
+    tracingParent,
+  } = args;
   logger.debug('Continuing from interruption');
   if (!state._lastTurnResponse || !state._lastProcessedResponse) {
     throw new UserError('No model response found in previous state', state);
@@ -44,7 +53,7 @@ export async function prepareSandboxInterruptedTurnResume<
   }
 
   const resumedPreservedSessions =
-    await sandboxRuntime.adoptPreservedOwnedSessions();
+    await sandboxRuntime.adoptPreservedOwnedSessions(tracingParent);
   if (resumedPreservedSessions || requiresExecutionToolRehydration) {
     await rehydrateInterruptedTurnExecutionTools({
       startingAgent,
@@ -52,6 +61,7 @@ export async function prepareSandboxInterruptedTurnResume<
       sandboxRuntime,
       runConfigModel,
       force: resumedPreservedSessions,
+      tracingParent,
     });
   }
 }
@@ -60,19 +70,23 @@ export async function finalizeSandboxRuntime<TContext>(args: {
   state: RunState<TContext, Agent<TContext, AgentOutputType>>;
   sandboxRuntime: SandboxRuntimeManager<TContext>;
   preserveSessionsForInterruption: boolean;
+  finishAgentSpanForInterruption?: boolean;
   runError?: unknown;
   groupId?: string;
   memoryContext?: SandboxMemoryPersistenceContext;
   runAgent: SandboxMemoryAgentRunner;
+  tracingParent?: Span<any> | Trace;
 }): Promise<void> {
   const {
     state,
     sandboxRuntime,
     preserveSessionsForInterruption,
+    finishAgentSpanForInterruption = false,
     runError,
     groupId,
     memoryContext,
     runAgent,
+    tracingParent,
   } = args;
 
   if (!preserveSessionsForInterruption) {
@@ -90,15 +104,20 @@ export async function finalizeSandboxRuntime<TContext>(args: {
     sdkSessionId: memoryContext?.sdkSessionId,
     runAgent: async (agent, input, runOptions) =>
       await runAgent(agent, input, runOptions),
+    tracingParent,
   });
   try {
     await sandboxRuntime.cleanup(state, {
       preserveOwnedSessions: preserveSessionsForInterruption,
+      tracingParent,
     });
   } finally {
     if (state._currentAgentSpan) {
       try {
-        if (!preserveSessionsForInterruption) {
+        if (
+          !preserveSessionsForInterruption ||
+          finishAgentSpanForInterruption
+        ) {
           state._currentAgentSpan.end();
         }
       } finally {
@@ -117,8 +136,16 @@ export async function rehydrateInterruptedTurnExecutionTools<
   sandboxRuntime: SandboxRuntimeManager<TContext>;
   runConfigModel?: SandboxRuntimeModel;
   force?: boolean;
+  tracingParent?: Span<any> | Trace;
 }): Promise<void> {
-  const { startingAgent, state, sandboxRuntime, runConfigModel, force } = args;
+  const {
+    startingAgent,
+    state,
+    sandboxRuntime,
+    runConfigModel,
+    force,
+    tracingParent,
+  } = args;
   if (
     !force &&
     !processedResponseRequiresExecutionToolRehydration(
@@ -132,6 +159,7 @@ export async function rehydrateInterruptedTurnExecutionTools<
     currentAgent: state._currentAgent,
     turnInput: [],
     runConfigModel,
+    tracingParent,
   });
   const artifacts = await prepareAgentArtifacts(
     state,

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -22,6 +22,7 @@ import {
   type ReasoningItemIdPolicy,
 } from './items';
 import logger from '../logger';
+import { getRunStateUsageRecorder } from './usageTracking';
 
 export type PreparedInputWithSessionResult = {
   preparedInput: string | AgentInputItem[];
@@ -686,17 +687,17 @@ async function runCompactionOnSession(
     return;
   }
   const usage = compactionResult.usage;
-  state._context.usage.add(
-    new Usage({
-      requests: 1,
-      inputTokens: usage.inputTokens,
-      outputTokens: usage.outputTokens,
-      totalTokens: usage.totalTokens,
-      inputTokensDetails: usage.inputTokensDetails,
-      outputTokensDetails: usage.outputTokensDetails,
-      requestUsageEntries: [usage],
-    }),
-  );
+  const usageIncrement = new Usage({
+    requests: 1,
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    totalTokens: usage.totalTokens,
+    inputTokensDetails: usage.inputTokensDetails,
+    outputTokensDetails: usage.outputTokensDetails,
+    requestUsageEntries: [usage],
+  });
+  state._context.usage.add(usageIncrement);
+  getRunStateUsageRecorder(state)?.(usageIncrement);
 }
 
 function buildItemFrequencyMap(

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -1,6 +1,9 @@
 import { FunctionCallResultItem } from '../types/protocol';
 import { Agent, AgentOutputType, ToolsToFinalOutputResult } from '../agent';
-import { setAgentToolParentRunConfigOnDetails } from '../agentToolRunConfig';
+import {
+  setAgentToolParentRunConfigOnDetails,
+  setToolCallParentSpanOnDetails,
+} from '../agentToolRunConfig';
 import { consumeAgentToolRunResult } from '../agentToolRunResults';
 import { ToolCallError, ToolTimeoutError, UserError } from '../errors';
 import { getTransferMessage, HandoffInputData } from '../handoff';
@@ -67,6 +70,11 @@ import type {
   ToolRunShell,
 } from './types';
 import { SingleStepResult } from './steps';
+import {
+  getRunStateUsageRecorder,
+  setToolUsageRecorder,
+} from './usageTracking';
+import { getRunStateTurnSpanParent } from './invocationContext';
 
 type FunctionToolCallDeps<TContext = UnknownContext> = {
   agent: Agent<TContext, any>;
@@ -83,12 +91,10 @@ const TOOL_APPROVAL_REJECTION_SCREENSHOT_DATA_URL =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/iZk9HQAAAABJRU5ErkJggg==';
 
 type ParseToolArgumentsResult =
-  | { success: true; args: any }
-  | { success: false; error: Error };
+  { success: true; args: any } | { success: false; error: Error };
 
 type ToolInputGuardrailCheckResult =
-  | { type: 'allow' }
-  | { type: 'reject'; message: string };
+  { type: 'allow' } | { type: 'reject'; message: string };
 
 function getFunctionToolIdentity<TContext>(
   toolRun: ToolRunFunction<TContext>,
@@ -360,7 +366,7 @@ async function buildApprovalRejectionResult<TContext>(
   const { agent, runner, state, toolErrorFormatter } = deps;
   const toolName = getFunctionToolIdentity(toolRun);
   const traceToolName = getFunctionToolTraceName(toolRun);
-  return withToolFunctionSpan(runner, traceToolName, async (span) => {
+  return withRunStateToolFunctionSpan(deps, traceToolName, async (span) => {
     const response = await resolveApprovalRejectionMessage({
       runContext: state._context,
       toolType: 'function',
@@ -496,7 +502,7 @@ async function runApprovedFunctionTool<TContext>(
   const { agent, runner, state, agentToolParentRunConfig } = deps;
   const toolName = getFunctionToolIdentity(toolRun);
   const traceToolName = getFunctionToolTraceName(toolRun);
-  return withToolFunctionSpan(runner, traceToolName, async (span) => {
+  return withRunStateToolFunctionSpan(deps, traceToolName, async (span) => {
     if (span && runner.config.traceIncludeSensitiveData) {
       span.spanData.input = toolRun.toolCall.arguments;
     }
@@ -536,10 +542,12 @@ async function runApprovedFunctionTool<TContext>(
             executedInput = cloneForCustomDataContext(input);
           },
         };
+        setToolUsageRecorder(toolDetails, getRunStateUsageRecorder(state));
         setAgentToolParentRunConfigOnDetails(
           toolDetails,
           agentToolParentRunConfig ?? runner.config,
         );
+        setToolCallParentSpanOnDetails(toolDetails, span);
         toolOutput = await invokeFunctionTool({
           tool: toolRun.tool,
           runContext: state._context,
@@ -598,8 +606,7 @@ async function runApprovedFunctionTool<TContext>(
       };
 
       const nestedRunResult = consumeAgentToolRunResult(toolRun.toolCall) as
-        | RunResult<TContext, Agent<TContext, any>>
-        | undefined;
+        RunResult<TContext, Agent<TContext, any>> | undefined;
       if (nestedRunResult) {
         functionResult.agentRunResult = nestedRunResult;
         const nestedInterruptions = nestedRunResult.interruptions;
@@ -726,16 +733,34 @@ async function withToolFunctionSpan<T>(
   runner: Runner,
   toolName: string,
   fn: (span?: Span<FunctionSpanData>) => Promise<T>,
+  parent?: Span<any>,
 ): Promise<T> {
-  if (runner.config.tracingDisabled || !getCurrentTrace()) {
+  if (runner.config.tracingDisabled || (!getCurrentTrace() && !parent)) {
     return fn();
   }
 
-  return withFunctionSpan(async (span) => fn(span), {
-    data: {
-      name: toolName,
+  return withFunctionSpan(
+    async (span) => fn(span),
+    {
+      data: {
+        name: toolName,
+      },
     },
-  });
+    parent,
+  );
+}
+
+async function withRunStateToolFunctionSpan<TContext, T>(
+  deps: FunctionToolCallDeps<TContext>,
+  toolName: string,
+  fn: (span?: Span<FunctionSpanData>) => Promise<T>,
+): Promise<T> {
+  return withToolFunctionSpan(
+    deps.runner,
+    toolName,
+    fn,
+    getRunStateTurnSpanParent(deps.state) ?? deps.state._currentAgentSpan,
+  );
 }
 
 type ApprovalResolution = 'approved' | 'rejected' | 'pending';
@@ -814,8 +839,7 @@ async function resolveToolApproval(options: {
 }
 
 type ApprovalDecisionResult =
-  | { status: 'approved' }
-  | { status: 'pending' | 'rejected'; item: RunItem };
+  { status: 'approved' } | { status: 'pending' | 'rejected'; item: RunItem };
 
 async function handleToolApprovalDecision(options: {
   runContext: RunContext;
@@ -1415,6 +1439,7 @@ export async function executeHandoffCalls<
   runHandoffs: ToolRunHandoff[],
   runner: Runner,
   runContext: RunContext<TContext>,
+  parent?: Span<any>,
 ): Promise<import('./steps').SingleStepResult> {
   newStepItems = [...newStepItems];
 
@@ -1526,6 +1551,7 @@ export async function executeHandoffCalls<
         from_agent: agent.name,
       },
     },
+    parent,
   );
 }
 

--- a/packages/agents-core/src/runner/tracing.ts
+++ b/packages/agents-core/src/runner/tracing.ts
@@ -2,11 +2,18 @@ import { Agent } from '../agent';
 import { Handoff } from '../handoff';
 import { ModelTracing } from '../model';
 import { Tool } from '../tool';
-import { setCurrentSpan } from '../tracing/context';
-import { createAgentSpan } from '../tracing';
+import { resetCurrentSpan, setCurrentSpan } from '../tracing/context';
+import { createAgentSpan, createTaskSpan, createTurnSpan } from '../tracing';
 import { getGlobalTraceProvider } from '../tracing/provider';
-import { Span } from '../tracing/spans';
+import {
+  Span,
+  type TaskSpanData,
+  type TaskUsageData,
+  type TurnSpanData,
+  type TurnUsageData,
+} from '../tracing/spans';
 import { Trace } from '../tracing/traces';
+import type { Usage } from '../usage';
 
 export type TraceOverrideConfig = {
   traceId?: string;
@@ -21,7 +28,217 @@ type EnsureAgentSpanParams<TContext> = {
   handoffs: Handoff<any, any>[];
   tools: Tool<TContext>[];
   currentSpan?: ReturnType<typeof createAgentSpan>;
+  parent?: Span<any> | Trace;
 };
+
+type UsageSnapshot = {
+  requests: number;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  cachedInputTokens: number;
+  cacheWriteInputTokens: number;
+};
+
+export type RunnerSpanLifecycle<TSpanData extends TaskSpanData | TurnSpanData> =
+  {
+    span: Span<TSpanData>;
+    ownedUsage: UsageSnapshot;
+  };
+
+function sumUsageDetail(usage: Usage, key: string): number {
+  return usage.inputTokensDetails.reduce(
+    (total, details) => total + (details[key] ?? 0),
+    0,
+  );
+}
+
+function snapshotUsage(usage: Usage): UsageSnapshot {
+  return {
+    requests: usage.requests,
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    totalTokens: usage.totalTokens,
+    cachedInputTokens:
+      sumUsageDetail(usage, 'cached_tokens') +
+      sumUsageDetail(usage, 'cached_input_tokens'),
+    cacheWriteInputTokens: sumUsageDetail(usage, 'cache_write_tokens'),
+  };
+}
+
+function emptyUsageSnapshot(): UsageSnapshot {
+  return {
+    requests: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    cachedInputTokens: 0,
+    cacheWriteInputTokens: 0,
+  };
+}
+
+function addUsageSnapshot(target: UsageSnapshot, increment: Usage): void {
+  const added = snapshotUsage(increment);
+  target.requests += added.requests;
+  target.inputTokens += added.inputTokens;
+  target.outputTokens += added.outputTokens;
+  target.totalTokens += added.totalTokens;
+  target.cachedInputTokens += added.cachedInputTokens;
+  target.cacheWriteInputTokens += added.cacheWriteInputTokens;
+}
+
+function trackRunnerSpanUsage<TSpanData extends TaskSpanData | TurnSpanData>(
+  span: Span<TSpanData>,
+): RunnerSpanLifecycle<TSpanData> {
+  return { span, ownedUsage: emptyUsageSnapshot() };
+}
+
+export function recordRunnerSpanUsage(
+  lifecycle: RunnerSpanLifecycle<TaskSpanData | TurnSpanData> | undefined,
+  increment: Usage,
+): void {
+  if (lifecycle) {
+    addUsageSnapshot(lifecycle.ownedUsage, increment);
+  }
+}
+
+function hasUsage(usage: UsageSnapshot): boolean {
+  return Object.values(usage).some((value) => value !== 0);
+}
+
+function toTurnUsageData(usage: UsageSnapshot): TurnUsageData {
+  return {
+    input_tokens: usage.inputTokens,
+    output_tokens: usage.outputTokens,
+    cached_input_tokens: usage.cachedInputTokens,
+    cache_write_input_tokens: usage.cacheWriteInputTokens,
+  };
+}
+
+export function startTaskSpan(
+  name: string,
+  parent?: Span<any> | Trace,
+): RunnerSpanLifecycle<TaskSpanData> {
+  const span = createTaskSpan({ data: { name } }, parent);
+  span.start();
+  setCurrentSpan(span);
+  return trackRunnerSpanUsage(span);
+}
+
+function startAgentSpanForInterruptedResume<TContext>(
+  agent: Agent<TContext, any>,
+  restoredSpan?: ReturnType<typeof createAgentSpan>,
+  parent?: Span<any> | Trace,
+): ReturnType<typeof createAgentSpan> {
+  const span = createAgentSpan(
+    {
+      data: {
+        name: agent.name,
+        handoffs: [...(restoredSpan?.spanData.handoffs ?? [])],
+        tools: [...(restoredSpan?.spanData.tools ?? [])],
+        output_type:
+          restoredSpan?.spanData.output_type ?? agent.outputSchemaName,
+      },
+    },
+    parent,
+  );
+  span.start();
+  setCurrentSpan(span);
+  return span;
+}
+
+export function ensureActiveAgentSpanForInterruptedResume<TContext>(options: {
+  agent: Agent<TContext, any>;
+  restoredAgentSpan?: ReturnType<typeof createAgentSpan>;
+  parent?: Span<any> | Trace;
+}): ReturnType<typeof createAgentSpan> {
+  if (options.restoredAgentSpan?.endedAt === null) {
+    setCurrentSpan(options.restoredAgentSpan);
+    return options.restoredAgentSpan;
+  }
+  return startAgentSpanForInterruptedResume(
+    options.agent,
+    options.restoredAgentSpan,
+    options.parent,
+  );
+}
+
+export function startRunnerInvocationSpans<TContext>(options: {
+  name: string;
+  agent: Agent<TContext, any>;
+  restoredAgentSpan?: ReturnType<typeof createAgentSpan>;
+  resumeInterruptedTurn: boolean;
+  parent?: Span<any> | Trace;
+}): {
+  taskSpan: RunnerSpanLifecycle<TaskSpanData>;
+  agentSpan?: ReturnType<typeof createAgentSpan>;
+} {
+  options.restoredAgentSpan?.end();
+  const taskSpan = startTaskSpan(options.name, options.parent);
+  const agentSpan = options.resumeInterruptedTurn
+    ? startAgentSpanForInterruptedResume(
+        options.agent,
+        options.restoredAgentSpan,
+        taskSpan.span,
+      )
+    : undefined;
+  return { taskSpan, agentSpan };
+}
+
+export function startTurnSpan(
+  turn: number,
+  agentName: string,
+  parent?: Span<any> | Trace,
+): RunnerSpanLifecycle<TurnSpanData> {
+  const span = createTurnSpan(
+    { data: { turn, agent_name: agentName } },
+    parent,
+  );
+  span.start();
+  setCurrentSpan(span);
+  return trackRunnerSpanUsage(span);
+}
+
+export function ensureTurnSpan(
+  current: RunnerSpanLifecycle<TurnSpanData> | undefined,
+  turn: number,
+  agentName: string,
+  parent?: Span<any> | Trace,
+): RunnerSpanLifecycle<TurnSpanData> {
+  return current ?? startTurnSpan(turn, agentName, parent);
+}
+
+export function finishRunnerSpan(
+  lifecycle: RunnerSpanLifecycle<TaskSpanData | TurnSpanData> | undefined,
+): void {
+  if (!lifecycle) {
+    return;
+  }
+  if (hasUsage(lifecycle.ownedUsage)) {
+    if (lifecycle.span.spanData.type === 'task') {
+      const taskUsage: TaskUsageData = {
+        ...toTurnUsageData(lifecycle.ownedUsage),
+        requests: lifecycle.ownedUsage.requests,
+        total_tokens: lifecycle.ownedUsage.totalTokens,
+      };
+      lifecycle.span.spanData.usage = taskUsage;
+    } else {
+      lifecycle.span.spanData.usage = toTurnUsageData(lifecycle.ownedUsage);
+    }
+  }
+  lifecycle.span.end();
+  resetCurrentSpan();
+}
+
+export function setRunnerSpanError(
+  lifecycle: RunnerSpanLifecycle<TaskSpanData | TurnSpanData> | undefined,
+  error: unknown,
+): void {
+  lifecycle?.span.setError({
+    message: 'Error in agent run',
+    data: { error: String(error) },
+  });
+}
 
 /**
  * Normalizes tracing configuration into the format expected by model providers.
@@ -112,7 +329,7 @@ export function applyTraceOverrides(
 export function ensureAgentSpan<TContext>(
   params: EnsureAgentSpanParams<TContext>,
 ) {
-  const { agent, handoffs, tools, currentSpan } = params;
+  const { agent, handoffs, tools, currentSpan, parent } = params;
   const existingSpan = currentSpan;
   if (existingSpan) {
     existingSpan.spanData.handoffs = handoffs.map((h) => h.agentName);
@@ -121,14 +338,17 @@ export function ensureAgentSpan<TContext>(
   }
 
   const handoffNames = handoffs.map((h) => h.agentName);
-  const span = createAgentSpan({
-    data: {
-      name: agent.name,
-      handoffs: handoffNames,
-      tools: tools.map((t) => t.name),
-      output_type: agent.outputSchemaName,
+  const span = createAgentSpan(
+    {
+      data: {
+        name: agent.name,
+        handoffs: handoffNames,
+        tools: tools.map((t) => t.name),
+        output_type: agent.outputSchemaName,
+      },
     },
-  });
+    parent,
+  );
   span.start();
   setCurrentSpan(span);
   return span;

--- a/packages/agents-core/src/runner/turnPreparation.ts
+++ b/packages/agents-core/src/runner/turnPreparation.ts
@@ -16,6 +16,7 @@ import {
 } from './guardrails';
 import { prepareModelInputItems } from './items';
 import { ensureAgentSpan } from './tracing';
+import type { Span, Trace } from '../tracing';
 import { getToolCallOutputItem } from './toolExecution';
 import type { ProcessedResponse } from './types';
 
@@ -47,6 +48,8 @@ type PrepareTurnOptions<
     agent: TAgent,
     turnInput: AgentInputItem[],
   ) => void;
+  onAgentSpanReady?: (turn: number, agentName: string) => void;
+  agentSpanParent?: Span<any> | Trace;
 };
 
 export async function prepareTurn<
@@ -64,6 +67,8 @@ export async function prepareTurn<
     inputGuardrailDefs,
     guardrailHandlers,
     emitAgentStart,
+    onAgentSpanReady,
+    agentSpanParent,
   } = options;
 
   const { isResumingFromInterruption } = beginTurn(state, {
@@ -93,8 +98,10 @@ export async function prepareTurn<
       handoffs: [],
       tools: [],
       currentSpan: state._currentAgentSpan,
+      parent: agentSpanParent,
     }),
   );
+  onAgentSpanReady?.(state._currentTurn, state._currentAgent.name);
 
   const { parallelGuardrailPromise } = await runInputGuardrailsForTurn(
     state,

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -36,6 +36,7 @@ import {
   collectInterruptions,
   getToolCallOutputItem,
 } from './toolExecution';
+import { getRunStateTurnSpanParent } from './invocationContext';
 import { handleHostedMcpApprovals } from './mcpApprovals';
 import * as ProviderData from '../types/providerData';
 import * as protocol from '../types/protocol';
@@ -874,8 +875,7 @@ export async function resolveInterruptedTurn<TContext>(
         item.rawItem.id ??
         (
           item.rawItem.providerData as
-            | ProviderData.HostedMCPApprovalRequest
-            | undefined
+            ProviderData.HostedMCPApprovalRequest | undefined
         )?.id;
       if (approvalRequestId) {
         return hostedMcpApprovals.pendingApprovalIds.has(approvalRequestId);
@@ -1066,6 +1066,7 @@ export async function resolveTurnAfterModelResponse<
       processedResponse.handoffs as ToolRunHandoff[],
       runner,
       state._context,
+      getRunStateTurnSpanParent(state) ?? state._currentAgentSpan,
     );
   }
 

--- a/packages/agents-core/src/runner/types.ts
+++ b/packages/agents-core/src/runner/types.ts
@@ -18,6 +18,8 @@ import type { Tool } from '../tool';
 import type { AgentInputItem, UnknownContext } from '../types';
 import type * as protocol from '../types/protocol';
 import type { ModelInputData } from './conversation';
+import type { Span } from '../tracing/spans';
+import type { Trace } from '../tracing/traces';
 
 export type ToolRunHandoff = {
   toolCall: protocol.FunctionCallItem;
@@ -79,7 +81,10 @@ export type PreparedModelCall<TContext = UnknownContext> =
   AgentArtifacts<TContext> & {
     model: Model;
     explicitlyModelSet: boolean;
-    modelRequestInternal: { reasoningEffortImplicit: boolean };
+    modelRequestInternal: {
+      reasoningEffortImplicit: boolean;
+      tracingParent?: Span<any> | Trace;
+    };
     modelSettings: ModelSettings;
     modelInput: ModelInputData;
     prompt?: Prompt;

--- a/packages/agents-core/src/runner/usageTracking.ts
+++ b/packages/agents-core/src/runner/usageTracking.ts
@@ -1,0 +1,69 @@
+import type { Usage } from '../usage';
+
+export type UsageRecorder = (usage: Usage) => void;
+
+const TOOL_USAGE_RECORDER_SYMBOL = Symbol.for(
+  'openai.agents.core.toolUsageRecorder',
+);
+const runnerParentUsageRecorders = new WeakMap<object, UsageRecorder>();
+const runStateUsageRecorders = new WeakMap<object, UsageRecorder>();
+
+export function setRunnerParentUsageRecorder(
+  runner: object,
+  recorder: UsageRecorder | undefined,
+): void {
+  if (recorder) {
+    runnerParentUsageRecorders.set(runner, recorder);
+  } else {
+    runnerParentUsageRecorders.delete(runner);
+  }
+}
+
+export function getRunnerParentUsageRecorder(
+  runner: object,
+): UsageRecorder | undefined {
+  return runnerParentUsageRecorders.get(runner);
+}
+
+export function setRunStateUsageRecorder(
+  state: object,
+  recorder: UsageRecorder,
+): void {
+  runStateUsageRecorders.set(state, recorder);
+}
+
+export function getRunStateUsageRecorder(
+  state: object,
+): UsageRecorder | undefined {
+  return runStateUsageRecorders.get(state);
+}
+
+export function setToolUsageRecorder(
+  details: object,
+  recorder: UsageRecorder | undefined,
+): void {
+  if (!recorder) {
+    return;
+  }
+  Object.defineProperty(details, TOOL_USAGE_RECORDER_SYMBOL, {
+    value: recorder,
+    enumerable: false,
+    configurable: true,
+    writable: false,
+  });
+}
+
+export function getToolUsageRecorder(
+  details: unknown,
+): UsageRecorder | undefined {
+  if (!details || typeof details !== 'object') {
+    return undefined;
+  }
+  return (details as Record<PropertyKey, unknown>)[
+    TOOL_USAGE_RECORDER_SYMBOL
+  ] as UsageRecorder | undefined;
+}
+
+export function recordToolUsage(details: unknown, usage: Usage): void {
+  getToolUsageRecorder(details)?.(usage);
+}

--- a/packages/agents-core/src/sandbox/capabilities/base.ts
+++ b/packages/agents-core/src/sandbox/capabilities/base.ts
@@ -1,15 +1,15 @@
 import type { AgentInputItem } from '../../types';
 import type { Model } from '../../model';
-import type { Tool } from '../../tool';
+import type { Tool, ToolCallDetails } from '../../tool';
+import { getToolCallParentSpanFromDetails } from '../../agentToolRunConfig';
+import type { Span, Trace } from '../../tracing';
 import { SandboxConfigurationError } from '../errors';
 import type { Manifest } from '../manifest';
 import type { SandboxSessionLike } from '../session';
 import type { SandboxUser } from '../users';
 
 export type CapabilityInstructionsResult =
-  | string
-  | null
-  | Promise<string | null>;
+  string | null | Promise<string | null>;
 
 export abstract class Capability {
   abstract readonly type: string;
@@ -17,12 +17,18 @@ export abstract class Capability {
   protected _session?: SandboxSessionLike;
   protected _runAs?: string;
   protected _modelInstance?: Model;
+  protected _tracingParent?: Span<any> | Trace;
 
   clone(): this {
     const cloned = Object.create(Object.getPrototypeOf(this)) as this;
 
     for (const [key, value] of Object.entries(this)) {
-      if (key === '_session' || key === '_runAs' || key === '_modelInstance') {
+      if (
+        key === '_session' ||
+        key === '_runAs' ||
+        key === '_modelInstance' ||
+        key === '_tracingParent'
+      ) {
         continue;
       }
       (cloned as Record<string, unknown>)[key] = cloneCapabilityValue(value);
@@ -44,6 +50,17 @@ export abstract class Capability {
   bindModel(_model: string, modelInstance?: Model): this {
     this._modelInstance = modelInstance;
     return this;
+  }
+
+  bindTracingParent(parent?: Span<any> | Trace): this {
+    this._tracingParent = parent;
+    return this;
+  }
+
+  protected tracingParent(
+    details?: ToolCallDetails,
+  ): Span<any> | Trace | undefined {
+    return getToolCallParentSpanFromDetails(details) ?? this._tracingParent;
   }
 
   requiredCapabilityTypes(): Set<string> {

--- a/packages/agents-core/src/sandbox/capabilities/filesystem.ts
+++ b/packages/agents-core/src/sandbox/capabilities/filesystem.ts
@@ -15,6 +15,7 @@ import type {
 import { ApplyPatchOperation } from '../../types/protocol';
 import { encodeUint8ArrayToBase64 } from '../../utils/base64';
 import type { ViewImageArgs } from '../session';
+import type { ToolCallDetails } from '../../tool';
 import { withSandboxSpan } from '../runtime/spans';
 import { isRecord } from '../shared/typeGuards';
 import {
@@ -534,7 +535,10 @@ class FilesystemCapability extends Capability {
     }
 
     const tools: Tool<any>[] = [];
-    const viewImage = async (path: string): Promise<ViewImageToolResult> => {
+    const viewImage = async (
+      path: string,
+      details?: ToolCallDetails,
+    ): Promise<ViewImageToolResult> => {
       if (!session.viewImage) {
         throw new UserError(
           'Filesystem sandbox sessions must provide viewImage().',
@@ -552,6 +556,7 @@ class FilesystemCapability extends Capability {
               path,
               runAs: this._runAs,
             } satisfies ViewImageArgs),
+          this.tracingParent(details),
         );
       } catch (error) {
         return renderViewImageError(path, error);
@@ -567,11 +572,11 @@ class FilesystemCapability extends Capability {
           parameters: z.object({
             path: z.string().describe('Local filesystem path to an image file'),
           }),
-          execute: async ({
-            path,
-          }: {
-            path: string;
-          }): Promise<ViewImageToolResult> => await viewImage(path),
+          execute: async (
+            { path }: { path: string },
+            _context,
+            details?: ToolCallDetails,
+          ): Promise<ViewImageToolResult> => await viewImage(path, details),
         }),
       );
     } else {
@@ -583,8 +588,12 @@ class FilesystemCapability extends Capability {
           parameters: z.object({
             path: z.string().describe('Local filesystem path to an image file'),
           }),
-          execute: async ({ path }: { path: string }): Promise<string> =>
-            renderImageForTextTransport(await viewImage(path)),
+          execute: async (
+            { path }: { path: string },
+            _context,
+            details?: ToolCallDetails,
+          ): Promise<string> =>
+            renderImageForTextTransport(await viewImage(path, details)),
         }),
       );
     }

--- a/packages/agents-core/src/sandbox/capabilities/memory.ts
+++ b/packages/agents-core/src/sandbox/capabilities/memory.ts
@@ -1,5 +1,6 @@
 import { UserError } from '../../errors';
 import type { Model, ModelSettings } from '../../model';
+import type { Span, Trace } from '../../tracing';
 import { dir } from '../entries';
 import { normalizeRelativePath, type Manifest } from '../manifest';
 import { withSandboxSpan } from '../runtime/spans';
@@ -114,6 +115,7 @@ class MemoryCapability extends Capability {
         session,
         runAs: this._runAs,
         store: this.store,
+        tracingParent: this._tracingParent,
       }).hydrateFromStore(this.layout.memoriesDir);
     }
     const memorySummary = await this.readMemorySummary(session);
@@ -154,6 +156,7 @@ class MemoryCapability extends Capability {
               runAs: this._runAs,
               maxBytes: MEMORY_SUMMARY_MAX_BYTES,
             } satisfies ReadFileArgs),
+          this._tracingParent,
         );
         return normalizeMemorySummaryPayload(payload);
       } catch (error) {
@@ -174,6 +177,7 @@ class MemoryCapability extends Capability {
         session,
         path,
         runAs: this._runAs,
+        tracingParent: this._tracingParent,
       });
     }
 
@@ -375,6 +379,7 @@ async function readMemorySummaryWithShell(args: {
   session: SandboxSessionLike;
   path: string;
   runAs?: string;
+  tracingParent?: Span<any> | Trace;
 }): Promise<string | null> {
   const command = [
     `if [ -f ${shellQuote(args.path)} ]; then`,
@@ -397,6 +402,7 @@ async function readMemorySummaryWithShell(args: {
         maxOutputTokens: 20_000,
         runAs: args.runAs,
       } satisfies ExecCommandArgs),
+    args.tracingParent,
   );
 
   const begin = output.indexOf(MEMORY_BEGIN_MARKER);

--- a/packages/agents-core/src/sandbox/capabilities/shell.ts
+++ b/packages/agents-core/src/sandbox/capabilities/shell.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { UserError } from '../../errors';
-import { tool, type Tool } from '../../tool';
+import { tool, type Tool, type ToolCallDetails } from '../../tool';
 import type { ExecCommandArgs, WriteStdinArgs } from '../session';
 import { withSandboxSpan } from '../runtime/spans';
 import {
@@ -88,23 +88,27 @@ class ShellCapability extends Capability {
               'Maximum number of tokens to return. Excess output will be truncated.',
             ),
         }),
-        execute: async ({
-          cmd,
-          workdir,
-          shell,
-          login,
-          tty,
-          yield_time_ms,
-          max_output_tokens,
-        }: {
-          cmd: string;
-          workdir?: string;
-          shell?: string;
-          login: boolean;
-          tty: boolean;
-          yield_time_ms: number;
-          max_output_tokens?: number;
-        }): Promise<string> =>
+        execute: async (
+          {
+            cmd,
+            workdir,
+            shell,
+            login,
+            tty,
+            yield_time_ms,
+            max_output_tokens,
+          }: {
+            cmd: string;
+            workdir?: string;
+            shell?: string;
+            login: boolean;
+            tty: boolean;
+            yield_time_ms: number;
+            max_output_tokens?: number;
+          },
+          _context,
+          details?: ToolCallDetails,
+        ): Promise<string> =>
           await withSandboxSpan(
             'sandbox.exec',
             {
@@ -126,6 +130,7 @@ class ShellCapability extends Capability {
                 maxOutputTokens: max_output_tokens,
                 runAs: this._runAs,
               } satisfies ExecCommandArgs),
+            this.tracingParent(details),
           ),
       }),
     ];
@@ -162,17 +167,21 @@ class ShellCapability extends Capability {
                 'Maximum number of tokens to return. Excess output will be truncated.',
               ),
           }),
-          execute: async ({
-            session_id,
-            chars,
-            yield_time_ms,
-            max_output_tokens,
-          }: {
-            session_id: number;
-            chars: string;
-            yield_time_ms: number;
-            max_output_tokens?: number;
-          }): Promise<string> =>
+          execute: async (
+            {
+              session_id,
+              chars,
+              yield_time_ms,
+              max_output_tokens,
+            }: {
+              session_id: number;
+              chars: string;
+              yield_time_ms: number;
+              max_output_tokens?: number;
+            },
+            _context,
+            details?: ToolCallDetails,
+          ): Promise<string> =>
             await withSandboxSpan(
               'sandbox.write_stdin',
               {
@@ -185,6 +194,7 @@ class ShellCapability extends Capability {
                   yieldTimeMs: yield_time_ms,
                   maxOutputTokens: max_output_tokens,
                 } satisfies WriteStdinArgs),
+              this.tracingParent(details),
             ),
         }),
       );

--- a/packages/agents-core/src/sandbox/memory/generation.ts
+++ b/packages/agents-core/src/sandbox/memory/generation.ts
@@ -5,6 +5,7 @@ import { UserError } from '../../errors';
 import logger from '../../logger';
 import type { RunState } from '../../runState';
 import type { AgentInputItem } from '../../types';
+import type { Span, Trace } from '../../tracing';
 import { Manifest } from '../manifest';
 import { registerSandboxPreStopHook } from '../runtime/sessionLifecycle';
 import { withSandboxSpan } from '../runtime/spans';
@@ -73,6 +74,7 @@ export function getOrCreateSandboxMemoryGenerationManager(args: {
   memory: Memory;
   runAs?: string;
   runAgent: SandboxMemoryAgentRunner;
+  tracingParent?: Span<any> | Trace;
 }): SandboxMemoryGenerationManager {
   if (args.memory.generate === null) {
     throw new UserError(
@@ -101,6 +103,7 @@ export function getOrCreateSandboxMemoryGenerationManager(args: {
       existing.manager.updateRuntimeContext({
         runAs: args.runAs,
         runAgent: args.runAgent,
+        tracingParent: args.tracingParent,
       });
       return existing.manager;
     }
@@ -138,6 +141,7 @@ export class SandboxMemoryGenerationManager {
   private readonly memory: Memory;
   private runAs?: string;
   private runAgent: SandboxMemoryAgentRunner;
+  private tracingParent?: Span<any> | Trace;
   private readonly storage: SandboxMemoryStorage;
   private readonly pendingRolloutIds = new Set<string>();
   private flushPromise?: Promise<void>;
@@ -149,15 +153,18 @@ export class SandboxMemoryGenerationManager {
     memory: Memory;
     runAs?: string;
     runAgent: SandboxMemoryAgentRunner;
+    tracingParent?: Span<any> | Trace;
   }) {
     this.session = args.session;
     this.memory = args.memory;
     this.runAs = args.runAs;
     this.runAgent = args.runAgent;
+    this.tracingParent = args.tracingParent;
     this.storage = new SandboxMemoryStorage({
       session: args.session,
       runAs: args.runAs,
       store: args.memory.store,
+      tracingParent: args.tracingParent,
     });
     this.unregisterPreStopHook = registerSandboxPreStopHook(
       this.session,
@@ -174,10 +181,15 @@ export class SandboxMemoryGenerationManager {
   updateRuntimeContext(args: {
     runAs?: string;
     runAgent: SandboxMemoryAgentRunner;
+    tracingParent?: Span<any> | Trace;
   }): void {
     this.runAs = args.runAs;
     this.runAgent = args.runAgent;
-    this.storage.updateRuntimeContext({ runAs: args.runAs });
+    this.tracingParent = args.tracingParent;
+    this.storage.updateRuntimeContext({
+      runAs: args.runAs,
+      tracingParent: args.tracingParent,
+    });
   }
 
   async enqueueState<TContext>(
@@ -218,6 +230,7 @@ export class SandboxMemoryGenerationManager {
         );
         this.pendingRolloutIds.add(rolloutId);
       },
+      this.tracingParent,
     );
   }
 
@@ -276,6 +289,7 @@ export class SandboxMemoryGenerationManager {
             }
           }
         },
+        this.tracingParent,
       );
     } finally {
       this.pendingRolloutIds.clear();

--- a/packages/agents-core/src/sandbox/memory/storage.ts
+++ b/packages/agents-core/src/sandbox/memory/storage.ts
@@ -1,4 +1,5 @@
 import { UserError } from '../../errors';
+import type { Span, Trace } from '../../tracing';
 import { dir, file } from '../entries';
 import { normalizeRelativePath } from '../manifest';
 import { withSandboxSpan } from '../runtime/spans';
@@ -69,19 +70,26 @@ export class SandboxMemoryStorage {
   private runAs?: string;
   private readonly store?: MemoryStore;
   private readonly appendQueues = new Map<string, Promise<void>>();
+  private tracingParent?: Span<any> | Trace;
 
   constructor(args: {
     session: SandboxSessionLike<SandboxSessionState>;
     runAs?: string;
     store?: MemoryStore;
+    tracingParent?: Span<any> | Trace;
   }) {
     this.session = args.session;
     this.runAs = args.runAs;
     this.store = args.store;
+    this.tracingParent = args.tracingParent;
   }
 
-  updateRuntimeContext(args: { runAs?: string }): void {
+  updateRuntimeContext(args: {
+    runAs?: string;
+    tracingParent?: Span<any> | Trace;
+  }): void {
     this.runAs = args.runAs;
+    this.tracingParent = args.tracingParent;
   }
 
   async ensureLayout(memory: Memory): Promise<void> {
@@ -139,6 +147,7 @@ export class SandboxMemoryStorage {
               runAs: this.runAs,
               maxBytes: MEMORY_TEXT_MAX_BYTES,
             } satisfies ReadFileArgs),
+          this.tracingParent,
         );
         return decodeText(payload);
       } catch (error) {
@@ -190,6 +199,7 @@ export class SandboxMemoryStorage {
               path: normalizedPath,
               runAs: this.runAs,
             } satisfies ReadFileArgs),
+          this.tracingParent,
         );
         return decodeText(payload);
       } catch (error) {
@@ -253,6 +263,7 @@ export class SandboxMemoryStorage {
           entry: file({ content }),
           runAs: this.runAs,
         } satisfies MaterializeEntryArgs),
+      this.tracingParent,
     );
     await this.store?.write(normalizedPath, payload);
   }
@@ -484,6 +495,7 @@ export class SandboxMemoryStorage {
               : Math.ceil((options.maxBytes + 4096) / 4),
           runAs: this.runAs,
         } satisfies ExecCommandArgs),
+      this.tracingParent,
     );
 
     const begin = output.indexOf(MEMORY_READ_BEGIN_MARKER);
@@ -548,6 +560,7 @@ export class SandboxMemoryStorage {
           maxOutputTokens: 20_000,
           runAs: this.runAs,
         } satisfies ExecCommandArgs),
+      this.tracingParent,
     );
     if (!execOutputSucceeded(output) || execOutputWasTruncated(output)) {
       throw new UserError(

--- a/packages/agents-core/src/sandbox/runtime/agentPreparation.ts
+++ b/packages/agents-core/src/sandbox/runtime/agentPreparation.ts
@@ -8,6 +8,7 @@ import type { Capability } from '../capabilities';
 import type { SandboxAgent } from '../agent';
 import { cloneManifest, Manifest } from '../manifest';
 import type { SandboxSessionLike, SandboxSessionState } from '../session';
+import type { Span, Trace } from '../../tracing';
 import {
   getDefaultSandboxInstructions,
   renderFilesystemInstructions,
@@ -24,6 +25,7 @@ type PrepareSandboxAgentArgs<TContext, TOutput extends AgentOutputType> = {
   capabilities?: Capability[];
   runConfigModel?: SandboxRuntimeModel;
   processManifest?: boolean;
+  tracingParent?: Span<any> | Trace;
 };
 
 export type ResolvedSandboxRuntimeModel = {
@@ -45,6 +47,7 @@ export function prepareSandboxAgent<TContext, TOutput extends AgentOutputType>({
   capabilities,
   runConfigModel,
   processManifest = true,
+  tracingParent,
 }: PrepareSandboxAgentArgs<TContext, TOutput>): SandboxAgent<
   TContext,
   TOutput
@@ -59,7 +62,8 @@ export function prepareSandboxAgent<TContext, TOutput extends AgentOutputType>({
     capability
       .bind(session)
       .bindRunAs(agent.runAs)
-      .bindModel(resolvedModel, resolvedModelInstance),
+      .bindModel(resolvedModel, resolvedModelInstance)
+      .bindTracingParent(tracingParent),
   );
   const boundCapabilityTypes = new Set(
     boundCapabilities.map((capability) => capability.type),

--- a/packages/agents-core/src/sandbox/runtime/manager.ts
+++ b/packages/agents-core/src/sandbox/runtime/manager.ts
@@ -3,6 +3,7 @@ import logger from '../../logger';
 import { UserError } from '../../errors';
 import type { RunState } from '../../runState';
 import type { AgentInputItem } from '../../types';
+import type { Span, Trace } from '../../tracing';
 import type { SandboxAgent } from '../agent';
 import type { Memory } from '../capabilities/memory';
 import { isMemoryCapability } from '../capabilities/memory';
@@ -131,8 +132,9 @@ export class SandboxRuntimeManager<TContext> {
     currentAgent: Agent<TContext, AgentOutputType>;
     turnInput: AgentInputItem[];
     runConfigModel?: SandboxRuntimeModel;
+    tracingParent?: Span<any> | Trace;
   }): Promise<SandboxPreparedAgent<TContext>> {
-    const { currentAgent, turnInput, runConfigModel } = args;
+    const { currentAgent, turnInput, runConfigModel, tracingParent } = args;
     if (!isSandboxAgent(currentAgent)) {
       this.activeMemory = undefined;
       return {
@@ -152,15 +154,16 @@ export class SandboxRuntimeManager<TContext> {
       {
         agent_name: currentAgent.name,
       },
-      async () => {
+      async (prepareSpan) => {
         this.acquireAgent(currentAgent);
-        const session = await this.ensureSession(currentAgent);
+        const session = await this.ensureSession(currentAgent, prepareSpan);
         // Bind a clone to the live session so capability tools and instructions can carry
         // per-session state without mutating the public SandboxAgent instance.
         const executionAgent = this.getPreparedAgent(
           currentAgent,
           session,
           runConfigModel,
+          tracingParent,
         );
         const memory = executionAgent.capabilities.find(isMemoryCapability);
         if (memory) {
@@ -181,6 +184,7 @@ export class SandboxRuntimeManager<TContext> {
           ),
         };
       },
+      tracingParent,
     );
   }
 
@@ -188,20 +192,24 @@ export class SandboxRuntimeManager<TContext> {
     state: RunState<TContext, Agent<TContext, AgentOutputType>>,
     options: {
       preserveOwnedSessions?: boolean;
+      tracingParent?: Span<any> | Trace;
     } = {},
   ): Promise<void> {
     const preserveOwnedSessions = options.preserveOwnedSessions ?? false;
-    const runCleanup = async () => {
+    const runCleanup = async (cleanupSpan?: Span<any> | Trace) => {
       let preserveCleanupHandles = false;
       try {
-        const cleanupPlan = await this.planCleanup(state, {
-          preserveOwnedSessions,
-        });
+        const cleanupPlan = await this.planCleanup(
+          state,
+          { preserveOwnedSessions },
+          cleanupSpan,
+        );
         await this.executeCleanupPlan(state, cleanupPlan, {
           onCloseError: () => {
             preserveCleanupHandles = true;
           },
           preserveOwnedSessions,
+          tracingParent: cleanupSpan,
         });
       } finally {
         this.releaseAgents();
@@ -224,11 +232,16 @@ export class SandboxRuntimeManager<TContext> {
       this.preparedAgents.size === 0 &&
       this.ownedSessionAgentKeys.size === 0
     ) {
-      await runCleanup();
+      await runCleanup(options.tracingParent);
       return;
     }
 
-    await withSandboxSpan('sandbox.cleanup', {}, runCleanup);
+    await withSandboxSpan(
+      'sandbox.cleanup',
+      {},
+      runCleanup,
+      options.tracingParent,
+    );
   }
 
   private async planCleanup(
@@ -236,11 +249,16 @@ export class SandboxRuntimeManager<TContext> {
     options: {
       preserveOwnedSessions: boolean;
     },
+    tracingParent?: Span<any> | Trace,
   ): Promise<SandboxCleanupPlan> {
     if (this.sessionsByAgentKey.size > 0) {
       return await this.planCleanupForActiveSessions(state, options);
     }
-    return await this.planCleanupForSerializedStateOnly(state, options);
+    return await this.planCleanupForSerializedStateOnly(
+      state,
+      options,
+      tracingParent,
+    );
   }
 
   private async planCleanupForActiveSessions(
@@ -306,6 +324,7 @@ export class SandboxRuntimeManager<TContext> {
     options: {
       preserveOwnedSessions: boolean;
     },
+    tracingParent?: Span<any> | Trace,
   ): Promise<SandboxCleanupPlan> {
     const cleanupPlan: SandboxCleanupPlan = options.preserveOwnedSessions
       ? {}
@@ -340,7 +359,7 @@ export class SandboxRuntimeManager<TContext> {
       if (hasPreservedOwnedSessions(sandboxState)) {
         if (this.sandboxConfig?.client) {
           try {
-            await this.adoptPreservedOwnedSessions();
+            await this.adoptPreservedOwnedSessions(tracingParent);
             if (this.ownedSessionAgentKeys.size > 0) {
               cleanupPlan.ownedSessionCloseTarget = 'all';
               cleanupPlan.afterOwnedSessionClose = {
@@ -377,6 +396,7 @@ export class SandboxRuntimeManager<TContext> {
     options: {
       onCloseError: () => void;
       preserveOwnedSessions: boolean;
+      tracingParent?: Span<any> | Trace;
     },
   ): Promise<void> {
     if (plan.ownedSessionCloseTarget) {
@@ -387,6 +407,7 @@ export class SandboxRuntimeManager<TContext> {
             : plan.ownedSessionCloseTarget,
           {
             preserveOwnedSessions: options.preserveOwnedSessions,
+            tracingParent: options.tracingParent,
           },
         );
       } catch (error) {
@@ -482,6 +503,7 @@ export class SandboxRuntimeManager<TContext> {
       inputOverride?: string | AgentInputItem[];
       sdkSessionId?: () => Promise<string | undefined>;
       runAgent: SandboxMemoryAgentRunner;
+      tracingParent?: Span<any> | Trace;
     },
   ): Promise<void> {
     if (!this.activeMemory || this.activeMemory.memory.generate === null) {
@@ -494,6 +516,7 @@ export class SandboxRuntimeManager<TContext> {
         memory: this.activeMemory.memory,
         runAs: this.activeMemory.runAs,
         runAgent: args.runAgent,
+        tracingParent: args.tracingParent,
       });
       await manager.enqueueState(state, {
         exception: args.exception,
@@ -509,7 +532,9 @@ export class SandboxRuntimeManager<TContext> {
     }
   }
 
-  async adoptPreservedOwnedSessions(): Promise<boolean> {
+  async adoptPreservedOwnedSessions(
+    tracingParent?: Span<any> | Trace,
+  ): Promise<boolean> {
     const sandboxState = getSerializedSandboxState(this.runState);
     if (!hasPreservedOwnedSessions(sandboxState)) {
       return false;
@@ -572,6 +597,7 @@ export class SandboxRuntimeManager<TContext> {
           await client.resume!(serializedState, {
             archiveLimits: this.sandboxConfig?.archiveLimits,
           }),
+        tracingParent,
       );
       this.applyArchiveLimits(session);
       this.sessionsByAgentKey.set(agentKey, session);
@@ -593,6 +619,7 @@ export class SandboxRuntimeManager<TContext> {
 
   private async ensureSession(
     agent: SandboxAgent<TContext, AgentOutputType>,
+    tracingParent?: Span<any> | Trace,
   ): Promise<SandboxSessionLike<SandboxSessionState>> {
     const agentId = getObjectId(agent);
     const agentKey = this.agentKey(agent);
@@ -606,6 +633,7 @@ export class SandboxRuntimeManager<TContext> {
       this.applyArchiveLimits(existingByKey);
       await this.ensureSessionStarted(existingByKey, agent, 'resume', {
         oncePerSession: true,
+        tracingParent,
       });
       this.currentAgentId = agentId;
       this.sessionsByAgent.set(agentId, existingByKey);
@@ -628,6 +656,7 @@ export class SandboxRuntimeManager<TContext> {
       );
       await this.ensureSessionStarted(session, agent, 'provided', {
         oncePerSession: true,
+        tracingParent,
       });
       this.registerSessionForAgent(agent, session);
       return session;
@@ -636,10 +665,16 @@ export class SandboxRuntimeManager<TContext> {
     const configuredManifest = this.resolveConfiguredManifest(agent);
 
     const client = this.requireClient();
-    const resumed = await this.resumeSessionForAgent(client, agent);
+    const resumed = await this.resumeSessionForAgent(
+      client,
+      agent,
+      tracingParent,
+    );
     if (resumed) {
       this.applyArchiveLimits(resumed);
-      await this.ensureSessionStarted(resumed, agent, 'resume');
+      await this.ensureSessionStarted(resumed, agent, 'resume', {
+        tracingParent,
+      });
       this.registerSessionForAgent(agent, resumed, { owned: true });
       return resumed;
     }
@@ -667,9 +702,12 @@ export class SandboxRuntimeManager<TContext> {
         backend_id: client.backendId,
       },
       async () => await createSession(createArgs),
+      tracingParent,
     );
     this.applyArchiveLimits(session);
-    await this.ensureSessionStarted(session, agent, 'create');
+    await this.ensureSessionStarted(session, agent, 'create', {
+      tracingParent,
+    });
     this.registerSessionForAgent(agent, session, { owned: true });
     return session;
   }
@@ -707,6 +745,7 @@ export class SandboxRuntimeManager<TContext> {
     reason: string,
     options: {
       oncePerSession?: boolean;
+      tracingParent?: Span<any> | Trace;
     } = {},
   ): Promise<void> {
     if (!session.start) {
@@ -736,6 +775,7 @@ export class SandboxRuntimeManager<TContext> {
       async () => {
         await session.start!({ reason });
       },
+      options.tracingParent,
     );
     if (options.oncePerSession) {
       this.sessionStartPromises.set(session, startPromise);
@@ -754,6 +794,7 @@ export class SandboxRuntimeManager<TContext> {
     agent: SandboxAgent<TContext, AgentOutputType>,
     session: SandboxSessionLike<SandboxSessionState>,
     runConfigModel?: SandboxRuntimeModel,
+    tracingParent?: Span<any> | Trace,
   ): SandboxAgent<TContext, AgentOutputType> {
     const agentId = getObjectId(agent);
     const manifestSignature = getManifestSignature(session.state.manifest);
@@ -763,7 +804,14 @@ export class SandboxRuntimeManager<TContext> {
       this.preparedSessions.get(agentId) === session &&
       this.preparedManifestSignatures.get(agentId) === manifestSignature
     ) {
-      return cached as SandboxAgent<TContext, AgentOutputType>;
+      const cachedSandboxAgent = cached as SandboxAgent<
+        TContext,
+        AgentOutputType
+      >;
+      for (const capability of cachedSandboxAgent.capabilities) {
+        capability.bindTracingParent(tracingParent);
+      }
+      return cachedSandboxAgent;
     }
 
     // Capability instructions include a rendered filesystem view, so a manifest change
@@ -774,6 +822,7 @@ export class SandboxRuntimeManager<TContext> {
       capabilities: cloneSandboxCapabilities(agent.capabilities),
       runConfigModel,
       processManifest: false,
+      tracingParent,
     });
     this.preparedAgents.set(agentId, prepared);
     this.preparedSessions.set(agentId, session);
@@ -784,6 +833,7 @@ export class SandboxRuntimeManager<TContext> {
   private async resumeSessionForAgent(
     client: SandboxClient,
     agent: SandboxAgent<TContext, AgentOutputType>,
+    tracingParent?: Span<any> | Trace,
   ): Promise<SandboxSessionLike<SandboxSessionState> | undefined> {
     const agentKey = this.agentKey(agent);
     const serializedEntry = getSerializedSessionEntryForAgent(
@@ -819,6 +869,7 @@ export class SandboxRuntimeManager<TContext> {
           await client.resume!(this.sandboxConfig!.sessionState!, {
             archiveLimits: this.sandboxConfig?.archiveLimits,
           }),
+        tracingParent,
       );
     }
 
@@ -840,6 +891,7 @@ export class SandboxRuntimeManager<TContext> {
         await client.resume!(serializedState, {
           archiveLimits: this.sandboxConfig?.archiveLimits,
         }),
+      tracingParent,
     );
   }
 
@@ -945,6 +997,7 @@ export class SandboxRuntimeManager<TContext> {
     agentKeys?: Iterable<string>,
     options: {
       preserveOwnedSessions?: boolean;
+      tracingParent?: Span<any> | Trace;
     } = {},
   ): Promise<void> {
     const keysToClose = [...(agentKeys ?? this.ownedSessionAgentKeys)].filter(
@@ -972,7 +1025,7 @@ export class SandboxRuntimeManager<TContext> {
       {
         session_count: sessionsToClose.size,
       },
-      async () => {
+      async (cleanupSessionsSpan) => {
         await Promise.all(
           [...sessionsToClose].map(async ([session, agentName]) => {
             await withSandboxSpan(
@@ -988,10 +1041,12 @@ export class SandboxRuntimeManager<TContext> {
                     : undefined,
                 );
               },
+              cleanupSessionsSpan,
             );
           }),
         );
       },
+      options.tracingParent,
     );
   }
 

--- a/packages/agents-core/src/sandbox/runtime/spans.ts
+++ b/packages/agents-core/src/sandbox/runtime/spans.ts
@@ -1,4 +1,9 @@
-import { getCurrentTrace, withCustomSpan } from '../../tracing';
+import {
+  getCurrentTrace,
+  Trace,
+  withCustomSpan,
+  withTraceContext,
+} from '../../tracing';
 import type { Span } from '../../tracing';
 import type { CustomSpanData } from '../../tracing/spans';
 import { emitSandboxEvent, serializeSandboxEventError } from '../events';
@@ -6,7 +11,8 @@ import { emitSandboxEvent, serializeSandboxEventError } from '../events';
 export async function withSandboxSpan<T>(
   name: string,
   data: Record<string, unknown>,
-  fn: () => Promise<T>,
+  fn: (span?: Span<CustomSpanData>) => Promise<T>,
+  parent?: Span<any> | Trace,
 ): Promise<T> {
   const startedAt = Date.now();
   await emitSandboxEvent({
@@ -19,7 +25,7 @@ export async function withSandboxSpan<T>(
 
   const runWithEvents = async (span?: Span<CustomSpanData>): Promise<T> => {
     try {
-      const result = await fn();
+      const result = await fn(span);
       await emitSandboxEvent({
         type: 'sandbox_operation',
         name,
@@ -45,16 +51,42 @@ export async function withSandboxSpan<T>(
     }
   };
 
-  if (!getCurrentTrace()) {
+  if (!getCurrentTrace() && !parent) {
     return await runWithEvents();
   }
 
-  return await withCustomSpan(async (span) => await runWithEvents(span), {
-    data: {
-      name,
-      data,
-    },
-  });
+  const runWithSpan = async () =>
+    await withCustomSpan(
+      async (span) => await runWithEvents(span),
+      {
+        data: {
+          name,
+          data,
+        },
+      },
+      parent,
+    );
+
+  if (!getCurrentTrace() && parent) {
+    const trace =
+      parent instanceof Trace
+        ? parent
+        : new Trace({
+            traceId: parent.traceId,
+            name: 'Agent workflow',
+            metadata: parent.traceMetadata,
+            tracingApiKey: parent.tracingApiKey,
+          });
+    return await withTraceContext(
+      {
+        trace,
+        span: parent instanceof Trace ? undefined : parent,
+      },
+      runWithSpan,
+    );
+  }
+
+  return await runWithSpan();
 }
 
 function recordSandboxSpanError(

--- a/packages/agents-core/src/tracing/config.ts
+++ b/packages/agents-core/src/tracing/config.ts
@@ -1,3 +1,35 @@
 export type TracingConfig = {
   apiKey?: string;
+  /**
+   * Whether runner-created task and turn spans are included in traces.
+   *
+   * Defaults to `true`. Set to `false` to keep the existing agent, model,
+   * tool, guardrail, and handoff spans without the additional task/turn
+   * hierarchy.
+   */
+  includeTaskAndTurnSpans?: boolean;
 };
+
+export function includeTaskAndTurnSpans(
+  config: TracingConfig | undefined,
+): boolean {
+  return config?.includeTaskAndTurnSpans ?? true;
+}
+
+export function mergeTracingConfig(
+  ...configs: (TracingConfig | undefined)[]
+): TracingConfig | undefined {
+  if (configs.every((config) => config === undefined)) {
+    return undefined;
+  }
+
+  const merged: Record<string, unknown> = {};
+  for (const config of configs) {
+    for (const [key, value] of Object.entries(config ?? {})) {
+      if (value !== undefined) {
+        merged[key] = value;
+      }
+    }
+  }
+  return merged as TracingConfig;
+}

--- a/packages/agents-core/src/tracing/createSpans.ts
+++ b/packages/agents-core/src/tracing/createSpans.ts
@@ -1,4 +1,5 @@
 import { DeepPartial } from '../types';
+import { StreamedRunResult } from '../result';
 import {
   resetCurrentSpan,
   setCurrentSpan,
@@ -10,6 +11,8 @@ import {
   ResponseSpanData,
   SpanData,
   AgentSpanData,
+  TaskSpanData,
+  TurnSpanData,
   FunctionSpanData,
   HandoffSpanData,
   GenerationSpanData,
@@ -24,6 +27,20 @@ import { Trace } from './traces';
 
 type CreateArgs<TData extends SpanData> = DeepPartial<CreateSpanOptions<TData>>;
 
+function setSpanError(span: Span<any>, error: unknown): void {
+  const errorRecord =
+    typeof error === 'object' && error !== null
+      ? (error as { message?: unknown; data?: Record<string, any> })
+      : undefined;
+  span.setError({
+    message:
+      typeof errorRecord?.message === 'string'
+        ? errorRecord.message
+        : String(error),
+    data: errorRecord?.data,
+  });
+}
+
 function _withSpanFactory<
   TData extends SpanData,
   TCreateSpanFunction extends (...args: any[]) => Span<TData>,
@@ -36,18 +53,38 @@ function _withSpanFactory<
     return withNewSpanContext(async () => {
       const span = createSpan(...args);
       setCurrentSpan(span);
+      let endDeferred = false;
       try {
         span.start();
-        return await fn(span);
-      } catch (error: any) {
-        span.setError({
-          message: error.message,
-          data: error.data,
-        });
+        const result = await fn(span);
+        if (result instanceof StreamedRunResult) {
+          const streamLoopPromise = result._getStreamLoopPromise();
+          if (streamLoopPromise) {
+            endDeferred = true;
+            resetCurrentSpan();
+            void streamLoopPromise.then(
+              () => {
+                if (result.error !== null && result.error !== undefined) {
+                  setSpanError(span, result.error);
+                }
+                span.end();
+              },
+              (error) => {
+                setSpanError(span, error);
+                span.end();
+              },
+            );
+          }
+        }
+        return result;
+      } catch (error: unknown) {
+        setSpanError(span, error);
         throw error;
       } finally {
-        span.end();
-        resetCurrentSpan();
+        if (!endDeferred) {
+          span.end();
+          resetCurrentSpan();
+        }
       }
     });
   };
@@ -130,6 +167,61 @@ export const withAgentSpan = _withSpanFactory<
   AgentSpanData,
   typeof createAgentSpan
 >(createAgentSpan);
+
+/**
+ * Create a new task span. A task represents one top-level Runner invocation.
+ * The span will not be started automatically.
+ */
+export function createTaskSpan(
+  options?: CreateArgs<TaskSpanData>,
+  parent?: Span<any> | Trace,
+): Span<TaskSpanData> {
+  return getGlobalTraceProvider().createSpan(
+    {
+      ...options,
+      data: {
+        type: 'task',
+        name: options?.data?.name ?? 'Agent workflow',
+        ...options?.data,
+      },
+    },
+    parent,
+  );
+}
+
+/** Create a task span and automatically start and end it. */
+export const withTaskSpan = _withSpanFactory<
+  TaskSpanData,
+  typeof createTaskSpan
+>(createTaskSpan);
+
+/**
+ * Create a new turn span. A turn represents one agent loop iteration.
+ * The span will not be started automatically.
+ */
+export function createTurnSpan(
+  options: CreateArgs<TurnSpanData> & {
+    data: { turn: number; agent_name: string };
+  },
+  parent?: Span<any> | Trace,
+): Span<TurnSpanData> {
+  return getGlobalTraceProvider().createSpan(
+    {
+      ...options,
+      data: {
+        type: 'turn',
+        ...options.data,
+      },
+    },
+    parent,
+  );
+}
+
+/** Create a turn span and automatically start and end it. */
+export const withTurnSpan = _withSpanFactory<
+  TurnSpanData,
+  typeof createTurnSpan
+>(createTurnSpan);
 
 /**
  * Create a new function span. The span will not be started automatically, you should either

--- a/packages/agents-core/src/tracing/index.ts
+++ b/packages/agents-core/src/tracing/index.ts
@@ -29,6 +29,10 @@ export { NoopSpan, Span } from './spans';
 export type {
   SpanData,
   AgentSpanData,
+  TaskSpanData,
+  TurnSpanData,
+  TaskUsageData,
+  TurnUsageData,
   FunctionSpanData,
   GenerationUsageData,
   GenerationSpanData,

--- a/packages/agents-core/src/tracing/spans.ts
+++ b/packages/agents-core/src/tracing/spans.ts
@@ -19,6 +19,31 @@ export type AgentSpanData = SpanDataBase & {
   output_type?: string;
 };
 
+export type TurnUsageData = {
+  input_tokens: number;
+  output_tokens: number;
+  cached_input_tokens: number;
+  cache_write_input_tokens: number;
+};
+
+export type TaskUsageData = TurnUsageData & {
+  requests: number;
+  total_tokens: number;
+};
+
+export type TaskSpanData = SpanDataBase & {
+  type: 'task';
+  name: string;
+  usage?: TaskUsageData;
+};
+
+export type TurnSpanData = SpanDataBase & {
+  type: 'turn';
+  turn: number;
+  agent_name: string;
+  usage?: TurnUsageData;
+};
+
 export type FunctionSpanData = SpanDataBase & {
   type: 'function';
   name: string;
@@ -116,6 +141,8 @@ export type MCPListToolsSpanData = SpanDataBase & {
 
 export type SpanData =
   | AgentSpanData
+  | TaskSpanData
+  | TurnSpanData
   | FunctionSpanData
   | GenerationSpanData
   | ResponseSpanData
@@ -268,10 +295,37 @@ export class Span<TData extends SpanData> {
       parent_id: this.parentId,
       started_at: this.startedAt,
       ended_at: this.endedAt,
-      span_data: removePrivateFields(this.spanData),
+      span_data: removePrivateFields(serializeSpanData(this.spanData)),
       error: this.error,
     };
   }
+}
+
+function serializeSpanData(spanData: SpanData): SpanData | CustomSpanData {
+  if (spanData.type === 'task') {
+    return {
+      type: 'custom',
+      name: 'task',
+      data: {
+        sdk_span_type: 'task',
+        name: spanData.name,
+        ...(spanData.usage ? { usage: spanData.usage } : {}),
+      },
+    };
+  }
+  if (spanData.type === 'turn') {
+    return {
+      type: 'custom',
+      name: 'turn',
+      data: {
+        sdk_span_type: 'turn',
+        turn: spanData.turn,
+        agent_name: spanData.agent_name,
+        ...(spanData.usage ? { usage: spanData.usage } : {}),
+      },
+    };
+  }
+  return spanData;
 }
 
 export class NoopSpan<TSpanData extends SpanData> extends Span<TSpanData> {

--- a/packages/agents-core/src/usage.ts
+++ b/packages/agents-core/src/usage.ts
@@ -17,13 +17,9 @@ export type UsageInput = Partial<
     output_tokens: number;
     total_tokens: number;
     input_tokens_details:
-      | Record<string, number>
-      | Array<Record<string, number>>
-      | object;
+      Record<string, number> | Array<Record<string, number>> | object;
     output_tokens_details:
-      | Record<string, number>
-      | Array<Record<string, number>>
-      | object;
+      Record<string, number> | Array<Record<string, number>> | object;
     request_usage_entries: RequestUsageInput[];
   }
 > & { requests?: number; requestUsageEntries?: RequestUsageInput[] };

--- a/packages/agents-core/src/utils/internal.ts
+++ b/packages/agents-core/src/utils/internal.ts
@@ -1,1 +1,2 @@
 export { formatInlineData, getInlineMediaType } from './inlineData';
+export { recordToolUsage } from '../runner/usageTracking';

--- a/packages/agents-core/test/createSpans.test.ts
+++ b/packages/agents-core/test/createSpans.test.ts
@@ -6,6 +6,8 @@ import {
   createGuardrailSpan,
   createSpeechSpan,
   createMCPListToolsSpan,
+  createTaskSpan,
+  createTurnSpan,
   withAgentSpan,
   withFunctionSpan,
 } from '../src/tracing/createSpans';
@@ -14,12 +16,17 @@ import {
   setTraceProcessors,
   setTracingDisabled,
   withTrace,
+  withTraceContext,
 } from '../src/tracing';
 import type { TraceProvider } from '../src/tracing/provider';
 import type { Span } from '../src/tracing/spans';
 import * as providerModule from '../src/tracing/provider';
 import { defaultProcessor, TracingProcessor } from '../src/tracing/processor';
 import type { Trace } from '../src/tracing/traces';
+import { Agent } from '../src/agent';
+import { StreamedRunResult } from '../src/result';
+import { RunContext } from '../src/runContext';
+import { RunState } from '../src/runState';
 
 class RecordingProcessor implements TracingProcessor {
   tracesStarted: Trace[] = [];
@@ -77,6 +84,35 @@ describe('create*Span helpers', () => {
     expect(createSpanMock).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ type: 'agent', name: 'Agent' }),
+      }),
+      undefined,
+    );
+  });
+
+  it('createTaskSpan falls back to the default workflow name', () => {
+    createTaskSpan();
+
+    expect(createSpanMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: 'task',
+          name: 'Agent workflow',
+        }),
+      }),
+      undefined,
+    );
+  });
+
+  it('createTurnSpan records the turn and agent name', () => {
+    createTurnSpan({ data: { turn: 2, agent_name: 'Researcher' } });
+
+    expect(createSpanMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          type: 'turn',
+          turn: 2,
+          agent_name: 'Researcher',
+        },
       }),
       undefined,
     );
@@ -172,6 +208,45 @@ describe('with*Span helpers', () => {
     expect(functionSpan?.error).toMatchObject({
       message: 'boom',
       data: { reason: 'bad input' },
+    });
+  });
+
+  it('records errors when a deferred stream loop rejects', async () => {
+    const trace = providerModule
+      .getGlobalTraceProvider()
+      .createTrace({ name: 'stream failure' });
+    const agent = new Agent({ name: 'stream agent' });
+    const state: RunState<unknown, Agent<any, any>> = new RunState(
+      new RunContext(),
+      [],
+      agent,
+      1,
+    );
+    let rejectStream!: (error: Error) => void;
+    const streamLoopPromise = new Promise<void>((_resolve, reject) => {
+      rejectStream = reject;
+    });
+    const result = new StreamedRunResult({ state });
+    result._setStreamLoopPromise(streamLoopPromise);
+    const streamError = Object.assign(new Error('stream failed'), {
+      data: { phase: 'stream loop' },
+    });
+
+    await trace.start();
+    await withTraceContext({ trace }, async () =>
+      withAgentSpan(async () => result, undefined, trace),
+    );
+    rejectStream(streamError);
+    await expect(streamLoopPromise).rejects.toBe(streamError);
+    await Promise.resolve();
+    await trace.end();
+
+    const agentSpan = processor.spansEnded.find(
+      (span) => span.spanData.type === 'agent',
+    );
+    expect(agentSpan?.error).toMatchObject({
+      message: 'stream failed',
+      data: { phase: 'stream loop' },
     });
   });
 });

--- a/packages/agents-core/test/runner/tracing.test.ts
+++ b/packages/agents-core/test/runner/tracing.test.ts
@@ -1,8 +1,21 @@
 import { describe, expect, it } from 'vitest';
 
 import { Agent } from '../../src/agent';
-import { getTracing, ensureAgentSpan } from '../../src/runner/tracing';
-import { withTrace } from '../../src/tracing';
+import {
+  ensureAgentSpan,
+  finishRunnerSpan,
+  getTracing,
+  recordRunnerSpanUsage,
+  startTaskSpan,
+  startTurnSpan,
+} from '../../src/runner/tracing';
+import {
+  createAgentSpan,
+  setCurrentSpan,
+  setTracingDisabled,
+  withTrace,
+} from '../../src/tracing';
+import { Usage } from '../../src/usage';
 
 describe('getTracing', () => {
   it('returns the correct tracing mode for each combination', () => {
@@ -29,6 +42,65 @@ describe('getTracing', () => {
 
       expect(updated.spanData.handoffs).toEqual(['delegate']);
       updated.end();
+    });
+  });
+
+  it('uses explicit runner-owned parents instead of the ambient span', async () => {
+    setTracingDisabled(false);
+    try {
+      await withTrace('workflow', async () => {
+        const taskSpan = startTaskSpan('workflow');
+        const ambientSpan = createAgentSpan({
+          data: { name: 'ambient sibling' },
+        });
+        ambientSpan.start();
+        setCurrentSpan(ambientSpan);
+
+        const agent = new Agent({ name: 'runner-owned agent' });
+        const agentSpan = ensureAgentSpan({
+          agent,
+          handoffs: [],
+          tools: [],
+          parent: taskSpan.span,
+        });
+
+        setCurrentSpan(ambientSpan);
+        const turnSpan = startTurnSpan(1, agent.name, agentSpan);
+
+        expect(agentSpan.parentId).toBe(taskSpan.span.spanId);
+        expect(turnSpan.span.parentId).toBe(agentSpan.spanId);
+
+        finishRunnerSpan(turnSpan);
+        agentSpan.end();
+        ambientSpan.end();
+        finishRunnerSpan(taskSpan);
+      });
+    } finally {
+      setTracingDisabled(true);
+    }
+  });
+
+  it('sums cached input token aliases in runner span usage', async () => {
+    await withTrace('workflow', async () => {
+      const taskSpan = startTaskSpan('workflow');
+
+      recordRunnerSpanUsage(
+        taskSpan,
+        new Usage({
+          inputTokens: 8,
+          outputTokens: 2,
+          totalTokens: 10,
+          inputTokensDetails: [
+            { cached_tokens: 2 },
+            { cached_input_tokens: 3 },
+          ],
+        }),
+      );
+      finishRunnerSpan(taskSpan);
+
+      expect(taskSpan.span.spanData.usage).toMatchObject({
+        cached_input_tokens: 5,
+      });
     });
   });
 });

--- a/packages/agents-core/test/runner/usageTracking.test.ts
+++ b/packages/agents-core/test/runner/usageTracking.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { Usage } from '../../src/usage';
+import {
+  getToolUsageRecorder,
+  recordToolUsage,
+  setToolUsageRecorder,
+} from '../../src/runner/usageTracking';
+
+describe('runner usage tracking', () => {
+  it('records tool usage through non-enumerable tool details metadata', () => {
+    const details = {};
+    const recorder = vi.fn();
+    const usage = new Usage({ inputTokens: 3, outputTokens: 2 });
+
+    setToolUsageRecorder(details, recorder);
+    recordToolUsage(details, usage);
+
+    expect(getToolUsageRecorder(details)).toBe(recorder);
+    expect(recorder).toHaveBeenCalledOnce();
+    expect(recorder).toHaveBeenCalledWith(usage);
+    expect(Object.keys(details)).toEqual([]);
+  });
+});

--- a/packages/agents-core/test/sandboxEvents.test.ts
+++ b/packages/agents-core/test/sandboxEvents.test.ts
@@ -12,12 +12,18 @@ import {
 } from '../src/sandbox';
 import {
   setTraceProcessors,
+  setTracingContextStorage,
   setTracingDisabled,
+  createCustomSpan,
+  getCurrentSpan,
+  getCurrentTrace,
   withTrace,
   type Span,
   type Trace,
   type TracingProcessor,
 } from '../src/tracing';
+import { getGlobalTraceProvider } from '../src/tracing/provider';
+import { AsyncLocalStorage as BrowserAsyncLocalStorage } from '../src/shims/shims-browser';
 
 class RecordingProcessor implements TracingProcessor {
   spansEnded: Span<any>[] = [];
@@ -35,9 +41,121 @@ class RecordingProcessor implements TracingProcessor {
 describe('sandbox events', () => {
   afterEach(() => {
     clearSandboxEventSinks();
+    setTracingContextStorage();
     setTracingDisabled(true);
     setTraceProcessors([]);
   });
+
+  it.each([
+    { browser: false, parentType: 'trace' as const },
+    { browser: false, parentType: 'span' as const },
+    { browser: true, parentType: 'trace' as const },
+    { browser: true, parentType: 'span' as const },
+  ])(
+    'restores tracing context for an explicit $parentType parent without ambient context (browser=$browser)',
+    async ({ browser, parentType }) => {
+      if (browser) {
+        setTracingContextStorage(new BrowserAsyncLocalStorage());
+      }
+      const processor = new RecordingProcessor();
+      setTraceProcessors([processor]);
+      setTracingDisabled(false);
+      const trace = getGlobalTraceProvider().createTrace({
+        name: 'detached sandbox operation',
+      });
+      await trace.start();
+      const parentSpan = createCustomSpan(
+        { data: { name: 'sandbox parent', data: {} } },
+        trace,
+      );
+      parentSpan.start();
+      const parent = parentType === 'trace' ? trace : parentSpan;
+
+      expect(getCurrentTrace()).toBeNull();
+      expect(getCurrentSpan()).toBeNull();
+      await expect(
+        withSandboxSpan(
+          'sandbox.detached',
+          { parent_type: parentType },
+          async (span) => {
+            expect(getCurrentTrace()?.traceId).toBe(trace.traceId);
+            expect(getCurrentSpan()).toBe(span);
+            return 'ok';
+          },
+          parent,
+        ),
+      ).resolves.toBe('ok');
+      expect(getCurrentTrace()).toBeNull();
+      expect(getCurrentSpan()).toBeNull();
+
+      const sandboxSpan = processor.spansEnded.find(
+        (span) =>
+          span.spanData.type === 'custom' &&
+          span.spanData.name === 'sandbox.detached',
+      );
+      expect(sandboxSpan?.traceId).toBe(trace.traceId);
+      expect(sandboxSpan?.parentId).toBe(
+        parentType === 'span' ? parentSpan.spanId : null,
+      );
+
+      parentSpan.end();
+      await trace.end();
+    },
+  );
+
+  it.each([false, true])(
+    'preserves detached sandbox failures and restores context (browser=%s)',
+    async (browser) => {
+      if (browser) {
+        setTracingContextStorage(new BrowserAsyncLocalStorage());
+      }
+      const processor = new RecordingProcessor();
+      setTraceProcessors([processor]);
+      setTracingDisabled(false);
+      const trace = getGlobalTraceProvider().createTrace({
+        name: 'detached sandbox failure',
+      });
+      await trace.start();
+      const parentSpan = createCustomSpan(
+        { data: { name: 'sandbox parent', data: {} } },
+        trace,
+      );
+      parentSpan.start();
+      const operationError = new SandboxProviderError('cleanup unavailable', {
+        status: 503,
+      });
+
+      await expect(
+        withSandboxSpan(
+          'sandbox.detached_cleanup',
+          {},
+          async () => {
+            throw operationError;
+          },
+          parentSpan,
+        ),
+      ).rejects.toBe(operationError);
+      expect(getCurrentTrace()).toBeNull();
+      expect(getCurrentSpan()).toBeNull();
+
+      const sandboxSpan = processor.spansEnded.find(
+        (span) =>
+          span.spanData.type === 'custom' &&
+          span.spanData.name === 'sandbox.detached_cleanup',
+      );
+      expect(sandboxSpan?.parentId).toBe(parentSpan.spanId);
+      expect(sandboxSpan?.spanData.data).toMatchObject({
+        error_retryable: true,
+        error: {
+          message: 'cleanup unavailable',
+          retryable: true,
+        },
+      });
+
+      parentSpan.end();
+      await trace.end();
+    },
+  );
 
   it('emits operation start and end events without exposing operation output', async () => {
     const events: SandboxEvent[] = [];

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -22,9 +22,11 @@ import {
   setDefaultModelProvider,
   setTraceProcessors,
   setTracingDisabled,
+  setTracingContextStorage,
   createAgentSpan,
   getCurrentSpan,
   setCurrentSpan,
+  ToolGuardrailFunctionOutputFactory,
   withTrace,
   tool,
   type Span,
@@ -48,6 +50,8 @@ import {
   Entry,
   filesystem,
   Manifest,
+  memory,
+  type MemoryStore,
   SANDBOX_SESSION_STATE_VERSION,
   shell,
   skills,
@@ -72,6 +76,7 @@ import {
   FakeShell,
   fakeModelMessage,
 } from './stubs';
+import { AsyncLocalStorage as BrowserAsyncLocalStorage } from '../src/shims/shims-browser';
 
 class StubEditor implements Editor {
   async createFile(
@@ -138,14 +143,16 @@ class RecordingStreamingModel implements Model {
 class OpenAIChatCompletionsModel extends RecordingFakeModel {}
 
 class RecordingTracingProcessor implements TracingProcessor {
+  public readonly tracesStarted: Trace[] = [];
+  public readonly tracesEnded: Trace[] = [];
   public readonly spansEnded: Span<any>[] = [];
 
-  async onTraceStart(_trace: Trace): Promise<void> {
-    // no-op
+  async onTraceStart(trace: Trace): Promise<void> {
+    this.tracesStarted.push(trace);
   }
 
-  async onTraceEnd(_trace: Trace): Promise<void> {
-    // no-op
+  async onTraceEnd(trace: Trace): Promise<void> {
+    this.tracesEnded.push(trace);
   }
 
   async onSpanStart(_span: Span<any>): Promise<void> {
@@ -394,6 +401,49 @@ class FakeSandboxClient implements SandboxClient<
   }
 }
 
+function createSandboxBarrier(participantCount: number) {
+  let remaining = participantCount;
+  let release!: () => void;
+  const ready = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return async () => {
+    remaining -= 1;
+    if (remaining === 0) {
+      release();
+    }
+    await ready;
+  };
+}
+
+class CoordinatedTracingSandboxClient extends FakeSandboxClient {
+  constructor(
+    private readonly waitForCreatePeers: () => Promise<void>,
+    private readonly waitForClosePeers: () => Promise<void>,
+  ) {
+    super();
+  }
+
+  override async create(
+    args?: SandboxClientCreateArgs<SandboxClientOptions> | Manifest,
+    manifestOptions?: SandboxClientOptions,
+  ): Promise<SandboxSessionLike<FakeSandboxSessionState>> {
+    await this.waitForCreatePeers();
+    return await super.create(args, manifestOptions);
+  }
+
+  protected override lifecycleHandlers(
+    state: FakeSandboxSessionState,
+  ): Partial<SandboxSessionLike<FakeSandboxSessionState>> {
+    return {
+      close: async () => {
+        await this.waitForClosePeers();
+        this.closeCalls.push(state.sessionId);
+      },
+    };
+  }
+}
+
 class NonPersistentFakeSandboxClient extends FakeSandboxClient {
   override async resume(
     state: FakeSandboxSessionState,
@@ -609,6 +659,7 @@ describe('sandbox runner integration', () => {
   afterEach(() => {
     setTraceProcessors([]);
     setTracingDisabled(true);
+    setTracingContextStorage(undefined);
   });
 
   it('requires RunConfig.sandbox when execution reaches a SandboxAgent', async () => {
@@ -2234,6 +2285,43 @@ describe('sandbox runner integration', () => {
     expect(sandboxRuntime.cleanup).toHaveBeenCalledOnce();
   });
 
+  it('finishes an interrupted agent span when task tracing owns its lifecycle', async () => {
+    setTracingDisabled(false);
+    const agent = new Agent<unknown, any>({ name: 'InterruptedAgent' });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      agent,
+      1,
+    );
+    const cleanupError = new Error('cleanup failed');
+    const sandboxRuntime = {
+      enqueueMemoryGeneration: vi.fn().mockResolvedValue(undefined),
+      cleanup: vi.fn().mockRejectedValue(cleanupError),
+    } as unknown as SandboxRuntimeManager<unknown>;
+
+    await withTrace('Interrupted agent span cleanup test', async () => {
+      const span = createAgentSpan({ data: { name: 'InterruptedAgent' } });
+      state._currentAgentSpan = span;
+      span.start();
+      setCurrentSpan(span);
+
+      await expect(
+        finalizeSandboxRuntime({
+          state,
+          sandboxRuntime,
+          preserveSessionsForInterruption: true,
+          finishAgentSpanForInterruption: true,
+          runAgent: async () => ({ finalOutput: undefined }),
+        }),
+      ).rejects.toBe(cleanupError);
+      expect(span.endedAt).not.toBeNull();
+      expect(getCurrentSpan()).toBeNull();
+    });
+
+    expect(sandboxRuntime.cleanup).toHaveBeenCalledOnce();
+  });
+
   it('preserves serialized sessions for sandbox agents untouched by a resumed run', async () => {
     const client = new FakeSandboxClient();
     const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
@@ -2353,6 +2441,293 @@ describe('sandbox runner integration', () => {
         'sandbox.shutdown',
       ]),
     );
+  });
+
+  it.each([true, false])(
+    'keeps parallel sandbox lifecycle spans in their own browser-runtime traces (task/turn=%s)',
+    async (includeTaskAndTurnSpans) => {
+      setTracingContextStorage(new BrowserAsyncLocalStorage());
+      const processor = new RecordingTracingProcessor();
+      setTraceProcessors([processor]);
+      setTracingDisabled(false);
+      const waitForCreatePeers = createSandboxBarrier(2);
+      const waitForClosePeers = createSandboxBarrier(2);
+      const agentA = new SandboxAgent({
+        name: `Parallel Sandbox Worker A ${includeTaskAndTurnSpans}`,
+        model: new RecordingFakeModel([
+          {
+            output: [fakeModelMessage('sandbox A done')],
+            usage: new Usage(),
+          },
+        ]),
+      });
+      const agentB = new SandboxAgent({
+        name: `Parallel Sandbox Worker B ${includeTaskAndTurnSpans}`,
+        model: new RecordingFakeModel([
+          {
+            output: [fakeModelMessage('sandbox B done')],
+            usage: new Usage(),
+          },
+        ]),
+      });
+
+      await Promise.all([
+        run(agentA, 'Hello A', {
+          sandbox: {
+            client: new CoordinatedTracingSandboxClient(
+              waitForCreatePeers,
+              waitForClosePeers,
+            ),
+          },
+          tracing: { includeTaskAndTurnSpans },
+        }),
+        run(agentB, 'Hello B', {
+          sandbox: {
+            client: new CoordinatedTracingSandboxClient(
+              waitForCreatePeers,
+              waitForClosePeers,
+            ),
+          },
+          tracing: { includeTaskAndTurnSpans },
+        }),
+      ]);
+
+      for (const agent of [agentA, agentB]) {
+        const agentSpan = processor.spansEnded.find(
+          (span) =>
+            span.spanData.type === 'agent' && span.spanData.name === agent.name,
+        );
+        const taskSpan = processor.spansEnded.find(
+          (span) =>
+            span.spanData.type === 'task' &&
+            span.spanId === agentSpan?.parentId,
+        );
+        const turnSpan = processor.spansEnded.find(
+          (span) =>
+            span.spanData.type === 'turn' &&
+            span.spanData.agent_name === agent.name,
+        );
+        const rootSpan = includeTaskAndTurnSpans ? taskSpan : agentSpan;
+        const shutdownSpan = processor.spansEnded.find(
+          (span) =>
+            span.spanData.type === 'custom' &&
+            span.spanData.name === 'sandbox.shutdown' &&
+            span.spanData.data.agent_name === agent.name,
+        );
+        const prepareSpan = processor.spansEnded.find(
+          (span) =>
+            span.spanData.type === 'custom' &&
+            span.spanData.name === 'sandbox.prepare_agent' &&
+            span.spanData.data.agent_name === agent.name,
+        );
+        const createSpan = processor.spansEnded.find(
+          (span) =>
+            span.spanData.type === 'custom' &&
+            span.spanData.name === 'sandbox.create_session' &&
+            span.spanData.data.agent_name === agent.name,
+        );
+        const cleanupSessionsSpan = processor.spansEnded.find(
+          (span) =>
+            span.spanData.type === 'custom' &&
+            span.spanData.name === 'sandbox.cleanup_sessions' &&
+            span.traceId === rootSpan?.traceId,
+        );
+        const cleanupSpan = processor.spansEnded.find(
+          (span) =>
+            span.spanData.type === 'custom' &&
+            span.spanData.name === 'sandbox.cleanup' &&
+            span.traceId === rootSpan?.traceId,
+        );
+        expect(shutdownSpan?.traceId).toBe(rootSpan?.traceId);
+        expect(prepareSpan?.parentId).toBe(
+          includeTaskAndTurnSpans ? turnSpan?.spanId : agentSpan?.spanId,
+        );
+        expect(createSpan?.parentId).toBe(prepareSpan?.spanId);
+        expect(cleanupSpan?.parentId).toBe(rootSpan?.spanId);
+        expect(cleanupSessionsSpan?.parentId).toBe(cleanupSpan?.spanId);
+        expect(shutdownSpan?.parentId).toBe(cleanupSessionsSpan?.spanId);
+      }
+    },
+  );
+
+  it('keeps parallel sandbox capability spans under their function spans in browser runtimes', async () => {
+    setTracingContextStorage(new BrowserAsyncLocalStorage());
+    const processor = new RecordingTracingProcessor();
+    setTraceProcessors([processor]);
+    setTracingDisabled(false);
+    const waitForBothGuardrails = createSandboxBarrier(2);
+
+    const createAgent = (label: string) =>
+      new SandboxAgent({
+        name: `Parallel sandbox capability agent ${label}`,
+        model: new RecordingFakeModel([
+          {
+            output: [
+              {
+                id: `tool-${label}`,
+                type: 'function_call',
+                name: 'exec_command',
+                callId: `tool-${label}`,
+                status: 'completed',
+                arguments: JSON.stringify({ cmd: `echo ${label}` }),
+              },
+            ],
+            usage: new Usage(),
+          },
+          {
+            output: [fakeModelMessage(`sandbox ${label} done`)],
+            usage: new Usage(),
+          },
+        ]),
+        capabilities: [
+          shell({
+            configureTools: (tools) =>
+              tools.map((capabilityTool) =>
+                capabilityTool.type === 'function' &&
+                capabilityTool.name === 'exec_command'
+                  ? {
+                      ...capabilityTool,
+                      inputGuardrails: [
+                        {
+                          type: 'tool_input' as const,
+                          name: `wait-for-peer-${label}`,
+                          run: async () => {
+                            await waitForBothGuardrails();
+                            return ToolGuardrailFunctionOutputFactory.allow();
+                          },
+                        },
+                      ],
+                    }
+                  : capabilityTool,
+              ),
+          }),
+        ],
+      });
+
+    const agents = [createAgent('A'), createAgent('B')];
+    await Promise.all(
+      agents.map((agent, index) =>
+        run(agent, `Hello ${index}`, {
+          sandbox: { client: new FakeSandboxClient() },
+        }),
+      ),
+    );
+
+    for (const label of ['A', 'B']) {
+      const functionSpan = processor.spansEnded.find(
+        (span) =>
+          span.spanData.type === 'function' &&
+          span.spanData.name === 'exec_command' &&
+          span.spanData.input === JSON.stringify({ cmd: `echo ${label}` }),
+      );
+      const sandboxSpan = processor.spansEnded.find(
+        (span) =>
+          span.spanData.type === 'custom' &&
+          span.spanData.name === 'sandbox.exec' &&
+          span.spanData.data.cmd === `echo ${label}`,
+      );
+      expect(sandboxSpan?.parentId).toBe(functionSpan?.spanId);
+      expect(sandboxSpan?.traceId).toBe(functionSpan?.traceId);
+    }
+  });
+
+  it('keeps parallel sandbox memory-read spans under their turn spans in browser runtimes', async () => {
+    setTracingContextStorage(new BrowserAsyncLocalStorage());
+    const processor = new RecordingTracingProcessor();
+    setTraceProcessors([processor]);
+    setTracingDisabled(false);
+    const waitForBothReads = createSandboxBarrier(2);
+
+    const createAgent = (label: string) => {
+      const store: MemoryStore = {
+        read: async () => {
+          await waitForBothReads();
+          return null;
+        },
+        write: async () => undefined,
+      };
+      return new SandboxAgent({
+        name: `Parallel sandbox memory agent ${label}`,
+        model: new RecordingFakeModel([
+          {
+            output: [fakeModelMessage(`sandbox ${label} done`)],
+            usage: new Usage(),
+          },
+        ]),
+        capabilities: [
+          shell(),
+          memory({
+            read: { liveUpdate: false },
+            generate: false,
+            layout: { memoriesDir: `memories-${label.toLowerCase()}` },
+            store,
+          }),
+        ],
+      });
+    };
+
+    const agents = [createAgent('A'), createAgent('B')];
+    await Promise.all(
+      agents.map((agent, index) =>
+        run(agent, `Hello ${index}`, {
+          sandbox: { client: new FakeSandboxClient() },
+        }),
+      ),
+    );
+
+    for (const label of ['A', 'B']) {
+      const turnSpan = processor.spansEnded.find(
+        (span) =>
+          span.spanData.type === 'turn' &&
+          span.spanData.agent_name === `Parallel sandbox memory agent ${label}`,
+      );
+      const memorySpan = processor.spansEnded.find(
+        (span) =>
+          span.spanData.type === 'custom' &&
+          span.spanData.name === 'sandbox.memory.read_summary' &&
+          span.spanData.data.path ===
+            `memories-${label.toLowerCase()}/memory_summary.md`,
+      );
+      expect(memorySpan?.parentId).toBe(turnSpan?.spanId);
+      expect(memorySpan?.traceId).toBe(turnSpan?.traceId);
+    }
+  });
+
+  it('does not emit sandbox spans when runner tracing is disabled', async () => {
+    const processor = new RecordingTracingProcessor();
+    setTraceProcessors([processor]);
+    setTracingDisabled(false);
+    const sandboxAgent = new SandboxAgent({
+      name: 'Tracing-disabled sandbox agent',
+      model: new RecordingFakeModel([
+        {
+          output: [
+            {
+              id: 'tool-disabled',
+              type: 'function_call',
+              name: 'exec_command',
+              callId: 'tool-disabled',
+              status: 'completed',
+              arguments: JSON.stringify({ cmd: 'echo disabled' }),
+            },
+          ],
+          usage: new Usage(),
+        },
+        {
+          output: [fakeModelMessage('sandbox done')],
+          usage: new Usage(),
+        },
+      ]),
+      capabilities: [shell()],
+    });
+
+    await new Runner({ tracingDisabled: true }).run(sandboxAgent, 'Hello', {
+      sandbox: { client: new FakeSandboxClient() },
+    });
+
+    expect(processor.spansEnded).toHaveLength(0);
+    expect(processor.tracesStarted).toHaveLength(0);
+    expect(processor.tracesEnded).toHaveLength(0);
   });
 
   it('rejects concurrent reuse of the same SandboxAgent across runs', async () => {

--- a/packages/agents-core/test/taskTurnTracing.test.ts
+++ b/packages/agents-core/test/taskTurnTracing.test.ts
@@ -1,0 +1,2766 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import {
+  Agent,
+  MemorySession,
+  OutputGuardrailTripwireTriggered,
+  RequestUsage,
+  Runner,
+  RunContext,
+  RunState,
+  Span,
+  Trace,
+  Usage,
+  createAgentSpan,
+  createGenerationSpan,
+  getGlobalTraceProvider,
+  handoff,
+  retryPolicies,
+  setTraceProcessors,
+  setTracingContextStorage,
+  setTracingDisabled,
+  tool,
+  withAgentSpan,
+  withGenerationSpan,
+  withTrace,
+  withTraceContext,
+  type Model,
+  type ModelRequest,
+  type ModelResponse,
+  type MCPServer,
+  type OpenAIResponsesCompactionResult,
+  type StreamEvent,
+  type TracingProcessor,
+} from '../src';
+import type { MCPTool } from '../src/mcp';
+import { defaultProcessor } from '../src/tracing/processor';
+import { mergeAgentToolRunConfig } from '../src/agentToolRunConfig';
+import { SandboxRuntimeManager } from '../src/sandbox/runtime';
+import { AsyncLocalStorage as BrowserAsyncLocalStorage } from '../src/shims/shims-browser';
+import { fakeModelMessage, FakeModel } from './stubs';
+
+class RecordingProcessor implements TracingProcessor {
+  readonly spansStarted: Span<any>[] = [];
+  readonly spansEnded: Span<any>[] = [];
+  readonly spanErrorsAtEnd = new Map<string, unknown>();
+
+  async onTraceStart(_trace: Trace): Promise<void> {}
+  async onTraceEnd(_trace: Trace): Promise<void> {}
+  async onSpanStart(span: Span<any>): Promise<void> {
+    this.spansStarted.push(span);
+  }
+  async onSpanEnd(span: Span<any>): Promise<void> {
+    this.spansEnded.push(span);
+    this.spanErrorsAtEnd.set(span.spanId, span.error);
+  }
+  async shutdown(): Promise<void> {}
+  async forceFlush(): Promise<void> {}
+}
+
+class StreamingModel implements Model {
+  private readonly responses: ModelResponse[];
+
+  constructor(response: ModelResponse | ModelResponse[]) {
+    this.responses = Array.isArray(response) ? [...response] : [response];
+  }
+
+  async getResponse(_request: ModelRequest): Promise<ModelResponse> {
+    throw new Error('Use getStreamedResponse for this model.');
+  }
+
+  async *getStreamedResponse(
+    _request: ModelRequest,
+  ): AsyncIterable<StreamEvent> {
+    const response = this.responses.shift();
+    if (!response) {
+      throw new Error('No response found.');
+    }
+    yield {
+      type: 'response_done',
+      response: {
+        id: 'stream-response',
+        output: response.output,
+        usage: response.usage,
+      },
+    } as StreamEvent;
+  }
+}
+
+class FailingModel implements Model {
+  constructor(private readonly error: Error) {}
+
+  async getResponse(): Promise<ModelResponse> {
+    throw this.error;
+  }
+
+  async *getStreamedResponse(): AsyncIterable<StreamEvent> {
+    throw this.error;
+    yield* [] as StreamEvent[];
+  }
+}
+
+class HangingStreamingModel implements Model {
+  async getResponse(): Promise<ModelResponse> {
+    throw new Error('Use getStreamedResponse for this model.');
+  }
+
+  async *getStreamedResponse(
+    request: ModelRequest,
+  ): AsyncIterable<StreamEvent> {
+    const abortError = new Error('aborted');
+    abortError.name = 'AbortError';
+    const signal = request.signal;
+    await new Promise((_resolve, reject) => {
+      if (signal?.aborted) {
+        reject(abortError);
+        return;
+      }
+      signal?.addEventListener('abort', () => reject(abortError), {
+        once: true,
+      });
+    });
+    yield* [] as StreamEvent[];
+  }
+}
+
+class AbortReconciliationUsageModel implements Model {
+  async getResponse(): Promise<ModelResponse> {
+    return responseWithSpecificUsage(7, 3);
+  }
+
+  async *getStreamedResponse(): AsyncIterable<StreamEvent> {
+    yield {
+      type: 'model',
+      event: {
+        type: 'response.created',
+        response: { id: 'response-before-abort' },
+      },
+    } as StreamEvent;
+    yield {
+      type: 'model',
+      event: {
+        type: 'response.output_item.done',
+        item: {
+          type: 'function_call',
+          id: 'function-call-before-abort',
+          call_id: 'call-before-abort',
+          name: 'slow_tool',
+          arguments: '{}',
+          status: 'completed',
+        },
+      },
+    } as StreamEvent;
+    const abortError = new Error('aborted');
+    abortError.name = 'AbortError';
+    throw abortError;
+  }
+}
+
+class UsageCompactionSession extends MemorySession {
+  async runCompaction(): Promise<OpenAIResponsesCompactionResult> {
+    return {
+      usage: new RequestUsage({
+        inputTokens: 5,
+        outputTokens: 2,
+        totalTokens: 7,
+        endpoint: 'responses.compact',
+      }),
+    };
+  }
+}
+
+class FailingCompactionSession extends MemorySession {
+  readonly error = new Error('session compaction failed');
+
+  async runCompaction(): Promise<OpenAIResponsesCompactionResult> {
+    throw this.error;
+  }
+}
+
+class FailingAddItemsSession extends MemorySession {
+  readonly error = new Error('session addItems failed');
+
+  async addItems(): Promise<void> {
+    throw this.error;
+  }
+}
+
+function createDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function createBarrier(participantCount: number) {
+  let remaining = participantCount;
+  const ready = createDeferred();
+  return async () => {
+    remaining -= 1;
+    if (remaining === 0) {
+      ready.resolve();
+    }
+    await ready.promise;
+  };
+}
+
+class CoordinatedModel implements Model {
+  private readonly responses: ModelResponse[];
+  private callCount = 0;
+
+  constructor(
+    response: ModelResponse | ModelResponse[],
+    private readonly waitForPeers: () => Promise<void>,
+    private readonly waitBeforeResponse?: Promise<void>,
+  ) {
+    this.responses = Array.isArray(response) ? [...response] : [response];
+  }
+
+  async getResponse(_request: ModelRequest): Promise<ModelResponse> {
+    if (this.callCount === 0) {
+      await this.waitForPeers();
+      await this.waitBeforeResponse;
+    }
+    this.callCount += 1;
+    const response = this.responses.shift();
+    if (!response) {
+      throw new Error('No coordinated response found.');
+    }
+    return response;
+  }
+
+  getStreamedResponse(_request: ModelRequest): AsyncIterable<StreamEvent> {
+    throw new Error('Streaming is not supported by this model.');
+  }
+}
+
+class CoordinatedTracingModel implements Model {
+  constructor(
+    private readonly label: string,
+    private readonly waitForPeers: () => Promise<void>,
+  ) {}
+
+  async getResponse(request: ModelRequest): Promise<ModelResponse> {
+    return withGenerationSpan(
+      async () => {
+        await this.waitForPeers();
+        return responseWithoutUsage();
+      },
+      { data: { model: this.label } },
+      request._internal?.tracingParent,
+    );
+  }
+
+  getStreamedResponse(_request: ModelRequest): AsyncIterable<StreamEvent> {
+    throw new Error('Streaming is not supported by this model.');
+  }
+}
+
+class RetryingTracingModel implements Model {
+  private attempts = 0;
+
+  async getResponse(request: ModelRequest): Promise<ModelResponse> {
+    return withGenerationSpan(
+      async () => {
+        this.attempts += 1;
+        if (this.attempts === 1) {
+          const error = new Error('Rate limited');
+          (error as Error & { statusCode?: number }).statusCode = 429;
+          throw error;
+        }
+        return responseWithSpecificUsage(7, 3);
+      },
+      { data: { model: `retry-attempt-${this.attempts + 1}` } },
+      request._internal?.tracingParent,
+    );
+  }
+
+  getStreamedResponse(_request: ModelRequest): AsyncIterable<StreamEvent> {
+    throw new Error('Streaming is not supported by this model.');
+  }
+}
+
+class CoordinatedStreamingTracingModel implements Model {
+  constructor(
+    private readonly label: string,
+    private readonly waitForPeers: () => Promise<void>,
+  ) {}
+
+  async getResponse(): Promise<ModelResponse> {
+    throw new Error('Use getStreamedResponse for this model.');
+  }
+
+  async *getStreamedResponse(
+    request: ModelRequest,
+  ): AsyncIterable<StreamEvent> {
+    const span = createGenerationSpan(
+      { data: { model: this.label } },
+      request._internal?.tracingParent,
+    );
+    span.start();
+    try {
+      await this.waitForPeers();
+      yield {
+        type: 'response_done',
+        response: {
+          id: `stream-response-${this.label}`,
+          output: responseWithoutUsage().output,
+          usage: new Usage(),
+        },
+      } as StreamEvent;
+    } finally {
+      span.end();
+    }
+  }
+}
+
+class CoordinatedMCPServer implements MCPServer {
+  readonly cacheToolsList = false;
+  readonly toolFilter = undefined;
+
+  constructor(
+    readonly name: string,
+    private readonly waitForPeers: () => Promise<void>,
+  ) {}
+
+  async connect(): Promise<void> {}
+  async close(): Promise<void> {}
+  async invalidateToolsCache(): Promise<void> {}
+
+  async listTools(): Promise<MCPTool[]> {
+    await this.waitForPeers();
+    return [];
+  }
+
+  async callTool(): Promise<[]> {
+    return [];
+  }
+}
+
+class CoordinatedMCPToolServer implements MCPServer {
+  readonly cacheToolsList = false;
+  readonly toolFilter = undefined;
+
+  constructor(
+    readonly name: string,
+    readonly toolName: string,
+    private readonly waitForPeers: () => Promise<void>,
+  ) {}
+
+  async connect(): Promise<void> {}
+  async close(): Promise<void> {}
+  async invalidateToolsCache(): Promise<void> {}
+
+  async listTools(): Promise<MCPTool[]> {
+    return [
+      {
+        name: this.toolName,
+        description: `Tool from ${this.name}.`,
+        inputSchema: {
+          type: 'object',
+          properties: { input: { type: 'string' } },
+          required: ['input'],
+          additionalProperties: false,
+        },
+      } as MCPTool,
+    ];
+  }
+
+  async callTool(): Promise<any> {
+    await this.waitForPeers();
+    return [{ type: 'text', text: 'ok' }];
+  }
+}
+
+function approvalResponse(toolName: string): ModelResponse {
+  return {
+    output: [
+      {
+        id: 'approval-call',
+        type: 'function_call',
+        name: toolName,
+        callId: 'approval-call-id',
+        status: 'completed',
+        arguments: '{}',
+      },
+    ],
+    usage: new Usage(),
+  };
+}
+
+function agentToolCallResponse(toolName: string): ModelResponse {
+  return {
+    output: [
+      {
+        id: 'agent-tool-call',
+        type: 'function_call',
+        name: toolName,
+        callId: 'agent-tool-call-id',
+        status: 'completed',
+        arguments: JSON.stringify({ input: 'hello' }),
+      },
+    ],
+    usage: new Usage(),
+  };
+}
+
+function handoffCallResponse(toolName: string): ModelResponse {
+  return {
+    output: [
+      {
+        id: `handoff-call-${toolName}`,
+        type: 'function_call',
+        name: toolName,
+        callId: `handoff-call-id-${toolName}`,
+        status: 'completed',
+        arguments: '{}',
+      },
+    ],
+    usage: new Usage(),
+  };
+}
+
+function parallelAgentToolCallResponse(toolNames: string[]): ModelResponse {
+  return {
+    output: toolNames.map((toolName, index) => ({
+      id: `agent-tool-call-${index}`,
+      type: 'function_call' as const,
+      name: toolName,
+      callId: `agent-tool-call-id-${index}`,
+      status: 'completed' as const,
+      arguments: JSON.stringify({ input: 'hello' }),
+    })),
+    usage: new Usage(),
+  };
+}
+
+function createNestedAgentToolScenario(
+  nestedTracing?: {
+    apiKey?: string;
+    includeTaskAndTurnSpans?: boolean;
+  },
+  nestedTracingDisabled?: boolean,
+) {
+  const nestedAgent = new Agent({
+    name: 'Nested agent',
+    model: new FakeModel([responseWithUsage()]),
+  });
+  const nestedTool = nestedAgent.asTool({
+    toolName: 'nested_agent',
+    toolDescription: 'Runs the nested agent.',
+    ...(nestedTracing === undefined && nestedTracingDisabled === undefined
+      ? {}
+      : {
+          runConfig: {
+            ...(nestedTracing === undefined ? {} : { tracing: nestedTracing }),
+            ...(nestedTracingDisabled === undefined
+              ? {}
+              : { tracingDisabled: nestedTracingDisabled }),
+          },
+        }),
+  });
+  const outerAgent = new Agent({
+    name: 'Outer agent',
+    model: new FakeModel([
+      agentToolCallResponse(nestedTool.name),
+      responseWithUsage(),
+    ]),
+    tools: [nestedTool],
+  });
+  return outerAgent;
+}
+
+function responseWithUsage(): ModelResponse {
+  return {
+    output: [fakeModelMessage('done')],
+    usage: new Usage({
+      requests: 1,
+      inputTokens: 12,
+      outputTokens: 4,
+      totalTokens: 16,
+      inputTokensDetails: {
+        cached_tokens: 2,
+        cache_write_tokens: 3,
+      },
+    }),
+  };
+}
+
+function responseWithSpecificUsage(
+  inputTokens: number,
+  outputTokens: number,
+): ModelResponse {
+  return {
+    output: [fakeModelMessage('done')],
+    usage: new Usage({
+      requests: 1,
+      inputTokens,
+      outputTokens,
+      totalTokens: inputTokens + outputTokens,
+    }),
+  };
+}
+
+function toolCallResponseWithSpecificUsage(
+  toolName: string,
+  inputTokens: number,
+  outputTokens: number,
+): ModelResponse {
+  return {
+    ...approvalResponse(toolName),
+    usage: new Usage({
+      requests: 1,
+      inputTokens,
+      outputTokens,
+      totalTokens: inputTokens + outputTokens,
+    }),
+  };
+}
+
+function responseWithoutUsage(): ModelResponse {
+  return {
+    output: [fakeModelMessage('done')],
+    usage: new Usage(),
+  };
+}
+
+function createApprovedAgentToolScenario(stream: boolean) {
+  const nestedAgent = new Agent({
+    name: 'Approved nested agent',
+    model: new FakeModel([responseWithUsage()]),
+  });
+  const nestedTool = nestedAgent.asTool({
+    toolName: 'approved_nested_agent',
+    toolDescription: 'Runs the approved nested agent.',
+    needsApproval: true,
+  });
+  const responses = [
+    agentToolCallResponse(nestedTool.name),
+    responseWithoutUsage(),
+  ];
+  const outerAgent = new Agent({
+    name: 'Outer approval agent',
+    model: stream ? new StreamingModel(responses) : new FakeModel(responses),
+    tools: [nestedTool],
+  });
+  return outerAgent;
+}
+
+function spanOfType(processor: RecordingProcessor, type: string): Span<any> {
+  const span = processor.spansEnded.find(
+    (candidate) => candidate.spanData.type === type,
+  );
+  if (!span) {
+    throw new Error(`Missing ${type} span.`);
+  }
+  return span;
+}
+
+describe('runner task and turn tracing', () => {
+  let processor: RecordingProcessor;
+
+  beforeEach(() => {
+    processor = new RecordingProcessor();
+    setTraceProcessors([processor]);
+    setTracingDisabled(false);
+  });
+
+  afterEach(() => {
+    setTracingContextStorage();
+    setTraceProcessors([defaultProcessor()]);
+    setTracingDisabled(true);
+  });
+
+  it('creates task and turn spans by default with Python-compatible usage', async () => {
+    const agent = new Agent({
+      name: 'Researcher',
+      model: new FakeModel([responseWithUsage()]),
+    });
+    const runner = new Runner({ workflowName: 'Tracing parity workflow' });
+
+    await runner.run(agent, 'hello');
+
+    const taskSpan = spanOfType(processor, 'task');
+    const agentSpan = spanOfType(processor, 'agent');
+    const turnSpan = spanOfType(processor, 'turn');
+
+    expect(taskSpan.parentId).toBeNull();
+    expect(agentSpan.parentId).toBe(taskSpan.spanId);
+    expect(turnSpan.parentId).toBe(agentSpan.spanId);
+    expect(taskSpan.spanData).toMatchObject({
+      type: 'task',
+      name: 'Tracing parity workflow',
+      usage: {
+        requests: 1,
+        input_tokens: 12,
+        output_tokens: 4,
+        total_tokens: 16,
+        cached_input_tokens: 2,
+        cache_write_input_tokens: 3,
+      },
+    });
+    expect(turnSpan.spanData).toMatchObject({
+      type: 'turn',
+      turn: 1,
+      agent_name: 'Researcher',
+      usage: {
+        input_tokens: 12,
+        output_tokens: 4,
+        cached_input_tokens: 2,
+        cache_write_input_tokens: 3,
+      },
+    });
+    expect(taskSpan.toJSON()).toMatchObject({
+      span_data: {
+        type: 'custom',
+        name: 'task',
+        data: {
+          sdk_span_type: 'task',
+          name: 'Tracing parity workflow',
+        },
+      },
+    });
+    expect(turnSpan.toJSON()).toMatchObject({
+      span_data: {
+        type: 'custom',
+        name: 'turn',
+        data: {
+          sdk_span_type: 'turn',
+          turn: 1,
+          agent_name: 'Researcher',
+        },
+      },
+    });
+  });
+
+  it('omits only task and turn spans when explicitly disabled', async () => {
+    const agent = new Agent({
+      name: 'Researcher',
+      model: new FakeModel([responseWithUsage()]),
+    });
+    const runner = new Runner({
+      tracing: { includeTaskAndTurnSpans: false },
+    });
+
+    await runner.run(agent, 'hello');
+
+    expect(
+      processor.spansEnded.some(
+        (span) =>
+          span.spanData.type === 'task' || span.spanData.type === 'turn',
+      ),
+    ).toBe(false);
+    expect(spanOfType(processor, 'agent').parentId).toBeNull();
+  });
+
+  it.each([false, true])(
+    'does not create task or turn spans when tracing is disabled (stream: %s)',
+    async (stream) => {
+      const response = responseWithUsage();
+      const agent = new Agent({
+        name: 'Researcher',
+        model: stream
+          ? new StreamingModel(response)
+          : new FakeModel([response]),
+      });
+      const runner = new Runner({ tracingDisabled: true });
+
+      if (stream) {
+        const result = await runner.run(agent, 'hello', { stream: true });
+        await result.completed;
+      } else {
+        await runner.run(agent, 'hello');
+      }
+
+      expect(processor.spansStarted).toHaveLength(0);
+      expect(processor.spansEnded).toHaveLength(0);
+    },
+  );
+
+  it('can re-enable tracing when resuming a state created by a disabled runner', async () => {
+    const approvalTool = tool({
+      name: 'approval_tool',
+      description: 'Requires approval.',
+      parameters: z.object({}),
+      needsApproval: true,
+      execute: async () => 'approved',
+    });
+    const agent = new Agent({
+      name: 'Re-enabled tracing agent',
+      model: new FakeModel([
+        agentToolCallResponse(approvalTool.name),
+        responseWithoutUsage(),
+      ]),
+      tools: [approvalTool],
+    });
+
+    const first = await new Runner({ tracingDisabled: true }).run(
+      agent,
+      'hello',
+    );
+    expect(first.interruptions).toHaveLength(1);
+    expect(processor.spansEnded).toHaveLength(0);
+    first.state.approve(first.interruptions[0]);
+
+    await new Runner().run(agent, first.state);
+
+    expect(
+      processor.spansEnded.filter((span) => span.spanData.type === 'task'),
+    ).toHaveLength(1);
+    expect(
+      processor.spansEnded.filter((span) => span.spanData.type === 'turn'),
+    ).toHaveLength(1);
+  });
+
+  it.each([false, true])(
+    'can re-enable tracing when resuming an in-memory state created while tracing is globally disabled (stream=%s)',
+    async (stream) => {
+      const approvalTool = tool({
+        name: stream
+          ? 'streaming_globally_disabled_approval_tool'
+          : 'globally_disabled_approval_tool',
+        description: 'Requires approval.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'approved',
+      });
+      const responses = [
+        approvalResponse(approvalTool.name),
+        responseWithoutUsage(),
+      ];
+      const agent = new Agent({
+        name: stream
+          ? 'Streaming globally re-enabled tracing agent'
+          : 'Globally re-enabled tracing agent',
+        model: stream
+          ? new StreamingModel(responses)
+          : new FakeModel(responses),
+        tools: [approvalTool],
+      });
+
+      setTracingDisabled(true);
+      const first = stream
+        ? await new Runner().run(agent, 'hello', { stream: true })
+        : await new Runner().run(agent, 'hello');
+      if ('completed' in first) {
+        await first.completed;
+      }
+      expect(first.interruptions).toHaveLength(1);
+      expect(processor.spansEnded).toHaveLength(0);
+      first.state.approve(first.interruptions[0]);
+
+      setTracingDisabled(false);
+      const resumed = stream
+        ? await new Runner().run(agent, first.state, { stream: true })
+        : await new Runner().run(agent, first.state);
+      if ('completed' in resumed) {
+        await resumed.completed;
+      }
+
+      expect(
+        processor.spansEnded.filter((span) => span.spanData.type === 'task'),
+      ).toHaveLength(1);
+      expect(
+        processor.spansEnded.filter((span) => span.spanData.type === 'turn'),
+      ).toHaveLength(1);
+    },
+  );
+
+  it('preserves the runner task and turn opt-out for nested agent tools when overriding the tracing API key', async () => {
+    const agent = createNestedAgentToolScenario();
+    const runner = new Runner({
+      tracing: { includeTaskAndTurnSpans: false },
+    });
+
+    await runner.run(agent, 'hello', {
+      tracing: {
+        apiKey: 'run-specific-key',
+        includeTaskAndTurnSpans: undefined,
+      },
+    });
+
+    expect(
+      processor.spansEnded.some(
+        (span) =>
+          span.spanData.type === 'task' || span.spanData.type === 'turn',
+      ),
+    ).toBe(false);
+    expect(
+      processor.spansEnded
+        .filter((span) => span.spanData.type === 'agent')
+        .every((span) => span.tracingApiKey === 'run-specific-key'),
+    ).toBe(true);
+  });
+
+  it('propagates the task and turn opt-out to nested agent tools', async () => {
+    const runnerConfiguredAgent = createNestedAgentToolScenario();
+    await new Runner({
+      tracing: { includeTaskAndTurnSpans: false },
+    }).run(runnerConfiguredAgent, 'hello');
+
+    expect(
+      processor.spansEnded.some(
+        (span) =>
+          span.spanData.type === 'task' || span.spanData.type === 'turn',
+      ),
+    ).toBe(false);
+
+    processor.spansStarted.length = 0;
+    processor.spansEnded.length = 0;
+
+    const callConfiguredAgent = createNestedAgentToolScenario();
+    await new Runner().run(callConfiguredAgent, 'hello', {
+      tracing: { includeTaskAndTurnSpans: false },
+    });
+
+    expect(
+      processor.spansEnded.some(
+        (span) =>
+          span.spanData.type === 'task' || span.spanData.type === 'turn',
+      ),
+    ).toBe(false);
+  });
+
+  it('propagates tracingDisabled to nested agent tools unless overridden', async () => {
+    const inheritedAgent = createNestedAgentToolScenario();
+    await new Runner({ tracingDisabled: true }).run(inheritedAgent, 'hello');
+
+    expect(
+      processor.spansEnded.some(
+        (span) =>
+          span.spanData.type === 'task' || span.spanData.type === 'turn',
+      ),
+    ).toBe(false);
+
+    processor.spansStarted.length = 0;
+    processor.spansEnded.length = 0;
+
+    const overriddenAgent = createNestedAgentToolScenario(undefined, false);
+    await new Runner({ tracingDisabled: true }).run(overriddenAgent, 'hello');
+
+    expect(
+      processor.spansEnded.filter((span) => span.spanData.type === 'task'),
+    ).toHaveLength(1);
+    expect(
+      processor.spansEnded.filter((span) => span.spanData.type === 'turn'),
+    ).toHaveLength(1);
+  });
+
+  it('isolates task and turn usage for parallel nested agent tools', async () => {
+    setTracingContextStorage(new BrowserAsyncLocalStorage());
+    const waitForBothModels = createBarrier(2);
+    const firstToolFinished = createDeferred();
+    const innerToolA = tool({
+      name: 'inner_tool_a',
+      description: 'Runs the first inner tool.',
+      parameters: z.object({}),
+      execute: async () => 'inner-a',
+    });
+    const innerToolB = tool({
+      name: 'inner_tool_b',
+      description: 'Runs the second inner tool.',
+      parameters: z.object({}),
+      execute: async () => 'inner-b',
+    });
+    const nestedAgentA = new Agent({
+      name: 'Nested agent A',
+      model: new CoordinatedModel(
+        [
+          toolCallResponseWithSpecificUsage(innerToolA.name, 10, 1),
+          responseWithSpecificUsage(11, 2),
+        ],
+        waitForBothModels,
+      ),
+      tools: [innerToolA],
+    });
+    const nestedAgentB = new Agent({
+      name: 'Nested agent B',
+      model: new CoordinatedModel(
+        [
+          toolCallResponseWithSpecificUsage(innerToolB.name, 20, 2),
+          responseWithSpecificUsage(21, 3),
+        ],
+        waitForBothModels,
+        firstToolFinished.promise,
+      ),
+      tools: [innerToolB],
+    });
+    const nestedToolA = nestedAgentA.asTool({
+      toolName: 'nested_agent_a',
+      toolDescription: 'Runs nested agent A.',
+      customOutputExtractor: (result) => {
+        firstToolFinished.resolve();
+        return String(result.finalOutput);
+      },
+    });
+    const nestedToolB = nestedAgentB.asTool({
+      toolName: 'nested_agent_b',
+      toolDescription: 'Runs nested agent B.',
+    });
+    const outerAgent = new Agent({
+      name: 'Outer parallel agent',
+      model: new FakeModel([
+        parallelAgentToolCallResponse([nestedToolA.name, nestedToolB.name]),
+        responseWithoutUsage(),
+      ]),
+      tools: [nestedToolA, nestedToolB],
+    });
+
+    await new Runner().run(outerAgent, 'hello');
+
+    const nestedAgentSpanA = processor.spansEnded.find(
+      (span) =>
+        span.spanData.type === 'agent' &&
+        span.spanData.name === nestedAgentA.name,
+    );
+    const nestedAgentSpanB = processor.spansEnded.find(
+      (span) =>
+        span.spanData.type === 'agent' &&
+        span.spanData.name === nestedAgentB.name,
+    );
+    const nestedTaskSpanA = processor.spansEnded.find(
+      (span) =>
+        span.spanData.type === 'task' &&
+        span.spanId === nestedAgentSpanA?.parentId,
+    );
+    const nestedTaskSpanB = processor.spansEnded.find(
+      (span) =>
+        span.spanData.type === 'task' &&
+        span.spanId === nestedAgentSpanB?.parentId,
+    );
+    const nestedTurnSpanA = processor.spansEnded.find(
+      (span) =>
+        span.spanData.type === 'turn' &&
+        span.parentId === nestedAgentSpanA?.spanId,
+    );
+    const nestedTurnSpanB = processor.spansEnded.find(
+      (span) =>
+        span.spanData.type === 'turn' &&
+        span.parentId === nestedAgentSpanB?.spanId,
+    );
+    const outerTaskSpan = processor.spansEnded.find(
+      (span) => span.spanData.type === 'task' && span.parentId === null,
+    );
+    const outerTurnSpan = processor.spansEnded.find(
+      (span) =>
+        span.spanData.type === 'turn' &&
+        span.spanData.agent_name === outerAgent.name,
+    );
+    const nestedFunctionSpanA = processor.spansEnded.find(
+      (span) =>
+        span.spanData.type === 'function' &&
+        span.spanData.name === nestedToolA.name,
+    );
+    const nestedFunctionSpanB = processor.spansEnded.find(
+      (span) =>
+        span.spanData.type === 'function' &&
+        span.spanData.name === nestedToolB.name,
+    );
+    const innerFunctionSpanA = processor.spansEnded.find(
+      (span) =>
+        span.spanData.type === 'function' &&
+        span.spanData.name === innerToolA.name,
+    );
+    const innerFunctionSpanB = processor.spansEnded.find(
+      (span) =>
+        span.spanData.type === 'function' &&
+        span.spanData.name === innerToolB.name,
+    );
+
+    expect(nestedFunctionSpanA?.parentId).toBe(outerTurnSpan?.spanId);
+    expect(nestedFunctionSpanB?.parentId).toBe(outerTurnSpan?.spanId);
+    expect(nestedTaskSpanA?.parentId).toBe(nestedFunctionSpanA?.spanId);
+    expect(nestedTaskSpanB?.parentId).toBe(nestedFunctionSpanB?.spanId);
+    expect(nestedTaskSpanA?.spanData.usage).toMatchObject({
+      requests: 2,
+      input_tokens: 21,
+      output_tokens: 3,
+      total_tokens: 24,
+    });
+    expect(nestedTaskSpanB?.spanData.usage).toMatchObject({
+      requests: 2,
+      input_tokens: 41,
+      output_tokens: 5,
+      total_tokens: 46,
+    });
+    expect(nestedTurnSpanA?.spanData.usage).toMatchObject({
+      input_tokens: 10,
+      output_tokens: 1,
+    });
+    expect(nestedTurnSpanB?.spanData.usage).toMatchObject({
+      input_tokens: 20,
+      output_tokens: 2,
+    });
+    expect(outerTaskSpan?.spanData.usage).toMatchObject({
+      requests: 4,
+      input_tokens: 62,
+      output_tokens: 8,
+      total_tokens: 70,
+    });
+    expect(outerTurnSpan?.spanData.usage).toMatchObject({
+      input_tokens: 62,
+      output_tokens: 8,
+    });
+    const nestedTurnSpansA = processor.spansEnded.filter(
+      (span) =>
+        span.spanData.type === 'turn' &&
+        span.spanData.agent_name === nestedAgentA.name,
+    );
+    const nestedTurnSpansB = processor.spansEnded.filter(
+      (span) =>
+        span.spanData.type === 'turn' &&
+        span.spanData.agent_name === nestedAgentB.name,
+    );
+    expect(nestedTurnSpansA).toHaveLength(2);
+    expect(nestedTurnSpansB).toHaveLength(2);
+    expect(innerFunctionSpanA?.parentId).toBe(nestedTurnSpansA[0]?.spanId);
+    expect(innerFunctionSpanB?.parentId).toBe(nestedTurnSpansB[0]?.spanId);
+    expect(
+      nestedTurnSpansA.every(
+        (span) => span.parentId === nestedAgentSpanA?.spanId,
+      ),
+    ).toBe(true);
+    expect(
+      nestedTurnSpansB.every(
+        (span) => span.parentId === nestedAgentSpanB?.spanId,
+      ),
+    ).toBe(true);
+  });
+
+  it('keeps parallel nested agent spans under their tools when task and turn spans are disabled', async () => {
+    setTracingContextStorage(new BrowserAsyncLocalStorage());
+    const waitForBothModels = createBarrier(2);
+    const nestedAgentA = new Agent({
+      name: 'Opt-out nested agent A',
+      model: new CoordinatedModel(responseWithoutUsage(), waitForBothModels),
+    });
+    const nestedAgentB = new Agent({
+      name: 'Opt-out nested agent B',
+      model: new CoordinatedModel(responseWithoutUsage(), waitForBothModels),
+    });
+    const nestedToolA = nestedAgentA.asTool({
+      toolName: 'opt_out_nested_agent_a',
+      toolDescription: 'Runs opt-out nested agent A.',
+    });
+    const nestedToolB = nestedAgentB.asTool({
+      toolName: 'opt_out_nested_agent_b',
+      toolDescription: 'Runs opt-out nested agent B.',
+    });
+    const outerAgent = new Agent({
+      name: 'Opt-out outer parallel agent',
+      model: new FakeModel([
+        parallelAgentToolCallResponse([nestedToolA.name, nestedToolB.name]),
+        responseWithoutUsage(),
+      ]),
+      tools: [nestedToolA, nestedToolB],
+    });
+
+    await new Runner({
+      tracing: { includeTaskAndTurnSpans: false },
+    }).run(outerAgent, 'hello');
+
+    expect(
+      processor.spansEnded.some(
+        (span) =>
+          span.spanData.type === 'task' || span.spanData.type === 'turn',
+      ),
+    ).toBe(false);
+    const outerAgentSpan = processor.spansEnded.find(
+      (span) =>
+        span.spanData.type === 'agent' &&
+        span.spanData.name === outerAgent.name,
+    );
+    const nestedAgentSpanA = processor.spansEnded.find(
+      (span) =>
+        span.spanData.type === 'agent' &&
+        span.spanData.name === nestedAgentA.name,
+    );
+    const nestedAgentSpanB = processor.spansEnded.find(
+      (span) =>
+        span.spanData.type === 'agent' &&
+        span.spanData.name === nestedAgentB.name,
+    );
+    const functionSpanA = processor.spansEnded.find(
+      (span) =>
+        span.spanData.type === 'function' &&
+        span.spanData.name === nestedToolA.name,
+    );
+    const functionSpanB = processor.spansEnded.find(
+      (span) =>
+        span.spanData.type === 'function' &&
+        span.spanData.name === nestedToolB.name,
+    );
+
+    expect(functionSpanA?.parentId).toBe(outerAgentSpan?.spanId);
+    expect(functionSpanB?.parentId).toBe(outerAgentSpan?.spanId);
+    expect(nestedAgentSpanA?.parentId).toBe(functionSpanA?.spanId);
+    expect(nestedAgentSpanB?.parentId).toBe(functionSpanB?.spanId);
+  });
+
+  it('keeps parallel nested handoff spans under their own turns in browser runtimes', async () => {
+    setTracingContextStorage(new BrowserAsyncLocalStorage());
+    const waitForBothModels = createBarrier(2);
+    const targetAgentA = new Agent({
+      name: 'Nested handoff target A',
+      model: new FakeModel([responseWithoutUsage()]),
+    });
+    const targetAgentB = new Agent({
+      name: 'Nested handoff target B',
+      model: new FakeModel([responseWithoutUsage()]),
+    });
+    const handoffA = handoff(targetAgentA);
+    const handoffB = handoff(targetAgentB);
+    const sourceAgentA = new Agent({
+      name: 'Nested handoff source A',
+      model: new CoordinatedModel(
+        handoffCallResponse(handoffA.toolName),
+        waitForBothModels,
+      ),
+      handoffs: [handoffA],
+    });
+    const sourceAgentB = new Agent({
+      name: 'Nested handoff source B',
+      model: new CoordinatedModel(
+        handoffCallResponse(handoffB.toolName),
+        waitForBothModels,
+      ),
+      handoffs: [handoffB],
+    });
+    const nestedToolA = sourceAgentA.asTool({
+      toolName: 'nested_handoff_agent_a',
+      toolDescription: 'Runs nested handoff agent A.',
+    });
+    const nestedToolB = sourceAgentB.asTool({
+      toolName: 'nested_handoff_agent_b',
+      toolDescription: 'Runs nested handoff agent B.',
+    });
+    const outerAgent = new Agent({
+      name: 'Outer parallel handoff agent',
+      model: new FakeModel([
+        parallelAgentToolCallResponse([nestedToolA.name, nestedToolB.name]),
+        responseWithoutUsage(),
+      ]),
+      tools: [nestedToolA, nestedToolB],
+    });
+
+    await new Runner().run(outerAgent, 'hello');
+
+    for (const sourceAgent of [sourceAgentA, sourceAgentB]) {
+      const sourceTurn = processor.spansEnded.find(
+        (span) =>
+          span.spanData.type === 'turn' &&
+          span.spanData.agent_name === sourceAgent.name,
+      );
+      const handoffSpan = processor.spansEnded.find(
+        (span) =>
+          span.spanData.type === 'handoff' &&
+          span.spanData.from_agent === sourceAgent.name,
+      );
+      expect(handoffSpan?.parentId).toBe(sourceTurn?.spanId);
+    }
+  });
+
+  it('keeps parallel nested MCP list spans under their own agents in browser runtimes', async () => {
+    setTracingContextStorage(new BrowserAsyncLocalStorage());
+    const waitForBothServers = createBarrier(2);
+    const serverA = new CoordinatedMCPServer(
+      'Nested MCP server A',
+      waitForBothServers,
+    );
+    const serverB = new CoordinatedMCPServer(
+      'Nested MCP server B',
+      waitForBothServers,
+    );
+    const nestedAgentA = new Agent({
+      name: 'Nested MCP agent A',
+      model: new FakeModel([responseWithoutUsage()]),
+      mcpServers: [serverA],
+    });
+    const nestedAgentB = new Agent({
+      name: 'Nested MCP agent B',
+      model: new FakeModel([responseWithoutUsage()]),
+      mcpServers: [serverB],
+    });
+    const nestedToolA = nestedAgentA.asTool({
+      toolName: 'nested_mcp_agent_a',
+      toolDescription: 'Runs nested MCP agent A.',
+    });
+    const nestedToolB = nestedAgentB.asTool({
+      toolName: 'nested_mcp_agent_b',
+      toolDescription: 'Runs nested MCP agent B.',
+    });
+    const outerAgent = new Agent({
+      name: 'Outer parallel MCP agent',
+      model: new FakeModel([
+        parallelAgentToolCallResponse([nestedToolA.name, nestedToolB.name]),
+        responseWithoutUsage(),
+      ]),
+      tools: [nestedToolA, nestedToolB],
+    });
+
+    await new Runner().run(outerAgent, 'hello');
+
+    for (const [agent, server] of [
+      [nestedAgentA, serverA],
+      [nestedAgentB, serverB],
+    ] as const) {
+      const agentSpan = processor.spansEnded.find(
+        (span) =>
+          span.spanData.type === 'agent' && span.spanData.name === agent.name,
+      );
+      const mcpSpan = processor.spansEnded.find(
+        (span) =>
+          span.spanData.type === 'mcp_tools' &&
+          span.spanData.server === server.name,
+      );
+      expect(mcpSpan?.parentId).toBe(agentSpan?.spanId);
+    }
+  });
+
+  it('records parallel MCP tool metadata on the matching function spans in browser runtimes', async () => {
+    setTracingContextStorage(new BrowserAsyncLocalStorage());
+    const waitForBothTools = createBarrier(2);
+    const serverA = new CoordinatedMCPToolServer(
+      'Parallel MCP tool server A',
+      'parallel_mcp_tool_a',
+      waitForBothTools,
+    );
+    const serverB = new CoordinatedMCPToolServer(
+      'Parallel MCP tool server B',
+      'parallel_mcp_tool_b',
+      waitForBothTools,
+    );
+    const agent = new Agent({
+      name: 'Parallel MCP tool agent',
+      model: new FakeModel([
+        parallelAgentToolCallResponse([serverA.toolName, serverB.toolName]),
+        responseWithoutUsage(),
+      ]),
+      mcpServers: [serverA, serverB],
+    });
+
+    await new Runner().run(agent, 'hello');
+
+    for (const server of [serverA, serverB]) {
+      const functionSpan = processor.spansEnded.find(
+        (span) =>
+          span.spanData.type === 'function' &&
+          span.spanData.name === server.toolName,
+      );
+      expect(functionSpan?.spanData).toMatchObject({
+        mcp_data: { server: server.name },
+      });
+    }
+  });
+
+  it('captures distinct external trace parents for concurrent runs on a shared runner', async () => {
+    setTracingContextStorage(new BrowserAsyncLocalStorage());
+    const waitForBothModels = createBarrier(2);
+    const agentA = new Agent({
+      name: 'Concurrent external parent agent A',
+      model: new CoordinatedModel(responseWithoutUsage(), waitForBothModels),
+    });
+    const agentB = new Agent({
+      name: 'Concurrent external parent agent B',
+      model: new CoordinatedModel(responseWithoutUsage(), waitForBothModels),
+    });
+    const runner = new Runner();
+
+    const runUnderParent = async (agent: Agent, label: string) =>
+      withTrace(`External workflow ${label}`, async (trace) => {
+        const parent = createAgentSpan(
+          { data: { name: `External parent ${label}` } },
+          trace,
+        );
+        parent.start();
+        try {
+          await withTraceContext({ trace, span: parent }, () =>
+            runner.run(agent, `hello ${label}`),
+          );
+        } finally {
+          parent.end();
+        }
+        return parent;
+      });
+
+    const [parentA, parentB] = await Promise.all([
+      runUnderParent(agentA, 'A'),
+      runUnderParent(agentB, 'B'),
+    ]);
+
+    for (const [agent, parent] of [
+      [agentA, parentA],
+      [agentB, parentB],
+    ] as const) {
+      const agentSpan = processor.spansEnded.find(
+        (span) =>
+          span.spanData.type === 'agent' && span.spanData.name === agent.name,
+      );
+      const taskSpan = processor.spansEnded.find(
+        (span) =>
+          span.spanData.type === 'task' && span.spanId === agentSpan?.parentId,
+      );
+      expect(taskSpan?.parentId).toBe(parent.spanId);
+      expect(taskSpan?.traceId).toBe(parent.traceId);
+    }
+  });
+
+  it.each([true, false])(
+    'creates distinct traces for concurrent top-level runs in browser runtimes (task/turn=%s)',
+    async (includeTaskAndTurnSpans) => {
+      setTracingContextStorage(new BrowserAsyncLocalStorage());
+      const waitForBothModels = createBarrier(2);
+      const agentA = new Agent({
+        name: 'Concurrent top-level agent A',
+        model: new CoordinatedModel(responseWithoutUsage(), waitForBothModels),
+      });
+      const agentB = new Agent({
+        name: 'Concurrent top-level agent B',
+        model: new CoordinatedModel(responseWithoutUsage(), waitForBothModels),
+      });
+      const runner = new Runner({
+        tracing: { includeTaskAndTurnSpans },
+      });
+
+      await Promise.all([
+        runner.run(agentA, 'hello A'),
+        runner.run(agentB, 'hello B'),
+      ]);
+
+      const rootSpanForAgent = (agent: Agent) => {
+        const agentSpan = processor.spansEnded.find(
+          (span) =>
+            span.spanData.type === 'agent' && span.spanData.name === agent.name,
+        );
+        return includeTaskAndTurnSpans
+          ? processor.spansEnded.find(
+              (span) =>
+                span.spanData.type === 'task' &&
+                span.spanId === agentSpan?.parentId,
+            )
+          : agentSpan;
+      };
+      expect(rootSpanForAgent(agentA)?.traceId).not.toBe(
+        rootSpanForAgent(agentB)?.traceId,
+      );
+      if (!includeTaskAndTurnSpans) {
+        expect(
+          processor.spansEnded.some(
+            (span) =>
+              span.spanData.type === 'task' || span.spanData.type === 'turn',
+          ),
+        ).toBe(false);
+      }
+    },
+  );
+
+  it('keeps parallel model generation spans under their own turns in browser runtimes', async () => {
+    setTracingContextStorage(new BrowserAsyncLocalStorage());
+    const waitForBothModels = createBarrier(2);
+    const agentA = new Agent({
+      name: 'Parallel generation agent A',
+      model: new CoordinatedTracingModel(
+        'parallel-generation-model-a',
+        waitForBothModels,
+      ),
+    });
+    const agentB = new Agent({
+      name: 'Parallel generation agent B',
+      model: new CoordinatedTracingModel(
+        'parallel-generation-model-b',
+        waitForBothModels,
+      ),
+    });
+
+    await Promise.all([
+      new Runner().run(agentA, 'hello A'),
+      new Runner().run(agentB, 'hello B'),
+    ]);
+
+    for (const [agent, model] of [
+      [agentA, 'parallel-generation-model-a'],
+      [agentB, 'parallel-generation-model-b'],
+    ] as const) {
+      const turnSpan = processor.spansEnded.find(
+        (span) =>
+          span.spanData.type === 'turn' &&
+          span.spanData.agent_name === agent.name,
+      );
+      const generationSpan = processor.spansEnded.find(
+        (span) =>
+          span.spanData.type === 'generation' && span.spanData.model === model,
+      );
+      expect(generationSpan?.parentId).toBe(turnSpan?.spanId);
+    }
+  });
+
+  it('keeps parallel streamed generation spans under their own turns in browser runtimes', async () => {
+    setTracingContextStorage(new BrowserAsyncLocalStorage());
+    const waitForBothModels = createBarrier(2);
+    const agentA = new Agent({
+      name: 'Parallel streamed generation agent A',
+      model: new CoordinatedStreamingTracingModel(
+        'parallel-streamed-generation-model-a',
+        waitForBothModels,
+      ),
+    });
+    const agentB = new Agent({
+      name: 'Parallel streamed generation agent B',
+      model: new CoordinatedStreamingTracingModel(
+        'parallel-streamed-generation-model-b',
+        waitForBothModels,
+      ),
+    });
+
+    const [resultA, resultB] = await Promise.all([
+      new Runner().run(agentA, 'hello A', { stream: true }),
+      new Runner().run(agentB, 'hello B', { stream: true }),
+    ]);
+    await Promise.all([resultA.completed, resultB.completed]);
+
+    for (const [agent, model] of [
+      [agentA, 'parallel-streamed-generation-model-a'],
+      [agentB, 'parallel-streamed-generation-model-b'],
+    ] as const) {
+      const turnSpan = processor.spansEnded.find(
+        (span) =>
+          span.spanData.type === 'turn' &&
+          span.spanData.agent_name === agent.name,
+      );
+      const generationSpan = processor.spansEnded.find(
+        (span) =>
+          span.spanData.type === 'generation' && span.spanData.model === model,
+      );
+      expect(generationSpan?.parentId).toBe(turnSpan?.spanId);
+    }
+  });
+
+  it('keeps parallel generation spans under their own agents when task and turn spans are disabled', async () => {
+    setTracingContextStorage(new BrowserAsyncLocalStorage());
+    const waitForBothModels = createBarrier(2);
+    const agentA = new Agent({
+      name: 'Opt-out parallel generation agent A',
+      model: new CoordinatedTracingModel(
+        'opt-out-parallel-generation-model-a',
+        waitForBothModels,
+      ),
+    });
+    const agentB = new Agent({
+      name: 'Opt-out parallel generation agent B',
+      model: new CoordinatedTracingModel(
+        'opt-out-parallel-generation-model-b',
+        waitForBothModels,
+      ),
+    });
+
+    await Promise.all([
+      new Runner({ tracing: { includeTaskAndTurnSpans: false } }).run(
+        agentA,
+        'hello A',
+      ),
+      new Runner({ tracing: { includeTaskAndTurnSpans: false } }).run(
+        agentB,
+        'hello B',
+      ),
+    ]);
+
+    expect(
+      processor.spansEnded.some(
+        (span) =>
+          span.spanData.type === 'task' || span.spanData.type === 'turn',
+      ),
+    ).toBe(false);
+    for (const [agent, model] of [
+      [agentA, 'opt-out-parallel-generation-model-a'],
+      [agentB, 'opt-out-parallel-generation-model-b'],
+    ] as const) {
+      const agentSpan = processor.spansEnded.find(
+        (span) =>
+          span.spanData.type === 'agent' && span.spanData.name === agent.name,
+      );
+      const generationSpan = processor.spansEnded.find(
+        (span) =>
+          span.spanData.type === 'generation' && span.spanData.model === model,
+      );
+      expect(generationSpan?.parentId).toBe(agentSpan?.spanId);
+    }
+  });
+
+  it('keeps every model retry span under the same turn and counts failed attempts', async () => {
+    const agent = new Agent({
+      name: 'Retry tracing agent',
+      model: new RetryingTracingModel(),
+      modelSettings: {
+        retry: {
+          maxRetries: 1,
+          backoff: { initialDelayMs: 0, jitter: false },
+          policy: retryPolicies.httpStatus([429]),
+        },
+      },
+    });
+
+    await new Runner().run(agent, 'hello');
+
+    const turnSpan = spanOfType(processor, 'turn');
+    const taskSpan = spanOfType(processor, 'task');
+    const generationSpans = processor.spansEnded.filter(
+      (span) => span.spanData.type === 'generation',
+    );
+    expect(generationSpans).toHaveLength(2);
+    expect(
+      generationSpans.every((span) => span.parentId === turnSpan.spanId),
+    ).toBe(true);
+    expect(generationSpans[0]?.error?.message).toBe('Rate limited');
+    expect(taskSpan.spanData.usage).toMatchObject({
+      requests: 2,
+      input_tokens: 7,
+      output_tokens: 3,
+      total_tokens: 10,
+    });
+  });
+
+  it('preserves the inherited task and turn opt-out when a nested agent tool overrides the tracing API key', async () => {
+    const agent = createNestedAgentToolScenario({
+      apiKey: 'nested-agent-key',
+    });
+
+    await new Runner({
+      tracing: { includeTaskAndTurnSpans: false },
+    }).run(agent, 'hello');
+
+    expect(
+      processor.spansEnded.some(
+        (span) =>
+          span.spanData.type === 'task' || span.spanData.type === 'turn',
+      ),
+    ).toBe(false);
+  });
+
+  it('merges inherited and nested agent tool tracing fields in both directions', () => {
+    expect(
+      mergeAgentToolRunConfig(
+        { tracing: { includeTaskAndTurnSpans: false } },
+        { tracing: { apiKey: 'nested-agent-key' } },
+      ).tracing,
+    ).toEqual({
+      apiKey: 'nested-agent-key',
+      includeTaskAndTurnSpans: false,
+    });
+    expect(
+      mergeAgentToolRunConfig(
+        { tracing: { apiKey: 'parent-key' } },
+        { tracing: { includeTaskAndTurnSpans: false } },
+      ).tracing,
+    ).toEqual({
+      apiKey: 'parent-key',
+      includeTaskAndTurnSpans: false,
+    });
+    expect(
+      mergeAgentToolRunConfig(
+        {
+          tracing: {
+            apiKey: 'parent-key',
+            includeTaskAndTurnSpans: false,
+          },
+        },
+        {
+          tracing: {
+            apiKey: undefined,
+            includeTaskAndTurnSpans: undefined,
+          },
+        },
+      ).tracing,
+    ).toEqual({
+      apiKey: 'parent-key',
+      includeTaskAndTurnSpans: false,
+    });
+  });
+
+  it('allows a nested agent tool to override the parent tracing opt-out', async () => {
+    const agent = createNestedAgentToolScenario({
+      includeTaskAndTurnSpans: true,
+    });
+
+    await new Runner({
+      tracing: { includeTaskAndTurnSpans: false },
+    }).run(agent, 'hello');
+
+    expect(
+      processor.spansEnded.filter((span) => span.spanData.type === 'task'),
+    ).toHaveLength(1);
+    expect(
+      processor.spansEnded.filter((span) => span.spanData.type === 'turn'),
+    ).toHaveLength(1);
+  });
+
+  it('keeps task and turn spans active until a streamed run completes', async () => {
+    const agent = new Agent({
+      name: 'Streamer',
+      model: new StreamingModel(responseWithUsage()),
+    });
+    const runner = new Runner();
+
+    const result = await runner.run(agent, 'hello', { stream: true });
+    await result.completed;
+
+    const taskSpan = spanOfType(processor, 'task');
+    const agentSpan = spanOfType(processor, 'agent');
+    const turnSpan = spanOfType(processor, 'turn');
+    expect(agentSpan.parentId).toBe(taskSpan.spanId);
+    expect(turnSpan.parentId).toBe(agentSpan.spanId);
+    expect(taskSpan.spanData.usage).toMatchObject({ requests: 1 });
+    expect(turnSpan.spanData.usage).toMatchObject({ input_tokens: 12 });
+  });
+
+  it('ends task and turn spans exactly once when a streamed run is cancelled', async () => {
+    const agent = new Agent({
+      name: 'Cancelled streamer',
+      model: new HangingStreamingModel(),
+    });
+    const result = await new Runner().run(agent, 'hello', { stream: true });
+    const reader = (result.toStream() as any).getReader();
+
+    await new Promise((resolve) => setImmediate(resolve));
+    await reader.cancel('stop');
+    await result._getStreamLoopPromise();
+
+    for (const type of ['task', 'agent', 'turn']) {
+      expect(
+        processor.spansStarted.filter((span) => span.spanData.type === type),
+      ).toHaveLength(1);
+      expect(
+        processor.spansEnded.filter((span) => span.spanData.type === type),
+      ).toHaveLength(1);
+    }
+    expect(result.state._currentTurnInProgress).toBe(true);
+  });
+
+  it.each([false, true])(
+    'keeps helper parent spans open until a streamed runner completes (browser=%s)',
+    async (browser) => {
+      if (browser) {
+        setTracingContextStorage(new BrowserAsyncLocalStorage());
+      }
+      const agent = new Agent({
+        name: 'Helper parent streamer',
+        model: new HangingStreamingModel(),
+      });
+
+      const result = await withTrace('Helper parent workflow', async () =>
+        withAgentSpan(
+          async () => new Runner().run(agent, 'hello', { stream: true }),
+          { data: { name: 'Helper parent' } },
+        ),
+      );
+      const helperParent = processor.spansStarted.find(
+        (span) =>
+          span.spanData.type === 'agent' &&
+          span.spanData.name === 'Helper parent',
+      );
+      const taskSpan = processor.spansStarted.find(
+        (span) => span.spanData.type === 'task',
+      );
+
+      expect(helperParent?.endedAt).toBeNull();
+      expect(taskSpan?.parentId).toBe(helperParent?.spanId);
+
+      const reader = (result.toStream() as any).getReader();
+      await new Promise((resolve) => setImmediate(resolve));
+      await reader.cancel('stop');
+      await result._getStreamLoopPromise();
+
+      expect(taskSpan?.endedAt).not.toBeNull();
+      expect(helperParent?.endedAt).not.toBeNull();
+      expect(processor.spanErrorsAtEnd.get(helperParent!.spanId)).toBeNull();
+      expect(Date.parse(taskSpan!.endedAt!)).toBeLessThanOrEqual(
+        Date.parse(helperParent!.endedAt!),
+      );
+    },
+  );
+
+  it.each([false, true])(
+    'marks helper parent spans when a streamed runner fails (browser=%s)',
+    async (browser) => {
+      if (browser) {
+        setTracingContextStorage(new BrowserAsyncLocalStorage());
+      }
+      const failureError = Object.assign(new Error('stream model failed'), {
+        data: { phase: 'model stream' },
+      });
+      const agent = new Agent({
+        name: 'Helper parent failure streamer',
+        model: new FailingModel(failureError),
+      });
+
+      const result = await withTrace(
+        'Helper parent failure workflow',
+        async () =>
+          withAgentSpan(
+            async () => new Runner().run(agent, 'hello', { stream: true }),
+            { data: { name: 'Helper parent failure' } },
+          ),
+      );
+
+      await expect(result.completed).rejects.toBe(failureError);
+      await result._getStreamLoopPromise();
+      await Promise.resolve();
+
+      const helperParent = processor.spansEnded.find(
+        (span) =>
+          span.spanData.type === 'agent' &&
+          span.spanData.name === 'Helper parent failure',
+      );
+      expect(helperParent).toBeDefined();
+      expect(processor.spanErrorsAtEnd.get(helperParent!.spanId)).toMatchObject(
+        {
+          message: 'stream model failed',
+          data: { phase: 'model stream' },
+        },
+      );
+    },
+  );
+
+  it('attributes stream abort reconciliation usage to the open task and turn', async () => {
+    const agent = new Agent({
+      name: 'Abort reconciliation usage agent',
+      model: new AbortReconciliationUsageModel(),
+    });
+
+    const result = await new Runner().run(agent, 'hello', {
+      stream: true,
+      conversationId: 'conversation-for-abort-reconciliation',
+    });
+    await result.completed;
+
+    expect(result.state._context.usage).toMatchObject({
+      requests: 1,
+      inputTokens: 7,
+      outputTokens: 3,
+      totalTokens: 10,
+    });
+    expect(spanOfType(processor, 'task').spanData.usage).toMatchObject({
+      requests: 1,
+      input_tokens: 7,
+      output_tokens: 3,
+      total_tokens: 10,
+    });
+    expect(spanOfType(processor, 'turn').spanData.usage).toMatchObject({
+      input_tokens: 7,
+      output_tokens: 3,
+    });
+  });
+
+  it('includes session compaction usage in task spans for non-streaming and streaming runs', async () => {
+    const runner = new Runner();
+    const nonStreamingAgent = new Agent({
+      name: 'Non-streaming compaction agent',
+      model: new FakeModel([responseWithUsage()]),
+    });
+
+    await runner.run(nonStreamingAgent, 'hello', {
+      session: new UsageCompactionSession(),
+    });
+
+    const nonStreamingTaskSpan = spanOfType(processor, 'task');
+    expect(nonStreamingTaskSpan.spanData.usage).toMatchObject({
+      requests: 2,
+      input_tokens: 17,
+      output_tokens: 6,
+      total_tokens: 23,
+    });
+
+    processor.spansStarted.length = 0;
+    processor.spansEnded.length = 0;
+
+    const streamingAgent = new Agent({
+      name: 'Streaming compaction agent',
+      model: new StreamingModel(responseWithUsage()),
+    });
+    const streamingResult = await runner.run(streamingAgent, 'hello', {
+      stream: true,
+      session: new UsageCompactionSession(),
+    });
+    await streamingResult.completed;
+
+    const streamingTaskSpan = spanOfType(processor, 'task');
+    expect(streamingTaskSpan.spanData.usage).toEqual(
+      nonStreamingTaskSpan.spanData.usage,
+    );
+  });
+
+  it.each([false, true])(
+    'ends task and turn spans when session compaction fails (stream=%s)',
+    async (stream) => {
+      const agent = new Agent({
+        name: stream
+          ? 'Streaming compaction failure agent'
+          : 'Compaction failure agent',
+        model: stream
+          ? new StreamingModel(responseWithUsage())
+          : new FakeModel([responseWithUsage()]),
+      });
+      const runner = new Runner();
+      const session = new FailingCompactionSession();
+
+      if (stream) {
+        const result = await runner.run(agent, 'hello', {
+          stream: true,
+          session,
+        });
+        await expect(result.completed).rejects.toBe(session.error);
+      } else {
+        await expect(runner.run(agent, 'hello', { session })).rejects.toBe(
+          session.error,
+        );
+      }
+
+      for (const type of ['task', 'agent', 'turn']) {
+        const started = processor.spansStarted.filter(
+          (span) => span.spanData.type === type,
+        );
+        const ended = processor.spansEnded.filter(
+          (span) => span.spanData.type === type,
+        );
+        expect(started, `started ${type} spans`).toHaveLength(1);
+        expect(ended, `ended ${type} spans`).toHaveLength(1);
+        expect(ended[0]?.endedAt).not.toBeNull();
+      }
+      expect(spanOfType(processor, 'task').spanData.usage).toMatchObject({
+        requests: 1,
+        input_tokens: 12,
+        output_tokens: 4,
+        total_tokens: 16,
+      });
+      const taskSpan = spanOfType(processor, 'task');
+      expect(processor.spanErrorsAtEnd.get(taskSpan.spanId)).toEqual({
+        message: 'Error in agent run',
+        data: { error: String(session.error) },
+      });
+      expect(spanOfType(processor, 'turn').error).toBeNull();
+    },
+  );
+
+  it('marks the task span when non-streaming session writes fail', async () => {
+    const agent = new Agent({
+      name: 'Session write failure agent',
+      model: new FakeModel([responseWithUsage()]),
+    });
+
+    const session = new FailingAddItemsSession();
+    await expect(new Runner().run(agent, 'hello', { session })).rejects.toBe(
+      session.error,
+    );
+
+    const taskSpan = spanOfType(processor, 'task');
+    expect(processor.spanErrorsAtEnd.get(taskSpan.spanId)).toEqual({
+      message: 'Error in agent run',
+      data: { error: String(session.error) },
+    });
+    expect(spanOfType(processor, 'turn').error).toBeNull();
+  });
+
+  it.each([false, true])(
+    'marks the task span when sandbox finalization fails (stream=%s)',
+    async (stream) => {
+      const cleanupError = new Error('sandbox cleanup failed');
+      const cleanupSpy = vi
+        .spyOn(SandboxRuntimeManager.prototype, 'cleanup')
+        .mockRejectedValue(cleanupError);
+      const agent = new Agent({
+        name: stream
+          ? 'Streaming sandbox cleanup failure agent'
+          : 'Sandbox cleanup failure agent',
+        model: stream
+          ? new StreamingModel(responseWithUsage())
+          : new FakeModel([responseWithUsage()]),
+      });
+
+      try {
+        if (stream) {
+          const result = await new Runner().run(agent, 'hello', {
+            stream: true,
+          });
+          await expect(result.completed).rejects.toBe(cleanupError);
+        } else {
+          await expect(new Runner().run(agent, 'hello')).rejects.toBe(
+            cleanupError,
+          );
+        }
+      } finally {
+        cleanupSpy.mockRestore();
+      }
+
+      const taskSpan = spanOfType(processor, 'task');
+      expect(processor.spanErrorsAtEnd.get(taskSpan.spanId)).toEqual({
+        message: 'Error in agent run',
+        data: { error: String(cleanupError) },
+      });
+      expect(spanOfType(processor, 'turn').error).toBeNull();
+    },
+  );
+
+  it.each([false, true])(
+    'keeps the turn span open until output guardrails settle (stream=%s)',
+    async (stream) => {
+      let signalGuardrailStarted: () => void = () => {};
+      const guardrailStarted = new Promise<void>((resolve) => {
+        signalGuardrailStarted = resolve;
+      });
+      let releaseGuardrail: () => void = () => {};
+      const guardrailRelease = new Promise<void>((resolve) => {
+        releaseGuardrail = resolve;
+      });
+      const agent = new Agent({
+        name: stream
+          ? 'Streaming output guardrail tracing agent'
+          : 'Output guardrail tracing agent',
+        model: stream
+          ? new StreamingModel(responseWithoutUsage())
+          : new FakeModel([responseWithoutUsage()]),
+        outputGuardrails: [
+          {
+            name: 'delayed output guardrail',
+            execute: async () => {
+              signalGuardrailStarted();
+              await guardrailRelease;
+              return {
+                tripwireTriggered: true,
+                outputInfo: { reason: 'blocked' },
+              };
+            },
+          },
+        ],
+      });
+      const runner = new Runner();
+
+      let completion: Promise<unknown>;
+      if (stream) {
+        const result = await runner.run(agent, 'hello', { stream: true });
+        completion = result.completed;
+      } else {
+        completion = runner.run(agent, 'hello');
+      }
+
+      await guardrailStarted;
+      const turnSpan = processor.spansStarted.find(
+        (span) => span.spanData.type === 'turn',
+      );
+      const guardrailSpan = processor.spansStarted.find(
+        (span) => span.spanData.type === 'guardrail',
+      );
+      expect(turnSpan?.endedAt).toBeNull();
+      expect(guardrailSpan?.endedAt).toBeNull();
+
+      releaseGuardrail();
+      await expect(completion).rejects.toBeInstanceOf(
+        OutputGuardrailTripwireTriggered,
+      );
+
+      expect(guardrailSpan?.endedAt).not.toBeNull();
+      expect(turnSpan?.endedAt).not.toBeNull();
+      expect(Date.parse(guardrailSpan!.endedAt!)).toBeLessThanOrEqual(
+        Date.parse(turnSpan!.endedAt!),
+      );
+    },
+  );
+
+  it.each(
+    ['model', 'tool', 'guardrail'].flatMap((failure) =>
+      [false, true].map((stream) => ({ failure, stream })),
+    ),
+  )(
+    'marks task and turn spans when a $failure failure escapes (stream=$stream)',
+    async ({ failure, stream }) => {
+      const failureError = new Error(`${failure} failure`);
+      const failingTool = tool({
+        name: 'failing_tool',
+        description: 'Fails for tracing verification.',
+        parameters: z.object({}),
+        execute: async () => {
+          throw failureError;
+        },
+        errorFunction: null,
+      });
+      const response =
+        failure === 'tool'
+          ? approvalResponse(failingTool.name)
+          : responseWithoutUsage();
+      const agent = new Agent({
+        name: `${failure} failure tracing agent`,
+        model:
+          failure === 'model'
+            ? new FailingModel(failureError)
+            : stream
+              ? new StreamingModel(response)
+              : new FakeModel([response]),
+        tools: failure === 'tool' ? [failingTool] : [],
+        outputGuardrails:
+          failure === 'guardrail'
+            ? [
+                {
+                  name: 'failing output guardrail',
+                  execute: async () => {
+                    throw failureError;
+                  },
+                },
+              ]
+            : [],
+      });
+      const runner = new Runner();
+
+      let completion: Promise<unknown>;
+      if (stream) {
+        const result = await runner.run(agent, 'hello', { stream: true });
+        completion = result.completed;
+      } else {
+        completion = runner.run(agent, 'hello');
+      }
+
+      let escapedError: unknown;
+      try {
+        await completion;
+      } catch (error) {
+        escapedError = error;
+      }
+      expect(escapedError).toBeDefined();
+
+      for (const type of ['task', 'turn']) {
+        const span = spanOfType(processor, type);
+        const expectedError = {
+          message: 'Error in agent run',
+          data: { error: String(escapedError) },
+        };
+        expect(span.error).toEqual(expectedError);
+        expect(processor.spanErrorsAtEnd.get(span.spanId)).toEqual(
+          expectedError,
+        );
+      }
+    },
+  );
+
+  it.each([false, true])(
+    'does not mark a recovered task as failed or replace its turn error (stream=%s)',
+    async (stream) => {
+      const response: ModelResponse = {
+        output: [fakeModelMessage('not valid json')],
+        usage: new Usage(),
+      };
+      const agent = new Agent({
+        name: 'Recovered tracing agent',
+        outputType: z.object({ summary: z.string() }),
+        model: stream
+          ? new StreamingModel(response)
+          : new FakeModel([response]),
+      });
+      const runner = new Runner();
+      const options = {
+        errorHandlers: {
+          invalidFinalOutput: () => ({
+            finalOutput: { summary: 'safe fallback' },
+          }),
+        },
+      };
+
+      if (stream) {
+        const result = await runner.run(agent, 'hello', {
+          ...options,
+          stream: true,
+        });
+        await result.completed;
+        expect(result.finalOutput).toEqual({ summary: 'safe fallback' });
+      } else {
+        const result = await runner.run(agent, 'hello', options);
+        expect(result.finalOutput).toEqual({ summary: 'safe fallback' });
+      }
+
+      expect(spanOfType(processor, 'task').error).toBeNull();
+      expect(spanOfType(processor, 'turn').error).toMatchObject({
+        message: expect.stringContaining('Invalid output type'),
+      });
+    },
+  );
+
+  it.each([false, true])(
+    'marks task and turn spans when an error handler fails (stream=%s)',
+    async (stream) => {
+      const response: ModelResponse = {
+        output: [fakeModelMessage('not valid json')],
+        usage: new Usage(),
+      };
+      const agent = new Agent({
+        name: 'Failed error handler tracing agent',
+        outputType: z.object({ summary: z.string() }),
+        model: stream
+          ? new StreamingModel(response)
+          : new FakeModel([response]),
+      });
+      const handlerError = new Error('error handler failure');
+      const options = {
+        errorHandlers: {
+          invalidFinalOutput: () => {
+            throw handlerError;
+          },
+        },
+      };
+
+      let completion: Promise<unknown>;
+      if (stream) {
+        const result = await new Runner().run(agent, 'hello', {
+          ...options,
+          stream: true,
+        });
+        completion = result.completed;
+      } else {
+        completion = new Runner().run(agent, 'hello', options);
+      }
+      await expect(completion).rejects.toBe(handlerError);
+
+      for (const type of ['task', 'turn']) {
+        const span = spanOfType(processor, type);
+        expect(processor.spanErrorsAtEnd.get(span.spanId)).toEqual({
+          message: 'Error in agent run',
+          data: { error: String(handlerError) },
+        });
+      }
+    },
+  );
+
+  it('omits task and turn spans from streamed runs when disabled', async () => {
+    const agent = new Agent({
+      name: 'Streamer',
+      model: new StreamingModel(responseWithUsage()),
+    });
+    const runner = new Runner({
+      tracing: { includeTaskAndTurnSpans: false },
+    });
+
+    const result = await runner.run(agent, 'hello', { stream: true });
+    await result.completed;
+
+    expect(
+      processor.spansEnded.some(
+        (span) =>
+          span.spanData.type === 'task' || span.spanData.type === 'turn',
+      ),
+    ).toBe(false);
+    expect(spanOfType(processor, 'agent').parentId).toBeNull();
+  });
+
+  it('uses invocation-local usage and a fresh agent span when resuming', async () => {
+    const agent = new Agent({
+      name: 'Resumed agent',
+      model: new FakeModel([responseWithUsage()]),
+    });
+    const state = new RunState(new RunContext(), 'hello', agent, 10);
+    state._context.usage.add(
+      new Usage({ inputTokens: 100, outputTokens: 50, totalTokens: 150 }),
+    );
+    const trace = getGlobalTraceProvider().createTrace({
+      name: 'Resumed workflow',
+    });
+    const restoredAgentSpan = createAgentSpan(
+      { data: { name: 'Resumed agent' } },
+      trace,
+    );
+    restoredAgentSpan.start();
+    state._trace = trace;
+    state.setCurrentAgentSpan(restoredAgentSpan);
+
+    await new Runner().run(agent, state);
+
+    const taskSpan = spanOfType(processor, 'task');
+    const turnSpan = spanOfType(processor, 'turn');
+    const freshAgentSpan = processor.spansEnded.find(
+      (span) =>
+        span.spanData.type === 'agent' &&
+        span.spanId !== restoredAgentSpan.spanId,
+    );
+    expect(restoredAgentSpan.endedAt).not.toBeNull();
+    expect(freshAgentSpan?.parentId).toBe(taskSpan.spanId);
+    expect(turnSpan.parentId).toBe(freshAgentSpan?.spanId);
+    expect(taskSpan.spanData.usage).toMatchObject({
+      input_tokens: 12,
+      output_tokens: 4,
+      total_tokens: 16,
+    });
+  });
+
+  it.each([false, true])(
+    'ends an interrupted agent span before its task span (stream=%s)',
+    async (stream) => {
+      const approvalTool = tool({
+        name: stream
+          ? 'streaming_interrupted_span_tool'
+          : 'interrupted_span_tool',
+        description: 'Requires approval.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'approved',
+      });
+      const response = approvalResponse(approvalTool.name);
+      const agent = new Agent({
+        name: stream
+          ? 'Streaming interrupted span agent'
+          : 'Interrupted span agent',
+        model: stream
+          ? new StreamingModel(response)
+          : new FakeModel([response]),
+        tools: [approvalTool],
+      });
+
+      const result = stream
+        ? await new Runner().run(agent, 'hello', { stream: true })
+        : await new Runner().run(agent, 'hello');
+      if ('completed' in result) {
+        await result.completed;
+      }
+
+      expect(result.interruptions).toHaveLength(1);
+      const agentSpan = result.state._currentAgentSpan;
+      const taskSpan = spanOfType(processor, 'task');
+      expect(agentSpan?.endedAt).not.toBeNull();
+      expect(processor.spansEnded).toContain(agentSpan);
+      expect(Date.parse(agentSpan!.endedAt!)).toBeLessThanOrEqual(
+        Date.parse(taskSpan.endedAt!),
+      );
+    },
+  );
+
+  it.each([false, true])(
+    'preserves an interrupted agent span when task and turn spans are disabled (stream=%s)',
+    async (stream) => {
+      const approvalTool = tool({
+        name: stream
+          ? 'streaming_opt_out_interrupted_span_tool'
+          : 'opt_out_interrupted_span_tool',
+        description: 'Requires approval.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'approved',
+      });
+      const responses = [
+        approvalResponse(approvalTool.name),
+        responseWithoutUsage(),
+      ];
+      const agent = new Agent({
+        name: stream
+          ? 'Streaming opt-out interrupted span agent'
+          : 'Opt-out interrupted span agent',
+        model: stream
+          ? new StreamingModel(responses)
+          : new FakeModel(responses),
+        tools: [approvalTool],
+      });
+      const runner = new Runner({
+        tracing: { includeTaskAndTurnSpans: false },
+      });
+
+      const result = stream
+        ? await runner.run(agent, 'hello', { stream: true })
+        : await runner.run(agent, 'hello');
+      if ('completed' in result) {
+        await result.completed;
+      }
+
+      expect(result.interruptions).toHaveLength(1);
+      const preservedAgentSpan = result.state._currentAgentSpan;
+      expect(preservedAgentSpan?.endedAt).toBeNull();
+      expect(
+        processor.spansStarted.some(
+          (span) =>
+            span.spanData.type === 'task' || span.spanData.type === 'turn',
+        ),
+      ).toBe(false);
+
+      result.state.approve(result.interruptions[0]);
+      const startedBeforeResume = processor.spansStarted.length;
+      const endedBeforeResume = processor.spansEnded.length;
+      const resumed = stream
+        ? await runner.run(agent, result.state, { stream: true })
+        : await runner.run(agent, result.state);
+      if ('completed' in resumed) {
+        await resumed.completed;
+      }
+
+      const resumedStartedSpans =
+        processor.spansStarted.slice(startedBeforeResume);
+      const resumedEndedSpans = processor.spansEnded.slice(endedBeforeResume);
+      const functionSpan = resumedEndedSpans.find(
+        (span) => span.spanData.type === 'function',
+      );
+      expect(
+        resumedStartedSpans.some((span) => span.spanData.type === 'agent'),
+      ).toBe(false);
+      expect(functionSpan?.parentId).toBe(preservedAgentSpan?.spanId);
+      expect(preservedAgentSpan?.endedAt).not.toBeNull();
+    },
+  );
+
+  it.each([false, true])(
+    'replaces an ended agent span when an approval resume opts out of task and turn spans (stream=%s)',
+    async (stream) => {
+      const approvalTool = tool({
+        name: stream
+          ? 'streaming_mixed_config_approval_tool'
+          : 'mixed_config_approval_tool',
+        description: 'Requires approval and then fails.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => {
+          throw new Error('mixed-config approved tool failed');
+        },
+        errorFunction: null,
+      });
+      const agent = new Agent({
+        name: stream
+          ? 'Streaming mixed-config approval agent'
+          : 'Mixed-config approval agent',
+        model: stream
+          ? new StreamingModel([approvalResponse(approvalTool.name)])
+          : new FakeModel([approvalResponse(approvalTool.name)]),
+        tools: [approvalTool],
+      });
+
+      const first = stream
+        ? await new Runner().run(agent, 'hello', { stream: true })
+        : await new Runner().run(agent, 'hello');
+      if ('completed' in first) {
+        await first.completed;
+      }
+      expect(first.interruptions).toHaveLength(1);
+      const interruptedAgentSpan = first.state._currentAgentSpan;
+      expect(interruptedAgentSpan?.endedAt).not.toBeNull();
+      first.state.approve(first.interruptions[0]);
+
+      const startedBeforeResume = processor.spansStarted.length;
+      const endedBeforeResume = processor.spansEnded.length;
+      const optOutRunner = new Runner({
+        tracing: { includeTaskAndTurnSpans: false },
+      });
+      if (stream) {
+        const resumed = await optOutRunner.run(agent, first.state, {
+          stream: true,
+        });
+        await expect(resumed.completed).rejects.toThrow(
+          'mixed-config approved tool failed',
+        );
+      } else {
+        await expect(optOutRunner.run(agent, first.state)).rejects.toThrow(
+          'mixed-config approved tool failed',
+        );
+      }
+
+      const resumedStartedSpans =
+        processor.spansStarted.slice(startedBeforeResume);
+      const resumedEndedSpans = processor.spansEnded.slice(endedBeforeResume);
+      const resumedAgentSpan = resumedStartedSpans.find(
+        (span) =>
+          span.spanData.type === 'agent' &&
+          span.spanId !== interruptedAgentSpan?.spanId,
+      );
+      const functionSpan = resumedEndedSpans.find(
+        (span) => span.spanData.type === 'function',
+      );
+
+      expect(resumedAgentSpan?.parentId).toBeNull();
+      expect(functionSpan?.parentId).toBe(resumedAgentSpan?.spanId);
+      expect(resumedAgentSpan?.error).toMatchObject({
+        message: 'Error in agent run',
+      });
+      expect(resumedAgentSpan?.endedAt).not.toBeNull();
+      expect(
+        resumedStartedSpans.some(
+          (span) =>
+            span.spanData.type === 'task' || span.spanData.type === 'turn',
+        ),
+      ).toBe(false);
+    },
+  );
+
+  it.each([false, true])(
+    'finishes a preserved opt-out agent span when tracing is disabled for resume (stream=%s)',
+    async (stream) => {
+      const approvalTool = tool({
+        name: stream
+          ? 'streaming_disable_tracing_on_resume_tool'
+          : 'disable_tracing_on_resume_tool',
+        description: 'Requires approval.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'approved',
+      });
+      const responses = [
+        approvalResponse(approvalTool.name),
+        responseWithoutUsage(),
+      ];
+      const agent = new Agent({
+        name: stream
+          ? 'Streaming disable tracing on resume agent'
+          : 'Disable tracing on resume agent',
+        model: stream
+          ? new StreamingModel(responses)
+          : new FakeModel(responses),
+        tools: [approvalTool],
+      });
+      const firstRunner = new Runner({
+        tracing: { includeTaskAndTurnSpans: false },
+      });
+
+      const first = stream
+        ? await firstRunner.run(agent, 'hello', { stream: true })
+        : await firstRunner.run(agent, 'hello');
+      if ('completed' in first) {
+        await first.completed;
+      }
+      const preservedAgentSpan = first.state._currentAgentSpan;
+      expect(preservedAgentSpan?.endedAt).toBeNull();
+      first.state.approve(first.interruptions[0]);
+
+      const disabledRunner = new Runner({ tracingDisabled: true });
+      const resumed = stream
+        ? await disabledRunner.run(agent, first.state, { stream: true })
+        : await disabledRunner.run(agent, first.state);
+      if ('completed' in resumed) {
+        await resumed.completed;
+      }
+
+      expect(preservedAgentSpan?.endedAt).not.toBeNull();
+      expect(
+        processor.spansEnded.filter(
+          (span) => span.spanId === preservedAgentSpan?.spanId,
+        ),
+      ).toHaveLength(1);
+      expect(resumed.state._trace).toBeNull();
+      expect(resumed.state._currentAgentSpan).toBeUndefined();
+    },
+  );
+
+  it('creates an agent parent under the resumed task for an approved tool', async () => {
+    const approvalTool = tool({
+      name: 'approval_tool',
+      description: 'Requires approval.',
+      parameters: z.object({}),
+      needsApproval: true,
+      execute: async () => 'approved',
+    });
+    const agent = new Agent({
+      name: 'Approval agent',
+      model: new FakeModel([
+        approvalResponse(approvalTool.name),
+        responseWithUsage(),
+      ]),
+      tools: [approvalTool],
+    });
+    const runner = new Runner();
+
+    const first = await runner.run(agent, 'hello');
+    expect(first.interruptions).toHaveLength(1);
+    const restoredState = await RunState.fromString(
+      agent,
+      first.state.toString(),
+    );
+    const restoredAgentSpan = restoredState._currentAgentSpan;
+    expect(restoredAgentSpan).toBeDefined();
+
+    expect(restoredState.getInterruptions()).toHaveLength(1);
+    restoredState.approve(restoredState.getInterruptions()[0]);
+    const endedBeforeResume = processor.spansEnded.length;
+    await runner.run(agent, restoredState);
+
+    const resumedSpans = processor.spansEnded.slice(endedBeforeResume);
+    const functionSpan = resumedSpans.find(
+      (span) => span.spanData.type === 'function',
+    );
+    const turnSpan = resumedSpans.find((span) => span.spanData.type === 'turn');
+    const taskSpan = resumedSpans.find((span) => span.spanData.type === 'task');
+    const resumedAgentSpan = resumedSpans.find(
+      (span) =>
+        span.spanData.type === 'agent' &&
+        span.spanId !== restoredAgentSpan?.spanId,
+    );
+    expect(
+      processor.spansEnded.filter(
+        (span) => span.spanId === restoredAgentSpan?.spanId,
+      ),
+    ).toHaveLength(1);
+    expect(taskSpan?.parentId).toBeNull();
+    expect(restoredAgentSpan?.endedAt).not.toBeNull();
+    expect(resumedAgentSpan?.parentId).toBe(taskSpan?.spanId);
+    expect(resumedAgentSpan?.spanData.tools).toContain(approvalTool.name);
+    expect(functionSpan?.parentId).toBe(turnSpan?.spanId);
+    expect(turnSpan?.parentId).toBe(resumedAgentSpan?.spanId);
+  });
+
+  it('creates an agent parent under the resumed task for streamed approval resumes', async () => {
+    const approvalTool = tool({
+      name: 'streaming_approval_tool',
+      description: 'Requires approval.',
+      parameters: z.object({}),
+      needsApproval: true,
+      execute: async () => 'approved',
+    });
+    const agent = new Agent({
+      name: 'Streaming approval agent',
+      model: new StreamingModel([
+        approvalResponse(approvalTool.name),
+        responseWithUsage(),
+      ]),
+      tools: [approvalTool],
+    });
+    const runner = new Runner();
+
+    const first = await runner.run(agent, 'hello', { stream: true });
+    await first.completed;
+    expect(first.interruptions).toHaveLength(1);
+    const restoredAgentSpan = first.state._currentAgentSpan;
+    expect(restoredAgentSpan).toBeDefined();
+
+    first.state.approve(first.interruptions[0]);
+    const endedBeforeResume = processor.spansEnded.length;
+    const resumed = await runner.run(agent, first.state, { stream: true });
+    await resumed.completed;
+
+    const resumedSpans = processor.spansEnded.slice(endedBeforeResume);
+    const functionSpan = resumedSpans.find(
+      (span) => span.spanData.type === 'function',
+    );
+    const turnSpan = resumedSpans.find((span) => span.spanData.type === 'turn');
+    const taskSpan = resumedSpans.find((span) => span.spanData.type === 'task');
+    const resumedAgentSpan = resumedSpans.find(
+      (span) =>
+        span.spanData.type === 'agent' &&
+        span.spanId !== restoredAgentSpan?.spanId,
+    );
+    expect(taskSpan?.parentId).toBeNull();
+    expect(restoredAgentSpan?.endedAt).not.toBeNull();
+    expect(resumedAgentSpan?.parentId).toBe(taskSpan?.spanId);
+    expect(functionSpan?.parentId).toBe(turnSpan?.spanId);
+    expect(turnSpan?.parentId).toBe(resumedAgentSpan?.spanId);
+  });
+
+  it.each([false, true])(
+    'keeps rejected approval resumes in the resumed turn (stream=%s)',
+    async (stream) => {
+      let executions = 0;
+      const approvalTool = tool({
+        name: stream ? 'streaming_rejected_tool' : 'rejected_tool',
+        description: 'Requires approval and must not execute when rejected.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => {
+          executions += 1;
+          return 'unexpected execution';
+        },
+      });
+      const agentName = stream
+        ? 'Streaming rejection agent'
+        : 'Rejection agent';
+      const responses = [
+        approvalResponse(approvalTool.name),
+        responseWithUsage(),
+      ];
+      const agent = new Agent({
+        name: agentName,
+        model: stream
+          ? new StreamingModel(responses)
+          : new FakeModel(responses),
+        tools: [approvalTool],
+      });
+      const runner = new Runner();
+
+      const first = stream
+        ? await runner.run(agent, 'hello', { stream: true })
+        : await runner.run(agent, 'hello');
+      if ('completed' in first) {
+        await first.completed;
+      }
+      expect(first.interruptions).toHaveLength(1);
+      const interruptedAgentSpan = first.state._currentAgentSpan;
+      first.state.reject(first.interruptions[0]);
+
+      const endedBeforeResume = processor.spansEnded.length;
+      const resumed = stream
+        ? await runner.run(agent, first.state, { stream: true })
+        : await runner.run(agent, first.state);
+      if ('completed' in resumed) {
+        await resumed.completed;
+      }
+
+      expect(executions).toBe(0);
+      const resumedSpans = processor.spansEnded.slice(endedBeforeResume);
+      const taskSpan = resumedSpans.find(
+        (span) => span.spanData.type === 'task' && span.parentId === null,
+      );
+      const agentSpan = resumedSpans.find(
+        (span) =>
+          span.spanData.type === 'agent' &&
+          span.spanData.name === agentName &&
+          span.spanId !== interruptedAgentSpan?.spanId,
+      );
+      const turnSpans = resumedSpans.filter(
+        (span) =>
+          span.spanData.type === 'turn' &&
+          span.spanData.agent_name === agentName,
+      );
+      const functionSpan = resumedSpans.find(
+        (span) => span.spanData.type === 'function',
+      );
+
+      expect(turnSpans).toHaveLength(1);
+      expect(agentSpan?.parentId).toBe(taskSpan?.spanId);
+      expect(turnSpans[0]?.parentId).toBe(agentSpan?.spanId);
+      expect(functionSpan?.parentId).toBe(turnSpans[0]?.spanId);
+      expect(turnSpans[0]?.spanData.usage).toMatchObject({
+        input_tokens: 12,
+        output_tokens: 4,
+      });
+    },
+  );
+
+  it('attributes approved agent-tool usage to the resumed turn', async () => {
+    const agent = createApprovedAgentToolScenario(false);
+    const runner = new Runner();
+
+    const first = await runner.run(agent, 'hello');
+    expect(first.interruptions).toHaveLength(1);
+    const interruptedAgentSpan = first.state._currentAgentSpan;
+    first.state.approve(first.interruptions[0]);
+
+    const endedBeforeResume = processor.spansEnded.length;
+    await runner.run(agent, first.state);
+
+    const resumedSpans = processor.spansEnded.slice(endedBeforeResume);
+    const functionSpan = resumedSpans.find(
+      (span) => span.spanData.type === 'function',
+    );
+    const turnSpans = resumedSpans.filter(
+      (span) =>
+        span.spanData.type === 'turn' &&
+        span.spanData.agent_name === 'Outer approval agent',
+    );
+    expect(turnSpans).toHaveLength(1);
+    const [turnSpan] = turnSpans;
+    const taskSpan = resumedSpans.find(
+      (span) => span.spanData.type === 'task' && span.parentId === null,
+    );
+    const resumedAgentSpan = resumedSpans.find(
+      (span) =>
+        span.spanData.type === 'agent' &&
+        span.spanData.name === 'Outer approval agent' &&
+        span.spanId !== interruptedAgentSpan?.spanId,
+    );
+    expect(resumedAgentSpan?.parentId).toBe(taskSpan?.spanId);
+    expect(turnSpan?.parentId).toBe(resumedAgentSpan?.spanId);
+    expect(functionSpan?.parentId).toBe(turnSpan?.spanId);
+    expect(turnSpan?.spanData.usage).toMatchObject({
+      input_tokens: 12,
+      output_tokens: 4,
+      cached_input_tokens: 2,
+      cache_write_input_tokens: 3,
+    });
+  });
+
+  it('attributes approved agent-tool usage to the resumed streamed turn', async () => {
+    const agent = createApprovedAgentToolScenario(true);
+    const runner = new Runner();
+
+    const first = await runner.run(agent, 'hello', { stream: true });
+    await first.completed;
+    expect(first.interruptions).toHaveLength(1);
+    const interruptedAgentSpan = first.state._currentAgentSpan;
+    first.state.approve(first.interruptions[0]);
+
+    const endedBeforeResume = processor.spansEnded.length;
+    const resumed = await runner.run(agent, first.state, { stream: true });
+    await resumed.completed;
+
+    const resumedSpans = processor.spansEnded.slice(endedBeforeResume);
+    const functionSpan = resumedSpans.find(
+      (span) => span.spanData.type === 'function',
+    );
+    const turnSpans = resumedSpans.filter(
+      (span) =>
+        span.spanData.type === 'turn' &&
+        span.spanData.agent_name === 'Outer approval agent',
+    );
+    expect(turnSpans).toHaveLength(1);
+    const [turnSpan] = turnSpans;
+    const taskSpan = resumedSpans.find(
+      (span) => span.spanData.type === 'task' && span.parentId === null,
+    );
+    const resumedAgentSpan = resumedSpans.find(
+      (span) =>
+        span.spanData.type === 'agent' &&
+        span.spanData.name === 'Outer approval agent' &&
+        span.spanId !== interruptedAgentSpan?.spanId,
+    );
+    expect(resumedAgentSpan?.parentId).toBe(taskSpan?.spanId);
+    expect(turnSpan?.parentId).toBe(resumedAgentSpan?.spanId);
+    expect(functionSpan?.parentId).toBe(turnSpan?.spanId);
+    expect(turnSpan?.spanData.usage).toMatchObject({
+      input_tokens: 12,
+      output_tokens: 4,
+      cached_input_tokens: 2,
+      cache_write_input_tokens: 3,
+    });
+  });
+
+  it('marks the resumed task agent span when an approved tool fails', async () => {
+    const approvalTool = tool({
+      name: 'failing_approval_tool',
+      description: 'Requires approval and then fails.',
+      parameters: z.object({}),
+      needsApproval: true,
+      execute: async () => {
+        throw new Error('approved tool failed');
+      },
+      errorFunction: null,
+    });
+    const agent = new Agent({
+      name: 'Failing approval agent',
+      model: new FakeModel([approvalResponse(approvalTool.name)]),
+      tools: [approvalTool],
+    });
+    const runner = new Runner();
+
+    const first = await runner.run(agent, 'hello');
+    expect(first.interruptions).toHaveLength(1);
+    const restoredAgentSpan = first.state._currentAgentSpan;
+    expect(restoredAgentSpan).toBeDefined();
+
+    first.state.approve(first.interruptions[0]);
+    const endedBeforeResume = processor.spansEnded.length;
+    const startedBeforeResume = processor.spansStarted.length;
+    await expect(runner.run(agent, first.state)).rejects.toThrow(
+      'approved tool failed',
+    );
+
+    const resumedSpans = processor.spansEnded.slice(endedBeforeResume);
+    const resumedStartedSpans =
+      processor.spansStarted.slice(startedBeforeResume);
+    const functionSpan = resumedSpans.find(
+      (span) => span.spanData.type === 'function',
+    );
+    const turnSpan = resumedSpans.find((span) => span.spanData.type === 'turn');
+    const taskSpan = resumedSpans.find((span) => span.spanData.type === 'task');
+    const resumedAgentSpan = resumedStartedSpans.find(
+      (span) =>
+        span.spanData.type === 'agent' &&
+        span.spanId !== restoredAgentSpan?.spanId,
+    );
+    expect(restoredAgentSpan?.endedAt).not.toBeNull();
+    expect(resumedAgentSpan?.parentId).toBe(taskSpan?.spanId);
+    expect(functionSpan?.parentId).toBe(turnSpan?.spanId);
+    expect(turnSpan?.parentId).toBe(resumedAgentSpan?.spanId);
+    expect(resumedAgentSpan?.error).toMatchObject({
+      message: 'Error in agent run',
+    });
+    expect(turnSpan?.error).toMatchObject({
+      message: 'Error in agent run',
+    });
+    expect(taskSpan?.error).toMatchObject({
+      message: 'Error in agent run',
+    });
+  });
+});

--- a/packages/agents-extensions/src/experimental/codex/index.ts
+++ b/packages/agents-extensions/src/experimental/codex/index.ts
@@ -11,6 +11,7 @@ import {
   toFunctionToolName,
   toSmartString,
 } from '@openai/agents-core/utils';
+import { recordToolUsage } from '@openai/agents-core/utils/internal';
 import type {
   CustomSpanData,
   FunctionCallItem,
@@ -209,15 +210,13 @@ const codexRunContextParametersSchema = z
   .strict();
 
 type CodexToolParametersSchema =
-  | typeof codexParametersSchema
-  | typeof codexRunContextParametersSchema;
+  typeof codexParametersSchema | typeof codexRunContextParametersSchema;
 type CodexToolParameters = z.infer<typeof codexParametersSchema>;
 type CodexToolRunContextParameters = z.infer<
   typeof codexRunContextParametersSchema
 >;
 type AnyCodexToolParameters =
-  | CodexToolParameters
-  | CodexToolRunContextParameters;
+  CodexToolParameters | CodexToolRunContextParameters;
 type OutputSchemaDescriptor = z.infer<typeof OutputSchemaDescriptorSchema>;
 type OutputSchemaField = z.infer<typeof OutputSchemaFieldSchema>;
 
@@ -255,9 +254,7 @@ export type CodexToolOptions = {
    * This schema is applied to every Codex turn.
    */
   outputSchema?:
-    | OutputSchemaDescriptor
-    | Record<string, unknown>
-    | z.ZodTypeAny;
+    OutputSchemaDescriptor | Record<string, unknown> | z.ZodTypeAny;
   /**
    * Reuse an existing Codex instance. When omitted a new Codex instance will be created.
    */
@@ -493,15 +490,15 @@ export function codexTool(
           typeof usage.cached_input_tokens === 'number'
             ? { cached_input_tokens: usage.cached_input_tokens }
             : undefined;
-        runContext.usage.add(
-          new Usage({
-            input_tokens: usage.input_tokens,
-            output_tokens: usage.output_tokens,
-            total_tokens: usage.input_tokens + usage.output_tokens,
-            input_tokens_details: inputTokensDetails,
-            requests: 1,
-          }),
-        );
+        const usageIncrement = new Usage({
+          input_tokens: usage.input_tokens,
+          output_tokens: usage.output_tokens,
+          total_tokens: usage.input_tokens + usage.output_tokens,
+          input_tokens_details: inputTokensDetails,
+          requests: 1,
+        });
+        runContext.usage.add(usageIncrement);
+        recordToolUsage(details, usageIncrement);
       }
       if (useRunContextThreadId) {
         storeThreadIdInRunContext(
@@ -1064,11 +1061,7 @@ function buildLiteral(
     return undefined;
   }
   const literal = extractFirst(def, 'value', 'literal') as
-    | string
-    | number
-    | boolean
-    | null
-    | undefined;
+    string | number | boolean | null | undefined;
   if (literal === undefined) {
     return undefined;
   }

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -35,10 +35,21 @@ import {
   convertHandoffTool,
   itemsToMessages,
 } from './openaiChatCompletionsConverter';
+
 import { protocol } from '@openai/agents-core';
 import { getOpenAIRetryAdvice } from './retryAdvice';
 import { normalizePromptCacheRetention } from './utils/modelSettings';
 import type { OpenAIClient } from './openaiClient';
+
+type ModelTracingParent = Parameters<typeof createGenerationSpan>[1];
+
+function getModelTracingParent(request: ModelRequest): ModelTracingParent {
+  return (
+    request as ModelRequest & {
+      _internal?: { tracingParent?: ModelTracingParent };
+    }
+  )._internal?.tracingParent;
+}
 
 export const FAKE_ID = 'FAKE_ID';
 const GPT_56_MODEL_PATTERN =
@@ -100,24 +111,28 @@ export class OpenAIChatCompletionsModel implements Model {
     this.#handleUnsupportedPrompt(request);
     this.#handleUnsupportedReasoningSettings(request);
 
-    const response = await withGenerationSpan(async (span) => {
-      span.spanData.model = this.#model;
-      span.spanData.model_config = request.modelSettings
-        ? {
-            temperature: request.modelSettings.temperature,
-            top_p: request.modelSettings.topP,
-            frequency_penalty: request.modelSettings.frequencyPenalty,
-            presence_penalty: request.modelSettings.presencePenalty,
-            reasoning_effort: request.modelSettings.reasoning?.effort,
-            verbosity: request.modelSettings.text?.verbosity,
-          }
-        : { base_url: this.#client.baseURL };
-      const response = await this.#fetchResponse(request, span, false);
-      if (span && request.tracing === true) {
-        span.spanData.output = [response];
-      }
-      return response;
-    });
+    const response = await withGenerationSpan(
+      async (span) => {
+        span.spanData.model = this.#model;
+        span.spanData.model_config = request.modelSettings
+          ? {
+              temperature: request.modelSettings.temperature,
+              top_p: request.modelSettings.topP,
+              frequency_penalty: request.modelSettings.frequencyPenalty,
+              presence_penalty: request.modelSettings.presencePenalty,
+              reasoning_effort: request.modelSettings.reasoning?.effort,
+              verbosity: request.modelSettings.text?.verbosity,
+            }
+          : { base_url: this.#client.baseURL };
+        const response = await this.#fetchResponse(request, span, false);
+        if (span && request.tracing === true) {
+          span.spanData.output = [response];
+        }
+        return response;
+      },
+      undefined,
+      getModelTracingParent(request),
+    );
 
     const output: protocol.OutputModelItem[] = [];
     if (response.choices && response.choices[0]) {
@@ -239,7 +254,9 @@ export class OpenAIChatCompletionsModel implements Model {
     this.#handleUnsupportedPrompt(request);
     this.#handleUnsupportedReasoningSettings(request);
 
-    const span = request.tracing ? createGenerationSpan() : undefined;
+    const span = request.tracing
+      ? createGenerationSpan(undefined, getModelTracingParent(request))
+      : undefined;
     try {
       if (span) {
         span.spanData.model = this.#model;

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -53,6 +53,7 @@ import {
   splitResponsesTransportOverrides,
 } from './responsesTransportUtils';
 import type { OpenAIClient } from './openaiClient';
+
 import {
   CodeInterpreterStatus,
   FileSearchStatus,
@@ -80,6 +81,16 @@ import {
   formatInlineData,
   getInlineMediaType,
 } from '@openai/agents-core/utils/internal';
+
+type ModelTracingParent = Parameters<typeof createResponseSpan>[1];
+
+function getModelTracingParent(request: ModelRequest): ModelTracingParent {
+  return (
+    request as ModelRequest & {
+      _internal?: { tracingParent?: ModelTracingParent };
+    }
+  )._internal?.tracingParent;
+}
 
 type ToolChoice =
   | ToolChoiceOptions
@@ -3178,17 +3189,21 @@ export class OpenAIResponsesModel implements Model {
    * @returns A promise that resolves to the response from the model.
    */
   async getResponse(request: ModelRequest): Promise<ModelResponse> {
-    const response = await withResponseSpan(async (span) => {
-      const response = await this._fetchResponse(request, false);
+    const response = await withResponseSpan(
+      async (span) => {
+        const response = await this._fetchResponse(request, false);
 
-      if (request.tracing) {
-        span.spanData.response_id = response.id;
-        span.spanData._input = request.input;
-        span.spanData._response = response;
-      }
+        if (request.tracing) {
+          span.spanData.response_id = response.id;
+          span.spanData._input = request.input;
+          span.spanData._response = response;
+        }
 
-      return response;
-    });
+        return response;
+      },
+      undefined,
+      getModelTracingParent(request),
+    );
 
     const responseForSDKOutput = this._getResponseForSDKOutput(response);
     const output: ModelResponse = {
@@ -3212,7 +3227,9 @@ export class OpenAIResponsesModel implements Model {
   async *getStreamedResponse(
     request: ModelRequest,
   ): AsyncIterable<ResponseStreamEvent> {
-    const span = request.tracing ? createResponseSpan() : undefined;
+    const span = request.tracing
+      ? createResponseSpan(undefined, getModelTracingParent(request))
+      : undefined;
     try {
       if (span) {
         span.start();

--- a/packages/agents-openai/test/modelTracingParent.test.ts
+++ b/packages/agents-openai/test/modelTracingParent.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  Span,
+  Trace,
+  createTaskSpan,
+  setTraceProcessors,
+  setTracingDisabled,
+  withTrace,
+  type ModelRequest,
+  type TracingProcessor,
+} from '@openai/agents-core';
+import type OpenAI from 'openai';
+import { OpenAIChatCompletionsModel } from '../src/openaiChatCompletionsModel';
+import { OpenAIResponsesModel } from '../src/openaiResponsesModel';
+
+class RecordingProcessor implements TracingProcessor {
+  readonly spansEnded: Span<any>[] = [];
+
+  async onTraceStart(_trace: Trace): Promise<void> {}
+  async onTraceEnd(_trace: Trace): Promise<void> {}
+  async onSpanStart(_span: Span<any>): Promise<void> {}
+  async onSpanEnd(span: Span<any>): Promise<void> {
+    this.spansEnded.push(span);
+  }
+  async shutdown(): Promise<void> {}
+  async forceFlush(): Promise<void> {}
+}
+
+function modelRequest(): ModelRequest {
+  return {
+    input: 'hello',
+    modelSettings: {},
+    tools: [],
+    outputType: 'text',
+    handoffs: [],
+    tracing: true,
+  };
+}
+
+describe('model tracing parent', () => {
+  afterEach(() => {
+    setTracingDisabled(true);
+    setTraceProcessors([]);
+  });
+
+  it('uses the explicit parent for Chat Completions generation spans', async () => {
+    const processor = new RecordingProcessor();
+    setTraceProcessors([processor]);
+    setTracingDisabled(false);
+    const nonStreamingResponse = {
+      id: 'chat-response',
+      choices: [{ message: { content: 'done' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    };
+    async function* streamingResponse() {
+      yield {
+        id: 'chat-stream-response',
+        created: 1,
+        model: 'gpt-test',
+        object: 'chat.completion.chunk',
+        choices: [
+          { index: 0, delta: { content: 'done' }, finish_reason: null },
+        ],
+      };
+      yield {
+        id: 'chat-stream-response',
+        created: 1,
+        model: 'gpt-test',
+        object: 'chat.completion.chunk',
+        choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      };
+    }
+    const create = vi
+      .fn()
+      .mockResolvedValueOnce(nonStreamingResponse)
+      .mockResolvedValueOnce(streamingResponse());
+    const client = {
+      baseURL: 'https://example.test',
+      chat: { completions: { create } },
+    };
+    const model = new OpenAIChatCompletionsModel(
+      client as unknown as OpenAI,
+      'gpt-test',
+    );
+
+    await withTrace('chat parent', async (trace) => {
+      const parent = createTaskSpan({ data: { name: 'chat task' } }, trace);
+      parent.start();
+      const request: any = modelRequest();
+      request._internal = { tracingParent: parent };
+      await model.getResponse(request);
+      for await (const _event of model.getStreamedResponse(request)) {
+        // Consume the stream.
+      }
+      parent.end();
+    });
+
+    const generationSpans = processor.spansEnded.filter(
+      (span) => span.spanData.type === 'generation',
+    );
+    const parent = processor.spansEnded.find(
+      (span) => span.spanData.type === 'task',
+    );
+    expect(generationSpans).toHaveLength(2);
+    expect(generationSpans.map((span) => span.parentId)).toEqual([
+      parent?.spanId,
+      parent?.spanId,
+    ]);
+  });
+
+  it('uses the explicit parent for Responses spans', async () => {
+    const processor = new RecordingProcessor();
+    setTraceProcessors([processor]);
+    setTracingDisabled(false);
+    const response = {
+      id: 'response-id',
+      object: 'response',
+      status: 'completed',
+      output: [],
+      usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+    };
+    async function* streamingResponse() {
+      yield { type: 'response.created', response };
+      yield { type: 'response.completed', response };
+    }
+    const create = vi
+      .fn()
+      .mockResolvedValueOnce(response)
+      .mockResolvedValueOnce(streamingResponse());
+    const client = { responses: { create } } as unknown as OpenAI;
+    const model = new OpenAIResponsesModel(client, 'gpt-test');
+
+    await withTrace('responses parent', async (trace) => {
+      const parent = createTaskSpan(
+        { data: { name: 'responses task' } },
+        trace,
+      );
+      parent.start();
+      const request: any = modelRequest();
+      request._internal = { tracingParent: parent };
+      await model.getResponse(request);
+      for await (const _event of model.getStreamedResponse(request)) {
+        // Consume the stream.
+      }
+      parent.end();
+    });
+
+    const responseSpans = processor.spansEnded.filter(
+      (span) => span.spanData.type === 'response',
+    );
+    const parent = processor.spansEnded.find(
+      (span) => span.spanData.type === 'task',
+    );
+    expect(responseSpans).toHaveLength(2);
+    expect(responseSpans.map((span) => span.parentId)).toEqual([
+      parent?.spanId,
+      parent?.spanId,
+    ]);
+  });
+});


### PR DESCRIPTION
This pull request adds default task and turn spans to `run()` and `Runner.run()` so the JS SDK emits the same high-level trace hierarchy and usage metadata as the Python SDK.

It also adds `TracingConfig.includeTaskAndTurnSpans` as a per-run opt-out that omits only runner-created task and turn spans while preserving existing agent, model, tool, guardrail, and handoff spans. Resumed runs start a fresh agent span under the new task without changing the RunState schema.