### PR TITLE
fix(realtime): preserve raw transport event payloads

### DIFF
--- a/.changeset/calm-realtime-events.md
+++ b/.changeset/calm-realtime-events.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: preserve raw Realtime server event payloads

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -220,12 +220,13 @@ export abstract class OpenAIRealtimeBase
   }
 
   protected _onMessage(event: MessageEvent | WebSocketMessageEvent): void {
-    const { data: parsed, isGeneric } = parseRealtimeEvent(event);
-    if (parsed === null) {
+    const result = parseRealtimeEvent(event);
+    if (result.data === null) {
       return;
     }
+    const { data: parsed, raw, isGeneric } = result;
 
-    this.emit('*', parsed);
+    this.emit('*', raw);
     if (isGeneric) {
       return;
     }

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -226,7 +226,7 @@ export abstract class OpenAIRealtimeBase
     }
     const { data: parsed, raw, isGeneric } = result;
 
-    this.emit('*', raw);
+    this.emit('*', structuredClone(raw));
     if (isGeneric) {
       return;
     }

--- a/packages/agents-realtime/src/openaiRealtimeEvents.ts
+++ b/packages/agents-realtime/src/openaiRealtimeEvents.ts
@@ -600,21 +600,24 @@ export type RealtimeClientEvent = z.infer<typeof realtimeClientEventSchema> &
 type ParseResult =
   | {
       data: RealtimeServerEvent;
+      raw: RealtimeServerGenericEvent;
       isGeneric: false;
     }
   | {
       data: RealtimeServerGenericEvent;
+      raw: RealtimeServerGenericEvent;
       isGeneric: true;
     }
   | {
       data: null;
+      raw: null;
       isGeneric: true;
     };
 
 /**
  * Parses a realtime event from the server. If the event is unknown to the client, it will be treated as a generic event.
  * @param event - The event to parse.
- * @returns The parsed event or null if the event is unknown to the client.
+ * @returns The validated event and original JSON payload, or null values if the payload is not a valid event object.
  */
 export function parseRealtimeEvent(
   event: MessageEvent | WebSocketMessageEvent,
@@ -623,15 +626,23 @@ export function parseRealtimeEvent(
   try {
     raw = JSON.parse(event.data.toString());
   } catch {
-    return { data: null, isGeneric: true };
+    return { data: null, raw: null, isGeneric: true };
   }
   const parsed = realtimeServerEventSchema.safeParse(raw);
   if (!parsed.success) {
     const genericParsed = genericEventSchema.safeParse(raw);
     if (genericParsed.success) {
-      return { data: genericParsed.data, isGeneric: true };
+      return {
+        data: genericParsed.data,
+        raw: raw as RealtimeServerGenericEvent,
+        isGeneric: true,
+      };
     }
-    return { data: null, isGeneric: true };
+    return { data: null, raw: null, isGeneric: true };
   }
-  return { data: parsed.data, isGeneric: false };
+  return {
+    data: parsed.data,
+    raw: raw as RealtimeServerGenericEvent,
+    isGeneric: false,
+  };
 }

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -87,35 +87,38 @@ describe('OpenAIRealtimeBase helpers', () => {
     const base = new TestBase();
     const typedEvents: any[] = [];
     const payload = {
-      type: 'conversation.created',
+      type: 'session.updated',
       event_id: 'evt_1',
-      conversation: {
-        id: 'conv_1',
-        object: 'realtime.conversation',
-        provider_nested: { value: true },
+      session: {
+        id: 'session_1',
+        instructions: 'original instructions',
+        provider_nested: { value: 'original value' },
       },
       provider_top_level: 123,
     };
     const rawListener = vi.fn((event: any) => {
       expect(event).toEqual(payload);
-      event.conversation.id = 'mutated_by_raw_listener';
+      event.session.instructions = 'mutated by raw listener';
+      event.session.provider_nested.value = 'mutated by raw listener';
     });
     base.on('*', rawListener);
-    base.on('conversation.created', (event) => typedEvents.push(event));
+    base.on('session.updated', (event) => typedEvents.push(event));
 
     (base as any)._onMessage({ data: JSON.stringify(payload) });
 
     expect(rawListener).toHaveBeenCalledOnce();
     expect(typedEvents).toEqual([
       {
-        type: 'conversation.created',
+        type: 'session.updated',
         event_id: 'evt_1',
-        conversation: {
-          id: 'conv_1',
-          object: 'realtime.conversation',
+        session: {
+          id: 'session_1',
+          instructions: 'original instructions',
+          provider_nested: { value: 'original value' },
         },
       },
     ]);
+    expect((base as any)._rawSessionConfig).toEqual(payload.session);
   });
 
   it('merges session config defaults', () => {

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -83,6 +83,41 @@ describe('OpenAIRealtimeBase helpers', () => {
     expectTypeOf(transport).toMatchTypeOf<OpenAIRealtimeBase>();
   });
 
+  it('isolates typed events from mutations to raw wildcard events', () => {
+    const base = new TestBase();
+    const typedEvents: any[] = [];
+    const payload = {
+      type: 'conversation.created',
+      event_id: 'evt_1',
+      conversation: {
+        id: 'conv_1',
+        object: 'realtime.conversation',
+        provider_nested: { value: true },
+      },
+      provider_top_level: 123,
+    };
+    const rawListener = vi.fn((event: any) => {
+      expect(event).toEqual(payload);
+      event.conversation.id = 'mutated_by_raw_listener';
+    });
+    base.on('*', rawListener);
+    base.on('conversation.created', (event) => typedEvents.push(event));
+
+    (base as any)._onMessage({ data: JSON.stringify(payload) });
+
+    expect(rawListener).toHaveBeenCalledOnce();
+    expect(typedEvents).toEqual([
+      {
+        type: 'conversation.created',
+        event_id: 'evt_1',
+        conversation: {
+          id: 'conv_1',
+          object: 'realtime.conversation',
+        },
+      },
+    ]);
+  });
+
   it('merges session config defaults', () => {
     const base = new TestBase();
     const config = (base as any)._getMergedSessionConfig({

--- a/packages/agents-realtime/test/openaiRealtimeEvents.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeEvents.test.ts
@@ -10,7 +10,7 @@ function createRawEvent(data: any): MessageEvent {
 }
 
 describe('parseRealtimeEvent', () => {
-  it('parses known conversation.item.created event', () => {
+  it('parses known conversation.item.added event', () => {
     const payload = {
       type: 'conversation.item.added',
       event_id: 'evt_1',
@@ -21,6 +21,7 @@ describe('parseRealtimeEvent', () => {
 
     expect(result.isGeneric).toBe(false);
     expect(result.data).toEqual(payload);
+    expect(result.raw).toEqual(payload);
   });
 
   it('returns generic result for unknown event type', () => {
@@ -29,6 +30,7 @@ describe('parseRealtimeEvent', () => {
 
     expect(result.isGeneric).toBe(true);
     expect(result.data).toEqual(payload);
+    expect(result.raw).toEqual(payload);
   });
 
   it('preserves fields for unknown events', () => {
@@ -41,23 +43,37 @@ describe('parseRealtimeEvent', () => {
 
     expect(result.isGeneric).toBe(true);
     expect(result.data).toEqual(payload);
+    expect(result.raw).toEqual(payload);
   });
 
-  it('parses event with extra fields', () => {
+  it('preserves extra fields in the raw value for known events', () => {
     const payload = {
       type: 'conversation.item.added',
       event_id: 'evt_2',
-      item: { extra: 'field' },
+      item: {
+        type: 'message',
+        content: [
+          {
+            type: 'input_text',
+            text: 'hello',
+            provider_nested: { value: true },
+          },
+        ],
+      },
       previous_item_id: 'evt_prev2',
-      another: 123,
+      provider_top_level: 123,
     };
     const result = parseRealtimeEvent(createEvent(payload));
 
     expect(result.isGeneric).toBe(false);
-    expect(result.data).toMatchObject({
+    expect(result.raw).toEqual(payload);
+    expect(result.data).toEqual({
       type: 'conversation.item.added',
       event_id: 'evt_2',
-      item: {},
+      item: {
+        type: 'message',
+        content: [{ type: 'input_text', text: 'hello' }],
+      },
       previous_item_id: 'evt_prev2',
     });
   });
@@ -66,12 +82,14 @@ describe('parseRealtimeEvent', () => {
     const result = parseRealtimeEvent(createEvent({ notype: true }));
     expect(result.isGeneric).toBe(true);
     expect(result.data).toBeNull();
+    expect(result.raw).toBeNull();
   });
 
   it('returns null data for malformed JSON', () => {
     const result = parseRealtimeEvent(createRawEvent('{'));
     expect(result.isGeneric).toBe(true);
     expect(result.data).toBeNull();
+    expect(result.raw).toBeNull();
   });
 
   it('returns null data for binary non-JSON frames', () => {
@@ -80,5 +98,6 @@ describe('parseRealtimeEvent', () => {
     );
     expect(result.isGeneric).toBe(true);
     expect(result.data).toBeNull();
+    expect(result.raw).toBeNull();
   });
 });

--- a/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
@@ -72,12 +72,7 @@ class FakeRTCPeerConnection {
 
   _simulateStateChange(
     state:
-      | 'new'
-      | 'connecting'
-      | 'connected'
-      | 'disconnected'
-      | 'failed'
-      | 'closed',
+      'new' | 'connecting' | 'connected' | 'disconnected' | 'failed' | 'closed',
   ) {
     if (this.connectionState === state) return;
     this.connectionState = state;
@@ -177,6 +172,29 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
     expect(JSON.parse(channel.sent[2])).toEqual({
       type: 'output_audio_buffer.clear',
     });
+  });
+
+  it('preserves known server payloads on wildcard events', async () => {
+    const rtc = new OpenAIRealtimeWebRTC();
+    await rtc.connect({ apiKey: 'ek_test' });
+    const events: any[] = [];
+    rtc.on('*', (event) => events.push(event));
+    const payload = {
+      type: 'conversation.created',
+      event_id: 'evt_known',
+      conversation: {
+        id: 'conv_1',
+        provider_nested: { value: true },
+      },
+      provider_top_level: 123,
+    };
+
+    const channel = lastChannel as FakeRTCDataChannel;
+    channel.dispatchEvent(
+      new MessageEvent('message', { data: JSON.stringify(payload) }),
+    );
+
+    expect(events).toEqual([payload]);
   });
 
   it('rejects with the provider error message when /realtime/calls fails', async () => {

--- a/packages/agents-realtime/test/openaiRealtimeWebsocket.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeWebsocket.test.ts
@@ -108,6 +108,28 @@ describe('OpenAIRealtimeWebSocket', () => {
     expect(events).toEqual([payload]);
   });
 
+  it('preserves known server payloads on wildcard events', async () => {
+    const ws = new OpenAIRealtimeWebSocket();
+    const events: any[] = [];
+    ws.on('*', (event) => events.push(event));
+    const p = ws.connect({ apiKey: 'ek_test', model: 'm' });
+    await vi.runAllTimersAsync();
+    await p;
+
+    const payload = {
+      type: 'conversation.created',
+      event_id: 'evt_known',
+      conversation: {
+        id: 'conv_1',
+        provider_nested: { value: true },
+      },
+      provider_top_level: 123,
+    };
+    lastFakeSocket!.emit('message', { data: JSON.stringify(payload) });
+
+    expect(events).toEqual([payload]);
+  });
+
   it('handles audio delta, speech started and created/done events', async () => {
     const ws = new OpenAIRealtimeWebSocket();
     const audioSpy = vi.fn();

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -462,6 +462,26 @@ describe('RealtimeSession', () => {
     expect(transport.closeCalls).toBe(1);
   });
 
+  it('forwards raw transport payloads unchanged', async () => {
+    const payload = {
+      type: 'conversation.created',
+      event_id: 'evt_known',
+      conversation: {
+        id: 'conv_1',
+        provider_nested: { value: true },
+      },
+      provider_top_level: 123,
+    };
+    const forwardedEvent = waitForEvent<[typeof payload]>(
+      session,
+      'transport_event',
+    );
+
+    transport.emit('*', payload);
+
+    await expect(forwardedEvent).resolves.toEqual([payload]);
+  });
+
   it('selects transport based on environment and options', () => {
     const agent = new RealtimeAgent({ name: 'A', handoffs: [] });
 


### PR DESCRIPTION
This pull request fixes raw Realtime transport events losing unknown provider fields when known server events are validated through Zod.

Wildcard transport listeners and session `transport_event` listeners now receive the exact parsed JSON payload, while typed event listeners and internal state transitions continue using the separately validated event representation. Malformed JSON, binary frames, and unknown-event behavior remain unchanged.