### PR TITLE
fix: propagate run cancellation signals to function tools and stop cancelled runs before the next model turn (#1521)

### DIFF
--- a/.changeset/tidy-tools-cancel.md
+++ b/.changeset/tidy-tools-cancel.md
@@ -2,4 +2,4 @@
 '@openai/agents-core': patch
 ---
 
-fix: propagate run cancellation signals to function tools (#1521)
+fix: propagate run cancellation signals to function tools and stop cancelled runs before the next model turn (#1521)

--- a/.changeset/tidy-tools-cancel.md
+++ b/.changeset/tidy-tools-cancel.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: propagate run cancellation signals to function tools (#1521)

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1043,6 +1043,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               runner: this,
               toolErrorFormatter,
               agentToolParentRunConfig,
+              signal: options.signal,
             });
 
             // Don't reset counter here - resolveInterruptedTurn already adjusted it via rewind logic
@@ -1220,6 +1221,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               toolErrorFormatter,
               agentToolParentRunConfig,
               options.errorHandlers,
+              options.signal,
             );
 
             applyTurnResult({
@@ -1497,6 +1499,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             runner: this,
             toolErrorFormatter,
             agentToolParentRunConfig,
+            signal: options.signal,
             onStepItems: (turnResult) => {
               addStepToRunResult(result, turnResult);
             },
@@ -1825,6 +1828,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             toolErrorFormatter,
             agentToolParentRunConfig,
             options.errorHandlers,
+            options.signal,
           );
 
           applyTurnResult({

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1011,8 +1011,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
 
       try {
         while (true) {
-          options.signal?.throwIfAborted();
-
           // if we don't have a current step, we treat this as a new run
           state._currentStep = state._currentStep ?? {
             type: 'next_step_run_again',
@@ -1047,6 +1045,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               agentToolParentRunConfig,
               signal: options.signal,
             });
+            options.signal?.throwIfAborted();
 
             // Don't reset counter here - resolveInterruptedTurn already adjusted it via rewind logic
             // The counter will be reset when _currentTurn is incremented (starting a new turn)
@@ -1233,6 +1232,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               toolsUsed: state._lastProcessedResponse?.toolsUsed ?? [],
               resetTurnPersistence: !isResumedState,
             });
+            options.signal?.throwIfAborted();
             if (turnResult.nextStep.type !== 'next_step_final_output') {
               finishRunnerSpan(currentTurnSpan);
               setRunStateTurnSpanParent(state, undefined);

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1011,6 +1011,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
 
       try {
         while (true) {
+          options.signal?.throwIfAborted();
+
           // if we don't have a current step, we treat this as a new run
           state._currentStep = state._currentStep ?? {
             type: 'next_step_run_again',

--- a/packages/agents-core/src/runner/runLoop.ts
+++ b/packages/agents-core/src/runner/runLoop.ts
@@ -64,6 +64,7 @@ export async function resumeInterruptedTurn<
   runner: Runner;
   toolErrorFormatter?: ToolErrorFormatter;
   agentToolParentRunConfig?: Partial<RunConfig>;
+  signal?: AbortSignal;
   onStepItems?: (turnResult: SingleStepResult) => void;
 }): Promise<InterruptedTurnOutcome> {
   const {
@@ -71,6 +72,7 @@ export async function resumeInterruptedTurn<
     runner,
     toolErrorFormatter,
     agentToolParentRunConfig,
+    signal,
     onStepItems,
   } = options;
   const turnResult = await resolveInterruptedTurn<TContext>(
@@ -83,6 +85,7 @@ export async function resumeInterruptedTurn<
     state,
     toolErrorFormatter,
     agentToolParentRunConfig,
+    signal,
   );
 
   applyTurnResult({

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -93,6 +93,7 @@ type FunctionToolCallDeps<TContext = UnknownContext> = {
   state: RunState<TContext, Agent<TContext, any>>;
   toolErrorFormatter?: ToolErrorFormatter;
   agentToolParentRunConfig?: Partial<RunConfig>;
+  signal?: AbortSignal;
 };
 
 const REDACTED_TOOL_ERROR_MESSAGE =
@@ -234,6 +235,7 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
   state: RunState<TContext, Agent<TContext, any>>,
   toolErrorFormatter?: ToolErrorFormatter,
   agentToolParentRunConfig?: Partial<RunConfig>,
+  signal?: AbortSignal,
 ): Promise<FunctionToolResult<TContext>[]> {
   const deps: FunctionToolCallDeps<TContext> = {
     agent,
@@ -241,6 +243,7 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
     state,
     toolErrorFormatter,
     agentToolParentRunConfig,
+    signal,
   };
 
   const executeToolRun = async (toolRun: ToolRunFunction<TContext>) => {
@@ -609,7 +612,7 @@ async function runApprovedFunctionTool<TContext>(
   toolRun: ToolRunFunction<TContext>,
   parsedInput: unknown,
 ): Promise<FunctionToolResult<TContext>> {
-  const { agent, runner, state, agentToolParentRunConfig } = deps;
+  const { agent, runner, state, agentToolParentRunConfig, signal } = deps;
   const toolName = getFunctionToolIdentity(toolRun);
   const traceToolName = getFunctionToolTraceName(toolRun);
   return withRunStateToolFunctionSpan(deps, traceToolName, async (span) => {
@@ -655,6 +658,7 @@ async function runApprovedFunctionTool<TContext>(
         toolDetails = {
           toolCall: toolRun.toolCall,
           resumeState,
+          ...(signal ? { signal } : {}),
           [FUNCTION_TOOL_PARSED_INPUT_CALLBACK]: (input: unknown) => {
             executedInput = cloneForCustomDataContext(input);
           },

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -630,6 +630,7 @@ export async function resolveInterruptedTurn<TContext>(
   state: RunState<TContext, Agent<TContext, any>>,
   toolErrorFormatter?: ToolErrorFormatter,
   agentToolParentRunConfig?: Partial<RunConfig>,
+  signal?: AbortSignal,
 ): Promise<SingleStepResult> {
   // call_ids for function tools
   const functionCallIds = originalPreStepItems
@@ -766,6 +767,7 @@ export async function resolveInterruptedTurn<TContext>(
     state,
     toolErrorFormatter,
     agentToolParentRunConfig,
+    signal,
   );
 
   // Computer actions may require approval; only pending approved actions are executed on resume.
@@ -956,6 +958,7 @@ export async function resolveTurnAfterModelResponse<
   toolErrorFormatter?: ToolErrorFormatter,
   agentToolParentRunConfig?: Partial<RunConfig>,
   errorHandlers?: RunErrorHandlers<TContext, TAgent>,
+  signal?: AbortSignal,
 ): Promise<SingleStepResult> {
   // Reuse the same array reference so we can compare object identity when deciding whether to
   // append new items, ensuring we never double-stream existing RunItems.
@@ -979,6 +982,7 @@ export async function resolveTurnAfterModelResponse<
       state,
       toolErrorFormatter,
       agentToolParentRunConfig,
+      signal,
     ),
     executeComputerActions(
       agent,

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -1451,6 +1451,81 @@ describe('Runner.run (streaming)', () => {
     expect(toolCalledIndex).toBeLessThan(toolOutputIndex);
   });
 
+  it('aborts an in-flight function tool when the stream is cancelled', async () => {
+    let toolSignal: AbortSignal | undefined;
+    let markToolStarted: (() => void) | undefined;
+    const toolStarted = new Promise<void>((resolve) => {
+      markToolStarted = resolve;
+    });
+    const abortableTool = tool({
+      name: 'test',
+      description: 'waits for the stream to be cancelled',
+      parameters: z.object({ test: z.string() }),
+      execute: async (_input, _context, details) => {
+        toolSignal = details?.signal;
+        markToolStarted?.();
+        if (!toolSignal) {
+          throw new Error('Expected the stream abort signal');
+        }
+        if (!toolSignal.aborted) {
+          await new Promise<void>((resolve) => {
+            toolSignal?.addEventListener('abort', () => resolve(), {
+              once: true,
+            });
+          });
+        }
+        return 'cancelled';
+      },
+    });
+
+    class AbortableToolStreamModel implements Model {
+      #callCount = 0;
+
+      async getResponse(_request: ModelRequest): Promise<ModelResponse> {
+        throw new Error('Unexpected non-streaming model request');
+      }
+
+      async *getStreamedResponse(
+        _request: ModelRequest,
+      ): AsyncIterable<StreamEvent> {
+        const output =
+          this.#callCount++ === 0
+            ? [{ ...TEST_MODEL_FUNCTION_CALL }]
+            : [fakeModelMessage('done')];
+        yield {
+          type: 'response_done',
+          response: {
+            id: `resp-${this.#callCount}`,
+            usage: {
+              requests: 1,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            output,
+          },
+        } as StreamEvent;
+      }
+    }
+
+    const agent = new Agent({
+      name: 'AbortableToolStreamAgent',
+      model: new AbortableToolStreamModel(),
+      tools: [abortableTool],
+    });
+    const result = await run(agent, 'start', { stream: true });
+    const reader = (result.toStream() as any).getReader();
+
+    await toolStarted;
+    expect(toolSignal).toBe(result._getAbortSignal());
+
+    await reader.cancel('stop');
+    await result._getStreamLoopPromise();
+
+    expect(result.cancelled).toBe(true);
+    expect(toolSignal?.aborted).toBe(true);
+  });
+
   it('enforces maxTurns across multiple streamed model calls', async () => {
     // Bug: After first model call, _lastTurnResponse is set, so turn counter never advances.
     // With maxTurns=1, we should only allow 1 model call, but currently allows 2.

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -129,7 +129,7 @@ describe('Runner.run', () => {
       expect(runner.config.toolExecution).toBe(toolExecution);
     });
 
-    it('passes the run abort signal to an in-flight function tool', async () => {
+    it('stops after an in-flight function tool observes run cancellation', async () => {
       const controller = new AbortController();
       const abortReason = new Error('stop tool');
       let toolSignal: AbortSignal | undefined;
@@ -162,27 +162,30 @@ describe('Runner.run', () => {
           output: [{ ...TEST_MODEL_FUNCTION_CALL }],
           usage: new Usage(),
         },
-        {
-          output: [fakeModelMessage('done')],
-          usage: new Usage(),
-        },
       ]);
+      const getResponseSpy = vi.spyOn(model, 'getResponse');
       const agent = new Agent({
         name: 'AbortableToolAgent',
         model,
         tools: [abortableTool],
       });
+      const state = new RunState(new RunContext(), 'start', agent, 10);
 
-      const runPromise = run(agent, 'start', { signal: controller.signal });
+      const runPromise = run(agent, state, { signal: controller.signal });
       await toolStarted;
 
       expect(toolSignal).toBe(controller.signal);
       controller.abort(abortReason);
 
-      const result = await runPromise;
+      await expect(runPromise).rejects.toBe(abortReason);
       expect(toolSignal?.aborted).toBe(true);
       expect(toolSignal?.reason).toBe(abortReason);
-      expect(result.finalOutput).toBe('done');
+      expect(getResponseSpy).toHaveBeenCalledTimes(1);
+      expect(
+        state._generatedItems.filter(
+          (item) => item.rawItem.type === 'function_call_result',
+        ),
+      ).toHaveLength(1);
     });
 
     it('accepts public tool not found behavior config', () => {

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -129,6 +129,62 @@ describe('Runner.run', () => {
       expect(runner.config.toolExecution).toBe(toolExecution);
     });
 
+    it('passes the run abort signal to an in-flight function tool', async () => {
+      const controller = new AbortController();
+      const abortReason = new Error('stop tool');
+      let toolSignal: AbortSignal | undefined;
+      let markToolStarted: (() => void) | undefined;
+      const toolStarted = new Promise<void>((resolve) => {
+        markToolStarted = resolve;
+      });
+      const abortableTool = tool({
+        name: 'test',
+        description: 'waits for the run to be aborted',
+        parameters: z.object({ test: z.string() }),
+        execute: async (_input, _context, details) => {
+          toolSignal = details?.signal;
+          markToolStarted?.();
+          if (!toolSignal) {
+            throw new Error('Expected the run abort signal');
+          }
+          if (!toolSignal.aborted) {
+            await new Promise<void>((resolve) => {
+              toolSignal?.addEventListener('abort', () => resolve(), {
+                once: true,
+              });
+            });
+          }
+          return 'cancelled';
+        },
+      });
+      const model = new FakeModel([
+        {
+          output: [{ ...TEST_MODEL_FUNCTION_CALL }],
+          usage: new Usage(),
+        },
+        {
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'AbortableToolAgent',
+        model,
+        tools: [abortableTool],
+      });
+
+      const runPromise = run(agent, 'start', { signal: controller.signal });
+      await toolStarted;
+
+      expect(toolSignal).toBe(controller.signal);
+      controller.abort(abortReason);
+
+      const result = await runPromise;
+      expect(toolSignal?.aborted).toBe(true);
+      expect(toolSignal?.reason).toBe(abortReason);
+      expect(result.finalOutput).toBe('done');
+    });
+
     it('accepts public tool not found behavior config', () => {
       const toolNotFoundBehavior =
         'return_error_to_model' satisfies ToolNotFoundBehavior;


### PR DESCRIPTION
This pull request resolves #1521 by propagating `RunOptions.signal` through the regular and resumed function-tool execution paths into `ToolCallDetails.signal`.

Streaming runs pass the combined run and reader-cancellation signal, allowing in-flight function tools to observe cancellation. Runs without a signal retain the existing details shape. The change remains scoped to function tools and does not alter stream completion, `RunState` resumption, handoffs, approvals, MCP, or non-function actions.