### PR TITLE
fix(sandbox): harden default snapshot path resolution

### DIFF
--- a/.changeset/tidy-snapshots-stay-absolute.md
+++ b/.changeset/tidy-snapshots-stay-absolute.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: ignore invalid environment paths for default sandbox snapshots

--- a/packages/agents-core/src/sandbox/sandboxes/shared/localSnapshotPaths.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/localSnapshotPaths.ts
@@ -1,5 +1,10 @@
 import { homedir, tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { posix, win32 } from 'node:path';
+
+function isAbsoluteWindowsPath(value: string): boolean {
+  const root = win32.parse(value).root;
+  return win32.isAbsolute(value) && root.length > 1;
+}
 
 export function defaultLocalSnapshotBaseDir(): string {
   const configured = process.env.OPENAI_AGENTS_SANDBOX_SNAPSHOT_DIR?.trim();
@@ -9,7 +14,7 @@ export function defaultLocalSnapshotBaseDir(): string {
 
   const home = homedir();
   if (process.platform === 'darwin' && home) {
-    return join(
+    return posix.join(
       home,
       'Library',
       'Application Support',
@@ -20,16 +25,24 @@ export function defaultLocalSnapshotBaseDir(): string {
 
   if (process.platform === 'win32') {
     const localAppData = process.env.LOCALAPPDATA?.trim();
-    return join(
-      localAppData || (home ? join(home, 'AppData', 'Local') : tmpdir()),
+    return win32.join(
+      localAppData && isAbsoluteWindowsPath(localAppData)
+        ? localAppData
+        : home
+          ? win32.join(home, 'AppData', 'Local')
+          : tmpdir(),
       'openai-agents-js',
       'sandbox-snapshots',
     );
   }
 
   const stateHome = process.env.XDG_STATE_HOME?.trim();
-  return join(
-    stateHome || (home ? join(home, '.local', 'state') : tmpdir()),
+  return posix.join(
+    stateHome && posix.isAbsolute(stateHome)
+      ? stateHome
+      : home
+        ? posix.join(home, '.local', 'state')
+        : tmpdir(),
     'openai-agents-js',
     'sandbox-snapshots',
   );

--- a/packages/agents-core/test/sandboxShared.test.ts
+++ b/packages/agents-core/test/sandboxShared.test.ts
@@ -165,14 +165,14 @@ describe('sandbox shared helpers', () => {
       '/Users/tester/Library/Application Support/openai-agents-js/sandbox-snapshots',
     );
 
-    vi.stubEnv('LOCALAPPDATA', '  /Users/tester/AppData/Local  ');
+    vi.stubEnv('LOCALAPPDATA', '  C:\\Users\\tester\\AppData\\Local  ');
     defaultLocalSnapshotBaseDir = await loadDefaultLocalSnapshotBaseDir({
       platform: 'win32',
-      home: '/Users/tester',
-      temp: '/tmp',
+      home: 'C:\\Users\\tester',
+      temp: 'C:\\Temp',
     });
     expect(defaultLocalSnapshotBaseDir()).toBe(
-      '/Users/tester/AppData/Local/openai-agents-js/sandbox-snapshots',
+      'C:\\Users\\tester\\AppData\\Local\\openai-agents-js\\sandbox-snapshots',
     );
 
     vi.stubEnv('LOCALAPPDATA', '');
@@ -184,6 +184,61 @@ describe('sandbox shared helpers', () => {
     });
     expect(defaultLocalSnapshotBaseDir()).toBe(
       '/state/openai-agents-js/sandbox-snapshots',
+    );
+  });
+
+  it('preserves explicit relative local snapshot directory overrides', async () => {
+    vi.stubEnv('OPENAI_AGENTS_SANDBOX_SNAPSHOT_DIR', '  relative/snapshots  ');
+    const defaultLocalSnapshotBaseDir = await loadDefaultLocalSnapshotBaseDir({
+      platform: 'linux',
+      home: '/home/tester',
+      temp: '/tmp',
+    });
+
+    expect(defaultLocalSnapshotBaseDir()).toBe('relative/snapshots');
+  });
+
+  it('ignores relative XDG state directories', async () => {
+    vi.stubEnv('XDG_STATE_HOME', 'relative-state');
+    const defaultLocalSnapshotBaseDir = await loadDefaultLocalSnapshotBaseDir({
+      platform: 'linux',
+      home: '/home/tester',
+      temp: '/tmp',
+    });
+
+    expect(defaultLocalSnapshotBaseDir()).toBe(
+      '/home/tester/.local/state/openai-agents-js/sandbox-snapshots',
+    );
+  });
+
+  it.each(['relative-local', '/tmp/localappdata'])(
+    'ignores invalid Windows app-data directories: %s',
+    async (localAppData) => {
+      vi.stubEnv('LOCALAPPDATA', localAppData);
+      const defaultLocalSnapshotBaseDir = await loadDefaultLocalSnapshotBaseDir(
+        {
+          platform: 'win32',
+          home: 'C:\\Users\\tester',
+          temp: 'C:\\Temp',
+        },
+      );
+
+      expect(defaultLocalSnapshotBaseDir()).toBe(
+        'C:\\Users\\tester\\AppData\\Local\\openai-agents-js\\sandbox-snapshots',
+      );
+    },
+  );
+
+  it('falls back to the temporary directory without a home directory', async () => {
+    vi.stubEnv('XDG_STATE_HOME', 'relative-state');
+    const defaultLocalSnapshotBaseDir = await loadDefaultLocalSnapshotBaseDir({
+      platform: 'linux',
+      home: '',
+      temp: '/tmp',
+    });
+
+    expect(defaultLocalSnapshotBaseDir()).toBe(
+      '/tmp/openai-agents-js/sandbox-snapshots',
     );
   });
 


### PR DESCRIPTION
This pull request fixes default sandbox snapshot path resolution so SDK-managed roots derived from `XDG_STATE_HOME` or `LOCALAPPDATA` are accepted only when they are absolute and valid for the active platform.

Invalid relative or platform-mismatched environment paths now use the existing home or temporary-directory fallback instead of resolving against the current working directory. Explicit `OPENAI_AGENTS_SANDBOX_SNAPSHOT_DIR` overrides and valid absolute environment paths remain unchanged.