### PR TITLE
fix: preserve inline compaction items across turns

### DIFF
--- a/.changeset/preserve-inline-compaction-items.md
+++ b/.changeset/preserve-inline-compaction-items.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents': patch
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+---
+
+fix: preserve inline compaction items across turns

--- a/packages/agents-core/src/events.ts
+++ b/packages/agents-core/src/events.ts
@@ -42,6 +42,7 @@ export type RunItemStreamEventName =
   | 'tool_called'
   | 'tool_output'
   | 'reasoning_item_created'
+  | 'compaction_item_created'
   | 'tool_approval_requested';
 
 /**
@@ -77,6 +78,4 @@ export class RunAgentUpdatedStreamEvent {
  * A streaming event from an agent run.
  */
 export type RunStreamEvent =
-  | RunRawModelStreamEvent
-  | RunItemStreamEvent
-  | RunAgentUpdatedStreamEvent;
+  RunRawModelStreamEvent | RunItemStreamEvent | RunAgentUpdatedStreamEvent;

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -96,6 +96,7 @@ export {
 export { assistant, system, user } from './helpers/message';
 export {
   extractAllTextOutput,
+  RunCompactionItem,
   RunHandoffCallItem,
   RunHandoffOutputItem,
   RunItem,

--- a/packages/agents-core/src/items.ts
+++ b/packages/agents-core/src/items.ts
@@ -167,6 +167,27 @@ export class RunReasoningItem extends RunItemBase {
   }
 }
 
+/**
+ * A compaction marker returned by a model.
+ */
+export class RunCompactionItem extends RunItemBase {
+  public readonly type = 'compaction_item' as const;
+
+  constructor(
+    public rawItem: protocol.CompactionItem,
+    public agent: Agent,
+  ) {
+    super();
+  }
+
+  toJSON() {
+    return {
+      ...super.toJSON(),
+      agent: this.agent.toJSON(),
+    };
+  }
+}
+
 export class RunHandoffCallItem extends RunItemBase {
   public readonly type = 'handoff_call_item' as const;
 
@@ -292,6 +313,7 @@ export type RunItem =
   | RunToolSearchCallItem
   | RunToolSearchOutputItem
   | RunReasoningItem
+  | RunCompactionItem
   | RunHandoffCallItem
   | RunToolCallOutputItem
   | RunHandoffOutputItem

--- a/packages/agents-core/src/memory/session.ts
+++ b/packages/agents-core/src/memory/session.ts
@@ -47,6 +47,17 @@ export interface Session {
   prepareHistoryItemForModelInput?(item: AgentInputItem): AgentInputItem;
 
   /**
+   * Optionally normalize stored and expected history before persistence reconciliation compares
+   * them.
+   *
+   * Session implementations can use this to remove backend-assigned metadata while preserving
+   * their public `getItems()` shape.
+   */
+  prepareHistoryItemsForPersistenceComparison?(
+    items: AgentInputItem[],
+  ): AgentInputItem[];
+
+  /**
    * Optionally preserve reasoning item IDs when persisting generated output.
    *
    * Some remote session stores require provider-assigned reasoning identities to accept stored
@@ -60,6 +71,16 @@ export interface Session {
    * @param items - Items to add to the session history.
    */
   addItems(items: AgentInputItem[]): Promise<void>;
+
+  /**
+   * Optionally replace the logical session history with a compaction marker and its retained
+   * suffix without resetting the session identity.
+   *
+   * Implementations may append the replacement when their backend treats the leading compaction
+   * item as the authoritative replay boundary. If this method is absent, the runner falls back to
+   * clearing and rebuilding the session with rollback protection.
+   */
+  replaceHistoryWithCompaction?(items: AgentInputItem[]): Promise<void>;
 
   /**
    * Remove and return the most recent item from the conversation history if it

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -69,6 +69,7 @@ import {
 import {
   createSessionPersistenceTracker,
   prepareInputItemsWithSession,
+  reconcileLegacyCompactionSessionBeforeResume,
   saveStreamInputToSession,
   saveStreamResultToSession,
   saveToSession,
@@ -653,6 +654,12 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     // When the server tracks conversation history we defer to it for previous turns so local session
     // persistence can focus solely on the new delta being generated in this process.
     const session = effectiveOptions.session;
+    if (resumingFromState && !serverManagesConversation) {
+      await reconcileLegacyCompactionSessionBeforeResume(
+        session,
+        input as RunState<TContext, TAgent>,
+      );
+    }
     const sessionPersistence = createSessionPersistenceTracker({
       session,
       hasCallModelInputFilter,

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -654,7 +654,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     // When the server tracks conversation history we defer to it for previous turns so local session
     // persistence can focus solely on the new delta being generated in this process.
     const session = effectiveOptions.session;
-    if (resumingFromState && !serverManagesConversation) {
+    if (resumingFromState) {
       await reconcileLegacyCompactionSessionBeforeResume(
         session,
         input as RunState<TContext, TAgent>,

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -108,7 +108,11 @@ import {
 import type { Span, TaskSpanData } from './tracing/spans';
 import { NoopTrace, type Trace } from './tracing/traces';
 import { NOOP_TRACE_OR_SPAN_ID } from './tracing/utils';
-import type { ReasoningItemIdPolicy } from './runner/items';
+import {
+  assertValidCompactionItems,
+  CompactionItemValidationError,
+  type ReasoningItemIdPolicy,
+} from './runner/items';
 import type {
   AgentArtifacts,
   CallModelInputFilter,
@@ -1569,6 +1573,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     // Tracks when we resume an approval interruption so the next run-again step stays in the same turn.
     let continuingInterruptedTurn = false;
     let runError: unknown;
+    let suppressStreamInputPersistence = false;
     let approvedToolCheckpointCompacted = false;
     let approvedToolCheckpointRequiresLocalInputCompaction =
       isResumedState && hasPersistedToolOutput(result.state);
@@ -1742,8 +1747,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           const { turnInput } = preparedTurn;
           parallelGuardrailPromise = preparedTurn.parallelGuardrailPromise;
           guardrailTracker.setPromise(parallelGuardrailPromise);
-          // If guardrails are still running, defer input persistence until they finish.
-          const delayStreamInputPersistence = guardrailTracker.pending;
           const preparedSandboxAgent = await sandboxRuntime.prepareAgent({
             currentAgent: result.state._currentAgent,
             turnInput,
@@ -1863,9 +1866,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           };
 
           sentInputToModel = true;
-          if (!delayStreamInputPersistence) {
-            await persistStreamInputIfNeeded();
-          }
 
           try {
             for await (const event of getStreamedResponseWithRetry(
@@ -1902,6 +1902,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 event,
               );
               if (event.type === 'response_done') {
+                assertValidCompactionItems(event.response.output);
                 const parsed = StreamEventResponseCompleted.parse(event);
                 finalResponse = {
                   usage: new Usage(parsed.response.usage),
@@ -2086,13 +2087,16 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       }
     } catch (error) {
       result.state._currentTurnInProgress = false;
+      suppressStreamInputPersistence =
+        error instanceof CompactionItemValidationError;
       if (guardrailTracker.pending) {
         await guardrailTracker.awaitCompletion({ suppressErrors: true });
       }
       if (
         sentInputToModel &&
         !streamInputPersisted &&
-        !guardrailTracker.failed
+        !guardrailTracker.failed &&
+        !suppressStreamInputPersistence
       ) {
         await persistStreamInputIfNeeded();
       }
@@ -2108,7 +2112,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         streamResult: result,
       });
       if (handledResult) {
-        await persistStreamInputIfNeeded();
+        if (!suppressStreamInputPersistence) {
+          await persistStreamInputIfNeeded();
+        }
         if (!serverManagesConversation) {
           await saveStreamResultWithCompactionOwnership();
         }
@@ -2146,7 +2152,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       if (
         sentInputToModel &&
         !streamInputPersisted &&
-        !guardrailTracker.failed
+        !guardrailTracker.failed &&
+        !suppressStreamInputPersistence
       ) {
         await persistStreamInputIfNeeded();
       }

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -1357,7 +1357,13 @@ function rehydrateLegacyCompactionRunItems(
     if (segmentStart === undefined) {
       throwLegacyCompactionOrderingError();
     }
-    generatedInsertionIndex = segmentStart + processedInsertionIndex!;
+    generatedInsertionIndex =
+      segmentStart +
+      findLegacyCompactionInsertionIndex(
+        stateJson.generatedItems.slice(segmentStart),
+        sourceResponse.output,
+        compactionIndex,
+      );
   } else {
     generatedInsertionIndex = findLegacyCompactionInsertionIndex(
       stateJson.generatedItems,
@@ -1405,37 +1411,40 @@ function findLegacyCompactionInsertionIndex(
   sourceOutput: protocol.OutputModelItem[],
   compactionIndex: number,
 ): number {
-  const expectedProviderIdentities = sourceOutput
-    .filter((_, index) => index !== compactionIndex)
-    .map(getProtocolItemIdentity);
-  const expectedIdentitySet = new Set(expectedProviderIdentities);
+  const representedSourceItems = sourceOutput.flatMap((item, index) =>
+    index === compactionIndex || item.type === 'unknown'
+      ? []
+      : [{ key: getCanonicalLegacyCompactionKey(item), sourceIndex: index }],
+  );
   const providerAnchors = items.flatMap((item, itemIndex) => {
     if (item.type === 'tool_approval_item') {
       return [];
     }
-    const identity = getProtocolItemIdentity(item.rawItem);
-    return expectedIdentitySet.has(identity) ? [{ identity, itemIndex }] : [];
+    return [{ key: getCanonicalLegacyCompactionKey(item.rawItem), itemIndex }];
   });
 
   if (
-    providerAnchors.length !== expectedProviderIdentities.length ||
+    providerAnchors.length !== representedSourceItems.length ||
     providerAnchors.some(
-      (anchor, index) => anchor.identity !== expectedProviderIdentities[index],
+      (anchor, index) => anchor.key !== representedSourceItems[index]?.key,
     )
   ) {
     throwLegacyCompactionOrderingError();
   }
 
-  if (expectedProviderIdentities.length === 0) {
+  if (representedSourceItems.length === 0) {
     if (items.length !== 0) {
       throwLegacyCompactionOrderingError();
     }
     return 0;
   }
 
-  const followingAnchor = providerAnchors[compactionIndex];
+  const retainedBeforeCompaction = representedSourceItems.filter(
+    (item) => item.sourceIndex < compactionIndex,
+  ).length;
+  const followingAnchor = providerAnchors[retainedBeforeCompaction];
   if (followingAnchor) {
-    if (compactionIndex === 0 && followingAnchor.itemIndex !== 0) {
+    if (retainedBeforeCompaction === 0 && followingAnchor.itemIndex !== 0) {
       throwLegacyCompactionOrderingError();
     }
     return followingAnchor.itemIndex;
@@ -1455,9 +1464,8 @@ function findTrailingProcessedSegmentStart(
     const matches = processedItems.every((processedItem, offset) => {
       const generatedItem = generatedItems[start + offset];
       return (
-        generatedItem.type === processedItem.type &&
-        getProtocolItemIdentity(generatedItem.rawItem) ===
-          getProtocolItemIdentity(processedItem.rawItem)
+        getCanonicalLegacyCompactionKey(generatedItem) ===
+        getCanonicalLegacyCompactionKey(processedItem)
       );
     });
     if (matches) {
@@ -1473,12 +1481,23 @@ function throwLegacyCompactionOrderingError(): never {
   );
 }
 
-function getProtocolItemIdentity(item: unknown): string {
-  const record = item as Record<string, unknown>;
-  const stableId = record.id ?? record.callId;
-  return typeof stableId === 'string'
-    ? `${String(record.type)}:${stableId}`
-    : JSON.stringify(record);
+function getCanonicalLegacyCompactionKey(value: unknown): string {
+  return JSON.stringify(sortLegacyCompactionValue(value));
+}
+
+function sortLegacyCompactionValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortLegacyCompactionValue);
+  }
+  if (typeof value !== 'object' || value === null) {
+    return value;
+  }
+  const record = value as Record<string, unknown>;
+  return Object.fromEntries(
+    Object.keys(record)
+      .sort()
+      .map((key) => [key, sortLegacyCompactionValue(record[key])]),
+  );
 }
 
 function containsProgrammaticToolCallingState(

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -18,7 +18,11 @@ import {
 } from './items';
 import type { ModelResponse, ModelSettings } from './model';
 import { RunContext } from './runContext';
-import { getTurnInput, type ReasoningItemIdPolicy } from './runner/items';
+import {
+  extractOutputItemsFromRunItems,
+  getTurnInput,
+  type ReasoningItemIdPolicy,
+} from './runner/items';
 import { AgentToolUseTracker } from './runner/toolUseTracker';
 import { nextStepSchema, NextStep } from './runner/steps';
 import type { ProcessedResponse } from './runner/types';
@@ -469,6 +473,7 @@ export const SerializedRunState = z.object({
   pendingAgentToolRuns: z.record(z.string(), z.string()).optional().default({}),
   lastProcessedResponse: serializedProcessedResponseSchema.optional(),
   currentTurnPersistedItemCount: z.number().int().min(0).optional(),
+  pendingLegacyCompactionSessionItems: z.array(protocol.ModelItem).optional(),
   conversationId: z.string().optional(),
   previousResponseId: z.string().optional(),
   reasoningItemIdPolicy: z.enum(['preserve', 'omit']).optional(),
@@ -582,6 +587,11 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
    */
   public _currentTurnPersistedItemCount: number;
   /**
+   * Compaction marker and persisted suffix that an ordinary session must reconcile once after a
+   * pre-1.16 snapshot is restored. The field remains serialized until reconciliation succeeds.
+   */
+  public _pendingLegacyCompactionSessionItems: AgentInputItem[] | undefined;
+  /**
    * Maximum allowed turns before forcing termination.
    */
   public _maxTurns: number | null;
@@ -658,6 +668,7 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     this._pendingAgentToolRuns = new Map();
     this._generatedItems = [];
     this._currentTurnPersistedItemCount = 0;
+    this._pendingLegacyCompactionSessionItems = undefined;
     this._maxTurns = maxTurns;
     this._inputGuardrailResults = [];
     this._outputGuardrailResults = [];
@@ -990,6 +1001,8 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
         this._pendingAgentToolRuns.entries(),
       ),
       currentTurnPersistedItemCount: this._currentTurnPersistedItemCount,
+      pendingLegacyCompactionSessionItems:
+        this._pendingLegacyCompactionSessionItems,
       lastProcessedResponse: this._lastProcessedResponse
         ? (serializeProcessedResponse(
             this._lastProcessedResponse,
@@ -1103,7 +1116,27 @@ async function buildRunStateFromString<
     currentSchemaVersion as SupportedSchemaVersion,
     stateJson,
   );
-  return buildRunStateFromJson(initialAgent, stateJson, options);
+  const normalizedState = rehydrateLegacyCompactionRunItems(
+    currentSchemaVersion as SupportedSchemaVersion,
+    stateJson,
+  );
+  const state = await buildRunStateFromJson(
+    initialAgent,
+    normalizedState.stateJson,
+    options,
+  );
+  if (normalizedState.sessionReconciliation) {
+    const { generatedInsertionIndex, previousPersistedItemCount } =
+      normalizedState.sessionReconciliation;
+    state._pendingLegacyCompactionSessionItems = extractOutputItemsFromRunItems(
+      state._generatedItems.slice(
+        generatedInsertionIndex,
+        previousPersistedItemCount + 1,
+      ),
+    );
+    state._currentTurnPersistedItemCount = previousPersistedItemCount + 1;
+  }
+  return state;
 }
 
 function assertSchemaVersionSupportsToolSearch(
@@ -1234,7 +1267,10 @@ function assertSchemaVersionSupportsCompactionItems(
     return;
   }
 
-  if (!containsSerializedCompactionRunItems(stateJson)) {
+  if (
+    !containsSerializedCompactionRunItems(stateJson) &&
+    stateJson.pendingLegacyCompactionSessionItems === undefined
+  ) {
     return;
   }
 
@@ -1256,6 +1292,193 @@ function containsCompactionRunItems(
   items: z.infer<typeof itemSchema>[] | undefined,
 ): boolean {
   return Boolean(items?.some((item) => item.type === 'compaction_item'));
+}
+
+/**
+ * Older writers kept raw compaction output but dropped its RunItem wrapper. Restore the latest
+ * marker before resuming because it carries the context required for the next model window.
+ */
+type LegacyCompactionRehydration = {
+  stateJson: z.infer<typeof SerializedRunState>;
+  sessionReconciliation?: {
+    generatedInsertionIndex: number;
+    previousPersistedItemCount: number;
+  };
+};
+
+function rehydrateLegacyCompactionRunItems(
+  schemaVersion: SupportedSchemaVersion,
+  stateJson: z.infer<typeof SerializedRunState>,
+): LegacyCompactionRehydration {
+  if (schemaVersion === CURRENT_SCHEMA_VERSION) {
+    return { stateJson };
+  }
+
+  const sourceResponse =
+    stateJson.lastModelResponse ?? stateJson.modelResponses.at(-1);
+  if (!sourceResponse) {
+    return { stateJson };
+  }
+
+  let compactionIndex = -1;
+  for (let index = sourceResponse.output.length - 1; index >= 0; index -= 1) {
+    if (sourceResponse.output[index].type === 'compaction') {
+      compactionIndex = index;
+      break;
+    }
+  }
+  if (compactionIndex < 0) {
+    return { stateJson };
+  }
+
+  const compactionItem = sourceResponse.output[
+    compactionIndex
+  ] as protocol.CompactionItem;
+  const serializedCompactionItem = {
+    type: 'compaction_item' as const,
+    rawItem: compactionItem,
+    agent: stateJson.currentAgent,
+  };
+
+  const processedItems = stateJson.lastProcessedResponse?.newItems;
+  const processedInsertionIndex = processedItems
+    ? findLegacyCompactionInsertionIndex(
+        processedItems,
+        sourceResponse.output,
+        compactionIndex,
+      )
+    : undefined;
+  let generatedInsertionIndex: number;
+  if (processedItems?.length) {
+    const segmentStart = findTrailingProcessedSegmentStart(
+      stateJson.generatedItems,
+      processedItems,
+    );
+    if (segmentStart === undefined) {
+      throwLegacyCompactionOrderingError();
+    }
+    generatedInsertionIndex = segmentStart + processedInsertionIndex!;
+  } else {
+    generatedInsertionIndex = findLegacyCompactionInsertionIndex(
+      stateJson.generatedItems,
+      sourceResponse.output,
+      compactionIndex,
+    );
+  }
+
+  const previousPersistedItemCount =
+    stateJson.currentTurnPersistedItemCount ?? 0;
+  return {
+    stateJson: {
+      ...stateJson,
+      generatedItems: [
+        ...stateJson.generatedItems.slice(0, generatedInsertionIndex),
+        serializedCompactionItem,
+        ...stateJson.generatedItems.slice(generatedInsertionIndex),
+      ],
+      ...(processedItems
+        ? {
+            lastProcessedResponse: {
+              ...stateJson.lastProcessedResponse!,
+              newItems: [
+                ...processedItems.slice(0, processedInsertionIndex),
+                serializedCompactionItem,
+                ...processedItems.slice(processedInsertionIndex),
+              ],
+            },
+          }
+        : {}),
+    },
+    ...(generatedInsertionIndex < previousPersistedItemCount
+      ? {
+          sessionReconciliation: {
+            generatedInsertionIndex,
+            previousPersistedItemCount,
+          },
+        }
+      : {}),
+  };
+}
+
+function findLegacyCompactionInsertionIndex(
+  items: z.infer<typeof itemSchema>[],
+  sourceOutput: protocol.OutputModelItem[],
+  compactionIndex: number,
+): number {
+  const expectedProviderIdentities = sourceOutput
+    .filter((_, index) => index !== compactionIndex)
+    .map(getProtocolItemIdentity);
+  const expectedIdentitySet = new Set(expectedProviderIdentities);
+  const providerAnchors = items.flatMap((item, itemIndex) => {
+    if (item.type === 'tool_approval_item') {
+      return [];
+    }
+    const identity = getProtocolItemIdentity(item.rawItem);
+    return expectedIdentitySet.has(identity) ? [{ identity, itemIndex }] : [];
+  });
+
+  if (
+    providerAnchors.length !== expectedProviderIdentities.length ||
+    providerAnchors.some(
+      (anchor, index) => anchor.identity !== expectedProviderIdentities[index],
+    )
+  ) {
+    throwLegacyCompactionOrderingError();
+  }
+
+  if (expectedProviderIdentities.length === 0) {
+    if (items.length !== 0) {
+      throwLegacyCompactionOrderingError();
+    }
+    return 0;
+  }
+
+  const followingAnchor = providerAnchors[compactionIndex];
+  if (followingAnchor) {
+    if (compactionIndex === 0 && followingAnchor.itemIndex !== 0) {
+      throwLegacyCompactionOrderingError();
+    }
+    return followingAnchor.itemIndex;
+  }
+  return items.length;
+}
+
+function findTrailingProcessedSegmentStart(
+  generatedItems: z.infer<typeof itemSchema>[],
+  processedItems: z.infer<typeof itemSchema>[],
+): number | undefined {
+  for (
+    let start = generatedItems.length - processedItems.length;
+    start >= 0;
+    start -= 1
+  ) {
+    const matches = processedItems.every((processedItem, offset) => {
+      const generatedItem = generatedItems[start + offset];
+      return (
+        generatedItem.type === processedItem.type &&
+        getProtocolItemIdentity(generatedItem.rawItem) ===
+          getProtocolItemIdentity(processedItem.rawItem)
+      );
+    });
+    if (matches) {
+      return start;
+    }
+  }
+  return undefined;
+}
+
+function throwLegacyCompactionOrderingError(): never {
+  throw new UserError(
+    'Run state cannot safely restore a legacy compaction item because its provider order is ambiguous.',
+  );
+}
+
+function getProtocolItemIdentity(item: unknown): string {
+  const record = item as Record<string, unknown>;
+  const stableId = record.id ?? record.callId;
+  return typeof stableId === 'string'
+    ? `${String(record.type)}:${stableId}`
+    : JSON.stringify(record);
 }
 
 function containsProgrammaticToolCallingState(
@@ -1850,6 +2073,8 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
   );
   state._currentTurnPersistedItemCount =
     stateJson.currentTurnPersistedItemCount ?? 0;
+  state._pendingLegacyCompactionSessionItems =
+    stateJson.pendingLegacyCompactionSessionItems;
   state._sandbox = stateJson.sandbox ?? undefined;
   await rehydrateToolSearchRuntimeTools(state);
   state._lastProcessedResponse = stateJson.lastProcessedResponse

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -1548,10 +1548,20 @@ function rehydrateLegacyCompactionRunItems(
   let generatedInsertionAgent: SerializedAgentReference | undefined;
   let generatedInsertionIndex: number;
   if (!isLatestSourceResponse) {
+    const followingResponseBoundary =
+      sourceResponseIndex === sourceResponses.length - 2 &&
+      stateJson.lastProcessedResponse
+        ? findFollowingLegacyResponseBoundary(
+            stateJson.generatedItems,
+            stateJson.lastProcessedResponse.newItems,
+            sourceResponses[sourceResponseIndex + 1].output,
+          )
+        : undefined;
     const historicalInsertion = findHistoricalLegacyCompactionInsertion(
       stateJson.generatedItems,
       sourceResponse.output,
       compactionIndex,
+      followingResponseBoundary,
     );
     generatedInsertionIndex = historicalInsertion.itemIndex;
     generatedInsertionAgent = historicalInsertion.agent;
@@ -1637,6 +1647,10 @@ function findHistoricalLegacyCompactionInsertion(
   items: z.infer<typeof itemSchema>[],
   sourceOutput: protocol.OutputModelItem[],
   compactionIndex: number,
+  followingResponseBoundary?: {
+    itemIndex: number;
+    agent: SerializedAgentReference;
+  },
 ): { itemIndex: number; agent: SerializedAgentReference } {
   const providerAnchors = getLegacyProviderOutputAnchors(items, sourceOutput);
   const representedSourceItems = getRepresentedLegacySourceItems(
@@ -1645,6 +1659,9 @@ function findHistoricalLegacyCompactionInsertion(
     providerAnchors,
   );
   if (representedSourceItems.length === 0) {
+    if (followingResponseBoundary) {
+      return followingResponseBoundary;
+    }
     throwLegacyCompactionOrderingError();
   }
 
@@ -1699,6 +1716,53 @@ function findHistoricalLegacyCompactionInsertion(
       previousAnchor.key
   ) {
     itemIndex += 1;
+  }
+  return { itemIndex, agent };
+}
+
+function findFollowingLegacyResponseBoundary(
+  generatedItems: z.infer<typeof itemSchema>[],
+  processedItems: z.infer<typeof itemSchema>[],
+  sourceOutput: protocol.OutputModelItem[],
+): { itemIndex: number; agent: SerializedAgentReference } | undefined {
+  const itemIndex = findTrailingProcessedSegmentStart(
+    generatedItems,
+    processedItems,
+  );
+  if (itemIndex === undefined) {
+    throwLegacyCompactionOrderingError();
+  }
+  if (itemIndex + processedItems.length !== generatedItems.length) {
+    throwLegacyCompactionOrderingError();
+  }
+
+  const providerAnchors = getLegacyProviderOutputAnchors(
+    processedItems,
+    sourceOutput,
+  );
+  const representedSourceItems = getRepresentedLegacySourceItems(
+    sourceOutput,
+    -1,
+    providerAnchors,
+  );
+  if (
+    providerAnchors.length === 0 ||
+    providerAnchors.length !== representedSourceItems.length ||
+    providerAnchors.some(
+      (anchor, index) => anchor.key !== representedSourceItems[index]?.key,
+    )
+  ) {
+    return undefined;
+  }
+
+  const agent = providerAnchors[0].agent;
+  const agentKey = getCanonicalLegacyCompactionKey(agent);
+  if (
+    providerAnchors.some(
+      (anchor) => getCanonicalLegacyCompactionKey(anchor.agent) !== agentKey,
+    )
+  ) {
+    throwLegacyCompactionOrderingError();
   }
   return { itemIndex, agent };
 }

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { Agent } from './agent';
+import type { Handoff } from './handoff';
 import { getAgentToolSourceAgent } from './agentToolSourceRegistry';
 import { buildAgentIdentityMap } from './runStateIdentity';
 export { buildAgentIdentityMap } from './runStateIdentity';
@@ -25,7 +26,7 @@ import {
 } from './runner/items';
 import { AgentToolUseTracker } from './runner/toolUseTracker';
 import { nextStepSchema, NextStep } from './runner/steps';
-import type { ProcessedResponse } from './runner/types';
+import { createToolRunFunction, type ProcessedResponse } from './runner/types';
 import type { AgentSpanData, Span } from './tracing/spans';
 import { SystemError, UserError } from './errors';
 import { getGlobalTraceProvider } from './tracing/provider';
@@ -33,7 +34,6 @@ import { Usage } from './usage';
 import { Trace } from './tracing/traces';
 import { getCurrentTrace } from './tracing';
 import logger from './logger';
-import { handoff } from './handoff';
 import * as protocol from './types/protocol';
 import { AgentInputItem, UnknownContext } from './types';
 import {
@@ -48,27 +48,42 @@ import type {
 import { safeExecute } from './utils/safeExecute';
 import {
   getClientToolSearchExecutor,
-  getToolSearchRuntimeToolKey,
+  getToolSearchRuntimeRoutingKey,
   HostedMCPTool,
+  FunctionTool,
   ShellTool,
   ApplyPatchTool,
   Tool,
 } from './tool';
 import type { AgentToolInvocation } from './agentToolInvocation';
 import {
+  buildFunctionToolLookupMap,
+  type FunctionToolLookupKey,
+  getFunctionToolLookupKey,
+  getFunctionToolLegacyStateKeyFromStateKey,
   getFunctionToolQualifiedName,
-  toolQualifiedName,
-  resolveFunctionToolCallName,
+  getFunctionToolStateKey,
+  getFunctionToolStateKeyForCall,
+  getFunctionToolStateKeyForResolvedCall,
+  getFunctionToolStateKeys,
+  getToolCallNamespace,
+  getToolCallDisplayName,
+  resolveFunctionToolCall,
 } from './toolIdentity';
 import {
   getToolSearchExecution,
   getToolSearchOutputReplacementKey,
+  getToolSearchProviderCallId,
   resolveToolSearchCallId,
 } from './utils/toolSearch';
 import {
   executeCustomClientToolSearch,
+  filterEnabledToolSearchRuntimeTools,
   getClientToolSearchHelper,
+  registerRuntimeToolSearchTools,
+  validateClientToolSearchSupport,
 } from './runner/toolSearch';
+import { resolveModelVisibleToolNameCollisions } from './runner/modelPreparation';
 import { ensureToolCallerAllowed } from './runner/toolCaller';
 import {
   getSerializedApplyPatchToolPlaceholder,
@@ -106,7 +121,8 @@ import {
  *   and optional assistant message phases.
  * - 1.15: Adds reconstructable sandbox environment value references and sandbox
  *   session-state envelope version 2.
- * - 1.16: Adds compaction items to serialized run state payloads.
+ * - 1.16: Adds compaction items, category-aware function tool keys, and agent-scoped
+ *   function approvals, including aliases for legacy pending-run accessors.
  */
 export const CURRENT_SCHEMA_VERSION = '1.16' as const;
 const SUPPORTED_SCHEMA_VERSIONS = [
@@ -257,6 +273,7 @@ const itemSchema = z.discriminatedUnion('type', [
       .or(protocol.ApplyPatchCallItem),
     agent: serializedAgentSchema,
     toolName: z.string().optional(),
+    functionToolStateKey: z.string().optional(),
   }),
 ]);
 
@@ -311,6 +328,7 @@ const serializedProcessedResponseSchema = z.object({
     z.object({
       toolCall: z.any(),
       handoff: z.any(),
+      targetAgent: serializedAgentSchema.optional(),
     }),
   ),
   functions: z.array(
@@ -432,6 +450,37 @@ const toolOutputGuardrailResultSchema = z.object({
   output: toolGuardrailFunctionOutputSchema,
 });
 
+const approvalRecordSchema = z.object({
+  approved: z.array(z.string()).or(z.boolean()),
+  rejected: z.array(z.string()).or(z.boolean()),
+  messages: z.record(z.string(), z.string()).optional(),
+  stickyRejectMessage: z.string().optional(),
+});
+
+const canonicalFunctionToolStateKeySchema = z
+  .string()
+  .refine(
+    (value) => getFunctionToolLegacyStateKeyFromStateKey(value) !== undefined,
+    'Function approval keys must use a canonical category-aware identity.',
+  );
+
+const functionApprovalsSchema = z.array(
+  z.object({
+    agentIdentity: z.string(),
+    approvals: z.record(
+      canonicalFunctionToolStateKeySchema,
+      approvalRecordSchema,
+    ),
+  }),
+);
+
+const functionApprovalContextSchema = z.object({
+  functionApprovals: functionApprovalsSchema.optional(),
+  legacyFunctionApprovals: z
+    .record(z.string(), approvalRecordSchema)
+    .optional(),
+});
+
 export const SerializedRunState = z.object({
   $schemaVersion,
   currentTurn: z.number(),
@@ -440,15 +489,11 @@ export const SerializedRunState = z.object({
   modelResponses: z.array(modelResponseSchema),
   context: z.object({
     usage: usageSchema,
-    approvals: z.record(
-      z.string(),
-      z.object({
-        approved: z.array(z.string()).or(z.boolean()),
-        rejected: z.array(z.string()).or(z.boolean()),
-        messages: z.record(z.string(), z.string()).optional(),
-        stickyRejectMessage: z.string().optional(),
-      }),
-    ),
+    approvals: z.record(z.string(), approvalRecordSchema),
+    functionApprovals: functionApprovalsSchema.optional(),
+    legacyFunctionApprovals: z
+      .record(z.string(), approvalRecordSchema)
+      .optional(),
     context: z.record(z.string(), z.any()),
     toolInput: z.any().optional(),
   }),
@@ -471,6 +516,10 @@ export const SerializedRunState = z.object({
   lastModelResponse: modelResponseSchema.optional(),
   generatedItems: z.array(itemSchema),
   pendingAgentToolRuns: z.record(z.string(), z.string()).optional().default({}),
+  pendingAgentToolRunAliases: z
+    .record(z.string(), z.string())
+    .optional()
+    .default({}),
   lastProcessedResponse: serializedProcessedResponseSchema.optional(),
   currentTurnPersistedItemCount: z.number().int().min(0).optional(),
   pendingLegacyCompactionSessionItems: z.array(protocol.ModelItem).optional(),
@@ -489,8 +538,15 @@ type ToolSearchRuntimeToolEntry<TContext = UnknownContext> = {
 };
 
 type ToolSearchRuntimeToolState<TContext = UnknownContext> = {
-  anonymousEntries: ToolSearchRuntimeToolEntry<TContext>[];
   keyedEntries: Map<string, ToolSearchRuntimeToolEntry<TContext>>;
+  routedOwners: Map<
+    string,
+    {
+      entry: ToolSearchRuntimeToolEntry<TContext>;
+      tool: Tool<TContext>;
+      toolIndex: number;
+    }
+  >;
   nextOrder: number;
 };
 
@@ -571,6 +627,10 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
    * Serialized pending nested agent runs keyed by tool name and call id.
    */
   public _pendingAgentToolRuns: Map<string, string>;
+  /**
+   * Legacy pending-run keys mapped to their canonical category-aware keys.
+   */
+  public _pendingAgentToolRunAliases: Map<string, string>;
   /**
    * Items generated by the agent during the run.
    */
@@ -666,6 +726,7 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     this._reasoningItemIdPolicy = undefined;
     this._toolUseTracker = new AgentToolUseTracker();
     this._pendingAgentToolRuns = new Map();
+    this._pendingAgentToolRunAliases = new Map();
     this._generatedItems = [];
     this._currentTurnPersistedItemCount = 0;
     this._pendingLegacyCompactionSessionItems = undefined;
@@ -719,8 +780,8 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     let state = this._toolSearchRuntimeToolsByAgent.get(agent);
     if (!state) {
       state = {
-        anonymousEntries: [],
         keyedEntries: new Map(),
+        routedOwners: new Map(),
         nextOrder: 0,
       };
       this._toolSearchRuntimeToolsByAgent.set(agent, state);
@@ -740,11 +801,50 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     };
     const replacementKey = getToolSearchOutputReplacementKey(toolSearchOutput);
     if (replacementKey) {
+      const previousEntry = runtimeState.keyedEntries.get(replacementKey);
+      if (previousEntry) {
+        for (const [routingKey, owner] of runtimeState.routedOwners) {
+          if (owner.entry === previousEntry) {
+            runtimeState.routedOwners.delete(routingKey);
+          }
+        }
+      }
       runtimeState.keyedEntries.set(replacementKey, entry);
-      return;
     }
 
-    runtimeState.anonymousEntries.push(entry);
+    for (const [toolIndex, tool] of tools.entries()) {
+      const routingKey = getToolSearchRuntimeRoutingKey(tool);
+      if (!routingKey) {
+        continue;
+      }
+      runtimeState.routedOwners.set(routingKey, {
+        entry,
+        tool,
+        toolIndex,
+      });
+    }
+  }
+
+  public getToolSearchRuntimeToolsForOutput(
+    agent: Agent<any, any>,
+    toolSearchOutput: protocol.ToolSearchOutputItem,
+  ): Tool<TContext>[] {
+    const replacementKey = getToolSearchOutputReplacementKey(toolSearchOutput);
+    if (!replacementKey) {
+      return [];
+    }
+    const runtimeState = this._toolSearchRuntimeToolsByAgent.get(agent);
+    const entry = runtimeState?.keyedEntries.get(replacementKey);
+    if (!runtimeState || !entry) {
+      return [];
+    }
+    return entry.tools.filter((tool) => {
+      const routingKey = getToolSearchRuntimeRoutingKey(tool);
+      return (
+        typeof routingKey === 'string' &&
+        runtimeState.routedOwners.get(routingKey)?.entry === entry
+      );
+    });
   }
 
   public getToolSearchRuntimeTools(agent: Agent<any, any>): Tool<TContext>[] {
@@ -753,23 +853,13 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
       return [];
     }
 
-    const dedupedTools = new Map<string, Tool<TContext>>();
-    const orderedEntries = [
-      ...runtimeState.keyedEntries.values(),
-      ...runtimeState.anonymousEntries,
-    ].sort((a, b) => a.order - b.order);
-    let anonymousCounter = 0;
-
-    for (const entry of orderedEntries) {
-      for (const tool of entry.tools) {
-        const key =
-          getToolSearchRuntimeToolKey(tool) ??
-          `anonymous:${entry.order}:${anonymousCounter++}`;
-        dedupedTools.set(key, tool);
-      }
-    }
-
-    return [...dedupedTools.values()];
+    return [...runtimeState.routedOwners.values()]
+      .sort(
+        (left, right) =>
+          left.entry.order - right.entry.order ||
+          left.toolIndex - right.toolIndex,
+      )
+      .map((owner) => owner.tool);
   }
 
   /**
@@ -836,15 +926,23 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     return `${toolName}:${callId}`;
   }
 
+  private resolvePendingAgentToolRunKey(
+    toolName: string,
+    callId: string,
+  ): string {
+    const key = this.getPendingAgentToolRunKey(toolName, callId);
+    return this._pendingAgentToolRunAliases.get(key) ?? key;
+  }
+
   getPendingAgentToolRun(toolName: string, callId: string): string | undefined {
     return this._pendingAgentToolRuns.get(
-      this.getPendingAgentToolRunKey(toolName, callId),
+      this.resolvePendingAgentToolRunKey(toolName, callId),
     );
   }
 
   hasPendingAgentToolRun(toolName: string, callId: string): boolean {
     return this._pendingAgentToolRuns.has(
-      this.getPendingAgentToolRunKey(toolName, callId),
+      this.resolvePendingAgentToolRunKey(toolName, callId),
     );
   }
 
@@ -852,17 +950,31 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     toolName: string,
     callId: string,
     serializedState: string,
+    aliases: readonly string[] = [],
   ) {
-    this._pendingAgentToolRuns.set(
-      this.getPendingAgentToolRunKey(toolName, callId),
-      serializedState,
-    );
+    const canonicalKey = this.resolvePendingAgentToolRunKey(toolName, callId);
+    this._pendingAgentToolRuns.set(canonicalKey, serializedState);
+    for (const alias of aliases) {
+      const aliasKey = this.getPendingAgentToolRunKey(alias, callId);
+      if (aliasKey === canonicalKey) {
+        continue;
+      }
+      this._pendingAgentToolRuns.delete(aliasKey);
+      this._pendingAgentToolRunAliases.set(aliasKey, canonicalKey);
+    }
   }
 
   clearPendingAgentToolRun(toolName: string, callId: string) {
-    this._pendingAgentToolRuns.delete(
-      this.getPendingAgentToolRunKey(toolName, callId),
-    );
+    const requestedKey = this.getPendingAgentToolRunKey(toolName, callId);
+    const canonicalKey = this.resolvePendingAgentToolRunKey(toolName, callId);
+    this._pendingAgentToolRuns.delete(canonicalKey);
+    this._pendingAgentToolRuns.delete(requestedKey);
+    for (const [aliasKey, targetKey] of this._pendingAgentToolRunAliases) {
+      if (aliasKey === requestedKey || targetKey === canonicalKey) {
+        this._pendingAgentToolRuns.delete(aliasKey);
+        this._pendingAgentToolRunAliases.delete(aliasKey);
+      }
+    }
   }
 
   /**
@@ -934,7 +1046,7 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     const agentIdentity = buildAgentIdentityMap(this.#startingAgent);
 
     const includeTracingApiKey = options.includeTracingApiKey === true;
-    const contextJson = this._context.toJSON();
+    const contextJson = this._context._toJSONForRunState(agentIdentity.byAgent);
     const output = {
       $schemaVersion: CURRENT_SCHEMA_VERSION,
       currentTurn: this._currentTurn,
@@ -999,6 +1111,9 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
       ),
       pendingAgentToolRuns: Object.fromEntries(
         this._pendingAgentToolRuns.entries(),
+      ),
+      pendingAgentToolRunAliases: Object.fromEntries(
+        this._pendingAgentToolRunAliases.entries(),
       ),
       currentTurnPersistedItemCount: this._currentTurnPersistedItemCount,
       pendingLegacyCompactionSessionItems:
@@ -1095,6 +1210,10 @@ async function buildRunStateFromString<
       `Run state schema version ${currentSchemaVersion} is not supported. Please use version ${CURRENT_SCHEMA_VERSION}.`,
     );
   }
+  validateFunctionApprovalEnvelope(
+    currentSchemaVersion as SupportedSchemaVersion,
+    jsonResult,
+  );
   const stateJson = SerializedRunState.parse(jsonResult);
   assertSchemaVersionSupportsToolSearch(
     currentSchemaVersion as SupportedSchemaVersion,
@@ -1137,6 +1256,40 @@ async function buildRunStateFromString<
     state._currentTurnPersistedItemCount = previousPersistedItemCount + 1;
   }
   return state;
+}
+
+function validateFunctionApprovalEnvelope(
+  schemaVersion: SupportedSchemaVersion,
+  stateJson: unknown,
+): void {
+  if (!stateJson || typeof stateJson !== 'object') {
+    return;
+  }
+  const context = (stateJson as { context?: unknown }).context;
+  if (!context || typeof context !== 'object') {
+    return;
+  }
+  const hasFunctionApprovals = Object.prototype.hasOwnProperty.call(
+    context,
+    'functionApprovals',
+  );
+  const hasLegacyFunctionApprovals = Object.prototype.hasOwnProperty.call(
+    context,
+    'legacyFunctionApprovals',
+  );
+  if (!hasFunctionApprovals && !hasLegacyFunctionApprovals) {
+    return;
+  }
+  if (schemaVersion !== CURRENT_SCHEMA_VERSION) {
+    throw new UserError(
+      `Run state schema version ${schemaVersion} does not support owner-scoped function approvals. Please reserialize the run state with schema ${CURRENT_SCHEMA_VERSION}.`,
+    );
+  }
+  if (!functionApprovalContextSchema.safeParse(context).success) {
+    throw new UserError(
+      'Failed to parse owner-scoped function approvals because their structure does not match the supported schema.',
+    );
+  }
 }
 
 function assertSchemaVersionSupportsToolSearch(
@@ -1255,15 +1408,32 @@ function assertSchemaVersionSupportsSandboxSessionEnvelope(
 }
 
 /**
- * Rejects snapshots that declare a pre-1.16 schema while carrying the new compaction run-item
- * wrapper. Raw compaction output in `modelResponses` remains valid because earlier writers could
- * record that provider output even though they did not create a corresponding run item.
+ * Requires current snapshots to pair each raw compaction output with its canonical run-item
+ * wrapper, and rejects older schemas that carry the new wrapper. Raw compaction output in older
+ * `modelResponses` remains valid because earlier writers could record it without creating a run
+ * item.
  */
 function assertSchemaVersionSupportsCompactionItems(
   schemaVersion: SupportedSchemaVersion,
   stateJson: z.infer<typeof SerializedRunState>,
 ): void {
   if (schemaVersion === CURRENT_SCHEMA_VERSION) {
+    const rawCompaction = findLatestCompactionSource(stateJson)?.item;
+    const serializedCompaction = stateJson.generatedItems
+      .slice()
+      .reverse()
+      .find((item) => item.type === 'compaction_item');
+    if (
+      Boolean(rawCompaction) !== Boolean(serializedCompaction) ||
+      (rawCompaction &&
+        serializedCompaction &&
+        getCanonicalLegacyCompactionKey(rawCompaction) !==
+          getCanonicalLegacyCompactionKey(serializedCompaction.rawItem))
+    ) {
+      throw new UserError(
+        `Run state schema version ${CURRENT_SCHEMA_VERSION} contains inconsistent compaction items.`,
+      );
+    }
     return;
   }
 
@@ -1294,6 +1464,43 @@ function containsCompactionRunItems(
   return Boolean(items?.some((item) => item.type === 'compaction_item'));
 }
 
+function getCompactionSourceResponses(
+  stateJson: z.infer<typeof SerializedRunState>,
+): z.infer<typeof modelResponseSchema>[] {
+  return stateJson.modelResponses.length > 0
+    ? stateJson.modelResponses
+    : stateJson.lastModelResponse
+      ? [stateJson.lastModelResponse]
+      : [];
+}
+
+function findLatestCompactionSource(
+  stateJson: z.infer<typeof SerializedRunState>,
+):
+  | {
+      sourceResponses: z.infer<typeof modelResponseSchema>[];
+      responseIndex: number;
+      itemIndex: number;
+      item: protocol.CompactionItem;
+    }
+  | undefined {
+  const sourceResponses = getCompactionSourceResponses(stateJson);
+  for (
+    let responseIndex = sourceResponses.length - 1;
+    responseIndex >= 0;
+    responseIndex -= 1
+  ) {
+    const output = sourceResponses[responseIndex].output;
+    for (let itemIndex = output.length - 1; itemIndex >= 0; itemIndex -= 1) {
+      const item = output[itemIndex];
+      if (item.type === 'compaction') {
+        return { sourceResponses, responseIndex, itemIndex, item };
+      }
+    }
+  }
+  return undefined;
+}
+
 /**
  * Older writers kept raw compaction output but dropped its RunItem wrapper. Restore the latest
  * marker before resuming because it carries the context required for the next model window.
@@ -1314,42 +1521,41 @@ function rehydrateLegacyCompactionRunItems(
     return { stateJson };
   }
 
-  const sourceResponse =
-    stateJson.lastModelResponse ?? stateJson.modelResponses.at(-1);
-  if (!sourceResponse) {
+  const latestCompaction = findLatestCompactionSource(stateJson);
+  if (!latestCompaction) {
     return { stateJson };
   }
 
-  let compactionIndex = -1;
-  for (let index = sourceResponse.output.length - 1; index >= 0; index -= 1) {
-    if (sourceResponse.output[index].type === 'compaction') {
-      compactionIndex = index;
-      break;
-    }
-  }
-  if (compactionIndex < 0) {
-    return { stateJson };
-  }
-
-  const compactionItem = sourceResponse.output[
-    compactionIndex
-  ] as protocol.CompactionItem;
-  const serializedCompactionItem = {
-    type: 'compaction_item' as const,
-    rawItem: compactionItem,
-    agent: stateJson.currentAgent,
-  };
-
-  const processedItems = stateJson.lastProcessedResponse?.newItems;
-  const processedInsertionIndex = processedItems
+  const {
+    sourceResponses,
+    responseIndex: sourceResponseIndex,
+    itemIndex: compactionIndex,
+    item: compactionItem,
+  } = latestCompaction;
+  const sourceResponse = sourceResponses[sourceResponseIndex];
+  const isLatestSourceResponse =
+    sourceResponseIndex === sourceResponses.length - 1;
+  const processedItems = isLatestSourceResponse
+    ? stateJson.lastProcessedResponse?.newItems
+    : undefined;
+  const processedInsertion = processedItems
     ? findLegacyCompactionInsertionIndex(
         processedItems,
         sourceResponse.output,
         compactionIndex,
       )
     : undefined;
+  let generatedInsertionAgent: SerializedAgentReference | undefined;
   let generatedInsertionIndex: number;
-  if (processedItems?.length) {
+  if (!isLatestSourceResponse) {
+    const historicalInsertion = findHistoricalLegacyCompactionInsertion(
+      stateJson.generatedItems,
+      sourceResponse.output,
+      compactionIndex,
+    );
+    generatedInsertionIndex = historicalInsertion.itemIndex;
+    generatedInsertionAgent = historicalInsertion.agent;
+  } else if (processedItems !== undefined) {
     const segmentStart = findTrailingProcessedSegmentStart(
       stateJson.generatedItems,
       processedItems,
@@ -1357,20 +1563,41 @@ function rehydrateLegacyCompactionRunItems(
     if (segmentStart === undefined) {
       throwLegacyCompactionOrderingError();
     }
-    generatedInsertionIndex =
-      segmentStart +
-      findLegacyCompactionInsertionIndex(
-        stateJson.generatedItems.slice(segmentStart),
-        sourceResponse.output,
-        compactionIndex,
-      );
+    const generatedInsertion = findLegacyCompactionInsertionIndex(
+      stateJson.generatedItems.slice(segmentStart),
+      sourceResponse.output,
+      compactionIndex,
+    );
+    generatedInsertionIndex = segmentStart + generatedInsertion.itemIndex;
+    generatedInsertionAgent = generatedInsertion.agent;
   } else {
-    generatedInsertionIndex = findLegacyCompactionInsertionIndex(
+    const generatedInsertion = findLegacyCompactionInsertionIndex(
       stateJson.generatedItems,
       sourceResponse.output,
       compactionIndex,
     );
+    generatedInsertionIndex = generatedInsertion.itemIndex;
+    generatedInsertionAgent = generatedInsertion.agent;
   }
+
+  const serializedCompactionAgent =
+    processedInsertion?.agent ??
+    generatedInsertionAgent ??
+    stateJson.currentAgent;
+  if (
+    processedInsertion?.agent &&
+    generatedInsertionAgent &&
+    getCanonicalLegacyCompactionKey(processedInsertion.agent) !==
+      getCanonicalLegacyCompactionKey(generatedInsertionAgent)
+  ) {
+    throwLegacyCompactionOrderingError();
+  }
+
+  const serializedCompactionItem = {
+    type: 'compaction_item' as const,
+    rawItem: compactionItem,
+    agent: serializedCompactionAgent,
+  };
 
   const previousPersistedItemCount =
     stateJson.currentTurnPersistedItemCount ?? 0;
@@ -1387,9 +1614,9 @@ function rehydrateLegacyCompactionRunItems(
             lastProcessedResponse: {
               ...stateJson.lastProcessedResponse!,
               newItems: [
-                ...processedItems.slice(0, processedInsertionIndex),
+                ...processedItems.slice(0, processedInsertion!.itemIndex),
                 serializedCompactionItem,
-                ...processedItems.slice(processedInsertionIndex),
+                ...processedItems.slice(processedInsertion!.itemIndex),
               ],
             },
           }
@@ -1406,22 +1633,163 @@ function rehydrateLegacyCompactionRunItems(
   };
 }
 
+function findHistoricalLegacyCompactionInsertion(
+  items: z.infer<typeof itemSchema>[],
+  sourceOutput: protocol.OutputModelItem[],
+  compactionIndex: number,
+): { itemIndex: number; agent: SerializedAgentReference } {
+  const providerAnchors = getLegacyProviderOutputAnchors(items, sourceOutput);
+  const representedSourceItems = getRepresentedLegacySourceItems(
+    sourceOutput,
+    compactionIndex,
+    providerAnchors,
+  );
+  if (representedSourceItems.length === 0) {
+    throwLegacyCompactionOrderingError();
+  }
+
+  const matchingStarts: number[] = [];
+  for (
+    let start = 0;
+    start <= providerAnchors.length - representedSourceItems.length;
+    start += 1
+  ) {
+    if (
+      representedSourceItems.every(
+        (sourceItem, offset) =>
+          providerAnchors[start + offset]?.key === sourceItem.key,
+      )
+    ) {
+      matchingStarts.push(start);
+    }
+  }
+  if (matchingStarts.length !== 1) {
+    throwLegacyCompactionOrderingError();
+  }
+
+  const matchedAnchors = providerAnchors.slice(
+    matchingStarts[0],
+    matchingStarts[0] + representedSourceItems.length,
+  );
+  const agent = matchedAnchors[0].agent;
+  const agentKey = getCanonicalLegacyCompactionKey(agent);
+  if (
+    matchedAnchors.some(
+      (anchor) => getCanonicalLegacyCompactionKey(anchor.agent) !== agentKey,
+    )
+  ) {
+    throwLegacyCompactionOrderingError();
+  }
+
+  const followingSourceIndex = representedSourceItems.findIndex(
+    (item) => item.sourceIndex > compactionIndex,
+  );
+  if (followingSourceIndex >= 0) {
+    return {
+      itemIndex: matchedAnchors[followingSourceIndex].itemIndex,
+      agent,
+    };
+  }
+
+  const previousAnchor = matchedAnchors[matchedAnchors.length - 1];
+  let itemIndex = previousAnchor.itemIndex + 1;
+  while (
+    items[itemIndex]?.type === 'tool_approval_item' &&
+    getCanonicalLegacyCompactionKey(items[itemIndex].rawItem) ===
+      previousAnchor.key
+  ) {
+    itemIndex += 1;
+  }
+  return { itemIndex, agent };
+}
+
+function isLegacyProviderOutputRunItem(
+  item: z.infer<typeof itemSchema>,
+): item is z.infer<typeof itemSchema> & { agent: SerializedAgentReference } {
+  return (
+    item.type === 'message_output_item' ||
+    item.type === 'tool_search_call_item' ||
+    item.type === 'tool_search_output_item' ||
+    item.type === 'tool_call_item' ||
+    (item.type === 'tool_call_output_item' &&
+      (item.rawItem.type === 'program_output' ||
+        item.rawItem.type === 'shell_call_output')) ||
+    item.type === 'reasoning_item' ||
+    item.type === 'handoff_call_item'
+  );
+}
+
+function getLegacyProviderOutputAnchors(
+  items: z.infer<typeof itemSchema>[],
+  sourceOutput: protocol.OutputModelItem[],
+): Array<{
+  key: string;
+  itemIndex: number;
+  agent: SerializedAgentReference;
+}> {
+  const rawToolSearchOutputKeys = new Set(
+    sourceOutput.flatMap((item) =>
+      item.type === 'tool_search_output'
+        ? [getLegacyProviderOutputKey(item)]
+        : [],
+    ),
+  );
+  return items.flatMap((item, itemIndex) => {
+    if (!isLegacyProviderOutputRunItem(item)) {
+      return [];
+    }
+    const key = getLegacyProviderOutputKey(item.rawItem);
+    if (
+      item.type === 'tool_search_output_item' &&
+      !rawToolSearchOutputKeys.has(key)
+    ) {
+      return [];
+    }
+    return [{ key, itemIndex, agent: item.agent }];
+  });
+}
+
+function getRepresentedLegacySourceItems(
+  sourceOutput: protocol.OutputModelItem[],
+  compactionIndex: number,
+  providerAnchors: Array<{ key: string }>,
+): Array<{ key: string; sourceIndex: number }> {
+  const providerKeys = new Set(providerAnchors.map((anchor) => anchor.key));
+  return sourceOutput.flatMap((item, sourceIndex) => {
+    if (sourceIndex === compactionIndex) {
+      return [];
+    }
+    const key = getLegacyProviderOutputKey(item);
+    return providerKeys.has(key) ? [{ key, sourceIndex }] : [];
+  });
+}
+
+function getLegacyProviderOutputKey(item: protocol.ModelItem): string {
+  if (item.type !== 'function_call') {
+    return getCanonicalLegacyCompactionKey(item);
+  }
+
+  const namespace = getToolCallNamespace(item);
+  if (!namespace) {
+    return getCanonicalLegacyCompactionKey(item);
+  }
+
+  const normalizedItem = { ...item, name: `${namespace}.${item.name}` };
+  delete normalizedItem.namespace;
+  return getCanonicalLegacyCompactionKey(normalizedItem);
+}
+
 function findLegacyCompactionInsertionIndex(
   items: z.infer<typeof itemSchema>[],
   sourceOutput: protocol.OutputModelItem[],
   compactionIndex: number,
-): number {
-  const representedSourceItems = sourceOutput.flatMap((item, index) =>
-    index === compactionIndex || item.type === 'unknown'
-      ? []
-      : [{ key: getCanonicalLegacyCompactionKey(item), sourceIndex: index }],
+): { itemIndex: number; agent?: SerializedAgentReference } {
+  const providerAnchors = getLegacyProviderOutputAnchors(items, sourceOutput);
+  const representedSourceItems = getRepresentedLegacySourceItems(
+    sourceOutput,
+    compactionIndex,
+    providerAnchors,
   );
-  const providerAnchors = items.flatMap((item, itemIndex) => {
-    if (item.type === 'tool_approval_item') {
-      return [];
-    }
-    return [{ key: getCanonicalLegacyCompactionKey(item.rawItem), itemIndex }];
-  });
 
   if (
     providerAnchors.length !== representedSourceItems.length ||
@@ -1436,7 +1804,17 @@ function findLegacyCompactionInsertionIndex(
     if (items.length !== 0) {
       throwLegacyCompactionOrderingError();
     }
-    return 0;
+    return { itemIndex: 0 };
+  }
+
+  const agent = providerAnchors[0].agent;
+  const agentKey = getCanonicalLegacyCompactionKey(agent);
+  if (
+    providerAnchors.some(
+      (anchor) => getCanonicalLegacyCompactionKey(anchor.agent) !== agentKey,
+    )
+  ) {
+    throwLegacyCompactionOrderingError();
   }
 
   const retainedBeforeCompaction = representedSourceItems.filter(
@@ -1447,9 +1825,9 @@ function findLegacyCompactionInsertionIndex(
     if (retainedBeforeCompaction === 0 && followingAnchor.itemIndex !== 0) {
       throwLegacyCompactionOrderingError();
     }
-    return followingAnchor.itemIndex;
+    return { itemIndex: followingAnchor.itemIndex, agent };
   }
-  return items.length;
+  return { itemIndex: items.length, agent };
 }
 
 function findTrailingProcessedSegmentStart(
@@ -1678,10 +2056,23 @@ function isToolSearchProtocolType(type: unknown): boolean {
   return type === 'tool_search_call' || type === 'tool_search_output';
 }
 
+function addSerializedRuntimeToolKey(
+  runtimeToolKeys: Set<string>,
+  runtimeToolKey: string,
+): void {
+  if (runtimeToolKeys.has(runtimeToolKey)) {
+    throw new UserError(
+      'Serialized client tool_search output contains multiple tools with the same routed identity. Assign unique tool names or namespaces before resuming RunState.',
+    );
+  }
+  runtimeToolKeys.add(runtimeToolKey);
+}
+
 function collectSerializedRuntimeToolKeys(
   value: unknown,
   runtimeToolKeys: Set<string>,
   namespace?: string,
+  validateRecognizedShape = false,
 ): void {
   if (!value || typeof value !== 'object') {
     return;
@@ -1691,21 +2082,34 @@ function collectSerializedRuntimeToolKeys(
     type?: unknown;
     name?: unknown;
     namespace?: unknown;
+    deferLoading?: unknown;
+    defer_loading?: unknown;
     tools?: unknown;
     server_label?: unknown;
     providerData?: unknown;
   };
 
-  if (candidate.type === 'namespace' && Array.isArray(candidate.tools)) {
+  if (candidate.type === 'namespace') {
+    if (
+      typeof candidate.name !== 'string' ||
+      candidate.name.length === 0 ||
+      !Array.isArray(candidate.tools)
+    ) {
+      if (validateRecognizedShape) {
+        throw new UserError(
+          'Serialized client tool_search output contains a namespace without a valid routed identity.',
+        );
+      }
+      return;
+    }
     const nestedNamespace =
-      typeof candidate.name === 'string' && candidate.name.length > 0
-        ? candidate.name
-        : namespace;
+      typeof candidate.name === 'string' ? candidate.name : namespace;
     for (const nestedTool of candidate.tools) {
       collectSerializedRuntimeToolKeys(
         nestedTool,
         runtimeToolKeys,
         nestedNamespace,
+        true,
       );
     }
     return;
@@ -1717,21 +2121,52 @@ function collectSerializedRuntimeToolKeys(
       : namespace;
   if (candidate.type === 'function') {
     if (typeof candidate.name !== 'string' || candidate.name.length === 0) {
+      if (validateRecognizedShape) {
+        throw new UserError(
+          'Serialized client tool_search output contains a function without a valid routed identity.',
+        );
+      }
       return;
     }
+    const directNamespace =
+      typeof candidate.namespace === 'string' && candidate.namespace.length > 0
+        ? candidate.namespace
+        : undefined;
+    if (candidate.name === namespace || candidate.name === directNamespace) {
+      throw new UserError(
+        'Responses tool search reserves same-name namespaces for deferred top-level function tools. Rename the namespace or tool name to avoid ambiguous dispatch.',
+      );
+    }
 
-    runtimeToolKeys.add(
-      toolQualifiedName(candidate.name, explicitNamespace) ?? candidate.name,
+    const lookupKey = getFunctionToolLookupKey(
+      candidate.name,
+      explicitNamespace ??
+        (candidate.deferLoading === true || candidate.defer_loading === true
+          ? candidate.name
+          : undefined),
     );
+    if (lookupKey) {
+      addSerializedRuntimeToolKey(runtimeToolKeys, lookupKey);
+    }
     return;
   }
 
-  if (
-    candidate.type === 'mcp' &&
-    typeof candidate.server_label === 'string' &&
-    candidate.server_label.length > 0
-  ) {
-    runtimeToolKeys.add(`mcp:${candidate.server_label}`);
+  if (candidate.type === 'mcp') {
+    if (
+      typeof candidate.server_label !== 'string' ||
+      candidate.server_label.length === 0
+    ) {
+      if (validateRecognizedShape) {
+        throw new UserError(
+          'Serialized client tool_search output contains an MCP tool without a valid routed identity.',
+        );
+      }
+      return;
+    }
+    addSerializedRuntimeToolKey(
+      runtimeToolKeys,
+      `mcp:${candidate.server_label}`,
+    );
     return;
   }
 
@@ -1743,6 +2178,7 @@ function collectSerializedRuntimeToolKeys(
     candidate.providerData,
     runtimeToolKeys,
     explicitNamespace,
+    false,
   );
 }
 
@@ -1751,18 +2187,22 @@ function getSerializedRuntimeToolKeys(
 ): Set<string> {
   const runtimeToolKeys = new Set<string>();
   for (const tool of toolSearchOutput.tools) {
-    collectSerializedRuntimeToolKeys(tool, runtimeToolKeys);
+    collectSerializedRuntimeToolKeys(tool, runtimeToolKeys, undefined, true);
   }
   return runtimeToolKeys;
 }
 
 function getRuntimeToolKeys<TContext>(
   runtimeTools: Tool<TContext>[],
-  options: { allowUnsupported?: boolean } = {},
+  options: {
+    allowUnsupported?: boolean;
+    rejectDuplicateKeys?: boolean;
+  } = {},
 ): Set<string> {
   const runtimeToolKeys = new Set<string>();
+  const runtimeToolsByKey = new Map<string, Tool<TContext>>();
   for (const tool of runtimeTools) {
-    const runtimeToolKey = getToolSearchRuntimeToolKey(tool);
+    const runtimeToolKey = getToolSearchRuntimeRoutingKey(tool);
     if (!runtimeToolKey) {
       if (options.allowUnsupported) {
         continue;
@@ -1771,6 +2211,12 @@ function getRuntimeToolKeys<TContext>(
         'Client tool_search execute() returned an unsupported runtime tool during RunState rehydration.',
       );
     }
+    if (options.rejectDuplicateKeys && runtimeToolsByKey.has(runtimeToolKey)) {
+      throw new UserError(
+        'Client tool_search execute() returned multiple tools with the same routed identity during RunState rehydration.',
+      );
+    }
+    runtimeToolsByKey.set(runtimeToolKey, tool);
     runtimeToolKeys.add(runtimeToolKey);
   }
   return runtimeToolKeys;
@@ -1780,18 +2226,21 @@ function formatRuntimeToolKeys(runtimeToolKeys: Set<string>): string {
   return [...runtimeToolKeys].sort().join(', ');
 }
 
-function assertRuntimeToolKeysMatch<TContext>(args: {
+function selectSerializedRuntimeTools<TContext>(args: {
   agent: Agent<any, any>;
   toolSearchCall: protocol.ToolSearchCallItem;
   expectedRuntimeToolKeys: Set<string>;
-  runtimeTools: Tool<TContext>[];
-}): void {
-  const { agent, toolSearchCall, expectedRuntimeToolKeys, runtimeTools } = args;
-  if (expectedRuntimeToolKeys.size === 0) {
-    return;
-  }
-
-  const actualRuntimeToolKeys = getRuntimeToolKeys(runtimeTools);
+  enabledRuntimeTools: Tool<TContext>[];
+}): Tool<TContext>[] {
+  const {
+    agent,
+    toolSearchCall,
+    expectedRuntimeToolKeys,
+    enabledRuntimeTools,
+  } = args;
+  const actualRuntimeToolKeys = getRuntimeToolKeys(enabledRuntimeTools, {
+    rejectDuplicateKeys: true,
+  });
   const hasExpectedKeys = [...expectedRuntimeToolKeys].every((runtimeToolKey) =>
     actualRuntimeToolKeys.has(runtimeToolKey),
   );
@@ -1799,7 +2248,18 @@ function assertRuntimeToolKeysMatch<TContext>(args: {
     expectedRuntimeToolKeys.has(runtimeToolKey),
   );
   if (hasExpectedKeys && hasActualKeys) {
-    return;
+    return enabledRuntimeTools.filter((runtimeTool) => {
+      const runtimeToolKey = getToolSearchRuntimeRoutingKey(runtimeTool);
+      return (
+        runtimeToolKey != null && expectedRuntimeToolKeys.has(runtimeToolKey)
+      );
+    });
+  }
+
+  if (logger.dontLogToolData) {
+    throw new UserError(
+      'RunState cannot resume custom client tool_search because the registered execute callback returned different runtime tools than the serialized state.',
+    );
   }
 
   const callId = resolveToolSearchCallId(toolSearchCall);
@@ -1826,24 +2286,410 @@ async function getConfiguredAgentTools<TContext>(args: {
   return configuredTools;
 }
 
+type RunStateCapabilitySnapshot<TContext> = {
+  availableTools: Tool<TContext>[];
+  callbackTools: Tool<TContext>[];
+  handoffs: Handoff<any, any>[];
+  functionMap: Map<FunctionToolLookupKey, FunctionTool<TContext>>;
+  functionToolsByCallId: Map<string, FunctionTool<TContext>>;
+  runtimeFunctionTools: Set<FunctionTool<TContext>>;
+  handoffMap: Map<string, Handoff<any, any>>;
+  mcpToolMap: Map<string, HostedMCPTool>;
+  replaceableRuntimeToolKeys: Set<string>;
+};
+
+function throwAmbiguousFunctionCallId(
+  agent: Agent<any, any>,
+  callId: string,
+  routedToolKeys: Iterable<string>,
+): never {
+  if (logger.dontLogToolData) {
+    throw new UserError(
+      'RunState cannot resume because a function call ID is associated with multiple routed tool identities.',
+    );
+  }
+
+  throw new UserError(
+    `RunState cannot resume function call ${callId} for agent ${agent.name} because the call ID is reused across routed tool identities [${[
+      ...routedToolKeys,
+    ].join(', ')}]. Use a unique call ID for each function call.`,
+  );
+}
+
+type DeferredFunctionCallExpectation = {
+  agent: Agent<any, any>;
+  toolCall: protocol.FunctionCallItem;
+  resolvedRoutedToolKey: string;
+};
+
+function assertUnambiguousFunctionCallIds<
+  TContext,
+  TAgent extends Agent<any, any>,
+>(
+  state: RunState<TContext, TAgent>,
+  agentMap: Map<string, Agent<any, any>>,
+  serializedProcessedResponse?: z.infer<
+    typeof serializedProcessedResponseSchema
+  >,
+): DeferredFunctionCallExpectation[] {
+  const deferredFunctionCallExpectations: DeferredFunctionCallExpectation[] =
+    [];
+  const generatedCallsByAgent = new Map<Agent<any, any>, Map<string, string>>();
+  for (const item of state._generatedItems) {
+    if (
+      !(item instanceof RunToolCallItem) ||
+      item.rawItem.type !== 'function_call'
+    ) {
+      continue;
+    }
+    const agent = item.agent as Agent<any, any>;
+    const routedToolKey = getFunctionToolStateKeyForCall(item.rawItem);
+    if (!routedToolKey) {
+      continue;
+    }
+    const callsById = generatedCallsByAgent.get(agent) ?? new Map();
+    const previousRoutedToolKey = callsById.get(item.rawItem.callId);
+    if (previousRoutedToolKey && previousRoutedToolKey !== routedToolKey) {
+      throwAmbiguousFunctionCallId(agent, item.rawItem.callId, [
+        previousRoutedToolKey,
+        routedToolKey,
+      ]);
+    }
+    callsById.set(item.rawItem.callId, routedToolKey);
+    generatedCallsByAgent.set(agent, callsById);
+  }
+
+  type ProcessedFunctionCallIdentity = {
+    rawRoutedToolKey: string;
+    resolvedRoutedToolKey: string;
+  };
+  const processedCallsByAgent = new Map<
+    Agent<any, any>,
+    Map<string, ProcessedFunctionCallIdentity>
+  >();
+  if (serializedProcessedResponse) {
+    const agent = state._currentAgent as Agent<any, any>;
+    const processedCallsById = new Map<string, ProcessedFunctionCallIdentity>();
+    for (const functionCall of serializedProcessedResponse.functions) {
+      const toolCall = functionCall.toolCall as protocol.FunctionCallItem;
+      const rawRoutedToolKey = getFunctionToolStateKeyForCall(toolCall);
+      if (!rawRoutedToolKey) {
+        continue;
+      }
+      const serializedToolStateKey = getToolCallNamespace(toolCall)
+        ? rawRoutedToolKey
+        : getFunctionToolStateKey(functionCall.tool);
+      const resolvedRoutedToolKey = serializedToolStateKey
+        ? getFunctionToolStateKeyForResolvedCall(
+            toolCall,
+            functionCall.tool,
+            serializedToolStateKey,
+          )
+        : rawRoutedToolKey;
+      if (!resolvedRoutedToolKey) {
+        throwAmbiguousFunctionCallId(agent, toolCall.callId, [
+          rawRoutedToolKey,
+          serializedToolStateKey!,
+        ]);
+      }
+      if (resolvedRoutedToolKey !== rawRoutedToolKey) {
+        deferredFunctionCallExpectations.push({
+          agent,
+          toolCall,
+          resolvedRoutedToolKey,
+        });
+      }
+      const callId = toolCall.callId;
+      const previousProcessedIdentity = processedCallsById.get(callId);
+      if (
+        previousProcessedIdentity &&
+        previousProcessedIdentity.resolvedRoutedToolKey !==
+          resolvedRoutedToolKey
+      ) {
+        throwAmbiguousFunctionCallId(agent, callId, [
+          previousProcessedIdentity.resolvedRoutedToolKey,
+          resolvedRoutedToolKey,
+        ]);
+      }
+      const generatedRoutedToolKey = generatedCallsByAgent
+        .get(agent)
+        ?.get(callId);
+      if (
+        generatedRoutedToolKey &&
+        generatedRoutedToolKey !== rawRoutedToolKey
+      ) {
+        throwAmbiguousFunctionCallId(agent, callId, [
+          generatedRoutedToolKey,
+          rawRoutedToolKey,
+        ]);
+      }
+      processedCallsById.set(callId, {
+        rawRoutedToolKey,
+        resolvedRoutedToolKey,
+      });
+    }
+    processedCallsByAgent.set(agent, processedCallsById);
+  }
+
+  if (state._currentStep?.type !== 'next_step_interruption') {
+    return deferredFunctionCallExpectations;
+  }
+
+  for (const value of state._currentStep.data?.interruptions ?? []) {
+    if (!value || typeof value !== 'object') {
+      continue;
+    }
+    const interruption = value as {
+      rawItem?: unknown;
+      functionToolStateKey?: unknown;
+      agent?: unknown;
+    };
+    if (
+      !interruption.rawItem ||
+      typeof interruption.rawItem !== 'object' ||
+      (interruption.rawItem as { type?: unknown }).type !== 'function_call'
+    ) {
+      continue;
+    }
+    const rawItem = interruption.rawItem as protocol.FunctionCallItem;
+    const rawItemRoutedToolKey = getFunctionToolStateKeyForCall(rawItem);
+    if (!rawItemRoutedToolKey) {
+      continue;
+    }
+    const interruptionAgent =
+      interruption.agent && typeof interruption.agent === 'object'
+        ? resolveSerializedAgent(
+            interruption.agent as any,
+            agentMap,
+            state._currentAgent,
+          )
+        : (state._currentAgent as Agent<any, any>);
+    const generatedRoutedToolKey = generatedCallsByAgent
+      .get(interruptionAgent)
+      ?.get(rawItem.callId);
+    if (
+      generatedRoutedToolKey &&
+      generatedRoutedToolKey !== rawItemRoutedToolKey
+    ) {
+      throwAmbiguousFunctionCallId(interruptionAgent, rawItem.callId, [
+        generatedRoutedToolKey,
+        rawItemRoutedToolKey,
+      ]);
+    }
+    const processedIdentity = processedCallsByAgent
+      .get(interruptionAgent)
+      ?.get(rawItem.callId);
+    if (
+      processedIdentity &&
+      processedIdentity.rawRoutedToolKey !== rawItemRoutedToolKey
+    ) {
+      throwAmbiguousFunctionCallId(interruptionAgent, rawItem.callId, [
+        processedIdentity.rawRoutedToolKey,
+        rawItemRoutedToolKey,
+      ]);
+    }
+    const expectedRoutedToolKey =
+      processedIdentity?.resolvedRoutedToolKey ?? rawItemRoutedToolKey;
+    if (typeof interruption.functionToolStateKey === 'string') {
+      const validationRequiresPendingNestedState =
+        interruptionAgent !== state._currentAgent && !processedIdentity;
+      if (
+        !validationRequiresPendingNestedState &&
+        interruption.functionToolStateKey !== expectedRoutedToolKey
+      ) {
+        throwAmbiguousFunctionCallId(interruptionAgent, rawItem.callId, [
+          expectedRoutedToolKey,
+          interruption.functionToolStateKey,
+        ]);
+      }
+    }
+  }
+  return deferredFunctionCallExpectations;
+}
+
+function collectDeferredToolSearchProvenanceByCallId<TContext>(args: {
+  state: RunState<TContext, Agent<any, any>>;
+  effectiveToolSearchOutputs: RunToolSearchOutputItem[];
+  serializedRuntimeToolKeysByOutput: Map<RunToolSearchOutputItem, Set<string>>;
+}): Map<Agent<any, any>, Map<string, string>> {
+  const {
+    state,
+    effectiveToolSearchOutputs,
+    serializedRuntimeToolKeysByOutput,
+  } = args;
+  const effectiveOutputs = new Set(effectiveToolSearchOutputs);
+  const routedOwnersByAgent = new Map<
+    Agent<any, any>,
+    Map<string, RunToolSearchOutputItem>
+  >();
+  const entriesByReplacementKeyByAgent = new Map<
+    Agent<any, any>,
+    Map<string, RunToolSearchOutputItem>
+  >();
+  const deferredKeysByCallIdByAgent = new Map<
+    Agent<any, any>,
+    Map<string, string>
+  >();
+
+  for (const item of state._generatedItems) {
+    if (item instanceof RunToolSearchOutputItem && effectiveOutputs.has(item)) {
+      const agent = item.agent as Agent<any, any>;
+      const routedOwners = routedOwnersByAgent.get(agent) ?? new Map();
+      const entriesByReplacementKey =
+        entriesByReplacementKeyByAgent.get(agent) ?? new Map();
+      const replacementKey = getToolSearchOutputReplacementKey(item.rawItem);
+      if (replacementKey) {
+        const previousEntry = entriesByReplacementKey.get(replacementKey);
+        if (previousEntry) {
+          for (const [routedKey, owner] of routedOwners) {
+            if (owner === previousEntry) {
+              routedOwners.delete(routedKey);
+            }
+          }
+        }
+        entriesByReplacementKey.set(replacementKey, item);
+      }
+      for (const routedKey of serializedRuntimeToolKeysByOutput.get(item) ??
+        []) {
+        routedOwners.set(routedKey, item);
+      }
+      routedOwnersByAgent.set(agent, routedOwners);
+      entriesByReplacementKeyByAgent.set(agent, entriesByReplacementKey);
+      continue;
+    }
+
+    if (
+      !(item instanceof RunToolCallItem) ||
+      item.rawItem.type !== 'function_call' ||
+      getToolCallNamespace(item.rawItem)
+    ) {
+      continue;
+    }
+    const name = item.rawItem.name;
+    const bareKey = getFunctionToolLookupKey(name);
+    const deferredKey = getFunctionToolLookupKey(name, name);
+    const routedOwners = routedOwnersByAgent.get(item.agent);
+    if (
+      !bareKey ||
+      !deferredKey ||
+      routedOwners?.has(bareKey) ||
+      !routedOwners?.has(deferredKey)
+    ) {
+      continue;
+    }
+    const keysByCallId =
+      deferredKeysByCallIdByAgent.get(item.agent) ?? new Map();
+    keysByCallId.set(item.rawItem.callId, deferredKey);
+    deferredKeysByCallIdByAgent.set(item.agent, keysByCallId);
+  }
+
+  return deferredKeysByCallIdByAgent;
+}
+
+function assertDeferredFunctionCallProvenance<TContext>(args: {
+  expectations: DeferredFunctionCallExpectation[];
+  capabilitySnapshotsByAgent: Map<
+    Agent<TContext, any>,
+    RunStateCapabilitySnapshot<TContext>
+  >;
+  deferredToolSearchKeysByCallIdByAgent: Map<
+    Agent<any, any>,
+    Map<string, string>
+  >;
+}): void {
+  const {
+    expectations,
+    capabilitySnapshotsByAgent,
+    deferredToolSearchKeysByCallIdByAgent,
+  } = args;
+  for (const expectation of expectations) {
+    const snapshot = capabilitySnapshotsByAgent.get(expectation.agent);
+    if (snapshot?.handoffMap.has(expectation.toolCall.name)) {
+      throwAmbiguousFunctionCallId(
+        expectation.agent,
+        expectation.toolCall.callId,
+        [expectation.toolCall.name, expectation.resolvedRoutedToolKey],
+      );
+    }
+    const configuredOwner = snapshot
+      ? resolveFunctionToolCall(expectation.toolCall, snapshot.functionMap)
+      : undefined;
+    if (configuredOwner) {
+      if (
+        getFunctionToolStateKey(configuredOwner) ===
+        expectation.resolvedRoutedToolKey
+      ) {
+        continue;
+      }
+      throwAmbiguousFunctionCallId(
+        expectation.agent,
+        expectation.toolCall.callId,
+        [
+          getFunctionToolStateKey(configuredOwner) ?? configuredOwner.name,
+          expectation.resolvedRoutedToolKey,
+        ],
+      );
+    }
+    if (
+      deferredToolSearchKeysByCallIdByAgent
+        .get(expectation.agent)
+        ?.get(expectation.toolCall.callId) !== expectation.resolvedRoutedToolKey
+    ) {
+      throwAmbiguousFunctionCallId(
+        expectation.agent,
+        expectation.toolCall.callId,
+        [
+          getFunctionToolStateKeyForCall(expectation.toolCall) ??
+            expectation.toolCall.name,
+          expectation.resolvedRoutedToolKey,
+        ],
+      );
+    }
+  }
+}
+
 async function rehydrateToolSearchRuntimeTools<
   TContext,
   TAgent extends Agent<any, any>,
->(state: RunState<TContext, TAgent>): Promise<void> {
+>(
+  state: RunState<TContext, TAgent>,
+  options: {
+    agentMap: Map<string, Agent<any, any>>;
+    schemaVersion: SupportedSchemaVersion;
+    serializedProcessedResponse?: z.infer<
+      typeof serializedProcessedResponseSchema
+    >;
+    prepareCurrentAgentForLegacyApprovals?: boolean;
+  },
+): Promise<Map<Agent<TContext, any>, RunStateCapabilitySnapshot<TContext>>> {
+  const deferredFunctionCallExpectations = assertUnambiguousFunctionCallIds(
+    state,
+    options.agentMap,
+    options.serializedProcessedResponse,
+  );
   const configuredToolsByAgent = new Map<
     Agent<TContext, any>,
     Tool<TContext>[]
   >();
-  const pendingToolSearchCalls = new Map<
+  const capabilitySnapshotsByAgent = new Map<
     Agent<TContext, any>,
-    Map<
-      string,
-      {
-        agent: Agent<TContext, any>;
-        toolSearchCall: protocol.ToolSearchCallItem;
-        runtimeTools?: Tool<TContext>[];
-      }
-    >
+    RunStateCapabilitySnapshot<TContext>
+  >();
+  type ToolSearchCallOccurrence = {
+    pendingCall: {
+      agent: Agent<TContext, any>;
+      toolSearchCall: protocol.ToolSearchCallItem;
+    };
+    output?: RunToolSearchOutputItem;
+  };
+  const toolSearchCallOccurrences: ToolSearchCallOccurrence[] = [];
+  const latestOccurrenceByAgentAndCallId = new Map<
+    Agent<TContext, any>,
+    Map<string, ToolSearchCallOccurrence>
+  >();
+  const pendingOccurrencesByAgent = new Map<
+    Agent<TContext, any>,
+    ToolSearchCallOccurrence[]
   >();
 
   for (const item of state._generatedItems) {
@@ -1854,109 +2700,336 @@ async function rehydrateToolSearchRuntimeTools<
 
       const callId = resolveToolSearchCallId(item.rawItem);
       const agent = item.agent as Agent<TContext, any>;
-      const pendingCallsById =
-        pendingToolSearchCalls.get(agent) ??
-        new Map<
-          string,
-          {
-            agent: Agent<TContext, any>;
-            toolSearchCall: protocol.ToolSearchCallItem;
-            runtimeTools?: Tool<TContext>[];
-          }
-        >();
-      pendingCallsById.set(callId, {
-        agent: item.agent as Agent<TContext, any>,
-        toolSearchCall: item.rawItem,
-      });
-      pendingToolSearchCalls.set(agent, pendingCallsById);
+      const occurrence: ToolSearchCallOccurrence = {
+        pendingCall: {
+          agent,
+          toolSearchCall: item.rawItem,
+        },
+      };
+      toolSearchCallOccurrences.push(occurrence);
+      const pendingOccurrences = pendingOccurrencesByAgent.get(agent) ?? [];
+      pendingOccurrences.push(occurrence);
+      pendingOccurrencesByAgent.set(agent, pendingOccurrences);
+      const occurrencesByCallId =
+        latestOccurrenceByAgentAndCallId.get(agent) ?? new Map();
+      occurrencesByCallId.set(callId, occurrence);
+      latestOccurrenceByAgentAndCallId.set(agent, occurrencesByCallId);
       continue;
     }
 
-    if (!(item instanceof RunToolSearchOutputItem)) {
+    if (
+      !(item instanceof RunToolSearchOutputItem) ||
+      getToolSearchExecution(item.rawItem) === 'server'
+    ) {
       continue;
     }
 
-    if (getToolSearchExecution(item.rawItem) === 'server') {
-      continue;
+    const agent = item.agent as Agent<TContext, any>;
+    const explicitCallId = getToolSearchProviderCallId(item.rawItem);
+    const pendingOccurrences = pendingOccurrencesByAgent.get(agent) ?? [];
+    const occurrence = explicitCallId
+      ? latestOccurrenceByAgentAndCallId.get(agent)?.get(explicitCallId)
+      : pendingOccurrences.shift();
+    if (!occurrence) {
+      const callId = resolveToolSearchCallId(item.rawItem);
+      throw new UserError(
+        logger.dontLogToolData
+          ? 'RunState cannot resume custom client tool_search because the serialized state is missing the matching tool_search call item.'
+          : `RunState cannot resume custom client tool_search output ${callId} for agent ${item.agent.name} because the serialized state is missing the matching tool_search call item.`,
+      );
     }
+    if (explicitCallId) {
+      const pendingIndex = pendingOccurrences.indexOf(occurrence);
+      if (pendingIndex >= 0) {
+        pendingOccurrences.splice(pendingIndex, 1);
+      }
+    }
+    occurrence.output = item;
+  }
 
+  const effectiveToolSearchOutputs = toolSearchCallOccurrences
+    .map((occurrence) => occurrence.output)
+    .filter((item): item is RunToolSearchOutputItem => Boolean(item));
+  const occurrencesByOutput = new Map(
+    toolSearchCallOccurrences.flatMap((occurrence) =>
+      occurrence.output ? [[occurrence.output, occurrence] as const] : [],
+    ),
+  );
+  const serializedRuntimeToolKeysByOutput = new Map<
+    RunToolSearchOutputItem,
+    Set<string>
+  >();
+  for (const item of effectiveToolSearchOutputs) {
+    serializedRuntimeToolKeysByOutput.set(
+      item,
+      getSerializedRuntimeToolKeys(item.rawItem),
+    );
+  }
+
+  const agentsToPrepare = new Set(
+    effectiveToolSearchOutputs.map(
+      (item) => item.agent as Agent<TContext, any>,
+    ),
+  );
+  if (options.serializedProcessedResponse) {
+    agentsToPrepare.add(state._currentAgent as Agent<TContext, any>);
+  }
+  if (options.prepareCurrentAgentForLegacyApprovals) {
+    agentsToPrepare.add(state._currentAgent as Agent<TContext, any>);
+  }
+
+  for (const agent of agentsToPrepare) {
     const configuredTools = await getConfiguredAgentTools({
-      agent: item.agent as Agent<TContext, any>,
+      agent,
       context: state._context,
       configuredToolsByAgent,
     });
-    const configuredToolKeys = getRuntimeToolKeys(configuredTools, {
-      allowUnsupported: true,
-    });
-    const expectedRuntimeToolKeys = new Set(
-      [...getSerializedRuntimeToolKeys(item.rawItem)].filter(
-        (runtimeToolKey) => !configuredToolKeys.has(runtimeToolKey),
+    const existingRuntimeTools = state.getToolSearchRuntimeTools(agent);
+    const enabledRuntimeTools = await getEnabledToolSearchRuntimeTools(
+      state,
+      agent,
+    );
+    const capabilities = resolveModelVisibleToolNameCollisions(
+      [...configuredTools, ...enabledRuntimeTools],
+      await agent.getEnabledHandoffs(state._context),
+      'warn',
+    );
+    const availableTools = [...capabilities.tools];
+    capabilitySnapshotsByAgent.set(agent, {
+      availableTools,
+      callbackTools: [...availableTools],
+      handoffs: capabilities.handoffs,
+      functionMap: buildFunctionToolLookupMap(
+        availableTools.filter((tool) => tool.type === 'function'),
       ),
+      functionToolsByCallId: new Map(),
+      runtimeFunctionTools: new Set(
+        existingRuntimeTools.filter(
+          (tool): tool is FunctionTool<TContext> => tool.type === 'function',
+        ),
+      ),
+      handoffMap: new Map(
+        capabilities.handoffs.map((handoff) => [handoff.toolName, handoff]),
+      ),
+      mcpToolMap: new Map(
+        availableTools
+          .filter(
+            (tool): tool is HostedMCPTool =>
+              tool.type === 'hosted_tool' && tool.providerData?.type === 'mcp',
+          )
+          .map((tool) => [tool.providerData.server_label, tool]),
+      ),
+      replaceableRuntimeToolKeys: new Set(
+        existingRuntimeTools
+          .map((tool) => getToolSearchRuntimeRoutingKey(tool))
+          .filter((key): key is string => typeof key === 'string'),
+      ),
+    });
+  }
+
+  assertDeferredFunctionCallProvenance({
+    expectations: deferredFunctionCallExpectations,
+    capabilitySnapshotsByAgent,
+    deferredToolSearchKeysByCallIdByAgent:
+      collectDeferredToolSearchProvenanceByCallId({
+        state: state as RunState<TContext, Agent<any, any>>,
+        effectiveToolSearchOutputs,
+        serializedRuntimeToolKeysByOutput,
+      }),
+  });
+
+  if (
+    options.schemaVersion === CURRENT_SCHEMA_VERSION &&
+    options.serializedProcessedResponse
+  ) {
+    const currentAgent = state._currentAgent as Agent<TContext, any>;
+    const currentSnapshot = capabilitySnapshotsByAgent.get(currentAgent)!;
+    for (const serializedHandoff of options.serializedProcessedResponse
+      .handoffs) {
+      if (!serializedHandoff.targetAgent) {
+        throw new UserError(
+          'Run state handoff is missing its required target agent identity.',
+        );
+      }
+      const targetAgent = resolveSerializedAgent(
+        serializedHandoff.targetAgent,
+        options.agentMap,
+      );
+      const handoff = currentSnapshot.handoffMap.get(
+        serializedHandoff.handoff.toolName,
+      );
+      if (!handoff || handoff.agent !== targetAgent) {
+        throw new UserError(
+          `Handoff ${serializedHandoff.handoff.toolName} not found`,
+        );
+      }
+    }
+  }
+
+  for (const agent of new Set(
+    effectiveToolSearchOutputs.map(
+      (item) => item.agent as Agent<TContext, any>,
+    ),
+  )) {
+    validateClientToolSearchSupport(
+      capabilitySnapshotsByAgent.get(agent)!.availableTools,
+    );
+  }
+
+  type ToolSearchRehydrationRecord = {
+    pendingCall: {
+      agent: Agent<TContext, any>;
+      toolSearchCall: protocol.ToolSearchCallItem;
+    };
+    expectedRuntimeToolKeys: Set<string>;
+    toolSearchTool?: Tool<TContext>;
+    runtimeTools?: Tool<TContext>[];
+  };
+  const rehydrationRecords = new Map<
+    RunToolSearchOutputItem,
+    ToolSearchRehydrationRecord
+  >();
+
+  for (const item of effectiveToolSearchOutputs) {
+    const callId = resolveToolSearchCallId(item.rawItem);
+    const agent = item.agent as Agent<TContext, any>;
+    const snapshot = capabilitySnapshotsByAgent.get(agent)!;
+    const expectedRuntimeToolKeys =
+      serializedRuntimeToolKeysByOutput.get(item)!;
+    const pendingCall = occurrencesByOutput.get(item)!.pendingCall;
+
+    const toolSearchTool = getClientToolSearchHelper(snapshot.availableTools);
+    const hasCustomExecutor = Boolean(
+      toolSearchTool && getClientToolSearchExecutor(toolSearchTool),
     );
     if (expectedRuntimeToolKeys.size === 0) {
+      rehydrationRecords.set(item, {
+        pendingCall,
+        expectedRuntimeToolKeys,
+        ...(hasCustomExecutor ? { toolSearchTool } : {}),
+      });
+      continue;
+    }
+    if (!hasCustomExecutor) {
+      const availableRuntimeToolKeys = getRuntimeToolKeys(
+        snapshot.availableTools,
+        { allowUnsupported: true },
+      );
+      if (
+        [...expectedRuntimeToolKeys].every((runtimeToolKey) =>
+          availableRuntimeToolKeys.has(runtimeToolKey),
+        )
+      ) {
+        rehydrationRecords.set(item, {
+          pendingCall,
+          expectedRuntimeToolKeys,
+        });
+        continue;
+      }
+      if (logger.dontLogToolData) {
+        throw new UserError(
+          'RunState cannot resume custom client tool_search because the agent no longer provides toolSearchTool({ execution: "client", execute }).',
+        );
+      }
+      throw new UserError(
+        `RunState cannot resume custom client tool_search call ${callId} for agent ${pendingCall.agent.name} because the agent no longer provides toolSearchTool({ execution: "client", execute }).`,
+      );
+    }
+    rehydrationRecords.set(item, {
+      pendingCall,
+      expectedRuntimeToolKeys,
+      toolSearchTool,
+    });
+  }
+
+  for (const generatedItem of state._generatedItems) {
+    if (!(generatedItem instanceof RunToolSearchOutputItem)) {
+      continue;
+    }
+    const record = rehydrationRecords.get(generatedItem);
+    if (!record?.toolSearchTool) {
+      continue;
+    }
+    const agent = record.pendingCall.agent;
+    const snapshot = capabilitySnapshotsByAgent.get(agent)!;
+    const { runtimeTools, callbackRuntimeTools } =
+      await executeCustomClientToolSearch({
+        agent,
+        runContext: state._context,
+        toolSearchCall: record.pendingCall.toolSearchCall,
+        toolSearchTool: record.toolSearchTool,
+        tools: snapshot.callbackTools,
+      });
+    const serializedRuntimeTools = selectSerializedRuntimeTools({
+      agent,
+      toolSearchCall: record.pendingCall.toolSearchCall,
+      expectedRuntimeToolKeys: record.expectedRuntimeToolKeys,
+      enabledRuntimeTools: runtimeTools,
+    });
+    record.runtimeTools = serializedRuntimeTools;
+    snapshot.callbackTools.push(...callbackRuntimeTools);
+  }
+
+  for (const generatedItem of state._generatedItems) {
+    if (generatedItem instanceof RunToolSearchOutputItem) {
+      const record = rehydrationRecords.get(generatedItem);
+      if (!record?.runtimeTools) {
+        continue;
+      }
+      const agent = record.pendingCall.agent;
+      const snapshot = capabilitySnapshotsByAgent.get(agent)!;
+      const replacedRuntimeTools = state.getToolSearchRuntimeToolsForOutput(
+        agent,
+        generatedItem.rawItem,
+      );
+      const registeredRuntimeTools = registerRuntimeToolSearchTools({
+        availableTools: snapshot.availableTools,
+        functionMap: snapshot.functionMap,
+        handoffMap: snapshot.handoffMap,
+        mcpToolMap: snapshot.mcpToolMap,
+        replaceableRuntimeToolKeys: snapshot.replaceableRuntimeToolKeys,
+        replacedRuntimeTools,
+        runtimeTools: record.runtimeTools,
+      });
+      for (const runtimeTool of registeredRuntimeTools) {
+        if (runtimeTool.type === 'function') {
+          snapshot.runtimeFunctionTools.add(runtimeTool);
+        }
+      }
+
+      state.recordToolSearchRuntimeTools(
+        agent,
+        generatedItem.rawItem,
+        registeredRuntimeTools,
+      );
       continue;
     }
 
-    const callId = resolveToolSearchCallId(item.rawItem);
-    const pendingCall = pendingToolSearchCalls
-      .get(item.agent as Agent<TContext, any>)
-      ?.get(callId);
-    if (!pendingCall) {
-      throw new UserError(
-        `RunState cannot resume custom client tool_search output ${callId} for agent ${item.agent.name} because the serialized state is missing the matching tool_search call item.`,
-      );
-    }
-
-    if (!pendingCall.runtimeTools) {
-      const availableTools = [
-        ...configuredTools,
-        ...state.getToolSearchRuntimeTools(pendingCall.agent),
-      ];
-      const toolSearchTool = getClientToolSearchHelper(configuredTools);
-      if (!toolSearchTool || !getClientToolSearchExecutor(toolSearchTool)) {
-        throw new UserError(
-          `RunState cannot resume custom client tool_search call ${callId} for agent ${pendingCall.agent.name} because the agent no longer provides toolSearchTool({ execution: "client", execute }).`,
-        );
+    if (
+      generatedItem instanceof RunToolCallItem &&
+      generatedItem.rawItem.type === 'function_call'
+    ) {
+      const agent = generatedItem.agent as Agent<TContext, any>;
+      const snapshot = capabilitySnapshotsByAgent.get(agent);
+      if (!snapshot) {
+        continue;
       }
-
-      const { runtimeTools } = await executeCustomClientToolSearch({
-        agent: pendingCall.agent,
-        runContext: state._context,
-        toolSearchCall: pendingCall.toolSearchCall,
-        toolSearchTool,
-        tools: availableTools,
-      });
-      const rehydratedRuntimeTools = runtimeTools.filter((tool) => {
-        const runtimeToolKey = getToolSearchRuntimeToolKey(tool);
-        if (!runtimeToolKey) {
-          throw new UserError(
-            'Client tool_search execute() returned an unsupported runtime tool during RunState rehydration.',
+      const functionTool = resolveFunctionToolCall(
+        generatedItem.rawItem,
+        snapshot.functionMap,
+      );
+      if (functionTool) {
+        if (snapshot.runtimeFunctionTools.has(functionTool)) {
+          snapshot.functionToolsByCallId.set(
+            generatedItem.rawItem.callId,
+            functionTool,
           );
         }
-        return !configuredToolKeys.has(runtimeToolKey);
-      });
-      assertRuntimeToolKeysMatch({
-        agent: pendingCall.agent,
-        toolSearchCall: pendingCall.toolSearchCall,
-        expectedRuntimeToolKeys,
-        runtimeTools: rehydratedRuntimeTools,
-      });
-      pendingCall.runtimeTools = rehydratedRuntimeTools;
+      }
     }
-
-    const runtimeTools = pendingCall.runtimeTools;
-    if (!runtimeTools) {
-      throw new UserError(
-        `RunState cannot resume custom client tool_search call ${callId} for agent ${pendingCall.agent.name} because no runtime tools were rehydrated.`,
-      );
-    }
-
-    state.recordToolSearchRuntimeTools(
-      pendingCall.agent,
-      item.rawItem,
-      runtimeTools,
-    );
   }
+
+  return capabilitySnapshotsByAgent;
 }
 
 async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
@@ -1971,6 +3044,8 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
     : buildAgentMap(initialAgent);
   const contextOverride = options.contextOverride;
   const contextStrategy = options.contextStrategy ?? 'merge';
+  const schemaVersion = stateJson.$schemaVersion as SupportedSchemaVersion;
+  let deferredLegacyApprovalContext: RunContext<TContext> | undefined;
 
   //
   // Rebuild the context
@@ -1978,17 +3053,49 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
   const context =
     contextOverride ??
     new RunContext<TContext>(stateJson.context.context as TContext);
+  context._validateFunctionApprovalOwners(
+    stateJson.context.functionApprovals ?? [],
+    agentMap,
+  );
   if (contextOverride) {
     if (contextStrategy === 'merge') {
-      context._mergeApprovals(stateJson.context.approvals);
+      if (schemaVersion === CURRENT_SCHEMA_VERSION) {
+        context._mergeApprovals(stateJson.context.approvals);
+        context._mergeFunctionApprovals(
+          stateJson.context.functionApprovals ?? [],
+          agentMap,
+        );
+        context._mergeLegacyFunctionApprovals(
+          stateJson.context.legacyFunctionApprovals ?? {},
+        );
+      } else {
+        deferredLegacyApprovalContext = new RunContext<TContext>(
+          stateJson.context.context as TContext,
+        );
+        deferredLegacyApprovalContext._rebuildApprovals(
+          stateJson.context.approvals,
+        );
+        deferredLegacyApprovalContext._rebuildLegacyFunctionApprovals(
+          stateJson.context.approvals,
+        );
+      }
     }
   } else {
     context._rebuildApprovals(stateJson.context.approvals);
+    context._rebuildFunctionApprovals(
+      stateJson.context.functionApprovals ?? [],
+      agentMap,
+    );
+    context._rebuildLegacyFunctionApprovals(
+      schemaVersion === CURRENT_SCHEMA_VERSION
+        ? (stateJson.context.legacyFunctionApprovals ?? {})
+        : stateJson.context.approvals,
+    );
   }
-  const shouldRestoreToolInput =
+  const shouldRestoreSerializedContext =
     !contextOverride || contextStrategy === 'merge';
   if (
-    shouldRestoreToolInput &&
+    shouldRestoreSerializedContext &&
     typeof stateJson.context.toolInput !== 'undefined' &&
     typeof context.toolInput === 'undefined'
   ) {
@@ -2043,6 +3150,7 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
   state._pendingAgentToolRuns = new Map(
     Object.entries(stateJson.pendingAgentToolRuns ?? {}),
   );
+  state._pendingAgentToolRunAliases = new Map();
 
   // rebuild current agent span
   if (stateJson.currentAgentSpan) {
@@ -2095,15 +3203,38 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
   state._pendingLegacyCompactionSessionItems =
     stateJson.pendingLegacyCompactionSessionItems;
   state._sandbox = stateJson.sandbox ?? undefined;
-  await rehydrateToolSearchRuntimeTools(state);
+  const capabilitySnapshotsByAgent = await rehydrateToolSearchRuntimeTools(
+    state,
+    {
+      agentMap,
+      schemaVersion,
+      serializedProcessedResponse: stateJson.lastProcessedResponse,
+      prepareCurrentAgentForLegacyApprovals:
+        schemaVersion !== CURRENT_SCHEMA_VERSION &&
+        shouldRestoreSerializedContext &&
+        Object.keys(stateJson.context.approvals).length > 0,
+    },
+  );
+  const currentCapabilitySnapshot = capabilitySnapshotsByAgent.get(
+    state._currentAgent as Agent<TContext, any>,
+  );
   state._lastProcessedResponse = stateJson.lastProcessedResponse
     ? await deserializeProcessedResponse(
         agentMap,
         state,
         stateJson.lastProcessedResponse,
+        {
+          executionTools: currentCapabilitySnapshot!.availableTools,
+          executionHandoffs: currentCapabilitySnapshot!.handoffs,
+          executionFunctionToolsByCallId:
+            currentCapabilitySnapshot!.functionToolsByCallId,
+        },
       )
     : undefined;
-
+  restorePendingAgentToolRunAliases(
+    state,
+    stateJson.pendingAgentToolRunAliases ?? {},
+  );
   if (stateJson.currentStep?.type === 'next_step_handoff') {
     state._currentStep = {
       type: 'next_step_handoff',
@@ -2113,17 +3244,71 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
       ) as TAgent,
     };
   } else if (stateJson.currentStep?.type === 'next_step_interruption') {
+    const interruptions = deserializeInterruptions(
+      stateJson.currentStep.data?.interruptions,
+      agentMap,
+      state._currentAgent,
+    );
+    rebindInterruptionFunctionToolStateKeys(
+      interruptions,
+      state._lastProcessedResponse,
+      state._currentAgent,
+      state,
+      schemaVersion,
+    );
     state._currentStep = {
       type: 'next_step_interruption',
       data: {
         ...stateJson.currentStep.data,
-        interruptions: deserializeInterruptions(
-          stateJson.currentStep.data?.interruptions,
-          agentMap,
-          state._currentAgent,
-        ),
+        interruptions,
       },
     };
+  }
+  const legacyAvailableToolsByAgent = new Map<
+    Agent<any, any>,
+    Tool<TContext>[]
+  >();
+  for (const agent of new Set(agentMap.values())) {
+    legacyAvailableToolsByAgent.set(agent, [
+      ...(agent.tools as Tool<TContext>[]),
+    ]);
+  }
+  for (const [agent, snapshot] of capabilitySnapshotsByAgent) {
+    const configuredTools = legacyAvailableToolsByAgent.get(agent) ?? [];
+    legacyAvailableToolsByAgent.set(agent, [
+      ...new Set([...configuredTools, ...snapshot.availableTools]),
+    ]);
+  }
+  const legacyFunctionApprovalKeys = migrateLegacyFunctionToolState(
+    state,
+    schemaVersion,
+    shouldRestoreSerializedContext,
+    deferredLegacyApprovalContext,
+    legacyAvailableToolsByAgent,
+  );
+  const legacyApprovalContext = deferredLegacyApprovalContext ?? context;
+  if (schemaVersion !== CURRENT_SCHEMA_VERSION) {
+    legacyApprovalContext._retainLegacyFunctionApprovals(
+      legacyFunctionApprovalKeys,
+    );
+    legacyApprovalContext._removeMigratedFunctionApprovalsFromAggregate(
+      legacyFunctionApprovalKeys,
+      new Set(
+        [...legacyAvailableToolsByAgent.values()].flatMap((tools) =>
+          tools.flatMap((tool) =>
+            tool.type !== 'function' && typeof tool.name === 'string'
+              ? [tool.name]
+              : [],
+          ),
+        ),
+      ),
+    );
+  }
+  if (deferredLegacyApprovalContext) {
+    context._mergeApprovalStatePreservingExactKeys(
+      deferredLegacyApprovalContext,
+      legacyFunctionApprovalKeys,
+    );
   }
   return state;
 }
@@ -2148,6 +3333,13 @@ export async function rehydrateProcessedResponseTools<
     state._lastProcessedResponse,
     agentIdentity.byAgent,
   );
+  const executionFunctionToolsByCallId = new Map(
+    state._lastProcessedResponse.functions.flatMap((functionCall) =>
+      functionCall.preserveToolOnExecutionRehydration
+        ? [[functionCall.toolCall.callId, functionCall.tool] as const]
+        : [],
+    ),
+  );
 
   state._lastProcessedResponse = await deserializeProcessedResponse(
     agentIdentity.byIdentity,
@@ -2155,6 +3347,7 @@ export async function rehydrateProcessedResponseTools<
     serializedProcessedResponse,
     {
       executionTools,
+      executionFunctionToolsByCallId,
       allowSerializedExecutionToolPlaceholder: false,
     },
   );
@@ -2306,6 +3499,20 @@ function serializeProcessedResponse<TContext>(
     newItems: processedResponse.newItems.map((item) =>
       serializeRunItem(item, agentIdentityKeys),
     ),
+    functions: processedResponse.functions.map(({ toolCall, tool }) => ({
+      toolCall,
+      tool,
+    })),
+    handoffs: processedResponse.handoffs.map(
+      ({ toolCall, handoff: processedHandoff }) => ({
+        toolCall,
+        handoff: processedHandoff,
+        targetAgent: serializeAgentReference(
+          processedHandoff.agent,
+          agentIdentityKeys,
+        ),
+      }),
+    ),
   } as z.infer<typeof serializedProcessedResponseSchema>;
 }
 
@@ -2417,6 +3624,7 @@ export function deserializeItem(
         serializedItem.rawItem,
         resolveSerializedAgent(serializedItem.agent, agentMap),
         serializedItem.toolName,
+        serializedItem.functionToolStateKey,
       );
   }
 }
@@ -2442,6 +3650,7 @@ function deserializeInterruptionItem(
         parsed.data.rawItem,
         mappedAgent,
         parsed.data.toolName,
+        parsed.data.functionToolStateKey,
       );
     }
 
@@ -2456,6 +3665,7 @@ function deserializeInterruptionItem(
   const value = serializedItem as {
     rawItem?: unknown;
     toolName?: unknown;
+    functionToolStateKey?: unknown;
     agent?: { name?: unknown; identity?: unknown };
   };
 
@@ -2499,11 +3709,16 @@ function deserializeInterruptionItem(
       : typeof rawItem.name === 'string'
         ? rawItem.name
         : undefined;
+  const functionToolStateKey =
+    typeof value.functionToolStateKey === 'string'
+      ? value.functionToolStateKey
+      : undefined;
 
   return new RunToolApprovalItem(
     value.rawItem as RunToolApprovalItem['rawItem'],
     mappedAgent,
     toolName,
+    functionToolStateKey,
   );
 }
 
@@ -2524,8 +3739,407 @@ function deserializeInterruptions(
     );
 }
 
+function rebindInterruptionFunctionToolStateKeys<TContext>(
+  interruptions: RunToolApprovalItem[],
+  processedResponse: ProcessedResponse<TContext> | undefined,
+  processedAgent: Agent<any, any>,
+  state: RunState<TContext, Agent<any, any>>,
+  schemaVersion: SupportedSchemaVersion,
+): void {
+  if (!processedResponse) {
+    for (const interruption of interruptions) {
+      if (
+        interruption.rawItem.type !== 'function_call' ||
+        !interruption.functionToolStateKey
+      ) {
+        continue;
+      }
+      const rawStateKey = getFunctionToolStateKeyForCall(interruption.rawItem);
+      if (rawStateKey && interruption.functionToolStateKey !== rawStateKey) {
+        throwAmbiguousFunctionCallId(
+          interruption.agent,
+          interruption.rawItem.callId,
+          [rawStateKey, interruption.functionToolStateKey],
+        );
+      }
+    }
+    return;
+  }
+
+  const functionsByCallId = new Map(
+    processedResponse.functions.map((functionCall) => [
+      functionCall.toolCall.callId,
+      functionCall,
+    ]),
+  );
+  for (const interruption of interruptions) {
+    if (interruption.rawItem.type !== 'function_call') {
+      continue;
+    }
+    let stateKey: string | undefined;
+    if (interruption.agent === processedAgent) {
+      stateKey = getFunctionToolStateKey(
+        functionsByCallId.get(interruption.rawItem.callId)?.tool,
+      );
+    } else {
+      stateKey = findNestedInterruptionFunctionToolStateKey(
+        state,
+        interruption,
+      );
+      if (schemaVersion === CURRENT_SCHEMA_VERSION) {
+        const rawStateKey = getFunctionToolStateKeyForCall(
+          interruption.rawItem,
+        );
+        const serializedStateKey = interruption.functionToolStateKey;
+        const expectedStateKey = stateKey ?? rawStateKey;
+        if (
+          serializedStateKey &&
+          expectedStateKey &&
+          serializedStateKey !== expectedStateKey
+        ) {
+          throwAmbiguousFunctionCallId(
+            interruption.agent,
+            interruption.rawItem.callId,
+            [expectedStateKey, serializedStateKey],
+          );
+        }
+      }
+    }
+    if (stateKey) {
+      interruption.functionToolStateKey = stateKey;
+    }
+  }
+}
+
+function findNestedInterruptionFunctionToolStateKey<TContext>(
+  state: RunState<TContext, Agent<any, any>>,
+  interruption: RunToolApprovalItem,
+): string | undefined {
+  if (interruption.rawItem.type !== 'function_call') {
+    return undefined;
+  }
+
+  const serializedPendingStates = new Set<string>();
+  for (const functionCall of state._lastProcessedResponse?.functions ?? []) {
+    if (getAgentToolSourceAgent(functionCall.tool) !== interruption.agent) {
+      continue;
+    }
+    const stateKeys = getFunctionToolStateKeys(
+      functionCall.tool,
+      functionCall.availableFunctionTools ?? [functionCall.tool],
+    );
+    for (const stateKey of stateKeys) {
+      const serializedState = state.getPendingAgentToolRun(
+        stateKey,
+        functionCall.toolCall.callId,
+      );
+      if (serializedState) {
+        serializedPendingStates.add(serializedState);
+      }
+    }
+  }
+
+  const resolvedStateKeys = new Set<string>();
+  for (const serializedState of serializedPendingStates) {
+    const resolvedStateKey =
+      getSerializedNestedInterruptionFunctionToolStateKey(
+        serializedState,
+        interruption.rawItem,
+      );
+    if (resolvedStateKey) {
+      resolvedStateKeys.add(resolvedStateKey);
+    }
+  }
+  if (resolvedStateKeys.size > 1) {
+    throwAmbiguousFunctionCallId(
+      interruption.agent,
+      interruption.rawItem.callId,
+      [...resolvedStateKeys],
+    );
+  }
+  return resolvedStateKeys.values().next().value;
+}
+
+function getSerializedNestedInterruptionFunctionToolStateKey(
+  serializedState: string,
+  interruptionRawItem: protocol.FunctionCallItem,
+): string | undefined {
+  let nestedState: unknown;
+  try {
+    nestedState = JSON.parse(serializedState);
+  } catch {
+    return undefined;
+  }
+  if (!nestedState || typeof nestedState !== 'object') {
+    return undefined;
+  }
+
+  const candidate = nestedState as {
+    currentStep?: {
+      type?: unknown;
+      data?: { interruptions?: unknown };
+    };
+    lastProcessedResponse?: {
+      functions?: unknown;
+    };
+  };
+  if (
+    candidate.currentStep?.type !== 'next_step_interruption' ||
+    !Array.isArray(candidate.currentStep.data?.interruptions) ||
+    !candidate.currentStep.data.interruptions.some((value) => {
+      if (!value || typeof value !== 'object') {
+        return false;
+      }
+      const rawItem = (value as { rawItem?: unknown }).rawItem;
+      return (
+        rawItem != null &&
+        typeof rawItem === 'object' &&
+        (rawItem as { type?: unknown }).type === 'function_call' &&
+        (rawItem as { callId?: unknown }).callId ===
+          interruptionRawItem.callId &&
+        getFunctionToolStateKeyForCall(rawItem as protocol.FunctionCallItem) ===
+          getFunctionToolStateKeyForCall(interruptionRawItem)
+      );
+    }) ||
+    !Array.isArray(candidate.lastProcessedResponse?.functions)
+  ) {
+    return undefined;
+  }
+
+  const stateKeys = new Set<string>();
+  for (const value of candidate.lastProcessedResponse.functions) {
+    if (!value || typeof value !== 'object') {
+      continue;
+    }
+    const functionCall = value as { toolCall?: unknown; tool?: unknown };
+    if (
+      !functionCall.toolCall ||
+      typeof functionCall.toolCall !== 'object' ||
+      (functionCall.toolCall as { callId?: unknown }).callId !==
+        interruptionRawItem.callId
+    ) {
+      continue;
+    }
+    const stateKey = getFunctionToolStateKey(functionCall.tool);
+    if (
+      stateKey &&
+      getFunctionToolStateKeyForResolvedCall(
+        interruptionRawItem,
+        functionCall.tool,
+        stateKey,
+      ) === stateKey
+    ) {
+      stateKeys.add(stateKey);
+    }
+  }
+  if (stateKeys.size !== 1) {
+    return undefined;
+  }
+  return stateKeys.values().next().value;
+}
+
+function restorePendingAgentToolRunAliases<TContext>(
+  state: RunState<TContext, Agent<any, any>>,
+  serializedAliases: Record<string, string>,
+): void {
+  const aliasEntries = Object.entries(serializedAliases);
+  if (aliasEntries.length === 0) {
+    return;
+  }
+
+  const validAliases = new Map<string, string>();
+  for (const functionCall of state._lastProcessedResponse?.functions ?? []) {
+    const [canonicalToolName, ...aliases] = getFunctionToolStateKeys(
+      functionCall.tool,
+      functionCall.availableFunctionTools ?? [functionCall.tool],
+    );
+    if (!canonicalToolName) {
+      continue;
+    }
+    const callId = functionCall.toolCall.callId;
+    const canonicalKey = `${canonicalToolName}:${callId}`;
+    for (const alias of aliases) {
+      validAliases.set(`${alias}:${callId}`, canonicalKey);
+    }
+  }
+
+  for (const [aliasKey, canonicalKey] of aliasEntries) {
+    if (
+      validAliases.get(aliasKey) !== canonicalKey ||
+      !state._pendingAgentToolRuns.has(canonicalKey)
+    ) {
+      throw new UserError(
+        'Run state pending agent tool aliases do not match the reconstructed pending function calls.',
+      );
+    }
+  }
+
+  state._pendingAgentToolRunAliases = new Map(aliasEntries);
+}
+
+function migrateLegacyFunctionToolState<TContext>(
+  state: RunState<TContext, Agent<any, any>>,
+  schemaVersion: SupportedSchemaVersion,
+  migrateApprovals: boolean,
+  approvalContext: RunContext<TContext> = state._context,
+  availableToolsByAgent: ReadonlyMap<
+    Agent<any, any>,
+    readonly Tool<TContext>[]
+  > = new Map(),
+): Set<string> {
+  if (schemaVersion === CURRENT_SCHEMA_VERSION) {
+    return new Set();
+  }
+
+  const approvalCallsByLegacyKey = new Map<
+    string,
+    Map<Agent<any, any>, Map<string, Set<string>>>
+  >();
+  const approvalOwnersByLegacyKey = new Map<
+    string,
+    Map<Agent<any, any>, Set<string>>
+  >();
+  const addApprovalOwner = (
+    legacyKey: string,
+    agent: Agent<any, any>,
+    canonicalKey: string,
+  ) => {
+    const ownersByAgent =
+      approvalOwnersByLegacyKey.get(legacyKey) ??
+      new Map<Agent<any, any>, Set<string>>();
+    const ownerKeys = ownersByAgent.get(agent) ?? new Set<string>();
+    ownerKeys.add(canonicalKey);
+    ownersByAgent.set(agent, ownerKeys);
+    approvalOwnersByLegacyKey.set(legacyKey, ownersByAgent);
+  };
+  const addApprovalCall = (
+    legacyKey: string,
+    agent: Agent<any, any>,
+    canonicalKey: string,
+    callId: string,
+  ) => {
+    addApprovalOwner(legacyKey, agent, canonicalKey);
+    const callsByAgent =
+      approvalCallsByLegacyKey.get(legacyKey) ??
+      new Map<Agent<any, any>, Map<string, Set<string>>>();
+    const callsByCanonicalKey =
+      callsByAgent.get(agent) ?? new Map<string, Set<string>>();
+    const callIds = callsByCanonicalKey.get(canonicalKey) ?? new Set<string>();
+    callIds.add(callId);
+    callsByCanonicalKey.set(canonicalKey, callIds);
+    callsByAgent.set(agent, callsByCanonicalKey);
+    approvalCallsByLegacyKey.set(legacyKey, callsByAgent);
+  };
+  for (const [agent, availableTools] of availableToolsByAgent) {
+    for (const tool of availableTools) {
+      if (tool.type !== 'function') {
+        continue;
+      }
+      const canonicalKey = getFunctionToolStateKey(tool);
+      const legacyKey = getFunctionToolQualifiedName(tool) ?? tool.name;
+      if (!canonicalKey || canonicalKey === legacyKey) {
+        continue;
+      }
+      addApprovalOwner(legacyKey, agent, canonicalKey);
+    }
+  }
+
+  for (const functionCall of state._lastProcessedResponse?.functions ?? []) {
+    const canonicalKey = getFunctionToolStateKey(functionCall.tool);
+    const legacyKey =
+      getFunctionToolQualifiedName(functionCall.tool) ?? functionCall.tool.name;
+    if (!canonicalKey || canonicalKey === legacyKey) {
+      continue;
+    }
+    const callId = functionCall.toolCall.callId;
+    const pendingState = state.getPendingAgentToolRun(legacyKey, callId);
+    if (pendingState !== undefined) {
+      state.setPendingAgentToolRun(canonicalKey, callId, pendingState, [
+        legacyKey,
+      ]);
+    }
+    if (!migrateApprovals) {
+      continue;
+    }
+    addApprovalCall(legacyKey, state._currentAgent, canonicalKey, callId);
+  }
+
+  if (state._currentStep?.type === 'next_step_interruption') {
+    for (const interruption of state._currentStep.data.interruptions) {
+      if (
+        interruption.rawItem.type !== 'function_call' ||
+        !interruption.functionToolStateKey
+      ) {
+        continue;
+      }
+      const legacyKey = getFunctionToolLegacyStateKeyFromStateKey(
+        interruption.functionToolStateKey,
+      );
+      if (!legacyKey) {
+        continue;
+      }
+      addApprovalCall(
+        legacyKey,
+        interruption.agent,
+        interruption.functionToolStateKey,
+        interruption.rawItem.callId,
+      );
+    }
+  }
+
+  if (migrateApprovals) {
+    for (const [legacyKey, ownersByAgent] of approvalOwnersByLegacyKey) {
+      const ownerEntries = [...ownersByAgent].flatMap(
+        ([agent, canonicalKeys]) =>
+          [...canonicalKeys].map((canonicalKey) => ({ agent, canonicalKey })),
+      );
+      if (ownerEntries.length !== 1) {
+        continue;
+      }
+      const [{ agent, canonicalKey }] = ownerEntries;
+      approvalContext._migrateToolApproval(
+        agent,
+        legacyKey,
+        canonicalKey,
+        [],
+        true,
+      );
+    }
+  }
+
+  for (const [legacyKey, callsByAgent] of approvalCallsByLegacyKey) {
+    const callOwners = new Map<string, number>();
+    for (const callsByCanonicalKey of callsByAgent.values()) {
+      for (const callIds of callsByCanonicalKey.values()) {
+        for (const callId of callIds) {
+          callOwners.set(callId, (callOwners.get(callId) ?? 0) + 1);
+        }
+      }
+    }
+    for (const [agent, callsByCanonicalKey] of callsByAgent) {
+      for (const [canonicalKey, callIds] of callsByCanonicalKey) {
+        for (const callId of callIds) {
+          const remainingOwners = (callOwners.get(callId) ?? 1) - 1;
+          callOwners.set(callId, remainingOwners);
+          approvalContext._migrateToolApproval(
+            agent,
+            legacyKey,
+            canonicalKey,
+            [callId],
+            false,
+            remainingOwners > 0,
+          );
+        }
+      }
+    }
+  }
+  return new Set(approvalOwnersByLegacyKey.keys());
+}
+
 type DeserializeProcessedResponseOptions<TContext> = {
   executionTools?: Tool<TContext>[];
+  executionHandoffs?: Handoff<any, any>[];
+  executionFunctionToolsByCallId?: Map<string, FunctionTool<TContext>>;
   allowSerializedExecutionToolPlaceholder?: boolean;
 };
 
@@ -2541,19 +4155,19 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
   options: DeserializeProcessedResponseOptions<TContext> = {},
 ): Promise<ProcessedResponse<TContext>> {
   const currentAgent = state._currentAgent;
-  const configuredTools =
-    options.executionTools ?? (await currentAgent.getAllTools(state._context));
-  const allTools = [
-    ...(configuredTools as Tool<TContext>[]),
-    ...state.getToolSearchRuntimeTools(currentAgent),
-  ];
+  const allTools = options.executionTools
+    ? options.executionTools
+    : [
+        ...((await currentAgent.getAllTools(
+          state._context,
+        )) as Tool<TContext>[]),
+        ...(await getEnabledToolSearchRuntimeTools(state, currentAgent)),
+      ];
   const baseAgentTools = currentAgent.tools as Tool<TContext>[];
   const allowSerializedExecutionToolPlaceholder =
     options.allowSerializedExecutionToolPlaceholder ?? true;
-  const tools = new Map(
-    allTools
-      .filter((tool) => tool.type === 'function')
-      .map((tool) => [getFunctionToolQualifiedName(tool) ?? tool.name, tool]),
+  const tools = buildFunctionToolLookupMap(
+    allTools.filter((tool) => tool.type === 'function'),
   );
   const computerTools = new Map(
     allTools
@@ -2596,14 +4210,11 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
       )
       .map((tool) => [tool.providerData.server_label, tool]),
   );
+  const enabledHandoffs = options.executionHandoffs
+    ? options.executionHandoffs
+    : await currentAgent.getEnabledHandoffs(state._context);
   const handoffs = new Map(
-    currentAgent.handoffs.map((entry) => {
-      if (entry instanceof Agent) {
-        return [entry.name, handoff(entry)];
-      }
-
-      return [entry.toolName, entry];
-    }),
+    enabledHandoffs.map((entry) => [entry.toolName, entry]),
   );
 
   const result = {
@@ -2611,31 +4222,60 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
       deserializeItem(item, agentMap),
     ),
     toolsUsed: serializedProcessedResponse.toolsUsed,
-    handoffs: serializedProcessedResponse.handoffs.map((handoff) => {
-      if (!handoffs.has(handoff.handoff.toolName)) {
-        throw new UserError(`Handoff ${handoff.handoff.toolName} not found`);
+    handoffs: serializedProcessedResponse.handoffs.map((serializedHandoff) => {
+      const toolName = serializedHandoff.handoff.toolName;
+      const resolvedHandoff = handoffs.get(toolName);
+      const serializedTargetAgent = serializedHandoff.targetAgent
+        ? resolveSerializedAgent(serializedHandoff.targetAgent, agentMap)
+        : undefined;
+      const targetMatches = serializedTargetAgent
+        ? resolvedHandoff?.agent === serializedTargetAgent
+        : resolvedHandoff?.agentName === serializedHandoff.handoff.agentName;
+      if (!resolvedHandoff || !targetMatches) {
+        throw new UserError(`Handoff ${toolName} not found`);
       }
-
-      const resolvedHandoff = handoffs.get(handoff.handoff.toolName)!;
       ensureToolCallerAllowed(
-        handoff.toolCall as protocol.FunctionCallItem,
+        serializedHandoff.toolCall as protocol.FunctionCallItem,
         undefined,
         resolvedHandoff.toolName,
         currentAgent,
       );
 
       return {
-        toolCall: handoff.toolCall,
+        toolCall: serializedHandoff.toolCall,
         handoff: resolvedHandoff,
       };
     }),
     functions: await Promise.all(
       serializedProcessedResponse.functions.map(async (functionCall) => {
         const toolIdentity =
-          resolveFunctionToolCallName(functionCall.toolCall, tools) ??
+          getToolCallDisplayName(functionCall.toolCall) ??
           functionCall.tool.name;
+        const exactRuntimeTool = options.executionFunctionToolsByCallId?.get(
+          functionCall.toolCall.callId,
+        );
+        if (
+          exactRuntimeTool &&
+          !getFunctionToolStateKeyForResolvedCall(
+            functionCall.toolCall as protocol.FunctionCallItem,
+            exactRuntimeTool,
+          )
+        ) {
+          throwAmbiguousFunctionCallId(
+            currentAgent,
+            functionCall.toolCall.callId,
+            [
+              getFunctionToolStateKey(exactRuntimeTool) ??
+                exactRuntimeTool.name,
+              getFunctionToolStateKeyForCall(
+                functionCall.toolCall as protocol.FunctionCallItem,
+              ) ?? functionCall.tool.name,
+            ],
+          );
+        }
         const resolvedTool =
-          tools.get(toolIdentity) ??
+          exactRuntimeTool ??
+          resolveFunctionToolCall(functionCall.toolCall, tools) ??
           getSerializedFunctionToolPlaceholder({
             agent: currentAgent,
             baseAgentTools,
@@ -2655,10 +4295,14 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
           currentAgent,
         );
 
-        return {
+        return createToolRunFunction({
           toolCall: functionCall.toolCall,
           tool: resolvedTool,
-        };
+          availableFunctionTools: [
+            ...new Set([...tools.values(), resolvedTool]),
+          ],
+          preserveToolOnExecutionRehydration: Boolean(exactRuntimeTool),
+        });
       }),
     ),
     functionToolsNotFound:
@@ -2794,4 +4438,15 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
       );
     },
   };
+}
+
+async function getEnabledToolSearchRuntimeTools<TContext>(
+  state: RunState<TContext, Agent<any, any>>,
+  agent: Agent<any, any>,
+): Promise<Tool<TContext>[]> {
+  return filterEnabledToolSearchRuntimeTools({
+    runtimeTools: state.getToolSearchRuntimeTools(agent),
+    runContext: state._context,
+    agent,
+  });
 }

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -1538,30 +1538,41 @@ function rehydrateLegacyCompactionRunItems(
   const processedItems = isLatestSourceResponse
     ? stateJson.lastProcessedResponse?.newItems
     : undefined;
+  const optionalLatestFunctionCallIndices =
+    getOmittedLegacyHandoffFunctionCallIndices(
+      sourceResponses.at(-1)?.output ?? [],
+      stateJson.lastProcessedResponse,
+    );
   const processedInsertion = processedItems
     ? findLegacyCompactionInsertionIndex(
         processedItems,
         sourceResponse.output,
         compactionIndex,
+        optionalLatestFunctionCallIndices,
       )
     : undefined;
   let generatedInsertionAgent: SerializedAgentReference | undefined;
   let generatedInsertionIndex: number;
   if (!isLatestSourceResponse) {
-    const followingResponseBoundary =
-      sourceResponseIndex === sourceResponses.length - 2 &&
-      stateJson.lastProcessedResponse
-        ? findFollowingLegacyResponseBoundary(
-            stateJson.generatedItems,
-            stateJson.lastProcessedResponse.newItems,
-            sourceResponses[sourceResponseIndex + 1].output,
-          )
-        : undefined;
+    const followingResponseBoundary = stateJson.lastProcessedResponse
+      ? findFollowingLegacyResponsesBoundary(
+          stateJson.generatedItems,
+          stateJson.lastProcessedResponse.newItems,
+          sourceResponses
+            .slice(sourceResponseIndex + 1)
+            .map((response) => response.output),
+          optionalLatestFunctionCallIndices,
+        )
+      : undefined;
+    if (!followingResponseBoundary) {
+      throwLegacyCompactionOrderingError();
+    }
     const historicalInsertion = findHistoricalLegacyCompactionInsertion(
-      stateJson.generatedItems,
+      stateJson.generatedItems.slice(0, followingResponseBoundary.itemIndex),
       sourceResponse.output,
       compactionIndex,
       followingResponseBoundary,
+      sourceResponseIndex > 0,
     );
     generatedInsertionIndex = historicalInsertion.itemIndex;
     generatedInsertionAgent = historicalInsertion.agent;
@@ -1577,6 +1588,7 @@ function rehydrateLegacyCompactionRunItems(
       stateJson.generatedItems.slice(segmentStart),
       sourceResponse.output,
       compactionIndex,
+      optionalLatestFunctionCallIndices,
     );
     generatedInsertionIndex = segmentStart + generatedInsertion.itemIndex;
     generatedInsertionAgent = generatedInsertion.agent;
@@ -1647,10 +1659,11 @@ function findHistoricalLegacyCompactionInsertion(
   items: z.infer<typeof itemSchema>[],
   sourceOutput: protocol.OutputModelItem[],
   compactionIndex: number,
-  followingResponseBoundary?: {
+  followingResponseBoundary: {
     itemIndex: number;
     agent: SerializedAgentReference;
   },
+  allowEarlierResponseAnchors: boolean,
 ): { itemIndex: number; agent: SerializedAgentReference } {
   const providerAnchors = getLegacyProviderOutputAnchors(items, sourceOutput);
   const representedSourceItems = getRepresentedLegacySourceItems(
@@ -1658,11 +1671,19 @@ function findHistoricalLegacyCompactionInsertion(
     compactionIndex,
     providerAnchors,
   );
+  const requiredSourceItems = getRequiredLegacySourceItems(
+    sourceOutput,
+    compactionIndex,
+  );
+  assertRequiredLegacySourceItemsRepresented(
+    requiredSourceItems,
+    representedSourceItems,
+  );
   if (representedSourceItems.length === 0) {
-    if (followingResponseBoundary) {
-      return followingResponseBoundary;
+    if (!allowEarlierResponseAnchors && providerAnchors.length > 0) {
+      throwLegacyCompactionOrderingError();
     }
-    throwLegacyCompactionOrderingError();
+    return followingResponseBoundary;
   }
 
   const matchingStarts: number[] = [];
@@ -1724,6 +1745,7 @@ function findFollowingLegacyResponseBoundary(
   generatedItems: z.infer<typeof itemSchema>[],
   processedItems: z.infer<typeof itemSchema>[],
   sourceOutput: protocol.OutputModelItem[],
+  optionalFunctionCallIndices: ReadonlySet<number> = new Set(),
 ): { itemIndex: number; agent: SerializedAgentReference } | undefined {
   const itemIndex = findTrailingProcessedSegmentStart(
     generatedItems,
@@ -1732,7 +1754,12 @@ function findFollowingLegacyResponseBoundary(
   if (itemIndex === undefined) {
     throwLegacyCompactionOrderingError();
   }
-  if (itemIndex + processedItems.length !== generatedItems.length) {
+  if (
+    getLegacyProviderOutputAnchors(
+      generatedItems.slice(itemIndex + processedItems.length),
+      sourceOutput,
+    ).length > 0
+  ) {
     throwLegacyCompactionOrderingError();
   }
 
@@ -1744,6 +1771,11 @@ function findFollowingLegacyResponseBoundary(
     sourceOutput,
     -1,
     providerAnchors,
+    optionalFunctionCallIndices,
+  );
+  assertRequiredLegacySourceItemsRepresented(
+    getRequiredLegacySourceItems(sourceOutput, -1, optionalFunctionCallIndices),
+    representedSourceItems,
   );
   if (
     providerAnchors.length === 0 ||
@@ -1765,6 +1797,108 @@ function findFollowingLegacyResponseBoundary(
     throwLegacyCompactionOrderingError();
   }
   return { itemIndex, agent };
+}
+
+function findFollowingLegacyResponsesBoundary(
+  generatedItems: z.infer<typeof itemSchema>[],
+  processedItems: z.infer<typeof itemSchema>[],
+  sourceOutputs: protocol.OutputModelItem[][],
+  optionalLatestFunctionCallIndices: ReadonlySet<number>,
+): { itemIndex: number; agent: SerializedAgentReference } | undefined {
+  const latestSourceOutput = sourceOutputs.at(-1);
+  if (!latestSourceOutput) {
+    return undefined;
+  }
+
+  let boundary = findFollowingLegacyResponseBoundary(
+    generatedItems,
+    processedItems,
+    latestSourceOutput,
+    optionalLatestFunctionCallIndices,
+  );
+  if (!boundary) {
+    return undefined;
+  }
+
+  for (let index = sourceOutputs.length - 2; index >= 0; index -= 1) {
+    boundary = findPrecedingLegacyResponseBoundary(
+      generatedItems,
+      boundary.itemIndex,
+      sourceOutputs[index],
+    );
+  }
+  return boundary;
+}
+
+function findPrecedingLegacyResponseBoundary(
+  generatedItems: z.infer<typeof itemSchema>[],
+  followingBoundaryIndex: number,
+  sourceOutput: protocol.OutputModelItem[],
+): { itemIndex: number; agent: SerializedAgentReference } {
+  const precedingItems = generatedItems.slice(0, followingBoundaryIndex);
+  const providerAnchors = getLegacyProviderOutputAnchors(
+    precedingItems,
+    sourceOutput,
+  );
+  const representedSourceItems = getRepresentedLegacySourceItems(
+    sourceOutput,
+    -1,
+    providerAnchors,
+  );
+  assertRequiredLegacySourceItemsRepresented(
+    getRequiredLegacySourceItems(sourceOutput, -1),
+    representedSourceItems,
+  );
+  if (representedSourceItems.length === 0) {
+    throwLegacyCompactionOrderingError();
+  }
+
+  const matchingStarts: number[] = [];
+  for (
+    let start = 0;
+    start <= providerAnchors.length - representedSourceItems.length;
+    start += 1
+  ) {
+    if (
+      representedSourceItems.every(
+        (sourceItem, offset) =>
+          providerAnchors[start + offset]?.key === sourceItem.key,
+      )
+    ) {
+      matchingStarts.push(start);
+    }
+  }
+  if (matchingStarts.length !== 1) {
+    throwLegacyCompactionOrderingError();
+  }
+
+  const matchingStart = matchingStarts[0];
+  const matchedAnchors = providerAnchors.slice(
+    matchingStart,
+    matchingStart + representedSourceItems.length,
+  );
+  const trailingAnchors = providerAnchors.slice(
+    matchingStart + representedSourceItems.length,
+  );
+  if (
+    trailingAnchors.some(
+      (anchor) =>
+        precedingItems[anchor.itemIndex]?.type !== 'tool_call_output_item',
+    )
+  ) {
+    throwLegacyCompactionOrderingError();
+  }
+
+  const agent = matchedAnchors[0].agent;
+  const agentKey = getCanonicalLegacyCompactionKey(agent);
+  if (
+    matchedAnchors.some(
+      (anchor) => getCanonicalLegacyCompactionKey(anchor.agent) !== agentKey,
+    )
+  ) {
+    throwLegacyCompactionOrderingError();
+  }
+  return { itemIndex: matchedAnchors[0].itemIndex, agent };
 }
 
 function isLegacyProviderOutputRunItem(
@@ -1791,12 +1925,8 @@ function getLegacyProviderOutputAnchors(
   itemIndex: number;
   agent: SerializedAgentReference;
 }> {
-  const rawToolSearchOutputKeys = new Set(
-    sourceOutput.flatMap((item) =>
-      item.type === 'tool_search_output'
-        ? [getLegacyProviderOutputKey(item)]
-        : [],
-    ),
+  const sourceOutputKeys = new Set(
+    sourceOutput.map((item) => getLegacyProviderOutputKey(item)),
   );
   return items.flatMap((item, itemIndex) => {
     if (!isLegacyProviderOutputRunItem(item)) {
@@ -1804,8 +1934,11 @@ function getLegacyProviderOutputAnchors(
     }
     const key = getLegacyProviderOutputKey(item.rawItem);
     if (
-      item.type === 'tool_search_output_item' &&
-      !rawToolSearchOutputKeys.has(key)
+      (item.type === 'tool_search_output_item' ||
+        (item.type === 'tool_call_output_item' &&
+          (item.rawItem.type === 'program_output' ||
+            item.rawItem.type === 'shell_call_output'))) &&
+      !sourceOutputKeys.has(key)
     ) {
       return [];
     }
@@ -1817,7 +1950,26 @@ function getRepresentedLegacySourceItems(
   sourceOutput: protocol.OutputModelItem[],
   compactionIndex: number,
   providerAnchors: Array<{ key: string }>,
+  optionalFunctionCallIndices: ReadonlySet<number> = new Set(),
 ): Array<{ key: string; sourceIndex: number }> {
+  if (optionalFunctionCallIndices.size > 0) {
+    let providerAnchorIndex = 0;
+    return sourceOutput.flatMap((item, sourceIndex) => {
+      if (
+        sourceIndex === compactionIndex ||
+        optionalFunctionCallIndices.has(sourceIndex)
+      ) {
+        return [];
+      }
+      const key = getLegacyProviderOutputKey(item);
+      if (providerAnchors[providerAnchorIndex]?.key !== key) {
+        return [];
+      }
+      providerAnchorIndex += 1;
+      return [{ key, sourceIndex }];
+    });
+  }
+
   const providerKeys = new Set(providerAnchors.map((anchor) => anchor.key));
   return sourceOutput.flatMap((item, sourceIndex) => {
     if (sourceIndex === compactionIndex) {
@@ -1826,6 +1978,92 @@ function getRepresentedLegacySourceItems(
     const key = getLegacyProviderOutputKey(item);
     return providerKeys.has(key) ? [{ key, sourceIndex }] : [];
   });
+}
+
+function getRequiredLegacySourceItems(
+  sourceOutput: protocol.OutputModelItem[],
+  compactionIndex: number,
+  optionalFunctionCallIndices: ReadonlySet<number> = new Set(),
+): Array<{ key: string; sourceIndex: number }> {
+  return sourceOutput.flatMap((item, sourceIndex) => {
+    const isOmittedHandoff =
+      item.type === 'function_call' &&
+      optionalFunctionCallIndices.has(sourceIndex);
+    if (
+      sourceIndex === compactionIndex ||
+      item.type === 'compaction' ||
+      isOmittedHandoff ||
+      item.type === 'function_call_result' ||
+      item.type === 'apply_patch_call_output' ||
+      item.type === 'unknown'
+    ) {
+      return [];
+    }
+    return [{ key: getLegacyProviderOutputKey(item), sourceIndex }];
+  });
+}
+
+function getOmittedLegacyHandoffFunctionCallIndices(
+  sourceOutput: protocol.OutputModelItem[],
+  processedResponse:
+    z.infer<typeof serializedProcessedResponseSchema> | undefined,
+): ReadonlySet<number> {
+  const matchedIndices: number[] = [];
+  let sourceStartIndex = 0;
+  for (const serializedHandoff of processedResponse?.handoffs ?? []) {
+    const parsedToolCall = protocol.FunctionCallItem.safeParse(
+      serializedHandoff.toolCall,
+    );
+    if (!parsedToolCall.success) {
+      return new Set();
+    }
+    const key = getLegacyProviderOutputKey(parsedToolCall.data);
+    const sourceIndex = sourceOutput.findIndex(
+      (item, index) =>
+        index >= sourceStartIndex &&
+        item.type === 'function_call' &&
+        getLegacyProviderOutputKey(item) === key,
+    );
+    if (sourceIndex < 0) {
+      return new Set();
+    }
+    matchedIndices.push(sourceIndex);
+    sourceStartIndex = sourceIndex + 1;
+  }
+  return new Set(matchedIndices.slice(1));
+}
+
+function assertRequiredLegacySourceItemsRepresented(
+  requiredItems: Array<{ key: string; sourceIndex: number }>,
+  representedItems: Array<{ key: string; sourceIndex: number }>,
+): void {
+  if (!isLegacySourceSubsequenceRepresented(requiredItems, representedItems)) {
+    throwLegacyCompactionOrderingError();
+  }
+}
+
+function isLegacySourceSubsequenceRepresented(
+  requiredItems: Array<{ key: string; sourceIndex: number }>,
+  representedItems: Array<{ key: string; sourceIndex: number }>,
+): boolean {
+  let representedIndex = 0;
+  for (const requiredItem of requiredItems) {
+    while (
+      representedIndex < representedItems.length &&
+      representedItems[representedIndex].sourceIndex < requiredItem.sourceIndex
+    ) {
+      representedIndex += 1;
+    }
+    if (
+      representedItems[representedIndex]?.sourceIndex !==
+        requiredItem.sourceIndex ||
+      representedItems[representedIndex]?.key !== requiredItem.key
+    ) {
+      return false;
+    }
+    representedIndex += 1;
+  }
+  return true;
 }
 
 function getLegacyProviderOutputKey(item: protocol.ModelItem): string {
@@ -1847,12 +2085,22 @@ function findLegacyCompactionInsertionIndex(
   items: z.infer<typeof itemSchema>[],
   sourceOutput: protocol.OutputModelItem[],
   compactionIndex: number,
+  optionalFunctionCallIndices: ReadonlySet<number> = new Set(),
 ): { itemIndex: number; agent?: SerializedAgentReference } {
   const providerAnchors = getLegacyProviderOutputAnchors(items, sourceOutput);
   const representedSourceItems = getRepresentedLegacySourceItems(
     sourceOutput,
     compactionIndex,
     providerAnchors,
+    optionalFunctionCallIndices,
+  );
+  assertRequiredLegacySourceItemsRepresented(
+    getRequiredLegacySourceItems(
+      sourceOutput,
+      compactionIndex,
+      optionalFunctionCallIndices,
+    ),
+    representedSourceItems,
   );
 
   if (

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -1408,32 +1408,15 @@ function assertSchemaVersionSupportsSandboxSessionEnvelope(
 }
 
 /**
- * Requires current snapshots to pair each raw compaction output with its canonical run-item
- * wrapper, and rejects older schemas that carry the new wrapper. Raw compaction output in older
- * `modelResponses` remains valid because earlier writers could record it without creating a run
- * item.
+ * Rejects older schemas that carry the new wrapper. Current snapshots treat generated items as
+ * the replay authority because a supported handoff input filter may remove or replace raw model
+ * output before it becomes history.
  */
 function assertSchemaVersionSupportsCompactionItems(
   schemaVersion: SupportedSchemaVersion,
   stateJson: z.infer<typeof SerializedRunState>,
 ): void {
   if (schemaVersion === CURRENT_SCHEMA_VERSION) {
-    const rawCompaction = findLatestCompactionSource(stateJson)?.item;
-    const serializedCompaction = stateJson.generatedItems
-      .slice()
-      .reverse()
-      .find((item) => item.type === 'compaction_item');
-    if (
-      Boolean(rawCompaction) !== Boolean(serializedCompaction) ||
-      (rawCompaction &&
-        serializedCompaction &&
-        getCanonicalLegacyCompactionKey(rawCompaction) !==
-          getCanonicalLegacyCompactionKey(serializedCompaction.rawItem))
-    ) {
-      throw new UserError(
-        `Run state schema version ${CURRENT_SCHEMA_VERSION} contains inconsistent compaction items.`,
-      );
-    }
     return;
   }
 

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 import { Agent } from './agent';
-import type { Handoff } from './handoff';
 import { getAgentToolSourceAgent } from './agentToolSourceRegistry';
 import { buildAgentIdentityMap } from './runStateIdentity';
 export { buildAgentIdentityMap } from './runStateIdentity';
@@ -13,6 +12,7 @@ import {
   RunToolSearchCallItem,
   RunToolSearchOutputItem,
   RunReasoningItem,
+  RunCompactionItem,
   RunHandoffCallItem,
   RunHandoffOutputItem,
 } from './items';
@@ -21,7 +21,7 @@ import { RunContext } from './runContext';
 import { getTurnInput, type ReasoningItemIdPolicy } from './runner/items';
 import { AgentToolUseTracker } from './runner/toolUseTracker';
 import { nextStepSchema, NextStep } from './runner/steps';
-import { createToolRunFunction, type ProcessedResponse } from './runner/types';
+import type { ProcessedResponse } from './runner/types';
 import type { AgentSpanData, Span } from './tracing/spans';
 import { SystemError, UserError } from './errors';
 import { getGlobalTraceProvider } from './tracing/provider';
@@ -29,6 +29,7 @@ import { Usage } from './usage';
 import { Trace } from './tracing/traces';
 import { getCurrentTrace } from './tracing';
 import logger from './logger';
+import { handoff } from './handoff';
 import * as protocol from './types/protocol';
 import { AgentInputItem, UnknownContext } from './types';
 import {
@@ -43,42 +44,27 @@ import type {
 import { safeExecute } from './utils/safeExecute';
 import {
   getClientToolSearchExecutor,
-  getToolSearchRuntimeRoutingKey,
+  getToolSearchRuntimeToolKey,
   HostedMCPTool,
-  FunctionTool,
   ShellTool,
   ApplyPatchTool,
   Tool,
 } from './tool';
 import type { AgentToolInvocation } from './agentToolInvocation';
 import {
-  buildFunctionToolLookupMap,
-  type FunctionToolLookupKey,
-  getFunctionToolLookupKey,
-  getFunctionToolLegacyStateKeyFromStateKey,
   getFunctionToolQualifiedName,
-  getFunctionToolStateKey,
-  getFunctionToolStateKeyForCall,
-  getFunctionToolStateKeyForResolvedCall,
-  getFunctionToolStateKeys,
-  getToolCallNamespace,
-  getToolCallDisplayName,
-  resolveFunctionToolCall,
+  toolQualifiedName,
+  resolveFunctionToolCallName,
 } from './toolIdentity';
 import {
   getToolSearchExecution,
   getToolSearchOutputReplacementKey,
-  getToolSearchProviderCallId,
   resolveToolSearchCallId,
 } from './utils/toolSearch';
 import {
   executeCustomClientToolSearch,
-  filterEnabledToolSearchRuntimeTools,
   getClientToolSearchHelper,
-  registerRuntimeToolSearchTools,
-  validateClientToolSearchSupport,
 } from './runner/toolSearch';
-import { resolveModelVisibleToolNameCollisions } from './runner/modelPreparation';
 import { ensureToolCallerAllowed } from './runner/toolCaller';
 import {
   getSerializedApplyPatchToolPlaceholder,
@@ -116,8 +102,7 @@ import {
  *   and optional assistant message phases.
  * - 1.15: Adds reconstructable sandbox environment value references and sandbox
  *   session-state envelope version 2.
- * - 1.16: Adds category-aware function tool keys and agent-scoped function approvals,
- *   including aliases for legacy pending-run accessors.
+ * - 1.16: Adds compaction items to serialized run state payloads.
  */
 export const CURRENT_SCHEMA_VERSION = '1.16' as const;
 const SUPPORTED_SCHEMA_VERSIONS = [
@@ -245,6 +230,11 @@ const itemSchema = z.discriminatedUnion('type', [
     agent: serializedAgentSchema,
   }),
   z.object({
+    type: z.literal('compaction_item'),
+    rawItem: protocol.CompactionItem,
+    agent: serializedAgentSchema,
+  }),
+  z.object({
     type: z.literal('handoff_call_item'),
     rawItem: protocol.FunctionCallItem,
     agent: serializedAgentSchema,
@@ -263,7 +253,6 @@ const itemSchema = z.discriminatedUnion('type', [
       .or(protocol.ApplyPatchCallItem),
     agent: serializedAgentSchema,
     toolName: z.string().optional(),
-    functionToolStateKey: z.string().optional(),
   }),
 ]);
 
@@ -318,7 +307,6 @@ const serializedProcessedResponseSchema = z.object({
     z.object({
       toolCall: z.any(),
       handoff: z.any(),
-      targetAgent: serializedAgentSchema.optional(),
     }),
   ),
   functions: z.array(
@@ -440,37 +428,6 @@ const toolOutputGuardrailResultSchema = z.object({
   output: toolGuardrailFunctionOutputSchema,
 });
 
-const approvalRecordSchema = z.object({
-  approved: z.array(z.string()).or(z.boolean()),
-  rejected: z.array(z.string()).or(z.boolean()),
-  messages: z.record(z.string(), z.string()).optional(),
-  stickyRejectMessage: z.string().optional(),
-});
-
-const canonicalFunctionToolStateKeySchema = z
-  .string()
-  .refine(
-    (value) => getFunctionToolLegacyStateKeyFromStateKey(value) !== undefined,
-    'Function approval keys must use a canonical category-aware identity.',
-  );
-
-const functionApprovalsSchema = z.array(
-  z.object({
-    agentIdentity: z.string(),
-    approvals: z.record(
-      canonicalFunctionToolStateKeySchema,
-      approvalRecordSchema,
-    ),
-  }),
-);
-
-const functionApprovalContextSchema = z.object({
-  functionApprovals: functionApprovalsSchema.optional(),
-  legacyFunctionApprovals: z
-    .record(z.string(), approvalRecordSchema)
-    .optional(),
-});
-
 export const SerializedRunState = z.object({
   $schemaVersion,
   currentTurn: z.number(),
@@ -479,11 +436,15 @@ export const SerializedRunState = z.object({
   modelResponses: z.array(modelResponseSchema),
   context: z.object({
     usage: usageSchema,
-    approvals: z.record(z.string(), approvalRecordSchema),
-    functionApprovals: functionApprovalsSchema.optional(),
-    legacyFunctionApprovals: z
-      .record(z.string(), approvalRecordSchema)
-      .optional(),
+    approvals: z.record(
+      z.string(),
+      z.object({
+        approved: z.array(z.string()).or(z.boolean()),
+        rejected: z.array(z.string()).or(z.boolean()),
+        messages: z.record(z.string(), z.string()).optional(),
+        stickyRejectMessage: z.string().optional(),
+      }),
+    ),
     context: z.record(z.string(), z.any()),
     toolInput: z.any().optional(),
   }),
@@ -506,10 +467,6 @@ export const SerializedRunState = z.object({
   lastModelResponse: modelResponseSchema.optional(),
   generatedItems: z.array(itemSchema),
   pendingAgentToolRuns: z.record(z.string(), z.string()).optional().default({}),
-  pendingAgentToolRunAliases: z
-    .record(z.string(), z.string())
-    .optional()
-    .default({}),
   lastProcessedResponse: serializedProcessedResponseSchema.optional(),
   currentTurnPersistedItemCount: z.number().int().min(0).optional(),
   conversationId: z.string().optional(),
@@ -527,15 +484,8 @@ type ToolSearchRuntimeToolEntry<TContext = UnknownContext> = {
 };
 
 type ToolSearchRuntimeToolState<TContext = UnknownContext> = {
+  anonymousEntries: ToolSearchRuntimeToolEntry<TContext>[];
   keyedEntries: Map<string, ToolSearchRuntimeToolEntry<TContext>>;
-  routedOwners: Map<
-    string,
-    {
-      entry: ToolSearchRuntimeToolEntry<TContext>;
-      tool: Tool<TContext>;
-      toolIndex: number;
-    }
-  >;
   nextOrder: number;
 };
 
@@ -616,10 +566,6 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
    * Serialized pending nested agent runs keyed by tool name and call id.
    */
   public _pendingAgentToolRuns: Map<string, string>;
-  /**
-   * Legacy pending-run keys mapped to their canonical category-aware keys.
-   */
-  public _pendingAgentToolRunAliases: Map<string, string>;
   /**
    * Items generated by the agent during the run.
    */
@@ -710,7 +656,6 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     this._reasoningItemIdPolicy = undefined;
     this._toolUseTracker = new AgentToolUseTracker();
     this._pendingAgentToolRuns = new Map();
-    this._pendingAgentToolRunAliases = new Map();
     this._generatedItems = [];
     this._currentTurnPersistedItemCount = 0;
     this._maxTurns = maxTurns;
@@ -763,8 +708,8 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     let state = this._toolSearchRuntimeToolsByAgent.get(agent);
     if (!state) {
       state = {
+        anonymousEntries: [],
         keyedEntries: new Map(),
-        routedOwners: new Map(),
         nextOrder: 0,
       };
       this._toolSearchRuntimeToolsByAgent.set(agent, state);
@@ -784,50 +729,11 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     };
     const replacementKey = getToolSearchOutputReplacementKey(toolSearchOutput);
     if (replacementKey) {
-      const previousEntry = runtimeState.keyedEntries.get(replacementKey);
-      if (previousEntry) {
-        for (const [routingKey, owner] of runtimeState.routedOwners) {
-          if (owner.entry === previousEntry) {
-            runtimeState.routedOwners.delete(routingKey);
-          }
-        }
-      }
       runtimeState.keyedEntries.set(replacementKey, entry);
+      return;
     }
 
-    for (const [toolIndex, tool] of tools.entries()) {
-      const routingKey = getToolSearchRuntimeRoutingKey(tool);
-      if (!routingKey) {
-        continue;
-      }
-      runtimeState.routedOwners.set(routingKey, {
-        entry,
-        tool,
-        toolIndex,
-      });
-    }
-  }
-
-  public getToolSearchRuntimeToolsForOutput(
-    agent: Agent<any, any>,
-    toolSearchOutput: protocol.ToolSearchOutputItem,
-  ): Tool<TContext>[] {
-    const replacementKey = getToolSearchOutputReplacementKey(toolSearchOutput);
-    if (!replacementKey) {
-      return [];
-    }
-    const runtimeState = this._toolSearchRuntimeToolsByAgent.get(agent);
-    const entry = runtimeState?.keyedEntries.get(replacementKey);
-    if (!runtimeState || !entry) {
-      return [];
-    }
-    return entry.tools.filter((tool) => {
-      const routingKey = getToolSearchRuntimeRoutingKey(tool);
-      return (
-        typeof routingKey === 'string' &&
-        runtimeState.routedOwners.get(routingKey)?.entry === entry
-      );
-    });
+    runtimeState.anonymousEntries.push(entry);
   }
 
   public getToolSearchRuntimeTools(agent: Agent<any, any>): Tool<TContext>[] {
@@ -836,13 +742,23 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
       return [];
     }
 
-    return [...runtimeState.routedOwners.values()]
-      .sort(
-        (left, right) =>
-          left.entry.order - right.entry.order ||
-          left.toolIndex - right.toolIndex,
-      )
-      .map((owner) => owner.tool);
+    const dedupedTools = new Map<string, Tool<TContext>>();
+    const orderedEntries = [
+      ...runtimeState.keyedEntries.values(),
+      ...runtimeState.anonymousEntries,
+    ].sort((a, b) => a.order - b.order);
+    let anonymousCounter = 0;
+
+    for (const entry of orderedEntries) {
+      for (const tool of entry.tools) {
+        const key =
+          getToolSearchRuntimeToolKey(tool) ??
+          `anonymous:${entry.order}:${anonymousCounter++}`;
+        dedupedTools.set(key, tool);
+      }
+    }
+
+    return [...dedupedTools.values()];
   }
 
   /**
@@ -909,23 +825,15 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     return `${toolName}:${callId}`;
   }
 
-  private resolvePendingAgentToolRunKey(
-    toolName: string,
-    callId: string,
-  ): string {
-    const key = this.getPendingAgentToolRunKey(toolName, callId);
-    return this._pendingAgentToolRunAliases.get(key) ?? key;
-  }
-
   getPendingAgentToolRun(toolName: string, callId: string): string | undefined {
     return this._pendingAgentToolRuns.get(
-      this.resolvePendingAgentToolRunKey(toolName, callId),
+      this.getPendingAgentToolRunKey(toolName, callId),
     );
   }
 
   hasPendingAgentToolRun(toolName: string, callId: string): boolean {
     return this._pendingAgentToolRuns.has(
-      this.resolvePendingAgentToolRunKey(toolName, callId),
+      this.getPendingAgentToolRunKey(toolName, callId),
     );
   }
 
@@ -933,31 +841,17 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     toolName: string,
     callId: string,
     serializedState: string,
-    aliases: readonly string[] = [],
   ) {
-    const canonicalKey = this.resolvePendingAgentToolRunKey(toolName, callId);
-    this._pendingAgentToolRuns.set(canonicalKey, serializedState);
-    for (const alias of aliases) {
-      const aliasKey = this.getPendingAgentToolRunKey(alias, callId);
-      if (aliasKey === canonicalKey) {
-        continue;
-      }
-      this._pendingAgentToolRuns.delete(aliasKey);
-      this._pendingAgentToolRunAliases.set(aliasKey, canonicalKey);
-    }
+    this._pendingAgentToolRuns.set(
+      this.getPendingAgentToolRunKey(toolName, callId),
+      serializedState,
+    );
   }
 
   clearPendingAgentToolRun(toolName: string, callId: string) {
-    const requestedKey = this.getPendingAgentToolRunKey(toolName, callId);
-    const canonicalKey = this.resolvePendingAgentToolRunKey(toolName, callId);
-    this._pendingAgentToolRuns.delete(canonicalKey);
-    this._pendingAgentToolRuns.delete(requestedKey);
-    for (const [aliasKey, targetKey] of this._pendingAgentToolRunAliases) {
-      if (aliasKey === requestedKey || targetKey === canonicalKey) {
-        this._pendingAgentToolRuns.delete(aliasKey);
-        this._pendingAgentToolRunAliases.delete(aliasKey);
-      }
-    }
+    this._pendingAgentToolRuns.delete(
+      this.getPendingAgentToolRunKey(toolName, callId),
+    );
   }
 
   /**
@@ -1029,7 +923,7 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     const agentIdentity = buildAgentIdentityMap(this.#startingAgent);
 
     const includeTracingApiKey = options.includeTracingApiKey === true;
-    const contextJson = this._context._toJSONForRunState(agentIdentity.byAgent);
+    const contextJson = this._context.toJSON();
     const output = {
       $schemaVersion: CURRENT_SCHEMA_VERSION,
       currentTurn: this._currentTurn,
@@ -1094,9 +988,6 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
       ),
       pendingAgentToolRuns: Object.fromEntries(
         this._pendingAgentToolRuns.entries(),
-      ),
-      pendingAgentToolRunAliases: Object.fromEntries(
-        this._pendingAgentToolRunAliases.entries(),
       ),
       currentTurnPersistedItemCount: this._currentTurnPersistedItemCount,
       lastProcessedResponse: this._lastProcessedResponse
@@ -1191,10 +1082,6 @@ async function buildRunStateFromString<
       `Run state schema version ${currentSchemaVersion} is not supported. Please use version ${CURRENT_SCHEMA_VERSION}.`,
     );
   }
-  validateFunctionApprovalEnvelope(
-    currentSchemaVersion as SupportedSchemaVersion,
-    jsonResult,
-  );
   const stateJson = SerializedRunState.parse(jsonResult);
   assertSchemaVersionSupportsToolSearch(
     currentSchemaVersion as SupportedSchemaVersion,
@@ -1212,41 +1099,11 @@ async function buildRunStateFromString<
     currentSchemaVersion as SupportedSchemaVersion,
     stateJson,
   );
+  assertSchemaVersionSupportsCompactionItems(
+    currentSchemaVersion as SupportedSchemaVersion,
+    stateJson,
+  );
   return buildRunStateFromJson(initialAgent, stateJson, options);
-}
-
-function validateFunctionApprovalEnvelope(
-  schemaVersion: SupportedSchemaVersion,
-  stateJson: unknown,
-): void {
-  if (!stateJson || typeof stateJson !== 'object') {
-    return;
-  }
-  const context = (stateJson as { context?: unknown }).context;
-  if (!context || typeof context !== 'object') {
-    return;
-  }
-  const hasFunctionApprovals = Object.prototype.hasOwnProperty.call(
-    context,
-    'functionApprovals',
-  );
-  const hasLegacyFunctionApprovals = Object.prototype.hasOwnProperty.call(
-    context,
-    'legacyFunctionApprovals',
-  );
-  if (!hasFunctionApprovals && !hasLegacyFunctionApprovals) {
-    return;
-  }
-  if (schemaVersion !== CURRENT_SCHEMA_VERSION) {
-    throw new UserError(
-      `Run state schema version ${schemaVersion} does not support owner-scoped function approvals. Please reserialize the run state with schema ${CURRENT_SCHEMA_VERSION}.`,
-    );
-  }
-  if (!functionApprovalContextSchema.safeParse(context).success) {
-    throw new UserError(
-      'Failed to parse owner-scoped function approvals because their structure does not match the supported schema.',
-    );
-  }
 }
 
 function assertSchemaVersionSupportsToolSearch(
@@ -1362,6 +1219,43 @@ function assertSchemaVersionSupportsSandboxSessionEnvelope(
   throw new UserError(
     `Run state schema version ${schemaVersion} does not support sandbox session state version ${SANDBOX_SESSION_STATE_VERSION}. Please reserialize the run state with schema ${CURRENT_SCHEMA_VERSION}.`,
   );
+}
+
+/**
+ * Rejects snapshots that declare a pre-1.16 schema while carrying the new compaction run-item
+ * wrapper. Raw compaction output in `modelResponses` remains valid because earlier writers could
+ * record that provider output even though they did not create a corresponding run item.
+ */
+function assertSchemaVersionSupportsCompactionItems(
+  schemaVersion: SupportedSchemaVersion,
+  stateJson: z.infer<typeof SerializedRunState>,
+): void {
+  if (schemaVersion === CURRENT_SCHEMA_VERSION) {
+    return;
+  }
+
+  if (!containsSerializedCompactionRunItems(stateJson)) {
+    return;
+  }
+
+  throw new UserError(
+    `Run state schema version ${schemaVersion} does not support compaction items. Please reserialize the run state with schema ${CURRENT_SCHEMA_VERSION}.`,
+  );
+}
+
+function containsSerializedCompactionRunItems(
+  stateJson: z.infer<typeof SerializedRunState>,
+): boolean {
+  return (
+    containsCompactionRunItems(stateJson.generatedItems) ||
+    containsCompactionRunItems(stateJson.lastProcessedResponse?.newItems)
+  );
+}
+
+function containsCompactionRunItems(
+  items: z.infer<typeof itemSchema>[] | undefined,
+): boolean {
+  return Boolean(items?.some((item) => item.type === 'compaction_item'));
 }
 
 function containsProgrammaticToolCallingState(
@@ -1542,23 +1436,10 @@ function isToolSearchProtocolType(type: unknown): boolean {
   return type === 'tool_search_call' || type === 'tool_search_output';
 }
 
-function addSerializedRuntimeToolKey(
-  runtimeToolKeys: Set<string>,
-  runtimeToolKey: string,
-): void {
-  if (runtimeToolKeys.has(runtimeToolKey)) {
-    throw new UserError(
-      'Serialized client tool_search output contains multiple tools with the same routed identity. Assign unique tool names or namespaces before resuming RunState.',
-    );
-  }
-  runtimeToolKeys.add(runtimeToolKey);
-}
-
 function collectSerializedRuntimeToolKeys(
   value: unknown,
   runtimeToolKeys: Set<string>,
   namespace?: string,
-  validateRecognizedShape = false,
 ): void {
   if (!value || typeof value !== 'object') {
     return;
@@ -1568,34 +1449,21 @@ function collectSerializedRuntimeToolKeys(
     type?: unknown;
     name?: unknown;
     namespace?: unknown;
-    deferLoading?: unknown;
-    defer_loading?: unknown;
     tools?: unknown;
     server_label?: unknown;
     providerData?: unknown;
   };
 
-  if (candidate.type === 'namespace') {
-    if (
-      typeof candidate.name !== 'string' ||
-      candidate.name.length === 0 ||
-      !Array.isArray(candidate.tools)
-    ) {
-      if (validateRecognizedShape) {
-        throw new UserError(
-          'Serialized client tool_search output contains a namespace without a valid routed identity.',
-        );
-      }
-      return;
-    }
+  if (candidate.type === 'namespace' && Array.isArray(candidate.tools)) {
     const nestedNamespace =
-      typeof candidate.name === 'string' ? candidate.name : namespace;
+      typeof candidate.name === 'string' && candidate.name.length > 0
+        ? candidate.name
+        : namespace;
     for (const nestedTool of candidate.tools) {
       collectSerializedRuntimeToolKeys(
         nestedTool,
         runtimeToolKeys,
         nestedNamespace,
-        true,
       );
     }
     return;
@@ -1607,52 +1475,21 @@ function collectSerializedRuntimeToolKeys(
       : namespace;
   if (candidate.type === 'function') {
     if (typeof candidate.name !== 'string' || candidate.name.length === 0) {
-      if (validateRecognizedShape) {
-        throw new UserError(
-          'Serialized client tool_search output contains a function without a valid routed identity.',
-        );
-      }
       return;
     }
-    const directNamespace =
-      typeof candidate.namespace === 'string' && candidate.namespace.length > 0
-        ? candidate.namespace
-        : undefined;
-    if (candidate.name === namespace || candidate.name === directNamespace) {
-      throw new UserError(
-        'Responses tool search reserves same-name namespaces for deferred top-level function tools. Rename the namespace or tool name to avoid ambiguous dispatch.',
-      );
-    }
 
-    const lookupKey = getFunctionToolLookupKey(
-      candidate.name,
-      explicitNamespace ??
-        (candidate.deferLoading === true || candidate.defer_loading === true
-          ? candidate.name
-          : undefined),
+    runtimeToolKeys.add(
+      toolQualifiedName(candidate.name, explicitNamespace) ?? candidate.name,
     );
-    if (lookupKey) {
-      addSerializedRuntimeToolKey(runtimeToolKeys, lookupKey);
-    }
     return;
   }
 
-  if (candidate.type === 'mcp') {
-    if (
-      typeof candidate.server_label !== 'string' ||
-      candidate.server_label.length === 0
-    ) {
-      if (validateRecognizedShape) {
-        throw new UserError(
-          'Serialized client tool_search output contains an MCP tool without a valid routed identity.',
-        );
-      }
-      return;
-    }
-    addSerializedRuntimeToolKey(
-      runtimeToolKeys,
-      `mcp:${candidate.server_label}`,
-    );
+  if (
+    candidate.type === 'mcp' &&
+    typeof candidate.server_label === 'string' &&
+    candidate.server_label.length > 0
+  ) {
+    runtimeToolKeys.add(`mcp:${candidate.server_label}`);
     return;
   }
 
@@ -1664,7 +1501,6 @@ function collectSerializedRuntimeToolKeys(
     candidate.providerData,
     runtimeToolKeys,
     explicitNamespace,
-    false,
   );
 }
 
@@ -1673,22 +1509,18 @@ function getSerializedRuntimeToolKeys(
 ): Set<string> {
   const runtimeToolKeys = new Set<string>();
   for (const tool of toolSearchOutput.tools) {
-    collectSerializedRuntimeToolKeys(tool, runtimeToolKeys, undefined, true);
+    collectSerializedRuntimeToolKeys(tool, runtimeToolKeys);
   }
   return runtimeToolKeys;
 }
 
 function getRuntimeToolKeys<TContext>(
   runtimeTools: Tool<TContext>[],
-  options: {
-    allowUnsupported?: boolean;
-    rejectDuplicateKeys?: boolean;
-  } = {},
+  options: { allowUnsupported?: boolean } = {},
 ): Set<string> {
   const runtimeToolKeys = new Set<string>();
-  const runtimeToolsByKey = new Map<string, Tool<TContext>>();
   for (const tool of runtimeTools) {
-    const runtimeToolKey = getToolSearchRuntimeRoutingKey(tool);
+    const runtimeToolKey = getToolSearchRuntimeToolKey(tool);
     if (!runtimeToolKey) {
       if (options.allowUnsupported) {
         continue;
@@ -1697,12 +1529,6 @@ function getRuntimeToolKeys<TContext>(
         'Client tool_search execute() returned an unsupported runtime tool during RunState rehydration.',
       );
     }
-    if (options.rejectDuplicateKeys && runtimeToolsByKey.has(runtimeToolKey)) {
-      throw new UserError(
-        'Client tool_search execute() returned multiple tools with the same routed identity during RunState rehydration.',
-      );
-    }
-    runtimeToolsByKey.set(runtimeToolKey, tool);
     runtimeToolKeys.add(runtimeToolKey);
   }
   return runtimeToolKeys;
@@ -1712,21 +1538,18 @@ function formatRuntimeToolKeys(runtimeToolKeys: Set<string>): string {
   return [...runtimeToolKeys].sort().join(', ');
 }
 
-function selectSerializedRuntimeTools<TContext>(args: {
+function assertRuntimeToolKeysMatch<TContext>(args: {
   agent: Agent<any, any>;
   toolSearchCall: protocol.ToolSearchCallItem;
   expectedRuntimeToolKeys: Set<string>;
-  enabledRuntimeTools: Tool<TContext>[];
-}): Tool<TContext>[] {
-  const {
-    agent,
-    toolSearchCall,
-    expectedRuntimeToolKeys,
-    enabledRuntimeTools,
-  } = args;
-  const actualRuntimeToolKeys = getRuntimeToolKeys(enabledRuntimeTools, {
-    rejectDuplicateKeys: true,
-  });
+  runtimeTools: Tool<TContext>[];
+}): void {
+  const { agent, toolSearchCall, expectedRuntimeToolKeys, runtimeTools } = args;
+  if (expectedRuntimeToolKeys.size === 0) {
+    return;
+  }
+
+  const actualRuntimeToolKeys = getRuntimeToolKeys(runtimeTools);
   const hasExpectedKeys = [...expectedRuntimeToolKeys].every((runtimeToolKey) =>
     actualRuntimeToolKeys.has(runtimeToolKey),
   );
@@ -1734,18 +1557,7 @@ function selectSerializedRuntimeTools<TContext>(args: {
     expectedRuntimeToolKeys.has(runtimeToolKey),
   );
   if (hasExpectedKeys && hasActualKeys) {
-    return enabledRuntimeTools.filter((runtimeTool) => {
-      const runtimeToolKey = getToolSearchRuntimeRoutingKey(runtimeTool);
-      return (
-        runtimeToolKey != null && expectedRuntimeToolKeys.has(runtimeToolKey)
-      );
-    });
-  }
-
-  if (logger.dontLogToolData) {
-    throw new UserError(
-      'RunState cannot resume custom client tool_search because the registered execute callback returned different runtime tools than the serialized state.',
-    );
+    return;
   }
 
   const callId = resolveToolSearchCallId(toolSearchCall);
@@ -1772,410 +1584,24 @@ async function getConfiguredAgentTools<TContext>(args: {
   return configuredTools;
 }
 
-type RunStateCapabilitySnapshot<TContext> = {
-  availableTools: Tool<TContext>[];
-  callbackTools: Tool<TContext>[];
-  handoffs: Handoff<any, any>[];
-  functionMap: Map<FunctionToolLookupKey, FunctionTool<TContext>>;
-  functionToolsByCallId: Map<string, FunctionTool<TContext>>;
-  runtimeFunctionTools: Set<FunctionTool<TContext>>;
-  handoffMap: Map<string, Handoff<any, any>>;
-  mcpToolMap: Map<string, HostedMCPTool>;
-  replaceableRuntimeToolKeys: Set<string>;
-};
-
-function throwAmbiguousFunctionCallId(
-  agent: Agent<any, any>,
-  callId: string,
-  routedToolKeys: Iterable<string>,
-): never {
-  if (logger.dontLogToolData) {
-    throw new UserError(
-      'RunState cannot resume because a function call ID is associated with multiple routed tool identities.',
-    );
-  }
-
-  throw new UserError(
-    `RunState cannot resume function call ${callId} for agent ${agent.name} because the call ID is reused across routed tool identities [${[
-      ...routedToolKeys,
-    ].join(', ')}]. Use a unique call ID for each function call.`,
-  );
-}
-
-type DeferredFunctionCallExpectation = {
-  agent: Agent<any, any>;
-  toolCall: protocol.FunctionCallItem;
-  resolvedRoutedToolKey: string;
-};
-
-function assertUnambiguousFunctionCallIds<
-  TContext,
-  TAgent extends Agent<any, any>,
->(
-  state: RunState<TContext, TAgent>,
-  agentMap: Map<string, Agent<any, any>>,
-  serializedProcessedResponse?: z.infer<
-    typeof serializedProcessedResponseSchema
-  >,
-): DeferredFunctionCallExpectation[] {
-  const deferredFunctionCallExpectations: DeferredFunctionCallExpectation[] =
-    [];
-  const generatedCallsByAgent = new Map<Agent<any, any>, Map<string, string>>();
-  for (const item of state._generatedItems) {
-    if (
-      !(item instanceof RunToolCallItem) ||
-      item.rawItem.type !== 'function_call'
-    ) {
-      continue;
-    }
-    const agent = item.agent as Agent<any, any>;
-    const routedToolKey = getFunctionToolStateKeyForCall(item.rawItem);
-    if (!routedToolKey) {
-      continue;
-    }
-    const callsById = generatedCallsByAgent.get(agent) ?? new Map();
-    const previousRoutedToolKey = callsById.get(item.rawItem.callId);
-    if (previousRoutedToolKey && previousRoutedToolKey !== routedToolKey) {
-      throwAmbiguousFunctionCallId(agent, item.rawItem.callId, [
-        previousRoutedToolKey,
-        routedToolKey,
-      ]);
-    }
-    callsById.set(item.rawItem.callId, routedToolKey);
-    generatedCallsByAgent.set(agent, callsById);
-  }
-
-  type ProcessedFunctionCallIdentity = {
-    rawRoutedToolKey: string;
-    resolvedRoutedToolKey: string;
-  };
-  const processedCallsByAgent = new Map<
-    Agent<any, any>,
-    Map<string, ProcessedFunctionCallIdentity>
-  >();
-  if (serializedProcessedResponse) {
-    const agent = state._currentAgent as Agent<any, any>;
-    const processedCallsById = new Map<string, ProcessedFunctionCallIdentity>();
-    for (const functionCall of serializedProcessedResponse.functions) {
-      const toolCall = functionCall.toolCall as protocol.FunctionCallItem;
-      const rawRoutedToolKey = getFunctionToolStateKeyForCall(toolCall);
-      if (!rawRoutedToolKey) {
-        continue;
-      }
-      const serializedToolStateKey = getToolCallNamespace(toolCall)
-        ? rawRoutedToolKey
-        : getFunctionToolStateKey(functionCall.tool);
-      const resolvedRoutedToolKey = serializedToolStateKey
-        ? getFunctionToolStateKeyForResolvedCall(
-            toolCall,
-            functionCall.tool,
-            serializedToolStateKey,
-          )
-        : rawRoutedToolKey;
-      if (!resolvedRoutedToolKey) {
-        throwAmbiguousFunctionCallId(agent, toolCall.callId, [
-          rawRoutedToolKey,
-          serializedToolStateKey!,
-        ]);
-      }
-      if (resolvedRoutedToolKey !== rawRoutedToolKey) {
-        deferredFunctionCallExpectations.push({
-          agent,
-          toolCall,
-          resolvedRoutedToolKey,
-        });
-      }
-      const callId = toolCall.callId;
-      const previousProcessedIdentity = processedCallsById.get(callId);
-      if (
-        previousProcessedIdentity &&
-        previousProcessedIdentity.resolvedRoutedToolKey !==
-          resolvedRoutedToolKey
-      ) {
-        throwAmbiguousFunctionCallId(agent, callId, [
-          previousProcessedIdentity.resolvedRoutedToolKey,
-          resolvedRoutedToolKey,
-        ]);
-      }
-      const generatedRoutedToolKey = generatedCallsByAgent
-        .get(agent)
-        ?.get(callId);
-      if (
-        generatedRoutedToolKey &&
-        generatedRoutedToolKey !== rawRoutedToolKey
-      ) {
-        throwAmbiguousFunctionCallId(agent, callId, [
-          generatedRoutedToolKey,
-          rawRoutedToolKey,
-        ]);
-      }
-      processedCallsById.set(callId, {
-        rawRoutedToolKey,
-        resolvedRoutedToolKey,
-      });
-    }
-    processedCallsByAgent.set(agent, processedCallsById);
-  }
-
-  if (state._currentStep?.type !== 'next_step_interruption') {
-    return deferredFunctionCallExpectations;
-  }
-
-  for (const value of state._currentStep.data?.interruptions ?? []) {
-    if (!value || typeof value !== 'object') {
-      continue;
-    }
-    const interruption = value as {
-      rawItem?: unknown;
-      functionToolStateKey?: unknown;
-      agent?: unknown;
-    };
-    if (
-      !interruption.rawItem ||
-      typeof interruption.rawItem !== 'object' ||
-      (interruption.rawItem as { type?: unknown }).type !== 'function_call'
-    ) {
-      continue;
-    }
-    const rawItem = interruption.rawItem as protocol.FunctionCallItem;
-    const rawItemRoutedToolKey = getFunctionToolStateKeyForCall(rawItem);
-    if (!rawItemRoutedToolKey) {
-      continue;
-    }
-    const interruptionAgent =
-      interruption.agent && typeof interruption.agent === 'object'
-        ? resolveSerializedAgent(
-            interruption.agent as any,
-            agentMap,
-            state._currentAgent,
-          )
-        : (state._currentAgent as Agent<any, any>);
-    const generatedRoutedToolKey = generatedCallsByAgent
-      .get(interruptionAgent)
-      ?.get(rawItem.callId);
-    if (
-      generatedRoutedToolKey &&
-      generatedRoutedToolKey !== rawItemRoutedToolKey
-    ) {
-      throwAmbiguousFunctionCallId(interruptionAgent, rawItem.callId, [
-        generatedRoutedToolKey,
-        rawItemRoutedToolKey,
-      ]);
-    }
-    const processedIdentity = processedCallsByAgent
-      .get(interruptionAgent)
-      ?.get(rawItem.callId);
-    if (
-      processedIdentity &&
-      processedIdentity.rawRoutedToolKey !== rawItemRoutedToolKey
-    ) {
-      throwAmbiguousFunctionCallId(interruptionAgent, rawItem.callId, [
-        processedIdentity.rawRoutedToolKey,
-        rawItemRoutedToolKey,
-      ]);
-    }
-    const expectedRoutedToolKey =
-      processedIdentity?.resolvedRoutedToolKey ?? rawItemRoutedToolKey;
-    if (typeof interruption.functionToolStateKey === 'string') {
-      const validationRequiresPendingNestedState =
-        interruptionAgent !== state._currentAgent && !processedIdentity;
-      if (
-        !validationRequiresPendingNestedState &&
-        interruption.functionToolStateKey !== expectedRoutedToolKey
-      ) {
-        throwAmbiguousFunctionCallId(interruptionAgent, rawItem.callId, [
-          expectedRoutedToolKey,
-          interruption.functionToolStateKey,
-        ]);
-      }
-    }
-  }
-  return deferredFunctionCallExpectations;
-}
-
-function collectDeferredToolSearchProvenanceByCallId<TContext>(args: {
-  state: RunState<TContext, Agent<any, any>>;
-  effectiveToolSearchOutputs: RunToolSearchOutputItem[];
-  serializedRuntimeToolKeysByOutput: Map<RunToolSearchOutputItem, Set<string>>;
-}): Map<Agent<any, any>, Map<string, string>> {
-  const {
-    state,
-    effectiveToolSearchOutputs,
-    serializedRuntimeToolKeysByOutput,
-  } = args;
-  const effectiveOutputs = new Set(effectiveToolSearchOutputs);
-  const routedOwnersByAgent = new Map<
-    Agent<any, any>,
-    Map<string, RunToolSearchOutputItem>
-  >();
-  const entriesByReplacementKeyByAgent = new Map<
-    Agent<any, any>,
-    Map<string, RunToolSearchOutputItem>
-  >();
-  const deferredKeysByCallIdByAgent = new Map<
-    Agent<any, any>,
-    Map<string, string>
-  >();
-
-  for (const item of state._generatedItems) {
-    if (item instanceof RunToolSearchOutputItem && effectiveOutputs.has(item)) {
-      const agent = item.agent as Agent<any, any>;
-      const routedOwners = routedOwnersByAgent.get(agent) ?? new Map();
-      const entriesByReplacementKey =
-        entriesByReplacementKeyByAgent.get(agent) ?? new Map();
-      const replacementKey = getToolSearchOutputReplacementKey(item.rawItem);
-      if (replacementKey) {
-        const previousEntry = entriesByReplacementKey.get(replacementKey);
-        if (previousEntry) {
-          for (const [routedKey, owner] of routedOwners) {
-            if (owner === previousEntry) {
-              routedOwners.delete(routedKey);
-            }
-          }
-        }
-        entriesByReplacementKey.set(replacementKey, item);
-      }
-      for (const routedKey of serializedRuntimeToolKeysByOutput.get(item) ??
-        []) {
-        routedOwners.set(routedKey, item);
-      }
-      routedOwnersByAgent.set(agent, routedOwners);
-      entriesByReplacementKeyByAgent.set(agent, entriesByReplacementKey);
-      continue;
-    }
-
-    if (
-      !(item instanceof RunToolCallItem) ||
-      item.rawItem.type !== 'function_call' ||
-      getToolCallNamespace(item.rawItem)
-    ) {
-      continue;
-    }
-    const name = item.rawItem.name;
-    const bareKey = getFunctionToolLookupKey(name);
-    const deferredKey = getFunctionToolLookupKey(name, name);
-    const routedOwners = routedOwnersByAgent.get(item.agent);
-    if (
-      !bareKey ||
-      !deferredKey ||
-      routedOwners?.has(bareKey) ||
-      !routedOwners?.has(deferredKey)
-    ) {
-      continue;
-    }
-    const keysByCallId =
-      deferredKeysByCallIdByAgent.get(item.agent) ?? new Map();
-    keysByCallId.set(item.rawItem.callId, deferredKey);
-    deferredKeysByCallIdByAgent.set(item.agent, keysByCallId);
-  }
-
-  return deferredKeysByCallIdByAgent;
-}
-
-function assertDeferredFunctionCallProvenance<TContext>(args: {
-  expectations: DeferredFunctionCallExpectation[];
-  capabilitySnapshotsByAgent: Map<
-    Agent<TContext, any>,
-    RunStateCapabilitySnapshot<TContext>
-  >;
-  deferredToolSearchKeysByCallIdByAgent: Map<
-    Agent<any, any>,
-    Map<string, string>
-  >;
-}): void {
-  const {
-    expectations,
-    capabilitySnapshotsByAgent,
-    deferredToolSearchKeysByCallIdByAgent,
-  } = args;
-  for (const expectation of expectations) {
-    const snapshot = capabilitySnapshotsByAgent.get(expectation.agent);
-    if (snapshot?.handoffMap.has(expectation.toolCall.name)) {
-      throwAmbiguousFunctionCallId(
-        expectation.agent,
-        expectation.toolCall.callId,
-        [expectation.toolCall.name, expectation.resolvedRoutedToolKey],
-      );
-    }
-    const configuredOwner = snapshot
-      ? resolveFunctionToolCall(expectation.toolCall, snapshot.functionMap)
-      : undefined;
-    if (configuredOwner) {
-      if (
-        getFunctionToolStateKey(configuredOwner) ===
-        expectation.resolvedRoutedToolKey
-      ) {
-        continue;
-      }
-      throwAmbiguousFunctionCallId(
-        expectation.agent,
-        expectation.toolCall.callId,
-        [
-          getFunctionToolStateKey(configuredOwner) ?? configuredOwner.name,
-          expectation.resolvedRoutedToolKey,
-        ],
-      );
-    }
-    if (
-      deferredToolSearchKeysByCallIdByAgent
-        .get(expectation.agent)
-        ?.get(expectation.toolCall.callId) !== expectation.resolvedRoutedToolKey
-    ) {
-      throwAmbiguousFunctionCallId(
-        expectation.agent,
-        expectation.toolCall.callId,
-        [
-          getFunctionToolStateKeyForCall(expectation.toolCall) ??
-            expectation.toolCall.name,
-          expectation.resolvedRoutedToolKey,
-        ],
-      );
-    }
-  }
-}
-
 async function rehydrateToolSearchRuntimeTools<
   TContext,
   TAgent extends Agent<any, any>,
->(
-  state: RunState<TContext, TAgent>,
-  options: {
-    agentMap: Map<string, Agent<any, any>>;
-    schemaVersion: SupportedSchemaVersion;
-    serializedProcessedResponse?: z.infer<
-      typeof serializedProcessedResponseSchema
-    >;
-    prepareCurrentAgentForLegacyApprovals?: boolean;
-  },
-): Promise<Map<Agent<TContext, any>, RunStateCapabilitySnapshot<TContext>>> {
-  const deferredFunctionCallExpectations = assertUnambiguousFunctionCallIds(
-    state,
-    options.agentMap,
-    options.serializedProcessedResponse,
-  );
+>(state: RunState<TContext, TAgent>): Promise<void> {
   const configuredToolsByAgent = new Map<
     Agent<TContext, any>,
     Tool<TContext>[]
   >();
-  const capabilitySnapshotsByAgent = new Map<
+  const pendingToolSearchCalls = new Map<
     Agent<TContext, any>,
-    RunStateCapabilitySnapshot<TContext>
-  >();
-  type ToolSearchCallOccurrence = {
-    pendingCall: {
-      agent: Agent<TContext, any>;
-      toolSearchCall: protocol.ToolSearchCallItem;
-    };
-    output?: RunToolSearchOutputItem;
-  };
-  const toolSearchCallOccurrences: ToolSearchCallOccurrence[] = [];
-  const latestOccurrenceByAgentAndCallId = new Map<
-    Agent<TContext, any>,
-    Map<string, ToolSearchCallOccurrence>
-  >();
-  const pendingOccurrencesByAgent = new Map<
-    Agent<TContext, any>,
-    ToolSearchCallOccurrence[]
+    Map<
+      string,
+      {
+        agent: Agent<TContext, any>;
+        toolSearchCall: protocol.ToolSearchCallItem;
+        runtimeTools?: Tool<TContext>[];
+      }
+    >
   >();
 
   for (const item of state._generatedItems) {
@@ -2186,336 +1612,109 @@ async function rehydrateToolSearchRuntimeTools<
 
       const callId = resolveToolSearchCallId(item.rawItem);
       const agent = item.agent as Agent<TContext, any>;
-      const occurrence: ToolSearchCallOccurrence = {
-        pendingCall: {
-          agent,
-          toolSearchCall: item.rawItem,
-        },
-      };
-      toolSearchCallOccurrences.push(occurrence);
-      const pendingOccurrences = pendingOccurrencesByAgent.get(agent) ?? [];
-      pendingOccurrences.push(occurrence);
-      pendingOccurrencesByAgent.set(agent, pendingOccurrences);
-      const occurrencesByCallId =
-        latestOccurrenceByAgentAndCallId.get(agent) ?? new Map();
-      occurrencesByCallId.set(callId, occurrence);
-      latestOccurrenceByAgentAndCallId.set(agent, occurrencesByCallId);
+      const pendingCallsById =
+        pendingToolSearchCalls.get(agent) ??
+        new Map<
+          string,
+          {
+            agent: Agent<TContext, any>;
+            toolSearchCall: protocol.ToolSearchCallItem;
+            runtimeTools?: Tool<TContext>[];
+          }
+        >();
+      pendingCallsById.set(callId, {
+        agent: item.agent as Agent<TContext, any>,
+        toolSearchCall: item.rawItem,
+      });
+      pendingToolSearchCalls.set(agent, pendingCallsById);
       continue;
     }
 
-    if (
-      !(item instanceof RunToolSearchOutputItem) ||
-      getToolSearchExecution(item.rawItem) === 'server'
-    ) {
+    if (!(item instanceof RunToolSearchOutputItem)) {
       continue;
     }
 
-    const agent = item.agent as Agent<TContext, any>;
-    const explicitCallId = getToolSearchProviderCallId(item.rawItem);
-    const pendingOccurrences = pendingOccurrencesByAgent.get(agent) ?? [];
-    const occurrence = explicitCallId
-      ? latestOccurrenceByAgentAndCallId.get(agent)?.get(explicitCallId)
-      : pendingOccurrences.shift();
-    if (!occurrence) {
-      const callId = resolveToolSearchCallId(item.rawItem);
-      throw new UserError(
-        logger.dontLogToolData
-          ? 'RunState cannot resume custom client tool_search because the serialized state is missing the matching tool_search call item.'
-          : `RunState cannot resume custom client tool_search output ${callId} for agent ${item.agent.name} because the serialized state is missing the matching tool_search call item.`,
-      );
+    if (getToolSearchExecution(item.rawItem) === 'server') {
+      continue;
     }
-    if (explicitCallId) {
-      const pendingIndex = pendingOccurrences.indexOf(occurrence);
-      if (pendingIndex >= 0) {
-        pendingOccurrences.splice(pendingIndex, 1);
-      }
-    }
-    occurrence.output = item;
-  }
 
-  const effectiveToolSearchOutputs = toolSearchCallOccurrences
-    .map((occurrence) => occurrence.output)
-    .filter((item): item is RunToolSearchOutputItem => Boolean(item));
-  const occurrencesByOutput = new Map(
-    toolSearchCallOccurrences.flatMap((occurrence) =>
-      occurrence.output ? [[occurrence.output, occurrence] as const] : [],
-    ),
-  );
-  const serializedRuntimeToolKeysByOutput = new Map<
-    RunToolSearchOutputItem,
-    Set<string>
-  >();
-  for (const item of effectiveToolSearchOutputs) {
-    serializedRuntimeToolKeysByOutput.set(
-      item,
-      getSerializedRuntimeToolKeys(item.rawItem),
-    );
-  }
-
-  const agentsToPrepare = new Set(
-    effectiveToolSearchOutputs.map(
-      (item) => item.agent as Agent<TContext, any>,
-    ),
-  );
-  if (options.serializedProcessedResponse) {
-    agentsToPrepare.add(state._currentAgent as Agent<TContext, any>);
-  }
-  if (options.prepareCurrentAgentForLegacyApprovals) {
-    agentsToPrepare.add(state._currentAgent as Agent<TContext, any>);
-  }
-
-  for (const agent of agentsToPrepare) {
     const configuredTools = await getConfiguredAgentTools({
-      agent,
+      agent: item.agent as Agent<TContext, any>,
       context: state._context,
       configuredToolsByAgent,
     });
-    const existingRuntimeTools = state.getToolSearchRuntimeTools(agent);
-    const enabledRuntimeTools = await getEnabledToolSearchRuntimeTools(
-      state,
-      agent,
-    );
-    const capabilities = resolveModelVisibleToolNameCollisions(
-      [...configuredTools, ...enabledRuntimeTools],
-      await agent.getEnabledHandoffs(state._context),
-      'warn',
-    );
-    const availableTools = [...capabilities.tools];
-    capabilitySnapshotsByAgent.set(agent, {
-      availableTools,
-      callbackTools: [...availableTools],
-      handoffs: capabilities.handoffs,
-      functionMap: buildFunctionToolLookupMap(
-        availableTools.filter((tool) => tool.type === 'function'),
-      ),
-      functionToolsByCallId: new Map(),
-      runtimeFunctionTools: new Set(
-        existingRuntimeTools.filter(
-          (tool): tool is FunctionTool<TContext> => tool.type === 'function',
-        ),
-      ),
-      handoffMap: new Map(
-        capabilities.handoffs.map((handoff) => [handoff.toolName, handoff]),
-      ),
-      mcpToolMap: new Map(
-        availableTools
-          .filter(
-            (tool): tool is HostedMCPTool =>
-              tool.type === 'hosted_tool' && tool.providerData?.type === 'mcp',
-          )
-          .map((tool) => [tool.providerData.server_label, tool]),
-      ),
-      replaceableRuntimeToolKeys: new Set(
-        existingRuntimeTools
-          .map((tool) => getToolSearchRuntimeRoutingKey(tool))
-          .filter((key): key is string => typeof key === 'string'),
-      ),
+    const configuredToolKeys = getRuntimeToolKeys(configuredTools, {
+      allowUnsupported: true,
     });
-  }
-
-  assertDeferredFunctionCallProvenance({
-    expectations: deferredFunctionCallExpectations,
-    capabilitySnapshotsByAgent,
-    deferredToolSearchKeysByCallIdByAgent:
-      collectDeferredToolSearchProvenanceByCallId({
-        state: state as RunState<TContext, Agent<any, any>>,
-        effectiveToolSearchOutputs,
-        serializedRuntimeToolKeysByOutput,
-      }),
-  });
-
-  if (
-    options.schemaVersion === CURRENT_SCHEMA_VERSION &&
-    options.serializedProcessedResponse
-  ) {
-    const currentAgent = state._currentAgent as Agent<TContext, any>;
-    const currentSnapshot = capabilitySnapshotsByAgent.get(currentAgent)!;
-    for (const serializedHandoff of options.serializedProcessedResponse
-      .handoffs) {
-      if (!serializedHandoff.targetAgent) {
-        throw new UserError(
-          'Run state handoff is missing its required target agent identity.',
-        );
-      }
-      const targetAgent = resolveSerializedAgent(
-        serializedHandoff.targetAgent,
-        options.agentMap,
-      );
-      const handoff = currentSnapshot.handoffMap.get(
-        serializedHandoff.handoff.toolName,
-      );
-      if (!handoff || handoff.agent !== targetAgent) {
-        throw new UserError(
-          `Handoff ${serializedHandoff.handoff.toolName} not found`,
-        );
-      }
-    }
-  }
-
-  for (const agent of new Set(
-    effectiveToolSearchOutputs.map(
-      (item) => item.agent as Agent<TContext, any>,
-    ),
-  )) {
-    validateClientToolSearchSupport(
-      capabilitySnapshotsByAgent.get(agent)!.availableTools,
-    );
-  }
-
-  type ToolSearchRehydrationRecord = {
-    pendingCall: {
-      agent: Agent<TContext, any>;
-      toolSearchCall: protocol.ToolSearchCallItem;
-    };
-    expectedRuntimeToolKeys: Set<string>;
-    toolSearchTool?: Tool<TContext>;
-    runtimeTools?: Tool<TContext>[];
-  };
-  const rehydrationRecords = new Map<
-    RunToolSearchOutputItem,
-    ToolSearchRehydrationRecord
-  >();
-
-  for (const item of effectiveToolSearchOutputs) {
-    const callId = resolveToolSearchCallId(item.rawItem);
-    const agent = item.agent as Agent<TContext, any>;
-    const snapshot = capabilitySnapshotsByAgent.get(agent)!;
-    const expectedRuntimeToolKeys =
-      serializedRuntimeToolKeysByOutput.get(item)!;
-    const pendingCall = occurrencesByOutput.get(item)!.pendingCall;
-
-    const toolSearchTool = getClientToolSearchHelper(snapshot.availableTools);
-    const hasCustomExecutor = Boolean(
-      toolSearchTool && getClientToolSearchExecutor(toolSearchTool),
+    const expectedRuntimeToolKeys = new Set(
+      [...getSerializedRuntimeToolKeys(item.rawItem)].filter(
+        (runtimeToolKey) => !configuredToolKeys.has(runtimeToolKey),
+      ),
     );
     if (expectedRuntimeToolKeys.size === 0) {
-      rehydrationRecords.set(item, {
-        pendingCall,
-        expectedRuntimeToolKeys,
-        ...(hasCustomExecutor ? { toolSearchTool } : {}),
-      });
       continue;
     }
-    if (!hasCustomExecutor) {
-      const availableRuntimeToolKeys = getRuntimeToolKeys(
-        snapshot.availableTools,
-        { allowUnsupported: true },
+
+    const callId = resolveToolSearchCallId(item.rawItem);
+    const pendingCall = pendingToolSearchCalls
+      .get(item.agent as Agent<TContext, any>)
+      ?.get(callId);
+    if (!pendingCall) {
+      throw new UserError(
+        `RunState cannot resume custom client tool_search output ${callId} for agent ${item.agent.name} because the serialized state is missing the matching tool_search call item.`,
       );
-      if (
-        [...expectedRuntimeToolKeys].every((runtimeToolKey) =>
-          availableRuntimeToolKeys.has(runtimeToolKey),
-        )
-      ) {
-        rehydrationRecords.set(item, {
-          pendingCall,
-          expectedRuntimeToolKeys,
-        });
-        continue;
-      }
-      if (logger.dontLogToolData) {
+    }
+
+    if (!pendingCall.runtimeTools) {
+      const availableTools = [
+        ...configuredTools,
+        ...state.getToolSearchRuntimeTools(pendingCall.agent),
+      ];
+      const toolSearchTool = getClientToolSearchHelper(configuredTools);
+      if (!toolSearchTool || !getClientToolSearchExecutor(toolSearchTool)) {
         throw new UserError(
-          'RunState cannot resume custom client tool_search because the agent no longer provides toolSearchTool({ execution: "client", execute }).',
+          `RunState cannot resume custom client tool_search call ${callId} for agent ${pendingCall.agent.name} because the agent no longer provides toolSearchTool({ execution: "client", execute }).`,
         );
       }
-      throw new UserError(
-        `RunState cannot resume custom client tool_search call ${callId} for agent ${pendingCall.agent.name} because the agent no longer provides toolSearchTool({ execution: "client", execute }).`,
-      );
-    }
-    rehydrationRecords.set(item, {
-      pendingCall,
-      expectedRuntimeToolKeys,
-      toolSearchTool,
-    });
-  }
 
-  for (const generatedItem of state._generatedItems) {
-    if (!(generatedItem instanceof RunToolSearchOutputItem)) {
-      continue;
-    }
-    const record = rehydrationRecords.get(generatedItem);
-    if (!record?.toolSearchTool) {
-      continue;
-    }
-    const agent = record.pendingCall.agent;
-    const snapshot = capabilitySnapshotsByAgent.get(agent)!;
-    const { runtimeTools, callbackRuntimeTools } =
-      await executeCustomClientToolSearch({
-        agent,
+      const { runtimeTools } = await executeCustomClientToolSearch({
+        agent: pendingCall.agent,
         runContext: state._context,
-        toolSearchCall: record.pendingCall.toolSearchCall,
-        toolSearchTool: record.toolSearchTool,
-        tools: snapshot.callbackTools,
+        toolSearchCall: pendingCall.toolSearchCall,
+        toolSearchTool,
+        tools: availableTools,
       });
-    const serializedRuntimeTools = selectSerializedRuntimeTools({
-      agent,
-      toolSearchCall: record.pendingCall.toolSearchCall,
-      expectedRuntimeToolKeys: record.expectedRuntimeToolKeys,
-      enabledRuntimeTools: runtimeTools,
-    });
-    record.runtimeTools = serializedRuntimeTools;
-    snapshot.callbackTools.push(...callbackRuntimeTools);
-  }
-
-  for (const generatedItem of state._generatedItems) {
-    if (generatedItem instanceof RunToolSearchOutputItem) {
-      const record = rehydrationRecords.get(generatedItem);
-      if (!record?.runtimeTools) {
-        continue;
-      }
-      const agent = record.pendingCall.agent;
-      const snapshot = capabilitySnapshotsByAgent.get(agent)!;
-      const replacedRuntimeTools = state.getToolSearchRuntimeToolsForOutput(
-        agent,
-        generatedItem.rawItem,
-      );
-      const registeredRuntimeTools = registerRuntimeToolSearchTools({
-        availableTools: snapshot.availableTools,
-        functionMap: snapshot.functionMap,
-        handoffMap: snapshot.handoffMap,
-        mcpToolMap: snapshot.mcpToolMap,
-        replaceableRuntimeToolKeys: snapshot.replaceableRuntimeToolKeys,
-        replacedRuntimeTools,
-        runtimeTools: record.runtimeTools,
-      });
-      for (const runtimeTool of registeredRuntimeTools) {
-        if (runtimeTool.type === 'function') {
-          snapshot.runtimeFunctionTools.add(runtimeTool);
-        }
-      }
-
-      state.recordToolSearchRuntimeTools(
-        agent,
-        generatedItem.rawItem,
-        registeredRuntimeTools,
-      );
-      continue;
-    }
-
-    if (
-      generatedItem instanceof RunToolCallItem &&
-      generatedItem.rawItem.type === 'function_call'
-    ) {
-      const agent = generatedItem.agent as Agent<TContext, any>;
-      const snapshot = capabilitySnapshotsByAgent.get(agent);
-      if (!snapshot) {
-        continue;
-      }
-      const functionTool = resolveFunctionToolCall(
-        generatedItem.rawItem,
-        snapshot.functionMap,
-      );
-      if (functionTool) {
-        if (snapshot.runtimeFunctionTools.has(functionTool)) {
-          snapshot.functionToolsByCallId.set(
-            generatedItem.rawItem.callId,
-            functionTool,
+      const rehydratedRuntimeTools = runtimeTools.filter((tool) => {
+        const runtimeToolKey = getToolSearchRuntimeToolKey(tool);
+        if (!runtimeToolKey) {
+          throw new UserError(
+            'Client tool_search execute() returned an unsupported runtime tool during RunState rehydration.',
           );
         }
-      }
+        return !configuredToolKeys.has(runtimeToolKey);
+      });
+      assertRuntimeToolKeysMatch({
+        agent: pendingCall.agent,
+        toolSearchCall: pendingCall.toolSearchCall,
+        expectedRuntimeToolKeys,
+        runtimeTools: rehydratedRuntimeTools,
+      });
+      pendingCall.runtimeTools = rehydratedRuntimeTools;
     }
-  }
 
-  return capabilitySnapshotsByAgent;
+    const runtimeTools = pendingCall.runtimeTools;
+    if (!runtimeTools) {
+      throw new UserError(
+        `RunState cannot resume custom client tool_search call ${callId} for agent ${pendingCall.agent.name} because no runtime tools were rehydrated.`,
+      );
+    }
+
+    state.recordToolSearchRuntimeTools(
+      pendingCall.agent,
+      item.rawItem,
+      runtimeTools,
+    );
+  }
 }
 
 async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
@@ -2530,8 +1729,6 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
     : buildAgentMap(initialAgent);
   const contextOverride = options.contextOverride;
   const contextStrategy = options.contextStrategy ?? 'merge';
-  const schemaVersion = stateJson.$schemaVersion as SupportedSchemaVersion;
-  let deferredLegacyApprovalContext: RunContext<TContext> | undefined;
 
   //
   // Rebuild the context
@@ -2539,49 +1736,17 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
   const context =
     contextOverride ??
     new RunContext<TContext>(stateJson.context.context as TContext);
-  context._validateFunctionApprovalOwners(
-    stateJson.context.functionApprovals ?? [],
-    agentMap,
-  );
   if (contextOverride) {
     if (contextStrategy === 'merge') {
-      if (schemaVersion === CURRENT_SCHEMA_VERSION) {
-        context._mergeApprovals(stateJson.context.approvals);
-        context._mergeFunctionApprovals(
-          stateJson.context.functionApprovals ?? [],
-          agentMap,
-        );
-        context._mergeLegacyFunctionApprovals(
-          stateJson.context.legacyFunctionApprovals ?? {},
-        );
-      } else {
-        deferredLegacyApprovalContext = new RunContext<TContext>(
-          stateJson.context.context as TContext,
-        );
-        deferredLegacyApprovalContext._rebuildApprovals(
-          stateJson.context.approvals,
-        );
-        deferredLegacyApprovalContext._rebuildLegacyFunctionApprovals(
-          stateJson.context.approvals,
-        );
-      }
+      context._mergeApprovals(stateJson.context.approvals);
     }
   } else {
     context._rebuildApprovals(stateJson.context.approvals);
-    context._rebuildFunctionApprovals(
-      stateJson.context.functionApprovals ?? [],
-      agentMap,
-    );
-    context._rebuildLegacyFunctionApprovals(
-      schemaVersion === CURRENT_SCHEMA_VERSION
-        ? (stateJson.context.legacyFunctionApprovals ?? {})
-        : stateJson.context.approvals,
-    );
   }
-  const shouldRestoreSerializedContext =
+  const shouldRestoreToolInput =
     !contextOverride || contextStrategy === 'merge';
   if (
-    shouldRestoreSerializedContext &&
+    shouldRestoreToolInput &&
     typeof stateJson.context.toolInput !== 'undefined' &&
     typeof context.toolInput === 'undefined'
   ) {
@@ -2636,7 +1801,6 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
   state._pendingAgentToolRuns = new Map(
     Object.entries(stateJson.pendingAgentToolRuns ?? {}),
   );
-  state._pendingAgentToolRunAliases = new Map();
 
   // rebuild current agent span
   if (stateJson.currentAgentSpan) {
@@ -2687,38 +1851,15 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
   state._currentTurnPersistedItemCount =
     stateJson.currentTurnPersistedItemCount ?? 0;
   state._sandbox = stateJson.sandbox ?? undefined;
-  const capabilitySnapshotsByAgent = await rehydrateToolSearchRuntimeTools(
-    state,
-    {
-      agentMap,
-      schemaVersion,
-      serializedProcessedResponse: stateJson.lastProcessedResponse,
-      prepareCurrentAgentForLegacyApprovals:
-        schemaVersion !== CURRENT_SCHEMA_VERSION &&
-        shouldRestoreSerializedContext &&
-        Object.keys(stateJson.context.approvals).length > 0,
-    },
-  );
-  const currentCapabilitySnapshot = capabilitySnapshotsByAgent.get(
-    state._currentAgent as Agent<TContext, any>,
-  );
+  await rehydrateToolSearchRuntimeTools(state);
   state._lastProcessedResponse = stateJson.lastProcessedResponse
     ? await deserializeProcessedResponse(
         agentMap,
         state,
         stateJson.lastProcessedResponse,
-        {
-          executionTools: currentCapabilitySnapshot!.availableTools,
-          executionHandoffs: currentCapabilitySnapshot!.handoffs,
-          executionFunctionToolsByCallId:
-            currentCapabilitySnapshot!.functionToolsByCallId,
-        },
       )
     : undefined;
-  restorePendingAgentToolRunAliases(
-    state,
-    stateJson.pendingAgentToolRunAliases ?? {},
-  );
+
   if (stateJson.currentStep?.type === 'next_step_handoff') {
     state._currentStep = {
       type: 'next_step_handoff',
@@ -2728,71 +1869,17 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
       ) as TAgent,
     };
   } else if (stateJson.currentStep?.type === 'next_step_interruption') {
-    const interruptions = deserializeInterruptions(
-      stateJson.currentStep.data?.interruptions,
-      agentMap,
-      state._currentAgent,
-    );
-    rebindInterruptionFunctionToolStateKeys(
-      interruptions,
-      state._lastProcessedResponse,
-      state._currentAgent,
-      state,
-      schemaVersion,
-    );
     state._currentStep = {
       type: 'next_step_interruption',
       data: {
         ...stateJson.currentStep.data,
-        interruptions,
+        interruptions: deserializeInterruptions(
+          stateJson.currentStep.data?.interruptions,
+          agentMap,
+          state._currentAgent,
+        ),
       },
     };
-  }
-  const legacyAvailableToolsByAgent = new Map<
-    Agent<any, any>,
-    Tool<TContext>[]
-  >();
-  for (const agent of new Set(agentMap.values())) {
-    legacyAvailableToolsByAgent.set(agent, [
-      ...(agent.tools as Tool<TContext>[]),
-    ]);
-  }
-  for (const [agent, snapshot] of capabilitySnapshotsByAgent) {
-    const configuredTools = legacyAvailableToolsByAgent.get(agent) ?? [];
-    legacyAvailableToolsByAgent.set(agent, [
-      ...new Set([...configuredTools, ...snapshot.availableTools]),
-    ]);
-  }
-  const legacyFunctionApprovalKeys = migrateLegacyFunctionToolState(
-    state,
-    schemaVersion,
-    shouldRestoreSerializedContext,
-    deferredLegacyApprovalContext,
-    legacyAvailableToolsByAgent,
-  );
-  const legacyApprovalContext = deferredLegacyApprovalContext ?? context;
-  if (schemaVersion !== CURRENT_SCHEMA_VERSION) {
-    legacyApprovalContext._retainLegacyFunctionApprovals(
-      legacyFunctionApprovalKeys,
-    );
-    legacyApprovalContext._removeMigratedFunctionApprovalsFromAggregate(
-      legacyFunctionApprovalKeys,
-      new Set(
-        [...legacyAvailableToolsByAgent.values()].flatMap((tools) =>
-          tools.flatMap((tool) =>
-            tool.type !== 'function' && typeof tool.name === 'string'
-              ? [tool.name]
-              : [],
-          ),
-        ),
-      ),
-    );
-  }
-  if (deferredLegacyApprovalContext) {
-    context._mergeApprovalStatePreservingExactKeys(
-      deferredLegacyApprovalContext,
-      legacyFunctionApprovalKeys,
-    );
   }
   return state;
 }
@@ -2817,13 +1904,6 @@ export async function rehydrateProcessedResponseTools<
     state._lastProcessedResponse,
     agentIdentity.byAgent,
   );
-  const executionFunctionToolsByCallId = new Map(
-    state._lastProcessedResponse.functions.flatMap((functionCall) =>
-      functionCall.preserveToolOnExecutionRehydration
-        ? [[functionCall.toolCall.callId, functionCall.tool] as const]
-        : [],
-    ),
-  );
 
   state._lastProcessedResponse = await deserializeProcessedResponse(
     agentIdentity.byIdentity,
@@ -2831,7 +1911,6 @@ export async function rehydrateProcessedResponseTools<
     serializedProcessedResponse,
     {
       executionTools,
-      executionFunctionToolsByCallId,
       allowSerializedExecutionToolPlaceholder: false,
     },
   );
@@ -2983,20 +2062,6 @@ function serializeProcessedResponse<TContext>(
     newItems: processedResponse.newItems.map((item) =>
       serializeRunItem(item, agentIdentityKeys),
     ),
-    functions: processedResponse.functions.map(({ toolCall, tool }) => ({
-      toolCall,
-      tool,
-    })),
-    handoffs: processedResponse.handoffs.map(
-      ({ toolCall, handoff: processedHandoff }) => ({
-        toolCall,
-        handoff: processedHandoff,
-        targetAgent: serializeAgentReference(
-          processedHandoff.agent,
-          agentIdentityKeys,
-        ),
-      }),
-    ),
   } as z.infer<typeof serializedProcessedResponseSchema>;
 }
 
@@ -3087,6 +2152,11 @@ export function deserializeItem(
         serializedItem.rawItem,
         resolveSerializedAgent(serializedItem.agent, agentMap),
       );
+    case 'compaction_item':
+      return new RunCompactionItem(
+        serializedItem.rawItem,
+        resolveSerializedAgent(serializedItem.agent, agentMap),
+      );
     case 'handoff_call_item':
       return new RunHandoffCallItem(
         serializedItem.rawItem,
@@ -3103,7 +2173,6 @@ export function deserializeItem(
         serializedItem.rawItem,
         resolveSerializedAgent(serializedItem.agent, agentMap),
         serializedItem.toolName,
-        serializedItem.functionToolStateKey,
       );
   }
 }
@@ -3129,7 +2198,6 @@ function deserializeInterruptionItem(
         parsed.data.rawItem,
         mappedAgent,
         parsed.data.toolName,
-        parsed.data.functionToolStateKey,
       );
     }
 
@@ -3144,7 +2212,6 @@ function deserializeInterruptionItem(
   const value = serializedItem as {
     rawItem?: unknown;
     toolName?: unknown;
-    functionToolStateKey?: unknown;
     agent?: { name?: unknown; identity?: unknown };
   };
 
@@ -3188,16 +2255,11 @@ function deserializeInterruptionItem(
       : typeof rawItem.name === 'string'
         ? rawItem.name
         : undefined;
-  const functionToolStateKey =
-    typeof value.functionToolStateKey === 'string'
-      ? value.functionToolStateKey
-      : undefined;
 
   return new RunToolApprovalItem(
     value.rawItem as RunToolApprovalItem['rawItem'],
     mappedAgent,
     toolName,
-    functionToolStateKey,
   );
 }
 
@@ -3218,407 +2280,8 @@ function deserializeInterruptions(
     );
 }
 
-function rebindInterruptionFunctionToolStateKeys<TContext>(
-  interruptions: RunToolApprovalItem[],
-  processedResponse: ProcessedResponse<TContext> | undefined,
-  processedAgent: Agent<any, any>,
-  state: RunState<TContext, Agent<any, any>>,
-  schemaVersion: SupportedSchemaVersion,
-): void {
-  if (!processedResponse) {
-    for (const interruption of interruptions) {
-      if (
-        interruption.rawItem.type !== 'function_call' ||
-        !interruption.functionToolStateKey
-      ) {
-        continue;
-      }
-      const rawStateKey = getFunctionToolStateKeyForCall(interruption.rawItem);
-      if (rawStateKey && interruption.functionToolStateKey !== rawStateKey) {
-        throwAmbiguousFunctionCallId(
-          interruption.agent,
-          interruption.rawItem.callId,
-          [rawStateKey, interruption.functionToolStateKey],
-        );
-      }
-    }
-    return;
-  }
-
-  const functionsByCallId = new Map(
-    processedResponse.functions.map((functionCall) => [
-      functionCall.toolCall.callId,
-      functionCall,
-    ]),
-  );
-  for (const interruption of interruptions) {
-    if (interruption.rawItem.type !== 'function_call') {
-      continue;
-    }
-    let stateKey: string | undefined;
-    if (interruption.agent === processedAgent) {
-      stateKey = getFunctionToolStateKey(
-        functionsByCallId.get(interruption.rawItem.callId)?.tool,
-      );
-    } else {
-      stateKey = findNestedInterruptionFunctionToolStateKey(
-        state,
-        interruption,
-      );
-      if (schemaVersion === CURRENT_SCHEMA_VERSION) {
-        const rawStateKey = getFunctionToolStateKeyForCall(
-          interruption.rawItem,
-        );
-        const serializedStateKey = interruption.functionToolStateKey;
-        const expectedStateKey = stateKey ?? rawStateKey;
-        if (
-          serializedStateKey &&
-          expectedStateKey &&
-          serializedStateKey !== expectedStateKey
-        ) {
-          throwAmbiguousFunctionCallId(
-            interruption.agent,
-            interruption.rawItem.callId,
-            [expectedStateKey, serializedStateKey],
-          );
-        }
-      }
-    }
-    if (stateKey) {
-      interruption.functionToolStateKey = stateKey;
-    }
-  }
-}
-
-function findNestedInterruptionFunctionToolStateKey<TContext>(
-  state: RunState<TContext, Agent<any, any>>,
-  interruption: RunToolApprovalItem,
-): string | undefined {
-  if (interruption.rawItem.type !== 'function_call') {
-    return undefined;
-  }
-
-  const serializedPendingStates = new Set<string>();
-  for (const functionCall of state._lastProcessedResponse?.functions ?? []) {
-    if (getAgentToolSourceAgent(functionCall.tool) !== interruption.agent) {
-      continue;
-    }
-    const stateKeys = getFunctionToolStateKeys(
-      functionCall.tool,
-      functionCall.availableFunctionTools ?? [functionCall.tool],
-    );
-    for (const stateKey of stateKeys) {
-      const serializedState = state.getPendingAgentToolRun(
-        stateKey,
-        functionCall.toolCall.callId,
-      );
-      if (serializedState) {
-        serializedPendingStates.add(serializedState);
-      }
-    }
-  }
-
-  const resolvedStateKeys = new Set<string>();
-  for (const serializedState of serializedPendingStates) {
-    const resolvedStateKey =
-      getSerializedNestedInterruptionFunctionToolStateKey(
-        serializedState,
-        interruption.rawItem,
-      );
-    if (resolvedStateKey) {
-      resolvedStateKeys.add(resolvedStateKey);
-    }
-  }
-  if (resolvedStateKeys.size > 1) {
-    throwAmbiguousFunctionCallId(
-      interruption.agent,
-      interruption.rawItem.callId,
-      [...resolvedStateKeys],
-    );
-  }
-  return resolvedStateKeys.values().next().value;
-}
-
-function getSerializedNestedInterruptionFunctionToolStateKey(
-  serializedState: string,
-  interruptionRawItem: protocol.FunctionCallItem,
-): string | undefined {
-  let nestedState: unknown;
-  try {
-    nestedState = JSON.parse(serializedState);
-  } catch {
-    return undefined;
-  }
-  if (!nestedState || typeof nestedState !== 'object') {
-    return undefined;
-  }
-
-  const candidate = nestedState as {
-    currentStep?: {
-      type?: unknown;
-      data?: { interruptions?: unknown };
-    };
-    lastProcessedResponse?: {
-      functions?: unknown;
-    };
-  };
-  if (
-    candidate.currentStep?.type !== 'next_step_interruption' ||
-    !Array.isArray(candidate.currentStep.data?.interruptions) ||
-    !candidate.currentStep.data.interruptions.some((value) => {
-      if (!value || typeof value !== 'object') {
-        return false;
-      }
-      const rawItem = (value as { rawItem?: unknown }).rawItem;
-      return (
-        rawItem != null &&
-        typeof rawItem === 'object' &&
-        (rawItem as { type?: unknown }).type === 'function_call' &&
-        (rawItem as { callId?: unknown }).callId ===
-          interruptionRawItem.callId &&
-        getFunctionToolStateKeyForCall(rawItem as protocol.FunctionCallItem) ===
-          getFunctionToolStateKeyForCall(interruptionRawItem)
-      );
-    }) ||
-    !Array.isArray(candidate.lastProcessedResponse?.functions)
-  ) {
-    return undefined;
-  }
-
-  const stateKeys = new Set<string>();
-  for (const value of candidate.lastProcessedResponse.functions) {
-    if (!value || typeof value !== 'object') {
-      continue;
-    }
-    const functionCall = value as { toolCall?: unknown; tool?: unknown };
-    if (
-      !functionCall.toolCall ||
-      typeof functionCall.toolCall !== 'object' ||
-      (functionCall.toolCall as { callId?: unknown }).callId !==
-        interruptionRawItem.callId
-    ) {
-      continue;
-    }
-    const stateKey = getFunctionToolStateKey(functionCall.tool);
-    if (
-      stateKey &&
-      getFunctionToolStateKeyForResolvedCall(
-        interruptionRawItem,
-        functionCall.tool,
-        stateKey,
-      ) === stateKey
-    ) {
-      stateKeys.add(stateKey);
-    }
-  }
-  if (stateKeys.size !== 1) {
-    return undefined;
-  }
-  return stateKeys.values().next().value;
-}
-
-function restorePendingAgentToolRunAliases<TContext>(
-  state: RunState<TContext, Agent<any, any>>,
-  serializedAliases: Record<string, string>,
-): void {
-  const aliasEntries = Object.entries(serializedAliases);
-  if (aliasEntries.length === 0) {
-    return;
-  }
-
-  const validAliases = new Map<string, string>();
-  for (const functionCall of state._lastProcessedResponse?.functions ?? []) {
-    const [canonicalToolName, ...aliases] = getFunctionToolStateKeys(
-      functionCall.tool,
-      functionCall.availableFunctionTools ?? [functionCall.tool],
-    );
-    if (!canonicalToolName) {
-      continue;
-    }
-    const callId = functionCall.toolCall.callId;
-    const canonicalKey = `${canonicalToolName}:${callId}`;
-    for (const alias of aliases) {
-      validAliases.set(`${alias}:${callId}`, canonicalKey);
-    }
-  }
-
-  for (const [aliasKey, canonicalKey] of aliasEntries) {
-    if (
-      validAliases.get(aliasKey) !== canonicalKey ||
-      !state._pendingAgentToolRuns.has(canonicalKey)
-    ) {
-      throw new UserError(
-        'Run state pending agent tool aliases do not match the reconstructed pending function calls.',
-      );
-    }
-  }
-
-  state._pendingAgentToolRunAliases = new Map(aliasEntries);
-}
-
-function migrateLegacyFunctionToolState<TContext>(
-  state: RunState<TContext, Agent<any, any>>,
-  schemaVersion: SupportedSchemaVersion,
-  migrateApprovals: boolean,
-  approvalContext: RunContext<TContext> = state._context,
-  availableToolsByAgent: ReadonlyMap<
-    Agent<any, any>,
-    readonly Tool<TContext>[]
-  > = new Map(),
-): Set<string> {
-  if (schemaVersion === CURRENT_SCHEMA_VERSION) {
-    return new Set();
-  }
-
-  const approvalCallsByLegacyKey = new Map<
-    string,
-    Map<Agent<any, any>, Map<string, Set<string>>>
-  >();
-  const approvalOwnersByLegacyKey = new Map<
-    string,
-    Map<Agent<any, any>, Set<string>>
-  >();
-  const addApprovalOwner = (
-    legacyKey: string,
-    agent: Agent<any, any>,
-    canonicalKey: string,
-  ) => {
-    const ownersByAgent =
-      approvalOwnersByLegacyKey.get(legacyKey) ??
-      new Map<Agent<any, any>, Set<string>>();
-    const ownerKeys = ownersByAgent.get(agent) ?? new Set<string>();
-    ownerKeys.add(canonicalKey);
-    ownersByAgent.set(agent, ownerKeys);
-    approvalOwnersByLegacyKey.set(legacyKey, ownersByAgent);
-  };
-  const addApprovalCall = (
-    legacyKey: string,
-    agent: Agent<any, any>,
-    canonicalKey: string,
-    callId: string,
-  ) => {
-    addApprovalOwner(legacyKey, agent, canonicalKey);
-    const callsByAgent =
-      approvalCallsByLegacyKey.get(legacyKey) ??
-      new Map<Agent<any, any>, Map<string, Set<string>>>();
-    const callsByCanonicalKey =
-      callsByAgent.get(agent) ?? new Map<string, Set<string>>();
-    const callIds = callsByCanonicalKey.get(canonicalKey) ?? new Set<string>();
-    callIds.add(callId);
-    callsByCanonicalKey.set(canonicalKey, callIds);
-    callsByAgent.set(agent, callsByCanonicalKey);
-    approvalCallsByLegacyKey.set(legacyKey, callsByAgent);
-  };
-  for (const [agent, availableTools] of availableToolsByAgent) {
-    for (const tool of availableTools) {
-      if (tool.type !== 'function') {
-        continue;
-      }
-      const canonicalKey = getFunctionToolStateKey(tool);
-      const legacyKey = getFunctionToolQualifiedName(tool) ?? tool.name;
-      if (!canonicalKey || canonicalKey === legacyKey) {
-        continue;
-      }
-      addApprovalOwner(legacyKey, agent, canonicalKey);
-    }
-  }
-
-  for (const functionCall of state._lastProcessedResponse?.functions ?? []) {
-    const canonicalKey = getFunctionToolStateKey(functionCall.tool);
-    const legacyKey =
-      getFunctionToolQualifiedName(functionCall.tool) ?? functionCall.tool.name;
-    if (!canonicalKey || canonicalKey === legacyKey) {
-      continue;
-    }
-    const callId = functionCall.toolCall.callId;
-    const pendingState = state.getPendingAgentToolRun(legacyKey, callId);
-    if (pendingState !== undefined) {
-      state.setPendingAgentToolRun(canonicalKey, callId, pendingState, [
-        legacyKey,
-      ]);
-    }
-    if (!migrateApprovals) {
-      continue;
-    }
-    addApprovalCall(legacyKey, state._currentAgent, canonicalKey, callId);
-  }
-
-  if (state._currentStep?.type === 'next_step_interruption') {
-    for (const interruption of state._currentStep.data.interruptions) {
-      if (
-        interruption.rawItem.type !== 'function_call' ||
-        !interruption.functionToolStateKey
-      ) {
-        continue;
-      }
-      const legacyKey = getFunctionToolLegacyStateKeyFromStateKey(
-        interruption.functionToolStateKey,
-      );
-      if (!legacyKey) {
-        continue;
-      }
-      addApprovalCall(
-        legacyKey,
-        interruption.agent,
-        interruption.functionToolStateKey,
-        interruption.rawItem.callId,
-      );
-    }
-  }
-
-  if (migrateApprovals) {
-    for (const [legacyKey, ownersByAgent] of approvalOwnersByLegacyKey) {
-      const ownerEntries = [...ownersByAgent].flatMap(
-        ([agent, canonicalKeys]) =>
-          [...canonicalKeys].map((canonicalKey) => ({ agent, canonicalKey })),
-      );
-      if (ownerEntries.length !== 1) {
-        continue;
-      }
-      const [{ agent, canonicalKey }] = ownerEntries;
-      approvalContext._migrateToolApproval(
-        agent,
-        legacyKey,
-        canonicalKey,
-        [],
-        true,
-      );
-    }
-  }
-
-  for (const [legacyKey, callsByAgent] of approvalCallsByLegacyKey) {
-    const callOwners = new Map<string, number>();
-    for (const callsByCanonicalKey of callsByAgent.values()) {
-      for (const callIds of callsByCanonicalKey.values()) {
-        for (const callId of callIds) {
-          callOwners.set(callId, (callOwners.get(callId) ?? 0) + 1);
-        }
-      }
-    }
-    for (const [agent, callsByCanonicalKey] of callsByAgent) {
-      for (const [canonicalKey, callIds] of callsByCanonicalKey) {
-        for (const callId of callIds) {
-          const remainingOwners = (callOwners.get(callId) ?? 1) - 1;
-          callOwners.set(callId, remainingOwners);
-          approvalContext._migrateToolApproval(
-            agent,
-            legacyKey,
-            canonicalKey,
-            [callId],
-            false,
-            remainingOwners > 0,
-          );
-        }
-      }
-    }
-  }
-  return new Set(approvalOwnersByLegacyKey.keys());
-}
-
 type DeserializeProcessedResponseOptions<TContext> = {
   executionTools?: Tool<TContext>[];
-  executionHandoffs?: Handoff<any, any>[];
-  executionFunctionToolsByCallId?: Map<string, FunctionTool<TContext>>;
   allowSerializedExecutionToolPlaceholder?: boolean;
 };
 
@@ -3634,19 +2297,19 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
   options: DeserializeProcessedResponseOptions<TContext> = {},
 ): Promise<ProcessedResponse<TContext>> {
   const currentAgent = state._currentAgent;
-  const allTools = options.executionTools
-    ? options.executionTools
-    : [
-        ...((await currentAgent.getAllTools(
-          state._context,
-        )) as Tool<TContext>[]),
-        ...(await getEnabledToolSearchRuntimeTools(state, currentAgent)),
-      ];
+  const configuredTools =
+    options.executionTools ?? (await currentAgent.getAllTools(state._context));
+  const allTools = [
+    ...(configuredTools as Tool<TContext>[]),
+    ...state.getToolSearchRuntimeTools(currentAgent),
+  ];
   const baseAgentTools = currentAgent.tools as Tool<TContext>[];
   const allowSerializedExecutionToolPlaceholder =
     options.allowSerializedExecutionToolPlaceholder ?? true;
-  const tools = buildFunctionToolLookupMap(
-    allTools.filter((tool) => tool.type === 'function'),
+  const tools = new Map(
+    allTools
+      .filter((tool) => tool.type === 'function')
+      .map((tool) => [getFunctionToolQualifiedName(tool) ?? tool.name, tool]),
   );
   const computerTools = new Map(
     allTools
@@ -3689,11 +2352,14 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
       )
       .map((tool) => [tool.providerData.server_label, tool]),
   );
-  const enabledHandoffs = options.executionHandoffs
-    ? options.executionHandoffs
-    : await currentAgent.getEnabledHandoffs(state._context);
   const handoffs = new Map(
-    enabledHandoffs.map((entry) => [entry.toolName, entry]),
+    currentAgent.handoffs.map((entry) => {
+      if (entry instanceof Agent) {
+        return [entry.name, handoff(entry)];
+      }
+
+      return [entry.toolName, entry];
+    }),
   );
 
   const result = {
@@ -3701,60 +2367,31 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
       deserializeItem(item, agentMap),
     ),
     toolsUsed: serializedProcessedResponse.toolsUsed,
-    handoffs: serializedProcessedResponse.handoffs.map((serializedHandoff) => {
-      const toolName = serializedHandoff.handoff.toolName;
-      const resolvedHandoff = handoffs.get(toolName);
-      const serializedTargetAgent = serializedHandoff.targetAgent
-        ? resolveSerializedAgent(serializedHandoff.targetAgent, agentMap)
-        : undefined;
-      const targetMatches = serializedTargetAgent
-        ? resolvedHandoff?.agent === serializedTargetAgent
-        : resolvedHandoff?.agentName === serializedHandoff.handoff.agentName;
-      if (!resolvedHandoff || !targetMatches) {
-        throw new UserError(`Handoff ${toolName} not found`);
+    handoffs: serializedProcessedResponse.handoffs.map((handoff) => {
+      if (!handoffs.has(handoff.handoff.toolName)) {
+        throw new UserError(`Handoff ${handoff.handoff.toolName} not found`);
       }
+
+      const resolvedHandoff = handoffs.get(handoff.handoff.toolName)!;
       ensureToolCallerAllowed(
-        serializedHandoff.toolCall as protocol.FunctionCallItem,
+        handoff.toolCall as protocol.FunctionCallItem,
         undefined,
         resolvedHandoff.toolName,
         currentAgent,
       );
 
       return {
-        toolCall: serializedHandoff.toolCall,
+        toolCall: handoff.toolCall,
         handoff: resolvedHandoff,
       };
     }),
     functions: await Promise.all(
       serializedProcessedResponse.functions.map(async (functionCall) => {
         const toolIdentity =
-          getToolCallDisplayName(functionCall.toolCall) ??
+          resolveFunctionToolCallName(functionCall.toolCall, tools) ??
           functionCall.tool.name;
-        const exactRuntimeTool = options.executionFunctionToolsByCallId?.get(
-          functionCall.toolCall.callId,
-        );
-        if (
-          exactRuntimeTool &&
-          !getFunctionToolStateKeyForResolvedCall(
-            functionCall.toolCall as protocol.FunctionCallItem,
-            exactRuntimeTool,
-          )
-        ) {
-          throwAmbiguousFunctionCallId(
-            currentAgent,
-            functionCall.toolCall.callId,
-            [
-              getFunctionToolStateKey(exactRuntimeTool) ??
-                exactRuntimeTool.name,
-              getFunctionToolStateKeyForCall(
-                functionCall.toolCall as protocol.FunctionCallItem,
-              ) ?? functionCall.tool.name,
-            ],
-          );
-        }
         const resolvedTool =
-          exactRuntimeTool ??
-          resolveFunctionToolCall(functionCall.toolCall, tools) ??
+          tools.get(toolIdentity) ??
           getSerializedFunctionToolPlaceholder({
             agent: currentAgent,
             baseAgentTools,
@@ -3774,14 +2411,10 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
           currentAgent,
         );
 
-        return createToolRunFunction({
+        return {
           toolCall: functionCall.toolCall,
           tool: resolvedTool,
-          availableFunctionTools: [
-            ...new Set([...tools.values(), resolvedTool]),
-          ],
-          preserveToolOnExecutionRehydration: Boolean(exactRuntimeTool),
-        });
+        };
       }),
     ),
     functionToolsNotFound:
@@ -3917,15 +2550,4 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
       );
     },
   };
-}
-
-async function getEnabledToolSearchRuntimeTools<TContext>(
-  state: RunState<TContext, Agent<any, any>>,
-  agent: Agent<any, any>,
-): Promise<Tool<TContext>[]> {
-  return filterEnabledToolSearchRuntimeTools({
-    runtimeTools: state.getToolSearchRuntimeTools(agent),
-    runContext: state._context,
-    agent,
-  });
 }

--- a/packages/agents-core/src/runner/items.ts
+++ b/packages/agents-core/src/runner/items.ts
@@ -1,5 +1,7 @@
 import { RunItem } from '../items';
+import { UserError } from '../errors';
 import { AgentInputItem } from '../types';
+import * as protocol from '../types/protocol';
 import { serializeBinary } from '../utils/binary';
 import {
   getToolResultCorrelationForCall,
@@ -12,6 +14,8 @@ import {
 
 export type AgentInputItemPool = Map<string, AgentInputItem[]>;
 
+export class CompactionItemValidationError extends UserError {}
+
 // Normalizes user-provided input into the structure the model expects. Strings become user messages,
 // arrays are kept as-is so downstream loops can treat both scenarios uniformly.
 export function toAgentInputList(
@@ -22,6 +26,21 @@ export function toAgentInputList(
   }
 
   return [...originalInput];
+}
+
+export function assertValidCompactionItems(
+  items: readonly AgentInputItem[],
+): void {
+  for (const item of items) {
+    if (
+      item.type === 'compaction' &&
+      !protocol.CompactionItem.safeParse(item).success
+    ) {
+      throw new CompactionItemValidationError(
+        'Compaction item missing encrypted_content',
+      );
+    }
+  }
 }
 
 export function getAgentInputItemKey(item: AgentInputItem): string {

--- a/packages/agents-core/src/runner/items.ts
+++ b/packages/agents-core/src/runner/items.ts
@@ -434,16 +434,15 @@ export function prepareModelInputItems(
     generatedItems,
     reasoningItemIdPolicy,
   );
-  return [...callerItems, ...preparedGeneratedItems];
+  return trimToLatestCompaction([...callerItems, ...preparedGeneratedItems]);
 }
 
 function getContinuationOutputItems(
   generatedItems: RunItem[],
   reasoningItemIdPolicy?: ReasoningItemIdPolicy,
 ): AgentInputItem[] {
-  const generatedOutputItems = extractOutputItemsFromRunItems(
-    generatedItems,
-    reasoningItemIdPolicy,
+  const generatedOutputItems = trimToLatestCompaction(
+    extractOutputItemsFromRunItems(generatedItems, reasoningItemIdPolicy),
   );
   return dropOrphanToolCalls(generatedOutputItems);
 }
@@ -464,5 +463,19 @@ export function getTurnInput(
     generatedItems,
     reasoningItemIdPolicy,
   );
-  return [...toAgentInputList(originalInput), ...outputItems];
+  return trimToLatestCompaction([
+    ...toAgentInputList(originalInput),
+    ...outputItems,
+  ]);
+}
+
+export function trimToLatestCompaction(
+  items: AgentInputItem[],
+): AgentInputItem[] {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    if (items[index]?.type === 'compaction') {
+      return items.slice(index);
+    }
+  }
+  return items;
 }

--- a/packages/agents-core/src/runner/modelOutputs.ts
+++ b/packages/agents-core/src/runner/modelOutputs.ts
@@ -2,6 +2,7 @@ import { Agent } from '../agent';
 import { ModelBehaviorError } from '../errors';
 import { Handoff } from '../handoff';
 import {
+  RunCompactionItem,
   RunHandoffCallItem,
   RunItem,
   RunMessageOutputItem,
@@ -832,6 +833,8 @@ export function processModelResponse<TContext>(
       }
     } else if (output.type === 'reasoning') {
       items.push(new RunReasoningItem(output, agent));
+    } else if (output.type === 'compaction') {
+      items.push(new RunCompactionItem(output, agent));
     } else if (output.type === 'computer_call') {
       handleToolCallAction({
         output,
@@ -1197,6 +1200,8 @@ export async function processModelResponseAsync<TContext>(
       }
     } else if (output.type === 'reasoning') {
       items.push(new RunReasoningItem(output, agent));
+    } else if (output.type === 'compaction') {
+      items.push(new RunCompactionItem(output, agent));
     } else if (output.type === 'computer_call') {
       handleToolCallAction({
         output,

--- a/packages/agents-core/src/runner/modelOutputs.ts
+++ b/packages/agents-core/src/runner/modelOutputs.ts
@@ -66,6 +66,7 @@ import {
   registerRuntimeToolSearchTools,
 } from './toolSearch';
 import { ensureToolCallerAllowed } from './toolCaller';
+import { assertValidCompactionItems } from './items';
 
 function ensureToolAvailable<T>(
   tool: T | undefined,
@@ -692,6 +693,7 @@ export function processModelResponse<TContext>(
   toolNotFoundBehavior: ToolNotFoundBehavior = 'raise_error',
   processingOptions: ModelResponseProcessingOptions = {},
 ): ProcessedResponse<TContext> {
+  assertValidCompactionItems(modelResponse.output);
   const items: RunItem[] = [];
   const runHandoffs: ToolRunHandoff[] = [];
   const runFunctions: ToolRunFunction<TContext>[] = [];
@@ -1014,6 +1016,7 @@ export async function processModelResponseAsync<TContext>(
   toolNotFoundBehavior: ToolNotFoundBehavior = 'raise_error',
   processingOptions: ModelResponseProcessingOptions = {},
 ): Promise<ProcessedResponse<TContext>> {
+  assertValidCompactionItems(modelResponse.output);
   const clientToolSearchTool = getClientToolSearchHelper(tools);
   const hasCustomClientToolSearchExecutor = Boolean(
     clientToolSearchTool && getClientToolSearchExecutor(clientToolSearchTool),

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -13,6 +13,7 @@ import { Usage } from '../usage';
 import { encodeUint8ArrayToBase64 } from '../utils/base64';
 import { toUint8ArrayFromBinary } from '../utils/binary';
 import {
+  assertValidCompactionItems,
   buildAgentInputPool,
   dropOrphanToolCalls,
   extractOutputItemsFromRunItems,
@@ -332,6 +333,7 @@ export async function saveStreamInputToSession(
   }
   const sanitizedInput = normalizeItemsForSessionPersistence(sessionInputItems);
   const compactedInput = trimToLatestCompaction(sanitizedInput);
+  assertPersistableCompactionBoundary(compactedInput);
   if (compactedInput[0]?.type === 'compaction') {
     const previousItems = await session.getItems();
     await replaceSessionItemsWithRecovery(
@@ -374,6 +376,7 @@ export async function reconcileLegacyCompactionSessionBeforeResume(
   }
   const normalizedPendingItems =
     normalizeItemsForSessionPersistence(pendingLegacyItems);
+  assertPersistableCompactionBoundary(normalizedPendingItems);
   assertPendingLegacyCompactionItemsMatchState(
     state,
     normalizedPendingItems,
@@ -454,6 +457,8 @@ export async function prepareInputItemsWithSession(
     reasoningItemIdPolicy?: ReasoningItemIdPolicy;
   },
 ): Promise<PreparedInputWithSessionResult> {
+  const newInputItems = toAgentInputList(input);
+  assertValidCompactionItems(newInputItems);
   if (!session) {
     return {
       preparedInput: input,
@@ -467,8 +472,7 @@ export async function prepareInputItemsWithSession(
   const reasoningItemIdPolicy = options?.reasoningItemIdPolicy;
 
   const history = trimToLatestCompaction(await session.getItems());
-  const newInputItems = toAgentInputList(input);
-
+  assertPersistableCompactionBoundary(history);
   if (!sessionInputCallback) {
     const historyForModelInput = history.map((item) =>
       prepareHistoryItemForModelInput(session, item, reasoningItemIdPolicy),
@@ -493,6 +497,7 @@ export async function prepareInputItemsWithSession(
       'Session input callback must return an array of AgentInputItem objects.',
     );
   }
+  assertValidCompactionItems(combined);
 
   const historyCounts = buildItemFrequencyMap(historySnapshot, {
     session,
@@ -792,6 +797,7 @@ async function persistRunItemsToSession(options: {
 
   const sanitizedItems = normalizeItemsForSessionPersistence(itemsToSave);
   const compactedItems = trimToLatestCompaction(sanitizedItems);
+  assertPersistableCompactionBoundary(compactedItems);
   if (compactedItems[0]?.type === 'compaction') {
     const previousItems = await session.getItems();
     await replaceSessionItemsWithRecovery(
@@ -821,27 +827,46 @@ async function reconcileLegacyCompactionSessionItems(
   if (pendingItems.length === 0 || pendingItems[0]?.type !== 'compaction') {
     throwLegacyCompactionReconciliationError();
   }
+  assertPersistableCompactionBoundary(pendingItems);
 
   const previousItems = await session.getItems();
+  assertValidCompactionItems(trimToLatestCompaction(previousItems));
+  const comparablePreviousItems =
+    session.prepareHistoryItemsForPersistenceComparison?.(previousItems) ??
+    previousItems;
+  const comparablePendingItems =
+    session.prepareHistoryItemsForPersistenceComparison?.(pendingItems) ??
+    pendingItems;
+  const compactedComparablePreviousItems = trimToLatestCompaction(
+    comparablePreviousItems,
+  );
   if (
-    previousItems.length === pendingItems.length &&
-    agentItemRangeMatches(previousItems, pendingItems, 0)
+    compactedComparablePreviousItems.length === comparablePendingItems.length &&
+    agentItemRangeMatches(
+      compactedComparablePreviousItems,
+      comparablePendingItems,
+      0,
+    )
   ) {
     return;
   }
 
-  const previouslyPersistedSuffix = pendingItems.slice(1);
+  const previouslyPersistedSuffix = comparablePendingItems.slice(1);
   if (
     !agentItemRangeMatches(
-      previousItems,
+      comparablePreviousItems,
       previouslyPersistedSuffix,
-      previousItems.length - previouslyPersistedSuffix.length,
+      comparablePreviousItems.length - previouslyPersistedSuffix.length,
     )
   ) {
     throwLegacyCompactionReconciliationError();
   }
 
   await replaceSessionItemsWithRecovery(session, previousItems, pendingItems);
+}
+
+function assertPersistableCompactionBoundary(items: AgentInputItem[]): void {
+  assertValidCompactionItems(items);
 }
 
 function agentItemRangeMatches(
@@ -888,6 +913,35 @@ async function replaceSessionItemsWithRecovery(
   previousItems: AgentInputItem[],
   replacementItems: AgentInputItem[],
 ): Promise<void> {
+  assertValidCompactionItems(trimToLatestCompaction(previousItems));
+  assertValidCompactionItems(trimToLatestCompaction(replacementItems));
+  if (
+    replacementItems[0]?.type === 'compaction' &&
+    session.replaceHistoryWithCompaction
+  ) {
+    const comparablePreviousItems =
+      session.prepareHistoryItemsForPersistenceComparison?.(previousItems) ??
+      previousItems;
+    const comparableReplacementItems =
+      session.prepareHistoryItemsForPersistenceComparison?.(replacementItems) ??
+      replacementItems;
+    const compactedPreviousItems = trimToLatestCompaction(
+      comparablePreviousItems,
+    );
+    if (
+      compactedPreviousItems.length === comparableReplacementItems.length &&
+      agentItemRangeMatches(
+        compactedPreviousItems,
+        comparableReplacementItems,
+        0,
+      )
+    ) {
+      return;
+    }
+    await session.replaceHistoryWithCompaction(replacementItems);
+    return;
+  }
+
   try {
     await session.clearSession();
     if (replacementItems.length > 0) {

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -22,7 +22,7 @@ import {
   stripReasoningItemIdForPolicy,
   type ReasoningItemIdPolicy,
 } from './items';
-import logger from '../logger';
+import logger, { logModelAndToolActionWarning } from '../logger';
 import { getRunStateUsageRecorder } from './usageTracking';
 
 export type PreparedInputWithSessionResult = {
@@ -334,6 +334,28 @@ export async function saveStreamResultToSession(
     runCompaction: options.runCompaction ?? true,
     compactionMode: options.compactionMode,
   });
+}
+
+export async function reconcileLegacyCompactionSessionBeforeResume(
+  session: Session | undefined,
+  state: RunState<any, any>,
+): Promise<void> {
+  const pendingLegacyItems = state._pendingLegacyCompactionSessionItems;
+  if (!session || pendingLegacyItems === undefined) {
+    return;
+  }
+
+  const reasoningItemIdPolicy =
+    session.preserveReasoningItemIdsForPersistence?.() === true
+      ? undefined
+      : state._reasoningItemIdPolicy;
+  const sanitizedPendingItems = normalizeItemsForSessionPersistence(
+    pendingLegacyItems.map((item) =>
+      stripReasoningItemIdForPolicy(item, reasoningItemIdPolicy),
+    ),
+  );
+  await reconcileLegacyCompactionSessionItems(session, sanitizedPendingItems);
+  state._pendingLegacyCompactionSessionItems = undefined;
 }
 
 export async function prepareInputItemsWithSession(
@@ -657,15 +679,16 @@ async function persistRunItemsToSession(options: {
     return;
   }
 
+  const reasoningItemIdPolicy =
+    session.preserveReasoningItemIdsForPersistence?.() === true
+      ? undefined
+      : state._reasoningItemIdPolicy;
   const itemsToSave = [
     ...extraInputItems,
-    ...extractOutputItemsFromRunItems(
-      newRunItems,
-      session.preserveReasoningItemIdsForPersistence?.() === true
-        ? undefined
-        : state._reasoningItemIdPolicy,
-    ),
+    ...extractOutputItemsFromRunItems(newRunItems, reasoningItemIdPolicy),
   ];
+
+  await reconcileLegacyCompactionSessionBeforeResume(session, state);
 
   if (itemsToSave.length === 0) {
     state._currentTurnPersistedItemCount =
@@ -693,6 +716,143 @@ async function persistRunItemsToSession(options: {
       compactionMode,
     );
   }
+}
+
+async function reconcileLegacyCompactionSessionItems(
+  session: Session,
+  pendingItems: AgentInputItem[],
+): Promise<void> {
+  if (pendingItems.length === 0 || pendingItems[0]?.type !== 'compaction') {
+    throw new UserError(
+      'Run state cannot safely reconcile its restored compaction item with session history.',
+    );
+  }
+
+  const previousItems = await session.getItems();
+  if (
+    agentItemRangeMatches(
+      previousItems,
+      pendingItems,
+      previousItems.length - pendingItems.length,
+    )
+  ) {
+    return;
+  }
+
+  const previouslyPersistedSuffix = pendingItems.slice(1);
+  if (previouslyPersistedSuffix.length === 0) {
+    await session.addItems(pendingItems);
+    return;
+  }
+  if (
+    !agentItemRangeMatches(
+      previousItems,
+      previouslyPersistedSuffix,
+      previousItems.length - previouslyPersistedSuffix.length,
+    )
+  ) {
+    throw new UserError(
+      'Run state cannot safely reconcile its restored compaction item with session history.',
+    );
+  }
+
+  const replacementItems = [
+    ...previousItems.slice(0, -previouslyPersistedSuffix.length),
+    ...pendingItems,
+  ];
+  await replaceSessionItemsWithRecovery(
+    session,
+    previousItems,
+    replacementItems,
+  );
+}
+
+function agentItemRangeMatches(
+  items: AgentInputItem[],
+  expected: AgentInputItem[],
+  start: number,
+): boolean {
+  if (start < 0 || start + expected.length > items.length) {
+    return false;
+  }
+  return expected.every(
+    (item, offset) =>
+      getSessionReconciliationItemKey(items[start + offset]) ===
+      getSessionReconciliationItemKey(item),
+  );
+}
+
+function getSessionReconciliationItemKey(item: AgentInputItem): string {
+  if (item && typeof item === 'object') {
+    const record = item as Record<string, unknown>;
+    const stableId = record.callId ?? record.id;
+    if (typeof stableId === 'string' && stableId.length > 0) {
+      return `${String(record.type)}:${stableId}`;
+    }
+  }
+  return getAgentInputItemKey(item);
+}
+
+async function replaceSessionItemsWithRecovery(
+  session: Session,
+  previousItems: AgentInputItem[],
+  replacementItems: AgentInputItem[],
+): Promise<void> {
+  try {
+    await session.clearSession();
+    if (replacementItems.length > 0) {
+      await session.addItems(replacementItems);
+    }
+  } catch (error) {
+    await restoreSessionItemsAfterFailedReplacement(
+      session,
+      previousItems,
+      error,
+    );
+    throw error;
+  }
+}
+
+async function restoreSessionItemsAfterFailedReplacement(
+  session: Session,
+  previousItems: AgentInputItem[],
+  replacementError: unknown,
+): Promise<void> {
+  try {
+    const currentItems = await session.getItems();
+    if (
+      currentItems.length === previousItems.length &&
+      agentItemRangeMatches(currentItems, previousItems, 0)
+    ) {
+      return;
+    }
+  } catch (inspectionError) {
+    logModelAndToolActionWarning(
+      logger,
+      'Failed to inspect session history after legacy compaction reconciliation failed.',
+      inspectionError,
+    );
+  }
+
+  try {
+    await session.clearSession();
+    if (previousItems.length > 0) {
+      await session.addItems(previousItems);
+    }
+  } catch (restoreError) {
+    logModelAndToolActionWarning(
+      logger,
+      'Failed to restore session history after legacy compaction reconciliation failed.',
+      restoreError,
+    );
+    return;
+  }
+
+  logModelAndToolActionWarning(
+    logger,
+    'Restored session history after legacy compaction reconciliation failed.',
+    replacementError,
+  );
 }
 
 async function runCompactionOnSession(

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -331,6 +331,16 @@ export async function saveStreamInputToSession(
     return;
   }
   const sanitizedInput = normalizeItemsForSessionPersistence(sessionInputItems);
+  const compactedInput = trimToLatestCompaction(sanitizedInput);
+  if (compactedInput[0]?.type === 'compaction') {
+    const previousItems = await session.getItems();
+    await replaceSessionItemsWithRecovery(
+      session,
+      previousItems,
+      compactedInput,
+    );
+    return;
+  }
   await session.addItems(sanitizedInput);
 }
 

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -35,6 +35,23 @@ export type SessionPersistenceOptions = {
   compactionMode?: OpenAIResponsesCompactionArgs['compactionMode'];
 };
 
+class SessionReconciliationRecoveryError extends Error {
+  readonly errors: readonly [unknown, unknown];
+  readonly cause: unknown;
+
+  constructor(
+    readonly primaryError: unknown,
+    readonly rollbackError: unknown,
+  ) {
+    super(
+      'Failed to reconcile legacy compaction session history and restore the previous session contents.',
+    );
+    this.name = 'SessionReconciliationRecoveryError';
+    this.errors = [primaryError, rollbackError];
+    this.cause = primaryError;
+  }
+}
+
 export type SessionPersistenceTracker = {
   setPreparedItems: (items?: AgentInputItem[]) => void;
   recordTurnItems: (
@@ -341,8 +358,11 @@ export async function reconcileLegacyCompactionSessionBeforeResume(
   state: RunState<any, any>,
 ): Promise<void> {
   const pendingLegacyItems = state._pendingLegacyCompactionSessionItems;
-  if (!session || pendingLegacyItems === undefined) {
+  if (pendingLegacyItems === undefined) {
     return;
+  }
+  if (!session) {
+    throwLegacyCompactionReconciliationError();
   }
 
   const reasoningItemIdPolicy =
@@ -354,8 +374,56 @@ export async function reconcileLegacyCompactionSessionBeforeResume(
       stripReasoningItemIdForPolicy(item, reasoningItemIdPolicy),
     ),
   );
+  assertPendingLegacyCompactionItemsMatchState(
+    state,
+    sanitizedPendingItems,
+    reasoningItemIdPolicy,
+  );
   await reconcileLegacyCompactionSessionItems(session, sanitizedPendingItems);
   state._pendingLegacyCompactionSessionItems = undefined;
+}
+
+function assertPendingLegacyCompactionItemsMatchState(
+  state: RunState<any, any>,
+  pendingItems: AgentInputItem[],
+  reasoningItemIdPolicy: ReasoningItemIdPolicy | undefined,
+): void {
+  if (pendingItems.length < 2 || pendingItems[0]?.type !== 'compaction') {
+    throwLegacyCompactionReconciliationError();
+  }
+
+  const persistedItemCount = state._currentTurnPersistedItemCount;
+  if (
+    !Number.isInteger(persistedItemCount) ||
+    persistedItemCount < 1 ||
+    persistedItemCount > state._generatedItems.length
+  ) {
+    throwLegacyCompactionReconciliationError();
+  }
+
+  let matchingCandidates = 0;
+  for (let index = 0; index < persistedItemCount; index += 1) {
+    if (state._generatedItems[index]?.type !== 'compaction_item') {
+      continue;
+    }
+    const candidateItems = normalizeItemsForSessionPersistence(
+      extractOutputItemsFromRunItems(
+        state._generatedItems.slice(index, persistedItemCount),
+        reasoningItemIdPolicy,
+      ),
+    );
+    if (
+      candidateItems.length > 1 &&
+      agentItemRangeMatches(candidateItems, pendingItems, 0) &&
+      candidateItems.length === pendingItems.length
+    ) {
+      matchingCandidates += 1;
+    }
+  }
+
+  if (matchingCandidates !== 1) {
+    throwLegacyCompactionReconciliationError();
+  }
 }
 
 export async function prepareInputItemsWithSession(
@@ -723,9 +791,7 @@ async function reconcileLegacyCompactionSessionItems(
   pendingItems: AgentInputItem[],
 ): Promise<void> {
   if (pendingItems.length === 0 || pendingItems[0]?.type !== 'compaction') {
-    throw new UserError(
-      'Run state cannot safely reconcile its restored compaction item with session history.',
-    );
+    throwLegacyCompactionReconciliationError();
   }
 
   const previousItems = await session.getItems();
@@ -751,9 +817,7 @@ async function reconcileLegacyCompactionSessionItems(
       previousItems.length - previouslyPersistedSuffix.length,
     )
   ) {
-    throw new UserError(
-      'Run state cannot safely reconcile its restored compaction item with session history.',
-    );
+    throwLegacyCompactionReconciliationError();
   }
 
   const replacementItems = [
@@ -783,14 +847,27 @@ function agentItemRangeMatches(
 }
 
 function getSessionReconciliationItemKey(item: AgentInputItem): string {
-  if (item && typeof item === 'object') {
-    const record = item as Record<string, unknown>;
-    const stableId = record.callId ?? record.id;
-    if (typeof stableId === 'string' && stableId.length > 0) {
-      return `${String(record.type)}:${stableId}`;
-    }
+  return JSON.stringify(sortSessionReconciliationValue(item));
+}
+
+function sortSessionReconciliationValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortSessionReconciliationValue);
   }
-  return getAgentInputItemKey(item);
+  if (!isPlainObject(value)) {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, sortSessionReconciliationValue(value[key])]),
+  );
+}
+
+function throwLegacyCompactionReconciliationError(): never {
+  throw new UserError(
+    'Run state cannot safely reconcile its restored compaction item with session history.',
+  );
 }
 
 async function replaceSessionItemsWithRecovery(
@@ -845,7 +922,10 @@ async function restoreSessionItemsAfterFailedReplacement(
       'Failed to restore session history after legacy compaction reconciliation failed.',
       restoreError,
     );
-    return;
+    throw new SessionReconciliationRecoveryError(
+      replacementError,
+      restoreError,
+    );
   }
 
   logModelAndToolActionWarning(

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -20,6 +20,7 @@ import {
   getAgentInputItemKey,
   removeAgentInputFromPool,
   stripReasoningItemIdForPolicy,
+  trimToLatestCompaction,
   type ReasoningItemIdPolicy,
 } from './items';
 import logger, { logModelAndToolActionWarning } from '../logger';
@@ -361,6 +362,13 @@ export async function reconcileLegacyCompactionSessionBeforeResume(
   if (pendingLegacyItems === undefined) {
     return;
   }
+  const normalizedPendingItems =
+    normalizeItemsForSessionPersistence(pendingLegacyItems);
+  assertPendingLegacyCompactionItemsMatchState(
+    state,
+    normalizedPendingItems,
+    undefined,
+  );
   if (!session) {
     throwLegacyCompactionReconciliationError();
   }
@@ -448,7 +456,7 @@ export async function prepareInputItemsWithSession(
   const preserveDroppedNewItems = options?.preserveDroppedNewItems ?? false;
   const reasoningItemIdPolicy = options?.reasoningItemIdPolicy;
 
-  const history = await session.getItems();
+  const history = trimToLatestCompaction(await session.getItems());
   const newInputItems = toAgentInputList(input);
 
   if (!sessionInputCallback) {
@@ -747,6 +755,8 @@ async function persistRunItemsToSession(options: {
     return;
   }
 
+  await reconcileLegacyCompactionSessionBeforeResume(session, state);
+
   const reasoningItemIdPolicy =
     session.preserveReasoningItemIdsForPersistence?.() === true
       ? undefined
@@ -755,8 +765,6 @@ async function persistRunItemsToSession(options: {
     ...extraInputItems,
     ...extractOutputItemsFromRunItems(newRunItems, reasoningItemIdPolicy),
   ];
-
-  await reconcileLegacyCompactionSessionBeforeResume(session, state);
 
   if (itemsToSave.length === 0) {
     state._currentTurnPersistedItemCount =
@@ -773,7 +781,17 @@ async function persistRunItemsToSession(options: {
   }
 
   const sanitizedItems = normalizeItemsForSessionPersistence(itemsToSave);
-  await session.addItems(sanitizedItems);
+  const compactedItems = trimToLatestCompaction(sanitizedItems);
+  if (compactedItems[0]?.type === 'compaction') {
+    const previousItems = await session.getItems();
+    await replaceSessionItemsWithRecovery(
+      session,
+      previousItems,
+      compactedItems,
+    );
+  } else {
+    await session.addItems(sanitizedItems);
+  }
   state._currentTurnPersistedItemCount =
     alreadyPersistedCount + newRunItems.length;
   if (runCompaction) {
@@ -796,20 +814,13 @@ async function reconcileLegacyCompactionSessionItems(
 
   const previousItems = await session.getItems();
   if (
-    agentItemRangeMatches(
-      previousItems,
-      pendingItems,
-      previousItems.length - pendingItems.length,
-    )
+    previousItems.length === pendingItems.length &&
+    agentItemRangeMatches(previousItems, pendingItems, 0)
   ) {
     return;
   }
 
   const previouslyPersistedSuffix = pendingItems.slice(1);
-  if (previouslyPersistedSuffix.length === 0) {
-    await session.addItems(pendingItems);
-    return;
-  }
   if (
     !agentItemRangeMatches(
       previousItems,
@@ -820,15 +831,7 @@ async function reconcileLegacyCompactionSessionItems(
     throwLegacyCompactionReconciliationError();
   }
 
-  const replacementItems = [
-    ...previousItems.slice(0, -previouslyPersistedSuffix.length),
-    ...pendingItems,
-  ];
-  await replaceSessionItemsWithRecovery(
-    session,
-    previousItems,
-    replacementItems,
-  );
+  await replaceSessionItemsWithRecovery(session, previousItems, pendingItems);
 }
 
 function agentItemRangeMatches(
@@ -906,7 +909,7 @@ async function restoreSessionItemsAfterFailedReplacement(
   } catch (inspectionError) {
     logModelAndToolActionWarning(
       logger,
-      'Failed to inspect session history after legacy compaction reconciliation failed.',
+      'Failed to inspect session history after compaction replacement failed.',
       inspectionError,
     );
   }
@@ -919,7 +922,7 @@ async function restoreSessionItemsAfterFailedReplacement(
   } catch (restoreError) {
     logModelAndToolActionWarning(
       logger,
-      'Failed to restore session history after legacy compaction reconciliation failed.',
+      'Failed to restore session history after compaction replacement failed.',
       restoreError,
     );
     throw new SessionReconciliationRecoveryError(
@@ -930,7 +933,7 @@ async function restoreSessionItemsAfterFailedReplacement(
 
   logModelAndToolActionWarning(
     logger,
-    'Restored session history after legacy compaction reconciliation failed.',
+    'Restored session history after compaction replacement failed.',
     replacementError,
   );
 }

--- a/packages/agents-core/src/runner/streaming.ts
+++ b/packages/agents-core/src/runner/streaming.ts
@@ -1,6 +1,7 @@
 import logger from '../logger';
 import { RunItemStreamEvent, RunItemStreamEventName } from '../events';
 import {
+  RunCompactionItem,
   RunHandoffCallItem,
   RunHandoffOutputItem,
   RunItem,
@@ -55,6 +56,11 @@ function enqueueRunItemStreamEvent(
   result: StreamedRunResult<any, any>,
   item: RunItem,
 ): void {
+  // Compaction remains observable through raw model events and the completed result. It does not
+  // have a separate high-level run-item event.
+  if (item instanceof RunCompactionItem) {
+    return;
+  }
   const itemName = getRunItemStreamEventName(item);
   if (!itemName) {
     if (logger.dontLogModelData || logger.dontLogToolData) {

--- a/packages/agents-core/src/runner/streaming.ts
+++ b/packages/agents-core/src/runner/streaming.ts
@@ -46,6 +46,9 @@ function getRunItemStreamEventName(
   if (item instanceof RunReasoningItem) {
     return 'reasoning_item_created';
   }
+  if (item instanceof RunCompactionItem) {
+    return 'compaction_item_created';
+  }
   if (item instanceof RunToolApprovalItem) {
     return 'tool_approval_requested';
   }
@@ -56,11 +59,6 @@ function enqueueRunItemStreamEvent(
   result: StreamedRunResult<any, any>,
   item: RunItem,
 ): void {
-  // Compaction remains observable through raw model events and the completed result. It does not
-  // have a separate high-level run-item event.
-  if (item instanceof RunCompactionItem) {
-    return;
-  }
   const itemName = getRunItemStreamEventName(item);
   if (!itemName) {
     if (logger.dontLogModelData || logger.dontLogToolData) {

--- a/packages/agents-core/src/utils/internal.ts
+++ b/packages/agents-core/src/utils/internal.ts
@@ -1,5 +1,9 @@
 export { formatInlineData, getInlineMediaType } from './inlineData';
 export { recordToolUsage } from '../runner/usageTracking';
+export {
+  assertValidCompactionItems,
+  CompactionItemValidationError,
+} from '../runner/items';
 export { normalizeToolAllowedCallers } from './toolCallers';
 export {
   hasDynamicFunctionToolApprovalPolicy,

--- a/packages/agents-core/test/index.test.ts
+++ b/packages/agents-core/test/index.test.ts
@@ -23,6 +23,7 @@ describe('index.ts', () => {
     expect(agent).toBeDefined();
     expect(agent.name).toEqual('TestAgent');
     expect(typeof AgentsCore.setSensitiveDataLoggingEnabled).toBe('function');
+    expect(typeof AgentsCore.RunCompactionItem).toBe('function');
   });
 
   test('exposes public lifecycle and agent tool types', () => {

--- a/packages/agents-core/test/items.test.ts
+++ b/packages/agents-core/test/items.test.ts
@@ -6,6 +6,7 @@ import {
   RunHandoffCallItem as HandoffCallItem,
   RunHandoffOutputItem as HandoffOutputItem,
   RunMessageOutputItem as MessageOutputItem,
+  RunCompactionItem as CompactionItem,
   RunReasoningItem as ReasoningItem,
   RunToolApprovalItem as ToolApprovalItem,
   RunToolCallItem as ToolCallItem,
@@ -213,6 +214,27 @@ describe('items toJSON()', () => {
     it('returns the correct JSON', () => {
       expect(item.toJSON()).toEqual({
         type: 'reasoning_item',
+        rawItem: item.rawItem,
+        agent: item.agent.toJSON(),
+      });
+    });
+  });
+
+  describe('CompactionItem', () => {
+    const item = new CompactionItem(
+      {
+        id: 'cmp_1',
+        type: 'compaction',
+        encrypted_content: 'ciphertext',
+        created_by: 'compaction_endpoint',
+        providerData: { extra: 'value' },
+      },
+      new Agent({ name: 'TestAgent' }),
+    );
+
+    it('returns the correct JSON', () => {
+      expect(item.toJSON()).toEqual({
+        type: 'compaction_item',
         rawItem: item.rawItem,
         agent: item.agent.toJSON(),
       });

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -3782,6 +3782,55 @@ describe('Runner.run (streaming)', () => {
     });
   });
 
+  it('replaces session history from explicit compaction input when streaming fails', async () => {
+    const previousSessionItem = user('previous session');
+    const discardedInput = user('discarded input');
+    const retainedInput = user('retained input');
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_stream_input_failure',
+      encrypted_content: 'ciphertext',
+    };
+    const sessionItems: AgentInputItem[] = [previousSessionItem];
+    const session: Session = {
+      getSessionId: vi.fn().mockResolvedValue('compacted-stream-session'),
+      getItems: vi.fn(async () => structuredClone(sessionItems)),
+      addItems: vi.fn(async (items: AgentInputItem[]) => {
+        sessionItems.push(...structuredClone(items));
+      }),
+      popItem: vi.fn(async () => sessionItems.pop()),
+      clearSession: vi.fn(async () => {
+        sessionItems.splice(0);
+      }),
+    };
+    const streamError = new Error('model stream failed after compaction');
+    let capturedRequest: ModelRequest | undefined;
+    const model: Model = {
+      async getResponse(_request: ModelRequest): Promise<ModelResponse> {
+        throw streamError;
+      },
+      getStreamedResponse(request: ModelRequest): AsyncIterable<StreamEvent> {
+        capturedRequest = request;
+        return new RejectingStreamingModel(streamError).getStreamedResponse(
+          request,
+        );
+      },
+    };
+    const agent = new Agent({ name: 'StreamCompactedInputFailure', model });
+    const result = await new Runner().run(
+      agent,
+      [discardedInput, compaction, retainedInput],
+      { stream: true, session },
+    );
+
+    await expect(result.completed).rejects.toThrow(
+      'model stream failed after compaction',
+    );
+
+    expect(capturedRequest?.input).toEqual([compaction, retainedInput]);
+    expect(sessionItems).toEqual([compaction, retainedInput]);
+  });
+
   it('persists filtered streaming input instead of the raw turn payload', async () => {
     const saveInputSpy = vi
       .spyOn(sessionPersistence, 'saveStreamInputToSession')

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -358,6 +358,62 @@ describe('Runner.run (streaming)', () => {
     ).toBe(false);
   });
 
+  it('does not persist input for a malformed terminal compaction item', async () => {
+    class MalformedCompactionStreamingModel implements Model {
+      async getResponse(_request: ModelRequest): Promise<ModelResponse> {
+        throw new Error('Unexpected non-streaming model request');
+      }
+
+      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
+        yield {
+          type: 'response_done',
+          response: {
+            id: 'resp-malformed-compaction-stream',
+            usage: {
+              requests: 1,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            output: [
+              {
+                type: 'compaction',
+                id: 'cmp_malformed_stream',
+              },
+            ],
+          },
+        } as StreamEvent;
+      }
+    }
+
+    const addItems = vi.fn(async (_items: AgentInputItem[]) => {});
+    const clearSession = vi.fn(async () => {});
+    const replaceHistoryWithCompaction = vi.fn(
+      async (_items: AgentInputItem[]) => {},
+    );
+    const session: Session = {
+      getSessionId: vi.fn().mockResolvedValue('malformed-stream-session'),
+      getItems: vi.fn().mockResolvedValue([]),
+      addItems,
+      popItem: vi.fn().mockResolvedValue(undefined),
+      clearSession,
+      replaceHistoryWithCompaction,
+    };
+    const agent = new Agent({
+      name: 'MalformedStreamingCompactionAgent',
+      model: new MalformedCompactionStreamingModel(),
+    });
+
+    const result = await run(agent, 'hello', { stream: true, session });
+
+    await expect(result.completed).rejects.toThrow(
+      'Compaction item missing encrypted_content',
+    );
+    expect(addItems).not.toHaveBeenCalled();
+    expect(clearSession).not.toHaveBeenCalled();
+    expect(replaceHistoryWithCompaction).not.toHaveBeenCalled();
+  });
+
   it('treats prior tool_search outputs in input history as loaded deferred tools', async () => {
     class QueueStreamingModel implements Model {
       constructor(private readonly responses: ModelResponse[]) {}

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -295,7 +295,7 @@ describe('Runner.run (streaming)', () => {
     expect((result.error as Error).message).toBe('Not implemented');
   });
 
-  it('retains a streamed compaction item without a high-level run item event', async () => {
+  it('emits a high-level run item event for streamed compaction', async () => {
     const compaction: protocol.CompactionItem = {
       type: 'compaction',
       id: 'cmp_stream',
@@ -350,12 +350,19 @@ describe('Runner.run (streaming)', () => {
       events.some((event) => event.type === 'raw_model_stream_event'),
     ).toBe(true);
     expect(
-      events.some(
+      events.find(
         (event) =>
           event.type === 'run_item_stream_event' &&
-          event.item.type === 'compaction_item',
+          event.name === 'compaction_item_created',
       ),
-    ).toBe(false);
+    ).toMatchObject({
+      type: 'run_item_stream_event',
+      name: 'compaction_item_created',
+      item: {
+        type: 'compaction_item',
+        rawItem: compaction,
+      },
+    });
   });
 
   it('does not persist input for a malformed terminal compaction item', async () => {
@@ -403,12 +410,20 @@ describe('Runner.run (streaming)', () => {
       name: 'MalformedStreamingCompactionAgent',
       model: new MalformedCompactionStreamingModel(),
     });
+    const defaultErrorHandler = vi.fn(() => ({
+      finalOutput: 'not used',
+    }));
 
-    const result = await run(agent, 'hello', { stream: true, session });
+    const result = await run(agent, 'hello', {
+      stream: true,
+      session,
+      errorHandlers: { default: defaultErrorHandler },
+    });
 
     await expect(result.completed).rejects.toThrow(
       'Compaction item missing encrypted_content',
     );
+    expect(defaultErrorHandler).not.toHaveBeenCalled();
     expect(addItems).not.toHaveBeenCalled();
     expect(clearSession).not.toHaveBeenCalled();
     expect(replaceHistoryWithCompaction).not.toHaveBeenCalled();

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -295,6 +295,69 @@ describe('Runner.run (streaming)', () => {
     expect((result.error as Error).message).toBe('Not implemented');
   });
 
+  it('retains a streamed compaction item without a high-level run item event', async () => {
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_stream',
+      encrypted_content: 'ciphertext',
+    };
+
+    class CompactionStreamingModel implements Model {
+      async getResponse(_request: ModelRequest): Promise<ModelResponse> {
+        throw new Error('Unexpected non-streaming model request');
+      }
+
+      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
+        yield {
+          type: 'model',
+          event: { type: 'response.output_item.added', item: compaction },
+        } as StreamEvent;
+        yield {
+          type: 'response_done',
+          response: {
+            id: 'resp-compaction-stream',
+            usage: {
+              requests: 1,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            output: [compaction, fakeModelMessage('streamed done')],
+          },
+        } as StreamEvent;
+      }
+    }
+
+    const agent = new Agent({
+      name: 'StreamingCompactionAgent',
+      model: new CompactionStreamingModel(),
+    });
+    const result = await run(agent, 'hi', { stream: true });
+
+    const events: RunStreamEvent[] = [];
+    for await (const event of result) {
+      events.push(event);
+    }
+    await result.completed;
+
+    expect(result.finalOutput).toBe('streamed done');
+    expect(result.newItems.map((item) => item.type)).toEqual([
+      'compaction_item',
+      'message_output_item',
+    ]);
+    expect(result.history).toContainEqual(compaction);
+    expect(
+      events.some((event) => event.type === 'raw_model_stream_event'),
+    ).toBe(true);
+    expect(
+      events.some(
+        (event) =>
+          event.type === 'run_item_stream_event' &&
+          event.item.type === 'compaction_item',
+      ),
+    ).toBe(false);
+  });
+
   it('treats prior tool_search outputs in input history as loaded deferred tools', async () => {
     class QueueStreamingModel implements Model {
       constructor(private readonly responses: ModelResponse[]) {}

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -51,6 +51,7 @@ import {
   RunToolSearchCallItem,
   RunToolSearchOutputItem,
 } from '../src/items';
+import { MemorySession as CoreMemorySession } from '../src/memory/memorySession';
 import { getTurnInput, selectModel } from '../src/run';
 import { RunContext } from '../src/runContext';
 import { RunState } from '../src/runState';
@@ -8363,6 +8364,110 @@ describe('Runner.run', () => {
         type: 'function_call_result',
         callId: 'call-1',
       });
+    });
+  });
+
+  describe('inline compaction items', () => {
+    class RecordingModel extends FakeModel {
+      readonly requests: ModelRequest[] = [];
+
+      override async getResponse(
+        request: ModelRequest,
+      ): Promise<ModelResponse> {
+        this.requests.push(request);
+        return super.getResponse(request);
+      }
+    }
+
+    const COMPACTION_ITEM: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_inline',
+      encrypted_content: 'ciphertext',
+      created_by: 'compaction_endpoint',
+      providerData: { extra: 'value' },
+    };
+
+    it('replays a compaction marker in provider order on the next request', async () => {
+      const lookup = tool({
+        name: 'lookup',
+        description: 'Look something up.',
+        parameters: z.object({}),
+        execute: async () => 'tool result payload',
+      });
+      const model = new RecordingModel([
+        {
+          output: [
+            COMPACTION_ITEM,
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              name: 'lookup',
+              callId: 'call_lookup',
+              arguments: '{}',
+            },
+          ],
+          usage: new Usage(),
+        },
+        { output: [fakeModelMessage('done')], usage: new Usage() },
+      ]);
+      const agent = new Agent({
+        name: 'CompactionAgent',
+        model,
+        tools: [lookup],
+      });
+
+      const result = await run(agent, [user('identifiable old user input')]);
+
+      expect(result.finalOutput).toBe('done');
+      expect(model.requests).toHaveLength(2);
+      const secondInput = getRequestInputItems(model.requests[1]);
+      expect(secondInput).toHaveLength(4);
+      expect(getFirstTextContent(secondInput[0])).toBe(
+        'identifiable old user input',
+      );
+      expect(secondInput[1]).toEqual(COMPACTION_ITEM);
+      expect(secondInput[2]).toMatchObject({
+        type: 'function_call',
+        callId: 'call_lookup',
+      });
+      expect(secondInput[3]).toMatchObject({
+        type: 'function_call_result',
+        callId: 'call_lookup',
+      });
+      expect(result.output).toContainEqual(COMPACTION_ITEM);
+      expect(result.history).toContainEqual(COMPACTION_ITEM);
+    });
+
+    it('persists a compaction marker without rewriting ordinary session history', async () => {
+      const session = new CoreMemorySession({
+        initialItems: [user('earlier stored input')],
+      });
+      const clearSession = vi.spyOn(session, 'clearSession');
+      const model = new RecordingModel([
+        {
+          output: [COMPACTION_ITEM, fakeModelMessage('first turn done')],
+          usage: new Usage(),
+        },
+        { output: [fakeModelMessage('second turn done')], usage: new Usage() },
+      ]);
+      const agent = new Agent({
+        name: 'SessionCompactionAgent',
+        model,
+      });
+
+      await run(agent, 'new user input', { session });
+
+      expect(clearSession).not.toHaveBeenCalled();
+      const stored = await session.getItems();
+      expect(getFirstTextContent(stored[0])).toBe('earlier stored input');
+      expect(stored).toContainEqual(COMPACTION_ITEM);
+
+      await run(agent, 'later user input', { session });
+      const laterInput = getRequestInputItems(model.requests[1]);
+      expect(getFirstTextContent(laterInput[0])).toBe('earlier stored input');
+      expect(laterInput).toContainEqual(COMPACTION_ITEM);
+      expect(getFirstTextContent(laterInput[laterInput.length - 1])).toBe(
+        'later user input',
+      );
     });
   });
 

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -8420,24 +8420,26 @@ describe('Runner.run', () => {
       expect(result.finalOutput).toBe('done');
       expect(model.requests).toHaveLength(2);
       const secondInput = getRequestInputItems(model.requests[1]);
-      expect(secondInput).toHaveLength(4);
-      expect(getFirstTextContent(secondInput[0])).toBe(
-        'identifiable old user input',
-      );
-      expect(secondInput[1]).toEqual(COMPACTION_ITEM);
-      expect(secondInput[2]).toMatchObject({
+      expect(secondInput).toHaveLength(3);
+      expect(secondInput[0]).toEqual(COMPACTION_ITEM);
+      expect(secondInput[1]).toMatchObject({
         type: 'function_call',
         callId: 'call_lookup',
       });
-      expect(secondInput[3]).toMatchObject({
+      expect(secondInput[2]).toMatchObject({
         type: 'function_call_result',
         callId: 'call_lookup',
       });
+      expect(secondInput).not.toContainEqual(
+        expect.objectContaining({
+          content: 'identifiable old user input',
+        }),
+      );
       expect(result.output).toContainEqual(COMPACTION_ITEM);
-      expect(result.history).toContainEqual(COMPACTION_ITEM);
+      expect(result.history[0]).toEqual(COMPACTION_ITEM);
     });
 
-    it('persists a compaction marker without rewriting ordinary session history', async () => {
+    it('rewrites ordinary session history from the latest compaction marker', async () => {
       const session = new CoreMemorySession({
         initialItems: [user('earlier stored input')],
       });
@@ -8456,15 +8458,17 @@ describe('Runner.run', () => {
 
       await run(agent, 'new user input', { session });
 
-      expect(clearSession).not.toHaveBeenCalled();
+      expect(clearSession).toHaveBeenCalledOnce();
       const stored = await session.getItems();
-      expect(getFirstTextContent(stored[0])).toBe('earlier stored input');
-      expect(stored).toContainEqual(COMPACTION_ITEM);
+      expect(stored[0]).toEqual(COMPACTION_ITEM);
+      expect(stored).toHaveLength(2);
 
       await run(agent, 'later user input', { session });
       const laterInput = getRequestInputItems(model.requests[1]);
-      expect(getFirstTextContent(laterInput[0])).toBe('earlier stored input');
-      expect(laterInput).toContainEqual(COMPACTION_ITEM);
+      expect(laterInput[0]).toEqual(COMPACTION_ITEM);
+      expect(laterInput).not.toContainEqual(
+        expect.objectContaining({ content: 'earlier stored input' }),
+      );
       expect(getFirstTextContent(laterInput[laterInput.length - 1])).toBe(
         'later user input',
       );

--- a/packages/agents-core/test/run.utils.test.ts
+++ b/packages/agents-core/test/run.utils.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { getTurnInput } from '../src/run';
 import {
   RunMessageOutputItem as MessageOutputItem,
+  RunCompactionItem as CompactionItem,
   RunReasoningItem as ReasoningItem,
   RunToolCallItem,
+  RunToolCallOutputItem,
 } from '../src/items';
 import { Agent } from '../src/agent';
 import { TEST_MODEL_MESSAGE } from './stubs';
@@ -77,5 +79,66 @@ describe('getTurnInput', () => {
         content: 'hello',
       },
     ]);
+  });
+
+  it('keeps only items from the latest compaction marker', () => {
+    const agent = new Agent({ name: 'A' });
+    const earlierMessage = new MessageOutputItem(TEST_MODEL_MESSAGE, agent);
+    const compaction = {
+      type: 'compaction',
+      id: 'cmp_latest',
+      encrypted_content: 'ciphertext',
+    } satisfies protocol.CompactionItem;
+    const latestMessage = {
+      ...TEST_MODEL_MESSAGE,
+      id: 'msg_latest',
+    };
+
+    const result = getTurnInput('old input', [
+      earlierMessage,
+      new CompactionItem(compaction, agent),
+      new MessageOutputItem(latestMessage, agent),
+    ]);
+
+    expect(result).toEqual([compaction, latestMessage]);
+  });
+
+  it('drops orphan calls before considering pre-compaction results', () => {
+    const agent = new Agent({ name: 'A' });
+    const callId = 'call_reused_after_compaction';
+    const oldResult = new RunToolCallOutputItem(
+      {
+        type: 'function_call_result',
+        name: 'reused_tool',
+        callId,
+        output: 'old result',
+        status: 'completed',
+      },
+      agent,
+      'old result',
+    );
+    const compaction = {
+      type: 'compaction',
+      id: 'cmp_reused_call',
+      encrypted_content: 'ciphertext',
+    } satisfies protocol.CompactionItem;
+    const newCall = new RunToolCallItem(
+      {
+        type: 'function_call',
+        name: 'reused_tool',
+        callId,
+        arguments: '{}',
+        status: 'completed',
+      },
+      agent,
+    );
+
+    const result = getTurnInput('old input', [
+      oldResult,
+      new CompactionItem(compaction, agent),
+      newCall,
+    ]);
+
+    expect(result).toEqual([compaction]);
   });
 });

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   RunState,
   buildAgentMap,
@@ -10,7 +10,10 @@ import {
 import { processedResponseRequiresExecutionToolRehydration } from '../src/sandbox/runtime/toolRehydration';
 import { RunContext } from '../src/runContext';
 import { Agent } from '../src/agent';
+import { handoff } from '../src/handoff';
 import { Usage } from '../src/usage';
+import type { ModelResponse } from '../src/model';
+import { processModelResponseAsync } from '../src/runner/modelOutputs';
 import {
   RunToolApprovalItem as ToolApprovalItem,
   RunCompactionItem,
@@ -30,6 +33,7 @@ import {
   shellTool,
   tool,
   toolNamespace,
+  type Tool,
 } from '../src/tool';
 import * as protocol from '../src/types/protocol';
 import {
@@ -39,11 +43,12 @@ import {
   FakeEditor,
 } from './stubs';
 import { RunResult } from '../src/result';
+import { UserError } from '../src/errors';
+import logger from '../src/logger';
 import { createAgentSpan } from '../src/tracing';
 import { getGlobalTraceProvider } from '../src/tracing/provider';
 import type { MCPServer, MCPTool } from '../src/mcp';
 import { SANDBOX_SESSION_STATE_VERSION, SandboxAgent } from '../src/sandbox';
-import { z } from 'zod';
 import { prepareModelInputItems } from '../src/runner/items';
 import { processModelResponse } from '../src/runner/modelOutputs';
 import { MemorySession } from '../src/memory/memorySession';
@@ -51,6 +56,18 @@ import {
   prepareInputItemsWithSession,
   saveToSession,
 } from '../src/runner/sessionPersistence';
+import {
+  getFunctionToolStateKey,
+  getFunctionToolStateKeyForCall,
+} from '../src/toolIdentity';
+import { z, ZodError } from 'zod';
+import { allowConsole } from '../../../helpers/tests/console-guard';
+type AliasTestKeys = {
+  crmAlias: string;
+  crmCanonical: string;
+  salesAlias: string;
+  salesCanonical: string;
+};
 
 function sandboxSessionStateEnvelope(
   providerState: Record<string, unknown>,
@@ -446,6 +463,12 @@ describe('RunState', () => {
       JSON.stringify(serialized),
     );
     expect(restored._sandbox).toEqual(state._sandbox);
+
+    const restoredFromSchema115 = await RunState.fromString(
+      agent,
+      JSON.stringify({ ...serialized, $schemaVersion: '1.15' }),
+    );
+    expect(restoredFromSchema115._sandbox).toEqual(state._sandbox);
   });
 
   it('keeps reading schema 1.8 payloads without sandbox state', async () => {
@@ -785,6 +808,188 @@ describe('RunState', () => {
     const restored = await RunState.fromString(agent, state.toString());
     expect(restored.getPendingAgentToolRun('toolA', 'call-1')).toBe('state-A');
     expect(restored.getPendingAgentToolRun('toolB', 'call-1')).toBe('state-B');
+  });
+
+  it('keeps pending agent tool aliases on one canonical state entry', async () => {
+    const context = new RunContext();
+    const namespacedLookup = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup',
+          description: 'Look up a CRM record.',
+          parameters: z.object({}).strict(),
+          execute: async () => 'lookup',
+        }),
+      ],
+    })[0]!;
+    const agent = new Agent({
+      name: 'PendingAliasAgent',
+      tools: [namespacedLookup],
+    });
+    const state = new RunState(context, 'input', agent, 1);
+    const canonicalKey = getFunctionToolStateKey(namespacedLookup)!;
+    const toolCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc-pending-alias',
+      callId: 'call-1',
+      name: 'lookup',
+      namespace: 'crm',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall, tool: namespacedLookup as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['crm.lookup'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+
+    state.setPendingAgentToolRun(canonicalKey, 'call-1', 'initial-state', [
+      'crm.lookup',
+    ]);
+
+    expect(state._pendingAgentToolRuns.size).toBe(1);
+    expect(state.getPendingAgentToolRun('crm.lookup', 'call-1')).toBe(
+      'initial-state',
+    );
+
+    state.setPendingAgentToolRun('crm.lookup', 'call-1', 'updated-state');
+
+    expect(state._pendingAgentToolRuns.size).toBe(1);
+    expect(state.getPendingAgentToolRun(canonicalKey, 'call-1')).toBe(
+      'updated-state',
+    );
+
+    const restored = await RunState.fromString(agent, state.toString());
+    expect(restored._pendingAgentToolRuns.size).toBe(1);
+    expect(restored.getPendingAgentToolRun('crm.lookup', 'call-1')).toBe(
+      'updated-state',
+    );
+
+    restored.clearPendingAgentToolRun('crm.lookup', 'call-1');
+
+    expect(restored.hasPendingAgentToolRun(canonicalKey, 'call-1')).toBe(false);
+    expect(restored.hasPendingAgentToolRun('crm.lookup', 'call-1')).toBe(false);
+    expect(restored._pendingAgentToolRuns.size).toBe(0);
+    expect(restored._pendingAgentToolRunAliases.size).toBe(0);
+  });
+
+  it.each([
+    {
+      name: 'dangling target',
+      mutate: (aliases: Record<string, string>, keys: AliasTestKeys) => {
+        aliases[keys.crmAlias] = `${keys.crmCanonical}:missing-call`;
+      },
+    },
+    {
+      name: 'cross-call target',
+      mutate: (aliases: Record<string, string>, keys: AliasTestKeys) => {
+        aliases[keys.crmAlias] = `${keys.crmCanonical}:call-2`;
+      },
+    },
+    {
+      name: 'cross-tool target',
+      mutate: (aliases: Record<string, string>, keys: AliasTestKeys) => {
+        aliases[keys.crmAlias] = `${keys.salesCanonical}:call-3`;
+      },
+    },
+    {
+      name: 'alias chain',
+      mutate: (aliases: Record<string, string>, keys: AliasTestKeys) => {
+        aliases[keys.crmAlias] = keys.salesAlias;
+      },
+    },
+    {
+      name: 'alias cycle',
+      mutate: (aliases: Record<string, string>, keys: AliasTestKeys) => {
+        aliases[keys.crmAlias] = keys.salesAlias;
+        aliases[keys.salesAlias] = keys.crmAlias;
+      },
+    },
+  ])('rejects a pending agent tool alias with a $name', async ({ mutate }) => {
+    const [crmLookup, salesLookup] = ['crm', 'sales'].map(
+      (namespace) =>
+        toolNamespace({
+          name: namespace,
+          description: `${namespace} tools.`,
+          tools: [
+            tool({
+              name: 'lookup',
+              description: `Look up a ${namespace} record.`,
+              parameters: z.object({}).strict(),
+              execute: async () => namespace,
+            }),
+          ],
+        })[0]!,
+    );
+    const agent = new Agent({
+      name: 'Invalid pending alias agent',
+      tools: [crmLookup, salesLookup],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    const crmCanonical = getFunctionToolStateKey(crmLookup)!;
+    const salesCanonical = getFunctionToolStateKey(salesLookup)!;
+    const createToolCall = (
+      namespace: string,
+      callId: string,
+    ): protocol.FunctionCallItem => ({
+      type: 'function_call',
+      id: `fc-${namespace}-${callId}`,
+      callId,
+      name: 'lookup',
+      namespace,
+      status: 'completed',
+      arguments: '{}',
+    });
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [
+        { toolCall: createToolCall('crm', 'call-1'), tool: crmLookup as any },
+        { toolCall: createToolCall('crm', 'call-2'), tool: crmLookup as any },
+        {
+          toolCall: createToolCall('sales', 'call-3'),
+          tool: salesLookup as any,
+        },
+      ],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['crm.lookup', 'sales.lookup'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+    state.setPendingAgentToolRun(crmCanonical, 'call-1', 'crm-state', [
+      'crm.lookup',
+    ]);
+    state.setPendingAgentToolRun(crmCanonical, 'call-2', 'crm-state-2', [
+      'crm.lookup',
+    ]);
+    state.setPendingAgentToolRun(salesCanonical, 'call-3', 'sales-state', [
+      'sales.lookup',
+    ]);
+
+    const serialized = state.toJSON();
+    const aliases = serialized.pendingAgentToolRunAliases!;
+    mutate(aliases, {
+      crmAlias: 'crm.lookup:call-1',
+      crmCanonical,
+      salesAlias: 'sales.lookup:call-3',
+      salesCanonical,
+    });
+
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow(
+      'Run state pending agent tool aliases do not match the reconstructed pending function calls.',
+    );
   });
 
   it('toJSON and toString produce valid JSON', () => {
@@ -1174,6 +1379,90 @@ describe('RunState', () => {
       expect(restored._modelResponses[0]?.output[0]).toEqual(compactionItem);
     });
 
+    it('rejects current schema raw compaction without its run item wrapper', async () => {
+      const agent = new Agent({ name: 'IncompleteCompactionStateAgent' });
+      const serialized = stateWithCompaction(agent).toJSON() as any;
+      serialized.generatedItems = [];
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow('contains inconsistent compaction items');
+    });
+
+    it('round-trips a migrated legacy state with multiple raw compactions', async () => {
+      const agent = new Agent({ name: 'MultipleLegacyCompactionAgent' });
+      const earlierCompaction = {
+        ...compactionItem,
+        id: 'cmp_earlier',
+        encrypted_content: 'earlier-ciphertext',
+      };
+      const latestCompaction = {
+        ...compactionItem,
+        id: 'cmp_latest',
+        encrypted_content: 'latest-ciphertext',
+      };
+      const earlierMessage: protocol.AssistantMessageItem = {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'earlier output' }],
+      };
+      const latestMessage: protocol.AssistantMessageItem = {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'latest output' }],
+      };
+      const earlierResponse = {
+        usage: new Usage(),
+        output: [earlierCompaction, earlierMessage],
+        responseId: 'response-earlier-compaction',
+      };
+      const latestResponse = {
+        usage: new Usage(),
+        output: [latestCompaction, latestMessage],
+        responseId: 'response-latest-compaction',
+      };
+      const earlierItem = new RunMessageOutputItem(earlierMessage, agent);
+      const latestItem = new RunMessageOutputItem(latestMessage, agent);
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._modelResponses = [earlierResponse, latestResponse];
+      state._lastTurnResponse = latestResponse;
+      state._generatedItems = [earlierItem, latestItem];
+      state._lastProcessedResponse = {
+        newItems: [latestItem],
+        handoffs: [],
+        functions: [],
+        functionToolsNotFound: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: [],
+        hasToolsOrApprovalsToRun: () => false,
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      const migrated = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+      const roundTripped = await RunState.fromString(
+        agent,
+        migrated.toString(),
+      );
+
+      expect(roundTripped._generatedItems.map((item) => item.type)).toEqual([
+        'message_output_item',
+        'compaction_item',
+        'message_output_item',
+      ]);
+      expect(
+        (roundTripped._generatedItems[1] as RunCompactionItem).rawItem,
+      ).toEqual(latestCompaction);
+    });
+
     it.each(['1.0', '1.15'] as const)(
       'rehydrates raw compaction output from legacy schema %s',
       async (schemaVersion) => {
@@ -1192,6 +1481,274 @@ describe('RunState', () => {
         expect(restored._modelResponses[0]?.output[0]).toEqual(compactionItem);
       },
     );
+
+    it('anchors legacy compaction against a normalized namespaced function call', async () => {
+      const namespacedLookup = toolNamespace({
+        name: 'crm',
+        description: 'CRM tools.',
+        tools: [
+          tool({
+            name: 'lookup',
+            description: 'Look up a CRM record.',
+            parameters: z.object({}).strict(),
+            execute: async () => 'lookup',
+          }),
+        ],
+      })[0]!;
+      const agent = new Agent({
+        name: 'LegacyNamespacedCompactionAgent',
+        tools: [namespacedLookup],
+      });
+      const rawCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: 'crm.lookup',
+        callId: 'call_legacy_namespaced_compaction',
+        arguments: '{}',
+        status: 'completed',
+      };
+      const response = {
+        usage: new Usage(),
+        output: [rawCall, compactionItem],
+        responseId: 'response-legacy-namespaced-compaction',
+      };
+      const processed = processModelResponse(
+        response,
+        agent,
+        [namespacedLookup],
+        [],
+      );
+      const legacyItems = processed.newItems.filter(
+        (item) => !(item instanceof RunCompactionItem),
+      );
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._modelResponses = [response];
+      state._lastTurnResponse = response;
+      state._generatedItems = legacyItems;
+      state._lastProcessedResponse = { ...processed, newItems: legacyItems };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._generatedItems.map((item) => item.type)).toEqual([
+        'tool_call_item',
+        'compaction_item',
+      ]);
+      expect(restored._generatedItems[0]?.rawItem).toMatchObject({
+        name: 'lookup',
+        namespace: 'crm',
+      });
+    });
+
+    it('anchors historical legacy compaction against a normalized namespaced function call', async () => {
+      const namespacedLookup = toolNamespace({
+        name: 'crm',
+        description: 'CRM tools.',
+        tools: [
+          tool({
+            name: 'lookup',
+            description: 'Look up a CRM record.',
+            parameters: z.object({}).strict(),
+            execute: async () => 'lookup',
+          }),
+        ],
+      })[0]!;
+      const agent = new Agent({
+        name: 'HistoricalNamespacedCompactionAgent',
+        tools: [namespacedLookup],
+      });
+      const rawCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: 'crm.lookup',
+        callId: 'call_historical_namespaced_compaction',
+        arguments: '{}',
+        status: 'completed',
+      };
+      const laterMessage: protocol.AssistantMessageItem = {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'later response' }],
+      };
+      const earlierResponse = {
+        usage: new Usage(),
+        output: [rawCall, compactionItem],
+        responseId: 'response-historical-namespaced-compaction',
+      };
+      const laterResponse = {
+        usage: new Usage(),
+        output: [laterMessage],
+        responseId: 'response-after-namespaced-compaction',
+      };
+      const earlierProcessed = processModelResponse(
+        earlierResponse,
+        agent,
+        [namespacedLookup],
+        [],
+      );
+      const laterProcessed = processModelResponse(laterResponse, agent, [], []);
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._modelResponses = [earlierResponse, laterResponse];
+      state._lastTurnResponse = laterResponse;
+      state._generatedItems = [
+        ...earlierProcessed.newItems.filter(
+          (item) => !(item instanceof RunCompactionItem),
+        ),
+        ...laterProcessed.newItems,
+      ];
+      state._lastProcessedResponse = laterProcessed;
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._generatedItems.map((item) => item.type)).toEqual([
+        'tool_call_item',
+        'compaction_item',
+        'message_output_item',
+      ]);
+    });
+
+    it('ignores later handoffs that released writers omitted around legacy compaction', async () => {
+      const firstTarget = new Agent({ name: 'FirstLegacyHandoffTarget' });
+      const secondTarget = new Agent({ name: 'SecondLegacyHandoffTarget' });
+      const firstHandoff = handoff(firstTarget, {
+        toolNameOverride: 'transfer_first',
+      });
+      const secondHandoff = handoff(secondTarget, {
+        toolNameOverride: 'transfer_second',
+      });
+      const agent = new Agent({
+        name: 'MultipleLegacyHandoffCompactionAgent',
+        handoffs: [firstHandoff, secondHandoff],
+      });
+      const firstCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: firstHandoff.toolName,
+        callId: 'call_first_legacy_handoff',
+        arguments: '{}',
+        status: 'completed',
+      };
+      const secondCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: secondHandoff.toolName,
+        callId: 'call_second_legacy_handoff',
+        arguments: '{}',
+        status: 'completed',
+      };
+      const response = {
+        usage: new Usage(),
+        output: [firstCall, compactionItem, secondCall],
+        responseId: 'response-multiple-legacy-handoffs',
+      };
+      const processed = processModelResponse(
+        response,
+        agent,
+        [],
+        [firstHandoff, secondHandoff],
+      );
+      const legacyItems = processed.newItems.filter(
+        (item) => !(item instanceof RunCompactionItem),
+      );
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._modelResponses = [response];
+      state._lastTurnResponse = response;
+      state._generatedItems = legacyItems;
+      state._lastProcessedResponse = { ...processed, newItems: legacyItems };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._generatedItems.map((item) => item.type)).toEqual([
+        'handoff_call_item',
+        'compaction_item',
+      ]);
+    });
+
+    it('ignores later handoffs when anchoring historical legacy compaction', async () => {
+      const firstTarget = new Agent({ name: 'FirstHistoricalHandoffTarget' });
+      const secondTarget = new Agent({ name: 'SecondHistoricalHandoffTarget' });
+      const firstHandoff = handoff(firstTarget, {
+        toolNameOverride: 'transfer_historical_first',
+      });
+      const secondHandoff = handoff(secondTarget, {
+        toolNameOverride: 'transfer_historical_second',
+      });
+      const agent = new Agent({
+        name: 'HistoricalMultipleHandoffCompactionAgent',
+        handoffs: [firstHandoff, secondHandoff],
+      });
+      const firstCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: firstHandoff.toolName,
+        callId: 'call_historical_first_handoff',
+        arguments: '{}',
+        status: 'completed',
+      };
+      const secondCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: secondHandoff.toolName,
+        callId: 'call_historical_second_handoff',
+        arguments: '{}',
+        status: 'completed',
+      };
+      const laterMessage: protocol.AssistantMessageItem = {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'later response' }],
+      };
+      const earlierResponse = {
+        usage: new Usage(),
+        output: [firstCall, compactionItem, secondCall],
+        responseId: 'response-historical-multiple-handoffs',
+      };
+      const laterResponse = {
+        usage: new Usage(),
+        output: [laterMessage],
+        responseId: 'response-after-multiple-handoffs',
+      };
+      const earlierProcessed = processModelResponse(
+        earlierResponse,
+        agent,
+        [],
+        [firstHandoff, secondHandoff],
+      );
+      const laterProcessed = processModelResponse(laterResponse, agent, [], []);
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._modelResponses = [earlierResponse, laterResponse];
+      state._lastTurnResponse = laterResponse;
+      state._generatedItems = [
+        ...earlierProcessed.newItems.filter(
+          (item) => !(item instanceof RunCompactionItem),
+        ),
+        ...laterProcessed.newItems,
+      ];
+      state._lastProcessedResponse = laterProcessed;
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._generatedItems.map((item) => item.type)).toEqual([
+        'handoff_call_item',
+        'compaction_item',
+        'message_output_item',
+      ]);
+    });
 
     it('rehydrates a legacy interrupted response in provider order', async () => {
       const approvalTool = tool({
@@ -1314,9 +1871,7 @@ describe('RunState', () => {
         prepareModelInputItems(
           restored._originalInput,
           restored._generatedItems,
-        )
-          .slice(1)
-          .map((item) => item.type),
+        ).map((item) => item.type),
       ).toEqual(['compaction', 'function_call', 'function_call_result']);
 
       const roundTripped = await RunState.fromString(
@@ -1384,6 +1939,164 @@ describe('RunState', () => {
       ).toEqual(['compaction_item', 'message_output_item']);
     });
 
+    it('uses the latest response wrapper agent for legacy compaction', async () => {
+      const sourceAgent = new Agent({ name: 'CompactionSourceAgent' });
+      const targetAgent = new Agent({
+        name: 'CompactionTargetAgent',
+        handoffs: [sourceAgent],
+      });
+      const message: protocol.AssistantMessageItem = {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'source output' }],
+      };
+      const response = {
+        usage: new Usage(),
+        output: [compactionItem, message],
+        responseId: 'response-with-source-agent-compaction',
+      };
+      const messageItem = new RunMessageOutputItem(message, sourceAgent);
+      const state = new RunState(new RunContext(), 'input', sourceAgent, 2);
+      state._currentAgent = targetAgent;
+      state._modelResponses = [response];
+      state._lastTurnResponse = response;
+      state._generatedItems = [messageItem];
+      state._lastProcessedResponse = {
+        newItems: [messageItem],
+        handoffs: [],
+        functions: [],
+        functionToolsNotFound: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: [],
+        hasToolsOrApprovalsToRun: () => false,
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      const restored = await RunState.fromString(
+        targetAgent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._generatedItems[0]).toBeInstanceOf(RunCompactionItem);
+      expect((restored._generatedItems[0] as RunCompactionItem).agent).toBe(
+        sourceAgent,
+      );
+      expect((restored._generatedItems[1] as RunMessageOutputItem).agent).toBe(
+        sourceAgent,
+      );
+    });
+
+    it('rehydrates the latest compaction from an earlier model response', async () => {
+      const automaticTool = tool({
+        name: 'automatic_legacy_tool',
+        description: 'Automatically executed tool.',
+        parameters: z.object({}),
+        execute: async () => 'automatic result',
+      });
+      const approvalTool = tool({
+        name: 'approval_legacy_tool',
+        description: 'Tool requiring approval.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'approved result',
+      });
+      const agent = new Agent({
+        name: 'HistoricalLegacyCompactionAgent',
+        tools: [automaticTool, approvalTool],
+      });
+      const automaticCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: automaticTool.name,
+        callId: 'call_automatic_legacy_compaction',
+        arguments: '{}',
+        status: 'completed',
+      };
+      const approvalCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: approvalTool.name,
+        callId: 'call_approval_after_compaction',
+        arguments: '{}',
+        status: 'completed',
+      };
+      const earlierResponse = {
+        usage: new Usage(),
+        output: [compactionItem, automaticCall],
+        responseId: 'response-with-earlier-compaction',
+      };
+      const latestResponse = {
+        usage: new Usage(),
+        output: [approvalCall],
+        responseId: 'response-with-later-approval',
+      };
+      const earlierProcessed = processModelResponse(
+        earlierResponse,
+        agent,
+        [automaticTool, approvalTool],
+        [],
+      );
+      const approvalCallItem = new RunToolCallItem(approvalCall, agent);
+      const approvalItem = new ToolApprovalItem(approvalCall, agent);
+      const latestProcessed = {
+        newItems: [approvalCallItem, approvalItem],
+        handoffs: [],
+        functions: [{ toolCall: approvalCall, tool: approvalTool as any }],
+        functionToolsNotFound: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: [approvalTool.name],
+        hasToolsOrApprovalsToRun: () => true,
+      };
+      const automaticResult: protocol.FunctionCallResultItem = {
+        type: 'function_call_result',
+        name: automaticTool.name,
+        callId: automaticCall.callId,
+        output: 'automatic result',
+        status: 'completed',
+      };
+      const state = new RunState(new RunContext(), 'old input', agent, 2);
+      state._modelResponses = [earlierResponse, latestResponse];
+      state._lastTurnResponse = latestResponse;
+      state._generatedItems = [
+        ...earlierProcessed.newItems.filter(
+          (item) => !(item instanceof RunCompactionItem),
+        ),
+        new RunToolCallOutputItem(automaticResult, agent, 'automatic result'),
+        ...latestProcessed.newItems,
+      ];
+      state._lastProcessedResponse = latestProcessed;
+      state._currentStep = {
+        type: 'next_step_interruption',
+        data: { interruptions: [approvalItem] },
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._generatedItems.map((item) => item.type)).toEqual([
+        'compaction_item',
+        'tool_call_item',
+        'tool_call_output_item',
+        'tool_call_item',
+        'tool_approval_item',
+      ]);
+      expect(
+        restored._lastProcessedResponse?.newItems.map((item) => item.type),
+      ).toEqual(['tool_call_item', 'tool_approval_item']);
+      expect(restored.history[0]).toEqual(compactionItem);
+      expect(restored.getInterruptions()).toHaveLength(1);
+    });
+
     it('ignores dropped unknown output when anchoring legacy compaction', async () => {
       const agent = new Agent({ name: 'UnknownLegacyCompactionAgent' });
       const unknownItem: protocol.UnknownItem = {
@@ -1433,6 +2146,246 @@ describe('RunState', () => {
       expect(
         restored._lastProcessedResponse?.newItems.map((item) => item.type),
       ).toEqual(['compaction_item', 'message_output_item']);
+    });
+
+    it('ignores dropped function results when anchoring legacy compaction', async () => {
+      const agent = new Agent({ name: 'DroppedResultCompactionAgent' });
+      const functionResult: protocol.FunctionCallResultItem = {
+        type: 'function_call_result',
+        name: 'completed_tool',
+        callId: 'call_completed_before_compaction',
+        output: 'completed',
+        status: 'completed',
+      };
+      const message: protocol.AssistantMessageItem = {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'retained output' }],
+      };
+      const response = {
+        usage: new Usage(),
+        output: [functionResult, compactionItem, message],
+        responseId: 'response-dropped-result-with-compaction',
+      };
+      const messageItem = new RunMessageOutputItem(message, agent);
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._modelResponses = [response];
+      state._lastTurnResponse = response;
+      state._generatedItems = [messageItem];
+      state._lastProcessedResponse = {
+        newItems: [messageItem],
+        handoffs: [],
+        functions: [],
+        functionToolsNotFound: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: [],
+        hasToolsOrApprovalsToRun: () => false,
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._generatedItems.map((item) => item.type)).toEqual([
+        'compaction_item',
+        'message_output_item',
+      ]);
+      expect(
+        restored._lastProcessedResponse?.newItems.map((item) => item.type),
+      ).toEqual(['compaction_item', 'message_output_item']);
+    });
+
+    it('ignores synthesized tool search output when anchoring latest compaction', async () => {
+      const agent = new Agent({ name: 'LatestToolSearchCompactionAgent' });
+      const toolSearchCall = {
+        type: 'tool_search_call',
+        id: 'ts_call_latest_compaction',
+        callId: 'ts_call_latest_compaction',
+        status: 'completed',
+        arguments: { query: 'latest tools' },
+      } as const;
+      const synthesizedOutput = {
+        type: 'tool_search_output',
+        id: 'ts_output_latest_compaction',
+        callId: toolSearchCall.callId,
+        status: 'completed',
+        tools: [],
+      } as const;
+      const response = {
+        usage: new Usage(),
+        output: [compactionItem, toolSearchCall],
+        responseId: 'response-latest-tool-search-compaction',
+      };
+      const callItem = new RunToolSearchCallItem(toolSearchCall as any, agent);
+      const outputItem = new RunToolSearchOutputItem(
+        synthesizedOutput as any,
+        agent,
+      );
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._modelResponses = [response as any];
+      state._lastTurnResponse = response as any;
+      state._generatedItems = [callItem, outputItem];
+      state._lastProcessedResponse = {
+        newItems: [callItem, outputItem],
+        handoffs: [],
+        functions: [],
+        functionToolsNotFound: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: ['tool_search'],
+        hasToolsOrApprovalsToRun: () => false,
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._generatedItems.map((item) => item.type)).toEqual([
+        'compaction_item',
+        'tool_search_call_item',
+        'tool_search_output_item',
+      ]);
+    });
+
+    it('ignores synthesized tool search output when anchoring historical compaction', async () => {
+      const agent = new Agent({ name: 'HistoricalToolSearchCompactionAgent' });
+      const toolSearchCall = {
+        type: 'tool_search_call',
+        id: 'ts_call_historical_compaction',
+        callId: 'ts_call_historical_compaction',
+        status: 'completed',
+        arguments: { query: 'historical tools' },
+      } as const;
+      const synthesizedOutput = {
+        type: 'tool_search_output',
+        id: 'ts_output_historical_compaction',
+        callId: toolSearchCall.callId,
+        status: 'completed',
+        tools: [],
+      } as const;
+      const anchoredMessage: protocol.AssistantMessageItem = {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'anchored output' }],
+      };
+      const laterMessage: protocol.AssistantMessageItem = {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'later output' }],
+      };
+      const compactionResponse = {
+        usage: new Usage(),
+        output: [toolSearchCall, compactionItem, anchoredMessage],
+        responseId: 'response-historical-tool-search-compaction',
+      };
+      const laterResponse = {
+        usage: new Usage(),
+        output: [laterMessage],
+        responseId: 'response-after-tool-search-compaction',
+      };
+      const callItem = new RunToolSearchCallItem(toolSearchCall as any, agent);
+      const outputItem = new RunToolSearchOutputItem(
+        synthesizedOutput as any,
+        agent,
+      );
+      const anchoredItem = new RunMessageOutputItem(anchoredMessage, agent);
+      const laterItem = new RunMessageOutputItem(laterMessage, agent);
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._modelResponses = [compactionResponse as any, laterResponse];
+      state._lastTurnResponse = laterResponse;
+      state._generatedItems = [callItem, outputItem, anchoredItem, laterItem];
+      state._lastProcessedResponse = {
+        newItems: [laterItem],
+        handoffs: [],
+        functions: [],
+        functionToolsNotFound: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: [],
+        hasToolsOrApprovalsToRun: () => false,
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._generatedItems.map((item) => item.type)).toEqual([
+        'tool_search_call_item',
+        'tool_search_output_item',
+        'compaction_item',
+        'message_output_item',
+        'message_output_item',
+      ]);
+    });
+
+    it('anchors a compaction-only response after an empty processed segment', async () => {
+      const agent = new Agent({ name: 'EmptyLegacyCompactionSegmentAgent' });
+      const earlierMessage: protocol.AssistantMessageItem = {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'earlier output' }],
+      };
+      const unknownItem: protocol.UnknownItem = {
+        type: 'unknown',
+        providerData: { type: 'future_output' },
+      };
+      const response = {
+        usage: new Usage(),
+        output: [unknownItem, compactionItem],
+        responseId: 'response-empty-compaction-segment',
+      };
+      const earlierItem = new RunMessageOutputItem(earlierMessage, agent);
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._modelResponses = [response];
+      state._lastTurnResponse = response;
+      state._generatedItems = [earlierItem];
+      state._lastProcessedResponse = {
+        newItems: [],
+        handoffs: [],
+        functions: [],
+        functionToolsNotFound: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: [],
+        hasToolsOrApprovalsToRun: () => false,
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._generatedItems.map((item) => item.type)).toEqual([
+        'message_output_item',
+        'compaction_item',
+      ]);
+      expect(
+        restored._lastProcessedResponse?.newItems.map((item) => item.type),
+      ).toEqual(['compaction_item']);
     });
 
     it('keeps trailing legacy compaction after a function approval wrapper', async () => {
@@ -1508,7 +2461,6 @@ describe('RunState', () => {
         runCompaction: false,
       });
       expect((await session.getItems()).map((item) => item.type)).toEqual([
-        'function_call',
         'compaction',
       ]);
     });
@@ -1680,7 +2632,6 @@ describe('RunState', () => {
         runCompaction: false,
       });
       expect((await session.getItems()).map((item) => item.type)).toEqual([
-        'hosted_tool_call',
         'compaction',
       ]);
     });
@@ -2208,6 +3159,988 @@ describe('RunState', () => {
     );
   });
 
+  it('reads schema 1.15 approval keys and emits category-aware schema 1.16 state', async () => {
+    const context = new RunContext();
+    const agent = new Agent({ name: 'ApprovalKeyMigrationAgent' });
+    const state = new RunState(context, 'input', agent, 2);
+    const rawItem: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'lookup',
+      callId: 'legacy-call',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state.reject(new ToolApprovalItem(rawItem, agent));
+
+    const serialized = state.toJSON() as any;
+    const categoryKey = getFunctionToolStateKeyForCall(rawItem)!;
+    const ownerApprovals = serialized.context.functionApprovals.find(
+      (entry: any) => entry.agentIdentity === agent.name,
+    ).approvals;
+    serialized.$schemaVersion = '1.15';
+    serialized.context.approvals.lookup = ownerApprovals[categoryKey];
+    delete serialized.context.functionApprovals;
+    delete serialized.context.legacyFunctionApprovals;
+
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+
+    expect(
+      restored._context.isToolApproved({
+        toolName: 'lookup',
+        callId: 'legacy-call',
+      }),
+    ).toBe(false);
+    expect(restored.toJSON().$schemaVersion).toBe('1.16');
+  });
+
+  it('rehydrates schema 1.15 approval identity from enabled prepared tools', async () => {
+    const enabledLookup = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup',
+          description: 'Look up a CRM record.',
+          parameters: z.object({}),
+          execute: async () => 'enabled',
+        }),
+      ],
+    })[0]!;
+    const disabledLookup = toolNamespace({
+      name: 'crm',
+      description: 'Disabled CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup',
+          description: 'Disabled duplicate.',
+          parameters: z.object({}),
+          isEnabled: false,
+          execute: async () => 'disabled',
+        }),
+      ],
+    })[0]!;
+    const agent = new Agent({
+      name: 'LegacyApprovalAgent',
+      tools: [enabledLookup, disabledLookup],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const rawItem: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'lookup',
+      namespace: 'crm',
+      callId: 'legacy-approval-call',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall: rawItem, tool: enabledLookup as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['crm.lookup'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: {
+        interruptions: [new ToolApprovalItem(rawItem, agent)],
+      },
+    };
+
+    const serialized = state.toJSON() as any;
+    serialized.$schemaVersion = '1.15';
+    delete serialized.currentStep.data.interruptions[0].functionToolStateKey;
+
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+    const [approvalItem] = restored.getInterruptions();
+
+    expect(approvalItem.functionToolStateKey).toBe(
+      getFunctionToolStateKey(enabledLookup),
+    );
+    restored.approve(approvalItem);
+    expect(
+      restored._context.isToolApproved({
+        toolName: getFunctionToolStateKey(enabledLookup)!,
+        callId: rawItem.callId,
+      }),
+    ).toBe(true);
+  });
+
+  it.each(['namespaced', 'dotted'] as const)(
+    'migrates schema 1.15 pending nested state for the exact %s tool category',
+    async (pendingCategory) => {
+      const dottedLookup = tool({
+        name: 'crm_lookup',
+        description: 'Look up a dotted CRM record.',
+        parameters: z.object({}),
+        execute: async () => 'dotted',
+      });
+      dottedLookup.name = 'crm.lookup';
+      const namespacedLookup = toolNamespace({
+        name: 'crm',
+        description: 'CRM tools.',
+        tools: [
+          tool({
+            name: 'lookup',
+            description: 'Look up a namespaced CRM record.',
+            parameters: z.object({}),
+            execute: async () => 'namespaced',
+          }),
+        ],
+      })[0]!;
+      const pendingTool =
+        pendingCategory === 'namespaced' ? namespacedLookup : dottedLookup;
+      const toolCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: pendingCategory === 'namespaced' ? 'lookup' : 'crm.lookup',
+        ...(pendingCategory === 'namespaced' ? { namespace: 'crm' } : {}),
+        callId: `legacy-${pendingCategory}-call`,
+        status: 'completed',
+        arguments: '{}',
+      };
+      const agent = new Agent({
+        name: `LegacyPending${pendingCategory}`,
+        tools: [dottedLookup, namespacedLookup],
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._lastProcessedResponse = {
+        newItems: [],
+        functions: [{ toolCall, tool: pendingTool as any }],
+        handoffs: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: ['crm.lookup'],
+        hasToolsOrApprovalsToRun: () => true,
+      };
+      state.setPendingAgentToolRun(
+        'crm.lookup',
+        toolCall.callId,
+        `${pendingCategory}-state`,
+      );
+
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+      delete serialized.pendingAgentToolRunAliases;
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+      const canonicalKey = getFunctionToolStateKey(pendingTool)!;
+
+      expect(
+        restored.getPendingAgentToolRun(canonicalKey, toolCall.callId),
+      ).toBe(`${pendingCategory}-state`);
+      expect(
+        restored.getPendingAgentToolRun('crm.lookup', toolCall.callId),
+      ).toBe(`${pendingCategory}-state`);
+      expect(restored._pendingAgentToolRuns.size).toBe(1);
+    },
+  );
+
+  it('migrates pending schema 1.15 approvals while preserving ambiguous permanent owners', async () => {
+    const decisions = [
+      {
+        name: 'approved call',
+        record: (callId: string) => ({
+          approved: [callId],
+          rejected: [],
+        }),
+        expected: true,
+      },
+      {
+        name: 'rejected call',
+        record: (callId: string) => ({
+          approved: [],
+          rejected: [callId],
+          messages: { [callId]: 'Rejected once' },
+        }),
+        expected: false,
+        message: 'Rejected once',
+      },
+      {
+        name: 'permanent approval',
+        record: () => ({ approved: true, rejected: [] }),
+        expected: true,
+      },
+      {
+        name: 'permanent rejection',
+        record: (callId: string) => ({
+          approved: false,
+          rejected: true,
+          messages: { [callId]: 'Always rejected' },
+          stickyRejectMessage: 'Always rejected',
+        }),
+        expected: false,
+        message: 'Always rejected',
+      },
+    ];
+
+    for (const pair of ['bare-deferred', 'dotted-namespaced'] as const) {
+      for (const decision of decisions) {
+        const bareTool = tool({
+          name: pair === 'bare-deferred' ? 'lookup' : 'crm_lookup',
+          description: 'Bare lookup.',
+          parameters: z.object({}),
+          execute: async () => 'bare',
+        });
+        if (pair === 'dotted-namespaced') {
+          bareTool.name = 'crm.lookup';
+        }
+        const structuredTool =
+          pair === 'bare-deferred'
+            ? tool({
+                name: 'lookup',
+                description: 'Deferred lookup.',
+                parameters: z.object({}),
+                deferLoading: true,
+                execute: async () => 'deferred',
+              })
+            : toolNamespace({
+                name: 'crm',
+                description: 'CRM tools.',
+                tools: [
+                  tool({
+                    name: 'lookup',
+                    description: 'Namespaced lookup.',
+                    parameters: z.object({}),
+                    execute: async () => 'namespaced',
+                  }),
+                ],
+              })[0]!;
+        const callId = `${pair}-${decision.name.replace(/ /g, '-')}`;
+        const toolCall: protocol.FunctionCallItem = {
+          type: 'function_call',
+          name: 'lookup',
+          namespace: pair === 'bare-deferred' ? 'lookup' : 'crm',
+          callId,
+          status: 'completed',
+          arguments: '{}',
+        };
+        const legacyKey = pair === 'bare-deferred' ? 'lookup' : 'crm.lookup';
+        const agent = new Agent({
+          name: `LegacyApproval-${pair}-${decision.name}`,
+          tools: [bareTool, structuredTool],
+        });
+        const state = new RunState(new RunContext(), 'input', agent, 2);
+        state._lastProcessedResponse = {
+          newItems: [],
+          functions: [{ toolCall, tool: structuredTool as any }],
+          handoffs: [],
+          computerActions: [],
+          shellActions: [],
+          applyPatchActions: [],
+          mcpApprovalRequests: [],
+          toolsUsed: [legacyKey],
+          hasToolsOrApprovalsToRun: () => true,
+        };
+        state._currentStep = {
+          type: 'next_step_interruption',
+          data: {
+            interruptions: [new ToolApprovalItem(toolCall, agent)],
+          },
+        };
+
+        const serialized = state.toJSON() as any;
+        serialized.$schemaVersion = '1.15';
+        serialized.context.approvals = {
+          [legacyKey]: decision.record(callId),
+        };
+        delete serialized.currentStep.data.interruptions[0]
+          .functionToolStateKey;
+
+        const restored = await RunState.fromString(
+          agent,
+          JSON.stringify(serialized),
+        );
+        const canonicalKey = getFunctionToolStateKey(structuredTool)!;
+        const isPermanent = decision.name.startsWith('permanent');
+
+        expect(
+          restored._context.isToolApproved({
+            toolName: canonicalKey,
+            callId,
+          }),
+          `${pair}: ${decision.name}`,
+        ).toBe(decision.expected);
+        expect(
+          restored._context.getRejectionMessage(canonicalKey, callId),
+        ).toBe(decision.message);
+        expect(
+          restored._context.isToolApproved({
+            toolName: canonicalKey,
+            callId: `${callId}-future`,
+          }),
+        ).toBe(isPermanent ? decision.expected : undefined);
+        expect(
+          restored._context.isToolApproved({
+            toolName: legacyKey,
+            callId,
+          }),
+          `${pair}: ${decision.name} legacy owner`,
+        ).toBe(isPermanent ? decision.expected : undefined);
+        expect(
+          restored._context.isToolApproved({
+            toolName: legacyKey,
+            callId: `${callId}-future`,
+          }),
+          `${pair}: ${decision.name} future legacy owner`,
+        ).toBe(isPermanent ? decision.expected : undefined);
+      }
+    }
+  });
+
+  it.each([
+    ['permanent approval', { approved: true, rejected: [] }, true, undefined],
+    [
+      'permanent rejection',
+      {
+        approved: false,
+        rejected: true,
+        stickyRejectMessage: 'Always rejected',
+      },
+      false,
+      'Always rejected',
+    ],
+  ] as const)(
+    'migrates a schema 1.15 %s when the legacy function owner is unique',
+    async (_name, approvalRecord, expectedApproval, expectedMessage) => {
+      const namespacedLookup = toolNamespace({
+        name: 'crm',
+        description: 'CRM tools.',
+        tools: [
+          tool({
+            name: 'lookup',
+            description: 'Namespaced lookup.',
+            parameters: z.object({}),
+            execute: async () => 'namespaced',
+          }),
+        ],
+      })[0]!;
+      const callId = 'unique-owner-call';
+      const toolCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: 'lookup',
+        namespace: 'crm',
+        callId,
+        status: 'completed',
+        arguments: '{}',
+      };
+      const agent = new Agent({
+        name: 'UniqueLegacyApprovalOwner',
+        tools: [namespacedLookup],
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._lastProcessedResponse = {
+        newItems: [],
+        functions: [{ toolCall, tool: namespacedLookup as any }],
+        handoffs: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: ['crm.lookup'],
+        hasToolsOrApprovalsToRun: () => true,
+      };
+
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+      serialized.context.approvals = {
+        'crm.lookup': approvalRecord,
+      };
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+      const canonicalKey = getFunctionToolStateKey(namespacedLookup)!;
+
+      expect(
+        restored._context.isToolApproved({
+          toolName: canonicalKey,
+          callId,
+        }),
+      ).toBe(expectedApproval);
+      expect(restored._context.getRejectionMessage(canonicalKey, callId)).toBe(
+        expectedMessage,
+      );
+      expect(
+        restored._context.isToolApproved({
+          toolName: 'crm.lookup',
+          callId,
+        }),
+      ).toBeUndefined();
+      const publicApproval = restored._context.toJSON().approvals['crm.lookup'];
+      expect(publicApproval).toBeDefined();
+      expect(publicApproval.approved === true).toBe(
+        approvalRecord.approved === true,
+      );
+      expect(publicApproval.rejected === true).toBe(
+        approvalRecord.rejected === true,
+      );
+      expect(
+        restored._context.toJSON().approvals[canonicalKey],
+      ).toBeUndefined();
+
+      const durable = restored.toJSON() as any;
+      expect(durable.context.approvals['crm.lookup']).toBeUndefined();
+      const durableApproval = durable.context.functionApprovals.find(
+        (entry: any) => entry.agentIdentity === agent.name,
+      ).approvals[canonicalKey];
+      expect(durableApproval.approved === true).toBe(
+        approvalRecord.approved === true,
+      );
+      expect(durableApproval.rejected === true).toBe(
+        approvalRecord.rejected === true,
+      );
+    },
+  );
+
+  it('migrates a unique schema 1.15 permanent owner without a current call', async () => {
+    const namespacedLookup = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup',
+          description: 'Namespaced lookup.',
+          parameters: z.object({}),
+          execute: async () => 'namespaced',
+        }),
+      ],
+    })[0]!;
+    const agent = new Agent({
+      name: 'Unique inactive legacy approval owner',
+      tools: [namespacedLookup],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+
+    const serialized = state.toJSON() as any;
+    serialized.$schemaVersion = '1.15';
+    serialized.context.approvals = {
+      'crm.lookup': { approved: true, rejected: [] },
+    };
+
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+    const canonicalKey = getFunctionToolStateKey(namespacedLookup)!;
+
+    expect(
+      restored._context.isToolApproved({
+        toolName: canonicalKey,
+        callId: 'future_call',
+      }),
+    ).toBe(true);
+    expect(
+      restored._context.isToolApproved({
+        toolName: 'crm.lookup',
+        callId: 'future_call',
+      }),
+    ).toBeUndefined();
+    const durable = restored.toJSON() as any;
+    expect(durable.context.approvals['crm.lookup']).toBeUndefined();
+    expect(durable.context.legacyFunctionApprovals).toBeUndefined();
+    expect(
+      durable.context.functionApprovals[0].approvals[canonicalKey],
+    ).toMatchObject({ approved: true, rejected: [] });
+  });
+
+  it('migrates a unique schema 1.15 approval owned by an inactive child agent', async () => {
+    const childLookup = toolNamespace({
+      name: 'crm',
+      description: 'Child CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup',
+          description: 'Child namespaced lookup.',
+          parameters: z.object({}),
+          execute: async () => 'child',
+        }),
+      ],
+    })[0]!;
+    const childAgent = new Agent({
+      name: 'Inactive legacy approval child',
+      tools: [childLookup],
+    });
+    const rootAgent = new Agent({
+      name: 'Inactive legacy approval root',
+      tools: [
+        childAgent.asTool({
+          toolName: 'run_child',
+          toolDescription: 'Runs the child agent.',
+        }),
+      ],
+    });
+    const state = new RunState(new RunContext(), 'input', rootAgent, 2);
+    const serialized = state.toJSON() as any;
+    serialized.$schemaVersion = '1.15';
+    serialized.context.approvals = {
+      'crm.lookup': { approved: true, rejected: [] },
+    };
+
+    const restored = await RunState.fromString(
+      rootAgent,
+      JSON.stringify(serialized),
+    );
+    const canonicalKey = getFunctionToolStateKey(childLookup)!;
+
+    expect(
+      restored._context.isToolApproved({
+        toolName: canonicalKey,
+        callId: 'future_child_call',
+        functionTool: false,
+        agent: childAgent,
+      }),
+    ).toBe(true);
+    const durable = restored.toJSON() as any;
+    expect(durable.context.approvals['crm.lookup']).toBeUndefined();
+    expect(durable.context.legacyFunctionApprovals).toBeUndefined();
+    expect(
+      durable.context.functionApprovals.find(
+        (entry: any) => entry.agentIdentity === childAgent.name,
+      ).approvals[canonicalKey],
+    ).toMatchObject({ approved: true, rejected: [] });
+  });
+
+  it('keeps an exact non-function override separate from an inactive schema 1.15 function owner', async () => {
+    const namespacedLookup = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup',
+          description: 'Namespaced lookup.',
+          parameters: z.object({}),
+          execute: async () => 'namespaced',
+        }),
+      ],
+    })[0]!;
+    const otherTool = tool({
+      name: 'other_tool',
+      description: 'Other tool.',
+      parameters: z.object({}),
+      execute: async () => 'other',
+    });
+    const otherCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'other_tool',
+      callId: 'merge_other_call',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const agent = new Agent({
+      name: 'Inactive merge approval owner',
+      tools: [namespacedLookup, otherTool],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [
+        {
+          toolCall: otherCall,
+          tool: otherTool as any,
+          availableFunctionTools: [namespacedLookup, otherTool] as any,
+        },
+      ],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['other_tool'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+    const serialized = state.toJSON() as any;
+    serialized.$schemaVersion = '1.15';
+    serialized.context.approvals = {
+      'crm.lookup': { approved: true, rejected: [] },
+    };
+    const overrideContext = new RunContext();
+    overrideContext.rejectTool(
+      new ToolApprovalItem(
+        {
+          type: 'shell_call',
+          callId: 'shell_crm_lookup',
+          status: 'completed',
+          action: { commands: ['echo rejected'] },
+        },
+        agent,
+        'crm.lookup',
+      ),
+      { alwaysReject: true },
+    );
+
+    const restored = await RunState.fromStringWithContext(
+      agent,
+      JSON.stringify(serialized),
+      overrideContext,
+      { contextStrategy: 'merge' },
+    );
+    const canonicalKey = getFunctionToolStateKey(namespacedLookup)!;
+
+    expect(
+      restored._context.isToolApproved({
+        toolName: canonicalKey,
+        callId: 'future_function_call',
+      }),
+    ).toBe(true);
+    expect(
+      restored._context.isToolApproved({
+        toolName: 'crm.lookup',
+        callId: 'future_shell_call',
+        functionTool: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps ambiguous legacy function fallback separate from an exact non-function override', async () => {
+    const dottedLookup = tool({
+      name: 'crm_lookup',
+      description: 'Dotted lookup.',
+      parameters: z.object({}),
+      execute: async () => 'dotted',
+    });
+    dottedLookup.name = 'crm.lookup';
+    const namespacedLookup = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup',
+          description: 'Namespaced lookup.',
+          parameters: z.object({}),
+          execute: async () => 'namespaced',
+        }),
+      ],
+    })[0]!;
+    const callId = 'ambiguous_merge_call';
+    const toolCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'lookup',
+      namespace: 'crm',
+      callId,
+      status: 'completed',
+      arguments: '{}',
+    };
+    const agent = new Agent({
+      name: 'Ambiguous legacy fallback merge',
+      tools: [dottedLookup, namespacedLookup],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall, tool: namespacedLookup as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['crm.lookup'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+    const serialized = state.toJSON() as any;
+    serialized.$schemaVersion = '1.15';
+    serialized.context.approvals = {
+      'crm.lookup': {
+        approved: false,
+        rejected: true,
+        stickyRejectMessage: 'Legacy rejection',
+      },
+    };
+
+    const overrideContext = new RunContext();
+    overrideContext.approveTool(
+      new ToolApprovalItem(
+        {
+          type: 'shell_call',
+          callId: 'shell_override_call',
+          status: 'completed',
+          action: { commands: ['echo approved'] },
+        },
+        agent,
+        'crm.lookup',
+      ),
+      { alwaysApprove: true },
+    );
+
+    const restored = await RunState.fromStringWithContext(
+      agent,
+      JSON.stringify(serialized),
+      overrideContext,
+      { contextStrategy: 'merge' },
+    );
+    const namespacedKey = getFunctionToolStateKey(namespacedLookup)!;
+    const dottedKey = getFunctionToolStateKey(dottedLookup)!;
+
+    for (const [toolName, checkedCallId] of [
+      [namespacedKey, callId],
+      [namespacedKey, 'future_namespaced_call'],
+      [dottedKey, 'future_dotted_call'],
+    ] as const) {
+      expect(
+        restored._context.isToolApproved({
+          toolName,
+          callId: checkedCallId,
+          functionTool: false,
+          agent,
+        }),
+      ).toBe(false);
+    }
+    expect(
+      restored._context.isToolApproved({
+        toolName: 'crm.lookup',
+        callId: 'future_shell_call',
+        functionTool: false,
+      }),
+    ).toBe(true);
+
+    const durable = restored.toJSON() as any;
+    expect(durable.context.approvals['crm.lookup'].approved).toBe(true);
+    expect(durable.context.legacyFunctionApprovals['crm.lookup'].rejected).toBe(
+      true,
+    );
+
+    const roundTripped = await RunState.fromString(agent, restored.toString());
+    expect(
+      roundTripped._context.isToolApproved({
+        toolName: dottedKey,
+        callId: 'round_trip_function_call',
+        functionTool: false,
+        agent,
+      }),
+    ).toBe(false);
+    expect(
+      roundTripped._context.isToolApproved({
+        toolName: 'crm.lookup',
+        callId: 'round_trip_shell_call',
+        functionTool: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps schema 1.15 approval ownership when merging a canonical override context', async () => {
+    const decisions = [
+      {
+        name: 'per-call approval',
+        record: (callId: string) => ({
+          approved: [callId],
+          rejected: [],
+        }),
+        expected: true,
+      },
+      {
+        name: 'permanent rejection',
+        record: (callId: string) => ({
+          approved: false,
+          rejected: true,
+          messages: { [callId]: 'Always rejected' },
+          stickyRejectMessage: 'Always rejected',
+        }),
+        expected: false,
+        message: 'Always rejected',
+      },
+    ];
+
+    for (const decision of decisions) {
+      const dottedLookup = tool({
+        name: 'crm_lookup',
+        description: 'Dotted lookup.',
+        parameters: z.object({}),
+        execute: async () => 'dotted',
+      });
+      dottedLookup.name = 'crm.lookup';
+      const namespacedLookup = toolNamespace({
+        name: 'crm',
+        description: 'CRM tools.',
+        tools: [
+          tool({
+            name: 'lookup',
+            description: 'Namespaced lookup.',
+            parameters: z.object({}),
+            execute: async () => 'namespaced',
+          }),
+        ],
+      })[0]!;
+      const agent = new Agent({
+        name: `MergeApproval-${decision.name}`,
+        tools: [dottedLookup, namespacedLookup],
+      });
+      const callId = `namespaced-${decision.name.replace(/ /g, '-')}`;
+      const namespacedCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: 'lookup',
+        namespace: 'crm',
+        callId,
+        status: 'completed',
+        arguments: '{}',
+      };
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._lastProcessedResponse = {
+        newItems: [],
+        functions: [
+          { toolCall: namespacedCall, tool: namespacedLookup as any },
+        ],
+        handoffs: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: ['crm.lookup'],
+        hasToolsOrApprovalsToRun: () => true,
+      };
+      state._currentStep = {
+        type: 'next_step_interruption',
+        data: {
+          interruptions: [new ToolApprovalItem(namespacedCall, agent)],
+        },
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+      serialized.context.approvals = {
+        'crm.lookup': decision.record(callId),
+        other: {
+          approved: ['serialized-other-call'],
+          rejected: [],
+        },
+      };
+      delete serialized.currentStep.data.interruptions[0].functionToolStateKey;
+
+      const overrideContext = new RunContext();
+      const existingBareCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: 'crm.lookup',
+        callId: 'existing-bare-call',
+        status: 'completed',
+        arguments: '{}',
+      };
+      overrideContext.approveTool(
+        new ToolApprovalItem(
+          existingBareCall,
+          agent,
+          undefined,
+          getFunctionToolStateKey(dottedLookup),
+        ),
+      );
+      overrideContext.approveTool(
+        new ToolApprovalItem(
+          {
+            type: 'function_call',
+            name: 'other',
+            callId: 'override-other-call',
+            status: 'completed',
+            arguments: '{}',
+          },
+          agent,
+        ),
+      );
+      overrideContext.approveTool(
+        new ToolApprovalItem(
+          {
+            type: 'shell_call',
+            callId: 'override-shell-call',
+            status: 'completed',
+            action: { commands: ['echo approved'] },
+          },
+          agent,
+          'crm.lookup',
+        ),
+        { alwaysApprove: true },
+      );
+
+      const restored = await RunState.fromStringWithContext(
+        agent,
+        JSON.stringify(serialized),
+        overrideContext,
+        { contextStrategy: 'merge' },
+      );
+      const namespacedKey = getFunctionToolStateKey(namespacedLookup)!;
+      const bareKey = getFunctionToolStateKey(dottedLookup)!;
+      const isPermanent = decision.name.startsWith('permanent');
+
+      expect(
+        restored._context.isToolApproved({
+          toolName: namespacedKey,
+          callId,
+        }),
+        decision.name,
+      ).toBe(decision.expected);
+      expect(restored._context.getRejectionMessage(namespacedKey, callId)).toBe(
+        decision.message,
+      );
+      expect(
+        restored._context.isToolApproved({
+          toolName: namespacedKey,
+          callId: `${callId}-future`,
+        }),
+      ).toBe(isPermanent ? decision.expected : undefined);
+      expect(
+        restored._context.isToolApproved({
+          toolName: 'crm.lookup',
+          callId,
+          functionTool: false,
+        }),
+      ).toBe(true);
+      expect(
+        restored._context.getRejectionMessage('crm.lookup', callId, {
+          functionTool: false,
+        }),
+      ).toBeUndefined();
+      expect(
+        restored._context.isToolApproved({
+          toolName: bareKey,
+          callId: 'existing-bare-call',
+          agent,
+        }),
+      ).toBe(true);
+      expect(
+        restored._context.isToolApproved({
+          toolName: bareKey,
+          callId: 'future-bare-call',
+          agent,
+        }),
+      ).toBe(isPermanent ? decision.expected : undefined);
+      expect(
+        restored._context.isToolApproved({
+          toolName: 'other',
+          callId: 'serialized-other-call',
+          functionTool: false,
+        }),
+      ).toBe(true);
+      expect(
+        restored._context.isToolApproved({
+          toolName: '["bare","other"]',
+          callId: 'override-other-call',
+        }),
+      ).toBe(true);
+      expect(
+        restored._context.isToolApproved({
+          toolName: '["bare","other"]',
+          callId: 'serialized-other-call',
+        }),
+      ).toBeUndefined();
+      expect(
+        restored._context.isToolApproved({
+          toolName: 'other',
+          callId: 'override-other-call',
+          functionTool: false,
+        }),
+      ).toBeUndefined();
+    }
+  });
+
   it('accepts schema version 1.6 payloads during deserialization', async () => {
     const context = new RunContext();
     const agent = new Agent({ name: 'Agent16' });
@@ -2375,6 +4308,74 @@ describe('RunState', () => {
       call_id: 'call_ts_raw',
       execution: 'server',
     });
+  });
+
+  it('rehydrates client tool_search outputs without explicit call_id by FIFO order', async () => {
+    const runtimeLookup = tool({
+      name: 'lookup_runtime',
+      description: 'Look up a runtime record.',
+      parameters: z.object({}),
+      execute: async () => 'runtime',
+    });
+    const execute = vi.fn(async () => runtimeLookup);
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'No call id tool-search restore agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_without_call_id',
+          execution: 'client',
+          status: 'completed',
+          arguments: {},
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_without_call_id',
+          execution: 'client',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'lookup_runtime',
+              description: 'Look up a runtime record.',
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+          ],
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(execute).toHaveBeenCalledOnce();
+    expect(
+      await (restored.getToolSearchRuntimeTools(agent)[0] as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('runtime');
   });
 
   it('skips rehydration for server tool_search outputs with concrete tool payloads', async () => {
@@ -2590,6 +4591,3368 @@ describe('RunState', () => {
     expect(restored.getToolSearchRuntimeTools(betaAgent)).toEqual([betaLookup]);
   });
 
+  it('uses the collision-filtered tool winner during tool-search rehydration', async () => {
+    const firstDuplicate = tool({
+      name: 'duplicate',
+      description: 'First duplicate.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'first',
+    });
+    const winningDuplicate = tool({
+      name: 'duplicate',
+      description: 'Winning duplicate.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'winner',
+    });
+    const losingRuntimeTool = tool({
+      name: 'losing_runtime',
+      description: 'Runtime tool selected from the unfiltered list.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'losing runtime',
+    });
+    const winningRuntimeTool = tool({
+      name: 'winning_runtime',
+      description: 'Runtime tool selected from the filtered list.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'winning runtime',
+    });
+    const execute = vi.fn(
+      async ({ availableTools }: { availableTools: Tool<any>[] }) => {
+        const selectedDuplicate = availableTools.find(
+          (candidate) =>
+            candidate.type === 'function' && candidate.name === 'duplicate',
+        );
+        return selectedDuplicate === winningDuplicate
+          ? winningRuntimeTool
+          : losingRuntimeTool;
+      },
+    );
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: {
+          type: 'tool_search',
+          execution: 'client',
+        },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Collision-filtered restore agent',
+      tools: [firstDuplicate, winningDuplicate, clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const callId = 'call_collision_filtered_restore';
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_collision_filtered_restore',
+          status: 'completed',
+          arguments: { query: 'runtime' },
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_collision_filtered_restore',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'winning_runtime',
+              description: 'Runtime tool selected from the filtered list.',
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+          ],
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+
+    allowConsole(['warn']);
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute.mock.calls[0]?.[0].availableTools).toEqual([
+      winningDuplicate,
+      clientToolSearch,
+    ]);
+    expect(restored.getToolSearchRuntimeTools(agent)).toEqual([
+      winningRuntimeTool,
+    ]);
+  });
+
+  it('freezes collision-filtered capabilities across tool-search rehydration callbacks', async () => {
+    type TestContext = {
+      functionEnabled: boolean;
+      handoffEnabled: boolean;
+    };
+
+    const transferFunction = tool({
+      name: 'transfer',
+      description: 'Function with the same name as a dynamic handoff.',
+      parameters: z.object({}).strict(),
+      isEnabled: ({ runContext }) =>
+        (runContext.context as TestContext).functionEnabled,
+      execute: async () => 'function',
+    });
+    const firstRuntimeTool = tool({
+      name: 'first_runtime',
+      description: 'First runtime tool.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'first runtime',
+    });
+    const secondRuntimeTool = tool({
+      name: 'second_runtime',
+      description: 'Second runtime tool.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'second runtime',
+    });
+    const availableToolSnapshots: Tool<any>[][] = [];
+    const execute = vi.fn(
+      async ({
+        availableTools,
+        runContext,
+      }: {
+        availableTools: Tool<TestContext>[];
+        runContext: RunContext<TestContext>;
+      }) => {
+        availableToolSnapshots.push(availableTools);
+        if (availableToolSnapshots.length === 1) {
+          runContext.context.functionEnabled = false;
+          runContext.context.handoffEnabled = true;
+          return firstRuntimeTool;
+        }
+        return secondRuntimeTool;
+      },
+    );
+    const clientToolSearch = attachClientToolSearchExecutor<TestContext>(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: {
+          type: 'tool_search',
+          execution: 'client',
+        },
+      },
+      execute,
+    );
+    const target = new Agent<TestContext>({ name: 'Dynamic target' });
+    const agent = new Agent<TestContext>({
+      name: 'Frozen capability restore agent',
+      tools: [transferFunction, clientToolSearch],
+      handoffs: [
+        handoff(target, {
+          toolNameOverride: 'transfer',
+          isEnabled: ({ runContext }) => runContext.context.handoffEnabled,
+        }),
+      ],
+    });
+    const state = new RunState(
+      new RunContext({ functionEnabled: true, handoffEnabled: false }),
+      'input',
+      agent,
+      2,
+    );
+    const processedToolCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_frozen_capability_restore',
+      callId: 'call_frozen_capability_restore',
+      name: 'transfer',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [
+        { toolCall: processedToolCall, tool: transferFunction as any },
+      ],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['transfer'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+    const addSerializedToolSearchResult = (
+      callId: string,
+      runtimeToolName: string,
+    ) => {
+      state._generatedItems.push(
+        new RunToolSearchCallItem(
+          {
+            type: 'tool_search_call',
+            id: `ts_${callId}`,
+            status: 'completed',
+            arguments: { query: runtimeToolName },
+            providerData: { call_id: callId, execution: 'client' },
+          } as protocol.ToolSearchCallItem,
+          agent as Agent<any, any>,
+        ),
+        new RunToolSearchOutputItem(
+          {
+            type: 'tool_search_output',
+            id: `tso_${callId}`,
+            status: 'completed',
+            tools: [
+              {
+                type: 'function',
+                name: runtimeToolName,
+                description: `${runtimeToolName} description.`,
+                strict: true,
+                parameters: {
+                  type: 'object',
+                  properties: {},
+                  required: [],
+                  additionalProperties: false,
+                },
+              },
+            ],
+            providerData: { call_id: callId, execution: 'client' },
+          } as protocol.ToolSearchOutputItem,
+          agent as Agent<any, any>,
+        ),
+      );
+    };
+    addSerializedToolSearchResult('call_first', 'first_runtime');
+    addSerializedToolSearchResult('call_second', 'second_runtime');
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(availableToolSnapshots).toEqual([
+      [transferFunction, clientToolSearch],
+      [transferFunction, clientToolSearch, firstRuntimeTool],
+    ]);
+    expect(restored.getToolSearchRuntimeTools(agent)).toEqual([
+      firstRuntimeTool,
+      secondRuntimeTool,
+    ]);
+    expect(restored._lastProcessedResponse?.functions[0]?.tool).toBe(
+      transferFunction,
+    );
+  });
+
+  it.each(['bare', 'namespaced', 'deferred'] as const)(
+    'round-trips the final same-key %s runtime tool from distinct tool-search calls',
+    async (kind) => {
+      const availableToolNames: string[][] = [];
+      const execute = vi.fn(
+        async ({
+          availableTools,
+          toolCall,
+        }: {
+          availableTools: Tool<any>[];
+          toolCall: protocol.ToolSearchCallItem;
+        }) => {
+          availableToolNames.push(availableTools.map((entry) => entry.name));
+          const result = String(
+            (toolCall.arguments as { result?: string }).result,
+          );
+          const runtimeTool = tool({
+            name: 'lookup',
+            description: `${result} lookup result.`,
+            parameters: z.object({}).strict(),
+            ...(kind === 'deferred' ? { deferLoading: true } : {}),
+            execute: async () => result,
+          });
+          return kind === 'namespaced'
+            ? toolNamespace({
+                name: 'crm',
+                description: 'CRM tools.',
+                tools: [runtimeTool],
+              })[0]
+            : runtimeTool;
+        },
+      );
+      const clientToolSearch = attachClientToolSearchExecutor(
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: {
+            type: 'tool_search',
+            execution: 'client',
+          },
+        },
+        execute,
+      );
+      const agent = new Agent({
+        name: 'Same-key round-trip agent',
+        tools: [clientToolSearch],
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      const createToolSearchCall = (
+        id: string,
+        result: string,
+      ): protocol.ToolSearchCallItem =>
+        ({
+          type: 'tool_search_call',
+          id: `ts_${id}`,
+          status: 'completed',
+          arguments: { result },
+          providerData: { call_id: id, execution: 'client' },
+        }) as protocol.ToolSearchCallItem;
+      const response: ModelResponse = {
+        output: [
+          createToolSearchCall('call_first_lookup', 'first'),
+          createToolSearchCall('call_second_lookup', 'second'),
+        ],
+        usage: new Usage(),
+      };
+
+      const processed = await processModelResponseAsync(
+        response,
+        agent,
+        [clientToolSearch],
+        [],
+        state,
+        [],
+      );
+      state._generatedItems.push(...processed.newItems);
+      state._lastProcessedResponse = processed;
+
+      const liveTools = state.getToolSearchRuntimeTools(agent);
+      expect(liveTools).toHaveLength(1);
+      expect(await (liveTools[0] as any).invoke(new RunContext(), '{}')).toBe(
+        'second',
+      );
+
+      const restored = await RunState.fromString(agent, state.toString());
+      const restoredTools = restored.getToolSearchRuntimeTools(agent);
+
+      expect(availableToolNames).toEqual([
+        ['tool_search'],
+        ['tool_search', 'lookup'],
+        ['tool_search'],
+        ['tool_search', 'lookup'],
+      ]);
+      expect(restoredTools).toHaveLength(1);
+      expect(
+        await (restoredTools[0] as any).invoke(new RunContext(), '{}'),
+      ).toBe('second');
+    },
+  );
+
+  it('round-trips interleaved handlers and callback inputs for repeated client tool_search call ids', async () => {
+    const execute = vi.fn(
+      async ({
+        availableTools,
+        toolCall,
+      }: {
+        availableTools: Tool<any>[];
+        toolCall: protocol.ToolSearchCallItem;
+      }) => {
+        const phase = String((toolCall.arguments as { phase?: string }).phase);
+        const hasFirstResult = availableTools.some(
+          (availableTool) =>
+            availableTool.type === 'function' &&
+            availableTool.description === 'first lookup result.',
+        );
+        const result = phase === 'final' && !hasFirstResult ? 'wrong' : phase;
+        return tool({
+          name: result === 'wrong' ? 'wrong_lookup' : 'lookup',
+          description: `${result} lookup result.`,
+          parameters: z.object({}).strict(),
+          needsApproval: true,
+          execute: async () => result,
+        });
+      },
+    );
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Repeated call id restore agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const sharedCallId = 'call_repeated_replacement';
+    const createToolSearchCall = (
+      id: string,
+      phase: string,
+    ): protocol.ToolSearchCallItem =>
+      ({
+        type: 'tool_search_call',
+        id,
+        status: 'completed',
+        arguments: { phase },
+        providerData: { call_id: sharedCallId, execution: 'client' },
+      }) as protocol.ToolSearchCallItem;
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_repeated_replacement',
+      callId: 'call_repeated_replacement_function',
+      name: 'lookup',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const processed = await processModelResponseAsync(
+      {
+        output: [
+          createToolSearchCall('ts_repeated_first', 'first'),
+          functionCall,
+          createToolSearchCall('ts_repeated_final', 'final'),
+        ],
+        usage: new Usage(),
+      },
+      agent,
+      [clientToolSearch],
+      [],
+      state,
+      [],
+    );
+    state._generatedItems.push(...processed.newItems);
+    state._lastProcessedResponse = processed;
+
+    expect(
+      await (processed.functions[0]!.tool as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('first');
+    expect(state.getToolSearchRuntimeTools(agent)).toHaveLength(1);
+    expect(
+      await (state.getToolSearchRuntimeTools(agent)[0] as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('final');
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(execute).toHaveBeenCalledTimes(4);
+    expect(restored.getToolSearchRuntimeTools(agent)).toHaveLength(1);
+    expect(
+      await (restored._lastProcessedResponse?.functions[0]!.tool as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('first');
+    expect(
+      await (restored.getToolSearchRuntimeTools(agent)[0] as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('final');
+
+    await rehydrateProcessedResponseTools(
+      agent,
+      restored,
+      restored.getToolSearchRuntimeTools(agent),
+    );
+
+    expect(
+      await (restored._lastProcessedResponse?.functions[0]!.tool as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('first');
+  });
+
+  it.each(['empty', 'disabled', 'different'] as const)(
+    'does not resurrect an older routed owner after a later call is replaced with %s',
+    async (replacement) => {
+      const firstLookup = tool({
+        name: 'lookup',
+        description: 'First lookup owner.',
+        parameters: z.object({}).strict(),
+        execute: async () => 'first',
+      });
+      const secondLookup = tool({
+        name: 'lookup',
+        description: 'Second lookup owner.',
+        parameters: z.object({}).strict(),
+        execute: async () => 'second',
+      });
+      const disabledLookup = tool({
+        name: 'lookup',
+        description: 'Disabled final lookup.',
+        parameters: z.object({}).strict(),
+        isEnabled: false,
+        execute: async () => 'disabled',
+      });
+      const alternateLookup = tool({
+        name: 'alternate_lookup',
+        description: 'Different final lookup.',
+        parameters: z.object({}).strict(),
+        execute: async () => 'alternate',
+      });
+      const execute = vi.fn(
+        async ({ toolCall }: { toolCall: protocol.ToolSearchCallItem }) => {
+          const phase = String(
+            (toolCall.arguments as { phase?: string }).phase,
+          );
+          if (phase === 'first') {
+            return firstLookup;
+          }
+          if (phase === 'second') {
+            return secondLookup;
+          }
+          if (replacement === 'disabled') {
+            return disabledLookup;
+          }
+          if (replacement === 'different') {
+            return alternateLookup;
+          }
+          return [];
+        },
+      );
+      const clientToolSearch = attachClientToolSearchExecutor(
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: { type: 'tool_search', execution: 'client' },
+        },
+        execute,
+      );
+      const agent = new Agent({
+        name: `Routed owner ${replacement} agent`,
+        tools: [clientToolSearch],
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      const createCall = (
+        id: string,
+        callId: string,
+        phase: string,
+      ): protocol.ToolSearchCallItem =>
+        ({
+          type: 'tool_search_call',
+          id,
+          status: 'completed',
+          arguments: { phase },
+          providerData: { call_id: callId, execution: 'client' },
+        }) as protocol.ToolSearchCallItem;
+      const processed = await processModelResponseAsync(
+        {
+          output: [
+            createCall('ts_owner_first', 'call_owner_first', 'first'),
+            createCall('ts_owner_second', 'call_owner_second', 'second'),
+            createCall('ts_owner_final', 'call_owner_second', 'final'),
+          ],
+          usage: new Usage(),
+        },
+        agent,
+        [clientToolSearch],
+        [],
+        state,
+        [],
+      );
+      state._generatedItems.push(...processed.newItems);
+      state._lastProcessedResponse = processed;
+
+      const expectedTools = replacement === 'different' ? 1 : 0;
+      expect(state.getToolSearchRuntimeTools(agent)).toHaveLength(
+        expectedTools,
+      );
+      if (replacement === 'different') {
+        expect(
+          await (state.getToolSearchRuntimeTools(agent)[0] as any).invoke(
+            new RunContext(),
+            '{}',
+          ),
+        ).toBe('alternate');
+      }
+
+      const restored = await RunState.fromString(agent, state.toString());
+
+      expect(restored.getToolSearchRuntimeTools(agent)).toHaveLength(
+        expectedTools,
+      );
+      if (replacement === 'different') {
+        expect(
+          await (restored.getToolSearchRuntimeTools(agent)[0] as any).invoke(
+            new RunContext(),
+            '{}',
+          ),
+        ).toBe('alternate');
+      }
+    },
+  );
+
+  it('keeps a later routed owner when an older call returned the same tool object', async () => {
+    const sharedLookup = tool({
+      name: 'lookup',
+      description: 'Shared lookup owner.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'shared',
+    });
+    const execute = vi.fn(
+      async ({ toolCall }: { toolCall: protocol.ToolSearchCallItem }) =>
+        (toolCall.arguments as { phase?: string }).phase === 'empty'
+          ? []
+          : sharedLookup,
+    );
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Shared object routed owner',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const createSearchCall = (
+      id: string,
+      callId: string,
+      phase: string,
+    ): protocol.ToolSearchCallItem =>
+      ({
+        type: 'tool_search_call',
+        id,
+        status: 'completed',
+        arguments: { phase },
+        providerData: { call_id: callId, execution: 'client' },
+      }) as protocol.ToolSearchCallItem;
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_shared_object_owner',
+      callId: 'call_shared_object_owner',
+      name: 'lookup',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const processed = await processModelResponseAsync(
+      {
+        output: [
+          createSearchCall('ts_owner_a', 'owner_a', 'shared'),
+          createSearchCall('ts_owner_b', 'owner_b', 'shared'),
+          createSearchCall('ts_owner_a_empty', 'owner_a', 'empty'),
+          functionCall,
+        ],
+        usage: new Usage(),
+      },
+      agent,
+      [clientToolSearch],
+      [],
+      state,
+      [],
+    );
+    state._generatedItems.push(...processed.newItems);
+    state._lastProcessedResponse = processed;
+
+    expect(processed.functions[0]?.tool).toBe(sharedLookup);
+    expect(state.getToolSearchRuntimeTools(agent)).toEqual([sharedLookup]);
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(restored._lastProcessedResponse?.functions[0]?.tool).toBe(
+      sharedLookup,
+    );
+    expect(restored.getToolSearchRuntimeTools(agent)).toEqual([sharedLookup]);
+  });
+
+  it('restores the runtime handler bound before a later same-key replacement', async () => {
+    const execute = vi.fn(
+      async ({ toolCall }: { toolCall: protocol.ToolSearchCallItem }) => {
+        const result = String(
+          (toolCall.arguments as { result?: string }).result,
+        );
+        return tool({
+          name: 'lookup',
+          description: `${result} lookup result.`,
+          parameters: z.object({}).strict(),
+          needsApproval: true,
+          execute: async () => result,
+        });
+      },
+    );
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Interleaved replacement restore agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const firstSearchCall = {
+      type: 'tool_search_call',
+      id: 'ts_call_first_interleaved',
+      status: 'completed',
+      arguments: { result: 'first' },
+      providerData: {
+        call_id: 'call_first_interleaved',
+        execution: 'client',
+      },
+    } as protocol.ToolSearchCallItem;
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_interleaved_lookup',
+      callId: 'call_interleaved_lookup',
+      name: 'lookup',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const secondSearchCall = {
+      type: 'tool_search_call',
+      id: 'ts_call_second_interleaved',
+      status: 'completed',
+      arguments: { result: 'second' },
+      providerData: {
+        call_id: 'call_second_interleaved',
+        execution: 'client',
+      },
+    } as protocol.ToolSearchCallItem;
+    const response: ModelResponse = {
+      output: [firstSearchCall, functionCall, secondSearchCall],
+      usage: new Usage(),
+    };
+
+    const processed = await processModelResponseAsync(
+      response,
+      agent,
+      [clientToolSearch],
+      [],
+      state,
+      [],
+    );
+    state._generatedItems.push(...processed.newItems);
+    state._lastProcessedResponse = processed;
+
+    expect(
+      await (processed.functions[0].tool as any).invoke(new RunContext(), '{}'),
+    ).toBe('first');
+    expect(
+      await (state.getToolSearchRuntimeTools(agent)[0] as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('second');
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(
+      await (restored._lastProcessedResponse?.functions[0].tool as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('first');
+    expect(
+      await (restored.getToolSearchRuntimeTools(agent)[0] as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('second');
+  });
+
+  it('round trips a flattened configured namespace call with its canonical approval key', async () => {
+    const namespacedLookup = toolNamespace({
+      name: 'crm',
+      description: 'CRM tools.',
+      tools: [
+        tool({
+          name: 'lookup',
+          description: 'Configured CRM lookup.',
+          parameters: z.object({}).strict(),
+          needsApproval: true,
+          execute: async () => 'configured',
+        }),
+      ],
+    })[0];
+    const agent = new Agent({
+      name: 'Flattened configured namespace restore agent',
+      tools: [namespacedLookup],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const flattenedCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_flattened_configured_namespace',
+      callId: 'call_flattened_configured_namespace',
+      name: 'crm.lookup',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const processed = await processModelResponseAsync(
+      { output: [flattenedCall], usage: new Usage() },
+      agent,
+      [namespacedLookup],
+      [],
+      state,
+      [],
+    );
+    const normalizedCall = processed.functions[0]!.toolCall;
+    const canonicalKey = getFunctionToolStateKey(namespacedLookup)!;
+    state._generatedItems.push(...processed.newItems);
+    state._lastProcessedResponse = processed;
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: {
+        interruptions: [
+          new ToolApprovalItem(normalizedCall, agent, undefined, canonicalKey),
+        ],
+      },
+    };
+
+    expect(normalizedCall).toMatchObject({
+      name: 'lookup',
+      namespace: 'crm',
+    });
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(
+      restored._lastProcessedResponse?.functions[0]?.toolCall,
+    ).toMatchObject({ name: 'lookup', namespace: 'crm' });
+    expect(restored.getInterruptions()[0]?.functionToolStateKey).toBe(
+      canonicalKey,
+    );
+    expect(restored.getInterruptions()[0]?.rawItem).toMatchObject({
+      name: 'lookup',
+      namespace: 'crm',
+    });
+    expect(
+      await (restored._lastProcessedResponse?.functions[0]?.tool as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('configured');
+  });
+
+  it('round trips a flattened namespace call with its runtime tool-search handler', async () => {
+    const execute = vi.fn(async () =>
+      toolNamespace({
+        name: 'crm',
+        description: 'Runtime CRM tools.',
+        tools: [
+          tool({
+            name: 'lookup',
+            description: 'Runtime CRM lookup.',
+            parameters: z.object({}).strict(),
+            needsApproval: true,
+            execute: async () => 'runtime',
+          }),
+        ],
+      }),
+    );
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Flattened runtime namespace restore agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const flattenedCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_flattened_runtime_namespace',
+      callId: 'call_flattened_runtime_namespace',
+      name: 'crm.lookup',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const processed = await processModelResponseAsync(
+      {
+        output: [
+          {
+            type: 'tool_search_call',
+            id: 'ts_flattened_runtime_namespace',
+            status: 'completed',
+            arguments: {},
+            providerData: {
+              call_id: 'search_flattened_runtime_namespace',
+              execution: 'client',
+            },
+          } as protocol.ToolSearchCallItem,
+          flattenedCall,
+        ],
+        usage: new Usage(),
+      },
+      agent,
+      [clientToolSearch],
+      [],
+      state,
+      [],
+    );
+    const normalizedCall = processed.functions[0]!.toolCall;
+    const runtimeTool = processed.functions[0]!.tool;
+    const canonicalKey = getFunctionToolStateKey(runtimeTool)!;
+    state._generatedItems.push(...processed.newItems);
+    state._lastProcessedResponse = processed;
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: {
+        interruptions: [
+          new ToolApprovalItem(normalizedCall, agent, undefined, canonicalKey),
+        ],
+      },
+    };
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(
+      restored._lastProcessedResponse?.functions[0]?.toolCall,
+    ).toMatchObject({ name: 'lookup', namespace: 'crm' });
+    expect(restored.getInterruptions()[0]?.functionToolStateKey).toBe(
+      canonicalKey,
+    );
+    expect(
+      await (restored._lastProcessedResponse?.functions[0]?.tool as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('runtime');
+
+    const restoredProcessedTool =
+      restored._lastProcessedResponse?.functions[0]?.tool;
+
+    await rehydrateProcessedResponseTools(agent, restored, []);
+
+    expect(restored._lastProcessedResponse?.functions[0]?.tool).toBe(
+      restoredProcessedTool,
+    );
+    expect(
+      await (restored._lastProcessedResponse?.functions[0]?.tool as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('runtime');
+  });
+
+  it.each([CURRENT_SCHEMA_VERSION, '1.15'] as const)(
+    'round trips a deferred runtime tool selected by a legacy bare call in schema %s',
+    async (schemaVersion) => {
+      const deferredLookup = tool({
+        name: 'lookup',
+        description: 'Deferred lookup.',
+        parameters: z.object({}).strict(),
+        deferLoading: true,
+        needsApproval: true,
+        execute: async () => 'deferred',
+      });
+      const execute = vi.fn(async () => deferredLookup);
+      const clientToolSearch = attachClientToolSearchExecutor(
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: { type: 'tool_search', execution: 'client' },
+        },
+        execute,
+      );
+      const agent = new Agent({
+        name: `Deferred bare restore ${schemaVersion}`,
+        tools: [clientToolSearch],
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      const functionCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        id: `fc_deferred_bare_${schemaVersion}`,
+        callId: `call_deferred_bare_${schemaVersion}`,
+        name: 'lookup',
+        status: 'completed',
+        arguments: '{}',
+      };
+      const processed = await processModelResponseAsync(
+        {
+          output: [
+            {
+              type: 'tool_search_call',
+              id: `ts_call_deferred_bare_${schemaVersion}`,
+              status: 'completed',
+              arguments: {},
+              providerData: {
+                call_id: `search_deferred_bare_${schemaVersion}`,
+                execution: 'client',
+              },
+            } as protocol.ToolSearchCallItem,
+            functionCall,
+          ],
+          usage: new Usage(),
+        },
+        agent,
+        [clientToolSearch],
+        [],
+        state,
+        [],
+      );
+      state._generatedItems.push(...processed.newItems);
+      state._lastProcessedResponse = processed;
+      state._currentStep = {
+        type: 'next_step_interruption',
+        data: {
+          interruptions: [
+            new ToolApprovalItem(
+              functionCall,
+              agent,
+              undefined,
+              getFunctionToolStateKey(deferredLookup),
+            ),
+          ],
+        },
+      };
+
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = schemaVersion;
+      if (schemaVersion === '1.15') {
+        delete serialized.currentStep.data.interruptions[0]
+          .functionToolStateKey;
+      }
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(execute).toHaveBeenCalledTimes(2);
+      expect(restored.getInterruptions()[0]?.functionToolStateKey).toBe(
+        getFunctionToolStateKey(deferredLookup),
+      );
+      expect(
+        await (
+          restored._lastProcessedResponse?.functions[0].tool as any
+        ).invoke(new RunContext(), '{}'),
+      ).toBe('deferred');
+    },
+  );
+
+  it('rejects an unproven deferred bare fallback instead of rebinding a bare owner', async () => {
+    const bareLookup = tool({
+      name: 'lookup',
+      description: 'Bare lookup.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'bare',
+    });
+    const deferredLookup = tool({
+      name: 'lookup',
+      description: 'Unproven deferred lookup.',
+      parameters: z.object({}).strict(),
+      deferLoading: true,
+      execute: async () => 'deferred',
+    });
+    const agent = new Agent({
+      name: 'Unproven deferred fallback agent',
+      tools: [bareLookup],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_unproven_deferred_fallback',
+      callId: 'call_unproven_deferred_fallback',
+      name: 'lookup',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._generatedItems.push(new RunToolCallItem(functionCall, agent));
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall: functionCall, tool: deferredLookup as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['lookup'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: {
+        interruptions: [
+          new ToolApprovalItem(
+            functionCall,
+            agent,
+            undefined,
+            getFunctionToolStateKey(deferredLookup),
+          ),
+        ],
+      },
+    };
+
+    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
+      'function call ID is associated with multiple routed tool identities',
+    );
+  });
+
+  it('round trips a legacy bare call resolved by a configured deferred owner', async () => {
+    const deferredLookup = tool({
+      name: 'lookup',
+      description: 'Configured deferred lookup.',
+      parameters: z.object({}).strict(),
+      deferLoading: true,
+      execute: async () => 'deferred',
+    });
+    const agent = new Agent({
+      name: 'Configured deferred fallback agent',
+      tools: [deferredLookup],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_configured_deferred_fallback',
+      callId: 'call_configured_deferred_fallback',
+      name: 'lookup',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._generatedItems.push(new RunToolCallItem(functionCall, agent));
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall: functionCall, tool: deferredLookup as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['lookup'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: {
+        interruptions: [
+          new ToolApprovalItem(
+            functionCall,
+            agent,
+            undefined,
+            getFunctionToolStateKey(deferredLookup),
+          ),
+        ],
+      },
+    };
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(restored.getInterruptions()[0]?.functionToolStateKey).toBe(
+      getFunctionToolStateKey(deferredLookup),
+    );
+    expect(
+      await (restored._lastProcessedResponse?.functions[0].tool as any).invoke(
+        new RunContext(),
+        '{}',
+      ),
+    ).toBe('deferred');
+  });
+
+  it.each([CURRENT_SCHEMA_VERSION, '1.15'] as const)(
+    'rejects a configured deferred bare fallback hidden by a handoff in schema %s',
+    async (schemaVersion) => {
+      const deferredLookup = tool({
+        name: 'lookup',
+        description: 'Configured deferred lookup.',
+        parameters: z.object({}).strict(),
+        deferLoading: true,
+        execute: async () => 'deferred',
+      });
+      const target = new Agent({ name: 'Deferred lookup target' });
+      const agent = new Agent({
+        name: `Configured deferred handoff collision ${schemaVersion}`,
+        tools: [deferredLookup],
+        handoffs: [handoff(target, { toolNameOverride: 'lookup' })],
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      const functionCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        id: `fc_configured_deferred_handoff_${schemaVersion}`,
+        callId: `call_configured_deferred_handoff_${schemaVersion}`,
+        name: 'lookup',
+        status: 'completed',
+        arguments: '{}',
+      };
+      state._generatedItems.push(new RunToolCallItem(functionCall, agent));
+      state._lastProcessedResponse = {
+        newItems: [],
+        functions: [{ toolCall: functionCall, tool: deferredLookup as any }],
+        handoffs: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: ['lookup'],
+        hasToolsOrApprovalsToRun: () => true,
+      };
+      state._currentStep = {
+        type: 'next_step_interruption',
+        data: {
+          interruptions: [
+            new ToolApprovalItem(
+              functionCall,
+              agent,
+              undefined,
+              getFunctionToolStateKey(deferredLookup),
+            ),
+          ],
+        },
+      };
+
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = schemaVersion;
+      if (schemaVersion === '1.15') {
+        delete serialized.currentStep.data.interruptions[0]
+          .functionToolStateKey;
+      }
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow(
+        'function call ID is associated with multiple routed tool identities',
+      );
+    },
+  );
+
+  it('scopes repeated function call ids to each interruption agent', async () => {
+    const outerTool = tool({
+      name: 'outer_tool',
+      description: 'Outer tool.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'outer',
+    });
+    const childTool = tool({
+      name: 'child_tool',
+      description: 'Child tool.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'child',
+    });
+    const child = new Agent({ name: 'Call id child', tools: [childTool] });
+    const root = new Agent({
+      name: 'Call id root',
+      tools: [outerTool],
+      handoffs: [child],
+    });
+    const state = new RunState(new RunContext(), 'input', root, 2);
+    const sharedCallId = 'agent_scoped_call_id';
+    const outerCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_outer_agent_scoped',
+      callId: sharedCallId,
+      name: 'outer_tool',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const childCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_child_agent_scoped',
+      callId: sharedCallId,
+      name: 'child_tool',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._generatedItems.push(
+      new RunToolCallItem(outerCall, root),
+      new RunToolCallItem(childCall, child),
+    );
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall: outerCall, tool: outerTool as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['outer_tool'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: {
+        interruptions: [
+          new ToolApprovalItem(
+            childCall,
+            child,
+            undefined,
+            getFunctionToolStateKey(childTool),
+          ),
+        ],
+      },
+    };
+
+    const restored = await RunState.fromString(root, state.toString());
+
+    expect(restored.getInterruptions()[0]?.agent).toBe(child);
+    expect(restored.getInterruptions()[0]?.functionToolStateKey).toBe(
+      getFunctionToolStateKey(childTool),
+    );
+  });
+
+  it('preserves independent function approvals with the same identity across agents', async () => {
+    const rootTool = tool({
+      name: 'shared_tool',
+      description: 'Root shared tool.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'root',
+    });
+    const childTool = tool({
+      name: 'shared_tool',
+      description: 'Child shared tool.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'child',
+    });
+    const child = new Agent({
+      name: 'Shared approval agent',
+      tools: [childTool],
+    });
+    const root = new Agent({
+      name: 'Shared approval agent',
+      tools: [rootTool],
+      handoffs: [child],
+    });
+    const sharedCallId = 'shared_approval_call_id';
+    const rootCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_shared_approval_root',
+      callId: sharedCallId,
+      name: 'shared_tool',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const childCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_shared_approval_child',
+      callId: sharedCallId,
+      name: 'shared_tool',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const state = new RunState(new RunContext(), 'input', root, 2);
+    state._generatedItems.push(
+      new RunToolCallItem(rootCall, root),
+      new RunToolCallItem(childCall, child),
+    );
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall: rootCall, tool: rootTool as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['shared_tool'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: {
+        interruptions: [
+          new ToolApprovalItem(
+            rootCall,
+            root,
+            undefined,
+            getFunctionToolStateKey(rootTool),
+          ),
+          new ToolApprovalItem(
+            childCall,
+            child,
+            undefined,
+            getFunctionToolStateKey(childTool),
+          ),
+        ],
+      },
+    };
+
+    const sharedStateKey = getFunctionToolStateKey(rootTool)!;
+    const legacySerialized = state.toJSON() as any;
+    legacySerialized.$schemaVersion = '1.15';
+    legacySerialized.context.approvals = {
+      shared_tool: { approved: [sharedCallId], rejected: [] },
+    };
+    delete legacySerialized.context.functionApprovals;
+    for (const interruption of legacySerialized.currentStep.data
+      .interruptions) {
+      delete interruption.functionToolStateKey;
+    }
+    const legacyRestored = await RunState.fromString(
+      root,
+      JSON.stringify(legacySerialized),
+    );
+    for (const owner of [root, child]) {
+      expect(
+        legacyRestored._context.isToolApproved({
+          toolName: sharedStateKey,
+          callId: sharedCallId,
+          functionTool: false,
+          agent: owner,
+        }),
+      ).toBe(true);
+    }
+    const legacyRoundTripped = await RunState.fromString(
+      root,
+      legacyRestored.toString(),
+    );
+    for (const owner of [root, child]) {
+      expect(
+        legacyRoundTripped._context.isToolApproved({
+          toolName: sharedStateKey,
+          callId: sharedCallId,
+          functionTool: false,
+          agent: owner,
+        }),
+      ).toBe(true);
+    }
+
+    const restored = await RunState.fromString(root, state.toString());
+    const [rootApproval, childApproval] = restored.getInterruptions();
+    restored.approve(rootApproval, { alwaysApprove: true });
+    restored.reject(childApproval, { message: 'Child call rejected.' });
+
+    const roundTripped = await RunState.fromString(root, restored.toString());
+    expect(
+      roundTripped._context.isToolApproved({
+        toolName: sharedStateKey,
+        callId: 'future-root-call',
+        functionTool: false,
+        agent: root,
+      }),
+    ).toBe(true);
+    expect(
+      roundTripped._context.isToolApproved({
+        toolName: sharedStateKey,
+        callId: sharedCallId,
+        functionTool: false,
+        agent: child,
+      }),
+    ).toBe(false);
+    expect(
+      roundTripped._context.isToolApproved({
+        toolName: sharedStateKey,
+        callId: 'future-child-call',
+        functionTool: false,
+        agent: child,
+      }),
+    ).toBeUndefined();
+    expect(
+      roundTripped._context._getFunctionRejectionMessage(
+        sharedStateKey,
+        sharedCallId,
+        child,
+      ),
+    ).toBe('Child call rejected.');
+    expect(
+      roundTripped._context._getFunctionRejectionMessage(
+        sharedStateKey,
+        sharedCallId,
+        root,
+      ),
+    ).toBeUndefined();
+  });
+
+  it('round trips function approvals for reserved agent identity names', async () => {
+    const agent = new Agent({ name: '__proto__' });
+    const rawItem: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'reserved_identity_tool',
+      callId: 'reserved_identity_call',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    state.reject(new ToolApprovalItem(rawItem, agent), {
+      message: 'Reserved identity rejected.',
+    });
+
+    const serialized = state.toJSON();
+    expect(serialized.context.functionApprovals).toEqual([
+      {
+        agentIdentity: '__proto__',
+        approvals: expect.any(Object),
+      },
+    ]);
+
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+    const stateKey = getFunctionToolStateKeyForCall(rawItem)!;
+    expect(
+      restored._context.isToolApproved({
+        toolName: stateKey,
+        callId: rawItem.callId,
+        functionTool: false,
+        agent,
+      }),
+    ).toBe(false);
+    expect(
+      restored._context._getFunctionRejectionMessage(
+        stateKey,
+        rawItem.callId,
+        agent,
+      ),
+    ).toBe('Reserved identity rejected.');
+  });
+
+  it('validates current function approval state before context replacement', async () => {
+    const agent = new Agent({ name: 'ApprovalOwnerValidationAgent' });
+    const rawItem: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'approval_owner_tool',
+      callId: 'approval_owner_call',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    state.approve(new ToolApprovalItem(rawItem, agent));
+    const serialized = state.toJSON() as any;
+    serialized.context.functionApprovals[0].agentIdentity = 'unknown-agent';
+
+    await expect(
+      RunState.fromStringWithContext(
+        agent,
+        JSON.stringify(serialized),
+        new RunContext(),
+        { contextStrategy: 'replace' },
+      ),
+    ).rejects.toBeInstanceOf(UserError);
+  });
+
+  it('rejects duplicate function approval owners before tool execution', async () => {
+    const execute = vi.fn(async () => 'executed');
+    const approvalTool = tool({
+      name: 'duplicate_owner_tool',
+      description: 'Duplicate owner tool.',
+      parameters: z.object({}),
+      execute,
+    });
+    const agent = new Agent({
+      name: 'DuplicateApprovalOwnerAgent',
+      tools: [approvalTool],
+    });
+    const rawItem: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: approvalTool.name,
+      callId: 'duplicate_owner_call',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    state.approve(new ToolApprovalItem(rawItem, agent));
+    const serialized = state.toJSON() as any;
+    serialized.context.functionApprovals.push({
+      ...serialized.context.functionApprovals[0],
+      approvals: {
+        ...serialized.context.functionApprovals[0].approvals,
+      },
+    });
+
+    await expect(
+      RunState.fromStringWithContext(
+        agent,
+        JSON.stringify(serialized),
+        new RunContext(),
+        { contextStrategy: 'replace' },
+      ),
+    ).rejects.toBeInstanceOf(UserError);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed current function approval state with UserError', async () => {
+    const agent = new Agent({ name: 'MalformedApprovalOwnerAgent' });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    const serialized = state.toJSON() as any;
+    serialized.context.functionApprovals = [
+      {
+        agentIdentity: agent.name,
+        approvals: {
+          malformed: { approved: 'yes', rejected: [] },
+        },
+      },
+    ];
+
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toBeInstanceOf(UserError);
+  });
+
+  it('rejects noncanonical current function approval keys with UserError', async () => {
+    const agent = new Agent({ name: 'NoncanonicalApprovalKeyAgent' });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    const serialized = state.toJSON() as any;
+    serialized.context.functionApprovals = [
+      {
+        agentIdentity: agent.name,
+        approvals: {
+          lookup: { approved: true, rejected: [] },
+        },
+      },
+    ];
+
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toBeInstanceOf(UserError);
+  });
+
+  it('preserves ZodError for unrelated malformed run state fields', async () => {
+    const agent = new Agent({ name: 'MalformedUnrelatedStateAgent' });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    const serialized = state.toJSON() as any;
+    serialized.currentTurn = 'not-a-number';
+
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toBeInstanceOf(ZodError);
+  });
+
+  it('rejects owner-scoped approval fields in legacy schemas', async () => {
+    const agent = new Agent({ name: 'LegacyApprovalOwnerFieldAgent' });
+    const rawItem: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'legacy_owner_tool',
+      callId: 'legacy_owner_call',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    state.approve(new ToolApprovalItem(rawItem, agent));
+    const serialized = state.toJSON() as any;
+    serialized.$schemaVersion = '1.15';
+
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow(
+      'Run state schema version 1.15 does not support owner-scoped function approvals.',
+    );
+  });
+
+  it('rejects interruption identity mismatches before callbacks without a processed response', async () => {
+    const dangerous = tool({
+      name: 'dangerous',
+      description: 'Dangerous action.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'dangerous',
+    });
+    const harmless = tool({
+      name: 'harmless',
+      description: 'Harmless action.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'harmless',
+    });
+    const runtimeLookup = tool({
+      name: 'runtime_lookup',
+      description: 'Runtime lookup.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'runtime',
+    });
+    const execute = vi.fn(async () => runtimeLookup);
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'No processed response interruption agent',
+      tools: [dangerous, harmless, clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const rawItem: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_no_processed_response',
+      callId: 'call_no_processed_response',
+      name: 'dangerous',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_no_processed_response',
+          status: 'completed',
+          arguments: {},
+          providerData: {
+            call_id: 'search_no_processed_response',
+            execution: 'client',
+          },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_no_processed_response',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'runtime_lookup',
+              description: 'Runtime lookup.',
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+          ],
+          providerData: {
+            call_id: 'search_no_processed_response',
+            execution: 'client',
+          },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+      new RunToolCallItem(rawItem, agent),
+    );
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: {
+        interruptions: [
+          new ToolApprovalItem(
+            rawItem,
+            agent,
+            undefined,
+            getFunctionToolStateKey(harmless),
+          ),
+        ],
+      },
+    };
+
+    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
+      'function call ID is associated with multiple routed tool identities',
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('rejects reused function call ids before tool-search rehydration callbacks', async () => {
+    const runtimeLookup = tool({
+      name: 'runtime_lookup',
+      description: 'Runtime lookup.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'runtime',
+    });
+    const configuredLookup = tool({
+      name: 'configured_lookup',
+      description: 'Configured lookup.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'configured',
+    });
+    const execute = vi.fn(async () => runtimeLookup);
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Reused function call id agent',
+      tools: [configuredLookup, clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const sharedCallId = 'reused_function_call_id';
+    const runtimeCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_runtime_lookup',
+      callId: sharedCallId,
+      name: 'runtime_lookup',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const configuredCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_configured_lookup',
+      callId: sharedCallId,
+      name: 'configured_lookup',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_reused_function_id',
+          status: 'completed',
+          arguments: {},
+          providerData: {
+            call_id: 'tool_search_reused_function_id',
+            execution: 'client',
+          },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_reused_function_id',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'runtime_lookup',
+              description: 'Runtime lookup.',
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+          ],
+          providerData: {
+            call_id: 'tool_search_reused_function_id',
+            execution: 'client',
+          },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+      new RunToolCallItem(runtimeCall, agent),
+      new RunToolCallItem(configuredCall, agent),
+    );
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall: configuredCall, tool: configuredLookup as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['configured_lookup'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+
+    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
+      'function call ID is associated with multiple routed tool identities',
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('rejects reused function call ids before legacy state migration', async () => {
+    const bareLookup = tool({
+      name: 'lookup',
+      description: 'Bare lookup.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'bare',
+    });
+    const deferredLookup = tool({
+      name: 'lookup',
+      description: 'Deferred lookup.',
+      parameters: z.object({}).strict(),
+      deferLoading: true,
+      execute: async () => 'deferred',
+    });
+    const agent = new Agent({
+      name: 'Legacy reused function call id agent',
+      tools: [bareLookup, deferredLookup],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const sharedCallId = 'legacy_reused_function_call_id';
+    const bareCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_legacy_bare_lookup',
+      callId: sharedCallId,
+      name: 'lookup',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const deferredCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_legacy_deferred_lookup',
+      callId: sharedCallId,
+      name: 'lookup',
+      namespace: 'lookup',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [
+        { toolCall: bareCall, tool: bareLookup as any },
+        { toolCall: deferredCall, tool: deferredLookup as any },
+      ],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['lookup'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+
+    const serialized = state.toJSON() as any;
+    serialized.$schemaVersion = '1.15';
+
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow(
+      'function call ID is associated with multiple routed tool identities',
+    );
+  });
+
+  it('rejects an interruption whose routed identity differs from its processed call', async () => {
+    const dangerous = tool({
+      name: 'dangerous',
+      description: 'Dangerous action.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'dangerous',
+    });
+    const harmless = tool({
+      name: 'harmless',
+      description: 'Harmless action.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'harmless',
+    });
+    const agent = new Agent({
+      name: 'Mismatched interruption identity agent',
+      tools: [dangerous, harmless],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const rawItem: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_dangerous',
+      callId: 'mismatched_interruption_identity',
+      name: 'dangerous',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall: rawItem, tool: dangerous as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['dangerous'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: {
+        interruptions: [new ToolApprovalItem(rawItem, agent)],
+      },
+    };
+
+    const serialized = state.toJSON() as any;
+    serialized.currentStep.data.interruptions[0].rawItem.name = 'harmless';
+
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow(
+      'function call ID is associated with multiple routed tool identities',
+    );
+  });
+
+  it('validates every tool-search output before invoking a rehydration callback', async () => {
+    const runtimeTool = tool({
+      name: 'lookup',
+      description: 'Lookup result.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'lookup',
+    });
+    const execute = vi.fn(async () => runtimeTool);
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Tool-search preflight agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_preflight_valid',
+          status: 'completed',
+          arguments: {},
+          providerData: {
+            call_id: 'call_preflight_valid',
+            execution: 'client',
+          },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_preflight_valid',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'lookup',
+              description: 'Lookup result.',
+              strict: true,
+              parameters: { type: 'object', properties: {}, required: [] },
+            },
+          ],
+          providerData: {
+            call_id: 'call_preflight_valid',
+            execution: 'client',
+          },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_preflight_orphan',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'orphan',
+              description: 'Orphan result.',
+              strict: true,
+              parameters: { type: 'object', properties: {}, required: [] },
+            },
+          ],
+          providerData: {
+            call_id: 'call_preflight_orphan',
+            execution: 'client',
+          },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+
+    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
+      'serialized state is missing the matching tool_search call item',
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed serialized runtime identity before rehydration callbacks', async () => {
+    const execute = vi.fn();
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Malformed tool-search identity agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const callId = 'call_malformed_identity';
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_malformed_identity',
+          status: 'completed',
+          arguments: {},
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_malformed_identity',
+          status: 'completed',
+          tools: [{ type: 'function' }],
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+
+    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
+      'function without a valid routed identity',
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('rejects a reserved serialized namespace before rehydration callbacks', async () => {
+    const execute = vi.fn(async () => []);
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Reserved serialized namespace agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const callId = 'call_reserved_serialized_namespace';
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_reserved_serialized_namespace',
+          status: 'completed',
+          arguments: {},
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_reserved_serialized_namespace',
+          status: 'completed',
+          tools: [
+            {
+              type: 'namespace',
+              name: 'lookup',
+              description: 'Reserved lookup namespace.',
+              tools: [
+                {
+                  type: 'function',
+                  name: 'lookup',
+                  description: 'Nested lookup.',
+                  strict: true,
+                  parameters: {
+                    type: 'object',
+                    properties: {},
+                    required: [],
+                    additionalProperties: false,
+                  },
+                },
+              ],
+            },
+          ],
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+
+    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
+      'Responses tool search reserves same-name namespaces for deferred top-level function tools.',
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('rejects a direct serialized self-namespace before rehydration callbacks', async () => {
+    const runtimeLookup = tool({
+      name: 'lookup',
+      description: 'Deferred lookup.',
+      parameters: z.object({}).strict(),
+      deferLoading: true,
+      execute: async () => 'lookup',
+    });
+    const execute = vi.fn(async () => runtimeLookup);
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Direct reserved serialized namespace agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const callId = 'call_direct_reserved_serialized_namespace';
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_direct_reserved_serialized_namespace',
+          status: 'completed',
+          arguments: {},
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_direct_reserved_serialized_namespace',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'lookup',
+              namespace: 'lookup',
+              description: 'Reserved lookup namespace.',
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+          ],
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+
+    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
+      'Responses tool search reserves same-name namespaces for deferred top-level function tools.',
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('replays an empty tool-search callback before later callbacks', async () => {
+    type TestContext = { ready: boolean };
+    const execute = vi.fn(
+      async ({
+        runContext,
+        toolCall,
+      }: {
+        runContext: RunContext<TestContext>;
+        toolCall: protocol.ToolSearchCallItem;
+      }) => {
+        const phase = (toolCall.arguments as { phase?: string }).phase;
+        if (phase === 'empty') {
+          runContext.context.ready = true;
+          return [];
+        }
+        const name = runContext.context.ready ? 'after_empty' : 'wrong';
+        return tool({
+          name,
+          description: 'Result after the empty callback.',
+          parameters: z.object({}).strict(),
+          execute: async () => name,
+        });
+      },
+    );
+    const clientToolSearch = attachClientToolSearchExecutor<TestContext>(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent<TestContext>({
+      name: 'Empty callback replay agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(
+      new RunContext({ ready: false }),
+      'input',
+      agent,
+      2,
+    );
+    const createCall = (
+      id: string,
+      phase: string,
+    ): protocol.ToolSearchCallItem =>
+      ({
+        type: 'tool_search_call',
+        id: `ts_${id}`,
+        status: 'completed',
+        arguments: { phase },
+        providerData: { call_id: id, execution: 'client' },
+      }) as protocol.ToolSearchCallItem;
+    const processed = await processModelResponseAsync(
+      {
+        output: [
+          createCall('call_empty_replay', 'empty'),
+          createCall('call_after_empty_replay', 'after'),
+        ],
+        usage: new Usage(),
+      },
+      agent,
+      [clientToolSearch],
+      [],
+      state,
+      [],
+    );
+    state._generatedItems.push(...processed.newItems);
+    state._lastProcessedResponse = processed;
+
+    const restored = await RunState.fromStringWithContext(
+      agent,
+      state.toString(),
+      new RunContext({ ready: false }),
+      { contextStrategy: 'replace' },
+    );
+
+    expect(execute).toHaveBeenCalledTimes(4);
+    expect(restored.getToolSearchRuntimeTools(agent)[0]?.name).toBe(
+      'after_empty',
+    );
+  });
+
+  it('rejects an empty custom tool-search output when its executor is unavailable', async () => {
+    type TestContext = { ready: boolean };
+    const execute = vi.fn(
+      async ({ runContext }: { runContext: RunContext<TestContext> }) => {
+        runContext.context.ready = true;
+        return [];
+      },
+    );
+    const customToolSearchProviderData = {
+      type: 'tool_search' as const,
+      execution: 'client' as const,
+      parameters: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+    };
+    const clientToolSearch = attachClientToolSearchExecutor<TestContext>(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: customToolSearchProviderData,
+      },
+      execute,
+    );
+    const agent = new Agent<TestContext>({
+      name: 'Empty custom callback restore agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(
+      new RunContext({ ready: false }),
+      'input',
+      agent,
+      2,
+    );
+    const processed = await processModelResponseAsync(
+      {
+        output: [
+          {
+            type: 'tool_search_call',
+            id: 'ts_call_empty_custom_restore',
+            status: 'completed',
+            arguments: {},
+            providerData: {
+              call_id: 'call_empty_custom_restore',
+              execution: 'client',
+            },
+          } as protocol.ToolSearchCallItem,
+        ],
+        usage: new Usage(),
+      },
+      agent,
+      [clientToolSearch],
+      [],
+      state,
+      [],
+    );
+    state._generatedItems.push(...processed.newItems);
+    state._lastProcessedResponse = processed;
+
+    const replacementAgent = new Agent<TestContext>({
+      name: agent.name,
+      tools: [
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: customToolSearchProviderData,
+        },
+      ],
+    });
+    const replacementContext = new RunContext({ ready: false });
+
+    await expect(
+      RunState.fromStringWithContext(
+        replacementAgent,
+        state.toString(),
+        replacementContext,
+        { contextStrategy: 'replace' },
+      ),
+    ).rejects.toThrow(
+      'require toolSearchTool({ execution: "client", execute }) when custom client tool_search parameters are provided',
+    );
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(replacementContext.context.ready).toBe(false);
+  });
+
+  it('restores an empty built-in tool-search output without an executor', async () => {
+    const clientToolSearch = {
+      type: 'hosted_tool' as const,
+      name: 'tool_search',
+      providerData: {
+        type: 'tool_search' as const,
+        execution: 'client' as const,
+      },
+    };
+    const agent = new Agent({
+      name: 'Empty built-in restore agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const callId = 'call_empty_builtin_restore';
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_empty_builtin_restore',
+          status: 'completed',
+          arguments: { paths: [] },
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_empty_builtin_restore',
+          status: 'completed',
+          tools: [],
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(restored.getToolSearchRuntimeTools(agent)).toEqual([]);
+  });
+
+  it('keeps disabled callback results visible to later tool-search callbacks', async () => {
+    type TestContext = { enabled: boolean };
+    const availableToolNames: string[][] = [];
+    const execute = vi.fn(
+      async ({
+        availableTools,
+        toolCall,
+      }: {
+        availableTools: Tool<TestContext>[];
+        toolCall: protocol.ToolSearchCallItem;
+      }) => {
+        availableToolNames.push(availableTools.map((entry) => entry.name));
+        const phase = (toolCall.arguments as { phase?: string }).phase;
+        if (phase === 'disabled') {
+          return tool({
+            name: 'disabled_runtime',
+            description: 'Disabled runtime result.',
+            parameters: z.object({}).strict(),
+            isEnabled: ({ runContext }) =>
+              (runContext.context as TestContext).enabled,
+            execute: async () => 'disabled',
+          });
+        }
+        const sawDisabled = availableTools.some(
+          (entry) => entry.name === 'disabled_runtime',
+        );
+        const name = sawDisabled ? 'after_disabled' : 'wrong';
+        return tool({
+          name,
+          description: 'Result after the disabled callback.',
+          parameters: z.object({}).strict(),
+          execute: async () => name,
+        });
+      },
+    );
+    const clientToolSearch = attachClientToolSearchExecutor<TestContext>(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent<TestContext>({
+      name: 'Disabled callback replay agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(
+      new RunContext({ enabled: false }),
+      'input',
+      agent,
+      2,
+    );
+    const createCall = (
+      id: string,
+      phase: string,
+    ): protocol.ToolSearchCallItem =>
+      ({
+        type: 'tool_search_call',
+        id: `ts_${id}`,
+        status: 'completed',
+        arguments: { phase },
+        providerData: { call_id: id, execution: 'client' },
+      }) as protocol.ToolSearchCallItem;
+    const processed = await processModelResponseAsync(
+      {
+        output: [
+          createCall('call_disabled_replay', 'disabled'),
+          createCall('call_after_disabled_replay', 'after'),
+        ],
+        usage: new Usage(),
+      },
+      agent,
+      [clientToolSearch],
+      [],
+      state,
+      [],
+    );
+    state._generatedItems.push(...processed.newItems);
+    state._lastProcessedResponse = processed;
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(availableToolNames).toEqual([
+      ['tool_search'],
+      ['tool_search', 'disabled_runtime'],
+      ['tool_search'],
+      ['tool_search', 'disabled_runtime'],
+    ]);
+    expect(
+      restored.getToolSearchRuntimeTools(agent).map((entry) => entry.name),
+    ).toEqual(['after_disabled']);
+  });
+
+  it.each([
+    ['an enabled and a disabled result', true],
+    ['two disabled results', false],
+  ] as const)(
+    'rehydrates client tool-search output after filtering %s',
+    async (_description, includeEnabledResult) => {
+      const enabledLookup = tool({
+        name: 'lookup',
+        description: 'Enabled lookup.',
+        parameters: z.object({}).strict(),
+        execute: async () => 'enabled',
+      });
+      const disabledLookup = tool({
+        name: 'lookup',
+        description: 'Disabled lookup.',
+        parameters: z.object({}).strict(),
+        isEnabled: false,
+        execute: async () => 'disabled',
+      });
+      const otherDisabledLookup = tool({
+        name: 'lookup',
+        description: 'Other disabled lookup.',
+        parameters: z.object({}).strict(),
+        isEnabled: false,
+        execute: async () => 'other disabled',
+      });
+      const execute = vi.fn(async () => [
+        includeEnabledResult ? enabledLookup : otherDisabledLookup,
+        disabledLookup,
+      ]);
+      const clientToolSearch = attachClientToolSearchExecutor(
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: { type: 'tool_search', execution: 'client' },
+        },
+        execute,
+      );
+      const agent = new Agent({
+        name: `Filtered duplicate restore ${includeEnabledResult}`,
+        tools: [clientToolSearch],
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      const processed = await processModelResponseAsync(
+        {
+          output: [
+            {
+              type: 'tool_search_call',
+              id: 'ts_call_filtered_duplicate_restore',
+              status: 'completed',
+              arguments: {},
+              providerData: {
+                call_id: 'call_filtered_duplicate_restore',
+                execution: 'client',
+              },
+            } as protocol.ToolSearchCallItem,
+          ],
+          usage: new Usage(),
+        },
+        agent,
+        [clientToolSearch],
+        [],
+        state,
+        [],
+      );
+      state._generatedItems.push(...processed.newItems);
+      state._lastProcessedResponse = processed;
+
+      const restored = await RunState.fromString(agent, state.toString());
+
+      expect(execute).toHaveBeenCalledTimes(2);
+      expect(restored.getToolSearchRuntimeTools(agent)).toEqual(
+        includeEnabledResult ? [enabledLookup] : [],
+      );
+    },
+  );
+
+  it.each([
+    ['one serialized tool', true],
+    ['an empty serialized result', false],
+  ] as const)(
+    'rejects extra enabled callback tools when rehydrating %s',
+    async (_description, includeSerializedLookup) => {
+      const lookup = tool({
+        name: 'lookup',
+        description: 'Serialized lookup.',
+        parameters: z.object({}).strict(),
+        execute: async () => 'lookup',
+      });
+      const extraLookup = tool({
+        name: 'extra_lookup',
+        description: 'Unexpected extra lookup.',
+        parameters: z.object({}).strict(),
+        execute: async () => 'extra',
+      });
+      const execute = vi.fn(async () => [lookup, extraLookup]);
+      const clientToolSearch = attachClientToolSearchExecutor(
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: { type: 'tool_search', execution: 'client' },
+        },
+        execute,
+      );
+      const agent = new Agent({
+        name: `Extra enabled restore ${includeSerializedLookup}`,
+        tools: [clientToolSearch],
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      const callId = 'call_extra_enabled_restore';
+      state._generatedItems.push(
+        new RunToolSearchCallItem(
+          {
+            type: 'tool_search_call',
+            id: 'ts_call_extra_enabled_restore',
+            status: 'completed',
+            arguments: {},
+            providerData: { call_id: callId, execution: 'client' },
+          } as protocol.ToolSearchCallItem,
+          agent,
+        ),
+        new RunToolSearchOutputItem(
+          {
+            type: 'tool_search_output',
+            id: 'ts_output_extra_enabled_restore',
+            status: 'completed',
+            tools: includeSerializedLookup
+              ? [
+                  {
+                    type: 'function',
+                    name: 'lookup',
+                    description: 'Serialized lookup.',
+                    strict: true,
+                    parameters: {
+                      type: 'object',
+                      properties: {},
+                      required: [],
+                      additionalProperties: false,
+                    },
+                  },
+                ]
+              : [],
+            providerData: { call_id: callId, execution: 'client' },
+          } as protocol.ToolSearchOutputItem,
+          agent,
+        ),
+      );
+
+      await expect(
+        RunState.fromString(agent, state.toString()),
+      ).rejects.toThrow(
+        'registered execute callback returned different runtime tools than the serialized state',
+      );
+      expect(execute).toHaveBeenCalledOnce();
+    },
+  );
+
+  it('rejects duplicate configured identities returned during tool-search rehydration', async () => {
+    const configuredTool = tool({
+      name: 'configured',
+      description: 'Configured tool.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'configured',
+    });
+    const runtimeTool = tool({
+      name: 'runtime',
+      description: 'Runtime tool.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'runtime',
+    });
+    const execute = vi.fn(async () => [
+      configuredTool,
+      configuredTool,
+      runtimeTool,
+    ]);
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Configured duplicate restore agent',
+      tools: [configuredTool, clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const callId = 'call_configured_duplicate_restore';
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_configured_duplicate_restore',
+          status: 'completed',
+          arguments: { query: 'runtime' },
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_configured_duplicate_restore',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'configured',
+              description: 'Configured tool.',
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+            {
+              type: 'function',
+              name: 'runtime',
+              description: 'Runtime tool.',
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+          ],
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+
+    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
+      'Client tool_search execute() returned multiple tools with the same routed identity.',
+    );
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['accepts the final replacement', true],
+    ['rejects a stale first result', false],
+  ] as const)(
+    '%s when rehydrating repeated client tool_search outputs',
+    async (_description, returnFinalReplacement) => {
+      const firstLookup = tool({
+        name: 'first_lookup',
+        description: 'First lookup result.',
+        parameters: z.object({}).strict(),
+        execute: async () => 'first',
+      });
+      const latestLookup = tool({
+        name: 'latest_lookup',
+        description: 'Latest lookup result.',
+        parameters: z.object({}).strict(),
+        execute: async () => 'latest',
+      });
+      const execute = vi.fn(async () =>
+        returnFinalReplacement ? latestLookup : firstLookup,
+      );
+      const clientToolSearch = attachClientToolSearchExecutor(
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: {
+            type: 'tool_search',
+            execution: 'client',
+          },
+        },
+        execute,
+      );
+      const agent = new Agent({
+        name: 'Replacement restore agent',
+        tools: [clientToolSearch],
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      const callId = 'call_replacement_restore';
+      state._generatedItems.push(
+        new RunToolSearchCallItem(
+          {
+            type: 'tool_search_call',
+            id: 'ts_call_replacement_restore',
+            status: 'completed',
+            arguments: { paths: [] },
+            providerData: { call_id: callId, execution: 'client' },
+          } as protocol.ToolSearchCallItem,
+          agent,
+        ),
+        new RunToolSearchOutputItem(
+          {
+            type: 'tool_search_output',
+            id: 'ts_output_replacement_first',
+            status: 'completed',
+            tools: [
+              {
+                type: 'function',
+                name: 'first_lookup',
+                description: 'First lookup result.',
+                strict: true,
+                parameters: {
+                  type: 'object',
+                  properties: {},
+                  required: [],
+                  additionalProperties: false,
+                },
+              },
+            ],
+            providerData: { call_id: callId, execution: 'client' },
+          } as protocol.ToolSearchOutputItem,
+          agent,
+        ),
+        new RunToolSearchOutputItem(
+          {
+            type: 'tool_search_output',
+            id: 'ts_output_replacement_latest',
+            status: 'completed',
+            tools: [
+              {
+                type: 'function',
+                name: 'latest_lookup',
+                description: 'Latest lookup result.',
+                strict: true,
+                parameters: {
+                  type: 'object',
+                  properties: {},
+                  required: [],
+                  additionalProperties: false,
+                },
+              },
+            ],
+            providerData: { call_id: callId, execution: 'client' },
+          } as protocol.ToolSearchOutputItem,
+          agent,
+        ),
+      );
+
+      const restoredPromise = RunState.fromString(agent, state.toString());
+      if (returnFinalReplacement) {
+        const restored = await restoredPromise;
+        expect(restored.getToolSearchRuntimeTools(agent)).toEqual([
+          latestLookup,
+        ]);
+      } else {
+        await expect(restoredPromise).rejects.toThrow(
+          'RunState cannot resume custom client tool_search because the registered execute callback returned different runtime tools than the serialized state.',
+        );
+      }
+      expect(execute).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('redacts runtime tool identities from RunState callback mismatches', async () => {
+    const expectedName = 'secret_expected_lookup';
+    const actualName = 'secret_actual_lookup';
+    const actualLookup = tool({
+      name: actualName,
+      description: 'Actual lookup.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'actual',
+    });
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      async () => actualLookup,
+    );
+    const agent = new Agent({
+      name: 'Redacted mismatch agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const callId = 'call_redacted_mismatch';
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_redacted_mismatch',
+          status: 'completed',
+          arguments: {},
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_redacted_mismatch',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: expectedName,
+              description: 'Expected lookup.',
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+          ],
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+    const redaction = vi
+      .spyOn(logger, 'dontLogToolData', 'get')
+      .mockReturnValue(true);
+
+    try {
+      const restored = RunState.fromString(agent, state.toString());
+      await expect(restored).rejects.toThrow(
+        'RunState cannot resume custom client tool_search because the registered execute callback returned different runtime tools than the serialized state.',
+      );
+      await expect(restored).rejects.not.toThrow(expectedName);
+      await expect(restored).rejects.not.toThrow(actualName);
+    } finally {
+      redaction.mockRestore();
+    }
+  });
+
+  it('redacts call and agent identities from missing tool-search executors', async () => {
+    const callId = 'secret_missing_executor_call';
+    const agent = new Agent({ name: 'Secret missing executor agent' });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_missing_executor',
+          status: 'completed',
+          arguments: {},
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_missing_executor',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'secret_runtime_lookup',
+              description: 'Secret runtime lookup.',
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+          ],
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+    const redaction = vi
+      .spyOn(logger, 'dontLogToolData', 'get')
+      .mockReturnValue(true);
+
+    try {
+      const restored = RunState.fromString(agent, state.toString());
+      await expect(restored).rejects.toThrow(
+        'RunState cannot resume custom client tool_search because the agent no longer provides toolSearchTool({ execution: "client", execute }).',
+      );
+      await expect(restored).rejects.not.toThrow(callId);
+      await expect(restored).rejects.not.toThrow(agent.name);
+    } finally {
+      redaction.mockRestore();
+    }
+  });
+
+  it('rehydrates same-name runtime tools from distinct function categories', async () => {
+    const bareLookup = tool({
+      name: 'lookup',
+      description: 'Immediate lookup.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'bare',
+    });
+    const deferredLookup = tool({
+      name: 'lookup',
+      description: 'Deferred lookup.',
+      parameters: z.object({}).strict(),
+      deferLoading: true,
+      execute: async () => 'deferred',
+    });
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: {
+          type: 'tool_search',
+          execution: 'client',
+        },
+      },
+      async () => [bareLookup, deferredLookup],
+    );
+    const agent = new Agent({
+      name: 'Category-aware restore agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const callId = 'call_tool_search_categories';
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_categories',
+          status: 'completed',
+          arguments: { paths: [] },
+          providerData: {
+            call_id: callId,
+            execution: 'client',
+          },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_categories',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'lookup',
+              description: 'Immediate lookup.',
+              strict: true,
+              deferLoading: false,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+            {
+              type: 'function',
+              name: 'lookup',
+              description: 'Deferred lookup.',
+              strict: true,
+              deferLoading: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+          ],
+          providerData: {
+            call_id: callId,
+            execution: 'client',
+          },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    expect(restored.getToolSearchRuntimeTools(agent)).toEqual([
+      bareLookup,
+      deferredLookup,
+    ]);
+  });
+
+  it('rejects a rehydrated bare runtime function that conflicts with an enabled handoff', async () => {
+    const runtimeLookup = tool({
+      name: 'lookup',
+      description: 'Look up a record.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'runtime',
+    });
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: {
+          type: 'tool_search',
+          execution: 'client',
+        },
+      },
+      async () => runtimeLookup,
+    );
+    const target = new Agent({ name: 'LookupTarget' });
+    const agent = new Agent({
+      name: 'RuntimeHandoffCollision',
+      tools: [clientToolSearch],
+      handoffs: [handoff(target, { toolNameOverride: 'lookup' })],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const callId = 'call_runtime_handoff_collision';
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_runtime_handoff_collision',
+          status: 'completed',
+          arguments: { paths: [] },
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_runtime_handoff_collision',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'lookup',
+              description: 'Look up a record.',
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+          ],
+          providerData: { call_id: callId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+
+    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
+      'Client tool_search execute() returned a bare function tool that conflicts with an available handoff. Assign a unique tool name or use a namespace.',
+    );
+  });
+
+  it.each([false, true])(
+    'rejects duplicate routed identities returned during tool-search rehydration (same object: %s)',
+    async (repeatSameObject) => {
+      const first = tool({
+        name: 'lookup',
+        description: 'First deferred lookup.',
+        parameters: z.object({}).strict(),
+        deferLoading: true,
+        execute: async () => 'first',
+      });
+      const second = tool({
+        name: 'lookup',
+        description: 'Second deferred lookup.',
+        parameters: z.object({}).strict(),
+        deferLoading: true,
+        execute: async () => 'second',
+      });
+      const clientToolSearch = attachClientToolSearchExecutor(
+        {
+          type: 'hosted_tool',
+          name: 'tool_search',
+          providerData: {
+            type: 'tool_search',
+            execution: 'client',
+          },
+        },
+        async () => (repeatSameObject ? [first, first] : [first, second]),
+      );
+      const agent = new Agent({
+        name: 'Duplicate restore agent',
+        tools: [clientToolSearch],
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      const callId = 'call_duplicate_restore';
+      state._generatedItems.push(
+        new RunToolSearchCallItem(
+          {
+            type: 'tool_search_call',
+            id: 'ts_call_duplicate_restore',
+            status: 'completed',
+            arguments: { paths: [] },
+            providerData: { call_id: callId, execution: 'client' },
+          } as protocol.ToolSearchCallItem,
+          agent,
+        ),
+        new RunToolSearchOutputItem(
+          {
+            type: 'tool_search_output',
+            id: 'ts_output_duplicate_restore',
+            status: 'completed',
+            tools: [
+              {
+                type: 'function',
+                name: 'lookup',
+                description: 'Deferred lookup.',
+                strict: true,
+                deferLoading: true,
+                parameters: {
+                  type: 'object',
+                  properties: {},
+                  required: [],
+                  additionalProperties: false,
+                },
+              },
+            ],
+            providerData: { call_id: callId, execution: 'client' },
+          } as protocol.ToolSearchOutputItem,
+          agent,
+        ),
+      );
+
+      await expect(
+        RunState.fromString(agent, state.toString()),
+      ).rejects.toThrow(
+        'Client tool_search execute() returned multiple tools with the same routed identity.',
+      );
+    },
+  );
+
+  it('rejects duplicate routed identities in serialized tool-search output before rehydration', async () => {
+    const validRuntimeLookup = tool({
+      name: 'valid_lookup',
+      description: 'Valid lookup.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'valid',
+    });
+    const duplicateRuntimeLookup = tool({
+      name: 'lookup',
+      description: 'Deferred lookup.',
+      parameters: z.object({}).strict(),
+      deferLoading: true,
+      execute: async () => 'lookup',
+    });
+    const execute = vi.fn(async () => validRuntimeLookup);
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: {
+          type: 'tool_search',
+          execution: 'client',
+        },
+      },
+      execute,
+    );
+    const agent = new Agent({
+      name: 'Duplicate serialized restore agent',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const validCallId = 'call_valid_serialized_restore';
+    const duplicateCallId = 'call_duplicate_serialized_restore';
+    const validSerializedTool = {
+      type: 'function',
+      name: 'valid_lookup',
+      description: 'Valid lookup.',
+      strict: true,
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      },
+    } as const;
+    const serializedTool = {
+      type: 'function',
+      name: duplicateRuntimeLookup.name,
+      description: duplicateRuntimeLookup.description,
+      strict: true,
+      deferLoading: true,
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      },
+    } as const;
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_valid_serialized_restore',
+          status: 'completed',
+          arguments: { query: 'valid' },
+          providerData: { call_id: validCallId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_valid_serialized_restore',
+          status: 'completed',
+          tools: [validSerializedTool],
+          providerData: { call_id: validCallId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_duplicate_serialized_restore',
+          status: 'completed',
+          arguments: { query: 'duplicate' },
+          providerData: { call_id: duplicateCallId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_duplicate_serialized_restore',
+          status: 'completed',
+          tools: [serializedTool, serializedTool],
+          providerData: { call_id: duplicateCallId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+
+    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
+      'Serialized client tool_search output contains multiple tools with the same routed identity. Assign unique tool names or namespaces before resuming RunState.',
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   it('accepts schema version 1.7 payloads when non-item context data mentions tool_search types', async () => {
     const context = new RunContext({
       custom: {
@@ -2726,6 +8089,12 @@ describe('RunState', () => {
 
     const serialized = JSON.parse(state.toString());
     serialized.$schemaVersion = '1.6';
+    const approvalKey = getFunctionToolStateKeyForCall(rawItem)!;
+    const ownerApprovals = serialized.context.functionApprovals.find(
+      (entry: any) => entry.agentIdentity === agent.name,
+    ).approvals;
+    serialized.context.approvals.toolLegacy = ownerApprovals[approvalKey];
+    delete serialized.context.functionApprovals;
     delete serialized.context.approvals.toolLegacy.messages;
 
     const restored = await RunState.fromString(
@@ -2815,8 +8184,8 @@ describe('RunState', () => {
       state._context.isToolApproved({ toolName: 'toolZ', callId: 'cid789' }),
     ).toBe(false);
     const approvals = state._context.toJSON().approvals;
-    expect(approvals['toolZ'].approved).toBe(false);
-    expect(approvals['toolZ'].rejected).toBe(true);
+    expect(approvals.toolZ.approved).toBe(false);
+    expect(approvals.toolZ.rejected).toBe(true);
   });
 
   it('alwaysReject with message stores call-specific and sticky rejection messages', () => {
@@ -2847,11 +8216,11 @@ describe('RunState', () => {
       'Blocked by policy',
     );
     const approvals = state._context.toJSON().approvals;
-    expect(approvals['toolAR'].rejected).toBe(true);
-    expect(approvals['toolAR'].messages).toEqual({
+    expect(approvals.toolAR.rejected).toBe(true);
+    expect(approvals.toolAR.messages).toEqual({
       'ar-1': 'Blocked by policy',
     });
-    expect(approvals['toolAR'].stickyRejectMessage).toBe('Blocked by policy');
+    expect(approvals.toolAR.stickyRejectMessage).toBe('Blocked by policy');
   });
 
   it('alwaysReject with empty message preserves the empty string', () => {
@@ -2922,10 +8291,11 @@ describe('RunState', () => {
     const approvalItem = new ToolApprovalItem(rawItem, agent);
 
     state.approve(approvalItem);
+    const approvalKey = getFunctionToolStateKeyForCall(rawItem)!;
 
     expect(
       state._context.isToolApproved({
-        toolName: 'crm.lookup_account',
+        toolName: approvalKey,
         callId: 'cid_namespace',
       }),
     ).toBe(true);
@@ -2956,16 +8326,17 @@ describe('RunState', () => {
     const restored = await RunState.fromString(agent, state.toString());
     const [approvalItem] = restored.getInterruptions();
     restored.approve(approvalItem);
+    const approvalKey = getFunctionToolStateKeyForCall(rawItem)!;
 
     expect(
       restored._context.isToolApproved({
-        toolName: 'get_shipping_eta',
+        toolName: approvalKey,
         callId: 'cid_shipping_eta',
       }),
     ).toBe(true);
     expect(
       restored._context.isToolApproved({
-        toolName: 'get_shipping_eta.get_shipping_eta',
+        toolName: 'get_shipping_eta',
         callId: 'cid_shipping_eta',
       }),
     ).toBeUndefined();
@@ -3006,16 +8377,17 @@ describe('RunState', () => {
     const restored = await RunState.fromString(agent, state.toString());
     const [approvalItem] = restored.getInterruptions();
     restored.approve(approvalItem);
+    const approvalKey = getFunctionToolStateKeyForCall(rawItem)!;
 
     expect(
       restored._context.isToolApproved({
-        toolName: 'get_shipping_eta',
+        toolName: approvalKey,
         callId: 'cid_shipping_eta',
       }),
     ).toBe(true);
     expect(
       restored._context.isToolApproved({
-        toolName: 'get_shipping_eta.get_shipping_eta',
+        toolName: 'get_shipping_eta',
         callId: 'cid_shipping_eta',
       }),
     ).toBeUndefined();
@@ -3413,6 +8785,220 @@ describe('deserialize helpers', () => {
         ],
       },
     ]);
+  });
+
+  it('restores the enabled handoff winner instead of a later disabled duplicate', async () => {
+    const enabledTarget = new Agent({
+      name: 'SharedTarget',
+      instructions: 'enabled target',
+    });
+    const disabledTarget = new Agent({
+      name: 'SharedTarget',
+      instructions: 'disabled target',
+    });
+    const enabledHandoff = handoff(enabledTarget, {
+      toolNameOverride: 'transfer',
+    });
+    const disabledHandoff = handoff(disabledTarget, {
+      toolNameOverride: 'transfer',
+      isEnabled: false,
+    });
+    const agent = new Agent({
+      name: 'HandoffWinnerRestore',
+      handoffs: [enabledHandoff, disabledHandoff],
+    });
+    const state = new RunState(new RunContext(), '', agent, 1);
+    const toolCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_handoff_winner',
+      callId: 'call_handoff_winner',
+      name: 'transfer',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [],
+      handoffs: [{ toolCall, handoff: enabledHandoff }],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['transfer'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+
+    const serialized = state.toJSON() as any;
+    expect(
+      serialized.lastProcessedResponse.handoffs[0].targetAgent.identity,
+    ).toEqual(expect.any(String));
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+
+    expect(restored._lastProcessedResponse?.handoffs[0]?.handoff).toBe(
+      enabledHandoff,
+    );
+
+    delete serialized.lastProcessedResponse.handoffs[0].targetAgent;
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow(
+      'Run state handoff is missing its required target agent identity.',
+    );
+
+    serialized.$schemaVersion = '1.15';
+    const restoredLegacy = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+    expect(restoredLegacy._lastProcessedResponse?.handoffs[0]?.handoff).toBe(
+      enabledHandoff,
+    );
+  });
+
+  it('rejects a schema 1.16 handoff without exact identity instead of rebinding a same-name target', async () => {
+    const executeToolSearch = vi.fn(async () => []);
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      executeToolSearch,
+    );
+    const firstTarget = new Agent({ name: 'SharedTarget' });
+    const secondTarget = new Agent({ name: 'SharedTarget' });
+    const firstHandoff = handoff(firstTarget, {
+      toolNameOverride: 'transfer',
+    });
+    const secondHandoff = handoff(secondTarget, {
+      toolNameOverride: 'transfer',
+    });
+    const agent = new Agent({
+      name: 'AmbiguousHandoffRestore',
+      tools: [clientToolSearch],
+      handoffs: [firstHandoff, secondHandoff],
+    });
+    const state = new RunState(new RunContext(), '', agent, 1);
+    const toolSearchCallId = 'call_ambiguous_handoff_search';
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_ambiguous_handoff_search',
+          status: 'completed',
+          arguments: { paths: [] },
+          providerData: {
+            call_id: toolSearchCallId,
+            execution: 'client',
+          },
+        } as protocol.ToolSearchCallItem,
+        agent,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_ambiguous_handoff_search',
+          status: 'completed',
+          tools: [],
+          providerData: {
+            call_id: toolSearchCallId,
+            execution: 'client',
+          },
+        } as protocol.ToolSearchOutputItem,
+        agent,
+      ),
+    );
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [],
+      handoffs: [
+        {
+          toolCall: {
+            type: 'function_call',
+            id: 'fc_ambiguous_handoff',
+            callId: 'call_ambiguous_handoff',
+            name: 'transfer',
+            status: 'completed',
+            arguments: '{}',
+          },
+          handoff: firstHandoff,
+        },
+      ],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['transfer'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+
+    const serialized = state.toJSON() as any;
+    allowConsole(['warn']);
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow('Handoff transfer not found');
+    expect(executeToolSearch).not.toHaveBeenCalled();
+
+    const missingTarget = JSON.parse(JSON.stringify(serialized));
+    delete missingTarget.lastProcessedResponse.handoffs[0].targetAgent;
+
+    await expect(
+      RunState.fromString(agent, JSON.stringify(missingTarget)),
+    ).rejects.toThrow(
+      'Run state handoff is missing its required target agent identity.',
+    );
+    expect(executeToolSearch).not.toHaveBeenCalled();
+
+    serialized.lastProcessedResponse.handoffs[0].targetAgent.identity =
+      'missing-target-identity';
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow('Agent identity missing-target-identity not found');
+    expect(executeToolSearch).not.toHaveBeenCalled();
+  });
+
+  it('rejects a handoff disabled by a replacement context during restore', async () => {
+    const target = new Agent<{ enabled: boolean }>({ name: 'DynamicTarget' });
+    const dynamicHandoff = handoff(target, {
+      toolNameOverride: 'transfer',
+      isEnabled: ({ runContext }) => runContext.context.enabled,
+    });
+    const agent = new Agent<{ enabled: boolean }>({
+      name: 'DynamicHandoffRestore',
+      handoffs: [dynamicHandoff],
+    });
+    const state = new RunState(new RunContext({ enabled: true }), '', agent, 1);
+    const toolCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_dynamic_handoff',
+      callId: 'call_dynamic_handoff',
+      name: 'transfer',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [],
+      handoffs: [{ toolCall, handoff: dynamicHandoff }],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['transfer'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+
+    await expect(
+      RunState.fromStringWithContext(
+        agent,
+        state.toString(),
+        new RunContext({ enabled: false }),
+        { contextStrategy: 'replace' },
+      ),
+    ).rejects.toThrow('Handoff transfer not found');
   });
 
   it('deserializeProcessedResponse restores namespaced function tools', async () => {
@@ -3969,6 +9555,143 @@ describe('deserialize helpers', () => {
       type: 'program',
       callerId: 'prog_approval_1',
     });
+  });
+
+  it('uses an explicit prepared tool snapshot without adding stored runtime tools', async () => {
+    const runtimeLookup = tool({
+      name: 'lookup_runtime',
+      description: 'Look up a runtime record.',
+      parameters: z.object({}),
+      execute: async () => 'runtime',
+    });
+    const agent = new Agent({ name: 'ExplicitPreparedTools' });
+    const state = new RunState(new RunContext(), '', agent, 1);
+    const toolCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_runtime_explicit',
+      callId: 'call_runtime_explicit',
+      name: 'lookup_runtime',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state.recordToolSearchRuntimeTools(
+      agent,
+      {
+        type: 'tool_search_output',
+        id: 'ts_output_runtime_explicit',
+        status: 'completed',
+        tools: [],
+      } as protocol.ToolSearchOutputItem,
+      [runtimeLookup],
+    );
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall, tool: runtimeLookup as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['lookup_runtime'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+
+    await expect(
+      rehydrateProcessedResponseTools(agent, state, []),
+    ).rejects.toThrow('Tool lookup_runtime not found');
+  });
+
+  it('rejects resumed runtime function tools when isEnabled is false in replacement context', async () => {
+    const lookupParams = z.object({});
+    const runtimeLookup = tool<typeof lookupParams, { enabled: boolean }>({
+      name: 'lookup_runtime',
+      description: 'Look up a runtime record.',
+      parameters: lookupParams,
+      isEnabled: async ({ runContext }) => runContext.context.enabled,
+      execute: async () => 'runtime',
+    });
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: {
+          type: 'tool_search',
+          execution: 'client',
+        },
+      },
+      async () => runtimeLookup,
+    );
+    const agent = new Agent<{ enabled: boolean }>({
+      name: 'RuntimeEnabledRestore',
+      tools: [clientToolSearch],
+    });
+    const state = new RunState(new RunContext({ enabled: true }), '', agent, 1);
+    const searchCallId = 'call_runtime_enabled_restore';
+    state._generatedItems.push(
+      new RunToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          id: 'ts_call_runtime_enabled_restore',
+          status: 'completed',
+          arguments: { paths: [] },
+          providerData: { call_id: searchCallId, execution: 'client' },
+        } as protocol.ToolSearchCallItem,
+        agent as any,
+      ),
+      new RunToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          id: 'ts_output_runtime_enabled_restore',
+          status: 'completed',
+          tools: [
+            {
+              type: 'function',
+              name: 'lookup_runtime',
+              description: 'Look up a runtime record.',
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+              },
+            },
+          ],
+          providerData: { call_id: searchCallId, execution: 'client' },
+        } as protocol.ToolSearchOutputItem,
+        agent as any,
+      ),
+    );
+    const toolCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_runtime_enabled_restore',
+      callId: 'call_lookup_runtime',
+      name: 'lookup_runtime',
+      status: 'completed',
+      arguments: '{}',
+    };
+    state._lastProcessedResponse = {
+      newItems: [],
+      functions: [{ toolCall, tool: runtimeLookup as any }],
+      handoffs: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: ['lookup_runtime'],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+
+    await expect(
+      RunState.fromStringWithContext(
+        agent,
+        state.toString(),
+        new RunContext({ enabled: false }),
+        { contextStrategy: 'replace' },
+      ),
+    ).rejects.toThrow(
+      'registered execute callback returned different runtime tools than the serialized state',
+    );
   });
 
   it('rejects resumed function tools when isEnabled is false in replacement context', async () => {

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -1675,7 +1675,165 @@ describe('RunState', () => {
       ]);
     });
 
-    it('ignores later handoffs when anchoring historical legacy compaction', async () => {
+    it('allocates identical omitted handoffs by occurrence', async () => {
+      const target = new Agent({ name: 'RepeatedLegacyHandoffTarget' });
+      const repeatedHandoff = handoff(target, {
+        toolNameOverride: 'transfer_repeated',
+      });
+      const agent = new Agent({
+        name: 'RepeatedLegacyHandoffCompactionAgent',
+        handoffs: [repeatedHandoff],
+      });
+      const repeatedCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: repeatedHandoff.toolName,
+        callId: 'call_repeated_legacy_handoff',
+        arguments: '{}',
+        status: 'completed',
+      };
+      const response = {
+        usage: new Usage(),
+        output: [repeatedCall, compactionItem, repeatedCall],
+        responseId: 'response-repeated-legacy-handoffs',
+      };
+      const processed = processModelResponse(
+        response,
+        agent,
+        [],
+        [repeatedHandoff],
+      );
+      const legacyItems = processed.newItems.filter(
+        (item) => !(item instanceof RunCompactionItem),
+      );
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._modelResponses = [response];
+      state._lastTurnResponse = response;
+      state._generatedItems = legacyItems;
+      state._lastProcessedResponse = { ...processed, newItems: legacyItems };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._generatedItems.map((item) => item.type)).toEqual([
+        'handoff_call_item',
+        'compaction_item',
+      ]);
+    });
+
+    it('rejects a missing first wrapper for identical legacy handoffs', async () => {
+      const target = new Agent({ name: 'MissingRepeatedHandoffTarget' });
+      const repeatedHandoff = handoff(target, {
+        toolNameOverride: 'transfer_missing_repeated',
+      });
+      const agent = new Agent({
+        name: 'MissingRepeatedHandoffCompactionAgent',
+        handoffs: [repeatedHandoff],
+      });
+      const repeatedCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: repeatedHandoff.toolName,
+        callId: 'call_missing_repeated_handoff',
+        arguments: '{}',
+        status: 'completed',
+      };
+      const response = {
+        usage: new Usage(),
+        output: [compactionItem, repeatedCall, repeatedCall],
+        responseId: 'response-missing-repeated-handoffs',
+      };
+      const processed = processModelResponse(
+        response,
+        agent,
+        [],
+        [repeatedHandoff],
+      );
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._modelResponses = [response];
+      state._lastTurnResponse = response;
+      state._generatedItems = [];
+      state._lastProcessedResponse = { ...processed, newItems: [] };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow('provider order is ambiguous');
+    });
+
+    it('allocates normalized legacy handoff key collisions by occurrence', async () => {
+      const target = new Agent({ name: 'NormalizedLegacyHandoffTarget' });
+      const repeatedHandoff = handoff(target, {
+        toolNameOverride: 'transfer_normalized',
+      });
+      const agent = new Agent({
+        name: 'NormalizedLegacyHandoffCompactionAgent',
+        handoffs: [repeatedHandoff],
+      });
+      const originalCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: repeatedHandoff.toolName,
+        callId: 'call_normalized_legacy_handoff',
+        arguments: '{}',
+        status: 'completed',
+      };
+      const flattenedCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: 'transfer.normalized',
+        callId: 'call_normalized_legacy_handoff',
+        arguments: '{}',
+        status: 'completed',
+      };
+      const namespacedCall: protocol.FunctionCallItem = {
+        ...flattenedCall,
+        name: 'normalized',
+        namespace: 'transfer',
+      };
+      const response = {
+        usage: new Usage(),
+        output: [originalCall, compactionItem, originalCall],
+        responseId: 'response-normalized-legacy-handoffs',
+      };
+      const processed = processModelResponse(
+        response,
+        agent,
+        [],
+        [repeatedHandoff],
+      );
+      const legacyItems = processed.newItems.filter(
+        (item) => !(item instanceof RunCompactionItem),
+      );
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._modelResponses = [response];
+      state._lastTurnResponse = response;
+      state._generatedItems = legacyItems;
+      state._lastProcessedResponse = { ...processed, newItems: legacyItems };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+      serialized.modelResponses[0].output[0] = flattenedCall;
+      serialized.modelResponses[0].output[2] = namespacedCall;
+      serialized.lastModelResponse.output[0] = flattenedCall;
+      serialized.lastModelResponse.output[2] = namespacedCall;
+      serialized.generatedItems[0].rawItem = flattenedCall;
+      serialized.lastProcessedResponse.newItems[0].rawItem = flattenedCall;
+      serialized.lastProcessedResponse.handoffs[0].toolCall = flattenedCall;
+      serialized.lastProcessedResponse.handoffs[1].toolCall = namespacedCall;
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._generatedItems.map((item) => item.type)).toEqual([
+        'handoff_call_item',
+        'compaction_item',
+      ]);
+    });
+
+    it('rejects historical omitted handoffs that cannot be proven from the latest processed response', async () => {
       const firstTarget = new Agent({ name: 'FirstHistoricalHandoffTarget' });
       const secondTarget = new Agent({ name: 'SecondHistoricalHandoffTarget' });
       const firstHandoff = handoff(firstTarget, {
@@ -1738,17 +1896,121 @@ describe('RunState', () => {
       const serialized = state.toJSON() as any;
       serialized.$schemaVersion = '1.15';
 
-      const restored = await RunState.fromString(
-        agent,
-        JSON.stringify(serialized),
-      );
-
-      expect(restored._generatedItems.map((item) => item.type)).toEqual([
-        'handoff_call_item',
-        'compaction_item',
-        'message_output_item',
-      ]);
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow('provider order is ambiguous');
     });
+
+    it.each(['latest', 'historical', 'intermediate'] as const)(
+      'rejects a missing second normal function wrapper in a %s response boundary',
+      async (position) => {
+        const agent = new Agent({ name: `MissingFunctionWrapper-${position}` });
+        const firstCall: protocol.FunctionCallItem = {
+          type: 'function_call',
+          name: 'first_normal_tool',
+          callId: `call_first_${position}`,
+          arguments: '{}',
+        };
+        const secondCall: protocol.FunctionCallItem = {
+          type: 'function_call',
+          name: 'second_normal_tool',
+          callId: `call_second_${position}`,
+          arguments: '{}',
+        };
+        const latestMessage: protocol.AssistantMessageItem = {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'latest response' }],
+        };
+        const firstCallItem = new RunToolCallItem(firstCall, agent);
+        const latestMessageItem = new RunMessageOutputItem(
+          latestMessage,
+          agent,
+        );
+        const responseWithMissingWrapper = {
+          usage: new Usage(),
+          output: [firstCall, compactionItem, secondCall],
+          responseId: `response-missing-function-${position}`,
+        };
+        const latestResponse = {
+          usage: new Usage(),
+          output: [latestMessage],
+          responseId: `response-latest-after-missing-function-${position}`,
+        };
+        const state = new RunState(new RunContext(), 'input', agent, 3);
+
+        if (position === 'latest') {
+          state._modelResponses = [responseWithMissingWrapper];
+          state._lastTurnResponse = responseWithMissingWrapper;
+          state._generatedItems = [firstCallItem];
+          state._lastProcessedResponse = {
+            newItems: [firstCallItem],
+            handoffs: [],
+            functions: [],
+            functionToolsNotFound: [],
+            computerActions: [],
+            shellActions: [],
+            applyPatchActions: [],
+            mcpApprovalRequests: [],
+            toolsUsed: [],
+            hasToolsOrApprovalsToRun: () => false,
+          };
+        } else if (position === 'historical') {
+          state._modelResponses = [responseWithMissingWrapper, latestResponse];
+          state._lastTurnResponse = latestResponse;
+          state._generatedItems = [firstCallItem, latestMessageItem];
+          state._lastProcessedResponse = {
+            newItems: [latestMessageItem],
+            handoffs: [],
+            functions: [],
+            functionToolsNotFound: [],
+            computerActions: [],
+            shellActions: [],
+            applyPatchActions: [],
+            mcpApprovalRequests: [],
+            toolsUsed: [],
+            hasToolsOrApprovalsToRun: () => false,
+          };
+        } else {
+          const compactionResponse = {
+            usage: new Usage(),
+            output: [compactionItem],
+            responseId: 'response-before-missing-function-boundary',
+          };
+          const intermediateResponse = {
+            ...responseWithMissingWrapper,
+            output: [firstCall, secondCall],
+          };
+          state._modelResponses = [
+            compactionResponse,
+            intermediateResponse,
+            latestResponse,
+          ];
+          state._lastTurnResponse = latestResponse;
+          state._generatedItems = [firstCallItem, latestMessageItem];
+          state._lastProcessedResponse = {
+            newItems: [latestMessageItem],
+            handoffs: [],
+            functions: [],
+            functionToolsNotFound: [],
+            computerActions: [],
+            shellActions: [],
+            applyPatchActions: [],
+            mcpApprovalRequests: [],
+            toolsUsed: [],
+            hasToolsOrApprovalsToRun: () => false,
+          };
+        }
+
+        const serialized = state.toJSON() as any;
+        serialized.$schemaVersion = '1.15';
+
+        await expect(
+          RunState.fromString(agent, JSON.stringify(serialized)),
+        ).rejects.toThrow('provider order is ambiguous');
+      },
+    );
 
     it('rehydrates a legacy interrupted response in provider order', async () => {
       const approvalTool = tool({
@@ -2168,6 +2430,360 @@ describe('RunState', () => {
         agent,
       );
     });
+
+    it('rehydrates a compaction-only response across multiple later responses', async () => {
+      const automaticTool = tool({
+        name: 'automatic_after_compaction_only',
+        description: 'Automatically executed after compaction.',
+        parameters: z.object({}),
+        execute: async () => 'automatic result',
+      });
+      const approvalTool = tool({
+        name: 'approval_after_multiple_responses',
+        description: 'Requires approval after the automatic turn.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'approved result',
+      });
+      const agent = new Agent({
+        name: 'MultipleResponsesAfterCompactionAgent',
+        tools: [automaticTool, approvalTool],
+      });
+      const automaticCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: automaticTool.name,
+        callId: 'call_after_compaction_only',
+        arguments: '{}',
+        status: 'completed',
+      };
+      const automaticResult: protocol.FunctionCallResultItem = {
+        type: 'function_call_result',
+        name: automaticTool.name,
+        callId: automaticCall.callId,
+        output: 'automatic result',
+        status: 'completed',
+      };
+      const approvalCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: approvalTool.name,
+        callId: 'call_approval_after_multiple_responses',
+        arguments: '{}',
+        status: 'completed',
+      };
+      const compactionResponse = {
+        usage: new Usage(),
+        output: [compactionItem],
+        responseId: 'response-compaction-only-before-multiple',
+      };
+      const automaticResponse = {
+        usage: new Usage(),
+        output: [automaticCall],
+        responseId: 'response-automatic-after-compaction-only',
+      };
+      const approvalResponse = {
+        usage: new Usage(),
+        output: [approvalCall],
+        responseId: 'response-approval-after-multiple',
+      };
+      const automaticCallItem = new RunToolCallItem(automaticCall, agent);
+      const automaticResultItem = new RunToolCallOutputItem(
+        automaticResult,
+        agent,
+        'automatic result',
+      );
+      const approvalCallItem = new RunToolCallItem(approvalCall, agent);
+      const approvalItem = new ToolApprovalItem(approvalCall, agent);
+      const latestProcessed = {
+        newItems: [approvalCallItem, approvalItem],
+        handoffs: [],
+        functions: [{ toolCall: approvalCall, tool: approvalTool as any }],
+        functionToolsNotFound: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: [approvalTool.name],
+        hasToolsOrApprovalsToRun: () => true,
+      };
+      const state = new RunState(new RunContext(), 'old input', agent, 3);
+      state._modelResponses = [
+        compactionResponse,
+        automaticResponse,
+        approvalResponse,
+      ];
+      state._lastTurnResponse = approvalResponse;
+      state._generatedItems = [
+        automaticCallItem,
+        automaticResultItem,
+        ...latestProcessed.newItems,
+      ];
+      state._lastProcessedResponse = latestProcessed;
+      state._currentStep = {
+        type: 'next_step_interruption',
+        data: { interruptions: [approvalItem] },
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._generatedItems.map((item) => item.type)).toEqual([
+        'compaction_item',
+        'tool_call_item',
+        'tool_call_output_item',
+        'tool_call_item',
+        'tool_approval_item',
+      ]);
+      expect(restored.history[0]).toEqual(compactionItem);
+      expect(restored.getInterruptions()).toHaveLength(1);
+      expect((restored._generatedItems[0] as RunCompactionItem).agent).toBe(
+        agent,
+      );
+    });
+
+    it('rejects a later response wrapper reused as a historical compaction anchor', async () => {
+      const agent = new Agent({ name: 'ReusedHistoricalAnchorAgent' });
+      const duplicatedMessage: protocol.AssistantMessageItem = {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'duplicated response' }],
+      };
+      const compactionResponse = {
+        usage: new Usage(),
+        output: [compactionItem, duplicatedMessage],
+        responseId: 'response-compaction-with-missing-wrapper',
+      };
+      const laterResponse = {
+        usage: new Usage(),
+        output: [duplicatedMessage],
+        responseId: 'response-with-reused-wrapper',
+      };
+      const laterProcessed = processModelResponse(laterResponse, agent, [], []);
+      const state = new RunState(new RunContext(), 'old input', agent, 2);
+      state._modelResponses = [compactionResponse, laterResponse];
+      state._lastTurnResponse = laterResponse;
+      state._generatedItems = laterProcessed.newItems;
+      state._lastProcessedResponse = laterProcessed;
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow(
+        'Run state cannot safely restore a legacy compaction item because its provider order is ambiguous.',
+      );
+    });
+
+    it('rejects an intermediate response with a missing retained wrapper', async () => {
+      const agent = new Agent({ name: 'MissingIntermediateWrapperAgent' });
+      const message = (text: string): protocol.AssistantMessageItem => ({
+        ...TEST_MODEL_MESSAGE,
+        content: [{ type: 'output_text', text }],
+      });
+      const retainedMessage = message('retained intermediate');
+      const missingMessage = message('missing intermediate');
+      const latestMessage = message('latest response');
+      const compactionResponse = {
+        usage: new Usage(),
+        output: [compactionItem],
+      };
+      const intermediateResponse = {
+        usage: new Usage(),
+        output: [retainedMessage, missingMessage],
+      };
+      const latestResponse = {
+        usage: new Usage(),
+        output: [latestMessage],
+      };
+      const retainedProcessed = processModelResponse(
+        { usage: new Usage(), output: [retainedMessage] },
+        agent,
+        [],
+        [],
+      );
+      const latestProcessed = processModelResponse(
+        latestResponse,
+        agent,
+        [],
+        [],
+      );
+      const state = new RunState(new RunContext(), 'old input', agent, 3);
+      state._modelResponses = [
+        compactionResponse,
+        intermediateResponse,
+        latestResponse,
+      ];
+      state._lastTurnResponse = latestResponse;
+      state._generatedItems = [
+        ...retainedProcessed.newItems,
+        ...latestProcessed.newItems,
+      ];
+      state._lastProcessedResponse = latestProcessed;
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow(
+        'Run state cannot safely restore a legacy compaction item because its provider order is ambiguous.',
+      );
+    });
+
+    it('allows a trailing local result after the validated latest response segment', async () => {
+      const approvalTool = tool({
+        name: 'approval_with_trailing_result',
+        description: 'Requires approval.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'approved',
+      });
+      const automaticTool = tool({
+        name: 'automatic_with_trailing_result',
+        description: 'Runs automatically.',
+        parameters: z.object({}),
+        execute: async () => 'automatic',
+      });
+      const agent = new Agent({
+        name: 'TrailingLocalResultAgent',
+        tools: [approvalTool, automaticTool],
+      });
+      const approvalCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: approvalTool.name,
+        callId: 'call_trailing_approval',
+        arguments: '{}',
+      };
+      const automaticCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: automaticTool.name,
+        callId: 'call_trailing_automatic',
+        arguments: '{}',
+      };
+      const laterResponse = {
+        usage: new Usage(),
+        output: [approvalCall, automaticCall],
+      };
+      const laterProcessed = processModelResponse(
+        laterResponse,
+        agent,
+        [approvalTool, automaticTool],
+        [],
+      );
+      const automaticResult: protocol.FunctionCallResultItem = {
+        type: 'function_call_result',
+        name: automaticTool.name,
+        callId: automaticCall.callId,
+        status: 'completed',
+        output: 'automatic',
+      };
+      const localResult = new RunToolCallOutputItem(
+        automaticResult,
+        agent,
+        'automatic',
+      );
+      const state = new RunState(new RunContext(), 'old input', agent, 2);
+      state._modelResponses = [
+        { usage: new Usage(), output: [compactionItem] },
+        laterResponse,
+      ];
+      state._lastTurnResponse = laterResponse;
+      state._generatedItems = [...laterProcessed.newItems, localResult];
+      state._lastProcessedResponse = laterProcessed;
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._generatedItems[0]).toBeInstanceOf(RunCompactionItem);
+      expect(restored._generatedItems.at(-1)?.type).toBe(
+        'tool_call_output_item',
+      );
+    });
+
+    it.each([
+      [
+        'shell',
+        {
+          type: 'shell_call_output',
+          callId: 'call_local_shell_result',
+          output: [
+            {
+              stdout: 'ok',
+              stderr: '',
+              outcome: { type: 'exit', exitCode: 0 },
+            },
+          ],
+        },
+      ],
+      [
+        'program',
+        {
+          type: 'program_output',
+          callId: 'call_local_program_result',
+          output: 'ok',
+          status: 'completed',
+        },
+      ],
+    ] as const)(
+      'allows a trailing local %s result after the validated latest response segment',
+      async (_kind, rawResult) => {
+        const agent = new Agent({ name: `TrailingLocalResult-${_kind}` });
+        const laterMessage: protocol.AssistantMessageItem = {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'later response' }],
+        };
+        const laterMessageItem = new RunMessageOutputItem(laterMessage, agent);
+        const localResult = new RunToolCallOutputItem(
+          rawResult as any,
+          agent,
+          rawResult.output,
+        );
+        const laterResponse = {
+          usage: new Usage(),
+          output: [laterMessage],
+        };
+        const state = new RunState(new RunContext(), 'old input', agent, 2);
+        state._modelResponses = [
+          { usage: new Usage(), output: [compactionItem] },
+          laterResponse,
+        ];
+        state._lastTurnResponse = laterResponse;
+        state._generatedItems = [laterMessageItem, localResult];
+        state._lastProcessedResponse = {
+          newItems: [laterMessageItem],
+          handoffs: [],
+          functions: [],
+          functionToolsNotFound: [],
+          computerActions: [],
+          shellActions: [],
+          applyPatchActions: [],
+          mcpApprovalRequests: [],
+          toolsUsed: [],
+          hasToolsOrApprovalsToRun: () => false,
+        };
+        const serialized = state.toJSON() as any;
+        serialized.$schemaVersion = '1.15';
+
+        const restored = await RunState.fromString(
+          agent,
+          JSON.stringify(serialized),
+        );
+
+        expect(restored._generatedItems[0]).toBeInstanceOf(RunCompactionItem);
+        expect(restored._generatedItems.at(-1)?.rawItem.type).toBe(
+          rawResult.type,
+        );
+      },
+    );
 
     it('rejects a stale duplicate as the following response boundary', async () => {
       const agent = new Agent({ name: 'StaleFollowingBoundaryAgent' });

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -2097,6 +2097,130 @@ describe('RunState', () => {
       expect(restored.getInterruptions()).toHaveLength(1);
     });
 
+    it('rehydrates a historical compaction-only response before an approval', async () => {
+      const approvalTool = tool({
+        name: 'approval_after_compaction_only',
+        description: 'Tool requiring approval after compaction.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'approved result',
+      });
+      const agent = new Agent({
+        name: 'HistoricalCompactionOnlyAgent',
+        tools: [approvalTool],
+      });
+      const approvalCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: approvalTool.name,
+        callId: 'call_after_compaction_only',
+        arguments: '{}',
+        status: 'completed',
+      };
+      const compactionResponse = {
+        usage: new Usage(),
+        output: [compactionItem],
+        responseId: 'response-compaction-only',
+      };
+      const approvalResponse = {
+        usage: new Usage(),
+        output: [approvalCall],
+        responseId: 'response-approval-after-compaction-only',
+      };
+      const approvalCallItem = new RunToolCallItem(approvalCall, agent);
+      const approvalItem = new ToolApprovalItem(approvalCall, agent);
+      const latestProcessed = {
+        newItems: [approvalCallItem, approvalItem],
+        handoffs: [],
+        functions: [{ toolCall: approvalCall, tool: approvalTool as any }],
+        functionToolsNotFound: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: [approvalTool.name],
+        hasToolsOrApprovalsToRun: () => true,
+      };
+      const state = new RunState(new RunContext(), 'old input', agent, 2);
+      state._modelResponses = [compactionResponse, approvalResponse];
+      state._lastTurnResponse = approvalResponse;
+      state._generatedItems = latestProcessed.newItems;
+      state._lastProcessedResponse = latestProcessed;
+      state._currentStep = {
+        type: 'next_step_interruption',
+        data: { interruptions: [approvalItem] },
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._generatedItems.map((item) => item.type)).toEqual([
+        'compaction_item',
+        'tool_call_item',
+        'tool_approval_item',
+      ]);
+      expect(restored.history[0]).toEqual(compactionItem);
+      expect(restored.getInterruptions()).toHaveLength(1);
+      expect((restored._generatedItems[0] as RunCompactionItem).agent).toBe(
+        agent,
+      );
+    });
+
+    it('rejects a stale duplicate as the following response boundary', async () => {
+      const agent = new Agent({ name: 'StaleFollowingBoundaryAgent' });
+      const duplicatedMessage: protocol.AssistantMessageItem = {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'duplicated response' }],
+      };
+      const unrelatedMessage: protocol.AssistantMessageItem = {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'unrelated later response' }],
+      };
+      const compactionResponse = {
+        usage: new Usage(),
+        output: [compactionItem],
+        responseId: 'response-stale-boundary-compaction',
+      };
+      const followingResponse = {
+        usage: new Usage(),
+        output: [duplicatedMessage],
+        responseId: 'response-stale-boundary-following',
+      };
+      const duplicatedItem = new RunMessageOutputItem(duplicatedMessage, agent);
+      const state = new RunState(new RunContext(), 'old input', agent, 2);
+      state._modelResponses = [compactionResponse, followingResponse];
+      state._lastTurnResponse = followingResponse;
+      state._generatedItems = [
+        duplicatedItem,
+        new RunMessageOutputItem(unrelatedMessage, agent),
+      ];
+      state._lastProcessedResponse = {
+        newItems: [duplicatedItem],
+        handoffs: [],
+        functions: [],
+        functionToolsNotFound: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: [],
+        hasToolsOrApprovalsToRun: () => false,
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow('provider order is ambiguous');
+    });
+
     it('ignores dropped unknown output when anchoring legacy compaction', async () => {
       const agent = new Agent({ name: 'UnknownLegacyCompactionAgent' });
       const unknownItem: protocol.UnknownItem = {

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -16,6 +16,7 @@ import type { ModelResponse } from '../src/model';
 import { processModelResponseAsync } from '../src/runner/modelOutputs';
 import {
   RunToolApprovalItem as ToolApprovalItem,
+  RunCompactionItem,
   RunMessageOutputItem,
   RunReasoningItem,
   RunToolCallItem,
@@ -1331,6 +1332,69 @@ describe('RunState', () => {
     await expect(
       RunState.fromString(agent, JSON.stringify(serialized)),
     ).rejects.toThrow('does not support Programmatic Tool Calling items');
+  });
+
+  describe('compaction items', () => {
+    const compactionItem: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_1',
+      encrypted_content: 'ciphertext',
+      created_by: 'compaction_endpoint',
+      providerData: { extra: 'value' },
+    };
+
+    function stateWithCompaction(agent: Agent<any, any>) {
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      state._generatedItems.push(new RunCompactionItem(compactionItem, agent));
+      state._modelResponses = [
+        {
+          usage: new Usage(),
+          output: [compactionItem],
+          responseId: 'response-compaction',
+        },
+      ];
+      return state;
+    }
+
+    it('round-trips a compaction run item at the current schema version', async () => {
+      const agent = new Agent({ name: 'CompactionStateAgent' });
+      const serialized = stateWithCompaction(agent).toJSON();
+      expect(serialized.$schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+      const restoredItem = restored._generatedItems[0] as RunCompactionItem;
+      expect(restoredItem).toBeInstanceOf(RunCompactionItem);
+      expect(restoredItem.rawItem).toEqual(compactionItem);
+      expect(restoredItem.agent.name).toBe('CompactionStateAgent');
+      expect(restored._modelResponses[0]?.output[0]).toEqual(compactionItem);
+    });
+
+    it('resumes a legacy snapshot containing only raw compaction output', async () => {
+      const agent = new Agent({ name: 'LegacyCompactionAgent' });
+      const serialized = stateWithCompaction(agent).toJSON() as any;
+      serialized.generatedItems = [];
+      serialized.$schemaVersion = '1.15';
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+      expect(restored._generatedItems).toEqual([]);
+      expect(restored._modelResponses[0]?.output[0]).toEqual(compactionItem);
+    });
+
+    it('rejects an older schema carrying a compaction run item', async () => {
+      const agent = new Agent({ name: 'MislabeledCompactionAgent' });
+      const serialized = stateWithCompaction(agent).toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow('does not support compaction items');
+    });
   });
 
   it('rejects pre-1.14 state with program-owned hosted calls', async () => {

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -1379,14 +1379,120 @@ describe('RunState', () => {
       expect(restored._modelResponses[0]?.output[0]).toEqual(compactionItem);
     });
 
-    it('rejects current schema raw compaction without its run item wrapper', async () => {
-      const agent = new Agent({ name: 'IncompleteCompactionStateAgent' });
+    it('round-trips filtered current-schema history without the raw compaction wrapper', async () => {
+      const agent = new Agent({ name: 'FilteredCompactionStateAgent' });
       const serialized = stateWithCompaction(agent).toJSON() as any;
       serialized.generatedItems = [];
 
-      await expect(
-        RunState.fromString(agent, JSON.stringify(serialized)),
-      ).rejects.toThrow('contains inconsistent compaction items');
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._generatedItems).toEqual([]);
+      expect(restored._modelResponses[0]?.output[0]).toEqual(compactionItem);
+    });
+
+    it('round-trips a filtered replacement compaction as authoritative history', async () => {
+      const agent = new Agent({ name: 'ReplacedCompactionStateAgent' });
+      const replacementCompaction = {
+        ...compactionItem,
+        id: 'cmp_replacement',
+        encrypted_content: 'replacement-ciphertext',
+      };
+      const serialized = stateWithCompaction(agent).toJSON() as any;
+      serialized.generatedItems = [
+        new RunCompactionItem(replacementCompaction, agent).toJSON(),
+      ];
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._generatedItems).toHaveLength(1);
+      expect(restored._generatedItems[0]?.rawItem).toEqual(
+        replacementCompaction,
+      );
+      expect(restored._modelResponses[0]?.output[0]).toEqual(compactionItem);
+    });
+
+    it('resumes an approval after a handoff filter removes compaction history', async () => {
+      const approvalTool = tool({
+        name: 'filtered_compaction_approval',
+        description: 'Requires approval after a filtered handoff.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'approved',
+      });
+      const targetAgent = new Agent({
+        name: 'FilteredCompactionTarget',
+        tools: [approvalTool],
+      });
+      const transfer = handoff(targetAgent, {
+        inputFilter: (data) => ({
+          ...data,
+          newItems: data.newItems.filter(
+            (item) => !(item instanceof RunCompactionItem),
+          ),
+        }),
+      });
+      const sourceAgent = new Agent({
+        name: 'FilteredCompactionSource',
+        handoffs: [transfer],
+      });
+      const handoffCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: transfer.toolName,
+        callId: 'call_filtered_compaction_handoff',
+        arguments: '{}',
+        status: 'completed',
+      };
+      const approvalCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: approvalTool.name,
+        callId: 'call_after_filtered_compaction',
+        arguments: '{}',
+        status: 'completed',
+      };
+      const handoffResponse = {
+        usage: new Usage(),
+        output: [compactionItem, handoffCall],
+        responseId: 'response-filtered-compaction-handoff',
+      };
+      const approvalResponse = {
+        usage: new Usage(),
+        output: [approvalCall],
+        responseId: 'response-after-filtered-compaction',
+      };
+      const latestProcessed = processModelResponse(
+        approvalResponse,
+        targetAgent,
+        [approvalTool],
+        [],
+      );
+      const approvalItem = new ToolApprovalItem(approvalCall, targetAgent);
+      const state = new RunState(new RunContext(), 'input', sourceAgent, 2);
+      state._currentAgent = targetAgent;
+      state._modelResponses = [handoffResponse, approvalResponse];
+      state._lastTurnResponse = approvalResponse;
+      state._generatedItems = [...latestProcessed.newItems, approvalItem];
+      state._lastProcessedResponse = latestProcessed;
+      state._currentStep = {
+        type: 'next_step_interruption',
+        data: { interruptions: [approvalItem] },
+      };
+
+      const restored = await RunState.fromString(sourceAgent, state.toString());
+
+      expect(
+        restored._generatedItems.some(
+          (item) => item instanceof RunCompactionItem,
+        ),
+      ).toBe(false);
+      expect(restored._modelResponses[0]?.output[0]).toEqual(compactionItem);
+      expect(restored.getInterruptions()).toHaveLength(1);
+      expect(restored._currentAgent).toBe(targetAgent);
     });
 
     it('round-trips a migrated legacy state with multiple raw compactions', async () => {

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -1384,6 +1384,135 @@ describe('RunState', () => {
       ).toEqual(['compaction_item', 'message_output_item']);
     });
 
+    it('ignores dropped unknown output when anchoring legacy compaction', async () => {
+      const agent = new Agent({ name: 'UnknownLegacyCompactionAgent' });
+      const unknownItem: protocol.UnknownItem = {
+        type: 'unknown',
+        providerData: { type: 'future_output' },
+      };
+      const message: protocol.AssistantMessageItem = {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'retained output' }],
+      };
+      const response = {
+        usage: new Usage(),
+        output: [unknownItem, compactionItem, message],
+        responseId: 'response-unknown-with-compaction',
+      };
+      const messageItem = new RunMessageOutputItem(message, agent);
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._modelResponses = [response];
+      state._lastTurnResponse = response;
+      state._generatedItems = [messageItem];
+      state._lastProcessedResponse = {
+        newItems: [messageItem],
+        handoffs: [],
+        functions: [],
+        functionToolsNotFound: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: [],
+        hasToolsOrApprovalsToRun: () => false,
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._generatedItems.map((item) => item.type)).toEqual([
+        'compaction_item',
+        'message_output_item',
+      ]);
+      expect(
+        restored._lastProcessedResponse?.newItems.map((item) => item.type),
+      ).toEqual(['compaction_item', 'message_output_item']);
+    });
+
+    it('keeps trailing legacy compaction after a function approval wrapper', async () => {
+      const approvalTool = tool({
+        name: 'legacy_trailing_compaction_tool',
+        description: 'Tool requiring approval.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'approved',
+      });
+      const agent = new Agent({
+        name: 'LegacyTrailingCompactionApprovalAgent',
+        tools: [approvalTool],
+      });
+      const functionCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: approvalTool.name,
+        callId: 'call_legacy_trailing_compaction',
+        arguments: '{}',
+        status: 'completed',
+      };
+      const response = {
+        usage: new Usage(),
+        output: [functionCall, compactionItem],
+        responseId: 'response-trailing-compaction-interruption',
+      };
+      const callItem = new RunToolCallItem(functionCall, agent);
+      const approvalItem = new ToolApprovalItem(functionCall, agent);
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._modelResponses = [response];
+      state._lastTurnResponse = response;
+      state._generatedItems = [callItem, approvalItem];
+      state._lastProcessedResponse = {
+        newItems: [callItem],
+        handoffs: [],
+        functions: [{ toolCall: functionCall, tool: approvalTool as any }],
+        functionToolsNotFound: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: [approvalTool.name],
+        hasToolsOrApprovalsToRun: () => true,
+      };
+      state._currentStep = {
+        type: 'next_step_interruption',
+        data: { interruptions: [approvalItem] },
+      };
+      const session = new MemorySession();
+      await saveToSession(session, [], new RunResult(state as any), {
+        runCompaction: false,
+      });
+
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._generatedItems.map((item) => item.type)).toEqual([
+        'tool_call_item',
+        'tool_approval_item',
+        'compaction_item',
+      ]);
+      expect(
+        restored._lastProcessedResponse?.newItems.map((item) => item.type),
+      ).toEqual(['tool_call_item', 'compaction_item']);
+      expect(restored._pendingLegacyCompactionSessionItems).toBeUndefined();
+      expect(restored._currentTurnPersistedItemCount).toBe(2);
+
+      await saveToSession(session, [], new RunResult(restored as any), {
+        runCompaction: false,
+      });
+      expect((await session.getItems()).map((item) => item.type)).toEqual([
+        'function_call',
+        'compaction',
+      ]);
+    });
+
     it('rehydrates legacy compaction with a hosted MCP approval', async () => {
       const mcpTool = hostedMcpTool({
         serverLabel: 'legacy_mcp',
@@ -1594,6 +1723,153 @@ describe('RunState', () => {
         mcpApprovalRequests: [],
         toolsUsed: [],
         hasToolsOrApprovalsToRun: () => false,
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow('provider order is ambiguous');
+    });
+
+    it('rejects same-id provider output reordered across legacy compaction', async () => {
+      const agent = new Agent({ name: 'DuplicateIdLegacyCompactionAgent' });
+      const firstMessage: protocol.AssistantMessageItem = {
+        id: 'msg_duplicate_compaction',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'first' }],
+      };
+      const secondMessage: protocol.AssistantMessageItem = {
+        id: 'msg_duplicate_compaction',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'second' }],
+      };
+      const response = {
+        usage: new Usage(),
+        output: [firstMessage, compactionItem, secondMessage],
+        responseId: 'response-duplicate-id-compaction',
+      };
+      const reorderedItems = [
+        new RunMessageOutputItem(secondMessage, agent),
+        new RunMessageOutputItem(firstMessage, agent),
+      ];
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._modelResponses = [response];
+      state._lastTurnResponse = response;
+      state._generatedItems = reorderedItems;
+      state._lastProcessedResponse = {
+        newItems: reorderedItems,
+        handoffs: [],
+        functions: [],
+        functionToolsNotFound: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: [],
+        hasToolsOrApprovalsToRun: () => false,
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow('provider order is ambiguous');
+    });
+
+    it('rejects generated provider wrappers absent from the raw response', async () => {
+      const agent = new Agent({ name: 'ExtraWrapperLegacyCompactionAgent' });
+      const retainedMessage: protocol.AssistantMessageItem = {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'retained' }],
+      };
+      const extraMessage: protocol.AssistantMessageItem = {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'extra' }],
+      };
+      const response = {
+        usage: new Usage(),
+        output: [compactionItem, retainedMessage],
+        responseId: 'response-extra-wrapper-compaction',
+      };
+      const retainedItem = new RunMessageOutputItem(retainedMessage, agent);
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._modelResponses = [response];
+      state._lastTurnResponse = response;
+      state._generatedItems = [
+        retainedItem,
+        new RunMessageOutputItem(extraMessage, agent),
+      ];
+      state._lastProcessedResponse = {
+        newItems: [retainedItem],
+        handoffs: [],
+        functions: [],
+        functionToolsNotFound: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: [],
+        hasToolsOrApprovalsToRun: () => false,
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow('provider order is ambiguous');
+    });
+
+    it('rejects processed and generated wrappers with different payloads', async () => {
+      const approvalTool = tool({
+        name: 'legacy_payload_mismatch_tool',
+        description: 'Tool used to verify payload matching.',
+        parameters: z.object({ value: z.number() }),
+        execute: async () => 'done',
+      });
+      const agent = new Agent({
+        name: 'PayloadMismatchLegacyCompactionAgent',
+        tools: [approvalTool],
+      });
+      const rawCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: approvalTool.name,
+        callId: 'call_payload_mismatch',
+        arguments: '{"value":1}',
+        status: 'completed',
+      };
+      const changedCall: protocol.FunctionCallItem = {
+        ...rawCall,
+        arguments: '{"value":2}',
+      };
+      const response = {
+        usage: new Usage(),
+        output: [compactionItem, rawCall],
+        responseId: 'response-payload-mismatch-compaction',
+      };
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._modelResponses = [response];
+      state._lastTurnResponse = response;
+      state._generatedItems = [new RunToolCallItem(changedCall, agent)];
+      state._lastProcessedResponse = {
+        newItems: [new RunToolCallItem(rawCall, agent)],
+        handoffs: [],
+        functions: [{ toolCall: rawCall, tool: approvalTool as any }],
+        functionToolsNotFound: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: [approvalTool.name],
+        hasToolsOrApprovalsToRun: () => true,
       };
       const serialized = state.toJSON() as any;
       serialized.$schemaVersion = '1.15';

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import {
   RunState,
   buildAgentMap,
@@ -10,10 +10,7 @@ import {
 import { processedResponseRequiresExecutionToolRehydration } from '../src/sandbox/runtime/toolRehydration';
 import { RunContext } from '../src/runContext';
 import { Agent } from '../src/agent';
-import { handoff } from '../src/handoff';
 import { Usage } from '../src/usage';
-import type { ModelResponse } from '../src/model';
-import { processModelResponseAsync } from '../src/runner/modelOutputs';
 import {
   RunToolApprovalItem as ToolApprovalItem,
   RunCompactionItem,
@@ -33,7 +30,6 @@ import {
   shellTool,
   tool,
   toolNamespace,
-  type Tool,
 } from '../src/tool';
 import * as protocol from '../src/types/protocol';
 import {
@@ -43,25 +39,18 @@ import {
   FakeEditor,
 } from './stubs';
 import { RunResult } from '../src/result';
-import { UserError } from '../src/errors';
-import logger from '../src/logger';
 import { createAgentSpan } from '../src/tracing';
 import { getGlobalTraceProvider } from '../src/tracing/provider';
 import type { MCPServer, MCPTool } from '../src/mcp';
 import { SANDBOX_SESSION_STATE_VERSION, SandboxAgent } from '../src/sandbox';
+import { z } from 'zod';
+import { prepareModelInputItems } from '../src/runner/items';
+import { processModelResponse } from '../src/runner/modelOutputs';
+import { MemorySession } from '../src/memory/memorySession';
 import {
-  getFunctionToolStateKey,
-  getFunctionToolStateKeyForCall,
-} from '../src/toolIdentity';
-import { z, ZodError } from 'zod';
-import { allowConsole } from '../../../helpers/tests/console-guard';
-
-type AliasTestKeys = {
-  crmAlias: string;
-  crmCanonical: string;
-  salesAlias: string;
-  salesCanonical: string;
-};
+  prepareInputItemsWithSession,
+  saveToSession,
+} from '../src/runner/sessionPersistence';
 
 function sandboxSessionStateEnvelope(
   providerState: Record<string, unknown>,
@@ -457,12 +446,6 @@ describe('RunState', () => {
       JSON.stringify(serialized),
     );
     expect(restored._sandbox).toEqual(state._sandbox);
-
-    const restoredFromSchema115 = await RunState.fromString(
-      agent,
-      JSON.stringify({ ...serialized, $schemaVersion: '1.15' }),
-    );
-    expect(restoredFromSchema115._sandbox).toEqual(state._sandbox);
   });
 
   it('keeps reading schema 1.8 payloads without sandbox state', async () => {
@@ -802,188 +785,6 @@ describe('RunState', () => {
     const restored = await RunState.fromString(agent, state.toString());
     expect(restored.getPendingAgentToolRun('toolA', 'call-1')).toBe('state-A');
     expect(restored.getPendingAgentToolRun('toolB', 'call-1')).toBe('state-B');
-  });
-
-  it('keeps pending agent tool aliases on one canonical state entry', async () => {
-    const context = new RunContext();
-    const namespacedLookup = toolNamespace({
-      name: 'crm',
-      description: 'CRM tools.',
-      tools: [
-        tool({
-          name: 'lookup',
-          description: 'Look up a CRM record.',
-          parameters: z.object({}).strict(),
-          execute: async () => 'lookup',
-        }),
-      ],
-    })[0]!;
-    const agent = new Agent({
-      name: 'PendingAliasAgent',
-      tools: [namespacedLookup],
-    });
-    const state = new RunState(context, 'input', agent, 1);
-    const canonicalKey = getFunctionToolStateKey(namespacedLookup)!;
-    const toolCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      id: 'fc-pending-alias',
-      callId: 'call-1',
-      name: 'lookup',
-      namespace: 'crm',
-      status: 'completed',
-      arguments: '{}',
-    };
-    state._lastProcessedResponse = {
-      newItems: [],
-      functions: [{ toolCall, tool: namespacedLookup as any }],
-      handoffs: [],
-      computerActions: [],
-      shellActions: [],
-      applyPatchActions: [],
-      mcpApprovalRequests: [],
-      toolsUsed: ['crm.lookup'],
-      hasToolsOrApprovalsToRun: () => true,
-    };
-
-    state.setPendingAgentToolRun(canonicalKey, 'call-1', 'initial-state', [
-      'crm.lookup',
-    ]);
-
-    expect(state._pendingAgentToolRuns.size).toBe(1);
-    expect(state.getPendingAgentToolRun('crm.lookup', 'call-1')).toBe(
-      'initial-state',
-    );
-
-    state.setPendingAgentToolRun('crm.lookup', 'call-1', 'updated-state');
-
-    expect(state._pendingAgentToolRuns.size).toBe(1);
-    expect(state.getPendingAgentToolRun(canonicalKey, 'call-1')).toBe(
-      'updated-state',
-    );
-
-    const restored = await RunState.fromString(agent, state.toString());
-    expect(restored._pendingAgentToolRuns.size).toBe(1);
-    expect(restored.getPendingAgentToolRun('crm.lookup', 'call-1')).toBe(
-      'updated-state',
-    );
-
-    restored.clearPendingAgentToolRun('crm.lookup', 'call-1');
-
-    expect(restored.hasPendingAgentToolRun(canonicalKey, 'call-1')).toBe(false);
-    expect(restored.hasPendingAgentToolRun('crm.lookup', 'call-1')).toBe(false);
-    expect(restored._pendingAgentToolRuns.size).toBe(0);
-    expect(restored._pendingAgentToolRunAliases.size).toBe(0);
-  });
-
-  it.each([
-    {
-      name: 'dangling target',
-      mutate: (aliases: Record<string, string>, keys: AliasTestKeys) => {
-        aliases[keys.crmAlias] = `${keys.crmCanonical}:missing-call`;
-      },
-    },
-    {
-      name: 'cross-call target',
-      mutate: (aliases: Record<string, string>, keys: AliasTestKeys) => {
-        aliases[keys.crmAlias] = `${keys.crmCanonical}:call-2`;
-      },
-    },
-    {
-      name: 'cross-tool target',
-      mutate: (aliases: Record<string, string>, keys: AliasTestKeys) => {
-        aliases[keys.crmAlias] = `${keys.salesCanonical}:call-3`;
-      },
-    },
-    {
-      name: 'alias chain',
-      mutate: (aliases: Record<string, string>, keys: AliasTestKeys) => {
-        aliases[keys.crmAlias] = keys.salesAlias;
-      },
-    },
-    {
-      name: 'alias cycle',
-      mutate: (aliases: Record<string, string>, keys: AliasTestKeys) => {
-        aliases[keys.crmAlias] = keys.salesAlias;
-        aliases[keys.salesAlias] = keys.crmAlias;
-      },
-    },
-  ])('rejects a pending agent tool alias with a $name', async ({ mutate }) => {
-    const [crmLookup, salesLookup] = ['crm', 'sales'].map(
-      (namespace) =>
-        toolNamespace({
-          name: namespace,
-          description: `${namespace} tools.`,
-          tools: [
-            tool({
-              name: 'lookup',
-              description: `Look up a ${namespace} record.`,
-              parameters: z.object({}).strict(),
-              execute: async () => namespace,
-            }),
-          ],
-        })[0]!,
-    );
-    const agent = new Agent({
-      name: 'Invalid pending alias agent',
-      tools: [crmLookup, salesLookup],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 1);
-    const crmCanonical = getFunctionToolStateKey(crmLookup)!;
-    const salesCanonical = getFunctionToolStateKey(salesLookup)!;
-    const createToolCall = (
-      namespace: string,
-      callId: string,
-    ): protocol.FunctionCallItem => ({
-      type: 'function_call',
-      id: `fc-${namespace}-${callId}`,
-      callId,
-      name: 'lookup',
-      namespace,
-      status: 'completed',
-      arguments: '{}',
-    });
-    state._lastProcessedResponse = {
-      newItems: [],
-      functions: [
-        { toolCall: createToolCall('crm', 'call-1'), tool: crmLookup as any },
-        { toolCall: createToolCall('crm', 'call-2'), tool: crmLookup as any },
-        {
-          toolCall: createToolCall('sales', 'call-3'),
-          tool: salesLookup as any,
-        },
-      ],
-      handoffs: [],
-      computerActions: [],
-      shellActions: [],
-      applyPatchActions: [],
-      mcpApprovalRequests: [],
-      toolsUsed: ['crm.lookup', 'sales.lookup'],
-      hasToolsOrApprovalsToRun: () => true,
-    };
-    state.setPendingAgentToolRun(crmCanonical, 'call-1', 'crm-state', [
-      'crm.lookup',
-    ]);
-    state.setPendingAgentToolRun(crmCanonical, 'call-2', 'crm-state-2', [
-      'crm.lookup',
-    ]);
-    state.setPendingAgentToolRun(salesCanonical, 'call-3', 'sales-state', [
-      'sales.lookup',
-    ]);
-
-    const serialized = state.toJSON();
-    const aliases = serialized.pendingAgentToolRunAliases!;
-    mutate(aliases, {
-      crmAlias: 'crm.lookup:call-1',
-      crmCanonical,
-      salesAlias: 'sales.lookup:call-3',
-      salesCanonical,
-    });
-
-    await expect(
-      RunState.fromString(agent, JSON.stringify(serialized)),
-    ).rejects.toThrow(
-      'Run state pending agent tool aliases do not match the reconstructed pending function calls.',
-    );
   });
 
   it('toJSON and toString produce valid JSON', () => {
@@ -1353,6 +1154,7 @@ describe('RunState', () => {
           responseId: 'response-compaction',
         },
       ];
+      state._lastTurnResponse = state._modelResponses[0];
       return state;
     }
 
@@ -1372,18 +1174,456 @@ describe('RunState', () => {
       expect(restored._modelResponses[0]?.output[0]).toEqual(compactionItem);
     });
 
-    it('resumes a legacy snapshot containing only raw compaction output', async () => {
-      const agent = new Agent({ name: 'LegacyCompactionAgent' });
-      const serialized = stateWithCompaction(agent).toJSON() as any;
-      serialized.generatedItems = [];
-      serialized.$schemaVersion = '1.15';
+    it.each(['1.0', '1.15'] as const)(
+      'rehydrates raw compaction output from legacy schema %s',
+      async (schemaVersion) => {
+        const agent = new Agent({ name: 'LegacyCompactionAgent' });
+        const serialized = stateWithCompaction(agent).toJSON() as any;
+        serialized.generatedItems = [];
+        serialized.$schemaVersion = schemaVersion;
 
+        const restored = await RunState.fromString(
+          agent,
+          JSON.stringify(serialized),
+        );
+        expect(restored._generatedItems).toHaveLength(1);
+        expect(restored._generatedItems[0]).toBeInstanceOf(RunCompactionItem);
+        expect(restored._generatedItems[0].rawItem).toEqual(compactionItem);
+        expect(restored._modelResponses[0]?.output[0]).toEqual(compactionItem);
+      },
+    );
+
+    it('rehydrates a legacy interrupted response in provider order', async () => {
+      const approvalTool = tool({
+        name: 'legacy_compaction_tool',
+        description: 'Tool requiring approval.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'approved',
+      });
+      const agent = new Agent({
+        name: 'LegacyCompactionApprovalAgent',
+        tools: [approvalTool],
+      });
+      const functionCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: approvalTool.name,
+        callId: 'call_legacy_compaction',
+        arguments: '{}',
+        status: 'completed',
+      };
+      const response = {
+        usage: new Usage(),
+        output: [compactionItem, functionCall],
+        responseId: 'response-compaction-interruption',
+      };
+      const callItem = new RunToolCallItem(functionCall, agent);
+      const approvalItem = new ToolApprovalItem(functionCall, agent);
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._modelResponses = [response];
+      state._lastTurnResponse = response;
+      state._generatedItems = [callItem, approvalItem];
+      state._lastProcessedResponse = {
+        newItems: [callItem],
+        handoffs: [],
+        functions: [{ toolCall: functionCall, tool: approvalTool as any }],
+        functionToolsNotFound: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: [approvalTool.name],
+        hasToolsOrApprovalsToRun: () => true,
+      };
+      state._currentStep = {
+        type: 'next_step_interruption',
+        data: { interruptions: [approvalItem] },
+      };
+      const session = new MemorySession();
+      await saveToSession(session, [], new RunResult(state as any), {
+        runCompaction: false,
+      });
+
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
       const restored = await RunState.fromString(
         agent,
         JSON.stringify(serialized),
       );
-      expect(restored._generatedItems).toEqual([]);
-      expect(restored._modelResponses[0]?.output[0]).toEqual(compactionItem);
+
+      expect(restored._generatedItems.map((item) => item.type)).toEqual([
+        'compaction_item',
+        'tool_call_item',
+        'tool_approval_item',
+      ]);
+      expect(
+        restored._lastProcessedResponse?.newItems.map((item) => item.type),
+      ).toEqual(['compaction_item', 'tool_call_item']);
+      expect(restored._currentTurnPersistedItemCount).toBe(3);
+      expect(
+        restored._pendingLegacyCompactionSessionItems?.map((item) => item.type),
+      ).toEqual(['compaction', 'function_call']);
+      const pendingRoundTripped = await RunState.fromString(
+        agent,
+        restored.toString(),
+      );
+      expect(
+        pendingRoundTripped._pendingLegacyCompactionSessionItems?.map(
+          (item) => item.type,
+        ),
+      ).toEqual(['compaction', 'function_call']);
+
+      await saveToSession(session, [], new RunResult(restored as any), {
+        runCompaction: false,
+      });
+      expect((await session.getItems()).map((item) => item.type)).toEqual([
+        'compaction',
+        'function_call',
+      ]);
+      expect(restored._pendingLegacyCompactionSessionItems).toBeUndefined();
+      const functionResult: protocol.FunctionCallResultItem = {
+        type: 'function_call_result',
+        name: approvalTool.name,
+        callId: functionCall.callId,
+        output: 'approved',
+        status: 'completed',
+      };
+      restored._generatedItems.push(
+        new RunToolCallOutputItem(functionResult, agent, 'approved'),
+      );
+      await saveToSession(session, [], new RunResult(restored as any), {
+        runCompaction: false,
+      });
+      expect((await session.getItems()).map((item) => item.type)).toEqual([
+        'compaction',
+        'function_call',
+        'function_call_result',
+      ]);
+      const prepared = await prepareInputItemsWithSession('continue', session);
+      expect(
+        (prepared.preparedInput as protocol.ModelItem[]).map(
+          (item) => item.type,
+        ),
+      ).toEqual([
+        'compaction',
+        'function_call',
+        'function_call_result',
+        'message',
+      ]);
+      expect(
+        prepareModelInputItems(
+          restored._originalInput,
+          restored._generatedItems,
+        )
+          .slice(1)
+          .map((item) => item.type),
+      ).toEqual(['compaction', 'function_call', 'function_call_result']);
+
+      const roundTripped = await RunState.fromString(
+        agent,
+        restored.toString(),
+      );
+      expect(
+        roundTripped._generatedItems.filter(
+          (item) => item instanceof RunCompactionItem,
+        ),
+      ).toHaveLength(1);
+    });
+
+    it('anchors legacy compaction within the latest processed response', async () => {
+      const agent = new Agent({ name: 'RepeatedLegacyCompactionAgent' });
+      const repeatedMessage: protocol.AssistantMessageItem = {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'repeated output' }],
+      };
+      const earlierResponse = {
+        usage: new Usage(),
+        output: [repeatedMessage],
+        responseId: 'response-before-compaction',
+      };
+      const latestResponse = {
+        usage: new Usage(),
+        output: [compactionItem, repeatedMessage],
+        responseId: 'response-with-compaction',
+      };
+      const earlierItem = new RunMessageOutputItem(repeatedMessage, agent);
+      const latestItem = new RunMessageOutputItem(repeatedMessage, agent);
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._modelResponses = [earlierResponse, latestResponse];
+      state._lastTurnResponse = latestResponse;
+      state._generatedItems = [earlierItem, latestItem];
+      state._lastProcessedResponse = {
+        newItems: [latestItem],
+        handoffs: [],
+        functions: [],
+        functionToolsNotFound: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: [],
+        hasToolsOrApprovalsToRun: () => false,
+      };
+
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._generatedItems.map((item) => item.type)).toEqual([
+        'message_output_item',
+        'compaction_item',
+        'message_output_item',
+      ]);
+      expect(
+        restored._lastProcessedResponse?.newItems.map((item) => item.type),
+      ).toEqual(['compaction_item', 'message_output_item']);
+    });
+
+    it('rehydrates legacy compaction with a hosted MCP approval', async () => {
+      const mcpTool = hostedMcpTool({
+        serverLabel: 'legacy_mcp',
+        serverUrl: 'https://mcp.example.com/legacy',
+        requireApproval: 'always',
+      });
+      const agent = new Agent({
+        name: 'LegacyCompactionMcpAgent',
+        tools: [mcpTool],
+      });
+      const approvalCall: protocol.HostedToolCallItem = {
+        type: 'hosted_tool_call',
+        id: 'approval_legacy_compaction',
+        name: 'mcp_approval_request',
+        status: 'completed',
+        providerData: {
+          type: 'mcp_approval_request',
+          server_label: 'legacy_mcp',
+          name: 'list_orders',
+          id: 'approval_legacy_compaction',
+          arguments: '{}',
+        },
+      };
+      const response = {
+        usage: new Usage(),
+        output: [compactionItem, approvalCall],
+        responseId: 'response-compaction-mcp-approval',
+      };
+      const processedResponse = processModelResponse(
+        response,
+        agent,
+        [mcpTool],
+        [],
+      );
+      const legacyItems = processedResponse.newItems.filter(
+        (item) => !(item instanceof RunCompactionItem),
+      );
+      const approvalItem = legacyItems.find(
+        (item): item is ToolApprovalItem => item instanceof ToolApprovalItem,
+      );
+      expect(approvalItem).toBeDefined();
+
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._modelResponses = [response];
+      state._lastTurnResponse = response;
+      state._generatedItems = legacyItems;
+      state._lastProcessedResponse = {
+        ...processedResponse,
+        newItems: legacyItems,
+      };
+      state._currentStep = {
+        type: 'next_step_interruption',
+        data: { interruptions: [approvalItem] },
+      };
+      const session = new MemorySession();
+      await saveToSession(session, [], new RunResult(state as any), {
+        runCompaction: false,
+      });
+
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._generatedItems.map((item) => item.type)).toEqual([
+        'compaction_item',
+        'tool_call_item',
+        'tool_approval_item',
+      ]);
+      expect(
+        restored._lastProcessedResponse?.newItems.map((item) => item.type),
+      ).toEqual(['compaction_item', 'tool_call_item', 'tool_approval_item']);
+      expect(restored.getInterruptions()).toHaveLength(1);
+      expect(restored._currentTurnPersistedItemCount).toBe(3);
+
+      await saveToSession(session, [], new RunResult(restored as any), {
+        runCompaction: false,
+      });
+      expect((await session.getItems()).map((item) => item.type)).toEqual([
+        'compaction',
+        'hosted_tool_call',
+      ]);
+    });
+
+    it('rehydrates trailing legacy compaction after a hosted MCP approval', async () => {
+      const mcpTool = hostedMcpTool({
+        serverLabel: 'legacy_trailing_mcp',
+        serverUrl: 'https://mcp.example.com/legacy-trailing',
+        requireApproval: 'always',
+      });
+      const agent = new Agent({
+        name: 'LegacyTrailingCompactionMcpAgent',
+        tools: [mcpTool],
+      });
+      const approvalCall: protocol.HostedToolCallItem = {
+        type: 'hosted_tool_call',
+        id: 'approval_trailing_compaction',
+        name: 'mcp_approval_request',
+        status: 'completed',
+        providerData: {
+          type: 'mcp_approval_request',
+          server_label: 'legacy_trailing_mcp',
+          name: 'list_orders',
+          id: 'approval_trailing_compaction',
+          arguments: '{}',
+        },
+      };
+      const response = {
+        usage: new Usage(),
+        output: [approvalCall, compactionItem],
+        responseId: 'response-trailing-compaction-mcp-approval',
+      };
+      const processedResponse = processModelResponse(
+        response,
+        agent,
+        [mcpTool],
+        [],
+      );
+      const legacyItems = processedResponse.newItems.filter(
+        (item) => !(item instanceof RunCompactionItem),
+      );
+      const approvalItem = legacyItems.find(
+        (item): item is ToolApprovalItem => item instanceof ToolApprovalItem,
+      );
+      expect(approvalItem).toBeDefined();
+
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._modelResponses = [response];
+      state._lastTurnResponse = response;
+      state._generatedItems = legacyItems;
+      state._lastProcessedResponse = {
+        ...processedResponse,
+        newItems: legacyItems,
+      };
+      state._currentStep = {
+        type: 'next_step_interruption',
+        data: { interruptions: [approvalItem] },
+      };
+      const session = new MemorySession();
+      await saveToSession(session, [], new RunResult(state as any), {
+        runCompaction: false,
+      });
+
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._generatedItems.map((item) => item.type)).toEqual([
+        'tool_call_item',
+        'tool_approval_item',
+        'compaction_item',
+      ]);
+      expect(
+        restored._lastProcessedResponse?.newItems.map((item) => item.type),
+      ).toEqual(['tool_call_item', 'tool_approval_item', 'compaction_item']);
+      expect(restored._pendingLegacyCompactionSessionItems).toBeUndefined();
+      expect(restored._currentTurnPersistedItemCount).toBe(2);
+
+      await saveToSession(session, [], new RunResult(restored as any), {
+        runCompaction: false,
+      });
+      expect((await session.getItems()).map((item) => item.type)).toEqual([
+        'hosted_tool_call',
+        'compaction',
+      ]);
+    });
+
+    it('rejects reordered provider output after legacy compaction', async () => {
+      const agent = new Agent({ name: 'ReorderedLegacyCompactionAgent' });
+      const firstMessage: protocol.AssistantMessageItem = {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'first' }],
+      };
+      const secondMessage: protocol.AssistantMessageItem = {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'second' }],
+      };
+      const response = {
+        usage: new Usage(),
+        output: [compactionItem, firstMessage, secondMessage],
+        responseId: 'response-reordered-after-compaction',
+      };
+      const reorderedItems = [
+        new RunMessageOutputItem(secondMessage, agent),
+        new RunMessageOutputItem(firstMessage, agent),
+      ];
+      const state = new RunState(new RunContext(), 'input', agent, 2);
+      state._modelResponses = [response];
+      state._lastTurnResponse = response;
+      state._generatedItems = reorderedItems;
+      state._lastProcessedResponse = {
+        newItems: reorderedItems,
+        handoffs: [],
+        functions: [],
+        functionToolsNotFound: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        toolsUsed: [],
+        hasToolsOrApprovalsToRun: () => false,
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow('provider order is ambiguous');
+    });
+
+    it('rejects legacy compaction state when provider order is ambiguous', async () => {
+      const agent = new Agent({ name: 'AmbiguousLegacyCompactionAgent' });
+      const state = stateWithCompaction(agent);
+      state._generatedItems = [
+        new ToolApprovalItem(
+          {
+            type: 'function_call',
+            name: 'missing_call',
+            callId: 'call_missing_compaction_anchor',
+            arguments: '{}',
+            status: 'completed',
+          },
+          agent,
+        ),
+      ];
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow('provider order is ambiguous');
     });
 
     it('rejects an older schema carrying a compaction run item', async () => {
@@ -1692,988 +1932,6 @@ describe('RunState', () => {
     );
   });
 
-  it('reads schema 1.15 approval keys and emits category-aware schema 1.16 state', async () => {
-    const context = new RunContext();
-    const agent = new Agent({ name: 'ApprovalKeyMigrationAgent' });
-    const state = new RunState(context, 'input', agent, 2);
-    const rawItem: protocol.FunctionCallItem = {
-      type: 'function_call',
-      name: 'lookup',
-      callId: 'legacy-call',
-      status: 'completed',
-      arguments: '{}',
-    };
-    state.reject(new ToolApprovalItem(rawItem, agent));
-
-    const serialized = state.toJSON() as any;
-    const categoryKey = getFunctionToolStateKeyForCall(rawItem)!;
-    const ownerApprovals = serialized.context.functionApprovals.find(
-      (entry: any) => entry.agentIdentity === agent.name,
-    ).approvals;
-    serialized.$schemaVersion = '1.15';
-    serialized.context.approvals.lookup = ownerApprovals[categoryKey];
-    delete serialized.context.functionApprovals;
-    delete serialized.context.legacyFunctionApprovals;
-
-    const restored = await RunState.fromString(
-      agent,
-      JSON.stringify(serialized),
-    );
-
-    expect(
-      restored._context.isToolApproved({
-        toolName: 'lookup',
-        callId: 'legacy-call',
-      }),
-    ).toBe(false);
-    expect(restored.toJSON().$schemaVersion).toBe('1.16');
-  });
-
-  it('rehydrates schema 1.15 approval identity from enabled prepared tools', async () => {
-    const enabledLookup = toolNamespace({
-      name: 'crm',
-      description: 'CRM tools.',
-      tools: [
-        tool({
-          name: 'lookup',
-          description: 'Look up a CRM record.',
-          parameters: z.object({}),
-          execute: async () => 'enabled',
-        }),
-      ],
-    })[0]!;
-    const disabledLookup = toolNamespace({
-      name: 'crm',
-      description: 'Disabled CRM tools.',
-      tools: [
-        tool({
-          name: 'lookup',
-          description: 'Disabled duplicate.',
-          parameters: z.object({}),
-          isEnabled: false,
-          execute: async () => 'disabled',
-        }),
-      ],
-    })[0]!;
-    const agent = new Agent({
-      name: 'LegacyApprovalAgent',
-      tools: [enabledLookup, disabledLookup],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    const rawItem: protocol.FunctionCallItem = {
-      type: 'function_call',
-      name: 'lookup',
-      namespace: 'crm',
-      callId: 'legacy-approval-call',
-      status: 'completed',
-      arguments: '{}',
-    };
-    state._lastProcessedResponse = {
-      newItems: [],
-      functions: [{ toolCall: rawItem, tool: enabledLookup as any }],
-      handoffs: [],
-      computerActions: [],
-      shellActions: [],
-      applyPatchActions: [],
-      mcpApprovalRequests: [],
-      toolsUsed: ['crm.lookup'],
-      hasToolsOrApprovalsToRun: () => true,
-    };
-    state._currentStep = {
-      type: 'next_step_interruption',
-      data: {
-        interruptions: [new ToolApprovalItem(rawItem, agent)],
-      },
-    };
-
-    const serialized = state.toJSON() as any;
-    serialized.$schemaVersion = '1.15';
-    delete serialized.currentStep.data.interruptions[0].functionToolStateKey;
-
-    const restored = await RunState.fromString(
-      agent,
-      JSON.stringify(serialized),
-    );
-    const [approvalItem] = restored.getInterruptions();
-
-    expect(approvalItem.functionToolStateKey).toBe(
-      getFunctionToolStateKey(enabledLookup),
-    );
-    restored.approve(approvalItem);
-    expect(
-      restored._context.isToolApproved({
-        toolName: getFunctionToolStateKey(enabledLookup)!,
-        callId: rawItem.callId,
-      }),
-    ).toBe(true);
-  });
-
-  it.each(['namespaced', 'dotted'] as const)(
-    'migrates schema 1.15 pending nested state for the exact %s tool category',
-    async (pendingCategory) => {
-      const dottedLookup = tool({
-        name: 'crm_lookup',
-        description: 'Look up a dotted CRM record.',
-        parameters: z.object({}),
-        execute: async () => 'dotted',
-      });
-      dottedLookup.name = 'crm.lookup';
-      const namespacedLookup = toolNamespace({
-        name: 'crm',
-        description: 'CRM tools.',
-        tools: [
-          tool({
-            name: 'lookup',
-            description: 'Look up a namespaced CRM record.',
-            parameters: z.object({}),
-            execute: async () => 'namespaced',
-          }),
-        ],
-      })[0]!;
-      const pendingTool =
-        pendingCategory === 'namespaced' ? namespacedLookup : dottedLookup;
-      const toolCall: protocol.FunctionCallItem = {
-        type: 'function_call',
-        name: pendingCategory === 'namespaced' ? 'lookup' : 'crm.lookup',
-        ...(pendingCategory === 'namespaced' ? { namespace: 'crm' } : {}),
-        callId: `legacy-${pendingCategory}-call`,
-        status: 'completed',
-        arguments: '{}',
-      };
-      const agent = new Agent({
-        name: `LegacyPending${pendingCategory}`,
-        tools: [dottedLookup, namespacedLookup],
-      });
-      const state = new RunState(new RunContext(), 'input', agent, 2);
-      state._lastProcessedResponse = {
-        newItems: [],
-        functions: [{ toolCall, tool: pendingTool as any }],
-        handoffs: [],
-        computerActions: [],
-        shellActions: [],
-        applyPatchActions: [],
-        mcpApprovalRequests: [],
-        toolsUsed: ['crm.lookup'],
-        hasToolsOrApprovalsToRun: () => true,
-      };
-      state.setPendingAgentToolRun(
-        'crm.lookup',
-        toolCall.callId,
-        `${pendingCategory}-state`,
-      );
-
-      const serialized = state.toJSON() as any;
-      serialized.$schemaVersion = '1.15';
-      delete serialized.pendingAgentToolRunAliases;
-
-      const restored = await RunState.fromString(
-        agent,
-        JSON.stringify(serialized),
-      );
-      const canonicalKey = getFunctionToolStateKey(pendingTool)!;
-
-      expect(
-        restored.getPendingAgentToolRun(canonicalKey, toolCall.callId),
-      ).toBe(`${pendingCategory}-state`);
-      expect(
-        restored.getPendingAgentToolRun('crm.lookup', toolCall.callId),
-      ).toBe(`${pendingCategory}-state`);
-      expect(restored._pendingAgentToolRuns.size).toBe(1);
-    },
-  );
-
-  it('migrates pending schema 1.15 approvals while preserving ambiguous permanent owners', async () => {
-    const decisions = [
-      {
-        name: 'approved call',
-        record: (callId: string) => ({
-          approved: [callId],
-          rejected: [],
-        }),
-        expected: true,
-      },
-      {
-        name: 'rejected call',
-        record: (callId: string) => ({
-          approved: [],
-          rejected: [callId],
-          messages: { [callId]: 'Rejected once' },
-        }),
-        expected: false,
-        message: 'Rejected once',
-      },
-      {
-        name: 'permanent approval',
-        record: () => ({ approved: true, rejected: [] }),
-        expected: true,
-      },
-      {
-        name: 'permanent rejection',
-        record: (callId: string) => ({
-          approved: false,
-          rejected: true,
-          messages: { [callId]: 'Always rejected' },
-          stickyRejectMessage: 'Always rejected',
-        }),
-        expected: false,
-        message: 'Always rejected',
-      },
-    ];
-
-    for (const pair of ['bare-deferred', 'dotted-namespaced'] as const) {
-      for (const decision of decisions) {
-        const bareTool = tool({
-          name: pair === 'bare-deferred' ? 'lookup' : 'crm_lookup',
-          description: 'Bare lookup.',
-          parameters: z.object({}),
-          execute: async () => 'bare',
-        });
-        if (pair === 'dotted-namespaced') {
-          bareTool.name = 'crm.lookup';
-        }
-        const structuredTool =
-          pair === 'bare-deferred'
-            ? tool({
-                name: 'lookup',
-                description: 'Deferred lookup.',
-                parameters: z.object({}),
-                deferLoading: true,
-                execute: async () => 'deferred',
-              })
-            : toolNamespace({
-                name: 'crm',
-                description: 'CRM tools.',
-                tools: [
-                  tool({
-                    name: 'lookup',
-                    description: 'Namespaced lookup.',
-                    parameters: z.object({}),
-                    execute: async () => 'namespaced',
-                  }),
-                ],
-              })[0]!;
-        const callId = `${pair}-${decision.name.replace(/ /g, '-')}`;
-        const toolCall: protocol.FunctionCallItem = {
-          type: 'function_call',
-          name: 'lookup',
-          namespace: pair === 'bare-deferred' ? 'lookup' : 'crm',
-          callId,
-          status: 'completed',
-          arguments: '{}',
-        };
-        const legacyKey = pair === 'bare-deferred' ? 'lookup' : 'crm.lookup';
-        const agent = new Agent({
-          name: `LegacyApproval-${pair}-${decision.name}`,
-          tools: [bareTool, structuredTool],
-        });
-        const state = new RunState(new RunContext(), 'input', agent, 2);
-        state._lastProcessedResponse = {
-          newItems: [],
-          functions: [{ toolCall, tool: structuredTool as any }],
-          handoffs: [],
-          computerActions: [],
-          shellActions: [],
-          applyPatchActions: [],
-          mcpApprovalRequests: [],
-          toolsUsed: [legacyKey],
-          hasToolsOrApprovalsToRun: () => true,
-        };
-        state._currentStep = {
-          type: 'next_step_interruption',
-          data: {
-            interruptions: [new ToolApprovalItem(toolCall, agent)],
-          },
-        };
-
-        const serialized = state.toJSON() as any;
-        serialized.$schemaVersion = '1.15';
-        serialized.context.approvals = {
-          [legacyKey]: decision.record(callId),
-        };
-        delete serialized.currentStep.data.interruptions[0]
-          .functionToolStateKey;
-
-        const restored = await RunState.fromString(
-          agent,
-          JSON.stringify(serialized),
-        );
-        const canonicalKey = getFunctionToolStateKey(structuredTool)!;
-        const isPermanent = decision.name.startsWith('permanent');
-
-        expect(
-          restored._context.isToolApproved({
-            toolName: canonicalKey,
-            callId,
-          }),
-          `${pair}: ${decision.name}`,
-        ).toBe(decision.expected);
-        expect(
-          restored._context.getRejectionMessage(canonicalKey, callId),
-        ).toBe(decision.message);
-        expect(
-          restored._context.isToolApproved({
-            toolName: canonicalKey,
-            callId: `${callId}-future`,
-          }),
-        ).toBe(isPermanent ? decision.expected : undefined);
-        expect(
-          restored._context.isToolApproved({
-            toolName: legacyKey,
-            callId,
-          }),
-          `${pair}: ${decision.name} legacy owner`,
-        ).toBe(isPermanent ? decision.expected : undefined);
-        expect(
-          restored._context.isToolApproved({
-            toolName: legacyKey,
-            callId: `${callId}-future`,
-          }),
-          `${pair}: ${decision.name} future legacy owner`,
-        ).toBe(isPermanent ? decision.expected : undefined);
-      }
-    }
-  });
-
-  it.each([
-    ['permanent approval', { approved: true, rejected: [] }, true, undefined],
-    [
-      'permanent rejection',
-      {
-        approved: false,
-        rejected: true,
-        stickyRejectMessage: 'Always rejected',
-      },
-      false,
-      'Always rejected',
-    ],
-  ] as const)(
-    'migrates a schema 1.15 %s when the legacy function owner is unique',
-    async (_name, approvalRecord, expectedApproval, expectedMessage) => {
-      const namespacedLookup = toolNamespace({
-        name: 'crm',
-        description: 'CRM tools.',
-        tools: [
-          tool({
-            name: 'lookup',
-            description: 'Namespaced lookup.',
-            parameters: z.object({}),
-            execute: async () => 'namespaced',
-          }),
-        ],
-      })[0]!;
-      const callId = 'unique-owner-call';
-      const toolCall: protocol.FunctionCallItem = {
-        type: 'function_call',
-        name: 'lookup',
-        namespace: 'crm',
-        callId,
-        status: 'completed',
-        arguments: '{}',
-      };
-      const agent = new Agent({
-        name: 'UniqueLegacyApprovalOwner',
-        tools: [namespacedLookup],
-      });
-      const state = new RunState(new RunContext(), 'input', agent, 2);
-      state._lastProcessedResponse = {
-        newItems: [],
-        functions: [{ toolCall, tool: namespacedLookup as any }],
-        handoffs: [],
-        computerActions: [],
-        shellActions: [],
-        applyPatchActions: [],
-        mcpApprovalRequests: [],
-        toolsUsed: ['crm.lookup'],
-        hasToolsOrApprovalsToRun: () => true,
-      };
-
-      const serialized = state.toJSON() as any;
-      serialized.$schemaVersion = '1.15';
-      serialized.context.approvals = {
-        'crm.lookup': approvalRecord,
-      };
-
-      const restored = await RunState.fromString(
-        agent,
-        JSON.stringify(serialized),
-      );
-      const canonicalKey = getFunctionToolStateKey(namespacedLookup)!;
-
-      expect(
-        restored._context.isToolApproved({
-          toolName: canonicalKey,
-          callId,
-        }),
-      ).toBe(expectedApproval);
-      expect(restored._context.getRejectionMessage(canonicalKey, callId)).toBe(
-        expectedMessage,
-      );
-      expect(
-        restored._context.isToolApproved({
-          toolName: 'crm.lookup',
-          callId,
-        }),
-      ).toBeUndefined();
-      const publicApproval = restored._context.toJSON().approvals['crm.lookup'];
-      expect(publicApproval).toBeDefined();
-      expect(publicApproval.approved === true).toBe(
-        approvalRecord.approved === true,
-      );
-      expect(publicApproval.rejected === true).toBe(
-        approvalRecord.rejected === true,
-      );
-      expect(
-        restored._context.toJSON().approvals[canonicalKey],
-      ).toBeUndefined();
-
-      const durable = restored.toJSON() as any;
-      expect(durable.context.approvals['crm.lookup']).toBeUndefined();
-      const durableApproval = durable.context.functionApprovals.find(
-        (entry: any) => entry.agentIdentity === agent.name,
-      ).approvals[canonicalKey];
-      expect(durableApproval.approved === true).toBe(
-        approvalRecord.approved === true,
-      );
-      expect(durableApproval.rejected === true).toBe(
-        approvalRecord.rejected === true,
-      );
-    },
-  );
-
-  it('migrates a unique schema 1.15 permanent owner without a current call', async () => {
-    const namespacedLookup = toolNamespace({
-      name: 'crm',
-      description: 'CRM tools.',
-      tools: [
-        tool({
-          name: 'lookup',
-          description: 'Namespaced lookup.',
-          parameters: z.object({}),
-          execute: async () => 'namespaced',
-        }),
-      ],
-    })[0]!;
-    const agent = new Agent({
-      name: 'Unique inactive legacy approval owner',
-      tools: [namespacedLookup],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-
-    const serialized = state.toJSON() as any;
-    serialized.$schemaVersion = '1.15';
-    serialized.context.approvals = {
-      'crm.lookup': { approved: true, rejected: [] },
-    };
-
-    const restored = await RunState.fromString(
-      agent,
-      JSON.stringify(serialized),
-    );
-    const canonicalKey = getFunctionToolStateKey(namespacedLookup)!;
-
-    expect(
-      restored._context.isToolApproved({
-        toolName: canonicalKey,
-        callId: 'future_call',
-      }),
-    ).toBe(true);
-    expect(
-      restored._context.isToolApproved({
-        toolName: 'crm.lookup',
-        callId: 'future_call',
-      }),
-    ).toBeUndefined();
-    const durable = restored.toJSON() as any;
-    expect(durable.context.approvals['crm.lookup']).toBeUndefined();
-    expect(durable.context.legacyFunctionApprovals).toBeUndefined();
-    expect(
-      durable.context.functionApprovals[0].approvals[canonicalKey],
-    ).toMatchObject({ approved: true, rejected: [] });
-  });
-
-  it('migrates a unique schema 1.15 approval owned by an inactive child agent', async () => {
-    const childLookup = toolNamespace({
-      name: 'crm',
-      description: 'Child CRM tools.',
-      tools: [
-        tool({
-          name: 'lookup',
-          description: 'Child namespaced lookup.',
-          parameters: z.object({}),
-          execute: async () => 'child',
-        }),
-      ],
-    })[0]!;
-    const childAgent = new Agent({
-      name: 'Inactive legacy approval child',
-      tools: [childLookup],
-    });
-    const rootAgent = new Agent({
-      name: 'Inactive legacy approval root',
-      tools: [
-        childAgent.asTool({
-          toolName: 'run_child',
-          toolDescription: 'Runs the child agent.',
-        }),
-      ],
-    });
-    const state = new RunState(new RunContext(), 'input', rootAgent, 2);
-    const serialized = state.toJSON() as any;
-    serialized.$schemaVersion = '1.15';
-    serialized.context.approvals = {
-      'crm.lookup': { approved: true, rejected: [] },
-    };
-
-    const restored = await RunState.fromString(
-      rootAgent,
-      JSON.stringify(serialized),
-    );
-    const canonicalKey = getFunctionToolStateKey(childLookup)!;
-
-    expect(
-      restored._context.isToolApproved({
-        toolName: canonicalKey,
-        callId: 'future_child_call',
-        functionTool: false,
-        agent: childAgent,
-      }),
-    ).toBe(true);
-    const durable = restored.toJSON() as any;
-    expect(durable.context.approvals['crm.lookup']).toBeUndefined();
-    expect(durable.context.legacyFunctionApprovals).toBeUndefined();
-    expect(
-      durable.context.functionApprovals.find(
-        (entry: any) => entry.agentIdentity === childAgent.name,
-      ).approvals[canonicalKey],
-    ).toMatchObject({ approved: true, rejected: [] });
-  });
-
-  it('keeps an exact non-function override separate from an inactive schema 1.15 function owner', async () => {
-    const namespacedLookup = toolNamespace({
-      name: 'crm',
-      description: 'CRM tools.',
-      tools: [
-        tool({
-          name: 'lookup',
-          description: 'Namespaced lookup.',
-          parameters: z.object({}),
-          execute: async () => 'namespaced',
-        }),
-      ],
-    })[0]!;
-    const otherTool = tool({
-      name: 'other_tool',
-      description: 'Other tool.',
-      parameters: z.object({}),
-      execute: async () => 'other',
-    });
-    const otherCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      name: 'other_tool',
-      callId: 'merge_other_call',
-      status: 'completed',
-      arguments: '{}',
-    };
-    const agent = new Agent({
-      name: 'Inactive merge approval owner',
-      tools: [namespacedLookup, otherTool],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    state._lastProcessedResponse = {
-      newItems: [],
-      functions: [
-        {
-          toolCall: otherCall,
-          tool: otherTool as any,
-          availableFunctionTools: [namespacedLookup, otherTool] as any,
-        },
-      ],
-      handoffs: [],
-      computerActions: [],
-      shellActions: [],
-      applyPatchActions: [],
-      mcpApprovalRequests: [],
-      toolsUsed: ['other_tool'],
-      hasToolsOrApprovalsToRun: () => true,
-    };
-    const serialized = state.toJSON() as any;
-    serialized.$schemaVersion = '1.15';
-    serialized.context.approvals = {
-      'crm.lookup': { approved: true, rejected: [] },
-    };
-    const overrideContext = new RunContext();
-    overrideContext.rejectTool(
-      new ToolApprovalItem(
-        {
-          type: 'shell_call',
-          callId: 'shell_crm_lookup',
-          status: 'completed',
-          action: { commands: ['echo rejected'] },
-        },
-        agent,
-        'crm.lookup',
-      ),
-      { alwaysReject: true },
-    );
-
-    const restored = await RunState.fromStringWithContext(
-      agent,
-      JSON.stringify(serialized),
-      overrideContext,
-      { contextStrategy: 'merge' },
-    );
-    const canonicalKey = getFunctionToolStateKey(namespacedLookup)!;
-
-    expect(
-      restored._context.isToolApproved({
-        toolName: canonicalKey,
-        callId: 'future_function_call',
-      }),
-    ).toBe(true);
-    expect(
-      restored._context.isToolApproved({
-        toolName: 'crm.lookup',
-        callId: 'future_shell_call',
-        functionTool: false,
-      }),
-    ).toBe(false);
-  });
-
-  it('keeps ambiguous legacy function fallback separate from an exact non-function override', async () => {
-    const dottedLookup = tool({
-      name: 'crm_lookup',
-      description: 'Dotted lookup.',
-      parameters: z.object({}),
-      execute: async () => 'dotted',
-    });
-    dottedLookup.name = 'crm.lookup';
-    const namespacedLookup = toolNamespace({
-      name: 'crm',
-      description: 'CRM tools.',
-      tools: [
-        tool({
-          name: 'lookup',
-          description: 'Namespaced lookup.',
-          parameters: z.object({}),
-          execute: async () => 'namespaced',
-        }),
-      ],
-    })[0]!;
-    const callId = 'ambiguous_merge_call';
-    const toolCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      name: 'lookup',
-      namespace: 'crm',
-      callId,
-      status: 'completed',
-      arguments: '{}',
-    };
-    const agent = new Agent({
-      name: 'Ambiguous legacy fallback merge',
-      tools: [dottedLookup, namespacedLookup],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    state._lastProcessedResponse = {
-      newItems: [],
-      functions: [{ toolCall, tool: namespacedLookup as any }],
-      handoffs: [],
-      computerActions: [],
-      shellActions: [],
-      applyPatchActions: [],
-      mcpApprovalRequests: [],
-      toolsUsed: ['crm.lookup'],
-      hasToolsOrApprovalsToRun: () => true,
-    };
-    const serialized = state.toJSON() as any;
-    serialized.$schemaVersion = '1.15';
-    serialized.context.approvals = {
-      'crm.lookup': {
-        approved: false,
-        rejected: true,
-        stickyRejectMessage: 'Legacy rejection',
-      },
-    };
-
-    const overrideContext = new RunContext();
-    overrideContext.approveTool(
-      new ToolApprovalItem(
-        {
-          type: 'shell_call',
-          callId: 'shell_override_call',
-          status: 'completed',
-          action: { commands: ['echo approved'] },
-        },
-        agent,
-        'crm.lookup',
-      ),
-      { alwaysApprove: true },
-    );
-
-    const restored = await RunState.fromStringWithContext(
-      agent,
-      JSON.stringify(serialized),
-      overrideContext,
-      { contextStrategy: 'merge' },
-    );
-    const namespacedKey = getFunctionToolStateKey(namespacedLookup)!;
-    const dottedKey = getFunctionToolStateKey(dottedLookup)!;
-
-    for (const [toolName, checkedCallId] of [
-      [namespacedKey, callId],
-      [namespacedKey, 'future_namespaced_call'],
-      [dottedKey, 'future_dotted_call'],
-    ] as const) {
-      expect(
-        restored._context.isToolApproved({
-          toolName,
-          callId: checkedCallId,
-          functionTool: false,
-          agent,
-        }),
-      ).toBe(false);
-    }
-    expect(
-      restored._context.isToolApproved({
-        toolName: 'crm.lookup',
-        callId: 'future_shell_call',
-        functionTool: false,
-      }),
-    ).toBe(true);
-
-    const durable = restored.toJSON() as any;
-    expect(durable.context.approvals['crm.lookup'].approved).toBe(true);
-    expect(durable.context.legacyFunctionApprovals['crm.lookup'].rejected).toBe(
-      true,
-    );
-
-    const roundTripped = await RunState.fromString(agent, restored.toString());
-    expect(
-      roundTripped._context.isToolApproved({
-        toolName: dottedKey,
-        callId: 'round_trip_function_call',
-        functionTool: false,
-        agent,
-      }),
-    ).toBe(false);
-    expect(
-      roundTripped._context.isToolApproved({
-        toolName: 'crm.lookup',
-        callId: 'round_trip_shell_call',
-        functionTool: false,
-      }),
-    ).toBe(true);
-  });
-
-  it('keeps schema 1.15 approval ownership when merging a canonical override context', async () => {
-    const decisions = [
-      {
-        name: 'per-call approval',
-        record: (callId: string) => ({
-          approved: [callId],
-          rejected: [],
-        }),
-        expected: true,
-      },
-      {
-        name: 'permanent rejection',
-        record: (callId: string) => ({
-          approved: false,
-          rejected: true,
-          messages: { [callId]: 'Always rejected' },
-          stickyRejectMessage: 'Always rejected',
-        }),
-        expected: false,
-        message: 'Always rejected',
-      },
-    ];
-
-    for (const decision of decisions) {
-      const dottedLookup = tool({
-        name: 'crm_lookup',
-        description: 'Dotted lookup.',
-        parameters: z.object({}),
-        execute: async () => 'dotted',
-      });
-      dottedLookup.name = 'crm.lookup';
-      const namespacedLookup = toolNamespace({
-        name: 'crm',
-        description: 'CRM tools.',
-        tools: [
-          tool({
-            name: 'lookup',
-            description: 'Namespaced lookup.',
-            parameters: z.object({}),
-            execute: async () => 'namespaced',
-          }),
-        ],
-      })[0]!;
-      const agent = new Agent({
-        name: `MergeApproval-${decision.name}`,
-        tools: [dottedLookup, namespacedLookup],
-      });
-      const callId = `namespaced-${decision.name.replace(/ /g, '-')}`;
-      const namespacedCall: protocol.FunctionCallItem = {
-        type: 'function_call',
-        name: 'lookup',
-        namespace: 'crm',
-        callId,
-        status: 'completed',
-        arguments: '{}',
-      };
-      const state = new RunState(new RunContext(), 'input', agent, 2);
-      state._lastProcessedResponse = {
-        newItems: [],
-        functions: [
-          { toolCall: namespacedCall, tool: namespacedLookup as any },
-        ],
-        handoffs: [],
-        computerActions: [],
-        shellActions: [],
-        applyPatchActions: [],
-        mcpApprovalRequests: [],
-        toolsUsed: ['crm.lookup'],
-        hasToolsOrApprovalsToRun: () => true,
-      };
-      state._currentStep = {
-        type: 'next_step_interruption',
-        data: {
-          interruptions: [new ToolApprovalItem(namespacedCall, agent)],
-        },
-      };
-      const serialized = state.toJSON() as any;
-      serialized.$schemaVersion = '1.15';
-      serialized.context.approvals = {
-        'crm.lookup': decision.record(callId),
-        other: {
-          approved: ['serialized-other-call'],
-          rejected: [],
-        },
-      };
-      delete serialized.currentStep.data.interruptions[0].functionToolStateKey;
-
-      const overrideContext = new RunContext();
-      const existingBareCall: protocol.FunctionCallItem = {
-        type: 'function_call',
-        name: 'crm.lookup',
-        callId: 'existing-bare-call',
-        status: 'completed',
-        arguments: '{}',
-      };
-      overrideContext.approveTool(
-        new ToolApprovalItem(
-          existingBareCall,
-          agent,
-          undefined,
-          getFunctionToolStateKey(dottedLookup),
-        ),
-      );
-      overrideContext.approveTool(
-        new ToolApprovalItem(
-          {
-            type: 'function_call',
-            name: 'other',
-            callId: 'override-other-call',
-            status: 'completed',
-            arguments: '{}',
-          },
-          agent,
-        ),
-      );
-      overrideContext.approveTool(
-        new ToolApprovalItem(
-          {
-            type: 'shell_call',
-            callId: 'override-shell-call',
-            status: 'completed',
-            action: { commands: ['echo approved'] },
-          },
-          agent,
-          'crm.lookup',
-        ),
-        { alwaysApprove: true },
-      );
-
-      const restored = await RunState.fromStringWithContext(
-        agent,
-        JSON.stringify(serialized),
-        overrideContext,
-        { contextStrategy: 'merge' },
-      );
-      const namespacedKey = getFunctionToolStateKey(namespacedLookup)!;
-      const bareKey = getFunctionToolStateKey(dottedLookup)!;
-      const isPermanent = decision.name.startsWith('permanent');
-
-      expect(
-        restored._context.isToolApproved({
-          toolName: namespacedKey,
-          callId,
-        }),
-        decision.name,
-      ).toBe(decision.expected);
-      expect(restored._context.getRejectionMessage(namespacedKey, callId)).toBe(
-        decision.message,
-      );
-      expect(
-        restored._context.isToolApproved({
-          toolName: namespacedKey,
-          callId: `${callId}-future`,
-        }),
-      ).toBe(isPermanent ? decision.expected : undefined);
-      expect(
-        restored._context.isToolApproved({
-          toolName: 'crm.lookup',
-          callId,
-          functionTool: false,
-        }),
-      ).toBe(true);
-      expect(
-        restored._context.getRejectionMessage('crm.lookup', callId, {
-          functionTool: false,
-        }),
-      ).toBeUndefined();
-      expect(
-        restored._context.isToolApproved({
-          toolName: bareKey,
-          callId: 'existing-bare-call',
-          agent,
-        }),
-      ).toBe(true);
-      expect(
-        restored._context.isToolApproved({
-          toolName: bareKey,
-          callId: 'future-bare-call',
-          agent,
-        }),
-      ).toBe(isPermanent ? decision.expected : undefined);
-      expect(
-        restored._context.isToolApproved({
-          toolName: 'other',
-          callId: 'serialized-other-call',
-          functionTool: false,
-        }),
-      ).toBe(true);
-      expect(
-        restored._context.isToolApproved({
-          toolName: '["bare","other"]',
-          callId: 'override-other-call',
-        }),
-      ).toBe(true);
-      expect(
-        restored._context.isToolApproved({
-          toolName: '["bare","other"]',
-          callId: 'serialized-other-call',
-        }),
-      ).toBeUndefined();
-      expect(
-        restored._context.isToolApproved({
-          toolName: 'other',
-          callId: 'override-other-call',
-          functionTool: false,
-        }),
-      ).toBeUndefined();
-    }
-  });
-
   it('accepts schema version 1.6 payloads during deserialization', async () => {
     const context = new RunContext();
     const agent = new Agent({ name: 'Agent16' });
@@ -2841,74 +2099,6 @@ describe('RunState', () => {
       call_id: 'call_ts_raw',
       execution: 'server',
     });
-  });
-
-  it('rehydrates client tool_search outputs without explicit call_id by FIFO order', async () => {
-    const runtimeLookup = tool({
-      name: 'lookup_runtime',
-      description: 'Look up a runtime record.',
-      parameters: z.object({}),
-      execute: async () => 'runtime',
-    });
-    const execute = vi.fn(async () => runtimeLookup);
-    const clientToolSearch = attachClientToolSearchExecutor(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: { type: 'tool_search', execution: 'client' },
-      },
-      execute,
-    );
-    const agent = new Agent({
-      name: 'No call id tool-search restore agent',
-      tools: [clientToolSearch],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    state._generatedItems.push(
-      new RunToolSearchCallItem(
-        {
-          type: 'tool_search_call',
-          id: 'ts_call_without_call_id',
-          execution: 'client',
-          status: 'completed',
-          arguments: {},
-        } as protocol.ToolSearchCallItem,
-        agent,
-      ),
-      new RunToolSearchOutputItem(
-        {
-          type: 'tool_search_output',
-          id: 'ts_output_without_call_id',
-          execution: 'client',
-          status: 'completed',
-          tools: [
-            {
-              type: 'function',
-              name: 'lookup_runtime',
-              description: 'Look up a runtime record.',
-              strict: true,
-              parameters: {
-                type: 'object',
-                properties: {},
-                required: [],
-                additionalProperties: false,
-              },
-            },
-          ],
-        } as protocol.ToolSearchOutputItem,
-        agent,
-      ),
-    );
-
-    const restored = await RunState.fromString(agent, state.toString());
-
-    expect(execute).toHaveBeenCalledOnce();
-    expect(
-      await (restored.getToolSearchRuntimeTools(agent)[0] as any).invoke(
-        new RunContext(),
-        '{}',
-      ),
-    ).toBe('runtime');
   });
 
   it('skips rehydration for server tool_search outputs with concrete tool payloads', async () => {
@@ -3124,3368 +2314,6 @@ describe('RunState', () => {
     expect(restored.getToolSearchRuntimeTools(betaAgent)).toEqual([betaLookup]);
   });
 
-  it('uses the collision-filtered tool winner during tool-search rehydration', async () => {
-    const firstDuplicate = tool({
-      name: 'duplicate',
-      description: 'First duplicate.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'first',
-    });
-    const winningDuplicate = tool({
-      name: 'duplicate',
-      description: 'Winning duplicate.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'winner',
-    });
-    const losingRuntimeTool = tool({
-      name: 'losing_runtime',
-      description: 'Runtime tool selected from the unfiltered list.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'losing runtime',
-    });
-    const winningRuntimeTool = tool({
-      name: 'winning_runtime',
-      description: 'Runtime tool selected from the filtered list.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'winning runtime',
-    });
-    const execute = vi.fn(
-      async ({ availableTools }: { availableTools: Tool<any>[] }) => {
-        const selectedDuplicate = availableTools.find(
-          (candidate) =>
-            candidate.type === 'function' && candidate.name === 'duplicate',
-        );
-        return selectedDuplicate === winningDuplicate
-          ? winningRuntimeTool
-          : losingRuntimeTool;
-      },
-    );
-    const clientToolSearch = attachClientToolSearchExecutor(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: {
-          type: 'tool_search',
-          execution: 'client',
-        },
-      },
-      execute,
-    );
-    const agent = new Agent({
-      name: 'Collision-filtered restore agent',
-      tools: [firstDuplicate, winningDuplicate, clientToolSearch],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    const callId = 'call_collision_filtered_restore';
-    state._generatedItems.push(
-      new RunToolSearchCallItem(
-        {
-          type: 'tool_search_call',
-          id: 'ts_call_collision_filtered_restore',
-          status: 'completed',
-          arguments: { query: 'runtime' },
-          providerData: { call_id: callId, execution: 'client' },
-        } as protocol.ToolSearchCallItem,
-        agent,
-      ),
-      new RunToolSearchOutputItem(
-        {
-          type: 'tool_search_output',
-          id: 'ts_output_collision_filtered_restore',
-          status: 'completed',
-          tools: [
-            {
-              type: 'function',
-              name: 'winning_runtime',
-              description: 'Runtime tool selected from the filtered list.',
-              strict: true,
-              parameters: {
-                type: 'object',
-                properties: {},
-                required: [],
-                additionalProperties: false,
-              },
-            },
-          ],
-          providerData: { call_id: callId, execution: 'client' },
-        } as protocol.ToolSearchOutputItem,
-        agent,
-      ),
-    );
-
-    allowConsole(['warn']);
-    const restored = await RunState.fromString(agent, state.toString());
-
-    expect(execute).toHaveBeenCalledTimes(1);
-    expect(execute.mock.calls[0]?.[0].availableTools).toEqual([
-      winningDuplicate,
-      clientToolSearch,
-    ]);
-    expect(restored.getToolSearchRuntimeTools(agent)).toEqual([
-      winningRuntimeTool,
-    ]);
-  });
-
-  it('freezes collision-filtered capabilities across tool-search rehydration callbacks', async () => {
-    type TestContext = {
-      functionEnabled: boolean;
-      handoffEnabled: boolean;
-    };
-
-    const transferFunction = tool({
-      name: 'transfer',
-      description: 'Function with the same name as a dynamic handoff.',
-      parameters: z.object({}).strict(),
-      isEnabled: ({ runContext }) =>
-        (runContext.context as TestContext).functionEnabled,
-      execute: async () => 'function',
-    });
-    const firstRuntimeTool = tool({
-      name: 'first_runtime',
-      description: 'First runtime tool.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'first runtime',
-    });
-    const secondRuntimeTool = tool({
-      name: 'second_runtime',
-      description: 'Second runtime tool.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'second runtime',
-    });
-    const availableToolSnapshots: Tool<any>[][] = [];
-    const execute = vi.fn(
-      async ({
-        availableTools,
-        runContext,
-      }: {
-        availableTools: Tool<TestContext>[];
-        runContext: RunContext<TestContext>;
-      }) => {
-        availableToolSnapshots.push(availableTools);
-        if (availableToolSnapshots.length === 1) {
-          runContext.context.functionEnabled = false;
-          runContext.context.handoffEnabled = true;
-          return firstRuntimeTool;
-        }
-        return secondRuntimeTool;
-      },
-    );
-    const clientToolSearch = attachClientToolSearchExecutor<TestContext>(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: {
-          type: 'tool_search',
-          execution: 'client',
-        },
-      },
-      execute,
-    );
-    const target = new Agent<TestContext>({ name: 'Dynamic target' });
-    const agent = new Agent<TestContext>({
-      name: 'Frozen capability restore agent',
-      tools: [transferFunction, clientToolSearch],
-      handoffs: [
-        handoff(target, {
-          toolNameOverride: 'transfer',
-          isEnabled: ({ runContext }) => runContext.context.handoffEnabled,
-        }),
-      ],
-    });
-    const state = new RunState(
-      new RunContext({ functionEnabled: true, handoffEnabled: false }),
-      'input',
-      agent,
-      2,
-    );
-    const processedToolCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      id: 'fc_frozen_capability_restore',
-      callId: 'call_frozen_capability_restore',
-      name: 'transfer',
-      status: 'completed',
-      arguments: '{}',
-    };
-    state._lastProcessedResponse = {
-      newItems: [],
-      functions: [
-        { toolCall: processedToolCall, tool: transferFunction as any },
-      ],
-      handoffs: [],
-      computerActions: [],
-      shellActions: [],
-      applyPatchActions: [],
-      mcpApprovalRequests: [],
-      toolsUsed: ['transfer'],
-      hasToolsOrApprovalsToRun: () => true,
-    };
-    const addSerializedToolSearchResult = (
-      callId: string,
-      runtimeToolName: string,
-    ) => {
-      state._generatedItems.push(
-        new RunToolSearchCallItem(
-          {
-            type: 'tool_search_call',
-            id: `ts_${callId}`,
-            status: 'completed',
-            arguments: { query: runtimeToolName },
-            providerData: { call_id: callId, execution: 'client' },
-          } as protocol.ToolSearchCallItem,
-          agent as Agent<any, any>,
-        ),
-        new RunToolSearchOutputItem(
-          {
-            type: 'tool_search_output',
-            id: `tso_${callId}`,
-            status: 'completed',
-            tools: [
-              {
-                type: 'function',
-                name: runtimeToolName,
-                description: `${runtimeToolName} description.`,
-                strict: true,
-                parameters: {
-                  type: 'object',
-                  properties: {},
-                  required: [],
-                  additionalProperties: false,
-                },
-              },
-            ],
-            providerData: { call_id: callId, execution: 'client' },
-          } as protocol.ToolSearchOutputItem,
-          agent as Agent<any, any>,
-        ),
-      );
-    };
-    addSerializedToolSearchResult('call_first', 'first_runtime');
-    addSerializedToolSearchResult('call_second', 'second_runtime');
-
-    const restored = await RunState.fromString(agent, state.toString());
-
-    expect(execute).toHaveBeenCalledTimes(2);
-    expect(availableToolSnapshots).toEqual([
-      [transferFunction, clientToolSearch],
-      [transferFunction, clientToolSearch, firstRuntimeTool],
-    ]);
-    expect(restored.getToolSearchRuntimeTools(agent)).toEqual([
-      firstRuntimeTool,
-      secondRuntimeTool,
-    ]);
-    expect(restored._lastProcessedResponse?.functions[0]?.tool).toBe(
-      transferFunction,
-    );
-  });
-
-  it.each(['bare', 'namespaced', 'deferred'] as const)(
-    'round-trips the final same-key %s runtime tool from distinct tool-search calls',
-    async (kind) => {
-      const availableToolNames: string[][] = [];
-      const execute = vi.fn(
-        async ({
-          availableTools,
-          toolCall,
-        }: {
-          availableTools: Tool<any>[];
-          toolCall: protocol.ToolSearchCallItem;
-        }) => {
-          availableToolNames.push(availableTools.map((entry) => entry.name));
-          const result = String(
-            (toolCall.arguments as { result?: string }).result,
-          );
-          const runtimeTool = tool({
-            name: 'lookup',
-            description: `${result} lookup result.`,
-            parameters: z.object({}).strict(),
-            ...(kind === 'deferred' ? { deferLoading: true } : {}),
-            execute: async () => result,
-          });
-          return kind === 'namespaced'
-            ? toolNamespace({
-                name: 'crm',
-                description: 'CRM tools.',
-                tools: [runtimeTool],
-              })[0]
-            : runtimeTool;
-        },
-      );
-      const clientToolSearch = attachClientToolSearchExecutor(
-        {
-          type: 'hosted_tool',
-          name: 'tool_search',
-          providerData: {
-            type: 'tool_search',
-            execution: 'client',
-          },
-        },
-        execute,
-      );
-      const agent = new Agent({
-        name: 'Same-key round-trip agent',
-        tools: [clientToolSearch],
-      });
-      const state = new RunState(new RunContext(), 'input', agent, 2);
-      const createToolSearchCall = (
-        id: string,
-        result: string,
-      ): protocol.ToolSearchCallItem =>
-        ({
-          type: 'tool_search_call',
-          id: `ts_${id}`,
-          status: 'completed',
-          arguments: { result },
-          providerData: { call_id: id, execution: 'client' },
-        }) as protocol.ToolSearchCallItem;
-      const response: ModelResponse = {
-        output: [
-          createToolSearchCall('call_first_lookup', 'first'),
-          createToolSearchCall('call_second_lookup', 'second'),
-        ],
-        usage: new Usage(),
-      };
-
-      const processed = await processModelResponseAsync(
-        response,
-        agent,
-        [clientToolSearch],
-        [],
-        state,
-        [],
-      );
-      state._generatedItems.push(...processed.newItems);
-      state._lastProcessedResponse = processed;
-
-      const liveTools = state.getToolSearchRuntimeTools(agent);
-      expect(liveTools).toHaveLength(1);
-      expect(await (liveTools[0] as any).invoke(new RunContext(), '{}')).toBe(
-        'second',
-      );
-
-      const restored = await RunState.fromString(agent, state.toString());
-      const restoredTools = restored.getToolSearchRuntimeTools(agent);
-
-      expect(availableToolNames).toEqual([
-        ['tool_search'],
-        ['tool_search', 'lookup'],
-        ['tool_search'],
-        ['tool_search', 'lookup'],
-      ]);
-      expect(restoredTools).toHaveLength(1);
-      expect(
-        await (restoredTools[0] as any).invoke(new RunContext(), '{}'),
-      ).toBe('second');
-    },
-  );
-
-  it('round-trips interleaved handlers and callback inputs for repeated client tool_search call ids', async () => {
-    const execute = vi.fn(
-      async ({
-        availableTools,
-        toolCall,
-      }: {
-        availableTools: Tool<any>[];
-        toolCall: protocol.ToolSearchCallItem;
-      }) => {
-        const phase = String((toolCall.arguments as { phase?: string }).phase);
-        const hasFirstResult = availableTools.some(
-          (availableTool) =>
-            availableTool.type === 'function' &&
-            availableTool.description === 'first lookup result.',
-        );
-        const result = phase === 'final' && !hasFirstResult ? 'wrong' : phase;
-        return tool({
-          name: result === 'wrong' ? 'wrong_lookup' : 'lookup',
-          description: `${result} lookup result.`,
-          parameters: z.object({}).strict(),
-          needsApproval: true,
-          execute: async () => result,
-        });
-      },
-    );
-    const clientToolSearch = attachClientToolSearchExecutor(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: { type: 'tool_search', execution: 'client' },
-      },
-      execute,
-    );
-    const agent = new Agent({
-      name: 'Repeated call id restore agent',
-      tools: [clientToolSearch],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    const sharedCallId = 'call_repeated_replacement';
-    const createToolSearchCall = (
-      id: string,
-      phase: string,
-    ): protocol.ToolSearchCallItem =>
-      ({
-        type: 'tool_search_call',
-        id,
-        status: 'completed',
-        arguments: { phase },
-        providerData: { call_id: sharedCallId, execution: 'client' },
-      }) as protocol.ToolSearchCallItem;
-    const functionCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      id: 'fc_repeated_replacement',
-      callId: 'call_repeated_replacement_function',
-      name: 'lookup',
-      status: 'completed',
-      arguments: '{}',
-    };
-    const processed = await processModelResponseAsync(
-      {
-        output: [
-          createToolSearchCall('ts_repeated_first', 'first'),
-          functionCall,
-          createToolSearchCall('ts_repeated_final', 'final'),
-        ],
-        usage: new Usage(),
-      },
-      agent,
-      [clientToolSearch],
-      [],
-      state,
-      [],
-    );
-    state._generatedItems.push(...processed.newItems);
-    state._lastProcessedResponse = processed;
-
-    expect(
-      await (processed.functions[0]!.tool as any).invoke(
-        new RunContext(),
-        '{}',
-      ),
-    ).toBe('first');
-    expect(state.getToolSearchRuntimeTools(agent)).toHaveLength(1);
-    expect(
-      await (state.getToolSearchRuntimeTools(agent)[0] as any).invoke(
-        new RunContext(),
-        '{}',
-      ),
-    ).toBe('final');
-
-    const restored = await RunState.fromString(agent, state.toString());
-
-    expect(execute).toHaveBeenCalledTimes(4);
-    expect(restored.getToolSearchRuntimeTools(agent)).toHaveLength(1);
-    expect(
-      await (restored._lastProcessedResponse?.functions[0]!.tool as any).invoke(
-        new RunContext(),
-        '{}',
-      ),
-    ).toBe('first');
-    expect(
-      await (restored.getToolSearchRuntimeTools(agent)[0] as any).invoke(
-        new RunContext(),
-        '{}',
-      ),
-    ).toBe('final');
-
-    await rehydrateProcessedResponseTools(
-      agent,
-      restored,
-      restored.getToolSearchRuntimeTools(agent),
-    );
-
-    expect(
-      await (restored._lastProcessedResponse?.functions[0]!.tool as any).invoke(
-        new RunContext(),
-        '{}',
-      ),
-    ).toBe('first');
-  });
-
-  it.each(['empty', 'disabled', 'different'] as const)(
-    'does not resurrect an older routed owner after a later call is replaced with %s',
-    async (replacement) => {
-      const firstLookup = tool({
-        name: 'lookup',
-        description: 'First lookup owner.',
-        parameters: z.object({}).strict(),
-        execute: async () => 'first',
-      });
-      const secondLookup = tool({
-        name: 'lookup',
-        description: 'Second lookup owner.',
-        parameters: z.object({}).strict(),
-        execute: async () => 'second',
-      });
-      const disabledLookup = tool({
-        name: 'lookup',
-        description: 'Disabled final lookup.',
-        parameters: z.object({}).strict(),
-        isEnabled: false,
-        execute: async () => 'disabled',
-      });
-      const alternateLookup = tool({
-        name: 'alternate_lookup',
-        description: 'Different final lookup.',
-        parameters: z.object({}).strict(),
-        execute: async () => 'alternate',
-      });
-      const execute = vi.fn(
-        async ({ toolCall }: { toolCall: protocol.ToolSearchCallItem }) => {
-          const phase = String(
-            (toolCall.arguments as { phase?: string }).phase,
-          );
-          if (phase === 'first') {
-            return firstLookup;
-          }
-          if (phase === 'second') {
-            return secondLookup;
-          }
-          if (replacement === 'disabled') {
-            return disabledLookup;
-          }
-          if (replacement === 'different') {
-            return alternateLookup;
-          }
-          return [];
-        },
-      );
-      const clientToolSearch = attachClientToolSearchExecutor(
-        {
-          type: 'hosted_tool',
-          name: 'tool_search',
-          providerData: { type: 'tool_search', execution: 'client' },
-        },
-        execute,
-      );
-      const agent = new Agent({
-        name: `Routed owner ${replacement} agent`,
-        tools: [clientToolSearch],
-      });
-      const state = new RunState(new RunContext(), 'input', agent, 2);
-      const createCall = (
-        id: string,
-        callId: string,
-        phase: string,
-      ): protocol.ToolSearchCallItem =>
-        ({
-          type: 'tool_search_call',
-          id,
-          status: 'completed',
-          arguments: { phase },
-          providerData: { call_id: callId, execution: 'client' },
-        }) as protocol.ToolSearchCallItem;
-      const processed = await processModelResponseAsync(
-        {
-          output: [
-            createCall('ts_owner_first', 'call_owner_first', 'first'),
-            createCall('ts_owner_second', 'call_owner_second', 'second'),
-            createCall('ts_owner_final', 'call_owner_second', 'final'),
-          ],
-          usage: new Usage(),
-        },
-        agent,
-        [clientToolSearch],
-        [],
-        state,
-        [],
-      );
-      state._generatedItems.push(...processed.newItems);
-      state._lastProcessedResponse = processed;
-
-      const expectedTools = replacement === 'different' ? 1 : 0;
-      expect(state.getToolSearchRuntimeTools(agent)).toHaveLength(
-        expectedTools,
-      );
-      if (replacement === 'different') {
-        expect(
-          await (state.getToolSearchRuntimeTools(agent)[0] as any).invoke(
-            new RunContext(),
-            '{}',
-          ),
-        ).toBe('alternate');
-      }
-
-      const restored = await RunState.fromString(agent, state.toString());
-
-      expect(restored.getToolSearchRuntimeTools(agent)).toHaveLength(
-        expectedTools,
-      );
-      if (replacement === 'different') {
-        expect(
-          await (restored.getToolSearchRuntimeTools(agent)[0] as any).invoke(
-            new RunContext(),
-            '{}',
-          ),
-        ).toBe('alternate');
-      }
-    },
-  );
-
-  it('keeps a later routed owner when an older call returned the same tool object', async () => {
-    const sharedLookup = tool({
-      name: 'lookup',
-      description: 'Shared lookup owner.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'shared',
-    });
-    const execute = vi.fn(
-      async ({ toolCall }: { toolCall: protocol.ToolSearchCallItem }) =>
-        (toolCall.arguments as { phase?: string }).phase === 'empty'
-          ? []
-          : sharedLookup,
-    );
-    const clientToolSearch = attachClientToolSearchExecutor(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: { type: 'tool_search', execution: 'client' },
-      },
-      execute,
-    );
-    const agent = new Agent({
-      name: 'Shared object routed owner',
-      tools: [clientToolSearch],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    const createSearchCall = (
-      id: string,
-      callId: string,
-      phase: string,
-    ): protocol.ToolSearchCallItem =>
-      ({
-        type: 'tool_search_call',
-        id,
-        status: 'completed',
-        arguments: { phase },
-        providerData: { call_id: callId, execution: 'client' },
-      }) as protocol.ToolSearchCallItem;
-    const functionCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      id: 'fc_shared_object_owner',
-      callId: 'call_shared_object_owner',
-      name: 'lookup',
-      status: 'completed',
-      arguments: '{}',
-    };
-    const processed = await processModelResponseAsync(
-      {
-        output: [
-          createSearchCall('ts_owner_a', 'owner_a', 'shared'),
-          createSearchCall('ts_owner_b', 'owner_b', 'shared'),
-          createSearchCall('ts_owner_a_empty', 'owner_a', 'empty'),
-          functionCall,
-        ],
-        usage: new Usage(),
-      },
-      agent,
-      [clientToolSearch],
-      [],
-      state,
-      [],
-    );
-    state._generatedItems.push(...processed.newItems);
-    state._lastProcessedResponse = processed;
-
-    expect(processed.functions[0]?.tool).toBe(sharedLookup);
-    expect(state.getToolSearchRuntimeTools(agent)).toEqual([sharedLookup]);
-
-    const restored = await RunState.fromString(agent, state.toString());
-
-    expect(restored._lastProcessedResponse?.functions[0]?.tool).toBe(
-      sharedLookup,
-    );
-    expect(restored.getToolSearchRuntimeTools(agent)).toEqual([sharedLookup]);
-  });
-
-  it('restores the runtime handler bound before a later same-key replacement', async () => {
-    const execute = vi.fn(
-      async ({ toolCall }: { toolCall: protocol.ToolSearchCallItem }) => {
-        const result = String(
-          (toolCall.arguments as { result?: string }).result,
-        );
-        return tool({
-          name: 'lookup',
-          description: `${result} lookup result.`,
-          parameters: z.object({}).strict(),
-          needsApproval: true,
-          execute: async () => result,
-        });
-      },
-    );
-    const clientToolSearch = attachClientToolSearchExecutor(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: { type: 'tool_search', execution: 'client' },
-      },
-      execute,
-    );
-    const agent = new Agent({
-      name: 'Interleaved replacement restore agent',
-      tools: [clientToolSearch],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    const firstSearchCall = {
-      type: 'tool_search_call',
-      id: 'ts_call_first_interleaved',
-      status: 'completed',
-      arguments: { result: 'first' },
-      providerData: {
-        call_id: 'call_first_interleaved',
-        execution: 'client',
-      },
-    } as protocol.ToolSearchCallItem;
-    const functionCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      id: 'fc_interleaved_lookup',
-      callId: 'call_interleaved_lookup',
-      name: 'lookup',
-      status: 'completed',
-      arguments: '{}',
-    };
-    const secondSearchCall = {
-      type: 'tool_search_call',
-      id: 'ts_call_second_interleaved',
-      status: 'completed',
-      arguments: { result: 'second' },
-      providerData: {
-        call_id: 'call_second_interleaved',
-        execution: 'client',
-      },
-    } as protocol.ToolSearchCallItem;
-    const response: ModelResponse = {
-      output: [firstSearchCall, functionCall, secondSearchCall],
-      usage: new Usage(),
-    };
-
-    const processed = await processModelResponseAsync(
-      response,
-      agent,
-      [clientToolSearch],
-      [],
-      state,
-      [],
-    );
-    state._generatedItems.push(...processed.newItems);
-    state._lastProcessedResponse = processed;
-
-    expect(
-      await (processed.functions[0].tool as any).invoke(new RunContext(), '{}'),
-    ).toBe('first');
-    expect(
-      await (state.getToolSearchRuntimeTools(agent)[0] as any).invoke(
-        new RunContext(),
-        '{}',
-      ),
-    ).toBe('second');
-
-    const restored = await RunState.fromString(agent, state.toString());
-
-    expect(
-      await (restored._lastProcessedResponse?.functions[0].tool as any).invoke(
-        new RunContext(),
-        '{}',
-      ),
-    ).toBe('first');
-    expect(
-      await (restored.getToolSearchRuntimeTools(agent)[0] as any).invoke(
-        new RunContext(),
-        '{}',
-      ),
-    ).toBe('second');
-  });
-
-  it('round trips a flattened configured namespace call with its canonical approval key', async () => {
-    const namespacedLookup = toolNamespace({
-      name: 'crm',
-      description: 'CRM tools.',
-      tools: [
-        tool({
-          name: 'lookup',
-          description: 'Configured CRM lookup.',
-          parameters: z.object({}).strict(),
-          needsApproval: true,
-          execute: async () => 'configured',
-        }),
-      ],
-    })[0];
-    const agent = new Agent({
-      name: 'Flattened configured namespace restore agent',
-      tools: [namespacedLookup],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    const flattenedCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      id: 'fc_flattened_configured_namespace',
-      callId: 'call_flattened_configured_namespace',
-      name: 'crm.lookup',
-      status: 'completed',
-      arguments: '{}',
-    };
-    const processed = await processModelResponseAsync(
-      { output: [flattenedCall], usage: new Usage() },
-      agent,
-      [namespacedLookup],
-      [],
-      state,
-      [],
-    );
-    const normalizedCall = processed.functions[0]!.toolCall;
-    const canonicalKey = getFunctionToolStateKey(namespacedLookup)!;
-    state._generatedItems.push(...processed.newItems);
-    state._lastProcessedResponse = processed;
-    state._currentStep = {
-      type: 'next_step_interruption',
-      data: {
-        interruptions: [
-          new ToolApprovalItem(normalizedCall, agent, undefined, canonicalKey),
-        ],
-      },
-    };
-
-    expect(normalizedCall).toMatchObject({
-      name: 'lookup',
-      namespace: 'crm',
-    });
-
-    const restored = await RunState.fromString(agent, state.toString());
-
-    expect(
-      restored._lastProcessedResponse?.functions[0]?.toolCall,
-    ).toMatchObject({ name: 'lookup', namespace: 'crm' });
-    expect(restored.getInterruptions()[0]?.functionToolStateKey).toBe(
-      canonicalKey,
-    );
-    expect(restored.getInterruptions()[0]?.rawItem).toMatchObject({
-      name: 'lookup',
-      namespace: 'crm',
-    });
-    expect(
-      await (restored._lastProcessedResponse?.functions[0]?.tool as any).invoke(
-        new RunContext(),
-        '{}',
-      ),
-    ).toBe('configured');
-  });
-
-  it('round trips a flattened namespace call with its runtime tool-search handler', async () => {
-    const execute = vi.fn(async () =>
-      toolNamespace({
-        name: 'crm',
-        description: 'Runtime CRM tools.',
-        tools: [
-          tool({
-            name: 'lookup',
-            description: 'Runtime CRM lookup.',
-            parameters: z.object({}).strict(),
-            needsApproval: true,
-            execute: async () => 'runtime',
-          }),
-        ],
-      }),
-    );
-    const clientToolSearch = attachClientToolSearchExecutor(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: { type: 'tool_search', execution: 'client' },
-      },
-      execute,
-    );
-    const agent = new Agent({
-      name: 'Flattened runtime namespace restore agent',
-      tools: [clientToolSearch],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    const flattenedCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      id: 'fc_flattened_runtime_namespace',
-      callId: 'call_flattened_runtime_namespace',
-      name: 'crm.lookup',
-      status: 'completed',
-      arguments: '{}',
-    };
-    const processed = await processModelResponseAsync(
-      {
-        output: [
-          {
-            type: 'tool_search_call',
-            id: 'ts_flattened_runtime_namespace',
-            status: 'completed',
-            arguments: {},
-            providerData: {
-              call_id: 'search_flattened_runtime_namespace',
-              execution: 'client',
-            },
-          } as protocol.ToolSearchCallItem,
-          flattenedCall,
-        ],
-        usage: new Usage(),
-      },
-      agent,
-      [clientToolSearch],
-      [],
-      state,
-      [],
-    );
-    const normalizedCall = processed.functions[0]!.toolCall;
-    const runtimeTool = processed.functions[0]!.tool;
-    const canonicalKey = getFunctionToolStateKey(runtimeTool)!;
-    state._generatedItems.push(...processed.newItems);
-    state._lastProcessedResponse = processed;
-    state._currentStep = {
-      type: 'next_step_interruption',
-      data: {
-        interruptions: [
-          new ToolApprovalItem(normalizedCall, agent, undefined, canonicalKey),
-        ],
-      },
-    };
-
-    const restored = await RunState.fromString(agent, state.toString());
-
-    expect(execute).toHaveBeenCalledTimes(2);
-    expect(
-      restored._lastProcessedResponse?.functions[0]?.toolCall,
-    ).toMatchObject({ name: 'lookup', namespace: 'crm' });
-    expect(restored.getInterruptions()[0]?.functionToolStateKey).toBe(
-      canonicalKey,
-    );
-    expect(
-      await (restored._lastProcessedResponse?.functions[0]?.tool as any).invoke(
-        new RunContext(),
-        '{}',
-      ),
-    ).toBe('runtime');
-
-    const restoredProcessedTool =
-      restored._lastProcessedResponse?.functions[0]?.tool;
-
-    await rehydrateProcessedResponseTools(agent, restored, []);
-
-    expect(restored._lastProcessedResponse?.functions[0]?.tool).toBe(
-      restoredProcessedTool,
-    );
-    expect(
-      await (restored._lastProcessedResponse?.functions[0]?.tool as any).invoke(
-        new RunContext(),
-        '{}',
-      ),
-    ).toBe('runtime');
-  });
-
-  it.each([CURRENT_SCHEMA_VERSION, '1.15'] as const)(
-    'round trips a deferred runtime tool selected by a legacy bare call in schema %s',
-    async (schemaVersion) => {
-      const deferredLookup = tool({
-        name: 'lookup',
-        description: 'Deferred lookup.',
-        parameters: z.object({}).strict(),
-        deferLoading: true,
-        needsApproval: true,
-        execute: async () => 'deferred',
-      });
-      const execute = vi.fn(async () => deferredLookup);
-      const clientToolSearch = attachClientToolSearchExecutor(
-        {
-          type: 'hosted_tool',
-          name: 'tool_search',
-          providerData: { type: 'tool_search', execution: 'client' },
-        },
-        execute,
-      );
-      const agent = new Agent({
-        name: `Deferred bare restore ${schemaVersion}`,
-        tools: [clientToolSearch],
-      });
-      const state = new RunState(new RunContext(), 'input', agent, 2);
-      const functionCall: protocol.FunctionCallItem = {
-        type: 'function_call',
-        id: `fc_deferred_bare_${schemaVersion}`,
-        callId: `call_deferred_bare_${schemaVersion}`,
-        name: 'lookup',
-        status: 'completed',
-        arguments: '{}',
-      };
-      const processed = await processModelResponseAsync(
-        {
-          output: [
-            {
-              type: 'tool_search_call',
-              id: `ts_call_deferred_bare_${schemaVersion}`,
-              status: 'completed',
-              arguments: {},
-              providerData: {
-                call_id: `search_deferred_bare_${schemaVersion}`,
-                execution: 'client',
-              },
-            } as protocol.ToolSearchCallItem,
-            functionCall,
-          ],
-          usage: new Usage(),
-        },
-        agent,
-        [clientToolSearch],
-        [],
-        state,
-        [],
-      );
-      state._generatedItems.push(...processed.newItems);
-      state._lastProcessedResponse = processed;
-      state._currentStep = {
-        type: 'next_step_interruption',
-        data: {
-          interruptions: [
-            new ToolApprovalItem(
-              functionCall,
-              agent,
-              undefined,
-              getFunctionToolStateKey(deferredLookup),
-            ),
-          ],
-        },
-      };
-
-      const serialized = state.toJSON() as any;
-      serialized.$schemaVersion = schemaVersion;
-      if (schemaVersion === '1.15') {
-        delete serialized.currentStep.data.interruptions[0]
-          .functionToolStateKey;
-      }
-
-      const restored = await RunState.fromString(
-        agent,
-        JSON.stringify(serialized),
-      );
-
-      expect(execute).toHaveBeenCalledTimes(2);
-      expect(restored.getInterruptions()[0]?.functionToolStateKey).toBe(
-        getFunctionToolStateKey(deferredLookup),
-      );
-      expect(
-        await (
-          restored._lastProcessedResponse?.functions[0].tool as any
-        ).invoke(new RunContext(), '{}'),
-      ).toBe('deferred');
-    },
-  );
-
-  it('rejects an unproven deferred bare fallback instead of rebinding a bare owner', async () => {
-    const bareLookup = tool({
-      name: 'lookup',
-      description: 'Bare lookup.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'bare',
-    });
-    const deferredLookup = tool({
-      name: 'lookup',
-      description: 'Unproven deferred lookup.',
-      parameters: z.object({}).strict(),
-      deferLoading: true,
-      execute: async () => 'deferred',
-    });
-    const agent = new Agent({
-      name: 'Unproven deferred fallback agent',
-      tools: [bareLookup],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    const functionCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      id: 'fc_unproven_deferred_fallback',
-      callId: 'call_unproven_deferred_fallback',
-      name: 'lookup',
-      status: 'completed',
-      arguments: '{}',
-    };
-    state._generatedItems.push(new RunToolCallItem(functionCall, agent));
-    state._lastProcessedResponse = {
-      newItems: [],
-      functions: [{ toolCall: functionCall, tool: deferredLookup as any }],
-      handoffs: [],
-      computerActions: [],
-      shellActions: [],
-      applyPatchActions: [],
-      mcpApprovalRequests: [],
-      toolsUsed: ['lookup'],
-      hasToolsOrApprovalsToRun: () => true,
-    };
-    state._currentStep = {
-      type: 'next_step_interruption',
-      data: {
-        interruptions: [
-          new ToolApprovalItem(
-            functionCall,
-            agent,
-            undefined,
-            getFunctionToolStateKey(deferredLookup),
-          ),
-        ],
-      },
-    };
-
-    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
-      'function call ID is associated with multiple routed tool identities',
-    );
-  });
-
-  it('round trips a legacy bare call resolved by a configured deferred owner', async () => {
-    const deferredLookup = tool({
-      name: 'lookup',
-      description: 'Configured deferred lookup.',
-      parameters: z.object({}).strict(),
-      deferLoading: true,
-      execute: async () => 'deferred',
-    });
-    const agent = new Agent({
-      name: 'Configured deferred fallback agent',
-      tools: [deferredLookup],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    const functionCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      id: 'fc_configured_deferred_fallback',
-      callId: 'call_configured_deferred_fallback',
-      name: 'lookup',
-      status: 'completed',
-      arguments: '{}',
-    };
-    state._generatedItems.push(new RunToolCallItem(functionCall, agent));
-    state._lastProcessedResponse = {
-      newItems: [],
-      functions: [{ toolCall: functionCall, tool: deferredLookup as any }],
-      handoffs: [],
-      computerActions: [],
-      shellActions: [],
-      applyPatchActions: [],
-      mcpApprovalRequests: [],
-      toolsUsed: ['lookup'],
-      hasToolsOrApprovalsToRun: () => true,
-    };
-    state._currentStep = {
-      type: 'next_step_interruption',
-      data: {
-        interruptions: [
-          new ToolApprovalItem(
-            functionCall,
-            agent,
-            undefined,
-            getFunctionToolStateKey(deferredLookup),
-          ),
-        ],
-      },
-    };
-
-    const restored = await RunState.fromString(agent, state.toString());
-
-    expect(restored.getInterruptions()[0]?.functionToolStateKey).toBe(
-      getFunctionToolStateKey(deferredLookup),
-    );
-    expect(
-      await (restored._lastProcessedResponse?.functions[0].tool as any).invoke(
-        new RunContext(),
-        '{}',
-      ),
-    ).toBe('deferred');
-  });
-
-  it.each([CURRENT_SCHEMA_VERSION, '1.15'] as const)(
-    'rejects a configured deferred bare fallback hidden by a handoff in schema %s',
-    async (schemaVersion) => {
-      const deferredLookup = tool({
-        name: 'lookup',
-        description: 'Configured deferred lookup.',
-        parameters: z.object({}).strict(),
-        deferLoading: true,
-        execute: async () => 'deferred',
-      });
-      const target = new Agent({ name: 'Deferred lookup target' });
-      const agent = new Agent({
-        name: `Configured deferred handoff collision ${schemaVersion}`,
-        tools: [deferredLookup],
-        handoffs: [handoff(target, { toolNameOverride: 'lookup' })],
-      });
-      const state = new RunState(new RunContext(), 'input', agent, 2);
-      const functionCall: protocol.FunctionCallItem = {
-        type: 'function_call',
-        id: `fc_configured_deferred_handoff_${schemaVersion}`,
-        callId: `call_configured_deferred_handoff_${schemaVersion}`,
-        name: 'lookup',
-        status: 'completed',
-        arguments: '{}',
-      };
-      state._generatedItems.push(new RunToolCallItem(functionCall, agent));
-      state._lastProcessedResponse = {
-        newItems: [],
-        functions: [{ toolCall: functionCall, tool: deferredLookup as any }],
-        handoffs: [],
-        computerActions: [],
-        shellActions: [],
-        applyPatchActions: [],
-        mcpApprovalRequests: [],
-        toolsUsed: ['lookup'],
-        hasToolsOrApprovalsToRun: () => true,
-      };
-      state._currentStep = {
-        type: 'next_step_interruption',
-        data: {
-          interruptions: [
-            new ToolApprovalItem(
-              functionCall,
-              agent,
-              undefined,
-              getFunctionToolStateKey(deferredLookup),
-            ),
-          ],
-        },
-      };
-
-      const serialized = state.toJSON() as any;
-      serialized.$schemaVersion = schemaVersion;
-      if (schemaVersion === '1.15') {
-        delete serialized.currentStep.data.interruptions[0]
-          .functionToolStateKey;
-      }
-
-      await expect(
-        RunState.fromString(agent, JSON.stringify(serialized)),
-      ).rejects.toThrow(
-        'function call ID is associated with multiple routed tool identities',
-      );
-    },
-  );
-
-  it('scopes repeated function call ids to each interruption agent', async () => {
-    const outerTool = tool({
-      name: 'outer_tool',
-      description: 'Outer tool.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'outer',
-    });
-    const childTool = tool({
-      name: 'child_tool',
-      description: 'Child tool.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'child',
-    });
-    const child = new Agent({ name: 'Call id child', tools: [childTool] });
-    const root = new Agent({
-      name: 'Call id root',
-      tools: [outerTool],
-      handoffs: [child],
-    });
-    const state = new RunState(new RunContext(), 'input', root, 2);
-    const sharedCallId = 'agent_scoped_call_id';
-    const outerCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      id: 'fc_outer_agent_scoped',
-      callId: sharedCallId,
-      name: 'outer_tool',
-      status: 'completed',
-      arguments: '{}',
-    };
-    const childCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      id: 'fc_child_agent_scoped',
-      callId: sharedCallId,
-      name: 'child_tool',
-      status: 'completed',
-      arguments: '{}',
-    };
-    state._generatedItems.push(
-      new RunToolCallItem(outerCall, root),
-      new RunToolCallItem(childCall, child),
-    );
-    state._lastProcessedResponse = {
-      newItems: [],
-      functions: [{ toolCall: outerCall, tool: outerTool as any }],
-      handoffs: [],
-      computerActions: [],
-      shellActions: [],
-      applyPatchActions: [],
-      mcpApprovalRequests: [],
-      toolsUsed: ['outer_tool'],
-      hasToolsOrApprovalsToRun: () => true,
-    };
-    state._currentStep = {
-      type: 'next_step_interruption',
-      data: {
-        interruptions: [
-          new ToolApprovalItem(
-            childCall,
-            child,
-            undefined,
-            getFunctionToolStateKey(childTool),
-          ),
-        ],
-      },
-    };
-
-    const restored = await RunState.fromString(root, state.toString());
-
-    expect(restored.getInterruptions()[0]?.agent).toBe(child);
-    expect(restored.getInterruptions()[0]?.functionToolStateKey).toBe(
-      getFunctionToolStateKey(childTool),
-    );
-  });
-
-  it('preserves independent function approvals with the same identity across agents', async () => {
-    const rootTool = tool({
-      name: 'shared_tool',
-      description: 'Root shared tool.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'root',
-    });
-    const childTool = tool({
-      name: 'shared_tool',
-      description: 'Child shared tool.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'child',
-    });
-    const child = new Agent({
-      name: 'Shared approval agent',
-      tools: [childTool],
-    });
-    const root = new Agent({
-      name: 'Shared approval agent',
-      tools: [rootTool],
-      handoffs: [child],
-    });
-    const sharedCallId = 'shared_approval_call_id';
-    const rootCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      id: 'fc_shared_approval_root',
-      callId: sharedCallId,
-      name: 'shared_tool',
-      status: 'completed',
-      arguments: '{}',
-    };
-    const childCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      id: 'fc_shared_approval_child',
-      callId: sharedCallId,
-      name: 'shared_tool',
-      status: 'completed',
-      arguments: '{}',
-    };
-    const state = new RunState(new RunContext(), 'input', root, 2);
-    state._generatedItems.push(
-      new RunToolCallItem(rootCall, root),
-      new RunToolCallItem(childCall, child),
-    );
-    state._lastProcessedResponse = {
-      newItems: [],
-      functions: [{ toolCall: rootCall, tool: rootTool as any }],
-      handoffs: [],
-      computerActions: [],
-      shellActions: [],
-      applyPatchActions: [],
-      mcpApprovalRequests: [],
-      toolsUsed: ['shared_tool'],
-      hasToolsOrApprovalsToRun: () => true,
-    };
-    state._currentStep = {
-      type: 'next_step_interruption',
-      data: {
-        interruptions: [
-          new ToolApprovalItem(
-            rootCall,
-            root,
-            undefined,
-            getFunctionToolStateKey(rootTool),
-          ),
-          new ToolApprovalItem(
-            childCall,
-            child,
-            undefined,
-            getFunctionToolStateKey(childTool),
-          ),
-        ],
-      },
-    };
-
-    const sharedStateKey = getFunctionToolStateKey(rootTool)!;
-    const legacySerialized = state.toJSON() as any;
-    legacySerialized.$schemaVersion = '1.15';
-    legacySerialized.context.approvals = {
-      shared_tool: { approved: [sharedCallId], rejected: [] },
-    };
-    delete legacySerialized.context.functionApprovals;
-    for (const interruption of legacySerialized.currentStep.data
-      .interruptions) {
-      delete interruption.functionToolStateKey;
-    }
-    const legacyRestored = await RunState.fromString(
-      root,
-      JSON.stringify(legacySerialized),
-    );
-    for (const owner of [root, child]) {
-      expect(
-        legacyRestored._context.isToolApproved({
-          toolName: sharedStateKey,
-          callId: sharedCallId,
-          functionTool: false,
-          agent: owner,
-        }),
-      ).toBe(true);
-    }
-    const legacyRoundTripped = await RunState.fromString(
-      root,
-      legacyRestored.toString(),
-    );
-    for (const owner of [root, child]) {
-      expect(
-        legacyRoundTripped._context.isToolApproved({
-          toolName: sharedStateKey,
-          callId: sharedCallId,
-          functionTool: false,
-          agent: owner,
-        }),
-      ).toBe(true);
-    }
-
-    const restored = await RunState.fromString(root, state.toString());
-    const [rootApproval, childApproval] = restored.getInterruptions();
-    restored.approve(rootApproval, { alwaysApprove: true });
-    restored.reject(childApproval, { message: 'Child call rejected.' });
-
-    const roundTripped = await RunState.fromString(root, restored.toString());
-    expect(
-      roundTripped._context.isToolApproved({
-        toolName: sharedStateKey,
-        callId: 'future-root-call',
-        functionTool: false,
-        agent: root,
-      }),
-    ).toBe(true);
-    expect(
-      roundTripped._context.isToolApproved({
-        toolName: sharedStateKey,
-        callId: sharedCallId,
-        functionTool: false,
-        agent: child,
-      }),
-    ).toBe(false);
-    expect(
-      roundTripped._context.isToolApproved({
-        toolName: sharedStateKey,
-        callId: 'future-child-call',
-        functionTool: false,
-        agent: child,
-      }),
-    ).toBeUndefined();
-    expect(
-      roundTripped._context._getFunctionRejectionMessage(
-        sharedStateKey,
-        sharedCallId,
-        child,
-      ),
-    ).toBe('Child call rejected.');
-    expect(
-      roundTripped._context._getFunctionRejectionMessage(
-        sharedStateKey,
-        sharedCallId,
-        root,
-      ),
-    ).toBeUndefined();
-  });
-
-  it('round trips function approvals for reserved agent identity names', async () => {
-    const agent = new Agent({ name: '__proto__' });
-    const rawItem: protocol.FunctionCallItem = {
-      type: 'function_call',
-      name: 'reserved_identity_tool',
-      callId: 'reserved_identity_call',
-      status: 'completed',
-      arguments: '{}',
-    };
-    const state = new RunState(new RunContext(), 'input', agent, 1);
-    state.reject(new ToolApprovalItem(rawItem, agent), {
-      message: 'Reserved identity rejected.',
-    });
-
-    const serialized = state.toJSON();
-    expect(serialized.context.functionApprovals).toEqual([
-      {
-        agentIdentity: '__proto__',
-        approvals: expect.any(Object),
-      },
-    ]);
-
-    const restored = await RunState.fromString(
-      agent,
-      JSON.stringify(serialized),
-    );
-    const stateKey = getFunctionToolStateKeyForCall(rawItem)!;
-    expect(
-      restored._context.isToolApproved({
-        toolName: stateKey,
-        callId: rawItem.callId,
-        functionTool: false,
-        agent,
-      }),
-    ).toBe(false);
-    expect(
-      restored._context._getFunctionRejectionMessage(
-        stateKey,
-        rawItem.callId,
-        agent,
-      ),
-    ).toBe('Reserved identity rejected.');
-  });
-
-  it('validates current function approval state before context replacement', async () => {
-    const agent = new Agent({ name: 'ApprovalOwnerValidationAgent' });
-    const rawItem: protocol.FunctionCallItem = {
-      type: 'function_call',
-      name: 'approval_owner_tool',
-      callId: 'approval_owner_call',
-      status: 'completed',
-      arguments: '{}',
-    };
-    const state = new RunState(new RunContext(), 'input', agent, 1);
-    state.approve(new ToolApprovalItem(rawItem, agent));
-    const serialized = state.toJSON() as any;
-    serialized.context.functionApprovals[0].agentIdentity = 'unknown-agent';
-
-    await expect(
-      RunState.fromStringWithContext(
-        agent,
-        JSON.stringify(serialized),
-        new RunContext(),
-        { contextStrategy: 'replace' },
-      ),
-    ).rejects.toBeInstanceOf(UserError);
-  });
-
-  it('rejects duplicate function approval owners before tool execution', async () => {
-    const execute = vi.fn(async () => 'executed');
-    const approvalTool = tool({
-      name: 'duplicate_owner_tool',
-      description: 'Duplicate owner tool.',
-      parameters: z.object({}),
-      execute,
-    });
-    const agent = new Agent({
-      name: 'DuplicateApprovalOwnerAgent',
-      tools: [approvalTool],
-    });
-    const rawItem: protocol.FunctionCallItem = {
-      type: 'function_call',
-      name: approvalTool.name,
-      callId: 'duplicate_owner_call',
-      status: 'completed',
-      arguments: '{}',
-    };
-    const state = new RunState(new RunContext(), 'input', agent, 1);
-    state.approve(new ToolApprovalItem(rawItem, agent));
-    const serialized = state.toJSON() as any;
-    serialized.context.functionApprovals.push({
-      ...serialized.context.functionApprovals[0],
-      approvals: {
-        ...serialized.context.functionApprovals[0].approvals,
-      },
-    });
-
-    await expect(
-      RunState.fromStringWithContext(
-        agent,
-        JSON.stringify(serialized),
-        new RunContext(),
-        { contextStrategy: 'replace' },
-      ),
-    ).rejects.toBeInstanceOf(UserError);
-    expect(execute).not.toHaveBeenCalled();
-  });
-
-  it('rejects malformed current function approval state with UserError', async () => {
-    const agent = new Agent({ name: 'MalformedApprovalOwnerAgent' });
-    const state = new RunState(new RunContext(), 'input', agent, 1);
-    const serialized = state.toJSON() as any;
-    serialized.context.functionApprovals = [
-      {
-        agentIdentity: agent.name,
-        approvals: {
-          malformed: { approved: 'yes', rejected: [] },
-        },
-      },
-    ];
-
-    await expect(
-      RunState.fromString(agent, JSON.stringify(serialized)),
-    ).rejects.toBeInstanceOf(UserError);
-  });
-
-  it('rejects noncanonical current function approval keys with UserError', async () => {
-    const agent = new Agent({ name: 'NoncanonicalApprovalKeyAgent' });
-    const state = new RunState(new RunContext(), 'input', agent, 1);
-    const serialized = state.toJSON() as any;
-    serialized.context.functionApprovals = [
-      {
-        agentIdentity: agent.name,
-        approvals: {
-          lookup: { approved: true, rejected: [] },
-        },
-      },
-    ];
-
-    await expect(
-      RunState.fromString(agent, JSON.stringify(serialized)),
-    ).rejects.toBeInstanceOf(UserError);
-  });
-
-  it('preserves ZodError for unrelated malformed run state fields', async () => {
-    const agent = new Agent({ name: 'MalformedUnrelatedStateAgent' });
-    const state = new RunState(new RunContext(), 'input', agent, 1);
-    const serialized = state.toJSON() as any;
-    serialized.currentTurn = 'not-a-number';
-
-    await expect(
-      RunState.fromString(agent, JSON.stringify(serialized)),
-    ).rejects.toBeInstanceOf(ZodError);
-  });
-
-  it('rejects owner-scoped approval fields in legacy schemas', async () => {
-    const agent = new Agent({ name: 'LegacyApprovalOwnerFieldAgent' });
-    const rawItem: protocol.FunctionCallItem = {
-      type: 'function_call',
-      name: 'legacy_owner_tool',
-      callId: 'legacy_owner_call',
-      status: 'completed',
-      arguments: '{}',
-    };
-    const state = new RunState(new RunContext(), 'input', agent, 1);
-    state.approve(new ToolApprovalItem(rawItem, agent));
-    const serialized = state.toJSON() as any;
-    serialized.$schemaVersion = '1.15';
-
-    await expect(
-      RunState.fromString(agent, JSON.stringify(serialized)),
-    ).rejects.toThrow(
-      'Run state schema version 1.15 does not support owner-scoped function approvals.',
-    );
-  });
-
-  it('rejects interruption identity mismatches before callbacks without a processed response', async () => {
-    const dangerous = tool({
-      name: 'dangerous',
-      description: 'Dangerous action.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'dangerous',
-    });
-    const harmless = tool({
-      name: 'harmless',
-      description: 'Harmless action.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'harmless',
-    });
-    const runtimeLookup = tool({
-      name: 'runtime_lookup',
-      description: 'Runtime lookup.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'runtime',
-    });
-    const execute = vi.fn(async () => runtimeLookup);
-    const clientToolSearch = attachClientToolSearchExecutor(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: { type: 'tool_search', execution: 'client' },
-      },
-      execute,
-    );
-    const agent = new Agent({
-      name: 'No processed response interruption agent',
-      tools: [dangerous, harmless, clientToolSearch],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    const rawItem: protocol.FunctionCallItem = {
-      type: 'function_call',
-      id: 'fc_no_processed_response',
-      callId: 'call_no_processed_response',
-      name: 'dangerous',
-      status: 'completed',
-      arguments: '{}',
-    };
-    state._generatedItems.push(
-      new RunToolSearchCallItem(
-        {
-          type: 'tool_search_call',
-          id: 'ts_call_no_processed_response',
-          status: 'completed',
-          arguments: {},
-          providerData: {
-            call_id: 'search_no_processed_response',
-            execution: 'client',
-          },
-        } as protocol.ToolSearchCallItem,
-        agent,
-      ),
-      new RunToolSearchOutputItem(
-        {
-          type: 'tool_search_output',
-          id: 'ts_output_no_processed_response',
-          status: 'completed',
-          tools: [
-            {
-              type: 'function',
-              name: 'runtime_lookup',
-              description: 'Runtime lookup.',
-              strict: true,
-              parameters: {
-                type: 'object',
-                properties: {},
-                required: [],
-                additionalProperties: false,
-              },
-            },
-          ],
-          providerData: {
-            call_id: 'search_no_processed_response',
-            execution: 'client',
-          },
-        } as protocol.ToolSearchOutputItem,
-        agent,
-      ),
-      new RunToolCallItem(rawItem, agent),
-    );
-    state._currentStep = {
-      type: 'next_step_interruption',
-      data: {
-        interruptions: [
-          new ToolApprovalItem(
-            rawItem,
-            agent,
-            undefined,
-            getFunctionToolStateKey(harmless),
-          ),
-        ],
-      },
-    };
-
-    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
-      'function call ID is associated with multiple routed tool identities',
-    );
-    expect(execute).not.toHaveBeenCalled();
-  });
-
-  it('rejects reused function call ids before tool-search rehydration callbacks', async () => {
-    const runtimeLookup = tool({
-      name: 'runtime_lookup',
-      description: 'Runtime lookup.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'runtime',
-    });
-    const configuredLookup = tool({
-      name: 'configured_lookup',
-      description: 'Configured lookup.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'configured',
-    });
-    const execute = vi.fn(async () => runtimeLookup);
-    const clientToolSearch = attachClientToolSearchExecutor(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: { type: 'tool_search', execution: 'client' },
-      },
-      execute,
-    );
-    const agent = new Agent({
-      name: 'Reused function call id agent',
-      tools: [configuredLookup, clientToolSearch],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    const sharedCallId = 'reused_function_call_id';
-    const runtimeCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      id: 'fc_runtime_lookup',
-      callId: sharedCallId,
-      name: 'runtime_lookup',
-      status: 'completed',
-      arguments: '{}',
-    };
-    const configuredCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      id: 'fc_configured_lookup',
-      callId: sharedCallId,
-      name: 'configured_lookup',
-      status: 'completed',
-      arguments: '{}',
-    };
-    state._generatedItems.push(
-      new RunToolSearchCallItem(
-        {
-          type: 'tool_search_call',
-          id: 'ts_call_reused_function_id',
-          status: 'completed',
-          arguments: {},
-          providerData: {
-            call_id: 'tool_search_reused_function_id',
-            execution: 'client',
-          },
-        } as protocol.ToolSearchCallItem,
-        agent,
-      ),
-      new RunToolSearchOutputItem(
-        {
-          type: 'tool_search_output',
-          id: 'ts_output_reused_function_id',
-          status: 'completed',
-          tools: [
-            {
-              type: 'function',
-              name: 'runtime_lookup',
-              description: 'Runtime lookup.',
-              strict: true,
-              parameters: {
-                type: 'object',
-                properties: {},
-                required: [],
-                additionalProperties: false,
-              },
-            },
-          ],
-          providerData: {
-            call_id: 'tool_search_reused_function_id',
-            execution: 'client',
-          },
-        } as protocol.ToolSearchOutputItem,
-        agent,
-      ),
-      new RunToolCallItem(runtimeCall, agent),
-      new RunToolCallItem(configuredCall, agent),
-    );
-    state._lastProcessedResponse = {
-      newItems: [],
-      functions: [{ toolCall: configuredCall, tool: configuredLookup as any }],
-      handoffs: [],
-      computerActions: [],
-      shellActions: [],
-      applyPatchActions: [],
-      mcpApprovalRequests: [],
-      toolsUsed: ['configured_lookup'],
-      hasToolsOrApprovalsToRun: () => true,
-    };
-
-    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
-      'function call ID is associated with multiple routed tool identities',
-    );
-    expect(execute).not.toHaveBeenCalled();
-  });
-
-  it('rejects reused function call ids before legacy state migration', async () => {
-    const bareLookup = tool({
-      name: 'lookup',
-      description: 'Bare lookup.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'bare',
-    });
-    const deferredLookup = tool({
-      name: 'lookup',
-      description: 'Deferred lookup.',
-      parameters: z.object({}).strict(),
-      deferLoading: true,
-      execute: async () => 'deferred',
-    });
-    const agent = new Agent({
-      name: 'Legacy reused function call id agent',
-      tools: [bareLookup, deferredLookup],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    const sharedCallId = 'legacy_reused_function_call_id';
-    const bareCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      id: 'fc_legacy_bare_lookup',
-      callId: sharedCallId,
-      name: 'lookup',
-      status: 'completed',
-      arguments: '{}',
-    };
-    const deferredCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      id: 'fc_legacy_deferred_lookup',
-      callId: sharedCallId,
-      name: 'lookup',
-      namespace: 'lookup',
-      status: 'completed',
-      arguments: '{}',
-    };
-    state._lastProcessedResponse = {
-      newItems: [],
-      functions: [
-        { toolCall: bareCall, tool: bareLookup as any },
-        { toolCall: deferredCall, tool: deferredLookup as any },
-      ],
-      handoffs: [],
-      computerActions: [],
-      shellActions: [],
-      applyPatchActions: [],
-      mcpApprovalRequests: [],
-      toolsUsed: ['lookup'],
-      hasToolsOrApprovalsToRun: () => true,
-    };
-
-    const serialized = state.toJSON() as any;
-    serialized.$schemaVersion = '1.15';
-
-    await expect(
-      RunState.fromString(agent, JSON.stringify(serialized)),
-    ).rejects.toThrow(
-      'function call ID is associated with multiple routed tool identities',
-    );
-  });
-
-  it('rejects an interruption whose routed identity differs from its processed call', async () => {
-    const dangerous = tool({
-      name: 'dangerous',
-      description: 'Dangerous action.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'dangerous',
-    });
-    const harmless = tool({
-      name: 'harmless',
-      description: 'Harmless action.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'harmless',
-    });
-    const agent = new Agent({
-      name: 'Mismatched interruption identity agent',
-      tools: [dangerous, harmless],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    const rawItem: protocol.FunctionCallItem = {
-      type: 'function_call',
-      id: 'fc_dangerous',
-      callId: 'mismatched_interruption_identity',
-      name: 'dangerous',
-      status: 'completed',
-      arguments: '{}',
-    };
-    state._lastProcessedResponse = {
-      newItems: [],
-      functions: [{ toolCall: rawItem, tool: dangerous as any }],
-      handoffs: [],
-      computerActions: [],
-      shellActions: [],
-      applyPatchActions: [],
-      mcpApprovalRequests: [],
-      toolsUsed: ['dangerous'],
-      hasToolsOrApprovalsToRun: () => true,
-    };
-    state._currentStep = {
-      type: 'next_step_interruption',
-      data: {
-        interruptions: [new ToolApprovalItem(rawItem, agent)],
-      },
-    };
-
-    const serialized = state.toJSON() as any;
-    serialized.currentStep.data.interruptions[0].rawItem.name = 'harmless';
-
-    await expect(
-      RunState.fromString(agent, JSON.stringify(serialized)),
-    ).rejects.toThrow(
-      'function call ID is associated with multiple routed tool identities',
-    );
-  });
-
-  it('validates every tool-search output before invoking a rehydration callback', async () => {
-    const runtimeTool = tool({
-      name: 'lookup',
-      description: 'Lookup result.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'lookup',
-    });
-    const execute = vi.fn(async () => runtimeTool);
-    const clientToolSearch = attachClientToolSearchExecutor(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: { type: 'tool_search', execution: 'client' },
-      },
-      execute,
-    );
-    const agent = new Agent({
-      name: 'Tool-search preflight agent',
-      tools: [clientToolSearch],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    state._generatedItems.push(
-      new RunToolSearchCallItem(
-        {
-          type: 'tool_search_call',
-          id: 'ts_call_preflight_valid',
-          status: 'completed',
-          arguments: {},
-          providerData: {
-            call_id: 'call_preflight_valid',
-            execution: 'client',
-          },
-        } as protocol.ToolSearchCallItem,
-        agent,
-      ),
-      new RunToolSearchOutputItem(
-        {
-          type: 'tool_search_output',
-          id: 'ts_output_preflight_valid',
-          status: 'completed',
-          tools: [
-            {
-              type: 'function',
-              name: 'lookup',
-              description: 'Lookup result.',
-              strict: true,
-              parameters: { type: 'object', properties: {}, required: [] },
-            },
-          ],
-          providerData: {
-            call_id: 'call_preflight_valid',
-            execution: 'client',
-          },
-        } as protocol.ToolSearchOutputItem,
-        agent,
-      ),
-      new RunToolSearchOutputItem(
-        {
-          type: 'tool_search_output',
-          id: 'ts_output_preflight_orphan',
-          status: 'completed',
-          tools: [
-            {
-              type: 'function',
-              name: 'orphan',
-              description: 'Orphan result.',
-              strict: true,
-              parameters: { type: 'object', properties: {}, required: [] },
-            },
-          ],
-          providerData: {
-            call_id: 'call_preflight_orphan',
-            execution: 'client',
-          },
-        } as protocol.ToolSearchOutputItem,
-        agent,
-      ),
-    );
-
-    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
-      'serialized state is missing the matching tool_search call item',
-    );
-    expect(execute).not.toHaveBeenCalled();
-  });
-
-  it('rejects a malformed serialized runtime identity before rehydration callbacks', async () => {
-    const execute = vi.fn();
-    const clientToolSearch = attachClientToolSearchExecutor(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: { type: 'tool_search', execution: 'client' },
-      },
-      execute,
-    );
-    const agent = new Agent({
-      name: 'Malformed tool-search identity agent',
-      tools: [clientToolSearch],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    const callId = 'call_malformed_identity';
-    state._generatedItems.push(
-      new RunToolSearchCallItem(
-        {
-          type: 'tool_search_call',
-          id: 'ts_call_malformed_identity',
-          status: 'completed',
-          arguments: {},
-          providerData: { call_id: callId, execution: 'client' },
-        } as protocol.ToolSearchCallItem,
-        agent,
-      ),
-      new RunToolSearchOutputItem(
-        {
-          type: 'tool_search_output',
-          id: 'ts_output_malformed_identity',
-          status: 'completed',
-          tools: [{ type: 'function' }],
-          providerData: { call_id: callId, execution: 'client' },
-        } as protocol.ToolSearchOutputItem,
-        agent,
-      ),
-    );
-
-    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
-      'function without a valid routed identity',
-    );
-    expect(execute).not.toHaveBeenCalled();
-  });
-
-  it('rejects a reserved serialized namespace before rehydration callbacks', async () => {
-    const execute = vi.fn(async () => []);
-    const clientToolSearch = attachClientToolSearchExecutor(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: { type: 'tool_search', execution: 'client' },
-      },
-      execute,
-    );
-    const agent = new Agent({
-      name: 'Reserved serialized namespace agent',
-      tools: [clientToolSearch],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    const callId = 'call_reserved_serialized_namespace';
-    state._generatedItems.push(
-      new RunToolSearchCallItem(
-        {
-          type: 'tool_search_call',
-          id: 'ts_call_reserved_serialized_namespace',
-          status: 'completed',
-          arguments: {},
-          providerData: { call_id: callId, execution: 'client' },
-        } as protocol.ToolSearchCallItem,
-        agent,
-      ),
-      new RunToolSearchOutputItem(
-        {
-          type: 'tool_search_output',
-          id: 'ts_output_reserved_serialized_namespace',
-          status: 'completed',
-          tools: [
-            {
-              type: 'namespace',
-              name: 'lookup',
-              description: 'Reserved lookup namespace.',
-              tools: [
-                {
-                  type: 'function',
-                  name: 'lookup',
-                  description: 'Nested lookup.',
-                  strict: true,
-                  parameters: {
-                    type: 'object',
-                    properties: {},
-                    required: [],
-                    additionalProperties: false,
-                  },
-                },
-              ],
-            },
-          ],
-          providerData: { call_id: callId, execution: 'client' },
-        } as protocol.ToolSearchOutputItem,
-        agent,
-      ),
-    );
-
-    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
-      'Responses tool search reserves same-name namespaces for deferred top-level function tools.',
-    );
-    expect(execute).not.toHaveBeenCalled();
-  });
-
-  it('rejects a direct serialized self-namespace before rehydration callbacks', async () => {
-    const runtimeLookup = tool({
-      name: 'lookup',
-      description: 'Deferred lookup.',
-      parameters: z.object({}).strict(),
-      deferLoading: true,
-      execute: async () => 'lookup',
-    });
-    const execute = vi.fn(async () => runtimeLookup);
-    const clientToolSearch = attachClientToolSearchExecutor(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: { type: 'tool_search', execution: 'client' },
-      },
-      execute,
-    );
-    const agent = new Agent({
-      name: 'Direct reserved serialized namespace agent',
-      tools: [clientToolSearch],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    const callId = 'call_direct_reserved_serialized_namespace';
-    state._generatedItems.push(
-      new RunToolSearchCallItem(
-        {
-          type: 'tool_search_call',
-          id: 'ts_call_direct_reserved_serialized_namespace',
-          status: 'completed',
-          arguments: {},
-          providerData: { call_id: callId, execution: 'client' },
-        } as protocol.ToolSearchCallItem,
-        agent,
-      ),
-      new RunToolSearchOutputItem(
-        {
-          type: 'tool_search_output',
-          id: 'ts_output_direct_reserved_serialized_namespace',
-          status: 'completed',
-          tools: [
-            {
-              type: 'function',
-              name: 'lookup',
-              namespace: 'lookup',
-              description: 'Reserved lookup namespace.',
-              strict: true,
-              parameters: {
-                type: 'object',
-                properties: {},
-                required: [],
-                additionalProperties: false,
-              },
-            },
-          ],
-          providerData: { call_id: callId, execution: 'client' },
-        } as protocol.ToolSearchOutputItem,
-        agent,
-      ),
-    );
-
-    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
-      'Responses tool search reserves same-name namespaces for deferred top-level function tools.',
-    );
-    expect(execute).not.toHaveBeenCalled();
-  });
-
-  it('replays an empty tool-search callback before later callbacks', async () => {
-    type TestContext = { ready: boolean };
-    const execute = vi.fn(
-      async ({
-        runContext,
-        toolCall,
-      }: {
-        runContext: RunContext<TestContext>;
-        toolCall: protocol.ToolSearchCallItem;
-      }) => {
-        const phase = (toolCall.arguments as { phase?: string }).phase;
-        if (phase === 'empty') {
-          runContext.context.ready = true;
-          return [];
-        }
-        const name = runContext.context.ready ? 'after_empty' : 'wrong';
-        return tool({
-          name,
-          description: 'Result after the empty callback.',
-          parameters: z.object({}).strict(),
-          execute: async () => name,
-        });
-      },
-    );
-    const clientToolSearch = attachClientToolSearchExecutor<TestContext>(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: { type: 'tool_search', execution: 'client' },
-      },
-      execute,
-    );
-    const agent = new Agent<TestContext>({
-      name: 'Empty callback replay agent',
-      tools: [clientToolSearch],
-    });
-    const state = new RunState(
-      new RunContext({ ready: false }),
-      'input',
-      agent,
-      2,
-    );
-    const createCall = (
-      id: string,
-      phase: string,
-    ): protocol.ToolSearchCallItem =>
-      ({
-        type: 'tool_search_call',
-        id: `ts_${id}`,
-        status: 'completed',
-        arguments: { phase },
-        providerData: { call_id: id, execution: 'client' },
-      }) as protocol.ToolSearchCallItem;
-    const processed = await processModelResponseAsync(
-      {
-        output: [
-          createCall('call_empty_replay', 'empty'),
-          createCall('call_after_empty_replay', 'after'),
-        ],
-        usage: new Usage(),
-      },
-      agent,
-      [clientToolSearch],
-      [],
-      state,
-      [],
-    );
-    state._generatedItems.push(...processed.newItems);
-    state._lastProcessedResponse = processed;
-
-    const restored = await RunState.fromStringWithContext(
-      agent,
-      state.toString(),
-      new RunContext({ ready: false }),
-      { contextStrategy: 'replace' },
-    );
-
-    expect(execute).toHaveBeenCalledTimes(4);
-    expect(restored.getToolSearchRuntimeTools(agent)[0]?.name).toBe(
-      'after_empty',
-    );
-  });
-
-  it('rejects an empty custom tool-search output when its executor is unavailable', async () => {
-    type TestContext = { ready: boolean };
-    const execute = vi.fn(
-      async ({ runContext }: { runContext: RunContext<TestContext> }) => {
-        runContext.context.ready = true;
-        return [];
-      },
-    );
-    const customToolSearchProviderData = {
-      type: 'tool_search' as const,
-      execution: 'client' as const,
-      parameters: {
-        type: 'object',
-        properties: {},
-        additionalProperties: false,
-      },
-    };
-    const clientToolSearch = attachClientToolSearchExecutor<TestContext>(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: customToolSearchProviderData,
-      },
-      execute,
-    );
-    const agent = new Agent<TestContext>({
-      name: 'Empty custom callback restore agent',
-      tools: [clientToolSearch],
-    });
-    const state = new RunState(
-      new RunContext({ ready: false }),
-      'input',
-      agent,
-      2,
-    );
-    const processed = await processModelResponseAsync(
-      {
-        output: [
-          {
-            type: 'tool_search_call',
-            id: 'ts_call_empty_custom_restore',
-            status: 'completed',
-            arguments: {},
-            providerData: {
-              call_id: 'call_empty_custom_restore',
-              execution: 'client',
-            },
-          } as protocol.ToolSearchCallItem,
-        ],
-        usage: new Usage(),
-      },
-      agent,
-      [clientToolSearch],
-      [],
-      state,
-      [],
-    );
-    state._generatedItems.push(...processed.newItems);
-    state._lastProcessedResponse = processed;
-
-    const replacementAgent = new Agent<TestContext>({
-      name: agent.name,
-      tools: [
-        {
-          type: 'hosted_tool',
-          name: 'tool_search',
-          providerData: customToolSearchProviderData,
-        },
-      ],
-    });
-    const replacementContext = new RunContext({ ready: false });
-
-    await expect(
-      RunState.fromStringWithContext(
-        replacementAgent,
-        state.toString(),
-        replacementContext,
-        { contextStrategy: 'replace' },
-      ),
-    ).rejects.toThrow(
-      'require toolSearchTool({ execution: "client", execute }) when custom client tool_search parameters are provided',
-    );
-    expect(execute).toHaveBeenCalledTimes(1);
-    expect(replacementContext.context.ready).toBe(false);
-  });
-
-  it('restores an empty built-in tool-search output without an executor', async () => {
-    const clientToolSearch = {
-      type: 'hosted_tool' as const,
-      name: 'tool_search',
-      providerData: {
-        type: 'tool_search' as const,
-        execution: 'client' as const,
-      },
-    };
-    const agent = new Agent({
-      name: 'Empty built-in restore agent',
-      tools: [clientToolSearch],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    const callId = 'call_empty_builtin_restore';
-    state._generatedItems.push(
-      new RunToolSearchCallItem(
-        {
-          type: 'tool_search_call',
-          id: 'ts_call_empty_builtin_restore',
-          status: 'completed',
-          arguments: { paths: [] },
-          providerData: { call_id: callId, execution: 'client' },
-        } as protocol.ToolSearchCallItem,
-        agent,
-      ),
-      new RunToolSearchOutputItem(
-        {
-          type: 'tool_search_output',
-          id: 'ts_output_empty_builtin_restore',
-          status: 'completed',
-          tools: [],
-          providerData: { call_id: callId, execution: 'client' },
-        } as protocol.ToolSearchOutputItem,
-        agent,
-      ),
-    );
-
-    const restored = await RunState.fromString(agent, state.toString());
-
-    expect(restored.getToolSearchRuntimeTools(agent)).toEqual([]);
-  });
-
-  it('keeps disabled callback results visible to later tool-search callbacks', async () => {
-    type TestContext = { enabled: boolean };
-    const availableToolNames: string[][] = [];
-    const execute = vi.fn(
-      async ({
-        availableTools,
-        toolCall,
-      }: {
-        availableTools: Tool<TestContext>[];
-        toolCall: protocol.ToolSearchCallItem;
-      }) => {
-        availableToolNames.push(availableTools.map((entry) => entry.name));
-        const phase = (toolCall.arguments as { phase?: string }).phase;
-        if (phase === 'disabled') {
-          return tool({
-            name: 'disabled_runtime',
-            description: 'Disabled runtime result.',
-            parameters: z.object({}).strict(),
-            isEnabled: ({ runContext }) =>
-              (runContext.context as TestContext).enabled,
-            execute: async () => 'disabled',
-          });
-        }
-        const sawDisabled = availableTools.some(
-          (entry) => entry.name === 'disabled_runtime',
-        );
-        const name = sawDisabled ? 'after_disabled' : 'wrong';
-        return tool({
-          name,
-          description: 'Result after the disabled callback.',
-          parameters: z.object({}).strict(),
-          execute: async () => name,
-        });
-      },
-    );
-    const clientToolSearch = attachClientToolSearchExecutor<TestContext>(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: { type: 'tool_search', execution: 'client' },
-      },
-      execute,
-    );
-    const agent = new Agent<TestContext>({
-      name: 'Disabled callback replay agent',
-      tools: [clientToolSearch],
-    });
-    const state = new RunState(
-      new RunContext({ enabled: false }),
-      'input',
-      agent,
-      2,
-    );
-    const createCall = (
-      id: string,
-      phase: string,
-    ): protocol.ToolSearchCallItem =>
-      ({
-        type: 'tool_search_call',
-        id: `ts_${id}`,
-        status: 'completed',
-        arguments: { phase },
-        providerData: { call_id: id, execution: 'client' },
-      }) as protocol.ToolSearchCallItem;
-    const processed = await processModelResponseAsync(
-      {
-        output: [
-          createCall('call_disabled_replay', 'disabled'),
-          createCall('call_after_disabled_replay', 'after'),
-        ],
-        usage: new Usage(),
-      },
-      agent,
-      [clientToolSearch],
-      [],
-      state,
-      [],
-    );
-    state._generatedItems.push(...processed.newItems);
-    state._lastProcessedResponse = processed;
-
-    const restored = await RunState.fromString(agent, state.toString());
-
-    expect(availableToolNames).toEqual([
-      ['tool_search'],
-      ['tool_search', 'disabled_runtime'],
-      ['tool_search'],
-      ['tool_search', 'disabled_runtime'],
-    ]);
-    expect(
-      restored.getToolSearchRuntimeTools(agent).map((entry) => entry.name),
-    ).toEqual(['after_disabled']);
-  });
-
-  it.each([
-    ['an enabled and a disabled result', true],
-    ['two disabled results', false],
-  ] as const)(
-    'rehydrates client tool-search output after filtering %s',
-    async (_description, includeEnabledResult) => {
-      const enabledLookup = tool({
-        name: 'lookup',
-        description: 'Enabled lookup.',
-        parameters: z.object({}).strict(),
-        execute: async () => 'enabled',
-      });
-      const disabledLookup = tool({
-        name: 'lookup',
-        description: 'Disabled lookup.',
-        parameters: z.object({}).strict(),
-        isEnabled: false,
-        execute: async () => 'disabled',
-      });
-      const otherDisabledLookup = tool({
-        name: 'lookup',
-        description: 'Other disabled lookup.',
-        parameters: z.object({}).strict(),
-        isEnabled: false,
-        execute: async () => 'other disabled',
-      });
-      const execute = vi.fn(async () => [
-        includeEnabledResult ? enabledLookup : otherDisabledLookup,
-        disabledLookup,
-      ]);
-      const clientToolSearch = attachClientToolSearchExecutor(
-        {
-          type: 'hosted_tool',
-          name: 'tool_search',
-          providerData: { type: 'tool_search', execution: 'client' },
-        },
-        execute,
-      );
-      const agent = new Agent({
-        name: `Filtered duplicate restore ${includeEnabledResult}`,
-        tools: [clientToolSearch],
-      });
-      const state = new RunState(new RunContext(), 'input', agent, 2);
-      const processed = await processModelResponseAsync(
-        {
-          output: [
-            {
-              type: 'tool_search_call',
-              id: 'ts_call_filtered_duplicate_restore',
-              status: 'completed',
-              arguments: {},
-              providerData: {
-                call_id: 'call_filtered_duplicate_restore',
-                execution: 'client',
-              },
-            } as protocol.ToolSearchCallItem,
-          ],
-          usage: new Usage(),
-        },
-        agent,
-        [clientToolSearch],
-        [],
-        state,
-        [],
-      );
-      state._generatedItems.push(...processed.newItems);
-      state._lastProcessedResponse = processed;
-
-      const restored = await RunState.fromString(agent, state.toString());
-
-      expect(execute).toHaveBeenCalledTimes(2);
-      expect(restored.getToolSearchRuntimeTools(agent)).toEqual(
-        includeEnabledResult ? [enabledLookup] : [],
-      );
-    },
-  );
-
-  it.each([
-    ['one serialized tool', true],
-    ['an empty serialized result', false],
-  ] as const)(
-    'rejects extra enabled callback tools when rehydrating %s',
-    async (_description, includeSerializedLookup) => {
-      const lookup = tool({
-        name: 'lookup',
-        description: 'Serialized lookup.',
-        parameters: z.object({}).strict(),
-        execute: async () => 'lookup',
-      });
-      const extraLookup = tool({
-        name: 'extra_lookup',
-        description: 'Unexpected extra lookup.',
-        parameters: z.object({}).strict(),
-        execute: async () => 'extra',
-      });
-      const execute = vi.fn(async () => [lookup, extraLookup]);
-      const clientToolSearch = attachClientToolSearchExecutor(
-        {
-          type: 'hosted_tool',
-          name: 'tool_search',
-          providerData: { type: 'tool_search', execution: 'client' },
-        },
-        execute,
-      );
-      const agent = new Agent({
-        name: `Extra enabled restore ${includeSerializedLookup}`,
-        tools: [clientToolSearch],
-      });
-      const state = new RunState(new RunContext(), 'input', agent, 2);
-      const callId = 'call_extra_enabled_restore';
-      state._generatedItems.push(
-        new RunToolSearchCallItem(
-          {
-            type: 'tool_search_call',
-            id: 'ts_call_extra_enabled_restore',
-            status: 'completed',
-            arguments: {},
-            providerData: { call_id: callId, execution: 'client' },
-          } as protocol.ToolSearchCallItem,
-          agent,
-        ),
-        new RunToolSearchOutputItem(
-          {
-            type: 'tool_search_output',
-            id: 'ts_output_extra_enabled_restore',
-            status: 'completed',
-            tools: includeSerializedLookup
-              ? [
-                  {
-                    type: 'function',
-                    name: 'lookup',
-                    description: 'Serialized lookup.',
-                    strict: true,
-                    parameters: {
-                      type: 'object',
-                      properties: {},
-                      required: [],
-                      additionalProperties: false,
-                    },
-                  },
-                ]
-              : [],
-            providerData: { call_id: callId, execution: 'client' },
-          } as protocol.ToolSearchOutputItem,
-          agent,
-        ),
-      );
-
-      await expect(
-        RunState.fromString(agent, state.toString()),
-      ).rejects.toThrow(
-        'registered execute callback returned different runtime tools than the serialized state',
-      );
-      expect(execute).toHaveBeenCalledOnce();
-    },
-  );
-
-  it('rejects duplicate configured identities returned during tool-search rehydration', async () => {
-    const configuredTool = tool({
-      name: 'configured',
-      description: 'Configured tool.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'configured',
-    });
-    const runtimeTool = tool({
-      name: 'runtime',
-      description: 'Runtime tool.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'runtime',
-    });
-    const execute = vi.fn(async () => [
-      configuredTool,
-      configuredTool,
-      runtimeTool,
-    ]);
-    const clientToolSearch = attachClientToolSearchExecutor(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: { type: 'tool_search', execution: 'client' },
-      },
-      execute,
-    );
-    const agent = new Agent({
-      name: 'Configured duplicate restore agent',
-      tools: [configuredTool, clientToolSearch],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    const callId = 'call_configured_duplicate_restore';
-    state._generatedItems.push(
-      new RunToolSearchCallItem(
-        {
-          type: 'tool_search_call',
-          id: 'ts_call_configured_duplicate_restore',
-          status: 'completed',
-          arguments: { query: 'runtime' },
-          providerData: { call_id: callId, execution: 'client' },
-        } as protocol.ToolSearchCallItem,
-        agent,
-      ),
-      new RunToolSearchOutputItem(
-        {
-          type: 'tool_search_output',
-          id: 'ts_output_configured_duplicate_restore',
-          status: 'completed',
-          tools: [
-            {
-              type: 'function',
-              name: 'configured',
-              description: 'Configured tool.',
-              strict: true,
-              parameters: {
-                type: 'object',
-                properties: {},
-                required: [],
-                additionalProperties: false,
-              },
-            },
-            {
-              type: 'function',
-              name: 'runtime',
-              description: 'Runtime tool.',
-              strict: true,
-              parameters: {
-                type: 'object',
-                properties: {},
-                required: [],
-                additionalProperties: false,
-              },
-            },
-          ],
-          providerData: { call_id: callId, execution: 'client' },
-        } as protocol.ToolSearchOutputItem,
-        agent,
-      ),
-    );
-
-    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
-      'Client tool_search execute() returned multiple tools with the same routed identity.',
-    );
-    expect(execute).toHaveBeenCalledTimes(1);
-  });
-
-  it.each([
-    ['accepts the final replacement', true],
-    ['rejects a stale first result', false],
-  ] as const)(
-    '%s when rehydrating repeated client tool_search outputs',
-    async (_description, returnFinalReplacement) => {
-      const firstLookup = tool({
-        name: 'first_lookup',
-        description: 'First lookup result.',
-        parameters: z.object({}).strict(),
-        execute: async () => 'first',
-      });
-      const latestLookup = tool({
-        name: 'latest_lookup',
-        description: 'Latest lookup result.',
-        parameters: z.object({}).strict(),
-        execute: async () => 'latest',
-      });
-      const execute = vi.fn(async () =>
-        returnFinalReplacement ? latestLookup : firstLookup,
-      );
-      const clientToolSearch = attachClientToolSearchExecutor(
-        {
-          type: 'hosted_tool',
-          name: 'tool_search',
-          providerData: {
-            type: 'tool_search',
-            execution: 'client',
-          },
-        },
-        execute,
-      );
-      const agent = new Agent({
-        name: 'Replacement restore agent',
-        tools: [clientToolSearch],
-      });
-      const state = new RunState(new RunContext(), 'input', agent, 2);
-      const callId = 'call_replacement_restore';
-      state._generatedItems.push(
-        new RunToolSearchCallItem(
-          {
-            type: 'tool_search_call',
-            id: 'ts_call_replacement_restore',
-            status: 'completed',
-            arguments: { paths: [] },
-            providerData: { call_id: callId, execution: 'client' },
-          } as protocol.ToolSearchCallItem,
-          agent,
-        ),
-        new RunToolSearchOutputItem(
-          {
-            type: 'tool_search_output',
-            id: 'ts_output_replacement_first',
-            status: 'completed',
-            tools: [
-              {
-                type: 'function',
-                name: 'first_lookup',
-                description: 'First lookup result.',
-                strict: true,
-                parameters: {
-                  type: 'object',
-                  properties: {},
-                  required: [],
-                  additionalProperties: false,
-                },
-              },
-            ],
-            providerData: { call_id: callId, execution: 'client' },
-          } as protocol.ToolSearchOutputItem,
-          agent,
-        ),
-        new RunToolSearchOutputItem(
-          {
-            type: 'tool_search_output',
-            id: 'ts_output_replacement_latest',
-            status: 'completed',
-            tools: [
-              {
-                type: 'function',
-                name: 'latest_lookup',
-                description: 'Latest lookup result.',
-                strict: true,
-                parameters: {
-                  type: 'object',
-                  properties: {},
-                  required: [],
-                  additionalProperties: false,
-                },
-              },
-            ],
-            providerData: { call_id: callId, execution: 'client' },
-          } as protocol.ToolSearchOutputItem,
-          agent,
-        ),
-      );
-
-      const restoredPromise = RunState.fromString(agent, state.toString());
-      if (returnFinalReplacement) {
-        const restored = await restoredPromise;
-        expect(restored.getToolSearchRuntimeTools(agent)).toEqual([
-          latestLookup,
-        ]);
-      } else {
-        await expect(restoredPromise).rejects.toThrow(
-          'RunState cannot resume custom client tool_search because the registered execute callback returned different runtime tools than the serialized state.',
-        );
-      }
-      expect(execute).toHaveBeenCalledTimes(1);
-    },
-  );
-
-  it('redacts runtime tool identities from RunState callback mismatches', async () => {
-    const expectedName = 'secret_expected_lookup';
-    const actualName = 'secret_actual_lookup';
-    const actualLookup = tool({
-      name: actualName,
-      description: 'Actual lookup.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'actual',
-    });
-    const clientToolSearch = attachClientToolSearchExecutor(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: { type: 'tool_search', execution: 'client' },
-      },
-      async () => actualLookup,
-    );
-    const agent = new Agent({
-      name: 'Redacted mismatch agent',
-      tools: [clientToolSearch],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    const callId = 'call_redacted_mismatch';
-    state._generatedItems.push(
-      new RunToolSearchCallItem(
-        {
-          type: 'tool_search_call',
-          id: 'ts_call_redacted_mismatch',
-          status: 'completed',
-          arguments: {},
-          providerData: { call_id: callId, execution: 'client' },
-        } as protocol.ToolSearchCallItem,
-        agent,
-      ),
-      new RunToolSearchOutputItem(
-        {
-          type: 'tool_search_output',
-          id: 'ts_output_redacted_mismatch',
-          status: 'completed',
-          tools: [
-            {
-              type: 'function',
-              name: expectedName,
-              description: 'Expected lookup.',
-              strict: true,
-              parameters: {
-                type: 'object',
-                properties: {},
-                required: [],
-                additionalProperties: false,
-              },
-            },
-          ],
-          providerData: { call_id: callId, execution: 'client' },
-        } as protocol.ToolSearchOutputItem,
-        agent,
-      ),
-    );
-    const redaction = vi
-      .spyOn(logger, 'dontLogToolData', 'get')
-      .mockReturnValue(true);
-
-    try {
-      const restored = RunState.fromString(agent, state.toString());
-      await expect(restored).rejects.toThrow(
-        'RunState cannot resume custom client tool_search because the registered execute callback returned different runtime tools than the serialized state.',
-      );
-      await expect(restored).rejects.not.toThrow(expectedName);
-      await expect(restored).rejects.not.toThrow(actualName);
-    } finally {
-      redaction.mockRestore();
-    }
-  });
-
-  it('redacts call and agent identities from missing tool-search executors', async () => {
-    const callId = 'secret_missing_executor_call';
-    const agent = new Agent({ name: 'Secret missing executor agent' });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    state._generatedItems.push(
-      new RunToolSearchCallItem(
-        {
-          type: 'tool_search_call',
-          id: 'ts_call_missing_executor',
-          status: 'completed',
-          arguments: {},
-          providerData: { call_id: callId, execution: 'client' },
-        } as protocol.ToolSearchCallItem,
-        agent,
-      ),
-      new RunToolSearchOutputItem(
-        {
-          type: 'tool_search_output',
-          id: 'ts_output_missing_executor',
-          status: 'completed',
-          tools: [
-            {
-              type: 'function',
-              name: 'secret_runtime_lookup',
-              description: 'Secret runtime lookup.',
-              strict: true,
-              parameters: {
-                type: 'object',
-                properties: {},
-                required: [],
-                additionalProperties: false,
-              },
-            },
-          ],
-          providerData: { call_id: callId, execution: 'client' },
-        } as protocol.ToolSearchOutputItem,
-        agent,
-      ),
-    );
-    const redaction = vi
-      .spyOn(logger, 'dontLogToolData', 'get')
-      .mockReturnValue(true);
-
-    try {
-      const restored = RunState.fromString(agent, state.toString());
-      await expect(restored).rejects.toThrow(
-        'RunState cannot resume custom client tool_search because the agent no longer provides toolSearchTool({ execution: "client", execute }).',
-      );
-      await expect(restored).rejects.not.toThrow(callId);
-      await expect(restored).rejects.not.toThrow(agent.name);
-    } finally {
-      redaction.mockRestore();
-    }
-  });
-
-  it('rehydrates same-name runtime tools from distinct function categories', async () => {
-    const bareLookup = tool({
-      name: 'lookup',
-      description: 'Immediate lookup.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'bare',
-    });
-    const deferredLookup = tool({
-      name: 'lookup',
-      description: 'Deferred lookup.',
-      parameters: z.object({}).strict(),
-      deferLoading: true,
-      execute: async () => 'deferred',
-    });
-    const clientToolSearch = attachClientToolSearchExecutor(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: {
-          type: 'tool_search',
-          execution: 'client',
-        },
-      },
-      async () => [bareLookup, deferredLookup],
-    );
-    const agent = new Agent({
-      name: 'Category-aware restore agent',
-      tools: [clientToolSearch],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    const callId = 'call_tool_search_categories';
-    state._generatedItems.push(
-      new RunToolSearchCallItem(
-        {
-          type: 'tool_search_call',
-          id: 'ts_call_categories',
-          status: 'completed',
-          arguments: { paths: [] },
-          providerData: {
-            call_id: callId,
-            execution: 'client',
-          },
-        } as protocol.ToolSearchCallItem,
-        agent,
-      ),
-      new RunToolSearchOutputItem(
-        {
-          type: 'tool_search_output',
-          id: 'ts_output_categories',
-          status: 'completed',
-          tools: [
-            {
-              type: 'function',
-              name: 'lookup',
-              description: 'Immediate lookup.',
-              strict: true,
-              deferLoading: false,
-              parameters: {
-                type: 'object',
-                properties: {},
-                required: [],
-                additionalProperties: false,
-              },
-            },
-            {
-              type: 'function',
-              name: 'lookup',
-              description: 'Deferred lookup.',
-              strict: true,
-              deferLoading: true,
-              parameters: {
-                type: 'object',
-                properties: {},
-                required: [],
-                additionalProperties: false,
-              },
-            },
-          ],
-          providerData: {
-            call_id: callId,
-            execution: 'client',
-          },
-        } as protocol.ToolSearchOutputItem,
-        agent,
-      ),
-    );
-
-    const restored = await RunState.fromString(agent, state.toString());
-
-    expect(restored.getToolSearchRuntimeTools(agent)).toEqual([
-      bareLookup,
-      deferredLookup,
-    ]);
-  });
-
-  it('rejects a rehydrated bare runtime function that conflicts with an enabled handoff', async () => {
-    const runtimeLookup = tool({
-      name: 'lookup',
-      description: 'Look up a record.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'runtime',
-    });
-    const clientToolSearch = attachClientToolSearchExecutor(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: {
-          type: 'tool_search',
-          execution: 'client',
-        },
-      },
-      async () => runtimeLookup,
-    );
-    const target = new Agent({ name: 'LookupTarget' });
-    const agent = new Agent({
-      name: 'RuntimeHandoffCollision',
-      tools: [clientToolSearch],
-      handoffs: [handoff(target, { toolNameOverride: 'lookup' })],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    const callId = 'call_runtime_handoff_collision';
-    state._generatedItems.push(
-      new RunToolSearchCallItem(
-        {
-          type: 'tool_search_call',
-          id: 'ts_call_runtime_handoff_collision',
-          status: 'completed',
-          arguments: { paths: [] },
-          providerData: { call_id: callId, execution: 'client' },
-        } as protocol.ToolSearchCallItem,
-        agent,
-      ),
-      new RunToolSearchOutputItem(
-        {
-          type: 'tool_search_output',
-          id: 'ts_output_runtime_handoff_collision',
-          status: 'completed',
-          tools: [
-            {
-              type: 'function',
-              name: 'lookup',
-              description: 'Look up a record.',
-              strict: true,
-              parameters: {
-                type: 'object',
-                properties: {},
-                required: [],
-                additionalProperties: false,
-              },
-            },
-          ],
-          providerData: { call_id: callId, execution: 'client' },
-        } as protocol.ToolSearchOutputItem,
-        agent,
-      ),
-    );
-
-    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
-      'Client tool_search execute() returned a bare function tool that conflicts with an available handoff. Assign a unique tool name or use a namespace.',
-    );
-  });
-
-  it.each([false, true])(
-    'rejects duplicate routed identities returned during tool-search rehydration (same object: %s)',
-    async (repeatSameObject) => {
-      const first = tool({
-        name: 'lookup',
-        description: 'First deferred lookup.',
-        parameters: z.object({}).strict(),
-        deferLoading: true,
-        execute: async () => 'first',
-      });
-      const second = tool({
-        name: 'lookup',
-        description: 'Second deferred lookup.',
-        parameters: z.object({}).strict(),
-        deferLoading: true,
-        execute: async () => 'second',
-      });
-      const clientToolSearch = attachClientToolSearchExecutor(
-        {
-          type: 'hosted_tool',
-          name: 'tool_search',
-          providerData: {
-            type: 'tool_search',
-            execution: 'client',
-          },
-        },
-        async () => (repeatSameObject ? [first, first] : [first, second]),
-      );
-      const agent = new Agent({
-        name: 'Duplicate restore agent',
-        tools: [clientToolSearch],
-      });
-      const state = new RunState(new RunContext(), 'input', agent, 2);
-      const callId = 'call_duplicate_restore';
-      state._generatedItems.push(
-        new RunToolSearchCallItem(
-          {
-            type: 'tool_search_call',
-            id: 'ts_call_duplicate_restore',
-            status: 'completed',
-            arguments: { paths: [] },
-            providerData: { call_id: callId, execution: 'client' },
-          } as protocol.ToolSearchCallItem,
-          agent,
-        ),
-        new RunToolSearchOutputItem(
-          {
-            type: 'tool_search_output',
-            id: 'ts_output_duplicate_restore',
-            status: 'completed',
-            tools: [
-              {
-                type: 'function',
-                name: 'lookup',
-                description: 'Deferred lookup.',
-                strict: true,
-                deferLoading: true,
-                parameters: {
-                  type: 'object',
-                  properties: {},
-                  required: [],
-                  additionalProperties: false,
-                },
-              },
-            ],
-            providerData: { call_id: callId, execution: 'client' },
-          } as protocol.ToolSearchOutputItem,
-          agent,
-        ),
-      );
-
-      await expect(
-        RunState.fromString(agent, state.toString()),
-      ).rejects.toThrow(
-        'Client tool_search execute() returned multiple tools with the same routed identity.',
-      );
-    },
-  );
-
-  it('rejects duplicate routed identities in serialized tool-search output before rehydration', async () => {
-    const validRuntimeLookup = tool({
-      name: 'valid_lookup',
-      description: 'Valid lookup.',
-      parameters: z.object({}).strict(),
-      execute: async () => 'valid',
-    });
-    const duplicateRuntimeLookup = tool({
-      name: 'lookup',
-      description: 'Deferred lookup.',
-      parameters: z.object({}).strict(),
-      deferLoading: true,
-      execute: async () => 'lookup',
-    });
-    const execute = vi.fn(async () => validRuntimeLookup);
-    const clientToolSearch = attachClientToolSearchExecutor(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: {
-          type: 'tool_search',
-          execution: 'client',
-        },
-      },
-      execute,
-    );
-    const agent = new Agent({
-      name: 'Duplicate serialized restore agent',
-      tools: [clientToolSearch],
-    });
-    const state = new RunState(new RunContext(), 'input', agent, 2);
-    const validCallId = 'call_valid_serialized_restore';
-    const duplicateCallId = 'call_duplicate_serialized_restore';
-    const validSerializedTool = {
-      type: 'function',
-      name: 'valid_lookup',
-      description: 'Valid lookup.',
-      strict: true,
-      parameters: {
-        type: 'object',
-        properties: {},
-        required: [],
-        additionalProperties: false,
-      },
-    } as const;
-    const serializedTool = {
-      type: 'function',
-      name: duplicateRuntimeLookup.name,
-      description: duplicateRuntimeLookup.description,
-      strict: true,
-      deferLoading: true,
-      parameters: {
-        type: 'object',
-        properties: {},
-        required: [],
-        additionalProperties: false,
-      },
-    } as const;
-    state._generatedItems.push(
-      new RunToolSearchCallItem(
-        {
-          type: 'tool_search_call',
-          id: 'ts_call_valid_serialized_restore',
-          status: 'completed',
-          arguments: { query: 'valid' },
-          providerData: { call_id: validCallId, execution: 'client' },
-        } as protocol.ToolSearchCallItem,
-        agent,
-      ),
-      new RunToolSearchOutputItem(
-        {
-          type: 'tool_search_output',
-          id: 'ts_output_valid_serialized_restore',
-          status: 'completed',
-          tools: [validSerializedTool],
-          providerData: { call_id: validCallId, execution: 'client' },
-        } as protocol.ToolSearchOutputItem,
-        agent,
-      ),
-      new RunToolSearchCallItem(
-        {
-          type: 'tool_search_call',
-          id: 'ts_call_duplicate_serialized_restore',
-          status: 'completed',
-          arguments: { query: 'duplicate' },
-          providerData: { call_id: duplicateCallId, execution: 'client' },
-        } as protocol.ToolSearchCallItem,
-        agent,
-      ),
-      new RunToolSearchOutputItem(
-        {
-          type: 'tool_search_output',
-          id: 'ts_output_duplicate_serialized_restore',
-          status: 'completed',
-          tools: [serializedTool, serializedTool],
-          providerData: { call_id: duplicateCallId, execution: 'client' },
-        } as protocol.ToolSearchOutputItem,
-        agent,
-      ),
-    );
-
-    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
-      'Serialized client tool_search output contains multiple tools with the same routed identity. Assign unique tool names or namespaces before resuming RunState.',
-    );
-    expect(execute).not.toHaveBeenCalled();
-  });
-
   it('accepts schema version 1.7 payloads when non-item context data mentions tool_search types', async () => {
     const context = new RunContext({
       custom: {
@@ -6622,12 +2450,6 @@ describe('RunState', () => {
 
     const serialized = JSON.parse(state.toString());
     serialized.$schemaVersion = '1.6';
-    const approvalKey = getFunctionToolStateKeyForCall(rawItem)!;
-    const ownerApprovals = serialized.context.functionApprovals.find(
-      (entry: any) => entry.agentIdentity === agent.name,
-    ).approvals;
-    serialized.context.approvals.toolLegacy = ownerApprovals[approvalKey];
-    delete serialized.context.functionApprovals;
     delete serialized.context.approvals.toolLegacy.messages;
 
     const restored = await RunState.fromString(
@@ -6717,8 +2539,8 @@ describe('RunState', () => {
       state._context.isToolApproved({ toolName: 'toolZ', callId: 'cid789' }),
     ).toBe(false);
     const approvals = state._context.toJSON().approvals;
-    expect(approvals.toolZ.approved).toBe(false);
-    expect(approvals.toolZ.rejected).toBe(true);
+    expect(approvals['toolZ'].approved).toBe(false);
+    expect(approvals['toolZ'].rejected).toBe(true);
   });
 
   it('alwaysReject with message stores call-specific and sticky rejection messages', () => {
@@ -6749,11 +2571,11 @@ describe('RunState', () => {
       'Blocked by policy',
     );
     const approvals = state._context.toJSON().approvals;
-    expect(approvals.toolAR.rejected).toBe(true);
-    expect(approvals.toolAR.messages).toEqual({
+    expect(approvals['toolAR'].rejected).toBe(true);
+    expect(approvals['toolAR'].messages).toEqual({
       'ar-1': 'Blocked by policy',
     });
-    expect(approvals.toolAR.stickyRejectMessage).toBe('Blocked by policy');
+    expect(approvals['toolAR'].stickyRejectMessage).toBe('Blocked by policy');
   });
 
   it('alwaysReject with empty message preserves the empty string', () => {
@@ -6824,11 +2646,10 @@ describe('RunState', () => {
     const approvalItem = new ToolApprovalItem(rawItem, agent);
 
     state.approve(approvalItem);
-    const approvalKey = getFunctionToolStateKeyForCall(rawItem)!;
 
     expect(
       state._context.isToolApproved({
-        toolName: approvalKey,
+        toolName: 'crm.lookup_account',
         callId: 'cid_namespace',
       }),
     ).toBe(true);
@@ -6859,17 +2680,16 @@ describe('RunState', () => {
     const restored = await RunState.fromString(agent, state.toString());
     const [approvalItem] = restored.getInterruptions();
     restored.approve(approvalItem);
-    const approvalKey = getFunctionToolStateKeyForCall(rawItem)!;
 
     expect(
       restored._context.isToolApproved({
-        toolName: approvalKey,
+        toolName: 'get_shipping_eta',
         callId: 'cid_shipping_eta',
       }),
     ).toBe(true);
     expect(
       restored._context.isToolApproved({
-        toolName: 'get_shipping_eta',
+        toolName: 'get_shipping_eta.get_shipping_eta',
         callId: 'cid_shipping_eta',
       }),
     ).toBeUndefined();
@@ -6910,17 +2730,16 @@ describe('RunState', () => {
     const restored = await RunState.fromString(agent, state.toString());
     const [approvalItem] = restored.getInterruptions();
     restored.approve(approvalItem);
-    const approvalKey = getFunctionToolStateKeyForCall(rawItem)!;
 
     expect(
       restored._context.isToolApproved({
-        toolName: approvalKey,
+        toolName: 'get_shipping_eta',
         callId: 'cid_shipping_eta',
       }),
     ).toBe(true);
     expect(
       restored._context.isToolApproved({
-        toolName: 'get_shipping_eta',
+        toolName: 'get_shipping_eta.get_shipping_eta',
         callId: 'cid_shipping_eta',
       }),
     ).toBeUndefined();
@@ -7318,220 +3137,6 @@ describe('deserialize helpers', () => {
         ],
       },
     ]);
-  });
-
-  it('restores the enabled handoff winner instead of a later disabled duplicate', async () => {
-    const enabledTarget = new Agent({
-      name: 'SharedTarget',
-      instructions: 'enabled target',
-    });
-    const disabledTarget = new Agent({
-      name: 'SharedTarget',
-      instructions: 'disabled target',
-    });
-    const enabledHandoff = handoff(enabledTarget, {
-      toolNameOverride: 'transfer',
-    });
-    const disabledHandoff = handoff(disabledTarget, {
-      toolNameOverride: 'transfer',
-      isEnabled: false,
-    });
-    const agent = new Agent({
-      name: 'HandoffWinnerRestore',
-      handoffs: [enabledHandoff, disabledHandoff],
-    });
-    const state = new RunState(new RunContext(), '', agent, 1);
-    const toolCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      id: 'fc_handoff_winner',
-      callId: 'call_handoff_winner',
-      name: 'transfer',
-      status: 'completed',
-      arguments: '{}',
-    };
-    state._lastProcessedResponse = {
-      newItems: [],
-      functions: [],
-      handoffs: [{ toolCall, handoff: enabledHandoff }],
-      computerActions: [],
-      shellActions: [],
-      applyPatchActions: [],
-      mcpApprovalRequests: [],
-      toolsUsed: ['transfer'],
-      hasToolsOrApprovalsToRun: () => true,
-    };
-
-    const serialized = state.toJSON() as any;
-    expect(
-      serialized.lastProcessedResponse.handoffs[0].targetAgent.identity,
-    ).toEqual(expect.any(String));
-    const restored = await RunState.fromString(
-      agent,
-      JSON.stringify(serialized),
-    );
-
-    expect(restored._lastProcessedResponse?.handoffs[0]?.handoff).toBe(
-      enabledHandoff,
-    );
-
-    delete serialized.lastProcessedResponse.handoffs[0].targetAgent;
-    await expect(
-      RunState.fromString(agent, JSON.stringify(serialized)),
-    ).rejects.toThrow(
-      'Run state handoff is missing its required target agent identity.',
-    );
-
-    serialized.$schemaVersion = '1.15';
-    const restoredLegacy = await RunState.fromString(
-      agent,
-      JSON.stringify(serialized),
-    );
-    expect(restoredLegacy._lastProcessedResponse?.handoffs[0]?.handoff).toBe(
-      enabledHandoff,
-    );
-  });
-
-  it('rejects a schema 1.16 handoff without exact identity instead of rebinding a same-name target', async () => {
-    const executeToolSearch = vi.fn(async () => []);
-    const clientToolSearch = attachClientToolSearchExecutor(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: { type: 'tool_search', execution: 'client' },
-      },
-      executeToolSearch,
-    );
-    const firstTarget = new Agent({ name: 'SharedTarget' });
-    const secondTarget = new Agent({ name: 'SharedTarget' });
-    const firstHandoff = handoff(firstTarget, {
-      toolNameOverride: 'transfer',
-    });
-    const secondHandoff = handoff(secondTarget, {
-      toolNameOverride: 'transfer',
-    });
-    const agent = new Agent({
-      name: 'AmbiguousHandoffRestore',
-      tools: [clientToolSearch],
-      handoffs: [firstHandoff, secondHandoff],
-    });
-    const state = new RunState(new RunContext(), '', agent, 1);
-    const toolSearchCallId = 'call_ambiguous_handoff_search';
-    state._generatedItems.push(
-      new RunToolSearchCallItem(
-        {
-          type: 'tool_search_call',
-          id: 'ts_call_ambiguous_handoff_search',
-          status: 'completed',
-          arguments: { paths: [] },
-          providerData: {
-            call_id: toolSearchCallId,
-            execution: 'client',
-          },
-        } as protocol.ToolSearchCallItem,
-        agent,
-      ),
-      new RunToolSearchOutputItem(
-        {
-          type: 'tool_search_output',
-          id: 'ts_output_ambiguous_handoff_search',
-          status: 'completed',
-          tools: [],
-          providerData: {
-            call_id: toolSearchCallId,
-            execution: 'client',
-          },
-        } as protocol.ToolSearchOutputItem,
-        agent,
-      ),
-    );
-    state._lastProcessedResponse = {
-      newItems: [],
-      functions: [],
-      handoffs: [
-        {
-          toolCall: {
-            type: 'function_call',
-            id: 'fc_ambiguous_handoff',
-            callId: 'call_ambiguous_handoff',
-            name: 'transfer',
-            status: 'completed',
-            arguments: '{}',
-          },
-          handoff: firstHandoff,
-        },
-      ],
-      computerActions: [],
-      shellActions: [],
-      applyPatchActions: [],
-      mcpApprovalRequests: [],
-      toolsUsed: ['transfer'],
-      hasToolsOrApprovalsToRun: () => true,
-    };
-
-    const serialized = state.toJSON() as any;
-    allowConsole(['warn']);
-    await expect(
-      RunState.fromString(agent, JSON.stringify(serialized)),
-    ).rejects.toThrow('Handoff transfer not found');
-    expect(executeToolSearch).not.toHaveBeenCalled();
-
-    const missingTarget = JSON.parse(JSON.stringify(serialized));
-    delete missingTarget.lastProcessedResponse.handoffs[0].targetAgent;
-
-    await expect(
-      RunState.fromString(agent, JSON.stringify(missingTarget)),
-    ).rejects.toThrow(
-      'Run state handoff is missing its required target agent identity.',
-    );
-    expect(executeToolSearch).not.toHaveBeenCalled();
-
-    serialized.lastProcessedResponse.handoffs[0].targetAgent.identity =
-      'missing-target-identity';
-    await expect(
-      RunState.fromString(agent, JSON.stringify(serialized)),
-    ).rejects.toThrow('Agent identity missing-target-identity not found');
-    expect(executeToolSearch).not.toHaveBeenCalled();
-  });
-
-  it('rejects a handoff disabled by a replacement context during restore', async () => {
-    const target = new Agent<{ enabled: boolean }>({ name: 'DynamicTarget' });
-    const dynamicHandoff = handoff(target, {
-      toolNameOverride: 'transfer',
-      isEnabled: ({ runContext }) => runContext.context.enabled,
-    });
-    const agent = new Agent<{ enabled: boolean }>({
-      name: 'DynamicHandoffRestore',
-      handoffs: [dynamicHandoff],
-    });
-    const state = new RunState(new RunContext({ enabled: true }), '', agent, 1);
-    const toolCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      id: 'fc_dynamic_handoff',
-      callId: 'call_dynamic_handoff',
-      name: 'transfer',
-      status: 'completed',
-      arguments: '{}',
-    };
-    state._lastProcessedResponse = {
-      newItems: [],
-      functions: [],
-      handoffs: [{ toolCall, handoff: dynamicHandoff }],
-      computerActions: [],
-      shellActions: [],
-      applyPatchActions: [],
-      mcpApprovalRequests: [],
-      toolsUsed: ['transfer'],
-      hasToolsOrApprovalsToRun: () => true,
-    };
-
-    await expect(
-      RunState.fromStringWithContext(
-        agent,
-        state.toString(),
-        new RunContext({ enabled: false }),
-        { contextStrategy: 'replace' },
-      ),
-    ).rejects.toThrow('Handoff transfer not found');
   });
 
   it('deserializeProcessedResponse restores namespaced function tools', async () => {
@@ -8088,143 +3693,6 @@ describe('deserialize helpers', () => {
       type: 'program',
       callerId: 'prog_approval_1',
     });
-  });
-
-  it('uses an explicit prepared tool snapshot without adding stored runtime tools', async () => {
-    const runtimeLookup = tool({
-      name: 'lookup_runtime',
-      description: 'Look up a runtime record.',
-      parameters: z.object({}),
-      execute: async () => 'runtime',
-    });
-    const agent = new Agent({ name: 'ExplicitPreparedTools' });
-    const state = new RunState(new RunContext(), '', agent, 1);
-    const toolCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      id: 'fc_runtime_explicit',
-      callId: 'call_runtime_explicit',
-      name: 'lookup_runtime',
-      status: 'completed',
-      arguments: '{}',
-    };
-    state.recordToolSearchRuntimeTools(
-      agent,
-      {
-        type: 'tool_search_output',
-        id: 'ts_output_runtime_explicit',
-        status: 'completed',
-        tools: [],
-      } as protocol.ToolSearchOutputItem,
-      [runtimeLookup],
-    );
-    state._lastProcessedResponse = {
-      newItems: [],
-      functions: [{ toolCall, tool: runtimeLookup as any }],
-      handoffs: [],
-      computerActions: [],
-      shellActions: [],
-      applyPatchActions: [],
-      mcpApprovalRequests: [],
-      toolsUsed: ['lookup_runtime'],
-      hasToolsOrApprovalsToRun: () => true,
-    };
-
-    await expect(
-      rehydrateProcessedResponseTools(agent, state, []),
-    ).rejects.toThrow('Tool lookup_runtime not found');
-  });
-
-  it('rejects resumed runtime function tools when isEnabled is false in replacement context', async () => {
-    const lookupParams = z.object({});
-    const runtimeLookup = tool<typeof lookupParams, { enabled: boolean }>({
-      name: 'lookup_runtime',
-      description: 'Look up a runtime record.',
-      parameters: lookupParams,
-      isEnabled: async ({ runContext }) => runContext.context.enabled,
-      execute: async () => 'runtime',
-    });
-    const clientToolSearch = attachClientToolSearchExecutor(
-      {
-        type: 'hosted_tool',
-        name: 'tool_search',
-        providerData: {
-          type: 'tool_search',
-          execution: 'client',
-        },
-      },
-      async () => runtimeLookup,
-    );
-    const agent = new Agent<{ enabled: boolean }>({
-      name: 'RuntimeEnabledRestore',
-      tools: [clientToolSearch],
-    });
-    const state = new RunState(new RunContext({ enabled: true }), '', agent, 1);
-    const searchCallId = 'call_runtime_enabled_restore';
-    state._generatedItems.push(
-      new RunToolSearchCallItem(
-        {
-          type: 'tool_search_call',
-          id: 'ts_call_runtime_enabled_restore',
-          status: 'completed',
-          arguments: { paths: [] },
-          providerData: { call_id: searchCallId, execution: 'client' },
-        } as protocol.ToolSearchCallItem,
-        agent as any,
-      ),
-      new RunToolSearchOutputItem(
-        {
-          type: 'tool_search_output',
-          id: 'ts_output_runtime_enabled_restore',
-          status: 'completed',
-          tools: [
-            {
-              type: 'function',
-              name: 'lookup_runtime',
-              description: 'Look up a runtime record.',
-              strict: true,
-              parameters: {
-                type: 'object',
-                properties: {},
-                required: [],
-                additionalProperties: false,
-              },
-            },
-          ],
-          providerData: { call_id: searchCallId, execution: 'client' },
-        } as protocol.ToolSearchOutputItem,
-        agent as any,
-      ),
-    );
-    const toolCall: protocol.FunctionCallItem = {
-      type: 'function_call',
-      id: 'fc_runtime_enabled_restore',
-      callId: 'call_lookup_runtime',
-      name: 'lookup_runtime',
-      status: 'completed',
-      arguments: '{}',
-    };
-    state._lastProcessedResponse = {
-      newItems: [],
-      functions: [{ toolCall, tool: runtimeLookup as any }],
-      handoffs: [],
-      computerActions: [],
-      shellActions: [],
-      applyPatchActions: [],
-      mcpApprovalRequests: [],
-      toolsUsed: ['lookup_runtime'],
-      hasToolsOrApprovalsToRun: () => true,
-    };
-
-    await expect(
-      RunState.fromStringWithContext(
-        agent,
-        state.toString(),
-        new RunContext({ enabled: false }),
-        { contextStrategy: 'replace' },
-      ),
-    ).rejects.toThrow(
-      'registered execute callback returned different runtime tools than the serialized state',
-    );
   });
 
   it('rejects resumed function tools when isEnabled is false in replacement context', async () => {

--- a/packages/agents-core/test/runner/items.helpers.test.ts
+++ b/packages/agents-core/test/runner/items.helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { Agent } from '../../src/agent';
 import {
+  RunCompactionItem,
   RunMessageOutputItem,
   RunReasoningItem,
   RunToolCallItem,
@@ -37,6 +38,45 @@ describe('prepareModelInputItems', () => {
         content: 'hello',
       },
     ]);
+  });
+
+  it('drops orphan calls before considering pre-compaction results', () => {
+    const agent = new Agent({ name: 'HelperAgent' });
+    const callId = 'call_reused_after_compaction';
+    const oldResult = new RunToolCallOutputItem(
+      {
+        type: 'function_call_result',
+        name: 'reused_tool',
+        callId,
+        output: 'old result',
+        status: 'completed',
+      },
+      agent,
+      'old result',
+    );
+    const compaction = {
+      type: 'compaction',
+      id: 'cmp_reused_call',
+      encrypted_content: 'ciphertext',
+    } satisfies protocol.CompactionItem;
+    const newCall = new RunToolCallItem(
+      {
+        type: 'function_call',
+        name: 'reused_tool',
+        callId,
+        arguments: '{}',
+        status: 'completed',
+      },
+      agent,
+    );
+
+    const prepared = prepareModelInputItems('old input', [
+      oldResult,
+      new RunCompactionItem(compaction, agent),
+      newCall,
+    ]);
+
+    expect(prepared).toEqual([compaction]);
   });
 
   it('drops orphan generated programs and keeps completed programs', () => {

--- a/packages/agents-core/test/runner/modelOutputs.test.ts
+++ b/packages/agents-core/test/runner/modelOutputs.test.ts
@@ -789,6 +789,45 @@ describe('processModelResponse', () => {
     expect(result.hasToolsOrApprovalsToRun()).toBe(false);
   });
 
+  it('rejects malformed compaction before synchronous output processing', () => {
+    const malformedCompaction = {
+      type: 'compaction',
+      id: 'cmp_malformed_sync_output',
+    } as protocol.CompactionItem;
+
+    expect(() =>
+      processModelResponse(
+        {
+          output: [malformedCompaction, TEST_MODEL_MESSAGE],
+          usage: new Usage(),
+        },
+        TEST_AGENT,
+        [],
+        [],
+      ),
+    ).toThrow('Compaction item missing encrypted_content');
+  });
+
+  it('rejects compaction with a malformed id before synchronous output processing', () => {
+    const malformedCompaction = {
+      type: 'compaction',
+      id: 7,
+      encrypted_content: 'ciphertext',
+    } as unknown as protocol.CompactionItem;
+
+    expect(() =>
+      processModelResponse(
+        {
+          output: [malformedCompaction, TEST_MODEL_MESSAGE],
+          usage: new Usage(),
+        },
+        TEST_AGENT,
+        [],
+        [],
+      ),
+    ).toThrow('Compaction item missing encrypted_content');
+  });
+
   it('classifies compaction items on the custom client tool_search async path', async () => {
     const clientToolSearch = attachClientToolSearchExecutor(
       {
@@ -844,6 +883,56 @@ describe('processModelResponse', () => {
     ]);
     expect(result.newItems[2]).toBeInstanceOf(CompactionItem);
     expect(result.newItems[2].rawItem).toEqual(compaction);
+  });
+
+  it('rejects malformed compaction before async client tool_search execution', async () => {
+    const execute = vi.fn().mockResolvedValue([]);
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: {
+          type: 'tool_search',
+          execution: 'client',
+          parameters: {
+            type: 'object',
+            properties: {},
+            additionalProperties: false,
+          },
+        },
+      },
+      execute,
+    );
+    const toolSearchCall = {
+      type: 'tool_search_call',
+      id: 'ts_call_malformed_compaction',
+      status: 'completed',
+      arguments: {},
+      providerData: {
+        call_id: 'call_malformed_compaction',
+        execution: 'client',
+      },
+    } as unknown as protocol.ToolSearchCallItem;
+    const malformedCompaction = {
+      type: 'compaction',
+      id: 'cmp_malformed_async_output',
+    } as protocol.CompactionItem;
+    const agent = new Agent({ name: 'MalformedCompactionAsyncAgent' });
+
+    await expect(
+      processModelResponseAsync(
+        {
+          output: [toolSearchCall, malformedCompaction],
+          usage: new Usage(),
+        },
+        agent,
+        [clientToolSearch],
+        [],
+        new RunState(new RunContext(), 'hello', agent, 3),
+        [],
+      ),
+    ).rejects.toThrow('Compaction item missing encrypted_content');
+    expect(execute).not.toHaveBeenCalled();
   });
 
   it('classifies tool search items as run items and records tool usage', () => {

--- a/packages/agents-core/test/runner/modelOutputs.test.ts
+++ b/packages/agents-core/test/runner/modelOutputs.test.ts
@@ -6,6 +6,7 @@ import { ModelBehaviorError, UserError } from '../../src/errors';
 import { handoff } from '../../src/handoff';
 import logger from '../../src/logger';
 import {
+  RunCompactionItem as CompactionItem,
   RunHandoffCallItem as HandoffCallItem,
   RunMessageOutputItem as MessageOutputItem,
   RunReasoningItem as ReasoningItem,
@@ -763,6 +764,86 @@ describe('processModelResponse', () => {
       TEST_MODEL_RESPONSE_WITH_FUNCTION.output[1],
     );
     expect(result.hasToolsOrApprovalsToRun()).toBe(true);
+  });
+
+  it('classifies compaction items as run items in provider order', () => {
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_1',
+      encrypted_content: 'ciphertext',
+    };
+    const modelResponse: ModelResponse = {
+      output: [compaction, TEST_MODEL_MESSAGE],
+      usage: new Usage(),
+    };
+
+    const result = processModelResponse(modelResponse, TEST_AGENT, [], []);
+
+    expect(result.newItems.map((item) => item.type)).toEqual([
+      'compaction_item',
+      'message_output_item',
+    ]);
+    expect(result.newItems[0]).toBeInstanceOf(CompactionItem);
+    expect(result.newItems[0].rawItem).toEqual(compaction);
+    expect(result.toolsUsed).toEqual([]);
+    expect(result.hasToolsOrApprovalsToRun()).toBe(false);
+  });
+
+  it('classifies compaction items on the custom client tool_search async path', async () => {
+    const clientToolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: {
+          type: 'tool_search',
+          execution: 'client',
+          parameters: {
+            type: 'object',
+            properties: {},
+            additionalProperties: false,
+          },
+        },
+      },
+      vi.fn().mockResolvedValue([]),
+    );
+    const toolSearchCall = {
+      type: 'tool_search_call',
+      id: 'ts_call_async',
+      status: 'completed',
+      arguments: {},
+      providerData: {
+        call_id: 'call_tool_search_async',
+        execution: 'client',
+      },
+    } as unknown as protocol.ToolSearchCallItem;
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_async',
+      encrypted_content: 'ciphertext',
+    };
+    const agent = new Agent({ name: 'CompactionAsyncAgent' });
+    const state = new RunState(new RunContext(), 'hello', agent, 3);
+
+    const result = await processModelResponseAsync(
+      {
+        output: [toolSearchCall, compaction, TEST_MODEL_MESSAGE],
+        usage: new Usage(),
+      },
+      agent,
+      [clientToolSearch],
+      [],
+      state,
+      [],
+    );
+
+    expect(result.newItems.map((item) => item.type)).toEqual([
+      'tool_search_call_item',
+      'tool_search_output_item',
+      'compaction_item',
+      'message_output_item',
+    ]);
+    expect(result.newItems[2]).toBeInstanceOf(CompactionItem);
+    expect(result.newItems[2].rawItem).toEqual(compaction);
   });
 
   it('classifies tool search items as run items and records tool usage', () => {

--- a/packages/agents-core/test/runner/sessionPersistence.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.test.ts
@@ -20,6 +20,7 @@ import {
 import { ModelResponse } from '../../src/model';
 import {
   prepareInputItemsWithSession,
+  saveStreamInputToSession,
   saveStreamResultToSession,
   saveToSession,
 } from '../../src/runner/sessionPersistence';
@@ -1348,6 +1349,88 @@ describe('prepareInputItemsWithSession', () => {
     ]);
   });
 
+  it('rejects malformed compacted history before invoking the input callback', async () => {
+    const malformedCompaction = {
+      type: 'compaction',
+      id: 'cmp_malformed_stored_history',
+    } as AgentInputItem;
+    const session = new StubSession([malformedCompaction]);
+    const callback = vi.fn((history: AgentInputItem[]) => history);
+
+    await expect(
+      prepareInputItemsWithSession('new', session, callback),
+    ).rejects.toThrow('Compaction item missing encrypted_content');
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed explicit marker before a later valid marker', async () => {
+    const malformedCompaction = {
+      type: 'compaction',
+      id: 'cmp_malformed_explicit_input',
+    } as AgentInputItem;
+    const validCompaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_valid_explicit_input',
+      encrypted_content: 'ciphertext',
+    };
+
+    await expect(
+      prepareInputItemsWithSession([malformedCompaction, validCompaction]),
+    ).rejects.toThrow('Compaction item missing encrypted_content');
+  });
+
+  it('rejects an explicit compaction marker with a malformed id', async () => {
+    const malformedCompaction = {
+      type: 'compaction',
+      id: 7,
+      encrypted_content: 'ciphertext',
+    } as unknown as AgentInputItem;
+
+    await expect(
+      prepareInputItemsWithSession([malformedCompaction]),
+    ).rejects.toThrow('Compaction item missing encrypted_content');
+  });
+
+  it('rejects malformed explicit input before invoking the input callback', async () => {
+    const malformedCompaction = {
+      type: 'compaction',
+      id: 'cmp_malformed_explicit_callback_input',
+    } as AgentInputItem;
+    const callback = vi.fn(
+      (history: AgentInputItem[], newItems: AgentInputItem[]) => [
+        ...history,
+        ...newItems,
+      ],
+    );
+
+    await expect(
+      prepareInputItemsWithSession(
+        [malformedCompaction],
+        new StubSession([]),
+        callback,
+      ),
+    ).rejects.toThrow('Compaction item missing encrypted_content');
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed callback marker before a later valid marker', async () => {
+    const malformedCompaction = {
+      type: 'compaction',
+      id: 'cmp_malformed_callback_output',
+    } as AgentInputItem;
+    const validCompaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_valid_callback_output',
+      encrypted_content: 'ciphertext',
+    };
+    const callback = vi.fn(() => [malformedCompaction, validCompaction]);
+
+    await expect(
+      prepareInputItemsWithSession('new', new StubSession([]), callback),
+    ).rejects.toThrow('Compaction item missing encrypted_content');
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
   it('passes only compacted session history to the input callback', async () => {
     const oldHistory: AgentInputItem = {
       type: 'message',
@@ -2117,6 +2200,126 @@ describe('saveToSession', () => {
     }
   }
 
+  it('uses a session compaction replacement capability without clearing identity', async () => {
+    const previousItem = fakeModelMessage('previous history');
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_identity_preserving_session',
+      encrypted_content: 'ciphertext',
+    };
+    const retainedItem = fakeModelMessage('retained history');
+    class IdentityPreservingSession extends MemorySession {
+      clearCount = 0;
+      replacementItems: AgentInputItem[] | undefined;
+
+      async replaceHistoryWithCompaction(
+        items: AgentInputItem[],
+      ): Promise<void> {
+        this.replacementItems = structuredClone(items);
+      }
+
+      async clearSession(): Promise<void> {
+        this.clearCount += 1;
+        await super.clearSession();
+      }
+    }
+    const session = new IdentityPreservingSession();
+    session.items = [previousItem];
+    const state = new RunState(new RunContext(), 'input', TEST_AGENT, 1);
+    state._generatedItems = [
+      new CompactionItem(compaction, TEST_AGENT),
+      new MessageOutputItem(retainedItem, TEST_AGENT),
+    ];
+
+    await saveToSession(session, [], new RunResult(state as any), {
+      runCompaction: false,
+    });
+
+    expect(session.replacementItems).toEqual([compaction, retainedItem]);
+    expect(session.clearCount).toBe(0);
+    expect(session.items).toEqual([previousItem]);
+  });
+
+  it('rejects malformed streaming compaction before mutating session history', async () => {
+    const previousItem = fakeModelMessage('previous history');
+    const session = new MemorySession();
+    session.items = [previousItem];
+    const malformedCompaction = {
+      type: 'compaction',
+      id: 'cmp_missing_ciphertext',
+    } as AgentInputItem;
+
+    await expect(
+      saveStreamInputToSession(session, [
+        malformedCompaction,
+        fakeModelMessage('new history'),
+      ]),
+    ).rejects.toThrow('Compaction item missing encrypted_content');
+    expect(session.items).toEqual([previousItem]);
+  });
+
+  it('rejects malformed result compaction before mutating session history', async () => {
+    const previousItem = fakeModelMessage('previous history');
+    const session = new MemorySession();
+    session.items = [previousItem];
+    const malformedCompaction = {
+      type: 'compaction',
+      id: 'cmp_missing_result_ciphertext',
+    } as protocol.CompactionItem;
+    const state = new RunState(new RunContext(), 'input', TEST_AGENT, 1);
+    state._generatedItems = [
+      new CompactionItem(malformedCompaction, TEST_AGENT),
+    ];
+
+    await expect(
+      saveToSession(session, [], new RunResult(state as any), {
+        runCompaction: false,
+      }),
+    ).rejects.toThrow('Compaction item missing encrypted_content');
+    expect(session.items).toEqual([previousItem]);
+  });
+
+  it('does not reappend an accepted compaction replacement on retry', async () => {
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_accepted_then_throw',
+      encrypted_content: 'ciphertext',
+    };
+    const retainedItem = fakeModelMessage('retained history');
+    class AcceptedThenThrowSession extends MemorySession {
+      replacementCount = 0;
+
+      async replaceHistoryWithCompaction(
+        items: AgentInputItem[],
+      ): Promise<void> {
+        this.replacementCount += 1;
+        this.items.push(...structuredClone(items));
+        throw new Error('write outcome unknown');
+      }
+    }
+    const session = new AcceptedThenThrowSession();
+    session.items = [fakeModelMessage('old history')];
+    const state = new RunState(new RunContext(), 'input', TEST_AGENT, 1);
+    state._generatedItems = [
+      new CompactionItem(compaction, TEST_AGENT),
+      new MessageOutputItem(retainedItem, TEST_AGENT),
+    ];
+    const result = new RunResult(state as any);
+
+    await expect(
+      saveToSession(session, [], result, { runCompaction: false }),
+    ).rejects.toThrow('write outcome unknown');
+    await expect(
+      saveToSession(session, [], result, { runCompaction: false }),
+    ).resolves.toBeUndefined();
+
+    expect(session.replacementCount).toBe(1);
+    expect(session.items.filter((item) => item.type === 'compaction')).toEqual([
+      compaction,
+    ]);
+    expect(state._currentTurnPersistedItemCount).toBe(2);
+  });
+
   it('does not require a process global for debug session logging', async () => {
     const processDescriptor = Object.getOwnPropertyDescriptor(
       globalThis,
@@ -2574,6 +2777,85 @@ describe('saveToSession', () => {
     expect(state._pendingLegacyCompactionSessionItems).toBeUndefined();
   });
 
+  it('uses session-owned persistence comparison and recognizes an appended compaction suffix', async () => {
+    const oldHistory = fakeModelMessage('old history');
+    const pendingMessage = fakeModelMessage('retained history');
+    const storedMessage = {
+      ...structuredClone(pendingMessage),
+      id: 'backend-assigned-message-id',
+      providerData: { backend: 'metadata' },
+    };
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_persistence_comparison',
+      encrypted_content: 'ciphertext',
+    };
+
+    class PersistenceNormalizingSession extends MemorySession {
+      replacementCount = 0;
+      clearCount = 0;
+
+      prepareHistoryItemsForPersistenceComparison(
+        items: AgentInputItem[],
+      ): AgentInputItem[] {
+        return items.map((item) => {
+          const normalized = structuredClone(item) as AgentInputItem & {
+            id?: string;
+            providerData?: unknown;
+          };
+          if (normalized.type !== 'reasoning') {
+            delete normalized.id;
+          }
+          delete normalized.providerData;
+          return normalized;
+        });
+      }
+
+      async replaceHistoryWithCompaction(
+        items: AgentInputItem[],
+      ): Promise<void> {
+        this.replacementCount += 1;
+        this.items.push(...structuredClone(items));
+      }
+
+      async clearSession(): Promise<void> {
+        this.clearCount += 1;
+        await super.clearSession();
+      }
+    }
+
+    const state = new RunState(new RunContext(), 'input', TEST_AGENT, 1);
+    state._generatedItems = [
+      new CompactionItem(compaction, TEST_AGENT),
+      new MessageOutputItem(pendingMessage, TEST_AGENT),
+    ];
+    state._pendingLegacyCompactionSessionItems = [compaction, pendingMessage];
+    state._currentTurnPersistedItemCount = 2;
+    const session = new PersistenceNormalizingSession();
+    session.items = [oldHistory, storedMessage];
+
+    await saveToSession(session, [], new RunResult(state as any), {
+      runCompaction: false,
+    });
+    expect(session.replacementCount).toBe(1);
+    expect(session.clearCount).toBe(0);
+    expect(session.items).toEqual([
+      oldHistory,
+      storedMessage,
+      compaction,
+      pendingMessage,
+    ]);
+    expect(state._pendingLegacyCompactionSessionItems).toBeUndefined();
+
+    state._pendingLegacyCompactionSessionItems = [compaction, pendingMessage];
+    await saveToSession(session, [], new RunResult(state as any), {
+      runCompaction: false,
+    });
+    expect(session.replacementCount).toBe(1);
+    expect(session.clearCount).toBe(0);
+    expect(state._pendingLegacyCompactionSessionItems).toBeUndefined();
+  });
+
   it('rejects mismatched session history before legacy compaction reconciliation', async () => {
     const call = functionCall('call_expected_legacy_reconciliation');
     const compaction: protocol.CompactionItem = {
@@ -2627,6 +2909,59 @@ describe('saveToSession', () => {
     expect(session.clearCount).toBe(0);
     expect(session.items).toEqual([
       functionCall('call_unexpected_legacy_reconciliation'),
+    ]);
+  });
+
+  it('rejects malformed stored reconciliation history before session policy hooks', async () => {
+    const call = functionCall('call_malformed_stored_reconciliation');
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_valid_pending_reconciliation',
+      encrypted_content: 'ciphertext',
+    };
+    const malformedStoredCompaction = {
+      type: 'compaction',
+      id: 'cmp_malformed_stored_reconciliation',
+    } as AgentInputItem;
+
+    class StoredValidationSession extends MemorySession {
+      comparisonCount = 0;
+      clearCount = 0;
+
+      prepareHistoryItemsForPersistenceComparison(
+        items: AgentInputItem[],
+      ): AgentInputItem[] {
+        this.comparisonCount += 1;
+        return items;
+      }
+
+      async clearSession(): Promise<void> {
+        this.clearCount += 1;
+        await super.clearSession();
+      }
+    }
+
+    const state = new RunState(new RunContext(), 'input', TEST_AGENT, 1);
+    state._generatedItems = [
+      new CompactionItem(compaction, TEST_AGENT),
+      new ToolCallItem(call, TEST_AGENT),
+    ];
+    state._pendingLegacyCompactionSessionItems = [compaction, call];
+    state._currentTurnPersistedItemCount = 2;
+    const session = new StoredValidationSession();
+    session.items = [malformedStoredCompaction, call];
+
+    await expect(
+      saveToSession(session, [], new RunResult(state as any), {
+        runCompaction: false,
+      }),
+    ).rejects.toThrow('Compaction item missing encrypted_content');
+    expect(session.comparisonCount).toBe(0);
+    expect(session.clearCount).toBe(0);
+    expect(session.items).toEqual([malformedStoredCompaction, call]);
+    expect(state._pendingLegacyCompactionSessionItems).toEqual([
+      compaction,
+      call,
     ]);
   });
 

--- a/packages/agents-core/test/runner/sessionPersistence.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.test.ts
@@ -8,6 +8,7 @@ import {
 import { Agent, AgentOutputType } from '../../src/agent';
 import {
   RunHandoffOutputItem as HandoffOutputItem,
+  RunCompactionItem as CompactionItem,
   RunMessageOutputItem as MessageOutputItem,
   RunReasoningItem as ReasoningItem,
   RunToolApprovalItem as ToolApprovalItem,
@@ -45,6 +46,7 @@ import type { AgentInputItem, UnknownContext } from '../../src/types';
 import * as protocol from '../../src/types/protocol';
 import { FakeModelProvider, TEST_AGENT, fakeModelMessage } from '../stubs';
 import logger from '../../src/logger';
+import { allowConsole } from '../../../../helpers/tests/console-guard';
 
 beforeAll(() => {
   setTracingDisabled(true);
@@ -2412,6 +2414,194 @@ describe('saveToSession', () => {
     ] as protocol.FunctionCallResultItem;
     expect(last.type).toBe('function_call_result');
     expect(last.callId).toBe(functionCall.callId);
+  });
+
+  it('restores session history when legacy compaction reconciliation fails', async () => {
+    allowConsole(['warn']);
+    const call = functionCall('call_legacy_reconciliation');
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_legacy_reconciliation',
+      encrypted_content: 'ciphertext',
+    };
+
+    class FailingReplacementSession implements Session {
+      items: AgentInputItem[] = [structuredClone(call)];
+      failNextAdd = true;
+
+      async getSessionId(): Promise<string> {
+        return 'failing-legacy-reconciliation';
+      }
+
+      async getItems(limit?: number): Promise<AgentInputItem[]> {
+        const items =
+          limit === undefined ? this.items : this.items.slice(-limit);
+        return structuredClone(items);
+      }
+
+      async addItems(items: AgentInputItem[]): Promise<void> {
+        if (this.failNextAdd) {
+          this.failNextAdd = false;
+          this.items.push(structuredClone(items[0]));
+          throw new Error('replacement failed');
+        }
+        this.items.push(...structuredClone(items));
+      }
+
+      async popItem(): Promise<AgentInputItem | undefined> {
+        return this.items.pop();
+      }
+
+      async clearSession(): Promise<void> {
+        this.items = [];
+      }
+    }
+
+    const state = new RunState(new RunContext(), 'input', TEST_AGENT, 1);
+    state._generatedItems = [
+      new CompactionItem(compaction, TEST_AGENT),
+      new ToolCallItem(call, TEST_AGENT),
+    ];
+    state._pendingLegacyCompactionSessionItems = [compaction, call];
+    state._currentTurnPersistedItemCount = 2;
+    const session = new FailingReplacementSession();
+
+    await expect(
+      saveToSession(session, [], new RunResult(state as any), {
+        runCompaction: false,
+      }),
+    ).rejects.toThrow('replacement failed');
+    expect(session.items).toEqual([call]);
+    expect(state._pendingLegacyCompactionSessionItems).toEqual([
+      compaction,
+      call,
+    ]);
+    expect(state._currentTurnPersistedItemCount).toBe(2);
+  });
+
+  it('rejects mismatched session history before legacy compaction reconciliation', async () => {
+    const call = functionCall('call_expected_legacy_reconciliation');
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_mismatched_reconciliation',
+      encrypted_content: 'ciphertext',
+    };
+
+    class MismatchedSession implements Session {
+      items: AgentInputItem[] = [
+        functionCall('call_unexpected_legacy_reconciliation'),
+      ];
+      clearCount = 0;
+
+      async getSessionId(): Promise<string> {
+        return 'mismatched-legacy-reconciliation';
+      }
+
+      async getItems(): Promise<AgentInputItem[]> {
+        return structuredClone(this.items);
+      }
+
+      async addItems(items: AgentInputItem[]): Promise<void> {
+        this.items.push(...structuredClone(items));
+      }
+
+      async popItem(): Promise<AgentInputItem | undefined> {
+        return this.items.pop();
+      }
+
+      async clearSession(): Promise<void> {
+        this.clearCount += 1;
+        this.items = [];
+      }
+    }
+
+    const state = new RunState(new RunContext(), 'input', TEST_AGENT, 1);
+    state._generatedItems = [
+      new CompactionItem(compaction, TEST_AGENT),
+      new ToolCallItem(call, TEST_AGENT),
+    ];
+    state._pendingLegacyCompactionSessionItems = [compaction, call];
+    state._currentTurnPersistedItemCount = 2;
+    const session = new MismatchedSession();
+
+    await expect(
+      saveToSession(session, [], new RunResult(state as any), {
+        runCompaction: false,
+      }),
+    ).rejects.toThrow('cannot safely reconcile');
+    expect(session.clearCount).toBe(0);
+    expect(session.items).toEqual([
+      functionCall('call_unexpected_legacy_reconciliation'),
+    ]);
+  });
+
+  it('reconciles legacy compaction before executing an approved tool', async () => {
+    let executions = 0;
+    const approvalTool = tool({
+      name: 'legacy_compaction_preflight',
+      description: 'Tool requiring approval.',
+      parameters: z.object({}),
+      needsApproval: true,
+      async execute() {
+        executions += 1;
+        return 'approved';
+      },
+    });
+    const agent = new Agent({
+      name: 'LegacyCompactionPreflightAgent',
+      tools: [approvalTool],
+    });
+    const call: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: approvalTool.name,
+      callId: 'call_legacy_compaction_preflight',
+      arguments: '{}',
+      status: 'completed',
+    };
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_legacy_compaction_preflight',
+      encrypted_content: 'ciphertext',
+    };
+    const callItem = new ToolCallItem(call, agent);
+    const approvalItem = new ToolApprovalItem(call, agent);
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    state._generatedItems = [
+      new CompactionItem(compaction, agent),
+      callItem,
+      approvalItem,
+    ];
+    state._lastProcessedResponse = {
+      newItems: [new CompactionItem(compaction, agent), callItem],
+      handoffs: [],
+      functions: [{ toolCall: call, tool: approvalTool as any }],
+      functionToolsNotFound: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: [approvalTool.name],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: { interruptions: [approvalItem] },
+    };
+    state._pendingLegacyCompactionSessionItems = [compaction, call];
+    state._currentTurnPersistedItemCount = 3;
+    state.approve(approvalItem);
+    const session = new MemorySession();
+    session.items = [functionCall('call_mismatched_preflight')];
+
+    await expect(new Runner().run(agent, state, { session })).rejects.toThrow(
+      'cannot safely reconcile',
+    );
+    expect(executions).toBe(0);
+    expect(session.items).toEqual([functionCall('call_mismatched_preflight')]);
+    expect(state._pendingLegacyCompactionSessionItems).toEqual([
+      compaction,
+      call,
+    ]);
   });
 
   it('persists HITL tool outputs when approval items are not the last generated entries', async () => {

--- a/packages/agents-core/test/runner/sessionPersistence.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.test.ts
@@ -2535,6 +2535,152 @@ describe('saveToSession', () => {
     ]);
   });
 
+  it('rejects legacy reconciliation state that is not derived from generated items', async () => {
+    const call = functionCall('call_uncorrelated_reconciliation');
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_uncorrelated_reconciliation',
+      encrypted_content: 'ciphertext',
+    };
+    const state = new RunState(new RunContext(), 'input', TEST_AGENT, 1);
+    state._pendingLegacyCompactionSessionItems = [compaction, call];
+    state._currentTurnPersistedItemCount = 0;
+    const session = new MemorySession();
+    session.items = [call];
+
+    await expect(
+      saveToSession(session, [], new RunResult(state as any), {
+        runCompaction: false,
+      }),
+    ).rejects.toThrow('cannot safely reconcile');
+    expect(session.items).toEqual([call]);
+  });
+
+  it('rejects pending reconciliation with same-id different payload', async () => {
+    const call = functionCall('call_changed_reconciliation', '{"value":1}');
+    const changedCall = functionCall(
+      'call_changed_reconciliation',
+      '{"value":2}',
+    );
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_changed_reconciliation',
+      encrypted_content: 'ciphertext',
+    };
+    const state = new RunState(new RunContext(), 'input', TEST_AGENT, 1);
+    state._generatedItems = [
+      new CompactionItem(compaction, TEST_AGENT),
+      new ToolCallItem(call, TEST_AGENT),
+    ];
+    state._pendingLegacyCompactionSessionItems = [compaction, changedCall];
+    state._currentTurnPersistedItemCount = 2;
+    const session = new MemorySession();
+    session.items = [changedCall];
+
+    await expect(
+      saveToSession(session, [], new RunResult(state as any), {
+        runCompaction: false,
+      }),
+    ).rejects.toThrow('cannot safely reconcile');
+    expect(session.items).toEqual([changedCall]);
+  });
+
+  it('rejects marker-only pending reconciliation before session mutation', async () => {
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_marker_only_reconciliation',
+      encrypted_content: 'ciphertext',
+    };
+    const state = new RunState(new RunContext(), 'input', TEST_AGENT, 1);
+    state._generatedItems = [new CompactionItem(compaction, TEST_AGENT)];
+    state._pendingLegacyCompactionSessionItems = [compaction];
+    state._currentTurnPersistedItemCount = 1;
+    const message = fakeModelMessage('existing history');
+    const session = new MemorySession();
+    session.items = [message];
+
+    await expect(
+      saveToSession(session, [], new RunResult(state as any), {
+        runCompaction: false,
+      }),
+    ).rejects.toThrow('cannot safely reconcile');
+    expect(session.items).toEqual([message]);
+  });
+
+  it('reports both replacement and rollback failures', async () => {
+    allowConsole(['warn']);
+    const call = functionCall('call_failed_rollback');
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_failed_rollback',
+      encrypted_content: 'ciphertext',
+    };
+
+    class FailingRollbackSession implements Session {
+      items: AgentInputItem[] = [structuredClone(call)];
+      addCount = 0;
+
+      async getSessionId(): Promise<string> {
+        return 'failing-rollback-reconciliation';
+      }
+
+      async getItems(): Promise<AgentInputItem[]> {
+        return structuredClone(this.items);
+      }
+
+      async addItems(items: AgentInputItem[]): Promise<void> {
+        this.addCount += 1;
+        this.items.push(...structuredClone(items.slice(0, 1)));
+        throw new Error(
+          this.addCount === 1 ? 'replacement failed' : 'rollback failed',
+        );
+      }
+
+      async popItem(): Promise<AgentInputItem | undefined> {
+        return this.items.pop();
+      }
+
+      async clearSession(): Promise<void> {
+        this.items = [];
+      }
+    }
+
+    const state = new RunState(new RunContext(), 'input', TEST_AGENT, 1);
+    state._generatedItems = [
+      new CompactionItem(compaction, TEST_AGENT),
+      new ToolCallItem(call, TEST_AGENT),
+    ];
+    state._pendingLegacyCompactionSessionItems = [compaction, call];
+    state._currentTurnPersistedItemCount = 2;
+    const session = new FailingRollbackSession();
+
+    const error = await saveToSession(
+      session,
+      [],
+      new RunResult(state as any),
+      { runCompaction: false },
+    ).catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toMatchObject({
+      name: 'SessionReconciliationRecoveryError',
+    });
+    expect((error as { errors: unknown[] }).errors).toEqual([
+      expect.objectContaining({ message: 'replacement failed' }),
+      expect.objectContaining({ message: 'rollback failed' }),
+    ]);
+    expect((error as { cause: unknown }).cause).toEqual(
+      expect.objectContaining({ message: 'replacement failed' }),
+    );
+    expect((error as { rollbackError: unknown }).rollbackError).toEqual(
+      expect.objectContaining({ message: 'rollback failed' }),
+    );
+    expect(state._pendingLegacyCompactionSessionItems).toEqual([
+      compaction,
+      call,
+    ]);
+  });
+
   it('reconciles legacy compaction before executing an approved tool', async () => {
     let executions = 0;
     const approvalTool = tool({
@@ -2598,6 +2744,74 @@ describe('saveToSession', () => {
     );
     expect(executions).toBe(0);
     expect(session.items).toEqual([functionCall('call_mismatched_preflight')]);
+    expect(state._pendingLegacyCompactionSessionItems).toEqual([
+      compaction,
+      call,
+    ]);
+  });
+
+  it('rejects legacy compaction before executing an approved tool without a session', async () => {
+    let executions = 0;
+    const approvalTool = tool({
+      name: 'legacy_compaction_session_required',
+      description: 'Tool requiring approval.',
+      parameters: z.object({}),
+      needsApproval: true,
+      async execute() {
+        executions += 1;
+        return 'approved';
+      },
+    });
+    const agent = new Agent({
+      name: 'LegacyCompactionSessionRequiredAgent',
+      tools: [approvalTool],
+    });
+    const call: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: approvalTool.name,
+      callId: 'call_legacy_compaction_session_required',
+      arguments: '{}',
+      status: 'completed',
+    };
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_legacy_compaction_session_required',
+      encrypted_content: 'ciphertext',
+    };
+    const callItem = new ToolCallItem(call, agent);
+    const approvalItem = new ToolApprovalItem(call, agent);
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    state._generatedItems = [
+      new CompactionItem(compaction, agent),
+      callItem,
+      approvalItem,
+    ];
+    state._lastProcessedResponse = {
+      newItems: [new CompactionItem(compaction, agent), callItem],
+      handoffs: [],
+      functions: [{ toolCall: call, tool: approvalTool as any }],
+      functionToolsNotFound: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: [approvalTool.name],
+      hasToolsOrApprovalsToRun: () => true,
+    };
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: { interruptions: [approvalItem] },
+    };
+    state._pendingLegacyCompactionSessionItems = [compaction, call];
+    state._currentTurnPersistedItemCount = 3;
+    state.approve(approvalItem);
+
+    await expect(
+      new Runner().run(agent, state, {
+        previousResponseId: 'response_legacy_compaction_session_required',
+      }),
+    ).rejects.toThrow('cannot safely reconcile');
+    expect(executions).toBe(0);
     expect(state._pendingLegacyCompactionSessionItems).toEqual([
       compaction,
       call,

--- a/packages/agents-core/test/runner/sessionPersistence.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.test.ts
@@ -1320,6 +1320,69 @@ describe('prepareInputItemsWithSession', () => {
     expect(sessionItems[1]).toBe(newItems[1]);
   });
 
+  it('uses only session history at and after the latest compaction', async () => {
+    const oldHistory: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'old history',
+    };
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_session_input',
+      encrypted_content: 'ciphertext',
+    };
+    const retainedHistory: AgentInputItem = {
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [{ type: 'output_text', text: 'retained history' }],
+    };
+    const session = new StubSession([oldHistory, compaction, retainedHistory]);
+
+    const result = await prepareInputItemsWithSession('new', session);
+
+    expect(result.preparedInput).toEqual([
+      compaction,
+      retainedHistory,
+      ...toAgentInputList('new'),
+    ]);
+  });
+
+  it('passes only compacted session history to the input callback', async () => {
+    const oldHistory: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'old history',
+    };
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_session_callback',
+      encrypted_content: 'ciphertext',
+    };
+    const retainedHistory: AgentInputItem = {
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [{ type: 'output_text', text: 'retained history' }],
+    };
+    const session = new StubSession([oldHistory, compaction, retainedHistory]);
+
+    const result = await prepareInputItemsWithSession(
+      'new',
+      session,
+      (history, newItems) => {
+        expect(history).toEqual([compaction, retainedHistory]);
+        return [...history, ...newItems];
+      },
+    );
+
+    expect(result.preparedInput).toEqual([
+      compaction,
+      retainedHistory,
+      ...toAgentInputList('new'),
+    ]);
+  });
+
   it('sanitizes assistant history items before model input when the session requests it', async () => {
     const userHistoryItem: AgentInputItem = {
       id: 'conv-user',
@@ -2479,6 +2542,38 @@ describe('saveToSession', () => {
     expect(state._currentTurnPersistedItemCount).toBe(2);
   });
 
+  it('replaces the full legacy session prefix and remains idempotent', async () => {
+    const oldHistory = fakeModelMessage('old history');
+    const call = functionCall('call_legacy_prefix_reconciliation');
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_legacy_prefix_reconciliation',
+      encrypted_content: 'ciphertext',
+    };
+    const state = new RunState(new RunContext(), 'input', TEST_AGENT, 1);
+    state._generatedItems = [
+      new CompactionItem(compaction, TEST_AGENT),
+      new ToolCallItem(call, TEST_AGENT),
+    ];
+    state._pendingLegacyCompactionSessionItems = [compaction, call];
+    state._currentTurnPersistedItemCount = 2;
+    const session = new MemorySession();
+    session.items = [oldHistory, call];
+
+    await saveToSession(session, [], new RunResult(state as any), {
+      runCompaction: false,
+    });
+    expect(session.items).toEqual([compaction, call]);
+    expect(state._pendingLegacyCompactionSessionItems).toBeUndefined();
+
+    state._pendingLegacyCompactionSessionItems = [compaction, call];
+    await saveToSession(session, [], new RunResult(state as any), {
+      runCompaction: false,
+    });
+    expect(session.items).toEqual([compaction, call]);
+    expect(state._pendingLegacyCompactionSessionItems).toBeUndefined();
+  });
+
   it('rejects mismatched session history before legacy compaction reconciliation', async () => {
     const call = functionCall('call_expected_legacy_reconciliation');
     const compaction: protocol.CompactionItem = {
@@ -2596,7 +2691,14 @@ describe('saveToSession', () => {
     state._pendingLegacyCompactionSessionItems = [compaction];
     state._currentTurnPersistedItemCount = 1;
     const message = fakeModelMessage('existing history');
-    const session = new MemorySession();
+    let policyReads = 0;
+    class PolicyThrowingSession extends MemorySession {
+      preserveReasoningItemIdsForPersistence(): boolean {
+        policyReads += 1;
+        throw new Error('session policy should not be read');
+      }
+    }
+    const session = new PolicyThrowingSession();
     session.items = [message];
 
     await expect(
@@ -2604,6 +2706,7 @@ describe('saveToSession', () => {
         runCompaction: false,
       }),
     ).rejects.toThrow('cannot safely reconcile');
+    expect(policyReads).toBe(0);
     expect(session.items).toEqual([message]);
   });
 

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -29,6 +29,7 @@ import {
   ToolGuardrailFunctionOutputFactory,
   withTrace,
   tool,
+  user,
   type Span,
   type Trace,
   type TracingProcessor,
@@ -52,6 +53,7 @@ import {
 import {
   Capability,
   Entry,
+  compaction,
   EnvValueReference,
   filesystem,
   isEnvValueReference,
@@ -59,6 +61,7 @@ import {
   memory,
   type MemoryStore,
   SANDBOX_SESSION_STATE_VERSION,
+  StaticCompactionPolicy,
   registerEnvValueReference,
   shell,
   skills,
@@ -1060,6 +1063,54 @@ describe('sandbox runner integration', () => {
       (normalizedInit.manifest.entries['init.txt'] as { content: string })
         .content,
     ).toBe('init');
+  });
+
+  it('trims context before a model-produced compaction marker on the next turn', async () => {
+    const client = new FakeSandboxClient();
+    const lookup = tool({
+      name: 'lookup',
+      description: 'Look something up.',
+      parameters: z.object({}),
+      execute: async () => 'tool result',
+    });
+    const model = new RecordingFakeModel([
+      {
+        output: [
+          {
+            type: 'compaction',
+            encrypted_content: 'compacted-up-to-here',
+          } as protocol.CompactionItem,
+          {
+            type: 'function_call',
+            id: 'fc_lookup',
+            callId: 'call_lookup',
+            name: 'lookup',
+            status: 'completed',
+            arguments: '{}',
+          } as protocol.FunctionCallItem,
+        ],
+        usage: new Usage(),
+      },
+      { output: [fakeModelMessage('sandbox done')], usage: new Usage() },
+    ]);
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model,
+      tools: [lookup],
+      capabilities: [compaction({ policy: new StaticCompactionPolicy(123) })],
+    });
+
+    const runner = new Runner({ sandbox: { client } });
+    const result = await runner.run(sandboxAgent, [user('old-user')]);
+
+    expect(result.finalOutput).toBe('sandbox done');
+    expect(model.requests[0].input).toEqual([user('old-user')]);
+    const secondInput = model.requests[1].input as protocol.ModelItem[];
+    expect(secondInput[0]).toMatchObject({ type: 'compaction' });
+    expect(secondInput.some((item) => item.type === 'message')).toBe(false);
+    expect(model.requests[1].modelSettings.providerData).toMatchObject({
+      context_management: [{ type: 'compaction', compact_threshold: 123 }],
+    });
   });
 
   it('passes object RunConfig model overrides into sandbox capability sampling', async () => {

--- a/packages/agents-openai/src/memory/openaiConversationsSession.ts
+++ b/packages/agents-openai/src/memory/openaiConversationsSession.ts
@@ -195,6 +195,14 @@ export class OpenAIConversationsSession
     return stripAssistantReplayMetadata(item);
   }
 
+  prepareHistoryItemsForPersistenceComparison(
+    items: AgentInputItem[],
+  ): AgentInputItem[] {
+    return normalizeItemsForConversationPersistence(
+      items,
+    ) as unknown as AgentInputItem[];
+  }
+
   preserveReasoningItemIdsForPersistence(): boolean {
     return true;
   }
@@ -205,11 +213,7 @@ export class OpenAIConversationsSession
     }
 
     await this.#runItemOperation(async (conversationId) => {
-      const normalizedItems =
-        stripProviderModelForConversationPersistence(items);
-      const sanitizedItems = stripConversationPersistenceMetadata(
-        getInputItems(normalizedItems),
-      );
+      const sanitizedItems = normalizeItemsForConversationPersistence(items);
       if (!sanitizedItems.length) {
         return;
       }
@@ -217,6 +221,10 @@ export class OpenAIConversationsSession
         items: sanitizedItems,
       });
     });
+  }
+
+  async replaceHistoryWithCompaction(items: AgentInputItem[]): Promise<void> {
+    await this.addItems(items);
   }
 
   async popItem(): Promise<AgentInputItem | undefined> {
@@ -293,6 +301,13 @@ export class OpenAIConversationsSession
 // --------------------------------------------------------------
 //  Internals
 // --------------------------------------------------------------
+
+function normalizeItemsForConversationPersistence(
+  items: AgentInputItem[],
+): OpenAI.Responses.ResponseInputItem[] {
+  const normalizedItems = stripProviderModelForConversationPersistence(items);
+  return stripConversationPersistenceMetadata(getInputItems(normalizedItems));
+}
 
 function stripProviderModelForConversationPersistence(
   items: AgentInputItem[],

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -78,6 +78,7 @@ import {
   normalizeHostedMcpRequireApproval,
 } from '@openai/agents-core/utils';
 import {
+  assertValidCompactionItems,
   formatInlineData,
   getInlineMediaType,
 } from '@openai/agents-core/utils/internal';
@@ -2651,14 +2652,13 @@ function getInputItems(
     if (item.type === 'compaction') {
       const encryptedContent =
         (item as any).encrypted_content ?? (item as any).encryptedContent;
-      if (typeof encryptedContent !== 'string') {
-        throw new UserError('Compaction item missing encrypted_content');
-      }
-      return {
+      const compactionItem = {
         type: 'compaction',
         id: item.id ?? undefined,
         encrypted_content: encryptedContent,
-      } as OpenAI.Responses.ResponseInputItem;
+      } as protocol.CompactionItem;
+      assertValidCompactionItems([compactionItem]);
+      return compactionItem as OpenAI.Responses.ResponseInputItem;
     }
 
     if (item.type === 'unknown') {
@@ -3103,16 +3103,14 @@ function convertToOutputItem(
         created_by?: string;
         id?: string;
       };
-      if (typeof encrypted_content !== 'string') {
-        throw new UserError('Compaction item missing encrypted_content');
-      }
-      const output: protocol.CompactionItem = {
+      const output = {
         type: 'compaction',
         id: item.id ?? undefined,
         encrypted_content,
         created_by,
         providerData,
-      };
+      } as unknown as protocol.CompactionItem;
+      assertValidCompactionItems([output]);
       return output;
     }
 

--- a/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
@@ -21,6 +21,20 @@ import logger from '../src/logger';
  * shapes expected by OpenAI's Chat Completions API.
  */
 describe('itemsToMessages', () => {
+  test('rejects Responses compaction history before conversion', () => {
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_1',
+      encrypted_content: 'ciphertext',
+    };
+
+    expect(() => itemsToMessages([compaction])).toThrowError(
+      new UserError(
+        'Compaction items are not supported for chat completions. Please use the Responses API when working with compaction.',
+      ),
+    );
+  });
+
   test('converts built-in file_search_call without throwing', () => {
     const items: protocol.ModelItem[] = [
       {

--- a/packages/agents-openai/test/openaiConversationsSession.test.ts
+++ b/packages/agents-openai/test/openaiConversationsSession.test.ts
@@ -657,6 +657,88 @@ describe('OpenAIConversationsSession', () => {
     });
   });
 
+  it('preserves the conversation ID when replacing history with compaction', async () => {
+    const createItems = vi.fn();
+    const deleteConversation = vi.fn();
+    const compaction = {
+      type: 'compaction',
+      id: 'cmp-preserve-conversation-id',
+      encrypted_content: 'ciphertext',
+    };
+    const retained = {
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [{ type: 'output_text', text: 'retained' }],
+    };
+    getInputItemsMock.mockReturnValue([compaction, retained] as any);
+    const session = createSession({
+      client: {
+        conversations: {
+          items: {
+            list: vi.fn(),
+            create: createItems,
+            delete: vi.fn(),
+          },
+          create: vi.fn(),
+          delete: deleteConversation,
+        },
+      } as any,
+      conversationId: 'conv-preserved',
+    });
+
+    await session.replaceHistoryWithCompaction([compaction, retained] as any);
+
+    expect(createItems).toHaveBeenCalledWith('conv-preserved', {
+      items: [
+        {
+          type: 'compaction',
+          encrypted_content: 'ciphertext',
+        },
+        retained,
+      ],
+    });
+    expect(deleteConversation).not.toHaveBeenCalled();
+    await expect(session.getSessionId()).resolves.toBe('conv-preserved');
+  });
+
+  it('normalizes backend-assigned metadata for persistence comparison', () => {
+    getInputItemsMock.mockImplementation((items) => items);
+    const session = createSession({
+      client: {} as any,
+      conversationId: 'conv-persistence-comparison',
+    });
+    const expected = {
+      type: 'function_call',
+      id: 'response-function-call-id',
+      callId: 'call-persistence-comparison',
+      name: 'lookup',
+      arguments: '{}',
+      providerData: { model: 'gpt-5', source: 'response' },
+    };
+    const stored = {
+      ...expected,
+      id: 'backend-assigned-conversation-item-id',
+      providerData: { source: 'conversation' },
+    };
+
+    expect(
+      session.prepareHistoryItemsForPersistenceComparison([expected] as any),
+    ).toEqual(
+      session.prepareHistoryItemsForPersistenceComparison([stored] as any),
+    );
+    expect(
+      session.prepareHistoryItemsForPersistenceComparison([expected] as any),
+    ).toEqual([
+      {
+        type: 'function_call',
+        callId: 'call-persistence-comparison',
+        name: 'lookup',
+        arguments: '{}',
+      },
+    ]);
+  });
+
   it('preserves reasoning identity and encrypted content when adding items', async () => {
     const createMock = vi.fn();
     const inputItems = [

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -4702,6 +4702,67 @@ describe('OpenAIResponsesModel', () => {
     });
   });
 
+  describe('compaction items', () => {
+    function fakeClientWithResponse(response: unknown) {
+      const createMock = vi.fn().mockResolvedValue(response);
+      return {
+        createMock,
+        client: {
+          responses: { create: createMock },
+        } as unknown as OpenAI,
+      };
+    }
+
+    const baseRequest = {
+      systemInstructions: undefined,
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    it('rejects a compaction input item without ciphertext before calling the client', async () => {
+      const { client, createMock } = fakeClientWithResponse({
+        id: 'unused',
+        usage: {},
+        output: [],
+      });
+      const model = new OpenAIResponsesModel(client, 'gpt-test');
+
+      await expect(
+        withTrace('test', () =>
+          model.getResponse({
+            ...baseRequest,
+            input: [
+              {
+                type: 'compaction',
+                providerData: { provider: 'example' },
+              },
+            ],
+          } as any),
+        ),
+      ).rejects.toThrow('Compaction item missing encrypted_content');
+      expect(createMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects a malformed provider compaction output item', async () => {
+      const { client } = fakeClientWithResponse({
+        id: 'res-compaction-malformed',
+        usage: {},
+        output: [{ type: 'compaction', id: 'cmp_bad' }],
+      });
+      const model = new OpenAIResponsesModel(client, 'gpt-test');
+
+      await expect(
+        withTrace('test', () =>
+          model.getResponse({ ...baseRequest, input: 'hello' } as any),
+        ),
+      ).rejects.toThrow('Compaction item missing encrypted_content');
+    });
+  });
+
   it('getStreamedResponse records span errors and rethrows when streaming fails', async () => {
     setTracingDisabled(false);
     const createdEvent: OpenAIResponseStreamEvent = {

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -10,6 +10,8 @@ import {
   Agent,
   retryPolicies,
   Runner,
+  type AgentInputItem,
+  type Session,
   setDefaultModelProvider,
   setTracingDisabled,
   withTrace,
@@ -4760,6 +4762,72 @@ describe('OpenAIResponsesModel', () => {
           model.getResponse({ ...baseRequest, input: 'hello' } as any),
         ),
       ).rejects.toThrow('Compaction item missing encrypted_content');
+    });
+
+    it('rejects a provider compaction output item with a malformed id', async () => {
+      const { client } = fakeClientWithResponse({
+        id: 'res-compaction-malformed-id',
+        usage: {},
+        output: [
+          { type: 'compaction', id: 7, encrypted_content: 'ciphertext' },
+        ],
+      });
+      const model = new OpenAIResponsesModel(client, 'gpt-test');
+
+      await expect(
+        withTrace('test', () =>
+          model.getResponse({ ...baseRequest, input: 'hello' } as any),
+        ),
+      ).rejects.toThrow('Compaction item missing encrypted_content');
+    });
+
+    it('does not persist session input when streamed provider compaction is malformed', async () => {
+      const completedEvent: OpenAIResponseStreamEvent = {
+        type: 'response.completed',
+        response: {
+          id: 'res-stream-compaction-malformed',
+          output: [{ type: 'compaction', id: 'cmp_bad' }],
+          usage: {},
+        } as any,
+        sequence_number: 0,
+      };
+      async function* fakeStream() {
+        yield completedEvent;
+      }
+      const createMock = vi.fn().mockResolvedValue(fakeStream());
+      const model = new OpenAIResponsesModel(
+        { responses: { create: createMock } } as unknown as OpenAI,
+        'gpt-test',
+      );
+      const addItems = vi.fn(async (_items: AgentInputItem[]) => {});
+      const clearSession = vi.fn(async () => {});
+      const replaceHistoryWithCompaction = vi.fn(
+        async (_items: AgentInputItem[]) => {},
+      );
+      const session: Session = {
+        getSessionId: vi.fn().mockResolvedValue('provider-stream-session'),
+        getItems: vi.fn().mockResolvedValue([]),
+        addItems,
+        popItem: vi.fn().mockResolvedValue(undefined),
+        clearSession,
+        replaceHistoryWithCompaction,
+      };
+      const agent = new Agent({
+        name: 'MalformedProviderStreamingCompactionAgent',
+        model,
+      });
+
+      const result = await new Runner().run(agent, 'persist-me', {
+        stream: true,
+        session,
+      });
+
+      await expect(result.completed).rejects.toThrow(
+        'Compaction item missing encrypted_content',
+      );
+      expect(addItems).not.toHaveBeenCalled();
+      expect(clearSession).not.toHaveBeenCalled();
+      expect(replaceHistoryWithCompaction).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/agents/test/index.test.ts
+++ b/packages/agents/test/index.test.ts
@@ -20,6 +20,7 @@ describe('Exports', () => {
     const agent = new Agents.Agent({ name: 'Test' });
     expect(agent.name).toBe('Test');
     expect(typeof Agents.setSensitiveDataLoggingEnabled).toBe('function');
+    expect(typeof Agents.RunCompactionItem).toBe('function');
   });
 
   test('lifecycle and agent tool types are out there', () => {


### PR DESCRIPTION
This pull request fixes encrypted Responses compaction items being dropped when model outputs are converted into run items, which broke client-managed continuation across tool turns, returned history, sessions, streaming completion, sandbox pruning, and serialized RunState resume.

It introduces a public `RunCompactionItem`, preserves provider ordering, advances RunState to version 1.16 with backward-compatible readers, and retains fail-fast behavior for missing encrypted content and Chat Completions. It also adds comprehensive regression coverage and a patch changeset for the affected packages.

Documentation updates are intentionally excluded and will be handled separately.
