### PR TITLE
fix: preserve inline compaction items across turns

### DIFF
--- a/.changeset/preserve-inline-compaction-items.md
+++ b/.changeset/preserve-inline-compaction-items.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents': patch
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+---
+
+fix: preserve inline compaction items across turns

--- a/docs/src/content/docs/guides/results.mdx
+++ b/docs/src/content/docs/guides/results.mdx
@@ -87,6 +87,9 @@ In practice:
 - [`RunToolCallItem`](/openai-agents-js/openai/agents/classes/runtoolcallitem) and [`RunToolCallOutputItem`](/openai-agents-js/openai/agents/classes/runtoolcalloutputitem) for tool calls and their results.
 - [`RunToolApprovalItem`](/openai-agents-js/openai/agents/classes/runtoolapprovalitem) for tool calls that paused for approval.
 - [`RunHandoffCallItem`](/openai-agents-js/openai/agents/classes/runhandoffcallitem) and [`RunHandoffOutputItem`](/openai-agents-js/openai/agents/classes/runhandoffoutputitem) for handoff requests and completed transfers.
+- [`RunCompactionItem`](/openai-agents-js/openai/agents/classes/runcompactionitem) for inline compaction markers returned when `modelSettings.contextManagement` is enabled.
+
+Both `output` and `history` retain a compaction marker in the order the model returned it, so it stays available for replay to the same provider.
 
 Choose `newItems` over `output` whenever you need to know which agent produced an item or whether it marks a tool, tool-search, handoff, or approval boundary. When you use `toolSearchTool()`, these tool-search items are the easiest way to inspect which deferred tools or namespaces were loaded before the normal tool call happened.
 

--- a/docs/src/content/docs/guides/sessions.mdx
+++ b/docs/src/content/docs/guides/sessions.mdx
@@ -202,3 +202,7 @@ Compaction clears and rewrites the underlying session, so the SDK waits for it b
 />
 
 You can call `runCompaction({ force: true })` at any time to shrink history before archiving or handoff. Enable debug logs with `DEBUG=openai-agents:openai:compaction` to trace compaction decisions.
+
+### Inline compaction is a different mechanism
+
+`modelSettings.contextManagement` asks the Responses API to compact context during an ordinary response, and that response can include a compaction marker among its output items. This does not involve `responses.compact` and does not rewrite anything: the runner keeps the marker in provider order and the session stores it like any other generated item, so nothing is removed from your stored history.

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -96,6 +96,7 @@ export {
 export { assistant, system, user } from './helpers/message';
 export {
   extractAllTextOutput,
+  RunCompactionItem,
   RunHandoffCallItem,
   RunHandoffOutputItem,
   RunItem,

--- a/packages/agents-core/src/items.ts
+++ b/packages/agents-core/src/items.ts
@@ -167,6 +167,24 @@ export class RunReasoningItem extends RunItemBase {
   }
 }
 
+export class RunCompactionItem extends RunItemBase {
+  public readonly type = 'compaction_item' as const;
+
+  constructor(
+    public rawItem: protocol.CompactionItem,
+    public agent: Agent,
+  ) {
+    super();
+  }
+
+  toJSON() {
+    return {
+      ...super.toJSON(),
+      agent: this.agent.toJSON(),
+    };
+  }
+}
+
 export class RunHandoffCallItem extends RunItemBase {
   public readonly type = 'handoff_call_item' as const;
 
@@ -294,6 +312,7 @@ export type RunItem =
   | RunToolSearchCallItem
   | RunToolSearchOutputItem
   | RunReasoningItem
+  | RunCompactionItem
   | RunHandoffCallItem
   | RunToolCallOutputItem
   | RunHandoffOutputItem

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -12,6 +12,7 @@ import {
   RunToolSearchCallItem,
   RunToolSearchOutputItem,
   RunReasoningItem,
+  RunCompactionItem,
   RunHandoffCallItem,
   RunHandoffOutputItem,
 } from './items';
@@ -101,8 +102,9 @@ import {
  *   and optional assistant message phases.
  * - 1.15: Adds reconstructable sandbox environment value references and sandbox
  *   session-state envelope version 2.
+ * - 1.16: Adds compaction items to serialized run state payloads.
  */
-export const CURRENT_SCHEMA_VERSION = '1.15' as const;
+export const CURRENT_SCHEMA_VERSION = '1.16' as const;
 const SUPPORTED_SCHEMA_VERSIONS = [
   '1.0',
   '1.1',
@@ -119,6 +121,7 @@ const SUPPORTED_SCHEMA_VERSIONS = [
   '1.12',
   '1.13',
   '1.14',
+  '1.15',
   CURRENT_SCHEMA_VERSION,
 ] as const;
 type SupportedSchemaVersion = (typeof SUPPORTED_SCHEMA_VERSIONS)[number];
@@ -224,6 +227,11 @@ const itemSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('reasoning_item'),
     rawItem: protocol.ReasoningItem,
+    agent: serializedAgentSchema,
+  }),
+  z.object({
+    type: z.literal('compaction_item'),
+    rawItem: protocol.CompactionItem,
     agent: serializedAgentSchema,
   }),
   z.object({
@@ -1091,6 +1099,10 @@ async function buildRunStateFromString<
     currentSchemaVersion as SupportedSchemaVersion,
     stateJson,
   );
+  assertSchemaVersionSupportsCompactionItems(
+    currentSchemaVersion as SupportedSchemaVersion,
+    stateJson,
+  );
   return buildRunStateFromJson(initialAgent, stateJson, options);
 }
 
@@ -1106,6 +1118,7 @@ function assertSchemaVersionSupportsToolSearch(
     schemaVersion === '1.12' ||
     schemaVersion === '1.13' ||
     schemaVersion === '1.14' ||
+    schemaVersion === '1.15' ||
     schemaVersion === CURRENT_SCHEMA_VERSION
   ) {
     return;
@@ -1127,6 +1140,7 @@ function assertSchemaVersionSupportsCustomData(
   if (
     schemaVersion === '1.13' ||
     schemaVersion === '1.14' ||
+    schemaVersion === '1.15' ||
     schemaVersion === CURRENT_SCHEMA_VERSION
   ) {
     return;
@@ -1150,6 +1164,7 @@ function schemaVersionSupportsAgentIdentity(
     schemaVersion === '1.12' ||
     schemaVersion === '1.13' ||
     schemaVersion === '1.14' ||
+    schemaVersion === '1.15' ||
     schemaVersion === CURRENT_SCHEMA_VERSION
   );
 }
@@ -1158,7 +1173,11 @@ function assertSchemaVersionSupportsProgrammaticToolCalling(
   schemaVersion: SupportedSchemaVersion,
   stateJson: z.infer<typeof SerializedRunState>,
 ): void {
-  if (schemaVersion === '1.14' || schemaVersion === CURRENT_SCHEMA_VERSION) {
+  if (
+    schemaVersion === '1.14' ||
+    schemaVersion === '1.15' ||
+    schemaVersion === CURRENT_SCHEMA_VERSION
+  ) {
     return;
   }
 
@@ -1175,7 +1194,11 @@ function assertSchemaVersionSupportsSandboxSessionEnvelope(
   schemaVersion: SupportedSchemaVersion,
   stateJson: z.infer<typeof SerializedRunState>,
 ): void {
-  if (schemaVersion === CURRENT_SCHEMA_VERSION || !stateJson.sandbox) {
+  if (
+    schemaVersion === '1.15' ||
+    schemaVersion === CURRENT_SCHEMA_VERSION ||
+    !stateJson.sandbox
+  ) {
     return;
   }
 
@@ -1196,6 +1219,43 @@ function assertSchemaVersionSupportsSandboxSessionEnvelope(
   throw new UserError(
     `Run state schema version ${schemaVersion} does not support sandbox session state version ${SANDBOX_SESSION_STATE_VERSION}. Please reserialize the run state with schema ${CURRENT_SCHEMA_VERSION}.`,
   );
+}
+
+/**
+ * Rejects payloads declaring a pre-1.16 schema that carry a `compaction_item` run item. Inspects
+ * only that wrapper, never raw `compaction` output in `modelResponses`: earlier writers wrote the
+ * raw output without a wrapper, and those snapshots still resume correctly.
+ */
+function assertSchemaVersionSupportsCompactionItems(
+  schemaVersion: SupportedSchemaVersion,
+  stateJson: z.infer<typeof SerializedRunState>,
+): void {
+  if (schemaVersion === CURRENT_SCHEMA_VERSION) {
+    return;
+  }
+
+  if (!containsSerializedCompactionRunItems(stateJson)) {
+    return;
+  }
+
+  throw new UserError(
+    `Run state schema version ${schemaVersion} does not support compaction items. Please reserialize the run state with schema ${CURRENT_SCHEMA_VERSION}.`,
+  );
+}
+
+function containsSerializedCompactionRunItems(
+  stateJson: z.infer<typeof SerializedRunState>,
+): boolean {
+  return (
+    containsCompactionRunItems(stateJson.generatedItems) ||
+    containsCompactionRunItems(stateJson.lastProcessedResponse?.newItems)
+  );
+}
+
+function containsCompactionRunItems(
+  items: z.infer<typeof itemSchema>[] | undefined,
+): boolean {
+  return Boolean(items?.some((item) => item.type === 'compaction_item'));
 }
 
 function containsProgrammaticToolCallingState(
@@ -2089,6 +2149,11 @@ export function deserializeItem(
       );
     case 'reasoning_item':
       return new RunReasoningItem(
+        serializedItem.rawItem,
+        resolveSerializedAgent(serializedItem.agent, agentMap),
+      );
+    case 'compaction_item':
+      return new RunCompactionItem(
         serializedItem.rawItem,
         resolveSerializedAgent(serializedItem.agent, agentMap),
       );

--- a/packages/agents-core/src/runner/modelOutputs.ts
+++ b/packages/agents-core/src/runner/modelOutputs.ts
@@ -2,6 +2,7 @@ import { Agent } from '../agent';
 import { ModelBehaviorError } from '../errors';
 import { Handoff } from '../handoff';
 import {
+  RunCompactionItem,
   RunHandoffCallItem,
   RunItem,
   RunMessageOutputItem,
@@ -922,6 +923,8 @@ export function processModelResponse<TContext>(
       }
     } else if (output.type === 'reasoning') {
       items.push(new RunReasoningItem(output, agent));
+    } else if (output.type === 'compaction') {
+      items.push(new RunCompactionItem(output, agent));
     } else if (output.type === 'computer_call') {
       handleToolCallAction({
         output,
@@ -1281,6 +1284,8 @@ export async function processModelResponseAsync<TContext>(
       }
     } else if (output.type === 'reasoning') {
       items.push(new RunReasoningItem(output, agent));
+    } else if (output.type === 'compaction') {
+      items.push(new RunCompactionItem(output, agent));
     } else if (output.type === 'computer_call') {
       handleToolCallAction({
         output,

--- a/packages/agents-core/src/runner/streaming.ts
+++ b/packages/agents-core/src/runner/streaming.ts
@@ -1,6 +1,7 @@
 import logger from '../logger';
 import { RunItemStreamEvent, RunItemStreamEventName } from '../events';
 import {
+  RunCompactionItem,
   RunHandoffCallItem,
   RunHandoffOutputItem,
   RunItem,
@@ -55,6 +56,11 @@ function enqueueRunItemStreamEvent(
   result: StreamedRunResult<any, any>,
   item: RunItem,
 ): void {
+  // Compaction is intentionally not a high-level run-item event; it stays observable through
+  // raw model events and the completed result.
+  if (item instanceof RunCompactionItem) {
+    return;
+  }
   const itemName = getRunItemStreamEventName(item);
   if (!itemName) {
     if (logger.dontLogModelData || logger.dontLogToolData) {

--- a/packages/agents-core/src/types/protocol.ts
+++ b/packages/agents-core/src/types/protocol.ts
@@ -834,9 +834,11 @@ export type ReasoningItem = z.infer<typeof ReasoningItem>;
 export const CompactionItem = ItemBase.extend({
   type: z.literal('compaction'),
   /**
-   * Encrypted payload returned by the compaction endpoint.
+   * Encrypted payload used by providers that expose one, such as the OpenAI Responses
+   * compaction item. Providers that represent a compaction checkpoint differently keep
+   * their replay data in `providerData` instead.
    */
-  encrypted_content: z.string(),
+  encrypted_content: z.string().optional(),
   /**
    * Identifier for the compaction item.
    */

--- a/packages/agents-core/test/index.test.ts
+++ b/packages/agents-core/test/index.test.ts
@@ -22,6 +22,7 @@ describe('index.ts', () => {
     expect(agent).toBeDefined();
     expect(agent.name).toEqual('TestAgent');
     expect(typeof AgentsCore.setSensitiveDataLoggingEnabled).toBe('function');
+    expect(typeof AgentsCore.RunCompactionItem).toBe('function');
   });
 
   test('exposes public lifecycle and agent tool types', () => {

--- a/packages/agents-core/test/items.test.ts
+++ b/packages/agents-core/test/items.test.ts
@@ -6,6 +6,7 @@ import {
   RunHandoffCallItem as HandoffCallItem,
   RunHandoffOutputItem as HandoffOutputItem,
   RunMessageOutputItem as MessageOutputItem,
+  RunCompactionItem as CompactionItem,
   RunReasoningItem as ReasoningItem,
   RunToolApprovalItem as ToolApprovalItem,
   RunToolCallItem as ToolCallItem,
@@ -213,6 +214,27 @@ describe('items toJSON()', () => {
     it('returns the correct JSON', () => {
       expect(item.toJSON()).toEqual({
         type: 'reasoning_item',
+        rawItem: item.rawItem,
+        agent: item.agent.toJSON(),
+      });
+    });
+  });
+
+  describe('CompactionItem', () => {
+    const item = new CompactionItem(
+      {
+        id: 'cmp_1',
+        type: 'compaction',
+        encrypted_content: 'ciphertext',
+        created_by: 'compaction_endpoint',
+        providerData: { extra: 'value' },
+      },
+      new Agent({ name: 'TestAgent' }),
+    );
+
+    it('returns the correct JSON', () => {
+      expect(item.toJSON()).toEqual({
+        type: 'compaction_item',
         rawItem: item.rawItem,
         agent: item.agent.toJSON(),
       });

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -295,6 +295,62 @@ describe('Runner.run (streaming)', () => {
     expect((result.error as Error).message).toBe('Not implemented');
   });
 
+  it('retains a streamed compaction item without a high-level run item event', async () => {
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_stream',
+      encrypted_content: 'ciphertext',
+    };
+
+    class CompactionStreamingModel implements Model {
+      async getResponse(_request: ModelRequest): Promise<ModelResponse> {
+        throw new Error('Unexpected non-streaming model request');
+      }
+
+      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
+        yield {
+          type: 'model',
+          event: { type: 'response.output_item.added', item: compaction },
+        } as StreamEvent;
+        yield {
+          type: 'response_done',
+          response: {
+            id: 'resp-compaction-stream',
+            usage: {
+              requests: 1,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            output: [compaction, fakeModelMessage('streamed done')],
+          },
+        } as StreamEvent;
+      }
+    }
+
+    const agent = new Agent({
+      name: 'StreamingCompactionAgent',
+      model: new CompactionStreamingModel(),
+    });
+    const result = await run(agent, 'hi', { stream: true });
+
+    const events: RunStreamEvent[] = [];
+    for await (const event of result) {
+      events.push(event);
+    }
+    await result.completed;
+
+    expect(result.finalOutput).toBe('streamed done');
+    expect(result.newItems.map((item) => item.type)).toEqual([
+      'compaction_item',
+      'message_output_item',
+    ]);
+    expect(result.history).toContainEqual(compaction);
+    expect(
+      events.some((event) => event.type === 'raw_model_stream_event'),
+    ).toBe(true);
+  });
+
   it('treats prior tool_search outputs in input history as loaded deferred tools', async () => {
     class QueueStreamingModel implements Model {
       constructor(private readonly responses: ModelResponse[]) {}

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -50,6 +50,8 @@ import {
   RunToolSearchCallItem,
   RunToolSearchOutputItem,
 } from '../src/items';
+// Aliased because a `describe('sessions')` block below declares its own MemorySession double.
+import { MemorySession as CoreMemorySession } from '../src/memory/memorySession';
 import { getTurnInput, selectModel } from '../src/run';
 import { RunContext } from '../src/runContext';
 import { RunState } from '../src/runState';
@@ -8298,6 +8300,117 @@ describe('Runner.run', () => {
         type: 'function_call_result',
         callId: 'call-1',
       });
+    });
+  });
+
+  describe('inline compaction items', () => {
+    class RecordingModel extends FakeModel {
+      readonly requests: ModelRequest[] = [];
+
+      override async getResponse(
+        request: ModelRequest,
+      ): Promise<ModelResponse> {
+        this.requests.push(request);
+        return super.getResponse(request);
+      }
+    }
+
+    const COMPACTION_ITEM: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_inline',
+      encrypted_content: 'ciphertext',
+      created_by: 'compaction_endpoint',
+      providerData: { extra: 'value' },
+    };
+
+    it('replays a compaction marker and the full prefix on the next request', async () => {
+      const lookup = tool({
+        name: 'lookup',
+        description: 'Look something up.',
+        parameters: z.object({}),
+        execute: async () => 'tool result payload',
+      });
+      const model = new RecordingModel([
+        {
+          output: [
+            COMPACTION_ITEM,
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              name: 'lookup',
+              callId: 'call_lookup',
+              arguments: '{}',
+            },
+          ],
+          usage: new Usage(),
+        },
+        { output: [fakeModelMessage('done')], usage: new Usage() },
+      ]);
+      const agent = new Agent({
+        name: 'CompactionAgent',
+        model,
+        tools: [lookup],
+      });
+
+      const result = await run(agent, [user('identifiable old user input')]);
+
+      expect(result.finalOutput).toBe('done');
+      expect(model.requests).toHaveLength(2);
+
+      const secondInput = getRequestInputItems(model.requests[1]);
+      expect(secondInput).toHaveLength(4);
+      expect(getFirstTextContent(secondInput[0])).toBe(
+        'identifiable old user input',
+      );
+      expect(secondInput[1]).toEqual(COMPACTION_ITEM);
+      expect(secondInput[2]).toMatchObject({
+        type: 'function_call',
+        callId: 'call_lookup',
+      });
+      expect(secondInput[3]).toMatchObject({
+        type: 'function_call_result',
+        callId: 'call_lookup',
+      });
+
+      expect(result.output).toContainEqual(COMPACTION_ITEM);
+      expect(getFirstTextContent(result.history[0])).toBe(
+        'identifiable old user input',
+      );
+      expect(result.history).toContainEqual(COMPACTION_ITEM);
+    });
+
+    it('appends a compaction marker to an ordinary session without clearing history', async () => {
+      const session = new CoreMemorySession({
+        initialItems: [user('earlier stored input')],
+      });
+      const clearSession = vi.spyOn(session, 'clearSession');
+      const model = new RecordingModel([
+        {
+          output: [COMPACTION_ITEM, fakeModelMessage('first turn done')],
+          usage: new Usage(),
+        },
+        { output: [fakeModelMessage('second turn done')], usage: new Usage() },
+      ]);
+      const agent = new Agent({
+        name: 'SessionCompactionAgent',
+        model,
+      });
+
+      await run(agent, 'new user input', { session });
+
+      expect(clearSession).not.toHaveBeenCalled();
+      const stored = await session.getItems();
+      expect(getFirstTextContent(stored[0])).toBe('earlier stored input');
+      expect(stored).toContainEqual(COMPACTION_ITEM);
+
+      // A later logical run over the same session replays the stored prefix and marker.
+      await run(agent, 'later user input', { session });
+
+      const laterInput = getRequestInputItems(model.requests[1]);
+      expect(getFirstTextContent(laterInput[0])).toBe('earlier stored input');
+      expect(laterInput).toContainEqual(COMPACTION_ITEM);
+      expect(getFirstTextContent(laterInput[laterInput.length - 1])).toBe(
+        'later user input',
+      );
     });
   });
 

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -13,6 +13,7 @@ import { Agent } from '../src/agent';
 import { Usage } from '../src/usage';
 import {
   RunToolApprovalItem as ToolApprovalItem,
+  RunCompactionItem,
   RunMessageOutputItem,
   RunReasoningItem,
   RunToolCallItem,
@@ -1125,6 +1126,73 @@ describe('RunState', () => {
     await expect(
       RunState.fromString(agent, JSON.stringify(serialized)),
     ).rejects.toThrow('does not support Programmatic Tool Calling items');
+  });
+
+  describe('compaction items', () => {
+    const compactionItem: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_1',
+      encrypted_content: 'ciphertext',
+      created_by: 'compaction_endpoint',
+      providerData: { extra: 'value' },
+    };
+
+    function stateWithCompaction(agent: Agent<any, any>) {
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      state._generatedItems.push(new RunCompactionItem(compactionItem, agent));
+      state._modelResponses = [
+        {
+          usage: new Usage(),
+          output: [compactionItem],
+          responseId: 'response-compaction',
+        },
+      ];
+      return state;
+    }
+
+    it('round-trips a compaction run item at the current schema version', async () => {
+      const agent = new Agent({ name: 'CompactionStateAgent' });
+      const serialized = stateWithCompaction(agent).toJSON();
+      expect(serialized.$schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+      const restoredItem = restored._generatedItems[0] as RunCompactionItem;
+      expect(restoredItem).toBeInstanceOf(RunCompactionItem);
+      expect(restoredItem.rawItem).toEqual(compactionItem);
+      expect(restoredItem.agent.name).toBe('CompactionStateAgent');
+      expect(restored._modelResponses[0]?.output[0]).toEqual(compactionItem);
+    });
+
+    // A pre-1.16 writer recorded the raw compaction output but had no run item for it, so its
+    // snapshots have the marker in modelResponses and nothing in generatedItems. Resuming that
+    // is harmless while this release keeps the full transcript: the turn simply replays the
+    // untrimmed prefix and loses only the compaction savings. Do not reject it.
+    it('resumes a legacy snapshot whose compaction marker was never recorded as a run item', async () => {
+      const agent = new Agent({ name: 'LegacyCompactionAgent' });
+      const serialized = stateWithCompaction(agent).toJSON() as any;
+      serialized.generatedItems = [];
+      serialized.$schemaVersion = '1.15';
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+      expect(restored._generatedItems).toEqual([]);
+      expect(restored._modelResponses[0]?.output[0]).toEqual(compactionItem);
+    });
+
+    it('rejects a payload that declares an older schema but carries a compaction run item', async () => {
+      const agent = new Agent({ name: 'MislabeledCompactionAgent' });
+      const serialized = stateWithCompaction(agent).toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow('does not support compaction items');
+    });
   });
 
   it('rejects pre-1.14 state with program-owned hosted calls', async () => {

--- a/packages/agents-core/test/runner/modelOutputs.test.ts
+++ b/packages/agents-core/test/runner/modelOutputs.test.ts
@@ -5,6 +5,7 @@ import { Agent } from '../../src/agent';
 import { ModelBehaviorError, UserError } from '../../src/errors';
 import { handoff } from '../../src/handoff';
 import {
+  RunCompactionItem as CompactionItem,
   RunHandoffCallItem as HandoffCallItem,
   RunMessageOutputItem as MessageOutputItem,
   RunReasoningItem as ReasoningItem,
@@ -684,6 +685,111 @@ describe('processModelResponse', () => {
       TEST_MODEL_RESPONSE_WITH_FUNCTION.output[1],
     );
     expect(result.hasToolsOrApprovalsToRun()).toBe(true);
+  });
+
+  it('parses both OpenAI and provider-neutral compaction protocol items', () => {
+    expect(
+      protocol.CompactionItem.parse({
+        type: 'compaction',
+        id: 'cmp_1',
+        encrypted_content: 'ciphertext',
+        created_by: 'compaction_endpoint',
+      }),
+    ).toMatchObject({ type: 'compaction', encrypted_content: 'ciphertext' });
+
+    expect(
+      protocol.CompactionItem.parse({
+        type: 'compaction',
+        providerData: { provider: 'example', summary: 'earlier turns' },
+      }),
+    ).toEqual({
+      type: 'compaction',
+      providerData: { provider: 'example', summary: 'earlier turns' },
+    });
+  });
+
+  it('classifies compaction items as run items in provider order', () => {
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_1',
+      encrypted_content: 'ciphertext',
+    };
+    const modelResponse: ModelResponse = {
+      output: [compaction, TEST_MODEL_MESSAGE],
+      usage: new Usage(),
+    };
+
+    const result = processModelResponse(modelResponse, TEST_AGENT, [], []);
+
+    expect(result.newItems.map((item) => item.type)).toEqual([
+      'compaction_item',
+      'message_output_item',
+    ]);
+    expect(result.newItems[0]).toBeInstanceOf(CompactionItem);
+    expect(result.newItems[0].rawItem).toEqual(compaction);
+    expect(result.toolsUsed).toEqual([]);
+    expect(result.hasToolsOrApprovalsToRun()).toBe(false);
+  });
+
+  it('classifies compaction items on the custom client tool_search async path', async () => {
+    // processModelResponseAsync delegates to processModelResponse unless BOTH a custom
+    // client-side tool_search executor is configured AND the response actually contains a
+    // matching client tool_search call, so the fixture needs both to reach its own loop.
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: {
+          type: 'tool_search',
+          execution: 'client',
+          parameters: {
+            type: 'object',
+            properties: {},
+            additionalProperties: false,
+          },
+        },
+      },
+      vi.fn().mockResolvedValue([]),
+    );
+    const toolSearchCall = {
+      type: 'tool_search_call',
+      id: 'ts_call_async',
+      status: 'completed',
+      arguments: {},
+      providerData: {
+        call_id: 'call_tool_search_async',
+        execution: 'client',
+      },
+    } as unknown as protocol.ToolSearchCallItem;
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_async',
+      encrypted_content: 'ciphertext',
+    };
+    const agent = new Agent({ name: 'CompactionAsyncAgent' });
+    const state = new RunState(new RunContext(), 'hello', agent, 3);
+
+    const result = await processModelResponseAsync(
+      {
+        output: [toolSearchCall, compaction, TEST_MODEL_MESSAGE],
+        usage: new Usage(),
+      },
+      agent,
+      [clientToolSearch],
+      [],
+      state,
+      [],
+    );
+
+    expect(result.newItems.map((item) => item.type)).toEqual([
+      'tool_search_call_item',
+      'tool_search_output_item',
+      'compaction_item',
+      'message_output_item',
+    ]);
+    const compactionRunItem = result.newItems[2];
+    expect(compactionRunItem).toBeInstanceOf(CompactionItem);
+    expect(compactionRunItem.rawItem).toEqual(compaction);
   });
 
   it('classifies tool search items as run items and records tool usage', () => {

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -11,6 +11,7 @@ import { Agent, AgentOutputType } from '../../src/agent';
 import { saveAgentToolRunResult } from '../../src/agentToolRunResults';
 import { getAgentToolParentRunConfigFromDetails } from '../../src/agentToolRunConfig';
 import {
+  RunCompactionItem as CompactionItem,
   RunHandoffCallItem as HandoffCallItem,
   RunHandoffOutputItem as HandoffOutputItem,
   RunMessageOutputItem as MessageOutputItem,
@@ -764,6 +765,12 @@ describe('addStepToRunResult', () => {
       agent,
     );
 
+    // Compaction is deliberately silent: no event name and no unknown-item warning.
+    const compactionItem = new CompactionItem(
+      { type: 'compaction', id: 'cmp_1', encrypted_content: 'ciphertext' },
+      agent,
+    );
+
     const step: any = {
       newStepItems: [
         messageItem,
@@ -774,11 +781,13 @@ describe('addStepToRunResult', () => {
         toolCallItem,
         toolOutputItem,
         reasoningItem,
+        compactionItem,
       ],
     };
 
     const streamedResult = new StreamedRunResult();
     const captured: { name: string; item: any }[] = [];
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
 
     (streamedResult as any)._addItem = (evt: any) => captured.push(evt);
 
@@ -796,6 +805,8 @@ describe('addStepToRunResult', () => {
       'tool_output',
       'reasoning_item_created',
     ]);
+    expect(warnSpy).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
   });
 
   it('does not re-emit items that were already streamed', () => {

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -29,6 +29,7 @@ import {
   ToolGuardrailFunctionOutputFactory,
   withTrace,
   tool,
+  user,
   type Span,
   type Trace,
   type TracingProcessor,
@@ -52,6 +53,7 @@ import {
 import {
   Capability,
   Entry,
+  compaction,
   EnvValueReference,
   filesystem,
   isEnvValueReference,
@@ -59,6 +61,7 @@ import {
   memory,
   type MemoryStore,
   SANDBOX_SESSION_STATE_VERSION,
+  StaticCompactionPolicy,
   registerEnvValueReference,
   shell,
   skills,
@@ -1060,6 +1063,56 @@ describe('sandbox runner integration', () => {
       (normalizedInit.manifest.entries['init.txt'] as { content: string })
         .content,
     ).toBe('init');
+  });
+
+  it('trims context before a model-produced compaction marker on the next turn', async () => {
+    const client = new FakeSandboxClient();
+    const lookup = tool({
+      name: 'lookup',
+      description: 'Look something up.',
+      parameters: z.object({}),
+      execute: async () => 'tool result',
+    });
+    const model = new RecordingFakeModel([
+      {
+        output: [
+          {
+            type: 'compaction',
+            encrypted_content: 'compacted-up-to-here',
+          } as protocol.CompactionItem,
+          {
+            type: 'function_call',
+            id: 'fc_lookup',
+            callId: 'call_lookup',
+            name: 'lookup',
+            status: 'completed',
+            arguments: '{}',
+          } as protocol.FunctionCallItem,
+        ],
+        usage: new Usage(),
+      },
+      { output: [fakeModelMessage('sandbox done')], usage: new Usage() },
+    ]);
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model,
+      tools: [lookup],
+      capabilities: [compaction({ policy: new StaticCompactionPolicy(123) })],
+    });
+
+    const runner = new Runner({ sandbox: { client } });
+    const result = await runner.run(sandboxAgent, [user('old-user')]);
+
+    expect(result.finalOutput).toBe('sandbox done');
+    // Turn 1 sends the untrimmed input. The model returns a compaction marker, which the runner
+    // now retains, so turn 2 is trimmed to start at that marker instead of replaying 'old-user'.
+    expect(model.requests[0].input).toEqual([user('old-user')]);
+    const secondInput = model.requests[1].input as protocol.ModelItem[];
+    expect(secondInput[0]).toMatchObject({ type: 'compaction' });
+    expect(secondInput.some((item) => item.type === 'message')).toBe(false);
+    expect(model.requests[1].modelSettings.providerData).toMatchObject({
+      context_management: [{ type: 'compaction', compact_threshold: 123 }],
+    });
   });
 
   it('passes object RunConfig model overrides into sandbox capability sampling', async () => {

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -4702,6 +4702,67 @@ describe('OpenAIResponsesModel', () => {
     });
   });
 
+  describe('compaction items', () => {
+    function fakeClientWithResponse(response: unknown) {
+      const createMock = vi.fn().mockResolvedValue(response);
+      return {
+        createMock,
+        client: {
+          responses: { create: createMock },
+        } as unknown as OpenAI,
+      };
+    }
+
+    const baseRequest = {
+      systemInstructions: undefined,
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    it('rejects a compaction input item without ciphertext before calling the client', async () => {
+      const { client, createMock } = fakeClientWithResponse({
+        id: 'unused',
+        usage: {},
+        output: [],
+      });
+      const model = new OpenAIResponsesModel(client, 'gpt-test');
+
+      await expect(
+        withTrace('test', () =>
+          model.getResponse({
+            ...baseRequest,
+            input: [
+              {
+                type: 'compaction',
+                providerData: { provider: 'example', summary: 'earlier turns' },
+              },
+            ],
+          } as any),
+        ),
+      ).rejects.toThrow('Compaction item missing encrypted_content');
+      expect(createMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects a malformed provider compaction output item', async () => {
+      const { client } = fakeClientWithResponse({
+        id: 'res-compaction-malformed',
+        usage: {},
+        output: [{ type: 'compaction', id: 'cmp_bad' }],
+      });
+      const model = new OpenAIResponsesModel(client, 'gpt-test');
+
+      await expect(
+        withTrace('test', () =>
+          model.getResponse({ ...baseRequest, input: 'hello' } as any),
+        ),
+      ).rejects.toThrow('Compaction item missing encrypted_content');
+    });
+  });
+
   it('getStreamedResponse records span errors and rethrows when streaming fails', async () => {
     setTracingDisabled(false);
     const createdEvent: OpenAIResponseStreamEvent = {

--- a/packages/agents/test/index.test.ts
+++ b/packages/agents/test/index.test.ts
@@ -19,6 +19,7 @@ describe('Exports', () => {
     const agent = new Agents.Agent({ name: 'Test' });
     expect(agent.name).toBe('Test');
     expect(typeof Agents.setSensitiveDataLoggingEnabled).toBe('function');
+    expect(typeof Agents.RunCompactionItem).toBe('function');
   });
 
   test('lifecycle and agent tool types are out there', () => {


### PR DESCRIPTION
### Summary

Inline compaction items returned by the Responses API were previously ignored while converting model output into run items. As a result, compaction markers were absent from run results and session history and could not be replayed on subsequent turns.

- Preserve inline Responses API compaction items as `RunCompactionItem` values so results, histories, sessions, and subsequent turns can replay them in provider order.
- Serialize compaction run items in RunState schema 1.16 while continuing to accept legacy 1.15 snapshots that contain only raw model output.
- Keep `encrypted_content` required, matching the released public protocol type and OpenAI's compaction input contract.
- Document inline compaction behavior and cover non-streaming, streaming, session, sandbox, provider, export, and serialization paths.

### Test plan

- Ran `.agents/skills/code-change-verification/scripts/run.sh` successfully, including frozen-lockfile install, build, recursive build checks, distribution checks, lint, unit tests, and changed-file formatting.
- Validated the changeset with the repository's `changeset-validation` workflow; all three affected packages receive patch bumps.

### Issue number

N/A — no related issue found.

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration` [(see details)](https://github.com/openai/openai-agents-js/tree/main/integration-tests)
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
- [x] I've added a changeset using `pnpm changeset` to indicate my changes
