### PR TITLE
chore: upgrade pnpm toolchain

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,5 +100,5 @@
     "verdaccio": "^6.7.4",
     "vitest": "^3.2.6"
   },
-  "packageManager": "pnpm@11.13.1+sha512.b2fc7683b8a6525414e7d13e1ba28caaddde96bf66ec540bfaeb7e702b81f3e0be4d1f295edf7f9fe0396740a8dce4509c582ddf79891f4543fea32d37645f25"
+  "packageManager": "pnpm@11.15.1+sha512.81350b07e53c9538a02f1f2303b4290fa2d7be04e56e2a970c4cc4b417dc761de196edabd49d55c7dc9580db81007c44143e4e3d7e462b3000d23c255122d065"
 }


### PR DESCRIPTION
This pull request updates the repository pnpm toolchain from 11.13.1 to 11.15.1 and records the exact registry-derived integrity hash in `packageManager`. The latest `pnpm/action-setup` release still resolves to the SHA already used by the workflows, so no CI pin changes are required.