### PR TITLE
fix: redact endpoint credentials from MCP transport errors

### DIFF
--- a/.changeset/redact-mcp-transport-errors.md
+++ b/.changeset/redact-mcp-transport-errors.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: redact endpoint credentials from MCP transport errors

--- a/packages/agents-core/src/mcpLogging.ts
+++ b/packages/agents-core/src/mcpLogging.ts
@@ -1,5 +1,4 @@
 const URL_DERIVED_NAME_PREFIXES = ['sse: ', 'streamable-http: '] as const;
-const HTTP_SCHEME_PATTERN = /^https?:/i;
 const MAX_PROTOTYPE_DEPTH = 8;
 const DOM_EXCEPTION_PROTOTYPE =
   typeof DOMException === 'undefined' ? undefined : DOMException.prototype;
@@ -7,9 +6,8 @@ const DOM_EXCEPTION_NAME_GETTER = DOM_EXCEPTION_PROTOTYPE
   ? Object.getOwnPropertyDescriptor(DOM_EXCEPTION_PROTOTYPE, 'name')?.get
   : undefined;
 
-type EndpointRedactionInfo = {
-  url?: URL;
-};
+type EndpointRedactionInfo =
+  { kind: 'invalid' } | { kind: 'sensitive'; url: URL };
 
 type CancellationName = 'AbortError' | 'CanceledError' | 'CancelledError';
 type CancellationCode = 'ABORT_ERR' | 'ERR_ABORTED';
@@ -25,44 +23,16 @@ function parseHttpUrl(candidate: string): URL | undefined {
   }
 }
 
-function hasMalformedEndpointSecrets(endpoint: string): boolean {
-  if (endpoint.includes('?') || endpoint.includes('#')) {
-    return true;
-  }
-  if (HTTP_SCHEME_PATTERN.test(endpoint) && endpoint.includes('@')) {
-    return true;
-  }
-  const schemeIndex = endpoint.indexOf('://');
-  if (schemeIndex < 0) {
-    return false;
-  }
-  const authorityStart = schemeIndex + 3;
-  const authorityEndCandidates = [
-    endpoint.indexOf('/', authorityStart),
-    endpoint.indexOf('?', authorityStart),
-    endpoint.indexOf('#', authorityStart),
-  ].filter((index) => index >= 0);
-  const authorityEnd =
-    authorityEndCandidates.length > 0
-      ? Math.min(...authorityEndCandidates)
-      : endpoint.length;
-  const atIndex = endpoint.lastIndexOf('@', authorityEnd);
-  return atIndex >= authorityStart && atIndex < authorityEnd;
-}
-
 function getEndpointRedactionInfo(
   endpoint: string,
 ): EndpointRedactionInfo | undefined {
   const url = parseHttpUrl(endpoint);
-  if (url) {
-    return url.username || url.password || url.search || url.hash
-      ? { url }
-      : undefined;
+  if (!url) {
+    return { kind: 'invalid' };
   }
-  if (!hasMalformedEndpointSecrets(endpoint)) {
-    return undefined;
-  }
-  return {};
+  return url.username || url.password || url.search || url.hash
+    ? { kind: 'sensitive', url }
+    : undefined;
 }
 
 function getIntrinsicString(
@@ -152,12 +122,7 @@ export function getMcpServerDiagnosticName(name: string): string {
   if (url) {
     return `${prefix ?? ''}${url.protocol}//${url.host}${url.pathname}`;
   }
-  if (
-    (prefix ||
-      candidate.includes('://') ||
-      HTTP_SCHEME_PATTERN.test(candidate)) &&
-    hasMalformedEndpointSecrets(candidate)
-  ) {
+  if (prefix) {
     return `${prefix ?? ''}<redacted endpoint>`;
   }
   return name;
@@ -178,11 +143,16 @@ export function sanitizeMcpTransportError(
       ? collectCancellationName(error)
       : undefined;
 
-  const safeEndpoint = redactionInfo.url
-    ? ` for ${redactionInfo.url.protocol}//${redactionInfo.url.host}${redactionInfo.url.pathname}`
-    : '';
+  const safeEndpoint =
+    redactionInfo.kind === 'sensitive'
+      ? ` for ${redactionInfo.url.protocol}//${redactionInfo.url.host}${redactionInfo.url.pathname}`
+      : '';
+  const redactionMessage =
+    redactionInfo.kind === 'sensitive'
+      ? 'configured endpoint credentials were redacted.'
+      : 'configured endpoint was invalid and was redacted.';
   const sanitized = new Error(
-    `MCP ${operation} failed${safeEndpoint}; configured endpoint credentials were redacted.`,
+    `MCP ${operation} failed${safeEndpoint}; ${redactionMessage}`,
   );
   sanitized.name = cancellationName ?? 'MCPTransportError';
   return sanitized;

--- a/packages/agents-core/src/mcpLogging.ts
+++ b/packages/agents-core/src/mcpLogging.ts
@@ -1,4 +1,5 @@
 const URL_DERIVED_NAME_PREFIXES = ['sse: ', 'streamable-http: '] as const;
+const HTTP_SCHEME_PATTERN = /^https?:/i;
 const MAX_PROTOTYPE_DEPTH = 8;
 const DOM_EXCEPTION_PROTOTYPE =
   typeof DOMException === 'undefined' ? undefined : DOMException.prototype;
@@ -26,6 +27,9 @@ function parseHttpUrl(candidate: string): URL | undefined {
 
 function hasMalformedEndpointSecrets(endpoint: string): boolean {
   if (endpoint.includes('?') || endpoint.includes('#')) {
+    return true;
+  }
+  if (HTTP_SCHEME_PATTERN.test(endpoint) && endpoint.includes('@')) {
     return true;
   }
   const schemeIndex = endpoint.indexOf('://');
@@ -149,7 +153,9 @@ export function getMcpServerDiagnosticName(name: string): string {
     return `${prefix ?? ''}${url.protocol}//${url.host}${url.pathname}`;
   }
   if (
-    (prefix || candidate.includes('://')) &&
+    (prefix ||
+      candidate.includes('://') ||
+      HTTP_SCHEME_PATTERN.test(candidate)) &&
     hasMalformedEndpointSecrets(candidate)
   ) {
     return `${prefix ?? ''}<redacted endpoint>`;

--- a/packages/agents-core/src/mcpLogging.ts
+++ b/packages/agents-core/src/mcpLogging.ts
@@ -1,10 +1,6 @@
 const URL_DERIVED_NAME_PREFIXES = ['sse: ', 'streamable-http: '] as const;
 const MAX_PROTOTYPE_DEPTH = 8;
 const MIN_WEAK_SECRET_SUBSTRING_LENGTH = 8;
-const NATIVE_ERROR_STACK_GETTER = Object.getOwnPropertyDescriptor(
-  new Error(),
-  'stack',
-)?.get;
 const DOM_EXCEPTION_PROTOTYPE =
   typeof DOMException === 'undefined' ? undefined : DOMException.prototype;
 const DOM_EXCEPTION_NAME_GETTER = DOM_EXCEPTION_PROTOTYPE
@@ -29,6 +25,7 @@ type EndpointRedactionInfo = {
 
 type SafeDiagnostics = {
   name?: string;
+  message?: string;
   code?: string | number;
   status?: string | number;
   statusCode?: string | number;
@@ -126,23 +123,20 @@ function getEndpointRedactionInfo(
 function stringContainsEndpointSecret(
   value: string,
   secrets: EndpointSecrets,
-  includeWeak: boolean,
 ): boolean {
   for (const secret of secrets.strong) {
     if (value.includes(secret)) {
       return true;
     }
   }
-  if (includeWeak) {
-    for (const secret of secrets.weak) {
-      if (
-        value === secret ||
-        (secret.length >= MIN_WEAK_SECRET_SUBSTRING_LENGTH &&
-          value.includes(secret)) ||
-        stringContainsDelimitedSecret(value, secret)
-      ) {
-        return true;
-      }
+  for (const secret of secrets.weak) {
+    if (
+      value === secret ||
+      (secret.length >= MIN_WEAK_SECRET_SUBSTRING_LENGTH &&
+        value.includes(secret)) ||
+      stringContainsDelimitedSecret(value, secret)
+    ) {
+      return true;
     }
   }
   return false;
@@ -187,64 +181,52 @@ function getIntrinsicPrimitive(
   }
 }
 
-function getPrototypeChain(value: object): object[] | undefined {
-  const prototypes: object[] = [];
-  try {
-    let prototype = Object.getPrototypeOf(value);
-    while (prototype !== null) {
-      if (prototypes.length >= MAX_PROTOTYPE_DEPTH) {
-        return undefined;
-      }
-      prototypes.push(prototype);
-      prototype = Object.getPrototypeOf(prototype);
-    }
-    return prototypes;
-  } catch {
-    return undefined;
-  }
-}
-
 function getSafeDiagnostic(
   value: unknown,
   secrets: EndpointSecrets,
 ): string | number | undefined {
   return (typeof value === 'string' || typeof value === 'number') &&
-    !stringContainsEndpointSecret(String(value), secrets, true)
+    !stringContainsEndpointSecret(String(value), secrets)
     ? value
     : undefined;
 }
 
-function inspectErrorGraph(
-  value: unknown,
+function collectPrototypeName(
+  value: object,
   secrets: EndpointSecrets,
-): ErrorGraphInspection {
-  const diagnostics: SafeDiagnostics = {};
-  if (typeof value === 'string') {
-    return {
-      kind: stringContainsEndpointSecret(value, secrets, true)
-        ? 'secret'
-        : 'safe',
-      diagnostics,
-    };
+): string | undefined {
+  try {
+    let prototype = Object.getPrototypeOf(value);
+    let depth = 0;
+    while (prototype !== null && depth < MAX_PROTOTYPE_DEPTH) {
+      const descriptor = Object.getOwnPropertyDescriptor(prototype, 'name');
+      if (descriptor) {
+        if ('value' in descriptor) {
+          const name = getSafeDiagnostic(descriptor.value, secrets);
+          return typeof name === 'string' ? name : undefined;
+        }
+        return undefined;
+      }
+      prototype = Object.getPrototypeOf(prototype);
+      depth += 1;
+    }
+  } catch {
+    return undefined;
   }
-  if (
-    value === null ||
-    (typeof value !== 'object' &&
-      typeof value !== 'function' &&
-      typeof value !== 'symbol')
-  ) {
-    return { kind: 'safe', diagnostics };
-  }
-  if (typeof value === 'function' || typeof value === 'symbol') {
-    return { kind: 'opaque', diagnostics };
-  }
+  return undefined;
+}
 
+function collectSafeDiagnostics(
+  value: object,
+  secrets: EndpointSecrets,
+): SafeDiagnostics {
+  const diagnostics: SafeDiagnostics = {};
   const domExceptionMessage = getIntrinsicPrimitive(
     value,
     DOM_EXCEPTION_MESSAGE_GETTER,
   );
-  const isDomException = typeof domExceptionMessage === 'string';
-  if (isDomException) {
+  if (typeof domExceptionMessage === 'string') {
+    const message = getSafeDiagnostic(domExceptionMessage, secrets);
     const name = getSafeDiagnostic(
       getIntrinsicPrimitive(value, DOM_EXCEPTION_NAME_GETTER),
       secrets,
@@ -253,64 +235,14 @@ function inspectErrorGraph(
       getIntrinsicPrimitive(value, DOM_EXCEPTION_CODE_GETTER),
       secrets,
     );
+    if (typeof message === 'string') {
+      diagnostics.message = message;
+    }
     if (typeof name === 'string') {
       diagnostics.name = name;
     }
     if (code !== undefined) {
       diagnostics.code = code;
-    }
-    if (stringContainsEndpointSecret(domExceptionMessage, secrets, true)) {
-      return { kind: 'secret', diagnostics };
-    }
-  }
-
-  const prototypes = getPrototypeChain(value);
-  if (!prototypes) {
-    return { kind: 'opaque', diagnostics };
-  }
-  if (isDomException && prototypes[0] === DOM_EXCEPTION_PROTOTYPE) {
-    // Native DOMException fields are read through captured intrinsic getters.
-  } else if (prototypes.length === 0 || prototypes[0] === Object.prototype) {
-    // Descriptor-only plain objects are safe to inspect below.
-  } else {
-    const errorPrototypeIndex = prototypes.indexOf(Error.prototype);
-    if (errorPrototypeIndex < 0) {
-      return { kind: 'opaque', diagnostics };
-    }
-    let hasCustomConstructor = false;
-    for (const prototype of prototypes.slice(0, errorPrototypeIndex)) {
-      let descriptors: PropertyDescriptorMap;
-      try {
-        descriptors = Object.getOwnPropertyDescriptors(prototype);
-      } catch {
-        return { kind: 'opaque', diagnostics };
-      }
-      for (const name of Reflect.ownKeys(descriptors)) {
-        if (typeof name === 'symbol') {
-          return { kind: 'opaque', diagnostics };
-        }
-        if (name === 'constructor') {
-          hasCustomConstructor = true;
-          continue;
-        }
-        const descriptor = descriptors[name];
-        if (
-          (name !== 'name' && name !== 'message') ||
-          !('value' in descriptor) ||
-          typeof descriptor.value !== 'string'
-        ) {
-          return { kind: 'opaque', diagnostics };
-        }
-        if (stringContainsEndpointSecret(descriptor.value, secrets, true)) {
-          return { kind: 'secret', diagnostics };
-        }
-        if (name === 'name') {
-          diagnostics.name = descriptor.value;
-        }
-      }
-    }
-    if (hasCustomConstructor) {
-      return { kind: 'opaque', diagnostics };
     }
   }
 
@@ -318,58 +250,60 @@ function inspectErrorGraph(
   try {
     descriptors = Object.getOwnPropertyDescriptors(value);
   } catch {
-    return { kind: 'opaque', diagnostics };
+    return diagnostics;
   }
   for (const propertyName of [
     'name',
+    'message',
     'code',
     'status',
     'statusCode',
   ] as const) {
     const descriptor = descriptors[propertyName];
-    if (descriptor && 'value' in descriptor) {
-      const diagnostic = getSafeDiagnostic(descriptor.value, secrets);
-      if (diagnostic !== undefined) {
-        if (propertyName === 'name') {
-          if (typeof diagnostic === 'string') {
-            diagnostics.name = diagnostic;
-          }
-        } else {
-          diagnostics[propertyName] = diagnostic;
-        }
+    if (!descriptor || !('value' in descriptor)) {
+      continue;
+    }
+    const diagnostic = getSafeDiagnostic(descriptor.value, secrets);
+    if (diagnostic === undefined) {
+      continue;
+    }
+    if (propertyName === 'name' || propertyName === 'message') {
+      if (typeof diagnostic === 'string') {
+        diagnostics[propertyName] = diagnostic;
       }
+    } else {
+      diagnostics[propertyName] = diagnostic;
     }
   }
-  for (const name of Reflect.ownKeys(descriptors)) {
-    if (typeof name === 'symbol') {
-      return { kind: 'opaque', diagnostics };
-    }
-    if (stringContainsEndpointSecret(name, secrets, true)) {
-      return { kind: 'secret', diagnostics };
-    }
-    const descriptor = descriptors[name];
-    if (!('value' in descriptor)) {
-      if (name === 'stack' && descriptor.get === NATIVE_ERROR_STACK_GETTER) {
-        continue;
-      }
-      return { kind: 'opaque', diagnostics };
-    }
-    if (
-      descriptor.value !== null &&
-      (typeof descriptor.value === 'object' ||
-        typeof descriptor.value === 'function' ||
-        typeof descriptor.value === 'symbol')
-    ) {
-      return { kind: 'opaque', diagnostics };
-    }
-    if (
-      typeof descriptor.value === 'string' &&
-      stringContainsEndpointSecret(descriptor.value, secrets, true)
-    ) {
-      return { kind: 'secret', diagnostics };
-    }
+  diagnostics.name ??= collectPrototypeName(value, secrets);
+  return diagnostics;
+}
+
+function inspectErrorGraph(
+  value: unknown,
+  secrets: EndpointSecrets,
+): ErrorGraphInspection {
+  if (typeof value === 'string') {
+    return {
+      kind: stringContainsEndpointSecret(value, secrets) ? 'secret' : 'safe',
+      diagnostics: {},
+    };
   }
-  return { kind: 'safe', diagnostics };
+  if (
+    value === null ||
+    (typeof value !== 'object' &&
+      typeof value !== 'function' &&
+      typeof value !== 'symbol')
+  ) {
+    return { kind: 'safe', diagnostics: {} };
+  }
+  if (typeof value === 'function' || typeof value === 'symbol') {
+    return { kind: 'opaque', diagnostics: {} };
+  }
+  return {
+    kind: 'opaque',
+    diagnostics: collectSafeDiagnostics(value, secrets),
+  };
 }
 
 // Some transports use their full endpoint URL as the default server name.
@@ -412,7 +346,8 @@ export function sanitizeMcpTransportError(
     ? ` for ${redactionInfo.url.protocol}//${redactionInfo.url.host}${redactionInfo.url.pathname}`
     : '';
   const sanitized = new Error(
-    `MCP ${operation} failed${safeEndpoint}; configured endpoint credentials were redacted.`,
+    inspection.diagnostics.message ??
+      `MCP ${operation} failed${safeEndpoint}; configured endpoint credentials were redacted.`,
   );
   sanitized.name =
     inspection.diagnostics.name === 'AbortError' ||

--- a/packages/agents-core/src/mcpLogging.ts
+++ b/packages/agents-core/src/mcpLogging.ts
@@ -1,40 +1,17 @@
 const URL_DERIVED_NAME_PREFIXES = ['sse: ', 'streamable-http: '] as const;
 const MAX_PROTOTYPE_DEPTH = 8;
-const MIN_WEAK_SECRET_SUBSTRING_LENGTH = 8;
 const DOM_EXCEPTION_PROTOTYPE =
   typeof DOMException === 'undefined' ? undefined : DOMException.prototype;
 const DOM_EXCEPTION_NAME_GETTER = DOM_EXCEPTION_PROTOTYPE
   ? Object.getOwnPropertyDescriptor(DOM_EXCEPTION_PROTOTYPE, 'name')?.get
   : undefined;
-const DOM_EXCEPTION_MESSAGE_GETTER = DOM_EXCEPTION_PROTOTYPE
-  ? Object.getOwnPropertyDescriptor(DOM_EXCEPTION_PROTOTYPE, 'message')?.get
-  : undefined;
-const DOM_EXCEPTION_CODE_GETTER = DOM_EXCEPTION_PROTOTYPE
-  ? Object.getOwnPropertyDescriptor(DOM_EXCEPTION_PROTOTYPE, 'code')?.get
-  : undefined;
-
-type EndpointSecrets = {
-  strong: Set<string>;
-  weak: Set<string>;
-};
 
 type EndpointRedactionInfo = {
-  secrets: EndpointSecrets;
   url?: URL;
 };
 
-type SafeDiagnostics = {
-  name?: string;
-  message?: string;
-  code?: string | number;
-  status?: string | number;
-  statusCode?: string | number;
-};
-
-type ErrorGraphInspection = {
-  kind: 'safe' | 'secret' | 'opaque';
-  diagnostics: SafeDiagnostics;
-};
+type CancellationName = 'AbortError' | 'CanceledError' | 'CancelledError';
+type CancellationCode = 'ABORT_ERR' | 'ERR_ABORTED';
 
 function parseHttpUrl(candidate: string): URL | undefined {
   try {
@@ -45,41 +22,6 @@ function parseHttpUrl(candidate: string): URL | undefined {
   } catch {
     return undefined;
   }
-}
-
-function addStringVariants(target: Set<string>, value: string): void {
-  if (!value) {
-    return;
-  }
-  target.add(value);
-  try {
-    target.add(decodeURIComponent(value));
-  } catch {
-    // Keep the original encoded value.
-  }
-}
-
-function getEndpointSecrets(url: URL): EndpointSecrets | undefined {
-  if (!url.username && !url.password && !url.search && !url.hash) {
-    return undefined;
-  }
-
-  const strong = new Set<string>();
-  const weak = new Set<string>();
-  addStringVariants(strong, url.href);
-  addStringVariants(strong, url.search);
-  addStringVariants(strong, url.hash);
-  if (url.username || url.password) {
-    addStringVariants(strong, `${url.username}:${url.password}@`);
-  }
-  addStringVariants(weak, url.username);
-  addStringVariants(weak, url.password);
-  addStringVariants(weak, url.search.slice(1));
-  addStringVariants(weak, url.hash.slice(1));
-  for (const [key, value] of url.searchParams) {
-    addStringVariants(weak, value || key);
-  }
-  return { strong, weak };
 }
 
 function hasMalformedEndpointSecrets(endpoint: string): boolean {
@@ -109,105 +51,57 @@ function getEndpointRedactionInfo(
 ): EndpointRedactionInfo | undefined {
   const url = parseHttpUrl(endpoint);
   if (url) {
-    const secrets = getEndpointSecrets(url);
-    return secrets ? { secrets, url } : undefined;
+    return url.username || url.password || url.search || url.hash
+      ? { url }
+      : undefined;
   }
   if (!hasMalformedEndpointSecrets(endpoint)) {
     return undefined;
   }
-  const strong = new Set<string>();
-  addStringVariants(strong, endpoint);
-  return { secrets: { strong, weak: new Set() } };
+  return {};
 }
 
-function stringContainsEndpointSecret(
-  value: string,
-  secrets: EndpointSecrets,
-): boolean {
-  for (const secret of secrets.strong) {
-    if (value.includes(secret)) {
-      return true;
-    }
-  }
-  for (const secret of secrets.weak) {
-    if (
-      value === secret ||
-      (secret.length >= MIN_WEAK_SECRET_SUBSTRING_LENGTH &&
-        value.includes(secret)) ||
-      stringContainsDelimitedSecret(value, secret)
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function stringContainsDelimitedSecret(value: string, secret: string): boolean {
-  let index = value.indexOf(secret);
-  while (index >= 0) {
-    const before = index === 0 ? undefined : value[index - 1];
-    const afterIndex = index + secret.length;
-    const after = afterIndex === value.length ? undefined : value[afterIndex];
-    if (
-      (!isIdentifierCharacter(secret[0]) || !isIdentifierCharacter(before)) &&
-      (!isIdentifierCharacter(secret[secret.length - 1]) ||
-        !isIdentifierCharacter(after))
-    ) {
-      return true;
-    }
-    index = value.indexOf(secret, index + 1);
-  }
-  return false;
-}
-
-function isIdentifierCharacter(value: string | undefined): boolean {
-  return value !== undefined && /[A-Za-z0-9_]/.test(value);
-}
-
-function getIntrinsicPrimitive(
+function getIntrinsicString(
   value: unknown,
   getter: (() => unknown) | undefined,
-): string | number | undefined {
+): string | undefined {
   if (!getter) {
     return undefined;
   }
   try {
     const result = getter.call(value);
-    return typeof result === 'string' || typeof result === 'number'
-      ? result
-      : undefined;
+    return typeof result === 'string' ? result : undefined;
   } catch {
     return undefined;
   }
 }
 
-function getSafeDiagnostic(
-  value: unknown,
-  secrets: EndpointSecrets,
-): string | number | undefined {
-  return (typeof value === 'string' || typeof value === 'number') &&
-    !stringContainsEndpointSecret(String(value), secrets)
+function getCancellationName(value: unknown): CancellationName | undefined {
+  return value === 'AbortError' ||
+    value === 'CanceledError' ||
+    value === 'CancelledError'
     ? value
     : undefined;
 }
 
-function collectPrototypeName(
+function getCancellationCode(value: unknown): CancellationCode | undefined {
+  return value === 'ABORT_ERR' || value === 'ERR_ABORTED' ? value : undefined;
+}
+
+function collectDescriptorCancellationValue<T>(
   value: object,
-  secrets: EndpointSecrets,
-): string | undefined {
+  propertyName: 'name' | 'code',
+  getValue: (candidate: unknown) => T | undefined,
+): T | undefined {
   try {
-    let prototype = Object.getPrototypeOf(value);
+    let current: object | null = value;
     let depth = 0;
-    while (prototype !== null && depth < MAX_PROTOTYPE_DEPTH) {
-      const descriptor = Object.getOwnPropertyDescriptor(prototype, 'name');
+    while (current !== null && depth <= MAX_PROTOTYPE_DEPTH) {
+      const descriptor = Object.getOwnPropertyDescriptor(current, propertyName);
       if (descriptor) {
-        if ('value' in descriptor) {
-          const name = getSafeDiagnostic(descriptor.value, secrets);
-          return typeof name === 'string' ? name : undefined;
-        }
-        return undefined;
+        return 'value' in descriptor ? getValue(descriptor.value) : undefined;
       }
-      prototype = Object.getPrototypeOf(prototype);
+      current = Object.getPrototypeOf(current);
       depth += 1;
     }
   } catch {
@@ -216,94 +110,29 @@ function collectPrototypeName(
   return undefined;
 }
 
-function collectSafeDiagnostics(
-  value: object,
-  secrets: EndpointSecrets,
-): SafeDiagnostics {
-  const diagnostics: SafeDiagnostics = {};
-  const domExceptionMessage = getIntrinsicPrimitive(
-    value,
-    DOM_EXCEPTION_MESSAGE_GETTER,
+function collectCancellationName(value: object): CancellationName | undefined {
+  const domExceptionName = getCancellationName(
+    getIntrinsicString(value, DOM_EXCEPTION_NAME_GETTER),
   );
-  if (typeof domExceptionMessage === 'string') {
-    const message = getSafeDiagnostic(domExceptionMessage, secrets);
-    const name = getSafeDiagnostic(
-      getIntrinsicPrimitive(value, DOM_EXCEPTION_NAME_GETTER),
-      secrets,
-    );
-    const code = getSafeDiagnostic(
-      getIntrinsicPrimitive(value, DOM_EXCEPTION_CODE_GETTER),
-      secrets,
-    );
-    if (typeof message === 'string') {
-      diagnostics.message = message;
-    }
-    if (typeof name === 'string') {
-      diagnostics.name = name;
-    }
-    if (code !== undefined) {
-      diagnostics.code = code;
-    }
+  if (domExceptionName) {
+    return domExceptionName;
   }
 
-  let descriptors: PropertyDescriptorMap;
-  try {
-    descriptors = Object.getOwnPropertyDescriptors(value);
-  } catch {
-    return diagnostics;
-  }
-  for (const propertyName of [
+  const descriptorName = collectDescriptorCancellationValue(
+    value,
     'name',
-    'message',
-    'code',
-    'status',
-    'statusCode',
-  ] as const) {
-    const descriptor = descriptors[propertyName];
-    if (!descriptor || !('value' in descriptor)) {
-      continue;
-    }
-    const diagnostic = getSafeDiagnostic(descriptor.value, secrets);
-    if (diagnostic === undefined) {
-      continue;
-    }
-    if (propertyName === 'name' || propertyName === 'message') {
-      if (typeof diagnostic === 'string') {
-        diagnostics[propertyName] = diagnostic;
-      }
-    } else {
-      diagnostics[propertyName] = diagnostic;
-    }
+    getCancellationName,
+  );
+  if (descriptorName) {
+    return descriptorName;
   }
-  diagnostics.name ??= collectPrototypeName(value, secrets);
-  return diagnostics;
-}
 
-function inspectErrorGraph(
-  value: unknown,
-  secrets: EndpointSecrets,
-): ErrorGraphInspection {
-  if (typeof value === 'string') {
-    return {
-      kind: stringContainsEndpointSecret(value, secrets) ? 'secret' : 'safe',
-      diagnostics: {},
-    };
-  }
-  if (
-    value === null ||
-    (typeof value !== 'object' &&
-      typeof value !== 'function' &&
-      typeof value !== 'symbol')
-  ) {
-    return { kind: 'safe', diagnostics: {} };
-  }
-  if (typeof value === 'function' || typeof value === 'symbol') {
-    return { kind: 'opaque', diagnostics: {} };
-  }
-  return {
-    kind: 'opaque',
-    diagnostics: collectSafeDiagnostics(value, secrets),
-  };
+  const descriptorCode = collectDescriptorCancellationValue(
+    value,
+    'code',
+    getCancellationCode,
+  );
+  return descriptorCode ? 'AbortError' : undefined;
 }
 
 // Some transports use their full endpoint URL as the default server name.
@@ -337,35 +166,18 @@ export function sanitizeMcpTransportError(
   if (!redactionInfo) {
     return error;
   }
-  const inspection = inspectErrorGraph(error, redactionInfo.secrets);
-  if (inspection.kind === 'safe') {
-    return error;
-  }
+
+  const cancellationName =
+    error !== null && typeof error === 'object'
+      ? collectCancellationName(error)
+      : undefined;
 
   const safeEndpoint = redactionInfo.url
     ? ` for ${redactionInfo.url.protocol}//${redactionInfo.url.host}${redactionInfo.url.pathname}`
     : '';
   const sanitized = new Error(
-    inspection.diagnostics.message ??
-      `MCP ${operation} failed${safeEndpoint}; configured endpoint credentials were redacted.`,
+    `MCP ${operation} failed${safeEndpoint}; configured endpoint credentials were redacted.`,
   );
-  sanitized.name =
-    inspection.diagnostics.name === 'AbortError' ||
-    inspection.diagnostics.name === 'CanceledError' ||
-    inspection.diagnostics.name === 'CancelledError'
-      ? inspection.diagnostics.name
-      : 'MCPTransportError';
-
-  for (const propertyName of ['code', 'status', 'statusCode'] as const) {
-    const value = inspection.diagnostics[propertyName];
-    if (value !== undefined) {
-      Object.defineProperty(sanitized, propertyName, {
-        value,
-        configurable: true,
-        enumerable: true,
-        writable: true,
-      });
-    }
-  }
+  sanitized.name = cancellationName ?? 'MCPTransportError';
   return sanitized;
 }

--- a/packages/agents-core/src/mcpLogging.ts
+++ b/packages/agents-core/src/mcpLogging.ts
@@ -1,4 +1,376 @@
 const URL_DERIVED_NAME_PREFIXES = ['sse: ', 'streamable-http: '] as const;
+const MAX_PROTOTYPE_DEPTH = 8;
+const MIN_WEAK_SECRET_SUBSTRING_LENGTH = 8;
+const NATIVE_ERROR_STACK_GETTER = Object.getOwnPropertyDescriptor(
+  new Error(),
+  'stack',
+)?.get;
+const DOM_EXCEPTION_PROTOTYPE =
+  typeof DOMException === 'undefined' ? undefined : DOMException.prototype;
+const DOM_EXCEPTION_NAME_GETTER = DOM_EXCEPTION_PROTOTYPE
+  ? Object.getOwnPropertyDescriptor(DOM_EXCEPTION_PROTOTYPE, 'name')?.get
+  : undefined;
+const DOM_EXCEPTION_MESSAGE_GETTER = DOM_EXCEPTION_PROTOTYPE
+  ? Object.getOwnPropertyDescriptor(DOM_EXCEPTION_PROTOTYPE, 'message')?.get
+  : undefined;
+const DOM_EXCEPTION_CODE_GETTER = DOM_EXCEPTION_PROTOTYPE
+  ? Object.getOwnPropertyDescriptor(DOM_EXCEPTION_PROTOTYPE, 'code')?.get
+  : undefined;
+
+type EndpointSecrets = {
+  strong: Set<string>;
+  weak: Set<string>;
+};
+
+type EndpointRedactionInfo = {
+  secrets: EndpointSecrets;
+  url?: URL;
+};
+
+type SafeDiagnostics = {
+  name?: string;
+  code?: string | number;
+  status?: string | number;
+  statusCode?: string | number;
+};
+
+type ErrorGraphInspection = {
+  kind: 'safe' | 'secret' | 'opaque';
+  diagnostics: SafeDiagnostics;
+};
+
+function parseHttpUrl(candidate: string): URL | undefined {
+  try {
+    const url = new URL(candidate);
+    return url.protocol === 'http:' || url.protocol === 'https:'
+      ? url
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function addStringVariants(target: Set<string>, value: string): void {
+  if (!value) {
+    return;
+  }
+  target.add(value);
+  try {
+    target.add(decodeURIComponent(value));
+  } catch {
+    // Keep the original encoded value.
+  }
+}
+
+function getEndpointSecrets(url: URL): EndpointSecrets | undefined {
+  if (!url.username && !url.password && !url.search && !url.hash) {
+    return undefined;
+  }
+
+  const strong = new Set<string>();
+  const weak = new Set<string>();
+  addStringVariants(strong, url.href);
+  addStringVariants(strong, url.search);
+  addStringVariants(strong, url.hash);
+  if (url.username || url.password) {
+    addStringVariants(strong, `${url.username}:${url.password}@`);
+  }
+  addStringVariants(weak, url.username);
+  addStringVariants(weak, url.password);
+  addStringVariants(weak, url.search.slice(1));
+  addStringVariants(weak, url.hash.slice(1));
+  for (const [key, value] of url.searchParams) {
+    addStringVariants(weak, value || key);
+  }
+  return { strong, weak };
+}
+
+function hasMalformedEndpointSecrets(endpoint: string): boolean {
+  if (endpoint.includes('?') || endpoint.includes('#')) {
+    return true;
+  }
+  const schemeIndex = endpoint.indexOf('://');
+  if (schemeIndex < 0) {
+    return false;
+  }
+  const authorityStart = schemeIndex + 3;
+  const authorityEndCandidates = [
+    endpoint.indexOf('/', authorityStart),
+    endpoint.indexOf('?', authorityStart),
+    endpoint.indexOf('#', authorityStart),
+  ].filter((index) => index >= 0);
+  const authorityEnd =
+    authorityEndCandidates.length > 0
+      ? Math.min(...authorityEndCandidates)
+      : endpoint.length;
+  const atIndex = endpoint.lastIndexOf('@', authorityEnd);
+  return atIndex >= authorityStart && atIndex < authorityEnd;
+}
+
+function getEndpointRedactionInfo(
+  endpoint: string,
+): EndpointRedactionInfo | undefined {
+  const url = parseHttpUrl(endpoint);
+  if (url) {
+    const secrets = getEndpointSecrets(url);
+    return secrets ? { secrets, url } : undefined;
+  }
+  if (!hasMalformedEndpointSecrets(endpoint)) {
+    return undefined;
+  }
+  const strong = new Set<string>();
+  addStringVariants(strong, endpoint);
+  return { secrets: { strong, weak: new Set() } };
+}
+
+function stringContainsEndpointSecret(
+  value: string,
+  secrets: EndpointSecrets,
+  includeWeak: boolean,
+): boolean {
+  for (const secret of secrets.strong) {
+    if (value.includes(secret)) {
+      return true;
+    }
+  }
+  if (includeWeak) {
+    for (const secret of secrets.weak) {
+      if (
+        value === secret ||
+        (secret.length >= MIN_WEAK_SECRET_SUBSTRING_LENGTH &&
+          value.includes(secret)) ||
+        stringContainsDelimitedSecret(value, secret)
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function stringContainsDelimitedSecret(value: string, secret: string): boolean {
+  let index = value.indexOf(secret);
+  while (index >= 0) {
+    const before = index === 0 ? undefined : value[index - 1];
+    const afterIndex = index + secret.length;
+    const after = afterIndex === value.length ? undefined : value[afterIndex];
+    if (
+      (!isIdentifierCharacter(secret[0]) || !isIdentifierCharacter(before)) &&
+      (!isIdentifierCharacter(secret[secret.length - 1]) ||
+        !isIdentifierCharacter(after))
+    ) {
+      return true;
+    }
+    index = value.indexOf(secret, index + 1);
+  }
+  return false;
+}
+
+function isIdentifierCharacter(value: string | undefined): boolean {
+  return value !== undefined && /[A-Za-z0-9_]/.test(value);
+}
+
+function getIntrinsicPrimitive(
+  value: unknown,
+  getter: (() => unknown) | undefined,
+): string | number | undefined {
+  if (!getter) {
+    return undefined;
+  }
+  try {
+    const result = getter.call(value);
+    return typeof result === 'string' || typeof result === 'number'
+      ? result
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function getPrototypeChain(value: object): object[] | undefined {
+  const prototypes: object[] = [];
+  try {
+    let prototype = Object.getPrototypeOf(value);
+    while (prototype !== null) {
+      if (prototypes.length >= MAX_PROTOTYPE_DEPTH) {
+        return undefined;
+      }
+      prototypes.push(prototype);
+      prototype = Object.getPrototypeOf(prototype);
+    }
+    return prototypes;
+  } catch {
+    return undefined;
+  }
+}
+
+function getSafeDiagnostic(
+  value: unknown,
+  secrets: EndpointSecrets,
+): string | number | undefined {
+  return (typeof value === 'string' || typeof value === 'number') &&
+    !stringContainsEndpointSecret(String(value), secrets, true)
+    ? value
+    : undefined;
+}
+
+function inspectErrorGraph(
+  value: unknown,
+  secrets: EndpointSecrets,
+): ErrorGraphInspection {
+  const diagnostics: SafeDiagnostics = {};
+  if (typeof value === 'string') {
+    return {
+      kind: stringContainsEndpointSecret(value, secrets, true)
+        ? 'secret'
+        : 'safe',
+      diagnostics,
+    };
+  }
+  if (
+    value === null ||
+    (typeof value !== 'object' &&
+      typeof value !== 'function' &&
+      typeof value !== 'symbol')
+  ) {
+    return { kind: 'safe', diagnostics };
+  }
+  if (typeof value === 'function' || typeof value === 'symbol') {
+    return { kind: 'opaque', diagnostics };
+  }
+
+  const domExceptionMessage = getIntrinsicPrimitive(
+    value,
+    DOM_EXCEPTION_MESSAGE_GETTER,
+  );
+  const isDomException = typeof domExceptionMessage === 'string';
+  if (isDomException) {
+    const name = getSafeDiagnostic(
+      getIntrinsicPrimitive(value, DOM_EXCEPTION_NAME_GETTER),
+      secrets,
+    );
+    const code = getSafeDiagnostic(
+      getIntrinsicPrimitive(value, DOM_EXCEPTION_CODE_GETTER),
+      secrets,
+    );
+    if (typeof name === 'string') {
+      diagnostics.name = name;
+    }
+    if (code !== undefined) {
+      diagnostics.code = code;
+    }
+    if (stringContainsEndpointSecret(domExceptionMessage, secrets, true)) {
+      return { kind: 'secret', diagnostics };
+    }
+  }
+
+  const prototypes = getPrototypeChain(value);
+  if (!prototypes) {
+    return { kind: 'opaque', diagnostics };
+  }
+  if (isDomException && prototypes[0] === DOM_EXCEPTION_PROTOTYPE) {
+    // Native DOMException fields are read through captured intrinsic getters.
+  } else if (prototypes.length === 0 || prototypes[0] === Object.prototype) {
+    // Descriptor-only plain objects are safe to inspect below.
+  } else {
+    const errorPrototypeIndex = prototypes.indexOf(Error.prototype);
+    if (errorPrototypeIndex < 0) {
+      return { kind: 'opaque', diagnostics };
+    }
+    let hasCustomConstructor = false;
+    for (const prototype of prototypes.slice(0, errorPrototypeIndex)) {
+      let descriptors: PropertyDescriptorMap;
+      try {
+        descriptors = Object.getOwnPropertyDescriptors(prototype);
+      } catch {
+        return { kind: 'opaque', diagnostics };
+      }
+      for (const name of Reflect.ownKeys(descriptors)) {
+        if (typeof name === 'symbol') {
+          return { kind: 'opaque', diagnostics };
+        }
+        if (name === 'constructor') {
+          hasCustomConstructor = true;
+          continue;
+        }
+        const descriptor = descriptors[name];
+        if (
+          (name !== 'name' && name !== 'message') ||
+          !('value' in descriptor) ||
+          typeof descriptor.value !== 'string'
+        ) {
+          return { kind: 'opaque', diagnostics };
+        }
+        if (stringContainsEndpointSecret(descriptor.value, secrets, true)) {
+          return { kind: 'secret', diagnostics };
+        }
+        if (name === 'name') {
+          diagnostics.name = descriptor.value;
+        }
+      }
+    }
+    if (hasCustomConstructor) {
+      return { kind: 'opaque', diagnostics };
+    }
+  }
+
+  let descriptors: PropertyDescriptorMap;
+  try {
+    descriptors = Object.getOwnPropertyDescriptors(value);
+  } catch {
+    return { kind: 'opaque', diagnostics };
+  }
+  for (const propertyName of [
+    'name',
+    'code',
+    'status',
+    'statusCode',
+  ] as const) {
+    const descriptor = descriptors[propertyName];
+    if (descriptor && 'value' in descriptor) {
+      const diagnostic = getSafeDiagnostic(descriptor.value, secrets);
+      if (diagnostic !== undefined) {
+        if (propertyName === 'name') {
+          if (typeof diagnostic === 'string') {
+            diagnostics.name = diagnostic;
+          }
+        } else {
+          diagnostics[propertyName] = diagnostic;
+        }
+      }
+    }
+  }
+  for (const name of Reflect.ownKeys(descriptors)) {
+    if (typeof name === 'symbol') {
+      return { kind: 'opaque', diagnostics };
+    }
+    if (stringContainsEndpointSecret(name, secrets, true)) {
+      return { kind: 'secret', diagnostics };
+    }
+    const descriptor = descriptors[name];
+    if (!('value' in descriptor)) {
+      if (name === 'stack' && descriptor.get === NATIVE_ERROR_STACK_GETTER) {
+        continue;
+      }
+      return { kind: 'opaque', diagnostics };
+    }
+    if (
+      descriptor.value !== null &&
+      (typeof descriptor.value === 'object' ||
+        typeof descriptor.value === 'function' ||
+        typeof descriptor.value === 'symbol')
+    ) {
+      return { kind: 'opaque', diagnostics };
+    }
+    if (
+      typeof descriptor.value === 'string' &&
+      stringContainsEndpointSecret(descriptor.value, secrets, true)
+    ) {
+      return { kind: 'secret', diagnostics };
+    }
+  }
+  return { kind: 'safe', diagnostics };
+}
 
 // Some transports use their full endpoint URL as the default server name.
 // In diagnostic mode, preserve ordinary names while removing URL credentials,
@@ -9,14 +381,56 @@ export function getMcpServerDiagnosticName(name: string): string {
     name.startsWith(candidate),
   );
   const candidate = prefix ? name.slice(prefix.length) : name;
-
-  try {
-    const url = new URL(candidate);
-    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-      return name;
-    }
+  const url = parseHttpUrl(candidate);
+  if (url) {
     return `${prefix ?? ''}${url.protocol}//${url.host}${url.pathname}`;
-  } catch {
-    return name;
   }
+  if (
+    (prefix || candidate.includes('://')) &&
+    hasMalformedEndpointSecrets(candidate)
+  ) {
+    return `${prefix ?? ''}<redacted endpoint>`;
+  }
+  return name;
+}
+
+export function sanitizeMcpTransportError(
+  error: unknown,
+  endpoint: string,
+  operation: string,
+): unknown {
+  const redactionInfo = getEndpointRedactionInfo(endpoint);
+  if (!redactionInfo) {
+    return error;
+  }
+  const inspection = inspectErrorGraph(error, redactionInfo.secrets);
+  if (inspection.kind === 'safe') {
+    return error;
+  }
+
+  const safeEndpoint = redactionInfo.url
+    ? ` for ${redactionInfo.url.protocol}//${redactionInfo.url.host}${redactionInfo.url.pathname}`
+    : '';
+  const sanitized = new Error(
+    `MCP ${operation} failed${safeEndpoint}; configured endpoint credentials were redacted.`,
+  );
+  sanitized.name =
+    inspection.diagnostics.name === 'AbortError' ||
+    inspection.diagnostics.name === 'CanceledError' ||
+    inspection.diagnostics.name === 'CancelledError'
+      ? inspection.diagnostics.name
+      : 'MCPTransportError';
+
+  for (const propertyName of ['code', 'status', 'statusCode'] as const) {
+    const value = inspection.diagnostics[propertyName];
+    if (value !== undefined) {
+      Object.defineProperty(sanitized, propertyName, {
+        value,
+        configurable: true,
+        enumerable: true,
+        writable: true,
+      });
+    }
+  }
+  return sanitized;
 }

--- a/packages/agents-core/src/mcpServers.ts
+++ b/packages/agents-core/src/mcpServers.ts
@@ -456,7 +456,9 @@ export class MCPServers {
         if (error) {
           throw error;
         }
-        throw new Error(`Failed to connect MCP server '${firstFailure.name}'.`);
+        throw new Error(
+          `Failed to connect MCP server '${getMcpServerDiagnosticName(firstFailure.name)}'.`,
+        );
       }
     }
   }
@@ -505,20 +507,24 @@ function createTimeoutError(
     return new Error(`MCP server ${action} timed out.`);
   }
   const error = new Error(
-    `MCP server ${action} timed out after ${timeoutMs}ms for '${server.name}'.`,
+    `MCP server ${action} timed out after ${timeoutMs}ms for '${getMcpServerDiagnosticName(server.name)}'.`,
   );
   error.name = 'TimeoutError';
   return error;
 }
 
 function createClosedError(server: MCPServer): Error {
-  const error = new Error(`MCP server '${server.name}' is closed.`);
+  const error = new Error(
+    `MCP server '${getMcpServerDiagnosticName(server.name)}' is closed.`,
+  );
   error.name = 'ClosedError';
   return error;
 }
 
 function createClosingError(server: MCPServer): Error {
-  const error = new Error(`MCP server '${server.name}' is closing.`);
+  const error = new Error(
+    `MCP server '${getMcpServerDiagnosticName(server.name)}' is closing.`,
+  );
   error.name = 'ClosingError';
   return error;
 }

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -25,7 +25,12 @@ import type {
   MCPServerStreamableHttpOptions,
   MCPServerSSEOptions,
 } from '../../mcp';
-import logger, { logToolActionError, logToolActionWarning } from '../../logger';
+import logger, {
+  type Logger,
+  logToolActionError,
+  logToolActionWarning,
+} from '../../logger';
+import { sanitizeMcpTransportError } from '../../mcpLogging';
 import { combineAbortSignals } from '../../utils/abortSignals';
 
 export interface SessionMessage {
@@ -194,6 +199,31 @@ function withTimeout<T>(
       },
     );
   });
+}
+
+async function runMcpTransportOperation<T>(
+  endpoint: string,
+  operation: string,
+  action: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await action();
+  } catch (error) {
+    throw sanitizeMcpTransportError(error, endpoint, operation);
+  }
+}
+
+function logMcpTransportWarning(
+  targetLogger: Logger,
+  endpoint: string,
+  operation: string,
+  message: string,
+  error: unknown,
+): void {
+  const logError = targetLogger.dontLogToolData
+    ? error
+    : sanitizeMcpTransportError(error, endpoint, operation);
+  logToolActionWarning(targetLogger, message, logError);
 }
 
 export class NodeMCPServerStdio extends BaseMCPServerStdio {
@@ -480,9 +510,14 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
         serverInfo: { name: this._name, version: '1.0.0' },
       } as InitializeResult;
     } catch (e) {
-      logToolActionError(this.logger, 'Error initializing MCP server:', e);
+      const error = sanitizeMcpTransportError(
+        e,
+        this.params.url,
+        'SSE connect',
+      );
+      logToolActionError(this.logger, 'Error initializing MCP server:', error);
       await this.close();
-      throw e;
+      throw error;
     }
     this.debugLog(() => `Connected to MCP server: ${this._name}`);
   }
@@ -508,7 +543,11 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
     const requestOptions = buildRequestOptions(
       this.clientSessionTimeoutSeconds,
     );
-    const response = await this.session.listTools(undefined, requestOptions);
+    const response = await runMcpTransportOperation(
+      this.params.url,
+      'SSE list tools',
+      () => this.session!.listTools(undefined, requestOptions),
+    );
     this.debugLog(() => `Listed tools: ${JSON.stringify(response)}`);
     this._toolsList = ListToolsResultSchema.parse(response).tools;
     return this._toolsList;
@@ -542,16 +581,19 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
       arguments: args ?? {},
       ...(meta != null ? { _meta: meta } : {}),
     };
-    const response = await callWithMCPRequestSignal(
-      options?.signal,
-      (requestSignal) =>
-        session.callTool(
-          params,
-          undefined,
-          buildRequestOptions(this.clientSessionTimeoutSeconds, {
-            timeout: this.timeout,
-            signal: requestSignal,
-          }),
+    const response = await runMcpTransportOperation(
+      this.params.url,
+      'SSE tool call',
+      () =>
+        callWithMCPRequestSignal(options?.signal, (requestSignal) =>
+          session.callTool(
+            params,
+            undefined,
+            buildRequestOptions(this.clientSessionTimeoutSeconds, {
+              timeout: this.timeout,
+              signal: requestSignal,
+            }),
+          ),
         ),
     );
     const parsed = CallToolResultSchema.parse(response);
@@ -576,7 +618,11 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
     const requestOptions = buildRequestOptions(
       this.clientSessionTimeoutSeconds,
     );
-    const response = await this.session.listResources(params, requestOptions);
+    const response = await runMcpTransportOperation(
+      this.params.url,
+      'SSE list resources',
+      () => this.session!.listResources(params, requestOptions),
+    );
     this.debugLog(() => `Listed resources: ${JSON.stringify(response)}`);
     return ListResourcesResultSchema.parse(response) as MCPListResourcesResult;
   }
@@ -594,9 +640,10 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
     const requestOptions = buildRequestOptions(
       this.clientSessionTimeoutSeconds,
     );
-    const response = await this.session.listResourceTemplates(
-      params,
-      requestOptions,
+    const response = await runMcpTransportOperation(
+      this.params.url,
+      'SSE list resource templates',
+      () => this.session!.listResourceTemplates(params, requestOptions),
     );
     this.debugLog(
       () => `Listed resource templates: ${JSON.stringify(response)}`,
@@ -617,7 +664,11 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
     const requestOptions = buildRequestOptions(
       this.clientSessionTimeoutSeconds,
     );
-    const response = await this.session.readResource({ uri }, requestOptions);
+    const response = await runMcpTransportOperation(
+      this.params.url,
+      'SSE read resource',
+      () => this.session!.readResource({ uri }, requestOptions),
+    );
     this.debugLog(() => `Read resource ${uri}: ${JSON.stringify(response)}`);
     return ReadResourceResultSchema.parse(response) as MCPReadResourceResult;
   }
@@ -627,34 +678,38 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
   }
 
   async close(): Promise<void> {
-    const transport = this.transport;
+    await runMcpTransportOperation(this.params.url, 'SSE cleanup', async () => {
+      const transport = this.transport;
 
-    if (hasSessionTransport(transport)) {
-      const sessionId = transport.sessionId;
+      if (hasSessionTransport(transport)) {
+        const sessionId = transport.sessionId;
 
-      if (sessionId && typeof transport.terminateSession === 'function') {
-        try {
-          // Best-effort cleanup: we do not actively manage session lifecycles,
-          // but if the server supports sessions we terminate to avoid leaks.
-          await transport.terminateSession();
-        } catch (error) {
-          logToolActionWarning(
-            this.logger,
-            'Failed to terminate MCP session:',
-            error,
-          );
+        if (sessionId && typeof transport.terminateSession === 'function') {
+          try {
+            // Best-effort cleanup: we do not actively manage session lifecycles,
+            // but if the server supports sessions we terminate to avoid leaks.
+            await transport.terminateSession();
+          } catch (error) {
+            logMcpTransportWarning(
+              this.logger,
+              this.params.url,
+              'SSE session termination',
+              'Failed to terminate MCP session:',
+              error,
+            );
+          }
         }
       }
-    }
 
-    if (transport) {
-      await transport.close();
-      this.transport = null;
-    }
-    if (this.session) {
-      await this.session.close();
-      this.session = null;
-    }
+      if (transport) {
+        await transport.close();
+        this.transport = null;
+      }
+      if (this.session) {
+        await this.session.close();
+        this.session = null;
+      }
+    });
   }
 }
 
@@ -876,7 +931,13 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
         await detachedTransport.close().catch(() => {});
       }
     } catch (error) {
-      logToolActionWarning(this.logger, warningMessage, error);
+      logMcpTransportWarning(
+        this.logger,
+        this.params.url,
+        'streamable HTTP session termination',
+        warningMessage,
+        error,
+      );
     }
   }
 
@@ -909,11 +970,23 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
       );
     } else if (transport) {
       await transport.close().catch((error) => {
-        logToolActionWarning(this.logger, closeWarningMessage, error);
+        logMcpTransportWarning(
+          this.logger,
+          this.params.url,
+          'streamable HTTP cleanup',
+          closeWarningMessage,
+          error,
+        );
       });
     } else if (client) {
       await client.close().catch((error) => {
-        logToolActionWarning(this.logger, closeWarningMessage, error);
+        logMcpTransportWarning(
+          this.logger,
+          this.params.url,
+          'streamable HTTP cleanup',
+          closeWarningMessage,
+          error,
+        );
       });
     }
 
@@ -984,16 +1057,34 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
 
     if (client.transport === transport) {
       await client.close().catch((error) => {
-        logToolActionWarning(this.logger, options.closeWarningMessage, error);
+        logMcpTransportWarning(
+          this.logger,
+          this.params.url,
+          'streamable HTTP cleanup',
+          options.closeWarningMessage,
+          error,
+        );
       });
       return;
     }
 
     await transport.close().catch((error) => {
-      logToolActionWarning(this.logger, options.closeWarningMessage, error);
+      logMcpTransportWarning(
+        this.logger,
+        this.params.url,
+        'streamable HTTP cleanup',
+        options.closeWarningMessage,
+        error,
+      );
     });
     await client.close().catch((error) => {
-      logToolActionWarning(this.logger, options.closeWarningMessage, error);
+      logMcpTransportWarning(
+        this.logger,
+        this.params.url,
+        'streamable HTTP cleanup',
+        options.closeWarningMessage,
+        error,
+      );
     });
   }
 
@@ -1286,8 +1377,13 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     } catch (e) {
       // A losing concurrent connect can fail after another connect already
       // published a healthy shared session, so avoid closing shared state here.
-      logToolActionError(this.logger, 'Error initializing MCP server:', e);
-      throw e;
+      const error = sanitizeMcpTransportError(
+        e,
+        this.params.url,
+        'streamable HTTP connect',
+      );
+      logToolActionError(this.logger, 'Error initializing MCP server:', error);
+      throw error;
     }
     this.debugLog(() => `Connected to MCP server: ${this._name}`);
   }
@@ -1313,7 +1409,11 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     const requestOptions = buildRequestOptions(
       this.clientSessionTimeoutSeconds,
     );
-    const response = await this.session.listTools(undefined, requestOptions);
+    const response = await runMcpTransportOperation(
+      this.params.url,
+      'streamable HTTP list tools',
+      () => this.session!.listTools(undefined, requestOptions),
+    );
     this.debugLog(() => `Listed tools: ${JSON.stringify(response)}`);
     this._toolsList = ListToolsResultSchema.parse(response).tools;
     return this._toolsList;
@@ -1355,7 +1455,11 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
       const recoveryStrategy =
         await this.shouldReconnectClosedStreamableHttpClient(error, client);
       if (recoveryStrategy === 'none') {
-        throw error;
+        throw sanitizeMcpTransportError(
+          error,
+          this.params.url,
+          'streamable HTTP tool call',
+        );
       }
 
       this.debugLog(
@@ -1363,14 +1467,23 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
           `Reconnecting closed streamable HTTP MCP session for ${toolName}.`,
       );
 
-      const recoveredClient = await this.reconnectClosedStreamableHttpClient({
-        cause: error,
-        failedClient: client,
-        failedStateVersion: callToolStateVersion,
-      });
+      const recoveredClient = await runMcpTransportOperation(
+        this.params.url,
+        'streamable HTTP reconnect',
+        () =>
+          this.reconnectClosedStreamableHttpClient({
+            cause: error,
+            failedClient: client,
+            failedStateVersion: callToolStateVersion,
+          }),
+      );
 
       if (recoveryStrategy === 'reconnect-only') {
-        throw error;
+        throw sanitizeMcpTransportError(
+          error,
+          this.params.url,
+          'streamable HTTP tool call',
+        );
       }
 
       try {
@@ -1382,7 +1495,11 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
           options,
         );
       } catch (retryError) {
-        throw attachCause(retryError, error);
+        throw sanitizeMcpTransportError(
+          attachCause(retryError, error),
+          this.params.url,
+          'streamable HTTP tool call retry',
+        );
       }
     }
 
@@ -1406,7 +1523,11 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     const requestOptions = buildRequestOptions(
       this.clientSessionTimeoutSeconds,
     );
-    const response = await this.session.listResources(params, requestOptions);
+    const response = await runMcpTransportOperation(
+      this.params.url,
+      'streamable HTTP list resources',
+      () => this.session!.listResources(params, requestOptions),
+    );
     this.debugLog(() => `Listed resources: ${JSON.stringify(response)}`);
     return ListResourcesResultSchema.parse(response) as MCPListResourcesResult;
   }
@@ -1424,9 +1545,10 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     const requestOptions = buildRequestOptions(
       this.clientSessionTimeoutSeconds,
     );
-    const response = await this.session.listResourceTemplates(
-      params,
-      requestOptions,
+    const response = await runMcpTransportOperation(
+      this.params.url,
+      'streamable HTTP list resource templates',
+      () => this.session!.listResourceTemplates(params, requestOptions),
     );
     this.debugLog(
       () => `Listed resource templates: ${JSON.stringify(response)}`,
@@ -1447,7 +1569,11 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     const requestOptions = buildRequestOptions(
       this.clientSessionTimeoutSeconds,
     );
-    const response = await this.session.readResource({ uri }, requestOptions);
+    const response = await runMcpTransportOperation(
+      this.params.url,
+      'streamable HTTP read resource',
+      () => this.session!.readResource({ uri }, requestOptions),
+    );
     this.debugLog(() => `Read resource ${uri}: ${JSON.stringify(response)}`);
     return ReadResourceResultSchema.parse(response) as MCPReadResourceResult;
   }

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -26,6 +26,7 @@ import type {
   MCPServerSSEOptions,
 } from '../../mcp';
 import logger, {
+  getSafeErrorType,
   type Logger,
   logToolActionError,
   logToolActionWarning,
@@ -205,12 +206,23 @@ async function runMcpTransportOperation<T>(
   endpoint: string,
   operation: string,
   action: () => Promise<T>,
+  sourceSignal?: AbortSignal,
 ): Promise<T> {
   try {
     return await action();
   } catch (error) {
+    if (isCallerAbortReason(error, sourceSignal)) {
+      throw error;
+    }
     throw sanitizeMcpTransportError(error, endpoint, operation);
   }
+}
+
+function isCallerAbortReason(
+  error: unknown,
+  sourceSignal: AbortSignal | undefined,
+): boolean {
+  return sourceSignal?.aborted === true && error === sourceSignal.reason;
 }
 
 function logMcpTransportWarning(
@@ -220,10 +232,11 @@ function logMcpTransportWarning(
   message: string,
   error: unknown,
 ): void {
-  const logError = targetLogger.dontLogToolData
-    ? error
+  const redact = targetLogger.dontLogToolData;
+  const logError = redact
+    ? getSafeErrorType(error)
     : sanitizeMcpTransportError(error, endpoint, operation);
-  logToolActionWarning(targetLogger, message, logError);
+  targetLogger.warn(message, logError);
 }
 
 export class NodeMCPServerStdio extends BaseMCPServerStdio {
@@ -595,6 +608,7 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
             }),
           ),
         ),
+      options?.signal,
     );
     const parsed = CallToolResultSchema.parse(response);
     const result = attachParsedCallToolResultMetadata(parsed as CallToolResult);
@@ -1452,8 +1466,14 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
         options,
       );
     } catch (error) {
-      const recoveryStrategy =
-        await this.shouldReconnectClosedStreamableHttpClient(error, client);
+      if (isCallerAbortReason(error, options?.signal)) {
+        throw error;
+      }
+      const recoveryStrategy = await runMcpTransportOperation(
+        this.params.url,
+        'streamable HTTP tool call recovery classification',
+        () => this.shouldReconnectClosedStreamableHttpClient(error, client),
+      );
       if (recoveryStrategy === 'none') {
         throw sanitizeMcpTransportError(
           error,
@@ -1495,6 +1515,9 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
           options,
         );
       } catch (retryError) {
+        if (isCallerAbortReason(retryError, options?.signal)) {
+          throw retryError;
+        }
         throw sanitizeMcpTransportError(
           attachCause(retryError, error),
           this.params.url,

--- a/packages/agents-core/test/mcpLogging.test.ts
+++ b/packages/agents-core/test/mcpLogging.test.ts
@@ -27,17 +27,9 @@ describe('getMcpServerDiagnosticName', () => {
     );
   });
 
-  it.each(['', '/'])(
-    'redacts malformed HTTP userinfo with %j after the scheme',
-    (slashPrefix) => {
-      const malformedEndpoint = `https:${slashPrefix}${[
-        'user_marker',
-        'password_marker',
-      ].join(':')}@`;
-
-      expect(getMcpServerDiagnosticName(malformedEndpoint)).toBe(
-        '<redacted endpoint>',
-      );
-    },
-  );
+  it('fails closed for invalid URL-derived server names', () => {
+    expect(getMcpServerDiagnosticName('sse: not an absolute URL')).toBe(
+      'sse: <redacted endpoint>',
+    );
+  });
 });

--- a/packages/agents-core/test/mcpLogging.test.ts
+++ b/packages/agents-core/test/mcpLogging.test.ts
@@ -26,4 +26,18 @@ describe('getMcpServerDiagnosticName', () => {
       'diagnostic-server',
     );
   });
+
+  it.each(['', '/'])(
+    'redacts malformed HTTP userinfo with %j after the scheme',
+    (slashPrefix) => {
+      const malformedEndpoint = `https:${slashPrefix}${[
+        'user_marker',
+        'password_marker',
+      ].join(':')}@`;
+
+      expect(getMcpServerDiagnosticName(malformedEndpoint)).toBe(
+        '<redacted endpoint>',
+      );
+    },
+  );
 });

--- a/packages/agents-core/test/mcpServers.test.ts
+++ b/packages/agents-core/test/mcpServers.test.ts
@@ -93,6 +93,27 @@ class FailingConnectServer extends BaseTestServer {
   }
 }
 
+class FixedErrorConnectServer extends BaseTestServer {
+  constructor(
+    name: string,
+    readonly error: Error,
+  ) {
+    super(name);
+  }
+
+  async connect(): Promise<void> {
+    await super.connect();
+    throw this.error;
+  }
+}
+
+class HangingConnectServer extends BaseTestServer {
+  async connect(): Promise<void> {
+    await super.connect();
+    await new Promise<void>(() => {});
+  }
+}
+
 class AbortConnectServer extends BaseTestServer {
   async connect(): Promise<void> {
     await super.connect();
@@ -294,6 +315,61 @@ describe('MCPServers', () => {
       `Failed to connect MCP server '${serverName}':`,
       expect.any(Error),
     );
+  });
+
+  it('preserves arbitrary errors from custom MCP servers', async () => {
+    const error = new Error('custom server password_marker detail');
+    const server = new FixedErrorConnectServer('custom-server', error);
+
+    const session = await connectMcpServers([server], {
+      connectTimeoutMs: null,
+      closeTimeoutMs: null,
+    });
+
+    expect(session.errors.get(server)).toBe(error);
+  });
+
+  it('removes credentials from URL-derived lifecycle timeout errors', async () => {
+    const endpoint = new URL('https://example.test/mcp');
+    endpoint.username = 'user_marker';
+    endpoint.password = 'password_marker';
+    endpoint.searchParams.set('token', 'query_marker');
+    endpoint.hash = 'fragment_marker';
+    const server = new HangingConnectServer(
+      `streamable-http: ${endpoint.toString()}`,
+    );
+
+    const session = await connectMcpServers([server], {
+      connectTimeoutMs: 1,
+      closeTimeoutMs: null,
+    });
+
+    const error = session.errors.get(server);
+    expect(error?.message).toContain('https://example.test/mcp');
+    expect(error?.message).not.toContain('user_marker');
+    expect(error?.message).not.toContain('password_marker');
+    expect(error?.message).not.toContain('query_marker');
+    expect(error?.message).not.toContain('fragment_marker');
+    await session.close();
+  });
+
+  it('removes credentials from malformed URL-derived lifecycle errors', async () => {
+    const server = new HangingConnectServer(
+      `streamable-http: https://${['user_marker', 'password_marker'].join(
+        ':',
+      )}@`,
+    );
+
+    const session = await connectMcpServers([server], {
+      connectTimeoutMs: 1,
+      closeTimeoutMs: null,
+    });
+
+    const error = session.errors.get(server);
+    expect(error?.message).toContain('streamable-http: <redacted endpoint>');
+    expect(error?.message).not.toContain('user_marker');
+    expect(error?.message).not.toContain('password_marker');
+    await session.close();
   });
 
   it('reconnects failed servers only by default', async () => {

--- a/packages/agents-core/test/shims/mcp-server/node.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/node.test.ts
@@ -592,24 +592,31 @@ describe('NodeMCPServerSSE', () => {
     expectNoCredentialMarkers(logger.error.mock.calls);
   });
 
-  test('should remove credentials from malformed SSE endpoint errors and logs', async () => {
-    const logger = createCapturingLogger();
-    const malformedEndpoint = `https://${[
-      'user_marker',
-      'password_marker',
-    ].join(':')}@`;
-    const server = new NodeMCPServerSSE({
-      url: malformedEndpoint,
-      logger,
-    });
+  test.each([
+    ['without slashes', ''],
+    ['with one slash', '/'],
+    ['with two slashes', '//'],
+  ])(
+    'should remove credentials from malformed SSE endpoint errors and logs %s',
+    async (_label, slashPrefix) => {
+      const logger = createCapturingLogger();
+      const malformedEndpoint = `https:${slashPrefix}${[
+        'user_marker',
+        'password_marker',
+      ].join(':')}@`;
+      const server = new NodeMCPServerSSE({
+        url: malformedEndpoint,
+        logger,
+      });
 
-    const error = await server.connect().catch((caught) => caught);
+      const error = await server.connect().catch((caught) => caught);
 
-    expect(error).toMatchObject({ name: 'MCPTransportError' });
-    expect((error as Error).message).not.toContain(malformedEndpoint);
-    expectNoCredentialMarkers(error);
-    expectNoCredentialMarkers(logger.error.mock.calls);
-  });
+      expect(error).toMatchObject({ name: 'MCPTransportError' });
+      expect((error as Error).message).not.toContain(malformedEndpoint);
+      expectNoCredentialMarkers(error);
+      expectNoCredentialMarkers(logger.error.mock.calls);
+    },
+  );
 
   test.each([
     [

--- a/packages/agents-core/test/shims/mcp-server/node.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/node.test.ts
@@ -592,31 +592,27 @@ describe('NodeMCPServerSSE', () => {
     expectNoCredentialMarkers(logger.error.mock.calls);
   });
 
-  test.each([
-    ['without slashes', ''],
-    ['with one slash', '/'],
-    ['with two slashes', '//'],
-  ])(
-    'should remove credentials from malformed SSE endpoint errors and logs %s',
-    async (_label, slashPrefix) => {
-      const logger = createCapturingLogger();
-      const malformedEndpoint = `https:${slashPrefix}${[
-        'user_marker',
-        'password_marker',
-      ].join(':')}@`;
-      const server = new NodeMCPServerSSE({
-        url: malformedEndpoint,
-        logger,
-      });
+  test('should fail closed for invalid SSE endpoint errors and logs', async () => {
+    const logger = createCapturingLogger();
+    const invalidEndpoint = `//${['user_marker', 'password_marker'].join(
+      ':',
+    )}@example.test/mcp`;
+    const server = new NodeMCPServerSSE({
+      url: invalidEndpoint,
+      logger,
+    });
 
-      const error = await server.connect().catch((caught) => caught);
+    const error = await server.connect().catch((caught) => caught);
 
-      expect(error).toMatchObject({ name: 'MCPTransportError' });
-      expect((error as Error).message).not.toContain(malformedEndpoint);
-      expectNoCredentialMarkers(error);
-      expectNoCredentialMarkers(logger.error.mock.calls);
-    },
-  );
+    expect(error).toMatchObject({
+      name: 'MCPTransportError',
+      message:
+        'MCP SSE connect failed; configured endpoint was invalid and was redacted.',
+    });
+    expect((error as Error & { input?: unknown }).input).toBeUndefined();
+    expectNoCredentialMarkers(error);
+    expectNoCredentialMarkers(logger.error.mock.calls);
+  });
 
   test.each([
     [

--- a/packages/agents-core/test/shims/mcp-server/node.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/node.test.ts
@@ -805,9 +805,9 @@ describe('NodeMCPServerSSE', () => {
 
     const error = await server.connect().catch((caught) => caught);
 
+    expect(constructorReads).toBe(0);
     expect(error).not.toBe(unsafeError);
     expect(error).toMatchObject({ name: 'MCPTransportError' });
-    expect(constructorReads).toBe(0);
     expectNoCredentialMarkers(error);
     expectNoCredentialMarkers(logger.error.mock.calls);
   });
@@ -998,10 +998,16 @@ describe('NodeMCPServerStreamableHttp', () => {
 
     const error = await server.connect().catch((caught) => caught);
 
-    expect(error).toBe(safeError);
+    expect(error).not.toBe(safeError);
+    expect(error).toMatchObject({
+      name: 'MCPTransportError',
+      message:
+        'Streamable HTTP error: Server returned 401 after successful authentication',
+      code: 401,
+    });
     expect(logger.error).toHaveBeenCalledWith(
       'Error initializing MCP server:',
-      safeError,
+      error,
     );
   });
 

--- a/packages/agents-core/test/shims/mcp-server/node.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/node.test.ts
@@ -18,6 +18,7 @@ import { RunContext } from '../../../src/runContext';
 import { TransportSendOptions } from '@modelcontextprotocol/sdk/shared/transport';
 import { JSONRPCMessage } from '@modelcontextprotocol/sdk/types';
 import { DEFAULT_REQUEST_TIMEOUT_MSEC } from '@modelcontextprotocol/sdk/shared/protocol';
+import type { Logger } from '../../../src/logger';
 
 let lastConnectOptions: any;
 let lastListToolsOptions: any;
@@ -31,7 +32,84 @@ let lastReadResourceOptions: any;
 let lastReadResourceParams: any;
 let callToolImplementation:
   ((params: any, resultSchema: any, options: any) => Promise<any>) | undefined;
+let connectImplementation:
+  ((transport: any, options: any) => Promise<void>) | undefined;
+let listResourcesImplementation:
+  ((params: any, options: any) => Promise<any>) | undefined;
+let terminateSessionImplementation: (() => Promise<void>) | undefined;
 let retainCallToolSignalListener = false;
+
+const credentialEndpoint = new URL('https://example.test/mcp');
+credentialEndpoint.username = 'user_marker';
+credentialEndpoint.password = 'password_marker';
+credentialEndpoint.searchParams.set('token', 'query_marker');
+credentialEndpoint.hash = 'fragment_marker';
+const CREDENTIAL_ENDPOINT = credentialEndpoint.toString();
+const CREDENTIAL_MARKERS = [
+  'user_marker',
+  'password_marker',
+  'query_marker',
+  'fragment_marker',
+] as const;
+
+function createUnsafeTransportError(): Error {
+  const cause = new Error(`Nested failure for ${CREDENTIAL_ENDPOINT}`);
+  const error = new Error(
+    `Transport failed for ${CREDENTIAL_ENDPOINT}`,
+  ) as Error & { event: { message: string }; status: number };
+  Object.defineProperty(error, 'cause', {
+    value: cause,
+    configurable: true,
+    writable: true,
+  });
+  error.event = { message: `Event failed for ${CREDENTIAL_ENDPOINT}` };
+  error.status = 502;
+  return error;
+}
+
+function getErrorGraphText(value: unknown, seen = new Set<object>()): string {
+  if (
+    value === null ||
+    (typeof value !== 'object' && typeof value !== 'function')
+  ) {
+    return typeof value === 'string' ? value : '';
+  }
+  if (seen.has(value)) {
+    return '';
+  }
+  seen.add(value);
+
+  const values: string[] = [];
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  for (const key of Reflect.ownKeys(descriptors)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor) {
+      continue;
+    }
+    if ('value' in descriptor) {
+      values.push(getErrorGraphText(descriptor.value, seen));
+    }
+  }
+  return values.join('\n');
+}
+
+function expectNoCredentialMarkers(value: unknown): void {
+  const graph = getErrorGraphText(value);
+  for (const marker of CREDENTIAL_MARKERS) {
+    expect(graph).not.toContain(marker);
+  }
+}
+
+function createCapturingLogger() {
+  return {
+    namespace: 'openai-agents:test:mcp-transport-redaction',
+    debug: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    dontLogModelData: false as boolean,
+    dontLogToolData: false as boolean,
+  } satisfies Logger;
+}
 
 beforeEach(() => {
   lastConnectOptions = undefined;
@@ -45,6 +123,9 @@ beforeEach(() => {
   lastReadResourceOptions = undefined;
   lastReadResourceParams = undefined;
   callToolImplementation = undefined;
+  connectImplementation = undefined;
+  listResourcesImplementation = undefined;
+  terminateSessionImplementation = undefined;
   retainCallToolSignalListener = false;
 });
 
@@ -310,6 +391,9 @@ class MockClient {
   }
   connect(_transport: any, options?: any): Promise<void> {
     lastConnectOptions = options;
+    if (connectImplementation) {
+      return connectImplementation(_transport, options);
+    }
     return Promise.resolve();
   }
   listTools(_params?: any, options?: any): Promise<any> {
@@ -345,6 +429,9 @@ class MockClient {
   listResources(params?: any, options?: any): Promise<any> {
     lastListResourcesParams = params;
     lastListResourcesOptions = options;
+    if (listResourcesImplementation) {
+      return listResourcesImplementation(params, options);
+    }
     return Promise.resolve({
       resources: [
         {
@@ -482,6 +569,249 @@ describe('NodeMCPServerSSE', () => {
     await server.close();
   });
 
+  test('should remove endpoint credentials from SSE connect errors and logs', async () => {
+    const logger = createCapturingLogger();
+    const unsafeError = createUnsafeTransportError();
+    connectImplementation = async () => {
+      throw unsafeError;
+    };
+    const server = new NodeMCPServerSSE({
+      url: CREDENTIAL_ENDPOINT,
+      logger,
+    });
+
+    const error = await server.connect().catch((caught) => caught);
+
+    expect(error).not.toBe(unsafeError);
+    expect(error).toMatchObject({
+      name: 'MCPTransportError',
+      status: 502,
+    });
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+    expectNoCredentialMarkers(error);
+    expectNoCredentialMarkers(logger.error.mock.calls);
+  });
+
+  test('should remove credentials from malformed SSE endpoint errors and logs', async () => {
+    const logger = createCapturingLogger();
+    const malformedEndpoint = `https://${[
+      'user_marker',
+      'password_marker',
+    ].join(':')}@`;
+    const server = new NodeMCPServerSSE({
+      url: malformedEndpoint,
+      logger,
+    });
+
+    const error = await server.connect().catch((caught) => caught);
+
+    expect(error).toMatchObject({ name: 'MCPTransportError' });
+    expect((error as Error).message).not.toContain(malformedEndpoint);
+    expectNoCredentialMarkers(error);
+    expectNoCredentialMarkers(logger.error.mock.calls);
+  });
+
+  test.each([
+    [
+      'symbol field',
+      () => {
+        const error = new Error('opaque transport failure');
+        Object.defineProperty(error, Symbol('details'), {
+          value: CREDENTIAL_ENDPOINT,
+        });
+        return error;
+      },
+    ],
+    [
+      'custom prototype',
+      () =>
+        Object.assign(Object.create({ details: CREDENTIAL_ENDPOINT }), {
+          message: 'opaque transport failure',
+        }),
+    ],
+    [
+      'Map field',
+      () =>
+        Object.assign(new Error('opaque transport failure'), {
+          details: new Map([['endpoint', CREDENTIAL_ENDPOINT]]),
+        }),
+    ],
+  ])('should replace SSE errors with an opaque %s', async (_label, factory) => {
+    const logger = createCapturingLogger();
+    const opaqueError = factory();
+    connectImplementation = async () => {
+      throw opaqueError;
+    };
+    const server = new NodeMCPServerSSE({
+      url: CREDENTIAL_ENDPOINT,
+      logger,
+    });
+
+    const error = await server.connect().catch((caught) => caught);
+
+    expect(error).not.toBe(opaqueError);
+    expect(error).toMatchObject({ name: 'MCPTransportError' });
+    expectNoCredentialMarkers(error);
+    expectNoCredentialMarkers(logger.error.mock.calls);
+  });
+
+  test('should not inspect accessor-backed SSE error fields', async () => {
+    const logger = createCapturingLogger();
+    const errorWithAccessor = new Error('opaque transport failure');
+    let accessorReads = 0;
+    Object.defineProperty(errorWithAccessor, 'details', {
+      configurable: true,
+      enumerable: true,
+      get: () => {
+        accessorReads += 1;
+        return CREDENTIAL_ENDPOINT;
+      },
+    });
+    connectImplementation = async () => {
+      throw errorWithAccessor;
+    };
+    const server = new NodeMCPServerSSE({
+      url: CREDENTIAL_ENDPOINT,
+      logger,
+    });
+
+    const error = await server.connect().catch((caught) => caught);
+
+    expect(error).toMatchObject({ name: 'MCPTransportError' });
+    expect(accessorReads).toBe(0);
+    expectNoCredentialMarkers(error);
+    expectNoCredentialMarkers(logger.error.mock.calls);
+  });
+
+  test('should replace opaque revoked proxy errors without inspecting them', async () => {
+    const logger = createCapturingLogger();
+    const { proxy, revoke } = Proxy.revocable(createUnsafeTransportError(), {});
+    revoke();
+    connectImplementation = async () => {
+      throw proxy;
+    };
+    const server = new NodeMCPServerSSE({
+      url: CREDENTIAL_ENDPOINT,
+      logger,
+    });
+
+    const error = await server.connect().catch((caught) => caught);
+
+    expect(error).toMatchObject({ name: 'MCPTransportError' });
+    expectNoCredentialMarkers(error);
+    expectNoCredentialMarkers(logger.error.mock.calls);
+  });
+
+  test('should redact DOMException details while preserving abort semantics', async () => {
+    const logger = createCapturingLogger();
+    const unsafeAbort = new DOMException(CREDENTIAL_ENDPOINT, 'AbortError');
+    connectImplementation = async () => {
+      throw unsafeAbort;
+    };
+    const server = new NodeMCPServerSSE({
+      url: CREDENTIAL_ENDPOINT,
+      logger,
+    });
+
+    const error = await server.connect().catch((caught) => caught);
+
+    expect(error).toMatchObject({ name: 'AbortError', code: 20 });
+    expectNoCredentialMarkers(error);
+    expectNoCredentialMarkers(logger.error.mock.calls);
+  });
+
+  test('should preserve prototype-backed abort semantics', async () => {
+    class PrototypeAbortError extends Error {}
+    Object.defineProperty(PrototypeAbortError.prototype, 'name', {
+      value: 'AbortError',
+    });
+    const logger = createCapturingLogger();
+    const unsafeAbort = new PrototypeAbortError(CREDENTIAL_ENDPOINT);
+    connectImplementation = async () => {
+      throw unsafeAbort;
+    };
+    const server = new NodeMCPServerSSE({
+      url: CREDENTIAL_ENDPOINT,
+      logger,
+    });
+
+    const error = await server.connect().catch((caught) => caught);
+
+    expect(error).toMatchObject({ name: 'AbortError' });
+    expectNoCredentialMarkers(error);
+    expectNoCredentialMarkers(logger.error.mock.calls);
+  });
+
+  test('should remove short query credentials embedded in error messages', async () => {
+    const logger = createCapturingLogger();
+    const endpoint = new URL('https://example.test/mcp');
+    endpoint.searchParams.set('token', 'abc');
+    const unsafeError = new Error('token abc was rejected');
+    connectImplementation = async () => {
+      throw unsafeError;
+    };
+    const server = new NodeMCPServerSSE({
+      url: endpoint.toString(),
+      logger,
+    });
+
+    const error = await server.connect().catch((caught) => caught);
+
+    expect(error).not.toBe(unsafeError);
+    expect(error).toMatchObject({ name: 'MCPTransportError' });
+    expect((error as Error).message).not.toContain('abc');
+    expectNoCredentialMarkers(logger.error.mock.calls);
+  });
+
+  test('should remove endpoint credentials stored only in a custom stack', async () => {
+    const logger = createCapturingLogger();
+    const unsafeError = new Error('safe transport failure');
+    unsafeError.stack = 'password_marker';
+    connectImplementation = async () => {
+      throw unsafeError;
+    };
+    const server = new NodeMCPServerSSE({
+      url: CREDENTIAL_ENDPOINT,
+      logger,
+    });
+
+    const error = await server.connect().catch((caught) => caught);
+
+    expect(error).not.toBe(unsafeError);
+    expect(error).toMatchObject({ name: 'MCPTransportError' });
+    expectNoCredentialMarkers(error);
+    expectNoCredentialMarkers(logger.error.mock.calls);
+  });
+
+  test('should replace Error subclasses with custom constructors', async () => {
+    class CustomConstructorError extends Error {}
+    let constructorReads = 0;
+    Object.defineProperty(CustomConstructorError.prototype, 'constructor', {
+      configurable: true,
+      get: () => {
+        constructorReads += 1;
+        return CREDENTIAL_ENDPOINT;
+      },
+    });
+    const logger = createCapturingLogger();
+    const unsafeError = new CustomConstructorError('safe transport failure');
+    connectImplementation = async () => {
+      throw unsafeError;
+    };
+    const server = new NodeMCPServerSSE({
+      url: CREDENTIAL_ENDPOINT,
+      logger,
+    });
+
+    const error = await server.connect().catch((caught) => caught);
+
+    expect(error).not.toBe(unsafeError);
+    expect(error).toMatchObject({ name: 'MCPTransportError' });
+    expect(constructorReads).toBe(0);
+    expectNoCredentialMarkers(error);
+    expectNoCredentialMarkers(logger.error.mock.calls);
+  });
+
   test('should pass request options to session calls', async () => {
     const server = new NodeMCPServerSSE({
       url: 'https://example.com/sse',
@@ -603,6 +933,9 @@ class MockStreamableHTTPClientTransport {
   }
 
   terminateSession(): Promise<void> {
+    if (terminateSessionImplementation) {
+      return terminateSessionImplementation();
+    }
     return this.terminateSessionMock();
   }
 }
@@ -645,6 +978,130 @@ describe('NodeMCPServerStreamableHttp', () => {
     expect(lastConnectOptions?.timeout).toBe(8000);
 
     await server.close();
+  });
+
+  test('should preserve safe streamable HTTP status errors', async () => {
+    const logger = createCapturingLogger();
+    const safeError = Object.assign(
+      new Error(
+        'Streamable HTTP error: Server returned 401 after successful authentication',
+      ),
+      { code: 401 },
+    );
+    connectImplementation = async () => {
+      throw safeError;
+    };
+    const server = new NodeMCPServerStreamableHttp({
+      url: 'https://example.test/mcp?version=1',
+      logger,
+    });
+
+    const error = await server.connect().catch((caught) => caught);
+
+    expect(error).toBe(safeError);
+    expect(logger.error).toHaveBeenCalledWith(
+      'Error initializing MCP server:',
+      safeError,
+    );
+  });
+
+  test('should remove endpoint credentials from resource errors', async () => {
+    const logger = createCapturingLogger();
+    const unsafeError = createUnsafeTransportError();
+    const server = new NodeMCPServerStreamableHttp({
+      url: CREDENTIAL_ENDPOINT,
+      logger,
+    });
+    await server.connect();
+    listResourcesImplementation = async () => {
+      throw unsafeError;
+    };
+
+    const error = await server.listResources().catch((caught) => caught);
+
+    expect(error).not.toBe(unsafeError);
+    expect(error).toMatchObject({
+      name: 'MCPTransportError',
+      status: 502,
+    });
+    expectNoCredentialMarkers(error);
+    await server.close();
+  });
+
+  test('should remove endpoint credentials from tool-call error graphs', async () => {
+    const logger = createCapturingLogger();
+    const unsafeError = createUnsafeTransportError();
+    const server = new NodeMCPServerStreamableHttp({
+      url: CREDENTIAL_ENDPOINT,
+      logger,
+    });
+    await server.connect();
+    callToolImplementation = async () => {
+      throw unsafeError;
+    };
+
+    const error = await server
+      .callTool('unsafe-tool', {})
+      .catch((caught) => caught);
+
+    expect(error).not.toBe(unsafeError);
+    expect(error).toMatchObject({
+      name: 'MCPTransportError',
+      status: 502,
+    });
+    expectNoCredentialMarkers(error);
+    await server.close();
+  });
+
+  test('should remove endpoint credentials from cleanup warnings', async () => {
+    const logger = createCapturingLogger();
+    const server = new NodeMCPServerStreamableHttp({
+      url: CREDENTIAL_ENDPOINT,
+      logger,
+    });
+    await server.connect();
+    terminateSessionImplementation = async () => {
+      throw createUnsafeTransportError();
+    };
+
+    await server.close();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Failed to terminate MCP session:',
+      expect.objectContaining({
+        name: 'MCPTransportError',
+        status: 502,
+      }),
+    );
+    expectNoCredentialMarkers(logger.warn.mock.calls);
+  });
+
+  test('should not inspect cleanup errors when tool logging is disabled', async () => {
+    const logger = createCapturingLogger();
+    logger.dontLogToolData = true;
+    const server = new NodeMCPServerStreamableHttp({
+      url: CREDENTIAL_ENDPOINT,
+      logger,
+    });
+    await server.connect();
+    let ownKeysReads = 0;
+    const error = new Proxy(new Error('opaque cleanup failure'), {
+      ownKeys(target) {
+        ownKeysReads += 1;
+        return Reflect.ownKeys(target);
+      },
+    });
+    terminateSessionImplementation = async () => {
+      throw error;
+    };
+
+    await server.close();
+
+    expect(ownKeysReads).toBe(0);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Failed to terminate MCP session:',
+      'object',
+    );
   });
 
   test('should forward request options to session methods', async () => {

--- a/packages/agents-core/test/shims/mcp-server/node.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/node.test.ts
@@ -19,6 +19,8 @@ import { TransportSendOptions } from '@modelcontextprotocol/sdk/shared/transport
 import { JSONRPCMessage } from '@modelcontextprotocol/sdk/types';
 import { DEFAULT_REQUEST_TIMEOUT_MSEC } from '@modelcontextprotocol/sdk/shared/protocol';
 import type { Logger } from '../../../src/logger';
+import { connectMcpServers } from '../../../src/mcpServers';
+import { allowConsole } from '../../../../../helpers/tests/console-guard';
 
 let lastConnectOptions: any;
 let lastListToolsOptions: any;
@@ -583,10 +585,8 @@ describe('NodeMCPServerSSE', () => {
     const error = await server.connect().catch((caught) => caught);
 
     expect(error).not.toBe(unsafeError);
-    expect(error).toMatchObject({
-      name: 'MCPTransportError',
-      status: 502,
-    });
+    expect(error).toMatchObject({ name: 'MCPTransportError' });
+    expect((error as Error & { status?: number }).status).toBeUndefined();
     expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
     expectNoCredentialMarkers(error);
     expectNoCredentialMarkers(logger.error.mock.calls);
@@ -715,7 +715,8 @@ describe('NodeMCPServerSSE', () => {
 
     const error = await server.connect().catch((caught) => caught);
 
-    expect(error).toMatchObject({ name: 'AbortError', code: 20 });
+    expect(error).toMatchObject({ name: 'AbortError' });
+    expect((error as Error & { code?: number }).code).toBeUndefined();
     expectNoCredentialMarkers(error);
     expectNoCredentialMarkers(logger.error.mock.calls);
   });
@@ -742,26 +743,71 @@ describe('NodeMCPServerSSE', () => {
     expectNoCredentialMarkers(logger.error.mock.calls);
   });
 
-  test('should remove short query credentials embedded in error messages', async () => {
-    const logger = createCapturingLogger();
-    const endpoint = new URL('https://example.test/mcp');
-    endpoint.searchParams.set('token', 'abc');
-    const unsafeError = new Error('token abc was rejected');
-    connectImplementation = async () => {
-      throw unsafeError;
-    };
-    const server = new NodeMCPServerSSE({
-      url: endpoint.toString(),
-      logger,
-    });
+  test.each(['ABORT_ERR', 'ERR_ABORTED'] as const)(
+    'should preserve manager abort semantics for %s',
+    async (code) => {
+      const logger = createCapturingLogger();
+      const abortError = Object.assign(new Error('request cancelled'), {
+        code,
+      });
+      connectImplementation = async () => {
+        throw abortError;
+      };
+      const server = new NodeMCPServerSSE({
+        url: CREDENTIAL_ENDPOINT,
+        logger,
+      });
+      allowConsole(['error']);
 
-    const error = await server.connect().catch((caught) => caught);
+      const session = await connectMcpServers([server], {
+        strict: true,
+        suppressAbortError: true,
+      });
 
-    expect(error).not.toBe(unsafeError);
-    expect(error).toMatchObject({ name: 'MCPTransportError' });
-    expect((error as Error).message).not.toContain('abc');
-    expectNoCredentialMarkers(logger.error.mock.calls);
-  });
+      expect(session.errors.get(server)).toMatchObject({
+        name: 'AbortError',
+      });
+      expect(
+        (session.errors.get(server) as (Error & { code?: string }) | undefined)
+          ?.code,
+      ).toBeUndefined();
+      expectNoCredentialMarkers(session.errors.get(server));
+      await session.close();
+    },
+  );
+
+  test.each([
+    ['Error message', 'abc', () => new Error('ERR_abc_INVALID')],
+    ['thrown string', 'abc', () => 'ERR_abc_INVALID'],
+    ['thrown number', '123', () => 123],
+    [
+      'numeric status field',
+      '123',
+      () => Object.assign(new Error('safe failure'), { status: 123 }),
+    ],
+  ])(
+    'should replace a transport %s for a short query credential',
+    async (_label, credential, factory) => {
+      const logger = createCapturingLogger();
+      const endpoint = new URL('https://example.test/mcp');
+      endpoint.searchParams.set('token', credential);
+      const unsafeError = factory();
+      connectImplementation = async () => {
+        throw unsafeError;
+      };
+      const server = new NodeMCPServerSSE({
+        url: endpoint.toString(),
+        logger,
+      });
+
+      const error = await server.connect().catch((caught) => caught);
+
+      expect(error).not.toBe(unsafeError);
+      expect(error).toMatchObject({ name: 'MCPTransportError' });
+      expect((error as Error).message).not.toContain(credential);
+      expect(JSON.stringify(logger.error.mock.calls)).not.toContain(credential);
+    },
+  );
 
   test('should remove endpoint credentials stored only in a custom stack', async () => {
     const logger = createCapturingLogger();
@@ -832,6 +878,38 @@ describe('NodeMCPServerSSE', () => {
     expect(lastCallToolOptions?.signal).toBeDefined();
     expect(lastCallToolOptions?.signal).not.toBe(controller.signal);
 
+    await server.close();
+  });
+
+  test('should preserve caller cancellation on credentialed endpoints', async () => {
+    let markCallStarted: (() => void) | undefined;
+    const callStarted = new Promise<void>((resolve) => {
+      markCallStarted = resolve;
+    });
+    callToolImplementation = async (_params, _resultSchema, options) => {
+      markCallStarted?.();
+      return new Promise((_, reject) => {
+        options.signal.addEventListener(
+          'abort',
+          () => reject(new Error('MCP SDK wrapped cancellation')),
+          { once: true },
+        );
+      });
+    };
+    const server = new NodeMCPServerSSE({
+      url: CREDENTIAL_ENDPOINT,
+    });
+    await server.connect();
+    const controller = new AbortController();
+    const abortReason = new Error('caller cancelled');
+
+    const pendingCall = server.callTool('mock-tool', {}, undefined, {
+      signal: controller.signal,
+    });
+    await callStarted;
+    controller.abort(abortReason);
+
+    await expect(pendingCall).rejects.toBe(abortReason);
     await server.close();
   });
 
@@ -980,7 +1058,7 @@ describe('NodeMCPServerStreamableHttp', () => {
     await server.close();
   });
 
-  test('should preserve safe streamable HTTP status errors', async () => {
+  test('should not copy numeric streamable HTTP status diagnostics', async () => {
     const logger = createCapturingLogger();
     const safeError = Object.assign(
       new Error(
@@ -1002,9 +1080,9 @@ describe('NodeMCPServerStreamableHttp', () => {
     expect(error).toMatchObject({
       name: 'MCPTransportError',
       message:
-        'Streamable HTTP error: Server returned 401 after successful authentication',
-      code: 401,
+        'MCP streamable HTTP connect failed for https://example.test/mcp; configured endpoint credentials were redacted.',
     });
+    expect((error as Error & { code?: number }).code).toBeUndefined();
     expect(logger.error).toHaveBeenCalledWith(
       'Error initializing MCP server:',
       error,
@@ -1026,10 +1104,8 @@ describe('NodeMCPServerStreamableHttp', () => {
     const error = await server.listResources().catch((caught) => caught);
 
     expect(error).not.toBe(unsafeError);
-    expect(error).toMatchObject({
-      name: 'MCPTransportError',
-      status: 502,
-    });
+    expect(error).toMatchObject({ name: 'MCPTransportError' });
+    expect((error as Error & { status?: number }).status).toBeUndefined();
     expectNoCredentialMarkers(error);
     await server.close();
   });
@@ -1051,10 +1127,35 @@ describe('NodeMCPServerStreamableHttp', () => {
       .catch((caught) => caught);
 
     expect(error).not.toBe(unsafeError);
-    expect(error).toMatchObject({
-      name: 'MCPTransportError',
-      status: 502,
+    expect(error).toMatchObject({ name: 'MCPTransportError' });
+    expect((error as Error & { status?: number }).status).toBeUndefined();
+    expectNoCredentialMarkers(error);
+    await server.close();
+  });
+
+  test('should sanitize errors thrown during recovery classification', async () => {
+    const logger = createCapturingLogger();
+    const server = new NodeMCPServerStreamableHttp({
+      url: CREDENTIAL_ENDPOINT,
+      logger,
     });
+    await server.connect();
+    const classificationInput = new Error('placeholder');
+    Object.defineProperty(classificationInput, 'message', {
+      configurable: true,
+      get: () => {
+        throw new Error(CREDENTIAL_ENDPOINT);
+      },
+    });
+    callToolImplementation = async () => {
+      throw classificationInput;
+    };
+
+    const error = await server
+      .callTool('unsafe-tool', {})
+      .catch((caught) => caught);
+
+    expect(error).toMatchObject({ name: 'MCPTransportError' });
     expectNoCredentialMarkers(error);
     await server.close();
   });
@@ -1076,22 +1177,30 @@ describe('NodeMCPServerStreamableHttp', () => {
       'Failed to terminate MCP session:',
       expect.objectContaining({
         name: 'MCPTransportError',
-        status: 502,
       }),
     );
+    const loggedError = logger.warn.mock.calls[0]?.[1] as
+      (Error & { status?: number }) | undefined;
+    expect(loggedError?.status).toBeUndefined();
     expectNoCredentialMarkers(logger.warn.mock.calls);
   });
 
   test('should not inspect cleanup errors when tool logging is disabled', async () => {
     const logger = createCapturingLogger();
-    logger.dontLogToolData = true;
     const server = new NodeMCPServerStreamableHttp({
       url: CREDENTIAL_ENDPOINT,
       logger,
     });
     await server.connect();
+    let policyReads = 0;
+    Object.defineProperty(logger, 'dontLogToolData', {
+      get: () => {
+        policyReads += 1;
+        return policyReads === 1;
+      },
+    });
     let ownKeysReads = 0;
-    const error = new Proxy(new Error('opaque cleanup failure'), {
+    const error = new Proxy(createUnsafeTransportError(), {
       ownKeys(target) {
         ownKeysReads += 1;
         return Reflect.ownKeys(target);
@@ -1103,11 +1212,13 @@ describe('NodeMCPServerStreamableHttp', () => {
 
     await server.close();
 
+    expect(policyReads).toBe(1);
     expect(ownKeysReads).toBe(0);
     expect(logger.warn).toHaveBeenCalledWith(
       'Failed to terminate MCP session:',
       'object',
     );
+    expectNoCredentialMarkers(logger.warn.mock.calls);
   });
 
   test('should forward request options to session methods', async () => {
@@ -1133,7 +1244,7 @@ describe('NodeMCPServerStreamableHttp', () => {
     await server.close();
   });
 
-  test('should not reconnect after caller cancellation', async () => {
+  test('should preserve caller cancellation on credentialed endpoints without reconnecting', async () => {
     let markCallStarted: (() => void) | undefined;
     const callStarted = new Promise<void>((resolve) => {
       markCallStarted = resolve;
@@ -1149,7 +1260,7 @@ describe('NodeMCPServerStreamableHttp', () => {
       });
     };
     const server = new NodeMCPServerStreamableHttp({
-      url: 'https://example.com/stream',
+      url: CREDENTIAL_ENDPOINT,
       name: 'cancel-without-reconnect',
     });
     await server.connect();


### PR DESCRIPTION
This pull request prevents MCP SSE and Streamable HTTP failures from retaining credential-bearing endpoint URLs in returned errors, manager state, or diagnostic logs. It safely handles malformed URLs and opaque error shapes, preserves status and cancellation diagnostics where supported, and leaves stdio and custom MCP server errors unchanged.