### PR TITLE
fix: include all paginated MCP tools

### DIFF
--- a/.changeset/calm-tools-list-all-pages.md
+++ b/.changeset/calm-tools-list-all-pages.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: include every paginated MCP tool in agent tool discovery

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -103,9 +103,123 @@ type MaybeProtocolVersionTransport = MaybeSessionTransport & {
   protocolVersion?: string;
 };
 
-type ClientWithToolMetadataCacheReset = {
+type ClientWithToolMetadataCache = {
   cacheToolMetadata?: (tools: unknown[]) => void;
 };
+
+type MCPToolsPage = {
+  tools: MCPTool[];
+  nextCursor?: string;
+};
+
+type MCPToolsResultSchema = Parameters<Client['request']>[1];
+
+function getOptionalClientToolMetadataCache(
+  client: Client,
+): ClientWithToolMetadataCache['cacheToolMetadata'] {
+  const cacheToolMetadata = (client as unknown as ClientWithToolMetadataCache)
+    .cacheToolMetadata;
+  return typeof cacheToolMetadata === 'function'
+    ? cacheToolMetadata
+    : undefined;
+}
+
+function getClientToolMetadataCache(
+  client: Client,
+): NonNullable<ClientWithToolMetadataCache['cacheToolMetadata']> {
+  const cacheToolMetadata = getOptionalClientToolMetadataCache(client);
+  if (typeof cacheToolMetadata !== 'function') {
+    throw new Error(
+      'The installed MCP SDK does not support tool metadata caching required for paginated tool listing.',
+    );
+  }
+  return cacheToolMetadata;
+}
+
+async function requestMcpToolsPage(
+  client: Client,
+  resultSchema: MCPToolsResultSchema,
+  options: RequestOptions | undefined,
+  cursor: string | undefined,
+): Promise<MCPToolsPage> {
+  return (await client.request(
+    {
+      method: 'tools/list',
+      params: cursor === undefined ? undefined : { cursor },
+    },
+    resultSchema,
+    options,
+  )) as MCPToolsPage;
+}
+
+function cacheClientToolMetadata(client: Client, tools: MCPTool[]): void {
+  const cacheToolMetadata = getClientToolMetadataCache(client);
+  cacheToolMetadata.call(client, tools);
+}
+
+function replaceClientToolMetadata(
+  client: Client,
+  tools: MCPTool[],
+  fallbackTools: MCPTool[],
+): void {
+  try {
+    cacheClientToolMetadata(client, tools);
+  } catch (error) {
+    cacheClientToolMetadata(client, fallbackTools);
+    throw error;
+  }
+}
+
+function assertMcpToolListingIsCurrent(args: {
+  listedClient: Client;
+  currentClient: Client | null;
+  listedGeneration: number;
+  currentGeneration: number;
+}): void {
+  if (
+    args.currentClient !== args.listedClient ||
+    args.currentGeneration !== args.listedGeneration
+  ) {
+    throw new Error('MCP tool listing became stale before it completed.');
+  }
+}
+
+async function listAllMcpTools(args: {
+  fetchPage: (cursor: string | undefined) => Promise<MCPToolsPage>;
+  onPage: (response: MCPToolsPage) => void;
+}): Promise<MCPTool[]> {
+  const tools: MCPTool[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+
+  while (true) {
+    let page: MCPToolsPage;
+    try {
+      page = await args.fetchPage(cursor);
+      args.onPage(page);
+    } catch (error) {
+      if (cursor === undefined) {
+        throw error;
+      }
+      throw new Error(
+        'MCP tool listing failed while fetching a continuation page.',
+      );
+    }
+    tools.push(...page.tools);
+
+    const nextCursor = page.nextCursor;
+    if (nextCursor === undefined) {
+      return tools;
+    }
+    if (seenCursors.has(nextCursor)) {
+      throw new Error(
+        'MCP server returned a repeated cursor while listing tools.',
+      );
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
+}
 
 type StreamableHttpToolRecoveryStrategy =
   'none' | 'reconnect-only' | 'reconnect-and-retry';
@@ -243,6 +357,7 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
   protected session: Client | null = null;
   protected _cacheDirty = true;
   protected _toolsList: any[] = [];
+  protected _toolsCacheGeneration = 0;
   protected serverInitializeResult: InitializeResult | null = null;
   protected clientSessionTimeoutSeconds?: number;
   protected timeout: number;
@@ -275,6 +390,9 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
   }
 
   async connect(): Promise<void> {
+    this._toolsCacheGeneration += 1;
+    this._cacheDirty = true;
+    this._toolsList = [];
     try {
       const { StdioClientTransport } =
         await import('@modelcontextprotocol/sdk/client/stdio.js').catch(
@@ -310,6 +428,7 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
   }
 
   async invalidateToolsCache(): Promise<void> {
+    this._toolsCacheGeneration += 1;
     await invalidateServerToolsCache(this.name);
     this._cacheDirty = true;
   }
@@ -326,14 +445,33 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
       return this._toolsList;
     }
 
-    this._cacheDirty = false;
     const requestOptions = buildRequestOptions(
       this.clientSessionTimeoutSeconds,
     );
-    const response = await this.session.listTools(undefined, requestOptions);
-    this.debugLog(() => `Listed tools: ${JSON.stringify(response)}`);
-    this._toolsList = ListToolsResultSchema.parse(response).tools;
-    return this._toolsList;
+    const session = this.session;
+    getClientToolMetadataCache(session);
+    const cacheGeneration = this._toolsCacheGeneration;
+    const tools = await listAllMcpTools({
+      fetchPage: (cursor) =>
+        requestMcpToolsPage(
+          session,
+          ListToolsResultSchema,
+          requestOptions,
+          cursor,
+        ),
+      onPage: (response) =>
+        this.debugLog(() => `Listed tools: ${JSON.stringify(response)}`),
+    });
+    assertMcpToolListingIsCurrent({
+      listedClient: session,
+      currentClient: this.session,
+      listedGeneration: cacheGeneration,
+      currentGeneration: this._toolsCacheGeneration,
+    });
+    replaceClientToolMetadata(session, tools, this._toolsList);
+    this._toolsList = tools;
+    this._cacheDirty = false;
+    return tools;
   }
 
   async callTool(
@@ -449,6 +587,9 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
   }
 
   async close(): Promise<void> {
+    this._toolsCacheGeneration += 1;
+    this._cacheDirty = true;
+    this._toolsList = [];
     const transport: any = this.transport;
 
     if (transport && typeof transport.terminateSession === 'function') {
@@ -479,6 +620,7 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
   protected session: Client | null = null;
   protected _cacheDirty = true;
   protected _toolsList: any[] = [];
+  protected _toolsCacheGeneration = 0;
   protected serverInitializeResult: InitializeResult | null = null;
   protected clientSessionTimeoutSeconds?: number;
   protected timeout: number;
@@ -496,6 +638,9 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
   }
 
   async connect(): Promise<void> {
+    this._toolsCacheGeneration += 1;
+    this._cacheDirty = true;
+    this._toolsList = [];
     try {
       const { SSEClientTransport } =
         await import('@modelcontextprotocol/sdk/client/sse.js').catch(
@@ -536,6 +681,7 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
   }
 
   async invalidateToolsCache(): Promise<void> {
+    this._toolsCacheGeneration += 1;
     await invalidateServerToolsCache(this.name);
     this._cacheDirty = true;
   }
@@ -552,18 +698,35 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
       return this._toolsList;
     }
 
-    this._cacheDirty = false;
     const requestOptions = buildRequestOptions(
       this.clientSessionTimeoutSeconds,
     );
-    const response = await runMcpTransportOperation(
-      this.params.url,
-      'SSE list tools',
-      () => this.session!.listTools(undefined, requestOptions),
-    );
-    this.debugLog(() => `Listed tools: ${JSON.stringify(response)}`);
-    this._toolsList = ListToolsResultSchema.parse(response).tools;
-    return this._toolsList;
+    const session = this.session;
+    getClientToolMetadataCache(session);
+    const cacheGeneration = this._toolsCacheGeneration;
+    const tools = await listAllMcpTools({
+      fetchPage: (cursor) =>
+        runMcpTransportOperation(this.params.url, 'SSE list tools', () =>
+          requestMcpToolsPage(
+            session,
+            ListToolsResultSchema,
+            requestOptions,
+            cursor,
+          ),
+        ),
+      onPage: (response) =>
+        this.debugLog(() => `Listed tools: ${JSON.stringify(response)}`),
+    });
+    assertMcpToolListingIsCurrent({
+      listedClient: session,
+      currentClient: this.session,
+      listedGeneration: cacheGeneration,
+      currentGeneration: this._toolsCacheGeneration,
+    });
+    replaceClientToolMetadata(session, tools, this._toolsList);
+    this._toolsList = tools;
+    this._cacheDirty = false;
+    return tools;
   }
 
   async callTool(
@@ -692,6 +855,9 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
   }
 
   async close(): Promise<void> {
+    this._toolsCacheGeneration += 1;
+    this._cacheDirty = true;
+    this._toolsList = [];
     await runMcpTransportOperation(this.params.url, 'SSE cleanup', async () => {
       const transport = this.transport;
 
@@ -731,6 +897,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
   protected session: Client | null = null;
   protected _cacheDirty = true;
   protected _toolsList: any[] = [];
+  protected _toolsCacheGeneration = 0;
   protected serverInitializeResult: InitializeResult | null = null;
   protected clientSessionTimeoutSeconds?: number;
   protected timeout: number;
@@ -829,7 +996,6 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
       name: this._name,
       version: '1.0.0',
     });
-
     try {
       const requestOptions = buildRequestOptions(
         this.clientSessionTimeoutSeconds,
@@ -858,9 +1024,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
   }
 
   private resetClientToolMetadataCache(client: Client): void {
-    (client as unknown as ClientWithToolMetadataCacheReset).cacheToolMetadata?.(
-      [],
-    );
+    getOptionalClientToolMetadataCache(client)?.call(client, []);
   }
 
   private async publishConnectedStreamableHttpClient(args: {
@@ -868,20 +1032,25 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     transport: MaybeSessionTransport;
     previousTransport?: MaybeSessionTransport | null;
   }): Promise<void> {
+    const previousClient = this.session;
+    const previousSessionId = getSessionId(args.previousTransport);
+    const nextSessionId = getSessionId(args.transport);
+    const preservesCommittedToolState =
+      previousClient === args.client &&
+      previousSessionId !== undefined &&
+      previousSessionId === nextSessionId;
+
+    if (!preservesCommittedToolState) {
+      this.resetClientToolMetadataCache(args.client);
+    }
+
     this.transport = args.transport;
     this.session = args.client;
     this.connectionStateVersion += 1;
+    this._toolsCacheGeneration += 1;
     this._cacheDirty = true;
-    this._toolsList = [];
-
-    const previousSessionId = getSessionId(args.previousTransport);
-    const nextSessionId = getSessionId(args.transport);
-    if (
-      previousSessionId === undefined ||
-      nextSessionId === undefined ||
-      previousSessionId !== nextSessionId
-    ) {
-      this.resetClientToolMetadataCache(args.client);
+    if (!preservesCommittedToolState) {
+      this._toolsList = [];
     }
 
     await invalidateServerToolsCache(this.name);
@@ -1403,6 +1572,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
   }
 
   async invalidateToolsCache(): Promise<void> {
+    this._toolsCacheGeneration += 1;
     await invalidateServerToolsCache(this.name);
     this._cacheDirty = true;
   }
@@ -1419,18 +1589,38 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
       return this._toolsList;
     }
 
-    this._cacheDirty = false;
     const requestOptions = buildRequestOptions(
       this.clientSessionTimeoutSeconds,
     );
-    const response = await runMcpTransportOperation(
-      this.params.url,
-      'streamable HTTP list tools',
-      () => this.session!.listTools(undefined, requestOptions),
-    );
-    this.debugLog(() => `Listed tools: ${JSON.stringify(response)}`);
-    this._toolsList = ListToolsResultSchema.parse(response).tools;
-    return this._toolsList;
+    const session = this.session;
+    getClientToolMetadataCache(session);
+    const cacheGeneration = this._toolsCacheGeneration;
+    const tools = await listAllMcpTools({
+      fetchPage: (cursor) =>
+        runMcpTransportOperation(
+          this.params.url,
+          'streamable HTTP list tools',
+          () =>
+            requestMcpToolsPage(
+              session,
+              ListToolsResultSchema,
+              requestOptions,
+              cursor,
+            ),
+        ),
+      onPage: (response) =>
+        this.debugLog(() => `Listed tools: ${JSON.stringify(response)}`),
+    });
+    assertMcpToolListingIsCurrent({
+      listedClient: session,
+      currentClient: this.session,
+      listedGeneration: cacheGeneration,
+      currentGeneration: this._toolsCacheGeneration,
+    });
+    replaceClientToolMetadata(session, tools, this._toolsList);
+    this._toolsList = tools;
+    this._cacheDirty = false;
+    return tools;
   }
 
   async callTool(
@@ -1613,6 +1803,9 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
   async close(): Promise<void> {
     this.isClosed = true;
     this.connectionStateVersion += 1;
+    this._toolsCacheGeneration += 1;
+    this._cacheDirty = true;
+    this._toolsList = [];
     const closeStateVersion = this.connectionStateVersion;
 
     const reconnectPromise = this.reconnectingClientPromise;

--- a/packages/agents-core/test/mcpToolFilter.test.ts
+++ b/packages/agents-core/test/mcpToolFilter.test.ts
@@ -9,7 +9,8 @@ class StubServer extends NodeMCPServerStdio {
     super({ command: 'noop', name, toolFilter: filter, cacheToolsList: true });
     this.toolList = tools;
     this.session = {
-      listTools: async () => ({ tools: this.toolList }),
+      cacheToolMetadata: () => {},
+      request: async () => ({ tools: this.toolList }),
       callTool: async () => [],
       close: async () => {},
     } as any;

--- a/packages/agents-core/test/shims/mcp-server/node.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/node.test.ts
@@ -36,6 +36,10 @@ let callToolImplementation:
   ((params: any, resultSchema: any, options: any) => Promise<any>) | undefined;
 let connectImplementation:
   ((transport: any, options: any) => Promise<void>) | undefined;
+let listToolsImplementation:
+  ((params: any, options: any) => Promise<any>) | undefined;
+let listToolsCalls: Array<{ params: any; options: any }>;
+let clientToolMetadataCacheCalls: any[][];
 let listResourcesImplementation:
   ((params: any, options: any) => Promise<any>) | undefined;
 let terminateSessionImplementation: (() => Promise<void>) | undefined;
@@ -67,6 +71,25 @@ function createUnsafeTransportError(): Error {
   error.event = { message: `Event failed for ${CREDENTIAL_ENDPOINT}` };
   error.status = 502;
   return error;
+}
+
+function createMockTool(name: string, extra: Record<string, unknown> = {}) {
+  return {
+    name,
+    description: `Mock tool ${name}`,
+    inputSchema: {
+      type: 'object',
+    },
+    ...extra,
+  };
+}
+
+function createDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
 }
 
 function getErrorGraphText(value: unknown, seen = new Set<object>()): string {
@@ -126,6 +149,9 @@ beforeEach(() => {
   lastReadResourceParams = undefined;
   callToolImplementation = undefined;
   connectImplementation = undefined;
+  listToolsImplementation = undefined;
+  listToolsCalls = [];
+  clientToolMetadataCacheCalls = [];
   listResourcesImplementation = undefined;
   terminateSessionImplementation = undefined;
   retainCallToolSignalListener = false;
@@ -164,6 +190,18 @@ describe('NodeMCPServerStdio', () => {
     await server.connect();
     expect(lastConnectOptions?.timeout).toBe(5000);
     await server.close();
+  });
+
+  test('installed MCP client should support aggregate tool metadata caching', async () => {
+    const { Client } = await vi.importActual<
+      typeof import('@modelcontextprotocol/sdk/client/index.js')
+    >('@modelcontextprotocol/sdk/client/index.js');
+    const client = new Client({
+      name: 'metadata-compatibility-test',
+      version: '1.0.0',
+    });
+
+    expect(typeof (client as any).cacheToolMetadata).toBe('function');
   });
 
   test('should apply custom client session timeout when connecting', async () => {
@@ -313,6 +351,165 @@ describe('NodeMCPServerStdio', () => {
     await server.close();
   });
 
+  test('should list every tool page and cache only the complete result', async () => {
+    const continuation = createDeferred();
+    const continuationStarted = createDeferred();
+    listToolsImplementation = async (params) => {
+      if (params === undefined) {
+        return {
+          tools: [createMockTool('first-tool')],
+          nextCursor: '',
+        };
+      }
+      expect(params).toEqual({ cursor: '' });
+      continuationStarted.resolve();
+      await continuation.promise;
+      return { tools: [createMockTool('second-tool')] };
+    };
+    const server = new NodeMCPServerStdio({
+      name: 'paginated-tools',
+      fullCommand: 'test',
+      cacheToolsList: true,
+      clientSessionTimeoutSeconds: 6,
+    });
+
+    await server.connect();
+    const pendingTools = server.listTools();
+    await continuationStarted.promise;
+
+    expect(clientToolMetadataCacheCalls).toEqual([]);
+
+    continuation.resolve();
+    const tools = await pendingTools;
+    const cachedTools = await server.listTools();
+
+    expect(tools.map((tool) => tool.name)).toEqual([
+      'first-tool',
+      'second-tool',
+    ]);
+    expect(cachedTools).toBe(tools);
+    expect(listToolsCalls.map((call) => call.params)).toEqual([
+      undefined,
+      { cursor: '' },
+    ]);
+    expect(listToolsCalls.map((call) => call.options.timeout)).toEqual([
+      6000, 6000,
+    ]);
+    expect(
+      clientToolMetadataCacheCalls.map((tools) =>
+        tools.map((tool) => tool.name),
+      ),
+    ).toEqual([['first-tool', 'second-tool']]);
+
+    await server.close();
+  });
+
+  test('should reject a tool listing invalidated before commit', async () => {
+    const continuation = createDeferred();
+    const continuationStarted = createDeferred();
+    listToolsImplementation = async (params) => {
+      if (params === undefined) {
+        return {
+          tools: [createMockTool('stale-first-tool')],
+          nextCursor: 'continuation',
+        };
+      }
+      continuationStarted.resolve();
+      await continuation.promise;
+      return { tools: [createMockTool('stale-second-tool')] };
+    };
+    const server = new NodeMCPServerStdio({
+      name: 'invalidated-pagination',
+      fullCommand: 'test',
+      cacheToolsList: true,
+    });
+
+    await server.connect();
+    const staleListing = server.listTools();
+    await continuationStarted.promise;
+    await server.invalidateToolsCache();
+    continuation.resolve();
+
+    await expect(staleListing).rejects.toThrow(
+      'MCP tool listing became stale before it completed.',
+    );
+    expect(clientToolMetadataCacheCalls).toEqual([]);
+
+    listToolsImplementation = async () => ({
+      tools: [createMockTool('refreshed-tool')],
+    });
+    expect((await server.listTools()).map((tool) => tool.name)).toEqual([
+      'refreshed-tool',
+    ]);
+
+    await server.close();
+  });
+
+  test('should reject a tool listing from a replaced session', async () => {
+    const continuation = createDeferred();
+    const continuationStarted = createDeferred();
+    listToolsImplementation = async (params) => {
+      if (params === undefined) {
+        return {
+          tools: [createMockTool('old-first-tool')],
+          nextCursor: 'continuation',
+        };
+      }
+      continuationStarted.resolve();
+      await continuation.promise;
+      return { tools: [createMockTool('old-second-tool')] };
+    };
+    const server = new NodeMCPServerStdio({
+      name: 'replaced-session-pagination',
+      fullCommand: 'test',
+      cacheToolsList: true,
+    });
+
+    await server.connect();
+    const staleListing = server.listTools();
+    await continuationStarted.promise;
+    await server.close();
+    await server.connect();
+    continuation.resolve();
+
+    await expect(staleListing).rejects.toThrow(
+      'MCP tool listing became stale before it completed.',
+    );
+    expect(clientToolMetadataCacheCalls).toEqual([]);
+
+    listToolsImplementation = async () => ({
+      tools: [createMockTool('new-session-tool')],
+    });
+    expect((await server.listTools()).map((tool) => tool.name)).toEqual([
+      'new-session-tool',
+    ]);
+
+    await server.close();
+  });
+
+  test('should limit missing metadata caching failures to tool listing', async () => {
+    const server = new NodeMCPServerStdio({
+      name: 'missing-metadata-cache',
+      fullCommand: 'test',
+    });
+
+    await server.connect();
+    const session = (server as any).session;
+    session.request = vi.fn(async () => ({
+      tools: [createMockTool('uncommitted-tool')],
+    }));
+    session.cacheToolMetadata = undefined;
+
+    const resources = await server.listResources();
+    expect(resources.resources[0].uri).toBe('file:///mock-resource.txt');
+    await expect(server.listTools()).rejects.toThrow(
+      'The installed MCP SDK does not support tool metadata caching required for paginated tool listing.',
+    );
+    expect(session.request).not.toHaveBeenCalled();
+
+    await server.close();
+  });
+
   test('should forward resource requests to session methods', async () => {
     const server = new NodeMCPServerStdio({
       name: 'resource-test',
@@ -398,19 +595,19 @@ class MockClient {
     }
     return Promise.resolve();
   }
-  listTools(_params?: any, options?: any): Promise<any> {
+  cacheToolMetadata(tools: any[]): void {
+    clientToolMetadataCacheCalls.push(tools);
+  }
+  async request(request: any, _resultSchema: any, options?: any): Promise<any> {
+    if (request.method !== 'tools/list') {
+      throw new Error(`Unexpected request method: ${request.method}`);
+    }
+    const params = request.params;
     lastListToolsOptions = options;
-    return Promise.resolve({
-      tools: [
-        {
-          name: 'mock-tool',
-          description: 'Mock tool',
-          inputSchema: {
-            type: 'object',
-          },
-        },
-      ],
-    });
+    listToolsCalls.push({ params, options });
+    return listToolsImplementation
+      ? await listToolsImplementation(params, options)
+      : { tools: [createMockTool('mock-tool')] };
   }
   callTool(_params: any, _resultSchema?: any, options?: any): Promise<any> {
     lastCallToolParams = _params;
@@ -884,6 +1081,49 @@ describe('NodeMCPServerSSE', () => {
     await server.close();
   });
 
+  test('should reject repeated tool cursors without caching partial results', async () => {
+    listToolsImplementation = async (params) => {
+      if (params === undefined) {
+        return {
+          tools: [createMockTool('first-tool')],
+          nextCursor: 'repeated-cursor',
+        };
+      }
+      return {
+        tools: [createMockTool('second-tool')],
+        nextCursor: 'repeated-cursor',
+      };
+    };
+    const server = new NodeMCPServerSSE({
+      url: 'https://example.com/sse',
+      name: 'repeated-tool-cursor',
+      cacheToolsList: true,
+    });
+
+    await server.connect();
+
+    await expect(server.listTools()).rejects.toThrow(
+      'MCP server returned a repeated cursor while listing tools.',
+    );
+    expect(listToolsCalls.map((call) => call.params)).toEqual([
+      undefined,
+      { cursor: 'repeated-cursor' },
+    ]);
+    expect(clientToolMetadataCacheCalls).toEqual([]);
+
+    listToolsCalls = [];
+    listToolsImplementation = async () => ({
+      tools: [createMockTool('recovered-tool')],
+    });
+
+    expect((await server.listTools()).map((tool) => tool.name)).toEqual([
+      'recovered-tool',
+    ]);
+    expect(listToolsCalls.map((call) => call.params)).toEqual([undefined]);
+
+    await server.close();
+  });
+
   test('should preserve caller cancellation on credentialed endpoints', async () => {
     let markCallStarted: (() => void) | undefined;
     const callStarted = new Promise<void>((resolve) => {
@@ -1243,6 +1483,41 @@ describe('NodeMCPServerStreamableHttp', () => {
     expect(lastCallToolOptions?.timeout).toBe(DEFAULT_REQUEST_TIMEOUT_MSEC);
     expect(lastCallToolOptions?.signal).toBeDefined();
     expect(lastCallToolOptions?.signal).not.toBe(controller.signal);
+
+    await server.close();
+  });
+
+  test('should redact cursors from later tool page errors and restore metadata', async () => {
+    const opaqueCursor = 'SECRET_OPAQUE_CURSOR';
+    const unsafeError = new Error(`Continuation failed for ${opaqueCursor}`);
+    listToolsImplementation = async (params) => {
+      if (params === undefined) {
+        return {
+          tools: [createMockTool('first-tool')],
+          nextCursor: opaqueCursor,
+        };
+      }
+      throw unsafeError;
+    };
+    const server = new NodeMCPServerStreamableHttp({
+      url: 'https://example.test/mcp',
+      name: 'unsafe-tool-page',
+    });
+
+    await server.connect();
+    const error = await server.listTools().catch((caught) => caught);
+
+    expect(error).not.toBe(unsafeError);
+    expect(error).toMatchObject({
+      name: 'Error',
+      message: 'MCP tool listing failed while fetching a continuation page.',
+    });
+    expect(getErrorGraphText(error)).not.toContain(opaqueCursor);
+    expect(listToolsCalls.map((call) => call.params)).toEqual([
+      undefined,
+      { cursor: opaqueCursor },
+    ]);
+    expect(clientToolMetadataCacheCalls.at(-1)).toEqual([]);
 
     await server.close();
   });

--- a/packages/agents-core/test/shims/mcp-server/streamableHttpRetry.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/streamableHttpRetry.test.ts
@@ -105,6 +105,7 @@ class MockStreamableHTTPClientTransport {
 
 class MockClient {
   static instances: MockClient[] = [];
+  static toolMetadataCacheSupported = true;
   static connectHandlers: Array<
     ((this: MockClient) => Promise<void>) | undefined
   > = [];
@@ -146,6 +147,11 @@ class MockClient {
   constructor(_options: { name: string; version: string }) {
     this.instanceIndex = MockClient.instances.length;
     MockClient.instances.push(this);
+    if (!MockClient.toolMetadataCacheSupported) {
+      Object.defineProperty(this, 'cacheToolMetadata', {
+        value: undefined,
+      });
+    }
   }
 
   private get transportIndex(): number {
@@ -196,9 +202,11 @@ class MockClient {
     }
   }
 
-  async listTools(): Promise<{ tools: MockTool[] }> {
+  async request(request: { method: string }): Promise<{ tools: MockTool[] }> {
+    if (request.method !== 'tools/list') {
+      throw new Error(`Unexpected request method: ${request.method}`);
+    }
     const tools = MockClient.listToolsResults[this.transportIndex] ?? [];
-    this.cacheToolMetadata(tools);
     return { tools };
   }
 
@@ -370,6 +378,7 @@ function throwProtocolNotConnected(this: MockClient): never {
 describe('NodeMCPServerStreamableHttp closed-session recovery', () => {
   beforeAll(() => {
     MockClient.instances = [];
+    MockClient.toolMetadataCacheSupported = true;
     MockClient.connectHandlers = [];
     MockClient.listToolsResults = [];
     MockClient.sessionIdAssignments = [];
@@ -380,12 +389,36 @@ describe('NodeMCPServerStreamableHttp closed-session recovery', () => {
 
   beforeEach(() => {
     MockClient.instances = [];
+    MockClient.toolMetadataCacheSupported = true;
     MockClient.connectHandlers = [];
     MockClient.listToolsResults = [];
     MockClient.sessionIdAssignments = [];
     MockClient.notificationHandlers = [];
     MockClient.callToolHandlers = [];
     MockStreamableHTTPClientTransport.instances = [];
+  });
+
+  it('publishes connections without metadata caching and fails tool listing early', async () => {
+    MockClient.toolMetadataCacheSupported = false;
+    const server = createServer('missing-metadata-cache-server');
+
+    await server.connect();
+
+    const client = MockClient.instances[0];
+    const requestSpy = vi.spyOn(client, 'request');
+    await expect(server.listTools()).rejects.toThrow(
+      'The installed MCP SDK does not support tool metadata caching required for paginated tool listing.',
+    );
+
+    expect(MockClient.instances).toHaveLength(1);
+    expect(client.connectMock).toHaveBeenCalledOnce();
+    expect((server as any).session).toBe(client);
+    expect((server as any).transport).toBe(
+      MockStreamableHTTPClientTransport.instances[0],
+    );
+    expect(requestSpy).not.toHaveBeenCalled();
+
+    await server.close();
   });
 
   it('heals closed streamable HTTP sessions for follow-up calls on the existing client', async () => {
@@ -524,6 +557,69 @@ describe('NodeMCPServerStreamableHttp closed-session recovery', () => {
       ]);
       expect(MockClient.instances).toHaveLength(1);
       expect(MockStreamableHTTPClientTransport.instances).toHaveLength(2);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('restores committed metadata when a same-session refresh fails', async () => {
+    MockClient.sessionIdAssignments = ['shared-session'];
+    MockClient.listToolsResults = [
+      [
+        {
+          name: 'regular-tool',
+          inputSchema: { type: 'object' },
+        },
+        {
+          name: 'previous-required-tool',
+          execution: { taskSupport: 'required' },
+          inputSchema: { type: 'object' },
+        },
+      ],
+      [
+        {
+          name: 'metadata-compile-failure',
+          inputSchema: { type: 'object' },
+        },
+      ],
+    ];
+    MockClient.callToolHandlers = [
+      async () => {
+        throw new McpError(ErrorCode.ConnectionClosed, 'shared session closed');
+      },
+    ];
+
+    const server = createServer('metadata-rollback-server');
+    await server.connect();
+
+    try {
+      expect(await server.listTools()).toHaveLength(2);
+      const client = MockClient.instances[0];
+      const cacheToolMetadata = client.cacheToolMetadata.bind(client);
+      client.cacheToolMetadata = (tools) => {
+        if (tools.some((tool) => tool.name === 'metadata-compile-failure')) {
+          cacheToolMetadata([]);
+          throw new Error('metadata compilation failed');
+        }
+        cacheToolMetadata(tools);
+      };
+
+      await expect(server.callTool('regular-tool', null)).rejects.toMatchObject(
+        {
+          name: 'McpError',
+          code: ErrorCode.ConnectionClosed,
+        },
+      );
+      await expect(server.listTools()).rejects.toThrow(
+        'metadata compilation failed',
+      );
+      await expect(
+        server.callTool('previous-required-tool', null),
+      ).rejects.toMatchObject({
+        name: 'McpError',
+        code: ErrorCode.InvalidRequest,
+      });
+      expect(MockClient.instances).toHaveLength(1);
     } finally {
       await server.close();
     }


### PR DESCRIPTION
This pull request fixes MCP tool discovery so stdio, SSE, and Streamable HTTP servers follow every `tools/list` continuation cursor before publishing the tool set. Previously, agents could omit tools beyond the first page, and a later-page failure could leave MCP SDK metadata inconsistent with the server cache or expose an opaque cursor through the error chain. The implementation now commits the complete tool list and metadata together, restores the latest committed metadata on failure, rejects repeated cursors, preserves empty-string cursors, and fails closed when the installed MCP client cannot cache aggregate metadata.

see also: https://github.com/openai/openai-agents-python/pull/4094