### PR TITLE
test: add published SDK behavior integration coverage

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -13,6 +13,8 @@ It is intentionally not part of the `pnpm` workspace and instead installs the pa
 - Run `pnpm exec playwright install` to install playwright
 - `pnpm test:integration` will create temporary `integration-tests/cloudflare-workers/worker/.dev.vars` and `integration-tests/vite-react/.env` files from `OPENAI_API_KEY` and restore any pre-existing files during cleanup
 - Integration test fixture subprocesses run with `NODE_ENV=development` so real-model SDK examples keep the normal server-runtime tracing behavior even though Vitest itself runs with `NODE_ENV=test`
+- The Node.js published SDK behavior fixture uses `OPENAI_AGENTS_INTEGRATION_MODEL` when set and defaults to `gpt-5.6`. Hosted multi-agent coverage uses `OPENAI_AGENTS_INTEGRATION_HOSTED_MODEL` and defaults to `gpt-5.6-sol`.
+- Hosted MCP coverage uses `OPENAI_AGENTS_INTEGRATION_MCP_SERVER_URL` when set and defaults to the public DeepWiki MCP endpoint. Hosted multi-agent is skipped with an explicit reason when the API project does not have beta access.
 - Optional sandbox storage mount coverage requires Docker with FUSE support and is skipped unless `OPENAI_AGENTS_RUN_STORAGE_MOUNT_INTEGRATION=1` is set. It starts local Azurite and MinIO containers and removes them after the test.
 
 2. **Local npm registry**
@@ -34,3 +36,12 @@ It is intentionally not part of the `pnpm` workspace and instead installs the pa
    ```bash
    pnpm test:integration
    ```
+
+   The published-package semantic profiles can also be run independently:
+
+   ```bash
+   pnpm test:integration:sdk-core
+   pnpm test:integration:sdk-capabilities
+   ```
+
+   The SDK core profile covers Responses behavior, structured output, delegation, approval/resume, conversation state, and tracing. The SDK capabilities profile covers guardrails, execution controls, Responses/Chat Completions parity, hosted tools, deferred tool search, programmatic tool calling, and hosted multi-agent caller identity.

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -14,7 +14,7 @@ It is intentionally not part of the `pnpm` workspace and instead installs the pa
 - `pnpm test:integration` will create temporary `integration-tests/cloudflare-workers/worker/.dev.vars` and `integration-tests/vite-react/.env` files from `OPENAI_API_KEY` and restore any pre-existing files during cleanup
 - Integration test fixture subprocesses run with `NODE_ENV=development` so real-model SDK examples keep the normal server-runtime tracing behavior even though Vitest itself runs with `NODE_ENV=test`
 - The Node.js published SDK behavior fixture uses `OPENAI_AGENTS_INTEGRATION_MODEL` when set and defaults to `gpt-5.6`. Hosted multi-agent coverage uses `OPENAI_AGENTS_INTEGRATION_HOSTED_MODEL` and defaults to `gpt-5.6-sol`.
-- Hosted MCP coverage uses `OPENAI_AGENTS_INTEGRATION_MCP_SERVER_URL` when set and defaults to the public DeepWiki MCP endpoint. Hosted multi-agent is skipped with an explicit reason when the API project does not have beta access.
+- Hosted MCP coverage uses `OPENAI_AGENTS_INTEGRATION_MCP_SERVER_URL` when set and defaults to the public DeepWiki MCP endpoint. Hosted multi-agent coverage requires API project access to the beta and fails when that access is unavailable.
 - Optional sandbox storage mount coverage requires Docker with FUSE support and is skipped unless `OPENAI_AGENTS_RUN_STORAGE_MOUNT_INTEGRATION=1` is set. It starts local Azurite and MinIO containers and removes them after the test.
 
 2. **Local npm registry**

--- a/integration-tests/node-sdk-behavior.test.ts
+++ b/integration-tests/node-sdk-behavior.test.ts
@@ -1,0 +1,34 @@
+import { rm } from 'node:fs/promises';
+
+import { beforeAll, describe, expect, test } from 'vitest';
+import { execa as execaBase } from 'execa';
+
+import { createIntegrationSubprocessEnv } from './_helpers/env';
+
+const fixtureDirectory = './integration-tests/node-sdk-behavior';
+const execa = execaBase({
+  cwd: fixtureDirectory,
+  env: createIntegrationSubprocessEnv(),
+});
+
+describe.sequential('Node.js published SDK behavior', () => {
+  beforeAll(async () => {
+    console.log('[node-sdk-behavior] Removing node_modules');
+    await rm(`${fixtureDirectory}/node_modules`, {
+      recursive: true,
+      force: true,
+    });
+    console.log('[node-sdk-behavior] Installing dependencies from Verdaccio');
+    await execa`npm install`;
+  }, 120_000);
+
+  test('core behavior profile', { timeout: 1_200_000 }, async () => {
+    const { stdout } = await execa`npm run test:core`;
+    expect(stdout).toContain('fail 0');
+  });
+
+  test('capability behavior profile', { timeout: 1_200_000 }, async () => {
+    const { stdout } = await execa`npm run test:capabilities`;
+    expect(stdout).toContain('fail 0');
+  });
+});

--- a/integration-tests/node-sdk-behavior/.npmrc
+++ b/integration-tests/node-sdk-behavior/.npmrc
@@ -1,0 +1,2 @@
+@openai:registry=http://localhost:4873
+package-lock=false

--- a/integration-tests/node-sdk-behavior/package.json
+++ b/integration-tests/node-sdk-behavior/package.json
@@ -1,0 +1,15 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "npm run test:core && npm run test:capabilities",
+    "test:core": "node --test --test-concurrency=1 test/core/*.test.mjs",
+    "test:capabilities": "node --test --test-concurrency=1 test/capabilities/*.test.mjs"
+  },
+  "dependencies": {
+    "@openai/agents": "latest",
+    "@openai/agents-openai": "latest",
+    "openai": "^6.46.0",
+    "zod": "^4.0.0"
+  }
+}

--- a/integration-tests/node-sdk-behavior/test/capabilities/execution-controls.test.mjs
+++ b/integration-tests/node-sdk-behavior/test/capabilities/execution-controls.test.mjs
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import OpenAI from 'openai';
+import {
+  Agent,
+  MaxTurnsExceededError,
+  OpenAIResponsesModel,
+  retryPolicies,
+  setTracingDisabled,
+  tool,
+} from '@openai/agents';
+import { z } from 'zod';
+
+import { createRunner, getToolOutputs, integrationModel } from '../helpers.mjs';
+
+setTracingDisabled(true);
+
+test('a model retry reaches the real API without duplicating session input', async () => {
+  const originalFetch = globalThis.fetch;
+  let attempts = 0;
+  const client = new OpenAI({
+    maxRetries: 0,
+    fetch: async (...args) => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new TypeError('Controlled integration transport failure.');
+      }
+      return originalFetch(...args);
+    },
+  });
+  const model = new OpenAIResponsesModel(client, integrationModel);
+  const agent = new Agent({
+    name: 'Published real retry agent',
+    model,
+    instructions: 'Reply exactly RETRY_RECOVERED.',
+    modelSettings: {
+      maxTokens: 256,
+      retry: {
+        maxRetries: 1,
+        backoff: {
+          initialDelayMs: 0,
+          maxDelayMs: 0,
+          multiplier: 1,
+          jitter: false,
+        },
+        policy: retryPolicies.networkError(),
+      },
+    },
+  });
+
+  const result = await createRunner().run(agent, 'Recover exactly once.');
+
+  assert.equal(attempts, 2);
+  assert.equal(result.finalOutput, 'RETRY_RECOVERED');
+  assert.equal(result.state.usage.requests, 2);
+});
+
+test('a pre-aborted run makes no model request or tool side effect', async () => {
+  let requests = 0;
+  let toolCalls = 0;
+  const client = new OpenAI({
+    maxRetries: 0,
+    fetch: async () => {
+      requests += 1;
+      throw new Error('The model request must not run.');
+    },
+  });
+  const sideEffect = tool({
+    name: 'side_effect',
+    description: 'Record a side effect.',
+    parameters: z.object({ value: z.string() }),
+    execute: async () => {
+      toolCalls += 1;
+      return 'done';
+    },
+  });
+  const agent = new Agent({
+    name: 'Published cancelled agent',
+    model: new OpenAIResponsesModel(client, integrationModel),
+    tools: [sideEffect],
+  });
+  const controller = new AbortController();
+  controller.abort(new Error('Controlled cancellation.'));
+
+  await assert.rejects(
+    createRunner().run(agent, 'Do work.', { signal: controller.signal }),
+    /abort|cancel/i,
+  );
+  assert.equal(requests, 0);
+  assert.equal(toolCalls, 0);
+});
+
+test('maxTurns preserves the completed tool side effect and resumable state', async () => {
+  const calls = [];
+  const checkpoint = tool({
+    name: 'checkpoint',
+    description: 'Record a deterministic checkpoint.',
+    parameters: z.object({ value: z.string() }),
+    execute: async ({ value }) => {
+      calls.push(value);
+      return 'CHECKPOINT_READY';
+    },
+  });
+  const agent = new Agent({
+    name: 'Published max-turn agent',
+    model: integrationModel,
+    instructions:
+      "Call checkpoint exactly once with value 'release', then reply exactly COMPLETE.",
+    tools: [checkpoint],
+    modelSettings: { maxTokens: 256, toolChoice: 'checkpoint' },
+  });
+
+  let caught;
+  try {
+    await createRunner().run(agent, 'Record the checkpoint.', { maxTurns: 1 });
+  } catch (error) {
+    caught = error;
+  }
+
+  assert.ok(caught instanceof MaxTurnsExceededError);
+  assert.deepEqual(calls, ['release']);
+  assert.ok(caught.state);
+  assert.equal(
+    getToolOutputs({ newItems: caught.state._generatedItems }).length,
+    1,
+  );
+  assert.equal(caught.state.usage.requests, 1);
+});

--- a/integration-tests/node-sdk-behavior/test/capabilities/guardrails.test.mjs
+++ b/integration-tests/node-sdk-behavior/test/capabilities/guardrails.test.mjs
@@ -1,0 +1,140 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  Agent,
+  InputGuardrailTripwireTriggered,
+  OutputGuardrailTripwireTriggered,
+  ToolCallError,
+  ToolGuardrailFunctionOutputFactory,
+  ToolInputGuardrailTripwireTriggered,
+  ToolOutputGuardrailTripwireTriggered,
+  defineToolInputGuardrail,
+  defineToolOutputGuardrail,
+  setTracingDisabled,
+  tool,
+} from '@openai/agents';
+import { z } from 'zod';
+
+import { createRunner, integrationModel } from '../helpers.mjs';
+
+setTracingDisabled(true);
+
+test('input and output guardrails preserve allow and tripwire behavior', async () => {
+  const inputGuardrail = {
+    name: 'deterministic input guardrail',
+    runInParallel: false,
+    execute: async ({ input }) => ({
+      outputInfo: { input },
+      tripwireTriggered: String(input).includes('BLOCK_INPUT'),
+    }),
+  };
+  const outputGuardrail = {
+    name: 'deterministic output guardrail',
+    execute: async ({ agentOutput }) => ({
+      outputInfo: { agentOutput },
+      tripwireTriggered: agentOutput === 'BLOCK_OUTPUT',
+    }),
+  };
+  const runner = createRunner();
+  const allowedAgent = new Agent({
+    name: 'Published guardrail allow agent',
+    model: integrationModel,
+    instructions: 'Reply exactly ALLOWED.',
+    inputGuardrails: [inputGuardrail],
+    outputGuardrails: [outputGuardrail],
+    modelSettings: { maxTokens: 128 },
+  });
+  const blockedOutputAgent = new Agent({
+    name: 'Published output guardrail block agent',
+    model: integrationModel,
+    instructions: 'Reply exactly BLOCK_OUTPUT.',
+    outputGuardrails: [outputGuardrail],
+    modelSettings: { maxTokens: 128 },
+  });
+
+  const allowed = await runner.run(allowedAgent, 'ALLOW_INPUT');
+  assert.equal(allowed.finalOutput, 'ALLOWED');
+  assert.equal(allowed.inputGuardrailResults.length, 1);
+  assert.equal(allowed.outputGuardrailResults.length, 1);
+
+  await assert.rejects(
+    runner.run(allowedAgent, 'BLOCK_INPUT'),
+    InputGuardrailTripwireTriggered,
+  );
+  await assert.rejects(
+    runner.run(blockedOutputAgent, 'ALLOW_INPUT'),
+    OutputGuardrailTripwireTriggered,
+  );
+});
+
+test('tool input and output guardrails run in order and fail fast', async () => {
+  const calls = [];
+  const order = [];
+  const inputGuardrail = defineToolInputGuardrail({
+    name: 'published tool input guardrail',
+    run: async ({ toolCall }) => {
+      order.push('input');
+      const { value } = JSON.parse(toolCall.arguments);
+      return value === 'blocked-input'
+        ? ToolGuardrailFunctionOutputFactory.throwException({ value })
+        : ToolGuardrailFunctionOutputFactory.allow({ value });
+    },
+  });
+  const outputGuardrail = defineToolOutputGuardrail({
+    name: 'published tool output guardrail',
+    run: async ({ output }) => {
+      order.push('output');
+      return output === 'blocked-output'
+        ? ToolGuardrailFunctionOutputFactory.throwException({ output })
+        : ToolGuardrailFunctionOutputFactory.allow({ output });
+    },
+  });
+  const guardedTool = tool({
+    name: 'guarded_action',
+    description: 'Return the supplied deterministic value.',
+    parameters: z.object({ value: z.string() }),
+    inputGuardrails: [inputGuardrail],
+    outputGuardrails: [outputGuardrail],
+    execute: async ({ value }) => {
+      order.push('execute');
+      calls.push(value);
+      return value;
+    },
+  });
+  const createAgent = (value) =>
+    new Agent({
+      name: `Published guarded tool agent ${value}`,
+      model: integrationModel,
+      instructions: `Call guarded_action exactly once with value '${value}', then reply exactly DONE.`,
+      tools: [guardedTool],
+      modelSettings: {
+        maxTokens: 256,
+        toolChoice: 'guarded_action',
+      },
+    });
+  const runner = createRunner();
+
+  const allowed = await runner.run(createAgent('allowed'), 'Run the action.');
+  assert.equal(allowed.finalOutput, 'DONE');
+  assert.deepEqual(order.splice(0), ['input', 'execute', 'output']);
+  assert.deepEqual(calls, ['allowed']);
+
+  await assert.rejects(
+    runner.run(createAgent('blocked-input'), 'Run the action.'),
+    (error) =>
+      error instanceof ToolCallError &&
+      error.error instanceof ToolInputGuardrailTripwireTriggered,
+  );
+  assert.deepEqual(order.splice(0), ['input']);
+  assert.deepEqual(calls, ['allowed']);
+
+  await assert.rejects(
+    runner.run(createAgent('blocked-output'), 'Run the action.'),
+    (error) =>
+      error instanceof ToolCallError &&
+      error.error instanceof ToolOutputGuardrailTripwireTriggered,
+  );
+  assert.deepEqual(order, ['input', 'execute', 'output']);
+  assert.deepEqual(calls, ['allowed', 'blocked-output']);
+});

--- a/integration-tests/node-sdk-behavior/test/capabilities/hosted-multi-agent.test.mjs
+++ b/integration-tests/node-sdk-behavior/test/capabilities/hosted-multi-agent.test.mjs
@@ -9,11 +9,11 @@ import {
 } from '@openai/agents-openai/experimental/hosted-multi-agent';
 import { z } from 'zod';
 
-import { createRunner, hostedModel, isBetaAccessError } from '../helpers.mjs';
+import { createRunner, hostedModel } from '../helpers.mjs';
 
 setTracingDisabled(true);
 
-test('hosted multi-agent preserves subagent tool caller identity', async (t) => {
+test('hosted multi-agent preserves subagent tool caller identity', async () => {
   const callers = new Set();
   const callIds = new Set();
   const inspectProposal = tool({
@@ -52,11 +52,6 @@ test('hosted multi-agent preserves subagent tool caller identity', async (t) => 
     assert.equal(callIds.size, 2);
     assert.ok(callers.size >= 2);
     assert.equal(callers.has('/root'), false);
-  } catch (error) {
-    if (isBetaAccessError(error)) {
-      return t.skip(`Hosted multi-agent beta is unavailable: ${error}`);
-    }
-    throw error;
   } finally {
     await model.close();
   }

--- a/integration-tests/node-sdk-behavior/test/capabilities/hosted-multi-agent.test.mjs
+++ b/integration-tests/node-sdk-behavior/test/capabilities/hosted-multi-agent.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import OpenAI from 'openai';
+import { Agent, setTracingDisabled, tool } from '@openai/agents';
+import {
+  OpenAIHostedMultiAgentModel,
+  getHostedAgentMetadata,
+} from '@openai/agents-openai/experimental/hosted-multi-agent';
+import { z } from 'zod';
+
+import { createRunner, hostedModel, isBetaAccessError } from '../helpers.mjs';
+
+setTracingDisabled(true);
+
+test('hosted multi-agent preserves subagent tool caller identity', async (t) => {
+  const callers = new Set();
+  const callIds = new Set();
+  const inspectProposal = tool({
+    name: 'inspect_proposal',
+    description: 'Return deterministic details for one proposal.',
+    parameters: z.object({ proposal: z.enum(['alpha', 'beta']) }),
+    execute: async ({ proposal }, _context, details) => {
+      const metadata = getHostedAgentMetadata(details);
+      callers.add(metadata?.agentName ?? '/root');
+      callIds.add(details?.toolCall?.callId);
+      return {
+        proposal,
+        estimatedWeeks: proposal === 'alpha' ? 6 : 8,
+      };
+    },
+  });
+  const model = new OpenAIHostedMultiAgentModel(new OpenAI(), hostedModel, {
+    maxConcurrentSubagents: 2,
+  });
+
+  try {
+    const agent = new Agent({
+      name: 'Published hosted coordinator',
+      model,
+      instructions:
+        'Create two subagents. Have one inspect proposal alpha and the other inspect proposal beta. Each subagent must call inspect_proposal before you compare them.',
+      tools: [inspectProposal],
+    });
+    const result = await createRunner().run(
+      agent,
+      'Compare proposal alpha and proposal beta.',
+      { maxTurns: 6 },
+    );
+
+    assert.ok(result.finalOutput);
+    assert.equal(callIds.size, 2);
+    assert.ok(callers.size >= 2);
+    assert.equal(callers.has('/root'), false);
+  } catch (error) {
+    if (isBetaAccessError(error)) {
+      return t.skip(`Hosted multi-agent beta is unavailable: ${error}`);
+    }
+    throw error;
+  } finally {
+    await model.close();
+  }
+});

--- a/integration-tests/node-sdk-behavior/test/capabilities/hosted-tools.test.mjs
+++ b/integration-tests/node-sdk-behavior/test/capabilities/hosted-tools.test.mjs
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  Agent,
+  RunState,
+  hostedMcpTool,
+  setTracingDisabled,
+  webSearchTool,
+} from '@openai/agents';
+
+import {
+  createRunner,
+  integrationModel,
+  mcpServerUrl,
+  normalizeText,
+} from '../helpers.mjs';
+
+setTracingDisabled(true);
+
+test('web search emits a provider-owned call item', async () => {
+  const agent = new Agent({
+    name: 'Published web search agent',
+    model: integrationModel,
+    instructions:
+      'Search the web before answering. Identify the organization that publishes the OpenAI Agents JS SDK, then answer with only OPENAI.',
+    tools: [webSearchTool()],
+    modelSettings: { maxTokens: 768, toolChoice: 'required' },
+  });
+
+  const result = await createRunner().run(
+    agent,
+    'Search for the official openai-agents-js GitHub repository publisher.',
+  );
+
+  assert.equal(normalizeText(result.finalOutput), 'OPENAI');
+  assert.ok(
+    result.newItems.some(
+      (item) =>
+        item.type === 'tool_call_item' &&
+        item.rawItem?.type === 'hosted_tool_call' &&
+        item.rawItem?.providerData?.type === 'web_search_call',
+    ),
+  );
+});
+
+test('hosted MCP lists and calls a trusted remote server', async () => {
+  const agent = new Agent({
+    name: 'Published hosted MCP agent',
+    model: integrationModel,
+    instructions:
+      'Use the DeepWiki MCP server to identify the main programming language of openai/openai-agents-js.',
+    tools: [
+      hostedMcpTool({
+        serverLabel: 'published_deepwiki',
+        serverUrl: mcpServerUrl,
+        allowedTools: ['ask_question'],
+        requireApproval: 'never',
+      }),
+    ],
+    modelSettings: { maxTokens: 768, toolChoice: 'required' },
+  });
+
+  const result = await createRunner().run(
+    agent,
+    'Which language is the openai/openai-agents-js repository mainly written in?',
+    { maxTurns: 5 },
+  );
+
+  assert.match(String(result.finalOutput), /typescript/i);
+  assert.ok(
+    result.newItems.some(
+      (item) =>
+        item.type === 'tool_call_item' &&
+        item.rawItem?.type === 'hosted_tool_call' &&
+        item.rawItem?.providerData?.type === 'mcp_list_tools',
+    ),
+  );
+  assert.ok(
+    result.newItems.some(
+      (item) =>
+        item.type === 'tool_call_item' &&
+        item.rawItem?.type === 'hosted_tool_call' &&
+        item.rawItem?.providerData?.type === 'mcp_call',
+    ),
+  );
+});
+
+test('hosted MCP approval survives serialized pause and resume', async () => {
+  const agent = new Agent({
+    name: 'Published hosted MCP approval agent',
+    model: integrationModel,
+    instructions:
+      'Use ask_question from DeepWiki to answer the repository language question.',
+    tools: [
+      hostedMcpTool({
+        serverLabel: 'published_mcp_approval',
+        serverUrl: mcpServerUrl,
+        allowedTools: ['ask_question'],
+        requireApproval: 'always',
+      }),
+    ],
+    modelSettings: { maxTokens: 768, toolChoice: 'required' },
+  });
+  const first = await createRunner().run(
+    agent,
+    'Which language is the openai/openai-agents-js repository mainly written in?',
+    { maxTurns: 6 },
+  );
+
+  assert.equal(first.interruptions?.length, 1);
+  assert.ok(
+    first.newItems.some(
+      (item) =>
+        item.type === 'tool_approval_item' &&
+        item.rawItem?.type === 'hosted_tool_call' &&
+        item.rawItem?.providerData?.type === 'mcp_approval_request',
+    ),
+  );
+
+  const restored = await RunState.fromString(agent, first.state.toString());
+  restored.approve(restored.getInterruptions()[0]);
+  const resumed = await createRunner({
+    modelSettings: { toolChoice: 'auto' },
+  }).run(agent, restored, { maxTurns: 6 });
+
+  assert.match(String(resumed.finalOutput), /typescript/i);
+  assert.ok(
+    resumed.newItems.some(
+      (item) =>
+        item.rawItem?.type === 'hosted_tool_call' &&
+        item.rawItem?.name === 'mcp_approval_response',
+    ),
+  );
+});

--- a/integration-tests/node-sdk-behavior/test/capabilities/programmatic-tool-calling.test.mjs
+++ b/integration-tests/node-sdk-behavior/test/capabilities/programmatic-tool-calling.test.mjs
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  Agent,
+  programmaticToolCallingTool,
+  setTracingDisabled,
+  tool,
+} from '@openai/agents';
+import { z } from 'zod';
+
+import { createRunner, integrationModel } from '../helpers.mjs';
+
+setTracingDisabled(true);
+
+test('programmatic tool calling retains program-owned calls and output', async () => {
+  const calls = [];
+  const inventoryOutput = z.object({ units: z.number().int() });
+  const readInventory = tool({
+    name: 'read_inventory',
+    description: 'Return deterministic available units for one item.',
+    parameters: z.object({ sku: z.enum(['alpha', 'beta']) }),
+    outputSchema: inventoryOutput,
+    allowedCallers: ['programmatic'],
+    execute: async ({ sku }) => {
+      calls.push(sku);
+      return { units: sku === 'alpha' ? 7 : 11 };
+    },
+  });
+  const agent = new Agent({
+    name: 'Published programmatic tool agent',
+    model: integrationModel,
+    instructions:
+      "Use Programmatic Tool Calling. Generate a JavaScript program that calls read_inventory for 'alpha' and 'beta' with Promise.all, adds their units, and returns the result. Then answer exactly TOTAL:18.",
+    tools: [readInventory, programmaticToolCallingTool()],
+    modelSettings: {
+      maxTokens: 1024,
+      toolChoice: 'programmatic_tool_calling',
+    },
+  });
+
+  const result = await createRunner().run(
+    agent,
+    'Calculate the total inventory.',
+    { maxTurns: 5 },
+  );
+  const functionCalls = result.newItems.filter(
+    (item) =>
+      item.type === 'tool_call_item' &&
+      item.rawItem?.type === 'function_call' &&
+      item.rawItem?.caller?.type === 'program',
+  );
+
+  assert.deepEqual(calls.sort(), ['alpha', 'beta']);
+  assert.equal(functionCalls.length, 2);
+  assert.ok(
+    result.newItems.some(
+      (item) =>
+        item.type === 'tool_call_item' && item.rawItem?.type === 'program',
+    ),
+  );
+  assert.ok(
+    result.newItems.some(
+      (item) =>
+        item.type === 'tool_call_output_item' &&
+        item.rawItem?.type === 'program_output',
+    ),
+  );
+  assert.equal(result.finalOutput, 'TOTAL:18');
+});

--- a/integration-tests/node-sdk-behavior/test/capabilities/provider-parity.test.mjs
+++ b/integration-tests/node-sdk-behavior/test/capabilities/provider-parity.test.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import OpenAI from 'openai';
+import {
+  Agent,
+  OpenAIChatCompletionsModel,
+  OpenAIResponsesModel,
+  setTracingDisabled,
+  tool,
+} from '@openai/agents';
+import { z } from 'zod';
+
+import {
+  createRunner,
+  getToolCalls,
+  getToolOutputs,
+  integrationModel,
+} from '../helpers.mjs';
+
+setTracingDisabled(true);
+
+const client = new OpenAI();
+const providers = [
+  [
+    'Responses',
+    new OpenAIResponsesModel(client, integrationModel),
+    { maxTokens: 512 },
+  ],
+  [
+    'Chat Completions',
+    new OpenAIChatCompletionsModel(client, integrationModel),
+    {
+      reasoning: { effort: 'none' },
+      providerData: {
+        max_completion_tokens: 512,
+      },
+    },
+  ],
+];
+
+for (const [providerName, model, providerSettings] of providers) {
+  test(`${providerName} preserves function tool calls and usage`, async () => {
+    const calls = [];
+    const packageStatus = tool({
+      name: 'package_status',
+      description: 'Return a deterministic package status.',
+      parameters: z.object({ packageName: z.string() }),
+      execute: async ({ packageName }) => {
+        calls.push(packageName);
+        return 'ready';
+      },
+    });
+    const agent = new Agent({
+      name: `Published ${providerName} tool agent`,
+      model,
+      instructions:
+        "Call package_status exactly once with packageName 'openai-agents', then reply exactly PROVIDER_READY.",
+      tools: [packageStatus],
+      modelSettings: {
+        ...providerSettings,
+        toolChoice: 'package_status',
+      },
+    });
+
+    const result = await createRunner().run(agent, 'Check the package.');
+
+    assert.deepEqual(calls, ['openai-agents']);
+    assert.equal(result.finalOutput, 'PROVIDER_READY');
+    assert.equal(getToolCalls(result, 'package_status').length, 1);
+    assert.equal(getToolOutputs(result).length, 1);
+    assert.ok(result.state.usage.totalTokens > 0);
+  });
+
+  test(`${providerName} preserves structured output`, async () => {
+    const outputType = z.object({
+      status: z.literal('STRUCTURED_READY'),
+      checkpoints: z.array(z.number().int()),
+    });
+    const agent = new Agent({
+      name: `Published ${providerName} structured agent`,
+      model,
+      instructions: 'Return status STRUCTURED_READY and checkpoints [2, 4, 8].',
+      outputType,
+      modelSettings: providerSettings,
+    });
+
+    const result = await createRunner().run(
+      agent,
+      'Return the requested structured status.',
+    );
+
+    assert.deepEqual(result.finalOutput, {
+      status: 'STRUCTURED_READY',
+      checkpoints: [2, 4, 8],
+    });
+    assert.ok(result.state.usage.totalTokens > 0);
+  });
+}

--- a/integration-tests/node-sdk-behavior/test/capabilities/tool-search.test.mjs
+++ b/integration-tests/node-sdk-behavior/test/capabilities/tool-search.test.mjs
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  Agent,
+  setTracingDisabled,
+  tool,
+  toolNamespace,
+  toolSearchTool,
+} from '@openai/agents';
+import { z } from 'zod';
+
+import {
+  createRunner,
+  getToolCalls,
+  getToolOutputs,
+  integrationModel,
+} from '../helpers.mjs';
+
+setTracingDisabled(true);
+
+test('tool search loads and executes a deferred namespaced tool', async () => {
+  const calls = [];
+  const lookupCustomer = tool({
+    name: 'lookup_customer',
+    description: 'Find a customer release readiness status.',
+    parameters: z.object({ customerId: z.string() }),
+    deferLoading: true,
+    execute: async ({ customerId }) => {
+      calls.push(customerId);
+      return 'READY';
+    },
+  });
+  const namespaced = toolNamespace({
+    name: 'customer_support',
+    description: 'Look up customer release readiness and support records.',
+    tools: [lookupCustomer],
+  });
+  const agent = new Agent({
+    name: 'Published deferred tool search agent',
+    model: integrationModel,
+    instructions:
+      "Find the customer support tool, call lookup_customer with customerId 'customer-42', then reply exactly SEARCH_READY.",
+    tools: [...namespaced, toolSearchTool()],
+    modelSettings: { maxTokens: 768, parallelToolCalls: false },
+  });
+
+  const result = await createRunner().run(
+    agent,
+    'Find and run the deferred customer lookup.',
+    { maxTurns: 5 },
+  );
+
+  assert.deepEqual(calls, ['customer-42']);
+  assert.equal(result.finalOutput, 'SEARCH_READY');
+  assert.ok(
+    result.newItems.some((item) => item.type === 'tool_search_call_item'),
+  );
+  assert.ok(
+    result.newItems.some((item) => item.type === 'tool_search_output_item'),
+  );
+  assert.equal(getToolCalls(result).length >= 1, true);
+  assert.equal(getToolOutputs(result).length >= 1, true);
+});
+
+test('tool search routes identical names by namespace without collisions', async () => {
+  const calls = [];
+  const billingLookup = tool({
+    name: 'lookup',
+    description: 'Look up customer billing status.',
+    parameters: z.object({ customerId: z.string() }),
+    deferLoading: true,
+    execute: async ({ customerId }) => {
+      calls.push(`billing:${customerId}`);
+      return 'BILLING_READY';
+    },
+  });
+  const shippingLookup = tool({
+    name: 'lookup',
+    description: 'Look up customer package shipping status.',
+    parameters: z.object({ customerId: z.string() }),
+    deferLoading: true,
+    execute: async ({ customerId }) => {
+      calls.push(`shipping:${customerId}`);
+      return 'SHIPPING_READY';
+    },
+  });
+  const agent = new Agent({
+    name: 'Published namespaced tool routing agent',
+    model: integrationModel,
+    instructions:
+      "Find the shipping namespace tool named lookup and call it exactly once with customerId 'customer-42'. Do not use billing. Reply exactly SHIPPING_READY.",
+    tools: [
+      ...toolNamespace({
+        name: 'billing',
+        description: 'Billing records.',
+        tools: [billingLookup],
+      }),
+      ...toolNamespace({
+        name: 'shipping',
+        description: 'Package shipping records.',
+        tools: [shippingLookup],
+      }),
+      toolSearchTool(),
+    ],
+    modelSettings: { maxTokens: 768, parallelToolCalls: false },
+  });
+
+  const result = await createRunner().run(
+    agent,
+    "Check the customer's shipping status.",
+    { maxTurns: 5 },
+  );
+
+  assert.deepEqual(calls, ['shipping:customer-42']);
+  assert.equal(result.finalOutput, 'SHIPPING_READY');
+});

--- a/integration-tests/node-sdk-behavior/test/core/delegation.test.mjs
+++ b/integration-tests/node-sdk-behavior/test/core/delegation.test.mjs
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { Agent, handoff, setTracingDisabled, tool } from '@openai/agents';
+import { z } from 'zod';
+
+import {
+  createRunner,
+  getToolCalls,
+  getToolOutputs,
+  hasRawModelEvent,
+  integrationModel,
+  runAgent,
+} from '../helpers.mjs';
+
+setTracingDisabled(true);
+
+for (const stream of [false, true]) {
+  test(`handoffs preserve the active agent and tool ownership (${stream ? 'streaming' : 'non-streaming'})`, async () => {
+    const calls = [];
+    const lookupTicket = tool({
+      name: 'lookup_ticket',
+      description: 'Return the deterministic status for a support ticket.',
+      parameters: z.object({ ticket: z.string() }),
+      execute: async ({ ticket }) => {
+        calls.push(ticket);
+        return 'resolved';
+      },
+    });
+    const specialist = new Agent({
+      name: 'Published support specialist',
+      model: integrationModel,
+      instructions:
+        "Call lookup_ticket exactly once with ticket 'CASE-42', then answer exactly HANDOFF_RESOLVED.",
+      tools: [lookupTicket],
+      modelSettings: { maxTokens: 512 },
+    });
+    const coordinator = new Agent({
+      name: 'Published handoff coordinator',
+      model: integrationModel,
+      instructions:
+        'Immediately transfer this support ticket to the support specialist.',
+      handoffs: [handoff(specialist)],
+      modelSettings: {
+        maxTokens: 512,
+        toolChoice: 'transfer_to_Published_support_specialist',
+      },
+    });
+    const executed = await runAgent(
+      createRunner(),
+      coordinator,
+      'Resolve support ticket CASE-42.',
+      { stream },
+    );
+    const result = stream ? executed.result : executed;
+    const callsBySpecialist = getToolCalls(result, 'lookup_ticket').filter(
+      (item) => item.agent === specialist,
+    );
+    const outputsBySpecialist = getToolOutputs(result).filter(
+      (item) => item.agent === specialist,
+    );
+
+    assert.deepEqual(calls, ['CASE-42']);
+    assert.equal(result.finalOutput, 'HANDOFF_RESOLVED');
+    assert.equal(result.lastAgent, specialist);
+    assert.equal(callsBySpecialist.length, 1);
+    assert.equal(outputsBySpecialist.length, 1);
+    if (stream) {
+      assert.ok(hasRawModelEvent(executed.events));
+      assert.ok(
+        executed.events.some(
+          (event) => event.type === 'agent_updated_stream_event',
+        ),
+      );
+    }
+  });
+}
+
+test('an agent exposed as a tool returns through the outer agent', async () => {
+  const worker = new Agent({
+    name: 'Published nested worker',
+    model: integrationModel,
+    instructions: 'Reply with exactly INNER:42.',
+    modelSettings: { maxTokens: 256 },
+  });
+  const coordinator = new Agent({
+    name: 'Published nested coordinator',
+    model: integrationModel,
+    instructions:
+      'Call ask_worker exactly once. After it returns, reply exactly OUTER:42.',
+    tools: [
+      worker.asTool({
+        toolName: 'ask_worker',
+        toolDescription: 'Ask the worker for the deterministic answer.',
+      }),
+    ],
+    modelSettings: { maxTokens: 512, toolChoice: 'ask_worker' },
+  });
+
+  const result = await createRunner().run(
+    coordinator,
+    'Use the nested worker.',
+  );
+
+  assert.equal(result.finalOutput, 'OUTER:42');
+  assert.equal(result.lastAgent, coordinator);
+  assert.equal(getToolCalls(result, 'ask_worker').length, 1);
+  assert.equal(getToolOutputs(result).length, 1);
+});

--- a/integration-tests/node-sdk-behavior/test/core/responses.test.mjs
+++ b/integration-tests/node-sdk-behavior/test/core/responses.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { Agent, setTracingDisabled, tool } from '@openai/agents';
+import { z } from 'zod';
+
+import {
+  assertInstalledPackageBoundary,
+  createRunner,
+  getToolCalls,
+  getToolOutputs,
+  hasRawModelEvent,
+  integrationModel,
+  runAgent,
+} from '../helpers.mjs';
+
+setTracingDisabled(true);
+
+test('loads the SDK from the Verdaccio-installed package', () => {
+  assertInstalledPackageBoundary();
+});
+
+for (const stream of [false, true]) {
+  test(`Responses function tools preserve calls, outputs, and usage (${stream ? 'streaming' : 'non-streaming'})`, async () => {
+    const calls = [];
+    const doubleNumber = tool({
+      name: 'double_number',
+      description: 'Double the supplied number.',
+      parameters: z.object({ value: z.number().int() }),
+      execute: async ({ value }) => {
+        calls.push(value);
+        return value * 2;
+      },
+    });
+    const agent = new Agent({
+      name: 'Published Responses tool agent',
+      model: integrationModel,
+      instructions:
+        'Call double_number exactly once with value 21, then reply exactly RESULT:42.',
+      tools: [doubleNumber],
+      modelSettings: { maxTokens: 512 },
+    });
+    const runner = createRunner();
+    const executed = await runAgent(runner, agent, 'Use the tool now.', {
+      stream,
+    });
+    const result = stream ? executed.result : executed;
+
+    assert.deepEqual(calls, [21]);
+    assert.equal(result.finalOutput, 'RESULT:42');
+    assert.equal(getToolCalls(result, 'double_number').length, 1);
+    assert.equal(getToolOutputs(result).length, 1);
+    assert.ok(result.state.usage.totalTokens > 0);
+    if (stream) {
+      assert.ok(hasRawModelEvent(executed.events));
+    }
+  });
+}
+
+test('Responses structured output is parsed by the installed package', async () => {
+  const statusSchema = z.object({
+    status: z.literal('READY'),
+    value: z.literal(42),
+    note: z.null(),
+  });
+  const agent = new Agent({
+    name: 'Published structured output agent',
+    model: integrationModel,
+    instructions: 'Return status READY, value 42, and note null.',
+    outputType: statusSchema,
+    modelSettings: { maxTokens: 256 },
+  });
+
+  const result = await createRunner().run(
+    agent,
+    'Return the requested structured result.',
+  );
+
+  assert.deepEqual(result.finalOutput, {
+    status: 'READY',
+    value: 42,
+    note: null,
+  });
+  assert.ok(result.state.usage.totalTokens > 0);
+});

--- a/integration-tests/node-sdk-behavior/test/core/state.test.mjs
+++ b/integration-tests/node-sdk-behavior/test/core/state.test.mjs
@@ -1,0 +1,163 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  Agent,
+  MemorySession,
+  OpenAIConversationsSession,
+  RunState,
+  setTracingDisabled,
+  tool,
+} from '@openai/agents';
+import { z } from 'zod';
+
+import {
+  createRunner,
+  getToolOutputs,
+  integrationModel,
+  normalizeText,
+} from '../helpers.mjs';
+
+setTracingDisabled(true);
+
+for (const approved of [false, true]) {
+  test(`tool approval survives serialized state and ${approved ? 'approval' : 'rejection'}`, async () => {
+    const calls = [];
+    const performAction = tool({
+      name: 'perform_action',
+      description: 'Perform the deterministic action after explicit approval.',
+      parameters: z.object({ action: z.string() }),
+      needsApproval: true,
+      execute: async ({ action }) => {
+        calls.push(action);
+        return 'completed';
+      },
+    });
+    const agent = new Agent({
+      name: 'Published approval agent',
+      model: integrationModel,
+      instructions:
+        'Call perform_action with action "deploy". If it succeeds reply exactly APPROVED. If it is rejected reply exactly REJECTED.',
+      tools: [performAction],
+      modelSettings: { maxTokens: 512, toolChoice: 'perform_action' },
+    });
+    const runner = createRunner();
+    const first = await runner.run(agent, 'Perform the deployment.');
+
+    assert.equal(first.interruptions?.length, 1);
+    assert.equal(first.interruptions[0].name, 'perform_action');
+
+    const restored = await RunState.fromString(agent, first.state.toString());
+    const interruption = restored.getInterruptions()[0];
+    if (approved) {
+      restored.approve(interruption);
+    } else {
+      restored.reject(interruption, {
+        message: 'The operator rejected deploy.',
+      });
+    }
+
+    const resumed = await runner.run(agent, restored);
+
+    assert.deepEqual(calls, approved ? ['deploy'] : []);
+    assert.equal(resumed.finalOutput, approved ? 'APPROVED' : 'REJECTED');
+    assert.ok(getToolOutputs(resumed).length >= 1);
+  });
+}
+
+test('MemorySession continues without repeating a completed tool call', async () => {
+  const calls = [];
+  const lookupCodeword = tool({
+    name: 'lookup_codeword',
+    description: 'Return a deterministic verification codeword.',
+    parameters: z.object({ label: z.string() }),
+    execute: async ({ label }) => {
+      calls.push(label);
+      return 'MARIGOLD';
+    },
+  });
+  const agent = new Agent({
+    name: 'Published memory session agent',
+    model: integrationModel,
+    instructions:
+      'Use lookup_codeword when explicitly asked. Remember its result for later turns.',
+    tools: [lookupCodeword],
+    modelSettings: { maxTokens: 384 },
+  });
+  const session = new MemorySession();
+  const runner = createRunner();
+
+  const first = await runner.run(
+    agent,
+    "Call lookup_codeword with label 'release' and reply only STORED.",
+    { session },
+  );
+  const second = await runner.run(
+    agent,
+    'What exact codeword did the tool return? Reply with only that word.',
+    { session },
+  );
+  const savedItems = await session.getItems();
+
+  assert.equal(first.finalOutput, 'STORED');
+  assert.equal(normalizeText(second.finalOutput), 'MARIGOLD');
+  assert.deepEqual(calls, ['release']);
+  assert.ok(savedItems.some((item) => item.type === 'function_call_result'));
+});
+
+test('previousResponseId continues server-managed response state', async () => {
+  const agent = new Agent({
+    name: 'Published previous response agent',
+    model: integrationModel,
+    instructions: 'Follow the requested exact output format.',
+    modelSettings: { maxTokens: 256 },
+  });
+  const runner = createRunner();
+  const first = await runner.run(
+    agent,
+    'Remember that the verification word is ORCHID. Reply only STORED.',
+  );
+
+  assert.ok(first.lastResponseId);
+
+  const second = await runner.run(
+    agent,
+    'What verification word did I ask you to remember? Reply with only that word.',
+    { previousResponseId: first.lastResponseId },
+  );
+
+  assert.equal(normalizeText(second.finalOutput), 'ORCHID');
+  assert.notEqual(second.lastResponseId, first.lastResponseId);
+});
+
+test('OpenAIConversationsSession persists and cleans up remote state', async () => {
+  const agent = new Agent({
+    name: 'Published Conversations session agent',
+    model: integrationModel,
+    instructions:
+      'Remember user-provided values and answer exactly as requested.',
+    modelSettings: { maxTokens: 256 },
+  });
+  const session = new OpenAIConversationsSession();
+  const runner = createRunner();
+
+  try {
+    const first = await runner.run(
+      agent,
+      'Remember that the release number is 907. Reply only STORED.',
+      { session },
+    );
+    const conversationId = await session.getSessionId();
+    const second = await runner.run(
+      agent,
+      'What release number did I provide? Reply with only the number.',
+      { session },
+    );
+
+    assert.equal(first.finalOutput, 'STORED');
+    assert.match(conversationId, /^conv_/);
+    assert.equal(String(second.finalOutput).trim(), '907');
+  } finally {
+    await session.clearSession();
+  }
+});

--- a/integration-tests/node-sdk-behavior/test/core/tracing.test.mjs
+++ b/integration-tests/node-sdk-behavior/test/core/tracing.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  Agent,
+  Runner,
+  setTraceProcessors,
+  setTracingDisabled,
+  tool,
+} from '@openai/agents';
+import { z } from 'zod';
+
+import { integrationModel } from '../helpers.mjs';
+
+class CollectingTraceProcessor {
+  tracesStarted = [];
+  tracesEnded = [];
+  spansStarted = [];
+  spansEnded = [];
+
+  async onTraceStart(trace) {
+    this.tracesStarted.push(trace);
+  }
+
+  async onTraceEnd(trace) {
+    this.tracesEnded.push(trace);
+  }
+
+  async onSpanStart(span) {
+    this.spansStarted.push(span);
+  }
+
+  async onSpanEnd(span) {
+    this.spansEnded.push(span);
+  }
+
+  async shutdown() {}
+
+  async forceFlush() {}
+}
+
+test('live spans finish without exposing sensitive model or tool data', async () => {
+  const calls = [];
+  const inspectSecret = tool({
+    name: 'inspect_secret',
+    description: 'Inspect a deterministic sensitive verification value.',
+    parameters: z.object({ value: z.string() }),
+    execute: async ({ value }) => {
+      calls.push(value);
+      return 'TRACE_READY';
+    },
+  });
+  const agent = new Agent({
+    name: 'Published traced agent',
+    model: integrationModel,
+    instructions:
+      "Call inspect_secret with value 'secret-token-42', then reply exactly TRACE_READY.",
+    tools: [inspectSecret],
+    modelSettings: { maxTokens: 384, toolChoice: 'inspect_secret' },
+  });
+  const processor = new CollectingTraceProcessor();
+  setTraceProcessors([processor]);
+  setTracingDisabled(false);
+
+  let result;
+  try {
+    result = await new Runner({
+      tracingDisabled: false,
+      traceIncludeSensitiveData: false,
+      workflowName: 'Published tracing compatibility',
+    }).run(agent, 'Inspect the secret.');
+  } finally {
+    setTraceProcessors([]);
+    setTracingDisabled(true);
+  }
+
+  assert.deepEqual(calls, ['secret-token-42']);
+  assert.equal(result.finalOutput, 'TRACE_READY');
+  assert.equal(processor.tracesStarted.length, 1);
+  assert.equal(processor.tracesEnded.length, 1);
+  assert.equal(processor.spansStarted.length, processor.spansEnded.length);
+  assert.ok(processor.spansEnded.length > 0);
+  assert.ok(processor.spansEnded.every((span) => span.endedAt !== null));
+
+  const spanTypes = new Set(
+    processor.spansEnded.map((span) => span.spanData.type),
+  );
+  assert.ok(spanTypes.has('agent'));
+  assert.ok(spanTypes.has('response'));
+  assert.ok(spanTypes.has('function'));
+  assert.ok(
+    processor.spansEnded.every(
+      (span) => !JSON.stringify(span.toJSON()).includes('secret-token-42'),
+    ),
+  );
+});

--- a/integration-tests/node-sdk-behavior/test/helpers.mjs
+++ b/integration-tests/node-sdk-behavior/test/helpers.mjs
@@ -65,15 +65,3 @@ export function normalizeText(value) {
     .trim()
     .toUpperCase();
 }
-
-export function isBetaAccessError(error) {
-  const status = error?.status ?? error?.cause?.status;
-  const message = String(error?.message ?? error);
-  return (
-    status === 403 ||
-    status === 404 ||
-    /beta|hosted multi-agent|hosted multi agent|not (?:enabled|available)|access/i.test(
-      message,
-    )
-  );
-}

--- a/integration-tests/node-sdk-behavior/test/helpers.mjs
+++ b/integration-tests/node-sdk-behavior/test/helpers.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+
+import { Runner } from '@openai/agents';
+
+export const integrationModel =
+  process.env.OPENAI_AGENTS_INTEGRATION_MODEL ?? 'gpt-5.6';
+
+export const hostedModel =
+  process.env.OPENAI_AGENTS_INTEGRATION_HOSTED_MODEL ?? 'gpt-5.6-sol';
+
+export const mcpServerUrl =
+  process.env.OPENAI_AGENTS_INTEGRATION_MCP_SERVER_URL ??
+  'https://mcp.deepwiki.com/mcp';
+
+export function assertInstalledPackageBoundary() {
+  const resolved = import.meta.resolve('@openai/agents');
+  assert.match(resolved, /node_modules\/@openai\/agents\/dist\/index\.mjs$/);
+  assert.doesNotMatch(resolved, /packages\/agents\/src/);
+}
+
+export function createRunner(config = {}) {
+  return new Runner({
+    tracingDisabled: true,
+    ...config,
+  });
+}
+
+export async function runAgent(runner, agent, input, options = {}) {
+  const { stream = false, ...runOptions } = options;
+  if (!stream) {
+    return runner.run(agent, input, runOptions);
+  }
+
+  const result = await runner.run(agent, input, {
+    ...runOptions,
+    stream: true,
+  });
+  const events = [];
+  for await (const event of result) {
+    events.push(event);
+  }
+  return { result, events };
+}
+
+export function getToolCalls(result, name) {
+  return result.newItems.filter(
+    (item) =>
+      item.type === 'tool_call_item' &&
+      (name === undefined || item.rawItem?.name === name),
+  );
+}
+
+export function getToolOutputs(result) {
+  return result.newItems.filter(
+    (item) => item.type === 'tool_call_output_item',
+  );
+}
+
+export function hasRawModelEvent(events) {
+  return events.some((event) => event.type === 'raw_model_stream_event');
+}
+
+export function normalizeText(value) {
+  return String(value ?? '')
+    .trim()
+    .toUpperCase();
+}
+
+export function isBetaAccessError(error) {
+  const status = error?.status ?? error?.cause?.status;
+  const message = String(error?.message ?? error);
+  return (
+    status === 403 ||
+    status === 404 ||
+    /beta|hosted multi-agent|hosted multi agent|not (?:enabled|available)|access/i.test(
+      message,
+    )
+  );
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "test:coverage": "NODE_ENV=test vitest run --coverage",
     "test:examples": "pnpm -r build-check",
     "test:integration": "NODE_ENV=test vitest run --config=vitest.integration.config.ts",
+    "test:integration:sdk-core": "NODE_ENV=test vitest run --config=vitest.integration.config.ts integration-tests/node-sdk-behavior.test.ts -t \"core behavior profile\"",
+    "test:integration:sdk-capabilities": "NODE_ENV=test vitest run --config=vitest.integration.config.ts integration-tests/node-sdk-behavior.test.ts -t \"capability behavior profile\"",
     "test:rclone-pin": "node --test scripts/update-rclone-pin.test.mjs",
     "test:watch": "NODE_ENV=test vitest --watch",
     "dev": "tsx scripts/dev.mts",


### PR DESCRIPTION
This pull request adds published-package SDK behavior integration tests that run through the existing local Verdaccio pipeline.

The new `core` profile covers essential Responses, delegation, state, approval, session, and tracing behavior. The `capabilities` profile covers guardrails, execution controls, provider parity, hosted tools, deferred tool search, programmatic tool calling, and hosted multi-agent behavior.