### PR TITLE
fix(extensions): support AI SDK v4 models

### DIFF
--- a/.changeset/fuzzy-badgers-adapt.md
+++ b/.changeset/fuzzy-badgers-adapt.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: support AI SDK v4 models and AI SDK 7 peers (#1499)

--- a/docs/src/content/docs/extensions/ai-sdk.mdx
+++ b/docs/src/content/docs/extensions/ai-sdk.mdx
@@ -105,7 +105,7 @@ There are two related integrations in `@openai/agents-extensions`:
 
 - The `@openai/agents-extensions/ai-sdk` adapter is still in beta, so it is worth testing carefully with your chosen provider, especially smaller ones.
 - If you are using OpenAI models, prefer the default OpenAI model provider instead of this adapter.
-- Supported AI SDK providers must expose `specificationVersion` `v2` or `v3`. If you need the older v1 provider style, copy the module from [examples/ai-sdk-v1](https://github.com/openai/openai-agents-js/tree/main/examples/ai-sdk-v1) into your project.
+- Supported AI SDK providers must expose `specificationVersion` `v2`, `v3`, or `v4`. If you need the older v1 provider style, copy the module from [examples/ai-sdk-v1](https://github.com/openai/openai-agents-js/tree/main/examples/ai-sdk-v1) into your project.
 - Computer tools require display metadata when used through this adapter. Make sure the tool includes both `environment` and `dimensions` metadata.
 - Deferred Responses tool-loading flows are not supported here. That includes `toolNamespace()`, function tools with `deferLoading: true`, and `toolSearchTool()`. If you need tool search, use an OpenAI Responses model directly. See the [Tools guide](/openai-agents-js/guides/tools#deferred-tool-loading-with-tool-search) and [Models guide](/openai-agents-js/guides/models#responses-only-deferred-tool-loading).
 

--- a/integration-tests/bun/aisdk.ts
+++ b/integration-tests/bun/aisdk.ts
@@ -4,13 +4,19 @@ import { Agent, Runner } from '@openai/agents';
 import { aisdk } from '@openai/agents-extensions/ai-sdk';
 
 const fakeModel = {
+  specificationVersion: 'v4',
   provider: 'fake',
   modelId: 'fake-model',
   async doGenerate() {
     return {
       content: [{ type: 'text', text: 'hello' }],
-      usage: { inputTokens: 1, outputTokens: 1 },
+      usage: {
+        inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+        outputTokens: { total: 1, text: 1, reasoning: 0 },
+      },
       providerMetadata: {},
+      finishReason: { unified: 'stop', raw: 'stop' },
+      warnings: [],
     };
   },
 };

--- a/integration-tests/node-ai-sdk-v4-ts.test.ts
+++ b/integration-tests/node-ai-sdk-v4-ts.test.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect, beforeAll } from 'vitest';
+import { execa as execaBase } from 'execa';
+
+import { createIntegrationSubprocessEnv } from './_helpers/env';
+
+const execa = execaBase({
+  cwd: './integration-tests/node-ai-sdk-v4-ts',
+  env: createIntegrationSubprocessEnv(),
+});
+
+describe('Node.js (TypeScript + AI SDK v4)', () => {
+  beforeAll(async () => {
+    console.log('[node-ai-sdk-v4-ts] Removing node_modules');
+    await execa`rm -rf node_modules`;
+    console.log('[node-ai-sdk-v4-ts] Installing dependencies');
+    await execa`npm install`;
+  }, 60000);
+
+  test('should build-check, build, and run', { timeout: 120000 }, async () => {
+    await execa`npm run build-check`;
+    await execa`npm run build`;
+    const { stdout } = await execa`npm run start`;
+    expect(stdout).toContain('[AISDK_V4_MODEL_READY]');
+  });
+});

--- a/integration-tests/node-ai-sdk-v4-ts/.npmrc
+++ b/integration-tests/node-ai-sdk-v4-ts/.npmrc
@@ -1,0 +1,2 @@
+@openai:registry=http://localhost:4873
+package-lock=false

--- a/integration-tests/node-ai-sdk-v4-ts/package.json
+++ b/integration-tests/node-ai-sdk-v4-ts/package.json
@@ -1,0 +1,20 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build-check": "tsc --noEmit",
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@ai-sdk/deepseek": "^3.0.0",
+    "@ai-sdk/provider": "^4.0.0",
+    "@openai/agents": "latest",
+    "@openai/agents-extensions": "latest",
+    "ai": "^7.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/integration-tests/node-ai-sdk-v4-ts/src/index.ts
+++ b/integration-tests/node-ai-sdk-v4-ts/src/index.ts
@@ -1,0 +1,11 @@
+import { deepseek } from '@ai-sdk/deepseek';
+import { Agent } from '@openai/agents';
+import { aisdk } from '@openai/agents-extensions/ai-sdk';
+
+const agent = new Agent({
+  name: 'AI SDK v4 Test Agent',
+  instructions: 'You are a helpful assistant.',
+  model: aisdk(deepseek('deepseek-chat')),
+});
+
+console.log(`[AISDK_V4_MODEL_READY]${agent.name}[/AISDK_V4_MODEL_READY]`);

--- a/integration-tests/node-ai-sdk-v4-ts/tsconfig.json
+++ b/integration-tests/node-ai-sdk-v4-ts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/agents-extensions/package.json
+++ b/packages/agents-extensions/package.json
@@ -76,7 +76,7 @@
     }
   },
   "peerDependencies": {
-    "@ai-sdk/provider": "^2.0.0 || ^3.0.0",
+    "@ai-sdk/provider": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "@blaxel/core": "^0.2.82",
     "@daytonaio/sdk": "^0.162.0",
     "@e2b/code-interpreter": "^2.3.3",
@@ -84,7 +84,7 @@
     "@openai/codex-sdk": ">=0.86.0",
     "@runloop/api-client": "^1.16.2",
     "@vercel/sandbox": "^1.9.3",
-    "ai": "^6.0.0",
+    "ai": "^6.0.0 || ^7.0.0",
     "e2b": "^2.14.1",
     "modal": "^0.7.6",
     "ws": "^8.21.0",
@@ -130,7 +130,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@ai-sdk/provider": "^3.0.0",
+    "@ai-sdk/provider": "^4.0.3",
     "@blaxel/core": "0.2.82",
     "@daytonaio/sdk": "0.162.0",
     "@e2b/code-interpreter": "2.6.1",

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -47,8 +47,8 @@ import {
 import { isZodObject } from '@openai/agents/utils';
 import { extractUsage, toTracingUsage } from './usage';
 
-// Minimal compatibility type to allow V3 (or future) models that follow the same shape as V2.
-type LanguageModelV3Compatible = {
+// Minimal compatibility type to allow V3/V4 models that follow the same shape as V2.
+type LanguageModelV3OrV4Compatible = {
   specificationVersion: string;
   provider: string;
   modelId: string;
@@ -62,7 +62,7 @@ type LanguageModelV3Compatible = {
     | any;
 };
 
-// Minimal provider tool shapes to avoid SDK type name drift across v2/v3.
+// Minimal provider tool shapes to avoid SDK type name drift across v2/v3/v4.
 type LanguageModelV2ProviderDefinedTool = {
   type: 'provider-defined';
   id: string;
@@ -165,7 +165,9 @@ type LanguageModelV2Compat = Omit<
 };
 
 type LanguageModelCompatible =
-  LanguageModelV2Compat | LanguageModelV3Compatible;
+  LanguageModelV2Compat | LanguageModelV3OrV4Compatible;
+
+type AiSdkSpecificationVersion = 'v2' | 'v3' | 'v4' | 'unknown';
 
 type SerializedComputerTool = Extract<SerializedTool, { type: 'computer' }>;
 
@@ -185,7 +187,7 @@ function hasComputerDisplayMetadata(
 
 function getSpecVersion(
   model: LanguageModelCompatible,
-): 'v2' | 'v3' | 'unknown' {
+): AiSdkSpecificationVersion {
   const spec = (model as any)?.specificationVersion;
   if (!spec) {
     // Default to v2 for backward compatibility with older AI SDK model wrappers.
@@ -197,6 +199,9 @@ function getSpecVersion(
   if (typeof spec === 'string' && spec.toLowerCase().startsWith('v3')) {
     return 'v3';
   }
+  if (typeof spec === 'string' && spec.toLowerCase().startsWith('v4')) {
+    return 'v4';
+  }
   return 'unknown';
 }
 
@@ -206,9 +211,26 @@ function ensureSupportedModel(model: LanguageModelCompatible): void {
     throw new UserError(
       `Unsupported AI SDK specificationVersion: ${String(
         (model as any)?.specificationVersion,
-      )}. Only v2 and v3 are supported.`,
+      )}. Only v2, v3, and v4 are supported.`,
     );
   }
+}
+
+function toAiSdkFileData(
+  model: LanguageModelCompatible,
+  data: string | URL,
+): any {
+  if (getSpecVersion(model) !== 'v4') {
+    return data;
+  }
+
+  return typeof data === 'string'
+    ? { type: 'data', data }
+    : { type: 'url', url: data };
+}
+
+function getProviderReferenceKey(model: LanguageModelCompatible): string {
+  return model.provider.split('.')[0] || model.provider;
 }
 
 type ParsedInlineImageData = {
@@ -392,7 +414,7 @@ export function itemsToLanguageV2Messages(
                     if (inlineImage) {
                       return {
                         type: 'file',
-                        data: inlineImage.data,
+                        data: toAiSdkFileData(model, inlineImage.data),
                         mediaType: inlineImage.mediaType,
                         providerOptions: toProviderOptions(
                           contentProviderData,
@@ -404,7 +426,7 @@ export function itemsToLanguageV2Messages(
                     const url = new URL(imageSource);
                     return {
                       type: 'file',
-                      data: url,
+                      data: toAiSdkFileData(model, url),
                       mediaType: 'image/*',
                       providerOptions: toProviderOptions(
                         contentProviderData,
@@ -512,7 +534,7 @@ export function itemsToLanguageV2Messages(
         type: 'tool-result',
         toolCallId: item.callId,
         toolName,
-        output: convertToAiSdkOutput(item.output, getSpecVersion(model)),
+        output: convertToAiSdkOutput(item.output, model),
         providerOptions: toProviderOptions(item.providerData, model),
       };
       messages.push({
@@ -766,13 +788,13 @@ function handoffToLanguageV2Tool(
 
 function convertToAiSdkOutput(
   output: protocol.FunctionCallResultItem['output'],
-  specVersion: 'v2' | 'v3' | 'unknown',
+  model: LanguageModelCompatible,
 ): LanguageModelV2ToolResultPart['output'] {
   if (typeof output === 'string') {
     return { type: 'text', value: output };
   }
   if (Array.isArray(output)) {
-    return convertStructuredOutputsToAiSdkOutput(output, specVersion);
+    return convertStructuredOutputsToAiSdkOutput(output, model);
   }
   if (isRecord(output) && typeof output.type === 'string') {
     if (output.type === 'text' && typeof output.text === 'string') {
@@ -782,10 +804,7 @@ function convertToAiSdkOutput(
       const structuredOutputs = convertLegacyToolOutputContent(
         output as protocol.ToolCallOutputContent,
       );
-      return convertStructuredOutputsToAiSdkOutput(
-        structuredOutputs,
-        specVersion,
-      );
+      return convertStructuredOutputsToAiSdkOutput(structuredOutputs, model);
     }
   }
   return { type: 'text', value: String(output) };
@@ -1165,15 +1184,25 @@ function createProtocolToolSearchOutputItem(args: {
  */
 function convertStructuredOutputsToAiSdkOutput(
   outputs: protocol.ToolCallStructuredOutput[],
-  specVersion: 'v2' | 'v3' | 'unknown',
+  model: LanguageModelCompatible,
 ): LanguageModelV2ToolResultPart['output'] {
   type ImagePart =
     | { type: 'media'; data: string; mediaType: string }
     | { type: 'image-data'; data: string; mediaType: string }
     | { type: 'image-url'; url: string }
-    | { type: 'image-file-id'; fileId: string };
+    | { type: 'image-file-id'; fileId: string }
+    | {
+        type: 'file';
+        data:
+          | { type: 'data'; data: string }
+          | { type: 'url'; url: URL }
+          | { type: 'reference'; reference: Record<string, string> };
+        mediaType: string;
+      };
 
+  const specVersion = getSpecVersion(model);
   const isV3 = specVersion === 'v3';
+  const isV4 = specVersion === 'v4';
   const textParts: string[] = [];
   const imageParts: ImagePart[] = [];
 
@@ -1193,8 +1222,21 @@ function convertStructuredOutputsToAiSdkOutput(
           : undefined;
       const imageFileId = imageObjectFileId ?? legacyFileId;
 
-      if (isV3 && imageFileId) {
-        imageParts.push({ type: 'image-file-id', fileId: imageFileId });
+      if ((isV3 || isV4) && imageFileId) {
+        imageParts.push(
+          isV4
+            ? {
+                type: 'file',
+                data: {
+                  type: 'reference',
+                  reference: {
+                    [getProviderReferenceKey(model)]: imageFileId,
+                  },
+                },
+                mediaType: 'image',
+              }
+            : { type: 'image-file-id', fileId: imageFileId },
+        );
         continue;
       }
 
@@ -1218,30 +1260,42 @@ function convertStructuredOutputsToAiSdkOutput(
       const inlineImage = parseBase64ImageDataUrl(imageValue);
       if (inlineImage) {
         imageParts.push(
-          isV3
+          isV4
             ? {
-                type: 'image-data',
-                data: inlineImage.data,
+                type: 'file',
+                data: { type: 'data', data: inlineImage.data },
                 mediaType: inlineImage.mediaType,
               }
-            : {
-                type: 'media',
-                data: inlineImage.data,
-                mediaType: inlineImage.mediaType,
-              },
+            : isV3
+              ? {
+                  type: 'image-data',
+                  data: inlineImage.data,
+                  mediaType: inlineImage.mediaType,
+                }
+              : {
+                  type: 'media',
+                  data: inlineImage.data,
+                  mediaType: inlineImage.mediaType,
+                },
         );
         continue;
       }
       try {
         const url = new URL(imageValue);
         imageParts.push(
-          isV3
-            ? { type: 'image-url', url: url.toString() }
-            : {
-                type: 'media',
-                data: url.toString(),
-                mediaType: 'image/*',
-              },
+          isV4
+            ? {
+                type: 'file',
+                data: { type: 'url', url },
+                mediaType: 'image',
+              }
+            : isV3
+              ? { type: 'image-url', url: url.toString() }
+              : {
+                  type: 'media',
+                  data: url.toString(),
+                  mediaType: 'image/*',
+                },
         );
       } catch {
         textParts.push(imageValue);
@@ -1509,8 +1563,11 @@ export function toolToLanguageV2Tool(
     };
   }
 
+  const specificationVersion = getSpecVersion(model);
   const providerToolType =
-    getSpecVersion(model) === 'v3' ? 'provider' : 'provider-defined';
+    specificationVersion === 'v3' || specificationVersion === 'v4'
+      ? 'provider'
+      : 'provider-defined';
   const providerToolPrefix = getProviderToolPrefix(model);
 
   if (tool.type === 'hosted_tool') {
@@ -1564,7 +1621,8 @@ export function toolToLanguageV2Tool(
 }
 
 function getProviderToolPrefix(model: LanguageModelCompatible): string {
-  if (getSpecVersion(model) !== 'v3') {
+  const specificationVersion = getSpecVersion(model);
+  if (specificationVersion !== 'v3' && specificationVersion !== 'v4') {
     return model.provider;
   }
   const providerLower = model.provider.toLowerCase();
@@ -1601,7 +1659,7 @@ export type AiSdkOutputTextTransformContext = {
   request: ModelRequest;
   provider: string;
   modelId: string;
-  specificationVersion: 'v2' | 'v3' | 'unknown';
+  specificationVersion: AiSdkSpecificationVersion;
   stream: boolean;
 };
 
@@ -1620,8 +1678,8 @@ export type AiSdkModelOptions = {
 };
 
 /**
- * Wraps a model from the AI SDK that adheres to the LanguageModelV2 spec to be used used as a model
- * in the OpenAI Agents SDK to use other models.
+ * Wraps a model from the AI SDK that adheres to the LanguageModel v2, v3, or v4
+ * specification to be used as a model in the OpenAI Agents SDK.
  *
  * While you can use this with the OpenAI models, it is recommended to use the default OpenAI model
  * provider instead.
@@ -2380,8 +2438,8 @@ export class AiSdkModel implements Model {
 }
 
 /**
- * Wraps a model from the AI SDK that adheres to the LanguageModelV2 spec to be used used as a model
- * in the OpenAI Agents SDK to use other models.
+ * Wraps a model from the AI SDK that adheres to the LanguageModel v2, v3, or v4
+ * specification to be used as a model in the OpenAI Agents SDK.
  *
  * While you can use this with the OpenAI models, it is recommended to use the default OpenAI model
  * provider instead.

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -321,6 +321,151 @@ describe('AiSdkModel end-to-end scenarios', () => {
     });
   });
 
+  test('supports v4 generation, reasoning, usage, and abort propagation', async () => {
+    const controller = new AbortController();
+    let receivedOptions: any;
+    const transformOutputText = vi.fn((text, context) => {
+      expect(context.specificationVersion).toBe('v4');
+      return text;
+    });
+    const v4Model: any = {
+      specificationVersion: 'v4',
+      provider: 'deepseek.chat',
+      modelId: 'deepseek-chat',
+      supportedUrls: {},
+      async doGenerate(options: any) {
+        receivedOptions = options;
+        return {
+          content: [
+            { type: 'reasoning', text: 'thinking' },
+            { type: 'text', text: 'hello v4' },
+          ],
+          usage: {
+            inputTokens: {
+              total: 3,
+              noCache: 2,
+              cacheRead: 1,
+              cacheWrite: 0,
+            },
+            outputTokens: { total: 5, text: 4, reasoning: 1 },
+          },
+          response: { id: 'resp-v4' },
+          providerMetadata: {},
+          finishReason: { unified: 'stop', raw: 'stop' },
+          warnings: [],
+        };
+      },
+      async doStream() {
+        return { stream: partsStream([]) };
+      },
+    };
+
+    const model = new AiSdkModel(v4Model, { transformOutputText });
+    const response = await withTrace('v4-model', () =>
+      model.getResponse({
+        input: 'prompt',
+        tools: [],
+        handoffs: [],
+        modelSettings: {},
+        outputType: 'text',
+        tracing: false,
+        signal: controller.signal,
+      } as any),
+    );
+
+    expect(receivedOptions.abortSignal).toBe(controller.signal);
+    expect(transformOutputText).toHaveBeenCalledOnce();
+    expect(response.output.map((item) => item.type)).toEqual([
+      'reasoning',
+      'message',
+    ]);
+    expect(response.output[1]).toMatchObject({
+      type: 'message',
+      content: [{ type: 'output_text', text: 'hello v4' }],
+    });
+    expect(response.usage).toMatchObject({
+      inputTokens: 3,
+      outputTokens: 5,
+      totalTokens: 8,
+    });
+  });
+
+  test('supports v4 streaming reasoning and object-shaped usage', async () => {
+    const controller = new AbortController();
+    let receivedOptions: any;
+    const v4Model: any = {
+      specificationVersion: 'v4',
+      provider: 'deepseek.chat',
+      modelId: 'deepseek-chat',
+      supportedUrls: {},
+      async doGenerate() {
+        return { content: [], usage: {} };
+      },
+      async doStream(options: any) {
+        receivedOptions = options;
+        return {
+          stream: partsStream([
+            { type: 'reasoning-start', id: 'reasoning-1' },
+            {
+              type: 'reasoning-delta',
+              id: 'reasoning-1',
+              delta: 'thinking',
+            },
+            { type: 'reasoning-end', id: 'reasoning-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'hello v4' },
+            {
+              type: 'finish',
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: {
+                inputTokens: {
+                  total: 2,
+                  noCache: 2,
+                  cacheRead: 0,
+                  cacheWrite: 0,
+                },
+                outputTokens: { total: 4, text: 3, reasoning: 1 },
+              },
+            },
+          ]),
+        };
+      },
+    };
+
+    const model = new AiSdkModel(v4Model);
+    const events: any[] = [];
+    for await (const event of model.getStreamedResponse({
+      input: 'prompt',
+      tools: [],
+      handoffs: [],
+      modelSettings: {},
+      outputType: 'text',
+      tracing: false,
+      signal: controller.signal,
+    } as any)) {
+      events.push(event);
+    }
+
+    const final = events.at(-1);
+    expect(receivedOptions.abortSignal).toBe(controller.signal);
+    expect(final.response.output.map((item: any) => item.type)).toEqual([
+      'reasoning',
+      'message',
+    ]);
+    expect(final.response.usage).toMatchObject({
+      inputTokens: 2,
+      outputTokens: 4,
+      totalTokens: 6,
+    });
+  });
+
+  test('rejects unsupported specification versions', () => {
+    expect(
+      () => new AiSdkModel(stubModel({}, { specificationVersion: 'v5' })),
+    ).toThrow(
+      'Unsupported AI SDK specificationVersion: v5. Only v2, v3, and v4 are supported.',
+    );
+  });
+
   test('returns JSON schema output in streaming finish', async () => {
     const schema: JSONSchema7 = {
       type: 'object',
@@ -1376,6 +1521,44 @@ describe('itemsToLanguageV2Messages', () => {
     ]);
   });
 
+  test('converts v4 user images to tagged file data', () => {
+    const imageUrl = 'https://example.com/image.png';
+    const items: protocol.ModelItem[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'input_image', image: 'data:image/png;base64,aGVsbG8=' },
+          { type: 'input_image', image: imageUrl },
+        ],
+      } as any,
+    ];
+    const msgs = itemsToLanguageV2Messages(
+      stubModel({}, { specificationVersion: 'v4' }),
+      items,
+    );
+
+    expect(msgs).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: { type: 'data', data: 'aGVsbG8=' },
+            mediaType: 'image/png',
+            providerOptions: {},
+          },
+          {
+            type: 'file',
+            data: { type: 'url', url: new URL(imageUrl) },
+            mediaType: 'image/*',
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+    ]);
+  });
+
   test('converts structured tool output lists', () => {
     const items: protocol.ModelItem[] = [
       {
@@ -1530,6 +1713,76 @@ describe('itemsToLanguageV2Messages', () => {
         providerOptions: {},
       },
     ]);
+  });
+
+  test('converts v4 image tool outputs to canonical file parts', () => {
+    const imageUrl = 'https://example.com/image.png';
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call',
+        callId: 'tool-1',
+        name: 'describe_image',
+        arguments: '{}',
+      } as any,
+      {
+        type: 'function_call_result',
+        callId: 'tool-1',
+        name: 'describe_image',
+        output: [
+          { type: 'input_text', text: 'A scenic view.' },
+          { type: 'input_image', image: imageUrl },
+          {
+            type: 'input_image',
+            image: 'data:image/png;base64,aGVsbG8=',
+          },
+          { type: 'input_image', image: { id: 'file_image_123' } },
+        ],
+      } as any,
+    ];
+
+    const msgs = itemsToLanguageV2Messages(
+      stubModel(
+        {},
+        { provider: 'openai.responses', specificationVersion: 'v4' },
+      ),
+      items,
+    );
+    expect(msgs[1]).toEqual({
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: 'tool-1',
+          toolName: 'describe_image',
+          output: {
+            type: 'content',
+            value: [
+              { type: 'text', text: 'A scenic view.' },
+              {
+                type: 'file',
+                data: { type: 'url', url: new URL(imageUrl) },
+                mediaType: 'image',
+              },
+              {
+                type: 'file',
+                data: { type: 'data', data: 'aGVsbG8=' },
+                mediaType: 'image/png',
+              },
+              {
+                type: 'file',
+                data: {
+                  type: 'reference',
+                  reference: { openai: 'file_image_123' },
+                },
+                mediaType: 'image',
+              },
+            ],
+          },
+          providerOptions: {},
+        },
+      ],
+      providerOptions: {},
+    });
   });
 
   test('handles undefined providerData without throwing', () => {
@@ -1749,7 +2002,7 @@ describe('toolToLanguageV2Tool', () => {
     });
   });
 
-  test('preserves AI SDK provider tool ids for v2 and v3 models', () => {
+  test('preserves AI SDK provider tool ids for v2, v3, and v4 models', () => {
     const tool = aiSdkToolSearchTool({
       type: 'provider',
       id: 'anthropic.tool_search_regex_20251119',
@@ -1773,24 +2026,38 @@ describe('toolToLanguageV2Tool', () => {
       name: 'tool_search',
       args: { maxUses: 2 },
     });
+
+    const v4Model = stubModel(
+      {},
+      { provider: 'anthropic.messages', specificationVersion: 'v4' },
+    );
+    expect(toolToLanguageV2Tool(v4Model, tool)).toEqual({
+      type: 'provider',
+      id: 'anthropic.tool_search_regex_20251119',
+      name: 'tool_search',
+      args: { maxUses: 2 },
+    });
   });
 
-  test('normalizes OpenAI v3 builtin tool IDs', () => {
-    const v3Model = stubModel(
-      {},
-      { provider: 'openai.responses', specificationVersion: 'v3' },
-    );
+  test('normalizes OpenAI v3 and v4 builtin tool IDs', () => {
     const tool = {
       type: 'hosted_tool',
       name: 'file_search',
       providerData: { args: { query: 'x' } },
     } as any;
-    expect(toolToLanguageV2Tool(v3Model, tool)).toEqual({
-      type: 'provider',
-      id: 'openai.file_search',
-      name: 'file_search',
-      args: { query: 'x' },
-    });
+
+    for (const specificationVersion of ['v3', 'v4']) {
+      const model = stubModel(
+        {},
+        { provider: 'openai.responses', specificationVersion },
+      );
+      expect(toolToLanguageV2Tool(model, tool)).toEqual({
+        type: 'provider',
+        id: 'openai.file_search',
+        name: 'file_search',
+        args: { query: 'x' },
+      });
+    }
   });
 
   test('maps computer tools', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -675,8 +675,8 @@ importers:
         version: 4.4.1
     devDependencies:
       '@ai-sdk/provider':
-        specifier: ^3.0.0
-        version: 3.0.2
+        specifier: ^4.0.3
+        version: 4.0.3
       '@blaxel/core':
         specifier: 0.2.82
         version: 0.2.82(@hey-api/openapi-ts@0.96.1(magicast@0.5.3)(typescript@5.9.3))(debug@4.4.1)
@@ -850,6 +850,10 @@ packages:
   '@ai-sdk/provider@3.0.4':
     resolution: {integrity: sha512-5KXyBOSEX+l67elrEa+wqo/LSsSTtrPj9Uoh3zMbe/ceQX4ucHI3b9nUEfNkGF3Ry1svv90widAt+aiKdIJasQ==}
     engines: {node: '>=18'}
+
+  '@ai-sdk/provider@4.0.3':
+    resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
+    engines: {node: '>=22'}
 
   '@ai-sdk/react@3.0.44':
     resolution: {integrity: sha512-TiCzQMRJZ8ASZjemz9eeX0/C5f6G1boRhrxVE3aNKvpuO/RUVQvkHsCIiJF3JgCyCEgQo//BqrXah1aSqgKDDA==}
@@ -8037,6 +8041,10 @@ snapshots:
       json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.4':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@4.0.3':
     dependencies:
       json-schema: 0.4.0
 


### PR DESCRIPTION
### Summary

Fixes the runtime `UserError` raised when `@openai/agents-extensions/ai-sdk` receives an AI SDK 7 `LanguageModelV4` model.

- Accepts `specificationVersion: 'v4'` while preserving released v2/v3 behavior.
- Emits v4 tagged file data, provider references, and provider-tool shapes.
- Widens the optional `@ai-sdk/provider` and `ai` peer ranges and adds a patch changeset.
- Adds unit coverage plus a keyless AI SDK 7/DeepSeek consumer fixture.

Risk class: additive compatibility change. No data migration or live-flow changes.

### Test plan

- `bash .agents/skills/code-change-verification/scripts/run.sh`
  - Passed frozen install, build, all workspace build-checks, all package dist-checks, lint, formatting, and 3,351 tests.
- `pnpm exec vitest run --config=vitest.integration.config.ts integration-tests/node-ai-sdk-v4-ts.test.ts`
  - Passed against locally published packages with AI SDK 7 and `@ai-sdk/deepseek` v3; no API call.
- Targeted Bun fixture was attempted but could not run because Bun is not installed in the test environment (`spawn bun ENOENT`).
- The credentialed/live integration suite was not run.

### Issue number

Closes #1499

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration` [(see details)](https://github.com/openai/openai-agents-js/tree/main/integration-tests)
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
- [x] I've added a changeset using `pnpm changeset` to indicate my changes
