### PR TITLE
fix(core): propagate non-streaming run cancellation to function tools

### DIFF
--- a/.changeset/gentle-tools-cancel.md
+++ b/.changeset/gentle-tools-cancel.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix(core): reconcile non-streaming function tool cancellation safely (#1521)

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -602,9 +602,12 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     const useTaskAndTurnSpans =
       !this.config.tracingDisabled && includeTaskAndTurnSpans(tracingConfig);
     const resumingFromState = input instanceof RunState;
+    // A resumed turn may be inactive but already have persisted items.
     const preserveTurnPersistenceOnResume =
       resumingFromState &&
-      (input as RunState<TContext, TAgent>)._currentTurnInProgress === true;
+      ((input as RunState<TContext, TAgent>)._currentTurnInProgress === true ||
+        (input as RunState<TContext, TAgent>)._currentTurnPersistedItemCount >
+          0);
     const resumedConversationId = resumingFromState
       ? (input as RunState<TContext, TAgent>)._conversationId
       : undefined;
@@ -1004,6 +1007,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       };
       setRunStateUsageRecorder(state, recordUsage);
       let completedResult: RunResult<TContext, TAgent> | undefined;
+      let persistenceCheckpoint: RunResult<TContext, TAgent> | undefined;
       const completeResult = (result: RunResult<TContext, TAgent>) => {
         completedResult = result;
         return result;
@@ -1043,7 +1047,12 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               runner: this,
               toolErrorFormatter,
               agentToolParentRunConfig,
+              signal: options.signal,
             });
+            if (options.signal?.aborted) {
+              persistenceCheckpoint = new RunResult<TContext, TAgent>(state);
+            }
+            options.signal?.throwIfAborted();
 
             // Don't reset counter here - resolveInterruptedTurn already adjusted it via rewind logic
             // The counter will be reset when _currentTurn is incremented (starting a new turn)
@@ -1220,6 +1229,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               toolErrorFormatter,
               agentToolParentRunConfig,
               options.errorHandlers,
+              options.signal,
             );
 
             applyTurnResult({
@@ -1229,6 +1239,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               toolsUsed: state._lastProcessedResponse?.toolsUsed ?? [],
               resetTurnPersistence: !isResumedState,
             });
+            if (options.signal?.aborted) {
+              persistenceCheckpoint = new RunResult<TContext, TAgent>(state);
+            }
+            options.signal?.throwIfAborted();
             if (turnResult.nextStep.type !== 'next_step_final_output') {
               finishRunnerSpan(currentTurnSpan);
               setRunStateTurnSpanParent(state, undefined);
@@ -1344,9 +1358,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             setRunnerSpanError(taskSpan, error);
             await Promise.reject(error);
           }
-          if (completedResult) {
+          const resultToPersist = completedResult ?? persistenceCheckpoint;
+          if (resultToPersist) {
             try {
-              await persistResult?.(completedResult);
+              await persistResult?.(resultToPersist);
             } catch (error) {
               setRunnerSpanError(taskSpan, error);
               await Promise.reject(error);

--- a/packages/agents-core/src/runner/runLoop.ts
+++ b/packages/agents-core/src/runner/runLoop.ts
@@ -64,6 +64,7 @@ export async function resumeInterruptedTurn<
   runner: Runner;
   toolErrorFormatter?: ToolErrorFormatter;
   agentToolParentRunConfig?: Partial<RunConfig>;
+  signal?: AbortSignal;
   onStepItems?: (turnResult: SingleStepResult) => void;
 }): Promise<InterruptedTurnOutcome> {
   const {
@@ -71,6 +72,7 @@ export async function resumeInterruptedTurn<
     runner,
     toolErrorFormatter,
     agentToolParentRunConfig,
+    signal,
     onStepItems,
   } = options;
   const turnResult = await resolveInterruptedTurn<TContext>(
@@ -83,6 +85,7 @@ export async function resumeInterruptedTurn<
     state,
     toolErrorFormatter,
     agentToolParentRunConfig,
+    signal,
   );
 
   applyTurnResult({

--- a/packages/agents-core/src/runner/streamReconciliation.ts
+++ b/packages/agents-core/src/runner/streamReconciliation.ts
@@ -3,6 +3,8 @@ import { randomUUID } from '@openai/agents-core/_shims';
 import type { ModelRequest, ModelResponse } from '../model';
 import type {
   ApplyPatchCallResultItem,
+  ComputerCallResultItem,
+  ComputerUseCallItem,
   FunctionCallItem,
   FunctionCallResultItem,
   ProgramCallResultItem,
@@ -28,6 +30,71 @@ export type StreamAbortReconciliationState = {
   pendingApplyPatchCalls: Map<string, PendingStreamedToolCall>;
   pendingProgramCalls: Map<string, string>;
 };
+
+// 1x1 transparent PNG data URL used when a computer result requires an image
+// but cancellation prevents the SDK from capturing the current screen.
+export const COMPUTER_FALLBACK_SCREENSHOT_DATA_URL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/iZk9HQAAAABJRU5ErkJggg==';
+
+export function buildFunctionAbortResult(
+  toolCall: PendingStreamedFunctionCall,
+): FunctionCallResultItem {
+  return {
+    type: 'function_call_result',
+    name: toolCall.name,
+    ...(typeof toolCall.namespace === 'string'
+      ? { namespace: toolCall.namespace }
+      : {}),
+    callId: toolCall.callId,
+    status: 'incomplete',
+    output: { type: 'text', text: 'aborted' },
+    ...(toolCall.caller ? { caller: toolCall.caller } : {}),
+  };
+}
+
+export function buildComputerAbortResult(
+  toolCall: Pick<ComputerUseCallItem, 'callId'>,
+): ComputerCallResultItem {
+  return {
+    type: 'computer_call_result',
+    callId: toolCall.callId,
+    output: {
+      type: 'computer_screenshot',
+      data: COMPUTER_FALLBACK_SCREENSHOT_DATA_URL,
+    },
+    providerData: { status: 'incomplete' },
+  };
+}
+
+export function buildShellAbortResult(
+  toolCall: PendingStreamedToolCall,
+): ShellCallResultItem {
+  return {
+    type: 'shell_call_output',
+    callId: toolCall.callId,
+    status: 'incomplete',
+    output: [
+      {
+        stdout: '',
+        stderr: 'aborted',
+        outcome: { type: 'timeout' },
+      },
+    ],
+    ...(toolCall.caller ? { caller: toolCall.caller } : {}),
+  };
+}
+
+export function buildApplyPatchAbortResult(
+  toolCall: PendingStreamedToolCall,
+): ApplyPatchCallResultItem {
+  return {
+    type: 'apply_patch_call_output',
+    callId: toolCall.callId,
+    status: 'failed',
+    output: 'aborted',
+    ...(toolCall.caller ? { caller: toolCall.caller } : {}),
+  };
+}
 
 export function createStreamAbortReconciliationState(): StreamAbortReconciliationState {
   return {
@@ -160,43 +227,15 @@ export function buildAbortReconciliationInput(
 )[] {
   const functionOutputs = Array.from(
     state.pendingFunctionCalls.values(),
-    (toolCall): FunctionCallResultItem => ({
-      type: 'function_call_result',
-      name: toolCall.name,
-      ...(typeof toolCall.namespace === 'string'
-        ? { namespace: toolCall.namespace }
-        : {}),
-      callId: toolCall.callId,
-      status: 'incomplete',
-      output: { type: 'text', text: 'aborted' },
-      ...(toolCall.caller ? { caller: toolCall.caller } : {}),
-    }),
+    buildFunctionAbortResult,
   );
   const shellOutputs = Array.from(
     state.pendingShellCalls.values(),
-    (toolCall): ShellCallResultItem => ({
-      type: 'shell_call_output',
-      callId: toolCall.callId,
-      status: 'incomplete',
-      output: [
-        {
-          stdout: '',
-          stderr: 'aborted',
-          outcome: { type: 'timeout' },
-        },
-      ],
-      ...(toolCall.caller ? { caller: toolCall.caller } : {}),
-    }),
+    buildShellAbortResult,
   );
   const applyPatchOutputs = Array.from(
     state.pendingApplyPatchCalls.values(),
-    (toolCall): ApplyPatchCallResultItem => ({
-      type: 'apply_patch_call_output',
-      callId: toolCall.callId,
-      status: 'failed',
-      output: 'aborted',
-      ...(toolCall.caller ? { caller: toolCall.caller } : {}),
-    }),
+    buildApplyPatchAbortResult,
   );
   const programOutputs = Array.from(
     state.pendingProgramCalls,

--- a/packages/agents-core/src/runner/streaming.ts
+++ b/packages/agents-core/src/runner/streaming.ts
@@ -14,24 +14,7 @@ import {
 } from '../items';
 import { StreamedRunResult } from '../result';
 
-export const isAbortError = (error: unknown): boolean => {
-  if (!error) {
-    return false;
-  }
-  if (error instanceof Error && error.name === 'AbortError') {
-    return true;
-  }
-  const DomExceptionCtor =
-    typeof DOMException !== 'undefined' ? DOMException : undefined;
-  if (
-    DomExceptionCtor &&
-    error instanceof DomExceptionCtor &&
-    error.name === 'AbortError'
-  ) {
-    return true;
-  }
-  return false;
-};
+export { isAbortError } from '../utils/abortSignals';
 
 function getRunItemStreamEventName(
   item: RunItem,

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -44,6 +44,7 @@ import {
 import type { ShellResult } from '../shell';
 import { RunContext } from '../runContext';
 import type { RunResult } from '../result';
+import { isAbortError } from '../utils/abortSignals';
 import { toSmartString } from '../utils/smartString';
 import { isZodObject } from '../utils';
 import { withFunctionSpan, withHandoffSpan } from '../tracing/createSpans';
@@ -86,6 +87,11 @@ import {
   setToolUsageRecorder,
 } from './usageTracking';
 import { getRunStateTurnSpanParent } from './invocationContext';
+import {
+  buildComputerAbortResult,
+  buildFunctionAbortResult,
+  COMPUTER_FALLBACK_SCREENSHOT_DATA_URL,
+} from './streamReconciliation';
 
 type FunctionToolCallDeps<TContext = UnknownContext> = {
   agent: Agent<TContext, any>;
@@ -93,13 +99,11 @@ type FunctionToolCallDeps<TContext = UnknownContext> = {
   state: RunState<TContext, Agent<TContext, any>>;
   toolErrorFormatter?: ToolErrorFormatter;
   agentToolParentRunConfig?: Partial<RunConfig>;
+  signal?: AbortSignal;
 };
 
 const REDACTED_TOOL_ERROR_MESSAGE =
   'Tool execution failed. Error details are redacted.';
-// 1x1 transparent PNG data URL used for rejected computer actions.
-const TOOL_APPROVAL_REJECTION_SCREENSHOT_DATA_URL =
-  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/iZk9HQAAAABJRU5ErkJggg==';
 
 type ParseToolArgumentsResult =
   { success: true; args: any } | { success: false; error: Error };
@@ -234,6 +238,7 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
   state: RunState<TContext, Agent<TContext, any>>,
   toolErrorFormatter?: ToolErrorFormatter,
   agentToolParentRunConfig?: Partial<RunConfig>,
+  signal?: AbortSignal,
 ): Promise<FunctionToolResult<TContext>[]> {
   const deps: FunctionToolCallDeps<TContext> = {
     agent,
@@ -241,9 +246,14 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
     state,
     toolErrorFormatter,
     agentToolParentRunConfig,
+    signal,
   };
 
   const executeToolRun = async (toolRun: ToolRunFunction<TContext>) => {
+    if (signal?.aborted) {
+      return buildFunctionCancellationResult(deps, toolRun);
+    }
+
     const parseResult = parseToolArguments(toolRun);
     const dynamicApprovalPolicy = hasDynamicFunctionToolApprovalPolicy(
       toolRun.tool,
@@ -275,7 +285,14 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
     if (approvalOutcome !== 'approved') {
       return approvalOutcome;
     }
-    return runApprovedFunctionTool(deps, toolRun, parseResult.args);
+    try {
+      return await runApprovedFunctionTool(deps, toolRun, parseResult.args);
+    } catch (error) {
+      if (signal?.aborted && (error === signal.reason || isAbortError(error))) {
+        return buildFunctionCancellationResult(deps, toolRun);
+      }
+      throw error;
+    }
   };
 
   try {
@@ -335,28 +352,31 @@ async function executeToolRunsWithConcurrency<TContext>(
 
   const results: FunctionToolResult<TContext>[] = [];
   let nextIndex = 0;
-  let firstError: unknown;
+  let firstError: { value: unknown } | undefined;
 
   const worker = async () => {
     while (nextIndex < toolRuns.length && firstError === undefined) {
       const currentIndex = nextIndex;
       nextIndex += 1;
       try {
-        results[currentIndex] = await executeToolRun(toolRuns[currentIndex]);
+        const result = await executeToolRun(toolRuns[currentIndex]);
+        results[currentIndex] = result;
       } catch (error) {
-        firstError ??= error;
+        firstError ??= { value: error };
         break;
       }
     }
   };
 
   const workerCount = Math.min(maxConcurrency, toolRuns.length);
+  // Drain every started worker before returning so no function tool retains
+  // ownership after the run surfaces an error or cancellation.
   await Promise.allSettled(
     Array.from({ length: workerCount }, async () => worker()),
   );
 
   if (firstError !== undefined) {
-    throw firstError;
+    throw firstError.value;
   }
   return results;
 }
@@ -416,6 +436,20 @@ function buildFunctionFailureResult<TContext>(
       deps.agent,
       output,
     ),
+  };
+}
+
+function buildFunctionCancellationResult<TContext>(
+  deps: FunctionToolCallDeps<TContext>,
+  toolRun: ToolRunFunction<TContext>,
+): FunctionToolResult<TContext> {
+  const output = 'aborted';
+  const rawItem = buildFunctionAbortResult(toolRun.toolCall);
+  return {
+    type: 'function_output',
+    tool: toolRun.tool,
+    output,
+    runItem: new RunToolCallOutputItem(rawItem, deps.agent, output),
   };
 }
 
@@ -609,7 +643,7 @@ async function runApprovedFunctionTool<TContext>(
   toolRun: ToolRunFunction<TContext>,
   parsedInput: unknown,
 ): Promise<FunctionToolResult<TContext>> {
-  const { agent, runner, state, agentToolParentRunConfig } = deps;
+  const { agent, runner, state, agentToolParentRunConfig, signal } = deps;
   const toolName = getFunctionToolIdentity(toolRun);
   const traceToolName = getFunctionToolTraceName(toolRun);
   return withRunStateToolFunctionSpan(deps, traceToolName, async (span) => {
@@ -627,6 +661,10 @@ async function runApprovedFunctionTool<TContext>(
           state._toolInputGuardrailResults.push(result);
         },
       });
+
+      if (signal?.aborted) {
+        return buildFunctionCancellationResult(deps, toolRun);
+      }
 
       emitToolStart(
         runner,
@@ -655,6 +693,7 @@ async function runApprovedFunctionTool<TContext>(
         toolDetails = {
           toolCall: toolRun.toolCall,
           resumeState,
+          ...(signal ? { signal } : {}),
           [FUNCTION_TOOL_PARSED_INPUT_CALLBACK]: (input: unknown) => {
             executedInput = cloneForCustomDataContext(input);
           },
@@ -665,6 +704,7 @@ async function runApprovedFunctionTool<TContext>(
           agentToolParentRunConfig ?? runner.config,
         );
         setToolCallParentSpanOnDetails(toolDetails, span);
+        signal?.throwIfAborted();
         const invokedToolOutput = await invokeFunctionTool({
           tool: toolRun.tool,
           runContext: state._context,
@@ -1378,12 +1418,18 @@ export async function executeComputerActions(
   runContext: RunContext,
   customLogger: Logger | undefined = undefined,
   toolErrorFormatter?: ToolErrorFormatter,
+  signal?: AbortSignal,
 ): Promise<RunItem[]> {
   const _logger = customLogger ?? logger;
   const results: RunItem[] = [];
   for (const action of actions) {
     const toolCall = action.toolCall;
     const computerTool = action.computer;
+    if (signal?.aborted) {
+      const rawItem = buildComputerAbortResult(toolCall);
+      results.push(new RunToolCallOutputItem(rawItem, agent, 'aborted'));
+      continue;
+    }
     const computerActions = getComputerToolActions(toolCall);
     let cachedRejectionMessage: string | undefined;
     const getRejectionMessage = async () => {
@@ -1434,7 +1480,7 @@ export async function executeComputerActions(
         const rejectionMessage = await getRejectionMessage();
         const rejectionOutput: protocol.ComputerToolOutput = {
           type: 'computer_screenshot',
-          data: TOOL_APPROVAL_REJECTION_SCREENSHOT_DATA_URL,
+          data: COMPUTER_FALLBACK_SCREENSHOT_DATA_URL,
           providerData: {
             approvalStatus: 'rejected',
             message: rejectionMessage,
@@ -1448,7 +1494,7 @@ export async function executeComputerActions(
         return new RunToolCallOutputItem(
           rawItem,
           agent,
-          TOOL_APPROVAL_REJECTION_SCREENSHOT_DATA_URL,
+          COMPUTER_FALLBACK_SCREENSHOT_DATA_URL,
         );
       },
     });
@@ -1776,7 +1822,18 @@ export async function checkForFinalOutputFromTools<
     );
   });
 
-  if (finalizationResults.length === 0) {
+  const isIncompleteFunctionResult = (result: FunctionToolResult<TContext>) => {
+    const rawItem = result.runItem.rawItem;
+    return (
+      result.type === 'function_output' &&
+      rawItem?.type === 'function_call_result' &&
+      rawItem.status === 'incomplete'
+    );
+  };
+  if (
+    finalizationResults.length === 0 ||
+    finalizationResults.some(isIncompleteFunctionResult)
+  ) {
     return NOT_FINAL_OUTPUT;
   }
 

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -51,6 +51,11 @@ import {
   validateRunErrorHandlerFinalOutput,
 } from './errorHandlers';
 import { getTurnInput } from './items';
+import {
+  buildApplyPatchAbortResult,
+  buildFunctionAbortResult,
+  buildShellAbortResult,
+} from './streamReconciliation';
 
 const DEFAULT_TOOL_NOT_FOUND_MESSAGE = (toolName: string) =>
   `Tool '${toolName}' not found.`;
@@ -484,6 +489,7 @@ async function executeShellAndApplyPatchActionsInOrder<TContext>(args: {
   runner: Runner;
   state: RunState<TContext, Agent<TContext, any>>;
   toolErrorFormatter?: ToolErrorFormatter;
+  signal?: AbortSignal;
 }): Promise<RunItem[]> {
   const results: RunItem[] = [];
   for (const action of orderShellAndApplyPatchActions(
@@ -491,6 +497,14 @@ async function executeShellAndApplyPatchActionsInOrder<TContext>(args: {
     args.shellActions,
     args.applyPatchActions,
   )) {
+    if (args.signal?.aborted) {
+      const rawItem =
+        action.type === 'shell'
+          ? buildShellAbortResult(action.action.toolCall)
+          : buildApplyPatchAbortResult(action.action.toolCall);
+      results.push(new RunToolCallOutputItem(rawItem, args.agent, 'aborted'));
+      continue;
+    }
     const items =
       action.type === 'shell'
         ? await executeShellActions(
@@ -630,6 +644,7 @@ export async function resolveInterruptedTurn<TContext>(
   state: RunState<TContext, Agent<TContext, any>>,
   toolErrorFormatter?: ToolErrorFormatter,
   agentToolParentRunConfig?: Partial<RunConfig>,
+  signal?: AbortSignal,
 ): Promise<SingleStepResult> {
   // call_ids for function tools
   const functionCallIds = originalPreStepItems
@@ -766,6 +781,7 @@ export async function resolveInterruptedTurn<TContext>(
     state,
     toolErrorFormatter,
     agentToolParentRunConfig,
+    signal,
   );
 
   // Computer actions may require approval; only pending approved actions are executed on resume.
@@ -778,6 +794,7 @@ export async function resolveInterruptedTurn<TContext>(
           state._context,
           undefined,
           toolErrorFormatter,
+          signal,
         )
       : [];
 
@@ -791,6 +808,7 @@ export async function resolveInterruptedTurn<TContext>(
           runner,
           state,
           toolErrorFormatter,
+          signal,
         })
       : [];
   const pendingFunctionToolsNotFound = filterPendingActions(
@@ -956,6 +974,7 @@ export async function resolveTurnAfterModelResponse<
   toolErrorFormatter?: ToolErrorFormatter,
   agentToolParentRunConfig?: Partial<RunConfig>,
   errorHandlers?: RunErrorHandlers<TContext, TAgent>,
+  signal?: AbortSignal,
 ): Promise<SingleStepResult> {
   // Reuse the same array reference so we can compare object identity when deciding whether to
   // append new items, ensuring we never double-stream existing RunItems.
@@ -979,6 +998,7 @@ export async function resolveTurnAfterModelResponse<
       state,
       toolErrorFormatter,
       agentToolParentRunConfig,
+      signal,
     ),
     executeComputerActions(
       agent,
@@ -987,6 +1007,7 @@ export async function resolveTurnAfterModelResponse<
       state._context,
       undefined,
       toolErrorFormatter,
+      signal,
     ),
   ]);
   const shellAndApplyPatchResults =
@@ -1000,6 +1021,7 @@ export async function resolveTurnAfterModelResponse<
           runner,
           state,
           toolErrorFormatter,
+          signal,
         })
       : [];
   const toolNotFoundResults = await buildToolNotFoundOutputItems(
@@ -1058,17 +1080,24 @@ export async function resolveTurnAfterModelResponse<
 
   // process handoffs
   if (processedResponse.handoffs.length > 0) {
-    return await executeHandoffCalls(
-      agent,
-      originalInput,
-      preStepItems,
-      newItems,
-      newResponse,
-      processedResponse.handoffs as ToolRunHandoff[],
-      runner,
-      state._context,
-      getRunStateTurnSpanParent(state) ?? state._currentAgentSpan,
-    );
+    if (signal?.aborted) {
+      for (const { toolCall } of processedResponse.handoffs) {
+        const rawItem = buildFunctionAbortResult(toolCall);
+        appendIfNew(new RunToolCallOutputItem(rawItem, agent, rawItem.output));
+      }
+    } else {
+      return await executeHandoffCalls(
+        agent,
+        originalInput,
+        preStepItems,
+        newItems,
+        newResponse,
+        processedResponse.handoffs as ToolRunHandoff[],
+        runner,
+        state._context,
+        getRunStateTurnSpanParent(state) ?? state._currentAgentSpan,
+      );
+    }
   }
 
   const completedStep = await maybeCompleteTurnFromToolResults({

--- a/packages/agents-core/src/tool.ts
+++ b/packages/agents-core/src/tool.ts
@@ -12,7 +12,7 @@ import { safeExecute } from './utils/safeExecute';
 import { toFunctionToolName } from './utils/tools';
 import { getSchemaAndParserFromInputType } from './utils/tools';
 import { isZodObject } from './utils/typeGuards';
-import { combineAbortSignals } from './utils/abortSignals';
+import { combineAbortSignals, isAbortError } from './utils/abortSignals';
 import { RunContext } from './runContext';
 import type { RunConfig } from './run';
 import type { RunResult } from './result';
@@ -2259,7 +2259,9 @@ export function tool<
     return _invoke(runContext, input, details).catch(async (error) => {
       if (
         details?.signal?.aborted &&
-        details.signal.reason instanceof ToolTimeoutError
+        (error === details.signal.reason ||
+          isAbortError(error) ||
+          details.signal.reason instanceof ToolTimeoutError)
       ) {
         throw error;
       }

--- a/packages/agents-core/src/utils/abortSignals.ts
+++ b/packages/agents-core/src/utils/abortSignals.ts
@@ -7,6 +7,22 @@ type CombineAbortSignalsOptions = {
   onAbortSignalAnyError?: (error: unknown) => void;
 };
 
+export function isAbortError(error: unknown): boolean {
+  if (!error) {
+    return false;
+  }
+  if (error instanceof Error && error.name === 'AbortError') {
+    return true;
+  }
+  const DomExceptionCtor =
+    typeof DOMException !== 'undefined' ? DOMException : undefined;
+  return Boolean(
+    DomExceptionCtor &&
+    error instanceof DomExceptionCtor &&
+    error.name === 'AbortError',
+  );
+}
+
 export function combineAbortSignals(
   ...signals: (AbortSignal | undefined)[]
 ): CombineAbortSignalsResult {

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -1,4 +1,5 @@
 import { Buffer } from 'node:buffer';
+import { setTimeout as setTimeoutPromise } from 'node:timers/promises';
 import {
   beforeAll,
   beforeEach,
@@ -60,6 +61,7 @@ import {
   hostedMcpTool,
   computerTool,
   shellTool,
+  applyPatchTool,
   type HostedTool,
 } from '../src/tool';
 import logger from '../src/logger';
@@ -76,6 +78,8 @@ import {
   TEST_MODEL_FUNCTION_CALL,
   TEST_TOOL,
   FakeComputer,
+  FakeEditor,
+  FakeShell,
 } from './stubs';
 import {
   Model,
@@ -127,6 +131,726 @@ describe('Runner.run', () => {
       });
 
       expect(runner.config.toolExecution).toBe(toolExecution);
+    });
+
+    it('propagates run cancellation to a direct function tool', async () => {
+      const controller = new AbortController();
+      const abortReason = new Error('stop direct tool');
+      let toolSignal: AbortSignal | undefined;
+      let markToolStarted: (() => void) | undefined;
+      const toolStarted = new Promise<void>((resolve) => {
+        markToolStarted = resolve;
+      });
+      let releaseTool: (() => void) | undefined;
+      const toolCanFinish = new Promise<void>((resolve) => {
+        releaseTool = resolve;
+      });
+      const abortableTool = tool({
+        name: 'test',
+        description: 'finishes cleanup after the run is cancelled',
+        parameters: z.object({ test: z.string() }),
+        execute: async (_input, _context, details) => {
+          toolSignal = details?.signal;
+          markToolStarted?.();
+          await toolCanFinish;
+          return 'cancelled after cleanup';
+        },
+      });
+      const model = new FakeModel([
+        {
+          output: [{ ...TEST_MODEL_FUNCTION_CALL }],
+          usage: new Usage(),
+        },
+        {
+          output: [fakeModelMessage('unexpected second response')],
+          usage: new Usage(),
+        },
+      ]);
+      const getResponseSpy = vi.spyOn(model, 'getResponse');
+      const agent = new Agent({
+        name: 'DirectCancellationAgent',
+        model,
+        tools: [abortableTool],
+      });
+      const state = new RunState(new RunContext(), 'start', agent, 10);
+
+      const runPromise = run(agent, state, { signal: controller.signal });
+      const rejection = expect(runPromise).rejects.toBe(abortReason);
+      await toolStarted;
+
+      expect(toolSignal).toBe(controller.signal);
+      controller.abort(abortReason);
+      releaseTool?.();
+
+      await rejection;
+      expect(getResponseSpy).toHaveBeenCalledTimes(1);
+      expect(
+        state._generatedItems.filter(
+          (item) => item.rawItem.type === 'function_call_result',
+        ),
+      ).toHaveLength(1);
+    });
+
+    it('preserves a function tool abort reason without wrapping it', async () => {
+      const controller = new AbortController();
+      const abortReason = new Error('stop failed tool');
+      let markToolStarted: (() => void) | undefined;
+      const toolStarted = new Promise<void>((resolve) => {
+        markToolStarted = resolve;
+      });
+      const abortableTool = tool({
+        name: 'test',
+        description: 'throws the run abort reason',
+        parameters: z.object({ test: z.string() }),
+        execute: async (_input, _context, details) => {
+          markToolStarted?.();
+          if (!details?.signal) {
+            throw new Error('Expected the run abort signal');
+          }
+          await setTimeoutPromise(60_000, undefined, {
+            signal: details.signal,
+          });
+          return 'unexpected tool output';
+        },
+      });
+      const model = new FakeModel([
+        {
+          output: [{ ...TEST_MODEL_FUNCTION_CALL }],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'AbortReasonAgent',
+        model,
+        tools: [abortableTool],
+      });
+      const state = new RunState(new RunContext(), 'start', agent, 10);
+
+      const runPromise = run(agent, state, { signal: controller.signal });
+      const rejection = expect(runPromise).rejects.toBe(abortReason);
+      await toolStarted;
+
+      controller.abort(abortReason);
+
+      await rejection;
+      expect(
+        state._generatedItems.filter(
+          (item) =>
+            item.rawItem.type === 'function_call_result' &&
+            item.rawItem.callId === TEST_MODEL_FUNCTION_CALL.callId &&
+            item.rawItem.status === 'incomplete',
+        ),
+      ).toHaveLength(1);
+    });
+
+    it('waits for sibling function tools before surfacing cancellation', async () => {
+      const controller = new AbortController();
+      const abortReason = new Error('stop parallel tools');
+      let markAbortToolStarted: (() => void) | undefined;
+      const abortToolStarted = new Promise<void>((resolve) => {
+        markAbortToolStarted = resolve;
+      });
+      let markAbortObserved: (() => void) | undefined;
+      const abortObserved = new Promise<void>((resolve) => {
+        markAbortObserved = resolve;
+      });
+      let markSiblingStarted: (() => void) | undefined;
+      const siblingStarted = new Promise<void>((resolve) => {
+        markSiblingStarted = resolve;
+      });
+      let releaseSibling: (() => void) | undefined;
+      const siblingCanFinish = new Promise<void>((resolve) => {
+        releaseSibling = resolve;
+      });
+      let siblingFinished = false;
+
+      const abortableTool = tool({
+        name: 'abortable_tool',
+        description: 'throws the run abort reason',
+        parameters: z.object({ test: z.string() }),
+        errorFunction: null,
+        execute: async (_input, _context, details) => {
+          markAbortToolStarted?.();
+          if (!details?.signal) {
+            throw new Error('Expected the run abort signal');
+          }
+          try {
+            await setTimeoutPromise(60_000, undefined, {
+              signal: details.signal,
+            });
+          } catch (error) {
+            markAbortObserved?.();
+            throw error;
+          }
+          return 'unexpected tool output';
+        },
+      });
+      const siblingTool = tool({
+        name: 'sibling_tool',
+        description: 'finishes independently of run cancellation',
+        parameters: z.object({ test: z.string() }),
+        execute: async () => {
+          markSiblingStarted?.();
+          await siblingCanFinish;
+          siblingFinished = true;
+          return 'sibling complete';
+        },
+      });
+      const model = new FakeModel([
+        {
+          output: [
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              id: 'abortable-call',
+              callId: 'abortable-call',
+              name: 'abortable_tool',
+            },
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              id: 'sibling-call',
+              callId: 'sibling-call',
+              name: 'sibling_tool',
+            },
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'ParallelCancellationAgent',
+        model,
+        tools: [abortableTool, siblingTool],
+      });
+      const state = new RunState(new RunContext(), 'start', agent, 10);
+
+      const runPromise = run(agent, state, { signal: controller.signal });
+      let runSettled = false;
+      const runOutcome = runPromise.then(
+        () => {
+          runSettled = true;
+          return { error: undefined };
+        },
+        (error: unknown) => {
+          runSettled = true;
+          return { error };
+        },
+      );
+      await Promise.all([abortToolStarted, siblingStarted]);
+
+      controller.abort(abortReason);
+      await abortObserved;
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      const settledBeforeSibling = runSettled;
+
+      releaseSibling?.();
+      const outcome = await runOutcome;
+
+      expect(settledBeforeSibling).toBe(false);
+      expect(siblingFinished).toBe(true);
+      expect(outcome.error).toBe(abortReason);
+      expect(
+        state._generatedItems.filter(
+          (item) =>
+            item.rawItem.type === 'function_call_result' &&
+            item.rawItem.callId === 'sibling-call',
+        ),
+      ).toHaveLength(1);
+    });
+
+    it('waits for a concurrent computer action before surfacing cancellation', async () => {
+      const controller = new AbortController();
+      const abortReason = new Error('stop parallel actions');
+      let markAbortToolStarted: (() => void) | undefined;
+      const abortToolStarted = new Promise<void>((resolve) => {
+        markAbortToolStarted = resolve;
+      });
+      let markAbortObserved: (() => void) | undefined;
+      const abortObserved = new Promise<void>((resolve) => {
+        markAbortObserved = resolve;
+      });
+      let markComputerStarted: (() => void) | undefined;
+      const computerStarted = new Promise<void>((resolve) => {
+        markComputerStarted = resolve;
+      });
+      let releaseComputer: (() => void) | undefined;
+      const computerCanFinish = new Promise<void>((resolve) => {
+        releaseComputer = resolve;
+      });
+      let computerFinished = false;
+
+      const abortableTool = tool({
+        name: 'abortable_tool',
+        description: 'throws the run abort reason',
+        parameters: z.object({ test: z.string() }),
+        errorFunction: null,
+        execute: async (_input, _context, details) => {
+          markAbortToolStarted?.();
+          if (!details?.signal) {
+            throw new Error('Expected the run abort signal');
+          }
+          if (!details.signal.aborted) {
+            await new Promise<void>((resolve) => {
+              details.signal?.addEventListener('abort', () => resolve(), {
+                once: true,
+              });
+            });
+          }
+          markAbortObserved?.();
+          details.signal.throwIfAborted();
+          return 'unexpected tool output';
+        },
+      });
+      const computer = new FakeComputer();
+      const computerClick = vi.fn(async () => {
+        markComputerStarted?.();
+        await computerCanFinish;
+        computerFinished = true;
+      });
+      computer.click = computerClick;
+      const computerCall: protocol.ComputerUseCallItem = {
+        type: 'computer_call',
+        id: 'computer-call',
+        callId: 'computer-call',
+        status: 'completed',
+        action: {
+          type: 'click',
+          x: 1,
+          y: 1,
+          button: 'left',
+        },
+      };
+      const model = new FakeModel([
+        {
+          output: [
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              id: 'abortable-call',
+              callId: 'abortable-call',
+              name: 'abortable_tool',
+            },
+            computerCall,
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'ParallelActionCancellationAgent',
+        model,
+        tools: [abortableTool, computerTool({ computer })],
+      });
+      const state = new RunState(new RunContext(), 'start', agent, 10);
+
+      const runPromise = run(agent, state, { signal: controller.signal });
+      let runSettled = false;
+      const runOutcome = runPromise.then(
+        () => {
+          runSettled = true;
+          return { error: undefined };
+        },
+        (error: unknown) => {
+          runSettled = true;
+          return { error };
+        },
+      );
+      await Promise.all([abortToolStarted, computerStarted]);
+
+      controller.abort(abortReason);
+      await abortObserved;
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      const settledBeforeComputer = runSettled;
+
+      releaseComputer?.();
+      const outcome = await runOutcome;
+
+      expect(settledBeforeComputer).toBe(false);
+      expect(computerFinished).toBe(true);
+      expect(outcome.error).toBe(abortReason);
+      expect(computerClick).toHaveBeenCalledTimes(1);
+      expect(
+        state._generatedItems.filter(
+          (item) => item.rawItem.type === 'computer_call_result',
+        ),
+      ).toHaveLength(1);
+    });
+
+    it('reconciles later actions without starting them after cancellation', async () => {
+      const controller = new AbortController();
+      const abortReason = new Error('stop mixed actions');
+      let markToolStarted: (() => void) | undefined;
+      const toolStarted = new Promise<void>((resolve) => {
+        markToolStarted = resolve;
+      });
+      const abortableTool = tool({
+        name: 'abortable_tool',
+        description: 'throws the run abort reason',
+        parameters: z.object({ test: z.string() }),
+        errorFunction: null,
+        execute: async (_input, _context, details) => {
+          markToolStarted?.();
+          if (!details?.signal) {
+            throw new Error('Expected the run abort signal');
+          }
+          if (!details.signal.aborted) {
+            await new Promise<void>((resolve) => {
+              details.signal?.addEventListener('abort', () => resolve(), {
+                once: true,
+              });
+            });
+          }
+          details.signal.throwIfAborted();
+          return 'unexpected tool output';
+        },
+      });
+      const approvalToolExecute = vi.fn(async () => 'approved');
+      const approvalTool = tool({
+        name: 'approval_tool',
+        description: 'requires approval',
+        parameters: z.object({ test: z.string() }),
+        needsApproval: true,
+        execute: approvalToolExecute,
+      });
+      const shell = new FakeShell();
+      const editor = new FakeEditor();
+      const model = new FakeModel([
+        {
+          output: [
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              id: 'abortable-call',
+              callId: 'abortable-call',
+              name: 'abortable_tool',
+            },
+            {
+              type: 'shell_call',
+              callId: 'shell-call',
+              status: 'completed',
+              action: { commands: ['echo completed'] },
+            },
+            {
+              type: 'apply_patch_call',
+              callId: 'apply-patch-call',
+              status: 'completed',
+              operation: {
+                type: 'update_file',
+                path: 'README.md',
+                diff: 'diff --git',
+              },
+            },
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              id: 'approval-call',
+              callId: 'approval-call',
+              name: 'approval_tool',
+            },
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'MixedActionCancellationAgent',
+        model,
+        tools: [
+          abortableTool,
+          approvalTool,
+          shellTool({ shell }),
+          applyPatchTool({ editor }),
+        ],
+      });
+      const state = new RunState(new RunContext(), 'start', agent, 10);
+
+      const runPromise = run(agent, state, { signal: controller.signal });
+      const rejection = expect(runPromise).rejects.toBe(abortReason);
+      await toolStarted;
+
+      controller.abort(abortReason);
+
+      await rejection;
+      expect(shell.calls).toHaveLength(0);
+      expect(editor.operations).toHaveLength(0);
+      expect(approvalToolExecute).not.toHaveBeenCalled();
+      expect(state.getInterruptions()).toHaveLength(1);
+      expect(state.getInterruptions()[0].rawItem).toMatchObject({
+        type: 'function_call',
+        callId: 'approval-call',
+      });
+      expect(
+        state._generatedItems.filter(
+          (item) =>
+            item.rawItem.type === 'function_call_result' &&
+            item.rawItem.callId === 'abortable-call' &&
+            item.rawItem.status === 'incomplete',
+        ),
+      ).toHaveLength(1);
+      expect(
+        state._generatedItems.filter(
+          (item) =>
+            item.rawItem.type === 'shell_call_output' &&
+            item.rawItem.callId === 'shell-call' &&
+            item.rawItem.status === 'incomplete',
+        ),
+      ).toHaveLength(1);
+      expect(
+        state._generatedItems.filter(
+          (item) =>
+            item.rawItem.type === 'apply_patch_call_output' &&
+            item.rawItem.callId === 'apply-patch-call' &&
+            item.rawItem.status === 'failed',
+        ),
+      ).toHaveLength(1);
+    });
+
+    it('does not start queued function tools after cancellation', async () => {
+      const controller = new AbortController();
+      const abortReason = new Error('stop queued tools');
+      let markToolStarted: (() => void) | undefined;
+      const toolStarted = new Promise<void>((resolve) => {
+        markToolStarted = resolve;
+      });
+      const abortableTool = tool({
+        name: 'abortable_tool',
+        description: 'throws the run abort reason',
+        parameters: z.object({ test: z.string() }),
+        errorFunction: null,
+        execute: async (_input, _context, details) => {
+          markToolStarted?.();
+          if (!details?.signal) {
+            throw new Error('Expected the run abort signal');
+          }
+          if (!details.signal.aborted) {
+            await new Promise<void>((resolve) => {
+              details.signal?.addEventListener('abort', () => resolve(), {
+                once: true,
+              });
+            });
+          }
+          details.signal.throwIfAborted();
+          return 'unexpected tool output';
+        },
+      });
+      const queuedExecute = vi.fn(async () => 'unexpected queued output');
+      const queuedTool = tool({
+        name: 'queued_tool',
+        description: 'must not start after cancellation',
+        parameters: z.object({ test: z.string() }),
+        execute: queuedExecute,
+      });
+      const model = new FakeModel([
+        {
+          output: [
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              id: 'abortable-call',
+              callId: 'abortable-call',
+              name: 'abortable_tool',
+            },
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              id: 'queued-call',
+              callId: 'queued-call',
+              name: 'queued_tool',
+            },
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'QueuedCancellationAgent',
+        model,
+        tools: [abortableTool, queuedTool],
+      });
+      const state = new RunState(new RunContext(), 'start', agent, 10);
+      const runner = new Runner({
+        toolExecution: { maxFunctionToolConcurrency: 1 },
+      });
+
+      const runPromise = runner.run(agent, state, {
+        signal: controller.signal,
+      });
+      const rejection = expect(runPromise).rejects.toBe(abortReason);
+      await toolStarted;
+
+      controller.abort(abortReason);
+
+      await rejection;
+      expect(queuedExecute).not.toHaveBeenCalled();
+      expect(
+        state._generatedItems.filter(
+          (item) =>
+            item.rawItem.type === 'function_call_result' &&
+            item.rawItem.status === 'incomplete',
+        ),
+      ).toHaveLength(2);
+    });
+
+    it('propagates run cancellation to an approved function tool', async () => {
+      const controller = new AbortController();
+      const abortReason = new Error('stop approved tool');
+      let toolSignal: AbortSignal | undefined;
+      let markToolStarted: (() => void) | undefined;
+      const toolStarted = new Promise<void>((resolve) => {
+        markToolStarted = resolve;
+      });
+      let releaseTool: (() => void) | undefined;
+      const toolCanFinish = new Promise<void>((resolve) => {
+        releaseTool = resolve;
+      });
+      const approvalTool = tool({
+        name: 'test',
+        description: 'requires approval before waiting for cancellation',
+        parameters: z.object({ test: z.string() }),
+        needsApproval: true,
+        execute: async (_input, _context, details) => {
+          toolSignal = details?.signal;
+          markToolStarted?.();
+          await toolCanFinish;
+          return 'approved tool cleanup complete';
+        },
+      });
+      const model = new FakeModel([
+        {
+          output: [{ ...TEST_MODEL_FUNCTION_CALL }],
+          usage: new Usage(),
+        },
+        {
+          output: [fakeModelMessage('unexpected second response')],
+          usage: new Usage(),
+        },
+      ]);
+      const getResponseSpy = vi.spyOn(model, 'getResponse');
+      const agent = new Agent({
+        name: 'ApprovedCancellationAgent',
+        model,
+        tools: [approvalTool],
+      });
+
+      const interruptedResult = await run(agent, 'start');
+      expect(interruptedResult.interruptions).toHaveLength(1);
+      interruptedResult.state.approve(interruptedResult.interruptions[0]);
+
+      const runPromise = run(agent, interruptedResult.state, {
+        signal: controller.signal,
+      });
+      const rejection = expect(runPromise).rejects.toBe(abortReason);
+      await toolStarted;
+
+      expect(toolSignal).toBe(controller.signal);
+      controller.abort(abortReason);
+      releaseTool?.();
+
+      await rejection;
+      expect(getResponseSpy).toHaveBeenCalledTimes(1);
+      expect(
+        interruptedResult.state._generatedItems.filter(
+          (item) => item.rawItem.type === 'function_call_result',
+        ),
+      ).toHaveLength(1);
+    });
+
+    it('preserves approved sibling results when cancellation is surfaced', async () => {
+      const controller = new AbortController();
+      const abortReason = new Error('stop approved siblings');
+      let markAbortToolStarted: (() => void) | undefined;
+      const abortToolStarted = new Promise<void>((resolve) => {
+        markAbortToolStarted = resolve;
+      });
+      let markSiblingStarted: (() => void) | undefined;
+      const siblingStarted = new Promise<void>((resolve) => {
+        markSiblingStarted = resolve;
+      });
+      let releaseSibling: (() => void) | undefined;
+      const siblingCanFinish = new Promise<void>((resolve) => {
+        releaseSibling = resolve;
+      });
+      const abortableTool = tool({
+        name: 'approved_abortable_tool',
+        description: 'throws the run abort reason after approval',
+        parameters: z.object({ test: z.string() }),
+        needsApproval: true,
+        errorFunction: null,
+        execute: async (_input, _context, details) => {
+          markAbortToolStarted?.();
+          if (!details?.signal) {
+            throw new Error('Expected the run abort signal');
+          }
+          if (!details.signal.aborted) {
+            await new Promise<void>((resolve) => {
+              details.signal?.addEventListener('abort', () => resolve(), {
+                once: true,
+              });
+            });
+          }
+          details.signal.throwIfAborted();
+          return 'unexpected tool output';
+        },
+      });
+      const siblingTool = tool({
+        name: 'approved_sibling_tool',
+        description: 'finishes independently after approval',
+        parameters: z.object({ test: z.string() }),
+        needsApproval: true,
+        execute: async () => {
+          markSiblingStarted?.();
+          await siblingCanFinish;
+          return 'approved sibling complete';
+        },
+      });
+      const model = new FakeModel([
+        {
+          output: [
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              id: 'approved-abortable-call',
+              callId: 'approved-abortable-call',
+              name: 'approved_abortable_tool',
+            },
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              id: 'approved-sibling-call',
+              callId: 'approved-sibling-call',
+              name: 'approved_sibling_tool',
+            },
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'ApprovedSiblingCancellationAgent',
+        model,
+        tools: [abortableTool, siblingTool],
+      });
+
+      const interruptedResult = await run(agent, 'start');
+      expect(interruptedResult.interruptions).toHaveLength(2);
+      for (const interruption of interruptedResult.interruptions) {
+        interruptedResult.state.approve(interruption);
+      }
+
+      const runPromise = run(agent, interruptedResult.state, {
+        signal: controller.signal,
+      });
+      const rejection = expect(runPromise).rejects.toBe(abortReason);
+      await Promise.all([abortToolStarted, siblingStarted]);
+
+      controller.abort(abortReason);
+      releaseSibling?.();
+
+      await rejection;
+      expect(interruptedResult.state.getInterruptions()).toHaveLength(0);
+      expect(
+        interruptedResult.state._generatedItems.filter(
+          (item) =>
+            item.rawItem.type === 'function_call_result' &&
+            item.rawItem.callId === 'approved-abortable-call' &&
+            item.rawItem.status === 'incomplete',
+        ),
+      ).toHaveLength(1);
+      expect(
+        interruptedResult.state._generatedItems.filter(
+          (item) =>
+            item.rawItem.type === 'function_call_result' &&
+            item.rawItem.callId === 'approved-sibling-call' &&
+            item.rawItem.status === 'completed',
+        ),
+      ).toHaveLength(1);
     });
 
     it('accepts public tool not found behavior config', () => {
@@ -3757,6 +4481,230 @@ describe('Runner.run', () => {
           ? (savedAssistant.content[0] as { providerData?: unknown })
           : undefined;
         expect(firstPart?.providerData).toEqual({ annotations: [] });
+      });
+
+      it('persists accepted tool results before surfacing cancellation', async () => {
+        const controller = new AbortController();
+        const abortReason = new Error('stop after tool result');
+        let markToolStarted: (() => void) | undefined;
+        const toolStarted = new Promise<void>((resolve) => {
+          markToolStarted = resolve;
+        });
+        let releaseTool: (() => void) | undefined;
+        const toolCanFinish = new Promise<void>((resolve) => {
+          releaseTool = resolve;
+        });
+        const abortableTool = tool({
+          name: 'test',
+          description: 'finishes after cancellation',
+          parameters: z.object({ test: z.string() }),
+          execute: async () => {
+            markToolStarted?.();
+            await toolCanFinish;
+            return 'completed tool result';
+          },
+        });
+        const model = new FakeModel([
+          {
+            output: [{ ...TEST_MODEL_FUNCTION_CALL }],
+            usage: new Usage(),
+          },
+        ]);
+        const agent = new Agent({
+          name: 'SessionCancellationAgent',
+          model,
+          tools: [abortableTool],
+        });
+        const session = new MemorySession();
+
+        const runPromise = run(agent, 'start', {
+          session,
+          signal: controller.signal,
+        });
+        const rejection = expect(runPromise).rejects.toBe(abortReason);
+        await toolStarted;
+
+        controller.abort(abortReason);
+        releaseTool?.();
+
+        await rejection;
+        expect(session.added).toHaveLength(1);
+        expect(session.added[0].map((item) => item.type)).toEqual([
+          'message',
+          'function_call',
+          'function_call_result',
+        ]);
+      });
+
+      it('does not persist a cancelled tool turn again when its state resumes', async () => {
+        const controller = new AbortController();
+        const abortReason = new Error('stop before the next model turn');
+        let markToolStarted: (() => void) | undefined;
+        const toolStarted = new Promise<void>((resolve) => {
+          markToolStarted = resolve;
+        });
+        let releaseTool: (() => void) | undefined;
+        const toolCanFinish = new Promise<void>((resolve) => {
+          releaseTool = resolve;
+        });
+        const abortableTool = tool({
+          name: 'test',
+          description: 'finishes after cancellation',
+          parameters: z.object({ test: z.string() }),
+          execute: async () => {
+            markToolStarted?.();
+            await toolCanFinish;
+            return 'completed tool result';
+          },
+        });
+        const model = new FakeModel([
+          {
+            output: [{ ...TEST_MODEL_FUNCTION_CALL }],
+            usage: new Usage(),
+          },
+          {
+            output: [fakeModelMessage('resumed response')],
+            usage: new Usage(),
+          },
+        ]);
+        const agent = new Agent({
+          name: 'SessionCancellationResumeAgent',
+          model,
+          tools: [abortableTool],
+        });
+        const state = new RunState(new RunContext(), 'start', agent, 10);
+        const session = new MemorySession([user('start')]);
+
+        const runPromise = run(agent, state, {
+          session,
+          signal: controller.signal,
+        });
+        const rejection = expect(runPromise).rejects.toBe(abortReason);
+        await toolStarted;
+
+        controller.abort(abortReason);
+        releaseTool?.();
+
+        await rejection;
+        expect(session.added).toHaveLength(1);
+        expect(session.added[0].map((item) => item.type)).toEqual([
+          'function_call',
+          'function_call_result',
+        ]);
+
+        await run(agent, state, { session });
+
+        expect(session.added).toHaveLength(2);
+        expect(session.added[1].map((item) => item.type)).toEqual(['message']);
+        expect(
+          session.added
+            .flat()
+            .filter(
+              (item) =>
+                item.type === 'function_call' &&
+                item.callId === TEST_MODEL_FUNCTION_CALL.callId,
+            ),
+        ).toHaveLength(1);
+      });
+
+      it('does not execute or repersist a handoff skipped by cancellation', async () => {
+        const controller = new AbortController();
+        const abortReason = new Error('stop before the handoff');
+        let markToolStarted: (() => void) | undefined;
+        const toolStarted = new Promise<void>((resolve) => {
+          markToolStarted = resolve;
+        });
+        let releaseTool: (() => void) | undefined;
+        const toolCanFinish = new Promise<void>((resolve) => {
+          releaseTool = resolve;
+        });
+        const abortableTool = tool({
+          name: 'test',
+          description: 'finishes after cancellation',
+          parameters: z.object({ test: z.string() }),
+          execute: async () => {
+            markToolStarted?.();
+            await toolCanFinish;
+            return 'completed tool result';
+          },
+        });
+        const agentB = new Agent({
+          name: 'SessionCancellationHandoffTarget',
+          model: new FakeModel([
+            {
+              output: [fakeModelMessage('handoff response')],
+              usage: new Usage(),
+            },
+          ]),
+        });
+        const onHandoff = vi.fn();
+        const handoffToB = handoff(agentB, { onHandoff });
+        const handoffCall: protocol.FunctionCallItem = {
+          id: 'handoff-call',
+          type: 'function_call',
+          name: handoffToB.toolName,
+          callId: 'handoff-call',
+          status: 'completed',
+          arguments: '{}',
+        };
+        const agentA = new Agent({
+          name: 'SessionCancellationHandoffSource',
+          model: new FakeModel([
+            {
+              output: [{ ...TEST_MODEL_FUNCTION_CALL }, handoffCall],
+              usage: new Usage(),
+            },
+            {
+              output: [fakeModelMessage('resumed source response')],
+              usage: new Usage(),
+            },
+          ]),
+          tools: [abortableTool],
+          handoffs: [handoffToB],
+        });
+        const state = new RunState(new RunContext(), 'start', agentA, 10);
+        const session = new MemorySession([user('start')]);
+
+        const runPromise = run(agentA, state, {
+          session,
+          signal: controller.signal,
+        });
+        const rejection = expect(runPromise).rejects.toBe(abortReason);
+        await toolStarted;
+
+        controller.abort(abortReason);
+        releaseTool?.();
+
+        await rejection;
+        expect(state._currentStep?.type).toBe('next_step_run_again');
+        expect(onHandoff).not.toHaveBeenCalled();
+        expect(session.added).toHaveLength(1);
+
+        const result = await run(agentA, state, { session });
+
+        expect(result.finalOutput).toBe('resumed source response');
+        expect(onHandoff).not.toHaveBeenCalled();
+        expect(session.added).toHaveLength(2);
+        expect(session.added[1].map((item) => item.type)).toEqual(['message']);
+        expect(
+          session.added
+            .flat()
+            .filter(
+              (item) =>
+                item.type === 'function_call' &&
+                item.callId === TEST_MODEL_FUNCTION_CALL.callId,
+            ),
+        ).toHaveLength(1);
+        expect(
+          session.added
+            .flat()
+            .filter(
+              (item) =>
+                item.type === 'function_call_result' &&
+                item.callId === handoffCall.callId &&
+                item.status === 'incomplete',
+            ),
+        ).toHaveLength(1);
       });
 
       it('applies runner-level reasoningItemIdPolicy to replayed session history', async () => {

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -423,6 +423,83 @@ describe('checkForFinalOutputFromTools', () => {
   });
 
   it.each(['stop_on_first_tool' as const, { stopAtToolNames: ['weather'] }])(
+    'does not promote a completed sibling after an incomplete result with %j',
+    async (behavior) => {
+      const agent = new Agent({
+        name: 'IncompleteResult',
+        toolUseBehavior: behavior,
+      });
+      const cancelledTool = tool({
+        name: 'cancelled_tool',
+        description: 'cancelled tool',
+        parameters: z.object({}),
+        execute: async () => 'unused',
+      });
+      const incompleteResult: FunctionToolResult = {
+        type: 'function_output',
+        tool: cancelledTool,
+        output: 'aborted',
+        runItem: new ToolCallOutputItem(
+          {
+            type: 'function_call_result',
+            name: 'cancelled_tool',
+            callId: 'call_cancelled_incomplete',
+            status: 'incomplete',
+            output: { type: 'text', text: 'aborted' },
+          },
+          agent,
+          'aborted',
+        ),
+      };
+
+      const res = await checkForFinalOutputFromTools(
+        agent,
+        [incompleteResult, toolResult],
+        state,
+      );
+
+      expect(res.isFinalOutput).toBe(false);
+    },
+  );
+
+  it('does not invoke custom finalization after an incomplete result', async () => {
+    const finalize = vi.fn(async () => ({
+      isFinalOutput: true as const,
+      finalOutput: 'sunny',
+      isInterrupted: undefined,
+    }));
+    const agent = new Agent({
+      name: 'CustomIncompleteResult',
+      toolUseBehavior: finalize,
+    });
+    const incompleteResult: FunctionToolResult = {
+      type: 'function_output',
+      tool: weatherTool,
+      output: 'aborted',
+      runItem: new ToolCallOutputItem(
+        {
+          type: 'function_call_result',
+          name: 'weather',
+          callId: 'call_weather_incomplete',
+          status: 'incomplete',
+          output: { type: 'text', text: 'aborted' },
+        },
+        agent,
+        'aborted',
+      ),
+    };
+
+    const res = await checkForFinalOutputFromTools(
+      agent,
+      [incompleteResult, toolResult],
+      state,
+    );
+
+    expect(res.isFinalOutput).toBe(false);
+    expect(finalize).not.toHaveBeenCalled();
+  });
+
+  it.each(['stop_on_first_tool' as const, { stopAtToolNames: ['weather'] }])(
     'does not finalize program-owned tool results with %j',
     async (behavior) => {
       const agent = new Agent({
@@ -864,6 +941,46 @@ describe('executeComputerActions', () => {
     );
     expect(items).toHaveLength(1);
     expect((items[0] as any).output).toBe('data:image/png;base64,img');
+  });
+
+  it('does not start an action after cancellation', async () => {
+    const controller = new AbortController();
+    controller.abort(new Error('stop before computer action'));
+    const fakeComputer = {
+      environment: 'mac',
+      dimensions: [1, 1] as [number, number],
+      screenshot: vi.fn().mockResolvedValue('img'),
+    } as any;
+    const computer = computerTool({ computer: fakeComputer });
+    const call: protocol.ComputerUseCallItem = {
+      type: 'computer_call',
+      callId: 'cancelled-computer-call',
+      status: 'completed',
+      action: { type: 'screenshot' } as any,
+    };
+
+    const items = await executeComputerActions(
+      new Agent({ name: 'CancelledComputer' }),
+      [{ toolCall: call, computer }],
+      new Runner(),
+      new RunContext(),
+      undefined,
+      undefined,
+      controller.signal,
+    );
+
+    expect(fakeComputer.screenshot).not.toHaveBeenCalled();
+    expect(items[0]).toMatchObject({
+      rawItem: {
+        type: 'computer_call_result',
+        callId: call.callId,
+        output: {
+          type: 'computer_screenshot',
+          data: expect.stringMatching(/^data:image\/png;base64,/),
+        },
+        providerData: { status: 'incomplete' },
+      },
+    });
   });
 
   it('does not emit a success end event when computer customDataExtractor fails', async () => {
@@ -3657,6 +3774,94 @@ describe('executeShellActions', () => {
       ).toEqual(['ok-1', 'ok-2', 'ok-3']);
     });
 
+    it('surfaces an uncapped tool failure without waiting for a pending sibling', async () => {
+      let markSiblingStarted: (() => void) | undefined;
+      const siblingStarted = new Promise<void>((resolve) => {
+        markSiblingStarted = resolve;
+      });
+      let releaseSibling: (() => void) | undefined;
+      const siblingCanFinish = new Promise<void>((resolve) => {
+        releaseSibling = resolve;
+      });
+      const failingTool = tool({
+        name: 'failing_tool',
+        description: 'fails while a sibling remains pending',
+        parameters: z.object({}),
+        errorFunction: null,
+        execute: vi.fn(async () => {
+          await siblingStarted;
+          throw new Error('boom');
+        }),
+      }) as unknown as FunctionTool;
+      const pendingTool = tool({
+        name: 'pending_tool',
+        description: 'remains pending until released',
+        parameters: z.object({}),
+        execute: vi.fn(async () => {
+          markSiblingStarted?.();
+          await siblingCanFinish;
+          return 'done';
+        }),
+      }) as unknown as FunctionTool;
+
+      const resultPromise = executeFunctionToolCalls(
+        state._currentAgent,
+        [
+          {
+            toolCall: {
+              ...toolCall,
+              callId: 'failing-call',
+              name: 'failing_tool',
+            },
+            tool: failingTool,
+          },
+          {
+            toolCall: {
+              ...toolCall,
+              callId: 'pending-call',
+              name: 'pending_tool',
+            },
+            tool: pendingTool,
+          },
+        ],
+        runner,
+        state,
+      );
+      await siblingStarted;
+
+      try {
+        await expect(resultPromise).rejects.toThrow(
+          /Failed to run function tools/,
+        );
+      } finally {
+        releaseSibling?.();
+      }
+    });
+
+    it('preserves undefined rejections in uncapped tools', async () => {
+      const t = tool({
+        name: 'undefined_error',
+        description: 'rejects without an error value',
+        parameters: z.object({}),
+        errorFunction: null,
+        execute: vi.fn(async () => {
+          throw undefined;
+        }),
+      }) as unknown as FunctionTool;
+
+      const error = await withTrace('test', () =>
+        executeFunctionToolCalls(
+          state._currentAgent,
+          [{ toolCall, tool: t }],
+          runner,
+          state,
+        ).catch((caught) => caught),
+      );
+
+      expect(error).toBeInstanceOf(ToolCallError);
+      expect((error as ToolCallError).error).toBeUndefined();
+    });
+
     it('limits function tool concurrency and preserves output order', async () => {
       let activeCount = 0;
       let maxSeenCount = 0;
@@ -3937,6 +4142,61 @@ describe('executeShellActions', () => {
       expect(invokeSpy).not.toHaveBeenCalled();
       expect(state._toolInputGuardrailResults).toHaveLength(1);
       expect(state._toolOutputGuardrailResults).toHaveLength(0);
+    });
+
+    it('does not invoke a tool when cancellation occurs during an input guardrail', async () => {
+      const controller = new AbortController();
+      let markGuardrailStarted: (() => void) | undefined;
+      const guardrailStarted = new Promise<void>((resolve) => {
+        markGuardrailStarted = resolve;
+      });
+      let releaseGuardrail: (() => void) | undefined;
+      const guardrailCanFinish = new Promise<void>((resolve) => {
+        releaseGuardrail = resolve;
+      });
+      const guardrail = defineToolInputGuardrail({
+        name: 'slow_allow',
+        run: async () => {
+          markGuardrailStarted?.();
+          await guardrailCanFinish;
+          return ToolGuardrailFunctionOutputFactory.allow();
+        },
+      });
+      const execute = vi.fn(async () => 'should-not-run');
+      const t = tool({
+        name: 'guarded_tool',
+        description: 'tool with an asynchronous input guardrail',
+        parameters: z.object({}),
+        execute,
+        inputGuardrails: [guardrail],
+      }) as unknown as FunctionTool;
+
+      const resultPromise = executeFunctionToolCalls(
+        state._currentAgent,
+        [{ toolCall, tool: t }],
+        runner,
+        state,
+        undefined,
+        undefined,
+        controller.signal,
+      );
+      await guardrailStarted;
+      controller.abort(new Error('stop during tool preparation'));
+      releaseGuardrail?.();
+
+      const result = await resultPromise;
+
+      expect(execute).not.toHaveBeenCalled();
+      expect(result[0]).toMatchObject({
+        type: 'function_output',
+        runItem: {
+          rawItem: {
+            type: 'function_call_result',
+            callId: toolCall.callId,
+            status: 'incomplete',
+          },
+        },
+      });
     });
 
     it('rejects input guardrail messages for Zod output schemas without a fallback', async () => {


### PR DESCRIPTION
This pull request implements the second stage of the cancellation work for #1521. It propagates cancellation into non-streaming function tools, building on the run-settlement invariant established by #1527.

It does not close the issue. Streamed function-tool cancellation and resumable streamed state remain for a separate follow-up.

## Background

`RunOptions.signal` already reaches model requests, and function tools already expose `ToolCallDetails.signal`. However, the non-streaming runner never connected those two surfaces.

As a result, an in-flight function tool could not observe cancellation requested by the caller. Even if the caller aborted the run, the tool continued until it completed independently.

PR #1527 addressed a prerequisite problem for streamed runs: `stream.completed` no longer settles while the background run loop still owns and mutates the exposed `RunState`. This pull request builds on that separation but intentionally does not modify the streamed execution path.

## What changed

For non-streaming runs, `RunOptions.signal` now follows the existing function-tool execution pipeline:

1. `Runner.run()` passes the signal into ordinary turn resolution or approval-resume resolution.
2. Turn resolution passes it to `executeFunctionToolCalls()`.
3. Approved function-tool invocations receive it through `ToolCallDetails.signal`.

After a function tool settles, the resolved action batch is applied to `RunState` before the runner checks the signal. Therefore, if a cooperative tool observes cancellation, performs cleanup, and returns a terminal result:

- its result remains recorded in the current run state;
- the run rejects with the abort reason;
- the runner does not begin another model request.

When a function tool configured with `errorFunction: null` throws the exact `signal.reason`, that reason is also preserved instead of being wrapped in `ToolCallError`. Unrelated tool failures retain the existing error behavior.

The same behavior applies when a previously interrupted function call is approved and resumed.

## Relationship to #1527

PR #1527 established this ownership rule for streamed runs:

> A caller must not resume a cancelled `RunState` until the previous background run loop has settled and relinquished ownership.

This pull request handles the next independent layer: connecting run cancellation to function-tool execution in the simpler non-streaming path.

Separating these stages keeps the signal propagation independent from streamed persistence, sandbox preservation, and resumable action-batch reconciliation.

## How this differs from the reverted work

PR #1523 propagated cancellation into both streaming and non-streaming function tools before the streamed completion boundary was safe. A cooperative streamed tool could settle after `stream.completed` had already resolved, allowing the original and resumed run loops to overlap on the same state.

PR #1525 then attempted to repair those consequences by adding cancellation checks across model preparation, guardrails, session writes, response acceptance, approvals, and sandbox cleanup. Each additional check exposed another ordering or persistence race because there was no single settlement boundary.

PR #1526 reverted that work, and PR #1527 subsequently fixed the underlying completion-ownership invariant.

This pull request is narrower than #1523 and #1525:

- It changes only non-streaming runner call sites.
- It uses the existing turn-resolution and function-tool invocation pipeline.
- It does not add RunState fields or serialized state.
- It does not modify streamed execution.
- It does not change session persistence or sandbox ownership.
- It does not propagate cancellation to computer, shell, apply-patch, hosted, or MCP tools.
- It preserves existing timeout-signal composition.

## Behavior considerations

Cancellation remains cooperative. JavaScript cannot forcibly terminate a Promise, so a function tool that ignores `details.signal` can keep the run pending until the tool settles.

If the tool observes cancellation but still returns a result after cleanup, that accepted result is retained before the run stops. This avoids discarding completed tool work while still preventing another model turn.

This pull request deliberately leaves the general documentation unchanged until streaming and non-streaming behavior have parity.

## Follow-up scope

The remaining streamed-run follow-up should:

- combine the run signal and reader-cancellation signal for function tools;
- settle the accepted model response and current function-tool action batch into `RunState`;
- stop before the next model turn after the batch settles;
- persist each function call and output pair exactly once;
- preserve sandbox state only for successful resumable cancellation;
- clean up sandbox resources when persistence, guardrails, or tool execution fail;
- allow callers to await `stream.completed` and resume without replaying model or tool side effects.

That follow-up should complete #1521 and document the unified cancellation contract.