### PR TITLE
fix: resolve model-visible tool name collisions consistently

### DIFF
--- a/.changeset/clear-tools-route-uniquely.md
+++ b/.changeset/clear-tools-route-uniquely.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents': patch
+'@openai/agents-core': patch
+'@openai/agents-extensions': patch
+---
+
+fix: resolve ambiguous tool and handoff names consistently with a warning by default and an opt-in error policy, including owner-scoped approvals for nested agents

--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -833,7 +833,7 @@ export class Agent<
               context &&
               resumeContext !== context
             ) {
-              resumeContext._mergeApprovals(context.toJSON().approvals);
+              resumeContext._mergeApprovalState(context);
             }
             runInput = await RunState.fromStringWithContext<TContext, TAgent>(
               this,

--- a/packages/agents-core/src/agentToolRunConfig.ts
+++ b/packages/agents-core/src/agentToolRunConfig.ts
@@ -314,6 +314,10 @@ export function getInheritedAgentToolRunConfig(
     inheritedRunConfig.toolNotFoundBehavior =
       parentRunConfig.toolNotFoundBehavior;
   }
+  if (typeof parentRunConfig.toolNameCollisionPolicy !== 'undefined') {
+    inheritedRunConfig.toolNameCollisionPolicy =
+      parentRunConfig.toolNameCollisionPolicy;
+  }
   if (typeof parentRunConfig.tracing !== 'undefined') {
     inheritedRunConfig.tracing = parentRunConfig.tracing;
   }

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -198,6 +198,7 @@ export type {
   ToolErrorFormatter,
   ToolErrorFormatterArgs,
   ToolExecutionConfig,
+  ToolNameCollisionPolicy,
   ToolNotFoundBehavior,
   ToolErrorKind,
   ReasoningItemIdPolicy,

--- a/packages/agents-core/src/items.ts
+++ b/packages/agents-core/src/items.ts
@@ -2,8 +2,8 @@ import { Agent } from './agent';
 import { toSmartString } from './utils/smartString';
 import * as protocol from './types/protocol';
 import {
-  getFunctionToolQualifiedName,
-  resolveFunctionToolCallName,
+  getFunctionToolStateKeyForCall,
+  getToolCallQualifiedName,
 } from './toolIdentity';
 import type { ToolOutputCustomData } from './utils/customData';
 
@@ -220,9 +220,13 @@ export class RunToolApprovalItem extends RunItemBase {
      * Explicit tool name to use for approval tracking when not present on the raw item.
      */
     public toolName?: string,
+    /** @internal Canonical function-tool key used by approval and resume state. */
+    public functionToolStateKey?: string,
   ) {
     super();
-    this.toolName = toolName ?? getDefaultApprovalToolName(rawItem, agent);
+    this.toolName = toolName ?? getDefaultApprovalToolName(rawItem);
+    this.functionToolStateKey =
+      functionToolStateKey ?? getDefaultApprovalFunctionToolStateKey(rawItem);
   }
 
   /**
@@ -245,42 +249,36 @@ export class RunToolApprovalItem extends RunItemBase {
       ...super.toJSON(),
       agent: this.agent.toJSON(),
       toolName: this.toolName,
+      functionToolStateKey: this.functionToolStateKey,
     };
   }
 }
 
+function getDefaultApprovalFunctionToolStateKey(
+  rawItem: RunToolApprovalItem['rawItem'],
+): string | undefined {
+  if (rawItem.type !== 'function_call') {
+    return undefined;
+  }
+  return getFunctionToolStateKeyForCall(rawItem);
+}
+
 function getDefaultApprovalToolName(
   rawItem: RunToolApprovalItem['rawItem'],
-  agent: Agent<any, any>,
 ): string | undefined {
   if (rawItem.type !== 'function_call') {
     return (rawItem as any).name;
   }
 
-  const availableFunctionTools = new Map(
-    agent.tools.flatMap((tool) => {
-      if (tool.type !== 'function' || typeof tool.name !== 'string') {
-        return [];
-      }
-      return [[getFunctionToolQualifiedName(tool) ?? tool.name, tool] as const];
-    }),
-  );
-
-  const resolvedToolName = resolveFunctionToolCallName(
-    rawItem,
-    availableFunctionTools,
-  );
-
   if (
     typeof rawItem.name === 'string' &&
     typeof rawItem.namespace === 'string' &&
-    rawItem.namespace === rawItem.name &&
-    !availableFunctionTools.has(`${rawItem.namespace}.${rawItem.name}`)
+    rawItem.namespace === rawItem.name
   ) {
     return rawItem.name;
   }
 
-  return resolvedToolName ?? rawItem.name;
+  return getToolCallQualifiedName(rawItem) ?? rawItem.name;
 }
 
 function getStringProperty(item: object, key: string): string | undefined {

--- a/packages/agents-core/src/model.ts
+++ b/packages/agents-core/src/model.ts
@@ -563,6 +563,7 @@ export type ModelRequest = {
     runnerManagedRetry?: boolean;
     reasoningEffortImplicit?: boolean;
     tracingParent?: Span<any> | Trace;
+    toolNameCollisionPolicy?: 'warn' | 'error';
   };
 };
 

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -87,6 +87,7 @@ import {
   ensureActiveAgentSpanForInterruptedResume,
   ensureTurnSpan,
   finishRunnerSpan,
+  getRunnerSpanErrorDetails,
   getTracing,
   setRunnerSpanError,
   startRunnerInvocationSpans,
@@ -131,9 +132,14 @@ import {
 import {
   getImplicitModelSettingsForResolvedModel,
   validateToolExecutionConfig,
+  validateToolNameCollisionPolicy,
   type ToolExecutionConfig,
+  type ToolNameCollisionPolicy,
 } from './runner/runConfig';
-export type { ToolExecutionConfig } from './runner/runConfig';
+export type {
+  ToolExecutionConfig,
+  ToolNameCollisionPolicy,
+} from './runner/runConfig';
 
 function hasPersistedToolOutput(state: RunState<any, any>): boolean {
   return state._generatedItems
@@ -303,6 +309,16 @@ export type RunConfig = {
   toolNotFoundBehavior?: ToolNotFoundBehavior;
 
   /**
+   * Controls collisions between enabled function tool and handoff names.
+   *
+   * - `warn` logs an actionable warning and exposes only the current dispatch winner.
+   * - `error` raises `UserError` before the model is called.
+   *
+   * Defaults to `warn`. Existing strict validation for namespaced and deferred tools is unchanged.
+   */
+  toolNameCollisionPolicy?: ToolNameCollisionPolicy;
+
+  /**
    * Customizes how session history is combined with the current turn's input.
    * When omitted, history items are appended before the new input.
    */
@@ -347,6 +363,7 @@ type SharedRunOptions<
   sandbox?: SandboxRunConfig;
   toolExecution?: ToolExecutionConfig;
   toolNotFoundBehavior?: ToolNotFoundBehavior;
+  toolNameCollisionPolicy?: ToolNameCollisionPolicy;
   /**
    * Error handlers keyed by error kind.
    */
@@ -479,6 +496,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       sandbox: config.sandbox,
       toolExecution: validateToolExecutionConfig(config.toolExecution),
       toolNotFoundBehavior: config.toolNotFoundBehavior ?? 'raise_error',
+      toolNameCollisionPolicy: validateToolNameCollisionPolicy(
+        config.toolNameCollisionPolicy,
+      ),
       sessionInputCallback: config.sessionInputCallback,
       callModelInputFilter: config.callModelInputFilter,
       toolErrorFormatter: config.toolErrorFormatter,
@@ -585,6 +605,11 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     );
     const toolNotFoundBehavior =
       resolvedOptions.toolNotFoundBehavior ?? this.config.toolNotFoundBehavior;
+    const toolNameCollisionPolicy = validateToolNameCollisionPolicy(
+      resolvedOptions.toolNameCollisionPolicy === undefined
+        ? this.config.toolNameCollisionPolicy
+        : resolvedOptions.toolNameCollisionPolicy,
+    );
     const hasCallModelInputFilter = Boolean(callModelInputFilter);
     const tracingConfig = mergeTracingConfig(
       this.config.tracing,
@@ -604,6 +629,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       reasoningItemIdPolicy,
       toolExecution,
       toolNotFoundBehavior,
+      toolNameCollisionPolicy,
       tracing: tracingConfig,
     };
     const useTaskAndTurnSpans =
@@ -850,11 +876,14 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       typeof options.toolExecution !== 'undefined';
     const hasToolNotFoundBehaviorOverride =
       typeof options.toolNotFoundBehavior !== 'undefined';
+    const hasToolNameCollisionPolicyOverride =
+      typeof options.toolNameCollisionPolicy !== 'undefined';
     const hasTracingOverride = typeof options.tracing !== 'undefined';
     if (
       !hasSandboxOverride &&
       !hasToolExecutionOverride &&
       !hasToolNotFoundBehaviorOverride &&
+      !hasToolNameCollisionPolicyOverride &&
       !hasTracingOverride
     ) {
       return this.config;
@@ -867,6 +896,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         : {}),
       ...(hasToolNotFoundBehaviorOverride
         ? { toolNotFoundBehavior: options.toolNotFoundBehavior }
+        : {}),
+      ...(hasToolNameCollisionPolicyOverride
+        ? { toolNameCollisionPolicy: options.toolNameCollisionPolicy }
         : {}),
       ...(hasTracingOverride ? { tracing: options.tracing } : {}),
     };
@@ -1044,6 +1076,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               runConfigModel: await this.#resolveSandboxRuntimeModelForAgent(
                 state._currentAgent,
               ),
+              toolNameCollisionPolicy: options.toolNameCollisionPolicy,
               tracingParent:
                 getRunStateTurnSpanParent(state) ?? state._currentAgentSpan,
             });
@@ -1161,6 +1194,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             const artifacts = await prepareAgentArtifacts(
               state,
               preparedSandboxAgent.executionAgent,
+              options.toolNameCollisionPolicy,
             );
             const preparedCall = await this.#prepareModelCall(
               state,
@@ -1347,11 +1381,24 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         if (state._currentAgentSpan) {
           state._currentAgentSpan.setError({
             message: 'Error in agent run',
-            data: { error: String(err) },
+            data: {
+              error: getRunnerSpanErrorDetails(
+                err,
+                this.config.traceIncludeSensitiveData,
+              ),
+            },
           });
         }
-        setRunnerSpanError(currentTurnSpan, err);
-        setRunnerSpanError(taskSpan, err);
+        setRunnerSpanError(
+          currentTurnSpan,
+          err,
+          this.config.traceIncludeSensitiveData,
+        );
+        setRunnerSpanError(
+          taskSpan,
+          err,
+          this.config.traceIncludeSensitiveData,
+        );
         runError = err;
         throw err;
       } finally {
@@ -1381,7 +1428,11 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 invocationSpanParent,
             });
           } catch (error) {
-            setRunnerSpanError(taskSpan, error);
+            setRunnerSpanError(
+              taskSpan,
+              error,
+              this.config.traceIncludeSensitiveData,
+            );
             await Promise.reject(error);
           }
           const resultToPersist = completedResult ?? persistenceCheckpoint;
@@ -1403,7 +1454,11 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                   : undefined;
               await persistResult?.(resultToPersist, persistenceOptions);
             } catch (error) {
-              setRunnerSpanError(taskSpan, error);
+              setRunnerSpanError(
+                taskSpan,
+                error,
+                this.config.traceIncludeSensitiveData,
+              );
               await Promise.reject(error);
             }
           }
@@ -1562,6 +1617,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             runConfigModel: await this.#resolveSandboxRuntimeModelForAgent(
               result.state._currentAgent,
             ),
+            toolNameCollisionPolicy: options.toolNameCollisionPolicy,
             tracingParent:
               getRunStateTurnSpanParent(result.state) ??
               result.state._currentAgentSpan,
@@ -1693,6 +1749,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           const artifacts = await prepareAgentArtifacts(
             result.state,
             preparedSandboxAgent.executionAgent,
+            options.toolNameCollisionPolicy,
           );
 
           const preparedCall = await this.#prepareModelCall(
@@ -2053,11 +2110,24 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       if (result.state._currentAgentSpan) {
         result.state._currentAgentSpan.setError({
           message: 'Error in agent run',
-          data: { error: String(error) },
+          data: {
+            error: getRunnerSpanErrorDetails(
+              error,
+              this.config.traceIncludeSensitiveData,
+            ),
+          },
         });
       }
-      setRunnerSpanError(currentTurnSpan, error);
-      setRunnerSpanError(taskSpan, error);
+      setRunnerSpanError(
+        currentTurnSpan,
+        error,
+        this.config.traceIncludeSensitiveData,
+      );
+      setRunnerSpanError(
+        taskSpan,
+        error,
+        this.config.traceIncludeSensitiveData,
+      );
       runError = error;
       throw error;
     } finally {
@@ -2100,7 +2170,11 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               invocationSpanParent,
           });
         } catch (error) {
-          setRunnerSpanError(taskSpan, error);
+          setRunnerSpanError(
+            taskSpan,
+            error,
+            this.config.traceIncludeSensitiveData,
+          );
           await Promise.reject(error);
         }
       } finally {
@@ -2288,6 +2362,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         !hasExplicitTopLevelReasoningEffort(agentModelSettings),
       tracingParent:
         getRunStateTurnSpanParent(state) ?? state._currentAgentSpan,
+      toolNameCollisionPolicy: options.toolNameCollisionPolicy ?? 'warn',
     };
 
     let modelSettings = mergeModelSettings(

--- a/packages/agents-core/src/runContext.ts
+++ b/packages/agents-core/src/runContext.ts
@@ -4,6 +4,7 @@ import { RunToolApprovalItem } from './items';
 import logger from './logger';
 import {
   getFunctionToolLookupKey,
+  getFunctionToolLegacyStateKeyFromStateKey,
   getFunctionToolStateKeyForCall,
 } from './toolIdentity';
 import { UnknownContext } from './types';
@@ -23,7 +24,7 @@ type SerializedFunctionApprovals = Array<{
 
 type FunctionApprovalState = {
   approvalsByAgent: Map<Agent<any, any>, Map<string, ApprovalRecord>>;
-  legacyFallback: boolean;
+  legacyApprovals: Map<string, ApprovalRecord>;
 };
 
 const COMPUTER_APPROVAL_TOOL_NAMES = new Set([
@@ -126,7 +127,7 @@ type RunContextJson = {
 
 type SerializedRunContextJson = RunContextJson & {
   functionApprovals?: SerializedFunctionApprovals;
-  legacyFunctionApprovalFallback?: boolean;
+  legacyFunctionApprovals?: Record<string, ApprovalRecord>;
 };
 
 /**
@@ -164,7 +165,7 @@ export class RunContext<TContext = UnknownContext> {
     this.#approvals = new Map();
     this.#functionApprovalState = {
       approvalsByAgent: new Map(),
-      legacyFallback: false,
+      legacyApprovals: new Map(),
     };
   }
 
@@ -229,6 +230,56 @@ export class RunContext<TContext = UnknownContext> {
   }
 
   /**
+   * Rebuild legacy function-only approvals from serialized RunState data.
+   * @internal
+   */
+  _rebuildLegacyFunctionApprovals(
+    approvals: Record<string, ApprovalRecord>,
+  ): void {
+    this.#functionApprovalState.legacyApprovals = new Map();
+    this._mergeLegacyFunctionApprovals(approvals);
+  }
+
+  /**
+   * Merge legacy function-only approvals from serialized RunState data.
+   * @internal
+   */
+  _mergeLegacyFunctionApprovals(
+    approvals: Record<string, ApprovalRecord>,
+  ): void {
+    for (const [toolName, incoming] of Object.entries(approvals)) {
+      this.#setLegacyFunctionApprovalRecord(toolName, incoming);
+    }
+  }
+
+  /**
+   * Retain only legacy approvals proven to belong to enabled function tools.
+   * @internal
+   */
+  _retainLegacyFunctionApprovals(toolNames: ReadonlySet<string>): void {
+    for (const toolName of this.#functionApprovalState.legacyApprovals.keys()) {
+      if (!toolNames.has(toolName)) {
+        this.#functionApprovalState.legacyApprovals.delete(toolName);
+      }
+    }
+  }
+
+  /**
+   * Remove migrated function-only keys from the non-function aggregate map.
+   * @internal
+   */
+  _removeMigratedFunctionApprovalsFromAggregate(
+    functionToolNames: ReadonlySet<string>,
+    exactNonFunctionToolNames: ReadonlySet<string>,
+  ): void {
+    for (const toolName of functionToolNames) {
+      if (!exactNonFunctionToolNames.has(toolName)) {
+        this.#approvals.delete(toolName);
+      }
+    }
+  }
+
+  /**
    * Merge owner-scoped function approvals from serialized RunState data.
    * @internal
    */
@@ -281,17 +332,10 @@ export class RunContext<TContext = UnknownContext> {
         this.#setFunctionApprovalRecord(agent, toolName, incoming);
       }
     }
-    this.#functionApprovalState.legacyFallback ||=
-      source.#functionApprovalState.legacyFallback;
-  }
-
-  /**
-   * Allow released unscoped approval records to remain authoritative while
-   * resuming RunState schema versions that predate owner-scoped approvals.
-   * @internal
-   */
-  _enableLegacyFunctionApprovalFallback(): void {
-    this.#functionApprovalState.legacyFallback = true;
+    for (const [toolName, incoming] of source.#functionApprovalState
+      .legacyApprovals) {
+      this.#setLegacyFunctionApprovalRecord(toolName, incoming);
+    }
   }
 
   /**
@@ -299,15 +343,25 @@ export class RunContext<TContext = UnknownContext> {
    * non-function records that use the same legacy name.
    * @internal
    */
-  _mergeApprovalsPreservingExactKeys(
-    approvals: Record<string, ApprovalRecord>,
+  _mergeApprovalStatePreservingExactKeys(
+    source: RunContext<TContext>,
     exactToolNames: ReadonlySet<string>,
-  ) {
-    for (const [toolName, incoming] of Object.entries(approvals)) {
+  ): void {
+    for (const [toolName, incoming] of source.#approvals) {
       if (exactToolNames.has(toolName) && this.#approvals.has(toolName)) {
         continue;
       }
       this.#setApprovalRecord(toolName, incoming);
+    }
+    for (const [agent, approvalsByTool] of source.#functionApprovalState
+      .approvalsByAgent) {
+      for (const [toolName, incoming] of approvalsByTool) {
+        this.#setFunctionApprovalRecord(agent, toolName, incoming);
+      }
+    }
+    for (const [toolName, incoming] of source.#functionApprovalState
+      .legacyApprovals) {
+      this.#setLegacyFunctionApprovalRecord(toolName, incoming);
     }
   }
 
@@ -316,15 +370,18 @@ export class RunContext<TContext = UnknownContext> {
    * @internal
    */
   _migrateToolApproval(
+    agent: Agent<any, any>,
     legacyToolName: string,
     canonicalToolName: string,
     callIds: readonly string[],
     migratePermanentDecision: boolean,
+    preserveMovedCallDecisions = false,
   ): void {
     if (legacyToolName === canonicalToolName) {
       return;
     }
-    const legacy = this.#approvals.get(legacyToolName);
+    const legacy =
+      this.#functionApprovalState.legacyApprovals.get(legacyToolName);
     if (!legacy) {
       return;
     }
@@ -380,7 +437,7 @@ export class RunContext<TContext = UnknownContext> {
     if (!hasMovedDecision) {
       return;
     }
-    this.#setApprovalRecord(canonicalToolName, moved);
+    this.#setFunctionApprovalRecord(agent, canonicalToolName, moved);
 
     const remainingApproved =
       legacy.approved === true
@@ -388,7 +445,9 @@ export class RunContext<TContext = UnknownContext> {
           ? []
           : true
         : Array.isArray(legacy.approved)
-          ? legacy.approved.filter((callId) => !callIdSet.has(callId))
+          ? legacy.approved.filter(
+              (callId) => preserveMovedCallDecisions || !callIdSet.has(callId),
+            )
           : [];
     const remainingRejected =
       legacy.rejected === true
@@ -396,12 +455,14 @@ export class RunContext<TContext = UnknownContext> {
           ? []
           : true
         : Array.isArray(legacy.rejected)
-          ? legacy.rejected.filter((callId) => !callIdSet.has(callId))
+          ? legacy.rejected.filter(
+              (callId) => preserveMovedCallDecisions || !callIdSet.has(callId),
+            )
           : [];
     const remainingMessages = legacy.messages
       ? Object.fromEntries(
           Object.entries(legacy.messages).filter(
-            ([callId]) => !callIdSet.has(callId),
+            ([callId]) => preserveMovedCallDecisions || !callIdSet.has(callId),
           ),
         )
       : undefined;
@@ -421,9 +482,12 @@ export class RunContext<TContext = UnknownContext> {
       (Array.isArray(remaining.approved) && remaining.approved.length > 0) ||
       (Array.isArray(remaining.rejected) && remaining.rejected.length > 0);
     if (hasRemainingDecision) {
-      this.#approvals.set(legacyToolName, remaining);
+      this.#functionApprovalState.legacyApprovals.set(
+        legacyToolName,
+        remaining,
+      );
     } else {
-      this.#approvals.delete(legacyToolName);
+      this.#functionApprovalState.legacyApprovals.delete(legacyToolName);
     }
   }
 
@@ -440,10 +504,18 @@ export class RunContext<TContext = UnknownContext> {
     options: { functionTool?: boolean } = {},
   ): string | undefined {
     const functionTool = options.functionTool ?? true;
+    const includeFunctionState =
+      functionTool ||
+      getFunctionToolLegacyStateKeyFromStateKey(toolName) !== undefined;
     return this.#getRejectionMessageFromEntries(
       [
         ...this.#getApprovalEntries(toolName, functionTool),
-        ...this.#getFunctionApprovalEntries(toolName, functionTool),
+        ...(includeFunctionState
+          ? [
+              ...this.#getLegacyFunctionApprovalEntries(toolName),
+              ...this.#getFunctionApprovalEntries(toolName, functionTool),
+            ]
+          : []),
       ],
       callId,
     );
@@ -473,10 +545,10 @@ export class RunContext<TContext = UnknownContext> {
     }
     if (
       scopedDecision === undefined &&
-      this.#functionApprovalState.legacyFallback
+      this.#functionApprovalState.legacyApprovals.size > 0
     ) {
       return this.#getRejectionMessageFromEntries(
-        this.#getApprovalEntries(toolName, false),
+        this.#getLegacyFunctionApprovalEntries(toolName),
         callId,
       );
     }
@@ -505,11 +577,21 @@ export class RunContext<TContext = UnknownContext> {
   ): SerializedRunContextJson {
     const approvals = new Map(this.#approvals);
     if (!agentIdentityKeys) {
+      for (const [toolName, incoming] of this.#functionApprovalState
+        .legacyApprovals) {
+        const current = approvals.get(toolName);
+        approvals.set(
+          toolName,
+          current ? mergeApprovalRecords(current, incoming) : incoming,
+        );
+      }
       for (const approvalsByTool of this.#functionApprovalState.approvalsByAgent.values()) {
         for (const [toolName, incoming] of approvalsByTool) {
-          const current = approvals.get(toolName);
+          const publicToolName =
+            getFunctionToolLegacyStateKeyFromStateKey(toolName) ?? toolName;
+          const current = approvals.get(publicToolName);
           approvals.set(
-            toolName,
+            publicToolName,
             current ? mergeApprovalRecords(current, incoming) : incoming,
           );
         }
@@ -538,8 +620,10 @@ export class RunContext<TContext = UnknownContext> {
       if (functionApprovals.length > 0) {
         json.functionApprovals = functionApprovals;
       }
-      if (this.#functionApprovalState.legacyFallback) {
-        json.legacyFunctionApprovalFallback = true;
+      if (this.#functionApprovalState.legacyApprovals.size > 0) {
+        json.legacyFunctionApprovals = Object.fromEntries(
+          this.#functionApprovalState.legacyApprovals,
+        );
       }
     }
     if (typeof this.toolInput !== 'undefined') {
@@ -583,15 +667,25 @@ export class RunContext<TContext = UnknownContext> {
       if (scopedDecision !== undefined) {
         return scopedDecision;
       }
-      if (!this.#functionApprovalState.legacyFallback) {
+      if (this.#functionApprovalState.legacyApprovals.size === 0) {
         return undefined;
       }
+      return this.#resolveApprovalEntries(
+        this.#getLegacyFunctionApprovalEntries(toolName),
+        callId,
+      );
     }
 
+    const includeFunctionState =
+      functionTool ||
+      getFunctionToolLegacyStateKeyFromStateKey(toolName) !== undefined;
     return this.#resolveApprovalEntries(
       [
         ...this.#getApprovalEntries(toolName, functionTool),
-        ...(!agent
+        ...(includeFunctionState
+          ? this.#getLegacyFunctionApprovalEntries(toolName)
+          : []),
+        ...(!agent && includeFunctionState
           ? this.#getFunctionApprovalEntries(toolName, functionTool)
           : []),
       ],
@@ -814,6 +908,16 @@ export class RunContext<TContext = UnknownContext> {
     );
   }
 
+  #getLegacyFunctionApprovalEntries(toolName: string): ApprovalRecord[] {
+    const legacyToolName =
+      getFunctionToolLegacyStateKeyFromStateKey(toolName) ?? toolName;
+    return getApprovalToolNameCandidates(legacyToolName, true)
+      .map((candidate) =>
+        this.#functionApprovalState.legacyApprovals.get(candidate),
+      )
+      .filter((approval): approval is ApprovalRecord => approval !== undefined);
+  }
+
   #getFunctionApprovalMap(agent: Agent<any, any>): Map<string, ApprovalRecord> {
     const existing = this.#functionApprovalState.approvalsByAgent.get(agent);
     if (existing) {
@@ -857,6 +961,17 @@ export class RunContext<TContext = UnknownContext> {
     const approvalsByTool = this.#getFunctionApprovalMap(agent);
     const current = approvalsByTool.get(toolName);
     approvalsByTool.set(
+      toolName,
+      current ? mergeApprovalRecords(current, incoming) : incoming,
+    );
+  }
+
+  #setLegacyFunctionApprovalRecord(
+    toolName: string,
+    incoming: ApprovalRecord,
+  ): void {
+    const current = this.#functionApprovalState.legacyApprovals.get(toolName);
+    this.#functionApprovalState.legacyApprovals.set(
       toolName,
       current ? mergeApprovalRecords(current, incoming) : incoming,
     );

--- a/packages/agents-core/src/runContext.ts
+++ b/packages/agents-core/src/runContext.ts
@@ -1,5 +1,11 @@
+import type { Agent } from './agent';
+import { UserError } from './errors';
 import { RunToolApprovalItem } from './items';
 import logger from './logger';
+import {
+  getFunctionToolLookupKey,
+  getFunctionToolStateKeyForCall,
+} from './toolIdentity';
 import { UnknownContext } from './types';
 import { Usage } from './usage';
 
@@ -10,19 +16,39 @@ type ApprovalRecord = {
   stickyRejectMessage?: string;
 };
 
+type SerializedFunctionApprovals = Array<{
+  agentIdentity: string;
+  approvals: Record<string, ApprovalRecord>;
+}>;
+
+type FunctionApprovalState = {
+  approvalsByAgent: Map<Agent<any, any>, Map<string, ApprovalRecord>>;
+  legacyFallback: boolean;
+};
+
 const COMPUTER_APPROVAL_TOOL_NAMES = new Set([
   'computer',
   'computer_use_preview',
 ]);
 
-function getApprovalToolNameCandidates(toolName: string): string[] {
-  if (!COMPUTER_APPROVAL_TOOL_NAMES.has(toolName)) {
-    return [toolName];
+function getApprovalToolNameCandidates(
+  toolName: string,
+  includeFunctionAliases: boolean,
+): string[] {
+  if (COMPUTER_APPROVAL_TOOL_NAMES.has(toolName)) {
+    return toolName === 'computer'
+      ? ['computer', 'computer_use_preview']
+      : ['computer_use_preview', 'computer'];
   }
 
-  return toolName === 'computer'
-    ? ['computer', 'computer_use_preview']
-    : ['computer_use_preview', 'computer'];
+  if (includeFunctionAliases) {
+    const bareFunctionKey = toolName.startsWith('[')
+      ? undefined
+      : getFunctionToolLookupKey(toolName);
+    return bareFunctionKey ? [toolName, bareFunctionKey] : [toolName];
+  }
+
+  return [toolName];
 }
 
 function mergeApprovalList(
@@ -98,6 +124,11 @@ type RunContextJson = {
   toolInput?: unknown;
 };
 
+type SerializedRunContextJson = RunContextJson & {
+  functionApprovals?: SerializedFunctionApprovals;
+  legacyFunctionApprovalFallback?: boolean;
+};
+
 /**
  * A context object that is passed to the `Runner.run()` method.
  */
@@ -122,10 +153,19 @@ export class RunContext<TContext = UnknownContext> {
    */
   #approvals: Map<string, ApprovalRecord>;
 
+  /**
+   * Function-tool approvals scoped to the public agent that owns the call.
+   */
+  #functionApprovalState: FunctionApprovalState;
+
   constructor(context: TContext = {} as TContext) {
     this.context = context;
     this.usage = new Usage();
     this.#approvals = new Map();
+    this.#functionApprovalState = {
+      approvalsByAgent: new Map(),
+      legacyFallback: false,
+    };
   }
 
   /**
@@ -147,6 +187,7 @@ export class RunContext<TContext = UnknownContext> {
     target.context = this.context;
     target.usage = this.usage;
     target.#approvals = this.#approvals;
+    target.#functionApprovalState = this.#functionApprovalState;
     return target;
   }
 
@@ -176,26 +217,335 @@ export class RunContext<TContext = UnknownContext> {
   }
 
   /**
+   * Rebuild owner-scoped function approvals from serialized RunState data.
+   * @internal
+   */
+  _rebuildFunctionApprovals(
+    approvals: SerializedFunctionApprovals,
+    agentsByIdentity: ReadonlyMap<string, Agent<any, any>>,
+  ): void {
+    this.#functionApprovalState.approvalsByAgent = new Map();
+    this._mergeFunctionApprovals(approvals, agentsByIdentity);
+  }
+
+  /**
+   * Merge owner-scoped function approvals from serialized RunState data.
+   * @internal
+   */
+  _mergeFunctionApprovals(
+    approvals: SerializedFunctionApprovals,
+    agentsByIdentity: ReadonlyMap<string, Agent<any, any>>,
+  ): void {
+    this._validateFunctionApprovalOwners(approvals, agentsByIdentity);
+    for (const { agentIdentity, approvals: approvalsByTool } of approvals) {
+      const agent = agentsByIdentity.get(agentIdentity)!;
+      for (const [toolName, incoming] of Object.entries(approvalsByTool)) {
+        this.#setFunctionApprovalRecord(agent, toolName, incoming);
+      }
+    }
+  }
+
+  /**
+   * Validate serialized function-approval owners without mutating this context.
+   * @internal
+   */
+  _validateFunctionApprovalOwners(
+    approvals: SerializedFunctionApprovals,
+    agentsByIdentity: ReadonlyMap<string, Agent<any, any>>,
+  ): void {
+    const seenAgentIdentities = new Set<string>();
+    for (const { agentIdentity } of approvals) {
+      if (
+        seenAgentIdentities.has(agentIdentity) ||
+        !agentsByIdentity.has(agentIdentity)
+      ) {
+        throw new UserError(
+          'RunState contains invalid function approval ownership for the current agent graph.',
+        );
+      }
+      seenAgentIdentities.add(agentIdentity);
+    }
+  }
+
+  /**
+   * Merge all approval state from another live context.
+   * @internal
+   */
+  _mergeApprovalState(source: RunContext<TContext>): void {
+    for (const [toolName, incoming] of source.#approvals) {
+      this.#setApprovalRecord(toolName, incoming);
+    }
+    for (const [agent, approvalsByTool] of source.#functionApprovalState
+      .approvalsByAgent) {
+      for (const [toolName, incoming] of approvalsByTool) {
+        this.#setFunctionApprovalRecord(agent, toolName, incoming);
+      }
+    }
+    this.#functionApprovalState.legacyFallback ||=
+      source.#functionApprovalState.legacyFallback;
+  }
+
+  /**
+   * Allow released unscoped approval records to remain authoritative while
+   * resuming RunState schema versions that predate owner-scoped approvals.
+   * @internal
+   */
+  _enableLegacyFunctionApprovalFallback(): void {
+    this.#functionApprovalState.legacyFallback = true;
+  }
+
+  /**
+   * Merges canonicalized legacy approvals without replacing existing exact
+   * non-function records that use the same legacy name.
+   * @internal
+   */
+  _mergeApprovalsPreservingExactKeys(
+    approvals: Record<string, ApprovalRecord>,
+    exactToolNames: ReadonlySet<string>,
+  ) {
+    for (const [toolName, incoming] of Object.entries(approvals)) {
+      if (exactToolNames.has(toolName) && this.#approvals.has(toolName)) {
+        continue;
+      }
+      this.#setApprovalRecord(toolName, incoming);
+    }
+  }
+
+  /**
+   * Moves a legacy function-tool approval to an exact category-aware key.
+   * @internal
+   */
+  _migrateToolApproval(
+    legacyToolName: string,
+    canonicalToolName: string,
+    callIds: readonly string[],
+    migratePermanentDecision: boolean,
+  ): void {
+    if (legacyToolName === canonicalToolName) {
+      return;
+    }
+    const legacy = this.#approvals.get(legacyToolName);
+    if (!legacy) {
+      return;
+    }
+
+    const callIdSet = new Set(callIds);
+    const movedApproved =
+      legacy.approved === true
+        ? migratePermanentDecision
+          ? true
+          : [...callIdSet]
+        : Array.isArray(legacy.approved)
+          ? legacy.approved.filter((callId) => callIdSet.has(callId))
+          : [];
+    const movedRejected =
+      legacy.rejected === true
+        ? migratePermanentDecision
+          ? true
+          : [...callIdSet]
+        : Array.isArray(legacy.rejected)
+          ? legacy.rejected.filter((callId) => callIdSet.has(callId))
+          : [];
+    let movedMessages = legacy.messages
+      ? Object.fromEntries(
+          Object.entries(legacy.messages).filter(([callId]) =>
+            callIdSet.has(callId),
+          ),
+        )
+      : undefined;
+    if (
+      legacy.rejected === true &&
+      !migratePermanentDecision &&
+      legacy.stickyRejectMessage !== undefined
+    ) {
+      for (const callId of callIdSet) {
+        (movedMessages ??= {})[callId] ??= legacy.stickyRejectMessage;
+      }
+    }
+    const moved: ApprovalRecord = {
+      approved: movedApproved,
+      rejected: movedRejected,
+      ...(movedMessages && Object.keys(movedMessages).length > 0
+        ? { messages: movedMessages }
+        : {}),
+      ...(migratePermanentDecision && legacy.stickyRejectMessage !== undefined
+        ? { stickyRejectMessage: legacy.stickyRejectMessage }
+        : {}),
+    };
+    const hasMovedDecision =
+      moved.approved === true ||
+      moved.rejected === true ||
+      (Array.isArray(moved.approved) && moved.approved.length > 0) ||
+      (Array.isArray(moved.rejected) && moved.rejected.length > 0);
+    if (!hasMovedDecision) {
+      return;
+    }
+    this.#setApprovalRecord(canonicalToolName, moved);
+
+    const remainingApproved =
+      legacy.approved === true
+        ? migratePermanentDecision
+          ? []
+          : true
+        : Array.isArray(legacy.approved)
+          ? legacy.approved.filter((callId) => !callIdSet.has(callId))
+          : [];
+    const remainingRejected =
+      legacy.rejected === true
+        ? migratePermanentDecision
+          ? []
+          : true
+        : Array.isArray(legacy.rejected)
+          ? legacy.rejected.filter((callId) => !callIdSet.has(callId))
+          : [];
+    const remainingMessages = legacy.messages
+      ? Object.fromEntries(
+          Object.entries(legacy.messages).filter(
+            ([callId]) => !callIdSet.has(callId),
+          ),
+        )
+      : undefined;
+    const remaining: ApprovalRecord = {
+      approved: remainingApproved,
+      rejected: remainingRejected,
+      ...(remainingMessages && Object.keys(remainingMessages).length > 0
+        ? { messages: remainingMessages }
+        : {}),
+      ...(!migratePermanentDecision && legacy.stickyRejectMessage !== undefined
+        ? { stickyRejectMessage: legacy.stickyRejectMessage }
+        : {}),
+    };
+    const hasRemainingDecision =
+      remaining.approved === true ||
+      remaining.rejected === true ||
+      (Array.isArray(remaining.approved) && remaining.approved.length > 0) ||
+      (Array.isArray(remaining.rejected) && remaining.rejected.length > 0);
+    if (hasRemainingDecision) {
+      this.#approvals.set(legacyToolName, remaining);
+    } else {
+      this.#approvals.delete(legacyToolName);
+    }
+  }
+
+  /**
    * Retrieve the caller-provided rejection message for a specific tool call.
    *
    * @param toolName - The name of the tool.
    * @param callId - The call ID of the tool invocation.
    * @returns The message string if one was provided, `undefined` otherwise.
    */
-  getRejectionMessage(toolName: string, callId: string): string | undefined {
-    for (const approvalEntry of this.#getApprovalEntries(toolName)) {
-      if (typeof approvalEntry.messages?.[callId] === 'string') {
-        return approvalEntry.messages[callId];
-      }
-    }
+  getRejectionMessage(
+    toolName: string,
+    callId: string,
+    options: { functionTool?: boolean } = {},
+  ): string | undefined {
+    const functionTool = options.functionTool ?? true;
+    return this.#getRejectionMessageFromEntries(
+      [
+        ...this.#getApprovalEntries(toolName, functionTool),
+        ...this.#getFunctionApprovalEntries(toolName, functionTool),
+      ],
+      callId,
+    );
+  }
 
-    for (const approvalEntry of this.#getApprovalEntries(toolName)) {
-      if (approvalEntry.rejected === true) {
-        return approvalEntry.stickyRejectMessage;
-      }
+  /**
+   * Retrieve a rejection message for the agent that owns a function call.
+   * @internal
+   */
+  _getFunctionRejectionMessage(
+    toolName: string,
+    callId: string,
+    agent: Agent<any, any>,
+  ): string | undefined {
+    const scopedEntries = this.#getFunctionApprovalEntries(
+      toolName,
+      false,
+      agent,
+    );
+    const scopedDecision = this.#resolveApprovalEntries(scopedEntries, callId);
+    const scopedMessage = this.#getRejectionMessageFromEntries(
+      scopedEntries,
+      callId,
+    );
+    if (scopedMessage !== undefined) {
+      return scopedMessage;
     }
-
+    if (
+      scopedDecision === undefined &&
+      this.#functionApprovalState.legacyFallback
+    ) {
+      return this.#getRejectionMessageFromEntries(
+        this.#getApprovalEntries(toolName, false),
+        callId,
+      );
+    }
     return undefined;
+  }
+
+  /**
+   * Serialize public RunContext state using the released aggregate shape.
+   */
+  toJSON(): RunContextJson {
+    return this.#serialize();
+  }
+
+  /**
+   * Serialize RunContext state with stable function-approval ownership.
+   * @internal
+   */
+  _toJSONForRunState(
+    agentIdentityKeys: ReadonlyMap<Agent<any, any>, string>,
+  ): SerializedRunContextJson {
+    return this.#serialize(agentIdentityKeys);
+  }
+
+  #serialize(
+    agentIdentityKeys?: ReadonlyMap<Agent<any, any>, string>,
+  ): SerializedRunContextJson {
+    const approvals = new Map(this.#approvals);
+    if (!agentIdentityKeys) {
+      for (const approvalsByTool of this.#functionApprovalState.approvalsByAgent.values()) {
+        for (const [toolName, incoming] of approvalsByTool) {
+          const current = approvals.get(toolName);
+          approvals.set(
+            toolName,
+            current ? mergeApprovalRecords(current, incoming) : incoming,
+          );
+        }
+      }
+    }
+    const json: SerializedRunContextJson = {
+      context: this.context,
+      usage: this.usage,
+      approvals: Object.fromEntries(approvals.entries()),
+    };
+    if (agentIdentityKeys) {
+      const functionApprovals: SerializedFunctionApprovals = [];
+      for (const [agent, approvalsByTool] of this.#functionApprovalState
+        .approvalsByAgent) {
+        const agentIdentity = agentIdentityKeys.get(agent);
+        if (!agentIdentity) {
+          // Nested agent runs share their parent's context. Only persist
+          // approvals owned by agents reachable from this RunState graph.
+          continue;
+        }
+        functionApprovals.push({
+          agentIdentity,
+          approvals: Object.fromEntries(approvalsByTool),
+        });
+      }
+      if (functionApprovals.length > 0) {
+        json.functionApprovals = functionApprovals;
+      }
+      if (this.#functionApprovalState.legacyFallback) {
+        json.legacyFunctionApprovalFallback = true;
+      }
+    }
+    if (typeof this.toolInput !== 'undefined') {
+      json.toolInput = this.toolInput;
+    }
+    return json;
   }
 
   #getCallId(approvalItem: RunToolApprovalItem): string {
@@ -204,8 +554,7 @@ export class RunContext<TContext = UnknownContext> {
     }
 
     const providerData = approvalItem.rawItem.providerData as
-      | { itemId?: string; id?: string }
-      | undefined;
+      { itemId?: string; id?: string } | undefined;
     return (
       approvalItem.rawItem.id ?? providerData?.itemId ?? providerData?.id ?? ''
     );
@@ -217,9 +566,43 @@ export class RunContext<TContext = UnknownContext> {
    * @param approval - Details about the tool call being evaluated.
    * @returns `true` if the tool call has been approved, `false` if blocked and `undefined` if not yet approved or rejected.
    */
-  isToolApproved(approval: { toolName: string; callId: string }) {
-    const { toolName, callId } = approval;
-    const approvalEntries = this.#getApprovalEntries(toolName);
+  isToolApproved(approval: {
+    toolName: string;
+    callId: string;
+    /** @internal Whether legacy function-tool aliases should be considered. */
+    functionTool?: boolean;
+    /** @internal Public agent that owns a function-tool approval. */
+    agent?: Agent<any, any>;
+  }) {
+    const { toolName, callId, functionTool = true, agent } = approval;
+    if (agent) {
+      const scopedDecision = this.#resolveApprovalEntries(
+        this.#getFunctionApprovalEntries(toolName, functionTool, agent),
+        callId,
+      );
+      if (scopedDecision !== undefined) {
+        return scopedDecision;
+      }
+      if (!this.#functionApprovalState.legacyFallback) {
+        return undefined;
+      }
+    }
+
+    return this.#resolveApprovalEntries(
+      [
+        ...this.#getApprovalEntries(toolName, functionTool),
+        ...(!agent
+          ? this.#getFunctionApprovalEntries(toolName, functionTool)
+          : []),
+      ],
+      callId,
+    );
+  }
+
+  #resolveApprovalEntries(
+    approvalEntries: readonly ApprovalRecord[],
+    callId: string,
+  ): boolean | undefined {
     const hasPermanentApproval = approvalEntries.some(
       (approvalEntry) => approvalEntry.approved === true,
     );
@@ -271,6 +654,23 @@ export class RunContext<TContext = UnknownContext> {
     return undefined;
   }
 
+  #getRejectionMessageFromEntries(
+    approvalEntries: readonly ApprovalRecord[],
+    callId: string,
+  ): string | undefined {
+    for (const approvalEntry of approvalEntries) {
+      if (typeof approvalEntry.messages?.[callId] === 'string') {
+        return approvalEntry.messages[callId];
+      }
+    }
+    for (const approvalEntry of approvalEntries) {
+      if (approvalEntry.rejected === true) {
+        return approvalEntry.stickyRejectMessage;
+      }
+    }
+    return undefined;
+  }
+
   /**
    * Approve a tool call.
    *
@@ -281,25 +681,32 @@ export class RunContext<TContext = UnknownContext> {
     approvalItem: RunToolApprovalItem,
     { alwaysApprove = false }: { alwaysApprove?: boolean } = {},
   ) {
-    const toolName =
-      approvalItem.toolName ?? (approvalItem.rawItem as any).name;
-    const approvalKey = this.#getApprovalStorageKey(toolName);
+    const toolName = this.#getApprovalItemToolName(approvalItem);
+    const approvals =
+      approvalItem.rawItem.type === 'function_call'
+        ? this.#getFunctionApprovalMap(approvalItem.agent)
+        : this.#approvals;
+    const approvalKey = this.#getApprovalStorageKey(
+      toolName,
+      approvalItem.rawItem.type === 'function_call',
+      approvals,
+    );
     if (alwaysApprove) {
-      this.#approvals.set(approvalKey, {
+      approvals.set(approvalKey, {
         approved: true,
         rejected: [],
       });
       return;
     }
 
-    const approvalEntry = this.#approvals.get(approvalKey) ?? {
+    const approvalEntry = approvals.get(approvalKey) ?? {
       approved: [],
       rejected: [],
     };
     if (Array.isArray(approvalEntry.approved)) {
       approvalEntry.approved.push(this.#getCallId(approvalItem));
     }
-    this.#approvals.set(approvalKey, approvalEntry);
+    approvals.set(approvalKey, approvalEntry);
   }
 
   /**
@@ -314,12 +721,19 @@ export class RunContext<TContext = UnknownContext> {
       message,
     }: { alwaysReject?: boolean; message?: string } = {},
   ) {
-    const toolName =
-      approvalItem.toolName ?? (approvalItem.rawItem as any).name;
-    const approvalKey = this.#getApprovalStorageKey(toolName);
+    const toolName = this.#getApprovalItemToolName(approvalItem);
+    const approvals =
+      approvalItem.rawItem.type === 'function_call'
+        ? this.#getFunctionApprovalMap(approvalItem.agent)
+        : this.#approvals;
+    const approvalKey = this.#getApprovalStorageKey(
+      toolName,
+      approvalItem.rawItem.type === 'function_call',
+      approvals,
+    );
     if (alwaysReject) {
       const callId = this.#getCallId(approvalItem);
-      this.#approvals.set(approvalKey, {
+      approvals.set(approvalKey, {
         approved: false,
         rejected: true,
         ...(message !== undefined
@@ -332,7 +746,7 @@ export class RunContext<TContext = UnknownContext> {
       return;
     }
 
-    const approvalEntry = this.#approvals.get(approvalKey) ?? {
+    const approvalEntry = approvals.get(approvalKey) ?? {
       approved: [] as string[],
       rejected: [] as string[],
     };
@@ -345,7 +759,7 @@ export class RunContext<TContext = UnknownContext> {
         approvalEntry.messages[callId] = message;
       }
     }
-    this.#approvals.set(approvalKey, approvalEntry);
+    approvals.set(approvalKey, approvalEntry);
   }
 
   /**
@@ -368,34 +782,88 @@ export class RunContext<TContext = UnknownContext> {
     return fork;
   }
 
-  toJSON(): RunContextJson {
-    const json: RunContextJson = {
-      context: this.context,
-      usage: this.usage,
-      approvals: Object.fromEntries(this.#approvals.entries()),
-    };
-    if (typeof this.toolInput !== 'undefined') {
-      json.toolInput = this.toolInput;
-    }
-    return json;
-  }
-
-  #getApprovalEntries(toolName: string): ApprovalRecord[] {
-    return getApprovalToolNameCandidates(toolName)
+  #getApprovalEntries(
+    toolName: string,
+    includeFunctionAliases: boolean,
+  ): ApprovalRecord[] {
+    return getApprovalToolNameCandidates(toolName, includeFunctionAliases)
       .map((candidate) => this.#approvals.get(candidate))
       .filter((approval): approval is ApprovalRecord => approval !== undefined);
   }
 
-  #getApprovalStorageKey(toolName: string): string {
+  #getFunctionApprovalEntries(
+    toolName: string,
+    includeFunctionAliases: boolean,
+    agent?: Agent<any, any>,
+  ): ApprovalRecord[] {
+    const candidates = getApprovalToolNameCandidates(
+      toolName,
+      includeFunctionAliases,
+    );
+    const approvalMaps = agent
+      ? [this.#functionApprovalState.approvalsByAgent.get(agent)]
+      : [...this.#functionApprovalState.approvalsByAgent.values()];
+    return approvalMaps.flatMap((approvalsByTool) =>
+      approvalsByTool
+        ? candidates
+            .map((candidate) => approvalsByTool.get(candidate))
+            .filter(
+              (approval): approval is ApprovalRecord => approval !== undefined,
+            )
+        : [],
+    );
+  }
+
+  #getFunctionApprovalMap(agent: Agent<any, any>): Map<string, ApprovalRecord> {
+    const existing = this.#functionApprovalState.approvalsByAgent.get(agent);
+    if (existing) {
+      return existing;
+    }
+    const approvals = new Map<string, ApprovalRecord>();
+    this.#functionApprovalState.approvalsByAgent.set(agent, approvals);
+    return approvals;
+  }
+
+  #getApprovalItemToolName(approvalItem: RunToolApprovalItem): string {
+    const fallbackName =
+      approvalItem.toolName ?? (approvalItem.rawItem as any).name;
+    if (approvalItem.rawItem.type !== 'function_call') {
+      return fallbackName;
+    }
     return (
-      getApprovalToolNameCandidates(toolName).find((candidate) =>
-        this.#approvals.has(candidate),
+      approvalItem.functionToolStateKey ??
+      getFunctionToolStateKeyForCall(approvalItem.rawItem, fallbackName) ??
+      fallbackName
+    );
+  }
+
+  #getApprovalStorageKey(
+    toolName: string,
+    includeFunctionAliases: boolean,
+    approvals: ReadonlyMap<string, ApprovalRecord> = this.#approvals,
+  ): string {
+    return (
+      getApprovalToolNameCandidates(toolName, includeFunctionAliases).find(
+        (candidate) => approvals.has(candidate),
       ) ?? toolName
     );
   }
 
+  #setFunctionApprovalRecord(
+    agent: Agent<any, any>,
+    toolName: string,
+    incoming: ApprovalRecord,
+  ): void {
+    const approvalsByTool = this.#getFunctionApprovalMap(agent);
+    const current = approvalsByTool.get(toolName);
+    approvalsByTool.set(
+      toolName,
+      current ? mergeApprovalRecords(current, incoming) : incoming,
+    );
+  }
+
   #setApprovalRecord(toolName: string, incoming: ApprovalRecord): void {
-    const candidates = getApprovalToolNameCandidates(toolName);
+    const candidates = getApprovalToolNameCandidates(toolName, false);
     const existingEntries = candidates
       .map((candidate) => this.#approvals.get(candidate))
       .filter((approval): approval is ApprovalRecord => approval !== undefined);

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { Agent } from './agent';
+import type { Handoff } from './handoff';
 import { getAgentToolSourceAgent } from './agentToolSourceRegistry';
 import { buildAgentIdentityMap } from './runStateIdentity';
 export { buildAgentIdentityMap } from './runStateIdentity';
@@ -20,7 +21,7 @@ import { RunContext } from './runContext';
 import { getTurnInput, type ReasoningItemIdPolicy } from './runner/items';
 import { AgentToolUseTracker } from './runner/toolUseTracker';
 import { nextStepSchema, NextStep } from './runner/steps';
-import type { ProcessedResponse } from './runner/types';
+import { createToolRunFunction, type ProcessedResponse } from './runner/types';
 import type { AgentSpanData, Span } from './tracing/spans';
 import { SystemError, UserError } from './errors';
 import { getGlobalTraceProvider } from './tracing/provider';
@@ -28,7 +29,6 @@ import { Usage } from './usage';
 import { Trace } from './tracing/traces';
 import { getCurrentTrace } from './tracing';
 import logger from './logger';
-import { handoff } from './handoff';
 import * as protocol from './types/protocol';
 import { AgentInputItem, UnknownContext } from './types';
 import {
@@ -43,27 +43,41 @@ import type {
 import { safeExecute } from './utils/safeExecute';
 import {
   getClientToolSearchExecutor,
-  getToolSearchRuntimeToolKey,
+  getToolSearchRuntimeRoutingKey,
   HostedMCPTool,
+  FunctionTool,
   ShellTool,
   ApplyPatchTool,
   Tool,
 } from './tool';
 import type { AgentToolInvocation } from './agentToolInvocation';
 import {
+  buildFunctionToolLookupMap,
+  type FunctionToolLookupKey,
+  getFunctionToolLookupKey,
   getFunctionToolQualifiedName,
-  toolQualifiedName,
-  resolveFunctionToolCallName,
+  getFunctionToolStateKey,
+  getFunctionToolStateKeyForCall,
+  getFunctionToolStateKeyForResolvedCall,
+  getFunctionToolStateKeys,
+  getToolCallNamespace,
+  getToolCallDisplayName,
+  resolveFunctionToolCall,
 } from './toolIdentity';
 import {
   getToolSearchExecution,
   getToolSearchOutputReplacementKey,
+  getToolSearchProviderCallId,
   resolveToolSearchCallId,
 } from './utils/toolSearch';
 import {
   executeCustomClientToolSearch,
+  filterEnabledToolSearchRuntimeTools,
   getClientToolSearchHelper,
+  registerRuntimeToolSearchTools,
+  validateClientToolSearchSupport,
 } from './runner/toolSearch';
+import { resolveModelVisibleToolNameCollisions } from './runner/modelPreparation';
 import { ensureToolCallerAllowed } from './runner/toolCaller';
 import {
   getSerializedApplyPatchToolPlaceholder,
@@ -101,8 +115,10 @@ import {
  *   and optional assistant message phases.
  * - 1.15: Adds reconstructable sandbox environment value references and sandbox
  *   session-state envelope version 2.
+ * - 1.16: Adds category-aware function tool keys and agent-scoped function approvals,
+ *   including aliases for legacy pending-run accessors.
  */
-export const CURRENT_SCHEMA_VERSION = '1.15' as const;
+export const CURRENT_SCHEMA_VERSION = '1.16' as const;
 const SUPPORTED_SCHEMA_VERSIONS = [
   '1.0',
   '1.1',
@@ -119,6 +135,7 @@ const SUPPORTED_SCHEMA_VERSIONS = [
   '1.12',
   '1.13',
   '1.14',
+  '1.15',
   CURRENT_SCHEMA_VERSION,
 ] as const;
 type SupportedSchemaVersion = (typeof SUPPORTED_SCHEMA_VERSIONS)[number];
@@ -245,6 +262,7 @@ const itemSchema = z.discriminatedUnion('type', [
       .or(protocol.ApplyPatchCallItem),
     agent: serializedAgentSchema,
     toolName: z.string().optional(),
+    functionToolStateKey: z.string().optional(),
   }),
 ]);
 
@@ -299,6 +317,7 @@ const serializedProcessedResponseSchema = z.object({
     z.object({
       toolCall: z.any(),
       handoff: z.any(),
+      targetAgent: serializedAgentSchema.optional(),
     }),
   ),
   functions: z.array(
@@ -420,6 +439,25 @@ const toolOutputGuardrailResultSchema = z.object({
   output: toolGuardrailFunctionOutputSchema,
 });
 
+const approvalRecordSchema = z.object({
+  approved: z.array(z.string()).or(z.boolean()),
+  rejected: z.array(z.string()).or(z.boolean()),
+  messages: z.record(z.string(), z.string()).optional(),
+  stickyRejectMessage: z.string().optional(),
+});
+
+const functionApprovalsSchema = z.array(
+  z.object({
+    agentIdentity: z.string(),
+    approvals: z.record(z.string(), approvalRecordSchema),
+  }),
+);
+
+const functionApprovalContextSchema = z.object({
+  functionApprovals: functionApprovalsSchema.optional(),
+  legacyFunctionApprovalFallback: z.boolean().optional(),
+});
+
 export const SerializedRunState = z.object({
   $schemaVersion,
   currentTurn: z.number(),
@@ -428,15 +466,9 @@ export const SerializedRunState = z.object({
   modelResponses: z.array(modelResponseSchema),
   context: z.object({
     usage: usageSchema,
-    approvals: z.record(
-      z.string(),
-      z.object({
-        approved: z.array(z.string()).or(z.boolean()),
-        rejected: z.array(z.string()).or(z.boolean()),
-        messages: z.record(z.string(), z.string()).optional(),
-        stickyRejectMessage: z.string().optional(),
-      }),
-    ),
+    approvals: z.record(z.string(), approvalRecordSchema),
+    functionApprovals: functionApprovalsSchema.optional(),
+    legacyFunctionApprovalFallback: z.boolean().optional(),
     context: z.record(z.string(), z.any()),
     toolInput: z.any().optional(),
   }),
@@ -459,6 +491,10 @@ export const SerializedRunState = z.object({
   lastModelResponse: modelResponseSchema.optional(),
   generatedItems: z.array(itemSchema),
   pendingAgentToolRuns: z.record(z.string(), z.string()).optional().default({}),
+  pendingAgentToolRunAliases: z
+    .record(z.string(), z.string())
+    .optional()
+    .default({}),
   lastProcessedResponse: serializedProcessedResponseSchema.optional(),
   currentTurnPersistedItemCount: z.number().int().min(0).optional(),
   conversationId: z.string().optional(),
@@ -476,8 +512,15 @@ type ToolSearchRuntimeToolEntry<TContext = UnknownContext> = {
 };
 
 type ToolSearchRuntimeToolState<TContext = UnknownContext> = {
-  anonymousEntries: ToolSearchRuntimeToolEntry<TContext>[];
   keyedEntries: Map<string, ToolSearchRuntimeToolEntry<TContext>>;
+  routedOwners: Map<
+    string,
+    {
+      entry: ToolSearchRuntimeToolEntry<TContext>;
+      tool: Tool<TContext>;
+      toolIndex: number;
+    }
+  >;
   nextOrder: number;
 };
 
@@ -558,6 +601,10 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
    * Serialized pending nested agent runs keyed by tool name and call id.
    */
   public _pendingAgentToolRuns: Map<string, string>;
+  /**
+   * Legacy pending-run keys mapped to their canonical category-aware keys.
+   */
+  public _pendingAgentToolRunAliases: Map<string, string>;
   /**
    * Items generated by the agent during the run.
    */
@@ -648,6 +695,7 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     this._reasoningItemIdPolicy = undefined;
     this._toolUseTracker = new AgentToolUseTracker();
     this._pendingAgentToolRuns = new Map();
+    this._pendingAgentToolRunAliases = new Map();
     this._generatedItems = [];
     this._currentTurnPersistedItemCount = 0;
     this._maxTurns = maxTurns;
@@ -700,8 +748,8 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     let state = this._toolSearchRuntimeToolsByAgent.get(agent);
     if (!state) {
       state = {
-        anonymousEntries: [],
         keyedEntries: new Map(),
+        routedOwners: new Map(),
         nextOrder: 0,
       };
       this._toolSearchRuntimeToolsByAgent.set(agent, state);
@@ -721,11 +769,50 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     };
     const replacementKey = getToolSearchOutputReplacementKey(toolSearchOutput);
     if (replacementKey) {
+      const previousEntry = runtimeState.keyedEntries.get(replacementKey);
+      if (previousEntry) {
+        for (const [routingKey, owner] of runtimeState.routedOwners) {
+          if (owner.entry === previousEntry) {
+            runtimeState.routedOwners.delete(routingKey);
+          }
+        }
+      }
       runtimeState.keyedEntries.set(replacementKey, entry);
-      return;
     }
 
-    runtimeState.anonymousEntries.push(entry);
+    for (const [toolIndex, tool] of tools.entries()) {
+      const routingKey = getToolSearchRuntimeRoutingKey(tool);
+      if (!routingKey) {
+        continue;
+      }
+      runtimeState.routedOwners.set(routingKey, {
+        entry,
+        tool,
+        toolIndex,
+      });
+    }
+  }
+
+  public getToolSearchRuntimeToolsForOutput(
+    agent: Agent<any, any>,
+    toolSearchOutput: protocol.ToolSearchOutputItem,
+  ): Tool<TContext>[] {
+    const replacementKey = getToolSearchOutputReplacementKey(toolSearchOutput);
+    if (!replacementKey) {
+      return [];
+    }
+    const runtimeState = this._toolSearchRuntimeToolsByAgent.get(agent);
+    const entry = runtimeState?.keyedEntries.get(replacementKey);
+    if (!runtimeState || !entry) {
+      return [];
+    }
+    return entry.tools.filter((tool) => {
+      const routingKey = getToolSearchRuntimeRoutingKey(tool);
+      return (
+        typeof routingKey === 'string' &&
+        runtimeState.routedOwners.get(routingKey)?.entry === entry
+      );
+    });
   }
 
   public getToolSearchRuntimeTools(agent: Agent<any, any>): Tool<TContext>[] {
@@ -734,23 +821,13 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
       return [];
     }
 
-    const dedupedTools = new Map<string, Tool<TContext>>();
-    const orderedEntries = [
-      ...runtimeState.keyedEntries.values(),
-      ...runtimeState.anonymousEntries,
-    ].sort((a, b) => a.order - b.order);
-    let anonymousCounter = 0;
-
-    for (const entry of orderedEntries) {
-      for (const tool of entry.tools) {
-        const key =
-          getToolSearchRuntimeToolKey(tool) ??
-          `anonymous:${entry.order}:${anonymousCounter++}`;
-        dedupedTools.set(key, tool);
-      }
-    }
-
-    return [...dedupedTools.values()];
+    return [...runtimeState.routedOwners.values()]
+      .sort(
+        (left, right) =>
+          left.entry.order - right.entry.order ||
+          left.toolIndex - right.toolIndex,
+      )
+      .map((owner) => owner.tool);
   }
 
   /**
@@ -817,15 +894,23 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     return `${toolName}:${callId}`;
   }
 
+  private resolvePendingAgentToolRunKey(
+    toolName: string,
+    callId: string,
+  ): string {
+    const key = this.getPendingAgentToolRunKey(toolName, callId);
+    return this._pendingAgentToolRunAliases.get(key) ?? key;
+  }
+
   getPendingAgentToolRun(toolName: string, callId: string): string | undefined {
     return this._pendingAgentToolRuns.get(
-      this.getPendingAgentToolRunKey(toolName, callId),
+      this.resolvePendingAgentToolRunKey(toolName, callId),
     );
   }
 
   hasPendingAgentToolRun(toolName: string, callId: string): boolean {
     return this._pendingAgentToolRuns.has(
-      this.getPendingAgentToolRunKey(toolName, callId),
+      this.resolvePendingAgentToolRunKey(toolName, callId),
     );
   }
 
@@ -833,17 +918,31 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     toolName: string,
     callId: string,
     serializedState: string,
+    aliases: readonly string[] = [],
   ) {
-    this._pendingAgentToolRuns.set(
-      this.getPendingAgentToolRunKey(toolName, callId),
-      serializedState,
-    );
+    const canonicalKey = this.resolvePendingAgentToolRunKey(toolName, callId);
+    this._pendingAgentToolRuns.set(canonicalKey, serializedState);
+    for (const alias of aliases) {
+      const aliasKey = this.getPendingAgentToolRunKey(alias, callId);
+      if (aliasKey === canonicalKey) {
+        continue;
+      }
+      this._pendingAgentToolRuns.delete(aliasKey);
+      this._pendingAgentToolRunAliases.set(aliasKey, canonicalKey);
+    }
   }
 
   clearPendingAgentToolRun(toolName: string, callId: string) {
-    this._pendingAgentToolRuns.delete(
-      this.getPendingAgentToolRunKey(toolName, callId),
-    );
+    const requestedKey = this.getPendingAgentToolRunKey(toolName, callId);
+    const canonicalKey = this.resolvePendingAgentToolRunKey(toolName, callId);
+    this._pendingAgentToolRuns.delete(canonicalKey);
+    this._pendingAgentToolRuns.delete(requestedKey);
+    for (const [aliasKey, targetKey] of this._pendingAgentToolRunAliases) {
+      if (aliasKey === requestedKey || targetKey === canonicalKey) {
+        this._pendingAgentToolRuns.delete(aliasKey);
+        this._pendingAgentToolRunAliases.delete(aliasKey);
+      }
+    }
   }
 
   /**
@@ -915,7 +1014,7 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     const agentIdentity = buildAgentIdentityMap(this.#startingAgent);
 
     const includeTracingApiKey = options.includeTracingApiKey === true;
-    const contextJson = this._context.toJSON();
+    const contextJson = this._context._toJSONForRunState(agentIdentity.byAgent);
     const output = {
       $schemaVersion: CURRENT_SCHEMA_VERSION,
       currentTurn: this._currentTurn,
@@ -980,6 +1079,9 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
       ),
       pendingAgentToolRuns: Object.fromEntries(
         this._pendingAgentToolRuns.entries(),
+      ),
+      pendingAgentToolRunAliases: Object.fromEntries(
+        this._pendingAgentToolRunAliases.entries(),
       ),
       currentTurnPersistedItemCount: this._currentTurnPersistedItemCount,
       lastProcessedResponse: this._lastProcessedResponse
@@ -1074,6 +1176,10 @@ async function buildRunStateFromString<
       `Run state schema version ${currentSchemaVersion} is not supported. Please use version ${CURRENT_SCHEMA_VERSION}.`,
     );
   }
+  validateFunctionApprovalEnvelope(
+    currentSchemaVersion as SupportedSchemaVersion,
+    jsonResult,
+  );
   const stateJson = SerializedRunState.parse(jsonResult);
   assertSchemaVersionSupportsToolSearch(
     currentSchemaVersion as SupportedSchemaVersion,
@@ -1094,6 +1200,40 @@ async function buildRunStateFromString<
   return buildRunStateFromJson(initialAgent, stateJson, options);
 }
 
+function validateFunctionApprovalEnvelope(
+  schemaVersion: SupportedSchemaVersion,
+  stateJson: unknown,
+): void {
+  if (!stateJson || typeof stateJson !== 'object') {
+    return;
+  }
+  const context = (stateJson as { context?: unknown }).context;
+  if (!context || typeof context !== 'object') {
+    return;
+  }
+  const hasFunctionApprovals = Object.prototype.hasOwnProperty.call(
+    context,
+    'functionApprovals',
+  );
+  const hasLegacyFallback = Object.prototype.hasOwnProperty.call(
+    context,
+    'legacyFunctionApprovalFallback',
+  );
+  if (!hasFunctionApprovals && !hasLegacyFallback) {
+    return;
+  }
+  if (schemaVersion !== CURRENT_SCHEMA_VERSION) {
+    throw new UserError(
+      `Run state schema version ${schemaVersion} does not support owner-scoped function approvals. Please reserialize the run state with schema ${CURRENT_SCHEMA_VERSION}.`,
+    );
+  }
+  if (!functionApprovalContextSchema.safeParse(context).success) {
+    throw new UserError(
+      'Failed to parse owner-scoped function approvals because their structure does not match the supported schema.',
+    );
+  }
+}
+
 function assertSchemaVersionSupportsToolSearch(
   schemaVersion: SupportedSchemaVersion,
   stateJson: z.infer<typeof SerializedRunState>,
@@ -1106,6 +1246,7 @@ function assertSchemaVersionSupportsToolSearch(
     schemaVersion === '1.12' ||
     schemaVersion === '1.13' ||
     schemaVersion === '1.14' ||
+    schemaVersion === '1.15' ||
     schemaVersion === CURRENT_SCHEMA_VERSION
   ) {
     return;
@@ -1127,6 +1268,7 @@ function assertSchemaVersionSupportsCustomData(
   if (
     schemaVersion === '1.13' ||
     schemaVersion === '1.14' ||
+    schemaVersion === '1.15' ||
     schemaVersion === CURRENT_SCHEMA_VERSION
   ) {
     return;
@@ -1150,6 +1292,7 @@ function schemaVersionSupportsAgentIdentity(
     schemaVersion === '1.12' ||
     schemaVersion === '1.13' ||
     schemaVersion === '1.14' ||
+    schemaVersion === '1.15' ||
     schemaVersion === CURRENT_SCHEMA_VERSION
   );
 }
@@ -1158,7 +1301,11 @@ function assertSchemaVersionSupportsProgrammaticToolCalling(
   schemaVersion: SupportedSchemaVersion,
   stateJson: z.infer<typeof SerializedRunState>,
 ): void {
-  if (schemaVersion === '1.14' || schemaVersion === CURRENT_SCHEMA_VERSION) {
+  if (
+    schemaVersion === '1.14' ||
+    schemaVersion === '1.15' ||
+    schemaVersion === CURRENT_SCHEMA_VERSION
+  ) {
     return;
   }
 
@@ -1175,7 +1322,11 @@ function assertSchemaVersionSupportsSandboxSessionEnvelope(
   schemaVersion: SupportedSchemaVersion,
   stateJson: z.infer<typeof SerializedRunState>,
 ): void {
-  if (schemaVersion === CURRENT_SCHEMA_VERSION || !stateJson.sandbox) {
+  if (
+    schemaVersion === '1.15' ||
+    schemaVersion === CURRENT_SCHEMA_VERSION ||
+    !stateJson.sandbox
+  ) {
     return;
   }
 
@@ -1376,10 +1527,23 @@ function isToolSearchProtocolType(type: unknown): boolean {
   return type === 'tool_search_call' || type === 'tool_search_output';
 }
 
+function addSerializedRuntimeToolKey(
+  runtimeToolKeys: Set<string>,
+  runtimeToolKey: string,
+): void {
+  if (runtimeToolKeys.has(runtimeToolKey)) {
+    throw new UserError(
+      'Serialized client tool_search output contains multiple tools with the same routed identity. Assign unique tool names or namespaces before resuming RunState.',
+    );
+  }
+  runtimeToolKeys.add(runtimeToolKey);
+}
+
 function collectSerializedRuntimeToolKeys(
   value: unknown,
   runtimeToolKeys: Set<string>,
   namespace?: string,
+  validateRecognizedShape = false,
 ): void {
   if (!value || typeof value !== 'object') {
     return;
@@ -1389,21 +1553,34 @@ function collectSerializedRuntimeToolKeys(
     type?: unknown;
     name?: unknown;
     namespace?: unknown;
+    deferLoading?: unknown;
+    defer_loading?: unknown;
     tools?: unknown;
     server_label?: unknown;
     providerData?: unknown;
   };
 
-  if (candidate.type === 'namespace' && Array.isArray(candidate.tools)) {
+  if (candidate.type === 'namespace') {
+    if (
+      typeof candidate.name !== 'string' ||
+      candidate.name.length === 0 ||
+      !Array.isArray(candidate.tools)
+    ) {
+      if (validateRecognizedShape) {
+        throw new UserError(
+          'Serialized client tool_search output contains a namespace without a valid routed identity.',
+        );
+      }
+      return;
+    }
     const nestedNamespace =
-      typeof candidate.name === 'string' && candidate.name.length > 0
-        ? candidate.name
-        : namespace;
+      typeof candidate.name === 'string' ? candidate.name : namespace;
     for (const nestedTool of candidate.tools) {
       collectSerializedRuntimeToolKeys(
         nestedTool,
         runtimeToolKeys,
         nestedNamespace,
+        true,
       );
     }
     return;
@@ -1415,21 +1592,52 @@ function collectSerializedRuntimeToolKeys(
       : namespace;
   if (candidate.type === 'function') {
     if (typeof candidate.name !== 'string' || candidate.name.length === 0) {
+      if (validateRecognizedShape) {
+        throw new UserError(
+          'Serialized client tool_search output contains a function without a valid routed identity.',
+        );
+      }
       return;
     }
+    const directNamespace =
+      typeof candidate.namespace === 'string' && candidate.namespace.length > 0
+        ? candidate.namespace
+        : undefined;
+    if (candidate.name === namespace || candidate.name === directNamespace) {
+      throw new UserError(
+        'Responses tool search reserves same-name namespaces for deferred top-level function tools. Rename the namespace or tool name to avoid ambiguous dispatch.',
+      );
+    }
 
-    runtimeToolKeys.add(
-      toolQualifiedName(candidate.name, explicitNamespace) ?? candidate.name,
+    const lookupKey = getFunctionToolLookupKey(
+      candidate.name,
+      explicitNamespace ??
+        (candidate.deferLoading === true || candidate.defer_loading === true
+          ? candidate.name
+          : undefined),
     );
+    if (lookupKey) {
+      addSerializedRuntimeToolKey(runtimeToolKeys, lookupKey);
+    }
     return;
   }
 
-  if (
-    candidate.type === 'mcp' &&
-    typeof candidate.server_label === 'string' &&
-    candidate.server_label.length > 0
-  ) {
-    runtimeToolKeys.add(`mcp:${candidate.server_label}`);
+  if (candidate.type === 'mcp') {
+    if (
+      typeof candidate.server_label !== 'string' ||
+      candidate.server_label.length === 0
+    ) {
+      if (validateRecognizedShape) {
+        throw new UserError(
+          'Serialized client tool_search output contains an MCP tool without a valid routed identity.',
+        );
+      }
+      return;
+    }
+    addSerializedRuntimeToolKey(
+      runtimeToolKeys,
+      `mcp:${candidate.server_label}`,
+    );
     return;
   }
 
@@ -1441,6 +1649,7 @@ function collectSerializedRuntimeToolKeys(
     candidate.providerData,
     runtimeToolKeys,
     explicitNamespace,
+    false,
   );
 }
 
@@ -1449,18 +1658,22 @@ function getSerializedRuntimeToolKeys(
 ): Set<string> {
   const runtimeToolKeys = new Set<string>();
   for (const tool of toolSearchOutput.tools) {
-    collectSerializedRuntimeToolKeys(tool, runtimeToolKeys);
+    collectSerializedRuntimeToolKeys(tool, runtimeToolKeys, undefined, true);
   }
   return runtimeToolKeys;
 }
 
 function getRuntimeToolKeys<TContext>(
   runtimeTools: Tool<TContext>[],
-  options: { allowUnsupported?: boolean } = {},
+  options: {
+    allowUnsupported?: boolean;
+    rejectDuplicateKeys?: boolean;
+  } = {},
 ): Set<string> {
   const runtimeToolKeys = new Set<string>();
+  const runtimeToolsByKey = new Map<string, Tool<TContext>>();
   for (const tool of runtimeTools) {
-    const runtimeToolKey = getToolSearchRuntimeToolKey(tool);
+    const runtimeToolKey = getToolSearchRuntimeRoutingKey(tool);
     if (!runtimeToolKey) {
       if (options.allowUnsupported) {
         continue;
@@ -1469,6 +1682,12 @@ function getRuntimeToolKeys<TContext>(
         'Client tool_search execute() returned an unsupported runtime tool during RunState rehydration.',
       );
     }
+    if (options.rejectDuplicateKeys && runtimeToolsByKey.has(runtimeToolKey)) {
+      throw new UserError(
+        'Client tool_search execute() returned multiple tools with the same routed identity during RunState rehydration.',
+      );
+    }
+    runtimeToolsByKey.set(runtimeToolKey, tool);
     runtimeToolKeys.add(runtimeToolKey);
   }
   return runtimeToolKeys;
@@ -1485,11 +1704,9 @@ function assertRuntimeToolKeysMatch<TContext>(args: {
   runtimeTools: Tool<TContext>[];
 }): void {
   const { agent, toolSearchCall, expectedRuntimeToolKeys, runtimeTools } = args;
-  if (expectedRuntimeToolKeys.size === 0) {
-    return;
-  }
-
-  const actualRuntimeToolKeys = getRuntimeToolKeys(runtimeTools);
+  const actualRuntimeToolKeys = getRuntimeToolKeys(runtimeTools, {
+    rejectDuplicateKeys: true,
+  });
   const hasExpectedKeys = [...expectedRuntimeToolKeys].every((runtimeToolKey) =>
     actualRuntimeToolKeys.has(runtimeToolKey),
   );
@@ -1498,6 +1715,12 @@ function assertRuntimeToolKeysMatch<TContext>(args: {
   );
   if (hasExpectedKeys && hasActualKeys) {
     return;
+  }
+
+  if (logger.dontLogToolData) {
+    throw new UserError(
+      'RunState cannot resume custom client tool_search because the registered execute callback returned different runtime tools than the serialized state.',
+    );
   }
 
   const callId = resolveToolSearchCallId(toolSearchCall);
@@ -1524,24 +1747,404 @@ async function getConfiguredAgentTools<TContext>(args: {
   return configuredTools;
 }
 
+type RunStateCapabilitySnapshot<TContext> = {
+  availableTools: Tool<TContext>[];
+  callbackTools: Tool<TContext>[];
+  handoffs: Handoff<any, any>[];
+  functionMap: Map<FunctionToolLookupKey, FunctionTool<TContext>>;
+  functionToolsByCallId: Map<string, FunctionTool<TContext>>;
+  runtimeFunctionTools: Set<FunctionTool<TContext>>;
+  handoffMap: Map<string, Handoff<any, any>>;
+  mcpToolMap: Map<string, HostedMCPTool>;
+  replaceableRuntimeToolKeys: Set<string>;
+};
+
+function throwAmbiguousFunctionCallId(
+  agent: Agent<any, any>,
+  callId: string,
+  routedToolKeys: Iterable<string>,
+): never {
+  if (logger.dontLogToolData) {
+    throw new UserError(
+      'RunState cannot resume because a function call ID is associated with multiple routed tool identities.',
+    );
+  }
+
+  throw new UserError(
+    `RunState cannot resume function call ${callId} for agent ${agent.name} because the call ID is reused across routed tool identities [${[
+      ...routedToolKeys,
+    ].join(', ')}]. Use a unique call ID for each function call.`,
+  );
+}
+
+type DeferredFunctionCallExpectation = {
+  agent: Agent<any, any>;
+  toolCall: protocol.FunctionCallItem;
+  resolvedRoutedToolKey: string;
+};
+
+function assertUnambiguousFunctionCallIds<
+  TContext,
+  TAgent extends Agent<any, any>,
+>(
+  state: RunState<TContext, TAgent>,
+  agentMap: Map<string, Agent<any, any>>,
+  serializedProcessedResponse?: z.infer<
+    typeof serializedProcessedResponseSchema
+  >,
+): DeferredFunctionCallExpectation[] {
+  const deferredFunctionCallExpectations: DeferredFunctionCallExpectation[] =
+    [];
+  const generatedCallsByAgent = new Map<Agent<any, any>, Map<string, string>>();
+  for (const item of state._generatedItems) {
+    if (
+      !(item instanceof RunToolCallItem) ||
+      item.rawItem.type !== 'function_call'
+    ) {
+      continue;
+    }
+    const agent = item.agent as Agent<any, any>;
+    const routedToolKey = getFunctionToolStateKeyForCall(item.rawItem);
+    if (!routedToolKey) {
+      continue;
+    }
+    const callsById = generatedCallsByAgent.get(agent) ?? new Map();
+    const previousRoutedToolKey = callsById.get(item.rawItem.callId);
+    if (previousRoutedToolKey && previousRoutedToolKey !== routedToolKey) {
+      throwAmbiguousFunctionCallId(agent, item.rawItem.callId, [
+        previousRoutedToolKey,
+        routedToolKey,
+      ]);
+    }
+    callsById.set(item.rawItem.callId, routedToolKey);
+    generatedCallsByAgent.set(agent, callsById);
+  }
+
+  type ProcessedFunctionCallIdentity = {
+    rawRoutedToolKey: string;
+    resolvedRoutedToolKey: string;
+  };
+  const processedCallsByAgent = new Map<
+    Agent<any, any>,
+    Map<string, ProcessedFunctionCallIdentity>
+  >();
+  if (serializedProcessedResponse) {
+    const agent = state._currentAgent as Agent<any, any>;
+    const processedCallsById = new Map<string, ProcessedFunctionCallIdentity>();
+    for (const functionCall of serializedProcessedResponse.functions) {
+      const toolCall = functionCall.toolCall as protocol.FunctionCallItem;
+      const rawRoutedToolKey = getFunctionToolStateKeyForCall(toolCall);
+      if (!rawRoutedToolKey) {
+        continue;
+      }
+      const serializedToolStateKey = getToolCallNamespace(toolCall)
+        ? rawRoutedToolKey
+        : getFunctionToolStateKey(functionCall.tool);
+      const resolvedRoutedToolKey = serializedToolStateKey
+        ? getFunctionToolStateKeyForResolvedCall(
+            toolCall,
+            functionCall.tool,
+            serializedToolStateKey,
+          )
+        : rawRoutedToolKey;
+      if (!resolvedRoutedToolKey) {
+        throwAmbiguousFunctionCallId(agent, toolCall.callId, [
+          rawRoutedToolKey,
+          serializedToolStateKey!,
+        ]);
+      }
+      if (resolvedRoutedToolKey !== rawRoutedToolKey) {
+        deferredFunctionCallExpectations.push({
+          agent,
+          toolCall,
+          resolvedRoutedToolKey,
+        });
+      }
+      const callId = toolCall.callId;
+      const previousProcessedIdentity = processedCallsById.get(callId);
+      if (
+        previousProcessedIdentity &&
+        previousProcessedIdentity.resolvedRoutedToolKey !==
+          resolvedRoutedToolKey
+      ) {
+        throwAmbiguousFunctionCallId(agent, callId, [
+          previousProcessedIdentity.resolvedRoutedToolKey,
+          resolvedRoutedToolKey,
+        ]);
+      }
+      const generatedRoutedToolKey = generatedCallsByAgent
+        .get(agent)
+        ?.get(callId);
+      if (
+        generatedRoutedToolKey &&
+        generatedRoutedToolKey !== rawRoutedToolKey
+      ) {
+        throwAmbiguousFunctionCallId(agent, callId, [
+          generatedRoutedToolKey,
+          rawRoutedToolKey,
+        ]);
+      }
+      processedCallsById.set(callId, {
+        rawRoutedToolKey,
+        resolvedRoutedToolKey,
+      });
+    }
+    processedCallsByAgent.set(agent, processedCallsById);
+  }
+
+  if (state._currentStep?.type !== 'next_step_interruption') {
+    return deferredFunctionCallExpectations;
+  }
+
+  for (const value of state._currentStep.data?.interruptions ?? []) {
+    if (!value || typeof value !== 'object') {
+      continue;
+    }
+    const interruption = value as {
+      rawItem?: unknown;
+      functionToolStateKey?: unknown;
+      agent?: unknown;
+    };
+    if (
+      !interruption.rawItem ||
+      typeof interruption.rawItem !== 'object' ||
+      (interruption.rawItem as { type?: unknown }).type !== 'function_call'
+    ) {
+      continue;
+    }
+    const rawItem = interruption.rawItem as protocol.FunctionCallItem;
+    const rawItemRoutedToolKey = getFunctionToolStateKeyForCall(rawItem);
+    if (!rawItemRoutedToolKey) {
+      continue;
+    }
+    const interruptionAgent =
+      interruption.agent && typeof interruption.agent === 'object'
+        ? resolveSerializedAgent(
+            interruption.agent as any,
+            agentMap,
+            state._currentAgent,
+          )
+        : (state._currentAgent as Agent<any, any>);
+    const generatedRoutedToolKey = generatedCallsByAgent
+      .get(interruptionAgent)
+      ?.get(rawItem.callId);
+    if (
+      generatedRoutedToolKey &&
+      generatedRoutedToolKey !== rawItemRoutedToolKey
+    ) {
+      throwAmbiguousFunctionCallId(interruptionAgent, rawItem.callId, [
+        generatedRoutedToolKey,
+        rawItemRoutedToolKey,
+      ]);
+    }
+    const processedIdentity = processedCallsByAgent
+      .get(interruptionAgent)
+      ?.get(rawItem.callId);
+    if (
+      processedIdentity &&
+      processedIdentity.rawRoutedToolKey !== rawItemRoutedToolKey
+    ) {
+      throwAmbiguousFunctionCallId(interruptionAgent, rawItem.callId, [
+        processedIdentity.rawRoutedToolKey,
+        rawItemRoutedToolKey,
+      ]);
+    }
+    const expectedRoutedToolKey =
+      processedIdentity?.resolvedRoutedToolKey ?? rawItemRoutedToolKey;
+    if (typeof interruption.functionToolStateKey === 'string') {
+      if (interruption.functionToolStateKey !== expectedRoutedToolKey) {
+        throwAmbiguousFunctionCallId(interruptionAgent, rawItem.callId, [
+          expectedRoutedToolKey,
+          interruption.functionToolStateKey,
+        ]);
+      }
+    }
+  }
+  return deferredFunctionCallExpectations;
+}
+
+function collectDeferredToolSearchProvenanceByCallId<TContext>(args: {
+  state: RunState<TContext, Agent<any, any>>;
+  effectiveToolSearchOutputs: RunToolSearchOutputItem[];
+  serializedRuntimeToolKeysByOutput: Map<RunToolSearchOutputItem, Set<string>>;
+}): Map<Agent<any, any>, Map<string, string>> {
+  const {
+    state,
+    effectiveToolSearchOutputs,
+    serializedRuntimeToolKeysByOutput,
+  } = args;
+  const effectiveOutputs = new Set(effectiveToolSearchOutputs);
+  const routedOwnersByAgent = new Map<
+    Agent<any, any>,
+    Map<string, RunToolSearchOutputItem>
+  >();
+  const entriesByReplacementKeyByAgent = new Map<
+    Agent<any, any>,
+    Map<string, RunToolSearchOutputItem>
+  >();
+  const deferredKeysByCallIdByAgent = new Map<
+    Agent<any, any>,
+    Map<string, string>
+  >();
+
+  for (const item of state._generatedItems) {
+    if (item instanceof RunToolSearchOutputItem && effectiveOutputs.has(item)) {
+      const agent = item.agent as Agent<any, any>;
+      const routedOwners = routedOwnersByAgent.get(agent) ?? new Map();
+      const entriesByReplacementKey =
+        entriesByReplacementKeyByAgent.get(agent) ?? new Map();
+      const replacementKey = getToolSearchOutputReplacementKey(item.rawItem);
+      if (replacementKey) {
+        const previousEntry = entriesByReplacementKey.get(replacementKey);
+        if (previousEntry) {
+          for (const [routedKey, owner] of routedOwners) {
+            if (owner === previousEntry) {
+              routedOwners.delete(routedKey);
+            }
+          }
+        }
+        entriesByReplacementKey.set(replacementKey, item);
+      }
+      for (const routedKey of serializedRuntimeToolKeysByOutput.get(item) ??
+        []) {
+        routedOwners.set(routedKey, item);
+      }
+      routedOwnersByAgent.set(agent, routedOwners);
+      entriesByReplacementKeyByAgent.set(agent, entriesByReplacementKey);
+      continue;
+    }
+
+    if (
+      !(item instanceof RunToolCallItem) ||
+      item.rawItem.type !== 'function_call' ||
+      getToolCallNamespace(item.rawItem)
+    ) {
+      continue;
+    }
+    const name = item.rawItem.name;
+    const bareKey = getFunctionToolLookupKey(name);
+    const deferredKey = getFunctionToolLookupKey(name, name);
+    const routedOwners = routedOwnersByAgent.get(item.agent);
+    if (
+      !bareKey ||
+      !deferredKey ||
+      routedOwners?.has(bareKey) ||
+      !routedOwners?.has(deferredKey)
+    ) {
+      continue;
+    }
+    const keysByCallId =
+      deferredKeysByCallIdByAgent.get(item.agent) ?? new Map();
+    keysByCallId.set(item.rawItem.callId, deferredKey);
+    deferredKeysByCallIdByAgent.set(item.agent, keysByCallId);
+  }
+
+  return deferredKeysByCallIdByAgent;
+}
+
+function assertDeferredFunctionCallProvenance<TContext>(args: {
+  expectations: DeferredFunctionCallExpectation[];
+  capabilitySnapshotsByAgent: Map<
+    Agent<TContext, any>,
+    RunStateCapabilitySnapshot<TContext>
+  >;
+  deferredToolSearchKeysByCallIdByAgent: Map<
+    Agent<any, any>,
+    Map<string, string>
+  >;
+}): void {
+  const {
+    expectations,
+    capabilitySnapshotsByAgent,
+    deferredToolSearchKeysByCallIdByAgent,
+  } = args;
+  for (const expectation of expectations) {
+    const snapshot = capabilitySnapshotsByAgent.get(expectation.agent);
+    if (snapshot?.handoffMap.has(expectation.toolCall.name)) {
+      throwAmbiguousFunctionCallId(
+        expectation.agent,
+        expectation.toolCall.callId,
+        [expectation.toolCall.name, expectation.resolvedRoutedToolKey],
+      );
+    }
+    const configuredOwner = snapshot
+      ? resolveFunctionToolCall(expectation.toolCall, snapshot.functionMap)
+      : undefined;
+    if (configuredOwner) {
+      if (
+        getFunctionToolStateKey(configuredOwner) ===
+        expectation.resolvedRoutedToolKey
+      ) {
+        continue;
+      }
+      throwAmbiguousFunctionCallId(
+        expectation.agent,
+        expectation.toolCall.callId,
+        [
+          getFunctionToolStateKey(configuredOwner) ?? configuredOwner.name,
+          expectation.resolvedRoutedToolKey,
+        ],
+      );
+    }
+    if (
+      deferredToolSearchKeysByCallIdByAgent
+        .get(expectation.agent)
+        ?.get(expectation.toolCall.callId) !== expectation.resolvedRoutedToolKey
+    ) {
+      throwAmbiguousFunctionCallId(
+        expectation.agent,
+        expectation.toolCall.callId,
+        [
+          getFunctionToolStateKeyForCall(expectation.toolCall) ??
+            expectation.toolCall.name,
+          expectation.resolvedRoutedToolKey,
+        ],
+      );
+    }
+  }
+}
+
 async function rehydrateToolSearchRuntimeTools<
   TContext,
   TAgent extends Agent<any, any>,
->(state: RunState<TContext, TAgent>): Promise<void> {
+>(
+  state: RunState<TContext, TAgent>,
+  options: {
+    agentMap: Map<string, Agent<any, any>>;
+    schemaVersion: SupportedSchemaVersion;
+    serializedProcessedResponse?: z.infer<
+      typeof serializedProcessedResponseSchema
+    >;
+  },
+): Promise<Map<Agent<TContext, any>, RunStateCapabilitySnapshot<TContext>>> {
+  const deferredFunctionCallExpectations = assertUnambiguousFunctionCallIds(
+    state,
+    options.agentMap,
+    options.serializedProcessedResponse,
+  );
   const configuredToolsByAgent = new Map<
     Agent<TContext, any>,
     Tool<TContext>[]
   >();
-  const pendingToolSearchCalls = new Map<
+  const capabilitySnapshotsByAgent = new Map<
     Agent<TContext, any>,
-    Map<
-      string,
-      {
-        agent: Agent<TContext, any>;
-        toolSearchCall: protocol.ToolSearchCallItem;
-        runtimeTools?: Tool<TContext>[];
-      }
-    >
+    RunStateCapabilitySnapshot<TContext>
+  >();
+  type ToolSearchCallOccurrence = {
+    pendingCall: {
+      agent: Agent<TContext, any>;
+      toolSearchCall: protocol.ToolSearchCallItem;
+    };
+    output?: RunToolSearchOutputItem;
+  };
+  const toolSearchCallOccurrences: ToolSearchCallOccurrence[] = [];
+  const latestOccurrenceByAgentAndCallId = new Map<
+    Agent<TContext, any>,
+    Map<string, ToolSearchCallOccurrence>
+  >();
+  const pendingOccurrencesByAgent = new Map<
+    Agent<TContext, any>,
+    ToolSearchCallOccurrence[]
   >();
 
   for (const item of state._generatedItems) {
@@ -1552,109 +2155,337 @@ async function rehydrateToolSearchRuntimeTools<
 
       const callId = resolveToolSearchCallId(item.rawItem);
       const agent = item.agent as Agent<TContext, any>;
-      const pendingCallsById =
-        pendingToolSearchCalls.get(agent) ??
-        new Map<
-          string,
-          {
-            agent: Agent<TContext, any>;
-            toolSearchCall: protocol.ToolSearchCallItem;
-            runtimeTools?: Tool<TContext>[];
-          }
-        >();
-      pendingCallsById.set(callId, {
-        agent: item.agent as Agent<TContext, any>,
-        toolSearchCall: item.rawItem,
-      });
-      pendingToolSearchCalls.set(agent, pendingCallsById);
+      const occurrence: ToolSearchCallOccurrence = {
+        pendingCall: {
+          agent,
+          toolSearchCall: item.rawItem,
+        },
+      };
+      toolSearchCallOccurrences.push(occurrence);
+      const pendingOccurrences = pendingOccurrencesByAgent.get(agent) ?? [];
+      pendingOccurrences.push(occurrence);
+      pendingOccurrencesByAgent.set(agent, pendingOccurrences);
+      const occurrencesByCallId =
+        latestOccurrenceByAgentAndCallId.get(agent) ?? new Map();
+      occurrencesByCallId.set(callId, occurrence);
+      latestOccurrenceByAgentAndCallId.set(agent, occurrencesByCallId);
       continue;
     }
 
-    if (!(item instanceof RunToolSearchOutputItem)) {
+    if (
+      !(item instanceof RunToolSearchOutputItem) ||
+      getToolSearchExecution(item.rawItem) === 'server'
+    ) {
       continue;
     }
 
-    if (getToolSearchExecution(item.rawItem) === 'server') {
-      continue;
+    const agent = item.agent as Agent<TContext, any>;
+    const explicitCallId = getToolSearchProviderCallId(item.rawItem);
+    const pendingOccurrences = pendingOccurrencesByAgent.get(agent) ?? [];
+    const occurrence = explicitCallId
+      ? latestOccurrenceByAgentAndCallId.get(agent)?.get(explicitCallId)
+      : pendingOccurrences.shift();
+    if (!occurrence) {
+      const callId = resolveToolSearchCallId(item.rawItem);
+      throw new UserError(
+        logger.dontLogToolData
+          ? 'RunState cannot resume custom client tool_search because the serialized state is missing the matching tool_search call item.'
+          : `RunState cannot resume custom client tool_search output ${callId} for agent ${item.agent.name} because the serialized state is missing the matching tool_search call item.`,
+      );
     }
+    if (explicitCallId) {
+      const pendingIndex = pendingOccurrences.indexOf(occurrence);
+      if (pendingIndex >= 0) {
+        pendingOccurrences.splice(pendingIndex, 1);
+      }
+    }
+    occurrence.output = item;
+  }
 
+  const effectiveToolSearchOutputs = toolSearchCallOccurrences
+    .map((occurrence) => occurrence.output)
+    .filter((item): item is RunToolSearchOutputItem => Boolean(item));
+  const occurrencesByOutput = new Map(
+    toolSearchCallOccurrences.flatMap((occurrence) =>
+      occurrence.output ? [[occurrence.output, occurrence] as const] : [],
+    ),
+  );
+  const serializedRuntimeToolKeysByOutput = new Map<
+    RunToolSearchOutputItem,
+    Set<string>
+  >();
+  for (const item of effectiveToolSearchOutputs) {
+    serializedRuntimeToolKeysByOutput.set(
+      item,
+      getSerializedRuntimeToolKeys(item.rawItem),
+    );
+  }
+
+  const agentsToPrepare = new Set(
+    effectiveToolSearchOutputs.map(
+      (item) => item.agent as Agent<TContext, any>,
+    ),
+  );
+  if (options.serializedProcessedResponse) {
+    agentsToPrepare.add(state._currentAgent as Agent<TContext, any>);
+  }
+
+  for (const agent of agentsToPrepare) {
     const configuredTools = await getConfiguredAgentTools({
-      agent: item.agent as Agent<TContext, any>,
+      agent,
       context: state._context,
       configuredToolsByAgent,
     });
-    const configuredToolKeys = getRuntimeToolKeys(configuredTools, {
-      allowUnsupported: true,
-    });
-    const expectedRuntimeToolKeys = new Set(
-      [...getSerializedRuntimeToolKeys(item.rawItem)].filter(
-        (runtimeToolKey) => !configuredToolKeys.has(runtimeToolKey),
+    const existingRuntimeTools = state.getToolSearchRuntimeTools(agent);
+    const enabledRuntimeTools = await getEnabledToolSearchRuntimeTools(
+      state,
+      agent,
+    );
+    const capabilities = resolveModelVisibleToolNameCollisions(
+      [...configuredTools, ...enabledRuntimeTools],
+      await agent.getEnabledHandoffs(state._context),
+      'warn',
+    );
+    const availableTools = [...capabilities.tools];
+    capabilitySnapshotsByAgent.set(agent, {
+      availableTools,
+      callbackTools: [...availableTools],
+      handoffs: capabilities.handoffs,
+      functionMap: buildFunctionToolLookupMap(
+        availableTools.filter((tool) => tool.type === 'function'),
       ),
+      functionToolsByCallId: new Map(),
+      runtimeFunctionTools: new Set(
+        existingRuntimeTools.filter(
+          (tool): tool is FunctionTool<TContext> => tool.type === 'function',
+        ),
+      ),
+      handoffMap: new Map(
+        capabilities.handoffs.map((handoff) => [handoff.toolName, handoff]),
+      ),
+      mcpToolMap: new Map(
+        availableTools
+          .filter(
+            (tool): tool is HostedMCPTool =>
+              tool.type === 'hosted_tool' && tool.providerData?.type === 'mcp',
+          )
+          .map((tool) => [tool.providerData.server_label, tool]),
+      ),
+      replaceableRuntimeToolKeys: new Set(
+        existingRuntimeTools
+          .map((tool) => getToolSearchRuntimeRoutingKey(tool))
+          .filter((key): key is string => typeof key === 'string'),
+      ),
+    });
+  }
+
+  assertDeferredFunctionCallProvenance({
+    expectations: deferredFunctionCallExpectations,
+    capabilitySnapshotsByAgent,
+    deferredToolSearchKeysByCallIdByAgent:
+      collectDeferredToolSearchProvenanceByCallId({
+        state: state as RunState<TContext, Agent<any, any>>,
+        effectiveToolSearchOutputs,
+        serializedRuntimeToolKeysByOutput,
+      }),
+  });
+
+  if (
+    options.schemaVersion === CURRENT_SCHEMA_VERSION &&
+    options.serializedProcessedResponse
+  ) {
+    const currentAgent = state._currentAgent as Agent<TContext, any>;
+    const currentSnapshot = capabilitySnapshotsByAgent.get(currentAgent)!;
+    for (const serializedHandoff of options.serializedProcessedResponse
+      .handoffs) {
+      if (!serializedHandoff.targetAgent) {
+        throw new UserError(
+          'Run state handoff is missing its required target agent identity.',
+        );
+      }
+      const targetAgent = resolveSerializedAgent(
+        serializedHandoff.targetAgent,
+        options.agentMap,
+      );
+      const handoff = currentSnapshot.handoffMap.get(
+        serializedHandoff.handoff.toolName,
+      );
+      if (!handoff || handoff.agent !== targetAgent) {
+        throw new UserError(
+          `Handoff ${serializedHandoff.handoff.toolName} not found`,
+        );
+      }
+    }
+  }
+
+  for (const agent of new Set(
+    effectiveToolSearchOutputs.map(
+      (item) => item.agent as Agent<TContext, any>,
+    ),
+  )) {
+    validateClientToolSearchSupport(
+      capabilitySnapshotsByAgent.get(agent)!.availableTools,
+    );
+  }
+
+  type ToolSearchRehydrationRecord = {
+    pendingCall: {
+      agent: Agent<TContext, any>;
+      toolSearchCall: protocol.ToolSearchCallItem;
+    };
+    expectedRuntimeToolKeys: Set<string>;
+    toolSearchTool?: Tool<TContext>;
+    runtimeTools?: Tool<TContext>[];
+  };
+  const rehydrationRecords = new Map<
+    RunToolSearchOutputItem,
+    ToolSearchRehydrationRecord
+  >();
+
+  for (const item of effectiveToolSearchOutputs) {
+    const callId = resolveToolSearchCallId(item.rawItem);
+    const agent = item.agent as Agent<TContext, any>;
+    const snapshot = capabilitySnapshotsByAgent.get(agent)!;
+    const expectedRuntimeToolKeys =
+      serializedRuntimeToolKeysByOutput.get(item)!;
+    const pendingCall = occurrencesByOutput.get(item)!.pendingCall;
+
+    const toolSearchTool = getClientToolSearchHelper(snapshot.availableTools);
+    const hasCustomExecutor = Boolean(
+      toolSearchTool && getClientToolSearchExecutor(toolSearchTool),
     );
     if (expectedRuntimeToolKeys.size === 0) {
+      rehydrationRecords.set(item, {
+        pendingCall,
+        expectedRuntimeToolKeys,
+        ...(hasCustomExecutor ? { toolSearchTool } : {}),
+      });
+      continue;
+    }
+    if (!hasCustomExecutor) {
+      const availableRuntimeToolKeys = getRuntimeToolKeys(
+        snapshot.availableTools,
+        { allowUnsupported: true },
+      );
+      if (
+        [...expectedRuntimeToolKeys].every((runtimeToolKey) =>
+          availableRuntimeToolKeys.has(runtimeToolKey),
+        )
+      ) {
+        rehydrationRecords.set(item, {
+          pendingCall,
+          expectedRuntimeToolKeys,
+        });
+        continue;
+      }
+      if (logger.dontLogToolData) {
+        throw new UserError(
+          'RunState cannot resume custom client tool_search because the agent no longer provides toolSearchTool({ execution: "client", execute }).',
+        );
+      }
+      throw new UserError(
+        `RunState cannot resume custom client tool_search call ${callId} for agent ${pendingCall.agent.name} because the agent no longer provides toolSearchTool({ execution: "client", execute }).`,
+      );
+    }
+    rehydrationRecords.set(item, {
+      pendingCall,
+      expectedRuntimeToolKeys,
+      toolSearchTool,
+    });
+  }
+
+  for (const generatedItem of state._generatedItems) {
+    if (!(generatedItem instanceof RunToolSearchOutputItem)) {
+      continue;
+    }
+    const record = rehydrationRecords.get(generatedItem);
+    if (!record?.toolSearchTool) {
+      continue;
+    }
+    const agent = record.pendingCall.agent;
+    const snapshot = capabilitySnapshotsByAgent.get(agent)!;
+    const { runtimeTools } = await executeCustomClientToolSearch({
+      agent,
+      runContext: state._context,
+      toolSearchCall: record.pendingCall.toolSearchCall,
+      toolSearchTool: record.toolSearchTool,
+      tools: snapshot.callbackTools,
+    });
+    assertRuntimeToolKeysMatch({
+      agent,
+      toolSearchCall: record.pendingCall.toolSearchCall,
+      expectedRuntimeToolKeys: record.expectedRuntimeToolKeys,
+      runtimeTools,
+    });
+    record.runtimeTools = runtimeTools;
+    snapshot.callbackTools.push(...runtimeTools);
+  }
+
+  for (const generatedItem of state._generatedItems) {
+    if (generatedItem instanceof RunToolSearchOutputItem) {
+      const record = rehydrationRecords.get(generatedItem);
+      if (!record?.runtimeTools) {
+        continue;
+      }
+      const agent = record.pendingCall.agent;
+      const snapshot = capabilitySnapshotsByAgent.get(agent)!;
+      const enabledRuntimeTools = await filterEnabledToolSearchRuntimeTools({
+        runtimeTools: record.runtimeTools,
+        runContext: state._context,
+        agent,
+      });
+      const replacedRuntimeTools = state.getToolSearchRuntimeToolsForOutput(
+        agent,
+        generatedItem.rawItem,
+      );
+      const registeredRuntimeTools = registerRuntimeToolSearchTools({
+        availableTools: snapshot.availableTools,
+        functionMap: snapshot.functionMap,
+        handoffMap: snapshot.handoffMap,
+        mcpToolMap: snapshot.mcpToolMap,
+        replaceableRuntimeToolKeys: snapshot.replaceableRuntimeToolKeys,
+        replacedRuntimeTools,
+        runtimeTools: enabledRuntimeTools,
+      });
+      for (const runtimeTool of registeredRuntimeTools) {
+        if (runtimeTool.type === 'function') {
+          snapshot.runtimeFunctionTools.add(runtimeTool);
+        }
+      }
+
+      state.recordToolSearchRuntimeTools(
+        agent,
+        generatedItem.rawItem,
+        registeredRuntimeTools,
+      );
       continue;
     }
 
-    const callId = resolveToolSearchCallId(item.rawItem);
-    const pendingCall = pendingToolSearchCalls
-      .get(item.agent as Agent<TContext, any>)
-      ?.get(callId);
-    if (!pendingCall) {
-      throw new UserError(
-        `RunState cannot resume custom client tool_search output ${callId} for agent ${item.agent.name} because the serialized state is missing the matching tool_search call item.`,
-      );
-    }
-
-    if (!pendingCall.runtimeTools) {
-      const availableTools = [
-        ...configuredTools,
-        ...state.getToolSearchRuntimeTools(pendingCall.agent),
-      ];
-      const toolSearchTool = getClientToolSearchHelper(configuredTools);
-      if (!toolSearchTool || !getClientToolSearchExecutor(toolSearchTool)) {
-        throw new UserError(
-          `RunState cannot resume custom client tool_search call ${callId} for agent ${pendingCall.agent.name} because the agent no longer provides toolSearchTool({ execution: "client", execute }).`,
-        );
+    if (
+      generatedItem instanceof RunToolCallItem &&
+      generatedItem.rawItem.type === 'function_call'
+    ) {
+      const agent = generatedItem.agent as Agent<TContext, any>;
+      const snapshot = capabilitySnapshotsByAgent.get(agent);
+      if (!snapshot) {
+        continue;
       }
-
-      const { runtimeTools } = await executeCustomClientToolSearch({
-        agent: pendingCall.agent,
-        runContext: state._context,
-        toolSearchCall: pendingCall.toolSearchCall,
-        toolSearchTool,
-        tools: availableTools,
-      });
-      const rehydratedRuntimeTools = runtimeTools.filter((tool) => {
-        const runtimeToolKey = getToolSearchRuntimeToolKey(tool);
-        if (!runtimeToolKey) {
-          throw new UserError(
-            'Client tool_search execute() returned an unsupported runtime tool during RunState rehydration.',
+      const functionTool = resolveFunctionToolCall(
+        generatedItem.rawItem,
+        snapshot.functionMap,
+      );
+      if (functionTool) {
+        if (snapshot.runtimeFunctionTools.has(functionTool)) {
+          snapshot.functionToolsByCallId.set(
+            generatedItem.rawItem.callId,
+            functionTool,
           );
         }
-        return !configuredToolKeys.has(runtimeToolKey);
-      });
-      assertRuntimeToolKeysMatch({
-        agent: pendingCall.agent,
-        toolSearchCall: pendingCall.toolSearchCall,
-        expectedRuntimeToolKeys,
-        runtimeTools: rehydratedRuntimeTools,
-      });
-      pendingCall.runtimeTools = rehydratedRuntimeTools;
+      }
     }
-
-    const runtimeTools = pendingCall.runtimeTools;
-    if (!runtimeTools) {
-      throw new UserError(
-        `RunState cannot resume custom client tool_search call ${callId} for agent ${pendingCall.agent.name} because no runtime tools were rehydrated.`,
-      );
-    }
-
-    state.recordToolSearchRuntimeTools(
-      pendingCall.agent,
-      item.rawItem,
-      runtimeTools,
-    );
   }
+
+  return capabilitySnapshotsByAgent;
 }
 
 async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
@@ -1669,6 +2500,8 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
     : buildAgentMap(initialAgent);
   const contextOverride = options.contextOverride;
   const contextStrategy = options.contextStrategy ?? 'merge';
+  const schemaVersion = stateJson.$schemaVersion as SupportedSchemaVersion;
+  let deferredLegacyApprovalContext: RunContext<TContext> | undefined;
 
   //
   // Rebuild the context
@@ -1676,17 +2509,48 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
   const context =
     contextOverride ??
     new RunContext<TContext>(stateJson.context.context as TContext);
+  context._validateFunctionApprovalOwners(
+    stateJson.context.functionApprovals ?? [],
+    agentMap,
+  );
   if (contextOverride) {
     if (contextStrategy === 'merge') {
-      context._mergeApprovals(stateJson.context.approvals);
+      if (schemaVersion === CURRENT_SCHEMA_VERSION) {
+        context._mergeApprovals(stateJson.context.approvals);
+        context._mergeFunctionApprovals(
+          stateJson.context.functionApprovals ?? [],
+          agentMap,
+        );
+        if (stateJson.context.legacyFunctionApprovalFallback === true) {
+          context._enableLegacyFunctionApprovalFallback();
+        }
+      } else {
+        deferredLegacyApprovalContext = new RunContext<TContext>(
+          stateJson.context.context as TContext,
+        );
+        deferredLegacyApprovalContext._rebuildApprovals(
+          stateJson.context.approvals,
+        );
+        deferredLegacyApprovalContext._enableLegacyFunctionApprovalFallback();
+      }
     }
   } else {
     context._rebuildApprovals(stateJson.context.approvals);
+    context._rebuildFunctionApprovals(
+      stateJson.context.functionApprovals ?? [],
+      agentMap,
+    );
+    if (
+      schemaVersion !== CURRENT_SCHEMA_VERSION ||
+      stateJson.context.legacyFunctionApprovalFallback === true
+    ) {
+      context._enableLegacyFunctionApprovalFallback();
+    }
   }
-  const shouldRestoreToolInput =
+  const shouldRestoreSerializedContext =
     !contextOverride || contextStrategy === 'merge';
   if (
-    shouldRestoreToolInput &&
+    shouldRestoreSerializedContext &&
     typeof stateJson.context.toolInput !== 'undefined' &&
     typeof context.toolInput === 'undefined'
   ) {
@@ -1741,6 +2605,7 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
   state._pendingAgentToolRuns = new Map(
     Object.entries(stateJson.pendingAgentToolRuns ?? {}),
   );
+  state._pendingAgentToolRunAliases = new Map();
 
   // rebuild current agent span
   if (stateJson.currentAgentSpan) {
@@ -1791,14 +2656,47 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
   state._currentTurnPersistedItemCount =
     stateJson.currentTurnPersistedItemCount ?? 0;
   state._sandbox = stateJson.sandbox ?? undefined;
-  await rehydrateToolSearchRuntimeTools(state);
+  const capabilitySnapshotsByAgent = await rehydrateToolSearchRuntimeTools(
+    state,
+    {
+      agentMap,
+      schemaVersion,
+      serializedProcessedResponse: stateJson.lastProcessedResponse,
+    },
+  );
+  const currentCapabilitySnapshot = capabilitySnapshotsByAgent.get(
+    state._currentAgent as Agent<TContext, any>,
+  );
   state._lastProcessedResponse = stateJson.lastProcessedResponse
     ? await deserializeProcessedResponse(
         agentMap,
         state,
         stateJson.lastProcessedResponse,
+        {
+          executionTools: currentCapabilitySnapshot!.availableTools,
+          executionHandoffs: currentCapabilitySnapshot!.handoffs,
+          executionFunctionToolsByCallId:
+            currentCapabilitySnapshot!.functionToolsByCallId,
+        },
       )
     : undefined;
+  restorePendingAgentToolRunAliases(
+    state,
+    stateJson.pendingAgentToolRunAliases ?? {},
+  );
+  const legacyFunctionApprovalKeys = migrateLegacyFunctionToolState(
+    state,
+    schemaVersion,
+    shouldRestoreSerializedContext,
+    deferredLegacyApprovalContext,
+  );
+  if (deferredLegacyApprovalContext) {
+    context._mergeApprovalsPreservingExactKeys(
+      deferredLegacyApprovalContext.toJSON().approvals,
+      legacyFunctionApprovalKeys,
+    );
+    context._enableLegacyFunctionApprovalFallback();
+  }
 
   if (stateJson.currentStep?.type === 'next_step_handoff') {
     state._currentStep = {
@@ -1809,15 +2707,21 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
       ) as TAgent,
     };
   } else if (stateJson.currentStep?.type === 'next_step_interruption') {
+    const interruptions = deserializeInterruptions(
+      stateJson.currentStep.data?.interruptions,
+      agentMap,
+      state._currentAgent,
+    );
+    rebindInterruptionFunctionToolStateKeys(
+      interruptions,
+      state._lastProcessedResponse,
+      state._currentAgent,
+    );
     state._currentStep = {
       type: 'next_step_interruption',
       data: {
         ...stateJson.currentStep.data,
-        interruptions: deserializeInterruptions(
-          stateJson.currentStep.data?.interruptions,
-          agentMap,
-          state._currentAgent,
-        ),
+        interruptions,
       },
     };
   }
@@ -1844,6 +2748,13 @@ export async function rehydrateProcessedResponseTools<
     state._lastProcessedResponse,
     agentIdentity.byAgent,
   );
+  const executionFunctionToolsByCallId = new Map(
+    state._lastProcessedResponse.functions.flatMap((functionCall) =>
+      functionCall.preserveToolOnExecutionRehydration
+        ? [[functionCall.toolCall.callId, functionCall.tool] as const]
+        : [],
+    ),
+  );
 
   state._lastProcessedResponse = await deserializeProcessedResponse(
     agentIdentity.byIdentity,
@@ -1851,6 +2762,7 @@ export async function rehydrateProcessedResponseTools<
     serializedProcessedResponse,
     {
       executionTools,
+      executionFunctionToolsByCallId,
       allowSerializedExecutionToolPlaceholder: false,
     },
   );
@@ -2002,6 +2914,20 @@ function serializeProcessedResponse<TContext>(
     newItems: processedResponse.newItems.map((item) =>
       serializeRunItem(item, agentIdentityKeys),
     ),
+    functions: processedResponse.functions.map(({ toolCall, tool }) => ({
+      toolCall,
+      tool,
+    })),
+    handoffs: processedResponse.handoffs.map(
+      ({ toolCall, handoff: processedHandoff }) => ({
+        toolCall,
+        handoff: processedHandoff,
+        targetAgent: serializeAgentReference(
+          processedHandoff.agent,
+          agentIdentityKeys,
+        ),
+      }),
+    ),
   } as z.infer<typeof serializedProcessedResponseSchema>;
 }
 
@@ -2108,6 +3034,7 @@ export function deserializeItem(
         serializedItem.rawItem,
         resolveSerializedAgent(serializedItem.agent, agentMap),
         serializedItem.toolName,
+        serializedItem.functionToolStateKey,
       );
   }
 }
@@ -2133,6 +3060,7 @@ function deserializeInterruptionItem(
         parsed.data.rawItem,
         mappedAgent,
         parsed.data.toolName,
+        parsed.data.functionToolStateKey,
       );
     }
 
@@ -2147,6 +3075,7 @@ function deserializeInterruptionItem(
   const value = serializedItem as {
     rawItem?: unknown;
     toolName?: unknown;
+    functionToolStateKey?: unknown;
     agent?: { name?: unknown; identity?: unknown };
   };
 
@@ -2190,11 +3119,16 @@ function deserializeInterruptionItem(
       : typeof rawItem.name === 'string'
         ? rawItem.name
         : undefined;
+  const functionToolStateKey =
+    typeof value.functionToolStateKey === 'string'
+      ? value.functionToolStateKey
+      : undefined;
 
   return new RunToolApprovalItem(
     value.rawItem as RunToolApprovalItem['rawItem'],
     mappedAgent,
     toolName,
+    functionToolStateKey,
   );
 }
 
@@ -2215,8 +3149,163 @@ function deserializeInterruptions(
     );
 }
 
+function rebindInterruptionFunctionToolStateKeys<TContext>(
+  interruptions: RunToolApprovalItem[],
+  processedResponse: ProcessedResponse<TContext> | undefined,
+  processedAgent: Agent<any, any>,
+): void {
+  if (!processedResponse) {
+    return;
+  }
+
+  const functionsByCallId = new Map(
+    processedResponse.functions.map((functionCall) => [
+      functionCall.toolCall.callId,
+      functionCall,
+    ]),
+  );
+  for (const interruption of interruptions) {
+    if (
+      interruption.agent !== processedAgent ||
+      interruption.rawItem.type !== 'function_call'
+    ) {
+      continue;
+    }
+    const functionCall = functionsByCallId.get(interruption.rawItem.callId);
+    const stateKey = functionCall
+      ? getFunctionToolStateKey(functionCall.tool)
+      : undefined;
+    if (stateKey) {
+      interruption.functionToolStateKey = stateKey;
+    }
+  }
+}
+
+function restorePendingAgentToolRunAliases<TContext>(
+  state: RunState<TContext, Agent<any, any>>,
+  serializedAliases: Record<string, string>,
+): void {
+  const aliasEntries = Object.entries(serializedAliases);
+  if (aliasEntries.length === 0) {
+    return;
+  }
+
+  const validAliases = new Map<string, string>();
+  for (const functionCall of state._lastProcessedResponse?.functions ?? []) {
+    const [canonicalToolName, ...aliases] = getFunctionToolStateKeys(
+      functionCall.tool,
+      functionCall.availableFunctionTools ?? [functionCall.tool],
+    );
+    if (!canonicalToolName) {
+      continue;
+    }
+    const callId = functionCall.toolCall.callId;
+    const canonicalKey = `${canonicalToolName}:${callId}`;
+    for (const alias of aliases) {
+      validAliases.set(`${alias}:${callId}`, canonicalKey);
+    }
+  }
+
+  for (const [aliasKey, canonicalKey] of aliasEntries) {
+    if (
+      validAliases.get(aliasKey) !== canonicalKey ||
+      !state._pendingAgentToolRuns.has(canonicalKey)
+    ) {
+      throw new UserError(
+        'Run state pending agent tool aliases do not match the reconstructed pending function calls.',
+      );
+    }
+  }
+
+  state._pendingAgentToolRunAliases = new Map(aliasEntries);
+}
+
+function migrateLegacyFunctionToolState<TContext>(
+  state: RunState<TContext, Agent<any, any>>,
+  schemaVersion: SupportedSchemaVersion,
+  migrateApprovals: boolean,
+  approvalContext: RunContext<TContext> = state._context,
+): Set<string> {
+  if (
+    schemaVersion === CURRENT_SCHEMA_VERSION ||
+    !state._lastProcessedResponse
+  ) {
+    return new Set();
+  }
+
+  const approvalCallsByLegacyKey = new Map<string, Map<string, string[]>>();
+  const approvalOwnersByLegacyKey = new Map<string, Set<string>>();
+  for (const functionCall of state._lastProcessedResponse.functions) {
+    for (const tool of functionCall.availableFunctionTools ?? [
+      functionCall.tool,
+    ]) {
+      const canonicalKey = getFunctionToolStateKey(tool);
+      const legacyKey = getFunctionToolQualifiedName(tool) ?? tool.name;
+      if (!canonicalKey || canonicalKey === legacyKey) {
+        continue;
+      }
+      const canonicalOwners =
+        approvalOwnersByLegacyKey.get(legacyKey) ?? new Set<string>();
+      canonicalOwners.add(canonicalKey);
+      approvalOwnersByLegacyKey.set(legacyKey, canonicalOwners);
+    }
+  }
+
+  for (const functionCall of state._lastProcessedResponse.functions) {
+    const canonicalKey = getFunctionToolStateKey(functionCall.tool);
+    const legacyKey =
+      getFunctionToolQualifiedName(functionCall.tool) ?? functionCall.tool.name;
+    if (!canonicalKey || canonicalKey === legacyKey) {
+      continue;
+    }
+    const callId = functionCall.toolCall.callId;
+    const pendingState = state.getPendingAgentToolRun(legacyKey, callId);
+    if (pendingState !== undefined) {
+      state.setPendingAgentToolRun(canonicalKey, callId, pendingState, [
+        legacyKey,
+      ]);
+    }
+    if (!migrateApprovals) {
+      continue;
+    }
+    const callsByCanonicalKey =
+      approvalCallsByLegacyKey.get(legacyKey) ?? new Map<string, string[]>();
+    const callIds = callsByCanonicalKey.get(canonicalKey) ?? [];
+    callIds.push(callId);
+    callsByCanonicalKey.set(canonicalKey, callIds);
+    approvalCallsByLegacyKey.set(legacyKey, callsByCanonicalKey);
+  }
+
+  if (migrateApprovals) {
+    for (const [legacyKey, canonicalOwners] of approvalOwnersByLegacyKey) {
+      if (canonicalOwners.size !== 1) {
+        continue;
+      }
+      const [canonicalKey] = canonicalOwners;
+      approvalContext._migrateToolApproval(legacyKey, canonicalKey!, [], true);
+    }
+  }
+
+  for (const [legacyKey, callsByCanonicalKey] of approvalCallsByLegacyKey) {
+    for (const [canonicalKey, callIds] of callsByCanonicalKey) {
+      const canonicalOwners = approvalOwnersByLegacyKey.get(legacyKey);
+      const migratePermanentDecision =
+        canonicalOwners?.size === 1 && canonicalOwners.has(canonicalKey);
+      approvalContext._migrateToolApproval(
+        legacyKey,
+        canonicalKey,
+        callIds,
+        migratePermanentDecision,
+      );
+    }
+  }
+  return new Set(approvalOwnersByLegacyKey.keys());
+}
+
 type DeserializeProcessedResponseOptions<TContext> = {
   executionTools?: Tool<TContext>[];
+  executionHandoffs?: Handoff<any, any>[];
+  executionFunctionToolsByCallId?: Map<string, FunctionTool<TContext>>;
   allowSerializedExecutionToolPlaceholder?: boolean;
 };
 
@@ -2232,19 +3321,19 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
   options: DeserializeProcessedResponseOptions<TContext> = {},
 ): Promise<ProcessedResponse<TContext>> {
   const currentAgent = state._currentAgent;
-  const configuredTools =
-    options.executionTools ?? (await currentAgent.getAllTools(state._context));
-  const allTools = [
-    ...(configuredTools as Tool<TContext>[]),
-    ...state.getToolSearchRuntimeTools(currentAgent),
-  ];
+  const allTools = options.executionTools
+    ? options.executionTools
+    : [
+        ...((await currentAgent.getAllTools(
+          state._context,
+        )) as Tool<TContext>[]),
+        ...(await getEnabledToolSearchRuntimeTools(state, currentAgent)),
+      ];
   const baseAgentTools = currentAgent.tools as Tool<TContext>[];
   const allowSerializedExecutionToolPlaceholder =
     options.allowSerializedExecutionToolPlaceholder ?? true;
-  const tools = new Map(
-    allTools
-      .filter((tool) => tool.type === 'function')
-      .map((tool) => [getFunctionToolQualifiedName(tool) ?? tool.name, tool]),
+  const tools = buildFunctionToolLookupMap(
+    allTools.filter((tool) => tool.type === 'function'),
   );
   const computerTools = new Map(
     allTools
@@ -2287,14 +3376,11 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
       )
       .map((tool) => [tool.providerData.server_label, tool]),
   );
+  const enabledHandoffs = options.executionHandoffs
+    ? options.executionHandoffs
+    : await currentAgent.getEnabledHandoffs(state._context);
   const handoffs = new Map(
-    currentAgent.handoffs.map((entry) => {
-      if (entry instanceof Agent) {
-        return [entry.name, handoff(entry)];
-      }
-
-      return [entry.toolName, entry];
-    }),
+    enabledHandoffs.map((entry) => [entry.toolName, entry]),
   );
 
   const result = {
@@ -2302,31 +3388,60 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
       deserializeItem(item, agentMap),
     ),
     toolsUsed: serializedProcessedResponse.toolsUsed,
-    handoffs: serializedProcessedResponse.handoffs.map((handoff) => {
-      if (!handoffs.has(handoff.handoff.toolName)) {
-        throw new UserError(`Handoff ${handoff.handoff.toolName} not found`);
+    handoffs: serializedProcessedResponse.handoffs.map((serializedHandoff) => {
+      const toolName = serializedHandoff.handoff.toolName;
+      const resolvedHandoff = handoffs.get(toolName);
+      const serializedTargetAgent = serializedHandoff.targetAgent
+        ? resolveSerializedAgent(serializedHandoff.targetAgent, agentMap)
+        : undefined;
+      const targetMatches = serializedTargetAgent
+        ? resolvedHandoff?.agent === serializedTargetAgent
+        : resolvedHandoff?.agentName === serializedHandoff.handoff.agentName;
+      if (!resolvedHandoff || !targetMatches) {
+        throw new UserError(`Handoff ${toolName} not found`);
       }
-
-      const resolvedHandoff = handoffs.get(handoff.handoff.toolName)!;
       ensureToolCallerAllowed(
-        handoff.toolCall as protocol.FunctionCallItem,
+        serializedHandoff.toolCall as protocol.FunctionCallItem,
         undefined,
         resolvedHandoff.toolName,
         currentAgent,
       );
 
       return {
-        toolCall: handoff.toolCall,
+        toolCall: serializedHandoff.toolCall,
         handoff: resolvedHandoff,
       };
     }),
     functions: await Promise.all(
       serializedProcessedResponse.functions.map(async (functionCall) => {
         const toolIdentity =
-          resolveFunctionToolCallName(functionCall.toolCall, tools) ??
+          getToolCallDisplayName(functionCall.toolCall) ??
           functionCall.tool.name;
+        const exactRuntimeTool = options.executionFunctionToolsByCallId?.get(
+          functionCall.toolCall.callId,
+        );
+        if (
+          exactRuntimeTool &&
+          !getFunctionToolStateKeyForResolvedCall(
+            functionCall.toolCall as protocol.FunctionCallItem,
+            exactRuntimeTool,
+          )
+        ) {
+          throwAmbiguousFunctionCallId(
+            currentAgent,
+            functionCall.toolCall.callId,
+            [
+              getFunctionToolStateKey(exactRuntimeTool) ??
+                exactRuntimeTool.name,
+              getFunctionToolStateKeyForCall(
+                functionCall.toolCall as protocol.FunctionCallItem,
+              ) ?? functionCall.tool.name,
+            ],
+          );
+        }
         const resolvedTool =
-          tools.get(toolIdentity) ??
+          exactRuntimeTool ??
+          resolveFunctionToolCall(functionCall.toolCall, tools) ??
           getSerializedFunctionToolPlaceholder({
             agent: currentAgent,
             baseAgentTools,
@@ -2346,10 +3461,14 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
           currentAgent,
         );
 
-        return {
+        return createToolRunFunction({
           toolCall: functionCall.toolCall,
           tool: resolvedTool,
-        };
+          availableFunctionTools: [
+            ...new Set([...tools.values(), resolvedTool]),
+          ],
+          preserveToolOnExecutionRehydration: Boolean(exactRuntimeTool),
+        });
       }),
     ),
     functionToolsNotFound:
@@ -2485,4 +3604,15 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
       );
     },
   };
+}
+
+async function getEnabledToolSearchRuntimeTools<TContext>(
+  state: RunState<TContext, Agent<any, any>>,
+  agent: Agent<any, any>,
+): Promise<Tool<TContext>[]> {
+  return filterEnabledToolSearchRuntimeTools({
+    runtimeTools: state.getToolSearchRuntimeTools(agent),
+    runContext: state._context,
+    agent,
+  });
 }

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -55,6 +55,7 @@ import {
   buildFunctionToolLookupMap,
   type FunctionToolLookupKey,
   getFunctionToolLookupKey,
+  getFunctionToolLegacyStateKeyFromStateKey,
   getFunctionToolQualifiedName,
   getFunctionToolStateKey,
   getFunctionToolStateKeyForCall,
@@ -446,16 +447,28 @@ const approvalRecordSchema = z.object({
   stickyRejectMessage: z.string().optional(),
 });
 
+const canonicalFunctionToolStateKeySchema = z
+  .string()
+  .refine(
+    (value) => getFunctionToolLegacyStateKeyFromStateKey(value) !== undefined,
+    'Function approval keys must use a canonical category-aware identity.',
+  );
+
 const functionApprovalsSchema = z.array(
   z.object({
     agentIdentity: z.string(),
-    approvals: z.record(z.string(), approvalRecordSchema),
+    approvals: z.record(
+      canonicalFunctionToolStateKeySchema,
+      approvalRecordSchema,
+    ),
   }),
 );
 
 const functionApprovalContextSchema = z.object({
   functionApprovals: functionApprovalsSchema.optional(),
-  legacyFunctionApprovalFallback: z.boolean().optional(),
+  legacyFunctionApprovals: z
+    .record(z.string(), approvalRecordSchema)
+    .optional(),
 });
 
 export const SerializedRunState = z.object({
@@ -468,7 +481,9 @@ export const SerializedRunState = z.object({
     usage: usageSchema,
     approvals: z.record(z.string(), approvalRecordSchema),
     functionApprovals: functionApprovalsSchema.optional(),
-    legacyFunctionApprovalFallback: z.boolean().optional(),
+    legacyFunctionApprovals: z
+      .record(z.string(), approvalRecordSchema)
+      .optional(),
     context: z.record(z.string(), z.any()),
     toolInput: z.any().optional(),
   }),
@@ -1215,11 +1230,11 @@ function validateFunctionApprovalEnvelope(
     context,
     'functionApprovals',
   );
-  const hasLegacyFallback = Object.prototype.hasOwnProperty.call(
+  const hasLegacyFunctionApprovals = Object.prototype.hasOwnProperty.call(
     context,
-    'legacyFunctionApprovalFallback',
+    'legacyFunctionApprovals',
   );
-  if (!hasFunctionApprovals && !hasLegacyFallback) {
+  if (!hasFunctionApprovals && !hasLegacyFunctionApprovals) {
     return;
   }
   if (schemaVersion !== CURRENT_SCHEMA_VERSION) {
@@ -1697,14 +1712,19 @@ function formatRuntimeToolKeys(runtimeToolKeys: Set<string>): string {
   return [...runtimeToolKeys].sort().join(', ');
 }
 
-function assertRuntimeToolKeysMatch<TContext>(args: {
+function selectSerializedRuntimeTools<TContext>(args: {
   agent: Agent<any, any>;
   toolSearchCall: protocol.ToolSearchCallItem;
   expectedRuntimeToolKeys: Set<string>;
-  runtimeTools: Tool<TContext>[];
-}): void {
-  const { agent, toolSearchCall, expectedRuntimeToolKeys, runtimeTools } = args;
-  const actualRuntimeToolKeys = getRuntimeToolKeys(runtimeTools, {
+  enabledRuntimeTools: Tool<TContext>[];
+}): Tool<TContext>[] {
+  const {
+    agent,
+    toolSearchCall,
+    expectedRuntimeToolKeys,
+    enabledRuntimeTools,
+  } = args;
+  const actualRuntimeToolKeys = getRuntimeToolKeys(enabledRuntimeTools, {
     rejectDuplicateKeys: true,
   });
   const hasExpectedKeys = [...expectedRuntimeToolKeys].every((runtimeToolKey) =>
@@ -1714,7 +1734,12 @@ function assertRuntimeToolKeysMatch<TContext>(args: {
     expectedRuntimeToolKeys.has(runtimeToolKey),
   );
   if (hasExpectedKeys && hasActualKeys) {
-    return;
+    return enabledRuntimeTools.filter((runtimeTool) => {
+      const runtimeToolKey = getToolSearchRuntimeRoutingKey(runtimeTool);
+      return (
+        runtimeToolKey != null && expectedRuntimeToolKeys.has(runtimeToolKey)
+      );
+    });
   }
 
   if (logger.dontLogToolData) {
@@ -1952,7 +1977,12 @@ function assertUnambiguousFunctionCallIds<
     const expectedRoutedToolKey =
       processedIdentity?.resolvedRoutedToolKey ?? rawItemRoutedToolKey;
     if (typeof interruption.functionToolStateKey === 'string') {
-      if (interruption.functionToolStateKey !== expectedRoutedToolKey) {
+      const validationRequiresPendingNestedState =
+        interruptionAgent !== state._currentAgent && !processedIdentity;
+      if (
+        !validationRequiresPendingNestedState &&
+        interruption.functionToolStateKey !== expectedRoutedToolKey
+      ) {
         throwAmbiguousFunctionCallId(interruptionAgent, rawItem.callId, [
           expectedRoutedToolKey,
           interruption.functionToolStateKey,
@@ -2115,6 +2145,7 @@ async function rehydrateToolSearchRuntimeTools<
     serializedProcessedResponse?: z.infer<
       typeof serializedProcessedResponseSchema
     >;
+    prepareCurrentAgentForLegacyApprovals?: boolean;
   },
 ): Promise<Map<Agent<TContext, any>, RunStateCapabilitySnapshot<TContext>>> {
   const deferredFunctionCallExpectations = assertUnambiguousFunctionCallIds(
@@ -2227,6 +2258,9 @@ async function rehydrateToolSearchRuntimeTools<
     ),
   );
   if (options.serializedProcessedResponse) {
+    agentsToPrepare.add(state._currentAgent as Agent<TContext, any>);
+  }
+  if (options.prepareCurrentAgentForLegacyApprovals) {
     agentsToPrepare.add(state._currentAgent as Agent<TContext, any>);
   }
 
@@ -2404,21 +2438,22 @@ async function rehydrateToolSearchRuntimeTools<
     }
     const agent = record.pendingCall.agent;
     const snapshot = capabilitySnapshotsByAgent.get(agent)!;
-    const { runtimeTools } = await executeCustomClientToolSearch({
-      agent,
-      runContext: state._context,
-      toolSearchCall: record.pendingCall.toolSearchCall,
-      toolSearchTool: record.toolSearchTool,
-      tools: snapshot.callbackTools,
-    });
-    assertRuntimeToolKeysMatch({
+    const { runtimeTools, callbackRuntimeTools } =
+      await executeCustomClientToolSearch({
+        agent,
+        runContext: state._context,
+        toolSearchCall: record.pendingCall.toolSearchCall,
+        toolSearchTool: record.toolSearchTool,
+        tools: snapshot.callbackTools,
+      });
+    const serializedRuntimeTools = selectSerializedRuntimeTools({
       agent,
       toolSearchCall: record.pendingCall.toolSearchCall,
       expectedRuntimeToolKeys: record.expectedRuntimeToolKeys,
-      runtimeTools,
+      enabledRuntimeTools: runtimeTools,
     });
-    record.runtimeTools = runtimeTools;
-    snapshot.callbackTools.push(...runtimeTools);
+    record.runtimeTools = serializedRuntimeTools;
+    snapshot.callbackTools.push(...callbackRuntimeTools);
   }
 
   for (const generatedItem of state._generatedItems) {
@@ -2429,11 +2464,6 @@ async function rehydrateToolSearchRuntimeTools<
       }
       const agent = record.pendingCall.agent;
       const snapshot = capabilitySnapshotsByAgent.get(agent)!;
-      const enabledRuntimeTools = await filterEnabledToolSearchRuntimeTools({
-        runtimeTools: record.runtimeTools,
-        runContext: state._context,
-        agent,
-      });
       const replacedRuntimeTools = state.getToolSearchRuntimeToolsForOutput(
         agent,
         generatedItem.rawItem,
@@ -2445,7 +2475,7 @@ async function rehydrateToolSearchRuntimeTools<
         mcpToolMap: snapshot.mcpToolMap,
         replaceableRuntimeToolKeys: snapshot.replaceableRuntimeToolKeys,
         replacedRuntimeTools,
-        runtimeTools: enabledRuntimeTools,
+        runtimeTools: record.runtimeTools,
       });
       for (const runtimeTool of registeredRuntimeTools) {
         if (runtimeTool.type === 'function') {
@@ -2521,9 +2551,9 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
           stateJson.context.functionApprovals ?? [],
           agentMap,
         );
-        if (stateJson.context.legacyFunctionApprovalFallback === true) {
-          context._enableLegacyFunctionApprovalFallback();
-        }
+        context._mergeLegacyFunctionApprovals(
+          stateJson.context.legacyFunctionApprovals ?? {},
+        );
       } else {
         deferredLegacyApprovalContext = new RunContext<TContext>(
           stateJson.context.context as TContext,
@@ -2531,7 +2561,9 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
         deferredLegacyApprovalContext._rebuildApprovals(
           stateJson.context.approvals,
         );
-        deferredLegacyApprovalContext._enableLegacyFunctionApprovalFallback();
+        deferredLegacyApprovalContext._rebuildLegacyFunctionApprovals(
+          stateJson.context.approvals,
+        );
       }
     }
   } else {
@@ -2540,12 +2572,11 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
       stateJson.context.functionApprovals ?? [],
       agentMap,
     );
-    if (
-      schemaVersion !== CURRENT_SCHEMA_VERSION ||
-      stateJson.context.legacyFunctionApprovalFallback === true
-    ) {
-      context._enableLegacyFunctionApprovalFallback();
-    }
+    context._rebuildLegacyFunctionApprovals(
+      schemaVersion === CURRENT_SCHEMA_VERSION
+        ? (stateJson.context.legacyFunctionApprovals ?? {})
+        : stateJson.context.approvals,
+    );
   }
   const shouldRestoreSerializedContext =
     !contextOverride || contextStrategy === 'merge';
@@ -2662,6 +2693,10 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
       agentMap,
       schemaVersion,
       serializedProcessedResponse: stateJson.lastProcessedResponse,
+      prepareCurrentAgentForLegacyApprovals:
+        schemaVersion !== CURRENT_SCHEMA_VERSION &&
+        shouldRestoreSerializedContext &&
+        Object.keys(stateJson.context.approvals).length > 0,
     },
   );
   const currentCapabilitySnapshot = capabilitySnapshotsByAgent.get(
@@ -2684,20 +2719,6 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
     state,
     stateJson.pendingAgentToolRunAliases ?? {},
   );
-  const legacyFunctionApprovalKeys = migrateLegacyFunctionToolState(
-    state,
-    schemaVersion,
-    shouldRestoreSerializedContext,
-    deferredLegacyApprovalContext,
-  );
-  if (deferredLegacyApprovalContext) {
-    context._mergeApprovalsPreservingExactKeys(
-      deferredLegacyApprovalContext.toJSON().approvals,
-      legacyFunctionApprovalKeys,
-    );
-    context._enableLegacyFunctionApprovalFallback();
-  }
-
   if (stateJson.currentStep?.type === 'next_step_handoff') {
     state._currentStep = {
       type: 'next_step_handoff',
@@ -2716,6 +2737,8 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
       interruptions,
       state._lastProcessedResponse,
       state._currentAgent,
+      state,
+      schemaVersion,
     );
     state._currentStep = {
       type: 'next_step_interruption',
@@ -2724,6 +2747,52 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
         interruptions,
       },
     };
+  }
+  const legacyAvailableToolsByAgent = new Map<
+    Agent<any, any>,
+    Tool<TContext>[]
+  >();
+  for (const agent of new Set(agentMap.values())) {
+    legacyAvailableToolsByAgent.set(agent, [
+      ...(agent.tools as Tool<TContext>[]),
+    ]);
+  }
+  for (const [agent, snapshot] of capabilitySnapshotsByAgent) {
+    const configuredTools = legacyAvailableToolsByAgent.get(agent) ?? [];
+    legacyAvailableToolsByAgent.set(agent, [
+      ...new Set([...configuredTools, ...snapshot.availableTools]),
+    ]);
+  }
+  const legacyFunctionApprovalKeys = migrateLegacyFunctionToolState(
+    state,
+    schemaVersion,
+    shouldRestoreSerializedContext,
+    deferredLegacyApprovalContext,
+    legacyAvailableToolsByAgent,
+  );
+  const legacyApprovalContext = deferredLegacyApprovalContext ?? context;
+  if (schemaVersion !== CURRENT_SCHEMA_VERSION) {
+    legacyApprovalContext._retainLegacyFunctionApprovals(
+      legacyFunctionApprovalKeys,
+    );
+    legacyApprovalContext._removeMigratedFunctionApprovalsFromAggregate(
+      legacyFunctionApprovalKeys,
+      new Set(
+        [...legacyAvailableToolsByAgent.values()].flatMap((tools) =>
+          tools.flatMap((tool) =>
+            tool.type !== 'function' && typeof tool.name === 'string'
+              ? [tool.name]
+              : [],
+          ),
+        ),
+      ),
+    );
+  }
+  if (deferredLegacyApprovalContext) {
+    context._mergeApprovalStatePreservingExactKeys(
+      deferredLegacyApprovalContext,
+      legacyFunctionApprovalKeys,
+    );
   }
   return state;
 }
@@ -3153,8 +3222,26 @@ function rebindInterruptionFunctionToolStateKeys<TContext>(
   interruptions: RunToolApprovalItem[],
   processedResponse: ProcessedResponse<TContext> | undefined,
   processedAgent: Agent<any, any>,
+  state: RunState<TContext, Agent<any, any>>,
+  schemaVersion: SupportedSchemaVersion,
 ): void {
   if (!processedResponse) {
+    for (const interruption of interruptions) {
+      if (
+        interruption.rawItem.type !== 'function_call' ||
+        !interruption.functionToolStateKey
+      ) {
+        continue;
+      }
+      const rawStateKey = getFunctionToolStateKeyForCall(interruption.rawItem);
+      if (rawStateKey && interruption.functionToolStateKey !== rawStateKey) {
+        throwAmbiguousFunctionCallId(
+          interruption.agent,
+          interruption.rawItem.callId,
+          [rawStateKey, interruption.functionToolStateKey],
+        );
+      }
+    }
     return;
   }
 
@@ -3165,20 +3252,169 @@ function rebindInterruptionFunctionToolStateKeys<TContext>(
     ]),
   );
   for (const interruption of interruptions) {
-    if (
-      interruption.agent !== processedAgent ||
-      interruption.rawItem.type !== 'function_call'
-    ) {
+    if (interruption.rawItem.type !== 'function_call') {
       continue;
     }
-    const functionCall = functionsByCallId.get(interruption.rawItem.callId);
-    const stateKey = functionCall
-      ? getFunctionToolStateKey(functionCall.tool)
-      : undefined;
+    let stateKey: string | undefined;
+    if (interruption.agent === processedAgent) {
+      stateKey = getFunctionToolStateKey(
+        functionsByCallId.get(interruption.rawItem.callId)?.tool,
+      );
+    } else {
+      stateKey = findNestedInterruptionFunctionToolStateKey(
+        state,
+        interruption,
+      );
+      if (schemaVersion === CURRENT_SCHEMA_VERSION) {
+        const rawStateKey = getFunctionToolStateKeyForCall(
+          interruption.rawItem,
+        );
+        const serializedStateKey = interruption.functionToolStateKey;
+        const expectedStateKey = stateKey ?? rawStateKey;
+        if (
+          serializedStateKey &&
+          expectedStateKey &&
+          serializedStateKey !== expectedStateKey
+        ) {
+          throwAmbiguousFunctionCallId(
+            interruption.agent,
+            interruption.rawItem.callId,
+            [expectedStateKey, serializedStateKey],
+          );
+        }
+      }
+    }
     if (stateKey) {
       interruption.functionToolStateKey = stateKey;
     }
   }
+}
+
+function findNestedInterruptionFunctionToolStateKey<TContext>(
+  state: RunState<TContext, Agent<any, any>>,
+  interruption: RunToolApprovalItem,
+): string | undefined {
+  if (interruption.rawItem.type !== 'function_call') {
+    return undefined;
+  }
+
+  const serializedPendingStates = new Set<string>();
+  for (const functionCall of state._lastProcessedResponse?.functions ?? []) {
+    if (getAgentToolSourceAgent(functionCall.tool) !== interruption.agent) {
+      continue;
+    }
+    const stateKeys = getFunctionToolStateKeys(
+      functionCall.tool,
+      functionCall.availableFunctionTools ?? [functionCall.tool],
+    );
+    for (const stateKey of stateKeys) {
+      const serializedState = state.getPendingAgentToolRun(
+        stateKey,
+        functionCall.toolCall.callId,
+      );
+      if (serializedState) {
+        serializedPendingStates.add(serializedState);
+      }
+    }
+  }
+
+  const resolvedStateKeys = new Set<string>();
+  for (const serializedState of serializedPendingStates) {
+    const resolvedStateKey =
+      getSerializedNestedInterruptionFunctionToolStateKey(
+        serializedState,
+        interruption.rawItem,
+      );
+    if (resolvedStateKey) {
+      resolvedStateKeys.add(resolvedStateKey);
+    }
+  }
+  if (resolvedStateKeys.size > 1) {
+    throwAmbiguousFunctionCallId(
+      interruption.agent,
+      interruption.rawItem.callId,
+      [...resolvedStateKeys],
+    );
+  }
+  return resolvedStateKeys.values().next().value;
+}
+
+function getSerializedNestedInterruptionFunctionToolStateKey(
+  serializedState: string,
+  interruptionRawItem: protocol.FunctionCallItem,
+): string | undefined {
+  let nestedState: unknown;
+  try {
+    nestedState = JSON.parse(serializedState);
+  } catch {
+    return undefined;
+  }
+  if (!nestedState || typeof nestedState !== 'object') {
+    return undefined;
+  }
+
+  const candidate = nestedState as {
+    currentStep?: {
+      type?: unknown;
+      data?: { interruptions?: unknown };
+    };
+    lastProcessedResponse?: {
+      functions?: unknown;
+    };
+  };
+  if (
+    candidate.currentStep?.type !== 'next_step_interruption' ||
+    !Array.isArray(candidate.currentStep.data?.interruptions) ||
+    !candidate.currentStep.data.interruptions.some((value) => {
+      if (!value || typeof value !== 'object') {
+        return false;
+      }
+      const rawItem = (value as { rawItem?: unknown }).rawItem;
+      return (
+        rawItem != null &&
+        typeof rawItem === 'object' &&
+        (rawItem as { type?: unknown }).type === 'function_call' &&
+        (rawItem as { callId?: unknown }).callId ===
+          interruptionRawItem.callId &&
+        getFunctionToolStateKeyForCall(rawItem as protocol.FunctionCallItem) ===
+          getFunctionToolStateKeyForCall(interruptionRawItem)
+      );
+    }) ||
+    !Array.isArray(candidate.lastProcessedResponse?.functions)
+  ) {
+    return undefined;
+  }
+
+  const stateKeys = new Set<string>();
+  for (const value of candidate.lastProcessedResponse.functions) {
+    if (!value || typeof value !== 'object') {
+      continue;
+    }
+    const functionCall = value as { toolCall?: unknown; tool?: unknown };
+    if (
+      !functionCall.toolCall ||
+      typeof functionCall.toolCall !== 'object' ||
+      (functionCall.toolCall as { callId?: unknown }).callId !==
+        interruptionRawItem.callId
+    ) {
+      continue;
+    }
+    const stateKey = getFunctionToolStateKey(functionCall.tool);
+    if (
+      stateKey &&
+      getFunctionToolStateKeyForResolvedCall(
+        interruptionRawItem,
+        functionCall.tool,
+        stateKey,
+      ) === stateKey
+    ) {
+      stateKeys.add(stateKey);
+    }
+  }
+  if (stateKeys.size !== 1) {
+    return undefined;
+  }
+  return stateKeys.values().next().value;
 }
 
 function restorePendingAgentToolRunAliases<TContext>(
@@ -3225,33 +3461,69 @@ function migrateLegacyFunctionToolState<TContext>(
   schemaVersion: SupportedSchemaVersion,
   migrateApprovals: boolean,
   approvalContext: RunContext<TContext> = state._context,
+  availableToolsByAgent: ReadonlyMap<
+    Agent<any, any>,
+    readonly Tool<TContext>[]
+  > = new Map(),
 ): Set<string> {
-  if (
-    schemaVersion === CURRENT_SCHEMA_VERSION ||
-    !state._lastProcessedResponse
-  ) {
+  if (schemaVersion === CURRENT_SCHEMA_VERSION) {
     return new Set();
   }
 
-  const approvalCallsByLegacyKey = new Map<string, Map<string, string[]>>();
-  const approvalOwnersByLegacyKey = new Map<string, Set<string>>();
-  for (const functionCall of state._lastProcessedResponse.functions) {
-    for (const tool of functionCall.availableFunctionTools ?? [
-      functionCall.tool,
-    ]) {
+  const approvalCallsByLegacyKey = new Map<
+    string,
+    Map<Agent<any, any>, Map<string, Set<string>>>
+  >();
+  const approvalOwnersByLegacyKey = new Map<
+    string,
+    Map<Agent<any, any>, Set<string>>
+  >();
+  const addApprovalOwner = (
+    legacyKey: string,
+    agent: Agent<any, any>,
+    canonicalKey: string,
+  ) => {
+    const ownersByAgent =
+      approvalOwnersByLegacyKey.get(legacyKey) ??
+      new Map<Agent<any, any>, Set<string>>();
+    const ownerKeys = ownersByAgent.get(agent) ?? new Set<string>();
+    ownerKeys.add(canonicalKey);
+    ownersByAgent.set(agent, ownerKeys);
+    approvalOwnersByLegacyKey.set(legacyKey, ownersByAgent);
+  };
+  const addApprovalCall = (
+    legacyKey: string,
+    agent: Agent<any, any>,
+    canonicalKey: string,
+    callId: string,
+  ) => {
+    addApprovalOwner(legacyKey, agent, canonicalKey);
+    const callsByAgent =
+      approvalCallsByLegacyKey.get(legacyKey) ??
+      new Map<Agent<any, any>, Map<string, Set<string>>>();
+    const callsByCanonicalKey =
+      callsByAgent.get(agent) ?? new Map<string, Set<string>>();
+    const callIds = callsByCanonicalKey.get(canonicalKey) ?? new Set<string>();
+    callIds.add(callId);
+    callsByCanonicalKey.set(canonicalKey, callIds);
+    callsByAgent.set(agent, callsByCanonicalKey);
+    approvalCallsByLegacyKey.set(legacyKey, callsByAgent);
+  };
+  for (const [agent, availableTools] of availableToolsByAgent) {
+    for (const tool of availableTools) {
+      if (tool.type !== 'function') {
+        continue;
+      }
       const canonicalKey = getFunctionToolStateKey(tool);
       const legacyKey = getFunctionToolQualifiedName(tool) ?? tool.name;
       if (!canonicalKey || canonicalKey === legacyKey) {
         continue;
       }
-      const canonicalOwners =
-        approvalOwnersByLegacyKey.get(legacyKey) ?? new Set<string>();
-      canonicalOwners.add(canonicalKey);
-      approvalOwnersByLegacyKey.set(legacyKey, canonicalOwners);
+      addApprovalOwner(legacyKey, agent, canonicalKey);
     }
   }
 
-  for (const functionCall of state._lastProcessedResponse.functions) {
+  for (const functionCall of state._lastProcessedResponse?.functions ?? []) {
     const canonicalKey = getFunctionToolStateKey(functionCall.tool);
     const legacyKey =
       getFunctionToolQualifiedName(functionCall.tool) ?? functionCall.tool.name;
@@ -3268,35 +3540,76 @@ function migrateLegacyFunctionToolState<TContext>(
     if (!migrateApprovals) {
       continue;
     }
-    const callsByCanonicalKey =
-      approvalCallsByLegacyKey.get(legacyKey) ?? new Map<string, string[]>();
-    const callIds = callsByCanonicalKey.get(canonicalKey) ?? [];
-    callIds.push(callId);
-    callsByCanonicalKey.set(canonicalKey, callIds);
-    approvalCallsByLegacyKey.set(legacyKey, callsByCanonicalKey);
+    addApprovalCall(legacyKey, state._currentAgent, canonicalKey, callId);
   }
 
-  if (migrateApprovals) {
-    for (const [legacyKey, canonicalOwners] of approvalOwnersByLegacyKey) {
-      if (canonicalOwners.size !== 1) {
+  if (state._currentStep?.type === 'next_step_interruption') {
+    for (const interruption of state._currentStep.data.interruptions) {
+      if (
+        interruption.rawItem.type !== 'function_call' ||
+        !interruption.functionToolStateKey
+      ) {
         continue;
       }
-      const [canonicalKey] = canonicalOwners;
-      approvalContext._migrateToolApproval(legacyKey, canonicalKey!, [], true);
+      const legacyKey = getFunctionToolLegacyStateKeyFromStateKey(
+        interruption.functionToolStateKey,
+      );
+      if (!legacyKey) {
+        continue;
+      }
+      addApprovalCall(
+        legacyKey,
+        interruption.agent,
+        interruption.functionToolStateKey,
+        interruption.rawItem.callId,
+      );
     }
   }
 
-  for (const [legacyKey, callsByCanonicalKey] of approvalCallsByLegacyKey) {
-    for (const [canonicalKey, callIds] of callsByCanonicalKey) {
-      const canonicalOwners = approvalOwnersByLegacyKey.get(legacyKey);
-      const migratePermanentDecision =
-        canonicalOwners?.size === 1 && canonicalOwners.has(canonicalKey);
+  if (migrateApprovals) {
+    for (const [legacyKey, ownersByAgent] of approvalOwnersByLegacyKey) {
+      const ownerEntries = [...ownersByAgent].flatMap(
+        ([agent, canonicalKeys]) =>
+          [...canonicalKeys].map((canonicalKey) => ({ agent, canonicalKey })),
+      );
+      if (ownerEntries.length !== 1) {
+        continue;
+      }
+      const [{ agent, canonicalKey }] = ownerEntries;
       approvalContext._migrateToolApproval(
+        agent,
         legacyKey,
         canonicalKey,
-        callIds,
-        migratePermanentDecision,
+        [],
+        true,
       );
+    }
+  }
+
+  for (const [legacyKey, callsByAgent] of approvalCallsByLegacyKey) {
+    const callOwners = new Map<string, number>();
+    for (const callsByCanonicalKey of callsByAgent.values()) {
+      for (const callIds of callsByCanonicalKey.values()) {
+        for (const callId of callIds) {
+          callOwners.set(callId, (callOwners.get(callId) ?? 0) + 1);
+        }
+      }
+    }
+    for (const [agent, callsByCanonicalKey] of callsByAgent) {
+      for (const [canonicalKey, callIds] of callsByCanonicalKey) {
+        for (const callId of callIds) {
+          const remainingOwners = (callOwners.get(callId) ?? 1) - 1;
+          callOwners.set(callId, remainingOwners);
+          approvalContext._migrateToolApproval(
+            agent,
+            legacyKey,
+            canonicalKey,
+            [callId],
+            false,
+            remainingOwners > 0,
+          );
+        }
+      }
     }
   }
   return new Set(approvalOwnersByLegacyKey.keys());

--- a/packages/agents-core/src/runner/approvalRejection.ts
+++ b/packages/agents-core/src/runner/approvalRejection.ts
@@ -1,4 +1,5 @@
 import logger, { getSafeErrorType } from '../logger';
+import type { Agent } from '../agent';
 import { RunContext } from '../runContext';
 import type { ToolErrorFormatter, ToolErrorFormatterArgs } from '../run';
 
@@ -11,6 +12,8 @@ type ApprovalRejectionMessageOptions<TContext = unknown> = {
   runContext: RunContext<TContext>;
   toolType: ApprovalRejectedToolType;
   toolName: string;
+  approvalToolNames?: readonly string[];
+  approvalAgent?: Agent<any, any>;
   callId: string;
   toolErrorFormatter?: ToolErrorFormatter<TContext>;
 };
@@ -23,12 +26,26 @@ export async function resolveApprovalRejectionMessage<TContext>({
   runContext,
   toolType,
   toolName,
+  approvalToolNames = [toolName],
+  approvalAgent,
   callId,
   toolErrorFormatter,
 }: ApprovalRejectionMessageOptions<TContext>): Promise<string> {
   // Per-call message from state.reject(item, { message }) takes precedence over
   // the global toolErrorFormatter callback and the SDK default.
-  const perCallMessage = runContext.getRejectionMessage(toolName, callId);
+  const perCallMessage = approvalToolNames
+    .map((approvalToolName) =>
+      approvalAgent
+        ? runContext._getFunctionRejectionMessage(
+            approvalToolName,
+            callId,
+            approvalAgent,
+          )
+        : runContext.getRejectionMessage(approvalToolName, callId, {
+            functionTool: false,
+          }),
+    )
+    .find((message): message is string => typeof message === 'string');
   if (typeof perCallMessage === 'string') {
     return perCallMessage;
   }

--- a/packages/agents-core/src/runner/mcpApprovals.ts
+++ b/packages/agents-core/src/runner/mcpApprovals.ts
@@ -86,7 +86,11 @@ export async function handleHostedMcpApprovals<TContext>({
     if (typeof approvalDecision !== 'undefined' && approvalRequestId) {
       const rejectionReason =
         approvalDecision === false
-          ? state._context.getRejectionMessage(rawItem.name, approvalRequestId)
+          ? state._context.getRejectionMessage(
+              rawItem.name,
+              approvalRequestId,
+              { functionTool: false },
+            )
           : undefined;
       const approvalResponseData: ProviderData.HostedMCPApprovalResponse = {
         approve: approvalDecision,

--- a/packages/agents-core/src/runner/modelOutputs.ts
+++ b/packages/agents-core/src/runner/modelOutputs.ts
@@ -61,7 +61,6 @@ import {
   addLoadedToolNamesFromToolSearchOutput,
   createBuiltInClientToolSearchOutput,
   executeCustomClientToolSearch,
-  filterEnabledToolSearchRuntimeTools,
   getClientToolSearchHelper,
   registerRuntimeToolSearchTools,
 } from './toolSearch';
@@ -454,6 +453,7 @@ function buildFunctionToolMap<TContext>(
 type GeneratedClientToolSearchOutput<TContext> = {
   output: protocol.ToolSearchOutputItem;
   runtimeTools: Tool<TContext>[];
+  callbackRuntimeTools: Tool<TContext>[];
 };
 
 function getUnresolvedClientToolSearchCalls(
@@ -596,7 +596,7 @@ async function buildGeneratedClientToolSearchOutputMapAsync<TContext>(args: {
         runtimeTools: generatedOutput.runtimeTools,
       });
       generatedOutputs.set(toolSearchCall, generatedOutput);
-      executionTools.push(...generatedOutput.runtimeTools);
+      executionTools.push(...generatedOutput.callbackRuntimeTools);
       continue;
     }
 
@@ -606,6 +606,7 @@ async function buildGeneratedClientToolSearchOutputMapAsync<TContext>(args: {
         executionTools,
       ),
       runtimeTools: [],
+      callbackRuntimeTools: [],
     });
   }
 
@@ -1109,11 +1110,6 @@ export async function processModelResponseAsync<TContext>(
             preserveExistingServerLabels: originalMcpServerLabels,
           },
         );
-        const enabledRuntimeTools = await filterEnabledToolSearchRuntimeTools({
-          agent,
-          runContext: state._context,
-          runtimeTools: generatedOutput.runtimeTools,
-        });
         const replacedRuntimeTools = state.getToolSearchRuntimeToolsForOutput(
           agent,
           generatedOutput.output,
@@ -1125,7 +1121,7 @@ export async function processModelResponseAsync<TContext>(
           mcpToolMap,
           replaceableRuntimeToolKeys,
           replacedRuntimeTools,
-          runtimeTools: enabledRuntimeTools,
+          runtimeTools: generatedOutput.runtimeTools,
         });
         state.recordToolSearchRuntimeTools(
           agent,

--- a/packages/agents-core/src/runner/modelOutputs.ts
+++ b/packages/agents-core/src/runner/modelOutputs.ts
@@ -25,15 +25,17 @@ import {
   Tool,
   type ToolAllowedCaller,
   getClientToolSearchExecutor,
-  getToolSearchRuntimeToolKey,
+  getToolSearchRuntimeRoutingKey,
 } from '../tool';
 import * as ProviderData from '../types/providerData';
 import { addErrorToCurrentSpan } from '../tracing/context';
 import {
-  getFunctionToolQualifiedName,
+  buildFunctionToolLookupMap,
+  type FunctionToolLookupKey,
   getFunctionToolNamespace,
+  getFunctionToolQualifiedName,
   getToolCallNamespace,
-  resolveFunctionToolCallName,
+  resolveFunctionToolCall,
 } from '../toolIdentity';
 import {
   getToolSearchMatchKey,
@@ -51,6 +53,7 @@ import type {
   ToolRunMCPApprovalRequest,
   ToolRunShell,
 } from './types';
+import { createToolRunFunction } from './types';
 import type { ToolNotFoundBehavior } from '../run';
 import * as protocol from '../types/protocol';
 import {
@@ -58,7 +61,9 @@ import {
   addLoadedToolNamesFromToolSearchOutput,
   createBuiltInClientToolSearchOutput,
   executeCustomClientToolSearch,
+  filterEnabledToolSearchRuntimeTools,
   getClientToolSearchHelper,
+  registerRuntimeToolSearchTools,
 } from './toolSearch';
 import { ensureToolCallerAllowed } from './toolCaller';
 
@@ -248,42 +253,29 @@ function recordHandoffRequest(
 function resolveFunctionOrHandoff(
   toolCall: protocol.FunctionCallItem,
   handoffMap: Map<string, Handoff<any, any>>,
-  functionMap: Map<string, FunctionTool<any>>,
-  agent: Agent<any, any>,
+  functionMap: Map<FunctionToolLookupKey, FunctionTool<any>>,
 ):
   | { type: 'handoff'; handoff: Handoff<any, any> }
   | { type: 'function'; tool: FunctionTool<any> }
   | { type: 'not_found'; toolName: string } {
-  const resolvedToolName =
-    resolveFunctionToolCallName(toolCall, functionMap) ?? toolCall.name;
   const namespace = getToolCallNamespace(toolCall);
-  if (!namespace && typeof resolvedToolName === 'string') {
-    const functionTool = functionMap.get(resolvedToolName);
+  if (!namespace) {
     const handoff = handoffMap.get(toolCall.name);
-    if (functionTool && handoff && resolvedToolName.includes('.')) {
-      const message = `Ambiguous dotted tool call ${resolvedToolName} in agent ${agent.name}: it matches both a namespaced function tool and a handoff. Rename one of them or emit the function call with explicit namespace metadata.`;
-      addErrorToCurrentSpan({
-        message,
-        data: {
-          tool_name: resolvedToolName,
-          agent_name: agent.name,
-        },
-      });
-      throw new ModelBehaviorError(message);
-    }
-
-    if (functionTool && resolvedToolName.includes('.')) {
-      return { type: 'function', tool: functionTool };
-    }
-
     if (handoff) {
       return { type: 'handoff', handoff };
     }
   }
 
-  const functionTool = functionMap.get(resolvedToolName);
+  const functionTool = resolveFunctionToolCall(toolCall, functionMap);
   if (!functionTool) {
-    return { type: 'not_found', toolName: resolvedToolName };
+    return {
+      type: 'not_found',
+      toolName:
+        getToolCallNamespace(toolCall) &&
+        getToolCallNamespace(toolCall) !== toolCall.name
+          ? `${getToolCallNamespace(toolCall)}.${toolCall.name}`
+          : toolCall.name,
+    };
   }
   return { type: 'function', tool: functionTool };
 }
@@ -453,83 +445,10 @@ function seedHostedMcpToolsFromLoadedDeferredToolState(
 
 function buildFunctionToolMap<TContext>(
   tools: Tool<TContext>[],
-): Map<string, FunctionTool<TContext>> {
-  return new Map(
-    tools
-      .filter((t): t is FunctionTool<TContext> => t.type === 'function')
-      .map((t) => [getFunctionToolQualifiedName(t) ?? t.name, t]),
+): Map<FunctionToolLookupKey, FunctionTool<TContext>> {
+  return buildFunctionToolLookupMap(
+    tools.filter((t): t is FunctionTool<TContext> => t.type === 'function'),
   );
-}
-
-function registerRuntimeToolSearchTools<TContext>(args: {
-  availableTools: Tool<TContext>[];
-  functionMap: Map<string, FunctionTool<TContext>>;
-  mcpToolMap: Map<string, HostedMCPTool>;
-  replaceableRuntimeToolKeys?: Set<string>;
-  runtimeTools: Tool<TContext>[];
-}): Tool<TContext>[] {
-  const {
-    availableTools,
-    functionMap,
-    mcpToolMap,
-    replaceableRuntimeToolKeys,
-    runtimeTools,
-  } = args;
-  const availableToolsByKey = new Map<string, Tool<TContext>>();
-  for (const tool of availableTools) {
-    const key = getToolSearchRuntimeToolKey(tool);
-    if (key) {
-      availableToolsByKey.set(key, tool);
-    }
-  }
-
-  const novelTools: Tool<TContext>[] = [];
-  for (const runtimeTool of runtimeTools) {
-    const runtimeToolKey = getToolSearchRuntimeToolKey(runtimeTool);
-    if (!runtimeToolKey) {
-      throw new ModelBehaviorError(
-        'Client tool_search execute() returned an unsupported tool type.',
-      );
-    }
-
-    const existingTool = availableToolsByKey.get(runtimeToolKey);
-    if (existingTool && existingTool !== runtimeTool) {
-      if (!replaceableRuntimeToolKeys?.has(runtimeToolKey)) {
-        throw new ModelBehaviorError(
-          `Client tool_search execute() returned tool "${runtimeToolKey}" that conflicts with an existing available tool.`,
-        );
-      }
-    } else if (existingTool === runtimeTool) {
-      continue;
-    }
-
-    availableToolsByKey.set(runtimeToolKey, runtimeTool);
-    novelTools.push(runtimeTool);
-    if (runtimeTool.type === 'function') {
-      functionMap.set(
-        getFunctionToolQualifiedName(runtimeTool) ?? runtimeTool.name,
-        runtimeTool,
-      );
-      continue;
-    }
-
-    if (
-      runtimeTool.type === 'hosted_tool' &&
-      runtimeTool.providerData?.type === 'mcp'
-    ) {
-      mcpToolMap.set(
-        runtimeTool.providerData.server_label,
-        runtimeTool as HostedMCPTool,
-      );
-      continue;
-    }
-
-    throw new ModelBehaviorError(
-      'Client tool_search execute() returned an unsupported tool type.',
-    );
-  }
-
-  return novelTools;
 }
 
 type GeneratedClientToolSearchOutput<TContext> = {
@@ -537,65 +456,70 @@ type GeneratedClientToolSearchOutput<TContext> = {
   runtimeTools: Tool<TContext>[];
 };
 
+function getUnresolvedClientToolSearchCalls(
+  modelResponse: ModelResponse,
+  hasClientToolSearchTool: boolean,
+): protocol.ToolSearchCallItem[] {
+  const clientToolSearchCalls: protocol.ToolSearchCallItem[] = [];
+  const pendingCalls: protocol.ToolSearchCallItem[] = [];
+  const latestCallByMatchKey = new Map<string, protocol.ToolSearchCallItem>();
+  const resolvedCalls = new Set<protocol.ToolSearchCallItem>();
+
+  for (const output of modelResponse.output) {
+    if (output.type === 'tool_search_call') {
+      const execution = getToolSearchExecution(output);
+      if (
+        execution === 'client' ||
+        (typeof execution === 'undefined' && hasClientToolSearchTool)
+      ) {
+        clientToolSearchCalls.push(output);
+        pendingCalls.push(output);
+        const matchKey = getToolSearchMatchKey(output);
+        if (matchKey) {
+          latestCallByMatchKey.set(matchKey, output);
+        }
+      }
+      continue;
+    }
+    if (
+      output.type !== 'tool_search_output' ||
+      getToolSearchExecution(output) === 'server'
+    ) {
+      continue;
+    }
+
+    const explicitCallId = getToolSearchProviderCallId(output);
+    const matchedCall = explicitCallId
+      ? latestCallByMatchKey.get(explicitCallId)
+      : pendingCalls.shift();
+    if (!matchedCall) {
+      continue;
+    }
+    resolvedCalls.add(matchedCall);
+    const pendingIndex = pendingCalls.indexOf(matchedCall);
+    if (pendingIndex >= 0) {
+      pendingCalls.splice(pendingIndex, 1);
+    }
+  }
+
+  return clientToolSearchCalls.filter((call) => !resolvedCalls.has(call));
+}
+
 function buildGeneratedClientToolSearchOutputMap<TContext>(
   modelResponse: ModelResponse,
   tools: Tool<TContext>[],
   hasClientToolSearchTool: boolean,
 ): Map<protocol.ToolSearchCallItem, protocol.ToolSearchOutputItem> {
-  const clientToolSearchCalls: protocol.ToolSearchCallItem[] = [];
-  const pendingClientToolSearchMatchKeys: string[] = [];
-  const resolvedToolSearchCallIds = new Set<string>();
-
-  for (const output of modelResponse.output) {
-    if (output.type === 'tool_search_call') {
-      const toolSearchExecution = getToolSearchExecution(output);
-      if (
-        toolSearchExecution === 'client' ||
-        (typeof toolSearchExecution === 'undefined' && hasClientToolSearchTool)
-      ) {
-        clientToolSearchCalls.push(output);
-        const matchKey = getToolSearchMatchKey(output);
-        if (matchKey) {
-          pendingClientToolSearchMatchKeys.push(matchKey);
-        }
-      }
-      continue;
-    }
-
-    if (output.type !== 'tool_search_output') {
-      continue;
-    }
-
-    const explicitCallId = getToolSearchProviderCallId(output);
-    const toolSearchExecution = getToolSearchExecution(output);
-    if (explicitCallId) {
-      resolvedToolSearchCallIds.add(explicitCallId);
-      const pendingIndex =
-        pendingClientToolSearchMatchKeys.indexOf(explicitCallId);
-      if (pendingIndex >= 0) {
-        pendingClientToolSearchMatchKeys.splice(pendingIndex, 1);
-      }
-      continue;
-    }
-
-    if (toolSearchExecution !== 'server') {
-      const pendingMatchKey = pendingClientToolSearchMatchKeys.shift();
-      if (pendingMatchKey) {
-        resolvedToolSearchCallIds.add(pendingMatchKey);
-      }
-    }
-  }
+  const clientToolSearchCalls = getUnresolvedClientToolSearchCalls(
+    modelResponse,
+    hasClientToolSearchTool,
+  );
 
   const generatedOutputs = new Map<
     protocol.ToolSearchCallItem,
     protocol.ToolSearchOutputItem
   >();
   for (const toolSearchCall of clientToolSearchCalls) {
-    const matchKey = getToolSearchMatchKey(toolSearchCall);
-    if (matchKey && resolvedToolSearchCallIds.has(matchKey)) {
-      continue;
-    }
-
     generatedOutputs.set(
       toolSearchCall,
       createBuiltInClientToolSearchOutput(toolSearchCall, tools),
@@ -607,70 +531,51 @@ function buildGeneratedClientToolSearchOutputMap<TContext>(
 
 async function buildGeneratedClientToolSearchOutputMapAsync<TContext>(args: {
   agent: Agent<any, any>;
+  handoffs: Handoff<any, any>[];
   modelResponse: ModelResponse;
+  replaceableRuntimeToolKeys: Set<string>;
   runContext: RunState<TContext, Agent<any, any>>['_context'];
   tools: Tool<TContext>[];
 }): Promise<
   Map<protocol.ToolSearchCallItem, GeneratedClientToolSearchOutput<TContext>>
 > {
-  const { agent, modelResponse, runContext, tools } = args;
+  const {
+    agent,
+    handoffs,
+    modelResponse,
+    replaceableRuntimeToolKeys,
+    runContext,
+    tools,
+  } = args;
   const clientToolSearchTool = getClientToolSearchHelper(tools);
   const hasClientToolSearchTool = typeof clientToolSearchTool !== 'undefined';
   const executionTools = [...tools];
-  const clientToolSearchCalls: protocol.ToolSearchCallItem[] = [];
-  const pendingClientToolSearchMatchKeys: string[] = [];
-  const resolvedToolSearchCallIds = new Set<string>();
-
-  for (const output of modelResponse.output) {
-    if (output.type === 'tool_search_call') {
-      const toolSearchExecution = getToolSearchExecution(output);
-      if (
-        toolSearchExecution === 'client' ||
-        (typeof toolSearchExecution === 'undefined' && hasClientToolSearchTool)
-      ) {
-        clientToolSearchCalls.push(output);
-        const matchKey = getToolSearchMatchKey(output);
-        if (matchKey) {
-          pendingClientToolSearchMatchKeys.push(matchKey);
-        }
-      }
-      continue;
-    }
-
-    if (output.type !== 'tool_search_output') {
-      continue;
-    }
-
-    const explicitCallId = getToolSearchProviderCallId(output);
-    const toolSearchExecution = getToolSearchExecution(output);
-    if (explicitCallId) {
-      resolvedToolSearchCallIds.add(explicitCallId);
-      const pendingIndex =
-        pendingClientToolSearchMatchKeys.indexOf(explicitCallId);
-      if (pendingIndex >= 0) {
-        pendingClientToolSearchMatchKeys.splice(pendingIndex, 1);
-      }
-      continue;
-    }
-
-    if (toolSearchExecution !== 'server') {
-      const pendingMatchKey = pendingClientToolSearchMatchKeys.shift();
-      if (pendingMatchKey) {
-        resolvedToolSearchCallIds.add(pendingMatchKey);
-      }
-    }
-  }
+  const validationAvailableTools = [...tools];
+  const validationFunctionMap = buildFunctionToolMap(tools);
+  const validationHandoffMap = new Map(
+    handoffs.map((handoff) => [handoff.toolName, handoff]),
+  );
+  const validationMcpToolMap = new Map(
+    tools
+      .filter(
+        (tool): tool is HostedMCPTool<any> =>
+          tool.type === 'hosted_tool' && tool.providerData?.type === 'mcp',
+      )
+      .map((tool) => [tool.providerData!.server_label, tool as HostedMCPTool]),
+  );
+  const validationReplaceableRuntimeToolKeys = new Set(
+    replaceableRuntimeToolKeys,
+  );
+  const clientToolSearchCalls = getUnresolvedClientToolSearchCalls(
+    modelResponse,
+    hasClientToolSearchTool,
+  );
 
   const generatedOutputs = new Map<
     protocol.ToolSearchCallItem,
     GeneratedClientToolSearchOutput<TContext>
   >();
   for (const toolSearchCall of clientToolSearchCalls) {
-    const matchKey = getToolSearchMatchKey(toolSearchCall);
-    if (matchKey && resolvedToolSearchCallIds.has(matchKey)) {
-      continue;
-    }
-
     if (
       clientToolSearchTool &&
       getClientToolSearchExecutor(clientToolSearchTool)
@@ -681,6 +586,14 @@ async function buildGeneratedClientToolSearchOutputMapAsync<TContext>(args: {
         toolSearchCall,
         toolSearchTool: clientToolSearchTool,
         tools: executionTools,
+      });
+      registerRuntimeToolSearchTools({
+        availableTools: validationAvailableTools,
+        functionMap: validationFunctionMap,
+        handoffMap: validationHandoffMap,
+        mcpToolMap: validationMcpToolMap,
+        replaceableRuntimeToolKeys: validationReplaceableRuntimeToolKeys,
+        runtimeTools: generatedOutput.runtimeTools,
       });
       generatedOutputs.set(toolSearchCall, generatedOutput);
       executionTools.push(...generatedOutput.runtimeTools);
@@ -789,11 +702,7 @@ export function processModelResponse<TContext>(
   const toolsUsed: string[] = [];
   const handoffMap = new Map(handoffs.map((h) => [h.toolName, h]));
   // Resolve tools upfront so we can look up the concrete handler in O(1) while iterating outputs.
-  const functionMap = new Map(
-    tools
-      .filter((t): t is FunctionTool<TContext> => t.type === 'function')
-      .map((t) => [getFunctionToolQualifiedName(t) ?? t.name, t]),
-  );
+  const functionMap = buildFunctionToolMap(tools);
   const computerTool = tools.find(
     (t): t is ComputerTool<TContext, any> => t.type === 'computer',
   );
@@ -1006,12 +915,7 @@ export function processModelResponse<TContext>(
       continue;
     }
 
-    const resolved = resolveFunctionOrHandoff(
-      output,
-      handoffMap,
-      functionMap,
-      agent,
-    );
+    const resolved = resolveFunctionOrHandoff(output, handoffMap, functionMap);
     if (resolved.type === 'not_found') {
       if (toolNotFoundBehavior !== 'return_error_to_model') {
         throwFunctionToolNotFound(resolved.toolName, agent);
@@ -1060,10 +964,13 @@ export function processModelResponse<TContext>(
         getFunctionToolQualifiedName(resolved.tool) ?? resolved.tool.name,
       );
       items.push(new RunToolCallItem(normalizedToolCall, agent));
-      runFunctions.push({
-        toolCall: normalizedToolCall,
-        tool: resolved.tool,
-      });
+      runFunctions.push(
+        createToolRunFunction({
+          toolCall: normalizedToolCall,
+          tool: resolved.tool,
+          availableFunctionTools: [...new Set(functionMap.values())],
+        }),
+      );
     }
   }
 
@@ -1155,7 +1062,7 @@ export async function processModelResponseAsync<TContext>(
   const replaceableRuntimeToolKeys = new Set(
     state
       .getToolSearchRuntimeTools(agent)
-      .map((tool) => getToolSearchRuntimeToolKey(tool))
+      .map((tool) => getToolSearchRuntimeRoutingKey(tool))
       .filter((key): key is string => typeof key === 'string'),
   );
   const loadedDeferredToolState = collectLoadedDeferredToolStateFromHistory(
@@ -1170,7 +1077,9 @@ export async function processModelResponseAsync<TContext>(
   const generatedClientToolSearchOutputsByCall =
     await buildGeneratedClientToolSearchOutputMapAsync({
       agent,
+      handoffs,
       modelResponse,
+      replaceableRuntimeToolKeys,
       runContext: state._context,
       tools,
     });
@@ -1200,17 +1109,28 @@ export async function processModelResponseAsync<TContext>(
             preserveExistingServerLabels: originalMcpServerLabels,
           },
         );
-        const novelRuntimeTools = registerRuntimeToolSearchTools({
+        const enabledRuntimeTools = await filterEnabledToolSearchRuntimeTools({
+          agent,
+          runContext: state._context,
+          runtimeTools: generatedOutput.runtimeTools,
+        });
+        const replacedRuntimeTools = state.getToolSearchRuntimeToolsForOutput(
+          agent,
+          generatedOutput.output,
+        );
+        const registeredRuntimeTools = registerRuntimeToolSearchTools({
           availableTools,
           functionMap,
+          handoffMap,
           mcpToolMap,
           replaceableRuntimeToolKeys,
-          runtimeTools: generatedOutput.runtimeTools,
+          replacedRuntimeTools,
+          runtimeTools: enabledRuntimeTools,
         });
         state.recordToolSearchRuntimeTools(
           agent,
           generatedOutput.output,
-          novelRuntimeTools,
+          registeredRuntimeTools,
         );
         hasGeneratedClientToolSearchOutputs = true;
       }
@@ -1361,12 +1281,7 @@ export async function processModelResponseAsync<TContext>(
       continue;
     }
 
-    const resolved = resolveFunctionOrHandoff(
-      output,
-      handoffMap,
-      functionMap,
-      agent,
-    );
+    const resolved = resolveFunctionOrHandoff(output, handoffMap, functionMap);
     if (resolved.type === 'not_found') {
       if (toolNotFoundBehavior !== 'return_error_to_model') {
         throwFunctionToolNotFound(resolved.toolName, agent);
@@ -1415,10 +1330,13 @@ export async function processModelResponseAsync<TContext>(
         getFunctionToolQualifiedName(resolved.tool) ?? resolved.tool.name,
       );
       items.push(new RunToolCallItem(normalizedToolCall, agent));
-      runFunctions.push({
-        toolCall: normalizedToolCall,
-        tool: resolved.tool,
-      });
+      runFunctions.push(
+        createToolRunFunction({
+          toolCall: normalizedToolCall,
+          tool: resolved.tool,
+          availableFunctionTools: [...new Set(functionMap.values())],
+        }),
+      );
     }
   }
 

--- a/packages/agents-core/src/runner/modelPreparation.ts
+++ b/packages/agents-core/src/runner/modelPreparation.ts
@@ -1,12 +1,19 @@
 import { Agent, AgentOutputType } from '../agent';
 import type { Computer } from '../computer';
+import { UserError } from '../errors';
 import { Handoff } from '../handoff';
-import { RunState } from '../runState';
+import logger from '../logger';
+import type { RunState } from '../runState';
 import { ComputerTool, Tool, resolveComputer } from '../tool';
+import {
+  getFunctionToolNamespace,
+  getFunctionToolQualifiedName,
+} from '../toolIdentity';
 import { serializeHandoff, serializeTool } from '../utils/serialize';
 import { ensureAgentSpan } from './tracing';
 import { validateClientToolSearchSupport } from './toolSearch';
 import { AgentArtifacts } from './types';
+import type { ToolNameCollisionPolicy } from './runConfig';
 
 const computerInitPromisesByRunState = new WeakMap<
   RunState<any, any>,
@@ -59,8 +66,17 @@ export async function prepareAgentArtifacts<
 >(
   state: RunState<TContext, TAgent>,
   executionAgent: Agent<TContext, AgentOutputType> = state._currentAgent,
+  toolNameCollisionPolicy: ToolNameCollisionPolicy = 'warn',
 ): Promise<AgentArtifacts<TContext>> {
-  const capabilities = await collectAgentCapabilities(state, executionAgent);
+  const collectedCapabilities = await collectAgentCapabilities(
+    state,
+    executionAgent,
+  );
+  const capabilities = resolveModelVisibleToolNameCollisions(
+    collectedCapabilities.tools,
+    collectedCapabilities.handoffs,
+    toolNameCollisionPolicy,
+  );
   validateClientToolSearchSupport(capabilities.tools);
   await warmUpComputerTools(capabilities.tools, state._context);
   await initializeComputerTools(capabilities.tools, state);
@@ -98,7 +114,201 @@ async function collectAgentCapabilities<TContext>(
   const runtimeLoadedTools = state.getToolSearchRuntimeTools(
     state._currentAgent,
   ) as Tool<TContext>[];
-  return { handoffs, tools: [...configuredTools, ...runtimeLoadedTools] };
+  const enabledRuntimeTools = (
+    await Promise.all(
+      runtimeLoadedTools.map(async (tool) => ({
+        tool,
+        enabled:
+          tool.type !== 'function' ||
+          (await tool.isEnabled(state._context, state._currentAgent)),
+      })),
+    )
+  )
+    .filter(({ enabled }) => enabled)
+    .map(({ tool }) => tool);
+  return { handoffs, tools: [...configuredTools, ...enabledRuntimeTools] };
+}
+
+type ModelVisibleToolKind = 'function tool' | 'handoff';
+type ModelVisibleFunctionCategory = 'top-level' | 'namespaced' | 'deferred';
+
+type ModelVisibleToolEntry = {
+  kind: ModelVisibleToolKind;
+  index: number;
+  functionCategory?: ModelVisibleFunctionCategory;
+};
+
+/** @internal */
+export function resolveModelVisibleToolNameCollisions<TContext>(
+  tools: Tool<TContext>[],
+  handoffs: Handoff<any, any>[],
+  collisionPolicy: ToolNameCollisionPolicy,
+): { tools: Tool<TContext>[]; handoffs: Handoff<any, any>[] } {
+  const topLevelEntriesByName = new Map<string, ModelVisibleToolEntry[]>();
+  const namespacedFunctionEntriesByName = new Map<
+    string,
+    ModelVisibleToolEntry[]
+  >();
+  const deferredFunctionEntriesByName = new Map<
+    string,
+    ModelVisibleToolEntry[]
+  >();
+  const addName = (
+    entriesByName: Map<string, ModelVisibleToolEntry[]>,
+    name: string,
+    entry: ModelVisibleToolEntry,
+  ) => {
+    const entries = entriesByName.get(name) ?? [];
+    entries.push(entry);
+    entriesByName.set(name, entries);
+  };
+
+  for (const [index, tool] of tools.entries()) {
+    if (tool.type === 'function') {
+      const namespace = getFunctionToolNamespace(tool);
+      if (namespace === tool.name) {
+        throw new UserError(
+          'Responses tool search reserves same-name namespaces for deferred top-level function tools. Rename the namespace or tool name to avoid ambiguous dispatch.',
+        );
+      }
+      const functionCategory: ModelVisibleFunctionCategory = namespace
+        ? 'namespaced'
+        : tool.deferLoading === true
+          ? 'deferred'
+          : 'top-level';
+      const entry: ModelVisibleToolEntry = {
+        kind: 'function tool',
+        index,
+        functionCategory,
+      };
+      const dispatchName = getFunctionToolQualifiedName(tool) ?? tool.name;
+      addName(
+        functionCategory === 'namespaced'
+          ? namespacedFunctionEntriesByName
+          : functionCategory === 'deferred'
+            ? deferredFunctionEntriesByName
+            : topLevelEntriesByName,
+        dispatchName,
+        entry,
+      );
+    }
+  }
+  for (const [index, handoff] of handoffs.entries()) {
+    addName(topLevelEntriesByName, handoff.toolName, {
+      kind: 'handoff',
+      index,
+    });
+  }
+
+  const namespacedDuplicates = [...namespacedFunctionEntriesByName.entries()]
+    .filter(([, entries]) => entries.length > 1)
+    .sort(([left], [right]) => left.localeCompare(right));
+  const deferredDuplicates = [...deferredFunctionEntriesByName.entries()]
+    .filter(([, entries]) => entries.length > 1)
+    .sort(([left], [right]) => left.localeCompare(right));
+  const strictDuplicatesByName = new Map<string, ModelVisibleToolEntry[]>([
+    ...namespacedDuplicates,
+    ...deferredDuplicates,
+  ]);
+  const strictDuplicates = [...strictDuplicatesByName.entries()].sort(
+    ([left], [right]) => left.localeCompare(right),
+  );
+  if (strictDuplicates.length > 0) {
+    throwToolNameCollisionError(strictDuplicates);
+  }
+
+  const topLevelDuplicates = [...topLevelEntriesByName.entries()]
+    .filter(([, entries]) => entries.length > 1)
+    .sort(([left], [right]) => left.localeCompare(right));
+  if (topLevelDuplicates.length === 0) {
+    return { tools, handoffs };
+  }
+
+  if (collisionPolicy === 'error') {
+    throwToolNameCollisionError(topLevelDuplicates);
+  }
+
+  const retainedToolIndices = new Set(tools.map((_, index) => index));
+  const retainedHandoffIndices = new Set(handoffs.map((_, index) => index));
+  for (const [name, entries] of topLevelDuplicates) {
+    warnToolNameCollision(name, entries);
+    const handoffEntries = entries.filter((entry) => entry.kind === 'handoff');
+    const winner = handoffEntries.at(-1) ?? entries.at(-1)!;
+    for (const entry of entries) {
+      if (entry === winner) {
+        continue;
+      }
+      if (entry.kind === 'function tool') {
+        retainedToolIndices.delete(entry.index);
+      } else {
+        retainedHandoffIndices.delete(entry.index);
+      }
+    }
+  }
+
+  return {
+    tools: tools.filter((_, index) => retainedToolIndices.has(index)),
+    handoffs: handoffs.filter((_, index) => retainedHandoffIndices.has(index)),
+  };
+}
+
+const toolNameCollisionRemediation =
+  'Function tools and handoffs must have unique routed names. Assign unique tool names or toolNameOverride values, or use a namespace.';
+
+function throwToolNameCollisionError(
+  duplicates: Array<[string, ModelVisibleToolEntry[]]>,
+): never {
+  if (logger.dontLogToolData) {
+    throw new UserError(
+      `Duplicate enabled function tool or handoff names found. ${toolNameCollisionRemediation}`,
+    );
+  }
+  const label = duplicates.length === 1 ? 'name' : 'names';
+  const details = duplicates
+    .map(
+      ([name, entries]) =>
+        `'${name}' (${formatToolKinds(entries.map((entry) => entry.kind))})`,
+    )
+    .join(', ');
+  throw new UserError(
+    `Duplicate enabled tool ${label} found: ${details}. ${toolNameCollisionRemediation}`,
+  );
+}
+
+function warnToolNameCollision(
+  name: string,
+  entries: readonly ModelVisibleToolEntry[],
+): void {
+  if (logger.dontLogToolData) {
+    logger.warn(
+      'Tool name collision detected. Assign unique routed tool names or enable tool data logging for details. Only the current dispatch winner will be exposed.',
+    );
+    return;
+  }
+  logger.warn(
+    `Duplicate enabled tool name found: '${name}' (${formatToolKinds(entries.map((entry) => entry.kind))}). ${toolNameCollisionRemediation} Only the current dispatch winner will be exposed.`,
+  );
+}
+
+function formatToolKinds(kinds: readonly ModelVisibleToolKind[]): string {
+  const functionToolCount = kinds.filter(
+    (kind) => kind === 'function tool',
+  ).length;
+  const handoffCount = kinds.length - functionToolCount;
+  const descriptions: string[] = [];
+  if (functionToolCount > 0) {
+    descriptions.push(
+      functionToolCount === 1
+        ? 'function tool'
+        : `${functionToolCount} function tools`,
+    );
+  }
+  if (handoffCount > 0) {
+    descriptions.push(
+      handoffCount === 1 ? 'handoff' : `${handoffCount} handoffs`,
+    );
+  }
+  return descriptions.join(' and ');
 }
 
 async function warmUpComputerTools<TContext>(

--- a/packages/agents-core/src/runner/runConfig.ts
+++ b/packages/agents-core/src/runner/runConfig.ts
@@ -16,6 +16,20 @@ export type ToolExecutionConfig = {
   preApprovalInputGuardrails?: boolean;
 };
 
+export type ToolNameCollisionPolicy = 'warn' | 'error';
+
+export function validateToolNameCollisionPolicy(
+  policy: ToolNameCollisionPolicy | undefined,
+): ToolNameCollisionPolicy {
+  const resolvedPolicy = policy === undefined ? 'warn' : policy;
+  if (resolvedPolicy !== 'warn' && resolvedPolicy !== 'error') {
+    throw new UserError(
+      'toolNameCollisionPolicy must be either "warn" or "error".',
+    );
+  }
+  return resolvedPolicy;
+}
+
 export function getImplicitModelSettingsForResolvedModel(
   explicitlyModelSet: boolean,
   resolvedModelName?: string,

--- a/packages/agents-core/src/runner/runLoop.ts
+++ b/packages/agents-core/src/runner/runLoop.ts
@@ -1,6 +1,7 @@
 import type { Agent, AgentOutputType } from '../agent';
 import type { RunState } from '../runState';
 import type { RunConfig, Runner, ToolErrorFormatter } from '../run';
+import { getFunctionToolStateKeyForCall } from '../toolIdentity';
 import type { SingleStepResult } from './steps';
 import type { ProcessedResponse } from './types';
 import { resolveInterruptedTurn } from './turnResolution';
@@ -81,7 +82,11 @@ export async function resumeInterruptedTurn<
     if (rawItem.type === 'hosted_tool_call') {
       return false;
     }
-    const toolName = item.name;
+    const toolName =
+      rawItem.type === 'function_call'
+        ? (item.functionToolStateKey ??
+          getFunctionToolStateKeyForCall(rawItem, item.name))
+        : item.name;
     const callId =
       'callId' in rawItem && typeof rawItem.callId === 'string'
         ? rawItem.callId
@@ -91,7 +96,12 @@ export async function resumeInterruptedTurn<
     return (
       toolName !== undefined &&
       callId !== undefined &&
-      state._context.isToolApproved({ toolName, callId }) === true
+      state._context.isToolApproved({
+        toolName,
+        callId,
+        functionTool: false,
+        ...(rawItem.type === 'function_call' ? { agent: item.agent } : {}),
+      }) === true
     );
   });
   const turnResult = await resolveInterruptedTurn<TContext>(

--- a/packages/agents-core/src/runner/sandbox.ts
+++ b/packages/agents-core/src/runner/sandbox.ts
@@ -13,6 +13,7 @@ import type { Span } from '../tracing/spans';
 import type { Trace } from '../tracing/traces';
 import type { AgentInputItem } from '../types';
 import { prepareAgentArtifacts } from './modelPreparation';
+import type { ToolNameCollisionPolicy } from './runConfig';
 
 export type SandboxMemoryPersistenceContext = {
   sdkSessionId?: () => Promise<string | undefined>;
@@ -27,6 +28,7 @@ export async function prepareSandboxInterruptedTurnResume<
   state: RunState<TContext, TAgent>;
   sandboxRuntime: SandboxRuntimeManager<TContext>;
   runConfigModel?: SandboxRuntimeModel;
+  toolNameCollisionPolicy?: ToolNameCollisionPolicy;
   tracingParent?: Span<any> | Trace;
 }): Promise<void> {
   const {
@@ -34,6 +36,7 @@ export async function prepareSandboxInterruptedTurnResume<
     state,
     sandboxRuntime,
     runConfigModel,
+    toolNameCollisionPolicy,
     tracingParent,
   } = args;
   logger.debug('Continuing from interruption');
@@ -60,6 +63,7 @@ export async function prepareSandboxInterruptedTurnResume<
       state,
       sandboxRuntime,
       runConfigModel,
+      toolNameCollisionPolicy,
       force: resumedPreservedSessions,
       tracingParent,
     });
@@ -139,6 +143,7 @@ export async function rehydrateInterruptedTurnExecutionTools<
   state: RunState<TContext, TAgent>;
   sandboxRuntime: SandboxRuntimeManager<TContext>;
   runConfigModel?: SandboxRuntimeModel;
+  toolNameCollisionPolicy?: ToolNameCollisionPolicy;
   force?: boolean;
   tracingParent?: Span<any> | Trace;
 }): Promise<void> {
@@ -147,6 +152,7 @@ export async function rehydrateInterruptedTurnExecutionTools<
     state,
     sandboxRuntime,
     runConfigModel,
+    toolNameCollisionPolicy,
     force,
     tracingParent,
   } = args;
@@ -168,6 +174,7 @@ export async function rehydrateInterruptedTurnExecutionTools<
   const artifacts = await prepareAgentArtifacts(
     state,
     preparedSandboxAgent.executionAgent,
+    toolNameCollisionPolicy,
   );
   await rehydrateProcessedResponseTools(startingAgent, state, artifacts.tools);
 }

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -58,6 +58,8 @@ import type { AgentInputItem, UnknownContext } from '../types';
 import type { RunConfig, Runner, ToolErrorFormatter } from '../run';
 import {
   getFunctionToolQualifiedName,
+  getFunctionToolStateKey,
+  getFunctionToolStateKeys,
   matchesFunctionToolName,
 } from '../toolIdentity';
 import {
@@ -129,6 +131,21 @@ function getFunctionToolTraceName<TContext>(
   toolRun: ToolRunFunction<TContext>,
 ): string {
   return getFunctionToolIdentity(toolRun);
+}
+
+function getFunctionToolApprovalStateKey<TContext>(
+  toolRun: ToolRunFunction<TContext>,
+): string {
+  return (
+    getFunctionToolStateKey(toolRun.tool) ?? getFunctionToolIdentity(toolRun)
+  );
+}
+
+function getFunctionToolPendingStateKeys<TContext>(
+  toolRun: ToolRunFunction<TContext>,
+): string[] {
+  const availableTools = toolRun.availableFunctionTools ?? [toolRun.tool];
+  return getFunctionToolStateKeys(toolRun.tool, availableTools);
 }
 
 const COMPUTER_TRACE_NAME = 'computer';
@@ -416,6 +433,7 @@ function buildApprovalRequestResult<TContext>(
       toolRun.toolCall,
       deps.agent,
       getFunctionToolIdentity(toolRun),
+      getFunctionToolStateKey(toolRun.tool),
     ),
   };
 }
@@ -512,12 +530,15 @@ async function buildApprovalRejectionResult<TContext>(
 ): Promise<FunctionToolResult<TContext>> {
   const { runner, state, toolErrorFormatter } = deps;
   const toolName = getFunctionToolIdentity(toolRun);
+  const approvalToolNames = [getFunctionToolApprovalStateKey(toolRun)];
   const traceToolName = getFunctionToolTraceName(toolRun);
   return withRunStateToolFunctionSpan(deps, traceToolName, async (span) => {
     const response = await resolveApprovalRejectionMessage({
       runContext: state._context,
       toolType: 'function',
       toolName,
+      approvalToolNames,
+      approvalAgent: deps.agent,
       callId: toolRun.toolCall.callId,
       toolErrorFormatter,
     });
@@ -553,14 +574,19 @@ async function handleFunctionApproval<TContext>(
   forceApproval: boolean = false,
 ): Promise<'approved' | FunctionToolResult<TContext>> {
   const { agent, state } = deps;
-  const toolName = getFunctionToolIdentity(toolRun);
+  const approvalStateKey = getFunctionToolApprovalStateKey(toolRun);
+  const pendingStateKeys = getFunctionToolPendingStateKeys(toolRun);
   const approval = state._context.isToolApproved({
-    toolName,
+    toolName: approvalStateKey,
     callId: toolRun.toolCall.callId,
+    functionTool: false,
+    agent,
   });
 
   if (approval === false) {
-    state.clearPendingAgentToolRun(toolName, toolRun.toolCall.callId);
+    for (const stateKey of pendingStateKeys) {
+      state.clearPendingAgentToolRun(stateKey, toolRun.toolCall.callId);
+    }
     return await buildApprovalRejectionResult(deps, toolRun);
   }
 
@@ -645,6 +671,7 @@ async function runApprovedFunctionTool<TContext>(
 ): Promise<FunctionToolResult<TContext>> {
   const { agent, runner, state, agentToolParentRunConfig, signal } = deps;
   const toolName = getFunctionToolIdentity(toolRun);
+  const stateKeys = getFunctionToolPendingStateKeys(toolRun);
   const traceToolName = getFunctionToolTraceName(toolRun);
   return withRunStateToolFunctionSpan(deps, traceToolName, async (span) => {
     if (span && runner.config.traceIncludeSensitiveData) {
@@ -686,10 +713,11 @@ async function runApprovedFunctionTool<TContext>(
           inputGuardrailResult.message,
         );
       } else {
-        const resumeState = state.getPendingAgentToolRun(
-          toolName,
-          toolRun.toolCall.callId,
-        );
+        const resumeState = stateKeys
+          .map((stateKey) =>
+            state.getPendingAgentToolRun(stateKey, toolRun.toolCall.callId),
+          )
+          .find((pendingState) => typeof pendingState !== 'undefined');
         toolDetails = {
           toolCall: toolRun.toolCall,
           resumeState,
@@ -781,13 +809,18 @@ async function runApprovedFunctionTool<TContext>(
         if (nestedInterruptions.length > 0) {
           functionResult.interruptions = nestedInterruptions;
           const nestedRunStateJson = nestedRunResult.state.toJSON();
+          const [stateKey, ...aliases] =
+            stateKeys.length > 0 ? stateKeys : [toolName];
           state.setPendingAgentToolRun(
-            toolName,
+            stateKey,
             toolRun.toolCall.callId,
             JSON.stringify(nestedRunStateJson),
+            aliases,
           );
         } else {
-          state.clearPendingAgentToolRun(toolName, toolRun.toolCall.callId);
+          for (const stateKey of stateKeys) {
+            state.clearPendingAgentToolRun(stateKey, toolRun.toolCall.callId);
+          }
         }
       }
 
@@ -963,6 +996,7 @@ async function resolveToolApproval(options: {
   const existingApproval = runContext.isToolApproved({
     toolName,
     callId,
+    functionTool: false,
   });
 
   if (existingApproval === true) {
@@ -995,6 +1029,7 @@ async function resolveToolApproval(options: {
   const approval = runContext.isToolApproved({
     toolName,
     callId,
+    functionTool: false,
   });
 
   if (approval === true) {

--- a/packages/agents-core/src/runner/toolSearch.ts
+++ b/packages/agents-core/src/runner/toolSearch.ts
@@ -720,6 +720,7 @@ export async function executeCustomClientToolSearch<TContext>(args: {
 }): Promise<{
   output: protocol.ToolSearchOutputItem;
   runtimeTools: Tool<TContext>[];
+  callbackRuntimeTools: Tool<TContext>[];
 }> {
   const { agent, runContext, toolSearchCall, toolSearchTool, tools } = args;
   const executor = getClientToolSearchExecutor(toolSearchTool);
@@ -729,7 +730,7 @@ export async function executeCustomClientToolSearch<TContext>(args: {
     );
   }
 
-  const runtimeTools = normalizeClientToolSearchExecutorResult(
+  const callbackRuntimeTools = normalizeClientToolSearchExecutorResult(
     await executor({
       agent,
       availableTools: [...tools],
@@ -738,11 +739,17 @@ export async function executeCustomClientToolSearch<TContext>(args: {
       toolCall: toolSearchCall,
     }),
   );
+  const runtimeTools = await filterEnabledToolSearchRuntimeTools({
+    agent,
+    runContext,
+    runtimeTools: callbackRuntimeTools,
+  });
   indexCustomClientToolSearchRuntimeTools(runtimeTools);
 
   return {
     output: createClientToolSearchOutputFromTools(toolSearchCall, runtimeTools),
     runtimeTools,
+    callbackRuntimeTools,
   };
 }
 

--- a/packages/agents-core/src/runner/toolSearch.ts
+++ b/packages/agents-core/src/runner/toolSearch.ts
@@ -1,9 +1,12 @@
 import type { Agent } from '../agent';
-import { UserError } from '../errors';
+import { ModelBehaviorError, UserError } from '../errors';
+import type { Handoff } from '../handoff';
+import logger from '../logger';
 import type { RunContext } from '../runContext';
 import {
   getClientToolSearchExecutor,
   getToolSearchRuntimeToolKey,
+  getToolSearchRuntimeRoutingKey,
   type FunctionTool,
   type HostedMCPTool,
   type Tool,
@@ -11,10 +14,13 @@ import {
 import type * as protocol from '../types/protocol';
 import * as ProviderData from '../types/providerData';
 import {
+  buildFunctionToolLookupMap,
+  getBareTopLevelFunctionToolName,
   getExplicitFunctionToolNamespace,
   getFunctionToolNamespaceDescription,
   getFunctionToolQualifiedName,
   toolQualifiedName,
+  type FunctionToolLookupKey,
 } from '../toolIdentity';
 import { serializeTool } from '../utils/serialize';
 import { normalizeHostedMcpRequireApproval } from '../utils/mcpApproval';
@@ -599,7 +605,7 @@ export function createClientToolSearchOutputFromTools(
   const seenToolKeys = new Set<string>();
 
   for (const tool of tools) {
-    const runtimeToolKey = getToolSearchRuntimeToolKey(tool);
+    const runtimeToolKey = getToolSearchRuntimeRoutingKey(tool);
     if (runtimeToolKey && seenToolKeys.has(runtimeToolKey)) {
       continue;
     }
@@ -676,6 +682,35 @@ export function createBuiltInClientToolSearchOutput(
   );
 }
 
+function indexCustomClientToolSearchRuntimeTools<TContext>(
+  runtimeTools: Tool<TContext>[],
+): Map<string, Tool<TContext>> {
+  const runtimeToolsByKey = new Map<string, Tool<TContext>>();
+  for (const runtimeTool of runtimeTools) {
+    if (
+      runtimeTool.type === 'function' &&
+      getExplicitFunctionToolNamespace(runtimeTool) === runtimeTool.name
+    ) {
+      throw new ModelBehaviorError(
+        'Responses tool search reserves same-name namespaces for deferred top-level function tools. Rename the namespace or tool name to avoid ambiguous dispatch.',
+      );
+    }
+    const runtimeToolKey = getToolSearchRuntimeRoutingKey(runtimeTool);
+    if (!runtimeToolKey) {
+      throw new ModelBehaviorError(
+        'Client tool_search execute() returned an unsupported tool type.',
+      );
+    }
+    if (runtimeToolsByKey.has(runtimeToolKey)) {
+      throw new ModelBehaviorError(
+        'Client tool_search execute() returned multiple tools with the same routed identity. Return only one tool for each routed identity.',
+      );
+    }
+    runtimeToolsByKey.set(runtimeToolKey, runtimeTool);
+  }
+  return runtimeToolsByKey;
+}
+
 export async function executeCustomClientToolSearch<TContext>(args: {
   agent: Agent<TContext, any>;
   runContext: RunContext<TContext>;
@@ -703,11 +738,155 @@ export async function executeCustomClientToolSearch<TContext>(args: {
       toolCall: toolSearchCall,
     }),
   );
+  indexCustomClientToolSearchRuntimeTools(runtimeTools);
 
   return {
     output: createClientToolSearchOutputFromTools(toolSearchCall, runtimeTools),
     runtimeTools,
   };
+}
+
+export async function filterEnabledToolSearchRuntimeTools<TContext>(args: {
+  agent: Agent<TContext, any>;
+  runContext: RunContext<TContext>;
+  runtimeTools: Tool<TContext>[];
+}): Promise<Tool<TContext>[]> {
+  const { agent, runContext, runtimeTools } = args;
+  const enabledTools: Tool<TContext>[] = [];
+  for (const runtimeTool of runtimeTools) {
+    if (
+      runtimeTool.type === 'function' &&
+      !(await runtimeTool.isEnabled(runContext, agent))
+    ) {
+      continue;
+    }
+    enabledTools.push(runtimeTool);
+  }
+  return enabledTools;
+}
+
+export function registerRuntimeToolSearchTools<TContext>(args: {
+  availableTools: Tool<TContext>[];
+  functionMap: Map<FunctionToolLookupKey, FunctionTool<TContext>>;
+  handoffMap: Map<string, Handoff<any, any>>;
+  mcpToolMap: Map<string, HostedMCPTool>;
+  replaceableRuntimeToolKeys?: Set<string>;
+  replacedRuntimeTools?: Tool<TContext>[];
+  runtimeTools: Tool<TContext>[];
+}): Tool<TContext>[] {
+  const {
+    availableTools,
+    functionMap,
+    handoffMap,
+    mcpToolMap,
+    replaceableRuntimeToolKeys,
+    replacedRuntimeTools = [],
+    runtimeTools,
+  } = args;
+  const availableToolsByKey = new Map<string, Tool<TContext>>();
+  for (const tool of availableTools) {
+    const key = getToolSearchRuntimeRoutingKey(tool);
+    if (key) {
+      availableToolsByKey.set(key, tool);
+    }
+  }
+
+  const runtimeToolsByKey =
+    indexCustomClientToolSearchRuntimeTools(runtimeTools);
+
+  for (const [runtimeToolKey, runtimeTool] of runtimeToolsByKey) {
+    const existingTool = availableToolsByKey.get(runtimeToolKey);
+    if (
+      existingTool &&
+      existingTool !== runtimeTool &&
+      !replaceableRuntimeToolKeys?.has(runtimeToolKey)
+    ) {
+      throw new ModelBehaviorError(
+        logger.dontLogToolData
+          ? 'Client tool_search execute() returned a tool that conflicts with an existing available tool.'
+          : `Client tool_search execute() returned tool "${getToolSearchRuntimeToolKey(runtimeTool) ?? runtimeToolKey}" that conflicts with an existing available tool.`,
+      );
+    }
+    if (runtimeTool.type === 'function') {
+      const bareToolName = getBareTopLevelFunctionToolName(runtimeTool);
+      if (bareToolName && handoffMap.has(bareToolName)) {
+        throw new ModelBehaviorError(
+          'Client tool_search execute() returned a bare function tool that conflicts with an available handoff. Assign a unique tool name or use a namespace.',
+        );
+      }
+      continue;
+    }
+    if (
+      runtimeTool.type === 'hosted_tool' &&
+      runtimeTool.providerData?.type === 'mcp'
+    ) {
+      continue;
+    }
+    throw new ModelBehaviorError(
+      'Client tool_search execute() returned an unsupported tool type.',
+    );
+  }
+
+  const replacedRuntimeToolSet = new Set(replacedRuntimeTools);
+  for (let index = availableTools.length - 1; index >= 0; index--) {
+    if (replacedRuntimeToolSet.has(availableTools[index]!)) {
+      availableTools.splice(index, 1);
+    }
+  }
+  for (const [key, tool] of functionMap) {
+    if (replacedRuntimeToolSet.has(tool)) {
+      functionMap.delete(key);
+    }
+  }
+  for (const [serverLabel, tool] of mcpToolMap) {
+    if (replacedRuntimeToolSet.has(tool)) {
+      mcpToolMap.delete(serverLabel);
+    }
+  }
+
+  const registeredTools: Tool<TContext>[] = [];
+  for (const [runtimeToolKey, runtimeTool] of runtimeToolsByKey) {
+    const existingIndex = availableTools.findIndex(
+      (availableTool) =>
+        getToolSearchRuntimeRoutingKey(availableTool) === runtimeToolKey,
+    );
+    const existingTool =
+      existingIndex >= 0 ? availableTools[existingIndex] : undefined;
+    if (existingTool === runtimeTool) {
+      if (replaceableRuntimeToolKeys?.has(runtimeToolKey)) {
+        registeredTools.push(runtimeTool);
+      }
+      continue;
+    }
+
+    if (existingIndex >= 0) {
+      availableTools[existingIndex] = runtimeTool;
+    } else {
+      availableTools.push(runtimeTool);
+    }
+    registeredTools.push(runtimeTool);
+    replaceableRuntimeToolKeys?.add(runtimeToolKey);
+    if (runtimeTool.type === 'function') {
+      const runtimeFunctionMap = buildFunctionToolLookupMap([runtimeTool]);
+      for (const [key, tool] of runtimeFunctionMap) {
+        functionMap.set(key, tool);
+      }
+      continue;
+    }
+
+    if (
+      runtimeTool.type === 'hosted_tool' &&
+      runtimeTool.providerData?.type === 'mcp'
+    ) {
+      mcpToolMap.set(
+        runtimeTool.providerData.server_label,
+        runtimeTool as HostedMCPTool,
+      );
+      continue;
+    }
+  }
+
+  return registeredTools;
 }
 
 export function getClientToolSearchHelper<TContext>(

--- a/packages/agents-core/src/runner/tracing.ts
+++ b/packages/agents-core/src/runner/tracing.ts
@@ -233,11 +233,24 @@ export function finishRunnerSpan(
 export function setRunnerSpanError(
   lifecycle: RunnerSpanLifecycle<TaskSpanData | TurnSpanData> | undefined,
   error: unknown,
+  traceIncludeSensitiveData: boolean,
 ): void {
   lifecycle?.span.setError({
     message: 'Error in agent run',
-    data: { error: String(error) },
+    data: {
+      error: getRunnerSpanErrorDetails(error, traceIncludeSensitiveData),
+    },
   });
+}
+
+export function getRunnerSpanErrorDetails(
+  error: unknown,
+  traceIncludeSensitiveData: boolean,
+): string {
+  if (traceIncludeSensitiveData) {
+    return String(error);
+  }
+  return error instanceof Error ? error.name : 'Error';
 }
 
 /**

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -42,7 +42,11 @@ import * as ProviderData from '../types/providerData';
 import * as protocol from '../types/protocol';
 import { AgentInputItem } from '../types';
 import type { FunctionToolResult } from '../tool';
-import { getFunctionToolQualifiedName } from '../toolIdentity';
+import {
+  getFunctionToolStateKey,
+  getFunctionToolStateKeyForCall,
+  getFunctionToolStateKeys,
+} from '../toolIdentity';
 import type { RunErrorData, RunErrorHandlers } from './errorHandlers';
 import {
   createRunErrorFinalOutputItem,
@@ -150,6 +154,7 @@ type ApprovalResolution = 'approved' | 'rejected' | 'pending';
 function resolveApprovalState(
   item: RunToolApprovalItem,
   state: RunState<any, any>,
+  processedResponse: ProcessedResponse<any>,
 ): ApprovalResolution {
   if (isHostedMcpApprovalItem(item)) {
     return 'pending';
@@ -172,7 +177,35 @@ function resolveApprovalState(
     return 'pending';
   }
 
-  const approval = state._context.isToolApproved({ toolName, callId });
+  let toolNames = [toolName];
+  if (rawItem.type === 'function_call') {
+    const functionRun =
+      item.agent === state._currentAgent
+        ? processedResponse.functions.find(
+            (run) => run.toolCall.callId === callId,
+          )
+        : undefined;
+    if (functionRun) {
+      const stateKey = getFunctionToolStateKey(functionRun.tool);
+      toolNames = stateKey ? [stateKey] : toolNames;
+    } else {
+      const stateKey =
+        item.functionToolStateKey ??
+        getFunctionToolStateKeyForCall(rawItem, toolName);
+      toolNames = stateKey ? [stateKey] : toolNames;
+    }
+  }
+
+  const approval = toolNames
+    .map((candidate) =>
+      state._context.isToolApproved({
+        toolName: candidate,
+        callId,
+        functionTool: false,
+        ...(rawItem.type === 'function_call' ? { agent: item.agent } : {}),
+      }),
+    )
+    .find((decision) => typeof decision !== 'undefined');
   if (approval === true) {
     return 'approved';
   }
@@ -202,23 +235,32 @@ function isApprovalItemLike(value: unknown): value is ApprovalItemLike {
   );
 }
 
-function getApprovalIdentity(approval: ApprovalItemLike): string | undefined {
+type ApprovalIdentity = {
+  agent: Agent<any, any> | undefined;
+  value: string;
+};
+
+function getApprovalIdentity(
+  approval: ApprovalItemLike,
+): ApprovalIdentity | undefined {
   const rawItem = approval.rawItem;
   if (!rawItem) {
     return undefined;
   }
 
+  const agent = 'agent' in approval ? approval.agent : undefined;
+
   if (rawItem.type === 'function_call' && rawItem.callId) {
-    return `function_call:${rawItem.callId}`;
+    return { agent, value: `function_call:${rawItem.callId}` };
   }
 
   if ('callId' in rawItem && rawItem.callId) {
-    return `${rawItem.type}:${rawItem.callId}`;
+    return { agent, value: `${rawItem.type}:${rawItem.callId}` };
   }
 
   const id = 'id' in rawItem ? rawItem.id : undefined;
   if (id) {
-    return `${rawItem.type}:${id}`;
+    return { agent, value: `${rawItem.type}:${id}` };
   }
 
   const providerData =
@@ -226,32 +268,53 @@ function getApprovalIdentity(approval: ApprovalItemLike): string | undefined {
       ? (rawItem.providerData as { id?: string })
       : undefined;
   if (providerData?.id) {
-    return `${rawItem.type}:provider:${providerData.id}`;
+    return { agent, value: `${rawItem.type}:provider:${providerData.id}` };
   }
 
   const agentName =
     'agent' in approval && approval.agent ? approval.agent.name : '';
 
   try {
-    return `${agentName}:${rawItem.type}:${JSON.stringify(rawItem)}`;
+    return {
+      agent,
+      value: `${agentName}:${rawItem.type}:${JSON.stringify(rawItem)}`,
+    };
   } catch {
-    return `${agentName}:${rawItem.type}`;
+    return { agent, value: `${agentName}:${rawItem.type}` };
   }
+}
+
+type ApprovalIdentityMap = Map<Agent<any, any> | undefined, Set<string>>;
+
+function hasApprovalIdentity(
+  identities: ApprovalIdentityMap,
+  identity: ApprovalIdentity,
+): boolean {
+  return identities.get(identity.agent)?.has(identity.value) ?? false;
+}
+
+function addApprovalIdentity(
+  identities: ApprovalIdentityMap,
+  identity: ApprovalIdentity,
+): void {
+  const values = identities.get(identity.agent) ?? new Set<string>();
+  values.add(identity.value);
+  identities.set(identity.agent, values);
 }
 
 type AppendContext = {
   seenItems: Set<RunItem>;
-  seenApprovalIdentities: Set<string>;
+  seenApprovalIdentities: ApprovalIdentityMap;
 };
 
 function buildAppendContext(existingItems: RunItem[]): AppendContext {
   const seenItems = new Set<RunItem>(existingItems);
-  const seenApprovalIdentities = new Set<string>();
+  const seenApprovalIdentities: ApprovalIdentityMap = new Map();
   for (const item of existingItems) {
     if (item instanceof RunToolApprovalItem) {
       const identity = getApprovalIdentity(item);
       if (identity) {
-        seenApprovalIdentities.add(identity);
+        addApprovalIdentity(seenApprovalIdentities, identity);
       }
     }
   }
@@ -269,10 +332,10 @@ function appendRunItemIfNew(
   if (item instanceof RunToolApprovalItem) {
     const identity = getApprovalIdentity(item);
     if (identity) {
-      if (context.seenApprovalIdentities.has(identity)) {
+      if (hasApprovalIdentity(context.seenApprovalIdentities, identity)) {
         return;
       }
-      context.seenApprovalIdentities.add(identity);
+      addApprovalIdentity(context.seenApprovalIdentities, identity);
     }
   }
   context.seenItems.add(item);
@@ -300,7 +363,11 @@ function buildApprovedCallIdSet(
   return callIds;
 }
 
-function collectCompletedCallIds(items: RunItem[], type: string): Set<string> {
+function collectCompletedCallIds(
+  items: RunItem[],
+  type: string,
+  agent?: Agent<any, any>,
+): Set<string> {
   const completed = new Set<string>();
   for (const item of items) {
     const rawItem = item.rawItem;
@@ -308,6 +375,9 @@ function collectCompletedCallIds(items: RunItem[], type: string): Set<string> {
       continue;
     }
     if ((rawItem as { type?: string }).type !== type) {
+      continue;
+    }
+    if (agent && (!('agent' in item) || item.agent !== agent)) {
       continue;
     }
     const callId = (rawItem as { callId?: unknown }).callId;
@@ -651,6 +721,7 @@ export async function resolveInterruptedTurn<TContext>(
     .filter(
       (item) =>
         item instanceof RunToolApprovalItem &&
+        item.agent === agent &&
         'callId' in item.rawItem &&
         item.rawItem.type === 'function_call',
     )
@@ -659,6 +730,7 @@ export async function resolveInterruptedTurn<TContext>(
   const completedFunctionCallIds = collectCompletedCallIds(
     originalPreStepItems,
     'function_call_result',
+    agent,
   );
   const completedComputerCallIds = collectCompletedCallIds(
     originalPreStepItems,
@@ -680,7 +752,7 @@ export async function resolveInterruptedTurn<TContext>(
     .getInterruptions()
     .filter(isApprovalItemLike);
 
-  const pendingApprovalIdentities = new Set<string>();
+  const pendingApprovalIdentities: ApprovalIdentityMap = new Map();
   for (const approval of pendingApprovalItems) {
     if (!(approval instanceof RunToolApprovalItem)) {
       continue;
@@ -691,6 +763,7 @@ export async function resolveInterruptedTurn<TContext>(
     const rawItem = approval.rawItem;
     if (
       rawItem.type === 'function_call' &&
+      approval.agent === agent &&
       rawItem.callId &&
       completedFunctionCallIds.has(rawItem.callId)
     ) {
@@ -719,8 +792,10 @@ export async function resolveInterruptedTurn<TContext>(
     }
     const identity = getApprovalIdentity(approval);
     if (identity) {
-      if (resolveApprovalState(approval, state) === 'pending') {
-        pendingApprovalIdentities.add(identity);
+      if (
+        resolveApprovalState(approval, state, processedResponse) === 'pending'
+      ) {
+        addApprovalIdentity(pendingApprovalIdentities, identity);
       }
     }
   }
@@ -731,10 +806,10 @@ export async function resolveInterruptedTurn<TContext>(
       return false;
     }
     const isApprovedCall = functionCallIds.includes(callId);
-    const isPendingNested = state.hasPendingAgentToolRun(
-      getFunctionToolQualifiedName(run.tool) ?? run.tool.name,
-      callId,
-    );
+    const isPendingNested = getFunctionToolStateKeys(
+      run.tool,
+      run.availableFunctionTools ?? [run.tool],
+    ).some((stateKey) => state.hasPendingAgentToolRun(stateKey, callId));
     if (!isApprovedCall && !isPendingNested) {
       return false;
     }
@@ -873,6 +948,7 @@ export async function resolveInterruptedTurn<TContext>(
       return state._context.isToolApproved({
         toolName: rawItem.name,
         callId: approvalRequestId,
+        functionTool: false,
       });
     },
   });
@@ -908,7 +984,7 @@ export async function resolveInterruptedTurn<TContext>(
     if (!identity) {
       return true;
     }
-    return pendingApprovalIdentities.has(identity);
+    return hasApprovalIdentity(pendingApprovalIdentities, identity);
   });
 
   const keptApprovalItems = new Set<RunToolApprovalItem>();
@@ -1073,6 +1149,7 @@ export async function resolveTurnAfterModelResponse<
         return state._context.isToolApproved({
           toolName: rawItem.name,
           callId: approvalRequestId,
+          functionTool: false,
         });
       },
     });

--- a/packages/agents-core/src/runner/types.ts
+++ b/packages/agents-core/src/runner/types.ts
@@ -20,6 +20,7 @@ import type * as protocol from '../types/protocol';
 import type { ModelInputData } from './conversation';
 import type { Span } from '../tracing/spans';
 import type { Trace } from '../tracing/traces';
+import type { ToolNameCollisionPolicy } from './runConfig';
 
 export type ToolRunHandoff = {
   toolCall: protocol.FunctionCallItem;
@@ -29,7 +30,35 @@ export type ToolRunHandoff = {
 export type ToolRunFunction<TContext = UnknownContext> = {
   toolCall: protocol.FunctionCallItem;
   tool: FunctionTool<TContext>;
+  /** @internal Exact prepared function-tool snapshot used to resolve this call. */
+  availableFunctionTools?: FunctionTool<TContext>[];
+  /** @internal Preserve a trusted runtime-loaded handler during sandbox tool rebinding. */
+  preserveToolOnExecutionRehydration?: boolean;
 };
+
+/** @internal */
+export function createToolRunFunction<TContext>(args: {
+  toolCall: protocol.FunctionCallItem;
+  tool: FunctionTool<TContext>;
+  availableFunctionTools: FunctionTool<TContext>[];
+  preserveToolOnExecutionRehydration?: boolean;
+}): ToolRunFunction<TContext> {
+  const toolRun: ToolRunFunction<TContext> = {
+    toolCall: args.toolCall,
+    tool: args.tool,
+  };
+  Object.defineProperty(toolRun, 'availableFunctionTools', {
+    value: args.availableFunctionTools,
+    enumerable: false,
+  });
+  if (args.preserveToolOnExecutionRehydration) {
+    Object.defineProperty(toolRun, 'preserveToolOnExecutionRehydration', {
+      value: true,
+      enumerable: false,
+    });
+  }
+  return toolRun;
+}
 
 export type ToolRunFunctionNotFound = {
   toolCall: protocol.FunctionCallItem;
@@ -84,6 +113,7 @@ export type PreparedModelCall<TContext = UnknownContext> =
     modelRequestInternal: {
       reasoningEffortImplicit: boolean;
       tracingParent?: Span<any> | Trace;
+      toolNameCollisionPolicy: ToolNameCollisionPolicy;
     };
     modelSettings: ModelSettings;
     modelInput: ModelInputData;

--- a/packages/agents-core/src/sandbox/runtime/toolRehydration.ts
+++ b/packages/agents-core/src/sandbox/runtime/toolRehydration.ts
@@ -11,8 +11,8 @@ import type {
 import {
   FUNCTION_TOOL_NAMESPACE,
   FUNCTION_TOOL_NAMESPACE_DESCRIPTION,
-  getFunctionToolQualifiedName,
-  resolveFunctionToolCallName,
+  getFunctionToolLookupKeyForCall,
+  getFunctionToolLookupKeyForTool,
 } from '../../toolIdentity';
 import * as protocol from '../../types/protocol';
 import { isSandboxAgent } from './agentKeys';
@@ -65,17 +65,16 @@ export function processedResponseRequiresExecutionToolRehydration(
 function hasConfiguredFunctionTool(
   tools: Tool<any>[],
   toolCall: protocol.FunctionCallItem,
-  toolIdentity: string,
 ): boolean {
-  const configuredFunctionTools = new Map(
-    tools
-      .filter((tool) => tool.type === 'function')
-      .map((tool) => [getFunctionToolQualifiedName(tool) ?? tool.name, tool]),
+  const callKey = getFunctionToolLookupKeyForCall(toolCall);
+  return Boolean(
+    callKey &&
+    tools.some(
+      (tool) =>
+        tool.type === 'function' &&
+        getFunctionToolLookupKeyForTool(tool) === callKey,
+    ),
   );
-  const configuredIdentity =
-    resolveFunctionToolCallName(toolCall, configuredFunctionTools) ??
-    toolIdentity;
-  return configuredFunctionTools.has(configuredIdentity);
 }
 
 function hasConfiguredTool(
@@ -158,11 +157,7 @@ export function getSerializedFunctionToolPlaceholder<TContext>(args: {
     !canUseSerializedExecutionToolPlaceholder({
       agent,
       allowSerializedExecutionToolPlaceholder,
-      configuredToolExists: hasConfiguredFunctionTool(
-        baseAgentTools,
-        toolCall,
-        toolIdentity,
-      ),
+      configuredToolExists: hasConfiguredFunctionTool(baseAgentTools, toolCall),
       serializedTool,
       type: 'function',
     })

--- a/packages/agents-core/src/tool.ts
+++ b/packages/agents-core/src/tool.ts
@@ -33,6 +33,7 @@ import type { ZodInfer, ZodObjectLike } from './utils/zodCompat';
 import {
   FUNCTION_TOOL_NAMESPACE,
   FUNCTION_TOOL_NAMESPACE_DESCRIPTION,
+  getFunctionToolLookupKeyForTool,
   getFunctionToolQualifiedName,
 } from './toolIdentity';
 import {
@@ -1323,6 +1324,16 @@ export function getToolSearchRuntimeToolKey<Context = UnknownContext>(
   }
 
   return undefined;
+}
+
+/** @internal */
+export function getToolSearchRuntimeRoutingKey<Context = UnknownContext>(
+  tool: Tool<Context>,
+): string | undefined {
+  if (tool.type === 'function') {
+    return getFunctionToolLookupKeyForTool(tool);
+  }
+  return getToolSearchRuntimeToolKey(tool);
 }
 
 /**

--- a/packages/agents-core/src/toolIdentity.ts
+++ b/packages/agents-core/src/toolIdentity.ts
@@ -1,4 +1,5 @@
 import type { FunctionTool } from './tool';
+import { UserError } from './errors';
 import { toolDisplayName, toolQualifiedName } from './tooling';
 export { toolDisplayName, toolQualifiedName } from './tooling';
 
@@ -19,8 +20,19 @@ type MaybeToolCallWithNamespace = {
   namespace?: unknown;
 };
 
+declare const FUNCTION_TOOL_LOOKUP_KEY: unique symbol;
+
+/** @internal */
+export type FunctionToolLookupKey = string & {
+  readonly [FUNCTION_TOOL_LOOKUP_KEY]: true;
+};
+
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0;
+}
+
+function encodeFunctionToolLookupKey(parts: string[]): FunctionToolLookupKey {
+  return JSON.stringify(parts) as FunctionToolLookupKey;
 }
 
 export function getToolCallNamespace(
@@ -53,60 +65,229 @@ export function getToolCallDisplayName(
   );
 }
 
-type ToolNameLookup = {
-  has(name: string): boolean;
-  get?(name: string): unknown;
-};
+/** @internal */
+export function getFunctionToolLookupKey(
+  name: string | undefined,
+  namespace?: string,
+): FunctionToolLookupKey | undefined {
+  if (!isNonEmptyString(name)) {
+    return undefined;
+  }
+  if (namespace === name) {
+    return encodeFunctionToolLookupKey(['deferred_top_level', name]);
+  }
+  if (isNonEmptyString(namespace)) {
+    return encodeFunctionToolLookupKey(['namespaced', namespace, name]);
+  }
+  return encodeFunctionToolLookupKey(['bare', name]);
+}
 
-function isTopLevelDeferredFunctionTool(
-  candidate: unknown,
-  bareName: string,
-): boolean {
-  const tool = candidate as MaybeFunctionToolWithNamespaceMetadata & {
-    type?: unknown;
-    name?: unknown;
-  };
-  return (
-    tool?.type === 'function' &&
-    tool.name === bareName &&
-    tool.deferLoading === true &&
-    !isNonEmptyString(tool?.[FUNCTION_TOOL_NAMESPACE])
+/** @internal */
+export function getFunctionToolLookupKeyForCall(
+  toolCall: MaybeToolCallWithNamespace,
+): FunctionToolLookupKey | undefined {
+  return getFunctionToolLookupKey(
+    getToolCallName(toolCall),
+    getToolCallNamespace(toolCall),
   );
 }
 
-export function resolveFunctionToolCallName(
-  toolCall: MaybeToolCallWithNamespace,
-  availableToolNames: ToolNameLookup,
+/** @internal */
+export function isDeferredTopLevelFunctionTool(tool: unknown): boolean {
+  const candidate = tool as MaybeFunctionToolWithNamespaceMetadata;
+  return (
+    candidate?.deferLoading === true &&
+    !getExplicitFunctionToolNamespace(tool) &&
+    isNonEmptyString(candidate?.name)
+  );
+}
+
+/** @internal */
+export function getBareTopLevelFunctionToolName(
+  tool: unknown,
 ): string | undefined {
-  const bareName = getToolCallName(toolCall);
-  const namespace = getToolCallNamespace(toolCall);
-  if (bareName && !namespace && availableToolNames.has(bareName)) {
-    return bareName;
+  const name = getFunctionToolName(tool);
+  if (
+    !name ||
+    getExplicitFunctionToolNamespace(tool) ||
+    isDeferredTopLevelFunctionTool(tool)
+  ) {
+    return undefined;
   }
+  return name;
+}
 
-  const qualifiedName = getToolCallQualifiedName(toolCall);
-  const bareTool =
-    bareName && typeof availableToolNames.get === 'function'
-      ? availableToolNames.get(bareName)
-      : undefined;
-  const preferBareSelfNamespacedDeferredTool =
-    bareName &&
-    namespace === bareName &&
-    availableToolNames.has(bareName) &&
-    isTopLevelDeferredFunctionTool(bareTool, bareName);
+/** @internal */
+export function getFunctionToolLookupKeyForTool(
+  tool: Pick<FunctionTool<any, any, any>, 'name'> | unknown,
+): FunctionToolLookupKey | undefined {
+  const name = getFunctionToolName(tool);
+  if (isDeferredTopLevelFunctionTool(tool)) {
+    return encodeFunctionToolLookupKey(['deferred_top_level', name!]);
+  }
+  return getFunctionToolLookupKey(name, getExplicitFunctionToolNamespace(tool));
+}
 
-  if (qualifiedName && availableToolNames.has(qualifiedName)) {
-    if (preferBareSelfNamespacedDeferredTool) {
-      return bareName;
+/** @internal */
+export function assertFunctionToolLookupConfiguration(
+  tools: readonly unknown[],
+): void {
+  const strictOwners = new Map<FunctionToolLookupKey, unknown>();
+  for (const tool of tools) {
+    const name = getFunctionToolName(tool);
+    const namespace = getExplicitFunctionToolNamespace(tool);
+    if (name && namespace === name) {
+      throw new UserError(
+        'Responses tool search reserves same-name namespaces for deferred top-level function tools. Rename the namespace or tool name to avoid ambiguous dispatch.',
+      );
     }
-    return qualifiedName;
+
+    if (!namespace && !isDeferredTopLevelFunctionTool(tool)) {
+      continue;
+    }
+    const key = getFunctionToolLookupKeyForTool(tool);
+    if (!key) {
+      continue;
+    }
+    if (strictOwners.has(key)) {
+      throw new UserError(
+        'Ambiguous function tool configuration. Assign unique names within each namespace and for deferred top-level tools.',
+      );
+    }
+    strictOwners.set(key, tool);
+  }
+}
+
+/** @internal */
+export function buildFunctionToolLookupMap<TTool>(
+  tools: readonly TTool[],
+): Map<FunctionToolLookupKey, TTool> {
+  assertFunctionToolLookupConfiguration(tools);
+  const lookup = new Map<FunctionToolLookupKey, TTool>();
+  for (const tool of tools) {
+    const key = getFunctionToolLookupKeyForTool(tool);
+    if (key) {
+      lookup.set(key, tool);
+    }
+  }
+  return lookup;
+}
+
+/** @internal */
+export function resolveFunctionToolCall<TTool>(
+  toolCall: MaybeToolCallWithNamespace,
+  availableTools: ReadonlyMap<FunctionToolLookupKey, TTool>,
+): TTool | undefined {
+  const key = getFunctionToolLookupKeyForCall(toolCall);
+  const directMatch = key ? availableTools.get(key) : undefined;
+  if (directMatch || getToolCallNamespace(toolCall)) {
+    return directMatch;
   }
 
-  if (bareName && namespace === bareName && availableToolNames.has(bareName)) {
-    return bareName;
+  const name = getToolCallName(toolCall);
+  const deferredKey = name
+    ? encodeFunctionToolLookupKey(['deferred_top_level', name])
+    : undefined;
+  const deferredMatch = deferredKey
+    ? availableTools.get(deferredKey)
+    : undefined;
+  if (deferredMatch || !name) {
+    return deferredMatch;
   }
 
-  return qualifiedName ?? bareName;
+  let flattenedNamespaceMatch: TTool | undefined;
+  for (const tool of availableTools.values()) {
+    if (
+      !getExplicitFunctionToolNamespace(tool) ||
+      getFunctionToolQualifiedName(tool) !== name
+    ) {
+      continue;
+    }
+    if (flattenedNamespaceMatch && flattenedNamespaceMatch !== tool) {
+      return undefined;
+    }
+    flattenedNamespaceMatch = tool;
+  }
+  return flattenedNamespaceMatch;
+}
+
+/** @internal */
+export function getFunctionToolStateKey(
+  tool: Pick<FunctionTool<any, any, any>, 'name'> | unknown,
+): string | undefined {
+  const name = getFunctionToolName(tool);
+  if (!name) {
+    return undefined;
+  }
+  return getFunctionToolLookupKeyForTool(tool);
+}
+
+/** @internal */
+export function getFunctionToolStateKeyForCall(
+  toolCall: MaybeToolCallWithNamespace,
+  fallbackName?: string,
+): string | undefined {
+  const name = getToolCallName(toolCall);
+  const namespace = getToolCallNamespace(toolCall);
+  return (
+    getFunctionToolLookupKey(name ?? fallbackName, namespace) ?? fallbackName
+  );
+}
+
+/** @internal */
+export function getFunctionToolStateKeyForResolvedCall(
+  toolCall: MaybeToolCallWithNamespace,
+  tool: Pick<FunctionTool<any, any, any>, 'name'> | unknown,
+  resolvedToolStateKey = getFunctionToolStateKey(tool),
+): string | undefined {
+  const callStateKey = getFunctionToolStateKeyForCall(toolCall);
+  if (!callStateKey || !resolvedToolStateKey) {
+    return undefined;
+  }
+  if (callStateKey === resolvedToolStateKey) {
+    return resolvedToolStateKey;
+  }
+
+  return !getToolCallNamespace(toolCall) &&
+    isDeferredTopLevelFunctionTool(tool) &&
+    getToolCallName(toolCall) === getFunctionToolName(tool)
+    ? resolvedToolStateKey
+    : undefined;
+}
+
+/** @internal */
+export function getFunctionToolStateKeys(
+  tool: Pick<FunctionTool<any, any, any>, 'name'> | unknown,
+  availableTools: readonly unknown[] = [],
+): string[] {
+  const primary = getFunctionToolStateKey(tool);
+  if (!primary) {
+    return [];
+  }
+  const name = getFunctionToolName(tool);
+  if (!name) {
+    return [primary];
+  }
+  const legacyKey = getFunctionToolLegacyStateKey(tool);
+  if (!legacyKey || legacyKey === primary) {
+    return [primary];
+  }
+  const hasLegacyCollision = availableTools.some(
+    (candidate) =>
+      candidate !== tool &&
+      getFunctionToolLegacyStateKey(candidate) === legacyKey &&
+      getFunctionToolStateKey(candidate) !== primary,
+  );
+  return hasLegacyCollision ? [primary] : [primary, legacyKey];
+}
+
+function getFunctionToolLegacyStateKey(tool: unknown): string | undefined {
+  const name = getFunctionToolName(tool);
+  if (!name) {
+    return undefined;
+  }
+  const namespace = getExplicitFunctionToolNamespace(tool);
+  return namespace ? toolQualifiedName(name, namespace) : name;
 }
 
 export function getExplicitFunctionToolNamespace(

--- a/packages/agents-core/src/toolIdentity.ts
+++ b/packages/agents-core/src/toolIdentity.ts
@@ -223,6 +223,37 @@ export function getFunctionToolStateKey(
 }
 
 /** @internal */
+export function getFunctionToolLegacyStateKeyFromStateKey(
+  stateKey: string,
+): string | undefined {
+  let parts: unknown;
+  try {
+    parts = JSON.parse(stateKey);
+  } catch {
+    return undefined;
+  }
+  if (!Array.isArray(parts)) {
+    return undefined;
+  }
+  if (
+    (parts[0] === 'bare' || parts[0] === 'deferred_top_level') &&
+    parts.length === 2 &&
+    isNonEmptyString(parts[1])
+  ) {
+    return parts[1];
+  }
+  if (
+    parts[0] === 'namespaced' &&
+    parts.length === 3 &&
+    isNonEmptyString(parts[1]) &&
+    isNonEmptyString(parts[2])
+  ) {
+    return toolQualifiedName(parts[2], parts[1]);
+  }
+  return undefined;
+}
+
+/** @internal */
 export function getFunctionToolStateKeyForCall(
   toolCall: MaybeToolCallWithNamespace,
   fallbackName?: string,

--- a/packages/agents-core/src/tracing/createSpans.ts
+++ b/packages/agents-core/src/tracing/createSpans.ts
@@ -78,7 +78,9 @@ function _withSpanFactory<
         }
         return result;
       } catch (error: unknown) {
-        setSpanError(span, error);
+        if (span.error === null) {
+          setSpanError(span, error);
+        }
         throw error;
       } finally {
         if (!endDeferred) {

--- a/packages/agents-core/test/agent.test.ts
+++ b/packages/agents-core/test/agent.test.ts
@@ -1056,6 +1056,7 @@ describe('Agent', () => {
       handoffInputFilter,
       traceIncludeSensitiveData: false,
       traceId: 'trace_parent_fixed',
+      toolNameCollisionPolicy: 'error',
     });
 
     await tool.invoke(
@@ -1076,6 +1077,7 @@ describe('Agent', () => {
     expect(nestedRunner.config.handoffInputFilter).toBeUndefined();
     expect(nestedRunner.config.traceId).toBeUndefined();
     expect(nestedRunner.config.traceIncludeSensitiveData).toBe(true);
+    expect(nestedRunner.config.toolNameCollisionPolicy).toBe('error');
   });
 
   it('does not inherit parent tool-selection modelSettings into nested agent tools', async () => {

--- a/packages/agents-core/test/agentScenarios.test.ts
+++ b/packages/agents-core/test/agentScenarios.test.ts
@@ -39,11 +39,13 @@ import {
   defineToolOutputGuardrail,
   shellTool,
   applyPatchTool,
+  attachClientToolSearchExecutor,
 } from '../src';
 import { getDefaultModelProvider } from '../src/providers';
 import { user } from '../src/helpers/message';
 import * as protocol from '../src/types/protocol';
 import logger from '../src/logger';
+import { getFunctionToolStateKey } from '../src/toolIdentity';
 
 /**
  * Fake model for scenario-style tests. It queues per-turn outputs (or errors),
@@ -83,9 +85,7 @@ class RecordingModel implements Model {
       throw new Error('No queued output');
     }
     return this.#turnOutputs.shift() as
-      | ModelResponse
-      | ModelResponse['output']
-      | Error;
+      ModelResponse | ModelResponse['output'] | Error;
   }
 
   #recordArgs(request: ModelRequest) {
@@ -575,6 +575,139 @@ describe('Agent scenarios (examples and docs patterns)', () => {
 
     warnSpy.mockRestore();
   });
+
+  it.each([
+    ['current schema after restoration', 'after restoration', false],
+    ['legacy schema before serialization', 'before serialization', true],
+    ['legacy schema after restoration', 'after restoration', true],
+  ] as const)(
+    'rebinds nested deferred bare approvals in %s',
+    async (_description, approvalTiming, downgrade) => {
+      let executions = 0;
+      const deferredApprovalTool = tool({
+        name: 'secure_lookup',
+        description: 'Requires approval after deferred loading.',
+        parameters: z.object({}).strict(),
+        deferLoading: true,
+        needsApproval: true,
+        execute: async () => {
+          executions += 1;
+          return 'approved lookup';
+        },
+      });
+      const clientToolSearch = attachClientToolSearchExecutor(
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: { type: 'tool_search', execution: 'client' },
+        },
+        async () => deferredApprovalTool,
+      );
+      const nestedModel = new RecordingModel();
+      nestedModel.addMultipleTurnOutputs([
+        [
+          {
+            type: 'tool_search_call',
+            id: 'nested-search-call',
+            status: 'completed',
+            arguments: {},
+            providerData: {
+              call_id: 'nested-search-provider-call',
+              execution: 'client',
+            },
+          } as protocol.ToolSearchCallItem,
+          functionToolCall('secure_lookup', '{}', 'nested-deferred-call'),
+        ],
+        [textMessage('Nested done')],
+      ]);
+      const nestedAgent = new Agent({
+        name: 'LegacyNestedDeferredAgent',
+        model: nestedModel,
+        tools: [clientToolSearch],
+      });
+      const nestedTool = nestedAgent.asTool({
+        toolName: 'legacy_nested_agent',
+        toolDescription: 'Runs the nested deferred approval agent.',
+      });
+      const outerModel = new RecordingModel();
+      outerModel.addMultipleTurnOutputs([
+        [
+          functionToolCall(
+            nestedTool.name,
+            JSON.stringify({ input: 'look up the record' }),
+            'outer-nested-call',
+          ),
+        ],
+        [textMessage('Outer done')],
+      ]);
+      const outerAgent = new Agent({
+        name: 'LegacyNestedDeferredOuterAgent',
+        model: outerModel,
+        tools: [nestedTool],
+      });
+      const runner = new Runner();
+
+      const first = await runner.run(outerAgent, 'start');
+      expect(first.interruptions).toHaveLength(1);
+      expect(first.interruptions[0]?.agent).toBe(nestedAgent);
+
+      if (approvalTiming === 'before serialization') {
+        first.state.approve(first.interruptions[0]!);
+      }
+      const publicApprovals = first.state._context.toJSON().approvals;
+      const serialized = first.state.toJSON() as any;
+      const downgradeToLegacy = (value: any) => {
+        value.$schemaVersion = '1.15';
+        delete value.context.functionApprovals;
+        delete value.context.legacyFunctionApprovals;
+        delete value.pendingAgentToolRunAliases;
+        for (const interruption of value.currentStep?.data?.interruptions ??
+          []) {
+          delete interruption.functionToolStateKey;
+        }
+      };
+      if (downgrade) {
+        for (const [key, pendingState] of Object.entries(
+          serialized.pendingAgentToolRuns,
+        )) {
+          const nestedState = JSON.parse(pendingState as string);
+          downgradeToLegacy(nestedState);
+          serialized.pendingAgentToolRuns[key] = JSON.stringify(nestedState);
+        }
+        downgradeToLegacy(serialized);
+        serialized.context.approvals = {
+          ...serialized.context.approvals,
+          ...publicApprovals,
+        };
+      }
+
+      const restored = await RunState.fromString(
+        outerAgent,
+        JSON.stringify(serialized),
+      );
+      const approval = restored.getInterruptions()[0];
+      expect(approval?.functionToolStateKey).toBe(
+        getFunctionToolStateKey(deferredApprovalTool),
+      );
+      if (approvalTiming === 'after restoration') {
+        restored.approve(approval!);
+      } else {
+        expect(
+          restored._context.isToolApproved({
+            toolName: getFunctionToolStateKey(deferredApprovalTool)!,
+            callId: 'nested-deferred-call',
+            functionTool: false,
+            agent: nestedAgent,
+          }),
+        ).toBe(true);
+      }
+
+      const resumed = await runner.run(outerAgent, restored);
+      expect(resumed.interruptions).toHaveLength(0);
+      expect(resumed.finalOutput).toBe('Outer done');
+      expect(executions).toBe(1);
+    },
+  );
 
   it('handles multi-step approvals in deeply nested agent tools', async () => {
     const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});

--- a/packages/agents-core/test/index.test.ts
+++ b/packages/agents-core/test/index.test.ts
@@ -9,6 +9,7 @@ import type {
   AgentToolOptionsWithDefault,
   AgentToolOptionsWithParameters,
   RunHookEvents,
+  ToolNameCollisionPolicy,
 } from '../src/index';
 import * as Sandbox from '../src/sandbox';
 import * as LocalSandbox from '../src/sandbox/local';
@@ -34,6 +35,7 @@ describe('index.ts', () => {
       AgentToolOptionsWithDefault<undefined, TestAgent>,
       AgentToolOptionsWithParameters<undefined, TestAgent, typeof _parameters>,
       AgentTool<undefined, TestAgent, typeof _parameters>,
+      ToolNameCollisionPolicy,
     ];
 
     expectTypeOf<PublicTypes>().not.toBeNever();

--- a/packages/agents-core/test/items.test.ts
+++ b/packages/agents-core/test/items.test.ts
@@ -284,6 +284,7 @@ describe('items toJSON()', () => {
         rawItem: item.rawItem,
         agent: item.agent.toJSON(),
         toolName: 'test',
+        functionToolStateKey: '["bare","test"]',
       });
     });
 
@@ -305,39 +306,51 @@ describe('items toJSON()', () => {
       expect(deferredItem.name).toBe('get_shipping_eta');
     });
 
-    it('keeps qualified approval names when agent tools resolve a same-name namespace', () => {
-      const namespacedLookupAccount = createLegacyNamespacedTool(
+    it('does not revalidate disabled agent tools when constructing approval items', () => {
+      const enabledLookupAccount = createLegacyNamespacedTool(
         tool({
           name: 'lookup_account',
           description: 'Look up an account.',
           parameters: z.object({
             accountId: z.string(),
           }),
-          deferLoading: true,
           execute: async () => 'ok',
         }),
-        'lookup_account',
-        'Resolve same-name namespace members.',
+        'crm',
+        'CRM tools.',
+      );
+      const disabledLookupAccount = createLegacyNamespacedTool(
+        tool({
+          name: 'lookup_account',
+          description: 'Disabled duplicate.',
+          parameters: z.object({}),
+          isEnabled: false,
+          execute: async () => 'disabled',
+        }),
+        'crm',
+        'CRM tools.',
       );
 
-      const namespacedItem = new ToolApprovalItem(
+      const approvalItem = new ToolApprovalItem(
         {
           id: 'approval_2',
           type: 'function_call',
           callId: 'call_2',
           name: 'lookup_account',
-          namespace: 'lookup_account',
+          namespace: 'crm',
           arguments: '{}',
           status: 'completed',
         },
         new Agent({
           name: 'NamespacedApprovalAgent',
-          tools: [namespacedLookupAccount],
+          tools: [enabledLookupAccount, disabledLookupAccount],
         }),
       );
 
-      expect(namespacedItem.toolName).toBe('lookup_account.lookup_account');
-      expect(namespacedItem.name).toBe('lookup_account.lookup_account');
+      expect(approvalItem.toolName).toBe('crm.lookup_account');
+      expect(approvalItem.functionToolStateKey).toBe(
+        '["namespaced","crm","lookup_account"]',
+      );
     });
   });
 });

--- a/packages/agents-core/test/run.approvalGuardrailSession.test.ts
+++ b/packages/agents-core/test/run.approvalGuardrailSession.test.ts
@@ -395,6 +395,123 @@ describe('approved tool output guardrail session persistence', () => {
     },
   );
 
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'scopes duplicate nested approval call IDs to the owning agent in $mode runs',
+    async (mode) => {
+      let firstExecutions = 0;
+      let secondExecutions = 0;
+      const createNestedAgent = (
+        name: string,
+        execute: () => Promise<string>,
+      ) => {
+        const approvalTool = tool({
+          name: 'shared_approval_tool',
+          description: 'Requires approval.',
+          parameters: z.object({}),
+          needsApproval: true,
+          execute,
+        });
+        return new Agent({
+          name,
+          model: new ApprovalSessionModel([
+            {
+              output: [
+                functionToolCall(
+                  'shared_approval_tool',
+                  'shared-provider-call-id',
+                ),
+              ],
+              usage: new Usage(),
+            },
+          ]),
+          tools: [approvalTool],
+          toolUseBehavior: 'stop_on_first_tool',
+        });
+      };
+      const firstNestedAgent = createNestedAgent(
+        'Duplicate approval agent',
+        async () => {
+          firstExecutions += 1;
+          return 'first-approved';
+        },
+      );
+      const secondNestedAgent = createNestedAgent(
+        'Duplicate approval agent',
+        async () => {
+          secondExecutions += 1;
+          return 'second-approved';
+        },
+      );
+      const firstNestedTool = firstNestedAgent.asTool({
+        toolName: 'first_nested_agent',
+        toolDescription: 'Runs the first nested agent.',
+      });
+      const secondNestedTool = secondNestedAgent.asTool({
+        toolName: 'second_nested_agent',
+        toolDescription: 'Runs the second nested agent.',
+      });
+      const outerAgent = new Agent({
+        name: 'Duplicate approval outer agent',
+        model: new ApprovalSessionModel([
+          {
+            output: [
+              functionToolCall(
+                firstNestedTool.name,
+                'first-outer-call',
+                JSON.stringify({ input: 'Run the first nested agent.' }),
+              ),
+              functionToolCall(
+                secondNestedTool.name,
+                'second-outer-call',
+                JSON.stringify({ input: 'Run the second nested agent.' }),
+              ),
+            ],
+            usage: new Usage(),
+          },
+        ]),
+        tools: [firstNestedTool, secondNestedTool],
+        toolUseBehavior: 'stop_on_first_tool',
+      });
+
+      const runOnce = async (
+        input: string | RunState<unknown, typeof outerAgent>,
+      ) => {
+        if (mode === 'streamed') {
+          const result = await run(outerAgent, input, { stream: true });
+          await result.completed;
+          return result;
+        }
+        return run(outerAgent, input);
+      };
+
+      const first = await runOnce('Run both nested agents.');
+      expect(first.interruptions).toHaveLength(2);
+
+      const restored = await RunState.fromString(
+        outerAgent,
+        first.state.toString(),
+      );
+      const firstApproval = restored
+        .getInterruptions()
+        .find((item) => item.agent === firstNestedAgent)!;
+      const secondApproval = restored
+        .getInterruptions()
+        .find((item) => item.agent === secondNestedAgent)!;
+      restored.approve(firstApproval);
+      restored.reject(secondApproval, { message: 'Second call rejected.' });
+
+      const decidedState = await RunState.fromString(
+        outerAgent,
+        restored.toString(),
+      );
+      const resumed = await runOnce(decidedState);
+
+      expect(resumed.interruptions).toHaveLength(0);
+      expect(firstExecutions).toBe(1);
+      expect(secondExecutions).toBe(0);
+    },
+  );
+
   it('runs streaming compaction after a partially approved resume', async () => {
     const approvalTool = tool({
       name: 'partial_approval_tool',

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -36,6 +36,7 @@ import {
   user,
   assistant,
   type ToolExecutionConfig,
+  type ToolNameCollisionPolicy,
   type ToolNotFoundBehavior,
 } from '../src';
 import { RunStreamEvent } from '../src/events';
@@ -865,6 +866,70 @@ describe('Runner.run', () => {
       expect(runner.config.toolNotFoundBehavior).toBe('return_error_to_model');
     });
 
+    it('defaults the public tool name collision policy to warn', () => {
+      const runner = new Runner({ tracingDisabled: true });
+
+      expect(runner.config.toolNameCollisionPolicy).toBe('warn');
+    });
+
+    it('accepts the public tool name collision policy config', () => {
+      const toolNameCollisionPolicy = 'error' satisfies ToolNameCollisionPolicy;
+      const runner = new Runner({
+        tracingDisabled: true,
+        toolNameCollisionPolicy,
+      });
+
+      expect(runner.config.toolNameCollisionPolicy).toBe('error');
+    });
+
+    it('rejects an invalid tool name collision policy in Runner config', () => {
+      expect(
+        () =>
+          new Runner({
+            toolNameCollisionPolicy: 'invalid' as ToolNameCollisionPolicy,
+          }),
+      ).toThrow('toolNameCollisionPolicy must be either "warn" or "error".');
+    });
+
+    it('rejects a null tool name collision policy in Runner config', () => {
+      expect(
+        () =>
+          new Runner({
+            toolNameCollisionPolicy: null as any,
+          }),
+      ).toThrow('toolNameCollisionPolicy must be either "warn" or "error".');
+    });
+
+    it('rejects an invalid per-run tool name collision policy before model calls', async () => {
+      const model = new FakeModel([TEST_MODEL_RESPONSE_BASIC]);
+      const getResponse = vi.spyOn(model, 'getResponse');
+      const agent = new Agent({ name: 'Invalid policy agent', model });
+
+      await expect(
+        new Runner().run(agent, 'hello', {
+          toolNameCollisionPolicy: 'invalid' as ToolNameCollisionPolicy,
+        }),
+      ).rejects.toThrow(
+        'toolNameCollisionPolicy must be either "warn" or "error".',
+      );
+      expect(getResponse).not.toHaveBeenCalled();
+    });
+
+    it('rejects a null per-run tool name collision policy before model calls', async () => {
+      const model = new FakeModel([TEST_MODEL_RESPONSE_BASIC]);
+      const getResponse = vi.spyOn(model, 'getResponse');
+      const agent = new Agent({ name: 'Null policy agent', model });
+
+      await expect(
+        new Runner().run(agent, 'hello', {
+          toolNameCollisionPolicy: null as any,
+        }),
+      ).rejects.toThrow(
+        'toolNameCollisionPolicy must be either "warn" or "error".',
+      );
+      expect(getResponse).not.toHaveBeenCalled();
+    });
+
     it('keeps the default provider lazy until a string model needs it', async () => {
       const model = new FakeModel([TEST_MODEL_RESPONSE_BASIC]);
       const provider = {
@@ -1578,7 +1643,7 @@ describe('Runner.run', () => {
       await expect(() =>
         RunState.fromString(agent, state.toString()),
       ).rejects.toThrow(
-        /no longer provides toolSearchTool\(\{ execution: "client", execute \}\)/,
+        /require toolSearchTool\(\{ execution: "client", execute \}\) when custom client tool_search parameters are provided/,
       );
     });
 

--- a/packages/agents-core/test/runContext.test.ts
+++ b/packages/agents-core/test/runContext.test.ts
@@ -2,6 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { RunContext } from '../src/runContext';
 import { RunToolApprovalItem as ToolApprovalItem } from '../src/items';
 import { Agent } from '../src/agent';
+import { tool } from '../src/tool';
+import {
+  getFunctionToolLookupKey,
+  getFunctionToolStateKeyForCall,
+} from '../src/toolIdentity';
+import { z } from 'zod';
 
 const agent = new Agent({ name: 'A' });
 const rawItem = {
@@ -44,6 +50,157 @@ function createRealtimeHostedApproval(
 }
 
 describe('RunContext', () => {
+  it.each(['shell', 'apply_patch', 'hosted_mcp'])(
+    'keeps %s approvals separate from same-name function aliases',
+    (toolName) => {
+      const functionKey = getFunctionToolLookupKey(toolName)!;
+      const permanentEntries = [
+        [functionKey, { approved: true, rejected: [] }],
+        [toolName, { approved: false, rejected: true }],
+      ] as const;
+      const perCallEntries = [
+        [
+          functionKey,
+          { approved: ['function-call'], rejected: [] as string[] },
+        ],
+        [
+          toolName,
+          { approved: [] as string[], rejected: ['non-function-call'] },
+        ],
+      ] as const;
+
+      for (const entries of [
+        permanentEntries,
+        [...permanentEntries].reverse(),
+      ]) {
+        const context = new RunContext();
+        context._rebuildApprovals(Object.fromEntries(entries));
+
+        expect(
+          context.isToolApproved({
+            toolName: functionKey,
+            callId: 'future-function-call',
+          }),
+        ).toBe(true);
+        expect(
+          context.isToolApproved({
+            toolName,
+            callId: 'future-non-function-call',
+            functionTool: false,
+          }),
+        ).toBe(false);
+      }
+
+      for (const entries of [perCallEntries, [...perCallEntries].reverse()]) {
+        const context = new RunContext();
+        context._rebuildApprovals(Object.fromEntries(entries));
+
+        expect(
+          context.isToolApproved({
+            toolName: functionKey,
+            callId: 'function-call',
+          }),
+        ).toBe(true);
+        expect(
+          context.isToolApproved({
+            toolName,
+            callId: 'function-call',
+            functionTool: false,
+          }),
+        ).toBeUndefined();
+        expect(
+          context.isToolApproved({
+            toolName,
+            callId: 'non-function-call',
+            functionTool: false,
+          }),
+        ).toBe(false);
+      }
+    },
+  );
+
+  it('keeps same-name bare and deferred approvals distinct', () => {
+    const bare = tool({
+      name: 'lookup',
+      description: 'Immediate lookup.',
+      parameters: z.object({}),
+      execute: async () => 'bare',
+    });
+    const deferred = tool({
+      name: 'lookup',
+      description: 'Deferred lookup.',
+      parameters: z.object({}),
+      deferLoading: true,
+      execute: async () => 'deferred',
+    });
+    const approvalAgent = new Agent({
+      name: 'Approval agent',
+      tools: [bare, deferred],
+    });
+    const deferredApproval = new ToolApprovalItem(
+      {
+        type: 'function_call',
+        name: 'lookup',
+        namespace: 'lookup',
+        callId: 'deferred-call',
+        arguments: '{}',
+      },
+      approvalAgent,
+    );
+    const ctx = new RunContext();
+
+    ctx.approveTool(deferredApproval, { alwaysApprove: true });
+
+    expect(
+      ctx.isToolApproved({
+        toolName: getFunctionToolStateKeyForCall(
+          deferredApproval.rawItem as { name?: string; namespace?: string },
+        )!,
+        callId: 'future-deferred-call',
+      }),
+    ).toBe(true);
+    expect(
+      ctx.isToolApproved({
+        toolName: 'lookup',
+        callId: 'future-bare-call',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('keeps dotted bare and explicit namespace approvals distinct', () => {
+    const namespacedApproval = new ToolApprovalItem(
+      {
+        type: 'function_call',
+        name: 'lookup',
+        namespace: 'crm',
+        callId: 'namespaced-call',
+        arguments: '{}',
+      },
+      agent,
+    );
+    const ctx = new RunContext();
+
+    ctx.approveTool(namespacedApproval, { alwaysApprove: true });
+
+    expect(
+      ctx.isToolApproved({
+        toolName: getFunctionToolStateKeyForCall(
+          namespacedApproval.rawItem as {
+            name?: string;
+            namespace?: string;
+          },
+        )!,
+        callId: 'future-namespaced-call',
+      }),
+    ).toBe(true);
+    expect(
+      ctx.isToolApproved({
+        toolName: 'crm.lookup',
+        callId: 'future-dotted-call',
+      }),
+    ).toBeUndefined();
+  });
+
   it('approves and rejects tool calls', () => {
     const ctx = new RunContext();
     const item = createApproval();
@@ -65,6 +222,53 @@ describe('RunContext', () => {
     );
   });
 
+  it('scopes function approval decisions to the owning agent', () => {
+    const otherAgent = new Agent({ name: 'B' });
+    const first = createApproval('shared-call');
+    const second = new ToolApprovalItem(
+      {
+        ...rawItem,
+        callId: 'shared-call',
+      } as any,
+      otherAgent,
+    );
+    const toolName = getFunctionToolStateKeyForCall(
+      first.rawItem as { name?: string; namespace?: string },
+    )!;
+    const ctx = new RunContext();
+
+    ctx.approveTool(first, { alwaysApprove: true });
+    ctx.rejectTool(second, { message: 'Rejected for B.' });
+
+    expect(
+      ctx.isToolApproved({
+        toolName,
+        callId: 'future-call',
+        functionTool: false,
+        agent,
+      }),
+    ).toBe(true);
+    expect(
+      ctx.isToolApproved({
+        toolName,
+        callId: 'shared-call',
+        functionTool: false,
+        agent: otherAgent,
+      }),
+    ).toBe(false);
+    expect(
+      ctx.isToolApproved({
+        toolName,
+        callId: 'future-call',
+        functionTool: false,
+        agent: otherAgent,
+      }),
+    ).toBeUndefined();
+    expect(
+      ctx._getFunctionRejectionMessage(toolName, 'shared-call', otherAgent),
+    ).toBe('Rejected for B.');
+  });
+
   it('reuses alwaysReject messages for future call ids', () => {
     const ctx = new RunContext();
     const item = createApproval();
@@ -76,10 +280,13 @@ describe('RunContext', () => {
 
     expect(ctx.getRejectionMessage('toolX', '123')).toBe('Blocked by policy.');
     expect(ctx.getRejectionMessage('toolX', '456')).toBe('Blocked by policy.');
-    expect(ctx.toJSON().approvals.toolX.messages).toEqual({
+    const approvalKey = getFunctionToolStateKeyForCall(
+      item.rawItem as { name?: string; namespace?: string },
+    )!;
+    expect(ctx.toJSON().approvals[approvalKey].messages).toEqual({
       '123': 'Blocked by policy.',
     });
-    expect(ctx.toJSON().approvals.toolX.stickyRejectMessage).toBe(
+    expect(ctx.toJSON().approvals[approvalKey].stickyRejectMessage).toBe(
       'Blocked by policy.',
     );
   });

--- a/packages/agents-core/test/runContext.test.ts
+++ b/packages/agents-core/test/runContext.test.ts
@@ -280,13 +280,10 @@ describe('RunContext', () => {
 
     expect(ctx.getRejectionMessage('toolX', '123')).toBe('Blocked by policy.');
     expect(ctx.getRejectionMessage('toolX', '456')).toBe('Blocked by policy.');
-    const approvalKey = getFunctionToolStateKeyForCall(
-      item.rawItem as { name?: string; namespace?: string },
-    )!;
-    expect(ctx.toJSON().approvals[approvalKey].messages).toEqual({
+    expect(ctx.toJSON().approvals.toolX.messages).toEqual({
       '123': 'Blocked by policy.',
     });
-    expect(ctx.toJSON().approvals[approvalKey].stickyRejectMessage).toBe(
+    expect(ctx.toJSON().approvals.toolX.stickyRejectMessage).toBe(
       'Blocked by policy.',
     );
   });

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   RunState,
   buildAgentMap,
@@ -10,7 +10,10 @@ import {
 import { processedResponseRequiresExecutionToolRehydration } from '../src/sandbox/runtime/toolRehydration';
 import { RunContext } from '../src/runContext';
 import { Agent } from '../src/agent';
+import { handoff } from '../src/handoff';
 import { Usage } from '../src/usage';
+import type { ModelResponse } from '../src/model';
+import { processModelResponseAsync } from '../src/runner/modelOutputs';
 import {
   RunToolApprovalItem as ToolApprovalItem,
   RunMessageOutputItem,
@@ -29,6 +32,7 @@ import {
   shellTool,
   tool,
   toolNamespace,
+  type Tool,
 } from '../src/tool';
 import * as protocol from '../src/types/protocol';
 import {
@@ -38,11 +42,25 @@ import {
   FakeEditor,
 } from './stubs';
 import { RunResult } from '../src/result';
+import { UserError } from '../src/errors';
+import logger from '../src/logger';
 import { createAgentSpan } from '../src/tracing';
 import { getGlobalTraceProvider } from '../src/tracing/provider';
 import type { MCPServer, MCPTool } from '../src/mcp';
 import { SANDBOX_SESSION_STATE_VERSION, SandboxAgent } from '../src/sandbox';
-import { z } from 'zod';
+import {
+  getFunctionToolStateKey,
+  getFunctionToolStateKeyForCall,
+} from '../src/toolIdentity';
+import { z, ZodError } from 'zod';
+import { allowConsole } from '../../../helpers/tests/console-guard';
+
+type AliasTestKeys = {
+  crmAlias: string;
+  crmCanonical: string;
+  salesAlias: string;
+  salesCanonical: string;
+};
 
 function sandboxSessionStateEnvelope(
   providerState: Record<string, unknown>,
@@ -438,6 +456,12 @@ describe('RunState', () => {
       JSON.stringify(serialized),
     );
     expect(restored._sandbox).toEqual(state._sandbox);
+
+    const restoredFromSchema115 = await RunState.fromString(
+      agent,
+      JSON.stringify({ ...serialized, $schemaVersion: '1.15' }),
+    );
+    expect(restoredFromSchema115._sandbox).toEqual(state._sandbox);
   });
 
   it('keeps reading schema 1.8 payloads without sandbox state', async () => {
@@ -777,6 +801,188 @@ describe('RunState', () => {
     const restored = await RunState.fromString(agent, state.toString());
     expect(restored.getPendingAgentToolRun('toolA', 'call-1')).toBe('state-A');
     expect(restored.getPendingAgentToolRun('toolB', 'call-1')).toBe('state-B');
+  });
+
+  it('keeps pending agent tool aliases on one canonical state entry', async () => {
+    const context = new RunContext();
+    const namespacedLookup = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup',
+          description: 'Look up a CRM record.',
+          parameters: z.object({}).strict(),
+          execute: async () => 'lookup',
+        }),
+      ],
+    })[0]!;
+    const agent = new Agent({
+      name: 'PendingAliasAgent',
+      tools: [namespacedLookup],
+    });
+    const state = new RunState(context, 'input', agent, 1);
+    const canonicalKey = getFunctionToolStateKey(namespacedLookup)!;
+    const toolCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc-pending-alias',
+      callId: 'call-1',
+      name: 'lookup',
+      namespace: 'crm',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall, tool: namespacedLookup as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['crm.lookup'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+
+    state.setPendingAgentToolRun(canonicalKey, 'call-1', 'initial-state', [
+      'crm.lookup',
+    ]);
+
+    expect(state._pendingAgentToolRuns.size).toBe(1);
+    expect(state.getPendingAgentToolRun('crm.lookup', 'call-1')).toBe(
+      'initial-state',
+    );
+
+    state.setPendingAgentToolRun('crm.lookup', 'call-1', 'updated-state');
+
+    expect(state._pendingAgentToolRuns.size).toBe(1);
+    expect(state.getPendingAgentToolRun(canonicalKey, 'call-1')).toBe(
+      'updated-state',
+    );
+
+    const restored = await RunState.fromString(agent, state.toString());
+    expect(restored._pendingAgentToolRuns.size).toBe(1);
+    expect(restored.getPendingAgentToolRun('crm.lookup', 'call-1')).toBe(
+      'updated-state',
+    );
+
+    restored.clearPendingAgentToolRun('crm.lookup', 'call-1');
+
+    expect(restored.hasPendingAgentToolRun(canonicalKey, 'call-1')).toBe(false);
+    expect(restored.hasPendingAgentToolRun('crm.lookup', 'call-1')).toBe(false);
+    expect(restored._pendingAgentToolRuns.size).toBe(0);
+    expect(restored._pendingAgentToolRunAliases.size).toBe(0);
+  });
+
+  it.each([
+    {
+      name: 'dangling target',
+      mutate: (aliases: Record<string, string>, keys: AliasTestKeys) => {
+        aliases[keys.crmAlias] = `${keys.crmCanonical}:missing-call`;
+      },
+    },
+    {
+      name: 'cross-call target',
+      mutate: (aliases: Record<string, string>, keys: AliasTestKeys) => {
+        aliases[keys.crmAlias] = `${keys.crmCanonical}:call-2`;
+      },
+    },
+    {
+      name: 'cross-tool target',
+      mutate: (aliases: Record<string, string>, keys: AliasTestKeys) => {
+        aliases[keys.crmAlias] = `${keys.salesCanonical}:call-3`;
+      },
+    },
+    {
+      name: 'alias chain',
+      mutate: (aliases: Record<string, string>, keys: AliasTestKeys) => {
+        aliases[keys.crmAlias] = keys.salesAlias;
+      },
+    },
+    {
+      name: 'alias cycle',
+      mutate: (aliases: Record<string, string>, keys: AliasTestKeys) => {
+        aliases[keys.crmAlias] = keys.salesAlias;
+        aliases[keys.salesAlias] = keys.crmAlias;
+      },
+    },
+  ])('rejects a pending agent tool alias with a $name', async ({ mutate }) => {
+    const [crmLookup, salesLookup] = ['crm', 'sales'].map(
+      (namespace) =>
+        toolNamespace({
+          name: namespace,
+          description: `${namespace} tools.`,
+          tools: [
+            tool({
+              name: 'lookup',
+              description: `Look up a ${namespace} record.`,
+              parameters: z.object({}).strict(),
+              execute: async () => namespace,
+            }),
+          ],
+        })[0]!,
+    );
+    const agent = new Agent({
+      name: 'Invalid pending alias agent',
+      tools: [crmLookup, salesLookup],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    const crmCanonical = getFunctionToolStateKey(crmLookup)!;
+    const salesCanonical = getFunctionToolStateKey(salesLookup)!;
+    const createToolCall = (
+      namespace: string,
+      callId: string,
+    ): protocol.FunctionCallItem => ({
+      type: 'function_call',
+      id: `fc-${namespace}-${callId}`,
+      callId,
+      name: 'lookup',
+      namespace,
+      status: 'completed',
+      arguments: '{}',
+    });
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [
+        { toolCall: createToolCall('crm', 'call-1'), tool: crmLookup as any },
+        { toolCall: createToolCall('crm', 'call-2'), tool: crmLookup as any },
+        {
+          toolCall: createToolCall('sales', 'call-3'),
+          tool: salesLookup as any,
+        },
+      ],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['crm.lookup', 'sales.lookup'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+    state.setPendingAgentToolRun(crmCanonical, 'call-1', 'crm-state', [
+      'crm.lookup',
+    ]);
+    state.setPendingAgentToolRun(crmCanonical, 'call-2', 'crm-state-2', [
+      'crm.lookup',
+    ]);
+    state.setPendingAgentToolRun(salesCanonical, 'call-3', 'sales-state', [
+      'sales.lookup',
+    ]);
+
+    const serialized = state.toJSON();
+    const aliases = serialized.pendingAgentToolRunAliases!;
+    mutate(aliases, {
+      crmAlias: 'crm.lookup:call-1',
+      crmCanonical,
+      salesAlias: 'sales.lookup:call-3',
+      salesCanonical,
+    });
+
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow(
+      'Run state pending agent tool aliases do not match the reconstructed pending function calls.',
+    );
   });
 
   it('toJSON and toString produce valid JSON', () => {
@@ -1422,6 +1628,804 @@ describe('RunState', () => {
     );
   });
 
+  it('reads schema 1.15 approval keys and emits category-aware schema 1.16 state', async () => {
+    const context = new RunContext();
+    const agent = new Agent({ name: 'ApprovalKeyMigrationAgent' });
+    const state = new RunState(context, 'input', agent, 2);
+    const rawItem: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'lookup',
+      callId: 'legacy-call',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state.reject(new ToolApprovalItem(rawItem, agent));
+
+    const serialized = state.toJSON() as any;
+    const categoryKey = getFunctionToolStateKeyForCall(rawItem)!;
+    const ownerApprovals = serialized.context.functionApprovals.find(
+      (entry: any) => entry.agentIdentity === agent.name,
+    ).approvals;
+    serialized.$schemaVersion = '1.15';
+    serialized.context.approvals.lookup = ownerApprovals[categoryKey];
+    delete serialized.context.functionApprovals;
+    delete serialized.context.legacyFunctionApprovalFallback;
+
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+
+    expect(
+      restored._context.isToolApproved({
+        toolName: 'lookup',
+        callId: 'legacy-call',
+      }),
+    ).toBe(false);
+    expect(restored.toJSON().$schemaVersion).toBe('1.16');
+  });
+
+  it('rehydrates schema 1.15 approval identity from enabled prepared tools', async () => {
+    const enabledLookup = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup',
+          description: 'Look up a CRM record.',
+          parameters: z.object({}),
+          execute: async () => 'enabled',
+        }),
+      ],
+    })[0]!;
+    const disabledLookup = toolNamespace({
+      name: 'crm',
+      description: 'Disabled CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup',
+          description: 'Disabled duplicate.',
+          parameters: z.object({}),
+          isEnabled: false,
+          execute: async () => 'disabled',
+        }),
+      ],
+    })[0]!;
+    const agent = new Agent({
+      name: 'LegacyApprovalAgent',
+      tools: [enabledLookup, disabledLookup],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const rawItem: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'lookup',
+      namespace: 'crm',
+      callId: 'legacy-approval-call',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall: rawItem, tool: enabledLookup as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['crm.lookup'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: {
+        interruptions: [new ToolApprovalItem(rawItem, agent)],
+      },
+    };
+
+    const serialized = state.toJSON() as any;
+    serialized.$schemaVersion = '1.15';
+    delete serialized.currentStep.data.interruptions[0].functionToolStateKey;
+
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+    const [approvalItem] = restored.getInterruptions();
+
+    expect(approvalItem.functionToolStateKey).toBe(
+      getFunctionToolStateKey(enabledLookup),
+    );
+    restored.approve(approvalItem);
+    expect(
+      restored._context.isToolApproved({
+        toolName: getFunctionToolStateKey(enabledLookup)!,
+        callId: rawItem.callId,
+      }),
+    ).toBe(true);
+  });
+
+  it.each(['namespaced', 'dotted'] as const)(
+    'migrates schema 1.15 pending nested state for the exact %s tool category',
+    async (pendingCategory) => {
+      const dottedLookup = tool({
+        name: 'crm_lookup',
+        description: 'Look up a dotted CRM record.',
+        parameters: z.object({}),
+        execute: async () => 'dotted',
+      });
+      dottedLookup.name = 'crm.lookup';
+      const namespacedLookup = toolNamespace({
+        name: 'crm',
+        description: 'CRM tools.',
+        tools: [
+          tool({
+            name: 'lookup',
+            description: 'Look up a namespaced CRM record.',
+            parameters: z.object({}),
+            execute: async () => 'namespaced',
+          }),
+        ],
+      })[0]!;
+      const pendingTool =
+        pendingCategory === 'namespaced' ? namespacedLookup : dottedLookup;
+      const toolCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: pendingCategory === 'namespaced' ? 'lookup' : 'crm.lookup',
+        ...(pendingCategory === 'namespaced' ? { namespace: 'crm' } : {}),
+        callId: `legacy-${pendingCategory}-call`,
+        status: 'completed',
+        arguments: '{}',
+      };
+      const agent = new Agent({
+        name: `LegacyPending${pendingCategory}`,
+        tools: [dottedLookup, namespacedLookup],
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._lastProcessedResponse = {
+        newItems: [],
+        functions: [{ toolCall, tool: pendingTool as any }],
+        handoffs: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: ['crm.lookup'],
+        hasToolsOrApprovalsToRun: () => true,
+      };
+      state.setPendingAgentToolRun(
+        'crm.lookup',
+        toolCall.callId,
+        `${pendingCategory}-state`,
+      );
+
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+      delete serialized.pendingAgentToolRunAliases;
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+      const canonicalKey = getFunctionToolStateKey(pendingTool)!;
+
+      expect(
+        restored.getPendingAgentToolRun(canonicalKey, toolCall.callId),
+      ).toBe(`${pendingCategory}-state`);
+      expect(
+        restored.getPendingAgentToolRun('crm.lookup', toolCall.callId),
+      ).toBe(`${pendingCategory}-state`);
+      expect(restored._pendingAgentToolRuns.size).toBe(1);
+    },
+  );
+
+  it('migrates pending schema 1.15 approvals while preserving ambiguous permanent owners', async () => {
+    const decisions = [
+      {
+        name: 'approved call',
+        record: (callId: string) => ({
+          approved: [callId],
+          rejected: [],
+        }),
+        expected: true,
+      },
+      {
+        name: 'rejected call',
+        record: (callId: string) => ({
+          approved: [],
+          rejected: [callId],
+          messages: { [callId]: 'Rejected once' },
+        }),
+        expected: false,
+        message: 'Rejected once',
+      },
+      {
+        name: 'permanent approval',
+        record: () => ({ approved: true, rejected: [] }),
+        expected: true,
+      },
+      {
+        name: 'permanent rejection',
+        record: (callId: string) => ({
+          approved: false,
+          rejected: true,
+          messages: { [callId]: 'Always rejected' },
+          stickyRejectMessage: 'Always rejected',
+        }),
+        expected: false,
+        message: 'Always rejected',
+      },
+    ];
+
+    for (const pair of ['bare-deferred', 'dotted-namespaced'] as const) {
+      for (const decision of decisions) {
+        const bareTool = tool({
+          name: pair === 'bare-deferred' ? 'lookup' : 'crm_lookup',
+          description: 'Bare lookup.',
+          parameters: z.object({}),
+          execute: async () => 'bare',
+        });
+        if (pair === 'dotted-namespaced') {
+          bareTool.name = 'crm.lookup';
+        }
+        const structuredTool =
+          pair === 'bare-deferred'
+            ? tool({
+                name: 'lookup',
+                description: 'Deferred lookup.',
+                parameters: z.object({}),
+                deferLoading: true,
+                execute: async () => 'deferred',
+              })
+            : toolNamespace({
+                name: 'crm',
+                description: 'CRM tools.',
+                tools: [
+                  tool({
+                    name: 'lookup',
+                    description: 'Namespaced lookup.',
+                    parameters: z.object({}),
+                    execute: async () => 'namespaced',
+                  }),
+                ],
+              })[0]!;
+        const callId = `${pair}-${decision.name.replace(/ /g, '-')}`;
+        const toolCall: protocol.FunctionCallItem = {
+          type: 'function_call',
+          name: 'lookup',
+          namespace: pair === 'bare-deferred' ? 'lookup' : 'crm',
+          callId,
+          status: 'completed',
+          arguments: '{}',
+        };
+        const legacyKey = pair === 'bare-deferred' ? 'lookup' : 'crm.lookup';
+        const agent = new Agent({
+          name: `LegacyApproval-${pair}-${decision.name}`,
+          tools: [bareTool, structuredTool],
+        });
+        const state = new RunState(new RunContext(), 'input', agent, 2);
+        state._lastProcessedResponse = {
+          newItems: [],
+          functions: [{ toolCall, tool: structuredTool as any }],
+          handoffs: [],
+          computerActions: [],
+          shellActions: [],
+          applyPatchActions: [],
+          mcpApprovalRequests: [],
+          toolsUsed: [legacyKey],
+          hasToolsOrApprovalsToRun: () => true,
+        };
+        state._currentStep = {
+          type: 'next_step_interruption',
+          data: {
+            interruptions: [new ToolApprovalItem(toolCall, agent)],
+          },
+        };
+
+        const serialized = state.toJSON() as any;
+        serialized.$schemaVersion = '1.15';
+        serialized.context.approvals = {
+          [legacyKey]: decision.record(callId),
+        };
+        delete serialized.currentStep.data.interruptions[0]
+          .functionToolStateKey;
+
+        const restored = await RunState.fromString(
+          agent,
+          JSON.stringify(serialized),
+        );
+        const canonicalKey = getFunctionToolStateKey(structuredTool)!;
+        const isPermanent = decision.name.startsWith('permanent');
+
+        expect(
+          restored._context.isToolApproved({
+            toolName: canonicalKey,
+            callId,
+          }),
+          `${pair}: ${decision.name}`,
+        ).toBe(decision.expected);
+        expect(
+          restored._context.getRejectionMessage(canonicalKey, callId),
+        ).toBe(decision.message);
+        expect(
+          restored._context.isToolApproved({
+            toolName: canonicalKey,
+            callId: `${callId}-future`,
+          }),
+        ).toBeUndefined();
+        expect(
+          restored._context.isToolApproved({
+            toolName: legacyKey,
+            callId,
+          }),
+          `${pair}: ${decision.name} legacy owner`,
+        ).toBe(isPermanent ? decision.expected : undefined);
+        expect(
+          restored._context.isToolApproved({
+            toolName: legacyKey,
+            callId: `${callId}-future`,
+          }),
+          `${pair}: ${decision.name} future legacy owner`,
+        ).toBe(isPermanent ? decision.expected : undefined);
+      }
+    }
+  });
+
+  it.each([
+    ['permanent approval', { approved: true, rejected: [] }, true, undefined],
+    [
+      'permanent rejection',
+      {
+        approved: false,
+        rejected: true,
+        stickyRejectMessage: 'Always rejected',
+      },
+      false,
+      'Always rejected',
+    ],
+  ] as const)(
+    'migrates a schema 1.15 %s when the legacy function owner is unique',
+    async (_name, approvalRecord, expectedApproval, expectedMessage) => {
+      const namespacedLookup = toolNamespace({
+        name: 'crm',
+        description: 'CRM tools.',
+        tools: [
+          tool({
+            name: 'lookup',
+            description: 'Namespaced lookup.',
+            parameters: z.object({}),
+            execute: async () => 'namespaced',
+          }),
+        ],
+      })[0]!;
+      const callId = 'unique-owner-call';
+      const toolCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: 'lookup',
+        namespace: 'crm',
+        callId,
+        status: 'completed',
+        arguments: '{}',
+      };
+      const agent = new Agent({
+        name: 'UniqueLegacyApprovalOwner',
+        tools: [namespacedLookup],
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._lastProcessedResponse = {
+        newItems: [],
+        functions: [{ toolCall, tool: namespacedLookup as any }],
+        handoffs: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: ['crm.lookup'],
+        hasToolsOrApprovalsToRun: () => true,
+      };
+
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+      serialized.context.approvals = {
+        'crm.lookup': approvalRecord,
+      };
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+      const canonicalKey = getFunctionToolStateKey(namespacedLookup)!;
+
+      expect(
+        restored._context.isToolApproved({
+          toolName: canonicalKey,
+          callId,
+        }),
+      ).toBe(expectedApproval);
+      expect(restored._context.getRejectionMessage(canonicalKey, callId)).toBe(
+        expectedMessage,
+      );
+      expect(
+        restored._context.isToolApproved({
+          toolName: 'crm.lookup',
+          callId,
+        }),
+      ).toBeUndefined();
+    },
+  );
+
+  it('migrates a unique schema 1.15 permanent owner without a current call', async () => {
+    const namespacedLookup = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup',
+          description: 'Namespaced lookup.',
+          parameters: z.object({}),
+          execute: async () => 'namespaced',
+        }),
+      ],
+    })[0]!;
+    const otherTool = tool({
+      name: 'other_tool',
+      description: 'Other tool.',
+      parameters: z.object({}),
+      execute: async () => 'other',
+    });
+    const otherCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'other_tool',
+      callId: 'other_call',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const agent = new Agent({
+      name: 'Unique inactive legacy approval owner',
+      tools: [namespacedLookup, otherTool],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [
+        {
+          toolCall: otherCall,
+          tool: otherTool as any,
+          availableFunctionTools: [namespacedLookup, otherTool] as any,
+        },
+      ],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['other_tool'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+
+    const serialized = state.toJSON() as any;
+    serialized.$schemaVersion = '1.15';
+    serialized.context.approvals = {
+      'crm.lookup': { approved: true, rejected: [] },
+    };
+
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+    const canonicalKey = getFunctionToolStateKey(namespacedLookup)!;
+
+    expect(
+      restored._context.isToolApproved({
+        toolName: canonicalKey,
+        callId: 'future_call',
+      }),
+    ).toBe(true);
+    expect(
+      restored._context.isToolApproved({
+        toolName: 'crm.lookup',
+        callId: 'future_call',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('keeps an exact non-function override separate from an inactive schema 1.15 function owner', async () => {
+    const namespacedLookup = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup',
+          description: 'Namespaced lookup.',
+          parameters: z.object({}),
+          execute: async () => 'namespaced',
+        }),
+      ],
+    })[0]!;
+    const otherTool = tool({
+      name: 'other_tool',
+      description: 'Other tool.',
+      parameters: z.object({}),
+      execute: async () => 'other',
+    });
+    const otherCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'other_tool',
+      callId: 'merge_other_call',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const agent = new Agent({
+      name: 'Inactive merge approval owner',
+      tools: [namespacedLookup, otherTool],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [
+        {
+          toolCall: otherCall,
+          tool: otherTool as any,
+          availableFunctionTools: [namespacedLookup, otherTool] as any,
+        },
+      ],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['other_tool'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+    const serialized = state.toJSON() as any;
+    serialized.$schemaVersion = '1.15';
+    serialized.context.approvals = {
+      'crm.lookup': { approved: true, rejected: [] },
+    };
+    const overrideContext = new RunContext();
+    overrideContext.rejectTool(
+      new ToolApprovalItem(
+        {
+          type: 'shell_call',
+          callId: 'shell_crm_lookup',
+          status: 'completed',
+          action: { commands: ['echo rejected'] },
+        },
+        agent,
+        'crm.lookup',
+      ),
+      { alwaysReject: true },
+    );
+
+    const restored = await RunState.fromStringWithContext(
+      agent,
+      JSON.stringify(serialized),
+      overrideContext,
+      { contextStrategy: 'merge' },
+    );
+    const canonicalKey = getFunctionToolStateKey(namespacedLookup)!;
+
+    expect(
+      restored._context.isToolApproved({
+        toolName: canonicalKey,
+        callId: 'future_function_call',
+      }),
+    ).toBe(true);
+    expect(
+      restored._context.isToolApproved({
+        toolName: 'crm.lookup',
+        callId: 'future_shell_call',
+        functionTool: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps schema 1.15 approval ownership when merging a canonical override context', async () => {
+    const decisions = [
+      {
+        name: 'per-call approval',
+        record: (callId: string) => ({
+          approved: [callId],
+          rejected: [],
+        }),
+        expected: true,
+      },
+      {
+        name: 'permanent rejection',
+        record: (callId: string) => ({
+          approved: false,
+          rejected: true,
+          messages: { [callId]: 'Always rejected' },
+          stickyRejectMessage: 'Always rejected',
+        }),
+        expected: false,
+        message: 'Always rejected',
+      },
+    ];
+
+    for (const decision of decisions) {
+      const dottedLookup = tool({
+        name: 'crm_lookup',
+        description: 'Dotted lookup.',
+        parameters: z.object({}),
+        execute: async () => 'dotted',
+      });
+      dottedLookup.name = 'crm.lookup';
+      const namespacedLookup = toolNamespace({
+        name: 'crm',
+        description: 'CRM tools.',
+        tools: [
+          tool({
+            name: 'lookup',
+            description: 'Namespaced lookup.',
+            parameters: z.object({}),
+            execute: async () => 'namespaced',
+          }),
+        ],
+      })[0]!;
+      const agent = new Agent({
+        name: `MergeApproval-${decision.name}`,
+        tools: [dottedLookup, namespacedLookup],
+      });
+      const callId = `namespaced-${decision.name.replace(/ /g, '-')}`;
+      const namespacedCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: 'lookup',
+        namespace: 'crm',
+        callId,
+        status: 'completed',
+        arguments: '{}',
+      };
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._lastProcessedResponse = {
+        newItems: [],
+        functions: [
+          { toolCall: namespacedCall, tool: namespacedLookup as any },
+        ],
+        handoffs: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: ['crm.lookup'],
+        hasToolsOrApprovalsToRun: () => true,
+      };
+      state._currentStep = {
+        type: 'next_step_interruption',
+        data: {
+          interruptions: [new ToolApprovalItem(namespacedCall, agent)],
+        },
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+      serialized.context.approvals = {
+        'crm.lookup': decision.record(callId),
+        other: {
+          approved: ['serialized-other-call'],
+          rejected: [],
+        },
+      };
+      delete serialized.currentStep.data.interruptions[0].functionToolStateKey;
+
+      const overrideContext = new RunContext();
+      const existingBareCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: 'crm.lookup',
+        callId: 'existing-bare-call',
+        status: 'completed',
+        arguments: '{}',
+      };
+      overrideContext.approveTool(
+        new ToolApprovalItem(
+          existingBareCall,
+          agent,
+          undefined,
+          getFunctionToolStateKey(dottedLookup),
+        ),
+      );
+      overrideContext.approveTool(
+        new ToolApprovalItem(
+          {
+            type: 'function_call',
+            name: 'other',
+            callId: 'override-other-call',
+            status: 'completed',
+            arguments: '{}',
+          },
+          agent,
+        ),
+      );
+      overrideContext.approveTool(
+        new ToolApprovalItem(
+          {
+            type: 'shell_call',
+            callId: 'override-shell-call',
+            status: 'completed',
+            action: { commands: ['echo approved'] },
+          },
+          agent,
+          'crm.lookup',
+        ),
+        { alwaysApprove: true },
+      );
+
+      const restored = await RunState.fromStringWithContext(
+        agent,
+        JSON.stringify(serialized),
+        overrideContext,
+        { contextStrategy: 'merge' },
+      );
+      const namespacedKey = getFunctionToolStateKey(namespacedLookup)!;
+      const bareKey = getFunctionToolStateKey(dottedLookup)!;
+
+      expect(
+        restored._context.isToolApproved({
+          toolName: namespacedKey,
+          callId,
+        }),
+        decision.name,
+      ).toBe(decision.expected);
+      expect(restored._context.getRejectionMessage(namespacedKey, callId)).toBe(
+        decision.message,
+      );
+      expect(
+        restored._context.isToolApproved({
+          toolName: namespacedKey,
+          callId: `${callId}-future`,
+        }),
+      ).toBeUndefined();
+      expect(
+        restored._context.isToolApproved({
+          toolName: 'crm.lookup',
+          callId,
+          functionTool: false,
+        }),
+      ).toBe(true);
+      expect(
+        restored._context.getRejectionMessage('crm.lookup', callId, {
+          functionTool: false,
+        }),
+      ).toBeUndefined();
+      expect(
+        restored._context.isToolApproved({
+          toolName: bareKey,
+          callId: 'existing-bare-call',
+        }),
+      ).toBe(true);
+      expect(
+        restored._context.isToolApproved({
+          toolName: bareKey,
+          callId: 'future-bare-call',
+        }),
+      ).toBeUndefined();
+      expect(
+        restored._context.isToolApproved({
+          toolName: 'other',
+          callId: 'serialized-other-call',
+          functionTool: false,
+        }),
+      ).toBe(true);
+      expect(
+        restored._context.isToolApproved({
+          toolName: '["bare","other"]',
+          callId: 'override-other-call',
+        }),
+      ).toBe(true);
+      expect(
+        restored._context.isToolApproved({
+          toolName: '["bare","other"]',
+          callId: 'serialized-other-call',
+        }),
+      ).toBeUndefined();
+      expect(
+        restored._context.isToolApproved({
+          toolName: 'other',
+          callId: 'override-other-call',
+          functionTool: false,
+        }),
+      ).toBeUndefined();
+    }
+  });
+
   it('accepts schema version 1.6 payloads during deserialization', async () => {
     const context = new RunContext();
     const agent = new Agent({ name: 'Agent16' });
@@ -1589,6 +2593,74 @@ describe('RunState', () => {
       call_id: 'call_ts_raw',
       execution: 'server',
     });
+  });
+
+  it('rehydrates client tool_search outputs without explicit call_id by FIFO order', async () => {
+    const runtimeLookup = tool({
+      name: 'lookup_runtime',
+      description: 'Look up a runtime record.',
+      parameters: z.object({}),
+      execute: async () => 'runtime',
+    });
+    const execute = vi.fn(async () => runtimeLookup);
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'No call id tool-search restore agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_without_call_id',
+          execution: 'client',
+          status: 'completed',
+          arguments: {},
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_without_call_id',
+          execution: 'client',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'lookup_runtime',
+              description: 'Look up a runtime record.',
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+          ],
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(execute).toHaveBeenCalledOnce();
+    expect(
+      await (restored.getToolSearchRuntimeTools(agent)[0] as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('runtime');
   });
 
   it('skips rehydration for server tool_search outputs with concrete tool payloads', async () => {
@@ -1804,6 +2876,3193 @@ describe('RunState', () => {
     expect(restored.getToolSearchRuntimeTools(betaAgent)).toEqual([betaLookup]);
   });
 
+  it('uses the collision-filtered tool winner during tool-search rehydration', async () => {
+    const firstDuplicate = tool({
+      name: 'duplicate',
+      description: 'First duplicate.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'first',
+    });
+    const winningDuplicate = tool({
+      name: 'duplicate',
+      description: 'Winning duplicate.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'winner',
+    });
+    const losingRuntimeTool = tool({
+      name: 'losing_runtime',
+      description: 'Runtime tool selected from the unfiltered list.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'losing runtime',
+    });
+    const winningRuntimeTool = tool({
+      name: 'winning_runtime',
+      description: 'Runtime tool selected from the filtered list.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'winning runtime',
+    });
+    const execute = vi.fn(
+      async ({ availableTools }: { availableTools: Tool<any>[] }) => {
+        const selectedDuplicate = availableTools.find(
+          (candidate) =>
+            candidate.type === 'function' && candidate.name === 'duplicate',
+        );
+        return selectedDuplicate === winningDuplicate
+          ? winningRuntimeTool
+          : losingRuntimeTool;
+      },
+    );
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: {
+          type: 'tool_search',
+          execution: 'client',
+        },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Collision-filtered restore agent',
+      tools: [firstDuplicate, winningDuplicate, clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const callId = 'call_collision_filtered_restore';
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_collision_filtered_restore',
+          status: 'completed',
+          arguments: { query: 'runtime' },
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_collision_filtered_restore',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'winning_runtime',
+              description: 'Runtime tool selected from the filtered list.',
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+          ],
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+
+    allowConsole(['warn']);
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute.mock.calls[0]?.[0].availableTools).toEqual([
+      winningDuplicate,
+      clientToolSearch,
+    ]);
+    expect(restored.getToolSearchRuntimeTools(agent)).toEqual([
+      winningRuntimeTool,
+    ]);
+  });
+
+  it('freezes collision-filtered capabilities across tool-search rehydration callbacks', async () => {
+    type TestContext = {
+      functionEnabled: boolean;
+      handoffEnabled: boolean;
+    };
+
+    const transferFunction = tool({
+      name: 'transfer',
+      description: 'Function with the same name as a dynamic handoff.',
+      parameters: z.object({}).strict(),
+      isEnabled: ({ runContext }) =>
+        (runContext.context as TestContext).functionEnabled,
+      execute: async () => 'function',
+    });
+    const firstRuntimeTool = tool({
+      name: 'first_runtime',
+      description: 'First runtime tool.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'first runtime',
+    });
+    const secondRuntimeTool = tool({
+      name: 'second_runtime',
+      description: 'Second runtime tool.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'second runtime',
+    });
+    const availableToolSnapshots: Tool<any>[][] = [];
+    const execute = vi.fn(
+      async ({
+        availableTools,
+        runContext,
+      }: {
+        availableTools: Tool<TestContext>[];
+        runContext: RunContext<TestContext>;
+      }) => {
+        availableToolSnapshots.push(availableTools);
+        if (availableToolSnapshots.length === 1) {
+          runContext.context.functionEnabled = false;
+          runContext.context.handoffEnabled = true;
+          return firstRuntimeTool;
+        }
+        return secondRuntimeTool;
+      },
+    );
+    const clientToolSearch = attachClientToolSearchExecutor<TestContext>(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: {
+          type: 'tool_search',
+          execution: 'client',
+        },
+      },
+      execute,
+    );
+    const target = new Agent<TestContext>({ name: 'Dynamic target' });
+    const agent = new Agent<TestContext>({
+      name: 'Frozen capability restore agent',
+      tools: [transferFunction, clientToolSearch],
+      handoffs: [
+        handoff(target, {
+          toolNameOverride: 'transfer',
+          isEnabled: ({ runContext }) => runContext.context.handoffEnabled,
+        }),
+      ],
+    });
+    const state = new RunState(
+      new RunContext({ functionEnabled: true, handoffEnabled: false }),
+      'input',
+      agent,
+      2,
+    );
+    const processedToolCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_frozen_capability_restore',
+      callId: 'call_frozen_capability_restore',
+      name: 'transfer',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [
+        { toolCall: processedToolCall, tool: transferFunction as any },
+      ],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['transfer'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+    const addSerializedToolSearchResult = (
+      callId: string,
+      runtimeToolName: string,
+    ) => {
+      state._generatedItems.push(
+        new RunToolSearchCallItem(
+          {
+            type: 'tool_search_call',
+            id: `ts_${callId}`,
+            status: 'completed',
+            arguments: { query: runtimeToolName },
+            providerData: { call_id: callId, execution: 'client' },
+          } as protocol.ToolSearchCallItem,
+          agent as Agent<any, any>,
+        ),
+        new RunToolSearchOutputItem(
+          {
+            type: 'tool_search_output',
+            id: `tso_${callId}`,
+            status: 'completed',
+            tools: [
+              {
+                type: 'function',
+                name: runtimeToolName,
+                description: `${runtimeToolName} description.`,
+                strict: true,
+                parameters: {
+                  type: 'object',
+                  properties: {},
+                  required: [],
+                  additionalProperties: false,
+                },
+              },
+            ],
+            providerData: { call_id: callId, execution: 'client' },
+          } as protocol.ToolSearchOutputItem,
+          agent as Agent<any, any>,
+        ),
+      );
+    };
+    addSerializedToolSearchResult('call_first', 'first_runtime');
+    addSerializedToolSearchResult('call_second', 'second_runtime');
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(availableToolSnapshots).toEqual([
+      [transferFunction, clientToolSearch],
+      [transferFunction, clientToolSearch, firstRuntimeTool],
+    ]);
+    expect(restored.getToolSearchRuntimeTools(agent)).toEqual([
+      firstRuntimeTool,
+      secondRuntimeTool,
+    ]);
+    expect(restored._lastProcessedResponse?.functions[0]?.tool).toBe(
+      transferFunction,
+    );
+  });
+
+  it.each(['bare', 'namespaced', 'deferred'] as const)(
+    'round-trips the final same-key %s runtime tool from distinct tool-search calls',
+    async (kind) => {
+      const availableToolNames: string[][] = [];
+      const execute = vi.fn(
+        async ({
+          availableTools,
+          toolCall,
+        }: {
+          availableTools: Tool<any>[];
+          toolCall: protocol.ToolSearchCallItem;
+        }) => {
+          availableToolNames.push(availableTools.map((entry) => entry.name));
+          const result = String(
+            (toolCall.arguments as { result?: string }).result,
+          );
+          const runtimeTool = tool({
+            name: 'lookup',
+            description: `${result} lookup result.`,
+            parameters: z.object({}).strict(),
+            ...(kind === 'deferred' ? { deferLoading: true } : {}),
+            execute: async () => result,
+          });
+          return kind === 'namespaced'
+            ? toolNamespace({
+                name: 'crm',
+                description: 'CRM tools.',
+                tools: [runtimeTool],
+              })[0]
+            : runtimeTool;
+        },
+      );
+      const clientToolSearch = attachClientToolSearchExecutor(
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: {
+            type: 'tool_search',
+            execution: 'client',
+          },
+        },
+        execute,
+      );
+      const agent = new Agent({
+        name: 'Same-key round-trip agent',
+        tools: [clientToolSearch],
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      const createToolSearchCall = (
+        id: string,
+        result: string,
+      ): protocol.ToolSearchCallItem =>
+        ({
+          type: 'tool_search_call',
+          id: `ts_${id}`,
+          status: 'completed',
+          arguments: { result },
+          providerData: { call_id: id, execution: 'client' },
+        }) as protocol.ToolSearchCallItem;
+      const response: ModelResponse = {
+        output: [
+          createToolSearchCall('call_first_lookup', 'first'),
+          createToolSearchCall('call_second_lookup', 'second'),
+        ],
+        usage: new Usage(),
+      };
+
+      const processed = await processModelResponseAsync(
+        response,
+        agent,
+        [clientToolSearch],
+        [],
+        state,
+        [],
+      );
+      state._generatedItems.push(...processed.newItems);
+      state._lastProcessedResponse = processed;
+
+      const liveTools = state.getToolSearchRuntimeTools(agent);
+      expect(liveTools).toHaveLength(1);
+      expect(await (liveTools[0] as any).invoke(new RunContext(), '{}')).toBe(
+        'second',
+      );
+
+      const restored = await RunState.fromString(agent, state.toString());
+      const restoredTools = restored.getToolSearchRuntimeTools(agent);
+
+      expect(availableToolNames).toEqual([
+        ['tool_search'],
+        ['tool_search', 'lookup'],
+        ['tool_search'],
+        ['tool_search', 'lookup'],
+      ]);
+      expect(restoredTools).toHaveLength(1);
+      expect(
+        await (restoredTools[0] as any).invoke(new RunContext(), '{}'),
+      ).toBe('second');
+    },
+  );
+
+  it('round-trips interleaved handlers and callback inputs for repeated client tool_search call ids', async () => {
+    const execute = vi.fn(
+      async ({
+        availableTools,
+        toolCall,
+      }: {
+        availableTools: Tool<any>[];
+        toolCall: protocol.ToolSearchCallItem;
+      }) => {
+        const phase = String((toolCall.arguments as { phase?: string }).phase);
+        const hasFirstResult = availableTools.some(
+          (availableTool) =>
+            availableTool.type === 'function' &&
+            availableTool.description === 'first lookup result.',
+        );
+        const result = phase === 'final' && !hasFirstResult ? 'wrong' : phase;
+        return tool({
+          name: result === 'wrong' ? 'wrong_lookup' : 'lookup',
+          description: `${result} lookup result.`,
+          parameters: z.object({}).strict(),
+          needsApproval: true,
+          execute: async () => result,
+        });
+      },
+    );
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Repeated call id restore agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const sharedCallId = 'call_repeated_replacement';
+    const createToolSearchCall = (
+      id: string,
+      phase: string,
+    ): protocol.ToolSearchCallItem =>
+      ({
+        type: 'tool_search_call',
+        id,
+        status: 'completed',
+        arguments: { phase },
+        providerData: { call_id: sharedCallId, execution: 'client' },
+      }) as protocol.ToolSearchCallItem;
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_repeated_replacement',
+      callId: 'call_repeated_replacement_function',
+      name: 'lookup',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const processed = await processModelResponseAsync(
+      {
+        output: [
+          createToolSearchCall('ts_repeated_first', 'first'),
+          functionCall,
+          createToolSearchCall('ts_repeated_final', 'final'),
+        ],
+        usage: new Usage(),
+      },
+      agent,
+      [clientToolSearch],
+      [],
+      state,
+      [],
+    );
+    state._generatedItems.push(...processed.newItems);
+    state._lastProcessedResponse = processed;
+
+    expect(
+      await (processed.functions[0]!.tool as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('first');
+    expect(state.getToolSearchRuntimeTools(agent)).toHaveLength(1);
+    expect(
+      await (state.getToolSearchRuntimeTools(agent)[0] as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('final');
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(execute).toHaveBeenCalledTimes(4);
+    expect(restored.getToolSearchRuntimeTools(agent)).toHaveLength(1);
+    expect(
+      await (restored._lastProcessedResponse?.functions[0]!.tool as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('first');
+    expect(
+      await (restored.getToolSearchRuntimeTools(agent)[0] as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('final');
+
+    await rehydrateProcessedResponseTools(
+      agent,
+      restored,
+      restored.getToolSearchRuntimeTools(agent),
+    );
+
+    expect(
+      await (restored._lastProcessedResponse?.functions[0]!.tool as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('first');
+  });
+
+  it.each(['empty', 'disabled', 'different'] as const)(
+    'does not resurrect an older routed owner after a later call is replaced with %s',
+    async (replacement) => {
+      const firstLookup = tool({
+        name: 'lookup',
+        description: 'First lookup owner.',
+        parameters: z.object({}).strict(),
+        execute: async () => 'first',
+      });
+      const secondLookup = tool({
+        name: 'lookup',
+        description: 'Second lookup owner.',
+        parameters: z.object({}).strict(),
+        execute: async () => 'second',
+      });
+      const disabledLookup = tool({
+        name: 'lookup',
+        description: 'Disabled final lookup.',
+        parameters: z.object({}).strict(),
+        isEnabled: false,
+        execute: async () => 'disabled',
+      });
+      const alternateLookup = tool({
+        name: 'alternate_lookup',
+        description: 'Different final lookup.',
+        parameters: z.object({}).strict(),
+        execute: async () => 'alternate',
+      });
+      const execute = vi.fn(
+        async ({ toolCall }: { toolCall: protocol.ToolSearchCallItem }) => {
+          const phase = String(
+            (toolCall.arguments as { phase?: string }).phase,
+          );
+          if (phase === 'first') {
+            return firstLookup;
+          }
+          if (phase === 'second') {
+            return secondLookup;
+          }
+          if (replacement === 'disabled') {
+            return disabledLookup;
+          }
+          if (replacement === 'different') {
+            return alternateLookup;
+          }
+          return [];
+        },
+      );
+      const clientToolSearch = attachClientToolSearchExecutor(
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: { type: 'tool_search', execution: 'client' },
+        },
+        execute,
+      );
+      const agent = new Agent({
+        name: `Routed owner ${replacement} agent`,
+        tools: [clientToolSearch],
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      const createCall = (
+        id: string,
+        callId: string,
+        phase: string,
+      ): protocol.ToolSearchCallItem =>
+        ({
+          type: 'tool_search_call',
+          id,
+          status: 'completed',
+          arguments: { phase },
+          providerData: { call_id: callId, execution: 'client' },
+        }) as protocol.ToolSearchCallItem;
+      const processed = await processModelResponseAsync(
+        {
+          output: [
+            createCall('ts_owner_first', 'call_owner_first', 'first'),
+            createCall('ts_owner_second', 'call_owner_second', 'second'),
+            createCall('ts_owner_final', 'call_owner_second', 'final'),
+          ],
+          usage: new Usage(),
+        },
+        agent,
+        [clientToolSearch],
+        [],
+        state,
+        [],
+      );
+      state._generatedItems.push(...processed.newItems);
+      state._lastProcessedResponse = processed;
+
+      const expectedTools = replacement === 'different' ? 1 : 0;
+      expect(state.getToolSearchRuntimeTools(agent)).toHaveLength(
+        expectedTools,
+      );
+      if (replacement === 'different') {
+        expect(
+          await (state.getToolSearchRuntimeTools(agent)[0] as any).invoke(
+            new RunContext(),
+            '{}',
+          ),
+        ).toBe('alternate');
+      }
+
+      const restored = await RunState.fromString(agent, state.toString());
+
+      expect(restored.getToolSearchRuntimeTools(agent)).toHaveLength(
+        expectedTools,
+      );
+      if (replacement === 'different') {
+        expect(
+          await (restored.getToolSearchRuntimeTools(agent)[0] as any).invoke(
+            new RunContext(),
+            '{}',
+          ),
+        ).toBe('alternate');
+      }
+    },
+  );
+
+  it('keeps a later routed owner when an older call returned the same tool object', async () => {
+    const sharedLookup = tool({
+      name: 'lookup',
+      description: 'Shared lookup owner.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'shared',
+    });
+    const execute = vi.fn(
+      async ({ toolCall }: { toolCall: protocol.ToolSearchCallItem }) =>
+        (toolCall.arguments as { phase?: string }).phase === 'empty'
+          ? []
+          : sharedLookup,
+    );
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Shared object routed owner',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const createSearchCall = (
+      id: string,
+      callId: string,
+      phase: string,
+    ): protocol.ToolSearchCallItem =>
+      ({
+        type: 'tool_search_call',
+        id,
+        status: 'completed',
+        arguments: { phase },
+        providerData: { call_id: callId, execution: 'client' },
+      }) as protocol.ToolSearchCallItem;
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_shared_object_owner',
+      callId: 'call_shared_object_owner',
+      name: 'lookup',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const processed = await processModelResponseAsync(
+      {
+        output: [
+          createSearchCall('ts_owner_a', 'owner_a', 'shared'),
+          createSearchCall('ts_owner_b', 'owner_b', 'shared'),
+          createSearchCall('ts_owner_a_empty', 'owner_a', 'empty'),
+          functionCall,
+        ],
+        usage: new Usage(),
+      },
+      agent,
+      [clientToolSearch],
+      [],
+      state,
+      [],
+    );
+    state._generatedItems.push(...processed.newItems);
+    state._lastProcessedResponse = processed;
+
+    expect(processed.functions[0]?.tool).toBe(sharedLookup);
+    expect(state.getToolSearchRuntimeTools(agent)).toEqual([sharedLookup]);
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(restored._lastProcessedResponse?.functions[0]?.tool).toBe(
+      sharedLookup,
+    );
+    expect(restored.getToolSearchRuntimeTools(agent)).toEqual([sharedLookup]);
+  });
+
+  it('restores the runtime handler bound before a later same-key replacement', async () => {
+    const execute = vi.fn(
+      async ({ toolCall }: { toolCall: protocol.ToolSearchCallItem }) => {
+        const result = String(
+          (toolCall.arguments as { result?: string }).result,
+        );
+        return tool({
+          name: 'lookup',
+          description: `${result} lookup result.`,
+          parameters: z.object({}).strict(),
+          needsApproval: true,
+          execute: async () => result,
+        });
+      },
+    );
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Interleaved replacement restore agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const firstSearchCall = {
+      type: 'tool_search_call',
+      id: 'ts_call_first_interleaved',
+      status: 'completed',
+      arguments: { result: 'first' },
+      providerData: {
+        call_id: 'call_first_interleaved',
+        execution: 'client',
+      },
+    } as protocol.ToolSearchCallItem;
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_interleaved_lookup',
+      callId: 'call_interleaved_lookup',
+      name: 'lookup',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const secondSearchCall = {
+      type: 'tool_search_call',
+      id: 'ts_call_second_interleaved',
+      status: 'completed',
+      arguments: { result: 'second' },
+      providerData: {
+        call_id: 'call_second_interleaved',
+        execution: 'client',
+      },
+    } as protocol.ToolSearchCallItem;
+    const response: ModelResponse = {
+      output: [firstSearchCall, functionCall, secondSearchCall],
+      usage: new Usage(),
+    };
+
+    const processed = await processModelResponseAsync(
+      response,
+      agent,
+      [clientToolSearch],
+      [],
+      state,
+      [],
+    );
+    state._generatedItems.push(...processed.newItems);
+    state._lastProcessedResponse = processed;
+
+    expect(
+      await (processed.functions[0].tool as any).invoke(new RunContext(), '{}'),
+    ).toBe('first');
+    expect(
+      await (state.getToolSearchRuntimeTools(agent)[0] as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('second');
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(
+      await (restored._lastProcessedResponse?.functions[0].tool as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('first');
+    expect(
+      await (restored.getToolSearchRuntimeTools(agent)[0] as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('second');
+  });
+
+  it('round trips a flattened configured namespace call with its canonical approval key', async () => {
+    const namespacedLookup = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup',
+          description: 'Configured CRM lookup.',
+          parameters: z.object({}).strict(),
+          needsApproval: true,
+          execute: async () => 'configured',
+        }),
+      ],
+    })[0];
+    const agent = new Agent({
+      name: 'Flattened configured namespace restore agent',
+      tools: [namespacedLookup],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const flattenedCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_flattened_configured_namespace',
+      callId: 'call_flattened_configured_namespace',
+      name: 'crm.lookup',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const processed = await processModelResponseAsync(
+      { output: [flattenedCall], usage: new Usage() },
+      agent,
+      [namespacedLookup],
+      [],
+      state,
+      [],
+    );
+    const normalizedCall = processed.functions[0]!.toolCall;
+    const canonicalKey = getFunctionToolStateKey(namespacedLookup)!;
+    state._generatedItems.push(...processed.newItems);
+    state._lastProcessedResponse = processed;
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: {
+        interruptions: [
+          new ToolApprovalItem(normalizedCall, agent, undefined, canonicalKey),
+        ],
+      },
+    };
+
+    expect(normalizedCall).toMatchObject({
+      name: 'lookup',
+      namespace: 'crm',
+    });
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(
+      restored._lastProcessedResponse?.functions[0]?.toolCall,
+    ).toMatchObject({ name: 'lookup', namespace: 'crm' });
+    expect(restored.getInterruptions()[0]?.functionToolStateKey).toBe(
+      canonicalKey,
+    );
+    expect(restored.getInterruptions()[0]?.rawItem).toMatchObject({
+      name: 'lookup',
+      namespace: 'crm',
+    });
+    expect(
+      await (restored._lastProcessedResponse?.functions[0]?.tool as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('configured');
+  });
+
+  it('round trips a flattened namespace call with its runtime tool-search handler', async () => {
+    const execute = vi.fn(async () =>
+      toolNamespace({
+        name: 'crm',
+        description: 'Runtime CRM tools.',
+        tools: [
+          tool({
+            name: 'lookup',
+            description: 'Runtime CRM lookup.',
+            parameters: z.object({}).strict(),
+            needsApproval: true,
+            execute: async () => 'runtime',
+          }),
+        ],
+      }),
+    );
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Flattened runtime namespace restore agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const flattenedCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_flattened_runtime_namespace',
+      callId: 'call_flattened_runtime_namespace',
+      name: 'crm.lookup',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const processed = await processModelResponseAsync(
+      {
+        output: [
+          {
+            type: 'tool_search_call',
+            id: 'ts_flattened_runtime_namespace',
+            status: 'completed',
+            arguments: {},
+            providerData: {
+              call_id: 'search_flattened_runtime_namespace',
+              execution: 'client',
+            },
+          } as protocol.ToolSearchCallItem,
+          flattenedCall,
+        ],
+        usage: new Usage(),
+      },
+      agent,
+      [clientToolSearch],
+      [],
+      state,
+      [],
+    );
+    const normalizedCall = processed.functions[0]!.toolCall;
+    const runtimeTool = processed.functions[0]!.tool;
+    const canonicalKey = getFunctionToolStateKey(runtimeTool)!;
+    state._generatedItems.push(...processed.newItems);
+    state._lastProcessedResponse = processed;
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: {
+        interruptions: [
+          new ToolApprovalItem(normalizedCall, agent, undefined, canonicalKey),
+        ],
+      },
+    };
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(
+      restored._lastProcessedResponse?.functions[0]?.toolCall,
+    ).toMatchObject({ name: 'lookup', namespace: 'crm' });
+    expect(restored.getInterruptions()[0]?.functionToolStateKey).toBe(
+      canonicalKey,
+    );
+    expect(
+      await (restored._lastProcessedResponse?.functions[0]?.tool as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('runtime');
+
+    const restoredProcessedTool =
+      restored._lastProcessedResponse?.functions[0]?.tool;
+
+    await rehydrateProcessedResponseTools(agent, restored, []);
+
+    expect(restored._lastProcessedResponse?.functions[0]?.tool).toBe(
+      restoredProcessedTool,
+    );
+    expect(
+      await (restored._lastProcessedResponse?.functions[0]?.tool as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('runtime');
+  });
+
+  it.each([CURRENT_SCHEMA_VERSION, '1.15'] as const)(
+    'round trips a deferred runtime tool selected by a legacy bare call in schema %s',
+    async (schemaVersion) => {
+      const deferredLookup = tool({
+        name: 'lookup',
+        description: 'Deferred lookup.',
+        parameters: z.object({}).strict(),
+        deferLoading: true,
+        needsApproval: true,
+        execute: async () => 'deferred',
+      });
+      const execute = vi.fn(async () => deferredLookup);
+      const clientToolSearch = attachClientToolSearchExecutor(
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: { type: 'tool_search', execution: 'client' },
+        },
+        execute,
+      );
+      const agent = new Agent({
+        name: `Deferred bare restore ${schemaVersion}`,
+        tools: [clientToolSearch],
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      const functionCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        id: `fc_deferred_bare_${schemaVersion}`,
+        callId: `call_deferred_bare_${schemaVersion}`,
+        name: 'lookup',
+        status: 'completed',
+        arguments: '{}',
+      };
+      const processed = await processModelResponseAsync(
+        {
+          output: [
+            {
+              type: 'tool_search_call',
+              id: `ts_call_deferred_bare_${schemaVersion}`,
+              status: 'completed',
+              arguments: {},
+              providerData: {
+                call_id: `search_deferred_bare_${schemaVersion}`,
+                execution: 'client',
+              },
+            } as protocol.ToolSearchCallItem,
+            functionCall,
+          ],
+          usage: new Usage(),
+        },
+        agent,
+        [clientToolSearch],
+        [],
+        state,
+        [],
+      );
+      state._generatedItems.push(...processed.newItems);
+      state._lastProcessedResponse = processed;
+      state._currentStep = {
+        type: 'next_step_interruption',
+        data: {
+          interruptions: [
+            new ToolApprovalItem(
+              functionCall,
+              agent,
+              undefined,
+              getFunctionToolStateKey(deferredLookup),
+            ),
+          ],
+        },
+      };
+
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = schemaVersion;
+      if (schemaVersion === '1.15') {
+        delete serialized.currentStep.data.interruptions[0]
+          .functionToolStateKey;
+      }
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(execute).toHaveBeenCalledTimes(2);
+      expect(restored.getInterruptions()[0]?.functionToolStateKey).toBe(
+        getFunctionToolStateKey(deferredLookup),
+      );
+      expect(
+        await (
+          restored._lastProcessedResponse?.functions[0].tool as any
+        ).invoke(new RunContext(), '{}'),
+      ).toBe('deferred');
+    },
+  );
+
+  it('rejects an unproven deferred bare fallback instead of rebinding a bare owner', async () => {
+    const bareLookup = tool({
+      name: 'lookup',
+      description: 'Bare lookup.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'bare',
+    });
+    const deferredLookup = tool({
+      name: 'lookup',
+      description: 'Unproven deferred lookup.',
+      parameters: z.object({}).strict(),
+      deferLoading: true,
+      execute: async () => 'deferred',
+    });
+    const agent = new Agent({
+      name: 'Unproven deferred fallback agent',
+      tools: [bareLookup],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_unproven_deferred_fallback',
+      callId: 'call_unproven_deferred_fallback',
+      name: 'lookup',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._generatedItems.push(new RunToolCallItem(functionCall, agent));
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall: functionCall, tool: deferredLookup as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['lookup'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: {
+        interruptions: [
+          new ToolApprovalItem(
+            functionCall,
+            agent,
+            undefined,
+            getFunctionToolStateKey(deferredLookup),
+          ),
+        ],
+      },
+    };
+
+    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
+      'function call ID is associated with multiple routed tool identities',
+    );
+  });
+
+  it('round trips a legacy bare call resolved by a configured deferred owner', async () => {
+    const deferredLookup = tool({
+      name: 'lookup',
+      description: 'Configured deferred lookup.',
+      parameters: z.object({}).strict(),
+      deferLoading: true,
+      execute: async () => 'deferred',
+    });
+    const agent = new Agent({
+      name: 'Configured deferred fallback agent',
+      tools: [deferredLookup],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_configured_deferred_fallback',
+      callId: 'call_configured_deferred_fallback',
+      name: 'lookup',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._generatedItems.push(new RunToolCallItem(functionCall, agent));
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall: functionCall, tool: deferredLookup as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['lookup'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: {
+        interruptions: [
+          new ToolApprovalItem(
+            functionCall,
+            agent,
+            undefined,
+            getFunctionToolStateKey(deferredLookup),
+          ),
+        ],
+      },
+    };
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(restored.getInterruptions()[0]?.functionToolStateKey).toBe(
+      getFunctionToolStateKey(deferredLookup),
+    );
+    expect(
+      await (restored._lastProcessedResponse?.functions[0].tool as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('deferred');
+  });
+
+  it.each([CURRENT_SCHEMA_VERSION, '1.15'] as const)(
+    'rejects a configured deferred bare fallback hidden by a handoff in schema %s',
+    async (schemaVersion) => {
+      const deferredLookup = tool({
+        name: 'lookup',
+        description: 'Configured deferred lookup.',
+        parameters: z.object({}).strict(),
+        deferLoading: true,
+        execute: async () => 'deferred',
+      });
+      const target = new Agent({ name: 'Deferred lookup target' });
+      const agent = new Agent({
+        name: `Configured deferred handoff collision ${schemaVersion}`,
+        tools: [deferredLookup],
+        handoffs: [handoff(target, { toolNameOverride: 'lookup' })],
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      const functionCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        id: `fc_configured_deferred_handoff_${schemaVersion}`,
+        callId: `call_configured_deferred_handoff_${schemaVersion}`,
+        name: 'lookup',
+        status: 'completed',
+        arguments: '{}',
+      };
+      state._generatedItems.push(new RunToolCallItem(functionCall, agent));
+      state._lastProcessedResponse = {
+        newItems: [],
+        functions: [{ toolCall: functionCall, tool: deferredLookup as any }],
+        handoffs: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: ['lookup'],
+        hasToolsOrApprovalsToRun: () => true,
+      };
+      state._currentStep = {
+        type: 'next_step_interruption',
+        data: {
+          interruptions: [
+            new ToolApprovalItem(
+              functionCall,
+              agent,
+              undefined,
+              getFunctionToolStateKey(deferredLookup),
+            ),
+          ],
+        },
+      };
+
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = schemaVersion;
+      if (schemaVersion === '1.15') {
+        delete serialized.currentStep.data.interruptions[0]
+          .functionToolStateKey;
+      }
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow(
+        'function call ID is associated with multiple routed tool identities',
+      );
+    },
+  );
+
+  it('scopes repeated function call ids to each interruption agent', async () => {
+    const outerTool = tool({
+      name: 'outer_tool',
+      description: 'Outer tool.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'outer',
+    });
+    const childTool = tool({
+      name: 'child_tool',
+      description: 'Child tool.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'child',
+    });
+    const child = new Agent({ name: 'Call id child', tools: [childTool] });
+    const root = new Agent({
+      name: 'Call id root',
+      tools: [outerTool],
+      handoffs: [child],
+    });
+    const state = new RunState(new RunContext(), 'input', root, 2);
+    const sharedCallId = 'agent_scoped_call_id';
+    const outerCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_outer_agent_scoped',
+      callId: sharedCallId,
+      name: 'outer_tool',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const childCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_child_agent_scoped',
+      callId: sharedCallId,
+      name: 'child_tool',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._generatedItems.push(
+      new RunToolCallItem(outerCall, root),
+      new RunToolCallItem(childCall, child),
+    );
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall: outerCall, tool: outerTool as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['outer_tool'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: {
+        interruptions: [
+          new ToolApprovalItem(
+            childCall,
+            child,
+            undefined,
+            getFunctionToolStateKey(childTool),
+          ),
+        ],
+      },
+    };
+
+    const restored = await RunState.fromString(root, state.toString());
+
+    expect(restored.getInterruptions()[0]?.agent).toBe(child);
+    expect(restored.getInterruptions()[0]?.functionToolStateKey).toBe(
+      getFunctionToolStateKey(childTool),
+    );
+  });
+
+  it('preserves independent function approvals with the same identity across agents', async () => {
+    const rootTool = tool({
+      name: 'shared_tool',
+      description: 'Root shared tool.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'root',
+    });
+    const childTool = tool({
+      name: 'shared_tool',
+      description: 'Child shared tool.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'child',
+    });
+    const child = new Agent({
+      name: 'Shared approval agent',
+      tools: [childTool],
+    });
+    const root = new Agent({
+      name: 'Shared approval agent',
+      tools: [rootTool],
+      handoffs: [child],
+    });
+    const sharedCallId = 'shared_approval_call_id';
+    const rootCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_shared_approval_root',
+      callId: sharedCallId,
+      name: 'shared_tool',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const childCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_shared_approval_child',
+      callId: sharedCallId,
+      name: 'shared_tool',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const state = new RunState(new RunContext(), 'input', root, 2);
+    state._generatedItems.push(
+      new RunToolCallItem(rootCall, root),
+      new RunToolCallItem(childCall, child),
+    );
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall: rootCall, tool: rootTool as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['shared_tool'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: {
+        interruptions: [
+          new ToolApprovalItem(
+            rootCall,
+            root,
+            undefined,
+            getFunctionToolStateKey(rootTool),
+          ),
+          new ToolApprovalItem(
+            childCall,
+            child,
+            undefined,
+            getFunctionToolStateKey(childTool),
+          ),
+        ],
+      },
+    };
+
+    const sharedStateKey = getFunctionToolStateKey(rootTool)!;
+    const legacySerialized = state.toJSON() as any;
+    legacySerialized.$schemaVersion = '1.15';
+    legacySerialized.context.approvals = {
+      shared_tool: { approved: [sharedCallId], rejected: [] },
+    };
+    delete legacySerialized.context.functionApprovals;
+    for (const interruption of legacySerialized.currentStep.data
+      .interruptions) {
+      delete interruption.functionToolStateKey;
+    }
+    const legacyRestored = await RunState.fromString(
+      root,
+      JSON.stringify(legacySerialized),
+    );
+    for (const owner of [root, child]) {
+      expect(
+        legacyRestored._context.isToolApproved({
+          toolName: sharedStateKey,
+          callId: sharedCallId,
+          functionTool: false,
+          agent: owner,
+        }),
+      ).toBe(true);
+    }
+    const legacyRoundTripped = await RunState.fromString(
+      root,
+      legacyRestored.toString(),
+    );
+    for (const owner of [root, child]) {
+      expect(
+        legacyRoundTripped._context.isToolApproved({
+          toolName: sharedStateKey,
+          callId: sharedCallId,
+          functionTool: false,
+          agent: owner,
+        }),
+      ).toBe(true);
+    }
+
+    const restored = await RunState.fromString(root, state.toString());
+    const [rootApproval, childApproval] = restored.getInterruptions();
+    restored.approve(rootApproval, { alwaysApprove: true });
+    restored.reject(childApproval, { message: 'Child call rejected.' });
+
+    const roundTripped = await RunState.fromString(root, restored.toString());
+    expect(
+      roundTripped._context.isToolApproved({
+        toolName: sharedStateKey,
+        callId: 'future-root-call',
+        functionTool: false,
+        agent: root,
+      }),
+    ).toBe(true);
+    expect(
+      roundTripped._context.isToolApproved({
+        toolName: sharedStateKey,
+        callId: sharedCallId,
+        functionTool: false,
+        agent: child,
+      }),
+    ).toBe(false);
+    expect(
+      roundTripped._context.isToolApproved({
+        toolName: sharedStateKey,
+        callId: 'future-child-call',
+        functionTool: false,
+        agent: child,
+      }),
+    ).toBeUndefined();
+    expect(
+      roundTripped._context._getFunctionRejectionMessage(
+        sharedStateKey,
+        sharedCallId,
+        child,
+      ),
+    ).toBe('Child call rejected.');
+    expect(
+      roundTripped._context._getFunctionRejectionMessage(
+        sharedStateKey,
+        sharedCallId,
+        root,
+      ),
+    ).toBeUndefined();
+  });
+
+  it('round trips function approvals for reserved agent identity names', async () => {
+    const agent = new Agent({ name: '__proto__' });
+    const rawItem: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'reserved_identity_tool',
+      callId: 'reserved_identity_call',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    state.reject(new ToolApprovalItem(rawItem, agent), {
+      message: 'Reserved identity rejected.',
+    });
+
+    const serialized = state.toJSON();
+    expect(serialized.context.functionApprovals).toEqual([
+      {
+        agentIdentity: '__proto__',
+        approvals: expect.any(Object),
+      },
+    ]);
+
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+    const stateKey = getFunctionToolStateKeyForCall(rawItem)!;
+    expect(
+      restored._context.isToolApproved({
+        toolName: stateKey,
+        callId: rawItem.callId,
+        functionTool: false,
+        agent,
+      }),
+    ).toBe(false);
+    expect(
+      restored._context._getFunctionRejectionMessage(
+        stateKey,
+        rawItem.callId,
+        agent,
+      ),
+    ).toBe('Reserved identity rejected.');
+  });
+
+  it('validates current function approval state before context replacement', async () => {
+    const agent = new Agent({ name: 'ApprovalOwnerValidationAgent' });
+    const rawItem: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'approval_owner_tool',
+      callId: 'approval_owner_call',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    state.approve(new ToolApprovalItem(rawItem, agent));
+    const serialized = state.toJSON() as any;
+    serialized.context.functionApprovals[0].agentIdentity = 'unknown-agent';
+
+    await expect(
+      RunState.fromStringWithContext(
+        agent,
+        JSON.stringify(serialized),
+        new RunContext(),
+        { contextStrategy: 'replace' },
+      ),
+    ).rejects.toBeInstanceOf(UserError);
+  });
+
+  it('rejects duplicate function approval owners before tool execution', async () => {
+    const execute = vi.fn(async () => 'executed');
+    const approvalTool = tool({
+      name: 'duplicate_owner_tool',
+      description: 'Duplicate owner tool.',
+      parameters: z.object({}),
+      execute,
+    });
+    const agent = new Agent({
+      name: 'DuplicateApprovalOwnerAgent',
+      tools: [approvalTool],
+    });
+    const rawItem: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: approvalTool.name,
+      callId: 'duplicate_owner_call',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    state.approve(new ToolApprovalItem(rawItem, agent));
+    const serialized = state.toJSON() as any;
+    serialized.context.functionApprovals.push({
+      ...serialized.context.functionApprovals[0],
+      approvals: {
+        ...serialized.context.functionApprovals[0].approvals,
+      },
+    });
+
+    await expect(
+      RunState.fromStringWithContext(
+        agent,
+        JSON.stringify(serialized),
+        new RunContext(),
+        { contextStrategy: 'replace' },
+      ),
+    ).rejects.toBeInstanceOf(UserError);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed current function approval state with UserError', async () => {
+    const agent = new Agent({ name: 'MalformedApprovalOwnerAgent' });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    const serialized = state.toJSON() as any;
+    serialized.context.functionApprovals = [
+      {
+        agentIdentity: agent.name,
+        approvals: {
+          malformed: { approved: 'yes', rejected: [] },
+        },
+      },
+    ];
+
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toBeInstanceOf(UserError);
+  });
+
+  it('preserves ZodError for unrelated malformed run state fields', async () => {
+    const agent = new Agent({ name: 'MalformedUnrelatedStateAgent' });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    const serialized = state.toJSON() as any;
+    serialized.currentTurn = 'not-a-number';
+
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toBeInstanceOf(ZodError);
+  });
+
+  it('rejects owner-scoped approval fields in legacy schemas', async () => {
+    const agent = new Agent({ name: 'LegacyApprovalOwnerFieldAgent' });
+    const rawItem: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'legacy_owner_tool',
+      callId: 'legacy_owner_call',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    state.approve(new ToolApprovalItem(rawItem, agent));
+    const serialized = state.toJSON() as any;
+    serialized.$schemaVersion = '1.15';
+
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow(
+      'Run state schema version 1.15 does not support owner-scoped function approvals.',
+    );
+  });
+
+  it('rejects interruption identity mismatches before callbacks without a processed response', async () => {
+    const dangerous = tool({
+      name: 'dangerous',
+      description: 'Dangerous action.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'dangerous',
+    });
+    const harmless = tool({
+      name: 'harmless',
+      description: 'Harmless action.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'harmless',
+    });
+    const runtimeLookup = tool({
+      name: 'runtime_lookup',
+      description: 'Runtime lookup.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'runtime',
+    });
+    const execute = vi.fn(async () => runtimeLookup);
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'No processed response interruption agent',
+      tools: [dangerous, harmless, clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const rawItem: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_no_processed_response',
+      callId: 'call_no_processed_response',
+      name: 'dangerous',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_no_processed_response',
+          status: 'completed',
+          arguments: {},
+          providerData: {
+            call_id: 'search_no_processed_response',
+            execution: 'client',
+          },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_no_processed_response',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'runtime_lookup',
+              description: 'Runtime lookup.',
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+          ],
+          providerData: {
+            call_id: 'search_no_processed_response',
+            execution: 'client',
+          },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+      new RunToolCallItem(rawItem, agent),
+    );
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: {
+        interruptions: [
+          new ToolApprovalItem(
+            rawItem,
+            agent,
+            undefined,
+            getFunctionToolStateKey(harmless),
+          ),
+        ],
+      },
+    };
+
+    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
+      'function call ID is associated with multiple routed tool identities',
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('rejects reused function call ids before tool-search rehydration callbacks', async () => {
+    const runtimeLookup = tool({
+      name: 'runtime_lookup',
+      description: 'Runtime lookup.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'runtime',
+    });
+    const configuredLookup = tool({
+      name: 'configured_lookup',
+      description: 'Configured lookup.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'configured',
+    });
+    const execute = vi.fn(async () => runtimeLookup);
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Reused function call id agent',
+      tools: [configuredLookup, clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const sharedCallId = 'reused_function_call_id';
+    const runtimeCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_runtime_lookup',
+      callId: sharedCallId,
+      name: 'runtime_lookup',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const configuredCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_configured_lookup',
+      callId: sharedCallId,
+      name: 'configured_lookup',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_reused_function_id',
+          status: 'completed',
+          arguments: {},
+          providerData: {
+            call_id: 'tool_search_reused_function_id',
+            execution: 'client',
+          },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_reused_function_id',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'runtime_lookup',
+              description: 'Runtime lookup.',
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+          ],
+          providerData: {
+            call_id: 'tool_search_reused_function_id',
+            execution: 'client',
+          },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+      new RunToolCallItem(runtimeCall, agent),
+      new RunToolCallItem(configuredCall, agent),
+    );
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall: configuredCall, tool: configuredLookup as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['configured_lookup'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+
+    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
+      'function call ID is associated with multiple routed tool identities',
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('rejects reused function call ids before legacy state migration', async () => {
+    const bareLookup = tool({
+      name: 'lookup',
+      description: 'Bare lookup.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'bare',
+    });
+    const deferredLookup = tool({
+      name: 'lookup',
+      description: 'Deferred lookup.',
+      parameters: z.object({}).strict(),
+      deferLoading: true,
+      execute: async () => 'deferred',
+    });
+    const agent = new Agent({
+      name: 'Legacy reused function call id agent',
+      tools: [bareLookup, deferredLookup],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const sharedCallId = 'legacy_reused_function_call_id';
+    const bareCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_legacy_bare_lookup',
+      callId: sharedCallId,
+      name: 'lookup',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const deferredCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_legacy_deferred_lookup',
+      callId: sharedCallId,
+      name: 'lookup',
+      namespace: 'lookup',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [
+        { toolCall: bareCall, tool: bareLookup as any },
+        { toolCall: deferredCall, tool: deferredLookup as any },
+      ],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['lookup'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+
+    const serialized = state.toJSON() as any;
+    serialized.$schemaVersion = '1.15';
+
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow(
+      'function call ID is associated with multiple routed tool identities',
+    );
+  });
+
+  it('rejects an interruption whose routed identity differs from its processed call', async () => {
+    const dangerous = tool({
+      name: 'dangerous',
+      description: 'Dangerous action.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'dangerous',
+    });
+    const harmless = tool({
+      name: 'harmless',
+      description: 'Harmless action.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'harmless',
+    });
+    const agent = new Agent({
+      name: 'Mismatched interruption identity agent',
+      tools: [dangerous, harmless],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const rawItem: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_dangerous',
+      callId: 'mismatched_interruption_identity',
+      name: 'dangerous',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall: rawItem, tool: dangerous as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['dangerous'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: {
+        interruptions: [new ToolApprovalItem(rawItem, agent)],
+      },
+    };
+
+    const serialized = state.toJSON() as any;
+    serialized.currentStep.data.interruptions[0].rawItem.name = 'harmless';
+
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow(
+      'function call ID is associated with multiple routed tool identities',
+    );
+  });
+
+  it('validates every tool-search output before invoking a rehydration callback', async () => {
+    const runtimeTool = tool({
+      name: 'lookup',
+      description: 'Lookup result.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'lookup',
+    });
+    const execute = vi.fn(async () => runtimeTool);
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Tool-search preflight agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_preflight_valid',
+          status: 'completed',
+          arguments: {},
+          providerData: {
+            call_id: 'call_preflight_valid',
+            execution: 'client',
+          },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_preflight_valid',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'lookup',
+              description: 'Lookup result.',
+              strict: true,
+              parameters: { type: 'object', properties: {}, required: [] },
+            },
+          ],
+          providerData: {
+            call_id: 'call_preflight_valid',
+            execution: 'client',
+          },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_preflight_orphan',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'orphan',
+              description: 'Orphan result.',
+              strict: true,
+              parameters: { type: 'object', properties: {}, required: [] },
+            },
+          ],
+          providerData: {
+            call_id: 'call_preflight_orphan',
+            execution: 'client',
+          },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+
+    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
+      'serialized state is missing the matching tool_search call item',
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed serialized runtime identity before rehydration callbacks', async () => {
+    const execute = vi.fn();
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Malformed tool-search identity agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const callId = 'call_malformed_identity';
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_malformed_identity',
+          status: 'completed',
+          arguments: {},
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_malformed_identity',
+          status: 'completed',
+          tools: [{ type: 'function' }],
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+
+    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
+      'function without a valid routed identity',
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('rejects a reserved serialized namespace before rehydration callbacks', async () => {
+    const execute = vi.fn(async () => []);
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Reserved serialized namespace agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const callId = 'call_reserved_serialized_namespace';
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_reserved_serialized_namespace',
+          status: 'completed',
+          arguments: {},
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_reserved_serialized_namespace',
+          status: 'completed',
+          tools: [
+            {
+              type: 'namespace',
+              name: 'lookup',
+              description: 'Reserved lookup namespace.',
+              tools: [
+                {
+                  type: 'function',
+                  name: 'lookup',
+                  description: 'Nested lookup.',
+                  strict: true,
+                  parameters: {
+                    type: 'object',
+                    properties: {},
+                    required: [],
+                    additionalProperties: false,
+                  },
+                },
+              ],
+            },
+          ],
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+
+    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
+      'Responses tool search reserves same-name namespaces for deferred top-level function tools.',
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('rejects a direct serialized self-namespace before rehydration callbacks', async () => {
+    const runtimeLookup = tool({
+      name: 'lookup',
+      description: 'Deferred lookup.',
+      parameters: z.object({}).strict(),
+      deferLoading: true,
+      execute: async () => 'lookup',
+    });
+    const execute = vi.fn(async () => runtimeLookup);
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Direct reserved serialized namespace agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const callId = 'call_direct_reserved_serialized_namespace';
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_direct_reserved_serialized_namespace',
+          status: 'completed',
+          arguments: {},
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_direct_reserved_serialized_namespace',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'lookup',
+              namespace: 'lookup',
+              description: 'Reserved lookup namespace.',
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+          ],
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+
+    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
+      'Responses tool search reserves same-name namespaces for deferred top-level function tools.',
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('replays an empty tool-search callback before later callbacks', async () => {
+    type TestContext = { ready: boolean };
+    const execute = vi.fn(
+      async ({
+        runContext,
+        toolCall,
+      }: {
+        runContext: RunContext<TestContext>;
+        toolCall: protocol.ToolSearchCallItem;
+      }) => {
+        const phase = (toolCall.arguments as { phase?: string }).phase;
+        if (phase === 'empty') {
+          runContext.context.ready = true;
+          return [];
+        }
+        const name = runContext.context.ready ? 'after_empty' : 'wrong';
+        return tool({
+          name,
+          description: 'Result after the empty callback.',
+          parameters: z.object({}).strict(),
+          execute: async () => name,
+        });
+      },
+    );
+    const clientToolSearch = attachClientToolSearchExecutor<TestContext>(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent<TestContext>({
+      name: 'Empty callback replay agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(
+      new RunContext({ ready: false }),
+      'input',
+      agent,
+      2,
+    );
+    const createCall = (
+      id: string,
+      phase: string,
+    ): protocol.ToolSearchCallItem =>
+      ({
+        type: 'tool_search_call',
+        id: `ts_${id}`,
+        status: 'completed',
+        arguments: { phase },
+        providerData: { call_id: id, execution: 'client' },
+      }) as protocol.ToolSearchCallItem;
+    const processed = await processModelResponseAsync(
+      {
+        output: [
+          createCall('call_empty_replay', 'empty'),
+          createCall('call_after_empty_replay', 'after'),
+        ],
+        usage: new Usage(),
+      },
+      agent,
+      [clientToolSearch],
+      [],
+      state,
+      [],
+    );
+    state._generatedItems.push(...processed.newItems);
+    state._lastProcessedResponse = processed;
+
+    const restored = await RunState.fromStringWithContext(
+      agent,
+      state.toString(),
+      new RunContext({ ready: false }),
+      { contextStrategy: 'replace' },
+    );
+
+    expect(execute).toHaveBeenCalledTimes(4);
+    expect(restored.getToolSearchRuntimeTools(agent)[0]?.name).toBe(
+      'after_empty',
+    );
+  });
+
+  it('rejects an empty custom tool-search output when its executor is unavailable', async () => {
+    type TestContext = { ready: boolean };
+    const execute = vi.fn(
+      async ({ runContext }: { runContext: RunContext<TestContext> }) => {
+        runContext.context.ready = true;
+        return [];
+      },
+    );
+    const customToolSearchProviderData = {
+      type: 'tool_search' as const,
+      execution: 'client' as const,
+      parameters: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+    };
+    const clientToolSearch = attachClientToolSearchExecutor<TestContext>(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: customToolSearchProviderData,
+      },
+      execute,
+    );
+    const agent = new Agent<TestContext>({
+      name: 'Empty custom callback restore agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(
+      new RunContext({ ready: false }),
+      'input',
+      agent,
+      2,
+    );
+    const processed = await processModelResponseAsync(
+      {
+        output: [
+          {
+            type: 'tool_search_call',
+            id: 'ts_call_empty_custom_restore',
+            status: 'completed',
+            arguments: {},
+            providerData: {
+              call_id: 'call_empty_custom_restore',
+              execution: 'client',
+            },
+          } as protocol.ToolSearchCallItem,
+        ],
+        usage: new Usage(),
+      },
+      agent,
+      [clientToolSearch],
+      [],
+      state,
+      [],
+    );
+    state._generatedItems.push(...processed.newItems);
+    state._lastProcessedResponse = processed;
+
+    const replacementAgent = new Agent<TestContext>({
+      name: agent.name,
+      tools: [
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: customToolSearchProviderData,
+        },
+      ],
+    });
+    const replacementContext = new RunContext({ ready: false });
+
+    await expect(
+      RunState.fromStringWithContext(
+        replacementAgent,
+        state.toString(),
+        replacementContext,
+        { contextStrategy: 'replace' },
+      ),
+    ).rejects.toThrow(
+      'require toolSearchTool({ execution: "client", execute }) when custom client tool_search parameters are provided',
+    );
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(replacementContext.context.ready).toBe(false);
+  });
+
+  it('restores an empty built-in tool-search output without an executor', async () => {
+    const clientToolSearch = {
+      type: 'hosted_tool' as const,
+      name: 'tool_search',
+      providerData: {
+        type: 'tool_search' as const,
+        execution: 'client' as const,
+      },
+    };
+    const agent = new Agent({
+      name: 'Empty built-in restore agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const callId = 'call_empty_builtin_restore';
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_empty_builtin_restore',
+          status: 'completed',
+          arguments: { paths: [] },
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_empty_builtin_restore',
+          status: 'completed',
+          tools: [],
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(restored.getToolSearchRuntimeTools(agent)).toEqual([]);
+  });
+
+  it('keeps disabled callback results visible to later tool-search callbacks', async () => {
+    type TestContext = { enabled: boolean };
+    const availableToolNames: string[][] = [];
+    const execute = vi.fn(
+      async ({
+        availableTools,
+        toolCall,
+      }: {
+        availableTools: Tool<TestContext>[];
+        toolCall: protocol.ToolSearchCallItem;
+      }) => {
+        availableToolNames.push(availableTools.map((entry) => entry.name));
+        const phase = (toolCall.arguments as { phase?: string }).phase;
+        if (phase === 'disabled') {
+          return tool({
+            name: 'disabled_runtime',
+            description: 'Disabled runtime result.',
+            parameters: z.object({}).strict(),
+            isEnabled: ({ runContext }) =>
+              (runContext.context as TestContext).enabled,
+            execute: async () => 'disabled',
+          });
+        }
+        const sawDisabled = availableTools.some(
+          (entry) => entry.name === 'disabled_runtime',
+        );
+        const name = sawDisabled ? 'after_disabled' : 'wrong';
+        return tool({
+          name,
+          description: 'Result after the disabled callback.',
+          parameters: z.object({}).strict(),
+          execute: async () => name,
+        });
+      },
+    );
+    const clientToolSearch = attachClientToolSearchExecutor<TestContext>(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent<TestContext>({
+      name: 'Disabled callback replay agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(
+      new RunContext({ enabled: false }),
+      'input',
+      agent,
+      2,
+    );
+    const createCall = (
+      id: string,
+      phase: string,
+    ): protocol.ToolSearchCallItem =>
+      ({
+        type: 'tool_search_call',
+        id: `ts_${id}`,
+        status: 'completed',
+        arguments: { phase },
+        providerData: { call_id: id, execution: 'client' },
+      }) as protocol.ToolSearchCallItem;
+    const processed = await processModelResponseAsync(
+      {
+        output: [
+          createCall('call_disabled_replay', 'disabled'),
+          createCall('call_after_disabled_replay', 'after'),
+        ],
+        usage: new Usage(),
+      },
+      agent,
+      [clientToolSearch],
+      [],
+      state,
+      [],
+    );
+    state._generatedItems.push(...processed.newItems);
+    state._lastProcessedResponse = processed;
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(availableToolNames).toEqual([
+      ['tool_search'],
+      ['tool_search', 'disabled_runtime'],
+      ['tool_search'],
+      ['tool_search', 'disabled_runtime'],
+    ]);
+    expect(
+      restored.getToolSearchRuntimeTools(agent).map((entry) => entry.name),
+    ).toEqual(['after_disabled']);
+  });
+
+  it('rejects duplicate configured identities returned during tool-search rehydration', async () => {
+    const configuredTool = tool({
+      name: 'configured',
+      description: 'Configured tool.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'configured',
+    });
+    const runtimeTool = tool({
+      name: 'runtime',
+      description: 'Runtime tool.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'runtime',
+    });
+    const execute = vi.fn(async () => [
+      configuredTool,
+      configuredTool,
+      runtimeTool,
+    ]);
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Configured duplicate restore agent',
+      tools: [configuredTool, clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const callId = 'call_configured_duplicate_restore';
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_configured_duplicate_restore',
+          status: 'completed',
+          arguments: { query: 'runtime' },
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_configured_duplicate_restore',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'configured',
+              description: 'Configured tool.',
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+            {
+              type: 'function',
+              name: 'runtime',
+              description: 'Runtime tool.',
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+          ],
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+
+    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
+      'Client tool_search execute() returned multiple tools with the same routed identity.',
+    );
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['accepts the final replacement', true],
+    ['rejects a stale first result', false],
+  ] as const)(
+    '%s when rehydrating repeated client tool_search outputs',
+    async (_description, returnFinalReplacement) => {
+      const firstLookup = tool({
+        name: 'first_lookup',
+        description: 'First lookup result.',
+        parameters: z.object({}).strict(),
+        execute: async () => 'first',
+      });
+      const latestLookup = tool({
+        name: 'latest_lookup',
+        description: 'Latest lookup result.',
+        parameters: z.object({}).strict(),
+        execute: async () => 'latest',
+      });
+      const execute = vi.fn(async () =>
+        returnFinalReplacement ? latestLookup : firstLookup,
+      );
+      const clientToolSearch = attachClientToolSearchExecutor(
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: {
+            type: 'tool_search',
+            execution: 'client',
+          },
+        },
+        execute,
+      );
+      const agent = new Agent({
+        name: 'Replacement restore agent',
+        tools: [clientToolSearch],
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      const callId = 'call_replacement_restore';
+      state._generatedItems.push(
+        new RunToolSearchCallItem(
+          {
+            type: 'tool_search_call',
+            id: 'ts_call_replacement_restore',
+            status: 'completed',
+            arguments: { paths: [] },
+            providerData: { call_id: callId, execution: 'client' },
+          } as protocol.ToolSearchCallItem,
+          agent,
+        ),
+        new RunToolSearchOutputItem(
+          {
+            type: 'tool_search_output',
+            id: 'ts_output_replacement_first',
+            status: 'completed',
+            tools: [
+              {
+                type: 'function',
+                name: 'first_lookup',
+                description: 'First lookup result.',
+                strict: true,
+                parameters: {
+                  type: 'object',
+                  properties: {},
+                  required: [],
+                  additionalProperties: false,
+                },
+              },
+            ],
+            providerData: { call_id: callId, execution: 'client' },
+          } as protocol.ToolSearchOutputItem,
+          agent,
+        ),
+        new RunToolSearchOutputItem(
+          {
+            type: 'tool_search_output',
+            id: 'ts_output_replacement_latest',
+            status: 'completed',
+            tools: [
+              {
+                type: 'function',
+                name: 'latest_lookup',
+                description: 'Latest lookup result.',
+                strict: true,
+                parameters: {
+                  type: 'object',
+                  properties: {},
+                  required: [],
+                  additionalProperties: false,
+                },
+              },
+            ],
+            providerData: { call_id: callId, execution: 'client' },
+          } as protocol.ToolSearchOutputItem,
+          agent,
+        ),
+      );
+
+      const restoredPromise = RunState.fromString(agent, state.toString());
+      if (returnFinalReplacement) {
+        const restored = await restoredPromise;
+        expect(restored.getToolSearchRuntimeTools(agent)).toEqual([
+          latestLookup,
+        ]);
+      } else {
+        await expect(restoredPromise).rejects.toThrow(
+          'RunState cannot resume custom client tool_search because the registered execute callback returned different runtime tools than the serialized state.',
+        );
+      }
+      expect(execute).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('redacts runtime tool identities from RunState callback mismatches', async () => {
+    const expectedName = 'secret_expected_lookup';
+    const actualName = 'secret_actual_lookup';
+    const actualLookup = tool({
+      name: actualName,
+      description: 'Actual lookup.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'actual',
+    });
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      async () => actualLookup,
+    );
+    const agent = new Agent({
+      name: 'Redacted mismatch agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const callId = 'call_redacted_mismatch';
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_redacted_mismatch',
+          status: 'completed',
+          arguments: {},
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_redacted_mismatch',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: expectedName,
+              description: 'Expected lookup.',
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+          ],
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+    const redaction = vi
+      .spyOn(logger, 'dontLogToolData', 'get')
+      .mockReturnValue(true);
+
+    try {
+      const restored = RunState.fromString(agent, state.toString());
+      await expect(restored).rejects.toThrow(
+        'RunState cannot resume custom client tool_search because the registered execute callback returned different runtime tools than the serialized state.',
+      );
+      await expect(restored).rejects.not.toThrow(expectedName);
+      await expect(restored).rejects.not.toThrow(actualName);
+    } finally {
+      redaction.mockRestore();
+    }
+  });
+
+  it('redacts call and agent identities from missing tool-search executors', async () => {
+    const callId = 'secret_missing_executor_call';
+    const agent = new Agent({ name: 'Secret missing executor agent' });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_missing_executor',
+          status: 'completed',
+          arguments: {},
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_missing_executor',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'secret_runtime_lookup',
+              description: 'Secret runtime lookup.',
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+          ],
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+    const redaction = vi
+      .spyOn(logger, 'dontLogToolData', 'get')
+      .mockReturnValue(true);
+
+    try {
+      const restored = RunState.fromString(agent, state.toString());
+      await expect(restored).rejects.toThrow(
+        'RunState cannot resume custom client tool_search because the agent no longer provides toolSearchTool({ execution: "client", execute }).',
+      );
+      await expect(restored).rejects.not.toThrow(callId);
+      await expect(restored).rejects.not.toThrow(agent.name);
+    } finally {
+      redaction.mockRestore();
+    }
+  });
+
+  it('rehydrates same-name runtime tools from distinct function categories', async () => {
+    const bareLookup = tool({
+      name: 'lookup',
+      description: 'Immediate lookup.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'bare',
+    });
+    const deferredLookup = tool({
+      name: 'lookup',
+      description: 'Deferred lookup.',
+      parameters: z.object({}).strict(),
+      deferLoading: true,
+      execute: async () => 'deferred',
+    });
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: {
+          type: 'tool_search',
+          execution: 'client',
+        },
+      },
+      async () => [bareLookup, deferredLookup],
+    );
+    const agent = new Agent({
+      name: 'Category-aware restore agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const callId = 'call_tool_search_categories';
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_categories',
+          status: 'completed',
+          arguments: { paths: [] },
+          providerData: {
+            call_id: callId,
+            execution: 'client',
+          },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_categories',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'lookup',
+              description: 'Immediate lookup.',
+              strict: true,
+              deferLoading: false,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+            {
+              type: 'function',
+              name: 'lookup',
+              description: 'Deferred lookup.',
+              strict: true,
+              deferLoading: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+          ],
+          providerData: {
+            call_id: callId,
+            execution: 'client',
+          },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(restored.getToolSearchRuntimeTools(agent)).toEqual([
+      bareLookup,
+      deferredLookup,
+    ]);
+  });
+
+  it('rejects a rehydrated bare runtime function that conflicts with an enabled handoff', async () => {
+    const runtimeLookup = tool({
+      name: 'lookup',
+      description: 'Look up a record.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'runtime',
+    });
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: {
+          type: 'tool_search',
+          execution: 'client',
+        },
+      },
+      async () => runtimeLookup,
+    );
+    const target = new Agent({ name: 'LookupTarget' });
+    const agent = new Agent({
+      name: 'RuntimeHandoffCollision',
+      tools: [clientToolSearch],
+      handoffs: [handoff(target, { toolNameOverride: 'lookup' })],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const callId = 'call_runtime_handoff_collision';
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_runtime_handoff_collision',
+          status: 'completed',
+          arguments: { paths: [] },
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_runtime_handoff_collision',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'lookup',
+              description: 'Look up a record.',
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+          ],
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+
+    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
+      'Client tool_search execute() returned a bare function tool that conflicts with an available handoff. Assign a unique tool name or use a namespace.',
+    );
+  });
+
+  it.each([false, true])(
+    'rejects duplicate routed identities returned during tool-search rehydration (same object: %s)',
+    async (repeatSameObject) => {
+      const first = tool({
+        name: 'lookup',
+        description: 'First deferred lookup.',
+        parameters: z.object({}).strict(),
+        deferLoading: true,
+        execute: async () => 'first',
+      });
+      const second = tool({
+        name: 'lookup',
+        description: 'Second deferred lookup.',
+        parameters: z.object({}).strict(),
+        deferLoading: true,
+        execute: async () => 'second',
+      });
+      const clientToolSearch = attachClientToolSearchExecutor(
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: {
+            type: 'tool_search',
+            execution: 'client',
+          },
+        },
+        async () => (repeatSameObject ? [first, first] : [first, second]),
+      );
+      const agent = new Agent({
+        name: 'Duplicate restore agent',
+        tools: [clientToolSearch],
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      const callId = 'call_duplicate_restore';
+      state._generatedItems.push(
+        new RunToolSearchCallItem(
+          {
+            type: 'tool_search_call',
+            id: 'ts_call_duplicate_restore',
+            status: 'completed',
+            arguments: { paths: [] },
+            providerData: { call_id: callId, execution: 'client' },
+          } as protocol.ToolSearchCallItem,
+          agent,
+        ),
+        new RunToolSearchOutputItem(
+          {
+            type: 'tool_search_output',
+            id: 'ts_output_duplicate_restore',
+            status: 'completed',
+            tools: [
+              {
+                type: 'function',
+                name: 'lookup',
+                description: 'Deferred lookup.',
+                strict: true,
+                deferLoading: true,
+                parameters: {
+                  type: 'object',
+                  properties: {},
+                  required: [],
+                  additionalProperties: false,
+                },
+              },
+            ],
+            providerData: { call_id: callId, execution: 'client' },
+          } as protocol.ToolSearchOutputItem,
+          agent,
+        ),
+      );
+
+      await expect(
+        RunState.fromString(agent, state.toString()),
+      ).rejects.toThrow(
+        'Client tool_search execute() returned multiple tools with the same routed identity.',
+      );
+    },
+  );
+
+  it('rejects duplicate routed identities in serialized tool-search output before rehydration', async () => {
+    const validRuntimeLookup = tool({
+      name: 'valid_lookup',
+      description: 'Valid lookup.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'valid',
+    });
+    const duplicateRuntimeLookup = tool({
+      name: 'lookup',
+      description: 'Deferred lookup.',
+      parameters: z.object({}).strict(),
+      deferLoading: true,
+      execute: async () => 'lookup',
+    });
+    const execute = vi.fn(async () => validRuntimeLookup);
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: {
+          type: 'tool_search',
+          execution: 'client',
+        },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Duplicate serialized restore agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const validCallId = 'call_valid_serialized_restore';
+    const duplicateCallId = 'call_duplicate_serialized_restore';
+    const validSerializedTool = {
+      type: 'function',
+      name: 'valid_lookup',
+      description: 'Valid lookup.',
+      strict: true,
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      },
+    } as const;
+    const serializedTool = {
+      type: 'function',
+      name: duplicateRuntimeLookup.name,
+      description: duplicateRuntimeLookup.description,
+      strict: true,
+      deferLoading: true,
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      },
+    } as const;
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_valid_serialized_restore',
+          status: 'completed',
+          arguments: { query: 'valid' },
+          providerData: { call_id: validCallId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_valid_serialized_restore',
+          status: 'completed',
+          tools: [validSerializedTool],
+          providerData: { call_id: validCallId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_duplicate_serialized_restore',
+          status: 'completed',
+          arguments: { query: 'duplicate' },
+          providerData: { call_id: duplicateCallId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_duplicate_serialized_restore',
+          status: 'completed',
+          tools: [serializedTool, serializedTool],
+          providerData: { call_id: duplicateCallId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+
+    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
+      'Serialized client tool_search output contains multiple tools with the same routed identity. Assign unique tool names or namespaces before resuming RunState.',
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   it('accepts schema version 1.7 payloads when non-item context data mentions tool_search types', async () => {
     const context = new RunContext({
       custom: {
@@ -1940,6 +6199,12 @@ describe('RunState', () => {
 
     const serialized = JSON.parse(state.toString());
     serialized.$schemaVersion = '1.6';
+    const approvalKey = getFunctionToolStateKeyForCall(rawItem)!;
+    const ownerApprovals = serialized.context.functionApprovals.find(
+      (entry: any) => entry.agentIdentity === agent.name,
+    ).approvals;
+    serialized.context.approvals.toolLegacy = ownerApprovals[approvalKey];
+    delete serialized.context.functionApprovals;
     delete serialized.context.approvals.toolLegacy.messages;
 
     const restored = await RunState.fromString(
@@ -2029,8 +6294,9 @@ describe('RunState', () => {
       state._context.isToolApproved({ toolName: 'toolZ', callId: 'cid789' }),
     ).toBe(false);
     const approvals = state._context.toJSON().approvals;
-    expect(approvals['toolZ'].approved).toBe(false);
-    expect(approvals['toolZ'].rejected).toBe(true);
+    const approvalKey = getFunctionToolStateKeyForCall(rawItem)!;
+    expect(approvals[approvalKey].approved).toBe(false);
+    expect(approvals[approvalKey].rejected).toBe(true);
   });
 
   it('alwaysReject with message stores call-specific and sticky rejection messages', () => {
@@ -2061,11 +6327,14 @@ describe('RunState', () => {
       'Blocked by policy',
     );
     const approvals = state._context.toJSON().approvals;
-    expect(approvals['toolAR'].rejected).toBe(true);
-    expect(approvals['toolAR'].messages).toEqual({
+    const approvalKey = getFunctionToolStateKeyForCall(rawItem)!;
+    expect(approvals[approvalKey].rejected).toBe(true);
+    expect(approvals[approvalKey].messages).toEqual({
       'ar-1': 'Blocked by policy',
     });
-    expect(approvals['toolAR'].stickyRejectMessage).toBe('Blocked by policy');
+    expect(approvals[approvalKey].stickyRejectMessage).toBe(
+      'Blocked by policy',
+    );
   });
 
   it('alwaysReject with empty message preserves the empty string', () => {
@@ -2136,10 +6405,11 @@ describe('RunState', () => {
     const approvalItem = new ToolApprovalItem(rawItem, agent);
 
     state.approve(approvalItem);
+    const approvalKey = getFunctionToolStateKeyForCall(rawItem)!;
 
     expect(
       state._context.isToolApproved({
-        toolName: 'crm.lookup_account',
+        toolName: approvalKey,
         callId: 'cid_namespace',
       }),
     ).toBe(true);
@@ -2170,16 +6440,17 @@ describe('RunState', () => {
     const restored = await RunState.fromString(agent, state.toString());
     const [approvalItem] = restored.getInterruptions();
     restored.approve(approvalItem);
+    const approvalKey = getFunctionToolStateKeyForCall(rawItem)!;
 
     expect(
       restored._context.isToolApproved({
-        toolName: 'get_shipping_eta',
+        toolName: approvalKey,
         callId: 'cid_shipping_eta',
       }),
     ).toBe(true);
     expect(
       restored._context.isToolApproved({
-        toolName: 'get_shipping_eta.get_shipping_eta',
+        toolName: 'get_shipping_eta',
         callId: 'cid_shipping_eta',
       }),
     ).toBeUndefined();
@@ -2220,16 +6491,17 @@ describe('RunState', () => {
     const restored = await RunState.fromString(agent, state.toString());
     const [approvalItem] = restored.getInterruptions();
     restored.approve(approvalItem);
+    const approvalKey = getFunctionToolStateKeyForCall(rawItem)!;
 
     expect(
       restored._context.isToolApproved({
-        toolName: 'get_shipping_eta',
+        toolName: approvalKey,
         callId: 'cid_shipping_eta',
       }),
     ).toBe(true);
     expect(
       restored._context.isToolApproved({
-        toolName: 'get_shipping_eta.get_shipping_eta',
+        toolName: 'get_shipping_eta',
         callId: 'cid_shipping_eta',
       }),
     ).toBeUndefined();
@@ -2627,6 +6899,220 @@ describe('deserialize helpers', () => {
         ],
       },
     ]);
+  });
+
+  it('restores the enabled handoff winner instead of a later disabled duplicate', async () => {
+    const enabledTarget = new Agent({
+      name: 'SharedTarget',
+      instructions: 'enabled target',
+    });
+    const disabledTarget = new Agent({
+      name: 'SharedTarget',
+      instructions: 'disabled target',
+    });
+    const enabledHandoff = handoff(enabledTarget, {
+      toolNameOverride: 'transfer',
+    });
+    const disabledHandoff = handoff(disabledTarget, {
+      toolNameOverride: 'transfer',
+      isEnabled: false,
+    });
+    const agent = new Agent({
+      name: 'HandoffWinnerRestore',
+      handoffs: [enabledHandoff, disabledHandoff],
+    });
+    const state = new RunState(new RunContext(), '', agent, 1);
+    const toolCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_handoff_winner',
+      callId: 'call_handoff_winner',
+      name: 'transfer',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [],
+      handoffs: [{ toolCall, handoff: enabledHandoff }],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['transfer'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+
+    const serialized = state.toJSON() as any;
+    expect(
+      serialized.lastProcessedResponse.handoffs[0].targetAgent.identity,
+    ).toEqual(expect.any(String));
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+
+    expect(restored._lastProcessedResponse?.handoffs[0]?.handoff).toBe(
+      enabledHandoff,
+    );
+
+    delete serialized.lastProcessedResponse.handoffs[0].targetAgent;
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow(
+      'Run state handoff is missing its required target agent identity.',
+    );
+
+    serialized.$schemaVersion = '1.15';
+    const restoredLegacy = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+    expect(restoredLegacy._lastProcessedResponse?.handoffs[0]?.handoff).toBe(
+      enabledHandoff,
+    );
+  });
+
+  it('rejects a schema 1.16 handoff without exact identity instead of rebinding a same-name target', async () => {
+    const executeToolSearch = vi.fn(async () => []);
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      executeToolSearch,
+    );
+    const firstTarget = new Agent({ name: 'SharedTarget' });
+    const secondTarget = new Agent({ name: 'SharedTarget' });
+    const firstHandoff = handoff(firstTarget, {
+      toolNameOverride: 'transfer',
+    });
+    const secondHandoff = handoff(secondTarget, {
+      toolNameOverride: 'transfer',
+    });
+    const agent = new Agent({
+      name: 'AmbiguousHandoffRestore',
+      tools: [clientToolSearch],
+      handoffs: [firstHandoff, secondHandoff],
+    });
+    const state = new RunState(new RunContext(), '', agent, 1);
+    const toolSearchCallId = 'call_ambiguous_handoff_search';
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_ambiguous_handoff_search',
+          status: 'completed',
+          arguments: { paths: [] },
+          providerData: {
+            call_id: toolSearchCallId,
+            execution: 'client',
+          },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_ambiguous_handoff_search',
+          status: 'completed',
+          tools: [],
+          providerData: {
+            call_id: toolSearchCallId,
+            execution: 'client',
+          },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [],
+      handoffs: [
+        {
+          toolCall: {
+            type: 'function_call',
+            id: 'fc_ambiguous_handoff',
+            callId: 'call_ambiguous_handoff',
+            name: 'transfer',
+            status: 'completed',
+            arguments: '{}',
+          },
+          handoff: firstHandoff,
+        },
+      ],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['transfer'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+
+    const serialized = state.toJSON() as any;
+    allowConsole(['warn']);
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow('Handoff transfer not found');
+    expect(executeToolSearch).not.toHaveBeenCalled();
+
+    const missingTarget = JSON.parse(JSON.stringify(serialized));
+    delete missingTarget.lastProcessedResponse.handoffs[0].targetAgent;
+
+    await expect(
+      RunState.fromString(agent, JSON.stringify(missingTarget)),
+    ).rejects.toThrow(
+      'Run state handoff is missing its required target agent identity.',
+    );
+    expect(executeToolSearch).not.toHaveBeenCalled();
+
+    serialized.lastProcessedResponse.handoffs[0].targetAgent.identity =
+      'missing-target-identity';
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow('Agent identity missing-target-identity not found');
+    expect(executeToolSearch).not.toHaveBeenCalled();
+  });
+
+  it('rejects a handoff disabled by a replacement context during restore', async () => {
+    const target = new Agent<{ enabled: boolean }>({ name: 'DynamicTarget' });
+    const dynamicHandoff = handoff(target, {
+      toolNameOverride: 'transfer',
+      isEnabled: ({ runContext }) => runContext.context.enabled,
+    });
+    const agent = new Agent<{ enabled: boolean }>({
+      name: 'DynamicHandoffRestore',
+      handoffs: [dynamicHandoff],
+    });
+    const state = new RunState(new RunContext({ enabled: true }), '', agent, 1);
+    const toolCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_dynamic_handoff',
+      callId: 'call_dynamic_handoff',
+      name: 'transfer',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [],
+      handoffs: [{ toolCall, handoff: dynamicHandoff }],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['transfer'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+
+    await expect(
+      RunState.fromStringWithContext(
+        agent,
+        state.toString(),
+        new RunContext({ enabled: false }),
+        { contextStrategy: 'replace' },
+      ),
+    ).rejects.toThrow('Handoff transfer not found');
   });
 
   it('deserializeProcessedResponse restores namespaced function tools', async () => {
@@ -3183,6 +7669,141 @@ describe('deserialize helpers', () => {
       type: 'program',
       callerId: 'prog_approval_1',
     });
+  });
+
+  it('uses an explicit prepared tool snapshot without adding stored runtime tools', async () => {
+    const runtimeLookup = tool({
+      name: 'lookup_runtime',
+      description: 'Look up a runtime record.',
+      parameters: z.object({}),
+      execute: async () => 'runtime',
+    });
+    const agent = new Agent({ name: 'ExplicitPreparedTools' });
+    const state = new RunState(new RunContext(), '', agent, 1);
+    const toolCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_runtime_explicit',
+      callId: 'call_runtime_explicit',
+      name: 'lookup_runtime',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state.recordToolSearchRuntimeTools(
+      agent,
+      {
+        type: 'tool_search_output',
+        id: 'ts_output_runtime_explicit',
+        status: 'completed',
+        tools: [],
+      } as protocol.ToolSearchOutputItem,
+      [runtimeLookup],
+    );
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall, tool: runtimeLookup as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['lookup_runtime'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+
+    await expect(
+      rehydrateProcessedResponseTools(agent, state, []),
+    ).rejects.toThrow('Tool lookup_runtime not found');
+  });
+
+  it('rejects resumed runtime function tools when isEnabled is false in replacement context', async () => {
+    const lookupParams = z.object({});
+    const runtimeLookup = tool<typeof lookupParams, { enabled: boolean }>({
+      name: 'lookup_runtime',
+      description: 'Look up a runtime record.',
+      parameters: lookupParams,
+      isEnabled: async ({ runContext }) => runContext.context.enabled,
+      execute: async () => 'runtime',
+    });
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: {
+          type: 'tool_search',
+          execution: 'client',
+        },
+      },
+      async () => runtimeLookup,
+    );
+    const agent = new Agent<{ enabled: boolean }>({
+      name: 'RuntimeEnabledRestore',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext({ enabled: true }), '', agent, 1);
+    const searchCallId = 'call_runtime_enabled_restore';
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_runtime_enabled_restore',
+          status: 'completed',
+          arguments: { paths: [] },
+          providerData: { call_id: searchCallId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent as any,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_runtime_enabled_restore',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'lookup_runtime',
+              description: 'Look up a runtime record.',
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+          ],
+          providerData: { call_id: searchCallId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent as any,
+      ),
+    );
+    const toolCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_runtime_enabled_restore',
+      callId: 'call_lookup_runtime',
+      name: 'lookup_runtime',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall, tool: runtimeLookup as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['lookup_runtime'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+
+    await expect(
+      RunState.fromStringWithContext(
+        agent,
+        state.toString(),
+        new RunContext({ enabled: false }),
+        { contextStrategy: 'replace' },
+      ),
+    ).rejects.toThrow('Tool lookup_runtime not found');
   });
 
   it('rejects resumed function tools when isEnabled is false in replacement context', async () => {

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -1649,7 +1649,7 @@ describe('RunState', () => {
     serialized.$schemaVersion = '1.15';
     serialized.context.approvals.lookup = ownerApprovals[categoryKey];
     delete serialized.context.functionApprovals;
-    delete serialized.context.legacyFunctionApprovalFallback;
+    delete serialized.context.legacyFunctionApprovals;
 
     const restored = await RunState.fromString(
       agent,
@@ -1951,7 +1951,7 @@ describe('RunState', () => {
             toolName: canonicalKey,
             callId: `${callId}-future`,
           }),
-        ).toBeUndefined();
+        ).toBe(isPermanent ? decision.expected : undefined);
         expect(
           restored._context.isToolApproved({
             toolName: legacyKey,
@@ -2050,6 +2050,29 @@ describe('RunState', () => {
           callId,
         }),
       ).toBeUndefined();
+      const publicApproval = restored._context.toJSON().approvals['crm.lookup'];
+      expect(publicApproval).toBeDefined();
+      expect(publicApproval.approved === true).toBe(
+        approvalRecord.approved === true,
+      );
+      expect(publicApproval.rejected === true).toBe(
+        approvalRecord.rejected === true,
+      );
+      expect(
+        restored._context.toJSON().approvals[canonicalKey],
+      ).toBeUndefined();
+
+      const durable = restored.toJSON() as any;
+      expect(durable.context.approvals['crm.lookup']).toBeUndefined();
+      const durableApproval = durable.context.functionApprovals.find(
+        (entry: any) => entry.agentIdentity === agent.name,
+      ).approvals[canonicalKey];
+      expect(durableApproval.approved === true).toBe(
+        approvalRecord.approved === true,
+      );
+      expect(durableApproval.rejected === true).toBe(
+        approvalRecord.rejected === true,
+      );
     },
   );
 
@@ -2066,41 +2089,11 @@ describe('RunState', () => {
         }),
       ],
     })[0]!;
-    const otherTool = tool({
-      name: 'other_tool',
-      description: 'Other tool.',
-      parameters: z.object({}),
-      execute: async () => 'other',
-    });
-    const otherCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      name: 'other_tool',
-      callId: 'other_call',
-      status: 'completed',
-      arguments: '{}',
-    };
     const agent = new Agent({
       name: 'Unique inactive legacy approval owner',
-      tools: [namespacedLookup, otherTool],
+      tools: [namespacedLookup],
     });
     const state = new RunState(new RunContext(), 'input', agent, 2);
-    state._lastProcessedResponse = {
-      newItems: [],
-      functions: [
-        {
-          toolCall: otherCall,
-          tool: otherTool as any,
-          availableFunctionTools: [namespacedLookup, otherTool] as any,
-        },
-      ],
-      handoffs: [],
-      computerActions: [],
-      shellActions: [],
-      applyPatchActions: [],
-      mcpApprovalRequests: [],
-      toolsUsed: ['other_tool'],
-      hasToolsOrApprovalsToRun: () => true,
-    };
 
     const serialized = state.toJSON() as any;
     serialized.$schemaVersion = '1.15';
@@ -2126,6 +2119,69 @@ describe('RunState', () => {
         callId: 'future_call',
       }),
     ).toBeUndefined();
+    const durable = restored.toJSON() as any;
+    expect(durable.context.approvals['crm.lookup']).toBeUndefined();
+    expect(durable.context.legacyFunctionApprovals).toBeUndefined();
+    expect(
+      durable.context.functionApprovals[0].approvals[canonicalKey],
+    ).toMatchObject({ approved: true, rejected: [] });
+  });
+
+  it('migrates a unique schema 1.15 approval owned by an inactive child agent', async () => {
+    const childLookup = toolNamespace({
+      name: 'crm',
+      description: 'Child CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup',
+          description: 'Child namespaced lookup.',
+          parameters: z.object({}),
+          execute: async () => 'child',
+        }),
+      ],
+    })[0]!;
+    const childAgent = new Agent({
+      name: 'Inactive legacy approval child',
+      tools: [childLookup],
+    });
+    const rootAgent = new Agent({
+      name: 'Inactive legacy approval root',
+      tools: [
+        childAgent.asTool({
+          toolName: 'run_child',
+          toolDescription: 'Runs the child agent.',
+        }),
+      ],
+    });
+    const state = new RunState(new RunContext(), 'input', rootAgent, 2);
+    const serialized = state.toJSON() as any;
+    serialized.$schemaVersion = '1.15';
+    serialized.context.approvals = {
+      'crm.lookup': { approved: true, rejected: [] },
+    };
+
+    const restored = await RunState.fromString(
+      rootAgent,
+      JSON.stringify(serialized),
+    );
+    const canonicalKey = getFunctionToolStateKey(childLookup)!;
+
+    expect(
+      restored._context.isToolApproved({
+        toolName: canonicalKey,
+        callId: 'future_child_call',
+        functionTool: false,
+        agent: childAgent,
+      }),
+    ).toBe(true);
+    const durable = restored.toJSON() as any;
+    expect(durable.context.approvals['crm.lookup']).toBeUndefined();
+    expect(durable.context.legacyFunctionApprovals).toBeUndefined();
+    expect(
+      durable.context.functionApprovals.find(
+        (entry: any) => entry.agentIdentity === childAgent.name,
+      ).approvals[canonicalKey],
+    ).toMatchObject({ approved: true, rejected: [] });
   });
 
   it('keeps an exact non-function override separate from an inactive schema 1.15 function owner', async () => {
@@ -2217,6 +2273,131 @@ describe('RunState', () => {
         functionTool: false,
       }),
     ).toBe(false);
+  });
+
+  it('keeps ambiguous legacy function fallback separate from an exact non-function override', async () => {
+    const dottedLookup = tool({
+      name: 'crm_lookup',
+      description: 'Dotted lookup.',
+      parameters: z.object({}),
+      execute: async () => 'dotted',
+    });
+    dottedLookup.name = 'crm.lookup';
+    const namespacedLookup = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup',
+          description: 'Namespaced lookup.',
+          parameters: z.object({}),
+          execute: async () => 'namespaced',
+        }),
+      ],
+    })[0]!;
+    const callId = 'ambiguous_merge_call';
+    const toolCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'lookup',
+      namespace: 'crm',
+      callId,
+      status: 'completed',
+      arguments: '{}',
+    };
+    const agent = new Agent({
+      name: 'Ambiguous legacy fallback merge',
+      tools: [dottedLookup, namespacedLookup],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall, tool: namespacedLookup as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['crm.lookup'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+    const serialized = state.toJSON() as any;
+    serialized.$schemaVersion = '1.15';
+    serialized.context.approvals = {
+      'crm.lookup': {
+        approved: false,
+        rejected: true,
+        stickyRejectMessage: 'Legacy rejection',
+      },
+    };
+
+    const overrideContext = new RunContext();
+    overrideContext.approveTool(
+      new ToolApprovalItem(
+        {
+          type: 'shell_call',
+          callId: 'shell_override_call',
+          status: 'completed',
+          action: { commands: ['echo approved'] },
+        },
+        agent,
+        'crm.lookup',
+      ),
+      { alwaysApprove: true },
+    );
+
+    const restored = await RunState.fromStringWithContext(
+      agent,
+      JSON.stringify(serialized),
+      overrideContext,
+      { contextStrategy: 'merge' },
+    );
+    const namespacedKey = getFunctionToolStateKey(namespacedLookup)!;
+    const dottedKey = getFunctionToolStateKey(dottedLookup)!;
+
+    for (const [toolName, checkedCallId] of [
+      [namespacedKey, callId],
+      [namespacedKey, 'future_namespaced_call'],
+      [dottedKey, 'future_dotted_call'],
+    ] as const) {
+      expect(
+        restored._context.isToolApproved({
+          toolName,
+          callId: checkedCallId,
+          functionTool: false,
+          agent,
+        }),
+      ).toBe(false);
+    }
+    expect(
+      restored._context.isToolApproved({
+        toolName: 'crm.lookup',
+        callId: 'future_shell_call',
+        functionTool: false,
+      }),
+    ).toBe(true);
+
+    const durable = restored.toJSON() as any;
+    expect(durable.context.approvals['crm.lookup'].approved).toBe(true);
+    expect(durable.context.legacyFunctionApprovals['crm.lookup'].rejected).toBe(
+      true,
+    );
+
+    const roundTripped = await RunState.fromString(agent, restored.toString());
+    expect(
+      roundTripped._context.isToolApproved({
+        toolName: dottedKey,
+        callId: 'round_trip_function_call',
+        functionTool: false,
+        agent,
+      }),
+    ).toBe(false);
+    expect(
+      roundTripped._context.isToolApproved({
+        toolName: 'crm.lookup',
+        callId: 'round_trip_shell_call',
+        functionTool: false,
+      }),
+    ).toBe(true);
   });
 
   it('keeps schema 1.15 approval ownership when merging a canonical override context', async () => {
@@ -2356,6 +2537,7 @@ describe('RunState', () => {
       );
       const namespacedKey = getFunctionToolStateKey(namespacedLookup)!;
       const bareKey = getFunctionToolStateKey(dottedLookup)!;
+      const isPermanent = decision.name.startsWith('permanent');
 
       expect(
         restored._context.isToolApproved({
@@ -2372,7 +2554,7 @@ describe('RunState', () => {
           toolName: namespacedKey,
           callId: `${callId}-future`,
         }),
-      ).toBeUndefined();
+      ).toBe(isPermanent ? decision.expected : undefined);
       expect(
         restored._context.isToolApproved({
           toolName: 'crm.lookup',
@@ -2389,14 +2571,16 @@ describe('RunState', () => {
         restored._context.isToolApproved({
           toolName: bareKey,
           callId: 'existing-bare-call',
+          agent,
         }),
       ).toBe(true);
       expect(
         restored._context.isToolApproved({
           toolName: bareKey,
           callId: 'future-bare-call',
+          agent,
         }),
-      ).toBeUndefined();
+      ).toBe(isPermanent ? decision.expected : undefined);
       expect(
         restored._context.isToolApproved({
           toolName: 'other',
@@ -4465,6 +4649,24 @@ describe('RunState', () => {
     ).rejects.toBeInstanceOf(UserError);
   });
 
+  it('rejects noncanonical current function approval keys with UserError', async () => {
+    const agent = new Agent({ name: 'NoncanonicalApprovalKeyAgent' });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    const serialized = state.toJSON() as any;
+    serialized.context.functionApprovals = [
+      {
+        agentIdentity: agent.name,
+        approvals: {
+          lookup: { approved: true, rejected: [] },
+        },
+      },
+    ];
+
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toBeInstanceOf(UserError);
+  });
+
   it('preserves ZodError for unrelated malformed run state fields', async () => {
     const agent = new Agent({ name: 'MalformedUnrelatedStateAgent' });
     const state = new RunState(new RunContext(), 'input', agent, 1);
@@ -5388,6 +5590,163 @@ describe('RunState', () => {
     ).toEqual(['after_disabled']);
   });
 
+  it.each([
+    ['an enabled and a disabled result', true],
+    ['two disabled results', false],
+  ] as const)(
+    'rehydrates client tool-search output after filtering %s',
+    async (_description, includeEnabledResult) => {
+      const enabledLookup = tool({
+        name: 'lookup',
+        description: 'Enabled lookup.',
+        parameters: z.object({}).strict(),
+        execute: async () => 'enabled',
+      });
+      const disabledLookup = tool({
+        name: 'lookup',
+        description: 'Disabled lookup.',
+        parameters: z.object({}).strict(),
+        isEnabled: false,
+        execute: async () => 'disabled',
+      });
+      const otherDisabledLookup = tool({
+        name: 'lookup',
+        description: 'Other disabled lookup.',
+        parameters: z.object({}).strict(),
+        isEnabled: false,
+        execute: async () => 'other disabled',
+      });
+      const execute = vi.fn(async () => [
+        includeEnabledResult ? enabledLookup : otherDisabledLookup,
+        disabledLookup,
+      ]);
+      const clientToolSearch = attachClientToolSearchExecutor(
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: { type: 'tool_search', execution: 'client' },
+        },
+        execute,
+      );
+      const agent = new Agent({
+        name: `Filtered duplicate restore ${includeEnabledResult}`,
+        tools: [clientToolSearch],
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      const processed = await processModelResponseAsync(
+        {
+          output: [
+            {
+              type: 'tool_search_call',
+              id: 'ts_call_filtered_duplicate_restore',
+              status: 'completed',
+              arguments: {},
+              providerData: {
+                call_id: 'call_filtered_duplicate_restore',
+                execution: 'client',
+              },
+            } as protocol.ToolSearchCallItem,
+          ],
+          usage: new Usage(),
+        },
+        agent,
+        [clientToolSearch],
+        [],
+        state,
+        [],
+      );
+      state._generatedItems.push(...processed.newItems);
+      state._lastProcessedResponse = processed;
+
+      const restored = await RunState.fromString(agent, state.toString());
+
+      expect(execute).toHaveBeenCalledTimes(2);
+      expect(restored.getToolSearchRuntimeTools(agent)).toEqual(
+        includeEnabledResult ? [enabledLookup] : [],
+      );
+    },
+  );
+
+  it.each([
+    ['one serialized tool', true],
+    ['an empty serialized result', false],
+  ] as const)(
+    'rejects extra enabled callback tools when rehydrating %s',
+    async (_description, includeSerializedLookup) => {
+      const lookup = tool({
+        name: 'lookup',
+        description: 'Serialized lookup.',
+        parameters: z.object({}).strict(),
+        execute: async () => 'lookup',
+      });
+      const extraLookup = tool({
+        name: 'extra_lookup',
+        description: 'Unexpected extra lookup.',
+        parameters: z.object({}).strict(),
+        execute: async () => 'extra',
+      });
+      const execute = vi.fn(async () => [lookup, extraLookup]);
+      const clientToolSearch = attachClientToolSearchExecutor(
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: { type: 'tool_search', execution: 'client' },
+        },
+        execute,
+      );
+      const agent = new Agent({
+        name: `Extra enabled restore ${includeSerializedLookup}`,
+        tools: [clientToolSearch],
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      const callId = 'call_extra_enabled_restore';
+      state._generatedItems.push(
+        new RunToolSearchCallItem(
+          {
+            type: 'tool_search_call',
+            id: 'ts_call_extra_enabled_restore',
+            status: 'completed',
+            arguments: {},
+            providerData: { call_id: callId, execution: 'client' },
+          } as protocol.ToolSearchCallItem,
+          agent,
+        ),
+        new RunToolSearchOutputItem(
+          {
+            type: 'tool_search_output',
+            id: 'ts_output_extra_enabled_restore',
+            status: 'completed',
+            tools: includeSerializedLookup
+              ? [
+                  {
+                    type: 'function',
+                    name: 'lookup',
+                    description: 'Serialized lookup.',
+                    strict: true,
+                    parameters: {
+                      type: 'object',
+                      properties: {},
+                      required: [],
+                      additionalProperties: false,
+                    },
+                  },
+                ]
+              : [],
+            providerData: { call_id: callId, execution: 'client' },
+          } as protocol.ToolSearchOutputItem,
+          agent,
+        ),
+      );
+
+      await expect(
+        RunState.fromString(agent, state.toString()),
+      ).rejects.toThrow(
+        'registered execute callback returned different runtime tools than the serialized state',
+      );
+      expect(execute).toHaveBeenCalledOnce();
+    },
+  );
+
   it('rejects duplicate configured identities returned during tool-search rehydration', async () => {
     const configuredTool = tool({
       name: 'configured',
@@ -6294,9 +6653,8 @@ describe('RunState', () => {
       state._context.isToolApproved({ toolName: 'toolZ', callId: 'cid789' }),
     ).toBe(false);
     const approvals = state._context.toJSON().approvals;
-    const approvalKey = getFunctionToolStateKeyForCall(rawItem)!;
-    expect(approvals[approvalKey].approved).toBe(false);
-    expect(approvals[approvalKey].rejected).toBe(true);
+    expect(approvals.toolZ.approved).toBe(false);
+    expect(approvals.toolZ.rejected).toBe(true);
   });
 
   it('alwaysReject with message stores call-specific and sticky rejection messages', () => {
@@ -6327,14 +6685,11 @@ describe('RunState', () => {
       'Blocked by policy',
     );
     const approvals = state._context.toJSON().approvals;
-    const approvalKey = getFunctionToolStateKeyForCall(rawItem)!;
-    expect(approvals[approvalKey].rejected).toBe(true);
-    expect(approvals[approvalKey].messages).toEqual({
+    expect(approvals.toolAR.rejected).toBe(true);
+    expect(approvals.toolAR.messages).toEqual({
       'ar-1': 'Blocked by policy',
     });
-    expect(approvals[approvalKey].stickyRejectMessage).toBe(
-      'Blocked by policy',
-    );
+    expect(approvals.toolAR.stickyRejectMessage).toBe('Blocked by policy');
   });
 
   it('alwaysReject with empty message preserves the empty string', () => {
@@ -7803,7 +8158,9 @@ describe('deserialize helpers', () => {
         new RunContext({ enabled: false }),
         { contextStrategy: 'replace' },
       ),
-    ).rejects.toThrow('Tool lookup_runtime not found');
+    ).rejects.toThrow(
+      'registered execute callback returned different runtime tools than the serialized state',
+    );
   });
 
   it('rejects resumed function tools when isEnabled is false in replacement context', async () => {

--- a/packages/agents-core/test/runner/modelOutputs.test.ts
+++ b/packages/agents-core/test/runner/modelOutputs.test.ts
@@ -4,6 +4,7 @@ import { setDefaultModelProvider, setTracingDisabled } from '../../src';
 import { Agent } from '../../src/agent';
 import { ModelBehaviorError, UserError } from '../../src/errors';
 import { handoff } from '../../src/handoff';
+import logger from '../../src/logger';
 import {
   RunHandoffCallItem as HandoffCallItem,
   RunMessageOutputItem as MessageOutputItem,
@@ -28,6 +29,7 @@ import {
   shellTool,
   tool,
   toolNamespace,
+  type ClientToolSearchExecutorArgs,
   type HostedTool,
 } from '../../src/tool';
 import {
@@ -79,6 +81,83 @@ function createLegacyNamespacedTool<T extends Record<string, any>>(
 }
 
 describe('processModelResponse', () => {
+  it.each(['sync', 'async'] as const)(
+    'routes same-name bare and deferred tools by wire category in %s processing',
+    async (mode) => {
+      const bare = tool({
+        name: 'lookup',
+        description: 'Immediate lookup.',
+        parameters: z.object({}),
+        execute: async () => 'bare',
+      });
+      const deferred = tool({
+        name: 'lookup',
+        description: 'Deferred lookup.',
+        parameters: z.object({}),
+        deferLoading: true,
+        execute: async () => 'deferred',
+      });
+      const response: ModelResponse = {
+        output: [
+          {
+            type: 'function_call',
+            callId: 'call_bare',
+            name: 'lookup',
+            arguments: '{}',
+          },
+          {
+            type: 'function_call',
+            callId: 'call_deferred',
+            name: 'lookup',
+            namespace: 'lookup',
+            arguments: '{}',
+          },
+        ],
+        usage: new Usage(),
+      };
+      const priorItems = [
+        new ToolSearchOutputItem(
+          {
+            type: 'tool_search_output',
+            id: 'ts_output_lookup',
+            status: 'completed',
+            tools: [
+              {
+                type: 'tool_reference',
+                functionName: 'lookup',
+                namespace: 'lookup',
+              },
+            ],
+          } as any,
+          TEST_AGENT,
+        ),
+      ];
+
+      const result =
+        mode === 'sync'
+          ? processModelResponse(
+              response,
+              TEST_AGENT,
+              [bare, deferred],
+              [],
+              priorItems,
+            )
+          : await processModelResponseAsync(
+              response,
+              TEST_AGENT,
+              [bare, deferred],
+              [],
+              new RunState(new RunContext(), 'hello', TEST_AGENT, 1),
+              priorItems,
+            );
+
+      expect(result.functions.map((functionRun) => functionRun.tool)).toEqual([
+        bare,
+        deferred,
+      ]);
+    },
+  );
+
   it('classifies program calls and outputs as ordered run items', () => {
     const result = processModelResponse(
       {
@@ -1348,6 +1427,644 @@ describe('processModelResponse', () => {
     expect(state.getToolSearchRuntimeTools(agent)).toEqual([lookupAccount]);
   });
 
+  it.each(['between', 'after'] as const)(
+    'matches one explicit repeated-id tool_search output to one occurrence when it appears %s calls',
+    async (outputPosition) => {
+      const execute = vi.fn(async (_args: ClientToolSearchExecutorArgs) => []);
+      const clientToolSearch = attachClientToolSearchExecutor(
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: { type: 'tool_search', execution: 'client' },
+        },
+        execute,
+      );
+      const createCall = (
+        id: string,
+        phase: string,
+      ): protocol.ToolSearchCallItem =>
+        ({
+          type: 'tool_search_call',
+          id,
+          status: 'completed',
+          arguments: { phase },
+          providerData: {
+            call_id: 'repeated_provider_call_id',
+            execution: 'client',
+          },
+        }) as protocol.ToolSearchCallItem;
+      const firstCall = createCall('ts_repeated_first', 'first');
+      const secondCall = createCall('ts_repeated_second', 'second');
+      const explicitOutput = {
+        type: 'tool_search_output',
+        id: 'ts_repeated_output',
+        status: 'completed',
+        tools: [],
+        providerData: {
+          call_id: 'repeated_provider_call_id',
+          execution: 'client',
+        },
+      } as protocol.ToolSearchOutputItem;
+      const agent = new Agent({ name: `Repeated output ${outputPosition}` });
+      const state = new RunState(new RunContext(), 'hello', agent, 3);
+
+      await processModelResponseAsync(
+        {
+          output:
+            outputPosition === 'between'
+              ? [firstCall, explicitOutput, secondCall]
+              : [firstCall, secondCall, explicitOutput],
+          usage: new Usage(),
+        },
+        agent,
+        [clientToolSearch],
+        [],
+        state,
+        [],
+      );
+
+      expect(execute).toHaveBeenCalledOnce();
+      expect(execute.mock.calls[0]?.[0].toolCall.arguments).toEqual({
+        phase: outputPosition === 'between' ? 'second' : 'first',
+      });
+    },
+  );
+
+  it('stops client tool_search callbacks after the first invalid result', async () => {
+    const conflictingLookup = tool({
+      name: 'lookup',
+      description: 'Conflicting lookup.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'lookup',
+    });
+    let callbackCount = 0;
+    const execute = vi.fn(async () => {
+      callbackCount++;
+      return callbackCount === 1 ? conflictingLookup : [];
+    });
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const target = new Agent({ name: 'Lookup handoff target' });
+    const lookupHandoff = handoff(target, { toolNameOverride: 'lookup' });
+    const createCall = (id: string): protocol.ToolSearchCallItem =>
+      ({
+        type: 'tool_search_call',
+        id,
+        status: 'completed',
+        arguments: {},
+        providerData: { call_id: id, execution: 'client' },
+      }) as protocol.ToolSearchCallItem;
+    const agent = new Agent({ name: 'Invalid search result agent' });
+    const state = new RunState(new RunContext(), 'hello', agent, 3);
+
+    await expect(
+      processModelResponseAsync(
+        {
+          output: [createCall('search_first'), createCall('search_second')],
+          usage: new Usage(),
+        },
+        agent,
+        [clientToolSearch],
+        [lookupHandoff],
+        state,
+        [],
+      ),
+    ).rejects.toThrow(
+      'returned a bare function tool that conflicts with an available handoff',
+    );
+    expect(execute).toHaveBeenCalledOnce();
+    expect(state.getToolSearchRuntimeTools(agent)).toEqual([]);
+  });
+
+  it('does not dispatch a disabled function returned by client tool_search', async () => {
+    const disabledLookup = tool({
+      name: 'disabled_lookup',
+      description: 'Disabled lookup result.',
+      parameters: z.object({}).strict(),
+      isEnabled: false,
+      execute: async () => 'disabled',
+    });
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      async () => disabledLookup,
+    );
+    const agent = new Agent({
+      name: 'DisabledClientToolSearchAgent',
+    });
+    const state = new RunState(new RunContext(), 'hello', agent, 3);
+    const response: ModelResponse = {
+      output: [
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_disabled_lookup',
+          status: 'completed',
+          arguments: {},
+          providerData: {
+            call_id: 'call_tool_search_disabled_lookup',
+            execution: 'client',
+          },
+        } as protocol.ToolSearchCallItem,
+        {
+          type: 'function_call',
+          id: 'fc_disabled_lookup',
+          callId: 'call_disabled_lookup',
+          name: 'disabled_lookup',
+          status: 'completed',
+          arguments: '{}',
+        },
+      ],
+      usage: new Usage(),
+    };
+
+    await expect(
+      processModelResponseAsync(
+        response,
+        agent,
+        [clientToolSearch],
+        [],
+        state,
+        [],
+      ),
+    ).rejects.toThrow('Tool disabled_lookup not found');
+    expect(state.getToolSearchRuntimeTools(agent)).toEqual([]);
+  });
+
+  it.each(['disabled', 'empty', 'different'] as const)(
+    'removes a replaced client tool_search handler when the final result is %s',
+    async (replacement) => {
+      const firstLookup = tool({
+        name: 'lookup',
+        description: 'First lookup result.',
+        parameters: z.object({}).strict(),
+        execute: async () => 'first',
+      });
+      const disabledLookup = tool({
+        name: 'lookup',
+        description: 'Disabled replacement.',
+        parameters: z.object({}).strict(),
+        isEnabled: false,
+        execute: async () => 'disabled',
+      });
+      const alternateLookup = tool({
+        name: 'alternate_lookup',
+        description: 'Alternate replacement.',
+        parameters: z.object({}).strict(),
+        execute: async () => 'alternate',
+      });
+      const clientToolSearch = attachClientToolSearchExecutor(
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: { type: 'tool_search', execution: 'client' },
+        },
+        async ({ toolCall }) => {
+          const phase = (toolCall.arguments as { phase?: string }).phase;
+          if (phase === 'first') {
+            return firstLookup;
+          }
+          if (replacement === 'disabled') {
+            return disabledLookup;
+          }
+          if (replacement === 'different') {
+            return alternateLookup;
+          }
+          return [];
+        },
+      );
+      const agent = new Agent({
+        name: `Replacement ${replacement} agent`,
+      });
+      const state = new RunState(new RunContext(), 'hello', agent, 3);
+      const replacementCallId = 'call_tool_search_replacement';
+      const createToolSearchCall = (
+        id: string,
+        phase: string,
+      ): protocol.ToolSearchCallItem =>
+        ({
+          type: 'tool_search_call',
+          id,
+          status: 'completed',
+          arguments: { phase },
+          providerData: {
+            call_id: replacementCallId,
+            execution: 'client',
+          },
+        }) as protocol.ToolSearchCallItem;
+      const response: ModelResponse = {
+        output: [
+          createToolSearchCall('ts_call_replacement_first', 'first'),
+          createToolSearchCall('ts_call_replacement_final', 'final'),
+          {
+            type: 'function_call',
+            id: 'fc_replaced_lookup',
+            callId: 'call_replaced_lookup',
+            name: 'lookup',
+            status: 'completed',
+            arguments: '{}',
+          },
+        ],
+        usage: new Usage(),
+      };
+
+      await expect(
+        processModelResponseAsync(
+          response,
+          agent,
+          [clientToolSearch],
+          [],
+          state,
+          [],
+        ),
+      ).rejects.toThrow('Tool lookup not found');
+      expect(state.getToolSearchRuntimeTools(agent)).toEqual(
+        replacement === 'different' ? [alternateLookup] : [],
+      );
+    },
+  );
+
+  it('retains same-name bare and deferred tools returned by custom client tool_search', async () => {
+    const bareLookup = tool({
+      name: 'lookup',
+      description: 'Immediate lookup.',
+      parameters: z.object({}),
+      execute: async () => 'bare',
+    });
+    const deferredLookup = tool({
+      name: 'lookup',
+      description: 'Deferred lookup.',
+      parameters: z.object({}),
+      deferLoading: true,
+      execute: async () => 'deferred',
+    });
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: {
+          type: 'tool_search',
+          execution: 'client',
+        },
+      },
+      async () => [bareLookup, deferredLookup],
+    );
+    const toolSearchCall: protocol.ToolSearchCallItem = {
+      type: 'tool_search_call',
+      id: 'ts_call_same_name',
+      status: 'completed',
+      arguments: { paths: [] },
+      providerData: {
+        call_id: 'call_tool_search_same_name',
+        execution: 'client',
+      },
+    } as any;
+    const bareCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      callId: 'call_bare_lookup',
+      name: 'lookup',
+      arguments: '{}',
+    };
+    const deferredCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      callId: 'call_deferred_lookup',
+      name: 'lookup',
+      namespace: 'lookup',
+      arguments: '{}',
+    };
+    const agent = new Agent({ name: 'Category-aware tool search agent' });
+    const state = new RunState(new RunContext(), 'hello', agent, 3);
+
+    const result = await processModelResponseAsync(
+      {
+        output: [toolSearchCall, bareCall, deferredCall],
+        usage: new Usage(),
+      },
+      agent,
+      [clientToolSearch],
+      [],
+      state,
+      [],
+    );
+
+    expect(result.functions.map((functionRun) => functionRun.tool)).toEqual([
+      bareLookup,
+      deferredLookup,
+    ]);
+    expect(state.getToolSearchRuntimeTools(agent)).toEqual([
+      bareLookup,
+      deferredLookup,
+    ]);
+    expect((result.newItems[1] as ToolSearchOutputItem).rawItem.tools).toEqual([
+      expect.objectContaining({ name: 'lookup', deferLoading: false }),
+      expect.objectContaining({ name: 'lookup', deferLoading: true }),
+    ]);
+  });
+
+  it.each([false, true])(
+    'rejects duplicate routed identities within one replacement tool_search result (same object: %s)',
+    async (repeatSameObject) => {
+      const previous = tool({
+        name: 'lookup',
+        description: 'Previously loaded lookup.',
+        parameters: z.object({}),
+        deferLoading: true,
+        execute: async () => 'previous',
+      });
+      const first = tool({
+        name: 'lookup',
+        description: 'First replacement.',
+        parameters: z.object({}),
+        deferLoading: true,
+        execute: async () => 'first',
+      });
+      const second = tool({
+        name: 'lookup',
+        description: 'Second replacement.',
+        parameters: z.object({}),
+        deferLoading: true,
+        execute: async () => 'second',
+      });
+      const clientToolSearch = attachClientToolSearchExecutor(
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: { type: 'tool_search', execution: 'client' },
+        },
+        async () => (repeatSameObject ? [first, first] : [first, second]),
+      );
+      const agent = new Agent({ name: 'Replacement validation agent' });
+      const state = new RunState(new RunContext(), 'hello', agent, 2);
+      state.recordToolSearchRuntimeTools(
+        agent,
+        {
+          type: 'tool_search_output',
+          status: 'completed',
+          tools: [],
+        } as protocol.ToolSearchOutputItem,
+        [previous],
+      );
+
+      await expect(
+        processModelResponseAsync(
+          {
+            output: [
+              {
+                type: 'tool_search_call',
+                id: 'ts_call_duplicate_replacement',
+                status: 'completed',
+                arguments: { paths: [] },
+                providerData: {
+                  call_id: 'call_duplicate_replacement',
+                  execution: 'client',
+                },
+              } as protocol.ToolSearchCallItem,
+            ],
+            usage: new Usage(),
+          },
+          agent,
+          [clientToolSearch],
+          [],
+          state,
+          [],
+        ),
+      ).rejects.toThrow(
+        'Client tool_search execute() returned multiple tools with the same routed identity.',
+      );
+      expect(state.getToolSearchRuntimeTools(agent)).toEqual([previous]);
+    },
+  );
+
+  it('rejects duplicate routed identities before enabled filtering', async () => {
+    const enabledLookup = tool({
+      name: 'lookup',
+      description: 'Enabled lookup.',
+      parameters: z.object({}),
+      deferLoading: true,
+      execute: async () => 'enabled',
+    });
+    const disabledLookup = tool({
+      name: 'lookup',
+      description: 'Disabled lookup.',
+      parameters: z.object({}),
+      deferLoading: true,
+      isEnabled: false,
+      execute: async () => 'disabled',
+    });
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      async () => [enabledLookup, disabledLookup],
+    );
+    const agent = new Agent({ name: 'Raw duplicate validation agent' });
+    const state = new RunState(new RunContext(), 'hello', agent, 2);
+
+    await expect(
+      processModelResponseAsync(
+        {
+          output: [
+            {
+              type: 'tool_search_call',
+              id: 'ts_call_raw_duplicate',
+              status: 'completed',
+              arguments: {},
+              providerData: {
+                call_id: 'call_raw_duplicate',
+                execution: 'client',
+              },
+            } as protocol.ToolSearchCallItem,
+          ],
+          usage: new Usage(),
+        },
+        agent,
+        [clientToolSearch],
+        [],
+        state,
+        [],
+      ),
+    ).rejects.toThrow(
+      'Client tool_search execute() returned multiple tools with the same routed identity.',
+    );
+    expect(state.getToolSearchRuntimeTools(agent)).toEqual([]);
+  });
+
+  it('rejects same-name namespace results before enabled filtering', async () => {
+    const namespacedLookup = createLegacyNamespacedTool(
+      tool({
+        name: 'lookup',
+        description: 'Nested lookup.',
+        parameters: z.object({}),
+        isEnabled: false,
+        execute: async () => 'lookup',
+      }),
+      'lookup',
+      'Reserved lookup namespace.',
+    );
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      async () => namespacedLookup,
+    );
+    const agent = new Agent({ name: 'Reserved namespace result agent' });
+    const state = new RunState(new RunContext(), 'hello', agent, 2);
+
+    await expect(
+      processModelResponseAsync(
+        {
+          output: [
+            {
+              type: 'tool_search_call',
+              id: 'ts_call_reserved_namespace',
+              status: 'completed',
+              arguments: {},
+              providerData: {
+                call_id: 'call_reserved_namespace',
+                execution: 'client',
+              },
+            } as protocol.ToolSearchCallItem,
+          ],
+          usage: new Usage(),
+        },
+        agent,
+        [clientToolSearch],
+        [],
+        state,
+        [],
+      ),
+    ).rejects.toThrow(
+      'Responses tool search reserves same-name namespaces for deferred top-level function tools.',
+    );
+    expect(state.getToolSearchRuntimeTools(agent)).toEqual([]);
+  });
+
+  it('redacts configured tool identities from client tool_search conflicts', async () => {
+    const sensitiveName = 'secret_customer_lookup';
+    const configuredLookup = tool({
+      name: sensitiveName,
+      description: 'Configured lookup.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'configured',
+    });
+    const runtimeLookup = tool({
+      name: sensitiveName,
+      description: 'Runtime lookup.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'runtime',
+    });
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      async () => runtimeLookup,
+    );
+    const agent = new Agent({ name: 'Redacted runtime conflict agent' });
+    const state = new RunState(new RunContext(), 'hello', agent, 2);
+    const redaction = vi
+      .spyOn(logger, 'dontLogToolData', 'get')
+      .mockReturnValue(true);
+
+    try {
+      const result = processModelResponseAsync(
+        {
+          output: [
+            {
+              type: 'tool_search_call',
+              id: 'ts_call_redacted_conflict',
+              status: 'completed',
+              arguments: {},
+              providerData: {
+                call_id: 'call_redacted_conflict',
+                execution: 'client',
+              },
+            } as protocol.ToolSearchCallItem,
+          ],
+          usage: new Usage(),
+        },
+        agent,
+        [configuredLookup, clientToolSearch],
+        [],
+        state,
+        [],
+      );
+
+      await expect(result).rejects.toThrow(
+        'Client tool_search execute() returned a tool that conflicts with an existing available tool.',
+      );
+      await expect(result).rejects.not.toThrow(sensitiveName);
+    } finally {
+      redaction.mockRestore();
+    }
+  });
+
+  it('rejects a bare runtime function that conflicts with an available handoff', async () => {
+    const lookupAccount = tool({
+      name: 'lookup_account',
+      description: 'Look up an account.',
+      parameters: z.object({}),
+      execute: async () => 'account',
+    });
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: {
+          type: 'tool_search',
+          execution: 'client',
+        },
+      },
+      async () => lookupAccount,
+    );
+    const lookupHandoff = handoff(new Agent({ name: 'Lookup target' }), {
+      toolNameOverride: 'lookup_account',
+    });
+    const agent = new Agent({ name: 'CustomClientToolSearchAgent' });
+    const state = new RunState(new RunContext(), 'hello', agent, 3);
+
+    await expect(
+      processModelResponseAsync(
+        {
+          output: [
+            {
+              type: 'tool_search_call',
+              id: 'ts_call_lookup_conflict',
+              status: 'completed',
+              arguments: { paths: [] },
+              providerData: {
+                call_id: 'call_tool_search_lookup_conflict',
+                execution: 'client',
+              },
+            },
+          ],
+          usage: new Usage(),
+        },
+        agent,
+        [clientToolSearch],
+        [lookupHandoff],
+        state,
+        [],
+      ),
+    ).rejects.toThrow(
+      'Client tool_search execute() returned a bare function tool that conflicts with an available handoff.',
+    );
+    expect(state.getToolSearchRuntimeTools(agent)).toEqual([]);
+  });
+
   it('rejects disallowed callers for tools loaded by custom client tool_search', async () => {
     const programOnlyLookup = tool({
       name: 'lookup_account',
@@ -2001,7 +2718,63 @@ describe('processModelResponse', () => {
     expect(result.toolsUsed).toEqual(['crm.lookup_account']);
   });
 
-  it('prefers real same-name namespaces over bare top-level tools', () => {
+  it.each(['sync', 'async'] as const)(
+    'resolves an unambiguous flattened qualified namespace call in %s processing',
+    async (mode) => {
+      const crmLookup = toolNamespace({
+        name: 'crm',
+        description: 'CRM tools',
+        tools: [
+          tool({
+            name: 'lookup_account',
+            description: 'Look up an account in CRM.',
+            parameters: z.object({
+              accountId: z.string(),
+            }),
+            execute: async () => 'crm',
+          }),
+        ],
+      })[0];
+      const functionCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        id: 'fc_flattened_crm_lookup',
+        callId: 'call_flattened_crm_lookup',
+        name: 'crm.lookup_account',
+        status: 'completed',
+        arguments: '{"accountId":"acct_42"}',
+      };
+      const modelResponse: ModelResponse = {
+        output: [functionCall],
+        usage: new Usage(),
+      };
+
+      const result =
+        mode === 'sync'
+          ? processModelResponse(modelResponse, TEST_AGENT, [crmLookup], [])
+          : await processModelResponseAsync(
+              modelResponse,
+              TEST_AGENT,
+              [crmLookup],
+              [],
+              new RunState(new RunContext(), 'hello', TEST_AGENT, 1),
+            );
+
+      expect(result.functions).toEqual([
+        {
+          toolCall: {
+            ...functionCall,
+            name: 'lookup_account',
+            namespace: 'crm',
+          },
+          tool: crmLookup,
+        },
+      ]);
+      expect(result.handoffs).toEqual([]);
+      expect(result.toolsUsed).toEqual(['crm.lookup_account']);
+    },
+  );
+
+  it('rejects namespaces reserved for deferred top-level tools', () => {
     const topLevelLookup = tool({
       name: 'lookup_account',
       description: 'Look up a top-level account.',
@@ -2054,24 +2827,20 @@ describe('processModelResponse', () => {
       ),
     ];
 
-    const result = processModelResponse(
-      modelResponse,
-      TEST_AGENT,
-      [topLevelLookup, namespacedLookup],
-      [],
-      priorItems,
+    expect(() =>
+      processModelResponse(
+        modelResponse,
+        TEST_AGENT,
+        [topLevelLookup, namespacedLookup],
+        [],
+        priorItems,
+      ),
+    ).toThrow(
+      'Responses tool search reserves same-name namespaces for deferred top-level function tools.',
     );
-
-    expect(result.functions).toEqual([
-      {
-        toolCall: functionCall,
-        tool: namespacedLookup,
-      },
-    ]);
-    expect(result.toolsUsed).toEqual(['lookup_account.lookup_account']);
   });
 
-  it('rejects ambiguous dotted handoff overrides that clash with namespace tools', () => {
+  it('prefers an exact dotted handoff over a flattened namespace tool call', () => {
     const target = new Agent({ name: 'EscalationTarget' });
     const h = handoff(target, {
       toolNameOverride: 'crm.lookup_account',
@@ -2103,11 +2872,90 @@ describe('processModelResponse', () => {
       usage: new Usage(),
     };
 
-    expect(() =>
-      processModelResponse(modelResponse, TEST_AGENT, [crmLookup], [h]),
-    ).toThrow(
-      /Ambiguous dotted tool call crm\.lookup_account in agent TestAgent: it matches both a namespaced function tool and a handoff/,
+    const result = processModelResponse(
+      modelResponse,
+      TEST_AGENT,
+      [crmLookup],
+      [h],
     );
+
+    expect(result.functions).toEqual([]);
+    expect(result.handoffs).toEqual([
+      {
+        toolCall: functionCall,
+        handoff: h,
+      },
+    ]);
+    expect(result.toolsUsed).toEqual(['crm.lookup_account']);
+  });
+
+  it('distinguishes a deferred top-level function from an equal handoff name', () => {
+    const deferredLookup = tool({
+      name: 'lookup_account',
+      description: 'Deferred account lookup.',
+      parameters: z.object({ accountId: z.string() }),
+      deferLoading: true,
+      execute: async () => 'deferred',
+    });
+    const h = handoff(new Agent({ name: 'LookupTarget' }), {
+      toolNameOverride: 'lookup_account',
+    });
+    const bareCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_lookup_handoff',
+      callId: 'call_lookup_handoff',
+      name: 'lookup_account',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const deferredCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_lookup_deferred',
+      callId: 'call_lookup_deferred',
+      name: 'lookup_account',
+      namespace: 'lookup_account',
+      status: 'completed',
+      arguments: '{"accountId":"acct_42"}',
+    };
+    const priorItems = [
+      new ToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_lookup',
+          status: 'completed',
+          tools: [
+            {
+              type: 'tool_reference',
+              functionName: 'lookup_account',
+            },
+          ],
+        } as any,
+        TEST_AGENT,
+      ),
+    ];
+
+    const handoffResult = processModelResponse(
+      { output: [bareCall], usage: new Usage() },
+      TEST_AGENT,
+      [deferredLookup],
+      [h],
+    );
+    const deferredResult = processModelResponse(
+      { output: [deferredCall], usage: new Usage() },
+      TEST_AGENT,
+      [deferredLookup],
+      [h],
+      priorItems,
+    );
+
+    expect(handoffResult.handoffs).toEqual([
+      { toolCall: bareCall, handoff: h },
+    ]);
+    expect(handoffResult.functions).toEqual([]);
+    expect(deferredResult.handoffs).toEqual([]);
+    expect(deferredResult.functions).toEqual([
+      { toolCall: deferredCall, tool: deferredLookup },
+    ]);
   });
 
   it('still resolves dotted handoff overrides when no matching function tool exists', () => {

--- a/packages/agents-core/test/runner/modelOutputs.test.ts
+++ b/packages/agents-core/test/runner/modelOutputs.test.ts
@@ -1542,6 +1542,130 @@ describe('processModelResponse', () => {
     expect(state.getToolSearchRuntimeTools(agent)).toEqual([]);
   });
 
+  it('omits disabled functions from generated client tool_search output', async () => {
+    const disabledLookup = tool({
+      name: 'disabled_lookup',
+      description: 'Disabled lookup result.',
+      parameters: z.object({}).strict(),
+      isEnabled: false,
+      execute: async () => 'disabled',
+    });
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      async () => disabledLookup,
+    );
+    const agent = new Agent({
+      name: 'DisabledClientToolSearchOutputAgent',
+    });
+    const state = new RunState(new RunContext(), 'hello', agent, 3);
+
+    const result = await processModelResponseAsync(
+      {
+        output: [
+          {
+            type: 'tool_search_call',
+            id: 'ts_call_disabled_output',
+            status: 'completed',
+            arguments: {},
+            providerData: {
+              call_id: 'call_tool_search_disabled_output',
+              execution: 'client',
+            },
+          } as protocol.ToolSearchCallItem,
+        ],
+        usage: new Usage(),
+      },
+      agent,
+      [clientToolSearch],
+      [],
+      state,
+      [],
+    );
+
+    expect(result.newItems).toHaveLength(2);
+    expect((result.newItems[1] as ToolSearchOutputItem).rawItem).toMatchObject({
+      type: 'tool_search_output',
+      tools: [],
+      providerData: {
+        call_id: 'call_tool_search_disabled_output',
+        execution: 'client',
+      },
+    });
+    expect(state.getToolSearchRuntimeTools(agent)).toEqual([]);
+  });
+
+  it.each(['configured function', 'handoff'] as const)(
+    'ignores disabled client tool_search collisions with an enabled %s',
+    async (collisionOwner) => {
+      const disabledLookup = tool({
+        name: 'lookup',
+        description: 'Disabled lookup result.',
+        parameters: z.object({}).strict(),
+        isEnabled: false,
+        execute: async () => 'disabled',
+      });
+      const configuredLookup = tool({
+        name: 'lookup',
+        description: 'Configured lookup.',
+        parameters: z.object({}).strict(),
+        execute: async () => 'configured',
+      });
+      const clientToolSearch = attachClientToolSearchExecutor(
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: { type: 'tool_search', execution: 'client' },
+        },
+        async () => disabledLookup,
+      );
+      const agent = new Agent({
+        name: `Disabled collision ${collisionOwner}`,
+      });
+      const lookupHandoff = handoff(
+        new Agent({ name: 'Disabled collision target' }),
+        { toolNameOverride: 'lookup' },
+      );
+      const state = new RunState(new RunContext(), 'hello', agent, 3);
+
+      const result = await processModelResponseAsync(
+        {
+          output: [
+            {
+              type: 'tool_search_call',
+              id: `ts_disabled_${collisionOwner}`,
+              status: 'completed',
+              arguments: {},
+              providerData: {
+                call_id: `call_disabled_${collisionOwner}`,
+                execution: 'client',
+              },
+            } as protocol.ToolSearchCallItem,
+          ],
+          usage: new Usage(),
+        },
+        agent,
+        collisionOwner === 'configured function'
+          ? [configuredLookup, clientToolSearch]
+          : [clientToolSearch],
+        collisionOwner === 'handoff' ? [lookupHandoff] : [],
+        state,
+        [],
+      );
+
+      expect(
+        (result.newItems[1] as ToolSearchOutputItem).rawItem,
+      ).toMatchObject({
+        type: 'tool_search_output',
+        tools: [],
+      });
+      expect(state.getToolSearchRuntimeTools(agent)).toEqual([]);
+    },
+  );
+
   it('does not dispatch a disabled function returned by client tool_search', async () => {
     const disabledLookup = tool({
       name: 'disabled_lookup',
@@ -1843,35 +1967,50 @@ describe('processModelResponse', () => {
     },
   );
 
-  it('rejects duplicate routed identities before enabled filtering', async () => {
-    const enabledLookup = tool({
-      name: 'lookup',
-      description: 'Enabled lookup.',
-      parameters: z.object({}),
-      deferLoading: true,
-      execute: async () => 'enabled',
-    });
-    const disabledLookup = tool({
-      name: 'lookup',
-      description: 'Disabled lookup.',
-      parameters: z.object({}),
-      deferLoading: true,
-      isEnabled: false,
-      execute: async () => 'disabled',
-    });
-    const clientToolSearch = attachClientToolSearchExecutor(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: { type: 'tool_search', execution: 'client' },
-      },
-      async () => [enabledLookup, disabledLookup],
-    );
-    const agent = new Agent({ name: 'Raw duplicate validation agent' });
-    const state = new RunState(new RunContext(), 'hello', agent, 2);
+  it.each([
+    ['an enabled and a disabled result', true],
+    ['two disabled results', false],
+  ] as const)(
+    'filters disabled duplicate identities before validating %s',
+    async (_description, includeEnabledResult) => {
+      const enabledLookup = tool({
+        name: 'lookup',
+        description: 'Enabled lookup.',
+        parameters: z.object({}),
+        deferLoading: true,
+        execute: async () => 'enabled',
+      });
+      const disabledLookup = tool({
+        name: 'lookup',
+        description: 'Disabled lookup.',
+        parameters: z.object({}),
+        deferLoading: true,
+        isEnabled: false,
+        execute: async () => 'disabled',
+      });
+      const otherDisabledLookup = tool({
+        name: 'lookup',
+        description: 'Other disabled lookup.',
+        parameters: z.object({}),
+        deferLoading: true,
+        isEnabled: false,
+        execute: async () => 'other disabled',
+      });
+      const clientToolSearch = attachClientToolSearchExecutor(
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: { type: 'tool_search', execution: 'client' },
+        },
+        async () => [
+          includeEnabledResult ? enabledLookup : otherDisabledLookup,
+          disabledLookup,
+        ],
+      );
+      const agent = new Agent({ name: 'Raw duplicate validation agent' });
+      const state = new RunState(new RunContext(), 'hello', agent, 2);
 
-    await expect(
-      processModelResponseAsync(
+      const result = await processModelResponseAsync(
         {
           output: [
             {
@@ -1892,14 +2031,17 @@ describe('processModelResponse', () => {
         [],
         state,
         [],
-      ),
-    ).rejects.toThrow(
-      'Client tool_search execute() returned multiple tools with the same routed identity.',
-    );
-    expect(state.getToolSearchRuntimeTools(agent)).toEqual([]);
-  });
+      );
+      expect(
+        (result.newItems[1] as ToolSearchOutputItem).rawItem.tools,
+      ).toHaveLength(includeEnabledResult ? 1 : 0);
+      expect(state.getToolSearchRuntimeTools(agent)).toEqual(
+        includeEnabledResult ? [enabledLookup] : [],
+      );
+    },
+  );
 
-  it('rejects same-name namespace results before enabled filtering', async () => {
+  it('filters disabled same-name namespace results before validation', async () => {
     const namespacedLookup = createLegacyNamespacedTool(
       tool({
         name: 'lookup',
@@ -1922,31 +2064,29 @@ describe('processModelResponse', () => {
     const agent = new Agent({ name: 'Reserved namespace result agent' });
     const state = new RunState(new RunContext(), 'hello', agent, 2);
 
-    await expect(
-      processModelResponseAsync(
-        {
-          output: [
-            {
-              type: 'tool_search_call',
-              id: 'ts_call_reserved_namespace',
-              status: 'completed',
-              arguments: {},
-              providerData: {
-                call_id: 'call_reserved_namespace',
-                execution: 'client',
-              },
-            } as protocol.ToolSearchCallItem,
-          ],
-          usage: new Usage(),
-        },
-        agent,
-        [clientToolSearch],
-        [],
-        state,
-        [],
-      ),
-    ).rejects.toThrow(
-      'Responses tool search reserves same-name namespaces for deferred top-level function tools.',
+    const result = await processModelResponseAsync(
+      {
+        output: [
+          {
+            type: 'tool_search_call',
+            id: 'ts_call_reserved_namespace',
+            status: 'completed',
+            arguments: {},
+            providerData: {
+              call_id: 'call_reserved_namespace',
+              execution: 'client',
+            },
+          } as protocol.ToolSearchCallItem,
+        ],
+        usage: new Usage(),
+      },
+      agent,
+      [clientToolSearch],
+      [],
+      state,
+    );
+    expect((result.newItems[1] as ToolSearchOutputItem).rawItem.tools).toEqual(
+      [],
     );
     expect(state.getToolSearchRuntimeTools(agent)).toEqual([]);
   });

--- a/packages/agents-core/test/runner/modelPreparation.test.ts
+++ b/packages/agents-core/test/runner/modelPreparation.test.ts
@@ -1,0 +1,565 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import {
+  Agent,
+  FunctionTool,
+  Handoff,
+  ModelRequest,
+  Runner,
+  RunContext,
+  RunState,
+  ToolNameCollisionPolicy,
+  Usage,
+  UserError,
+  handoff,
+  protocol,
+  run,
+  setDefaultModelProvider,
+  setTraceProcessors,
+  setTracingDisabled,
+  tool,
+  toolNamespace,
+  type Span,
+  type Trace,
+  type TracingProcessor,
+} from '../../src';
+import logger from '../../src/logger';
+import { FUNCTION_TOOL_NAMESPACE } from '../../src/toolIdentity';
+import { prepareAgentArtifacts } from '../../src/runner/modelPreparation';
+import { withTrace } from '../../src/tracing/context';
+import {
+  FakeModel,
+  TEST_MODEL_FUNCTION_CALL,
+  TEST_MODEL_RESPONSE_BASIC,
+  FakeModelProvider,
+} from '../stubs';
+
+class RecordingModel extends FakeModel {
+  readonly requests: ModelRequest[] = [];
+
+  override async getResponse(request: ModelRequest) {
+    this.requests.push(request);
+    return super.getResponse(request);
+  }
+
+  override async *getStreamedResponse(
+    request: ModelRequest,
+  ): AsyncIterable<protocol.StreamEvent> {
+    const response = await this.getResponse(request);
+    yield {
+      type: 'response_done',
+      response: {
+        id: response.responseId ?? 'recording-response',
+        usage: {
+          requests: response.usage.requests,
+          inputTokens: response.usage.inputTokens,
+          outputTokens: response.usage.outputTokens,
+          totalTokens: response.usage.totalTokens,
+        },
+        output: response.output.map((item) =>
+          protocol.OutputModelItem.parse(item),
+        ),
+      },
+    };
+  }
+}
+
+class RecordingTracingProcessor implements TracingProcessor {
+  readonly spansEnded: Span<any>[] = [];
+
+  async onTraceStart(_trace: Trace): Promise<void> {}
+  async onTraceEnd(_trace: Trace): Promise<void> {}
+  async onSpanStart(_span: Span<any>): Promise<void> {}
+  async onSpanEnd(span: Span<any>): Promise<void> {
+    this.spansEnded.push(span);
+  }
+  async shutdown(): Promise<void> {}
+  async forceFlush(): Promise<void> {}
+}
+
+function functionTool(
+  name: string,
+  isEnabled: boolean = true,
+  description: string = `Tool ${name}`,
+  execute: () => string | Promise<string> = async () => name,
+): FunctionTool<any, any, any> {
+  return tool({
+    name,
+    description,
+    parameters: z.object({}),
+    isEnabled,
+    execute,
+  });
+}
+
+async function expectRejectedBeforeModelRequest(args: {
+  tools?: FunctionTool<any, any, any>[];
+  handoffs?: Handoff<any, any>[];
+  expectedMessage: string;
+  policy?: ToolNameCollisionPolicy;
+}): Promise<void> {
+  const model = new RecordingModel([TEST_MODEL_RESPONSE_BASIC]);
+  const agent = new Agent({
+    name: 'Collision agent',
+    model,
+    tools: args.tools,
+    handoffs: args.handoffs,
+  });
+
+  await expect(
+    run(agent, 'hello', {
+      toolNameCollisionPolicy: args.policy ?? 'error',
+    }),
+  ).rejects.toMatchObject({
+    name: UserError.name,
+    message: args.expectedMessage,
+  });
+  expect(model.requests).toHaveLength(0);
+}
+
+describe('model-visible tool name validation', () => {
+  setTracingDisabled(true);
+  setDefaultModelProvider(new FakeModelProvider());
+
+  beforeEach(() => {
+    vi.spyOn(logger, 'dontLogToolData', 'get').mockReturnValue(false);
+    vi.spyOn(logger, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const remediation =
+    'Function tools and handoffs must have unique routed names. Assign unique tool names or toolNameOverride values, or use a namespace.';
+
+  it.each([false, true])(
+    'redacts collision names from runner span errors (stream: %s)',
+    async (stream) => {
+      const secretToolName = 'SECRET_COLLISION_TRACE';
+      const processor = new RecordingTracingProcessor();
+      const model = new RecordingModel([TEST_MODEL_RESPONSE_BASIC]);
+      const agent = new Agent({
+        name: 'Trace collision agent',
+        model,
+        tools: [functionTool(secretToolName), functionTool(secretToolName)],
+      });
+      const runner = new Runner({
+        toolNameCollisionPolicy: 'error',
+        traceIncludeSensitiveData: false,
+      });
+      setTraceProcessors([processor]);
+      setTracingDisabled(false);
+
+      try {
+        if (stream) {
+          const result = await runner.run(agent, 'hello', { stream: true });
+          await expect(result.completed).rejects.toThrow(secretToolName);
+        } else {
+          await expect(runner.run(agent, 'hello')).rejects.toThrow(
+            secretToolName,
+          );
+        }
+
+        const spanErrors = processor.spansEnded
+          .map((span) => span.error)
+          .filter((error) => error !== null);
+        expect(spanErrors.length).toBeGreaterThan(0);
+        expect(JSON.stringify(spanErrors)).not.toContain(secretToolName);
+      } finally {
+        setTraceProcessors([]);
+        setTracingDisabled(true);
+      }
+    },
+  );
+
+  it('rejects duplicate enabled function tools before a model request', async () => {
+    await expectRejectedBeforeModelRequest({
+      tools: [functionTool('duplicate'), functionTool('duplicate')],
+      expectedMessage: `Duplicate enabled tool name found: 'duplicate' (2 function tools). ${remediation}`,
+    });
+  });
+
+  it('rejects duplicate enabled function tools within the same namespace', async () => {
+    const duplicateTools = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools',
+      tools: [functionTool('duplicate'), functionTool('duplicate')],
+    });
+
+    await expectRejectedBeforeModelRequest({
+      tools: [...duplicateTools],
+      policy: 'warn',
+      expectedMessage: `Duplicate enabled tool name found: 'crm.duplicate' (2 function tools). ${remediation}`,
+    });
+  });
+
+  it.each<ToolNameCollisionPolicy>(['warn', 'error'])(
+    'rejects duplicate deferred top-level function tools under the %s policy',
+    async (policy) => {
+      const first = functionTool('duplicate');
+      const second = functionTool('duplicate');
+      first.deferLoading = true;
+      second.deferLoading = true;
+
+      await expectRejectedBeforeModelRequest({
+        tools: [first, second],
+        policy,
+        expectedMessage: `Duplicate enabled tool name found: 'duplicate' (2 function tools). ${remediation}`,
+      });
+    },
+  );
+
+  it('keeps bare and deferred functions with the same public name distinct', async () => {
+    const bare = functionTool('lookup');
+    const deferred = functionTool('lookup');
+    deferred.deferLoading = true;
+    const model = new RecordingModel([TEST_MODEL_RESPONSE_BASIC]);
+    const agent = new Agent({
+      name: 'Category-aware function agent',
+      model,
+      tools: [bare, deferred],
+    });
+
+    await run(agent, 'hello');
+
+    expect(model.requests[0]?.tools).toEqual([
+      expect.objectContaining({ name: 'lookup', deferLoading: false }),
+      expect.objectContaining({ name: 'lookup', deferLoading: true }),
+    ]);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it.each<ToolNameCollisionPolicy>(['warn', 'error'])(
+    'rejects a namespace reserved for deferred top-level tools under the %s policy',
+    async (policy) => {
+      const reservedNamespaceTool = functionTool('lookup');
+      Object.defineProperty(reservedNamespaceTool, FUNCTION_TOOL_NAMESPACE, {
+        value: 'lookup',
+      });
+
+      await expectRejectedBeforeModelRequest({
+        tools: [reservedNamespaceTool],
+        policy,
+        expectedMessage:
+          'Responses tool search reserves same-name namespaces for deferred top-level function tools. Rename the namespace or tool name to avoid ambiguous dispatch.',
+      });
+    },
+  );
+
+  it('rejects duplicate enabled handoffs before a model request', async () => {
+    const first = handoff(new Agent({ name: 'First target' }), {
+      toolNameOverride: 'duplicate',
+    });
+    const second = handoff(new Agent({ name: 'Second target' }), {
+      toolNameOverride: 'duplicate',
+    });
+
+    await expectRejectedBeforeModelRequest({
+      handoffs: [first, second],
+      expectedMessage: `Duplicate enabled tool name found: 'duplicate' (2 handoffs). ${remediation}`,
+    });
+  });
+
+  it('rejects mixed enabled function tool and handoff names before a model request', async () => {
+    const duplicateHandoff = handoff(new Agent({ name: 'Target' }), {
+      toolNameOverride: 'duplicate',
+    });
+
+    await expectRejectedBeforeModelRequest({
+      tools: [functionTool('duplicate')],
+      handoffs: [duplicateHandoff],
+      expectedMessage: `Duplicate enabled tool name found: 'duplicate' (function tool and handoff). ${remediation}`,
+    });
+  });
+
+  it('warns by default and exposes only the last function tool', async () => {
+    const model = new RecordingModel([TEST_MODEL_RESPONSE_BASIC]);
+    const agent = new Agent({
+      name: 'Last function wins agent',
+      model,
+      tools: [
+        functionTool('duplicate', true, 'First tool'),
+        functionTool('duplicate', true, 'Second tool'),
+      ],
+    });
+
+    await run(agent, 'hello');
+
+    expect(model.requests).toHaveLength(1);
+    expect(model.requests[0]?.tools).toEqual([
+      expect.objectContaining({
+        name: 'duplicate',
+        description: 'Second tool',
+      }),
+    ]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      `Duplicate enabled tool name found: 'duplicate' (2 function tools). ${remediation} Only the current dispatch winner will be exposed.`,
+    );
+  });
+
+  it('dispatches the same last function tool that was exposed to the model', async () => {
+    const firstExecute = vi.fn(async () => 'first');
+    const secondExecute = vi.fn(async () => 'second');
+    const model = new RecordingModel([
+      {
+        output: [
+          {
+            ...TEST_MODEL_FUNCTION_CALL,
+            name: 'duplicate',
+            arguments: '{}',
+          },
+        ],
+        usage: new Usage(),
+      },
+      TEST_MODEL_RESPONSE_BASIC,
+    ]);
+    const agent = new Agent({
+      name: 'Dispatch winner agent',
+      model,
+      tools: [
+        functionTool('duplicate', true, 'First tool', firstExecute),
+        functionTool('duplicate', true, 'Second tool', secondExecute),
+      ],
+    });
+
+    await run(agent, 'hello');
+
+    expect(model.requests[0]?.tools).toEqual([
+      expect.objectContaining({ description: 'Second tool' }),
+    ]);
+    expect(firstExecute).not.toHaveBeenCalled();
+    expect(secondExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns by default and gives handoffs priority over function tools', async () => {
+    const firstHandoff = handoff(new Agent({ name: 'First target' }), {
+      toolNameOverride: 'duplicate',
+      toolDescriptionOverride: 'First handoff',
+    });
+    const secondHandoff = handoff(new Agent({ name: 'Second target' }), {
+      toolNameOverride: 'duplicate',
+      toolDescriptionOverride: 'Second handoff',
+    });
+    const model = new RecordingModel([TEST_MODEL_RESPONSE_BASIC]);
+    const agent = new Agent({
+      name: 'Handoff wins agent',
+      model,
+      tools: [functionTool('duplicate')],
+      handoffs: [firstHandoff, secondHandoff],
+    });
+
+    await run(agent, 'hello');
+
+    expect(model.requests).toHaveLength(1);
+    expect(model.requests[0]?.tools).toEqual([]);
+    expect(model.requests[0]?.handoffs).toEqual([
+      expect.objectContaining({
+        toolName: 'duplicate',
+        toolDescription: 'Second handoff',
+      }),
+    ]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      `Duplicate enabled tool name found: 'duplicate' (function tool and 2 handoffs). ${remediation} Only the current dispatch winner will be exposed.`,
+    );
+  });
+
+  it('ignores disabled function tools and handoffs when checking names', async () => {
+    const enabledHandoff = handoff(new Agent({ name: 'Enabled target' }), {
+      toolNameOverride: 'handoff_duplicate',
+    });
+    const disabledHandoff = handoff(new Agent({ name: 'Disabled target' }), {
+      toolNameOverride: 'handoff_duplicate',
+      isEnabled: false,
+    });
+    const model = new RecordingModel([TEST_MODEL_RESPONSE_BASIC]);
+    const agent = new Agent({
+      name: 'Filtered capabilities agent',
+      model,
+      tools: [
+        functionTool('function_duplicate'),
+        functionTool('function_duplicate', false),
+      ],
+      handoffs: [enabledHandoff, disabledHandoff],
+    });
+
+    await run(agent, 'hello');
+
+    expect(model.requests).toHaveLength(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(model.requests[0]?.tools).toEqual([
+      expect.objectContaining({ name: 'function_duplicate' }),
+    ]);
+    expect(model.requests[0]?.handoffs).toEqual([
+      expect.objectContaining({ toolName: 'handoff_duplicate' }),
+    ]);
+  });
+
+  it('filters disabled runtime-loaded function tools before validation', async () => {
+    const configured = functionTool('lookup');
+    const disabledRuntime = functionTool('lookup', false);
+    const model = new RecordingModel([TEST_MODEL_RESPONSE_BASIC]);
+    const agent = new Agent({
+      name: 'Runtime filtering agent',
+      model,
+      tools: [configured],
+    });
+    const state = new RunState(new RunContext(), 'hello', agent, 1);
+    state.recordToolSearchRuntimeTools(
+      agent,
+      {
+        type: 'tool_search_output',
+        status: 'completed',
+        tools: [],
+      } as protocol.ToolSearchOutputItem,
+      [disabledRuntime],
+    );
+
+    await run(agent, state);
+
+    expect(model.requests).toHaveLength(1);
+    expect(model.requests[0]?.tools).toEqual([
+      expect.objectContaining({ name: 'lookup' }),
+    ]);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('evaluates runtime-loaded tools against their public owning agent', async () => {
+    const publicAgent = new Agent({
+      name: 'Public sandbox agent',
+    }) as Agent<unknown, any>;
+    const executionAgent = new Agent({
+      name: 'Prepared sandbox agent',
+    }) as Agent<unknown, any>;
+    const evaluatedAgents: Agent<any, any>[] = [];
+    const runtimeTool = tool({
+      name: 'runtime_lookup',
+      description: 'Runtime lookup.',
+      parameters: z.object({}),
+      isEnabled: ({ agent }) => {
+        evaluatedAgents.push(agent);
+        return agent === publicAgent;
+      },
+      execute: async () => 'runtime',
+    });
+    const state = new RunState(new RunContext(), 'hello', publicAgent, 1);
+    state.recordToolSearchRuntimeTools(
+      publicAgent,
+      {
+        type: 'tool_search_output',
+        status: 'completed',
+        tools: [],
+      } as protocol.ToolSearchOutputItem,
+      [runtimeTool],
+    );
+
+    const artifacts = await withTrace('runtime tool owner test', async () =>
+      prepareAgentArtifacts(state, executionAgent),
+    );
+
+    expect(evaluatedAgents).toEqual([publicAgent]);
+    expect(artifacts.tools).toContain(runtimeTool);
+  });
+
+  it('keeps equal bare names distinct when namespaces disambiguate routing', async () => {
+    const [crmLookup] = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools',
+      tools: [functionTool('lookup')],
+    });
+    const [billingLookup] = toolNamespace({
+      name: 'billing',
+      description: 'Billing tools',
+      tools: [functionTool('lookup')],
+    });
+    const model = new RecordingModel([TEST_MODEL_RESPONSE_BASIC]);
+    const dottedHandoff = handoff(new Agent({ name: 'Dotted target' }), {
+      toolNameOverride: 'crm.lookup',
+    });
+    const agent = new Agent({
+      name: 'Namespaced capabilities agent',
+      model,
+      tools: [functionTool('lookup'), crmLookup!, billingLookup!],
+      handoffs: [dottedHandoff],
+    });
+
+    await run(agent, 'hello');
+
+    expect(model.requests).toHaveLength(1);
+    expect(model.requests[0]?.tools).toEqual([
+      expect.objectContaining({ name: 'lookup' }),
+      expect.objectContaining({ name: 'lookup', namespace: 'crm' }),
+      expect.objectContaining({ name: 'lookup', namespace: 'billing' }),
+    ]);
+    expect(model.requests[0]?.handoffs).toEqual([
+      expect.objectContaining({ toolName: 'crm.lookup' }),
+    ]);
+  });
+
+  it('uses the same pre-request validation for streaming runs', async () => {
+    const duplicateHandoff = handoff(new Agent({ name: 'Stream target' }), {
+      toolNameOverride: 'duplicate',
+    });
+    const model = new FakeModel([TEST_MODEL_RESPONSE_BASIC]);
+    const getResponse = vi.spyOn(model, 'getResponse');
+    const getStreamedResponse = vi.spyOn(model, 'getStreamedResponse');
+    const agent = new Agent({
+      name: 'Streaming collision agent',
+      model,
+      tools: [functionTool('duplicate')],
+      handoffs: [duplicateHandoff],
+    });
+
+    const result = await run(agent, 'hello', {
+      stream: true,
+      toolNameCollisionPolicy: 'error',
+    });
+
+    await expect(result.completed).rejects.toMatchObject({
+      name: UserError.name,
+      message: `Duplicate enabled tool name found: 'duplicate' (function tool and handoff). ${remediation}`,
+    });
+    expect(getResponse).not.toHaveBeenCalled();
+    expect(getStreamedResponse).not.toHaveBeenCalled();
+  });
+
+  it('redacts colliding names while keeping remediation actionable', async () => {
+    const redaction = vi
+      .spyOn(logger, 'dontLogToolData', 'get')
+      .mockReturnValue(true);
+    try {
+      await expectRejectedBeforeModelRequest({
+        tools: [
+          functionTool('sensitive_duplicate'),
+          functionTool('sensitive_duplicate'),
+        ],
+        expectedMessage:
+          'Duplicate enabled function tool or handoff names found. ' +
+          remediation,
+        policy: 'error',
+      });
+    } finally {
+      redaction.mockRestore();
+    }
+  });
+
+  it('redacts warning details while keeping remediation actionable', async () => {
+    vi.spyOn(logger, 'dontLogToolData', 'get').mockReturnValue(true);
+    const model = new RecordingModel([TEST_MODEL_RESPONSE_BASIC]);
+    const agent = new Agent({
+      name: 'Redacted warning agent',
+      model,
+      tools: [
+        functionTool('sensitive_duplicate'),
+        functionTool('sensitive_duplicate'),
+      ],
+    });
+
+    await run(agent, 'hello');
+
+    expect(model.requests[0]?.tools).toHaveLength(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Tool name collision detected. Assign unique routed tool names or enable tool data logging for details. Only the current dispatch winner will be exposed.',
+    );
+  });
+});

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -27,6 +27,7 @@ import {
 } from '../../src/runner/streaming';
 import {
   checkForFinalOutputFromTools,
+  collectInterruptions,
   executeApplyPatchOperations,
   executeComputerActions,
   executeFunctionToolCalls,
@@ -83,6 +84,7 @@ import {
 } from '../../src/tracing/processor';
 import type { Span } from '../../src/tracing/spans';
 import type { Trace } from '../../src/tracing/traces';
+import { getFunctionToolStateKey } from '../../src/toolIdentity';
 
 const createMockLogger = (): Logger => ({
   namespace: 'test',
@@ -388,6 +390,30 @@ describe('getToolCallOutputItem', () => {
 });
 
 describe('checkForFinalOutputFromTools', () => {
+  it('keeps the same function approval identity for separate agents', () => {
+    const root = new Agent({ name: 'Approval identity root' });
+    const child = new Agent({ name: 'Approval identity child' });
+    const createCall = (id: string): protocol.FunctionCallItem => ({
+      type: 'function_call',
+      id,
+      callId: 'shared_approval_call_id',
+      name: 'shared_tool',
+      status: 'completed',
+      arguments: '{}',
+    });
+
+    const interruptions = collectInterruptions(
+      [],
+      [
+        new ToolApprovalItem(createCall('root_call'), root),
+        new ToolApprovalItem(createCall('child_call'), child),
+      ],
+    );
+
+    expect(interruptions).toHaveLength(2);
+    expect(interruptions.map((item) => item.agent)).toEqual([root, child]);
+  });
+
   const state: RunState<any, any> = {} as any;
 
   const weatherTool = tool({
@@ -2722,6 +2748,156 @@ describe('executeShellActions', () => {
       expect(invokeSpy).not.toHaveBeenCalled();
     });
 
+    it('does not reuse a bare approval for a same-name deferred tool', async () => {
+      const deferredExecute = vi.fn(async () => 'deferred');
+      const bare = tool({
+        name: 'lookup',
+        description: 'Immediate lookup.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: vi.fn(async () => 'bare'),
+      }) as unknown as FunctionTool;
+      const deferred = tool({
+        name: 'lookup',
+        description: 'Deferred lookup.',
+        parameters: z.object({}),
+        deferLoading: true,
+        needsApproval: true,
+        execute: deferredExecute,
+      }) as unknown as FunctionTool;
+      state._context.approveTool(
+        new ToolApprovalItem(
+          {
+            type: 'function_call',
+            callId: 'approved-bare',
+            name: 'lookup',
+            arguments: '{}',
+          },
+          state._currentAgent,
+        ),
+        { alwaysApprove: true },
+      );
+
+      const [result] = await executeFunctionToolCalls(
+        state._currentAgent,
+        [
+          {
+            toolCall: {
+              type: 'function_call',
+              callId: 'deferred-call',
+              name: 'lookup',
+              namespace: 'lookup',
+              arguments: '{}',
+            },
+            tool: deferred,
+            availableFunctionTools: [bare, deferred],
+          },
+        ],
+        runner,
+        state,
+      );
+
+      expect(result.type).toBe('function_approval');
+      expect(deferredExecute).not.toHaveBeenCalled();
+    });
+
+    it('does not use a bare function approval for a deferred tool', async () => {
+      const deferredExecute = vi.fn(async () => 'deferred');
+      const deferred = tool({
+        name: 'lookup',
+        description: 'Deferred lookup.',
+        parameters: z.object({}),
+        deferLoading: true,
+        needsApproval: true,
+        execute: deferredExecute,
+      }) as unknown as FunctionTool;
+      state._context.approveTool(
+        new ToolApprovalItem(
+          {
+            type: 'function_call',
+            callId: 'legacy-approval',
+            name: 'lookup',
+            arguments: '{}',
+          },
+          state._currentAgent,
+        ),
+        { alwaysApprove: true },
+      );
+
+      const [result] = await executeFunctionToolCalls(
+        state._currentAgent,
+        [
+          {
+            toolCall: {
+              type: 'function_call',
+              callId: 'deferred-call',
+              name: 'lookup',
+              namespace: 'lookup',
+              arguments: '{}',
+            },
+            tool: deferred,
+            availableFunctionTools: [deferred],
+          },
+        ],
+        runner,
+        state,
+      );
+
+      expect(result.type).toBe('function_approval');
+      expect(deferredExecute).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['per-call', false],
+      ['permanent', true],
+    ] as const)(
+      'does not use a same-name shell %s approval for a function tool',
+      async (_decision, alwaysApprove) => {
+        const execute = vi.fn(async () => 'function');
+        const functionTool = tool({
+          name: 'shell',
+          description: 'Function named shell.',
+          parameters: z.object({}),
+          needsApproval: true,
+          execute,
+        }) as unknown as FunctionTool;
+        const sharedCallId = 'same-name-shell-function';
+        state._context.approveTool(
+          new ToolApprovalItem(
+            {
+              type: 'shell_call',
+              callId: sharedCallId,
+              status: 'completed',
+              action: { commands: ['echo approved'] },
+            },
+            state._currentAgent,
+            'shell',
+          ),
+          { alwaysApprove },
+        );
+
+        const [result] = await executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                type: 'function_call',
+                callId: sharedCallId,
+                name: 'shell',
+                arguments: '{}',
+              },
+              tool: functionTool,
+            },
+          ],
+          runner,
+          state,
+        );
+
+        expect(result.type).toBe('function_approval');
+        expect(execute).not.toHaveBeenCalled();
+      },
+    );
+
     it.each([
       ['malformed JSON', '{'],
       ['an array', '[]'],
@@ -3312,7 +3488,9 @@ describe('executeShellActions', () => {
       };
       const approvalSpy = vi
         .spyOn(state._context, 'isToolApproved')
-        .mockReturnValue(false as any);
+        .mockImplementation(({ toolName }) =>
+          toolName === getFunctionToolStateKey(t) ? false : undefined,
+        );
       const customRunner = new Runner({ tracingDisabled: false });
 
       await withRecordingTrace(async (processor) => {
@@ -3327,8 +3505,10 @@ describe('executeShellActions', () => {
 
         expect(res[0].type).toBe('function_output');
         expect(approvalSpy).toHaveBeenCalledWith({
-          toolName: 'get_shipping_eta',
+          toolName: getFunctionToolStateKey(t),
           callId: 'call_shipping_eta',
+          functionTool: false,
+          agent: state._currentAgent,
         });
         getEndedFunctionSpan(processor, 'get_shipping_eta');
         expect(

--- a/packages/agents-core/test/runner/turnResolution.test.ts
+++ b/packages/agents-core/test/runner/turnResolution.test.ts
@@ -29,6 +29,7 @@ import {
   applyPatchTool,
   shellTool,
   tool,
+  toolNamespace,
   hostedMcpTool,
 } from '../../src/tool';
 import { Usage } from '../../src/usage';
@@ -907,6 +908,82 @@ describe('resolveTurnAfterModelResponse', () => {
 });
 
 describe('resolveInterruptedTurn', () => {
+  it('removes a resolved namespaced approval and rewinds persistence', async () => {
+    const execute = vi.fn(async () => 'account');
+    const [lookupAccount] = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup_account',
+          description: 'Look up an account.',
+          parameters: z.object({}),
+          needsApproval: true,
+          execute,
+        }),
+      ],
+    });
+    const agent = new Agent({
+      name: 'Namespaced approval agent',
+      tools: [lookupAccount!],
+    });
+    const toolCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'lookup_account',
+      namespace: 'crm',
+      callId: 'call_lookup_account',
+      arguments: '{}',
+      status: 'completed',
+    };
+    const approvalItem = new ToolApprovalItem(toolCall, agent);
+    const state = new RunState(new RunContext(), 'hello', agent, 2);
+    state._currentTurnPersistedItemCount = 1;
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: { interruptions: [approvalItem] },
+    };
+    state._context.approveTool(approvalItem);
+    const processedResponse: ProcessedResponse = {
+      newItems: [approvalItem],
+      handoffs: [],
+      functions: [
+        {
+          toolCall,
+          tool: lookupAccount! as any,
+          availableFunctionTools: [lookupAccount! as any],
+        },
+      ],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['crm.lookup_account'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+
+    const result = await resolveInterruptedTurn(
+      agent,
+      'hello',
+      [approvalItem],
+      TEST_MODEL_RESPONSE_BASIC,
+      processedResponse,
+      new Runner({ tracingDisabled: true }),
+      state,
+    );
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(result.preStepItems).not.toContain(approvalItem);
+    expect(state._currentTurnPersistedItemCount).toBe(0);
+    expect(result.newStepItems).toContainEqual(
+      expect.objectContaining({
+        rawItem: expect.objectContaining({
+          type: 'function_call_result',
+          callId: 'call_lookup_account',
+        }),
+      }),
+    );
+  });
+
   it('ignores already-completed approvals when resuming', async () => {
     const agent = new Agent({ name: 'rewind-agent2' });
     const state = new RunState(new RunContext(), 'hello', agent, 1);
@@ -1863,6 +1940,91 @@ describe('resolveInterruptedTurn', () => {
     expect(editor.operations).toHaveLength(1);
     expect(executedFunctionCallIds).toEqual(['call-func-1', 'call-func-2']);
     expect(result.nextStep.type).toBe('next_step_run_again');
+  });
+
+  it('keeps same-call-id approvals independent across agents', async () => {
+    const rootExecute = vi.fn(async () => 'root');
+    const childExecute = vi.fn(async () => 'child');
+    const rootTool = tool({
+      name: 'root_tool',
+      description: 'Root tool.',
+      parameters: z.object({}),
+      needsApproval: true,
+      execute: rootExecute,
+    });
+    const childTool = tool({
+      name: 'child_tool',
+      description: 'Child tool.',
+      parameters: z.object({}),
+      needsApproval: true,
+      execute: childExecute,
+    });
+    const child = new Agent({ name: 'Approval child', tools: [childTool] });
+    const root = new Agent({
+      name: 'Approval root',
+      tools: [rootTool],
+      handoffs: [child],
+    });
+    const sharedCallId = 'shared_agent_call_id';
+    const rootCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_root_shared',
+      callId: sharedCallId,
+      name: 'root_tool',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const childCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_child_shared',
+      callId: sharedCallId,
+      name: 'child_tool',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const rootApproval = new ToolApprovalItem(rootCall, root);
+    const childApproval = new ToolApprovalItem(childCall, child);
+    const originalItems = [
+      new ToolCallItem(rootCall, root),
+      rootApproval,
+      new ToolCallItem(childCall, child),
+      childApproval,
+    ];
+    const processedResponse: ProcessedResponse<UnknownContext> = {
+      newItems: [],
+      handoffs: [],
+      functions: [{ toolCall: rootCall, tool: rootTool as any }],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: [],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+    const state = new RunState(new RunContext(), 'hello', root, 5);
+    state._generatedItems = originalItems;
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: { interruptions: [rootApproval, childApproval] },
+    };
+    state._context.approveTool(rootApproval);
+
+    const result = await withTrace('test', () =>
+      resolveInterruptedTurn(
+        root,
+        'hello',
+        originalItems,
+        { output: [], usage: new Usage() },
+        processedResponse,
+        new Runner({ tracingDisabled: true }),
+        state,
+      ),
+    );
+
+    expect(rootExecute).toHaveBeenCalledOnce();
+    expect(childExecute).not.toHaveBeenCalled();
+    expect(result.preStepItems).toContain(childApproval);
+    expect(result.preStepItems).not.toContain(rootApproval);
   });
 
   it('removes resolved hosted MCP approvals but keeps unresolved ones', async () => {

--- a/packages/agents-core/test/sandboxToolRehydration.test.ts
+++ b/packages/agents-core/test/sandboxToolRehydration.test.ts
@@ -12,10 +12,11 @@ import {
 } from '../src/sandbox/runtime/toolRehydration';
 import { SandboxAgent } from '../src/sandbox';
 import {
+  buildFunctionToolLookupMap,
   getFunctionToolQualifiedName,
-  resolveFunctionToolCallName,
+  resolveFunctionToolCall,
 } from '../src/toolIdentity';
-import { shellTool, tool } from '../src/tool';
+import { shellTool, tool, toolNamespace } from '../src/tool';
 import type * as protocol from '../src/types/protocol';
 import { FakeShell } from './stubs';
 
@@ -57,11 +58,11 @@ describe('serialized sandbox execution tool placeholders', () => {
       'crm.lookup_customer',
     );
     expect(
-      resolveFunctionToolCallName(
+      resolveFunctionToolCall(
         functionCall,
-        new Map([['crm.lookup_customer', placeholder!]]),
+        buildFunctionToolLookupMap([placeholder!]),
       ),
-    ).toBe('crm.lookup_customer');
+    ).toBe(placeholder);
     await expect(placeholder!.invoke(new RunContext(), '{}')).rejects.toThrow(
       'Function tool crm.lookup_customer was restored from serialized execution-time metadata without an executable handler.',
     );
@@ -305,7 +306,7 @@ describe('serialized sandbox execution tool placeholders', () => {
         agent: sandboxAgent,
         baseAgentTools: [configuredFunction],
         serializedTool: { type: 'function' },
-        toolCall: { ...functionCall, namespace: 'lookup_customer' },
+        toolCall: { ...functionCall, namespace: undefined },
         toolIdentity: 'lookup_customer',
         allowSerializedExecutionToolPlaceholder: true,
       }),
@@ -349,5 +350,64 @@ describe('serialized sandbox execution tool placeholders', () => {
         allowSerializedExecutionToolPlaceholder: true,
       }),
     ).toBeUndefined();
+  });
+
+  it('checks configured identity without validating disabled duplicates', () => {
+    const [enabledLookup] = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup_customer',
+          description: 'Looks up a customer.',
+          parameters: z.object({}),
+          execute: async () => 'configured',
+        }),
+      ],
+    });
+    const [disabledLookup] = toolNamespace({
+      name: 'crm',
+      description: 'Disabled CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup_customer',
+          description: 'Disabled duplicate.',
+          parameters: z.object({}),
+          isEnabled: false,
+          execute: async () => 'disabled',
+        }),
+      ],
+    });
+
+    expect(
+      getSerializedFunctionToolPlaceholder({
+        agent: new SandboxAgent({ name: 'Sandbox' }),
+        baseAgentTools: [enabledLookup!, disabledLookup!],
+        serializedTool: { type: 'function' },
+        toolCall: functionCall,
+        toolIdentity: 'crm.lookup_customer',
+        allowSerializedExecutionToolPlaceholder: true,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('does not treat a bare configured function as a deferred self-namespaced function', () => {
+    const configuredFunction = tool({
+      name: 'lookup_customer',
+      description: 'Looks up a customer.',
+      parameters: z.object({}),
+      execute: async () => 'configured',
+    });
+
+    expect(
+      getSerializedFunctionToolPlaceholder({
+        agent: new SandboxAgent({ name: 'Sandbox' }),
+        baseAgentTools: [configuredFunction],
+        serializedTool: { type: 'function', deferLoading: true },
+        toolCall: { ...functionCall, namespace: 'lookup_customer' },
+        toolIdentity: 'lookup_customer',
+        allowSerializedExecutionToolPlaceholder: true,
+      }),
+    ).toBeDefined();
   });
 });

--- a/packages/agents-core/test/toolIdentity.test.ts
+++ b/packages/agents-core/test/toolIdentity.test.ts
@@ -3,12 +3,30 @@ import { describe, expect, it } from 'vitest';
 import {
   FUNCTION_TOOL_NAMESPACE,
   buildFunctionToolLookupMap,
+  getFunctionToolLegacyStateKeyFromStateKey,
   getFunctionToolStateKeyForResolvedCall,
   getFunctionToolStateKeys,
   resolveFunctionToolCall,
 } from '../src/toolIdentity';
 
 describe('category-aware function tool lookup', () => {
+  it('projects canonical state keys to released public approval names', () => {
+    expect(getFunctionToolLegacyStateKeyFromStateKey('["bare","lookup"]')).toBe(
+      'lookup',
+    );
+    expect(
+      getFunctionToolLegacyStateKeyFromStateKey(
+        '["deferred_top_level","lookup"]',
+      ),
+    ).toBe('lookup');
+    expect(
+      getFunctionToolLegacyStateKeyFromStateKey(
+        '["namespaced","crm","lookup"]',
+      ),
+    ).toBe('crm.lookup');
+    expect(getFunctionToolLegacyStateKeyFromStateKey('lookup')).toBeUndefined();
+  });
+
   it('distinguishes bare and deferred top-level tools with the same name', () => {
     const bare = { type: 'function', name: 'lookup', deferLoading: false };
     const deferred = { type: 'function', name: 'lookup', deferLoading: true };

--- a/packages/agents-core/test/toolIdentity.test.ts
+++ b/packages/agents-core/test/toolIdentity.test.ts
@@ -2,131 +2,165 @@ import { describe, expect, it } from 'vitest';
 
 import {
   FUNCTION_TOOL_NAMESPACE,
-  resolveFunctionToolCallName,
+  buildFunctionToolLookupMap,
+  getFunctionToolStateKeyForResolvedCall,
+  getFunctionToolStateKeys,
+  resolveFunctionToolCall,
 } from '../src/toolIdentity';
 
-function createToolLookup(
-  tools: Array<{ key: string; value?: Record<string, any> }>,
-): Map<string, Record<string, any>> {
-  return new Map(tools.map(({ key, value }) => [key, value ?? { name: key }]));
-}
+describe('category-aware function tool lookup', () => {
+  it('distinguishes bare and deferred top-level tools with the same name', () => {
+    const bare = { type: 'function', name: 'lookup', deferLoading: false };
+    const deferred = { type: 'function', name: 'lookup', deferLoading: true };
+    const tools = buildFunctionToolLookupMap([bare, deferred]);
 
-describe('resolveFunctionToolCallName', () => {
-  it('prefers the bare name for self-namespaced top-level deferred calls', () => {
-    const availableToolNames = createToolLookup([
-      {
-        key: 'lookup_account',
-        value: {
-          type: 'function',
-          name: 'lookup_account',
-          deferLoading: true,
-        },
-      },
+    expect(resolveFunctionToolCall({ name: 'lookup' }, tools)).toBe(bare);
+    expect(
+      resolveFunctionToolCall({ name: 'lookup', namespace: 'lookup' }, tools),
+    ).toBe(deferred);
+  });
+
+  it('distinguishes dotted bare names from explicit namespaces', () => {
+    const dotted = { type: 'function', name: 'crm.lookup' };
+    const namespaced = {
+      type: 'function',
+      name: 'lookup',
+      [FUNCTION_TOOL_NAMESPACE]: 'crm',
+    };
+    const tools = buildFunctionToolLookupMap([dotted, namespaced]);
+
+    expect(resolveFunctionToolCall({ name: 'crm.lookup' }, tools)).toBe(dotted);
+    expect(
+      resolveFunctionToolCall({ name: 'lookup', namespace: 'crm' }, tools),
+    ).toBe(namespaced);
+  });
+
+  it('resolves an unambiguous flattened qualified namespace call', () => {
+    const namespaced = {
+      type: 'function',
+      name: 'lookup',
+      [FUNCTION_TOOL_NAMESPACE]: 'crm',
+    };
+    const tools = buildFunctionToolLookupMap([namespaced]);
+
+    expect(resolveFunctionToolCall({ name: 'crm.lookup' }, tools)).toBe(
+      namespaced,
+    );
+  });
+
+  it('leaves ambiguous flattened namespace calls unresolved', () => {
+    const firstNamespaced = {
+      type: 'function',
+      name: 'lookup.detail',
+      [FUNCTION_TOOL_NAMESPACE]: 'crm',
+    };
+    const secondNamespaced = {
+      type: 'function',
+      name: 'detail',
+      [FUNCTION_TOOL_NAMESPACE]: 'crm.lookup',
+    };
+    const ambiguousTools = buildFunctionToolLookupMap([
+      firstNamespaced,
+      secondNamespaced,
     ]);
 
     expect(
-      resolveFunctionToolCallName(
-        {
-          name: 'lookup_account',
-          namespace: 'lookup_account',
-        },
-        availableToolNames,
-      ),
-    ).toBe('lookup_account');
-  });
+      resolveFunctionToolCall({ name: 'crm.lookup.detail' }, ambiguousTools),
+    ).toBeUndefined();
 
-  it('falls back to the qualified name when a self-namespaced bare tool is absent', () => {
-    const availableToolNames = new Set(['lookup_account.lookup_account']);
-
-    expect(
-      resolveFunctionToolCallName(
-        {
-          name: 'lookup_account',
-          namespace: 'lookup_account',
-        },
-        availableToolNames,
-      ),
-    ).toBe('lookup_account.lookup_account');
-  });
-
-  it('prefers the bare name when both self-namespaced candidates are present', () => {
-    const availableToolNames = createToolLookup([
-      {
-        key: 'lookup_account',
-        value: {
-          type: 'function',
-          name: 'lookup_account',
-          deferLoading: true,
-        },
-      },
-      {
-        key: 'lookup_account.lookup_account',
-        value: {
-          type: 'function',
-          name: 'lookup_account',
-          deferLoading: true,
-          [FUNCTION_TOOL_NAMESPACE]: 'lookup_account',
-        },
-      },
+    const deferred = {
+      type: 'function',
+      name: 'crm.lookup.detail',
+      deferLoading: true,
+    };
+    const toolsWithDeferred = buildFunctionToolLookupMap([
+      firstNamespaced,
+      secondNamespaced,
+      deferred,
     ]);
 
     expect(
-      resolveFunctionToolCallName(
-        {
-          name: 'lookup_account',
-          namespace: 'lookup_account',
-        },
-        availableToolNames,
-      ),
-    ).toBe('lookup_account');
+      resolveFunctionToolCall({ name: 'crm.lookup.detail' }, toolsWithDeferred),
+    ).toBe(deferred);
   });
 
-  it('prefers the qualified name when the bare tool is not deferred', () => {
-    const availableToolNames = createToolLookup([
-      {
-        key: 'lookup_account',
-        value: {
-          type: 'function',
-          name: 'lookup_account',
-          deferLoading: false,
-        },
-      },
-      {
-        key: 'lookup_account.lookup_account',
-        value: {
-          type: 'function',
-          name: 'lookup_account',
-          deferLoading: true,
-          [FUNCTION_TOOL_NAMESPACE]: 'lookup_account',
-        },
-      },
-    ]);
+  it('accepts legacy bare calls for deferred tools only when no bare tool exists', () => {
+    const deferred = { type: 'function', name: 'lookup', deferLoading: true };
+    const tools = buildFunctionToolLookupMap([deferred]);
 
-    expect(
-      resolveFunctionToolCallName(
-        {
-          name: 'lookup_account',
-          namespace: 'lookup_account',
-        },
-        availableToolNames,
-      ),
-    ).toBe('lookup_account.lookup_account');
+    expect(resolveFunctionToolCall({ name: 'lookup' }, tools)).toBe(deferred);
   });
 
-  it('keeps qualified matches for real namespace calls', () => {
-    const availableToolNames = new Set([
-      'lookup_account',
-      'crm.lookup_account',
-    ]);
+  it('does not route a bare call to a deferred tool when a bare tool exists', () => {
+    const bare = { type: 'function', name: 'lookup' };
+    const deferred = { type: 'function', name: 'lookup', deferLoading: true };
+    const tools = buildFunctionToolLookupMap([deferred, bare]);
+
+    expect(resolveFunctionToolCall({ name: 'lookup' }, tools)).toBe(bare);
+  });
+
+  it('normalizes a resolved deferred bare fallback to its canonical state key', () => {
+    const deferred = { type: 'function', name: 'lookup', deferLoading: true };
 
     expect(
-      resolveFunctionToolCallName(
-        {
-          name: 'lookup_account',
-          namespace: 'crm',
-        },
-        availableToolNames,
-      ),
-    ).toBe('crm.lookup_account');
+      getFunctionToolStateKeyForResolvedCall({ name: 'lookup' }, deferred),
+    ).toBe('["deferred_top_level","lookup"]');
+    expect(
+      getFunctionToolStateKeyForResolvedCall({ name: 'different' }, deferred),
+    ).toBeUndefined();
+  });
+
+  it('keeps released state-key fallbacks when they are unambiguous', () => {
+    const deferred = { type: 'function', name: 'lookup', deferLoading: true };
+    const namespaced = {
+      type: 'function',
+      name: 'lookup',
+      [FUNCTION_TOOL_NAMESPACE]: 'crm',
+    };
+
+    expect(getFunctionToolStateKeys(deferred, [deferred])).toEqual([
+      '["deferred_top_level","lookup"]',
+      'lookup',
+    ]);
+    expect(getFunctionToolStateKeys(namespaced, [namespaced])).toEqual([
+      '["namespaced","crm","lookup"]',
+      'crm.lookup',
+    ]);
+  });
+
+  it('omits released state-key fallbacks when another category owns them', () => {
+    const bare = { type: 'function', name: 'lookup' };
+    const deferred = { type: 'function', name: 'lookup', deferLoading: true };
+    const dotted = { type: 'function', name: 'crm.lookup' };
+    const namespaced = {
+      type: 'function',
+      name: 'lookup',
+      [FUNCTION_TOOL_NAMESPACE]: 'crm',
+    };
+
+    expect(getFunctionToolStateKeys(deferred, [bare, deferred])).toEqual([
+      '["deferred_top_level","lookup"]',
+    ]);
+    expect(getFunctionToolStateKeys(bare, [bare, deferred])).toEqual([
+      '["bare","lookup"]',
+    ]);
+    expect(getFunctionToolStateKeys(namespaced, [dotted, namespaced])).toEqual([
+      '["namespaced","crm","lookup"]',
+    ]);
+    expect(getFunctionToolStateKeys(dotted, [dotted, namespaced])).toEqual([
+      '["bare","crm.lookup"]',
+    ]);
+  });
+
+  it('rejects explicit namespaces reserved for deferred top-level tools', () => {
+    const namespaced = {
+      type: 'function',
+      name: 'lookup',
+      [FUNCTION_TOOL_NAMESPACE]: 'lookup',
+    };
+
+    expect(() => buildFunctionToolLookupMap([namespaced])).toThrow(
+      'Responses tool search reserves same-name namespaces for deferred top-level function tools.',
+    );
   });
 });

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -910,16 +910,38 @@ function expectsObjectArguments(
   return false;
 }
 
-function buildRequestedToolsByName(
-  request: Pick<ModelRequest, 'tools' | 'handoffs'>,
-): Map<string, SerializedTool | SerializedHandoff> {
+function resolveRequestedTools(
+  request: Pick<ModelRequest, 'tools' | 'handoffs'> & {
+    _internal?: { toolNameCollisionPolicy?: 'warn' | 'error' };
+  },
+  logger: ReturnType<typeof getLogger>,
+): {
+  tools: SerializedTool[];
+  handoffs: SerializedHandoff[];
+  toolsByName: Map<string, SerializedTool | SerializedHandoff>;
+} {
   const toolsByName = new Map<string, SerializedTool | SerializedHandoff>();
+  const retainedToolIndices = new Set(request.tools.map((_, index) => index));
+  const retainedHandoffIndices = new Set(
+    request.handoffs.map((_, index) => index),
+  );
+  const routableEntriesByName = new Map<
+    string,
+    {
+      tool: SerializedTool | SerializedHandoff;
+      kind: 'tool' | 'handoff';
+      index: number;
+    }
+  >();
+  const collisionPolicy = request._internal?.toolNameCollisionPolicy ?? 'warn';
 
   const addRequestedTool = (
     name: string,
     tool: SerializedTool | SerializedHandoff,
+    entry: { kind: 'tool' | 'handoff'; index: number },
   ) => {
     const existing = toolsByName.get(name);
+    const existingRoutableEntry = routableEntriesByName.get(name);
     if (
       name === 'tool_search' &&
       existing &&
@@ -929,24 +951,111 @@ function buildRequestedToolsByName(
         'AiSdkModel cannot disambiguate a hosted tool_search helper from a custom tool or handoff that is also named "tool_search". Rename the custom tool or use a different adapter.',
       );
     }
-
+    if (
+      existing &&
+      isFunctionToolOrHandoff(existing) !== isFunctionToolOrHandoff(tool)
+    ) {
+      const remediation =
+        'Assign unique tool names or toolNameOverride values, or use distinct namespaces.';
+      throw new UserError(
+        logger.dontLogToolData
+          ? `AiSdkModel cannot disambiguate tools with the same flattened name. ${remediation}`
+          : `AiSdkModel cannot disambiguate the flattened tool name '${name}'. ${remediation}`,
+      );
+    }
+    if (
+      existing &&
+      !isFunctionToolOrHandoff(existing) &&
+      !isFunctionToolOrHandoff(tool)
+    ) {
+      const remediation = 'Assign unique provider tool names.';
+      throw new UserError(
+        logger.dontLogToolData
+          ? `AiSdkModel cannot disambiguate provider tools with the same flattened name. ${remediation}`
+          : `AiSdkModel cannot disambiguate the flattened provider tool name '${name}'. ${remediation}`,
+      );
+    }
+    if (existingRoutableEntry && isFunctionToolOrHandoff(tool)) {
+      const remediation =
+        'Assign unique tool names or toolNameOverride values, or use distinct namespaces.';
+      const hasStructuredFunctionIdentity =
+        isStructuredFunctionTool(existingRoutableEntry.tool) ||
+        isStructuredFunctionTool(tool);
+      if (hasStructuredFunctionIdentity || collisionPolicy === 'error') {
+        throw new UserError(
+          logger.dontLogToolData
+            ? `AiSdkModel cannot disambiguate function tools and handoffs with the same flattened name. ${remediation}`
+            : `AiSdkModel cannot disambiguate the flattened tool name '${name}'. ${remediation}`,
+        );
+      }
+      logger.warn(
+        logger.dontLogToolData
+          ? `AI SDK tool name collision detected. ${remediation} Only the current dispatch winner will be exposed.`
+          : `AI SDK tool name collision detected for '${name}'. ${remediation} Only the current dispatch winner will be exposed.`,
+      );
+      if (existingRoutableEntry.kind === 'tool') {
+        retainedToolIndices.delete(existingRoutableEntry.index);
+      } else {
+        retainedHandoffIndices.delete(existingRoutableEntry.index);
+      }
+    }
     toolsByName.set(name, tool);
+    if (isFunctionToolOrHandoff(tool)) {
+      routableEntriesByName.set(name, { tool, ...entry });
+    }
   };
 
-  for (const tool of request.tools) {
+  for (const [index, tool] of request.tools.entries()) {
+    if (
+      tool.type === 'function' &&
+      typeof tool.namespace === 'string' &&
+      tool.namespace === tool.name
+    ) {
+      const remediation =
+        'Rename the namespace or tool, or use a Responses model for deferred top-level tools.';
+      throw new UserError(
+        logger.dontLogToolData
+          ? `AiSdkModel cannot route a function tool whose namespace matches its name because that wire shape is reserved for deferred top-level tools. ${remediation}`
+          : `AiSdkModel cannot route the function tool '${tool.name}' because its namespace matches its name and that wire shape is reserved for deferred top-level tools. ${remediation}`,
+      );
+    }
     addRequestedTool(
       tool.type === 'function'
         ? getSerializedFunctionToolName(tool)
         : tool.name,
       tool,
+      { kind: 'tool', index },
     );
   }
 
-  for (const handoff of request.handoffs) {
-    addRequestedTool(handoff.toolName, handoff);
+  for (const [index, handoff] of request.handoffs.entries()) {
+    addRequestedTool(handoff.toolName, handoff, { kind: 'handoff', index });
   }
 
-  return toolsByName;
+  return {
+    tools: request.tools.filter((_, index) => retainedToolIndices.has(index)),
+    handoffs: request.handoffs.filter((_, index) =>
+      retainedHandoffIndices.has(index),
+    ),
+    toolsByName,
+  };
+}
+
+function isFunctionToolOrHandoff(
+  tool: SerializedTool | SerializedHandoff,
+): boolean {
+  return 'toolName' in tool || tool.type === 'function';
+}
+
+function isStructuredFunctionTool(
+  tool: SerializedTool | SerializedHandoff,
+): tool is Extract<SerializedTool, { type: 'function' }> {
+  return (
+    !('toolName' in tool) &&
+    tool.type === 'function' &&
+    ((typeof tool.namespace === 'string' && tool.namespace.length > 0) ||
+      tool.deferLoading === true)
+  );
 }
 
 function isHostedToolSearchTool(
@@ -1122,11 +1231,19 @@ function createProtocolToolCallItem(args: {
   } else {
     toolCallArguments = JSON.stringify(input ?? {});
   }
+  const requestedFunctionTool =
+    requestedTool &&
+    !('toolName' in requestedTool) &&
+    requestedTool.type === 'function'
+      ? requestedTool
+      : undefined;
+  const namespace = requestedFunctionTool?.namespace;
 
   return {
     type: 'function_call',
     callId: toolCallId,
-    name: toolName,
+    name: namespace ? requestedFunctionTool.name : toolName,
+    ...(namespace ? { namespace } : {}),
     arguments: toolCallArguments,
     status: 'completed',
     providerData,
@@ -1794,11 +1911,15 @@ export class AiSdkModel implements Model {
           ];
         }
 
+        const resolvedRequestedTools = resolveRequestedTools(
+          request,
+          this.#logger,
+        );
         const tools = [
-          ...request.tools.map((tool) =>
+          ...resolvedRequestedTools.tools.map((tool) =>
             toolToLanguageV2Tool(this.#model, tool),
           ),
-          ...request.handoffs.map((handoff) =>
+          ...resolvedRequestedTools.handoffs.map((handoff) =>
             handoffToLanguageV2Tool(this.#model, handoff),
           ),
         ];
@@ -1811,7 +1932,7 @@ export class AiSdkModel implements Model {
           throw new UserError('Zod output type is not yet supported');
         }
 
-        const requestedToolsByName = buildRequestedToolsByName(request);
+        const requestedToolsByName = resolvedRequestedTools.toolsByName;
 
         const responseFormat: LanguageModelV2CallOptions['responseFormat'] =
           getResponseFormat(request.outputType);
@@ -2084,9 +2205,15 @@ export class AiSdkModel implements Model {
         ];
       }
 
+      const resolvedRequestedTools = resolveRequestedTools(
+        request,
+        this.#logger,
+      );
       const tools = [
-        ...request.tools.map((tool) => toolToLanguageV2Tool(this.#model, tool)),
-        ...request.handoffs.map((handoff) =>
+        ...resolvedRequestedTools.tools.map((tool) =>
+          toolToLanguageV2Tool(this.#model, tool),
+        ),
+        ...resolvedRequestedTools.handoffs.map((handoff) =>
           handoffToLanguageV2Tool(this.#model, handoff),
         ),
       ];
@@ -2113,7 +2240,7 @@ export class AiSdkModel implements Model {
         abortSignal: request.signal,
         ...(request.modelSettings.providerData ?? {}),
       };
-      const requestedToolsByName = buildRequestedToolsByName(request);
+      const requestedToolsByName = resolvedRequestedTools.toolsByName;
 
       if (this.#logger.dontLogModelData) {
         this.#logger.debug('Request received (streamed)');
@@ -2401,7 +2528,9 @@ export class AiSdkModel implements Model {
       if (span) {
         span.setError({
           message:
-            error instanceof Error ? error.message : 'Error streaming response',
+            request.tracing === true && error instanceof Error
+              ? error.message
+              : 'Unknown error',
           data: {
             error:
               request.tracing === true

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -9,7 +9,21 @@ import {
   toolChoiceToLanguageV2Format,
   toolToLanguageV2Tool,
 } from '../../src/ai-sdk/index';
-import { Agent, protocol, run, withTrace, UserError } from '@openai/agents';
+import {
+  Agent,
+  handoff,
+  protocol,
+  run,
+  tool,
+  toolNamespace,
+  withTrace,
+  UserError,
+  setTraceProcessors,
+  setTracingDisabled,
+  type Span,
+  type Trace,
+  type TracingProcessor,
+} from '@openai/agents';
 import { ReadableStream } from 'node:stream/web';
 import {
   APICallError,
@@ -65,6 +79,19 @@ function partsStream(parts: any[]): ReadableStream<any> {
       }
     })(),
   );
+}
+
+class RecordingTracingProcessor implements TracingProcessor {
+  readonly spansEnded: Span<any>[] = [];
+
+  async onTraceStart(_trace: Trace): Promise<void> {}
+  async onTraceEnd(_trace: Trace): Promise<void> {}
+  async onSpanStart(_span: Span<any>): Promise<void> {}
+  async onSpanEnd(span: Span<any>): Promise<void> {
+    this.spansEnded.push(span);
+  }
+  async shutdown(): Promise<void> {}
+  async forceFlush(): Promise<void> {}
 }
 
 const structuredOutputType: SerializedOutputType = {
@@ -186,6 +213,100 @@ describe('AiSdkModel end-to-end scenarios', () => {
     const result = await run(agent, 'hi');
     expect(result.finalOutput).toEqual({ content: 'structured' });
   });
+
+  test.each(['generate', 'stream'] as const)(
+    'executes namespaced function tools in %s runs',
+    async (mode) => {
+      let turn = 0;
+      const execute = vi.fn(async () => 'account');
+      const [lookupAccount] = toolNamespace({
+        name: 'crm',
+        description: 'CRM tools.',
+        tools: [
+          tool({
+            name: 'lookup_account',
+            description: 'Look up an account.',
+            parameters: z.object({}),
+            execute,
+          }),
+        ],
+      });
+      const languageModel = stubModel({
+        async doGenerate() {
+          turn += 1;
+          return turn === 1
+            ? ({
+                content: [
+                  {
+                    type: 'tool-call',
+                    toolCallId: 'call_lookup_account',
+                    toolName: 'crm.lookup_account',
+                    input: {},
+                  },
+                ],
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                response: { id: 'response_1' },
+                finishReason: 'tool-calls',
+                warnings: [],
+              } as any)
+            : ({
+                content: [{ type: 'text', text: 'Done.' }],
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                response: { id: 'response_2' },
+                finishReason: 'stop',
+                warnings: [],
+              } as any);
+        },
+        async doStream() {
+          turn += 1;
+          return {
+            stream: partsStream(
+              turn === 1
+                ? [
+                    {
+                      type: 'tool-call',
+                      toolCallId: 'call_lookup_account',
+                      toolName: 'crm.lookup_account',
+                      input: {},
+                    },
+                    {
+                      type: 'finish',
+                      finishReason: 'tool-calls',
+                      usage: { inputTokens: 1, outputTokens: 1 },
+                    },
+                  ]
+                : [
+                    { type: 'text-delta', id: 'text-1', delta: 'Done.' },
+                    {
+                      type: 'finish',
+                      finishReason: 'stop',
+                      usage: { inputTokens: 1, outputTokens: 1 },
+                    },
+                  ],
+            ),
+          } as any;
+        },
+      });
+      const agent = new Agent({
+        name: 'Namespaced tool agent',
+        model: new AiSdkModel(languageModel),
+        tools: [lookupAccount!],
+      });
+
+      let finalOutput: string | undefined;
+      if (mode === 'stream') {
+        const result = await run(agent, 'hi', { stream: true });
+        await result.completed;
+        finalOutput = result.finalOutput;
+      } else {
+        const result = await run(agent, 'hi');
+        finalOutput = result.finalOutput;
+      }
+
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(finalOutput).toBe('Done.');
+    },
+  );
 
   test('streams text blocks and tool calls with a stable message ID', async () => {
     const parts = [
@@ -2489,7 +2610,8 @@ describe('AiSdkModel.getResponse', () => {
     expect(res.output).toHaveLength(1);
     expect(res.output[0]).toMatchObject({
       type: 'function_call',
-      name: 'crm.lookup_account',
+      name: 'lookup_account',
+      namespace: 'crm',
       arguments: '{}',
     });
     expect(warnSpy).not.toHaveBeenCalled();
@@ -2845,50 +2967,115 @@ describe('AiSdkModel.getResponse', () => {
     expect(doGenerate).not.toHaveBeenCalled();
   });
 
-  test('keeps same-name namespace tool calls distinct from bare tools in doGenerate', async () => {
-    allowConsole(['warn']);
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  test('rejects flattened namespace and handoff name collisions in doGenerate', async () => {
+    const doGenerate = vi.fn();
     const model = new AiSdkModel(
       stubModel({
-        async doGenerate() {
-          return {
-            content: [
-              {
-                type: 'tool-call',
-                toolCallId: 'call-1',
-                toolName: 'lookup_account.lookup_account',
-                input: '',
-              },
-            ],
-            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-            providerMetadata: { meta: true },
-            response: { id: 'id' },
-            finishReason: 'tool-calls',
-            warnings: [],
-          } as any;
+        async doGenerate(...args: any[]) {
+          return doGenerate(...args);
         },
       }),
     );
 
-    const res = await withTrace('t', () =>
-      model.getResponse({
+    await expect(
+      withTrace('t', () =>
+        model.getResponse({
+          input: 'hi',
+          tools: [
+            {
+              type: 'function',
+              name: 'lookup',
+              namespace: 'crm',
+              description: 'Look up a CRM record.',
+              parameters: {
+                type: 'object',
+                properties: {},
+                additionalProperties: false,
+              },
+            } as any,
+          ],
+          handoffs: [
+            {
+              toolName: 'crm.lookup',
+              toolDescription: 'Handoff with the same flattened name.',
+              inputJsonSchema: {
+                type: 'object',
+                properties: {},
+                additionalProperties: false,
+              },
+              strictJsonSchema: true,
+            },
+          ],
+          modelSettings: {},
+          outputType: 'text',
+          tracing: false,
+          _internal: { toolNameCollisionPolicy: 'error' },
+        } as any),
+      ),
+    ).rejects.toThrow(
+      'AiSdkModel cannot disambiguate function tools and handoffs with the same flattened name.',
+    );
+    expect(doGenerate).not.toHaveBeenCalled();
+  });
+
+  test('rejects flattened deferred and handoff name collisions in doGenerate', async () => {
+    const doGenerate = vi.fn();
+    const model = new AiSdkModel(stubModel({ doGenerate }));
+
+    await expect(
+      withTrace('t', () =>
+        model.getResponse({
+          input: 'hi',
+          tools: [
+            {
+              type: 'function',
+              name: 'lookup',
+              description: 'Deferred lookup.',
+              parameters: {
+                type: 'object',
+                properties: {},
+                additionalProperties: false,
+              },
+              deferLoading: true,
+            } as any,
+          ],
+          handoffs: [
+            {
+              toolName: 'lookup',
+              toolDescription: 'Handoff with the same flattened name.',
+              inputJsonSchema: {
+                type: 'object',
+                properties: {},
+                additionalProperties: false,
+              },
+              strictJsonSchema: true,
+            },
+          ],
+          modelSettings: {},
+          outputType: 'text',
+          tracing: false,
+        } as any),
+      ),
+    ).rejects.toThrow(
+      'AiSdkModel cannot disambiguate function tools and handoffs with the same flattened name.',
+    );
+    expect(doGenerate).not.toHaveBeenCalled();
+  });
+
+  test.each([false, true])(
+    'redacts flattened collision names from AI SDK span errors (stream: %s)',
+    async (stream) => {
+      const secretNamespace = 'SECRET_AI_SDK_TRACE';
+      const processor = new RecordingTracingProcessor();
+      const model = new AiSdkModel(stubModel({}));
+      const request = {
         input: 'hi',
         tools: [
           {
             type: 'function',
-            name: 'lookup_account',
-            description: 'Top-level lookup tool.',
-            parameters: {
-              type: 'object',
-              properties: {},
-              additionalProperties: false,
-            },
-          } as any,
-          {
-            type: 'function',
-            name: 'lookup_account',
-            namespace: 'lookup_account',
-            description: 'Same-name namespace lookup tool.',
+            name: 'lookup',
+            namespace: secretNamespace,
+            description: 'Look up a record.',
             parameters: {
               type: 'object',
               properties: {},
@@ -2896,21 +3083,324 @@ describe('AiSdkModel.getResponse', () => {
             },
           } as any,
         ],
-        handoffs: [],
+        handoffs: [
+          {
+            toolName: `${secretNamespace}.lookup`,
+            toolDescription: 'Conflicting handoff.',
+            inputJsonSchema: {
+              type: 'object',
+              properties: {},
+              additionalProperties: false,
+            },
+            strictJsonSchema: true,
+          },
+        ],
         modelSettings: {},
         outputType: 'text',
-        tracing: false,
-      } as any),
-    );
+        tracing: 'enabled_without_data',
+      } as any;
+      vi.stubEnv('OPENAI_AGENTS_DONT_LOG_TOOL_DATA', '0');
+      vi.stubEnv('OPENAI_AGENTS_DONT_LOG_MODEL_DATA', '0');
+      setTraceProcessors([processor]);
+      setTracingDisabled(false);
 
-    expect(res.output).toHaveLength(1);
-    expect(res.output[0]).toMatchObject({
-      type: 'function_call',
-      name: 'lookup_account.lookup_account',
-      arguments: '{}',
+      try {
+        let callerError: unknown;
+        if (stream) {
+          try {
+            await withTrace('trace-redaction', async () => {
+              for await (const _event of model.getStreamedResponse(request)) {
+                void _event;
+              }
+            });
+          } catch (error) {
+            callerError = error;
+          }
+        } else {
+          try {
+            await withTrace('trace-redaction', () =>
+              model.getResponse(request),
+            );
+          } catch (error) {
+            callerError = error;
+          }
+        }
+
+        expect(callerError).toBeInstanceOf(UserError);
+        expect(String(callerError)).toContain(secretNamespace);
+        const spanErrors = processor.spansEnded
+          .map((span) => span.error)
+          .filter((error) => error !== null);
+        expect(spanErrors.length).toBeGreaterThan(0);
+        expect(JSON.stringify(spanErrors)).not.toContain(secretNamespace);
+      } finally {
+        vi.unstubAllEnvs();
+        setTraceProcessors([]);
+        setTracingDisabled(true);
+      }
+    },
+  );
+
+  test('rejects flattened function and provider tool collisions in doGenerate', async () => {
+    const doGenerate = vi.fn();
+    const model = new AiSdkModel(stubModel({ doGenerate }));
+
+    await expect(
+      withTrace('t', () =>
+        model.getResponse({
+          input: 'hi',
+          tools: [
+            {
+              type: 'function',
+              name: 'lookup',
+              namespace: 'crm',
+              description: 'Look up a CRM record.',
+              parameters: {
+                type: 'object',
+                properties: {},
+                additionalProperties: false,
+              },
+            } as any,
+            {
+              type: 'hosted_tool',
+              name: 'crm.lookup',
+              providerData: { type: 'web_search' },
+            } as any,
+          ],
+          handoffs: [],
+          modelSettings: {},
+          outputType: 'text',
+          tracing: false,
+        } as any),
+      ),
+    ).rejects.toThrow(
+      /AiSdkModel cannot disambiguate (?:tools with the same flattened name|the flattened tool name 'crm\.lookup')/,
+    );
+    expect(doGenerate).not.toHaveBeenCalled();
+  });
+
+  test('rejects duplicate provider tool names before doGenerate', async () => {
+    const doGenerate = vi.fn();
+    const model = new AiSdkModel(stubModel({ doGenerate }));
+    const providerTool = {
+      type: 'hosted_tool',
+      name: 'search',
+      providerData: { type: 'web_search' },
+    } as any;
+
+    await expect(
+      withTrace('t', () =>
+        model.getResponse({
+          input: 'hi',
+          tools: [providerTool, { ...providerTool }],
+          handoffs: [],
+          modelSettings: {},
+          outputType: 'text',
+          tracing: false,
+        } as any),
+      ),
+    ).rejects.toThrow(
+      /AiSdkModel cannot disambiguate (?:provider tools with the same flattened name|the flattened provider tool name 'search')/,
+    );
+    expect(doGenerate).not.toHaveBeenCalled();
+  });
+
+  test('redacts duplicate provider tool names before doGenerate', async () => {
+    const original = process.env.OPENAI_AGENTS_DONT_LOG_TOOL_DATA;
+    process.env.OPENAI_AGENTS_DONT_LOG_TOOL_DATA = '1';
+    const doGenerate = vi.fn();
+    const model = new AiSdkModel(stubModel({ doGenerate }));
+    const secret = 'SECRET_DUPLICATE_PROVIDER_TOOL';
+
+    try {
+      await expect(
+        withTrace('t', () =>
+          model.getResponse({
+            input: 'hi',
+            tools: [
+              {
+                type: 'hosted_tool',
+                name: secret,
+                providerData: { type: 'web_search' },
+              },
+              {
+                type: 'hosted_tool',
+                name: secret,
+                providerData: { type: 'web_search' },
+              },
+            ],
+            handoffs: [],
+            modelSettings: {},
+            outputType: 'text',
+            tracing: false,
+          } as any),
+        ),
+      ).rejects.toThrow(
+        'AiSdkModel cannot disambiguate provider tools with the same flattened name.',
+      );
+      expect(doGenerate).not.toHaveBeenCalled();
+    } finally {
+      if (original === undefined) {
+        delete process.env.OPENAI_AGENTS_DONT_LOG_TOOL_DATA;
+      } else {
+        process.env.OPENAI_AGENTS_DONT_LOG_TOOL_DATA = original;
+      }
+    }
+  });
+
+  test('rejects a default-policy flattened collision before doGenerate', async () => {
+    const doGenerate = vi.fn();
+    const model = new AiSdkModel(stubModel({ doGenerate }));
+    const [lookup] = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup',
+          description: 'Look up a CRM record.',
+          parameters: z.object({}),
+          execute: async () => 'record',
+        }),
+      ],
     });
-    expect(warnSpy).not.toHaveBeenCalled();
-    warnSpy.mockRestore();
+    const lookupHandoff = handoff(new Agent({ name: 'CRM specialist' }), {
+      toolNameOverride: 'crm.lookup',
+    });
+    await expect(
+      run(
+        new Agent({
+          name: 'Routing agent',
+          model,
+          tools: [lookup!],
+          handoffs: [lookupHandoff],
+        }),
+        'hi',
+      ),
+    ).rejects.toThrow(
+      'AiSdkModel cannot disambiguate function tools and handoffs with the same flattened name.',
+    );
+    expect(doGenerate).not.toHaveBeenCalled();
+  });
+
+  test('exposes one winner when the same function tool object is repeated in doGenerate', async () => {
+    allowConsole(['warn']);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const doGenerate = vi.fn(async (_options: any): Promise<any> => ({
+      content: [],
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      response: { id: 'id' },
+      providerMetadata: {},
+      finishReason: 'stop',
+      warnings: [],
+    }));
+    const model = new AiSdkModel(stubModel({ doGenerate }));
+    const duplicateTool = {
+      type: 'function',
+      name: 'duplicate',
+      description: 'Repeated tool object.',
+      parameters: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+    } as any;
+
+    try {
+      await withTrace('t', () =>
+        model.getResponse({
+          input: 'hi',
+          tools: [duplicateTool, duplicateTool],
+          handoffs: [],
+          modelSettings: {},
+          outputType: 'text',
+          tracing: false,
+        } as any),
+      );
+
+      expect(doGenerate.mock.calls[0]![0].tools).toEqual([
+        expect.objectContaining({ name: 'duplicate' }),
+      ]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test('rejects same-name namespaces before doGenerate', async () => {
+    const doGenerate = vi.fn();
+    const model = new AiSdkModel(stubModel({ doGenerate }));
+
+    await expect(
+      withTrace('t', () =>
+        model.getResponse({
+          input: 'hi',
+          tools: [
+            {
+              type: 'function',
+              name: 'lookup_account',
+              namespace: 'lookup_account',
+              description: 'Same-name namespace lookup tool.',
+              parameters: {
+                type: 'object',
+                properties: {},
+                additionalProperties: false,
+              },
+            } as any,
+          ],
+          handoffs: [],
+          modelSettings: {},
+          outputType: 'text',
+          tracing: false,
+        } as any),
+      ),
+    ).rejects.toThrow(
+      /AiSdkModel cannot route (?:a function tool whose namespace matches its name|the function tool 'lookup_account' because its namespace matches its name)/,
+    );
+    expect(doGenerate).not.toHaveBeenCalled();
+  });
+
+  test('redacts same-name namespaces before doGenerate', async () => {
+    const original = process.env.OPENAI_AGENTS_DONT_LOG_TOOL_DATA;
+    process.env.OPENAI_AGENTS_DONT_LOG_TOOL_DATA = '1';
+    const doGenerate = vi.fn();
+    const model = new AiSdkModel(stubModel({ doGenerate }));
+    const secret = 'SECRET_SAME_NAME_NAMESPACE';
+
+    try {
+      await expect(
+        withTrace('t', () =>
+          model.getResponse({
+            input: 'hi',
+            tools: [
+              {
+                type: 'function',
+                name: secret,
+                namespace: secret,
+                description: 'Same-name namespace tool.',
+                parameters: {
+                  type: 'object',
+                  properties: {},
+                  additionalProperties: false,
+                },
+              } as any,
+            ],
+            handoffs: [],
+            modelSettings: {},
+            outputType: 'text',
+            tracing: false,
+          } as any),
+        ),
+      ).rejects.toThrow(
+        'AiSdkModel cannot route a function tool whose namespace matches its name',
+      );
+      expect(doGenerate).not.toHaveBeenCalled();
+    } finally {
+      if (original === undefined) {
+        delete process.env.OPENAI_AGENTS_DONT_LOG_TOOL_DATA;
+      } else {
+        process.env.OPENAI_AGENTS_DONT_LOG_TOOL_DATA = original;
+      }
+    }
   });
 
   test('normalizes empty string tool input for handoff schemas', async () => {
@@ -4986,6 +5476,272 @@ describe('AiSdkModel', () => {
       /cannot disambiguate a hosted tool_search helper from a custom tool or handoff/,
     );
     expect(doStream).not.toHaveBeenCalled();
+  });
+
+  test('rejects flattened namespace and handoff name collisions in streaming mode', async () => {
+    const doStream = vi.fn();
+    const model = new AiSdkModel(
+      stubModel({
+        async doStream(...args: any[]) {
+          return doStream(...args);
+        },
+      }),
+    );
+
+    await expect(async () => {
+      for await (const _event of model.getStreamedResponse({
+        input: 'hi',
+        tools: [
+          {
+            type: 'function',
+            name: 'lookup',
+            namespace: 'crm',
+            description: 'Look up a CRM record.',
+            parameters: {
+              type: 'object',
+              properties: {},
+              additionalProperties: false,
+            },
+          } as any,
+        ],
+        handoffs: [
+          {
+            toolName: 'crm.lookup',
+            toolDescription: 'Handoff with the same flattened name.',
+            inputJsonSchema: {
+              type: 'object',
+              properties: {},
+              additionalProperties: false,
+            },
+            strictJsonSchema: true,
+          },
+        ],
+        modelSettings: {},
+        outputType: 'text',
+        tracing: false,
+        _internal: { toolNameCollisionPolicy: 'error' },
+      } as any)) {
+        void _event;
+      }
+    }).rejects.toThrow(
+      'AiSdkModel cannot disambiguate function tools and handoffs with the same flattened name.',
+    );
+    expect(doStream).not.toHaveBeenCalled();
+  });
+
+  test('rejects flattened deferred and handoff name collisions in streaming mode', async () => {
+    const doStream = vi.fn();
+    const model = new AiSdkModel(stubModel({ doStream }));
+
+    await expect(async () => {
+      for await (const _event of model.getStreamedResponse({
+        input: 'hi',
+        tools: [
+          {
+            type: 'function',
+            name: 'lookup',
+            description: 'Deferred lookup.',
+            parameters: {
+              type: 'object',
+              properties: {},
+              additionalProperties: false,
+            },
+            deferLoading: true,
+          } as any,
+        ],
+        handoffs: [
+          {
+            toolName: 'lookup',
+            toolDescription: 'Handoff with the same flattened name.',
+            inputJsonSchema: {
+              type: 'object',
+              properties: {},
+              additionalProperties: false,
+            },
+            strictJsonSchema: true,
+          },
+        ],
+        modelSettings: {},
+        outputType: 'text',
+        tracing: false,
+      } as any)) {
+        void _event;
+      }
+    }).rejects.toThrow(
+      'AiSdkModel cannot disambiguate function tools and handoffs with the same flattened name.',
+    );
+    expect(doStream).not.toHaveBeenCalled();
+  });
+
+  test('rejects flattened function and provider tool collisions in streaming mode', async () => {
+    const doStream = vi.fn();
+    const model = new AiSdkModel(stubModel({ doStream }));
+
+    await expect(async () => {
+      for await (const _event of model.getStreamedResponse({
+        input: 'hi',
+        tools: [
+          {
+            type: 'function',
+            name: 'lookup',
+            namespace: 'crm',
+            description: 'Look up a CRM record.',
+            parameters: {
+              type: 'object',
+              properties: {},
+              additionalProperties: false,
+            },
+          } as any,
+          {
+            type: 'hosted_tool',
+            name: 'crm.lookup',
+            providerData: { type: 'web_search' },
+          } as any,
+        ],
+        handoffs: [],
+        modelSettings: {},
+        outputType: 'text',
+        tracing: false,
+      } as any)) {
+        void _event;
+      }
+    }).rejects.toThrow(
+      /AiSdkModel cannot disambiguate (?:tools with the same flattened name|the flattened tool name 'crm\.lookup')/,
+    );
+    expect(doStream).not.toHaveBeenCalled();
+  });
+
+  test('rejects duplicate provider tool names before streaming', async () => {
+    const doStream = vi.fn();
+    const model = new AiSdkModel(stubModel({ doStream }));
+    const providerTool = {
+      type: 'hosted_tool',
+      name: 'search',
+      providerData: { type: 'web_search' },
+    } as any;
+
+    await expect(async () => {
+      for await (const _event of model.getStreamedResponse({
+        input: 'hi',
+        tools: [providerTool, { ...providerTool }],
+        handoffs: [],
+        modelSettings: {},
+        outputType: 'text',
+        tracing: false,
+      } as any)) {
+        void _event;
+      }
+    }).rejects.toThrow(
+      /AiSdkModel cannot disambiguate (?:provider tools with the same flattened name|the flattened provider tool name 'search')/,
+    );
+    expect(doStream).not.toHaveBeenCalled();
+  });
+
+  test('rejects a default-policy flattened collision before streaming', async () => {
+    const doStream = vi.fn();
+    const model = new AiSdkModel(stubModel({ doStream }));
+    const [lookup] = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup',
+          description: 'Look up a CRM record.',
+          parameters: z.object({}),
+          execute: async () => 'record',
+        }),
+      ],
+    });
+    const lookupHandoff = handoff(new Agent({ name: 'CRM specialist' }), {
+      toolNameOverride: 'crm.lookup',
+    });
+    const result = await run(
+      new Agent({
+        name: 'Routing agent',
+        model,
+        tools: [lookup!],
+        handoffs: [lookupHandoff],
+      }),
+      'hi',
+      { stream: true },
+    );
+
+    await expect(result.completed).rejects.toThrow(
+      'AiSdkModel cannot disambiguate function tools and handoffs with the same flattened name.',
+    );
+    expect(doStream).not.toHaveBeenCalled();
+  });
+
+  test('rejects same-name namespaces before streaming', async () => {
+    const doStream = vi.fn();
+    const model = new AiSdkModel(stubModel({ doStream }));
+
+    await expect(async () => {
+      for await (const _event of model.getStreamedResponse({
+        input: 'hi',
+        tools: [
+          {
+            type: 'function',
+            name: 'lookup_account',
+            namespace: 'lookup_account',
+            description: 'Same-name namespace lookup tool.',
+            parameters: {
+              type: 'object',
+              properties: {},
+              additionalProperties: false,
+            },
+          } as any,
+        ],
+        handoffs: [],
+        modelSettings: {},
+        outputType: 'text',
+        tracing: false,
+      } as any)) {
+        void _event;
+      }
+    }).rejects.toThrow(
+      /AiSdkModel cannot route (?:a function tool whose namespace matches its name|the function tool 'lookup_account' because its namespace matches its name)/,
+    );
+    expect(doStream).not.toHaveBeenCalled();
+  });
+
+  test('exposes one winner when the same function tool object is repeated in streaming mode', async () => {
+    allowConsole(['warn']);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const doStream = vi.fn(async (_options: any): Promise<any> => ({
+      stream: partsStream([]),
+    }));
+    const model = new AiSdkModel(stubModel({ doStream }));
+    const duplicateTool = {
+      type: 'function',
+      name: 'duplicate',
+      description: 'Repeated tool object.',
+      parameters: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+    } as any;
+
+    try {
+      for await (const _event of model.getStreamedResponse({
+        input: 'hi',
+        tools: [duplicateTool, duplicateTool],
+        handoffs: [],
+        modelSettings: {},
+        outputType: 'text',
+        tracing: false,
+      } as any)) {
+        void _event;
+      }
+
+      expect(doStream.mock.calls[0]![0].tools).toEqual([
+        expect.objectContaining({ name: 'duplicate' }),
+      ]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   describe('parseArguments', () => {

--- a/packages/agents/test/index.test.ts
+++ b/packages/agents/test/index.test.ts
@@ -6,6 +6,7 @@ import type {
   AgentToolOptionsWithDefault,
   AgentToolOptionsWithParameters,
   RunHookEvents,
+  ToolNameCollisionPolicy,
 } from '../src/index';
 import * as Sandbox from '../src/sandbox';
 import * as LocalSandbox from '../src/sandbox/local';
@@ -31,6 +32,7 @@ describe('Exports', () => {
       AgentToolOptionsWithDefault<undefined, TestAgent>,
       AgentToolOptionsWithParameters<undefined, TestAgent, typeof _parameters>,
       AgentTool<undefined, TestAgent, typeof _parameters>,
+      ToolNameCollisionPolicy,
     ];
 
     expectTypeOf<PublicTypes>().not.toBeNever();


### PR DESCRIPTION
This pull request makes model-visible tool and handoff collision handling consistent across serialization, dispatch, tracing, streaming, resume, tool search, and the AI SDK adapter.

It adds deterministic warning-based collision resolution by default, supports an opt-in error policy, preserves namespace-qualified routing, and scopes function-tool approval state to the owning agent so nested agent runs may safely reuse provider call IDs.

RunState persistence and legacy migration preserve approval decisions while validating malformed, duplicate, or unknown owner records. The public RunContext API remains unchanged.