### PR TITLE
docs: clarify sandbox client support on Windows

### DIFF
--- a/.changeset/clear-sandbox-windows.md
+++ b/.changeset/clear-sandbox-windows.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents': patch
+---
+
+docs: clarify sandbox client support on Windows

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ npm install @openai/agents zod
 
 Use a [Sandbox Agent](https://openai.github.io/openai-agents-js/guides/sandbox-agents) when the agent should work in a filesystem, run commands, or carry workspace state across longer tasks. Sandbox Agents are in beta.
 
+This example uses `UnixLocalSandboxClient`, which is supported on macOS and Linux. On Windows, use `DockerSandboxClient` or a hosted sandbox client instead; see [Sandbox clients](https://openai.github.io/openai-agents-js/guides/sandbox-agents/clients) for setup details.
+
 ```js
 import { run } from '@openai/agents';
 import { gitRepo, SandboxAgent } from '@openai/agents/sandbox';

--- a/docs/src/content/docs/guides/sandbox-agents.mdx
+++ b/docs/src/content/docs/guides/sandbox-agents.mdx
@@ -20,7 +20,7 @@ The SDK gives you that execution harness without making you wire together file s
 
 - Node.js 22 or higher.
 - Basic familiarity with the OpenAI Agents SDK.
-- A sandbox client. For local development, start with `UnixLocalSandboxClient`.
+- A sandbox client. For local development on macOS or Linux, start with `UnixLocalSandboxClient`. On Windows, use `DockerSandboxClient` or a hosted sandbox client instead.
 
 This quickstart uses Node.js and npm commands, but the SDK is not limited to Node.js. Sandbox agents can also run on Deno and Bun when your project uses compatible package resolution and runtime APIs.
 

--- a/docs/src/content/docs/guides/sandbox-agents/concepts.mdx
+++ b/docs/src/content/docs/guides/sandbox-agents/concepts.mdx
@@ -92,7 +92,7 @@ If you do not need access to files or a living filesystem, keep using `Agent`. I
 
 ## Choose a sandbox client
 
-Start with `UnixLocalSandboxClient` for local development. Move to `DockerSandboxClient` when you need container isolation or image parity. Move to a hosted provider when you need provider-managed execution.
+Start with `UnixLocalSandboxClient` for local development on macOS or Linux. On Windows, use `DockerSandboxClient` or a hosted provider instead. On any supported platform, move to `DockerSandboxClient` when you need container isolation or image parity, or to a hosted provider when you need provider-managed execution.
 
 In most cases, the `SandboxAgent` definition stays the same while the sandbox client and its options change in the `sandbox` run option. See [Sandbox clients](/openai-agents-js/guides/sandbox-agents/clients) for local, Docker, hosted, and remote-mount options.
 

--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -46,6 +46,8 @@ npm install @openai/agents zod
 
 Use a [Sandbox Agent](https://openai.github.io/openai-agents-js/guides/sandbox-agents) when the agent should work in a filesystem, run commands, or carry workspace state across longer tasks. Sandbox Agents are in beta.
 
+This example uses `UnixLocalSandboxClient`, which is supported on macOS and Linux. On Windows, use `DockerSandboxClient` or a hosted sandbox client instead; see [Sandbox clients](https://openai.github.io/openai-agents-js/guides/sandbox-agents/clients) for setup details.
+
 ```js
 import { run } from '@openai/agents';
 import { gitRepo, SandboxAgent } from '@openai/agents/sandbox';


### PR DESCRIPTION
This pull request clarifies that `UnixLocalSandboxClient` is supported on macOS and Linux. It directs Windows users to `DockerSandboxClient` or a hosted sandbox client in the README, package README, quickstart, and sandbox concepts guide.