### PR TITLE
fix(extensions): drop unresolved server tool_search calls once past the deferral resume window

### DIFF
--- a/.changeset/aisdk-deferred-tool-search.md
+++ b/.changeset/aisdk-deferred-tool-search.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: drop unresolved server tool_search calls from AI SDK requests once past the deferral resume window

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -34,6 +34,7 @@ import {
   HostedTool,
 } from '@openai/agents';
 import {
+  getToolSearchMatchKey,
   getToolSearchProviderCallId,
   resolveToolSearchCallId,
   shouldQueuePendingToolSearchCall,
@@ -289,7 +290,9 @@ export function itemsToLanguageV2Messages(
   let currentAssistantMessage: LanguageModelV2Message | undefined;
   let pendingReasonerReasoning:
     { text: string; providerOptions: Record<string, any> } | undefined;
-  const collapsedItems = collapseReplacedToolSearchOutputs(items);
+  const collapsedItems = dropAbandonedServerToolSearchCalls(
+    collapseReplacedToolSearchOutputs(items),
+  );
   const consumePendingReasonerReasoning = () => {
     if (!(
       shouldIncludeReasoningContent(model, modelSettings) &&
@@ -1049,6 +1052,108 @@ function getToolSearchOutputReplacementKey(
   }
 
   return undefined;
+}
+
+/**
+ * Returns whether the provider can still resume a deferred server tool_search
+ * call at `callIndex`: the call must remain in the final assistant turn,
+ * followed only by that turn's client tool calls and their results.
+ */
+function isAwaitingDeferredToolSearchResume(
+  items: protocol.ModelItem[],
+  callIndex: number,
+): boolean {
+  let sawClientToolResult = false;
+  for (let index = callIndex + 1; index < items.length; index += 1) {
+    const item = items[index];
+    if (item.type === 'function_call_result') {
+      sawClientToolResult = true;
+      continue;
+    }
+
+    if (item.type === 'tool_search_output') {
+      if (getToolSearchExecution(item) !== 'server') {
+        // Client tool_search results reply to the same assistant turn, just
+        // like function call results.
+        sawClientToolResult = true;
+        continue;
+      }
+      if (sawClientToolResult) {
+        return false;
+      }
+      continue;
+    }
+
+    if (sawClientToolResult) {
+      return false;
+    }
+
+    if (item.type === 'function_call' || item.type === 'tool_search_call') {
+      // Additional tool calls emitted in the same assistant turn.
+      continue;
+    }
+
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Anthropic defers a server tool_search that is co-emitted with a client tool
+ * call: the response carries the server_tool_use block without a result, and
+ * the caller resumes it by replying with only the client tool results. The
+ * unresolved call must stay in history while that resume is still possible,
+ * but once the conversation moves past the turn it can never be resolved and
+ * replaying the unpaired call makes the provider reject the request.
+ */
+function dropAbandonedServerToolSearchCalls(
+  items: protocol.ModelItem[],
+): protocol.ModelItem[] {
+  const unresolvedCalls: Array<{ index: number; key: string | undefined }> =
+    [];
+
+  items.forEach((item, index) => {
+    if (item.type === 'tool_search_call') {
+      if (getToolSearchExecution(item) === 'server') {
+        unresolvedCalls.push({ index, key: getToolSearchMatchKey(item) });
+      }
+      return;
+    }
+
+    if (
+      item.type !== 'tool_search_output' ||
+      getToolSearchExecution(item) !== 'server'
+    ) {
+      return;
+    }
+
+    // Mirror takeQueuedToolSearchResultCallId(): an explicit call id resolves
+    // the matching call; otherwise the result resolves the oldest pending one.
+    const explicitCallId = getToolSearchProviderCallId(item);
+    if (explicitCallId) {
+      const matchIndex = unresolvedCalls.findIndex(
+        (call) => call.key === explicitCallId,
+      );
+      if (matchIndex >= 0) {
+        unresolvedCalls.splice(matchIndex, 1);
+      }
+      return;
+    }
+
+    unresolvedCalls.shift();
+  });
+
+  const abandonedCallIndexes = new Set(
+    unresolvedCalls
+      .filter(({ index }) => !isAwaitingDeferredToolSearchResume(items, index))
+      .map(({ index }) => index),
+  );
+  if (abandonedCallIndexes.size === 0) {
+    return items;
+  }
+
+  return items.filter((_, index) => !abandonedCallIndexes.has(index));
 }
 
 function collapseReplacedToolSearchOutputs(

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -1056,15 +1056,17 @@ function getToolSearchOutputReplacementKey(
 
 /**
  * Returns whether the provider can still resume a deferred server tool_search
- * call at `callIndex`: the call must remain in the final assistant turn,
- * followed only by that turn's client tool calls and their results.
+ * call at `callIndex` as of `endIndex` (exclusive): the call must remain in
+ * the latest assistant turn, followed only by that turn's client tool calls
+ * and their results.
  */
 function isAwaitingDeferredToolSearchResume(
   items: protocol.ModelItem[],
   callIndex: number,
+  endIndex: number,
 ): boolean {
   let sawClientToolResult = false;
-  for (let index = callIndex + 1; index < items.length; index += 1) {
+  for (let index = callIndex + 1; index < endIndex; index += 1) {
     const item = items[index];
     if (item.type === 'function_call_result') {
       sawClientToolResult = true;
@@ -1110,13 +1112,25 @@ function isAwaitingDeferredToolSearchResume(
 function dropAbandonedServerToolSearchCalls(
   items: protocol.ModelItem[],
 ): protocol.ModelItem[] {
-  const unresolvedCalls: Array<{ index: number; key: string | undefined }> =
-    [];
+  // A call leaves this queue either resolved (kept) or abandoned (dropped);
+  // only membership in abandonedCallIndexes removes an item from the history.
+  const pendingCalls: Array<{ index: number; key: string | undefined }> = [];
+  const abandonedCallIndexes = new Set<number>();
+  const purgeAbandonedCalls = (endIndex: number) => {
+    for (let i = pendingCalls.length - 1; i >= 0; i -= 1) {
+      const { index } = pendingCalls[i];
+      if (!isAwaitingDeferredToolSearchResume(items, index, endIndex)) {
+        // Past its resume window: mark the item for removal and stop tracking it.
+        abandonedCallIndexes.add(index);
+        pendingCalls.splice(i, 1);
+      }
+    }
+  };
 
   items.forEach((item, index) => {
     if (item.type === 'tool_search_call') {
       if (getToolSearchExecution(item) === 'server') {
-        unresolvedCalls.push({ index, key: getToolSearchMatchKey(item) });
+        pendingCalls.push({ index, key: getToolSearchMatchKey(item) });
       }
       return;
     }
@@ -1132,23 +1146,26 @@ function dropAbandonedServerToolSearchCalls(
     // the matching call; otherwise the result resolves the oldest pending one.
     const explicitCallId = getToolSearchProviderCallId(item);
     if (explicitCallId) {
-      const matchIndex = unresolvedCalls.findIndex(
+      const matchIndex = pendingCalls.findIndex(
         (call) => call.key === explicitCallId,
       );
       if (matchIndex >= 0) {
-        unresolvedCalls.splice(matchIndex, 1);
+        // Resolved by id: keep the call's item, stop tracking it.
+        pendingCalls.splice(matchIndex, 1);
       }
       return;
     }
 
-    unresolvedCalls.shift();
+    // An id-less output can only resolve a call whose resume window was still
+    // open when the output appeared; purge stale calls first so they cannot
+    // starve the live turn's call.
+    purgeAbandonedCalls(index);
+    // Resolved positionally: keep the oldest surviving call, stop tracking it.
+    pendingCalls.shift();
   });
 
-  const abandonedCallIndexes = new Set(
-    unresolvedCalls
-      .filter(({ index }) => !isAwaitingDeferredToolSearchResume(items, index))
-      .map(({ index }) => index),
-  );
+  // Calls still pending here survive only if their resume window is open.
+  purgeAbandonedCalls(items.length);
   if (abandonedCallIndexes.size === 0) {
     return items;
   }

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -1511,6 +1511,119 @@ describe('itemsToLanguageV2Messages', () => {
     ]);
   });
 
+  test('does not let id-less server outputs resolve stale searches instead of the live call', () => {
+    // A server tool_search output without call_id pairs positionally. A stale
+    // abandoned call must be dropped before the output is consumed, so the
+    // output resolves the live turn's call rather than the stale one.
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call',
+        callId: 'ui_1',
+        name: 'ui_status',
+        arguments: '{"status":"searching"}',
+        status: 'completed',
+      },
+      {
+        type: 'tool_search_call',
+        id: 'srvtoolu_stale',
+        execution: 'server',
+        arguments: { query: 'billing tools' },
+        status: 'completed',
+      },
+      {
+        type: 'function_call_result',
+        callId: 'ui_1',
+        name: 'ui_status',
+        status: 'completed',
+        output: 'ok',
+      },
+      {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'Retrying the search.' }],
+        status: 'completed',
+      },
+      {
+        type: 'tool_search_call',
+        id: 'srvtoolu_new',
+        execution: 'server',
+        arguments: { query: 'billing tools again' },
+        status: 'completed',
+      },
+      {
+        type: 'tool_search_output',
+        execution: 'server',
+        status: 'completed',
+        tools: [{ type: 'tool_reference', toolName: 'lookup_invoice' }],
+      } as any,
+    ];
+
+    const messages = itemsToLanguageV2Messages(stubModel({}), items);
+    const toolSearchParts = messages.flatMap((message) =>
+      Array.isArray(message.content)
+        ? (message.content as any[]).filter(
+            (part) => part.toolName === 'tool_search',
+          )
+        : [],
+    );
+    expect(toolSearchParts.map((part) => [part.type, part.toolCallId])).toEqual(
+      [
+        ['tool-call', 'srvtoolu_new'],
+        ['tool-result', 'srvtoolu_new'],
+      ],
+    );
+  });
+
+  test('pairs an id-less deferred output with a call whose resume window is still open', () => {
+    // The purge must evaluate the resume window at the output's position:
+    // a deferred call followed only by client results is still resumable, so
+    // an id-less output arriving next belongs to it.
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call',
+        callId: 'ui_1',
+        name: 'ui_status',
+        arguments: '{"status":"searching"}',
+        status: 'completed',
+      },
+      {
+        type: 'tool_search_call',
+        id: 'srvtoolu_1',
+        execution: 'server',
+        arguments: { query: 'billing tools' },
+        status: 'completed',
+      },
+      {
+        type: 'function_call_result',
+        callId: 'ui_1',
+        name: 'ui_status',
+        status: 'completed',
+        output: 'ok',
+      },
+      {
+        type: 'tool_search_output',
+        execution: 'server',
+        status: 'completed',
+        tools: [{ type: 'tool_reference', toolName: 'lookup_invoice' }],
+      } as any,
+    ];
+
+    const messages = itemsToLanguageV2Messages(stubModel({}), items);
+    const toolSearchParts = messages.flatMap((message) =>
+      Array.isArray(message.content)
+        ? (message.content as any[]).filter(
+            (part) => part.toolName === 'tool_search',
+          )
+        : [],
+    );
+    expect(toolSearchParts.map((part) => [part.type, part.toolCallId])).toEqual(
+      [
+        ['tool-call', 'srvtoolu_1'],
+        ['tool-result', 'srvtoolu_1'],
+      ],
+    );
+  });
+
   test('keeps unresolved client tool_search calls even after the conversation continues', () => {
     // Only provider-executed (server) tool_search calls are subject to the
     // deferral cleanup; client calls are resolved by the runner and must be
@@ -1535,7 +1648,8 @@ describe('itemsToLanguageV2Messages', () => {
     const toolSearchCalls = messages.flatMap((message) =>
       Array.isArray(message.content)
         ? message.content.filter(
-            (part) => part.type === 'tool-call' && part.toolName === 'tool_search',
+            (part) =>
+              part.type === 'tool-call' && part.toolName === 'tool_search',
           )
         : [],
     );

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -1278,6 +1278,270 @@ describe('itemsToLanguageV2Messages', () => {
     ]);
   });
 
+  test('drops a provider-deferred tool_search call once the conversation moves past the resume window', () => {
+    // Anthropic defers a server tool_search co-emitted after a client tool
+    // call: the response carries the server_tool_use with no result. Once the
+    // conversation continues past that turn, replaying the unpaired call makes
+    // Anthropic reject the request with a 400.
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call',
+        callId: 'ui_1',
+        name: 'ui_status',
+        arguments: '{"status":"searching"}',
+        status: 'completed',
+      },
+      {
+        type: 'tool_search_call',
+        id: 'srvtoolu_1',
+        execution: 'server',
+        arguments: { query: 'billing tools' },
+        status: 'completed',
+      },
+      {
+        type: 'function_call_result',
+        callId: 'ui_1',
+        name: 'ui_status',
+        status: 'completed',
+        output: 'ok',
+      },
+      {
+        type: 'message',
+        role: 'assistant',
+        content: [
+          { type: 'output_text', text: 'Continuing without the search.' },
+        ],
+        status: 'completed',
+      },
+    ];
+
+    expect(itemsToLanguageV2Messages(stubModel({}), items)).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'ui_1',
+            toolName: 'ui_status',
+            input: { status: 'searching' },
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'ui_1',
+            toolName: 'ui_status',
+            output: { type: 'text', value: 'ok' },
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: 'Continuing without the search.',
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+    ]);
+  });
+
+  test('keeps an unresolved provider-executed tool_search call while awaiting the deferred resume', () => {
+    // While the deferred call is still in the final assistant turn (followed
+    // only by client tool results), it must stay in history so the provider
+    // can resume it on the next request.
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call',
+        callId: 'ui_1',
+        name: 'ui_status',
+        arguments: '{"status":"searching"}',
+        status: 'completed',
+      },
+      {
+        type: 'tool_search_call',
+        id: 'srvtoolu_1',
+        execution: 'server',
+        arguments: { query: 'billing tools' },
+        status: 'completed',
+      },
+      {
+        type: 'function_call_result',
+        callId: 'ui_1',
+        name: 'ui_status',
+        status: 'completed',
+        output: 'ok',
+      },
+    ];
+
+    expect(itemsToLanguageV2Messages(stubModel({}), items)).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'ui_1',
+            toolName: 'ui_status',
+            input: { status: 'searching' },
+            providerOptions: {},
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'srvtoolu_1',
+            toolName: 'tool_search',
+            input: { query: 'billing tools' },
+            providerExecuted: true,
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'ui_1',
+            toolName: 'ui_status',
+            output: { type: 'text', value: 'ok' },
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+    ]);
+  });
+
+  test('pairs a deferred tool_search output from a later turn with its original call', () => {
+    // When the provider resumes the deferred search, its result begins the
+    // next response. The original call must stay in history and the late
+    // result must pair with it instead of being treated as an orphan.
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call',
+        callId: 'ui_1',
+        name: 'ui_status',
+        arguments: '{"status":"searching"}',
+        status: 'completed',
+      },
+      {
+        type: 'tool_search_call',
+        id: 'srvtoolu_1',
+        execution: 'server',
+        arguments: { query: 'billing tools' },
+        status: 'completed',
+      },
+      {
+        type: 'function_call_result',
+        callId: 'ui_1',
+        name: 'ui_status',
+        status: 'completed',
+        output: 'ok',
+      },
+      {
+        type: 'tool_search_output',
+        callId: 'srvtoolu_1',
+        execution: 'server',
+        status: 'completed',
+        tools: [{ type: 'tool_reference', toolName: 'lookup_invoice' }],
+      },
+    ];
+
+    expect(itemsToLanguageV2Messages(stubModel({}), items)).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'ui_1',
+            toolName: 'ui_status',
+            input: { status: 'searching' },
+            providerOptions: {},
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'srvtoolu_1',
+            toolName: 'tool_search',
+            input: { query: 'billing tools' },
+            providerExecuted: true,
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'ui_1',
+            toolName: 'ui_status',
+            output: { type: 'text', value: 'ok' },
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'srvtoolu_1',
+            toolName: 'tool_search',
+            output: {
+              type: 'json',
+              value: [{ type: 'tool_reference', toolName: 'lookup_invoice' }],
+            },
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+    ]);
+  });
+
+  test('keeps unresolved client tool_search calls even after the conversation continues', () => {
+    // Only provider-executed (server) tool_search calls are subject to the
+    // deferral cleanup; client calls are resolved by the runner and must be
+    // replayed unchanged regardless of position.
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'tool_search_call',
+        id: 'ts_client_1',
+        status: 'completed',
+        arguments: { paths: ['billing'] },
+        providerData: { execution: 'client' },
+      } as any,
+      {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'Searching...' }],
+        status: 'completed',
+      },
+    ];
+
+    const messages = itemsToLanguageV2Messages(stubModel({}), items);
+    const toolSearchCalls = messages.flatMap((message) =>
+      Array.isArray(message.content)
+        ? message.content.filter(
+            (part) => part.type === 'tool-call' && part.toolName === 'tool_search',
+          )
+        : [],
+    );
+    expect(toolSearchCalls).toHaveLength(1);
+  });
+
   test('does not queue hosted tool_search calls as pending client searches', () => {
     const items: protocol.ModelItem[] = [
       {


### PR DESCRIPTION
### Summary

When an Anthropic model co-emits a server `tool_search` after a client tool call, Anthropic defers the server tool: the response carries the `server_tool_use` block with no result. The AI SDK adapter surfaced this as a `tool_search_call` item with no matching `tool_search_output`, and `itemsToLanguageV2Messages` replayed that unpaired `providerExecuted` tool-call on every later request — which Anthropic rejects with a 400 (`tool_search_tool_regex tool use … was found without a corresponding tool_search_tool_regex_tool_result block`) once the conversation has moved past that turn. This PR keeps the unresolved call only while it is still in the documented resume window (final assistant turn, followed solely by that turn's client tool results) and drops it from the serialized request afterwards, so the deferral can still resolve when the provider resumes it, and a stale orphan can never fail the run.

### Behavior

| Scenario | Before | After |
| --- | --- | --- |
| Server `tool_search` resolved inline (same response) | Call + result serialized as a pair | Unchanged |
| Deferred server `tool_search` (co-emitted with a client tool), next request | Unpaired `server_tool_use` replayed with the client `tool_result` (documented resume shape) | Unchanged — the resume window is preserved |
| Deferred server `tool_search`, conversation continued past the turn | Unpaired `server_tool_use` replayed on every later request → Anthropic 400, run fails | Orphaned call stripped from the serialized request; run continues |
| Deferred result arriving on a later turn (explicit call id) | Paired with the original call | Unchanged — resolved calls are never stripped |
| Client-executed / default `tool_search` calls | Replayed unchanged | Unchanged (filter is scoped to `execution: 'server'`) |

Non-Anthropic providers are unaffected: `tool_search_call` items are only produced for hosted tool_search tools, client/default execution is never touched (pinned by a new test), and providers that resolve server searches inline always produce paired calls, making the filter a no-op.

### Test plan

- New unit tests in `packages/agents-extensions/test/ai-sdk/index.test.ts`: the stale-orphan repro (fails without the fix), plus pinning tests for the resume window, cross-turn pairing of a deferred result, and unresolved client-execution calls being left untouched.
- `pnpm build`, `pnpm -r build-check`, `CI=1 pnpm test` (full suite), `pnpm lint`, and `.agents/skills/code-change-verification/scripts/run.sh` all pass.

### Issue number

Closes #1542

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration` [(see details)](https://github.com/openai/openai-agents-js/tree/main/integration-tests)
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
- [x] I've added a changeset using `pnpm changeset` to indicate my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
