### PR TITLE
fix(ai-sdk): flush pending assistant message before user/system turns

### DIFF
--- a/.changeset/flush-pending-assistant-tool-search.md
+++ b/.changeset/flush-pending-assistant-tool-search.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix(ai-sdk): flush the pending assistant message before user and system turns
+
+Provider-executed tool search folds its result into the in-progress assistant message and leaves it pending (no flush). The `user` and `system` message branches in `itemsToLanguageV2Messages` did not flush that pending assistant message before pushing their own, so a server tool-search turn followed by a new user turn emitted the assistant message last — the request ended on an assistant message and Anthropic rejected it as an unintended prefill. Route all turn-boundary branches through a shared `flushCurrentAssistantMessage()` helper so the pending assistant is always flushed first.

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -357,6 +357,12 @@ export function itemsToLanguageV2Messages(
       ...currentAssistantMessage.providerOptions,
     };
   };
+  const flushCurrentAssistantMessage = () => {
+    if (currentAssistantMessage) {
+      messages.push(currentAssistantMessage);
+      currentAssistantMessage = undefined;
+    }
+  };
 
   for (const item of collapsedItems) {
     if ('caller' in item && item.caller?.type === 'program') {
@@ -369,6 +375,7 @@ export function itemsToLanguageV2Messages(
       const { role, content, providerData } = item;
       if (role === 'system') {
         flushPendingReasonerReasoningToMessages();
+        flushCurrentAssistantMessage();
         messages.push({
           role: 'system',
           content: content,
@@ -379,6 +386,7 @@ export function itemsToLanguageV2Messages(
 
       if (role === 'user') {
         flushPendingReasonerReasoningToMessages();
+        flushCurrentAssistantMessage();
         messages.push({
           role,
           content:
@@ -445,10 +453,7 @@ export function itemsToLanguageV2Messages(
       }
 
       if (role === 'assistant') {
-        if (currentAssistantMessage) {
-          messages.push(currentAssistantMessage);
-          currentAssistantMessage = undefined;
-        }
+        flushCurrentAssistantMessage();
 
         const assistantProviderOptions = toProviderOptions(providerData, model);
         const assistantContent: Array<
@@ -524,10 +529,7 @@ export function itemsToLanguageV2Messages(
       continue;
     } else if (item.type === 'function_call_result') {
       flushPendingReasonerReasoningToMessages();
-      if (currentAssistantMessage) {
-        messages.push(currentAssistantMessage);
-        currentAssistantMessage = undefined;
-      }
+      flushCurrentAssistantMessage();
       const toolName =
         toolCallNamesById.get(item.callId) ?? getAiSdkToolName(item);
       const toolResult: LanguageModelV2ToolResultPart = {
@@ -678,10 +680,7 @@ export function itemsToLanguageV2Messages(
       }
 
       flushPendingReasonerReasoningToMessages();
-      if (currentAssistantMessage) {
-        messages.push(currentAssistantMessage);
-        currentAssistantMessage = undefined;
-      }
+      flushCurrentAssistantMessage();
       messages.push({
         role: 'tool',
         content: [toolResult],

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -1118,6 +1118,62 @@ describe('itemsToLanguageV2Messages', () => {
     ]);
   });
 
+  test('flushes a pending provider-executed tool search before the next user turn', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        role: 'user',
+        content: [{ type: 'input_text', text: 'first question' }],
+      } as any,
+      {
+        type: 'tool_search_call',
+        id: 'search_1',
+        execution: 'server',
+        arguments: { query: 'site tools' },
+        status: 'completed',
+      } as any,
+      {
+        type: 'tool_search_output',
+        callId: 'search_1',
+        execution: 'server',
+        status: 'completed',
+        tools: [{ type: 'tool_reference', toolName: 'list_sites' }],
+      } as any,
+      {
+        role: 'user',
+        content: [{ type: 'input_text', text: 'follow-up question' }],
+      } as any,
+    ];
+
+    const msgs = itemsToLanguageV2Messages(stubModel({}), items);
+
+    // The provider-executed tool search folds its result into a pending
+    // assistant message. It must be flushed BEFORE the follow-up user message,
+    // otherwise the prompt ends on an assistant turn and Anthropic rejects it
+    // as an unintended assistant-message prefill.
+    expect(msgs.map((m) => m.role)).toEqual(['user', 'assistant', 'user']);
+    // The folded server tool-use + its result survive the flush intact.
+    expect(msgs[1].content).toEqual([
+      {
+        type: 'tool-call',
+        toolCallId: 'search_1',
+        toolName: 'tool_search',
+        input: { query: 'site tools' },
+        providerExecuted: true,
+        providerOptions: {},
+      },
+      {
+        type: 'tool-result',
+        toolCallId: 'search_1',
+        toolName: 'tool_search',
+        output: {
+          type: 'json',
+          value: [{ type: 'tool_reference', toolName: 'list_sites' }],
+        },
+        providerOptions: {},
+      },
+    ]);
+  });
+
   test('replays provider-executed tool search errors as error results', () => {
     const errorResult = {
       type: 'tool_search_tool_result_error',


### PR DESCRIPTION
Fixes #1506.

## Summary

Provider-executed tool search (added in #1483) folds its `tool_search_output` result into the in-progress `currentAssistantMessage` and intentionally leaves it pending so the server tool-use and its result stay in one assistant turn. But the `user` and `system` branches of `itemsToLanguageV2Messages` push their message *without* first flushing that pending assistant — unlike the `assistant` and `function_call_result` branches, which do flush. So when a turn that ran a server-side tool search is followed by a new user message, the pending assistant turn is emitted last (by the end-of-loop flush) and lands after the user message. The converted prompt then ends on an assistant message, and Anthropic rejects the request as an unintended prefill ("assistant message prefill is not supported").

This routes every turn-boundary branch through a shared `flushCurrentAssistantMessage()` helper, so `user` and `system` now flush the pending assistant first, matching the other branches. The `tool_search_output` folding path is intentionally unchanged — flushing there would break the deliberate same-turn grouping/reordering of the server tool-use, its result, and any client tool call in the same turn. Adds a regression test and a changeset.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Server tool-search turn, then a new user message | Prompt ends on the assistant (server tool-use + result) message → Anthropic 400 "assistant message prefill" | Assistant turn ordered before the user message; prompt ends on the user message → accepted |
| Server tool-search followed by assistant text (same turn) | Correct (the `assistant` branch already flushed) | Unchanged |
| Client tool call in the same turn as the server search | Folded/reordered into one assistant message | Unchanged |
