### PR TITLE
feat: disable sensitive data logging by default

### DIFF
--- a/.changeset/safe-logs-default.md
+++ b/.changeset/safe-logs-default.md
@@ -1,0 +1,8 @@
+---
+'@openai/agents-core': minor
+'@openai/agents-extensions': minor
+'@openai/agents-openai': minor
+'@openai/agents-realtime': minor
+---
+
+feat: disable sensitive model and tool data logging by default

--- a/.changeset/safe-logs-default.md
+++ b/.changeset/safe-logs-default.md
@@ -1,8 +1,9 @@
 ---
+'@openai/agents': minor
 '@openai/agents-core': minor
 '@openai/agents-extensions': minor
 '@openai/agents-openai': minor
 '@openai/agents-realtime': minor
 ---
 
-feat: disable sensitive model and tool data logging by default
+feat: disable sensitive model and tool data logging by default with a programmatic opt-in

--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -66,6 +66,7 @@ import {
 } from './runner/usageTracking';
 import { setRunnerInvocationSpanParent } from './runner/invocationContext';
 import type { Span } from './tracing';
+import { hasDefinitelyDifferentOutputTypes } from './agentOutputTypeWarning';
 
 type CompletedRunResult<TContext, TAgent extends Agent<TContext, any>> = (
   RunResult<TContext, TAgent> | StreamedRunResult<TContext, TAgent>
@@ -601,7 +602,7 @@ export class Agent<
         }
 
         if (logger.dontLogModelData) {
-          if (new Set<unknown>(outputTypes).size > 1) {
+          if (hasDefinitelyDifferentOutputTypes(outputTypes)) {
             logger.warn(
               '[Agent] Warning: Handoff agents have different output types. Output type details are redacted. You can make it type-safe by using Agent.create({ ... }) method instead.',
             );

--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -590,19 +590,31 @@ export class Agent<
       config.handoffOutputTypeWarningEnabled === undefined ||
       config.handoffOutputTypeWarningEnabled
     ) {
-      if (!logger.dontLogModelData && this.handoffs && this.outputType) {
-        const outputTypes = new Set<string>([JSON.stringify(this.outputType)]);
+      if (this.handoffs && this.outputType) {
+        const outputTypes: unknown[] = [this.outputType];
         for (const h of this.handoffs) {
           if ('outputType' in h && h.outputType) {
-            outputTypes.add(JSON.stringify(h.outputType));
+            outputTypes.push(h.outputType);
           } else if ('agent' in h && h.agent.outputType) {
-            outputTypes.add(JSON.stringify(h.agent.outputType));
+            outputTypes.push(h.agent.outputType);
           }
         }
-        if (outputTypes.size > 1) {
-          logger.warn(
-            `[Agent] Warning: Handoff agents have different output types: ${Array.from(outputTypes).join(', ')}. You can make it type-safe by using Agent.create({ ... }) method instead.`,
+
+        if (logger.dontLogModelData) {
+          if (new Set<unknown>(outputTypes).size > 1) {
+            logger.warn(
+              '[Agent] Warning: Handoff agents have different output types. Output type details are redacted. You can make it type-safe by using Agent.create({ ... }) method instead.',
+            );
+          }
+        } else {
+          const serializedOutputTypes = outputTypes.map((type) =>
+            JSON.stringify(type),
           );
+          if (new Set<string>(serializedOutputTypes).size > 1) {
+            logger.warn(
+              `[Agent] Warning: Handoff agents have different output types: ${serializedOutputTypes.join(', ')}. You can make it type-safe by using Agent.create({ ... }) method instead.`,
+            );
+          }
         }
       }
     }

--- a/packages/agents-core/src/agentOutputTypeWarning.ts
+++ b/packages/agents-core/src/agentOutputTypeWarning.ts
@@ -1,7 +1,15 @@
 import type { AgentOutputType } from './agent';
 import { convertAgentOutputTypeToSerializable } from './utils/tools';
 
-type StructuralComparison = 'equal' | 'different' | 'unknown';
+type ComparableJsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | ComparableJsonValue[]
+  | { [key: string]: ComparableJsonValue };
+
+const NOT_COMPARABLE = Symbol('notComparable');
 
 function isPrimitiveOutputType(value: unknown): boolean {
   return (
@@ -81,39 +89,6 @@ function getComparableOutputType(outputType: unknown): unknown | undefined {
   }
 }
 
-function getComparableObjectProperties(
-  value: object,
-): Record<string, PropertyDescriptor> | undefined {
-  let descriptors: Record<string, PropertyDescriptor>;
-  try {
-    descriptors = Object.getOwnPropertyDescriptors(value);
-  } catch (_error) {
-    return undefined;
-  }
-
-  const comparable: Record<string, PropertyDescriptor> = {};
-  for (const [key, descriptor] of Object.entries(descriptors)) {
-    if (!descriptor.enumerable || key === 'toJSON') {
-      continue;
-    }
-    if (!('value' in descriptor)) {
-      return undefined;
-    }
-    if (
-      descriptor.value === undefined ||
-      typeof descriptor.value === 'function' ||
-      typeof descriptor.value === 'symbol'
-    ) {
-      continue;
-    }
-    if (typeof descriptor.value === 'bigint') {
-      return undefined;
-    }
-    comparable[key] = descriptor;
-  }
-  return comparable;
-}
-
 function detectArray(value: object): boolean | undefined {
   try {
     return Array.isArray(value);
@@ -129,124 +104,143 @@ function readArrayLength(value: object): number | undefined {
     : undefined;
 }
 
-function compareJsonLikeValues(
-  left: unknown,
-  right: unknown,
-  visited: WeakMap<object, WeakMap<object, StructuralComparison>>,
-): StructuralComparison {
-  if (Object.is(left, right)) {
-    return 'equal';
-  }
-  if (left === null || right === null) {
-    return 'different';
-  }
-  if (typeof left !== typeof right) {
-    return 'different';
-  }
-  if (typeof left !== 'object' || typeof right !== 'object') {
-    if (
-      (typeof left === 'number' && !Number.isFinite(left)) ||
-      (typeof right === 'number' && !Number.isFinite(right)) ||
-      typeof left === 'bigint' ||
-      typeof left === 'function' ||
-      typeof left === 'symbol' ||
-      typeof left === 'undefined'
-    ) {
-      return 'unknown';
-    }
-    return 'different';
-  }
-
-  const leftIsArray = detectArray(left);
-  const rightIsArray = detectArray(right);
-  if (leftIsArray === undefined || rightIsArray === undefined) {
-    return 'unknown';
-  }
-  if (leftIsArray !== rightIsArray) {
-    return 'different';
-  }
-
-  const priorComparison = visited.get(left)?.get(right);
-  if (priorComparison) {
-    return priorComparison === 'unknown' ? 'unknown' : priorComparison;
-  }
-  const rightComparisons = visited.get(left) ?? new WeakMap();
-  visited.set(left, rightComparisons);
-  rightComparisons.set(right, 'unknown');
-
-  if (leftIsArray && rightIsArray) {
-    const leftLength = readArrayLength(left);
-    const rightLength = readArrayLength(right);
-    if (leftLength === undefined || rightLength === undefined) {
-      return 'unknown';
-    }
-    if (leftLength !== rightLength) {
-      rightComparisons.set(right, 'different');
-      return 'different';
-    }
-    for (let index = 0; index < leftLength; index += 1) {
-      const leftValue = readOwnDataProperty(left, index);
-      const rightValue = readOwnDataProperty(right, index);
-      if (!leftValue || !rightValue) {
-        return 'unknown';
-      }
-      const comparison = compareJsonLikeValues(
-        leftValue.found ? leftValue.value : null,
-        rightValue.found ? rightValue.value : null,
-        visited,
-      );
-      if (comparison !== 'equal') {
-        rightComparisons.set(right, comparison);
-        return comparison;
-      }
-    }
-    rightComparisons.set(right, 'equal');
-    return 'equal';
-  }
-
-  const leftProperties = getComparableObjectProperties(left);
-  const rightProperties = getComparableObjectProperties(right);
-  if (!leftProperties || !rightProperties) {
-    return 'unknown';
-  }
-  const leftKeys = Object.keys(leftProperties).sort();
-  const rightKeys = Object.keys(rightProperties).sort();
-  if (
-    leftKeys.length !== rightKeys.length ||
-    leftKeys.some((key, index) => key !== rightKeys[index])
-  ) {
-    rightComparisons.set(right, 'different');
-    return 'different';
-  }
-
-  for (const key of leftKeys) {
-    const comparison = compareJsonLikeValues(
-      leftProperties[key].value,
-      rightProperties[key].value,
-      visited,
-    );
-    if (comparison !== 'equal') {
-      rightComparisons.set(right, comparison);
-      return comparison;
-    }
-  }
-  rightComparisons.set(right, 'equal');
-  return 'equal';
+function isOmittedJsonObjectValue(value: unknown): boolean {
+  return (
+    value === undefined ||
+    typeof value === 'function' ||
+    typeof value === 'symbol'
+  );
 }
 
-function compareStructuredOutputTypes(
-  comparableLeft: unknown,
-  comparableRight: unknown,
-): StructuralComparison {
-  if (comparableLeft === undefined || comparableRight === undefined) {
-    return 'unknown';
+function toComparableJsonValue(
+  value: unknown,
+  ancestors: Set<object>,
+): ComparableJsonValue | typeof NOT_COMPARABLE {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'boolean'
+  ) {
+    return value;
   }
-  return compareJsonLikeValues(comparableLeft, comparableRight, new WeakMap());
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : NOT_COMPARABLE;
+  }
+  if (typeof value !== 'object') {
+    return NOT_COMPARABLE;
+  }
+  if (ancestors.has(value)) {
+    return NOT_COMPARABLE;
+  }
+
+  const isArray = detectArray(value);
+  if (isArray === undefined) {
+    return NOT_COMPARABLE;
+  }
+
+  ancestors.add(value);
+  try {
+    if (isArray) {
+      const length = readArrayLength(value);
+      if (length === undefined) {
+        return NOT_COMPARABLE;
+      }
+      const comparable: ComparableJsonValue[] = [];
+      for (let index = 0; index < length; index += 1) {
+        const element = readOwnDataProperty(value, index);
+        if (!element) {
+          return NOT_COMPARABLE;
+        }
+        if (!element.found || isOmittedJsonObjectValue(element.value)) {
+          comparable.push(null);
+          continue;
+        }
+        const comparableElement = toComparableJsonValue(
+          element.value,
+          ancestors,
+        );
+        if (comparableElement === NOT_COMPARABLE) {
+          return NOT_COMPARABLE;
+        }
+        comparable.push(comparableElement);
+      }
+      return comparable;
+    }
+
+    let descriptors: Record<string, PropertyDescriptor>;
+    try {
+      descriptors = Object.getOwnPropertyDescriptors(value);
+    } catch (_error) {
+      return NOT_COMPARABLE;
+    }
+
+    const comparable: { [key: string]: ComparableJsonValue } =
+      Object.create(null);
+    for (const key of Object.keys(descriptors).sort()) {
+      const descriptor = descriptors[key];
+      if (!descriptor.enumerable) {
+        continue;
+      }
+      if (!('value' in descriptor)) {
+        return NOT_COMPARABLE;
+      }
+      if (isOmittedJsonObjectValue(descriptor.value)) {
+        continue;
+      }
+      const comparableProperty = toComparableJsonValue(
+        descriptor.value,
+        ancestors,
+      );
+      if (comparableProperty === NOT_COMPARABLE) {
+        return NOT_COMPARABLE;
+      }
+      comparable[key] = comparableProperty;
+    }
+    return comparable;
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function stringifyComparableJsonValue(value: ComparableJsonValue): string {
+  if (value === null) {
+    return 'null';
+  }
+  if (typeof value === 'string') {
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stringifyComparableJsonValue).join(',')}]`;
+  }
+  return `{${Object.keys(value)
+    .map(
+      (key) =>
+        `${JSON.stringify(key)}:${stringifyComparableJsonValue(value[key])}`,
+    )
+    .join(',')}}`;
+}
+
+function getOutputTypeFingerprint(outputType: unknown): string | undefined {
+  const comparableOutputType = getComparableOutputType(outputType);
+  if (comparableOutputType === undefined) {
+    return undefined;
+  }
+  const comparableJsonValue = toComparableJsonValue(
+    comparableOutputType,
+    new Set(),
+  );
+  if (comparableJsonValue === NOT_COMPARABLE) {
+    return undefined;
+  }
+  return stringifyComparableJsonValue(comparableJsonValue);
 }
 
 /**
- * Returns true only when different output types can be established without invoking schema
- * serialization hooks. Supported structured schemas are compared without exposing their details.
+ * Returns true only when different output types can be established from canonical snapshots that
+ * do not invoke schema accessors or serialization hooks.
  *
  * @internal
  */
@@ -256,7 +250,7 @@ export function hasDefinitelyDifferentOutputTypes(
   if (outputTypes.length < 2) {
     return false;
   }
-  const comparableOutputTypes = outputTypes.map(getComparableOutputType);
+  const outputTypeFingerprints = outputTypes.map(getOutputTypeFingerprint);
 
   for (let leftIndex = 0; leftIndex < outputTypes.length - 1; leftIndex += 1) {
     for (
@@ -275,11 +269,12 @@ export function hasDefinitelyDifferentOutputTypes(
       ) {
         return true;
       }
+      const leftFingerprint = outputTypeFingerprints[leftIndex];
+      const rightFingerprint = outputTypeFingerprints[rightIndex];
       if (
-        compareStructuredOutputTypes(
-          comparableOutputTypes[leftIndex],
-          comparableOutputTypes[rightIndex],
-        ) === 'different'
+        leftFingerprint !== undefined &&
+        rightFingerprint !== undefined &&
+        leftFingerprint !== rightFingerprint
       ) {
         return true;
       }

--- a/packages/agents-core/src/agentOutputTypeWarning.ts
+++ b/packages/agents-core/src/agentOutputTypeWarning.ts
@@ -1,0 +1,30 @@
+function isPrimitiveOutputType(value: unknown): boolean {
+  return (
+    value === null || (typeof value !== 'object' && typeof value !== 'function')
+  );
+}
+
+/**
+ * Returns true only when different output types can be established without inspecting schema
+ * objects. Distinct schema objects may still be structurally equivalent, so they remain unknown.
+ *
+ * @internal
+ */
+export function hasDefinitelyDifferentOutputTypes(
+  outputTypes: unknown[],
+): boolean {
+  if (outputTypes.length < 2) {
+    return false;
+  }
+  const firstOutputType = outputTypes[0];
+
+  return outputTypes.slice(1).some((outputType) => {
+    if (Object.is(outputType, firstOutputType)) {
+      return false;
+    }
+    return (
+      isPrimitiveOutputType(firstOutputType) ||
+      isPrimitiveOutputType(outputType)
+    );
+  });
+}

--- a/packages/agents-core/src/agentOutputTypeWarning.ts
+++ b/packages/agents-core/src/agentOutputTypeWarning.ts
@@ -114,6 +114,21 @@ function getComparableObjectProperties(
   return comparable;
 }
 
+function detectArray(value: object): boolean | undefined {
+  try {
+    return Array.isArray(value);
+  } catch (_error) {
+    return undefined;
+  }
+}
+
+function readArrayLength(value: object): number | undefined {
+  const length = readOwnDataProperty(value, 'length');
+  return length?.found && typeof length.value === 'number'
+    ? length.value
+    : undefined;
+}
+
 function compareJsonLikeValues(
   left: unknown,
   right: unknown,
@@ -142,8 +157,11 @@ function compareJsonLikeValues(
     return 'different';
   }
 
-  const leftIsArray = Array.isArray(left);
-  const rightIsArray = Array.isArray(right);
+  const leftIsArray = detectArray(left);
+  const rightIsArray = detectArray(right);
+  if (leftIsArray === undefined || rightIsArray === undefined) {
+    return 'unknown';
+  }
   if (leftIsArray !== rightIsArray) {
     return 'different';
   }
@@ -157,11 +175,16 @@ function compareJsonLikeValues(
   rightComparisons.set(right, 'unknown');
 
   if (leftIsArray && rightIsArray) {
-    if (left.length !== right.length) {
+    const leftLength = readArrayLength(left);
+    const rightLength = readArrayLength(right);
+    if (leftLength === undefined || rightLength === undefined) {
+      return 'unknown';
+    }
+    if (leftLength !== rightLength) {
       rightComparisons.set(right, 'different');
       return 'different';
     }
-    for (let index = 0; index < left.length; index += 1) {
+    for (let index = 0; index < leftLength; index += 1) {
       const leftValue = readOwnDataProperty(left, index);
       const rightValue = readOwnDataProperty(right, index);
       if (!leftValue || !rightValue) {
@@ -212,11 +235,9 @@ function compareJsonLikeValues(
 }
 
 function compareStructuredOutputTypes(
-  left: unknown,
-  right: unknown,
+  comparableLeft: unknown,
+  comparableRight: unknown,
 ): StructuralComparison {
-  const comparableLeft = getComparableOutputType(left);
-  const comparableRight = getComparableOutputType(right);
   if (comparableLeft === undefined || comparableRight === undefined) {
     return 'unknown';
   }
@@ -235,20 +256,34 @@ export function hasDefinitelyDifferentOutputTypes(
   if (outputTypes.length < 2) {
     return false;
   }
-  const firstOutputType = outputTypes[0];
+  const comparableOutputTypes = outputTypes.map(getComparableOutputType);
 
-  return outputTypes.slice(1).some((outputType) => {
-    if (Object.is(outputType, firstOutputType)) {
-      return false;
-    }
-    if (
-      isPrimitiveOutputType(firstOutputType) ||
-      isPrimitiveOutputType(outputType)
+  for (let leftIndex = 0; leftIndex < outputTypes.length - 1; leftIndex += 1) {
+    for (
+      let rightIndex = leftIndex + 1;
+      rightIndex < outputTypes.length;
+      rightIndex += 1
     ) {
-      return true;
+      const leftOutputType = outputTypes[leftIndex];
+      const rightOutputType = outputTypes[rightIndex];
+      if (Object.is(leftOutputType, rightOutputType)) {
+        continue;
+      }
+      if (
+        isPrimitiveOutputType(leftOutputType) ||
+        isPrimitiveOutputType(rightOutputType)
+      ) {
+        return true;
+      }
+      if (
+        compareStructuredOutputTypes(
+          comparableOutputTypes[leftIndex],
+          comparableOutputTypes[rightIndex],
+        ) === 'different'
+      ) {
+        return true;
+      }
     }
-    return (
-      compareStructuredOutputTypes(firstOutputType, outputType) === 'different'
-    );
-  });
+  }
+  return false;
 }

--- a/packages/agents-core/src/agentOutputTypeWarning.ts
+++ b/packages/agents-core/src/agentOutputTypeWarning.ts
@@ -1,12 +1,231 @@
+import type { AgentOutputType } from './agent';
+import { convertAgentOutputTypeToSerializable } from './utils/tools';
+
+type StructuralComparison = 'equal' | 'different' | 'unknown';
+
 function isPrimitiveOutputType(value: unknown): boolean {
   return (
     value === null || (typeof value !== 'object' && typeof value !== 'function')
   );
 }
 
+function readOwnDataProperty(
+  value: object,
+  key: PropertyKey,
+): { found: boolean; value?: unknown } | undefined {
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor) {
+      return { found: false };
+    }
+    if (!('value' in descriptor)) {
+      return undefined;
+    }
+    return { found: true, value: descriptor.value };
+  } catch (_error) {
+    return undefined;
+  }
+}
+
+function getComparableJsonSchemaOutputType(
+  outputType: object,
+): unknown | undefined {
+  const type = readOwnDataProperty(outputType, 'type');
+  if (type?.found && type.value === 'json_schema') {
+    const name = readOwnDataProperty(outputType, 'name');
+    const strict = readOwnDataProperty(outputType, 'strict');
+    const schema = readOwnDataProperty(outputType, 'schema');
+    if (!name?.found || !strict?.found || !schema?.found) {
+      return undefined;
+    }
+    return {
+      type: type.value,
+      name: name.value,
+      strict: strict.value,
+      schema: schema.value,
+    };
+  }
+
+  return undefined;
+}
+
+function getComparableOutputType(outputType: unknown): unknown | undefined {
+  if (typeof outputType !== 'object' || outputType === null) {
+    return outputType;
+  }
+
+  const outputTypeDiscriminator = readOwnDataProperty(outputType, 'type');
+  if (!outputTypeDiscriminator) {
+    return undefined;
+  }
+  if (
+    outputTypeDiscriminator.found &&
+    outputTypeDiscriminator.value === 'json_schema'
+  ) {
+    return getComparableJsonSchemaOutputType(outputType);
+  }
+
+  try {
+    const serializedOutputType = convertAgentOutputTypeToSerializable(
+      outputType as AgentOutputType,
+    );
+    if (
+      typeof serializedOutputType !== 'object' ||
+      serializedOutputType === null
+    ) {
+      return serializedOutputType;
+    }
+    return getComparableJsonSchemaOutputType(serializedOutputType);
+  } catch (_error) {
+    return undefined;
+  }
+}
+
+function getComparableObjectProperties(
+  value: object,
+): Record<string, PropertyDescriptor> | undefined {
+  let descriptors: Record<string, PropertyDescriptor>;
+  try {
+    descriptors = Object.getOwnPropertyDescriptors(value);
+  } catch (_error) {
+    return undefined;
+  }
+
+  const comparable: Record<string, PropertyDescriptor> = {};
+  for (const [key, descriptor] of Object.entries(descriptors)) {
+    if (!descriptor.enumerable || key === 'toJSON') {
+      continue;
+    }
+    if (!('value' in descriptor)) {
+      return undefined;
+    }
+    if (
+      descriptor.value === undefined ||
+      typeof descriptor.value === 'function' ||
+      typeof descriptor.value === 'symbol'
+    ) {
+      continue;
+    }
+    if (typeof descriptor.value === 'bigint') {
+      return undefined;
+    }
+    comparable[key] = descriptor;
+  }
+  return comparable;
+}
+
+function compareJsonLikeValues(
+  left: unknown,
+  right: unknown,
+  visited: WeakMap<object, WeakMap<object, StructuralComparison>>,
+): StructuralComparison {
+  if (Object.is(left, right)) {
+    return 'equal';
+  }
+  if (left === null || right === null) {
+    return 'different';
+  }
+  if (typeof left !== typeof right) {
+    return 'different';
+  }
+  if (typeof left !== 'object' || typeof right !== 'object') {
+    if (
+      (typeof left === 'number' && !Number.isFinite(left)) ||
+      (typeof right === 'number' && !Number.isFinite(right)) ||
+      typeof left === 'bigint' ||
+      typeof left === 'function' ||
+      typeof left === 'symbol' ||
+      typeof left === 'undefined'
+    ) {
+      return 'unknown';
+    }
+    return 'different';
+  }
+
+  const leftIsArray = Array.isArray(left);
+  const rightIsArray = Array.isArray(right);
+  if (leftIsArray !== rightIsArray) {
+    return 'different';
+  }
+
+  const priorComparison = visited.get(left)?.get(right);
+  if (priorComparison) {
+    return priorComparison === 'unknown' ? 'unknown' : priorComparison;
+  }
+  const rightComparisons = visited.get(left) ?? new WeakMap();
+  visited.set(left, rightComparisons);
+  rightComparisons.set(right, 'unknown');
+
+  if (leftIsArray && rightIsArray) {
+    if (left.length !== right.length) {
+      rightComparisons.set(right, 'different');
+      return 'different';
+    }
+    for (let index = 0; index < left.length; index += 1) {
+      const leftValue = readOwnDataProperty(left, index);
+      const rightValue = readOwnDataProperty(right, index);
+      if (!leftValue || !rightValue) {
+        return 'unknown';
+      }
+      const comparison = compareJsonLikeValues(
+        leftValue.found ? leftValue.value : null,
+        rightValue.found ? rightValue.value : null,
+        visited,
+      );
+      if (comparison !== 'equal') {
+        rightComparisons.set(right, comparison);
+        return comparison;
+      }
+    }
+    rightComparisons.set(right, 'equal');
+    return 'equal';
+  }
+
+  const leftProperties = getComparableObjectProperties(left);
+  const rightProperties = getComparableObjectProperties(right);
+  if (!leftProperties || !rightProperties) {
+    return 'unknown';
+  }
+  const leftKeys = Object.keys(leftProperties).sort();
+  const rightKeys = Object.keys(rightProperties).sort();
+  if (
+    leftKeys.length !== rightKeys.length ||
+    leftKeys.some((key, index) => key !== rightKeys[index])
+  ) {
+    rightComparisons.set(right, 'different');
+    return 'different';
+  }
+
+  for (const key of leftKeys) {
+    const comparison = compareJsonLikeValues(
+      leftProperties[key].value,
+      rightProperties[key].value,
+      visited,
+    );
+    if (comparison !== 'equal') {
+      rightComparisons.set(right, comparison);
+      return comparison;
+    }
+  }
+  rightComparisons.set(right, 'equal');
+  return 'equal';
+}
+
+function compareStructuredOutputTypes(
+  left: unknown,
+  right: unknown,
+): StructuralComparison {
+  const comparableLeft = getComparableOutputType(left);
+  const comparableRight = getComparableOutputType(right);
+  if (comparableLeft === undefined || comparableRight === undefined) {
+    return 'unknown';
+  }
+  return compareJsonLikeValues(comparableLeft, comparableRight, new WeakMap());
+}
+
 /**
- * Returns true only when different output types can be established without inspecting schema
- * objects. Distinct schema objects may still be structurally equivalent, so they remain unknown.
+ * Returns true only when different output types can be established without invoking schema
+ * serialization hooks. Supported structured schemas are compared without exposing their details.
  *
  * @internal
  */
@@ -22,9 +241,14 @@ export function hasDefinitelyDifferentOutputTypes(
     if (Object.is(outputType, firstOutputType)) {
       return false;
     }
-    return (
+    if (
       isPrimitiveOutputType(firstOutputType) ||
       isPrimitiveOutputType(outputType)
+    ) {
+      return true;
+    }
+    return (
+      compareStructuredOutputTypes(firstOutputType, outputType) === 'different'
     );
   });
 }

--- a/packages/agents-core/src/config.ts
+++ b/packages/agents-core/src/config.ts
@@ -61,8 +61,15 @@ let sensitiveDataLoggingEnabledOverride: boolean | undefined;
  * This override takes precedence over the logging environment variables.
  *
  * @param enabled - Whether sensitive model and tool data may be logged.
+ * @throws {TypeError} If `enabled` is not a primitive boolean.
  */
 export function setSensitiveDataLoggingEnabled(enabled: boolean): void {
+  if (typeof enabled !== 'boolean') {
+    sensitiveDataLoggingEnabledOverride = false;
+    throw new TypeError(
+      'Sensitive data logging can only be enabled or disabled with a boolean value.',
+    );
+  }
   sensitiveDataLoggingEnabledOverride = enabled;
 }
 

--- a/packages/agents-core/src/config.ts
+++ b/packages/agents-core/src/config.ts
@@ -45,7 +45,32 @@ function isEnabled(flagName: string, defaultValue: boolean = false): boolean {
   if (flagValue === undefined) {
     return defaultValue;
   }
-  return flagValue === 'true' || flagValue === '1';
+  if (flagValue === 'true' || flagValue === '1') {
+    return true;
+  }
+  if (flagValue === 'false' || flagValue === '0') {
+    return false;
+  }
+  return defaultValue;
+}
+
+let sensitiveDataLoggingEnabledOverride: boolean | undefined;
+
+/**
+ * Enables or disables sensitive model and tool data logging programmatically.
+ * This override takes precedence over the logging environment variables.
+ *
+ * @param enabled - Whether sensitive model and tool data may be logged.
+ */
+export function setSensitiveDataLoggingEnabled(enabled: boolean): void {
+  sensitiveDataLoggingEnabledOverride = enabled;
+}
+
+function shouldSuppressSensitiveData(flagName: string): boolean {
+  if (sensitiveDataLoggingEnabledOverride !== undefined) {
+    return !sensitiveDataLoggingEnabledOverride;
+  }
+  return isEnabled(flagName, true);
 }
 
 /**
@@ -68,9 +93,9 @@ export const tracing = {
  */
 export const logging = {
   get dontLogModelData() {
-    return isEnabled('OPENAI_AGENTS_DONT_LOG_MODEL_DATA', true);
+    return shouldSuppressSensitiveData('OPENAI_AGENTS_DONT_LOG_MODEL_DATA');
   },
   get dontLogToolData() {
-    return isEnabled('OPENAI_AGENTS_DONT_LOG_TOOL_DATA', true);
+    return shouldSuppressSensitiveData('OPENAI_AGENTS_DONT_LOG_TOOL_DATA');
   },
 };

--- a/packages/agents-core/src/config.ts
+++ b/packages/agents-core/src/config.ts
@@ -37,14 +37,15 @@ export function loadEnv(): Record<string, string | undefined> {
  * Checks if a flag is enabled in the environment.
  *
  * @param flagName - The name of the flag to check.
+ * @param defaultValue - The value to return when the flag is not set.
  * @returns `true` if the flag is enabled, `false` otherwise.
  */
-function isEnabled(flagName: string): boolean {
-  const env = loadEnv();
-  return (
-    typeof env !== 'undefined' &&
-    (env[flagName] === 'true' || env[flagName] === '1')
-  );
+function isEnabled(flagName: string, defaultValue: boolean = false): boolean {
+  const flagValue = loadEnv()[flagName];
+  if (flagValue === undefined) {
+    return defaultValue;
+  }
+  return flagValue === 'true' || flagValue === '1';
 }
 
 /**
@@ -67,9 +68,9 @@ export const tracing = {
  */
 export const logging = {
   get dontLogModelData() {
-    return isEnabled('OPENAI_AGENTS_DONT_LOG_MODEL_DATA');
+    return isEnabled('OPENAI_AGENTS_DONT_LOG_MODEL_DATA', true);
   },
   get dontLogToolData() {
-    return isEnabled('OPENAI_AGENTS_DONT_LOG_TOOL_DATA');
+    return isEnabled('OPENAI_AGENTS_DONT_LOG_TOOL_DATA', true);
   },
 };

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -103,6 +103,7 @@ export {
 } from './items';
 export { AgentHooks } from './lifecycle';
 export { getLogger } from './logger';
+export { setSensitiveDataLoggingEnabled } from './config';
 export { applyDiff } from './utils/applyDiff';
 export {
   getAllMcpTools,

--- a/packages/agents-core/src/utils/tools.ts
+++ b/packages/agents-core/src/utils/tools.ts
@@ -1,9 +1,9 @@
 import { zodResponsesFunction, zodTextFormat } from 'openai/helpers/zod';
 import { UserError } from '../errors';
-import { ToolInputParameters } from '../tool';
+import type { ToolInputParameters } from '../tool';
 import { JsonObjectSchema, JsonSchemaDefinition, TextOutput } from '../types';
 import { isZodObject } from './typeGuards';
-import { AgentOutputType } from '../agent';
+import type { AgentOutputType } from '../agent';
 import {
   zodJsonSchemaCompat,
   hasJsonSchemaObjectShape,

--- a/packages/agents-core/test/agent.test.ts
+++ b/packages/agents-core/test/agent.test.ts
@@ -42,7 +42,7 @@ describe('Agent', () => {
     expect(agent.resetToolChoice).toBe(true);
   });
 
-  it('does not inspect handoff output schemas when model logging is disabled', () => {
+  it('warns without inspecting handoff output schemas when model logging is disabled', () => {
     const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
     vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(true);
     const secret = 'SECRET_HANDOFF_OUTPUT_SCHEMA_123';
@@ -70,10 +70,84 @@ describe('Agent', () => {
           name: 'ParentAgent',
           outputType,
           handoffs: [handoffAgent],
+          handoffOutputTypeWarningEnabled: true,
         }),
     ).not.toThrow();
     expect(toJSON).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[Agent] Warning: Handoff agents have different output types. Output type details are redacted. You can make it type-safe by using Agent.create({ ... }) method instead.',
+    );
     expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(secret);
+  });
+
+  it('includes handoff output schema details when model logging is enabled', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(false);
+    const parentSecret = 'SECRET_PARENT_OUTPUT_SCHEMA_123';
+    const handoffSecret = 'SECRET_HANDOFF_OUTPUT_SCHEMA_456';
+    const parentOutputType = {
+      type: 'json_schema',
+      name: 'ParentOutput',
+      strict: true,
+      schema: { const: parentSecret },
+    } as unknown as JsonSchemaDefinition;
+    const handoffOutputType = {
+      type: 'json_schema',
+      name: 'HandoffOutput',
+      strict: true,
+      schema: { const: handoffSecret },
+    } as unknown as JsonSchemaDefinition;
+    const handoffAgent = new Agent({
+      name: 'HandoffAgent',
+      outputType: handoffOutputType,
+    });
+
+    new Agent({
+      name: 'ParentAgent',
+      outputType: parentOutputType,
+      handoffs: [handoffAgent],
+    });
+
+    const warningCalls = JSON.stringify(warnSpy.mock.calls);
+    expect(warningCalls).toContain(parentSecret);
+    expect(warningCalls).toContain(handoffSecret);
+  });
+
+  it('does not warn for the same handoff output type when model logging is disabled', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(true);
+    const outputType = z.object({ value: z.string() });
+    const handoffAgent = new Agent({
+      name: 'HandoffAgent',
+      outputType,
+    });
+
+    new Agent({
+      name: 'ParentAgent',
+      outputType,
+      handoffs: [handoffAgent],
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('honors an explicit opt-out from handoff output type warnings', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(true);
+
+    new Agent({
+      name: 'ParentAgent',
+      outputType: z.object({ parent: z.string() }),
+      handoffs: [
+        new Agent({
+          name: 'HandoffAgent',
+          outputType: z.object({ child: z.string() }),
+        }),
+      ],
+      handoffOutputTypeWarningEnabled: false,
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it('should throw if name is missing', () => {

--- a/packages/agents-core/test/agent.test.ts
+++ b/packages/agents-core/test/agent.test.ts
@@ -165,6 +165,111 @@ describe('Agent', () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
+  it('warns for different JSON schemas without exposing details when model logging is disabled', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(true);
+    const parentSecret = 'SECRET_PARENT_SCHEMA_DESCRIPTION_123';
+    const handoffSecret = 'SECRET_HANDOFF_SCHEMA_DESCRIPTION_456';
+    const createOutputType = (property: string, description: string) =>
+      ({
+        type: 'json_schema',
+        name: 'StructuredOutput',
+        strict: true,
+        schema: {
+          type: 'object',
+          properties: { [property]: { type: 'string', description } },
+          required: [property],
+          additionalProperties: false,
+        },
+      }) as JsonSchemaDefinition;
+    const handoffAgent = new Agent({
+      name: 'HandoffAgent',
+      outputType: createOutputType('child', handoffSecret),
+    });
+
+    new Agent({
+      name: 'ParentAgent',
+      outputType: createOutputType('parent', parentSecret),
+      handoffs: [handoffAgent],
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[Agent] Warning: Handoff agents have different output types. Output type details are redacted. You can make it type-safe by using Agent.create({ ... }) method instead.',
+    );
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(parentSecret);
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(handoffSecret);
+  });
+
+  it('warns for different Zod schemas without exposing details when model logging is disabled', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(true);
+    const parentSecret = 'SECRET_PARENT_ZOD_DESCRIPTION_123';
+    const handoffSecret = 'SECRET_HANDOFF_ZOD_DESCRIPTION_456';
+    const handoffAgent = new Agent({
+      name: 'HandoffAgent',
+      outputType: z.object({ child: z.string().describe(handoffSecret) }),
+    });
+
+    new Agent({
+      name: 'ParentAgent',
+      outputType: z.object({ parent: z.string().describe(parentSecret) }),
+      handoffs: [handoffAgent],
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[Agent] Warning: Handoff agents have different output types. Output type details are redacted. You can make it type-safe by using Agent.create({ ... }) method instead.',
+    );
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(parentSecret);
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(handoffSecret);
+  });
+
+  it('does not invoke JSON schema accessors when model logging is disabled', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(true);
+    const propertiesGetter = vi.fn(() => {
+      throw new Error('SECRET_SCHEMA_GETTER_123');
+    });
+    const schema = {
+      type: 'object',
+      required: [],
+      additionalProperties: false,
+    } as Record<string, unknown>;
+    Object.defineProperty(schema, 'properties', {
+      enumerable: true,
+      get: propertiesGetter,
+    });
+    const handoffAgent = new Agent({
+      name: 'HandoffAgent',
+      outputType: {
+        type: 'json_schema',
+        name: 'AccessorOutput',
+        strict: true,
+        schema,
+      } as JsonSchemaDefinition,
+    });
+
+    expect(
+      () =>
+        new Agent({
+          name: 'ParentAgent',
+          outputType: {
+            type: 'json_schema',
+            name: 'AccessorOutput',
+            strict: true,
+            schema: {
+              type: 'object',
+              properties: {},
+              required: [],
+              additionalProperties: false,
+            },
+          },
+          handoffs: [handoffAgent],
+        }),
+    ).not.toThrow();
+    expect(propertiesGetter).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
   it('honors an explicit opt-out from handoff output type warnings', () => {
     const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
     vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(true);

--- a/packages/agents-core/test/agent.test.ts
+++ b/packages/agents-core/test/agent.test.ts
@@ -128,6 +128,7 @@ describe('Agent', () => {
           properties: { value: { type: 'string' } },
           required: ['value'],
           additionalProperties: false,
+          toJSON,
         },
         toJSON,
       }) as unknown as JsonSchemaDefinition;
@@ -145,6 +146,37 @@ describe('Agent', () => {
     expect(warnSpy).not.toHaveBeenCalled();
     expect(parentToJSON).not.toHaveBeenCalled();
     expect(handoffToJSON).not.toHaveBeenCalled();
+  });
+
+  it('warns when schemas differ by an output property named toJSON', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(true);
+    const createOutputType = (properties: Record<string, { type: string }>) =>
+      ({
+        type: 'json_schema',
+        name: 'ToJsonPropertyOutput',
+        strict: true,
+        schema: {
+          type: 'object',
+          properties,
+          required: [],
+          additionalProperties: false,
+        },
+      }) as JsonSchemaDefinition;
+    const handoffAgent = new Agent({
+      name: 'HandoffAgent',
+      outputType: createOutputType({}),
+    });
+
+    new Agent({
+      name: 'ParentAgent',
+      outputType: createOutputType({ toJSON: { type: 'string' } }),
+      handoffs: [handoffAgent],
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[Agent] Warning: Handoff agents have different output types. Output type details are redacted. You can make it type-safe by using Agent.create({ ... }) method instead.',
+    );
   });
 
   it('does not warn for separately constructed equivalent Zod schemas when model logging is disabled', () => {

--- a/packages/agents-core/test/agent.test.ts
+++ b/packages/agents-core/test/agent.test.ts
@@ -270,6 +270,118 @@ describe('Agent', () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
+  it('does not read array proxy lengths when model logging is disabled', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(true);
+    const lengthGetter = vi.fn(() => {
+      throw new Error('SECRET_ARRAY_LENGTH_GETTER_123');
+    });
+    const lengthDescriptorGetter = vi.fn(() => {
+      throw new Error('SECRET_ARRAY_LENGTH_DESCRIPTOR_456');
+    });
+    const required = new Proxy(['value'], {
+      get(target, property, receiver) {
+        if (property === 'length') {
+          return lengthGetter();
+        }
+        return Reflect.get(target, property, receiver);
+      },
+      getOwnPropertyDescriptor(target, property) {
+        if (property === 'length') {
+          return lengthDescriptorGetter();
+        }
+        return Reflect.getOwnPropertyDescriptor(target, property);
+      },
+    });
+    const handoffAgent = new Agent({
+      name: 'HandoffAgent',
+      outputType: {
+        type: 'json_schema',
+        name: 'ProxyArrayOutput',
+        strict: true,
+        schema: {
+          type: 'object',
+          properties: { value: { type: 'string' } },
+          required,
+          additionalProperties: false,
+        },
+      },
+    });
+
+    expect(
+      () =>
+        new Agent({
+          name: 'ParentAgent',
+          outputType: {
+            type: 'json_schema',
+            name: 'ProxyArrayOutput',
+            strict: true,
+            schema: {
+              type: 'object',
+              properties: { value: { type: 'string' } },
+              required: ['value'],
+              additionalProperties: false,
+            },
+          },
+          handoffs: [handoffAgent],
+        }),
+    ).not.toThrow();
+    expect(lengthGetter).not.toHaveBeenCalled();
+    expect(lengthDescriptorGetter).toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('compares handoff schemas when the parent schema is not comparable', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(true);
+    const propertiesGetter = vi.fn(() => {
+      throw new Error('SECRET_PARENT_SCHEMA_GETTER_123');
+    });
+    const parentSchema = {
+      type: 'object',
+      required: [],
+      additionalProperties: false,
+    } as Record<string, unknown>;
+    Object.defineProperty(parentSchema, 'properties', {
+      enumerable: true,
+      get: propertiesGetter,
+    });
+    const createHandoffAgent = (name: string, property: string) =>
+      new Agent({
+        name,
+        outputType: {
+          type: 'json_schema',
+          name: 'HandoffOutput',
+          strict: true,
+          schema: {
+            type: 'object',
+            properties: { [property]: { type: 'string' } },
+            required: [property],
+            additionalProperties: false,
+          },
+        },
+      });
+
+    new Agent({
+      name: 'ParentAgent',
+      outputType: {
+        type: 'json_schema',
+        name: 'ParentOutput',
+        strict: true,
+        schema: parentSchema,
+      } as JsonSchemaDefinition,
+      handoffs: [
+        createHandoffAgent('FirstHandoffAgent', 'first'),
+        createHandoffAgent('SecondHandoffAgent', 'second'),
+      ],
+    });
+
+    expect(propertiesGetter).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[Agent] Warning: Handoff agents have different output types. Output type details are redacted. You can make it type-safe by using Agent.create({ ... }) method instead.',
+    );
+  });
+
   it('honors an explicit opt-out from handoff output type warnings', () => {
     const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
     vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(true);

--- a/packages/agents-core/test/agent.test.ts
+++ b/packages/agents-core/test/agent.test.ts
@@ -47,7 +47,7 @@ describe('Agent', () => {
     vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(true);
     const secret = 'SECRET_HANDOFF_OUTPUT_SCHEMA_123';
     const toJSON = vi.fn(() => ({ secret }));
-    const outputType = {
+    const handoffOutputType = {
       type: 'json_schema',
       name: 'SensitiveOutput',
       strict: true,
@@ -61,14 +61,14 @@ describe('Agent', () => {
     } as unknown as JsonSchemaDefinition;
     const handoffAgent = new Agent({
       name: 'HandoffAgent',
-      outputType: z.object({ value: z.string() }),
+      outputType: handoffOutputType,
     });
 
     expect(
       () =>
         new Agent({
           name: 'ParentAgent',
-          outputType,
+          outputType: 'text',
           handoffs: [handoffAgent],
           handoffOutputTypeWarningEnabled: true,
         }),
@@ -113,18 +113,52 @@ describe('Agent', () => {
     expect(warningCalls).toContain(handoffSecret);
   });
 
-  it('does not warn for the same handoff output type when model logging is disabled', () => {
+  it('does not warn for separately constructed equivalent schemas when model logging is disabled', () => {
     const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
     vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(true);
-    const outputType = z.object({ value: z.string() });
+    const parentToJSON = vi.fn(() => ({ type: 'object' }));
+    const handoffToJSON = vi.fn(() => ({ type: 'object' }));
+    const createOutputType = (toJSON: () => object) =>
+      ({
+        type: 'json_schema',
+        name: 'EquivalentOutput',
+        strict: true,
+        schema: {
+          type: 'object',
+          properties: { value: { type: 'string' } },
+          required: ['value'],
+          additionalProperties: false,
+        },
+        toJSON,
+      }) as unknown as JsonSchemaDefinition;
     const handoffAgent = new Agent({
       name: 'HandoffAgent',
-      outputType,
+      outputType: createOutputType(handoffToJSON),
     });
 
     new Agent({
       name: 'ParentAgent',
-      outputType,
+      outputType: createOutputType(parentToJSON),
+      handoffs: [handoffAgent],
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(parentToJSON).not.toHaveBeenCalled();
+    expect(handoffToJSON).not.toHaveBeenCalled();
+  });
+
+  it('does not warn for separately constructed equivalent Zod schemas when model logging is disabled', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(true);
+    const createOutputType = () => z.object({ value: z.string() });
+    const handoffAgent = new Agent({
+      name: 'HandoffAgent',
+      outputType: createOutputType(),
+    });
+
+    new Agent({
+      name: 'ParentAgent',
+      outputType: createOutputType(),
       handoffs: [handoffAgent],
     });
 

--- a/packages/agents-core/test/config.test.ts
+++ b/packages/agents-core/test/config.test.ts
@@ -92,4 +92,19 @@ describe('logging', () => {
     expect(logging.dontLogModelData).toBe(false);
     expect(logging.dontLogToolData).toBe(false);
   });
+
+  test.each(['false', 1, null, undefined, new Boolean(true)])(
+    'rejects non-boolean programmatic override %j and fails closed',
+    async (invalidValue) => {
+      const { logging, setSensitiveDataLoggingEnabled } =
+        await import('../src/config');
+      setSensitiveDataLoggingEnabled(true);
+
+      expect(() =>
+        setSensitiveDataLoggingEnabled(invalidValue as never),
+      ).toThrow(TypeError);
+      expect(logging.dontLogModelData).toBe(true);
+      expect(logging.dontLogToolData).toBe(true);
+    },
+  );
 });

--- a/packages/agents-core/test/config.test.ts
+++ b/packages/agents-core/test/config.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { logging } from '../src/config';
+
+const loggingFlagNames = [
+  'OPENAI_AGENTS_DONT_LOG_MODEL_DATA',
+  'OPENAI_AGENTS_DONT_LOG_TOOL_DATA',
+] as const;
+
+const originalLoggingFlags = Object.fromEntries(
+  loggingFlagNames.map((flagName) => [flagName, process.env[flagName]]),
+) as Record<(typeof loggingFlagNames)[number], string | undefined>;
+
+afterEach(() => {
+  for (const flagName of loggingFlagNames) {
+    const originalValue = originalLoggingFlags[flagName];
+    if (originalValue === undefined) {
+      delete process.env[flagName];
+    } else {
+      process.env[flagName] = originalValue;
+    }
+  }
+});
+
+describe('logging', () => {
+  test('does not log model or tool data by default', () => {
+    delete process.env.OPENAI_AGENTS_DONT_LOG_MODEL_DATA;
+    delete process.env.OPENAI_AGENTS_DONT_LOG_TOOL_DATA;
+
+    expect(logging.dontLogModelData).toBe(true);
+    expect(logging.dontLogToolData).toBe(true);
+  });
+
+  test.each(['0', 'false'])(
+    'enables sensitive data logging when the flags are %s',
+    (flagValue) => {
+      process.env.OPENAI_AGENTS_DONT_LOG_MODEL_DATA = flagValue;
+      process.env.OPENAI_AGENTS_DONT_LOG_TOOL_DATA = flagValue;
+
+      expect(logging.dontLogModelData).toBe(false);
+      expect(logging.dontLogToolData).toBe(false);
+    },
+  );
+
+  test.each(['1', 'true'])(
+    'disables sensitive data logging when the flags are %s',
+    (flagValue) => {
+      process.env.OPENAI_AGENTS_DONT_LOG_MODEL_DATA = flagValue;
+      process.env.OPENAI_AGENTS_DONT_LOG_TOOL_DATA = flagValue;
+
+      expect(logging.dontLogModelData).toBe(true);
+      expect(logging.dontLogToolData).toBe(true);
+    },
+  );
+});

--- a/packages/agents-core/test/config.test.ts
+++ b/packages/agents-core/test/config.test.ts
@@ -1,5 +1,4 @@
-import { afterEach, describe, expect, test } from 'vitest';
-import { logging } from '../src/config';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 const loggingFlagNames = [
   'OPENAI_AGENTS_DONT_LOG_MODEL_DATA',
@@ -11,6 +10,7 @@ const originalLoggingFlags = Object.fromEntries(
 ) as Record<(typeof loggingFlagNames)[number], string | undefined>;
 
 afterEach(() => {
+  vi.resetModules();
   for (const flagName of loggingFlagNames) {
     const originalValue = originalLoggingFlags[flagName];
     if (originalValue === undefined) {
@@ -22,9 +22,10 @@ afterEach(() => {
 });
 
 describe('logging', () => {
-  test('does not log model or tool data by default', () => {
+  test('does not log model or tool data by default', async () => {
     delete process.env.OPENAI_AGENTS_DONT_LOG_MODEL_DATA;
     delete process.env.OPENAI_AGENTS_DONT_LOG_TOOL_DATA;
+    const { logging } = await import('../src/config');
 
     expect(logging.dontLogModelData).toBe(true);
     expect(logging.dontLogToolData).toBe(true);
@@ -32,9 +33,10 @@ describe('logging', () => {
 
   test.each(['0', 'false'])(
     'enables sensitive data logging when the flags are %s',
-    (flagValue) => {
+    async (flagValue) => {
       process.env.OPENAI_AGENTS_DONT_LOG_MODEL_DATA = flagValue;
       process.env.OPENAI_AGENTS_DONT_LOG_TOOL_DATA = flagValue;
+      const { logging } = await import('../src/config');
 
       expect(logging.dontLogModelData).toBe(false);
       expect(logging.dontLogToolData).toBe(false);
@@ -43,12 +45,51 @@ describe('logging', () => {
 
   test.each(['1', 'true'])(
     'disables sensitive data logging when the flags are %s',
-    (flagValue) => {
+    async (flagValue) => {
       process.env.OPENAI_AGENTS_DONT_LOG_MODEL_DATA = flagValue;
       process.env.OPENAI_AGENTS_DONT_LOG_TOOL_DATA = flagValue;
+      const { logging } = await import('../src/config');
 
       expect(logging.dontLogModelData).toBe(true);
       expect(logging.dontLogToolData).toBe(true);
     },
   );
+
+  test.each(['', 'TRUE', 'False', 'yes', ' 0 '])(
+    'keeps sensitive data logging disabled for unrecognized value %j',
+    async (flagValue) => {
+      process.env.OPENAI_AGENTS_DONT_LOG_MODEL_DATA = flagValue;
+      process.env.OPENAI_AGENTS_DONT_LOG_TOOL_DATA = flagValue;
+      const { logging } = await import('../src/config');
+
+      expect(logging.dontLogModelData).toBe(true);
+      expect(logging.dontLogToolData).toBe(true);
+    },
+  );
+
+  test('supports a programmatic override when environment variables are unavailable', async () => {
+    delete process.env.OPENAI_AGENTS_DONT_LOG_MODEL_DATA;
+    delete process.env.OPENAI_AGENTS_DONT_LOG_TOOL_DATA;
+    const { logging, setSensitiveDataLoggingEnabled } =
+      await import('../src/config');
+
+    setSensitiveDataLoggingEnabled(true);
+    expect(logging.dontLogModelData).toBe(false);
+    expect(logging.dontLogToolData).toBe(false);
+
+    setSensitiveDataLoggingEnabled(false);
+    expect(logging.dontLogModelData).toBe(true);
+    expect(logging.dontLogToolData).toBe(true);
+  });
+
+  test('gives the programmatic override precedence over environment variables', async () => {
+    process.env.OPENAI_AGENTS_DONT_LOG_MODEL_DATA = '1';
+    process.env.OPENAI_AGENTS_DONT_LOG_TOOL_DATA = '1';
+    const { logging, setSensitiveDataLoggingEnabled } =
+      await import('../src/config');
+
+    setSensitiveDataLoggingEnabled(true);
+    expect(logging.dontLogModelData).toBe(false);
+    expect(logging.dontLogToolData).toBe(false);
+  });
 });

--- a/packages/agents-core/test/index.test.ts
+++ b/packages/agents-core/test/index.test.ts
@@ -12,6 +12,7 @@ describe('index.ts', () => {
     });
     expect(agent).toBeDefined();
     expect(agent.name).toEqual('TestAgent');
+    expect(typeof AgentsCore.setSensitiveDataLoggingEnabled).toBe('function');
   });
 
   test('does not expose sandbox exports from the top-level entry', () => {

--- a/packages/agents-core/test/logger.test.ts
+++ b/packages/agents-core/test/logger.test.ts
@@ -36,6 +36,39 @@ describe('logger', () => {
     expect(toolDataSpy).toHaveBeenCalledTimes(1);
   });
 
+  test('applies the programmatic sensitive data logging override to logger instances', async () => {
+    const { setSensitiveDataLoggingEnabled } = await import('../src/config');
+    const loggerModule = await import('../src/logger');
+    const targetLogger = loggerModule.getLogger('test');
+    const errorSpy = vi
+      .spyOn(targetLogger, 'error')
+      .mockImplementation(() => {});
+    const secret = 'SECRET_PROGRAMMATIC_LOG_OVERRIDE_123';
+    const error = new Error(secret);
+    const details = { secret };
+
+    setSensitiveDataLoggingEnabled(true);
+    loggerModule.logModelActionError(
+      targetLogger,
+      'Operation failed',
+      error,
+      details,
+    );
+    expect(errorSpy).toHaveBeenCalledWith('Operation failed', error, details);
+    expect(JSON.stringify(errorSpy.mock.calls)).toContain(secret);
+
+    errorSpy.mockClear();
+    setSensitiveDataLoggingEnabled(false);
+    loggerModule.logToolActionError(
+      targetLogger,
+      'Operation failed',
+      error,
+      details,
+    );
+    expect(errorSpy).toHaveBeenCalledWith('Operation failed', 'object');
+    expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(secret);
+  });
+
   test.each([
     ['tool', 'logToolActionError', 'dontLogToolData'],
     ['model', 'logModelActionError', 'dontLogModelData'],

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -3292,7 +3292,7 @@ describe('executeShellActions', () => {
         expect(res[0].output).toBe('Tool execution was not approved.');
       }
       expect(warnSpy).toHaveBeenCalledWith(
-        'toolErrorFormatter threw while formatting approval rejection: formatter failed',
+        'toolErrorFormatter threw while formatting approval rejection: object',
       );
       warnSpy.mockRestore();
     });

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -690,6 +690,12 @@ describe('ConsoleSpanExporter', () => {
   it('logs traces and spans when tracing is enabled', async () => {
     allowConsole(['log']);
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const modelDataSpy = vi
+      .spyOn(coreLogger, 'dontLogModelData', 'get')
+      .mockReturnValue(false);
+    const toolDataSpy = vi
+      .spyOn(coreLogger, 'dontLogToolData', 'get')
+      .mockReturnValue(false);
     const originalEnv = process.env.NODE_ENV;
     const originalDisableTracing = process.env.OPENAI_AGENTS_DISABLE_TRACING;
     process.env.NODE_ENV = 'production';
@@ -721,6 +727,8 @@ describe('ConsoleSpanExporter', () => {
     expect(messages.some((msg) => msg.includes('Export span'))).toBe(true);
 
     logSpy.mockRestore();
+    modelDataSpy.mockRestore();
+    toolDataSpy.mockRestore();
     process.env.NODE_ENV = originalEnv;
     if (typeof originalDisableTracing === 'undefined') {
       delete process.env.OPENAI_AGENTS_DISABLE_TRACING;
@@ -917,7 +925,7 @@ describe('BatchTraceProcessor', () => {
       expect(exportCalls).toBe(1);
       expect(errorSpy).toHaveBeenCalledWith(
         'Tracing exporter failed to export batch',
-        expect.any(Error),
+        'object',
       );
 
       await processor.onTraceStart(recovered);

--- a/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
+++ b/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
@@ -158,12 +158,7 @@ describe('TwilioRealtimeTransportLayer', () => {
     transport.on('error', errListener);
     twilio.emit('message', { toString: () => 'bad{' });
     expect(errListener).toHaveBeenCalled();
-    expect(errorSpy).toHaveBeenCalledWith(
-      'Error parsing message:',
-      expect.any(Error),
-      'Message:',
-      expect.any(Object),
-    );
+    expect(errorSpy).toHaveBeenCalledWith('Error parsing message:', 'object');
     errorSpy.mockRestore();
 
     twilio.emit('close');
@@ -364,7 +359,9 @@ describe('TwilioRealtimeTransportLayer', () => {
     twilio.emit('message', {
       toString: () => JSON.stringify({ event: 'mark', mark: { name: 'u:x' } }),
     });
-    expect(warnSpy).toHaveBeenCalledWith('Invalid mark name received:', 'u:x');
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Invalid mark name received. Mark data is redacted.',
+    );
 
     twilio.emit('message', {
       toString: () =>

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -3068,7 +3068,7 @@ describe('AiSdkModel.getResponse', () => {
       },
     ]);
     expect(warnSpy).toHaveBeenCalledWith(
-      "Received tool call for unknown tool 'foo'.",
+      'Received tool call for an unknown tool. Tool name is redacted.',
     );
     warnSpy.mockRestore();
   });
@@ -3243,7 +3243,7 @@ describe('AiSdkModel.getResponse', () => {
       ...resultProviderMetadata,
     });
     expect(warnSpy).toHaveBeenCalledWith(
-      "Received tool call for unknown tool 'foo'.",
+      'Received tool call for an unknown tool. Tool name is redacted.',
     );
     warnSpy.mockRestore();
   });

--- a/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
+++ b/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
@@ -583,7 +583,7 @@ describe('OpenAIResponsesCompactionSession', () => {
       expect(underlyingSession.addCalls).toBe(2);
       expect(warn).toHaveBeenCalledWith(
         'Restored previous session history after compaction replacement failed.',
-        expect.any(Error),
+        'object',
       );
     } finally {
       warn.mockRestore();
@@ -732,7 +732,7 @@ describe('OpenAIResponsesCompactionSession', () => {
       expect(underlyingSession.popCalls).toBe(0);
       expect(warn).toHaveBeenCalledWith(
         'Restored previous session history after compaction replacement failed.',
-        expect.any(Error),
+        'object',
       );
     } finally {
       warn.mockRestore();
@@ -812,7 +812,7 @@ describe('OpenAIResponsesCompactionSession', () => {
       expect(underlyingSession.addCalls).toBe(1);
       expect(warn).toHaveBeenCalledWith(
         'Restored previous session history after compaction replacement failed.',
-        expect.any(Error),
+        'object',
       );
     } finally {
       warn.mockRestore();
@@ -864,7 +864,7 @@ describe('OpenAIResponsesCompactionSession', () => {
       ).rejects.toThrow('replacement failed');
       expect(warn).toHaveBeenCalledWith(
         'Failed to restore session history after compaction replacement failed.',
-        expect.any(Error),
+        'object',
       );
       expect(underlyingSession.clearCalls).toBe(2);
       expect(underlyingSession.addCalls).toBe(2);

--- a/packages/agents-openai/test/openaiTracingExporter.test.ts
+++ b/packages/agents-openai/test/openaiTracingExporter.test.ts
@@ -1227,7 +1227,7 @@ describe('OpenAITracingExporter', () => {
     await exporter.export([item]);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(errorSpy).toHaveBeenCalledWith(
-      '[non-fatal] Tracing client error 400: bad',
+      '[non-fatal] Tracing client error 400. Response data is redacted.',
     );
     errorSpy.mockRestore();
   });

--- a/packages/agents-realtime/src/index.ts
+++ b/packages/agents-realtime/src/index.ts
@@ -84,6 +84,7 @@ export {
   FunctionTool,
   ModelBehaviorError,
   OutputGuardrailTripwireTriggered,
+  setSensitiveDataLoggingEnabled,
   tool,
   UserError,
 } from '@openai/agents-core';

--- a/packages/agents-realtime/test/index.test.ts
+++ b/packages/agents-realtime/test/index.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect } from 'vitest';
-import { RealtimeAgent, RealtimeSession } from '../src';
+import {
+  RealtimeAgent,
+  RealtimeSession,
+  setSensitiveDataLoggingEnabled,
+} from '../src';
 
 describe('RealtimeAgent', () => {
   test('should be available', () => {
@@ -20,5 +24,11 @@ describe('RealtimeSession', () => {
       }),
     );
     expect(session).toBeDefined();
+  });
+});
+
+describe('Sensitive data logging', () => {
+  test('exports the programmatic logging override', () => {
+    expect(typeof setSensitiveDataLoggingEnabled).toBe('function');
   });
 });

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -1020,7 +1020,7 @@ describe('RealtimeSession', () => {
     expect(invokeSpy).not.toHaveBeenCalled();
     expect(errorSpy).toHaveBeenCalledWith(
       'Error handling function call',
-      expect.any(Error),
+      'object',
     );
     errorSpy.mockRestore();
   });
@@ -1225,7 +1225,7 @@ describe('RealtimeSession', () => {
     expect(invokeSpy).toHaveBeenCalled();
     expect(errorSpy).toHaveBeenCalledWith(
       'Error handling function call',
-      expect.any(Error),
+      'object',
     );
     errorSpy.mockRestore();
   });
@@ -2094,7 +2094,7 @@ describe('RealtimeSession', () => {
     expect(startResponse).toBe(true);
     expect(invokeSpy).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalledWith(
-      'toolErrorFormatter threw while formatting approval rejection: formatter failed',
+      'toolErrorFormatter threw while formatting approval rejection: object',
     );
     warnSpy.mockRestore();
   });

--- a/packages/agents/test/index.test.ts
+++ b/packages/agents/test/index.test.ts
@@ -9,6 +9,7 @@ describe('Exports', () => {
   test('Agent is out there', () => {
     const agent = new Agents.Agent({ name: 'Test' });
     expect(agent.name).toBe('Test');
+    expect(typeof Agents.setSensitiveDataLoggingEnabled).toBe('function');
   });
 });
 


### PR DESCRIPTION
This pull request disables model and tool data logging when the corresponding environment variables are unset, aligning the next minor release with the Python SDK.

Setting `OPENAI_AGENTS_DONT_LOG_MODEL_DATA` or `OPENAI_AGENTS_DONT_LOG_TOOL_DATA` to `0` or `false` continues to explicitly enable sensitive data logging. Regression coverage and a minor changeset are included.

Documentation will be handled separately in a follow-up.