### PR TITLE
fix(core): parse SELinux permission markers

### DIFF
--- a/.changeset/soft-lions-parse.md
+++ b/.changeset/soft-lions-parse.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: parse SELinux security-context markers in permission strings

--- a/packages/agents-core/src/sandbox/permissions.ts
+++ b/packages/agents-core/src/sandbox/permissions.ts
@@ -78,7 +78,7 @@ export class Permissions {
 
   static fromString(value: string): Permissions {
     const permissions =
-      value.length === 11 && /[@+]$/u.test(value) ? value.slice(0, -1) : value;
+      value.length === 11 && /[.@+]$/u.test(value) ? value.slice(0, -1) : value;
     if (permissions.length !== 10) {
       throw new Error(`Invalid permissions string length: ${value}`);
     }

--- a/packages/agents-core/test/sandboxManifest.test.ts
+++ b/packages/agents-core/test/sandboxManifest.test.ts
@@ -875,6 +875,14 @@ describe('Manifest', () => {
     expect(directory.toString()).toBe('drwxr-x---');
   });
 
+  it.each([
+    ['drwxr-xr-x.', 'drwxr-xr-x'],
+    ['-rw-r--r--+', '-rw-r--r--'],
+    ['-rw-r--r--@', '-rw-r--r--'],
+  ])('strips a trailing alternate access marker: %s', (value, expected) => {
+    expect(Permissions.fromString(value).toString()).toBe(expected);
+  });
+
   it('parses position-specific special permission bits', () => {
     const stickyDirectory = Permissions.fromString('drwxrwxrwt');
     const specialWithExec = Permissions.fromString('-rwsr-sr-t');


### PR DESCRIPTION
This pull request fixes `Permissions.fromString()` so it accepts the trailing `.` marker emitted by `ls` for files with an SELinux security context. Previously, the parser stripped ACL (`+`) and extended-attribute (`@`) markers but rejected valid permission strings such as `drwxr-xr-x.` during length validation.

This aligns the behavior with the corresponding Python SDK fix: https://github.com/openai/openai-agents-python/pull/3904