### PR TITLE
fix(core): wait for cancelled stream cleanup before resolving completion

### DIFF
--- a/.changeset/steady-streams-settle.md
+++ b/.changeset/steady-streams-settle.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix(core): wait for cancelled stream cleanup before resolving completion (#1521)

--- a/packages/agents-core/src/result.ts
+++ b/packages/agents-core/src/result.ts
@@ -411,8 +411,8 @@ export class StreamedRunResult<
     if (!this.cancelled && this.#readableController) {
       this.#readableController.close();
       this.#readableController = undefined;
-      this.#completedPromiseResolve?.();
     }
+    this.#completedPromiseResolve?.();
     this.#detachAbortHandler();
   }
 
@@ -552,7 +552,6 @@ export class StreamedRunResult<
       }
     }
 
-    this.#completedPromiseResolve?.();
     this.#detachAbortHandler();
   }
 

--- a/packages/agents-core/test/result.test.ts
+++ b/packages/agents-core/test/result.test.ts
@@ -230,9 +230,52 @@ describe('StreamedRunResult', () => {
     controller.abort();
 
     await expect(consumePromise).resolves.toBeUndefined();
+    sr._done();
     await expect(sr.completed).resolves.toBeUndefined();
     expect(sr.cancelled).toBe(true);
     expect(sr.error).toBe(null);
+  });
+
+  it('waits for the background run loop after cancellation', async () => {
+    const state = createState();
+    const controller = new AbortController();
+    const sr = new StreamedRunResult({ state, signal: controller.signal });
+    const reader = (sr.toStream() as any).getReader();
+
+    controller.abort();
+    await expect(reader.read()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+
+    let completedSettled = false;
+    void sr.completed.then(() => {
+      completedSettled = true;
+    });
+    await Promise.resolve();
+
+    expect(completedSettled).toBe(false);
+
+    sr._done();
+    await expect(sr.completed).resolves.toBeUndefined();
+  });
+
+  it('reports a background run error after cancellation', async () => {
+    const state = createState();
+    const controller = new AbortController();
+    const sr = new StreamedRunResult({ state, signal: controller.signal });
+    const reader = (sr.toStream() as any).getReader();
+    const error = new Error('failed after cancellation');
+
+    controller.abort();
+    await expect(reader.read()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+    sr._raiseError(error);
+
+    await expect(sr.completed).rejects.toBe(error);
+    expect(sr.error).toBe(error);
   });
 
   it('preserves an already-aborted signal for the run loop', async () => {
@@ -247,6 +290,7 @@ describe('StreamedRunResult', () => {
     expect(signal).toBeDefined();
     expect(signal?.aborted).toBe(true);
     expect(sr.cancelled).toBe(true);
+    sr._done();
     await expect(sr.completed).resolves.toBeUndefined();
   });
 
@@ -263,6 +307,7 @@ describe('StreamedRunResult', () => {
 
     const reader = (sr.toStream() as any).getReader();
     await reader.cancel();
+    sr._done();
     await sr.completed;
 
     expect(sr.cancelled).toBe(true);

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -1236,6 +1236,68 @@ describe('Runner.run (streaming)', () => {
     expect(result.error).toBe(null);
   });
 
+  it('waits for the background run loop after cancellation', async () => {
+    let markAbortObserved: (() => void) | undefined;
+    const abortObserved = new Promise<void>((resolve) => {
+      markAbortObserved = resolve;
+    });
+    let releaseModel: (() => void) | undefined;
+    const modelReleased = new Promise<void>((resolve) => {
+      releaseModel = resolve;
+    });
+
+    class SettlingStreamingModel implements Model {
+      async getResponse(): Promise<ModelResponse> {
+        throw new Error('Unexpected non-streaming model request');
+      }
+
+      async *getStreamedResponse(
+        request: ModelRequest,
+      ): AsyncIterable<StreamEvent> {
+        yield { type: 'output_text_delta', delta: 'hello' } as StreamEvent;
+        if (!request.signal) {
+          throw new Error('Expected an abort signal');
+        }
+        if (!request.signal.aborted) {
+          await new Promise<void>((resolve) => {
+            request.signal?.addEventListener('abort', () => resolve(), {
+              once: true,
+            });
+          });
+        }
+        markAbortObserved?.();
+        await modelReleased;
+        const error = new Error('Aborted');
+        error.name = 'AbortError';
+        throw error;
+      }
+    }
+
+    const agent = new Agent({
+      name: 'SettlingStream',
+      model: new SettlingStreamingModel(),
+    });
+    const result = await run(agent, 'go', { stream: true });
+    const reader = (result.toStream() as any).getReader();
+
+    await expect(reader.read()).resolves.toMatchObject({ done: false });
+    await reader.cancel('stop');
+    await abortObserved;
+
+    let completedSettled = false;
+    void result.completed.then(() => {
+      completedSettled = true;
+    });
+    await Promise.resolve();
+
+    expect(completedSettled).toBe(false);
+
+    releaseModel?.();
+    await expect(result.completed).resolves.toBeUndefined();
+    expect(result.cancelled).toBe(true);
+    expect(result.error).toBe(null);
+  });
+
   it('marks inputs as sent when aborted before first stream event in server-managed conversations', async () => {
     const waitWithAbort = (ms: number, signal?: AbortSignal) =>
       new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
This pull request fixes the settlement contract of cancelled streamed runs. It is a prerequisite for #1521, but it does not resolve the issue or propagate cancellation signals into function tools.

## Background

`StreamedRunResult` exposes both a readable event stream and a `completed` promise. Cancelling the reader correctly closed the readable stream immediately, but the same abort handler also resolved `completed` before the background run loop had finished.

That allowed the following sequence:

1. A caller cancelled the stream.
2. `stream.completed` resolved immediately.
3. The caller resumed or inspected `stream.state`.
4. The original background loop continued mutating that same state, persisting session data, or cleaning up resources.

This contradicted the documented contract that callers can await `stream.completed` before treating the run as settled.

## What changed

Cancellation still closes the readable event stream immediately and marks the result as cancelled. However, the abort handler no longer resolves `completed`.

`completed` is now settled only by the background run loop:

- `_done()` resolves it after normal cancellation settlement and cleanup.
- `_raiseError()` rejects it when the background loop discovers an error after cancellation.

As a result, once `stream.completed` settles, the previous run loop no longer owns or mutates the exposed `RunState`.

## Relationship to #1521

Issue #1521 reports that `RunOptions.signal` does not reach `ToolCallDetails.signal`, so in-flight function tools cannot observe run cancellation.

This pull request does not add that signal propagation. It establishes the lifecycle invariant needed to implement it safely in a follow-up:

> A caller must not resume a cancelled `RunState` until the cancelled run has finished settling and relinquished ownership of that state.

After this change is merged, a follow-up for #1521 can propagate cancellation into function tools while reasoning from a stable completion boundary.

## How this differs from the reverted work

PR #1523 propagated run and reader-cancellation signals directly into function tools. However, it left the existing early `completed` resolution unchanged. A cooperative tool could therefore settle after the public completion promise had already resolved, allowing the original and resumed loops to mutate the same `RunState`.

PR #1525 attempted to repair the resulting behavior by adding cancellation checks throughout the run loop. Those checks expanded into preparation, guardrail, session-persistence, accepted-response, approval, turn-accounting, and sandbox-lifetime cases. The approach lacked a single ownership boundary, so each additional check exposed another race.

PR #1526 reverted #1523 before release.

This pull request takes a narrower approach:

- It does not modify `run.ts`, tool execution, action resolution, sessions, sandboxes, approvals, or RunState serialization.
- It does not attempt to stop or reconcile function tools.
- It fixes one underlying invariant at the owner of the public completion promise.
- It keeps stream closure prompt while separating stream consumption from background-run settlement.

## Behavior consideration

If a provider or user callback does not cooperate with cancellation and remains pending, `stream.completed` will also remain pending until that work settles. JavaScript promises cannot be forcibly stopped, and resolving `completed` while such work still owns the run state would reintroduce the race this change fixes.

The readable event stream still closes immediately, so consumers can stop reading without waiting for background settlement.

## Follow-up scope

A separate follow-up for #1521 should:

- propagate the run cancellation signal into supported function-tool execution paths;
- settle the accepted current action batch into a resumable state;
- prevent another model turn after cancellation;
- preserve session and sandbox state only for successful resumable cancellation;
- keep persistence or cleanup failures as errors rather than exposing them as successfully completed cancellation.