### PR TITLE
fix: preserve assistant message phases across Responses history and replay

### DIFF
--- a/.changeset/cool-phases-persist.md
+++ b/.changeset/cool-phases-persist.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+---
+
+fix: preserve assistant message phases across Responses history and replay

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -94,7 +94,8 @@ import {
  * - 1.11: Allows null maxTurns to persist runs without a turn limit.
  * - 1.12: Adds optional missing function tool calls to processed responses.
  * - 1.13: Adds optional SDK-only customData on tool output run items.
- * - 1.14: Adds Programmatic Tool Calling program items, outputs, and caller linkage.
+ * - 1.14: Adds Programmatic Tool Calling program items, outputs, caller linkage,
+ *   and optional assistant message phases.
  */
 export const CURRENT_SCHEMA_VERSION = '1.14' as const;
 const SUPPORTED_SCHEMA_VERSIONS = [

--- a/packages/agents-core/src/types/protocol.ts
+++ b/packages/agents-core/src/types/protocol.ts
@@ -379,6 +379,11 @@ export const AssistantMessageItem = MessageBase.extend({
   role: z.literal('assistant'),
 
   /**
+   * Whether this assistant message is intermediate commentary or a final answer.
+   */
+  phase: z.enum(['commentary', 'final_answer']).optional(),
+
+  /**
    * The status of the message.
    */
   status: z.enum(['in_progress', 'completed', 'incomplete']),

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -169,6 +169,51 @@ describe('RunState', () => {
     expect(restored.history).toEqual(state.history);
   });
 
+  it.each(['commentary', 'final_answer'] as const)(
+    'preserves assistant phase "%s" across history and serialized model responses',
+    async (phase) => {
+      const context = new RunContext();
+      const agent = new Agent({ name: 'AssistantPhaseAgent' });
+      const state = new RunState(context, 'input', agent, 1);
+      const message: protocol.AssistantMessageItem = {
+        ...TEST_MODEL_MESSAGE,
+        phase,
+      };
+      state._generatedItems.push(new RunMessageOutputItem(message, agent));
+      state._modelResponses = [
+        {
+          usage: new Usage(),
+          output: [message],
+          responseId: 'response-phase',
+        },
+      ];
+
+      const restored = await RunState.fromString(agent, state.toString());
+
+      expect(restored.history[1]).toMatchObject({ phase });
+      expect(restored._generatedItems[0]?.rawItem).toMatchObject({ phase });
+      expect(restored._modelResponses[0]?.output[0]).toMatchObject({ phase });
+      expect(restored.toJSON().$schemaVersion).toBe('1.14');
+    },
+  );
+
+  it('rejects invalid assistant message phases when restoring run state', async () => {
+    const agent = new Agent({ name: 'InvalidAssistantPhaseAgent' });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    state._generatedItems.push(
+      new RunMessageOutputItem(
+        { ...TEST_MODEL_MESSAGE, phase: 'commentary' },
+        agent,
+      ),
+    );
+    const serialized = state.toJSON();
+    (serialized.generatedItems[0]?.rawItem as any).phase = 'invalid';
+
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow();
+  });
+
   it('preserves reasoningItemIdPolicy after serialization', async () => {
     const context = new RunContext();
     const agent = new Agent({ name: 'ReasoningPolicyState' });

--- a/packages/agents-core/test/runner/sessionPersistence.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.test.ts
@@ -1331,6 +1331,7 @@ describe('prepareInputItemsWithSession', () => {
       type: 'message',
       role: 'assistant',
       status: 'completed',
+      phase: 'commentary',
       content: [
         {
           type: 'output_text',
@@ -1370,6 +1371,7 @@ describe('prepareInputItemsWithSession', () => {
         type: 'message',
         role: 'assistant',
         status: 'completed',
+        phase: 'commentary',
         content: [
           {
             type: 'output_text',

--- a/packages/agents-openai/src/memory/openaiConversationsSession.ts
+++ b/packages/agents-openai/src/memory/openaiConversationsSession.ts
@@ -331,10 +331,19 @@ function stripAssistantReplayMetadata(item: AgentInputItem): AgentInputItem {
 
   const {
     id: _id,
-    providerData: _providerData,
+    providerData,
     provider_data: _provider_data,
     ...rest
   } = record;
+  if (
+    typeof rest.phase === 'undefined' &&
+    providerData &&
+    typeof providerData === 'object' &&
+    !Array.isArray(providerData) &&
+    typeof (providerData as Record<string, unknown>).phase !== 'undefined'
+  ) {
+    rest.phase = (providerData as Record<string, unknown>).phase;
+  }
   return rest as AgentInputItem;
 }
 

--- a/packages/agents-openai/src/openaiChatCompletionsConverter.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsConverter.ts
@@ -310,6 +310,21 @@ export function itemsToMessages(
       const { content, role, providerData } = item;
       flushAssistantMessage();
       if (role === 'assistant') {
+        const phase = item.phase ?? providerData?.phase;
+        if (typeof phase !== 'undefined' && phase !== null) {
+          if (phase !== 'commentary' && phase !== 'final_answer') {
+            throw new UserError(
+              `Invalid assistant message phase: ${JSON.stringify(phase)}. Expected "commentary" or "final_answer".`,
+            );
+          }
+
+          const message =
+            'Assistant message phase is not supported by the Chat Completions API. Use the Responses API to preserve assistant message phases.';
+          if (options.strictFeatureValidation) {
+            throw new UserError(message);
+          }
+          logger.warn(`${message} The phase will be dropped.`);
+        }
         const assistant: ChatCompletionAssistantMessageParam = {
           role: 'assistant',
           content: extractAllAssistantContent(content),
@@ -318,6 +333,7 @@ export function itemsToMessages(
             'content',
             'tool_calls',
             'audio',
+            'phase',
           ]),
         };
 
@@ -339,6 +355,7 @@ export function itemsToMessages(
           ...getProviderDataWithoutReservedKeys(providerData, [
             'role',
             'content',
+            'phase',
           ]),
         });
       } else if (role === 'system') {
@@ -348,6 +365,7 @@ export function itemsToMessages(
           ...getProviderDataWithoutReservedKeys(providerData, [
             'role',
             'content',
+            'phase',
           ]),
         });
       }

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -1984,6 +1984,7 @@ function getMessageItem(
         'id',
         'role',
         'content',
+        'phase',
       ]),
     };
   }
@@ -1998,6 +1999,7 @@ function getMessageItem(
           'id',
           'role',
           'content',
+          'phase',
         ]),
       };
     }
@@ -2010,23 +2012,37 @@ function getMessageItem(
         'id',
         'role',
         'content',
+        'phase',
       ]),
     };
   }
 
   if (item.role === 'assistant') {
+    const phase =
+      item.phase ?? getProviderDataField<unknown>(item.providerData, ['phase']);
+    if (
+      typeof phase !== 'undefined' &&
+      phase !== 'commentary' &&
+      phase !== 'final_answer'
+    ) {
+      throw new UserError(
+        `Invalid assistant message phase: ${JSON.stringify(phase)}. Expected "commentary" or "final_answer".`,
+      );
+    }
     const assistantMessage: OpenAI.Responses.ResponseOutputMessage = {
       type: 'message',
       id: item.id!,
       role: 'assistant',
       content: item.content.map(getOutputMessageContent),
       status: item.status,
+      ...(typeof phase === 'undefined' ? {} : { phase }),
       ...getSnakeCasedProviderDataWithoutReservedKeys(item.providerData, [
         'type',
         'id',
         'role',
         'content',
         'status',
+        'phase',
       ]),
     };
     return assistantMessage;
@@ -2696,14 +2712,22 @@ function convertToOutputItem(
 ): protocol.OutputModelItem[] {
   return items.map((item) => {
     if (item.type === 'message') {
-      const { id, type, role, content, status, ...providerData } = item;
+      const { id, type, role, content, status, phase, ...providerData } = item;
       return {
         id,
         type,
         role,
         content: content.map(convertToMessageContentItem),
         status,
-        providerData,
+        ...(phase === 'commentary' || phase === 'final_answer'
+          ? { phase }
+          : {}),
+        providerData: {
+          ...providerData,
+          ...(phase === 'commentary' || phase === 'final_answer'
+            ? { phase }
+            : {}),
+        },
       };
     } else if (item.type === 'tool_search_call') {
       const {

--- a/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
@@ -492,6 +492,119 @@ describe('itemsToMessages', () => {
     ]);
   });
 
+  test.each(['commentary', 'final_answer'] as const)(
+    'warns before dropping unsupported assistant phase "%s"',
+    (phase) => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      const items: protocol.ModelItem[] = [
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          phase,
+          content: [{ type: 'output_text', text: 'assistant reply' }],
+        },
+      ];
+
+      try {
+        expect(itemsToMessages(items)).toEqual([
+          {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'assistant reply' }],
+          },
+        ]);
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Assistant message phase is not supported'),
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    },
+  );
+
+  test('rejects unsupported assistant phases in strict validation mode', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        phase: 'commentary',
+        content: [{ type: 'output_text', text: 'assistant reply' }],
+      },
+    ];
+
+    expect(() =>
+      itemsToMessages(items, { strictFeatureValidation: true }),
+    ).toThrow(UserError);
+    expect(() =>
+      itemsToMessages(items, { strictFeatureValidation: true }),
+    ).toThrow('Use the Responses API to preserve assistant message phases.');
+  });
+
+  test('detects and removes assistant phases stored in legacy providerData', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'assistant reply' }],
+        providerData: { phase: 'commentary', custom: 'keep' },
+      },
+    ];
+
+    try {
+      expect(itemsToMessages(items)).toEqual([
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'assistant reply' }],
+          custom: 'keep',
+        },
+      ]);
+      expect(warnSpy).toHaveBeenCalledOnce();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test('rejects invalid assistant phases in Chat Completions conversion', () => {
+    const items = [
+      {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        phase: 'invalid',
+        content: [{ type: 'output_text', text: 'assistant reply' }],
+      },
+    ] as any;
+
+    expect(() => itemsToMessages(items)).toThrow(
+      'Invalid assistant message phase: "invalid". Expected "commentary" or "final_answer".',
+    );
+  });
+
+  test('does not forward assistant-only phase metadata on other message roles', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'message',
+        role: 'system',
+        content: 'instructions',
+        providerData: { phase: 'commentary', custom: 'keep-system' },
+      },
+      {
+        type: 'message',
+        role: 'user',
+        content: 'input',
+        providerData: { phase: 'final_answer', custom: 'keep-user' },
+      },
+    ];
+
+    expect(itemsToMessages(items)).toEqual([
+      { role: 'system', content: 'instructions', custom: 'keep-system' },
+      { role: 'user', content: 'input', custom: 'keep-user' },
+    ]);
+  });
+
   test('handles function call and result path', () => {
     const items: protocol.ModelItem[] = [
       {

--- a/packages/agents-openai/test/openaiConversationsSession.test.ts
+++ b/packages/agents-openai/test/openaiConversationsSession.test.ts
@@ -515,6 +515,7 @@ describe('OpenAIConversationsSession', () => {
       type: 'message',
       role: 'assistant',
       content: [],
+      phase: 'commentary',
       providerData: { server: 'metadata' },
       provider_data: { server: 'snake' },
     };
@@ -538,6 +539,41 @@ describe('OpenAIConversationsSession', () => {
       type: 'message',
       role: 'assistant',
       content: [],
+      phase: 'commentary',
+    });
+  });
+
+  it('preserves legacy assistant phases when stripping replay metadata', () => {
+    const session = createSession({
+      client: {
+        conversations: {
+          items: {
+            list: vi.fn(),
+            create: vi.fn(),
+            delete: vi.fn(),
+          },
+          create: vi.fn(),
+          delete: vi.fn(),
+        },
+      } as any,
+      conversationId: 'conv-123',
+    });
+
+    expect(
+      session.prepareHistoryItemForModelInput({
+        id: 'conv-assistant',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [],
+        providerData: { phase: 'final_answer', ignored: 'metadata' },
+      } as any),
+    ).toEqual({
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [],
+      phase: 'final_answer',
     });
   });
 

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -127,6 +127,174 @@ describe('OpenAIResponsesModel', () => {
     });
   });
 
+  it.each(['commentary', 'final_answer'] as const)(
+    'preserves assistant message phase "%s" in requests and responses',
+    async (phase) => {
+      const fakeResponse = {
+        id: 'res-phase',
+        usage: {},
+        output: [
+          {
+            id: 'assistant-output',
+            type: 'message',
+            status: 'completed',
+            role: 'assistant',
+            phase,
+            content: [{ type: 'output_text', text: 'response' }],
+          },
+        ],
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const model = new OpenAIResponsesModel(
+        { responses: { create: createMock } } as unknown as OpenAI,
+        'gpt-test',
+      );
+
+      const result = await withTrace('assistant-phase', () =>
+        model.getResponse({
+          input: [
+            {
+              type: 'message',
+              id: 'assistant-input',
+              role: 'assistant',
+              status: 'completed',
+              phase,
+              content: [{ type: 'output_text', text: 'previous reply' }],
+              providerData: {
+                phase: phase === 'commentary' ? 'final_answer' : 'commentary',
+                customMetadata: 'keep',
+              },
+            },
+          ],
+          modelSettings: {},
+          tools: [],
+          outputType: 'text',
+          handoffs: [],
+          tracing: false,
+        } as any),
+      );
+
+      expect(createMock.mock.calls[0][0].input[0]).toMatchObject({
+        role: 'assistant',
+        phase,
+        custom_metadata: 'keep',
+      });
+      expect(result.output[0]).toMatchObject({ phase });
+      expect(result.output[0]?.providerData).toMatchObject({ phase });
+    },
+  );
+
+  it('preserves assistant phases stored in legacy providerData', async () => {
+    const createMock = vi.fn().mockResolvedValue({
+      id: 'res-legacy-phase',
+      usage: {},
+      output: [],
+    });
+    const model = new OpenAIResponsesModel(
+      { responses: { create: createMock } } as unknown as OpenAI,
+      'gpt-test',
+    );
+
+    await withTrace('assistant-legacy-phase', () =>
+      model.getResponse({
+        input: [
+          {
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [{ type: 'output_text', text: 'previous reply' }],
+            providerData: { phase: 'commentary' },
+          },
+        ],
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+      } as any),
+    );
+
+    expect(createMock.mock.calls[0][0].input[0]).toHaveProperty(
+      'phase',
+      'commentary',
+    );
+  });
+
+  it('does not send assistant-only phases on user or system messages', async () => {
+    const createMock = vi.fn().mockResolvedValue({
+      id: 'res-user-phase',
+      usage: {},
+      output: [],
+    });
+    const model = new OpenAIResponsesModel(
+      { responses: { create: createMock } } as unknown as OpenAI,
+      'gpt-test',
+    );
+
+    await withTrace('non-assistant-phase', () =>
+      model.getResponse({
+        input: [
+          {
+            type: 'message',
+            role: 'system',
+            content: 'instructions',
+            providerData: { phase: 'commentary', customFlag: true },
+          },
+          {
+            type: 'message',
+            role: 'user',
+            content: 'user input',
+            providerData: { phase: 'final_answer', customFlag: true },
+          },
+        ],
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+      } as any),
+    );
+
+    expect(createMock.mock.calls[0][0].input).toEqual([
+      expect.objectContaining({ role: 'system', custom_flag: true }),
+      expect.objectContaining({ role: 'user', custom_flag: true }),
+    ]);
+    expect(createMock.mock.calls[0][0].input[0]).not.toHaveProperty('phase');
+    expect(createMock.mock.calls[0][0].input[1]).not.toHaveProperty('phase');
+  });
+
+  it('rejects invalid assistant message phases before making a request', async () => {
+    const createMock = vi.fn();
+    const model = new OpenAIResponsesModel(
+      { responses: { create: createMock } } as unknown as OpenAI,
+      'gpt-test',
+    );
+
+    await expect(
+      withTrace('assistant-invalid-phase', () =>
+        model.getResponse({
+          input: [
+            {
+              type: 'message',
+              role: 'assistant',
+              status: 'completed',
+              phase: 'invalid',
+              content: [{ type: 'output_text', text: 'previous reply' }],
+            },
+          ],
+          modelSettings: {},
+          tools: [],
+          outputType: 'text',
+          handoffs: [],
+          tracing: false,
+        } as any),
+      ),
+    ).rejects.toThrow(
+      'Invalid assistant message phase: "invalid". Expected "commentary" or "final_answer".',
+    );
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
   it('getRetryAdvice does not suggest retries from transport heuristics alone', () => {
     const fakeClient = {
       responses: { create: vi.fn() },
@@ -4182,6 +4350,7 @@ describe('OpenAIResponsesModel', () => {
                 status: 'completed',
                 content: [{ type: 'output_text', text: 'delta' }],
                 role: 'assistant',
+                phase: 'commentary',
               },
             ],
             usage: {},
@@ -4265,7 +4434,13 @@ describe('OpenAIResponsesModel', () => {
       expect(textDelta).toMatchObject({ itemId: 'item-1' });
       expect(completed).toMatchObject({
         response: {
-          output: [expect.objectContaining({ type: 'message', id: 'item-1' })],
+          output: [
+            expect.objectContaining({
+              type: 'message',
+              id: 'item-1',
+              phase: 'commentary',
+            }),
+          ],
         },
       });
     });


### PR DESCRIPTION
This pull request preserves assistant message phase values across Responses API requests, streamed and non-streamed outputs, serialized run state, and conversation history replay. It maintains compatibility with existing providerData-based phase consumers, prevents phase from being forwarded on non-assistant messages, and warns or raises an error when Chat Completions cannot represent the requested phase.