### PR TITLE
fix(realtime): configure replacement peer connection before setup

### DIFF
--- a/.changeset/tidy-radios-connect.md
+++ b/.changeset/tidy-radios-connect.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: set up media and events on replacement WebRTC peer connections

--- a/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
@@ -249,6 +249,9 @@ export class OpenAIRealtimeWebRTC
               rejectConnection(new Error(CONNECTION_CLOSED_DURING_SETUP));
               return;
             }
+            if (replacementPeerConnection !== provisionalPeerConnection) {
+              provisionalPeerConnection.close();
+            }
             peerConnection = replacementPeerConnection;
           } catch (error) {
             if (connectAttempt.cancelled) {

--- a/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
@@ -24,6 +24,7 @@ const CONNECTION_CLOSED_DURING_SETUP =
 type WebRTCConnectAttempt = {
   cancelled: boolean;
   rejectConnection: (reason?: unknown) => void;
+  selectedPeerConnection: Promise<RTCPeerConnection | undefined>;
   pendingPeerConnection?: RTCPeerConnection;
 };
 
@@ -155,6 +156,34 @@ export class OpenAIRealtimeWebRTC
     return this.#muted;
   }
 
+  async #isPeerConnectionSelectedByNewerAttempt(
+    peerConnection: RTCPeerConnection,
+    staleAttempt: WebRTCConnectAttempt,
+  ) {
+    while (true) {
+      if (this.#state.peerConnection === peerConnection) {
+        return true;
+      }
+
+      const activeAttempt = this.#connectAttempt;
+      if (!activeAttempt || activeAttempt === staleAttempt) {
+        return false;
+      }
+
+      const selectedPeerConnection = await activeAttempt.selectedPeerConnection;
+      if (
+        selectedPeerConnection === peerConnection ||
+        this.#state.peerConnection === peerConnection
+      ) {
+        return true;
+      }
+
+      if (this.#connectAttempt === activeAttempt) {
+        return false;
+      }
+    }
+  }
+
   /**
    * Connect to the Realtime API. This will establish the connection to the OpenAI Realtime API
    * via WebRTC.
@@ -190,9 +219,18 @@ export class OpenAIRealtimeWebRTC
       resolveConnection = resolve;
       rejectConnection = reject;
     });
+    let resolveSelectedPeerConnection!: (
+      peerConnection: RTCPeerConnection | undefined,
+    ) => void;
+    const selectedPeerConnection = new Promise<RTCPeerConnection | undefined>(
+      (resolve) => {
+        resolveSelectedPeerConnection = resolve;
+      },
+    );
     const connectAttempt: WebRTCConnectAttempt = {
       cancelled: false,
       rejectConnection,
+      selectedPeerConnection,
     };
     this.#connectAttempt = connectAttempt;
 
@@ -201,11 +239,13 @@ export class OpenAIRealtimeWebRTC
       try {
         apiKey = await this._getApiKey(options);
       } catch (error) {
+        resolveSelectedPeerConnection(undefined);
         rejectConnection(error);
         return;
       }
 
       if (connectAttempt.cancelled) {
+        resolveSelectedPeerConnection(undefined);
         rejectConnection(new Error(CONNECTION_CLOSED_DURING_SETUP));
         return;
       }
@@ -213,6 +253,7 @@ export class OpenAIRealtimeWebRTC
       const isClientKey =
         typeof apiKey === 'string' && apiKey.startsWith('ek_');
       if (isBrowserEnvironment() && !this.#useInsecureApiKey && !isClientKey) {
+        resolveSelectedPeerConnection(undefined);
         rejectConnection(
           new UserError(
             'Using the WebRTC connection in a browser environment requires an ephemeral client key. If you need to use a regular API key, use the WebSocket transport or set the `useInsecureApiKey` option to true.',
@@ -236,13 +277,15 @@ export class OpenAIRealtimeWebRTC
           try {
             const replacementPeerConnection =
               await this.options.changePeerConnection(peerConnection);
+            resolveSelectedPeerConnection(replacementPeerConnection);
 
             if (connectAttempt.cancelled) {
-              // Let a newer attempt awaiting the same replacement publish ownership first.
-              await Promise.resolve();
               if (
                 replacementPeerConnection !== provisionalPeerConnection &&
-                replacementPeerConnection !== this.#state.peerConnection
+                !(await this.#isPeerConnectionSelectedByNewerAttempt(
+                  replacementPeerConnection,
+                  connectAttempt,
+                ))
               ) {
                 replacementPeerConnection.close();
               }
@@ -254,6 +297,7 @@ export class OpenAIRealtimeWebRTC
             }
             peerConnection = replacementPeerConnection;
           } catch (error) {
+            resolveSelectedPeerConnection(undefined);
             if (connectAttempt.cancelled) {
               rejectConnection(new Error(CONNECTION_CLOSED_DURING_SETUP));
               return;
@@ -267,6 +311,8 @@ export class OpenAIRealtimeWebRTC
               connectAttempt.pendingPeerConnection = undefined;
             }
           }
+        } else {
+          resolveSelectedPeerConnection(provisionalPeerConnection);
         }
 
         const dataChannel = peerConnection.createDataChannel('oai-events');
@@ -468,6 +514,7 @@ export class OpenAIRealtimeWebRTC
 
         await peerConnection.setRemoteDescription(answer);
       } catch (error) {
+        resolveSelectedPeerConnection(undefined);
         this.close();
         this._onError(error);
         rejectConnection(error);

--- a/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
@@ -271,9 +271,9 @@ export class OpenAIRealtimeWebRTC
         const connectionUrl = new URL(baseUrl);
 
         const provisionalPeerConnection = new RTCPeerConnection();
+        connectAttempt.pendingPeerConnection = provisionalPeerConnection;
         let peerConnection: RTCPeerConnection = provisionalPeerConnection;
         if (this.options.changePeerConnection) {
-          connectAttempt.pendingPeerConnection = provisionalPeerConnection;
           try {
             const replacementPeerConnection =
               await this.options.changePeerConnection(peerConnection);
@@ -296,20 +296,20 @@ export class OpenAIRealtimeWebRTC
               provisionalPeerConnection.close();
             }
             peerConnection = replacementPeerConnection;
+            connectAttempt.pendingPeerConnection = peerConnection;
           } catch (error) {
             resolveSelectedPeerConnection(undefined);
             if (connectAttempt.cancelled) {
               rejectConnection(new Error(CONNECTION_CLOSED_DURING_SETUP));
               return;
             }
-            provisionalPeerConnection.close();
-            throw error;
-          } finally {
             if (
               connectAttempt.pendingPeerConnection === provisionalPeerConnection
             ) {
               connectAttempt.pendingPeerConnection = undefined;
             }
+            provisionalPeerConnection.close();
+            throw error;
           }
         } else {
           resolveSelectedPeerConnection(provisionalPeerConnection);
@@ -333,6 +333,9 @@ export class OpenAIRealtimeWebRTC
           dataChannel,
           callId,
         };
+        if (connectAttempt.pendingPeerConnection === peerConnection) {
+          connectAttempt.pendingPeerConnection = undefined;
+        }
         this.emit('connection_change', this.#state.status);
 
         dataChannel.addEventListener('open', () => {
@@ -514,6 +517,11 @@ export class OpenAIRealtimeWebRTC
 
         await peerConnection.setRemoteDescription(answer);
       } catch (error) {
+        if (connectAttempt.pendingPeerConnection) {
+          const pendingPeerConnection = connectAttempt.pendingPeerConnection;
+          connectAttempt.pendingPeerConnection = undefined;
+          pendingPeerConnection.close();
+        }
         resolveSelectedPeerConnection(undefined);
         this.close();
         this._onError(error);

--- a/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
@@ -70,7 +70,8 @@ export type OpenAIRealtimeWebRTCOptions = {
   /**
    * Optional hook invoked with the freshly created peer connection. Returning a
    * different connection will override the one created by the transport layer.
-   * This is called right before the offer is created and can be asynchronous.
+   * This is called before the transport configures the data channel and media,
+   * and can be asynchronous.
    */
   changePeerConnection?: (
     peerConnection: RTCPeerConnection,
@@ -210,6 +211,11 @@ export class OpenAIRealtimeWebRTC
         const connectionUrl = new URL(baseUrl);
 
         let peerConnection: RTCPeerConnection = new RTCPeerConnection();
+        if (this.options.changePeerConnection) {
+          peerConnection =
+            await this.options.changePeerConnection(peerConnection);
+        }
+
         const dataChannel = peerConnection.createDataChannel('oai-events');
         let callId: string | undefined = undefined;
 
@@ -371,17 +377,6 @@ export class OpenAIRealtimeWebRTC
             audio: true,
           }));
         peerConnection.addTrack(stream.getAudioTracks()[0]);
-
-        if (this.options.changePeerConnection) {
-          const originalPeerConnection = peerConnection;
-          peerConnection =
-            await this.options.changePeerConnection(peerConnection);
-          if (originalPeerConnection !== peerConnection) {
-            originalPeerConnection.onconnectionstatechange = null;
-          }
-          attachConnectionStateHandler(peerConnection);
-          this.#state = { ...this.#state, peerConnection };
-        }
 
         const offer = await peerConnection.createOffer();
         await peerConnection.setLocalDescription(offer);

--- a/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
@@ -18,6 +18,8 @@ import { ResponseCreateSequencer } from './responseCreateSequencer';
 import { HEADERS } from './utils';
 
 const PEER_CONNECTION_DISCONNECTED_GRACE_MS = 5000;
+const CONNECTION_CLOSED_DURING_SETUP =
+  'Connection closed before peer connection setup completed';
 
 /**
  * The connection state of the WebRTC connection.
@@ -102,6 +104,8 @@ export class OpenAIRealtimeWebRTC
   #muted = false;
   #connectPromise: Promise<void> | undefined;
   #connectAttemptId = 0;
+  #connectCancelled = false;
+  #pendingPeerConnection: RTCPeerConnection | undefined;
   #peerConnectionDisconnectedTimeout: ReturnType<typeof setTimeout> | undefined;
   #responseCreateSequencer = new ResponseCreateSequencer(
     (event) => this.#sendEventNow(event),
@@ -171,6 +175,7 @@ export class OpenAIRealtimeWebRTC
       return;
     }
 
+    this.#connectCancelled = false;
     const model = options.model ?? this.currentModel;
     this.currentModel = model;
     const baseUrl = options.url ?? this.#url;
@@ -188,6 +193,11 @@ export class OpenAIRealtimeWebRTC
         apiKey = await this._getApiKey(options);
       } catch (error) {
         rejectConnection(error);
+        return;
+      }
+
+      if (this.#connectCancelled) {
+        rejectConnection(new Error(CONNECTION_CLOSED_DURING_SETUP));
         return;
       }
 
@@ -210,14 +220,33 @@ export class OpenAIRealtimeWebRTC
 
         const connectionUrl = new URL(baseUrl);
 
-        let peerConnection: RTCPeerConnection = new RTCPeerConnection();
+        const provisionalPeerConnection = new RTCPeerConnection();
+        let peerConnection: RTCPeerConnection = provisionalPeerConnection;
         if (this.options.changePeerConnection) {
+          this.#pendingPeerConnection = provisionalPeerConnection;
           try {
-            peerConnection =
+            const replacementPeerConnection =
               await this.options.changePeerConnection(peerConnection);
+
+            if (this.#connectCancelled) {
+              if (replacementPeerConnection !== provisionalPeerConnection) {
+                replacementPeerConnection.close();
+              }
+              rejectConnection(new Error(CONNECTION_CLOSED_DURING_SETUP));
+              return;
+            }
+            peerConnection = replacementPeerConnection;
           } catch (error) {
-            peerConnection.close();
+            if (this.#connectCancelled) {
+              rejectConnection(new Error(CONNECTION_CLOSED_DURING_SETUP));
+              return;
+            }
+            provisionalPeerConnection.close();
             throw error;
+          } finally {
+            if (this.#pendingPeerConnection === provisionalPeerConnection) {
+              this.#pendingPeerConnection = undefined;
+            }
           }
         }
 
@@ -555,6 +584,14 @@ export class OpenAIRealtimeWebRTC
    * Close the connection to the Realtime API and disconnects the underlying WebRTC connection.
    */
   close() {
+    if (this.#connectPromise) {
+      this.#connectCancelled = true;
+    }
+    if (this.#pendingPeerConnection) {
+      const pendingPeerConnection = this.#pendingPeerConnection;
+      this.#pendingPeerConnection = undefined;
+      pendingPeerConnection.close();
+    }
     this.#clearPeerConnectionDisconnectedTimeout();
     this.#responseCreateSequencer.releaseWaiters();
     this.#cancelOngoingResponse = false;

--- a/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
@@ -238,7 +238,10 @@ export class OpenAIRealtimeWebRTC
               await this.options.changePeerConnection(peerConnection);
 
             if (connectAttempt.cancelled) {
-              if (replacementPeerConnection !== provisionalPeerConnection) {
+              if (
+                replacementPeerConnection !== provisionalPeerConnection &&
+                replacementPeerConnection !== this.#state.peerConnection
+              ) {
                 replacementPeerConnection.close();
               }
               rejectConnection(new Error(CONNECTION_CLOSED_DURING_SETUP));

--- a/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
@@ -238,6 +238,8 @@ export class OpenAIRealtimeWebRTC
               await this.options.changePeerConnection(peerConnection);
 
             if (connectAttempt.cancelled) {
+              // Let a newer attempt awaiting the same replacement publish ownership first.
+              await Promise.resolve();
               if (
                 replacementPeerConnection !== provisionalPeerConnection &&
                 replacementPeerConnection !== this.#state.peerConnection

--- a/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
@@ -212,8 +212,13 @@ export class OpenAIRealtimeWebRTC
 
         let peerConnection: RTCPeerConnection = new RTCPeerConnection();
         if (this.options.changePeerConnection) {
-          peerConnection =
-            await this.options.changePeerConnection(peerConnection);
+          try {
+            peerConnection =
+              await this.options.changePeerConnection(peerConnection);
+          } catch (error) {
+            peerConnection.close();
+            throw error;
+          }
         }
 
         const dataChannel = peerConnection.createDataChannel('oai-events');

--- a/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
@@ -21,6 +21,12 @@ const PEER_CONNECTION_DISCONNECTED_GRACE_MS = 5000;
 const CONNECTION_CLOSED_DURING_SETUP =
   'Connection closed before peer connection setup completed';
 
+type WebRTCConnectAttempt = {
+  cancelled: boolean;
+  rejectConnection: (reason?: unknown) => void;
+  pendingPeerConnection?: RTCPeerConnection;
+};
+
 /**
  * The connection state of the WebRTC connection.
  */
@@ -104,8 +110,7 @@ export class OpenAIRealtimeWebRTC
   #muted = false;
   #connectPromise: Promise<void> | undefined;
   #connectAttemptId = 0;
-  #connectCancelled = false;
-  #pendingPeerConnection: RTCPeerConnection | undefined;
+  #connectAttempt: WebRTCConnectAttempt | undefined;
   #peerConnectionDisconnectedTimeout: ReturnType<typeof setTimeout> | undefined;
   #responseCreateSequencer = new ResponseCreateSequencer(
     (event) => this.#sendEventNow(event),
@@ -175,17 +180,21 @@ export class OpenAIRealtimeWebRTC
       return;
     }
 
-    this.#connectCancelled = false;
     const model = options.model ?? this.currentModel;
     this.currentModel = model;
     const baseUrl = options.url ?? this.#url;
     const attemptId = ++this.#connectAttemptId;
-    let resolveConnection: () => void;
-    let rejectConnection: (reason?: unknown) => void;
+    let resolveConnection!: () => void;
+    let rejectConnection!: (reason?: unknown) => void;
     const connectionReady = new Promise<void>((resolve, reject) => {
       resolveConnection = resolve;
       rejectConnection = reject;
     });
+    const connectAttempt: WebRTCConnectAttempt = {
+      cancelled: false,
+      rejectConnection,
+    };
+    this.#connectAttempt = connectAttempt;
 
     const prepareConnection = async () => {
       let apiKey: string | undefined;
@@ -196,7 +205,7 @@ export class OpenAIRealtimeWebRTC
         return;
       }
 
-      if (this.#connectCancelled) {
+      if (connectAttempt.cancelled) {
         rejectConnection(new Error(CONNECTION_CLOSED_DURING_SETUP));
         return;
       }
@@ -223,12 +232,12 @@ export class OpenAIRealtimeWebRTC
         const provisionalPeerConnection = new RTCPeerConnection();
         let peerConnection: RTCPeerConnection = provisionalPeerConnection;
         if (this.options.changePeerConnection) {
-          this.#pendingPeerConnection = provisionalPeerConnection;
+          connectAttempt.pendingPeerConnection = provisionalPeerConnection;
           try {
             const replacementPeerConnection =
               await this.options.changePeerConnection(peerConnection);
 
-            if (this.#connectCancelled) {
+            if (connectAttempt.cancelled) {
               if (replacementPeerConnection !== provisionalPeerConnection) {
                 replacementPeerConnection.close();
               }
@@ -237,15 +246,17 @@ export class OpenAIRealtimeWebRTC
             }
             peerConnection = replacementPeerConnection;
           } catch (error) {
-            if (this.#connectCancelled) {
+            if (connectAttempt.cancelled) {
               rejectConnection(new Error(CONNECTION_CLOSED_DURING_SETUP));
               return;
             }
             provisionalPeerConnection.close();
             throw error;
           } finally {
-            if (this.#pendingPeerConnection === provisionalPeerConnection) {
-              this.#pendingPeerConnection = undefined;
+            if (
+              connectAttempt.pendingPeerConnection === provisionalPeerConnection
+            ) {
+              connectAttempt.pendingPeerConnection = undefined;
             }
           }
         }
@@ -458,7 +469,8 @@ export class OpenAIRealtimeWebRTC
     this.#connectPromise = connectionReady.finally(() => {
       // Only clear if this is still the active connection attempt.
       // A newer connect() may have already replaced #connectPromise.
-      if (this.#connectAttemptId === attemptId) {
+      if (this.#connectAttempt === connectAttempt) {
+        this.#connectAttempt = undefined;
         this.#connectPromise = undefined;
       }
     });
@@ -584,13 +596,21 @@ export class OpenAIRealtimeWebRTC
    * Close the connection to the Realtime API and disconnects the underlying WebRTC connection.
    */
   close() {
-    if (this.#connectPromise) {
-      this.#connectCancelled = true;
+    const connectAttempt = this.#connectAttempt;
+    if (connectAttempt) {
+      connectAttempt.cancelled = true;
     }
-    if (this.#pendingPeerConnection) {
-      const pendingPeerConnection = this.#pendingPeerConnection;
-      this.#pendingPeerConnection = undefined;
+    if (connectAttempt?.pendingPeerConnection) {
+      const pendingPeerConnection = connectAttempt.pendingPeerConnection;
+      connectAttempt.pendingPeerConnection = undefined;
       pendingPeerConnection.close();
+      connectAttempt.rejectConnection(
+        new Error(CONNECTION_CLOSED_DURING_SETUP),
+      );
+      if (this.#connectAttempt === connectAttempt) {
+        this.#connectAttempt = undefined;
+        this.#connectPromise = undefined;
+      }
     }
     this.#clearPeerConnectionDisconnectedTimeout();
     this.#responseCreateSequencer.releaseWaiters();

--- a/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
@@ -713,6 +713,45 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
     expect(connectionChanges).toEqual(['connecting', 'connected']);
     expect(rtc.connectionState.peerConnection).toBe(retryPeerConnection as any);
   });
+
+  it('keeps a replacement peer connection reused by a retry open', async () => {
+    const firstReplacement = createDeferred<RTCPeerConnection>();
+    const sharedClose = vi.fn();
+
+    class SharedPeerConnection extends FakeRTCPeerConnection {
+      close() {
+        sharedClose();
+        super.close();
+      }
+    }
+
+    const sharedPeerConnection = new SharedPeerConnection();
+    const changePeerConnection = vi
+      .fn()
+      .mockImplementationOnce(() => firstReplacement.promise)
+      .mockImplementationOnce(() => sharedPeerConnection as any);
+    const rtc = new OpenAIRealtimeWebRTC({ changePeerConnection });
+
+    const firstConnect = rtc.connect({ apiKey: 'ek_test' });
+    const firstRejection = expect(firstConnect).rejects.toThrow(
+      'Connection closed before peer connection setup completed',
+    );
+    await vi.waitFor(() => expect(changePeerConnection).toHaveBeenCalledOnce());
+
+    rtc.close();
+    await firstRejection;
+    await rtc.connect({ apiKey: 'ek_test' });
+
+    firstReplacement.resolve(sharedPeerConnection as any);
+    await firstReplacement.promise;
+    await Promise.resolve();
+
+    expect(sharedClose).not.toHaveBeenCalled();
+    expect(rtc.status).toBe('connected');
+    expect(rtc.connectionState.peerConnection).toBe(
+      sharedPeerConnection as any,
+    );
+  });
 });
 
 describe('OpenAIRealtimeWebRTC.connectionState', () => {

--- a/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
@@ -72,12 +72,7 @@ class FakeRTCPeerConnection {
 
   _simulateStateChange(
     state:
-      | 'new'
-      | 'connecting'
-      | 'connected'
-      | 'disconnected'
-      | 'failed'
-      | 'closed',
+      'new' | 'connecting' | 'connected' | 'disconnected' | 'failed' | 'closed',
   ) {
     if (this.connectionState === state) return;
     this.connectionState = state;
@@ -462,15 +457,23 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
 
   it('ignores stale data channel errors after a failed connect is retried', async () => {
     let shouldFailConnection = true;
-    const rtc = new OpenAIRealtimeWebRTC({
-      changePeerConnection: async (peerConnection) => {
+    Object.defineProperty(globalThis, 'fetch', {
+      value: async () => {
         if (shouldFailConnection) {
           shouldFailConnection = false;
           throw new Error('first connection failed');
         }
-        return peerConnection;
+        return {
+          ok: true,
+          status: 200,
+          text: async () => 'answer',
+          headers: { get: () => null },
+        };
       },
+      configurable: true,
+      writable: true,
     });
+    const rtc = new OpenAIRealtimeWebRTC();
     rtc.on('error', () => {});
 
     await expect(rtc.connect({ apiKey: 'ek_test' })).rejects.toThrow(
@@ -568,14 +571,55 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
     expect(() => rtc.sendEvent({ type: 'test' } as any)).toThrow();
   });
 
-  it('allows overriding the peer connection', async () => {
-    class NewPeerConnection extends FakeRTCPeerConnection {}
+  it('sets up the peer connection returned by changePeerConnection', async () => {
+    const track = { enabled: true };
+    const audioElement = { autoplay: false, srcObject: null };
+    const originalConnections: FakeRTCPeerConnection[] = [];
+    const createDataChannel = vi.fn();
+    const addTrack = vi.fn();
+    const createOffer = vi.fn();
+
+    class OriginalPeerConnection extends FakeRTCPeerConnection {
+      constructor() {
+        super();
+        originalConnections.push(this);
+      }
+    }
+
+    class NewPeerConnection extends FakeRTCPeerConnection {
+      createDataChannel(name: string) {
+        createDataChannel(name);
+        return super.createDataChannel(name);
+      }
+      addTrack(addedTrack?: unknown) {
+        addTrack(addedTrack);
+      }
+      async createOffer() {
+        createOffer();
+        return super.createOffer();
+      }
+    }
     const custom = new NewPeerConnection();
+    (global as any).RTCPeerConnection = OriginalPeerConnection as any;
     const rtc = new OpenAIRealtimeWebRTC({
       changePeerConnection: async () => custom as any,
+      mediaStream: {
+        getAudioTracks: () => [track],
+      } as any,
+      audioElement: audioElement as any,
     });
+
     await rtc.connect({ apiKey: 'ek_test' });
+
     expect(rtc.connectionState.peerConnection).toBe(custom as any);
+    expect(createDataChannel).toHaveBeenCalledWith('oai-events');
+    expect(addTrack).toHaveBeenCalledWith(track);
+    expect(createOffer).toHaveBeenCalledOnce();
+    expect(custom.ontrack).toBeTypeOf('function');
+    custom.ontrack?.({ streams: ['remote-stream'] } as any);
+    expect(audioElement.srcObject).toBe('remote-stream');
+    expect(originalConnections[0]?.ontrack).toBeNull();
+    expect(lastChannel).toBe(rtc.connectionState.dataChannel);
   });
 });
 

--- a/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
@@ -647,6 +647,54 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
     expect(close).toHaveBeenCalledOnce();
     expect(rtc.status).toBe('disconnected');
   });
+
+  it('cancels peer connection setup if close is called during changePeerConnection', async () => {
+    const replacement = createDeferred<RTCPeerConnection>();
+    const provisionalClose = vi.fn();
+    const replacementClose = vi.fn();
+    const createDataChannel = vi.fn();
+
+    class ProvisionalPeerConnection extends FakeRTCPeerConnection {
+      close() {
+        provisionalClose();
+        super.close();
+      }
+    }
+
+    class ReplacementPeerConnection extends FakeRTCPeerConnection {
+      createDataChannel(name: string) {
+        createDataChannel(name);
+        return super.createDataChannel(name);
+      }
+      close() {
+        replacementClose();
+        super.close();
+      }
+    }
+
+    (global as any).RTCPeerConnection = ProvisionalPeerConnection as any;
+    const changePeerConnection = vi.fn(() => replacement.promise);
+    const rtc = new OpenAIRealtimeWebRTC({ changePeerConnection });
+    const connectionChanges: string[] = [];
+    rtc.on('connection_change', (status) => connectionChanges.push(status));
+
+    const connectPromise = rtc.connect({ apiKey: 'ek_test' });
+    const rejection = expect(connectPromise).rejects.toThrow(
+      'Connection closed before peer connection setup completed',
+    );
+    await vi.waitFor(() => expect(changePeerConnection).toHaveBeenCalledOnce());
+
+    rtc.close();
+    expect(provisionalClose).toHaveBeenCalledOnce();
+
+    replacement.resolve(new ReplacementPeerConnection() as any);
+    await rejection;
+
+    expect(replacementClose).toHaveBeenCalledOnce();
+    expect(createDataChannel).not.toHaveBeenCalled();
+    expect(connectionChanges).toEqual([]);
+    expect(rtc.status).toBe('disconnected');
+  });
 });
 
 describe('OpenAIRealtimeWebRTC.connectionState', () => {

--- a/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
@@ -654,6 +654,33 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
     expect(rtc.status).toBe('disconnected');
   });
 
+  it('closes the selected peer connection if data channel setup fails', async () => {
+    const replacementClose = vi.fn();
+
+    class ReplacementPeerConnection extends FakeRTCPeerConnection {
+      createDataChannel(_name: string): never {
+        throw new Error('data channel setup failed');
+      }
+      close() {
+        replacementClose();
+        super.close();
+      }
+    }
+
+    const replacementPeerConnection = new ReplacementPeerConnection();
+    const rtc = new OpenAIRealtimeWebRTC({
+      changePeerConnection: async () => replacementPeerConnection as any,
+    });
+    rtc.on('error', () => {});
+
+    await expect(rtc.connect({ apiKey: 'ek_test' })).rejects.toThrow(
+      'data channel setup failed',
+    );
+
+    expect(replacementClose).toHaveBeenCalledOnce();
+    expect(rtc.status).toBe('disconnected');
+  });
+
   it('cancels peer connection setup if close is called during changePeerConnection', async () => {
     const firstReplacement = createDeferred<RTCPeerConnection>();
     const provisionalClose = vi.fn();

--- a/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
@@ -722,6 +722,7 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
 
   it('keeps a replacement peer connection reused by a retry open', async () => {
     const sharedReplacement = createDeferred<RTCPeerConnection>();
+    const retryApiKey = createDeferred<string>();
     const sharedClose = vi.fn();
 
     class SharedPeerConnection extends FakeRTCPeerConnection {
@@ -743,14 +744,17 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
 
     rtc.close();
     await firstRejection;
-    const retryConnect = rtc.connect({ apiKey: 'ek_test' });
-    await vi.waitFor(() =>
-      expect(changePeerConnection).toHaveBeenCalledTimes(2),
-    );
+    const retryConnect = rtc.connect({ apiKey: () => retryApiKey.promise });
 
     sharedReplacement.resolve(sharedPeerConnection as any);
+    await Promise.resolve();
+    expect(changePeerConnection).toHaveBeenCalledOnce();
+    expect(sharedClose).not.toHaveBeenCalled();
+
+    retryApiKey.resolve('ek_test');
     await retryConnect;
 
+    expect(changePeerConnection).toHaveBeenCalledTimes(2);
     expect(sharedClose).not.toHaveBeenCalled();
     expect(rtc.status).toBe('connected');
     expect(rtc.connectionState.peerConnection).toBe(

--- a/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
@@ -575,6 +575,7 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
     const track = { enabled: true };
     const audioElement = { autoplay: false, srcObject: null };
     const originalConnections: FakeRTCPeerConnection[] = [];
+    const originalClose = vi.fn();
     const createDataChannel = vi.fn();
     const addTrack = vi.fn();
     const createOffer = vi.fn();
@@ -583,6 +584,10 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
       constructor() {
         super();
         originalConnections.push(this);
+      }
+      close() {
+        originalClose();
+        super.close();
       }
     }
 
@@ -615,6 +620,7 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
     expect(createDataChannel).toHaveBeenCalledWith('oai-events');
     expect(addTrack).toHaveBeenCalledWith(track);
     expect(createOffer).toHaveBeenCalledOnce();
+    expect(originalClose).toHaveBeenCalledOnce();
     expect(custom.ontrack).toBeTypeOf('function');
     custom.ontrack?.({ streams: ['remote-stream'] } as any);
     expect(audioElement.srcObject).toBe('remote-stream');

--- a/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
@@ -621,6 +621,32 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
     expect(originalConnections[0]?.ontrack).toBeNull();
     expect(lastChannel).toBe(rtc.connectionState.dataChannel);
   });
+
+  it('closes the provisional peer connection if changePeerConnection fails', async () => {
+    const close = vi.fn();
+
+    class ProvisionalPeerConnection extends FakeRTCPeerConnection {
+      close() {
+        close();
+        super.close();
+      }
+    }
+
+    (global as any).RTCPeerConnection = ProvisionalPeerConnection as any;
+    const rtc = new OpenAIRealtimeWebRTC({
+      changePeerConnection: async () => {
+        throw new Error('replacement failed');
+      },
+    });
+    rtc.on('error', () => {});
+
+    await expect(rtc.connect({ apiKey: 'ek_test' })).rejects.toThrow(
+      'replacement failed',
+    );
+
+    expect(close).toHaveBeenCalledOnce();
+    expect(rtc.status).toBe('disconnected');
+  });
 });
 
 describe('OpenAIRealtimeWebRTC.connectionState', () => {

--- a/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
@@ -715,7 +715,7 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
   });
 
   it('keeps a replacement peer connection reused by a retry open', async () => {
-    const firstReplacement = createDeferred<RTCPeerConnection>();
+    const sharedReplacement = createDeferred<RTCPeerConnection>();
     const sharedClose = vi.fn();
 
     class SharedPeerConnection extends FakeRTCPeerConnection {
@@ -726,10 +726,7 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
     }
 
     const sharedPeerConnection = new SharedPeerConnection();
-    const changePeerConnection = vi
-      .fn()
-      .mockImplementationOnce(() => firstReplacement.promise)
-      .mockImplementationOnce(() => sharedPeerConnection as any);
+    const changePeerConnection = vi.fn(() => sharedReplacement.promise);
     const rtc = new OpenAIRealtimeWebRTC({ changePeerConnection });
 
     const firstConnect = rtc.connect({ apiKey: 'ek_test' });
@@ -740,11 +737,13 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
 
     rtc.close();
     await firstRejection;
-    await rtc.connect({ apiKey: 'ek_test' });
+    const retryConnect = rtc.connect({ apiKey: 'ek_test' });
+    await vi.waitFor(() =>
+      expect(changePeerConnection).toHaveBeenCalledTimes(2),
+    );
 
-    firstReplacement.resolve(sharedPeerConnection as any);
-    await firstReplacement.promise;
-    await Promise.resolve();
+    sharedReplacement.resolve(sharedPeerConnection as any);
+    await retryConnect;
 
     expect(sharedClose).not.toHaveBeenCalled();
     expect(rtc.status).toBe('connected');

--- a/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
@@ -649,10 +649,11 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
   });
 
   it('cancels peer connection setup if close is called during changePeerConnection', async () => {
-    const replacement = createDeferred<RTCPeerConnection>();
+    const firstReplacement = createDeferred<RTCPeerConnection>();
     const provisionalClose = vi.fn();
-    const replacementClose = vi.fn();
-    const createDataChannel = vi.fn();
+    const staleReplacementClose = vi.fn();
+    const staleCreateDataChannel = vi.fn();
+    const retryCreateDataChannel = vi.fn();
 
     class ProvisionalPeerConnection extends FakeRTCPeerConnection {
       close() {
@@ -661,19 +662,30 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
       }
     }
 
-    class ReplacementPeerConnection extends FakeRTCPeerConnection {
+    class StaleReplacementPeerConnection extends FakeRTCPeerConnection {
       createDataChannel(name: string) {
-        createDataChannel(name);
+        staleCreateDataChannel(name);
         return super.createDataChannel(name);
       }
       close() {
-        replacementClose();
+        staleReplacementClose();
         super.close();
       }
     }
 
+    class RetryPeerConnection extends FakeRTCPeerConnection {
+      createDataChannel(name: string) {
+        retryCreateDataChannel(name);
+        return super.createDataChannel(name);
+      }
+    }
+
     (global as any).RTCPeerConnection = ProvisionalPeerConnection as any;
-    const changePeerConnection = vi.fn(() => replacement.promise);
+    const retryPeerConnection = new RetryPeerConnection();
+    const changePeerConnection = vi
+      .fn()
+      .mockImplementationOnce(() => firstReplacement.promise)
+      .mockImplementationOnce(() => retryPeerConnection as any);
     const rtc = new OpenAIRealtimeWebRTC({ changePeerConnection });
     const connectionChanges: string[] = [];
     rtc.on('connection_change', (status) => connectionChanges.push(status));
@@ -686,14 +698,20 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
 
     rtc.close();
     expect(provisionalClose).toHaveBeenCalledOnce();
-
-    replacement.resolve(new ReplacementPeerConnection() as any);
     await rejection;
 
-    expect(replacementClose).toHaveBeenCalledOnce();
-    expect(createDataChannel).not.toHaveBeenCalled();
-    expect(connectionChanges).toEqual([]);
-    expect(rtc.status).toBe('disconnected');
+    await rtc.connect({ apiKey: 'ek_test' });
+    expect(rtc.status).toBe('connected');
+
+    firstReplacement.resolve(new StaleReplacementPeerConnection() as any);
+    await vi.waitFor(() =>
+      expect(staleReplacementClose).toHaveBeenCalledOnce(),
+    );
+
+    expect(staleCreateDataChannel).not.toHaveBeenCalled();
+    expect(retryCreateDataChannel).toHaveBeenCalledOnce();
+    expect(connectionChanges).toEqual(['connecting', 'connected']);
+    expect(rtc.connectionState.peerConnection).toBe(retryPeerConnection as any);
   });
 });
 


### PR DESCRIPTION
The `changePeerConnection` hook can return a different peer connection, but the transport previously created its data channel, attached audio playback, and added the microphone track to the original connection. The SDP offer was then generated from the replacement without those resources.

This moves the hook before transport setup so the selected connection owns the data channel, media track, playback handler, connection-state handler, and offer. It also adds regression coverage for replacement connections and a patch changeset.

Validation: full build, workspace typechecks, declaration checks, lint, formatting, and all 3,344 unit tests pass.
