### PR TITLE
fix(core): resolve strict schema local references

### DIFF
--- a/.changeset/sharp-ravens-resolve.md
+++ b/.changeset/sharp-ravens-resolve.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: strip strict optional nulls through local JSON Schema references

--- a/packages/agents-core/src/utils/strictToolSchema.ts
+++ b/packages/agents-core/src/utils/strictToolSchema.ts
@@ -102,7 +102,7 @@ function isSchemaNullable(schema: Record<string, unknown>): boolean {
     return true;
   }
 
-  for (const key of ['anyOf', 'oneOf', 'allOf']) {
+  for (const key of ['anyOf', 'oneOf']) {
     const entries = schema[key];
     if (
       Array.isArray(entries) &&
@@ -117,6 +117,20 @@ function isSchemaNullable(schema: Record<string, unknown>): boolean {
     }
   }
 
+  const allOf = schema.allOf;
+  if (
+    Array.isArray(allOf) &&
+    allOf.length > 0 &&
+    allOf.every(
+      (entry) =>
+        typeof entry === 'object' &&
+        entry !== null &&
+        isSchemaNullable(entry as Record<string, unknown>),
+    )
+  ) {
+    return true;
+  }
+
   return false;
 }
 
@@ -125,45 +139,73 @@ export function stripStrictNullsForJsonSchema(
   value: unknown,
   optionalProperty: boolean = false,
 ): unknown {
+  return stripStrictNullsForJsonSchemaEntry(
+    schema,
+    value,
+    optionalProperty,
+    schema,
+  );
+}
+
+function stripStrictNullsForJsonSchemaEntry(
+  schema: unknown,
+  value: unknown,
+  optionalProperty: boolean,
+  rootSchema: unknown,
+): unknown {
   if (value === undefined) {
     return undefined;
   }
   if (value === null) {
-    if (optionalProperty && !jsonSchemaAllowsNull(schema)) {
+    if (optionalProperty && !jsonSchemaAllowsNull(schema, rootSchema)) {
       return undefined;
     }
     return value;
   }
 
+  const resolvedSchema = resolveLocalJsonSchema(schema, rootSchema);
+
   if (Array.isArray(value)) {
-    const schemaRecord = isRecord(schema) ? schema : undefined;
+    const schemaRecord = isRecord(resolvedSchema) ? resolvedSchema : undefined;
     const items = schemaRecord?.items;
     if (Array.isArray(items)) {
       return value.map((entry, index) =>
-        stripStrictNullsForJsonSchema(items[index], entry),
+        stripStrictNullsForJsonSchemaEntry(
+          items[index],
+          entry,
+          false,
+          rootSchema,
+        ),
       );
     }
     if (items && typeof items === 'object') {
-      return value.map((entry) => stripStrictNullsForJsonSchema(items, entry));
+      return value.map((entry) =>
+        stripStrictNullsForJsonSchemaEntry(items, entry, false, rootSchema),
+      );
     }
     return value;
   }
 
-  if (!isRecord(value) || !isJsonSchemaObject(schema)) {
+  if (!isRecord(value) || !isJsonSchemaObject(resolvedSchema)) {
     return value;
   }
 
-  const properties = isRecord(schema.properties) ? schema.properties : {};
+  const properties = isRecord(resolvedSchema.properties)
+    ? resolvedSchema.properties
+    : {};
   const required = new Set(
-    Array.isArray(schema.required) ? schema.required.map(String) : [],
+    Array.isArray(resolvedSchema.required)
+      ? resolvedSchema.required.map(String)
+      : [],
   );
   const normalized: Record<string, unknown> = { ...value };
 
   for (const [key, propertySchema] of Object.entries(properties)) {
-    const nextValue = stripStrictNullsForJsonSchema(
+    const nextValue = stripStrictNullsForJsonSchemaEntry(
       propertySchema,
       normalized[key],
       !required.has(key),
+      rootSchema,
     );
     if (typeof nextValue === 'undefined') {
       delete normalized[key];
@@ -192,8 +234,68 @@ function isJsonSchemaObject(schema: unknown): schema is Record<
   );
 }
 
-function jsonSchemaAllowsNull(schema: unknown): boolean {
-  return isRecord(schema) ? isSchemaNullable(schema) : false;
+function jsonSchemaAllowsNull(schema: unknown, rootSchema: unknown): boolean {
+  if (!isRecord(schema)) {
+    return false;
+  }
+  if (isSchemaNullable(schema)) {
+    return true;
+  }
+
+  const resolvedSchema = resolveLocalJsonSchema(schema, rootSchema);
+  return (
+    resolvedSchema !== schema &&
+    isRecord(resolvedSchema) &&
+    isSchemaNullable(resolvedSchema)
+  );
+}
+
+function resolveLocalJsonSchema(schema: unknown, rootSchema: unknown): unknown {
+  let current = schema;
+  const visitedReferences = new Set<string>();
+
+  while (isRecord(current) && typeof current.$ref === 'string') {
+    const reference = current.$ref;
+    if (
+      (reference !== '#' && !reference.startsWith('#/')) ||
+      visitedReferences.has(reference)
+    ) {
+      return schema;
+    }
+    visitedReferences.add(reference);
+
+    const resolved =
+      reference === '#'
+        ? rootSchema
+        : resolveJsonPointer(rootSchema, reference);
+    if (typeof resolved === 'undefined') {
+      return schema;
+    }
+    current = resolved;
+  }
+
+  return current;
+}
+
+function resolveJsonPointer(root: unknown, reference: string): unknown {
+  let current = root;
+
+  for (const rawToken of reference.slice(2).split('/')) {
+    if (/~(?:[^01]|$)/.test(rawToken)) {
+      return undefined;
+    }
+    const token = rawToken.replace(/~1/g, '/').replace(/~0/g, '~');
+    if (
+      typeof current !== 'object' ||
+      current === null ||
+      !Object.prototype.hasOwnProperty.call(current, token)
+    ) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[token];
+  }
+
+  return current;
 }
 
 export function stripStrictNullsForZodSchema(

--- a/packages/agents-core/src/utils/strictToolSchema.ts
+++ b/packages/agents-core/src/utils/strictToolSchema.ts
@@ -125,13 +125,33 @@ function isSchemaNullable(schema: Record<string, unknown>): boolean {
       (entry) =>
         typeof entry === 'object' &&
         entry !== null &&
-        isSchemaNullable(entry as Record<string, unknown>),
+        allowsNull(entry as Record<string, unknown>),
     )
   ) {
     return true;
   }
 
   return false;
+}
+
+// Keywords that can rule null out. A branch carrying none of them (`{}`, or one
+// that only adds a description/title) constrains nothing, so it still admits null.
+const TYPE_CONSTRAINING_KEYWORDS = [
+  'type',
+  'enum',
+  'const',
+  '$ref',
+  'anyOf',
+  'oneOf',
+  'allOf',
+  'not',
+];
+
+function allowsNull(schema: Record<string, unknown>): boolean {
+  if (isSchemaNullable(schema)) {
+    return true;
+  }
+  return !TYPE_CONSTRAINING_KEYWORDS.some((keyword) => keyword in schema);
 }
 
 export function stripStrictNullsForJsonSchema(

--- a/packages/agents-core/test/tool.test.ts
+++ b/packages/agents-core/test/tool.test.ts
@@ -983,6 +983,42 @@ describe('tool.invoke', () => {
     expect(res).toBe('hi there');
   });
 
+  it('strips strict nulls through local JSON Schema references', async () => {
+    const execute = vi.fn(() => 'ok');
+    const t = tool({
+      name: 'local_ref',
+      description: 'Uses a local JSON Schema reference.',
+      parameters: {
+        type: 'object',
+        properties: {
+          payload: { $ref: '#/$defs/payload' },
+        },
+        required: ['payload'],
+        $defs: {
+          payload: {
+            type: 'object',
+            properties: {
+              note: { type: 'string' },
+            },
+            required: [],
+          },
+        },
+      } as any,
+      execute,
+    });
+
+    await t.invoke(
+      new RunContext(),
+      JSON.stringify({ payload: { note: null } }),
+    );
+
+    expect(execute).toHaveBeenCalledWith(
+      { payload: {} },
+      expect.any(RunContext),
+      undefined,
+    );
+  });
+
   it('uses errorFunction on parse error', async () => {
     const t = tool({
       name: 'fail',

--- a/packages/agents-core/test/utils/strictToolSchema.test.ts
+++ b/packages/agents-core/test/utils/strictToolSchema.test.ts
@@ -210,6 +210,149 @@ describe('utils/strictToolSchema', () => {
     });
   });
 
+  it('strips strict nulls through $defs references', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        payload: { $ref: '#/$defs/payload' },
+      },
+      required: ['payload'],
+      $defs: {
+        payload: {
+          type: 'object',
+          properties: {
+            note: { type: 'string' },
+          },
+          required: [],
+        },
+      },
+    };
+
+    expect(
+      stripStrictNullsForJsonSchema(schema, {
+        payload: { note: null },
+      }),
+    ).toEqual({ payload: {} });
+  });
+
+  it('strips strict nulls through legacy definitions references', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        payload: { $ref: '#/definitions/payload' },
+      },
+      required: ['payload'],
+      definitions: {
+        payload: {
+          type: 'object',
+          properties: {
+            note: { type: 'string' },
+          },
+          required: [],
+        },
+      },
+    };
+
+    expect(
+      stripStrictNullsForJsonSchema(schema, {
+        payload: { note: null },
+      }),
+    ).toEqual({ payload: {} });
+  });
+
+  it('decodes RFC 6901 escaped reference tokens', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        payload: { $ref: '#/$defs/path~1with~0tilde' },
+      },
+      required: ['payload'],
+      $defs: {
+        'path/with~tilde': {
+          type: 'object',
+          properties: {
+            note: { type: 'string' },
+          },
+          required: [],
+        },
+      },
+    };
+
+    expect(
+      stripStrictNullsForJsonSchema(schema, {
+        payload: { note: null },
+      }),
+    ).toEqual({ payload: {} });
+  });
+
+  it('stops resolving cyclic references', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        payload: { $ref: '#/$defs/first' },
+      },
+      required: ['payload'],
+      $defs: {
+        first: { $ref: '#/$defs/second' },
+        second: { $ref: '#/$defs/first' },
+      },
+    };
+    const value = { payload: { note: null } };
+
+    expect(stripStrictNullsForJsonSchema(schema, value)).toEqual(value);
+  });
+
+  it('strips strict nulls through recursive root references', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        note: { type: 'string' },
+        child: { $ref: '#' },
+      },
+      required: [],
+    };
+
+    expect(
+      stripStrictNullsForJsonSchema(schema, {
+        note: null,
+        child: { note: null },
+      }),
+    ).toEqual({ child: {} });
+  });
+
+  it('strips nulls unless every referenced allOf branch allows null', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        value: { $ref: '#/$defs/value' },
+      },
+      required: [],
+      $defs: {
+        value: {
+          allOf: [{ type: ['string', 'null'] }, { type: 'string' }],
+        },
+      },
+    };
+
+    expect(stripStrictNullsForJsonSchema(schema, { value: null })).toEqual({});
+  });
+
+  it.each([
+    ['unresolved', '#/$defs/missing'],
+    ['external', 'https://example.com/schema.json#/$defs/payload'],
+  ])('leaves values behind %s references unchanged', (_name, $ref) => {
+    const schema = {
+      type: 'object',
+      properties: {
+        payload: { $ref },
+      },
+      required: ['payload'],
+    };
+    const value = { payload: { note: null } };
+
+    expect(stripStrictNullsForJsonSchema(schema, value)).toEqual(value);
+  });
+
   it('strips strict nulls from optional Zod object, union, array, tuple, and record fields', () => {
     const schema = z.object({
       direct: z.string().optional(),

--- a/packages/agents-core/test/utils/strictToolSchema.test.ts
+++ b/packages/agents-core/test/utils/strictToolSchema.test.ts
@@ -338,6 +338,50 @@ describe('utils/strictToolSchema', () => {
   });
 
   it.each([
+    ['annotation-only', { description: 'a note' }],
+    ['empty', {}],
+    ['title-only', { title: 'Value' }],
+    ['nested allOf', { allOf: [{ description: 'a note' }] }],
+  ])('keeps null across a %s allOf branch', (_name, sibling) => {
+    const schema = {
+      type: 'object',
+      properties: {
+        value: { $ref: '#/$defs/value' },
+      },
+      required: [],
+      $defs: {
+        value: {
+          allOf: [{ type: ['string', 'null'] }, sibling],
+        },
+      },
+    };
+
+    expect(stripStrictNullsForJsonSchema(schema, { value: null })).toEqual({
+      value: null,
+    });
+  });
+
+  it('still strips null when an allOf branch rejects it', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        value: { $ref: '#/$defs/value' },
+      },
+      required: [],
+      $defs: {
+        value: {
+          allOf: [
+            { type: ['string', 'null'] },
+            { description: 'a note', type: 'string' },
+          ],
+        },
+      },
+    };
+
+    expect(stripStrictNullsForJsonSchema(schema, { value: null })).toEqual({});
+  });
+
+  it.each([
     ['unresolved', '#/$defs/missing'],
     ['external', 'https://example.com/schema.json#/$defs/payload'],
   ])('leaves values behind %s references unchanged', (_name, $ref) => {


### PR DESCRIPTION
### Summary

Strict tool argument cleanup stopped at local JSON Schema `$ref` entries, so optional values converted to `null` inside referenced object schemas could reach tool handlers instead of being removed.

This change resolves bounded same-document pointers through `$defs`, legacy `definitions`, and recursive root (`#`) references while decoding RFC 6901 escaped tokens. Cyclic, unresolved, and external references use the existing safe fallback and leave values unchanged. It also corrects `allOf` nullability so an `allOf` schema is nullable only when every branch permits `null`, addressing the Codex review finding.

### Test plan

- `CI=1 NODE_ENV=test ./node_modules/.bin/vitest run packages/agents-core/test/utils/strictToolSchema.test.ts packages/agents-core/test/tool.test.ts` (97 passed)
- `bash .agents/skills/code-change-verification/scripts/run.sh` (passed the locked install, build, workspace build checks, declaration checks, lint, formatting, and test phases)
- `pnpm changeset:validate-prompt` (`ok=true`, patch, no warnings or errors)
- `codex review --uncommitted` (completed; both findings were addressed and verification was rerun)

### Issue number

No issue is associated with this change.

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [ ] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration` [(see details)](https://github.com/openai/openai-agents-js/tree/main/integration-tests)
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
- [ ] I've added a changeset using `pnpm changeset` to indicate my changes
