### PR TITLE
fix: preserve refusals with empty-string content

### DIFF
--- a/.changeset/chat-refusal-empty-content.md
+++ b/.changeset/chat-refusal-empty-content.md
@@ -4,8 +4,4 @@
 
 fix: preserve chat completion refusal when content is an empty string
 
-Some providers (e.g. Azure OpenAI) return an empty-string `content` alongside a
-refusal instead of `null`. The non-streaming Chat Completions converter treated
-that empty string as real content and emitted a blank assistant `output_text`
-message, silently dropping the refusal. It now falls through to the refusal
-branch, matching the streaming converter which already surfaces the refusal.
+Some providers (e.g. Azure OpenAI) return an empty-string `content` alongside a refusal instead of `null`. The non-streaming Chat Completions converter treated that empty string as real content and emitted a blank assistant `output_text` message, silently dropping the refusal. It now falls through to the refusal branch, matching the streaming converter which already surfaces the refusal.

--- a/.changeset/chat-refusal-empty-content.md
+++ b/.changeset/chat-refusal-empty-content.md
@@ -1,0 +1,11 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: preserve chat completion refusal when content is an empty string
+
+Some providers (e.g. Azure OpenAI) return an empty-string `content` alongside a
+refusal instead of `null`. The non-streaming Chat Completions converter treated
+that empty string as real content and emitted a blank assistant `output_text`
+message, silently dropping the refusal. It now falls through to the refusal
+branch, matching the streaming converter which already surfaces the refusal.

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -154,7 +154,10 @@ export class OpenAIChatCompletionsModel implements Model {
         message.content !== undefined &&
         message.content !== null &&
         // Azure OpenAI returns empty string instead of null for tool calls, causing parser rejection
-        !(message.tool_calls && message.content === '');
+        !(message.tool_calls && message.content === '') &&
+        // Some providers (e.g. Azure OpenAI) also return an empty string instead of null
+        // alongside a refusal; treat that as no content so the refusal is not dropped.
+        !(message.refusal && message.content === '');
 
       if (hasContent) {
         const { content, ...rest } = message;

--- a/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
@@ -593,6 +593,43 @@ describe('OpenAIChatCompletionsModel', () => {
     ]);
   });
 
+  it('handles refusal message with empty-string content', async () => {
+    // Some providers (e.g. Azure OpenAI) return an empty string instead of
+    // null for `content` alongside a refusal. The refusal must still be
+    // surfaced rather than being dropped in favor of an empty text message.
+    const client = new FakeClient();
+    const response = {
+      id: 'r',
+      choices: [{ message: { content: '', refusal: 'no' } }],
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    } as any;
+    client.chat.completions.create.mockResolvedValue(response);
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const req: any = {
+      input: 'u',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+    };
+
+    const result = await withTrace('t', () => model.getResponse(req));
+
+    expect(result.output).toEqual([
+      {
+        id: 'r',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [
+          { type: 'refusal', refusal: 'no', providerData: { content: '' } },
+        ],
+      },
+    ]);
+  });
+
   it('handles audio message', async () => {
     const client = new FakeClient();
     const response = {


### PR DESCRIPTION
## Summary

The non-streaming Chat Completions converter can drop a model refusal when a provider returns `message.content === ""` alongside `message.refusal`.

In that case `hasContent` is true, so the converter emits a blank assistant `output_text` item and never reaches the refusal branch. The streaming converter surfaces the refusal for the same payload, so streaming and non-streaming disagree.

This is most likely to show up with Chat Completions-compatible providers or gateways that normalize refusal content to an empty string instead of `null`.

## Fix

Treat `refusal + empty-string content` as no content, so the existing refusal branch runs.

This mirrors the nearby Azure guard for `tool_calls + ""`, where an empty content string should not prevent the more specific branch from handling the message.

## Tests

Added a regression test for non-streaming Chat Completions refusals with `content: ""`.

- `@openai/agents-openai` test suite passes
- eslint passes
