### PR TITLE
fix(realtime): apply output guardrails to text deltas

### DIFF
--- a/.changeset/realtime-text-output-guardrails.md
+++ b/.changeset/realtime-text-output-guardrails.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: apply realtime output guardrails to text deltas

--- a/docs/src/content/docs/guides/voice-agents/build.mdx
+++ b/docs/src/content/docs/guides/voice-agents/build.mdx
@@ -239,7 +239,7 @@ By default, function-tool input guardrails run after approval, immediately befor
 
 ### Guardrails
 
-Guardrails offer a way to monitor whether what the agent has said violated a set of rules and immediately cut off the response. These checks run against the transcript stream of the agent's response. In audio sessions, the SDK uses output audio transcripts and transcript deltas, so the important prerequisite is transcript availability rather than a separate text output modality.
+Guardrails offer a way to monitor whether what the agent has said violated a set of rules and immediately cut off the response. These checks run against the output stream of the agent's response. In text-only sessions, the SDK evaluates output text deltas. In audio sessions, it uses output audio transcripts and transcript deltas, so the important prerequisite is transcript availability rather than a separate text output modality.
 
 The guardrails you provide run asynchronously as a model response is returned, allowing you to cut off the response based on a predefined classification trigger, for example "mentions a specific banned word".
 

--- a/packages/agents-realtime/src/index.ts
+++ b/packages/agents-realtime/src/index.ts
@@ -17,6 +17,7 @@ export {
   TransportLayerAudio,
   TransportLayerResponseCompleted,
   TransportLayerResponseStarted,
+  TransportLayerOutputTextDelta,
   TransportLayerTranscriptDelta,
   TransportError,
   TransportToolCallEvent,

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -332,6 +332,13 @@ export abstract class OpenAIRealtimeBase
           itemId: parsed.item_id,
           responseId: parsed.response_id,
         });
+      } else if (parsed.type === 'response.output_text.delta') {
+        this.emit('output_text_delta', {
+          type: 'output_text_delta',
+          delta: parsed.delta,
+          itemId: parsed.item_id,
+          responseId: parsed.response_id,
+        });
       }
       // no support for partial transcripts yet.
       return;

--- a/packages/agents-realtime/src/realtimeSession.ts
+++ b/packages/agents-realtime/src/realtimeSession.ts
@@ -50,7 +50,9 @@ import { RealtimeAgent } from './realtimeAgent';
 import { RealtimeSessionEventTypes } from './realtimeSessionEvents';
 import type { ApiKey, RealtimeTransportLayer } from './transportLayer';
 import type {
+  TransportLayerOutputTextDelta,
   TransportLayerResponseStarted,
+  TransportLayerTranscriptDelta,
   TransportToolCallEvent,
 } from './transportLayerEvents';
 import type { InputAudioTranscriptionCompletedEvent } from './transportLayerEvents';
@@ -245,6 +247,13 @@ type PendingRealtimeFunctionCall<TBaseContext> = {
   approvalItem: RunToolApprovalItem;
 };
 
+type OutputGuardrailDeltaSource = 'audio' | 'text';
+
+type OutputGuardrailDeltaState = {
+  text: string;
+  lastRunIndex: number;
+};
+
 function normalizeRealtimeFunctionCallId(
   toolCall: TransportToolCallEvent,
 ): TransportToolCallEvent {
@@ -318,10 +327,16 @@ export class RealtimeSession<
   #context: RunContext<RealtimeContextData<TBaseContext>>;
   #outputGuardrails: RealtimeOutputGuardrailDefinition[] = [];
   #outputGuardrailSettings: RealtimeOutputGuardrailSettings;
-  #transcribedTextDeltas: Record<string, string> = {};
+  #outputGuardrailDeltaState = new Map<
+    string,
+    Map<string, OutputGuardrailDeltaState>
+  >();
   #history: RealtimeItem[] = [];
   #shouldIncludeAudioData: boolean;
   #interruptedByGuardrail: Record<string, boolean> = {};
+  #activeResponseId: string | undefined;
+  #responseGeneration = 0;
+  #connectionGeneration = 0;
   #audioStarted = false;
   // Tracks all MCP tools fetched per server label (from mcp_list_tools results).
   #allMcpToolsByServer: Map<string, RealtimeMcpToolInfo[]> = new Map();
@@ -945,13 +960,17 @@ export class RealtimeSession<
     output: string,
     responseId: string,
     itemId: string,
+    sourceAgent: SessionRealtimeAgent<TBaseContext>,
+    source: OutputGuardrailDeltaSource | 'final',
+    responseGeneration: number,
+    connectionGeneration: number,
   ) {
     if (this.#outputGuardrails.length === 0) {
       return;
     }
 
     const guardrailArgs: OutputGuardrailFunctionArgs<unknown, 'text'> = {
-      agent: this.#currentAgent as Agent<unknown, 'text'>,
+      agent: sourceAgent as Agent<unknown, 'text'>,
       agentOutput: output,
       context: this.#context,
     };
@@ -963,6 +982,9 @@ export class RealtimeSession<
       (result) => result.output.tripwireTriggered,
     );
     if (firstTripwireTriggered) {
+      if (connectionGeneration !== this.#connectionGeneration) {
+        return;
+      }
       // this ensures that if one guardrail already trips and we are in the middle of another
       // guardrail run, we don't trip again
       if (this.#interruptedByGuardrail[responseId]) {
@@ -973,10 +995,26 @@ export class RealtimeSession<
         `Output guardrail triggered: ${JSON.stringify(firstTripwireTriggered.output.outputInfo)}`,
         firstTripwireTriggered,
       );
-      this.emit('guardrail_tripped', this.#context, this.#currentAgent, error, {
+      this.emit('guardrail_tripped', this.#context, sourceAgent, error, {
         itemId,
       });
-      this.interrupt();
+
+      if (
+        responseGeneration !== this.#responseGeneration ||
+        (this.#activeResponseId !== undefined &&
+          this.#activeResponseId !== responseId)
+      ) {
+        return;
+      }
+
+      if (source === 'text' && this.#activeResponseId === responseId) {
+        this.#transport.sendEvent({
+          type: 'response.cancel',
+          response_id: responseId,
+        });
+      } else if (source !== 'text') {
+        this.interrupt();
+      }
 
       const feedbackText = getRealtimeGuardrailFeedbackMessage(
         firstTripwireTriggered,
@@ -984,6 +1022,70 @@ export class RealtimeSession<
       this.sendMessage(feedbackText);
       return;
     }
+  }
+
+  #scheduleOutputGuardrails(
+    output: string,
+    responseId: string,
+    itemId: string,
+    source: OutputGuardrailDeltaSource | 'final',
+    sourceAgent: SessionRealtimeAgent<TBaseContext>,
+    responseGeneration = this.#responseGeneration,
+    connectionGeneration = this.#connectionGeneration,
+  ) {
+    void this.#runOutputGuardrails(
+      output,
+      responseId,
+      itemId,
+      sourceAgent,
+      source,
+      responseGeneration,
+      connectionGeneration,
+    ).catch((error) => {
+      this.emit('error', { type: 'error', error });
+    });
+  }
+
+  #handleOutputGuardrailDelta(
+    event: TransportLayerTranscriptDelta | TransportLayerOutputTextDelta,
+    source: OutputGuardrailDeltaSource,
+  ) {
+    const { delta, itemId, responseId } = event;
+    let responseState = this.#outputGuardrailDeltaState.get(responseId);
+    if (!responseState) {
+      responseState = new Map();
+      this.#outputGuardrailDeltaState.set(responseId, responseState);
+    }
+
+    const state = responseState.get(itemId) ?? {
+      text: '',
+      lastRunIndex: 0,
+    };
+    state.text += delta;
+    responseState.set(itemId, state);
+
+    if (this.#outputGuardrailSettings.debounceTextLength < 0) {
+      return;
+    }
+
+    const newRunIndex = Math.floor(
+      state.text.length / this.#outputGuardrailSettings.debounceTextLength,
+    );
+    if (newRunIndex <= state.lastRunIndex) {
+      return;
+    }
+
+    state.lastRunIndex = newRunIndex;
+    const sourceAgent =
+      this.#responseDispatchSnapshots.get(responseId)?.agent ??
+      this.#currentAgent;
+    this.#scheduleOutputGuardrails(
+      state.text,
+      responseId,
+      itemId,
+      source,
+      sourceAgent,
+    );
   }
 
   #setEventListeners() {
@@ -1029,12 +1131,23 @@ export class RealtimeSession<
       this.#audioStarted = false;
       const responseId = getStartedResponseId(event);
       if (responseId) {
+        this.#activeResponseId = responseId;
+        this.#responseGeneration += 1;
         this.#captureResponseDispatchSnapshot(responseId);
       }
       this.emit('agent_start', this.#context, this.#currentAgent);
       this.#currentAgent.emit('agent_start', this.#context, this.#currentAgent);
     });
     this.#transport.on('turn_done', (event) => {
+      const responseId = event.response.id;
+      const sourceAgent =
+        this.#responseDispatchSnapshots.get(responseId)?.agent ??
+        this.#currentAgent;
+      const responseGeneration = this.#responseGeneration;
+      const connectionGeneration = this.#connectionGeneration;
+      if (this.#activeResponseId === responseId) {
+        this.#activeResponseId = undefined;
+      }
       const outputItems = event.response.output ?? [];
       let textOutput = '';
       let itemId = '';
@@ -1059,8 +1172,17 @@ export class RealtimeSession<
       this.emit('agent_end', this.#context, this.#currentAgent, textOutput);
       this.#currentAgent.emit('agent_end', this.#context, textOutput);
 
-      this.#runOutputGuardrails(textOutput, event.response.id, itemId);
-      this.#responseDispatchSnapshots.delete(event.response.id);
+      this.#scheduleOutputGuardrails(
+        textOutput,
+        responseId,
+        itemId,
+        'final',
+        sourceAgent,
+        responseGeneration,
+        connectionGeneration,
+      );
+      this.#outputGuardrailDeltaState.delete(responseId);
+      this.#responseDispatchSnapshots.delete(responseId);
     });
 
     this.#transport.on('audio_done', () => {
@@ -1070,35 +1192,20 @@ export class RealtimeSession<
       this.emit('audio_stopped', this.#context, this.#currentAgent);
     });
 
-    let lastRunIndex = 0;
-    let lastItemId: string | undefined;
     this.#transport.on('audio_transcript_delta', (event) => {
       try {
-        const delta = event.delta;
-        const itemId = event.itemId;
-        const responseId = event.responseId;
-        if (lastItemId !== itemId) {
-          lastItemId = itemId;
-          lastRunIndex = 0;
-        }
-        const currentText = this.#transcribedTextDeltas[itemId] ?? '';
-        const newText = currentText + delta;
-        this.#transcribedTextDeltas[itemId] = newText;
+        this.#handleOutputGuardrailDelta(event, 'audio');
+      } catch (err) {
+        this.emit('error', {
+          type: 'error',
+          error: err,
+        });
+      }
+    });
 
-        if (this.#outputGuardrailSettings.debounceTextLength < 0) {
-          return;
-        }
-
-        const newRunIndex = Math.floor(
-          newText.length / this.#outputGuardrailSettings.debounceTextLength,
-        );
-        if (newRunIndex > lastRunIndex) {
-          lastRunIndex = newRunIndex;
-          // We don't cancel existing runs because we want the first one to fail to fail
-          // The transport layer should upon failure handle the interruption and stop the model
-          // from generating further
-          this.#runOutputGuardrails(newText, responseId, itemId);
-        }
+    this.#transport.on('output_text_delta', (event) => {
+      try {
+        this.#handleOutputGuardrailDelta(event, 'text');
       } catch (err) {
         this.emit('error', {
           type: 'error',
@@ -1273,6 +1380,11 @@ export class RealtimeSession<
    * @param options - The options for the connection.
    */
   async connect(options: RealtimeSessionConnectOptions) {
+    this.#connectionGeneration += 1;
+    this.#responseGeneration = 0;
+    this.#activeResponseId = undefined;
+    this.#outputGuardrailDeltaState.clear();
+    this.#interruptedByGuardrail = {};
     this.#responseDispatchSnapshots.clear();
     // makes sure the current agent is correctly set and loads the tools
     await this.#setCurrentAgent(this.initialAgent);
@@ -1347,6 +1459,10 @@ export class RealtimeSession<
    * Disconnect from the session.
    */
   close() {
+    this.#connectionGeneration += 1;
+    this.#responseGeneration = 0;
+    this.#activeResponseId = undefined;
+    this.#outputGuardrailDeltaState.clear();
     this.#interruptedByGuardrail = {};
     this.#pendingFunctionCalls.clear();
     this.#responseDispatchSnapshots.clear();

--- a/packages/agents-realtime/src/realtimeSession.ts
+++ b/packages/agents-realtime/src/realtimeSession.ts
@@ -320,6 +320,8 @@ export class RealtimeSession<
     string,
     RealtimeDispatchSnapshot<TBaseContext>
   >();
+  #pendingResponseDispatchSnapshot:
+    RealtimeDispatchSnapshot<TBaseContext> | undefined;
   #pendingFunctionCalls = new Map<
     string,
     PendingRealtimeFunctionCall<TBaseContext>
@@ -504,7 +506,9 @@ export class RealtimeSession<
       return existingSnapshot;
     }
 
-    const snapshot = this.#currentDispatchSnapshot;
+    const snapshot =
+      this.#pendingResponseDispatchSnapshot ?? this.#currentDispatchSnapshot;
+    this.#pendingResponseDispatchSnapshot = undefined;
     if (snapshot) {
       this.#responseDispatchSnapshots.set(responseId, snapshot);
     }
@@ -1051,6 +1055,10 @@ export class RealtimeSession<
     source: OutputGuardrailDeltaSource,
   ) {
     const { delta, itemId, responseId } = event;
+    if (this.#activeResponseId === undefined) {
+      this.#activeResponseId = responseId;
+      this.#captureResponseDispatchSnapshot(responseId);
+    }
     let responseState = this.#outputGuardrailDeltaState.get(responseId);
     if (!responseState) {
       responseState = new Map();
@@ -1130,9 +1138,10 @@ export class RealtimeSession<
     this.#transport.on('turn_started', (event) => {
       this.#audioStarted = false;
       const responseId = getStartedResponseId(event);
+      this.#activeResponseId = responseId;
+      this.#responseGeneration += 1;
+      this.#pendingResponseDispatchSnapshot = this.#currentDispatchSnapshot;
       if (responseId) {
-        this.#activeResponseId = responseId;
-        this.#responseGeneration += 1;
         this.#captureResponseDispatchSnapshot(responseId);
       }
       this.emit('agent_start', this.#context, this.#currentAgent);
@@ -1141,7 +1150,7 @@ export class RealtimeSession<
     this.#transport.on('turn_done', (event) => {
       const responseId = event.response.id;
       const sourceAgent =
-        this.#responseDispatchSnapshots.get(responseId)?.agent ??
+        this.#captureResponseDispatchSnapshot(responseId)?.agent ??
         this.#currentAgent;
       const responseGeneration = this.#responseGeneration;
       const connectionGeneration = this.#connectionGeneration;
@@ -1385,6 +1394,7 @@ export class RealtimeSession<
     this.#activeResponseId = undefined;
     this.#outputGuardrailDeltaState.clear();
     this.#interruptedByGuardrail = {};
+    this.#pendingResponseDispatchSnapshot = undefined;
     this.#responseDispatchSnapshots.clear();
     // makes sure the current agent is correctly set and loads the tools
     await this.#setCurrentAgent(this.initialAgent);
@@ -1464,6 +1474,7 @@ export class RealtimeSession<
     this.#activeResponseId = undefined;
     this.#outputGuardrailDeltaState.clear();
     this.#interruptedByGuardrail = {};
+    this.#pendingResponseDispatchSnapshot = undefined;
     this.#pendingFunctionCalls.clear();
     this.#responseDispatchSnapshots.clear();
     this.#transport.close();

--- a/packages/agents-realtime/src/transportLayerEvents.ts
+++ b/packages/agents-realtime/src/transportLayerEvents.ts
@@ -65,6 +65,13 @@ export type TransportLayerTranscriptDelta = {
   responseId: string;
 };
 
+export type TransportLayerOutputTextDelta = {
+  type: 'output_text_delta';
+  itemId: string;
+  delta: string;
+  responseId: string;
+};
+
 export type TransportLayerResponseCompleted =
   protocol.StreamEventResponseCompleted;
 export type TransportLayerResponseStarted = protocol.StreamEventResponseStarted;
@@ -113,6 +120,11 @@ export type RealtimeTransportEventTypes = {
    * Triggered when there is a new text delta of the transcript available.
    */
   audio_transcript_delta: [deltaEvent: TransportLayerTranscriptDelta];
+
+  /**
+   * Triggered when there is a new text output delta available.
+   */
+  output_text_delta: [deltaEvent: TransportLayerOutputTextDelta];
 
   /**
    * Triggered when the audio generation is done.

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -869,6 +869,31 @@ describe('OpenAIRealtimeBase helpers', () => {
     });
   });
 
+  it('emits output text delta events', () => {
+    const base = new TestBase();
+    const deltas: any[] = [];
+    base.on('output_text_delta', (delta) => deltas.push(delta));
+
+    (base as any)._onMessage({
+      data: JSON.stringify({
+        type: 'response.output_text.delta',
+        event_id: 'd1',
+        item_id: 'item1',
+        content_index: 0,
+        delta: 'hi',
+        output_index: 0,
+        response_id: 'r1',
+      }),
+    });
+
+    expect(deltas[0]).toMatchObject({
+      type: 'output_text_delta',
+      delta: 'hi',
+      itemId: 'item1',
+      responseId: 'r1',
+    });
+  });
+
   it('emits mcp_tools_listed for completed list tools items', () => {
     const base = new TestBase();
     const listed: any[] = [];

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -661,6 +661,184 @@ describe('RealtimeSession', () => {
     vi.restoreAllMocks();
   });
 
+  it('applies output guardrails to text deltas without interrupting audio', async () => {
+    const runMock = vi.fn(async () => ({
+      guardrail: { name: 'test', version: '1', policyHint: 'bad' },
+      output: { tripwireTriggered: true, outputInfo: { r: 'bad' } },
+    }));
+    vi.spyOn(guardrailModule, 'defineRealtimeOutputGuardrail').mockReturnValue({
+      run: runMock,
+    } as any);
+    const localTransport = new FakeTransport();
+    const agent = new RealtimeAgent({ name: 'A', handoffs: [] });
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+      outputGuardrails: [
+        {
+          name: 'test',
+          execute: async () => ({ tripwireTriggered: true }),
+        } as any,
+      ],
+      outputGuardrailSettings: { debounceTextLength: 3 },
+    });
+    await localSession.connect({ apiKey: 'test' });
+
+    localTransport.emit('turn_started', {
+      type: 'response_started',
+      providerData: { response: { id: 'response-1' } },
+    });
+    const guardrailTripped = waitForEvent<any[]>(
+      localSession,
+      'guardrail_tripped',
+    );
+    localTransport.emit('output_text_delta', {
+      type: 'output_text_delta',
+      delta: 'bad',
+      itemId: 'item-1',
+      responseId: 'response-1',
+    });
+
+    const [, eventAgent, , details] = await guardrailTripped;
+    expect(eventAgent).toBe(agent);
+    expect(details).toEqual({ itemId: 'item-1' });
+    expect(runMock).toHaveBeenCalledTimes(1);
+    expect(localTransport.sendEventCalls).toContainEqual({
+      type: 'response.cancel',
+      response_id: 'response-1',
+    });
+    expect(localTransport.interruptCalls).toBe(0);
+    expect(localTransport.sendMessageCalls.at(-1)?.[0]).toContain('blocked');
+    vi.restoreAllMocks();
+  });
+
+  it('does not let a stale text guardrail interrupt a newer response', async () => {
+    const resolvers = new Map<
+      string,
+      (result: {
+        guardrail: { name: string; version: string; policyHint: string };
+        output: { tripwireTriggered: boolean; outputInfo: { text: string } };
+      }) => void
+    >();
+    const runMock = vi.fn(
+      async ({ agentOutput }: { agentOutput: unknown }) =>
+        new Promise<any>((resolve) => {
+          resolvers.set(String(agentOutput), resolve);
+        }),
+    );
+    vi.spyOn(guardrailModule, 'defineRealtimeOutputGuardrail').mockReturnValue({
+      run: runMock,
+    } as any);
+    const localTransport = new FakeTransport();
+    const sourceAgent = new RealtimeAgent({ name: 'Source', handoffs: [] });
+    const newerAgent = new RealtimeAgent({ name: 'Newer', handoffs: [] });
+    const localSession = new RealtimeSession(sourceAgent, {
+      transport: localTransport,
+      outputGuardrails: [{ name: 'test', execute: async () => ({}) } as any],
+      outputGuardrailSettings: { debounceTextLength: 1 },
+    });
+    const trippedAgents: unknown[] = [];
+    localSession.on('guardrail_tripped', (_context, agent) => {
+      trippedAgents.push(agent);
+    });
+    await localSession.connect({ apiKey: 'test' });
+
+    localTransport.emit('turn_started', {
+      type: 'response_started',
+      providerData: { response: { id: 'response-a' } },
+    });
+    localTransport.emit('output_text_delta', {
+      type: 'output_text_delta',
+      delta: 'alpha',
+      itemId: 'item-a',
+      responseId: 'response-a',
+    });
+    await vi.waitFor(() => expect(resolvers.has('alpha')).toBe(true));
+
+    await localSession.updateAgent(newerAgent);
+    localTransport.emit('turn_started', {
+      type: 'response_started',
+      providerData: { response: { id: 'response-b' } },
+    });
+    localTransport.emit('output_text_delta', {
+      type: 'output_text_delta',
+      delta: 'bravo',
+      itemId: 'item-b',
+      responseId: 'response-b',
+    });
+    await vi.waitFor(() => expect(resolvers.has('bravo')).toBe(true));
+
+    resolvers.get('bravo')!({
+      guardrail: { name: 'test', version: '1', policyHint: 'bad' },
+      output: { tripwireTriggered: true, outputInfo: { text: 'bravo' } },
+    });
+    await vi.waitFor(() => expect(trippedAgents).toEqual([newerAgent]));
+    expect(localTransport.sendEventCalls).toEqual([
+      { type: 'response.cancel', response_id: 'response-b' },
+    ]);
+    expect(localTransport.sendMessageCalls).toHaveLength(1);
+
+    resolvers.get('alpha')!({
+      guardrail: { name: 'test', version: '1', policyHint: 'bad' },
+      output: { tripwireTriggered: true, outputInfo: { text: 'alpha' } },
+    });
+    await vi.waitFor(() =>
+      expect(trippedAgents).toEqual([newerAgent, sourceAgent]),
+    );
+    expect(localTransport.sendEventCalls).toEqual([
+      { type: 'response.cancel', response_id: 'response-b' },
+    ]);
+    expect(localTransport.sendMessageCalls).toHaveLength(1);
+    expect(localTransport.interruptCalls).toBe(0);
+    vi.restoreAllMocks();
+  });
+
+  it('ignores guardrail results from a closed connection', async () => {
+    let resolveGuardrail!: (result: any) => void;
+    const runMock = vi.fn(
+      async () =>
+        new Promise<any>((resolve) => {
+          resolveGuardrail = resolve;
+        }),
+    );
+    vi.spyOn(guardrailModule, 'defineRealtimeOutputGuardrail').mockReturnValue({
+      run: runMock,
+    } as any);
+    const localTransport = new FakeTransport();
+    const agent = new RealtimeAgent({ name: 'A', handoffs: [] });
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+      outputGuardrails: [{ name: 'test', execute: async () => ({}) } as any],
+      outputGuardrailSettings: { debounceTextLength: 1 },
+    });
+    const guardrailTripped = vi.fn();
+    localSession.on('guardrail_tripped', guardrailTripped);
+    await localSession.connect({ apiKey: 'test' });
+    localTransport.emit('turn_started', {
+      type: 'response_started',
+      providerData: { response: { id: 'response-1' } },
+    });
+    localTransport.emit('output_text_delta', {
+      type: 'output_text_delta',
+      delta: 'bad',
+      itemId: 'item-1',
+      responseId: 'response-1',
+    });
+    await vi.waitFor(() => expect(runMock).toHaveBeenCalledTimes(1));
+
+    localSession.close();
+    resolveGuardrail({
+      guardrail: { name: 'test', version: '1', policyHint: 'bad' },
+      output: { tripwireTriggered: true, outputInfo: { text: 'bad' } },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(guardrailTripped).not.toHaveBeenCalled();
+    expect(localTransport.sendEventCalls).toHaveLength(0);
+    expect(localTransport.sendMessageCalls).toHaveLength(0);
+    expect(localTransport.interruptCalls).toBe(0);
+    vi.restoreAllMocks();
+  });
+
   it('runs tool calls end-to-end and emits lifecycle events', async () => {
     const transport = new FakeTransport();
     const echoTool = tool({

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -661,8 +661,8 @@ describe('RealtimeSession', () => {
     vi.restoreAllMocks();
   });
 
-  it('applies output guardrails to text deltas without interrupting audio', async () => {
-    const runMock = vi.fn(async () => ({
+  it('derives text response ownership from deltas for generic start events', async () => {
+    const runMock = vi.fn(async (_args: any) => ({
       guardrail: { name: 'test', version: '1', policyHint: 'bad' },
       output: { tripwireTriggered: true, outputInfo: { r: 'bad' } },
     }));
@@ -670,8 +670,9 @@ describe('RealtimeSession', () => {
       run: runMock,
     } as any);
     const localTransport = new FakeTransport();
-    const agent = new RealtimeAgent({ name: 'A', handoffs: [] });
-    const localSession = new RealtimeSession(agent, {
+    const sourceAgent = new RealtimeAgent({ name: 'Source', handoffs: [] });
+    const newerAgent = new RealtimeAgent({ name: 'Newer', handoffs: [] });
+    const localSession = new RealtimeSession(sourceAgent, {
       transport: localTransport,
       outputGuardrails: [
         {
@@ -685,8 +686,8 @@ describe('RealtimeSession', () => {
 
     localTransport.emit('turn_started', {
       type: 'response_started',
-      providerData: { response: { id: 'response-1' } },
     });
+    await localSession.updateAgent(newerAgent);
     const guardrailTripped = waitForEvent<any[]>(
       localSession,
       'guardrail_tripped',
@@ -699,9 +700,10 @@ describe('RealtimeSession', () => {
     });
 
     const [, eventAgent, , details] = await guardrailTripped;
-    expect(eventAgent).toBe(agent);
+    expect(eventAgent).toBe(sourceAgent);
     expect(details).toEqual({ itemId: 'item-1' });
     expect(runMock).toHaveBeenCalledTimes(1);
+    expect(runMock.mock.calls[0]?.[0].agent).toBe(sourceAgent);
     expect(localTransport.sendEventCalls).toContainEqual({
       type: 'response.cancel',
       response_id: 'response-1',


### PR DESCRIPTION
This pull request fixes Realtime output guardrails for text-only responses. It normalizes `response.output_text.delta` events into the transport layer, accumulates text per response and item, and evaluates guardrails at the configured debounce interval.

When a text guardrail trips, the session cancels only the originating response using its `response_id` without invoking audio interruption or truncation. Response and connection ownership checks prevent delayed guardrail results from affecting newer turns or reconnected sessions. Existing audio transcript and final-output guardrail behavior remains unchanged.

see also: https://github.com/openai/openai-agents-python/pull/3933