### PR TITLE
fix(examples): fail closed without financial research sources

### DIFF
--- a/examples/financial-research-agent/README.md
+++ b/examples/financial-research-agent/README.md
@@ -11,7 +11,7 @@ The manager orchestrates several specialized agents:
 3. **Writer** – synthesizes the search results, optionally calling fundamentals and risk analyst tools.
 4. **Verifier** – checks the final report for consistency and issues.
 
-After running these steps the manager prints a short summary, the full markdown report, suggested follow-up questions, and verification results. If blocking source-grounding issues remain after two revisions, it exits with an error instead of presenting the unverified report as successful output.
+After running these steps the manager prints a short summary, the full markdown report, suggested follow-up questions, and verification results. If no search produces a usable summary, or if blocking source-grounding issues remain after two revisions, it exits with an error instead of presenting an ungrounded or unverified report as successful output.
 
 Run the example with:
 

--- a/examples/financial-research-agent/main.ts
+++ b/examples/financial-research-agent/main.ts
@@ -6,17 +6,16 @@ import { FinancialResearchManager } from './manager';
 // "Write up an analysis of Apple Inc.'s most recent quarter."
 
 async function main() {
-  const readline = await import('readline');
+  const readline = await import('node:readline/promises');
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
   });
-  rl.question('Enter a financial research query: ', async (query: string) => {
-    rl.close();
-    await withTrace('Financial research workflow', async () => {
-      const manager = new FinancialResearchManager();
-      await manager.run(query);
-    });
+  const query = await rl.question('Enter a financial research query: ');
+  rl.close();
+  await withTrace('Financial research workflow', async () => {
+    const manager = new FinancialResearchManager();
+    await manager.run(query);
   });
 }
 

--- a/examples/financial-research-agent/manager.test.ts
+++ b/examples/financial-research-agent/manager.test.ts
@@ -20,6 +20,7 @@ const revisedReport: FinancialReportData = {
 
 class TestFinancialResearchManager extends FinancialResearchManager {
   searchResults = ['Primary source summary'];
+  writeReportSearchResults: string[] | undefined;
   writeReportCalls = 0;
   verificationCalls = 0;
   revisionCalls = 0;
@@ -33,8 +34,12 @@ class TestFinancialResearchManager extends FinancialResearchManager {
     return this.searchResults;
   }
 
-  async writeReport(): Promise<FinancialReportData> {
+  async writeReport(
+    _query: string,
+    searchResults: string[],
+  ): Promise<FinancialReportData> {
     this.writeReportCalls++;
+    this.writeReportSearchResults = searchResults;
     return initialReport;
   }
 
@@ -102,6 +107,35 @@ test('fails before writing when no usable search summaries remain', async () => 
 
   expect(manager.writeReportCalls).toBe(0);
   expect(manager.verificationCalls).toBe(0);
+});
+
+test('fails before writing when the search summary is blank', async () => {
+  const manager = new TestFinancialResearchManager();
+  manager.searchResults = [''];
+
+  await expect(manager.run('Research query')).rejects.toThrow(
+    'Financial research failed because no usable search summaries were returned.',
+  );
+
+  expect(manager.writeReportCalls).toBe(0);
+  expect(manager.verificationCalls).toBe(0);
+});
+
+test('filters blank search summaries while preserving usable results', async () => {
+  const manager = new TestFinancialResearchManager();
+  manager.searchResults = [
+    '',
+    'Primary source summary',
+    ' \n',
+    'Secondary source summary',
+  ];
+
+  await manager.run('Research query');
+
+  expect(manager.writeReportSearchResults).toEqual([
+    'Primary source summary',
+    'Secondary source summary',
+  ]);
 });
 
 test('fails closed when the report remains unverified', async () => {

--- a/examples/financial-research-agent/manager.test.ts
+++ b/examples/financial-research-agent/manager.test.ts
@@ -19,6 +19,8 @@ const revisedReport: FinancialReportData = {
 };
 
 class TestFinancialResearchManager extends FinancialResearchManager {
+  searchResults = ['Primary source summary'];
+  writeReportCalls = 0;
   verificationCalls = 0;
   revisionCalls = 0;
   verificationFailuresBeforePass = 0;
@@ -28,10 +30,11 @@ class TestFinancialResearchManager extends FinancialResearchManager {
   }
 
   async performSearches(): Promise<string[]> {
-    return ['Primary source summary'];
+    return this.searchResults;
   }
 
   async writeReport(): Promise<FinancialReportData> {
+    this.writeReportCalls++;
     return initialReport;
   }
 
@@ -87,6 +90,18 @@ test('does not revise a report that passes verification', async () => {
 
   expect(manager.revisionCalls).toBe(0);
   expect(manager.verificationCalls).toBe(1);
+});
+
+test('fails before writing when no usable search summaries remain', async () => {
+  const manager = new TestFinancialResearchManager();
+  manager.searchResults = [];
+
+  await expect(manager.run('Research query')).rejects.toThrow(
+    'Financial research failed because no usable search summaries were returned.',
+  );
+
+  expect(manager.writeReportCalls).toBe(0);
+  expect(manager.verificationCalls).toBe(0);
 });
 
 test('fails closed when the report remains unverified', async () => {

--- a/examples/financial-research-agent/manager.ts
+++ b/examples/financial-research-agent/manager.ts
@@ -45,6 +45,11 @@ export class FinancialResearchManager {
     console.log(`[start] Starting financial research...`);
     const searchPlan = await this.planSearches(query);
     const searchResults = await this.performSearches(searchPlan);
+    if (searchResults.length === 0) {
+      throw new Error(
+        'Financial research failed because no usable search summaries were returned.',
+      );
+    }
     let report = await this.writeReport(query, searchResults);
     let verification = await this.verifyReport(report, searchResults);
     let revisions = 0;

--- a/examples/financial-research-agent/manager.ts
+++ b/examples/financial-research-agent/manager.ts
@@ -44,7 +44,9 @@ export class FinancialResearchManager {
   async run(query: string): Promise<void> {
     console.log(`[start] Starting financial research...`);
     const searchPlan = await this.planSearches(query);
-    const searchResults = await this.performSearches(searchPlan);
+    const searchResults = (await this.performSearches(searchPlan)).filter(
+      (result) => result.trim().length > 0,
+    );
     if (searchResults.length === 0) {
       throw new Error(
         'Financial research failed because no usable search summaries were returned.',


### PR DESCRIPTION
This pull request resolves #1544 by stopping financial report generation when no usable search summaries remain.

It preserves partial-search success, routes prompt-driven failures through the existing top-level error handler by awaiting the readline promise, adds regression coverage, and documents the fail-closed behavior. The already shipped verification-exhaustion guard remains unchanged.