### PR TITLE
feat(core): subscribe to MCP server logging events

### DIFF
--- a/.changeset/mcp-server-logging.md
+++ b/.changeset/mcp-server-logging.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+feat(core): subscribe to MCP server logging notifications via `serverLogging`

--- a/docs/src/content/docs/guides/mcp.mdx
+++ b/docs/src/content/docs/guides/mcp.mdx
@@ -316,7 +316,7 @@ const mcpServer = new MCPServerStdio({
 
 The `handler` receives each notification's `level`, optional `logger`, `data` payload, and any protocol `meta`. When `level` is omitted the server decides which messages to emit. Requesting a `level` is best-effort: if the server rejects it the connection stays up and a warning is logged.
 
-Only enable `serverLogging` for servers you trust. A server controls how often it logs and what `data`/`meta` it sends, so treat those payloads as untrusted input. Keep your `handler` from throwing: exceptions raised inside it are swallowed by the MCP client and your logs will silently stop flowing.
+Only enable `serverLogging` for servers you trust. A server controls how often it logs and what `data`/`meta` it sends, so treat those payloads as untrusted input. If your `handler` throws, the error is caught and logged as a warning rather than interrupting the run, but the offending notification is dropped, so prefer a handler that does not throw.
 
 ### Tool filtering
 

--- a/docs/src/content/docs/guides/mcp.mdx
+++ b/docs/src/content/docs/guides/mcp.mdx
@@ -295,6 +295,29 @@ With this setting, a `search` tool from a `docs` server is exposed to the model 
 
 Generated names are ASCII-safe, stay within the function-tool name limit, and avoid local function tool names and enabled handoff names on the same agent. The setting only affects local Streamable HTTP and stdio MCP tools; hosted MCP tools keep their hosted server labels and tool metadata.
 
+### Server logging
+
+Stdio, SSE, and Streamable HTTP MCP servers can emit `notifications/message` logging events while a tool runs. This is useful for surfacing progress from long-running tools instead of waiting silently. Subscribe by passing `serverLogging` to the server:
+
+```ts
+const mcpServer = new MCPServerStdio({
+  name: 'Logging Demo Server',
+  fullCommand: 'pnpm tsx logging-server.ts',
+  serverLogging: {
+    // Optional: request a minimum severity from the server. Only sent when the
+    // server advertises the `logging` capability.
+    level: 'info',
+    handler: ({ level, logger, data }) => {
+      console.log(`[mcp:${level}] ${logger ?? 'server'}`, data);
+    },
+  },
+});
+```
+
+The `handler` receives each notification's `level`, optional `logger`, `data` payload, and any protocol `meta`. When `level` is omitted the server decides which messages to emit. Requesting a `level` is best-effort: if the server rejects it the connection stays up and a warning is logged.
+
+Only enable `serverLogging` for servers you trust. A server controls how often it logs and what `data`/`meta` it sends, so treat those payloads as untrusted input. Keep your `handler` from throwing: exceptions raised inside it are swallowed by the MCP client and your logs will silently stop flowing.
+
 ### Tool filtering
 
 You can restrict which tools are exposed from each server by passing either a static filter via `createMCPToolStaticFilter` or a custom function. Here’s a combined example showing both approaches:

--- a/examples/mcp/logging-example.ts
+++ b/examples/mcp/logging-example.ts
@@ -1,0 +1,42 @@
+import { Agent, run, MCPServerStdio, withTrace } from '@openai/agents';
+import * as path from 'node:path';
+
+async function main() {
+  const serverPath = path.join(__dirname, 'logging-server.ts');
+  const mcpServer = new MCPServerStdio({
+    name: 'Logging Demo Server',
+    command: 'pnpm',
+    args: ['tsx', serverPath],
+    // Subscribe to logs the server emits while tools run. `level` requests a
+    // minimum severity from the server; `handler` receives each notification.
+    serverLogging: {
+      level: 'info',
+      handler: ({ level, logger, data }) => {
+        const source = logger ? `${logger}` : 'server';
+        console.log(`[mcp:${level}] (${source}) ${JSON.stringify(data)}`);
+      },
+    },
+  });
+
+  await mcpServer.connect();
+
+  try {
+    await withTrace('MCP Server Logging Example', async () => {
+      const agent = new Agent({
+        name: 'MCP Assistant',
+        instructions: 'Use the analyze tool to answer the user.',
+        mcpServers: [mcpServer],
+        modelSettings: { toolChoice: 'required' },
+      });
+      const result = await run(agent, 'Run an analysis and summarize it.');
+      console.log(`\n${result.finalOutput}`);
+    });
+  } finally {
+    await mcpServer.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/mcp/logging-server.ts
+++ b/examples/mcp/logging-server.ts
@@ -1,0 +1,35 @@
+// A minimal stdio MCP server that emits `notifications/message` logging events
+// while a long-running tool executes. Used by `logging-example.ts` to
+// demonstrate subscribing to server logs from an Agent.
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+async function main() {
+  const server = new McpServer(
+    { name: 'logging-demo-server', version: '1.0.0' },
+    { capabilities: { logging: {} } },
+  );
+
+  server.tool(
+    'analyze',
+    'Pretend to analyze something, emitting progress logs along the way.',
+    async () => {
+      const steps = ['loading data', 'crunching numbers', 'finalizing report'];
+      for (const [index, step] of steps.entries()) {
+        await server.server.sendLoggingMessage({
+          level: 'info',
+          logger: 'analyze',
+          data: `step ${index + 1}/${steps.length}: ${step}`,
+        });
+      }
+      return { content: [{ type: 'text', text: 'Analysis complete.' }] };
+    },
+  );
+
+  await server.connect(new StdioServerTransport());
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/mcp/package.json
+++ b/examples/mcp/package.json
@@ -15,6 +15,7 @@
     "start:hosted-mcp-simple": "tsx hosted-mcp-simple.ts",
     "start:tool-filter": "tsx tool-filter-example.ts",
     "start:sse": "tsx sse-example.ts",
+    "start:logging": "tsx logging-example.ts",
     "start:get-all-tools": "tsx get-all-mcp-tools-example.ts",
     "start:mcp-servers": "tsx mcp-servers-example.ts"
   }

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -127,6 +127,10 @@ export {
   GetAllMcpToolsOptions,
   MCPToolCacheKeyGenerator,
   MCPToolErrorFunction,
+  MCPServerLoggingLevel,
+  MCPServerLoggingMessage,
+  MCPServerLoggingHandler,
+  MCPServerLoggingOptions,
 } from './mcp';
 export {
   MCPServers,

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -59,6 +59,57 @@ export type MCPToolErrorFunction = (args: {
   error: Error | unknown;
 }) => Promise<string> | string;
 
+/**
+ * Severity levels emitted by MCP servers via `notifications/message`, matching
+ * the levels defined by the MCP specification. Declared structurally so that
+ * consuming `@openai/agents-core` never forces resolution of the optional
+ * `@modelcontextprotocol/sdk` package.
+ */
+export type MCPServerLoggingLevel =
+  | 'debug'
+  | 'info'
+  | 'notice'
+  | 'warning'
+  | 'error'
+  | 'critical'
+  | 'alert'
+  | 'emergency';
+
+/**
+ * A single logging notification emitted by an MCP server.
+ */
+export interface MCPServerLoggingMessage {
+  /** Severity of the log message. */
+  level: MCPServerLoggingLevel;
+  /** Optional name of the logger that produced the message. */
+  logger?: string;
+  /** Arbitrary JSON-serializable payload attached to the message. */
+  data: unknown;
+  /** Optional protocol-level metadata (`_meta`) attached to the notification. */
+  meta?: Record<string, unknown>;
+}
+
+/**
+ * Handler invoked for every MCP `notifications/message` logging event.
+ */
+export type MCPServerLoggingHandler = (
+  message: MCPServerLoggingMessage,
+) => void | Promise<void>;
+
+/**
+ * Options for subscribing to logging notifications emitted by an MCP server.
+ */
+export interface MCPServerLoggingOptions {
+  /**
+   * Minimum severity to request from the server via `logging/setLevel`. The
+   * request is only sent when the connected server advertises the `logging`
+   * capability; when omitted the server decides which messages to emit.
+   */
+  level?: MCPServerLoggingLevel;
+  /** Invoked for each logging notification the server sends. */
+  handler: MCPServerLoggingHandler;
+}
+
 const MCP_FUNCTION_TOOL_NAME_MAX_LENGTH = 64;
 const MCP_FUNCTION_TOOL_HASH_LENGTH = 8;
 
@@ -1194,6 +1245,11 @@ export interface BaseMCPServerStdioOptions {
    * Set to null to rethrow errors instead of converting them.
    */
   errorFunction?: MCPToolErrorFunction | null;
+  /**
+   * Subscribe to logging notifications (`notifications/message`) emitted by the
+   * MCP server. Useful for surfacing progress from long-running tools.
+   */
+  serverLogging?: MCPServerLoggingOptions;
   timeout?: number;
 }
 export interface DefaultMCPServerStdioOptions extends BaseMCPServerStdioOptions {
@@ -1231,6 +1287,11 @@ export interface MCPServerStreamableHttpOptions {
    * Set to null to rethrow errors instead of converting them.
    */
   errorFunction?: MCPToolErrorFunction | null;
+  /**
+   * Subscribe to logging notifications (`notifications/message`) emitted by the
+   * MCP server. Useful for surfacing progress from long-running tools.
+   */
+  serverLogging?: MCPServerLoggingOptions;
   timeout?: number;
 
   // ----------------------------------------------------
@@ -1273,6 +1334,11 @@ export interface MCPServerSSEOptions {
    * Set to null to rethrow errors instead of converting them.
    */
   errorFunction?: MCPToolErrorFunction | null;
+  /**
+   * Subscribe to logging notifications (`notifications/message`) emitted by the
+   * MCP server. Useful for surfacing progress from long-running tools.
+   */
+  serverLogging?: MCPServerLoggingOptions;
   timeout?: number;
 
   // ----------------------------------------------------

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -90,12 +90,19 @@ async function registerMCPServerLoggingHandler(
     LoggingMessageNotificationSchema,
     async (notification) => {
       const { level, logger: loggerName, data, _meta } = notification.params;
-      await serverLogging.handler({
-        level,
-        logger: loggerName,
-        data,
-        meta: _meta,
-      });
+      // Isolate the user handler: a throwing/rejecting handler must not escape
+      // this callback, since nothing awaits the notification and it would
+      // otherwise surface as an unhandled rejection.
+      try {
+        await serverLogging.handler({
+          level,
+          logger: loggerName,
+          data,
+          meta: _meta,
+        });
+      } catch (error) {
+        logger.warn('MCP server logging handler threw; ignoring:', error);
+      }
     },
   );
 }

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -20,6 +20,7 @@ import type {
   MCPListResourcesResult,
   MCPListResourceTemplatesResult,
   MCPReadResourceResult,
+  MCPServerLoggingOptions,
   MCPServerStdioOptions,
   MCPServerStreamableHttpOptions,
   MCPServerSSEOptions,
@@ -68,6 +69,68 @@ function buildRequestOptions(
       : { timeout: clientSessionTimeoutSeconds * 1000 };
   const mergedOptions = { ...(baseOptions ?? {}), ...(overrides ?? {}) };
   return Object.keys(mergedOptions).length === 0 ? undefined : mergedOptions;
+}
+
+/**
+ * Subscribe to the MCP server's `notifications/message` logging events.
+ *
+ * Registered before `connect()` so that log notifications emitted during the
+ * initialize handshake are not dropped.
+ */
+async function registerMCPServerLoggingHandler(
+  client: Client,
+  serverLogging: MCPServerLoggingOptions | undefined,
+): Promise<void> {
+  if (!serverLogging) {
+    return;
+  }
+  const { LoggingMessageNotificationSchema } =
+    await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
+  client.setNotificationHandler(
+    LoggingMessageNotificationSchema,
+    async (notification) => {
+      const { level, logger: loggerName, data, _meta } = notification.params;
+      await serverLogging.handler({
+        level,
+        logger: loggerName,
+        data,
+        meta: _meta,
+      });
+    },
+  );
+}
+
+/**
+ * Request a minimum logging level from the MCP server via `logging/setLevel`.
+ *
+ * `logging/setLevel` requires the server to advertise the `logging` capability,
+ * which is only known after the initialize handshake. When a session is reused
+ * without initializing (for example an explicit streamable HTTP `sessionId`)
+ * the capability is unknown, so the request is skipped rather than allowed to
+ * reject and tear down the connection. Requesting the level is a best-effort
+ * convenience: if the server rejects it, we log a warning and stay connected
+ * instead of failing the whole connection over an optional feature.
+ */
+async function applyMCPServerLoggingLevel(
+  client: Client,
+  serverLogging: MCPServerLoggingOptions | undefined,
+  requestOptions?: RequestOptions,
+): Promise<void> {
+  if (!serverLogging?.level) {
+    return;
+  }
+  const capabilities = client.getServerCapabilities?.();
+  if (!capabilities?.logging) {
+    return;
+  }
+  try {
+    await client.setLoggingLevel(serverLogging.level, requestOptions);
+  } catch (error) {
+    logger.warn(
+      'Failed to set MCP server logging level; continuing without it:',
+      error,
+    );
+  }
 }
 
 type MaybeSessionTransport = Transport & {
@@ -239,7 +302,16 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
       const requestOptions = buildRequestOptions(
         this.clientSessionTimeoutSeconds,
       );
+      await registerMCPServerLoggingHandler(
+        this.session,
+        this.params.serverLogging,
+      );
       await this.session.connect(this.transport, requestOptions);
+      await applyMCPServerLoggingLevel(
+        this.session,
+        this.params.serverLogging,
+        requestOptions,
+      );
       this.serverInitializeResult = {
         serverInfo: { name: this._name, version: '1.0.0' },
       } as InitializeResult;
@@ -450,7 +522,16 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
       const requestOptions = buildRequestOptions(
         this.clientSessionTimeoutSeconds,
       );
+      await registerMCPServerLoggingHandler(
+        this.session,
+        this.params.serverLogging,
+      );
       await this.session.connect(this.transport, requestOptions);
+      await applyMCPServerLoggingLevel(
+        this.session,
+        this.params.serverLogging,
+        requestOptions,
+      );
       this.serverInitializeResult = {
         serverInfo: { name: this._name, version: '1.0.0' },
       } as InitializeResult;
@@ -730,7 +811,13 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
       const requestOptions = buildRequestOptions(
         this.clientSessionTimeoutSeconds,
       );
+      await registerMCPServerLoggingHandler(client, this.params.serverLogging);
       await client.connect(transport, requestOptions);
+      await applyMCPServerLoggingLevel(
+        client,
+        this.params.serverLogging,
+        requestOptions,
+      );
       return { client, transport };
     } catch (error) {
       await this.closeStreamableHttpClient(
@@ -980,12 +1067,21 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
       const requestOptions = buildRequestOptions(
         this.clientSessionTimeoutSeconds,
       );
+      await registerMCPServerLoggingHandler(
+        args.client,
+        this.params.serverLogging,
+      );
       await args.client.connect(transport, requestOptions);
       if (args.sessionId !== undefined) {
         // Reconnecting with an existing session skips initialize(), so resend
         // initialized to reopen the shared SSE stream for async responses.
         await this.reopenSharedStreamableHttpSession(args.client);
       }
+      await applyMCPServerLoggingLevel(
+        args.client,
+        this.params.serverLogging,
+        requestOptions,
+      );
       return { client: args.client, transport };
     } catch (error) {
       await this.closeStreamableHttpClient(

--- a/packages/agents-core/test/shims/mcp-server/node.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/node.test.ts
@@ -15,6 +15,7 @@ import {
 import { TransportSendOptions } from '@modelcontextprotocol/sdk/shared/transport';
 import { JSONRPCMessage } from '@modelcontextprotocol/sdk/types';
 import { DEFAULT_REQUEST_TIMEOUT_MSEC } from '@modelcontextprotocol/sdk/shared/protocol';
+import logger from '../../../src/logger';
 
 let lastConnectOptions: any;
 let lastListToolsOptions: any;
@@ -26,6 +27,13 @@ let lastCallToolOptions: any;
 let lastCallToolParams: any;
 let lastReadResourceOptions: any;
 let lastReadResourceParams: any;
+let lastNotificationSchema: any;
+let lastNotificationHandler: any;
+let lastSetLoggingLevel: any;
+let lastSetLoggingLevelOptions: any;
+let loggingOperationOrder: string[];
+let mockServerCapabilities: any;
+let mockSetLoggingLevelError: any;
 
 beforeEach(() => {
   lastConnectOptions = undefined;
@@ -38,6 +46,16 @@ beforeEach(() => {
   lastCallToolParams = undefined;
   lastReadResourceOptions = undefined;
   lastReadResourceParams = undefined;
+  lastNotificationSchema = undefined;
+  lastNotificationHandler = undefined;
+  lastSetLoggingLevel = undefined;
+  lastSetLoggingLevelOptions = undefined;
+  loggingOperationOrder = [];
+  // Default to a server that advertises the `logging` capability so that
+  // `logging/setLevel` is exercised. Individual tests override this to model
+  // sessions where capabilities were never discovered.
+  mockServerCapabilities = { logging: {} };
+  mockSetLoggingLevelError = undefined;
 });
 
 describe('NodeMCPServerStdio', () => {
@@ -149,6 +167,87 @@ describe('NodeMCPServerStdio', () => {
     await server.close();
   });
 
+  test('should subscribe to MCP server logging messages', async () => {
+    const handler = vi.fn();
+    const server = new NodeMCPServerStdio({
+      name: 'logging-test',
+      fullCommand: 'test',
+      clientSessionTimeoutSeconds: 11,
+      serverLogging: {
+        level: 'info',
+        handler,
+      },
+    });
+
+    await server.connect();
+    await lastNotificationHandler({
+      method: 'notifications/message',
+      params: {
+        level: 'info',
+        logger: 'mock-server',
+        data: { progress: 'halfway' },
+        _meta: { requestId: 'req-123' },
+      },
+    });
+
+    // Handler must be registered before connect() so notifications emitted
+    // during the initialize handshake are not dropped, and setLoggingLevel is
+    // only sent afterwards.
+    expect(loggingOperationOrder).toEqual([
+      'setNotificationHandler',
+      'connect',
+      'setLoggingLevel',
+    ]);
+    expect(lastNotificationSchema?.shape?.method?.value).toBe(
+      'notifications/message',
+    );
+    expect(lastSetLoggingLevel).toBe('info');
+    expect(lastSetLoggingLevelOptions?.timeout).toBe(11000);
+    expect(handler).toHaveBeenCalledWith({
+      level: 'info',
+      logger: 'mock-server',
+      data: { progress: 'halfway' },
+      meta: { requestId: 'req-123' },
+    });
+
+    await server.close();
+  });
+
+  test('should stay connected when logging/setLevel fails', async () => {
+    // Requesting a level is best-effort: a server that advertises the logging
+    // capability but rejects logging/setLevel must not fail the connection.
+    mockSetLoggingLevelError = new Error('setLevel not supported');
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const handler = vi.fn();
+    const server = new NodeMCPServerStdio({
+      name: 'logging-failure-test',
+      fullCommand: 'test',
+      serverLogging: {
+        level: 'info',
+        handler,
+      },
+    });
+
+    await expect(server.connect()).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+    // Server remains usable and notifications remain subscribed.
+    const tools = await server.listTools();
+    expect(tools).toHaveLength(1);
+    await lastNotificationHandler({
+      method: 'notifications/message',
+      params: { level: 'info', data: 'still flowing' },
+    });
+    expect(handler).toHaveBeenCalledWith({
+      level: 'info',
+      logger: undefined,
+      data: 'still flowing',
+      meta: undefined,
+    });
+
+    warnSpy.mockRestore();
+    await server.close();
+  });
+
   test('should forward resource requests to session methods', async () => {
     const server = new NodeMCPServerStdio({
       name: 'resource-test',
@@ -228,8 +327,26 @@ class MockClient {
     this.options = options;
   }
   connect(_transport: any, options?: any): Promise<void> {
+    loggingOperationOrder.push('connect');
     lastConnectOptions = options;
     return Promise.resolve();
+  }
+  setNotificationHandler(schema: any, handler: any): void {
+    loggingOperationOrder.push('setNotificationHandler');
+    lastNotificationSchema = schema;
+    lastNotificationHandler = handler;
+  }
+  setLoggingLevel(level: any, options?: any): Promise<any> {
+    loggingOperationOrder.push('setLoggingLevel');
+    lastSetLoggingLevel = level;
+    lastSetLoggingLevelOptions = options;
+    if (mockSetLoggingLevelError) {
+      return Promise.reject(mockSetLoggingLevelError);
+    }
+    return Promise.resolve({});
+  }
+  getServerCapabilities(): any {
+    return mockServerCapabilities;
   }
   listTools(_params?: any, options?: any): Promise<any> {
     lastListToolsOptions = options;
@@ -433,6 +550,42 @@ describe('NodeMCPServerSSE', () => {
     await server.close();
   });
 
+  test('should subscribe to MCP server logging without changing level', async () => {
+    const handler = vi.fn();
+    const server = new NodeMCPServerSSE({
+      url: 'https://example.com/sse',
+      name: 'test-sse-logging',
+      serverLogging: {
+        handler,
+      },
+    });
+
+    await server.connect();
+    await lastNotificationHandler({
+      method: 'notifications/message',
+      params: {
+        level: 'debug',
+        data: 'working',
+      },
+    });
+
+    // Without an explicit level the client subscribes to notifications but must
+    // not send logging/setLevel.
+    expect(loggingOperationOrder).toEqual([
+      'setNotificationHandler',
+      'connect',
+    ]);
+    expect(lastSetLoggingLevel).toBeUndefined();
+    expect(handler).toHaveBeenCalledWith({
+      level: 'debug',
+      logger: undefined,
+      data: 'working',
+      meta: undefined,
+    });
+
+    await server.close();
+  });
+
   test('should forward resource requests to session methods', async () => {
     const server = new NodeMCPServerSSE({
       url: 'https://example.com/sse',
@@ -608,6 +761,93 @@ describe('NodeMCPServerStreamableHttp', () => {
     await server.close();
 
     expect(server.sessionId).toBeUndefined();
+  });
+
+  test('should subscribe to streamable HTTP MCP server logging', async () => {
+    const handler = vi.fn();
+    const server = new NodeMCPServerStreamableHttp({
+      url: 'https://example.com/stream',
+      name: 'test-stream-logging',
+      clientSessionTimeoutSeconds: 3,
+      serverLogging: {
+        level: 'warning',
+        handler,
+      },
+    });
+
+    await server.connect();
+    await lastNotificationHandler({
+      method: 'notifications/message',
+      params: {
+        level: 'warning',
+        logger: 'stream-server',
+        data: ['retrying'],
+      },
+    });
+
+    expect(loggingOperationOrder).toEqual([
+      'setNotificationHandler',
+      'connect',
+      'setLoggingLevel',
+    ]);
+    expect(lastSetLoggingLevel).toBe('warning');
+    expect(lastSetLoggingLevelOptions?.timeout).toBe(3000);
+    expect(handler).toHaveBeenCalledWith({
+      level: 'warning',
+      logger: 'stream-server',
+      data: ['retrying'],
+      meta: undefined,
+    });
+
+    await server.close();
+  });
+
+  test('should not send logging/setLevel when reusing an explicit session', async () => {
+    // Regression: reconnecting to an explicit `sessionId` skips the initialize
+    // handshake, so server capabilities are unknown. Sending logging/setLevel
+    // in that state rejects and breaks the connection, so it must be skipped
+    // while notifications remain subscribed.
+    mockServerCapabilities = undefined;
+    const handler = vi.fn();
+    const server = new NodeMCPServerStreamableHttp({
+      url: 'https://example.com/stream',
+      name: 'test-stream-session-logging',
+      sessionId: 'existing-session',
+      serverLogging: {
+        level: 'info',
+        handler,
+      },
+    });
+
+    await server.connect();
+    await lastNotificationHandler({
+      method: 'notifications/message',
+      params: {
+        level: 'info',
+        data: 'still logging',
+      },
+    });
+
+    // The connection was made against the explicit session, which is what
+    // causes initialize (and therefore capability discovery) to be skipped.
+    expect(
+      MockStreamableHTTPClientTransport.instances.some(
+        (instance) => instance.sessionId === 'existing-session',
+      ),
+    ).toBe(true);
+    expect(loggingOperationOrder).not.toContain('setLoggingLevel');
+    expect(lastSetLoggingLevel).toBeUndefined();
+    expect(
+      loggingOperationOrder.indexOf('setNotificationHandler'),
+    ).toBeLessThan(loggingOperationOrder.indexOf('connect'));
+    expect(handler).toHaveBeenCalledWith({
+      level: 'info',
+      logger: undefined,
+      data: 'still logging',
+      meta: undefined,
+    });
+
+    await server.close();
   });
 
   test('should forward resource requests to session methods', async () => {

--- a/packages/agents-core/test/shims/mcp-server/node.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/node.test.ts
@@ -213,6 +213,32 @@ describe('NodeMCPServerStdio', () => {
     await server.close();
   });
 
+  test('should not let a throwing logging handler reject the notification', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const handler = vi.fn().mockRejectedValue(new Error('handler boom'));
+    const server = new NodeMCPServerStdio({
+      name: 'logging-throw-test',
+      fullCommand: 'test',
+      serverLogging: {
+        handler,
+      },
+    });
+
+    await server.connect();
+    // The notification callback must resolve even though the handler rejects.
+    await expect(
+      lastNotificationHandler({
+        method: 'notifications/message',
+        params: { level: 'info', data: 'boom' },
+      }),
+    ).resolves.toBeUndefined();
+    expect(handler).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    await server.close();
+  });
+
   test('should stay connected when logging/setLevel fails', async () => {
     // Requesting a level is best-effort: a server that advertises the logging
     // capability but rejects logging/setLevel must not fail the connection.


### PR DESCRIPTION
## What

Adds an opt-in `serverLogging` option to the local MCP servers (`MCPServerStdio`, `MCPServerSSE`, `MCPServerStreamableHttp`) so an Agent can subscribe to `notifications/message` logging events emitted by an MCP server.

```ts
const mcpServer = new MCPServerStdio({
  name: 'Logging Demo Server',
  fullCommand: 'pnpm tsx logging-server.ts',
  serverLogging: {
    level: 'info', // optional minimum severity requested from the server
    handler: ({ level, logger, data, meta }) => {
      console.log(`[mcp:${level}] ${logger ?? 'server'}`, data);
    },
  },
});
```

## Why

Fixes #793. Long-running MCP tools (the issue reports 2–4 minute calls) can report progress via `sendLoggingMessage`, but today the SDK offers no way to observe those logs without building a custom SSE/transport pipeline by hand. This surfaces them through a documented `serverLogging.handler`, following the API shape @seratch proposed in the issue.

## How

- New **structural** public types in `mcp.ts` (`MCPServerLoggingLevel` / `MCPServerLoggingMessage` / `MCPServerLoggingHandler` / `MCPServerLoggingOptions`), declared locally so consuming `@openai/agents-core` never forces resolution of the optional `@modelcontextprotocol/sdk` package.
- The `notifications/message` handler is registered **before** `connect()` on every transport, so logs emitted during the initialize handshake are not dropped.
- An optional `level` is sent via `logging/setLevel` **after** connect, but only when the server advertises the `logging` capability. This keeps a reused streamable-HTTP session (an explicit `sessionId`, which skips initialize/capability discovery) from being torn down by a `setLevel` that would otherwise reject. The request is best-effort: a rejecting server logs a warning and stays connected.

## Tests

`packages/agents-core/test/shims/mcp-server/node.test.ts`, across stdio / SSE / streamable-HTTP:

- handler registered before connect, `setLevel` sent after (ordering asserted)
- notification `_meta` mapped to `meta`
- handler-only (no `level`) does **not** send `setLevel`
- explicit `sessionId` reuse skips `setLevel` while notifications still flow
- a rejecting `setLevel` still yields a connected, usable server

`pnpm build && pnpm -r build-check && pnpm test && pnpm lint` all pass. Includes a changeset and a runnable demo (`pnpm -F mcp start:logging`).

## Notes

- Scoped to local MCP servers in `agents-core`; no changes to hosted MCP.
- Happy to adjust the `serverLogging` shape (naming, sync vs async handler, per-transport nuances) to match your preference.
