### PR TITLE
fix(sandbox): support native Windows paths in path grants

### DIFF
--- a/.changeset/native-sandbox-path-grants.md
+++ b/.changeset/native-sandbox-path-grants.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-extensions': patch
+---
+
+fix: support native Windows host paths in sandbox path grants (#1537)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -173,7 +173,7 @@ jobs:
       - name: Run Windows sandbox path tests
         if: ${{ needs.changes.outputs.run_ci == 'true' }}
         shell: bash
-        run: pnpm exec vitest --run --project "@openai/agents-core" packages/agents-core/test/sandboxWorkspacePaths.test.ts packages/agents-core/test/sandboxManifest.test.ts
+        run: pnpm exec vitest --run --project "@openai/agents-core" packages/agents-core/test/sandboxWorkspacePaths.test.ts packages/agents-core/test/sandboxManifest.test.ts packages/agents-core/test/sandboxNativePathGrants.test.ts
       - name: Run Windows remote path tests
         if: ${{ needs.changes.outputs.run_ci == 'true' }}
         shell: bash

--- a/packages/agents-core/src/sandbox/internal.ts
+++ b/packages/agents-core/src/sandbox/internal.ts
@@ -1,9 +1,12 @@
 export {
+  assertHostPathGrantsRebound,
+  deserializeHostPathGrantRedactionMetadata,
   deserializeManifest,
   mergeManifestEntryDelta,
   mergeManifestDelta,
   sanitizeEnvironmentForPersistence,
   serializeEnvironmentForPersistence,
+  serializeHostPathGrantRedactionMetadata,
   serializeManifest,
   serializeManifestRecord,
 } from './sandboxes/shared/manifestPersistence';
@@ -17,6 +20,7 @@ export {
   isHostPathWithinRoot,
   relativeHostPathEscapesRoot,
   relativeHostPathEscapesRootOrSelf,
+  sandboxPathGrantHostPath,
 } from './shared/hostPath';
 export {
   hasBackslashPathSeparator,

--- a/packages/agents-core/src/sandbox/localSkills.ts
+++ b/packages/agents-core/src/sandbox/localSkills.ts
@@ -8,7 +8,10 @@ import {
 import { localDir } from './entries';
 import type { Manifest } from './manifest';
 import type { SandboxPathGrant } from './pathGrants';
-import { isHostPathWithinRoot } from './shared/hostPath';
+import {
+  isHostPathWithinRoot,
+  sandboxPathGrantHostPath,
+} from './shared/hostPath';
 
 export type LocalDirLazySkillSourceOptions = {
   /**
@@ -86,7 +89,10 @@ function resolveLocalSkillSourcePath(
   if (
     isHostPathWithinRoot(base, resolvedSourcePath) ||
     sourceGrants.some((grant) =>
-      isHostPathWithinRoot(resolve(grant.path), resolvedSourcePath),
+      isHostPathWithinRoot(
+        resolve(sandboxPathGrantHostPath(grant)),
+        resolvedSourcePath,
+      ),
     )
   ) {
     return resolvedSourcePath;

--- a/packages/agents-core/src/sandbox/pathGrants.ts
+++ b/packages/agents-core/src/sandbox/pathGrants.ts
@@ -5,13 +5,19 @@ import {
 } from './shared/posixPath';
 
 export type SandboxPathGrantInit = {
+  /** Absolute POSIX path visible inside the sandbox. */
   path: string;
+  /** Absolute native host path. Defaults to `path`. */
+  hostPath?: string;
   readOnly?: boolean;
   description?: string;
 };
 
 export type SandboxPathGrant = {
+  /** Absolute POSIX path visible inside the sandbox. */
   path: string;
+  /** Absolute native host path when it differs from `path`. */
+  hostPath?: string;
   readOnly: boolean;
   description?: string;
 };
@@ -19,9 +25,15 @@ export type SandboxPathGrant = {
 export function normalizePathGrant(
   grant: SandboxPathGrantInit,
 ): SandboxPathGrant {
-  if ('read_only' in (grant as Record<string, unknown>)) {
+  const grantRecord = grant as Record<string, unknown>;
+  if ('read_only' in grantRecord) {
     throw new Error(
       'Use camelCase config keys in sandbox path grants; snake_case key "read_only" is not supported.',
+    );
+  }
+  if ('host_path' in grantRecord) {
+    throw new Error(
+      'Use camelCase config keys in sandbox path grants; snake_case key "host_path" is not supported.',
     );
   }
   if (hasParentPathSegment(grant.path)) {
@@ -39,10 +51,60 @@ export function normalizePathGrant(
   if (normalizedPath === '/') {
     throw new Error('Sandbox path grant path must not be filesystem root.');
   }
+  const normalizedHostPath =
+    grant.hostPath === undefined
+      ? undefined
+      : normalizePathGrantHostPath(grant.hostPath);
 
   return {
     path: normalizedPath,
+    ...(normalizedHostPath === undefined
+      ? {}
+      : { hostPath: normalizedHostPath }),
     readOnly: grant.readOnly ?? false,
     ...(grant.description ? { description: grant.description } : {}),
   };
+}
+
+function normalizePathGrantHostPath(hostPath: string): string {
+  if (hostPath.startsWith('\\\\') || hostPath.startsWith('//')) {
+    throw new Error(
+      'Sandbox path grant hostPath does not support UNC or device paths.',
+    );
+  }
+  if (hostPath.split(/[\\/]/u).some((segment) => segment === '..')) {
+    throw new Error(
+      'Sandbox path grant hostPath must not contain parent segments.',
+    );
+  }
+  const windowsDriveMatch = /^([A-Za-z]:)[\\/]/u.exec(hostPath);
+  if (windowsDriveMatch) {
+    const segments = hostPath
+      .slice(windowsDriveMatch[0].length)
+      .split(/[\\/]/u)
+      .filter((segment) => segment && segment !== '.');
+    if (segments.length === 0) {
+      throw new Error(
+        'Sandbox path grant hostPath must not be filesystem root.',
+      );
+    }
+    return `${windowsDriveMatch[1]}\\${segments.join('\\')}`;
+  }
+  if (!hostPath.startsWith('/')) {
+    throw new Error(
+      'Sandbox path grant hostPath must be an absolute host path.',
+    );
+  }
+  const normalizedHostPath = normalizePosixHostPath(hostPath);
+  if (normalizedHostPath === '/') {
+    throw new Error('Sandbox path grant hostPath must not be filesystem root.');
+  }
+  return normalizedHostPath;
+}
+
+function normalizePosixHostPath(hostPath: string): string {
+  const segments = hostPath
+    .split('/')
+    .filter((segment) => segment && segment !== '.');
+  return segments.length > 0 ? `/${segments.join('/')}` : '/';
 }

--- a/packages/agents-core/src/sandbox/runtime/agentKeys.ts
+++ b/packages/agents-core/src/sandbox/runtime/agentKeys.ts
@@ -17,6 +17,31 @@ export function allocateAgentKeys<TContext>(
   const keys = new Map<number, string>();
   const counts = new Map<string, number>();
   const usedKeys = new Set<string>();
+  for (const agent of collectReachableAgents(startingAgent)) {
+    keys.set(
+      getObjectId(agent),
+      allocateUniqueAgentKey(agent.name, counts, usedKeys),
+    );
+  }
+  return keys;
+}
+
+export function indexAgentsByKey<TContext>(
+  startingAgent: Agent<TContext, AgentOutputType>,
+  keys: ReadonlyMap<number, string>,
+): Map<string, Agent<TContext, AgentOutputType>> {
+  return new Map(
+    collectReachableAgents(startingAgent).flatMap((agent) => {
+      const key = keys.get(getObjectId(agent));
+      return key ? [[key, agent]] : [];
+    }),
+  );
+}
+
+function collectReachableAgents<TContext>(
+  startingAgent: Agent<TContext, AgentOutputType>,
+): Agent<TContext, AgentOutputType>[] {
+  const agents: Agent<TContext, AgentOutputType>[] = [];
   const queue: Agent<TContext, AgentOutputType>[] = [startingAgent];
   const visited = new Set<Agent<TContext, AgentOutputType>>();
 
@@ -26,11 +51,7 @@ export function allocateAgentKeys<TContext>(
       continue;
     }
     visited.add(agent);
-
-    keys.set(
-      getObjectId(agent),
-      allocateUniqueAgentKey(agent.name, counts, usedKeys),
-    );
+    agents.push(agent);
 
     for (const handoff of agent.handoffs) {
       queue.push(
@@ -41,7 +62,7 @@ export function allocateAgentKeys<TContext>(
     }
   }
 
-  return keys;
+  return agents;
 }
 
 function allocateUniqueAgentKey(

--- a/packages/agents-core/src/sandbox/runtime/manager.ts
+++ b/packages/agents-core/src/sandbox/runtime/manager.ts
@@ -32,6 +32,7 @@ import {
   acquireSandboxAgent,
   allocateAgentKeys,
   getObjectId,
+  indexAgentsByKey,
   isSandboxAgent,
   releaseSandboxAgents,
 } from './agentKeys';
@@ -44,6 +45,10 @@ import {
 } from './livePreservedSessions';
 import { applyManifestToProvidedSession } from './providedSessionManifest';
 import { serializeSandboxRuntimeState } from './sessionSerialization';
+import {
+  assertHostPathGrantsRebound,
+  rebindPersistedPathGrants,
+} from '../sandboxes/shared/manifestPersistence';
 import {
   cleanupSandboxSession,
   hasSessionCleanup,
@@ -77,6 +82,16 @@ type SandboxCleanupPlan = {
   deferredError?: unknown;
 };
 
+type SandboxAgentIdentityRegistry = {
+  agentKeys: Map<number, string>;
+  agentsByKey: Map<string, Agent<any, AgentOutputType>>;
+};
+
+const sandboxAgentIdentitiesByRunState = new WeakMap<
+  object,
+  SandboxAgentIdentityRegistry
+>();
+
 export class SandboxRuntimeManager<TContext> {
   private readonly sandboxConfig?: SandboxRunConfig;
   private readonly runState?: RunState<
@@ -84,6 +99,7 @@ export class SandboxRuntimeManager<TContext> {
     Agent<TContext, AgentOutputType>
   >;
   private readonly agentKeys: Map<number, string>;
+  private readonly agentsByKey: Map<string, Agent<TContext, AgentOutputType>>;
   private readonly acquiredAgents = new Map<
     number,
     SandboxAgent<TContext, AgentOutputType>
@@ -125,7 +141,22 @@ export class SandboxRuntimeManager<TContext> {
   }) {
     this.sandboxConfig = args.sandboxConfig;
     this.runState = args.runState;
-    this.agentKeys = allocateAgentKeys(args.startingAgent);
+    const existingIdentityRegistry = args.runState
+      ? sandboxAgentIdentitiesByRunState.get(args.runState)
+      : undefined;
+    if (existingIdentityRegistry) {
+      this.agentKeys = existingIdentityRegistry.agentKeys;
+      this.agentsByKey = existingIdentityRegistry.agentsByKey;
+    } else {
+      this.agentKeys = allocateAgentKeys(args.startingAgent);
+      this.agentsByKey = indexAgentsByKey(args.startingAgent, this.agentKeys);
+      if (args.runState) {
+        sandboxAgentIdentitiesByRunState.set(args.runState, {
+          agentKeys: this.agentKeys,
+          agentsByKey: this.agentsByKey,
+        });
+      }
+    }
   }
 
   async prepareAgent(args: {
@@ -212,6 +243,14 @@ export class SandboxRuntimeManager<TContext> {
           tracingParent: cleanupSpan,
         });
       } finally {
+        if (hasPreservedOwnedSessions(getSerializedSandboxState(state))) {
+          sandboxAgentIdentitiesByRunState.set(state, {
+            agentKeys: this.agentKeys,
+            agentsByKey: this.agentsByKey,
+          });
+        } else {
+          sandboxAgentIdentitiesByRunState.delete(state);
+        }
         this.releaseAgents();
         this.sessionsByAgent.clear();
         if (!preserveCleanupHandles) {
@@ -587,6 +626,7 @@ export class SandboxRuntimeManager<TContext> {
       const serializedState = await deserializeSandboxSessionStateEntry(
         client,
         entry,
+        this.resolveTrustedManifestForAgentKey(agentKey),
       );
       if (!serializedState) {
         continue;
@@ -672,6 +712,7 @@ export class SandboxRuntimeManager<TContext> {
     const resumed = await this.resumeSessionForAgent(
       client,
       agent,
+      configuredManifest.manifest,
       tracingParent,
     );
     if (resumed) {
@@ -837,6 +878,7 @@ export class SandboxRuntimeManager<TContext> {
   private async resumeSessionForAgent(
     client: SandboxClient,
     agent: SandboxAgent<TContext, AgentOutputType>,
+    trustedManifest: Manifest,
     tracingParent?: Span<any> | Trace,
   ): Promise<SandboxSessionLike<SandboxSessionState> | undefined> {
     const agentKey = this.agentKey(agent);
@@ -863,6 +905,11 @@ export class SandboxRuntimeManager<TContext> {
     }
 
     if (this.sandboxConfig?.sessionState) {
+      const sessionState = rebindPersistedPathGrants(
+        this.sandboxConfig.sessionState,
+        trustedManifest,
+      );
+      assertHostPathGrantsRebound(sessionState);
       return await withSandboxSpan(
         'sandbox.resume_session',
         {
@@ -870,7 +917,7 @@ export class SandboxRuntimeManager<TContext> {
           backend_id: client.backendId,
         },
         async () =>
-          await client.resume!(this.sandboxConfig!.sessionState!, {
+          await client.resume!(sessionState, {
             archiveLimits: this.sandboxConfig?.archiveLimits,
           }),
         tracingParent,
@@ -880,6 +927,7 @@ export class SandboxRuntimeManager<TContext> {
     const serializedState = await deserializeSandboxSessionStateEntry(
       client,
       serializedEntry,
+      trustedManifest,
     );
     if (!serializedState) {
       return undefined;
@@ -945,11 +993,13 @@ export class SandboxRuntimeManager<TContext> {
     const agentId = getObjectId(agent);
     const existing = this.agentKeys.get(agentId);
     if (existing) {
+      this.agentsByKey.set(existing, agent);
       return existing;
     }
 
     const agentKey = this.allocateRuntimeAgentKey(agent.name);
     this.agentKeys.set(agentId, agentKey);
+    this.agentsByKey.set(agentKey, agent);
     return agentKey;
   }
 
@@ -995,6 +1045,16 @@ export class SandboxRuntimeManager<TContext> {
       passToCreate:
         baseManifest !== undefined || !isDefaultManifest(configuredManifest),
     };
+  }
+
+  private resolveTrustedManifestForAgentKey(
+    agentKey: string,
+  ): Manifest | undefined {
+    const agent = this.agentsByKey.get(agentKey);
+    if (!agent || !isSandboxAgent(agent)) {
+      return undefined;
+    }
+    return this.resolveConfiguredManifest(agent).manifest;
   }
 
   private async closeOwnedSessions(

--- a/packages/agents-core/src/sandbox/runtime/sessionState.ts
+++ b/packages/agents-core/src/sandbox/runtime/sessionState.ts
@@ -2,12 +2,17 @@ import { UserError } from '../../errors';
 import type { RunState } from '../../runState';
 import type { Agent, AgentOutputType } from '../../agent';
 import type { SandboxClient } from '../client';
+import type { Manifest } from '../manifest';
 import {
   SANDBOX_SESSION_STATE_VERSION,
   type SandboxSessionState,
   type SandboxSessionStateEnvelope,
 } from '../session';
 import {
+  assertHostPathGrantsRebound,
+  deserializeHostPathGrantRedactionMetadata,
+  rebindPersistedPathGrants,
+  serializeHostPathGrantRedactionMetadata,
   serializeManifest,
   serializeManifestRecord,
 } from '../sandboxes/shared/manifestPersistence';
@@ -58,8 +63,24 @@ export function toSessionStateEnvelope(
       : {}),
     // Keep provider-owned fields separate from the SDK envelope so version and backend
     // checks can run before deserializing provider-specific state.
-    providerState,
+    providerState: {
+      ...providerStateWithoutSdkEnvelopeFields(providerState),
+      ...serializeHostPathGrantRedactionMetadata(state),
+    },
   };
+}
+
+function providerStateWithoutSdkEnvelopeFields(
+  providerState: Record<string, unknown>,
+): Record<string, unknown> {
+  const sanitized = { ...providerState };
+  delete sanitized.manifest;
+  delete sanitized.snapshot;
+  delete sanitized.snapshotFingerprint;
+  delete sanitized.snapshotFingerprintVersion;
+  delete sanitized.workspaceReady;
+  delete sanitized.exposedPorts;
+  return sanitized;
 }
 
 export function assertSessionStateEnvelope(
@@ -81,6 +102,7 @@ export function assertSessionStateEnvelope(
 export async function deserializeSandboxSessionStateEntry(
   client: SandboxClient,
   serializedEntry: SerializedSandboxSessionEntry | undefined,
+  trustedManifest?: Manifest,
 ): Promise<SandboxSessionState | undefined> {
   if (!serializedEntry) {
     return undefined;
@@ -97,9 +119,18 @@ export async function deserializeSandboxSessionStateEntry(
   }
   const envelope = serializedEntry.sessionState;
   assertSessionStateEnvelope(client, envelope);
-  return await client.deserializeSessionState(
+  const state = await client.deserializeSessionState(
     providerStateWithSdkEnvelopeFields(envelope),
   );
+  const reboundState = rebindPersistedPathGrants(
+    {
+      ...state,
+      ...deserializeHostPathGrantRedactionMetadata(envelope.providerState),
+    },
+    trustedManifest,
+  );
+  assertHostPathGrantsRebound(reboundState);
+  return reboundState;
 }
 
 function providerStateWithSdkEnvelopeFields(

--- a/packages/agents-core/src/sandbox/sandboxes/docker.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/docker.ts
@@ -3,6 +3,7 @@ import type {
   ApplyPatchOperation,
   ApplyPatchResult,
   Editor,
+  EditorInvocationContext,
 } from '../../editor';
 import type { ToolOutputImage } from '../../tool';
 import { applyDiff } from '../../utils/applyDiff';
@@ -73,9 +74,11 @@ import {
   pathExists,
 } from './shared/localWorkspace';
 import {
+  assertHostPathGrantsRebound,
   mergeManifestEntryDelta,
   mergeManifestDelta,
   sanitizeEnvironmentForPersistence,
+  serializeHostPathGrantRedactionMetadata,
   serializeManifest,
 } from './shared/manifestPersistence';
 import { imageOutputFromBytes } from '../shared/media';
@@ -105,6 +108,7 @@ import {
   readStringArray,
 } from '../shared/typeGuards';
 import { validateCredentialPair as validateSandboxCredentialPair } from '../shared/credentials';
+import { sandboxPathGrantHostPath } from '../shared/hostPath';
 
 const DEFAULT_DOCKER_IMAGE = 'python:3.14-slim';
 const DEFAULT_CONTAINER_COMMAND =
@@ -144,14 +148,15 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
   }
 
   override createEditor(runAs?: string): Editor {
-    if (!runAs) {
-      return super.createEditor();
-    }
-    return new DockerSandboxEditor(this, runAs);
+    return new DockerSandboxEditor(
+      this,
+      runAs,
+      runAs ? undefined : super.createEditor(),
+    );
   }
 
   override async viewImage(args: ViewImageArgs): Promise<ToolOutputImage> {
-    if (!args.runAs) {
+    if (!args.runAs && !this.pathRequiresDockerFilesystem(args.path)) {
       return await super.viewImage(args);
     }
     const bytes = await this.readDockerFileAs(
@@ -202,7 +207,11 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
       `list directory ${absolutePath}`,
       absolutePath,
     );
-    const logicalPath = this.resolveLogicalPath(args.path);
+    const resolvedPath = new WorkspacePathPolicy({
+      root: this.state.manifest.root,
+      extraPathGrants: this.state.manifest.extraPathGrants,
+    }).resolve(args.path);
+    const logicalPath = resolvedPath.workspaceRelativePath ?? resolvedPath.path;
     return output
       .split(/\r?\n/u)
       .filter((line) => line.trim().length > 0)
@@ -220,7 +229,14 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
 
   private pathRequiresDockerFilesystem(path?: string): boolean {
     return Boolean(
-      dockerInContainerMountContainingPath(this.state.manifest, path),
+      dockerInContainerMountContainingPath(this.state.manifest, path) ||
+      dockerSplitPathGrantContainingPath(this.state.manifest, path),
+    );
+  }
+
+  pathUsesSplitGrant(path?: string): boolean {
+    return Boolean(
+      dockerSplitPathGrantContainingPath(this.state.manifest, path),
     );
   }
 
@@ -313,7 +329,7 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
     manifest: Manifest,
     runAs?: string,
   ): Promise<void> {
-    assertDockerManifestDeltaSupported(manifest);
+    assertDockerManifestDeltaSupported(this.state.manifest, manifest);
     assertDockerCanApplyInContainerMounts(this.state.manifest, manifest);
     const environment = await manifest.resolveEnvironment();
     const previousEnvironment = this.state.environment;
@@ -576,7 +592,7 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
   async writeDockerTextFileAs(
     path: string,
     content: string,
-    runAs: string,
+    runAs?: string,
   ): Promise<void> {
     const parent = dockerPosixDirname(path);
     await this.runCheckedDockerFilesystemCommand(
@@ -588,7 +604,7 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
     );
   }
 
-  async deleteDockerPathAs(path: string, runAs: string): Promise<void> {
+  async deleteDockerPathAs(path: string, runAs?: string): Promise<void> {
     await this.runCheckedDockerFilesystemCommand(
       `rm -f -- ${shellQuote(path)}`,
       { runAs },
@@ -596,7 +612,7 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
     );
   }
 
-  async mkdirDockerPathAs(path: string, runAs: string): Promise<void> {
+  async mkdirDockerPathAs(path: string, runAs?: string): Promise<void> {
     await this.runCheckedDockerFilesystemCommand(
       `mkdir -p -- ${shellQuote(path)}`,
       { runAs },
@@ -686,10 +702,21 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
 class DockerSandboxEditor implements Editor {
   constructor(
     private readonly session: DockerSandboxSession,
-    private readonly runAs: string,
+    private readonly runAs?: string,
+    private readonly hostEditor?: Editor,
   ) {}
 
   canAccessPathForEdit(path: string): boolean {
+    if (!this.shouldUseDockerFilesystem(path)) {
+      const canAccessPathForEdit = (
+        this.hostEditor as
+          | (Editor & {
+              canAccessPathForEdit?: (path: string) => boolean;
+            })
+          | undefined
+      )?.canAccessPathForEdit;
+      return canAccessPathForEdit?.call(this.hostEditor, path) ?? false;
+    }
     try {
       this.session.resolveContainerFilesystemPath(path, { forWrite: true });
       return true;
@@ -700,7 +727,11 @@ class DockerSandboxEditor implements Editor {
 
   async createFile(
     operation: Extract<ApplyPatchOperation, { type: 'create_file' }>,
+    context?: EditorInvocationContext,
   ): Promise<ApplyPatchResult> {
+    if (!this.shouldUseDockerFilesystem(operation.path)) {
+      return (await this.hostEditor!.createFile(operation, context)) ?? {};
+    }
     const path = this.session.resolveContainerFilesystemPath(operation.path, {
       forWrite: true,
     });
@@ -720,7 +751,11 @@ class DockerSandboxEditor implements Editor {
 
   async updateFile(
     operation: Extract<ApplyPatchOperation, { type: 'update_file' }>,
+    context?: EditorInvocationContext,
   ): Promise<ApplyPatchResult> {
+    if (!this.shouldUseDockerFilesystem(operation.path, operation.moveTo)) {
+      return (await this.hostEditor!.updateFile(operation, context)) ?? {};
+    }
     const path = this.session.resolveContainerFilesystemPath(operation.path, {
       forWrite: true,
     });
@@ -746,7 +781,11 @@ class DockerSandboxEditor implements Editor {
 
   async deleteFile(
     operation: Extract<ApplyPatchOperation, { type: 'delete_file' }>,
+    context?: EditorInvocationContext,
   ): Promise<ApplyPatchResult> {
+    if (!this.shouldUseDockerFilesystem(operation.path)) {
+      return (await this.hostEditor!.deleteFile(operation, context)) ?? {};
+    }
     await this.session.deleteDockerPathAs(
       this.session.resolveContainerFilesystemPath(operation.path, {
         forWrite: true,
@@ -754,6 +793,13 @@ class DockerSandboxEditor implements Editor {
       this.runAs,
     );
     return {};
+  }
+
+  private shouldUseDockerFilesystem(...paths: Array<string | undefined>) {
+    return (
+      !this.hostEditor ||
+      paths.some((path) => this.session.pathUsesSplitGrant(path))
+    );
   }
 }
 
@@ -863,6 +909,7 @@ export class DockerSandboxClient implements SandboxClient<
     state: DockerSandboxSessionState,
     options: SandboxClientResumeOptions = {},
   ): Promise<DockerSandboxSession> {
+    assertHostPathGrantsRebound(state);
     assertDockerManifestSupported(state.manifest);
     await ensureDockerAvailable();
     const archiveLimits =
@@ -875,6 +922,10 @@ export class DockerSandboxClient implements SandboxClient<
       state: restoredState,
       archiveLimits,
     });
+  }
+
+  canReusePreservedOwnedSession(state: DockerSandboxSessionState): boolean {
+    return state.manifest.extraPathGrants.length === 0;
   }
 
   async serializeSessionState(
@@ -890,6 +941,7 @@ export class DockerSandboxClient implements SandboxClient<
     state.snapshotSpec = snapshotSpec;
 
     return {
+      ...serializeHostPathGrantRedactionMetadata(state),
       manifest: serializeManifest(state.manifest),
       workspaceRootPath: state.workspaceRootPath,
       workspaceRootOwned: state.workspaceRootOwned,
@@ -934,7 +986,15 @@ export class DockerSandboxClient implements SandboxClient<
 
     if (workspaceExists) {
       if (containerRunning) {
-        return state;
+        if (state.manifest.extraPathGrants.length === 0) {
+          return state;
+        }
+        await this.cleanupDockerResources(state);
+        return await this.restartContainer(
+          state,
+          state.workspaceRootPath,
+          archiveLimits,
+        );
       }
       if (await canReuseLocalSnapshotWorkspace(state)) {
         await this.cleanupDockerResources(state);
@@ -1074,6 +1134,9 @@ async function cleanupStartedDockerContainer(args: {
 
 function assertDockerManifestSupported(manifest: Manifest): void {
   assertDockerManifestRootSupported(manifest);
+  for (const grant of manifest.extraPathGrants) {
+    sandboxPathGrantHostPath(grant);
+  }
   assertLocalWorkspaceManifestMetadataSupported(
     'DockerSandboxClient',
     manifest,
@@ -1085,10 +1148,31 @@ function assertDockerManifestSupported(manifest: Manifest): void {
   );
 }
 
-function assertDockerManifestDeltaSupported(manifest: Manifest): void {
+function assertDockerManifestDeltaSupported(
+  currentManifest: Manifest,
+  deltaManifest: Manifest,
+): void {
+  const currentGrantsByPath = new Map(
+    currentManifest.extraPathGrants.map((grant) => [grant.path, grant]),
+  );
+  const splitGrant = deltaManifest.extraPathGrants.find(
+    (grant) =>
+      grant.hostPath !== undefined ||
+      currentGrantsByPath.get(grant.path)?.hostPath !== undefined,
+  );
+  if (splitGrant) {
+    throw new SandboxUnsupportedFeatureError(
+      `DockerSandboxClient cannot add or change path grant hostPath for "${splitGrant.path}" on an already-running container. Configure it in the manifest passed to create().`,
+      {
+        provider: 'DockerSandboxClient',
+        feature: 'manifest.extraPathGrants.hostPath',
+        path: splitGrant.path,
+      },
+    );
+  }
   assertLocalWorkspaceManifestMetadataSupported(
     'DockerSandboxClient',
-    manifest,
+    deltaManifest,
     {
       allowLocalBindMounts: false,
       allowIdentityMetadata: true,
@@ -1474,6 +1558,25 @@ function dockerInContainerMountContainingPath(
   path?: string,
 ): string | undefined {
   return dockerMountContainingPath(manifest, path, isDockerInContainerMount);
+}
+
+function dockerSplitPathGrantContainingPath(
+  manifest: Manifest,
+  path?: string,
+): string | undefined {
+  const { grant } = new WorkspacePathPolicy({
+    root: manifest.root,
+    extraPathGrants: manifest.extraPathGrants,
+  }).resolve(path);
+  return grant && sandboxPathGrantUsesDistinctHostPath(grant)
+    ? grant.path
+    : undefined;
+}
+
+function sandboxPathGrantUsesDistinctHostPath(
+  grant: Manifest['extraPathGrants'][number],
+): boolean {
+  return grant.hostPath !== undefined && grant.hostPath !== grant.path;
 }
 
 function dockerMountContainingPath(
@@ -2301,7 +2404,7 @@ function dockerExtraPathGrantMountArgs(manifest: Manifest): string[] {
     '--mount',
     dockerMountArg({
       type: 'bind',
-      source: grant.path,
+      source: sandboxPathGrantHostPath(grant),
       target: grant.path,
       readOnly: grant.readOnly,
     }),

--- a/packages/agents-core/src/sandbox/sandboxes/shared/localWorkspace.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/localWorkspace.ts
@@ -39,6 +39,7 @@ import {
   isHostPathWithinRoot,
   isHostPathStrictlyWithinRoot,
   relativeHostPathEscapesRoot,
+  sandboxPathGrantHostPath,
 } from '../../shared/hostPath';
 import { isSandboxPathNotFoundError } from '../../shared/pathProbe';
 
@@ -651,7 +652,10 @@ function resolveLocalSourcePath(
   if (
     isHostPathWithinRoot(base, resolvedSourcePath) ||
     (options.localSourceGrants ?? []).some((grant) =>
-      isHostPathWithinRoot(resolve(grant.path), resolvedSourcePath),
+      isHostPathWithinRoot(
+        resolve(sandboxPathGrantHostPath(grant)),
+        resolvedSourcePath,
+      ),
     )
   ) {
     return resolvedSourcePath;

--- a/packages/agents-core/src/sandbox/sandboxes/shared/manifestPersistence.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/manifestPersistence.ts
@@ -1,5 +1,7 @@
 import { isMount, type Entry } from '../../entries';
+import { UserError } from '../../../errors';
 import { Manifest, type EnvValue } from '../../manifest';
+import type { SandboxSessionState } from '../../session';
 import {
   mergeNamedObjects,
   mergePathKeyedObjects,
@@ -19,8 +21,106 @@ type ManifestPersistenceState = {
   environment?: Record<string, string>;
 };
 
+const redactedHostPathGrantPathsKey =
+  '__openaiAgentsRedactedHostPathGrantPaths';
+
 export function serializeManifest(manifest: Manifest): Manifest {
   return deserializeManifest(serializeManifestRecord(manifest));
+}
+
+export function serializeHostPathGrantRedactionMetadata(
+  state: SandboxSessionState,
+): Record<string, unknown> {
+  const paths = new Set(readRedactedHostPathGrantPaths(state));
+  for (const grant of state.manifest.extraPathGrants) {
+    if (grant.hostPath !== undefined) {
+      paths.add(grant.path);
+    }
+  }
+  return paths.size > 0 ? { [redactedHostPathGrantPathsKey]: [...paths] } : {};
+}
+
+export function deserializeHostPathGrantRedactionMetadata(
+  state: Record<string, unknown>,
+): Record<string, unknown> {
+  const paths = readRedactedHostPathGrantPaths(state);
+  return paths.length > 0 ? { [redactedHostPathGrantPathsKey]: paths } : {};
+}
+
+export function rebindPersistedPathGrants<TState extends SandboxSessionState>(
+  state: TState,
+  trustedManifest: Manifest | undefined,
+): TState {
+  // Native host paths are runtime authority. Only the current manifest may
+  // reintroduce them after persisted session state has been deserialized.
+  const reboundState: SandboxSessionState = { ...state };
+  const trustedGrantsByPath = new Map(
+    (trustedManifest?.extraPathGrants ?? []).map((grant) => [
+      grant.path,
+      grant,
+    ]),
+  );
+  const unmatchedGrantPaths = state.manifest.extraPathGrants
+    .filter((grant) => !trustedGrantsByPath.has(grant.path))
+    .map((grant) => grant.path);
+  if (unmatchedGrantPaths.length > 0) {
+    throw new UserError(
+      `Sandbox session state contains path grants that are not present in the current trusted manifest: ${unmatchedGrantPaths.join(', ')}. Define each grant in the current manifest before resuming.`,
+    );
+  }
+  const extraPathGrants = state.manifest.extraPathGrants.map((grant) => {
+    return structuredClone(trustedGrantsByPath.get(grant.path)!);
+  });
+
+  reboundState.manifest = new Manifest({
+    version: state.manifest.version,
+    root: state.manifest.root,
+    entries: structuredClone(state.manifest.entries),
+    environment: Object.fromEntries(
+      Object.entries(state.manifest.environment).map(([key, value]) => [
+        key,
+        value.init(),
+      ]),
+    ),
+    users: structuredClone(state.manifest.users),
+    groups: structuredClone(state.manifest.groups),
+    extraPathGrants,
+    remoteMountCommandAllowlist: [
+      ...state.manifest.remoteMountCommandAllowlist,
+    ],
+  });
+
+  const reboundGrantsByPath = new Map(
+    reboundState.manifest.extraPathGrants.map((grant) => [grant.path, grant]),
+  );
+  const unresolvedPaths = readRedactedHostPathGrantPaths(state).filter(
+    (path) => reboundGrantsByPath.get(path)?.hostPath === undefined,
+  );
+  if (unresolvedPaths.length > 0) {
+    reboundState[redactedHostPathGrantPathsKey] = unresolvedPaths;
+  } else {
+    delete reboundState[redactedHostPathGrantPathsKey];
+  }
+  return reboundState as TState;
+}
+
+export function assertHostPathGrantsRebound(state: SandboxSessionState): void {
+  const paths = readRedactedHostPathGrantPaths(state);
+  if (paths.length === 0) {
+    return;
+  }
+  throw new UserError(
+    `Sandbox session state requires trusted hostPath values for these path grants: ${paths.join(', ')}. Resume it through the Runner with a current manifest that defines each hostPath.`,
+  );
+}
+
+function readRedactedHostPathGrantPaths(
+  state: Record<string, unknown>,
+): string[] {
+  const value = state[redactedHostPathGrantPathsKey];
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === 'string')
+    : [];
 }
 
 export function serializeManifestRecord(
@@ -33,7 +133,11 @@ export function serializeManifestRecord(
     environment: serializePersistentManifestEnvironment(manifest),
     users: structuredClone(manifest.users),
     groups: structuredClone(manifest.groups),
-    extraPathGrants: structuredClone(manifest.extraPathGrants),
+    // Native host paths are rebound from trusted current configuration on resume.
+    extraPathGrants: manifest.extraPathGrants.map((grant) => {
+      const { hostPath: _hostPath, ...persistentGrant } = grant;
+      return structuredClone(persistentGrant);
+    }),
     remoteMountCommandAllowlist: [...manifest.remoteMountCommandAllowlist],
   };
 }
@@ -215,6 +319,18 @@ function deserializeManifestRecord(
     entries: deserializeEntriesForRuntime(
       value.entries as Record<string, Entry> | undefined,
     ),
+    extraPathGrants: Array.isArray(value.extraPathGrants)
+      ? value.extraPathGrants.map((grant) => {
+          if (typeof grant !== 'object' || grant === null) {
+            return grant;
+          }
+          const { hostPath: _hostPath, ...persistentGrant } = grant as Record<
+            string,
+            unknown
+          >;
+          return persistentGrant;
+        })
+      : value.extraPathGrants,
   };
 }
 

--- a/packages/agents-core/src/sandbox/sandboxes/shared/sessionStateValues.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/sessionStateValues.ts
@@ -9,6 +9,7 @@ import {
 } from '../../shared/typeGuards';
 import type { LocalSandboxSnapshot, LocalSandboxSnapshotSpec } from '../types';
 import { rehydrateLocalSnapshotSpec } from './localSnapshots';
+import { deserializeHostPathGrantRedactionMetadata } from './manifestPersistence';
 
 export type LocalSandboxSessionStateValues = {
   manifest: Manifest;
@@ -49,6 +50,7 @@ export function deserializeLocalSandboxSessionStateValues(
       readOptionalNumberArray(state.configuredExposedPorts),
     ),
     exposedPorts: readExposedPortsState(state),
+    ...deserializeHostPathGrantRedactionMetadata(state),
   };
 }
 

--- a/packages/agents-core/src/sandbox/sandboxes/unixLocal.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/unixLocal.ts
@@ -49,7 +49,10 @@ import {
   type WorkspaceArchiveOptions,
 } from '../session';
 import { Manifest, normalizeRelativePath } from '../manifest';
-import { SandboxConfigurationError } from '../errors';
+import {
+  SandboxConfigurationError,
+  SandboxUnsupportedFeatureError,
+} from '../errors';
 import {
   WorkspacePathPolicy,
   type ResolveSandboxPathOptions,
@@ -65,6 +68,7 @@ import {
   pathExists,
 } from './shared/localWorkspace';
 import {
+  assertHostPathGrantsRebound,
   mergeManifestEntryDelta,
   mergeManifestDelta,
   sanitizeEnvironmentForPersistence,
@@ -417,6 +421,7 @@ export class UnixLocalSandboxSession<
   }
 
   async applyManifest(manifest: Manifest, runAs?: string): Promise<void> {
+    assertUnixLocalHostPathGrantsUnsupported(manifest);
     assertLocalWorkspaceManifestMetadataSupported(
       'UnixLocalSandboxClient',
       manifest,
@@ -903,6 +908,7 @@ export class UnixLocalSandboxClient implements SandboxClient<
         ? { archiveLimits: createArgs.archiveLimits }
         : {}),
     };
+    assertUnixLocalHostPathGrantsUnsupported(manifest);
     assertLocalWorkspaceManifestMetadataSupported(
       'UnixLocalSandboxClient',
       manifest,
@@ -941,6 +947,8 @@ export class UnixLocalSandboxClient implements SandboxClient<
     state: UnixLocalSandboxSessionState,
     options: SandboxClientResumeOptions = {},
   ): Promise<UnixLocalSandboxSession> {
+    assertHostPathGrantsRebound(state);
+    assertUnixLocalHostPathGrantsUnsupported(state.manifest);
     const archiveLimits =
       options.archiveLimits === undefined
         ? this.options.archiveLimits
@@ -956,6 +964,7 @@ export class UnixLocalSandboxClient implements SandboxClient<
   async serializeSessionState(
     state: UnixLocalSandboxSessionState,
   ): Promise<Record<string, unknown>> {
+    assertUnixLocalHostPathGrantsUnsupported(state.manifest);
     const snapshotSpec = state.snapshotSpec ?? this.options.snapshot ?? null;
     const snapshot = await persistLocalSnapshot(
       'UnixLocalSandboxClient',
@@ -1063,6 +1072,24 @@ function localBindMountSource(entry: {
 
 function pathWithinLogicalRoot(path: string, root: string): boolean {
   return path === root || path.startsWith(`${root}/`);
+}
+
+function assertUnixLocalHostPathGrantsUnsupported(manifest: Manifest): void {
+  const grant = manifest.extraPathGrants.find(
+    ({ hostPath }) => hostPath !== undefined,
+  );
+  if (!grant) {
+    return;
+  }
+
+  throw new SandboxUnsupportedFeatureError(
+    `UnixLocalSandboxClient does not support path grant hostPath for "${grant.path}". Omit hostPath when the host and sandbox paths are the same, or use DockerSandboxClient when they differ.`,
+    {
+      provider: 'UnixLocalSandboxClient',
+      feature: 'manifest.extraPathGrants.hostPath',
+      path: grant.path,
+    },
+  );
 }
 
 function validateResolvedHostPath(args: {

--- a/packages/agents-core/src/sandbox/shared/hostPath.ts
+++ b/packages/agents-core/src/sandbox/shared/hostPath.ts
@@ -1,4 +1,24 @@
 import { isAbsolute, relative, sep } from 'node:path';
+import type { SandboxPathGrant } from '../pathGrants';
+
+export function sandboxPathGrantHostPath(grant: SandboxPathGrant): string {
+  const hostPath = grant.hostPath ?? grant.path;
+  if (grant.hostPath !== undefined && !isAbsolute(hostPath)) {
+    throw new Error(
+      `Sandbox path grant hostPath must be absolute on the current host: ${hostPath}`,
+    );
+  }
+  if (
+    grant.hostPath !== undefined &&
+    sep === '\\' &&
+    !/^[A-Za-z]:\\/u.test(hostPath)
+  ) {
+    throw new Error(
+      `Sandbox path grant hostPath must be drive-qualified on Windows: ${hostPath}`,
+    );
+  }
+  return hostPath;
+}
 
 export function relativeHostPathEscapesRoot(relativePath: string): boolean {
   return (

--- a/packages/agents-core/test/sandboxManifest.test.ts
+++ b/packages/agents-core/test/sandboxManifest.test.ts
@@ -1,3 +1,5 @@
+import { tmpdir } from 'node:os';
+import { join, normalize, sep } from 'node:path';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import {
   cloneManifest,
@@ -580,6 +582,7 @@ describe('Manifest', () => {
   });
 
   it('clones manifests without sharing entries or environment values', () => {
+    const hostPath = join(tmpdir(), 'manifest-clone-data');
     const manifest = new Manifest({
       entries: {
         'notes.txt': {
@@ -597,7 +600,13 @@ describe('Manifest', () => {
       },
       users: [{ name: 'sandbox-user' }],
       groups: [{ name: 'sandbox-group', users: [{ name: 'sandbox-user' }] }],
-      extraPathGrants: [{ path: '/tmp/data', readOnly: true }],
+      extraPathGrants: [
+        {
+          path: '/tmp/data',
+          hostPath,
+          readOnly: true,
+        },
+      ],
       remoteMountCommandAllowlist: ['ls', 'cat'],
     });
     const cloned = cloneManifest(manifest);
@@ -623,6 +632,7 @@ describe('Manifest', () => {
     expect(cloned.extraPathGrants).toEqual([
       {
         path: '/tmp/data',
+        hostPath: normalize(hostPath),
         readOnly: true,
       },
     ]);
@@ -630,6 +640,7 @@ describe('Manifest', () => {
   });
 
   it('normalizes manifest identity, permissions, and path policy fields', () => {
+    const hostPath = join(tmpdir(), 'manifest-normalized-data');
     const manifest = new Manifest({
       users: [{ name: ' sandbox-user ' }],
       groups: [
@@ -641,6 +652,7 @@ describe('Manifest', () => {
       extraPathGrants: [
         {
           path: '/var/tmp/data',
+          hostPath,
           readOnly: true,
           description: 'fixture data',
         },
@@ -680,6 +692,7 @@ describe('Manifest', () => {
     expect(manifest.extraPathGrants).toEqual([
       {
         path: '/var/tmp/data',
+        hostPath: normalize(hostPath),
         readOnly: true,
         description: 'fixture data',
       },
@@ -934,6 +947,61 @@ describe('Manifest', () => {
     expect(
       () =>
         new Manifest({
+          extraPathGrants: [
+            {
+              path: '/mnt/data',
+              hostPath: 'relative/data',
+            },
+          ],
+        }),
+    ).toThrow(/hostPath must be an absolute host path/i);
+    expect(
+      () =>
+        new Manifest({
+          extraPathGrants: [
+            {
+              path: '/mnt/data',
+              hostPath: `${tmpdir()}${sep}..${sep}data`,
+            },
+          ],
+        }),
+    ).toThrow(/path grant hostPath must not contain parent segments/i);
+    expect(
+      () =>
+        new Manifest({
+          extraPathGrants: [
+            {
+              path: '/mnt/data',
+              host_path: join(tmpdir(), 'data'),
+            } as never,
+          ],
+        }),
+    ).toThrow(/snake_case key "host_path" is not supported/i);
+    expect(
+      () =>
+        new Manifest({
+          extraPathGrants: [
+            {
+              path: '/mnt/data',
+              hostPath: '//server/share/data',
+            },
+          ],
+        }),
+    ).toThrow(/hostPath does not support UNC or device paths/i);
+    expect(
+      () =>
+        new Manifest({
+          extraPathGrants: [
+            {
+              path: '/mnt/data',
+              hostPath: 'C:\\',
+            },
+          ],
+        }),
+    ).toThrow(/hostPath must not be filesystem root/i);
+    expect(
+      () =>
+        new Manifest({
           entries: {
             data: {
               type: 'mount',
@@ -1175,5 +1243,39 @@ describe('Manifest', () => {
     expect(rendered.renderedPaths).toBeLessThan(rendered.totalPaths);
     expect(rendered.text.length).toBeLessThanOrEqual(180);
     expect(rendered.text).toContain('truncated');
+  });
+
+  it('normalizes Windows drive host paths without changing sandbox paths', () => {
+    const manifest = new Manifest({
+      extraPathGrants: [
+        {
+          path: '/mnt/shared-skills',
+          hostPath: 'C:/Users/example/shared-skills',
+          readOnly: true,
+        },
+      ],
+    });
+
+    expect(manifest.extraPathGrants).toEqual([
+      {
+        path: '/mnt/shared-skills',
+        hostPath: 'C:\\Users\\example\\shared-skills',
+        readOnly: true,
+      },
+    ]);
+  });
+
+  it('preserves whitespace in POSIX host paths', () => {
+    const manifest = new Manifest({
+      extraPathGrants: [
+        {
+          path: '/mnt/shared-data',
+          hostPath: '/srv/shared-data ',
+          readOnly: true,
+        },
+      ],
+    });
+
+    expect(manifest.extraPathGrants[0]?.hostPath).toBe('/srv/shared-data ');
   });
 });

--- a/packages/agents-core/test/sandboxNativePathGrants.test.ts
+++ b/packages/agents-core/test/sandboxNativePathGrants.test.ts
@@ -1,0 +1,108 @@
+import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Manifest, skills } from '../src/sandbox';
+import { sandboxPathGrantHostPath } from '../src/sandbox/internal';
+import {
+  localDirLazySkillSource,
+  UnixLocalSandboxClient,
+} from '../src/sandbox/local';
+
+describe('native sandbox path grants', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((path) => rm(path, { recursive: true, force: true })),
+    );
+  });
+
+  it('rejects hostPath for UnixLocal before creating a workspace', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agents-native-grant-'));
+    tempDirs.push(root);
+    const hostSource = join(root, 'shared-data');
+    const workspaceBaseDir = join(root, 'workspaces');
+    await mkdir(hostSource);
+    await mkdir(workspaceBaseDir);
+
+    const client = new UnixLocalSandboxClient({ workspaceBaseDir });
+    await expect(
+      client.create(
+        new Manifest({
+          extraPathGrants: [
+            {
+              path: '/mnt/shared-data',
+              hostPath: hostSource,
+              readOnly: true,
+            },
+          ],
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: 'unsupported_feature',
+      details: {
+        provider: 'UnixLocalSandboxClient',
+        feature: 'manifest.extraPathGrants.hostPath',
+        path: '/mnt/shared-data',
+      },
+    });
+    await expect(readdir(workspaceBaseDir)).resolves.toEqual([]);
+  });
+
+  it('uses hostPath for lazy local skill discovery', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agents-native-skills-'));
+    tempDirs.push(root);
+    const skillsRoot = join(root, 'skills');
+    const skillDir = join(skillsRoot, 'native-skill');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      [
+        '---',
+        'name: native-skill',
+        'description: Loaded through a native host path',
+        '---',
+        '# Native skill',
+      ].join('\n'),
+    );
+
+    const capability = skills({
+      lazyFrom: localDirLazySkillSource(skillsRoot),
+    });
+    const manifest = new Manifest({
+      extraPathGrants: [
+        {
+          path: '/mnt/shared-skills',
+          hostPath: skillsRoot,
+          readOnly: true,
+        },
+      ],
+    });
+
+    await expect(capability.instructions(manifest)).resolves.toContain(
+      '- native-skill: Loaded through a native host path (file: .agents/native-skill)',
+    );
+  });
+
+  it('rejects drive-less hostPath values on Windows', () => {
+    if (process.platform !== 'win32') {
+      return;
+    }
+    const manifest = new Manifest({
+      extraPathGrants: [
+        {
+          path: '/mnt/shared-data',
+          hostPath: '/Users/example/shared-data',
+          readOnly: true,
+        },
+      ],
+    });
+
+    expect(() =>
+      sandboxPathGrantHostPath(manifest.extraPathGrants[0]!),
+    ).toThrow(/hostPath must be drive-qualified on Windows/i);
+  });
+});

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -39,7 +39,10 @@ import {
   prepareSandboxInterruptedTurnResume,
 } from '../src/runner/sandbox';
 import { serializeSandboxRuntimeState } from '../src/sandbox/runtime/sessionSerialization';
-import { deserializeSandboxSessionStateEntry } from '../src/sandbox/runtime/sessionState';
+import {
+  deserializeSandboxSessionStateEntry,
+  type SerializedSandboxSessionEntry,
+} from '../src/sandbox/runtime/sessionState';
 import {
   cleanupSandboxSession,
   registerSandboxPreStopHook,
@@ -383,9 +386,7 @@ class FakeSandboxClient implements SandboxClient<
     state: Record<string, unknown>,
   ): Promise<FakeSandboxSessionState> {
     return {
-      manifest: new Manifest({
-        root: String(state.root),
-      }),
+      manifest: new Manifest(state.manifest as any),
       sessionId: String(state.sessionId),
     };
   }
@@ -507,6 +508,42 @@ class DefaultSnapshotFakeSandboxClient extends FakeSandboxClient {
 class SerializedResumeFakeSandboxClient extends FakeSandboxClient {
   canReusePreservedOwnedSession(): boolean {
     return false;
+  }
+}
+
+class ManifestSerializingFakeSandboxClient extends FakeSandboxClient {
+  override async serializeSessionState(
+    state: FakeSandboxSessionState,
+    options: SandboxSessionSerializationOptions = {},
+  ): Promise<Record<string, unknown>> {
+    return {
+      ...(await super.serializeSessionState(state, options)),
+      manifest: state.manifest,
+    };
+  }
+}
+
+class RedactedHostPathSerializedResumeFakeSandboxClient extends SerializedResumeFakeSandboxClient {
+  override async serializeSessionState(
+    state: FakeSandboxSessionState,
+    options: SandboxSessionSerializationOptions = {},
+  ): Promise<Record<string, unknown>> {
+    return {
+      ...(await super.serializeSessionState(state, options)),
+      __openaiAgentsRedactedHostPathGrantPaths: state.manifest.extraPathGrants
+        .filter(({ hostPath }) => hostPath !== undefined)
+        .map(({ path }) => path),
+    };
+  }
+
+  override async deserializeSessionState(
+    state: Record<string, unknown>,
+  ): Promise<FakeSandboxSessionState> {
+    return {
+      ...(await super.deserializeSessionState(state)),
+      __openaiAgentsRedactedHostPathGrantPaths:
+        state.__openaiAgentsRedactedHostPathGrantPaths,
+    };
   }
 }
 
@@ -669,7 +706,7 @@ describe('sandbox runner integration', () => {
         usage: new Usage(),
       },
     ]);
-    const sandboxAgent = new SandboxAgent({
+    const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
       name: 'SandboxWorker',
       model: sandboxModel,
     });
@@ -1463,7 +1500,7 @@ describe('sandbox runner integration', () => {
   });
 
   it('serializes sandbox session state and resumes it on the next run', async () => {
-    const client = new FakeSandboxClient();
+    const client = new ManifestSerializingFakeSandboxClient();
     const sandboxModel = new RecordingFakeModel([
       {
         output: [fakeModelMessage('turn one')],
@@ -1477,7 +1514,16 @@ describe('sandbox runner integration', () => {
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
       model: sandboxModel,
-      defaultManifest: new Manifest({ root: '/workspace' }),
+      defaultManifest: new Manifest({
+        root: '/workspace',
+        extraPathGrants: [
+          {
+            path: '/mnt/shared-data',
+            hostPath: process.cwd(),
+            readOnly: true,
+          },
+        ],
+      }),
     });
     const runner = new Runner();
 
@@ -1498,6 +1544,7 @@ describe('sandbox runner integration', () => {
         workspaceReady: true,
         providerState: {
           sessionId: 'session-1',
+          __openaiAgentsRedactedHostPathGrantPaths: ['/mnt/shared-data'],
         },
       },
       sessionsByAgent: {
@@ -1506,12 +1553,14 @@ describe('sandbox runner integration', () => {
           sessionState: {
             providerState: {
               sessionId: 'session-1',
+              __openaiAgentsRedactedHostPathGrantPaths: ['/mnt/shared-data'],
             },
           },
         },
       },
     });
     expect(client.createCalls).toHaveLength(1);
+    expect(firstResult.state.toString()).not.toContain('hostPath');
     expect(client.serializedOptions).toEqual([
       {
         preserveOwnedSession: false,
@@ -1519,6 +1568,21 @@ describe('sandbox runner integration', () => {
         willCloseAfterSerialize: true,
       },
     ]);
+
+    const serializedEntry = firstResult.state._sandbox?.sessionsByAgent
+      .SandboxWorker as SerializedSandboxSessionEntry;
+    const markerlessEntry = structuredClone(serializedEntry);
+    delete markerlessEntry.sessionState.providerState
+      .__openaiAgentsRedactedHostPathGrantPaths;
+    await expect(
+      deserializeSandboxSessionStateEntry(
+        client,
+        markerlessEntry,
+        new Manifest({ root: '/workspace' }),
+      ),
+    ).rejects.toThrow(
+      'Sandbox session state contains path grants that are not present in the current trusted manifest: /mnt/shared-data.',
+    );
 
     const resumedState = await RunState.fromString(
       sandboxAgent,
@@ -1540,6 +1604,17 @@ describe('sandbox runner integration', () => {
     expect(client.createCalls).toHaveLength(1);
     expect(client.resumeCalls).toMatchObject([
       {
+        state: {
+          manifest: {
+            extraPathGrants: [
+              {
+                path: '/mnt/shared-data',
+                hostPath: process.cwd(),
+                readOnly: true,
+              },
+            ],
+          },
+        },
         archiveLimits: {
           maxInputBytes: 10,
           maxExtractedBytes: 20,
@@ -1547,6 +1622,82 @@ describe('sandbox runner integration', () => {
         },
       },
     ]);
+  });
+
+  it('rebinds explicit session state path grants without consuming their redaction metadata', async () => {
+    const client = new FakeSandboxClient();
+    const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
+      name: 'SandboxWorker',
+      model: new RecordingFakeModel([]),
+      defaultManifest: new Manifest({
+        extraPathGrants: [
+          {
+            path: '/mnt/shared-data',
+            hostPath: process.cwd(),
+            readOnly: true,
+          },
+        ],
+      }),
+    });
+    const sessionState: FakeSandboxSessionState = {
+      manifest: new Manifest({
+        extraPathGrants: [
+          {
+            path: '/mnt/shared-data',
+            readOnly: true,
+          },
+        ],
+      }),
+      sessionId: 'persisted',
+      __openaiAgentsRedactedHostPathGrantPaths: ['/mnt/shared-data'],
+    };
+    const runState = new RunState<
+      unknown,
+      SandboxAgent<unknown, AgentOutputType>
+    >(new RunContext(), 'Hello', sandboxAgent, 1);
+    const manager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent,
+      sandboxConfig: {
+        client,
+        sessionState,
+      },
+      runState,
+    });
+
+    await manager.prepareAgent({
+      currentAgent: sandboxAgent,
+      turnInput: [],
+    });
+
+    expect(client.resumeCalls).toMatchObject([
+      {
+        state: {
+          manifest: {
+            extraPathGrants: [
+              {
+                path: '/mnt/shared-data',
+                hostPath: process.cwd(),
+                readOnly: true,
+              },
+            ],
+          },
+        },
+      },
+    ]);
+    expect(
+      client.resumeCalls[0]?.state.__openaiAgentsRedactedHostPathGrantPaths,
+    ).toBeUndefined();
+    expect(sessionState.manifest.extraPathGrants).toEqual([
+      {
+        path: '/mnt/shared-data',
+        readOnly: true,
+      },
+    ]);
+    expect(sessionState.__openaiAgentsRedactedHostPathGrantPaths).toEqual([
+      '/mnt/shared-data',
+    ]);
+
+    await manager.cleanup(runState);
   });
 
   it('sanitizes manifest data in serialized sandbox state envelopes', async () => {
@@ -1860,9 +2011,7 @@ describe('sandbox runner integration', () => {
     client.deserializeSessionState = async (state) => {
       deserializedStates.push(state);
       return {
-        manifest: new Manifest({
-          root: String((state.manifest as { root?: unknown }).root),
-        }),
+        manifest: new Manifest(state.manifest as any),
         sessionId: String(state.sessionId),
         snapshot: state.snapshot as FakeSandboxSessionState['snapshot'],
         snapshotFingerprint:
@@ -1875,33 +2024,52 @@ describe('sandbox runner integration', () => {
       };
     };
 
-    const state = await deserializeSandboxSessionStateEntry(client, {
-      backendId: 'fake-sandbox',
-      currentAgentKey: 'SandboxWorker',
-      currentAgentName: 'SandboxWorker',
-      sessionState: fakeSandboxSessionStateEnvelope(
-        {
-          sessionId: 'persisted',
-        },
-        {
-          manifest: {
-            version: 1,
-            root: '/workspace',
-            entries: {
-              'README.md': { type: 'file', content: 'hello\n' },
+    const state = await deserializeSandboxSessionStateEntry(
+      client,
+      {
+        backendId: 'fake-sandbox',
+        currentAgentKey: 'SandboxWorker',
+        currentAgentName: 'SandboxWorker',
+        sessionState: fakeSandboxSessionStateEnvelope(
+          {
+            sessionId: 'persisted',
+          },
+          {
+            manifest: {
+              version: 1,
+              root: '/workspace',
+              entries: {
+                'README.md': { type: 'file', content: 'hello\n' },
+              },
+              environment: {},
+              extraPathGrants: [
+                {
+                  path: '/mnt/shared-data',
+                  hostPath: '/private/tmp/untrusted-data',
+                  readOnly: false,
+                },
+              ],
             },
-            environment: {},
+            snapshot: { provider: 'snapshot' },
+            snapshotFingerprint: 'fingerprint',
+            snapshotFingerprintVersion: '2',
+            workspaceReady: false,
+            exposedPorts: {
+              '3000': { host: '127.0.0.1', port: 3000 },
+            },
           },
-          snapshot: { provider: 'snapshot' },
-          snapshotFingerprint: 'fingerprint',
-          snapshotFingerprintVersion: '2',
-          workspaceReady: false,
-          exposedPorts: {
-            '3000': { host: '127.0.0.1', port: 3000 },
+        ),
+      },
+      new Manifest({
+        extraPathGrants: [
+          {
+            path: '/mnt/shared-data',
+            hostPath: '/private/tmp/trusted-data',
+            readOnly: true,
           },
-        },
-      ),
-    });
+        ],
+      }),
+    );
 
     expect(deserializedStates[0]).toMatchObject({
       sessionId: 'persisted',
@@ -1923,6 +2091,13 @@ describe('sandbox runner integration', () => {
     expect(state?.exposedPorts).toEqual({
       '3000': { host: '127.0.0.1', port: 3000 },
     });
+    expect(state?.manifest.extraPathGrants).toEqual([
+      {
+        path: '/mnt/shared-data',
+        hostPath: '/private/tmp/trusted-data',
+        readOnly: true,
+      },
+    ]);
   });
 
   it('resets required tool choice after a sandbox agent uses a tool', async () => {
@@ -3170,6 +3345,87 @@ describe('sandbox runner integration', () => {
       'RuntimeWorker_2',
     ]);
     expect(state._sandbox?.currentAgentKey).toBe('RuntimeWorker_2');
+  });
+
+  it('rebinds preserved runtime agent path grants with their original identities', async () => {
+    const client = new RedactedHostPathSerializedResumeFakeSandboxClient();
+    const startingAgent = new Agent({
+      name: 'Router',
+      model: new RecordingFakeModel([]),
+    }) as Agent<unknown, AgentOutputType>;
+    const firstAgent = new SandboxAgent<unknown, AgentOutputType>({
+      name: 'RuntimeWorker',
+      model: new RecordingFakeModel([]),
+      defaultManifest: new Manifest({
+        extraPathGrants: [
+          {
+            path: '/mnt/shared-data',
+            hostPath: '/private/tmp/runtime-worker-first',
+            readOnly: true,
+          },
+        ],
+      }),
+    });
+    const secondAgent = new SandboxAgent<unknown, AgentOutputType>({
+      name: 'RuntimeWorker',
+      model: new RecordingFakeModel([]),
+      defaultManifest: new Manifest({
+        extraPathGrants: [
+          {
+            path: '/mnt/shared-data',
+            hostPath: '/private/tmp/runtime-worker-second',
+            readOnly: true,
+          },
+        ],
+      }),
+    });
+    const state = new RunState<unknown, Agent<unknown, AgentOutputType>>(
+      new RunContext(),
+      'Hello',
+      startingAgent,
+      1,
+    );
+    const firstManager = new SandboxRuntimeManager({
+      startingAgent,
+      sandboxConfig: {
+        client,
+      },
+    });
+
+    await firstManager.prepareAgent({
+      currentAgent: firstAgent,
+      turnInput: [],
+    });
+    await firstManager.prepareAgent({
+      currentAgent: secondAgent,
+      turnInput: [],
+    });
+    state._currentAgent = secondAgent;
+    await firstManager.cleanup(state, { preserveOwnedSessions: true });
+
+    expect(state._sandbox?.currentAgentKey).toBe('RuntimeWorker_2');
+    expect(JSON.stringify(state._sandbox)).not.toContain('hostPath');
+
+    const secondManager = new SandboxRuntimeManager({
+      startingAgent,
+      sandboxConfig: {
+        client,
+      },
+      runState: state,
+    });
+    await secondManager.adoptPreservedOwnedSessions();
+
+    expect(
+      client.resumeCalls.map(
+        ({ state: resumedState }) =>
+          resumedState.manifest.extraPathGrants[0]?.hostPath,
+      ),
+    ).toEqual([
+      '/private/tmp/runtime-worker-first',
+      '/private/tmp/runtime-worker-second',
+    ]);
+
+    await secondManager.cleanup(state);
   });
 
   it('runs preStop without stopping provided sandbox sessions during cleanup', async () => {

--- a/packages/agents-core/test/sandboxShared.test.ts
+++ b/packages/agents-core/test/sandboxShared.test.ts
@@ -232,6 +232,13 @@ describe('sandbox shared helpers', () => {
           ephemeral: true,
         },
       },
+      extraPathGrants: [
+        {
+          path: '/mnt/shared-data',
+          hostPath: '/private/tmp/shared-data',
+          readOnly: true,
+        },
+      ],
     });
 
     const serialized = serializeManifestRecord(manifest);
@@ -264,6 +271,12 @@ describe('sandbox shared helpers', () => {
       environment: {
         KEPT: { value: 'ok' },
       },
+      extraPathGrants: [
+        {
+          path: '/mnt/shared-data',
+          readOnly: true,
+        },
+      ],
     });
     expect(serialized.entries).not.toHaveProperty('tmp.txt');
     expect(serialized.entries).not.toHaveProperty([
@@ -275,6 +288,30 @@ describe('sandbox shared helpers', () => {
       'dir',
       'children',
       'nested.tmp',
+    ]);
+    expect(serialized.extraPathGrants).not.toHaveProperty([0, 'hostPath']);
+  });
+
+  it('does not restore host path grants from persisted manifests', () => {
+    const restored = deserializeManifest({
+      version: 1,
+      root: '/workspace',
+      entries: {},
+      environment: {},
+      extraPathGrants: [
+        {
+          path: '/mnt/shared-data',
+          hostPath: '/private/tmp/untrusted-data',
+          readOnly: true,
+        },
+      ],
+    });
+
+    expect(restored.extraPathGrants).toEqual([
+      {
+        path: '/mnt/shared-data',
+        readOnly: true,
+      },
     ]);
   });
 
@@ -490,19 +527,33 @@ describe('sandbox shared helpers', () => {
   });
 
   it('merges manifest deltas by replacing named and path-keyed entries', () => {
+    const baseHostPath = process.cwd();
+    const updatedHostPath = `${process.cwd()}-updated`;
     const base = new Manifest({
       entries: {
         'base.txt': file({ content: 'base' }),
       },
       groups: [{ name: 'operators', users: [{ name: 'agent' }] }],
-      extraPathGrants: [{ path: '/tmp/base', readOnly: true }],
+      extraPathGrants: [
+        {
+          path: '/tmp/base',
+          hostPath: baseHostPath,
+          readOnly: true,
+        },
+      ],
     });
     const update = new Manifest({
       entries: {
         'update.txt': file({ content: 'update' }),
       },
       groups: [{ name: 'operators', users: [{ name: 'reviewer' }] }],
-      extraPathGrants: [{ path: '/tmp/base', readOnly: false }],
+      extraPathGrants: [
+        {
+          path: '/tmp/base',
+          hostPath: updatedHostPath,
+          readOnly: false,
+        },
+      ],
     });
 
     const merged = mergeManifestDelta(base, update);
@@ -512,7 +563,11 @@ describe('sandbox shared helpers', () => {
       { name: 'operators', users: [{ name: 'reviewer' }] },
     ]);
     expect(merged.extraPathGrants).toEqual([
-      { path: '/tmp/base', readOnly: false },
+      {
+        path: '/tmp/base',
+        hostPath: updatedHostPath,
+        readOnly: false,
+      },
     ]);
   });
 

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -1856,6 +1856,363 @@ describe('DockerSandboxClient unit behavior', () => {
     );
   });
 
+  it('uses hostPath as the Docker bind source and path as the target', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+
+    await client.create(
+      new Manifest({
+        extraPathGrants: [
+          {
+            path: '/mnt/shared-data',
+            hostPath: rootDir,
+            readOnly: true,
+          },
+        ],
+      }),
+    );
+
+    const runCall = processMocks.runSandboxProcess.mock.calls.find(
+      ([, args]) => args[0] === 'run',
+    );
+    expect(runCall?.[1]).toEqual(
+      expect.arrayContaining([
+        '--mount',
+        `type=bind,source=${rootDir},target=/mnt/shared-data,readonly`,
+      ]),
+    );
+  });
+
+  it('uses the container filesystem for split path grants', async () => {
+    const pngBytes = Uint8Array.from([0x89, 0x50, 0x4e, 0x47]);
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
+      const command = args.at(-1) ?? '';
+      if (command.startsWith('base64 --')) {
+        const bytes = command.includes('picture.png')
+          ? pngBytes
+          : new TextEncoder().encode('hello');
+        return dockerSpawnResult({
+          stdout: Buffer.from(bytes).toString('base64'),
+          status: 0,
+        });
+      }
+      if (command.startsWith('find ')) {
+        return dockerSpawnResult({ stdout: 'f\tdata.txt\n', status: 0 });
+      }
+      return dockerSpawnResult({ status: 0 });
+    });
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          'workspace.txt': {
+            type: 'file',
+            content: 'workspace',
+          },
+        },
+        extraPathGrants: [
+          {
+            path: '/mnt/shared-data',
+            hostPath: rootDir,
+          },
+        ],
+      }),
+    );
+    const editor = session.createEditor();
+
+    await editor.deleteFile({
+      type: 'delete_file',
+      path: 'workspace.txt',
+    });
+    await expect(
+      stat(join(session.state.workspaceRootPath, 'workspace.txt')),
+    ).rejects.toThrow();
+    expect(childProcessMocks.spawn).not.toHaveBeenCalled();
+
+    await expect(session.pathExists('/mnt/shared-data/data.txt')).resolves.toBe(
+      true,
+    );
+    await expect(
+      session
+        .readFile({ path: '/mnt/shared-data/data.txt' })
+        .then((bytes) => new TextDecoder().decode(bytes)),
+    ).resolves.toBe('hello');
+    await expect(
+      session.listDir({ path: '/mnt/shared-data' }),
+    ).resolves.toEqual([
+      {
+        name: 'data.txt',
+        path: '/mnt/shared-data/data.txt',
+        type: 'file',
+      },
+    ]);
+    await expect(
+      session.viewImage({ path: '/mnt/shared-data/picture.png' }),
+    ).resolves.toMatchObject({
+      type: 'image',
+      image: {
+        data: pngBytes,
+        mediaType: 'image/png',
+      },
+    });
+    await editor.deleteFile({
+      type: 'delete_file',
+      path: '/mnt/shared-data/data.txt',
+    });
+
+    const dockerCommands = childProcessMocks.spawn.mock.calls.map(([, args]) =>
+      (args as string[]).at(-1),
+    );
+    expect(dockerCommands).toEqual(
+      expect.arrayContaining([
+        "test -e '/mnt/shared-data/data.txt'",
+        "base64 -- '/mnt/shared-data/data.txt'",
+        "find '/mnt/shared-data' -mindepth 1 -maxdepth 1 -printf '%y\\t%f\\n'",
+        "base64 -- '/mnt/shared-data/picture.png'",
+        "rm -f -- '/mnt/shared-data/data.txt'",
+      ]),
+    );
+  });
+
+  it('rejects split path grants when applying a manifest delta', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(new Manifest());
+
+    await expect(
+      session.applyManifest(
+        new Manifest({
+          extraPathGrants: [
+            {
+              path: '/mnt/shared-data',
+              hostPath: rootDir,
+            },
+          ],
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: 'unsupported_feature',
+      details: {
+        provider: 'DockerSandboxClient',
+        feature: 'manifest.extraPathGrants.hostPath',
+        path: '/mnt/shared-data',
+      },
+    });
+    expect(session.state.manifest.extraPathGrants).toEqual([]);
+    expect(childProcessMocks.spawn).not.toHaveBeenCalled();
+
+    const splitSession = await client.create(
+      new Manifest({
+        extraPathGrants: [
+          {
+            path: '/mnt/shared-data',
+            hostPath: rootDir,
+          },
+        ],
+      }),
+    );
+    await expect(
+      splitSession.applyManifest(
+        new Manifest({
+          extraPathGrants: [
+            {
+              path: '/mnt/shared-data',
+            },
+          ],
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: 'unsupported_feature',
+      details: {
+        feature: 'manifest.extraPathGrants.hostPath',
+        path: '/mnt/shared-data',
+      },
+    });
+    expect(splitSession.state.manifest.extraPathGrants).toEqual([
+      {
+        path: '/mnt/shared-data',
+        hostPath: rootDir,
+        readOnly: false,
+      },
+    ]);
+  });
+
+  it('restarts a running container before using rebound path grants', async () => {
+    let runCount = 0;
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          return success(`container-${runCount}\n`);
+        }
+        if (args[0] === 'inspect') {
+          return success('true\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(
+      new Manifest({
+        extraPathGrants: [
+          {
+            path: '/mnt/shared-data',
+            hostPath: join(rootDir, 'original-source'),
+            readOnly: false,
+          },
+        ],
+      }),
+    );
+    const reboundHostPath = join(rootDir, 'rebound-source');
+
+    const resumed = await client.resume({
+      ...session.state,
+      manifest: new Manifest({
+        extraPathGrants: [
+          {
+            path: '/mnt/shared-data',
+            hostPath: reboundHostPath,
+            readOnly: true,
+          },
+        ],
+      }),
+    });
+
+    expect(resumed.state.containerId).toBe('container-2');
+    expect(client.canReusePreservedOwnedSession(session.state)).toBe(false);
+    const calls = processMocks.runSandboxProcess.mock.calls;
+    const removeIndex = calls.findIndex(
+      ([, args]) => args[0] === 'rm' && args[2] === 'container-1',
+    );
+    const secondRunIndex = calls.findIndex(
+      ([, args], index) => index > removeIndex && args[0] === 'run',
+    );
+    expect(removeIndex).toBeGreaterThanOrEqual(0);
+    expect(secondRunIndex).toBeGreaterThan(removeIndex);
+    expect(calls[secondRunIndex]?.[1]).toEqual(
+      expect.arrayContaining([
+        '--mount',
+        `type=bind,source=${reboundHostPath},target=/mnt/shared-data,readonly`,
+      ]),
+    );
+  });
+
+  it('rejects foreign host paths before checking Docker or creating a workspace', async () => {
+    const foreignHostPath = process.platform === 'win32' ? '/data' : 'C:\\data';
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+
+    await expect(
+      client.create(
+        new Manifest({
+          extraPathGrants: [
+            {
+              path: '/mnt/shared-data',
+              hostPath: foreignHostPath,
+              readOnly: true,
+            },
+          ],
+        }),
+      ),
+    ).rejects.toThrow(/hostPath must (?:be absolute|be drive-qualified)/i);
+
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
+    await expect(readdir(rootDir)).resolves.toEqual([]);
+  });
+
+  it('rejects direct resume when native host paths need trusted rebinding', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: new NoopSnapshotSpec(),
+    });
+    const session = await client.create(
+      new Manifest({
+        extraPathGrants: [
+          {
+            path: '/mnt/shared-data',
+            hostPath: rootDir,
+            readOnly: true,
+          },
+        ],
+      }),
+    );
+
+    const serialized = JSON.parse(
+      JSON.stringify(await client.serializeSessionState(session.state)),
+    ) as Record<string, unknown>;
+    const deserialized = await client.deserializeSessionState(serialized);
+
+    expect(serialized.__openaiAgentsRedactedHostPathGrantPaths).toEqual([
+      '/mnt/shared-data',
+    ]);
+    expect(deserialized.manifest.extraPathGrants).toEqual([
+      {
+        path: '/mnt/shared-data',
+        readOnly: true,
+      },
+    ]);
+    await expect(client.resume(deserialized)).rejects.toThrow(
+      'Sandbox session state requires trusted hostPath values for these path grants: /mnt/shared-data.',
+    );
+  });
+
   it('allows extra path grants during docker manifest application for host filesystem helpers', async () => {
     processMocks.runSandboxProcess.mockImplementation(
       async (_command: string, args: string[]) => {

--- a/packages/agents-core/test/sandboxes/unixLocal.test.ts
+++ b/packages/agents-core/test/sandboxes/unixLocal.test.ts
@@ -1040,6 +1040,37 @@ describe('UnixLocalSandboxClient', () => {
     });
   });
 
+  it('rejects hostPath before applying a manifest delta', async () => {
+    const client = new UnixLocalSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(new Manifest());
+
+    await expect(
+      session.applyManifest(
+        new Manifest({
+          extraPathGrants: [
+            {
+              path: '/mnt/shared-data',
+              hostPath: rootDir,
+              readOnly: true,
+            },
+          ],
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: 'unsupported_feature',
+      details: {
+        provider: 'UnixLocalSandboxClient',
+        feature: 'manifest.extraPathGrants.hostPath',
+        path: '/mnt/shared-data',
+      },
+    });
+    expect(session.state.manifest.extraPathGrants).toEqual([]);
+
+    await session.close();
+  });
+
   it('supports incremental filesystem operations and manifest application', async () => {
     const client = new UnixLocalSandboxClient({
       workspaceBaseDir: rootDir,

--- a/packages/agents-extensions/src/sandbox/blaxel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/blaxel/sandbox.ts
@@ -24,6 +24,7 @@ import {
   addPtyWebSocketListener,
   appendPtyOutput,
   assertCoreSnapshotUnsupported,
+  assertRemoteSandboxSessionStateCanResume,
   assertResumeRecreateAllowed,
   createPtyProcessEntry,
   assertSandboxManifestMetadataSupported,
@@ -984,6 +985,7 @@ export class BlaxelSandboxClient implements SandboxClient<
   async resume(
     state: BlaxelSandboxSessionState,
   ): Promise<BlaxelSandboxSession> {
+    assertRemoteSandboxSessionStateCanResume(state);
     const SandboxInstance = await loadBlaxelSandboxClass();
     let sandbox: BlaxelSandboxLike;
     try {

--- a/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
@@ -89,6 +89,7 @@ import {
   sandboxUserShellCommand,
 } from '../shared/runAs';
 import {
+  assertRemoteSandboxSessionStateCanResume,
   deserializeRemoteSandboxSessionStateValues,
   serializeRemoteSandboxSessionState,
 } from '../shared/sessionState';
@@ -1210,6 +1211,7 @@ export class CloudflareSandboxClient implements SandboxClient<
   async resume(
     state: CloudflareSandboxSessionState,
   ): Promise<CloudflareSandboxSession> {
+    assertRemoteSandboxSessionStateCanResume(state);
     const sandboxId = normalizeCloudflarePersistedSandboxId(
       (state as Record<string, unknown>).sandboxId,
     );

--- a/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
@@ -26,6 +26,7 @@ import {
 import {
   appendPtyOutput,
   assertCoreSnapshotUnsupported,
+  assertRemoteSandboxSessionStateCanResume,
   assertTarWorkspacePersistence,
   createPtyProcessEntry,
   imageOutputFromBytes,
@@ -1184,6 +1185,7 @@ export class DaytonaSandboxClient implements SandboxClient<
   async resume(
     state: DaytonaSandboxSessionState,
   ): Promise<DaytonaSandboxSession> {
+    assertRemoteSandboxSessionStateCanResume(state);
     const client = await createDaytonaClient({
       ...this.options,
       apiKey: state.apiKey ?? this.options.apiKey,

--- a/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
@@ -22,6 +22,7 @@ import {
 import {
   appendPtyOutput,
   assertCoreSnapshotUnsupported,
+  assertRemoteSandboxSessionStateCanResume,
   assertResumeRecreateAllowed,
   assertTarWorkspacePersistence,
   createPtyProcessEntry,
@@ -975,6 +976,7 @@ export class E2BSandboxClient implements SandboxClient<
   }
 
   async resume(state: E2BSandboxSessionState): Promise<E2BSandboxSession> {
+    assertRemoteSandboxSessionStateCanResume(state);
     const Sandbox = await loadE2BSandboxClass(state.sandboxType);
     const connect = Sandbox.connect ?? Sandbox.resume;
     if (connect) {

--- a/packages/agents-extensions/src/sandbox/modal/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/modal/sandbox.ts
@@ -33,6 +33,7 @@ import {
 import { posix as pathPosix } from 'node:path';
 import {
   assertCoreSnapshotUnsupported,
+  assertRemoteSandboxSessionStateCanResume,
   imageOutputFromBytes,
   RemoteSandboxEditor,
   assertTarWorkspacePersistence,
@@ -1495,6 +1496,7 @@ export class ModalSandboxClient implements SandboxClient<
   }
 
   async resume(state: ModalSandboxSessionState): Promise<ModalSandboxSession> {
+    assertRemoteSandboxSessionStateCanResume(state);
     if (!state.sandboxId) {
       throw new UserError(
         'Modal sandbox resume requires a persisted sandboxId.',

--- a/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
@@ -19,6 +19,7 @@ import {
 import { posix as pathPosix } from 'node:path';
 import {
   assertCoreSnapshotUnsupported,
+  assertRemoteSandboxSessionStateCanResume,
   assertTarWorkspacePersistence,
   assertResumeRecreateAllowed,
   assertRunAsUnsupported,
@@ -1522,6 +1523,7 @@ export class RunloopSandboxClient implements SandboxClient<
   async resume(
     state: RunloopSandboxSessionState,
   ): Promise<RunloopSandboxSession> {
+    assertRemoteSandboxSessionStateCanResume(state);
     const resumeState: RunloopSandboxSessionState = {
       ...state,
       baseUrl: this.options.baseUrl,

--- a/packages/agents-extensions/src/sandbox/shared/index.ts
+++ b/packages/agents-extensions/src/sandbox/shared/index.ts
@@ -105,6 +105,7 @@ export {
   type RemoteSandboxSessionBaseOptions,
 } from './sessionBase';
 export {
+  assertRemoteSandboxSessionStateCanResume,
   deserializeRemoteSandboxSessionStateValues,
   serializeRemoteSandboxSessionState,
 } from './sessionState';

--- a/packages/agents-extensions/src/sandbox/shared/localSources.ts
+++ b/packages/agents-extensions/src/sandbox/shared/localSources.ts
@@ -3,6 +3,7 @@ import { type Entry, type Manifest } from '@openai/agents-core/sandbox';
 import {
   isHostPathStrictlyWithinRoot,
   isHostPathWithinRoot,
+  sandboxPathGrantHostPath,
 } from '@openai/agents-core/sandbox/internal';
 import { constants, type Dirent, type Stats } from 'node:fs';
 import {
@@ -196,7 +197,10 @@ function resolveLocalSourcePath(
   if (
     isHostPathWithinRoot(base, resolvedSourcePath) ||
     (options.localSourceGrants ?? []).some((grant) =>
-      isHostPathWithinRoot(resolve(grant.path), resolvedSourcePath),
+      isHostPathWithinRoot(
+        resolve(sandboxPathGrantHostPath(grant)),
+        resolvedSourcePath,
+      ),
     )
   ) {
     return resolvedSourcePath;

--- a/packages/agents-extensions/src/sandbox/shared/sessionState.ts
+++ b/packages/agents-extensions/src/sandbox/shared/sessionState.ts
@@ -1,12 +1,19 @@
-import type { Manifest } from '@openai/agents-core/sandbox';
+import type {
+  Manifest,
+  SandboxSessionState,
+} from '@openai/agents-core/sandbox';
+import {
+  assertHostPathGrantsRebound,
+  deserializeHostPathGrantRedactionMetadata,
+  serializeHostPathGrantRedactionMetadata,
+} from '@openai/agents-core/sandbox/internal';
 import {
   deserializePersistedEnvironmentForRuntime,
   serializeRuntimeEnvironmentForPersistence,
 } from './environment';
 import { deserializeManifest, serializeManifestRecord } from './manifest';
 
-export type RemoteSandboxSessionStateValues = {
-  manifest: Manifest;
+export type RemoteSandboxSessionStateValues = SandboxSessionState & {
   environment: Record<string, string>;
 };
 
@@ -15,6 +22,7 @@ export function serializeRemoteSandboxSessionState<
 >(state: TState): Record<string, unknown> {
   return {
     ...state,
+    ...serializeHostPathGrantRedactionMetadata(state),
     environment: serializeRemoteRuntimeEnvironmentForPersistence(
       state.manifest,
       state.environment,
@@ -37,7 +45,14 @@ export function deserializeRemoteSandboxSessionStateValues(
       state.environment as Record<string, string> | undefined,
       configuredEnvironment,
     ),
+    ...deserializeHostPathGrantRedactionMetadata(state),
   };
+}
+
+export function assertRemoteSandboxSessionStateCanResume(
+  state: SandboxSessionState,
+): void {
+  assertHostPathGrantsRebound(state);
 }
 
 function serializeRemoteRuntimeEnvironmentForPersistence(

--- a/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
@@ -24,6 +24,7 @@ import {
 } from '@openai/agents-core/sandbox';
 import {
   assertCoreSnapshotUnsupported,
+  assertRemoteSandboxSessionStateCanResume,
   assertSandboxManifestMetadataSupported,
   assertRunAsUnsupported,
   cloneManifestWithoutMountEntries,
@@ -1520,6 +1521,7 @@ export class VercelSandboxClient implements SandboxClient<
   async resume(
     state: VercelSandboxSessionState,
   ): Promise<VercelSandboxSession> {
+    assertRemoteSandboxSessionStateCanResume(state);
     if (hasVercelMounts(state.manifest)) {
       // This is an intentional lifecycle boundary, not a missing restore path.
       // A fresh create supplies trusted credentials and mount configuration.

--- a/packages/agents-extensions/test/sandbox/remotePaths.test.ts
+++ b/packages/agents-extensions/test/sandbox/remotePaths.test.ts
@@ -1,4 +1,5 @@
-import { win32 as pathWin32 } from 'node:path';
+import { tmpdir } from 'node:os';
+import { join, win32 as pathWin32 } from 'node:path';
 import { describe, expect, test } from 'vitest';
 import { validateRemoteSandboxPath } from '../../src/sandbox/shared';
 
@@ -54,6 +55,37 @@ describe('remote sandbox path command construction', () => {
     expect(extractHelperDir(commands[0])).not.toBe(
       extractHelperDir(commands[1]),
     );
+  });
+
+  test('does not send local hostPath values to remote path helpers', async () => {
+    const commands: string[] = [];
+    const hostPath = join(tmpdir(), 'host-only-data');
+
+    await validateRemoteSandboxPath({
+      root: '/workspace',
+      path: '/mnt/data/input.txt',
+      options: {
+        extraPathGrants: [
+          {
+            path: '/mnt/data',
+            hostPath,
+            readOnly: true,
+          },
+        ],
+      },
+      runCommand: async (command) => {
+        commands.push(command);
+        return {
+          status: 0,
+          stdout: '/mnt/data/input.txt\n',
+          stderr: '',
+        };
+      },
+    });
+
+    expect(commands).toHaveLength(1);
+    expect(commands[0]).toContain("'/mnt/data' '1'");
+    expect(commands[0]).not.toContain(hostPath);
   });
 
   test('returns the remote validated resolved path to callers', async () => {

--- a/packages/agents-extensions/test/sandbox/shared.test.ts
+++ b/packages/agents-extensions/test/sandbox/shared.test.ts
@@ -2958,8 +2958,16 @@ describe('remote sandbox path helpers', () => {
       'test',
       {
         localSourceGrants: [
-          { path: dirname(sourceFile), readOnly: true },
-          { path: sourceDir, readOnly: true },
+          {
+            path: '/mnt/source-file',
+            hostPath: dirname(sourceFile),
+            readOnly: true,
+          },
+          {
+            path: '/mnt/source-dir',
+            hostPath: sourceDir,
+            readOnly: true,
+          },
         ],
       },
     );

--- a/packages/agents-extensions/test/sandbox/sharedSession.test.ts
+++ b/packages/agents-extensions/test/sandbox/sharedSession.test.ts
@@ -9,9 +9,12 @@ import { describe, expect, test } from 'vitest';
 import {
   assertCoreConcurrencyLimitsUnsupported,
   assertCoreSnapshotUnsupported,
+  assertRemoteSandboxSessionStateCanResume,
   assertResumeRecreateAllowed,
+  deserializeRemoteSandboxSessionStateValues,
   isProviderSandboxNotFoundError,
   closeRemoteSessionOnManifestError,
+  serializeRemoteSandboxSessionState,
   withProviderError,
   providerErrorRetryability,
   RemoteSandboxSessionBase,
@@ -134,6 +137,37 @@ class FailedPathProbeSession extends FakeRemoteSession {
 }
 
 describe('shared sandbox session helpers', () => {
+  test('rejects direct resume when native host paths need trusted rebinding', () => {
+    const serialized = serializeRemoteSandboxSessionState({
+      manifest: new Manifest({
+        extraPathGrants: [
+          {
+            path: '/mnt/shared-data',
+            hostPath: process.cwd(),
+            readOnly: true,
+          },
+        ],
+      }),
+      environment: {},
+    });
+    const deserialized = deserializeRemoteSandboxSessionStateValues(serialized);
+
+    expect(serialized.__openaiAgentsRedactedHostPathGrantPaths).toEqual([
+      '/mnt/shared-data',
+    ]);
+    expect(deserialized.manifest.extraPathGrants).toEqual([
+      {
+        path: '/mnt/shared-data',
+        readOnly: true,
+      },
+    ]);
+    expect(() =>
+      assertRemoteSandboxSessionStateCanResume(deserialized),
+    ).toThrow(
+      'Sandbox session state requires trusted hostPath values for these path grants: /mnt/shared-data.',
+    );
+  });
+
   test('rejects unsupported core create options for provider clients', () => {
     expect(() =>
       assertCoreSnapshotUnsupported('ProviderSandboxClient', { type: 'noop' }),


### PR DESCRIPTION
This pull request resolves #1537.

It adds an optional `hostPath` to sandbox path grants, keeping `path` as the POSIX path visible inside the sandbox while using the native path for host authorization and Docker bind mounts. Windows paths must be drive-qualified, unsupported UnixLocal combinations fail early, and the documentation and Windows CI coverage are updated.

Native host paths are excluded from serialized session state and restored only from the current trusted manifest. Direct resumes reject unresolved redacted paths, while interrupted runs preserve runtime-agent identities so sessions can be safely rebound.