### PR TITLE
chore: add sensitive logging audit skill

### DIFF
--- a/.agents/skills/sensitive-logging-audit/SKILL.md
+++ b/.agents/skills/sensitive-logging-audit/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: sensitive-logging-audit
+description: Audit and fix sensitive-data exposure through runtime logging in openai-agents-js. Use when reviewing logger or console calls, checking OPENAI_AGENTS_DONT_LOG_MODEL_DATA or OPENAI_AGENTS_DONT_LOG_TOOL_DATA coverage, investigating exceptions or payloads that may reveal model inputs and outputs, tool arguments and results, Realtime events, MCP data, session history, or arbitrary thrown values, and when the task should continue from detection through code fixes, regression tests, changesets, and repository verification.
+---
+
+# Sensitive Logging Audit
+
+## Objective
+
+Complete the remediation, not only the scan. Inventory every runtime log sink, classify each dynamic value, fix every demonstrated model/tool-data leak in scope, add adversarial regression tests, and run all repository-required close-out gates.
+
+Do not claim automated taint analysis. The inventory proves sink coverage; source-to-sink classification still requires code tracing.
+
+## Workflow
+
+### 1. Establish the baseline
+
+- Work in the user's current checkout and branch. Preserve unrelated changes.
+- Record `git status --short --branch` and the current commit.
+- Read the logging policy in `packages/agents-core/src/config.ts` and helpers in `packages/agents-core/src/logger.ts` before judging call sites.
+- Treat model/tool errors as potentially sensitive: messages, causes, stacks, schema errors, and arbitrary thrown values can retain user data.
+
+Run the deterministic inventory from the repository root:
+
+```bash
+node .agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs --format json > /tmp/sensitive-logging-before.json
+node .agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs --summary-only
+```
+
+Run its tests before relying on the report:
+
+```bash
+node --test .agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
+```
+
+### 2. Classify every dynamic sink
+
+Review the complete JSON ledger. Do not stop after the first confirmed leak. Prioritize:
+
+1. Raw `console.*` calls, because they bypass `Logger` policy.
+2. Calls that log a caught value.
+3. Calls with supplemental payloads.
+4. Dynamic messages using interpolation, `JSON.stringify`, schema formatting, or `toErrorMessage`.
+5. Model, tool, Realtime, MCP, session, tracing, and cleanup boundaries.
+
+Assign one disposition to every dynamic entry:
+
+- `model`: may contain model requests, responses, Realtime model events, or derived values.
+- `tool`: may contain tool arguments, outputs, tool events, MCP payloads, or derived values.
+- `model+tool`: may contain either class.
+- `operational`: proven to contain only non-sensitive SDK metadata.
+- `uncertain`: source tracing is incomplete; investigate before deciding.
+
+Record file, line, fingerprint, disposition, evidence, and action in the task notes. A variable name or log message is not sufficient evidence. Trace producers, formatters, callbacks, and thrown-value ownership.
+
+### 3. Fix demonstrated leaks
+
+Before changing runtime code, use `$implementation-strategy` and follow the repository's compatibility decision. Then implement the narrowest shared-boundary fix.
+
+- Prefer `logModelActionError` or `logToolActionError` for error-level paths.
+- For debug or warning paths, apply the relevant logger flag before formatting or inspecting sensitive values. Add a shared helper only when multiple paths need the same semantics.
+- For `model+tool`, redact when either relevant policy disables data logging.
+- Preserve existing diagnostic details when the applicable logging flags allow them.
+- In redacted mode, emit only a fixed message and a safe fixed type. Do not inspect `error.constructor`, stack, message, cause, proxy properties, or supplemental payloads.
+- Keep logging failure from changing caller behavior. Fallback results, event emission, cleanup, rejection, and cancellation must still complete.
+- Do not redact operational metadata merely because it is dynamic. Explain why each retained value is safe.
+
+When a candidate is not a leak, keep the code unchanged and record the concrete source-to-sink reason.
+
+### 4. Add adversarial regressions
+
+Read [the redaction validation matrix](references/redaction-validation.md) and cover every changed sensitive path. At minimum test:
+
+- redacted and diagnostic modes;
+- model-only, tool-only, and both-flags combinations as applicable;
+- unique sentinel strings across the full captured logger call;
+- `Error`, string, object, supplemental payload, constructor override, revoked `Proxy`, and throwing `getPrototypeOf` cases where arbitrary thrown values are accepted;
+- observable caller behavior after logging.
+
+Prefer focused unit tests at the real caller boundary. Helper-only tests do not prove all call sites use the helper.
+
+### 5. Re-audit the whole tree
+
+Run the inventory again:
+
+```bash
+node .agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs --format json > /tmp/sensitive-logging-after.json
+```
+
+Compare the before/after findings by fingerprint and inspect every new or changed dynamic call. Revisit the full candidate list, not only edited files. The completion report must state:
+
+- total and dynamic sink counts;
+- all confirmed leaks fixed;
+- all retained candidates and their evidence-backed dispositions;
+- any unresolved candidate and why it remains unresolved.
+
+Do not report completion while a demonstrated leak remains in scope.
+
+### 6. Run repository close-out gates
+
+- If `packages/` changed, use `$changeset-validation` and ensure every affected package has an appropriate changeset.
+- For runtime code, tests, scripts, or build/test behavior, use `$code-change-verification` and rerun the full stack after the final fix.
+- Use `$pr-draft-summary` after all edits and verification.
+- Stop after local changes and verification unless the user explicitly requests a remote action in the same turn.
+
+## Reporting
+
+Lead with whether any real leaks were found and fixed. Separate confirmed leaks from conservative review candidates. Include the inventory counts, affected paths, adversarial cases, verification results, and remaining uncertainty. Do not equate a clean inventory shape with proof that all dynamic values are non-sensitive.

--- a/.agents/skills/sensitive-logging-audit/agents/openai.yaml
+++ b/.agents/skills/sensitive-logging-audit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Sensitive Logging Audit"
+  short_description: "Audit and fix sensitive runtime logging paths"
+  default_prompt: "Use $sensitive-logging-audit to inventory, verify, and fix sensitive logging leaks in this repository."

--- a/.agents/skills/sensitive-logging-audit/references/redaction-validation.md
+++ b/.agents/skills/sensitive-logging-audit/references/redaction-validation.md
@@ -1,0 +1,46 @@
+# Sensitive logging audit
+
+Use `scripts/inventory-logging.mjs` from the skill directory to inventory every SDK runtime logger call that may carry model data, tool data, thrown values, or other dynamic payloads.
+
+```bash
+node .agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs --summary-only
+node .agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs --format json > /tmp/sensitive-logging.json
+```
+
+The inventory is deliberately broader than a vulnerability detector. Static analysis can prove that a dynamic value reaches a log call, but it cannot reliably decide whether an arbitrary value is sensitive. Review every dynamic entry and classify it as one of:
+
+- `model`: model requests, responses, Realtime model events, or errors that may include those values.
+- `tool`: tool arguments, outputs, tool events, or errors that may include those values.
+- `model+tool`: a payload may include both classes.
+- `operational`: the value is demonstrably limited to non-sensitive SDK metadata.
+
+For model or tool entries, route logging through a policy-aware helper or guard it with `dontLogModelData` / `dontLogToolData`. Do not treat an exception as operational merely because the call site logs only the exception: messages, causes, stacks, schema errors, and arbitrary thrown values may retain sensitive input.
+
+## Required validation matrix
+
+For each policy-aware logging path, test both the redacted and diagnostic modes. Use unique sentinel strings and assert against the complete captured logger call, not only one argument.
+
+| Case | Model flag | Tool flag | Thrown value | Required assertion |
+| --- | --- | --- | --- | --- |
+| Model redaction | on | off | `Error(secret)` | No sentinel appears; diagnostic type is stable |
+| Tool redaction | off | on | `Error(secret)` | No sentinel appears; diagnostic type is stable |
+| Both redacted | on | on | object/string/error | No sentinel appears in any logger call |
+| Diagnostic mode | off | off | ordinary error | Existing diagnostic detail is preserved |
+| Hostile constructor | applicable flag on | applicable | `Error` with throwing or controlled `constructor` | Logging does not throw or reveal attacker-controlled data |
+| Hostile prototype | applicable flag on | applicable | revoked `Proxy` or throwing `getPrototypeOf` trap | Logging does not throw and the caller's fallback continues |
+| Supplemental payload | applicable flag on | applicable | safe-looking error plus secret detail object | Supplemental arguments are omitted |
+
+Also exercise the observable caller behavior after logging. Error handling is not correct if redaction prevents a fallback result, event emission, cleanup, or rejection from completing.
+
+## Review procedure
+
+1. Run the full inventory against `packages/*/src`.
+2. Review raw `console.*` calls first because they bypass `Logger` policy flags.
+3. Review caught-value calls next; arbitrary thrown values are attacker-controlled at JavaScript boundaries.
+4. Review every remaining dynamic call and record its model/tool/operational classification in the audit notes.
+5. Trace sensitive values through formatting helpers such as template literals, `JSON.stringify`, schema errors, and `toErrorMessage`; formatting is not redaction.
+6. Verify both streaming and non-streaming paths, Realtime and regular runs, tool approval rejection, MCP/tool adapters, session callbacks, tracing/export failures, and cleanup paths when they can carry user data.
+7. Add the focused matrix above for every sensitive path that is changed.
+8. Re-run the inventory after the fix and compare fingerprints. Every added or changed dynamic call requires classification before merge.
+
+The audit supports a strong completeness claim about reviewed log sinks, not automatic information-flow proof. A future CI gate can store reviewed fingerprints and fail on new or changed dynamic calls; the JSON output is stable enough to build that ledger without tying policy decisions to line numbers.

--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
@@ -2,11 +2,20 @@
 
 import { createHash } from 'node:crypto';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { relative, resolve } from 'node:path';
+import { dirname, relative, resolve } from 'node:path';
 import process from 'node:process';
 import ts from 'typescript';
 
 const LOGGER_METHODS = new Set(['debug', 'error', 'info', 'log', 'warn']);
+const LOGGER_TYPE_PROPERTIES = [
+  'debug',
+  'dontLogModelData',
+  'dontLogToolData',
+  'error',
+  'namespace',
+  'warn',
+];
+const STANDARD_GLOBALS = new Set(['global', 'globalThis', 'window']);
 const SENSITIVE_HELPERS = new Map([
   ['logModelActionError', 'model-helper'],
   ['logModelActionWarning', 'model-helper'],
@@ -102,6 +111,31 @@ function propertyAccessParts(expression) {
   return null;
 }
 
+function isGloballyQualifiedConsole(expression) {
+  const access = propertyAccessParts(expression);
+  if (!access || access.method !== 'console') {
+    return false;
+  }
+  const receiver = unwrapExpression(access.receiver);
+  return ts.isIdentifier(receiver) && STANDARD_GLOBALS.has(receiver.text);
+}
+
+function checkerRecognizesLogger(expression, checker) {
+  if (!checker) {
+    return false;
+  }
+  try {
+    const type = checker.getApparentType(
+      checker.getNonNullableType(checker.getTypeAtLocation(expression)),
+    );
+    return LOGGER_TYPE_PROPERTIES.every((property) =>
+      checker.getPropertyOfType(type, property),
+    );
+  } catch {
+    return false;
+  }
+}
+
 function normalizeFilePath(path) {
   return path.replace(/\\/g, '/');
 }
@@ -184,7 +218,7 @@ function heritageReferencesLogger(node, loggerTypeBindings) {
   );
 }
 
-function collectLoggingSymbols(sourceFile) {
+function collectLoggingSymbols(sourceFile, checker) {
   const consoleBindings = new Set(['console']);
   const consoleMethodBindings = new Map();
   const loggerBindings = new Set();
@@ -321,6 +355,9 @@ function collectLoggingSymbols(sourceFile) {
       if (ts.isIdentifier(current)) {
         return consoleBindings.has(current.text);
       }
+      if (isGloballyQualifiedConsole(current)) {
+        return true;
+      }
       if (ts.isConditionalExpression(current)) {
         return (
           isKnownConsoleExpression(current.whenTrue) ||
@@ -397,6 +434,9 @@ function collectLoggingSymbols(sourceFile) {
     }
     function isKnownLoggerExpression(expression) {
       const current = unwrapExpression(expression);
+      if (checkerRecognizesLogger(current, checker)) {
+        return true;
+      }
       if (ts.isIdentifier(current)) {
         return loggerBindings.has(current.text);
       }
@@ -633,6 +673,9 @@ function collectLoggingSymbols(sourceFile) {
 
   function isLoggerReceiver(expression) {
     const current = unwrapExpression(expression);
+    if (checkerRecognizesLogger(current, checker)) {
+      return true;
+    }
     if (ts.isIdentifier(current)) {
       return loggerBindings.has(current.text);
     }
@@ -695,7 +738,8 @@ function collectLoggingSymbols(sourceFile) {
       return null;
     }
     const receiver = unwrapExpression(access.receiver);
-    return ts.isIdentifier(receiver) && consoleBindings.has(receiver.text)
+    return (ts.isIdentifier(receiver) && consoleBindings.has(receiver.text)) ||
+      isGloballyQualifiedConsole(receiver)
       ? access.method
       : null;
   }
@@ -881,6 +925,15 @@ function callSiteContext(node, sourceFile) {
     if (ts.isSwitchStatement(current)) {
       parts.push(`switch:${normalizeNodeText(current.expression, sourceFile)}`);
     }
+    if (ts.isTryStatement(current)) {
+      const branch =
+        current.tryBlock === child
+          ? 'try'
+          : current.catchClause === child
+            ? 'catch'
+            : 'finally';
+      parts.push(`try:${branch}`);
+    }
     if (ts.isCallExpression(current) && current.arguments.includes(child)) {
       const callbackIndex = current.arguments.indexOf(child);
       parts.push(
@@ -952,18 +1005,7 @@ function signalsFor(text) {
   return signals;
 }
 
-export function inventorySource(sourceText, filePath = 'fixture.ts') {
-  filePath = normalizeFilePath(filePath);
-  const scriptKind = filePath.endsWith('.tsx')
-    ? ts.ScriptKind.TSX
-    : ts.ScriptKind.TS;
-  const sourceFile = ts.createSourceFile(
-    filePath,
-    sourceText,
-    ts.ScriptTarget.Latest,
-    true,
-    scriptKind,
-  );
+function inventoryParsedSource(sourceFile, filePath, checker = null) {
   const findings = [];
   const occurrences = new Map();
   const {
@@ -971,7 +1013,7 @@ export function inventorySource(sourceText, filePath = 'fixture.ts') {
     resolveConsoleMethod,
     resolveLoggerMethod,
     resolveSensitiveHelper,
-  } = collectLoggingSymbols(sourceFile);
+  } = collectLoggingSymbols(sourceFile, checker);
 
   function recordCall(call, kind, method, policy) {
     const start = sourceFile.getLineAndCharacterOfPosition(call.getStart());
@@ -1056,6 +1098,92 @@ export function inventorySource(sourceText, filePath = 'fixture.ts') {
   return findings;
 }
 
+export function inventorySource(sourceText, filePath = 'fixture.ts') {
+  filePath = normalizeFilePath(filePath);
+  const scriptKind = filePath.endsWith('.tsx')
+    ? ts.ScriptKind.TSX
+    : ts.ScriptKind.TS;
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKind,
+  );
+  return inventoryParsedSource(sourceFile, filePath);
+}
+
+export function inventorySources(sources) {
+  const virtualRoot = resolve('/__sensitive_logging_inventory__');
+  const entries = Object.entries(sources).map(([filePath, sourceText]) => {
+    const normalizedPath = normalizeFilePath(filePath).replace(/^\/+/, '');
+    return {
+      absolutePath: resolve(virtualRoot, normalizedPath),
+      filePath: normalizedPath,
+      sourceText,
+    };
+  });
+  const sourceByPath = new Map(
+    entries.map((entry) => [entry.absolutePath, entry.sourceText]),
+  );
+  const options = {
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    noEmit: true,
+    skipLibCheck: true,
+    target: ts.ScriptTarget.Latest,
+  };
+  const host = ts.createCompilerHost(options);
+  const defaultDirectoryExists = host.directoryExists?.bind(host);
+  const defaultFileExists = host.fileExists.bind(host);
+  const defaultGetSourceFile = host.getSourceFile.bind(host);
+  const defaultRealpath = host.realpath?.bind(host);
+  const defaultReadFile = host.readFile.bind(host);
+  host.directoryExists = (directoryName) => {
+    const absoluteDirectory = resolve(directoryName);
+    return (
+      absoluteDirectory === virtualRoot ||
+      [...sourceByPath.keys()].some((fileName) =>
+        fileName.startsWith(`${absoluteDirectory}/`),
+      ) ||
+      defaultDirectoryExists?.(directoryName) === true
+    );
+  };
+  host.fileExists = (fileName) =>
+    sourceByPath.has(resolve(fileName)) || defaultFileExists(fileName);
+  host.realpath = (fileName) =>
+    sourceByPath.has(resolve(fileName))
+      ? resolve(fileName)
+      : (defaultRealpath?.(fileName) ?? fileName);
+  host.readFile = (fileName) =>
+    sourceByPath.get(resolve(fileName)) ?? defaultReadFile(fileName);
+  host.getSourceFile = (fileName, languageVersion, onError) => {
+    const sourceText = sourceByPath.get(resolve(fileName));
+    return sourceText === undefined
+      ? defaultGetSourceFile(fileName, languageVersion, onError)
+      : ts.createSourceFile(
+          fileName,
+          sourceText,
+          languageVersion,
+          true,
+          fileName.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+        );
+  };
+  host.getCurrentDirectory = () => virtualRoot;
+  const program = ts.createProgram({
+    rootNames: entries.map((entry) => entry.absolutePath),
+    options,
+    host,
+  });
+  const checker = program.getTypeChecker();
+  return entries.flatMap((entry) => {
+    const sourceFile = program.getSourceFile(entry.absolutePath);
+    return sourceFile
+      ? inventoryParsedSource(sourceFile, entry.filePath, checker)
+      : [];
+  });
+}
+
 function summarize(findings) {
   const dynamic = findings.filter(
     (finding) => finding.shape !== 'static-message',
@@ -1119,6 +1247,36 @@ Default roots: packages/*/src
 `;
 }
 
+function createInventoryProgram(cwd, absolutePaths) {
+  let compilerOptions = {
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Node10,
+    noEmit: true,
+    skipLibCheck: true,
+    target: ts.ScriptTarget.Latest,
+  };
+  const configPath = ts.findConfigFile(cwd, ts.sys.fileExists, 'tsconfig.json');
+  if (configPath) {
+    const loaded = ts.readConfigFile(configPath, ts.sys.readFile);
+    if (!loaded.error) {
+      const parsed = ts.parseJsonConfigFileContent(
+        loaded.config,
+        ts.sys,
+        dirname(configPath),
+      );
+      compilerOptions = {
+        ...parsed.options,
+        noEmit: true,
+        skipLibCheck: true,
+      };
+    }
+  }
+  return ts.createProgram({
+    rootNames: absolutePaths,
+    options: compilerOptions,
+  });
+}
+
 export function run(argv = process.argv.slice(2)) {
   const options = parseArguments(argv);
   if (options.help) {
@@ -1141,13 +1299,16 @@ export function run(argv = process.argv.slice(2)) {
             }
           });
 
-  const findings = roots
-    .flatMap(collectSourceFiles)
-    .sort()
-    .flatMap((absolutePath) => {
-      const filePath = normalizeFilePath(relative(cwd, absolutePath));
-      return inventorySource(readFileSync(absolutePath, 'utf8'), filePath);
-    });
+  const absolutePaths = roots.flatMap(collectSourceFiles).sort();
+  const program = createInventoryProgram(cwd, absolutePaths);
+  const checker = program.getTypeChecker();
+  const findings = absolutePaths.flatMap((absolutePath) => {
+    const filePath = normalizeFilePath(relative(cwd, absolutePath));
+    const sourceFile = program.getSourceFile(absolutePath);
+    return sourceFile
+      ? inventoryParsedSource(sourceFile, filePath, checker)
+      : inventorySource(readFileSync(absolutePath, 'utf8'), filePath);
+  });
   const summary = summarize(findings);
 
   if (options.format === 'json') {

--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
@@ -9,7 +9,13 @@ import ts from 'typescript';
 const LOGGER_METHODS = new Set(['debug', 'error', 'info', 'log', 'warn']);
 const SENSITIVE_HELPERS = new Map([
   ['logModelActionError', 'model-helper'],
+  ['logModelActionWarning', 'model-helper'],
+  ['logModelAndToolActionDebug', 'model+tool-helper'],
+  ['logModelAndToolActionError', 'model+tool-helper'],
+  ['logModelAndToolActionWarning', 'model+tool-helper'],
   ['logToolActionError', 'tool-helper'],
+  ['logToolActionDebug', 'tool-helper'],
+  ['logToolActionWarning', 'tool-helper'],
 ]);
 const SOURCE_EXTENSIONS = new Set(['.cts', '.mts', '.ts', '.tsx']);
 
@@ -134,7 +140,7 @@ function referencesIdentifier(node, identifier) {
   return found;
 }
 
-function enclosingCatchVariable(node) {
+function enclosingRejectedValueIdentifier(node) {
   let current = node.parent;
   while (current) {
     if (ts.isCatchClause(current)) {
@@ -143,9 +149,79 @@ function enclosingCatchVariable(node) {
         ? declaration.name.text
         : null;
     }
+    if (ts.isFunctionLike(current)) {
+      const callback = current;
+      const call = callback.parent;
+      if (ts.isCallExpression(call)) {
+        const callbackIndex = call.arguments.indexOf(callback);
+        const access = propertyAccessParts(call.expression);
+        const isRejectionHandler =
+          (access?.method === 'catch' && callbackIndex === 0) ||
+          (access?.method === 'then' && callbackIndex === 1);
+        if (isRejectionHandler) {
+          const parameter = callback.parameters[0];
+          return parameter && ts.isIdentifier(parameter.name)
+            ? parameter.name.text
+            : null;
+        }
+      }
+    }
     current = current.parent;
   }
   return null;
+}
+
+function normalizeNodeText(node, sourceFile) {
+  return node.getText(sourceFile).replace(/\s+/g, ' ').trim();
+}
+
+function declarationName(node, sourceFile) {
+  if (
+    (ts.isFunctionDeclaration(node) ||
+      ts.isClassDeclaration(node) ||
+      ts.isMethodDeclaration(node) ||
+      ts.isPropertyDeclaration(node)) &&
+    node.name
+  ) {
+    return normalizeNodeText(node.name, sourceFile);
+  }
+  if (ts.isConstructorDeclaration(node)) {
+    return 'constructor';
+  }
+  if (ts.isVariableDeclaration(node)) {
+    return normalizeNodeText(node.name, sourceFile);
+  }
+  if (ts.isPropertyAssignment(node)) {
+    return normalizeNodeText(node.name, sourceFile);
+  }
+  return null;
+}
+
+function callSiteContext(node, sourceFile) {
+  const parts = [];
+  let child = node;
+  let current = node.parent;
+  while (current && !ts.isSourceFile(current)) {
+    const name = declarationName(current, sourceFile);
+    if (name) {
+      parts.push(`${ts.SyntaxKind[current.kind]}:${name}`);
+    }
+    if (ts.isIfStatement(current)) {
+      const branch = current.thenStatement === child ? 'then' : 'else';
+      parts.push(
+        `if:${normalizeNodeText(current.expression, sourceFile)}:${branch}`,
+      );
+    }
+    if (ts.isCallExpression(current) && current.arguments.includes(child)) {
+      const callbackIndex = current.arguments.indexOf(child);
+      parts.push(
+        `callback:${normalizeNodeText(current.expression, sourceFile)}:${callbackIndex}`,
+      );
+    }
+    child = current;
+    current = current.parent;
+  }
+  return parts.reverse().join('>') || '<module>';
 }
 
 function guardedPolicy(node, sourceFile) {
@@ -177,9 +253,9 @@ function normalizeCallText(call, sourceFile) {
   return call.getText(sourceFile).replace(/\s+/g, ' ').trim();
 }
 
-function fingerprint(path, normalizedCall) {
+function fingerprint(path, context, normalizedCall, occurrence) {
   return createHash('sha256')
-    .update(`${path}\0${normalizedCall}`)
+    .update(`${path}\0${context}\0${normalizedCall}\0${occurrence}`)
     .digest('hex')
     .slice(0, 12);
 }
@@ -216,11 +292,16 @@ export function inventorySource(sourceText, filePath = 'fixture.ts') {
     scriptKind,
   );
   const findings = [];
+  const occurrences = new Map();
 
   function recordCall(call, kind, method, policy) {
     const start = sourceFile.getLineAndCharacterOfPosition(call.getStart());
     const normalizedCall = normalizeCallText(call, sourceFile);
-    const catchVariable = enclosingCatchVariable(call);
+    const context = callSiteContext(call, sourceFile);
+    const occurrenceKey = `${context}\0${normalizedCall}`;
+    const occurrence = occurrences.get(occurrenceKey) ?? 0;
+    occurrences.set(occurrenceKey, occurrence + 1);
+    const catchVariable = enclosingRejectedValueIdentifier(call);
     const referencesCatchValue = Boolean(
       catchVariable &&
       call.arguments.some((argument) =>
@@ -230,7 +311,7 @@ export function inventorySource(sourceText, filePath = 'fixture.ts') {
     const dynamicMessage = hasDynamicMessage(call);
     const hasPayload = call.arguments.length > 1;
     findings.push({
-      fingerprint: fingerprint(filePath, normalizedCall),
+      fingerprint: fingerprint(filePath, context, normalizedCall, occurrence),
       file: filePath,
       line: start.line + 1,
       column: start.character + 1,
@@ -243,6 +324,7 @@ export function inventorySource(sourceText, filePath = 'fixture.ts') {
           : 'static-message',
       policy,
       catchValue: referencesCatchValue ? catchVariable : null,
+      context,
       signals: signalsFor(normalizedCall),
       call: normalizedCall,
     });

--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
@@ -161,11 +161,35 @@ function typeIsLoggerValue(typeNode, loggerTypeBindings) {
   );
 }
 
+function heritageReferencesLogger(node, loggerTypeBindings) {
+  return Boolean(
+    node.heritageClauses?.some((clause) =>
+      clause.types.some((heritageType) => {
+        const expression = unwrapExpression(heritageType.expression);
+        if (
+          (ts.isIdentifier(expression) &&
+            loggerTypeBindings.has(expression.text)) ||
+          (ts.isPropertyAccessExpression(expression) &&
+            expression.name.text === 'Logger')
+        ) {
+          return true;
+        }
+        return (
+          heritageType.typeArguments?.some((type) =>
+            typeIsLoggerValue(type, loggerTypeBindings),
+          ) === true
+        );
+      }),
+    ),
+  );
+}
+
 function collectLoggingSymbols(sourceFile) {
   const consoleBindings = new Set(['console']);
   const consoleMethodBindings = new Map();
   const loggerBindings = new Set();
   const loggerFactoryBindings = new Set(['getLogger']);
+  const loggerMethodBindings = new Map();
   const loggerNamespaceBindings = new Set();
   const loggerPropertyNames = new Set();
   const loggerTypeBindings = new Set(['Logger']);
@@ -324,14 +348,14 @@ function collectLoggingSymbols(sourceFile) {
       if (isLoggerFactoryCall(current)) {
         return true;
       }
-      if (ts.isPropertyAccessExpression(current)) {
-        const propertyName = propertyNameText(current.name, sourceFile);
-        const receiver = unwrapExpression(current.expression);
+      const access = propertyAccessParts(current);
+      if (access) {
+        const receiver = unwrapExpression(access.receiver);
         return (
-          loggerPropertyNames.has(propertyName) ||
+          loggerPropertyNames.has(access.method) ||
           (ts.isIdentifier(receiver) &&
             loggerNamespaceBindings.has(receiver.text) &&
-            propertyName === 'logger')
+            access.method === 'logger')
         );
       }
       if (ts.isConditionalExpression(current)) {
@@ -350,6 +374,49 @@ function collectLoggingSymbols(sourceFile) {
         );
       }
       return false;
+    }
+    function resolveLoggerMethod(expression) {
+      const current = unwrapExpression(expression);
+      if (ts.isIdentifier(current)) {
+        return loggerMethodBindings.get(current.text) ?? null;
+      }
+      const access = propertyAccessParts(current);
+      return access &&
+        LOGGER_METHODS.has(access.method) &&
+        isKnownLoggerExpression(access.receiver)
+        ? access.method
+        : null;
+    }
+    function recordLoggerMethodDeclaration(declaration) {
+      if (!declaration.initializer) {
+        return;
+      }
+      if (ts.isIdentifier(declaration.name)) {
+        addMapping(
+          loggerMethodBindings,
+          declaration.name.text,
+          resolveLoggerMethod(declaration.initializer),
+        );
+        return;
+      }
+      if (
+        !ts.isObjectBindingPattern(declaration.name) ||
+        !isKnownLoggerExpression(declaration.initializer)
+      ) {
+        return;
+      }
+      for (const element of declaration.name.elements) {
+        if (element.dotDotDotToken || !ts.isIdentifier(element.name)) {
+          continue;
+        }
+        const method = propertyNameText(
+          element.propertyName ?? element.name,
+          sourceFile,
+        );
+        if (LOGGER_METHODS.has(method)) {
+          addMapping(loggerMethodBindings, element.name.text, method);
+        }
+      }
     }
     function recordDeclaration(declaration) {
       if (typeIsLoggerValue(declaration.type, loggerTypeBindings)) {
@@ -396,6 +463,14 @@ function collectLoggingSymbols(sourceFile) {
         add(loggerTypeBindings, current.name.text);
       }
       if (
+        (ts.isInterfaceDeclaration(current) ||
+          ts.isClassDeclaration(current)) &&
+        current.name &&
+        heritageReferencesLogger(current, loggerTypeBindings)
+      ) {
+        add(loggerTypeBindings, current.name.text);
+      }
+      if (
         ts.isPropertySignature(current) &&
         typeIsLoggerValue(current.type, loggerTypeBindings)
       ) {
@@ -410,6 +485,7 @@ function collectLoggingSymbols(sourceFile) {
       }
       if (ts.isVariableDeclaration(current)) {
         recordConsoleDeclaration(current);
+        recordLoggerMethodDeclaration(current);
       }
       if (
         ts.isPropertyAssignment(current) &&
@@ -431,8 +507,11 @@ function collectLoggingSymbols(sourceFile) {
         if (isKnownLoggerExpression(current.right)) {
           if (ts.isIdentifier(target)) {
             add(loggerBindings, target.text);
-          } else if (ts.isPropertyAccessExpression(target)) {
-            add(loggerPropertyNames, propertyNameText(target.name, sourceFile));
+          } else {
+            const targetAccess = propertyAccessParts(target);
+            if (targetAccess) {
+              add(loggerPropertyNames, targetAccess.method);
+            }
           }
         }
         if (ts.isIdentifier(target)) {
@@ -443,6 +522,11 @@ function collectLoggingSymbols(sourceFile) {
             consoleMethodBindings,
             target.text,
             resolveConsoleMethod(current.right),
+          );
+          addMapping(
+            loggerMethodBindings,
+            target.text,
+            resolveLoggerMethod(current.right),
           );
         }
       }
@@ -469,16 +553,16 @@ function collectLoggingSymbols(sourceFile) {
         loggerNamespaceBindings.has(unwrapExpression(access.receiver).text),
       );
     }
-    if (ts.isPropertyAccessExpression(current)) {
-      const propertyName = propertyNameText(current.name, sourceFile);
-      const receiver = unwrapExpression(current.expression);
+    const access = propertyAccessParts(current);
+    if (access) {
+      const receiver = unwrapExpression(access.receiver);
       return (
-        loggerPropertyNames.has(propertyName) ||
+        loggerPropertyNames.has(access.method) ||
         (receiver.kind === ts.SyntaxKind.ThisKeyword &&
-          propertyName === 'logger') ||
+          access.method === 'logger') ||
         (ts.isIdentifier(receiver) &&
           loggerNamespaceBindings.has(receiver.text) &&
-          propertyName === 'logger')
+          access.method === 'logger')
       );
     }
     return false;
@@ -519,7 +603,25 @@ function collectLoggingSymbols(sourceFile) {
       : null;
   }
 
-  return { isLoggerReceiver, resolveConsoleMethod, resolveSensitiveHelper };
+  function resolveLoggerMethod(expression) {
+    const current = unwrapExpression(expression);
+    if (ts.isIdentifier(current)) {
+      return loggerMethodBindings.get(current.text) ?? null;
+    }
+    const access = propertyAccessParts(current);
+    return access &&
+      LOGGER_METHODS.has(access.method) &&
+      isLoggerReceiver(access.receiver)
+      ? access.method
+      : null;
+  }
+
+  return {
+    isLoggerReceiver,
+    resolveConsoleMethod,
+    resolveLoggerMethod,
+    resolveSensitiveHelper,
+  };
 }
 
 function isStaticString(expression) {
@@ -766,8 +868,12 @@ export function inventorySource(sourceText, filePath = 'fixture.ts') {
   );
   const findings = [];
   const occurrences = new Map();
-  const { isLoggerReceiver, resolveConsoleMethod, resolveSensitiveHelper } =
-    collectLoggingSymbols(sourceFile);
+  const {
+    isLoggerReceiver,
+    resolveConsoleMethod,
+    resolveLoggerMethod,
+    resolveSensitiveHelper,
+  } = collectLoggingSymbols(sourceFile);
 
   function recordCall(call, kind, method, policy) {
     const start = sourceFile.getLineAndCharacterOfPosition(call.getStart());
@@ -810,9 +916,17 @@ export function inventorySource(sourceText, filePath = 'fixture.ts') {
   function visit(node) {
     if (ts.isCallExpression(node)) {
       const consoleMethod = resolveConsoleMethod(node.expression);
+      const loggerMethod = resolveLoggerMethod(node.expression);
       const sensitiveHelper = resolveSensitiveHelper(node.expression);
       if (consoleMethod) {
         recordCall(node, 'console', consoleMethod, 'none');
+      } else if (loggerMethod) {
+        recordCall(
+          node,
+          'logger',
+          loggerMethod,
+          guardedPolicy(node, sourceFile),
+        );
       } else if (sensitiveHelper) {
         recordCall(
           node,

--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
@@ -102,14 +102,259 @@ function propertyAccessParts(expression) {
   return null;
 }
 
-function isLoggerReceiver(expression, sourceFile) {
-  const text = expression.getText(sourceFile);
-  return /logger$/i.test(text);
-}
-
 function isConsoleReceiver(expression) {
   const unwrapped = unwrapExpression(expression);
   return ts.isIdentifier(unwrapped) && unwrapped.text === 'console';
+}
+
+function normalizeFilePath(path) {
+  return path.replace(/\\/g, '/');
+}
+
+function importName(specifier) {
+  return specifier.propertyName?.text ?? specifier.name.text;
+}
+
+function isLoggerModule(moduleName) {
+  return /(?:^|\/)logger(?:\.[cm]?[jt]s)?$/.test(moduleName);
+}
+
+function propertyNameText(name, sourceFile) {
+  return name ? normalizeNodeText(name, sourceFile) : null;
+}
+
+function typeReferencesLogger(typeNode, loggerTypeBindings) {
+  let found = false;
+  function visit(current) {
+    if (found) {
+      return;
+    }
+    if (
+      ts.isTypeReferenceNode(current) &&
+      ((ts.isIdentifier(current.typeName) &&
+        loggerTypeBindings.has(current.typeName.text)) ||
+        (ts.isQualifiedName(current.typeName) &&
+          current.typeName.right.text === 'Logger'))
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(current, visit);
+  }
+  if (typeNode) {
+    visit(typeNode);
+  }
+  return found;
+}
+
+function collectLoggerSymbols(sourceFile) {
+  const loggerBindings = new Set();
+  const loggerFactoryBindings = new Set(['getLogger']);
+  const loggerNamespaceBindings = new Set();
+  const loggerPropertyNames = new Set();
+  const loggerTypeBindings = new Set(['Logger']);
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement)) {
+      continue;
+    }
+    const moduleName = ts.isStringLiteral(statement.moduleSpecifier)
+      ? statement.moduleSpecifier.text
+      : '';
+    const clause = statement.importClause;
+    if (!clause) {
+      continue;
+    }
+    if (clause.name && isLoggerModule(moduleName)) {
+      loggerBindings.add(clause.name.text);
+    }
+    const bindings = clause.namedBindings;
+    if (bindings && ts.isNamespaceImport(bindings)) {
+      loggerNamespaceBindings.add(bindings.name.text);
+      continue;
+    }
+    if (!bindings || !ts.isNamedImports(bindings)) {
+      continue;
+    }
+    for (const specifier of bindings.elements) {
+      const imported = importName(specifier);
+      const local = specifier.name.text;
+      if (imported === 'getLogger') {
+        loggerFactoryBindings.add(local);
+      } else if (imported === 'logger') {
+        loggerBindings.add(local);
+      } else if (imported === 'Logger') {
+        loggerTypeBindings.add(local);
+      }
+    }
+  }
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    function add(set, value) {
+      if (value && !set.has(value)) {
+        set.add(value);
+        changed = true;
+      }
+    }
+    function isLoggerFactoryCall(expression) {
+      const current = unwrapExpression(expression);
+      if (!ts.isCallExpression(current)) {
+        return false;
+      }
+      const callee = unwrapExpression(current.expression);
+      if (ts.isIdentifier(callee) && loggerFactoryBindings.has(callee.text)) {
+        return true;
+      }
+      const access = propertyAccessParts(callee);
+      return Boolean(
+        access &&
+        access.method === 'getLogger' &&
+        ts.isIdentifier(unwrapExpression(access.receiver)) &&
+        loggerNamespaceBindings.has(unwrapExpression(access.receiver).text),
+      );
+    }
+    function isKnownLoggerExpression(expression) {
+      const current = unwrapExpression(expression);
+      if (ts.isIdentifier(current)) {
+        return loggerBindings.has(current.text);
+      }
+      if (isLoggerFactoryCall(current)) {
+        return true;
+      }
+      if (ts.isPropertyAccessExpression(current)) {
+        const propertyName = propertyNameText(current.name, sourceFile);
+        const receiver = unwrapExpression(current.expression);
+        return (
+          loggerPropertyNames.has(propertyName) ||
+          (ts.isIdentifier(receiver) &&
+            loggerNamespaceBindings.has(receiver.text) &&
+            propertyName === 'logger')
+        );
+      }
+      if (ts.isConditionalExpression(current)) {
+        return (
+          isKnownLoggerExpression(current.whenTrue) ||
+          isKnownLoggerExpression(current.whenFalse)
+        );
+      }
+      if (
+        ts.isBinaryExpression(current) &&
+        current.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken
+      ) {
+        return (
+          isKnownLoggerExpression(current.left) ||
+          isKnownLoggerExpression(current.right)
+        );
+      }
+      return false;
+    }
+    function recordDeclaration(declaration) {
+      if (
+        declaration.type &&
+        typeReferencesLogger(declaration.type, loggerTypeBindings)
+      ) {
+        if (ts.isPropertyDeclaration(declaration)) {
+          add(
+            loggerPropertyNames,
+            propertyNameText(declaration.name, sourceFile),
+          );
+        } else if (ts.isIdentifier(declaration.name)) {
+          add(loggerBindings, declaration.name.text);
+          if (ts.isParameter(declaration) && declaration.modifiers?.length) {
+            add(
+              loggerPropertyNames,
+              propertyNameText(declaration.name, sourceFile),
+            );
+          }
+        }
+      }
+      if (
+        !declaration.initializer ||
+        !isKnownLoggerExpression(declaration.initializer)
+      ) {
+        return;
+      }
+      if (ts.isPropertyDeclaration(declaration)) {
+        add(
+          loggerPropertyNames,
+          propertyNameText(declaration.name, sourceFile),
+        );
+      } else if (ts.isIdentifier(declaration.name)) {
+        add(loggerBindings, declaration.name.text);
+      } else {
+        add(
+          loggerPropertyNames,
+          propertyNameText(declaration.name, sourceFile),
+        );
+      }
+    }
+    function visit(current) {
+      if (
+        ts.isTypeAliasDeclaration(current) &&
+        typeReferencesLogger(current.type, loggerTypeBindings)
+      ) {
+        add(loggerTypeBindings, current.name.text);
+      }
+      if (
+        ts.isVariableDeclaration(current) ||
+        ts.isParameter(current) ||
+        ts.isPropertyDeclaration(current)
+      ) {
+        recordDeclaration(current);
+      }
+      if (
+        ts.isBinaryExpression(current) &&
+        current.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        isKnownLoggerExpression(current.right)
+      ) {
+        const target = unwrapExpression(current.left);
+        if (ts.isIdentifier(target)) {
+          add(loggerBindings, target.text);
+        } else if (ts.isPropertyAccessExpression(target)) {
+          add(loggerPropertyNames, propertyNameText(target.name, sourceFile));
+        }
+      }
+      ts.forEachChild(current, visit);
+    }
+    visit(sourceFile);
+  }
+
+  function isLoggerReceiver(expression) {
+    const current = unwrapExpression(expression);
+    if (ts.isIdentifier(current)) {
+      return loggerBindings.has(current.text);
+    }
+    if (ts.isCallExpression(current)) {
+      const callee = unwrapExpression(current.expression);
+      if (ts.isIdentifier(callee) && loggerFactoryBindings.has(callee.text)) {
+        return true;
+      }
+      const access = propertyAccessParts(callee);
+      return Boolean(
+        access &&
+        access.method === 'getLogger' &&
+        ts.isIdentifier(unwrapExpression(access.receiver)) &&
+        loggerNamespaceBindings.has(unwrapExpression(access.receiver).text),
+      );
+    }
+    if (ts.isPropertyAccessExpression(current)) {
+      const propertyName = propertyNameText(current.name, sourceFile);
+      const receiver = unwrapExpression(current.expression);
+      return (
+        loggerPropertyNames.has(propertyName) ||
+        (receiver.kind === ts.SyntaxKind.ThisKeyword &&
+          propertyName === 'logger') ||
+        (ts.isIdentifier(receiver) &&
+          loggerNamespaceBindings.has(receiver.text) &&
+          propertyName === 'logger')
+      );
+    }
+    return false;
+  }
+
+  return { isLoggerReceiver };
 }
 
 function isStaticString(expression) {
@@ -157,7 +402,13 @@ function enclosingRejectedValueIdentifier(node) {
         const access = propertyAccessParts(call.expression);
         const isRejectionHandler =
           (access?.method === 'catch' && callbackIndex === 0) ||
-          (access?.method === 'then' && callbackIndex === 1);
+          (access?.method === 'then' && callbackIndex === 1) ||
+          ((access?.method === 'on' ||
+            access?.method === 'once' ||
+            access?.method === 'addListener') &&
+            callbackIndex === 1 &&
+            ts.isStringLiteral(call.arguments[0]) &&
+            call.arguments[0].text === 'unhandledRejection');
         if (isRejectionHandler) {
           const parameter = callback.parameters[0];
           return parameter && ts.isIdentifier(parameter.name)
@@ -281,6 +532,7 @@ function signalsFor(text) {
 }
 
 export function inventorySource(sourceText, filePath = 'fixture.ts') {
+  filePath = normalizeFilePath(filePath);
   const scriptKind = filePath.endsWith('.tsx')
     ? ts.ScriptKind.TSX
     : ts.ScriptKind.TS;
@@ -293,6 +545,7 @@ export function inventorySource(sourceText, filePath = 'fixture.ts') {
   );
   const findings = [];
   const occurrences = new Map();
+  const { isLoggerReceiver } = collectLoggerSymbols(sourceFile);
 
   function recordCall(call, kind, method, policy) {
     const start = sourceFile.getLineAndCharacterOfPosition(call.getStart());
@@ -348,7 +601,7 @@ export function inventorySource(sourceText, filePath = 'fixture.ts') {
         if (access && LOGGER_METHODS.has(access.method)) {
           if (isConsoleReceiver(access.receiver)) {
             recordCall(node, 'console', access.method, 'none');
-          } else if (isLoggerReceiver(access.receiver, sourceFile)) {
+          } else if (isLoggerReceiver(access.receiver)) {
             recordCall(
               node,
               'logger',
@@ -455,7 +708,7 @@ export function run(argv = process.argv.slice(2)) {
     .flatMap(collectSourceFiles)
     .sort()
     .flatMap((absolutePath) => {
-      const filePath = relative(cwd, absolutePath);
+      const filePath = normalizeFilePath(relative(cwd, absolutePath));
       return inventorySource(readFileSync(absolutePath, 'utf8'), filePath);
     });
   const summary = summarize(findings);

--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
@@ -320,6 +320,18 @@ function collectLoggerSymbols(sourceFile) {
         recordDeclaration(current);
       }
       if (
+        ts.isPropertyAssignment(current) &&
+        isKnownLoggerExpression(current.initializer)
+      ) {
+        add(loggerPropertyNames, propertyNameText(current.name, sourceFile));
+      }
+      if (
+        ts.isShorthandPropertyAssignment(current) &&
+        loggerBindings.has(current.name.text)
+      ) {
+        add(loggerPropertyNames, current.name.text);
+      }
+      if (
         ts.isBinaryExpression(current) &&
         current.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
         isKnownLoggerExpression(current.right)
@@ -420,14 +432,41 @@ function referencesIdentifier(node, identifier) {
   return found;
 }
 
-function enclosingRejectedValueIdentifier(node) {
+function bindingIdentifiers(name) {
+  const identifiers = [];
+
+  function visit(current) {
+    if (ts.isIdentifier(current)) {
+      identifiers.push(current.text);
+      return;
+    }
+    if (
+      ts.isObjectBindingPattern(current) ||
+      ts.isArrayBindingPattern(current)
+    ) {
+      for (const element of current.elements) {
+        if (ts.isBindingElement(element)) {
+          visit(element.name);
+        }
+      }
+    }
+  }
+
+  visit(name);
+  return identifiers;
+}
+
+function enclosingRejectedValueIdentifiers(node) {
+  const identifiers = new Set();
   let current = node.parent;
   while (current) {
     if (ts.isCatchClause(current)) {
       const declaration = current.variableDeclaration;
-      return declaration && ts.isIdentifier(declaration.name)
-        ? declaration.name.text
-        : null;
+      if (declaration) {
+        for (const identifier of bindingIdentifiers(declaration.name)) {
+          identifiers.add(identifier);
+        }
+      }
     }
     if (ts.isFunctionLike(current)) {
       const callback = current;
@@ -446,15 +485,17 @@ function enclosingRejectedValueIdentifier(node) {
             call.arguments[0].text === 'unhandledRejection');
         if (isRejectionHandler) {
           const parameter = callback.parameters[0];
-          return parameter && ts.isIdentifier(parameter.name)
-            ? parameter.name.text
-            : null;
+          if (parameter) {
+            for (const identifier of bindingIdentifiers(parameter.name)) {
+              identifiers.add(identifier);
+            }
+          }
         }
       }
     }
     current = current.parent;
   }
-  return null;
+  return [...identifiers];
 }
 
 function normalizeNodeText(node, sourceFile) {
@@ -493,10 +534,34 @@ function callSiteContext(node, sourceFile) {
       parts.push(`${ts.SyntaxKind[current.kind]}:${name}`);
     }
     if (ts.isIfStatement(current)) {
-      const branch = current.thenStatement === child ? 'then' : 'else';
+      const branch =
+        current.expression === child
+          ? 'condition'
+          : current.thenStatement === child
+            ? 'then'
+            : 'else';
       parts.push(
         `if:${normalizeNodeText(current.expression, sourceFile)}:${branch}`,
       );
+    }
+    if (ts.isConditionalExpression(current)) {
+      const branch =
+        current.condition === child
+          ? 'condition'
+          : current.whenTrue === child
+            ? 'true'
+            : 'false';
+      parts.push(
+        `conditional:${normalizeNodeText(current.condition, sourceFile)}:${branch}`,
+      );
+    }
+    if (ts.isCaseClause(current)) {
+      parts.push(`case:${normalizeNodeText(current.expression, sourceFile)}`);
+    } else if (ts.isDefaultClause(current)) {
+      parts.push('case:default');
+    }
+    if (ts.isSwitchStatement(current)) {
+      parts.push(`switch:${normalizeNodeText(current.expression, sourceFile)}`);
     }
     if (ts.isCallExpression(current) && current.arguments.includes(child)) {
       const callbackIndex = current.arguments.indexOf(child);
@@ -593,11 +658,10 @@ export function inventorySource(sourceText, filePath = 'fixture.ts') {
     const occurrenceKey = `${context}\0${normalizedCall}`;
     const occurrence = occurrences.get(occurrenceKey) ?? 0;
     occurrences.set(occurrenceKey, occurrence + 1);
-    const catchVariable = enclosingRejectedValueIdentifier(call);
-    const referencesCatchValue = Boolean(
-      catchVariable &&
+    const catchValues = enclosingRejectedValueIdentifiers(call);
+    const referencedCatchValues = catchValues.filter((catchValue) =>
       call.arguments.some((argument) =>
-        referencesIdentifier(argument, catchVariable),
+        referencesIdentifier(argument, catchValue),
       ),
     );
     const dynamicMessage = hasDynamicMessage(call);
@@ -615,7 +679,10 @@ export function inventorySource(sourceText, filePath = 'fixture.ts') {
           ? 'dynamic-message'
           : 'static-message',
       policy,
-      catchValue: referencesCatchValue ? catchVariable : null,
+      catchValue:
+        referencedCatchValues.length > 0
+          ? referencedCatchValues.join(', ')
+          : null,
       context,
       signals: signalsFor(normalizedCall),
       call: normalizedCall,

--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
@@ -19,13 +19,10 @@ const LOGGER_TYPE_PROPERTIES = [
 const STANDARD_GLOBALS = new Set(['global', 'globalThis', 'window']);
 const SENSITIVE_HELPERS = new Map([
   ['logModelActionError', 'model-helper'],
-  ['logModelActionWarning', 'model-helper'],
-  ['logModelAndToolActionDebug', 'model+tool-helper'],
-  ['logModelAndToolActionError', 'model+tool-helper'],
-  ['logModelAndToolActionWarning', 'model+tool-helper'],
   ['logToolActionError', 'tool-helper'],
-  ['logToolActionDebug', 'tool-helper'],
-  ['logToolActionWarning', 'tool-helper'],
+]);
+const SENSITIVE_HELPER_MODULES = new Set([
+  '@openai/agents-core/utils/internal',
 ]);
 const SOURCE_EXTENSIONS = new Set(['.cts', '.mts', '.ts', '.tsx']);
 
@@ -149,6 +146,10 @@ function isLoggerModule(moduleName) {
   return /(?:^|\/)logger(?:\.[cm]?[jt]s)?$/.test(moduleName);
 }
 
+function isSensitiveHelperModule(moduleName) {
+  return isLoggerModule(moduleName) || SENSITIVE_HELPER_MODULES.has(moduleName);
+}
+
 function propertyNameText(name, sourceFile) {
   if (!name) {
     return null;
@@ -222,6 +223,7 @@ function heritageReferencesLogger(node, loggerTypeBindings) {
 function collectLoggingSymbols(sourceFile, checker) {
   const consoleBindings = new Set(['console']);
   const consoleMethodBindings = new Map();
+  const consolePropertyNames = new Set();
   const loggerBindings = new Set();
   const loggerFactoryBindings = new Set(['getLogger']);
   const loggerMethodBindings = new Map();
@@ -229,12 +231,7 @@ function collectLoggingSymbols(sourceFile, checker) {
   const loggerObjectTypeProperties = new Map();
   const loggerPropertyNames = new Set();
   const loggerTypeBindings = new Set(['Logger']);
-  const sensitiveHelperBindings = new Map(
-    [...SENSITIVE_HELPERS].map(([name, policy]) => [
-      name,
-      { method: name, policy },
-    ]),
-  );
+  const sensitiveHelperBindings = new Map();
   const sensitiveHelperNamespaceBindings = new Set();
 
   for (const statement of sourceFile.statements) {
@@ -244,6 +241,7 @@ function collectLoggingSymbols(sourceFile, checker) {
     const moduleName = ts.isStringLiteral(statement.moduleSpecifier)
       ? statement.moduleSpecifier.text
       : '';
+    const trustedSensitiveHelperModule = isSensitiveHelperModule(moduleName);
     const clause = statement.importClause;
     if (!clause) {
       continue;
@@ -254,7 +252,9 @@ function collectLoggingSymbols(sourceFile, checker) {
     const bindings = clause.namedBindings;
     if (bindings && ts.isNamespaceImport(bindings)) {
       loggerNamespaceBindings.add(bindings.name.text);
-      sensitiveHelperNamespaceBindings.add(bindings.name.text);
+      if (trustedSensitiveHelperModule) {
+        sensitiveHelperNamespaceBindings.add(bindings.name.text);
+      }
       continue;
     }
     if (!bindings || !ts.isNamedImports(bindings)) {
@@ -271,7 +271,7 @@ function collectLoggingSymbols(sourceFile, checker) {
         loggerTypeBindings.add(local);
       }
       const sensitivePolicy = SENSITIVE_HELPERS.get(imported);
-      if (sensitivePolicy) {
+      if (sensitivePolicy && trustedSensitiveHelperModule) {
         sensitiveHelperBindings.set(local, {
           method: imported,
           policy: sensitivePolicy,
@@ -357,6 +357,10 @@ function collectLoggingSymbols(sourceFile, checker) {
         return consoleBindings.has(current.text);
       }
       if (isGloballyQualifiedConsole(current)) {
+        return true;
+      }
+      const access = propertyAccessParts(current);
+      if (access && consolePropertyNames.has(access.method)) {
         return true;
       }
       if (ts.isConditionalExpression(current)) {
@@ -626,6 +630,18 @@ function collectLoggingSymbols(sourceFile, checker) {
       }
       if (
         ts.isPropertyAssignment(current) &&
+        isKnownConsoleExpression(current.initializer)
+      ) {
+        add(consolePropertyNames, propertyNameText(current.name, sourceFile));
+      }
+      if (
+        ts.isShorthandPropertyAssignment(current) &&
+        consoleBindings.has(current.name.text)
+      ) {
+        add(consolePropertyNames, current.name.text);
+      }
+      if (
+        ts.isPropertyAssignment(current) &&
         isKnownLoggerExpression(current.initializer)
       ) {
         add(loggerPropertyNames, propertyNameText(current.name, sourceFile));
@@ -665,6 +681,11 @@ function collectLoggingSymbols(sourceFile, checker) {
             target.text,
             resolveLoggerMethods(current.right),
           );
+        } else if (isKnownConsoleExpression(current.right)) {
+          const targetAccess = propertyAccessParts(target);
+          if (targetAccess) {
+            add(consolePropertyNames, targetAccess.method);
+          }
         }
       }
       ts.forEachChild(current, visit);
@@ -739,8 +760,10 @@ function collectLoggingSymbols(sourceFile, checker) {
       return null;
     }
     const receiver = unwrapExpression(access.receiver);
+    const receiverAccess = propertyAccessParts(receiver);
     return (ts.isIdentifier(receiver) && consoleBindings.has(receiver.text)) ||
-      isGloballyQualifiedConsole(receiver)
+      isGloballyQualifiedConsole(receiver) ||
+      (receiverAccess && consolePropertyNames.has(receiverAccess.method))
       ? access.method
       : null;
   }
@@ -951,8 +974,86 @@ function callSiteContext(node, sourceFile) {
   return parts.reverse().join('>') || '<module>';
 }
 
-function guardedPolicy(node, sourceFile) {
+function possibleBooleanResults(expression, flagName, flagValue) {
+  const current = unwrapExpression(expression);
+  if (
+    referencesIdentifier(current, flagName) &&
+    ((ts.isIdentifier(current) && current.text === flagName) ||
+      propertyAccessParts(current)?.method === flagName)
+  ) {
+    return new Set([flagValue]);
+  }
+  if (current.kind === ts.SyntaxKind.TrueKeyword) {
+    return new Set([true]);
+  }
+  if (current.kind === ts.SyntaxKind.FalseKeyword) {
+    return new Set([false]);
+  }
+  if (
+    ts.isPrefixUnaryExpression(current) &&
+    current.operator === ts.SyntaxKind.ExclamationToken
+  ) {
+    return new Set(
+      [...possibleBooleanResults(current.operand, flagName, flagValue)].map(
+        (value) => !value,
+      ),
+    );
+  }
+  if (ts.isBinaryExpression(current)) {
+    const operator = current.operatorToken.kind;
+    const left = possibleBooleanResults(current.left, flagName, flagValue);
+    const right = possibleBooleanResults(current.right, flagName, flagValue);
+    if (
+      operator === ts.SyntaxKind.AmpersandAmpersandToken ||
+      operator === ts.SyntaxKind.BarBarToken
+    ) {
+      const results = new Set();
+      for (const leftValue of left) {
+        for (const rightValue of right) {
+          results.add(
+            operator === ts.SyntaxKind.AmpersandAmpersandToken
+              ? leftValue && rightValue
+              : leftValue || rightValue,
+          );
+        }
+      }
+      return results;
+    }
+    if (
+      operator === ts.SyntaxKind.EqualsEqualsToken ||
+      operator === ts.SyntaxKind.EqualsEqualsEqualsToken ||
+      operator === ts.SyntaxKind.ExclamationEqualsToken ||
+      operator === ts.SyntaxKind.ExclamationEqualsEqualsToken
+    ) {
+      const negated =
+        operator === ts.SyntaxKind.ExclamationEqualsToken ||
+        operator === ts.SyntaxKind.ExclamationEqualsEqualsToken;
+      const results = new Set();
+      for (const leftValue of left) {
+        for (const rightValue of right) {
+          results.add(
+            negated ? leftValue !== rightValue : leftValue === rightValue,
+          );
+        }
+      }
+      return results;
+    }
+  }
+  return new Set([false, true]);
+}
+
+function branchGuaranteesFlagDisabled(condition, branchValue, flagName) {
+  return (
+    referencesIdentifier(condition, flagName) &&
+    !possibleBooleanResults(condition, flagName, true).has(branchValue)
+  );
+}
+
+function guardedPolicy(node) {
+  let child = node;
   let current = node.parent;
+  let modelGuard = false;
+  let toolGuard = false;
   while (current) {
     if (ts.isFunctionLike(current)) {
       break;
@@ -961,20 +1062,38 @@ function guardedPolicy(node, sourceFile) {
       const conditionNode = ts.isIfStatement(current)
         ? current.expression
         : current.condition;
-      const condition = conditionNode.getText(sourceFile);
-      const hasModelPolicy = condition.includes('dontLogModelData');
-      const hasToolPolicy = condition.includes('dontLogToolData');
-      if (hasModelPolicy && hasToolPolicy) {
-        return 'model+tool-guard';
-      }
-      if (hasModelPolicy) {
-        return 'model-guard';
-      }
-      if (hasToolPolicy) {
-        return 'tool-guard';
+      const trueBranch = ts.isIfStatement(current)
+        ? current.thenStatement
+        : current.whenTrue;
+      const falseBranch = ts.isIfStatement(current)
+        ? current.elseStatement
+        : current.whenFalse;
+      const branchValue =
+        child === trueBranch ? true : child === falseBranch ? false : null;
+      if (branchValue !== null) {
+        modelGuard ||= branchGuaranteesFlagDisabled(
+          conditionNode,
+          branchValue,
+          'dontLogModelData',
+        );
+        toolGuard ||= branchGuaranteesFlagDisabled(
+          conditionNode,
+          branchValue,
+          'dontLogToolData',
+        );
       }
     }
+    child = current;
     current = current.parent;
+  }
+  if (modelGuard && toolGuard) {
+    return 'model+tool-guard';
+  }
+  if (modelGuard) {
+    return 'model-guard';
+  }
+  if (toolGuard) {
+    return 'tool-guard';
   }
   return 'none';
 }
@@ -1121,7 +1240,7 @@ function inventoryParsedSource(sourceFile, filePath, checker = null) {
           argument,
           'logger',
           loggerMethod,
-          guardedPolicy(argument, sourceFile),
+          guardedPolicy(argument),
           call,
           callbackIndex,
         );
@@ -1140,12 +1259,7 @@ function inventoryParsedSource(sourceFile, filePath, checker = null) {
       if (consoleMethod) {
         recordCall(node, 'console', consoleMethod, 'none');
       } else if (loggerMethod) {
-        recordCall(
-          node,
-          'logger',
-          loggerMethod,
-          guardedPolicy(node, sourceFile),
-        );
+        recordCall(node, 'logger', loggerMethod, guardedPolicy(node));
       } else if (sensitiveHelper) {
         recordCall(
           node,
@@ -1160,12 +1274,7 @@ function inventoryParsedSource(sourceFile, filePath, checker = null) {
             (access.computed || LOGGER_METHODS.has(access.method)) &&
             isLoggerReceiver(access.receiver)
           ) {
-            recordCall(
-              node,
-              'logger',
-              access.method,
-              guardedPolicy(node, sourceFile),
-            );
+            recordCall(node, 'logger', access.method, guardedPolicy(node));
           }
         }
       }

--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
@@ -191,6 +191,7 @@ function collectLoggingSymbols(sourceFile) {
   const loggerFactoryBindings = new Set(['getLogger']);
   const loggerMethodBindings = new Map();
   const loggerNamespaceBindings = new Set();
+  const loggerObjectTypeProperties = new Map();
   const loggerPropertyNames = new Set();
   const loggerTypeBindings = new Set(['Logger']);
   const sensitiveHelperBindings = new Map(
@@ -253,11 +254,67 @@ function collectLoggingSymbols(sourceFile) {
         changed = true;
       }
     }
-    function addMapping(map, key, value) {
-      if (key && value && map.get(key) !== value) {
-        map.set(key, value);
-        changed = true;
+    function addMappings(map, key, values) {
+      if (!key) {
+        return;
       }
+      for (const value of values) {
+        if (!value) {
+          continue;
+        }
+        let mapped = map.get(key);
+        if (!mapped) {
+          mapped = new Set();
+          map.set(key, mapped);
+        }
+        if (!mapped.has(value)) {
+          mapped.add(value);
+          changed = true;
+        }
+      }
+    }
+    function loggerPropertiesForType(typeNode) {
+      if (!typeNode) {
+        return new Set();
+      }
+      if (
+        ts.isParenthesizedTypeNode(typeNode) ||
+        ts.isTypeOperatorNode(typeNode)
+      ) {
+        return loggerPropertiesForType(typeNode.type);
+      }
+      if (ts.isUnionTypeNode(typeNode) || ts.isIntersectionTypeNode(typeNode)) {
+        return new Set(
+          typeNode.types.flatMap((type) => [...loggerPropertiesForType(type)]),
+        );
+      }
+      if (ts.isTypeLiteralNode(typeNode)) {
+        return new Set(
+          typeNode.members.flatMap((member) =>
+            ts.isPropertySignature(member) &&
+            typeIsLoggerValue(member.type, loggerTypeBindings)
+              ? [propertyNameText(member.name, sourceFile)]
+              : [],
+          ),
+        );
+      }
+      if (!ts.isTypeReferenceNode(typeNode)) {
+        return new Set();
+      }
+      const properties = new Set();
+      if (ts.isIdentifier(typeNode.typeName)) {
+        for (const property of loggerObjectTypeProperties.get(
+          typeNode.typeName.text,
+        ) ?? []) {
+          properties.add(property);
+        }
+      }
+      for (const typeArgument of typeNode.typeArguments ?? []) {
+        for (const property of loggerPropertiesForType(typeArgument)) {
+          properties.add(property);
+        }
+      }
+      return properties;
     }
     function isKnownConsoleExpression(expression) {
       const current = unwrapExpression(expression);
@@ -281,15 +338,15 @@ function collectLoggingSymbols(sourceFile) {
       }
       return false;
     }
-    function resolveConsoleMethod(expression) {
+    function resolveConsoleMethods(expression) {
       const current = unwrapExpression(expression);
       if (ts.isIdentifier(current)) {
-        return consoleMethodBindings.get(current.text) ?? null;
+        return consoleMethodBindings.get(current.text) ?? [];
       }
       const access = propertyAccessParts(current);
       return access && isKnownConsoleExpression(access.receiver)
-        ? access.method
-        : null;
+        ? [access.method]
+        : [];
     }
     function recordConsoleDeclaration(declaration) {
       if (!declaration.initializer) {
@@ -299,10 +356,10 @@ function collectLoggingSymbols(sourceFile) {
         if (isKnownConsoleExpression(declaration.initializer)) {
           add(consoleBindings, declaration.name.text);
         }
-        addMapping(
+        addMappings(
           consoleMethodBindings,
           declaration.name.text,
-          resolveConsoleMethod(declaration.initializer),
+          resolveConsoleMethods(declaration.initializer),
         );
         return;
       }
@@ -316,11 +373,9 @@ function collectLoggingSymbols(sourceFile) {
         if (element.dotDotDotToken || !ts.isIdentifier(element.name)) {
           continue;
         }
-        addMapping(
-          consoleMethodBindings,
-          element.name.text,
+        addMappings(consoleMethodBindings, element.name.text, [
           propertyNameText(element.propertyName ?? element.name, sourceFile),
-        );
+        ]);
       }
     }
     function isLoggerFactoryCall(expression) {
@@ -375,27 +430,27 @@ function collectLoggingSymbols(sourceFile) {
       }
       return false;
     }
-    function resolveLoggerMethod(expression) {
+    function resolveLoggerMethods(expression) {
       const current = unwrapExpression(expression);
       if (ts.isIdentifier(current)) {
-        return loggerMethodBindings.get(current.text) ?? null;
+        return loggerMethodBindings.get(current.text) ?? [];
       }
       const access = propertyAccessParts(current);
       return access &&
         LOGGER_METHODS.has(access.method) &&
         isKnownLoggerExpression(access.receiver)
-        ? access.method
-        : null;
+        ? [access.method]
+        : [];
     }
     function recordLoggerMethodDeclaration(declaration) {
       if (!declaration.initializer) {
         return;
       }
       if (ts.isIdentifier(declaration.name)) {
-        addMapping(
+        addMappings(
           loggerMethodBindings,
           declaration.name.text,
-          resolveLoggerMethod(declaration.initializer),
+          resolveLoggerMethods(declaration.initializer),
         );
         return;
       }
@@ -414,11 +469,26 @@ function collectLoggingSymbols(sourceFile) {
           sourceFile,
         );
         if (LOGGER_METHODS.has(method)) {
-          addMapping(loggerMethodBindings, element.name.text, method);
+          addMappings(loggerMethodBindings, element.name.text, [method]);
         }
       }
     }
     function recordDeclaration(declaration) {
+      if (ts.isObjectBindingPattern(declaration.name)) {
+        const loggerProperties = loggerPropertiesForType(declaration.type);
+        for (const element of declaration.name.elements) {
+          if (element.dotDotDotToken || !ts.isIdentifier(element.name)) {
+            continue;
+          }
+          const propertyName = propertyNameText(
+            element.propertyName ?? element.name,
+            sourceFile,
+          );
+          if (loggerProperties.has(propertyName)) {
+            add(loggerBindings, element.name.text);
+          }
+        }
+      }
       if (typeIsLoggerValue(declaration.type, loggerTypeBindings)) {
         if (ts.isPropertyDeclaration(declaration)) {
           add(
@@ -461,6 +531,32 @@ function collectLoggingSymbols(sourceFile) {
         typeIsLoggerValue(current.type, loggerTypeBindings)
       ) {
         add(loggerTypeBindings, current.name.text);
+      }
+      if (ts.isTypeAliasDeclaration(current)) {
+        addMappings(
+          loggerObjectTypeProperties,
+          current.name.text,
+          loggerPropertiesForType(current.type),
+        );
+      }
+      if (ts.isInterfaceDeclaration(current)) {
+        const properties = current.members.flatMap((member) =>
+          ts.isPropertySignature(member) &&
+          typeIsLoggerValue(member.type, loggerTypeBindings)
+            ? [propertyNameText(member.name, sourceFile)]
+            : [],
+        );
+        for (const clause of current.heritageClauses ?? []) {
+          for (const heritageType of clause.types) {
+            const expression = unwrapExpression(heritageType.expression);
+            if (ts.isIdentifier(expression)) {
+              properties.push(
+                ...(loggerObjectTypeProperties.get(expression.text) ?? []),
+              );
+            }
+          }
+        }
+        addMappings(loggerObjectTypeProperties, current.name.text, properties);
       }
       if (
         (ts.isInterfaceDeclaration(current) ||
@@ -518,15 +614,15 @@ function collectLoggingSymbols(sourceFile) {
           if (isKnownConsoleExpression(current.right)) {
             add(consoleBindings, target.text);
           }
-          addMapping(
+          addMappings(
             consoleMethodBindings,
             target.text,
-            resolveConsoleMethod(current.right),
+            resolveConsoleMethods(current.right),
           );
-          addMapping(
+          addMappings(
             loggerMethodBindings,
             target.text,
-            resolveLoggerMethod(current.right),
+            resolveLoggerMethods(current.right),
           );
         }
       }
@@ -591,7 +687,8 @@ function collectLoggingSymbols(sourceFile) {
   function resolveConsoleMethod(expression) {
     const current = unwrapExpression(expression);
     if (ts.isIdentifier(current)) {
-      return consoleMethodBindings.get(current.text) ?? null;
+      const methods = consoleMethodBindings.get(current.text);
+      return methods ? [...methods].sort().join('|') : null;
     }
     const access = propertyAccessParts(current);
     if (!access) {
@@ -606,7 +703,8 @@ function collectLoggingSymbols(sourceFile) {
   function resolveLoggerMethod(expression) {
     const current = unwrapExpression(expression);
     if (ts.isIdentifier(current)) {
-      return loggerMethodBindings.get(current.text) ?? null;
+      const methods = loggerMethodBindings.get(current.text);
+      return methods ? [...methods].sort().join('|') : null;
     }
     const access = propertyAccessParts(current);
     return access &&

--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
@@ -7,6 +7,7 @@ import process from 'node:process';
 import ts from 'typescript';
 
 const LOGGER_METHODS = new Set(['debug', 'error', 'info', 'log', 'warn']);
+const COMPUTED_METHOD = 'computed';
 const LOGGER_TYPE_PROPERTIES = [
   'debug',
   'dontLogModelData',
@@ -93,19 +94,19 @@ function propertyAccessParts(expression) {
   const unwrapped = unwrapExpression(expression);
   if (ts.isPropertyAccessExpression(unwrapped)) {
     return {
+      computed: false,
       receiver: unwrapped.expression,
       method: unwrapped.name.text,
     };
   }
-  if (
-    ts.isElementAccessExpression(unwrapped) &&
-    unwrapped.argumentExpression &&
-    (ts.isStringLiteral(unwrapped.argumentExpression) ||
-      ts.isNoSubstitutionTemplateLiteral(unwrapped.argumentExpression))
-  ) {
+  if (ts.isElementAccessExpression(unwrapped) && unwrapped.argumentExpression) {
+    const isStatic =
+      ts.isStringLiteral(unwrapped.argumentExpression) ||
+      ts.isNoSubstitutionTemplateLiteral(unwrapped.argumentExpression);
     return {
+      computed: !isStatic,
       receiver: unwrapped.expression,
-      method: unwrapped.argumentExpression.text,
+      method: isStatic ? unwrapped.argumentExpression.text : COMPUTED_METHOD,
     };
   }
   return null;
@@ -477,7 +478,7 @@ function collectLoggingSymbols(sourceFile, checker) {
       }
       const access = propertyAccessParts(current);
       return access &&
-        LOGGER_METHODS.has(access.method) &&
+        (access.computed || LOGGER_METHODS.has(access.method)) &&
         isKnownLoggerExpression(access.receiver)
         ? [access.method]
         : [];
@@ -752,7 +753,7 @@ function collectLoggingSymbols(sourceFile, checker) {
     }
     const access = propertyAccessParts(current);
     return access &&
-      LOGGER_METHODS.has(access.method) &&
+      (access.computed || LOGGER_METHODS.has(access.method)) &&
       isLoggerReceiver(access.receiver)
       ? access.method
       : null;
@@ -818,6 +819,20 @@ function bindingIdentifiers(name) {
   return identifiers;
 }
 
+function isRejectionCallbackArgument(call, callbackIndex) {
+  const access = propertyAccessParts(call.expression);
+  return (
+    (access?.method === 'catch' && callbackIndex === 0) ||
+    (access?.method === 'then' && callbackIndex === 1) ||
+    ((access?.method === 'on' ||
+      access?.method === 'once' ||
+      access?.method === 'addListener') &&
+      callbackIndex === 1 &&
+      ts.isStringLiteral(call.arguments[0]) &&
+      call.arguments[0].text === 'unhandledRejection')
+  );
+}
+
 function enclosingRejectedValueIdentifiers(node) {
   const identifiers = new Set();
   let current = node.parent;
@@ -835,17 +850,7 @@ function enclosingRejectedValueIdentifiers(node) {
       const call = callback.parent;
       if (ts.isCallExpression(call)) {
         const callbackIndex = call.arguments.indexOf(callback);
-        const access = propertyAccessParts(call.expression);
-        const isRejectionHandler =
-          (access?.method === 'catch' && callbackIndex === 0) ||
-          (access?.method === 'then' && callbackIndex === 1) ||
-          ((access?.method === 'on' ||
-            access?.method === 'once' ||
-            access?.method === 'addListener') &&
-            callbackIndex === 1 &&
-            ts.isStringLiteral(call.arguments[0]) &&
-            call.arguments[0].text === 'unhandledRejection');
-        if (isRejectionHandler) {
+        if (isRejectionCallbackArgument(call, callbackIndex)) {
           const parameter = callback.parameters[0];
           if (parameter) {
             for (const identifier of bindingIdentifiers(parameter.name)) {
@@ -1015,13 +1020,38 @@ function inventoryParsedSource(sourceFile, filePath, checker = null) {
     resolveSensitiveHelper,
   } = collectLoggingSymbols(sourceFile, checker);
 
-  function recordCall(call, kind, method, policy) {
-    const start = sourceFile.getLineAndCharacterOfPosition(call.getStart());
-    const normalizedCall = normalizeCallText(call, sourceFile);
-    const context = callSiteContext(call, sourceFile);
+  function recordFinding(
+    node,
+    normalizedCall,
+    kind,
+    method,
+    shape,
+    policy,
+    catchValue,
+  ) {
+    const start = sourceFile.getLineAndCharacterOfPosition(node.getStart());
+    const context = callSiteContext(node, sourceFile);
     const occurrenceKey = `${context}\0${normalizedCall}`;
     const occurrence = occurrences.get(occurrenceKey) ?? 0;
     occurrences.set(occurrenceKey, occurrence + 1);
+    findings.push({
+      fingerprint: fingerprint(filePath, context, normalizedCall, occurrence),
+      file: filePath,
+      line: start.line + 1,
+      column: start.character + 1,
+      kind,
+      method,
+      shape,
+      policy,
+      catchValue,
+      context,
+      signals: signalsFor(normalizedCall),
+      call: normalizedCall,
+    });
+  }
+
+  function recordCall(call, kind, method, policy) {
+    const normalizedCall = normalizeCallText(call, sourceFile);
     const catchValues = enclosingRejectedValueIdentifiers(call);
     const referencedCatchValues = catchValues.filter((catchValue) =>
       call.arguments.some((argument) =>
@@ -1030,27 +1060,73 @@ function inventoryParsedSource(sourceFile, filePath, checker = null) {
     );
     const dynamicMessage = hasDynamicMessage(call);
     const hasPayload = call.arguments.length > 1;
-    findings.push({
-      fingerprint: fingerprint(filePath, context, normalizedCall, occurrence),
-      file: filePath,
-      line: start.line + 1,
-      column: start.character + 1,
+    recordFinding(
+      call,
+      normalizedCall,
       kind,
       method,
-      shape: hasPayload
+      hasPayload
         ? 'payload'
         : dynamicMessage
           ? 'dynamic-message'
           : 'static-message',
       policy,
-      catchValue:
-        referencedCatchValues.length > 0
-          ? referencedCatchValues.join(', ')
-          : null,
-      context,
-      signals: signalsFor(normalizedCall),
-      call: normalizedCall,
-    });
+      referencedCatchValues.length > 0
+        ? referencedCatchValues.join(', ')
+        : null,
+    );
+  }
+
+  function recordCallbackReference(
+    reference,
+    kind,
+    method,
+    policy,
+    parentCall,
+    callbackIndex,
+  ) {
+    recordFinding(
+      reference,
+      normalizeNodeText(reference, sourceFile),
+      kind,
+      method,
+      'dynamic-message',
+      policy,
+      isRejectionCallbackArgument(parentCall, callbackIndex)
+        ? 'rejection reason'
+        : null,
+    );
+  }
+
+  function recordCallbackReferences(call, parentIsSink) {
+    if (parentIsSink) {
+      return;
+    }
+    for (const [callbackIndex, argument] of call.arguments.entries()) {
+      const consoleMethod = resolveConsoleMethod(argument);
+      if (consoleMethod) {
+        recordCallbackReference(
+          argument,
+          'console',
+          consoleMethod,
+          'none',
+          call,
+          callbackIndex,
+        );
+        continue;
+      }
+      const loggerMethod = resolveLoggerMethod(argument);
+      if (loggerMethod) {
+        recordCallbackReference(
+          argument,
+          'logger',
+          loggerMethod,
+          guardedPolicy(argument, sourceFile),
+          call,
+          callbackIndex,
+        );
+      }
+    }
   }
 
   function visit(node) {
@@ -1058,6 +1134,9 @@ function inventoryParsedSource(sourceFile, filePath, checker = null) {
       const consoleMethod = resolveConsoleMethod(node.expression);
       const loggerMethod = resolveLoggerMethod(node.expression);
       const sensitiveHelper = resolveSensitiveHelper(node.expression);
+      const parentIsSink = Boolean(
+        consoleMethod || loggerMethod || sensitiveHelper,
+      );
       if (consoleMethod) {
         recordCall(node, 'console', consoleMethod, 'none');
       } else if (loggerMethod) {
@@ -1078,7 +1157,7 @@ function inventoryParsedSource(sourceFile, filePath, checker = null) {
         const access = propertyAccessParts(node.expression);
         if (access) {
           if (
-            LOGGER_METHODS.has(access.method) &&
+            (access.computed || LOGGER_METHODS.has(access.method)) &&
             isLoggerReceiver(access.receiver)
           ) {
             recordCall(
@@ -1090,6 +1169,7 @@ function inventoryParsedSource(sourceFile, filePath, checker = null) {
           }
         }
       }
+      recordCallbackReferences(node, parentIsSink);
     }
     ts.forEachChild(node, visit);
   }

--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
@@ -1,0 +1,406 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+import process from 'node:process';
+import ts from 'typescript';
+
+const LOGGER_METHODS = new Set(['debug', 'error', 'info', 'log', 'warn']);
+const SENSITIVE_HELPERS = new Map([
+  ['logModelActionError', 'model-helper'],
+  ['logToolActionError', 'tool-helper'],
+]);
+const SOURCE_EXTENSIONS = new Set(['.cts', '.mts', '.ts', '.tsx']);
+
+function parseArguments(argv) {
+  const options = {
+    format: 'markdown',
+    roots: [],
+    summaryOnly: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--format') {
+      const format = argv[index + 1];
+      if (format !== 'json' && format !== 'markdown') {
+        throw new Error('--format must be either json or markdown.');
+      }
+      options.format = format;
+      index += 1;
+    } else if (argument === '--summary-only') {
+      options.summaryOnly = true;
+    } else if (argument === '--help' || argument === '-h') {
+      options.help = true;
+    } else if (argument.startsWith('-')) {
+      throw new Error(`Unknown option: ${argument}`);
+    } else {
+      options.roots.push(argument);
+    }
+  }
+
+  return options;
+}
+
+function extension(path) {
+  const match = path.match(/(\.[^.]+)$/);
+  return match?.[1] ?? '';
+}
+
+function collectSourceFiles(path) {
+  const absolutePath = resolve(path);
+  const stats = statSync(absolutePath);
+  if (stats.isFile()) {
+    return SOURCE_EXTENSIONS.has(extension(absolutePath)) ? [absolutePath] : [];
+  }
+
+  return readdirSync(absolutePath, { withFileTypes: true })
+    .filter((entry) => !entry.name.startsWith('.') && entry.name !== 'dist')
+    .flatMap((entry) => collectSourceFiles(resolve(absolutePath, entry.name)));
+}
+
+function unwrapExpression(expression) {
+  let current = expression;
+  while (
+    ts.isAsExpression(current) ||
+    ts.isNonNullExpression(current) ||
+    ts.isParenthesizedExpression(current) ||
+    ts.isSatisfiesExpression(current) ||
+    ts.isTypeAssertionExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function propertyAccessParts(expression) {
+  const unwrapped = unwrapExpression(expression);
+  if (ts.isPropertyAccessExpression(unwrapped)) {
+    return {
+      receiver: unwrapped.expression,
+      method: unwrapped.name.text,
+    };
+  }
+  if (
+    ts.isElementAccessExpression(unwrapped) &&
+    unwrapped.argumentExpression &&
+    (ts.isStringLiteral(unwrapped.argumentExpression) ||
+      ts.isNoSubstitutionTemplateLiteral(unwrapped.argumentExpression))
+  ) {
+    return {
+      receiver: unwrapped.expression,
+      method: unwrapped.argumentExpression.text,
+    };
+  }
+  return null;
+}
+
+function isLoggerReceiver(expression, sourceFile) {
+  const text = expression.getText(sourceFile);
+  return /logger$/i.test(text);
+}
+
+function isConsoleReceiver(expression) {
+  const unwrapped = unwrapExpression(expression);
+  return ts.isIdentifier(unwrapped) && unwrapped.text === 'console';
+}
+
+function isStaticString(expression) {
+  const unwrapped = unwrapExpression(expression);
+  return (
+    ts.isStringLiteral(unwrapped) ||
+    ts.isNoSubstitutionTemplateLiteral(unwrapped)
+  );
+}
+
+function hasDynamicMessage(call) {
+  return call.arguments.length > 0 && !isStaticString(call.arguments[0]);
+}
+
+function referencesIdentifier(node, identifier) {
+  let found = false;
+  function visit(current) {
+    if (found) {
+      return;
+    }
+    if (ts.isIdentifier(current) && current.text === identifier) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(current, visit);
+  }
+  visit(node);
+  return found;
+}
+
+function enclosingCatchVariable(node) {
+  let current = node.parent;
+  while (current) {
+    if (ts.isCatchClause(current)) {
+      const declaration = current.variableDeclaration;
+      return declaration && ts.isIdentifier(declaration.name)
+        ? declaration.name.text
+        : null;
+    }
+    current = current.parent;
+  }
+  return null;
+}
+
+function guardedPolicy(node, sourceFile) {
+  let current = node.parent;
+  while (current) {
+    if (ts.isFunctionLike(current)) {
+      break;
+    }
+    if (ts.isIfStatement(current) || ts.isConditionalExpression(current)) {
+      const condition = current.expression.getText(sourceFile);
+      const hasModelPolicy = condition.includes('dontLogModelData');
+      const hasToolPolicy = condition.includes('dontLogToolData');
+      if (hasModelPolicy && hasToolPolicy) {
+        return 'model+tool-guard';
+      }
+      if (hasModelPolicy) {
+        return 'model-guard';
+      }
+      if (hasToolPolicy) {
+        return 'tool-guard';
+      }
+    }
+    current = current.parent;
+  }
+  return 'none';
+}
+
+function normalizeCallText(call, sourceFile) {
+  return call.getText(sourceFile).replace(/\s+/g, ' ').trim();
+}
+
+function fingerprint(path, normalizedCall) {
+  return createHash('sha256')
+    .update(`${path}\0${normalizedCall}`)
+    .digest('hex')
+    .slice(0, 12);
+}
+
+function signalsFor(text) {
+  const normalized = text.toLowerCase();
+  const signals = [];
+  const groups = [
+    ['model', /\b(model|response|request|completion|llm|realtime event)\b/],
+    [
+      'tool',
+      /\b(tool|function call|arguments|computer action|shell action|apply_patch|mcp)\b/,
+    ],
+    ['error', /\b(error|err|exception|failure|failed|reason)\b/],
+    ['payload', /\b(input|output|item|event|payload|data|trace|span)\b/],
+  ];
+  for (const [name, pattern] of groups) {
+    if (pattern.test(normalized)) {
+      signals.push(name);
+    }
+  }
+  return signals;
+}
+
+export function inventorySource(sourceText, filePath = 'fixture.ts') {
+  const scriptKind = filePath.endsWith('.tsx')
+    ? ts.ScriptKind.TSX
+    : ts.ScriptKind.TS;
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKind,
+  );
+  const findings = [];
+
+  function recordCall(call, kind, method, policy) {
+    const start = sourceFile.getLineAndCharacterOfPosition(call.getStart());
+    const normalizedCall = normalizeCallText(call, sourceFile);
+    const catchVariable = enclosingCatchVariable(call);
+    const referencesCatchValue = Boolean(
+      catchVariable &&
+      call.arguments.some((argument) =>
+        referencesIdentifier(argument, catchVariable),
+      ),
+    );
+    const dynamicMessage = hasDynamicMessage(call);
+    const hasPayload = call.arguments.length > 1;
+    findings.push({
+      fingerprint: fingerprint(filePath, normalizedCall),
+      file: filePath,
+      line: start.line + 1,
+      column: start.character + 1,
+      kind,
+      method,
+      shape: hasPayload
+        ? 'payload'
+        : dynamicMessage
+          ? 'dynamic-message'
+          : 'static-message',
+      policy,
+      catchValue: referencesCatchValue ? catchVariable : null,
+      signals: signalsFor(normalizedCall),
+      call: normalizedCall,
+    });
+  }
+
+  function visit(node) {
+    if (ts.isCallExpression(node)) {
+      const unwrappedExpression = unwrapExpression(node.expression);
+      if (
+        ts.isIdentifier(unwrappedExpression) &&
+        SENSITIVE_HELPERS.has(unwrappedExpression.text)
+      ) {
+        recordCall(
+          node,
+          'sensitive-helper',
+          unwrappedExpression.text,
+          SENSITIVE_HELPERS.get(unwrappedExpression.text),
+        );
+      } else {
+        const access = propertyAccessParts(node.expression);
+        if (access && LOGGER_METHODS.has(access.method)) {
+          if (isConsoleReceiver(access.receiver)) {
+            recordCall(node, 'console', access.method, 'none');
+          } else if (isLoggerReceiver(access.receiver, sourceFile)) {
+            recordCall(
+              node,
+              'logger',
+              access.method,
+              guardedPolicy(node, sourceFile),
+            );
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return findings;
+}
+
+function summarize(findings) {
+  const dynamic = findings.filter(
+    (finding) => finding.shape !== 'static-message',
+  );
+  return {
+    total: findings.length,
+    dynamic: dynamic.length,
+    unclassifiedDynamic: dynamic.filter((finding) => finding.policy === 'none')
+      .length,
+    catchValueLogs: findings.filter((finding) => finding.catchValue).length,
+    unclassifiedCatchValueLogs: findings.filter(
+      (finding) => finding.catchValue && finding.policy === 'none',
+    ).length,
+    rawConsoleCalls: findings.filter((finding) => finding.kind === 'console')
+      .length,
+  };
+}
+
+function markdown(findings, summary, summaryOnly) {
+  const lines = [
+    '# Sensitive logging inventory',
+    '',
+    `- Total logging calls: ${summary.total}`,
+    `- Dynamic calls: ${summary.dynamic}`,
+    `- Dynamic calls without an explicit model/tool policy: ${summary.unclassifiedDynamic}`,
+    `- Calls that log a caught value: ${summary.catchValueLogs}`,
+    `- Caught-value calls without an explicit model/tool policy: ${summary.unclassifiedCatchValueLogs}`,
+    `- Raw console calls: ${summary.rawConsoleCalls}`,
+  ];
+
+  if (summaryOnly) {
+    return `${lines.join('\n')}\n`;
+  }
+
+  lines.push(
+    '',
+    '| Location | Kind | Shape | Policy | Catch value | Signals | Fingerprint |',
+    '| --- | --- | --- | --- | --- | --- | --- |',
+  );
+  for (const finding of findings) {
+    lines.push(
+      `| ${finding.file}:${finding.line} | ${finding.kind}.${finding.method} | ${finding.shape} | ${finding.policy} | ${finding.catchValue ?? ''} | ${finding.signals.join(', ')} | ${finding.fingerprint} |`,
+    );
+  }
+  lines.push('');
+  return `${lines.join('\n')}\n`;
+}
+
+function usage() {
+  return `Usage: node .agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs [options] [roots...]
+
+Inventory runtime logger and console calls so every dynamic payload can be
+classified as model data, tool data, both, or operationally safe.
+
+Options:
+  --format <markdown|json>  Output format (default: markdown)
+  --summary-only            Print counts without the per-call ledger
+  -h, --help                Show this help
+
+Default roots: packages/*/src
+`;
+}
+
+export function run(argv = process.argv.slice(2)) {
+  const options = parseArguments(argv);
+  if (options.help) {
+    process.stdout.write(usage());
+    return;
+  }
+
+  const cwd = process.cwd();
+  const roots =
+    options.roots.length > 0
+      ? options.roots
+      : readdirSync(resolve(cwd, 'packages'), { withFileTypes: true })
+          .filter((entry) => entry.isDirectory())
+          .map((entry) => resolve(cwd, 'packages', entry.name, 'src'))
+          .filter((path) => {
+            try {
+              return statSync(path).isDirectory();
+            } catch {
+              return false;
+            }
+          });
+
+  const findings = roots
+    .flatMap(collectSourceFiles)
+    .sort()
+    .flatMap((absolutePath) => {
+      const filePath = relative(cwd, absolutePath);
+      return inventorySource(readFileSync(absolutePath, 'utf8'), filePath);
+    });
+  const summary = summarize(findings);
+
+  if (options.format === 'json') {
+    process.stdout.write(
+      `${JSON.stringify(
+        options.summaryOnly ? { summary } : { summary, findings },
+        null,
+        2,
+      )}\n`,
+    );
+  } else {
+    process.stdout.write(markdown(findings, summary, options.summaryOnly));
+  }
+}
+
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === resolve(import.meta.filename)
+) {
+  try {
+    run();
+  } catch (error) {
+    process.stderr.write(
+      `Sensitive logging audit failed: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  }
+}

--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
@@ -153,6 +153,13 @@ function collectLoggerSymbols(sourceFile) {
   const loggerNamespaceBindings = new Set();
   const loggerPropertyNames = new Set();
   const loggerTypeBindings = new Set(['Logger']);
+  const sensitiveHelperBindings = new Map(
+    [...SENSITIVE_HELPERS].map(([name, policy]) => [
+      name,
+      { method: name, policy },
+    ]),
+  );
+  const sensitiveHelperNamespaceBindings = new Set();
 
   for (const statement of sourceFile.statements) {
     if (!ts.isImportDeclaration(statement)) {
@@ -171,6 +178,7 @@ function collectLoggerSymbols(sourceFile) {
     const bindings = clause.namedBindings;
     if (bindings && ts.isNamespaceImport(bindings)) {
       loggerNamespaceBindings.add(bindings.name.text);
+      sensitiveHelperNamespaceBindings.add(bindings.name.text);
       continue;
     }
     if (!bindings || !ts.isNamedImports(bindings)) {
@@ -185,6 +193,13 @@ function collectLoggerSymbols(sourceFile) {
         loggerBindings.add(local);
       } else if (imported === 'Logger') {
         loggerTypeBindings.add(local);
+      }
+      const sensitivePolicy = SENSITIVE_HELPERS.get(imported);
+      if (sensitivePolicy) {
+        sensitiveHelperBindings.set(local, {
+          method: imported,
+          policy: sensitivePolicy,
+        });
       }
     }
   }
@@ -354,7 +369,27 @@ function collectLoggerSymbols(sourceFile) {
     return false;
   }
 
-  return { isLoggerReceiver };
+  function resolveSensitiveHelper(expression) {
+    const current = unwrapExpression(expression);
+    if (ts.isIdentifier(current)) {
+      return sensitiveHelperBindings.get(current.text) ?? null;
+    }
+    const access = propertyAccessParts(current);
+    if (!access) {
+      return null;
+    }
+    const receiver = unwrapExpression(access.receiver);
+    if (
+      !ts.isIdentifier(receiver) ||
+      !sensitiveHelperNamespaceBindings.has(receiver.text)
+    ) {
+      return null;
+    }
+    const policy = SENSITIVE_HELPERS.get(access.method);
+    return policy ? { method: access.method, policy } : null;
+  }
+
+  return { isLoggerReceiver, resolveSensitiveHelper };
 }
 
 function isStaticString(expression) {
@@ -482,7 +517,10 @@ function guardedPolicy(node, sourceFile) {
       break;
     }
     if (ts.isIfStatement(current) || ts.isConditionalExpression(current)) {
-      const condition = current.expression.getText(sourceFile);
+      const conditionNode = ts.isIfStatement(current)
+        ? current.expression
+        : current.condition;
+      const condition = conditionNode.getText(sourceFile);
       const hasModelPolicy = condition.includes('dontLogModelData');
       const hasToolPolicy = condition.includes('dontLogToolData');
       if (hasModelPolicy && hasToolPolicy) {
@@ -545,7 +583,8 @@ export function inventorySource(sourceText, filePath = 'fixture.ts') {
   );
   const findings = [];
   const occurrences = new Map();
-  const { isLoggerReceiver } = collectLoggerSymbols(sourceFile);
+  const { isLoggerReceiver, resolveSensitiveHelper } =
+    collectLoggerSymbols(sourceFile);
 
   function recordCall(call, kind, method, policy) {
     const start = sourceFile.getLineAndCharacterOfPosition(call.getStart());
@@ -585,23 +624,23 @@ export function inventorySource(sourceText, filePath = 'fixture.ts') {
 
   function visit(node) {
     if (ts.isCallExpression(node)) {
-      const unwrappedExpression = unwrapExpression(node.expression);
-      if (
-        ts.isIdentifier(unwrappedExpression) &&
-        SENSITIVE_HELPERS.has(unwrappedExpression.text)
-      ) {
+      const sensitiveHelper = resolveSensitiveHelper(node.expression);
+      if (sensitiveHelper) {
         recordCall(
           node,
           'sensitive-helper',
-          unwrappedExpression.text,
-          SENSITIVE_HELPERS.get(unwrappedExpression.text),
+          sensitiveHelper.method,
+          sensitiveHelper.policy,
         );
       } else {
         const access = propertyAccessParts(node.expression);
-        if (access && LOGGER_METHODS.has(access.method)) {
+        if (access) {
           if (isConsoleReceiver(access.receiver)) {
             recordCall(node, 'console', access.method, 'none');
-          } else if (isLoggerReceiver(access.receiver)) {
+          } else if (
+            LOGGER_METHODS.has(access.method) &&
+            isLoggerReceiver(access.receiver)
+          ) {
             recordCall(
               node,
               'logger',

--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
@@ -102,11 +102,6 @@ function propertyAccessParts(expression) {
   return null;
 }
 
-function isConsoleReceiver(expression) {
-  const unwrapped = unwrapExpression(expression);
-  return ts.isIdentifier(unwrapped) && unwrapped.text === 'console';
-}
-
 function normalizeFilePath(path) {
   return path.replace(/\\/g, '/');
 }
@@ -120,34 +115,55 @@ function isLoggerModule(moduleName) {
 }
 
 function propertyNameText(name, sourceFile) {
-  return name ? normalizeNodeText(name, sourceFile) : null;
+  if (!name) {
+    return null;
+  }
+  if (
+    ts.isIdentifier(name) ||
+    ts.isStringLiteral(name) ||
+    ts.isNoSubstitutionTemplateLiteral(name) ||
+    ts.isNumericLiteral(name)
+  ) {
+    return name.text;
+  }
+  return normalizeNodeText(name, sourceFile);
 }
 
-function typeReferencesLogger(typeNode, loggerTypeBindings) {
-  let found = false;
-  function visit(current) {
-    if (found) {
-      return;
-    }
-    if (
-      ts.isTypeReferenceNode(current) &&
-      ((ts.isIdentifier(current.typeName) &&
-        loggerTypeBindings.has(current.typeName.text)) ||
-        (ts.isQualifiedName(current.typeName) &&
-          current.typeName.right.text === 'Logger'))
-    ) {
-      found = true;
-      return;
-    }
-    ts.forEachChild(current, visit);
+function typeIsLoggerValue(typeNode, loggerTypeBindings) {
+  if (!typeNode) {
+    return false;
   }
-  if (typeNode) {
-    visit(typeNode);
+  if (ts.isParenthesizedTypeNode(typeNode) || ts.isTypeOperatorNode(typeNode)) {
+    return typeIsLoggerValue(typeNode.type, loggerTypeBindings);
   }
-  return found;
+  if (ts.isUnionTypeNode(typeNode) || ts.isIntersectionTypeNode(typeNode)) {
+    return typeNode.types.some((type) =>
+      typeIsLoggerValue(type, loggerTypeBindings),
+    );
+  }
+  if (!ts.isTypeReferenceNode(typeNode)) {
+    return false;
+  }
+  if (
+    (ts.isIdentifier(typeNode.typeName) &&
+      loggerTypeBindings.has(typeNode.typeName.text)) ||
+    (ts.isQualifiedName(typeNode.typeName) &&
+      typeNode.typeName.right.text === 'Logger')
+  ) {
+    return true;
+  }
+  return (
+    ts.isIdentifier(typeNode.typeName) &&
+    ['Partial', 'Readonly', 'Required'].includes(typeNode.typeName.text) &&
+    typeNode.typeArguments?.some((type) =>
+      typeIsLoggerValue(type, loggerTypeBindings),
+    ) === true
+  );
 }
 
-function collectLoggerSymbols(sourceFile) {
+function collectLoggingSymbols(sourceFile) {
+  const consoleBindings = new Set(['console']);
+  const consoleMethodBindings = new Map();
   const loggerBindings = new Set();
   const loggerFactoryBindings = new Set(['getLogger']);
   const loggerNamespaceBindings = new Set();
@@ -213,6 +229,76 @@ function collectLoggerSymbols(sourceFile) {
         changed = true;
       }
     }
+    function addMapping(map, key, value) {
+      if (key && value && map.get(key) !== value) {
+        map.set(key, value);
+        changed = true;
+      }
+    }
+    function isKnownConsoleExpression(expression) {
+      const current = unwrapExpression(expression);
+      if (ts.isIdentifier(current)) {
+        return consoleBindings.has(current.text);
+      }
+      if (ts.isConditionalExpression(current)) {
+        return (
+          isKnownConsoleExpression(current.whenTrue) ||
+          isKnownConsoleExpression(current.whenFalse)
+        );
+      }
+      if (
+        ts.isBinaryExpression(current) &&
+        current.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken
+      ) {
+        return (
+          isKnownConsoleExpression(current.left) ||
+          isKnownConsoleExpression(current.right)
+        );
+      }
+      return false;
+    }
+    function resolveConsoleMethod(expression) {
+      const current = unwrapExpression(expression);
+      if (ts.isIdentifier(current)) {
+        return consoleMethodBindings.get(current.text) ?? null;
+      }
+      const access = propertyAccessParts(current);
+      return access && isKnownConsoleExpression(access.receiver)
+        ? access.method
+        : null;
+    }
+    function recordConsoleDeclaration(declaration) {
+      if (!declaration.initializer) {
+        return;
+      }
+      if (ts.isIdentifier(declaration.name)) {
+        if (isKnownConsoleExpression(declaration.initializer)) {
+          add(consoleBindings, declaration.name.text);
+        }
+        addMapping(
+          consoleMethodBindings,
+          declaration.name.text,
+          resolveConsoleMethod(declaration.initializer),
+        );
+        return;
+      }
+      if (
+        !ts.isObjectBindingPattern(declaration.name) ||
+        !isKnownConsoleExpression(declaration.initializer)
+      ) {
+        return;
+      }
+      for (const element of declaration.name.elements) {
+        if (element.dotDotDotToken || !ts.isIdentifier(element.name)) {
+          continue;
+        }
+        addMapping(
+          consoleMethodBindings,
+          element.name.text,
+          propertyNameText(element.propertyName ?? element.name, sourceFile),
+        );
+      }
+    }
     function isLoggerFactoryCall(expression) {
       const current = unwrapExpression(expression);
       if (!ts.isCallExpression(current)) {
@@ -266,10 +352,7 @@ function collectLoggerSymbols(sourceFile) {
       return false;
     }
     function recordDeclaration(declaration) {
-      if (
-        declaration.type &&
-        typeReferencesLogger(declaration.type, loggerTypeBindings)
-      ) {
+      if (typeIsLoggerValue(declaration.type, loggerTypeBindings)) {
         if (ts.isPropertyDeclaration(declaration)) {
           add(
             loggerPropertyNames,
@@ -308,9 +391,15 @@ function collectLoggerSymbols(sourceFile) {
     function visit(current) {
       if (
         ts.isTypeAliasDeclaration(current) &&
-        typeReferencesLogger(current.type, loggerTypeBindings)
+        typeIsLoggerValue(current.type, loggerTypeBindings)
       ) {
         add(loggerTypeBindings, current.name.text);
+      }
+      if (
+        ts.isPropertySignature(current) &&
+        typeIsLoggerValue(current.type, loggerTypeBindings)
+      ) {
+        add(loggerPropertyNames, propertyNameText(current.name, sourceFile));
       }
       if (
         ts.isVariableDeclaration(current) ||
@@ -318,6 +407,9 @@ function collectLoggerSymbols(sourceFile) {
         ts.isPropertyDeclaration(current)
       ) {
         recordDeclaration(current);
+      }
+      if (ts.isVariableDeclaration(current)) {
+        recordConsoleDeclaration(current);
       }
       if (
         ts.isPropertyAssignment(current) &&
@@ -333,14 +425,25 @@ function collectLoggerSymbols(sourceFile) {
       }
       if (
         ts.isBinaryExpression(current) &&
-        current.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
-        isKnownLoggerExpression(current.right)
+        current.operatorToken.kind === ts.SyntaxKind.EqualsToken
       ) {
         const target = unwrapExpression(current.left);
+        if (isKnownLoggerExpression(current.right)) {
+          if (ts.isIdentifier(target)) {
+            add(loggerBindings, target.text);
+          } else if (ts.isPropertyAccessExpression(target)) {
+            add(loggerPropertyNames, propertyNameText(target.name, sourceFile));
+          }
+        }
         if (ts.isIdentifier(target)) {
-          add(loggerBindings, target.text);
-        } else if (ts.isPropertyAccessExpression(target)) {
-          add(loggerPropertyNames, propertyNameText(target.name, sourceFile));
+          if (isKnownConsoleExpression(current.right)) {
+            add(consoleBindings, target.text);
+          }
+          addMapping(
+            consoleMethodBindings,
+            target.text,
+            resolveConsoleMethod(current.right),
+          );
         }
       }
       ts.forEachChild(current, visit);
@@ -401,7 +504,22 @@ function collectLoggerSymbols(sourceFile) {
     return policy ? { method: access.method, policy } : null;
   }
 
-  return { isLoggerReceiver, resolveSensitiveHelper };
+  function resolveConsoleMethod(expression) {
+    const current = unwrapExpression(expression);
+    if (ts.isIdentifier(current)) {
+      return consoleMethodBindings.get(current.text) ?? null;
+    }
+    const access = propertyAccessParts(current);
+    if (!access) {
+      return null;
+    }
+    const receiver = unwrapExpression(access.receiver);
+    return ts.isIdentifier(receiver) && consoleBindings.has(receiver.text)
+      ? access.method
+      : null;
+  }
+
+  return { isLoggerReceiver, resolveConsoleMethod, resolveSensitiveHelper };
 }
 
 function isStaticString(expression) {
@@ -648,8 +766,8 @@ export function inventorySource(sourceText, filePath = 'fixture.ts') {
   );
   const findings = [];
   const occurrences = new Map();
-  const { isLoggerReceiver, resolveSensitiveHelper } =
-    collectLoggerSymbols(sourceFile);
+  const { isLoggerReceiver, resolveConsoleMethod, resolveSensitiveHelper } =
+    collectLoggingSymbols(sourceFile);
 
   function recordCall(call, kind, method, policy) {
     const start = sourceFile.getLineAndCharacterOfPosition(call.getStart());
@@ -691,8 +809,11 @@ export function inventorySource(sourceText, filePath = 'fixture.ts') {
 
   function visit(node) {
     if (ts.isCallExpression(node)) {
+      const consoleMethod = resolveConsoleMethod(node.expression);
       const sensitiveHelper = resolveSensitiveHelper(node.expression);
-      if (sensitiveHelper) {
+      if (consoleMethod) {
+        recordCall(node, 'console', consoleMethod, 'none');
+      } else if (sensitiveHelper) {
         recordCall(
           node,
           'sensitive-helper',
@@ -702,9 +823,7 @@ export function inventorySource(sourceText, filePath = 'fixture.ts') {
       } else {
         const access = propertyAccessParts(node.expression);
         if (access) {
-          if (isConsoleReceiver(access.receiver)) {
-            recordCall(node, 'console', access.method, 'none');
-          } else if (
+          if (
             LOGGER_METHODS.has(access.method) &&
             isLoggerReceiver(access.receiver)
           ) {

--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
@@ -224,11 +224,17 @@ test('resolves Logger-typed object members', () => {
     function reportInterface(options: AuditOptions) {
       options.sink.info('Interface options failed', secret);
     }
+    function reportDestructured({ logger }: { logger: Logger }) {
+      logger.error('Destructured options failed', secret);
+    }
+    function reportAliased({ logger: sink }: ReportOptions) {
+      sink.warn('Aliased destructuring failed', secret);
+    }
   `);
 
   assert.deepEqual(
     findings.map(({ method }) => method),
-    ['error', 'warn', 'info'],
+    ['error', 'warn', 'info', 'error', 'warn'],
   );
 });
 
@@ -291,6 +297,28 @@ test('resolves console object and extracted method aliases', () => {
       { kind: 'console', method: 'warn' },
       { kind: 'console', method: 'log' },
       { kind: 'console', method: 'trace' },
+    ],
+  );
+});
+
+test('method alias analysis converges across reassignments', () => {
+  const findings = inventorySource(`
+    let emit = console.log;
+    emit = console.error;
+
+    const logger = getLogger('fixture');
+    let report = logger.warn;
+    report = logger.error;
+
+    emit(secret);
+    report('Failed', secret);
+  `);
+
+  assert.deepEqual(
+    findings.map(({ kind, method }) => ({ kind, method })),
+    [
+      { kind: 'console', method: 'error|log' },
+      { kind: 'logger', method: 'error|warn' },
     ],
   );
 });

--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
@@ -23,17 +23,21 @@ test('inventories static and dynamic logger calls', () => {
 
 test('recognizes model and tool policy boundaries', () => {
   const findings = inventorySource(`
+    import {
+      logModelActionError,
+      logToolActionError,
+    } from './logger';
+
     const logger = getLogger('fixture');
     if (!logger.dontLogModelData) {
       logger.debug('Response:', response);
     }
     if (logger.dontLogToolData) {
-      logger.warn('Tool failed');
+      logger.warn('Tool data exposed', secret);
     } else {
       logger.warn('Tool failed', error);
     }
     logModelActionError(logger, 'Model failed', error, event);
-    logModelAndToolActionWarning(logger, 'Run failed', error, item);
     logToolActionError(logger, 'Tool failed', error, toolCall);
   `);
 
@@ -41,13 +45,9 @@ test('recognizes model and tool policy boundaries', () => {
     findings.map(({ method, policy }) => ({ method, policy })),
     [
       { method: 'debug', policy: 'model-guard' },
-      { method: 'warn', policy: 'tool-guard' },
+      { method: 'warn', policy: 'none' },
       { method: 'warn', policy: 'tool-guard' },
       { method: 'logModelActionError', policy: 'model-helper' },
-      {
-        method: 'logModelAndToolActionWarning',
-        policy: 'model+tool-helper',
-      },
       { method: 'logToolActionError', policy: 'tool-helper' },
     ],
   );
@@ -64,9 +64,31 @@ test('reads policy conditions from conditional expressions', () => {
   assert.deepEqual(
     findings.map(({ method, policy }) => ({ method, policy })),
     [
-      { method: 'warn', policy: 'tool-guard' },
+      { method: 'warn', policy: 'none' },
       { method: 'warn', policy: 'tool-guard' },
     ],
+  );
+});
+
+test('requires guard polarity to guarantee sensitive logging is enabled', () => {
+  const findings = inventorySource(`
+    const logger = getLogger('fixture');
+    if (!logger.dontLogToolData && ready) {
+      logger.error('Protected tool data', secret);
+    }
+    if (logger.dontLogModelData || disabled) {
+      logger.error('Potentially exposed model data', secret);
+    } else {
+      logger.error('Protected model data', secret);
+    }
+    if (!logger.dontLogModelData && !logger.dontLogToolData) {
+      logger.error('Protected model and tool data', secret);
+    }
+  `);
+
+  assert.deepEqual(
+    findings.map(({ policy }) => policy),
+    ['tool-guard', 'none', 'model-guard', 'model+tool-guard'],
   );
 });
 
@@ -370,11 +392,13 @@ test('resolves console object and extracted method aliases', () => {
     const nestedSink = sink;
     const { warn, log: emit } = nestedSink;
     const trace = console.trace;
+    const sinks = { raw: console };
 
     sink.error('Request failed', secret);
     warn(secret);
     emit(payload);
     trace(error);
+    sinks.raw.error('Object member failed', secret);
   `);
 
   assert.deepEqual(
@@ -384,6 +408,7 @@ test('resolves console object and extracted method aliases', () => {
       { kind: 'console', method: 'warn' },
       { kind: 'console', method: 'log' },
       { kind: 'console', method: 'trace' },
+      { kind: 'console', method: 'error' },
     ],
   );
 });
@@ -446,6 +471,25 @@ test('resolves sensitive helper import aliases and namespace accesses', () => {
       { method: 'logModelActionError', policy: 'model-helper' },
     ],
   );
+});
+
+test('does not trust sensitive helper spellings without provenance', () => {
+  const findings = inventorySource(`
+    import {
+      logModelActionError as unrelatedHelper,
+    } from './unrelated';
+    import * as unrelated from './unrelated';
+
+    function logToolActionError(target, message, secret) {
+      target(message, secret);
+    }
+
+    logToolActionError(sink, 'Local helper', secret);
+    unrelatedHelper(sink, 'Imported helper', secret);
+    unrelated.logToolActionError(sink, 'Namespace helper', secret);
+  `);
+
+  assert.equal(findings.length, 0);
 });
 
 test('fingerprints distinguish call sites and survive unrelated line shifts', () => {

--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
@@ -5,6 +5,7 @@ import { inventorySource } from './inventory-logging.mjs';
 
 test('inventories static and dynamic logger calls', () => {
   const findings = inventorySource(`
+    const logger = getLogger('fixture');
     logger.debug('ready');
     logger.warn(\`Failed for \${requestId}\`);
     logger.error('Request failed', error, response);
@@ -22,6 +23,7 @@ test('inventories static and dynamic logger calls', () => {
 
 test('recognizes model and tool policy boundaries', () => {
   const findings = inventorySource(`
+    const logger = getLogger('fixture');
     if (!logger.dontLogModelData) {
       logger.debug('Response:', response);
     }
@@ -53,6 +55,7 @@ test('recognizes model and tool policy boundaries', () => {
 
 test('flags caught values passed to logger and console calls', () => {
   const findings = inventorySource(`
+    const appLogger: Logger = getLogger('app');
     try {
       await run();
     } catch (reason) {
@@ -76,18 +79,60 @@ test('flags caught values passed to logger and console calls', () => {
 
 test('flags promise rejection handler values as caught values', () => {
   const findings = inventorySource(`
+    const logger = getLogger('fixture');
     run().catch((reason) => logger.warn('Run failed', reason));
     run().then(undefined, (error) => console.error('Run failed', error));
+    process.on('unhandledRejection', (reason, promise) => {
+      logger.error('Unhandled rejection', reason, promise);
+    });
   `);
 
   assert.deepEqual(
     findings.map(({ catchValue }) => catchValue),
-    ['reason', 'error'],
+    ['reason', 'error', 'reason'],
+  );
+});
+
+test('resolves logger factories, imports, aliases, properties, and types', () => {
+  const findings = inventorySource(`
+    import defaultSink from './logger';
+    import * as core from '@openai/agents-core';
+    import { getLogger as createSink, logger as sharedSink } from './logger';
+    import type { Logger as Sink } from './logger';
+
+    const audit = createSink('audit');
+    const alias = audit;
+    const namespaced = core.getLogger('namespaced');
+    defaultSink.error('Default failed', response);
+    sharedSink.warn('Shared failed', response);
+    audit.error('Audit failed', response);
+    alias.info('Alias failed', response);
+    namespaced.error('Namespaced failed', response);
+
+    class Service {
+      private readonly sink = createSink('service');
+      report(problem, injected: Sink) {
+        this.sink.error('Service failed', problem);
+        injected.error('Injected failed', problem);
+      }
+    }
+
+    class InheritedService {
+      report(problem) {
+        this.logger.error('Inherited logger failed', problem);
+      }
+    }
+  `);
+
+  assert.deepEqual(
+    findings.map(({ method }) => method),
+    ['error', 'warn', 'error', 'info', 'error', 'error', 'error', 'error'],
   );
 });
 
 test('fingerprints distinguish call sites and survive unrelated line shifts', () => {
   const source = `
+    const logger = getLogger('fixture');
     function logModel(error) {
       logger.error('Operation failed', error);
     }
@@ -107,6 +152,24 @@ test('fingerprints distinguish call sites and survive unrelated line shifts', ()
     shiftedFindings.map(({ fingerprint }) => fingerprint),
     findings.map(({ fingerprint }) => fingerprint),
   );
+});
+
+test('normalizes path separators before recording and hashing', () => {
+  const source = `
+    const logger = getLogger('fixture');
+    logger.error('Operation failed', error);
+  `;
+  const windowsFinding = inventorySource(
+    source,
+    'packages\\agents-core\\src\\fixture.ts',
+  )[0];
+  const posixFinding = inventorySource(
+    source,
+    'packages/agents-core/src/fixture.ts',
+  )[0];
+
+  assert.equal(windowsFinding.file, 'packages/agents-core/src/fixture.ts');
+  assert.equal(windowsFinding.fingerprint, posixFinding.fingerprint);
 });
 
 test('ignores unrelated methods that happen to share logger method names', () => {

--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
@@ -183,6 +183,30 @@ test('resolves logger instances stored in object literals', () => {
   );
 });
 
+test('resolves Logger-typed object members', () => {
+  const findings = inventorySource(`
+    type ReportOptions = { logger?: Logger };
+    interface AuditOptions {
+      sink: Readonly<Logger>;
+    }
+
+    function report(options: { logger: Logger }) {
+      options.logger.error('Inline options failed', secret);
+    }
+    function reportAlias(options: ReportOptions) {
+      options.logger?.warn('Alias options failed', secret);
+    }
+    function reportInterface(options: AuditOptions) {
+      options.sink.info('Interface options failed', secret);
+    }
+  `);
+
+  assert.deepEqual(
+    findings.map(({ method }) => method),
+    ['error', 'warn', 'info'],
+  );
+});
+
 test('inventories every direct console method', () => {
   const findings = inventorySource(`
     console.dir(secret);
@@ -196,6 +220,30 @@ test('inventories every direct console method', () => {
       { kind: 'console', method: 'dir', policy: 'none' },
       { kind: 'console', method: 'table', policy: 'none' },
       { kind: 'console', method: 'trace', policy: 'none' },
+    ],
+  );
+});
+
+test('resolves console object and extracted method aliases', () => {
+  const findings = inventorySource(`
+    const sink = console;
+    const nestedSink = sink;
+    const { warn, log: emit } = nestedSink;
+    const trace = console.trace;
+
+    sink.error('Request failed', secret);
+    warn(secret);
+    emit(payload);
+    trace(error);
+  `);
+
+  assert.deepEqual(
+    findings.map(({ kind, method }) => ({ kind, method })),
+    [
+      { kind: 'console', method: 'error' },
+      { kind: 'console', method: 'warn' },
+      { kind: 'console', method: 'log' },
+      { kind: 'console', method: 'trace' },
     ],
   );
 });

--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
@@ -173,13 +173,38 @@ test('resolves logger instances stored in object literals', () => {
       audit,
     };
     sinks.audit.error('Nested audit failed', response);
+    sinks['audit'].warn('Bracket audit failed', response);
     sinks.auditAlias.warn('Audit alias failed', response);
     sinks.audit.info('Shorthand audit failed', response);
   `);
 
   assert.deepEqual(
     findings.map(({ method }) => method),
-    ['error', 'warn', 'info'],
+    ['error', 'warn', 'warn', 'info'],
+  );
+});
+
+test('resolves extracted Logger method aliases', () => {
+  const findings = inventorySource(`
+    const logger = getLogger('fixture');
+    const { error: report, warn } = logger;
+    const debug = logger['debug'];
+    const reportAlias = report;
+
+    report('Report failed', secret);
+    warn('Warning', secret);
+    debug('Debug value', secret);
+    reportAlias('Alias failed', secret);
+  `);
+
+  assert.deepEqual(
+    findings.map(({ kind, method }) => ({ kind, method })),
+    [
+      { kind: 'logger', method: 'error' },
+      { kind: 'logger', method: 'warn' },
+      { kind: 'logger', method: 'debug' },
+      { kind: 'logger', method: 'error' },
+    ],
   );
 });
 
@@ -204,6 +229,28 @@ test('resolves Logger-typed object members', () => {
   assert.deepEqual(
     findings.map(({ method }) => method),
     ['error', 'warn', 'info'],
+  );
+});
+
+test('resolves Logger subtypes declared with heritage clauses', () => {
+  const findings = inventorySource(`
+    interface AuditLogger extends Logger {}
+    interface NestedAuditLogger extends AuditLogger {}
+    class ServiceLogger implements Logger {}
+    class NestedServiceLogger extends ServiceLogger {}
+
+    function report(
+      audit: NestedAuditLogger,
+      service: NestedServiceLogger,
+    ) {
+      audit.error('Audit failed', secret);
+      service.warn('Service failed', secret);
+    }
+  `);
+
+  assert.deepEqual(
+    findings.map(({ method }) => method),
+    ['error', 'warn'],
   );
 });
 

--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
@@ -110,6 +110,43 @@ test('flags promise rejection handler values as caught values', () => {
   );
 });
 
+test('inventories logging method references passed as callbacks', () => {
+  const findings = inventorySource(`
+    const logger = getLogger('fixture');
+    const { warn } = logger;
+    run().catch(console.error);
+    run().then(undefined, logger.error);
+    process.on('unhandledRejection', warn);
+    items.forEach(console.log);
+  `);
+
+  assert.deepEqual(
+    findings.map(({ kind, method, catchValue }) => ({
+      kind,
+      method,
+      catchValue,
+    })),
+    [
+      {
+        kind: 'console',
+        method: 'error',
+        catchValue: 'rejection reason',
+      },
+      {
+        kind: 'logger',
+        method: 'error',
+        catchValue: 'rejection reason',
+      },
+      {
+        kind: 'logger',
+        method: 'warn',
+        catchValue: 'rejection reason',
+      },
+      { kind: 'console', method: 'log', catchValue: null },
+    ],
+  );
+});
+
 test('flags destructured rejection values as caught values', () => {
   const findings = inventorySource(`
     const logger = getLogger('fixture');
@@ -369,6 +406,26 @@ test('method alias analysis converges across reassignments', () => {
     [
       { kind: 'console', method: 'error|log' },
       { kind: 'logger', method: 'error|warn' },
+    ],
+  );
+});
+
+test('inventories computed methods on known logging receivers', () => {
+  const findings = inventorySource(`
+    const logger = getLogger('fixture');
+    const level: 'error' | 'warn' = choose();
+    logger[level]('Logger failed', secret);
+    console[level]('Console failed', secret);
+    const emit = console[level];
+    emit(payload);
+  `);
+
+  assert.deepEqual(
+    findings.map(({ kind, method }) => ({ kind, method })),
+    [
+      { kind: 'logger', method: 'computed' },
+      { kind: 'console', method: 'computed' },
+      { kind: 'console', method: 'computed' },
     ],
   );
 });

--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
@@ -110,6 +110,23 @@ test('flags promise rejection handler values as caught values', () => {
   );
 });
 
+test('flags destructured rejection values as caught values', () => {
+  const findings = inventorySource(`
+    const logger = getLogger('fixture');
+    try {
+      await run();
+    } catch ({ message, cause: nestedCause }) {
+      logger.error('Run failed', message, nestedCause);
+    }
+    run().catch(({ reason }) => logger.warn('Run failed', reason));
+  `);
+
+  assert.deepEqual(
+    findings.map(({ catchValue }) => catchValue),
+    ['message, nestedCause', 'reason'],
+  );
+});
+
 test('resolves logger factories, imports, aliases, properties, and types', () => {
   const findings = inventorySource(`
     import defaultSink from './logger';
@@ -144,6 +161,25 @@ test('resolves logger factories, imports, aliases, properties, and types', () =>
   assert.deepEqual(
     findings.map(({ method }) => method),
     ['error', 'warn', 'error', 'info', 'error', 'error', 'error', 'error'],
+  );
+});
+
+test('resolves logger instances stored in object literals', () => {
+  const findings = inventorySource(`
+    const audit = getLogger('audit');
+    const sinks = {
+      audit: getLogger('nested-audit'),
+      auditAlias: audit,
+      audit,
+    };
+    sinks.audit.error('Nested audit failed', response);
+    sinks.auditAlias.warn('Audit alias failed', response);
+    sinks.audit.info('Shorthand audit failed', response);
+  `);
+
+  assert.deepEqual(
+    findings.map(({ method }) => method),
+    ['error', 'warn', 'info'],
   );
 });
 
@@ -204,6 +240,40 @@ test('fingerprints distinguish call sites and survive unrelated line shifts', ()
     shiftedFindings.map(({ fingerprint }) => fingerprint),
     findings.map(({ fingerprint }) => fingerprint),
   );
+});
+
+test('fingerprints identify switch branches without order-dependent reuse', () => {
+  const source = `
+    const logger = getLogger('fixture');
+    switch (kind) {
+      case 'model':
+        logger.error('Operation failed', error);
+        break;
+      case 'tool':
+        logger.error('Operation failed', error);
+        break;
+      default:
+        logger.error('Operation failed', error);
+    }
+  `;
+  const sourceWithEarlierCase = source.replace(
+    "case 'model':",
+    `case 'new':
+        logger.error('Operation failed', error);
+        break;
+      case 'model':`,
+  );
+  const findings = inventorySource(source);
+  const shiftedFindings = inventorySource(sourceWithEarlierCase);
+
+  assert.equal(new Set(findings.map(({ fingerprint }) => fingerprint)).size, 3);
+  assert.deepEqual(
+    shiftedFindings.slice(1).map(({ fingerprint }) => fingerprint),
+    findings.map(({ fingerprint }) => fingerprint),
+  );
+  assert.match(findings[0].context, /switch:kind>case:'model'/);
+  assert.match(findings[1].context, /switch:kind>case:'tool'/);
+  assert.match(findings[2].context, /switch:kind>case:default/);
 });
 
 test('normalizes path separators before recording and hashing', () => {

--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
@@ -31,6 +31,7 @@ test('recognizes model and tool policy boundaries', () => {
       logger.warn('Tool failed', error);
     }
     logModelActionError(logger, 'Model failed', error, event);
+    logModelAndToolActionWarning(logger, 'Run failed', error, item);
     logToolActionError(logger, 'Tool failed', error, toolCall);
   `);
 
@@ -41,6 +42,10 @@ test('recognizes model and tool policy boundaries', () => {
       { method: 'warn', policy: 'tool-guard' },
       { method: 'warn', policy: 'tool-guard' },
       { method: 'logModelActionError', policy: 'model-helper' },
+      {
+        method: 'logModelAndToolActionWarning',
+        policy: 'model+tool-helper',
+      },
       { method: 'logToolActionError', policy: 'tool-helper' },
     ],
   );
@@ -66,6 +71,41 @@ test('flags caught values passed to logger and console calls', () => {
       { kind: 'logger', catchValue: 'reason', policy: 'none' },
       { kind: 'console', catchValue: 'reason', policy: 'none' },
     ],
+  );
+});
+
+test('flags promise rejection handler values as caught values', () => {
+  const findings = inventorySource(`
+    run().catch((reason) => logger.warn('Run failed', reason));
+    run().then(undefined, (error) => console.error('Run failed', error));
+  `);
+
+  assert.deepEqual(
+    findings.map(({ catchValue }) => catchValue),
+    ['reason', 'error'],
+  );
+});
+
+test('fingerprints distinguish call sites and survive unrelated line shifts', () => {
+  const source = `
+    function logModel(error) {
+      logger.error('Operation failed', error);
+    }
+    function logTool(error) {
+      logger.error('Operation failed', error);
+    }
+  `;
+  const shiftedSource = `
+    const unrelated = true;
+    ${source}
+  `;
+  const findings = inventorySource(source);
+  const shiftedFindings = inventorySource(shiftedSource);
+
+  assert.equal(new Set(findings.map(({ fingerprint }) => fingerprint)).size, 2);
+  assert.deepEqual(
+    shiftedFindings.map(({ fingerprint }) => fingerprint),
+    findings.map(({ fingerprint }) => fingerprint),
   );
 });
 

--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
@@ -53,6 +53,23 @@ test('recognizes model and tool policy boundaries', () => {
   );
 });
 
+test('reads policy conditions from conditional expressions', () => {
+  const findings = inventorySource(`
+    const logger = getLogger('fixture');
+    logger.dontLogToolData
+      ? logger.warn('Tool logging disabled')
+      : logger.warn('Tool failed', error);
+  `);
+
+  assert.deepEqual(
+    findings.map(({ method, policy }) => ({ method, policy })),
+    [
+      { method: 'warn', policy: 'tool-guard' },
+      { method: 'warn', policy: 'tool-guard' },
+    ],
+  );
+});
+
 test('flags caught values passed to logger and console calls', () => {
   const findings = inventorySource(`
     const appLogger: Logger = getLogger('app');
@@ -127,6 +144,41 @@ test('resolves logger factories, imports, aliases, properties, and types', () =>
   assert.deepEqual(
     findings.map(({ method }) => method),
     ['error', 'warn', 'error', 'info', 'error', 'error', 'error', 'error'],
+  );
+});
+
+test('inventories every direct console method', () => {
+  const findings = inventorySource(`
+    console.dir(secret);
+    console.table(payload);
+    console.trace(error);
+  `);
+
+  assert.deepEqual(
+    findings.map(({ kind, method, policy }) => ({ kind, method, policy })),
+    [
+      { kind: 'console', method: 'dir', policy: 'none' },
+      { kind: 'console', method: 'table', policy: 'none' },
+      { kind: 'console', method: 'trace', policy: 'none' },
+    ],
+  );
+});
+
+test('resolves sensitive helper import aliases and namespace accesses', () => {
+  const findings = inventorySource(`
+    import { logToolActionError as reportFailure } from './logger';
+    import * as logging from '@openai/agents-core/utils/internal';
+
+    reportFailure(logger, 'Tool failed', error, payload);
+    logging.logModelActionError(logger, 'Model failed', error, response);
+  `);
+
+  assert.deepEqual(
+    findings.map(({ method, policy }) => ({ method, policy })),
+    [
+      { method: 'logToolActionError', policy: 'tool-helper' },
+      { method: 'logModelActionError', policy: 'model-helper' },
+    ],
   );
 });
 

--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { inventorySource } from './inventory-logging.mjs';
+import { inventorySource, inventorySources } from './inventory-logging.mjs';
 
 test('inventories static and dynamic logger calls', () => {
   const findings = inventorySource(`
@@ -238,6 +238,36 @@ test('resolves Logger-typed object members', () => {
   );
 });
 
+test('resolves imported Logger-valued object members', () => {
+  const findings = inventorySources({
+    'types.ts': `
+      export type Logger = {
+        namespace: string;
+        debug(message: string, ...args: unknown[]): void;
+        error(message: string, ...args: unknown[]): void;
+        warn(message: string, ...args: unknown[]): void;
+        dontLogModelData: boolean;
+        dontLogToolData: boolean;
+      };
+      export interface ReportOptions {
+        logger: Logger;
+      }
+    `,
+    'report.ts': `
+      import type { ReportOptions } from './types';
+
+      export function report(options: ReportOptions) {
+        options.logger.error('Imported options failed', secret);
+      }
+    `,
+  });
+
+  assert.deepEqual(
+    findings.map(({ file, method }) => ({ file, method })),
+    [{ file: 'report.ts', method: 'error' }],
+  );
+});
+
 test('resolves Logger subtypes declared with heritage clauses', () => {
   const findings = inventorySource(`
     interface AuditLogger extends Logger {}
@@ -273,6 +303,26 @@ test('inventories every direct console method', () => {
       { kind: 'console', method: 'dir', policy: 'none' },
       { kind: 'console', method: 'table', policy: 'none' },
       { kind: 'console', method: 'trace', policy: 'none' },
+    ],
+  );
+});
+
+test('recognizes globally qualified console receivers', () => {
+  const findings = inventorySource(`
+    globalThis.console.error('Global failure', secret);
+    window.console.warn(secret);
+    global.console.log(payload);
+    const sink = globalThis.console;
+    sink.trace(error);
+  `);
+
+  assert.deepEqual(
+    findings.map(({ kind, method }) => ({ kind, method })),
+    [
+      { kind: 'console', method: 'error' },
+      { kind: 'console', method: 'warn' },
+      { kind: 'console', method: 'log' },
+      { kind: 'console', method: 'trace' },
     ],
   );
 });
@@ -397,6 +447,35 @@ test('fingerprints identify switch branches without order-dependent reuse', () =
   assert.match(findings[0].context, /switch:kind>case:'model'/);
   assert.match(findings[1].context, /switch:kind>case:'tool'/);
   assert.match(findings[2].context, /switch:kind>case:default/);
+});
+
+test('fingerprints identify try branches without order-dependent reuse', () => {
+  const source = `
+    const logger = getLogger('fixture');
+    try {
+      logger.error('Operation failed', error);
+    } catch {
+      logger.error('Operation failed', error);
+    } finally {
+      logger.error('Operation failed', error);
+    }
+  `;
+  const sourceWithEarlierCall = source.replace(
+    'try {',
+    `logger.error('Operation failed', error);
+    try {`,
+  );
+  const findings = inventorySource(source);
+  const shiftedFindings = inventorySource(sourceWithEarlierCall);
+
+  assert.equal(new Set(findings.map(({ fingerprint }) => fingerprint)).size, 3);
+  assert.deepEqual(
+    shiftedFindings.slice(1).map(({ fingerprint }) => fingerprint),
+    findings.map(({ fingerprint }) => fingerprint),
+  );
+  assert.match(findings[0].context, /try:try/);
+  assert.match(findings[1].context, /try:catch/);
+  assert.match(findings[2].context, /try:finally/);
 });
 
 test('normalizes path separators before recording and hashing', () => {

--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { inventorySource } from './inventory-logging.mjs';
+
+test('inventories static and dynamic logger calls', () => {
+  const findings = inventorySource(`
+    logger.debug('ready');
+    logger.warn(\`Failed for \${requestId}\`);
+    logger.error('Request failed', error, response);
+  `);
+
+  assert.deepEqual(
+    findings.map(({ method, shape, policy }) => ({ method, shape, policy })),
+    [
+      { method: 'debug', shape: 'static-message', policy: 'none' },
+      { method: 'warn', shape: 'dynamic-message', policy: 'none' },
+      { method: 'error', shape: 'payload', policy: 'none' },
+    ],
+  );
+});
+
+test('recognizes model and tool policy boundaries', () => {
+  const findings = inventorySource(`
+    if (!logger.dontLogModelData) {
+      logger.debug('Response:', response);
+    }
+    if (logger.dontLogToolData) {
+      logger.warn('Tool failed');
+    } else {
+      logger.warn('Tool failed', error);
+    }
+    logModelActionError(logger, 'Model failed', error, event);
+    logToolActionError(logger, 'Tool failed', error, toolCall);
+  `);
+
+  assert.deepEqual(
+    findings.map(({ method, policy }) => ({ method, policy })),
+    [
+      { method: 'debug', policy: 'model-guard' },
+      { method: 'warn', policy: 'tool-guard' },
+      { method: 'warn', policy: 'tool-guard' },
+      { method: 'logModelActionError', policy: 'model-helper' },
+      { method: 'logToolActionError', policy: 'tool-helper' },
+    ],
+  );
+});
+
+test('flags caught values passed to logger and console calls', () => {
+  const findings = inventorySource(`
+    try {
+      await run();
+    } catch (reason) {
+      appLogger.error('Run failed', reason);
+      console.warn(\`Run failed: \${reason}\`);
+    }
+  `);
+
+  assert.deepEqual(
+    findings.map(({ kind, catchValue, policy }) => ({
+      kind,
+      catchValue,
+      policy,
+    })),
+    [
+      { kind: 'logger', catchValue: 'reason', policy: 'none' },
+      { kind: 'console', catchValue: 'reason', policy: 'none' },
+    ],
+  );
+});
+
+test('ignores unrelated methods that happen to share logger method names', () => {
+  const findings = inventorySource(`
+    controller.error(problem);
+    loggerLikeButNotExact.info(details);
+  `);
+
+  assert.equal(findings.length, 0);
+});

--- a/.changeset/tidy-logs-protect-data.md
+++ b/.changeset/tidy-logs-protect-data.md
@@ -1,0 +1,8 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-extensions': patch
+'@openai/agents-openai': patch
+'@openai/agents-realtime': patch
+---
+
+fix: prevent sensitive model and tool data from leaking through runtime logs

--- a/.changeset/tidy-logs-protect-data.md
+++ b/.changeset/tidy-logs-protect-data.md
@@ -1,8 +1,0 @@
----
-'@openai/agents-core': patch
-'@openai/agents-extensions': patch
-'@openai/agents-openai': patch
-'@openai/agents-realtime': patch
----
-
-fix: prevent sensitive model and tool data from leaking through runtime logs


### PR DESCRIPTION
This pull request adds an AST-based inventory for runtime logger and console calls that may expose model data, tool data, or arbitrary thrown values. It includes focused detector tests and a review framework covering redacted and diagnostic modes, sentinel payloads, hostile thrown values, supplemental arguments, and caller behavior after logging.

The inventory intentionally reports review candidates rather than claiming automatic taint analysis, allowing maintainers to classify every dynamic log sink and detect newly introduced or changed callsites by stable fingerprints.