### PR TITLE
fix(sandbox): preserve verified Docker sessions across resumes

### DIFF
--- a/.changeset/preserve-docker-path-grant-sessions.md
+++ b/.changeset/preserve-docker-path-grant-sessions.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: preserve Docker path-grant sessions with verified live reuse and safe snapshot fallback

--- a/packages/agents-core/src/sandbox/client.ts
+++ b/packages/agents-core/src/sandbox/client.ts
@@ -79,6 +79,11 @@ export type SandboxPreservedSessionReuseOptions<
   TOptions extends SandboxClientOptions = SandboxClientOptions,
 > = {
   clientOptions?: TOptions;
+  /**
+   * Revalidate the entries materialized when the backend was created before
+   * reusing a same-process preserved session.
+   */
+  revalidateManifestEntries?: boolean;
 };
 
 export interface SandboxClient<

--- a/packages/agents-core/src/sandbox/client.ts
+++ b/packages/agents-core/src/sandbox/client.ts
@@ -75,6 +75,12 @@ export type SandboxSessionSerializationOptions = {
   willCloseAfterSerialize?: boolean;
 };
 
+export type SandboxPreservedSessionReuseOptions<
+  TOptions extends SandboxClientOptions = SandboxClientOptions,
+> = {
+  clientOptions?: TOptions;
+};
+
 export interface SandboxClient<
   TOptions extends SandboxClientOptions = SandboxClientOptions,
   TSessionState extends SandboxSessionState = SandboxSessionState,
@@ -92,6 +98,7 @@ export interface SandboxClient<
   ): Promise<boolean> | boolean;
   canReusePreservedOwnedSession?(
     state: TSessionState,
+    options?: SandboxPreservedSessionReuseOptions<TOptions>,
   ): Promise<boolean> | boolean;
   deserializeSessionState?(
     state: Record<string, unknown>,

--- a/packages/agents-core/src/sandbox/internal/sessionStateTrust.ts
+++ b/packages/agents-core/src/sandbox/internal/sessionStateTrust.ts
@@ -1,0 +1,14 @@
+import type { SandboxSessionState } from '../session';
+
+const runStateSessionStates = new WeakSet<object>();
+
+export function markRunStateSessionState<TState extends SandboxSessionState>(
+  state: TState,
+): TState {
+  runStateSessionStates.add(state);
+  return state;
+}
+
+export function isRunStateSessionState(state: SandboxSessionState): boolean {
+  return runStateSessionStates.has(state);
+}

--- a/packages/agents-core/src/sandbox/internal/sessionStateTrust.ts
+++ b/packages/agents-core/src/sandbox/internal/sessionStateTrust.ts
@@ -1,14 +1,31 @@
+import type { SandboxClientOptions } from '../client';
 import type { SandboxSessionState } from '../session';
+import type { SnapshotSpec } from '../snapshot';
 
-const runStateSessionStates = new WeakSet<object>();
+export type RunStateSessionTrustedConfig = {
+  clientOptions?: SandboxClientOptions;
+  snapshot?: SnapshotSpec;
+};
+
+const runStateSessionTrust = new WeakMap<
+  object,
+  RunStateSessionTrustedConfig
+>();
 
 export function markRunStateSessionState<TState extends SandboxSessionState>(
   state: TState,
+  trustedConfig: RunStateSessionTrustedConfig = {},
 ): TState {
-  runStateSessionStates.add(state);
+  runStateSessionTrust.set(state, trustedConfig);
   return state;
 }
 
 export function isRunStateSessionState(state: SandboxSessionState): boolean {
-  return runStateSessionStates.has(state);
+  return runStateSessionTrust.has(state);
+}
+
+export function getRunStateSessionTrustedConfig(
+  state: SandboxSessionState,
+): RunStateSessionTrustedConfig | undefined {
+  return runStateSessionTrust.get(state);
 }

--- a/packages/agents-core/src/sandbox/runtime/livePreservedSessions.ts
+++ b/packages/agents-core/src/sandbox/runtime/livePreservedSessions.ts
@@ -12,6 +12,7 @@ export type LivePreservedOwnedSessionEntry = {
   backendId: string;
   currentAgentName: string;
   session: SandboxSessionLike<SandboxSessionState>;
+  reuseRejected?: boolean;
 };
 
 const livePreservedOwnedSessionsByRunState = new WeakMap<
@@ -60,6 +61,45 @@ export function forgetLivePreservedOwnedSessions<TContext>(
   state: RunState<TContext, Agent<TContext, AgentOutputType>>,
 ): void {
   livePreservedOwnedSessionsByRunState.delete(state);
+}
+
+export function forgetLivePreservedOwnedSessionHandle<TContext>(args: {
+  state: RunState<TContext, Agent<TContext, AgentOutputType>> | undefined;
+  session: SandboxSessionLike<SandboxSessionState>;
+}): void {
+  if (!args.state) {
+    return;
+  }
+  const liveSessions = livePreservedOwnedSessionsByRunState.get(args.state);
+  if (!liveSessions) {
+    return;
+  }
+  for (const [agentKey, entry] of liveSessions) {
+    if (entry.session === args.session) {
+      liveSessions.delete(agentKey);
+    }
+  }
+  if (liveSessions.size === 0) {
+    livePreservedOwnedSessionsByRunState.delete(args.state);
+  }
+}
+
+export function rejectLivePreservedOwnedSessionHandle<TContext>(args: {
+  state: RunState<TContext, Agent<TContext, AgentOutputType>> | undefined;
+  session: SandboxSessionLike<SandboxSessionState>;
+}): void {
+  if (!args.state) {
+    return;
+  }
+  const liveSessions = livePreservedOwnedSessionsByRunState.get(args.state);
+  if (!liveSessions) {
+    return;
+  }
+  for (const entry of liveSessions.values()) {
+    if (entry.session === args.session) {
+      entry.reuseRejected = true;
+    }
+  }
 }
 
 export function livePreservedOwnedSessionEntries<TContext>(

--- a/packages/agents-core/src/sandbox/runtime/manager.ts
+++ b/packages/agents-core/src/sandbox/runtime/manager.ts
@@ -919,6 +919,16 @@ export class SandboxRuntimeManager<TContext> {
     }
 
     if (this.sandboxConfig?.sessionState) {
+      if (
+        client.backendId === 'docker' &&
+        Object.keys(this.sandboxConfig.sessionState.manifest.environment).some(
+          (key) => !(key in trustedManifest.environment),
+        )
+      ) {
+        throw new UserError(
+          'Docker sandbox session state cannot be resumed because the current trusted manifest removes an environment variable. Start a fresh session from a snapshot instead.',
+        );
+      }
       const sessionState = rebindPersistedPathGrants(
         this.sandboxConfig.sessionState,
         trustedManifest,
@@ -926,6 +936,12 @@ export class SandboxRuntimeManager<TContext> {
           replaceWithTrustedManifest: client.backendId === 'docker',
         },
       );
+      if (client.backendId === 'docker') {
+        sessionState.environment = {
+          ...(sessionState.environment ?? {}),
+          ...(await trustedManifest.resolveEnvironment()),
+        };
+      }
       assertHostPathGrantsRebound(sessionState);
       return await withSandboxSpan(
         'sandbox.resume_session',
@@ -1000,6 +1016,26 @@ export class SandboxRuntimeManager<TContext> {
       return liveEntry;
     }
 
+    const trustedManifest = args.trustedManifest;
+    if (
+      args.client.backendId === 'docker' &&
+      trustedManifest &&
+      Object.keys(liveEntry.session.state.manifest.environment).some(
+        (key) => !(key in trustedManifest.environment),
+      )
+    ) {
+      rejectLivePreservedOwnedSessionHandle({
+        state: this.runState,
+        session: liveEntry.session,
+      });
+      await cleanupSandboxSession(liveEntry.session);
+      forgetLivePreservedOwnedSessionHandle({
+        state: this.runState,
+        session: liveEntry.session,
+      });
+      return undefined;
+    }
+
     const candidateState = args.trustedManifest
       ? rebindPersistedPathGrants(
           liveEntry.session.state,
@@ -1032,13 +1068,16 @@ export class SandboxRuntimeManager<TContext> {
     // matches the current trusted manifest.
     liveEntry.session.state.manifest =
       args.client.backendId === 'docker' && args.trustedManifest
-        ? rebindPersistedPathGrants(
-            liveEntry.session.state,
+        ? manifestWithTrustedEnvironment(
+            rebindPersistedPathGrants(
+              liveEntry.session.state,
+              args.trustedManifest,
+              {
+                replaceWithTrustedGrantSet: true,
+              },
+            ).manifest,
             args.trustedManifest,
-            {
-              replaceWithTrustedGrantSet: true,
-            },
-          ).manifest
+          )
         : candidateState.manifest;
     if (args.client.backendId === 'docker') {
       liveEntry.session.state.environment = candidateState.environment;
@@ -1254,6 +1293,27 @@ function isDefaultManifest(manifest: Manifest): boolean {
     manifest.extraPathGrants.length === 0 &&
     isDefaultRemoteMountCommandAllowlist(manifest.remoteMountCommandAllowlist)
   );
+}
+
+function manifestWithTrustedEnvironment(
+  manifest: Manifest,
+  trustedManifest: Manifest,
+): Manifest {
+  return new Manifest({
+    version: manifest.version,
+    root: manifest.root,
+    entries: structuredClone(manifest.entries),
+    environment: Object.fromEntries(
+      Object.entries(trustedManifest.environment).map(([key, value]) => [
+        key,
+        value.init(),
+      ]),
+    ),
+    users: structuredClone(manifest.users),
+    groups: structuredClone(manifest.groups),
+    extraPathGrants: structuredClone(manifest.extraPathGrants),
+    remoteMountCommandAllowlist: [...manifest.remoteMountCommandAllowlist],
+  });
 }
 
 function removeClosedPreservedOwnedSessions(

--- a/packages/agents-core/src/sandbox/runtime/manager.ts
+++ b/packages/agents-core/src/sandbox/runtime/manager.ts
@@ -38,10 +38,13 @@ import {
 } from './agentKeys';
 import {
   forgetLivePreservedOwnedSessions,
+  forgetLivePreservedOwnedSessionHandle,
   livePreservedOwnedSessionEntries,
   livePreservedOwnedSession,
   preservedOwnedSessionAgentKeysWithoutLiveReuse,
+  rejectLivePreservedOwnedSessionHandle,
   rememberLivePreservedOwnedSessions,
+  type LivePreservedOwnedSessionEntry,
 } from './livePreservedSessions';
 import { applyManifestToProvidedSession } from './providedSessionManifest';
 import { serializeSandboxRuntimeState } from './sessionSerialization';
@@ -78,6 +81,7 @@ type SandboxCleanupPlan = {
   afterOwnedSessionClose?: {
     clearSandboxState?: boolean;
     forgetLivePreservedSessions?: boolean;
+    removeClosedSessionsFromSandboxState?: boolean;
   };
   deferredError?: unknown;
 };
@@ -239,7 +243,6 @@ export class SandboxRuntimeManager<TContext> {
           onCloseError: () => {
             preserveCleanupHandles = true;
           },
-          preserveOwnedSessions,
           tracingParent: cleanupSpan,
         });
       } finally {
@@ -351,6 +354,7 @@ export class SandboxRuntimeManager<TContext> {
         cleanupPlan.ownedSessionCloseTarget = 'all';
         cleanupPlan.afterOwnedSessionClose = {
           forgetLivePreservedSessions: true,
+          removeClosedSessionsFromSandboxState: true,
         };
       }
     }
@@ -379,20 +383,25 @@ export class SandboxRuntimeManager<TContext> {
       hasPreservedOwnedSessions(sandboxState) &&
       !options.preserveOwnedSessions
     ) {
-      const closedLiveSessionAgentKeys =
+      const { closedAgentKeys, closeErrors } =
         await this.closeLivePreservedOwnedSessions(state);
-      if (closedLiveSessionAgentKeys.size > 0) {
-        forgetLivePreservedOwnedSessions(state);
+      if (closedAgentKeys.size > 0) {
         if (
           sandboxState &&
-          !removeClosedPreservedOwnedSessions(
-            sandboxState,
-            closedLiveSessionAgentKeys,
-          )
+          !removeClosedPreservedOwnedSessions(sandboxState, closedAgentKeys)
         ) {
           state._sandbox = undefined;
           sandboxState = undefined;
         }
+      }
+      if (closeErrors.length === 1) {
+        throw closeErrors[0];
+      }
+      if (closeErrors.length > 1) {
+        throw new SandboxLifecycleError(
+          'Failed to close one or more live preserved owned sandbox sessions.',
+          { errors: closeErrors },
+        );
       }
 
       if (hasPreservedOwnedSessions(sandboxState)) {
@@ -418,7 +427,7 @@ export class SandboxRuntimeManager<TContext> {
           cleanupPlan.ownedSessionCloseTarget = undefined;
           cleanupPlan.afterOwnedSessionClose = undefined;
         }
-      } else if (closedLiveSessionAgentKeys.size > 0) {
+      } else if (closedAgentKeys.size > 0) {
         state._sandbox = undefined;
       }
     } else if (!hasPreservedOwnedSessions(sandboxState)) {
@@ -434,20 +443,17 @@ export class SandboxRuntimeManager<TContext> {
     plan: SandboxCleanupPlan,
     options: {
       onCloseError: () => void;
-      preserveOwnedSessions: boolean;
       tracingParent?: Span<any> | Trace;
     },
   ): Promise<void> {
     if (plan.ownedSessionCloseTarget) {
+      let closedSessionAgentKeys: ReadonlySet<string>;
       try {
-        await this.closeOwnedSessions(
+        closedSessionAgentKeys = await this.closeOwnedSessions(
           plan.ownedSessionCloseTarget === 'all'
             ? undefined
             : plan.ownedSessionCloseTarget,
-          {
-            preserveOwnedSessions: options.preserveOwnedSessions,
-            tracingParent: options.tracingParent,
-          },
+          { tracingParent: options.tracingParent },
         );
       } catch (error) {
         options.onCloseError();
@@ -456,6 +462,15 @@ export class SandboxRuntimeManager<TContext> {
 
       if (plan.afterOwnedSessionClose?.forgetLivePreservedSessions) {
         forgetLivePreservedOwnedSessions(state);
+      }
+      if (plan.afterOwnedSessionClose?.removeClosedSessionsFromSandboxState) {
+        const sandboxState = getSerializedSandboxState(state);
+        if (
+          sandboxState &&
+          !removeClosedSerializedSessions(sandboxState, closedSessionAgentKeys)
+        ) {
+          state._sandbox = undefined;
+        }
       }
       if (plan.afterOwnedSessionClose?.clearSandboxState) {
         state._sandbox = undefined;
@@ -469,7 +484,10 @@ export class SandboxRuntimeManager<TContext> {
 
   private async closeLivePreservedOwnedSessions(
     state: RunState<TContext, Agent<TContext, AgentOutputType>>,
-  ): Promise<Set<string>> {
+  ): Promise<{
+    closedAgentKeys: Set<string>;
+    closeErrors: unknown[];
+  }> {
     const sessionAgentKeys = new Map<
       SandboxSessionLike<SandboxSessionState>,
       string[]
@@ -482,8 +500,10 @@ export class SandboxRuntimeManager<TContext> {
     const closedAgentKeys = new Set<string>();
     const closeErrors: unknown[] = [];
     for (const [session, agentKeys] of sessionAgentKeys) {
+      rejectLivePreservedOwnedSessionHandle({ state, session });
       try {
         await cleanupSandboxSession(session);
+        forgetLivePreservedOwnedSessionHandle({ state, session });
         for (const agentKey of agentKeys) {
           closedAgentKeys.add(agentKey);
         }
@@ -491,16 +511,7 @@ export class SandboxRuntimeManager<TContext> {
         closeErrors.push(error);
       }
     }
-    if (closeErrors.length === 1) {
-      throw closeErrors[0];
-    }
-    if (closeErrors.length > 1) {
-      throw new SandboxLifecycleError(
-        'Failed to close one or more live preserved owned sandbox sessions.',
-        { errors: closeErrors },
-      );
-    }
-    return closedAgentKeys;
+    return { closedAgentKeys, closeErrors };
   }
 
   private async runPreStopHooksBeforeRelease(): Promise<void> {
@@ -604,15 +615,13 @@ export class SandboxRuntimeManager<TContext> {
       if (this.sessionsByAgentKey.has(agentKey)) {
         continue;
       }
-      const liveEntry = livePreservedOwnedSession({
-        runState: this.runState,
+      const liveEntry = await this.reusableLivePreservedOwnedSession({
         client,
         agentKey,
         serializedEntry: entry,
+        trustedManifest: this.resolveTrustedManifestForAgentKey(agentKey),
       });
       if (liveEntry) {
-        // Same RunState can resume immediately without round-tripping through provider
-        // reconnect APIs when the backend says its live handle is reusable.
         this.sessionsByAgentKey.set(agentKey, liveEntry.session);
         this.sessionAgentNamesByKey.set(agentKey, liveEntry.currentAgentName);
         this.ownedSessionAgentKeys.add(agentKey);
@@ -894,11 +903,11 @@ export class SandboxRuntimeManager<TContext> {
       }
       return undefined;
     }
-    const liveEntry = livePreservedOwnedSession({
-      runState: this.runState,
+    const liveEntry = await this.reusableLivePreservedOwnedSession({
       client,
       agentKey,
       serializedEntry,
+      trustedManifest,
     });
     if (liveEntry) {
       return liveEntry.session;
@@ -908,6 +917,9 @@ export class SandboxRuntimeManager<TContext> {
       const sessionState = rebindPersistedPathGrants(
         this.sandboxConfig.sessionState,
         trustedManifest,
+        {
+          replaceWithTrustedManifest: client.backendId === 'docker',
+        },
       );
       assertHostPathGrantsRebound(sessionState);
       return await withSandboxSpan(
@@ -945,6 +957,73 @@ export class SandboxRuntimeManager<TContext> {
         }),
       tracingParent,
     );
+  }
+
+  private async reusableLivePreservedOwnedSession(args: {
+    client: SandboxClient;
+    agentKey: string;
+    serializedEntry: ReturnType<typeof getSerializedSessionEntryForAgent>;
+    trustedManifest?: Manifest;
+  }): Promise<LivePreservedOwnedSessionEntry | undefined> {
+    const liveEntry = livePreservedOwnedSession({
+      runState: this.runState,
+      client: args.client,
+      agentKey: args.agentKey,
+      serializedEntry: args.serializedEntry,
+    });
+    if (!liveEntry) {
+      return undefined;
+    }
+
+    if (liveEntry.reuseRejected) {
+      await cleanupSandboxSession(liveEntry.session);
+      forgetLivePreservedOwnedSessionHandle({
+        state: this.runState,
+        session: liveEntry.session,
+      });
+      return undefined;
+    }
+
+    const canReuse = args.client.canReusePreservedOwnedSession;
+    if (!canReuse) {
+      return liveEntry;
+    }
+
+    const candidateState = args.trustedManifest
+      ? rebindPersistedPathGrants(
+          liveEntry.session.state,
+          args.trustedManifest,
+          {
+            replaceWithTrustedManifest: args.client.backendId === 'docker',
+          },
+        )
+      : liveEntry.session.state;
+    if (!(await canReuse.call(args.client, candidateState))) {
+      rejectLivePreservedOwnedSessionHandle({
+        state: this.runState,
+        session: liveEntry.session,
+      });
+      await cleanupSandboxSession(liveEntry.session);
+      forgetLivePreservedOwnedSessionHandle({
+        state: this.runState,
+        session: liveEntry.session,
+      });
+      return undefined;
+    }
+
+    // Rebind only after the backend has verified that its live authority still
+    // matches the current trusted manifest.
+    liveEntry.session.state.manifest =
+      args.client.backendId === 'docker' && args.trustedManifest
+        ? rebindPersistedPathGrants(
+            liveEntry.session.state,
+            args.trustedManifest,
+            {
+              replaceWithTrustedGrantSet: true,
+            },
+          ).manifest
+        : candidateState.manifest;
+    return liveEntry;
   }
 
   private async serializeState(
@@ -1060,28 +1139,36 @@ export class SandboxRuntimeManager<TContext> {
   private async closeOwnedSessions(
     agentKeys?: Iterable<string>,
     options: {
-      preserveOwnedSessions?: boolean;
       tracingParent?: Span<any> | Trace;
     } = {},
-  ): Promise<void> {
+  ): Promise<ReadonlySet<string>> {
     const keysToClose = [...(agentKeys ?? this.ownedSessionAgentKeys)].filter(
       (agentKey) => this.ownedSessionAgentKeys.has(agentKey),
     );
     const sessionsToClose = new Map<
       SandboxSessionLike<SandboxSessionState>,
-      string | undefined
+      {
+        agentKeys: string[];
+        agentName: string | undefined;
+      }
     >();
     for (const agentKey of keysToClose) {
       const session = this.sessionsByAgentKey.get(agentKey);
       if (!session || !hasSessionCleanup(session)) {
         continue;
       }
-      if (!sessionsToClose.has(session)) {
-        sessionsToClose.set(session, this.sessionAgentNamesByKey.get(agentKey));
+      const existing = sessionsToClose.get(session);
+      if (existing) {
+        existing.agentKeys.push(agentKey);
+      } else {
+        sessionsToClose.set(session, {
+          agentKeys: [agentKey],
+          agentName: this.sessionAgentNamesByKey.get(agentKey),
+        });
       }
     }
     if (sessionsToClose.size === 0) {
-      return;
+      return new Set();
     }
 
     await withSandboxSpan(
@@ -1091,19 +1178,18 @@ export class SandboxRuntimeManager<TContext> {
       },
       async (cleanupSessionsSpan) => {
         await Promise.all(
-          [...sessionsToClose].map(async ([session, agentName]) => {
+          [...sessionsToClose].map(async ([session, { agentName }]) => {
             await withSandboxSpan(
               'sandbox.shutdown',
               {
                 agent_name: agentName,
               },
               async () => {
-                await cleanupSandboxSession(
+                rejectLivePreservedOwnedSessionHandle({
+                  state: this.runState,
                   session,
-                  options.preserveOwnedSessions
-                    ? { preserveOwnedSessions: true }
-                    : undefined,
-                );
+                });
+                await cleanupSandboxSession(session);
               },
               cleanupSessionsSpan,
             );
@@ -1111,6 +1197,9 @@ export class SandboxRuntimeManager<TContext> {
         );
       },
       options.tracingParent,
+    );
+    return new Set(
+      [...sessionsToClose.values()].flatMap(({ agentKeys }) => agentKeys),
     );
   }
 
@@ -1151,11 +1240,27 @@ function removeClosedPreservedOwnedSessions(
   sandboxState: SerializedSandboxState,
   agentKeys: ReadonlySet<string>,
 ): boolean {
+  return removeClosedSerializedSessions(sandboxState, agentKeys, {
+    requirePreservedSession: true,
+  });
+}
+
+function removeClosedSerializedSessions(
+  sandboxState: SerializedSandboxState,
+  agentKeys: ReadonlySet<string>,
+  options: {
+    requirePreservedSession?: boolean;
+  } = {},
+): boolean {
   for (const agentKey of agentKeys) {
     delete sandboxState.sessionsByAgent[agentKey];
   }
 
-  if (!hasPreservedOwnedSessions(sandboxState)) {
+  const remainingEntries = Object.values(sandboxState.sessionsByAgent);
+  if (
+    options.requirePreservedSession &&
+    !remainingEntries.some((entry) => entry.preservedOwnedSession)
+  ) {
     return false;
   }
 
@@ -1167,9 +1272,9 @@ function removeClosedPreservedOwnedSessions(
     return true;
   }
 
-  const nextEntry = Object.values(sandboxState.sessionsByAgent).find(
-    (entry) => entry.preservedOwnedSession,
-  );
+  const nextEntry = options.requirePreservedSession
+    ? remainingEntries.find((entry) => entry.preservedOwnedSession)
+    : remainingEntries[0];
   if (!nextEntry) {
     return false;
   }

--- a/packages/agents-core/src/sandbox/runtime/manager.ts
+++ b/packages/agents-core/src/sandbox/runtime/manager.ts
@@ -1051,7 +1051,11 @@ export class SandboxRuntimeManager<TContext> {
         ...(await args.trustedManifest.resolveEnvironment()),
       };
     }
-    if (!(await canReuse.call(args.client, candidateState))) {
+    if (
+      !(await canReuse.call(args.client, candidateState, {
+        clientOptions: this.sandboxConfig?.options,
+      }))
+    ) {
       rejectLivePreservedOwnedSessionHandle({
         state: this.runState,
         session: liveEntry.session,
@@ -1103,6 +1107,7 @@ export class SandboxRuntimeManager<TContext> {
       sessionsByAgentKey: this.sessionsByAgentKey,
       sessionAgentNamesByKey: this.sessionAgentNamesByKey,
       ownedSessionAgentKeys: this.ownedSessionAgentKeys,
+      clientOptions: this.sandboxConfig?.options,
       includeOwnedSessions: args.includeOwnedSessions,
       preferredCurrentAgentKey,
     });

--- a/packages/agents-core/src/sandbox/runtime/manager.ts
+++ b/packages/agents-core/src/sandbox/runtime/manager.ts
@@ -59,6 +59,7 @@ import {
   runSandboxSessionPreStopHooks,
 } from './sessionLifecycle';
 import {
+  assertTrustedManifestForDockerRunState,
   deserializeSandboxSessionStateEntry,
   getPreviousSerializedSessionsByAgent,
   getSerializedSandboxState,
@@ -636,6 +637,10 @@ export class SandboxRuntimeManager<TContext> {
         client,
         entry,
         this.resolveTrustedManifestForAgentKey(agentKey),
+        {
+          clientOptions: this.sandboxConfig?.options,
+          snapshot: this.sandboxConfig?.snapshot,
+        },
       );
       if (!serializedState) {
         continue;
@@ -940,6 +945,10 @@ export class SandboxRuntimeManager<TContext> {
       client,
       serializedEntry,
       trustedManifest,
+      {
+        clientOptions: this.sandboxConfig?.options,
+        snapshot: this.sandboxConfig?.snapshot,
+      },
     );
     if (!serializedState) {
       return undefined;
@@ -975,6 +984,8 @@ export class SandboxRuntimeManager<TContext> {
       return undefined;
     }
 
+    assertTrustedManifestForDockerRunState(args.client, args.trustedManifest);
+
     if (liveEntry.reuseRejected) {
       await cleanupSandboxSession(liveEntry.session);
       forgetLivePreservedOwnedSessionHandle({
@@ -998,6 +1009,12 @@ export class SandboxRuntimeManager<TContext> {
           },
         )
       : liveEntry.session.state;
+    if (args.client.backendId === 'docker' && args.trustedManifest) {
+      candidateState.environment = {
+        ...(liveEntry.session.state.environment ?? {}),
+        ...(await args.trustedManifest.resolveEnvironment()),
+      };
+    }
     if (!(await canReuse.call(args.client, candidateState))) {
       rejectLivePreservedOwnedSessionHandle({
         state: this.runState,
@@ -1023,6 +1040,9 @@ export class SandboxRuntimeManager<TContext> {
             },
           ).manifest
         : candidateState.manifest;
+    if (args.client.backendId === 'docker') {
+      liveEntry.session.state.environment = candidateState.environment;
+    }
     return liveEntry;
   }
 

--- a/packages/agents-core/src/sandbox/runtime/manager.ts
+++ b/packages/agents-core/src/sandbox/runtime/manager.ts
@@ -87,6 +87,11 @@ type SandboxCleanupPlan = {
   deferredError?: unknown;
 };
 
+type LivePreservedOwnedSessionReuseDecision = {
+  entry: LivePreservedOwnedSessionEntry;
+  reusable: boolean;
+};
+
 type SandboxAgentIdentityRegistry = {
   agentKeys: Map<number, string>;
   agentsByKey: Map<string, Agent<any, AgentOutputType>>;
@@ -616,15 +621,18 @@ export class SandboxRuntimeManager<TContext> {
       if (this.sessionsByAgentKey.has(agentKey)) {
         continue;
       }
-      const liveEntry = await this.reusableLivePreservedOwnedSession({
+      const liveDecision = await this.inspectLivePreservedOwnedSessionReuse({
         client,
         agentKey,
         serializedEntry: entry,
         trustedManifest: this.resolveTrustedManifestForAgentKey(agentKey),
       });
-      if (liveEntry) {
-        this.sessionsByAgentKey.set(agentKey, liveEntry.session);
-        this.sessionAgentNamesByKey.set(agentKey, liveEntry.currentAgentName);
+      if (liveDecision?.reusable) {
+        this.sessionsByAgentKey.set(agentKey, liveDecision.entry.session);
+        this.sessionAgentNamesByKey.set(
+          agentKey,
+          liveDecision.entry.currentAgentName,
+        );
         this.ownedSessionAgentKeys.add(agentKey);
         continue;
       }
@@ -633,6 +641,8 @@ export class SandboxRuntimeManager<TContext> {
           'Sandbox client must implement resume() to restore preserved sandbox sessions.',
         );
       }
+      const rejectedLiveEntry =
+        await this.prepareRejectedLiveSessionReplacement(client, liveDecision);
       const serializedState = await deserializeSandboxSessionStateEntry(
         client,
         entry,
@@ -645,7 +655,7 @@ export class SandboxRuntimeManager<TContext> {
       if (!serializedState) {
         continue;
       }
-      const session = await withSandboxSpan(
+      let session = await withSandboxSpan(
         'sandbox.resume_session',
         {
           agent_name: entry.currentAgentName,
@@ -656,6 +666,10 @@ export class SandboxRuntimeManager<TContext> {
             archiveLimits: this.sandboxConfig?.archiveLimits,
           }),
         tracingParent,
+      );
+      session = await this.replaceRejectedLiveSession(
+        rejectedLiveEntry,
+        session,
       );
       this.applyArchiveLimits(session);
       this.sessionsByAgentKey.set(agentKey, session);
@@ -908,15 +922,19 @@ export class SandboxRuntimeManager<TContext> {
       }
       return undefined;
     }
-    const liveEntry = await this.reusableLivePreservedOwnedSession({
+    const liveDecision = await this.inspectLivePreservedOwnedSessionReuse({
       client,
       agentKey,
       serializedEntry,
       trustedManifest,
     });
-    if (liveEntry) {
-      return liveEntry.session;
+    if (liveDecision?.reusable) {
+      return liveDecision.entry.session;
     }
+    const rejectedLiveEntry = await this.prepareRejectedLiveSessionReplacement(
+      client,
+      liveDecision,
+    );
 
     if (this.sandboxConfig?.sessionState) {
       if (
@@ -943,7 +961,7 @@ export class SandboxRuntimeManager<TContext> {
         };
       }
       assertHostPathGrantsRebound(sessionState);
-      return await withSandboxSpan(
+      const session = await withSandboxSpan(
         'sandbox.resume_session',
         {
           agent_name: agent.name,
@@ -955,6 +973,7 @@ export class SandboxRuntimeManager<TContext> {
           }),
         tracingParent,
       );
+      return await this.replaceRejectedLiveSession(rejectedLiveEntry, session);
     }
 
     const serializedState = await deserializeSandboxSessionStateEntry(
@@ -970,7 +989,7 @@ export class SandboxRuntimeManager<TContext> {
       return undefined;
     }
 
-    return await withSandboxSpan(
+    const session = await withSandboxSpan(
       'sandbox.resume_session',
       {
         agent_name: agent.name,
@@ -982,14 +1001,15 @@ export class SandboxRuntimeManager<TContext> {
         }),
       tracingParent,
     );
+    return await this.replaceRejectedLiveSession(rejectedLiveEntry, session);
   }
 
-  private async reusableLivePreservedOwnedSession(args: {
+  private async inspectLivePreservedOwnedSessionReuse(args: {
     client: SandboxClient;
     agentKey: string;
     serializedEntry: ReturnType<typeof getSerializedSessionEntryForAgent>;
     trustedManifest?: Manifest;
-  }): Promise<LivePreservedOwnedSessionEntry | undefined> {
+  }): Promise<LivePreservedOwnedSessionReuseDecision | undefined> {
     const liveEntry = livePreservedOwnedSession({
       runState: this.runState,
       client: args.client,
@@ -1003,17 +1023,12 @@ export class SandboxRuntimeManager<TContext> {
     assertTrustedManifestForDockerRunState(args.client, args.trustedManifest);
 
     if (liveEntry.reuseRejected) {
-      await cleanupSandboxSession(liveEntry.session);
-      forgetLivePreservedOwnedSessionHandle({
-        state: this.runState,
-        session: liveEntry.session,
-      });
-      return undefined;
+      return { entry: liveEntry, reusable: false };
     }
 
     const canReuse = args.client.canReusePreservedOwnedSession;
     if (!canReuse) {
-      return liveEntry;
+      return { entry: liveEntry, reusable: true };
     }
 
     const trustedManifest = args.trustedManifest;
@@ -1028,12 +1043,7 @@ export class SandboxRuntimeManager<TContext> {
         state: this.runState,
         session: liveEntry.session,
       });
-      await cleanupSandboxSession(liveEntry.session);
-      forgetLivePreservedOwnedSessionHandle({
-        state: this.runState,
-        session: liveEntry.session,
-      });
-      return undefined;
+      return { entry: liveEntry, reusable: false };
     }
 
     const candidateState = args.trustedManifest
@@ -1054,25 +1064,21 @@ export class SandboxRuntimeManager<TContext> {
     if (
       !(await canReuse.call(args.client, candidateState, {
         clientOptions: this.sandboxConfig?.options,
+        revalidateManifestEntries: true,
       }))
     ) {
       rejectLivePreservedOwnedSessionHandle({
         state: this.runState,
         session: liveEntry.session,
       });
-      await cleanupSandboxSession(liveEntry.session);
-      forgetLivePreservedOwnedSessionHandle({
-        state: this.runState,
-        session: liveEntry.session,
-      });
-      return undefined;
+      return { entry: liveEntry, reusable: false };
     }
 
     // Rebind only after the backend has verified that its live authority still
     // matches the current trusted manifest.
     liveEntry.session.state.manifest =
       args.client.backendId === 'docker' && args.trustedManifest
-        ? manifestWithTrustedEnvironment(
+        ? manifestWithTrustedRuntimePolicies(
             rebindPersistedPathGrants(
               liveEntry.session.state,
               args.trustedManifest,
@@ -1086,7 +1092,55 @@ export class SandboxRuntimeManager<TContext> {
     if (args.client.backendId === 'docker') {
       liveEntry.session.state.environment = candidateState.environment;
     }
-    return liveEntry;
+    return { entry: liveEntry, reusable: true };
+  }
+
+  private async prepareRejectedLiveSessionReplacement(
+    client: SandboxClient,
+    decision: LivePreservedOwnedSessionReuseDecision | undefined,
+  ): Promise<LivePreservedOwnedSessionEntry | undefined> {
+    if (!decision || decision.reusable) {
+      return undefined;
+    }
+    if (client.backendId === 'docker') {
+      return decision.entry;
+    }
+    await cleanupSandboxSession(decision.entry.session);
+    forgetLivePreservedOwnedSessionHandle({
+      state: this.runState,
+      session: decision.entry.session,
+    });
+    return undefined;
+  }
+
+  private async replaceRejectedLiveSession(
+    rejectedEntry: LivePreservedOwnedSessionEntry | undefined,
+    replacement: SandboxSessionLike<SandboxSessionState>,
+  ): Promise<SandboxSessionLike<SandboxSessionState>> {
+    if (!rejectedEntry) {
+      return replacement;
+    }
+
+    try {
+      await cleanupSandboxSession(rejectedEntry.session);
+    } catch (rejectedCleanupError) {
+      try {
+        await cleanupSandboxSession(replacement);
+      } catch (replacementCleanupError) {
+        throw new SandboxLifecycleError(
+          'Failed to close the rejected live sandbox session and its replacement.',
+          {
+            errors: [rejectedCleanupError, replacementCleanupError],
+          },
+        );
+      }
+      throw rejectedCleanupError;
+    }
+    forgetLivePreservedOwnedSessionHandle({
+      state: this.runState,
+      session: rejectedEntry.session,
+    });
+    return replacement;
   }
 
   private async serializeState(
@@ -1300,7 +1354,7 @@ function isDefaultManifest(manifest: Manifest): boolean {
   );
 }
 
-function manifestWithTrustedEnvironment(
+function manifestWithTrustedRuntimePolicies(
   manifest: Manifest,
   trustedManifest: Manifest,
 ): Manifest {
@@ -1317,7 +1371,9 @@ function manifestWithTrustedEnvironment(
     users: structuredClone(manifest.users),
     groups: structuredClone(manifest.groups),
     extraPathGrants: structuredClone(manifest.extraPathGrants),
-    remoteMountCommandAllowlist: [...manifest.remoteMountCommandAllowlist],
+    remoteMountCommandAllowlist: [
+      ...trustedManifest.remoteMountCommandAllowlist,
+    ],
   });
 }
 

--- a/packages/agents-core/src/sandbox/runtime/sessionSerialization.ts
+++ b/packages/agents-core/src/sandbox/runtime/sessionSerialization.ts
@@ -63,7 +63,8 @@ export async function serializeSandboxRuntimeState(args: {
     const providerState = await client.serializeSessionState(session.state, {
       preserveOwnedSession: isOwnedSession && !!includeOwnedSessions,
       reuseLiveSession,
-      willCloseAfterSerialize: isOwnedSession && !includeOwnedSessions,
+      willCloseAfterSerialize:
+        isOwnedSession && (!includeOwnedSessions || !reuseLiveSession),
     });
     sessionsByAgent[currentAgentKey] = {
       backendId: client.backendId,

--- a/packages/agents-core/src/sandbox/runtime/sessionSerialization.ts
+++ b/packages/agents-core/src/sandbox/runtime/sessionSerialization.ts
@@ -1,4 +1,4 @@
-import type { SandboxClient } from '../client';
+import type { SandboxClient, SandboxClientOptions } from '../client';
 import type { SandboxSessionLike, SandboxSessionState } from '../session';
 import {
   getPreviousSerializedSessionsByAgent,
@@ -16,6 +16,7 @@ export async function serializeSandboxRuntimeState(args: {
   >;
   sessionAgentNamesByKey: ReadonlyMap<string, string>;
   ownedSessionAgentKeys: ReadonlySet<string>;
+  clientOptions?: SandboxClientOptions;
   includeOwnedSessions?: boolean;
   preferredCurrentAgentKey?: string;
 }): Promise<SerializedSandboxState | undefined> {
@@ -25,6 +26,7 @@ export async function serializeSandboxRuntimeState(args: {
     sessionsByAgentKey,
     sessionAgentNamesByKey,
     ownedSessionAgentKeys,
+    clientOptions,
     includeOwnedSessions,
     preferredCurrentAgentKey,
   } = args;
@@ -56,7 +58,9 @@ export async function serializeSandboxRuntimeState(args: {
       isOwnedSession &&
       includeOwnedSessions &&
       client.canReusePreservedOwnedSession
-        ? await client.canReusePreservedOwnedSession(session.state)
+        ? await client.canReusePreservedOwnedSession(session.state, {
+            clientOptions,
+          })
         : true;
     // Start from previous entries so handoff agents that were not touched this turn
     // keep their sandbox sessions in the RunState.

--- a/packages/agents-core/src/sandbox/runtime/sessionState.ts
+++ b/packages/agents-core/src/sandbox/runtime/sessionState.ts
@@ -16,7 +16,10 @@ import {
   serializeManifest,
   serializeManifestRecord,
 } from '../sandboxes/shared/manifestPersistence';
-import { markRunStateSessionState } from '../internal/sessionStateTrust';
+import {
+  markRunStateSessionState,
+  type RunStateSessionTrustedConfig,
+} from '../internal/sessionStateTrust';
 
 export type SerializedSandboxSessionEntry = {
   backendId: string;
@@ -108,6 +111,7 @@ export async function deserializeSandboxSessionStateEntry(
   client: SandboxClient,
   serializedEntry: SerializedSandboxSessionEntry | undefined,
   trustedManifest?: Manifest,
+  trustedConfig: RunStateSessionTrustedConfig = {},
 ): Promise<SandboxSessionState | undefined> {
   if (!serializedEntry) {
     return undefined;
@@ -117,6 +121,7 @@ export async function deserializeSandboxSessionStateEntry(
       'RunState sandbox backend does not match the configured sandbox client.',
     );
   }
+  assertTrustedManifestForDockerRunState(client, trustedManifest);
   if (!client.deserializeSessionState) {
     throw new UserError(
       'Sandbox client must implement deserializeSessionState() to resume RunState sandbox state.',
@@ -142,7 +147,18 @@ export async function deserializeSandboxSessionStateEntry(
     },
   );
   assertHostPathGrantsRebound(reboundState);
-  return markRunStateSessionState(reboundState);
+  return markRunStateSessionState(reboundState, trustedConfig);
+}
+
+export function assertTrustedManifestForDockerRunState(
+  client: SandboxClient,
+  trustedManifest: Manifest | undefined,
+): void {
+  if (client.backendId === 'docker' && trustedManifest === undefined) {
+    throw new UserError(
+      'Docker RunState resume requires a current trusted manifest for the sandbox agent.',
+    );
+  }
 }
 
 function providerStateWithSdkEnvelopeFields(

--- a/packages/agents-core/src/sandbox/runtime/sessionState.ts
+++ b/packages/agents-core/src/sandbox/runtime/sessionState.ts
@@ -16,6 +16,7 @@ import {
   serializeManifest,
   serializeManifestRecord,
 } from '../sandboxes/shared/manifestPersistence';
+import { markRunStateSessionState } from '../internal/sessionStateTrust';
 
 export type SerializedSandboxSessionEntry = {
   backendId: string;
@@ -64,7 +65,7 @@ export function toSessionStateEnvelope(
     // Keep provider-owned fields separate from the SDK envelope so version and backend
     // checks can run before deserializing provider-specific state.
     providerState: {
-      ...providerStateWithoutSdkEnvelopeFields(providerState),
+      ...providerStateWithoutSdkEnvelopeFields(providerState, backendId),
       ...serializeHostPathGrantRedactionMetadata(state),
     },
   };
@@ -72,9 +73,13 @@ export function toSessionStateEnvelope(
 
 function providerStateWithoutSdkEnvelopeFields(
   providerState: Record<string, unknown>,
+  backendId: string,
 ): Record<string, unknown> {
   const sanitized = { ...providerState };
   delete sanitized.manifest;
+  if (backendId === 'docker') {
+    delete sanitized.sessionIdentity;
+  }
   delete sanitized.snapshot;
   delete sanitized.snapshotFingerprint;
   delete sanitized.snapshotFingerprintVersion;
@@ -122,22 +127,32 @@ export async function deserializeSandboxSessionStateEntry(
   const state = await client.deserializeSessionState(
     providerStateWithSdkEnvelopeFields(envelope),
   );
+  if (client.backendId === 'docker') {
+    delete state.sessionIdentity;
+  }
   const reboundState = rebindPersistedPathGrants(
     {
       ...state,
       ...deserializeHostPathGrantRedactionMetadata(envelope.providerState),
     },
     trustedManifest,
+    {
+      replaceWithTrustedManifest:
+        client.backendId === 'docker' && trustedManifest !== undefined,
+    },
   );
   assertHostPathGrantsRebound(reboundState);
-  return reboundState;
+  return markRunStateSessionState(reboundState);
 }
 
 function providerStateWithSdkEnvelopeFields(
   envelope: SandboxSessionStateEnvelope,
 ): Record<string, unknown> {
   return {
-    ...envelope.providerState,
+    ...providerStateWithoutSdkEnvelopeFields(
+      envelope.providerState,
+      envelope.backendId,
+    ),
     manifest: envelope.manifest,
     ...(envelope.snapshot !== undefined ? { snapshot: envelope.snapshot } : {}),
     ...(envelope.snapshotFingerprint !== undefined

--- a/packages/agents-core/src/sandbox/sandboxes/docker.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/docker.ts
@@ -13,7 +13,7 @@ import {
   SandboxUnsupportedFeatureError,
   SandboxWorkspaceReadNotFoundError,
 } from '../errors';
-import { chmod, mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, realpath, rm, stat } from 'node:fs/promises';
 import { createHash, randomUUID } from 'node:crypto';
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { isAbsolute, join, resolve } from 'node:path';
@@ -42,6 +42,7 @@ import type {
   SandboxArchiveLimits,
   SandboxClientResumeOptions,
   SandboxConcurrencyLimits,
+  SandboxSessionSerializationOptions,
 } from '../client';
 import { normalizeSandboxClientCreateArgs } from '../client';
 import { Manifest } from '../manifest';
@@ -109,6 +110,7 @@ import {
 } from '../shared/typeGuards';
 import { validateCredentialPair as validateSandboxCredentialPair } from '../shared/credentials';
 import { sandboxPathGrantHostPath } from '../shared/hostPath';
+import { isRunStateSessionState } from '../internal/sessionStateTrust';
 
 const DEFAULT_DOCKER_IMAGE = 'python:3.14-slim';
 const DEFAULT_CONTAINER_COMMAND =
@@ -116,6 +118,10 @@ const DEFAULT_CONTAINER_COMMAND =
 const DOCKER_FAST_COMMAND_TIMEOUT_MS = 10_000;
 const DOCKER_CONTAINER_START_TIMEOUT_MS = 2 * 60_000;
 const DOCKER_CONTAINER_REMOVE_TIMEOUT_MS = 30_000;
+const DOCKER_OWNERSHIP_LABEL = 'openai-agents-sandbox';
+const DOCKER_SESSION_IDENTITY_LABEL = 'openai-agents-sandbox.session-identity';
+const DOCKER_MOUNT_AUTHORITY_FINGERPRINT_LABEL =
+  'openai-agents-sandbox.mount-authority-fingerprint';
 
 export interface DockerSandboxClientOptions extends SandboxClientOptions {
   image?: string;
@@ -127,6 +133,7 @@ export interface DockerSandboxClientOptions extends SandboxClientOptions {
 }
 
 export interface DockerSandboxSessionState extends UnixLocalSandboxSessionState {
+  sessionIdentity?: string;
   containerId: string;
   image: string;
   defaultUser?: string;
@@ -883,17 +890,20 @@ export class DockerSandboxClient implements SandboxClient<
     const configuredExposedPorts = normalizeExposedPorts(
       resolvedOptions.exposedPorts,
     );
+    const sessionIdentity = randomUUID();
     const container = await startDockerContainer({
       image,
       manifest,
       manifestRoot: manifest.root,
       workspaceRootPath,
+      sessionIdentity,
       environment,
       defaultUser,
       exposedPorts: configuredExposedPorts,
     });
     const session = new DockerSandboxSession({
       state: {
+        sessionIdentity,
         manifest,
         workspaceRootPath,
         workspaceRootOwned: true,
@@ -943,12 +953,25 @@ export class DockerSandboxClient implements SandboxClient<
     });
   }
 
-  canReusePreservedOwnedSession(state: DockerSandboxSessionState): boolean {
-    return state.manifest.extraPathGrants.length === 0;
+  async canReusePreservedOwnedSession(
+    state: DockerSandboxSessionState,
+  ): Promise<boolean> {
+    if (isRunStateSessionState(state)) {
+      return false;
+    }
+    try {
+      if (!(await inspectContainerRunning(state.containerId))) {
+        return false;
+      }
+      return (await inspectRunningDockerContainerForReuse(state)).reusable;
+    } catch {
+      return false;
+    }
   }
 
   async serializeSessionState(
     state: DockerSandboxSessionState,
+    options: SandboxSessionSerializationOptions = {},
   ): Promise<Record<string, unknown>> {
     const snapshotSpec = state.snapshotSpec ?? this.options.snapshot ?? null;
     attachDockerSnapshotExcludedPaths(state);
@@ -958,10 +981,21 @@ export class DockerSandboxClient implements SandboxClient<
       snapshotSpec,
     );
     state.snapshotSpec = snapshotSpec;
+    if (
+      options.preserveOwnedSession === true &&
+      options.reuseLiveSession === false &&
+      options.willCloseAfterSerialize === true &&
+      snapshot === null
+    ) {
+      throw new UserError(
+        'Docker sandbox session cannot be preserved after live reuse was rejected because no restorable snapshot is configured.',
+      );
+    }
 
     return {
       ...serializeHostPathGrantRedactionMetadata(state),
       manifest: serializeManifest(state.manifest),
+      sessionIdentity: state.sessionIdentity,
       workspaceRootPath: state.workspaceRootPath,
       workspaceRootOwned: state.workspaceRootOwned,
       environment: sanitizeEnvironmentForPersistence(state),
@@ -987,6 +1021,7 @@ export class DockerSandboxClient implements SandboxClient<
     );
     return {
       ...baseState,
+      sessionIdentity: readOptionalString(state, 'sessionIdentity'),
       image: readString(state, 'image'),
       containerId: readString(state, 'containerId'),
       defaultUser:
@@ -1000,13 +1035,27 @@ export class DockerSandboxClient implements SandboxClient<
     archiveLimits?: SandboxArchiveLimits | null,
   ): Promise<DockerSandboxSessionState> {
     attachDockerSnapshotExcludedPaths(state);
+    if (isRunStateSessionState(state)) {
+      if (!(await localSnapshotIsRestorable(state))) {
+        throw new UserError(
+          'Docker sandbox resources are unavailable and no local snapshot could be restored.',
+        );
+      }
+      return await this.restoreSnapshotIntoNewWorkspace(state, archiveLimits);
+    }
     const containerRunning = await inspectContainerRunning(state.containerId);
     const workspaceExists = await pathExists(state.workspaceRootPath);
 
     if (workspaceExists) {
       if (containerRunning) {
-        if (state.manifest.extraPathGrants.length === 0) {
+        const inspection = await inspectRunningDockerContainerForReuse(state);
+        if (inspection.reusable) {
           return state;
+        }
+        if (!inspection.ownershipVerified) {
+          throw new UserError(
+            'Docker sandbox container identity could not be verified. Refusing to resume or replace the running container.',
+          );
         }
         await this.cleanupDockerResources(state);
         return await this.restartContainer(
@@ -1038,6 +1087,17 @@ export class DockerSandboxClient implements SandboxClient<
       }
     }
 
+    if (
+      containerRunning &&
+      !dockerContainerIdentityMatches(
+        state.sessionIdentity,
+        await inspectDockerContainerLabels(state.containerId),
+      )
+    ) {
+      throw new UserError(
+        'Docker sandbox container identity could not be verified. Refusing to resume or replace the running container.',
+      );
+    }
     if (!(await localSnapshotIsRestorable(state))) {
       throw new UserError(
         'Docker sandbox resources are unavailable and no local snapshot could be restored.',
@@ -1045,27 +1105,40 @@ export class DockerSandboxClient implements SandboxClient<
     }
     await this.cleanupDockerResources(state);
 
+    return await this.restoreSnapshotIntoNewWorkspace(state, archiveLimits);
+  }
+
+  private async restoreSnapshotIntoNewWorkspace(
+    state: DockerSandboxSessionState,
+    archiveLimits?: SandboxArchiveLimits | null,
+  ): Promise<DockerSandboxSessionState> {
     const workspaceRootPath = await mkdtemp(
       join(
         this.options.workspaceBaseDir ?? tmpdir(),
         'openai-agents-docker-sandbox-',
       ),
     );
-    const restoredState = await restoreLocalSnapshotToWorkspace(
-      {
-        ...state,
+    try {
+      const restoredState = await restoreLocalSnapshotToWorkspace(
+        {
+          ...state,
+          workspaceRootPath,
+          workspaceRootOwned: true,
+        },
         workspaceRootPath,
-        workspaceRootOwned: true,
-      },
-      workspaceRootPath,
-      { archiveLimits },
-    );
-
-    return await this.restartContainer(
-      restoredState,
-      workspaceRootPath,
-      archiveLimits,
-    );
+        { archiveLimits },
+      );
+      return await this.restartContainer(
+        restoredState,
+        workspaceRootPath,
+        archiveLimits,
+      );
+    } catch (error) {
+      await rm(workspaceRootPath, { recursive: true, force: true }).catch(
+        () => undefined,
+      );
+      throw error;
+    }
   }
 
   private async cleanupDockerResources(
@@ -1098,17 +1171,20 @@ export class DockerSandboxClient implements SandboxClient<
       },
     );
     await prepareDockerWorkspaceRoot(workspaceRootPath, state.manifest);
+    const sessionIdentity = state.sessionIdentity ?? randomUUID();
     const container = await startDockerContainer({
       image: state.image,
       manifest: state.manifest,
       manifestRoot: state.manifest.root,
       workspaceRootPath,
+      sessionIdentity,
       environment: state.environment,
       defaultUser: state.defaultUser,
       exposedPorts: state.configuredExposedPorts,
     });
     const nextState = {
       ...state,
+      sessionIdentity,
       workspaceRootPath,
       containerId: container.containerId,
       dockerVolumeNames: container.volumeNames,
@@ -1165,6 +1241,434 @@ function assertDockerManifestSupported(manifest: Manifest): void {
       supportsMount: isSupportedDockerCreateMount,
     },
   );
+}
+
+type DockerContainerReuseInspection = {
+  ownershipVerified: boolean;
+  reusable: boolean;
+};
+
+async function inspectRunningDockerContainerForReuse(
+  state: DockerSandboxSessionState,
+): Promise<DockerContainerReuseInspection> {
+  const labels = await inspectDockerContainerLabels(state.containerId);
+  const sessionIdentity = state.sessionIdentity;
+  if (!labels) {
+    return { ownershipVerified: false, reusable: false };
+  }
+  if (!sessionIdentity) {
+    return await inspectLegacyDockerContainerForReuse(state, labels);
+  }
+  if (!dockerContainerIdentityMatches(sessionIdentity, labels)) {
+    return { ownershipVerified: false, reusable: false };
+  }
+  const workspaceMountBeforeInspect = await resolveDockerWorkspaceMount(
+    state.workspaceRootPath,
+    state.manifest.root,
+  );
+  const pathGrantMountsBeforeInspect = await resolveDockerPathGrantMounts(
+    state.manifest,
+  );
+  const manifestBindMountsBeforeInspect = await resolveDockerManifestBindMounts(
+    state.manifest,
+  );
+  const actualBindMounts = await inspectDockerBindMounts(state.containerId);
+
+  const workspaceMountAfterInspect = await resolveDockerWorkspaceMount(
+    state.workspaceRootPath,
+    state.manifest.root,
+  );
+  const pathGrantMountsAfterInspect = await resolveDockerPathGrantMounts(
+    state.manifest,
+  );
+  const manifestBindMountsAfterInspect = await resolveDockerManifestBindMounts(
+    state.manifest,
+  );
+  if (!actualBindMounts) {
+    return { ownershipVerified: false, reusable: false };
+  }
+
+  const expectedWorkspaceMount = dockerBindMountsFromAuthority([
+    workspaceMountAfterInspect,
+  ])[0]!;
+  const ownershipVerified = actualBindMounts.some((mount) =>
+    dockerBindMountsEqual(mount, expectedWorkspaceMount),
+  );
+  if (!ownershipVerified) {
+    return { ownershipVerified: false, reusable: false };
+  }
+
+  const expectedBindMounts = dockerBindMountsFromAuthority([
+    workspaceMountAfterInspect,
+    ...pathGrantMountsAfterInspect,
+    ...manifestBindMountsAfterInspect,
+  ]);
+  const recordedFingerprint = labels[DOCKER_MOUNT_AUTHORITY_FINGERPRINT_LABEL];
+  if (recordedFingerprint === undefined) {
+    return { ownershipVerified: true, reusable: false };
+  }
+  const fingerprintBeforeInspect = dockerMountAuthorityFingerprint(
+    sessionIdentity,
+    workspaceMountBeforeInspect,
+    pathGrantMountsBeforeInspect,
+    manifestBindMountsBeforeInspect,
+  );
+  const fingerprintAfterInspect = dockerMountAuthorityFingerprint(
+    sessionIdentity,
+    workspaceMountAfterInspect,
+    pathGrantMountsAfterInspect,
+    manifestBindMountsAfterInspect,
+  );
+  return {
+    ownershipVerified: true,
+    reusable:
+      fingerprintBeforeInspect === fingerprintAfterInspect &&
+      recordedFingerprint === fingerprintAfterInspect &&
+      dockerBindMountSetsEqual(actualBindMounts, expectedBindMounts),
+  };
+}
+
+async function inspectLegacyDockerContainerForReuse(
+  state: DockerSandboxSessionState,
+  labels: Record<string, unknown>,
+): Promise<DockerContainerReuseInspection> {
+  if (
+    labels[DOCKER_OWNERSHIP_LABEL] !== 'true' ||
+    labels[DOCKER_SESSION_IDENTITY_LABEL] !== undefined ||
+    labels[DOCKER_MOUNT_AUTHORITY_FINGERPRINT_LABEL] !== undefined
+  ) {
+    return { ownershipVerified: false, reusable: false };
+  }
+
+  const workspaceMountBeforeInspect = await resolveDockerWorkspaceMount(
+    state.workspaceRootPath,
+    state.manifest.root,
+  );
+  const manifestBindMountsBeforeInspect = await resolveDockerManifestBindMounts(
+    state.manifest,
+  );
+  const actualBindMounts = await inspectDockerBindMounts(state.containerId);
+  const workspaceMountAfterInspect = await resolveDockerWorkspaceMount(
+    state.workspaceRootPath,
+    state.manifest.root,
+  );
+  const manifestBindMountsAfterInspect = await resolveDockerManifestBindMounts(
+    state.manifest,
+  );
+  if (!actualBindMounts) {
+    return { ownershipVerified: false, reusable: false };
+  }
+
+  const expectedWorkspaceMount = dockerBindMountsFromAuthority([
+    workspaceMountAfterInspect,
+  ])[0]!;
+  const ownershipVerified = actualBindMounts.some((mount) =>
+    dockerBindMountsEqual(mount, expectedWorkspaceMount),
+  );
+  return {
+    ownershipVerified,
+    reusable:
+      ownershipVerified &&
+      dockerMountAuthoritiesEqual(
+        workspaceMountBeforeInspect,
+        workspaceMountAfterInspect,
+      ) &&
+      dockerMountAuthoritySetsEqual(
+        manifestBindMountsBeforeInspect,
+        manifestBindMountsAfterInspect,
+      ) &&
+      state.manifest.extraPathGrants.length === 0 &&
+      dockerBindMountSetsEqual(actualBindMounts, [
+        expectedWorkspaceMount,
+        ...dockerBindMountsFromAuthority(manifestBindMountsAfterInspect),
+      ]),
+  };
+}
+
+function dockerContainerIdentityMatches(
+  sessionIdentity: string | undefined,
+  labels: Record<string, unknown> | undefined,
+): boolean {
+  return (
+    sessionIdentity !== undefined &&
+    labels?.[DOCKER_OWNERSHIP_LABEL] === 'true' &&
+    labels[DOCKER_SESSION_IDENTITY_LABEL] === sessionIdentity
+  );
+}
+
+function dockerMountAuthoritiesEqual(
+  left: DockerMountAuthority,
+  right: DockerMountAuthority,
+): boolean {
+  return (
+    left.source === right.source &&
+    left.sourceIdentity.device === right.sourceIdentity.device &&
+    left.sourceIdentity.inode === right.sourceIdentity.inode &&
+    left.target === right.target &&
+    left.readOnly === right.readOnly
+  );
+}
+
+function dockerMountAuthoritySetsEqual(
+  left: DockerMountAuthority[],
+  right: DockerMountAuthority[],
+): boolean {
+  const sortedLeft = sortDockerMountAuthorities(left);
+  const sortedRight = sortDockerMountAuthorities(right);
+  return (
+    sortedLeft.length === sortedRight.length &&
+    sortedLeft.every((mount, index) =>
+      dockerMountAuthoritiesEqual(mount, sortedRight[index]!),
+    )
+  );
+}
+
+function sortDockerMountAuthorities(
+  mounts: DockerMountAuthority[],
+): DockerMountAuthority[] {
+  return [...mounts].sort((left, right) => {
+    const targetOrder = left.target.localeCompare(right.target);
+    return targetOrder !== 0
+      ? targetOrder
+      : left.source.localeCompare(right.source);
+  });
+}
+
+type DockerInspectMount = {
+  Type?: unknown;
+  Source?: unknown;
+  Destination?: unknown;
+  RW?: unknown;
+};
+
+type DockerBindMount = {
+  source: string;
+  target: string;
+  readWrite: boolean;
+};
+
+type DockerMountAuthority = {
+  source: string;
+  sourceIdentity: {
+    device: string;
+    inode: string;
+  };
+  target: string;
+  readOnly: boolean;
+};
+
+async function inspectDockerContainerLabels(
+  containerId: string,
+): Promise<Record<string, unknown> | undefined> {
+  const result = await runSandboxProcess(
+    'docker',
+    [
+      'inspect',
+      '--type',
+      'container',
+      '--format',
+      '{{json .Config.Labels}}',
+      containerId,
+    ],
+    {
+      timeoutMs: DOCKER_FAST_COMMAND_TIMEOUT_MS,
+    },
+  );
+  if (result.status !== 0) {
+    return undefined;
+  }
+
+  try {
+    const labels: unknown = JSON.parse(result.stdout);
+    return typeof labels === 'object' &&
+      labels !== null &&
+      !Array.isArray(labels)
+      ? (labels as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function inspectDockerBindMounts(
+  containerId: string,
+): Promise<DockerBindMount[] | undefined> {
+  const result = await runSandboxProcess(
+    'docker',
+    [
+      'inspect',
+      '--type',
+      'container',
+      '--format',
+      '{{json .Mounts}}',
+      containerId,
+    ],
+    {
+      timeoutMs: DOCKER_FAST_COMMAND_TIMEOUT_MS,
+    },
+  );
+  if (result.status !== 0) {
+    return undefined;
+  }
+  try {
+    const mounts: unknown = JSON.parse(result.stdout);
+    if (!Array.isArray(mounts)) {
+      return undefined;
+    }
+    return await Promise.all(
+      mounts
+        .filter(
+          (mount): mount is DockerInspectMount =>
+            typeof mount === 'object' &&
+            mount !== null &&
+            (mount as DockerInspectMount).Type === 'bind',
+        )
+        .map(async (mount): Promise<DockerBindMount> => {
+          if (
+            typeof mount.Source !== 'string' ||
+            typeof mount.Destination !== 'string' ||
+            typeof mount.RW !== 'boolean'
+          ) {
+            throw new Error('Invalid Docker bind mount inspection result.');
+          }
+          return {
+            source: await realpath(mount.Source),
+            target: mount.Destination,
+            readWrite: mount.RW,
+          };
+        }),
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+function dockerBindMountsEqual(
+  left: DockerBindMount,
+  right: DockerBindMount,
+): boolean {
+  return (
+    left.source === right.source &&
+    left.target === right.target &&
+    left.readWrite === right.readWrite
+  );
+}
+
+function dockerBindMountsFromAuthority(
+  mounts: DockerMountAuthority[],
+): DockerBindMount[] {
+  return mounts.map((mount) => ({
+    source: mount.source,
+    target: mount.target,
+    readWrite: !mount.readOnly,
+  }));
+}
+
+function dockerBindMountSetsEqual(
+  left: DockerBindMount[],
+  right: DockerBindMount[],
+): boolean {
+  return (
+    JSON.stringify(sortDockerBindMounts(left)) ===
+    JSON.stringify(sortDockerBindMounts(right))
+  );
+}
+
+function sortDockerBindMounts(mounts: DockerBindMount[]): DockerBindMount[] {
+  return [...mounts].sort((left, right) => {
+    const targetOrder = left.target.localeCompare(right.target);
+    return targetOrder !== 0
+      ? targetOrder
+      : left.source.localeCompare(right.source);
+  });
+}
+
+type DockerPathGrantMount = DockerMountAuthority;
+
+async function resolveDockerWorkspaceMount(
+  workspaceRootPath: string,
+  manifestRoot: string,
+): Promise<DockerMountAuthority> {
+  return await resolveDockerMountAuthority(
+    workspaceRootPath,
+    manifestRoot,
+    false,
+  );
+}
+
+async function resolveDockerMountAuthority(
+  sourcePath: string,
+  target: string,
+  readOnly: boolean,
+): Promise<DockerMountAuthority> {
+  const source = await realpath(sourcePath);
+  const sourceStats = await stat(source, { bigint: true });
+  return {
+    source,
+    sourceIdentity: {
+      device: sourceStats.dev.toString(),
+      inode: sourceStats.ino.toString(),
+    },
+    target,
+    readOnly,
+  };
+}
+
+async function resolveDockerPathGrantMounts(
+  manifest: Manifest,
+): Promise<DockerPathGrantMount[]> {
+  return await Promise.all(
+    manifest.extraPathGrants.map(
+      async (grant) =>
+        await resolveDockerMountAuthority(
+          sandboxPathGrantHostPath(grant),
+          grant.path,
+          grant.readOnly,
+        ),
+    ),
+  );
+}
+
+async function resolveDockerManifestBindMounts(
+  manifest: Manifest,
+): Promise<DockerMountAuthority[]> {
+  return await Promise.all(
+    manifest
+      .mountTargetsForMaterialization()
+      .filter(({ entry }) => isDockerBindMount(entry))
+      .map(
+        async ({ mountPath, entry }) =>
+          await resolveDockerMountAuthority(
+            (entry as Mount & { source: string }).source,
+            mountPath,
+            entry.readOnly ?? true,
+          ),
+      ),
+  );
+}
+
+function dockerMountAuthorityFingerprint(
+  sessionIdentity: string,
+  workspaceMount: DockerMountAuthority,
+  pathGrantMounts: DockerPathGrantMount[],
+  manifestBindMounts: DockerMountAuthority[],
+): string {
+  const mountedGrants = [...pathGrantMounts].sort((left, right) =>
+    left.target < right.target ? -1 : left.target > right.target ? 1 : 0,
+  );
+  const mountedManifestBinds = [...manifestBindMounts].sort((left, right) =>
+    left.target < right.target ? -1 : left.target > right.target ? 1 : 0,
+  );
+  return createHash('sha256')
+    .update(
+      JSON.stringify({
+        sessionIdentity,
+        workspaceMount,
+        mountedGrants,
+        mountedManifestBinds,
+      }),
+    )
+    .digest('hex');
 }
 
 function assertDockerManifestDeltaSupported(
@@ -1330,7 +1834,24 @@ async function inspectContainerRunning(containerId: string): Promise<boolean> {
     },
   );
 
-  return result.status === 0 && result.stdout.trim() === 'true';
+  if (result.status !== 0) {
+    if (isMissingDockerContainerError(result)) {
+      return false;
+    }
+    throw new UserError(
+      `Failed to inspect Docker sandbox container: ${formatSandboxProcessError(result)}`,
+    );
+  }
+  const running = result.stdout.trim();
+  if (running === 'true') {
+    return true;
+  }
+  if (running === 'false') {
+    return false;
+  }
+  throw new UserError(
+    `Failed to inspect Docker sandbox container: unexpected running state "${running}".`,
+  );
 }
 
 async function runDockerProcess(
@@ -1401,6 +1922,7 @@ async function startDockerContainer(args: {
   manifest: Manifest;
   manifestRoot: string;
   workspaceRootPath: string;
+  sessionIdentity: string;
   environment: Record<string, string>;
   defaultUser?: string;
   exposedPorts?: number[];
@@ -1415,9 +1937,18 @@ async function startDockerContainer(args: {
     `127.0.0.1::${port}`,
   ]);
   const containerName = `openai-agents-sandbox-${randomUUID().slice(0, 8)}`;
+  const workspaceMount = await resolveDockerWorkspaceMount(
+    args.workspaceRootPath,
+    args.manifestRoot,
+  );
+  const pathGrantMounts = await resolveDockerPathGrantMounts(args.manifest);
+  const manifestBindMounts = await resolveDockerManifestBindMounts(
+    args.manifest,
+  );
   const { mountArgs, volumeNames } = dockerMountArgsForManifest(
     args.manifest,
     containerName,
+    manifestBindMounts,
   );
   const privilegeArgs = dockerInContainerMountPrivilegeArgs(args.manifest);
   const result = await runSandboxProcess(
@@ -1428,10 +1959,14 @@ async function startDockerContainer(args: {
       '--name',
       containerName,
       '--label',
-      'openai-agents-sandbox=true',
+      `${DOCKER_OWNERSHIP_LABEL}=true`,
+      '--label',
+      `${DOCKER_SESSION_IDENTITY_LABEL}=${args.sessionIdentity}`,
+      '--label',
+      `${DOCKER_MOUNT_AUTHORITY_FINGERPRINT_LABEL}=${dockerMountAuthorityFingerprint(args.sessionIdentity, workspaceMount, pathGrantMounts, manifestBindMounts)}`,
       '-v',
-      `${args.workspaceRootPath}:${args.manifestRoot}`,
-      ...dockerExtraPathGrantMountArgs(args.manifest),
+      `${workspaceMount.source}:${args.manifestRoot}`,
+      ...dockerExtraPathGrantMountArgs(pathGrantMounts),
       ...mountArgs,
       ...privilegeArgs,
       '-w',
@@ -2377,21 +2912,31 @@ function dockerFusePatternBoolean(
 function dockerMountArgsForManifest(
   manifest: Manifest,
   containerName: string,
+  manifestBindMounts: DockerMountAuthority[],
 ): { mountArgs: string[]; volumeNames: string[] } {
   const mountArgs: string[] = [];
   const volumeNames: string[] = [];
+  const bindMountsByTarget = new Map(
+    manifestBindMounts.map((mount) => [mount.target, mount]),
+  );
   for (const {
     mountPath,
     entry,
   } of manifest.mountTargetsForMaterialization()) {
     if (isDockerBindMount(entry)) {
+      const bindMount = bindMountsByTarget.get(mountPath);
+      if (!bindMount) {
+        throw new SandboxConfigurationError(
+          `Docker bind mount authority was not resolved for "${mountPath}".`,
+        );
+      }
       mountArgs.push(
         '--mount',
         dockerMountArg({
           type: 'bind',
-          source: entry.source,
+          source: bindMount.source,
           target: mountPath,
-          readOnly: entry.readOnly ?? true,
+          readOnly: bindMount.readOnly,
         }),
       );
       continue;
@@ -2418,13 +2963,15 @@ function dockerMountArgsForManifest(
   return { mountArgs, volumeNames };
 }
 
-function dockerExtraPathGrantMountArgs(manifest: Manifest): string[] {
-  return manifest.extraPathGrants.flatMap((grant) => [
+function dockerExtraPathGrantMountArgs(
+  pathGrantMounts: DockerPathGrantMount[],
+): string[] {
+  return pathGrantMounts.flatMap((grant) => [
     '--mount',
     dockerMountArg({
       type: 'bind',
-      source: sandboxPathGrantHostPath(grant),
-      target: grant.path,
+      source: grant.source,
+      target: grant.target,
       readOnly: grant.readOnly,
     }),
   ]);

--- a/packages/agents-core/src/sandbox/sandboxes/docker.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/docker.ts
@@ -139,6 +139,12 @@ export interface DockerSandboxClientOptions extends SandboxClientOptions {
 
 export interface DockerSandboxSessionState extends UnixLocalSandboxSessionState {
   sessionIdentity?: string;
+  /**
+   * Fingerprint of non-mount entries materialized before container creation.
+   * Entries applied later at runtime are intentionally not included. This is
+   * trusted same-process state and must not be serialized.
+   */
+  materializedEntriesFingerprint?: string;
   containerId: string;
   image: string;
   defaultUser?: string;
@@ -909,6 +915,8 @@ export class DockerSandboxClient implements SandboxClient<
     const session = new DockerSandboxSession({
       state: {
         sessionIdentity,
+        materializedEntriesFingerprint:
+          dockerMaterializedEntriesFingerprint(manifest),
         manifest,
         workspaceRootPath,
         workspaceRootOwned: true,
@@ -978,14 +986,29 @@ export class DockerSandboxClient implements SandboxClient<
     ) {
       return false;
     }
+    if (options.revalidateManifestEntries === true) {
+      if (state.materializedEntriesFingerprint === undefined) {
+        return false;
+      }
+      if (
+        state.materializedEntriesFingerprint !==
+        dockerMaterializedEntriesFingerprint(state.manifest)
+      ) {
+        throw new UserError(
+          'Docker sandbox resume cannot apply changes to non-mount manifest entries. Start a fresh sandbox session instead.',
+        );
+      }
+    }
+    let inspection: DockerContainerReuseInspection;
     try {
       if (!(await inspectContainerRunning(state.containerId))) {
         return false;
       }
-      return (await inspectRunningDockerContainerForReuse(state)).reusable;
+      inspection = await inspectRunningDockerContainerForReuse(state);
     } catch {
       return false;
     }
+    return inspection.reusable;
   }
 
   async serializeSessionState(
@@ -1064,6 +1087,7 @@ export class DockerSandboxClient implements SandboxClient<
       const trustedState: DockerSandboxSessionState = {
         ...state,
         sessionIdentity: undefined,
+        materializedEntriesFingerprint: undefined,
         image: resolvedOptions.image ?? DEFAULT_DOCKER_IMAGE,
         environment: await state.manifest.resolveEnvironment(),
         snapshotSpec:
@@ -1229,6 +1253,9 @@ export class DockerSandboxClient implements SandboxClient<
     const nextState = {
       ...state,
       sessionIdentity,
+      materializedEntriesFingerprint: dockerMaterializedEntriesFingerprint(
+        state.manifest,
+      ),
       workspaceRootPath,
       containerId: container.containerId,
       dockerVolumeNames: container.volumeNames,
@@ -1722,6 +1749,43 @@ function dockerMountAuthorityFingerprint(
       }),
     )
     .digest('hex');
+}
+
+function dockerMaterializedEntriesFingerprint(manifest: Manifest): string {
+  return createHash('sha256')
+    .update(
+      stableJsonStringify({
+        entries: dockerNonMountManifestEntries(manifest),
+      }),
+    )
+    .digest('hex');
+}
+
+function dockerNonMountManifestEntries(
+  manifest: Manifest,
+): Array<{ path: string; entry: Entry }> {
+  const flattened: Array<{ path: string; entry: Entry }> = [];
+  const visit = (children: Record<string, Entry>, parentPath = '') => {
+    for (const [name, entry] of Object.entries(children).sort(
+      ([left], [right]) => left.localeCompare(right),
+    )) {
+      const path = parentPath ? `${parentPath}/${name}` : name;
+      if (isMount(entry)) {
+        continue;
+      }
+      if (entry.type === 'dir') {
+        const { children: nestedChildren, ...directory } = entry;
+        flattened.push({ path, entry: directory as Entry });
+        if (nestedChildren) {
+          visit(nestedChildren, path);
+        }
+        continue;
+      }
+      flattened.push({ path, entry });
+    }
+  };
+  visit(manifest.entries);
+  return flattened;
 }
 
 function dockerExposedPortSetsEqual(left: number[], right: number[]): boolean {

--- a/packages/agents-core/src/sandbox/sandboxes/docker.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/docker.ts
@@ -1375,6 +1375,9 @@ async function inspectLegacyDockerContainerForReuse(
     state.workspaceRootPath,
     state.manifest.root,
   );
+  const pathGrantMountsBeforeInspect = await resolveDockerPathGrantMounts(
+    state.manifest,
+  );
   const manifestBindMountsBeforeInspect = await resolveDockerManifestBindMounts(
     state.manifest,
   );
@@ -1382,6 +1385,9 @@ async function inspectLegacyDockerContainerForReuse(
   const workspaceMountAfterInspect = await resolveDockerWorkspaceMount(
     state.workspaceRootPath,
     state.manifest.root,
+  );
+  const pathGrantMountsAfterInspect = await resolveDockerPathGrantMounts(
+    state.manifest,
   );
   const manifestBindMountsAfterInspect = await resolveDockerManifestBindMounts(
     state.manifest,
@@ -1405,12 +1411,16 @@ async function inspectLegacyDockerContainerForReuse(
         workspaceMountAfterInspect,
       ) &&
       dockerMountAuthoritySetsEqual(
+        pathGrantMountsBeforeInspect,
+        pathGrantMountsAfterInspect,
+      ) &&
+      dockerMountAuthoritySetsEqual(
         manifestBindMountsBeforeInspect,
         manifestBindMountsAfterInspect,
       ) &&
-      state.manifest.extraPathGrants.length === 0 &&
       dockerBindMountSetsEqual(actualBindMounts, [
         expectedWorkspaceMount,
+        ...dockerBindMountsFromAuthority(pathGrantMountsAfterInspect),
         ...dockerBindMountsFromAuthority(manifestBindMountsAfterInspect),
       ]),
   };

--- a/packages/agents-core/src/sandbox/sandboxes/docker.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/docker.ts
@@ -42,6 +42,7 @@ import type {
   SandboxArchiveLimits,
   SandboxClientResumeOptions,
   SandboxConcurrencyLimits,
+  SandboxPreservedSessionReuseOptions,
   SandboxSessionSerializationOptions,
 } from '../client';
 import { normalizeSandboxClientCreateArgs } from '../client';
@@ -959,8 +960,22 @@ export class DockerSandboxClient implements SandboxClient<
 
   async canReusePreservedOwnedSession(
     state: DockerSandboxSessionState,
+    options: SandboxPreservedSessionReuseOptions<DockerSandboxClientOptions> = {},
   ): Promise<boolean> {
     if (isRunStateSessionState(state)) {
+      return false;
+    }
+    const resolvedOptions = {
+      ...this.options,
+      ...options.clientOptions,
+    };
+    if (
+      state.image !== (resolvedOptions.image ?? DEFAULT_DOCKER_IMAGE) ||
+      !dockerExposedPortSetsEqual(
+        state.configuredExposedPorts ?? [],
+        normalizeExposedPorts(resolvedOptions.exposedPorts),
+      )
+    ) {
       return false;
     }
     try {
@@ -1698,6 +1713,8 @@ function dockerMountAuthorityFingerprint(
         workspaceMount,
         mountedGrants,
         mountedManifestBinds,
+        users: manifest.users,
+        groups: manifest.groups,
         mountedManifestEntries: manifest
           .mountTargetsForMaterialization()
           .map(({ mountPath, entry }) => ({ mountPath, entry }))
@@ -1705,6 +1722,13 @@ function dockerMountAuthorityFingerprint(
       }),
     )
     .digest('hex');
+}
+
+function dockerExposedPortSetsEqual(left: number[], right: number[]): boolean {
+  return (
+    JSON.stringify([...left].sort((a, b) => a - b)) ===
+    JSON.stringify([...right].sort((a, b) => a - b))
+  );
 }
 
 function assertDockerManifestDeltaSupported(

--- a/packages/agents-core/src/sandbox/sandboxes/docker.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/docker.ts
@@ -110,7 +110,11 @@ import {
 } from '../shared/typeGuards';
 import { validateCredentialPair as validateSandboxCredentialPair } from '../shared/credentials';
 import { sandboxPathGrantHostPath } from '../shared/hostPath';
-import { isRunStateSessionState } from '../internal/sessionStateTrust';
+import {
+  getRunStateSessionTrustedConfig,
+  isRunStateSessionState,
+} from '../internal/sessionStateTrust';
+import { stableJsonStringify } from '../shared/stableJson';
 
 const DEFAULT_DOCKER_IMAGE = 'python:3.14-slim';
 const DEFAULT_CONTAINER_COMMAND =
@@ -1036,12 +1040,39 @@ export class DockerSandboxClient implements SandboxClient<
   ): Promise<DockerSandboxSessionState> {
     attachDockerSnapshotExcludedPaths(state);
     if (isRunStateSessionState(state)) {
-      if (!(await localSnapshotIsRestorable(state))) {
+      const trustedConfig = getRunStateSessionTrustedConfig(state);
+      const resolvedOptions: DockerSandboxClientOptions = {
+        ...this.options,
+        ...(trustedConfig?.clientOptions as
+          DockerSandboxClientOptions | undefined),
+      };
+      const trustedState: DockerSandboxSessionState = {
+        ...state,
+        sessionIdentity: undefined,
+        image: resolvedOptions.image ?? DEFAULT_DOCKER_IMAGE,
+        environment: await state.manifest.resolveEnvironment(),
+        snapshotSpec:
+          (trustedConfig?.snapshot as LocalSandboxSnapshotSpec | undefined) ??
+          resolvedOptions.snapshot ??
+          null,
+        defaultUser: getHostDockerUser(),
+        configuredExposedPorts: normalizeExposedPorts(
+          resolvedOptions.exposedPorts,
+        ),
+        dockerVolumeNames: [],
+        exposedPorts: undefined,
+      };
+      attachDockerSnapshotExcludedPaths(trustedState);
+      if (!(await localSnapshotIsRestorable(trustedState))) {
         throw new UserError(
           'Docker sandbox resources are unavailable and no local snapshot could be restored.',
         );
       }
-      return await this.restoreSnapshotIntoNewWorkspace(state, archiveLimits);
+      return await this.restoreSnapshotIntoNewWorkspace(
+        trustedState,
+        archiveLimits,
+        resolvedOptions.workspaceBaseDir,
+      );
     }
     const containerRunning = await inspectContainerRunning(state.containerId);
     const workspaceExists = await pathExists(state.workspaceRootPath);
@@ -1111,12 +1142,10 @@ export class DockerSandboxClient implements SandboxClient<
   private async restoreSnapshotIntoNewWorkspace(
     state: DockerSandboxSessionState,
     archiveLimits?: SandboxArchiveLimits | null,
+    workspaceBaseDir = this.options.workspaceBaseDir,
   ): Promise<DockerSandboxSessionState> {
     const workspaceRootPath = await mkdtemp(
-      join(
-        this.options.workspaceBaseDir ?? tmpdir(),
-        'openai-agents-docker-sandbox-',
-      ),
+      join(workspaceBaseDir ?? tmpdir(), 'openai-agents-docker-sandbox-'),
     );
     try {
       const restoredState = await restoreLocalSnapshotToWorkspace(
@@ -1312,12 +1341,14 @@ async function inspectRunningDockerContainerForReuse(
     workspaceMountBeforeInspect,
     pathGrantMountsBeforeInspect,
     manifestBindMountsBeforeInspect,
+    state.manifest,
   );
   const fingerprintAfterInspect = dockerMountAuthorityFingerprint(
     sessionIdentity,
     workspaceMountAfterInspect,
     pathGrantMountsAfterInspect,
     manifestBindMountsAfterInspect,
+    state.manifest,
   );
   return {
     ownershipVerified: true,
@@ -1652,6 +1683,7 @@ function dockerMountAuthorityFingerprint(
   workspaceMount: DockerMountAuthority,
   pathGrantMounts: DockerPathGrantMount[],
   manifestBindMounts: DockerMountAuthority[],
+  manifest: Manifest,
 ): string {
   const mountedGrants = [...pathGrantMounts].sort((left, right) =>
     left.target < right.target ? -1 : left.target > right.target ? 1 : 0,
@@ -1661,11 +1693,15 @@ function dockerMountAuthorityFingerprint(
   );
   return createHash('sha256')
     .update(
-      JSON.stringify({
+      stableJsonStringify({
         sessionIdentity,
         workspaceMount,
         mountedGrants,
         mountedManifestBinds,
+        mountedManifestEntries: manifest
+          .mountTargetsForMaterialization()
+          .map(({ mountPath, entry }) => ({ mountPath, entry }))
+          .sort((left, right) => left.mountPath.localeCompare(right.mountPath)),
       }),
     )
     .digest('hex');
@@ -1963,7 +1999,7 @@ async function startDockerContainer(args: {
       '--label',
       `${DOCKER_SESSION_IDENTITY_LABEL}=${args.sessionIdentity}`,
       '--label',
-      `${DOCKER_MOUNT_AUTHORITY_FINGERPRINT_LABEL}=${dockerMountAuthorityFingerprint(args.sessionIdentity, workspaceMount, pathGrantMounts, manifestBindMounts)}`,
+      `${DOCKER_MOUNT_AUTHORITY_FINGERPRINT_LABEL}=${dockerMountAuthorityFingerprint(args.sessionIdentity, workspaceMount, pathGrantMounts, manifestBindMounts, args.manifest)}`,
       '-v',
       `${workspaceMount.source}:${args.manifestRoot}`,
       ...dockerExtraPathGrantMountArgs(pathGrantMounts),

--- a/packages/agents-core/src/sandbox/sandboxes/docker.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/docker.ts
@@ -1375,9 +1375,6 @@ async function inspectLegacyDockerContainerForReuse(
     state.workspaceRootPath,
     state.manifest.root,
   );
-  const pathGrantMountsBeforeInspect = await resolveDockerPathGrantMounts(
-    state.manifest,
-  );
   const manifestBindMountsBeforeInspect = await resolveDockerManifestBindMounts(
     state.manifest,
   );
@@ -1385,9 +1382,6 @@ async function inspectLegacyDockerContainerForReuse(
   const workspaceMountAfterInspect = await resolveDockerWorkspaceMount(
     state.workspaceRootPath,
     state.manifest.root,
-  );
-  const pathGrantMountsAfterInspect = await resolveDockerPathGrantMounts(
-    state.manifest,
   );
   const manifestBindMountsAfterInspect = await resolveDockerManifestBindMounts(
     state.manifest,
@@ -1411,16 +1405,12 @@ async function inspectLegacyDockerContainerForReuse(
         workspaceMountAfterInspect,
       ) &&
       dockerMountAuthoritySetsEqual(
-        pathGrantMountsBeforeInspect,
-        pathGrantMountsAfterInspect,
-      ) &&
-      dockerMountAuthoritySetsEqual(
         manifestBindMountsBeforeInspect,
         manifestBindMountsAfterInspect,
       ) &&
+      state.manifest.extraPathGrants.length === 0 &&
       dockerBindMountSetsEqual(actualBindMounts, [
         expectedWorkspaceMount,
-        ...dockerBindMountsFromAuthority(pathGrantMountsAfterInspect),
         ...dockerBindMountsFromAuthority(manifestBindMountsAfterInspect),
       ]),
   };

--- a/packages/agents-core/src/sandbox/sandboxes/shared/manifestPersistence.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/manifestPersistence.ts
@@ -1,6 +1,6 @@
 import { isMount, type Entry } from '../../entries';
 import { UserError } from '../../../errors';
-import { Manifest, type EnvValue } from '../../manifest';
+import { cloneManifest, Manifest, type EnvValue } from '../../manifest';
 import type { SandboxSessionState } from '../../session';
 import {
   mergeNamedObjects,
@@ -50,27 +50,44 @@ export function deserializeHostPathGrantRedactionMetadata(
 export function rebindPersistedPathGrants<TState extends SandboxSessionState>(
   state: TState,
   trustedManifest: Manifest | undefined,
+  options: {
+    replaceWithTrustedManifest?: boolean;
+    replaceWithTrustedGrantSet?: boolean;
+  } = {},
 ): TState {
   // Native host paths are runtime authority. Only the current manifest may
   // reintroduce them after persisted session state has been deserialized.
   const reboundState: SandboxSessionState = { ...state };
+  if (options.replaceWithTrustedManifest && trustedManifest) {
+    reboundState.manifest = cloneManifest(trustedManifest);
+    delete reboundState[redactedHostPathGrantPathsKey];
+    return reboundState as TState;
+  }
+
   const trustedGrantsByPath = new Map(
     (trustedManifest?.extraPathGrants ?? []).map((grant) => [
       grant.path,
       grant,
     ]),
   );
-  const unmatchedGrantPaths = state.manifest.extraPathGrants
-    .filter((grant) => !trustedGrantsByPath.has(grant.path))
-    .map((grant) => grant.path);
-  if (unmatchedGrantPaths.length > 0) {
-    throw new UserError(
-      `Sandbox session state contains path grants that are not present in the current trusted manifest: ${unmatchedGrantPaths.join(', ')}. Define each grant in the current manifest before resuming.`,
+  let extraPathGrants: Manifest['extraPathGrants'];
+  if (options.replaceWithTrustedGrantSet && trustedManifest) {
+    extraPathGrants = trustedManifest.extraPathGrants.map((grant) =>
+      structuredClone(grant),
     );
+  } else {
+    const unmatchedGrantPaths = state.manifest.extraPathGrants
+      .filter((grant) => !trustedGrantsByPath.has(grant.path))
+      .map((grant) => grant.path);
+    if (unmatchedGrantPaths.length > 0) {
+      throw new UserError(
+        `Sandbox session state contains path grants that are not present in the current trusted manifest: ${unmatchedGrantPaths.join(', ')}. Define each grant in the current manifest before resuming.`,
+      );
+    }
+    extraPathGrants = state.manifest.extraPathGrants.map((grant) => {
+      return structuredClone(trustedGrantsByPath.get(grant.path)!);
+    });
   }
-  const extraPathGrants = state.manifest.extraPathGrants.map((grant) => {
-    return structuredClone(trustedGrantsByPath.get(grant.path)!);
-  });
 
   reboundState.manifest = new Manifest({
     version: state.manifest.version,
@@ -93,9 +110,11 @@ export function rebindPersistedPathGrants<TState extends SandboxSessionState>(
   const reboundGrantsByPath = new Map(
     reboundState.manifest.extraPathGrants.map((grant) => [grant.path, grant]),
   );
-  const unresolvedPaths = readRedactedHostPathGrantPaths(state).filter(
-    (path) => reboundGrantsByPath.get(path)?.hostPath === undefined,
-  );
+  const unresolvedPaths = options.replaceWithTrustedGrantSet
+    ? []
+    : readRedactedHostPathGrantPaths(state).filter(
+        (path) => reboundGrantsByPath.get(path)?.hostPath === undefined,
+      );
   if (unresolvedPaths.length > 0) {
     reboundState[redactedHostPathGrantPathsKey] = unresolvedPaths;
   } else {

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -519,16 +519,21 @@ class SerializedResumeFakeSandboxClient extends FakeSandboxClient {
 class RevalidatingLiveProcessFakeSandboxClient extends FakeSandboxClient {
   readonly reuseChecks: Manifest[] = [];
   readonly reuseEnvironments: Array<Record<string, string> | undefined> = [];
+  readonly reuseClientOptions: Array<SandboxClientOptions | undefined> = [];
 
   constructor(private readonly reuseResults: boolean[] = [true, true]) {
     super();
   }
 
-  canReusePreservedOwnedSession(state: FakeSandboxSessionState): boolean {
+  canReusePreservedOwnedSession(
+    state: FakeSandboxSessionState,
+    options: { clientOptions?: SandboxClientOptions } = {},
+  ): boolean {
     this.reuseChecks.push(state.manifest);
     this.reuseEnvironments.push(
       state.environment ? { ...state.environment } : undefined,
     );
+    this.reuseClientOptions.push(options.clientOptions);
     return this.reuseResults[this.reuseChecks.length - 1] ?? false;
   }
 
@@ -5458,6 +5463,10 @@ describe('sandbox runner integration', () => {
       sandboxConfig: {
         client,
         manifest,
+        options: {
+          image: 'trusted-image',
+          exposedPorts: [8080],
+        },
       },
       runState: state,
     });
@@ -5494,6 +5503,10 @@ describe('sandbox runner integration', () => {
       sandboxConfig: {
         client,
         manifest: refreshedManifest,
+        options: {
+          image: 'trusted-image',
+          exposedPorts: [8080],
+        },
       },
       runState: state,
     });
@@ -5508,6 +5521,16 @@ describe('sandbox runner integration', () => {
         SECRET_ENV: 'refreshed-secret',
         ADDED_ENV: 'added-value',
         PROVIDER_ENV: 'provider-value',
+      },
+    ]);
+    expect(client.reuseClientOptions).toEqual([
+      {
+        image: 'trusted-image',
+        exposedPorts: [8080],
+      },
+      {
+        image: 'trusted-image',
+        exposedPorts: [8080],
       },
     ]);
     expect(liveSession.state.environment).toEqual({

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -518,6 +518,7 @@ class SerializedResumeFakeSandboxClient extends FakeSandboxClient {
 
 class RevalidatingLiveProcessFakeSandboxClient extends FakeSandboxClient {
   readonly reuseChecks: Manifest[] = [];
+  readonly reuseEnvironments: Array<Record<string, string> | undefined> = [];
 
   constructor(private readonly reuseResults: boolean[] = [true, true]) {
     super();
@@ -525,6 +526,9 @@ class RevalidatingLiveProcessFakeSandboxClient extends FakeSandboxClient {
 
   canReusePreservedOwnedSession(state: FakeSandboxSessionState): boolean {
     this.reuseChecks.push(state.manifest);
+    this.reuseEnvironments.push(
+      state.environment ? { ...state.environment } : undefined,
+    );
     return this.reuseResults[this.reuseChecks.length - 1] ?? false;
   }
 
@@ -2243,6 +2247,31 @@ describe('sandbox runner integration', () => {
     expect(result?.sessionState.providerState).not.toHaveProperty(
       'sessionIdentity',
     );
+  });
+
+  it('requires a trusted manifest before deserializing Docker RunState', async () => {
+    const client = new FakeSandboxClient();
+    Object.defineProperty(client, 'backendId', { value: 'docker' });
+    const deserializeSessionState = vi.spyOn(client, 'deserializeSessionState');
+
+    await expect(
+      deserializeSandboxSessionStateEntry(client, {
+        backendId: 'docker',
+        currentAgentKey: 'SandboxWorker',
+        currentAgentName: 'SandboxWorker',
+        sessionState: fakeSandboxSessionStateEnvelope(
+          {
+            sessionId: 'persisted',
+          },
+          {
+            backendId: 'docker',
+          },
+        ),
+      }),
+    ).rejects.toThrow(
+      'Docker RunState resume requires a current trusted manifest for the sandbox agent.',
+    );
+    expect(deserializeSessionState).not.toHaveBeenCalled();
   });
 
   it('resets required tool choice after a sandbox agent uses a tool', async () => {
@@ -5292,6 +5321,82 @@ describe('sandbox runner integration', () => {
       },
     ]);
     expect(client.closeCalls).toEqual([liveSession?.state.sessionId]);
+  });
+
+  it('refreshes trusted environment values before reusing a live Docker session', async () => {
+    let resolvedSecret = 'initial-secret';
+    const client = new DockerRevalidatingLiveProcessFakeSandboxClient();
+    const manifest = new Manifest({
+      environment: {
+        SECRET_ENV: {
+          value: '',
+          resolve: () => resolvedSecret,
+          ephemeral: true,
+        },
+      },
+      extraPathGrants: [
+        {
+          path: '/mnt/shared-data',
+          readOnly: true,
+        },
+      ],
+    });
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model: new RecordingFakeModel([]),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      sandboxAgent as Agent<unknown, any>,
+      1,
+    );
+    const firstManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+        manifest,
+      },
+      runState: state,
+    });
+    await firstManager.prepareAgent({
+      currentAgent: sandboxAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+    const liveSession = client.createdSessions[0]!;
+    liveSession.state.environment = {
+      SECRET_ENV: 'initial-secret',
+      PROVIDER_ENV: 'provider-value',
+    };
+    await firstManager.cleanup(state, { preserveOwnedSessions: true });
+    resolvedSecret = 'refreshed-secret';
+
+    const secondManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+        manifest,
+      },
+      runState: state,
+    });
+    await secondManager.adoptPreservedOwnedSessions();
+
+    expect(client.reuseEnvironments).toEqual([
+      {
+        SECRET_ENV: 'initial-secret',
+        PROVIDER_ENV: 'provider-value',
+      },
+      {
+        SECRET_ENV: 'refreshed-secret',
+        PROVIDER_ENV: 'provider-value',
+      },
+    ]);
+    expect(liveSession.state.environment).toEqual({
+      SECRET_ENV: 'refreshed-secret',
+      PROVIDER_ENV: 'provider-value',
+    });
+
+    await secondManager.cleanup(state);
   });
 
   it('revalidates preserved live sessions before reusing their handles', async () => {

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -520,6 +520,7 @@ class RevalidatingLiveProcessFakeSandboxClient extends FakeSandboxClient {
   readonly reuseChecks: Manifest[] = [];
   readonly reuseEnvironments: Array<Record<string, string> | undefined> = [];
   readonly reuseClientOptions: Array<SandboxClientOptions | undefined> = [];
+  readonly reuseManifestEntryRevalidations: boolean[] = [];
 
   constructor(private readonly reuseResults: boolean[] = [true, true]) {
     super();
@@ -527,13 +528,19 @@ class RevalidatingLiveProcessFakeSandboxClient extends FakeSandboxClient {
 
   canReusePreservedOwnedSession(
     state: FakeSandboxSessionState,
-    options: { clientOptions?: SandboxClientOptions } = {},
+    options: {
+      clientOptions?: SandboxClientOptions;
+      revalidateManifestEntries?: boolean;
+    } = {},
   ): boolean {
     this.reuseChecks.push(state.manifest);
     this.reuseEnvironments.push(
       state.environment ? { ...state.environment } : undefined,
     );
     this.reuseClientOptions.push(options.clientOptions);
+    this.reuseManifestEntryRevalidations.push(
+      options.revalidateManifestEntries === true,
+    );
     return this.reuseResults[this.reuseChecks.length - 1] ?? false;
   }
 
@@ -573,6 +580,24 @@ class DockerRevalidatingLiveProcessFakeSandboxClient extends RevalidatingLivePro
   override readonly backendId = 'docker';
 }
 
+class DockerRejectingManifestEntriesFakeSandboxClient extends DockerRevalidatingLiveProcessFakeSandboxClient {
+  override canReusePreservedOwnedSession(
+    state: FakeSandboxSessionState,
+    options: {
+      clientOptions?: SandboxClientOptions;
+      revalidateManifestEntries?: boolean;
+    } = {},
+  ): boolean {
+    const reusable = super.canReusePreservedOwnedSession(state, options);
+    if (options.revalidateManifestEntries) {
+      throw new UserError(
+        'Docker sandbox resume cannot apply changes to non-mount manifest entries. Start a fresh sandbox session instead.',
+      );
+    }
+    return reusable;
+  }
+}
+
 class RetryableResumeFakeSandboxClient extends RevalidatingLiveProcessFakeSandboxClient {
   private resumeFailuresRemaining = 1;
 
@@ -586,6 +611,10 @@ class RetryableResumeFakeSandboxClient extends RevalidatingLiveProcessFakeSandbo
     }
     return await super.resume(state, options);
   }
+}
+
+class DockerRetryableResumeFakeSandboxClient extends RetryableResumeFakeSandboxClient {
+  override readonly backendId = 'docker';
 }
 
 class FailingLiveCleanupFakeSandboxClient extends RevalidatingLiveProcessFakeSandboxClient {
@@ -607,6 +636,10 @@ class FailingLiveCleanupFakeSandboxClient extends RevalidatingLiveProcessFakeSan
       },
     };
   }
+}
+
+class DockerFailingLiveCleanupFakeSandboxClient extends FailingLiveCleanupFakeSandboxClient {
+  override readonly backendId = 'docker';
 }
 
 class ManifestSerializingFakeSandboxClient extends FakeSandboxClient {
@@ -5447,6 +5480,7 @@ describe('sandbox runner integration', () => {
           readOnly: true,
         },
       ],
+      remoteMountCommandAllowlist: ['mount-old'],
     });
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
@@ -5496,6 +5530,7 @@ describe('sandbox runner integration', () => {
           readOnly: true,
         },
       ],
+      remoteMountCommandAllowlist: ['mount-new'],
     });
 
     const secondManager = new SandboxRuntimeManager({
@@ -5541,6 +5576,9 @@ describe('sandbox runner integration', () => {
     expect(Object.keys(liveSession.state.manifest.environment)).toEqual([
       'SECRET_ENV',
       'ADDED_ENV',
+    ]);
+    expect(liveSession.state.manifest.remoteMountCommandAllowlist).toEqual([
+      'mount-new',
     ]);
 
     await secondManager.cleanup(state);
@@ -5780,8 +5818,80 @@ describe('sandbox runner integration', () => {
     await secondManager.cleanup(state);
   });
 
-  it('does not reuse a closed live handle after serialized resume fails', async () => {
-    const client = new RetryableResumeFakeSandboxClient([true, false, true]);
+  it('rejects live Docker reuse when non-mount entries change', async () => {
+    const client = new DockerRejectingManifestEntriesFakeSandboxClient();
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model: new RecordingFakeModel([]),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      sandboxAgent as Agent<unknown, any>,
+      1,
+    );
+    const firstManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+        manifest: new Manifest({
+          entries: {
+            'config.txt': {
+              type: 'file',
+              content: 'old',
+            },
+          },
+        }),
+      },
+      runState: state,
+    });
+    await firstManager.prepareAgent({
+      currentAgent: sandboxAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+    const liveSession = client.createdSessions[0]!;
+    await liveSession.exec!({ cmd: 'sleep 60' });
+    await firstManager.cleanup(state, { preserveOwnedSessions: true });
+
+    const secondManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+        manifest: new Manifest({
+          entries: {
+            'config.txt': {
+              type: 'file',
+              content: 'new',
+            },
+          },
+        }),
+      },
+      runState: state,
+    });
+
+    await expect(secondManager.adoptPreservedOwnedSessions()).rejects.toThrow(
+      'Docker sandbox resume cannot apply changes to non-mount manifest entries',
+    );
+    expect(client.reuseChecks).toHaveLength(2);
+    expect(client.reuseManifestEntryRevalidations).toEqual([false, true]);
+    expect(client.resumeCalls).toHaveLength(0);
+    expect(client.closeCalls).toHaveLength(0);
+    await expect(
+      liveSession.writeStdin!({
+        sessionId: 1,
+        chars: 'still-running',
+      }),
+    ).resolves.toBe('continued');
+
+    await secondManager.cleanup(state);
+  });
+
+  it('keeps a rejected live handle open until serialized resume succeeds', async () => {
+    const client = new DockerRetryableResumeFakeSandboxClient([
+      true,
+      false,
+      true,
+    ]);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
       model: new RecordingFakeModel([]),
@@ -5804,6 +5914,9 @@ describe('sandbox runner integration', () => {
       turnInput: [],
     });
     const liveSession = client.createdSessions[0];
+    await liveSession!.exec!({
+      cmd: 'sleep 60',
+    });
     await firstManager.cleanup(state, { preserveOwnedSessions: true });
 
     const secondManager = new SandboxRuntimeManager({
@@ -5816,6 +5929,13 @@ describe('sandbox runner integration', () => {
     await expect(secondManager.adoptPreservedOwnedSessions()).rejects.toThrow(
       'resume failed',
     );
+    expect(client.closeCalls).toEqual([]);
+    await expect(
+      liveSession!.writeStdin!({
+        sessionId: 1,
+        chars: 'still-running',
+      }),
+    ).resolves.toBe('continued');
     await secondManager.adoptPreservedOwnedSessions();
 
     const adoptedSession = (
@@ -5835,7 +5955,11 @@ describe('sandbox runner integration', () => {
   });
 
   it('does not retry a rejected live handle after its cleanup fails', async () => {
-    const client = new FailingLiveCleanupFakeSandboxClient([true, false, true]);
+    const client = new DockerFailingLiveCleanupFakeSandboxClient([
+      true,
+      false,
+      true,
+    ]);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
       model: new RecordingFakeModel([]),
@@ -5881,10 +6005,11 @@ describe('sandbox runner integration', () => {
       }
     ).sessionsByAgentKey.get('SandboxWorker');
     expect(client.reuseChecks).toHaveLength(2);
-    expect(client.resumeCalls).toHaveLength(1);
-    expect(adoptedSession).toBe(client.resumedSessions[0]);
+    expect(client.resumeCalls).toHaveLength(2);
+    expect(adoptedSession).toBe(client.resumedSessions[1]);
     expect(adoptedSession).not.toBe(liveSession);
     expect(client.closeCalls).toEqual([
+      liveSession?.state.sessionId,
       liveSession?.state.sessionId,
       liveSession?.state.sessionId,
     ]);

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -41,6 +41,7 @@ import {
 import { serializeSandboxRuntimeState } from '../src/sandbox/runtime/sessionSerialization';
 import {
   deserializeSandboxSessionStateEntry,
+  toSessionStateEnvelope,
   type SerializedSandboxSessionEntry,
 } from '../src/sandbox/runtime/sessionState';
 import {
@@ -253,7 +254,7 @@ class FakeSandboxClient implements SandboxClient<
   SandboxClientOptions,
   FakeSandboxSessionState
 > {
-  readonly backendId = 'fake-sandbox';
+  readonly backendId: string = 'fake-sandbox';
   readonly createCalls: Array<{
     manifest: Manifest;
     options?: SandboxClientOptions;
@@ -271,7 +272,11 @@ class FakeSandboxClient implements SandboxClient<
   readonly serializedStates: Array<FakeSandboxSessionState> = [];
   readonly serializedOptions: SandboxSessionSerializationOptions[] = [];
   readonly closeCalls: string[] = [];
-  readonly shutdownCalls: Array<{ sessionId: string; reason?: string }> = [];
+  readonly shutdownCalls: Array<{
+    sessionId: string;
+    reason?: string;
+    preserveOwnedSessions?: boolean;
+  }> = [];
   readonly startCalls: Array<{ sessionId: string; reason?: string }> = [];
   readonly createdSessions: Array<SandboxSessionLike<FakeSandboxSessionState>> =
     [];
@@ -511,6 +516,90 @@ class SerializedResumeFakeSandboxClient extends FakeSandboxClient {
   }
 }
 
+class RevalidatingLiveProcessFakeSandboxClient extends FakeSandboxClient {
+  readonly reuseChecks: Manifest[] = [];
+
+  constructor(private readonly reuseResults: boolean[] = [true, true]) {
+    super();
+  }
+
+  canReusePreservedOwnedSession(state: FakeSandboxSessionState): boolean {
+    this.reuseChecks.push(state.manifest);
+    return this.reuseResults[this.reuseChecks.length - 1] ?? false;
+  }
+
+  override makeSession(
+    state: FakeSandboxSessionState,
+  ): SandboxSessionLike<FakeSandboxSessionState> {
+    const session = super.makeSession(state);
+    const activeProcessIds = new Set<number>();
+    const close = session.close?.bind(session);
+    return {
+      ...session,
+      exec: async () => {
+        activeProcessIds.add(1);
+        return {
+          output: '',
+          stdout: '',
+          stderr: '',
+          wallTimeSeconds: 0,
+          sessionId: 1,
+        };
+      },
+      writeStdin: async ({ sessionId }) => {
+        if (!activeProcessIds.has(sessionId)) {
+          throw new Error(`Unknown process session ${sessionId}`);
+        }
+        return 'continued';
+      },
+      close: async () => {
+        activeProcessIds.clear();
+        await close?.();
+      },
+    };
+  }
+}
+
+class DockerRevalidatingLiveProcessFakeSandboxClient extends RevalidatingLiveProcessFakeSandboxClient {
+  override readonly backendId = 'docker';
+}
+
+class RetryableResumeFakeSandboxClient extends RevalidatingLiveProcessFakeSandboxClient {
+  private resumeFailuresRemaining = 1;
+
+  override async resume(
+    state: FakeSandboxSessionState,
+    options: { archiveLimits?: SandboxClientCreateArgs['archiveLimits'] } = {},
+  ): Promise<SandboxSessionLike<FakeSandboxSessionState>> {
+    if (this.resumeFailuresRemaining > 0) {
+      this.resumeFailuresRemaining -= 1;
+      throw new Error('resume failed');
+    }
+    return await super.resume(state, options);
+  }
+}
+
+class FailingLiveCleanupFakeSandboxClient extends RevalidatingLiveProcessFakeSandboxClient {
+  private cleanupFailuresRemaining = 1;
+
+  override makeSession(
+    state: FakeSandboxSessionState,
+  ): SandboxSessionLike<FakeSandboxSessionState> {
+    const session = super.makeSession(state);
+    const close = session.close!.bind(session);
+    return {
+      ...session,
+      close: async () => {
+        await close();
+        if (this.cleanupFailuresRemaining > 0) {
+          this.cleanupFailuresRemaining -= 1;
+          throw new Error('live cleanup failed');
+        }
+      },
+    };
+  }
+}
+
 class ManifestSerializingFakeSandboxClient extends FakeSandboxClient {
   override async serializeSessionState(
     state: FakeSandboxSessionState,
@@ -580,9 +669,18 @@ class ShutdownOnlyFakeSandboxClient extends FakeSandboxClient {
         this.shutdownCalls.push({
           sessionId: state.sessionId,
           reason: options?.reason,
+          ...(options?.preserveOwnedSessions === true
+            ? { preserveOwnedSessions: true }
+            : {}),
         });
       },
     };
+  }
+}
+
+class SerializedShutdownOnlyFakeSandboxClient extends ShutdownOnlyFakeSandboxClient {
+  canReusePreservedOwnedSession(): boolean {
+    return false;
   }
 }
 
@@ -2018,6 +2116,7 @@ describe('sandbox runner integration', () => {
           state.snapshotFingerprint as FakeSandboxSessionState['snapshotFingerprint'],
         snapshotFingerprintVersion:
           state.snapshotFingerprintVersion as FakeSandboxSessionState['snapshotFingerprintVersion'],
+        sessionIdentity: 'forged-deserializer-identity',
         workspaceReady: state.workspaceReady as boolean,
         exposedPorts:
           state.exposedPorts as FakeSandboxSessionState['exposedPorts'],
@@ -2033,6 +2132,7 @@ describe('sandbox runner integration', () => {
         sessionState: fakeSandboxSessionStateEnvelope(
           {
             sessionId: 'persisted',
+            sessionIdentity: 'forged-provider-identity',
           },
           {
             manifest: {
@@ -2087,7 +2187,16 @@ describe('sandbox runner integration', () => {
         '3000': { host: '127.0.0.1', port: 3000 },
       },
     });
+    expect(deserializedStates[0]?.sessionIdentity).toBe(
+      'forged-provider-identity',
+    );
     expect(state?.workspaceReady).toBe(false);
+    expect(
+      (
+        state as
+          (SandboxSessionState & { sessionIdentity?: string }) | undefined
+      )?.sessionIdentity,
+    ).toBe('forged-deserializer-identity');
     expect(state?.exposedPorts).toEqual({
       '3000': { host: '127.0.0.1', port: 3000 },
     });
@@ -2098,6 +2207,42 @@ describe('sandbox runner integration', () => {
         readOnly: true,
       },
     ]);
+  });
+
+  it('redacts Docker session identity without changing other provider state', async () => {
+    const client = new FakeSandboxClient();
+    client.serializeSessionState = async () => ({
+      sessionId: 'persisted',
+      sessionIdentity: 'forged-provider-identity',
+    });
+    const session = client.makeSession({
+      manifest: new Manifest(),
+      sessionId: 'persisted',
+      sessionIdentity: 'live-session-identity',
+    });
+    const customProviderEnvelope = toSessionStateEnvelope(
+      client.backendId,
+      session.state,
+      await client.serializeSessionState(session.state),
+    );
+    expect(customProviderEnvelope.providerState.sessionIdentity).toBe(
+      'forged-provider-identity',
+    );
+    Object.defineProperty(client, 'backendId', { value: 'docker' });
+
+    const result = await serializeSandboxRuntimeState({
+      client,
+      sandboxState: undefined,
+      sessionsByAgentKey: new Map([['SandboxWorker', session]]),
+      sessionAgentNamesByKey: new Map([['SandboxWorker', 'SandboxWorker']]),
+      ownedSessionAgentKeys: new Set(),
+      preferredCurrentAgentKey: 'SandboxWorker',
+    });
+
+    expect(result?.sessionState).not.toHaveProperty('sessionIdentity');
+    expect(result?.sessionState.providerState).not.toHaveProperty(
+      'sessionIdentity',
+    );
   });
 
   it('resets required tool choice after a sandbox agent uses a tool', async () => {
@@ -3703,6 +3848,92 @@ describe('sandbox runner integration', () => {
     expect(client.closeCalls).toEqual(['session-1']);
   });
 
+  it('does not preserve owned sessions when interruption serialization fails', async () => {
+    const client = new ShutdownOnlyFakeSandboxClient();
+    vi.spyOn(client, 'serializeSessionState').mockRejectedValue(
+      new Error('snapshot failed'),
+    );
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model: new RecordingFakeModel([]),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      sandboxAgent as Agent<unknown, any>,
+      1,
+    );
+    state._sandbox = {
+      backendId: 'fake-sandbox',
+      currentAgentKey: 'SandboxWorker',
+      currentAgentName: 'SandboxWorker',
+      sessionState: fakeSandboxSessionStateEnvelope({
+        sessionId: 'preserved-session',
+      }),
+      sessionsByAgent: {
+        SandboxWorker: {
+          backendId: 'fake-sandbox',
+          currentAgentKey: 'SandboxWorker',
+          currentAgentName: 'SandboxWorker',
+          preservedOwnedSession: true,
+          sessionState: fakeSandboxSessionStateEnvelope({
+            sessionId: 'preserved-session',
+          }),
+        },
+        OtherWorker: {
+          backendId: 'fake-sandbox',
+          currentAgentKey: 'OtherWorker',
+          currentAgentName: 'OtherWorker',
+          preservedOwnedSession: true,
+          sessionState: fakeSandboxSessionStateEnvelope({
+            sessionId: 'untouched-session',
+          }),
+        },
+      },
+    };
+    const manager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+      },
+      runState: state,
+    });
+    await manager.prepareAgent({
+      currentAgent: sandboxAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+
+    await expect(
+      manager.cleanup(state, { preserveOwnedSessions: true }),
+    ).rejects.toThrow('snapshot failed');
+
+    expect(client.shutdownCalls).toEqual([
+      {
+        sessionId: 'preserved-session',
+        reason: 'cleanup',
+      },
+    ]);
+    expect(state._sandbox).toMatchObject({
+      currentAgentKey: 'OtherWorker',
+      currentAgentName: 'OtherWorker',
+      sessionState: {
+        providerState: {
+          sessionId: 'untouched-session',
+        },
+      },
+      sessionsByAgent: {
+        OtherWorker: {
+          sessionState: {
+            providerState: {
+              sessionId: 'untouched-session',
+            },
+          },
+        },
+      },
+    });
+    expect(state._sandbox?.sessionsByAgent.SandboxWorker).toBeUndefined();
+  });
+
   it('keeps owned sandbox sessions alive across approval interruptions', async () => {
     const client = new NonPersistentFakeSandboxClient();
     const approvalTool = tool({
@@ -4041,8 +4272,9 @@ describe('sandbox runner integration', () => {
   });
 
   it('continues closing live preserved owned sessions after a close failure', async () => {
+    const failingSessionIds = new Set(['session-1']);
     const client = new SelectiveCloseFailureFakeSandboxClient(
-      new Set(['session-1']),
+      failingSessionIds,
     );
     const firstSandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
       name: 'FirstSandboxWorker',
@@ -4118,6 +4350,23 @@ describe('sandbox runner integration', () => {
 
     expect(client.closeAttempts).toEqual(['session-1', 'session-2']);
     expect(client.closeCalls).toEqual(['session-2']);
+    expect(state._sandbox?.sessionsByAgent.FirstSandboxWorker).toBeDefined();
+    expect(state._sandbox?.sessionsByAgent.SecondSandboxWorker).toBeUndefined();
+
+    failingSessionIds.clear();
+    const thirdManager = new SandboxRuntimeManager({
+      startingAgent: plainAgent,
+      runState: state,
+    });
+    await thirdManager.cleanup(state);
+
+    expect(client.closeAttempts).toEqual([
+      'session-1',
+      'session-2',
+      'session-1',
+    ]);
+    expect(client.closeCalls).toEqual(['session-2', 'session-1']);
+    expect(state._sandbox).toBeUndefined();
   });
 
   it('closes mixed live and restorable preserved sessions on non-sandbox interruption cleanup', async () => {
@@ -4956,7 +5205,97 @@ describe('sandbox runner integration', () => {
   });
 
   it('reuses preserved live owned sessions during same-process resumes', async () => {
-    const client = new FakeSandboxClient();
+    const client = new RevalidatingLiveProcessFakeSandboxClient();
+    const manifest = new Manifest({
+      extraPathGrants: [
+        {
+          path: '/mnt/shared-data',
+          readOnly: true,
+        },
+      ],
+    });
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model: new RecordingFakeModel([]),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      sandboxAgent as Agent<unknown, any>,
+      1,
+    );
+    const firstManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+        manifest,
+      },
+      runState: state,
+    });
+
+    await withTrace('owned session prepare test', async () => {
+      await firstManager.prepareAgent({
+        currentAgent: sandboxAgent as Agent<unknown, any>,
+        turnInput: [],
+      });
+    });
+    const liveSession = client.createdSessions[0];
+    expect(liveSession).toBeDefined();
+    const activeProcess = await liveSession!.exec!({
+      cmd: 'sleep 60',
+    });
+
+    await withTrace('owned session preserve test', async () => {
+      await firstManager.cleanup(state, { preserveOwnedSessions: true });
+    });
+    expect(client.closeCalls).toEqual([]);
+
+    const secondManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+        manifest,
+      },
+      runState: state,
+    });
+
+    await withTrace('owned session adopt live test', async () => {
+      await secondManager.adoptPreservedOwnedSessions();
+      const adoptedSession = (
+        secondManager as unknown as {
+          sessionsByAgentKey: Map<
+            string,
+            SandboxSessionLike<FakeSandboxSessionState>
+          >;
+        }
+      ).sessionsByAgentKey.get('SandboxWorker');
+      expect(adoptedSession).toBe(liveSession);
+      await expect(
+        adoptedSession!.writeStdin!({
+          sessionId: activeProcess.sessionId!,
+          chars: 'next',
+        }),
+      ).resolves.toBe('continued');
+      await secondManager.prepareAgent({
+        currentAgent: sandboxAgent as Agent<unknown, any>,
+        turnInput: [],
+      });
+      await secondManager.cleanup(state);
+    });
+
+    expect(client.resumeCalls).toHaveLength(0);
+    expect(client.reuseChecks).toHaveLength(2);
+    expect(client.reuseChecks[1]?.extraPathGrants).toEqual([
+      {
+        path: '/mnt/shared-data',
+        readOnly: true,
+      },
+    ]);
+    expect(client.closeCalls).toEqual([liveSession?.state.sessionId]);
+  });
+
+  it('revalidates preserved live sessions before reusing their handles', async () => {
+    const client = new RevalidatingLiveProcessFakeSandboxClient([true, false]);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
       model: new RecordingFakeModel([]),
@@ -4974,18 +5313,15 @@ describe('sandbox runner integration', () => {
       },
       runState: state,
     });
-
-    await withTrace('owned session preserve test', async () => {
-      await firstManager.prepareAgent({
-        currentAgent: sandboxAgent as Agent<unknown, any>,
-        turnInput: [],
-      });
-      await firstManager.cleanup(state, { preserveOwnedSessions: true });
+    await firstManager.prepareAgent({
+      currentAgent: sandboxAgent as Agent<unknown, any>,
+      turnInput: [],
     });
-
     const liveSession = client.createdSessions[0];
-    expect(liveSession).toBeDefined();
-    expect(client.closeCalls).toEqual([]);
+    const activeProcess = await liveSession!.exec!({
+      cmd: 'sleep 60',
+    });
+    await firstManager.cleanup(state, { preserveOwnedSessions: true });
 
     const secondManager = new SandboxRuntimeManager({
       startingAgent: sandboxAgent as Agent<unknown, any>,
@@ -4994,18 +5330,317 @@ describe('sandbox runner integration', () => {
       },
       runState: state,
     });
+    await secondManager.adoptPreservedOwnedSessions();
 
-    await withTrace('owned session adopt live test', async () => {
-      await secondManager.adoptPreservedOwnedSessions();
-      await secondManager.prepareAgent({
-        currentAgent: sandboxAgent as Agent<unknown, any>,
-        turnInput: [],
-      });
-      await secondManager.cleanup(state);
-    });
-
-    expect(client.resumeCalls).toHaveLength(0);
+    const adoptedSession = (
+      secondManager as unknown as {
+        sessionsByAgentKey: Map<
+          string,
+          SandboxSessionLike<FakeSandboxSessionState>
+        >;
+      }
+    ).sessionsByAgentKey.get('SandboxWorker');
+    expect(client.reuseChecks).toHaveLength(2);
+    expect(client.resumeCalls).toHaveLength(1);
+    expect(adoptedSession).toBe(client.resumedSessions[0]);
+    expect(adoptedSession).not.toBe(liveSession);
+    await expect(
+      liveSession!.writeStdin!({
+        sessionId: activeProcess.sessionId!,
+        chars: 'next',
+      }),
+    ).rejects.toThrow('Unknown process session 1');
     expect(client.closeCalls).toEqual([liveSession?.state.sessionId]);
+
+    await secondManager.cleanup(state);
+  });
+
+  it('revalidates the complete trusted Docker mount-authority manifest', async () => {
+    const client = new DockerRevalidatingLiveProcessFakeSandboxClient([
+      true,
+      false,
+    ]);
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model: new RecordingFakeModel([]),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      sandboxAgent as Agent<unknown, any>,
+      1,
+    );
+    const firstManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+        manifest: new Manifest({
+          root: '/old-workspace',
+          entries: {
+            oldBind: {
+              type: 'mount',
+              source: '/private/old-bind',
+              mountStrategy: {
+                type: 'local_bind',
+              },
+            },
+          },
+          extraPathGrants: [
+            {
+              path: '/mnt/changed-data',
+              hostPath: '/private/changed-data',
+              readOnly: false,
+            },
+            {
+              path: '/mnt/removed-data',
+              hostPath: '/private/removed-data',
+              readOnly: false,
+            },
+          ],
+        }),
+      },
+      runState: state,
+    });
+    await firstManager.prepareAgent({
+      currentAgent: sandboxAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+    const liveSession = client.createdSessions[0];
+    await firstManager.cleanup(state, { preserveOwnedSessions: true });
+
+    const trustedManifest = new Manifest({
+      root: '/new-workspace',
+      entries: {
+        newBind: {
+          type: 'mount',
+          source: '/private/new-bind',
+          mountStrategy: {
+            type: 'local_bind',
+          },
+        },
+      },
+      extraPathGrants: [
+        {
+          path: '/mnt/changed-data',
+          readOnly: true,
+        },
+        {
+          path: '/mnt/added-data',
+          readOnly: true,
+        },
+      ],
+    });
+    const secondManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+        manifest: trustedManifest,
+      },
+      runState: state,
+    });
+    await secondManager.adoptPreservedOwnedSessions();
+
+    expect(client.reuseChecks).toHaveLength(2);
+    expect(client.reuseChecks[1]?.extraPathGrants).toEqual(
+      trustedManifest.extraPathGrants,
+    );
+    expect(client.reuseChecks[1]?.root).toBe(trustedManifest.root);
+    expect(client.reuseChecks[1]?.entries).toEqual(trustedManifest.entries);
+    expect(client.closeCalls).toEqual([liveSession?.state.sessionId]);
+    expect(client.resumeCalls).toHaveLength(1);
+    expect(client.resumeCalls[0]?.state.manifest.extraPathGrants).toEqual(
+      trustedManifest.extraPathGrants,
+    );
+    expect(client.resumeCalls[0]?.state.manifest.root).toBe(
+      trustedManifest.root,
+    );
+    expect(client.resumeCalls[0]?.state.manifest.entries).toEqual(
+      trustedManifest.entries,
+    );
+
+    await secondManager.cleanup(state);
+  });
+
+  it('does not reuse a closed live handle after serialized resume fails', async () => {
+    const client = new RetryableResumeFakeSandboxClient([true, false, true]);
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model: new RecordingFakeModel([]),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      sandboxAgent as Agent<unknown, any>,
+      1,
+    );
+    const firstManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+      },
+      runState: state,
+    });
+    await firstManager.prepareAgent({
+      currentAgent: sandboxAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+    const liveSession = client.createdSessions[0];
+    await firstManager.cleanup(state, { preserveOwnedSessions: true });
+
+    const secondManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+      },
+      runState: state,
+    });
+    await expect(secondManager.adoptPreservedOwnedSessions()).rejects.toThrow(
+      'resume failed',
+    );
+    await secondManager.adoptPreservedOwnedSessions();
+
+    const adoptedSession = (
+      secondManager as unknown as {
+        sessionsByAgentKey: Map<
+          string,
+          SandboxSessionLike<FakeSandboxSessionState>
+        >;
+      }
+    ).sessionsByAgentKey.get('SandboxWorker');
+    expect(client.reuseChecks).toHaveLength(2);
+    expect(adoptedSession).toBe(client.resumedSessions[0]);
+    expect(adoptedSession).not.toBe(liveSession);
+    expect(client.closeCalls).toEqual([liveSession?.state.sessionId]);
+
+    await secondManager.cleanup(state);
+  });
+
+  it('does not retry a rejected live handle after its cleanup fails', async () => {
+    const client = new FailingLiveCleanupFakeSandboxClient([true, false, true]);
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model: new RecordingFakeModel([]),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      sandboxAgent as Agent<unknown, any>,
+      1,
+    );
+    const firstManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+      },
+      runState: state,
+    });
+    await firstManager.prepareAgent({
+      currentAgent: sandboxAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+    const liveSession = client.createdSessions[0];
+    await firstManager.cleanup(state, { preserveOwnedSessions: true });
+
+    const secondManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+      },
+      runState: state,
+    });
+    await expect(secondManager.adoptPreservedOwnedSessions()).rejects.toThrow(
+      'live cleanup failed',
+    );
+    await secondManager.adoptPreservedOwnedSessions();
+
+    const adoptedSession = (
+      secondManager as unknown as {
+        sessionsByAgentKey: Map<
+          string,
+          SandboxSessionLike<FakeSandboxSessionState>
+        >;
+      }
+    ).sessionsByAgentKey.get('SandboxWorker');
+    expect(client.reuseChecks).toHaveLength(2);
+    expect(client.resumeCalls).toHaveLength(1);
+    expect(adoptedSession).toBe(client.resumedSessions[0]);
+    expect(adoptedSession).not.toBe(liveSession);
+    expect(client.closeCalls).toEqual([
+      liveSession?.state.sessionId,
+      liveSession?.state.sessionId,
+    ]);
+
+    await secondManager.cleanup(state);
+  });
+
+  it('does not reuse an adopted live handle after cleanup fails', async () => {
+    const client = new FailingLiveCleanupFakeSandboxClient([true, true, true]);
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model: new RecordingFakeModel([]),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      sandboxAgent as Agent<unknown, any>,
+      1,
+    );
+    const firstManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+      },
+      runState: state,
+    });
+    await firstManager.prepareAgent({
+      currentAgent: sandboxAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+    const liveSession = client.createdSessions[0];
+    await firstManager.cleanup(state, { preserveOwnedSessions: true });
+
+    const secondManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+      },
+      runState: state,
+    });
+    await secondManager.adoptPreservedOwnedSessions();
+    vi.spyOn(client, 'serializeSessionState').mockRejectedValueOnce(
+      new Error('snapshot failed'),
+    );
+    await expect(secondManager.cleanup(state)).rejects.toThrow(
+      'live cleanup failed',
+    );
+
+    const thirdManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+      },
+      runState: state,
+    });
+    await thirdManager.adoptPreservedOwnedSessions();
+
+    const adoptedSession = (
+      thirdManager as unknown as {
+        sessionsByAgentKey: Map<
+          string,
+          SandboxSessionLike<FakeSandboxSessionState>
+        >;
+      }
+    ).sessionsByAgentKey.get('SandboxWorker');
+    expect(client.reuseChecks).toHaveLength(2);
+    expect(client.resumeCalls).toHaveLength(1);
+    expect(adoptedSession).toBe(client.resumedSessions[0]);
+    expect(adoptedSession).not.toBe(liveSession);
+    expect(client.closeCalls).toEqual([
+      liveSession?.state.sessionId,
+      liveSession?.state.sessionId,
+    ]);
+
+    await thirdManager.cleanup(state);
   });
 
   it('reuses preserved live owned sessions when the client has no resume API', async () => {
@@ -5104,6 +5739,44 @@ describe('sandbox runner integration', () => {
     expect(client.closeCalls).toEqual(['session-1']);
   });
 
+  it('closes owned session backends when live reuse is unavailable', async () => {
+    const client = new SerializedShutdownOnlyFakeSandboxClient();
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model: new RecordingFakeModel([]),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      sandboxAgent as Agent<unknown, any>,
+      1,
+    );
+    const manager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+      },
+      runState: state,
+    });
+    await manager.prepareAgent({
+      currentAgent: sandboxAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+
+    await manager.cleanup(state, { preserveOwnedSessions: true });
+
+    expect(state._sandbox?.sessionsByAgent.SandboxWorker).toMatchObject({
+      preservedOwnedSession: true,
+      reuseLiveSession: false,
+    });
+    expect(client.shutdownCalls).toEqual([
+      {
+        sessionId: 'session-1',
+        reason: 'cleanup',
+      },
+    ]);
+  });
+
   it('resumes serialized preserved sessions when live reuse is disabled', async () => {
     const client = new SerializedResumeFakeSandboxClient();
     const sandboxAgent = new SandboxAgent({
@@ -5140,7 +5813,7 @@ describe('sandbox runner integration', () => {
       {
         preserveOwnedSession: true,
         reuseLiveSession: false,
-        willCloseAfterSerialize: false,
+        willCloseAfterSerialize: true,
       },
     ]);
     expect(client.closeCalls).toEqual(['session-1']);

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -1802,6 +1802,108 @@ describe('sandbox runner integration', () => {
     await manager.cleanup(runState);
   });
 
+  it('refreshes trusted environment for explicit Docker session state', async () => {
+    const client = new FakeSandboxClient();
+    Object.defineProperty(client, 'backendId', { value: 'docker' });
+    const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
+      name: 'SandboxWorker',
+      model: new RecordingFakeModel([]),
+      defaultManifest: new Manifest({
+        environment: {
+          SECRET_ENV: {
+            value: '',
+            resolve: () => 'refreshed-secret',
+            ephemeral: true,
+          },
+        },
+      }),
+    });
+    const sessionState: FakeSandboxSessionState = {
+      manifest: new Manifest(),
+      sessionId: 'persisted',
+      environment: {
+        PROVIDER_ENV: 'provider-value',
+      },
+    };
+    const runState = new RunState<
+      unknown,
+      SandboxAgent<unknown, AgentOutputType>
+    >(new RunContext(), 'Hello', sandboxAgent, 1);
+    const manager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent,
+      sandboxConfig: {
+        client,
+        sessionState,
+      },
+      runState,
+    });
+
+    await manager.prepareAgent({
+      currentAgent: sandboxAgent,
+      turnInput: [],
+    });
+
+    expect(client.resumeCalls[0]?.state.environment).toEqual({
+      PROVIDER_ENV: 'provider-value',
+      SECRET_ENV: 'refreshed-secret',
+    });
+    expect(
+      client.resumeCalls[0]?.state.manifest.environment.SECRET_ENV,
+    ).toEqual(
+      expect.objectContaining({
+        ephemeral: true,
+      }),
+    );
+    expect(sessionState.environment).toEqual({
+      PROVIDER_ENV: 'provider-value',
+    });
+
+    await manager.cleanup(runState);
+  });
+
+  it('rejects explicit Docker session state when trusted environment removes a key', async () => {
+    const client = new FakeSandboxClient();
+    Object.defineProperty(client, 'backendId', { value: 'docker' });
+    const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
+      name: 'SandboxWorker',
+      model: new RecordingFakeModel([]),
+    });
+    const sessionState: FakeSandboxSessionState = {
+      manifest: new Manifest({
+        environment: {
+          REVOKED_ENV: 'credential',
+        },
+      }),
+      sessionId: 'persisted',
+      environment: {
+        REVOKED_ENV: 'credential',
+      },
+    };
+    const runState = new RunState<
+      unknown,
+      SandboxAgent<unknown, AgentOutputType>
+    >(new RunContext(), 'Hello', sandboxAgent, 1);
+    const manager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent,
+      sandboxConfig: {
+        client,
+        sessionState,
+        manifest: new Manifest(),
+      },
+      runState,
+    });
+
+    await expect(
+      manager.prepareAgent({
+        currentAgent: sandboxAgent,
+        turnInput: [],
+      }),
+    ).rejects.toThrow(
+      'Docker sandbox session state cannot be resumed because the current trusted manifest removes an environment variable.',
+    );
+    expect(client.resumeCalls).toHaveLength(0);
+  });
+
   it('sanitizes manifest data in serialized sandbox state envelopes', async () => {
     const client = new FakeSandboxClient();
     const sandboxAgent = new SandboxAgent({
@@ -5370,12 +5472,28 @@ describe('sandbox runner integration', () => {
     };
     await firstManager.cleanup(state, { preserveOwnedSessions: true });
     resolvedSecret = 'refreshed-secret';
+    const refreshedManifest = new Manifest({
+      environment: {
+        SECRET_ENV: {
+          value: '',
+          resolve: () => resolvedSecret,
+          ephemeral: true,
+        },
+        ADDED_ENV: 'added-value',
+      },
+      extraPathGrants: [
+        {
+          path: '/mnt/shared-data',
+          readOnly: true,
+        },
+      ],
+    });
 
     const secondManager = new SandboxRuntimeManager({
       startingAgent: sandboxAgent as Agent<unknown, any>,
       sandboxConfig: {
         client,
-        manifest,
+        manifest: refreshedManifest,
       },
       runState: state,
     });
@@ -5388,13 +5506,86 @@ describe('sandbox runner integration', () => {
       },
       {
         SECRET_ENV: 'refreshed-secret',
+        ADDED_ENV: 'added-value',
         PROVIDER_ENV: 'provider-value',
       },
     ]);
     expect(liveSession.state.environment).toEqual({
       SECRET_ENV: 'refreshed-secret',
+      ADDED_ENV: 'added-value',
       PROVIDER_ENV: 'provider-value',
     });
+    expect(Object.keys(liveSession.state.manifest.environment)).toEqual([
+      'SECRET_ENV',
+      'ADDED_ENV',
+    ]);
+
+    await secondManager.cleanup(state);
+  });
+
+  it('rejects live Docker reuse when trusted environment removes a key', async () => {
+    const client = new DockerRevalidatingLiveProcessFakeSandboxClient();
+    const initialManifest = new Manifest({
+      environment: {
+        REVOKED_ENV: 'credential',
+      },
+      extraPathGrants: [
+        {
+          path: '/mnt/shared-data',
+          readOnly: true,
+        },
+      ],
+    });
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model: new RecordingFakeModel([]),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      sandboxAgent as Agent<unknown, any>,
+      1,
+    );
+    const firstManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+        manifest: initialManifest,
+      },
+      runState: state,
+    });
+    await firstManager.prepareAgent({
+      currentAgent: sandboxAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+    const liveSession = client.createdSessions[0]!;
+    liveSession.state.environment = {
+      REVOKED_ENV: 'credential',
+      PROVIDER_ENV: 'provider-value',
+    };
+    await firstManager.cleanup(state, { preserveOwnedSessions: true });
+
+    const secondManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+        manifest: new Manifest({
+          extraPathGrants: [
+            {
+              path: '/mnt/shared-data',
+              readOnly: true,
+            },
+          ],
+        }),
+      },
+      runState: state,
+    });
+    await secondManager.adoptPreservedOwnedSessions();
+
+    expect(client.reuseChecks).toHaveLength(1);
+    expect(client.closeCalls).toEqual([liveSession.state.sessionId]);
+    expect(client.resumeCalls).toHaveLength(1);
+    expect(client.resumeCalls[0]?.state.environment).toBeUndefined();
 
     await secondManager.cleanup(state);
   });

--- a/packages/agents-core/test/sandboxes/docker.test.ts
+++ b/packages/agents-core/test/sandboxes/docker.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -7,6 +7,7 @@ import {
   DockerSandboxClient,
   inContainerMountStrategy,
   Manifest,
+  NoopSnapshotSpec,
 } from '../../src/sandbox/local';
 
 const ONE_BY_ONE_PNG = Uint8Array.from(
@@ -242,6 +243,46 @@ describe('DockerSandboxClient', () => {
         baseDir: rootDir,
       });
       expect(restoredOutput).toContain('after');
+    },
+    DOCKER_TEST_TIMEOUT_MS,
+  );
+
+  itIfDocker(
+    'reuses a running container when bind mount authority is unchanged',
+    async () => {
+      rootDir = await mkdtemp(
+        join(tmpdir(), 'agents-core-docker-sandbox-test-'),
+      );
+      const sharedPath = join(rootDir, 'shared');
+      await mkdir(sharedPath);
+      const client = new DockerSandboxClient({
+        workspaceBaseDir: rootDir,
+        image: DOCKER_TEST_IMAGE,
+        snapshot: new NoopSnapshotSpec(),
+      });
+      const session = await client.create(
+        new Manifest({
+          extraPathGrants: [{ path: sharedPath, readOnly: true }],
+        }),
+      );
+      cleanupContainerIds.add(session.state.containerId);
+      await session.execCommand({
+        cmd: 'printf retained > /tmp/container-only-state',
+      });
+      const serialized = await client.serializeSessionState(session.state);
+
+      const resumed = await client.resume(
+        await client.deserializeSessionState(
+          JSON.parse(JSON.stringify(serialized)) as Record<string, unknown>,
+        ),
+      );
+
+      expect(resumed.state.containerId).toBe(session.state.containerId);
+      expect(
+        await resumed.execCommand({
+          cmd: 'cat /tmp/container-only-state',
+        }),
+      ).toContain('retained');
     },
     DOCKER_TEST_TIMEOUT_MS,
   );

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -2320,6 +2320,16 @@ describe('DockerSandboxClient unit behavior', () => {
     await expect(
       client.canReusePreservedOwnedSession(session.state),
     ).resolves.toBe(true);
+    await expect(
+      client.canReusePreservedOwnedSession(session.state, {
+        clientOptions: { image: 'different-image' },
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      client.canReusePreservedOwnedSession(session.state, {
+        clientOptions: { exposedPorts: [8080] },
+      }),
+    ).resolves.toBe(false);
     expect(activeChild.kill).not.toHaveBeenCalled();
     expect(runCount).toBe(1);
     expect(processMocks.runSandboxProcess).not.toHaveBeenCalledWith(
@@ -2329,6 +2339,59 @@ describe('DockerSandboxClient unit behavior', () => {
     );
 
     await session.close();
+  });
+
+  it('restarts when container account provisioning changes', async () => {
+    let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `container-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          const inspection = dockerInspectionResult(inspections, args);
+          if (inspection) {
+            return inspection;
+          }
+          return success('true\n');
+        }
+        if (args[0] === 'rm' || args[0] === 'exec') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(new Manifest());
+
+    const resumed = await client.resume({
+      ...session.state,
+      manifest: new Manifest({
+        users: [{ name: 'sandbox-user' }],
+      }),
+    });
+
+    expect(resumed.state.containerId).toBe('container-2');
+    expect(runCount).toBe(2);
+    expect(processMocks.runSandboxProcess).toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining(['rm', '-f', 'container-1']),
+      expect.anything(),
+    );
+    expect(processMocks.runSandboxProcess).toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining(['exec', '-u', 'root', 'container-2']),
+      expect.anything(),
+    );
   });
 
   it('rejects a fully swapped running Docker session without deleting it', async () => {

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -2341,6 +2341,56 @@ describe('DockerSandboxClient unit behavior', () => {
     await session.close();
   });
 
+  it('preserves live reuse after runtime files are materialized', async () => {
+    let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `container-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          const inspection = dockerInspectionResult(inspections, args);
+          if (inspection) {
+            return inspection;
+          }
+          return success('true\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(new Manifest());
+    await session.applyManifest(
+      new Manifest({
+        entries: {
+          'runtime.txt': {
+            type: 'file',
+            content: 'runtime',
+          },
+        },
+      }),
+    );
+
+    await expect(
+      client.canReusePreservedOwnedSession(session.state),
+    ).resolves.toBe(true);
+    expect(runCount).toBe(1);
+
+    await session.close();
+  });
+
   it('restarts when container account provisioning changes', async () => {
     let runCount = 0;
     const inspections = new Map<string, DockerContainerInspection>();
@@ -2393,6 +2443,92 @@ describe('DockerSandboxClient unit behavior', () => {
       expect.anything(),
     );
   });
+
+  it.each([
+    ['replaced persistent', 'old', 'new', false],
+    ['replaced ephemeral', 'old', 'new', true],
+    ['added', undefined, 'new', false],
+    ['removed', 'old', undefined, false],
+  ])(
+    'rejects changed %s non-mount entries without removing the container',
+    async (_kind, initialContent, currentContent, ephemeral) => {
+      let runCount = 0;
+      const inspections = new Map<string, DockerContainerInspection>();
+      processMocks.runSandboxProcess.mockImplementation(
+        async (_command: string, args: string[]) => {
+          if (args[0] === 'version') {
+            return success('Docker version test');
+          }
+          if (args[0] === 'run') {
+            runCount += 1;
+            const containerId = `container-${runCount}`;
+            inspections.set(containerId, dockerRunInspection(args));
+            return success(`${containerId}\n`);
+          }
+          if (args[0] === 'inspect') {
+            const inspection = dockerInspectionResult(inspections, args);
+            if (inspection) {
+              return inspection;
+            }
+            return success('true\n');
+          }
+          if (args[0] === 'rm') {
+            return success();
+          }
+          return failure('unexpected docker command');
+        },
+      );
+      const client = new DockerSandboxClient({
+        workspaceBaseDir: rootDir,
+      });
+      const session = await client.create(
+        new Manifest({
+          entries:
+            initialContent === undefined
+              ? {}
+              : {
+                  'config.txt': {
+                    type: 'file',
+                    content: initialContent,
+                    ephemeral,
+                  },
+                },
+        }),
+      );
+
+      const changedState = {
+        ...session.state,
+        manifest: new Manifest({
+          entries:
+            currentContent === undefined
+              ? {}
+              : {
+                  'config.txt': {
+                    type: 'file' as const,
+                    content: currentContent,
+                    ephemeral,
+                  },
+                },
+        }),
+      };
+
+      await expect(
+        client.canReusePreservedOwnedSession(changedState, {
+          revalidateManifestEntries: true,
+        }),
+      ).rejects.toThrow(
+        'Docker sandbox resume cannot apply changes to non-mount manifest entries',
+      );
+      expect(runCount).toBe(1);
+      expect(processMocks.runSandboxProcess).not.toHaveBeenCalledWith(
+        'docker',
+        expect.arrayContaining(['rm', '-f', 'container-1']),
+        expect.anything(),
+      );
+
+      await session.close();
+    },
+  );
 
   it('rejects a fully swapped running Docker session without deleting it', async () => {
     let runCount = 0;
@@ -3346,7 +3482,10 @@ describe('DockerSandboxClient unit behavior', () => {
       '/mnt/shared-data',
     ]);
     expect(serialized.sessionIdentity).toBe(session.state.sessionIdentity);
+    expect(session.state.materializedEntriesFingerprint).toBeDefined();
+    expect(serialized).not.toHaveProperty('materializedEntriesFingerprint');
     expect(deserialized.sessionIdentity).toBe(session.state.sessionIdentity);
+    expect(deserialized.materializedEntriesFingerprint).toBeUndefined();
     expect(deserialized.manifest.extraPathGrants).toEqual([
       {
         path: '/mnt/shared-data',

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -2415,7 +2415,7 @@ describe('DockerSandboxClient unit behavior', () => {
     await secondSession.close();
   });
 
-  it('reuses a legacy zero-grant container with exact declared bind mounts', async () => {
+  it('reuses a legacy container with exact grant and declared bind mounts', async () => {
     let runCount = 0;
     const inspections = new Map<string, DockerContainerInspection>();
     processMocks.runSandboxProcess.mockImplementation(
@@ -2446,9 +2446,17 @@ describe('DockerSandboxClient unit behavior', () => {
       workspaceBaseDir: rootDir,
     });
     const declaredSource = join(rootDir, 'declared');
+    const grantedSource = join(rootDir, 'granted');
     await mkdir(declaredSource);
+    await mkdir(grantedSource);
     const session = await client.create(
       new Manifest({
+        extraPathGrants: [
+          {
+            path: grantedSource,
+            readOnly: true,
+          },
+        ],
         entries: {
           declared: {
             type: 'mount',

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -2692,6 +2692,70 @@ describe('DockerSandboxClient unit behavior', () => {
     );
   });
 
+  it('restarts when a path-granted session changes a non-bind mount', async () => {
+    let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `container-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          const inspection = dockerInspectionResult(inspections, args);
+          if (inspection) {
+            return inspection;
+          }
+          return success('true\n');
+        }
+        if (args[0] === 'rm' || args[0] === 'volume') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const sharedPath = join(rootDir, 'shared-data');
+    await mkdir(sharedPath);
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          logs: {
+            type: 's3_mount',
+            bucket: 'agent-logs',
+            mountPath: '/mnt/logs',
+            mountStrategy: dockerVolumeMountStrategy({
+              driver: 'rclone',
+            }),
+          },
+        },
+        extraPathGrants: [{ path: sharedPath, readOnly: true }],
+      }),
+    );
+
+    const resumed = await client.resume({
+      ...session.state,
+      manifest: new Manifest({
+        extraPathGrants: [{ path: sharedPath, readOnly: true }],
+      }),
+    });
+
+    expect(resumed.state.containerId).toBe('container-2');
+    expect(runCount).toBe(2);
+    expect(processMocks.runSandboxProcess).toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining(['rm', '-f', 'container-1']),
+      expect.anything(),
+    );
+  });
+
   it('restarts a running container when path grant mount policy changes', async () => {
     let runCount = 0;
     const inspections = new Map<string, DockerContainerInspection>();
@@ -3774,6 +3838,7 @@ describe('DockerSandboxClient unit behavior', () => {
 
   it('restores untrusted running RunState without touching its live resources', async () => {
     let runCount = 0;
+    let resolvedSecret = 'initial-secret';
     const inspections = new Map<string, DockerContainerInspection>();
     processMocks.runSandboxProcess.mockImplementation(
       async (_command: string, args: string[]) => {
@@ -3801,6 +3866,8 @@ describe('DockerSandboxClient unit behavior', () => {
     );
     const client = new DockerSandboxClient({
       workspaceBaseDir: rootDir,
+      image: 'client:image',
+      exposedPorts: [3000],
       snapshot: {
         type: 'local',
         baseDir: rootDir,
@@ -3808,6 +3875,13 @@ describe('DockerSandboxClient unit behavior', () => {
     });
     const session = await client.create(
       new Manifest({
+        environment: {
+          SECRET_ENV: {
+            value: '',
+            resolve: () => resolvedSecret,
+            ephemeral: true,
+          },
+        },
         entries: {
           'notes.txt': {
             type: 'file',
@@ -3818,6 +3892,13 @@ describe('DockerSandboxClient unit behavior', () => {
     );
 
     const serialized = await client.serializeSessionState(session.state);
+    serialized.image = 'untrusted:image';
+    serialized.environment = {
+      SECRET_ENV: 'stale-secret',
+      UNTRUSTED_ENV: 'untrusted-value',
+    };
+    serialized.defaultUser = 'root';
+    serialized.configuredExposedPorts = [9999];
     expect(serialized.snapshotFingerprint).toEqual(expect.any(String));
     expect(serialized.snapshotFingerprintVersion).toBe(
       'workspace_tree_sha256_v1',
@@ -3828,6 +3909,7 @@ describe('DockerSandboxClient unit behavior', () => {
       'drifted\n',
       'utf8',
     );
+    resolvedSecret = 'refreshed-secret';
 
     const persistedState = (await deserializeSandboxSessionStateEntry(
       client,
@@ -3842,6 +3924,17 @@ describe('DockerSandboxClient unit behavior', () => {
         ),
       },
       session.state.manifest,
+      {
+        clientOptions: {
+          image: 'run:image',
+          exposedPorts: [4000],
+          workspaceBaseDir: rootDir,
+        },
+        snapshot: {
+          type: 'local',
+          baseDir: rootDir,
+        },
+      },
     )) as DockerSandboxSessionState;
 
     const restored = await client.resume(persistedState);
@@ -3860,6 +3953,28 @@ describe('DockerSandboxClient unit behavior', () => {
         ([, args]) => args[0] === 'inspect',
       ),
     ).toBe(false);
+    expect(restored.state.image).toBe('run:image');
+    expect(restored.state.environment).toEqual({
+      SECRET_ENV: 'refreshed-secret',
+    });
+    expect(restored.state.defaultUser).not.toBe('root');
+    expect(restored.state.configuredExposedPorts).toEqual([4000]);
+    const restoredRunArgs = processMocks.runSandboxProcess.mock.calls.filter(
+      ([, args]) => args[0] === 'run',
+    )[1]?.[1];
+    expect(restoredRunArgs).toEqual(
+      expect.arrayContaining([
+        '-e',
+        'SECRET_ENV=refreshed-secret',
+        '-p',
+        '127.0.0.1::4000',
+        'run:image',
+      ]),
+    );
+    expect(restoredRunArgs).not.toContain('stale-secret');
+    expect(restoredRunArgs).not.toContain('UNTRUSTED_ENV=untrusted-value');
+    expect(restoredRunArgs).not.toContain('127.0.0.1::9999');
+    expect(restoredRunArgs).not.toContain('untrusted:image');
     await expect(
       readFile(join(session.state.workspaceRootPath, 'notes.txt'), 'utf8'),
     ).resolves.toBe('drifted\n');

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -4,9 +4,12 @@ import {
   mkdtemp,
   readdir,
   readFile,
+  realpath,
+  rename,
   rm,
   stat,
   symlink,
+  unlink,
   writeFile,
 } from 'node:fs/promises';
 import { EventEmitter } from 'node:events';
@@ -15,8 +18,16 @@ import { join } from 'node:path';
 import { PassThrough } from 'node:stream';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SandboxProcessResult } from '../../src/sandbox/sandboxes/shared/runProcess';
+import { rebindPersistedPathGrants } from '../../src/sandbox/sandboxes/shared/manifestPersistence';
+import {
+  deserializeSandboxSessionStateEntry,
+  toSessionStateEnvelope,
+} from '../../src/sandbox/runtime/sessionState';
 
 const dockerStdinWrites: Array<string | Uint8Array> = [];
+const dockerMountAuthorityFingerprintLabel =
+  'openai-agents-sandbox.mount-authority-fingerprint';
+const dockerSessionIdentityLabel = 'openai-agents-sandbox.session-identity';
 const processMocks = vi.hoisted(() => ({
   runSandboxProcess: vi.fn(),
 }));
@@ -40,6 +51,7 @@ vi.mock('node:child_process', async (importOriginal) => {
 import {
   dockerVolumeMountStrategy,
   DockerSandboxClient,
+  type DockerSandboxSessionState,
   inContainerMountStrategy,
   Manifest,
   NoopSnapshotSpec,
@@ -62,15 +74,101 @@ const failure = (stderr: string): SandboxProcessResult => ({
   timedOut: false,
 });
 
+function dockerRunLabels(args: string[]): Record<string, string> {
+  return Object.fromEntries(
+    args.flatMap((arg, index) => {
+      if (arg !== '--label') {
+        return [];
+      }
+      const value = args[index + 1];
+      const separatorIndex = value?.indexOf('=') ?? -1;
+      return separatorIndex > 0
+        ? [[value!.slice(0, separatorIndex), value!.slice(separatorIndex + 1)]]
+        : [];
+    }),
+  );
+}
+
+function dockerWorkspaceMount(source: string, target = '/workspace') {
+  return [
+    {
+      Type: 'bind',
+      Source: source,
+      Destination: target,
+      RW: true,
+    },
+  ];
+}
+
+type DockerContainerInspection = {
+  labels: Record<string, string>;
+  mounts: ReturnType<typeof dockerWorkspaceMount>;
+};
+
+function dockerRunInspection(args: string[]): DockerContainerInspection {
+  const workspaceMountIndex = args.indexOf('-v');
+  const workspaceMount = args[workspaceMountIndex + 1] ?? '';
+  const separatorIndex = workspaceMount.indexOf(':');
+  const mounts = dockerWorkspaceMount(
+    workspaceMount.slice(0, separatorIndex),
+    workspaceMount.slice(separatorIndex + 1),
+  );
+  for (let index = 0; index < args.length - 1; index += 1) {
+    if (args[index] !== '--mount') {
+      continue;
+    }
+    const options = Object.fromEntries(
+      (args[index + 1] ?? '').split(',').map((option) => {
+        const optionSeparatorIndex = option.indexOf('=');
+        return optionSeparatorIndex === -1
+          ? [option, true]
+          : [
+              option.slice(0, optionSeparatorIndex),
+              option.slice(optionSeparatorIndex + 1),
+            ];
+      }),
+    );
+    if (options.type !== 'bind') {
+      continue;
+    }
+    mounts.push({
+      Type: 'bind',
+      Source: String(options.source),
+      Destination: String(options.target),
+      RW: options.readonly !== true,
+    });
+  }
+  return {
+    labels: dockerRunLabels(args),
+    mounts,
+  };
+}
+
+function dockerInspectionResult(
+  inspections: Map<string, DockerContainerInspection>,
+  args: string[],
+): SandboxProcessResult | undefined {
+  const inspection = inspections.get(args[5]!);
+  if (args[4] === '{{json .Config.Labels}}') {
+    return success(JSON.stringify(inspection?.labels ?? {}));
+  }
+  if (args[4] === '{{json .Mounts}}') {
+    return success(JSON.stringify(inspection?.mounts ?? []));
+  }
+  return undefined;
+}
+
 function dockerSpawnResult(args: {
   stdout?: string;
   stderr?: string;
   status?: number;
+  remainActive?: boolean;
 }) {
   const child = new EventEmitter() as EventEmitter & {
     stdout: PassThrough;
     stderr: PassThrough;
     stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> };
+    kill: ReturnType<typeof vi.fn>;
   };
   child.stdout = new PassThrough();
   child.stderr = new PassThrough();
@@ -80,17 +178,28 @@ function dockerSpawnResult(args: {
     }),
     end: vi.fn(),
   };
-  queueMicrotask(() => {
-    if (args.stdout) {
-      child.stdout.write(args.stdout);
-    }
-    if (args.stderr) {
-      child.stderr.write(args.stderr);
-    }
+  const close = (status: number | null, signal: NodeJS.Signals | null) => {
     child.stdout.end();
     child.stderr.end();
-    child.emit('close', args.status ?? 0);
+    child.emit('close', status, signal);
+  };
+  child.kill = vi.fn(() => {
+    queueMicrotask(() => {
+      close(null, 'SIGTERM');
+    });
+    return true;
   });
+  if (!args.remainActive) {
+    queueMicrotask(() => {
+      if (args.stdout) {
+        child.stdout.write(args.stdout);
+      }
+      if (args.stderr) {
+        child.stderr.write(args.stderr);
+      }
+      close(args.status ?? 0, null);
+    });
+  }
   return child;
 }
 
@@ -322,10 +431,11 @@ describe('DockerSandboxClient unit behavior', () => {
       ([, args]) => args[0] === 'run',
     );
     const runArgs: string[] = runCall?.[1] ?? [];
+    const resolvedHostDataDir = await realpath(hostDataDir);
     expect(runArgs).toEqual(
       expect.arrayContaining([
         '--mount',
-        `type=bind,source=${hostDataDir},target=/workspace/mounted/host,readonly`,
+        `type=bind,source=${resolvedHostDataDir},target=/workspace/mounted/host,readonly`,
       ]),
     );
     expect(
@@ -1848,10 +1958,11 @@ describe('DockerSandboxClient unit behavior', () => {
     const runCall = processMocks.runSandboxProcess.mock.calls.find(
       ([, args]) => args[0] === 'run',
     );
+    const resolvedRootDir = await realpath(rootDir);
     expect(runCall?.[1]).toEqual(
       expect.arrayContaining([
         '--mount',
-        `type=bind,source=${rootDir},target=${rootDir},readonly`,
+        `type=bind,source=${resolvedRootDir},target=${rootDir},readonly`,
       ]),
     );
   });
@@ -1887,10 +1998,11 @@ describe('DockerSandboxClient unit behavior', () => {
     const runCall = processMocks.runSandboxProcess.mock.calls.find(
       ([, args]) => args[0] === 'run',
     );
+    const resolvedRootDir = await realpath(rootDir);
     expect(runCall?.[1]).toEqual(
       expect.arrayContaining([
         '--mount',
-        `type=bind,source=${rootDir},target=/mnt/shared-data,readonly`,
+        `type=bind,source=${resolvedRootDir},target=/mnt/shared-data,readonly`,
       ]),
     );
   });
@@ -2155,8 +2267,221 @@ describe('DockerSandboxClient unit behavior', () => {
     ]);
   });
 
-  it('restarts a running container before using rebound path grants', async () => {
+  it('allows live-session reuse with unchanged ordinary path grants', async () => {
     let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
+    const activeChild = dockerSpawnResult({ remainActive: true });
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `container-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          const inspection = dockerInspectionResult(inspections, args);
+          if (inspection) {
+            return inspection;
+          }
+          return success('true\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockReturnValue(activeChild);
+    const sharedPath = join(rootDir, 'shared-data');
+    await mkdir(sharedPath, { recursive: true });
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(
+      new Manifest({
+        extraPathGrants: [
+          {
+            path: sharedPath,
+            readOnly: true,
+          },
+        ],
+      }),
+    );
+    const activeProcess = await session.exec({
+      cmd: 'sleep 60',
+      yieldTimeMs: 0,
+    });
+
+    expect(activeProcess.sessionId).toBe(1);
+    await expect(
+      client.canReusePreservedOwnedSession(session.state),
+    ).resolves.toBe(true);
+    expect(activeChild.kill).not.toHaveBeenCalled();
+    expect(runCount).toBe(1);
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining(['rm', '-f', 'container-1']),
+      expect.anything(),
+    );
+
+    await session.close();
+  });
+
+  it('rejects a fully swapped running Docker session without deleting it', async () => {
+    let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `container-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          const inspection = dockerInspectionResult(inspections, args);
+          if (inspection) {
+            return inspection;
+          }
+          return success('true\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const sharedPath = join(rootDir, 'shared-data');
+    await mkdir(sharedPath);
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: new NoopSnapshotSpec(),
+    });
+    const manifest = new Manifest({
+      extraPathGrants: [{ path: sharedPath, readOnly: true }],
+    });
+    const firstSession = await client.create(manifest);
+    const secondSession = await client.create(manifest);
+    const firstProviderState = await client.serializeSessionState(
+      firstSession.state,
+    );
+    const secondProviderState = await client.serializeSessionState(
+      secondSession.state,
+    );
+    const swappedEnvelope = toSessionStateEnvelope(
+      client.backendId,
+      firstSession.state,
+      firstProviderState,
+    );
+    swappedEnvelope.providerState = {
+      ...secondProviderState,
+    };
+    (swappedEnvelope as unknown as Record<string, unknown>).sessionIdentity =
+      secondSession.state.sessionIdentity;
+    const swappedState = (await deserializeSandboxSessionStateEntry(
+      client,
+      {
+        backendId: client.backendId,
+        currentAgentKey: 'SandboxWorker',
+        currentAgentName: 'SandboxWorker',
+        sessionState: swappedEnvelope,
+      },
+      manifest,
+    )) as DockerSandboxSessionState;
+
+    await expect(
+      client.canReusePreservedOwnedSession(swappedState),
+    ).resolves.toBe(false);
+    expect(swappedState).not.toHaveProperty('sessionIdentity');
+
+    await expect(client.resume(swappedState)).rejects.toThrow(
+      'Docker sandbox resources are unavailable and no local snapshot could be restored.',
+    );
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining(['rm', '-f', 'container-2']),
+      expect.anything(),
+    );
+    expect(runCount).toBe(2);
+
+    await firstSession.close();
+    await secondSession.close();
+  });
+
+  it('reuses a legacy zero-grant container with exact declared bind mounts', async () => {
+    let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `container-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          const inspection = dockerInspectionResult(inspections, args);
+          if (inspection) {
+            return inspection;
+          }
+          return success('true\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const declaredSource = join(rootDir, 'declared');
+    await mkdir(declaredSource);
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          declared: {
+            type: 'mount',
+            source: declaredSource,
+            mountPath: 'mounted/declared',
+            mountStrategy: { type: 'local_bind' },
+          },
+        },
+      }),
+    );
+    const inspection = inspections.get(session.state.containerId)!;
+    delete inspection.labels[dockerSessionIdentityLabel];
+    delete inspection.labels[dockerMountAuthorityFingerprintLabel];
+    delete session.state.sessionIdentity;
+
+    const resumed = await client.resume(session.state);
+
+    expect(resumed.state.containerId).toBe('container-1');
+    expect(runCount).toBe(1);
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining(['rm', '-f', 'container-1']),
+      expect.anything(),
+    );
+
+    await resumed.close();
+  });
+
+  it('rejects a container that lost its current session identity label', async () => {
+    let runCount = 0;
+    let workspaceSource = '';
+    const declaredSource = join(rootDir, 'declared');
+    await mkdir(declaredSource);
     processMocks.runSandboxProcess.mockImplementation(
       async (_command: string, args: string[]) => {
         if (args[0] === 'version') {
@@ -2167,6 +2492,638 @@ describe('DockerSandboxClient unit behavior', () => {
           return success(`container-${runCount}\n`);
         }
         if (args[0] === 'inspect') {
+          if (args[4] === '{{json .Config.Labels}}') {
+            return success(JSON.stringify({ 'openai-agents-sandbox': 'true' }));
+          }
+          if (args[4] === '{{json .Mounts}}') {
+            return success(
+              JSON.stringify([
+                {
+                  Type: 'bind',
+                  Source: workspaceSource,
+                  Destination: '/workspace',
+                  RW: true,
+                },
+                {
+                  Type: 'bind',
+                  Source: declaredSource,
+                  Destination: '/workspace/mounted/declared',
+                  RW: false,
+                },
+              ]),
+            );
+          }
+          return success('true\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          declared: {
+            type: 'mount',
+            source: declaredSource,
+            mountPath: 'mounted/declared',
+            mountStrategy: { type: 'local_bind' },
+          },
+        },
+      }),
+    );
+    workspaceSource = session.state.workspaceRootPath;
+
+    await expect(client.resume(session.state)).rejects.toThrow(
+      'Docker sandbox container identity could not be verified',
+    );
+    expect(runCount).toBe(1);
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining(['rm', '-f', 'container-1']),
+      expect.anything(),
+    );
+
+    await session.close();
+  });
+
+  it('restarts an identity-verified container without a mount fingerprint', async () => {
+    let runCount = 0;
+    let workspaceSource = '';
+    const undeclaredSource = join(rootDir, 'undeclared');
+    await mkdir(undeclaredSource);
+    const labelsByContainer = new Map<string, Record<string, string>>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `container-${runCount}`;
+          labelsByContainer.set(containerId, dockerRunLabels(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          if (args[4] === '{{json .Config.Labels}}') {
+            return success(
+              JSON.stringify(labelsByContainer.get(args[5]!) ?? {}),
+            );
+          }
+          if (args[4] === '{{json .Mounts}}') {
+            return success(
+              JSON.stringify([
+                {
+                  Type: 'bind',
+                  Source: workspaceSource,
+                  Destination: '/workspace',
+                  RW: true,
+                },
+                {
+                  Type: 'bind',
+                  Source: undeclaredSource,
+                  Destination: '/mnt/undeclared',
+                  RW: true,
+                },
+              ]),
+            );
+          }
+          return success('true\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(new Manifest());
+    workspaceSource = session.state.workspaceRootPath;
+    delete labelsByContainer.get(session.state.containerId)?.[
+      dockerMountAuthorityFingerprintLabel
+    ];
+    expect(
+      labelsByContainer.get(session.state.containerId)?.[
+        dockerSessionIdentityLabel
+      ],
+    ).toBe(session.state.sessionIdentity);
+
+    const resumed = await client.resume(session.state);
+
+    expect(resumed.state.containerId).toBe('container-2');
+    expect(runCount).toBe(2);
+    expect(processMocks.runSandboxProcess).toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining(['rm', '-f', 'container-1']),
+      expect.anything(),
+    );
+  });
+
+  it('restarts when persisted state omits a manifest bind mount', async () => {
+    let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `container-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          const inspection = dockerInspectionResult(inspections, args);
+          if (inspection) {
+            return inspection;
+          }
+          return success('true\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const declaredSource = join(rootDir, 'declared');
+    await mkdir(declaredSource);
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          declared: {
+            type: 'mount',
+            source: declaredSource,
+            mountPath: 'mounted/declared',
+            mountStrategy: { type: 'local_bind' },
+          },
+        },
+      }),
+    );
+
+    const unchanged = await client.resume(session.state);
+    const resumed = await client.resume({
+      ...unchanged.state,
+      manifest: new Manifest(),
+    });
+
+    expect(unchanged.state.containerId).toBe('container-1');
+    expect(resumed.state.containerId).toBe('container-2');
+    expect(runCount).toBe(2);
+    expect(processMocks.runSandboxProcess).toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining(['rm', '-f', 'container-1']),
+      expect.anything(),
+    );
+    const secondRunArgs = processMocks.runSandboxProcess.mock.calls.filter(
+      ([, args]) => args[0] === 'run',
+    )[1]?.[1];
+    expect(secondRunArgs).not.toContain(
+      `type=bind,source=${await realpath(declaredSource)},target=/workspace/mounted/declared,readonly`,
+    );
+  });
+
+  it('restarts a running container when path grant mount policy changes', async () => {
+    let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `container-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          const inspection = dockerInspectionResult(inspections, args);
+          if (inspection) {
+            return inspection;
+          }
+          return success('true\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const sharedPath = join(rootDir, 'shared-data');
+    await mkdir(sharedPath, { recursive: true });
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(
+      new Manifest({
+        extraPathGrants: [
+          {
+            path: sharedPath,
+            readOnly: false,
+          },
+        ],
+      }),
+    );
+    const reboundState = rebindPersistedPathGrants(
+      session.state,
+      new Manifest({
+        extraPathGrants: [
+          {
+            path: sharedPath,
+            readOnly: true,
+          },
+        ],
+      }),
+    );
+
+    const resumed = await client.resume(reboundState);
+    const resumedAgain = await client.resume(resumed.state);
+
+    expect(resumed.state.containerId).toBe('container-2');
+    expect(resumedAgain.state.containerId).toBe('container-2');
+    expect(runCount).toBe(2);
+    expect(processMocks.runSandboxProcess).toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining(['rm', '-f', 'container-1']),
+      expect.anything(),
+    );
+  });
+
+  it('restarts when persisted state omits a container-mounted path grant', async () => {
+    let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `container-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          const inspection = dockerInspectionResult(inspections, args);
+          if (inspection) {
+            return inspection;
+          }
+          return success('true\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const retainedPath = join(rootDir, 'retained-data');
+    const omittedPath = join(rootDir, 'omitted-data');
+    await mkdir(retainedPath, { recursive: true });
+    await mkdir(omittedPath, { recursive: true });
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(
+      new Manifest({
+        extraPathGrants: [
+          { path: retainedPath, readOnly: true },
+          { path: omittedPath, readOnly: true },
+        ],
+      }),
+    );
+
+    const resumed = await client.resume({
+      ...session.state,
+      manifest: new Manifest({
+        extraPathGrants: [{ path: retainedPath, readOnly: true }],
+      }),
+    });
+
+    expect(resumed.state.containerId).toBe('container-2');
+    expect(runCount).toBe(2);
+    const secondRunArgs = processMocks.runSandboxProcess.mock.calls.filter(
+      ([, args]) => args[0] === 'run',
+    )[1]?.[1];
+    const resolvedRetainedPath = await realpath(retainedPath);
+    const resolvedOmittedPath = await realpath(omittedPath);
+    expect(secondRunArgs).toEqual(
+      expect.arrayContaining([
+        '--mount',
+        `type=bind,source=${resolvedRetainedPath},target=${retainedPath},readonly`,
+      ]),
+    );
+    expect(secondRunArgs).not.toContain(
+      `type=bind,source=${resolvedOmittedPath},target=${omittedPath},readonly`,
+    );
+  });
+
+  it('restarts a running container before using rebound path grants', async () => {
+    let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `container-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          const inspection = dockerInspectionResult(inspections, args);
+          if (inspection) {
+            return inspection;
+          }
+          return success('true\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const originalHostPath = join(rootDir, 'original-source');
+    const reboundHostPath = join(rootDir, 'rebound-source');
+    await mkdir(originalHostPath);
+    await mkdir(reboundHostPath);
+    const session = await client.create(
+      new Manifest({
+        extraPathGrants: [
+          {
+            path: '/mnt/shared-data',
+            hostPath: originalHostPath,
+            readOnly: false,
+          },
+        ],
+      }),
+    );
+
+    const resumed = await client.resume({
+      ...session.state,
+      manifest: new Manifest({
+        extraPathGrants: [
+          {
+            path: '/mnt/shared-data',
+            hostPath: reboundHostPath,
+            readOnly: true,
+          },
+        ],
+      }),
+    });
+
+    expect(resumed.state.containerId).toBe('container-2');
+    await expect(
+      client.canReusePreservedOwnedSession({
+        ...session.state,
+        manifest: new Manifest({
+          extraPathGrants: [
+            {
+              path: '/mnt/shared-data',
+              hostPath: reboundHostPath,
+              readOnly: true,
+            },
+          ],
+        }),
+      }),
+    ).resolves.toBe(false);
+    const calls = processMocks.runSandboxProcess.mock.calls;
+    const removeIndex = calls.findIndex(
+      ([, args]) => args[0] === 'rm' && args[2] === 'container-1',
+    );
+    const secondRunIndex = calls.findIndex(
+      ([, args], index) => index > removeIndex && args[0] === 'run',
+    );
+    expect(removeIndex).toBeGreaterThanOrEqual(0);
+    expect(secondRunIndex).toBeGreaterThan(removeIndex);
+    const resolvedReboundHostPath = await realpath(reboundHostPath);
+    expect(calls[secondRunIndex]?.[1]).toEqual(
+      expect.arrayContaining([
+        '--mount',
+        `type=bind,source=${resolvedReboundHostPath},target=/mnt/shared-data,readonly`,
+      ]),
+    );
+  });
+
+  it('restarts when a path grant host symlink is retargeted', async () => {
+    let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `container-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          const inspection = dockerInspectionResult(inspections, args);
+          if (inspection) {
+            return inspection;
+          }
+          return success('true\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const firstSource = join(rootDir, 'first-source');
+    const secondSource = join(rootDir, 'second-source');
+    const hostPath = join(rootDir, 'current-source');
+    await mkdir(firstSource);
+    await mkdir(secondSource);
+    await symlink(firstSource, hostPath);
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(
+      new Manifest({
+        extraPathGrants: [
+          {
+            path: '/mnt/shared-data',
+            hostPath,
+            readOnly: true,
+          },
+        ],
+      }),
+    );
+    await unlink(hostPath);
+    await symlink(secondSource, hostPath);
+
+    const resumed = await client.resume(session.state);
+
+    expect(resumed.state.containerId).toBe('container-2');
+    expect(runCount).toBe(2);
+    const secondRunArgs = processMocks.runSandboxProcess.mock.calls.filter(
+      ([, args]) => args[0] === 'run',
+    )[1]?.[1];
+    expect(secondRunArgs).toEqual(
+      expect.arrayContaining([
+        '--mount',
+        `type=bind,source=${await realpath(secondSource)},target=/mnt/shared-data,readonly`,
+      ]),
+    );
+    expect(secondRunArgs).not.toContain(
+      `type=bind,source=${await realpath(firstSource)},target=/mnt/shared-data,readonly`,
+    );
+  });
+
+  it('restarts when a path grant source is replaced at the same real path', async () => {
+    let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `container-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          const inspection = dockerInspectionResult(inspections, args);
+          if (inspection) {
+            return inspection;
+          }
+          return success('true\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const sharedPath = join(rootDir, 'shared-data');
+    const previousSharedPath = join(rootDir, 'previous-shared-data');
+    await mkdir(sharedPath);
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(
+      new Manifest({
+        extraPathGrants: [
+          {
+            path: '/mnt/shared-data',
+            hostPath: sharedPath,
+            readOnly: true,
+          },
+        ],
+      }),
+    );
+    await rename(sharedPath, previousSharedPath);
+    await mkdir(sharedPath);
+
+    const resumed = await client.resume(session.state);
+
+    expect(resumed.state.containerId).toBe('container-2');
+    expect(runCount).toBe(2);
+    expect(processMocks.runSandboxProcess).toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining(['rm', '-f', 'container-1']),
+      expect.anything(),
+    );
+  });
+
+  it('declines live reuse when a path grant source disappears', async () => {
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          inspections.set('container-1', dockerRunInspection(args));
+          return success('container-1\n');
+        }
+        if (args[0] === 'inspect') {
+          const inspection = dockerInspectionResult(inspections, args);
+          if (inspection) {
+            return inspection;
+          }
+          return success('true\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const sharedPath = join(rootDir, 'shared-data');
+    await mkdir(sharedPath);
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(
+      new Manifest({
+        extraPathGrants: [
+          {
+            path: '/mnt/shared-data',
+            hostPath: sharedPath,
+            readOnly: true,
+          },
+        ],
+      }),
+    );
+    await rm(sharedPath, { recursive: true });
+
+    await expect(
+      client.canReusePreservedOwnedSession(session.state),
+    ).resolves.toBe(false);
+
+    await session.close();
+  });
+
+  it('restarts when a path grant source changes during container inspection', async () => {
+    let runCount = 0;
+    let sourceReplaced = false;
+    const inspections = new Map<string, DockerContainerInspection>();
+    const sharedPath = join(rootDir, 'shared-data');
+    const previousSharedPath = join(rootDir, 'previous-shared-data');
+    await mkdir(sharedPath);
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `container-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          if (args[4] === '{{json .Config.Labels}}') {
+            if (!sourceReplaced) {
+              sourceReplaced = true;
+              await rename(sharedPath, previousSharedPath);
+              await mkdir(sharedPath);
+            }
+          }
+          const inspection = dockerInspectionResult(inspections, args);
+          if (inspection) {
+            return inspection;
+          }
           return success('true\n');
         }
         if (args[0] === 'rm') {
@@ -2183,43 +3140,21 @@ describe('DockerSandboxClient unit behavior', () => {
         extraPathGrants: [
           {
             path: '/mnt/shared-data',
-            hostPath: join(rootDir, 'original-source'),
-            readOnly: false,
-          },
-        ],
-      }),
-    );
-    const reboundHostPath = join(rootDir, 'rebound-source');
-
-    const resumed = await client.resume({
-      ...session.state,
-      manifest: new Manifest({
-        extraPathGrants: [
-          {
-            path: '/mnt/shared-data',
-            hostPath: reboundHostPath,
+            hostPath: sharedPath,
             readOnly: true,
           },
         ],
       }),
-    });
+    );
+
+    const resumed = await client.resume(session.state);
 
     expect(resumed.state.containerId).toBe('container-2');
-    expect(client.canReusePreservedOwnedSession(session.state)).toBe(false);
-    const calls = processMocks.runSandboxProcess.mock.calls;
-    const removeIndex = calls.findIndex(
-      ([, args]) => args[0] === 'rm' && args[2] === 'container-1',
-    );
-    const secondRunIndex = calls.findIndex(
-      ([, args], index) => index > removeIndex && args[0] === 'run',
-    );
-    expect(removeIndex).toBeGreaterThanOrEqual(0);
-    expect(secondRunIndex).toBeGreaterThan(removeIndex);
-    expect(calls[secondRunIndex]?.[1]).toEqual(
-      expect.arrayContaining([
-        '--mount',
-        `type=bind,source=${reboundHostPath},target=/mnt/shared-data,readonly`,
-      ]),
+    expect(runCount).toBe(2);
+    expect(processMocks.runSandboxProcess).toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining(['rm', '-f', 'container-1']),
+      expect.anything(),
     );
   });
 
@@ -2283,6 +3218,8 @@ describe('DockerSandboxClient unit behavior', () => {
     expect(serialized.__openaiAgentsRedactedHostPathGrantPaths).toEqual([
       '/mnt/shared-data',
     ]);
+    expect(serialized.sessionIdentity).toBe(session.state.sessionIdentity);
+    expect(deserialized.sessionIdentity).toBe(session.state.sessionIdentity);
     expect(deserialized.manifest.extraPathGrants).toEqual([
       {
         path: '/mnt/shared-data',
@@ -2295,13 +3232,28 @@ describe('DockerSandboxClient unit behavior', () => {
   });
 
   it('limits dynamically applied path grants to host filesystem helpers', async () => {
+    let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
     processMocks.runSandboxProcess.mockImplementation(
       async (_command: string, args: string[]) => {
         if (args[0] === 'version') {
           return success('Docker version test');
         }
         if (args[0] === 'run') {
-          return success('container-123\n');
+          runCount += 1;
+          const containerId = `container-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          const inspection = dockerInspectionResult(inspections, args);
+          if (inspection) {
+            return inspection;
+          }
+          return success('true\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
         }
         return failure('unexpected docker command');
       },
@@ -2325,6 +3277,21 @@ describe('DockerSandboxClient unit behavior', () => {
       }),
     ).rejects.toThrow();
     expect(childProcessMocks.spawn).not.toHaveBeenCalled();
+
+    const resumed = await client.resume(session.state);
+
+    expect(resumed.state.containerId).toBe('container-2');
+    expect(runCount).toBe(2);
+    const secondRunCall = processMocks.runSandboxProcess.mock.calls.filter(
+      ([, args]) => args[0] === 'run',
+    )[1];
+    const resolvedRootDir = await realpath(rootDir);
+    expect(secondRunCall?.[1]).toEqual(
+      expect.arrayContaining([
+        '--mount',
+        `type=bind,source=${resolvedRootDir},target=${rootDir}`,
+      ]),
+    );
   });
 
   it('rejects applying in-container mounts that need missing Docker privileges', async () => {
@@ -2805,17 +3772,29 @@ describe('DockerSandboxClient unit behavior', () => {
     ).rejects.toThrow();
   });
 
-  it('does not restore a local snapshot over a drifted live workspace', async () => {
+  it('restores untrusted running RunState without touching its live resources', async () => {
+    let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
     processMocks.runSandboxProcess.mockImplementation(
       async (_command: string, args: string[]) => {
         if (args[0] === 'version') {
           return success('Docker version test');
         }
         if (args[0] === 'run') {
-          return success('container-123\n');
+          runCount += 1;
+          const containerId = `container-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
         }
         if (args[0] === 'inspect') {
+          const inspection = dockerInspectionResult(inspections, args);
+          if (inspection) {
+            return inspection;
+          }
           return success('true\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
         }
         return failure('unexpected docker command');
       },
@@ -2850,16 +3829,223 @@ describe('DockerSandboxClient unit behavior', () => {
       'utf8',
     );
 
-    const restored = await client.resume(
-      await client.deserializeSessionState(serialized),
-    );
+    const persistedState = (await deserializeSandboxSessionStateEntry(
+      client,
+      {
+        backendId: client.backendId,
+        currentAgentKey: 'SandboxWorker',
+        currentAgentName: 'SandboxWorker',
+        sessionState: toSessionStateEnvelope(
+          client.backendId,
+          session.state,
+          serialized,
+        ),
+      },
+      session.state.manifest,
+    )) as DockerSandboxSessionState;
 
-    expect(restored.state.workspaceRootPath).toBe(
+    const restored = await client.resume(persistedState);
+
+    expect(restored.state.containerId).toBe('container-2');
+    expect(restored.state.workspaceRootPath).not.toBe(
       session.state.workspaceRootPath,
     );
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining(['rm', '-f', 'container-1']),
+      expect.anything(),
+    );
+    expect(
+      processMocks.runSandboxProcess.mock.calls.some(
+        ([, args]) => args[0] === 'inspect',
+      ),
+    ).toBe(false);
+    await expect(
+      readFile(join(session.state.workspaceRootPath, 'notes.txt'), 'utf8'),
+    ).resolves.toBe('drifted\n');
     await expect(
       readFile(join(restored.state.workspaceRootPath, 'notes.txt'), 'utf8'),
-    ).resolves.toBe('drifted\n');
+    ).resolves.toBe('snapshot\n');
+
+    await restored.close();
+    await session.close();
+  });
+
+  it('restores untrusted stopped RunState into new Docker resources', async () => {
+    let runCount = 0;
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          return success(`container-${runCount}\n`);
+        }
+        if (args[0] === 'inspect') {
+          return success('false\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: {
+        type: 'local',
+        baseDir: rootDir,
+      },
+    });
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          'notes.txt': {
+            type: 'file',
+            content: 'snapshot\n',
+          },
+        },
+      }),
+    );
+    const originalWorkspaceRootPath = session.state.workspaceRootPath;
+    const serialized = await client.serializeSessionState(session.state);
+    const persistedState = (await deserializeSandboxSessionStateEntry(
+      client,
+      {
+        backendId: client.backendId,
+        currentAgentKey: 'SandboxWorker',
+        currentAgentName: 'SandboxWorker',
+        sessionState: toSessionStateEnvelope(
+          client.backendId,
+          session.state,
+          serialized,
+        ),
+      },
+      session.state.manifest,
+    )) as DockerSandboxSessionState;
+
+    const restored = await client.resume(persistedState);
+
+    expect(restored.state.containerId).toBe('container-2');
+    expect(restored.state.workspaceRootPath).not.toBe(
+      originalWorkspaceRootPath,
+    );
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining(['rm', '-f', 'container-1']),
+      expect.anything(),
+    );
+    expect(
+      processMocks.runSandboxProcess.mock.calls.some(
+        ([, args]) => args[0] === 'inspect',
+      ),
+    ).toBe(false);
+    await expect(
+      readFile(join(restored.state.workspaceRootPath, 'notes.txt'), 'utf8'),
+    ).resolves.toBe('snapshot\n');
+  });
+
+  it('removes a fresh RunState workspace when container restore fails', async () => {
+    let failRun = false;
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return failRun
+            ? failure('container restore failed')
+            : success('container-1\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: {
+        type: 'local',
+        baseDir: rootDir,
+      },
+    });
+    const session = await client.create(new Manifest());
+    const serialized = await client.serializeSessionState(session.state);
+    const persistedState = (await deserializeSandboxSessionStateEntry(
+      client,
+      {
+        backendId: client.backendId,
+        currentAgentKey: 'SandboxWorker',
+        currentAgentName: 'SandboxWorker',
+        sessionState: toSessionStateEnvelope(
+          client.backendId,
+          session.state,
+          serialized,
+        ),
+      },
+      session.state.manifest,
+    )) as DockerSandboxSessionState;
+    const entriesBeforeRestore = (await readdir(rootDir)).sort();
+    failRun = true;
+
+    await expect(client.resume(persistedState)).rejects.toThrow(
+      'container restore failed',
+    );
+
+    expect((await readdir(rootDir)).sort()).toEqual(entriesBeforeRestore);
+    failRun = false;
+    await session.close();
+  });
+
+  it('does not restore explicit state when container status cannot be inspected', async () => {
+    let runCount = 0;
+    let failInspection = false;
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          return success(`container-${runCount}\n`);
+        }
+        if (args[0] === 'inspect') {
+          return failInspection
+            ? failure('permission denied')
+            : success('true\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: {
+        type: 'local',
+        baseDir: rootDir,
+      },
+    });
+    const session = await client.create(new Manifest());
+    const serialized = await client.serializeSessionState(session.state);
+    const persistedState = await client.deserializeSessionState(serialized);
+    failInspection = true;
+
+    await expect(client.resume(persistedState)).rejects.toThrow(
+      'Failed to inspect Docker sandbox container: permission denied',
+    );
+    expect(runCount).toBe(1);
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining(['rm', '-f', 'container-1']),
+      expect.anything(),
+    );
+
+    failInspection = false;
+    await session.close();
   });
 
   it('removes stopped containers and volumes before restarting from an existing workspace', async () => {
@@ -2947,6 +4133,7 @@ describe('DockerSandboxClient unit behavior', () => {
 
   it('removes a running container before restoring a missing workspace', async () => {
     let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
     processMocks.runSandboxProcess.mockImplementation(
       async (_command: string, args: string[]) => {
         if (args[0] === 'version') {
@@ -2954,9 +4141,15 @@ describe('DockerSandboxClient unit behavior', () => {
         }
         if (args[0] === 'run') {
           runCount += 1;
-          return success(`container-${runCount}\n`);
+          const containerId = `container-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
         }
         if (args[0] === 'inspect') {
+          const inspection = dockerInspectionResult(inspections, args);
+          if (inspection) {
+            return inspection;
+          }
           return success('true\n');
         }
         if (args[0] === 'rm') {
@@ -3132,6 +4325,15 @@ describe('DockerSandboxClient unit behavior', () => {
 
     expect(serialized.snapshotSpec).toEqual({ type: 'noop' });
     expect(serialized.snapshot).toBeNull();
+    await expect(
+      client.serializeSessionState(session.state, {
+        preserveOwnedSession: true,
+        reuseLiveSession: false,
+        willCloseAfterSerialize: true,
+      }),
+    ).rejects.toThrow(
+      'Docker sandbox session cannot be preserved after live reuse was rejected because no restorable snapshot is configured.',
+    );
   });
 
   it('persists live environment values when serializing state', async () => {

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -2415,7 +2415,7 @@ describe('DockerSandboxClient unit behavior', () => {
     await secondSession.close();
   });
 
-  it('reuses a legacy container with exact grant and declared bind mounts', async () => {
+  it('reuses a legacy zero-grant container with exact declared bind mounts', async () => {
     let runCount = 0;
     const inspections = new Map<string, DockerContainerInspection>();
     processMocks.runSandboxProcess.mockImplementation(
@@ -2446,17 +2446,9 @@ describe('DockerSandboxClient unit behavior', () => {
       workspaceBaseDir: rootDir,
     });
     const declaredSource = join(rootDir, 'declared');
-    const grantedSource = join(rootDir, 'granted');
     await mkdir(declaredSource);
-    await mkdir(grantedSource);
     const session = await client.create(
       new Manifest({
-        extraPathGrants: [
-          {
-            path: grantedSource,
-            readOnly: true,
-          },
-        ],
         entries: {
           declared: {
             type: 'mount',


### PR DESCRIPTION
This pull request fixes Docker sandbox session preservation across approval interruptions.

It preserves the original container and live process handles only when the current trusted manifest, environment authority, image, exposed ports, workspace mount, path grants, bind mounts, and account provisioning remain compatible. Rejected live reuse falls back to a fresh snapshot restoration without allowing serialized RunState data to authorize adoption or deletion of an existing container.

The change also refreshes ephemeral environment values, rejects removed environment authority, preserves explicit Docker state round trips, and retains the legacy zero-grant reconnect path where no path-grant validation is required.