### PR TITLE
feat: preserve sandbox environment secret references

### DIFF
--- a/.changeset/sandbox-env-value-references.md
+++ b/.changeset/sandbox-env-value-references.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-extensions': patch
+---
+
+feat: preserve sandbox environment secret references

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -31,7 +31,10 @@ import logger from './logger';
 import { handoff } from './handoff';
 import * as protocol from './types/protocol';
 import { AgentInputItem, UnknownContext } from './types';
-import { SANDBOX_SESSION_STATE_VERSION } from './sandbox/session';
+import {
+  SANDBOX_SESSION_STATE_VERSION,
+  SUPPORTED_SANDBOX_SESSION_STATE_VERSIONS,
+} from './sandbox/session';
 import type { InputGuardrailResult, OutputGuardrailResult } from './guardrail';
 import type {
   ToolInputGuardrailResult,
@@ -96,8 +99,10 @@ import {
  * - 1.13: Adds optional SDK-only customData on tool output run items.
  * - 1.14: Adds Programmatic Tool Calling program items, outputs, caller linkage,
  *   and optional assistant message phases.
+ * - 1.15: Adds reconstructable sandbox environment value references and sandbox
+ *   session-state envelope version 2.
  */
-export const CURRENT_SCHEMA_VERSION = '1.14' as const;
+export const CURRENT_SCHEMA_VERSION = '1.15' as const;
 const SUPPORTED_SCHEMA_VERSIONS = [
   '1.0',
   '1.1',
@@ -113,6 +118,7 @@ const SUPPORTED_SCHEMA_VERSIONS = [
   '1.11',
   '1.12',
   '1.13',
+  '1.14',
   CURRENT_SCHEMA_VERSION,
 ] as const;
 type SupportedSchemaVersion = (typeof SUPPORTED_SCHEMA_VERSIONS)[number];
@@ -254,7 +260,11 @@ const serializedTraceSchema = z.object({
 });
 
 const sandboxSessionStateEnvelopeSchema = z.object({
-  version: z.literal(SANDBOX_SESSION_STATE_VERSION),
+  version: z.union(
+    SUPPORTED_SANDBOX_SESSION_STATE_VERSIONS.map((version) =>
+      z.literal(version),
+    ) as [z.ZodLiteral<1>, z.ZodLiteral<typeof SANDBOX_SESSION_STATE_VERSION>],
+  ),
   backendId: z.string(),
   manifest: z.record(z.string(), z.any()),
   snapshot: z.record(z.string(), z.any()).nullable().optional(),
@@ -1077,6 +1087,10 @@ async function buildRunStateFromString<
     currentSchemaVersion as SupportedSchemaVersion,
     stateJson,
   );
+  assertSchemaVersionSupportsSandboxSessionEnvelope(
+    currentSchemaVersion as SupportedSchemaVersion,
+    stateJson,
+  );
   return buildRunStateFromJson(initialAgent, stateJson, options);
 }
 
@@ -1091,6 +1105,7 @@ function assertSchemaVersionSupportsToolSearch(
     schemaVersion === '1.11' ||
     schemaVersion === '1.12' ||
     schemaVersion === '1.13' ||
+    schemaVersion === '1.14' ||
     schemaVersion === CURRENT_SCHEMA_VERSION
   ) {
     return;
@@ -1109,7 +1124,11 @@ function assertSchemaVersionSupportsCustomData(
   schemaVersion: SupportedSchemaVersion,
   stateJson: z.infer<typeof SerializedRunState>,
 ): void {
-  if (schemaVersion === '1.13' || schemaVersion === CURRENT_SCHEMA_VERSION) {
+  if (
+    schemaVersion === '1.13' ||
+    schemaVersion === '1.14' ||
+    schemaVersion === CURRENT_SCHEMA_VERSION
+  ) {
     return;
   }
 
@@ -1130,6 +1149,7 @@ function schemaVersionSupportsAgentIdentity(
     schemaVersion === '1.11' ||
     schemaVersion === '1.12' ||
     schemaVersion === '1.13' ||
+    schemaVersion === '1.14' ||
     schemaVersion === CURRENT_SCHEMA_VERSION
   );
 }
@@ -1138,7 +1158,7 @@ function assertSchemaVersionSupportsProgrammaticToolCalling(
   schemaVersion: SupportedSchemaVersion,
   stateJson: z.infer<typeof SerializedRunState>,
 ): void {
-  if (schemaVersion === CURRENT_SCHEMA_VERSION) {
+  if (schemaVersion === '1.14' || schemaVersion === CURRENT_SCHEMA_VERSION) {
     return;
   }
 
@@ -1148,6 +1168,33 @@ function assertSchemaVersionSupportsProgrammaticToolCalling(
 
   throw new UserError(
     `Run state schema version ${schemaVersion} does not support Programmatic Tool Calling items. Please reserialize the run state with schema ${CURRENT_SCHEMA_VERSION}.`,
+  );
+}
+
+function assertSchemaVersionSupportsSandboxSessionEnvelope(
+  schemaVersion: SupportedSchemaVersion,
+  stateJson: z.infer<typeof SerializedRunState>,
+): void {
+  if (schemaVersion === CURRENT_SCHEMA_VERSION || !stateJson.sandbox) {
+    return;
+  }
+
+  const envelopes = [
+    stateJson.sandbox.sessionState,
+    ...Object.values(stateJson.sandbox.sessionsByAgent).map(
+      (entry) => entry.sessionState,
+    ),
+  ];
+  if (
+    envelopes.every(
+      (envelope) => envelope.version !== SANDBOX_SESSION_STATE_VERSION,
+    )
+  ) {
+    return;
+  }
+
+  throw new UserError(
+    `Run state schema version ${schemaVersion} does not support sandbox session state version ${SANDBOX_SESSION_STATE_VERSION}. Please reserialize the run state with schema ${CURRENT_SCHEMA_VERSION}.`,
   );
 }
 

--- a/packages/agents-core/src/sandbox/internal.ts
+++ b/packages/agents-core/src/sandbox/internal.ts
@@ -38,6 +38,7 @@ export {
   materializeStaticEnvironment,
   mergeMaterializedEnvironment,
   mergeStaticMaterializedEnvironment,
+  rehydratePersistedEnvironmentForRuntime,
   serializeManifestEnvironment,
   serializeRuntimeEnvironmentForPersistence,
 } from './shared/environment';

--- a/packages/agents-core/src/sandbox/internal.ts
+++ b/packages/agents-core/src/sandbox/internal.ts
@@ -39,6 +39,7 @@ export {
   mergeMaterializedEnvironment,
   mergeStaticMaterializedEnvironment,
   rehydratePersistedEnvironmentForRuntime,
+  resolveEnvironmentReferences,
   serializeManifestEnvironment,
   serializeRuntimeEnvironmentForPersistence,
 } from './shared/environment';

--- a/packages/agents-core/src/sandbox/manifest.ts
+++ b/packages/agents-core/src/sandbox/manifest.ts
@@ -377,6 +377,12 @@ export abstract class EnvValueReference extends Environment {
     return parseEnvValueReference(serializeEnvValueReference(this));
   }
 
+  override normalized(): never {
+    throw new TypeError(
+      'EnvValueReference cannot be normalized to an EnvValue. Use serializeEnvValueReference() instead.',
+    );
+  }
+
   toJSON(): SerializedEnvValueReference {
     return serializeEnvValueReference(this);
   }

--- a/packages/agents-core/src/sandbox/manifest.ts
+++ b/packages/agents-core/src/sandbox/manifest.ts
@@ -42,7 +42,13 @@ export type EnvValue = {
   description?: string;
 };
 
-export type EnvEntry = string | EnvResolver | EnvValue | Environment;
+export type SerializedEnvValueReference = {
+  type: string;
+  [key: string]: unknown;
+};
+
+export type EnvEntry =
+  string | EnvResolver | EnvValue | Environment | SerializedEnvValueReference;
 
 export type RenderManifestDescriptionOptions = {
   depth?: number | null;
@@ -59,12 +65,20 @@ type ManifestEnvironmentValues<TEnvironment extends ManifestEnvironment> = {
 };
 
 export class Environment {
-  readonly value: string;
+  readonly value!: string;
   readonly resolver?: EnvResolver;
-  readonly ephemeral: boolean;
+  readonly ephemeral!: boolean;
   readonly description?: string;
 
   constructor(entry: EnvEntry) {
+    if (entry instanceof EnvValueReference) {
+      return entry;
+    }
+
+    if (isSerializedEnvValueReference(entry)) {
+      return parseEnvValueReference(entry);
+    }
+
     if (entry instanceof Environment) {
       this.value = entry.value;
       this.resolver = entry.resolver;
@@ -306,6 +320,187 @@ export class Manifest<
   }
 }
 
+export type EnvValueReferenceClass<
+  TReference extends EnvValueReference = EnvValueReference,
+> = {
+  readonly type: string;
+  readonly prototype: TReference;
+};
+
+export type EnvValueReferenceParser<
+  TReference extends EnvValueReference = EnvValueReference,
+> = (payload: Readonly<Record<string, unknown>>) => TReference;
+
+type EnvValueReferenceRegistration<
+  TReference extends EnvValueReference = EnvValueReference,
+> = {
+  referenceClass: EnvValueReferenceClass<TReference>;
+  parse: EnvValueReferenceParser<TReference>;
+};
+
+const envValueReferenceRegistry = new Map<
+  string,
+  EnvValueReferenceRegistration
+>();
+
+/**
+ * A JSON-serializable reference to a runtime sandbox environment value.
+ *
+ * Subclasses must serialize only non-secret lookup metadata. Register each
+ * subclass in every process that reconstructs manifests before parsing JSON.
+ */
+export abstract class EnvValueReference extends Environment {
+  static readonly type: string = '';
+
+  protected constructor(
+    options: {
+      ephemeral?: boolean;
+      description?: string;
+    } = {},
+  ) {
+    super({
+      value: '',
+      ...(options.ephemeral ? { ephemeral: true } : {}),
+      ...(options.description ? { description: options.description } : {}),
+    });
+  }
+
+  get type(): string {
+    return (this.constructor as typeof EnvValueReference).type;
+  }
+
+  abstract serialize(): Record<string, unknown>;
+
+  abstract override resolve(): Promise<string>;
+
+  override init(): EnvValueReference {
+    return parseEnvValueReference(serializeEnvValueReference(this));
+  }
+
+  toJSON(): SerializedEnvValueReference {
+    return serializeEnvValueReference(this);
+  }
+}
+
+/**
+ * Registers one environment reference subtype for JSON reconstruction.
+ *
+ * The parser receives persisted data and must validate it before constructing
+ * a reference, including allowlisting any secret-store lookup keys.
+ *
+ * Returns an unregister callback for test isolation and controlled module
+ * lifecycle cleanup. Conflicting registrations fail instead of replacing the
+ * active parser.
+ */
+export function registerEnvValueReference<TReference extends EnvValueReference>(
+  referenceClass: EnvValueReferenceClass<TReference>,
+  parse: EnvValueReferenceParser<TReference>,
+): () => void {
+  if (typeof (referenceClass as unknown) !== 'function') {
+    throw new TypeError('EnvValueReference registration requires a class.');
+  }
+  if (!Object.prototype.hasOwnProperty.call(referenceClass, 'type')) {
+    throw new TypeError(
+      `${envValueReferenceClassName(referenceClass)} must declare its own static type.`,
+    );
+  }
+  const type = referenceClass.type;
+  if (typeof type !== 'string' || type.trim() === '') {
+    throw new TypeError('EnvValueReference type must be a non-empty string.');
+  }
+  const existing = envValueReferenceRegistry.get(type);
+  if (existing) {
+    throw new TypeError(
+      `Environment value reference type "${type}" is already registered by ${envValueReferenceClassName(existing.referenceClass)}.`,
+    );
+  }
+
+  const registration: EnvValueReferenceRegistration<TReference> = {
+    referenceClass,
+    parse,
+  };
+  envValueReferenceRegistry.set(type, registration);
+  return () => {
+    if (envValueReferenceRegistry.get(type) === registration) {
+      envValueReferenceRegistry.delete(type);
+    }
+  };
+}
+
+export function serializeEnvValueReference(
+  reference: EnvValueReference,
+): SerializedEnvValueReference {
+  const registration = envValueReferenceRegistry.get(reference.type);
+  if (
+    !registration ||
+    reference.constructor !== (registration.referenceClass as unknown)
+  ) {
+    throw new TypeError(
+      `${reference.constructor.name || 'EnvValueReference subclass'} must be registered with its own static type before serialization.`,
+    );
+  }
+  const serialized = reference.serialize();
+  if (!isRecord(serialized)) {
+    throw new TypeError(
+      `${reference.constructor.name || 'EnvValueReference subclass'}.serialize() must return a record.`,
+    );
+  }
+  if ('value' in serialized) {
+    throw new TypeError(
+      `${reference.constructor.name || 'EnvValueReference subclass'}.serialize() must not return the reserved "value" field.`,
+    );
+  }
+  return {
+    ...serialized,
+    type: reference.type,
+  };
+}
+
+export function isEnvValueReference(
+  value: unknown,
+): value is EnvValueReference {
+  return value instanceof EnvValueReference;
+}
+
+export function isSerializedEnvValueReference(
+  value: unknown,
+): value is SerializedEnvValueReference {
+  return (
+    isRecord(value) && typeof value.type === 'string' && !('value' in value)
+  );
+}
+
+function parseEnvValueReference(
+  serialized: SerializedEnvValueReference,
+): EnvValueReference {
+  const registration = envValueReferenceRegistry.get(serialized.type);
+  if (!registration) {
+    const knownTypes = [...envValueReferenceRegistry.keys()].sort().join(', ');
+    throw new TypeError(
+      `Unknown environment value reference type "${serialized.type}". Registered types: ${knownTypes || '<none>'}.`,
+    );
+  }
+  const { type: _type, ...payload } = serialized;
+  const reference = registration.parse(payload);
+  if (
+    !(reference instanceof EnvValueReference) ||
+    reference.constructor !== (registration.referenceClass as unknown) ||
+    reference.type !== serialized.type
+  ) {
+    throw new TypeError(
+      `Parser for environment value reference type "${serialized.type}" must return an instance of ${envValueReferenceClassName(registration.referenceClass)}.`,
+    );
+  }
+  return reference;
+}
+
+function envValueReferenceClassName(
+  referenceClass: EnvValueReferenceClass,
+): string {
+  const name = (referenceClass as { readonly name?: unknown }).name;
+  return typeof name === 'string' && name ? name : 'EnvValueReference subclass';
+}
+
 export type ManifestInput<
   TEntries extends ManifestEntries = ManifestEntries,
   TEnvironment extends ManifestEnvironment = ManifestEnvironment,
@@ -356,11 +551,7 @@ export function normalizeRelativePath(path: string): string {
 function normalizeGitRepoSubpath(repo: string, subpath: string): string {
   const trimmed = subpath.trim();
   let reason:
-    | 'absolute'
-    | 'empty'
-    | 'parent_traversal'
-    | 'windows_path'
-    | undefined;
+    'absolute' | 'empty' | 'parent_traversal' | 'windows_path' | undefined;
 
   if (subpath === '' || normalizePosixPath(trimmed) === '.') {
     return '';

--- a/packages/agents-core/src/sandbox/runtime/manager.ts
+++ b/packages/agents-core/src/sandbox/runtime/manager.ts
@@ -16,7 +16,10 @@ import { SandboxLifecycleError } from '../errors';
 import { cloneManifest, Manifest } from '../manifest';
 import { type SandboxSessionLike, type SandboxSessionState } from '../session';
 import { isDefaultRemoteMountCommandAllowlist } from '../shared/remoteMountCommandAllowlist';
-import { serializeManifestEnvironment } from '../shared/environment';
+import {
+  resolveEnvironmentReferences,
+  serializeManifestEnvironment,
+} from '../shared/environment';
 import { stableJsonStringify } from '../shared/stableJson';
 import type { SnapshotSpec } from '../snapshot';
 import {
@@ -1028,6 +1031,10 @@ export class SandboxRuntimeManager<TContext> {
 
     const canReuse = args.client.canReusePreservedOwnedSession;
     if (!canReuse) {
+      await refreshLiveEnvironmentReferences(
+        liveEntry.session.state,
+        args.trustedManifest,
+      );
       return { entry: liveEntry, reusable: true };
     }
 
@@ -1072,6 +1079,13 @@ export class SandboxRuntimeManager<TContext> {
         session: liveEntry.session,
       });
       return { entry: liveEntry, reusable: false };
+    }
+
+    if (args.client.backendId !== 'docker') {
+      await refreshLiveEnvironmentReferences(
+        liveEntry.session.state,
+        args.trustedManifest,
+      );
     }
 
     // Rebind only after the backend has verified that its live authority still
@@ -1375,6 +1389,24 @@ function manifestWithTrustedRuntimePolicies(
       ...trustedManifest.remoteMountCommandAllowlist,
     ],
   });
+}
+
+async function refreshLiveEnvironmentReferences(
+  state: SandboxSessionState,
+  trustedManifest: Manifest | undefined,
+): Promise<void> {
+  if (!trustedManifest) {
+    return;
+  }
+  const resolvedReferences =
+    await resolveEnvironmentReferences(trustedManifest);
+  if (Object.keys(resolvedReferences).length === 0) {
+    return;
+  }
+  state.environment = {
+    ...(state.environment ?? {}),
+    ...resolvedReferences,
+  };
 }
 
 function removeClosedPreservedOwnedSessions(

--- a/packages/agents-core/src/sandbox/runtime/manager.ts
+++ b/packages/agents-core/src/sandbox/runtime/manager.ts
@@ -1341,9 +1341,7 @@ function getManifestSignature(manifest: Manifest): string {
     version: manifest.version,
     root: manifest.root,
     entries: manifest.entries,
-    environment: serializeManifestEnvironment(manifest, {
-      allowResolverPlaceholders: true,
-    }),
+    environment: serializeManifestEnvironment(manifest),
     users: manifest.users,
     groups: manifest.groups,
     extraPathGrants: manifest.extraPathGrants,

--- a/packages/agents-core/src/sandbox/runtime/manager.ts
+++ b/packages/agents-core/src/sandbox/runtime/manager.ts
@@ -1341,7 +1341,9 @@ function getManifestSignature(manifest: Manifest): string {
     version: manifest.version,
     root: manifest.root,
     entries: manifest.entries,
-    environment: serializeManifestEnvironment(manifest),
+    environment: serializeManifestEnvironment(manifest, {
+      allowResolverPlaceholders: true,
+    }),
     users: manifest.users,
     groups: manifest.groups,
     extraPathGrants: manifest.extraPathGrants,

--- a/packages/agents-core/src/sandbox/runtime/manager.ts
+++ b/packages/agents-core/src/sandbox/runtime/manager.ts
@@ -13,13 +13,10 @@ import type {
   SandboxRunConfig,
 } from '../client';
 import { SandboxLifecycleError } from '../errors';
-import { cloneManifest, Manifest } from '../manifest';
+import { cloneManifest, isEnvValueReference, Manifest } from '../manifest';
 import { type SandboxSessionLike, type SandboxSessionState } from '../session';
 import { isDefaultRemoteMountCommandAllowlist } from '../shared/remoteMountCommandAllowlist';
-import {
-  resolveEnvironmentReferences,
-  serializeManifestEnvironment,
-} from '../shared/environment';
+import { serializeManifestEnvironment } from '../shared/environment';
 import { stableJsonStringify } from '../shared/stableJson';
 import type { SnapshotSpec } from '../snapshot';
 import {
@@ -1083,7 +1080,7 @@ export class SandboxRuntimeManager<TContext> {
 
     if (args.client.backendId !== 'docker') {
       await refreshLiveEnvironmentReferences(
-        liveEntry.session.state,
+        candidateState,
         args.trustedManifest,
       );
     }
@@ -1103,9 +1100,7 @@ export class SandboxRuntimeManager<TContext> {
             args.trustedManifest,
           )
         : candidateState.manifest;
-    if (args.client.backendId === 'docker') {
-      liveEntry.session.state.environment = candidateState.environment;
-    }
+    liveEntry.session.state.environment = candidateState.environment;
     return { entry: liveEntry, reusable: true };
   }
 
@@ -1398,15 +1393,57 @@ async function refreshLiveEnvironmentReferences(
   if (!trustedManifest) {
     return;
   }
-  const resolvedReferences =
-    await resolveEnvironmentReferences(trustedManifest);
-  if (Object.keys(resolvedReferences).length === 0) {
+  const referenceKeys = new Set([
+    ...Object.entries(state.manifest.environment)
+      .filter(([, value]) => isEnvValueReference(value))
+      .map(([key]) => key),
+    ...Object.entries(trustedManifest.environment)
+      .filter(([, value]) => isEnvValueReference(value))
+      .map(([key]) => key),
+  ]);
+  if (referenceKeys.size === 0) {
     return;
   }
+  const resolvedEnvironment = Object.fromEntries(
+    (
+      await Promise.all(
+        [...referenceKeys].map(async (key) => {
+          const value = trustedManifest.environment[key];
+          return value ? ([key, await value.resolve()] as const) : undefined;
+        }),
+      )
+    ).filter((entry) => entry !== undefined),
+  );
+  const environment = { ...(state.environment ?? {}) };
+  const manifestEnvironment = Object.fromEntries(
+    Object.entries(state.manifest.environment)
+      .filter(([key]) => !referenceKeys.has(key))
+      .map(([key, value]) => [key, value.init()]),
+  );
+  for (const key of referenceKeys) {
+    delete environment[key];
+    const value = trustedManifest.environment[key];
+    if (value) {
+      manifestEnvironment[key] = value.init();
+    }
+  }
+  const manifest = new Manifest({
+    version: state.manifest.version,
+    root: state.manifest.root,
+    entries: structuredClone(state.manifest.entries),
+    environment: manifestEnvironment,
+    users: structuredClone(state.manifest.users),
+    groups: structuredClone(state.manifest.groups),
+    extraPathGrants: structuredClone(state.manifest.extraPathGrants),
+    remoteMountCommandAllowlist: [
+      ...state.manifest.remoteMountCommandAllowlist,
+    ],
+  });
   state.environment = {
-    ...(state.environment ?? {}),
-    ...resolvedReferences,
+    ...environment,
+    ...resolvedEnvironment,
   };
+  state.manifest = manifest;
 }
 
 function removeClosedPreservedOwnedSessions(

--- a/packages/agents-core/src/sandbox/runtime/providedSessionManifest.ts
+++ b/packages/agents-core/src/sandbox/runtime/providedSessionManifest.ts
@@ -68,12 +68,8 @@ function validateProvidedSessionManifestUpdate(
 }
 
 function validateNoEnvironmentDelta(current: Manifest, target: Manifest): void {
-  const currentEnvironment = serializeManifestEnvironment(current, {
-    allowResolverPlaceholders: true,
-  });
-  const targetEnvironment = serializeManifestEnvironment(target, {
-    allowResolverPlaceholders: true,
-  });
+  const currentEnvironment = serializeManifestEnvironment(current);
+  const targetEnvironment = serializeManifestEnvironment(target);
   const hasDelta = Object.entries(targetEnvironment).some(
     ([key, value]) => !jsonEqual(currentEnvironment[key], value),
   );

--- a/packages/agents-core/src/sandbox/runtime/providedSessionManifest.ts
+++ b/packages/agents-core/src/sandbox/runtime/providedSessionManifest.ts
@@ -68,8 +68,12 @@ function validateProvidedSessionManifestUpdate(
 }
 
 function validateNoEnvironmentDelta(current: Manifest, target: Manifest): void {
-  const currentEnvironment = serializeManifestEnvironment(current);
-  const targetEnvironment = serializeManifestEnvironment(target);
+  const currentEnvironment = serializeManifestEnvironment(current, {
+    allowResolverPlaceholders: true,
+  });
+  const targetEnvironment = serializeManifestEnvironment(target, {
+    allowResolverPlaceholders: true,
+  });
   const hasDelta = Object.entries(targetEnvironment).some(
     ([key, value]) => !jsonEqual(currentEnvironment[key], value),
   );

--- a/packages/agents-core/src/sandbox/runtime/sessionState.ts
+++ b/packages/agents-core/src/sandbox/runtime/sessionState.ts
@@ -2,9 +2,15 @@ import { UserError } from '../../errors';
 import type { RunState } from '../../runState';
 import type { Agent, AgentOutputType } from '../../agent';
 import type { SandboxClient } from '../client';
-import type { Manifest } from '../manifest';
+import {
+  isEnvValueReference,
+  isSerializedEnvValueReference,
+  type Manifest,
+  type ManifestEnvironment,
+} from '../manifest';
 import {
   SANDBOX_SESSION_STATE_VERSION,
+  SUPPORTED_SANDBOX_SESSION_STATE_VERSIONS,
   type SandboxSessionState,
   type SandboxSessionStateEnvelope,
 } from '../session';
@@ -95,7 +101,11 @@ export function assertSessionStateEnvelope(
   client: SandboxClient,
   envelope: SandboxSessionStateEnvelope,
 ): void {
-  if (envelope.version !== SANDBOX_SESSION_STATE_VERSION) {
+  if (
+    !SUPPORTED_SANDBOX_SESSION_STATE_VERSIONS.includes(
+      envelope.version as (typeof SUPPORTED_SANDBOX_SESSION_STATE_VERSIONS)[number],
+    )
+  ) {
     throw new UserError(
       `Sandbox session state version ${envelope.version} is not supported. Please use version ${SANDBOX_SESSION_STATE_VERSION}.`,
     );
@@ -129,8 +139,9 @@ export async function deserializeSandboxSessionStateEntry(
   }
   const envelope = serializedEntry.sessionState;
   assertSessionStateEnvelope(client, envelope);
+  assertTrustedEnvironmentForPersistedReferences(envelope, trustedManifest);
   const state = await client.deserializeSessionState(
-    providerStateWithSdkEnvelopeFields(envelope),
+    providerStateWithSdkEnvelopeFields(envelope, trustedManifest),
   );
   if (client.backendId === 'docker') {
     delete state.sessionIdentity;
@@ -163,13 +174,19 @@ export function assertTrustedManifestForDockerRunState(
 
 function providerStateWithSdkEnvelopeFields(
   envelope: SandboxSessionStateEnvelope,
+  trustedManifest?: Manifest,
 ): Record<string, unknown> {
   return {
     ...providerStateWithoutSdkEnvelopeFields(
       envelope.providerState,
       envelope.backendId,
     ),
-    manifest: envelope.manifest,
+    manifest: trustedManifest
+      ? {
+          ...envelope.manifest,
+          environment: cloneManifestEnvironment(trustedManifest.environment),
+        }
+      : envelope.manifest,
     ...(envelope.snapshot !== undefined ? { snapshot: envelope.snapshot } : {}),
     ...(envelope.snapshotFingerprint !== undefined
       ? { snapshotFingerprint: envelope.snapshotFingerprint }
@@ -184,6 +201,51 @@ function providerStateWithSdkEnvelopeFields(
       ? { exposedPorts: structuredClone(envelope.exposedPorts) }
       : {}),
   };
+}
+
+function assertTrustedEnvironmentForPersistedReferences(
+  envelope: SandboxSessionStateEnvelope,
+  trustedManifest: Manifest | undefined,
+): void {
+  const persistedEnvironment = envelope.manifest.environment;
+  if (
+    !persistedEnvironment ||
+    typeof persistedEnvironment !== 'object' ||
+    Array.isArray(persistedEnvironment)
+  ) {
+    return;
+  }
+
+  const referenceKeys = Object.entries(persistedEnvironment)
+    .filter(([, value]) => isSerializedEnvValueReference(value))
+    .map(([key]) => key);
+  if (referenceKeys.length === 0) {
+    return;
+  }
+  if (!trustedManifest) {
+    throw new UserError(
+      'RunState sandbox session state with environment value references requires a current trusted manifest for the sandbox agent.',
+    );
+  }
+
+  const missingReferenceKeys = referenceKeys.filter(
+    (key) =>
+      !trustedManifest.environment[key] ||
+      !isEnvValueReference(trustedManifest.environment[key]),
+  );
+  if (missingReferenceKeys.length > 0) {
+    throw new UserError(
+      `RunState sandbox session state contains environment value references that are not present in the current trusted manifest: ${missingReferenceKeys.join(', ')}.`,
+    );
+  }
+}
+
+function cloneManifestEnvironment(
+  environment: Record<string, { init(): ManifestEnvironment[string] }>,
+): ManifestEnvironment {
+  return Object.fromEntries(
+    Object.entries(environment).map(([key, value]) => [key, value.init()]),
+  );
 }
 
 export function getSerializedSessionEntryForAgent(

--- a/packages/agents-core/src/sandbox/sandboxes/docker.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/docker.ts
@@ -46,7 +46,7 @@ import type {
   SandboxSessionSerializationOptions,
 } from '../client';
 import { normalizeSandboxClientCreateArgs } from '../client';
-import { Manifest } from '../manifest';
+import { isEnvValueReference, Manifest } from '../manifest';
 import {
   WorkspacePathPolicy,
   type ResolveSandboxPathOptions,
@@ -1057,7 +1057,7 @@ export class DockerSandboxClient implements SandboxClient<
   async deserializeSessionState(
     state: Record<string, unknown>,
   ): Promise<DockerSandboxSessionState> {
-    const baseState = deserializeLocalSandboxSessionStateValues(
+    const baseState = await deserializeLocalSandboxSessionStateValues(
       state,
       this.options.snapshot,
     );
@@ -1089,7 +1089,7 @@ export class DockerSandboxClient implements SandboxClient<
         sessionIdentity: undefined,
         materializedEntriesFingerprint: undefined,
         image: resolvedOptions.image ?? DEFAULT_DOCKER_IMAGE,
-        environment: await state.manifest.resolveEnvironment(),
+        environment: await resolveDockerRunStateEnvironment(state),
         snapshotSpec:
           (trustedConfig?.snapshot as LocalSandboxSnapshotSpec | undefined) ??
           resolvedOptions.snapshot ??
@@ -1296,6 +1296,21 @@ async function cleanupStartedDockerContainer(args: {
       () => undefined,
     );
   }
+}
+
+async function resolveDockerRunStateEnvironment(
+  state: DockerSandboxSessionState,
+): Promise<Record<string, string>> {
+  return Object.fromEntries(
+    await Promise.all(
+      Object.entries(state.manifest.environment).map(async ([key, value]) => [
+        key,
+        isEnvValueReference(value) && typeof state.environment[key] === 'string'
+          ? state.environment[key]
+          : await value.resolve(),
+      ]),
+    ),
+  );
 }
 
 function assertDockerManifestSupported(manifest: Manifest): void {

--- a/packages/agents-core/src/sandbox/sandboxes/shared/manifestPersistence.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/manifestPersistence.ts
@@ -1,6 +1,11 @@
 import { isMount, type Entry } from '../../entries';
 import { UserError } from '../../../errors';
-import { cloneManifest, Manifest, type EnvValue } from '../../manifest';
+import {
+  cloneManifest,
+  isEnvValueReference,
+  Manifest,
+  type EnvValue,
+} from '../../manifest';
 import type { SandboxSessionState } from '../../session';
 import {
   mergeNamedObjects,
@@ -178,13 +183,13 @@ export function sanitizeEnvironmentForPersistence(
 
 export function serializeEnvironmentForPersistence(
   state: ManifestPersistenceState,
-): SerializedManifestEnvironment {
+): Record<string, EnvValue> {
   const runtimeEnvironment = state.environment ?? {};
   const ephemeralKeys = new Set<string>();
-  const serialized: SerializedManifestEnvironment = {};
+  const serialized: Record<string, EnvValue> = {};
 
   for (const [key, value] of Object.entries(state.manifest.environment)) {
-    if (value.ephemeral) {
+    if (value.ephemeral || isEnvValueReference(value)) {
       ephemeralKeys.add(key);
       continue;
     }

--- a/packages/agents-core/src/sandbox/sandboxes/shared/sessionStateValues.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/sessionStateValues.ts
@@ -10,6 +10,7 @@ import {
 import type { LocalSandboxSnapshot, LocalSandboxSnapshotSpec } from '../types';
 import { rehydrateLocalSnapshotSpec } from './localSnapshots';
 import { deserializeHostPathGrantRedactionMetadata } from './manifestPersistence';
+import { rehydratePersistedEnvironmentForRuntime } from '../../shared/environment';
 
 export type LocalSandboxSessionStateValues = {
   manifest: Manifest;
@@ -24,15 +25,28 @@ export type LocalSandboxSessionStateValues = {
   exposedPorts?: Record<string, ExposedPortEndpoint>;
 };
 
-export function deserializeLocalSandboxSessionStateValues(
+export async function deserializeLocalSandboxSessionStateValues(
   state: Record<string, unknown>,
   configuredSnapshot: LocalSandboxSnapshotSpec | null | undefined,
-): LocalSandboxSessionStateValues {
+): Promise<LocalSandboxSessionStateValues> {
+  const manifest = new Manifest(state.manifest as Manifest);
+  const persistedEnvironment = readEnvironmentState(state.environment);
+  const runtimeEnvironment = Object.fromEntries(
+    Object.entries(persistedEnvironment).filter(
+      ([key]) => !(key in manifest.environment),
+    ),
+  );
   return {
-    manifest: new Manifest(state.manifest as Manifest),
+    manifest,
     workspaceRootPath: readString(state, 'workspaceRootPath'),
     workspaceRootOwned: Boolean(state.workspaceRootOwned),
-    environment: readEnvironmentState(state.environment),
+    environment: {
+      ...runtimeEnvironment,
+      ...(await rehydratePersistedEnvironmentForRuntime(
+        manifest,
+        persistedEnvironment,
+      )),
+    },
     snapshotSpec: rehydrateLocalSnapshotSpec(
       state.snapshotSpec,
       configuredSnapshot,

--- a/packages/agents-core/src/sandbox/session.ts
+++ b/packages/agents-core/src/sandbox/session.ts
@@ -6,7 +6,13 @@ import type { Entry } from './entries';
 import type { Manifest } from './manifest';
 import type { Snapshot } from './snapshot';
 
-export const SANDBOX_SESSION_STATE_VERSION = 1 as const;
+export const SANDBOX_SESSION_STATE_VERSION = 2 as const;
+export const SUPPORTED_SANDBOX_SESSION_STATE_VERSIONS = [
+  1,
+  SANDBOX_SESSION_STATE_VERSION,
+] as const;
+export type SandboxSessionStateVersion =
+  (typeof SUPPORTED_SANDBOX_SESSION_STATE_VERSIONS)[number];
 
 export type ExposedPortScheme = 'http' | 'ws';
 
@@ -21,7 +27,7 @@ export type ExposedPortEndpoint = {
 };
 
 export type SandboxSessionStateEnvelope = {
-  version: typeof SANDBOX_SESSION_STATE_VERSION;
+  version: SandboxSessionStateVersion;
   backendId: string;
   manifest: Record<string, unknown>;
   snapshot?: Snapshot | null;

--- a/packages/agents-core/src/sandbox/shared/environment.ts
+++ b/packages/agents-core/src/sandbox/shared/environment.ts
@@ -135,27 +135,22 @@ export async function rehydratePersistedEnvironmentForRuntime(
   environment: Record<string, string> | undefined,
   baseEnvironment: Record<string, string> = {},
 ): Promise<Record<string, string>> {
-  const manifestEnvironment = await manifest.resolveEnvironment();
-  const persistentManifestEnvironment = Object.fromEntries(
-    Object.entries(manifestEnvironment).filter(
-      ([key]) =>
-        !manifest.environment[key]?.ephemeral ||
-        isEnvValueReference(manifest.environment[key]),
-    ),
+  const runtimeEnvironment = deserializePersistedEnvironmentForRuntime(
+    manifest,
+    environment,
+    baseEnvironment,
   );
-  const persistedEnvironment = Object.fromEntries(
-    Object.entries(environment ?? {}).filter(
-      ([key]) =>
-        key in manifestEnvironment &&
-        !manifest.environment[key]?.ephemeral &&
-        !isEnvValueReference(manifest.environment[key]!),
+  const resolvedReferences = Object.fromEntries(
+    await Promise.all(
+      Object.entries(manifest.environment)
+        .filter(([, value]) => isEnvValueReference(value))
+        .map(async ([key, value]) => [key, await value.resolve()]),
     ),
   );
 
   return {
-    ...baseEnvironment,
-    ...persistentManifestEnvironment,
-    ...persistedEnvironment,
+    ...runtimeEnvironment,
+    ...resolvedReferences,
   };
 }
 

--- a/packages/agents-core/src/sandbox/shared/environment.ts
+++ b/packages/agents-core/src/sandbox/shared/environment.ts
@@ -140,18 +140,24 @@ export async function rehydratePersistedEnvironmentForRuntime(
     environment,
     baseEnvironment,
   );
-  const resolvedReferences = Object.fromEntries(
+  const resolvedReferences = await resolveEnvironmentReferences(manifest);
+
+  return {
+    ...runtimeEnvironment,
+    ...resolvedReferences,
+  };
+}
+
+export async function resolveEnvironmentReferences(
+  manifest: Manifest,
+): Promise<Record<string, string>> {
+  return Object.fromEntries(
     await Promise.all(
       Object.entries(manifest.environment)
         .filter(([, value]) => isEnvValueReference(value))
         .map(async ([key, value]) => [key, await value.resolve()]),
     ),
   );
-
-  return {
-    ...runtimeEnvironment,
-    ...resolvedReferences,
-  };
 }
 
 export function assertShellEnvironmentName(name: string): void {

--- a/packages/agents-core/src/sandbox/shared/environment.ts
+++ b/packages/agents-core/src/sandbox/shared/environment.ts
@@ -70,14 +70,20 @@ export function mergeStaticMaterializedEnvironment(
 
 export function serializeManifestEnvironment(
   manifest: Manifest,
+  options: { allowResolverPlaceholders?: boolean } = {},
 ): SerializedManifestEnvironment {
   return Object.fromEntries(
-    Object.entries(manifest.environment).map(([key, value]) => [
-      key,
-      isEnvValueReference(value)
-        ? serializeEnvValueReference(value)
-        : value.normalized(),
-    ]),
+    Object.entries(manifest.environment).map(([key, value]) => {
+      if (isEnvValueReference(value)) {
+        return [key, serializeEnvValueReference(value)];
+      }
+      if (value.resolver && !options.allowResolverPlaceholders) {
+        throw new TypeError(
+          `Environment variable "${key}" uses a resolver function and cannot be serialized. Use a static value or EnvValueReference for persisted manifests.`,
+        );
+      }
+      return [key, value.normalized()];
+    }),
   );
 }
 

--- a/packages/agents-core/src/sandbox/shared/environment.ts
+++ b/packages/agents-core/src/sandbox/shared/environment.ts
@@ -1,11 +1,17 @@
 import { UserError } from '../../errors';
-import type { Manifest } from '../manifest';
+import {
+  isEnvValueReference,
+  serializeEnvValueReference,
+  type Manifest,
+  type SerializedEnvValueReference,
+} from '../manifest';
 
 const SHELL_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 export type SerializedManifestEnvironment = Record<
   string,
-  { value: string; ephemeral?: boolean; description?: string }
+  | { value: string; ephemeral?: boolean; description?: string }
+  | SerializedEnvValueReference
 >;
 
 export async function materializeEnvironment(
@@ -68,7 +74,9 @@ export function serializeManifestEnvironment(
   return Object.fromEntries(
     Object.entries(manifest.environment).map(([key, value]) => [
       key,
-      value.normalized(),
+      isEnvValueReference(value)
+        ? serializeEnvValueReference(value)
+        : value.normalized(),
     ]),
   );
 }
@@ -82,6 +90,7 @@ export function serializeRuntimeEnvironmentForPersistence(
       .filter(
         ([key, value]) =>
           !value.ephemeral &&
+          !isEnvValueReference(value) &&
           key in environment &&
           typeof environment[key] === 'string',
       )
@@ -100,13 +109,46 @@ export function deserializePersistedEnvironmentForRuntime(
   const manifestEnvironment = materializeStaticEnvironment(manifest);
   const persistentManifestEnvironment = Object.fromEntries(
     Object.entries(manifestEnvironment).filter(
-      ([key]) => !manifest.environment[key]?.ephemeral,
+      ([key]) =>
+        !manifest.environment[key]?.ephemeral &&
+        !isEnvValueReference(manifest.environment[key]!),
     ),
   );
   const persistedEnvironment = Object.fromEntries(
     Object.entries(environment ?? {}).filter(
       ([key]) =>
-        key in manifestEnvironment && !manifest.environment[key]?.ephemeral,
+        key in manifestEnvironment &&
+        !manifest.environment[key]?.ephemeral &&
+        !isEnvValueReference(manifest.environment[key]!),
+    ),
+  );
+
+  return {
+    ...baseEnvironment,
+    ...persistentManifestEnvironment,
+    ...persistedEnvironment,
+  };
+}
+
+export async function rehydratePersistedEnvironmentForRuntime(
+  manifest: Manifest,
+  environment: Record<string, string> | undefined,
+  baseEnvironment: Record<string, string> = {},
+): Promise<Record<string, string>> {
+  const manifestEnvironment = await manifest.resolveEnvironment();
+  const persistentManifestEnvironment = Object.fromEntries(
+    Object.entries(manifestEnvironment).filter(
+      ([key]) =>
+        !manifest.environment[key]?.ephemeral ||
+        isEnvValueReference(manifest.environment[key]),
+    ),
+  );
+  const persistedEnvironment = Object.fromEntries(
+    Object.entries(environment ?? {}).filter(
+      ([key]) =>
+        key in manifestEnvironment &&
+        !manifest.environment[key]?.ephemeral &&
+        !isEnvValueReference(manifest.environment[key]!),
     ),
   );
 

--- a/packages/agents-core/src/sandbox/shared/environment.ts
+++ b/packages/agents-core/src/sandbox/shared/environment.ts
@@ -70,17 +70,11 @@ export function mergeStaticMaterializedEnvironment(
 
 export function serializeManifestEnvironment(
   manifest: Manifest,
-  options: { allowResolverPlaceholders?: boolean } = {},
 ): SerializedManifestEnvironment {
   return Object.fromEntries(
     Object.entries(manifest.environment).map(([key, value]) => {
       if (isEnvValueReference(value)) {
         return [key, serializeEnvValueReference(value)];
-      }
-      if (value.resolver && !options.allowResolverPlaceholders) {
-        throw new TypeError(
-          `Environment variable "${key}" uses a resolver function and cannot be serialized. Use a static value or EnvValueReference for persisted manifests.`,
-        );
       }
       return [key, value.normalized()];
     }),

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -193,7 +193,7 @@ describe('RunState', () => {
       expect(restored.history[1]).toMatchObject({ phase });
       expect(restored._generatedItems[0]?.rawItem).toMatchObject({ phase });
       expect(restored._modelResponses[0]?.output[0]).toMatchObject({ phase });
-      expect(restored.toJSON().$schemaVersion).toBe('1.14');
+      expect(restored.toJSON().$schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     },
   );
 
@@ -458,6 +458,52 @@ describe('RunState', () => {
 
     expect(restored._sandbox).toBeUndefined();
     expect(restored._currentAgent.name).toBe('LegacySandboxStateAgent');
+  });
+
+  it('keeps reading schema 1.14 payloads with sandbox session state version 1', async () => {
+    const agent = new Agent({ name: 'LegacySandboxEnvelopeAgent' });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    state._sandbox = {
+      backendId: 'unix-local',
+      currentAgentKey: 'LegacySandboxEnvelopeAgent',
+      currentAgentName: 'LegacySandboxEnvelopeAgent',
+      sessionState: sandboxSessionStateEnvelope(
+        { workspaceId: 'ws_legacy' },
+        { version: 1 },
+      ),
+      sessionsByAgent: {},
+    };
+    const serialized = state.toJSON();
+    serialized.$schemaVersion = '1.14';
+
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+
+    expect(restored._sandbox?.sessionState.version).toBe(1);
+  });
+
+  it('rejects sandbox session state version 2 under schema 1.14', async () => {
+    const agent = new Agent({ name: 'InvalidLegacySandboxEnvelopeAgent' });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    state._sandbox = {
+      backendId: 'unix-local',
+      currentAgentKey: 'InvalidLegacySandboxEnvelopeAgent',
+      currentAgentName: 'InvalidLegacySandboxEnvelopeAgent',
+      sessionState: sandboxSessionStateEnvelope({
+        workspaceId: 'ws_current',
+      }),
+      sessionsByAgent: {},
+    };
+    const serialized = state.toJSON();
+    serialized.$schemaVersion = '1.14';
+
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow(
+      `Run state schema version 1.14 does not support sandbox session state version ${SANDBOX_SESSION_STATE_VERSION}.`,
+    );
   });
 
   it('does not serialize runtime-only agent-tool metadata', async () => {
@@ -1065,7 +1111,7 @@ describe('RunState', () => {
     );
 
     const serialized = state.toJSON();
-    expect(serialized.$schemaVersion).toBe('1.14');
+    expect(serialized.$schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     const restored = await RunState.fromString(
       agent,
       JSON.stringify(serialized),

--- a/packages/agents-core/test/sandboxManifest.test.ts
+++ b/packages/agents-core/test/sandboxManifest.test.ts
@@ -4,10 +4,12 @@ import { describe, expect, expectTypeOf, it } from 'vitest';
 import {
   cloneManifest,
   Environment,
+  EnvValueReference,
   FileMode,
   Manifest,
   normalizeRelativePath,
   Permissions,
+  registerEnvValueReference,
   renderManifestDescription,
   SandboxGitSubpathError,
   type Dir,
@@ -27,6 +29,46 @@ import {
   type S3FilesMount,
   type S3Mount,
 } from '../src/sandbox';
+
+let currentReferencedSecret = 'initial-secret';
+
+class TestSecretReference extends EnvValueReference {
+  static readonly type = 'test.secret_reference';
+
+  constructor(
+    readonly key: string,
+    options: { description?: string; ephemeral?: boolean } = {},
+  ) {
+    super(options);
+  }
+
+  serialize(): Record<string, unknown> {
+    return {
+      type: 'ignored-by-sdk',
+      key: this.key,
+      ...(this.description ? { description: this.description } : {}),
+      ...(this.ephemeral ? { ephemeral: true } : {}),
+    };
+  }
+
+  async resolve(): Promise<string> {
+    return `${currentReferencedSecret}:${this.key}`;
+  }
+}
+
+function parseTestSecretReference(
+  payload: Readonly<Record<string, unknown>>,
+): TestSecretReference {
+  if (typeof payload.key !== 'string') {
+    throw new TypeError('Test secret reference key must be a string.');
+  }
+  return new TestSecretReference(payload.key, {
+    ...(typeof payload.description === 'string'
+      ? { description: payload.description }
+      : {}),
+    ...(payload.ephemeral === true ? { ephemeral: true } : {}),
+  });
+}
 
 describe('Manifest', () => {
   it('infers inline entry types from entry discriminators', () => {
@@ -210,6 +252,157 @@ describe('Manifest', () => {
     expect(manifest.environment.TOKEN.normalized()).toEqual({
       value: '',
     });
+  });
+
+  it('round-trips registered environment references without serializing resolved secrets', async () => {
+    const unregister = registerEnvValueReference(
+      TestSecretReference,
+      parseTestSecretReference,
+    );
+    currentReferencedSecret = 'workflow-secret';
+    try {
+      const manifest = new Manifest({
+        environment: {
+          TOKEN: new TestSecretReference('openai-key', {
+            description: 'Temporal secret reference',
+          }),
+        },
+      });
+
+      const serialized = JSON.stringify(manifest);
+      const payload = JSON.parse(serialized);
+
+      expect(serialized).not.toContain('workflow-secret');
+      expect(payload.environment.TOKEN).toEqual({
+        type: TestSecretReference.type,
+        key: 'openai-key',
+        description: 'Temporal secret reference',
+      });
+
+      currentReferencedSecret = 'replayed-secret';
+      const restored = new Manifest(payload);
+      expect(restored.environment.TOKEN).toBeInstanceOf(TestSecretReference);
+      await expect(restored.resolveEnvironment()).resolves.toEqual({
+        TOKEN: 'replayed-secret:openai-key',
+      });
+
+      const cloned = cloneManifest(restored);
+      expect(cloned.environment.TOKEN).toBeInstanceOf(TestSecretReference);
+      await expect(cloned.resolveEnvironment()).resolves.toEqual({
+        TOKEN: 'replayed-secret:openai-key',
+      });
+    } finally {
+      unregister();
+    }
+  });
+
+  it('rejects unknown, unregistered, duplicate, and inherited environment reference types', () => {
+    class UnregisteredReference extends EnvValueReference {
+      static readonly type = 'test.unregistered';
+
+      constructor() {
+        super();
+      }
+
+      serialize(): Record<string, unknown> {
+        return {};
+      }
+
+      async resolve(): Promise<string> {
+        return 'unused';
+      }
+    }
+
+    class InheritedReference extends TestSecretReference {}
+
+    class ReservedValueReference extends EnvValueReference {
+      static readonly type = 'test.reserved_value';
+
+      constructor() {
+        super();
+      }
+
+      serialize(): Record<string, unknown> {
+        return { value: 'must-not-be-serialized' };
+      }
+
+      async resolve(): Promise<string> {
+        return 'unused';
+      }
+    }
+
+    expect(
+      () =>
+        new Manifest({
+          environment: {
+            TOKEN: {
+              type: 'test.unknown',
+              key: 'openai-key',
+            },
+          },
+        }),
+    ).toThrow('Unknown environment value reference type "test.unknown"');
+    expect(() =>
+      JSON.stringify(
+        new Manifest({
+          environment: {
+            TOKEN: new UnregisteredReference(),
+          },
+        }),
+      ),
+    ).toThrow('must be registered with its own static type');
+    expect(() =>
+      registerEnvValueReference(
+        InheritedReference,
+        (payload) =>
+          new InheritedReference(String(payload.key ?? 'missing-key')),
+      ),
+    ).toThrow('must declare its own static type');
+
+    const unregister = registerEnvValueReference(
+      TestSecretReference,
+      parseTestSecretReference,
+    );
+    try {
+      expect(() =>
+        registerEnvValueReference(
+          TestSecretReference,
+          parseTestSecretReference,
+        ),
+      ).toThrow(
+        `Environment value reference type "${TestSecretReference.type}" is already registered`,
+      );
+    } finally {
+      unregister();
+    }
+
+    const unregisterReserved = registerEnvValueReference(
+      ReservedValueReference,
+      () => new ReservedValueReference(),
+    );
+    try {
+      expect(() => JSON.stringify(new ReservedValueReference())).toThrow(
+        'must not return the reserved "value" field',
+      );
+    } finally {
+      unregisterReserved();
+    }
+  });
+
+  it('preserves legacy environment values with additional type metadata', () => {
+    const entry = {
+      value: 'enabled',
+      type: 'application.metadata',
+    };
+    const manifest = new Manifest({
+      environment: {
+        FEATURE: entry,
+      },
+    });
+
+    expect(manifest.environment.FEATURE).toBeInstanceOf(Environment);
+    expect(manifest.environment.FEATURE).not.toBeInstanceOf(EnvValueReference);
+    expect(manifest.environment.FEATURE.value).toBe('enabled');
   });
 
   it('accepts string shorthand for users and group users', () => {

--- a/packages/agents-core/test/sandboxManifest.test.ts
+++ b/packages/agents-core/test/sandboxManifest.test.ts
@@ -269,6 +269,9 @@ describe('Manifest', () => {
         },
       });
 
+      expect(() => manifest.environment.TOKEN.normalized()).toThrow(
+        'EnvValueReference cannot be normalized to an EnvValue. Use serializeEnvValueReference() instead.',
+      );
       const serialized = JSON.stringify(manifest);
       const payload = JSON.parse(serialized);
 

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -5577,6 +5577,89 @@ describe('sandbox runner integration', () => {
     expect(client.closeCalls).toEqual([liveSession?.state.sessionId]);
   });
 
+  it('refreshes environment references before reusing a live remote session', async () => {
+    class LiveSecretReference extends EnvValueReference {
+      static readonly type = 'test.live_remote_secret_reference';
+
+      constructor(readonly key: string) {
+        super();
+      }
+
+      override serialize(): Record<string, unknown> {
+        return { key: this.key };
+      }
+
+      override async resolve(): Promise<string> {
+        resolveCount += 1;
+        return `credential-${resolveCount}:${this.key}`;
+      }
+    }
+
+    let resolveCount = 0;
+    const unregister = registerEnvValueReference(
+      LiveSecretReference,
+      (payload) => {
+        if (typeof payload.key !== 'string') {
+          throw new TypeError('Live secret reference key must be a string.');
+        }
+        return new LiveSecretReference(payload.key);
+      },
+    );
+    try {
+      const client = new FakeSandboxClient();
+      const manifest = new Manifest({
+        environment: {
+          TOKEN: new LiveSecretReference('openai-key'),
+        },
+      });
+      const sandboxAgent = new SandboxAgent({
+        name: 'SandboxWorker',
+        model: new RecordingFakeModel([]),
+      });
+      const state = new RunState<unknown, Agent<unknown, any>>(
+        new RunContext(),
+        'Hello',
+        sandboxAgent as Agent<unknown, any>,
+        1,
+      );
+      const firstManager = new SandboxRuntimeManager({
+        startingAgent: sandboxAgent as Agent<unknown, any>,
+        sandboxConfig: {
+          client,
+          manifest,
+        },
+        runState: state,
+      });
+      await firstManager.prepareAgent({
+        currentAgent: sandboxAgent as Agent<unknown, any>,
+        turnInput: [],
+      });
+      const liveSession = client.createdSessions[0]!;
+      liveSession.state.environment = await manifest.resolveEnvironment();
+      expect(resolveCount).toBe(1);
+      await firstManager.cleanup(state, { preserveOwnedSessions: true });
+
+      const secondManager = new SandboxRuntimeManager({
+        startingAgent: sandboxAgent as Agent<unknown, any>,
+        sandboxConfig: {
+          client,
+          manifest,
+        },
+        runState: state,
+      });
+      await secondManager.adoptPreservedOwnedSessions();
+
+      expect(resolveCount).toBe(2);
+      expect(liveSession.state.environment).toEqual({
+        TOKEN: 'credential-2:openai-key',
+      });
+      expect(client.resumeCalls).toHaveLength(0);
+      await secondManager.cleanup(state);
+    } finally {
+      unregister();
+    }
+  });
+
   it('refreshes trusted environment values before reusing a live Docker session', async () => {
     let resolvedSecret = 'initial-secret';
     const client = new DockerRevalidatingLiveProcessFakeSandboxClient();

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -1852,7 +1852,8 @@ describe('sandbox runner integration', () => {
       defaultManifest: new Manifest({
         environment: {
           SECRET_ENV: {
-            value: 'refreshed-secret',
+            value: '',
+            resolve: () => 'refreshed-secret',
             ephemeral: true,
           },
         },
@@ -5697,11 +5698,13 @@ describe('sandbox runner integration', () => {
   });
 
   it('refreshes trusted environment values before reusing a live Docker session', async () => {
+    let resolvedSecret = 'initial-secret';
     const client = new DockerRevalidatingLiveProcessFakeSandboxClient();
     const manifest = new Manifest({
       environment: {
         SECRET_ENV: {
-          value: 'initial-secret',
+          value: '',
+          resolve: () => resolvedSecret,
           ephemeral: true,
         },
       },
@@ -5745,10 +5748,12 @@ describe('sandbox runner integration', () => {
       PROVIDER_ENV: 'provider-value',
     };
     await firstManager.cleanup(state, { preserveOwnedSessions: true });
+    resolvedSecret = 'refreshed-secret';
     const refreshedManifest = new Manifest({
       environment: {
         SECRET_ENV: {
-          value: 'refreshed-secret',
+          value: '',
+          resolve: () => resolvedSecret,
           ephemeral: true,
         },
         ADDED_ENV: 'added-value',

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -52,11 +52,14 @@ import {
 import {
   Capability,
   Entry,
+  EnvValueReference,
   filesystem,
+  isEnvValueReference,
   Manifest,
   memory,
   type MemoryStore,
   SANDBOX_SESSION_STATE_VERSION,
+  registerEnvValueReference,
   shell,
   skills,
   SandboxAgent,
@@ -2241,7 +2244,7 @@ describe('sandbox runner integration', () => {
         },
       }),
     ).rejects.toThrow(
-      'Sandbox session state version 999 is not supported. Please use version 1.',
+      `Sandbox session state version 999 is not supported. Please use version ${SANDBOX_SESSION_STATE_VERSION}.`,
     );
     expect(client.createCalls).toHaveLength(0);
     expect(client.resumeCalls).toHaveLength(0);
@@ -2351,6 +2354,117 @@ describe('sandbox runner integration', () => {
         readOnly: true,
       },
     ]);
+  });
+
+  it('binds persisted environment references to the current trusted manifest before deserialization', async () => {
+    class TestSecretReference extends EnvValueReference {
+      static readonly type = 'test.runner_secret_ref';
+
+      constructor(
+        readonly key: string,
+        private readonly resolveKey: (key: string) => string,
+      ) {
+        super();
+      }
+
+      override serialize(): Record<string, unknown> {
+        return { key: this.key };
+      }
+
+      override async resolve(): Promise<string> {
+        return this.resolveKey(this.key);
+      }
+    }
+
+    const resolvedKeys: string[] = [];
+    const resolveKey = (key: string) => {
+      resolvedKeys.push(key);
+      return `secret:${key}`;
+    };
+    const unregister = registerEnvValueReference(
+      TestSecretReference,
+      (payload) => new TestSecretReference(String(payload.key), resolveKey),
+    );
+    try {
+      const client = new FakeSandboxClient();
+      client.deserializeSessionState = async (providerState) => {
+        const manifest = new Manifest(providerState.manifest as any);
+        return {
+          manifest,
+          environment: await manifest.resolveEnvironment(),
+          sessionId: String(providerState.sessionId),
+        };
+      };
+      const trustedManifest = new Manifest({
+        environment: {
+          TOKEN: new TestSecretReference('trusted-key', resolveKey),
+        },
+      });
+
+      const state = await deserializeSandboxSessionStateEntry(
+        client,
+        {
+          backendId: 'fake-sandbox',
+          currentAgentKey: 'SandboxWorker',
+          currentAgentName: 'SandboxWorker',
+          sessionState: fakeSandboxSessionStateEnvelope(
+            { sessionId: 'persisted' },
+            {
+              manifest: {
+                version: 1,
+                root: '/workspace',
+                entries: {},
+                environment: {
+                  TOKEN: {
+                    type: TestSecretReference.type,
+                    key: 'tampered-key',
+                  },
+                },
+              },
+            },
+          ),
+        },
+        trustedManifest,
+      );
+
+      expect(resolvedKeys).toEqual(['trusted-key']);
+      expect(state?.environment).toEqual({ TOKEN: 'secret:trusted-key' });
+      expect(isEnvValueReference(state!.manifest.environment.TOKEN)).toBe(true);
+    } finally {
+      unregister();
+    }
+  });
+
+  it('rejects persisted environment references without a current trusted manifest', async () => {
+    const client = new FakeSandboxClient();
+    const deserializeSessionState = vi.spyOn(client, 'deserializeSessionState');
+
+    await expect(
+      deserializeSandboxSessionStateEntry(client, {
+        backendId: 'fake-sandbox',
+        currentAgentKey: 'SandboxWorker',
+        currentAgentName: 'SandboxWorker',
+        sessionState: fakeSandboxSessionStateEnvelope(
+          { sessionId: 'persisted' },
+          {
+            manifest: {
+              version: 1,
+              root: '/workspace',
+              entries: {},
+              environment: {
+                TOKEN: {
+                  type: 'test.runner_secret_ref',
+                  key: 'persisted-key',
+                },
+              },
+            },
+          },
+        ),
+      }),
+    ).rejects.toThrow(
+      'RunState sandbox session state with environment value references requires a current trusted manifest for the sandbox agent.',
+    );
+    expect(deserializeSessionState).not.toHaveBeenCalled();
   });
 
   it('redacts Docker session identity without changing other provider state', async () => {

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -1852,8 +1852,7 @@ describe('sandbox runner integration', () => {
       defaultManifest: new Manifest({
         environment: {
           SECRET_ENV: {
-            value: '',
-            resolve: () => 'refreshed-secret',
+            value: 'refreshed-secret',
             ephemeral: true,
           },
         },
@@ -5698,13 +5697,11 @@ describe('sandbox runner integration', () => {
   });
 
   it('refreshes trusted environment values before reusing a live Docker session', async () => {
-    let resolvedSecret = 'initial-secret';
     const client = new DockerRevalidatingLiveProcessFakeSandboxClient();
     const manifest = new Manifest({
       environment: {
         SECRET_ENV: {
-          value: '',
-          resolve: () => resolvedSecret,
+          value: 'initial-secret',
           ephemeral: true,
         },
       },
@@ -5748,12 +5745,10 @@ describe('sandbox runner integration', () => {
       PROVIDER_ENV: 'provider-value',
     };
     await firstManager.cleanup(state, { preserveOwnedSessions: true });
-    resolvedSecret = 'refreshed-secret';
     const refreshedManifest = new Manifest({
       environment: {
         SECRET_ENV: {
-          value: '',
-          resolve: () => resolvedSecret,
+          value: 'refreshed-secret',
           ephemeral: true,
         },
         ADDED_ENV: 'added-value',

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -5578,6 +5578,7 @@ describe('sandbox runner integration', () => {
   });
 
   it('refreshes environment references before reusing a live remote session', async () => {
+    const resolveCounts = new Map<string, number>();
     class LiveSecretReference extends EnvValueReference {
       static readonly type = 'test.live_remote_secret_reference';
 
@@ -5590,12 +5591,12 @@ describe('sandbox runner integration', () => {
       }
 
       override async resolve(): Promise<string> {
-        resolveCount += 1;
-        return `credential-${resolveCount}:${this.key}`;
+        const count = (resolveCounts.get(this.key) ?? 0) + 1;
+        resolveCounts.set(this.key, count);
+        return `credential-${count}:${this.key}`;
       }
     }
 
-    let resolveCount = 0;
     const unregister = registerEnvValueReference(
       LiveSecretReference,
       (payload) => {
@@ -5609,7 +5610,15 @@ describe('sandbox runner integration', () => {
       const client = new FakeSandboxClient();
       const manifest = new Manifest({
         environment: {
-          TOKEN: new LiveSecretReference('openai-key'),
+          ROTATING_TOKEN: new LiveSecretReference('rotating'),
+          REMOVED_TOKEN: new LiveSecretReference('removed'),
+          REPLACED_TOKEN: new LiveSecretReference('replaced'),
+        },
+      });
+      const trustedManifest = new Manifest({
+        environment: {
+          ROTATING_TOKEN: new LiveSecretReference('rotating'),
+          REPLACED_TOKEN: 'configured-value',
         },
       });
       const sandboxAgent = new SandboxAgent({
@@ -5635,24 +5644,52 @@ describe('sandbox runner integration', () => {
         turnInput: [],
       });
       const liveSession = client.createdSessions[0]!;
-      liveSession.state.environment = await manifest.resolveEnvironment();
-      expect(resolveCount).toBe(1);
+      liveSession.state.environment = {
+        RUNTIME_ONLY: 'preserved',
+        ...(await manifest.resolveEnvironment()),
+      };
+      expect(resolveCounts).toEqual(
+        new Map([
+          ['rotating', 1],
+          ['removed', 1],
+          ['replaced', 1],
+        ]),
+      );
       await firstManager.cleanup(state, { preserveOwnedSessions: true });
 
       const secondManager = new SandboxRuntimeManager({
         startingAgent: sandboxAgent as Agent<unknown, any>,
         sandboxConfig: {
           client,
-          manifest,
+          manifest: trustedManifest,
         },
         runState: state,
       });
       await secondManager.adoptPreservedOwnedSessions();
 
-      expect(resolveCount).toBe(2);
+      expect(resolveCounts).toEqual(
+        new Map([
+          ['rotating', 2],
+          ['removed', 1],
+          ['replaced', 1],
+        ]),
+      );
       expect(liveSession.state.environment).toEqual({
-        TOKEN: 'credential-2:openai-key',
+        RUNTIME_ONLY: 'preserved',
+        ROTATING_TOKEN: 'credential-2:rotating',
+        REPLACED_TOKEN: 'configured-value',
       });
+      expect(
+        isEnvValueReference(
+          liveSession.state.manifest.environment.ROTATING_TOKEN,
+        ),
+      ).toBe(true);
+      expect(liveSession.state.manifest.environment.REPLACED_TOKEN.value).toBe(
+        'configured-value',
+      );
+      expect(liveSession.state.manifest.environment.REMOVED_TOKEN).toBe(
+        undefined,
+      );
       expect(client.resumeCalls).toHaveLength(0);
       await secondManager.cleanup(state);
     } finally {

--- a/packages/agents-core/test/sandboxShared.test.ts
+++ b/packages/agents-core/test/sandboxShared.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { Manifest, dir, file, mount } from '../src/sandbox';
+import {
+  EnvValueReference,
+  Manifest,
+  dir,
+  file,
+  mount,
+  registerEnvValueReference,
+} from '../src/sandbox';
 import {
   deserializeManifest,
   deserializePersistedEnvironmentForRuntime,
@@ -11,6 +18,7 @@ import {
   mergeManifestEntryDelta,
   mergeMaterializedEnvironment,
   mergeStaticMaterializedEnvironment,
+  rehydratePersistedEnvironmentForRuntime,
   serializeManifestEnvironment,
   serializeManifestRecord,
   serializeRuntimeEnvironmentForPersistence,
@@ -461,6 +469,74 @@ describe('sandbox shared helpers', () => {
       KEEP: 'persisted',
       TOKEN: 'persisted-token',
     });
+  });
+
+  it('persists environment references without their resolved runtime values', async () => {
+    let currentSecret = 'first-secret';
+    class SessionSecretReference extends EnvValueReference {
+      static readonly type = 'test.session_secret_reference';
+
+      constructor(readonly key: string) {
+        super();
+      }
+
+      serialize(): Record<string, unknown> {
+        return { key: this.key };
+      }
+
+      async resolve(): Promise<string> {
+        return `${currentSecret}:${this.key}`;
+      }
+    }
+    const unregister = registerEnvValueReference(
+      SessionSecretReference,
+      (payload) => {
+        if (typeof payload.key !== 'string') {
+          throw new TypeError('Session secret reference key must be a string.');
+        }
+        return new SessionSecretReference(payload.key);
+      },
+    );
+    try {
+      const manifest = new Manifest({
+        environment: {
+          TOKEN: new SessionSecretReference('openai-key'),
+          STATIC: 'enabled',
+        },
+      });
+
+      expect(serializeManifestRecord(manifest).environment).toEqual({
+        TOKEN: {
+          type: SessionSecretReference.type,
+          key: 'openai-key',
+        },
+        STATIC: { value: 'enabled' },
+      });
+      expect(
+        serializeRuntimeEnvironmentForPersistence(manifest, {
+          TOKEN: 'first-secret:openai-key',
+          STATIC: 'runtime-override',
+        }),
+      ).toEqual({
+        STATIC: 'enabled',
+      });
+
+      const restored = deserializeManifest(
+        JSON.parse(JSON.stringify(serializeManifestRecord(manifest))),
+      );
+      currentSecret = 'replayed-secret';
+      await expect(
+        rehydratePersistedEnvironmentForRuntime(restored, {
+          TOKEN: 'persisted-plaintext-must-not-win',
+          STATIC: 'enabled',
+        }),
+      ).resolves.toEqual({
+        TOKEN: 'replayed-secret:openai-key',
+        STATIC: 'enabled',
+      });
+    } finally {
+      unregister();
+    }
   });
 
   it('materializes static manifest environment without invoking resolvers', () => {

--- a/packages/agents-core/test/sandboxShared.test.ts
+++ b/packages/agents-core/test/sandboxShared.test.ts
@@ -424,19 +424,9 @@ describe('sandbox shared helpers', () => {
       },
     });
 
-    expect(serializeManifestEnvironment(manifest)).toEqual({
-      KEEP: {
-        value: 'manifest',
-        description: 'stored',
-      },
-      TOKEN: {
-        value: 'placeholder',
-      },
-      SECRET: {
-        value: 'secret',
-        ephemeral: true,
-      },
-    });
+    expect(() => serializeManifestEnvironment(manifest)).toThrow(
+      'Environment variable "TOKEN" uses a resolver function and cannot be serialized. Use a static value or EnvValueReference for persisted manifests.',
+    );
     await expect(materializeEnvironment(manifest)).resolves.toMatchObject({
       TOKEN: 'resolved-token',
     });

--- a/packages/agents-core/test/sandboxShared.test.ts
+++ b/packages/agents-core/test/sandboxShared.test.ts
@@ -424,9 +424,19 @@ describe('sandbox shared helpers', () => {
       },
     });
 
-    expect(() => serializeManifestEnvironment(manifest)).toThrow(
-      'Environment variable "TOKEN" uses a resolver function and cannot be serialized. Use a static value or EnvValueReference for persisted manifests.',
-    );
+    expect(serializeManifestEnvironment(manifest)).toEqual({
+      KEEP: {
+        value: 'manifest',
+        description: 'stored',
+      },
+      TOKEN: {
+        value: 'placeholder',
+      },
+      SECRET: {
+        value: 'secret',
+        ephemeral: true,
+      },
+    });
     await expect(materializeEnvironment(manifest)).resolves.toMatchObject({
       TOKEN: 'resolved-token',
     });

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -4081,8 +4081,7 @@ describe('DockerSandboxClient unit behavior', () => {
       new Manifest({
         environment: {
           SECRET_ENV: {
-            value: '',
-            resolve: () => resolvedSecret,
+            value: 'initial-secret',
             ephemeral: true,
           },
         },
@@ -4114,6 +4113,15 @@ describe('DockerSandboxClient unit behavior', () => {
       'utf8',
     );
     resolvedSecret = 'refreshed-secret';
+    const trustedManifest = new Manifest({
+      environment: {
+        SECRET_ENV: {
+          value: '',
+          resolve: () => resolvedSecret,
+          ephemeral: true,
+        },
+      },
+    });
 
     const persistedState = (await deserializeSandboxSessionStateEntry(
       client,
@@ -4127,7 +4135,7 @@ describe('DockerSandboxClient unit behavior', () => {
           serialized,
         ),
       },
-      session.state.manifest,
+      trustedManifest,
       {
         clientOptions: {
           image: 'run:image',
@@ -4247,16 +4255,22 @@ describe('DockerSandboxClient unit behavior', () => {
         new Manifest({
           environment: {
             TOKEN: new DockerSecretReference('openai-key'),
-            ROTATING_TOKEN: async () => {
-              ordinaryResolveCount += 1;
-              return `rotating-credential-${ordinaryResolveCount}`;
-            },
+            ROTATING_TOKEN: 'persisted-placeholder',
           },
         }),
       );
       const serialized = await client.serializeSessionState(session.state);
       resolveCount = 0;
       ordinaryResolveCount = 0;
+      const trustedManifest = new Manifest({
+        environment: {
+          TOKEN: new DockerSecretReference('openai-key'),
+          ROTATING_TOKEN: async () => {
+            ordinaryResolveCount += 1;
+            return `rotating-credential-${ordinaryResolveCount}`;
+          },
+        },
+      });
 
       const persistedState = (await deserializeSandboxSessionStateEntry(
         client,
@@ -4270,7 +4284,7 @@ describe('DockerSandboxClient unit behavior', () => {
             serialized,
           ),
         },
-        session.state.manifest,
+        trustedManifest,
       )) as DockerSandboxSessionState;
       expect(resolveCount).toBe(1);
       expect(ordinaryResolveCount).toBe(0);

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -4081,7 +4081,8 @@ describe('DockerSandboxClient unit behavior', () => {
       new Manifest({
         environment: {
           SECRET_ENV: {
-            value: 'initial-secret',
+            value: '',
+            resolve: () => resolvedSecret,
             ephemeral: true,
           },
         },
@@ -4113,15 +4114,6 @@ describe('DockerSandboxClient unit behavior', () => {
       'utf8',
     );
     resolvedSecret = 'refreshed-secret';
-    const trustedManifest = new Manifest({
-      environment: {
-        SECRET_ENV: {
-          value: '',
-          resolve: () => resolvedSecret,
-          ephemeral: true,
-        },
-      },
-    });
 
     const persistedState = (await deserializeSandboxSessionStateEntry(
       client,
@@ -4135,7 +4127,7 @@ describe('DockerSandboxClient unit behavior', () => {
           serialized,
         ),
       },
-      trustedManifest,
+      session.state.manifest,
       {
         clientOptions: {
           image: 'run:image',
@@ -4255,22 +4247,16 @@ describe('DockerSandboxClient unit behavior', () => {
         new Manifest({
           environment: {
             TOKEN: new DockerSecretReference('openai-key'),
-            ROTATING_TOKEN: 'persisted-placeholder',
+            ROTATING_TOKEN: async () => {
+              ordinaryResolveCount += 1;
+              return `rotating-credential-${ordinaryResolveCount}`;
+            },
           },
         }),
       );
       const serialized = await client.serializeSessionState(session.state);
       resolveCount = 0;
       ordinaryResolveCount = 0;
-      const trustedManifest = new Manifest({
-        environment: {
-          TOKEN: new DockerSecretReference('openai-key'),
-          ROTATING_TOKEN: async () => {
-            ordinaryResolveCount += 1;
-            return `rotating-credential-${ordinaryResolveCount}`;
-          },
-        },
-      });
 
       const persistedState = (await deserializeSandboxSessionStateEntry(
         client,
@@ -4284,7 +4270,7 @@ describe('DockerSandboxClient unit behavior', () => {
             serialized,
           ),
         },
-        trustedManifest,
+        session.state.manifest,
       )) as DockerSandboxSessionState;
       expect(resolveCount).toBe(1);
       expect(ordinaryResolveCount).toBe(0);

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -4190,7 +4190,7 @@ describe('DockerSandboxClient unit behavior', () => {
     await session.close();
   });
 
-  it('resolves environment references once while restoring Docker RunState', async () => {
+  it('resolves environment values once while restoring Docker RunState', async () => {
     class DockerSecretReference extends EnvValueReference {
       static readonly type = 'test.docker_run_state_secret_reference';
 
@@ -4210,6 +4210,7 @@ describe('DockerSandboxClient unit behavior', () => {
 
     let runCount = 0;
     let resolveCount = 0;
+    let ordinaryResolveCount = 0;
     processMocks.runSandboxProcess.mockImplementation(
       async (_command: string, args: string[]) => {
         if (args[0] === 'version') {
@@ -4246,11 +4247,16 @@ describe('DockerSandboxClient unit behavior', () => {
         new Manifest({
           environment: {
             TOKEN: new DockerSecretReference('openai-key'),
+            ROTATING_TOKEN: async () => {
+              ordinaryResolveCount += 1;
+              return `rotating-credential-${ordinaryResolveCount}`;
+            },
           },
         }),
       );
       const serialized = await client.serializeSessionState(session.state);
       resolveCount = 0;
+      ordinaryResolveCount = 0;
 
       const persistedState = (await deserializeSandboxSessionStateEntry(
         client,
@@ -4267,12 +4273,15 @@ describe('DockerSandboxClient unit behavior', () => {
         session.state.manifest,
       )) as DockerSandboxSessionState;
       expect(resolveCount).toBe(1);
+      expect(ordinaryResolveCount).toBe(0);
 
       const restored = await client.resume(persistedState);
 
       expect(resolveCount).toBe(1);
+      expect(ordinaryResolveCount).toBe(1);
       expect(restored.state.environment).toEqual({
         TOKEN: 'credential-1:openai-key',
+        ROTATING_TOKEN: 'rotating-credential-1',
       });
       await restored.close();
       await session.close();

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -52,9 +52,11 @@ import {
   dockerVolumeMountStrategy,
   DockerSandboxClient,
   type DockerSandboxSessionState,
+  EnvValueReference,
   inContainerMountStrategy,
   Manifest,
   NoopSnapshotSpec,
+  registerEnvValueReference,
   skills,
 } from '../../src/sandbox/local';
 
@@ -4186,6 +4188,97 @@ describe('DockerSandboxClient unit behavior', () => {
 
     await restored.close();
     await session.close();
+  });
+
+  it('resolves environment references once while restoring Docker RunState', async () => {
+    class DockerSecretReference extends EnvValueReference {
+      static readonly type = 'test.docker_run_state_secret_reference';
+
+      constructor(readonly key: string) {
+        super({ ephemeral: true });
+      }
+
+      override serialize(): Record<string, unknown> {
+        return { key: this.key };
+      }
+
+      override async resolve(): Promise<string> {
+        resolveCount += 1;
+        return `credential-${resolveCount}:${this.key}`;
+      }
+    }
+
+    let runCount = 0;
+    let resolveCount = 0;
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          return success(`container-${runCount}\n`);
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const unregister = registerEnvValueReference(
+      DockerSecretReference,
+      (payload) => {
+        if (typeof payload.key !== 'string') {
+          throw new TypeError('Docker secret reference key must be a string.');
+        }
+        return new DockerSecretReference(payload.key);
+      },
+    );
+    try {
+      const client = new DockerSandboxClient({
+        workspaceBaseDir: rootDir,
+        snapshot: {
+          type: 'local',
+          baseDir: rootDir,
+        },
+      });
+      const session = await client.create(
+        new Manifest({
+          environment: {
+            TOKEN: new DockerSecretReference('openai-key'),
+          },
+        }),
+      );
+      const serialized = await client.serializeSessionState(session.state);
+      resolveCount = 0;
+
+      const persistedState = (await deserializeSandboxSessionStateEntry(
+        client,
+        {
+          backendId: client.backendId,
+          currentAgentKey: 'SandboxWorker',
+          currentAgentName: 'SandboxWorker',
+          sessionState: toSessionStateEnvelope(
+            client.backendId,
+            session.state,
+            serialized,
+          ),
+        },
+        session.state.manifest,
+      )) as DockerSandboxSessionState;
+      expect(resolveCount).toBe(1);
+
+      const restored = await client.resume(persistedState);
+
+      expect(resolveCount).toBe(1);
+      expect(restored.state.environment).toEqual({
+        TOKEN: 'credential-1:openai-key',
+      });
+      await restored.close();
+      await session.close();
+    } finally {
+      unregister();
+    }
   });
 
   it('restores untrusted stopped RunState into new Docker resources', async () => {

--- a/packages/agents-core/test/sandboxes/unixLocal.test.ts
+++ b/packages/agents-core/test/sandboxes/unixLocal.test.ts
@@ -269,10 +269,12 @@ describe('UnixLocalSandboxClient', () => {
       login: false,
       yieldTimeMs: 1_000,
     });
-    const serialized = await client.serializeSessionState(session.state);
 
     expect(output).toContain('runtime-value');
-    expect(serialized.environment).not.toHaveProperty('RESOLVED_ENV');
+    await expect(client.serializeSessionState(session.state)).rejects.toThrow(
+      'Environment variable "RESOLVED_ENV" uses a resolver function and cannot be serialized. Use a static value or EnvValueReference for persisted manifests.',
+    );
+    await session.close();
   });
 
   it('rejects symbolic links inside local_dir entries', async () => {

--- a/packages/agents-core/test/sandboxes/unixLocal.test.ts
+++ b/packages/agents-core/test/sandboxes/unixLocal.test.ts
@@ -270,11 +270,10 @@ describe('UnixLocalSandboxClient', () => {
       yieldTimeMs: 1_000,
     });
 
+    const serialized = await client.serializeSessionState(session.state);
+
     expect(output).toContain('runtime-value');
-    await expect(client.serializeSessionState(session.state)).rejects.toThrow(
-      'Environment variable "RESOLVED_ENV" uses a resolver function and cannot be serialized. Use a static value or EnvValueReference for persisted manifests.',
-    );
-    await session.close();
+    expect(serialized.environment).not.toHaveProperty('RESOLVED_ENV');
   });
 
   it('rejects symbolic links inside local_dir entries', async () => {

--- a/packages/agents-core/test/sandboxes/unixLocal.test.ts
+++ b/packages/agents-core/test/sandboxes/unixLocal.test.ts
@@ -13,9 +13,11 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  EnvValueReference,
   Manifest,
   InMemoryRemoteSnapshotStore,
   NoopSnapshotSpec,
+  registerEnvValueReference,
   skills,
   UnixLocalSandboxClient,
   urlForExposedPort,
@@ -1466,6 +1468,85 @@ describe('UnixLocalSandboxClient', () => {
     await expect(stat(join(snapshot.path, 'keep.txt'))).resolves.toBeTruthy();
     await expect(stat(join(snapshot.path, 'tmp.txt'))).rejects.toThrow();
     await expect(stat(join(snapshot.path, 'dir/nested.tmp'))).rejects.toThrow();
+  });
+
+  it('re-resolves registered environment references without persisting secrets', async () => {
+    let currentSecret = 'activity-secret';
+    class LocalSecretReference extends EnvValueReference {
+      static readonly type = 'test.local_secret_reference';
+
+      constructor(readonly key: string) {
+        super();
+      }
+
+      serialize(): Record<string, unknown> {
+        return { key: this.key };
+      }
+
+      async resolve(): Promise<string> {
+        return `${currentSecret}:${this.key}`;
+      }
+    }
+    const unregister = registerEnvValueReference(
+      LocalSecretReference,
+      (payload) => {
+        if (typeof payload.key !== 'string') {
+          throw new TypeError('Local secret reference key must be a string.');
+        }
+        return new LocalSecretReference(payload.key);
+      },
+    );
+    try {
+      const client = new UnixLocalSandboxClient({
+        workspaceBaseDir: rootDir,
+        snapshot: {
+          type: 'local',
+          baseDir: rootDir,
+        },
+      });
+      const session = await client.create(
+        new Manifest({
+          environment: {
+            TOKEN: new LocalSecretReference('openai-key'),
+          },
+        }),
+      );
+
+      const serialized = await client.serializeSessionState(session.state);
+      const serializedJson = JSON.stringify(serialized);
+      expect(serializedJson).not.toContain('activity-secret');
+      expect(serialized.manifest).toMatchObject({
+        environment: {
+          TOKEN: {
+            type: LocalSecretReference.type,
+            key: 'openai-key',
+          },
+        },
+      });
+      expect(serialized.environment).toEqual({});
+
+      currentSecret = 'worker-secret';
+      const restoredState = await client.deserializeSessionState(
+        JSON.parse(serializedJson),
+      );
+      expect(restoredState.manifest.environment.TOKEN).toBeInstanceOf(
+        LocalSecretReference,
+      );
+      expect(restoredState.environment).toEqual({
+        TOKEN: 'worker-secret:openai-key',
+      });
+
+      const restored = await client.resume(restoredState);
+      const output = await restored.execCommand({
+        cmd: 'printf "%s\\n" "$TOKEN"',
+        shell: '/bin/sh',
+        login: false,
+        yieldTimeMs: 500,
+      });
+      expect(output).toContain('worker-secret:openai-key');
+    } finally {
+      unregister();
+    }
   });
 
   it('excludes an ephemeral root entry from local snapshots', async () => {

--- a/packages/agents-extensions/src/sandbox/blaxel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/blaxel/sandbox.ts
@@ -35,6 +35,7 @@ import {
   rehydrateRemoteSandboxSessionStateValues,
   formatPtyExecUpdate,
   materializeEnvironment,
+  manifestWithMaterializedEnvironmentReferences,
   openPtyWebSocket,
   parseExposedPortEndpoint,
   posixDirname,
@@ -1025,8 +1026,12 @@ export class BlaxelSandboxClient implements SandboxClient<
   private async recreateFromState(
     state: BlaxelSandboxSessionState,
   ): Promise<BlaxelSandboxSession> {
+    const manifest = state.manifest;
     const session = await this.create(
-      state.manifest,
+      manifestWithMaterializedEnvironmentReferences(
+        manifest,
+        state.environment,
+      ),
       {
         image: state.image,
         memory: state.memory,
@@ -1048,6 +1053,7 @@ export class BlaxelSandboxClient implements SandboxClient<
         allowExistingNamedSandbox: !state.ownsSandbox,
       },
     );
+    session.state.manifest = manifest;
     return session;
   }
 }

--- a/packages/agents-extensions/src/sandbox/blaxel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/blaxel/sandbox.ts
@@ -32,7 +32,7 @@ import {
   assertRunAsUnsupported,
   closeRemoteSessionOnManifestError,
   assertShellEnvironmentName,
-  deserializeRemoteSandboxSessionStateValues,
+  rehydrateRemoteSandboxSessionStateValues,
   formatPtyExecUpdate,
   materializeEnvironment,
   openPtyWebSocket,
@@ -948,7 +948,7 @@ export class BlaxelSandboxClient implements SandboxClient<
   async deserializeSessionState(
     state: Record<string, unknown>,
   ): Promise<BlaxelSandboxSessionState> {
-    const baseState = deserializeRemoteSandboxSessionStateValues(
+    const baseState = await rehydrateRemoteSandboxSessionStateValues(
       state,
       this.options.env,
     );

--- a/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
@@ -90,7 +90,7 @@ import {
 } from '../shared/runAs';
 import {
   assertRemoteSandboxSessionStateCanResume,
-  deserializeRemoteSandboxSessionStateValues,
+  rehydrateRemoteSandboxSessionStateValues,
   serializeRemoteSandboxSessionState,
 } from '../shared/sessionState';
 import {
@@ -1184,7 +1184,7 @@ export class CloudflareSandboxClient implements SandboxClient<
   async deserializeSessionState(
     state: Record<string, unknown>,
   ): Promise<CloudflareSandboxSessionState> {
-    const baseState = deserializeRemoteSandboxSessionStateValues(state);
+    const baseState = await rehydrateRemoteSandboxSessionStateValues(state);
     return {
       ...state,
       ...baseState,

--- a/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
@@ -37,7 +37,7 @@ import {
   closeRemoteSessionOnManifestError,
   cloneManifestWithRoot,
   createRunAsRemoteEditor,
-  deserializeRemoteSandboxSessionStateValues,
+  rehydrateRemoteSandboxSessionStateValues,
   elapsedSeconds,
   formatExecResponse,
   formatPtyExecUpdate,
@@ -1155,7 +1155,7 @@ export class DaytonaSandboxClient implements SandboxClient<
   async deserializeSessionState(
     state: Record<string, unknown>,
   ): Promise<DaytonaSandboxSessionState> {
-    const baseState = deserializeRemoteSandboxSessionStateValues(
+    const baseState = await rehydrateRemoteSandboxSessionStateValues(
       state,
       this.options.env,
     );

--- a/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
@@ -26,7 +26,7 @@ import {
   assertResumeRecreateAllowed,
   assertTarWorkspacePersistence,
   createPtyProcessEntry,
-  deserializeRemoteSandboxSessionStateValues,
+  rehydrateRemoteSandboxSessionStateValues,
   formatPtyExecUpdate,
   assertSandboxManifestMetadataSupported,
   SANDBOX_MANIFEST_METADATA_SUPPORT,
@@ -934,7 +934,7 @@ export class E2BSandboxClient implements SandboxClient<
   async deserializeSessionState(
     state: Record<string, unknown>,
   ): Promise<E2BSandboxSessionState> {
-    const baseState = deserializeRemoteSandboxSessionStateValues(
+    const baseState = await rehydrateRemoteSandboxSessionStateValues(
       state,
       this.options.env,
     );

--- a/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
@@ -34,6 +34,7 @@ import {
   decodeNativeSnapshotRef,
   encodeNativeSnapshotRef,
   materializeEnvironment,
+  manifestWithMaterializedEnvironmentReferences,
   parseExposedPortEndpoint,
   providerErrorMessage,
   shellQuote,
@@ -1001,10 +1002,19 @@ export class E2BSandboxClient implements SandboxClient<
       }
     }
 
-    return await this.create(state.manifest, {
-      ...stateToCreateOptions(state),
-      env: state.environment,
-    });
+    const manifest = state.manifest;
+    const session = await this.create(
+      manifestWithMaterializedEnvironmentReferences(
+        manifest,
+        state.environment,
+      ),
+      {
+        ...stateToCreateOptions(state),
+        env: state.environment,
+      },
+    );
+    session.state.manifest = manifest;
+    return session;
   }
 }
 

--- a/packages/agents-extensions/src/sandbox/modal/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/modal/sandbox.ts
@@ -43,7 +43,7 @@ import {
   closeRemoteSessionOnManifestError,
   createRunAsRemoteEditor,
   decodeNativeSnapshotRef,
-  deserializeRemoteSandboxSessionStateValues,
+  rehydrateRemoteSandboxSessionStateValues,
   elapsedSeconds,
   encodeNativeSnapshotRef,
   formatExecResponse,
@@ -1455,7 +1455,7 @@ export class ModalSandboxClient implements SandboxClient<
   async deserializeSessionState(
     state: Record<string, unknown>,
   ): Promise<ModalSandboxSessionState> {
-    const baseState = deserializeRemoteSandboxSessionStateValues(
+    const baseState = await rehydrateRemoteSandboxSessionStateValues(
       state,
       this.options.env,
     );

--- a/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
@@ -29,7 +29,7 @@ import {
   cloneManifestWithRoot,
   decodeNativeSnapshotRef,
   assertShellEnvironmentName,
-  deserializeRemoteSandboxSessionStateValues,
+  rehydrateRemoteSandboxSessionStateValues,
   encodeNativeSnapshotRef,
   materializeEnvironment,
   providerErrorMessage,
@@ -1480,7 +1480,7 @@ export class RunloopSandboxClient implements SandboxClient<
   async deserializeSessionState(
     state: Record<string, unknown>,
   ): Promise<RunloopSandboxSessionState> {
-    const baseState = deserializeRemoteSandboxSessionStateValues(
+    const baseState = await rehydrateRemoteSandboxSessionStateValues(
       state,
       this.options.env,
     );

--- a/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
@@ -32,6 +32,7 @@ import {
   rehydrateRemoteSandboxSessionStateValues,
   encodeNativeSnapshotRef,
   materializeEnvironment,
+  manifestWithMaterializedEnvironmentReferences,
   providerErrorMessage,
   serializeRemoteSandboxSessionState,
   shellQuote,
@@ -1583,7 +1584,16 @@ export class RunloopSandboxClient implements SandboxClient<
         createTimeoutMs: resumeState.createTimeoutMs,
         timeouts: resumeState.timeouts,
       };
-      return await this.create(resumeState.manifest, recreateOptions);
+      const manifest = resumeState.manifest;
+      const session = await this.create(
+        manifestWithMaterializedEnvironmentReferences(
+          manifest,
+          resumeState.environment,
+        ),
+        recreateOptions,
+      );
+      session.state.manifest = manifest;
+      return session;
     }
   }
 }

--- a/packages/agents-extensions/src/sandbox/shared/environment.ts
+++ b/packages/agents-extensions/src/sandbox/shared/environment.ts
@@ -5,6 +5,7 @@ export {
   materializeStaticEnvironment,
   mergeMaterializedEnvironment,
   mergeStaticMaterializedEnvironment,
+  rehydratePersistedEnvironmentForRuntime,
   serializeManifestEnvironment,
   serializeRuntimeEnvironmentForPersistence,
 } from '@openai/agents-core/sandbox/internal';

--- a/packages/agents-extensions/src/sandbox/shared/index.ts
+++ b/packages/agents-extensions/src/sandbox/shared/index.ts
@@ -25,6 +25,7 @@ export {
   entryContainsLocalSource,
   materializeInlineManifestEntry,
   materializeInlineManifest,
+  manifestWithMaterializedEnvironmentReferences,
   manifestContainsLocalSource,
   mergeManifestDelta,
   mergeManifestEntryDelta,

--- a/packages/agents-extensions/src/sandbox/shared/index.ts
+++ b/packages/agents-extensions/src/sandbox/shared/index.ts
@@ -107,6 +107,7 @@ export {
 export {
   assertRemoteSandboxSessionStateCanResume,
   deserializeRemoteSandboxSessionStateValues,
+  rehydrateRemoteSandboxSessionStateValues,
   serializeRemoteSandboxSessionState,
 } from './sessionState';
 export {

--- a/packages/agents-extensions/src/sandbox/shared/manifest.ts
+++ b/packages/agents-extensions/src/sandbox/shared/manifest.ts
@@ -59,8 +59,9 @@ export function manifestWithMaterializedEnvironmentReferences(
   for (const [key, value] of Object.entries(manifest.environment)) {
     if (isEnvValueReference(value) && typeof environment[key] === 'string') {
       materializedManifest.environment[key] = new Environment({
-        ...value.normalized(),
         value: environment[key],
+        ...(value.ephemeral ? { ephemeral: true } : {}),
+        ...(value.description ? { description: value.description } : {}),
       });
     }
   }

--- a/packages/agents-extensions/src/sandbox/shared/manifest.ts
+++ b/packages/agents-extensions/src/sandbox/shared/manifest.ts
@@ -1,5 +1,7 @@
 import { UserError } from '@openai/agents-core';
 import {
+  Environment,
+  isEnvValueReference,
   isMount,
   Manifest,
   normalizeRelativePath,
@@ -47,6 +49,22 @@ export function cloneManifestWithoutMountEntries(manifest: Manifest): Manifest {
   return cloneManifestWithOverrides(manifest, {
     entries: removeMountEntries(manifest.entries),
   });
+}
+
+export function manifestWithMaterializedEnvironmentReferences(
+  manifest: Manifest,
+  environment: Record<string, string>,
+): Manifest {
+  const materializedManifest = cloneManifestWithOverrides(manifest);
+  for (const [key, value] of Object.entries(manifest.environment)) {
+    if (isEnvValueReference(value) && typeof environment[key] === 'string') {
+      materializedManifest.environment[key] = new Environment({
+        ...value.normalized(),
+        value: environment[key],
+      });
+    }
+  }
+  return materializedManifest;
 }
 
 export function manifestContainsLocalSource(manifest: Manifest): boolean {

--- a/packages/agents-extensions/src/sandbox/shared/sessionState.ts
+++ b/packages/agents-extensions/src/sandbox/shared/sessionState.ts
@@ -9,6 +9,7 @@ import {
 } from '@openai/agents-core/sandbox/internal';
 import {
   deserializePersistedEnvironmentForRuntime,
+  rehydratePersistedEnvironmentForRuntime,
   serializeRuntimeEnvironmentForPersistence,
 } from './environment';
 import { deserializeManifest, serializeManifestRecord } from './manifest';
@@ -41,6 +42,24 @@ export function deserializeRemoteSandboxSessionStateValues(
   return {
     manifest,
     environment: deserializeRemotePersistedEnvironmentForRuntime(
+      manifest,
+      state.environment as Record<string, string> | undefined,
+      configuredEnvironment,
+    ),
+    ...deserializeHostPathGrantRedactionMetadata(state),
+  };
+}
+
+export async function rehydrateRemoteSandboxSessionStateValues(
+  state: Record<string, unknown>,
+  configuredEnvironment?: Record<string, string>,
+): Promise<RemoteSandboxSessionStateValues> {
+  const manifest = deserializeManifest(
+    state.manifest as Record<string, unknown> | undefined,
+  );
+  return {
+    manifest,
+    environment: await rehydrateRemotePersistedEnvironmentForRuntime(
       manifest,
       state.environment as Record<string, string> | undefined,
       configuredEnvironment,
@@ -91,5 +110,27 @@ function deserializeRemotePersistedEnvironmentForRuntime(
       environment,
       configuredEnvironment,
     ),
+  };
+}
+
+async function rehydrateRemotePersistedEnvironmentForRuntime(
+  manifest: Manifest,
+  environment: Record<string, string> | undefined,
+  configuredEnvironment: Record<string, string> = {},
+): Promise<Record<string, string>> {
+  const runtimeEnvironment = Object.fromEntries(
+    Object.entries(environment ?? {}).filter(
+      ([key, value]) =>
+        !(key in manifest.environment) && typeof value === 'string',
+    ),
+  );
+
+  return {
+    ...runtimeEnvironment,
+    ...(await rehydratePersistedEnvironmentForRuntime(
+      manifest,
+      environment,
+      configuredEnvironment,
+    )),
   };
 }

--- a/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
@@ -29,7 +29,7 @@ import {
   assertRunAsUnsupported,
   cloneManifestWithoutMountEntries,
   cloneManifestWithRoot,
-  deserializeRemoteSandboxSessionStateValues,
+  rehydrateRemoteSandboxSessionStateValues,
   decodeNativeSnapshotRef,
   encodeNativeSnapshotRef,
   hydrateRemoteWorkspaceTar,
@@ -1476,7 +1476,7 @@ export class VercelSandboxClient implements SandboxClient<
   async deserializeSessionState(
     state: Record<string, unknown>,
   ): Promise<VercelSandboxSessionState> {
-    const baseState = deserializeRemoteSandboxSessionStateValues(
+    const baseState = await rehydrateRemoteSandboxSessionStateValues(
       state,
       this.options.env,
     );

--- a/packages/agents-extensions/test/sandbox/e2b.test.ts
+++ b/packages/agents-extensions/test/sandbox/e2b.test.ts
@@ -1,5 +1,7 @@
 import {
+  EnvValueReference,
   Manifest,
+  registerEnvValueReference,
   SandboxProviderError,
   SandboxUnsupportedFeatureError,
 } from '@openai/agents-core/sandbox';
@@ -733,6 +735,72 @@ describe('E2BSandboxClient', () => {
     expect(connectMock).toHaveBeenCalledWith('sbx_test', undefined);
     expect(createMock).toHaveBeenCalledWith('base', {});
     expect(recreated.state.sandboxId).toBe('sbx_test');
+  });
+
+  test('reuses refreshed environment references when recreating a missing sandbox', async () => {
+    let resolveCount = 0;
+    class E2BSecretReference extends EnvValueReference {
+      static readonly type = 'test.e2b_secret_reference';
+
+      constructor(readonly key: string) {
+        super();
+      }
+
+      override serialize(): Record<string, unknown> {
+        return { key: this.key };
+      }
+
+      override async resolve(): Promise<string> {
+        resolveCount += 1;
+        return `credential-${resolveCount}:${this.key}`;
+      }
+    }
+
+    const unregister = registerEnvValueReference(
+      E2BSecretReference,
+      (payload) => {
+        if (typeof payload.key !== 'string') {
+          throw new TypeError('E2B secret reference key must be a string.');
+        }
+        return new E2BSecretReference(payload.key);
+      },
+    );
+    try {
+      const client = new E2BSandboxClient({
+        pauseOnExit: true,
+        template: 'base',
+      });
+      const session = await client.create(
+        new Manifest({
+          environment: {
+            TOKEN: new E2BSecretReference('openai-key'),
+          },
+        }),
+      );
+      const serialized = await client.serializeSessionState(session.state);
+      resolveCount = 0;
+      const restored = await client.deserializeSessionState(serialized);
+      expect(resolveCount).toBe(1);
+      expect(restored.environment).toEqual({
+        TOKEN: 'credential-1:openai-key',
+      });
+      createMock.mockClear();
+      connectMock.mockRejectedValueOnce(new Error('not found'));
+
+      const recreated = await client.resume(restored);
+
+      expect(resolveCount).toBe(1);
+      expect(createMock).toHaveBeenCalledWith('base', {
+        envs: {
+          TOKEN: 'credential-1:openai-key',
+        },
+      });
+      expect(recreated.state.manifest.environment.TOKEN).toBeInstanceOf(
+        E2BSecretReference,
+      );
+    } finally {
+      unregister();
+    }
   });
 
   test('fails fast when reconnect fails with a provider error', async () => {

--- a/packages/agents-extensions/test/sandbox/shared.test.ts
+++ b/packages/agents-extensions/test/sandbox/shared.test.ts
@@ -47,6 +47,7 @@ import {
   encodeNativeSnapshotRef,
   deserializeRemoteSandboxSessionStateValues,
   getCachedExposedPortEndpoint,
+  rehydrateRemoteSandboxSessionStateValues,
   requireNativeSnapshotRef,
   recordResolvedExposedPortEndpoint,
   readRunAsRemoteFile,
@@ -87,6 +88,7 @@ import {
 } from '../../src/sandbox/shared/inContainerMounts';
 import { makePaxRecord, makeTarArchive } from './tarFixture';
 import {
+  EnvValueReference,
   Manifest,
   SandboxArchiveError,
   SandboxConfigurationError,
@@ -101,6 +103,7 @@ import {
   localDir,
   localFile,
   mount,
+  registerEnvValueReference,
   type SandboxSessionState,
   type AzureBlobMount,
   type GCSMount,
@@ -1254,6 +1257,73 @@ describe('remote sandbox path helpers', () => {
       FEATURE_FLAG: 'enabled',
       KEEP: 'manifest',
     });
+  });
+
+  test('round-trips remote environment references without resolved secrets', async () => {
+    let currentSecret = 'activity-secret';
+    class RemoteSecretReference extends EnvValueReference {
+      static readonly type = 'test.remote_secret_reference';
+
+      constructor(readonly key: string) {
+        super();
+      }
+
+      serialize(): Record<string, unknown> {
+        return { key: this.key };
+      }
+
+      async resolve(): Promise<string> {
+        return `${currentSecret}:${this.key}`;
+      }
+    }
+    const unregister = registerEnvValueReference(
+      RemoteSecretReference,
+      (payload) => {
+        if (typeof payload.key !== 'string') {
+          throw new TypeError('Remote secret reference key must be a string.');
+        }
+        return new RemoteSecretReference(payload.key);
+      },
+    );
+    try {
+      const manifest = new Manifest({
+        environment: {
+          TOKEN: new RemoteSecretReference('openai-key'),
+        },
+      });
+      const serialized = serializeRemoteSandboxSessionState({
+        manifest,
+        environment: {
+          TOKEN: 'activity-secret:openai-key',
+          PROVIDER_VALUE: 'persisted',
+        },
+      });
+      const serializedJson = JSON.stringify(serialized);
+
+      expect(serializedJson).not.toContain('activity-secret');
+      expect(serialized.manifest).toMatchObject({
+        environment: {
+          TOKEN: {
+            type: RemoteSecretReference.type,
+            key: 'openai-key',
+          },
+        },
+      });
+
+      currentSecret = 'worker-secret';
+      const restored = await rehydrateRemoteSandboxSessionStateValues(
+        JSON.parse(serializedJson),
+      );
+      expect(restored.manifest.environment.TOKEN).toBeInstanceOf(
+        RemoteSecretReference,
+      );
+      expect(restored.environment).toEqual({
+        TOKEN: 'worker-secret:openai-key',
+        PROVIDER_VALUE: 'persisted',
+      });
+    } finally {
+      unregister();
+    }
   });
 
   test('materializes and merges environment values', async () => {


### PR DESCRIPTION
This pull request adds reconstructable sandbox environment value references so workflows can persist non-secret lookup metadata without storing resolved secrets. It registers reference subtypes for JSON reconstruction, keeps resolved values runtime-only across local and hosted sandbox session persistence, and binds runner-managed resume to the current trusted manifest before any reference is resolved.

It also advances the RunState schema to 1.15 and the sandbox session envelope to version 2, while preserving reads of RunState 1.14 and session envelope version 1.

see also: https://github.com/openai/openai-agents-python/pull/4039