### PR TITLE
fix: fail closed on invalid dynamic tool approval arguments

### DIFF
--- a/.changeset/fair-tools-approve.md
+++ b/.changeset/fair-tools-approve.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-realtime': patch
+---
+
+fix: fail closed when dynamic tool approval receives invalid arguments

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -35,6 +35,8 @@ import {
   FUNCTION_TOOL_PARSED_INPUT_CALLBACK,
   ApplyPatchToolCustomDataContext,
   invokeFunctionTool,
+  hasDynamicFunctionToolApprovalPolicy,
+  hasInspectableFunctionToolArguments,
   validateFunctionToolOutput,
   resolveComputer,
   Tool,
@@ -243,9 +245,23 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
 
   const executeToolRun = async (toolRun: ToolRunFunction<TContext>) => {
     const parseResult = parseToolArguments(toolRun);
+    const dynamicApprovalPolicy = hasDynamicFunctionToolApprovalPolicy(
+      toolRun.tool,
+    );
 
     // Handle parse errors gracefully instead of crashing.
     if (!parseResult.success) {
+      if (dynamicApprovalPolicy) {
+        const approvalOutcome = await handleFunctionApproval(
+          deps,
+          toolRun,
+          undefined,
+          true,
+        );
+        if (approvalOutcome !== 'approved') {
+          return approvalOutcome;
+        }
+      }
       return buildParseErrorResult(deps, toolRun, parseResult.error);
     }
 
@@ -253,6 +269,8 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
       deps,
       toolRun,
       parseResult.args,
+      dynamicApprovalPolicy &&
+        !hasInspectableFunctionToolArguments(parseResult.args),
     );
     if (approvalOutcome !== 'approved') {
       return approvalOutcome;
@@ -494,6 +512,7 @@ async function handleFunctionApproval<TContext>(
   deps: FunctionToolCallDeps<TContext>,
   toolRun: ToolRunFunction<TContext>,
   parsedArgs: any,
+  forceApproval: boolean = false,
 ): Promise<'approved' | FunctionToolResult<TContext>> {
   const { agent, state } = deps;
   const toolName = getFunctionToolIdentity(toolRun);
@@ -511,11 +530,13 @@ async function handleFunctionApproval<TContext>(
     return 'approved';
   }
 
-  const needsApproval = await toolRun.tool.needsApproval(
-    state._context,
-    parsedArgs,
-    toolRun.toolCall.callId,
-  );
+  const needsApproval =
+    forceApproval ||
+    (await toolRun.tool.needsApproval(
+      state._context,
+      parsedArgs,
+      toolRun.toolCall.callId,
+    ));
 
   if (!needsApproval) {
     return 'approved';

--- a/packages/agents-core/src/tool.ts
+++ b/packages/agents-core/src/tool.ts
@@ -84,6 +84,21 @@ export const FUNCTION_TOOL_PARSED_INPUT_CALLBACK = Symbol(
 const FUNCTION_TOOL_OUTPUT_VALIDATOR = Symbol(
   'openai.agents.functionToolOutputValidator',
 );
+const STATIC_FUNCTION_TOOL_APPROVAL_POLICIES = new WeakSet<
+  ToolApprovalFunction<any>
+>();
+
+export function hasDynamicFunctionToolApprovalPolicy(
+  tool: Pick<FunctionTool<any, any, any>, 'needsApproval'>,
+): boolean {
+  return !STATIC_FUNCTION_TOOL_APPROVAL_POLICIES.has(tool.needsApproval);
+}
+
+export function hasInspectableFunctionToolArguments(
+  value: unknown,
+): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
 
 export type ToolCallDetails = {
   toolCall?: protocol.FunctionCallItem;
@@ -2298,6 +2313,9 @@ export function tool<
           typeof options.needsApproval === 'boolean'
             ? options.needsApproval
             : false;
+  if (typeof options.needsApproval !== 'function') {
+    STATIC_FUNCTION_TOOL_APPROVAL_POLICIES.add(needsApproval);
+  }
 
   const isEnabled: ToolEnabledFunction<Context> =
     typeof options.isEnabled === 'function'

--- a/packages/agents-core/src/utils/internal.ts
+++ b/packages/agents-core/src/utils/internal.ts
@@ -1,3 +1,7 @@
 export { formatInlineData, getInlineMediaType } from './inlineData';
 export { recordToolUsage } from '../runner/usageTracking';
 export { normalizeToolAllowedCallers } from './toolCallers';
+export {
+  hasDynamicFunctionToolApprovalPolicy,
+  hasInspectableFunctionToolArguments,
+} from '../tool';

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -2577,6 +2577,201 @@ describe('executeShellActions', () => {
       expect(invokeSpy).not.toHaveBeenCalled();
     });
 
+    it.each([
+      ['malformed JSON', '{'],
+      ['an array', '[]'],
+      ['null', 'null'],
+      ['a number', '42'],
+      ['a string', '"unsafe"'],
+      ['a boolean', 'true'],
+    ])(
+      'requires approval without invoking a dynamic policy for %s',
+      async (_label, args) => {
+        const needsApproval = vi.fn(async () => false);
+        const t = tool({
+          name: 'hi',
+          description: 'dynamic approval tool',
+          parameters: {
+            type: 'object',
+            properties: {},
+            required: [],
+            additionalProperties: false,
+          },
+          needsApproval,
+          execute: vi.fn(async () => 'ok'),
+        }) as unknown as FunctionTool;
+        const invokeSpy = vi.spyOn(t, 'invoke');
+
+        const result = await executeFunctionToolCalls(
+          state._currentAgent,
+          [{ toolCall: { ...toolCall, arguments: args }, tool: t }],
+          runner,
+          state,
+        );
+
+        expect(result[0].type).toBe('function_approval');
+        expect(needsApproval).not.toHaveBeenCalled();
+        expect(invokeSpy).not.toHaveBeenCalled();
+      },
+    );
+
+    it('fails closed for directly constructed dynamic approval policies', async () => {
+      const needsApproval = vi.fn(async () => false);
+      const t = {
+        ...tool({
+          name: 'hi',
+          description: 'directly constructed approval tool',
+          parameters: {
+            type: 'object',
+            properties: {},
+            required: [],
+            additionalProperties: false,
+          },
+          needsApproval: false,
+          execute: vi.fn(async () => 'ok'),
+        }),
+        needsApproval,
+      } as unknown as FunctionTool;
+      const invokeSpy = vi.spyOn(t, 'invoke');
+
+      const result = await executeFunctionToolCalls(
+        state._currentAgent,
+        [{ toolCall: { ...toolCall, arguments: '[]' }, tool: t }],
+        runner,
+        state,
+      );
+
+      expect(result[0].type).toBe('function_approval');
+      expect(needsApproval).not.toHaveBeenCalled();
+      expect(invokeSpy).not.toHaveBeenCalled();
+    });
+
+    it('continues evaluating dynamic approval policies for valid objects', async () => {
+      const needsApproval = vi.fn(async () => false);
+      const t = tool({
+        name: 'hi',
+        description: 'dynamic approval tool',
+        parameters: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+        needsApproval,
+        execute: vi.fn(async () => 'ok'),
+      }) as unknown as FunctionTool;
+
+      const result = await executeFunctionToolCalls(
+        state._currentAgent,
+        [
+          {
+            toolCall: { ...toolCall, arguments: '{"safe":true}' },
+            tool: t,
+          },
+        ],
+        runner,
+        state,
+      );
+
+      expect(result[0].type).toBe('function_output');
+      expect(needsApproval).toHaveBeenCalledWith(
+        state._context,
+        { safe: true },
+        toolCall.callId,
+      );
+    });
+
+    it('rejects malformed arguments without invoking the approval policy', async () => {
+      const needsApproval = vi.fn(async () => false);
+      const t = tool({
+        name: 'hi',
+        description: 'dynamic approval tool',
+        parameters: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+        needsApproval,
+        execute: vi.fn(async () => 'ok'),
+      }) as unknown as FunctionTool;
+      const invalidCall = { ...toolCall, arguments: '{' };
+      state._context.rejectTool(
+        new ToolApprovalItem(invalidCall, state._currentAgent),
+      );
+      const invokeSpy = vi.spyOn(t, 'invoke');
+
+      const result = await executeFunctionToolCalls(
+        state._currentAgent,
+        [{ toolCall: invalidCall, tool: t }],
+        runner,
+        state,
+      );
+
+      expect(result[0].type).toBe('function_output');
+      expect(needsApproval).not.toHaveBeenCalled();
+      expect(invokeSpy).not.toHaveBeenCalled();
+    });
+
+    it('keeps approved malformed arguments on the existing parse-error path', async () => {
+      const needsApproval = vi.fn(async () => false);
+      const t = tool({
+        name: 'hi',
+        description: 'dynamic approval tool',
+        parameters: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+        needsApproval,
+        execute: vi.fn(async () => 'ok'),
+      }) as unknown as FunctionTool;
+      const invalidCall = { ...toolCall, arguments: '{' };
+      state._context.approveTool(
+        new ToolApprovalItem(invalidCall, state._currentAgent),
+      );
+      const invokeSpy = vi.spyOn(t, 'invoke');
+
+      const result = await executeFunctionToolCalls(
+        state._currentAgent,
+        [{ toolCall: invalidCall, tool: t }],
+        runner,
+        state,
+      );
+
+      expect(result[0]).toMatchObject({
+        type: 'function_output',
+        output: expect.stringContaining('valid JSON'),
+      });
+      expect(needsApproval).not.toHaveBeenCalled();
+      expect(invokeSpy).not.toHaveBeenCalled();
+    });
+
+    it('preserves fixed approval behavior for non-object arguments', async () => {
+      const t = tool({
+        name: 'hi',
+        description: 'fixed approval tool',
+        parameters: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+        needsApproval: false,
+        execute: vi.fn(async () => 'ok'),
+      }) as unknown as FunctionTool;
+
+      const result = await executeFunctionToolCalls(
+        state._currentAgent,
+        [{ toolCall: { ...toolCall, arguments: '[]' }, tool: t }],
+        runner,
+        state,
+      );
+
+      expect(result[0].type).toBe('function_output');
+    });
+
     it('does not run input guardrails before pending approval by default', async () => {
       const guardrailRun = vi.fn(async () =>
         ToolGuardrailFunctionOutputFactory.allow(),

--- a/packages/agents-realtime/src/realtimeSession.ts
+++ b/packages/agents-realtime/src/realtimeSession.ts
@@ -734,14 +734,23 @@ export class RealtimeSession<
       dynamicApprovalPolicy &&
       (argumentParseError !== undefined ||
         !hasInspectableFunctionToolArguments(parsedArgs));
+    const existingApproval = dynamicApprovalPolicy
+      ? this.context.isToolApproved({
+          toolName: tool.name,
+          callId: toolCall.callId,
+        })
+      : undefined;
     const needsApproval =
       forceApproval ||
+      existingApproval !== undefined ||
       (await tool.needsApproval(this.#context, parsedArgs, toolCall.callId));
     if (needsApproval) {
-      const approval = this.context.isToolApproved({
-        toolName: tool.name,
-        callId: toolCall.callId,
-      });
+      const approval =
+        existingApproval ??
+        this.context.isToolApproved({
+          toolName: tool.name,
+          callId: toolCall.callId,
+        });
       if (approval === false) {
         this.#pendingFunctionCalls.delete(toolCall.callId);
         this.emit('agent_tool_start', this.#context, agent, tool, {
@@ -800,7 +809,9 @@ export class RealtimeSession<
 
     this.#pendingFunctionCalls.delete(toolCall.callId);
     if (argumentParseError !== undefined) {
-      throw argumentParseError;
+      const errorMessage = `An error occurred while parsing tool arguments. Please try again with valid JSON. Error: ${toErrorMessage(argumentParseError)}`;
+      this.#transport.sendFunctionCallOutput(toolCall, errorMessage, true);
+      return;
     }
 
     const inputGuardrailResult = await runToolInputGuardrails({

--- a/packages/agents-realtime/src/realtimeSession.ts
+++ b/packages/agents-realtime/src/realtimeSession.ts
@@ -16,6 +16,10 @@ import {
 } from '@openai/agents-core';
 import { RuntimeEventEmitter } from '@openai/agents-core/_shims';
 import { isZodObject, toSmartString } from '@openai/agents-core/utils';
+import {
+  hasDynamicFunctionToolApprovalPolicy,
+  hasInspectableFunctionToolArguments,
+} from '@openai/agents-core/utils/internal';
 import type {
   RealtimeSessionConfig,
   RealtimeSessionConfigDefinition,
@@ -710,18 +714,29 @@ export class RealtimeSession<
     const toolCall = normalizeRealtimeFunctionCallId(incomingToolCall);
     this.#context.context.history = JSON.parse(JSON.stringify(this.#history)); // deep copy of the history
     let parsedArgs: any = toolCall.arguments;
-    if (tool.parameters) {
-      if (isZodObject(tool.parameters)) {
-        parsedArgs = tool.parameters.parse(parsedArgs);
-      } else {
-        parsedArgs = JSON.parse(parsedArgs);
+    const dynamicApprovalPolicy = hasDynamicFunctionToolApprovalPolicy(tool);
+    let argumentParseError: unknown;
+    try {
+      if (tool.parameters) {
+        if (isZodObject(tool.parameters)) {
+          parsedArgs = tool.parameters.parse(parsedArgs);
+        } else {
+          parsedArgs = JSON.parse(parsedArgs);
+        }
       }
+    } catch (error) {
+      if (!dynamicApprovalPolicy) {
+        throw error;
+      }
+      argumentParseError = error;
     }
-    const needsApproval = await tool.needsApproval(
-      this.#context,
-      parsedArgs,
-      toolCall.callId,
-    );
+    const forceApproval =
+      dynamicApprovalPolicy &&
+      (argumentParseError !== undefined ||
+        !hasInspectableFunctionToolArguments(parsedArgs));
+    const needsApproval =
+      forceApproval ||
+      (await tool.needsApproval(this.#context, parsedArgs, toolCall.callId));
     if (needsApproval) {
       const approval = this.context.isToolApproved({
         toolName: tool.name,
@@ -784,6 +799,9 @@ export class RealtimeSession<
     }
 
     this.#pendingFunctionCalls.delete(toolCall.callId);
+    if (argumentParseError !== undefined) {
+      throw argumentParseError;
+    }
 
     const inputGuardrailResult = await runToolInputGuardrails({
       guardrails: tool.inputGuardrails,

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -1190,6 +1190,241 @@ describe('RealtimeSession', () => {
     expect(invokeSpy).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['malformed JSON', '{'],
+    ['an array', '[]'],
+    ['null', 'null'],
+    ['a number', '42'],
+    ['a string', '"unsafe"'],
+    ['a boolean', 'true'],
+  ])(
+    'requires realtime approval without invoking a dynamic policy for %s',
+    async (_label, args) => {
+      const needsApproval = vi.fn(async () => false);
+      const execute = vi.fn(async () => 'ok');
+      const guardedTool = tool({
+        name: 'dynamic_approval',
+        description: 'Dynamic approval tool',
+        parameters: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+        needsApproval,
+        execute,
+      });
+      const agent = new RealtimeAgent({
+        name: 'ApprovalAgent',
+        handoffs: [],
+        tools: [guardedTool],
+      });
+      const localTransport = new FakeTransport();
+      const localSession = new RealtimeSession(agent, {
+        transport: localTransport,
+      });
+      await localSession.connect({ apiKey: 'test' });
+
+      const approvalRequest = waitForEvent<any[]>(
+        localSession,
+        'tool_approval_requested',
+      );
+      localTransport.emit('function_call', {
+        type: 'function_call',
+        name: 'dynamic_approval',
+        callId: 'invalid-approval-call',
+        arguments: args,
+        status: 'completed',
+        responseId: 'invalid-approval-response',
+      } as any);
+
+      const [, , payload] = await approvalRequest;
+      expect(payload.type).toBe('function_approval');
+      expect(needsApproval).not.toHaveBeenCalled();
+      expect(execute).not.toHaveBeenCalled();
+      expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(0);
+    },
+  );
+
+  it('fails closed for directly constructed realtime approval policies', async () => {
+    const needsApproval = vi.fn(async () => false);
+    const execute = vi.fn(async () => 'ok');
+    const guardedTool = {
+      ...tool({
+        name: 'direct_approval',
+        description: 'Direct approval tool',
+        parameters: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+        needsApproval: false,
+        execute,
+      }),
+      needsApproval,
+    };
+    const agent = new RealtimeAgent({
+      name: 'ApprovalAgent',
+      handoffs: [],
+      tools: [guardedTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+
+    const approvalRequest = waitForEvent<any[]>(
+      localSession,
+      'tool_approval_requested',
+    );
+    localTransport.emit('function_call', {
+      type: 'function_call',
+      name: 'direct_approval',
+      callId: 'direct-approval-call',
+      arguments: '[]',
+      status: 'completed',
+      responseId: 'direct-approval-response',
+    } as any);
+
+    const [, , payload] = await approvalRequest;
+    expect(payload.type).toBe('function_approval');
+    expect(needsApproval).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('continues evaluating realtime approval policies for valid objects', async () => {
+    const needsApproval = vi.fn(async () => false);
+    const execute = vi.fn(async () => 'ok');
+    const guardedTool = tool({
+      name: 'dynamic_approval',
+      description: 'Dynamic approval tool',
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      },
+      needsApproval,
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'ApprovalAgent',
+      handoffs: [],
+      tools: [guardedTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+
+    const output = localTransport.waitForNextFunctionCallOutput();
+    localTransport.emit('function_call', {
+      type: 'function_call',
+      name: 'dynamic_approval',
+      callId: 'valid-approval-call',
+      arguments: '{"safe":true}',
+      status: 'completed',
+      responseId: 'valid-approval-response',
+    } as any);
+
+    await output;
+    expect(needsApproval).toHaveBeenCalledWith(
+      localSession.context,
+      { safe: true },
+      'valid-approval-call',
+    );
+    expect(execute).toHaveBeenCalledOnce();
+  });
+
+  it('rejects malformed realtime arguments without invoking the approval policy', async () => {
+    const needsApproval = vi.fn(async () => false);
+    const execute = vi.fn(async () => 'ok');
+    const guardedTool = tool({
+      name: 'dynamic_approval',
+      description: 'Dynamic approval tool',
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      },
+      needsApproval,
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'ApprovalAgent',
+      handoffs: [],
+      tools: [guardedTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+
+    const approvalRequest = waitForEvent<any[]>(
+      localSession,
+      'tool_approval_requested',
+    );
+    localTransport.emit('function_call', {
+      type: 'function_call',
+      name: 'dynamic_approval',
+      callId: 'malformed-rejection-call',
+      arguments: '{',
+      status: 'completed',
+      responseId: 'malformed-rejection-response',
+    } as any);
+    const [, , payload] = await approvalRequest;
+
+    await localSession.reject(payload.approvalItem);
+
+    expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(1);
+    expect(needsApproval).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('preserves fixed realtime approval behavior for non-object arguments', async () => {
+    const execute = vi.fn(async () => 'ok');
+    const guardedTool = tool({
+      name: 'fixed_approval',
+      description: 'Fixed approval tool',
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      },
+      needsApproval: false,
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'ApprovalAgent',
+      handoffs: [],
+      tools: [guardedTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+
+    const output = localTransport.waitForNextFunctionCallOutput();
+    localTransport.emit('function_call', {
+      type: 'function_call',
+      name: 'fixed_approval',
+      callId: 'fixed-approval-call',
+      arguments: '[]',
+      status: 'completed',
+      responseId: 'fixed-approval-response',
+    } as any);
+
+    await output;
+    expect(execute).toHaveBeenCalledOnce();
+  });
+
   it('keeps pending approvals distinct when call IDs are missing', async () => {
     const execute = vi.fn(async ({ request }: { request: string }) => request);
     const needsApprovalTool = tool({

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -1386,6 +1386,199 @@ describe('RealtimeSession', () => {
     expect(execute).not.toHaveBeenCalled();
   });
 
+  it('completes malformed realtime calls with a parse error after approval', async () => {
+    const needsApproval = vi.fn(async () => false);
+    const execute = vi.fn(async () => 'should not run');
+    const guardedTool = tool({
+      name: 'dynamic_approval',
+      description: 'Dynamic approval tool',
+      parameters: z.object({}),
+      needsApproval,
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'ApprovalAgent',
+      handoffs: [],
+      tools: [guardedTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+
+    const approvalRequest = waitForEvent<any[]>(
+      localSession,
+      'tool_approval_requested',
+    );
+    localTransport.emit('function_call', {
+      type: 'function_call',
+      name: 'dynamic_approval',
+      callId: 'malformed-approval-call',
+      arguments: '{',
+      status: 'completed',
+      responseId: 'malformed-approval-response',
+    } as any);
+    const [, , payload] = await approvalRequest;
+
+    await expect(localSession.approve(payload.approvalItem)).resolves.toBe(
+      undefined,
+    );
+
+    expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(1);
+    expect(localTransport.sendFunctionCallOutputCalls[0]).toEqual([
+      expect.objectContaining({ callId: 'malformed-approval-call' }),
+      expect.stringContaining('Please try again with valid JSON.'),
+      true,
+    ]);
+    expect(needsApproval).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('completes malformed realtime calls with an existing approval decision', async () => {
+    const needsApproval = vi.fn(async () => false);
+    const execute = vi.fn(async () => 'should not run');
+    const guardedTool = tool({
+      name: 'dynamic_approval',
+      description: 'Dynamic approval tool',
+      parameters: z.object({}),
+      needsApproval,
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'ApprovalAgent',
+      handoffs: [],
+      tools: [guardedTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+    const toolCall = {
+      type: 'function_call',
+      name: 'dynamic_approval',
+      callId: 'preapproved-malformed-call',
+      arguments: '{',
+      status: 'completed',
+      responseId: 'preapproved-malformed-response',
+    } as const;
+    localSession.context.approveTool(
+      new RunToolApprovalItem(toolCall as any, agent),
+    );
+
+    const output = localTransport.waitForNextFunctionCallOutput();
+    localTransport.emit('function_call', toolCall as any);
+    const [, result, startResponse] = await output;
+
+    expect(result).toContain('Please try again with valid JSON.');
+    expect(startResponse).toBe(true);
+    expect(needsApproval).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('honors a rejection without reevaluating a changing dynamic approval policy', async () => {
+    const needsApproval = vi
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    const execute = vi.fn(async () => 'must not run');
+    const guardedTool = tool({
+      name: 'dynamic_approval',
+      description: 'Dynamic approval tool',
+      parameters: z.object({}),
+      needsApproval,
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'ApprovalAgent',
+      handoffs: [],
+      tools: [guardedTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+    const approvalRequest = waitForEvent<any[]>(
+      localSession,
+      'tool_approval_requested',
+    );
+    localTransport.emit('function_call', {
+      type: 'function_call',
+      name: 'dynamic_approval',
+      callId: 'changing-policy-rejection',
+      arguments: '{}',
+      status: 'completed',
+      responseId: 'changing-policy-response',
+    } as any);
+    const [, , payload] = await approvalRequest;
+
+    await localSession.reject(payload.approvalItem);
+
+    expect(localTransport.sendFunctionCallOutputCalls).toEqual([
+      [
+        expect.objectContaining({ callId: 'changing-policy-rejection' }),
+        'Tool execution was not approved.',
+        true,
+      ],
+    ]);
+    expect(needsApproval).toHaveBeenCalledOnce();
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('honors approval without reevaluating a failing dynamic approval policy', async () => {
+    const needsApproval = vi
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValueOnce(true)
+      .mockRejectedValueOnce(new Error('policy must not run after approval'));
+    const execute = vi.fn(async () => 'approved output');
+    const guardedTool = tool({
+      name: 'dynamic_approval',
+      description: 'Dynamic approval tool',
+      parameters: z.object({}),
+      needsApproval,
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'ApprovalAgent',
+      handoffs: [],
+      tools: [guardedTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+    const approvalRequest = waitForEvent<any[]>(
+      localSession,
+      'tool_approval_requested',
+    );
+    localTransport.emit('function_call', {
+      type: 'function_call',
+      name: 'dynamic_approval',
+      callId: 'changing-policy-approval',
+      arguments: '{}',
+      status: 'completed',
+      responseId: 'changing-policy-approval-response',
+    } as any);
+    const [, , payload] = await approvalRequest;
+
+    await expect(localSession.approve(payload.approvalItem)).resolves.toBe(
+      undefined,
+    );
+
+    expect(localTransport.sendFunctionCallOutputCalls).toEqual([
+      [
+        expect.objectContaining({ callId: 'changing-policy-approval' }),
+        'approved output',
+        true,
+      ],
+    ]);
+    expect(needsApproval).toHaveBeenCalledOnce();
+    expect(execute).toHaveBeenCalledOnce();
+  });
+
   it('preserves fixed realtime approval behavior for non-object arguments', async () => {
     const execute = vi.fn(async () => 'ok');
     const guardedTool = tool({


### PR DESCRIPTION
This pull request fixes function-tool approval policies that could fail open when model-provided arguments contained malformed or non-object JSON. Both the text runner and Realtime sessions now require approval without invoking dynamic policy callbacks for uninspectable arguments, while preserving valid-object handling, fixed boolean approval behavior, and existing rejected/approved flows.