### PR TITLE
fix(core): preserve approved tool results across output guardrails

### DIFF
--- a/.changeset/steady-tools-survive-guardrails.md
+++ b/.changeset/steady-tools-survive-guardrails.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: preserve approved tool results when output guardrails trip

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -72,6 +72,7 @@ import {
   saveStreamInputToSession,
   saveStreamResultToSession,
   saveToSession,
+  type SessionPersistenceOptions,
 } from './runner/sessionPersistence';
 import { resolveTurnAfterModelResponse } from './runner/turnResolution';
 import { prepareTurn } from './runner/turnPreparation';
@@ -133,6 +134,12 @@ import {
   type ToolExecutionConfig,
 } from './runner/runConfig';
 export type { ToolExecutionConfig } from './runner/runConfig';
+
+function hasPersistedToolOutput(state: RunState<any, any>): boolean {
+  return state._generatedItems
+    .slice(0, state._currentTurnPersistedItemCount)
+    .some((item) => item.type === 'tool_call_output_item');
+}
 
 export type {
   CallModelInputFilter,
@@ -887,7 +894,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     invocationSpanParent?: Span<any> | Trace,
     persistResult?: (
       result: RunResult<TContext, TAgent>,
-      options?: { runCompaction?: boolean },
+      options?: SessionPersistenceOptions,
     ) => Promise<void>,
   ): Promise<RunResult<TContext, TAgent>> {
     return withNewSpanContext(async () => {
@@ -1013,7 +1020,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       let completedResult: RunResult<TContext, TAgent> | undefined;
       let persistenceCheckpoint: RunResult<TContext, TAgent> | undefined;
       let approvedToolCheckpointCompacted = false;
-      let approvedToolCheckpointModelResponseCount = 0;
+      let approvedToolCheckpointRequiresLocalInputCompaction =
+        isResumedState && hasPersistedToolOutput(state);
+      let approvedToolCheckpointModelResponseCount =
+        state._modelResponses.length;
       const completeResult = (result: RunResult<TContext, TAgent>) => {
         completedResult = result;
         return result;
@@ -1057,7 +1067,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             });
             if (interruptedOutcome.approvedToolResumed && persistResult) {
               const approvedToolResult = new RunResult<TContext, TAgent>(state);
-              await persistResult(approvedToolResult);
+              approvedToolCheckpointRequiresLocalInputCompaction = true;
+              await persistResult(approvedToolResult, {
+                compactionMode: 'input',
+              });
               approvedToolCheckpointCompacted = true;
               approvedToolCheckpointModelResponseCount =
                 approvedToolResult.rawResponses.length;
@@ -1380,14 +1393,15 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               const modelResponseAdvanced =
                 resultToPersist.rawResponses.length >
                 approvedToolCheckpointModelResponseCount;
-              await persistResult?.(
-                resultToPersist,
-                approvedToolCheckpointCompacted &&
-                  !hasUnpersistedItems &&
-                  !modelResponseAdvanced
-                  ? { runCompaction: false }
-                  : undefined,
-              );
+              const persistenceOptions =
+                approvedToolCheckpointRequiresLocalInputCompaction
+                  ? approvedToolCheckpointCompacted &&
+                    !hasUnpersistedItems &&
+                    !modelResponseAdvanced
+                    ? { runCompaction: false }
+                    : { compactionMode: 'input' as const }
+                  : undefined;
+              await persistResult?.(resultToPersist, persistenceOptions);
             } catch (error) {
               setRunnerSpanError(taskSpan, error);
               await Promise.reject(error);
@@ -1494,7 +1508,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     let continuingInterruptedTurn = false;
     let runError: unknown;
     let approvedToolCheckpointCompacted = false;
-    let approvedToolCheckpointModelResponseCount = 0;
+    let approvedToolCheckpointRequiresLocalInputCompaction =
+      isResumedState && hasPersistedToolOutput(result.state);
+    let approvedToolCheckpointModelResponseCount = result.rawResponses.length;
     let currentTurnSpan: ReturnType<typeof startTurnSpan> | undefined;
     const parentUsageRecorder = getRunnerParentUsageRecorder(this);
     const recordUsage = (usage: Usage) => {
@@ -1508,14 +1524,18 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         result.newItems.length > result.state._currentTurnPersistedItemCount;
       const modelResponseAdvanced =
         result.rawResponses.length > approvedToolCheckpointModelResponseCount;
+      const persistenceOptions =
+        approvedToolCheckpointRequiresLocalInputCompaction
+          ? approvedToolCheckpointCompacted &&
+            !hasUnpersistedItems &&
+            !modelResponseAdvanced
+            ? { runCompaction: false }
+            : { compactionMode: 'input' as const }
+          : undefined;
       await saveStreamResultToSession(
         options.session,
         result,
-        approvedToolCheckpointCompacted &&
-          !hasUnpersistedItems &&
-          !modelResponseAdvanced
-          ? { runCompaction: false }
-          : undefined,
+        persistenceOptions,
       );
     };
 
@@ -1572,7 +1592,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             !serverManagesConversation &&
             options.session
           ) {
-            await saveStreamResultToSession(options.session, result);
+            approvedToolCheckpointRequiresLocalInputCompaction = true;
+            await saveStreamResultToSession(options.session, result, {
+              compactionMode: 'input',
+            });
             approvedToolCheckpointCompacted = true;
             approvedToolCheckpointModelResponseCount =
               result.rawResponses.length;

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1012,6 +1012,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       setRunStateUsageRecorder(state, recordUsage);
       let completedResult: RunResult<TContext, TAgent> | undefined;
       let persistenceCheckpoint: RunResult<TContext, TAgent> | undefined;
+      let approvedToolCheckpointCompacted = false;
+      let approvedToolCheckpointModelResponseCount = 0;
       const completeResult = (result: RunResult<TContext, TAgent>) => {
         completedResult = result;
         return result;
@@ -1055,9 +1057,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             });
             if (interruptedOutcome.approvedToolResumed && persistResult) {
               const approvedToolResult = new RunResult<TContext, TAgent>(state);
-              await persistResult(approvedToolResult, {
-                runCompaction: false,
-              });
+              await persistResult(approvedToolResult);
+              approvedToolCheckpointCompacted = true;
+              approvedToolCheckpointModelResponseCount =
+                approvedToolResult.rawResponses.length;
             }
             if (options.signal?.aborted) {
               persistenceCheckpoint = new RunResult<TContext, TAgent>(state);
@@ -1371,7 +1374,20 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           const resultToPersist = completedResult ?? persistenceCheckpoint;
           if (resultToPersist) {
             try {
-              await persistResult?.(resultToPersist);
+              const hasUnpersistedItems =
+                resultToPersist.newItems.length >
+                state._currentTurnPersistedItemCount;
+              const modelResponseAdvanced =
+                resultToPersist.rawResponses.length >
+                approvedToolCheckpointModelResponseCount;
+              await persistResult?.(
+                resultToPersist,
+                approvedToolCheckpointCompacted &&
+                  !hasUnpersistedItems &&
+                  !modelResponseAdvanced
+                  ? { runCompaction: false }
+                  : undefined,
+              );
             } catch (error) {
               setRunnerSpanError(taskSpan, error);
               await Promise.reject(error);
@@ -1477,6 +1493,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     // Tracks when we resume an approval interruption so the next run-again step stays in the same turn.
     let continuingInterruptedTurn = false;
     let runError: unknown;
+    let approvedToolCheckpointCompacted = false;
+    let approvedToolCheckpointModelResponseCount = 0;
     let currentTurnSpan: ReturnType<typeof startTurnSpan> | undefined;
     const parentUsageRecorder = getRunnerParentUsageRecorder(this);
     const recordUsage = (usage: Usage) => {
@@ -1485,6 +1503,21 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       parentUsageRecorder?.(usage);
     };
     setRunStateUsageRecorder(result.state, recordUsage);
+    const saveStreamResultWithCompactionOwnership = async () => {
+      const hasUnpersistedItems =
+        result.newItems.length > result.state._currentTurnPersistedItemCount;
+      const modelResponseAdvanced =
+        result.rawResponses.length > approvedToolCheckpointModelResponseCount;
+      await saveStreamResultToSession(
+        options.session,
+        result,
+        approvedToolCheckpointCompacted &&
+          !hasUnpersistedItems &&
+          !modelResponseAdvanced
+          ? { runCompaction: false }
+          : undefined,
+      );
+    };
 
     try {
       while (true) {
@@ -1539,9 +1572,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             !serverManagesConversation &&
             options.session
           ) {
-            await saveStreamResultToSession(options.session, result, {
-              runCompaction: false,
-            });
+            await saveStreamResultToSession(options.session, result);
+            approvedToolCheckpointCompacted = true;
+            approvedToolCheckpointModelResponseCount =
+              result.rawResponses.length;
           }
 
           // Don't reset counter here - resolveInterruptedTurn already adjusted it via rewind logic
@@ -1916,7 +1950,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             await persistStreamInputIfNeeded();
             // Guardrails must succeed before persisting session memory to avoid storing blocked outputs.
             if (!serverManagesConversation) {
-              await saveStreamResultToSession(options.session, result);
+              await saveStreamResultWithCompactionOwnership();
             }
             this.emit(
               'agent_end',
@@ -1934,7 +1968,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             // We are done for now. Don't run any output guardrails.
             await persistStreamInputIfNeeded();
             if (!serverManagesConversation) {
-              await saveStreamResultToSession(options.session, result);
+              await saveStreamResultWithCompactionOwnership();
             }
             return;
           case 'next_step_handoff':
@@ -1989,7 +2023,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       if (handledResult) {
         await persistStreamInputIfNeeded();
         if (!serverManagesConversation) {
-          await saveStreamResultToSession(options.session, result);
+          await saveStreamResultWithCompactionOwnership();
         }
         return;
       }

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -691,11 +691,12 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         },
         effectiveInvocationSpanParent,
         sessionPersistence && !serverManagesConversation
-          ? async (result) => {
+          ? async (result, persistenceOptions) => {
               await saveToSession(
                 session,
                 sessionPersistence.getItemsForPersistence(),
                 result,
+                persistenceOptions,
               );
             }
           : undefined,
@@ -884,7 +885,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     preserveTurnPersistenceOnResume?: boolean,
     sandboxMemoryRunContext?: SandboxMemoryPersistenceContext,
     invocationSpanParent?: Span<any> | Trace,
-    persistResult?: (result: RunResult<TContext, TAgent>) => Promise<void>,
+    persistResult?: (
+      result: RunResult<TContext, TAgent>,
+      options?: { runCompaction?: boolean },
+    ) => Promise<void>,
   ): Promise<RunResult<TContext, TAgent>> {
     return withNewSpanContext(async () => {
       // if we have a saved state we use that one, otherwise we create a new one
@@ -1049,6 +1053,12 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               agentToolParentRunConfig,
               signal: options.signal,
             });
+            if (interruptedOutcome.approvedToolResumed && persistResult) {
+              const approvedToolResult = new RunResult<TContext, TAgent>(state);
+              await persistResult(approvedToolResult, {
+                runCompaction: false,
+              });
+            }
             if (options.signal?.aborted) {
               persistenceCheckpoint = new RunResult<TContext, TAgent>(state);
             }
@@ -1524,6 +1534,15 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               addStepToRunResult(result, turnResult);
             },
           });
+          if (
+            interruptedOutcome.approvedToolResumed &&
+            !serverManagesConversation &&
+            options.session
+          ) {
+            await saveStreamResultToSession(options.session, result, {
+              runCompaction: false,
+            });
+          }
 
           // Don't reset counter here - resolveInterruptedTurn already adjusted it via rewind logic
           // The counter will be reset when _currentTurn is incremented (starting a new turn)

--- a/packages/agents-core/src/runner/runLoop.ts
+++ b/packages/agents-core/src/runner/runLoop.ts
@@ -76,31 +76,24 @@ export async function resumeInterruptedTurn<
     signal,
     onStepItems,
   } = options;
-  const approvedToolCallIds = new Set<string>();
-  for (const item of state.getInterruptions()) {
+  const approvedToolWillResume = state.getInterruptions().some((item) => {
     const rawItem = item.rawItem;
     if (rawItem.type === 'hosted_tool_call') {
-      continue;
+      return false;
     }
-    const toolName =
-      item.toolName ??
-      ('name' in rawItem && typeof rawItem.name === 'string'
-        ? rawItem.name
-        : undefined);
+    const toolName = item.name;
     const callId =
       'callId' in rawItem && typeof rawItem.callId === 'string'
         ? rawItem.callId
         : 'id' in rawItem && typeof rawItem.id === 'string'
           ? rawItem.id
           : undefined;
-    if (
+    return (
       toolName !== undefined &&
       callId !== undefined &&
       state._context.isToolApproved({ toolName, callId }) === true
-    ) {
-      approvedToolCallIds.add(callId);
-    }
-  }
+    );
+  });
   const turnResult = await resolveInterruptedTurn<TContext>(
     state._currentAgent,
     state._originalInput,
@@ -113,19 +106,9 @@ export async function resumeInterruptedTurn<
     agentToolParentRunConfig,
     signal,
   );
-  const approvedToolResumed = turnResult.newStepItems.some((item) => {
-    const rawItem = item.rawItem;
-    if (!rawItem || !('callId' in rawItem)) {
-      return false;
-    }
-    return (
-      (rawItem.type === 'function_call_result' ||
-        rawItem.type === 'computer_call_result' ||
-        rawItem.type === 'shell_call_output' ||
-        rawItem.type === 'apply_patch_call_output') &&
-      approvedToolCallIds.has(rawItem.callId)
-    );
-  });
+  const approvedToolResumed =
+    approvedToolWillResume &&
+    turnResult.generatedItems.length > state._currentTurnPersistedItemCount;
 
   applyTurnResult({
     state,

--- a/packages/agents-core/src/runner/runLoop.ts
+++ b/packages/agents-core/src/runner/runLoop.ts
@@ -8,6 +8,7 @@ import { resolveInterruptedTurn } from './turnResolution';
 export type InterruptedTurnOutcome = {
   nextStep: SingleStepResult['nextStep'];
   action: 'return_interruption' | 'rerun_turn' | 'advance_step';
+  approvedToolResumed: boolean;
 };
 
 export type InterruptedTurnControl = {
@@ -75,6 +76,31 @@ export async function resumeInterruptedTurn<
     signal,
     onStepItems,
   } = options;
+  const approvedToolCallIds = new Set<string>();
+  for (const item of state.getInterruptions()) {
+    const rawItem = item.rawItem;
+    if (rawItem.type === 'hosted_tool_call') {
+      continue;
+    }
+    const toolName =
+      item.toolName ??
+      ('name' in rawItem && typeof rawItem.name === 'string'
+        ? rawItem.name
+        : undefined);
+    const callId =
+      'callId' in rawItem && typeof rawItem.callId === 'string'
+        ? rawItem.callId
+        : 'id' in rawItem && typeof rawItem.id === 'string'
+          ? rawItem.id
+          : undefined;
+    if (
+      toolName !== undefined &&
+      callId !== undefined &&
+      state._context.isToolApproved({ toolName, callId }) === true
+    ) {
+      approvedToolCallIds.add(callId);
+    }
+  }
   const turnResult = await resolveInterruptedTurn<TContext>(
     state._currentAgent,
     state._originalInput,
@@ -87,6 +113,19 @@ export async function resumeInterruptedTurn<
     agentToolParentRunConfig,
     signal,
   );
+  const approvedToolResumed = turnResult.newStepItems.some((item) => {
+    const rawItem = item.rawItem;
+    if (!rawItem || !('callId' in rawItem)) {
+      return false;
+    }
+    return (
+      (rawItem.type === 'function_call_result' ||
+        rawItem.type === 'computer_call_result' ||
+        rawItem.type === 'shell_call_output' ||
+        rawItem.type === 'apply_patch_call_output') &&
+      approvedToolCallIds.has(rawItem.callId)
+    );
+  });
 
   applyTurnResult({
     state,
@@ -101,12 +140,24 @@ export async function resumeInterruptedTurn<
   // return_interruption: still waiting on approvals. rerun_turn: same turn rerun without increment.
   // advance_step: proceed without rerunning the same turn.
   if (turnResult.nextStep.type === 'next_step_interruption') {
-    return { nextStep: turnResult.nextStep, action: 'return_interruption' };
+    return {
+      nextStep: turnResult.nextStep,
+      action: 'return_interruption',
+      approvedToolResumed,
+    };
   }
   if (turnResult.nextStep.type === 'next_step_run_again') {
-    return { nextStep: turnResult.nextStep, action: 'rerun_turn' };
+    return {
+      nextStep: turnResult.nextStep,
+      action: 'rerun_turn',
+      approvedToolResumed,
+    };
   }
-  return { nextStep: turnResult.nextStep, action: 'advance_step' };
+  return {
+    nextStep: turnResult.nextStep,
+    action: 'advance_step',
+    approvedToolResumed,
+  };
 }
 
 export function handleInterruptedOutcome<

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -1,6 +1,7 @@
 import { UserError } from '../errors';
 import {
   isOpenAIResponsesCompactionAwareSession,
+  type OpenAIResponsesCompactionArgs,
   type Session,
   type SessionInputCallback,
 } from '../memory/session';
@@ -27,6 +28,11 @@ import { getRunStateUsageRecorder } from './usageTracking';
 export type PreparedInputWithSessionResult = {
   preparedInput: string | AgentInputItem[];
   sessionItems?: AgentInputItem[];
+};
+
+export type SessionPersistenceOptions = {
+  runCompaction?: boolean;
+  compactionMode?: OpenAIResponsesCompactionArgs['compactionMode'];
 };
 
 export type SessionPersistenceTracker = {
@@ -268,7 +274,7 @@ export async function saveToSession(
   session: Session | undefined,
   sessionInputItems: AgentInputItem[] | undefined,
   result: RunResult<any, any>,
-  options: { runCompaction?: boolean } = {},
+  options: SessionPersistenceOptions = {},
 ): Promise<void> {
   const state = result.state;
   const alreadyPersisted = state._currentTurnPersistedItemCount ?? 0;
@@ -292,6 +298,7 @@ export async function saveToSession(
     lastResponseId: result.lastResponseId,
     alreadyPersistedCount: alreadyPersisted,
     runCompaction: options.runCompaction ?? true,
+    compactionMode: options.compactionMode,
   });
 }
 
@@ -312,7 +319,7 @@ export async function saveStreamInputToSession(
 export async function saveStreamResultToSession(
   session: Session | undefined,
   result: StreamedRunResult<any, any>,
-  options: { runCompaction?: boolean } = {},
+  options: SessionPersistenceOptions = {},
 ): Promise<void> {
   const state = result.state;
   const alreadyPersisted = state._currentTurnPersistedItemCount ?? 0;
@@ -325,6 +332,7 @@ export async function saveStreamResultToSession(
     lastResponseId: result.lastResponseId,
     alreadyPersistedCount: alreadyPersisted,
     runCompaction: options.runCompaction ?? true,
+    compactionMode: options.compactionMode,
   });
 }
 
@@ -632,6 +640,7 @@ async function persistRunItemsToSession(options: {
   lastResponseId?: string;
   alreadyPersistedCount: number;
   runCompaction: boolean;
+  compactionMode?: OpenAIResponsesCompactionArgs['compactionMode'];
 }): Promise<void> {
   const {
     session,
@@ -641,6 +650,7 @@ async function persistRunItemsToSession(options: {
     lastResponseId,
     alreadyPersistedCount,
     runCompaction,
+    compactionMode,
   } = options;
 
   if (!session) {
@@ -661,24 +671,35 @@ async function persistRunItemsToSession(options: {
     state._currentTurnPersistedItemCount =
       alreadyPersistedCount + newRunItems.length;
     if (runCompaction) {
-      await runCompactionOnSession(session, lastResponseId, state);
+      await runCompactionOnSession(
+        session,
+        lastResponseId,
+        state,
+        compactionMode,
+      );
     }
     return;
   }
 
   const sanitizedItems = normalizeItemsForSessionPersistence(itemsToSave);
   await session.addItems(sanitizedItems);
-  if (runCompaction) {
-    await runCompactionOnSession(session, lastResponseId, state);
-  }
   state._currentTurnPersistedItemCount =
     alreadyPersistedCount + newRunItems.length;
+  if (runCompaction) {
+    await runCompactionOnSession(
+      session,
+      lastResponseId,
+      state,
+      compactionMode,
+    );
+  }
 }
 
 async function runCompactionOnSession(
   session: Session | undefined,
   responseId: string | undefined,
   state: RunState<any, any>,
+  compactionMode?: OpenAIResponsesCompactionArgs['compactionMode'],
 ): Promise<void> {
   if (!isOpenAIResponsesCompactionAwareSession(session)) {
     return;
@@ -686,11 +707,14 @@ async function runCompactionOnSession(
   const store =
     state._lastModelSettings?.store ?? state._currentAgent.modelSettings?.store;
   const compactionArgs =
-    typeof responseId === 'undefined' && typeof store === 'undefined'
+    typeof responseId === 'undefined' &&
+    typeof store === 'undefined' &&
+    typeof compactionMode === 'undefined'
       ? undefined
       : {
           ...(typeof responseId === 'undefined' ? {} : { responseId }),
           ...(typeof store === 'undefined' ? {} : { store }),
+          ...(typeof compactionMode === 'undefined' ? {} : { compactionMode }),
         };
   const compactionResult = await session.runCompaction(compactionArgs);
   if (!compactionResult) {

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -268,6 +268,7 @@ export async function saveToSession(
   session: Session | undefined,
   sessionInputItems: AgentInputItem[] | undefined,
   result: RunResult<any, any>,
+  options: { runCompaction?: boolean } = {},
 ): Promise<void> {
   const state = result.state;
   const alreadyPersisted = state._currentTurnPersistedItemCount ?? 0;
@@ -290,6 +291,7 @@ export async function saveToSession(
     extraInputItems: sessionInputItems,
     lastResponseId: result.lastResponseId,
     alreadyPersistedCount: alreadyPersisted,
+    runCompaction: options.runCompaction ?? true,
   });
 }
 
@@ -310,6 +312,7 @@ export async function saveStreamInputToSession(
 export async function saveStreamResultToSession(
   session: Session | undefined,
   result: StreamedRunResult<any, any>,
+  options: { runCompaction?: boolean } = {},
 ): Promise<void> {
   const state = result.state;
   const alreadyPersisted = state._currentTurnPersistedItemCount ?? 0;
@@ -321,6 +324,7 @@ export async function saveStreamResultToSession(
     newRunItems,
     lastResponseId: result.lastResponseId,
     alreadyPersistedCount: alreadyPersisted,
+    runCompaction: options.runCompaction ?? true,
   });
 }
 
@@ -627,6 +631,7 @@ async function persistRunItemsToSession(options: {
   extraInputItems?: AgentInputItem[] | undefined;
   lastResponseId?: string;
   alreadyPersistedCount: number;
+  runCompaction: boolean;
 }): Promise<void> {
   const {
     session,
@@ -635,6 +640,7 @@ async function persistRunItemsToSession(options: {
     extraInputItems = [],
     lastResponseId,
     alreadyPersistedCount,
+    runCompaction,
   } = options;
 
   if (!session) {
@@ -654,13 +660,17 @@ async function persistRunItemsToSession(options: {
   if (itemsToSave.length === 0) {
     state._currentTurnPersistedItemCount =
       alreadyPersistedCount + newRunItems.length;
-    await runCompactionOnSession(session, lastResponseId, state);
+    if (runCompaction) {
+      await runCompactionOnSession(session, lastResponseId, state);
+    }
     return;
   }
 
   const sanitizedItems = normalizeItemsForSessionPersistence(itemsToSave);
   await session.addItems(sanitizedItems);
-  await runCompactionOnSession(session, lastResponseId, state);
+  if (runCompaction) {
+    await runCompactionOnSession(session, lastResponseId, state);
+  }
   state._currentTurnPersistedItemCount =
     alreadyPersistedCount + newRunItems.length;
 }

--- a/packages/agents-core/test/run.approvalGuardrailSession.test.ts
+++ b/packages/agents-core/test/run.approvalGuardrailSession.test.ts
@@ -10,9 +10,11 @@ import {
   setTracingDisabled,
   tool,
   type AgentInputItem,
+  type CallModelInputFilterArgs,
   type Model,
   type ModelRequest,
   type ModelResponse,
+  type OpenAIResponsesCompactionArgs,
   type OpenAIResponsesCompactionResult,
   type StreamEvent,
 } from '../src';
@@ -23,10 +25,54 @@ type RunMode = 'non_streamed' | 'streamed';
 
 class CompactionTrackingSession extends MemorySession {
   readonly compactionSnapshots: AgentInputItem[][] = [];
+  readonly compactionArgs: (OpenAIResponsesCompactionArgs | undefined)[] = [];
 
-  async runCompaction(): Promise<OpenAIResponsesCompactionResult | null> {
-    this.compactionSnapshots.push(await this.getItems());
+  async runCompaction(
+    args?: OpenAIResponsesCompactionArgs,
+  ): Promise<OpenAIResponsesCompactionResult | null> {
+    const snapshot = await this.getItems();
+    this.compactionSnapshots.push(snapshot);
+    this.compactionArgs.push(args);
+    if (
+      this.compactionSnapshots.length > 1 &&
+      snapshot.some((item) => item.type === 'function_call_result') &&
+      args?.compactionMode !== 'input'
+    ) {
+      await this.clearSession();
+      await this.addItems(
+        snapshot.filter((item) => item.type !== 'function_call_result'),
+      );
+    }
     return null;
+  }
+}
+
+class FailingCheckpointCompactionSession extends CompactionTrackingSession {
+  private failedCheckpoint = false;
+
+  async runCompaction(
+    args?: OpenAIResponsesCompactionArgs,
+  ): Promise<OpenAIResponsesCompactionResult | null> {
+    const result = await super.runCompaction(args);
+    const snapshot = this.compactionSnapshots.at(-1) ?? [];
+    if (
+      !this.failedCheckpoint &&
+      snapshot.some((item) => item.type === 'function_call_result')
+    ) {
+      this.failedCheckpoint = true;
+      throw new Error('checkpoint compaction failed');
+    }
+    if (
+      this.failedCheckpoint &&
+      snapshot.some((item) => item.type === 'function_call_result') &&
+      args?.compactionMode !== 'input'
+    ) {
+      await this.clearSession();
+      await this.addItems(
+        snapshot.filter((item) => item.type !== 'function_call_result'),
+      );
+    }
+    return result;
   }
 }
 
@@ -177,6 +223,9 @@ describe('approved tool output guardrail session persistence', () => {
         output: { type: 'text', text: 'approved-result' },
       });
       expect(session.compactionSnapshots).toHaveLength(2);
+      expect(session.compactionArgs[1]).toMatchObject({
+        compactionMode: 'input',
+      });
       expect(
         getPersistedToolItems(session.compactionSnapshots[1]).map((item) => [
           item.type,
@@ -316,6 +365,9 @@ describe('approved tool output guardrail session persistence', () => {
         output: { type: 'text', text: 'nested-done' },
       });
       expect(session.compactionSnapshots).toHaveLength(2);
+      expect(session.compactionArgs[1]).toMatchObject({
+        compactionMode: 'input',
+      });
       expect(
         getPersistedToolItems(session.compactionSnapshots[1]).map((item) => [
           item.type,
@@ -509,6 +561,7 @@ describe('approved tool output guardrail session persistence', () => {
             ),
           ],
           usage: new Usage(),
+          responseId: 'response-before-tool',
         },
         {
           output: [],
@@ -518,6 +571,7 @@ describe('approved tool output guardrail session persistence', () => {
       const agent = new Agent({
         name: 'Empty post-resume response agent',
         model,
+        modelSettings: { store: false },
         tools: [approvalTool],
         toolUseBehavior: 'run_llm_again',
       });
@@ -528,6 +582,12 @@ describe('approved tool output guardrail session persistence', () => {
         const options = {
           session,
           maxTurns: 1,
+          callModelInputFilter: ({ modelData }: CallModelInputFilterArgs) => ({
+            ...modelData,
+            input: modelData.input.filter(
+              (item: AgentInputItem) => item.type !== 'function_call_result',
+            ),
+          }),
           errorHandlers: {
             maxTurns: () => ({
               finalOutput: 'handled-empty-response',
@@ -556,6 +616,10 @@ describe('approved tool output guardrail session persistence', () => {
         mode === 'streamed' ? 'stream-response' : undefined,
       );
       expect(session.compactionSnapshots).toHaveLength(3);
+      expect(session.compactionArgs[2]).toMatchObject({
+        compactionMode: 'input',
+        store: false,
+      });
       expect(
         getPersistedToolItems(await session.getItems()).map((item) => [
           item.type,
@@ -565,6 +629,70 @@ describe('approved tool output guardrail session persistence', () => {
         ['function_call', 'call-before-empty-response'],
         ['function_call_result', 'call-before-empty-response'],
       ]);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'does not duplicate an approved result when $mode checkpoint compaction is retried',
+    async (mode) => {
+      const approvalTool = tool({
+        name: 'retry_compaction_tool',
+        description: 'Returns a result after approval.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'retry-compaction-result',
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output: [
+            functionToolCall('retry_compaction_tool', 'call-retry-compaction'),
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'Retry checkpoint compaction agent',
+        model,
+        tools: [approvalTool],
+        toolUseBehavior: 'stop_on_first_tool',
+      });
+      const session = new FailingCheckpointCompactionSession();
+      const runOnce = async (
+        input: string | RunState<unknown, typeof agent>,
+      ) => {
+        if (mode === 'streamed') {
+          const result = await run(agent, input, { session, stream: true });
+          await result.completed;
+          return result;
+        }
+        return await run(agent, input, { session });
+      };
+
+      const first = await runOnce('Use retry_compaction_tool');
+      expect(first.interruptions).toHaveLength(1);
+      first.state.approve(first.interruptions[0]);
+
+      await expect(runOnce(first.state)).rejects.toThrow(
+        'checkpoint compaction failed',
+      );
+      const retried = await runOnce(first.state);
+
+      expect(retried.finalOutput).toBe('retry-compaction-result');
+      expect(
+        getPersistedToolItems(await session.getItems()).map((item) => [
+          item.type,
+          item.callId,
+        ]),
+      ).toEqual([
+        ['function_call', 'call-retry-compaction'],
+        ['function_call_result', 'call-retry-compaction'],
+      ]);
+      expect(session.compactionArgs[1]).toMatchObject({
+        compactionMode: 'input',
+      });
+      expect(session.compactionArgs[2]).toMatchObject({
+        compactionMode: 'input',
+      });
     },
   );
 });

--- a/packages/agents-core/test/run.approvalGuardrailSession.test.ts
+++ b/packages/agents-core/test/run.approvalGuardrailSession.test.ts
@@ -1,0 +1,211 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import {
+  Agent,
+  MemorySession,
+  OutputGuardrailTripwireTriggered,
+  RunState,
+  Usage,
+  run,
+  setTracingDisabled,
+  tool,
+  type AgentInputItem,
+  type Model,
+  type ModelRequest,
+  type ModelResponse,
+  type OpenAIResponsesCompactionResult,
+  type StreamEvent,
+} from '../src';
+import * as protocol from '../src/types/protocol';
+import { fakeModelMessage } from './stubs';
+
+type RunMode = 'non_streamed' | 'streamed';
+
+class CompactionTrackingSession extends MemorySession {
+  readonly compactionSnapshots: AgentInputItem[][] = [];
+
+  async runCompaction(): Promise<OpenAIResponsesCompactionResult | null> {
+    this.compactionSnapshots.push(await this.getItems());
+    return null;
+  }
+}
+
+class ApprovalSessionModel implements Model {
+  readonly requests: ModelRequest[] = [];
+
+  constructor(private readonly responses: ModelResponse[]) {}
+
+  async getResponse(request: ModelRequest): Promise<ModelResponse> {
+    this.requests.push(request);
+    const response = this.responses.shift();
+    if (!response) {
+      throw new Error('No response found.');
+    }
+    return response;
+  }
+
+  async *getStreamedResponse(
+    request: ModelRequest,
+  ): AsyncIterable<StreamEvent> {
+    const response = await this.getResponse(request);
+    yield {
+      type: 'response_done',
+      response: {
+        id: response.responseId ?? 'stream-response',
+        output: response.output,
+        usage: response.usage,
+      },
+    } as StreamEvent;
+  }
+}
+
+function approvedToolCall(): protocol.FunctionCallItem {
+  return {
+    type: 'function_call',
+    id: 'approval-tool-call',
+    callId: 'call-approved',
+    name: 'approval_tool',
+    status: 'completed',
+    arguments: '{}',
+    providerData: {},
+  };
+}
+
+function getPersistedToolItems(items: AgentInputItem[]) {
+  return items.filter(
+    (
+      item,
+    ): item is protocol.FunctionCallItem | protocol.FunctionCallResultItem =>
+      item.type === 'function_call' || item.type === 'function_call_result',
+  );
+}
+
+describe('approved tool output guardrail session persistence', () => {
+  beforeAll(() => {
+    setTracingDisabled(true);
+  });
+
+  it.each<{
+    mode: RunMode;
+    tripwire: boolean;
+  }>([
+    { mode: 'non_streamed', tripwire: false },
+    { mode: 'non_streamed', tripwire: true },
+    { mode: 'streamed', tripwire: false },
+    { mode: 'streamed', tripwire: true },
+  ])(
+    'persists an approved tool result once when $mode guardrails trip=$tripwire',
+    async ({ mode, tripwire }) => {
+      let guardrailShouldTrip = tripwire;
+      const approvalTool = tool({
+        name: 'approval_tool',
+        description: 'Returns a result after approval.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'approved-result',
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output: [approvedToolCall()],
+          usage: new Usage(),
+        },
+        {
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'Approval session agent',
+        model,
+        tools: [approvalTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'approval output guardrail',
+            execute: async () => ({
+              outputInfo: null,
+              tripwireTriggered: guardrailShouldTrip,
+            }),
+          },
+        ],
+      });
+      const session = new CompactionTrackingSession();
+
+      const runOnce = async (
+        input: string | RunState<unknown, typeof agent>,
+      ) => {
+        if (mode === 'streamed') {
+          const result = await run(agent, input, { session, stream: true });
+          await result.completed;
+          return result;
+        }
+        return await run(agent, input, { session });
+      };
+
+      const first = await runOnce('Use approval_tool');
+      expect(first.interruptions).toHaveLength(1);
+      first.state.approve(first.interruptions[0]);
+
+      if (tripwire) {
+        await expect(runOnce(first.state)).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+      } else {
+        const resumed = await runOnce(first.state);
+        expect(resumed.finalOutput).toBe('approved-result');
+      }
+
+      const persistedItems = await session.getItems();
+      expect(
+        persistedItems.map((item) =>
+          item.type === 'message' ? `${item.type}:${item.role}` : item.type,
+        ),
+      ).toEqual(['message:user', 'function_call', 'function_call_result']);
+      const persistedToolItems = getPersistedToolItems(persistedItems);
+      expect(
+        persistedToolItems.map((item) => [item.type, item.callId]),
+      ).toEqual([
+        ['function_call', 'call-approved'],
+        ['function_call_result', 'call-approved'],
+      ]);
+      expect(persistedToolItems[1]).toMatchObject({
+        type: 'function_call_result',
+        output: { type: 'text', text: 'approved-result' },
+      });
+      expect(session.compactionSnapshots).toHaveLength(tripwire ? 1 : 2);
+      if (!tripwire) {
+        expect(
+          getPersistedToolItems(session.compactionSnapshots[1]).map((item) => [
+            item.type,
+            item.callId,
+          ]),
+        ).toEqual([
+          ['function_call', 'call-approved'],
+          ['function_call_result', 'call-approved'],
+        ]);
+      }
+
+      if (tripwire) {
+        guardrailShouldTrip = false;
+        const next = await runOnce('Continue');
+        expect(next.finalOutput).toBe('done');
+
+        const replayedInput = model.requests.at(-1)?.input;
+        expect(Array.isArray(replayedInput)).toBe(true);
+        const replayedToolItems = getPersistedToolItems(
+          replayedInput as AgentInputItem[],
+        );
+        expect(
+          replayedToolItems.map((item) => [item.type, item.callId]),
+        ).toEqual([
+          ['function_call', 'call-approved'],
+          ['function_call_result', 'call-approved'],
+        ]);
+        expect(replayedToolItems[1]).toMatchObject({
+          type: 'function_call_result',
+          output: { type: 'text', text: 'approved-result' },
+        });
+      }
+    },
+  );
+});

--- a/packages/agents-core/test/run.approvalGuardrailSession.test.ts
+++ b/packages/agents-core/test/run.approvalGuardrailSession.test.ts
@@ -59,14 +59,18 @@ class ApprovalSessionModel implements Model {
   }
 }
 
-function approvedToolCall(): protocol.FunctionCallItem {
+function functionToolCall(
+  name: string,
+  callId: string,
+  argumentsValue = '{}',
+): protocol.FunctionCallItem {
   return {
     type: 'function_call',
-    id: 'approval-tool-call',
-    callId: 'call-approved',
-    name: 'approval_tool',
+    id: `${callId}-item`,
+    callId,
+    name,
     status: 'completed',
-    arguments: '{}',
+    arguments: argumentsValue,
     providerData: {},
   };
 }
@@ -106,7 +110,7 @@ describe('approved tool output guardrail session persistence', () => {
       });
       const model = new ApprovalSessionModel([
         {
-          output: [approvedToolCall()],
+          output: [functionToolCall('approval_tool', 'call-approved')],
           usage: new Usage(),
         },
         {
@@ -172,18 +176,16 @@ describe('approved tool output guardrail session persistence', () => {
         type: 'function_call_result',
         output: { type: 'text', text: 'approved-result' },
       });
-      expect(session.compactionSnapshots).toHaveLength(tripwire ? 1 : 2);
-      if (!tripwire) {
-        expect(
-          getPersistedToolItems(session.compactionSnapshots[1]).map((item) => [
-            item.type,
-            item.callId,
-          ]),
-        ).toEqual([
-          ['function_call', 'call-approved'],
-          ['function_call_result', 'call-approved'],
-        ]);
-      }
+      expect(session.compactionSnapshots).toHaveLength(2);
+      expect(
+        getPersistedToolItems(session.compactionSnapshots[1]).map((item) => [
+          item.type,
+          item.callId,
+        ]),
+      ).toEqual([
+        ['function_call', 'call-approved'],
+        ['function_call_result', 'call-approved'],
+      ]);
 
       if (tripwire) {
         guardrailShouldTrip = false;
@@ -206,6 +208,363 @@ describe('approved tool output guardrail session persistence', () => {
           output: { type: 'text', text: 'approved-result' },
         });
       }
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'persists a nested approved tool result once when $mode guardrails trip',
+    async (mode) => {
+      let guardrailShouldTrip = true;
+      const nestedApprovalTool = tool({
+        name: 'nested_approval_tool',
+        description: 'Returns a nested result after approval.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'nested-approved-result',
+      });
+      const nestedModel = new ApprovalSessionModel([
+        {
+          output: [
+            functionToolCall('nested_approval_tool', 'nested-approved-call'),
+          ],
+          usage: new Usage(),
+        },
+        {
+          output: [fakeModelMessage('nested-done')],
+          usage: new Usage(),
+        },
+      ]);
+      const nestedAgent = new Agent({
+        name: 'Nested approval agent',
+        model: nestedModel,
+        tools: [nestedApprovalTool],
+      });
+      const nestedTool = nestedAgent.asTool({
+        toolName: 'nested_agent_tool',
+        toolDescription: 'Runs the nested approval agent.',
+      });
+      const outerModel = new ApprovalSessionModel([
+        {
+          output: [
+            functionToolCall(
+              nestedTool.name,
+              'outer-agent-tool-call',
+              JSON.stringify({ input: 'Use the nested approval tool' }),
+            ),
+          ],
+          usage: new Usage(),
+        },
+        {
+          output: [fakeModelMessage('outer-done')],
+          usage: new Usage(),
+        },
+      ]);
+      const outerAgent = new Agent({
+        name: 'Outer approval agent',
+        model: outerModel,
+        tools: [nestedTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'outer output guardrail',
+            execute: async () => ({
+              outputInfo: null,
+              tripwireTriggered: guardrailShouldTrip,
+            }),
+          },
+        ],
+      });
+      const session = new CompactionTrackingSession();
+
+      const runOnce = async (
+        input: string | RunState<unknown, typeof outerAgent>,
+      ) => {
+        if (mode === 'streamed') {
+          const result = await run(outerAgent, input, {
+            session,
+            stream: true,
+          });
+          await result.completed;
+          return result;
+        }
+        return await run(outerAgent, input, { session });
+      };
+
+      const first = await runOnce('Use nested_agent_tool');
+      expect(first.interruptions).toHaveLength(1);
+      expect(first.interruptions[0].agent).toBe(nestedAgent);
+      expect(first.interruptions[0].rawItem).toMatchObject({
+        callId: 'nested-approved-call',
+      });
+      first.state.approve(first.interruptions[0]);
+
+      await expect(runOnce(first.state)).rejects.toBeInstanceOf(
+        OutputGuardrailTripwireTriggered,
+      );
+
+      const persistedToolItems = getPersistedToolItems(
+        await session.getItems(),
+      );
+      expect(
+        persistedToolItems.map((item) => [item.type, item.callId]),
+      ).toEqual([
+        ['function_call', 'outer-agent-tool-call'],
+        ['function_call_result', 'outer-agent-tool-call'],
+      ]);
+      expect(persistedToolItems[1]).toMatchObject({
+        type: 'function_call_result',
+        output: { type: 'text', text: 'nested-done' },
+      });
+      expect(session.compactionSnapshots).toHaveLength(2);
+      expect(
+        getPersistedToolItems(session.compactionSnapshots[1]).map((item) => [
+          item.type,
+          item.callId,
+        ]),
+      ).toEqual([
+        ['function_call', 'outer-agent-tool-call'],
+        ['function_call_result', 'outer-agent-tool-call'],
+      ]);
+
+      guardrailShouldTrip = false;
+      const next = await runOnce('Continue');
+      expect(next.finalOutput).toBe('outer-done');
+      const replayedInput = outerModel.requests.at(-1)?.input;
+      expect(Array.isArray(replayedInput)).toBe(true);
+      const replayedToolItems = getPersistedToolItems(
+        replayedInput as AgentInputItem[],
+      );
+      expect(replayedToolItems.map((item) => [item.type, item.callId])).toEqual(
+        [
+          ['function_call', 'outer-agent-tool-call'],
+          ['function_call_result', 'outer-agent-tool-call'],
+        ],
+      );
+    },
+  );
+
+  it('runs streaming compaction after a partially approved resume', async () => {
+    const approvalTool = tool({
+      name: 'partial_approval_tool',
+      description: 'Returns a result after approval.',
+      parameters: z.object({}),
+      needsApproval: true,
+      execute: async () => 'partially-approved-result',
+    });
+    const model = new ApprovalSessionModel([
+      {
+        output: [
+          functionToolCall('partial_approval_tool', 'call-approved-first'),
+          functionToolCall('partial_approval_tool', 'call-still-pending'),
+        ],
+        usage: new Usage(),
+      },
+    ]);
+    const agent = new Agent({
+      name: 'Partial approval session agent',
+      model,
+      tools: [approvalTool],
+    });
+    const session = new CompactionTrackingSession();
+
+    const first = await run(agent, 'Use both tools', {
+      session,
+      stream: true,
+    });
+    await first.completed;
+    expect(first.interruptions).toHaveLength(2);
+    expect(session.compactionSnapshots).toHaveLength(1);
+
+    first.state.approve(first.interruptions[0]);
+    const resumed = await run(agent, first.state, {
+      session,
+      stream: true,
+    });
+    await resumed.completed;
+
+    expect(resumed.interruptions).toHaveLength(1);
+    expect(resumed.interruptions[0].rawItem).toMatchObject({
+      callId: 'call-still-pending',
+    });
+    expect(session.compactionSnapshots).toHaveLength(2);
+    const persistedToolItems = getPersistedToolItems(
+      session.compactionSnapshots[1],
+    );
+    expect(persistedToolItems.map((item) => [item.type, item.callId])).toEqual([
+      ['function_call', 'call-approved-first'],
+      ['function_call', 'call-still-pending'],
+      ['function_call_result', 'call-approved-first'],
+    ]);
+  });
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'compacts an approved result once when a $mode resume is cancelled',
+    async (mode) => {
+      let markToolStarted: (() => void) | undefined;
+      const toolStarted = new Promise<void>((resolve) => {
+        markToolStarted = resolve;
+      });
+      const approvalTool = tool({
+        name: 'cancelled_approval_tool',
+        description: 'Returns after the resumed run is cancelled.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async (_input, _context, details) => {
+          markToolStarted?.();
+          const signal = details?.signal;
+          if (!signal?.aborted) {
+            await new Promise<void>((resolve) => {
+              signal?.addEventListener('abort', () => resolve(), {
+                once: true,
+              });
+            });
+          }
+          return 'cancelled-approved-result';
+        },
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output: [
+            functionToolCall(
+              'cancelled_approval_tool',
+              'call-cancelled-approved',
+            ),
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'Cancelled approval session agent',
+        model,
+        tools: [approvalTool],
+        toolUseBehavior: 'stop_on_first_tool',
+      });
+      const session = new CompactionTrackingSession();
+
+      const first = await (async () => {
+        if (mode === 'streamed') {
+          const result = await run(agent, 'Use cancelled_approval_tool', {
+            session,
+            stream: true,
+          });
+          await result.completed;
+          return result;
+        }
+        return await run(agent, 'Use cancelled_approval_tool', { session });
+      })();
+      expect(first.interruptions).toHaveLength(1);
+      first.state.approve(first.interruptions[0]);
+
+      if (mode === 'streamed') {
+        const resumed = await run(agent, first.state, {
+          session,
+          stream: true,
+        });
+        const reader = (resumed.toStream() as any).getReader();
+        await toolStarted;
+        await reader.cancel('stop');
+        await resumed.completed;
+      } else {
+        const controller = new AbortController();
+        const abortReason = new Error('stop approved resume');
+        const resumed = run(agent, first.state, {
+          session,
+          signal: controller.signal,
+        });
+        const rejection = expect(resumed).rejects.toBe(abortReason);
+        await toolStarted;
+        controller.abort(abortReason);
+        await rejection;
+      }
+
+      expect(session.compactionSnapshots).toHaveLength(2);
+      expect(
+        getPersistedToolItems(await session.getItems()).map((item) => [
+          item.type,
+          item.callId,
+        ]),
+      ).toEqual([
+        ['function_call', 'call-cancelled-approved'],
+        ['function_call_result', 'call-cancelled-approved'],
+      ]);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'compacts an empty post-resume response when $mode handling omits history',
+    async (mode) => {
+      const approvalTool = tool({
+        name: 'empty_response_approval_tool',
+        description: 'Returns a result after approval.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'approved-before-empty-response',
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output: [
+            functionToolCall(
+              'empty_response_approval_tool',
+              'call-before-empty-response',
+            ),
+          ],
+          usage: new Usage(),
+        },
+        {
+          output: [],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'Empty post-resume response agent',
+        model,
+        tools: [approvalTool],
+        toolUseBehavior: 'run_llm_again',
+      });
+      const session = new CompactionTrackingSession();
+      const runOnce = async (
+        input: string | RunState<unknown, typeof agent>,
+      ) => {
+        const options = {
+          session,
+          maxTurns: 1,
+          errorHandlers: {
+            maxTurns: () => ({
+              finalOutput: 'handled-empty-response',
+              includeInHistory: false,
+            }),
+          },
+        } as const;
+        if (mode === 'streamed') {
+          const result = await run(agent, input, {
+            ...options,
+            stream: true,
+          });
+          await result.completed;
+          return result;
+        }
+        return await run(agent, input, options);
+      };
+
+      const first = await runOnce('Use empty_response_approval_tool');
+      expect(first.interruptions).toHaveLength(1);
+      first.state.approve(first.interruptions[0]);
+
+      const resumed = await runOnce(first.state);
+      expect(resumed.finalOutput).toBe('handled-empty-response');
+      expect(resumed.lastResponseId).toBe(
+        mode === 'streamed' ? 'stream-response' : undefined,
+      );
+      expect(session.compactionSnapshots).toHaveLength(3);
+      expect(
+        getPersistedToolItems(await session.getItems()).map((item) => [
+          item.type,
+          item.callId,
+        ]),
+      ).toEqual([
+        ['function_call', 'call-before-empty-response'],
+        ['function_call_result', 'call-before-empty-response'],
+      ]);
     },
   );
 });

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -1765,7 +1765,11 @@ describe('Runner.run (streaming)', () => {
     expect(resumed.state._currentTurnInProgress).toBe(false);
     expect(resumed.finalOutput).toBe('cancelled');
     expect(guardrail.execute).toHaveBeenCalledTimes(1);
-    expect(saveResultSpy).toHaveBeenCalledTimes(2);
+    expect(saveResultSpy).toHaveBeenCalledTimes(3);
+    expect(saveResultSpy.mock.calls[1]?.[2]).toEqual({
+      runCompaction: false,
+    });
+    expect(saveResultSpy.mock.calls[2]?.[2]).toBeUndefined();
     expect(agentEnd).toHaveBeenCalledTimes(1);
     expect(
       resumed.state._generatedItems.some(

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -1766,8 +1766,12 @@ describe('Runner.run (streaming)', () => {
     expect(resumed.finalOutput).toBe('cancelled');
     expect(guardrail.execute).toHaveBeenCalledTimes(1);
     expect(saveResultSpy).toHaveBeenCalledTimes(3);
-    expect(saveResultSpy.mock.calls[1]?.[2]).toBeUndefined();
-    expect(saveResultSpy.mock.calls[2]?.[2]).toBeUndefined();
+    expect(saveResultSpy.mock.calls[1]?.[2]).toEqual({
+      compactionMode: 'input',
+    });
+    expect(saveResultSpy.mock.calls[2]?.[2]).toEqual({
+      compactionMode: 'input',
+    });
     expect(agentEnd).toHaveBeenCalledTimes(1);
     expect(
       resumed.state._generatedItems.some(

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -1766,9 +1766,7 @@ describe('Runner.run (streaming)', () => {
     expect(resumed.finalOutput).toBe('cancelled');
     expect(guardrail.execute).toHaveBeenCalledTimes(1);
     expect(saveResultSpy).toHaveBeenCalledTimes(3);
-    expect(saveResultSpy.mock.calls[1]?.[2]).toEqual({
-      runCompaction: false,
-    });
+    expect(saveResultSpy.mock.calls[1]?.[2]).toBeUndefined();
     expect(saveResultSpy.mock.calls[2]?.[2]).toBeUndefined();
     expect(agentEnd).toHaveBeenCalledTimes(1);
     expect(


### PR DESCRIPTION
This pull request fixes session persistence when an explicitly approved tool resumes and an output guardrail subsequently trips. It checkpoints the committed tool call and result exactly once, retains local-input compaction ownership throughout the resumed invocation, and prevents compaction, filtering, missing response IDs, or retries from dropping or duplicating the result.

Streaming and non-streaming behavior remain aligned, including nested agent tools, cancellation, retry, and next-turn replay. Ordinary blocked assistant output continues to be excluded from session history.