### PR TITLE
fix: distinguish missing sandbox paths from inaccessible files

### DIFF
--- a/.changeset/sandbox-path-probe-errors.md
+++ b/.changeset/sandbox-path-probe-errors.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-extensions': patch
+---
+
+fix: distinguish missing sandbox paths from inaccessible files and provider failures

--- a/packages/agents-core/src/sandbox/capabilities/skills.ts
+++ b/packages/agents-core/src/sandbox/capabilities/skills.ts
@@ -14,6 +14,7 @@ import {
 } from '../entries';
 import { SandboxSkillsConfigError } from '../errors';
 import { normalizeRelativePath, type Manifest } from '../manifest';
+import { isSandboxPathNotFoundError } from '../shared/pathProbe';
 import { prompt } from '../runtime/prompts';
 import type { MaterializeEntryArgs } from '../session';
 import { Capability, requireBoundSession } from './base';
@@ -223,8 +224,11 @@ class SkillsCapability extends Capability {
         path: this.skillsPath,
         runAs: this._runAs,
       });
-    } catch {
-      return [];
+    } catch (error) {
+      if (isSandboxPathNotFoundError(error)) {
+        return [];
+      }
+      throw error;
     }
 
     const metadata: SkillIndexEntry[] = [];
@@ -239,8 +243,11 @@ class SkillsCapability extends Capability {
           path: joinRelativePaths(entry.path, 'SKILL.md'),
           runAs: this._runAs,
         });
-      } catch {
-        continue;
+      } catch (error) {
+        if (isSandboxPathNotFoundError(error)) {
+          continue;
+        }
+        throw error;
       }
 
       const markdown =

--- a/packages/agents-core/src/sandbox/internal.ts
+++ b/packages/agents-core/src/sandbox/internal.ts
@@ -39,6 +39,11 @@ export {
 } from './shared/environment';
 export { shellQuote } from './shared/shell';
 export {
+  isSandboxPathNotFoundError,
+  probeSandboxPathExists,
+  type SandboxPathProbeResult,
+} from './shared/pathProbe';
+export {
   isRecord,
   isStringRecord,
   readOptionalBoolean,

--- a/packages/agents-core/src/sandbox/sandboxes/docker.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/docker.ts
@@ -10,6 +10,7 @@ import {
   SandboxConfigurationError,
   SandboxMountError,
   SandboxUnsupportedFeatureError,
+  SandboxWorkspaceReadNotFoundError,
 } from '../errors';
 import { chmod, mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { createHash, randomUUID } from 'node:crypto';
@@ -529,12 +530,34 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
   }
 
   async readDockerFileAs(path: string, runAs?: string): Promise<Uint8Array> {
-    const output = await this.runCheckedDockerFilesystemCommand(
+    const result = await this.runDockerFilesystemCommand(
       `base64 -- ${shellQuote(path)}`,
       { runAs },
-      `read file ${path}`,
     );
-    return Buffer.from(output.replace(/\s+/gu, ''), 'base64');
+    if (result.status !== 0) {
+      if (
+        result.status === 1 &&
+        !result.timedOut &&
+        !result.signal &&
+        !result.error
+      ) {
+        const exists = await probeSandboxPathExists({
+          path,
+          runCommand: async (command) =>
+            await this.runDockerFilesystemCommand(command, { runAs }),
+        });
+        if (!exists) {
+          throw new SandboxWorkspaceReadNotFoundError(
+            `DockerSandboxClient file does not exist: ${path}`,
+            { path },
+          );
+        }
+      }
+      throw new UserError(
+        `DockerSandboxClient failed to read file ${path}: ${formatSandboxProcessError(result)}`,
+      );
+    }
+    return Buffer.from(result.stdout.replace(/\s+/gu, ''), 'base64');
   }
 
   async writeDockerTextFileAs(

--- a/packages/agents-core/src/sandbox/sandboxes/docker.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/docker.ts
@@ -194,12 +194,13 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
       return await super.listDir(args);
     }
     const absolutePath = this.resolveContainerFilesystemPath(args.path);
-    const output = await this.runCheckedDockerFilesystemCommand(
+    const output = await this.runReadableDockerFilesystemCommand(
       [
         `find ${shellQuote(absolutePath)} -mindepth 1 -maxdepth 1 -printf '%y\\t%f\\n'`,
       ].join(' && '),
       { runAs: args.runAs },
       `list directory ${absolutePath}`,
+      absolutePath,
     );
     const logicalPath = this.resolveLogicalPath(args.path);
     return output
@@ -530,10 +531,22 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
   }
 
   async readDockerFileAs(path: string, runAs?: string): Promise<Uint8Array> {
-    const result = await this.runDockerFilesystemCommand(
+    const output = await this.runReadableDockerFilesystemCommand(
       `base64 -- ${shellQuote(path)}`,
       { runAs },
+      `read file ${path}`,
+      path,
     );
+    return Buffer.from(output.replace(/\s+/gu, ''), 'base64');
+  }
+
+  private async runReadableDockerFilesystemCommand(
+    command: string,
+    options: { runAs?: string },
+    action: string,
+    path: string,
+  ): Promise<string> {
+    const result = await this.runDockerFilesystemCommand(command, options);
     if (result.status !== 0) {
       if (
         result.status === 1 &&
@@ -544,20 +557,20 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
         const exists = await probeSandboxPathExists({
           path,
           runCommand: async (command) =>
-            await this.runDockerFilesystemCommand(command, { runAs }),
+            await this.runDockerFilesystemCommand(command, options),
         });
         if (!exists) {
           throw new SandboxWorkspaceReadNotFoundError(
-            `DockerSandboxClient file does not exist: ${path}`,
+            `DockerSandboxClient path does not exist: ${path}`,
             { path },
           );
         }
       }
       throw new UserError(
-        `DockerSandboxClient failed to read file ${path}: ${formatSandboxProcessError(result)}`,
+        `DockerSandboxClient failed to ${action}: ${formatSandboxProcessError(result)}`,
       );
     }
-    return Buffer.from(result.stdout.replace(/\s+/gu, ''), 'base64');
+    return result.stdout;
   }
 
   async writeDockerTextFileAs(

--- a/packages/agents-core/src/sandbox/sandboxes/docker.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/docker.ts
@@ -93,6 +93,7 @@ import {
 } from './shared/runProcess';
 import { resolveFallbackShellCommand } from './shared/shellCommand';
 import { shellQuote } from '../shared/shell';
+import { probeSandboxPathExists } from '../shared/pathProbe';
 import {
   deserializeLocalSandboxSessionStateValues,
   normalizeExposedPorts,
@@ -163,11 +164,12 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
     if (!runAs && !this.pathRequiresDockerFilesystem(path)) {
       return await super.pathExists(path);
     }
-    const result = await this.runDockerFilesystemCommand(
-      `test -e ${shellQuote(this.resolveContainerFilesystemPath(path))}`,
-      { runAs },
-    );
-    return result.status === 0;
+    const absolutePath = this.resolveContainerFilesystemPath(path);
+    return await probeSandboxPathExists({
+      path: absolutePath,
+      runCommand: async (command) =>
+        await this.runDockerFilesystemCommand(command, { runAs }),
+    });
   }
 
   override async readFile(args: ReadFileArgs): Promise<Uint8Array> {

--- a/packages/agents-core/src/sandbox/sandboxes/shared/localWorkspace.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/localWorkspace.ts
@@ -40,6 +40,7 @@ import {
   isHostPathStrictlyWithinRoot,
   relativeHostPathEscapesRoot,
 } from '../../shared/hostPath';
+import { isSandboxPathNotFoundError } from '../../shared/pathProbe';
 
 const GIT_VERSION_TIMEOUT_MS = 10_000;
 const GIT_CLONE_TIMEOUT_MS = 5 * 60_000;
@@ -263,7 +264,12 @@ export async function applyOwnershipRecursive(
   uid: number,
   gid: number,
 ): Promise<void> {
-  const info = await lstat(targetPath).catch(() => null);
+  const info = await lstat(targetPath).catch((error: unknown) => {
+    if (isSandboxPathNotFoundError(error)) {
+      return null;
+    }
+    throw error;
+  });
   if (!info) {
     return;
   }
@@ -288,8 +294,23 @@ export async function pathExists(path: string): Promise<boolean> {
   try {
     await stat(path);
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    if (!isSandboxPathNotFoundError(error)) {
+      throw error;
+    }
+    let info: Stats;
+    try {
+      info = await lstat(path);
+    } catch (probeError) {
+      if (isSandboxPathNotFoundError(probeError)) {
+        return false;
+      }
+      throw probeError;
+    }
+    if (info.isSymbolicLink()) {
+      return false;
+    }
+    throw error;
   }
 }
 

--- a/packages/agents-core/src/sandbox/sandboxes/shared/localWorkspace.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/localWorkspace.ts
@@ -308,9 +308,17 @@ export async function pathExists(path: string): Promise<boolean> {
       throw probeError;
     }
     if (info.isSymbolicLink()) {
-      return false;
+      try {
+        await stat(path);
+        return true;
+      } catch (retryError) {
+        if (isSandboxPathNotFoundError(retryError)) {
+          return false;
+        }
+        throw retryError;
+      }
     }
-    throw error;
+    return true;
   }
 }
 

--- a/packages/agents-core/src/sandbox/shared/pathProbe.ts
+++ b/packages/agents-core/src/sandbox/shared/pathProbe.ts
@@ -23,8 +23,10 @@ const READ_PATH_PROBE_SCRIPT = `
 # OPENAI_AGENTS_READ_PATH_PROBE_V1
 LC_ALL=C
 export LC_ALL
+original_path=$path
 resolved_path=
 symlink_depth=0
+lookup_retries=0
 
 resolve_probe_path() {
   if [ "$symlink_depth" -gt 40 ] || [ "\${#1}" -gt 4095 ]; then
@@ -88,6 +90,19 @@ while :; do
     )
     lookup_status=\${lookup_result##*.}
     lookup_error=\${lookup_result%.*}
+    if [ "$lookup_status" -eq 0 ]; then
+      if [ "$lookup_retries" -ge 1 ]; then
+        exit 2
+      fi
+      lookup_retries=$((lookup_retries + 1))
+      resolved_path=
+      symlink_depth=0
+      resolve_probe_path "$original_path" || exit 2
+      path=$resolved_path
+      candidate=$path
+      child=
+      continue
+    fi
     if [ "$lookup_status" -eq 1 ]; then
       lookup_error=$(printf %s "$lookup_error")
       case "$lookup_error" in

--- a/packages/agents-core/src/sandbox/shared/pathProbe.ts
+++ b/packages/agents-core/src/sandbox/shared/pathProbe.ts
@@ -184,9 +184,12 @@ function isMissingPathDiagnostic(diagnostic: string, path: string): boolean {
     return false;
   }
   const escapedPath = path.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+  const pathExpression = `(?:["'\\x60])?${escapedPath}(?:["'\\x60])?`;
+  const missingExpression =
+    '(?:no such file or directory|not found|does not exist|missing(?: path| file)?)';
   return new RegExp(
-    `(?:^|[\\s"'\\x60])${escapedPath}(?:$|[\\s"':\\x60])`,
-    'u',
+    `(?:${pathExpression}\\s*:\\s*${missingExpression}|${pathExpression}\\s+(?:was\\s+)?${missingExpression}|${missingExpression}\\s*:?\\s*${pathExpression})(?:$|[\\s.;])`,
+    'iu',
   ).test(diagnostic);
 }
 

--- a/packages/agents-core/src/sandbox/shared/pathProbe.ts
+++ b/packages/agents-core/src/sandbox/shared/pathProbe.ts
@@ -139,10 +139,12 @@ export async function probeSandboxPathExists(
     throw createPathProbeError(options, initial);
   }
   if (diagnostic.length > 0) {
-    if (isMissingPathDiagnostic(diagnostic)) {
+    if (isMissingPathDiagnostic(diagnostic, options.path)) {
       return false;
     }
-    throw createPathProbeError(options, initial);
+    if (!hasMissingPathDiagnostic(diagnostic)) {
+      throw createPathProbeError(options, initial);
+    }
   }
 
   const result = await options.runCommand(
@@ -155,7 +157,7 @@ export async function probeSandboxPathExists(
     const probeDiagnostic = pathProbeDiagnostic(result);
     if (
       (!result.stdout?.trim() && probeDiagnostic.length === 0) ||
-      isMissingPathDiagnostic(probeDiagnostic)
+      isMissingPathDiagnostic(probeDiagnostic, options.path)
     ) {
       return false;
     }
@@ -171,10 +173,21 @@ function pathProbeDiagnostic(result: SandboxPathProbeResult): string {
   return result.stderr?.trim() ?? '';
 }
 
-function isMissingPathDiagnostic(diagnostic: string): boolean {
+function hasMissingPathDiagnostic(diagnostic: string): boolean {
   return /(?:no such file or directory|not found|does not exist|missing(?: path| file)?)/iu.test(
     diagnostic,
   );
+}
+
+function isMissingPathDiagnostic(diagnostic: string, path: string): boolean {
+  if (!hasMissingPathDiagnostic(diagnostic)) {
+    return false;
+  }
+  const escapedPath = path.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+  return new RegExp(
+    `(?:^|[\\s"'\\x60])${escapedPath}(?:$|[\\s"':\\x60])`,
+    'u',
+  ).test(diagnostic);
 }
 
 function createPathProbeError(

--- a/packages/agents-core/src/sandbox/shared/pathProbe.ts
+++ b/packages/agents-core/src/sandbox/shared/pathProbe.ts
@@ -1,0 +1,199 @@
+import {
+  SandboxWorkspaceArchiveReadError,
+  SandboxWorkspaceReadNotFoundError,
+} from '../errors';
+import { shellQuote } from './shell';
+
+export type SandboxPathProbeResult = {
+  status: number | null;
+  stdout?: string;
+  stderr?: string;
+  signal?: string | null;
+  timedOut?: boolean;
+  error?: Error;
+};
+
+type SandboxPathProbeOptions = {
+  path: string;
+  runCommand: (command: string) => Promise<SandboxPathProbeResult>;
+  createError?: (result: SandboxPathProbeResult) => Error;
+};
+
+const READ_PATH_PROBE_SCRIPT = `
+# OPENAI_AGENTS_READ_PATH_PROBE_V1
+LC_ALL=C
+export LC_ALL
+resolved_path=
+symlink_depth=0
+
+resolve_probe_path() {
+  if [ "$symlink_depth" -gt 40 ] || [ "\${#1}" -gt 4095 ]; then
+    return 2
+  fi
+  if [ "$1" = / ]; then
+    resolved_path=/
+    return 0
+  fi
+
+  parent=\${1%/*}
+  if [ -z "$parent" ] || [ "$parent" = "$1" ]; then
+    parent=/
+  fi
+  resolve_probe_path "$parent" || return 2
+  resolved_parent=$resolved_path
+  base=\${1##*/}
+  if [ "\${#base}" -gt 255 ]; then
+    return 2
+  fi
+  if [ "$resolved_parent" = / ]; then
+    candidate=/$base
+  else
+    candidate=$resolved_parent/$base
+  fi
+
+  if [ -L "$candidate" ]; then
+    target_with_marker=$(readlink -n "$candidate" && printf .) || return 2
+    target=\${target_with_marker%.}
+    symlink_depth=$((symlink_depth + 1))
+    if [ "$symlink_depth" -gt 40 ]; then
+      return 2
+    fi
+    case "$target" in
+      /*) resolve_probe_path "$target" ;;
+      *) resolve_probe_path "$resolved_parent/$target" ;;
+    esac
+    return $?
+  fi
+
+  resolved_path=$candidate
+}
+
+resolve_probe_path "$path" || exit 2
+path=$resolved_path
+candidate=$path
+child=
+
+while :; do
+  if [ -e "$candidate" ]; then
+    if [ "$candidate" = "$path" ]; then
+      exit 0
+    fi
+    if [ ! -d "$candidate" ] || [ ! -x "$candidate" ]; then
+      exit 2
+    fi
+    lookup_result=$(
+      find "$child" -prune -print 2>&1 >/dev/null
+      lookup_status=$?
+      printf '.%s' "$lookup_status"
+    )
+    lookup_status=\${lookup_result##*.}
+    lookup_error=\${lookup_result%.*}
+    if [ "$lookup_status" -eq 1 ]; then
+      lookup_error=$(printf %s "$lookup_error")
+      case "$lookup_error" in
+        *": No such file or directory") exit 1 ;;
+      esac
+    fi
+    exit 2
+  fi
+  if [ "$candidate" = / ]; then
+    exit 2
+  fi
+  child=$candidate
+  candidate=\${candidate%/*}
+  if [ -z "$candidate" ]; then
+    candidate=/
+  fi
+done
+`.trim();
+
+export function isSandboxPathNotFoundError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+  try {
+    if (error instanceof SandboxWorkspaceReadNotFoundError) {
+      return true;
+    }
+    const code = (error as { code?: unknown }).code;
+    return code === 'ENOENT' || code === 'workspace_read_not_found';
+  } catch {
+    return false;
+  }
+}
+
+export async function probeSandboxPathExists(
+  options: SandboxPathProbeOptions,
+): Promise<boolean> {
+  const quotedPath = shellQuote(options.path);
+  const initial = await options.runCommand(`test -e ${quotedPath}`);
+  if (initial.status === 0 && !hasProcessFailure(initial)) {
+    return true;
+  }
+  if (initial.status !== 1 || hasProcessFailure(initial)) {
+    throw createPathProbeError(options, initial);
+  }
+
+  const diagnostic = pathProbeDiagnostic(initial);
+  if (diagnostic.length === 0 && initial.stdout?.trim()) {
+    throw createPathProbeError(options, initial);
+  }
+  if (diagnostic.length > 0) {
+    if (isMissingPathDiagnostic(diagnostic)) {
+      return false;
+    }
+    throw createPathProbeError(options, initial);
+  }
+
+  const result = await options.runCommand(
+    `test -e ${quotedPath} || (path=${quotedPath}; ${READ_PATH_PROBE_SCRIPT})`,
+  );
+  if (result.status === 0 && !hasProcessFailure(result)) {
+    return true;
+  }
+  if (result.status === 1 && !hasProcessFailure(result)) {
+    const probeDiagnostic = pathProbeDiagnostic(result);
+    if (
+      (!result.stdout?.trim() && probeDiagnostic.length === 0) ||
+      isMissingPathDiagnostic(probeDiagnostic)
+    ) {
+      return false;
+    }
+  }
+  throw createPathProbeError(options, result);
+}
+
+function hasProcessFailure(result: SandboxPathProbeResult): boolean {
+  return Boolean(result.timedOut || result.signal || result.error);
+}
+
+function pathProbeDiagnostic(result: SandboxPathProbeResult): string {
+  return result.stderr?.trim() ?? '';
+}
+
+function isMissingPathDiagnostic(diagnostic: string): boolean {
+  return /(?:no such file or directory|not found|does not exist|missing(?: path| file)?)/iu.test(
+    diagnostic,
+  );
+}
+
+function createPathProbeError(
+  options: SandboxPathProbeOptions,
+  result: SandboxPathProbeResult,
+): Error {
+  if (options.createError) {
+    return options.createError(result);
+  }
+  const diagnostic = pathProbeDiagnostic(result);
+  const suffix = diagnostic ? `: ${diagnostic}` : '';
+  return new SandboxWorkspaceArchiveReadError(
+    `Failed to determine whether sandbox path exists: ${options.path}${suffix}`,
+    {
+      path: options.path,
+      status: result.status,
+      signal: result.signal,
+      timedOut: result.timedOut,
+      stdoutBytes: result.stdout?.length ?? 0,
+    },
+  );
+}

--- a/packages/agents-core/test/sandboxPathProbe.test.ts
+++ b/packages/agents-core/test/sandboxPathProbe.test.ts
@@ -2,6 +2,7 @@ import {
   chmod,
   mkdir,
   mkdtemp,
+  readdir,
   rm,
   symlink,
   writeFile,
@@ -210,12 +211,26 @@ describe('sandbox path probes', () => {
       await expect(
         probeSandboxPathExists({ path: invalid, runCommand }),
       ).rejects.toBeInstanceOf(SandboxWorkspaceArchiveReadError);
-      await expect(
-        probeSandboxPathExists({
-          path: join(inaccessible, 'nested.txt'),
-          runCommand,
-        }),
-      ).rejects.toBeInstanceOf(SandboxWorkspaceArchiveReadError);
+      const canTraverseInaccessible = await readdir(inaccessible).then(
+        () => true,
+        (error: NodeJS.ErrnoException) => {
+          if (error.code === 'EACCES' || error.code === 'EPERM') {
+            return false;
+          }
+          throw error;
+        },
+      );
+      const inaccessiblePathProbe = probeSandboxPathExists({
+        path: join(inaccessible, 'nested.txt'),
+        runCommand,
+      });
+      if (canTraverseInaccessible) {
+        await expect(inaccessiblePathProbe).resolves.toBe(false);
+      } else {
+        await expect(inaccessiblePathProbe).rejects.toBeInstanceOf(
+          SandboxWorkspaceArchiveReadError,
+        );
+      }
     } finally {
       await chmod(inaccessible, 0o700);
       await rm(root, { recursive: true, force: true });

--- a/packages/agents-core/test/sandboxPathProbe.test.ts
+++ b/packages/agents-core/test/sandboxPathProbe.test.ts
@@ -72,6 +72,37 @@ describe('sandbox path probes', () => {
   });
 
   it.each([
+    'sandbox not found',
+    'executable file not found',
+    'test: /workspace/other: No such file or directory',
+  ])('rejects unrelated not-found diagnostics: %s', async (diagnostic) => {
+    const runCommand = vi.fn(async (_command: string) => ({
+      status: 1,
+      stderr: diagnostic,
+    }));
+
+    await expect(
+      probeSandboxPathExists({ path: '/workspace/missing', runCommand }),
+    ).rejects.toBeInstanceOf(SandboxWorkspaceArchiveReadError);
+    expect(runCommand).toHaveBeenCalledTimes(2);
+  });
+
+  it('confirms generic missing diagnostics with a path-specific probe', async () => {
+    const runCommand = vi
+      .fn()
+      .mockResolvedValueOnce({ status: 1, stderr: 'missing path' })
+      .mockResolvedValueOnce({
+        status: 1,
+        stderr: 'find: /workspace/missing: No such file or directory',
+      });
+
+    await expect(
+      probeSandboxPathExists({ path: '/workspace/missing', runCommand }),
+    ).resolves.toBe(false);
+    expect(runCommand).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
     { status: 1, stderr: 'Permission denied' },
     { status: 2, stderr: 'Input/output error' },
     { status: 1, timedOut: true },

--- a/packages/agents-core/test/sandboxPathProbe.test.ts
+++ b/packages/agents-core/test/sandboxPathProbe.test.ts
@@ -18,6 +18,7 @@ import {
   isSandboxPathNotFoundError,
   probeSandboxPathExists,
 } from '../src/sandbox/shared/pathProbe';
+import { shellQuote } from '../src/sandbox/shared/shell';
 import { runSandboxProcess } from '../src/sandbox/sandboxes/shared/runProcess';
 
 describe('sandbox path probes', () => {
@@ -182,6 +183,67 @@ describe('sandbox path probes', () => {
     });
     expect((thrown as Error).message).not.toContain(sensitiveOutput);
   });
+
+  it.each([
+    {
+      name: 'regular file',
+      createCommand: (path: string, _target: string) =>
+        `printf created > ${shellQuote(path)}`,
+      exists: true,
+    },
+    {
+      name: 'directory',
+      createCommand: (path: string, _target: string) =>
+        `mkdir -- ${shellQuote(path)}`,
+      exists: true,
+    },
+    {
+      name: 'valid symbolic link',
+      createCommand: (path: string, target: string) =>
+        `ln -s -- ${shellQuote(target)} ${shellQuote(path)}`,
+      exists: true,
+    },
+    {
+      name: 'dangling symbolic link',
+      createCommand: (path: string, _target: string) =>
+        `ln -s -- missing-target ${shellQuote(path)}`,
+      exists: false,
+    },
+  ])(
+    'retries a $name created during the fallback lookup',
+    async ({ createCommand, exists }) => {
+      const root = await mkdtemp(join(tmpdir(), 'agents-path-probe-race-'));
+      const path = join(root, 'created');
+      const target = join(root, 'target');
+      const marker = join(root, 'lookup-started');
+      await writeFile(target, 'target');
+      const runCommand = async (command: string) => {
+        const interceptedCommand = command.includes(
+          'OPENAI_AGENTS_READ_PATH_PROBE_V1',
+        )
+          ? [
+              'find() {',
+              `  if [ ! -e ${shellQuote(marker)} ]; then`,
+              `    printf created > ${shellQuote(marker)}`,
+              `    ${createCommand(path, target)}`,
+              '  fi',
+              '  command find "$@"',
+              '}',
+              command,
+            ].join('\n')
+          : command;
+        return await runSandboxProcess('/bin/sh', ['-c', interceptedCommand]);
+      };
+
+      try {
+        await expect(
+          probeSandboxPathExists({ path, runCommand }),
+        ).resolves.toBe(exists);
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
 
   it('classifies real missing paths, broken links, and inaccessible ancestors', async () => {
     const root = await mkdtemp(join(tmpdir(), 'agents-path-probe-'));

--- a/packages/agents-core/test/sandboxPathProbe.test.ts
+++ b/packages/agents-core/test/sandboxPathProbe.test.ts
@@ -1,0 +1,174 @@
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  SandboxWorkspaceArchiveReadError,
+  SandboxWorkspaceReadNotFoundError,
+} from '../src/sandbox';
+import {
+  isSandboxPathNotFoundError,
+  probeSandboxPathExists,
+} from '../src/sandbox/shared/pathProbe';
+import { runSandboxProcess } from '../src/sandbox/sandboxes/shared/runProcess';
+
+describe('sandbox path probes', () => {
+  it('recognizes typed and filesystem not-found errors only', () => {
+    expect(isSandboxPathNotFoundError({ code: 'ENOENT' })).toBe(true);
+    expect(
+      isSandboxPathNotFoundError({ code: 'workspace_read_not_found' }),
+    ).toBe(true);
+    expect(
+      isSandboxPathNotFoundError(
+        new SandboxWorkspaceReadNotFoundError('missing'),
+      ),
+    ).toBe(true);
+    expect(isSandboxPathNotFoundError({ code: 'EACCES' })).toBe(false);
+    expect(isSandboxPathNotFoundError(new Error('missing'))).toBe(false);
+    const hostile = Proxy.revocable({}, {});
+    hostile.revoke();
+    expect(isSandboxPathNotFoundError(hostile.proxy)).toBe(false);
+  });
+
+  it('returns existing paths without running the diagnostic probe', async () => {
+    const runCommand = vi.fn(async () => ({ status: 0 }));
+
+    await expect(
+      probeSandboxPathExists({ path: '/workspace/exists', runCommand }),
+    ).resolves.toBe(true);
+    expect(runCommand).toHaveBeenCalledOnce();
+    expect(runCommand).toHaveBeenCalledWith("test -e '/workspace/exists'");
+  });
+
+  it('diagnoses ambiguous missing-path probe results', async () => {
+    const runCommand = vi.fn(async (_command: string) => ({ status: 1 }));
+
+    await expect(
+      probeSandboxPathExists({ path: '/workspace/missing', runCommand }),
+    ).resolves.toBe(false);
+    expect(runCommand).toHaveBeenCalledTimes(2);
+    expect(runCommand.mock.calls[1]?.[0]).toContain(
+      'OPENAI_AGENTS_READ_PATH_PROBE_V1',
+    );
+  });
+
+  it('accepts an explicit missing-path diagnostic without a second probe', async () => {
+    const runCommand = vi.fn(async () => ({
+      status: 1,
+      stderr: 'test: /workspace/missing: No such file or directory',
+    }));
+
+    await expect(
+      probeSandboxPathExists({ path: '/workspace/missing', runCommand }),
+    ).resolves.toBe(false);
+    expect(runCommand).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { status: 1, stderr: 'Permission denied' },
+    { status: 2, stderr: 'Input/output error' },
+    { status: 1, timedOut: true },
+    { status: null, signal: 'SIGTERM' },
+  ])('rejects inaccessible and failed path probes: %j', async (result) => {
+    await expect(
+      probeSandboxPathExists({
+        path: '/workspace/blocked',
+        runCommand: async () => result,
+      }),
+    ).rejects.toBeInstanceOf(SandboxWorkspaceArchiveReadError);
+  });
+
+  it('rejects broken or inaccessible paths discovered by the second probe', async () => {
+    const runCommand = vi
+      .fn()
+      .mockResolvedValueOnce({ status: 1 })
+      .mockResolvedValueOnce({ status: 2 });
+
+    await expect(
+      probeSandboxPathExists({ path: '/workspace/broken', runCommand }),
+    ).rejects.toMatchObject({
+      code: 'workspace_archive_read_error',
+      details: { path: '/workspace/broken', status: 2 },
+    });
+  });
+
+  it('preserves provider and transport failures', async () => {
+    const failure = new Error('provider unavailable');
+
+    await expect(
+      probeSandboxPathExists({
+        path: '/workspace/blocked',
+        runCommand: async () => {
+          throw failure;
+        },
+      }),
+    ).rejects.toBe(failure);
+  });
+
+  it('does not retain partial stdout in path probe errors', async () => {
+    const sensitiveOutput = 'sensitive partial contents';
+
+    let thrown: unknown;
+    try {
+      await probeSandboxPathExists({
+        path: '/workspace/blocked',
+        runCommand: async () => ({ status: 1, stdout: sensitiveOutput }),
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toMatchObject({
+      code: 'workspace_archive_read_error',
+      details: { stdoutBytes: sensitiveOutput.length },
+    });
+    expect((thrown as Error).message).not.toContain(sensitiveOutput);
+  });
+
+  it('classifies real missing paths, broken links, and inaccessible ancestors', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agents-path-probe-'));
+    const existing = join(root, 'exists.txt');
+    const missing = join(root, 'missing.txt');
+    const dangling = join(root, 'dangling');
+    const invalid = join(root, 'invalid');
+    const inaccessible = join(root, 'inaccessible');
+    await writeFile(existing, 'hello');
+    await symlink('missing-target', dangling);
+    await symlink('exists.txt/nested', invalid);
+    await mkdir(inaccessible, { mode: 0o700 });
+    await chmod(inaccessible, 0);
+    const runCommand = async (command: string) =>
+      await runSandboxProcess('/bin/sh', ['-c', command]);
+
+    try {
+      await expect(
+        probeSandboxPathExists({ path: existing, runCommand }),
+      ).resolves.toBe(true);
+      await expect(
+        probeSandboxPathExists({ path: missing, runCommand }),
+      ).resolves.toBe(false);
+      await expect(
+        probeSandboxPathExists({ path: dangling, runCommand }),
+      ).resolves.toBe(false);
+      await expect(
+        probeSandboxPathExists({ path: invalid, runCommand }),
+      ).rejects.toBeInstanceOf(SandboxWorkspaceArchiveReadError);
+      await expect(
+        probeSandboxPathExists({
+          path: join(inaccessible, 'nested.txt'),
+          runCommand,
+        }),
+      ).rejects.toBeInstanceOf(SandboxWorkspaceArchiveReadError);
+    } finally {
+      await chmod(inaccessible, 0o700);
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/agents-core/test/sandboxPathProbe.test.ts
+++ b/packages/agents-core/test/sandboxPathProbe.test.ts
@@ -75,6 +75,8 @@ describe('sandbox path probes', () => {
     'sandbox not found',
     'executable file not found',
     'test: /workspace/other: No such file or directory',
+    `command "test -e '/workspace/missing'" failed: sandbox not found`,
+    `command "test -e '/workspace/missing'" failed: executable file not found`,
   ])('rejects unrelated not-found diagnostics: %s', async (diagnostic) => {
     const runCommand = vi.fn(async (_command: string) => ({
       status: 1,
@@ -85,6 +87,23 @@ describe('sandbox path probes', () => {
       probeSandboxPathExists({ path: '/workspace/missing', runCommand }),
     ).rejects.toBeInstanceOf(SandboxWorkspaceArchiveReadError);
     expect(runCommand).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    'test: /workspace/missing: No such file or directory',
+    `base64: '/workspace/missing': No such file or directory`,
+    '/workspace/missing not found',
+    'missing path: /workspace/missing',
+  ])('accepts path-associated missing diagnostics: %s', async (diagnostic) => {
+    const runCommand = vi.fn(async (_command: string) => ({
+      status: 1,
+      stderr: diagnostic,
+    }));
+
+    await expect(
+      probeSandboxPathExists({ path: '/workspace/missing', runCommand }),
+    ).resolves.toBe(false);
+    expect(runCommand).toHaveBeenCalledOnce();
   });
 
   it('confirms generic missing diagnostics with a path-specific probe', async () => {

--- a/packages/agents-core/test/sandboxSkills.test.ts
+++ b/packages/agents-core/test/sandboxSkills.test.ts
@@ -7,7 +7,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   skills,
   type Entry,
@@ -16,6 +16,7 @@ import {
   type SandboxSessionState,
   Manifest,
   SandboxSkillsConfigError,
+  SandboxWorkspaceReadNotFoundError,
 } from '../src/sandbox';
 import { localDirLazySkillSource } from '../src/sandbox/local';
 
@@ -61,7 +62,9 @@ class FakeSkillsSession implements SandboxSession {
   async readFile(args: { path: string }): Promise<string | Uint8Array> {
     const content = this.files.get(args.path);
     if (typeof content === 'undefined') {
-      throw new Error(`file not found: ${args.path}`);
+      throw new SandboxWorkspaceReadNotFoundError(
+        `file not found: ${args.path}`,
+      );
     }
     return content;
   }
@@ -591,6 +594,68 @@ describe('Skills', () => {
     expect(instructions).toContain(
       '- spreadsheet-review: Review spreadsheets quickly (file: .agents/sheet-tools)',
     );
+  });
+
+  it('ignores missing skill directories while preserving access failures', async () => {
+    const capability = skills({ from: { type: 'dir', children: {} } });
+    const session = new FakeSkillsSession();
+    capability.bind(session);
+
+    vi.spyOn(session, 'listDir').mockRejectedValueOnce(
+      new SandboxWorkspaceReadNotFoundError('missing skill directory'),
+    );
+    await expect(capability.instructions(new Manifest())).resolves.toContain(
+      '.agents',
+    );
+
+    const denied = Object.assign(new Error('Permission denied'), {
+      code: 'EACCES',
+    });
+    vi.spyOn(session, 'listDir').mockRejectedValueOnce(denied);
+    await expect(capability.instructions(new Manifest())).rejects.toBe(denied);
+  });
+
+  it('skips missing skill files without suppressing unreadable files', async () => {
+    const capability = skills({ from: { type: 'dir', children: {} } });
+    const session = new FakeSkillsSession();
+    session.files.set('.agents/blocked/SKILL.md', '# Placeholder');
+    capability.bind(session);
+
+    vi.spyOn(session, 'readFile').mockRejectedValueOnce(
+      new SandboxWorkspaceReadNotFoundError('missing skill file'),
+    );
+    await expect(capability.instructions(new Manifest())).resolves.toContain(
+      '.agents',
+    );
+
+    const denied = Object.assign(new Error('Permission denied'), {
+      code: 'EACCES',
+    });
+    vi.spyOn(session, 'readFile').mockRejectedValueOnce(denied);
+    await expect(capability.instructions(new Manifest())).rejects.toBe(denied);
+  });
+
+  it('does not materialize lazy skills when their existence cannot be determined', async () => {
+    const capability = skills({
+      lazyFrom: {
+        source: { type: 'local_dir', src: 'skills' },
+        index: [{ name: 'dynamic-skill', description: 'dynamic' }],
+      },
+    });
+    const session = new FakeSkillsSession();
+    const denied = Object.assign(new Error('Permission denied'), {
+      code: 'EACCES',
+    });
+    vi.spyOn(session, 'pathExists').mockRejectedValue(denied);
+    capability.bind(session);
+
+    await expect(
+      (capability.tools()[0] as any).invoke(
+        undefined,
+        JSON.stringify({ skill_name: 'dynamic-skill' }),
+      ),
+    ).resolves.toContain('Permission denied');
+    expect(session.materializeCalls).toEqual([]);
   });
 
   it('renders lazy loading guidance for lazy skill sources', async () => {

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -1520,6 +1520,36 @@ describe('DockerSandboxClient unit behavior', () => {
     );
   });
 
+  it.each([
+    { status: 1, stderr: 'Permission denied' },
+    { status: 2, stderr: 'Input/output error' },
+  ])('preserves failed Docker filesystem probes: %j', async (result) => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation(() => dockerSpawnResult(result));
+    const client = new DockerSandboxClient({ workspaceBaseDir: rootDir });
+    const session = await client.create(new Manifest());
+
+    await expect(
+      session.pathExists('blocked.txt', 'node'),
+    ).rejects.toMatchObject({
+      code: 'workspace_archive_read_error',
+      details: {
+        path: '/workspace/blocked.txt',
+        status: result.status,
+      },
+    });
+  });
+
   it('provisions manifest identity metadata inside the container', async () => {
     processMocks.runSandboxProcess.mockImplementation(
       async (_command: string, args: string[]) => {

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -43,6 +43,7 @@ import {
   inContainerMountStrategy,
   Manifest,
   NoopSnapshotSpec,
+  skills,
 } from '../../src/sandbox/local';
 
 const success = (stdout = ''): SandboxProcessResult => ({
@@ -1548,6 +1549,89 @@ describe('DockerSandboxClient unit behavior', () => {
         status: result.status,
       },
     });
+  });
+
+  it('normalizes missing Docker filesystem reads to typed not-found errors', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
+      const command = args.at(-1) ?? '';
+      const path = '/workspace/.agents/.git/SKILL.md';
+      if (command.startsWith('base64 --')) {
+        return dockerSpawnResult({
+          status: 1,
+          stderr: `base64: ${path}: No such file or directory`,
+        });
+      }
+      if (command.startsWith('test -e')) {
+        return dockerSpawnResult({
+          status: 1,
+          stderr: `test: ${path}: No such file or directory`,
+        });
+      }
+      return dockerSpawnResult({ status: 0 });
+    });
+    const client = new DockerSandboxClient({ workspaceBaseDir: rootDir });
+    const session = await client.create(new Manifest());
+
+    await expect(
+      session.readFile({ path: '.agents/.git/SKILL.md', runAs: 'node' }),
+    ).rejects.toMatchObject({
+      code: 'workspace_read_not_found',
+      details: { path: '/workspace/.agents/.git/SKILL.md' },
+    });
+  });
+
+  it('skips Docker Git metadata when discovering materialized skills', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
+      const command = args.at(-1) ?? '';
+      const missingPath = '/workspace/.agents/.git/SKILL.md';
+      if (command.startsWith('find ')) {
+        return dockerSpawnResult({ stdout: 'd\t.git\nd\tdynamic-skill\n' });
+      }
+      if (command.includes(missingPath)) {
+        return dockerSpawnResult({
+          status: 1,
+          stderr: `base64: ${missingPath}: No such file or directory`,
+        });
+      }
+      if (command.startsWith('base64 --')) {
+        return dockerSpawnResult({
+          stdout: Buffer.from(
+            '---\nname: dynamic-skill\ndescription: Dynamic skill\n---\n',
+          ).toString('base64'),
+        });
+      }
+      return dockerSpawnResult({ status: 0 });
+    });
+    const client = new DockerSandboxClient({ workspaceBaseDir: rootDir });
+    const session = await client.create(new Manifest());
+    const capability = skills({ from: { type: 'dir', children: {} } });
+    capability.bind(session).bindRunAs('node');
+
+    await expect(
+      capability.instructions(session.state.manifest),
+    ).resolves.toContain('- dynamic-skill: Dynamic skill');
   });
 
   it('provisions manifest identity metadata inside the container', async () => {

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -1591,6 +1591,114 @@ describe('DockerSandboxClient unit behavior', () => {
     });
   });
 
+  it('normalizes missing Docker directory listings to typed not-found errors', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
+      const command = args.at(-1) ?? '';
+      const path = '/workspace/.agents';
+      if (command.startsWith('find ')) {
+        return dockerSpawnResult({
+          status: 1,
+          stderr: `find: ${path}: No such file or directory`,
+        });
+      }
+      if (command.startsWith('test -e')) {
+        return dockerSpawnResult({
+          status: 1,
+          stderr: `test: ${path}: No such file or directory`,
+        });
+      }
+      return dockerSpawnResult({ status: 0 });
+    });
+    const client = new DockerSandboxClient({ workspaceBaseDir: rootDir });
+    const session = await client.create(new Manifest());
+
+    await expect(
+      session.listDir({ path: '.agents', runAs: 'node' }),
+    ).rejects.toMatchObject({
+      code: 'workspace_read_not_found',
+      details: { path: '/workspace/.agents' },
+    });
+  });
+
+  it('uses the discovery fallback when Docker skill directories are missing', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
+      const command = args.at(-1) ?? '';
+      const path = '/workspace/.agents';
+      if (command.startsWith('find ') || command.startsWith('test -e')) {
+        return dockerSpawnResult({
+          status: 1,
+          stderr: `find: ${path}: No such file or directory`,
+        });
+      }
+      return dockerSpawnResult({ status: 0 });
+    });
+    const client = new DockerSandboxClient({ workspaceBaseDir: rootDir });
+    const session = await client.create(new Manifest());
+    const capability = skills({ from: { type: 'dir', children: {} } });
+    capability.bind(session).bindRunAs('node');
+
+    await expect(
+      capability.instructions(session.state.manifest),
+    ).resolves.toContain('.agents');
+  });
+
+  it('does not treat inaccessible Docker skill directories as missing', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
+      const command = args.at(-1) ?? '';
+      if (command.startsWith('find ')) {
+        return dockerSpawnResult({
+          status: 1,
+          stderr: 'find: /workspace/.agents: Permission denied',
+        });
+      }
+      if (command.startsWith('test -e')) {
+        return dockerSpawnResult({ status: 0 });
+      }
+      return dockerSpawnResult({ status: 0 });
+    });
+    const client = new DockerSandboxClient({ workspaceBaseDir: rootDir });
+    const session = await client.create(new Manifest());
+    const capability = skills({ from: { type: 'dir', children: {} } });
+    capability.bind(session).bindRunAs('node');
+
+    await expect(
+      capability.instructions(session.state.manifest),
+    ).rejects.toThrow('Permission denied');
+  });
+
   it('skips Docker Git metadata when discovering materialized skills', async () => {
     processMocks.runSandboxProcess.mockImplementation(
       async (_command: string, args: string[]) => {

--- a/packages/agents-core/test/sandboxes/localWorkspace.pathProbe.test.ts
+++ b/packages/agents-core/test/sandboxes/localWorkspace.pathProbe.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const filesystemMocks = vi.hoisted(() => ({
+  lstat: vi.fn(),
+  stat: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    lstat: filesystemMocks.lstat,
+    stat: filesystemMocks.stat,
+  };
+});
+
+import { pathExists } from '../../src/sandbox/sandboxes/shared/localWorkspace';
+
+describe('local workspace path probes', () => {
+  beforeEach(() => {
+    filesystemMocks.stat.mockReset();
+    filesystemMocks.lstat.mockReset();
+  });
+
+  it.each([
+    { name: 'a regular file', isSymbolicLink: false },
+    { name: 'a directory', isSymbolicLink: false },
+  ])(
+    'recognizes $name created after the initial stat',
+    async ({ isSymbolicLink }) => {
+      filesystemMocks.stat.mockRejectedValueOnce(
+        Object.assign(new Error('No such file or directory'), {
+          code: 'ENOENT',
+        }),
+      );
+      filesystemMocks.lstat.mockResolvedValueOnce({
+        isSymbolicLink: () => isSymbolicLink,
+      });
+
+      await expect(pathExists('/workspace/concurrent')).resolves.toBe(true);
+    },
+  );
+
+  it('continues treating dangling symbolic links as missing', async () => {
+    filesystemMocks.stat.mockRejectedValueOnce(
+      Object.assign(new Error('No such file or directory'), { code: 'ENOENT' }),
+    );
+    filesystemMocks.lstat.mockResolvedValueOnce({ isSymbolicLink: () => true });
+    filesystemMocks.stat.mockRejectedValueOnce(
+      Object.assign(new Error('No such file or directory'), { code: 'ENOENT' }),
+    );
+
+    await expect(pathExists('/workspace/dangling')).resolves.toBe(false);
+  });
+
+  it('recognizes a valid symbolic link created after the initial stat', async () => {
+    filesystemMocks.stat.mockRejectedValueOnce(
+      Object.assign(new Error('No such file or directory'), { code: 'ENOENT' }),
+    );
+    filesystemMocks.lstat.mockResolvedValueOnce({ isSymbolicLink: () => true });
+    filesystemMocks.stat.mockResolvedValueOnce({});
+
+    await expect(pathExists('/workspace/created-link')).resolves.toBe(true);
+  });
+});

--- a/packages/agents-core/test/sandboxes/unixLocal.test.ts
+++ b/packages/agents-core/test/sandboxes/unixLocal.test.ts
@@ -24,6 +24,7 @@ import {
   applyOwnershipRecursive,
   materializeLocalWorkspaceManifest,
   materializeLocalWorkspaceManifestMounts,
+  pathExists,
 } from '../../src/sandbox/sandboxes/shared/localWorkspace';
 
 const ONE_BY_ONE_PNG = Uint8Array.from(
@@ -44,6 +45,27 @@ describe('UnixLocalSandboxClient', () => {
 
   afterEach(async () => {
     await rm(rootDir, { recursive: true, force: true });
+  });
+
+  it('distinguishes missing local paths from invalid and recursive symbolic links', async () => {
+    const missingPath = join(rootDir, 'missing');
+    const brokenPath = join(rootDir, 'broken');
+    const invalidPath = join(rootDir, 'invalid');
+    const recursivePath = join(rootDir, 'recursive');
+    await writeFile(join(rootDir, 'not-a-directory'), 'hello');
+    await symlink('missing-target', brokenPath);
+    await symlink('not-a-directory/child', invalidPath);
+    await symlink('recursive', recursivePath);
+
+    await expect(pathExists(missingPath)).resolves.toBe(false);
+    await expect(pathExists(rootDir)).resolves.toBe(true);
+    await expect(pathExists(brokenPath)).resolves.toBe(false);
+    await expect(pathExists(invalidPath)).rejects.toMatchObject({
+      code: 'ENOTDIR',
+    });
+    await expect(pathExists(recursivePath)).rejects.toMatchObject({
+      code: 'ELOOP',
+    });
   });
 
   it('materializes manifest entries and runs commands in the workspace', async () => {

--- a/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
@@ -385,7 +385,8 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
           const result = await this.execShell(command);
           return {
             status: result.exitCode,
-            stderr: result.output,
+            stdout: result.stdout,
+            stderr: result.stderr,
           };
         },
       });
@@ -721,9 +722,12 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
     });
   }
 
-  private async execShell(
-    shellCommand: string,
-  ): Promise<{ exitCode: number; output: string }> {
+  private async execShell(shellCommand: string): Promise<{
+    exitCode: number;
+    output: string;
+    stdout: string;
+    stderr: string;
+  }> {
     const response = await this.fetch(
       `/v1/sandbox/${this.state.sandboxId}/exec`,
       {
@@ -866,6 +870,8 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
     return {
       exitCode: exitCode ?? 1,
       output,
+      stdout,
+      stderr,
     };
   }
 
@@ -878,8 +884,8 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
     );
     return {
       status: result.exitCode,
-      stdout: result.output,
-      stderr: '',
+      stdout: result.stdout,
+      stderr: result.stderr,
     };
   }
 
@@ -1012,8 +1018,8 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
         const result = await this.execShell(command);
         return {
           status: result.exitCode,
-          stdout: result.output,
-          stderr: '',
+          stdout: result.stdout,
+          stderr: result.stderr,
         };
       },
     });

--- a/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
@@ -55,6 +55,7 @@ import {
   truncateOutput,
 } from '../shared/output';
 import { assertConfiguredExposedPort } from '../shared/ports';
+import { probeRemoteSandboxPathExists } from '../shared/pathProbe';
 import {
   addPtyWebSocketListener,
   appendPtyOutput,
@@ -376,15 +377,27 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
   async pathExists(path: string, runAs?: string): Promise<boolean> {
     const absolutePath = await this.resolveRemotePath(path);
     if (!runAs) {
-      const result = await this.execShell(
-        `test -e ${shellQuote(absolutePath)}`,
-      );
-      return result.exitCode === 0;
+      return await probeRemoteSandboxPathExists({
+        providerName: 'CloudflareSandboxClient',
+        providerId: 'cloudflare',
+        path: absolutePath,
+        runCommand: async (command) => {
+          const result = await this.execShell(command);
+          return {
+            status: result.exitCode,
+            stderr: result.output,
+          };
+        },
+      });
     }
     return await runAsRemotePathExists(
       absolutePath,
       runAs,
       this.runAsCommandRunner.bind(this),
+      {
+        providerName: 'CloudflareSandboxClient',
+        providerId: 'cloudflare',
+      },
     );
   }
 

--- a/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
@@ -45,6 +45,7 @@ import {
   materializeEnvironment,
   manifestMaterializationOptionsWithRunAs,
   persistRemoteWorkspaceTar,
+  probeRemoteSandboxPathExists,
   assertConfiguredExposedPort,
   getCachedExposedPortEndpoint,
   parseExposedPortEndpoint,
@@ -436,18 +437,32 @@ export class DaytonaSandboxSession implements SandboxSession<DaytonaSandboxSessi
   async pathExists(path: string, runAs?: string): Promise<boolean> {
     const absolutePath = await this.resolveRemotePath(path);
     if (!runAs) {
-      const result = await this.sandbox.process.executeCommand(
-        `test -e ${shellQuote(absolutePath)}`,
-        this.state.manifest.root,
-        this.state.environment,
-        5,
-      );
-      return result.exitCode === 0;
+      return await probeRemoteSandboxPathExists({
+        providerName: 'DaytonaSandboxClient',
+        providerId: 'daytona',
+        path: absolutePath,
+        runCommand: async (command) => {
+          const result = await this.sandbox.process.executeCommand(
+            command,
+            this.state.manifest.root,
+            this.state.environment,
+            5,
+          );
+          return {
+            status: result.exitCode,
+            stderr: result.exitCode === 0 ? '' : result.result,
+          };
+        },
+      });
     }
     return await runAsRemotePathExists(
       absolutePath,
       runAs,
       this.runAsCommandRunner.bind(this),
+      {
+        providerName: 'DaytonaSandboxClient',
+        providerId: 'daytona',
+      },
     );
   }
 

--- a/packages/agents-extensions/src/sandbox/modal/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/modal/sandbox.ts
@@ -28,6 +28,7 @@ import {
 import {
   normalizePosixPath,
   relativePosixPathWithinRoot,
+  shellQuote,
 } from '@openai/agents-core/sandbox/internal';
 import { posix as pathPosix } from 'node:path';
 import {
@@ -49,6 +50,7 @@ import {
   manifestMaterializationOptionsWithRunAs,
   materializeEnvironment,
   persistRemoteWorkspaceTar,
+  probeRemoteSandboxPathExists,
   providerErrorMessage,
   assertConfiguredExposedPort,
   getCachedExposedPortEndpoint,
@@ -216,9 +218,7 @@ type ModalCloudBucketMountsProvider = () => Promise<
 >;
 
 export type ModalWorkspacePersistence =
-  | 'tar'
-  | 'snapshot_filesystem'
-  | 'snapshot_directory';
+  'tar' | 'snapshot_filesystem' | 'snapshot_directory';
 
 export type ModalImageSelectorKind = 'image' | 'id' | 'tag';
 
@@ -524,18 +524,44 @@ export class ModalSandboxSession implements SandboxSession<ModalSandboxSessionSt
   async pathExists(path: string, runAs?: string): Promise<boolean> {
     const absolutePath = await this.resolveRemotePath(path);
     if (!runAs) {
-      const process = await this.sandbox.exec(['test', '-e', absolutePath], {
-        mode: 'text',
-        workdir: this.state.manifest.root,
-        stdout: 'ignore',
-        stderr: 'pipe',
+      return await probeRemoteSandboxPathExists({
+        providerName: 'ModalSandboxClient',
+        providerId: 'modal',
+        path: absolutePath,
+        runCommand: async (command) => {
+          const argv =
+            command === `test -e ${shellQuote(absolutePath)}`
+              ? ['test', '-e', absolutePath]
+              : ['/bin/sh', '-c', command];
+          const process = await this.sandbox.exec(argv, {
+            mode: 'text',
+            workdir: this.state.manifest.root,
+            stdout: 'ignore',
+            stderr: 'pipe',
+          });
+          let stderr = '';
+          const stderrPump = startTextStreamPump(process.stderr, (chunk) => {
+            stderr += chunk;
+          });
+          try {
+            const status = await process.wait();
+            await stderrPump.promise;
+            return { status, stderr };
+          } catch (error) {
+            await stderrPump.cancel();
+            throw error;
+          }
+        },
       });
-      return (await process.wait()) === 0;
     }
     return await runAsRemotePathExists(
       absolutePath,
       runAs,
       this.runAsCommandRunner.bind(this),
+      {
+        providerName: 'ModalSandboxClient',
+        providerId: 'modal',
+      },
     );
   }
 
@@ -1302,8 +1328,7 @@ export class ModalSandboxClient implements SandboxClient<
         );
         const imageState = modalImageStateFromOptions(resolvedOptions);
         let cloudBucketMounts:
-          | Record<string, ModalCloudBucketMountLike>
-          | undefined;
+          Record<string, ModalCloudBucketMountLike> | undefined;
         let sandbox: ModalSandboxLike;
         if (resolvedOptions.sandbox) {
           sandbox = await withProviderError(

--- a/packages/agents-extensions/src/sandbox/shared/editor.ts
+++ b/packages/agents-extensions/src/sandbox/shared/editor.ts
@@ -5,6 +5,7 @@ import {
   type ApplyPatchResult,
   type Editor,
 } from '@openai/agents-core';
+import { isSandboxPathNotFoundError } from '@openai/agents-core/sandbox/internal';
 import { posixDirname } from './paths';
 import type { RemoteEditorIo } from './types';
 
@@ -79,8 +80,11 @@ export class RemoteSandboxEditor implements Editor {
     try {
       await this.io.readText(path);
       return true;
-    } catch {
-      return false;
+    } catch (error) {
+      if (isSandboxPathNotFoundError(error)) {
+        return false;
+      }
+      throw error;
     }
   }
 }

--- a/packages/agents-extensions/src/sandbox/shared/index.ts
+++ b/packages/agents-extensions/src/sandbox/shared/index.ts
@@ -96,6 +96,7 @@ export {
   type RemoteRunAsCommandResult,
   type RemoteRunAsCommandRunner,
 } from './runAs';
+export { probeRemoteSandboxPathExists } from './pathProbe';
 export {
   RemoteSandboxSessionBase,
   type RemoteSandboxCommandKind,

--- a/packages/agents-extensions/src/sandbox/shared/pathProbe.ts
+++ b/packages/agents-extensions/src/sandbox/shared/pathProbe.ts
@@ -1,0 +1,32 @@
+import { SandboxProviderError } from '@openai/agents-core/sandbox';
+import {
+  probeSandboxPathExists,
+  type SandboxPathProbeResult,
+} from '@openai/agents-core/sandbox/internal';
+
+export async function probeRemoteSandboxPathExists(args: {
+  providerName: string;
+  providerId: string;
+  path: string;
+  runCommand: (command: string) => Promise<SandboxPathProbeResult>;
+}): Promise<boolean> {
+  return await probeSandboxPathExists({
+    path: args.path,
+    runCommand: args.runCommand,
+    createError: (result) => {
+      const diagnostic = result.stderr?.trim() ?? '';
+      const suffix = diagnostic ? `: ${diagnostic}` : '';
+      return new SandboxProviderError(
+        `${args.providerName} failed to check path ${args.path}${suffix}`,
+        {
+          provider: args.providerId,
+          path: args.path,
+          status: result.status,
+          signal: result.signal,
+          timedOut: result.timedOut,
+          stdoutBytes: result.stdout?.length ?? 0,
+        },
+      );
+    },
+  });
+}

--- a/packages/agents-extensions/src/sandbox/shared/runAs.ts
+++ b/packages/agents-extensions/src/sandbox/shared/runAs.ts
@@ -2,6 +2,7 @@ import { SandboxProviderError, type Entry } from '@openai/agents-core/sandbox';
 import { RemoteSandboxEditor } from './editor';
 import type { ManifestMaterializationOptions } from './manifest';
 import { sandboxEntryPermissionsMode } from './metadata';
+import { probeRemoteSandboxPathExists } from './pathProbe';
 import { shellQuote } from './paths';
 import type {
   RemoteManifestWriter,
@@ -74,7 +75,10 @@ export function createRunAsRemoteEditor(args: {
         }),
       ),
     pathExists: async (path) =>
-      await runAsRemotePathExists(path, args.runAs, args.runCommand),
+      await runAsRemotePathExists(path, args.runAs, args.runCommand, {
+        providerName: args.providerName,
+        providerId: args.providerId,
+      }),
     writeText: async (path, content) => {
       await args.beforeFilesystemMutation?.();
       await writeRunAsRemoteText({
@@ -123,9 +127,19 @@ export async function runAsRemotePathExists(
   path: string,
   runAs: string | undefined,
   runCommand: RemoteRunAsCommandRunner,
+  provider: {
+    providerName: string;
+    providerId: string;
+  } = {
+    providerName: 'RemoteSandboxClient',
+    providerId: 'remote',
+  },
 ): Promise<boolean> {
-  const result = await runCommand(`test -e ${shellQuote(path)}`, { runAs });
-  return result.status === 0;
+  return await probeRemoteSandboxPathExists({
+    ...provider,
+    path,
+    runCommand: async (command) => await runCommand(command, { runAs }),
+  });
 }
 
 export async function writeRunAsRemoteText(args: {

--- a/packages/agents-extensions/src/sandbox/shared/sessionBase.ts
+++ b/packages/agents-extensions/src/sandbox/shared/sessionBase.ts
@@ -50,6 +50,7 @@ import {
   parseExposedPortEndpoint,
   recordResolvedExposedPortEndpoint,
 } from './ports';
+import { probeRemoteSandboxPathExists } from './pathProbe';
 import { assertRunAsUnsupported } from './session';
 import type {
   RemoteManifestWriter,
@@ -59,11 +60,7 @@ import type {
 } from './types';
 
 export type RemoteSandboxCommandKind =
-  | 'archive'
-  | 'exec'
-  | 'manifest'
-  | 'path'
-  | 'running';
+  'archive' | 'exec' | 'manifest' | 'path' | 'running';
 
 export type RemoteSandboxCommandOptions = {
   kind: RemoteSandboxCommandKind;
@@ -187,15 +184,17 @@ export abstract class RemoteSandboxSessionBase<
   async pathExists(path: string, runAs?: string): Promise<boolean> {
     this.assertFilesystemRunAs(runAs);
     const absolutePath = await this.resolveRemotePath(path);
-    const result = await this.runRemoteCommand(
-      `test -e ${shellQuote(absolutePath)}`,
-      {
-        kind: 'path',
-        workdir: this.state.manifest.root,
-        runAs,
-      },
-    );
-    return result.status === 0;
+    return await probeRemoteSandboxPathExists({
+      providerName: this.providerName,
+      providerId: this.providerId,
+      path: absolutePath,
+      runCommand: async (command) =>
+        await this.runRemoteCommand(command, {
+          kind: 'path',
+          workdir: this.state.manifest.root,
+          runAs,
+        }),
+    });
   }
 
   async readFile(args: ReadFileArgs): Promise<Uint8Array> {
@@ -363,8 +362,7 @@ export abstract class RemoteSandboxSessionBase<
   }
 
   protected manifestMetadataSupport():
-    | SandboxManifestMetadataSupport
-    | undefined {
+    SandboxManifestMetadataSupport | undefined {
     return undefined;
   }
 

--- a/packages/agents-extensions/test/sandbox/cloudflare.test.ts
+++ b/packages/agents-extensions/test/sandbox/cloudflare.test.ts
@@ -351,6 +351,61 @@ describe('CloudflareSandboxClient', () => {
     });
   });
 
+  test.each([undefined, 'root'])(
+    'does not expose Cloudflare path probe stdout for runAs %s',
+    async (runAs) => {
+      const sensitiveOutput = 'sensitive login profile output';
+      const client = new CloudflareSandboxClient();
+      const session = await client.create(new Manifest(), {
+        workerUrl: 'https://worker.example.com',
+      });
+      const originalFetchImplementation = vi
+        .mocked(global.fetch)
+        .getMockImplementation();
+      vi.mocked(global.fetch).mockImplementation(async (input, init) => {
+        if (String(input).includes('/exec')) {
+          const payload = JSON.parse(String(init?.body)) as { argv?: string[] };
+          if (payload.argv?.[2]?.includes('test -e ')) {
+            return sseExecResponse([
+              {
+                event: 'stdout',
+                data: Buffer.from(sensitiveOutput).toString('base64'),
+              },
+              {
+                event: 'stderr',
+                data: Buffer.from('Permission denied').toString('base64'),
+              },
+              {
+                event: 'exit',
+                data: JSON.stringify({ exit_code: 1 }),
+              },
+            ]);
+          }
+        }
+        return await originalFetchImplementation!(input, init);
+      });
+
+      let thrown: unknown;
+      try {
+        await session.pathExists('/workspace/blocked', runAs);
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(SandboxProviderError);
+      expect(thrown).toMatchObject({
+        details: {
+          provider: 'cloudflare',
+          path: '/workspace/blocked',
+          status: 1,
+          stdoutBytes: sensitiveOutput.length,
+        },
+      });
+      expect((thrown as Error).message).toContain('Permission denied');
+      expect((thrown as Error).message).not.toContain(sensitiveOutput);
+    },
+  );
+
   test('rejects invalid sandbox ids returned by create', async () => {
     vi.mocked(global.fetch).mockResolvedValueOnce(
       jsonResponse({ id: '../cf_test' }),

--- a/packages/agents-extensions/test/sandbox/cloudflare.test.ts
+++ b/packages/agents-extensions/test/sandbox/cloudflare.test.ts
@@ -309,6 +309,48 @@ describe('CloudflareSandboxClient', () => {
     ).toBe(true);
   });
 
+  test.each([
+    { status: 1, stderr: 'Permission denied' },
+    { status: 2, stderr: 'Input/output error' },
+  ])('preserves failed Cloudflare filesystem probes: %j', async (result) => {
+    const client = new CloudflareSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workerUrl: 'https://worker.example.com',
+    });
+    const originalFetchImplementation = vi
+      .mocked(global.fetch)
+      .getMockImplementation();
+    vi.mocked(global.fetch).mockImplementation(async (input, init) => {
+      if (String(input).includes('/exec')) {
+        const payload = JSON.parse(String(init?.body)) as { argv?: string[] };
+        if (payload.argv?.[2]?.startsWith('test -e ')) {
+          return sseExecResponse([
+            {
+              event: 'stderr',
+              data: Buffer.from(result.stderr).toString('base64'),
+            },
+            {
+              event: 'exit',
+              data: JSON.stringify({ exit_code: result.status }),
+            },
+          ]);
+        }
+      }
+      return await originalFetchImplementation!(input, init);
+    });
+
+    await expect(
+      session.pathExists('/workspace/blocked'),
+    ).rejects.toMatchObject({
+      code: 'provider_error',
+      details: {
+        provider: 'cloudflare',
+        path: '/workspace/blocked',
+        status: result.status,
+      },
+    });
+  });
+
   test('rejects invalid sandbox ids returned by create', async () => {
     vi.mocked(global.fetch).mockResolvedValueOnce(
       jsonResponse({ id: '../cf_test' }),
@@ -852,6 +894,11 @@ describe('CloudflareSandboxClient', () => {
             ),
           },
           { event: 'exit', data: JSON.stringify({ exit_code: 0 }) },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        sseExecResponse([
+          { event: 'exit', data: JSON.stringify({ exit_code: 1 }) },
         ]),
       )
       .mockResolvedValueOnce(

--- a/packages/agents-extensions/test/sandbox/daytona.test.ts
+++ b/packages/agents-extensions/test/sandbox/daytona.test.ts
@@ -155,6 +155,34 @@ describe('DaytonaSandboxClient', () => {
     ).toBe(true);
   });
 
+  test.each([undefined, 'root'])(
+    'preserves Daytona provider identity for failed path probes with runAs=%s',
+    async (runAs) => {
+      const client = new DaytonaSandboxClient();
+      const session = await client.create(new Manifest());
+      const originalImplementation = executeCommandMock.getMockImplementation();
+      executeCommandMock.mockImplementation(async (command, ...args) => {
+        if (String(command).includes('test -e ')) {
+          return {
+            exitCode: 1,
+            result: 'Permission denied',
+            artifacts: { stdout: 'Permission denied' },
+          };
+        }
+        return await originalImplementation?.(command, ...args);
+      });
+
+      await expect(session.pathExists('blocked', runAs)).rejects.toMatchObject({
+        code: 'provider_error',
+        details: {
+          provider: 'daytona',
+          path: '/home/daytona/workspace/blocked',
+          status: 1,
+        },
+      });
+    },
+  );
+
   test('cleans up when workspace root preparation fails', async () => {
     executeCommandMock.mockResolvedValueOnce({
       exitCode: 1,

--- a/packages/agents-extensions/test/sandbox/e2b.test.ts
+++ b/packages/agents-extensions/test/sandbox/e2b.test.ts
@@ -1164,6 +1164,13 @@ describe('E2BSandboxClient', () => {
         };
       }
       if (command.startsWith('test -e ')) {
+        if (command.includes('OPENAI_AGENTS_READ_PATH_PROBE_V1')) {
+          return {
+            stdout: '',
+            stderr: 'find: /workspace/missing.txt: No such file or directory',
+            exitCode: 1,
+          };
+        }
         throw Object.assign(new Error('missing path'), {
           exitCode: 1,
           stderr: 'missing path',

--- a/packages/agents-extensions/test/sandbox/modal.test.ts
+++ b/packages/agents-extensions/test/sandbox/modal.test.ts
@@ -209,6 +209,17 @@ describe('ModalSandboxClient', () => {
     sandboxExecMock.mockImplementation(
       async (command: string[], _params?: Record<string, unknown>) => {
         if (command[0] === '/bin/sh') {
+          if (command[2]?.includes('OPENAI_AGENTS_READ_PATH_PROBE_V1')) {
+            return {
+              stdin: {
+                writeText: async (_text: string) => {},
+                close: async () => {},
+              },
+              stdout: textStream(''),
+              stderr: textStream(''),
+              wait: async () => 1,
+            };
+          }
           const resolvedPath = resolvedRemotePathFromValidationCommand(
             command[2] ?? '',
           );
@@ -356,6 +367,38 @@ describe('ModalSandboxClient', () => {
         command.join(' ').includes("target_user='root'"),
       ),
     ).toBe(true);
+  });
+
+  test.each([
+    { status: 1, stderr: 'Permission denied' },
+    { status: 2, stderr: 'Input/output error' },
+  ])('preserves failed Modal filesystem probes: %j', async (result) => {
+    const client = new ModalSandboxClient();
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+    } satisfies ModalSandboxClientOptions);
+    const originalImplementation = sandboxExecMock.getMockImplementation();
+    sandboxExecMock.mockImplementation(async (command, options) => {
+      if (command[0] === 'test') {
+        return {
+          stdout: textStream(''),
+          stderr: textStream(result.stderr),
+          wait: async () => result.status,
+        };
+      }
+      return await originalImplementation?.(command, options);
+    });
+
+    await expect(
+      session.pathExists('/workspace/blocked'),
+    ).rejects.toMatchObject({
+      code: 'provider_error',
+      details: {
+        provider: 'modal',
+        path: '/workspace/blocked',
+        status: result.status,
+      },
+    });
   });
 
   test('clears exec yield timers when commands finish before timeout', async () => {

--- a/packages/agents-extensions/test/sandbox/shared.test.ts
+++ b/packages/agents-extensions/test/sandbox/shared.test.ts
@@ -1661,6 +1661,27 @@ describe('remote sandbox path helpers', () => {
     expect(files.has('renamed/new.txt')).toBe(false);
   });
 
+  test('does not treat unreadable editor fallback reads as missing files', async () => {
+    const denied = Object.assign(new Error('Permission denied'), {
+      code: 'EACCES',
+    });
+    const editor = new RemoteSandboxEditor({
+      readText: async () => {
+        throw denied;
+      },
+      writeText: vi.fn(),
+      deletePath: vi.fn(),
+    });
+
+    await expect(
+      editor.createFile({
+        type: 'create_file',
+        path: '/workspace/blocked',
+        diff: '+hello',
+      }),
+    ).rejects.toBe(denied);
+  });
+
   test('prepares runAs remote writes with privileged ownership commands', async () => {
     const commands: Array<{
       command: string;
@@ -1761,7 +1782,32 @@ describe('remote sandbox path helpers', () => {
         command: "test -e '/workspace/missing'",
         options: { runAs: 'sandbox-user' },
       },
+      {
+        command: expect.stringContaining('OPENAI_AGENTS_READ_PATH_PROBE_V1'),
+        options: { runAs: 'sandbox-user' },
+      },
     ]);
+  });
+
+  test.each([
+    { status: 1, stderr: 'Permission denied' },
+    { status: 2, stderr: 'Input/output error' },
+  ])('preserves failed runAs path probes: %j', async (result) => {
+    await expect(
+      runAsRemotePathExists(
+        '/workspace/blocked',
+        'sandbox-user',
+        async () => result,
+        { providerName: 'FakeSandboxClient', providerId: 'fake' },
+      ),
+    ).rejects.toMatchObject({
+      code: 'provider_error',
+      details: {
+        provider: 'fake',
+        path: '/workspace/blocked',
+        status: result.status,
+      },
+    });
   });
 
   test('reports runAs command failures with provider context', async () => {
@@ -1826,18 +1872,22 @@ describe('remote sandbox path helpers', () => {
       options: { runAs: 'sandbox-user' },
     });
     expect(commands[1]).toEqual({
+      command: expect.stringContaining('OPENAI_AGENTS_READ_PATH_PROBE_V1'),
+      options: { runAs: 'sandbox-user' },
+    });
+    expect(commands[2]).toEqual({
       command: "mkdir -p -- '/workspace/src'",
       options: { runAs: 'sandbox-user' },
     });
-    expect(commands[2]).toMatchObject({
+    expect(commands[3]).toMatchObject({
       command: expect.stringContaining("chown 'sandbox-user':'sandbox-user'"),
       options: { runAs: 'root' },
     });
-    expect(commands[3]).toMatchObject({
+    expect(commands[4]).toMatchObject({
       command: expect.stringContaining("cat -- '/tmp/openai-agents-"),
       options: { runAs: 'sandbox-user' },
     });
-    expect(commands[4]).toMatchObject({
+    expect(commands[5]).toMatchObject({
       command: expect.stringContaining("rm -f -- '/tmp/openai-agents-"),
       options: { runAs: 'root' },
     });

--- a/packages/agents-extensions/test/sandbox/sharedSession.test.ts
+++ b/packages/agents-extensions/test/sandbox/sharedSession.test.ts
@@ -117,6 +117,22 @@ class FakeRemoteSession extends RemoteSandboxSessionBase<FakeRemoteSessionState>
   }
 }
 
+class FailedPathProbeSession extends FakeRemoteSession {
+  constructor(private readonly result: RemoteSandboxCommandResult) {
+    super();
+  }
+
+  protected override async runRemoteCommand(
+    command: string,
+    options: RemoteSandboxCommandOptions,
+  ): Promise<RemoteSandboxCommandResult> {
+    if (command.startsWith('test -e ')) {
+      return this.result;
+    }
+    return await super.runRemoteCommand(command, options);
+  }
+}
+
 describe('shared sandbox session helpers', () => {
   test('rejects unsupported core create options for provider clients', () => {
     expect(() =>
@@ -378,6 +394,22 @@ describe('shared sandbox session helpers', () => {
       host: 'sandbox.example.com',
       port: 8080,
       tls: true,
+    });
+  });
+
+  test.each([
+    { status: 1, stderr: 'Permission denied' },
+    { status: 2, stderr: 'Input/output error' },
+  ])('preserves failed remote path probes: %j', async (result) => {
+    const session = new FailedPathProbeSession(result);
+
+    await expect(session.pathExists('blocked')).rejects.toMatchObject({
+      code: 'provider_error',
+      details: {
+        provider: 'fake',
+        path: '/workspace/blocked',
+        status: result.status,
+      },
     });
   });
 

--- a/packages/agents-extensions/test/sandbox/vercel.test.ts
+++ b/packages/agents-extensions/test/sandbox/vercel.test.ts
@@ -166,7 +166,7 @@ function vercelHttpError(status: number): Error {
 }
 
 function testExistsPath(command: string): string | undefined {
-  return command.match(/^test -e '([^']+)'$/u)?.[1];
+  return command.match(/^test -e '([^']+)'(?:$| \|\| \(path=)/u)?.[1];
 }
 
 function vercelS3Manifest(
@@ -1496,6 +1496,29 @@ describe('VercelSandboxClient', () => {
         content: 'hello',
       },
     ]);
+  });
+
+  test.each([
+    { status: 1, stderr: 'Permission denied' },
+    { status: 2, stderr: 'Input/output error' },
+  ])('preserves failed Vercel filesystem probes: %j', async (result) => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(new Manifest());
+    runCommandMock.mockImplementation(async (params: MockRunCommandParams) => {
+      if (params.args?.[1]?.startsWith('test -e ')) {
+        return commandResult(result.status, '', result.stderr);
+      }
+      return await defaultRunCommand(params);
+    });
+
+    await expect(session.pathExists('blocked')).rejects.toMatchObject({
+      code: 'provider_error',
+      details: {
+        provider: 'vercel',
+        path: '/vercel/sandbox/blocked',
+        status: result.status,
+      },
+    });
   });
 
   test('fails editor deletes when remote rm fails', async () => {


### PR DESCRIPTION
This pull request fixes sandbox path existence checks that previously treated permission failures, I/O errors, invalid symbolic links, and provider failures as missing files. It introduces consistent fail-closed probing across local and remote sandbox providers, preserves genuine not-found behavior for lazy skill discovery and editors, and prevents partial stdout from leaking into error details.