### PR TITLE
fix: clean MCP servers before reconnecting

### DIFF
--- a/.changeset/clean-mcp-reconnect-targets.md
+++ b/.changeset/clean-mcp-reconnect-targets.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: clean MCP servers before reconnecting

--- a/packages/agents-core/src/mcpServers.ts
+++ b/packages/agents-core/src/mcpServers.ts
@@ -167,6 +167,7 @@ export class MCPServers {
   private errorsByServer = new Map<MCPServer, Error>();
   private suppressedAbortFailures = new Set<MCPServer>();
   private workers = new Map<MCPServer, ServerWorker>();
+  private serialCloseTasks = new Map<MCPServer, Promise<void>>();
 
   private readonly connectTimeoutMs: number | null;
   private readonly closeTimeoutMs: number | null;
@@ -239,30 +240,57 @@ export class MCPServers {
     options: MCPServersReconnectOptions = {},
   ): Promise<MCPServer[]> {
     const failedOnly = options.failedOnly ?? true;
-    let serversToRetry: MCPServer[];
-
-    if (failedOnly) {
-      serversToRetry = uniqueServers(this.failedServers);
-    } else {
-      serversToRetry = [...this.allServers];
-      this.failedServers = [];
-      this.failedServerSet = new Set();
-      this.errorsByServer = new Map();
-      this.suppressedAbortFailures = new Set();
-    }
+    const serversToCleanup = failedOnly
+      ? uniqueServers(this.failedServers)
+      : [...this.allServers];
 
     logger.debug(
-      `Reconnecting MCP servers (failedOnly=${failedOnly}) with ${serversToRetry.length} target(s).`,
+      `Reconnecting MCP servers (failedOnly=${failedOnly}) with ${serversToCleanup.length} target(s).`,
     );
-    if (this.connectInParallel) {
-      await this.connectAllParallel(serversToRetry);
-    } else {
-      for (const server of serversToRetry) {
-        await this.attemptConnect(server);
+
+    if (!failedOnly) {
+      for (const server of serversToCleanup) {
+        if (!this.failedServerSet.has(server)) {
+          this.storeFailure(server, createClosedError(server));
+        }
       }
     }
 
-    this.refreshActiveServers();
+    try {
+      const serversToRetry = await this.closeServers(serversToCleanup);
+      if (!failedOnly) {
+        const cleanedServers = new Set(serversToRetry);
+        const cleanupFailures = serversToCleanup.flatMap((server) => {
+          if (cleanedServers.has(server)) {
+            return [];
+          }
+          const error = this.errorsByServer.get(server);
+          return error ? [{ server, error }] : [];
+        });
+
+        this.failedServers = [];
+        this.failedServerSet = new Set();
+        this.errorsByServer = new Map();
+        this.suppressedAbortFailures = new Set();
+        for (const { server, error } of cleanupFailures) {
+          this.storeFailure(server, error);
+        }
+        for (const server of serversToRetry) {
+          this.storeFailure(server, createClosedError(server));
+        }
+      }
+
+      if (this.connectInParallel) {
+        await this.connectAllParallel(serversToRetry);
+      } else {
+        for (const server of serversToRetry) {
+          await this.attemptConnect(server);
+        }
+      }
+    } finally {
+      this.refreshActiveServers();
+    }
+
     return this.active;
   }
 
@@ -365,6 +393,10 @@ export class MCPServers {
       `Failed to ${phase} ${getMcpServerLogLabel(server)}:`,
       error,
     );
+    this.storeFailure(server, error);
+  }
+
+  private storeFailure(server: MCPServer, error: Error): void {
     if (!this.failedServerSet.has(server)) {
       this.failedServers.push(server);
       this.failedServerSet.add(server);
@@ -385,11 +417,12 @@ export class MCPServers {
     );
   }
 
-  private async closeServer(server: MCPServer): Promise<void> {
+  private async closeServer(server: MCPServer): Promise<boolean> {
     try {
       logger.debug(`Closing ${getMcpServerLogLabel(server)}.`);
       await this.runClose(server);
       logger.debug(`Closed ${getMcpServerLogLabel(server)}.`);
+      return true;
     } catch (error) {
       const err = toError(error);
       if (isAbortError(err)) {
@@ -402,7 +435,7 @@ export class MCPServers {
           err,
         );
         this.errorsByServer.set(server, err);
-        return;
+        return false;
       }
       logToolActionError(
         logger,
@@ -410,6 +443,7 @@ export class MCPServers {
         err,
       );
       this.errorsByServer.set(server, err);
+      return false;
     }
   }
 
@@ -424,17 +458,42 @@ export class MCPServers {
         return;
       }
     }
-    await runWithTimeout(
-      () => server.close(),
+    if (this.serialCloseTasks.has(server)) {
+      throw createClosingError(server);
+    }
+
+    const closeTask = server.close();
+    const trackedCloseTask = closeTask
+      .then(
+        () => undefined,
+        () => undefined,
+      )
+      .finally(() => {
+        if (this.serialCloseTasks.get(server) === trackedCloseTask) {
+          this.serialCloseTasks.delete(server);
+        }
+      });
+    this.serialCloseTasks.set(server, trackedCloseTask);
+    await runWithTimeoutTask(
+      closeTask,
       this.closeTimeoutMs,
       createTimeoutError('close', server, this.closeTimeoutMs),
     );
   }
 
-  private async closeServers(servers: MCPServer[]): Promise<void> {
+  private async closeServers(servers: MCPServer[]): Promise<MCPServer[]> {
+    const closedServers = new Set<MCPServer>();
     for (const server of [...servers].reverse()) {
-      await this.closeServer(server);
+      try {
+        if (await this.closeServer(server)) {
+          closedServers.add(server);
+        }
+      } catch (error) {
+        this.errorsByServer.set(server, toError(error));
+        throw error;
+      }
     }
+    return servers.filter((server) => closedServers.has(server));
   }
 
   private async connectAllParallel(servers: MCPServer[]): Promise<void> {
@@ -447,9 +506,11 @@ export class MCPServers {
     if (rejection) {
       throw rejection.reason;
     }
-    if (this.strict && this.failedServers.length > 0) {
-      const firstFailure = this.failedServers.find(
-        (server) => !this.suppressedAbortFailures.has(server),
+    if (this.strict) {
+      const firstFailure = servers.find(
+        (server) =>
+          this.failedServerSet.has(server) &&
+          !this.suppressedAbortFailures.has(server),
       );
       if (firstFailure) {
         const error = this.errorsByServer.get(firstFailure);

--- a/packages/agents-core/test/mcpServers.test.ts
+++ b/packages/agents-core/test/mcpServers.test.ts
@@ -181,6 +181,45 @@ class FlakyCloseServer extends BaseTestServer {
   }
 }
 
+class ResourceTrackingServer extends BaseTestServer {
+  public resourceOpen = false;
+  public failClose: boolean;
+
+  constructor(
+    name: string,
+    private readonly lifecycleEvents: string[],
+    options: { failConnectCall?: number; failClose?: boolean } = {},
+  ) {
+    super(name);
+    this.failConnectCall = options.failConnectCall;
+    this.failClose = options.failClose ?? false;
+  }
+
+  private readonly failConnectCall: number | undefined;
+
+  async connect(): Promise<void> {
+    this.connectCalls += 1;
+    this.lifecycleEvents.push(`${this.name}:connect`);
+    if (this.resourceOpen) {
+      throw new Error('connect called before cleanup');
+    }
+    this.resourceOpen = true;
+    if (this.connectCalls === this.failConnectCall) {
+      throw new Error('connect failed after opening resource');
+    }
+  }
+
+  async close(): Promise<void> {
+    this.closeCalls += 1;
+    this.lifecycleEvents.push(`${this.name}:close`);
+    if (this.failClose) {
+      throw new Error('close failed');
+    }
+    this.resourceOpen = false;
+    this.cleaned = true;
+  }
+}
+
 async function withTimeout<T>(
   promise: Promise<T>,
   timeoutMs: number,
@@ -270,6 +309,7 @@ describe('MCPServers', () => {
       'Close cancelled for MCP server:',
       'object',
     );
+    expect(session.errors.get(server)?.name).toBe('AbortError');
     const calls = JSON.stringify([
       ...mcpLogger.debug.mock.calls,
       ...mcpLogger.error.mock.calls,
@@ -384,6 +424,71 @@ describe('MCPServers', () => {
     expect(session.failed).toEqual([]);
   });
 
+  it.each([false, true])(
+    'cleans a partially opened server before reconnecting (parallel=%s)',
+    async (connectInParallel) => {
+      const lifecycleEvents: string[] = [];
+      const healthy = new BaseTestServer('healthy');
+      const failed = new ResourceTrackingServer('failed', lifecycleEvents, {
+        failConnectCall: 1,
+      });
+      const session = await connectMcpServers([healthy, failed], {
+        connectInParallel,
+        connectTimeoutMs: null,
+        closeTimeoutMs: null,
+      });
+
+      try {
+        expect(session.active).toEqual([healthy]);
+        expect(session.failed).toEqual([failed]);
+
+        await session.reconnect();
+
+        expect(lifecycleEvents).toEqual([
+          'failed:connect',
+          'failed:close',
+          'failed:connect',
+        ]);
+        expect(failed.resourceOpen).toBe(true);
+        expect(session.active).toEqual([healthy, failed]);
+        expect(session.failed).toEqual([]);
+        expect(session.errors.has(failed)).toBe(false);
+        expect(healthy.connectCalls).toBe(1);
+        expect(healthy.closeCalls).toBe(0);
+      } finally {
+        await session.close();
+      }
+    },
+  );
+
+  it.each([false, true])(
+    'does not reconnect after cleanup fails (parallel=%s)',
+    async (connectInParallel) => {
+      const lifecycleEvents: string[] = [];
+      const server = new ResourceTrackingServer('failed', lifecycleEvents, {
+        failConnectCall: 1,
+        failClose: true,
+      });
+      const session = await connectMcpServers([server], {
+        connectInParallel,
+        connectTimeoutMs: null,
+        closeTimeoutMs: null,
+      });
+
+      await session.reconnect();
+
+      expect(lifecycleEvents).toEqual(['failed:connect', 'failed:close']);
+      expect(server.connectCalls).toBe(1);
+      expect(server.resourceOpen).toBe(true);
+      expect(session.active).toEqual([]);
+      expect(session.failed).toEqual([server]);
+      expect(session.errors.get(server)?.message).toBe('close failed');
+
+      server.failClose = false;
+      await session.close();
+    },
+  );
+
   it('deduplicates failures across reconnect attempts', async () => {
     const server = new FlakyServer('flaky', 2);
     const session = await connectMcpServers([server], {
@@ -418,6 +523,81 @@ describe('MCPServers', () => {
     expect(session.failed).toEqual([]);
     expect(server.connectCalls).toBe(2);
   });
+
+  it.each([false, true])(
+    'cleans every reconnect-all target before reconnecting successful cleanups (parallel=%s)',
+    async (connectInParallel) => {
+      const lifecycleEvents: string[] = [];
+      const cleanupFailure = new ResourceTrackingServer(
+        'cleanup-failure',
+        lifecycleEvents,
+        { failClose: true },
+      );
+      const reconnectable = new ResourceTrackingServer(
+        'reconnectable',
+        lifecycleEvents,
+      );
+      const session = await connectMcpServers([cleanupFailure, reconnectable], {
+        connectInParallel,
+        connectTimeoutMs: null,
+        closeTimeoutMs: null,
+      });
+      lifecycleEvents.length = 0;
+
+      await session.reconnect({ failedOnly: false });
+
+      expect(lifecycleEvents).toEqual([
+        'reconnectable:close',
+        'cleanup-failure:close',
+        'reconnectable:connect',
+      ]);
+      expect(cleanupFailure.connectCalls).toBe(1);
+      expect(reconnectable.connectCalls).toBe(2);
+      expect(session.active).toEqual([reconnectable]);
+      expect(session.failed).toEqual([cleanupFailure]);
+      expect(session.errors.get(cleanupFailure)?.message).toBe('close failed');
+
+      cleanupFailure.failClose = false;
+      await session.close();
+    },
+  );
+
+  it.each([false, true])(
+    'keeps closed servers inactive when strict reconnect-all fails (parallel=%s)',
+    async (connectInParallel) => {
+      const lifecycleEvents: string[] = [];
+      const reconnectFailure = new ResourceTrackingServer(
+        'reconnect-failure',
+        lifecycleEvents,
+        { failConnectCall: 2 },
+      );
+      const peer = new ResourceTrackingServer('peer', lifecycleEvents);
+      const session = await connectMcpServers([reconnectFailure, peer], {
+        connectInParallel,
+        connectTimeoutMs: null,
+        closeTimeoutMs: null,
+        strict: true,
+      });
+      lifecycleEvents.length = 0;
+
+      await expect(session.reconnect({ failedOnly: false })).rejects.toThrow(
+        'connect failed after opening resource',
+      );
+
+      expect(session.failed).toContain(reconnectFailure);
+      expect(session.active).not.toContain(reconnectFailure);
+      if (connectInParallel) {
+        expect(session.active).toEqual([peer]);
+        expect(session.failed).not.toContain(peer);
+      } else {
+        expect(session.active).toEqual([]);
+        expect(session.failed).toContain(peer);
+        expect(session.errors.get(peer)?.name).toBe('ClosedError');
+      }
+
+      await session.close();
+    },
+  );
 
   it('keeps failed servers active when dropFailed is false', async () => {
     const server = new FlakyServer('flaky', 1);
@@ -495,36 +675,80 @@ describe('MCPServers', () => {
     expect(aborting.cleaned).toBe(true);
   });
 
-  it('rejects commands while a timed-out close is still in flight', async () => {
-    const closeGate = createDeferred<void>();
-    const server = new SlowCloseServer('slow', closeGate);
-    const session = await connectMcpServers([server], {
-      connectInParallel: true,
-      closeTimeoutMs: 1,
-    });
+  it.each([false, true])(
+    'keeps reconnect-all targets inactive when cleanup aborts (parallel=%s)',
+    async (connectInParallel) => {
+      const aborting = new AbortCloseServer('aborting');
+      const session = await connectMcpServers([aborting], {
+        connectInParallel,
+        suppressAbortError: false,
+      });
 
-    await session.close();
-    const reconnectPromise = session.reconnect({ failedOnly: false });
-    await expect(withTimeout(reconnectPromise, 500)).resolves.toEqual([]);
-    expect(session.failed).toEqual([server]);
-    expect(session.errors.get(server)?.name).toBe('ClosingError');
-    closeGate.resolve();
-  });
+      await expect(session.reconnect({ failedOnly: false })).rejects.toThrow(
+        'close aborted',
+      );
 
-  it('allows retrying close after a failure in parallel workers', async () => {
-    const server = new FlakyCloseServer('flaky', 1);
-    const session = await connectMcpServers([server], {
-      connectInParallel: true,
-    });
+      expect(session.active).toEqual([]);
+      expect(session.failed).toEqual([aborting]);
+      expect(session.errors.get(aborting)?.name).toBe('AbortError');
+      expect(aborting.connectCalls).toBe(1);
+    },
+  );
 
-    await session.close();
-    expect(server.cleaned).toBe(false);
-    expect(server.closeCalls).toBe(1);
+  it.each([false, true])(
+    'skips reconnect-all targets after suppressed cleanup aborts (parallel=%s)',
+    async (connectInParallel) => {
+      const aborting = new AbortCloseServer('aborting');
+      const session = await connectMcpServers([aborting], {
+        connectInParallel,
+      });
 
-    await session.close();
-    expect(server.cleaned).toBe(true);
-    expect(server.closeCalls).toBe(2);
-  });
+      await expect(session.reconnect({ failedOnly: false })).resolves.toEqual(
+        [],
+      );
+
+      expect(session.failed).toEqual([aborting]);
+      expect(session.errors.get(aborting)?.name).toBe('AbortError');
+      expect(aborting.connectCalls).toBe(1);
+    },
+  );
+
+  it.each([false, true])(
+    'rejects commands while a timed-out close is still in flight (parallel=%s)',
+    async (connectInParallel) => {
+      const closeGate = createDeferred<void>();
+      const server = new SlowCloseServer('slow', closeGate);
+      const session = await connectMcpServers([server], {
+        connectInParallel,
+        closeTimeoutMs: 1,
+      });
+
+      await session.close();
+      const reconnectPromise = session.reconnect({ failedOnly: false });
+      await expect(withTimeout(reconnectPromise, 500)).resolves.toEqual([]);
+      expect(session.failed).toEqual([server]);
+      expect(session.errors.get(server)?.name).toBe('ClosingError');
+      closeGate.resolve();
+    },
+  );
+
+  it.each([false, true])(
+    'allows retrying close after a failure (parallel=%s)',
+    async (connectInParallel) => {
+      const server = new FlakyCloseServer('flaky', 1);
+      const session = await connectMcpServers([server], {
+        connectInParallel,
+      });
+
+      await session.close();
+      expect(server.cleaned).toBe(false);
+      expect(server.closeCalls).toBe(1);
+
+      await session.close();
+      expect(server.cleaned).toBe(true);
+      expect(server.closeCalls).toBe(2);
+    },
+  );
 
   it('attaches async dispose when supported', async () => {
     const server = new BaseTestServer('server');


### PR DESCRIPTION
This pull request fixes MCP server reconnects that could retry before resources from the previous connection attempt were closed.

Reconnect now cleans every selected server first and retries only servers whose cleanup completed successfully. Cleanup failures, timeouts, and aborts remain inactive and observable through the manager state, including in serial and parallel modes. Reconnect-all also keeps closed or unattempted servers inactive when strict reconnection fails.