### PR TITLE
fix(sandbox): allow Docker workdirs within path grants

### DIFF
--- a/.changeset/docker-path-grant-workdirs.md
+++ b/.changeset/docker-path-grant-workdirs.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: allow Docker command workdirs within sandbox path grants (#1539)

--- a/packages/agents-core/src/sandbox/sandboxes/docker.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/docker.ts
@@ -137,6 +137,18 @@ export interface DockerSandboxSessionState extends UnixLocalSandboxSessionState 
 
 export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxSessionState> {
   private containerClosed = false;
+  private readonly mountedPathGrants: Manifest['extraPathGrants'];
+
+  constructor(args: {
+    state: DockerSandboxSessionState;
+    defaultShell?: string;
+    archiveLimits?: SandboxArchiveLimits | null;
+  }) {
+    super(args);
+    this.mountedPathGrants = args.state.manifest.extraPathGrants.map(
+      (grant) => ({ ...grant }),
+    );
+  }
 
   override async resolveFilesystemRunAs(runAs?: string): Promise<undefined> {
     if (runAs && runAs.trim().length > 0) {
@@ -435,8 +447,12 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
   }
 
   protected override resolveCommandWorkdir(path?: string): string {
-    if (this.pathUsesSplitGrant(path)) {
-      return this.resolveContainerFilesystemPath(path);
+    const resolvedPath = new WorkspacePathPolicy({
+      root: this.state.manifest.root,
+      extraPathGrants: this.mountedPathGrants,
+    }).resolve(path);
+    if (resolvedPath.grant) {
+      return resolvedPath.path;
     }
     const logicalPath = this.resolveLogicalPath(path);
     return joinSandboxLogicalPath(this.state.manifest.root, logicalPath);

--- a/packages/agents-core/src/sandbox/sandboxes/docker.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/docker.ts
@@ -435,7 +435,11 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
   }
 
   protected override resolveCommandWorkdir(path?: string): string {
-    return this.resolveContainerFilesystemPath(path);
+    if (this.pathUsesSplitGrant(path)) {
+      return this.resolveContainerFilesystemPath(path);
+    }
+    const logicalPath = this.resolveLogicalPath(path);
+    return joinSandboxLogicalPath(this.state.manifest.root, logicalPath);
   }
 
   protected override async spawnShellCommand(

--- a/packages/agents-core/src/sandbox/sandboxes/docker.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/docker.ts
@@ -435,8 +435,7 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
   }
 
   protected override resolveCommandWorkdir(path?: string): string {
-    const logicalPath = this.resolveLogicalPath(path);
-    return joinSandboxLogicalPath(this.state.manifest.root, logicalPath);
+    return this.resolveContainerFilesystemPath(path);
   }
 
   protected override async spawnShellCommand(

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -1895,7 +1895,7 @@ describe('DockerSandboxClient unit behavior', () => {
     );
   });
 
-  it('uses split path grants as command workdirs', async () => {
+  it('uses create-time path grants as command workdirs', async () => {
     processMocks.runSandboxProcess.mockImplementation(
       async (_command: string, args: string[]) => {
         if (args[0] === 'version') {
@@ -1917,6 +1917,10 @@ describe('DockerSandboxClient unit behavior', () => {
       new Manifest({
         extraPathGrants: [
           {
+            path: rootDir,
+            readOnly: true,
+          },
+          {
             path: '/mnt/shared-data',
             hostPath: rootDir,
             readOnly: true,
@@ -1925,6 +1929,25 @@ describe('DockerSandboxClient unit behavior', () => {
       }),
     );
 
+    await session.execCommand({
+      cmd: 'pwd',
+      workdir: rootDir,
+      yieldTimeMs: 0,
+    });
+    expect(childProcessMocks.spawn).toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining([
+        'exec',
+        '-i',
+        '-w',
+        rootDir,
+        'container-123',
+        'pwd',
+      ]),
+      { stdio: 'pipe' },
+    );
+
+    childProcessMocks.spawn.mockClear();
     await session.execCommand({
       cmd: 'pwd',
       workdir: '/mnt/shared-data',

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -2271,7 +2271,7 @@ describe('DockerSandboxClient unit behavior', () => {
     );
   });
 
-  it('allows extra path grants during docker manifest application for host filesystem helpers', async () => {
+  it('limits dynamically applied path grants to host filesystem helpers', async () => {
     processMocks.runSandboxProcess.mockImplementation(
       async (_command: string, args: string[]) => {
         if (args[0] === 'version') {
@@ -2295,6 +2295,13 @@ describe('DockerSandboxClient unit behavior', () => {
     );
 
     await expect(session.pathExists(rootDir)).resolves.toBe(true);
+    await expect(
+      session.execCommand({
+        cmd: 'pwd',
+        workdir: rootDir,
+      }),
+    ).rejects.toThrow();
+    expect(childProcessMocks.spawn).not.toHaveBeenCalled();
   });
 
   it('rejects applying in-container mounts that need missing Docker privileges', async () => {

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -1895,6 +1895,64 @@ describe('DockerSandboxClient unit behavior', () => {
     );
   });
 
+  it('uses split path grants as command workdirs', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation(() =>
+      dockerSpawnResult({ stdout: '/mnt/shared-data\n', status: 0 }),
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(
+      new Manifest({
+        extraPathGrants: [
+          {
+            path: '/mnt/shared-data',
+            hostPath: rootDir,
+            readOnly: true,
+          },
+        ],
+      }),
+    );
+
+    await session.execCommand({
+      cmd: 'pwd',
+      workdir: '/mnt/shared-data',
+      yieldTimeMs: 0,
+    });
+    expect(childProcessMocks.spawn).toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining([
+        'exec',
+        '-i',
+        '-w',
+        '/mnt/shared-data',
+        'container-123',
+        'pwd',
+      ]),
+      { stdio: 'pipe' },
+    );
+
+    childProcessMocks.spawn.mockClear();
+    await expect(
+      session.execCommand({
+        cmd: 'pwd',
+        workdir: '/mnt/not-granted',
+      }),
+    ).rejects.toThrow(/escapes the workspace root/);
+    expect(childProcessMocks.spawn).not.toHaveBeenCalled();
+  });
+
   it('uses the container filesystem for split path grants', async () => {
     const pngBytes = Uint8Array.from([0x89, 0x50, 0x4e, 0x47]);
     processMocks.runSandboxProcess.mockImplementation(


### PR DESCRIPTION
This pull request resolves #1539.

`DockerSandboxSession` previously resolved `execCommand` workdirs using workspace-only logical path handling. As a result, container paths covered by `extraPathGrants` were rejected before `docker exec`.

This change reuses the existing container filesystem path policy for command workdirs. Granted paths are forwarded through Docker's `-w` option, while ungranted absolute paths continue to fail before process creation. Regression coverage verifies both behaviors.