### PR TITLE
fix: reject ephemeral paths during sandbox archive hydration

### DIFF
--- a/.changeset/protect-ephemeral-archives.md
+++ b/.changeset/protect-ephemeral-archives.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: reject ephemeral manifest paths during sandbox archive hydration

--- a/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
@@ -29,8 +29,10 @@ import {
 } from '@openai/agents-core/sandbox';
 import {
   assertTarWorkspacePersistence,
+  createEmptyWorkspaceTarArchive,
   toWorkspaceArchiveBytes,
   validateWorkspaceTarArchive,
+  workspaceTarProtectedPaths,
 } from '../shared/archive';
 import { RemoteSandboxEditor } from '../shared/editor';
 import {
@@ -567,10 +569,11 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
 
   async persistWorkspace(): Promise<Uint8Array> {
     assertTarWorkspacePersistence('CloudflareSandboxClient', 'tar');
-    const excludes = [...this.state.manifest.ephemeralPersistencePaths()]
-      .filter((path) => path.length > 0)
-      .sort((left, right) => left.localeCompare(right))
-      .join(',');
+    const protectedPaths = workspaceTarProtectedPaths(this.state.manifest);
+    if (protectedPaths.includes('')) {
+      return createEmptyWorkspaceTarArchive();
+    }
+    const excludes = protectedPaths.join(',');
     const response = await this.fetch(
       `/v1/sandbox/${this.state.sandboxId}/persist${
         excludes ? `?excludes=${encodeURIComponent(excludes)}` : ''
@@ -605,6 +608,7 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
     const archive = toWorkspaceArchiveBytes(data);
     validateWorkspaceTarArchive(archive, {
       allowExternalSymlinkTargets: false,
+      rejectRelPaths: workspaceTarProtectedPaths(this.state.manifest),
       archiveLimits:
         options.archiveLimits === undefined
           ? this.archiveLimits

--- a/packages/agents-extensions/src/sandbox/shared/archive.ts
+++ b/packages/agents-extensions/src/sandbox/shared/archive.ts
@@ -736,14 +736,19 @@ function parsePaxPayload(payload: Uint8Array): Record<string, string> {
       throw tarError('<pax>', 'invalid PAX record framing');
     }
 
+    let key: string;
+    let value: string;
     try {
       const decoder = new TextDecoder('utf-8', { fatal: true });
-      const key = decoder.decode(payload.subarray(space + 1, equals));
-      const value = decoder.decode(payload.subarray(equals + 1, recordEnd - 1));
-      values[key] = value;
+      key = decoder.decode(payload.subarray(space + 1, equals));
+      value = decoder.decode(payload.subarray(equals + 1, recordEnd - 1));
     } catch {
       throw tarError('<pax>', 'invalid UTF-8 in PAX record');
     }
+    if (key.includes('\0') || value.includes('\0')) {
+      throw tarError('<pax>', 'NUL byte in PAX record');
+    }
+    values[key] = value;
 
     offset = recordEnd;
   }

--- a/packages/agents-extensions/src/sandbox/shared/archive.ts
+++ b/packages/agents-extensions/src/sandbox/shared/archive.ts
@@ -66,6 +66,11 @@ export async function persistRemoteWorkspaceTar(args: {
   const archivePath = args.archivePath ?? remoteArchivePath(args.providerName);
   assertRemoteWorkspaceTarRoot(args.providerName, root, archivePath, 'persist');
 
+  const protectedPaths = workspaceTarProtectedPaths(args.manifest);
+  if (protectedPaths.includes('')) {
+    return createEmptyWorkspaceTarArchive();
+  }
+
   await validateRemoteSandboxPathForManifest({
     manifest: args.manifest,
     path: root,
@@ -137,6 +142,7 @@ export async function hydrateRemoteWorkspaceTar(args: {
   const archive = toWorkspaceArchiveBytes(args.data);
   validateWorkspaceTarArchive(archive, {
     allowSymlinks: false,
+    rejectRelPaths: workspaceTarProtectedPaths(args.manifest),
     archiveLimits: args.archiveLimits,
   });
 
@@ -247,11 +253,26 @@ export function validateWorkspaceTarArchive(
       }
       offset += Math.ceil(size / TAR_BLOCK_SIZE) * TAR_BLOCK_SIZE;
 
-      if (rawType === 'x') {
-        pendingPax = parsePaxPayload(payload);
-        continue;
-      }
-      if (rawType === 'g') {
+      if (rawType === 'x' || rawType === 'g') {
+        const pax = parsePaxPayload(payload);
+        if (pax['GNU.sparse.name'] !== undefined) {
+          throw tarError(
+            readTarString(header, 0, 100),
+            'PAX GNU.sparse.name override not allowed',
+          );
+        }
+        if (rawType === 'x') {
+          pendingPax = pax;
+          continue;
+        }
+        for (const key of ['path', 'linkpath'] as const) {
+          if (pax[key] !== undefined) {
+            throw tarError(
+              readTarString(header, 0, 100),
+              `global PAX ${key} override not allowed`,
+            );
+          }
+        }
         continue;
       }
       if (rawType === 'L') {
@@ -363,13 +384,22 @@ export function toWorkspaceArchiveBytes(
 }
 
 export function workspaceTarExcludeArgs(manifest: Manifest): string[] {
-  return [...manifest.ephemeralPersistencePaths()]
+  return workspaceTarProtectedPaths(manifest)
     .filter((path) => path.length > 0)
-    .sort((left, right) => left.localeCompare(right))
     .map(
       (path) =>
         `--exclude=${shellQuote(`./${path.replace(/([*?[\]\\])/gu, '\\$1')}`)}`,
     );
+}
+
+export function workspaceTarProtectedPaths(manifest: Manifest): string[] {
+  return [...manifest.ephemeralPersistencePaths()].sort((left, right) =>
+    left.localeCompare(right),
+  );
+}
+
+export function createEmptyWorkspaceTarArchive(): Uint8Array {
+  return new Uint8Array(TAR_BLOCK_SIZE * 2);
 }
 
 type TarMember = {
@@ -658,25 +688,58 @@ function normalizePosixPathWithoutRoot(path: string): string[] | null {
 }
 
 function parsePaxPayload(payload: Uint8Array): Record<string, string> {
-  const text = decodeBytes(payload);
-  const values: Record<string, string> = {};
+  const values: Record<string, string> = Object.create(null);
   let offset = 0;
-  while (offset < text.length) {
-    const space = text.indexOf(' ', offset);
+  while (offset < payload.byteLength) {
+    const space = payload.indexOf(0x20, offset);
     if (space === -1) {
-      break;
+      throw tarError('<pax>', 'invalid PAX record length');
     }
-    const length = Number(text.slice(offset, space));
-    if (!Number.isInteger(length) || length <= 0) {
-      break;
+    if (space === offset) {
+      throw tarError('<pax>', 'invalid PAX record length');
     }
-    const record = text.slice(space + 1, offset + length);
-    const trimmed = record.endsWith('\n') ? record.slice(0, -1) : record;
-    const equals = trimmed.indexOf('=');
-    if (equals > 0) {
-      values[trimmed.slice(0, equals)] = trimmed.slice(equals + 1);
+
+    let length = 0;
+    for (let index = offset; index < space; index += 1) {
+      const digit = payload[index] - 0x30;
+      if (digit < 0 || digit > 9) {
+        throw tarError('<pax>', 'invalid PAX record length');
+      }
+      length = length * 10 + digit;
+      if (!Number.isSafeInteger(length)) {
+        throw tarError('<pax>', 'invalid PAX record length');
+      }
     }
-    offset += length;
+
+    const recordEnd = offset + length;
+    if (recordEnd > payload.byteLength) {
+      throw tarError('<pax>', 'PAX record exceeds payload');
+    }
+    if (recordEnd < space + 4 || payload[recordEnd - 1] !== 0x0a) {
+      throw tarError('<pax>', 'invalid PAX record framing');
+    }
+
+    let equals = -1;
+    for (let index = space + 1; index < recordEnd - 1; index += 1) {
+      if (payload[index] === 0x3d) {
+        equals = index;
+        break;
+      }
+    }
+    if (equals <= space + 1) {
+      throw tarError('<pax>', 'invalid PAX record framing');
+    }
+
+    try {
+      const decoder = new TextDecoder('utf-8', { fatal: true });
+      const key = decoder.decode(payload.subarray(space + 1, equals));
+      const value = decoder.decode(payload.subarray(equals + 1, recordEnd - 1));
+      values[key] = value;
+    } catch {
+      throw tarError('<pax>', 'invalid UTF-8 in PAX record');
+    }
+
+    offset = recordEnd;
   }
   return values;
 }

--- a/packages/agents-extensions/src/sandbox/shared/archive.ts
+++ b/packages/agents-extensions/src/sandbox/shared/archive.ts
@@ -255,6 +255,12 @@ export function validateWorkspaceTarArchive(
 
       if (rawType === 'x' || rawType === 'g') {
         const pax = parsePaxPayload(payload);
+        if (pax.size !== undefined) {
+          throw tarError(
+            readTarString(header, 0, 100),
+            'PAX size override not allowed',
+          );
+        }
         if (pax['GNU.sparse.name'] !== undefined) {
           throw tarError(
             readTarString(header, 0, 100),

--- a/packages/agents-extensions/test/sandbox/cloudflare.test.ts
+++ b/packages/agents-extensions/test/sandbox/cloudflare.test.ts
@@ -1822,6 +1822,60 @@ describe('CloudflareSandboxClient', () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
+  test('rejects ephemeral paths before hydrating workspace archives', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+    const session = await client.resume({
+      manifest: new Manifest({
+        entries: {
+          logs: { type: 'dir', ephemeral: true },
+        },
+      }),
+      workerUrl: 'https://worker.example.com',
+      sandboxId: 'cf_test',
+      environment: {},
+    });
+    vi.mocked(global.fetch).mockClear();
+
+    await expect(
+      session.hydrateWorkspace(
+        makeTarArchive([
+          { name: 'logs/events.jsonl', content: 'persisted log' },
+        ]),
+      ),
+    ).rejects.toMatchObject({
+      details: {
+        reason: 'archive member overlaps protected path: logs',
+      },
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('persists an empty tar when the workspace root is ephemeral', async () => {
+    const client = new CloudflareSandboxClient({
+      workerUrl: 'https://worker.example.com',
+    });
+    const session = await client.resume({
+      manifest: new Manifest({
+        entries: {
+          '': { type: 'dir', ephemeral: true },
+        },
+      }),
+      workerUrl: 'https://worker.example.com',
+      sandboxId: 'cf_test',
+      environment: {},
+    });
+    vi.mocked(global.fetch).mockClear();
+
+    await expect(session.persistWorkspace()).resolves.toEqual(
+      makeTarArchive([]),
+    );
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
   test('rejects unsupported manifest metadata during resume', async () => {
     const client = new CloudflareSandboxClient({
       workerUrl: 'https://worker.example.com',

--- a/packages/agents-extensions/test/sandbox/e2b.test.ts
+++ b/packages/agents-extensions/test/sandbox/e2b.test.ts
@@ -1035,27 +1035,7 @@ describe('E2BSandboxClient', () => {
     expect(createSnapshotMock).not.toHaveBeenCalled();
   });
 
-  test('falls back to tar snapshots when the workspace root is ephemeral', async () => {
-    const archive = makeTarArchive([{ name: 'keep.txt', content: 'keep' }]);
-    runMock.mockImplementation(async (command: string) => {
-      const resolvedPath = resolvedRemotePathFromValidationCommand(command);
-      if (resolvedPath) {
-        return {
-          stdout: `${resolvedPath}\n`,
-          stderr: '',
-          exitCode: 0,
-        };
-      }
-      const archivePath = command.match(/-cf '([^']+)'/)?.[1];
-      if (archivePath) {
-        files.set(archivePath, archive);
-      }
-      return {
-        stdout: '',
-        stderr: '',
-        exitCode: 0,
-      };
-    });
+  test('persists an empty tar when the workspace root is ephemeral', async () => {
     const client = new E2BSandboxClient({
       workspacePersistence: 'snapshot',
     });
@@ -1069,9 +1049,13 @@ describe('E2BSandboxClient', () => {
         },
       }),
     );
+    runMock.mockClear();
 
-    await expect(session.persistWorkspace()).resolves.toEqual(archive);
+    await expect(session.persistWorkspace()).resolves.toEqual(
+      makeTarArchive([]),
+    );
     expect(createSnapshotMock).not.toHaveBeenCalled();
+    expect(runMock).not.toHaveBeenCalled();
   });
 
   test('resolves configured exposed ports through E2B hosts', async () => {

--- a/packages/agents-extensions/test/sandbox/modal.test.ts
+++ b/packages/agents-extensions/test/sandbox/modal.test.ts
@@ -645,6 +645,37 @@ describe('ModalSandboxClient', () => {
     expect(sandboxFilesystemWriteBytesMock).not.toHaveBeenCalled();
   });
 
+  test('rejects ephemeral paths before tar hydration side effects', async () => {
+    const client = new ModalSandboxClient();
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          logs: { type: 'dir', ephemeral: true },
+        },
+      }),
+      {
+        appName: 'sandbox-tests',
+      },
+    );
+
+    sandboxExecMock.mockClear();
+    sandboxFilesystemWriteBytesMock.mockClear();
+
+    await expect(
+      session.hydrateWorkspace(
+        makeTarArchive([
+          { name: 'logs/events.jsonl', content: 'persisted log' },
+        ]),
+      ),
+    ).rejects.toMatchObject({
+      details: {
+        reason: 'archive member overlaps protected path: logs',
+      },
+    });
+    expect(sandboxExecMock).not.toHaveBeenCalled();
+    expect(sandboxFilesystemWriteBytesMock).not.toHaveBeenCalled();
+  });
+
   test('rejects partial S3 cloud bucket credentials', async () => {
     const client = new ModalSandboxClient();
 
@@ -1303,35 +1334,7 @@ describe('ModalSandboxClient', () => {
     expect(session.state.idleTimeoutMs).toBe(60_000);
   });
 
-  test('falls back to tar persistence when the workspace root is ephemeral', async () => {
-    const archive = makeTarArchive([{ name: 'keep.txt', content: 'keep' }]);
-    sandboxExecMock.mockImplementation(
-      async (command: string[], _params?: Record<string, unknown>) => {
-        if (command[0] === '/bin/sh') {
-          const resolvedPath = resolvedRemotePathFromValidationCommand(
-            command[2] ?? '',
-          );
-          if (resolvedPath) {
-            return {
-              stdin: { writeText: async () => {}, close: async () => {} },
-              stdout: textStream(`${resolvedPath}\n`),
-              stderr: textStream(''),
-              wait: async () => 0,
-            };
-          }
-          const archivePath = command[2]?.match(/-cf '([^']+)'/)?.[1];
-          if (archivePath) {
-            files.set(archivePath, archive);
-          }
-        }
-        return {
-          stdin: { writeText: async () => {}, close: async () => {} },
-          stdout: textStream(''),
-          stderr: textStream(''),
-          wait: async () => 0,
-        };
-      },
-    );
+  test('persists an empty tar when the workspace root is ephemeral', async () => {
     const client = new ModalSandboxClient();
     const session = await client.create(
       new Manifest({
@@ -1347,12 +1350,16 @@ describe('ModalSandboxClient', () => {
         workspacePersistence: 'snapshot_filesystem',
       } satisfies ModalSandboxClientOptions,
     );
+    sandboxExecMock.mockClear();
+    sandboxFilesystemReadBytesMock.mockClear();
 
     const snapshotBytes = await session.persistWorkspace();
 
     expect(sandboxSnapshotFilesystemMock).not.toHaveBeenCalled();
     expect(decodeNativeSnapshotRef(snapshotBytes)).toBeUndefined();
-    expect(snapshotBytes).toEqual(archive);
+    expect(snapshotBytes).toEqual(makeTarArchive([]));
+    expect(sandboxExecMock).not.toHaveBeenCalled();
+    expect(sandboxFilesystemReadBytesMock).not.toHaveBeenCalled();
   });
 
   test('clears cached exposed ports after snapshot filesystem restore', async () => {

--- a/packages/agents-extensions/test/sandbox/runloop.test.ts
+++ b/packages/agents-extensions/test/sandbox/runloop.test.ts
@@ -1881,7 +1881,7 @@ describe('RunloopSandboxClient', () => {
     expect(downloadMock).toHaveBeenCalled();
   });
 
-  test('falls back to tar persistence when the workspace root is ephemeral', async () => {
+  test('persists an empty tar when the workspace root is ephemeral', async () => {
     const client = new RunloopSandboxClient();
     const session = await client.create(
       runloopManifest({
@@ -1893,16 +1893,12 @@ describe('RunloopSandboxClient', () => {
         },
       }),
     );
-    const archive = makeTarArchive([{ name: 'keep.txt', content: 'keep' }]);
-    downloadMock.mockResolvedValueOnce({
-      buffer: async () => Buffer.from(archive),
-    });
-
     const snapshotBytes = await session.persistWorkspace();
 
     expect(snapshotDiskMock).not.toHaveBeenCalled();
     expect(decodeNativeSnapshotRef(snapshotBytes)).toBeUndefined();
-    expect(downloadMock).toHaveBeenCalled();
+    expect(snapshotBytes).toEqual(makeTarArchive([]));
+    expect(downloadMock).not.toHaveBeenCalled();
   });
 
   test('reports provider errors when native snapshot restore is unsupported', async () => {

--- a/packages/agents-extensions/test/sandbox/shared.test.ts
+++ b/packages/agents-extensions/test/sandbox/shared.test.ts
@@ -2628,6 +2628,54 @@ describe('remote sandbox path helpers', () => {
     expect(runCommand).not.toHaveBeenCalled();
   });
 
+  test('rejects PAX size overrides before hydration side effects', async () => {
+    const embeddedHeader = makeTarArchive([
+      { name: 'logs/events.jsonl', content: '' },
+    ]).subarray(0, 512);
+    const archive = makeTarArchive([
+      {
+        name: 'local-pax',
+        type: 'x',
+        content: makePaxRecord('size', '0'),
+      },
+      { name: 'safe.txt', content: embeddedHeader },
+    ]);
+    const writeFile = vi.fn();
+    const runCommand = vi.fn(async (command: string) => ({
+      status: 0,
+      stdout: command.includes('resolve-workspace-path.sh')
+        ? '/custom/workspace\n'
+        : '',
+      stderr: '',
+    }));
+
+    await expect(
+      hydrateRemoteWorkspaceTar({
+        providerName: 'FakeProvider',
+        manifest: new Manifest({
+          root: '/custom/workspace',
+          entries: {
+            logs: { type: 'dir', ephemeral: true },
+          },
+        }),
+        data: archive,
+        io: {
+          mkdir: vi.fn(),
+          readFile: vi.fn(),
+          writeFile,
+          runCommand,
+        },
+      }),
+    ).rejects.toMatchObject({
+      details: {
+        reason: 'PAX size override not allowed',
+      },
+    });
+
+    expect(writeFile).not.toHaveBeenCalled();
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
   test('rejects GNU sparse PAX destinations before hydration side effects', async () => {
     const archive = makeTarArchive([
       {

--- a/packages/agents-extensions/test/sandbox/shared.test.ts
+++ b/packages/agents-extensions/test/sandbox/shared.test.ts
@@ -2177,7 +2177,7 @@ describe('remote sandbox path helpers', () => {
       {
         name: 'global-pax',
         type: 'g',
-        content: makePaxRecord('path', 'workspace/not-used.txt'),
+        content: makePaxRecord('comment', 'harmless metadata'),
       },
       {
         name: 'long-name',
@@ -2212,6 +2212,47 @@ describe('remote sandbox path helpers', () => {
         rejectSymlinkRelPaths: ['workspace/keep/link'],
       }),
     ).toThrow(/symlink member not allowed: workspace\/keep\/link/);
+  });
+
+  test.each(['path', 'linkpath'])('rejects global PAX %s overrides', (key) => {
+    const archive = makeTarArchive([
+      {
+        name: 'global-pax',
+        type: 'g',
+        content: makePaxRecord(key, 'logs/events.jsonl'),
+      },
+      { name: 'safe.txt', content: 'unsafe destination' },
+    ]);
+
+    expect(() => validateWorkspaceTarArchive(archive)).toThrow(
+      new RegExp(`global PAX ${key} override not allowed`),
+    );
+  });
+
+  test('rejects malformed PAX byte framing and encoding', () => {
+    const archive = makeTarArchive([
+      {
+        name: 'local-pax',
+        type: 'x',
+        content: '999 path=logs/events.jsonl\n',
+      },
+      { name: 'safe.txt', content: 'unsafe destination' },
+    ]);
+
+    expect(() => validateWorkspaceTarArchive(archive)).toThrow(
+      /PAX record exceeds payload/,
+    );
+
+    const invalidUtf8 = makeTarArchive([
+      {
+        name: 'local-pax',
+        type: 'x',
+        content: new Uint8Array([0x37, 0x20, 0x78, 0x3d, 0xc3, 0x28, 0x0a]),
+      },
+    ]);
+    expect(() => validateWorkspaceTarArchive(invalidUtf8)).toThrow(
+      /invalid UTF-8 in PAX record/,
+    );
   });
 
   test('rejects malformed tar headers and unsupported member types', () => {
@@ -2367,6 +2408,362 @@ describe('remote sandbox path helpers', () => {
       }),
     ).rejects.toBeInstanceOf(SandboxArchiveError);
     expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    {
+      name: 'an exact ephemeral file',
+      manifest: new Manifest({
+        root: '/custom/workspace',
+        entries: {
+          'secret.txt': {
+            type: 'file',
+            content: 'runtime-only',
+            ephemeral: true,
+          },
+        },
+      }),
+      archive: makeTarArchive([
+        { name: 'secret.txt', content: 'persisted secret' },
+      ]),
+      protectedPath: 'secret.txt',
+    },
+    {
+      name: 'a descendant of an ephemeral directory',
+      manifest: new Manifest({
+        root: '/custom/workspace',
+        entries: {
+          logs: { type: 'dir', ephemeral: true },
+        },
+      }),
+      archive: makeTarArchive([
+        { name: 'logs/events.jsonl', content: 'persisted log' },
+      ]),
+      protectedPath: 'logs',
+    },
+    {
+      name: 'a file that blocks an ephemeral descendant',
+      manifest: new Manifest({
+        root: '/custom/workspace',
+        entries: {
+          cache: {
+            type: 'dir',
+            children: {
+              'session.json': {
+                type: 'file',
+                content: 'runtime-only',
+                ephemeral: true,
+              },
+            },
+          },
+        },
+      }),
+      archive: makeTarArchive([{ name: 'cache', content: 'blocking file' }]),
+      protectedPath: 'cache/session.json',
+    },
+    {
+      name: 'a descendant of an ephemeral mount target',
+      manifest: new Manifest({
+        root: '/custom/workspace',
+        entries: {
+          remote: mount({
+            source: 's3://bucket/data',
+            mountPath: 'mounted/cache',
+            ephemeral: true,
+            mountStrategy: { type: 'in_container' },
+          }),
+        },
+      }),
+      archive: makeTarArchive([
+        { name: 'mounted/cache/data.json', content: 'persisted mount data' },
+      ]),
+      protectedPath: 'mounted/cache',
+    },
+  ])(
+    'rejects $name before hydrating tar archives',
+    async ({ manifest, archive, protectedPath }) => {
+      const writeFile = vi.fn();
+      const runCommand = vi.fn(async (command: string) => ({
+        status: 0,
+        stdout: command.includes('resolve-workspace-path.sh')
+          ? `${manifest.root}\n`
+          : '',
+        stderr: '',
+      }));
+
+      await expect(
+        hydrateRemoteWorkspaceTar({
+          providerName: 'FakeProvider',
+          manifest,
+          data: archive,
+          io: {
+            mkdir: vi.fn(),
+            readFile: vi.fn(),
+            writeFile,
+            runCommand,
+          },
+        }),
+      ).rejects.toMatchObject({
+        details: {
+          reason: `archive member overlaps protected path: ${protectedPath}`,
+        },
+      });
+      expect(writeFile).not.toHaveBeenCalled();
+      expect(runCommand).not.toHaveBeenCalled();
+    },
+  );
+
+  test('hydrates tar archives without ephemeral manifest paths', async () => {
+    const archive = makeTarArchive([
+      { name: 'src/index.ts', content: 'export {};' },
+    ]);
+    const writeFile = vi.fn();
+    const runCommand = vi.fn(async (command: string) => ({
+      status: 0,
+      stdout: command.includes('resolve-workspace-path.sh')
+        ? '/custom/workspace\n'
+        : '',
+      stderr: '',
+    }));
+
+    await hydrateRemoteWorkspaceTar({
+      providerName: 'FakeProvider',
+      manifest: new Manifest({
+        root: '/custom/workspace',
+        entries: {
+          logs: { type: 'dir', ephemeral: true },
+        },
+      }),
+      data: archive,
+      io: {
+        mkdir: vi.fn(),
+        readFile: vi.fn(),
+        writeFile,
+        runCommand,
+      },
+    });
+
+    expect(writeFile).toHaveBeenCalledWith(expect.any(String), archive);
+    expect(runCommand).toHaveBeenCalled();
+  });
+
+  test('rejects global PAX path overrides before hydration side effects', async () => {
+    const archive = makeTarArchive([
+      {
+        name: 'global-pax',
+        type: 'g',
+        content: makePaxRecord('path', 'logs/events.jsonl'),
+      },
+      { name: 'safe.txt', content: 'unsafe destination' },
+    ]);
+    const writeFile = vi.fn();
+    const runCommand = vi.fn();
+
+    await expect(
+      hydrateRemoteWorkspaceTar({
+        providerName: 'FakeProvider',
+        manifest: new Manifest({
+          root: '/custom/workspace',
+          entries: {
+            logs: { type: 'dir', ephemeral: true },
+          },
+        }),
+        data: archive,
+        io: {
+          mkdir: vi.fn(),
+          readFile: vi.fn(),
+          writeFile,
+          runCommand,
+        },
+      }),
+    ).rejects.toMatchObject({
+      details: {
+        reason: 'global PAX path override not allowed',
+      },
+    });
+
+    expect(writeFile).not.toHaveBeenCalled();
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  test('parses multibyte PAX records before protected paths', async () => {
+    const archive = makeTarArchive([
+      {
+        name: 'local-pax',
+        type: 'x',
+        content: `${makePaxRecord('comment', 'é')}${makePaxRecord(
+          'path',
+          'logs/events.jsonl',
+        )}`,
+      },
+      { name: 'safe.txt', content: 'unsafe destination' },
+    ]);
+    const writeFile = vi.fn();
+    const runCommand = vi.fn();
+
+    await expect(
+      hydrateRemoteWorkspaceTar({
+        providerName: 'FakeProvider',
+        manifest: new Manifest({
+          root: '/custom/workspace',
+          entries: {
+            logs: { type: 'dir', ephemeral: true },
+          },
+        }),
+        data: archive,
+        io: {
+          mkdir: vi.fn(),
+          readFile: vi.fn(),
+          writeFile,
+          runCommand,
+        },
+      }),
+    ).rejects.toMatchObject({
+      details: {
+        reason: 'archive member overlaps protected path: logs',
+      },
+    });
+
+    expect(writeFile).not.toHaveBeenCalled();
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  test('rejects GNU sparse PAX destinations before hydration side effects', async () => {
+    const archive = makeTarArchive([
+      {
+        name: 'local-pax',
+        type: 'x',
+        content: makePaxRecord('GNU.sparse.name', 'logs/events.jsonl'),
+      },
+      { name: 'safe.txt', content: 'unsafe destination' },
+    ]);
+    const writeFile = vi.fn();
+    const runCommand = vi.fn();
+
+    await expect(
+      hydrateRemoteWorkspaceTar({
+        providerName: 'FakeProvider',
+        manifest: new Manifest({
+          root: '/custom/workspace',
+          entries: {
+            logs: { type: 'dir', ephemeral: true },
+          },
+        }),
+        data: archive,
+        io: {
+          mkdir: vi.fn(),
+          readFile: vi.fn(),
+          writeFile,
+          runCommand,
+        },
+      }),
+    ).rejects.toMatchObject({
+      details: {
+        reason: 'PAX GNU.sparse.name override not allowed',
+      },
+    });
+
+    expect(writeFile).not.toHaveBeenCalled();
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  test('rejects populated tar archives when the workspace root is ephemeral', async () => {
+    const archive = makeTarArchive([
+      { name: 'src/index.ts', content: 'export {};' },
+    ]);
+    const writeFile = vi.fn();
+    const runCommand = vi.fn(async (command: string) => ({
+      status: 0,
+      stdout: command.includes('resolve-workspace-path.sh')
+        ? '/custom/workspace\n'
+        : '',
+      stderr: '',
+    }));
+
+    await expect(
+      hydrateRemoteWorkspaceTar({
+        providerName: 'FakeProvider',
+        manifest: new Manifest({
+          root: '/custom/workspace',
+          entries: {
+            '': { type: 'dir', ephemeral: true },
+          },
+        }),
+        data: archive,
+        io: {
+          mkdir: vi.fn(),
+          readFile: vi.fn(),
+          writeFile,
+          runCommand,
+        },
+      }),
+    ).rejects.toMatchObject({
+      details: {
+        reason: 'archive member overlaps protected path: ',
+      },
+    });
+
+    expect(writeFile).not.toHaveBeenCalled();
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  test('round-trips an ephemeral workspace root as an empty tar archive', async () => {
+    const manifest = new Manifest({
+      root: '/custom/workspace',
+      entries: {
+        '': { type: 'dir', ephemeral: true },
+      },
+    });
+    const persistedContent = makeTarArchive([
+      { name: 'secret.txt', content: 'must not persist' },
+    ]);
+    const persistRunCommand = vi.fn(async (command: string) => ({
+      status: 0,
+      stdout: command.includes('resolve-workspace-path.sh')
+        ? '/custom/workspace\n'
+        : '',
+      stderr: '',
+    }));
+    const persistReadFile = vi.fn(async () => persistedContent);
+
+    const archive = await persistRemoteWorkspaceTar({
+      providerName: 'FakeProvider',
+      manifest,
+      io: {
+        mkdir: vi.fn(),
+        readFile: persistReadFile,
+        writeFile: vi.fn(),
+        runCommand: persistRunCommand,
+      },
+    });
+
+    expect(archive).toEqual(makeTarArchive([]));
+    expect(persistReadFile).not.toHaveBeenCalled();
+    expect(persistRunCommand).not.toHaveBeenCalled();
+
+    const hydrateWriteFile = vi.fn();
+    const hydrateRunCommand = vi.fn(async (command: string) => ({
+      status: 0,
+      stdout: command.includes('resolve-workspace-path.sh')
+        ? '/custom/workspace\n'
+        : '',
+      stderr: '',
+    }));
+
+    await hydrateRemoteWorkspaceTar({
+      providerName: 'FakeProvider',
+      manifest,
+      data: archive,
+      io: {
+        mkdir: vi.fn(),
+        readFile: vi.fn(),
+        writeFile: hydrateWriteFile,
+        runCommand: hydrateRunCommand,
+      },
+    });
+
+    expect(hydrateWriteFile).toHaveBeenCalledWith(expect.any(String), archive);
+    expect(hydrateRunCommand).toHaveBeenCalled();
   });
 
   test('clears remote workspace root before hydrating tar archives', async () => {

--- a/packages/agents-extensions/test/sandbox/shared.test.ts
+++ b/packages/agents-extensions/test/sandbox/shared.test.ts
@@ -2628,6 +2628,55 @@ describe('remote sandbox path helpers', () => {
     expect(runCommand).not.toHaveBeenCalled();
   });
 
+  test('rejects NUL-bearing PAX paths before hydration side effects', async () => {
+    const archive = makeTarArchive([
+      {
+        name: 'local-pax',
+        type: 'x',
+        content: makePaxRecord('path', 'secret.txt\0ignored'),
+      },
+      { name: 'safe.txt', content: 'persisted secret' },
+    ]);
+    const writeFile = vi.fn();
+    const runCommand = vi.fn(async (command: string) => ({
+      status: 0,
+      stdout: command.includes('resolve-workspace-path.sh')
+        ? '/custom/workspace\n'
+        : '',
+      stderr: '',
+    }));
+
+    await expect(
+      hydrateRemoteWorkspaceTar({
+        providerName: 'FakeProvider',
+        manifest: new Manifest({
+          root: '/custom/workspace',
+          entries: {
+            'secret.txt': {
+              type: 'file',
+              content: 'runtime-only',
+              ephemeral: true,
+            },
+          },
+        }),
+        data: archive,
+        io: {
+          mkdir: vi.fn(),
+          readFile: vi.fn(),
+          writeFile,
+          runCommand,
+        },
+      }),
+    ).rejects.toMatchObject({
+      details: {
+        reason: 'NUL byte in PAX record',
+      },
+    });
+
+    expect(writeFile).not.toHaveBeenCalled();
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
   test('rejects PAX size overrides before hydration side effects', async () => {
     const embeddedHeader = makeTarArchive([
       { name: 'logs/events.jsonl', content: '' },

--- a/packages/agents-extensions/test/sandbox/tarFixture.ts
+++ b/packages/agents-extensions/test/sandbox/tarFixture.ts
@@ -24,13 +24,15 @@ export function makeTarArchive(entries: TarFixtureEntry[]): Uint8Array {
 }
 
 export function makePaxRecord(key: string, value: string): string {
-  let length = `${key}=${value}\n`.length + 2;
+  const encoder = new TextEncoder();
+  let length = encoder.encode(`${key}=${value}\n`).byteLength + 2;
   while (true) {
     const record = `${length} ${key}=${value}\n`;
-    if (record.length === length) {
+    const byteLength = encoder.encode(record).byteLength;
+    if (byteLength === length) {
       return record;
     }
-    length = record.length;
+    length = byteLength;
   }
 }
 


### PR DESCRIPTION
This pull request fixes sandbox tar hydration so archives cannot restore content into non-empty ephemeral manifest paths. It reuses the tar writer's path selection in the shared validator, rejects unsafe archives before provider I/O, preserves the existing empty-root fallback, adds shared and Modal regression coverage, and includes a patch changeset for `@openai/agents-extensions`.