### PR TITLE
feat: support MCP SDK v2 negotiation

### DIFF
--- a/.changeset/modern-mcp-negotiation.md
+++ b/.changeset/modern-mcp-negotiation.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': minor
+---
+
+feat: support MCP 2026-07-28 negotiation with legacy fallback

--- a/packages/agents-core/package.json
+++ b/packages/agents-core/package.json
@@ -113,7 +113,7 @@
   ],
   "license": "MIT",
   "optionalDependencies": {
-    "@modelcontextprotocol/sdk": "^1.26.0"
+    "@modelcontextprotocol/client": "^2.0.0"
   },
   "dependencies": {
     "debug": "^4.4.0",

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -1295,14 +1295,14 @@ export interface MCPServerStreamableHttpOptions {
 
   // ----------------------------------------------------
   // OAuth
-  // import { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
+  // import { OAuthClientProvider } from '@modelcontextprotocol/client';
   authProvider?: any;
   // RequestInit
   requestInit?: any;
   // Custom fetch implementation used for all network requests.
-  // import { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js';
+  // import { FetchLike } from '@modelcontextprotocol/client';
   fetch?: any;
-  // import { StreamableHTTPReconnectionOptions } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+  // import { StreamableHTTPReconnectionOptions } from '@modelcontextprotocol/client';
   reconnectionOptions?: any;
   sessionId?: string;
   // ----------------------------------------------------
@@ -1337,14 +1337,14 @@ export interface MCPServerSSEOptions {
 
   // ----------------------------------------------------
   // OAuth
-  // import { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
+  // import { OAuthClientProvider } from '@modelcontextprotocol/client';
   authProvider?: any;
   // RequestInit
   requestInit?: any;
   // Custom fetch implementation used for all network requests.
-  // import { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js';
+  // import { FetchLike } from '@modelcontextprotocol/client';
   fetch?: any;
-  // import { SSEReconnectionOptions } from '@modelcontextprotocol/sdk/client/sse.js';
+  // import { SSEClientTransportOptions } from '@modelcontextprotocol/client';
   eventSourceInit?: any;
   // ----------------------------------------------------
 }

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -1,7 +1,12 @@
-import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { DEFAULT_REQUEST_TIMEOUT_MSEC } from '@modelcontextprotocol/sdk/shared/protocol.js';
-import type { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js';
-import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import {
+  DEFAULT_REQUEST_TIMEOUT_MSEC,
+  ProtocolError,
+  ProtocolErrorCode,
+  type CacheableRequestOptions,
+  type Client,
+  type RequestOptions,
+  type Transport,
+} from '@modelcontextprotocol/client';
 
 import {
   BaseMCPServerStdio,
@@ -38,18 +43,14 @@ export interface SessionMessage {
   message: any;
 }
 
-type StreamableHttpClientModule =
-  typeof import('@modelcontextprotocol/sdk/client/index.js');
-type StreamableHttpTransportModule =
-  typeof import('@modelcontextprotocol/sdk/client/streamableHttp.js');
-type MCPTypesModule = typeof import('@modelcontextprotocol/sdk/types.js');
+type MCPClientModule = typeof import('@modelcontextprotocol/client');
 
 function failedToImport(error: unknown): never {
   logger.error(
     `
-Failed to load the MCP SDK. Please install the @modelcontextprotocol/sdk package.
+Failed to load the MCP SDK. Please install the @modelcontextprotocol/client package.
 
-npm install @modelcontextprotocol/sdk
+npm install @modelcontextprotocol/client
     `.trim(),
   );
   throw error;
@@ -78,6 +79,98 @@ function buildRequestOptions(
   return Object.keys(mergedOptions).length === 0 ? undefined : mergedOptions;
 }
 
+function buildCacheableRequestOptions(
+  clientSessionTimeoutSeconds?: number,
+  cacheMode: CacheableRequestOptions['cacheMode'] = 'refresh',
+): CacheableRequestOptions {
+  return {
+    ...buildRequestOptions(clientSessionTimeoutSeconds),
+    cacheMode,
+  };
+}
+
+const MCP_LIST_MAX_PAGES = 64;
+
+async function listToolsForResumedSession(
+  client: Client,
+  requestOptions: RequestOptions | undefined,
+): Promise<{ tools: MCPTool[] }> {
+  const tools: MCPTool[] = [];
+  let cursor: string | undefined;
+
+  for (let page = 0; page < MCP_LIST_MAX_PAGES; page += 1) {
+    const response = await client.request(
+      {
+        method: 'tools/list',
+        ...(cursor === undefined ? {} : { params: { cursor } }),
+      },
+      requestOptions,
+    );
+    tools.push(...(response.tools as MCPTool[]));
+    cursor = response.nextCursor;
+    if (cursor === undefined) {
+      return { tools };
+    }
+  }
+
+  throw new Error(
+    `MCP tools/list pagination exceeded ${MCP_LIST_MAX_PAGES} pages.`,
+  );
+}
+
+function shouldListToolsForResumedSession(
+  client: Client,
+  transport: unknown,
+): boolean {
+  return (
+    client.getServerCapabilities() === undefined &&
+    getSessionId(transport) !== undefined
+  );
+}
+
+function getListedToolForCall(tools: readonly MCPTool[], toolName: string) {
+  const tool = tools.find((tool) => tool.name === toolName) as
+    | (MCPTool & {
+        execution?: { taskSupport?: 'forbidden' | 'optional' | 'required' };
+      })
+    | undefined;
+  if (tool?.execution?.taskSupport === 'required') {
+    throw new ProtocolError(
+      ProtocolErrorCode.InvalidRequest,
+      `Tool "${toolName}" requires task-based execution. Use client.experimental.tasks.callToolStream() instead.`,
+    );
+  }
+  return tool;
+}
+
+function listResourcesPage(
+  client: Client,
+  params: MCPListResourcesParams | undefined,
+  requestOptions: RequestOptions | undefined,
+) {
+  return client.request(
+    {
+      method: 'resources/list',
+      ...(params === undefined ? {} : { params }),
+    },
+    requestOptions,
+  );
+}
+
+function listResourceTemplatesPage(
+  client: Client,
+  params: MCPListResourcesParams | undefined,
+  requestOptions: RequestOptions | undefined,
+) {
+  return client.request(
+    {
+      method: 'resources/templates/list',
+      ...(params === undefined ? {} : { params }),
+    },
+    requestOptions,
+  );
+}
+
 async function callWithMCPRequestSignal<T>(
   sourceSignal: AbortSignal | undefined,
   call: (requestSignal: AbortSignal | undefined) => Promise<T>,
@@ -103,73 +196,6 @@ type MaybeProtocolVersionTransport = MaybeSessionTransport & {
   protocolVersion?: string;
 };
 
-type ClientWithToolMetadataCache = {
-  cacheToolMetadata?: (tools: unknown[]) => void;
-};
-
-type MCPToolsPage = {
-  tools: MCPTool[];
-  nextCursor?: string;
-};
-
-type MCPToolsResultSchema = Parameters<Client['request']>[1];
-
-function getOptionalClientToolMetadataCache(
-  client: Client,
-): ClientWithToolMetadataCache['cacheToolMetadata'] {
-  const cacheToolMetadata = (client as unknown as ClientWithToolMetadataCache)
-    .cacheToolMetadata;
-  return typeof cacheToolMetadata === 'function'
-    ? cacheToolMetadata
-    : undefined;
-}
-
-function getClientToolMetadataCache(
-  client: Client,
-): NonNullable<ClientWithToolMetadataCache['cacheToolMetadata']> {
-  const cacheToolMetadata = getOptionalClientToolMetadataCache(client);
-  if (typeof cacheToolMetadata !== 'function') {
-    throw new Error(
-      'The installed MCP SDK does not support tool metadata caching required for paginated tool listing.',
-    );
-  }
-  return cacheToolMetadata;
-}
-
-async function requestMcpToolsPage(
-  client: Client,
-  resultSchema: MCPToolsResultSchema,
-  options: RequestOptions | undefined,
-  cursor: string | undefined,
-): Promise<MCPToolsPage> {
-  return (await client.request(
-    {
-      method: 'tools/list',
-      params: cursor === undefined ? undefined : { cursor },
-    },
-    resultSchema,
-    options,
-  )) as MCPToolsPage;
-}
-
-function cacheClientToolMetadata(client: Client, tools: MCPTool[]): void {
-  const cacheToolMetadata = getClientToolMetadataCache(client);
-  cacheToolMetadata.call(client, tools);
-}
-
-function replaceClientToolMetadata(
-  client: Client,
-  tools: MCPTool[],
-  fallbackTools: MCPTool[],
-): void {
-  try {
-    cacheClientToolMetadata(client, tools);
-  } catch (error) {
-    cacheClientToolMetadata(client, fallbackTools);
-    throw error;
-  }
-}
-
 function assertMcpToolListingIsCurrent(args: {
   listedClient: Client;
   currentClient: Client | null;
@@ -181,43 +207,6 @@ function assertMcpToolListingIsCurrent(args: {
     args.currentGeneration !== args.listedGeneration
   ) {
     throw new Error('MCP tool listing became stale before it completed.');
-  }
-}
-
-async function listAllMcpTools(args: {
-  fetchPage: (cursor: string | undefined) => Promise<MCPToolsPage>;
-  onPage: (response: MCPToolsPage) => void;
-}): Promise<MCPTool[]> {
-  const tools: MCPTool[] = [];
-  const seenCursors = new Set<string>();
-  let cursor: string | undefined;
-
-  while (true) {
-    let page: MCPToolsPage;
-    try {
-      page = await args.fetchPage(cursor);
-      args.onPage(page);
-    } catch (error) {
-      if (cursor === undefined) {
-        throw error;
-      }
-      throw new Error(
-        'MCP tool listing failed while fetching a continuation page.',
-      );
-    }
-    tools.push(...page.tools);
-
-    const nextCursor = page.nextCursor;
-    if (nextCursor === undefined) {
-      return tools;
-    }
-    if (seenCursors.has(nextCursor)) {
-      throw new Error(
-        'MCP server returned a repeated cursor while listing tools.',
-      );
-    }
-    seenCursors.add(nextCursor);
-    cursor = nextCursor;
   }
 }
 
@@ -245,14 +234,6 @@ function getTransportProtocolVersion(transport: unknown): string | undefined {
   }
 
   return undefined;
-}
-
-function isNotConnectedError(error: unknown, client: Client): boolean {
-  return (
-    error instanceof Error &&
-    error.message === 'Not connected' &&
-    client.transport == null
-  );
 }
 
 function attachCause(error: unknown, cause: unknown): unknown {
@@ -395,23 +376,25 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
     this._toolsList = [];
     try {
       const { StdioClientTransport } =
-        await import('@modelcontextprotocol/sdk/client/stdio.js').catch(
+        await import('@modelcontextprotocol/client/stdio').catch(
           failedToImport,
         );
-      const { Client } =
-        await import('@modelcontextprotocol/sdk/client/index.js').catch(
-          failedToImport,
-        );
+      const { Client } = await import('@modelcontextprotocol/client').catch(
+        failedToImport,
+      );
       this.transport = new StdioClientTransport({
         command: this.params.command,
         args: this.params.args,
         env: this.params.env,
         cwd: this.params.cwd,
       });
-      this.session = new Client({
-        name: this._name,
-        version: '1.0.0', // You may want to make this configurable
-      });
+      this.session = new Client(
+        {
+          name: this._name,
+          version: '1.0.0', // You may want to make this configurable
+        },
+        { versionNegotiation: { mode: 'auto' } },
+      );
       const requestOptions = buildRequestOptions(
         this.clientSessionTimeoutSeconds,
       );
@@ -434,8 +417,6 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
   }
 
   async listTools(): Promise<MCPTool[]> {
-    const { ListToolsResultSchema } =
-      await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
     if (!this.session) {
       throw new Error(
         'Server not initialized. Make sure you call connect() first.',
@@ -445,30 +426,21 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
       return this._toolsList;
     }
 
-    const requestOptions = buildRequestOptions(
+    const requestOptions = buildCacheableRequestOptions(
       this.clientSessionTimeoutSeconds,
+      'bypass',
     );
     const session = this.session;
-    getClientToolMetadataCache(session);
     const cacheGeneration = this._toolsCacheGeneration;
-    const tools = await listAllMcpTools({
-      fetchPage: (cursor) =>
-        requestMcpToolsPage(
-          session,
-          ListToolsResultSchema,
-          requestOptions,
-          cursor,
-        ),
-      onPage: (response) =>
-        this.debugLog(() => `Listed tools: ${JSON.stringify(response)}`),
-    });
+    const response = await session.listTools(undefined, requestOptions);
+    this.debugLog(() => `Listed tools: ${JSON.stringify(response)}`);
     assertMcpToolListingIsCurrent({
       listedClient: session,
       currentClient: this.session,
       listedGeneration: cacheGeneration,
       currentGeneration: this._toolsCacheGeneration,
     });
-    replaceClientToolMetadata(session, tools, this._toolsList);
+    const tools = response.tools as MCPTool[];
     this._toolsList = tools;
     this._cacheDirty = false;
     return tools;
@@ -489,8 +461,6 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
     meta?: Record<string, unknown> | null,
     options?: MCPCallToolOptions,
   ): Promise<CallToolResult> {
-    const { CallToolResultSchema } =
-      await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
     if (!this.session) {
       throw new Error(
         'Server not initialized. Make sure you call connect() first.',
@@ -505,17 +475,17 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
     const response = await callWithMCPRequestSignal(
       options?.signal,
       (requestSignal) =>
-        session.callTool(
-          params,
-          undefined,
-          buildRequestOptions(this.clientSessionTimeoutSeconds, {
+        session.callTool(params, {
+          ...buildRequestOptions(this.clientSessionTimeoutSeconds, {
             timeout: this.timeout,
             signal: requestSignal,
           }),
-        ),
+          toolDefinition: getListedToolForCall(this._toolsList, toolName),
+        }),
     );
-    const parsed = CallToolResultSchema.parse(response);
-    const result = attachParsedCallToolResultMetadata(parsed as CallToolResult);
+    const result = attachParsedCallToolResultMetadata(
+      response as CallToolResult,
+    );
     this.debugLog(
       () =>
         `Called tool ${toolName} (args: ${JSON.stringify(args)}, result: ${JSON.stringify(result)})`,
@@ -526,8 +496,6 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
   async listResources(
     params?: MCPListResourcesParams,
   ): Promise<MCPListResourcesResult> {
-    const { ListResourcesResultSchema } =
-      await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
     if (!this.session) {
       throw new Error(
         'Server not initialized. Make sure you call connect() first.',
@@ -536,16 +504,18 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
     const requestOptions = buildRequestOptions(
       this.clientSessionTimeoutSeconds,
     );
-    const response = await this.session.listResources(params, requestOptions);
+    const response = await listResourcesPage(
+      this.session,
+      params,
+      requestOptions,
+    );
     this.debugLog(() => `Listed resources: ${JSON.stringify(response)}`);
-    return ListResourcesResultSchema.parse(response) as MCPListResourcesResult;
+    return response as MCPListResourcesResult;
   }
 
   async listResourceTemplates(
     params?: MCPListResourcesParams,
   ): Promise<MCPListResourceTemplatesResult> {
-    const { ListResourceTemplatesResultSchema } =
-      await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
     if (!this.session) {
       throw new Error(
         'Server not initialized. Make sure you call connect() first.',
@@ -554,32 +524,29 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
     const requestOptions = buildRequestOptions(
       this.clientSessionTimeoutSeconds,
     );
-    const response = await this.session.listResourceTemplates(
+    const response = await listResourceTemplatesPage(
+      this.session,
       params,
       requestOptions,
     );
     this.debugLog(
       () => `Listed resource templates: ${JSON.stringify(response)}`,
     );
-    return ListResourceTemplatesResultSchema.parse(
-      response,
-    ) as MCPListResourceTemplatesResult;
+    return response as MCPListResourceTemplatesResult;
   }
 
   async readResource(uri: string): Promise<MCPReadResourceResult> {
-    const { ReadResourceResultSchema } =
-      await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
     if (!this.session) {
       throw new Error(
         'Server not initialized. Make sure you call connect() first.',
       );
     }
-    const requestOptions = buildRequestOptions(
+    const requestOptions = buildCacheableRequestOptions(
       this.clientSessionTimeoutSeconds,
     );
     const response = await this.session.readResource({ uri }, requestOptions);
     this.debugLog(() => `Read resource ${uri}: ${JSON.stringify(response)}`);
-    return ReadResourceResultSchema.parse(response) as MCPReadResourceResult;
+    return response as MCPReadResourceResult;
   }
 
   get name() {
@@ -643,13 +610,10 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
     this._toolsList = [];
     try {
       const { SSEClientTransport } =
-        await import('@modelcontextprotocol/sdk/client/sse.js').catch(
-          failedToImport,
-        );
-      const { Client } =
-        await import('@modelcontextprotocol/sdk/client/index.js').catch(
-          failedToImport,
-        );
+        await import('@modelcontextprotocol/client').catch(failedToImport);
+      const { Client } = await import('@modelcontextprotocol/client').catch(
+        failedToImport,
+      );
       this.transport = new SSEClientTransport(new URL(this.params.url), {
         authProvider: this.params.authProvider,
         requestInit: this.params.requestInit,
@@ -687,8 +651,6 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
   }
 
   async listTools(): Promise<MCPTool[]> {
-    const { ListToolsResultSchema } =
-      await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
     if (!this.session) {
       throw new Error(
         'Server not initialized. Make sure you call connect() first.',
@@ -698,32 +660,25 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
       return this._toolsList;
     }
 
-    const requestOptions = buildRequestOptions(
+    const requestOptions = buildCacheableRequestOptions(
       this.clientSessionTimeoutSeconds,
+      'bypass',
     );
     const session = this.session;
-    getClientToolMetadataCache(session);
     const cacheGeneration = this._toolsCacheGeneration;
-    const tools = await listAllMcpTools({
-      fetchPage: (cursor) =>
-        runMcpTransportOperation(this.params.url, 'SSE list tools', () =>
-          requestMcpToolsPage(
-            session,
-            ListToolsResultSchema,
-            requestOptions,
-            cursor,
-          ),
-        ),
-      onPage: (response) =>
-        this.debugLog(() => `Listed tools: ${JSON.stringify(response)}`),
-    });
+    const response = await runMcpTransportOperation(
+      this.params.url,
+      'SSE list tools',
+      () => session.listTools(undefined, requestOptions),
+    );
+    this.debugLog(() => `Listed tools: ${JSON.stringify(response)}`);
     assertMcpToolListingIsCurrent({
       listedClient: session,
       currentClient: this.session,
       listedGeneration: cacheGeneration,
       currentGeneration: this._toolsCacheGeneration,
     });
-    replaceClientToolMetadata(session, tools, this._toolsList);
+    const tools = response.tools as MCPTool[];
     this._toolsList = tools;
     this._cacheDirty = false;
     return tools;
@@ -744,8 +699,6 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
     meta?: Record<string, unknown> | null,
     options?: MCPCallToolOptions,
   ): Promise<CallToolResult> {
-    const { CallToolResultSchema } =
-      await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
     if (!this.session) {
       throw new Error(
         'Server not initialized. Make sure you call connect() first.',
@@ -762,19 +715,19 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
       'SSE tool call',
       () =>
         callWithMCPRequestSignal(options?.signal, (requestSignal) =>
-          session.callTool(
-            params,
-            undefined,
-            buildRequestOptions(this.clientSessionTimeoutSeconds, {
+          session.callTool(params, {
+            ...buildRequestOptions(this.clientSessionTimeoutSeconds, {
               timeout: this.timeout,
               signal: requestSignal,
             }),
-          ),
+            toolDefinition: getListedToolForCall(this._toolsList, toolName),
+          }),
         ),
       options?.signal,
     );
-    const parsed = CallToolResultSchema.parse(response);
-    const result = attachParsedCallToolResultMetadata(parsed as CallToolResult);
+    const result = attachParsedCallToolResultMetadata(
+      response as CallToolResult,
+    );
     this.debugLog(
       () =>
         `Called tool ${toolName} (args: ${JSON.stringify(args)}, result: ${JSON.stringify(result)})`,
@@ -785,8 +738,6 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
   async listResources(
     params?: MCPListResourcesParams,
   ): Promise<MCPListResourcesResult> {
-    const { ListResourcesResultSchema } =
-      await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
     if (!this.session) {
       throw new Error(
         'Server not initialized. Make sure you call connect() first.',
@@ -798,17 +749,15 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
     const response = await runMcpTransportOperation(
       this.params.url,
       'SSE list resources',
-      () => this.session!.listResources(params, requestOptions),
+      () => listResourcesPage(this.session!, params, requestOptions),
     );
     this.debugLog(() => `Listed resources: ${JSON.stringify(response)}`);
-    return ListResourcesResultSchema.parse(response) as MCPListResourcesResult;
+    return response as MCPListResourcesResult;
   }
 
   async listResourceTemplates(
     params?: MCPListResourcesParams,
   ): Promise<MCPListResourceTemplatesResult> {
-    const { ListResourceTemplatesResultSchema } =
-      await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
     if (!this.session) {
       throw new Error(
         'Server not initialized. Make sure you call connect() first.',
@@ -820,25 +769,21 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
     const response = await runMcpTransportOperation(
       this.params.url,
       'SSE list resource templates',
-      () => this.session!.listResourceTemplates(params, requestOptions),
+      () => listResourceTemplatesPage(this.session!, params, requestOptions),
     );
     this.debugLog(
       () => `Listed resource templates: ${JSON.stringify(response)}`,
     );
-    return ListResourceTemplatesResultSchema.parse(
-      response,
-    ) as MCPListResourceTemplatesResult;
+    return response as MCPListResourceTemplatesResult;
   }
 
   async readResource(uri: string): Promise<MCPReadResourceResult> {
-    const { ReadResourceResultSchema } =
-      await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
     if (!this.session) {
       throw new Error(
         'Server not initialized. Make sure you call connect() first.',
       );
     }
-    const requestOptions = buildRequestOptions(
+    const requestOptions = buildCacheableRequestOptions(
       this.clientSessionTimeoutSeconds,
     );
     const response = await runMcpTransportOperation(
@@ -847,7 +792,7 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
       () => this.session!.readResource({ uri }, requestOptions),
     );
     this.debugLog(() => `Read resource ${uri}: ${JSON.stringify(response)}`);
-    return ReadResourceResultSchema.parse(response) as MCPReadResourceResult;
+    return response as MCPReadResourceResult;
   }
 
   get name() {
@@ -922,27 +867,20 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
   }
 
   private async loadStreamableHttpRuntime(): Promise<{
-    clientModule: StreamableHttpClientModule;
-    transportModule: StreamableHttpTransportModule;
-    typesModule: MCPTypesModule;
+    clientModule: MCPClientModule;
+    transportModule: MCPClientModule;
   }> {
-    const [clientModule, transportModule, typesModule] = await Promise.all([
-      import('@modelcontextprotocol/sdk/client/index.js').catch(failedToImport),
-      import('@modelcontextprotocol/sdk/client/streamableHttp.js').catch(
-        failedToImport,
-      ),
-      import('@modelcontextprotocol/sdk/types.js').catch(failedToImport),
-    ]);
+    const clientModule = await import('@modelcontextprotocol/client').catch(
+      failedToImport,
+    );
 
-    return { clientModule, transportModule, typesModule };
+    return { clientModule, transportModule: clientModule };
   }
 
   private createStreamableHttpTransport(
-    StreamableHTTPClientTransport: StreamableHttpTransportModule['StreamableHTTPClientTransport'],
+    StreamableHTTPClientTransport: MCPClientModule['StreamableHTTPClientTransport'],
     options: { protocolVersion?: string; sessionId?: string } = {},
-  ): InstanceType<
-    StreamableHttpTransportModule['StreamableHTTPClientTransport']
-  > {
+  ): InstanceType<MCPClientModule['StreamableHTTPClientTransport']> {
     const transportOptions = {
       authProvider: this.params.authProvider,
       requestInit: this.params.requestInit,
@@ -960,14 +898,14 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
       options.protocolVersion !== undefined &&
       typeof (
         transport as InstanceType<
-          StreamableHttpTransportModule['StreamableHTTPClientTransport']
+          MCPClientModule['StreamableHTTPClientTransport']
         > &
           MaybeProtocolVersionTransport
       ).setProtocolVersion === 'function'
     ) {
       (
         transport as InstanceType<
-          StreamableHttpTransportModule['StreamableHTTPClientTransport']
+          MCPClientModule['StreamableHTTPClientTransport']
         > &
           MaybeProtocolVersionTransport
       ).setProtocolVersion!(options.protocolVersion);
@@ -980,9 +918,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     options: { sessionId?: string } = {},
   ): Promise<{
     client: Client;
-    transport: InstanceType<
-      StreamableHttpTransportModule['StreamableHTTPClientTransport']
-    >;
+    transport: InstanceType<MCPClientModule['StreamableHTTPClientTransport']>;
   }> {
     const { clientModule, transportModule } =
       await this.loadStreamableHttpRuntime();
@@ -992,10 +928,13 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
       StreamableHTTPClientTransport,
       options,
     );
-    const client = new Client({
-      name: this._name,
-      version: '1.0.0',
-    });
+    const client = new Client(
+      {
+        name: this._name,
+        version: '1.0.0',
+      },
+      { versionNegotiation: { mode: 'auto' } },
+    );
     try {
       const requestOptions = buildRequestOptions(
         this.clientSessionTimeoutSeconds,
@@ -1023,33 +962,17 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     return Math.max(1, (this.clientSessionTimeoutSeconds ?? 5) * 1000);
   }
 
-  private resetClientToolMetadataCache(client: Client): void {
-    getOptionalClientToolMetadataCache(client)?.call(client, []);
-  }
-
   private async publishConnectedStreamableHttpClient(args: {
     client: Client;
     transport: MaybeSessionTransport;
-    previousTransport?: MaybeSessionTransport | null;
+    preserveTools?: boolean;
   }): Promise<void> {
-    const previousClient = this.session;
-    const previousSessionId = getSessionId(args.previousTransport);
-    const nextSessionId = getSessionId(args.transport);
-    const preservesCommittedToolState =
-      previousClient === args.client &&
-      previousSessionId !== undefined &&
-      previousSessionId === nextSessionId;
-
-    if (!preservesCommittedToolState) {
-      this.resetClientToolMetadataCache(args.client);
-    }
-
     this.transport = args.transport;
     this.session = args.client;
     this.connectionStateVersion += 1;
     this._toolsCacheGeneration += 1;
     this._cacheDirty = true;
-    if (!preservesCommittedToolState) {
+    if (!args.preserveTools) {
       this._toolsList = [];
     }
 
@@ -1195,8 +1118,6 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     meta?: Record<string, unknown> | null,
     options?: MCPCallToolOptions,
   ): Promise<CallToolResult> {
-    const { CallToolResultSchema } =
-      await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
     const params = {
       name: toolName,
       arguments: args ?? {},
@@ -1205,17 +1126,15 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     const response = await callWithMCPRequestSignal(
       options?.signal,
       (requestSignal) =>
-        client.callTool(
-          params,
-          undefined,
-          buildRequestOptions(this.clientSessionTimeoutSeconds, {
+        client.callTool(params, {
+          ...buildRequestOptions(this.clientSessionTimeoutSeconds, {
             timeout: this.timeout,
             signal: requestSignal,
           }),
-        ),
+          toolDefinition: getListedToolForCall(this._toolsList, toolName),
+        }),
     );
-    const parsed = CallToolResultSchema.parse(response);
-    return attachParsedCallToolResultMetadata(parsed as CallToolResult);
+    return attachParsedCallToolResultMetadata(response as CallToolResult);
   }
 
   private async closeStreamableHttpClient(
@@ -1271,15 +1190,28 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     });
   }
 
+  private async closeStreamableHttpTransport(
+    transport: MaybeSessionTransport,
+    warningMessage: string,
+  ): Promise<void> {
+    await transport.close().catch((error) => {
+      logMcpTransportWarning(
+        this.logger,
+        this.params.url,
+        'streamable HTTP cleanup',
+        warningMessage,
+        error,
+      );
+    });
+  }
+
   private async reconnectExistingStreamableHttpClient(args: {
     client: Client;
     sessionId?: string;
     protocolVersion?: string;
   }): Promise<{
     client: Client;
-    transport: InstanceType<
-      StreamableHttpTransportModule['StreamableHTTPClientTransport']
-    >;
+    transport: InstanceType<MCPClientModule['StreamableHTTPClientTransport']>;
   }> {
     const { transportModule } = await this.loadStreamableHttpRuntime();
     const { StreamableHTTPClientTransport } = transportModule;
@@ -1296,7 +1228,10 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
         this.clientSessionTimeoutSeconds,
       );
       await args.client.connect(transport, requestOptions);
-      if (args.sessionId !== undefined) {
+      if (
+        args.sessionId !== undefined &&
+        args.client.getProtocolEra() === 'legacy'
+      ) {
         // Reconnecting with an existing session skips initialize(), so resend
         // initialized to reopen the shared SSE stream for async responses.
         await this.reopenSharedStreamableHttpSession(args.client);
@@ -1381,17 +1316,26 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
       }
 
       try {
-        await this.closeStreamableHttpClient(
-          {
-            client: previousClient,
-            transport: previousTransport,
-          },
-          {
-            terminateSession: false,
-            closeWarningMessage: 'Failed to close stale MCP client:',
-            terminateWarningMessage: 'Failed to terminate stale MCP session:',
-          },
-        );
+        if (sessionId === undefined) {
+          await this.closeStreamableHttpClient(
+            {
+              client: previousClient,
+              transport: previousTransport,
+            },
+            {
+              terminateSession: false,
+              closeWarningMessage: 'Failed to close stale MCP client:',
+              terminateWarningMessage: 'Failed to terminate stale MCP session:',
+            },
+          );
+        } else {
+          // Keep the v2 Client's negotiated capabilities and tool metadata when
+          // resuming the same server session on a replacement transport.
+          await this.closeStreamableHttpTransport(
+            previousTransport,
+            'Failed to close stale MCP transport:',
+          );
+        }
 
         const recovered = await this.reconnectExistingStreamableHttpClient({
           client: previousClient,
@@ -1433,7 +1377,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
         await this.publishConnectedStreamableHttpClient({
           client: recovered.client,
           transport: recovered.transport,
-          previousTransport,
+          preserveTools: sessionId !== undefined,
         });
 
         return recovered.client;
@@ -1475,15 +1419,25 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
       return 'none';
     }
 
-    if (isNotConnectedError(error, client)) {
+    const { clientModule } = await this.loadStreamableHttpRuntime();
+    const { SdkError, SdkErrorCode } = clientModule;
+
+    if (error instanceof SdkError && error.code === SdkErrorCode.NotConnected) {
+      return client.transport == null ? 'reconnect-and-retry' : 'none';
+    }
+
+    // MCP SDK v2 currently throws this plain Error after a transport detaches.
+    // Guard the message match with the actual disconnected client state.
+    if (
+      client.transport == null &&
+      error instanceof Error &&
+      error.message === 'Not connected'
+    ) {
       return 'reconnect-and-retry';
     }
 
-    const { typesModule } = await this.loadStreamableHttpRuntime();
-    const { ErrorCode, McpError } = typesModule;
-
-    return error instanceof McpError &&
-      error.code === ErrorCode.ConnectionClosed
+    return error instanceof SdkError &&
+      error.code === SdkErrorCode.ConnectionClosed
       ? 'reconnect-only'
       : 'none';
   }
@@ -1534,7 +1488,6 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
       await this.publishConnectedStreamableHttpClient({
         client,
         transport,
-        previousTransport,
       });
       this.serverInitializeResult = {
         serverInfo: { name: this._name, version: '1.0.0' },
@@ -1578,8 +1531,6 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
   }
 
   async listTools(): Promise<MCPTool[]> {
-    const { ListToolsResultSchema } =
-      await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
     if (!this.session) {
       throw new Error(
         'Server not initialized. Make sure you call connect() first.',
@@ -1589,35 +1540,30 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
       return this._toolsList;
     }
 
-    const requestOptions = buildRequestOptions(
+    const requestOptions = buildCacheableRequestOptions(
       this.clientSessionTimeoutSeconds,
+      'bypass',
     );
     const session = this.session;
-    getClientToolMetadataCache(session);
     const cacheGeneration = this._toolsCacheGeneration;
-    const tools = await listAllMcpTools({
-      fetchPage: (cursor) =>
-        runMcpTransportOperation(
-          this.params.url,
-          'streamable HTTP list tools',
-          () =>
-            requestMcpToolsPage(
-              session,
-              ListToolsResultSchema,
-              requestOptions,
-              cursor,
-            ),
-        ),
-      onPage: (response) =>
-        this.debugLog(() => `Listed tools: ${JSON.stringify(response)}`),
-    });
+    const response = await runMcpTransportOperation(
+      this.params.url,
+      'streamable HTTP list tools',
+      () =>
+        shouldListToolsForResumedSession(session, this.transport)
+          ? listToolsForResumedSession(session, requestOptions)
+          : session
+              .listTools(undefined, requestOptions)
+              .then((response) => ({ tools: response.tools as MCPTool[] })),
+    );
+    this.debugLog(() => `Listed tools: ${JSON.stringify(response)}`);
     assertMcpToolListingIsCurrent({
       listedClient: session,
       currentClient: this.session,
       listedGeneration: cacheGeneration,
       currentGeneration: this._toolsCacheGeneration,
     });
-    replaceClientToolMetadata(session, tools, this._toolsList);
+    const tools = response.tools as MCPTool[];
     this._toolsList = tools;
     this._cacheDirty = false;
     return tools;
@@ -1726,8 +1672,6 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
   async listResources(
     params?: MCPListResourcesParams,
   ): Promise<MCPListResourcesResult> {
-    const { ListResourcesResultSchema } =
-      await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
     if (!this.session) {
       throw new Error(
         'Server not initialized. Make sure you call connect() first.',
@@ -1739,17 +1683,15 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     const response = await runMcpTransportOperation(
       this.params.url,
       'streamable HTTP list resources',
-      () => this.session!.listResources(params, requestOptions),
+      () => listResourcesPage(this.session!, params, requestOptions),
     );
     this.debugLog(() => `Listed resources: ${JSON.stringify(response)}`);
-    return ListResourcesResultSchema.parse(response) as MCPListResourcesResult;
+    return response as MCPListResourcesResult;
   }
 
   async listResourceTemplates(
     params?: MCPListResourcesParams,
   ): Promise<MCPListResourceTemplatesResult> {
-    const { ListResourceTemplatesResultSchema } =
-      await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
     if (!this.session) {
       throw new Error(
         'Server not initialized. Make sure you call connect() first.',
@@ -1761,25 +1703,21 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     const response = await runMcpTransportOperation(
       this.params.url,
       'streamable HTTP list resource templates',
-      () => this.session!.listResourceTemplates(params, requestOptions),
+      () => listResourceTemplatesPage(this.session!, params, requestOptions),
     );
     this.debugLog(
       () => `Listed resource templates: ${JSON.stringify(response)}`,
     );
-    return ListResourceTemplatesResultSchema.parse(
-      response,
-    ) as MCPListResourceTemplatesResult;
+    return response as MCPListResourceTemplatesResult;
   }
 
   async readResource(uri: string): Promise<MCPReadResourceResult> {
-    const { ReadResourceResultSchema } =
-      await import('@modelcontextprotocol/sdk/types.js').catch(failedToImport);
     if (!this.session) {
       throw new Error(
         'Server not initialized. Make sure you call connect() first.',
       );
     }
-    const requestOptions = buildRequestOptions(
+    const requestOptions = buildCacheableRequestOptions(
       this.clientSessionTimeoutSeconds,
     );
     const response = await runMcpTransportOperation(
@@ -1788,7 +1726,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
       () => this.session!.readResource({ uri }, requestOptions),
     );
     this.debugLog(() => `Read resource ${uri}: ${JSON.stringify(response)}`);
-    return ReadResourceResultSchema.parse(response) as MCPReadResourceResult;
+    return response as MCPReadResourceResult;
   }
 
   get name() {

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -89,43 +89,67 @@ function buildCacheableRequestOptions(
   };
 }
 
-const MCP_LIST_MAX_PAGES = 64;
-
-async function listToolsForResumedSession(
+async function listAllMcpTools(
   client: Client,
   requestOptions: RequestOptions | undefined,
 ): Promise<{ tools: MCPTool[] }> {
   const tools: MCPTool[] = [];
+  const seenCursors = new Set<string>();
   let cursor: string | undefined;
 
-  for (let page = 0; page < MCP_LIST_MAX_PAGES; page += 1) {
-    const response = await client.request(
-      {
-        method: 'tools/list',
-        ...(cursor === undefined ? {} : { params: { cursor } }),
-      },
-      requestOptions,
-    );
-    tools.push(...(response.tools as MCPTool[]));
-    cursor = response.nextCursor;
-    if (cursor === undefined) {
+  while (true) {
+    let response: { tools: MCPTool[]; nextCursor?: string };
+    try {
+      response = (await client.request(
+        {
+          method: 'tools/list',
+          ...(cursor === undefined ? {} : { params: { cursor } }),
+        },
+        requestOptions,
+      )) as { tools: MCPTool[]; nextCursor?: string };
+    } catch (error) {
+      if (cursor === undefined) {
+        throw error;
+      }
+      throw new Error(
+        'MCP tool listing failed while fetching a continuation page.',
+      );
+    }
+    tools.push(...response.tools);
+
+    const nextCursor = response.nextCursor;
+    if (nextCursor === undefined) {
       return { tools };
     }
+    if (seenCursors.has(nextCursor)) {
+      throw new Error(
+        'MCP server returned a repeated cursor while listing tools.',
+      );
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
   }
-
-  throw new Error(
-    `MCP tools/list pagination exceeded ${MCP_LIST_MAX_PAGES} pages.`,
-  );
 }
 
-function shouldListToolsForResumedSession(
+async function listMcpTools(
   client: Client,
-  transport: unknown,
-): boolean {
-  return (
-    client.getServerCapabilities() === undefined &&
-    getSessionId(transport) !== undefined
-  );
+  requestOptions: RequestOptions | undefined,
+): Promise<{ tools: MCPTool[] }> {
+  if (getNegotiatedModernCapabilities(client) !== undefined) {
+    const response = await client.listTools(undefined, {
+      ...requestOptions,
+      cacheMode: 'bypass',
+    });
+    return { tools: response.tools as MCPTool[] };
+  }
+  return listAllMcpTools(client, requestOptions);
+}
+
+function getNegotiatedModernCapabilities(client: Client) {
+  const capabilities = client.getServerCapabilities();
+  return client.getProtocolEra() === 'modern' && capabilities !== undefined
+    ? capabilities
+    : undefined;
 }
 
 function getListedToolForCall(tools: readonly MCPTool[], toolName: string) {
@@ -147,28 +171,36 @@ function listResourcesPage(
   client: Client,
   params: MCPListResourcesParams | undefined,
   requestOptions: RequestOptions | undefined,
-) {
+): Promise<MCPListResourcesResult> {
+  const capabilities = getNegotiatedModernCapabilities(client);
+  if (capabilities !== undefined && capabilities.resources === undefined) {
+    return Promise.resolve({ resources: [] });
+  }
   return client.request(
     {
       method: 'resources/list',
       ...(params === undefined ? {} : { params }),
     },
     requestOptions,
-  );
+  ) as Promise<MCPListResourcesResult>;
 }
 
 function listResourceTemplatesPage(
   client: Client,
   params: MCPListResourcesParams | undefined,
   requestOptions: RequestOptions | undefined,
-) {
+): Promise<MCPListResourceTemplatesResult> {
+  const capabilities = getNegotiatedModernCapabilities(client);
+  if (capabilities !== undefined && capabilities.resources === undefined) {
+    return Promise.resolve({ resourceTemplates: [] });
+  }
   return client.request(
     {
       method: 'resources/templates/list',
       ...(params === undefined ? {} : { params }),
     },
     requestOptions,
-  );
+  ) as Promise<MCPListResourceTemplatesResult>;
 }
 
 async function callWithMCPRequestSignal<T>(
@@ -393,7 +425,7 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
           name: this._name,
           version: '1.0.0', // You may want to make this configurable
         },
-        { versionNegotiation: { mode: 'auto' } },
+        { versionNegotiation: { mode: 'auto' }, listMaxPages: 0 },
       );
       const requestOptions = buildRequestOptions(
         this.clientSessionTimeoutSeconds,
@@ -426,13 +458,12 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
       return this._toolsList;
     }
 
-    const requestOptions = buildCacheableRequestOptions(
+    const requestOptions = buildRequestOptions(
       this.clientSessionTimeoutSeconds,
-      'bypass',
     );
     const session = this.session;
     const cacheGeneration = this._toolsCacheGeneration;
-    const response = await session.listTools(undefined, requestOptions);
+    const response = await listMcpTools(session, requestOptions);
     this.debugLog(() => `Listed tools: ${JSON.stringify(response)}`);
     assertMcpToolListingIsCurrent({
       listedClient: session,
@@ -620,10 +651,13 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
         eventSourceInit: this.params.eventSourceInit,
         fetch: this.params.fetch,
       });
-      this.session = new Client({
-        name: this._name,
-        version: '1.0.0', // You may want to make this configurable
-      });
+      this.session = new Client(
+        {
+          name: this._name,
+          version: '1.0.0', // You may want to make this configurable
+        },
+        { listMaxPages: 0 },
+      );
       const requestOptions = buildRequestOptions(
         this.clientSessionTimeoutSeconds,
       );
@@ -660,16 +694,15 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
       return this._toolsList;
     }
 
-    const requestOptions = buildCacheableRequestOptions(
+    const requestOptions = buildRequestOptions(
       this.clientSessionTimeoutSeconds,
-      'bypass',
     );
     const session = this.session;
     const cacheGeneration = this._toolsCacheGeneration;
     const response = await runMcpTransportOperation(
       this.params.url,
       'SSE list tools',
-      () => session.listTools(undefined, requestOptions),
+      () => listMcpTools(session, requestOptions),
     );
     this.debugLog(() => `Listed tools: ${JSON.stringify(response)}`);
     assertMcpToolListingIsCurrent({
@@ -933,7 +966,7 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
         name: this._name,
         version: '1.0.0',
       },
-      { versionNegotiation: { mode: 'auto' } },
+      { versionNegotiation: { mode: 'auto' }, listMaxPages: 0 },
     );
     try {
       const requestOptions = buildRequestOptions(
@@ -1540,21 +1573,15 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
       return this._toolsList;
     }
 
-    const requestOptions = buildCacheableRequestOptions(
+    const requestOptions = buildRequestOptions(
       this.clientSessionTimeoutSeconds,
-      'bypass',
     );
     const session = this.session;
     const cacheGeneration = this._toolsCacheGeneration;
     const response = await runMcpTransportOperation(
       this.params.url,
       'streamable HTTP list tools',
-      () =>
-        shouldListToolsForResumedSession(session, this.transport)
-          ? listToolsForResumedSession(session, requestOptions)
-          : session
-              .listTools(undefined, requestOptions)
-              .then((response) => ({ tools: response.tools as MCPTool[] })),
+      () => listMcpTools(session, requestOptions),
     );
     this.debugLog(() => `Listed tools: ${JSON.stringify(response)}`);
     assertMcpToolListingIsCurrent({

--- a/packages/agents-core/test/mcpProtocolCancellation.test.ts
+++ b/packages/agents-core/test/mcpProtocolCancellation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { Client } from '@modelcontextprotocol/client';
 import { z } from 'zod';
 
 class ProbeTransport {
@@ -79,6 +79,134 @@ class ProbeTransport {
   }
 }
 
+class NegotiationProbeTransport {
+  onmessage?: (message: unknown) => void;
+  onerror?: (error: unknown) => void;
+  onclose?: () => void;
+
+  readonly sentMethods: string[] = [];
+  sessionId?: string;
+  protocolVersion?: string;
+
+  constructor(private readonly era: 'legacy' | 'modern') {}
+
+  async start(): Promise<void> {}
+
+  async close(): Promise<void> {
+    this.onclose?.();
+  }
+
+  setProtocolVersion(version: string): void {
+    this.protocolVersion = version;
+  }
+
+  async send(message: {
+    id?: number;
+    method?: string;
+    params?: { cursor?: string };
+  }): Promise<void> {
+    this.sentMethods.push(message.method ?? `response:${message.id}`);
+    if (message.id === undefined) {
+      return;
+    }
+
+    if (message.method === 'server/discover') {
+      if (this.era === 'legacy') {
+        this.onmessage?.({
+          jsonrpc: '2.0',
+          id: message.id,
+          error: { code: -32601, message: 'Method not found' },
+        });
+        return;
+      }
+      this.onmessage?.({
+        jsonrpc: '2.0',
+        id: message.id,
+        result: {
+          resultType: 'complete',
+          ttlMs: 0,
+          cacheScope: 'private',
+          supportedVersions: ['2026-07-28'],
+          capabilities: { tools: {} },
+        },
+      });
+      return;
+    }
+
+    if (message.method === 'initialize') {
+      this.onmessage?.({
+        jsonrpc: '2.0',
+        id: message.id,
+        result: {
+          protocolVersion: '2025-06-18',
+          capabilities: { tools: {} },
+          serverInfo: { name: 'legacy-probe-server', version: '1.0.0' },
+        },
+      });
+      return;
+    }
+
+    if (message.method === 'tools/list') {
+      const modernContinuation = message.params?.cursor === 'modern-next';
+      this.onmessage?.({
+        jsonrpc: '2.0',
+        id: message.id,
+        result:
+          this.era === 'modern'
+            ? {
+                resultType: 'complete',
+                ttlMs: 0,
+                cacheScope: 'private',
+                tools: [
+                  {
+                    name: modernContinuation
+                      ? 'modern-tool-2'
+                      : 'modern-tool-1',
+                    inputSchema: { type: 'object' },
+                    ...(!modernContinuation
+                      ? {
+                          outputSchema: {
+                            type: 'object',
+                            properties: { message: { type: 'string' } },
+                            required: ['message'],
+                          },
+                        }
+                      : {}),
+                  },
+                ],
+                ...(modernContinuation ? {} : { nextCursor: 'modern-next' }),
+              }
+            : {
+                tools: [
+                  {
+                    name: 'legacy-tool',
+                    inputSchema: { type: 'object' },
+                  },
+                ],
+              },
+      });
+      return;
+    }
+
+    if (message.method === 'tools/call') {
+      this.onmessage?.({
+        jsonrpc: '2.0',
+        id: message.id,
+        result:
+          this.era === 'modern'
+            ? {
+                resultType: 'complete',
+                content: [{ type: 'text', text: 'invalid structured result' }],
+                structuredContent: { message: 123 },
+              }
+            : {
+                content: [{ type: 'text', text: 'legacy result' }],
+              },
+      });
+    }
+  }
+}
+
 describe('upstream MCP request cancellation characterization', () => {
   it('cancels only the aborted request and lets siblings complete', async () => {
     const transport = new ProbeTransport();
@@ -105,9 +233,9 @@ describe('upstream MCP request cancellation characterization', () => {
       expect(slowResult).toMatchObject({
         status: 'rejected',
         reason: expect.objectContaining({
-          name: 'McpError',
-          code: -32001,
-          message: 'MCP error -32001: probe abort',
+          name: 'SdkError',
+          code: 'REQUEST_TIMEOUT',
+          message: 'probe abort',
         }),
       });
       expect(fastResult).toEqual({
@@ -122,6 +250,92 @@ describe('upstream MCP request cancellation characterization', () => {
         'fast',
         'notifications/cancelled',
       ]);
+    } finally {
+      await client.close();
+    }
+  });
+});
+
+describe('upstream MCP v2 protocol negotiation', () => {
+  it('uses the 2026 protocol when server/discover succeeds', async () => {
+    const transport = new NegotiationProbeTransport('modern');
+    const client = new Client(
+      { name: 'modern-probe-client', version: '1.0.0' },
+      { versionNegotiation: { mode: 'auto' } },
+    );
+
+    await client.connect(transport as any);
+    try {
+      expect(client.getProtocolEra()).toBe('modern');
+      expect(client.getNegotiatedProtocolVersion()).toBe('2026-07-28');
+      expect((await client.listTools()).tools.map((tool) => tool.name)).toEqual(
+        ['modern-tool-1', 'modern-tool-2'],
+      );
+      expect(transport.sentMethods).toEqual([
+        'server/discover',
+        'tools/list',
+        'tools/list',
+      ]);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('falls back to the legacy initialize flow for an old server', async () => {
+    const transport = new NegotiationProbeTransport('legacy');
+    const client = new Client(
+      { name: 'legacy-probe-client', version: '1.0.0' },
+      { versionNegotiation: { mode: 'auto' } },
+    );
+
+    await client.connect(transport as any);
+    try {
+      expect(client.getProtocolEra()).toBe('legacy');
+      expect(client.getNegotiatedProtocolVersion()).toBe('2025-06-18');
+      expect((await client.listTools()).tools.map((tool) => tool.name)).toEqual(
+        ['legacy-tool'],
+      );
+      expect(transport.sentMethods).toEqual([
+        'server/discover',
+        'initialize',
+        'notifications/initialized',
+        'tools/list',
+      ]);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('preserves negotiated state and tool metadata across same-session reconnects', async () => {
+    const firstTransport = new NegotiationProbeTransport('modern');
+    const client = new Client(
+      { name: 'resume-probe-client', version: '1.0.0' },
+      { versionNegotiation: { mode: 'auto' } },
+    );
+
+    await client.connect(firstTransport as any);
+    expect((await client.listTools()).tools.map((tool) => tool.name)).toEqual([
+      'modern-tool-1',
+      'modern-tool-2',
+    ]);
+    firstTransport.sessionId = 'shared-session';
+    await firstTransport.close();
+
+    const resumedTransport = new NegotiationProbeTransport('modern');
+    resumedTransport.sessionId = 'shared-session';
+    await client.connect(resumedTransport as any);
+
+    try {
+      expect(client.getServerCapabilities()).toMatchObject({ tools: {} });
+      expect(client.getNegotiatedProtocolVersion()).toBe('2026-07-28');
+      expect(resumedTransport.protocolVersion).toBe('2026-07-28');
+      await expect(
+        client.callTool({ name: 'modern-tool-1', arguments: {} }),
+      ).rejects.toMatchObject({
+        name: 'ProtocolError',
+        code: -32602,
+      });
+      expect(resumedTransport.sentMethods).toEqual(['tools/call']);
     } finally {
       await client.close();
     }

--- a/packages/agents-core/test/mcpToolFilter.test.ts
+++ b/packages/agents-core/test/mcpToolFilter.test.ts
@@ -9,9 +9,8 @@ class StubServer extends NodeMCPServerStdio {
     super({ command: 'noop', name, toolFilter: filter, cacheToolsList: true });
     this.toolList = tools;
     this.session = {
-      cacheToolMetadata: () => {},
-      request: async () => ({ tools: this.toolList }),
-      callTool: async () => [],
+      listTools: async () => ({ tools: this.toolList }),
+      callTool: async () => ({ content: [] }),
       close: async () => {},
     } as any;
     this._cacheDirty = true;
@@ -401,7 +400,7 @@ describe('MCP tool filtering', () => {
 
       // swap out the underlying list, invalidate cache, then call again
       server.toolList = tools2 as any;
-      server.invalidateToolsCache();
+      await server.invalidateToolsCache();
 
       result = await server.listTools();
       expect(result.map((t) => t.name)).toEqual(['b']);

--- a/packages/agents-core/test/mcpToolFilter.test.ts
+++ b/packages/agents-core/test/mcpToolFilter.test.ts
@@ -9,7 +9,9 @@ class StubServer extends NodeMCPServerStdio {
     super({ command: 'noop', name, toolFilter: filter, cacheToolsList: true });
     this.toolList = tools;
     this.session = {
-      listTools: async () => ({ tools: this.toolList }),
+      getProtocolEra: () => 'legacy',
+      getServerCapabilities: () => ({ tools: {} }),
+      request: async () => ({ tools: this.toolList }),
       callTool: async () => ({ content: [] }),
       close: async () => {},
     } as any;

--- a/packages/agents-core/test/shims/mcp-server/mcpV2Compatibility.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/mcpV2Compatibility.test.ts
@@ -1,0 +1,388 @@
+import { describe, expect, it } from 'vitest';
+import { NodeMCPServerStreamableHttp } from '../../../src/shims/mcp-server/node';
+
+function createTool(name: string) {
+  return {
+    name,
+    description: `Tool ${name}`,
+    inputSchema: {
+      type: 'object' as const,
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    },
+  };
+}
+
+describe('MCP SDK v2 compatibility', () => {
+  it('uses a pinned session without initialize and preserves one-page resource lists', async () => {
+    const requests: Array<{ method: string; params?: { cursor?: string } }> =
+      [];
+    const fetch = async (_url: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'DELETE') {
+        return new Response(null, { status: 200 });
+      }
+
+      const message = JSON.parse(String(init?.body)) as {
+        id?: number;
+        method: string;
+        params?: { cursor?: string };
+      };
+      requests.push({ method: message.method, params: message.params });
+
+      if (message.id === undefined) {
+        return new Response(null, { status: 202 });
+      }
+
+      let result: Record<string, unknown>;
+      switch (message.method) {
+        case 'tools/list':
+          result =
+            message.params?.cursor === 'next-tools'
+              ? { tools: [createTool('second-tool')] }
+              : {
+                  tools: [createTool('first-tool')],
+                  nextCursor: 'next-tools',
+                };
+          break;
+        case 'tools/call':
+          result = {
+            content: [{ type: 'text', text: 'called' }],
+          };
+          break;
+        case 'resources/list':
+          result = {
+            resources: [{ uri: 'file:///first.txt', name: 'First resource' }],
+            nextCursor: 'next-resources',
+          };
+          break;
+        case 'resources/templates/list':
+          result = {
+            resourceTemplates: [
+              {
+                uriTemplate: 'file:///{name}.txt',
+                name: 'Text resource',
+              },
+            ],
+            nextCursor: 'next-templates',
+          };
+          break;
+        default:
+          throw new Error(`Unexpected MCP request: ${message.method}`);
+      }
+
+      return Response.json({ jsonrpc: '2.0', id: message.id, result });
+    };
+    const server = new NodeMCPServerStreamableHttp({
+      name: 'pinned-v2-client',
+      url: 'https://example.test/mcp',
+      sessionId: 'existing-session',
+      fetch,
+    });
+
+    await server.connect();
+    try {
+      expect((await server.listTools()).map((tool) => tool.name)).toEqual([
+        'first-tool',
+        'second-tool',
+      ]);
+      await expect(server.callTool('first-tool', {})).resolves.toEqual([
+        { type: 'text', text: 'called' },
+      ]);
+      await expect(server.listResources()).resolves.toMatchObject({
+        resources: [{ uri: 'file:///first.txt' }],
+        nextCursor: 'next-resources',
+      });
+      await expect(server.listResourceTemplates()).resolves.toMatchObject({
+        resourceTemplates: [{ uriTemplate: 'file:///{name}.txt' }],
+        nextCursor: 'next-templates',
+      });
+      expect(requests.map((request) => request.method)).toEqual([
+        'tools/list',
+        'tools/list',
+        'tools/call',
+        'resources/list',
+        'resources/templates/list',
+      ]);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('reconnects a modern same-session client without legacy initialized', async () => {
+    const requests: string[] = [];
+    const fetch = async (_url: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'DELETE') {
+        return new Response(null, { status: 200 });
+      }
+
+      const message = JSON.parse(String(init?.body)) as {
+        id?: number;
+        method: string;
+      };
+      requests.push(message.method);
+      if (message.id === undefined) {
+        return new Response(null, { status: 202 });
+      }
+
+      if (message.method === 'server/discover') {
+        return Response.json({
+          jsonrpc: '2.0',
+          id: message.id,
+          result: {
+            resultType: 'complete',
+            ttlMs: 0,
+            cacheScope: 'private',
+            supportedVersions: ['2026-07-28'],
+            capabilities: { tools: {} },
+          },
+        });
+      }
+      if (message.method === 'tools/list') {
+        return Response.json({
+          jsonrpc: '2.0',
+          id: message.id,
+          result: {
+            resultType: 'complete',
+            ttlMs: 0,
+            cacheScope: 'private',
+            tools: [createTool('modern-tool')],
+          },
+        });
+      }
+      if (message.method === 'tools/call') {
+        return Response.json({
+          jsonrpc: '2.0',
+          id: message.id,
+          result: {
+            resultType: 'complete',
+            content: [{ type: 'text', text: 'recovered modern call' }],
+          },
+        });
+      }
+      throw new Error(`Unexpected MCP request: ${message.method}`);
+    };
+    const server = new NodeMCPServerStreamableHttp({
+      name: 'modern-resume-client',
+      url: 'https://example.test/mcp',
+      fetch,
+    });
+
+    await server.connect();
+    await server.listTools();
+    const originalTransport = (server as any).transport;
+    originalTransport._sessionId = 'modern-session';
+    await originalTransport.close();
+
+    try {
+      await expect(server.callTool('modern-tool', {})).resolves.toEqual([
+        { type: 'text', text: 'recovered modern call' },
+      ]);
+      expect(server.sessionId).toBe('modern-session');
+      expect(requests).toEqual(['server/discover', 'tools/list', 'tools/call']);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('rejects required-task tools before and after a legacy same-session reconnect', async () => {
+    const requests: string[] = [];
+    const fetch = async (_url: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'DELETE') {
+        return new Response(null, { status: 200 });
+      }
+
+      const message = JSON.parse(String(init?.body)) as {
+        id?: number;
+        method: string;
+      };
+      requests.push(message.method);
+      if (message.id === undefined) {
+        return new Response(null, { status: 202 });
+      }
+      if (message.method === 'server/discover') {
+        return Response.json({
+          jsonrpc: '2.0',
+          id: message.id,
+          error: { code: -32601, message: 'Method not found' },
+        });
+      }
+      if (message.method === 'initialize') {
+        return Response.json(
+          {
+            jsonrpc: '2.0',
+            id: message.id,
+            result: {
+              protocolVersion: '2025-06-18',
+              capabilities: { tools: {} },
+              serverInfo: { name: 'legacy-server', version: '1.0.0' },
+            },
+          },
+          { headers: { 'mcp-session-id': 'legacy-session' } },
+        );
+      }
+      if (message.method === 'tools/list') {
+        return Response.json({
+          jsonrpc: '2.0',
+          id: message.id,
+          result: {
+            tools: [
+              createTool('regular-tool'),
+              {
+                ...createTool('required-task-tool'),
+                execution: { taskSupport: 'required' },
+              },
+            ],
+          },
+        });
+      }
+      if (message.method === 'tools/call') {
+        return Response.json({
+          jsonrpc: '2.0',
+          id: message.id,
+          result: {
+            content: [{ type: 'text', text: 'recovered legacy call' }],
+          },
+        });
+      }
+      throw new Error(`Unexpected MCP request: ${message.method}`);
+    };
+    const server = new NodeMCPServerStreamableHttp({
+      name: 'legacy-task-resume-client',
+      url: 'https://example.test/mcp',
+      fetch,
+    });
+
+    await server.connect();
+    await server.listTools();
+    await expect(
+      server.callTool('required-task-tool', {}),
+    ).rejects.toMatchObject({
+      name: 'ProtocolError',
+      code: -32600,
+    });
+    await (server as any).transport.close();
+
+    try {
+      await expect(server.callTool('regular-tool', {})).resolves.toEqual([
+        { type: 'text', text: 'recovered legacy call' },
+      ]);
+      await expect(
+        server.callTool('required-task-tool', {}),
+      ).rejects.toMatchObject({
+        name: 'ProtocolError',
+        code: -32600,
+      });
+      expect(requests).toEqual([
+        'server/discover',
+        'initialize',
+        'notifications/initialized',
+        'tools/list',
+        'notifications/initialized',
+        'tools/call',
+      ]);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('does not let a rejected tool listing populate v2 call metadata', async () => {
+    let markListStarted!: () => void;
+    const listStarted = new Promise<void>((resolve) => {
+      markListStarted = resolve;
+    });
+    let resolveListResponse!: (response: Response) => void;
+    const listResponse = new Promise<Response>((resolve) => {
+      resolveListResponse = resolve;
+    });
+    let listRequestId: number | undefined;
+    const requests: string[] = [];
+    const fetch = async (_url: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'DELETE') {
+        return new Response(null, { status: 200 });
+      }
+
+      const message = JSON.parse(String(init?.body)) as {
+        id?: number;
+        method: string;
+      };
+      requests.push(message.method);
+      if (message.id === undefined) {
+        return new Response(null, { status: 202 });
+      }
+      if (message.method === 'server/discover') {
+        return Response.json({
+          jsonrpc: '2.0',
+          id: message.id,
+          result: {
+            resultType: 'complete',
+            ttlMs: 0,
+            cacheScope: 'private',
+            supportedVersions: ['2026-07-28'],
+            capabilities: { tools: {} },
+          },
+        });
+      }
+      if (message.method === 'tools/list') {
+        listRequestId = message.id;
+        markListStarted();
+        return listResponse;
+      }
+      if (message.method === 'tools/call') {
+        return Response.json({
+          jsonrpc: '2.0',
+          id: message.id,
+          result: {
+            resultType: 'complete',
+            content: [{ type: 'text', text: 'call completed' }],
+            structuredContent: { message: 123 },
+          },
+        });
+      }
+      throw new Error(`Unexpected MCP request: ${message.method}`);
+    };
+    const server = new NodeMCPServerStreamableHttp({
+      name: 'stale-list-client',
+      url: 'https://example.test/mcp',
+      fetch,
+    });
+
+    await server.connect();
+    const listing = server.listTools();
+    await listStarted;
+    await server.invalidateToolsCache();
+    resolveListResponse(
+      Response.json({
+        jsonrpc: '2.0',
+        id: listRequestId,
+        result: {
+          resultType: 'complete',
+          ttlMs: 0,
+          cacheScope: 'private',
+          tools: [
+            {
+              ...createTool('stale-tool'),
+              outputSchema: {
+                type: 'object',
+                properties: { message: { type: 'string' } },
+                required: ['message'],
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    try {
+      await expect(listing).rejects.toThrow(
+        'MCP tool listing became stale before it completed.',
+      );
+      await expect(server.callTool('stale-tool', {})).resolves.toEqual([
+        { type: 'text', text: 'call completed' },
+      ]);
+      expect(requests).toEqual(['server/discover', 'tools/list', 'tools/call']);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/packages/agents-core/test/shims/mcp-server/mcpV2Compatibility.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/mcpV2Compatibility.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { NodeMCPServerStreamableHttp } from '../../../src/shims/mcp-server/node';
+import { allowConsole } from '../../../../../helpers/tests/console-guard';
 
 function createTool(name: string) {
   return {
@@ -80,8 +81,8 @@ describe('MCP SDK v2 compatibility', () => {
       fetch,
     });
 
-    await server.connect();
     try {
+      await server.connect();
       expect((await server.listTools()).map((tool) => tool.name)).toEqual([
         'first-tool',
         'second-tool',
@@ -109,8 +110,100 @@ describe('MCP SDK v2 compatibility', () => {
     }
   });
 
-  it('reconnects a modern same-session client without legacy initialized', async () => {
+  it('lists more than 64 tool pages for a pinned session', async () => {
+    const pageCount = 65;
+    const requestedCursors: Array<string | undefined> = [];
+    const fetch = async (_url: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'DELETE') {
+        return new Response(null, { status: 200 });
+      }
+
+      const message = JSON.parse(String(init?.body)) as {
+        id: number;
+        method: string;
+        params?: { cursor?: string };
+      };
+      if (message.method !== 'tools/list') {
+        throw new Error(`Unexpected MCP request: ${message.method}`);
+      }
+
+      const cursor = message.params?.cursor;
+      requestedCursors.push(cursor);
+      const page = cursor === undefined ? 0 : Number(cursor);
+      return Response.json({
+        jsonrpc: '2.0',
+        id: message.id,
+        result: {
+          tools: [createTool(`tool-${page}`)],
+          ...(page + 1 < pageCount ? { nextCursor: String(page + 1) } : {}),
+        },
+      });
+    };
+    const server = new NodeMCPServerStreamableHttp({
+      name: 'large-pinned-tool-list',
+      url: 'https://example.test/mcp',
+      sessionId: 'existing-session',
+      fetch,
+    });
+
+    await server.connect();
+    try {
+      const tools = await server.listTools();
+      expect(tools).toHaveLength(pageCount);
+      expect(tools[0]?.name).toBe('tool-0');
+      expect(tools.at(-1)?.name).toBe('tool-64');
+      expect(requestedCursors).toHaveLength(pageCount);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('rejects repeated tool-list cursors for a pinned session', async () => {
+    let listRequests = 0;
+    const fetch = async (_url: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'DELETE') {
+        return new Response(null, { status: 200 });
+      }
+
+      const message = JSON.parse(String(init?.body)) as {
+        id: number;
+        method: string;
+      };
+      if (message.method !== 'tools/list') {
+        throw new Error(`Unexpected MCP request: ${message.method}`);
+      }
+
+      listRequests += 1;
+      return Response.json({
+        jsonrpc: '2.0',
+        id: message.id,
+        result: {
+          tools: [createTool(`tool-${listRequests}`)],
+          nextCursor: 'repeated-cursor',
+        },
+      });
+    };
+    const server = new NodeMCPServerStreamableHttp({
+      name: 'repeated-pinned-tool-cursor',
+      url: 'https://example.test/mcp',
+      sessionId: 'existing-session',
+      fetch,
+    });
+
+    await server.connect();
+    try {
+      await expect(server.listTools()).rejects.toThrow(
+        'MCP server returned a repeated cursor while listing tools.',
+      );
+      expect(listRequests).toBe(2);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('preserves modern header filtering across a same-session reconnect', async () => {
     const requests: string[] = [];
+    let mirroredHeader: string | null = null;
     const fetch = async (_url: string | URL | Request, init?: RequestInit) => {
       if (init?.method === 'DELETE') {
         return new Response(null, { status: 200 });
@@ -146,11 +239,43 @@ describe('MCP SDK v2 compatibility', () => {
             resultType: 'complete',
             ttlMs: 0,
             cacheScope: 'private',
-            tools: [createTool('modern-tool')],
+            tools: [
+              {
+                ...createTool('modern-tool'),
+                inputSchema: {
+                  type: 'object',
+                  properties: {
+                    token: {
+                      type: 'string',
+                      'x-mcp-header': 'X-Test-Token',
+                    },
+                  },
+                  required: ['token'],
+                  additionalProperties: false,
+                },
+              },
+              {
+                ...createTool('invalid-header-tool'),
+                inputSchema: {
+                  type: 'object',
+                  properties: {
+                    token: {
+                      type: 'string',
+                      'x-mcp-header': 'Bad Header',
+                    },
+                  },
+                  required: ['token'],
+                  additionalProperties: false,
+                },
+              },
+            ],
           },
         });
       }
       if (message.method === 'tools/call') {
+        mirroredHeader = new Headers(init?.headers).get(
+          'Mcp-Param-X-Test-Token',
+        );
         return Response.json({
           jsonrpc: '2.0',
           id: message.id,
@@ -167,19 +292,77 @@ describe('MCP SDK v2 compatibility', () => {
       url: 'https://example.test/mcp',
       fetch,
     });
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     await server.connect();
-    await server.listTools();
-    const originalTransport = (server as any).transport;
-    originalTransport._sessionId = 'modern-session';
-    await originalTransport.close();
-
     try {
-      await expect(server.callTool('modern-tool', {})).resolves.toEqual([
-        { type: 'text', text: 'recovered modern call' },
+      expect((await server.listTools()).map((tool) => tool.name)).toEqual([
+        'modern-tool',
       ]);
+      const originalTransport = (server as any).transport;
+      originalTransport._sessionId = 'modern-session';
+      await originalTransport.close();
+
+      await expect(
+        server.callTool('modern-tool', { token: 'header-value' }),
+      ).resolves.toEqual([{ type: 'text', text: 'recovered modern call' }]);
       expect(server.sessionId).toBe('modern-session');
+      expect(mirroredHeader).toBe('header-value');
+      expect(consoleWarn).toHaveBeenCalledWith(
+        expect.stringContaining("excluding tool 'invalid-header-tool'"),
+      );
       expect(requests).toEqual(['server/discover', 'tools/list', 'tools/call']);
+    } finally {
+      consoleWarn.mockRestore();
+      await server.close();
+    }
+  });
+
+  it('does not request unadvertised lists from a modern server', async () => {
+    allowConsole(['debug']);
+    const requests: string[] = [];
+    const fetch = async (_url: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'DELETE') {
+        return new Response(null, { status: 200 });
+      }
+
+      const message = JSON.parse(String(init?.body)) as {
+        id?: number;
+        method: string;
+      };
+      requests.push(message.method);
+      if (message.id === undefined) {
+        return new Response(null, { status: 202 });
+      }
+      if (message.method === 'server/discover') {
+        return Response.json({
+          jsonrpc: '2.0',
+          id: message.id,
+          result: {
+            resultType: 'complete',
+            ttlMs: 0,
+            cacheScope: 'private',
+            supportedVersions: ['2026-07-28'],
+            capabilities: {},
+          },
+        });
+      }
+      throw new Error(`Unexpected MCP request: ${message.method}`);
+    };
+    const server = new NodeMCPServerStreamableHttp({
+      name: 'modern-server-without-lists',
+      url: 'https://example.test/mcp',
+      fetch,
+    });
+
+    await server.connect();
+    try {
+      await expect(server.listTools()).resolves.toEqual([]);
+      await expect(server.listResources()).resolves.toEqual({ resources: [] });
+      await expect(server.listResourceTemplates()).resolves.toEqual({
+        resourceTemplates: [],
+      });
+      expect(requests).toEqual(['server/discover']);
     } finally {
       await server.close();
     }

--- a/packages/agents-core/test/shims/mcp-server/node.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/node.test.ts
@@ -15,9 +15,11 @@ import {
 } from '../../../src/shims/mcp-server/node';
 import { mcpToFunctionTool } from '../../../src/mcp';
 import { RunContext } from '../../../src/runContext';
-import { TransportSendOptions } from '@modelcontextprotocol/sdk/shared/transport';
-import { JSONRPCMessage } from '@modelcontextprotocol/sdk/types';
-import { DEFAULT_REQUEST_TIMEOUT_MSEC } from '@modelcontextprotocol/sdk/shared/protocol';
+import {
+  DEFAULT_REQUEST_TIMEOUT_MSEC,
+  type JSONRPCMessage,
+  type TransportSendOptions,
+} from '@modelcontextprotocol/client';
 import type { Logger } from '../../../src/logger';
 import { connectMcpServers } from '../../../src/mcpServers';
 import { allowConsole } from '../../../../../helpers/tests/console-guard';
@@ -32,14 +34,14 @@ let lastCallToolOptions: any;
 let lastCallToolParams: any;
 let lastReadResourceOptions: any;
 let lastReadResourceParams: any;
+let lastClientOptions: any;
 let callToolImplementation:
-  ((params: any, resultSchema: any, options: any) => Promise<any>) | undefined;
+  ((params: any, options: any) => Promise<any>) | undefined;
 let connectImplementation:
   ((transport: any, options: any) => Promise<void>) | undefined;
 let listToolsImplementation:
   ((params: any, options: any) => Promise<any>) | undefined;
 let listToolsCalls: Array<{ params: any; options: any }>;
-let clientToolMetadataCacheCalls: any[][];
 let listResourcesImplementation:
   ((params: any, options: any) => Promise<any>) | undefined;
 let terminateSessionImplementation: (() => Promise<void>) | undefined;
@@ -147,11 +149,11 @@ beforeEach(() => {
   lastCallToolParams = undefined;
   lastReadResourceOptions = undefined;
   lastReadResourceParams = undefined;
+  lastClientOptions = undefined;
   callToolImplementation = undefined;
   connectImplementation = undefined;
   listToolsImplementation = undefined;
   listToolsCalls = [];
-  clientToolMetadataCacheCalls = [];
   listResourcesImplementation = undefined;
   terminateSessionImplementation = undefined;
   retainCallToolSignalListener = false;
@@ -159,24 +161,18 @@ beforeEach(() => {
 
 describe('NodeMCPServerStdio', () => {
   beforeAll(() => {
-    vi.mock(
-      '@modelcontextprotocol/sdk/client/stdio.js',
-      async (importOriginal) => {
-        return {
-          ...(await importOriginal()),
-          StdioClientTransport: MockStdioClientTransport,
-        };
-      },
-    );
-    vi.mock(
-      '@modelcontextprotocol/sdk/client/index.js',
-      async (importOriginal) => {
-        return {
-          ...(await importOriginal()),
-          Client: MockClient,
-        };
-      },
-    );
+    vi.doMock('@modelcontextprotocol/client/stdio', async (importOriginal) => {
+      return {
+        ...(await importOriginal()),
+        StdioClientTransport: MockStdioClientTransport,
+      };
+    });
+    vi.doMock('@modelcontextprotocol/client', async (importOriginal) => ({
+      ...(await importOriginal()),
+      Client: MockClient,
+      SSEClientTransport: MockSSEClientTransport,
+      StreamableHTTPClientTransport: MockStreamableHTTPClientTransport,
+    }));
   });
   test('should be available', async () => {
     const server = new NodeMCPServerStdio({
@@ -189,19 +185,20 @@ describe('NodeMCPServerStdio', () => {
     expect(server.cacheToolsList).toBe(true);
     await server.connect();
     expect(lastConnectOptions?.timeout).toBe(5000);
+    expect(lastClientOptions?.versionNegotiation).toEqual({ mode: 'auto' });
     await server.close();
   });
 
-  test('installed MCP client should support aggregate tool metadata caching', async () => {
+  test('installed MCP client should support automatic tool pagination', async () => {
     const { Client } = await vi.importActual<
-      typeof import('@modelcontextprotocol/sdk/client/index.js')
-    >('@modelcontextprotocol/sdk/client/index.js');
+      typeof import('@modelcontextprotocol/client')
+    >('@modelcontextprotocol/client');
     const client = new Client({
       name: 'metadata-compatibility-test',
       version: '1.0.0',
     });
 
-    expect(typeof (client as any).cacheToolMetadata).toBe('function');
+    expect(typeof client.listTools).toBe('function');
   });
 
   test('should apply custom client session timeout when connecting', async () => {
@@ -234,9 +231,13 @@ describe('NodeMCPServerStdio', () => {
 
     expect(lastConnectOptions?.timeout).toBe(6000);
     expect(lastListToolsOptions?.timeout).toBe(6000);
+    expect(lastListToolsOptions?.cacheMode).toBe('bypass');
     expect(lastCallToolOptions?.timeout).toBe(DEFAULT_REQUEST_TIMEOUT_MSEC);
     expect(lastCallToolOptions?.signal).toBeDefined();
     expect(lastCallToolOptions?.signal).not.toBe(controller.signal);
+    expect(lastCallToolOptions?.toolDefinition).toMatchObject({
+      name: 'mock-tool',
+    });
 
     await server.close();
   });
@@ -246,7 +247,7 @@ describe('NodeMCPServerStdio', () => {
     const callStarted = new Promise<void>((resolve) => {
       markCallStarted = resolve;
     });
-    callToolImplementation = async (_params, _resultSchema, options) => {
+    callToolImplementation = async (_params, options) => {
       markCallStarted?.();
       return new Promise((_, reject) => {
         options.signal.addEventListener(
@@ -377,8 +378,6 @@ describe('NodeMCPServerStdio', () => {
     const pendingTools = server.listTools();
     await continuationStarted.promise;
 
-    expect(clientToolMetadataCacheCalls).toEqual([]);
-
     continuation.resolve();
     const tools = await pendingTools;
     const cachedTools = await server.listTools();
@@ -395,12 +394,6 @@ describe('NodeMCPServerStdio', () => {
     expect(listToolsCalls.map((call) => call.options.timeout)).toEqual([
       6000, 6000,
     ]);
-    expect(
-      clientToolMetadataCacheCalls.map((tools) =>
-        tools.map((tool) => tool.name),
-      ),
-    ).toEqual([['first-tool', 'second-tool']]);
-
     await server.close();
   });
 
@@ -433,8 +426,6 @@ describe('NodeMCPServerStdio', () => {
     await expect(staleListing).rejects.toThrow(
       'MCP tool listing became stale before it completed.',
     );
-    expect(clientToolMetadataCacheCalls).toEqual([]);
-
     listToolsImplementation = async () => ({
       tools: [createMockTool('refreshed-tool')],
     });
@@ -475,8 +466,6 @@ describe('NodeMCPServerStdio', () => {
     await expect(staleListing).rejects.toThrow(
       'MCP tool listing became stale before it completed.',
     );
-    expect(clientToolMetadataCacheCalls).toEqual([]);
-
     listToolsImplementation = async () => ({
       tools: [createMockTool('new-session-tool')],
     });
@@ -487,7 +476,7 @@ describe('NodeMCPServerStdio', () => {
     await server.close();
   });
 
-  test('should limit missing metadata caching failures to tool listing', async () => {
+  test('should use the v2 high-level list method without private metadata APIs', async () => {
     const server = new NodeMCPServerStdio({
       name: 'missing-metadata-cache',
       fullCommand: 'test',
@@ -495,17 +484,16 @@ describe('NodeMCPServerStdio', () => {
 
     await server.connect();
     const session = (server as any).session;
-    session.request = vi.fn(async () => ({
-      tools: [createMockTool('uncommitted-tool')],
+    session.listTools = vi.fn(async () => ({
+      tools: [createMockTool('committed-tool')],
     }));
-    session.cacheToolMetadata = undefined;
 
     const resources = await server.listResources();
     expect(resources.resources[0].uri).toBe('file:///mock-resource.txt');
-    await expect(server.listTools()).rejects.toThrow(
-      'The installed MCP SDK does not support tool metadata caching required for paginated tool listing.',
-    );
-    expect(session.request).not.toHaveBeenCalled();
+    expect((await server.listTools()).map((tool) => tool.name)).toEqual([
+      'committed-tool',
+    ]);
+    expect(session.listTools).toHaveBeenCalledOnce();
 
     await server.close();
   });
@@ -534,14 +522,17 @@ describe('NodeMCPServerStdio', () => {
     });
     expect(lastListResourcesParams).toEqual({ cursor: 'resource-cursor' });
     expect(lastListResourcesOptions?.timeout).toBe(7000);
+    expect(lastListResourcesOptions?.cacheMode).toBeUndefined();
     expect(lastListResourceTemplatesParams).toEqual({
       cursor: 'template-cursor',
     });
     expect(lastListResourceTemplatesOptions?.timeout).toBe(7000);
+    expect(lastListResourceTemplatesOptions?.cacheMode).toBeUndefined();
     expect(lastReadResourceParams).toEqual({
       uri: 'file:///mock-resource.txt',
     });
     expect(lastReadResourceOptions?.timeout).toBe(7000);
+    expect(lastReadResourceOptions?.cacheMode).toBe('refresh');
 
     await server.close();
   });
@@ -585,8 +576,9 @@ class MockClient {
     name: string;
     version: string;
   };
-  constructor(options: { name: string; version: string }) {
+  constructor(options: { name: string; version: string }, clientOptions?: any) {
     this.options = options;
+    lastClientOptions = clientOptions;
   }
   connect(_transport: any, options?: any): Promise<void> {
     lastConnectOptions = options;
@@ -595,28 +587,51 @@ class MockClient {
     }
     return Promise.resolve();
   }
-  cacheToolMetadata(tools: any[]): void {
-    clientToolMetadataCacheCalls.push(tools);
+  getServerCapabilities(): Record<string, unknown> {
+    return { tools: {}, resources: {} };
   }
-  async request(request: any, _resultSchema: any, options?: any): Promise<any> {
-    if (request.method !== 'tools/list') {
-      throw new Error(`Unexpected request method: ${request.method}`);
+  request(request: any, options?: any): Promise<any> {
+    switch (request.method) {
+      case 'resources/list':
+        return this.listResources(request.params, options);
+      case 'resources/templates/list':
+        return this.listResourceTemplates(request.params, options);
+      case 'tools/list':
+        return this.listTools(request.params, options);
+      default:
+        throw new Error(`Unexpected mock MCP request: ${request.method}`);
     }
-    const params = request.params;
-    lastListToolsOptions = options;
-    listToolsCalls.push({ params, options });
-    return listToolsImplementation
-      ? await listToolsImplementation(params, options)
-      : { tools: [createMockTool('mock-tool')] };
   }
-  callTool(_params: any, _resultSchema?: any, options?: any): Promise<any> {
+  async listTools(params?: any, options?: any): Promise<any> {
+    const tools: any[] = [];
+    const seenCursors = new Set<string>();
+    let cursor = params?.cursor;
+    do {
+      const pageParams = cursor === undefined ? undefined : { cursor };
+      lastListToolsOptions = options;
+      listToolsCalls.push({ params: pageParams, options });
+      const page = listToolsImplementation
+        ? await listToolsImplementation(pageParams, options)
+        : { tools: [createMockTool('mock-tool')] };
+      tools.push(...page.tools);
+      cursor = page.nextCursor;
+      if (cursor !== undefined) {
+        if (seenCursors.has(cursor)) {
+          break;
+        }
+        seenCursors.add(cursor);
+      }
+    } while (params?.cursor === undefined && cursor !== undefined);
+    return { tools };
+  }
+  callTool(_params: any, options?: any): Promise<any> {
     lastCallToolParams = _params;
     lastCallToolOptions = options;
     if (retainCallToolSignalListener && options?.signal) {
       options.signal.addEventListener('abort', () => {});
     }
     if (callToolImplementation) {
-      return callToolImplementation(_params, _resultSchema, options);
+      return callToolImplementation(_params, options);
     }
     return Promise.resolve({
       content: [{ type: 'text', text: 'ok' }],
@@ -713,27 +728,6 @@ class MockSSEClientTransport {
 }
 
 describe('NodeMCPServerSSE', () => {
-  beforeAll(() => {
-    vi.mock(
-      '@modelcontextprotocol/sdk/client/sse.js',
-      async (importOriginal) => {
-        return {
-          ...(await importOriginal()),
-          SSEClientTransport: MockSSEClientTransport,
-        };
-      },
-    );
-    vi.mock(
-      '@modelcontextprotocol/sdk/client/index.js',
-      async (importOriginal) => {
-        return {
-          ...(await importOriginal()),
-          Client: MockClient,
-        };
-      },
-    );
-  });
-
   test('should forward custom fetch to SSEClientTransport', async () => {
     const customFetch = vi.fn(async (_input, _init) => {
       return new Response('{}', { status: 200 });
@@ -1074,6 +1068,7 @@ describe('NodeMCPServerSSE', () => {
 
     expect(lastConnectOptions?.timeout).toBe(4000);
     expect(lastListToolsOptions?.timeout).toBe(4000);
+    expect(lastListToolsOptions?.cacheMode).toBe('bypass');
     expect(lastCallToolOptions?.timeout).toBe(DEFAULT_REQUEST_TIMEOUT_MSEC);
     expect(lastCallToolOptions?.signal).toBeDefined();
     expect(lastCallToolOptions?.signal).not.toBe(controller.signal);
@@ -1081,7 +1076,7 @@ describe('NodeMCPServerSSE', () => {
     await server.close();
   });
 
-  test('should reject repeated tool cursors without caching partial results', async () => {
+  test('should stop repeated tool cursors and cache the aggregate', async () => {
     listToolsImplementation = async (params) => {
       if (params === undefined) {
         return {
@@ -1102,24 +1097,22 @@ describe('NodeMCPServerSSE', () => {
 
     await server.connect();
 
-    await expect(server.listTools()).rejects.toThrow(
-      'MCP server returned a repeated cursor while listing tools.',
-    );
+    const tools = await server.listTools();
+    expect(tools.map((tool) => tool.name)).toEqual([
+      'first-tool',
+      'second-tool',
+    ]);
     expect(listToolsCalls.map((call) => call.params)).toEqual([
       undefined,
       { cursor: 'repeated-cursor' },
     ]);
-    expect(clientToolMetadataCacheCalls).toEqual([]);
-
     listToolsCalls = [];
     listToolsImplementation = async () => ({
       tools: [createMockTool('recovered-tool')],
     });
 
-    expect((await server.listTools()).map((tool) => tool.name)).toEqual([
-      'recovered-tool',
-    ]);
-    expect(listToolsCalls.map((call) => call.params)).toEqual([undefined]);
+    expect(await server.listTools()).toBe(tools);
+    expect(listToolsCalls).toEqual([]);
 
     await server.close();
   });
@@ -1129,7 +1122,7 @@ describe('NodeMCPServerSSE', () => {
     const callStarted = new Promise<void>((resolve) => {
       markCallStarted = resolve;
     });
-    callToolImplementation = async (_params, _resultSchema, options) => {
+    callToolImplementation = async (_params, options) => {
       markCallStarted?.();
       return new Promise((_, reject) => {
         options.signal.addEventListener(
@@ -1262,27 +1255,6 @@ class MockStreamableHTTPClientTransport {
 }
 
 describe('NodeMCPServerStreamableHttp', () => {
-  beforeAll(() => {
-    vi.mock(
-      '@modelcontextprotocol/sdk/client/streamableHttp.js',
-      async (importOriginal) => {
-        return {
-          ...(await importOriginal()),
-          StreamableHTTPClientTransport: MockStreamableHTTPClientTransport,
-        };
-      },
-    );
-    vi.mock(
-      '@modelcontextprotocol/sdk/client/index.js',
-      async (importOriginal) => {
-        return {
-          ...(await importOriginal()),
-          Client: MockClient,
-        };
-      },
-    );
-  });
-
   beforeEach(() => {
     MockStreamableHTTPClientTransport.instances = [];
   });
@@ -1480,6 +1452,7 @@ describe('NodeMCPServerStreamableHttp', () => {
 
     expect(lastConnectOptions?.timeout).toBe(9000);
     expect(lastListToolsOptions?.timeout).toBe(9000);
+    expect(lastListToolsOptions?.cacheMode).toBe('bypass');
     expect(lastCallToolOptions?.timeout).toBe(DEFAULT_REQUEST_TIMEOUT_MSEC);
     expect(lastCallToolOptions?.signal).toBeDefined();
     expect(lastCallToolOptions?.signal).not.toBe(controller.signal);
@@ -1487,7 +1460,7 @@ describe('NodeMCPServerStreamableHttp', () => {
     await server.close();
   });
 
-  test('should redact cursors from later tool page errors and restore metadata', async () => {
+  test('should not cache a failed paginated tool listing', async () => {
     const opaqueCursor = 'SECRET_OPAQUE_CURSOR';
     const unsafeError = new Error(`Continuation failed for ${opaqueCursor}`);
     listToolsImplementation = async (params) => {
@@ -1507,17 +1480,18 @@ describe('NodeMCPServerStreamableHttp', () => {
     await server.connect();
     const error = await server.listTools().catch((caught) => caught);
 
-    expect(error).not.toBe(unsafeError);
-    expect(error).toMatchObject({
-      name: 'Error',
-      message: 'MCP tool listing failed while fetching a continuation page.',
-    });
-    expect(getErrorGraphText(error)).not.toContain(opaqueCursor);
+    expect(error).toBe(unsafeError);
     expect(listToolsCalls.map((call) => call.params)).toEqual([
       undefined,
       { cursor: opaqueCursor },
     ]);
-    expect(clientToolMetadataCacheCalls.at(-1)).toEqual([]);
+
+    listToolsImplementation = async () => ({
+      tools: [createMockTool('recovered-tool')],
+    });
+    expect((await server.listTools()).map((tool) => tool.name)).toEqual([
+      'recovered-tool',
+    ]);
 
     await server.close();
   });
@@ -1527,7 +1501,7 @@ describe('NodeMCPServerStreamableHttp', () => {
     const callStarted = new Promise<void>((resolve) => {
       markCallStarted = resolve;
     });
-    callToolImplementation = async (_params, _resultSchema, options) => {
+    callToolImplementation = async (_params, options) => {
       markCallStarted?.();
       return new Promise((_, reject) => {
         options.signal.addEventListener(

--- a/packages/agents-core/test/shims/mcp-server/node.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/node.test.ts
@@ -186,6 +186,7 @@ describe('NodeMCPServerStdio', () => {
     await server.connect();
     expect(lastConnectOptions?.timeout).toBe(5000);
     expect(lastClientOptions?.versionNegotiation).toEqual({ mode: 'auto' });
+    expect(lastClientOptions?.listMaxPages).toBe(0);
     await server.close();
   });
 
@@ -231,7 +232,6 @@ describe('NodeMCPServerStdio', () => {
 
     expect(lastConnectOptions?.timeout).toBe(6000);
     expect(lastListToolsOptions?.timeout).toBe(6000);
-    expect(lastListToolsOptions?.cacheMode).toBe('bypass');
     expect(lastCallToolOptions?.timeout).toBe(DEFAULT_REQUEST_TIMEOUT_MSEC);
     expect(lastCallToolOptions?.signal).toBeDefined();
     expect(lastCallToolOptions?.signal).not.toBe(controller.signal);
@@ -476,28 +476,6 @@ describe('NodeMCPServerStdio', () => {
     await server.close();
   });
 
-  test('should use the v2 high-level list method without private metadata APIs', async () => {
-    const server = new NodeMCPServerStdio({
-      name: 'missing-metadata-cache',
-      fullCommand: 'test',
-    });
-
-    await server.connect();
-    const session = (server as any).session;
-    session.listTools = vi.fn(async () => ({
-      tools: [createMockTool('committed-tool')],
-    }));
-
-    const resources = await server.listResources();
-    expect(resources.resources[0].uri).toBe('file:///mock-resource.txt');
-    expect((await server.listTools()).map((tool) => tool.name)).toEqual([
-      'committed-tool',
-    ]);
-    expect(session.listTools).toHaveBeenCalledOnce();
-
-    await server.close();
-  });
-
   test('should forward resource requests to session methods', async () => {
     const server = new NodeMCPServerStdio({
       name: 'resource-test',
@@ -590,6 +568,9 @@ class MockClient {
   getServerCapabilities(): Record<string, unknown> {
     return { tools: {}, resources: {} };
   }
+  getProtocolEra(): 'legacy' {
+    return 'legacy';
+  }
   request(request: any, options?: any): Promise<any> {
     switch (request.method) {
       case 'resources/list':
@@ -597,32 +578,14 @@ class MockClient {
       case 'resources/templates/list':
         return this.listResourceTemplates(request.params, options);
       case 'tools/list':
-        return this.listTools(request.params, options);
+        lastListToolsOptions = options;
+        listToolsCalls.push({ params: request.params, options });
+        return listToolsImplementation
+          ? listToolsImplementation(request.params, options)
+          : Promise.resolve({ tools: [createMockTool('mock-tool')] });
       default:
         throw new Error(`Unexpected mock MCP request: ${request.method}`);
     }
-  }
-  async listTools(params?: any, options?: any): Promise<any> {
-    const tools: any[] = [];
-    const seenCursors = new Set<string>();
-    let cursor = params?.cursor;
-    do {
-      const pageParams = cursor === undefined ? undefined : { cursor };
-      lastListToolsOptions = options;
-      listToolsCalls.push({ params: pageParams, options });
-      const page = listToolsImplementation
-        ? await listToolsImplementation(pageParams, options)
-        : { tools: [createMockTool('mock-tool')] };
-      tools.push(...page.tools);
-      cursor = page.nextCursor;
-      if (cursor !== undefined) {
-        if (seenCursors.has(cursor)) {
-          break;
-        }
-        seenCursors.add(cursor);
-      }
-    } while (params?.cursor === undefined && cursor !== undefined);
-    return { tools };
   }
   callTool(_params: any, options?: any): Promise<any> {
     lastCallToolParams = _params;
@@ -1068,7 +1031,6 @@ describe('NodeMCPServerSSE', () => {
 
     expect(lastConnectOptions?.timeout).toBe(4000);
     expect(lastListToolsOptions?.timeout).toBe(4000);
-    expect(lastListToolsOptions?.cacheMode).toBe('bypass');
     expect(lastCallToolOptions?.timeout).toBe(DEFAULT_REQUEST_TIMEOUT_MSEC);
     expect(lastCallToolOptions?.signal).toBeDefined();
     expect(lastCallToolOptions?.signal).not.toBe(controller.signal);
@@ -1076,7 +1038,7 @@ describe('NodeMCPServerSSE', () => {
     await server.close();
   });
 
-  test('should stop repeated tool cursors and cache the aggregate', async () => {
+  test('should reject repeated tool cursors without caching partial results', async () => {
     listToolsImplementation = async (params) => {
       if (params === undefined) {
         return {
@@ -1097,11 +1059,9 @@ describe('NodeMCPServerSSE', () => {
 
     await server.connect();
 
-    const tools = await server.listTools();
-    expect(tools.map((tool) => tool.name)).toEqual([
-      'first-tool',
-      'second-tool',
-    ]);
+    await expect(server.listTools()).rejects.toThrow(
+      'MCP server returned a repeated cursor while listing tools.',
+    );
     expect(listToolsCalls.map((call) => call.params)).toEqual([
       undefined,
       { cursor: 'repeated-cursor' },
@@ -1111,8 +1071,10 @@ describe('NodeMCPServerSSE', () => {
       tools: [createMockTool('recovered-tool')],
     });
 
-    expect(await server.listTools()).toBe(tools);
-    expect(listToolsCalls).toEqual([]);
+    expect((await server.listTools()).map((tool) => tool.name)).toEqual([
+      'recovered-tool',
+    ]);
+    expect(listToolsCalls.map((call) => call.params)).toEqual([undefined]);
 
     await server.close();
   });
@@ -1452,7 +1414,6 @@ describe('NodeMCPServerStreamableHttp', () => {
 
     expect(lastConnectOptions?.timeout).toBe(9000);
     expect(lastListToolsOptions?.timeout).toBe(9000);
-    expect(lastListToolsOptions?.cacheMode).toBe('bypass');
     expect(lastCallToolOptions?.timeout).toBe(DEFAULT_REQUEST_TIMEOUT_MSEC);
     expect(lastCallToolOptions?.signal).toBeDefined();
     expect(lastCallToolOptions?.signal).not.toBe(controller.signal);
@@ -1460,7 +1421,7 @@ describe('NodeMCPServerStreamableHttp', () => {
     await server.close();
   });
 
-  test('should not cache a failed paginated tool listing', async () => {
+  test('should redact cursors from later tool page errors', async () => {
     const opaqueCursor = 'SECRET_OPAQUE_CURSOR';
     const unsafeError = new Error(`Continuation failed for ${opaqueCursor}`);
     listToolsImplementation = async (params) => {
@@ -1480,11 +1441,22 @@ describe('NodeMCPServerStreamableHttp', () => {
     await server.connect();
     const error = await server.listTools().catch((caught) => caught);
 
-    expect(error).toBe(unsafeError);
+    expect(error).not.toBe(unsafeError);
+    expect(error).toMatchObject({
+      name: 'Error',
+      message: 'MCP tool listing failed while fetching a continuation page.',
+    });
+    expect(getErrorGraphText(error)).not.toContain(opaqueCursor);
     expect(listToolsCalls.map((call) => call.params)).toEqual([
       undefined,
       { cursor: opaqueCursor },
     ]);
+
+    const firstPageError = new Error('First page failed');
+    listToolsImplementation = async () => {
+      throw firstPageError;
+    };
+    await expect(server.listTools()).rejects.toBe(firstPageError);
 
     listToolsImplementation = async () => ({
       tools: [createMockTool('recovered-tool')],

--- a/packages/agents-core/test/shims/mcp-server/streamableHttpRetry.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/streamableHttpRetry.test.ts
@@ -7,13 +7,24 @@ import {
   it,
   vi,
 } from 'vitest';
-import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types';
+import { SdkError, SdkErrorCode } from '@modelcontextprotocol/client';
 import { MCPServerStreamableHttp } from '../../../src/mcp';
 import type { Logger } from '../../../src/logger';
 import { NodeMCPServerStreamableHttp } from '../../../src/shims/mcp-server/node';
 
 const TEST_URL = 'https://example.invalid/mcp';
 const TEST_PROTOCOL_VERSION = '2025-06-18';
+const ErrorCode = {
+  ConnectionClosed: SdkErrorCode.ConnectionClosed,
+  InvalidParams: 'INVALID_PARAMS' as SdkErrorCode,
+  InvalidRequest: 'INVALID_REQUEST' as SdkErrorCode,
+  NotConnected: SdkErrorCode.NotConnected,
+  RequestTimeout: SdkErrorCode.RequestTimeout,
+};
+
+class McpError extends SdkError {
+  override name = 'McpError';
+}
 const silentLogger: Logger = {
   namespace: 'openai-agents:test:mcp-streamable-http-retry',
   debug: () => {},
@@ -105,7 +116,6 @@ class MockStreamableHTTPClientTransport {
 
 class MockClient {
   static instances: MockClient[] = [];
-  static toolMetadataCacheSupported = true;
   static connectHandlers: Array<
     ((this: MockClient) => Promise<void>) | undefined
   > = [];
@@ -134,6 +144,7 @@ class MockClient {
   > = [];
 
   readonly instanceIndex: number;
+  readonly clientOptions: unknown;
   transport: MockStreamableHTTPClientTransport | null = null;
   connectMock = vi.fn().mockResolvedValue(undefined);
   closeMock = vi.fn().mockResolvedValue(undefined);
@@ -144,14 +155,13 @@ class MockClient {
     NonNullable<MockTool['outputSchema']>
   >();
 
-  constructor(_options: { name: string; version: string }) {
+  constructor(
+    _options: { name: string; version: string },
+    clientOptions?: unknown,
+  ) {
     this.instanceIndex = MockClient.instances.length;
+    this.clientOptions = clientOptions;
     MockClient.instances.push(this);
-    if (!MockClient.toolMetadataCacheSupported) {
-      Object.defineProperty(this, 'cacheToolMetadata', {
-        value: undefined,
-      });
-    }
   }
 
   private get transportIndex(): number {
@@ -202,11 +212,17 @@ class MockClient {
     }
   }
 
-  async request(request: { method: string }): Promise<{ tools: MockTool[] }> {
-    if (request.method !== 'tools/list') {
-      throw new Error(`Unexpected request method: ${request.method}`);
-    }
+  getServerCapabilities(): Record<string, unknown> {
+    return { tools: {} };
+  }
+
+  getProtocolEra(): 'legacy' {
+    return 'legacy';
+  }
+
+  async listTools(): Promise<{ tools: MockTool[] }> {
     const tools = MockClient.listToolsResults[this.transportIndex] ?? [];
+    this.cacheToolMetadata(tools);
     return { tools };
   }
 
@@ -223,12 +239,19 @@ class MockClient {
     await this.notificationMock(notification);
   }
 
-  async callTool(params: {
-    name: string;
-    arguments: Record<string, unknown>;
-    _meta?: Record<string, unknown>;
-  }): Promise<any> {
-    if (this.cachedRequiredTaskTools.has(params.name)) {
+  async callTool(
+    params: {
+      name: string;
+      arguments: Record<string, unknown>;
+      _meta?: Record<string, unknown>;
+    },
+    options?: { toolDefinition?: MockTool },
+  ): Promise<any> {
+    if (
+      options?.toolDefinition?.execution?.taskSupport === 'required' ||
+      (options?.toolDefinition === undefined &&
+        this.cachedRequiredTaskTools.has(params.name))
+    ) {
       throw new McpError(
         ErrorCode.InvalidRequest,
         `Tool "${params.name}" requires task-based execution.`,
@@ -247,12 +270,21 @@ class MockClient {
           ],
         };
 
-    this.validateStructuredContent(params.name, result);
+    this.validateStructuredContent(
+      params.name,
+      result,
+      options?.toolDefinition?.outputSchema,
+    );
     return result;
   }
 
-  private validateStructuredContent(toolName: string, result: any): void {
-    const outputSchema = this.cachedToolOutputSchemas.get(toolName);
+  private validateStructuredContent(
+    toolName: string,
+    result: any,
+    overrideOutputSchema?: MockTool['outputSchema'],
+  ): void {
+    const outputSchema =
+      overrideOutputSchema ?? this.cachedToolOutputSchemas.get(toolName);
     if (!outputSchema) {
       return;
     }
@@ -311,6 +343,7 @@ class MockClient {
   }
 
   async close(): Promise<void> {
+    this.cacheToolMetadata([]);
     await this.closeMock();
     if (this.transport) {
       await this.transport.close();
@@ -319,22 +352,12 @@ class MockClient {
   }
 }
 
-vi.mock(
-  '@modelcontextprotocol/sdk/client/streamableHttp.js',
-  async (importOriginal) => ({
-    ...(await importOriginal()),
-    StreamableHTTPClientTransport: MockStreamableHTTPClientTransport,
-    StreamableHTTPError: MockStreamableHTTPError,
-  }),
-);
-
-vi.mock(
-  '@modelcontextprotocol/sdk/client/index.js',
-  async (importOriginal) => ({
-    ...(await importOriginal()),
-    Client: MockClient,
-  }),
-);
+vi.doMock('@modelcontextprotocol/client', async (importOriginal) => ({
+  ...(await importOriginal()),
+  StreamableHTTPClientTransport: MockStreamableHTTPClientTransport,
+  StreamableHTTPError: MockStreamableHTTPError,
+  Client: MockClient,
+}));
 
 function createServer(
   name: string,
@@ -378,7 +401,6 @@ function throwProtocolNotConnected(this: MockClient): never {
 describe('NodeMCPServerStreamableHttp closed-session recovery', () => {
   beforeAll(() => {
     MockClient.instances = [];
-    MockClient.toolMetadataCacheSupported = true;
     MockClient.connectHandlers = [];
     MockClient.listToolsResults = [];
     MockClient.sessionIdAssignments = [];
@@ -389,7 +411,6 @@ describe('NodeMCPServerStreamableHttp closed-session recovery', () => {
 
   beforeEach(() => {
     MockClient.instances = [];
-    MockClient.toolMetadataCacheSupported = true;
     MockClient.connectHandlers = [];
     MockClient.listToolsResults = [];
     MockClient.sessionIdAssignments = [];
@@ -398,25 +419,21 @@ describe('NodeMCPServerStreamableHttp closed-session recovery', () => {
     MockStreamableHTTPClientTransport.instances = [];
   });
 
-  it('publishes connections without metadata caching and fails tool listing early', async () => {
-    MockClient.toolMetadataCacheSupported = false;
-    const server = createServer('missing-metadata-cache-server');
+  it('configures automatic modern-to-legacy protocol negotiation', async () => {
+    const server = createServer('auto-negotiation-server');
 
     await server.connect();
 
     const client = MockClient.instances[0];
-    const requestSpy = vi.spyOn(client, 'request');
-    await expect(server.listTools()).rejects.toThrow(
-      'The installed MCP SDK does not support tool metadata caching required for paginated tool listing.',
-    );
-
     expect(MockClient.instances).toHaveLength(1);
     expect(client.connectMock).toHaveBeenCalledOnce();
+    expect(client.clientOptions).toEqual({
+      versionNegotiation: { mode: 'auto' },
+    });
     expect((server as any).session).toBe(client);
     expect((server as any).transport).toBe(
       MockStreamableHTTPClientTransport.instances[0],
     );
-    expect(requestSpy).not.toHaveBeenCalled();
 
     await server.close();
   });
@@ -453,7 +470,7 @@ describe('NodeMCPServerStreamableHttp closed-session recovery', () => {
       expect(MockClient.instances[0].notificationMock).toHaveBeenCalledWith({
         method: 'notifications/initialized',
       });
-      expect(MockClient.instances[0].closeMock).toHaveBeenCalledTimes(1);
+      expect(MockClient.instances[0].closeMock).not.toHaveBeenCalled();
       expect(
         MockStreamableHTTPClientTransport.instances[0].closeMock,
       ).toHaveBeenCalledTimes(1);
@@ -469,7 +486,7 @@ describe('NodeMCPServerStreamableHttp closed-session recovery', () => {
     }
   });
 
-  it('preserves tool metadata after healing the shared client', async () => {
+  it('preserves tool metadata while healing the shared client', async () => {
     MockClient.listToolsResults = [
       [
         {
@@ -545,8 +562,8 @@ describe('NodeMCPServerStreamableHttp closed-session recovery', () => {
       await expect(
         server.callTool('required-task-tool', null),
       ).rejects.toMatchObject({
-        name: 'McpError',
-        code: ErrorCode.InvalidRequest,
+        name: 'ProtocolError',
+        code: -32600,
       });
       await expect(server.callTool('schema-tool', null)).rejects.toMatchObject({
         name: 'McpError',
@@ -562,7 +579,7 @@ describe('NodeMCPServerStreamableHttp closed-session recovery', () => {
     }
   });
 
-  it('restores committed metadata when a same-session refresh fails', async () => {
+  it('retains last known metadata when a same-session refresh fails', async () => {
     MockClient.sessionIdAssignments = ['shared-session'];
     MockClient.listToolsResults = [
       [
@@ -616,8 +633,8 @@ describe('NodeMCPServerStreamableHttp closed-session recovery', () => {
       await expect(
         server.callTool('previous-required-tool', null),
       ).rejects.toMatchObject({
-        name: 'McpError',
-        code: ErrorCode.InvalidRequest,
+        name: 'ProtocolError',
+        code: -32600,
       });
       expect(MockClient.instances).toHaveLength(1);
     } finally {

--- a/packages/agents-core/test/shims/mcp-server/streamableHttpRetry.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/streamableHttpRetry.test.ts
@@ -220,10 +220,13 @@ class MockClient {
     return 'legacy';
   }
 
-  async listTools(): Promise<{ tools: MockTool[] }> {
-    const tools = MockClient.listToolsResults[this.transportIndex] ?? [];
-    this.cacheToolMetadata(tools);
-    return { tools };
+  async request(request: { method: string }): Promise<{ tools: MockTool[] }> {
+    if (request.method !== 'tools/list') {
+      throw new Error(`Unexpected MCP request: ${request.method}`);
+    }
+    return {
+      tools: MockClient.listToolsResults[this.transportIndex] ?? [],
+    };
   }
 
   async notification(notification: {
@@ -429,6 +432,7 @@ describe('NodeMCPServerStreamableHttp closed-session recovery', () => {
     expect(client.connectMock).toHaveBeenCalledOnce();
     expect(client.clientOptions).toEqual({
       versionNegotiation: { mode: 'auto' },
+      listMaxPages: 0,
     });
     expect((server as any).session).toBe(client);
     expect((server as any).transport).toBe(
@@ -612,13 +616,15 @@ describe('NodeMCPServerStreamableHttp closed-session recovery', () => {
     try {
       expect(await server.listTools()).toHaveLength(2);
       const client = MockClient.instances[0];
-      const cacheToolMetadata = client.cacheToolMetadata.bind(client);
-      client.cacheToolMetadata = (tools) => {
-        if (tools.some((tool) => tool.name === 'metadata-compile-failure')) {
-          cacheToolMetadata([]);
+      const request = client.request.bind(client);
+      client.request = async (params) => {
+        const result = await request(params);
+        if (
+          result.tools.some((tool) => tool.name === 'metadata-compile-failure')
+        ) {
           throw new Error('metadata compilation failed');
         }
-        cacheToolMetadata(tools);
+        return result;
       };
 
       await expect(server.callTool('regular-tool', null)).rejects.toMatchObject(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -658,9 +658,9 @@ importers:
         specifier: ^4.0.0
         version: 4.3.5
     optionalDependencies:
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.26.0
-        version: 1.26.0(zod@4.3.5)
+      '@modelcontextprotocol/client':
+        specifier: ^2.0.0
+        version: 2.0.0
 
   packages/agents-extensions:
     dependencies:
@@ -2064,6 +2064,14 @@ packages:
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@modelcontextprotocol/client@2.0.0':
+    resolution: {integrity: sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
+    engines: {node: '>=20'}
 
   '@modelcontextprotocol/sdk@1.26.0':
     resolution: {integrity: sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==}
@@ -9593,6 +9601,22 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@modelcontextprotocol/client@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      jose: 6.1.3
+      pkce-challenge: 5.0.1
+      zod: 4.3.5
+    optional: true
+
+  '@modelcontextprotocol/core@2.0.0':
+    dependencies:
+      zod: 4.3.5
+    optional: true
 
   '@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,6 +22,8 @@ overrides:
 publishBranch: main
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
+  - '@modelcontextprotocol/client@2.0.0'
+  - '@modelcontextprotocol/core@2.0.0'
   - openai@6.46.0
 blockExoticSubdeps: true
 strictDepBuilds: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,8 +22,6 @@ overrides:
 publishBranch: main
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
-  - '@modelcontextprotocol/client@2.0.0'
-  - '@modelcontextprotocol/core@2.0.0'
   - openai@6.46.0
 blockExoticSubdeps: true
 strictDepBuilds: true


### PR DESCRIPTION
This pull request adds MCP TypeScript SDK v2 support to the local MCP clients. Stdio and Streamable HTTP clients now negotiate MCP 2026-07-28 with legacy fallback, while deprecated SSE remains legacy-only.

It preserves the released resource pagination, cache invalidation, cancellation, required-task rejection, and reconnect behavior. It also adds real v2 client coverage for modern and legacy negotiation, explicit sessions, session recovery, and stale tool-list isolation.

The exact MCP v2 client and core releases are excluded from the dependency freshness window because installation was otherwise blocked.

see also: https://github.com/openai/openai-agents-python/pull/4106