### PR TITLE
fix(core): export lifecycle and agent tool helper types

### DIFF
--- a/.changeset/public-agent-helper-types.md
+++ b/.changeset/public-agent-helper-types.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents': patch
+'@openai/agents-core': patch
+---
+
+fix: export lifecycle hook and agent tool helper types (#1534)

--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -107,7 +107,7 @@ type AgentToolEventHandler<TAgent extends Agent<any, any>> = (
 ) => void | Promise<void>;
 type AgentToolInputBuilder<TParameters extends AgentToolInputParameters> =
   StructuredToolInputBuilder<ToolExecuteArgument<TParameters>>;
-type AgentToolOptions<
+export type AgentToolOptions<
   TContext,
   TAgent extends Agent<TContext, any>,
   TParameters extends AgentToolInputParameters,
@@ -171,21 +171,21 @@ type AgentToolOptions<
    */
   onStream?: (event: AgentToolStreamEvent<TAgent>) => void | Promise<void>;
 };
-type AgentToolOptionsWithDefault<
+export type AgentToolOptionsWithDefault<
   TContext,
   TAgent extends Agent<TContext, any>,
 > = Omit<
   AgentToolOptions<TContext, TAgent, typeof AgentAsToolInputSchema>,
   'parameters'
 > & { parameters?: undefined };
-type AgentToolOptionsWithParameters<
+export type AgentToolOptionsWithParameters<
   TContext,
   TAgent extends Agent<TContext, any>,
   TParameters extends AgentToolInputParameters,
 > = AgentToolOptions<TContext, TAgent, TParameters> & {
   parameters: TParameters;
 };
-type AgentTool<
+export type AgentTool<
   TContext,
   TAgent extends Agent<TContext, any>,
   TParameters extends AgentToolInputParameters,

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -13,7 +13,13 @@ export {
   ToolUseBehavior,
   ToolUseBehaviorFlags,
 } from './agent';
-export type { CompletedAgentToolInvocationRunResult } from './agent';
+export type {
+  AgentTool,
+  AgentToolOptions,
+  AgentToolOptionsWithDefault,
+  AgentToolOptionsWithParameters,
+  CompletedAgentToolInvocationRunResult,
+} from './agent';
 export { Computer } from './computer';
 export { ShellAction, ShellResult, ShellOutputResult, Shell } from './shell';
 export {
@@ -102,6 +108,7 @@ export {
   RunToolSearchOutputItem,
 } from './items';
 export { AgentHooks } from './lifecycle';
+export type { AgentHookEvents, RunHookEvents } from './lifecycle';
 export { getLogger } from './logger';
 export { setSensitiveDataLoggingEnabled } from './config';
 export { applyDiff } from './utils/applyDiff';

--- a/packages/agents-core/test/index.test.ts
+++ b/packages/agents-core/test/index.test.ts
@@ -1,6 +1,15 @@
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, expectTypeOf } from 'vitest';
+import { z } from 'zod';
 
 import * as AgentsCore from '../src/index';
+import type {
+  AgentHookEvents,
+  AgentTool,
+  AgentToolOptions,
+  AgentToolOptionsWithDefault,
+  AgentToolOptionsWithParameters,
+  RunHookEvents,
+} from '../src/index';
 import * as Sandbox from '../src/sandbox';
 import * as LocalSandbox from '../src/sandbox/local';
 
@@ -13,6 +22,21 @@ describe('index.ts', () => {
     expect(agent).toBeDefined();
     expect(agent.name).toEqual('TestAgent');
     expect(typeof AgentsCore.setSensitiveDataLoggingEnabled).toBe('function');
+  });
+
+  test('exposes public lifecycle and agent tool types', () => {
+    const _parameters = z.object({ query: z.string() });
+    type TestAgent = AgentsCore.Agent<undefined>;
+    type PublicTypes = [
+      AgentHookEvents<undefined>,
+      RunHookEvents<undefined>,
+      AgentToolOptions<undefined, TestAgent, typeof _parameters>,
+      AgentToolOptionsWithDefault<undefined, TestAgent>,
+      AgentToolOptionsWithParameters<undefined, TestAgent, typeof _parameters>,
+      AgentTool<undefined, TestAgent, typeof _parameters>,
+    ];
+
+    expectTypeOf<PublicTypes>().not.toBeNever();
   });
 
   test('does not expose sandbox exports from the top-level entry', () => {

--- a/packages/agents/test/index.test.ts
+++ b/packages/agents/test/index.test.ts
@@ -1,15 +1,39 @@
 import * as Agents from '../src/index';
+import type {
+  AgentHookEvents,
+  AgentTool,
+  AgentToolOptions,
+  AgentToolOptionsWithDefault,
+  AgentToolOptionsWithParameters,
+  RunHookEvents,
+} from '../src/index';
 import * as Sandbox from '../src/sandbox';
 import * as LocalSandbox from '../src/sandbox/local';
 import { RealtimeAgent } from '../src/realtime';
 import { isZodObject } from '../src/utils';
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, expectTypeOf } from 'vitest';
+import { z } from 'zod';
 
 describe('Exports', () => {
   test('Agent is out there', () => {
     const agent = new Agents.Agent({ name: 'Test' });
     expect(agent.name).toBe('Test');
     expect(typeof Agents.setSensitiveDataLoggingEnabled).toBe('function');
+  });
+
+  test('lifecycle and agent tool types are out there', () => {
+    const _parameters = z.object({ query: z.string() });
+    type TestAgent = Agents.Agent<undefined>;
+    type PublicTypes = [
+      AgentHookEvents<undefined>,
+      RunHookEvents<undefined>,
+      AgentToolOptions<undefined, TestAgent, typeof _parameters>,
+      AgentToolOptionsWithDefault<undefined, TestAgent>,
+      AgentToolOptionsWithParameters<undefined, TestAgent, typeof _parameters>,
+      AgentTool<undefined, TestAgent, typeof _parameters>,
+    ];
+
+    expectTypeOf<PublicTypes>().not.toBeNever();
   });
 });
 


### PR DESCRIPTION
This pull request resolves #1534 by making the stable lifecycle hook event maps and `Agent.asTool()` option and return helper types importable from `@openai/agents-core` and `@openai/agents`.

It adds type-level entrypoint coverage and a patch changeset. `SharedRunOptions` remains internal because the existing public run-option variants already support forwarding use cases. There are no runtime behavior changes.