### PR TITLE
fix(core): propagate streamed cancellation to function tools

### DIFF
--- a/.changeset/swift-streams-cancel.md
+++ b/.changeset/swift-streams-cancel.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix(core): propagate streamed cancellation to function tools without replaying settled work (#1521)

--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -893,11 +893,12 @@ export class Agent<
             }
             await streamResult.completed;
             if (streamResult.cancelled) {
-              const finalOutputCommitted =
-                streamResult.state._currentStep?.type ===
-                  'next_step_final_output' &&
-                streamResult.state._currentTurnInProgress === false;
-              if (!finalOutputCommitted) {
+              const currentStep = streamResult.state._currentStep;
+              const hasCommittedOutcome =
+                (currentStep?.type === 'next_step_final_output' &&
+                  streamResult.state._currentTurnInProgress === false) ||
+                (streamResult.interruptions?.length ?? 0) > 0;
+              if (!hasCommittedOutcome) {
                 combinedSignal?.throwIfAborted();
                 throw new Error('Nested agent run was cancelled.');
               }
@@ -935,6 +936,8 @@ export class Agent<
             outputText = await customOutputExtractor(
               completedResultWithAgentToolInvocation,
             );
+          } else if ((completedResult.interruptions?.length ?? 0) > 0) {
+            outputText = '';
           } else {
             const finalOutputText =
               typeof completedResult.finalOutput !== 'undefined'

--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -893,8 +893,14 @@ export class Agent<
             }
             await streamResult.completed;
             if (streamResult.cancelled) {
-              combinedSignal?.throwIfAborted();
-              throw new Error('Nested agent run was cancelled.');
+              const finalOutputCommitted =
+                streamResult.state._currentStep?.type ===
+                  'next_step_final_output' &&
+                streamResult.state._currentTurnInProgress === false;
+              if (!finalOutputCommitted) {
+                combinedSignal?.throwIfAborted();
+                throw new Error('Nested agent run was cancelled.');
+              }
             }
           }
 

--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -892,6 +892,10 @@ export class Agent<
               });
             }
             await streamResult.completed;
+            if (streamResult.cancelled) {
+              combinedSignal?.throwIfAborted();
+              throw new Error('Nested agent run was cancelled.');
+            }
           }
 
           const completedResult = result as CompletedRunResult<

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1478,6 +1478,13 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
 
     try {
       while (true) {
+        // Let the current action batch settle, but never start new work after
+        // cancellation once a turn has already begun. Preserve the existing
+        // first-request behavior for an initially aborted stream.
+        if (result.cancelled && result.state._currentTurn > 0) {
+          return;
+        }
+
         const currentAgent = result.state._currentAgent;
 
         result.state._currentStep = result.state._currentStep ?? {
@@ -1512,6 +1519,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             runner: this,
             toolErrorFormatter,
             agentToolParentRunConfig,
+            signal: options.signal,
             onStepItems: (turnResult) => {
               addStepToRunResult(result, turnResult);
             },
@@ -1622,6 +1630,16 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           );
 
           await guardrailTracker.throwIfError();
+
+          // Initial request and session-persistence ordering remain unchanged.
+          // Once a logical turn is established, do not start another model
+          // request if cancellation arrives during asynchronous preparation.
+          if (
+            (sentInputToModel || preserveTurnPersistenceOnResume) &&
+            result.cancelled
+          ) {
+            return;
+          }
 
           let finalResponse: ModelResponse | undefined = undefined;
           const abortReconciliationState =
@@ -1840,6 +1858,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             toolErrorFormatter,
             agentToolParentRunConfig,
             options.errorHandlers,
+            options.signal,
           );
 
           applyTurnResult({
@@ -1857,6 +1876,16 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             setRunStateTurnSpanParent(result.state, undefined);
             currentTurnSpan = undefined;
           }
+        }
+
+        // Finalization is an atomic commit once entered: guardrails, persistence,
+        // and end hooks must run exactly once. Other next steps would start new
+        // work, so leave them resumable after cancellation.
+        if (
+          result.cancelled &&
+          result.state._currentStep.type !== 'next_step_final_output'
+        ) {
+          return;
         }
 
         const currentStep = result.state._currentStep;
@@ -1982,7 +2011,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         await persistStreamInputIfNeeded();
       }
       const preserveSandboxSessions =
-        result.state._currentStep?.type === 'next_step_interruption';
+        result.state._currentStep?.type === 'next_step_interruption' ||
+        (result.cancelled &&
+          result.state._currentTurnInProgress &&
+          runError === undefined);
       try {
         try {
           await finalizeSandboxRuntime({

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1634,10 +1634,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           // Initial request and session-persistence ordering remain unchanged.
           // Once a logical turn is established, do not start another model
           // request if cancellation arrives during asynchronous preparation.
-          if (
-            (sentInputToModel || preserveTurnPersistenceOnResume) &&
-            result.cancelled
-          ) {
+          if ((sentInputToModel || isResumedState) && result.cancelled) {
             return;
           }
 
@@ -1878,16 +1875,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           }
         }
 
-        // Finalization is an atomic commit once entered: guardrails, persistence,
-        // and end hooks must run exactly once. Other next steps would start new
-        // work, so leave them resumable after cancellation.
-        if (
-          result.cancelled &&
-          result.state._currentStep.type !== 'next_step_final_output'
-        ) {
-          return;
-        }
-
         const currentStep = result.state._currentStep;
         switch (currentStep.type) {
           case 'next_step_final_output':
@@ -2013,7 +2000,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       const preserveSandboxSessions =
         result.state._currentStep?.type === 'next_step_interruption' ||
         (result.cancelled &&
-          result.state._currentTurnInProgress &&
+          result.state._currentStep?.type !== 'next_step_final_output' &&
           runError === undefined);
       try {
         try {

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -62,6 +62,36 @@ function getRequestInputItems(request: ModelRequest): AgentInputItem[] {
   return Array.isArray(request.input) ? request.input : [];
 }
 
+class CountingFunctionToolStreamModel implements Model {
+  callCount = 0;
+
+  async getResponse(_request: ModelRequest): Promise<ModelResponse> {
+    throw new Error('Unexpected non-streaming model request');
+  }
+
+  async *getStreamedResponse(
+    _request: ModelRequest,
+  ): AsyncIterable<StreamEvent> {
+    const output =
+      this.callCount++ === 0
+        ? [{ ...TEST_MODEL_FUNCTION_CALL }]
+        : [fakeModelMessage('done')];
+    yield {
+      type: 'response_done',
+      response: {
+        id: `resp-${this.callCount}`,
+        usage: {
+          requests: 1,
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+        },
+        output,
+      },
+    } as StreamEvent;
+  }
+}
+
 class AbortAfterStreamedFunctionCallModel implements Model {
   public requests: ModelRequest[] = [];
 
@@ -1511,6 +1541,541 @@ describe('Runner.run (streaming)', () => {
     expect(toolCalledIndex).toBeGreaterThan(-1);
     expect(toolOutputIndex).toBeGreaterThan(-1);
     expect(toolCalledIndex).toBeLessThan(toolOutputIndex);
+  });
+
+  it('settles a cancelled function tool without starting another model turn', async () => {
+    let markToolStarted: (() => void) | undefined;
+    let releaseTool: (() => void) | undefined;
+    let toolSignal: AbortSignal | undefined;
+    const toolStarted = new Promise<void>((resolve) => {
+      markToolStarted = resolve;
+    });
+    const toolCanFinish = new Promise<void>((resolve) => {
+      releaseTool = resolve;
+    });
+    const abortableTool = tool({
+      name: 'test',
+      description: 'waits for the streamed run to be cancelled',
+      parameters: z.object({ test: z.string() }),
+      execute: async (_input, _context, details) => {
+        toolSignal = details?.signal;
+        markToolStarted?.();
+        if (!toolSignal?.aborted) {
+          await Promise.race([
+            toolCanFinish,
+            new Promise<void>((resolve) => {
+              toolSignal?.addEventListener('abort', () => resolve(), {
+                once: true,
+              });
+            }),
+          ]);
+        }
+        return 'cancelled';
+      },
+    });
+    const model = new CountingFunctionToolStreamModel();
+    const agent = new Agent({
+      name: 'AbortableToolStreamAgent',
+      model,
+      tools: [abortableTool],
+    });
+    const result = await run(agent, 'start', { stream: true });
+    const reader = (result.toStream() as any).getReader();
+
+    await toolStarted;
+    await reader.cancel('stop');
+    releaseTool?.();
+    await result.completed;
+
+    expect(result.cancelled).toBe(true);
+    expect(toolSignal?.aborted).toBe(true);
+    expect(model.callCount).toBe(1);
+    expect(
+      result.state._generatedItems.some(
+        (item) =>
+          item.rawItem.type === 'function_call_result' &&
+          item.rawItem.status === 'completed',
+      ),
+    ).toBe(true);
+  });
+
+  it('atomically finalizes a completed tool output after cancellation', async () => {
+    const saveResultSpy = vi
+      .spyOn(sessionPersistence, 'saveStreamResultToSession')
+      .mockResolvedValue();
+    let markToolStarted: (() => void) | undefined;
+    let releaseTool: (() => void) | undefined;
+    const toolStarted = new Promise<void>((resolve) => {
+      markToolStarted = resolve;
+    });
+    const toolCanFinish = new Promise<void>((resolve) => {
+      releaseTool = resolve;
+    });
+    const execute = vi.fn(async (_input, _context, details) => {
+      markToolStarted?.();
+      const signal = details?.signal as AbortSignal | undefined;
+      if (!signal?.aborted) {
+        await Promise.race([
+          toolCanFinish,
+          new Promise<void>((resolve) => {
+            signal?.addEventListener('abort', () => resolve(), { once: true });
+          }),
+        ]);
+      }
+      return 'settled after cancellation';
+    });
+    const finalTool = tool({
+      name: 'test',
+      description: 'returns the final output after cancellation',
+      parameters: z.object({ test: z.string() }),
+      execute,
+    });
+    const guardrail = {
+      name: 'allow-final-output',
+      execute: vi.fn().mockResolvedValue({
+        tripwireTriggered: false,
+        outputInfo: { safe: true },
+      }),
+    };
+    const model = new CountingFunctionToolStreamModel();
+    const agent = new Agent({
+      name: 'CancelledFinalToolStreamAgent',
+      model,
+      tools: [finalTool],
+      toolUseBehavior: 'stop_on_first_tool',
+      outputGuardrails: [guardrail],
+    });
+    const runner = new Runner();
+    const agentEnd = vi.fn();
+    runner.on('agent_end', agentEnd);
+    const session = createSessionMock();
+    const cancelled = await runner.run(agent, 'start', {
+      stream: true,
+      session,
+    });
+    const reader = (cancelled.toStream() as any).getReader();
+
+    await toolStarted;
+    await reader.cancel('stop');
+    releaseTool?.();
+    await cancelled.completed;
+
+    expect(cancelled.cancelled).toBe(true);
+    expect(cancelled.finalOutput).toBe('settled after cancellation');
+    expect(cancelled.state._currentStep).toEqual({
+      type: 'next_step_final_output',
+      output: 'settled after cancellation',
+    });
+    expect(cancelled.state._currentTurnInProgress).toBe(false);
+    expect(model.callCount).toBe(1);
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(guardrail.execute).toHaveBeenCalledTimes(1);
+    expect(saveResultSpy).toHaveBeenCalledTimes(1);
+    expect(agentEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('atomically finalizes a completed resumed tool after cancellation', async () => {
+    const saveResultSpy = vi
+      .spyOn(sessionPersistence, 'saveStreamResultToSession')
+      .mockResolvedValue();
+    let markToolStarted: (() => void) | undefined;
+    let releaseTool: (() => void) | undefined;
+    const toolStarted = new Promise<void>((resolve) => {
+      markToolStarted = resolve;
+    });
+    const toolCanFinish = new Promise<void>((resolve) => {
+      releaseTool = resolve;
+    });
+    const execute = vi.fn(async (_input, _context, details) => {
+      markToolStarted?.();
+      const signal = details?.signal as AbortSignal | undefined;
+      if (!signal?.aborted) {
+        await Promise.race([
+          toolCanFinish,
+          new Promise<void>((resolve) => {
+            signal?.addEventListener('abort', () => resolve(), { once: true });
+          }),
+        ]);
+      }
+      return 'cancelled';
+    });
+    const abortableTool = tool({
+      name: 'test',
+      description: 'waits for the resumed stream to be cancelled',
+      parameters: z.object({ test: z.string() }),
+      needsApproval: true,
+      execute,
+    });
+    const guardrail = {
+      name: 'allow-resumed-final-output',
+      execute: vi.fn().mockResolvedValue({
+        tripwireTriggered: false,
+        outputInfo: { safe: true },
+      }),
+    };
+    const model = new CountingFunctionToolStreamModel();
+    const agent = new Agent({
+      name: 'ResumedAbortableToolStreamAgent',
+      model,
+      tools: [abortableTool],
+      toolUseBehavior: 'stop_on_first_tool',
+      outputGuardrails: [guardrail],
+    });
+    const runner = new Runner();
+    const agentEnd = vi.fn();
+    runner.on('agent_end', agentEnd);
+    const session = createSessionMock();
+    const interrupted = await runner.run(agent, 'start', {
+      stream: true,
+      session,
+    });
+    for await (const _event of interrupted) {
+      // Drain the interrupted run.
+    }
+    interrupted.state.approve(interrupted.interruptions[0]);
+
+    const resumed = await runner.run(agent, interrupted.state, {
+      stream: true,
+      session,
+    });
+    const reader = (resumed.toStream() as any).getReader();
+
+    await toolStarted;
+    await reader.cancel('stop');
+    releaseTool?.();
+    await resumed.completed;
+
+    expect(resumed.cancelled).toBe(true);
+    expect(model.callCount).toBe(1);
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(resumed.state._currentStep).toEqual({
+      type: 'next_step_final_output',
+      output: 'cancelled',
+    });
+    expect(resumed.state._currentTurnInProgress).toBe(false);
+    expect(resumed.finalOutput).toBe('cancelled');
+    expect(guardrail.execute).toHaveBeenCalledTimes(1);
+    expect(saveResultSpy).toHaveBeenCalledTimes(2);
+    expect(agentEnd).toHaveBeenCalledTimes(1);
+    expect(
+      resumed.state._generatedItems.some(
+        (item) =>
+          item.rawItem.type === 'function_call_result' &&
+          item.rawItem.status === 'completed',
+      ),
+    ).toBe(true);
+  });
+
+  it('finishes finalization once output guardrails have started', async () => {
+    const saveResultSpy = vi
+      .spyOn(sessionPersistence, 'saveStreamResultToSession')
+      .mockResolvedValue();
+    let markGuardrailStarted: (() => void) | undefined;
+    let releaseGuardrail: (() => void) | undefined;
+    const guardrailStarted = new Promise<void>((resolve) => {
+      markGuardrailStarted = resolve;
+    });
+    const guardrailCanFinish = new Promise<void>((resolve) => {
+      releaseGuardrail = resolve;
+    });
+    const guardrail = {
+      name: 'delayed-final-output-guardrail',
+      execute: vi.fn(async () => {
+        markGuardrailStarted?.();
+        await guardrailCanFinish;
+        return {
+          tripwireTriggered: false,
+          outputInfo: { safe: true },
+        };
+      }),
+    };
+    const execute = vi.fn(async () => 'guarded output');
+    const finalTool = tool({
+      name: 'test',
+      description: 'returns output guarded before finalization',
+      parameters: z.object({ test: z.string() }),
+      execute,
+    });
+    const model = new CountingFunctionToolStreamModel();
+    const agent = new Agent({
+      name: 'CancelDuringOutputGuardrailAgent',
+      model,
+      tools: [finalTool],
+      toolUseBehavior: 'stop_on_first_tool',
+      outputGuardrails: [guardrail],
+    });
+    const runner = new Runner();
+    const agentEnd = vi.fn();
+    runner.on('agent_end', agentEnd);
+    const session = createSessionMock();
+    const cancelled = await runner.run(agent, 'start', {
+      stream: true,
+      session,
+    });
+    const reader = (cancelled.toStream() as any).getReader();
+
+    await guardrailStarted;
+    await reader.cancel('stop');
+    releaseGuardrail?.();
+    await cancelled.completed;
+
+    expect(cancelled.cancelled).toBe(true);
+    expect(cancelled.state._currentStep).toEqual({
+      type: 'next_step_final_output',
+      output: 'guarded output',
+    });
+    expect(cancelled.finalOutput).toBe('guarded output');
+    expect(cancelled.state._currentTurnInProgress).toBe(false);
+    expect(guardrail.execute).toHaveBeenCalledTimes(1);
+    expect(model.callCount).toBe(1);
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(saveResultSpy).toHaveBeenCalledTimes(1);
+    expect(agentEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('finishes finalization when cancellation arrives during persistence', async () => {
+    let markPersistenceStarted: (() => void) | undefined;
+    let releasePersistence: (() => void) | undefined;
+    const persistenceStarted = new Promise<void>((resolve) => {
+      markPersistenceStarted = resolve;
+    });
+    const persistenceCanFinish = new Promise<void>((resolve) => {
+      releasePersistence = resolve;
+    });
+    const saveResultSpy = vi
+      .spyOn(sessionPersistence, 'saveStreamResultToSession')
+      .mockImplementation(async () => {
+        markPersistenceStarted?.();
+        await persistenceCanFinish;
+      });
+    const finalTool = tool({
+      name: 'test',
+      description: 'returns output before persistence',
+      parameters: z.object({ test: z.string() }),
+      execute: async () => 'persisted output',
+    });
+    const model = new CountingFunctionToolStreamModel();
+    const agent = new Agent({
+      name: 'CancelDuringFinalPersistenceAgent',
+      model,
+      tools: [finalTool],
+      toolUseBehavior: 'stop_on_first_tool',
+    });
+    const runner = new Runner();
+    const agentEnd = vi.fn();
+    runner.on('agent_end', agentEnd);
+    const result = await runner.run(agent, 'start', {
+      stream: true,
+      session: createSessionMock(),
+    });
+    const reader = (result.toStream() as any).getReader();
+
+    await persistenceStarted;
+    await reader.cancel('stop');
+    releasePersistence?.();
+    await result.completed;
+
+    expect(result.cancelled).toBe(true);
+    expect(result.finalOutput).toBe('persisted output');
+    expect(result.state._currentTurnInProgress).toBe(false);
+    expect(saveResultSpy).toHaveBeenCalledTimes(1);
+    expect(agentEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('records a cancelled streaming agent tool as incomplete', async () => {
+    let markNestedModelStarted: (() => void) | undefined;
+    const nestedModelStarted = new Promise<void>((resolve) => {
+      markNestedModelStarted = resolve;
+    });
+    const nestedModel: Model = {
+      async getResponse() {
+        throw new Error('Unexpected non-streaming nested model request');
+      },
+      async *getStreamedResponse(request) {
+        markNestedModelStarted?.();
+        if (!request.signal) {
+          throw new Error('Expected nested model abort signal');
+        }
+        if (!request.signal.aborted) {
+          await new Promise<void>((resolve) => {
+            request.signal!.addEventListener('abort', () => resolve(), {
+              once: true,
+            });
+          });
+        }
+        request.signal.throwIfAborted();
+        yield {
+          type: 'response_done',
+          response: {
+            id: 'unexpected-nested-response',
+            usage: {
+              requests: 1,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            output: [fakeModelMessage('unexpected nested completion')],
+          },
+        } as StreamEvent;
+      },
+    };
+    const nestedAgent = new Agent({
+      name: 'NestedStreamingAgent',
+      model: nestedModel,
+    });
+    const nestedTool = nestedAgent.asTool({
+      toolName: 'test',
+      toolDescription: 'runs a nested streaming agent',
+      parameters: z.object({ test: z.string() }),
+      inputBuilder: ({ params }) => params.test,
+      onStream: () => {},
+    });
+    const model = new CountingFunctionToolStreamModel();
+    const agent = new Agent({
+      name: 'ParentStreamingAgent',
+      model,
+      tools: [nestedTool],
+    });
+    const cancelled = await run(agent, 'start', { stream: true });
+    const reader = (cancelled.toStream() as any).getReader();
+
+    await nestedModelStarted;
+    await reader.cancel('stop');
+    await cancelled.completed;
+
+    expect(cancelled.cancelled).toBe(true);
+    expect(model.callCount).toBe(1);
+    expect(
+      cancelled.state._generatedItems.find(
+        (item) => item.rawItem.type === 'function_call_result',
+      )?.rawItem,
+    ).toMatchObject({
+      type: 'function_call_result',
+      callId: TEST_MODEL_FUNCTION_CALL.callId,
+      status: 'incomplete',
+      output: { type: 'text', text: 'aborted' },
+    });
+    expect(
+      cancelled.state.hasPendingAgentToolRun(
+        nestedTool.name,
+        TEST_MODEL_FUNCTION_CALL.callId,
+      ),
+    ).toBe(false);
+
+    const resumed = await run(agent, cancelled.state, { stream: true });
+    for await (const _event of resumed) {
+      // Drain the resumed run.
+    }
+
+    expect(resumed.finalOutput).toBe('done');
+    expect(model.callCount).toBe(2);
+  });
+
+  it('does not call the model when cancelled during next-turn preparation', async () => {
+    let filterCalls = 0;
+    let markNextTurnPreparationStarted: (() => void) | undefined;
+    let finishNextTurnPreparation: (() => void) | undefined;
+    const nextTurnPreparationStarted = new Promise<void>((resolve) => {
+      markNextTurnPreparationStarted = resolve;
+    });
+    const nextTurnPreparationCanFinish = new Promise<void>((resolve) => {
+      finishNextTurnPreparation = resolve;
+    });
+    const testTool = tool({
+      name: 'test',
+      description: 'completes before the next model turn',
+      parameters: z.object({ test: z.string() }),
+      execute: async () => 'completed',
+    });
+    const model = new CountingFunctionToolStreamModel();
+    const agent = new Agent({
+      name: 'CancelDuringPreparationAgent',
+      model,
+      tools: [testTool],
+    });
+    const runner = new Runner({
+      callModelInputFilter: async ({ modelData }) => {
+        filterCalls += 1;
+        if (filterCalls === 2) {
+          markNextTurnPreparationStarted?.();
+          await nextTurnPreparationCanFinish;
+        }
+        return modelData;
+      },
+    });
+    const result = await runner.run(agent, 'start', { stream: true });
+    const reader = (result.toStream() as any).getReader();
+
+    await nextTurnPreparationStarted;
+    await reader.cancel('stop');
+    finishNextTurnPreparation?.();
+    await result.completed;
+
+    expect(result.cancelled).toBe(true);
+    expect(model.callCount).toBe(1);
+  });
+
+  it('does not call the model when a resumed turn is cancelled during preparation', async () => {
+    let markToolStarted: (() => void) | undefined;
+    const toolStarted = new Promise<void>((resolve) => {
+      markToolStarted = resolve;
+    });
+    const testTool = tool({
+      name: 'test',
+      description: 'settles after cancellation',
+      parameters: z.object({ test: z.string() }),
+      execute: async (_input, _context, details) => {
+        markToolStarted?.();
+        const signal = details?.signal;
+        if (!signal?.aborted) {
+          await new Promise<void>((resolve) => {
+            signal?.addEventListener('abort', () => resolve(), { once: true });
+          });
+        }
+        return 'completed';
+      },
+    });
+    const model = new CountingFunctionToolStreamModel();
+    const agent = new Agent({
+      name: 'CancelDuringResumedPreparationAgent',
+      model,
+      tools: [testTool],
+    });
+    const first = await run(agent, 'start', { stream: true });
+    const firstReader = (first.toStream() as any).getReader();
+
+    await toolStarted;
+    await firstReader.cancel('stop');
+    await first.completed;
+
+    expect(first.state._currentStep?.type).toBe('next_step_run_again');
+    expect(first.state._currentTurnInProgress).toBe(true);
+
+    let markPreparationStarted: (() => void) | undefined;
+    let releasePreparation: (() => void) | undefined;
+    const preparationStarted = new Promise<void>((resolve) => {
+      markPreparationStarted = resolve;
+    });
+    const preparationCanFinish = new Promise<void>((resolve) => {
+      releasePreparation = resolve;
+    });
+    const runner = new Runner({
+      callModelInputFilter: async ({ modelData }) => {
+        markPreparationStarted?.();
+        await preparationCanFinish;
+        return modelData;
+      },
+    });
+    const resumed = await runner.run(agent, first.state, { stream: true });
+    const resumedReader = (resumed.toStream() as any).getReader();
+
+    await preparationStarted;
+    await resumedReader.cancel('stop');
+    releasePreparation?.();
+    await resumed.completed;
+
+    expect(resumed.cancelled).toBe(true);
+    expect(model.callCount).toBe(1);
   });
 
   it('enforces maxTurns across multiple streamed model calls', async () => {

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -1579,7 +1579,10 @@ describe('Runner.run (streaming)', () => {
       model,
       tools: [abortableTool],
     });
-    const result = await run(agent, 'start', { stream: true });
+    const result = await run(agent, 'start', {
+      stream: true,
+      maxTurns: 1,
+    });
     const reader = (result.toStream() as any).getReader();
 
     await toolStarted;
@@ -1590,6 +1593,7 @@ describe('Runner.run (streaming)', () => {
     expect(result.cancelled).toBe(true);
     expect(toolSignal?.aborted).toBe(true);
     expect(model.callCount).toBe(1);
+    expect(result.state._currentTurnInProgress).toBe(false);
     expect(
       result.state._generatedItems.some(
         (item) =>
@@ -1597,6 +1601,12 @@ describe('Runner.run (streaming)', () => {
           item.rawItem.status === 'completed',
       ),
     ).toBe(true);
+
+    const resumed = await run(agent, result.state, { stream: true });
+    await expect(resumed.completed).rejects.toBeInstanceOf(
+      MaxTurnsExceededError,
+    );
+    expect(model.callCount).toBe(1);
   });
 
   it('atomically finalizes a completed tool output after cancellation', async () => {
@@ -2131,7 +2141,7 @@ describe('Runner.run (streaming)', () => {
     await first.completed;
 
     expect(first.state._currentStep?.type).toBe('next_step_run_again');
-    expect(first.state._currentTurnInProgress).toBe(true);
+    expect(first.state._currentTurnInProgress).toBe(false);
 
     let markPreparationStarted: (() => void) | undefined;
     let releasePreparation: (() => void) | undefined;

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -1971,6 +1971,88 @@ describe('Runner.run (streaming)', () => {
     expect(model.callCount).toBe(2);
   });
 
+  it('preserves a nested agent output committed during cancellation', async () => {
+    let markGuardrailStarted: (() => void) | undefined;
+    let releaseGuardrail: (() => void) | undefined;
+    const guardrailStarted = new Promise<void>((resolve) => {
+      markGuardrailStarted = resolve;
+    });
+    const guardrailCanFinish = new Promise<void>((resolve) => {
+      releaseGuardrail = resolve;
+    });
+    const nestedGuardrail = {
+      name: 'delayed-nested-output-guardrail',
+      execute: vi.fn(async () => {
+        markGuardrailStarted?.();
+        await guardrailCanFinish;
+        return {
+          tripwireTriggered: false,
+          outputInfo: { safe: true },
+        };
+      }),
+    };
+    const nestedModel: Model = {
+      async getResponse() {
+        throw new Error('Unexpected non-streaming nested model request');
+      },
+      async *getStreamedResponse() {
+        yield {
+          type: 'response_done',
+          response: {
+            id: 'nested-final-response',
+            usage: {
+              requests: 1,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            output: [fakeModelMessage('nested final output')],
+          },
+        } as StreamEvent;
+      },
+    };
+    const nestedAgent = new Agent({
+      name: 'CommittedNestedStreamingAgent',
+      model: nestedModel,
+      outputGuardrails: [nestedGuardrail],
+    });
+    const nestedTool = nestedAgent.asTool({
+      toolName: 'test',
+      toolDescription: 'runs a nested streaming agent',
+      parameters: z.object({ test: z.string() }),
+      inputBuilder: ({ params }) => params.test,
+      onStream: () => {},
+    });
+    const model = new CountingFunctionToolStreamModel();
+    const agent = new Agent({
+      name: 'ParentOfCommittedNestedAgent',
+      model,
+      tools: [nestedTool],
+      toolUseBehavior: 'stop_on_first_tool',
+    });
+    const result = await run(agent, 'start', { stream: true });
+    const reader = (result.toStream() as any).getReader();
+
+    await guardrailStarted;
+    await reader.cancel('stop');
+    releaseGuardrail?.();
+    await result.completed;
+
+    expect(result.cancelled).toBe(true);
+    expect(result.finalOutput).toBe('nested final output');
+    expect(nestedGuardrail.execute).toHaveBeenCalledTimes(1);
+    expect(
+      result.state._generatedItems.find(
+        (item) => item.rawItem.type === 'function_call_result',
+      )?.rawItem,
+    ).toMatchObject({
+      type: 'function_call_result',
+      callId: TEST_MODEL_FUNCTION_CALL.callId,
+      status: 'completed',
+      output: { type: 'text', text: 'nested final output' },
+    });
+  });
+
   it('does not call the model when cancelled during next-turn preparation', async () => {
     let filterCalls = 0;
     let markNextTurnPreparationStarted: (() => void) | undefined;

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -2063,6 +2063,97 @@ describe('Runner.run (streaming)', () => {
     });
   });
 
+  it('preserves a nested approval committed during cancellation', async () => {
+    let markPersistenceStarted: (() => void) | undefined;
+    let releasePersistence: (() => void) | undefined;
+    const persistenceStarted = new Promise<void>((resolve) => {
+      markPersistenceStarted = resolve;
+    });
+    const persistenceCanFinish = new Promise<void>((resolve) => {
+      releasePersistence = resolve;
+    });
+    let blockedNestedPersistence = false;
+    const saveResultSpy = vi
+      .spyOn(sessionPersistence, 'saveStreamResultToSession')
+      .mockImplementation(async (_session, nestedResult) => {
+        if (
+          !blockedNestedPersistence &&
+          nestedResult.state._currentStep?.type === 'next_step_interruption'
+        ) {
+          blockedNestedPersistence = true;
+          markPersistenceStarted?.();
+          await persistenceCanFinish;
+        }
+      });
+    const approvalTool = tool({
+      name: 'test',
+      description: 'requires approval in the nested agent',
+      parameters: z.object({ test: z.string() }),
+      needsApproval: true,
+      execute: async () => 'approved',
+    });
+    const nestedModel = new CountingFunctionToolStreamModel();
+    const nestedAgent = new Agent({
+      name: 'NestedApprovalAgent',
+      model: nestedModel,
+      tools: [approvalTool],
+    });
+    const nestedSession = createSessionMock();
+    const nestedTool = nestedAgent.asTool({
+      toolName: 'test',
+      toolDescription: 'runs a nested agent that requires approval',
+      parameters: z.object({ test: z.string() }),
+      inputBuilder: ({ params }) => params.test,
+      onStream: () => {},
+      runOptions: { session: nestedSession },
+    });
+    const outerModel = new CountingFunctionToolStreamModel();
+    const outerAgent = new Agent({
+      name: 'ParentOfNestedApprovalAgent',
+      model: outerModel,
+      tools: [nestedTool],
+    });
+    const runner = new Runner();
+    const cancelled = await runner.run(outerAgent, 'start', { stream: true });
+    const reader = (cancelled.toStream() as any).getReader();
+
+    await persistenceStarted;
+    await reader.cancel('stop');
+    releasePersistence?.();
+    await cancelled.completed;
+
+    expect(cancelled.cancelled).toBe(true);
+    expect(cancelled.interruptions).toHaveLength(1);
+    expect(cancelled.interruptions[0]?.agent).toBe(nestedAgent);
+    expect(
+      cancelled.state.hasPendingAgentToolRun(
+        nestedTool.name,
+        TEST_MODEL_FUNCTION_CALL.callId,
+      ),
+    ).toBe(true);
+    expect(
+      saveResultSpy.mock.calls.filter(([session]) => session === nestedSession),
+    ).toHaveLength(1);
+
+    cancelled.state.approve(cancelled.interruptions[0]);
+    const resumed = await runner.run(outerAgent, cancelled.state, {
+      stream: true,
+    });
+    for await (const _event of resumed) {
+      // Drain the resumed run.
+    }
+
+    expect(resumed.finalOutput).toBe('done');
+    expect(
+      resumed.state.hasPendingAgentToolRun(
+        nestedTool.name,
+        TEST_MODEL_FUNCTION_CALL.callId,
+      ),
+    ).toBe(false);
+    expect(nestedModel.callCount).toBe(2);
+    expect(outerModel.callCount).toBe(2);
+  });
+
   it('does not call the model when cancelled during next-turn preparation', async () => {
     let filterCalls = 0;
     let markNextTurnPreparationStarted: (() => void) | undefined;

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -2206,6 +2206,95 @@ describe('sandbox runner integration', () => {
     ).toBe(true);
   });
 
+  it('preserves owned sandbox sessions for a resumable streamed cancellation', async () => {
+    const client = new FakeSandboxClient();
+    let markToolStarted: (() => void) | undefined;
+    let releaseTool: (() => void) | undefined;
+    const toolStarted = new Promise<void>((resolve) => {
+      markToolStarted = resolve;
+    });
+    const toolCanFinish = new Promise<void>((resolve) => {
+      releaseTool = resolve;
+    });
+    const sandboxTool = tool({
+      name: 'sandbox_tool',
+      description: 'Settles when the streamed run is cancelled.',
+      parameters: z.object({}).strict(),
+      execute: async (_input, _context, details) => {
+        markToolStarted?.();
+        const signal = details?.signal;
+        if (!signal?.aborted) {
+          await Promise.race([
+            toolCanFinish,
+            new Promise<void>((resolve) => {
+              signal?.addEventListener('abort', () => resolve(), {
+                once: true,
+              });
+            }),
+          ]);
+        }
+        return 'cancelled tool result';
+      },
+    });
+    const sandboxModel = new RecordingStreamingModel([
+      {
+        output: [
+          {
+            id: 'fc_cancelled_sandbox_tool',
+            type: 'function_call',
+            name: 'sandbox_tool',
+            callId: 'call_cancelled_sandbox_tool',
+            status: 'completed',
+            arguments: '{}',
+          } satisfies protocol.FunctionCallItem,
+        ],
+        usage: new Usage(),
+      },
+      {
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+      },
+    ]);
+    const sandboxAgent = new SandboxAgent({
+      name: 'CancelledSandboxWorker',
+      model: sandboxModel,
+      tools: [sandboxTool],
+      defaultManifest: new Manifest({ root: '/workspace' }),
+    });
+    const runner = new Runner();
+    const cancelled = await runner.run(sandboxAgent, 'Hello', {
+      stream: true,
+      sandbox: { client },
+    });
+    const reader = (cancelled.toStream() as any).getReader();
+
+    await toolStarted;
+    await reader.cancel('stop');
+    releaseTool?.();
+    await cancelled.completed;
+
+    expect(cancelled.cancelled).toBe(true);
+    expect(client.closeCalls).toEqual([]);
+    expect(cancelled.state._sandbox).toBeDefined();
+    expect(
+      cancelled.state._generatedItems.some(
+        (item) => item.rawItem.type === 'function_call_result',
+      ),
+    ).toBe(true);
+
+    const resumed = await runner.run(sandboxAgent, cancelled.state, {
+      stream: true,
+      sandbox: { client },
+    });
+    for await (const _event of resumed) {
+      // Drain the resumed run.
+    }
+
+    expect(resumed.finalOutput).toBe('done');
+    expect(client.createCalls).toHaveLength(1);
+    expect(client.closeCalls).toEqual(['session-1']);
+  });
+
   it('clears prior sandbox state when a resumed turn does not touch sandbox agents', async () => {
     const agent = new Agent<unknown, any>({ name: 'PlainAgent' });
     const state = new RunState<unknown, Agent<unknown, any>>(


### PR DESCRIPTION
This pull request resolves #1521 by implementing streamed function-tool cancellation on top of the two prerequisite lifecycle fixes split out from the earlier reverted attempt.

## Background

The original implementation in #1523 propagated cancellation into both streaming and non-streaming function tools before the streamed completion boundary was safe. Follow-up fixes expanded across guardrails, persistence, approvals, and sandbox cleanup because a cancelled background loop could still mutate the exposed `RunState` after `stream.completed` had resolved.

PR #1526 reverted that implementation so the underlying boundaries could be addressed independently:

- #1527 established that `stream.completed` does not settle until the cancelled background loop has finished and relinquished ownership of the exposed `RunState`.
- #1528 implemented non-streaming function-tool cancellation, preserving settled tool results and stopping before another model turn begins.
- This pull request implements the remaining streamed path.

## Changes

The streamed runner now passes its cancellation signal through normal and approval-resumed function-tool execution. Once cancellation occurs, already-started actions are allowed to settle and their accepted results are recorded, but the runner does not start another model request or another resumable action.

Cancellation is rechecked after asynchronous model preparation for both same-invocation continuation turns and resumed in-progress turns. This prevents a custom model implementation from receiving an already-aborted request after preparation completes.

Final-output processing uses a single commit boundary. Cancellation observed before finalization prevents it from starting; once output guardrails begin, guardrails, session persistence, lifecycle events, and sandbox cleanup complete atomically. This avoids partially finalized states that would require replaying guardrails or persistence after resume.

A cancelled streaming `Agent.asTool()` invocation is recorded as an incomplete function result. It is not stored in the pending nested-agent map because that map remains reserved for actual approval interruptions. Resuming the parent run therefore presents the recorded aborted result to the parent model instead of orphaning or automatically replaying nested work.

Runner-owned sandbox sessions are preserved only when cancellation leaves an in-progress resumable turn. Sessions are cleaned up normally when cancellation races with an already committed final output.

## Relationship to the prerequisite pull requests

- #1527 owns streamed completion and `RunState` settlement.
- #1528 owns non-streaming function-tool cancellation.
- This pull request owns streamed signal propagation and the state transition after streamed tool cancellation.

Unlike the reverted implementation, this change does not introduce per-await rollback or resumable-finalization machinery. It uses the existing action-settlement boundary, records incomplete cancelled calls, and treats finalization as an atomic commit.