### PR TITLE
fix: honor sensitive logging flags across runtime paths

### DIFF
--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.mjs
@@ -18,8 +18,13 @@ const LOGGER_TYPE_PROPERTIES = [
 ];
 const STANDARD_GLOBALS = new Set(['global', 'globalThis', 'window']);
 const SENSITIVE_HELPERS = new Map([
+  ['logModelAndToolActionDebug', 'model+tool-helper'],
+  ['logModelAndToolActionError', 'model+tool-helper'],
+  ['logModelAndToolActionWarning', 'model+tool-helper'],
   ['logModelActionError', 'model-helper'],
+  ['logToolActionDebug', 'tool-helper'],
   ['logToolActionError', 'tool-helper'],
+  ['logToolActionWarning', 'tool-helper'],
 ]);
 const SENSITIVE_HELPER_MODULES = new Set([
   '@openai/agents-core/utils/internal',

--- a/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
+++ b/.agents/skills/sensitive-logging-audit/scripts/inventory-logging.test.mjs
@@ -24,7 +24,9 @@ test('inventories static and dynamic logger calls', () => {
 test('recognizes model and tool policy boundaries', () => {
   const findings = inventorySource(`
     import {
+      logModelAndToolActionWarning,
       logModelActionError,
+      logToolActionDebug,
       logToolActionError,
     } from './logger';
 
@@ -38,6 +40,8 @@ test('recognizes model and tool policy boundaries', () => {
       logger.warn('Tool failed', error);
     }
     logModelActionError(logger, 'Model failed', error, event);
+    logModelAndToolActionWarning(logger, 'Run failed', error, event);
+    logToolActionDebug(logger, 'Tool debug failed', error, toolCall);
     logToolActionError(logger, 'Tool failed', error, toolCall);
   `);
 
@@ -48,6 +52,11 @@ test('recognizes model and tool policy boundaries', () => {
       { method: 'warn', policy: 'none' },
       { method: 'warn', policy: 'tool-guard' },
       { method: 'logModelActionError', policy: 'model-helper' },
+      {
+        method: 'logModelAndToolActionWarning',
+        policy: 'model+tool-helper',
+      },
+      { method: 'logToolActionDebug', policy: 'tool-helper' },
       { method: 'logToolActionError', policy: 'tool-helper' },
     ],
   );

--- a/.changeset/quiet-sinks-protect.md
+++ b/.changeset/quiet-sinks-protect.md
@@ -2,6 +2,7 @@
 '@openai/agents-core': patch
 '@openai/agents-extensions': patch
 '@openai/agents-openai': patch
+'@openai/agents-realtime': patch
 ---
 
 fix: honor sensitive logging flags across runtime error and payload paths

--- a/.changeset/quiet-sinks-protect.md
+++ b/.changeset/quiet-sinks-protect.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-extensions': patch
+'@openai/agents-openai': patch
+---
+
+fix: honor sensitive logging flags across runtime error and payload paths

--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -590,7 +590,7 @@ export class Agent<
       config.handoffOutputTypeWarningEnabled === undefined ||
       config.handoffOutputTypeWarningEnabled
     ) {
-      if (this.handoffs && this.outputType) {
+      if (!logger.dontLogModelData && this.handoffs && this.outputType) {
         const outputTypes = new Set<string>([JSON.stringify(this.outputType)]);
         for (const h of this.handoffs) {
           if ('outputType' in h && h.outputType) {

--- a/packages/agents-core/src/logger.ts
+++ b/packages/agents-core/src/logger.ts
@@ -60,13 +60,7 @@ export function getLogger(namespace: string = 'openai-agents'): Logger {
 }
 
 export function getSafeErrorType(error: unknown): string {
-  const errorType = typeof error;
-
-  try {
-    return error instanceof Error ? 'Error' : errorType;
-  } catch {
-    return errorType;
-  }
+  return typeof error;
 }
 
 type SensitiveLogMethod = 'debug' | 'error' | 'warn';

--- a/packages/agents-core/src/logger.ts
+++ b/packages/agents-core/src/logger.ts
@@ -69,18 +69,38 @@ export function getSafeErrorType(error: unknown): string {
   }
 }
 
+type SensitiveLogMethod = 'debug' | 'error' | 'warn';
+
+function logSensitiveActionError(
+  targetLogger: Logger,
+  method: SensitiveLogMethod,
+  redact: boolean,
+  message: string,
+  error: unknown,
+  details: unknown[],
+): void {
+  if (redact) {
+    targetLogger[method](message, getSafeErrorType(error));
+    return;
+  }
+
+  targetLogger[method](message, error, ...details);
+}
+
 export function logToolActionError(
   targetLogger: Logger,
   message: string,
   error: unknown,
   ...details: unknown[]
 ): void {
-  if (targetLogger.dontLogToolData) {
-    targetLogger.error(message, getSafeErrorType(error));
-    return;
-  }
-
-  targetLogger.error(message, error, ...details);
+  logSensitiveActionError(
+    targetLogger,
+    'error',
+    targetLogger.dontLogToolData,
+    message,
+    error,
+    details,
+  );
 }
 
 export function logModelActionError(
@@ -89,12 +109,94 @@ export function logModelActionError(
   error: unknown,
   ...details: unknown[]
 ): void {
-  if (targetLogger.dontLogModelData) {
-    targetLogger.error(message, getSafeErrorType(error));
-    return;
-  }
+  logSensitiveActionError(
+    targetLogger,
+    'error',
+    targetLogger.dontLogModelData,
+    message,
+    error,
+    details,
+  );
+}
 
-  targetLogger.error(message, error, ...details);
+export function logToolActionWarning(
+  targetLogger: Logger,
+  message: string,
+  error: unknown,
+  ...details: unknown[]
+): void {
+  logSensitiveActionError(
+    targetLogger,
+    'warn',
+    targetLogger.dontLogToolData,
+    message,
+    error,
+    details,
+  );
+}
+
+export function logToolActionDebug(
+  targetLogger: Logger,
+  message: string,
+  error: unknown,
+  ...details: unknown[]
+): void {
+  logSensitiveActionError(
+    targetLogger,
+    'debug',
+    targetLogger.dontLogToolData,
+    message,
+    error,
+    details,
+  );
+}
+
+export function logModelAndToolActionError(
+  targetLogger: Logger,
+  message: string,
+  error: unknown,
+  ...details: unknown[]
+): void {
+  logSensitiveActionError(
+    targetLogger,
+    'error',
+    targetLogger.dontLogModelData || targetLogger.dontLogToolData,
+    message,
+    error,
+    details,
+  );
+}
+
+export function logModelAndToolActionWarning(
+  targetLogger: Logger,
+  message: string,
+  error: unknown,
+  ...details: unknown[]
+): void {
+  logSensitiveActionError(
+    targetLogger,
+    'warn',
+    targetLogger.dontLogModelData || targetLogger.dontLogToolData,
+    message,
+    error,
+    details,
+  );
+}
+
+export function logModelAndToolActionDebug(
+  targetLogger: Logger,
+  message: string,
+  error: unknown,
+  ...details: unknown[]
+): void {
+  logSensitiveActionError(
+    targetLogger,
+    'debug',
+    targetLogger.dontLogModelData || targetLogger.dontLogToolData,
+    message,
+    error,
+    details,
+  );
 }
 
 export const logger = getLogger('openai-agents:core');

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -12,7 +12,11 @@ import {
   type MCPListToolsSpanData,
   type Span,
 } from './tracing';
-import { logger as globalLogger, type Logger } from './logger';
+import {
+  logger as globalLogger,
+  logToolActionWarning,
+  type Logger,
+} from './logger';
 import {
   JsonObjectSchema,
   JsonObjectSchemaNonStrict,
@@ -1093,7 +1097,11 @@ export function mcpToFunctionTool(
         },
       });
     } catch (e) {
-      globalLogger.warn(`Error converting MCP schema to strict mode: ${e}`);
+      logToolActionWarning(
+        globalLogger,
+        'Error converting MCP schema to strict mode:',
+        e,
+      );
     }
   }
 

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -31,6 +31,7 @@ import type {
   MCPToolMetaContext,
   MCPToolMetaResolver,
 } from './mcpUtil';
+import { getMcpServerLogName } from './mcpLogging';
 import type { RunContext } from './runContext';
 import type { Agent } from './agent';
 import { maybeExtractToolOutputCustomData } from './utils/customData';
@@ -496,7 +497,7 @@ async function getMcpToolsFromServer<TContext = UnknownContext>({
             const filtered = await filter(context, tool);
             if (!filtered) {
               globalLogger.debug(
-                `MCP Tool (server: ${server.name}, tool: ${tool.name}) is blocked by the callable filter.`,
+                `MCP Tool (server: ${getMcpServerLogName(server.name)}, tool: ${tool.name}) is blocked by the callable filter.`,
               );
               continue;
             }
@@ -515,11 +516,11 @@ async function getMcpToolsFromServer<TContext = UnknownContext>({
               if (!allowed || blocked) {
                 if (blocked) {
                   globalLogger.debug(
-                    `MCP Tool (server: ${server.name}, tool: ${tool.name}) is blocked by the static filter.`,
+                    `MCP Tool (server: ${getMcpServerLogName(server.name)}, tool: ${tool.name}) is blocked by the static filter.`,
                   );
                 } else if (!allowed) {
                   globalLogger.debug(
-                    `MCP Tool (server: ${server.name}, tool: ${tool.name}) is not allowed by the static filter.`,
+                    `MCP Tool (server: ${getMcpServerLogName(server.name)}, tool: ${tool.name}) is not allowed by the static filter.`,
                   );
                 }
                 continue;

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -31,7 +31,7 @@ import type {
   MCPToolMetaContext,
   MCPToolMetaResolver,
 } from './mcpUtil';
-import { getMcpServerLogName } from './mcpLogging';
+import { getMcpServerDiagnosticName } from './mcpLogging';
 import type { RunContext } from './runContext';
 import type { Agent } from './agent';
 import { maybeExtractToolOutputCustomData } from './utils/customData';
@@ -455,6 +455,12 @@ export const defaultMCPToolCacheKey: MCPToolCacheKeyGenerator = ({
   return server.name;
 };
 
+function logMcpToolFilterDebug(buildMessage: () => string): void {
+  if (!globalLogger.dontLogToolData) {
+    globalLogger.debug(buildMessage());
+  }
+}
+
 /**
  * Fetches and filters raw MCP tools from a single MCP server.
  */
@@ -496,8 +502,9 @@ async function getMcpToolsFromServer<TContext = UnknownContext>({
           if (typeof filter === 'function') {
             const filtered = await filter(context, tool);
             if (!filtered) {
-              globalLogger.debug(
-                `MCP Tool (server: ${getMcpServerLogName(server.name)}, tool: ${tool.name}) is blocked by the callable filter.`,
+              logMcpToolFilterDebug(
+                () =>
+                  `MCP Tool (server: ${getMcpServerDiagnosticName(server.name)}, tool: ${tool.name}) is blocked by the callable filter.`,
               );
               continue;
             }
@@ -515,12 +522,14 @@ async function getMcpToolsFromServer<TContext = UnknownContext>({
                   : false;
               if (!allowed || blocked) {
                 if (blocked) {
-                  globalLogger.debug(
-                    `MCP Tool (server: ${getMcpServerLogName(server.name)}, tool: ${tool.name}) is blocked by the static filter.`,
+                  logMcpToolFilterDebug(
+                    () =>
+                      `MCP Tool (server: ${getMcpServerDiagnosticName(server.name)}, tool: ${tool.name}) is blocked by the static filter.`,
                   );
                 } else if (!allowed) {
-                  globalLogger.debug(
-                    `MCP Tool (server: ${getMcpServerLogName(server.name)}, tool: ${tool.name}) is not allowed by the static filter.`,
+                  logMcpToolFilterDebug(
+                    () =>
+                      `MCP Tool (server: ${getMcpServerDiagnosticName(server.name)}, tool: ${tool.name}) is not allowed by the static filter.`,
                   );
                 }
                 continue;

--- a/packages/agents-core/src/mcpLogging.ts
+++ b/packages/agents-core/src/mcpLogging.ts
@@ -1,0 +1,21 @@
+const URL_DERIVED_NAME_PREFIXES = ['sse: ', 'streamable-http: '] as const;
+
+// Some transports use their full endpoint URL as the default server name.
+// Preserve ordinary names while removing URL credentials, query parameters,
+// and fragments before a server name is written to logs.
+export function getMcpServerLogName(name: string): string {
+  const prefix = URL_DERIVED_NAME_PREFIXES.find((candidate) =>
+    name.startsWith(candidate),
+  );
+  const candidate = prefix ? name.slice(prefix.length) : name;
+
+  try {
+    const url = new URL(candidate);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return name;
+    }
+    return `${prefix ?? ''}${url.protocol}//${url.host}${url.pathname}`;
+  } catch {
+    return name;
+  }
+}

--- a/packages/agents-core/src/mcpLogging.ts
+++ b/packages/agents-core/src/mcpLogging.ts
@@ -1,9 +1,10 @@
 const URL_DERIVED_NAME_PREFIXES = ['sse: ', 'streamable-http: '] as const;
 
 // Some transports use their full endpoint URL as the default server name.
-// Preserve ordinary names while removing URL credentials, query parameters,
-// and fragments before a server name is written to logs.
-export function getMcpServerLogName(name: string): string {
+// In diagnostic mode, preserve ordinary names while removing URL credentials,
+// query parameters, and fragments. Redacted logging must use a fixed label
+// without reading the server name at all.
+export function getMcpServerDiagnosticName(name: string): string {
   const prefix = URL_DERIVED_NAME_PREFIXES.find((candidate) =>
     name.startsWith(candidate),
   );

--- a/packages/agents-core/src/mcpServers.ts
+++ b/packages/agents-core/src/mcpServers.ts
@@ -1,4 +1,4 @@
-import { getLogger } from './logger';
+import { getLogger, logToolActionDebug, logToolActionError } from './logger';
 import type { MCPServer } from './mcp';
 
 const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
@@ -352,7 +352,11 @@ export class MCPServers {
   }
 
   private recordFailure(server: MCPServer, error: Error, phase: string): void {
-    logger.error(`Failed to ${phase} MCP server '${server.name}':`, error);
+    logToolActionError(
+      logger,
+      `Failed to ${phase} MCP server '${server.name}':`,
+      error,
+    );
     if (!this.failedServerSet.has(server)) {
       this.failedServers.push(server);
       this.failedServerSet.add(server);
@@ -384,11 +388,19 @@ export class MCPServers {
         if (!this.suppressAbortError) {
           throw err;
         }
-        logger.debug(`Close cancelled for MCP server '${server.name}': ${err}`);
+        logToolActionDebug(
+          logger,
+          `Close cancelled for MCP server '${server.name}':`,
+          err,
+        );
         this.errorsByServer.set(server, err);
         return;
       }
-      logger.error(`Failed to close MCP server '${server.name}':`, err);
+      logToolActionError(
+        logger,
+        `Failed to close MCP server '${server.name}':`,
+        err,
+      );
       this.errorsByServer.set(server, err);
     }
   }

--- a/packages/agents-core/src/mcpServers.ts
+++ b/packages/agents-core/src/mcpServers.ts
@@ -1,11 +1,18 @@
 import { getLogger, logToolActionDebug, logToolActionError } from './logger';
 import type { MCPServer } from './mcp';
-import { getMcpServerLogName } from './mcpLogging';
+import { getMcpServerDiagnosticName } from './mcpLogging';
 
 const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
 const DEFAULT_CLOSE_TIMEOUT_MS = 10_000;
 
 const logger = getLogger('openai-agents:mcp-servers');
+
+function getMcpServerLogLabel(server: MCPServer): string {
+  if (logger.dontLogToolData) {
+    return 'MCP server';
+  }
+  return `MCP server '${getMcpServerDiagnosticName(server.name)}'`;
+}
 
 type ServerAction = 'connect' | 'close';
 
@@ -312,10 +319,9 @@ export class MCPServers {
   private async attemptConnect(server: MCPServer): Promise<void> {
     const raiseOnError = this.strict;
     try {
-      const serverLogName = getMcpServerLogName(server.name);
-      logger.debug(`Connecting MCP server '${serverLogName}'.`);
+      logger.debug(`Connecting ${getMcpServerLogLabel(server)}.`);
       await this.runConnect(server);
-      logger.debug(`Connected MCP server '${serverLogName}'.`);
+      logger.debug(`Connected ${getMcpServerLogLabel(server)}.`);
       if (this.failedServerSet.has(server)) {
         this.removeFailedServer(server);
         this.errorsByServer.delete(server);
@@ -354,10 +360,9 @@ export class MCPServers {
   }
 
   private recordFailure(server: MCPServer, error: Error, phase: string): void {
-    const serverLogName = getMcpServerLogName(server.name);
     logToolActionError(
       logger,
-      `Failed to ${phase} MCP server '${serverLogName}':`,
+      `Failed to ${phase} ${getMcpServerLogLabel(server)}:`,
       error,
     );
     if (!this.failedServerSet.has(server)) {
@@ -381,11 +386,10 @@ export class MCPServers {
   }
 
   private async closeServer(server: MCPServer): Promise<void> {
-    const serverLogName = getMcpServerLogName(server.name);
     try {
-      logger.debug(`Closing MCP server '${serverLogName}'.`);
+      logger.debug(`Closing ${getMcpServerLogLabel(server)}.`);
       await this.runClose(server);
-      logger.debug(`Closed MCP server '${serverLogName}'.`);
+      logger.debug(`Closed ${getMcpServerLogLabel(server)}.`);
     } catch (error) {
       const err = toError(error);
       if (isAbortError(err)) {
@@ -394,7 +398,7 @@ export class MCPServers {
         }
         logToolActionDebug(
           logger,
-          `Close cancelled for MCP server '${serverLogName}':`,
+          `Close cancelled for ${getMcpServerLogLabel(server)}:`,
           err,
         );
         this.errorsByServer.set(server, err);
@@ -402,7 +406,7 @@ export class MCPServers {
       }
       logToolActionError(
         logger,
-        `Failed to close MCP server '${serverLogName}':`,
+        `Failed to close ${getMcpServerLogLabel(server)}:`,
         err,
       );
       this.errorsByServer.set(server, err);

--- a/packages/agents-core/src/mcpServers.ts
+++ b/packages/agents-core/src/mcpServers.ts
@@ -1,5 +1,6 @@
 import { getLogger, logToolActionDebug, logToolActionError } from './logger';
 import type { MCPServer } from './mcp';
+import { getMcpServerLogName } from './mcpLogging';
 
 const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
 const DEFAULT_CLOSE_TIMEOUT_MS = 10_000;
@@ -311,9 +312,10 @@ export class MCPServers {
   private async attemptConnect(server: MCPServer): Promise<void> {
     const raiseOnError = this.strict;
     try {
-      logger.debug(`Connecting MCP server '${server.name}'.`);
+      const serverLogName = getMcpServerLogName(server.name);
+      logger.debug(`Connecting MCP server '${serverLogName}'.`);
       await this.runConnect(server);
-      logger.debug(`Connected MCP server '${server.name}'.`);
+      logger.debug(`Connected MCP server '${serverLogName}'.`);
       if (this.failedServerSet.has(server)) {
         this.removeFailedServer(server);
         this.errorsByServer.delete(server);
@@ -352,9 +354,10 @@ export class MCPServers {
   }
 
   private recordFailure(server: MCPServer, error: Error, phase: string): void {
+    const serverLogName = getMcpServerLogName(server.name);
     logToolActionError(
       logger,
-      `Failed to ${phase} MCP server '${server.name}':`,
+      `Failed to ${phase} MCP server '${serverLogName}':`,
       error,
     );
     if (!this.failedServerSet.has(server)) {
@@ -378,10 +381,11 @@ export class MCPServers {
   }
 
   private async closeServer(server: MCPServer): Promise<void> {
+    const serverLogName = getMcpServerLogName(server.name);
     try {
-      logger.debug(`Closing MCP server '${server.name}'.`);
+      logger.debug(`Closing MCP server '${serverLogName}'.`);
       await this.runClose(server);
-      logger.debug(`Closed MCP server '${server.name}'.`);
+      logger.debug(`Closed MCP server '${serverLogName}'.`);
     } catch (error) {
       const err = toError(error);
       if (isAbortError(err)) {
@@ -390,7 +394,7 @@ export class MCPServers {
         }
         logToolActionDebug(
           logger,
-          `Close cancelled for MCP server '${server.name}':`,
+          `Close cancelled for MCP server '${serverLogName}':`,
           err,
         );
         this.errorsByServer.set(server, err);
@@ -398,7 +402,7 @@ export class MCPServers {
       }
       logToolActionError(
         logger,
-        `Failed to close MCP server '${server.name}':`,
+        `Failed to close MCP server '${serverLogName}':`,
         err,
       );
       this.errorsByServer.set(server, err);

--- a/packages/agents-core/src/mcpShared.ts
+++ b/packages/agents-core/src/mcpShared.ts
@@ -80,7 +80,7 @@ export abstract class BaseMCPServerStdio implements MCPServer {
    * @param buildMessage A function that returns the message to log.
    */
   protected debugLog(buildMessage: () => string): void {
-    if (debug.enabled(this.logger.namespace)) {
+    if (!this.logger.dontLogToolData && debug.enabled(this.logger.namespace)) {
       // Only build the message when debug logging is enabled.
       this.logger.debug(buildMessage());
     }
@@ -138,7 +138,7 @@ export abstract class BaseMCPServerStreamableHttp implements MCPServer {
    * @param buildMessage A function that returns the message to log.
    */
   protected debugLog(buildMessage: () => string): void {
-    if (debug.enabled(this.logger.namespace)) {
+    if (!this.logger.dontLogToolData && debug.enabled(this.logger.namespace)) {
       // Only build the message when debug logging is enabled.
       this.logger.debug(buildMessage());
     }
@@ -194,7 +194,7 @@ export abstract class BaseMCPServerSSE implements MCPServer {
    * @param buildMessage A function that returns the message to log.
    */
   protected debugLog(buildMessage: () => string): void {
-    if (debug.enabled(this.logger.namespace)) {
+    if (!this.logger.dontLogToolData && debug.enabled(this.logger.namespace)) {
       // Only build the message when debug logging is enabled.
       this.logger.debug(buildMessage());
     }

--- a/packages/agents-core/src/memory/memorySession.ts
+++ b/packages/agents-core/src/memory/memorySession.ts
@@ -38,9 +38,11 @@ export class MemorySession implements SessionHistoryRewriteAwareSession {
   async getItems(limit?: number): Promise<AgentInputItem[]> {
     if (limit === undefined) {
       const cloned = this.items.map(cloneAgentItem);
-      this.logger.debug(
-        `Getting items from memory session (${this.sessionId}): ${JSON.stringify(cloned)}`,
-      );
+      if (!this.logger.dontLogModelData && !this.logger.dontLogToolData) {
+        this.logger.debug(
+          `Getting items from memory session (${this.sessionId}): ${JSON.stringify(cloned)}`,
+        );
+      }
       return cloned;
     }
     if (limit <= 0) {
@@ -48,9 +50,11 @@ export class MemorySession implements SessionHistoryRewriteAwareSession {
     }
     const start = Math.max(this.items.length - limit, 0);
     const items = this.items.slice(start).map(cloneAgentItem);
-    this.logger.debug(
-      `Getting items from memory session (${this.sessionId}): ${JSON.stringify(items)}`,
-    );
+    if (!this.logger.dontLogModelData && !this.logger.dontLogToolData) {
+      this.logger.debug(
+        `Getting items from memory session (${this.sessionId}): ${JSON.stringify(items)}`,
+      );
+    }
     return items;
   }
 
@@ -59,9 +63,11 @@ export class MemorySession implements SessionHistoryRewriteAwareSession {
       return;
     }
     const cloned = items.map(cloneAgentItem);
-    this.logger.debug(
-      `Adding items to memory session (${this.sessionId}): ${JSON.stringify(cloned)}`,
-    );
+    if (!this.logger.dontLogModelData && !this.logger.dontLogToolData) {
+      this.logger.debug(
+        `Adding items to memory session (${this.sessionId}): ${JSON.stringify(cloned)}`,
+      );
+    }
     this.items = [...this.items, ...cloned];
   }
 
@@ -71,9 +77,11 @@ export class MemorySession implements SessionHistoryRewriteAwareSession {
     }
     const item = this.items[this.items.length - 1];
     const cloned = cloneAgentItem(item);
-    this.logger.debug(
-      `Popping item from memory session (${this.sessionId}): ${JSON.stringify(cloned)}`,
-    );
+    if (!this.logger.dontLogModelData && !this.logger.dontLogToolData) {
+      this.logger.debug(
+        `Popping item from memory session (${this.sessionId}): ${JSON.stringify(cloned)}`,
+      );
+    }
     this.items = this.items.slice(0, -1);
     return cloned;
   }

--- a/packages/agents-core/src/result.ts
+++ b/packages/agents-core/src/result.ts
@@ -21,7 +21,7 @@ import { RunState } from './runState';
 import { RunContext } from './runContext';
 import type { AgentToolInvocation } from './agentToolInvocation';
 import type { InputGuardrailResult, OutputGuardrailResult } from './guardrail';
-import logger from './logger';
+import logger, { logModelAndToolActionDebug } from './logger';
 import { StreamEventTextStream } from './types/protocol';
 import type {
   ToolInputGuardrailResult,
@@ -102,8 +102,7 @@ export interface RunResultData<
    * The output of the last agent, or any handoff agent.
    */
   finalOutput?:
-    | ResolvedAgentOutput<TAgent['outputType']>
-    | HandoffsOutput<THandoffs>;
+    ResolvedAgentOutput<TAgent['outputType']> | HandoffsOutput<THandoffs>;
 
   /**
    * The interruptions that occurred during the agent run.
@@ -347,7 +346,11 @@ export class StreamedRunResult<
         [result.signal, this.#abortController.signal],
         {
           onAbortSignalAnyError: (error) => {
-            logger.debug(`AbortSignal.any failed, falling back: ${error}`);
+            logModelAndToolActionDebug(
+              logger,
+              'AbortSignal.any failed, falling back:',
+              error,
+            );
           },
         },
       );
@@ -425,7 +428,7 @@ export class StreamedRunResult<
     this.#error = err;
     this.#completedPromiseReject?.(err);
     this.#completedPromise.catch((e) => {
-      logger.debug(`Resulted in an error: ${e}`);
+      logModelAndToolActionDebug(logger, 'Resulted in an error:', e);
     });
     this.#detachAbortHandler();
   }
@@ -541,7 +544,11 @@ export class StreamedRunResult<
       try {
         controller.close();
       } catch (err) {
-        logger.debug(`Failed to close readable stream on abort: ${err}`);
+        logModelAndToolActionDebug(
+          logger,
+          'Failed to close readable stream on abort:',
+          err,
+        );
       }
     }
 
@@ -558,13 +565,21 @@ export class StreamedRunResult<
       try {
         this.#combinedSignal.removeEventListener('abort', this.#abortHandler);
       } catch (err) {
-        logger.debug(`Failed to remove abort listener: ${err}`);
+        logModelAndToolActionDebug(
+          logger,
+          'Failed to remove abort listener:',
+          err,
+        );
       }
     }
     try {
       this.#combinedSignalCleanup();
     } catch (err) {
-      logger.debug(`Failed to clean up combined abort listeners: ${err}`);
+      logModelAndToolActionDebug(
+        logger,
+        'Failed to clean up combined abort listeners:',
+        err,
+      );
     }
     this.#combinedSignalCleanup = () => {};
     this.#abortHandler = undefined;

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -15,7 +15,7 @@ import type {
 } from './guardrail';
 import { Handoff, HandoffInputFilter } from './handoff';
 import { RunHooks } from './lifecycle';
-import logger from './logger';
+import logger, { logToolActionDebug } from './logger';
 import { Model, ModelProvider, ModelResponse, ModelSettings } from './model';
 import { getDefaultModelProvider } from './providers';
 import { RunContext } from './runContext';
@@ -1684,7 +1684,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 serverConversationTracker.previousResponseId,
               );
             } catch (error) {
-              logger.debug(
+              logToolActionDebug(
+                logger,
                 'Failed to reconcile streamed tool calls after abort.',
                 error,
               );

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -15,7 +15,7 @@ import type {
 } from './guardrail';
 import { Handoff, HandoffInputFilter } from './handoff';
 import { RunHooks } from './lifecycle';
-import logger, { logToolActionDebug } from './logger';
+import logger, { logModelAndToolActionDebug } from './logger';
 import { Model, ModelProvider, ModelResponse, ModelSettings } from './model';
 import { getDefaultModelProvider } from './providers';
 import { RunContext } from './runContext';
@@ -1684,7 +1684,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 serverConversationTracker.previousResponseId,
               );
             } catch (error) {
-              logToolActionDebug(
+              logModelAndToolActionDebug(
                 logger,
                 'Failed to reconcile streamed tool calls after abort.',
                 error,

--- a/packages/agents-core/src/runner/sandbox.ts
+++ b/packages/agents-core/src/runner/sandbox.ts
@@ -1,6 +1,6 @@
 import type { Agent, AgentOutputType } from '../agent';
 import { UserError } from '../errors';
-import logger from '../logger';
+import logger, { logToolActionWarning } from '../logger';
 import { rehydrateProcessedResponseTools, type RunState } from '../runState';
 import type { SandboxRuntimeManager } from '../sandbox/runtime';
 import type { SandboxMemoryAgentRunner } from '../sandbox/memory/generation';
@@ -93,7 +93,11 @@ export async function finalizeSandboxRuntime<TContext>(args: {
     try {
       await disposeResolvedComputers({ runContext: state._context });
     } catch (error) {
-      logger.warn(`Failed to dispose computers after run: ${error}`);
+      logToolActionWarning(
+        logger,
+        'Failed to dispose computers after run:',
+        error,
+      );
     }
   }
 

--- a/packages/agents-core/src/runner/streaming.ts
+++ b/packages/agents-core/src/runner/streaming.ts
@@ -74,7 +74,11 @@ function enqueueRunItemStreamEvent(
 ): void {
   const itemName = getRunItemStreamEventName(item);
   if (!itemName) {
-    logger.warn('Unknown item type: ', item);
+    if (logger.dontLogModelData || logger.dontLogToolData) {
+      logger.warn('Unknown item type. Item data is redacted.');
+    } else {
+      logger.warn('Unknown item type: ', item);
+    }
     return;
   }
   result._addItem(new RunItemStreamEvent(itemName, item));

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -7,7 +7,7 @@ import {
   RunToolApprovalItem,
   RunToolCallOutputItem,
 } from '../items';
-import logger from '../logger';
+import logger, { logToolActionWarning } from '../logger';
 import { ModelResponse } from '../model';
 import type { RunConfig, Runner, ToolErrorFormatter } from '../run';
 import { RunState } from '../runState';
@@ -84,9 +84,10 @@ async function resolveToolNotFoundMessage<TContext>(
       );
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    logger.warn(
-      `toolErrorFormatter threw while formatting tool not found: ${message}`,
+    logToolActionWarning(
+      logger,
+      'toolErrorFormatter threw while formatting tool not found:',
+      error,
     );
   }
 

--- a/packages/agents-core/src/sandbox/memory/generation.ts
+++ b/packages/agents-core/src/sandbox/memory/generation.ts
@@ -2,7 +2,7 @@ import { randomUUID } from '@openai/agents-core/_shims';
 import { z } from 'zod';
 import type { Agent, AgentOutputType } from '../../agent';
 import { UserError } from '../../errors';
-import logger from '../../logger';
+import logger, { logModelAndToolActionWarning } from '../../logger';
 import type { RunState } from '../../runState';
 import type { AgentInputItem } from '../../types';
 import type { Span, Trace } from '../../tracing';
@@ -275,8 +275,11 @@ export class SandboxMemoryGenerationManager {
               await this.persistPhaseOneArtifacts(rolloutId, extraction);
               wroteArtifacts = true;
             } catch (error) {
-              logger.warn(
-                `Sandbox memory phase 1 failed for rollout ${rolloutId}: ${error}`,
+              logModelAndToolActionWarning(
+                logger,
+                'Sandbox memory phase 1 failed:',
+                error,
+                { rolloutId },
               );
             }
           }
@@ -285,7 +288,11 @@ export class SandboxMemoryGenerationManager {
             try {
               await this.runPhaseTwo();
             } catch (error) {
-              logger.warn(`Sandbox memory phase 2 failed: ${error}`);
+              logModelAndToolActionWarning(
+                logger,
+                'Sandbox memory phase 2 failed:',
+                error,
+              );
             }
           }
         },

--- a/packages/agents-core/src/sandbox/runtime/manager.ts
+++ b/packages/agents-core/src/sandbox/runtime/manager.ts
@@ -1,5 +1,5 @@
 import type { Agent, AgentOutputType } from '../../agent';
-import logger from '../../logger';
+import logger, { logModelAndToolActionWarning } from '../../logger';
 import { UserError } from '../../errors';
 import type { RunState } from '../../runState';
 import type { AgentInputItem } from '../../types';
@@ -528,7 +528,11 @@ export class SandboxRuntimeManager<TContext> {
         },
       });
     } catch (error) {
-      logger.warn(`Failed to enqueue sandbox memory generation: ${error}`);
+      logModelAndToolActionWarning(
+        logger,
+        'Failed to enqueue sandbox memory generation:',
+        error,
+      );
     }
   }
 

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -24,7 +24,7 @@ import type {
   MCPServerStreamableHttpOptions,
   MCPServerSSEOptions,
 } from '../../mcp';
-import logger from '../../logger';
+import logger, { logToolActionError, logToolActionWarning } from '../../logger';
 
 export interface SessionMessage {
   message: any;
@@ -85,9 +85,7 @@ type ClientWithToolMetadataCacheReset = {
 };
 
 type StreamableHttpToolRecoveryStrategy =
-  | 'none'
-  | 'reconnect-only'
-  | 'reconnect-and-retry';
+  'none' | 'reconnect-only' | 'reconnect-and-retry';
 
 function hasSessionTransport(
   transport: any,
@@ -244,7 +242,7 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
         serverInfo: { name: this._name, version: '1.0.0' },
       } as InitializeResult;
     } catch (e) {
-      this.logger.error('Error initializing MCP server:', e);
+      logToolActionError(this.logger, 'Error initializing MCP server:', e);
       await this.close();
       throw e;
     }
@@ -393,7 +391,11 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
         // but if the server supports sessions we terminate to avoid leaks.
         await transport.terminateSession();
       } catch (error) {
-        this.logger.warn('Failed to terminate MCP session:', error);
+        logToolActionWarning(
+          this.logger,
+          'Failed to terminate MCP session:',
+          error,
+        );
       }
     }
     if (transport) {
@@ -455,7 +457,7 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
         serverInfo: { name: this._name, version: '1.0.0' },
       } as InitializeResult;
     } catch (e) {
-      this.logger.error('Error initializing MCP server:', e);
+      logToolActionError(this.logger, 'Error initializing MCP server:', e);
       await this.close();
       throw e;
     }
@@ -607,7 +609,11 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
           // but if the server supports sessions we terminate to avoid leaks.
           await transport.terminateSession();
         } catch (error) {
-          this.logger.warn('Failed to terminate MCP session:', error);
+          logToolActionWarning(
+            this.logger,
+            'Failed to terminate MCP session:',
+            error,
+          );
         }
       }
     }
@@ -841,7 +847,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
         await detachedTransport.close().catch(() => {});
       }
     } catch (error) {
-      this.logger.warn(warningMessage, error);
+      logToolActionWarning(this.logger, warningMessage, error);
     }
   }
 
@@ -874,11 +880,11 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
       );
     } else if (transport) {
       await transport.close().catch((error) => {
-        this.logger.warn(closeWarningMessage, error);
+        logToolActionWarning(this.logger, closeWarningMessage, error);
       });
     } else if (client) {
       await client.close().catch((error) => {
-        this.logger.warn(closeWarningMessage, error);
+        logToolActionWarning(this.logger, closeWarningMessage, error);
       });
     }
 
@@ -943,16 +949,16 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
 
     if (client.transport === transport) {
       await client.close().catch((error) => {
-        this.logger.warn(options.closeWarningMessage, error);
+        logToolActionWarning(this.logger, options.closeWarningMessage, error);
       });
       return;
     }
 
     await transport.close().catch((error) => {
-      this.logger.warn(options.closeWarningMessage, error);
+      logToolActionWarning(this.logger, options.closeWarningMessage, error);
     });
     await client.close().catch((error) => {
-      this.logger.warn(options.closeWarningMessage, error);
+      logToolActionWarning(this.logger, options.closeWarningMessage, error);
     });
   }
 
@@ -1245,7 +1251,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     } catch (e) {
       // A losing concurrent connect can fail after another connect already
       // published a healthy shared session, so avoid closing shared state here.
-      this.logger.error('Error initializing MCP server:', e);
+      logToolActionError(this.logger, 'Error initializing MCP server:', e);
       throw e;
     }
     this.debugLog(() => `Connected to MCP server: ${this._name}`);

--- a/packages/agents-core/src/tool.ts
+++ b/packages/agents-core/src/tool.ts
@@ -22,7 +22,7 @@ import {
   ToolTimeoutError,
   UserError,
 } from './errors';
-import logger from './logger';
+import logger, { logToolActionWarning } from './logger';
 import { getCurrentSpan } from './tracing';
 import { RunToolApprovalItem, RunToolCallOutputItem } from './items';
 import { toSmartString } from './utils/smartString';
@@ -770,7 +770,11 @@ export async function disposeResolvedComputers<Context>({
     try {
       await dispose();
     } catch (error) {
-      logger.warn(`Failed to dispose computer for run context: ${error}`);
+      logToolActionWarning(
+        logger,
+        'Failed to dispose computer for run context:',
+        error,
+      );
     }
   }
 }

--- a/packages/agents-core/src/tracing/processor.ts
+++ b/packages/agents-core/src/tracing/processor.ts
@@ -1,6 +1,6 @@
 import { Span as TSpan } from './spans';
 import { Trace } from './traces';
-import logger from '../logger';
+import logger, { logModelAndToolActionError } from '../logger';
 import {
   timer as _timer,
   isTracingLoopRunningByDefault,
@@ -83,6 +83,14 @@ export class ConsoleSpanExporter implements TracingExporter {
     }
 
     for (const item of items) {
+      if (logger.dontLogModelData || logger.dontLogToolData) {
+        console.log(
+          item.type === 'trace'
+            ? '[Exporter] Export trace. Trace data is redacted.'
+            : '[Exporter] Export span. Span data is redacted.',
+        );
+        continue;
+      }
       if (item.type === 'trace') {
         console.log(
           `[Exporter] Export trace traceId=${item.traceId} name=${item.name}${item.groupId ? ` groupId=${item.groupId}` : ''}`,
@@ -208,7 +216,11 @@ export class BatchTraceProcessor implements TracingProcessor {
       try {
         await this.#exporter.export(batch, combinedSignal.signal);
       } catch (error) {
-        logger.error('Tracing exporter failed to export batch', error);
+        logModelAndToolActionError(
+          logger,
+          'Tracing exporter failed to export batch',
+          error,
+        );
       } finally {
         combinedSignal.cleanup();
         this.#activeExportAbortControllers.delete(activeExportAbortController);

--- a/packages/agents-core/src/tracing/provider.ts
+++ b/packages/agents-core/src/tracing/provider.ts
@@ -1,7 +1,7 @@
 import { getCurrentSpan, getCurrentTrace } from './context';
 import { supportsProcessLifecycleEvents } from '@openai/agents-core/_shims';
 import { tracing } from '../config';
-import logger from '../logger';
+import logger, { logModelAndToolActionError } from '../logger';
 import { MultiTracingProcessor, TracingProcessor } from './processor';
 import { NoopSpan, Span, SpanData, SpanOptions } from './spans';
 import { NoopTrace, Trace, TraceOptions } from './traces';
@@ -118,7 +118,11 @@ export class TraceProvider {
    */
   async dispatchTrace(trace: Trace): Promise<void> {
     if (this.#disabled) {
-      logger.debug('Tracing is disabled, Not dispatching trace %o', trace);
+      if (logger.dontLogModelData || logger.dontLogToolData) {
+        logger.debug('Tracing is disabled. Not dispatching trace.');
+      } else {
+        logger.debug('Tracing is disabled, Not dispatching trace %o', trace);
+      }
       return;
     }
 
@@ -136,7 +140,11 @@ export class TraceProvider {
     span: Span<TSpanData>,
   ): Promise<void> {
     if (this.#disabled) {
-      logger.debug('Tracing is disabled, Not dispatching span %o', span);
+      if (logger.dontLogModelData || logger.dontLogToolData) {
+        logger.debug('Tracing is disabled. Not dispatching span.');
+      } else {
+        logger.debug('Tracing is disabled, Not dispatching span %o', span);
+      }
       return;
     }
 
@@ -153,7 +161,14 @@ export class TraceProvider {
     span: Span<TSpanData>,
   ): Promise<void> {
     if (this.#disabled) {
-      logger.debug('Tracing is disabled, Not dispatching span start %o', span);
+      if (logger.dontLogModelData || logger.dontLogToolData) {
+        logger.debug('Tracing is disabled. Not dispatching span start.');
+      } else {
+        logger.debug(
+          'Tracing is disabled, Not dispatching span start %o',
+          span,
+        );
+      }
       return;
     }
 
@@ -170,7 +185,11 @@ export class TraceProvider {
     span: Span<TSpanData>,
   ): Promise<void> {
     if (this.#disabled) {
-      logger.debug('Tracing is disabled, Not dispatching span end %o', span);
+      if (logger.dontLogModelData || logger.dontLogToolData) {
+        logger.debug('Tracing is disabled. Not dispatching span end.');
+      } else {
+        logger.debug('Tracing is disabled, Not dispatching span end %o', span);
+      }
       return;
     }
 
@@ -179,14 +198,25 @@ export class TraceProvider {
 
   createTrace(traceOptions: TraceOptions): Trace {
     if (this.#disabled) {
-      logger.debug('Tracing is disabled, Not creating trace %o', traceOptions);
+      if (logger.dontLogModelData || logger.dontLogToolData) {
+        logger.debug('Tracing is disabled. Not creating trace.');
+      } else {
+        logger.debug(
+          'Tracing is disabled, Not creating trace %o',
+          traceOptions,
+        );
+      }
       return new NoopTrace();
     }
 
     const traceId = traceOptions.traceId ?? this.generateTraceId();
     const name = traceOptions.name ?? 'Agent workflow';
 
-    logger.debug('Creating trace %s with name %s', traceId, name);
+    if (logger.dontLogModelData || logger.dontLogToolData) {
+      logger.debug('Creating trace. Trace data is redacted.');
+    } else {
+      logger.debug('Creating trace %s with name %s', traceId, name);
+    }
 
     return new Trace({ ...traceOptions, name, traceId }, this.#multiProcessor);
   }
@@ -196,7 +226,11 @@ export class TraceProvider {
     parent?: Span<any> | Trace,
   ): Span<TSpanData> {
     if (this.#disabled || spanOptions.disabled) {
-      logger.debug('Tracing is disabled, Not creating span %o', spanOptions);
+      if (logger.dontLogModelData || logger.dontLogToolData) {
+        logger.debug('Tracing is disabled. Not creating span.');
+      } else {
+        logger.debug('Tracing is disabled, Not creating span %o', spanOptions);
+      }
       return new NoopSpan(spanOptions.data, this.#multiProcessor);
     }
 
@@ -286,9 +320,13 @@ export class TraceProvider {
       return new NoopSpan(spanOptions.data, this.#multiProcessor);
     }
 
-    logger.debug(
-      `Creating span ${JSON.stringify(spanOptions.data)} with id ${spanId}`,
-    );
+    if (logger.dontLogModelData || logger.dontLogToolData) {
+      logger.debug('Creating span. Span data is redacted.');
+    } else {
+      logger.debug(
+        `Creating span ${JSON.stringify(spanOptions.data)} with id ${spanId}`,
+      );
+    }
 
     return new Span(
       {
@@ -310,7 +348,11 @@ export class TraceProvider {
           logger.debug('Shutting down tracing provider');
           await this.#multiProcessor.shutdown(timeout);
         } catch (error) {
-          logger.error('Error shutting down tracing provider %o', error);
+          logModelAndToolActionError(
+            logger,
+            'Error shutting down tracing provider',
+            error,
+          );
         }
       })();
     }
@@ -368,7 +410,12 @@ export class TraceProvider {
       });
 
       process.on('unhandledRejection', async (reason, promise) => {
-        logger.error('Unhandled rejection', reason, promise);
+        logModelAndToolActionError(
+          logger,
+          'Unhandled rejection',
+          reason,
+          promise,
+        );
         await cleanup();
         if (!hasOtherListenersForEvents('unhandledRejection')) {
           // Only when there are no other listeners, exit the process on this SDK side

--- a/packages/agents-core/src/tracing/spans.ts
+++ b/packages/agents-core/src/tracing/spans.ts
@@ -240,7 +240,11 @@ export class Span<TData extends SpanData> {
 
   end() {
     if (this.#endedAt) {
-      logger.debug('Span already finished', this.spanData);
+      if (logger.dontLogModelData || logger.dontLogToolData) {
+        logger.debug('Span already finished. Span data is redacted.');
+      } else {
+        logger.debug('Span already finished', this.spanData);
+      }
       return;
     }
 

--- a/packages/agents-core/src/utils/internal.ts
+++ b/packages/agents-core/src/utils/internal.ts
@@ -8,5 +8,10 @@ export {
 export {
   getSafeErrorType,
   logModelActionError,
+  logModelAndToolActionDebug,
+  logModelAndToolActionError,
+  logModelAndToolActionWarning,
+  logToolActionDebug,
   logToolActionError,
+  logToolActionWarning,
 } from '../logger';

--- a/packages/agents-core/test/agent.test.ts
+++ b/packages/agents-core/test/agent.test.ts
@@ -42,6 +42,40 @@ describe('Agent', () => {
     expect(agent.resetToolChoice).toBe(true);
   });
 
+  it('does not inspect handoff output schemas when model logging is disabled', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(true);
+    const secret = 'SECRET_HANDOFF_OUTPUT_SCHEMA_123';
+    const toJSON = vi.fn(() => ({ secret }));
+    const outputType = {
+      type: 'json_schema',
+      name: 'SensitiveOutput',
+      strict: true,
+      schema: {
+        type: 'object',
+        properties: { secret: { type: 'string', description: secret } },
+        required: ['secret'],
+        additionalProperties: false,
+      },
+      toJSON,
+    } as unknown as JsonSchemaDefinition;
+    const handoffAgent = new Agent({
+      name: 'HandoffAgent',
+      outputType: z.object({ value: z.string() }),
+    });
+
+    expect(
+      () =>
+        new Agent({
+          name: 'ParentAgent',
+          outputType,
+          handoffs: [handoffAgent],
+        }),
+    ).not.toThrow();
+    expect(toJSON).not.toHaveBeenCalled();
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(secret);
+  });
+
   it('should throw if name is missing', () => {
     expect(() => new Agent({} as any)).toThrow('Agent must have a name.');
     expect(() => new Agent({ name: '' } as any)).toThrow(

--- a/packages/agents-core/test/defaultModel.test.ts
+++ b/packages/agents-core/test/defaultModel.test.ts
@@ -10,6 +10,10 @@ import { loadEnv } from '../src/config';
 import { Agent } from '../src/agent';
 vi.mock('../src/config', () => ({
   loadEnv: vi.fn(),
+  logging: {
+    dontLogModelData: false,
+    dontLogToolData: false,
+  },
 }));
 const mockedLoadEnv = vi.mocked(loadEnv);
 beforeEach(() => {

--- a/packages/agents-core/test/logger.test.ts
+++ b/packages/agents-core/test/logger.test.ts
@@ -65,6 +65,99 @@ describe('logger', () => {
   );
 
   test.each([
+    ['logToolActionDebug', 'debug'],
+    ['logToolActionWarning', 'warn'],
+  ] as const)(
+    'redacts tool errors logged with %s',
+    async (helperName, method) => {
+      const loggerModule = await import('../src/logger');
+      const targetLogger = loggerModule.getLogger('test');
+      const logSpy = vi
+        .spyOn(targetLogger, method)
+        .mockImplementation(() => {});
+      vi.spyOn(targetLogger, 'dontLogToolData', 'get').mockReturnValue(true);
+      const secret = 'SECRET_TOOL_LOG_VALUE_123';
+
+      loggerModule[helperName](
+        targetLogger,
+        'Operation failed',
+        new Error(secret),
+        { secret },
+      );
+
+      expect(logSpy).toHaveBeenCalledWith('Operation failed', 'Error');
+      expect(JSON.stringify(logSpy.mock.calls)).not.toContain(secret);
+    },
+  );
+
+  test.each([
+    ['logModelAndToolActionDebug', 'debug'],
+    ['logModelAndToolActionError', 'error'],
+    ['logModelAndToolActionWarning', 'warn'],
+  ] as const)(
+    'redacts model and tool errors logged with %s when either flag is enabled',
+    async (helperName, method) => {
+      const loggerModule = await import('../src/logger');
+      const secret = 'SECRET_COMBINED_LOG_VALUE_123';
+
+      for (const [dontLogModelData, dontLogToolData] of [
+        [true, false],
+        [false, true],
+        [true, true],
+      ] as const) {
+        const targetLogger = loggerModule.getLogger('test');
+        const logSpy = vi
+          .spyOn(targetLogger, method)
+          .mockImplementation(() => {});
+        vi.spyOn(targetLogger, 'dontLogModelData', 'get').mockReturnValue(
+          dontLogModelData,
+        );
+        vi.spyOn(targetLogger, 'dontLogToolData', 'get').mockReturnValue(
+          dontLogToolData,
+        );
+
+        loggerModule[helperName](
+          targetLogger,
+          'Operation failed',
+          new Error(secret),
+          { secret },
+        );
+
+        expect(logSpy).toHaveBeenCalledWith('Operation failed', 'Error');
+        expect(JSON.stringify(logSpy.mock.calls)).not.toContain(secret);
+      }
+    },
+  );
+
+  test.each([
+    ['logModelAndToolActionDebug', 'debug'],
+    ['logModelAndToolActionError', 'error'],
+    ['logModelAndToolActionWarning', 'warn'],
+  ] as const)(
+    'preserves model and tool diagnostics logged with %s when both flags are disabled',
+    async (helperName, method) => {
+      const loggerModule = await import('../src/logger');
+      const targetLogger = loggerModule.getLogger('test');
+      const logSpy = vi
+        .spyOn(targetLogger, method)
+        .mockImplementation(() => {});
+      vi.spyOn(targetLogger, 'dontLogModelData', 'get').mockReturnValue(false);
+      vi.spyOn(targetLogger, 'dontLogToolData', 'get').mockReturnValue(false);
+      const error = new Error('SECRET_COMBINED_LOG_VALUE_123');
+      const details = { secret: 'SECRET_COMBINED_LOG_VALUE_123' };
+
+      loggerModule[helperName](
+        targetLogger,
+        'Operation failed',
+        error,
+        details,
+      );
+
+      expect(logSpy).toHaveBeenCalledWith('Operation failed', error, details);
+    },
+  );
+
+  test.each([
     ['tool', 'logToolActionError', 'dontLogToolData'],
     ['model', 'logModelActionError', 'dontLogModelData'],
   ] as const)(
@@ -156,6 +249,68 @@ describe('logger', () => {
     expect(getSafeErrorType(error)).toBe('Error');
     expect(constructorGetter).not.toHaveBeenCalled();
   });
+
+  test.each([
+    ['string', (): unknown => 'SECRET_COMBINED_STRING_123', 'string'],
+    [
+      'object',
+      (): unknown => ({ secret: 'SECRET_COMBINED_OBJECT_123' }),
+      'object',
+    ],
+    [
+      'overridden Error constructor',
+      (): unknown => {
+        const error = new Error('SECRET_COMBINED_ERROR_123');
+        Object.defineProperty(error, 'constructor', {
+          value: { name: 'SECRET_COMBINED_CONSTRUCTOR_123' },
+        });
+        return error;
+      },
+      'Error',
+    ],
+    [
+      'revoked Proxy',
+      (): unknown => {
+        const { proxy, revoke } = Proxy.revocable({}, {});
+        revoke();
+        return proxy;
+      },
+      'object',
+    ],
+    [
+      'throwing prototype trap',
+      (): unknown =>
+        new Proxy(
+          {},
+          {
+            getPrototypeOf() {
+              throw new Error('SECRET_COMBINED_PROXY_TRAP_123');
+            },
+          },
+        ),
+      'object',
+    ],
+  ] as const)(
+    'safely redacts combined model and tool errors with a %s',
+    async (_description, createError, expectedType) => {
+      const loggerModule = await import('../src/logger');
+      const targetLogger = loggerModule.getLogger('test');
+      const warnSpy = vi
+        .spyOn(targetLogger, 'warn')
+        .mockImplementation(() => {});
+      vi.spyOn(targetLogger, 'dontLogModelData', 'get').mockReturnValue(true);
+      vi.spyOn(targetLogger, 'dontLogToolData', 'get').mockReturnValue(false);
+
+      expect(() =>
+        loggerModule.logModelAndToolActionWarning(
+          targetLogger,
+          'Operation failed',
+          createError(),
+        ),
+      ).not.toThrow();
+      expect(warnSpy).toHaveBeenCalledWith('Operation failed', expectedType);
+    },
+  );
 
   test('does not expose overridden Error constructor names', async () => {
     const { getSafeErrorType } = await import('../src/logger');

--- a/packages/agents-core/test/logger.test.ts
+++ b/packages/agents-core/test/logger.test.ts
@@ -59,7 +59,7 @@ describe('logger', () => {
         },
       );
 
-      expect(errorSpy).toHaveBeenCalledWith('Operation failed', 'Error');
+      expect(errorSpy).toHaveBeenCalledWith('Operation failed', 'object');
       expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(secret);
     },
   );
@@ -85,7 +85,7 @@ describe('logger', () => {
         { secret },
       );
 
-      expect(logSpy).toHaveBeenCalledWith('Operation failed', 'Error');
+      expect(logSpy).toHaveBeenCalledWith('Operation failed', 'object');
       expect(JSON.stringify(logSpy.mock.calls)).not.toContain(secret);
     },
   );
@@ -123,7 +123,7 @@ describe('logger', () => {
           { secret },
         );
 
-        expect(logSpy).toHaveBeenCalledWith('Operation failed', 'Error');
+        expect(logSpy).toHaveBeenCalledWith('Operation failed', 'object');
         expect(JSON.stringify(logSpy.mock.calls)).not.toContain(secret);
       }
     },
@@ -217,6 +217,17 @@ describe('logger', () => {
     expect(getSafeErrorType(createError())).toBe('object');
   });
 
+  test('does not inspect object prototypes while classifying redacted values', async () => {
+    const { getSafeErrorType } = await import('../src/logger');
+    const getPrototypeOf = vi.fn(() => {
+      throw new Error('SECRET_GET_PROTOTYPE_TRAP_123');
+    });
+    const value = new Proxy({}, { getPrototypeOf });
+
+    expect(getSafeErrorType(value)).toBe('object');
+    expect(getPrototypeOf).not.toHaveBeenCalled();
+  });
+
   test.each([
     ['tool', 'logToolActionError', 'dontLogToolData'],
     ['model', 'logModelActionError', 'dontLogModelData'],
@@ -246,7 +257,7 @@ describe('logger', () => {
     const error = new Error('SECRET_LOG_VALUE_123');
     Object.defineProperty(error, 'constructor', { get: constructorGetter });
 
-    expect(getSafeErrorType(error)).toBe('Error');
+    expect(getSafeErrorType(error)).toBe('object');
     expect(constructorGetter).not.toHaveBeenCalled();
   });
 
@@ -266,7 +277,7 @@ describe('logger', () => {
         });
         return error;
       },
-      'Error',
+      'object',
     ],
     [
       'revoked Proxy',
@@ -319,6 +330,6 @@ describe('logger', () => {
       value: { name: 'SECRET_CONSTRUCTOR_NAME_123' },
     });
 
-    expect(getSafeErrorType(error)).toBe('Error');
+    expect(getSafeErrorType(error)).toBe('object');
   });
 });

--- a/packages/agents-core/test/mcpCache.test.ts
+++ b/packages/agents-core/test/mcpCache.test.ts
@@ -38,19 +38,20 @@ class StubServer extends NodeMCPServerStdio {
 }
 
 describe('MCP tools cache invalidation', () => {
-  it('sanitizes URL-derived MCP server names in filter diagnostics', async () => {
-    const serverSecret = 'SECRET_MCP_FILTER_QUERY_123';
+  it('suppresses MCP filter diagnostics when tool logging is disabled', async () => {
+    const serverSecret = 'SECRET_MCP_FILTER_PATH_123';
+    const toolSecret = 'SECRET_MCP_FILTER_TOOL_123';
     const server = new StubServer(
-      `streamable-http: https://example.test/mcp?token=${serverSecret}`,
+      `streamable-http: https://example.test/mcp/${serverSecret}`,
       [
         {
-          name: 'blocked_tool',
+          name: toolSecret,
           description: '',
           inputSchema: { type: 'object', properties: {} },
         },
       ],
     );
-    server.toolFilter = { blockedToolNames: ['blocked_tool'] };
+    server.toolFilter = { blockedToolNames: [toolSecret] };
     const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
     const toolFlagSpy = vi
       .spyOn(logger, 'dontLogToolData', 'get')
@@ -64,11 +65,41 @@ describe('MCP tools cache invalidation', () => {
       });
 
       expect(result).toEqual([]);
+      expect(debugSpy).not.toHaveBeenCalled();
+    } finally {
+      debugSpy.mockRestore();
+      toolFlagSpy.mockRestore();
+    }
+  });
+
+  it('preserves sanitized MCP filter diagnostics when tool logging is enabled', async () => {
+    const server = new StubServer(
+      'streamable-http: https://example.test/mcp?token=SECRET_MCP_FILTER_QUERY_123',
+      [
+        {
+          name: 'blocked_tool',
+          description: '',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ],
+    );
+    server.toolFilter = { blockedToolNames: ['blocked_tool'] };
+    const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+    const toolFlagSpy = vi
+      .spyOn(logger, 'dontLogToolData', 'get')
+      .mockReturnValue(false);
+
+    try {
+      const result = await getAllMcpTools({
+        mcpServers: [server],
+        runContext: new RunContext({}),
+        agent: new Agent({ name: 'AgentOne' }),
+      });
+
+      expect(result).toEqual([]);
       expect(debugSpy).toHaveBeenCalledWith(
         'MCP Tool (server: streamable-http: https://example.test/mcp, tool: blocked_tool) is blocked by the static filter.',
       );
-      const calls = JSON.stringify(debugSpy.mock.calls);
-      expect(calls).not.toContain(serverSecret);
     } finally {
       debugSpy.mockRestore();
       toolFlagSpy.mockRestore();

--- a/packages/agents-core/test/mcpCache.test.ts
+++ b/packages/agents-core/test/mcpCache.test.ts
@@ -9,6 +9,7 @@ import { RunContext } from '../src/runContext';
 import { Agent } from '../src/agent';
 import { handoff } from '../src/handoff';
 import { z } from 'zod';
+import logger from '../src/logger';
 
 class StubServer extends NodeMCPServerStdio {
   public toolList: any[];
@@ -37,6 +38,43 @@ class StubServer extends NodeMCPServerStdio {
 }
 
 describe('MCP tools cache invalidation', () => {
+  it('sanitizes URL-derived MCP server names in filter diagnostics', async () => {
+    const serverSecret = 'SECRET_MCP_FILTER_QUERY_123';
+    const server = new StubServer(
+      `streamable-http: https://example.test/mcp?token=${serverSecret}`,
+      [
+        {
+          name: 'blocked_tool',
+          description: '',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ],
+    );
+    server.toolFilter = { blockedToolNames: ['blocked_tool'] };
+    const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+    const toolFlagSpy = vi
+      .spyOn(logger, 'dontLogToolData', 'get')
+      .mockReturnValue(true);
+
+    try {
+      const result = await getAllMcpTools({
+        mcpServers: [server],
+        runContext: new RunContext({}),
+        agent: new Agent({ name: 'AgentOne' }),
+      });
+
+      expect(result).toEqual([]);
+      expect(debugSpy).toHaveBeenCalledWith(
+        'MCP Tool (server: streamable-http: https://example.test/mcp, tool: blocked_tool) is blocked by the static filter.',
+      );
+      const calls = JSON.stringify(debugSpy.mock.calls);
+      expect(calls).not.toContain(serverSecret);
+    } finally {
+      debugSpy.mockRestore();
+      toolFlagSpy.mockRestore();
+    }
+  });
+
   it('fetches fresh tools after cache invalidation', async () => {
     await withTrace('test', async () => {
       const toolsA = [

--- a/packages/agents-core/test/mcpLogging.test.ts
+++ b/packages/agents-core/test/mcpLogging.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { getMcpServerLogName } from '../src/mcpLogging';
+
+describe('getMcpServerLogName', () => {
+  it('removes credentials, query strings, and fragments from URL-derived names', () => {
+    const credentialedUrl = new URL(
+      'https://example.test:8443/mcp?token=secret#fragment',
+    );
+    credentialedUrl.username = 'user';
+    credentialedUrl.password = 'password';
+
+    expect(
+      getMcpServerLogName(`streamable-http: ${credentialedUrl.toString()}`),
+    ).toBe('streamable-http: https://example.test:8443/mcp');
+    expect(
+      getMcpServerLogName('sse: https://example.test/events?api_key=secret'),
+    ).toBe('sse: https://example.test/events');
+  });
+
+  it('preserves ordinary server names', () => {
+    expect(getMcpServerLogName('diagnostic-server')).toBe('diagnostic-server');
+  });
+});

--- a/packages/agents-core/test/mcpLogging.test.ts
+++ b/packages/agents-core/test/mcpLogging.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { getMcpServerLogName } from '../src/mcpLogging';
+import { getMcpServerDiagnosticName } from '../src/mcpLogging';
 
-describe('getMcpServerLogName', () => {
+describe('getMcpServerDiagnosticName', () => {
   it('removes credentials, query strings, and fragments from URL-derived names', () => {
     const credentialedUrl = new URL(
       'https://example.test:8443/mcp?token=secret#fragment',
@@ -10,14 +10,20 @@ describe('getMcpServerLogName', () => {
     credentialedUrl.password = 'password';
 
     expect(
-      getMcpServerLogName(`streamable-http: ${credentialedUrl.toString()}`),
+      getMcpServerDiagnosticName(
+        `streamable-http: ${credentialedUrl.toString()}`,
+      ),
     ).toBe('streamable-http: https://example.test:8443/mcp');
     expect(
-      getMcpServerLogName('sse: https://example.test/events?api_key=secret'),
+      getMcpServerDiagnosticName(
+        'sse: https://example.test/events?api_key=secret',
+      ),
     ).toBe('sse: https://example.test/events');
   });
 
   it('preserves ordinary server names', () => {
-    expect(getMcpServerLogName('diagnostic-server')).toBe('diagnostic-server');
+    expect(getMcpServerDiagnosticName('diagnostic-server')).toBe(
+      'diagnostic-server',
+    );
   });
 });

--- a/packages/agents-core/test/mcpServers.test.ts
+++ b/packages/agents-core/test/mcpServers.test.ts
@@ -102,6 +102,15 @@ class AbortConnectServer extends BaseTestServer {
   }
 }
 
+class AbortCloseServer extends BaseTestServer {
+  async close(): Promise<void> {
+    this.closeCalls += 1;
+    const error = new Error('close aborted');
+    error.name = 'AbortError';
+    throw error;
+  }
+}
+
 type Deferred<T> = {
   promise: Promise<T>;
   resolve: (value: T | PromiseLike<T>) => void;
@@ -179,9 +188,9 @@ describe('MCPServers', () => {
     mcpLogger.dontLogToolData = false;
   });
 
-  it('sanitizes URL-derived server names when connecting fails', async () => {
+  it('uses fixed messages for URL-derived server names when connecting fails in redacted mode', async () => {
     const serverName =
-      'streamable-http: https://example.test/mcp?token=SECRET_MCP_NAME_123';
+      'streamable-http: https://example.test/mcp/SECRET_MCP_PATH_123?token=SECRET_MCP_QUERY_123';
     const server = new FlakyServer(serverName, 1);
     mcpLogger.dontLogToolData = true;
 
@@ -192,20 +201,19 @@ describe('MCPServers', () => {
 
     expect(session.failed).toEqual([server]);
     expect(mcpLogger.error).toHaveBeenCalledWith(
-      "Failed to connect MCP server 'streamable-http: https://example.test/mcp':",
+      'Failed to connect MCP server:',
       'object',
     );
-    expect(JSON.stringify(mcpLogger.debug.mock.calls)).not.toContain(
-      'SECRET_MCP_NAME_123',
-    );
-    expect(JSON.stringify(mcpLogger.error.mock.calls)).not.toContain(
-      'SECRET_MCP_NAME_123',
-    );
+    const calls = JSON.stringify([
+      ...mcpLogger.debug.mock.calls,
+      ...mcpLogger.error.mock.calls,
+    ]);
+    expect(calls).not.toContain('SECRET_MCP_PATH_123');
+    expect(calls).not.toContain('SECRET_MCP_QUERY_123');
   });
 
-  it('sanitizes URL-derived server names when closing fails', async () => {
-    const serverName =
-      'sse: https://example.test/mcp?token=SECRET_MCP_CLOSE_NAME_123';
+  it('uses fixed messages for custom server names when closing fails in redacted mode', async () => {
+    const serverName = 'SECRET_CUSTOM_MCP_SERVER_123';
     const server = new FlakyCloseServer(serverName, 1);
     mcpLogger.dontLogToolData = true;
     const session = await connectMcpServers([server], {
@@ -216,14 +224,61 @@ describe('MCPServers', () => {
     await session.close();
 
     expect(mcpLogger.error).toHaveBeenCalledWith(
-      "Failed to close MCP server 'sse: https://example.test/mcp':",
+      'Failed to close MCP server:',
       'object',
     );
     const calls = JSON.stringify([
       ...mcpLogger.debug.mock.calls,
       ...mcpLogger.error.mock.calls,
     ]);
-    expect(calls).not.toContain('SECRET_MCP_CLOSE_NAME_123');
+    expect(calls).not.toContain(serverName);
+  });
+
+  it('uses fixed messages when closing is cancelled in redacted mode', async () => {
+    const serverName = 'SECRET_CANCELLED_MCP_SERVER_123';
+    const server = new AbortCloseServer(serverName);
+    mcpLogger.dontLogToolData = true;
+    const session = await connectMcpServers([server], {
+      connectTimeoutMs: null,
+      closeTimeoutMs: null,
+    });
+
+    await session.close();
+
+    expect(mcpLogger.debug).toHaveBeenCalledWith(
+      'Close cancelled for MCP server:',
+      'object',
+    );
+    const calls = JSON.stringify([
+      ...mcpLogger.debug.mock.calls,
+      ...mcpLogger.error.mock.calls,
+    ]);
+    expect(calls).not.toContain(serverName);
+  });
+
+  it('does not read server names while formatting redacted logs', async () => {
+    const server = new FlakyServer('unused', 1);
+    let nameReads = 0;
+    Object.defineProperty(server, 'name', {
+      configurable: true,
+      get: () => {
+        nameReads += 1;
+        return 'SECRET_MCP_GETTER_NAME_123';
+      },
+    });
+    mcpLogger.dontLogToolData = true;
+
+    const session = await connectMcpServers([server], {
+      connectTimeoutMs: null,
+      closeTimeoutMs: null,
+    });
+
+    expect(session.failed).toEqual([server]);
+    expect(nameReads).toBe(0);
+    expect(mcpLogger.error).toHaveBeenCalledWith(
+      'Failed to connect MCP server:',
+      'object',
+    );
   });
 
   it('preserves MCP server failure diagnostics when tool logging is enabled', async () => {

--- a/packages/agents-core/test/mcpServers.test.ts
+++ b/packages/agents-core/test/mcpServers.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CallToolResultContent, MCPServer, MCPTool } from '../src/mcp';
+
+const mcpLogger = vi.hoisted(() => ({
+  debug: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  dontLogModelData: false,
+  dontLogToolData: false,
+}));
 
 vi.mock('../src/logger', async () => {
   const actual =
@@ -10,8 +18,15 @@ vi.mock('../src/logger', async () => {
       const base = actual.getLogger(namespace);
       return {
         ...base,
-        error: () => {},
-        warn: () => {},
+        debug: mcpLogger.debug,
+        error: mcpLogger.error,
+        warn: mcpLogger.warn,
+        get dontLogModelData() {
+          return mcpLogger.dontLogModelData;
+        },
+        get dontLogToolData() {
+          return mcpLogger.dontLogToolData;
+        },
       };
     },
   };
@@ -158,6 +173,74 @@ async function withTimeout<T>(
 }
 
 describe('MCPServers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mcpLogger.dontLogModelData = false;
+    mcpLogger.dontLogToolData = false;
+  });
+
+  it('sanitizes URL-derived server names when connecting fails', async () => {
+    const serverName =
+      'streamable-http: https://example.test/mcp?token=SECRET_MCP_NAME_123';
+    const server = new FlakyServer(serverName, 1);
+    mcpLogger.dontLogToolData = true;
+
+    const session = await connectMcpServers([server], {
+      connectTimeoutMs: null,
+      closeTimeoutMs: null,
+    });
+
+    expect(session.failed).toEqual([server]);
+    expect(mcpLogger.error).toHaveBeenCalledWith(
+      "Failed to connect MCP server 'streamable-http: https://example.test/mcp':",
+      'object',
+    );
+    expect(JSON.stringify(mcpLogger.debug.mock.calls)).not.toContain(
+      'SECRET_MCP_NAME_123',
+    );
+    expect(JSON.stringify(mcpLogger.error.mock.calls)).not.toContain(
+      'SECRET_MCP_NAME_123',
+    );
+  });
+
+  it('sanitizes URL-derived server names when closing fails', async () => {
+    const serverName =
+      'sse: https://example.test/mcp?token=SECRET_MCP_CLOSE_NAME_123';
+    const server = new FlakyCloseServer(serverName, 1);
+    mcpLogger.dontLogToolData = true;
+    const session = await connectMcpServers([server], {
+      connectTimeoutMs: null,
+      closeTimeoutMs: null,
+    });
+
+    await session.close();
+
+    expect(mcpLogger.error).toHaveBeenCalledWith(
+      "Failed to close MCP server 'sse: https://example.test/mcp':",
+      'object',
+    );
+    const calls = JSON.stringify([
+      ...mcpLogger.debug.mock.calls,
+      ...mcpLogger.error.mock.calls,
+    ]);
+    expect(calls).not.toContain('SECRET_MCP_CLOSE_NAME_123');
+  });
+
+  it('preserves MCP server failure diagnostics when tool logging is enabled', async () => {
+    const serverName = 'diagnostic-server';
+    const server = new FlakyServer(serverName, 1);
+
+    await connectMcpServers([server], {
+      connectTimeoutMs: null,
+      closeTimeoutMs: null,
+    });
+
+    expect(mcpLogger.error).toHaveBeenCalledWith(
+      `Failed to connect MCP server '${serverName}':`,
+      expect.any(Error),
+    );
+  });
+
   it('reconnects failed servers only by default', async () => {
     const server = new FlakyServer('flaky', 1);
     const session = await connectMcpServers([server]);

--- a/packages/agents-core/test/mcpShared.test.ts
+++ b/packages/agents-core/test/mcpShared.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('debug', () => ({
+  default: Object.assign(() => vi.fn(), { enabled: () => true }),
+}));
+
+import {
+  BaseMCPServerSSE,
+  BaseMCPServerStdio,
+  BaseMCPServerStreamableHttp,
+} from '../src/mcpShared';
+import type { Logger } from '../src/logger';
+
+const serverBases = [
+  ['stdio', BaseMCPServerStdio],
+  ['streamable HTTP', BaseMCPServerStreamableHttp],
+  ['SSE', BaseMCPServerSSE],
+] as const;
+
+function createServer(
+  Base: (typeof serverBases)[number][1],
+  logger: Logger,
+): { emitDebug: (buildMessage: () => string) => void } {
+  const TestServer = class extends (Base as any) {
+    constructor(options: { logger: Logger }) {
+      super(options);
+    }
+
+    get name() {
+      return 'test';
+    }
+
+    emitDebug(buildMessage: () => string): void {
+      this.debugLog(buildMessage);
+    }
+  };
+
+  return new TestServer({ logger });
+}
+
+describe('MCP shared debug logging', () => {
+  it.each(serverBases)(
+    'does not build %s tool messages when tool logging is disabled',
+    (_name, Base) => {
+      const debug = vi.fn();
+      const logger: Logger = {
+        namespace: 'mcp-shared-test',
+        debug,
+        error: vi.fn(),
+        warn: vi.fn(),
+        dontLogModelData: false,
+        dontLogToolData: true,
+      };
+      const server = createServer(Base, logger);
+      const secret = 'SECRET_MCP_DEBUG_PAYLOAD_123';
+      const buildMessage = vi.fn(() => secret);
+
+      server.emitDebug(buildMessage);
+
+      expect(buildMessage).not.toHaveBeenCalled();
+      expect(debug).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(serverBases)(
+    'preserves %s diagnostics when tool logging is enabled',
+    (_name, Base) => {
+      const debug = vi.fn();
+      const logger: Logger = {
+        namespace: 'mcp-shared-test',
+        debug,
+        error: vi.fn(),
+        warn: vi.fn(),
+        dontLogModelData: false,
+        dontLogToolData: false,
+      };
+      const server = createServer(Base, logger);
+      const secret = 'SECRET_MCP_DEBUG_DIAGNOSTIC_123';
+
+      server.emitDebug(() => secret);
+
+      expect(debug).toHaveBeenCalledWith(secret);
+    },
+  );
+});

--- a/packages/agents-core/test/memorySession.test.ts
+++ b/packages/agents-core/test/memorySession.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { MemorySession } from '../src/memory/memorySession';
+import type { Logger } from '../src/logger';
 import type { AgentInputItem } from '../src/types';
 
 const createUserMessage = (text: string): AgentInputItem => ({
@@ -14,6 +15,61 @@ const createUserMessage = (text: string): AgentInputItem => ({
 });
 
 describe('MemorySession', () => {
+  test.each([
+    [true, false],
+    [false, true],
+    [true, true],
+  ])(
+    'redacts item contents when model=%s or tool=%s logging is disabled',
+    async (dontLogModelData, dontLogToolData) => {
+      const debug = vi.fn();
+      const logger: Logger = {
+        namespace: 'memory-session-test',
+        debug,
+        error: vi.fn(),
+        warn: vi.fn(),
+        dontLogModelData,
+        dontLogToolData,
+      };
+      const secret = 'SECRET_MEMORY_SESSION_VALUE_123';
+      const session = new MemorySession({
+        sessionId: 'session-redacted',
+        logger,
+        initialItems: [createUserMessage(secret)],
+      });
+
+      expect(await session.getItems()).toEqual([createUserMessage(secret)]);
+      await session.addItems([createUserMessage(`${secret}-added`)]);
+      expect(await session.popItem()).toEqual(
+        createUserMessage(`${secret}-added`),
+      );
+
+      expect(JSON.stringify(debug.mock.calls)).not.toContain(secret);
+    },
+  );
+
+  test('preserves item diagnostics when model and tool logging are enabled', async () => {
+    const debug = vi.fn();
+    const logger: Logger = {
+      namespace: 'memory-session-test',
+      debug,
+      error: vi.fn(),
+      warn: vi.fn(),
+      dontLogModelData: false,
+      dontLogToolData: false,
+    };
+    const secret = 'SECRET_MEMORY_SESSION_DIAGNOSTIC_123';
+    const session = new MemorySession({
+      sessionId: 'session-diagnostic',
+      logger,
+      initialItems: [createUserMessage(secret)],
+    });
+
+    await session.getItems();
+
+    expect(JSON.stringify(debug.mock.calls)).toContain(secret);
+  });
+
   test('stores and retrieves items in memory', async () => {
     const initialItems = [createUserMessage('hello')];
     const session = new MemorySession({

--- a/packages/agents-core/test/result.test.ts
+++ b/packages/agents-core/test/result.test.ts
@@ -191,7 +191,7 @@ describe('StreamedRunResult', () => {
 
       await expect(sr.completed).rejects.toBe(err);
       expect(sr.error).toBe(err);
-      expect(debugSpy).toHaveBeenCalledWith('Resulted in an error:', 'Error');
+      expect(debugSpy).toHaveBeenCalledWith('Resulted in an error:', 'object');
       expect(JSON.stringify(debugSpy.mock.calls)).not.toContain(secret);
       vi.restoreAllMocks();
     },

--- a/packages/agents-core/test/result.test.ts
+++ b/packages/agents-core/test/result.test.ts
@@ -168,6 +168,52 @@ describe('StreamedRunResult', () => {
     expect(sr.error).toBe(err);
   });
 
+  it.each([
+    [true, false],
+    [false, true],
+    [true, true],
+  ])(
+    'redacts streamed run errors when model=%s or tool=%s logging is disabled',
+    async (dontLogModelData, dontLogToolData) => {
+      const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+      vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(
+        dontLogModelData,
+      );
+      vi.spyOn(logger, 'dontLogToolData', 'get').mockReturnValue(
+        dontLogToolData,
+      );
+      const state = createState();
+      const sr = new StreamedRunResult({ state });
+      const secret = 'SECRET_STREAMED_RUN_ERROR_123';
+      const err = new Error(secret);
+
+      sr._raiseError(err);
+
+      await expect(sr.completed).rejects.toBe(err);
+      expect(sr.error).toBe(err);
+      expect(debugSpy).toHaveBeenCalledWith('Resulted in an error:', 'Error');
+      expect(JSON.stringify(debugSpy.mock.calls)).not.toContain(secret);
+      vi.restoreAllMocks();
+    },
+  );
+
+  it('keeps rejecting when redacted streamed run logging receives a revoked Proxy', async () => {
+    const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+    vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(true);
+    vi.spyOn(logger, 'dontLogToolData', 'get').mockReturnValue(false);
+    const state = createState();
+    const sr = new StreamedRunResult({ state });
+    const { proxy, revoke } = Proxy.revocable({}, {});
+    revoke();
+
+    sr._raiseError(proxy);
+
+    await expect(sr.completed).rejects.toBe(proxy);
+    expect(sr.error).toBe(proxy);
+    expect(debugSpy).toHaveBeenCalledWith('Resulted in an error:', 'object');
+    vi.restoreAllMocks();
+  });
+
   it('handles abort while iterating without throwing', async () => {
     const state = createState();
     const controller = new AbortController();

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -109,6 +109,20 @@ class AbortAfterStreamedFunctionCallModel implements Model {
   }
 }
 
+class FailingAbortReconciliationModel extends AbortAfterStreamedFunctionCallModel {
+  constructor(
+    responseId: string,
+    private readonly reconciliationError: unknown,
+  ) {
+    super(responseId);
+  }
+
+  override async getResponse(request: ModelRequest): Promise<ModelResponse> {
+    this.requests.push(request);
+    throw this.reconciliationError;
+  }
+}
+
 class AbortAfterStreamedProgramModel implements Model {
   public requests: ModelRequest[] = [];
 
@@ -467,6 +481,42 @@ describe('Runner.run (streaming)', () => {
       }),
     ]);
   });
+
+  it.each([
+    [true, false],
+    [false, true],
+    [true, true],
+  ])(
+    'redacts abort reconciliation failures when model=%s or tool=%s logging is disabled',
+    async (dontLogModelData, dontLogToolData) => {
+      const secret = 'SECRET_ABORT_RECONCILIATION_123';
+      const model = new FailingAbortReconciliationModel(
+        'resp-aborted',
+        new Error(secret),
+      );
+      const agent = new Agent({ name: 'AbortReconcileFailure', model });
+      const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+      vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(
+        dontLogModelData,
+      );
+      vi.spyOn(logger, 'dontLogToolData', 'get').mockReturnValue(
+        dontLogToolData,
+      );
+
+      const result = await run(agent, 'hi', {
+        stream: true,
+        conversationId: 'conv-abort-failure',
+      });
+
+      await expect(result.completed).resolves.toBeUndefined();
+      expect(model.requests).toHaveLength(2);
+      expect(debugSpy).toHaveBeenCalledWith(
+        'Failed to reconcile streamed tool calls after abort.',
+        'object',
+      );
+      expect(JSON.stringify(debugSpy.mock.calls)).not.toContain(secret);
+    },
+  );
 
   it('uses the streamed response id when reconciling previousResponseId-only aborts', async () => {
     const model = new AbortAfterStreamedFunctionCallModel('resp-aborted');

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -363,6 +363,77 @@ describe('Runner.run', () => {
       });
     });
 
+    it('redacts hostile tool-not-found formatter errors and keeps the fallback result', async () => {
+      class RecordingModel extends FakeModel {
+        readonly requests: ModelRequest[] = [];
+
+        async getResponse(request: ModelRequest): Promise<ModelResponse> {
+          this.requests.push(request);
+          return super.getResponse(request);
+        }
+      }
+
+      const model = new RecordingModel([
+        {
+          output: [
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              name: 'missing_tool',
+              callId: 'call_missing',
+              arguments: '{}',
+            },
+          ],
+          usage: new Usage(),
+        },
+        {
+          output: [fakeModelMessage('formatter fallback recovered')],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'MissingToolFormatterFallbackAgent',
+        model,
+        toolUseBehavior: 'run_llm_again',
+      });
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      vi.spyOn(logger, 'dontLogToolData', 'get').mockReturnValue(true);
+      const hostileError = new Proxy(
+        {},
+        {
+          getPrototypeOf() {
+            throw new Error('SECRET_TOOL_NOT_FOUND_FORMATTER_123');
+          },
+        },
+      );
+
+      const result = await run(agent, 'start', {
+        toolNotFoundBehavior: 'return_error_to_model',
+        toolErrorFormatter: () => {
+          throw hostileError;
+        },
+      });
+
+      expect(result.finalOutput).toBe('formatter fallback recovered');
+      expect(warnSpy).toHaveBeenCalledWith(
+        'toolErrorFormatter threw while formatting tool not found:',
+        'object',
+      );
+      expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(
+        'SECRET_TOOL_NOT_FOUND_FORMATTER_123',
+      );
+      const secondInput = model.requests[1].input as AgentInputItem[];
+      expect(secondInput).toContainEqual({
+        type: 'function_call_result',
+        name: 'missing_tool',
+        callId: 'call_missing',
+        status: 'completed',
+        output: {
+          type: 'text',
+          text: "Tool 'missing_tool' not found.",
+        },
+      });
+    });
+
     it('does not persist nested agent-tool metadata when resuming a RunState', async () => {
       const agent = new Agent({
         name: 'ReusedNestedStateAgent',

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -34,7 +34,7 @@ import {
   executeShellActions,
   getToolCallOutputItem,
 } from '../../src/runner/toolExecution';
-import type { Logger } from '../../src/logger';
+import logger, { type Logger } from '../../src/logger';
 import { Runner } from '../../src/run';
 import { RunContext } from '../../src/runContext';
 import { RunResult, StreamedRunResult } from '../../src/result';
@@ -77,7 +77,6 @@ import {
 import * as protocol from '../../src/types/protocol';
 import { AgentToolUseTracker } from '../../src/runner/toolUseTracker';
 import { z } from 'zod';
-import logger from '../../src/logger';
 import {
   defaultProcessor,
   TracingProcessor,
@@ -776,6 +775,35 @@ describe('addStepToRunResult', () => {
       'tool_output',
     ]);
   });
+
+  it.each([
+    [true, false],
+    [false, true],
+    [true, true],
+  ])(
+    'redacts unknown run items when model=%s or tool=%s logging is disabled',
+    (dontLogModelData, dontLogToolData) => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(
+        dontLogModelData,
+      );
+      vi.spyOn(logger, 'dontLogToolData', 'get').mockReturnValue(
+        dontLogToolData,
+      );
+      const streamedResult = new StreamedRunResult();
+      const secret = 'SECRET_UNKNOWN_RUN_ITEM_123';
+
+      streamStepItemsToRunResult(streamedResult, [
+        { type: 'unknown', secret } as any,
+      ]);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Unknown item type. Item data is redacted.',
+      );
+      expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(secret);
+      vi.restoreAllMocks();
+    },
+  );
 });
 
 describe('AgentToolUseTracker', () => {

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -2078,7 +2078,7 @@ describe('executeShellActions', () => {
     });
     expect(mockLogger.error).toHaveBeenCalledWith(
       'Failed to execute shell action:',
-      'Error',
+      'object',
     );
   });
 
@@ -2368,7 +2368,7 @@ describe('executeShellActions', () => {
       expect(rawItem.output).toBe('cannot delete');
       expect(mockLogger.error).toHaveBeenCalledWith(
         'Failed to execute apply_patch operation:',
-        'Error',
+        'object',
       );
     });
 
@@ -3332,7 +3332,7 @@ describe('executeShellActions', () => {
 
         expect(result[0].type).toBe('function_output');
         expect(warnSpy).toHaveBeenCalledWith(
-          'toolErrorFormatter threw while formatting approval rejection: Error',
+          'toolErrorFormatter threw while formatting approval rejection: object',
         );
         expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(secret);
         expect(constructorGetter).not.toHaveBeenCalled();
@@ -4544,7 +4544,7 @@ describe('executeShellActions', () => {
       });
       expect(mockLogger.error).toHaveBeenCalledWith(
         'Failed to execute computer action:',
-        'Error',
+        'object',
       );
     });
 

--- a/packages/agents-core/test/tool.test.ts
+++ b/packages/agents-core/test/tool.test.ts
@@ -19,6 +19,7 @@ import { serializeTool } from '../src/utils/serialize';
 import { FakeEditor, FakeShell } from './stubs';
 import { InvalidToolOutputError, ToolTimeoutError } from '../src/errors';
 import type { JsonObjectSchema } from '../src/types';
+import logger from '../src/logger';
 
 interface Bar {
   bar: string;
@@ -551,6 +552,49 @@ describe('Tool', () => {
     expect(dispose).toHaveBeenCalledTimes(1);
     expect(dispose).toHaveBeenCalledWith({ runContext: ctx, computer: first });
     expect(second).not.toBe(first);
+  });
+
+  it('redacts computer disposal errors and completes cleanup', async () => {
+    const computer = {
+      environment: 'mac' as const,
+      dimensions: [1, 1] as [number, number],
+      screenshot: async () => 'img',
+      click: async () => {},
+      doubleClick: async () => {},
+      drag: async () => {},
+      keypress: async () => {},
+      move: async () => {},
+      scroll: async () => {},
+      type: async () => {},
+      wait: async () => {},
+    };
+    const secret = 'SECRET_COMPUTER_DISPOSAL_123';
+    const initializer = vi.fn(async () => computer);
+    const t = computerTool({
+      computer: {
+        create: initializer,
+        dispose: async () => {
+          throw new Error(secret);
+        },
+      },
+    });
+    const ctx = new RunContext();
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    vi.spyOn(logger, 'dontLogToolData', 'get').mockReturnValue(true);
+
+    await resolveComputer({ tool: t, runContext: ctx });
+    await expect(disposeResolvedComputers({ runContext: ctx })).resolves.toBe(
+      undefined,
+    );
+    await resolveComputer({ tool: t, runContext: ctx });
+
+    expect(initializer).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Failed to dispose computer for run context:',
+      'Error',
+    );
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(secret);
+    vi.restoreAllMocks();
   });
 
   it('shellTool assigns default name', () => {

--- a/packages/agents-core/test/tool.test.ts
+++ b/packages/agents-core/test/tool.test.ts
@@ -591,7 +591,7 @@ describe('Tool', () => {
     expect(initializer).toHaveBeenCalledTimes(2);
     expect(warnSpy).toHaveBeenCalledWith(
       'Failed to dispose computer for run context:',
-      'Error',
+      'object',
     );
     expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(secret);
     vi.restoreAllMocks();

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -729,6 +729,58 @@ describe('ConsoleSpanExporter', () => {
     }
     setTracingDisabled(true);
   });
+
+  it.each([
+    [true, false],
+    [false, true],
+    [true, true],
+  ])(
+    'redacts console-exported trace data when model=%s or tool=%s logging is disabled',
+    async (dontLogModelData, dontLogToolData) => {
+      allowConsole(['log']);
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      vi.spyOn(coreLogger, 'dontLogModelData', 'get').mockReturnValue(
+        dontLogModelData,
+      );
+      vi.spyOn(coreLogger, 'dontLogToolData', 'get').mockReturnValue(
+        dontLogToolData,
+      );
+      const originalEnv = process.env.NODE_ENV;
+      const originalDisableTracing = process.env.OPENAI_AGENTS_DISABLE_TRACING;
+      process.env.NODE_ENV = 'production';
+      delete process.env.OPENAI_AGENTS_DISABLE_TRACING;
+      setTracingDisabled(false);
+      const secret = 'SECRET_CONSOLE_TRACE_123';
+      const exporter = new ConsoleSpanExporter();
+      const trace = new Trace({ name: secret, groupId: secret });
+      const span = new Span(
+        {
+          traceId: trace.traceId,
+          data: { type: 'custom', name: secret, data: { secret } },
+        },
+        new TestProcessor(),
+      );
+
+      await exporter.export([trace, span]);
+
+      expect(logSpy).toHaveBeenCalledWith(
+        '[Exporter] Export trace. Trace data is redacted.',
+      );
+      expect(logSpy).toHaveBeenCalledWith(
+        '[Exporter] Export span. Span data is redacted.',
+      );
+      expect(JSON.stringify(logSpy.mock.calls)).not.toContain(secret);
+
+      vi.restoreAllMocks();
+      process.env.NODE_ENV = originalEnv;
+      if (typeof originalDisableTracing === 'undefined') {
+        delete process.env.OPENAI_AGENTS_DISABLE_TRACING;
+      } else {
+        process.env.OPENAI_AGENTS_DISABLE_TRACING = originalDisableTracing;
+      }
+      setTracingDisabled(true);
+    },
+  );
 });
 
 // -----------------------------------------------------------------------------------------
@@ -877,6 +929,52 @@ describe('BatchTraceProcessor', () => {
       await processor.shutdown();
     } finally {
       errorSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('redacts exporter exceptions and continues scheduled exports', async () => {
+    vi.useFakeTimers();
+    const errorSpy = vi.spyOn(coreLogger, 'error').mockImplementation(() => {});
+    vi.spyOn(coreLogger, 'dontLogModelData', 'get').mockReturnValue(true);
+    vi.spyOn(coreLogger, 'dontLogToolData', 'get').mockReturnValue(false);
+    try {
+      const secret = 'SECRET_TRACE_EXPORTER_ERROR_123';
+      let exportCalls = 0;
+      const exported: Array<(Trace | Span<any>)[]> = [];
+      const flakyExporter: TracingExporter = {
+        export: async (items) => {
+          exportCalls += 1;
+          if (exportCalls === 1) {
+            throw new Error(secret);
+          }
+          exported.push([...items]);
+        },
+      };
+      const processor = new BatchTraceProcessor(flakyExporter, {
+        maxQueueSize: 10,
+        maxBatchSize: 1,
+        scheduleDelay: 50,
+      });
+      const failed = new Trace({ name: 'failed' });
+      const recovered = new Trace({ name: 'recovered' });
+
+      await processor.onTraceStart(failed);
+      await vi.advanceTimersByTimeAsync(60);
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Tracing exporter failed to export batch',
+        'Error',
+      );
+      expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(secret);
+
+      await processor.onTraceStart(recovered);
+      await vi.advanceTimersByTimeAsync(60);
+
+      expect(exportCalls).toBe(2);
+      expect(exported).toEqual([[recovered]]);
+      await processor.shutdown();
+    } finally {
+      vi.restoreAllMocks();
       vi.useRealTimers();
     }
   });

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -963,7 +963,7 @@ describe('BatchTraceProcessor', () => {
       await vi.advanceTimersByTimeAsync(60);
       expect(errorSpy).toHaveBeenCalledWith(
         'Tracing exporter failed to export batch',
-        'Error',
+        'object',
       );
       expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(secret);
 

--- a/packages/agents-extensions/src/TwilioRealtimeTransport.ts
+++ b/packages/agents-extensions/src/TwilioRealtimeTransport.ts
@@ -7,6 +7,7 @@ import {
   RealtimeSessionConfig,
 } from '@openai/agents/realtime';
 import { getLogger } from '@openai/agents';
+import { logModelActionError } from '@openai/agents-core/utils/internal';
 import type {
   WebSocket as NodeWebSocket,
   MessageEvent as NodeMessageEvent,
@@ -122,7 +123,9 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
         try {
           const data = JSON.parse(message.data.toString());
           if (this.#logger.dontLogModelData) {
-            this.#logger.debug('Twilio message:', data.event);
+            this.#logger.debug(
+              'Twilio message received. Message data is redacted.',
+            );
           } else {
             this.#logger.debug('Twilio message:', data);
           }
@@ -146,10 +149,16 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
                 if (Number.isFinite(count)) {
                   this.#lastPlayedChunkCount = count;
                 } else {
-                  this.#logger.warn(
-                    'Invalid mark name received:',
-                    data.mark.name,
-                  );
+                  if (this.#logger.dontLogModelData) {
+                    this.#logger.warn(
+                      'Invalid mark name received. Mark data is redacted.',
+                    );
+                  } else {
+                    this.#logger.warn(
+                      'Invalid mark name received:',
+                      data.mark.name,
+                    );
+                  }
                 }
               } else if (data.mark.name.startsWith('done:')) {
                 this.#lastPlayedChunkCount = 0;
@@ -162,7 +171,8 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
               break;
           }
         } catch (error) {
-          this.#logger.error(
+          logModelActionError(
+            this.#logger,
             'Error parsing message:',
             error,
             'Message:',

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -1890,9 +1890,18 @@ export class AiSdkModel implements Model {
 
           if (part.type === 'tool-call') {
             if (!requestedTool && part.toolName) {
-              this.#logger.warn(
-                `Received tool call for unknown tool '${part.toolName}'.`,
-              );
+              if (
+                this.#logger.dontLogModelData ||
+                this.#logger.dontLogToolData
+              ) {
+                this.#logger.warn(
+                  'Received tool call for an unknown tool. Tool name is redacted.',
+                );
+              } else {
+                this.#logger.warn(
+                  `Received tool call for unknown tool '${part.toolName}'.`,
+                );
+              }
             }
             if (requestedTool && typeof part.toolCallId === 'string') {
               requestedToolsByCallId.set(part.toolCallId, requestedTool);

--- a/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
+++ b/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
@@ -172,6 +172,49 @@ describe('TwilioRealtimeTransportLayer', () => {
     expect(closeSpy).toHaveBeenCalledTimes(2);
   });
 
+  test('redacts Twilio message and parse-error data when model logging is disabled', async () => {
+    allowConsole(['error', 'warn']);
+    const original = process.env.OPENAI_AGENTS_DONT_LOG_MODEL_DATA;
+    process.env.OPENAI_AGENTS_DONT_LOG_MODEL_DATA = '1';
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: asTwilioWebSocket(twilio),
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const secret = 'SECRET_TWILIO_MESSAGE_123';
+    const emittedErrors: unknown[] = [];
+    transport.on('error', (error) => emittedErrors.push(error));
+
+    try {
+      twilio.emit('message', {
+        toString: () =>
+          JSON.stringify({ event: 'mark', mark: { name: `u:${secret}` } }),
+      });
+      twilio.emit('message', {
+        secret,
+        toString: () => `bad{${secret}`,
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Invalid mark name received. Mark data is redacted.',
+      );
+      expect(errorSpy).toHaveBeenCalledWith('Error parsing message:', 'Error');
+      expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(secret);
+      expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(secret);
+      expect(emittedErrors).toHaveLength(1);
+    } finally {
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+      if (typeof original === 'undefined') {
+        delete process.env.OPENAI_AGENTS_DONT_LOG_MODEL_DATA;
+      } else {
+        process.env.OPENAI_AGENTS_DONT_LOG_MODEL_DATA = original;
+      }
+    }
+  });
+
   test('_onAudio resets chunk count and emits', async () => {
     const twilio = new FakeTwilioWebSocket();
     const transport = new TwilioRealtimeTransportLayer({

--- a/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
+++ b/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
@@ -200,7 +200,7 @@ describe('TwilioRealtimeTransportLayer', () => {
       expect(warnSpy).toHaveBeenCalledWith(
         'Invalid mark name received. Mark data is redacted.',
       );
-      expect(errorSpy).toHaveBeenCalledWith('Error parsing message:', 'Error');
+      expect(errorSpy).toHaveBeenCalledWith('Error parsing message:', 'object');
       expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(secret);
       expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(secret);
       expect(emittedErrors).toHaveLength(1);

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -3073,6 +3073,67 @@ describe('AiSdkModel.getResponse', () => {
     warnSpy.mockRestore();
   });
 
+  test.each([
+    'OPENAI_AGENTS_DONT_LOG_MODEL_DATA',
+    'OPENAI_AGENTS_DONT_LOG_TOOL_DATA',
+  ] as const)(
+    'redacts unknown tool names when %s is enabled',
+    async (flagName) => {
+      allowConsole(['warn']);
+      const original = process.env[flagName];
+      process.env[flagName] = '1';
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const secret = 'SECRET_UNKNOWN_AI_SDK_TOOL_123';
+      const model = new AiSdkModel(
+        stubModel({
+          async doGenerate() {
+            return {
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'c1',
+                  toolName: secret,
+                  input: {} as any,
+                },
+              ],
+              usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+              providerMetadata: { p: 1 },
+              response: { id: 'id' },
+              finishReason: 'stop',
+              warnings: [],
+            } as any;
+          },
+        }),
+      );
+
+      try {
+        const res = await withTrace('t', () =>
+          model.getResponse({
+            input: 'hi',
+            tools: [],
+            handoffs: [],
+            modelSettings: {},
+            outputType: 'text',
+            tracing: false,
+          } as any),
+        );
+
+        expect(res.output[0]).toMatchObject({ name: secret });
+        expect(warnSpy).toHaveBeenCalledWith(
+          'Received tool call for an unknown tool. Tool name is redacted.',
+        );
+        expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(secret);
+      } finally {
+        warnSpy.mockRestore();
+        if (typeof original === 'undefined') {
+          delete process.env[flagName];
+        } else {
+          process.env[flagName] = original;
+        }
+      }
+    },
+  );
+
   test('preserves per-tool-call providerMetadata (e.g., Gemini thoughtSignature)', async () => {
     const toolCallProviderMetadata = {
       google: { thoughtSignature: 'sig123' },

--- a/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
+++ b/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
@@ -12,6 +12,7 @@ import type {
   Session,
 } from '@openai/agents-core';
 import type { OpenAIResponsesCompactionResult } from '@openai/agents-core';
+import { logModelAndToolActionWarning } from '@openai/agents-core/utils/internal';
 import { DEFAULT_OPENAI_MODEL, getDefaultOpenAIClient } from '../defaults';
 import { getInputItems } from '../openaiResponsesModel';
 import {
@@ -24,9 +25,7 @@ const DEFAULT_COMPACTION_THRESHOLD = 10;
 const logger = getLogger('openai-agents:openai:compaction');
 
 export type OpenAIResponsesCompactionMode =
-  | 'previous_response_id'
-  | 'input'
-  | 'auto';
+  'previous_response_id' | 'input' | 'auto';
 
 export type OpenAIResponsesCompactionDecisionContext = {
   /**
@@ -328,7 +327,8 @@ export class OpenAIResponsesCompactionSession
     try {
       currentItems = await this.getAllUnderlyingSessionItems();
     } catch (inspectionError) {
-      logger.warn(
+      logModelAndToolActionWarning(
+        logger,
         'Failed to inspect session history after compaction replacement clear failed.',
         inspectionError,
       );
@@ -367,14 +367,16 @@ export class OpenAIResponsesCompactionSession
         await this.underlyingSession.addItems(previousItems);
       }
     } catch (restoreError) {
-      logger.warn(
+      logModelAndToolActionWarning(
+        logger,
         'Failed to restore session history after compaction replacement failed.',
         restoreError,
       );
       return;
     }
 
-    logger.warn(
+    logModelAndToolActionWarning(
+      logger,
       'Restored previous session history after compaction replacement failed.',
       error,
     );

--- a/packages/agents-openai/src/openaiTracingExporter.ts
+++ b/packages/agents-openai/src/openaiTracingExporter.ts
@@ -6,6 +6,7 @@ import {
   type GenerationSpanData,
   type Trace,
 } from '@openai/agents-core';
+import { logModelAndToolActionError } from '@openai/agents-core/utils/internal';
 import { getTracingExportApiKey, HEADERS } from './defaults';
 import logger from './logger';
 
@@ -772,11 +773,17 @@ export class OpenAITracingExporter implements TracingExporter {
           }
 
           if (response.status >= 400 && response.status < 500) {
-            logger.error(
-              `[non-fatal] Tracing client error ${
-                response.status
-              }: ${await response.text()}`,
-            );
+            if (logger.dontLogModelData || logger.dontLogToolData) {
+              logger.error(
+                `[non-fatal] Tracing client error ${response.status}. Response data is redacted.`,
+              );
+            } else {
+              logger.error(
+                `[non-fatal] Tracing client error ${
+                  response.status
+                }: ${await response.text()}`,
+              );
+            }
             break;
           }
 
@@ -784,7 +791,11 @@ export class OpenAITracingExporter implements TracingExporter {
             `[non-fatal] Tracing: server error ${response.status}, retrying.`,
           );
         } catch (error: any) {
-          logger.error('[non-fatal] Tracing: request failed: ', error);
+          logModelAndToolActionError(
+            logger,
+            '[non-fatal] Tracing: request failed:',
+            error,
+          );
         }
 
         if (signal?.aborted) {

--- a/packages/agents-openai/src/openaiTracingExporter.ts
+++ b/packages/agents-openai/src/openaiTracingExporter.ts
@@ -774,6 +774,11 @@ export class OpenAITracingExporter implements TracingExporter {
 
           if (response.status >= 400 && response.status < 500) {
             if (logger.dontLogModelData || logger.dontLogToolData) {
+              try {
+                await response.body?.cancel();
+              } catch {
+                // Best-effort cleanup must not replace the tracing response error.
+              }
               logger.error(
                 `[non-fatal] Tracing client error ${response.status}. Response data is redacted.`,
               );

--- a/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
+++ b/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
@@ -12,12 +12,13 @@ import { OPENAI_SESSION_API } from '../src/memory/openaiSessionApi';
 class PartiallyFailingReplacementSession extends MemorySession {
   addCalls = 0;
   clearCalls = 0;
+  failureMessage = 'replacement failed';
 
   async addItems(items: AgentInputItem[]): Promise<void> {
     this.addCalls += 1;
     if (this.addCalls === 1) {
       await super.addItems(items.slice(0, 1));
-      throw new Error('replacement failed');
+      throw new Error(this.failureMessage);
     }
     await super.addItems(items);
   }
@@ -586,6 +587,63 @@ describe('OpenAIResponsesCompactionSession', () => {
       );
     } finally {
       warn.mockRestore();
+    }
+  });
+
+  it('redacts replacement errors while restoring the previous session history', async () => {
+    const original = process.env.OPENAI_AGENTS_DONT_LOG_MODEL_DATA;
+    process.env.OPENAI_AGENTS_DONT_LOG_MODEL_DATA = '1';
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const secret = 'SECRET_COMPACTION_REPLACEMENT_123';
+    const history = [
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: secret }],
+      },
+    ] as AgentInputItem[];
+    const underlyingSession = new PartiallyFailingReplacementSession({
+      initialItems: history,
+    });
+    underlyingSession.failureMessage = secret;
+    const compact = vi.fn().mockResolvedValue({
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'compacted' }],
+        },
+      ],
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        total_tokens: 2,
+      },
+    });
+    const session = new OpenAIResponsesCompactionSession({
+      client: { responses: { compact } } as any,
+      underlyingSession,
+      compactionMode: 'input',
+    });
+
+    try {
+      await expect(
+        session.runCompaction({ force: true, compactionMode: 'input' }),
+      ).rejects.toThrow(secret);
+      expect(await underlyingSession.getItems()).toEqual(history);
+      expect(warn).toHaveBeenCalledWith(
+        'Restored previous session history after compaction replacement failed.',
+        'Error',
+      );
+      expect(JSON.stringify(warn.mock.calls)).not.toContain(secret);
+    } finally {
+      warn.mockRestore();
+      if (typeof original === 'undefined') {
+        delete process.env.OPENAI_AGENTS_DONT_LOG_MODEL_DATA;
+      } else {
+        process.env.OPENAI_AGENTS_DONT_LOG_MODEL_DATA = original;
+      }
     }
   });
 

--- a/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
+++ b/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
@@ -634,7 +634,7 @@ describe('OpenAIResponsesCompactionSession', () => {
       expect(await underlyingSession.getItems()).toEqual(history);
       expect(warn).toHaveBeenCalledWith(
         'Restored previous session history after compaction replacement failed.',
-        'Error',
+        'object',
       );
       expect(JSON.stringify(warn.mock.calls)).not.toContain(secret);
     } finally {

--- a/packages/agents-openai/test/openaiTracingExporter.test.ts
+++ b/packages/agents-openai/test/openaiTracingExporter.test.ts
@@ -1247,10 +1247,12 @@ describe('OpenAITracingExporter', () => {
         dontLogToolData,
       );
       const text = vi.fn(async () => 'SECRET_TRACE_CLIENT_BODY_123');
+      const cancel = vi.fn(async () => {});
       const fetchMock = vi.fn().mockResolvedValue({
         ok: false,
         status: 400,
         text,
+        body: { cancel },
       });
       vi.stubGlobal('fetch', fetchMock);
       const exporter = new OpenAITracingExporter({
@@ -1262,6 +1264,7 @@ describe('OpenAITracingExporter', () => {
       await exporter.export([fakeSpan]);
 
       expect(text).not.toHaveBeenCalled();
+      expect(cancel).toHaveBeenCalledTimes(1);
       expect(errorSpy).toHaveBeenCalledWith(
         '[non-fatal] Tracing client error 400. Response data is redacted.',
       );
@@ -1270,6 +1273,36 @@ describe('OpenAITracingExporter', () => {
       );
     },
   );
+
+  it('keeps tracing client errors non-fatal when response cancellation fails', async () => {
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(true);
+    vi.spyOn(logger, 'dontLogToolData', 'get').mockReturnValue(false);
+    const secret = 'SECRET_TRACE_CANCEL_FAILURE_123';
+    const text = vi.fn(async () => secret);
+    const cancel = vi.fn().mockRejectedValue(new Error(secret));
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text,
+      body: { cancel },
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const exporter = new OpenAITracingExporter({
+      apiKey: 'key3',
+      endpoint: 'u',
+      maxRetries: 2,
+    });
+
+    await expect(exporter.export([fakeSpan])).resolves.toBeUndefined();
+
+    expect(text).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[non-fatal] Tracing client error 400. Response data is redacted.',
+    );
+    expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(secret);
+  });
 
   it('redacts tracing request failures when sensitive logging is disabled', async () => {
     const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
@@ -1288,7 +1321,7 @@ describe('OpenAITracingExporter', () => {
 
     expect(errorSpy).toHaveBeenCalledWith(
       '[non-fatal] Tracing: request failed:',
-      'Error',
+      'object',
     );
     expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(secret);
   });

--- a/packages/agents-openai/test/openaiTracingExporter.test.ts
+++ b/packages/agents-openai/test/openaiTracingExporter.test.ts
@@ -1232,6 +1232,67 @@ describe('OpenAITracingExporter', () => {
     errorSpy.mockRestore();
   });
 
+  it.each([
+    [true, false],
+    [false, true],
+    [true, true],
+  ])(
+    'does not inspect client-error bodies when model=%s or tool=%s logging is disabled',
+    async (dontLogModelData, dontLogToolData) => {
+      const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+      vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(
+        dontLogModelData,
+      );
+      vi.spyOn(logger, 'dontLogToolData', 'get').mockReturnValue(
+        dontLogToolData,
+      );
+      const text = vi.fn(async () => 'SECRET_TRACE_CLIENT_BODY_123');
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text,
+      });
+      vi.stubGlobal('fetch', fetchMock);
+      const exporter = new OpenAITracingExporter({
+        apiKey: 'key3',
+        endpoint: 'u',
+        maxRetries: 2,
+      });
+
+      await exporter.export([fakeSpan]);
+
+      expect(text).not.toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[non-fatal] Tracing client error 400. Response data is redacted.',
+      );
+      expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(
+        'SECRET_TRACE_CLIENT_BODY_123',
+      );
+    },
+  );
+
+  it('redacts tracing request failures when sensitive logging is disabled', async () => {
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(false);
+    vi.spyOn(logger, 'dontLogToolData', 'get').mockReturnValue(true);
+    const secret = 'SECRET_TRACE_REQUEST_FAILURE_123';
+    const fetchMock = vi.fn().mockRejectedValue(new Error(secret));
+    vi.stubGlobal('fetch', fetchMock);
+    const exporter = new OpenAITracingExporter({
+      apiKey: 'key3',
+      endpoint: 'u',
+      maxRetries: 1,
+    });
+
+    await exporter.export([fakeSpan]);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[non-fatal] Tracing: request failed:',
+      'Error',
+    );
+    expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(secret);
+  });
+
   it('uses item-level API keys when exporting', async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true });
     vi.stubGlobal('fetch', fetchMock);

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -365,7 +365,7 @@ describe('OpenAIRealtimeBase helpers', () => {
       if (redactToolData) {
         expect(logger.error).toHaveBeenCalledWith(
           'Error parsing tool call item',
-          'Error',
+          'object',
         );
         expect(
           JSON.stringify(vi.mocked(logger.error).mock.calls),
@@ -404,7 +404,7 @@ describe('OpenAIRealtimeBase helpers', () => {
       if (redactModelData) {
         expect(logger.error).toHaveBeenCalledWith(
           'Error parsing response done event',
-          'Error',
+          'object',
         );
         expect(
           JSON.stringify(vi.mocked(logger.error).mock.calls),
@@ -883,7 +883,7 @@ describe('OpenAIRealtimeBase helpers', () => {
       if (redactToolData) {
         expect(logger.error).toHaveBeenCalledWith(
           'Error emitting mcp_tools_listed',
-          'Error',
+          'object',
         );
         expect(
           JSON.stringify(vi.mocked(logger.error).mock.calls),

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -1069,7 +1069,7 @@ describe('RealtimeSession', () => {
         if (redactToolData) {
           expect(errorSpy).toHaveBeenCalledWith(
             'Error handling function call',
-            'Error',
+            'object',
           );
           expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(secret);
         } else {
@@ -2151,7 +2151,7 @@ describe('RealtimeSession', () => {
 
       expect(output).toBe('Tool execution was not approved.');
       expect(warnSpy).toHaveBeenCalledWith(
-        'toolErrorFormatter threw while formatting approval rejection: Error',
+        'toolErrorFormatter threw while formatting approval rejection: object',
       );
       expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(secret);
       expect(constructorGetter).not.toHaveBeenCalled();


### PR DESCRIPTION
This pull request fixes runtime logging paths that could expose model data, tool data, session history, tracing payloads, MCP content, Realtime messages, or arbitrary thrown values when sensitive-data logging was disabled.

It centralizes safe redaction for error, warning, and debug paths; guards payload formatting across core, extensions, and OpenAI integrations; and adds adversarial regression coverage. Diagnostic details remain available when logging flags are disabled, while redacted mode emits only fixed messages and safe value types.