### PR TITLE
fix(openai): serialize conversation session ID lifecycle

### DIFF
--- a/.changeset/quiet-conversations-share-lifecycle.md
+++ b/.changeset/quiet-conversations-share-lifecycle.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: serialize OpenAI conversation session ID lifecycle operations

--- a/packages/agents-openai/src/memory/openaiConversationsSession.ts
+++ b/packages/agents-openai/src/memory/openaiConversationsSession.ts
@@ -36,6 +36,7 @@ export class OpenAIConversationsSession
 
   #client: OpenAI;
   #conversationId?: string;
+  #conversationIdOperation: Promise<void> = Promise.resolve();
 
   constructor(options: OpenAIConversationsSessionOptions = {}) {
     this.#client = resolveClient(options);
@@ -47,13 +48,15 @@ export class OpenAIConversationsSession
   }
 
   async getSessionId(): Promise<string> {
-    if (!this.#conversationId) {
-      this.#conversationId = await startOpenAIConversationsSession(
-        this.#client,
-      );
-    }
+    return this.#runConversationIdOperation(async () => {
+      if (!this.#conversationId) {
+        this.#conversationId = await startOpenAIConversationsSession(
+          this.#client,
+        );
+      }
 
-    return this.#conversationId;
+      return this.#conversationId;
+    });
   }
 
   async getItems(limit?: number): Promise<AgentInputItem[]> {
@@ -231,12 +234,23 @@ export class OpenAIConversationsSession
   }
 
   async clearSession(): Promise<void> {
-    if (!this.#conversationId) {
-      return;
-    }
+    await this.#runConversationIdOperation(async () => {
+      if (!this.#conversationId) {
+        return;
+      }
 
-    await this.#client.conversations.delete(this.#conversationId);
-    this.#conversationId = undefined;
+      await this.#client.conversations.delete(this.#conversationId);
+      this.#conversationId = undefined;
+    });
+  }
+
+  #runConversationIdOperation<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.#conversationIdOperation.then(operation);
+    this.#conversationIdOperation = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
   }
 }
 

--- a/packages/agents-openai/src/memory/openaiConversationsSession.ts
+++ b/packages/agents-openai/src/memory/openaiConversationsSession.ts
@@ -37,6 +37,7 @@ export class OpenAIConversationsSession
   #client: OpenAI;
   #conversationId?: string;
   #conversationIdOperation: Promise<void> = Promise.resolve();
+  #activeItemOperations = new Set<Promise<void>>();
 
   constructor(options: OpenAIConversationsSessionOptions = {}) {
     this.#client = resolveClient(options);
@@ -48,19 +49,19 @@ export class OpenAIConversationsSession
   }
 
   async getSessionId(): Promise<string> {
-    return this.#runConversationIdOperation(async () => {
-      if (!this.#conversationId) {
-        this.#conversationId = await startOpenAIConversationsSession(
-          this.#client,
-        );
-      }
-
-      return this.#conversationId;
-    });
+    return this.#runConversationIdOperation(() => this.#getSessionId());
   }
 
   async getItems(limit?: number): Promise<AgentInputItem[]> {
-    const conversationId = await this.getSessionId();
+    return this.#runItemOperation((conversationId) =>
+      this.#getItems(conversationId, limit),
+    );
+  }
+
+  async #getItems(
+    conversationId: string,
+    limit?: number,
+  ): Promise<AgentInputItem[]> {
     // Convert each API item into the Agent SDK's input shape. Some API payloads expand into multiple items.
     const toAgentItems = (item: APIConversationItem): AgentInputItem[] => {
       if (item.type === 'message' && item.role === 'system') {
@@ -203,34 +204,37 @@ export class OpenAIConversationsSession
       return;
     }
 
-    const conversationId = await this.getSessionId();
-    const normalizedItems = stripProviderModelForConversationPersistence(items);
-    const sanitizedItems = stripConversationPersistenceMetadata(
-      getInputItems(normalizedItems),
-    );
-    if (!sanitizedItems.length) {
-      return;
-    }
-    await this.#client.conversations.items.create(conversationId, {
-      items: sanitizedItems,
+    await this.#runItemOperation(async (conversationId) => {
+      const normalizedItems =
+        stripProviderModelForConversationPersistence(items);
+      const sanitizedItems = stripConversationPersistenceMetadata(
+        getInputItems(normalizedItems),
+      );
+      if (!sanitizedItems.length) {
+        return;
+      }
+      await this.#client.conversations.items.create(conversationId, {
+        items: sanitizedItems,
+      });
     });
   }
 
   async popItem(): Promise<AgentInputItem | undefined> {
-    const conversationId = await this.getSessionId();
-    const [latest] = await this.getItems(1);
-    if (!latest) {
-      return undefined;
-    }
+    return this.#runItemOperation(async (conversationId) => {
+      const [latest] = await this.#getItems(conversationId, 1);
+      if (!latest) {
+        return undefined;
+      }
 
-    const itemId = (latest as { id?: string }).id;
-    if (itemId) {
-      await this.#client.conversations.items.delete(itemId, {
-        conversation_id: conversationId,
-      });
-    }
+      const itemId = (latest as { id?: string }).id;
+      if (itemId) {
+        await this.#client.conversations.items.delete(itemId, {
+          conversation_id: conversationId,
+        });
+      }
 
-    return latest;
+      return latest;
+    });
   }
 
   async clearSession(): Promise<void> {
@@ -239,9 +243,41 @@ export class OpenAIConversationsSession
         return;
       }
 
+      await Promise.all(this.#activeItemOperations);
       await this.#client.conversations.delete(this.#conversationId);
       this.#conversationId = undefined;
     });
+  }
+
+  async #getSessionId(): Promise<string> {
+    if (!this.#conversationId) {
+      this.#conversationId = await startOpenAIConversationsSession(
+        this.#client,
+      );
+    }
+
+    return this.#conversationId;
+  }
+
+  async #runItemOperation<T>(
+    operation: (conversationId: string) => Promise<T>,
+  ): Promise<T> {
+    let resolveOperation!: () => void;
+    const operationFinished = new Promise<void>((resolve) => {
+      resolveOperation = resolve;
+    });
+    const conversationId = await this.#runConversationIdOperation(async () => {
+      const conversationId = await this.#getSessionId();
+      this.#activeItemOperations.add(operationFinished);
+      return conversationId;
+    });
+
+    try {
+      return await operation(conversationId);
+    } finally {
+      this.#activeItemOperations.delete(operationFinished);
+      resolveOperation();
+    }
   }
 
   #runConversationIdOperation<T>(operation: () => Promise<T>): Promise<T> {

--- a/packages/agents-openai/test/openaiConversationsSession.test.ts
+++ b/packages/agents-openai/test/openaiConversationsSession.test.ts
@@ -966,6 +966,7 @@ describe('OpenAIConversationsSession', () => {
   });
 
   it('clearSession is a no-op before a conversation is created', async () => {
+    const createConversation = vi.fn();
     const deleteConversation = vi.fn();
 
     const session = createSession({
@@ -976,7 +977,7 @@ describe('OpenAIConversationsSession', () => {
             create: vi.fn(),
             delete: vi.fn(),
           },
-          create: vi.fn(),
+          create: createConversation,
           delete: deleteConversation,
         },
       } as any,
@@ -984,7 +985,147 @@ describe('OpenAIConversationsSession', () => {
 
     await session.clearSession();
 
+    expect(createConversation).not.toHaveBeenCalled();
     expect(deleteConversation).not.toHaveBeenCalled();
+    expect(session.sessionId).toBeUndefined();
+  });
+
+  it('shares one lazy conversation across concurrent getSessionId calls', async () => {
+    let resolveCreate!: (value: { id: string }) => void;
+    const createConversation = vi.fn(
+      () =>
+        new Promise<{ id: string }>((resolve) => {
+          resolveCreate = resolve;
+        }),
+    );
+
+    const session = createSession({
+      client: {
+        conversations: {
+          items: {
+            list: vi.fn(),
+            create: vi.fn(),
+            delete: vi.fn(),
+          },
+          create: createConversation,
+          delete: vi.fn(),
+        },
+      } as any,
+    });
+
+    const firstId = session.getSessionId();
+    const secondId = session.getSessionId();
+
+    await vi.waitFor(() => expect(createConversation).toHaveBeenCalledTimes(1));
+    resolveCreate({ id: 'conv-shared' });
+
+    await expect(Promise.all([firstId, secondId])).resolves.toEqual([
+      'conv-shared',
+      'conv-shared',
+    ]);
+    expect(createConversation).toHaveBeenCalledTimes(1);
+    expect(session.sessionId).toBe('conv-shared');
+  });
+
+  it('retries lazy creation after a create failure', async () => {
+    const createConversation = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Create failed'))
+      .mockResolvedValueOnce({ id: 'conv-retry' });
+
+    const session = createSession({
+      client: {
+        conversations: {
+          items: {
+            list: vi.fn(),
+            create: vi.fn(),
+            delete: vi.fn(),
+          },
+          create: createConversation,
+          delete: vi.fn(),
+        },
+      } as any,
+    });
+
+    await expect(session.getSessionId()).rejects.toThrow('Create failed');
+    expect(session.sessionId).toBeUndefined();
+
+    await expect(session.getSessionId()).resolves.toBe('conv-retry');
+    expect(createConversation).toHaveBeenCalledTimes(2);
+    expect(session.sessionId).toBe('conv-retry');
+  });
+
+  it('retains and retries the same conversation ID after delete failure', async () => {
+    const createConversation = vi.fn();
+    const deleteConversation = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Delete failed'))
+      .mockResolvedValueOnce({ deleted: true });
+
+    const session = createSession({
+      client: {
+        conversations: {
+          items: {
+            list: vi.fn(),
+            create: vi.fn(),
+            delete: vi.fn(),
+          },
+          create: createConversation,
+          delete: deleteConversation,
+        },
+      } as any,
+      conversationId: 'conv-existing',
+    });
+
+    await expect(session.clearSession()).rejects.toThrow('Delete failed');
+    expect(session.sessionId).toBe('conv-existing');
+
+    await expect(session.clearSession()).resolves.toBeUndefined();
+    expect(deleteConversation).toHaveBeenCalledTimes(2);
+    expect(deleteConversation).toHaveBeenNthCalledWith(1, 'conv-existing');
+    expect(deleteConversation).toHaveBeenNthCalledWith(2, 'conv-existing');
+    expect(createConversation).not.toHaveBeenCalled();
+    expect(session.sessionId).toBeUndefined();
+  });
+
+  it('creates a new conversation after a concurrent clear completes', async () => {
+    let resolveDelete!: () => void;
+    const deleteConversation = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDelete = resolve;
+        }),
+    );
+    const createConversation = vi.fn().mockResolvedValue({ id: 'conv-new' });
+
+    const session = createSession({
+      client: {
+        conversations: {
+          items: {
+            list: vi.fn(),
+            create: vi.fn(),
+            delete: vi.fn(),
+          },
+          create: createConversation,
+          delete: deleteConversation,
+        },
+      } as any,
+      conversationId: 'conv-old',
+    });
+
+    const clear = session.clearSession();
+    await vi.waitFor(() =>
+      expect(deleteConversation).toHaveBeenCalledWith('conv-old'),
+    );
+
+    const getId = session.getSessionId();
+    expect(createConversation).not.toHaveBeenCalled();
+
+    resolveDelete();
+    await expect(clear).resolves.toBeUndefined();
+    await expect(getId).resolves.toBe('conv-new');
+    expect(createConversation).toHaveBeenCalledTimes(1);
+    expect(session.sessionId).toBe('conv-new');
   });
 
   it('treats input_* output arrays as raw items instead of response output arrays', async () => {

--- a/packages/agents-openai/test/openaiConversationsSession.test.ts
+++ b/packages/agents-openai/test/openaiConversationsSession.test.ts
@@ -16,6 +16,22 @@ import { OpenAIConversationsSession } from '../src';
 const createSession = (options: OpenAIConversationsSessionOptions) =>
   new OpenAIConversationsSession(options);
 
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve: Deferred<T>['resolve'];
+  let reject: Deferred<T>['reject'];
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    resolve = innerResolve;
+    reject = innerReject;
+  });
+  return { promise, resolve: resolve!, reject: reject! };
+}
+
 describe('OpenAIConversationsSession', () => {
   beforeEach(() => {
     convertToOutputItemMock.mockReset();
@@ -1126,6 +1142,112 @@ describe('OpenAIConversationsSession', () => {
     await expect(getId).resolves.toBe('conv-new');
     expect(createConversation).toHaveBeenCalledTimes(1);
     expect(session.sessionId).toBe('conv-new');
+  });
+
+  it.each(['getItems', 'addItems', 'popItem'] as const)(
+    'waits for an in-flight lazy %s operation before clearing',
+    async (operationName) => {
+      const createConversation = createDeferred<{ id: string }>();
+      const itemOperation = createDeferred<void>();
+      const itemOperationStarted = createDeferred<void>();
+      const deleteConversation = vi.fn();
+      const list = vi.fn(() => ({
+        [Symbol.asyncIterator]() {
+          return {
+            async next() {
+              itemOperationStarted.resolve(undefined);
+              await itemOperation.promise;
+              return { done: true, value: undefined };
+            },
+          };
+        },
+      }));
+      const createItems = vi.fn(async () => {
+        itemOperationStarted.resolve(undefined);
+        await itemOperation.promise;
+      });
+
+      getInputItemsMock.mockReturnValue([
+        { type: 'message', role: 'user', content: 'hello' },
+      ] as any);
+
+      const session = createSession({
+        client: {
+          conversations: {
+            items: {
+              list,
+              create: createItems,
+              delete: vi.fn(),
+            },
+            create: vi.fn(() => createConversation.promise),
+            delete: deleteConversation,
+          },
+        } as any,
+      });
+
+      const operation =
+        operationName === 'getItems'
+          ? session.getItems()
+          : operationName === 'addItems'
+            ? session.addItems([
+                { type: 'message', role: 'user', content: 'hello' },
+              ] as any)
+            : session.popItem();
+      const clear = session.clearSession();
+
+      createConversation.resolve({ id: 'conv-lazy' });
+      await itemOperationStarted.promise;
+      expect(deleteConversation).not.toHaveBeenCalled();
+
+      itemOperation.resolve(undefined);
+      await operation;
+      await clear;
+
+      expect(deleteConversation).toHaveBeenCalledOnce();
+      expect(deleteConversation).toHaveBeenCalledWith('conv-lazy');
+      expect(session.sessionId).toBeUndefined();
+    },
+  );
+
+  it('releases a queued clear when an active item operation fails', async () => {
+    const itemOperation = createDeferred<void>();
+    const createItems = vi.fn(() => itemOperation.promise);
+    const deleteConversation = vi.fn();
+
+    getInputItemsMock.mockReturnValue([
+      { type: 'message', role: 'user', content: 'hello' },
+    ] as any);
+
+    const session = createSession({
+      client: {
+        conversations: {
+          items: {
+            list: vi.fn(),
+            create: createItems,
+            delete: vi.fn(),
+          },
+          create: vi.fn(),
+          delete: deleteConversation,
+        },
+      } as any,
+      conversationId: 'conv-existing',
+    });
+
+    const addItems = session.addItems([
+      { type: 'message', role: 'user', content: 'hello' },
+    ] as any);
+    const addItemsResult = expect(addItems).rejects.toThrow('Item failed');
+    await vi.waitFor(() => expect(createItems).toHaveBeenCalledOnce());
+
+    const clear = session.clearSession();
+    expect(deleteConversation).not.toHaveBeenCalled();
+
+    itemOperation.reject(new Error('Item failed'));
+    await addItemsResult;
+    await clear;
+
+    expect(deleteConversation).toHaveBeenCalledWith('conv-existing');
+    expect(session.sessionId).toBeUndefined();
   });
 
   it('treats input_* output arrays as raw items instead of response output arrays', async () => {


### PR DESCRIPTION
This pull request fixes concurrent conversation ID lifecycle operations in `OpenAIConversationsSession`. It serializes lazy creation and deletion per session instance so concurrent callers share one remote conversation, failed deletions remain retryable against the same ID, and a queued `getSessionId()` cannot be overwritten by an older clear operation.

The existing public API, lazy creation behavior, uninitialized clear behavior, and cross-instance coordination boundaries remain unchanged.