### PR TITLE
fix(extensions): preserve refusal messages in AI SDK history

### DIFF
--- a/.changeset/quiet-refusals-preserve.md
+++ b/.changeset/quiet-refusals-preserve.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: preserve refusal messages in AI SDK history

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -458,16 +458,18 @@ export function itemsToLanguageV2Messages(
         const assistantProviderOptions = toProviderOptions(providerData, model);
         const assistantContent: Array<
           LanguageModelV2ReasoningPart | LanguageModelV2TextPart
-        > = content
-          .filter((c) => c.type === 'output_text')
-          .map<LanguageModelV2TextPart>((c) => {
-            const { providerData: contentProviderData } = c;
-            return {
-              type: 'text',
-              text: c.text,
-              providerOptions: toProviderOptions(contentProviderData, model),
-            };
-          });
+        > = content.flatMap<LanguageModelV2TextPart>((c) => {
+          if (c.type !== 'output_text' && c.type !== 'refusal') {
+            return [];
+          }
+
+          const { providerData: contentProviderData } = c;
+          return {
+            type: 'text',
+            text: c.type === 'output_text' ? c.text : c.refusal,
+            providerOptions: toProviderOptions(contentProviderData, model),
+          };
+        });
 
         if (
           shouldIncludeReasoningContent(model, modelSettings) &&

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -583,6 +583,63 @@ describe('itemsToLanguageV2Messages', () => {
     ]);
   });
 
+  test('converts assistant refusals to text content', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'refusal',
+            refusal: 'I cannot help with that.',
+            providerData: { test: { source: 'refusal' } },
+          },
+        ],
+        providerData: { message: { source: 'assistant' } },
+      } as any,
+    ];
+
+    const msgs = itemsToLanguageV2Messages(stubModel({}), items);
+    expect(msgs).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: 'I cannot help with that.',
+            providerOptions: { test: { source: 'refusal' } },
+          },
+        ],
+        providerOptions: { message: { source: 'assistant' } },
+      },
+    ]);
+  });
+
+  test('preserves the order of assistant text and refusal content', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'output_text', text: 'Visible A' },
+          { type: 'refusal', refusal: 'Blocked B' },
+          { type: 'output_text', text: 'Visible C' },
+        ],
+      } as any,
+    ];
+
+    const msgs = itemsToLanguageV2Messages(stubModel({}), items);
+    expect(msgs).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Visible A', providerOptions: {} },
+          { type: 'text', text: 'Blocked B', providerOptions: {} },
+          { type: 'text', text: 'Visible C', providerOptions: {} },
+        ],
+        providerOptions: {},
+      },
+    ]);
+  });
+
   test('preserves qualified names for namespaced function calls', () => {
     const items: protocol.ModelItem[] = [
       {


### PR DESCRIPTION
This pull request resolves #1522.

AI SDK message conversion previously discarded assistant refusal content because it only mapped `output_text` parts. A refusal-only message therefore reached providers such as Anthropic with an empty content array and caused the request to fail. The conversion now maps refusals to text parts while preserving content order and provider options. This keeps refusal history available to downstream providers without changing the public API or adding provider-specific behavior.