### PR TITLE
fix(core): propagate cancellation to MCP tool requests

### DIFF
--- a/.changeset/calm-mcp-tools-cancel.md
+++ b/.changeset/calm-mcp-tools-cancel.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: propagate run cancellation to MCP tool requests (#1530)

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -109,6 +109,7 @@ export {
   getAllMcpTools,
   invalidateServerToolsCache,
   mcpToFunctionTool,
+  MCPCallToolOptions,
   MCPBlobResourceContent,
   CallToolResult,
   CallToolResultContent,

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -64,6 +64,10 @@ export type MCPToolErrorFunction = (args: {
   error: Error | unknown;
 }) => Promise<string> | string;
 
+export interface MCPCallToolOptions {
+  signal?: AbortSignal;
+}
+
 const MCP_FUNCTION_TOOL_NAME_MAX_LENGTH = 64;
 const MCP_FUNCTION_TOOL_HASH_LENGTH = 8;
 
@@ -103,6 +107,7 @@ export interface MCPServer {
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResultContent>;
   /**
    * Invoke a tool and return the full serializable MCP result.
@@ -111,6 +116,7 @@ export interface MCPServer {
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResult>;
   invalidateToolsCache(): Promise<void>;
 }
@@ -248,15 +254,17 @@ export class MCPServerStdio
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResultContent> {
-    return (await this.callToolResult(toolName, args, meta)).content;
+    return (await this.callToolResult(toolName, args, meta, options)).content;
   }
   callToolResult(
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResult> {
-    return this.underlying.callToolResult(toolName, args, meta);
+    return this.underlying.callToolResult(toolName, args, meta, options);
   }
   listResources(
     params?: MCPListResourcesParams,
@@ -330,17 +338,24 @@ export class MCPServerStreamableHttp
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResultContent> {
-    return (await this.callToolResult(toolName, args, meta)).content;
+    return (await this.callToolResult(toolName, args, meta, options)).content;
   }
   async callToolResult(
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResult> {
     const previousSessionId = this.sessionId;
     try {
-      return await this.underlying.callToolResult(toolName, args, meta);
+      return await this.underlying.callToolResult(
+        toolName,
+        args,
+        meta,
+        options,
+      );
     } finally {
       if (previousSessionId !== this.sessionId) {
         this.clearLocalToolsCache();
@@ -398,15 +413,17 @@ export class MCPServerSSE
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResultContent> {
-    return (await this.callToolResult(toolName, args, meta)).content;
+    return (await this.callToolResult(toolName, args, meta, options)).content;
   }
   callToolResult(
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResult> {
-    return this.underlying.callToolResult(toolName, args, meta);
+    return this.underlying.callToolResult(toolName, args, meta, options);
   }
   listResources(
     params?: MCPListResourcesParams,
@@ -1027,19 +1044,29 @@ export function mcpToFunctionTool(
     const meta = runContext
       ? await resolveMcpToolMeta(server, runContext, mcpTool.name, args)
       : undefined;
-    const result: CallToolResult =
+    const callOptions = details?.signal
+      ? { signal: details.signal }
+      : undefined;
+    const useFullResult =
       (server.useStructuredContent === true ||
         server.customDataExtractor !== undefined) &&
-      server.callToolResult
-        ? meta === undefined
-          ? await server.callToolResult(mcpTool.name, args)
-          : await server.callToolResult(mcpTool.name, args, meta)
-        : {
-            content:
-              meta === undefined
-                ? await server.callTool(mcpTool.name, args)
-                : await server.callTool(mcpTool.name, args, meta),
-          };
+      server.callToolResult !== undefined;
+    let result: CallToolResult;
+    if (useFullResult) {
+      result = callOptions
+        ? await server.callToolResult!(mcpTool.name, args, meta, callOptions)
+        : meta === undefined
+          ? await server.callToolResult!(mcpTool.name, args)
+          : await server.callToolResult!(mcpTool.name, args, meta);
+    } else {
+      result = {
+        content: callOptions
+          ? await server.callTool(mcpTool.name, args, meta, callOptions)
+          : meta === undefined
+            ? await server.callTool(mcpTool.name, args)
+            : await server.callTool(mcpTool.name, args, meta),
+      };
+    }
     const content = result.content as CallToolResultContent;
     const resultMeta = result._meta ?? content._meta;
     const structuredContent =

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -16,6 +16,7 @@ import type {
   CallToolResultContent,
   DefaultMCPServerStdioOptions,
   InitializeResult,
+  MCPCallToolOptions,
   MCPListResourcesParams,
   MCPListResourcesResult,
   MCPListResourceTemplatesResult,
@@ -280,14 +281,16 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResultContent> {
-    return (await this.callToolResult(toolName, args, meta)).content;
+    return (await this.callToolResult(toolName, args, meta, options)).content;
   }
 
   async callToolResult(
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResult> {
     const { CallToolResultSchema } =
       await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
@@ -298,7 +301,7 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
     }
     const requestOptions = buildRequestOptions(
       this.clientSessionTimeoutSeconds,
-      { timeout: this.timeout },
+      { timeout: this.timeout, signal: options?.signal },
     );
     const params = {
       name: toolName,
@@ -495,14 +498,16 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResultContent> {
-    return (await this.callToolResult(toolName, args, meta)).content;
+    return (await this.callToolResult(toolName, args, meta, options)).content;
   }
 
   async callToolResult(
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResult> {
     const { CallToolResultSchema } =
       await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
@@ -513,7 +518,7 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
     }
     const requestOptions = buildRequestOptions(
       this.clientSessionTimeoutSeconds,
-      { timeout: this.timeout },
+      { timeout: this.timeout, signal: options?.signal },
     );
     const params = {
       name: toolName,
@@ -908,6 +913,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResult> {
     const { CallToolResultSchema } =
       await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
@@ -915,6 +921,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
       this.clientSessionTimeoutSeconds,
       {
         timeout: this.timeout,
+        signal: options?.signal,
       },
     );
     const params = {
@@ -1288,14 +1295,16 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResultContent> {
-    return (await this.callToolResult(toolName, args, meta)).content;
+    return (await this.callToolResult(toolName, args, meta, options)).content;
   }
 
   async callToolResult(
     toolName: string,
     args: Record<string, unknown> | null,
     meta?: Record<string, unknown> | null,
+    options?: MCPCallToolOptions,
   ): Promise<CallToolResult> {
     const client = this.session;
     if (!client) {
@@ -1307,7 +1316,13 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     let result: CallToolResult;
 
     try {
-      result = await this.callToolWithClient(client, toolName, args, meta);
+      result = await this.callToolWithClient(
+        client,
+        toolName,
+        args,
+        meta,
+        options,
+      );
     } catch (error) {
       const recoveryStrategy =
         await this.shouldReconnectClosedStreamableHttpClient(error, client);
@@ -1336,6 +1351,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
           toolName,
           args,
           meta,
+          options,
         );
       } catch (retryError) {
         throw attachCause(retryError, error);

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -26,6 +26,7 @@ import type {
   MCPServerSSEOptions,
 } from '../../mcp';
 import logger, { logToolActionError, logToolActionWarning } from '../../logger';
+import { combineAbortSignals } from '../../utils/abortSignals';
 
 export interface SessionMessage {
   message: any;
@@ -69,6 +70,21 @@ function buildRequestOptions(
       : { timeout: clientSessionTimeoutSeconds * 1000 };
   const mergedOptions = { ...(baseOptions ?? {}), ...(overrides ?? {}) };
   return Object.keys(mergedOptions).length === 0 ? undefined : mergedOptions;
+}
+
+async function callWithMCPRequestSignal<T>(
+  sourceSignal: AbortSignal | undefined,
+  call: (requestSignal: AbortSignal | undefined) => Promise<T>,
+): Promise<T> {
+  const { signal: requestSignal, cleanup } = combineAbortSignals(sourceSignal);
+  try {
+    return await call(requestSignal);
+  } catch (error) {
+    sourceSignal?.throwIfAborted();
+    throw error;
+  } finally {
+    cleanup();
+  }
 }
 
 type MaybeSessionTransport = Transport & {
@@ -299,19 +315,23 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
         'Server not initialized. Make sure you call connect() first.',
       );
     }
-    const requestOptions = buildRequestOptions(
-      this.clientSessionTimeoutSeconds,
-      { timeout: this.timeout, signal: options?.signal },
-    );
+    const session = this.session;
     const params = {
       name: toolName,
       arguments: args ?? {},
       ...(meta != null ? { _meta: meta } : {}),
     };
-    const response = await this.session.callTool(
-      params,
-      undefined,
-      requestOptions,
+    const response = await callWithMCPRequestSignal(
+      options?.signal,
+      (requestSignal) =>
+        session.callTool(
+          params,
+          undefined,
+          buildRequestOptions(this.clientSessionTimeoutSeconds, {
+            timeout: this.timeout,
+            signal: requestSignal,
+          }),
+        ),
     );
     const parsed = CallToolResultSchema.parse(response);
     const result = attachParsedCallToolResultMetadata(parsed as CallToolResult);
@@ -516,19 +536,23 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
         'Server not initialized. Make sure you call connect() first.',
       );
     }
-    const requestOptions = buildRequestOptions(
-      this.clientSessionTimeoutSeconds,
-      { timeout: this.timeout, signal: options?.signal },
-    );
+    const session = this.session;
     const params = {
       name: toolName,
       arguments: args ?? {},
       ...(meta != null ? { _meta: meta } : {}),
     };
-    const response = await this.session.callTool(
-      params,
-      undefined,
-      requestOptions,
+    const response = await callWithMCPRequestSignal(
+      options?.signal,
+      (requestSignal) =>
+        session.callTool(
+          params,
+          undefined,
+          buildRequestOptions(this.clientSessionTimeoutSeconds, {
+            timeout: this.timeout,
+            signal: requestSignal,
+          }),
+        ),
     );
     const parsed = CallToolResultSchema.parse(response);
     const result = attachParsedCallToolResultMetadata(parsed as CallToolResult);
@@ -917,19 +941,23 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
   ): Promise<CallToolResult> {
     const { CallToolResultSchema } =
       await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
-    const requestOptions = buildRequestOptions(
-      this.clientSessionTimeoutSeconds,
-      {
-        timeout: this.timeout,
-        signal: options?.signal,
-      },
-    );
     const params = {
       name: toolName,
       arguments: args ?? {},
       ...(meta != null ? { _meta: meta } : {}),
     };
-    const response = await client.callTool(params, undefined, requestOptions);
+    const response = await callWithMCPRequestSignal(
+      options?.signal,
+      (requestSignal) =>
+        client.callTool(
+          params,
+          undefined,
+          buildRequestOptions(this.clientSessionTimeoutSeconds, {
+            timeout: this.timeout,
+            signal: requestSignal,
+          }),
+        ),
+    );
     const parsed = CallToolResultSchema.parse(response);
     return attachParsedCallToolResultMetadata(parsed as CallToolResult);
   }

--- a/packages/agents-core/test/mcpToFunctionTool.test.ts
+++ b/packages/agents-core/test/mcpToFunctionTool.test.ts
@@ -128,6 +128,88 @@ describe('mcpToFunctionTool', () => {
     ]);
   });
 
+  it('forwards the tool-call abort signal to MCP calls', async () => {
+    const callTool = vi.fn(async () => [
+      { type: 'text', text: 'legacy output' },
+    ]);
+    const server: MCPServer = {
+      name: 'signal-server',
+      cacheToolsList: false,
+      connect: async () => {},
+      close: async () => {},
+      listTools: async () => [],
+      callTool,
+      invalidateToolsCache: async () => {},
+    };
+    const tool = mcpToFunctionTool(
+      {
+        name: 'signal_tool',
+        description: '',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      } as any,
+      server,
+      false,
+    );
+    const controller = new AbortController();
+
+    await tool.invoke(new RunContext({}), '{}', {
+      signal: controller.signal,
+    });
+
+    expect(callTool).toHaveBeenCalledWith('signal_tool', {}, undefined, {
+      signal: controller.signal,
+    });
+  });
+
+  it('forwards the tool-call abort signal to full-result MCP calls', async () => {
+    const callToolResult = vi.fn(async () => ({
+      content: [{ type: 'text', text: 'legacy output' }],
+      structuredContent: { answer: 42 },
+    }));
+    const server: MCPServer = {
+      name: 'full-result-signal-server',
+      cacheToolsList: false,
+      useStructuredContent: true,
+      connect: async () => {},
+      close: async () => {},
+      listTools: async () => [],
+      callTool: async () => [{ type: 'text', text: 'legacy output' }],
+      callToolResult,
+      invalidateToolsCache: async () => {},
+    };
+    const tool = mcpToFunctionTool(
+      {
+        name: 'full_result_signal_tool',
+        description: '',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      } as any,
+      server,
+      false,
+    );
+    const controller = new AbortController();
+
+    await tool.invoke(new RunContext({}), '{}', {
+      signal: controller.signal,
+    });
+
+    expect(callToolResult).toHaveBeenCalledWith(
+      'full_result_signal_tool',
+      {},
+      undefined,
+      { signal: controller.signal },
+    );
+  });
+
   it('uses structured MCP output only when explicitly enabled', async () => {
     const callTool = vi.fn(async () => [
       { type: 'text', text: 'legacy output' },

--- a/packages/agents-core/test/shims/mcp-server/node.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/node.test.ts
@@ -98,11 +98,15 @@ describe('NodeMCPServerStdio', () => {
 
     await server.connect();
     await server.listTools();
-    await server.callTool('mock-tool', {});
+    const controller = new AbortController();
+    await server.callTool('mock-tool', {}, undefined, {
+      signal: controller.signal,
+    });
 
     expect(lastConnectOptions?.timeout).toBe(6000);
     expect(lastListToolsOptions?.timeout).toBe(6000);
     expect(lastCallToolOptions?.timeout).toBe(DEFAULT_REQUEST_TIMEOUT_MSEC);
+    expect(lastCallToolOptions?.signal).toBe(controller.signal);
 
     await server.close();
   });
@@ -404,11 +408,15 @@ describe('NodeMCPServerSSE', () => {
 
     await server.connect();
     await server.listTools();
-    await server.callTool('mock-tool', {});
+    const controller = new AbortController();
+    await server.callTool('mock-tool', {}, undefined, {
+      signal: controller.signal,
+    });
 
     expect(lastConnectOptions?.timeout).toBe(4000);
     expect(lastListToolsOptions?.timeout).toBe(4000);
     expect(lastCallToolOptions?.timeout).toBe(DEFAULT_REQUEST_TIMEOUT_MSEC);
+    expect(lastCallToolOptions?.signal).toBe(controller.signal);
 
     await server.close();
   });
@@ -564,11 +572,15 @@ describe('NodeMCPServerStreamableHttp', () => {
 
     await server.connect();
     await server.listTools();
-    await server.callTool('mock-tool', {});
+    const controller = new AbortController();
+    await server.callTool('mock-tool', {}, undefined, {
+      signal: controller.signal,
+    });
 
     expect(lastConnectOptions?.timeout).toBe(9000);
     expect(lastListToolsOptions?.timeout).toBe(9000);
     expect(lastCallToolOptions?.timeout).toBe(DEFAULT_REQUEST_TIMEOUT_MSEC);
+    expect(lastCallToolOptions?.signal).toBe(controller.signal);
 
     await server.close();
   });

--- a/packages/agents-core/test/shims/mcp-server/node.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/node.test.ts
@@ -7,11 +7,14 @@ import {
   beforeAll,
   beforeEach,
 } from 'vitest';
+import { getEventListeners } from 'node:events';
 import {
   NodeMCPServerStdio,
   NodeMCPServerSSE,
   NodeMCPServerStreamableHttp,
 } from '../../../src/shims/mcp-server/node';
+import { mcpToFunctionTool } from '../../../src/mcp';
+import { RunContext } from '../../../src/runContext';
 import { TransportSendOptions } from '@modelcontextprotocol/sdk/shared/transport';
 import { JSONRPCMessage } from '@modelcontextprotocol/sdk/types';
 import { DEFAULT_REQUEST_TIMEOUT_MSEC } from '@modelcontextprotocol/sdk/shared/protocol';
@@ -26,6 +29,9 @@ let lastCallToolOptions: any;
 let lastCallToolParams: any;
 let lastReadResourceOptions: any;
 let lastReadResourceParams: any;
+let callToolImplementation:
+  ((params: any, resultSchema: any, options: any) => Promise<any>) | undefined;
+let retainCallToolSignalListener = false;
 
 beforeEach(() => {
   lastConnectOptions = undefined;
@@ -38,6 +44,8 @@ beforeEach(() => {
   lastCallToolParams = undefined;
   lastReadResourceOptions = undefined;
   lastReadResourceParams = undefined;
+  callToolImplementation = undefined;
+  retainCallToolSignalListener = false;
 });
 
 describe('NodeMCPServerStdio', () => {
@@ -106,8 +114,77 @@ describe('NodeMCPServerStdio', () => {
     expect(lastConnectOptions?.timeout).toBe(6000);
     expect(lastListToolsOptions?.timeout).toBe(6000);
     expect(lastCallToolOptions?.timeout).toBe(DEFAULT_REQUEST_TIMEOUT_MSEC);
-    expect(lastCallToolOptions?.signal).toBe(controller.signal);
+    expect(lastCallToolOptions?.signal).toBeDefined();
+    expect(lastCallToolOptions?.signal).not.toBe(controller.signal);
 
+    await server.close();
+  });
+
+  test('should preserve caller cancellation for in-flight tool calls', async () => {
+    let markCallStarted: (() => void) | undefined;
+    const callStarted = new Promise<void>((resolve) => {
+      markCallStarted = resolve;
+    });
+    callToolImplementation = async (_params, _resultSchema, options) => {
+      markCallStarted?.();
+      return new Promise((_, reject) => {
+        options.signal.addEventListener(
+          'abort',
+          () => reject(new Error('MCP SDK wrapped cancellation')),
+          { once: true },
+        );
+      });
+    };
+    const server = new NodeMCPServerStdio({
+      name: 'cancel-in-flight',
+      fullCommand: 'test',
+    });
+    await server.connect();
+    const tool = mcpToFunctionTool(
+      {
+        name: 'mock-tool',
+        description: 'Mock tool',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      },
+      server,
+      false,
+    );
+    const controller = new AbortController();
+    const abortReason = new Error('caller cancelled');
+
+    const pendingCall = tool.invoke(new RunContext({}), '{}', {
+      signal: controller.signal,
+    });
+    await callStarted;
+    controller.abort(abortReason);
+
+    await expect(pendingCall).rejects.toBe(abortReason);
+    await server.close();
+  });
+
+  test('should isolate retained request listeners from the caller signal', async () => {
+    retainCallToolSignalListener = true;
+    const server = new NodeMCPServerStdio({
+      name: 'isolated-request-signal',
+      fullCommand: 'test',
+    });
+    await server.connect();
+    const controller = new AbortController();
+
+    await server.callTool('mock-tool', {}, undefined, {
+      signal: controller.signal,
+    });
+
+    expect(lastCallToolOptions.signal).not.toBe(controller.signal);
+    expect(getEventListeners(lastCallToolOptions.signal, 'abort')).toHaveLength(
+      1,
+    );
+    expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0);
     await server.close();
   });
 
@@ -252,6 +329,12 @@ class MockClient {
   callTool(_params: any, _resultSchema?: any, options?: any): Promise<any> {
     lastCallToolParams = _params;
     lastCallToolOptions = options;
+    if (retainCallToolSignalListener && options?.signal) {
+      options.signal.addEventListener('abort', () => {});
+    }
+    if (callToolImplementation) {
+      return callToolImplementation(_params, _resultSchema, options);
+    }
     return Promise.resolve({
       content: [{ type: 'text', text: 'ok' }],
       _meta: { renderer: 'chart' },
@@ -416,7 +499,8 @@ describe('NodeMCPServerSSE', () => {
     expect(lastConnectOptions?.timeout).toBe(4000);
     expect(lastListToolsOptions?.timeout).toBe(4000);
     expect(lastCallToolOptions?.timeout).toBe(DEFAULT_REQUEST_TIMEOUT_MSEC);
-    expect(lastCallToolOptions?.signal).toBe(controller.signal);
+    expect(lastCallToolOptions?.signal).toBeDefined();
+    expect(lastCallToolOptions?.signal).not.toBe(controller.signal);
 
     await server.close();
   });
@@ -580,8 +664,43 @@ describe('NodeMCPServerStreamableHttp', () => {
     expect(lastConnectOptions?.timeout).toBe(9000);
     expect(lastListToolsOptions?.timeout).toBe(9000);
     expect(lastCallToolOptions?.timeout).toBe(DEFAULT_REQUEST_TIMEOUT_MSEC);
-    expect(lastCallToolOptions?.signal).toBe(controller.signal);
+    expect(lastCallToolOptions?.signal).toBeDefined();
+    expect(lastCallToolOptions?.signal).not.toBe(controller.signal);
 
+    await server.close();
+  });
+
+  test('should not reconnect after caller cancellation', async () => {
+    let markCallStarted: (() => void) | undefined;
+    const callStarted = new Promise<void>((resolve) => {
+      markCallStarted = resolve;
+    });
+    callToolImplementation = async (_params, _resultSchema, options) => {
+      markCallStarted?.();
+      return new Promise((_, reject) => {
+        options.signal.addEventListener(
+          'abort',
+          () => reject(new Error('MCP SDK wrapped cancellation')),
+          { once: true },
+        );
+      });
+    };
+    const server = new NodeMCPServerStreamableHttp({
+      url: 'https://example.com/stream',
+      name: 'cancel-without-reconnect',
+    });
+    await server.connect();
+    const controller = new AbortController();
+    const abortReason = new Error('caller cancelled');
+
+    const pendingCall = server.callTool('mock-tool', {}, undefined, {
+      signal: controller.signal,
+    });
+    await callStarted;
+    controller.abort(abortReason);
+
+    await expect(pendingCall).rejects.toBe(abortReason);
+    expect(MockStreamableHTTPClientTransport.instances).toHaveLength(1);
     await server.close();
   });
 


### PR DESCRIPTION
This pull request resolves #1530 by forwarding the run's AbortSignal through MCP function-tool wrappers into per-request options for stdio, SSE, and Streamable HTTP transports. It preserves existing no-signal call arity and MCP error handling without adding reconnect cancellation machinery or rewriting unrelated errors.