### PR TITLE
fix(mcp): forward the run abort signal into MCP tool calls

### DIFF
--- a/.changeset/slow-tools-cancel.md
+++ b/.changeset/slow-tools-cancel.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix(mcp): forward run cancellation signals to MCP tool calls

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -110,6 +110,7 @@ export {
   invalidateServerToolsCache,
   mcpToFunctionTool,
   MCPBlobResourceContent,
+  MCPCallToolOptions,
   CallToolResult,
   CallToolResultContent,
   MCPListResourcesParams,

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -76,6 +76,10 @@ type PrefixedToolNameCandidate = {
   toolIndex: number;
 };
 
+export type MCPCallToolOptions = {
+  signal?: AbortSignal;
+};
+
 /**
  * Interface for MCP server implementations.
  * Provides methods for connecting, listing tools, calling tools, and cleanup.
@@ -103,6 +107,7 @@ export interface MCPServer {
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResultContent>;
   /**
    * Invoke a tool and return the full serializable MCP result.
@@ -111,6 +116,7 @@ export interface MCPServer {
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResult>;
   invalidateToolsCache(): Promise<void>;
 }
@@ -248,15 +254,23 @@ export class MCPServerStdio
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResultContent> {
-    return (await this.callToolResult(toolName, args, meta)).content;
+    return (
+      await (options === undefined
+        ? this.callToolResult(toolName, args, meta)
+        : this.callToolResult(toolName, args, meta, options))
+    ).content;
   }
   callToolResult(
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResult> {
-    return this.underlying.callToolResult(toolName, args, meta);
+    return options === undefined
+      ? this.underlying.callToolResult(toolName, args, meta)
+      : this.underlying.callToolResult(toolName, args, meta, options);
   }
   listResources(
     params?: MCPListResourcesParams,
@@ -330,17 +344,25 @@ export class MCPServerStreamableHttp
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResultContent> {
-    return (await this.callToolResult(toolName, args, meta)).content;
+    return (
+      await (options === undefined
+        ? this.callToolResult(toolName, args, meta)
+        : this.callToolResult(toolName, args, meta, options))
+    ).content;
   }
   async callToolResult(
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResult> {
     const previousSessionId = this.sessionId;
     try {
-      return await this.underlying.callToolResult(toolName, args, meta);
+      return await (options === undefined
+        ? this.underlying.callToolResult(toolName, args, meta)
+        : this.underlying.callToolResult(toolName, args, meta, options));
     } finally {
       if (previousSessionId !== this.sessionId) {
         this.clearLocalToolsCache();
@@ -398,15 +420,23 @@ export class MCPServerSSE
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResultContent> {
-    return (await this.callToolResult(toolName, args, meta)).content;
+    return (
+      await (options === undefined
+        ? this.callToolResult(toolName, args, meta)
+        : this.callToolResult(toolName, args, meta, options))
+    ).content;
   }
   callToolResult(
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResult> {
-    return this.underlying.callToolResult(toolName, args, meta);
+    return options === undefined
+      ? this.underlying.callToolResult(toolName, args, meta)
+      : this.underlying.callToolResult(toolName, args, meta, options);
   }
   listResources(
     params?: MCPListResourcesParams,
@@ -1027,18 +1057,25 @@ export function mcpToFunctionTool(
     const meta = runContext
       ? await resolveMcpToolMeta(server, runContext, mcpTool.name, args)
       : undefined;
+    const callOptions: MCPCallToolOptions | undefined = details?.signal
+      ? { signal: details.signal }
+      : undefined;
     const result: CallToolResult =
       (server.useStructuredContent === true ||
         server.customDataExtractor !== undefined) &&
       server.callToolResult
-        ? meta === undefined
-          ? await server.callToolResult(mcpTool.name, args)
-          : await server.callToolResult(mcpTool.name, args, meta)
+        ? callOptions !== undefined
+          ? await server.callToolResult(mcpTool.name, args, meta, callOptions)
+          : meta === undefined
+            ? await server.callToolResult(mcpTool.name, args)
+            : await server.callToolResult(mcpTool.name, args, meta)
         : {
             content:
-              meta === undefined
-                ? await server.callTool(mcpTool.name, args)
-                : await server.callTool(mcpTool.name, args, meta),
+              callOptions !== undefined
+                ? await server.callTool(mcpTool.name, args, meta, callOptions)
+                : meta === undefined
+                  ? await server.callTool(mcpTool.name, args)
+                  : await server.callTool(mcpTool.name, args, meta),
           };
     const content = result.content as CallToolResultContent;
     const resultMeta = result._meta ?? content._meta;

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -1082,9 +1082,11 @@ export function mcpToFunctionTool(
     } catch (error) {
       // The SDK rejects cancelled requests with an McpError (-32001) rather
       // than the abort reason, which the tool error path would treat as an
-      // ordinary failure; surface the cancellation instead.
+      // ordinary failure; surface the cancellation instead. The reason is
+      // thrown as-is — an aborted signal always carries one, and null is a
+      // valid value the cancellation checks compare against by identity.
       if (details?.signal?.aborted) {
-        throw details.signal.reason ?? error;
+        throw details.signal.reason;
       }
       throw error;
     }

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -1085,7 +1085,9 @@ export function mcpToFunctionTool(
       // ordinary failure; surface the cancellation instead. The reason is
       // thrown as-is — an aborted signal always carries one, and null is a
       // valid value the cancellation checks compare against by identity.
-      if (details?.signal?.aborted) {
+      // An explicit `errorFunction: null` opts out of every conversion, so
+      // the raw MCP failure is preserved for that configuration.
+      if (details?.signal?.aborted && errorFunction !== null) {
         throw details.signal.reason;
       }
       throw error;

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -1060,23 +1060,34 @@ export function mcpToFunctionTool(
     const callOptions: MCPCallToolOptions | undefined = details?.signal
       ? { signal: details.signal }
       : undefined;
-    const result: CallToolResult =
-      (server.useStructuredContent === true ||
-        server.customDataExtractor !== undefined) &&
-      server.callToolResult
-        ? callOptions !== undefined
-          ? await server.callToolResult(mcpTool.name, args, meta, callOptions)
-          : meta === undefined
-            ? await server.callToolResult(mcpTool.name, args)
-            : await server.callToolResult(mcpTool.name, args, meta)
-        : {
-            content:
-              callOptions !== undefined
-                ? await server.callTool(mcpTool.name, args, meta, callOptions)
-                : meta === undefined
-                  ? await server.callTool(mcpTool.name, args)
-                  : await server.callTool(mcpTool.name, args, meta),
-          };
+    let result: CallToolResult;
+    try {
+      result =
+        (server.useStructuredContent === true ||
+          server.customDataExtractor !== undefined) &&
+        server.callToolResult
+          ? callOptions !== undefined
+            ? await server.callToolResult(mcpTool.name, args, meta, callOptions)
+            : meta === undefined
+              ? await server.callToolResult(mcpTool.name, args)
+              : await server.callToolResult(mcpTool.name, args, meta)
+          : {
+              content:
+                callOptions !== undefined
+                  ? await server.callTool(mcpTool.name, args, meta, callOptions)
+                  : meta === undefined
+                    ? await server.callTool(mcpTool.name, args)
+                    : await server.callTool(mcpTool.name, args, meta),
+            };
+    } catch (error) {
+      // The SDK rejects cancelled requests with an McpError (-32001) rather
+      // than the abort reason, which the tool error path would treat as an
+      // ordinary failure; surface the cancellation instead.
+      if (details?.signal?.aborted) {
+        throw details.signal.reason ?? error;
+      }
+      throw error;
+    }
     const content = result.content as CallToolResultContent;
     const resultMeta = result._meta ?? content._meta;
     const structuredContent =

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -1347,6 +1347,12 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
         throw error;
       }
 
+      // The strategy lookup awaits; cancellation may have arrived while it
+      // ran, and recovery mutates the shared client — recheck before starting.
+      if (options?.signal?.aborted) {
+        throw error;
+      }
+
       this.debugLog(
         () =>
           `Reconnecting closed streamable HTTP MCP session for ${toolName}.`,

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -1352,11 +1352,41 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
           `Reconnecting closed streamable HTTP MCP session for ${toolName}.`,
       );
 
-      const recoveredClient = await this.reconnectClosedStreamableHttpClient({
+      // Race this caller's wait against its signal: a cancelled caller must
+      // unwind immediately, while the shared reconnection (and any late
+      // failure it produces) stays observed for other callers.
+      const reconnectPromise = this.reconnectClosedStreamableHttpClient({
         cause: error,
         failedClient: client,
         failedStateVersion: callToolStateVersion,
       });
+      let recoveredClient: Client;
+      const signal = options?.signal;
+      if (signal) {
+        let onAbort: (() => void) | undefined;
+        try {
+          recoveredClient = await Promise.race([
+            reconnectPromise,
+            new Promise<never>((_resolve, reject) => {
+              onAbort = () => reject(error);
+              if (signal.aborted) {
+                reject(error);
+                return;
+              }
+              signal.addEventListener('abort', onAbort, { once: true });
+            }),
+          ]);
+        } catch (raceError) {
+          reconnectPromise.catch(() => {});
+          throw raceError;
+        } finally {
+          if (onAbort) {
+            signal.removeEventListener('abort', onAbort);
+          }
+        }
+      } else {
+        recoveredClient = await reconnectPromise;
+      }
 
       if (recoveryStrategy === 'reconnect-only') {
         throw error;

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -1336,6 +1336,11 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
         options,
       );
     } catch (error) {
+      // A cancelled call must not hold up settlement on reconnection; the
+      // caller is no longer waiting for a result.
+      if (options?.signal?.aborted) {
+        throw error;
+      }
       const recoveryStrategy =
         await this.shouldReconnectClosedStreamableHttpClient(error, client);
       if (recoveryStrategy === 'none') {
@@ -1354,6 +1359,10 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
       });
 
       if (recoveryStrategy === 'reconnect-only') {
+        throw error;
+      }
+
+      if (options?.signal?.aborted) {
         throw error;
       }
 

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -20,6 +20,7 @@ import type {
   MCPListResourcesResult,
   MCPListResourceTemplatesResult,
   MCPReadResourceResult,
+  MCPCallToolOptions,
   MCPServerStdioOptions,
   MCPServerStreamableHttpOptions,
   MCPServerSSEOptions,
@@ -280,14 +281,20 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResultContent> {
-    return (await this.callToolResult(toolName, args, meta)).content;
+    return (
+      await (options === undefined
+        ? this.callToolResult(toolName, args, meta)
+        : this.callToolResult(toolName, args, meta, options))
+    ).content;
   }
 
   async callToolResult(
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResult> {
     const { CallToolResultSchema } =
       await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
@@ -298,7 +305,7 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
     }
     const requestOptions = buildRequestOptions(
       this.clientSessionTimeoutSeconds,
-      { timeout: this.timeout },
+      { timeout: this.timeout, ...options },
     );
     const params = {
       name: toolName,
@@ -495,14 +502,20 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResultContent> {
-    return (await this.callToolResult(toolName, args, meta)).content;
+    return (
+      await (options === undefined
+        ? this.callToolResult(toolName, args, meta)
+        : this.callToolResult(toolName, args, meta, options))
+    ).content;
   }
 
   async callToolResult(
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResult> {
     const { CallToolResultSchema } =
       await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
@@ -513,7 +526,7 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
     }
     const requestOptions = buildRequestOptions(
       this.clientSessionTimeoutSeconds,
-      { timeout: this.timeout },
+      { timeout: this.timeout, ...options },
     );
     const params = {
       name: toolName,
@@ -908,6 +921,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResult> {
     const { CallToolResultSchema } =
       await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
@@ -915,6 +929,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
       this.clientSessionTimeoutSeconds,
       {
         timeout: this.timeout,
+        ...options,
       },
     );
     const params = {
@@ -1288,14 +1303,20 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResultContent> {
-    return (await this.callToolResult(toolName, args, meta)).content;
+    return (
+      await (options === undefined
+        ? this.callToolResult(toolName, args, meta)
+        : this.callToolResult(toolName, args, meta, options))
+    ).content;
   }
 
   async callToolResult(
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResult> {
     const client = this.session;
     if (!client) {
@@ -1307,7 +1328,13 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     let result: CallToolResult;
 
     try {
-      result = await this.callToolWithClient(client, toolName, args, meta);
+      result = await this.callToolWithClient(
+        client,
+        toolName,
+        args,
+        meta,
+        options,
+      );
     } catch (error) {
       const recoveryStrategy =
         await this.shouldReconnectClosedStreamableHttpClient(error, client);
@@ -1336,6 +1363,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
           toolName,
           args,
           meta,
+          options,
         );
       } catch (retryError) {
         throw attachCause(retryError, error);

--- a/packages/agents-core/test/mcp.test.ts
+++ b/packages/agents-core/test/mcp.test.ts
@@ -1,5 +1,5 @@
-import { describe, test, expect } from 'vitest';
-import { MCPServerStdio } from '../src';
+import { describe, test, expect, vi } from 'vitest';
+import { MCPServerSSE, MCPServerStdio, MCPServerStreamableHttp } from '../src';
 
 describe('MCPServerStdio', () => {
   test('should be available', () => {
@@ -11,5 +11,48 @@ describe('MCPServerStdio', () => {
     expect(server).toBeDefined();
     expect(server.name).toBe('test');
     expect(server.cacheToolsList).toBe(true);
+  });
+
+  test.each([
+    [
+      'stdio',
+      () =>
+        new MCPServerStdio({
+          name: 'stdio',
+          fullCommand: 'test',
+        }),
+    ],
+    [
+      'streamable HTTP',
+      () =>
+        new MCPServerStreamableHttp({
+          name: 'streamable-http',
+          url: 'https://example.com/mcp',
+        }),
+    ],
+    [
+      'SSE',
+      () =>
+        new MCPServerSSE({
+          name: 'sse',
+          url: 'https://example.com/sse',
+        }),
+    ],
+  ])('forwards call options through the %s wrapper', async (_name, create) => {
+    const callToolResult = vi.fn(async () => ({
+      content: [{ type: 'text', text: 'ok' }],
+    }));
+    const server = create();
+    (server as any).underlying = {
+      callToolResult,
+      sessionId: undefined,
+    };
+    const signal = new AbortController().signal;
+
+    await server.callTool('mock-tool', {}, undefined, { signal });
+
+    expect(callToolResult).toHaveBeenCalledWith('mock-tool', {}, undefined, {
+      signal,
+    });
   });
 });

--- a/packages/agents-core/test/mcpRunCancellation.test.ts
+++ b/packages/agents-core/test/mcpRunCancellation.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import { Agent } from '../src/agent';
+import type { MCPServer } from '../src/mcp';
+import type { ModelResponse } from '../src/model';
+import { run } from '../src/run';
+import { setTracingDisabled } from '../src/tracing';
+import { Usage } from '../src/usage';
+import { FakeModel } from './stubs';
+
+setTracingDisabled(true);
+
+describe('MCP run cancellation', () => {
+  it('cancels an in-flight MCP request without a stale completion', async () => {
+    let mcpCallStarted = false;
+    let mcpCallEnded = false;
+    let mcpCancelled = false;
+
+    const server: MCPServer = {
+      name: 'cancellation-server',
+      cacheToolsList: false,
+      connect: async () => {},
+      close: async () => {},
+      listTools: async () => [
+        {
+          name: 'slow_tool',
+          description: 'Waits before returning.',
+          inputSchema: {
+            type: 'object',
+            properties: {},
+            required: [],
+            additionalProperties: false,
+          },
+        } as any,
+      ],
+      callTool: (_name, _args, _meta, options) => {
+        mcpCallStarted = true;
+        return new Promise((resolve, reject) => {
+          const timer = setTimeout(() => {
+            mcpCallEnded = true;
+            resolve([{ type: 'text', text: 'late result' }] as any);
+          }, 800);
+          options?.signal?.addEventListener(
+            'abort',
+            () => {
+              mcpCancelled = true;
+              clearTimeout(timer);
+              reject(new DOMException('MCP request cancelled', 'AbortError'));
+            },
+            { once: true },
+          );
+        }) as any;
+      },
+      invalidateToolsCache: async () => {},
+    };
+    const responses: ModelResponse[] = [
+      {
+        output: [
+          {
+            type: 'function_call',
+            callId: 'call-1',
+            name: 'slow_tool',
+            arguments: '{}',
+            status: 'completed',
+          } as any,
+        ],
+        usage: new Usage(),
+      } as any,
+      {
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [{ type: 'output_text', text: 'done' }],
+          } as any,
+        ],
+        usage: new Usage(),
+      } as any,
+    ];
+    const agent = new Agent({
+      name: 'cancellation-agent',
+      model: new FakeModel(responses),
+      mcpServers: [server],
+    });
+    const controller = new AbortController();
+    const started = Date.now();
+    const outcomePromise = run(agent, 'go', {
+      signal: controller.signal,
+    }).then(
+      () => ({ kind: 'resolved' as const, error: '' }),
+      (error) => ({ kind: 'rejected' as const, error: String(error) }),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    controller.abort(new Error('user aborted'));
+    const outcome = await outcomePromise;
+    const elapsed = Date.now() - started;
+    await new Promise((resolve) => setTimeout(resolve, 75));
+
+    expect(outcome).toEqual({
+      kind: 'rejected',
+      error: expect.stringContaining('user aborted'),
+    });
+    expect(mcpCallStarted).toBe(true);
+    expect(mcpCancelled).toBe(true);
+    expect(mcpCallEnded).toBe(false);
+    expect(elapsed).toBeLessThan(500);
+  }, 5_000);
+});

--- a/packages/agents-core/test/mcpRunCancellation.test.ts
+++ b/packages/agents-core/test/mcpRunCancellation.test.ts
@@ -10,9 +10,21 @@ import { FakeModel } from './stubs';
 
 setTracingDisabled(true);
 
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe('MCP run cancellation', () => {
   it('cancels an in-flight MCP request without a stale completion', async () => {
-    let mcpCallStarted = false;
+    const requestStarted = deferred();
+    const releaseLateCompletion = deferred();
+    const lateCompletionRan = deferred();
     let mcpCallEnded = false;
     let mcpCancelled = false;
 
@@ -34,17 +46,17 @@ describe('MCP run cancellation', () => {
         } as any,
       ],
       callTool: (_name, _args, _meta, options) => {
-        mcpCallStarted = true;
+        requestStarted.resolve();
         return new Promise((resolve, reject) => {
-          const timer = setTimeout(() => {
+          releaseLateCompletion.promise.then(() => {
             mcpCallEnded = true;
             resolve([{ type: 'text', text: 'late result' }] as any);
-          }, 800);
+            lateCompletionRan.resolve();
+          });
           options?.signal?.addEventListener(
             'abort',
             () => {
               mcpCancelled = true;
-              clearTimeout(timer);
               reject(new DOMException('MCP request cancelled', 'AbortError'));
             },
             { once: true },
@@ -84,7 +96,6 @@ describe('MCP run cancellation', () => {
       mcpServers: [server],
     });
     const controller = new AbortController();
-    const started = Date.now();
     const outcomePromise = run(agent, 'go', {
       signal: controller.signal,
     }).then(
@@ -92,19 +103,19 @@ describe('MCP run cancellation', () => {
       (error) => ({ kind: 'rejected' as const, error: String(error) }),
     );
 
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await requestStarted.promise;
     controller.abort(new Error('user aborted'));
     const outcome = await outcomePromise;
-    const elapsed = Date.now() - started;
-    await new Promise((resolve) => setTimeout(resolve, 75));
 
     expect(outcome).toEqual({
       kind: 'rejected',
       error: expect.stringContaining('user aborted'),
     });
-    expect(mcpCallStarted).toBe(true);
     expect(mcpCancelled).toBe(true);
     expect(mcpCallEnded).toBe(false);
-    expect(elapsed).toBeLessThan(500);
+
+    releaseLateCompletion.resolve();
+    await lateCompletionRan.promise;
+    expect(mcpCallEnded).toBe(true);
   }, 5_000);
 });

--- a/packages/agents-core/test/mcpRunCancellation.test.ts
+++ b/packages/agents-core/test/mcpRunCancellation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { Agent } from '../src/agent';
 import type { MCPServer } from '../src/mcp';
@@ -117,5 +117,79 @@ describe('MCP run cancellation', () => {
     releaseLateCompletion.resolve();
     await lateCompletionRan.promise;
     expect(mcpCallEnded).toBe(true);
+  }, 5_000);
+
+  it('settles on the abort reason when the transport rejects with an MCP cancellation error', async () => {
+    const requestStarted = deferred();
+    const errorFunction = vi.fn(() => 'wrapped tool error');
+    const mcpError = Object.assign(
+      new Error('MCP error -32001: Request cancelled'),
+      { code: -32001 },
+    );
+
+    const server: MCPServer = {
+      name: 'protocol-cancellation-server',
+      cacheToolsList: false,
+      errorFunction: errorFunction as any,
+      connect: async () => {},
+      close: async () => {},
+      listTools: async () => [
+        {
+          name: 'slow_tool',
+          description: 'Waits before returning.',
+          inputSchema: {
+            type: 'object',
+            properties: {},
+            required: [],
+            additionalProperties: false,
+          },
+        } as any,
+      ],
+      callTool: (_name, _args, _meta, options) => {
+        requestStarted.resolve();
+        return new Promise((_resolve, reject) => {
+          options?.signal?.addEventListener('abort', () => reject(mcpError), {
+            once: true,
+          });
+        }) as any;
+      },
+      invalidateToolsCache: async () => {},
+    };
+    const responses: ModelResponse[] = [
+      {
+        output: [
+          {
+            type: 'function_call',
+            callId: 'call-1',
+            name: 'slow_tool',
+            arguments: '{}',
+            status: 'completed',
+          } as any,
+        ],
+        usage: new Usage(),
+      } as any,
+    ];
+    const agent = new Agent({
+      name: 'protocol-cancellation-agent',
+      model: new FakeModel(responses),
+      mcpServers: [server],
+    });
+    const controller = new AbortController();
+    const outcomePromise = run(agent, 'go', {
+      signal: controller.signal,
+    }).then(
+      () => ({ kind: 'resolved' as const, error: '' }),
+      (error) => ({ kind: 'rejected' as const, error: String(error) }),
+    );
+
+    await requestStarted.promise;
+    controller.abort(new Error('user aborted'));
+    const outcome = await outcomePromise;
+
+    expect(outcome).toEqual({
+      kind: 'rejected',
+      error: expect.stringContaining('user aborted'),
+    });
+    expect(errorFunction).not.toHaveBeenCalled();
   }, 5_000);
 });

--- a/packages/agents-core/test/mcpStreamableHttpReconnect.test.ts
+++ b/packages/agents-core/test/mcpStreamableHttpReconnect.test.ts
@@ -65,6 +65,45 @@ describe('NodeMCPServerStreamableHttp reconnect recovery under cancellation', ()
     expect(callToolWithClient).toHaveBeenCalledTimes(1);
   });
 
+  it('unwinds immediately when cancellation arrives while reconnection is pending', async () => {
+    const server = makeServer();
+    const connError = Object.assign(new Error('connection closed'), {
+      code: -32000,
+    });
+    const callToolWithClient = vi.fn(async () => {
+      throw connError;
+    });
+    let releaseReconnect!: (client: unknown) => void;
+    const reconnect = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          releaseReconnect = resolve;
+        }),
+    );
+    const shouldReconnect = vi.fn(async () => 'reconnect-and-retry');
+    (server as any).callToolWithClient = callToolWithClient;
+    (server as any).shouldReconnectClosedStreamableHttpClient = shouldReconnect;
+    (server as any).reconnectClosedStreamableHttpClient = reconnect;
+
+    const controller = new AbortController();
+    const outcome = server
+      .callToolResult('slow_tool', {}, undefined, {
+        signal: controller.signal,
+      })
+      .then(
+        () => ({ kind: 'resolved' as const }),
+        (error) => ({ kind: 'rejected' as const, error }),
+      );
+
+    await Promise.resolve();
+    controller.abort(new Error('user aborted'));
+
+    expect(await outcome).toEqual({ kind: 'rejected', error: connError });
+    expect(callToolWithClient).toHaveBeenCalledTimes(1);
+
+    releaseReconnect({ fake: true });
+  });
+
   it('still reconnects and retries when no signal is aborted', async () => {
     const server = makeServer();
     const connError = Object.assign(new Error('connection closed'), {

--- a/packages/agents-core/test/mcpStreamableHttpReconnect.test.ts
+++ b/packages/agents-core/test/mcpStreamableHttpReconnect.test.ts
@@ -65,6 +65,33 @@ describe('NodeMCPServerStreamableHttp reconnect recovery under cancellation', ()
     expect(callToolWithClient).toHaveBeenCalledTimes(1);
   });
 
+  it('skips recovery when cancellation arrives during the strategy lookup', async () => {
+    const server = makeServer();
+    const connError = Object.assign(new Error('connection closed'), {
+      code: -32000,
+    });
+    const callToolWithClient = vi.fn(async () => {
+      throw connError;
+    });
+    const controller = new AbortController();
+    const shouldReconnect = vi.fn(async () => {
+      controller.abort(new Error('user aborted'));
+      return 'reconnect-and-retry';
+    });
+    const reconnect = vi.fn(async () => ({ fake: true }));
+    (server as any).callToolWithClient = callToolWithClient;
+    (server as any).shouldReconnectClosedStreamableHttpClient = shouldReconnect;
+    (server as any).reconnectClosedStreamableHttpClient = reconnect;
+
+    await expect(
+      server.callToolResult('slow_tool', {}, undefined, {
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(connError);
+    expect(reconnect).not.toHaveBeenCalled();
+    expect(callToolWithClient).toHaveBeenCalledTimes(1);
+  });
+
   it('unwinds immediately when cancellation arrives while reconnection is pending', async () => {
     const server = makeServer();
     const connError = Object.assign(new Error('connection closed'), {
@@ -73,13 +100,17 @@ describe('NodeMCPServerStreamableHttp reconnect recovery under cancellation', ()
     const callToolWithClient = vi.fn(async () => {
       throw connError;
     });
+    let reconnectStarted!: () => void;
+    const reconnectStartedPromise = new Promise<void>((resolve) => {
+      reconnectStarted = resolve;
+    });
     let releaseReconnect!: (client: unknown) => void;
-    const reconnect = vi.fn(
-      () =>
-        new Promise((resolve) => {
-          releaseReconnect = resolve;
-        }),
-    );
+    const reconnect = vi.fn(() => {
+      reconnectStarted();
+      return new Promise((resolve) => {
+        releaseReconnect = resolve;
+      });
+    });
     const shouldReconnect = vi.fn(async () => 'reconnect-and-retry');
     (server as any).callToolWithClient = callToolWithClient;
     (server as any).shouldReconnectClosedStreamableHttpClient = shouldReconnect;
@@ -95,7 +126,7 @@ describe('NodeMCPServerStreamableHttp reconnect recovery under cancellation', ()
         (error) => ({ kind: 'rejected' as const, error }),
       );
 
-    await Promise.resolve();
+    await reconnectStartedPromise;
     controller.abort(new Error('user aborted'));
 
     expect(await outcome).toEqual({ kind: 'rejected', error: connError });

--- a/packages/agents-core/test/mcpStreamableHttpReconnect.test.ts
+++ b/packages/agents-core/test/mcpStreamableHttpReconnect.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { NodeMCPServerStreamableHttp } from '../src/shims/mcp-server/node';
+
+function makeServer() {
+  const server = new NodeMCPServerStreamableHttp({
+    url: 'http://localhost:9/mcp',
+    name: 'reconnect-test-server',
+  });
+  (server as any).session = { fake: true };
+  return server;
+}
+
+describe('NodeMCPServerStreamableHttp reconnect recovery under cancellation', () => {
+  it('skips reconnection when the call was already cancelled', async () => {
+    const server = makeServer();
+    const connError = Object.assign(new Error('connection closed'), {
+      code: -32000,
+    });
+    const callToolWithClient = vi.fn(async () => {
+      throw connError;
+    });
+    const shouldReconnect = vi.fn(async () => 'reconnect-and-retry');
+    const reconnect = vi.fn(async () => ({ fake: true }));
+    (server as any).callToolWithClient = callToolWithClient;
+    (server as any).shouldReconnectClosedStreamableHttpClient = shouldReconnect;
+    (server as any).reconnectClosedStreamableHttpClient = reconnect;
+
+    const controller = new AbortController();
+    controller.abort(new Error('user aborted'));
+
+    await expect(
+      server.callToolResult('slow_tool', {}, undefined, {
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(connError);
+    expect(reconnect).not.toHaveBeenCalled();
+    expect(callToolWithClient).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops before the retry when cancellation arrives during reconnection', async () => {
+    const server = makeServer();
+    const connError = Object.assign(new Error('connection closed'), {
+      code: -32000,
+    });
+    const callToolWithClient = vi.fn(async () => {
+      throw connError;
+    });
+    const controller = new AbortController();
+    const shouldReconnect = vi.fn(async () => 'reconnect-and-retry');
+    const reconnect = vi.fn(async () => {
+      controller.abort(new Error('user aborted'));
+      return { fake: true };
+    });
+    (server as any).callToolWithClient = callToolWithClient;
+    (server as any).shouldReconnectClosedStreamableHttpClient = shouldReconnect;
+    (server as any).reconnectClosedStreamableHttpClient = reconnect;
+
+    await expect(
+      server.callToolResult('slow_tool', {}, undefined, {
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(connError);
+    expect(reconnect).toHaveBeenCalledTimes(1);
+    expect(callToolWithClient).toHaveBeenCalledTimes(1);
+  });
+
+  it('still reconnects and retries when no signal is aborted', async () => {
+    const server = makeServer();
+    const connError = Object.assign(new Error('connection closed'), {
+      code: -32000,
+    });
+    const successResult = { content: [{ type: 'text', text: 'ok' }] };
+    const callToolWithClient = vi
+      .fn()
+      .mockRejectedValueOnce(connError)
+      .mockResolvedValueOnce(successResult);
+    const shouldReconnect = vi.fn(async () => 'reconnect-and-retry');
+    const reconnect = vi.fn(async () => ({ fake: true }));
+    (server as any).callToolWithClient = callToolWithClient;
+    (server as any).shouldReconnectClosedStreamableHttpClient = shouldReconnect;
+    (server as any).reconnectClosedStreamableHttpClient = reconnect;
+
+    await expect(
+      server.callToolResult('slow_tool', {}, undefined, {
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toBe(successResult);
+    expect(reconnect).toHaveBeenCalledTimes(1);
+    expect(callToolWithClient).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/agents-core/test/mcpToFunctionTool.test.ts
+++ b/packages/agents-core/test/mcpToFunctionTool.test.ts
@@ -834,6 +834,64 @@ describe('mcpToFunctionTool', () => {
     expect(await outcome).toEqual({ kind: 'rejected', error: reason });
   });
 
+  it('preserves a null abort reason during cancellation', async () => {
+    const mcpError = Object.assign(
+      new Error('MCP error -32001: Request cancelled'),
+      { code: -32001 },
+    );
+    let requestStarted!: () => void;
+    const requestStartedPromise = new Promise<void>((resolve) => {
+      requestStarted = resolve;
+    });
+    const tool = mcpToFunctionTool(
+      {
+        name: 'null_reason_tool',
+        description: '',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      } as any,
+      {
+        name: 'null-reason-server',
+        cacheToolsList: false,
+        connect: async () => {},
+        close: async () => {},
+        listTools: async () => [],
+        callTool: ((
+          _name: string,
+          _args: unknown,
+          _meta?: unknown,
+          options?: { signal?: AbortSignal },
+        ) => {
+          requestStarted();
+          return new Promise<never>((_resolve, reject) => {
+            options?.signal?.addEventListener('abort', () => reject(mcpError), {
+              once: true,
+            });
+          });
+        }) as any,
+        invalidateToolsCache: async () => {},
+      },
+      false,
+    );
+    const controller = new AbortController();
+
+    const invocation = tool.invoke(new RunContext({}), '{}', {
+      signal: controller.signal,
+    } as any);
+    const outcome = invocation.then(
+      (value) => ({ kind: 'resolved' as const, value }),
+      (error) => ({ kind: 'rejected' as const, error }),
+    );
+    await requestStartedPromise;
+    controller.abort(null);
+
+    expect(await outcome).toEqual({ kind: 'rejected', error: null });
+  });
+
   it('keeps non-cancellation SDK errors on the normal error path', async () => {
     const serverError = Object.assign(new Error('MCP error -32603: boom'), {
       code: -32603,

--- a/packages/agents-core/test/mcpToFunctionTool.test.ts
+++ b/packages/agents-core/test/mcpToFunctionTool.test.ts
@@ -892,6 +892,65 @@ describe('mcpToFunctionTool', () => {
     expect(await outcome).toEqual({ kind: 'rejected', error: null });
   });
 
+  it('preserves the raw MCP failure when errorFunction is null', async () => {
+    const mcpError = Object.assign(
+      new Error('MCP error -32001: Request cancelled'),
+      { code: -32001 },
+    );
+    let requestStarted!: () => void;
+    const requestStartedPromise = new Promise<void>((resolve) => {
+      requestStarted = resolve;
+    });
+    const tool = mcpToFunctionTool(
+      {
+        name: 'raw_error_tool',
+        description: '',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      } as any,
+      {
+        name: 'raw-error-server',
+        cacheToolsList: false,
+        errorFunction: null,
+        connect: async () => {},
+        close: async () => {},
+        listTools: async () => [],
+        callTool: ((
+          _name: string,
+          _args: unknown,
+          _meta?: unknown,
+          options?: { signal?: AbortSignal },
+        ) => {
+          requestStarted();
+          return new Promise<never>((_resolve, reject) => {
+            options?.signal?.addEventListener('abort', () => reject(mcpError), {
+              once: true,
+            });
+          });
+        }) as any,
+        invalidateToolsCache: async () => {},
+      },
+      false,
+    );
+    const controller = new AbortController();
+
+    const invocation = tool.invoke(new RunContext({}), '{}', {
+      signal: controller.signal,
+    } as any);
+    const outcome = invocation.then(
+      (value) => ({ kind: 'resolved' as const, value }),
+      (error) => ({ kind: 'rejected' as const, error }),
+    );
+    await requestStartedPromise;
+    controller.abort(new Error('user aborted'));
+
+    expect(await outcome).toEqual({ kind: 'rejected', error: mcpError });
+  });
+
   it('keeps non-cancellation SDK errors on the normal error path', async () => {
     const serverError = Object.assign(new Error('MCP error -32603: boom'), {
       code: -32603,

--- a/packages/agents-core/test/mcpToFunctionTool.test.ts
+++ b/packages/agents-core/test/mcpToFunctionTool.test.ts
@@ -771,4 +771,100 @@ describe('mcpToFunctionTool', () => {
       );
     });
   });
+
+  it('normalizes an SDK rejection as cancellation when the signal is aborted', async () => {
+    const mcpError = Object.assign(
+      new Error('MCP error -32001: Request cancelled'),
+      { code: -32001 },
+    );
+    let requestStarted!: () => void;
+    const requestStartedPromise = new Promise<void>((resolve) => {
+      requestStarted = resolve;
+    });
+    const callTool = vi.fn(
+      (
+        _name: string,
+        _args: unknown,
+        _meta?: unknown,
+        options?: { signal?: AbortSignal },
+      ) => {
+        requestStarted();
+        return new Promise<never>((_resolve, reject) => {
+          options?.signal?.addEventListener('abort', () => reject(mcpError), {
+            once: true,
+          });
+        });
+      },
+    );
+    const tool = mcpToFunctionTool(
+      {
+        name: 'cancelling_tool',
+        description: '',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      } as any,
+      {
+        name: 'cancelling-server',
+        cacheToolsList: false,
+        connect: async () => {},
+        close: async () => {},
+        listTools: async () => [],
+        callTool: callTool as any,
+        invalidateToolsCache: async () => {},
+      },
+      false,
+    );
+    const controller = new AbortController();
+    const reason = new Error('user aborted');
+
+    const invocation = tool.invoke(new RunContext({}), '{}', {
+      signal: controller.signal,
+    } as any);
+    const outcome = invocation.then(
+      (value) => ({ kind: 'resolved' as const, value }),
+      (error) => ({ kind: 'rejected' as const, error }),
+    );
+    await requestStartedPromise;
+    controller.abort(reason);
+
+    expect(await outcome).toEqual({ kind: 'rejected', error: reason });
+  });
+
+  it('keeps non-cancellation SDK errors on the normal error path', async () => {
+    const serverError = Object.assign(new Error('MCP error -32603: boom'), {
+      code: -32603,
+    });
+    const tool = mcpToFunctionTool(
+      {
+        name: 'failing_tool',
+        description: '',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      } as any,
+      {
+        name: 'failing-server',
+        cacheToolsList: false,
+        connect: async () => {},
+        close: async () => {},
+        listTools: async () => [],
+        callTool: async () => {
+          throw serverError;
+        },
+        invalidateToolsCache: async () => {},
+      },
+      false,
+    );
+
+    const result = await tool.invoke(new RunContext({}), '{}');
+
+    expect(String(result)).toContain('An error occurred');
+  });
 });

--- a/packages/agents-core/test/mcpToFunctionTool.test.ts
+++ b/packages/agents-core/test/mcpToFunctionTool.test.ts
@@ -128,6 +128,104 @@ describe('mcpToFunctionTool', () => {
     ]);
   });
 
+  it('passes the tool call signal to MCP calls', async () => {
+    const callTool = vi.fn(async () => [{ type: 'text', text: 'legacy' }]);
+    const callToolResult = vi.fn(async () => ({
+      content: [{ type: 'text', text: 'structured' }],
+      structuredContent: { answer: 42 },
+    }));
+    const signal = new AbortController().signal;
+    const legacyTool = mcpToFunctionTool(
+      {
+        name: 'legacy_signal',
+        description: '',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      } as any,
+      {
+        name: 'legacy-signal-server',
+        cacheToolsList: false,
+        connect: async () => {},
+        close: async () => {},
+        listTools: async () => [],
+        callTool,
+        invalidateToolsCache: async () => {},
+      },
+      false,
+    );
+    const structuredTool = mcpToFunctionTool(
+      {
+        name: 'structured_signal',
+        description: '',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      } as any,
+      {
+        name: 'structured-signal-server',
+        cacheToolsList: false,
+        useStructuredContent: true,
+        connect: async () => {},
+        close: async () => {},
+        listTools: async () => [],
+        callTool,
+        callToolResult,
+        invalidateToolsCache: async () => {},
+      },
+      false,
+    );
+
+    await legacyTool.invoke(new RunContext({}), '{}', { signal });
+    await structuredTool.invoke(new RunContext({}), '{}', { signal });
+
+    expect(callTool).toHaveBeenCalledWith('legacy_signal', {}, undefined, {
+      signal,
+    });
+    expect(callToolResult).toHaveBeenCalledWith(
+      'structured_signal',
+      {},
+      undefined,
+      { signal },
+    );
+  });
+
+  it('preserves MCP call arity when no signal is present', async () => {
+    const callTool = vi.fn(async () => [{ type: 'text', text: 'ok' }]);
+    const tool = mcpToFunctionTool(
+      {
+        name: 'no_signal',
+        description: '',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      } as any,
+      {
+        name: 'no-signal-server',
+        cacheToolsList: false,
+        connect: async () => {},
+        close: async () => {},
+        listTools: async () => [],
+        callTool,
+        invalidateToolsCache: async () => {},
+      },
+      false,
+    );
+
+    await tool.invoke(new RunContext({}), '{}');
+
+    expect(callTool.mock.calls[0]).toEqual(['no_signal', {}]);
+  });
+
   it('uses structured MCP output only when explicitly enabled', async () => {
     const callTool = vi.fn(async () => [
       { type: 'text', text: 'legacy output' },
@@ -512,7 +610,9 @@ describe('mcpToFunctionTool', () => {
       false,
     );
 
-    const result = await tool.invoke(new RunContext({}), '{}');
+    const result = await tool.invoke(new RunContext({}), '{}', {
+      signal: new AbortController().signal,
+    });
 
     expect(result).toBe(
       'An error occurred while running the tool. Please try again. Error: AbortError: synthetic abort',

--- a/packages/agents-core/test/shims/mcp-server/node.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/node.test.ts
@@ -98,11 +98,13 @@ describe('NodeMCPServerStdio', () => {
 
     await server.connect();
     await server.listTools();
-    await server.callTool('mock-tool', {});
+    const signal = new AbortController().signal;
+    await server.callTool('mock-tool', {}, undefined, { signal });
 
     expect(lastConnectOptions?.timeout).toBe(6000);
     expect(lastListToolsOptions?.timeout).toBe(6000);
     expect(lastCallToolOptions?.timeout).toBe(DEFAULT_REQUEST_TIMEOUT_MSEC);
+    expect(lastCallToolOptions?.signal).toBe(signal);
 
     await server.close();
   });
@@ -404,11 +406,13 @@ describe('NodeMCPServerSSE', () => {
 
     await server.connect();
     await server.listTools();
-    await server.callTool('mock-tool', {});
+    const signal = new AbortController().signal;
+    await server.callTool('mock-tool', {}, undefined, { signal });
 
     expect(lastConnectOptions?.timeout).toBe(4000);
     expect(lastListToolsOptions?.timeout).toBe(4000);
     expect(lastCallToolOptions?.timeout).toBe(DEFAULT_REQUEST_TIMEOUT_MSEC);
+    expect(lastCallToolOptions?.signal).toBe(signal);
 
     await server.close();
   });
@@ -564,11 +568,13 @@ describe('NodeMCPServerStreamableHttp', () => {
 
     await server.connect();
     await server.listTools();
-    await server.callTool('mock-tool', {});
+    const signal = new AbortController().signal;
+    await server.callTool('mock-tool', {}, undefined, { signal });
 
     expect(lastConnectOptions?.timeout).toBe(9000);
     expect(lastListToolsOptions?.timeout).toBe(9000);
     expect(lastCallToolOptions?.timeout).toBe(DEFAULT_REQUEST_TIMEOUT_MSEC);
+    expect(lastCallToolOptions?.signal).toBe(signal);
 
     await server.close();
   });


### PR DESCRIPTION
Aborting a run cancels plain function tools mid-flight, but an MCP-backed tool's request keeps running to completion: `mcpToFunctionTool` never reads `details.signal`, and `MCPServer.callTool` has no parameter to carry it to the transport, so the abort settles only after the call finishes and the server never sees a cancellation.

This threads an optional `options` parameter with `{ signal }` through `MCPServer.callTool` / `callToolResult` into the MCP SDK's `RequestOptions`, forwarded from `ToolCallDetails.signal`, with the argument appended only when a signal exists — existing call arity, the #1118 error path, `mcpShared.ts`, and the browser shim all stay unchanged.

An aborted run now rejects in tens of milliseconds with the request cancelled via `notifications/cancelled`; the new unit and end-to-end tests plus all existing `mcp*`, `run.test.ts`, and `run.stream.test.ts` suites pass.

Fixes #1530
