### PR TITLE
fix: normalize closed typeless object schemas in strict tools

### DIFF
--- a/.changeset/strict-typeless-objects.md
+++ b/.changeset/strict-typeless-objects.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: normalize closed typeless object schemas in strict tools

--- a/packages/agents-core/src/utils/strictToolSchema.ts
+++ b/packages/agents-core/src/utils/strictToolSchema.ts
@@ -1,26 +1,40 @@
 import type { JsonObjectSchema } from '../types';
+import { UserError } from '../errors';
 import { readZodDefinition, readZodType } from './zodCompat';
 
 export function toOpenAIStrictToolSchema<T extends JsonObjectSchema<any>>(
   schema: T,
 ): T {
-  return ensureStrictSchemaEntry(structuredClone(schema)) as T;
+  return ensureStrictSchemaEntry(structuredClone(schema), true) as T;
 }
 
-function ensureStrictSchemaEntry(entry: unknown): unknown {
+function ensureStrictSchemaEntry(entry: unknown, isRoot = false): unknown {
   if (typeof entry !== 'object' || entry === null) {
     return entry;
   }
 
   const record = entry as Record<string, unknown>;
+  const properties = isRecord(record.properties)
+    ? record.properties
+    : undefined;
+  const hasObjectKeywords =
+    properties !== undefined || 'additionalProperties' in record;
 
   if (
-    record.type === 'object' &&
-    typeof record.properties === 'object' &&
-    record.properties !== null &&
-    !Array.isArray(record.properties)
+    record.type === undefined &&
+    hasObjectKeywords &&
+    record.additionalProperties !== false
   ) {
-    const properties = record.properties as Record<string, unknown>;
+    throw new UserError(
+      'Cannot convert a typeless open JSON schema to strict mode. Set `type: "object"` with `additionalProperties: false`, or disable strict mode.',
+    );
+  }
+
+  if (!isRoot && record.type === undefined && properties !== undefined) {
+    record.type = 'object';
+  }
+
+  if (record.type === 'object' && properties !== undefined) {
     const originalRequired = new Set(
       Array.isArray(record.required) ? record.required.map(String) : [],
     );

--- a/packages/agents-core/test/tool.test.ts
+++ b/packages/agents-core/test/tool.test.ts
@@ -17,8 +17,12 @@ import { Agent } from '../src/agent';
 import { RunContext } from '../src/runContext';
 import { serializeTool } from '../src/utils/serialize';
 import { FakeEditor, FakeShell } from './stubs';
-import { InvalidToolOutputError, ToolTimeoutError } from '../src/errors';
-import type { JsonObjectSchema } from '../src/types';
+import {
+  InvalidToolOutputError,
+  ToolTimeoutError,
+  UserError,
+} from '../src/errors';
+import type { JsonObjectSchema, JsonObjectSchemaNonStrict } from '../src/types';
 import logger from '../src/logger';
 
 interface Bar {
@@ -40,6 +44,101 @@ describe('Tool', () => {
     });
     expect(Object.keys(t.parameters.properties).length).toEqual(1);
     expect(t.parameters.required.length).toEqual(1);
+  });
+
+  it('normalizes typeless nested objects in strict JSON schemas', () => {
+    const parameters: JsonObjectSchema<any> = {
+      type: 'object',
+      properties: {
+        nested: {
+          properties: {
+            optional: { type: 'string' },
+          },
+          required: [],
+          additionalProperties: false,
+        },
+      },
+      required: ['nested'],
+      additionalProperties: false,
+    };
+    const t = tool({
+      name: 'typeless_nested_object',
+      description: 'Normalize a typeless nested object.',
+      parameters,
+      execute: async () => 'ok',
+    });
+
+    expect(serializeTool(t)).toMatchObject({
+      strict: true,
+      parameters: {
+        type: 'object',
+        properties: {
+          nested: {
+            type: 'object',
+            properties: {
+              optional: {
+                anyOf: [{ type: 'string' }, { type: 'null' }],
+              },
+            },
+            required: ['optional'],
+            additionalProperties: false,
+          },
+        },
+        required: ['nested'],
+        additionalProperties: false,
+      },
+    });
+    expect(parameters.properties.nested).not.toHaveProperty('type');
+  });
+
+  it('rejects typeless open objects when constructing strict tools', () => {
+    const parameters: JsonObjectSchema<any> = {
+      type: 'object',
+      properties: {
+        open: {
+          properties: {},
+          additionalProperties: true,
+        },
+      },
+      required: ['open'],
+      additionalProperties: false,
+    };
+
+    expect(() =>
+      tool({
+        name: 'typeless_open_object',
+        description: 'Reject a typeless open object.',
+        parameters,
+        execute: async () => 'ok',
+      }),
+    ).toThrow(UserError);
+    expect(parameters.properties.open).not.toHaveProperty('type');
+  });
+
+  it('preserves typeless open objects for non-strict tools', () => {
+    const parameters: JsonObjectSchemaNonStrict<any> = {
+      type: 'object',
+      properties: {
+        open: {
+          properties: {},
+          additionalProperties: true,
+        },
+      },
+      required: ['open'],
+      additionalProperties: true,
+    };
+    const t = tool({
+      name: 'non_strict_typeless_open_object',
+      description: 'Preserve a typeless open object.',
+      parameters,
+      strict: false,
+      execute: async () => 'ok',
+    });
+
+    expect(serializeTool(t)).toMatchObject({
+      strict: false,
+      parameters,
+    });
   });
 
   it('records deferLoading when requested', () => {

--- a/packages/agents-core/test/utils/strictToolSchema.test.ts
+++ b/packages/agents-core/test/utils/strictToolSchema.test.ts
@@ -167,6 +167,91 @@ describe('utils/strictToolSchema', () => {
     });
   });
 
+  it('infers closed typeless nested objects without mutating the input', () => {
+    const input = {
+      type: 'object',
+      properties: {
+        nested: {
+          properties: {
+            value: { type: 'string', description: 'Nested value' },
+          },
+          required: [],
+          additionalProperties: false,
+        },
+        union: {
+          anyOf: [
+            {
+              properties: {
+                count: { type: 'number' },
+              },
+              required: ['count'],
+              additionalProperties: false,
+            },
+          ],
+        },
+      },
+      required: ['nested', 'union'],
+      additionalProperties: false,
+    } as const;
+
+    const result = toOpenAIStrictToolSchema(input as any);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        nested: {
+          type: 'object',
+          properties: {
+            value: {
+              description: 'Nested value',
+              anyOf: [
+                { type: 'string', description: 'Nested value' },
+                { type: 'null' },
+              ],
+            },
+          },
+          required: ['value'],
+          additionalProperties: false,
+        },
+        union: {
+          anyOf: [
+            {
+              type: 'object',
+              properties: {
+                count: { type: 'number' },
+              },
+              required: ['count'],
+              additionalProperties: false,
+            },
+          ],
+        },
+      },
+      required: ['nested', 'union'],
+      additionalProperties: false,
+    });
+    expect(input.properties.nested).not.toHaveProperty('type');
+    expect(input.properties.nested.required).toEqual([]);
+  });
+
+  it('rejects typeless open object schemas instead of narrowing them', () => {
+    const input = {
+      type: 'object',
+      properties: {
+        open: {
+          properties: {
+            value: { type: 'string' },
+          },
+        },
+      },
+      required: ['open'],
+      additionalProperties: false,
+    };
+
+    expect(() => toOpenAIStrictToolSchema(input as any)).toThrow(
+      'Cannot convert a typeless open JSON schema to strict mode.',
+    );
+  });
+
   it('strips strict nulls from optional JSON Schema object and array fields', () => {
     const schema = {
       type: 'object',


### PR DESCRIPTION
This pull request fixes strict tool conversion for nested closed JSON Schema objects that define `properties` without an explicit `type`. It infers `type: "object"` before applying the existing recursive required, nullable, and `additionalProperties` normalization.

Typeless open schemas now fail during strict tool construction instead of being silently narrowed, while `strict: false` continues to preserve intentionally open schemas.