### PR TITLE
fix: redact sensitive tool and model data from error logs

### DIFF
--- a/.changeset/calm-logs-redact.md
+++ b/.changeset/calm-logs-redact.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-realtime': patch
+---
+
+fix: redact sensitive tool and model data from error logs

--- a/packages/agents-core/src/logger.ts
+++ b/packages/agents-core/src/logger.ts
@@ -59,6 +59,38 @@ export function getLogger(namespace: string = 'openai-agents'): Logger {
   };
 }
 
+export function getSafeErrorType(error: unknown): string {
+  return error instanceof Error ? 'Error' : typeof error;
+}
+
+export function logToolActionError(
+  targetLogger: Logger,
+  message: string,
+  error: unknown,
+  ...details: unknown[]
+): void {
+  if (targetLogger.dontLogToolData) {
+    targetLogger.error(message, getSafeErrorType(error));
+    return;
+  }
+
+  targetLogger.error(message, error, ...details);
+}
+
+export function logModelActionError(
+  targetLogger: Logger,
+  message: string,
+  error: unknown,
+  ...details: unknown[]
+): void {
+  if (targetLogger.dontLogModelData) {
+    targetLogger.error(message, getSafeErrorType(error));
+    return;
+  }
+
+  targetLogger.error(message, error, ...details);
+}
+
 export const logger = getLogger('openai-agents:core');
 
 export default logger;

--- a/packages/agents-core/src/logger.ts
+++ b/packages/agents-core/src/logger.ts
@@ -60,7 +60,13 @@ export function getLogger(namespace: string = 'openai-agents'): Logger {
 }
 
 export function getSafeErrorType(error: unknown): string {
-  return error instanceof Error ? 'Error' : typeof error;
+  const errorType = typeof error;
+
+  try {
+    return error instanceof Error ? 'Error' : errorType;
+  } catch {
+    return errorType;
+  }
 }
 
 export function logToolActionError(

--- a/packages/agents-core/src/runner/approvalRejection.ts
+++ b/packages/agents-core/src/runner/approvalRejection.ts
@@ -1,4 +1,4 @@
-import logger from '../logger';
+import logger, { getSafeErrorType } from '../logger';
 import { RunContext } from '../runContext';
 import type { ToolErrorFormatter, ToolErrorFormatterArgs } from '../run';
 
@@ -56,8 +56,11 @@ export async function resolveApprovalRejectionMessage<TContext>({
       );
     }
   } catch (error) {
+    const errorDetails = logger.dontLogToolData
+      ? getSafeErrorType(error)
+      : toErrorMessage(error);
     logger.warn(
-      `toolErrorFormatter threw while formatting approval rejection: ${toErrorMessage(error)}`,
+      `toolErrorFormatter threw while formatting approval rejection: ${errorDetails}`,
     );
   }
 

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -22,7 +22,7 @@ import {
   RunToolCallOutputItem,
 } from '../items';
 import { assistant } from '../helpers/message';
-import logger, { Logger } from '../logger';
+import logger, { Logger, logToolActionError } from '../logger';
 import { ModelResponse } from '../model';
 import {
   ComputerSafetyCheck,
@@ -376,7 +376,11 @@ function parseToolArguments<TContext>(
     }
     return { success: true, args: parsedArgs };
   } catch (error) {
-    logger.debug(`Failed to parse tool arguments for ${toolName}: ${error}`);
+    if (logger.dontLogToolData) {
+      logger.debug(`Failed to parse tool arguments for ${toolName}`);
+    } else {
+      logger.debug(`Failed to parse tool arguments for ${toolName}: ${error}`);
+    }
     return { success: false, error: error as Error };
   }
 }
@@ -1154,7 +1158,7 @@ export async function executeShellActions(
               error: traceError,
             },
           });
-          _logger.error('Failed to execute shell action:', err);
+          logToolActionError(_logger, 'Failed to execute shell action:', err);
         }
 
         shellOutputs = shellOutputs ?? [];
@@ -1309,7 +1313,11 @@ export async function executeApplyPatchOperations(
               error: traceError,
             },
           });
-          _logger.error('Failed to execute apply_patch operation:', err);
+          logToolActionError(
+            _logger,
+            'Failed to execute apply_patch operation:',
+            err,
+          );
         }
 
         const rawItem: protocol.ApplyPatchCallResultItem = {
@@ -1495,7 +1503,11 @@ export async function executeComputerActions(
             runContext,
           );
         } catch (err) {
-          _logger.error('Failed to execute computer action:', err);
+          logToolActionError(
+            _logger,
+            'Failed to execute computer action:',
+            err,
+          );
           output = '';
           const errorText = toErrorMessage(err);
           const traceError = getTraceToolError(

--- a/packages/agents-core/src/utils/internal.ts
+++ b/packages/agents-core/src/utils/internal.ts
@@ -5,3 +5,8 @@ export {
   hasDynamicFunctionToolApprovalPolicy,
   hasInspectableFunctionToolArguments,
 } from '../tool';
+export {
+  getSafeErrorType,
+  logModelActionError,
+  logToolActionError,
+} from '../logger';

--- a/packages/agents-core/test/logger.test.ts
+++ b/packages/agents-core/test/logger.test.ts
@@ -35,4 +35,87 @@ describe('logger', () => {
     expect(modelDataSpy).toHaveBeenCalledTimes(1);
     expect(toolDataSpy).toHaveBeenCalledTimes(1);
   });
+
+  test.each([
+    ['tool', 'logToolActionError', 'dontLogToolData'],
+    ['model', 'logModelActionError', 'dontLogModelData'],
+  ] as const)(
+    'redacts %s errors and supplemental payloads when data logging is disabled',
+    async (_kind, helperName, flagName) => {
+      const loggerModule = await import('../src/logger');
+      const targetLogger = loggerModule.getLogger('test');
+      const errorSpy = vi
+        .spyOn(targetLogger, 'error')
+        .mockImplementation(() => {});
+      vi.spyOn(targetLogger, flagName, 'get').mockReturnValue(true);
+      const secret = 'SECRET_LOG_VALUE_123';
+
+      loggerModule[helperName](
+        targetLogger,
+        'Operation failed',
+        new Error(secret),
+        {
+          secret,
+        },
+      );
+
+      expect(errorSpy).toHaveBeenCalledWith('Operation failed', 'Error');
+      expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(secret);
+    },
+  );
+
+  test.each([
+    ['tool', 'logToolActionError', 'dontLogToolData'],
+    ['model', 'logModelActionError', 'dontLogModelData'],
+  ] as const)(
+    'preserves existing %s error details when data logging is enabled',
+    async (_kind, helperName, flagName) => {
+      const loggerModule = await import('../src/logger');
+      const targetLogger = loggerModule.getLogger('test');
+      const errorSpy = vi
+        .spyOn(targetLogger, 'error')
+        .mockImplementation(() => {});
+      vi.spyOn(targetLogger, flagName, 'get').mockReturnValue(false);
+      const error = new Error('SECRET_LOG_VALUE_123');
+      const details = { secret: 'SECRET_LOG_VALUE_123' };
+
+      loggerModule[helperName](
+        targetLogger,
+        'Operation failed',
+        error,
+        details,
+      );
+
+      expect(errorSpy).toHaveBeenCalledWith('Operation failed', error, details);
+    },
+  );
+
+  test('uses safe types for non-Error thrown values', async () => {
+    const { getSafeErrorType } = await import('../src/logger');
+
+    expect(getSafeErrorType('SECRET_LOG_VALUE_123')).toBe('string');
+    expect(getSafeErrorType({ secret: 'SECRET_LOG_VALUE_123' })).toBe('object');
+  });
+
+  test('does not inspect overridden Error constructors', async () => {
+    const { getSafeErrorType } = await import('../src/logger');
+    const constructorGetter = vi.fn(() => {
+      throw new Error('The Error constructor must not be inspected.');
+    });
+    const error = new Error('SECRET_LOG_VALUE_123');
+    Object.defineProperty(error, 'constructor', { get: constructorGetter });
+
+    expect(getSafeErrorType(error)).toBe('Error');
+    expect(constructorGetter).not.toHaveBeenCalled();
+  });
+
+  test('does not expose overridden Error constructor names', async () => {
+    const { getSafeErrorType } = await import('../src/logger');
+    const error = new Error('SECRET_LOG_VALUE_123');
+    Object.defineProperty(error, 'constructor', {
+      value: { name: 'SECRET_CONSTRUCTOR_NAME_123' },
+    });
+
+    expect(getSafeErrorType(error)).toBe('Error');
+  });
 });

--- a/packages/agents-core/test/logger.test.ts
+++ b/packages/agents-core/test/logger.test.ts
@@ -97,6 +97,54 @@ describe('logger', () => {
     expect(getSafeErrorType({ secret: 'SECRET_LOG_VALUE_123' })).toBe('object');
   });
 
+  test.each([
+    [
+      'revoked Proxy',
+      () => {
+        const { proxy, revoke } = Proxy.revocable({}, {});
+        revoke();
+        return proxy;
+      },
+    ],
+    [
+      'Proxy with a throwing prototype trap',
+      () =>
+        new Proxy(
+          {},
+          {
+            getPrototypeOf() {
+              throw new Error('SECRET_PROXY_TRAP_123');
+            },
+          },
+        ),
+    ],
+  ] as const)('safely classifies a %s', async (_description, createError) => {
+    const { getSafeErrorType } = await import('../src/logger');
+
+    expect(getSafeErrorType(createError())).toBe('object');
+  });
+
+  test.each([
+    ['tool', 'logToolActionError', 'dontLogToolData'],
+    ['model', 'logModelActionError', 'dontLogModelData'],
+  ] as const)(
+    'safely redacts hostile %s error values',
+    async (_kind, helperName, flagName) => {
+      const loggerModule = await import('../src/logger');
+      const targetLogger = loggerModule.getLogger('test');
+      const errorSpy = vi
+        .spyOn(targetLogger, 'error')
+        .mockImplementation(() => {});
+      vi.spyOn(targetLogger, flagName, 'get').mockReturnValue(true);
+      const { proxy, revoke } = Proxy.revocable({}, {});
+      revoke();
+
+      loggerModule[helperName](targetLogger, 'Operation failed', proxy);
+
+      expect(errorSpy).toHaveBeenCalledWith('Operation failed', 'object');
+    },
+  );
+
   test('does not inspect overridden Error constructors', async () => {
     const { getSafeErrorType } = await import('../src/logger');
     const constructorGetter = vi.fn(() => {

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -2050,7 +2050,7 @@ describe('executeShellActions', () => {
     });
     expect(mockLogger.error).toHaveBeenCalledWith(
       'Failed to execute shell action:',
-      shell.error,
+      'Error',
     );
   });
 
@@ -2340,7 +2340,7 @@ describe('executeShellActions', () => {
       expect(rawItem.output).toBe('cannot delete');
       expect(mockLogger.error).toHaveBeenCalledWith(
         'Failed to execute apply_patch operation:',
-        editor.errors.delete_file,
+        'Error',
       );
     });
 
@@ -3267,6 +3267,51 @@ describe('executeShellActions', () => {
         'toolErrorFormatter threw while formatting approval rejection: formatter failed',
       );
       warnSpy.mockRestore();
+    });
+
+    it('redacts toolErrorFormatter errors when tool-data logging is disabled', async () => {
+      const secret = 'SECRET_FORMATTER_VALUE_123';
+      const constructorGetter = vi.fn(() => {
+        throw new Error('The Error constructor must not be inspected.');
+      });
+      const formatterError = new Error(secret);
+      Object.defineProperty(formatterError, 'constructor', {
+        get: constructorGetter,
+      });
+      const t = makeTool(true);
+      vi.spyOn(state._context, 'isToolApproved').mockReturnValue(false as any);
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(true);
+      const customRunner = new Runner({
+        tracingDisabled: true,
+        toolErrorFormatter: () => {
+          throw formatterError;
+        },
+      });
+
+      try {
+        const result = await withTrace('test', () =>
+          executeFunctionToolCalls(
+            state._currentAgent,
+            [{ toolCall, tool: t }],
+            customRunner,
+            state,
+            customRunner.config.toolErrorFormatter,
+          ),
+        );
+
+        expect(result[0].type).toBe('function_output');
+        expect(warnSpy).toHaveBeenCalledWith(
+          'toolErrorFormatter threw while formatting approval rejection: Error',
+        );
+        expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(secret);
+        expect(constructorGetter).not.toHaveBeenCalled();
+      } finally {
+        flagSpy.mockRestore();
+        warnSpy.mockRestore();
+      }
     });
 
     it('clears pending nested agent run when approval is rejected', async () => {
@@ -4425,7 +4470,7 @@ describe('executeShellActions', () => {
       });
       expect(mockLogger.error).toHaveBeenCalledWith(
         'Failed to execute computer action:',
-        expect.any(Error),
+        'Error',
       );
     });
 

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -3314,6 +3314,52 @@ describe('executeShellActions', () => {
       }
     });
 
+    it('falls back when a redacted toolErrorFormatter throws a hostile Proxy', async () => {
+      const formatterError = new Proxy(
+        {},
+        {
+          getPrototypeOf() {
+            throw new Error('SECRET_PROXY_TRAP_123');
+          },
+        },
+      );
+      const t = makeTool(true);
+      vi.spyOn(state._context, 'isToolApproved').mockReturnValue(false as any);
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(true);
+      const customRunner = new Runner({
+        tracingDisabled: true,
+        toolErrorFormatter: () => {
+          throw formatterError;
+        },
+      });
+
+      try {
+        const result = await withTrace('test', () =>
+          executeFunctionToolCalls(
+            state._currentAgent,
+            [{ toolCall, tool: t }],
+            customRunner,
+            state,
+            customRunner.config.toolErrorFormatter,
+          ),
+        );
+
+        expect(result[0].type).toBe('function_output');
+        if (result[0].type === 'function_output') {
+          expect(result[0].output).toBe('Tool execution was not approved.');
+        }
+        expect(warnSpy).toHaveBeenCalledWith(
+          'toolErrorFormatter threw while formatting approval rejection: object',
+        );
+      } finally {
+        flagSpy.mockRestore();
+        warnSpy.mockRestore();
+      }
+    });
+
     it('clears pending nested agent run when approval is rejected', async () => {
       const t = makeTool(true);
       state.setPendingAgentToolRun(t.name, toolCall.callId, 'pending-state');

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -1,5 +1,9 @@
 import { RuntimeEventEmitter, Usage } from '@openai/agents-core';
 import { normalizeHostedMcpRequireApproval } from '@openai/agents-core/utils';
+import {
+  logModelActionError,
+  logToolActionError,
+} from '@openai/agents-core/utils/internal';
 import type { MessageEvent as WebSocketMessageEvent } from 'ws';
 
 import {
@@ -177,10 +181,7 @@ export abstract class OpenAIRealtimeBase
   }
 
   abstract get status():
-    | 'connected'
-    | 'disconnected'
-    | 'connecting'
-    | 'disconnecting';
+    'connected' | 'disconnected' | 'connecting' | 'disconnecting';
 
   abstract connect(
     options: RealtimeTransportLayerConnectOptions,
@@ -252,7 +253,11 @@ export abstract class OpenAIRealtimeBase
     if (parsed.type === 'response.done') {
       const response = responseDoneEventSchema.safeParse(parsed);
       if (!response.success) {
-        logger.error('Error parsing response done event', response.error);
+        logModelActionError(
+          logger,
+          'Error parsing response done event',
+          response.error,
+        );
         return;
       }
       const inputTokens = response.data.response.usage?.input_tokens ?? 0;
@@ -349,7 +354,12 @@ export abstract class OpenAIRealtimeBase
             tools,
           });
         } catch (err) {
-          logger.error('Error emitting mcp_tools_listed', err, parsed.item);
+          logToolActionError(
+            logger,
+            'Error emitting mcp_tools_listed',
+            err,
+            parsed.item,
+          );
         }
         // We do not add this item to history; it's a transport-level side-channel.
         return;
@@ -898,7 +908,12 @@ export abstract class OpenAIRealtimeBase
       });
       this.emit('item_update', item);
     } catch (error) {
-      logger.error('Error parsing tool call item', error, toolCall);
+      logToolActionError(
+        logger,
+        'Error parsing tool call item',
+        error,
+        toolCall,
+      );
     }
 
     if (startResponse) {

--- a/packages/agents-realtime/src/realtimeSession.ts
+++ b/packages/agents-realtime/src/realtimeSession.ts
@@ -17,8 +17,10 @@ import {
 import { RuntimeEventEmitter } from '@openai/agents-core/_shims';
 import { isZodObject, toSmartString } from '@openai/agents-core/utils';
 import {
+  getSafeErrorType,
   hasDynamicFunctionToolApprovalPolicy,
   hasInspectableFunctionToolArguments,
+  logToolActionError,
 } from '@openai/agents-core/utils/internal';
 import type {
   RealtimeSessionConfig,
@@ -697,8 +699,11 @@ export class RealtimeSession<
         );
       }
     } catch (error) {
+      const errorDetails = logger.dontLogToolData
+        ? getSafeErrorType(error)
+        : toErrorMessage(error);
       logger.warn(
-        `toolErrorFormatter threw while formatting approval rejection: ${toErrorMessage(error)}`,
+        `toolErrorFormatter threw while formatting approval rejection: ${errorDetails}`,
       );
     }
 
@@ -1162,7 +1167,7 @@ export class RealtimeSession<
         }
         await this.#handleFunctionCall(event, dispatchSnapshot);
       } catch (error) {
-        logger.error('Error handling function call', error);
+        logToolActionError(logger, 'Error handling function call', error);
         this.emit('error', {
           type: 'error',
           error,

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -14,6 +14,7 @@ import {
   OpenAIRealtimeBase,
 } from '../src/openaiRealtimeBase';
 import logger from '../src/logger';
+import { responseDoneEventSchema } from '../src/openaiRealtimeEvents';
 
 class TestBase extends OpenAIRealtimeBase {
   status: 'connected' | 'disconnected' | 'connecting' | 'disconnecting' =
@@ -341,6 +342,81 @@ describe('OpenAIRealtimeBase helpers', () => {
 
     expect(logger.error).toHaveBeenCalled();
   });
+
+  it.each([true, false])(
+    'applies tool-data logging policy to malformed function call items (%s)',
+    (redactToolData) => {
+      const secret = 'SECRET_REALTIME_TOOL_VALUE_123';
+      vi.spyOn(logger, 'dontLogToolData', 'get').mockReturnValue(
+        redactToolData,
+      );
+      const base = new TestBase();
+      const toolCall = {
+        type: 'function_call',
+        id: '1',
+        callId: 'c1',
+        name: 'tool',
+        arguments: 123,
+        secret,
+      } as any;
+
+      base.sendFunctionCallOutput(toolCall, secret, false);
+
+      if (redactToolData) {
+        expect(logger.error).toHaveBeenCalledWith(
+          'Error parsing tool call item',
+          'Error',
+        );
+        expect(
+          JSON.stringify(vi.mocked(logger.error).mock.calls),
+        ).not.toContain(secret);
+      } else {
+        expect(logger.error).toHaveBeenCalledWith(
+          'Error parsing tool call item',
+          expect.any(Error),
+          toolCall,
+        );
+      }
+    },
+  );
+
+  it.each([true, false])(
+    'applies model-data logging policy to invalid response events (%s)',
+    (redactModelData) => {
+      const secret = 'SECRET_REALTIME_MODEL_VALUE_123';
+      vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(
+        redactModelData,
+      );
+      vi.spyOn(responseDoneEventSchema, 'safeParse').mockReturnValueOnce({
+        success: false,
+        error: new Error(secret),
+      } as any);
+      const base = new TestBase();
+
+      (base as any)._onMessage({
+        data: JSON.stringify({
+          type: 'response.done',
+          event_id: 'response-invalid',
+          response: { status: 'completed' },
+        }),
+      });
+
+      if (redactModelData) {
+        expect(logger.error).toHaveBeenCalledWith(
+          'Error parsing response done event',
+          'Error',
+        );
+        expect(
+          JSON.stringify(vi.mocked(logger.error).mock.calls),
+        ).not.toContain(secret);
+      } else {
+        expect(logger.error).toHaveBeenCalledWith(
+          'Error parsing response done event',
+          expect.any(Error),
+        );
+      }
+    },
+  );
 
   it('sendAudio optionally commits', () => {
     const base = new TestBase();
@@ -778,6 +854,51 @@ describe('OpenAIRealtimeBase helpers', () => {
       tools: [{ name: 'tool', description: 'desc' }],
     });
   });
+
+  it.each([true, false])(
+    'applies tool-data logging policy when MCP tool events fail (%s)',
+    (redactToolData) => {
+      const secret = 'SECRET_MCP_EVENT_VALUE_123';
+      vi.spyOn(logger, 'dontLogToolData', 'get').mockReturnValue(
+        redactToolData,
+      );
+      const base = new TestBase();
+      base.on('mcp_tools_listed', () => {
+        throw new Error(secret);
+      });
+
+      (base as any)._onMessage({
+        data: JSON.stringify({
+          type: 'conversation.item.done',
+          event_id: 'mcp-secret-event',
+          item: {
+            id: 'tools1',
+            type: 'mcp_list_tools',
+            server_label: 'srv',
+            tools: [{ name: 'tool', description: secret }],
+          },
+        }),
+      });
+
+      if (redactToolData) {
+        expect(logger.error).toHaveBeenCalledWith(
+          'Error emitting mcp_tools_listed',
+          'Error',
+        );
+        expect(
+          JSON.stringify(vi.mocked(logger.error).mock.calls),
+        ).not.toContain(secret);
+      } else {
+        expect(logger.error).toHaveBeenCalledWith(
+          'Error emitting mcp_tools_listed',
+          expect.any(Error),
+          expect.objectContaining({
+            tools: [{ name: 'tool', description: secret }],
+          }),
+        );
+      }
+    },
+  );
 
   it('emits error events when server reports errors', () => {
     const base = new TestBase();

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -1085,6 +1085,63 @@ describe('RealtimeSession', () => {
     },
   );
 
+  it('emits function call errors when a redacted guardrail throws a hostile Proxy', async () => {
+    const guardrailError = new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          throw new Error('SECRET_PROXY_TRAP_123');
+        },
+      },
+    );
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    const flagSpy = vi
+      .spyOn(logger, 'dontLogToolData', 'get')
+      .mockReturnValue(true);
+    const localTransport = new FakeTransport();
+    const guardrail = defineToolInputGuardrail({
+      name: 'throw-hostile-proxy',
+      run: async () => {
+        throw guardrailError;
+      },
+    });
+    const guardedTool = tool({
+      name: 'guarded_hostile_proxy',
+      description: 'guarded tool',
+      parameters: z.object({}),
+      execute: vi.fn(async () => 'never'),
+      inputGuardrails: [guardrail],
+    }) as any;
+    const localSession = new RealtimeSession(
+      new RealtimeAgent({ name: 'A', tools: [guardedTool] }),
+      { transport: localTransport },
+    );
+
+    try {
+      await localSession.connect({ apiKey: 'test' });
+      const errorEvent = waitForEvent<any[]>(localSession, 'error');
+
+      localTransport.emit('function_call', {
+        type: 'function_call',
+        name: 'guarded_hostile_proxy',
+        callId: 'hostile-proxy-call',
+        status: 'completed',
+        arguments: '{}',
+        responseId: 'hostile-proxy-response',
+      } as any);
+
+      const [error] = await errorEvent;
+      expect(error.error).toBe(guardrailError);
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Error handling function call',
+        'object',
+      );
+    } finally {
+      flagSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+
   it('applies output tool guardrail rejectContent and replaces output', async () => {
     const localTransport = new FakeTransport();
     const guardrail = defineToolOutputGuardrail({
@@ -2098,6 +2155,66 @@ describe('RealtimeSession', () => {
       );
       expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(secret);
       expect(constructorGetter).not.toHaveBeenCalled();
+    } finally {
+      flagSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('falls back when a redacted toolErrorFormatter throws a hostile Proxy', async () => {
+    const formatterError = new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          throw new Error('SECRET_PROXY_TRAP_123');
+        },
+      },
+    );
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const flagSpy = vi
+      .spyOn(logger, 'dontLogToolData', 'get')
+      .mockReturnValue(true);
+    const needsApprovalTool = tool({
+      name: 'needs_approval',
+      description: 'Needs approval tool',
+      parameters: z.object({}),
+      needsApproval: true,
+      execute: vi.fn(async () => 'ok'),
+    });
+    const agent = new RealtimeAgent({
+      name: 'ApprovalAgent',
+      handoffs: [],
+      tools: [needsApprovalTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+      toolErrorFormatter: () => {
+        throw formatterError;
+      },
+    });
+
+    try {
+      await localSession.connect({ apiKey: 'test' });
+      const toolCall: TransportToolCallEvent = {
+        type: 'function_call',
+        name: 'needs_approval',
+        callId: 'call-hostile-formatter',
+        arguments: '{}',
+        responseId: 'approval-hostile-formatter-response',
+      };
+      localSession.context.rejectTool(
+        new RunToolApprovalItem(toolCall as any, agent),
+      );
+      const outputPromise = localTransport.waitForNextFunctionCallOutput();
+
+      localTransport.emit('function_call', toolCall as any);
+      const [, output] = await outputPromise;
+
+      expect(output).toBe('Tool execution was not approved.');
+      expect(warnSpy).toHaveBeenCalledWith(
+        'toolErrorFormatter threw while formatting approval rejection: object',
+      );
     } finally {
       flagSpy.mockRestore();
       warnSpy.mockRestore();

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -1025,6 +1025,66 @@ describe('RealtimeSession', () => {
     errorSpy.mockRestore();
   });
 
+  it.each([true, false])(
+    'applies tool-data logging policy to function call failures (%s)',
+    async (redactToolData) => {
+      const secret = 'SECRET_REALTIME_FUNCTION_VALUE_123';
+      const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(redactToolData);
+      const localTransport = new FakeTransport();
+      const guardrail = defineToolInputGuardrail({
+        name: 'throw-secret',
+        run: async () => {
+          throw new Error(secret);
+        },
+      });
+      const guardedTool = tool({
+        name: 'guarded_secret',
+        description: 'guarded tool',
+        parameters: z.object({}),
+        execute: vi.fn(async () => 'never'),
+        inputGuardrails: [guardrail],
+      }) as any;
+      const localSession = new RealtimeSession(
+        new RealtimeAgent({ name: 'A', tools: [guardedTool] }),
+        { transport: localTransport },
+      );
+
+      try {
+        await localSession.connect({ apiKey: 'test' });
+        const errorEvent = waitForEvent<any[]>(localSession, 'error');
+
+        localTransport.emit('function_call', {
+          type: 'function_call',
+          name: 'guarded_secret',
+          callId: 'secret-call',
+          status: 'completed',
+          arguments: '{}',
+          responseId: 'secret-response',
+        } as any);
+        await errorEvent;
+
+        if (redactToolData) {
+          expect(errorSpy).toHaveBeenCalledWith(
+            'Error handling function call',
+            'Error',
+          );
+          expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(secret);
+        } else {
+          expect(errorSpy).toHaveBeenCalledWith(
+            'Error handling function call',
+            expect.any(Error),
+          );
+        }
+      } finally {
+        flagSpy.mockRestore();
+        errorSpy.mockRestore();
+      }
+    },
+  );
+
   it('applies output tool guardrail rejectContent and replaces output', async () => {
     const localTransport = new FakeTransport();
     const guardrail = defineToolOutputGuardrail({
@@ -1980,6 +2040,68 @@ describe('RealtimeSession', () => {
       'toolErrorFormatter threw while formatting approval rejection: formatter failed',
     );
     warnSpy.mockRestore();
+  });
+
+  it('redacts toolErrorFormatter failures when tool-data logging is disabled', async () => {
+    const secret = 'SECRET_REALTIME_FORMATTER_VALUE_123';
+    const constructorGetter = vi.fn(() => {
+      throw new Error('The Error constructor must not be inspected.');
+    });
+    const formatterError = new Error(secret);
+    Object.defineProperty(formatterError, 'constructor', {
+      get: constructorGetter,
+    });
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const flagSpy = vi
+      .spyOn(logger, 'dontLogToolData', 'get')
+      .mockReturnValue(true);
+    const needsApprovalTool = tool({
+      name: 'needs_approval',
+      description: 'Needs approval tool',
+      parameters: z.object({}),
+      needsApproval: true,
+      execute: vi.fn(async () => 'ok'),
+    });
+    const agent = new RealtimeAgent({
+      name: 'ApprovalAgent',
+      handoffs: [],
+      tools: [needsApprovalTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+      toolErrorFormatter: () => {
+        throw formatterError;
+      },
+    });
+
+    try {
+      await localSession.connect({ apiKey: 'test' });
+      const toolCall: TransportToolCallEvent = {
+        type: 'function_call',
+        name: 'needs_approval',
+        callId: 'call-redacted-formatter',
+        arguments: '{}',
+        responseId: 'approval-redacted-formatter-response',
+      };
+      localSession.context.rejectTool(
+        new RunToolApprovalItem(toolCall as any, agent),
+      );
+      const outputPromise = localTransport.waitForNextFunctionCallOutput();
+
+      localTransport.emit('function_call', toolCall as any);
+      const [, output] = await outputPromise;
+
+      expect(output).toBe('Tool execution was not approved.');
+      expect(warnSpy).toHaveBeenCalledWith(
+        'toolErrorFormatter threw while formatting approval rejection: Error',
+      );
+      expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(secret);
+      expect(constructorGetter).not.toHaveBeenCalled();
+    } finally {
+      flagSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
   });
 
   it('uses reject message from session.reject when provided', async () => {


### PR DESCRIPTION
This pull request fixes logging paths that exposed raw exception messages, stacks, tool arguments, and Realtime event payloads even when sensitive-data logging was disabled. Core tool execution, approval rejection formatting, Realtime function handling, MCP events, and model event errors now log only safe error types when their respective redaction flags are enabled, while preserving existing defaults and full diagnostic output when logging is explicitly permitted.