### PR TITLE
fix(mcp): clear wrapper tool cache on Stdio/SSE connect/close/invalidate

### DIFF
--- a/.changeset/mcp-stdio-sse-cache-invalidation.md
+++ b/.changeset/mcp-stdio-sse-cache-invalidation.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: clear the local tool cache on MCPServerStdio/MCPServerSSE connect(), close(), and invalidateToolsCache()
+
+The public `MCPServerStdio` and `MCPServerSSE` wrappers keep their own `_cachedTools` (separate from the underlying shim's cache). Previously only `MCPServerStreamableHttp` cleared that wrapper cache, so the Stdio/SSE wrappers served stale tools indefinitely after `invalidateToolsCache()`, `close()`, or a reconnect via `connect()`. This mirrors the existing `clearLocalToolsCache()` behavior from `MCPServerStreamableHttp`.

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -223,10 +223,15 @@ export class MCPServerStdio
   get name(): string {
     return this.underlying.name;
   }
-  connect(): Promise<void> {
+  private clearLocalToolsCache(): void {
+    this._cachedTools = undefined;
+  }
+  async connect(): Promise<void> {
+    this.clearLocalToolsCache();
     return this.underlying.connect();
   }
-  close(): Promise<void> {
+  async close(): Promise<void> {
+    this.clearLocalToolsCache();
     return this.underlying.close();
   }
   async listTools(): Promise<MCPTool[]> {
@@ -266,7 +271,8 @@ export class MCPServerStdio
   readResource(uri: string): Promise<MCPReadResourceResult> {
     return this.underlying.readResource(uri);
   }
-  invalidateToolsCache(): Promise<void> {
+  async invalidateToolsCache(): Promise<void> {
+    this.clearLocalToolsCache();
     return this.underlying.invalidateToolsCache();
   }
 }
@@ -373,10 +379,15 @@ export class MCPServerSSE
   get name(): string {
     return this.underlying.name;
   }
-  connect(): Promise<void> {
+  private clearLocalToolsCache(): void {
+    this._cachedTools = undefined;
+  }
+  async connect(): Promise<void> {
+    this.clearLocalToolsCache();
     return this.underlying.connect();
   }
-  close(): Promise<void> {
+  async close(): Promise<void> {
+    this.clearLocalToolsCache();
     return this.underlying.close();
   }
   async listTools(): Promise<MCPTool[]> {
@@ -416,7 +427,8 @@ export class MCPServerSSE
   readResource(uri: string): Promise<MCPReadResourceResult> {
     return this.underlying.readResource(uri);
   }
-  invalidateToolsCache(): Promise<void> {
+  async invalidateToolsCache(): Promise<void> {
+    this.clearLocalToolsCache();
     return this.underlying.invalidateToolsCache();
   }
 }

--- a/packages/agents-core/test/mcpCache.test.ts
+++ b/packages/agents-core/test/mcpCache.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
-import { getAllMcpTools, invalidateServerToolsCache } from '../src/mcp';
+import {
+  getAllMcpTools,
+  invalidateServerToolsCache,
+  MCPServerStdio,
+  MCPServerSSE,
+} from '../src/mcp';
 import { UserError } from '../src/errors';
 import { tool, type FunctionTool } from '../src/tool';
 import { withTrace } from '../src/tracing';
@@ -840,5 +845,164 @@ describe('MCP tools without tracing', () => {
     const tools = await getAllMcpTools([server]);
     expect(tools.map((tool) => tool.name)).toEqual(['tool']);
     expect(listCalls).toBe(1);
+  });
+});
+
+// Regression tests for the public MCPServerStdio / MCPServerSSE wrappers.
+// These wrappers keep their own `_cachedTools` (separate from the underlying
+// shim's cache). Previously only MCPServerStreamableHttp cleared that wrapper
+// cache on connect()/close()/invalidateToolsCache(), so the Stdio/SSE wrappers
+// served stale tools forever after invalidation or reconnect.
+function toolNamed(name: string) {
+  return {
+    name,
+    description: '',
+    inputSchema: { type: 'object', properties: {} },
+  };
+}
+
+function createStubUnderlying(initialTools: any[]) {
+  let toolList = [...initialTools];
+  let invalidateCalls = 0;
+  const stub = {
+    name: 'stub',
+    async connect() {},
+    async close() {},
+    async listTools() {
+      return [...toolList];
+    },
+    async invalidateToolsCache() {
+      invalidateCalls += 1;
+    },
+    async callToolResult() {
+      return { content: [] as CallToolResultContent[] } as any;
+    },
+    async callTool() {
+      return [] as CallToolResultContent[];
+    },
+  };
+  return {
+    stub,
+    setTools: (tools: any[]) => (toolList = [...tools]),
+    invalidateCalls: () => invalidateCalls,
+  };
+}
+
+describe('MCPServerStdio wrapper cache invalidation', () => {
+  it('returns fresh tools after invalidateToolsCache()', async () => {
+    const server = new MCPServerStdio({
+      command: 'noop',
+      name: 'stub',
+      cacheToolsList: true,
+    });
+    const { stub, setTools } = createStubUnderlying([toolNamed('a')]);
+    (server as any).underlying = stub;
+
+    await server.connect();
+    expect((await server.listTools()).map((t: any) => t.name)).toEqual(['a']);
+
+    setTools([toolNamed('b')]);
+    await server.invalidateToolsCache();
+    expect((await server.listTools()).map((t: any) => t.name)).toEqual(['b']);
+  });
+
+  it('does not serve stale tools after close()', async () => {
+    const server = new MCPServerStdio({
+      command: 'noop',
+      name: 'stub',
+      cacheToolsList: true,
+    });
+    const { stub, setTools } = createStubUnderlying([toolNamed('a')]);
+    (server as any).underlying = stub;
+
+    await server.connect();
+    await server.listTools();
+
+    setTools([toolNamed('b')]);
+    await server.close();
+    expect((await server.listTools()).map((t: any) => t.name)).toEqual(['b']);
+  });
+
+  it('clears the wrapper cache on connect() (reconnect scenario)', async () => {
+    const server = new MCPServerStdio({
+      command: 'noop',
+      name: 'stub',
+      cacheToolsList: true,
+    });
+    const { stub, setTools } = createStubUnderlying([toolNamed('a')]);
+    (server as any).underlying = stub;
+
+    await server.connect();
+    await server.listTools();
+
+    setTools([toolNamed('b')]);
+    await server.connect();
+    expect((await server.listTools()).map((t: any) => t.name)).toEqual(['b']);
+  });
+
+  it('forwards invalidateToolsCache() to the underlying shim', async () => {
+    const server = new MCPServerStdio({
+      command: 'noop',
+      name: 'stub',
+      cacheToolsList: true,
+    });
+    const { stub, invalidateCalls } = createStubUnderlying([toolNamed('a')]);
+    (server as any).underlying = stub;
+
+    await server.invalidateToolsCache();
+    expect(invalidateCalls()).toBe(1);
+  });
+});
+
+describe('MCPServerSSE wrapper cache invalidation', () => {
+  it('returns fresh tools after invalidateToolsCache()', async () => {
+    const server = new MCPServerSSE({
+      url: 'http://localhost:1',
+      name: 'stub',
+      cacheToolsList: true,
+    });
+    const { stub, setTools } = createStubUnderlying([toolNamed('a')]);
+    (server as any).underlying = stub;
+
+    await server.connect();
+    expect((await server.listTools()).map((t: any) => t.name)).toEqual(['a']);
+
+    setTools([toolNamed('b')]);
+    await server.invalidateToolsCache();
+    expect((await server.listTools()).map((t: any) => t.name)).toEqual(['b']);
+  });
+
+  it('does not serve stale tools after close()', async () => {
+    const server = new MCPServerSSE({
+      url: 'http://localhost:1',
+      name: 'stub',
+      cacheToolsList: true,
+    });
+    const { stub, setTools } = createStubUnderlying([toolNamed('a')]);
+    (server as any).underlying = stub;
+
+    await server.connect();
+    await server.listTools();
+
+    setTools([toolNamed('b')]);
+    await server.close();
+    expect((await server.listTools()).map((t: any) => t.name)).toEqual(['b']);
+  });
+
+  it('clears the wrapper cache on connect() (reconnect scenario)', async () => {
+    const server = new MCPServerSSE({
+      url: 'http://localhost:1',
+      name: 'stub',
+      cacheToolsList: true,
+    });
+    const { stub, setTools } = createStubUnderlying([toolNamed('a')]);
+    (server as any).underlying = stub;
+
+    await server.connect();
+    await server.listTools();
+
+    setTools([toolNamed('b')]);
+    await server.connect();
+    expect((await server.listTools()).map((t: any) => t.name)).toEqual(['b']);
   });
 });


### PR DESCRIPTION
## Problem

When `cacheToolsList: true` is enabled, the public `MCPServerStdio` and `MCPServerSSE` wrapper classes cache the tool list in their own `_cachedTools` field (separate from the underlying shim's cache). Unlike `MCPServerStreamableHttp`, neither wrapper ever cleared that local cache, so they **served a stale tool list indefinitely** after any of:

- `invalidateToolsCache()` — the documented way to refresh tools
- `close()` followed by `listTools()`
- a reconnect via `connect()`

Only `MCPServerStreamableHttp` had a `clearLocalToolsCache()` helper wired into these methods. Stdio/SSE were left out.

## Fix

Mirror the existing `MCPServerStreamableHttp` behavior:

- Add a private `clearLocalToolsCache()` helper to both `MCPServerStdio` and `MCPServerSSE` that resets `_cachedTools`.
- Call it in `connect()`, `close()`, and `invalidateToolsCache()`.
- Make those three methods `async` so the local cache is cleared and the forwarded call to the underlying shim both settle before returning (matching `MCPServerStreamableHttp`).

The `invalidateToolsCache()` path still forwards to the underlying shim's cache invalidation as before — it just also clears the wrapper-local cache now.

## Verification

Added regression tests in `packages/agents-core/test/mcpCache.test.ts` covering both `MCPServerStdio` and `MCPServerSSE`:

- returns fresh tools after `invalidateToolsCache()`
- does not serve stale tools after `close()`
- clears the wrapper cache on `connect()` (reconnect scenario)
- (Stdio) forwards `invalidateToolsCache()` to the underlying shim

Confirmed the tests actually catch the bug: with only the source change reverted, **6 of the new regression tests fail** (`expected [ 'a' ] to deeply equal [ 'b' ]`); with the fix applied, all 27 tests in the file pass.

```
✓ |@openai/agents-core| test/mcpCache.test.ts (27 tests)
```

Also ran the broader MCP test set (71 tests) plus `pnpm -F @openai/agents-core build-check`, ESLint, and Prettier — all clean.

## Changeset

Added `.changeset/mcp-stdio-sse-cache-invalidation.md` (`@openai/agents-core`: patch).
