### PR TITLE
fix(core): stop cancelled streams before another model turn

### DIFF
--- a/.changeset/lucky-badgers-itch.md
+++ b/.changeset/lucky-badgers-itch.md
@@ -2,4 +2,4 @@
 '@openai/agents-core': patch
 ---
 
-fix(core): stop cancelled streams before another model turn
+fix(core): stop cancelled streams before another model turn and preserve in-progress turn state across resume

--- a/.changeset/lucky-badgers-itch.md
+++ b/.changeset/lucky-badgers-itch.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix(core): stop cancelled streams before another model turn

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1687,18 +1687,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           };
 
           // Preparation can run user-provided async code, so cancellation must be
-          // rechecked after its final await and before persisting or calling the model.
-          if (result.cancelled) {
-            await awaitGuardrailsAndPersistInput();
-            return;
-          }
-
-          if (!delayStreamInputPersistence) {
-            await persistStreamInputIfNeeded();
-          }
-
-          // Persistence can also be asynchronous, so do not start the request if
-          // cancellation occurs while the session write is in progress.
+          // rechecked after its final await and before calling the model.
           if (result.cancelled) {
             await awaitGuardrailsAndPersistInput();
             return;
@@ -1734,6 +1723,11 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               },
             )) {
               await guardrailTracker.throwIfError();
+              // Cross the model request boundary before starting an asynchronous
+              // session write so cancellation cannot persist an unsent prompt.
+              if (!delayStreamInputPersistence) {
+                await persistStreamInputIfNeeded();
+              }
               markInputOnce();
               recordStreamEventForAbortReconciliation(
                 abortReconciliationState,

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1686,12 +1686,19 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             }
           };
 
+          // Preparation can run user-provided async code, so cancellation must be
+          // rechecked after its final await and before persisting or calling the model.
+          if (result.cancelled) {
+            await awaitGuardrailsAndPersistInput();
+            return;
+          }
+
           if (!delayStreamInputPersistence) {
             await persistStreamInputIfNeeded();
           }
 
-          // Preparation can run user-provided async code, so cancellation must be
-          // rechecked after its final await and immediately before calling the model.
+          // Persistence can also be asynchronous, so do not start the request if
+          // cancellation occurs while the session write is in progress.
           if (result.cancelled) {
             await awaitGuardrailsAndPersistInput();
             return;

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -992,8 +992,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         state.setCurrentAgentSpan(optOutResumeAgentSpan);
       }
 
-      // Tracks when we resume an approval interruption so the next run-again step stays in the same turn.
-      let continuingInterruptedTurn = false;
       let runError: unknown;
       let currentTurnSpan: ReturnType<typeof startTurnSpan> | undefined;
       const parentUsageRecorder = getRunnerParentUsageRecorder(this);
@@ -1053,9 +1051,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             const { shouldReturn, shouldContinue } = handleInterruptedOutcome({
               state,
               outcome: interruptedOutcome,
-              setContinuingInterruptedTurn: (value) => {
-                continuingInterruptedTurn = value;
-              },
             });
             if (!shouldContinue) {
               finishRunnerSpan(currentTurnSpan);
@@ -1072,8 +1067,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           }
 
           if (state._currentStep.type === 'next_step_run_again') {
-            const wasContinuingInterruptedTurn = continuingInterruptedTurn;
-            continuingInterruptedTurn = false;
             const guardrailTracker = createGuardrailTracker();
             const previousTurn = state._currentTurn;
             const previousPersistedCount = state._currentTurnPersistedItemCount;
@@ -1084,7 +1077,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               generatedItems: state._generatedItems,
               isResumedState,
               preserveTurnPersistenceOnResume,
-              continuingInterruptedTurn: wasContinuingInterruptedTurn,
               serverConversationTracker,
               inputGuardrailDefs: this.inputGuardrailDefs,
               guardrailHandlers: {
@@ -1453,8 +1445,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     const useTaskAndTurnSpans =
       !this.config.tracingDisabled && includeTaskAndTurnSpans(options.tracing);
 
-    // Tracks when we resume an approval interruption so the next run-again step stays in the same turn.
-    let continuingInterruptedTurn = false;
     let runError: unknown;
     let currentTurnSpan: ReturnType<typeof startTurnSpan> | undefined;
     const parentUsageRecorder = getRunnerParentUsageRecorder(this);
@@ -1518,9 +1508,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           const { shouldReturn, shouldContinue } = handleInterruptedOutcome({
             state: result.state,
             outcome: interruptedOutcome,
-            setContinuingInterruptedTurn: (value) => {
-              continuingInterruptedTurn = value;
-            },
           });
           if (!shouldContinue) {
             finishRunnerSpan(currentTurnSpan);
@@ -1539,8 +1526,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         if (result.state._currentStep.type === 'next_step_run_again') {
           parallelGuardrailPromise = undefined;
           guardrailTracker = createGuardrailTracker();
-          const wasContinuingInterruptedTurn = continuingInterruptedTurn;
-          continuingInterruptedTurn = false;
           const previousTurn = result.state._currentTurn;
           const previousPersistedCount =
             result.state._currentTurnPersistedItemCount;
@@ -1551,7 +1536,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             generatedItems: result.newItems,
             isResumedState,
             preserveTurnPersistenceOnResume,
-            continuingInterruptedTurn: wasContinuingInterruptedTurn,
             serverConversationTracker,
             inputGuardrailDefs: this.inputGuardrailDefs,
             guardrailHandlers: {

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1467,6 +1467,11 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
 
     try {
       while (true) {
+        // Let the current action batch settle, but never start new work after cancellation.
+        if (result.cancelled) {
+          return;
+        }
+
         const currentAgent = result.state._currentAgent;
 
         result.state._currentStep = result.state._currentStep ?? {

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1693,6 +1693,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           // Preparation can run user-provided async code, so cancellation must be
           // rechecked after its final await and immediately before calling the model.
           if (result.cancelled) {
+            await awaitGuardrailsAndPersistInput();
             return;
           }
 

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1723,11 +1723,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               },
             )) {
               await guardrailTracker.throwIfError();
-              // Cross the model request boundary before starting an asynchronous
-              // session write so cancellation cannot persist an unsent prompt.
-              if (!delayStreamInputPersistence) {
-                await persistStreamInputIfNeeded();
-              }
               markInputOnce();
               recordStreamEventForAbortReconciliation(
                 abortReconciliationState,
@@ -1744,14 +1739,22 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 result.state._context.usage.add(finalResponse.usage);
                 recordUsage(finalResponse.usage);
               }
+              result._addItem(new RunRawModelStreamEvent(event));
+              // Record pulled model events before awaiting session storage so a
+              // cancellation during the write cannot discard an accepted response.
+              if (!delayStreamInputPersistence) {
+                await persistStreamInputIfNeeded();
+              }
               if (result.cancelled) {
-                // When the user's code exits a loop to consume the stream, we need to break
-                // this loop to prevent internal false errors and unnecessary processing
                 await awaitGuardrailsAndPersistInput();
+                if (finalResponse) {
+                  // Finish resolving the accepted response and its current action
+                  // batch, then let the outer loop stop before another model turn.
+                  break;
+                }
                 await reconcileStreamAbortIfNeeded();
                 return;
               }
-              result._addItem(new RunRawModelStreamEvent(event));
             }
           } catch (error) {
             if (isAbortError(error)) {
@@ -1770,10 +1773,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           }
 
           await awaitGuardrailsAndPersistInput();
-
-          if (result.cancelled) {
-            return;
-          }
 
           result.state._noActiveAgentRun = false;
 
@@ -1970,7 +1969,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         await persistStreamInputIfNeeded();
       }
       const preserveSandboxSessions =
-        result.state._currentStep?.type === 'next_step_interruption';
+        result.state._currentStep?.type === 'next_step_interruption' ||
+        (result.cancelled &&
+          result.state._currentStep?.type !== 'next_step_final_output');
       try {
         try {
           await finalizeSandboxRuntime({

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1702,11 +1702,17 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             }
           };
 
-          sentInputToModel = true;
           if (!delayStreamInputPersistence) {
             await persistStreamInputIfNeeded();
           }
 
+          // Preparation can run user-provided async code, so cancellation must be
+          // rechecked after its final await and immediately before calling the model.
+          if (result.cancelled) {
+            return;
+          }
+
+          sentInputToModel = true;
           try {
             for await (const event of getStreamedResponseWithRetry(
               preparedCall.model,

--- a/packages/agents-core/src/runner/runLoop.ts
+++ b/packages/agents-core/src/runner/runLoop.ts
@@ -124,6 +124,7 @@ export function handleInterruptedOutcome<
       return { shouldReturn: true, shouldContinue: false };
     case 'rerun_turn':
       // Clear the step so the outer loop treats this as a new run-again without incrementing the turn.
+      state._currentTurnInProgress = true;
       state._currentStep = undefined;
       return { shouldReturn: false, shouldContinue: true };
     case 'advance_step':

--- a/packages/agents-core/src/runner/runLoop.ts
+++ b/packages/agents-core/src/runner/runLoop.ts
@@ -115,9 +115,8 @@ export function handleInterruptedOutcome<
 >(options: {
   state: RunState<TContext, TAgent>;
   outcome: InterruptedTurnOutcome;
-  setContinuingInterruptedTurn: (value: boolean) => void;
 }): InterruptedTurnControl {
-  const { state, outcome, setContinuingInterruptedTurn } = options;
+  const { state, outcome } = options;
 
   switch (outcome.action) {
     case 'return_interruption':
@@ -125,11 +124,9 @@ export function handleInterruptedOutcome<
       return { shouldReturn: true, shouldContinue: false };
     case 'rerun_turn':
       // Clear the step so the outer loop treats this as a new run-again without incrementing the turn.
-      setContinuingInterruptedTurn(true);
       state._currentStep = undefined;
       return { shouldReturn: false, shouldContinue: true };
     case 'advance_step':
-      setContinuingInterruptedTurn(false);
       state._currentStep = outcome.nextStep;
       return { shouldReturn: false, shouldContinue: false };
     default: {

--- a/packages/agents-core/src/runner/turnPreparation.ts
+++ b/packages/agents-core/src/runner/turnPreparation.ts
@@ -39,7 +39,6 @@ type PrepareTurnOptions<
   generatedItems: RunItem[];
   isResumedState: boolean;
   preserveTurnPersistenceOnResume?: boolean;
-  continuingInterruptedTurn: boolean;
   serverConversationTracker?: ServerConversationTracker;
   inputGuardrailDefs: InputGuardrailDefinition[];
   guardrailHandlers?: GuardrailHandlers;
@@ -62,7 +61,6 @@ export async function prepareTurn<
     generatedItems,
     isResumedState,
     preserveTurnPersistenceOnResume,
-    continuingInterruptedTurn,
     serverConversationTracker,
     inputGuardrailDefs,
     guardrailHandlers,
@@ -71,10 +69,9 @@ export async function prepareTurn<
     agentSpanParent,
   } = options;
 
-  const { isResumingFromInterruption } = beginTurn(state, {
+  const { isResumingTurnInProgress } = beginTurn(state, {
     isResumedState,
     preserveTurnPersistenceOnResume,
-    continuingInterruptedTurn,
   });
 
   if (state._maxTurns !== null && state._currentTurn > state._maxTurns) {
@@ -106,7 +103,7 @@ export async function prepareTurn<
   const { parallelGuardrailPromise } = await runInputGuardrailsForTurn(
     state,
     inputGuardrailDefs,
-    isResumingFromInterruption,
+    isResumingTurnInProgress,
     guardrailHandlers,
   );
 
@@ -192,10 +189,10 @@ async function runInputGuardrailsForTurn<
 >(
   state: RunState<TContext, TAgent>,
   runnerGuardrails: InputGuardrailDefinition[],
-  isResumingFromInterruption: boolean,
+  isResumingTurnInProgress: boolean,
   handlers: GuardrailHandlers = {},
 ): Promise<{ parallelGuardrailPromise?: Promise<InputGuardrailResult[]> }> {
-  if (state._currentTurn !== 1 || isResumingFromInterruption) {
+  if (state._currentTurn !== 1 || isResumingTurnInProgress) {
     return {};
   }
 
@@ -222,17 +219,13 @@ function beginTurn<TContext, TAgent extends Agent<TContext, AgentOutputType>>(
   options: {
     isResumedState: boolean;
     preserveTurnPersistenceOnResume?: boolean;
-    continuingInterruptedTurn: boolean;
   },
-): { isResumingFromInterruption: boolean } {
-  const isResumingFromInterruption =
-    options.isResumedState && options.continuingInterruptedTurn;
-  const resumingTurnInProgress =
+): { isResumingTurnInProgress: boolean } {
+  const isResumingTurnInProgress =
     options.isResumedState && state._currentTurnInProgress === true;
 
-  // Do not advance the turn when resuming from an interruption; the next model call is
-  // still part of the same logical turn.
-  if (!isResumingFromInterruption && !resumingTurnInProgress) {
+  // Do not advance a turn that was already in progress before the state was resumed.
+  if (!isResumingTurnInProgress) {
     state._currentTurn++;
     if (!options.isResumedState || !options.preserveTurnPersistenceOnResume) {
       state.resetTurnPersistence();
@@ -245,5 +238,5 @@ function beginTurn<TContext, TAgent extends Agent<TContext, AgentOutputType>>(
   }
   state._currentTurnInProgress = true;
 
-  return { isResumingFromInterruption };
+  return { isResumingTurnInProgress };
 }

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -1685,6 +1685,60 @@ describe('Runner.run (streaming)', () => {
     expect(await session.getItems()).toEqual([]);
   });
 
+  it('starts the model request before asynchronous session persistence', async () => {
+    let markPersistenceStarted: (() => void) | undefined;
+    let finishPersistence: (() => void) | undefined;
+    const persistenceStarted = new Promise<void>((resolve) => {
+      markPersistenceStarted = resolve;
+    });
+    const persistenceCanFinish = new Promise<void>((resolve) => {
+      finishPersistence = resolve;
+    });
+    const persistedItems: AgentInputItem[] = [];
+    const session: Session = {
+      async getSessionId() {
+        return 'blocking-session';
+      },
+      async getItems() {
+        return structuredClone(persistedItems);
+      },
+      async addItems(items) {
+        markPersistenceStarted?.();
+        await persistenceCanFinish;
+        persistedItems.push(...structuredClone(items));
+      },
+      async popItem() {
+        return persistedItems.pop();
+      },
+      async clearSession() {
+        persistedItems.length = 0;
+      },
+    };
+    const model = new CountingFunctionToolStreamModel();
+    const agent = new Agent({
+      name: 'CancelDuringPersistenceAgent',
+      model,
+    });
+    const result = await run(agent, 'sent before persistence', {
+      stream: true,
+      session,
+    });
+    const reader = (result.toStream() as any).getReader();
+
+    await persistenceStarted;
+    const modelCallsWhenPersistenceStarted = model.callCount;
+    await reader.cancel('stop');
+    finishPersistence?.();
+    await result._getStreamLoopPromise();
+
+    expect(result.cancelled).toBe(true);
+    expect(modelCallsWhenPersistenceStarted).toBe(1);
+    expect(model.callCount).toBe(1);
+    expect(await session.getItems()).toMatchObject([
+      { role: 'user', content: 'sent before persistence' },
+    ]);
+  });
+
   it('surfaces a pending input guardrail failure after cancellation during preparation', async () => {
     let markGuardrailStarted: (() => void) | undefined;
     let finishGuardrail:

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -1585,6 +1585,50 @@ describe('Runner.run (streaming)', () => {
     ).toBe(true);
   });
 
+  it('does not call the model when cancelled during next-turn preparation', async () => {
+    let filterCalls = 0;
+    let markNextTurnPreparationStarted: (() => void) | undefined;
+    let finishNextTurnPreparation: (() => void) | undefined;
+    const nextTurnPreparationStarted = new Promise<void>((resolve) => {
+      markNextTurnPreparationStarted = resolve;
+    });
+    const nextTurnPreparationCanFinish = new Promise<void>((resolve) => {
+      finishNextTurnPreparation = resolve;
+    });
+    const testTool = tool({
+      name: 'test',
+      description: 'completes before the next model turn',
+      parameters: z.object({ test: z.string() }),
+      execute: async () => 'completed',
+    });
+    const model = new CountingFunctionToolStreamModel();
+    const agent = new Agent({
+      name: 'CancelDuringPreparationAgent',
+      model,
+      tools: [testTool],
+    });
+    const runner = new Runner({
+      callModelInputFilter: async ({ modelData }) => {
+        filterCalls += 1;
+        if (filterCalls === 2) {
+          markNextTurnPreparationStarted?.();
+          await nextTurnPreparationCanFinish;
+        }
+        return modelData;
+      },
+    });
+    const result = await runner.run(agent, 'start', { stream: true });
+    const reader = (result.toStream() as any).getReader();
+
+    await nextTurnPreparationStarted;
+    await reader.cancel('stop');
+    finishNextTurnPreparation?.();
+    await result._getStreamLoopPromise();
+
+    expect(result.cancelled).toBe(true);
+    expect(model.callCount).toBe(1);
+  });
+
   it('enforces maxTurns across multiple streamed model calls', async () => {
     // Bug: After first model call, _lastTurnResponse is set, so turn counter never advances.
     // With maxTurns=1, we should only allow 1 model call, but currently allows 2.

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -1714,10 +1714,18 @@ describe('Runner.run (streaming)', () => {
         persistedItems.length = 0;
       },
     };
+    const executeTestTool = vi.fn(async () => 'completed');
+    const testTool = tool({
+      name: 'test',
+      description: 'records the accepted function call',
+      parameters: z.object({ test: z.string() }),
+      execute: executeTestTool,
+    });
     const model = new CountingFunctionToolStreamModel();
     const agent = new Agent({
       name: 'CancelDuringPersistenceAgent',
       model,
+      tools: [testTool],
     });
     const result = await run(agent, 'sent before persistence', {
       stream: true,
@@ -1734,9 +1742,25 @@ describe('Runner.run (streaming)', () => {
     expect(result.cancelled).toBe(true);
     expect(modelCallsWhenPersistenceStarted).toBe(1);
     expect(model.callCount).toBe(1);
+    expect(executeTestTool).toHaveBeenCalledTimes(1);
+    expect(result.state._modelResponses).toHaveLength(1);
+    expect(
+      result.state._generatedItems.some(
+        (item) => item.rawItem.type === 'function_call_result',
+      ),
+    ).toBe(true);
     expect(await session.getItems()).toMatchObject([
       { role: 'user', content: 'sent before persistence' },
     ]);
+
+    const resumed = await run(agent, result.state, { stream: true });
+    for await (const _event of resumed) {
+      // Drain the resumed run.
+    }
+
+    expect(resumed.finalOutput).toBe('done');
+    expect(model.callCount).toBe(2);
+    expect(executeTestTool).toHaveBeenCalledTimes(1);
   });
 
   it('surfaces a pending input guardrail failure after cancellation during preparation', async () => {
@@ -3604,7 +3628,7 @@ describe('Runner.run (streaming)', () => {
     expect(result.cancelled).toBe(true);
   });
 
-  it('persists streaming input after cancellation once parallel guardrails finish', async () => {
+  it('persists an accepted response after cancellation once parallel guardrails finish', async () => {
     const saveInputSpy = vi
       .spyOn(sessionPersistence, 'saveStreamInputToSession')
       .mockResolvedValue();
@@ -3651,8 +3675,10 @@ describe('Runner.run (streaming)', () => {
     await result._getStreamLoopPromise();
 
     expect(saveInputSpy).toHaveBeenCalledTimes(1);
-    expect(saveResultSpy).not.toHaveBeenCalled();
+    expect(saveResultSpy).toHaveBeenCalledTimes(1);
     expect(guardrail.execute).toHaveBeenCalledTimes(1);
+    expect(result.state._modelResponses).toHaveLength(1);
+    expect(result.finalOutput).toBe('Chunk1');
   });
 
   it('resumes a cancelled in-progress turn without double-counting turns', async () => {

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -29,6 +29,7 @@ import {
   OutputGuardrailTripwireTriggered,
   RunState,
   shellTool,
+  MemorySession,
 } from '../src';
 import {
   FakeModel,
@@ -1644,6 +1645,44 @@ describe('Runner.run (streaming)', () => {
 
     expect(result.cancelled).toBe(true);
     expect(model.callCount).toBe(1);
+  });
+
+  it('does not persist input when cancelled during initial preparation', async () => {
+    let markPreparationStarted: (() => void) | undefined;
+    let finishPreparation: (() => void) | undefined;
+    const preparationStarted = new Promise<void>((resolve) => {
+      markPreparationStarted = resolve;
+    });
+    const preparationCanFinish = new Promise<void>((resolve) => {
+      finishPreparation = resolve;
+    });
+    const model = new CountingFunctionToolStreamModel();
+    const agent = new Agent({
+      name: 'CancelInitialPreparationAgent',
+      model,
+    });
+    const runner = new Runner({
+      callModelInputFilter: async ({ modelData }) => {
+        markPreparationStarted?.();
+        await preparationCanFinish;
+        return modelData;
+      },
+    });
+    const session = new MemorySession();
+    const result = await runner.run(agent, 'not sent', {
+      stream: true,
+      session,
+    });
+    const reader = (result.toStream() as any).getReader();
+
+    await preparationStarted;
+    await reader.cancel('stop');
+    finishPreparation?.();
+    await result._getStreamLoopPromise();
+
+    expect(result.cancelled).toBe(true);
+    expect(model.callCount).toBe(0);
+    expect(await session.getItems()).toEqual([]);
   });
 
   it('surfaces a pending input guardrail failure after cancellation during preparation', async () => {

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -62,6 +62,36 @@ function getRequestInputItems(request: ModelRequest): AgentInputItem[] {
   return Array.isArray(request.input) ? request.input : [];
 }
 
+class CountingFunctionToolStreamModel implements Model {
+  callCount = 0;
+
+  async getResponse(_request: ModelRequest): Promise<ModelResponse> {
+    throw new Error('Unexpected non-streaming model request');
+  }
+
+  async *getStreamedResponse(
+    _request: ModelRequest,
+  ): AsyncIterable<StreamEvent> {
+    const output =
+      this.callCount++ === 0
+        ? [{ ...TEST_MODEL_FUNCTION_CALL }]
+        : [fakeModelMessage('done')];
+    yield {
+      type: 'response_done',
+      response: {
+        id: `resp-${this.callCount}`,
+        usage: {
+          requests: 1,
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+        },
+        output,
+      },
+    } as StreamEvent;
+  }
+}
+
 class AbortAfterStreamedFunctionCallModel implements Model {
   public requests: ModelRequest[] = [];
 
@@ -1478,39 +1508,10 @@ describe('Runner.run (streaming)', () => {
       },
     });
 
-    class AbortableToolStreamModel implements Model {
-      #callCount = 0;
-
-      async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-        throw new Error('Unexpected non-streaming model request');
-      }
-
-      async *getStreamedResponse(
-        _request: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        const output =
-          this.#callCount++ === 0
-            ? [{ ...TEST_MODEL_FUNCTION_CALL }]
-            : [fakeModelMessage('done')];
-        yield {
-          type: 'response_done',
-          response: {
-            id: `resp-${this.#callCount}`,
-            usage: {
-              requests: 1,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
-            },
-            output,
-          },
-        } as StreamEvent;
-      }
-    }
-
+    const model = new CountingFunctionToolStreamModel();
     const agent = new Agent({
       name: 'AbortableToolStreamAgent',
-      model: new AbortableToolStreamModel(),
+      model,
       tools: [abortableTool],
     });
     const result = await run(agent, 'start', { stream: true });
@@ -1524,6 +1525,64 @@ describe('Runner.run (streaming)', () => {
 
     expect(result.cancelled).toBe(true);
     expect(toolSignal?.aborted).toBe(true);
+    expect(model.callCount).toBe(1);
+  });
+
+  it('does not start a new model turn after cancelling a resumed function tool', async () => {
+    let markToolStarted: (() => void) | undefined;
+    const toolStarted = new Promise<void>((resolve) => {
+      markToolStarted = resolve;
+    });
+    const abortableTool = tool({
+      name: 'test',
+      description: 'waits for the resumed stream to be cancelled',
+      parameters: z.object({ test: z.string() }),
+      needsApproval: true,
+      execute: async (_input, _context, details) => {
+        markToolStarted?.();
+        const signal = details?.signal;
+        if (!signal) {
+          throw new Error('Expected the stream abort signal');
+        }
+        if (!signal.aborted) {
+          await new Promise<void>((resolve) => {
+            signal.addEventListener('abort', () => resolve(), { once: true });
+          });
+        }
+        return 'cancelled';
+      },
+    });
+
+    const model = new CountingFunctionToolStreamModel();
+    const agent = new Agent({
+      name: 'ResumedAbortableToolStreamAgent',
+      model,
+      tools: [abortableTool],
+    });
+    const runner = new Runner();
+    const interrupted = await runner.run(agent, 'start', { stream: true });
+    for await (const _event of interrupted) {
+      // Drain the interrupted run.
+    }
+    expect(interrupted.interruptions).toHaveLength(1);
+    interrupted.state.approve(interrupted.interruptions[0]);
+
+    const resumed = await runner.run(agent, interrupted.state, {
+      stream: true,
+    });
+    const reader = (resumed.toStream() as any).getReader();
+
+    await toolStarted;
+    await reader.cancel('stop');
+    await resumed._getStreamLoopPromise();
+
+    expect(resumed.cancelled).toBe(true);
+    expect(model.callCount).toBe(1);
+    expect(
+      resumed.state._generatedItems.some(
+        (item) => item.rawItem.type === 'function_call_result',
+      ),
+    ).toBe(true);
   });
 
   it('enforces maxTurns across multiple streamed model calls', async () => {

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -1646,6 +1646,66 @@ describe('Runner.run (streaming)', () => {
     expect(model.callCount).toBe(1);
   });
 
+  it('surfaces a pending input guardrail failure after cancellation during preparation', async () => {
+    let markGuardrailStarted: (() => void) | undefined;
+    let finishGuardrail:
+      ((output: GuardrailFunctionOutput) => void) | undefined;
+    let markPreparationStarted: (() => void) | undefined;
+    let finishPreparation: (() => void) | undefined;
+    const guardrailStarted = new Promise<void>((resolve) => {
+      markGuardrailStarted = resolve;
+    });
+    const guardrailCanFinish = new Promise<GuardrailFunctionOutput>(
+      (resolve) => {
+        finishGuardrail = resolve;
+      },
+    );
+    const preparationStarted = new Promise<void>((resolve) => {
+      markPreparationStarted = resolve;
+    });
+    const preparationCanFinish = new Promise<void>((resolve) => {
+      finishPreparation = resolve;
+    });
+    const inputGuardrail = {
+      name: 'pending-guardrail',
+      execute: vi.fn(async () => {
+        markGuardrailStarted?.();
+        return guardrailCanFinish;
+      }),
+    };
+    const model = new CountingFunctionToolStreamModel();
+    const agent = new Agent({
+      name: 'CancelWithPendingGuardrailAgent',
+      model,
+    });
+    const runner = new Runner({
+      inputGuardrails: [inputGuardrail],
+      callModelInputFilter: async ({ modelData }) => {
+        markPreparationStarted?.();
+        await preparationCanFinish;
+        return modelData;
+      },
+    });
+    const result = await runner.run(agent, 'start', { stream: true });
+    const reader = (result.toStream() as any).getReader();
+
+    await Promise.all([guardrailStarted, preparationStarted]);
+    await reader.cancel('stop');
+    finishPreparation?.();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(model.callCount).toBe(0);
+
+    finishGuardrail?.({
+      tripwireTriggered: true,
+      outputInfo: { reason: 'blocked' },
+    });
+    await result._getStreamLoopPromise();
+
+    expect(result.error).toBeInstanceOf(InputGuardrailTripwireTriggered);
+    expect(result.state._currentTurnInProgress).toBe(false);
+    expect(model.callCount).toBe(0);
+  });
+
   it('enforces maxTurns across multiple streamed model calls', async () => {
     // Bug: After first model call, _lastTurnResponse is set, so turn counter never advances.
     // With maxTurns=1, we should only allow 1 model call, but currently allows 2.

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -1559,7 +1559,13 @@ describe('Runner.run (streaming)', () => {
       model,
       tools: [abortableTool],
     });
-    const runner = new Runner();
+    const inputGuardrail = vi.fn(async () => ({
+      tripwireTriggered: false,
+      outputInfo: {},
+    }));
+    const runner = new Runner({
+      inputGuardrails: [{ name: 'run-once', execute: inputGuardrail }],
+    });
     const interrupted = await runner.run(agent, 'start', { stream: true });
     for await (const _event of interrupted) {
       // Drain the interrupted run.
@@ -1583,6 +1589,17 @@ describe('Runner.run (streaming)', () => {
         (item) => item.rawItem.type === 'function_call_result',
       ),
     ).toBe(true);
+
+    const completed = await runner.run(agent, resumed.state, {
+      stream: true,
+    });
+    for await (const _event of completed) {
+      // Drain the completed run.
+    }
+
+    expect(completed.finalOutput).toBe('done');
+    expect(model.callCount).toBe(2);
+    expect(inputGuardrail).toHaveBeenCalledTimes(1);
   });
 
   it('does not call the model when cancelled during next-turn preparation', async () => {

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -3380,6 +3380,57 @@ describe('Runner.run', () => {
       expect(result.state._currentTurn).toBe(1);
     });
 
+    it('does not advance the turn when resuming a schema 1.0 approval interruption', async () => {
+      const approvalTool = tool({
+        name: 'get_weather',
+        description: 'Gets weather for a city.',
+        parameters: z.object({ city: z.string() }),
+        needsApproval: async () => true,
+        execute: async ({ city }) => `Weather in ${city}`,
+      });
+      const model = new FakeModel([
+        {
+          output: [
+            {
+              type: 'function_call',
+              id: 'fc_1',
+              callId: 'call_weather_1',
+              name: 'get_weather',
+              status: 'completed',
+              arguments: JSON.stringify({ city: 'Seattle' }),
+              providerData: {},
+            } as protocol.FunctionCallItem,
+          ],
+          usage: new Usage(),
+        },
+        { output: [fakeModelMessage('All set.')], usage: new Usage() },
+      ]);
+      const agent = new Agent({
+        name: 'LegacyApprovalResume',
+        model,
+        tools: [approvalTool],
+        toolUseBehavior: 'run_llm_again',
+      });
+
+      const interrupted = await run(agent, 'How is the weather?', {
+        maxTurns: 1,
+      });
+      const json = interrupted.state.toJSON() as any;
+      delete json.currentAgentSpan;
+      delete json.currentTurnInProgress;
+      delete json.conversationId;
+      delete json.previousResponseId;
+      json.$schemaVersion = '1.0';
+      const restored = await RunState.fromString(agent, JSON.stringify(json));
+      expect(restored._currentTurnInProgress).toBe(false);
+      restored.approve(restored.getInterruptions()[0]);
+
+      const resumed = await run(agent, restored, { maxTurns: 1 });
+
+      expect(resumed.finalOutput).toBe('All set.');
+      expect(resumed.state._currentTurn).toBe(1);
+    });
+
     it('does nothing when no input guardrails are configured', async () => {
       setTracingDisabled(false);
       setTraceProcessors([new BatchTraceProcessor(new FakeTracingExporter())]);

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -2206,6 +2206,86 @@ describe('sandbox runner integration', () => {
     ).toBe(true);
   });
 
+  it('preserves owned sandbox sessions when a streamed tool settles after cancellation', async () => {
+    const client = new FakeSandboxClient();
+    let markToolStarted: (() => void) | undefined;
+    const toolStarted = new Promise<void>((resolve) => {
+      markToolStarted = resolve;
+    });
+    const sandboxTool = tool({
+      name: 'sandbox_tool',
+      description: 'Settles when the streamed run is cancelled.',
+      parameters: z.object({}).strict(),
+      execute: async (_input, _context, details) => {
+        markToolStarted?.();
+        if (!details?.signal?.aborted) {
+          await new Promise<void>((resolve) => {
+            details?.signal?.addEventListener('abort', () => resolve(), {
+              once: true,
+            });
+          });
+        }
+        return 'cancelled tool result';
+      },
+    });
+    const sandboxModel = new RecordingStreamingModel([
+      {
+        output: [
+          {
+            id: 'fc_cancelled_sandbox_tool',
+            type: 'function_call',
+            name: 'sandbox_tool',
+            callId: 'call_cancelled_sandbox_tool',
+            status: 'completed',
+            arguments: '{}',
+          } satisfies protocol.FunctionCallItem,
+        ],
+        usage: new Usage(),
+      },
+      {
+        output: [fakeModelMessage('resumed sandbox done')],
+        usage: new Usage(),
+      },
+    ]);
+    const sandboxAgent = new SandboxAgent({
+      name: 'CancelledSandboxWorker',
+      model: sandboxModel,
+      tools: [sandboxTool],
+      defaultManifest: new Manifest({ root: '/workspace' }),
+    });
+    const runner = new Runner();
+    const cancelled = await runner.run(sandboxAgent, 'Hello', {
+      stream: true,
+      sandbox: { client },
+    });
+    const reader = (cancelled.toStream() as any).getReader();
+
+    await toolStarted;
+    await reader.cancel('stop');
+    await cancelled._getStreamLoopPromise();
+
+    expect(cancelled.cancelled).toBe(true);
+    expect(client.closeCalls).toEqual([]);
+    expect(cancelled.state._sandbox).toBeDefined();
+    expect(
+      cancelled.state._generatedItems.some(
+        (item) => item.rawItem.type === 'function_call_result',
+      ),
+    ).toBe(true);
+
+    const resumed = await runner.run(sandboxAgent, cancelled.state, {
+      stream: true,
+      sandbox: { client },
+    });
+    for await (const _event of resumed) {
+      // Drain the resumed run.
+    }
+
+    expect(resumed.finalOutput).toBe('resumed sandbox done');
+    expect(client.createCalls).toHaveLength(1);
+    expect(client.closeCalls).toEqual(['session-1']);
+  });
+
   it('clears prior sandbox state when a resumed turn does not touch sandbox agents', async () => {
     const agent = new Agent<unknown, any>({ name: 'PlainAgent' });
     const state = new RunState<unknown, Agent<unknown, any>>(


### PR DESCRIPTION
This pull request is a follow-up for https://github.com/openai/openai-agents-js/pull/1523 and  fixes a streamed-run cancellation race where an in-flight function tool could observe the abort signal, settle, and then allow the runner to begin another model turn. It adds a single cancellation boundary to the streaming loop so the current action batch and RunState updates settle before orchestration stops. Regression coverage verifies both direct and approval-resumed function-tool runs make exactly one model invocation.