### PR TITLE
fix(examples): improve semantic validation flows

### DIFF
--- a/examples/agent-patterns/human-in-the-loop-stream.ts
+++ b/examples/agent-patterns/human-in-the-loop-stream.ts
@@ -23,8 +23,11 @@ async function main() {
   // Define a tool that requires approval for certain inputs
   const getWeatherTool = tool({
     name: 'get_weather',
-    description: 'Get the weather for a given city',
-    parameters: z.object({ city: z.string() }),
+    description:
+      'Get weather conditions for one city. The result does not include temperature.',
+    parameters: z.object({
+      city: z.string().describe('City whose weather conditions to retrieve.'),
+    }),
     async execute({ city }) {
       return `The weather in ${city} is sunny.`;
     },
@@ -32,16 +35,18 @@ async function main() {
 
   const weatherAgent = new Agent({
     name: 'Weather agent',
-    instructions: 'You provide weather information.',
+    instructions:
+      'Use the available tool to report weather conditions for every requested city. Report conditions only, without temperatures.',
     handoffDescription: 'Handles weather-related queries',
     tools: [getWeatherTool],
   });
 
   const getTemperatureTool = tool({
     name: 'get_temperature',
-    description: 'Get the temperature for a given city',
+    description:
+      'Get the current temperature for one city. Call separately for each requested city.',
     parameters: z.object({
-      city: z.string(),
+      city: z.string().describe('City whose current temperature to retrieve.'),
     }),
     needsApproval: async (_ctx, { city }) => city.includes('Oakland'),
     execute: async ({ city }) => {
@@ -52,13 +57,13 @@ async function main() {
   const mainAgent = new Agent({
     name: 'Main agent',
     instructions:
-      'You are a general assistant. For weather questions, call the weather agent tool with a short input string and then answer.',
+      'Use the available tools to answer weather questions. Retrieve every requested kind of information for every requested city before answering.',
     tools: [
       getTemperatureTool,
       weatherAgent.asTool({
         toolName: 'ask_weather_agent',
         toolDescription:
-          'Ask the weather agent about locations by passing a short input.',
+          'Get weather conditions for one or more locations. This tool does not return temperatures.',
         // Require approval when the generated input mentions San Francisco.
         needsApproval: async (_ctx, { input }) =>
           input.includes('San Francisco'),
@@ -68,7 +73,7 @@ async function main() {
 
   let stream = await run(
     mainAgent,
-    'What is the weather and temperature in San Francisco and Oakland? Use available tools as needed.',
+    'What is the weather and temperature in San Francisco and Oakland?',
     { stream: true },
   );
   stream.toTextStream({ compatibleWithNodeStreams: true }).pipe(process.stdout);

--- a/examples/agent-patterns/human-in-the-loop.ts
+++ b/examples/agent-patterns/human-in-the-loop.ts
@@ -5,9 +5,10 @@ import { Agent, run, tool, RunState, RunResult } from '@openai/agents';
 
 const getWeatherTool = tool({
   name: 'get_weather',
-  description: 'Get the weather for a given city',
+  description:
+    'Get weather conditions for one city. The result does not include temperature.',
   parameters: z.object({
-    city: z.string(),
+    city: z.string().describe('City whose weather conditions to retrieve.'),
   }),
   execute: async ({ city }) => {
     return `The weather in ${city} is sunny`;
@@ -17,16 +18,18 @@ const getWeatherTool = tool({
 // A specialist sub-agent that we will expose as a tool.
 const weatherAgent = new Agent({
   name: 'Weather agent',
-  instructions: 'You provide concise weather information based on the input.',
+  instructions:
+    'Use the available tool to report weather conditions for every requested city. Report conditions only, without temperatures.',
   handoffDescription: 'Handles weather-related queries',
   tools: [getWeatherTool],
 });
 
 const getTemperatureTool = tool({
   name: 'get_temperature',
-  description: 'Get the temperature for a given city',
+  description:
+    'Get the current temperature for one city. Call separately for each requested city.',
   parameters: z.object({
-    city: z.string(),
+    city: z.string().describe('City whose current temperature to retrieve.'),
   }),
   needsApproval: async (_ctx, { city }) => city.includes('Oakland'),
   execute: async ({ city }) => {
@@ -38,13 +41,13 @@ const getTemperatureTool = tool({
 const agent = new Agent({
   name: 'Basic test agent',
   instructions:
-    'You are a basic agent. For weather questions, use the weather agent tool with an appropriate input string and then answer.',
+    'Use the available tools to answer weather questions. Retrieve every requested kind of information for every requested city before answering.',
   tools: [
     getTemperatureTool,
     weatherAgent.asTool({
       toolName: 'ask_weather_agent',
       toolDescription:
-        'Ask the weather agent about a location. Pass a short input string.',
+        'Get weather conditions for one or more locations. This tool does not return temperatures.',
       // Demonstrate approvals at the agent-as-tool level.
       // Require approval when the input mentions San Francisco.
       needsApproval: async (_ctx, { input }) => input.includes('San Francisco'),
@@ -73,7 +76,7 @@ async function confirm(question: string) {
 async function main() {
   let result: RunResult<unknown, Agent<unknown, any>> = await run(
     agent,
-    'What is the weather and temperature in San Francisco and Oakland? Use available tools as needed.',
+    'What is the weather and temperature in San Francisco and Oakland?',
   );
   let hasInterruptions = result.interruptions?.length > 0;
   while (hasInterruptions) {

--- a/examples/financial-research-agent/agents.ts
+++ b/examples/financial-research-agent/agents.ts
@@ -104,6 +104,7 @@ export const writerPrompt = `You are a senior financial analyst.
 You will be provided with the original query and a set of raw search summaries.
 Your task is to synthesize these into a long-form markdown report (at least several paragraphs) including a short executive summary and follow-up questions.
 Use only facts supported by the supplied summaries, preserve their source URLs as inline Markdown citations, and clearly label uncertainty or conflicting information.
+When source summaries conflict on a fact, do not choose a version based on how often it appears. Omit the disputed fact from the executive summary and bottom-line conclusions unless a supplied source directly reconciles the conflict.
 If needed, you can call the available analysis tools (e.g. fundamentals_analysis, risk_analysis) to get short specialist write-ups to incorporate.`;
 
 export const FinancialReportData = z.object({

--- a/examples/financial-research-agent/manager.test.ts
+++ b/examples/financial-research-agent/manager.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  FinancialReportData,
+  FinancialSearchPlan,
+  VerificationResult,
+} from './agents';
+import { FinancialResearchManager } from './manager';
+
+const initialReport: FinancialReportData = {
+  short_summary: 'Initial summary',
+  markdown_report: 'Initial report',
+  follow_up_questions: [],
+};
+
+const revisedReport: FinancialReportData = {
+  short_summary: 'Revised summary',
+  markdown_report: 'Revised report',
+  follow_up_questions: [],
+};
+
+class TestFinancialResearchManager extends FinancialResearchManager {
+  verificationCalls = 0;
+  revisionCalls = 0;
+  verificationFailuresBeforePass = 0;
+
+  async planSearches(): Promise<FinancialSearchPlan> {
+    return { searches: [] };
+  }
+
+  async performSearches(): Promise<string[]> {
+    return ['Primary source summary'];
+  }
+
+  async writeReport(): Promise<FinancialReportData> {
+    return initialReport;
+  }
+
+  async verifyReport(
+    _report: FinancialReportData,
+  ): Promise<VerificationResult> {
+    this.verificationCalls++;
+    if (this.verificationCalls <= this.verificationFailuresBeforePass) {
+      return {
+        verified: false,
+        issues: `Resolve verification issue ${this.verificationCalls}.`,
+      };
+    }
+    return { verified: true, issues: '' };
+  }
+
+  async reviseReport(
+    _query: string,
+    _report: FinancialReportData,
+    _verification: VerificationResult,
+    _searchResults: string[],
+  ): Promise<FinancialReportData> {
+    this.revisionCalls++;
+    return {
+      ...revisedReport,
+      short_summary: `Revised summary ${this.revisionCalls}`,
+    };
+  }
+}
+
+test('revises and re-verifies until the report passes verification', async () => {
+  const manager = new TestFinancialResearchManager();
+  manager.verificationFailuresBeforePass = 2;
+
+  await manager.run('Research query');
+
+  assert.equal(manager.revisionCalls, 2);
+  assert.equal(manager.verificationCalls, 3);
+});
+
+test('does not revise a report that passes verification', async () => {
+  const manager = new TestFinancialResearchManager();
+
+  await manager.run('Research query');
+
+  assert.equal(manager.revisionCalls, 0);
+  assert.equal(manager.verificationCalls, 1);
+});

--- a/examples/financial-research-agent/manager.test.ts
+++ b/examples/financial-research-agent/manager.test.ts
@@ -1,5 +1,4 @@
-import assert from 'node:assert/strict';
-import test from 'node:test';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import {
   FinancialReportData,
   FinancialSearchPlan,
@@ -63,14 +62,22 @@ class TestFinancialResearchManager extends FinancialResearchManager {
   }
 }
 
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 test('revises and re-verifies until the report passes verification', async () => {
   const manager = new TestFinancialResearchManager();
   manager.verificationFailuresBeforePass = 2;
 
   await manager.run('Research query');
 
-  assert.equal(manager.revisionCalls, 2);
-  assert.equal(manager.verificationCalls, 3);
+  expect(manager.revisionCalls).toBe(2);
+  expect(manager.verificationCalls).toBe(3);
 });
 
 test('does not revise a report that passes verification', async () => {
@@ -78,6 +85,6 @@ test('does not revise a report that passes verification', async () => {
 
   await manager.run('Research query');
 
-  assert.equal(manager.revisionCalls, 0);
-  assert.equal(manager.verificationCalls, 1);
+  expect(manager.revisionCalls).toBe(0);
+  expect(manager.verificationCalls).toBe(1);
 });

--- a/examples/financial-research-agent/manager.ts
+++ b/examples/financial-research-agent/manager.ts
@@ -10,6 +10,8 @@ import { searchAgent } from './agents';
 import { verifierAgent, VerificationResult } from './agents';
 import { writerAgent, FinancialReportData } from './agents';
 
+const MAX_REPORT_REVISIONS = 2;
+
 function formatSearchResults(searchResults: string[]): string {
   return searchResults
     .map((result, index) => `Source summary ${index + 1}:\n${result}`)
@@ -28,8 +30,19 @@ export class FinancialResearchManager {
     console.log(`[start] Starting financial research...`);
     const searchPlan = await this.planSearches(query);
     const searchResults = await this.performSearches(searchPlan);
-    const report = await this.writeReport(query, searchResults);
-    const verification = await this.verifyReport(report, searchResults);
+    let report = await this.writeReport(query, searchResults);
+    let verification = await this.verifyReport(report, searchResults);
+    let revisions = 0;
+    while (!verification.verified && revisions < MAX_REPORT_REVISIONS) {
+      report = await this.reviseReport(
+        query,
+        report,
+        verification,
+        searchResults,
+      );
+      verification = await this.verifyReport(report, searchResults);
+      revisions++;
+    }
     const finalReport = `Report summary\n\n${report.short_summary}`;
     console.log(finalReport);
     console.log('\n\n=====REPORT=====\n\n');
@@ -112,6 +125,30 @@ export class FinancialResearchManager {
     const inputData = `Report:\n${report.markdown_report}\n\nSource summaries:\n${formatSearchResults(searchResults)}`;
     const result = await run(verifierAgent, inputData);
     console.log(`[verifying] Done verifying report.`);
+    return result.finalOutput!;
+  }
+
+  async reviseReport(
+    query: string,
+    report: FinancialReportData,
+    verification: VerificationResult,
+    searchResults: string[],
+  ): Promise<FinancialReportData> {
+    console.log(`[revising] Revising report from verifier feedback...`);
+    const inputData = `Original query: ${query}
+
+The current report failed verification. Revise it to resolve every verifier issue. Remove unsupported claims instead of guessing, and preserve explicit uncertainty when the supplied sources conflict.
+
+Verifier feedback:
+${verification.issues}
+
+Current report:
+${JSON.stringify(report, null, 2)}
+
+Source summaries:
+${formatSearchResults(searchResults)}`;
+    const result = await run(writerAgent, inputData);
+    console.log(`[revising] Done revising report.`);
     return result.finalOutput!;
   }
 }

--- a/examples/financial-research-agent/manager.ts
+++ b/examples/financial-research-agent/manager.ts
@@ -25,6 +25,21 @@ async function summaryExtractor(
   return String(runResult.finalOutput.summary);
 }
 
+const reportWriterAgent = writerAgent.clone({
+  tools: [
+    financialsAgent.asTool({
+      toolName: 'fundamentals_analysis',
+      toolDescription: 'Use to get a short write-up of key financial metrics',
+      customOutputExtractor: summaryExtractor,
+    }),
+    riskAgent.asTool({
+      toolName: 'risk_analysis',
+      toolDescription: 'Use to get a short write-up of potential red flags',
+      customOutputExtractor: summaryExtractor,
+    }),
+  ],
+});
+
 export class FinancialResearchManager {
   async run(query: string): Promise<void> {
     console.log(`[start] Starting financial research...`);
@@ -96,23 +111,9 @@ export class FinancialResearchManager {
     query: string,
     searchResults: string[],
   ): Promise<FinancialReportData> {
-    // Expose the specialist analysts as tools
-    const fundamentalsTool = financialsAgent.asTool({
-      toolName: 'fundamentals_analysis',
-      toolDescription: 'Use to get a short write-up of key financial metrics',
-      customOutputExtractor: summaryExtractor,
-    });
-    const riskTool = riskAgent.asTool({
-      toolName: 'risk_analysis',
-      toolDescription: 'Use to get a short write-up of potential red flags',
-      customOutputExtractor: summaryExtractor,
-    });
-    const writerWithTools = writerAgent.clone({
-      tools: [fundamentalsTool, riskTool],
-    });
     console.log(`[writing] Thinking about report...`);
     const inputData = `Original query: ${query}\n\n${formatSearchResults(searchResults)}`;
-    const result = await run(writerWithTools, inputData);
+    const result = await run(reportWriterAgent, inputData);
     console.log(`[writing] Done writing report.`);
     return result.finalOutput!;
   }
@@ -147,7 +148,7 @@ ${JSON.stringify(report, null, 2)}
 
 Source summaries:
 ${formatSearchResults(searchResults)}`;
-    const result = await run(writerAgent, inputData);
+    const result = await run(reportWriterAgent, inputData);
     console.log(`[revising] Done revising report.`);
     return result.finalOutput!;
   }

--- a/examples/financial-research-agent/package.json
+++ b/examples/financial-research-agent/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "build-check": "tsc --noEmit",
-    "start": "tsx main.ts"
+    "start": "tsx main.ts",
+    "test": "tsx --test manager.test.ts"
   }
 }

--- a/examples/financial-research-agent/package.json
+++ b/examples/financial-research-agent/package.json
@@ -7,7 +7,6 @@
   },
   "scripts": {
     "build-check": "tsc --noEmit",
-    "start": "tsx main.ts",
-    "test": "tsx --test manager.test.ts"
+    "start": "tsx main.ts"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,10 @@ const rootDir = dirname(fileURLToPath(import.meta.url));
 const packagesDir = resolve(rootDir, 'packages');
 const workspacePackages = readWorkspacePackages(packagesDir);
 const testAliases = createWorkspacePackageAliases(workspacePackages);
+const financialResearchExampleRoot = resolve(
+  rootDir,
+  'examples/financial-research-agent',
+);
 
 const baseTestConfig = {
   setupFiles: [resolve(rootDir, 'helpers/tests/console-guard.ts')],
@@ -30,6 +34,19 @@ const packageProjects = workspacePackages.map(({ name, root }) => {
   };
 });
 
+const financialResearchExampleProject = {
+  root: financialResearchExampleRoot,
+  resolve: {
+    alias: testAliases,
+  },
+  test: {
+    ...baseTestConfig,
+    alias: testAliases,
+    name: 'financial-research-agent-example',
+    include: ['manager.test.ts'],
+  },
+};
+
 export default defineConfig({
   test: {
     pool: 'threads',
@@ -42,6 +59,7 @@ export default defineConfig({
         },
       },
       ...packageProjects,
+      financialResearchExampleProject,
     ],
     // Coverage options are global in Vitest workspaces.
     // Keep the filter at the root to avoid scanning docs/examples/dist output.


### PR DESCRIPTION
This pull request fixes examples that could exit successfully while producing semantically incomplete output. It clarifies the weather and temperature tool boundaries so both streaming and non-streaming HITL flows satisfy a naturally phrased request without exposing tool names in the user prompt. It also makes financial reports handle conflicting source summaries conservatively and revise failed reports from verifier feedback with a bounded retry loop.