### PR TITLE
fix: redact MCP URL credentials from external metadata

### DIFF
--- a/.changeset/redact-mcp-external-metadata.md
+++ b/.changeset/redact-mcp-external-metadata.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: redact MCP URL credentials from external metadata

--- a/docs/src/content/docs/guides/mcp.mdx
+++ b/docs/src/content/docs/guides/mcp.mdx
@@ -154,6 +154,7 @@ Notes:
 - When `errorFunction` is unset, the SDK uses the default tool error formatter.
 - Server-level `errorFunction` values override `Agent.mcpConfig.errorFunction` for that server.
 - `includeServerInToolNames` is opt-in. When enabled, each local MCP tool is exposed to the model with a deterministic server-prefixed name, which helps avoid collisions when multiple MCP servers publish tools with the same name.
+- If distinct URL-derived server names become identical after credentials, query parameters, and fragments are removed and they publish the same tool name, configuration fails before the model request. Set explicit, unique, non-secret `name` values for those servers.
 
 ## 2. Streamable HTTP MCP servers
 

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -31,7 +31,7 @@ import type {
   MCPToolMetaContext,
   MCPToolMetaResolver,
 } from './mcpUtil';
-import { getMcpServerDiagnosticName } from './mcpLogging';
+import { getMcpServerExternalName } from './mcpLogging';
 import type { RunContext } from './runContext';
 import type { Agent } from './agent';
 import { maybeExtractToolOutputCustomData } from './utils/customData';
@@ -521,7 +521,7 @@ async function getMcpToolsFromServer<TContext = UnknownContext>({
             if (!filtered) {
               logMcpToolFilterDebug(
                 () =>
-                  `MCP Tool (server: ${getMcpServerDiagnosticName(server.name)}, tool: ${tool.name}) is blocked by the callable filter.`,
+                  `MCP Tool (server: ${getMcpServerExternalName(server.name)}, tool: ${tool.name}) is blocked by the callable filter.`,
               );
               continue;
             }
@@ -541,12 +541,12 @@ async function getMcpToolsFromServer<TContext = UnknownContext>({
                 if (blocked) {
                   logMcpToolFilterDebug(
                     () =>
-                      `MCP Tool (server: ${getMcpServerDiagnosticName(server.name)}, tool: ${tool.name}) is blocked by the static filter.`,
+                      `MCP Tool (server: ${getMcpServerExternalName(server.name)}, tool: ${tool.name}) is blocked by the static filter.`,
                   );
                 } else if (!allowed) {
                   logMcpToolFilterDebug(
                     () =>
-                      `MCP Tool (server: ${getMcpServerDiagnosticName(server.name)}, tool: ${tool.name}) is not allowed by the static filter.`,
+                      `MCP Tool (server: ${getMcpServerExternalName(server.name)}, tool: ${tool.name}) is not allowed by the static filter.`,
                   );
                 }
                 continue;
@@ -580,7 +580,7 @@ async function getMcpToolsFromServer<TContext = UnknownContext>({
   return withMCPListToolsSpan(
     listToolsForServer,
     {
-      data: { server: server.name },
+      data: { server: getMcpServerExternalName(server.name) },
     },
     tracingParent,
   );
@@ -914,17 +914,19 @@ function buildPrefixedToolNameOverrides(
 ): Map<string, string> {
   const baseNameCounts = new Map<string, number>();
   for (const { server, mcpTools } of serverToolBatches) {
+    const serverName = getMcpServerExternalName(server.name);
     for (const mcpTool of mcpTools) {
-      const baseName = buildPrefixedToolBaseName(server.name, mcpTool.name);
+      const baseName = buildPrefixedToolBaseName(serverName, mcpTool.name);
       baseNameCounts.set(baseName, (baseNameCounts.get(baseName) ?? 0) + 1);
     }
   }
 
   const candidates: PrefixedToolNameCandidate[] = [];
   for (const { server, serverIndex, mcpTools } of serverToolBatches) {
+    const serverName = getMcpServerExternalName(server.name);
     mcpTools.forEach((mcpTool, toolIndex) => {
-      const baseName = buildPrefixedToolBaseName(server.name, mcpTool.name);
-      const seed = `${server.name}\0${mcpTool.name}`;
+      const baseName = buildPrefixedToolBaseName(serverName, mcpTool.name);
+      const seed = `${serverName}\0${mcpTool.name}`;
       const forceHash =
         (baseNameCounts.get(baseName) ?? 0) > 1 || reservedNames.has(baseName);
       candidates.push({
@@ -1039,7 +1041,9 @@ export function mcpToFunctionTool(
     const currentSpan =
       getToolCallParentSpanFromDetails(details) ?? getCurrentSpan();
     if (currentSpan) {
-      currentSpan.spanData['mcp_data'] = { server: server.name };
+      currentSpan.spanData['mcp_data'] = {
+        server: getMcpServerExternalName(server.name),
+      };
     }
     const meta = runContext
       ? await resolveMcpToolMeta(server, runContext, mcpTool.name, args)

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -922,11 +922,22 @@ function buildPrefixedToolNameOverrides(
   }
 
   const candidates: PrefixedToolNameCandidate[] = [];
+  const rawServerNamesBySeed = new Map<string, string>();
   for (const { server, serverIndex, mcpTools } of serverToolBatches) {
     const serverName = getMcpServerExternalName(server.name);
     mcpTools.forEach((mcpTool, toolIndex) => {
       const baseName = buildPrefixedToolBaseName(serverName, mcpTool.name);
       const seed = `${serverName}\0${mcpTool.name}`;
+      const previousRawServerName = rawServerNamesBySeed.get(seed);
+      if (
+        previousRawServerName !== undefined &&
+        previousRawServerName !== server.name
+      ) {
+        throw new UserError(
+          `MCP server names are indistinguishable after URL redaction for tool '${mcpTool.name}': '${serverName}'. Configure unique safe server names when includeServerInToolNames is enabled.`,
+        );
+      }
+      rawServerNamesBySeed.set(seed, server.name);
       const forceHash =
         (baseNameCounts.get(baseName) ?? 0) > 1 || reservedNames.has(baseName);
       candidates.push({

--- a/packages/agents-core/src/mcpLogging.ts
+++ b/packages/agents-core/src/mcpLogging.ts
@@ -119,14 +119,18 @@ export function getMcpServerExternalName(name: string): string {
     name.startsWith(candidate),
   );
   const candidate = prefix ? name.slice(prefix.length) : name;
-  const url = parseHttpUrl(candidate);
-  if (url) {
+  const redactionInfo = getEndpointRedactionInfo(candidate);
+  if (!redactionInfo) {
+    return name;
+  }
+  if (redactionInfo.kind === 'sensitive') {
+    const url = redactionInfo.url;
     return `${prefix ?? ''}${url.protocol}//${url.host}${url.pathname}`;
   }
   if (prefix) {
     return `${prefix}${INVALID_URL_DERIVED_NAME}`;
   }
-  if (/^https?:\/\//i.test(candidate)) {
+  if (/^https?:\/\//i.test(candidate.trimStart())) {
     return INVALID_URL_DERIVED_NAME;
   }
   return name;

--- a/packages/agents-core/src/mcpLogging.ts
+++ b/packages/agents-core/src/mcpLogging.ts
@@ -1,4 +1,5 @@
 const URL_DERIVED_NAME_PREFIXES = ['sse: ', 'streamable-http: '] as const;
+const INVALID_URL_DERIVED_NAME = '<redacted endpoint>';
 const MAX_PROTOTYPE_DEPTH = 8;
 const DOM_EXCEPTION_PROTOTYPE =
   typeof DOMException === 'undefined' ? undefined : DOMException.prototype;
@@ -110,10 +111,10 @@ function collectCancellationName(value: object): CancellationName | undefined {
 }
 
 // Some transports use their full endpoint URL as the default server name.
-// In diagnostic mode, preserve ordinary names while removing URL credentials,
-// query parameters, and fragments. Redacted logging must use a fixed label
-// without reading the server name at all.
-export function getMcpServerDiagnosticName(name: string): string {
+// Preserve ordinary names while removing URL credentials, query parameters,
+// and fragments from external surfaces. Redacted logging must use a fixed
+// label without reading the server name at all.
+export function getMcpServerExternalName(name: string): string {
   const prefix = URL_DERIVED_NAME_PREFIXES.find((candidate) =>
     name.startsWith(candidate),
   );
@@ -123,7 +124,10 @@ export function getMcpServerDiagnosticName(name: string): string {
     return `${prefix ?? ''}${url.protocol}//${url.host}${url.pathname}`;
   }
   if (prefix) {
-    return `${prefix ?? ''}<redacted endpoint>`;
+    return `${prefix}${INVALID_URL_DERIVED_NAME}`;
+  }
+  if (/^https?:\/\//i.test(candidate)) {
+    return INVALID_URL_DERIVED_NAME;
   }
   return name;
 }

--- a/packages/agents-core/src/mcpServers.ts
+++ b/packages/agents-core/src/mcpServers.ts
@@ -1,6 +1,6 @@
 import { getLogger, logToolActionDebug, logToolActionError } from './logger';
 import type { MCPServer } from './mcp';
-import { getMcpServerDiagnosticName } from './mcpLogging';
+import { getMcpServerExternalName } from './mcpLogging';
 
 const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
 const DEFAULT_CLOSE_TIMEOUT_MS = 10_000;
@@ -11,7 +11,7 @@ function getMcpServerLogLabel(server: MCPServer): string {
   if (logger.dontLogToolData) {
     return 'MCP server';
   }
-  return `MCP server '${getMcpServerDiagnosticName(server.name)}'`;
+  return `MCP server '${getMcpServerExternalName(server.name)}'`;
 }
 
 type ServerAction = 'connect' | 'close';
@@ -457,7 +457,7 @@ export class MCPServers {
           throw error;
         }
         throw new Error(
-          `Failed to connect MCP server '${getMcpServerDiagnosticName(firstFailure.name)}'.`,
+          `Failed to connect MCP server '${getMcpServerExternalName(firstFailure.name)}'.`,
         );
       }
     }
@@ -507,7 +507,7 @@ function createTimeoutError(
     return new Error(`MCP server ${action} timed out.`);
   }
   const error = new Error(
-    `MCP server ${action} timed out after ${timeoutMs}ms for '${getMcpServerDiagnosticName(server.name)}'.`,
+    `MCP server ${action} timed out after ${timeoutMs}ms for '${getMcpServerExternalName(server.name)}'.`,
   );
   error.name = 'TimeoutError';
   return error;
@@ -515,7 +515,7 @@ function createTimeoutError(
 
 function createClosedError(server: MCPServer): Error {
   const error = new Error(
-    `MCP server '${getMcpServerDiagnosticName(server.name)}' is closed.`,
+    `MCP server '${getMcpServerExternalName(server.name)}' is closed.`,
   );
   error.name = 'ClosedError';
   return error;
@@ -523,7 +523,7 @@ function createClosedError(server: MCPServer): Error {
 
 function createClosingError(server: MCPServer): Error {
   const error = new Error(
-    `MCP server '${getMcpServerDiagnosticName(server.name)}' is closing.`,
+    `MCP server '${getMcpServerExternalName(server.name)}' is closing.`,
   );
   error.name = 'ClosingError';
   return error;

--- a/packages/agents-core/test/mcpCache.test.ts
+++ b/packages/agents-core/test/mcpCache.test.ts
@@ -430,6 +430,115 @@ describe('MCP tools uniqueness', () => {
     });
   });
 
+  it('redacts URL credentials from prefixed tool names while dispatching the original tool name', async () => {
+    const endpoint = new URL(
+      'https://example.test:8443/mcp?token=URL_QUERY#URL_FRAGMENT',
+    );
+    endpoint.username = 'URL_USER';
+    endpoint.password = 'URL_PASSWORD';
+    const rawServerName = `streamable-http: ${endpoint.toString()}`;
+    const server = new StubServer(rawServerName, [
+      {
+        name: 'search',
+        description: '',
+        inputSchema: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+        },
+      },
+    ]);
+    server.cacheToolsList = false;
+    const callTool = vi.fn(async () => [{ type: 'text', text: 'ok' }]);
+    server.callTool = callTool;
+
+    const tools = (await getAllMcpTools({
+      mcpServers: [server],
+      includeServerInToolNames: true,
+    })) as FunctionTool[];
+
+    expect(tools).toHaveLength(1);
+    expect(tools[0].name).toContain('example_test_8443_mcp');
+    for (const secret of [
+      'URL_USER',
+      'URL_PASSWORD',
+      'URL_QUERY',
+      'URL_FRAGMENT',
+    ]) {
+      expect(tools[0].name).not.toContain(secret);
+    }
+
+    await tools[0].invoke(
+      new RunContext({}),
+      JSON.stringify({ query: 'agents' }),
+    );
+    expect(callTool).toHaveBeenCalledWith('search', { query: 'agents' });
+    expect(server.name).toBe(rawServerName);
+  });
+
+  it('allocates sanitized URL-derived tool name collisions deterministically', async () => {
+    async function getNames(): Promise<string[]> {
+      const endpointA = new URL(
+        'https://example.test/mcp?token=QUERY_A#FRAGMENT_A',
+      );
+      endpointA.username = 'USER_A';
+      endpointA.password = 'PASSWORD_A';
+      const endpointB = new URL(
+        'https://example.test/mcp?token=QUERY_B#FRAGMENT_B',
+      );
+      endpointB.username = 'USER_B';
+      endpointB.password = 'PASSWORD_B';
+      const serverA = new StubServer(
+        `streamable-http: ${endpointA.toString()}`,
+        [
+          {
+            name: 'search',
+            description: '',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+      );
+      const serverB = new StubServer(
+        `streamable-http: ${endpointB.toString()}`,
+        [
+          {
+            name: 'search',
+            description: '',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+      );
+      serverA.cacheToolsList = false;
+      serverB.cacheToolsList = false;
+
+      const tools = await getAllMcpTools({
+        mcpServers: [serverA, serverB],
+        includeServerInToolNames: true,
+      });
+      return tools.map((candidate) => candidate.name);
+    }
+
+    const first = await getNames();
+    const second = await getNames();
+
+    expect(first).toEqual(second);
+    expect(new Set(first).size).toBe(2);
+    expect(first.every((name) => name.startsWith('mcp_streamable_http'))).toBe(
+      true,
+    );
+    for (const secret of [
+      'USER_A',
+      'PASSWORD_A',
+      'QUERY_A',
+      'FRAGMENT_A',
+      'USER_B',
+      'PASSWORD_B',
+      'QUERY_B',
+      'FRAGMENT_B',
+    ]) {
+      expect(JSON.stringify(first)).not.toContain(secret);
+    }
+  });
+
   it('sanitizes non-ASCII MCP server and tool names before prefixing', async () => {
     await withTrace('test', async () => {
       const server = new StubServer('天気サーバー', [

--- a/packages/agents-core/test/mcpCache.test.ts
+++ b/packages/agents-core/test/mcpCache.test.ts
@@ -475,56 +475,56 @@ describe('MCP tools uniqueness', () => {
     expect(server.name).toBe(rawServerName);
   });
 
-  it('allocates sanitized URL-derived tool name collisions deterministically', async () => {
-    async function getNames(): Promise<string[]> {
-      const endpointA = new URL(
-        'https://example.test/mcp?token=QUERY_A#FRAGMENT_A',
-      );
-      endpointA.username = 'USER_A';
-      endpointA.password = 'PASSWORD_A';
-      const endpointB = new URL(
-        'https://example.test/mcp?token=QUERY_B#FRAGMENT_B',
-      );
-      endpointB.username = 'USER_B';
-      endpointB.password = 'PASSWORD_B';
-      const serverA = new StubServer(
-        `streamable-http: ${endpointA.toString()}`,
-        [
-          {
-            name: 'search',
-            description: '',
-            inputSchema: { type: 'object', properties: {} },
-          },
-        ],
-      );
-      const serverB = new StubServer(
-        `streamable-http: ${endpointB.toString()}`,
-        [
-          {
-            name: 'search',
-            description: '',
-            inputSchema: { type: 'object', properties: {} },
-          },
-        ],
-      );
-      serverA.cacheToolsList = false;
-      serverB.cacheToolsList = false;
+  it('rejects URL-derived server names that collide after redaction', async () => {
+    const endpointA = new URL(
+      'https://example.test/mcp?token=QUERY_A#FRAGMENT_A',
+    );
+    endpointA.username = 'USER_A';
+    endpointA.password = 'PASSWORD_A';
+    const endpointB = new URL(
+      'https://example.test/mcp?token=QUERY_B#FRAGMENT_B',
+    );
+    endpointB.username = 'USER_B';
+    endpointB.password = 'PASSWORD_B';
+    const rawServerNames = [
+      `streamable-http: ${endpointA.toString()}`,
+      `streamable-http: ${endpointB.toString()}`,
+    ];
 
-      const tools = await getAllMcpTools({
-        mcpServers: [serverA, serverB],
-        includeServerInToolNames: true,
+    async function getCollisionError(serverNames: string[]): Promise<Error> {
+      const servers = serverNames.map((name) => {
+        const server = new StubServer(name, [
+          {
+            name: 'search',
+            description: '',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ]);
+        server.cacheToolsList = false;
+        return server;
       });
-      return tools.map((candidate) => candidate.name);
+
+      try {
+        await getAllMcpTools({
+          mcpServers: servers,
+          includeServerInToolNames: true,
+        });
+      } catch (error) {
+        expect(error).toBeInstanceOf(UserError);
+        return error as Error;
+      }
+      throw new Error('Expected sanitized MCP server name collision.');
     }
 
-    const first = await getNames();
-    const second = await getNames();
-
-    expect(first).toEqual(second);
-    expect(new Set(first).size).toBe(2);
-    expect(first.every((name) => name.startsWith('mcp_streamable_http'))).toBe(
-      true,
+    const forwardError = await getCollisionError(rawServerNames);
+    const reversedError = await getCollisionError(
+      [...rawServerNames].reverse(),
     );
+    const expectedMessage =
+      "MCP server names are indistinguishable after URL redaction for tool 'search': 'streamable-http: https://example.test/mcp'. Configure unique safe server names when includeServerInToolNames is enabled.";
+
+    expect(forwardError.message).toBe(expectedMessage);
+    expect(reversedError.message).toBe(expectedMessage);
     for (const secret of [
       'USER_A',
       'PASSWORD_A',
@@ -535,7 +535,8 @@ describe('MCP tools uniqueness', () => {
       'QUERY_B',
       'FRAGMENT_B',
     ]) {
-      expect(JSON.stringify(first)).not.toContain(secret);
+      expect(forwardError.message).not.toContain(secret);
+      expect(reversedError.message).not.toContain(secret);
     }
   });
 

--- a/packages/agents-core/test/mcpCache.test.ts
+++ b/packages/agents-core/test/mcpCache.test.ts
@@ -475,6 +475,30 @@ describe('MCP tools uniqueness', () => {
     expect(server.name).toBe(rawServerName);
   });
 
+  it('preserves credential-free URL spelling in prefixed tool names', async () => {
+    const server = new StubServer(
+      'streamable-http: https://EXAMPLE.test:443/mcp',
+      [
+        {
+          name: 'search',
+          description: '',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ],
+    );
+    server.cacheToolsList = false;
+
+    const tools = await getAllMcpTools({
+      mcpServers: [server],
+      includeServerInToolNames: true,
+    });
+
+    expect(tools).toHaveLength(1);
+    expect(tools[0].name).toBe(
+      'mcp_streamable_http__https___EXAMPLE_test_443_mcp__search',
+    );
+  });
+
   it('rejects URL-derived server names that collide after redaction', async () => {
     const endpointA = new URL(
       'https://example.test/mcp?token=QUERY_A#FRAGMENT_A',

--- a/packages/agents-core/test/mcpLogging.test.ts
+++ b/packages/agents-core/test/mcpLogging.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { getMcpServerDiagnosticName } from '../src/mcpLogging';
+import { getMcpServerExternalName } from '../src/mcpLogging';
 
-describe('getMcpServerDiagnosticName', () => {
+describe('getMcpServerExternalName', () => {
   it('removes credentials, query strings, and fragments from URL-derived names', () => {
     const credentialedUrl = new URL(
       'https://example.test:8443/mcp?token=secret#fragment',
@@ -10,26 +10,42 @@ describe('getMcpServerDiagnosticName', () => {
     credentialedUrl.password = 'password';
 
     expect(
-      getMcpServerDiagnosticName(
+      getMcpServerExternalName(
         `streamable-http: ${credentialedUrl.toString()}`,
       ),
     ).toBe('streamable-http: https://example.test:8443/mcp');
     expect(
-      getMcpServerDiagnosticName(
+      getMcpServerExternalName(
         'sse: https://example.test/events?api_key=secret',
       ),
     ).toBe('sse: https://example.test/events');
   });
 
   it('preserves ordinary server names', () => {
-    expect(getMcpServerDiagnosticName('diagnostic-server')).toBe(
+    expect(getMcpServerExternalName('diagnostic-server')).toBe(
       'diagnostic-server',
     );
   });
 
   it('fails closed for invalid URL-derived server names', () => {
-    expect(getMcpServerDiagnosticName('sse: not an absolute URL')).toBe(
+    expect(getMcpServerExternalName('sse: not an absolute URL')).toBe(
       'sse: <redacted endpoint>',
+    );
+    const invalidCredentialedUrl = ['https://', 'user:password', '@'].join('');
+    expect(getMcpServerExternalName(invalidCredentialedUrl)).toBe(
+      '<redacted endpoint>',
+    );
+  });
+
+  it('sanitizes direct HTTP URLs and preserves IPv6 hosts, ports, and paths', () => {
+    const credentialedUrl = new URL(
+      'https://[2001:db8::1]:8443/mcp?token=secret#fragment',
+    );
+    credentialedUrl.username = 'user';
+    credentialedUrl.password = 'password';
+
+    expect(getMcpServerExternalName(credentialedUrl.toString())).toBe(
+      'https://[2001:db8::1]:8443/mcp',
     );
   });
 });

--- a/packages/agents-core/test/mcpLogging.test.ts
+++ b/packages/agents-core/test/mcpLogging.test.ts
@@ -27,12 +27,29 @@ describe('getMcpServerExternalName', () => {
     );
   });
 
+  it('preserves the exact spelling of credential-free HTTP URLs', () => {
+    const prefixedName = 'streamable-http: https://EXAMPLE.test:443/mcp';
+    const directName = 'https://EXAMPLE.test:443/mcp';
+
+    expect(getMcpServerExternalName(prefixedName)).toBe(prefixedName);
+    expect(getMcpServerExternalName(directName)).toBe(directName);
+  });
+
   it('fails closed for invalid URL-derived server names', () => {
     expect(getMcpServerExternalName('sse: not an absolute URL')).toBe(
       'sse: <redacted endpoint>',
     );
     const invalidCredentialedUrl = ['https://', 'user:password', '@'].join('');
     expect(getMcpServerExternalName(invalidCredentialedUrl)).toBe(
+      '<redacted endpoint>',
+    );
+    const whitespacePrefixedInvalidUrl = [
+      ' ',
+      'https://',
+      'user:password',
+      '@',
+    ].join('');
+    expect(getMcpServerExternalName(whitespacePrefixedInvalidUrl)).toBe(
       '<redacted endpoint>',
     );
   });

--- a/packages/agents-core/test/mcpToFunctionTool.test.ts
+++ b/packages/agents-core/test/mcpToFunctionTool.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { mcpToFunctionTool, MCPServer } from '../src/mcp';
 import type { MCPToolMetaContext } from '../src/mcpUtil';
 import { RunContext } from '../src/runContext';
+import { sanitizeMcpTransportError } from '../src/mcpLogging';
 import { withTrace } from '../src/tracing';
 import { withCustomSpan } from '../src/tracing/createSpans';
 import { getCurrentSpan } from '../src/tracing';
@@ -401,6 +402,12 @@ describe('mcpToFunctionTool', () => {
   });
 
   it('resolves and passes MCP tool metadata', async () => {
+    const endpoint = new URL(
+      'https://example.test/mcp?token=META_QUERY#META_FRAGMENT',
+    );
+    endpoint.username = 'META_USER';
+    endpoint.password = 'META_PASSWORD';
+    const rawServerName = `streamable-http: ${endpoint.toString()}`;
     const callTool = vi.fn(
       async (
         _toolName: string,
@@ -418,7 +425,7 @@ describe('mcpToFunctionTool', () => {
     });
 
     const server: MCPServer = {
-      name: 'stub',
+      name: rawServerName,
       cacheToolsList: false,
       toolMetaResolver,
       connect: async () => {},
@@ -454,7 +461,7 @@ describe('mcpToFunctionTool', () => {
     expect(toolMetaResolver).toHaveBeenCalledTimes(1);
     const metaContext = toolMetaResolver.mock.calls[0][0];
     expect(metaContext.runContext).toBe(runContext);
-    expect(metaContext.serverName).toBe('stub');
+    expect(metaContext.serverName).toBe(rawServerName);
     expect(metaContext.toolName).toBe('meta');
     expect(metaContext.arguments).toEqual({ foo: 'bar' });
   });
@@ -602,6 +609,56 @@ describe('mcpToFunctionTool', () => {
     expect(callTool).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps URL credentials out of the default model-visible MCP error', async () => {
+    const endpointUrl = new URL(
+      'https://example.test:8443/mcp?token=ERROR_QUERY#ERROR_FRAGMENT',
+    );
+    endpointUrl.username = 'ERROR_USER';
+    endpointUrl.password = 'ERROR_PASSWORD';
+    const endpoint = endpointUrl.toString();
+    const server: MCPServer = {
+      name: `streamable-http: ${endpoint}`,
+      cacheToolsList: false,
+      connect: async () => {},
+      close: async () => {},
+      listTools: async () => [],
+      callTool: async () => {
+        throw sanitizeMcpTransportError(
+          new Error(`request failed for ${endpoint}`),
+          endpoint,
+          'streamable HTTP tool call',
+        );
+      },
+      invalidateToolsCache: async () => {},
+    };
+    const tool = mcpToFunctionTool(
+      {
+        name: 'safe_error',
+        description: '',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      } as any,
+      server,
+      false,
+    );
+
+    const result = await tool.invoke(new RunContext({}), '{}');
+
+    expect(result).toContain('https://example.test:8443/mcp');
+    for (const secret of [
+      'ERROR_USER',
+      'ERROR_PASSWORD',
+      'ERROR_QUERY',
+      'ERROR_FRAGMENT',
+    ]) {
+      expect(result).not.toContain(secret);
+    }
+  });
+
   it('rethrows tool failures when server errorFunction is null', async () => {
     const callTool = vi.fn(async () => {
       throw new Error('boom');
@@ -709,8 +766,14 @@ describe('mcpToFunctionTool', () => {
   });
 
   it('annotates the current span when invoking the tool', async () => {
+    const endpoint = new URL(
+      'https://example.test:8443/mcp?token=SPAN_QUERY#SPAN_FRAGMENT',
+    );
+    endpoint.username = 'SPAN_USER';
+    endpoint.password = 'SPAN_PASSWORD';
+    const rawServerName = `streamable-http: ${endpoint.toString()}`;
     const server: MCPServer = {
-      name: 'annotated',
+      name: rawServerName,
       cacheToolsList: false,
       connect: async () => {},
       close: async () => {},
@@ -746,8 +809,9 @@ describe('mcpToFunctionTool', () => {
           );
           expect(result).toEqual({ type: 'text', text: '{"foo":"bar"}' });
           expect(getCurrentSpan()?.spanData.mcp_data).toEqual({
-            server: 'annotated',
+            server: 'streamable-http: https://example.test:8443/mcp',
           });
+          expect(server.name).toBe(rawServerName);
         },
         { data: { name: 'span' } },
       );

--- a/packages/agents-core/test/taskTurnTracing.test.ts
+++ b/packages/agents-core/test/taskTurnTracing.test.ts
@@ -13,6 +13,7 @@ import {
   Usage,
   createAgentSpan,
   createGenerationSpan,
+  getAllMcpTools,
   getGlobalTraceProvider,
   handoff,
   retryPolicies,
@@ -1253,6 +1254,85 @@ describe('runner task and turn tracing', () => {
       });
     }
   });
+
+  it.each([true, false])(
+    'redacts MCP URL credentials from spans and RunState when traceIncludeSensitiveData=%s',
+    async (traceIncludeSensitiveData) => {
+      const endpoint = new URL(
+        'https://example.test:8443/mcp?token=TRACE_QUERY#TRACE_FRAGMENT',
+      );
+      endpoint.username = 'TRACE_USER';
+      endpoint.password = 'TRACE_PASSWORD';
+      const rawServerName = `streamable-http: ${endpoint.toString()}`;
+      const safeServerName = 'streamable-http: https://example.test:8443/mcp';
+      const server: MCPServer = {
+        name: rawServerName,
+        cacheToolsList: false,
+        connect: async () => {},
+        close: async () => {},
+        invalidateToolsCache: async () => {},
+        listTools: async () => [
+          {
+            name: 'search',
+            description: 'Search documentation.',
+            inputSchema: {
+              type: 'object',
+              properties: { input: { type: 'string' } },
+              required: ['input'],
+              additionalProperties: false,
+            },
+          } as MCPTool,
+        ],
+        callTool: async () => [{ type: 'text', text: 'ok' }],
+      };
+      const [preparedTool] = await getAllMcpTools({
+        mcpServers: [server],
+        includeServerInToolNames: true,
+      });
+      expect(preparedTool).toBeDefined();
+      const agent = new Agent({
+        name: 'MCP URL redaction agent',
+        model: new FakeModel([
+          agentToolCallResponse(preparedTool!.name),
+          responseWithoutUsage(),
+        ]),
+        mcpServers: [server],
+        mcpConfig: { includeServerInToolNames: true },
+      });
+
+      const result = await new Runner({ traceIncludeSensitiveData }).run(
+        agent,
+        'hello',
+      );
+
+      const mcpSpan = processor.spansEnded.find(
+        (span) => span.spanData.type === 'mcp_tools',
+      );
+      const functionSpan = processor.spansEnded.find(
+        (span) => span.spanData.type === 'function',
+      );
+      expect(mcpSpan?.spanData.server).toBe(safeServerName);
+      expect(functionSpan?.spanData).toMatchObject({
+        mcp_data: { server: safeServerName },
+      });
+      expect(server.name).toBe(rawServerName);
+
+      const serializedExternalData = JSON.stringify({
+        spans: processor.spansEnded.map((span) => span.toJSON()),
+        state: result.state.toJSON(),
+        toolName: preparedTool!.name,
+      });
+      expect(serializedExternalData).toContain('example.test:8443');
+      for (const secret of [
+        'TRACE_USER',
+        'TRACE_PASSWORD',
+        'TRACE_QUERY',
+        'TRACE_FRAGMENT',
+      ]) {
+        expect(serializedExternalData).not.toContain(secret);
+      }
+    },
+  );
 
   it('captures distinct external trace parents for concurrent runs on a shared runner', async () => {
     setTracingContextStorage(new BrowserAsyncLocalStorage());

--- a/packages/agents-core/test/taskTurnTracing.test.ts
+++ b/packages/agents-core/test/taskTurnTracing.test.ts
@@ -1317,9 +1317,14 @@ describe('runner task and turn tracing', () => {
       });
       expect(server.name).toBe(rawServerName);
 
+      const restoredState = await RunState.fromString(
+        agent,
+        result.state.toString(),
+      );
       const serializedExternalData = JSON.stringify({
         spans: processor.spansEnded.map((span) => span.toJSON()),
         state: result.state.toJSON(),
+        restoredState: restoredState.toJSON(),
         toolName: preparedTool!.name,
       });
       expect(serializedExternalData).toContain('example.test:8443');

--- a/packages/agents-core/test/toolCustomData.test.ts
+++ b/packages/agents-core/test/toolCustomData.test.ts
@@ -136,6 +136,13 @@ describe('tool output customData', () => {
   });
 
   it('maps local MCP result metadata to tool output customData', async () => {
+    const endpoint = new URL(
+      'https://example.test/mcp?token=CUSTOM_QUERY#CUSTOM_FRAGMENT',
+    );
+    endpoint.username = 'CUSTOM_USER';
+    endpoint.password = 'CUSTOM_PASSWORD';
+    const rawServerName = `streamable-http: ${endpoint.toString()}`;
+    let capturedServerName: string | undefined;
     const model = new RecordingModel([
       {
         output: [
@@ -155,14 +162,17 @@ describe('tool output customData', () => {
       },
     ]);
     const server: MCPServer = {
-      name: 'meta-server',
+      name: rawServerName,
       cacheToolsList: false,
-      customDataExtractor: (context) => ({
-        responseMeta: context.resultMeta,
-        structuredContent: context.structuredContent,
-        isError: context.isError,
-        output: context.toolOutput,
-      }),
+      customDataExtractor: (context) => {
+        capturedServerName = context.serverName;
+        return {
+          responseMeta: context.resultMeta,
+          structuredContent: context.structuredContent,
+          isError: context.isError,
+          output: context.toolOutput,
+        };
+      },
       connect: async () => {},
       close: async () => {},
       listTools: async () => [],
@@ -213,6 +223,16 @@ describe('tool output customData', () => {
     expect(modelInput).toContain('mcp result');
     expect(modelInput).not.toContain('rows');
     expect(modelInput).not.toContain('customData');
+    expect(capturedServerName).toBe(rawServerName);
+    const serializedState = result.state.toString();
+    for (const secret of [
+      'CUSTOM_USER',
+      'CUSTOM_PASSWORD',
+      'CUSTOM_QUERY',
+      'CUSTOM_FRAGMENT',
+    ]) {
+      expect(serializedState).not.toContain(secret);
+    }
   });
 
   it('attaches computer tool customData', async () => {


### PR DESCRIPTION
This pull request prevents credentials, query parameters, and fragments from MCP server URLs from appearing in SDK-owned traces, serialized run state, diagnostics, and model-visible tool names. It preserves raw server identity for callbacks, caching, and MCP tool dispatch while constructing credential-bearing test URLs at runtime to avoid secret-scanner false positives.