### PR TITLE
fix(extensions): preserve AI SDK v3 image tool outputs

### DIFF
--- a/.changeset/bright-images-appear.md
+++ b/.changeset/bright-images-appear.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: preserve AI SDK v3 image tool outputs as image content

--- a/.changeset/bright-images-appear.md
+++ b/.changeset/bright-images-appear.md
@@ -2,4 +2,4 @@
 '@openai/agents-extensions': patch
 ---
 
-fix: preserve AI SDK v3 image tool outputs as image content
+fix: preserve AI SDK v3 image tool outputs as image URLs, data, and file IDs

--- a/examples/ai-sdk/README.md
+++ b/examples/ai-sdk/README.md
@@ -10,7 +10,7 @@ These examples show how to wrap models from the [AI SDK](https://www.npmjs.com/p
 | [gpt-5.ts](./gpt-5.ts) | `pnpm -F ai-sdk start:gpt-5` | OpenAI (`OPENAI_API_KEY`) | Shows a single agent that must call the `get_weather` tool using `gpt-5.4` with custom provider options. |
 | [retry.ts](./retry.ts) | `pnpm -F ai-sdk start:retry` | OpenAI (`OPENAI_API_KEY`) | Configures opt-in model retries for an AI SDK-backed agent and logs retry decisions when transient failures occur. |
 | [stream.ts](./stream.ts) | `pnpm -F ai-sdk start:stream` | OpenAI (`OPENAI_API_KEY`) | Demonstrates streaming text output from an AI SDK model wrapped with `aisdk()`. |
-| [image-tool-output.ts](./image-tool-output.ts) | `pnpm -F ai-sdk start:image-tool-output` | OpenRouter (`OPENROUTER_API_KEY`) | Returns a `ToolOutputImage` from a tool call and asks the model to describe the image. |
+| [image-tool-output.ts](./image-tool-output.ts) | `pnpm -F ai-sdk start:image-tool-output` | OpenAI (`OPENAI_API_KEY`) | Returns a `ToolOutputImage` from a tool call and asks `gpt-5.6-luna` to describe the image. |
 
 ## Prerequisites
 

--- a/examples/ai-sdk/image-tool-output.ts
+++ b/examples/ai-sdk/image-tool-output.ts
@@ -33,14 +33,9 @@ export async function runAgents(model: AiSdkModel) {
   // This image features the clock tower commonly known as Big Ben attached to the Palace of Westminster in London, captured against a clear blue sky. The ornate architecture and the clock face stand out prominently above surrounding buildings, with a hint of passing traffic below.
 }
 
-import { createOpenRouter } from '@openrouter/ai-sdk-provider';
-// import { openai } from '@ai-sdk/openai';
+import { openai } from '@ai-sdk/openai';
 
 (async function () {
-  // const model = aisdk(openai('gpt-4.1-nano'));
-  const openRouter = createOpenRouter({
-    apiKey: process.env.OPENROUTER_API_KEY,
-  });
-  const model = aisdk(openRouter('openai/gpt-oss-120b'));
+  const model = aisdk(openai('gpt-5.6-luna'));
   await runAgents(model);
 })();

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -506,7 +506,7 @@ export function itemsToLanguageV2Messages(
         type: 'tool-result',
         toolCallId: item.callId,
         toolName,
-        output: convertToAiSdkOutput(item.output),
+        output: convertToAiSdkOutput(item.output, getSpecVersion(model)),
         providerOptions: toProviderOptions(item.providerData, model),
       };
       messages.push({
@@ -760,12 +760,13 @@ function handoffToLanguageV2Tool(
 
 function convertToAiSdkOutput(
   output: protocol.FunctionCallResultItem['output'],
+  specVersion: 'v2' | 'v3' | 'unknown',
 ): LanguageModelV2ToolResultPart['output'] {
   if (typeof output === 'string') {
     return { type: 'text', value: output };
   }
   if (Array.isArray(output)) {
-    return convertStructuredOutputsToAiSdkOutput(output);
+    return convertStructuredOutputsToAiSdkOutput(output, specVersion);
   }
   if (isRecord(output) && typeof output.type === 'string') {
     if (output.type === 'text' && typeof output.text === 'string') {
@@ -775,7 +776,10 @@ function convertToAiSdkOutput(
       const structuredOutputs = convertLegacyToolOutputContent(
         output as protocol.ToolCallOutputContent,
       );
-      return convertStructuredOutputsToAiSdkOutput(structuredOutputs);
+      return convertStructuredOutputsToAiSdkOutput(
+        structuredOutputs,
+        specVersion,
+      );
     }
   }
   return { type: 'text', value: String(output) };
@@ -1150,16 +1154,21 @@ function createProtocolToolSearchOutputItem(args: {
 }
 
 /**
- * Maps the protocol-level structured outputs into the Language Model V2 result primitives.
- * The AI SDK expects either plain text or content parts (text + media), so we merge multiple
- * items accordingly.
+ * Maps protocol-level structured outputs into the content-part format for the
+ * target AI SDK specification version.
  */
 function convertStructuredOutputsToAiSdkOutput(
   outputs: protocol.ToolCallStructuredOutput[],
+  specVersion: 'v2' | 'v3' | 'unknown',
 ): LanguageModelV2ToolResultPart['output'] {
+  type ImagePart =
+    | { type: 'media'; data: string; mediaType: string }
+    | { type: 'image-data'; data: string; mediaType: string }
+    | { type: 'image-url'; url: string };
+
+  const isV3 = specVersion === 'v3';
   const textParts: string[] = [];
-  const mediaParts: Array<{ type: 'media'; data: string; mediaType: string }> =
-    [];
+  const imageParts: ImagePart[] = [];
 
   for (const item of outputs) {
     if (item.type === 'input_text') {
@@ -1187,20 +1196,32 @@ function convertStructuredOutputsToAiSdkOutput(
       }
       const inlineImage = parseBase64ImageDataUrl(imageValue);
       if (inlineImage) {
-        mediaParts.push({
-          type: 'media',
-          data: inlineImage.data,
-          mediaType: inlineImage.mediaType,
-        });
+        imageParts.push(
+          isV3
+            ? {
+                type: 'image-data',
+                data: inlineImage.data,
+                mediaType: inlineImage.mediaType,
+              }
+            : {
+                type: 'media',
+                data: inlineImage.data,
+                mediaType: inlineImage.mediaType,
+              },
+        );
         continue;
       }
       try {
         const url = new URL(imageValue);
-        mediaParts.push({
-          type: 'media',
-          data: url.toString(),
-          mediaType: 'image/*',
-        });
+        imageParts.push(
+          isV3
+            ? { type: 'image-url', url: url.toString() }
+            : {
+                type: 'media',
+                data: url.toString(),
+                mediaType: 'image/*',
+              },
+        );
       } catch {
         textParts.push(imageValue);
       }
@@ -1213,20 +1234,20 @@ function convertStructuredOutputsToAiSdkOutput(
     }
   }
 
-  if (mediaParts.length === 0) {
+  if (imageParts.length === 0) {
     return { type: 'text', value: textParts.join('') };
   }
 
-  const value: Array<
-    | { type: 'text'; text: string }
-    | { type: 'media'; data: string; mediaType: string }
-  > = [];
+  const value: Array<{ type: 'text'; text: string } | ImagePart> = [];
 
   if (textParts.length > 0) {
     value.push({ type: 'text', text: textParts.join('') });
   }
-  value.push(...mediaParts);
-  return { type: 'content', value };
+  value.push(...imageParts);
+  return {
+    type: 'content',
+    value,
+  } as LanguageModelV2ToolResultPart['output'];
 }
 
 function isRecord(value: unknown): value is Record<string, any> {

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -1164,7 +1164,8 @@ function convertStructuredOutputsToAiSdkOutput(
   type ImagePart =
     | { type: 'media'; data: string; mediaType: string }
     | { type: 'image-data'; data: string; mediaType: string }
-    | { type: 'image-url'; url: string };
+    | { type: 'image-url'; url: string }
+    | { type: 'image-file-id'; fileId: string };
 
   const isV3 = specVersion === 'v3';
   const textParts: string[] = [];
@@ -1176,17 +1177,31 @@ function convertStructuredOutputsToAiSdkOutput(
       continue;
     }
     if (item.type === 'input_image') {
+      const imageObjectFileId =
+        isRecord(item.image) && typeof item.image.id === 'string'
+          ? item.image.id
+          : undefined;
+      const legacyFileId =
+        typeof (item as any).fileId === 'string'
+          ? (item as any).fileId
+          : undefined;
+      const imageFileId = imageObjectFileId ?? legacyFileId;
+
+      if (isV3 && imageFileId) {
+        imageParts.push({ type: 'image-file-id', fileId: imageFileId });
+        continue;
+      }
+
       const imageValue =
         typeof item.image === 'string'
           ? item.image
-          : isRecord(item.image) && typeof item.image.id === 'string'
-            ? `openai-file:${item.image.id}`
+          : imageObjectFileId
+            ? `openai-file:${imageObjectFileId}`
             : typeof (item as any).imageUrl === 'string'
               ? (item as any).imageUrl
               : undefined;
 
-      const legacyFileId = (item as any).fileId;
-      if (!imageValue && typeof legacyFileId === 'string') {
+      if (!imageValue && legacyFileId) {
         textParts.push(`[image file_id=${legacyFileId}]`);
         continue;
       }

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -1421,6 +1421,82 @@ describe('itemsToLanguageV2Messages', () => {
     ]);
   });
 
+  test('converts V3 image tool outputs without relying on URL extensions', () => {
+    const imageUrl =
+      'https://images.unsplash.com/photo-1505761671935-60b3a7427bad?auto=format&fit=crop&w=400&q=80';
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call',
+        callId: 'tool-1',
+        name: 'describe_image',
+        arguments: '{}',
+      } as any,
+      {
+        type: 'function_call_result',
+        callId: 'tool-1',
+        name: 'describe_image',
+        output: [
+          { type: 'input_text', text: 'A scenic view.' },
+          {
+            type: 'input_image',
+            image: imageUrl,
+          },
+          {
+            type: 'input_image',
+            image: 'data:image/png;base64,aGVsbG8=',
+          },
+        ],
+      } as any,
+    ];
+
+    const msgs = itemsToLanguageV2Messages(
+      stubModel({}, { specificationVersion: 'v3' }),
+      items,
+    );
+    expect(msgs).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'tool-1',
+            toolName: 'describe_image',
+            input: {},
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'tool-1',
+            toolName: 'describe_image',
+            output: {
+              type: 'content',
+              value: [
+                { type: 'text', text: 'A scenic view.' },
+                {
+                  type: 'image-url',
+                  url: imageUrl,
+                },
+                {
+                  type: 'image-data',
+                  data: 'aGVsbG8=',
+                  mediaType: 'image/png',
+                },
+              ],
+            },
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+    ]);
+  });
+
   test('handles undefined providerData without throwing', () => {
     const items: protocol.ModelItem[] = [
       {

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -1421,7 +1421,7 @@ describe('itemsToLanguageV2Messages', () => {
     ]);
   });
 
-  test('converts V3 image tool outputs without relying on URL extensions', () => {
+  test('converts V3 image tool outputs and preserves file IDs', () => {
     const imageUrl =
       'https://images.unsplash.com/photo-1505761671935-60b3a7427bad?auto=format&fit=crop&w=400&q=80';
     const items: protocol.ModelItem[] = [
@@ -1444,6 +1444,10 @@ describe('itemsToLanguageV2Messages', () => {
           {
             type: 'input_image',
             image: 'data:image/png;base64,aGVsbG8=',
+          },
+          {
+            type: 'input_image',
+            image: { id: 'file_image_123' },
           },
         ],
       } as any,
@@ -1486,6 +1490,10 @@ describe('itemsToLanguageV2Messages', () => {
                   type: 'image-data',
                   data: 'aGVsbG8=',
                   mediaType: 'image/png',
+                },
+                {
+                  type: 'image-file-id',
+                  fileId: 'file_image_123',
                 },
               ],
             },


### PR DESCRIPTION
This pull request fixes AI SDK v3 image tool outputs that were encoded using the v2 media format, causing providers to treat image URLs as text instead of image content. It emits `image-url` and `image-data` parts for v3 models while preserving v2 behavior, adds regression coverage for extensionless image URLs, and updates the example to use `gpt-5.6-luna` through the OpenAI Responses provider.