### PR TITLE
fix: preserve causal order when deduplicating model input

### DIFF
--- a/.changeset/fair-items-keep-order.md
+++ b/.changeset/fair-items-keep-order.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: deduplicate provider-identified model inputs without breaking causal item order

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -697,7 +697,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       } else {
         preparedInput = prepared.preparedInput;
       }
-      sessionPersistence?.setPreparedItems(prepared.sessionItems);
+      sessionPersistence?.setPreparedItems(
+        prepared.sessionItems,
+        prepared.preparedInput,
+      );
     }
     // Streaming runs persist the input asynchronously, so track a one-shot helper
     // that can be awaited from multiple branches without double-writing.
@@ -713,7 +716,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           preparedInput,
           effectiveOptions,
           ensureStreamInputPersisted,
+          sessionPersistence?.setPreparedTurnItems,
           sessionPersistence?.recordTurnItems,
+          sessionPersistence?.getItemsForPersistence,
           preserveTurnPersistenceOnResume,
           {
             sdkSessionId: async () => await session?.getSessionId(),
@@ -727,6 +732,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         agent,
         preparedInput,
         effectiveOptions,
+        sessionPersistence?.setPreparedTurnItems,
         sessionPersistence?.recordTurnItems,
         preserveTurnPersistenceOnResume,
         {
@@ -926,6 +932,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     startingAgent: TAgent,
     input: string | AgentInputItem[] | RunState<TContext, TAgent>,
     options: NonStreamRunOptions<TContext, TAgent>,
+    sessionTurnInputUpdate?: (turnInput: AgentInputItem[]) => void,
     // sessionInputUpdate lets the caller adjust queued session items after filters run so we
     // persist exactly what we send to the model (e.g., after redactions or truncation).
     sessionInputUpdate?: (
@@ -1194,6 +1201,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             }
 
             guardrailTracker.setPromise(parallelGuardrailPromise);
+            sessionTurnInputUpdate?.(turnInput);
             const preparedSandboxAgent = await sandboxRuntime.prepareAgent({
               currentAgent: state._currentAgent,
               turnInput,
@@ -1248,7 +1256,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             );
             if (serverConversationTracker) {
               serverConversationTracker.markInputAsSent(
-                preparedCall.sourceItems,
+                preparedCall.filterApplied
+                  ? preparedCall.sourceItems
+                  : preparedCall.turnInput,
                 {
                   filterApplied: preparedCall.filterApplied,
                   allTurnItems: preparedCall.turnInput,
@@ -1493,10 +1503,12 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     options: StreamRunOptions<TContext, TAgent>,
     isResumedState: boolean,
     ensureStreamInputPersisted?: () => Promise<void>,
+    sessionTurnInputUpdate?: (turnInput: AgentInputItem[]) => void,
     sessionInputUpdate?: (
       sourceItems: (AgentInputItem | undefined)[],
       filteredItems?: AgentInputItem[],
     ) => void,
+    getStreamInputForPersistence?: () => AgentInputItem[] | undefined,
     preserveTurnPersistenceOnResume?: boolean,
     sandboxMemoryRunContext?: SandboxMemoryPersistenceContext,
     taskSpan?: RunnerSpanLifecycle<TaskSpanData>,
@@ -1539,17 +1551,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       streamInputPersisted = true;
     };
     let parallelGuardrailPromise: Promise<InputGuardrailResult[]> | undefined;
-    const awaitGuardrailsAndPersistInput = async () => {
+    const awaitInputGuardrails = async () => {
       await guardrailTracker.awaitCompletion();
       if (guardrailTracker.failed) {
         throw guardrailTracker.error;
-      }
-      if (
-        sentInputToModel &&
-        !streamInputPersisted &&
-        !guardrailTracker.failed
-      ) {
-        await persistStreamInputIfNeeded();
       }
     };
 
@@ -1599,10 +1604,17 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             ? { runCompaction: false }
             : { compactionMode: 'input' as const }
           : undefined;
+      const sessionInputItems = streamInputPersisted
+        ? undefined
+        : getStreamInputForPersistence?.();
+      // A remote session may commit addItems before rejecting, and compaction happens after the
+      // append. Once the combined save starts, retrying the input is therefore unsafe.
+      streamInputPersisted = true;
       await saveStreamResultToSession(
         options.session,
         result,
         persistenceOptions,
+        sessionInputItems,
       );
     };
 
@@ -1747,6 +1759,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           const { turnInput } = preparedTurn;
           parallelGuardrailPromise = preparedTurn.parallelGuardrailPromise;
           guardrailTracker.setPromise(parallelGuardrailPromise);
+          sessionTurnInputUpdate?.(turnInput);
+          // If guardrails are still running, defer input persistence until they finish.
           const preparedSandboxAgent = await sandboxRuntime.prepareAgent({
             currentAgent: result.state._currentAgent,
             turnInput,
@@ -1795,7 +1809,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             // unmarked so a retry can resend safely.
             // Record the exact input that was sent so the server tracker can advance safely.
             serverConversationTracker.markInputAsSent(
-              preparedCall.sourceItems,
+              preparedCall.filterApplied
+                ? preparedCall.sourceItems
+                : preparedCall.turnInput,
               {
                 filterApplied: preparedCall.filterApplied,
                 allTurnItems: preparedCall.turnInput,
@@ -1866,7 +1882,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           };
 
           sentInputToModel = true;
-
           try {
             for await (const event of getStreamedResponseWithRetry(
               preparedCall.model,
@@ -1916,7 +1931,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               if (result.cancelled) {
                 // When the user's code exits a loop to consume the stream, we need to break
                 // this loop to prevent internal false errors and unnecessary processing
-                await awaitGuardrailsAndPersistInput();
+                await awaitInputGuardrails();
                 await reconcileStreamAbortIfNeeded();
                 return;
               }
@@ -1927,7 +1942,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               if (sentInputToModel) {
                 markInputOnce();
               }
-              await awaitGuardrailsAndPersistInput();
+              await awaitInputGuardrails();
               await reconcileStreamAbortIfNeeded();
               return;
             }
@@ -1938,7 +1953,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             markInputOnce();
           }
 
-          await awaitGuardrailsAndPersistInput();
+          await awaitInputGuardrails();
 
           if (result.cancelled) {
             return;
@@ -2035,7 +2050,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               throw error;
             }
             result.state._currentTurnInProgress = false;
-            await persistStreamInputIfNeeded();
             // Guardrails must succeed before persisting session memory to avoid storing blocked outputs.
             if (!serverManagesConversation) {
               await saveStreamResultWithCompactionOwnership();
@@ -2054,7 +2068,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             return;
           case 'next_step_interruption':
             // We are done for now. Don't run any output guardrails.
-            await persistStreamInputIfNeeded();
             if (!serverManagesConversation) {
               await saveStreamResultWithCompactionOwnership();
             }
@@ -2092,14 +2105,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       if (guardrailTracker.pending) {
         await guardrailTracker.awaitCompletion({ suppressErrors: true });
       }
-      if (
-        sentInputToModel &&
-        !streamInputPersisted &&
-        !guardrailTracker.failed &&
-        !suppressStreamInputPersistence
-      ) {
-        await persistStreamInputIfNeeded();
-      }
       const handledResult = await tryHandleRunError({
         error,
         state: result.state,
@@ -2112,9 +2117,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         streamResult: result,
       });
       if (handledResult) {
-        if (!suppressStreamInputPersistence) {
-          await persistStreamInputIfNeeded();
-        }
         if (!serverManagesConversation) {
           await saveStreamResultWithCompactionOwnership();
         }
@@ -2208,10 +2210,12 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     input: string | AgentInputItem[] | RunState<TContext, TAgent>,
     options?: StreamRunOptions<TContext, TAgent>,
     ensureStreamInputPersisted?: () => Promise<void>,
+    sessionTurnInputUpdate?: (turnInput: AgentInputItem[]) => void,
     sessionInputUpdate?: (
       sourceItems: (AgentInputItem | undefined)[],
       filteredItems?: AgentInputItem[],
     ) => void,
+    getStreamInputForPersistence?: () => AgentInputItem[] | undefined,
     preserveTurnPersistenceOnResume?: boolean,
     sandboxMemoryRunContext?: SandboxMemoryPersistenceContext,
     invocationSpanParent?: Span<any> | Trace,
@@ -2314,7 +2318,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         streamOptions,
         isResumedState,
         ensureStreamInputPersisted,
+        sessionTurnInputUpdate,
         sessionInputUpdate,
+        getStreamInputForPersistence,
         preserveTurnPersistenceOnResume,
         sandboxMemoryRunContext,
         taskSpan,
@@ -2419,13 +2425,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         systemInstructions,
       );
 
-    // Provide filtered clones whenever filters run so session history mirrors the model payload.
-    // Returning an empty array is intentional: it tells the session layer to persist "nothing"
-    // instead of falling back to the unfiltered originals when the filter redacts everything.
-    sessionInputUpdate?.(
-      sourceItems,
-      filterApplied ? persistedItems : undefined,
-    );
+    // Persist normalized clones so session history mirrors the exact model payload. An empty array
+    // is intentional when a filter removes everything.
+    sessionInputUpdate?.(sourceItems, persistedItems);
 
     const previousResponseId =
       serverConversationTracker?.previousResponseId ??

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -935,7 +935,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     sessionTurnInputUpdate?: (
       preparedInput: AgentInputItem[],
       processedInput: AgentInputItem[],
-      processedSourceIndexes?: (number | undefined)[],
     ) => void,
     // sessionInputUpdate lets the caller adjust queued session items after filters run so we
     // persist exactly what we send to the model (e.g., after redactions or truncation).
@@ -1213,11 +1212,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               ),
               tracingParent: currentTurnSpan?.span ?? state._currentAgentSpan,
             });
-            sessionTurnInputUpdate?.(
-              turnInput,
-              preparedSandboxAgent.turnInput,
-              preparedSandboxAgent.turnInputSourceIndexes,
-            );
+            sessionTurnInputUpdate?.(turnInput, preparedSandboxAgent.turnInput);
             const artifacts = await prepareAgentArtifacts(
               state,
               preparedSandboxAgent.executionAgent,
@@ -1514,7 +1509,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     sessionTurnInputUpdate?: (
       preparedInput: AgentInputItem[],
       processedInput: AgentInputItem[],
-      processedSourceIndexes?: (number | undefined)[],
     ) => void,
     sessionInputUpdate?: (
       sourceItems: (AgentInputItem | undefined)[],
@@ -1781,11 +1775,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             tracingParent:
               currentTurnSpan?.span ?? result.state._currentAgentSpan,
           });
-          sessionTurnInputUpdate?.(
-            turnInput,
-            preparedSandboxAgent.turnInput,
-            preparedSandboxAgent.turnInputSourceIndexes,
-          );
+          sessionTurnInputUpdate?.(turnInput, preparedSandboxAgent.turnInput);
           const artifacts = await prepareAgentArtifacts(
             result.state,
             preparedSandboxAgent.executionAgent,
@@ -2229,7 +2219,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     sessionTurnInputUpdate?: (
       preparedInput: AgentInputItem[],
       processedInput: AgentInputItem[],
-      processedSourceIndexes?: (number | undefined)[],
     ) => void,
     sessionInputUpdate?: (
       sourceItems: (AgentInputItem | undefined)[],

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1204,6 +1204,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             }
 
             guardrailTracker.setPromise(parallelGuardrailPromise);
+            const sessionPreparedTurnInput = [...turnInput];
             const preparedSandboxAgent = await sandboxRuntime.prepareAgent({
               currentAgent: state._currentAgent,
               turnInput,
@@ -1212,7 +1213,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               ),
               tracingParent: currentTurnSpan?.span ?? state._currentAgentSpan,
             });
-            sessionTurnInputUpdate?.(turnInput, preparedSandboxAgent.turnInput);
+            sessionTurnInputUpdate?.(
+              sessionPreparedTurnInput,
+              preparedSandboxAgent.turnInput,
+            );
             const artifacts = await prepareAgentArtifacts(
               state,
               preparedSandboxAgent.executionAgent,
@@ -1766,6 +1770,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           parallelGuardrailPromise = preparedTurn.parallelGuardrailPromise;
           guardrailTracker.setPromise(parallelGuardrailPromise);
           // If guardrails are still running, defer input persistence until they finish.
+          const sessionPreparedTurnInput = [...turnInput];
           const preparedSandboxAgent = await sandboxRuntime.prepareAgent({
             currentAgent: result.state._currentAgent,
             turnInput,
@@ -1775,7 +1780,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             tracingParent:
               currentTurnSpan?.span ?? result.state._currentAgentSpan,
           });
-          sessionTurnInputUpdate?.(turnInput, preparedSandboxAgent.turnInput);
+          sessionTurnInputUpdate?.(
+            sessionPreparedTurnInput,
+            preparedSandboxAgent.turnInput,
+          );
           const artifacts = await prepareAgentArtifacts(
             result.state,
             preparedSandboxAgent.executionAgent,

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -932,7 +932,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     startingAgent: TAgent,
     input: string | AgentInputItem[] | RunState<TContext, TAgent>,
     options: NonStreamRunOptions<TContext, TAgent>,
-    sessionTurnInputUpdate?: (turnInput: AgentInputItem[]) => void,
+    sessionTurnInputUpdate?: (
+      preparedInput: AgentInputItem[],
+      processedInput: AgentInputItem[],
+    ) => void,
     // sessionInputUpdate lets the caller adjust queued session items after filters run so we
     // persist exactly what we send to the model (e.g., after redactions or truncation).
     sessionInputUpdate?: (
@@ -1201,7 +1204,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             }
 
             guardrailTracker.setPromise(parallelGuardrailPromise);
-            sessionTurnInputUpdate?.(turnInput);
             const preparedSandboxAgent = await sandboxRuntime.prepareAgent({
               currentAgent: state._currentAgent,
               turnInput,
@@ -1210,6 +1212,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               ),
               tracingParent: currentTurnSpan?.span ?? state._currentAgentSpan,
             });
+            sessionTurnInputUpdate?.(turnInput, preparedSandboxAgent.turnInput);
             const artifacts = await prepareAgentArtifacts(
               state,
               preparedSandboxAgent.executionAgent,
@@ -1503,7 +1506,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     options: StreamRunOptions<TContext, TAgent>,
     isResumedState: boolean,
     ensureStreamInputPersisted?: () => Promise<void>,
-    sessionTurnInputUpdate?: (turnInput: AgentInputItem[]) => void,
+    sessionTurnInputUpdate?: (
+      preparedInput: AgentInputItem[],
+      processedInput: AgentInputItem[],
+    ) => void,
     sessionInputUpdate?: (
       sourceItems: (AgentInputItem | undefined)[],
       filteredItems?: AgentInputItem[],
@@ -1759,7 +1765,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           const { turnInput } = preparedTurn;
           parallelGuardrailPromise = preparedTurn.parallelGuardrailPromise;
           guardrailTracker.setPromise(parallelGuardrailPromise);
-          sessionTurnInputUpdate?.(turnInput);
           // If guardrails are still running, defer input persistence until they finish.
           const preparedSandboxAgent = await sandboxRuntime.prepareAgent({
             currentAgent: result.state._currentAgent,
@@ -1770,6 +1775,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             tracingParent:
               currentTurnSpan?.span ?? result.state._currentAgentSpan,
           });
+          sessionTurnInputUpdate?.(turnInput, preparedSandboxAgent.turnInput);
           const artifacts = await prepareAgentArtifacts(
             result.state,
             preparedSandboxAgent.executionAgent,
@@ -2210,7 +2216,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     input: string | AgentInputItem[] | RunState<TContext, TAgent>,
     options?: StreamRunOptions<TContext, TAgent>,
     ensureStreamInputPersisted?: () => Promise<void>,
-    sessionTurnInputUpdate?: (turnInput: AgentInputItem[]) => void,
+    sessionTurnInputUpdate?: (
+      preparedInput: AgentInputItem[],
+      processedInput: AgentInputItem[],
+    ) => void,
     sessionInputUpdate?: (
       sourceItems: (AgentInputItem | undefined)[],
       filteredItems?: AgentInputItem[],

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -935,6 +935,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     sessionTurnInputUpdate?: (
       preparedInput: AgentInputItem[],
       processedInput: AgentInputItem[],
+      processedSourceIndexes?: (number | undefined)[],
     ) => void,
     // sessionInputUpdate lets the caller adjust queued session items after filters run so we
     // persist exactly what we send to the model (e.g., after redactions or truncation).
@@ -1212,7 +1213,11 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               ),
               tracingParent: currentTurnSpan?.span ?? state._currentAgentSpan,
             });
-            sessionTurnInputUpdate?.(turnInput, preparedSandboxAgent.turnInput);
+            sessionTurnInputUpdate?.(
+              turnInput,
+              preparedSandboxAgent.turnInput,
+              preparedSandboxAgent.turnInputSourceIndexes,
+            );
             const artifacts = await prepareAgentArtifacts(
               state,
               preparedSandboxAgent.executionAgent,
@@ -1509,6 +1514,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     sessionTurnInputUpdate?: (
       preparedInput: AgentInputItem[],
       processedInput: AgentInputItem[],
+      processedSourceIndexes?: (number | undefined)[],
     ) => void,
     sessionInputUpdate?: (
       sourceItems: (AgentInputItem | undefined)[],
@@ -1775,7 +1781,11 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             tracingParent:
               currentTurnSpan?.span ?? result.state._currentAgentSpan,
           });
-          sessionTurnInputUpdate?.(turnInput, preparedSandboxAgent.turnInput);
+          sessionTurnInputUpdate?.(
+            turnInput,
+            preparedSandboxAgent.turnInput,
+            preparedSandboxAgent.turnInputSourceIndexes,
+          );
           const artifacts = await prepareAgentArtifacts(
             result.state,
             preparedSandboxAgent.executionAgent,
@@ -2219,6 +2229,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     sessionTurnInputUpdate?: (
       preparedInput: AgentInputItem[],
       processedInput: AgentInputItem[],
+      processedSourceIndexes?: (number | undefined)[],
     ) => void,
     sessionInputUpdate?: (
       sourceItems: (AgentInputItem | undefined)[],

--- a/packages/agents-core/src/runner/conversation.ts
+++ b/packages/agents-core/src/runner/conversation.ts
@@ -7,6 +7,7 @@ import { AgentInputItem } from '../types';
 import { addErrorToCurrentSpan } from '../tracing/context';
 import {
   buildAgentInputPool,
+  deduplicateAgentInputItemsPreferringLatest,
   extractOutputItemsFromRunItems,
   getAgentInputItemKey,
   removeAgentInputFromPool,
@@ -43,8 +44,8 @@ export type CallModelInputFilter<TContext = unknown> = (
  * - `modelInput` is the payload that goes to the model.
  * - `sourceItems` maps each filtered item back to the original turn item (or `undefined` when none).
  *   This lets the conversation tracker know which originals reached the model.
- * - `persistedItems` are the filtered clones we should commit to session memory so the stored
- *   history reflects any redactions or truncation introduced by the filter.
+ * - `persistedItems` are the normalized clones we should commit to session memory so the stored
+ *   history reflects identity-aware replacement plus any redactions or truncation from the filter.
  * - `filterApplied` signals whether a filter ran so callers can distinguish empty filtered results
  *   from the filter being skipped entirely.
  */
@@ -80,32 +81,6 @@ export async function applyCallModelInputFilter<TContext>(
 
   // Record the relationship between the cloned array passed to filters and the original inputs.
   const cloneMap = new WeakMap<object, AgentInputItem>();
-  const originalPool = buildAgentInputPool(inputItems);
-  const fallbackOriginals: AgentInputItem[] = [];
-  // Track any original object inputs so filtered replacements can still mark them as delivered.
-  for (const item of inputItems) {
-    if (item && typeof item === 'object') {
-      fallbackOriginals.push(item);
-    }
-  }
-  const removeFromFallback = (candidate: AgentInputItem | undefined) => {
-    if (!candidate || typeof candidate !== 'object') {
-      return;
-    }
-    const index = fallbackOriginals.findIndex(
-      (original) => original === candidate,
-    );
-    if (index !== -1) {
-      fallbackOriginals.splice(index, 1);
-    }
-  };
-  const takeFallbackOriginal = (): AgentInputItem | undefined => {
-    const next = fallbackOriginals.shift();
-    if (next) {
-      removeAgentInputFromPool(originalPool, next);
-    }
-    return next;
-  };
 
   // Always create a deep copy so downstream mutations inside filters cannot affect
   // the cached turn state.
@@ -115,10 +90,14 @@ export async function applyCallModelInputFilter<TContext>(
     instructions: systemInstructions,
   };
   if (!callModelInputFilter) {
+    const normalizedInput =
+      deduplicateAgentInputItemsPreferringLatest(clonedBaseInput);
     return {
-      modelInput: base,
-      sourceItems: [...inputItems],
-      persistedItems: [],
+      modelInput: { ...base, input: normalizedInput },
+      sourceItems: normalizedInput.map(
+        (item) => cloneMap.get(item as object) ?? item,
+      ),
+      persistedItems: cloneInputItems(normalizedInput),
       filterApplied: false,
     };
   }
@@ -136,32 +115,100 @@ export async function applyCallModelInputFilter<TContext>(
       );
     }
 
+    const normalizedBaseSources = deduplicateAgentInputItemsPreferringLatest(
+      clonedBaseInput,
+    ).map((item) => cloneMap.get(item as object) ?? item);
+    const originalPool = buildAgentInputPool(normalizedBaseSources);
+    const fallbackOriginals = normalizedBaseSources.filter(
+      (item) => item && typeof item === 'object',
+    );
+    const removeFromFallback = (candidate: AgentInputItem | undefined) => {
+      if (!candidate || typeof candidate !== 'object') {
+        return;
+      }
+      const index = fallbackOriginals.findIndex(
+        (original) => original === candidate,
+      );
+      if (index !== -1) {
+        fallbackOriginals.splice(index, 1);
+      }
+    };
+    const takeFallbackOriginal = (): AgentInputItem | undefined => {
+      const next = fallbackOriginals.shift();
+      if (next) {
+        removeAgentInputFromPool(originalPool, next);
+      }
+      return next;
+    };
+
+    const normalizedInput = deduplicateAgentInputItemsPreferringLatest(
+      result.input,
+    );
+    const consumedExactClones = new WeakSet<object>();
+    const injectedExactCloneIndexes = new Set<number>();
+
     // Preserve a pointer to the original object backing each filtered clone so downstream
     // trackers can keep their bookkeeping consistent even after redaction.
-    const sourceItems = result.input.map((item) => {
-      if (!item || typeof item !== 'object') {
-        return undefined;
-      }
-      const original = cloneMap.get(item as object);
-      if (original) {
+    const sourceItems: (AgentInputItem | undefined)[] = normalizedInput.map(
+      (item, index) => {
+        if (!item || typeof item !== 'object') {
+          return undefined;
+        }
+        const original = cloneMap.get(item as object);
+        if (!original) {
+          return undefined;
+        }
+        if (consumedExactClones.has(item as object)) {
+          injectedExactCloneIndexes.add(index);
+          return undefined;
+        }
+        consumedExactClones.add(item as object);
         removeFromFallback(original);
         removeAgentInputFromPool(originalPool, original);
         return original;
+      },
+    );
+
+    // Reserve all exact clone matches before considering equal-content items. A prepended clone
+    // that happens to equal a later unchanged item must remain an injected item.
+    for (let index = 0; index < sourceItems.length; index++) {
+      if (sourceItems[index] !== undefined) {
+        continue;
+      }
+      if (injectedExactCloneIndexes.has(index)) {
+        continue;
+      }
+      const item = normalizedInput[index];
+      if (!item || typeof item !== 'object') {
+        continue;
       }
       const key = getAgentInputItemKey(item as AgentInputItem);
       const matchedByContent = takeAgentInputFromPool(originalPool, key);
       if (matchedByContent) {
         removeFromFallback(matchedByContent);
-        return matchedByContent;
+        sourceItems[index] = matchedByContent;
+      }
+    }
+
+    // Assign replacement fallbacks only after every exact and content match has been reserved.
+    for (let index = 0; index < sourceItems.length; index++) {
+      if (sourceItems[index] !== undefined) {
+        continue;
+      }
+      if (injectedExactCloneIndexes.has(index)) {
+        continue;
+      }
+      const item = normalizedInput[index];
+      if (!item || typeof item !== 'object') {
+        continue;
       }
       const fallback = takeFallbackOriginal();
       if (fallback) {
-        return fallback;
+        sourceItems[index] = fallback;
       }
-      return undefined;
-    });
+    }
 
-    const clonedFilteredInput = cloneInputItems(result.input);
+    const clonedFilteredInput = cloneInputItems(normalizedInput);
     return {
       modelInput: {
         input: clonedFilteredInput,
@@ -424,8 +471,7 @@ export class ServerConversationTracker {
     );
     for (const [index, preparedItem] of preparedGeneratedItems.entries()) {
       const sourceItem = generatedItemsForInput[index]?.rawItem as
-        | AgentInputItem
-        | undefined;
+        AgentInputItem | undefined;
       this.registerPreparedItemSource(preparedItem, sourceItem);
     }
     inputItems.push(...preparedGeneratedItems);

--- a/packages/agents-core/src/runner/items.ts
+++ b/packages/agents-core/src/runner/items.ts
@@ -157,6 +157,8 @@ function isCausalPrecursorItem(item: AgentInputItem): boolean {
   }
   return (
     item.type === 'tool_search_call' ||
+    (item.type === 'hosted_tool_call' &&
+      getToolResultCorrelationForResult(item) === undefined) ||
     item.type === 'reasoning' ||
     getToolResultCorrelationForCall(item) !== undefined
   );

--- a/packages/agents-core/src/runner/items.ts
+++ b/packages/agents-core/src/runner/items.ts
@@ -1,5 +1,6 @@
 import { RunItem } from '../items';
 import { UserError } from '../errors';
+import { getToolSearchProviderCallId } from '../tooling';
 import { AgentInputItem } from '../types';
 import * as protocol from '../types/protocol';
 import { serializeBinary } from '../utils/binary';
@@ -97,6 +98,104 @@ export function removeAgentInputFromPool(
     pool.delete(key);
   }
   return true;
+}
+
+function getAgentInputItemDeduplicationKey(
+  item: AgentInputItem,
+): string | undefined {
+  if (!item || typeof item !== 'object') {
+    return undefined;
+  }
+
+  const candidate = item as {
+    id?: unknown;
+    role?: unknown;
+    type?: unknown;
+  };
+  const itemType = candidate.type;
+  if (typeof candidate.role === 'string' || itemType === 'message') {
+    return undefined;
+  }
+  if (typeof itemType !== 'string') {
+    return undefined;
+  }
+  if (itemType === 'tool_search_call' || itemType === 'tool_search_output') {
+    const callId = getToolSearchProviderCallId(item);
+    if (callId) {
+      return JSON.stringify(['call', itemType, callId]);
+    }
+  }
+
+  const callCorrelation = getToolResultCorrelationForCall(item);
+  if (callCorrelation && callCorrelation.id.length > 0) {
+    return JSON.stringify([
+      'call',
+      itemType,
+      getToolResultCorrelationKey(callCorrelation),
+    ]);
+  }
+
+  const resultCorrelation = getToolResultCorrelationForResult(item);
+  if (resultCorrelation && resultCorrelation.id.length > 0) {
+    return JSON.stringify([
+      'result',
+      itemType,
+      getToolResultCorrelationKey(resultCorrelation),
+    ]);
+  }
+
+  if (typeof candidate.id === 'string' && candidate.id.length > 0) {
+    return JSON.stringify(['item', itemType, candidate.id]);
+  }
+
+  return undefined;
+}
+
+function isCausalPrecursorItem(item: AgentInputItem): boolean {
+  if (!item || typeof item !== 'object') {
+    return false;
+  }
+  return (
+    item.type === 'reasoning' ||
+    getToolResultCorrelationForCall(item) !== undefined
+  );
+}
+
+/**
+ * Deduplicates provider-identified items while preserving causal ordering.
+ *
+ * The latest payload wins. Calls, reasoning, and approval requests stay at their earliest
+ * occurrence so they cannot move behind a required follower; other identified items stay at
+ * their latest occurrence so stale outputs are not moved earlier. Items without stable provider
+ * identity, including ordinary messages, remain untouched.
+ */
+export function deduplicateAgentInputItemsPreferringLatest(
+  items: AgentInputItem[],
+): AgentInputItem[] {
+  const latestByKey = new Map<string, AgentInputItem>();
+  const anchorIndexByKey = new Map<string, number>();
+
+  for (const [index, item] of items.entries()) {
+    const key = getAgentInputItemDeduplicationKey(item);
+    if (!key) {
+      continue;
+    }
+    latestByKey.set(key, item);
+    if (!anchorIndexByKey.has(key) || !isCausalPrecursorItem(item)) {
+      anchorIndexByKey.set(key, index);
+    }
+  }
+
+  const deduplicated: AgentInputItem[] = [];
+  for (const [index, item] of items.entries()) {
+    const key = getAgentInputItemDeduplicationKey(item);
+    if (!key) {
+      deduplicated.push(item);
+    } else if (anchorIndexByKey.get(key) === index) {
+      deduplicated.push(latestByKey.get(key) as AgentInputItem);
+    }
+  }
+  return deduplicated;
 }
 
 export function agentInputSerializationReplacer(

--- a/packages/agents-core/src/runner/items.ts
+++ b/packages/agents-core/src/runner/items.ts
@@ -156,6 +156,7 @@ function isCausalPrecursorItem(item: AgentInputItem): boolean {
     return false;
   }
   return (
+    item.type === 'tool_search_call' ||
     item.type === 'reasoning' ||
     getToolResultCorrelationForCall(item) !== undefined
   );

--- a/packages/agents-core/src/runner/items.ts
+++ b/packages/agents-core/src/runner/items.ts
@@ -159,6 +159,7 @@ function isCausalPrecursorItem(item: AgentInputItem): boolean {
     item.type === 'tool_search_call' ||
     (item.type === 'hosted_tool_call' &&
       getToolResultCorrelationForResult(item) === undefined) ||
+    item.type === 'compaction' ||
     item.type === 'reasoning' ||
     getToolResultCorrelationForCall(item) !== undefined
   );
@@ -167,10 +168,10 @@ function isCausalPrecursorItem(item: AgentInputItem): boolean {
 /**
  * Deduplicates provider-identified items while preserving causal ordering.
  *
- * The latest payload wins. Calls, reasoning, and approval requests stay at their earliest
- * occurrence so they cannot move behind a required follower; other identified items stay at
- * their latest occurrence so stale outputs are not moved earlier. Items without stable provider
- * identity, including ordinary messages, remain untouched.
+ * The latest payload wins. Calls, compaction, reasoning, and approval requests stay at their
+ * earliest occurrence so they cannot move behind a required follower; other identified items
+ * stay at their latest occurrence so stale outputs are not moved earlier. Items without stable
+ * provider identity, including ordinary messages, remain untouched.
  */
 export function deduplicateAgentInputItemsPreferringLatest(
   items: AgentInputItem[],

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -58,12 +58,20 @@ class SessionReconciliationRecoveryError extends Error {
 type PersistedInputOccurrence =
   { type: 'owned'; index: number } | { type: 'injected'; item: AgentInputItem };
 
+type PreparedOwnedSource = {
+  item: AgentInputItem;
+  ownerIndex: number;
+};
+
 export type SessionPersistenceTracker = {
   setPreparedItems: (
     items?: AgentInputItem[],
     preparedInput?: string | AgentInputItem[],
   ) => void;
-  setPreparedTurnItems: (items: AgentInputItem[]) => void;
+  setPreparedTurnItems: (
+    preparedItems: AgentInputItem[],
+    processedItems: AgentInputItem[],
+  ) => void;
   recordTurnItems: (
     sourceItems: (AgentInputItem | undefined)[],
     filteredItems?: AgentInputItem[],
@@ -91,7 +99,7 @@ export function createSessionPersistenceTracker(options: {
     private readonly persistInput?: typeof saveStreamInputToSession;
     private originalSnapshot: AgentInputItem[] | undefined;
     private filteredSnapshot: AgentInputItem[] | undefined;
-    private preparedSources: AgentInputItem[] | undefined;
+    private preparedSources: PreparedOwnedSource[] | undefined;
     private preparedSourceIndexes: number[] | undefined;
     private ownedFilteredItems = new Map<number, AgentInputItem>();
     private persistedInputOrder: PersistedInputOccurrence[] = [];
@@ -122,21 +130,28 @@ export function createSessionPersistenceTracker(options: {
           sessionItems,
         );
       } else {
-        this.preparedSources = sessionItems;
+        this.preparedSources = sessionItems.map((item, ownerIndex) => ({
+          item,
+          ownerIndex,
+        }));
         this.preparedSourceIndexes = undefined;
       }
       this.ownedFilteredItems.clear();
       this.persistedInputOrder = [];
     };
 
-    setPreparedTurnItems = (items: AgentInputItem[]) => {
+    setPreparedTurnItems = (
+      preparedItems: AgentInputItem[],
+      processedItems: AgentInputItem[],
+    ) => {
       if (!this.preparedSourceIndexes) {
         return;
       }
-      this.preparedSources = this.preparedSourceIndexes
-        .map((index) => items[index])
-        .filter((item): item is AgentInputItem => item !== undefined);
-      this.preparedSourceIndexes = undefined;
+      this.preparedSources = mapPreparedSourcesAfterContextProcessing(
+        preparedItems,
+        processedItems,
+        this.preparedSourceIndexes,
+      );
     };
 
     recordTurnItems = (
@@ -163,7 +178,9 @@ export function createSessionPersistenceTracker(options: {
 
       this.filteredSnapshot = buildSnapshotForUnfilteredItems({
         preparedSourceCounts: this.preparedSources
-          ? countItemReferences(this.preparedSources)
+          ? countItemReferences(
+              this.preparedSources.map((source) => source.item),
+            )
           : undefined,
         sourceItems,
         existingSnapshot: this.filteredSnapshot,
@@ -233,8 +250,87 @@ function findOwnedItemIndexes(
   return indexes;
 }
 
+function mapPreparedSourcesAfterContextProcessing(
+  preparedItems: AgentInputItem[],
+  processedItems: AgentInputItem[],
+  preparedSourceIndexes: number[],
+): PreparedOwnedSource[] {
+  const preparedIndexesByReference = new Map<AgentInputItem, number[]>();
+  const preparedIndexesByKey = new Map<string, number[]>();
+  for (const [index, item] of preparedItems.entries()) {
+    const referenceIndexes = preparedIndexesByReference.get(item) ?? [];
+    referenceIndexes.push(index);
+    preparedIndexesByReference.set(item, referenceIndexes);
+
+    const key = getAgentInputItemKey(item);
+    const keyIndexes = preparedIndexesByKey.get(key) ?? [];
+    keyIndexes.push(index);
+    preparedIndexesByKey.set(key, keyIndexes);
+  }
+
+  const mappedPreparedIndexes = new Array<number | undefined>(
+    processedItems.length,
+  );
+  const usedPreparedIndexes = new Set<number>();
+
+  // Match from the end so prefix-removing context processors preserve occurrence positions.
+  for (let index = processedItems.length - 1; index >= 0; index--) {
+    const item = processedItems[index];
+    if (!item) {
+      continue;
+    }
+    const preparedIndex = preparedIndexesByReference.get(item)?.pop();
+    if (preparedIndex !== undefined) {
+      mappedPreparedIndexes[index] = preparedIndex;
+      usedPreparedIndexes.add(preparedIndex);
+    }
+  }
+
+  // Public capabilities may return clones. Resolve remaining occurrences against the complete
+  // prepared sequence so callback reordering and equal-content history retain their ownership.
+  for (let index = processedItems.length - 1; index >= 0; index--) {
+    if (mappedPreparedIndexes[index] !== undefined) {
+      continue;
+    }
+    const item = processedItems[index];
+    if (!item) {
+      continue;
+    }
+    const preparedIndexes = preparedIndexesByKey.get(
+      getAgentInputItemKey(item),
+    );
+    while (
+      preparedIndexes &&
+      preparedIndexes.length > 0 &&
+      usedPreparedIndexes.has(preparedIndexes[preparedIndexes.length - 1])
+    ) {
+      preparedIndexes.pop();
+    }
+    const preparedIndex = preparedIndexes?.pop();
+    if (preparedIndex !== undefined) {
+      mappedPreparedIndexes[index] = preparedIndex;
+      usedPreparedIndexes.add(preparedIndex);
+    }
+  }
+
+  const ownerIndexByPreparedIndex = new Map(
+    preparedSourceIndexes.map((preparedIndex, ownerIndex) => [
+      preparedIndex,
+      ownerIndex,
+    ]),
+  );
+  return processedItems.flatMap((item, index) => {
+    const preparedIndex = mappedPreparedIndexes[index];
+    const ownerIndex =
+      preparedIndex === undefined
+        ? undefined
+        : ownerIndexByPreparedIndex.get(preparedIndex);
+    return ownerIndex === undefined ? [] : [{ item, ownerIndex }];
+  });
+}
+
 function reconcilePersistableFilteredItems(options: {
-  preparedSources: AgentInputItem[];
+  preparedSources: PreparedOwnedSource[];
   sourceItems: (AgentInputItem | undefined)[];
   filteredItems: AgentInputItem[];
   ownedFilteredItems: Map<number, AgentInputItem>;
@@ -251,11 +347,11 @@ function reconcilePersistableFilteredItems(options: {
     ownedFilteredItems,
     persistedInputOrder,
   } = options;
-  const sourceIndexes = new Map<AgentInputItem, number[]>();
-  for (const [index, source] of preparedSources.entries()) {
-    const indexes = sourceIndexes.get(source) ?? [];
-    indexes.push(index);
-    sourceIndexes.set(source, indexes);
+  const sourceOwnerIndexes = new Map<AgentInputItem, number[]>();
+  for (const source of preparedSources) {
+    const ownerIndexes = sourceOwnerIndexes.get(source.item) ?? [];
+    ownerIndexes.push(source.ownerIndex);
+    sourceOwnerIndexes.set(source.item, ownerIndexes);
   }
   const sourceOccurrences = new Map<AgentInputItem, number>();
   const representedOwnedIndexes = new Set<number>();
@@ -271,7 +367,7 @@ function reconcilePersistableFilteredItems(options: {
     if (source && typeof source === 'object') {
       const occurrence = sourceOccurrences.get(source) ?? 0;
       sourceOccurrences.set(source, occurrence + 1);
-      const ownedIndex = sourceIndexes.get(source)?.[occurrence];
+      const ownedIndex = sourceOwnerIndexes.get(source)?.[occurrence];
       if (ownedIndex !== undefined) {
         representedOwnedIndexes.add(ownedIndex);
         nextOwnedFilteredItems.set(ownedIndex, structuredClone(filteredItem));

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -63,6 +63,11 @@ type PreparedOwnedSource = {
   ownerIndex: number;
 };
 
+type PreparedOwnedSourcePosition = {
+  preparedIndex: number;
+  ownerIndex: number;
+};
+
 export type SessionPersistenceTracker = {
   setPreparedItems: (
     items?: AgentInputItem[],
@@ -100,7 +105,8 @@ export function createSessionPersistenceTracker(options: {
     private originalSnapshot: AgentInputItem[] | undefined;
     private filteredSnapshot: AgentInputItem[] | undefined;
     private preparedSources: PreparedOwnedSource[] | undefined;
-    private preparedSourceIndexes: number[] | undefined;
+    private initialPreparedItems: AgentInputItem[] | undefined;
+    private initialSourcePositions: PreparedOwnedSourcePosition[] | undefined;
     private ownedFilteredItems = new Map<number, AgentInputItem>();
     private persistedInputOrder: PersistedInputOccurrence[] = [];
     private persistedInput = false;
@@ -112,7 +118,8 @@ export function createSessionPersistenceTracker(options: {
       this.originalSnapshot = options.resumingFromState ? [] : undefined;
       this.filteredSnapshot = undefined;
       this.preparedSources = options.resumingFromState ? [] : undefined;
-      this.preparedSourceIndexes = options.resumingFromState ? [] : undefined;
+      this.initialPreparedItems = options.resumingFromState ? [] : undefined;
+      this.initialSourcePositions = options.resumingFromState ? [] : undefined;
     }
 
     setPreparedItems = (
@@ -125,7 +132,8 @@ export function createSessionPersistenceTracker(options: {
       );
       if (Array.isArray(preparedInput)) {
         this.preparedSources = undefined;
-        this.preparedSourceIndexes = findOwnedItemIndexes(
+        this.initialPreparedItems = preparedInput;
+        this.initialSourcePositions = findOwnedItemIndexes(
           preparedInput,
           sessionItems,
         );
@@ -134,7 +142,8 @@ export function createSessionPersistenceTracker(options: {
           item,
           ownerIndex,
         }));
-        this.preparedSourceIndexes = undefined;
+        this.initialPreparedItems = undefined;
+        this.initialSourcePositions = undefined;
       }
       this.ownedFilteredItems.clear();
       this.persistedInputOrder = [];
@@ -144,13 +153,19 @@ export function createSessionPersistenceTracker(options: {
       preparedItems: AgentInputItem[],
       processedItems: AgentInputItem[],
     ) => {
-      if (!this.preparedSourceIndexes) {
+      if (!this.initialPreparedItems || !this.initialSourcePositions) {
         return;
       }
+      const preparedSources = mapPreparedSourcesAfterContextProcessing(
+        this.initialPreparedItems,
+        preparedItems,
+        this.initialSourcePositions,
+        { validateReplacements: false },
+      );
       this.preparedSources = mapPreparedSourcesAfterContextProcessing(
         preparedItems,
         processedItems,
-        this.preparedSourceIndexes,
+        findPreparedSourcePositions(preparedItems, preparedSources),
       );
     };
 
@@ -236,27 +251,52 @@ function countItemReferences(
 function findOwnedItemIndexes(
   preparedInput: AgentInputItem[],
   ownedItems: AgentInputItem[],
-): number[] {
-  const remaining = countItemReferences(ownedItems);
-  const indexes: number[] = [];
+): PreparedOwnedSourcePosition[] {
+  const remainingOwnerIndexes = new Map<AgentInputItem, number[]>();
+  for (const [ownerIndex, item] of ownedItems.entries()) {
+    const indexes = remainingOwnerIndexes.get(item) ?? [];
+    indexes.push(ownerIndex);
+    remainingOwnerIndexes.set(item, indexes);
+  }
+  const positions: PreparedOwnedSourcePosition[] = [];
   for (const [index, item] of preparedInput.entries()) {
-    const count = remaining.get(item) ?? 0;
-    if (count <= 0) {
+    const ownerIndex = remainingOwnerIndexes.get(item)?.shift();
+    if (ownerIndex === undefined) {
       continue;
     }
-    indexes.push(index);
-    remaining.set(item, count - 1);
+    positions.push({ preparedIndex: index, ownerIndex });
   }
-  return indexes;
+  return positions;
+}
+
+function findPreparedSourcePositions(
+  preparedItems: AgentInputItem[],
+  preparedSources: PreparedOwnedSource[],
+): PreparedOwnedSourcePosition[] {
+  const remainingOwnerIndexes = new Map<AgentInputItem, number[]>();
+  for (const source of preparedSources) {
+    const indexes = remainingOwnerIndexes.get(source.item) ?? [];
+    indexes.push(source.ownerIndex);
+    remainingOwnerIndexes.set(source.item, indexes);
+  }
+  const positions: PreparedOwnedSourcePosition[] = [];
+  for (const [preparedIndex, item] of preparedItems.entries()) {
+    const ownerIndex = remainingOwnerIndexes.get(item)?.shift();
+    if (ownerIndex !== undefined) {
+      positions.push({ preparedIndex, ownerIndex });
+    }
+  }
+  return positions;
 }
 
 function mapPreparedSourcesAfterContextProcessing(
   preparedItems: AgentInputItem[],
   processedItems: AgentInputItem[],
-  preparedSourceIndexes: number[],
+  preparedSourcePositions: PreparedOwnedSourcePosition[],
+  options: { validateReplacements?: boolean } = {},
 ): PreparedOwnedSource[] {
   const ownerIndexByPreparedIndex = new Map(
-    preparedSourceIndexes.map((preparedIndex, ownerIndex) => [
+    preparedSourcePositions.map(({ preparedIndex, ownerIndex }) => [
       preparedIndex,
       ownerIndex,
     ]),
@@ -414,6 +454,7 @@ function mapPreparedSourcesAfterContextProcessing(
   // occurrence exists, an unmatched item could instead be a deletion plus an injection, so leave
   // it unowned rather than assigning Session provenance from matching residual cardinality alone.
   if (
+    options.validateReplacements !== false &&
     preparedItems.length === 1 &&
     processedItems.length === 1 &&
     remainingProcessedIndexes.length === 1 &&
@@ -447,6 +488,7 @@ function mapPreparedSourcesAfterContextProcessing(
       indexes.some((index) => !usedPreparedIndexes.has(index)),
   );
   if (
+    options.validateReplacements !== false &&
     hasUnmatchedProcessedItem &&
     (hasUnmatchedOwnedItem || hasUnprovenOwnedClone)
   ) {

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -15,6 +15,7 @@ import { toUint8ArrayFromBinary } from '../utils/binary';
 import {
   assertValidCompactionItems,
   buildAgentInputPool,
+  deduplicateAgentInputItemsPreferringLatest,
   dropOrphanToolCalls,
   extractOutputItemsFromRunItems,
   toAgentInputList,
@@ -54,8 +55,15 @@ class SessionReconciliationRecoveryError extends Error {
   }
 }
 
+type PersistedInputOccurrence =
+  { type: 'owned'; index: number } | { type: 'injected'; item: AgentInputItem };
+
 export type SessionPersistenceTracker = {
-  setPreparedItems: (items?: AgentInputItem[]) => void;
+  setPreparedItems: (
+    items?: AgentInputItem[],
+    preparedInput?: string | AgentInputItem[],
+  ) => void;
+  setPreparedTurnItems: (items: AgentInputItem[]) => void;
   recordTurnItems: (
     sourceItems: (AgentInputItem | undefined)[],
     filteredItems?: AgentInputItem[],
@@ -83,7 +91,10 @@ export function createSessionPersistenceTracker(options: {
     private readonly persistInput?: typeof saveStreamInputToSession;
     private originalSnapshot: AgentInputItem[] | undefined;
     private filteredSnapshot: AgentInputItem[] | undefined;
-    private pendingWriteCounts: Map<string, number> | undefined;
+    private preparedSources: AgentInputItem[] | undefined;
+    private preparedSourceIndexes: number[] | undefined;
+    private ownedFilteredItems = new Map<number, AgentInputItem>();
+    private persistedInputOrder: PersistedInputOccurrence[] = [];
     private persistedInput = false;
 
     constructor() {
@@ -92,48 +103,68 @@ export function createSessionPersistenceTracker(options: {
       this.persistInput = options.persistInput;
       this.originalSnapshot = options.resumingFromState ? [] : undefined;
       this.filteredSnapshot = undefined;
-      this.pendingWriteCounts = options.resumingFromState
-        ? new Map()
-        : undefined;
+      this.preparedSources = options.resumingFromState ? [] : undefined;
+      this.preparedSourceIndexes = options.resumingFromState ? [] : undefined;
     }
 
-    setPreparedItems = (items?: AgentInputItem[]) => {
+    setPreparedItems = (
+      items?: AgentInputItem[],
+      preparedInput?: string | AgentInputItem[],
+    ) => {
       const sessionItems = items ?? [];
-      this.originalSnapshot = sessionItems.map((item) => structuredClone(item));
-      this.pendingWriteCounts = new Map();
-      for (const item of sessionItems) {
-        const key = getAgentInputItemKey(item);
-        this.pendingWriteCounts.set(
-          key,
-          (this.pendingWriteCounts.get(key) ?? 0) + 1,
+      this.originalSnapshot = cloneItems(
+        deduplicateAgentInputItemsPreferringLatest(sessionItems),
+      );
+      if (Array.isArray(preparedInput)) {
+        this.preparedSources = undefined;
+        this.preparedSourceIndexes = findOwnedItemIndexes(
+          preparedInput,
+          sessionItems,
         );
+      } else {
+        this.preparedSources = sessionItems;
+        this.preparedSourceIndexes = undefined;
       }
+      this.ownedFilteredItems.clear();
+      this.persistedInputOrder = [];
+    };
+
+    setPreparedTurnItems = (items: AgentInputItem[]) => {
+      if (!this.preparedSourceIndexes) {
+        return;
+      }
+      this.preparedSources = this.preparedSourceIndexes
+        .map((index) => items[index])
+        .filter((item): item is AgentInputItem => item !== undefined);
+      this.preparedSourceIndexes = undefined;
     };
 
     recordTurnItems = (
       sourceItems: (AgentInputItem | undefined)[],
       filteredItems?: AgentInputItem[],
     ) => {
-      const pendingCounts = this.pendingWriteCounts;
       if (filteredItems !== undefined) {
-        if (!pendingCounts) {
+        if (!this.preparedSources) {
           this.filteredSnapshot = cloneItems(filteredItems);
           return;
         }
-        const nextSnapshot = collectPersistableFilteredItems({
-          pendingCounts,
+        const next = reconcilePersistableFilteredItems({
+          preparedSources: this.preparedSources,
           sourceItems,
           filteredItems,
-          existingSnapshot: this.filteredSnapshot,
+          ownedFilteredItems: this.ownedFilteredItems,
+          persistedInputOrder: this.persistedInputOrder,
         });
-        if (nextSnapshot !== undefined) {
-          this.filteredSnapshot = nextSnapshot;
-        }
+        this.ownedFilteredItems = next.ownedFilteredItems;
+        this.persistedInputOrder = next.persistedInputOrder;
+        this.filteredSnapshot = next.filteredSnapshot;
         return;
       }
 
       this.filteredSnapshot = buildSnapshotForUnfilteredItems({
-        pendingCounts,
+        preparedSourceCounts: this.preparedSources
+          ? countItemReferences(this.preparedSources)
+          : undefined,
         sourceItems,
         existingSnapshot: this.filteredSnapshot,
       });
@@ -175,91 +206,114 @@ function cloneItems(items: AgentInputItem[]): AgentInputItem[] {
   return items.map((item) => structuredClone(item));
 }
 
-function buildSourceOccurrenceCounts(
-  sourceItems: (AgentInputItem | undefined)[],
-) {
-  const sourceOccurrenceCounts = new WeakMap<AgentInputItem, number>();
-  for (const source of sourceItems) {
-    if (!source || typeof source !== 'object') {
-      continue;
-    }
-    const nextCount = (sourceOccurrenceCounts.get(source) ?? 0) + 1;
-    sourceOccurrenceCounts.set(source, nextCount);
+function countItemReferences(
+  items: AgentInputItem[],
+): Map<AgentInputItem, number> {
+  const counts = new Map<AgentInputItem, number>();
+  for (const item of items) {
+    counts.set(item, (counts.get(item) ?? 0) + 1);
   }
-  return sourceOccurrenceCounts;
+  return counts;
 }
 
-function collectPersistableFilteredItems(options: {
-  pendingCounts: Map<string, number>;
+function findOwnedItemIndexes(
+  preparedInput: AgentInputItem[],
+  ownedItems: AgentInputItem[],
+): number[] {
+  const remaining = countItemReferences(ownedItems);
+  const indexes: number[] = [];
+  for (const [index, item] of preparedInput.entries()) {
+    const count = remaining.get(item) ?? 0;
+    if (count <= 0) {
+      continue;
+    }
+    indexes.push(index);
+    remaining.set(item, count - 1);
+  }
+  return indexes;
+}
+
+function reconcilePersistableFilteredItems(options: {
+  preparedSources: AgentInputItem[];
   sourceItems: (AgentInputItem | undefined)[];
   filteredItems: AgentInputItem[];
-  existingSnapshot: AgentInputItem[] | undefined;
-}): AgentInputItem[] | undefined {
-  const { pendingCounts, sourceItems, filteredItems, existingSnapshot } =
-    options;
-  const persistableItems: AgentInputItem[] = [];
-  const sourceOccurrenceCounts = buildSourceOccurrenceCounts(sourceItems);
-  const consumeAnyPendingWriteSlot = () => {
-    for (const [key, remaining] of pendingCounts) {
-      if (remaining > 0) {
-        pendingCounts.set(key, remaining - 1);
-        return true;
-      }
-    }
-    return false;
-  };
+  ownedFilteredItems: Map<number, AgentInputItem>;
+  persistedInputOrder: PersistedInputOccurrence[];
+}): {
+  ownedFilteredItems: Map<number, AgentInputItem>;
+  persistedInputOrder: PersistedInputOccurrence[];
+  filteredSnapshot: AgentInputItem[];
+} {
+  const {
+    preparedSources,
+    sourceItems,
+    filteredItems,
+    ownedFilteredItems,
+    persistedInputOrder,
+  } = options;
+  const sourceIndexes = new Map<AgentInputItem, number[]>();
+  for (const [index, source] of preparedSources.entries()) {
+    const indexes = sourceIndexes.get(source) ?? [];
+    indexes.push(index);
+    sourceIndexes.set(source, indexes);
+  }
+  const sourceOccurrences = new Map<AgentInputItem, number>();
+  const representedOwnedIndexes = new Set<number>();
+  const currentOrder: PersistedInputOccurrence[] = [];
+  const nextOwnedFilteredItems = new Map(ownedFilteredItems);
 
   for (let i = 0; i < filteredItems.length; i++) {
     const filteredItem = filteredItems[i];
     if (!filteredItem) {
       continue;
     }
-    let allocated = false;
     const source = sourceItems[i];
     if (source && typeof source === 'object') {
-      const pendingOccurrences = (sourceOccurrenceCounts.get(source) ?? 0) - 1;
-      sourceOccurrenceCounts.set(source, pendingOccurrences);
-      if (pendingOccurrences > 0) {
-        continue;
+      const occurrence = sourceOccurrences.get(source) ?? 0;
+      sourceOccurrences.set(source, occurrence + 1);
+      const ownedIndex = sourceIndexes.get(source)?.[occurrence];
+      if (ownedIndex !== undefined) {
+        representedOwnedIndexes.add(ownedIndex);
+        nextOwnedFilteredItems.set(ownedIndex, structuredClone(filteredItem));
+        currentOrder.push({ type: 'owned', index: ownedIndex });
       }
-      const sourceKey = getAgentInputItemKey(source);
-      const remaining = pendingCounts.get(sourceKey) ?? 0;
-      if (remaining > 0) {
-        pendingCounts.set(sourceKey, remaining - 1);
-        persistableItems.push(structuredClone(filteredItem));
-        allocated = true;
-        continue;
-      }
-    }
-    const filteredKey = getAgentInputItemKey(filteredItem);
-    const filteredRemaining = pendingCounts.get(filteredKey) ?? 0;
-    if (filteredRemaining > 0) {
-      pendingCounts.set(filteredKey, filteredRemaining - 1);
-      persistableItems.push(structuredClone(filteredItem));
-      allocated = true;
       continue;
     }
-    if (!source && consumeAnyPendingWriteSlot()) {
-      persistableItems.push(structuredClone(filteredItem));
-      allocated = true;
-    }
-    if (!allocated && !source && existingSnapshot === undefined) {
-      persistableItems.push(structuredClone(filteredItem));
-    }
+    // Items without a source were injected by the callback. Preserve them without attempting
+    // content-based identity matching, which could collapse ordinary messages.
+    currentOrder.push({
+      type: 'injected',
+      item: structuredClone(filteredItem),
+    });
   }
-  if (persistableItems.length > 0 || existingSnapshot === undefined) {
-    return persistableItems;
-  }
-  return existingSnapshot;
+
+  const nextPersistedInputOrder = persistedInputOrder.filter(
+    (occurrence) =>
+      occurrence.type !== 'owned' ||
+      !representedOwnedIndexes.has(occurrence.index),
+  );
+  nextPersistedInputOrder.push(...currentOrder);
+
+  return {
+    ownedFilteredItems: nextOwnedFilteredItems,
+    persistedInputOrder: nextPersistedInputOrder,
+    filteredSnapshot: nextPersistedInputOrder.flatMap((occurrence) => {
+      if (occurrence.type === 'injected') {
+        return [structuredClone(occurrence.item)];
+      }
+      const item = nextOwnedFilteredItems.get(occurrence.index);
+      return item ? [structuredClone(item)] : [];
+    }),
+  };
 }
 
 function buildSnapshotForUnfilteredItems(options: {
-  pendingCounts: Map<string, number> | undefined;
+  preparedSourceCounts: Map<AgentInputItem, number> | undefined;
   sourceItems: (AgentInputItem | undefined)[];
   existingSnapshot: AgentInputItem[] | undefined;
 }): AgentInputItem[] {
-  const { pendingCounts, sourceItems, existingSnapshot } = options;
-  if (!pendingCounts) {
+  const { preparedSourceCounts, sourceItems, existingSnapshot } = options;
+  if (!preparedSourceCounts) {
     const filtered = sourceItems
       .filter((item): item is AgentInputItem => Boolean(item))
       .map((item) => structuredClone(item));
@@ -271,16 +325,17 @@ function buildSnapshotForUnfilteredItems(options: {
   }
 
   const filtered: AgentInputItem[] = [];
+  const includedSourceCounts = new Map<AgentInputItem, number>();
   for (const item of sourceItems) {
     if (!item) {
       continue;
     }
-    const key = getAgentInputItemKey(item);
-    const remaining = pendingCounts.get(key) ?? 0;
-    if (remaining <= 0) {
+    const preparedOccurrences = preparedSourceCounts.get(item) ?? 0;
+    const includedOccurrences = includedSourceCounts.get(item) ?? 0;
+    if (includedOccurrences >= preparedOccurrences) {
       continue;
     }
-    pendingCounts.set(key, remaining - 1);
+    includedSourceCounts.set(item, includedOccurrences + 1);
     filtered.push(structuredClone(item));
   }
   if (filtered.length > 0) {
@@ -350,6 +405,7 @@ export async function saveStreamResultToSession(
   session: Session | undefined,
   result: StreamedRunResult<any, any>,
   options: SessionPersistenceOptions = {},
+  sessionInputItems?: AgentInputItem[],
 ): Promise<void> {
   const state = result.state;
   const alreadyPersisted = state._currentTurnPersistedItemCount ?? 0;
@@ -359,6 +415,7 @@ export async function saveStreamResultToSession(
     session,
     state,
     newRunItems,
+    extraInputItems: sessionInputItems,
     lastResponseId: result.lastResponseId,
     alreadyPersistedCount: alreadyPersisted,
     runCompaction: options.runCompaction ?? true,
@@ -621,8 +678,8 @@ function getHistoryItemModelInputKey(
 function normalizeItemsForSessionPersistence(
   items: AgentInputItem[],
 ): AgentInputItem[] {
-  return items.map((item) =>
-    sanitizeValueForSession(stripTransientCallIds(item)),
+  return deduplicateAgentInputItemsPreferringLatest(
+    items.map((item) => sanitizeValueForSession(stripTransientCallIds(item))),
   );
 }
 

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -319,8 +319,6 @@ function mapPreparedSourcesAfterContextProcessing(
   }
   mapOccurrences(processedIndexesByReference, preparedIndexesByReference);
 
-  // Public capabilities may return clones. Resolve remaining occurrences against the complete
-  // prepared sequence so callback reordering and equal-content history retain their ownership.
   const processedIndexesByKey = new Map<string, number[]>();
   for (const [index, item] of processedItems.entries()) {
     if (mappedPreparedIndexes[index] !== undefined) {
@@ -331,7 +329,85 @@ function mapPreparedSourcesAfterContextProcessing(
     indexes.push(index);
     processedIndexesByKey.set(key, indexes);
   }
-  mapOccurrences(processedIndexesByKey, preparedIndexesByKey);
+  const availablePreparedCountByKey = new Map<string, number>();
+  for (const [key, indexes] of preparedIndexesByKey) {
+    availablePreparedCountByKey.set(
+      key,
+      indexes.filter((index) => !usedPreparedIndexes.has(index)).length,
+    );
+  }
+  const ambiguousKeys = new Set<string>();
+  const ambiguousProcessedIndexes = new Set<number>();
+  for (const [key, indexes] of processedIndexesByKey) {
+    const availablePreparedCount = availablePreparedCountByKey.get(key) ?? 0;
+    if (
+      preparedIndexesByKey.has(key) &&
+      indexes.length > availablePreparedCount
+    ) {
+      ambiguousKeys.add(key);
+      indexes.forEach((index) => ambiguousProcessedIndexes.add(index));
+    }
+  }
+
+  // Reserve unchanged positional clones before matching equal-content occurrences globally.
+  // Otherwise, an earlier removed occurrence can steal a later clone's prepared position and
+  // cause an injected replacement to inherit the clone's Session ownership. Equal-sized key
+  // groups retain forward occurrence matching because unrelated insertions may shift the group.
+  for (const [index, item] of processedItems.entries()) {
+    const preparedItem = preparedItems[index];
+    const key = getAgentInputItemKey(item);
+    if (
+      mappedPreparedIndexes[index] !== undefined ||
+      ambiguousProcessedIndexes.has(index) ||
+      preparedItem === undefined ||
+      usedPreparedIndexes.has(index) ||
+      key !== getAgentInputItemKey(preparedItem) ||
+      (processedIndexesByKey.get(key)?.length ?? 0) >=
+        (availablePreparedCountByKey.get(key) ?? 0)
+    ) {
+      continue;
+    }
+    mappedPreparedIndexes[index] = index;
+    usedPreparedIndexes.add(index);
+  }
+
+  // Public capabilities may return clones. Resolve remaining occurrences against the complete
+  // prepared sequence so callback reordering and equal-content history retain their ownership.
+  const matchableProcessedIndexesByKey = new Map(
+    [...processedIndexesByKey].filter(([, indexes]) =>
+      indexes.every((index) => !ambiguousProcessedIndexes.has(index)),
+    ),
+  );
+  mapOccurrences(matchableProcessedIndexesByKey, preparedIndexesByKey);
+
+  const remainingProcessedIndexes = processedItems
+    .map((_, index) => index)
+    .filter(
+      (index) =>
+        mappedPreparedIndexes[index] === undefined &&
+        !ambiguousProcessedIndexes.has(index),
+    );
+  const remainingPreparedIndexes = preparedItems
+    .map((_, index) => index)
+    .filter(
+      (index) =>
+        !usedPreparedIndexes.has(index) &&
+        !ambiguousKeys.has(getAgentInputItemKey(preparedItems[index]!)),
+    );
+
+  // Treat a one-to-one set of unmatched occurrences as ordered replacements. Public capabilities
+  // may rewrite cloned item content, so neither reference nor serialized-value matching applies.
+  // Different cardinalities remain unmatched because insertions and removals erase that lineage.
+  if (remainingProcessedIndexes.length === remainingPreparedIndexes.length) {
+    for (const [index, processedIndex] of remainingProcessedIndexes.entries()) {
+      const preparedIndex = remainingPreparedIndexes[index];
+      if (preparedIndex === undefined) {
+        continue;
+      }
+      mappedPreparedIndexes[processedIndex] = preparedIndex;
+      usedPreparedIndexes.add(preparedIndex);
+    }
+  }
 
   return processedItems.flatMap((item, index) => {
     const preparedIndex = mappedPreparedIndexes[index];

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -320,6 +320,7 @@ function mapPreparedSourcesAfterContextProcessing(
     processedIndexesByReference.set(item, indexes);
   }
   mapOccurrences(processedIndexesByReference, preparedIndexesByReference);
+  const referenceMappedPreparedIndexes = new Set(usedPreparedIndexes);
   for (const [item, processedIndexes] of processedIndexesByReference) {
     const preparedIndexes = preparedIndexesByReference.get(item);
     if (preparedIndexes === undefined) {
@@ -424,6 +425,34 @@ function mapPreparedSourcesAfterContextProcessing(
       mappedPreparedIndexes[processedIndex] = preparedIndex;
       usedPreparedIndexes.add(preparedIndex);
     }
+  }
+
+  const hasUnmatchedProcessedItem = remainingProcessedIndexes.some(
+    (index) => mappedPreparedIndexes[index] === undefined,
+  );
+  const hasUnmatchedOwnedItem = remainingPreparedIndexes.some(
+    (index) =>
+      !usedPreparedIndexes.has(index) && ownerIndexByPreparedIndex.has(index),
+  );
+  const hasUnprovenOwnedClone = [...preparedIndexesByKey.values()].some(
+    (indexes) =>
+      indexes.some((index) => ownerIndexByPreparedIndex.has(index)) &&
+      indexes.some((index) => !ownerIndexByPreparedIndex.has(index)) &&
+      indexes.some(
+        (index) =>
+          ownerIndexByPreparedIndex.has(index) &&
+          usedPreparedIndexes.has(index) &&
+          !referenceMappedPreparedIndexes.has(index),
+      ) &&
+      indexes.some((index) => !usedPreparedIndexes.has(index)),
+  );
+  if (
+    hasUnmatchedProcessedItem &&
+    (hasUnmatchedOwnedItem || hasUnprovenOwnedClone)
+  ) {
+    throw new UserError(
+      'Capability.processContext() cannot replace Session-owned input without preserving its identity. Use callModelInputFilter for persistence-aware input replacement.',
+    );
   }
 
   return processedItems.flatMap((item, index) => {

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -255,6 +255,12 @@ function mapPreparedSourcesAfterContextProcessing(
   processedItems: AgentInputItem[],
   preparedSourceIndexes: number[],
 ): PreparedOwnedSource[] {
+  const ownerIndexByPreparedIndex = new Map(
+    preparedSourceIndexes.map((preparedIndex, ownerIndex) => [
+      preparedIndex,
+      ownerIndex,
+    ]),
+  );
   const preparedIndexesByReference = new Map<AgentInputItem, number[]>();
   const preparedIndexesByKey = new Map<string, number[]>();
   for (const [index, item] of preparedItems.entries()) {
@@ -273,52 +279,71 @@ function mapPreparedSourcesAfterContextProcessing(
   );
   const usedPreparedIndexes = new Set<number>();
 
-  // Match from the end so prefix-removing context processors preserve occurrence positions.
-  for (let index = processedItems.length - 1; index >= 0; index--) {
-    const item = processedItems[index];
-    if (!item) {
-      continue;
+  const mapOccurrences = <T>(
+    processedIndexesByIdentity: Map<T, number[]>,
+    preparedIndexesByIdentity: Map<T, number[]>,
+  ) => {
+    for (const [identity, processedIndexes] of processedIndexesByIdentity) {
+      const availablePreparedIndexes = (
+        preparedIndexesByIdentity.get(identity) ?? []
+      ).filter((index) => !usedPreparedIndexes.has(index));
+      const availableProcessedIndexes = processedIndexes.filter(
+        (index) => mappedPreparedIndexes[index] === undefined,
+      );
+
+      // When processing keeps every occurrence, preserve their relative order. If an
+      // indistinguishable cloned subset remains, prefer Session-owned occurrences because the
+      // transformation no longer contains enough information to identify which clone survived.
+      if (availableProcessedIndexes.length < availablePreparedIndexes.length) {
+        availablePreparedIndexes.sort((left, right) => {
+          const leftOwned = ownerIndexByPreparedIndex.has(left);
+          const rightOwned = ownerIndexByPreparedIndex.has(right);
+          return leftOwned === rightOwned ? left - right : leftOwned ? -1 : 1;
+        });
+      }
+
+      for (
+        let index = 0;
+        index <
+        Math.min(
+          availableProcessedIndexes.length,
+          availablePreparedIndexes.length,
+        );
+        index++
+      ) {
+        const processedIndex = availableProcessedIndexes[index];
+        const preparedIndex = availablePreparedIndexes[index];
+        if (processedIndex === undefined || preparedIndex === undefined) {
+          continue;
+        }
+        mappedPreparedIndexes[processedIndex] = preparedIndex;
+        usedPreparedIndexes.add(preparedIndex);
+      }
     }
-    const preparedIndex = preparedIndexesByReference.get(item)?.pop();
-    if (preparedIndex !== undefined) {
-      mappedPreparedIndexes[index] = preparedIndex;
-      usedPreparedIndexes.add(preparedIndex);
-    }
+  };
+
+  const processedIndexesByReference = new Map<AgentInputItem, number[]>();
+  for (const [index, item] of processedItems.entries()) {
+    const indexes = processedIndexesByReference.get(item) ?? [];
+    indexes.push(index);
+    processedIndexesByReference.set(item, indexes);
   }
+  mapOccurrences(processedIndexesByReference, preparedIndexesByReference);
 
   // Public capabilities may return clones. Resolve remaining occurrences against the complete
   // prepared sequence so callback reordering and equal-content history retain their ownership.
-  for (let index = processedItems.length - 1; index >= 0; index--) {
+  const processedIndexesByKey = new Map<string, number[]>();
+  for (const [index, item] of processedItems.entries()) {
     if (mappedPreparedIndexes[index] !== undefined) {
       continue;
     }
-    const item = processedItems[index];
-    if (!item) {
-      continue;
-    }
-    const preparedIndexes = preparedIndexesByKey.get(
-      getAgentInputItemKey(item),
-    );
-    while (
-      preparedIndexes &&
-      preparedIndexes.length > 0 &&
-      usedPreparedIndexes.has(preparedIndexes[preparedIndexes.length - 1])
-    ) {
-      preparedIndexes.pop();
-    }
-    const preparedIndex = preparedIndexes?.pop();
-    if (preparedIndex !== undefined) {
-      mappedPreparedIndexes[index] = preparedIndex;
-      usedPreparedIndexes.add(preparedIndex);
-    }
+    const key = getAgentInputItemKey(item);
+    const indexes = processedIndexesByKey.get(key) ?? [];
+    indexes.push(index);
+    processedIndexesByKey.set(key, indexes);
   }
+  mapOccurrences(processedIndexesByKey, preparedIndexesByKey);
 
-  const ownerIndexByPreparedIndex = new Map(
-    preparedSourceIndexes.map((preparedIndex, ownerIndex) => [
-      preparedIndex,
-      ownerIndex,
-    ]),
-  );
   return processedItems.flatMap((item, index) => {
     const preparedIndex = mappedPreparedIndexes[index];
     const ownerIndex =
@@ -385,7 +410,7 @@ function reconcilePersistableFilteredItems(options: {
 
   const nextPersistedInputOrder = persistedInputOrder.filter(
     (occurrence) =>
-      occurrence.type !== 'owned' ||
+      occurrence.type === 'owned' &&
       !representedOwnedIndexes.has(occurrence.index),
   );
   nextPersistedInputOrder.push(...currentOrder);

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -278,6 +278,8 @@ function mapPreparedSourcesAfterContextProcessing(
     processedItems.length,
   );
   const usedPreparedIndexes = new Set<number>();
+  const ambiguousKeys = new Set<string>();
+  const ambiguousProcessedIndexes = new Set<number>();
 
   const mapOccurrences = <T>(
     processedIndexesByIdentity: Map<T, number[]>,
@@ -318,10 +320,24 @@ function mapPreparedSourcesAfterContextProcessing(
     processedIndexesByReference.set(item, indexes);
   }
   mapOccurrences(processedIndexesByReference, preparedIndexesByReference);
+  for (const [item, processedIndexes] of processedIndexesByReference) {
+    const preparedIndexes = preparedIndexesByReference.get(item);
+    if (preparedIndexes === undefined) {
+      continue;
+    }
+    const preparedCount = preparedIndexes.length;
+    for (const processedIndex of processedIndexes.slice(preparedCount)) {
+      ambiguousKeys.add(getAgentInputItemKey(item));
+      ambiguousProcessedIndexes.add(processedIndex);
+    }
+  }
 
   const processedIndexesByKey = new Map<string, number[]>();
   for (const [index, item] of processedItems.entries()) {
-    if (mappedPreparedIndexes[index] !== undefined) {
+    if (
+      mappedPreparedIndexes[index] !== undefined ||
+      ambiguousProcessedIndexes.has(index)
+    ) {
       continue;
     }
     const key = getAgentInputItemKey(item);
@@ -336,8 +352,6 @@ function mapPreparedSourcesAfterContextProcessing(
       indexes.filter((index) => !usedPreparedIndexes.has(index)).length,
     );
   }
-  const ambiguousKeys = new Set<string>();
-  const ambiguousProcessedIndexes = new Set<number>();
   for (const [key, indexes] of processedIndexesByKey) {
     const availablePreparedCount = availablePreparedCountByKey.get(key) ?? 0;
     if (
@@ -395,15 +409,18 @@ function mapPreparedSourcesAfterContextProcessing(
         !ambiguousKeys.has(getAgentInputItemKey(preparedItems[index]!)),
     );
 
-  // Treat a one-to-one set of unmatched occurrences as ordered replacements. Public capabilities
-  // may rewrite cloned item content, so neither reference nor serialized-value matching applies.
-  // Different cardinalities remain unmatched because insertions and removals erase that lineage.
-  if (remainingProcessedIndexes.length === remainingPreparedIndexes.length) {
-    for (const [index, processedIndex] of remainingProcessedIndexes.entries()) {
-      const preparedIndex = remainingPreparedIndexes[index];
-      if (preparedIndex === undefined) {
-        continue;
-      }
+  // Preserve the explicitly supported whole-context single-item rewrite. Once any surrounding
+  // occurrence exists, an unmatched item could instead be a deletion plus an injection, so leave
+  // it unowned rather than assigning Session provenance from matching residual cardinality alone.
+  if (
+    preparedItems.length === 1 &&
+    processedItems.length === 1 &&
+    remainingProcessedIndexes.length === 1 &&
+    remainingPreparedIndexes.length === 1
+  ) {
+    const processedIndex = remainingProcessedIndexes[0];
+    const preparedIndex = remainingPreparedIndexes[0];
+    if (processedIndex !== undefined && preparedIndex !== undefined) {
       mappedPreparedIndexes[processedIndex] = preparedIndex;
       usedPreparedIndexes.add(preparedIndex);
     }

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -71,6 +71,7 @@ export type SessionPersistenceTracker = {
   setPreparedTurnItems: (
     preparedItems: AgentInputItem[],
     processedItems: AgentInputItem[],
+    processedSourceIndexes?: (number | undefined)[],
   ) => void;
   recordTurnItems: (
     sourceItems: (AgentInputItem | undefined)[],
@@ -143,6 +144,7 @@ export function createSessionPersistenceTracker(options: {
     setPreparedTurnItems = (
       preparedItems: AgentInputItem[],
       processedItems: AgentInputItem[],
+      processedSourceIndexes?: (number | undefined)[],
     ) => {
       if (!this.preparedSourceIndexes) {
         return;
@@ -151,6 +153,7 @@ export function createSessionPersistenceTracker(options: {
         preparedItems,
         processedItems,
         this.preparedSourceIndexes,
+        processedSourceIndexes,
       );
     };
 
@@ -254,6 +257,7 @@ function mapPreparedSourcesAfterContextProcessing(
   preparedItems: AgentInputItem[],
   processedItems: AgentInputItem[],
   preparedSourceIndexes: number[],
+  processedSourceIndexes?: (number | undefined)[],
 ): PreparedOwnedSource[] {
   const ownerIndexByPreparedIndex = new Map(
     preparedSourceIndexes.map((preparedIndex, ownerIndex) => [
@@ -279,6 +283,22 @@ function mapPreparedSourcesAfterContextProcessing(
   );
   const usedPreparedIndexes = new Set<number>();
 
+  for (const [processedIndex, preparedIndex] of (
+    processedSourceIndexes ?? []
+  ).entries()) {
+    if (
+      processedIndex >= processedItems.length ||
+      preparedIndex === undefined ||
+      preparedIndex < 0 ||
+      preparedIndex >= preparedItems.length ||
+      usedPreparedIndexes.has(preparedIndex)
+    ) {
+      continue;
+    }
+    mappedPreparedIndexes[processedIndex] = preparedIndex;
+    usedPreparedIndexes.add(preparedIndex);
+  }
+
   const mapOccurrences = <T>(
     processedIndexesByIdentity: Map<T, number[]>,
     preparedIndexesByIdentity: Map<T, number[]>,
@@ -291,15 +311,10 @@ function mapPreparedSourcesAfterContextProcessing(
         (index) => mappedPreparedIndexes[index] === undefined,
       );
 
-      // When processing keeps every occurrence, preserve their relative order. If an
-      // indistinguishable cloned subset remains, prefer Session-owned occurrences because the
-      // transformation no longer contains enough information to identify which clone survived.
+      // If provenance was discarded and only an indistinguishable subset remains, do not guess
+      // which prepared occurrence survived. Guessing can persist history as new Session input.
       if (availableProcessedIndexes.length < availablePreparedIndexes.length) {
-        availablePreparedIndexes.sort((left, right) => {
-          const leftOwned = ownerIndexByPreparedIndex.has(left);
-          const rightOwned = ownerIndexByPreparedIndex.has(right);
-          return leftOwned === rightOwned ? left - right : leftOwned ? -1 : 1;
-        });
+        continue;
       }
 
       for (

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -71,7 +71,6 @@ export type SessionPersistenceTracker = {
   setPreparedTurnItems: (
     preparedItems: AgentInputItem[],
     processedItems: AgentInputItem[],
-    processedSourceIndexes?: (number | undefined)[],
   ) => void;
   recordTurnItems: (
     sourceItems: (AgentInputItem | undefined)[],
@@ -144,7 +143,6 @@ export function createSessionPersistenceTracker(options: {
     setPreparedTurnItems = (
       preparedItems: AgentInputItem[],
       processedItems: AgentInputItem[],
-      processedSourceIndexes?: (number | undefined)[],
     ) => {
       if (!this.preparedSourceIndexes) {
         return;
@@ -153,7 +151,6 @@ export function createSessionPersistenceTracker(options: {
         preparedItems,
         processedItems,
         this.preparedSourceIndexes,
-        processedSourceIndexes,
       );
     };
 
@@ -257,7 +254,6 @@ function mapPreparedSourcesAfterContextProcessing(
   preparedItems: AgentInputItem[],
   processedItems: AgentInputItem[],
   preparedSourceIndexes: number[],
-  processedSourceIndexes?: (number | undefined)[],
 ): PreparedOwnedSource[] {
   const ownerIndexByPreparedIndex = new Map(
     preparedSourceIndexes.map((preparedIndex, ownerIndex) => [
@@ -283,22 +279,6 @@ function mapPreparedSourcesAfterContextProcessing(
   );
   const usedPreparedIndexes = new Set<number>();
 
-  for (const [processedIndex, preparedIndex] of (
-    processedSourceIndexes ?? []
-  ).entries()) {
-    if (
-      processedIndex >= processedItems.length ||
-      preparedIndex === undefined ||
-      preparedIndex < 0 ||
-      preparedIndex >= preparedItems.length ||
-      usedPreparedIndexes.has(preparedIndex)
-    ) {
-      continue;
-    }
-    mappedPreparedIndexes[processedIndex] = preparedIndex;
-    usedPreparedIndexes.add(preparedIndex);
-  }
-
   const mapOccurrences = <T>(
     processedIndexesByIdentity: Map<T, number[]>,
     preparedIndexesByIdentity: Map<T, number[]>,
@@ -310,12 +290,6 @@ function mapPreparedSourcesAfterContextProcessing(
       const availableProcessedIndexes = processedIndexes.filter(
         (index) => mappedPreparedIndexes[index] === undefined,
       );
-
-      // If provenance was discarded and only an indistinguishable subset remains, do not guess
-      // which prepared occurrence survived. Guessing can persist history as new Session input.
-      if (availableProcessedIndexes.length < availablePreparedIndexes.length) {
-        continue;
-      }
 
       for (
         let index = 0;

--- a/packages/agents-core/src/sandbox/runtime/manager.ts
+++ b/packages/agents-core/src/sandbox/runtime/manager.ts
@@ -7,6 +7,7 @@ import type { Span, Trace } from '../../tracing';
 import type { SandboxAgent } from '../agent';
 import type { Memory } from '../capabilities/memory';
 import { isMemoryCapability } from '../capabilities/memory';
+import type { Capability } from '../capabilities/base';
 import type {
   SandboxClient,
   SandboxClientCreateArgs,
@@ -73,7 +74,88 @@ import { manifestWithRunAsUser, sandboxRunAsName } from './runAsManifest';
 type SandboxPreparedAgent<TContext> = {
   executionAgent: Agent<TContext, AgentOutputType>;
   turnInput: AgentInputItem[];
+  turnInputSourceIndexes?: (number | undefined)[];
 };
+
+const CONTEXT_PROVENANCE_PREFIX =
+  '__openai_agents_internal_context_provenance_';
+let nextContextProvenanceId = 0;
+
+function processCapabilityContext(
+  turnInput: AgentInputItem[],
+  capabilities: Capability[],
+): {
+  turnInput: AgentInputItem[];
+  sourceIndexes: (number | undefined)[];
+} {
+  let provenanceKey: string;
+  do {
+    provenanceKey = `${CONTEXT_PROVENANCE_PREFIX}${nextContextProvenanceId++}`;
+  } while (
+    turnInput.some((item) =>
+      Object.prototype.hasOwnProperty.call(item, provenanceKey),
+    )
+  );
+
+  const taggedItems = new Set<Record<string, unknown>>();
+  const tagItem = (item: AgentInputItem, sourceIndex: number) => {
+    const taggedItem = { ...item } as Record<string, unknown>;
+    Object.defineProperty(taggedItem, provenanceKey, {
+      configurable: true,
+      enumerable: true,
+      value: sourceIndex,
+    });
+    taggedItems.add(taggedItem);
+    return taggedItem as unknown as AgentInputItem;
+  };
+  let processedInput = turnInput.map(tagItem);
+
+  try {
+    for (const capability of capabilities) {
+      processedInput = capability.processContext(processedInput);
+      for (const item of processedInput) {
+        taggedItems.add(item as unknown as Record<string, unknown>);
+      }
+    }
+
+    const sourceIndexes = processedInput.map((item) => {
+      const sourceIndex = (item as unknown as Record<string, unknown>)[
+        provenanceKey
+      ];
+      return Number.isInteger(sourceIndex) &&
+        (sourceIndex as number) >= 0 &&
+        (sourceIndex as number) < turnInput.length
+        ? (sourceIndex as number)
+        : undefined;
+    });
+    const cleanInput = processedInput.map((item) => {
+      if (!Object.prototype.hasOwnProperty.call(item, provenanceKey)) {
+        return item;
+      }
+      const cleanItem = {
+        ...(item as unknown as Record<string, unknown>),
+      };
+      delete cleanItem[provenanceKey];
+      return cleanItem as unknown as AgentInputItem;
+    });
+
+    return {
+      turnInput: cleanInput,
+      sourceIndexes,
+    };
+  } finally {
+    for (const item of taggedItems) {
+      try {
+        const descriptor = Object.getOwnPropertyDescriptor(item, provenanceKey);
+        if (descriptor?.configurable) {
+          Reflect.deleteProperty(item, provenanceKey);
+        }
+      } catch {
+        // Provenance cleanup must not mask a capability error.
+      }
+    }
+  }
+}
 
 type OwnedSessionCloseTarget = 'all' | ReadonlySet<string>;
 
@@ -217,12 +299,14 @@ export class SandboxRuntimeManager<TContext> {
           this.activeMemory = undefined;
         }
 
+        const processedContext = processCapabilityContext(
+          turnInput,
+          executionAgent.capabilities,
+        );
         return {
           executionAgent,
-          turnInput: executionAgent.capabilities.reduce(
-            (input, capability) => capability.processContext(input),
-            turnInput,
-          ),
+          turnInput: processedContext.turnInput,
+          turnInputSourceIndexes: processedContext.sourceIndexes,
         };
       },
       tracingParent,

--- a/packages/agents-core/src/sandbox/runtime/manager.ts
+++ b/packages/agents-core/src/sandbox/runtime/manager.ts
@@ -7,7 +7,6 @@ import type { Span, Trace } from '../../tracing';
 import type { SandboxAgent } from '../agent';
 import type { Memory } from '../capabilities/memory';
 import { isMemoryCapability } from '../capabilities/memory';
-import type { Capability } from '../capabilities/base';
 import type {
   SandboxClient,
   SandboxClientCreateArgs,
@@ -74,88 +73,7 @@ import { manifestWithRunAsUser, sandboxRunAsName } from './runAsManifest';
 type SandboxPreparedAgent<TContext> = {
   executionAgent: Agent<TContext, AgentOutputType>;
   turnInput: AgentInputItem[];
-  turnInputSourceIndexes?: (number | undefined)[];
 };
-
-const CONTEXT_PROVENANCE_PREFIX =
-  '__openai_agents_internal_context_provenance_';
-let nextContextProvenanceId = 0;
-
-function processCapabilityContext(
-  turnInput: AgentInputItem[],
-  capabilities: Capability[],
-): {
-  turnInput: AgentInputItem[];
-  sourceIndexes: (number | undefined)[];
-} {
-  let provenanceKey: string;
-  do {
-    provenanceKey = `${CONTEXT_PROVENANCE_PREFIX}${nextContextProvenanceId++}`;
-  } while (
-    turnInput.some((item) =>
-      Object.prototype.hasOwnProperty.call(item, provenanceKey),
-    )
-  );
-
-  const taggedItems = new Set<Record<string, unknown>>();
-  const tagItem = (item: AgentInputItem, sourceIndex: number) => {
-    const taggedItem = { ...item } as Record<string, unknown>;
-    Object.defineProperty(taggedItem, provenanceKey, {
-      configurable: true,
-      enumerable: true,
-      value: sourceIndex,
-    });
-    taggedItems.add(taggedItem);
-    return taggedItem as unknown as AgentInputItem;
-  };
-  let processedInput = turnInput.map(tagItem);
-
-  try {
-    for (const capability of capabilities) {
-      processedInput = capability.processContext(processedInput);
-      for (const item of processedInput) {
-        taggedItems.add(item as unknown as Record<string, unknown>);
-      }
-    }
-
-    const sourceIndexes = processedInput.map((item) => {
-      const sourceIndex = (item as unknown as Record<string, unknown>)[
-        provenanceKey
-      ];
-      return Number.isInteger(sourceIndex) &&
-        (sourceIndex as number) >= 0 &&
-        (sourceIndex as number) < turnInput.length
-        ? (sourceIndex as number)
-        : undefined;
-    });
-    const cleanInput = processedInput.map((item) => {
-      if (!Object.prototype.hasOwnProperty.call(item, provenanceKey)) {
-        return item;
-      }
-      const cleanItem = {
-        ...(item as unknown as Record<string, unknown>),
-      };
-      delete cleanItem[provenanceKey];
-      return cleanItem as unknown as AgentInputItem;
-    });
-
-    return {
-      turnInput: cleanInput,
-      sourceIndexes,
-    };
-  } finally {
-    for (const item of taggedItems) {
-      try {
-        const descriptor = Object.getOwnPropertyDescriptor(item, provenanceKey);
-        if (descriptor?.configurable) {
-          Reflect.deleteProperty(item, provenanceKey);
-        }
-      } catch {
-        // Provenance cleanup must not mask a capability error.
-      }
-    }
-  }
-}
 
 type OwnedSessionCloseTarget = 'all' | ReadonlySet<string>;
 
@@ -299,14 +217,12 @@ export class SandboxRuntimeManager<TContext> {
           this.activeMemory = undefined;
         }
 
-        const processedContext = processCapabilityContext(
-          turnInput,
-          executionAgent.capabilities,
-        );
         return {
           executionAgent,
-          turnInput: processedContext.turnInput,
-          turnInputSourceIndexes: processedContext.sourceIndexes,
+          turnInput: executionAgent.capabilities.reduce(
+            (input, capability) => capability.processContext(input),
+            turnInput,
+          ),
         };
       },
       tracingParent,

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -3782,10 +3782,14 @@ describe('Runner.run (streaming)', () => {
     });
   });
 
-  it('persists streaming input only after the run completes successfully', async () => {
+  it('persists streaming input with the result after the run completes successfully', async () => {
     const saveInputSpy = vi
       .spyOn(sessionPersistence, 'saveStreamInputToSession')
       .mockResolvedValue();
+    const saveResultSpy = vi.spyOn(
+      sessionPersistence,
+      'saveStreamResultToSession',
+    );
 
     const session = createSessionMock();
 
@@ -3806,8 +3810,9 @@ describe('Runner.run (streaming)', () => {
 
     await result.completed;
 
-    expect(saveInputSpy).toHaveBeenCalledTimes(1);
-    const [sessionArg, persistedItems] = saveInputSpy.mock.calls[0];
+    expect(saveInputSpy).not.toHaveBeenCalled();
+    expect(saveResultSpy).toHaveBeenCalledTimes(1);
+    const [sessionArg, , , persistedItems] = saveResultSpy.mock.calls[0];
     expect(sessionArg).toBe(session);
     if (!Array.isArray(persistedItems)) {
       throw new Error('Expected persisted session items to be an array.');
@@ -3902,10 +3907,46 @@ describe('Runner.run (streaming)', () => {
     expect(sessionItems).toEqual([compaction, retainedInput]);
   });
 
+  it('does not retry streamed input after combined persistence reaches compaction', async () => {
+    const compactionError = new Error('compaction failed');
+    const session = {
+      ...createSessionMock(),
+      runCompaction: vi.fn().mockRejectedValue(compactionError),
+    };
+    const agent = new Agent({
+      name: 'StreamCompactionFailure',
+      model: new ImmediateStreamingModel({
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+      }),
+    });
+
+    const result = await run(agent, 'persist once', {
+      stream: true,
+      session,
+    });
+
+    await expect(result.completed).rejects.toThrow('compaction failed');
+    expect(session.addItems).toHaveBeenCalledTimes(1);
+    const persistedItems = vi.mocked(session.addItems).mock.calls[0][0];
+    expect(
+      persistedItems.filter(
+        (item) =>
+          item.type === 'message' &&
+          item.role === 'user' &&
+          getFirstTextContent(item) === 'persist once',
+      ),
+    ).toHaveLength(1);
+  });
+
   it('persists filtered streaming input instead of the raw turn payload', async () => {
     const saveInputSpy = vi
       .spyOn(sessionPersistence, 'saveStreamInputToSession')
       .mockResolvedValue();
+    const saveResultSpy = vi.spyOn(
+      sessionPersistence,
+      'saveStreamResultToSession',
+    );
 
     const session = createSessionMock();
 
@@ -3949,8 +3990,9 @@ describe('Runner.run (streaming)', () => {
 
     await result.completed;
 
-    expect(saveInputSpy).toHaveBeenCalledTimes(1);
-    const [, persistedItems] = saveInputSpy.mock.calls[0];
+    expect(saveInputSpy).not.toHaveBeenCalled();
+    expect(saveResultSpy).toHaveBeenCalledTimes(1);
+    const [, , , persistedItems] = saveResultSpy.mock.calls[0];
     if (!Array.isArray(persistedItems)) {
       throw new Error('Expected persisted session items to be an array.');
     }
@@ -4387,7 +4429,7 @@ describe('Runner.run (streaming)', () => {
     const result = await run(agent, 'hello', { stream: true, session });
     await result.completed;
 
-    expect(saveInputSpy).toHaveBeenCalledTimes(1);
+    expect(saveInputSpy).not.toHaveBeenCalled();
     expect(saveResultSpy).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -5567,6 +5567,206 @@ describe('Runner.run', () => {
       expect(getFirstTextContent(sentInput[0])).toBe('Second input');
     });
 
+    it('keeps duplicate calls before their outputs in non-streaming runs', async () => {
+      const model = new FilterTrackingModel([
+        {
+          ...TEST_MODEL_RESPONSE_BASIC,
+          output: [fakeModelMessage('deduplicated result')],
+        },
+      ]);
+      const agent = new Agent({ name: 'DeduplicateCallAgent', model });
+      const oldCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        callId: 'call_deduplicated',
+        name: 'lookup',
+        arguments: '{"value":"old"}',
+      };
+      const output: protocol.FunctionCallResultItem = {
+        type: 'function_call_result',
+        callId: 'call_deduplicated',
+        name: 'lookup',
+        status: 'completed',
+        output: 'done',
+      };
+      const newCall: protocol.FunctionCallItem = {
+        ...oldCall,
+        arguments: '{"value":"new"}',
+      };
+      const runner = new Runner({
+        callModelInputFilter: () => ({
+          input: [oldCall, output, newCall],
+        }),
+      });
+
+      await runner.run(agent, 'start');
+
+      expect(model.lastRequest?.input).toEqual([newCall, output]);
+    });
+
+    it('persists normalized input plus items injected by a later model call', async () => {
+      const executeTool = tool({
+        name: 'execute_later_injection',
+        description: 'Executes a test call.',
+        parameters: z.object({}),
+        execute: async () => 'done',
+      });
+      const model = new FilterTrackingModel([
+        {
+          output: [
+            {
+              type: 'function_call',
+              callId: 'call_execute_later_injection',
+              name: executeTool.name,
+              arguments: '{}',
+            },
+          ],
+          usage: new Usage(),
+        },
+        {
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'LaterInjectionAgent',
+        model,
+        tools: [executeTool],
+      });
+      const oldCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        callId: 'call_input_duplicate',
+        name: 'lookup',
+        arguments: '{"value":"old"}',
+      };
+      const newCall: protocol.FunctionCallItem = {
+        ...oldCall,
+        arguments: '{"value":"new"}',
+      };
+      const injected = user('injected later');
+      const persisted: AgentInputItem[] = [];
+      const session: Session = {
+        getSessionId: async () => 'later-injection',
+        getItems: async () => [...persisted],
+        addItems: async (items) => {
+          persisted.push(...items);
+        },
+        popItem: async () => persisted.pop(),
+        clearSession: async () => {
+          persisted.length = 0;
+        },
+      };
+      let filterCalls = 0;
+      const runner = new Runner({
+        callModelInputFilter: ({ modelData }) => {
+          filterCalls++;
+          return {
+            ...modelData,
+            input:
+              filterCalls === 1
+                ? modelData.input
+                : [injected, ...modelData.input],
+          };
+        },
+      });
+
+      await runner.run(agent, [oldCall, newCall], { session });
+
+      expect(persisted.slice(0, 2)).toEqual([injected, newCall]);
+      expect(
+        persisted.filter(
+          (item) =>
+            item.type === 'function_call' && item.callId === oldCall.callId,
+        ),
+      ).toHaveLength(1);
+    });
+
+    it('persists an earlier duplicate explicitly selected by the filter', async () => {
+      const model = new FilterTrackingModel([
+        {
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({ name: 'EarlierDuplicateAgent', model });
+      const oldCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        callId: 'call_earlier_duplicate',
+        name: 'lookup',
+        arguments: '{"value":"old"}',
+      };
+      const newCall: protocol.FunctionCallItem = {
+        ...oldCall,
+        arguments: '{"value":"new"}',
+      };
+      const persisted: AgentInputItem[] = [];
+      const session: Session = {
+        getSessionId: async () => 'earlier-duplicate',
+        getItems: async () => [...persisted],
+        addItems: async (items) => {
+          persisted.push(...items);
+        },
+        popItem: async () => persisted.pop(),
+        clearSession: async () => {
+          persisted.length = 0;
+        },
+      };
+      const runner = new Runner({
+        callModelInputFilter: ({ modelData }) => ({
+          ...modelData,
+          input: modelData.input.slice(0, 1),
+        }),
+      });
+
+      await runner.run(agent, [oldCall, newCall], { session });
+
+      expect(model.lastRequest?.input).toEqual([oldCall]);
+      expect(persisted[0]).toEqual(oldCall);
+    });
+
+    it('persists a repeated current clone separately from equal-content history', async () => {
+      const model = new FilterTrackingModel([
+        {
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({ name: 'RepeatedCurrentCloneAgent', model });
+      const sameMessage = user('same');
+      const persisted: AgentInputItem[] = [structuredClone(sameMessage)];
+      const session: Session = {
+        getSessionId: async () => 'repeated-current-clone',
+        getItems: async () => structuredClone(persisted),
+        addItems: async (items) => {
+          persisted.push(...structuredClone(items));
+        },
+        popItem: async () => persisted.pop(),
+        clearSession: async () => {
+          persisted.length = 0;
+        },
+      };
+      const runner = new Runner({
+        callModelInputFilter: ({ modelData }) => {
+          const current = modelData.input.at(-1);
+          if (!current) {
+            throw new Error('Expected current input.');
+          }
+          return { ...modelData, input: [current, current] };
+        },
+      });
+
+      await runner.run(agent, [sameMessage], { session });
+
+      expect(model.lastRequest?.input).toHaveLength(2);
+      expect(
+        persisted.filter(
+          (item) =>
+            item.type === 'message' &&
+            item.role === 'user' &&
+            getFirstTextContent(item) === 'same',
+        ),
+      ).toHaveLength(3);
+    });
+
     it('supports async filters for streaming runs', async () => {
       const streamingModel = new FilterStreamingModel({
         output: [fakeModelMessage('stream response')],
@@ -5610,6 +5810,44 @@ describe('Runner.run', () => {
           streamInput[0].role,
       ).toBe('user');
       expect(getFirstTextContent(streamInput[0])).toBe('Alpha');
+    });
+
+    it('keeps duplicate outputs at their latest position in streaming runs', async () => {
+      const model = new FilterStreamingModel({
+        output: [fakeModelMessage('stream response')],
+        usage: new Usage(),
+      });
+      const agent = new Agent({ name: 'StreamDeduplicateOutputAgent', model });
+      const oldOutput: protocol.FunctionCallResultItem = {
+        type: 'function_call_result',
+        callId: 'call_stream_output',
+        name: 'lookup',
+        status: 'completed',
+        output: 'old',
+      };
+      const call: protocol.FunctionCallItem = {
+        type: 'function_call',
+        callId: 'call_stream_output',
+        name: 'lookup',
+        arguments: '{}',
+      };
+      const newOutput: protocol.FunctionCallResultItem = {
+        ...oldOutput,
+        output: 'new',
+      };
+      const runner = new Runner({
+        callModelInputFilter: async () => ({
+          input: [oldOutput, call, newOutput],
+        }),
+      });
+
+      const result = await runner.run(agent, 'start', { stream: true });
+      for await (const _event of result.toStream()) {
+        // Drain the stream.
+      }
+      await result.completed;
+
+      expect(model.lastRequest?.input).toEqual([call, newOutput]);
     });
 
     it('does not mutate run history when filter mutates input items', async () => {
@@ -5991,7 +6229,7 @@ describe('Runner.run', () => {
       expect(texts).toContain('second turn');
     });
 
-    it('keeps original inputs when filters prepend new items', async () => {
+    it('keeps equal-content injected and original inputs', async () => {
       class RecordingSession implements Session {
         #history: AgentInputItem[] = [];
         added: AgentInputItem[][] = [];
@@ -6037,7 +6275,7 @@ describe('Runner.run', () => {
       const runner = new Runner({
         callModelInputFilter: ({ modelData }) => ({
           instructions: modelData.instructions,
-          input: [assistant('primer'), ...modelData.input],
+          input: [structuredClone(modelData.input[0]), ...modelData.input],
         }),
       });
 
@@ -6048,7 +6286,9 @@ describe('Runner.run', () => {
       const persistedTexts = persisted
         .map((item) => getFirstTextContent(item))
         .filter((text): text is string => typeof text === 'string');
-      expect(persistedTexts).toContain('Persist me');
+      expect(
+        persistedTexts.filter((text) => text === 'Persist me'),
+      ).toHaveLength(2);
     });
 
     it('throws when filter returns invalid data', async () => {
@@ -6637,10 +6877,10 @@ describe('Runner.run', () => {
       }
       await result.completed;
 
-      expect(session.added).toHaveLength(2);
-      const streamedItems = session.added[1];
-      expect(streamedItems).toHaveLength(1);
-      const savedAssistant = streamedItems[0] as protocol.AssistantMessageItem;
+      expect(session.added).toHaveLength(1);
+      const streamedItems = session.added[0];
+      expect(streamedItems).toHaveLength(2);
+      const savedAssistant = streamedItems[1] as protocol.AssistantMessageItem;
       expect(savedAssistant.providerData).toEqual({ annotations: ['keep-me'] });
       expect(getFirstTextContent(savedAssistant)).toBe(
         'assistant with metadata',

--- a/packages/agents-core/test/runner/conversation.test.ts
+++ b/packages/agents-core/test/runner/conversation.test.ts
@@ -36,7 +36,8 @@ describe('applyCallModelInputFilter', () => {
     expect(result.modelInput.input).toEqual(original);
     expect(result.modelInput.input[0]).not.toBe(original[0]);
     expect(result.sourceItems[0]).toBe(original[0]);
-    expect(result.persistedItems).toEqual([]);
+    expect(result.persistedItems).toEqual(original);
+    expect(result.persistedItems[0]).not.toBe(result.modelInput.input[0]);
     expect(result.modelInput.instructions).toBe('sys');
   });
 
@@ -124,6 +125,79 @@ describe('applyCallModelInputFilter', () => {
     });
   });
 
+  it('reserves exact sources before matching equal-content injected items', async () => {
+    const agent = makeAgent('FilterEqualInjection');
+    const context = new RunContext();
+    const original: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'same',
+    };
+
+    const result = await applyCallModelInputFilter(
+      agent,
+      ({ modelData }) => ({
+        input: [structuredClone(modelData.input[0]), modelData.input[0]],
+      }),
+      context,
+      [original],
+      undefined,
+    );
+
+    expect(result.modelInput.input).toHaveLength(2);
+    expect(result.sourceItems).toEqual([undefined, original]);
+    expect(result.persistedItems).toHaveLength(2);
+  });
+
+  it('treats repeated use of one filter clone as an injected occurrence', async () => {
+    const agent = makeAgent('FilterRepeatedClone');
+    const context = new RunContext();
+    const original: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'repeat',
+    };
+
+    const result = await applyCallModelInputFilter(
+      agent,
+      ({ modelData }) => ({
+        input: [modelData.input[0], modelData.input[0]],
+      }),
+      context,
+      [original],
+      undefined,
+    );
+
+    expect(result.modelInput.input).toHaveLength(2);
+    expect(result.sourceItems).toEqual([original, undefined]);
+    expect(result.persistedItems).toHaveLength(2);
+  });
+
+  it('does not match a repeated filter clone to equal-content history', async () => {
+    const agent = makeAgent('FilterRepeatedCloneEqualHistory');
+    const context = new RunContext();
+    const history: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'same',
+    };
+    const current: AgentInputItem = { ...history };
+
+    const result = await applyCallModelInputFilter(
+      agent,
+      ({ modelData }) => ({
+        input: [modelData.input[1], modelData.input[1]],
+      }),
+      context,
+      [history, current],
+      undefined,
+    );
+
+    expect(result.modelInput.input).toHaveLength(2);
+    expect(result.sourceItems).toEqual([current, undefined]);
+    expect(result.persistedItems).toHaveLength(2);
+  });
+
   it('throws a UserError when the filter returns an invalid shape', async () => {
     const agent = makeAgent('InvalidFilter');
     const context = new RunContext();
@@ -139,5 +213,102 @@ describe('applyCallModelInputFilter', () => {
         undefined,
       ),
     ).rejects.toBeInstanceOf(UserError);
+  });
+
+  it('normalizes provider-identified duplicates after the filter returns', async () => {
+    const agent = makeAgent('FilterDuplicates');
+    const context = new RunContext();
+    const oldCall: AgentInputItem = {
+      type: 'function_call',
+      callId: 'call_filter',
+      name: 'lookup',
+      arguments: '{"value":"old"}',
+    };
+    const output: AgentInputItem = {
+      type: 'function_call_result',
+      callId: 'call_filter',
+      name: 'lookup',
+      status: 'completed',
+      output: 'done',
+    };
+    const newCall: AgentInputItem = {
+      ...oldCall,
+      arguments: '{"value":"new"}',
+    };
+
+    const result = await applyCallModelInputFilter(
+      agent,
+      ({ modelData }) => modelData,
+      context,
+      [oldCall, output, newCall],
+      undefined,
+    );
+
+    expect(result.modelInput.input).toEqual([newCall, output]);
+    expect(result.persistedItems).toEqual([newCall, output]);
+    expect(result.sourceItems).toEqual([newCall, output]);
+  });
+
+  it('normalizes mixed item and call identities without a filter', async () => {
+    const agent = makeAgent('MixedIdentities');
+    const context = new RunContext();
+    const oldCall: AgentInputItem = {
+      type: 'function_call',
+      id: 'item_old',
+      callId: 'call_mixed',
+      name: 'lookup',
+      arguments: '{"value":"old"}',
+    };
+    const output: AgentInputItem = {
+      type: 'function_call_result',
+      callId: 'call_mixed',
+      name: 'lookup',
+      status: 'completed',
+      output: 'done',
+    };
+    const newCall: AgentInputItem = {
+      ...oldCall,
+      id: undefined,
+      arguments: '{"value":"new"}',
+    };
+
+    const result = await applyCallModelInputFilter(
+      agent,
+      undefined,
+      context,
+      [oldCall, output, newCall],
+      undefined,
+    );
+
+    expect(result.modelInput.input).toEqual([newCall, output]);
+    expect(result.persistedItems).toEqual([newCall, output]);
+    expect(result.sourceItems).toEqual([newCall, output]);
+  });
+
+  it('preserves filtered duplicates with empty correlations', async () => {
+    const agent = makeAgent('FilterEmptyCorrelations');
+    const context = new RunContext();
+    const oldCall: AgentInputItem = {
+      type: 'function_call',
+      callId: '',
+      name: 'lookup',
+      arguments: '{"value":"old"}',
+    };
+    const newCall: AgentInputItem = {
+      ...oldCall,
+      arguments: '{"value":"new"}',
+    };
+
+    const result = await applyCallModelInputFilter(
+      agent,
+      ({ modelData }) => modelData,
+      context,
+      [oldCall, newCall],
+      undefined,
+    );
+
+    expect(result.modelInput.input).toEqual([oldCall, newCall]);
+    expect(result.persistedItems).toEqual([oldCall, newCall]);
+    expect(result.sourceItems).toEqual([oldCall, newCall]);
   });
 });

--- a/packages/agents-core/test/runner/items.helpers.test.ts
+++ b/packages/agents-core/test/runner/items.helpers.test.ts
@@ -9,12 +9,295 @@ import {
   RunToolCallOutputItem,
 } from '../../src/items';
 import {
+  deduplicateAgentInputItemsPreferringLatest,
   dropOrphanToolCalls,
   extractOutputItemsFromRunItems,
   prepareModelInputItems,
 } from '../../src/runner/items';
 import type { AgentInputItem } from '../../src/types';
 import * as protocol from '../../src/types/protocol';
+
+describe('deduplicateAgentInputItemsPreferringLatest', () => {
+  it('keeps the latest duplicate call at the earliest causal position', () => {
+    const oldCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      callId: 'call_ordered',
+      name: 'lookup',
+      arguments: '{"version":"old"}',
+    };
+    const output: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      callId: 'call_ordered',
+      name: 'lookup',
+      status: 'completed',
+      output: 'done',
+    };
+    const newCall: protocol.FunctionCallItem = {
+      ...oldCall,
+      arguments: '{"version":"new"}',
+    };
+
+    expect(
+      deduplicateAgentInputItemsPreferringLatest([oldCall, output, newCall]),
+    ).toEqual([newCall, output]);
+  });
+
+  it('prefers call correlation over mixed item ids', () => {
+    const oldCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'item_old',
+      callId: 'call_mixed_identity',
+      name: 'lookup',
+      arguments: '{"version":"old"}',
+    };
+    const output: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      callId: 'call_mixed_identity',
+      name: 'lookup',
+      status: 'completed',
+      output: 'done',
+    };
+    const newCall: protocol.FunctionCallItem = {
+      ...oldCall,
+      id: undefined,
+      arguments: '{"version":"new"}',
+    };
+
+    expect(
+      deduplicateAgentInputItemsPreferringLatest([oldCall, output, newCall]),
+    ).toEqual([newCall, output]);
+  });
+
+  it('prefers tool-search call correlation over item ids', () => {
+    const oldOutput: protocol.ToolSearchOutputItem = {
+      type: 'tool_search_output',
+      id: 'item_old',
+      execution: 'client',
+      status: 'in_progress',
+      tools: [],
+      providerData: {
+        type: 'tool_search_output',
+        call_id: 'call_shared',
+        execution: 'client',
+      },
+    };
+    const newOutput: protocol.ToolSearchOutputItem = {
+      ...oldOutput,
+      id: 'item_new',
+      status: 'completed',
+    };
+
+    expect(
+      deduplicateAgentInputItemsPreferringLatest([oldOutput, newOutput]),
+    ).toEqual([newOutput]);
+  });
+
+  it('keeps client tool-search calls before their required output', () => {
+    const oldCall: protocol.ToolSearchCallItem = {
+      type: 'tool_search_call',
+      callId: 'call_client_search',
+      execution: 'client',
+      arguments: { query: 'old' },
+    };
+    const output: protocol.ToolSearchOutputItem = {
+      type: 'tool_search_output',
+      callId: 'call_client_search',
+      execution: 'client',
+      status: 'completed',
+      tools: [],
+    };
+    const newCall: protocol.ToolSearchCallItem = {
+      ...oldCall,
+      arguments: { query: 'new' },
+    };
+
+    expect(
+      deduplicateAgentInputItemsPreferringLatest([oldCall, output, newCall]),
+    ).toEqual([newCall, output]);
+  });
+
+  it('keeps server tool-search updates at their latest position', () => {
+    const oldCall: protocol.ToolSearchCallItem = {
+      type: 'tool_search_call',
+      callId: 'call_server_search',
+      execution: 'server',
+      arguments: { query: 'old' },
+      status: 'in_progress',
+    };
+    const message: AgentInputItem = {
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [{ type: 'output_text', text: 'searching' }],
+    };
+    const newCall: protocol.ToolSearchCallItem = {
+      ...oldCall,
+      arguments: { query: 'new' },
+      status: 'completed',
+    };
+
+    expect(
+      deduplicateAgentInputItemsPreferringLatest([oldCall, message, newCall]),
+    ).toEqual([message, newCall]);
+  });
+
+  it('uses the core item type for hosted-tool provider ids', () => {
+    const oldCall: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      id: 'hosted_shared',
+      name: 'web_search_call',
+      status: 'in_progress',
+      providerData: { type: 'web_search' },
+    };
+    const message: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'searching',
+    };
+    const newCall: protocol.HostedToolCallItem = {
+      ...oldCall,
+      status: 'completed',
+      providerData: { type: 'web_search_call' },
+    };
+
+    expect(
+      deduplicateAgentInputItemsPreferringLatest([oldCall, message, newCall]),
+    ).toEqual([message, newCall]);
+  });
+
+  it('keeps the latest duplicate output at its latest position', () => {
+    const oldOutput: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      callId: 'call_output',
+      name: 'lookup',
+      status: 'completed',
+      output: 'old',
+    };
+    const message: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'next',
+    };
+    const newOutput: protocol.FunctionCallResultItem = {
+      ...oldOutput,
+      output: 'new',
+    };
+
+    expect(
+      deduplicateAgentInputItemsPreferringLatest([
+        oldOutput,
+        message,
+        newOutput,
+      ]),
+    ).toEqual([message, newOutput]);
+  });
+
+  it('keeps latest reasoning before its required follower', () => {
+    const oldReasoning: protocol.ReasoningItem = {
+      type: 'reasoning',
+      id: 'rs_ordered',
+      content: [{ type: 'input_text', text: 'old' }],
+    };
+    const call: protocol.FunctionCallItem = {
+      type: 'function_call',
+      callId: 'call_after_reasoning',
+      name: 'lookup',
+      arguments: '{}',
+    };
+    const newReasoning: protocol.ReasoningItem = {
+      ...oldReasoning,
+      content: [{ type: 'input_text', text: 'new' }],
+    };
+
+    expect(
+      deduplicateAgentInputItemsPreferringLatest([
+        oldReasoning,
+        call,
+        newReasoning,
+      ]),
+    ).toEqual([newReasoning, call]);
+  });
+
+  it('keeps latest MCP approval request before its response', () => {
+    const oldRequest: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      id: 'approval_ordered',
+      name: 'mcp_approval_request',
+      status: 'in_progress',
+      providerData: {
+        type: 'mcp_approval_request',
+        id: 'approval_ordered',
+        arguments: 'old',
+      },
+    };
+    const response: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      name: 'mcp_approval_response',
+      status: 'completed',
+      providerData: {
+        type: 'mcp_approval_response',
+        approval_request_id: 'approval_ordered',
+        approve: true,
+      },
+    };
+    const newRequest: protocol.HostedToolCallItem = {
+      ...oldRequest,
+      providerData: { ...oldRequest.providerData, arguments: 'new' },
+    };
+
+    expect(
+      deduplicateAgentInputItemsPreferringLatest([
+        oldRequest,
+        response,
+        newRequest,
+      ]),
+    ).toEqual([newRequest, response]);
+  });
+
+  it('preserves unique items and duplicate messages without stable identity', () => {
+    const duplicateMessage: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'repeat me',
+    };
+    const uniqueCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      callId: 'call_unique',
+      name: 'lookup',
+      arguments: '{}',
+    };
+    const items = [duplicateMessage, uniqueCall, duplicateMessage];
+
+    expect(deduplicateAgentInputItemsPreferringLatest(items)).toEqual(items);
+  });
+
+  it('preserves duplicate calls and outputs with empty correlations', () => {
+    const oldCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      callId: '',
+      name: 'lookup',
+      arguments: '{"value":"old"}',
+    };
+    const newCall: protocol.FunctionCallItem = {
+      ...oldCall,
+      arguments: '{"value":"new"}',
+    };
+    const oldOutput: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      callId: '',
+      name: 'lookup',
+      status: 'completed',
+      output: 'old',
+    };
+    const newOutput: protocol.FunctionCallResultItem = {
+      ...oldOutput,
+      output: 'new',
+    };
+    const items = [oldCall, oldOutput, newCall, newOutput];
+
+    expect(deduplicateAgentInputItemsPreferringLatest(items)).toEqual(items);
+  });
+});
 
 describe('prepareModelInputItems', () => {
   it('drops orphan generated hosted shell calls', () => {

--- a/packages/agents-core/test/runner/items.helpers.test.ts
+++ b/packages/agents-core/test/runner/items.helpers.test.ts
@@ -116,7 +116,7 @@ describe('deduplicateAgentInputItemsPreferringLatest', () => {
     ).toEqual([newCall, output]);
   });
 
-  it('keeps server tool-search updates at their latest position', () => {
+  it('keeps server tool-search calls before their output', () => {
     const oldCall: protocol.ToolSearchCallItem = {
       type: 'tool_search_call',
       callId: 'call_server_search',
@@ -124,11 +124,12 @@ describe('deduplicateAgentInputItemsPreferringLatest', () => {
       arguments: { query: 'old' },
       status: 'in_progress',
     };
-    const message: AgentInputItem = {
-      type: 'message',
-      role: 'assistant',
+    const output: protocol.ToolSearchOutputItem = {
+      type: 'tool_search_output',
+      callId: 'call_server_search',
+      execution: 'server',
       status: 'completed',
-      content: [{ type: 'output_text', text: 'searching' }],
+      tools: [],
     };
     const newCall: protocol.ToolSearchCallItem = {
       ...oldCall,
@@ -137,8 +138,8 @@ describe('deduplicateAgentInputItemsPreferringLatest', () => {
     };
 
     expect(
-      deduplicateAgentInputItemsPreferringLatest([oldCall, message, newCall]),
-    ).toEqual([message, newCall]);
+      deduplicateAgentInputItemsPreferringLatest([oldCall, output, newCall]),
+    ).toEqual([newCall, output]);
   });
 
   it('uses the core item type for hosted-tool provider ids', () => {

--- a/packages/agents-core/test/runner/items.helpers.test.ts
+++ b/packages/agents-core/test/runner/items.helpers.test.ts
@@ -219,6 +219,31 @@ describe('deduplicateAgentInputItemsPreferringLatest', () => {
     ).toEqual([newReasoning, call]);
   });
 
+  it('keeps latest compaction at its earliest causal position', () => {
+    const oldCompaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'compaction_ordered',
+      encrypted_content: 'old',
+    };
+    const message: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'next',
+    };
+    const newCompaction: protocol.CompactionItem = {
+      ...oldCompaction,
+      encrypted_content: 'new',
+    };
+
+    expect(
+      deduplicateAgentInputItemsPreferringLatest([
+        oldCompaction,
+        message,
+        newCompaction,
+      ]),
+    ).toEqual([newCompaction, message]);
+  });
+
   it('keeps latest MCP approval request before its response', () => {
     const oldRequest: protocol.HostedToolCallItem = {
       type: 'hosted_tool_call',
@@ -326,6 +351,20 @@ describe('deduplicateAgentInputItemsPreferringLatest', () => {
       output: 'new',
     };
     const items = [oldCall, oldOutput, newCall, newOutput];
+
+    expect(deduplicateAgentInputItemsPreferringLatest(items)).toEqual(items);
+  });
+
+  it('preserves duplicate compaction items without stable identity', () => {
+    const oldCompaction: protocol.CompactionItem = {
+      type: 'compaction',
+      encrypted_content: 'old',
+    };
+    const newCompaction: protocol.CompactionItem = {
+      type: 'compaction',
+      encrypted_content: 'new',
+    };
+    const items = [oldCompaction, newCompaction];
 
     expect(deduplicateAgentInputItemsPreferringLatest(items)).toEqual(items);
   });

--- a/packages/agents-core/test/runner/items.helpers.test.ts
+++ b/packages/agents-core/test/runner/items.helpers.test.ts
@@ -142,7 +142,7 @@ describe('deduplicateAgentInputItemsPreferringLatest', () => {
     ).toEqual([newCall, output]);
   });
 
-  it('uses the core item type for hosted-tool provider ids', () => {
+  it('keeps hosted tool calls at their earliest causal position', () => {
     const oldCall: protocol.HostedToolCallItem = {
       type: 'hosted_tool_call',
       id: 'hosted_shared',
@@ -163,7 +163,7 @@ describe('deduplicateAgentInputItemsPreferringLatest', () => {
 
     expect(
       deduplicateAgentInputItemsPreferringLatest([oldCall, message, newCall]),
-    ).toEqual([message, newCall]);
+    ).toEqual([newCall, message]);
   });
 
   it('keeps the latest duplicate output at its latest position', () => {
@@ -253,6 +253,37 @@ describe('deduplicateAgentInputItemsPreferringLatest', () => {
         newRequest,
       ]),
     ).toEqual([newRequest, response]);
+  });
+
+  it('keeps the latest MCP approval response at its latest position', () => {
+    const oldResponse: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      name: 'mcp_approval_response',
+      status: 'in_progress',
+      providerData: {
+        type: 'mcp_approval_response',
+        approval_request_id: 'approval_response_ordered',
+        approve: false,
+      },
+    };
+    const message: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'approval processed',
+    };
+    const newResponse: protocol.HostedToolCallItem = {
+      ...oldResponse,
+      status: 'completed',
+      providerData: { ...oldResponse.providerData, approve: true },
+    };
+
+    expect(
+      deduplicateAgentInputItemsPreferringLatest([
+        oldResponse,
+        message,
+        newResponse,
+      ]),
+    ).toEqual([message, newResponse]);
   });
 
   it('preserves unique items and duplicate messages without stable identity', () => {

--- a/packages/agents-core/test/runner/sessionPersistence.extended.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.extended.test.ts
@@ -209,7 +209,7 @@ describe('sessionPersistence tracker (extended)', () => {
     tracker.setPreparedItems([current], preparedInput);
     const turnInput = structuredClone(preparedInput);
     const processedInput = structuredClone(turnInput.slice(0, 1));
-    tracker.setPreparedTurnItems(turnInput, processedInput, [0]);
+    tracker.setPreparedTurnItems(turnInput, processedInput);
 
     tracker.recordTurnItems(processedInput, [
       { ...current, content: 'current-filtered' },

--- a/packages/agents-core/test/runner/sessionPersistence.extended.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.extended.test.ts
@@ -193,6 +193,33 @@ describe('sessionPersistence tracker (extended)', () => {
     ]);
   });
 
+  it('keeps current ownership when an equal-content cloned context removes a suffix', () => {
+    const session = makeSession();
+    const tracker = createSessionPersistenceTracker({
+      session,
+      hasCallModelInputFilter: true,
+    })!;
+    const current = {
+      type: 'message',
+      role: 'user',
+      content: 'same',
+    } as const;
+    const history = { ...current };
+    const preparedInput = [current, history];
+    tracker.setPreparedItems([current], preparedInput);
+    const turnInput = structuredClone(preparedInput);
+    const processedInput = structuredClone(turnInput.slice(0, 1));
+    tracker.setPreparedTurnItems(turnInput, processedInput);
+
+    tracker.recordTurnItems(processedInput, [
+      { ...current, content: 'current-filtered' },
+    ]);
+
+    expect(tracker.getItemsForPersistence()).toEqual([
+      { ...current, content: 'current-filtered' },
+    ]);
+  });
+
   it('remaps cloned current input ownership on a later model call', () => {
     const session = makeSession();
     const tracker = createSessionPersistenceTracker({
@@ -312,6 +339,42 @@ describe('sessionPersistence tracker (extended)', () => {
     tracker.recordTurnItems([undefined], [injected]);
 
     expect(tracker.getItemsForPersistence()).toEqual([current, injected]);
+  });
+
+  it('replaces prior filter injections while preserving current duplicates', () => {
+    const session = makeSession();
+    const tracker = createSessionPersistenceTracker({
+      session,
+      hasCallModelInputFilter: true,
+    })!;
+    const current = {
+      type: 'message',
+      role: 'user',
+      content: 'current',
+    } as const;
+    const injected = {
+      type: 'message',
+      role: 'user',
+      content: 'guidance',
+    } as const;
+    tracker.setPreparedItems([current], [current]);
+    const turnInput = structuredClone([current]);
+    tracker.setPreparedTurnItems(turnInput, turnInput);
+
+    tracker.recordTurnItems(
+      [undefined, undefined, turnInput[0]],
+      [structuredClone(injected), structuredClone(injected), current],
+    );
+    tracker.recordTurnItems(
+      [undefined, undefined, turnInput[0]],
+      [structuredClone(injected), structuredClone(injected), current],
+    );
+
+    expect(tracker.getItemsForPersistence()).toEqual([
+      injected,
+      injected,
+      current,
+    ]);
   });
 
   it('keeps normalized prepared input when a later model call injects an item', () => {

--- a/packages/agents-core/test/runner/sessionPersistence.extended.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.extended.test.ts
@@ -138,6 +138,42 @@ describe('sessionPersistence tracker (extended)', () => {
     expect(tracker.getItemsForPersistence()).toEqual([current]);
   });
 
+  it('remaps owned input after turn preparation trims a compaction prefix', () => {
+    const session = makeSession();
+    const tracker = createSessionPersistenceTracker({
+      session,
+      hasCallModelInputFilter: true,
+    })!;
+    const history = {
+      type: 'message',
+      role: 'user',
+      content: 'history',
+    } as const;
+    const discarded = {
+      type: 'message',
+      role: 'user',
+      content: 'discarded',
+    } as const;
+    const compacted = {
+      type: 'compaction',
+      encrypted_content: 'summary',
+    } as const;
+    const current = {
+      type: 'message',
+      role: 'user',
+      content: 'current',
+    } as const;
+    tracker.setPreparedItems(
+      [discarded, compacted, current],
+      [history, discarded, compacted, current],
+    );
+    const preparedTurnInput = structuredClone([compacted, current]);
+    tracker.setPreparedTurnItems(preparedTurnInput, preparedTurnInput);
+    tracker.recordTurnItems(preparedTurnInput, preparedTurnInput);
+
+    expect(tracker.getItemsForPersistence()).toEqual([compacted, current]);
+  });
+
   it('keeps current input ownership when context processing clones items', () => {
     const session = makeSession();
     const tracker = createSessionPersistenceTracker({

--- a/packages/agents-core/test/runner/sessionPersistence.extended.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.extended.test.ts
@@ -92,7 +92,7 @@ describe('sessionPersistence tracker (extended)', () => {
     const preparedInput = [first, second];
     tracker.setPreparedItems([second], preparedInput);
     const turnInput = structuredClone(preparedInput);
-    tracker.setPreparedTurnItems(turnInput);
+    tracker.setPreparedTurnItems(turnInput, turnInput);
 
     tracker.recordTurnItems(
       [turnInput[1], turnInput[0]],
@@ -130,12 +130,136 @@ describe('sessionPersistence tracker (extended)', () => {
     const preparedInput = [history, compacted, current];
     tracker.setPreparedItems([current], preparedInput);
     const turnInput = structuredClone(preparedInput);
-    tracker.setPreparedTurnItems(turnInput);
     const processedInput = turnInput.slice(1);
+    tracker.setPreparedTurnItems(turnInput, processedInput);
 
     tracker.recordTurnItems(processedInput, processedInput);
 
     expect(tracker.getItemsForPersistence()).toEqual([current]);
+  });
+
+  it('keeps current input ownership when context processing clones items', () => {
+    const session = makeSession();
+    const tracker = createSessionPersistenceTracker({
+      session,
+      hasCallModelInputFilter: true,
+    })!;
+    const history = {
+      type: 'message',
+      role: 'user',
+      content: 'history',
+    } as const;
+    const current = {
+      type: 'message',
+      role: 'user',
+      content: 'current',
+    } as const;
+    const preparedInput = [history, current];
+    tracker.setPreparedItems([current], preparedInput);
+    const turnInput = structuredClone(preparedInput);
+    const processedInput = structuredClone(turnInput);
+    tracker.setPreparedTurnItems(turnInput, processedInput);
+
+    tracker.recordTurnItems(processedInput, structuredClone(processedInput));
+
+    expect(tracker.getItemsForPersistence()).toEqual([current]);
+  });
+
+  it('keeps reordered equal-content current input ownership after context cloning', () => {
+    const session = makeSession();
+    const tracker = createSessionPersistenceTracker({
+      session,
+      hasCallModelInputFilter: true,
+    })!;
+    const current = {
+      type: 'message',
+      role: 'user',
+      content: 'same',
+    } as const;
+    const history = { ...current };
+    const preparedInput = [current, history];
+    tracker.setPreparedItems([current], preparedInput);
+    const turnInput = structuredClone(preparedInput);
+    const processedInput = structuredClone(turnInput);
+    tracker.setPreparedTurnItems(turnInput, processedInput);
+
+    tracker.recordTurnItems(processedInput, [
+      { ...current, content: 'current-filtered' },
+      { ...history, content: 'history-filtered' },
+    ]);
+
+    expect(tracker.getItemsForPersistence()).toEqual([
+      { ...current, content: 'current-filtered' },
+    ]);
+  });
+
+  it('remaps cloned current input ownership on a later model call', () => {
+    const session = makeSession();
+    const tracker = createSessionPersistenceTracker({
+      session,
+      hasCallModelInputFilter: true,
+    })!;
+    const current = {
+      type: 'message',
+      role: 'user',
+      content: 'current',
+    } as const;
+    tracker.setPreparedItems([current], [current]);
+
+    const firstTurnInput = structuredClone([current]);
+    const firstProcessedInput = structuredClone(firstTurnInput);
+    tracker.setPreparedTurnItems(firstTurnInput, firstProcessedInput);
+    tracker.recordTurnItems([], []);
+
+    const secondTurnInput = structuredClone([current]);
+    const secondProcessedInput = structuredClone(secondTurnInput);
+    tracker.setPreparedTurnItems(secondTurnInput, secondProcessedInput);
+    tracker.recordTurnItems(secondProcessedInput, [
+      { ...current, content: 'current-filtered' },
+    ]);
+
+    expect(tracker.getItemsForPersistence()).toEqual([
+      { ...current, content: 'current-filtered' },
+    ]);
+  });
+
+  it('keeps stable ownership when a later cloned turn retains only a subset', () => {
+    const session = makeSession();
+    const tracker = createSessionPersistenceTracker({
+      session,
+      hasCallModelInputFilter: true,
+    })!;
+    const first = {
+      type: 'message',
+      role: 'user',
+      content: 'first',
+    } as const;
+    const second = {
+      type: 'message',
+      role: 'user',
+      content: 'second',
+    } as const;
+    tracker.setPreparedItems([first, second], [first, second]);
+
+    const firstTurnInput = structuredClone([first, second]);
+    const firstProcessedInput = structuredClone(firstTurnInput);
+    tracker.setPreparedTurnItems(firstTurnInput, firstProcessedInput);
+    tracker.recordTurnItems(firstProcessedInput, [
+      { ...first, content: 'first-filtered' },
+      { ...second, content: 'second-filtered' },
+    ]);
+
+    const secondTurnInput = structuredClone([first, second]);
+    const secondProcessedInput = structuredClone([secondTurnInput[1]!]);
+    tracker.setPreparedTurnItems(secondTurnInput, secondProcessedInput);
+    tracker.recordTurnItems(secondProcessedInput, [
+      { ...second, content: 'second-refiltered' },
+    ]);
+
+    expect(tracker.getItemsForPersistence()).toEqual([
+      { ...first, content: 'first-filtered' },
+      { ...second, content: 'second-refiltered' },
+    ]);
   });
 
   it('retains captured owned input when a later model call omits it', () => {
@@ -152,7 +276,7 @@ describe('sessionPersistence tracker (extended)', () => {
     const preparedInput = [current];
     tracker.setPreparedItems([current], preparedInput);
     const turnInput = structuredClone(preparedInput);
-    tracker.setPreparedTurnItems(turnInput);
+    tracker.setPreparedTurnItems(turnInput, turnInput);
     tracker.recordTurnItems([turnInput[0]], [{ ...current }]);
 
     const laterCompaction = {
@@ -177,7 +301,7 @@ describe('sessionPersistence tracker (extended)', () => {
     } as const;
     tracker.setPreparedItems([current], [current]);
     const turnInput = structuredClone([current]);
-    tracker.setPreparedTurnItems(turnInput);
+    tracker.setPreparedTurnItems(turnInput, turnInput);
     tracker.recordTurnItems([turnInput[0]], [{ ...current }]);
 
     const injected = {

--- a/packages/agents-core/test/runner/sessionPersistence.extended.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.extended.test.ts
@@ -357,7 +357,7 @@ describe('sessionPersistence tracker (extended)', () => {
     expect(tracker.getItemsForPersistence()).toEqual([]);
   });
 
-  it('keeps an unrelated rewrite outside an ambiguous surplus clone group', () => {
+  it('does not assign current ownership to a mixed replacement', () => {
     const session = makeSession();
     const tracker = createSessionPersistenceTracker({
       session,
@@ -378,14 +378,39 @@ describe('sessionPersistence tracker (extended)', () => {
     const turnInput = structuredClone(preparedInput);
     const processedInput = [
       turnInput[0],
-      structuredClone(turnInput[0]),
-      { ...turnInput[1], content: 'redacted current input' },
+      { type: 'message', role: 'user', content: 'injected context' } as const,
     ];
     tracker.setPreparedTurnItems(turnInput, processedInput);
 
     tracker.recordTurnItems(processedInput, processedInput);
 
-    expect(tracker.getItemsForPersistence()).toEqual([processedInput[2]]);
+    expect(tracker.getItemsForPersistence()).toEqual([]);
+  });
+
+  it('does not assign current ownership to a surplus exact reference', () => {
+    const session = makeSession();
+    const tracker = createSessionPersistenceTracker({
+      session,
+      hasCallModelInputFilter: true,
+    })!;
+    const history = {
+      type: 'message',
+      role: 'user',
+      content: 'same',
+    } as const;
+    const current = { ...history };
+    const preparedInput = [history, current];
+    tracker.setPreparedItems([current], preparedInput);
+    const turnInput = structuredClone(preparedInput);
+    const processedInput = [turnInput[0], turnInput[0]];
+    tracker.setPreparedTurnItems(turnInput, processedInput);
+
+    tracker.recordTurnItems(processedInput, [
+      { ...processedInput[0], content: 'history-filtered' },
+      { ...processedInput[1], content: 'current-filtered' },
+    ]);
+
+    expect(tracker.getItemsForPersistence()).toEqual([]);
   });
 
   it('does not guess transformed ownership when cardinality changes', () => {

--- a/packages/agents-core/test/runner/sessionPersistence.extended.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.extended.test.ts
@@ -209,7 +209,7 @@ describe('sessionPersistence tracker (extended)', () => {
     tracker.setPreparedItems([current], preparedInput);
     const turnInput = structuredClone(preparedInput);
     const processedInput = structuredClone(turnInput.slice(0, 1));
-    tracker.setPreparedTurnItems(turnInput, processedInput);
+    tracker.setPreparedTurnItems(turnInput, processedInput, [0]);
 
     tracker.recordTurnItems(processedInput, [
       { ...current, content: 'current-filtered' },
@@ -218,6 +218,31 @@ describe('sessionPersistence tracker (extended)', () => {
     expect(tracker.getItemsForPersistence()).toEqual([
       { ...current, content: 'current-filtered' },
     ]);
+  });
+
+  it('does not guess ownership for an equal-content cloned subset without provenance', () => {
+    const session = makeSession();
+    const tracker = createSessionPersistenceTracker({
+      session,
+      hasCallModelInputFilter: true,
+    })!;
+    const history = {
+      type: 'message',
+      role: 'user',
+      content: 'same',
+    } as const;
+    const current = { ...history };
+    const preparedInput = [history, current];
+    tracker.setPreparedItems([current], preparedInput);
+    const turnInput = structuredClone(preparedInput);
+    const processedInput = structuredClone(turnInput.slice(0, 1));
+    tracker.setPreparedTurnItems(turnInput, processedInput);
+
+    tracker.recordTurnItems(processedInput, [
+      { ...history, content: 'history-filtered' },
+    ]);
+
+    expect(tracker.getItemsForPersistence()).toEqual([]);
   });
 
   it('remaps cloned current input ownership on a later model call', () => {

--- a/packages/agents-core/test/runner/sessionPersistence.extended.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.extended.test.ts
@@ -269,7 +269,7 @@ describe('sessionPersistence tracker (extended)', () => {
     expect(tracker.getItemsForPersistence()).toEqual(processedInput);
   });
 
-  it('reserves an unchanged current clone before mapping an injected replacement', () => {
+  it('rejects an ambiguous current clone beside an injected replacement', () => {
     const session = makeSession();
     const tracker = createSessionPersistenceTracker({
       session,
@@ -288,11 +288,11 @@ describe('sessionPersistence tracker (extended)', () => {
       { ...turnInput[0], content: 'injected context' },
       structuredClone(turnInput[1]),
     ];
-    tracker.setPreparedTurnItems(turnInput, processedInput);
-
-    tracker.recordTurnItems(processedInput, processedInput);
-
-    expect(tracker.getItemsForPersistence()).toEqual([processedInput[1]]);
+    expect(() =>
+      tracker.setPreparedTurnItems(turnInput, processedInput),
+    ).toThrowError(
+      'Capability.processContext() cannot replace Session-owned input without preserving its identity. Use callModelInputFilter for persistence-aware input replacement.',
+    );
   });
 
   it('uses forward occurrence order when injected context shifts equal-content clones', () => {
@@ -357,34 +357,35 @@ describe('sessionPersistence tracker (extended)', () => {
     expect(tracker.getItemsForPersistence()).toEqual([]);
   });
 
-  it('does not assign current ownership to a mixed replacement', () => {
+  it('rejects rewritten current input when cloned history surrounds it', () => {
     const session = makeSession();
     const tracker = createSessionPersistenceTracker({
       session,
       hasCallModelInputFilter: true,
     })!;
-    const history = {
+    const current = {
       type: 'message',
       role: 'user',
       content: 'same',
     } as const;
-    const current = {
-      type: 'message',
-      role: 'user',
-      content: 'sensitive current input',
-    } as const;
-    const preparedInput = [history, current];
+    const history = { ...current };
+    const preparedInput = [current, history];
     tracker.setPreparedItems([current], preparedInput);
     const turnInput = structuredClone(preparedInput);
     const processedInput = [
-      turnInput[0],
-      { type: 'message', role: 'user', content: 'injected context' } as const,
+      structuredClone(turnInput[1]),
+      {
+        type: 'message',
+        role: 'user',
+        content: 'redacted current input',
+      } as const,
     ];
-    tracker.setPreparedTurnItems(turnInput, processedInput);
 
-    tracker.recordTurnItems(processedInput, processedInput);
-
-    expect(tracker.getItemsForPersistence()).toEqual([]);
+    expect(() =>
+      tracker.setPreparedTurnItems(turnInput, processedInput),
+    ).toThrowError(
+      'Capability.processContext() cannot replace Session-owned input without preserving its identity. Use callModelInputFilter for persistence-aware input replacement.',
+    );
   });
 
   it('does not assign current ownership to a surplus exact reference', () => {
@@ -413,7 +414,7 @@ describe('sessionPersistence tracker (extended)', () => {
     expect(tracker.getItemsForPersistence()).toEqual([]);
   });
 
-  it('does not guess transformed ownership when cardinality changes', () => {
+  it('rejects transformed ownership when cardinality changes', () => {
     const session = makeSession();
     const tracker = createSessionPersistenceTracker({
       session,
@@ -431,11 +432,11 @@ describe('sessionPersistence tracker (extended)', () => {
       { ...turnInput[0], content: 'redacted current input' },
       { ...turnInput[0], content: 'injected context' },
     ];
-    tracker.setPreparedTurnItems(turnInput, processedInput);
-
-    tracker.recordTurnItems(processedInput, processedInput);
-
-    expect(tracker.getItemsForPersistence()).toEqual([]);
+    expect(() =>
+      tracker.setPreparedTurnItems(turnInput, processedInput),
+    ).toThrowError(
+      'Capability.processContext() cannot replace Session-owned input without preserving its identity. Use callModelInputFilter for persistence-aware input replacement.',
+    );
   });
 
   it('remaps cloned current input ownership on a later model call', () => {

--- a/packages/agents-core/test/runner/sessionPersistence.extended.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.extended.test.ts
@@ -245,6 +245,174 @@ describe('sessionPersistence tracker (extended)', () => {
     expect(tracker.getItemsForPersistence()).toEqual([]);
   });
 
+  it('retains current ownership for an ordered transformed clone', () => {
+    const session = makeSession();
+    const tracker = createSessionPersistenceTracker({
+      session,
+      hasCallModelInputFilter: true,
+    })!;
+    const current = {
+      type: 'message',
+      role: 'user',
+      content: 'sensitive current input',
+    } as const;
+    const preparedInput = [current];
+    tracker.setPreparedItems([current], preparedInput);
+    const turnInput = structuredClone(preparedInput);
+    const processedInput = [
+      { ...turnInput[0], content: 'redacted current input' },
+    ];
+    tracker.setPreparedTurnItems(turnInput, processedInput);
+
+    tracker.recordTurnItems(processedInput, processedInput);
+
+    expect(tracker.getItemsForPersistence()).toEqual(processedInput);
+  });
+
+  it('reserves an unchanged current clone before mapping an injected replacement', () => {
+    const session = makeSession();
+    const tracker = createSessionPersistenceTracker({
+      session,
+      hasCallModelInputFilter: true,
+    })!;
+    const history = {
+      type: 'message',
+      role: 'user',
+      content: 'same',
+    } as const;
+    const current = { ...history };
+    const preparedInput = [history, current];
+    tracker.setPreparedItems([current], preparedInput);
+    const turnInput = structuredClone(preparedInput);
+    const processedInput = [
+      { ...turnInput[0], content: 'injected context' },
+      structuredClone(turnInput[1]),
+    ];
+    tracker.setPreparedTurnItems(turnInput, processedInput);
+
+    tracker.recordTurnItems(processedInput, processedInput);
+
+    expect(tracker.getItemsForPersistence()).toEqual([processedInput[1]]);
+  });
+
+  it('uses forward occurrence order when injected context shifts equal-content clones', () => {
+    const session = makeSession();
+    const tracker = createSessionPersistenceTracker({
+      session,
+      hasCallModelInputFilter: true,
+    })!;
+    const history = {
+      type: 'message',
+      role: 'user',
+      content: 'same',
+    } as const;
+    const current = { ...history };
+    const preparedInput = [history, current];
+    tracker.setPreparedItems([current], preparedInput);
+    const turnInput = structuredClone(preparedInput);
+    const processedInput = [
+      { ...turnInput[0], content: 'injected context' },
+      ...structuredClone(turnInput),
+    ];
+    tracker.setPreparedTurnItems(turnInput, processedInput);
+
+    tracker.recordTurnItems(processedInput, [
+      { ...processedInput[0], content: 'injected-filtered' },
+      { ...processedInput[1], content: 'history-filtered' },
+      { ...processedInput[2], content: 'current-filtered' },
+    ]);
+
+    expect(tracker.getItemsForPersistence()).toEqual([
+      { ...current, content: 'current-filtered' },
+    ]);
+  });
+
+  it('does not assign ownership within a surplus equal-content clone group', () => {
+    const session = makeSession();
+    const tracker = createSessionPersistenceTracker({
+      session,
+      hasCallModelInputFilter: true,
+    })!;
+    const history = {
+      type: 'message',
+      role: 'user',
+      content: 'same',
+    } as const;
+    const current = { ...history };
+    const preparedInput = [history, current];
+    tracker.setPreparedItems([current], preparedInput);
+    const turnInput = structuredClone(preparedInput);
+    const processedInput = [
+      structuredClone(turnInput[0]),
+      ...structuredClone(turnInput),
+    ];
+    tracker.setPreparedTurnItems(turnInput, processedInput);
+
+    tracker.recordTurnItems(processedInput, [
+      { ...processedInput[0], content: 'injected-filtered' },
+      { ...processedInput[1], content: 'history-filtered' },
+      { ...processedInput[2], content: 'current-filtered' },
+    ]);
+
+    expect(tracker.getItemsForPersistence()).toEqual([]);
+  });
+
+  it('keeps an unrelated rewrite outside an ambiguous surplus clone group', () => {
+    const session = makeSession();
+    const tracker = createSessionPersistenceTracker({
+      session,
+      hasCallModelInputFilter: true,
+    })!;
+    const history = {
+      type: 'message',
+      role: 'user',
+      content: 'same',
+    } as const;
+    const current = {
+      type: 'message',
+      role: 'user',
+      content: 'sensitive current input',
+    } as const;
+    const preparedInput = [history, current];
+    tracker.setPreparedItems([current], preparedInput);
+    const turnInput = structuredClone(preparedInput);
+    const processedInput = [
+      turnInput[0],
+      structuredClone(turnInput[0]),
+      { ...turnInput[1], content: 'redacted current input' },
+    ];
+    tracker.setPreparedTurnItems(turnInput, processedInput);
+
+    tracker.recordTurnItems(processedInput, processedInput);
+
+    expect(tracker.getItemsForPersistence()).toEqual([processedInput[2]]);
+  });
+
+  it('does not guess transformed ownership when cardinality changes', () => {
+    const session = makeSession();
+    const tracker = createSessionPersistenceTracker({
+      session,
+      hasCallModelInputFilter: true,
+    })!;
+    const current = {
+      type: 'message',
+      role: 'user',
+      content: 'sensitive current input',
+    } as const;
+    const preparedInput = [current];
+    tracker.setPreparedItems([current], preparedInput);
+    const turnInput = structuredClone(preparedInput);
+    const processedInput = [
+      { ...turnInput[0], content: 'redacted current input' },
+      { ...turnInput[0], content: 'injected context' },
+    ];
+    tracker.setPreparedTurnItems(turnInput, processedInput);
+
+    tracker.recordTurnItems(processedInput, processedInput);
+
+    expect(tracker.getItemsForPersistence()).toEqual([]);
+  });
+
   it('remaps cloned current input ownership on a later model call', () => {
     const session = makeSession();
     const tracker = createSessionPersistenceTracker({

--- a/packages/agents-core/test/runner/sessionPersistence.extended.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.extended.test.ts
@@ -54,25 +54,179 @@ describe('sessionPersistence tracker (extended)', () => {
     expect(tracker.getItemsForPersistence()).toEqual(filtered);
   });
 
-  it('deduplicates multiple references to the same source item when filtering', () => {
+  it.each([false, true])(
+    'persists repeated source occurrences with filter configured as %s',
+    (hasCallModelInputFilter) => {
+      const session = makeSession();
+      const tracker = createSessionPersistenceTracker({
+        session,
+        hasCallModelInputFilter,
+      })!;
+
+      const shared = {
+        type: 'message',
+        role: 'user',
+        content: 'shared',
+      } as const;
+      tracker.setPreparedItems([shared, shared]);
+
+      const filtered = [{ ...shared }, { ...shared }];
+      tracker.recordTurnItems([shared, shared], filtered);
+
+      expect(tracker.getItemsForPersistence()).toEqual(filtered);
+    },
+  );
+
+  it('uses exact source ownership for equal-content items', () => {
     const session = makeSession();
     const tracker = createSessionPersistenceTracker({
       session,
-      hasCallModelInputFilter: false,
+      hasCallModelInputFilter: true,
     })!;
-
-    const shared = {
+    const first = {
       type: 'message',
       role: 'user',
-      content: 'shared',
+      content: 'same',
     } as const;
-    tracker.setPreparedItems([shared, shared]);
+    const second = { ...first };
+    const preparedInput = [first, second];
+    tracker.setPreparedItems([second], preparedInput);
+    const turnInput = structuredClone(preparedInput);
+    tracker.setPreparedTurnItems(turnInput);
 
-    const filtered = toAgentInputList('shared');
-    tracker.recordTurnItems([shared, shared], filtered);
+    tracker.recordTurnItems(
+      [turnInput[1], turnInput[0]],
+      [
+        { ...second, content: 'current' },
+        { ...first, content: 'history' },
+      ],
+    );
 
-    const resolved = tracker.getItemsForPersistence();
-    expect(resolved).toEqual([]);
+    expect(tracker.getItemsForPersistence()).toEqual([
+      { ...second, content: 'current' },
+    ]);
+  });
+
+  it('keeps current input ownership when context processing removes a prefix', () => {
+    const session = makeSession();
+    const tracker = createSessionPersistenceTracker({
+      session,
+      hasCallModelInputFilter: true,
+    })!;
+    const history = {
+      type: 'message',
+      role: 'user',
+      content: 'history',
+    } as const;
+    const compacted = {
+      type: 'compaction',
+      encrypted_content: 'summary',
+    } as const;
+    const current = {
+      type: 'message',
+      role: 'user',
+      content: 'current',
+    } as const;
+    const preparedInput = [history, compacted, current];
+    tracker.setPreparedItems([current], preparedInput);
+    const turnInput = structuredClone(preparedInput);
+    tracker.setPreparedTurnItems(turnInput);
+    const processedInput = turnInput.slice(1);
+
+    tracker.recordTurnItems(processedInput, processedInput);
+
+    expect(tracker.getItemsForPersistence()).toEqual([current]);
+  });
+
+  it('retains captured owned input when a later model call omits it', () => {
+    const session = makeSession();
+    const tracker = createSessionPersistenceTracker({
+      session,
+      hasCallModelInputFilter: true,
+    })!;
+    const current = {
+      type: 'message',
+      role: 'user',
+      content: 'current',
+    } as const;
+    const preparedInput = [current];
+    tracker.setPreparedItems([current], preparedInput);
+    const turnInput = structuredClone(preparedInput);
+    tracker.setPreparedTurnItems(turnInput);
+    tracker.recordTurnItems([turnInput[0]], [{ ...current }]);
+
+    const laterCompaction = {
+      type: 'compaction',
+      encrypted_content: 'later',
+    } as const;
+    tracker.recordTurnItems([laterCompaction], [laterCompaction]);
+
+    expect(tracker.getItemsForPersistence()).toEqual([current]);
+  });
+
+  it('adds later injected items without removing captured owned input', () => {
+    const session = makeSession();
+    const tracker = createSessionPersistenceTracker({
+      session,
+      hasCallModelInputFilter: true,
+    })!;
+    const current = {
+      type: 'message',
+      role: 'user',
+      content: 'current',
+    } as const;
+    tracker.setPreparedItems([current], [current]);
+    const turnInput = structuredClone([current]);
+    tracker.setPreparedTurnItems(turnInput);
+    tracker.recordTurnItems([turnInput[0]], [{ ...current }]);
+
+    const injected = {
+      type: 'message',
+      role: 'user',
+      content: 'injected later',
+    } as const;
+    tracker.recordTurnItems([undefined], [injected]);
+
+    expect(tracker.getItemsForPersistence()).toEqual([current, injected]);
+  });
+
+  it('keeps normalized prepared input when a later model call injects an item', () => {
+    const session = makeSession();
+    const tracker = createSessionPersistenceTracker({
+      session,
+      hasCallModelInputFilter: true,
+    })!;
+    const oldCall = {
+      type: 'function_call',
+      callId: 'call_later_injection',
+      name: 'lookup',
+      arguments: '{"value":"old"}',
+    } as const;
+    const newCall = {
+      ...oldCall,
+      arguments: '{"value":"new"}',
+    };
+    const generated = {
+      type: 'function_call_result',
+      callId: oldCall.callId,
+      name: oldCall.name,
+      status: 'completed',
+      output: 'done',
+    } as const;
+    const injected = {
+      type: 'message',
+      role: 'user',
+      content: 'injected',
+    } as const;
+    tracker.setPreparedItems([oldCall, newCall]);
+
+    tracker.recordTurnItems([newCall], [newCall]);
+    tracker.recordTurnItems(
+      [undefined, newCall, generated],
+      [injected, newCall, generated],
+    );
+
+    expect(tracker.getItemsForPersistence()).toEqual([injected, newCall]);
   });
 
   it('persists injected filtered items alongside mapped originals', () => {
@@ -121,8 +275,9 @@ describe('sessionPersistence tracker (extended)', () => {
     await ensure?.();
     expect(persist).not.toHaveBeenCalled();
 
-    tracker.setPreparedItems(toAgentInputList('stream me'));
-    tracker.recordTurnItems(toAgentInputList('stream me'));
+    const preparedItems = toAgentInputList('stream me');
+    tracker.setPreparedItems(preparedItems);
+    tracker.recordTurnItems(preparedItems);
 
     await ensure?.();
     expect(persist).toHaveBeenCalledTimes(1);

--- a/packages/agents-core/test/runner/sessionPersistence.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.test.ts
@@ -321,7 +321,7 @@ describe('saveStreamResultToSession', () => {
     }
 
     async popItem(): Promise<AgentInputItem | undefined> {
-      return undefined;
+      return this.items.pop();
     }
 
     async clearSession(): Promise<void> {
@@ -388,6 +388,53 @@ describe('saveStreamResultToSession', () => {
 
     expect(session.events).toEqual(['addItems:1', 'runCompaction:resp_stream']);
     expect(session.items).toHaveLength(1);
+    expect(state._currentTurnPersistedItemCount).toBe(1);
+  });
+
+  it('persists streamed input and output as one normalized turn', async () => {
+    const textAgent = new Agent<UnknownContext, 'text'>({
+      name: 'StreamReconciliation',
+      outputType: 'text',
+      instructions: 'stream reconciliation test',
+    });
+    const agent = textAgent as unknown as Agent<
+      UnknownContext,
+      AgentOutputType
+    >;
+    const session = new TrackingSession();
+    const context = new RunContext<UnknownContext>(undefined as UnknownContext);
+    const state = new RunState<
+      UnknownContext,
+      Agent<UnknownContext, AgentOutputType>
+    >(context, 'hello', agent, 10);
+    const oldOutput: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      callId: 'call_stream_ordered',
+      name: 'lookup',
+      status: 'completed',
+      output: 'old',
+    };
+    const call: protocol.FunctionCallItem = {
+      type: 'function_call',
+      callId: 'call_stream_ordered',
+      name: 'lookup',
+      arguments: '{}',
+    };
+    const newOutput: protocol.FunctionCallResultItem = {
+      ...oldOutput,
+      output: 'new',
+    };
+    state._generatedItems = [
+      new ToolCallOutputItem(newOutput, textAgent, newOutput.output),
+    ];
+    const streamedResult = new StreamedRunResult({ state });
+
+    await saveStreamResultToSession(session, streamedResult, {}, [
+      oldOutput,
+      call,
+    ]);
+
+    expect(session.items).toEqual([call, newOutput]);
     expect(state._currentTurnPersistedItemCount).toBe(1);
   });
 
@@ -2398,6 +2445,105 @@ describe('saveToSession', () => {
         content: [{ type: 'input_text', text: 'thinking' }],
       },
     ]);
+  });
+
+  it('keeps the latest persisted tool output after its matching call', async () => {
+    const agent = new Agent<UnknownContext, 'text'>({
+      name: 'OrderedSessionAgent',
+      outputType: 'text',
+      instructions: 'test',
+    });
+    const session = new MemorySession();
+    const state = new RunState(new RunContext(), 'hello', agent as any, 10);
+    const oldOutput: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      callId: 'call_ordered',
+      name: 'lookup',
+      status: 'completed',
+      output: 'old',
+    };
+    const call: protocol.FunctionCallItem = {
+      type: 'function_call',
+      callId: 'call_ordered',
+      name: 'lookup',
+      arguments: '{}',
+    };
+    const newOutput: protocol.FunctionCallResultItem = {
+      ...oldOutput,
+      output: 'new',
+    };
+    state._generatedItems = [
+      new ToolCallOutputItem(newOutput, agent, newOutput.output),
+    ];
+
+    await saveToSession(session, [oldOutput, call], new RunResult(state));
+
+    expect(session.items).toEqual([call, newOutput]);
+  });
+
+  it('deduplicates replayed calls with mixed item and call identities', async () => {
+    const agent = new Agent<UnknownContext, 'text'>({
+      name: 'MixedIdentitySessionAgent',
+      outputType: 'text',
+      instructions: 'test',
+    });
+    const session = new MemorySession();
+    const state = new RunState(new RunContext(), 'hello', agent as any, 10);
+    const oldCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'item_old',
+      callId: 'call_mixed',
+      name: 'lookup',
+      arguments: '{"value":"old"}',
+    };
+    const output: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      callId: 'call_mixed',
+      name: 'lookup',
+      status: 'completed',
+      output: 'done',
+    };
+    const newCall: protocol.FunctionCallItem = {
+      ...oldCall,
+      id: undefined,
+      arguments: '{"value":"new"}',
+    };
+
+    await saveToSession(
+      session,
+      [oldCall, output, newCall],
+      new RunResult(state),
+    );
+
+    expect(session.items).toEqual([newCall, output]);
+  });
+
+  it('preserves persisted duplicates with empty correlations', async () => {
+    const agent = new Agent<UnknownContext, 'text'>({
+      name: 'EmptyCorrelationSessionAgent',
+      outputType: 'text',
+      instructions: 'test',
+    });
+    const session = new MemorySession();
+    const state = new RunState(new RunContext(), 'hello', agent as any, 10);
+    const oldOutput: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      callId: '',
+      name: 'lookup',
+      status: 'completed',
+      output: 'old',
+    };
+    const newOutput: protocol.FunctionCallResultItem = {
+      ...oldOutput,
+      output: 'new',
+    };
+    state._generatedItems = [
+      new ToolCallOutputItem(newOutput, agent, newOutput.output),
+    ];
+
+    await saveToSession(session, [oldOutput], new RunResult(state));
+
+    expect(session.items).toEqual([oldOutput, newOutput]);
   });
 
   it('keeps tool_search ids when persisting session history without call ids', async () => {

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -248,6 +248,32 @@ class CloningPrefixContextCapability extends Capability {
   }
 }
 
+class FrozenCloningContextCapability extends Capability {
+  readonly type = 'frozen_cloning_context';
+
+  override processContext(context: AgentInputItem[]): AgentInputItem[] {
+    return structuredClone(context).map((item) => Object.freeze(item));
+  }
+}
+
+class FrozenCloningPrefixContextCapability extends Capability {
+  readonly type = 'frozen_cloning_prefix_context';
+
+  override processContext(context: AgentInputItem[]): AgentInputItem[] {
+    return structuredClone(context.slice(0, 1)).map((item) =>
+      Object.freeze(item),
+    );
+  }
+}
+
+class ThrowingContextCapability extends Capability {
+  readonly type = 'throwing_context';
+
+  override processContext(_context: AgentInputItem[]): AgentInputItem[] {
+    throw new Error('capability context failed');
+  }
+}
+
 class CloningSubsetContextCapability extends Capability {
   readonly type = 'cloning_subset_context';
 
@@ -1016,6 +1042,200 @@ describe('sandbox runner integration', () => {
       expect(persisted).toContain('current-filtered');
     },
   );
+
+  it.each([false, true])(
+    'does not persist equal-content history as current when cloned sandbox context keeps a prefix (stream=%s)',
+    async (stream) => {
+      const client = new FakeSandboxClient();
+      const response = {
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+      };
+      const model = stream
+        ? new RecordingStreamingModel([response])
+        : new RecordingFakeModel([response]);
+      const agent = new SandboxAgent({
+        name: 'CloningHistoryPrefixPersistenceAgent',
+        model,
+        capabilities: [new CloningPrefixContextCapability()],
+      });
+      const session = new MemorySession({
+        initialItems: [user('same input')],
+      });
+      const options = {
+        session,
+        sandbox: { client },
+        sessionInputCallback: (
+          history: AgentInputItem[],
+          newItems: AgentInputItem[],
+        ) => history.concat(newItems),
+        callModelInputFilter: ({ modelData }: CallModelInputFilterArgs) => ({
+          ...modelData,
+          input: modelData.input.map((item) =>
+            item.type === 'message' && item.role === 'user'
+              ? user('history-filtered')
+              : item,
+          ),
+        }),
+      };
+
+      if (stream) {
+        const result = await run(agent, [user('same input')], {
+          ...options,
+          stream: true,
+        });
+        await result.completed;
+      } else {
+        await run(agent, [user('same input')], {
+          ...options,
+          stream: false,
+        });
+      }
+
+      const persisted = JSON.stringify(await session.getItems());
+      expect(persisted).not.toContain('history-filtered');
+      expect(persisted.match(/same input/g)).toHaveLength(1);
+      expect(JSON.stringify(model.requests)).not.toContain(
+        '__openai_agents_internal_context_provenance_',
+      );
+    },
+  );
+
+  it.each([false, true])(
+    'preserves provenance when frozen cloned sandbox context keeps a prefix (stream=%s)',
+    async (stream) => {
+      const client = new FakeSandboxClient();
+      const response = {
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+      };
+      const model = stream
+        ? new RecordingStreamingModel([response])
+        : new RecordingFakeModel([response]);
+      const agent = new SandboxAgent({
+        name: 'FrozenCloningHistoryPrefixPersistenceAgent',
+        model,
+        capabilities: [new FrozenCloningPrefixContextCapability()],
+      });
+      const session = new MemorySession({
+        initialItems: [user('same input')],
+      });
+      const options = {
+        session,
+        sandbox: { client },
+        sessionInputCallback: (
+          history: AgentInputItem[],
+          newItems: AgentInputItem[],
+        ) => history.concat(newItems),
+        callModelInputFilter: ({ modelData }: CallModelInputFilterArgs) => ({
+          ...modelData,
+          input: modelData.input.map((item) =>
+            item.type === 'message' && item.role === 'user'
+              ? user('history-filtered')
+              : item,
+          ),
+        }),
+      };
+
+      if (stream) {
+        const result = await run(agent, [user('same input')], {
+          ...options,
+          stream: true,
+        });
+        await result.completed;
+      } else {
+        await run(agent, [user('same input')], {
+          ...options,
+          stream: false,
+        });
+      }
+
+      const persisted = JSON.stringify(await session.getItems());
+      expect(persisted).not.toContain('history-filtered');
+      expect(persisted.match(/same input/g)).toHaveLength(1);
+      expect(JSON.stringify(model.requests)).not.toContain(
+        '__openai_agents_internal_context_provenance_',
+      );
+    },
+  );
+
+  it.each([false, true])(
+    'preserves provenance through an intermediate frozen sandbox context (stream=%s)',
+    async (stream) => {
+      const client = new FakeSandboxClient();
+      const response = {
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+      };
+      const model = stream
+        ? new RecordingStreamingModel([response])
+        : new RecordingFakeModel([response]);
+      const agent = new SandboxAgent({
+        name: 'IntermediateFrozenContextPersistenceAgent',
+        model,
+        capabilities: [
+          new FrozenCloningContextCapability(),
+          new CloningPrefixContextCapability(),
+        ],
+      });
+      const session = new MemorySession({
+        initialItems: [user('same input')],
+      });
+      const options = {
+        session,
+        sandbox: { client },
+        sessionInputCallback: (
+          history: AgentInputItem[],
+          newItems: AgentInputItem[],
+        ) => newItems.concat(history),
+        callModelInputFilter: ({ modelData }: CallModelInputFilterArgs) => ({
+          ...modelData,
+          input: modelData.input.map((item) =>
+            item.type === 'message' && item.role === 'user'
+              ? user('current-filtered')
+              : item,
+          ),
+        }),
+      };
+
+      if (stream) {
+        const result = await run(agent, [user('same input')], {
+          ...options,
+          stream: true,
+        });
+        await result.completed;
+      } else {
+        await run(agent, [user('same input')], {
+          ...options,
+          stream: false,
+        });
+      }
+
+      expect(JSON.stringify(await session.getItems())).toContain(
+        'current-filtered',
+      );
+      expect(JSON.stringify(model.requests)).not.toContain(
+        '__openai_agents_internal_context_provenance_',
+      );
+    },
+  );
+
+  it('does not mask a capability error after an intermediate frozen context', async () => {
+    const agent = new SandboxAgent({
+      name: 'ThrowingAfterFrozenContextAgent',
+      model: new RecordingFakeModel([]),
+      capabilities: [
+        new FrozenCloningContextCapability(),
+        new ThrowingContextCapability(),
+      ],
+    });
+
+    await expect(
+      run(agent, [user('input')], {
+        sandbox: { client: new FakeSandboxClient() },
+      }),
+    ).rejects.toThrow('capability context failed');
+  });
 
   it.each([false, true])(
     'persists session input introduced on a later cloned sandbox turn (stream=%s)',

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -313,15 +313,12 @@ class PrependingEqualCloningContextCapability extends Capability {
   }
 }
 
-class SurplusHistoryAndRedactingCurrentCapability extends Capability {
-  readonly type = 'surplus_history_and_redacting_current';
+class ReplacingCurrentContextCapability extends Capability {
+  readonly type = 'replacing_current_context';
 
   override processContext(context: AgentInputItem[]): AgentInputItem[] {
-    return [
-      context[0],
-      structuredClone(context[0]),
-      user('redacted current input'),
-    ];
+    context[1] = context[0];
+    return context;
   }
 }
 
@@ -1337,7 +1334,7 @@ describe('sandbox runner integration', () => {
   );
 
   it.each([false, true])(
-    'persists a rewritten current input beside an ambiguous surplus clone group (stream=%s)',
+    'does not persist a repeated history reference that replaces current input (stream=%s)',
     async (stream) => {
       const response = {
         output: [fakeModelMessage('done')],
@@ -1347,9 +1344,9 @@ describe('sandbox runner integration', () => {
         ? new RecordingStreamingModel([response])
         : new RecordingFakeModel([response]);
       const agent = new SandboxAgent({
-        name: 'SurplusHistoryAndRedactingCurrentPersistenceAgent',
+        name: 'ReplacingCurrentContextPersistenceAgent',
         model,
-        capabilities: [new SurplusHistoryAndRedactingCurrentCapability()],
+        capabilities: [new ReplacingCurrentContextCapability()],
       });
       const session = new MemorySession({
         initialItems: [user('same input')],
@@ -1357,24 +1354,33 @@ describe('sandbox runner integration', () => {
       const options = {
         session,
         sandbox: { client: new FakeSandboxClient() },
+        callModelInputFilter: ({ modelData }: CallModelInputFilterArgs) => ({
+          ...modelData,
+          input: modelData.input.map((item, index) =>
+            item.type === 'message' && item.role === 'user'
+              ? user(index === 0 ? 'history-filtered' : 'current-filtered')
+              : item,
+          ),
+        }),
       };
 
       if (stream) {
-        const result = await run(agent, [user('sensitive current input')], {
+        const result = await run(agent, [user('same input')], {
           ...options,
           stream: true,
         });
         await result.completed;
       } else {
-        await run(agent, [user('sensitive current input')], {
+        await run(agent, [user('same input')], {
           ...options,
           stream: false,
         });
       }
 
       const persisted = JSON.stringify(await session.getItems());
-      expect(persisted).toContain('redacted current input');
-      expect(persisted).not.toContain('sensitive current input');
+      expect(persisted.match(/same input/g)).toHaveLength(1);
+      expect(persisted).not.toContain('history-filtered');
+      expect(persisted).not.toContain('current-filtered');
     },
   );
 

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -276,6 +276,55 @@ class CloningSubsetContextCapability extends Capability {
   }
 }
 
+class RedactingCloningContextCapability extends Capability {
+  readonly type = 'redacting_cloning_context';
+
+  override processContext(context: AgentInputItem[]): AgentInputItem[] {
+    return structuredClone(context).map((item) =>
+      item.type === 'message' && item.role === 'user'
+        ? user('redacted current input')
+        : item,
+    );
+  }
+}
+
+class ReplacingHistoryCloningContextCapability extends Capability {
+  readonly type = 'replacing_history_cloning_context';
+
+  override processContext(context: AgentInputItem[]): AgentInputItem[] {
+    const cloned = structuredClone(context);
+    return [user('injected sandbox context'), cloned[1]];
+  }
+}
+
+class PrependingCloningContextCapability extends Capability {
+  readonly type = 'prepending_cloning_context';
+
+  override processContext(context: AgentInputItem[]): AgentInputItem[] {
+    return [user('injected sandbox context'), ...structuredClone(context)];
+  }
+}
+
+class PrependingEqualCloningContextCapability extends Capability {
+  readonly type = 'prepending_equal_cloning_context';
+
+  override processContext(context: AgentInputItem[]): AgentInputItem[] {
+    return [structuredClone(context[0]), ...structuredClone(context)];
+  }
+}
+
+class SurplusHistoryAndRedactingCurrentCapability extends Capability {
+  readonly type = 'surplus_history_and_redacting_current';
+
+  override processContext(context: AgentInputItem[]): AgentInputItem[] {
+    return [
+      context[0],
+      structuredClone(context[0]),
+      user('redacted current input'),
+    ];
+  }
+}
+
 class ReservedFunctionNameCapability extends Capability {
   readonly type = 'reserved_function_name';
 
@@ -1085,6 +1134,247 @@ describe('sandbox runner integration', () => {
       expect(JSON.stringify(seenContexts)).not.toContain(
         '__openai_agents_internal_context_provenance_',
       );
+    },
+  );
+
+  it.each([false, true])(
+    'persists current input rewritten by a cloned sandbox context (stream=%s)',
+    async (stream) => {
+      const response = {
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+      };
+      const model = stream
+        ? new RecordingStreamingModel([response])
+        : new RecordingFakeModel([response]);
+      const agent = new SandboxAgent({
+        name: 'RedactingCloningContextPersistenceAgent',
+        model,
+        capabilities: [new RedactingCloningContextCapability()],
+      });
+      const session = new MemorySession();
+      const options = {
+        session,
+        sandbox: { client: new FakeSandboxClient() },
+      };
+
+      if (stream) {
+        const result = await run(agent, [user('sensitive current input')], {
+          ...options,
+          stream: true,
+        });
+        await result.completed;
+      } else {
+        await run(agent, [user('sensitive current input')], {
+          ...options,
+          stream: false,
+        });
+      }
+
+      const persisted = JSON.stringify(await session.getItems());
+      expect(persisted).toContain('redacted current input');
+      expect(persisted).not.toContain('sensitive current input');
+    },
+  );
+
+  it.each([false, true])(
+    'persists an unchanged current clone when sandbox context replaces equal history (stream=%s)',
+    async (stream) => {
+      const response = {
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+      };
+      const model = stream
+        ? new RecordingStreamingModel([response])
+        : new RecordingFakeModel([response]);
+      const agent = new SandboxAgent({
+        name: 'ReplacingHistoryCloningContextPersistenceAgent',
+        model,
+        capabilities: [new ReplacingHistoryCloningContextCapability()],
+      });
+      const session = new MemorySession({
+        initialItems: [user('same input')],
+      });
+      const options = {
+        session,
+        sandbox: { client: new FakeSandboxClient() },
+      };
+
+      if (stream) {
+        const result = await run(agent, [user('same input')], {
+          ...options,
+          stream: true,
+        });
+        await result.completed;
+      } else {
+        await run(agent, [user('same input')], {
+          ...options,
+          stream: false,
+        });
+      }
+
+      const persisted = JSON.stringify(await session.getItems());
+      expect(persisted.match(/same input/g)).toHaveLength(2);
+      expect(persisted).not.toContain('injected sandbox context');
+    },
+  );
+
+  it.each([false, true])(
+    'persists current input when injected sandbox context shifts equal-content clones (stream=%s)',
+    async (stream) => {
+      const response = {
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+      };
+      const model = stream
+        ? new RecordingStreamingModel([response])
+        : new RecordingFakeModel([response]);
+      const agent = new SandboxAgent({
+        name: 'PrependingCloningContextPersistenceAgent',
+        model,
+        capabilities: [new PrependingCloningContextCapability()],
+      });
+      const session = new MemorySession({
+        initialItems: [user('same input')],
+      });
+      const options = {
+        session,
+        sandbox: { client: new FakeSandboxClient() },
+        callModelInputFilter: ({ modelData }: CallModelInputFilterArgs) => ({
+          ...modelData,
+          input: modelData.input.map((item, index) => {
+            if (item.type !== 'message' || item.role !== 'user') {
+              return item;
+            }
+            return user(
+              index === 0
+                ? 'injected-filtered'
+                : index === 1
+                  ? 'history-filtered'
+                  : 'current-filtered',
+            );
+          }),
+        }),
+      };
+
+      if (stream) {
+        const result = await run(agent, [user('same input')], {
+          ...options,
+          stream: true,
+        });
+        await result.completed;
+      } else {
+        await run(agent, [user('same input')], {
+          ...options,
+          stream: false,
+        });
+      }
+
+      const persisted = JSON.stringify(await session.getItems());
+      expect(persisted).toContain('current-filtered');
+      expect(persisted).not.toContain('history-filtered');
+      expect(persisted).not.toContain('injected-filtered');
+    },
+  );
+
+  it.each([false, true])(
+    'does not guess current ownership for a surplus equal-content sandbox clone (stream=%s)',
+    async (stream) => {
+      const response = {
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+      };
+      const model = stream
+        ? new RecordingStreamingModel([response])
+        : new RecordingFakeModel([response]);
+      const agent = new SandboxAgent({
+        name: 'PrependingEqualCloningContextPersistenceAgent',
+        model,
+        capabilities: [new PrependingEqualCloningContextCapability()],
+      });
+      const session = new MemorySession({
+        initialItems: [user('same input')],
+      });
+      const options = {
+        session,
+        sandbox: { client: new FakeSandboxClient() },
+        callModelInputFilter: ({ modelData }: CallModelInputFilterArgs) => ({
+          ...modelData,
+          input: modelData.input.map((item, index) => {
+            if (item.type !== 'message' || item.role !== 'user') {
+              return item;
+            }
+            return user(
+              index === 0
+                ? 'injected-filtered'
+                : index === 1
+                  ? 'history-filtered'
+                  : 'current-filtered',
+            );
+          }),
+        }),
+      };
+
+      if (stream) {
+        const result = await run(agent, [user('same input')], {
+          ...options,
+          stream: true,
+        });
+        await result.completed;
+      } else {
+        await run(agent, [user('same input')], {
+          ...options,
+          stream: false,
+        });
+      }
+
+      const persisted = JSON.stringify(await session.getItems());
+      expect(persisted.match(/same input/g)).toHaveLength(1);
+      expect(persisted).not.toContain('injected-filtered');
+      expect(persisted).not.toContain('history-filtered');
+      expect(persisted).not.toContain('current-filtered');
+    },
+  );
+
+  it.each([false, true])(
+    'persists a rewritten current input beside an ambiguous surplus clone group (stream=%s)',
+    async (stream) => {
+      const response = {
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+      };
+      const model = stream
+        ? new RecordingStreamingModel([response])
+        : new RecordingFakeModel([response]);
+      const agent = new SandboxAgent({
+        name: 'SurplusHistoryAndRedactingCurrentPersistenceAgent',
+        model,
+        capabilities: [new SurplusHistoryAndRedactingCurrentCapability()],
+      });
+      const session = new MemorySession({
+        initialItems: [user('same input')],
+      });
+      const options = {
+        session,
+        sandbox: { client: new FakeSandboxClient() },
+      };
+
+      if (stream) {
+        const result = await run(agent, [user('sensitive current input')], {
+          ...options,
+          stream: true,
+        });
+        await result.completed;
+      } else {
+        await run(agent, [user('sensitive current input')], {
+          ...options,
+          stream: false,
+        });
+      }
+
+      const persisted = JSON.stringify(await session.getItems());
+      expect(persisted).toContain('redacted current input');
+      expect(persisted).not.toContain('sensitive current input');
     },
   );
 

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -57,7 +57,6 @@ import {
   Capability,
   compaction,
   Entry,
-  compaction,
   EnvValueReference,
   filesystem,
   isEnvValueReference,
@@ -1747,7 +1746,7 @@ describe('sandbox runner integration', () => {
   );
 
   it.each([false, true])(
-    'retains current session input when a later sandbox turn compacts it away (stream=%s)',
+    'replaces current session input when a later sandbox turn compacts it away (stream=%s)',
     async (stream) => {
       const client = new FakeSandboxClient();
       const continueTool = tool({
@@ -1805,6 +1804,10 @@ describe('sandbox runner integration', () => {
       }
 
       const persisted = await session.getItems();
+      expect(persisted[0]).toMatchObject({
+        type: 'compaction',
+        encrypted_content: 'later compacted history',
+      });
       expect(
         persisted.filter(
           (item) =>
@@ -1817,7 +1820,7 @@ describe('sandbox runner integration', () => {
                 content.text === 'current input',
             ),
         ),
-      ).toHaveLength(1);
+      ).toHaveLength(0);
     },
   );
 

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -16,6 +16,7 @@ import {
 import { RunContext } from '../src/runContext';
 import {
   run,
+  MemorySession,
   RunItemStreamEvent,
   RunState,
   Runner,
@@ -52,6 +53,7 @@ import {
 } from '../src/sandbox/runtime/sessionLifecycle';
 import {
   Capability,
+  compaction,
   Entry,
   compaction,
   EnvValueReference,
@@ -834,6 +836,139 @@ function fakeSandboxSessionStateEnvelope(
 }
 
 describe('sandbox runner integration', () => {
+  it.each([false, true])(
+    'persists current session input after sandbox compaction (stream=%s)',
+    async (stream) => {
+      const client = new FakeSandboxClient();
+      const response = {
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+      };
+      const model = stream
+        ? new RecordingStreamingModel([response])
+        : new RecordingFakeModel([response]);
+      const agent = new SandboxAgent({
+        name: 'CompactionPersistenceAgent',
+        model,
+        capabilities: [compaction()],
+      });
+      const current = user('current input');
+      const session = new MemorySession({
+        initialItems: [
+          user('old history'),
+          {
+            type: 'compaction',
+            encrypted_content: 'compacted history',
+          },
+        ],
+      });
+      if (stream) {
+        const result = await run(agent, [current], {
+          stream: true,
+          session,
+          sandbox: { client },
+        });
+        await result.completed;
+      } else {
+        await run(agent, [current], {
+          stream: false,
+          session,
+          sandbox: { client },
+        });
+      }
+
+      const persisted = await session.getItems();
+      expect(
+        persisted.filter(
+          (item) =>
+            item.type === 'message' &&
+            item.role === 'user' &&
+            Array.isArray(item.content) &&
+            item.content.some(
+              (content) =>
+                content.type === 'input_text' &&
+                content.text === 'current input',
+            ),
+        ),
+      ).toHaveLength(1);
+    },
+  );
+
+  it.each([false, true])(
+    'retains current session input when a later sandbox turn compacts it away (stream=%s)',
+    async (stream) => {
+      const client = new FakeSandboxClient();
+      const continueTool = tool({
+        name: 'continue_after_compaction',
+        description: 'Continues after a compaction item.',
+        parameters: z.object({}),
+        execute: async () => 'continued',
+      });
+      const responses: ModelResponse[] = [
+        {
+          output: [
+            {
+              type: 'compaction',
+              encrypted_content: 'later compacted history',
+            },
+            {
+              type: 'function_call',
+              callId: 'call_after_compaction',
+              name: continueTool.name,
+              arguments: '{}',
+            },
+          ],
+          usage: new Usage(),
+        },
+        {
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        },
+      ];
+      const model = stream
+        ? new RecordingStreamingModel(responses)
+        : new RecordingFakeModel(responses);
+      const agent = new SandboxAgent({
+        name: 'LaterCompactionPersistenceAgent',
+        model,
+        tools: [continueTool],
+        capabilities: [compaction()],
+      });
+      const session = new MemorySession();
+      const current = user('current input');
+
+      if (stream) {
+        const result = await run(agent, [current], {
+          stream: true,
+          session,
+          sandbox: { client },
+        });
+        await result.completed;
+      } else {
+        await run(agent, [current], {
+          stream: false,
+          session,
+          sandbox: { client },
+        });
+      }
+
+      const persisted = await session.getItems();
+      expect(
+        persisted.filter(
+          (item) =>
+            item.type === 'message' &&
+            item.role === 'user' &&
+            Array.isArray(item.content) &&
+            item.content.some(
+              (content) =>
+                content.type === 'input_text' &&
+                content.text === 'current input',
+            ),
+        ),
+      ).toHaveLength(1);
+    },
+  );
+
   beforeAll(() => {
     setTracingDisabled(true);
     setDefaultModelProvider(new FakeModelProvider());

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -242,35 +242,20 @@ class CloningContextCapability extends Capability {
 
 class CloningPrefixContextCapability extends Capability {
   readonly type = 'cloning_prefix_context';
+  readonly seenContexts?: AgentInputItem[][];
+
+  constructor(seenContexts?: AgentInputItem[][]) {
+    super();
+    this.seenContexts = seenContexts;
+  }
+
+  override clone(): this {
+    return new CloningPrefixContextCapability(this.seenContexts) as this;
+  }
 
   override processContext(context: AgentInputItem[]): AgentInputItem[] {
+    this.seenContexts?.push(structuredClone(context));
     return structuredClone(context.slice(0, 1));
-  }
-}
-
-class FrozenCloningContextCapability extends Capability {
-  readonly type = 'frozen_cloning_context';
-
-  override processContext(context: AgentInputItem[]): AgentInputItem[] {
-    return structuredClone(context).map((item) => Object.freeze(item));
-  }
-}
-
-class FrozenCloningPrefixContextCapability extends Capability {
-  readonly type = 'frozen_cloning_prefix_context';
-
-  override processContext(context: AgentInputItem[]): AgentInputItem[] {
-    return structuredClone(context.slice(0, 1)).map((item) =>
-      Object.freeze(item),
-    );
-  }
-}
-
-class ThrowingContextCapability extends Capability {
-  readonly type = 'throwing_context';
-
-  override processContext(_context: AgentInputItem[]): AgentInputItem[] {
-    throw new Error('capability context failed');
   }
 }
 
@@ -1047,6 +1032,7 @@ describe('sandbox runner integration', () => {
     'does not persist equal-content history as current when cloned sandbox context keeps a prefix (stream=%s)',
     async (stream) => {
       const client = new FakeSandboxClient();
+      const seenContexts: AgentInputItem[][] = [];
       const response = {
         output: [fakeModelMessage('done')],
         usage: new Usage(),
@@ -1057,7 +1043,7 @@ describe('sandbox runner integration', () => {
       const agent = new SandboxAgent({
         name: 'CloningHistoryPrefixPersistenceAgent',
         model,
-        capabilities: [new CloningPrefixContextCapability()],
+        capabilities: [new CloningPrefixContextCapability(seenContexts)],
       });
       const session = new MemorySession({
         initialItems: [user('same input')],
@@ -1095,147 +1081,12 @@ describe('sandbox runner integration', () => {
       const persisted = JSON.stringify(await session.getItems());
       expect(persisted).not.toContain('history-filtered');
       expect(persisted.match(/same input/g)).toHaveLength(1);
-      expect(JSON.stringify(model.requests)).not.toContain(
+      expect(seenContexts).toHaveLength(1);
+      expect(JSON.stringify(seenContexts)).not.toContain(
         '__openai_agents_internal_context_provenance_',
       );
     },
   );
-
-  it.each([false, true])(
-    'preserves provenance when frozen cloned sandbox context keeps a prefix (stream=%s)',
-    async (stream) => {
-      const client = new FakeSandboxClient();
-      const response = {
-        output: [fakeModelMessage('done')],
-        usage: new Usage(),
-      };
-      const model = stream
-        ? new RecordingStreamingModel([response])
-        : new RecordingFakeModel([response]);
-      const agent = new SandboxAgent({
-        name: 'FrozenCloningHistoryPrefixPersistenceAgent',
-        model,
-        capabilities: [new FrozenCloningPrefixContextCapability()],
-      });
-      const session = new MemorySession({
-        initialItems: [user('same input')],
-      });
-      const options = {
-        session,
-        sandbox: { client },
-        sessionInputCallback: (
-          history: AgentInputItem[],
-          newItems: AgentInputItem[],
-        ) => history.concat(newItems),
-        callModelInputFilter: ({ modelData }: CallModelInputFilterArgs) => ({
-          ...modelData,
-          input: modelData.input.map((item) =>
-            item.type === 'message' && item.role === 'user'
-              ? user('history-filtered')
-              : item,
-          ),
-        }),
-      };
-
-      if (stream) {
-        const result = await run(agent, [user('same input')], {
-          ...options,
-          stream: true,
-        });
-        await result.completed;
-      } else {
-        await run(agent, [user('same input')], {
-          ...options,
-          stream: false,
-        });
-      }
-
-      const persisted = JSON.stringify(await session.getItems());
-      expect(persisted).not.toContain('history-filtered');
-      expect(persisted.match(/same input/g)).toHaveLength(1);
-      expect(JSON.stringify(model.requests)).not.toContain(
-        '__openai_agents_internal_context_provenance_',
-      );
-    },
-  );
-
-  it.each([false, true])(
-    'preserves provenance through an intermediate frozen sandbox context (stream=%s)',
-    async (stream) => {
-      const client = new FakeSandboxClient();
-      const response = {
-        output: [fakeModelMessage('done')],
-        usage: new Usage(),
-      };
-      const model = stream
-        ? new RecordingStreamingModel([response])
-        : new RecordingFakeModel([response]);
-      const agent = new SandboxAgent({
-        name: 'IntermediateFrozenContextPersistenceAgent',
-        model,
-        capabilities: [
-          new FrozenCloningContextCapability(),
-          new CloningPrefixContextCapability(),
-        ],
-      });
-      const session = new MemorySession({
-        initialItems: [user('same input')],
-      });
-      const options = {
-        session,
-        sandbox: { client },
-        sessionInputCallback: (
-          history: AgentInputItem[],
-          newItems: AgentInputItem[],
-        ) => newItems.concat(history),
-        callModelInputFilter: ({ modelData }: CallModelInputFilterArgs) => ({
-          ...modelData,
-          input: modelData.input.map((item) =>
-            item.type === 'message' && item.role === 'user'
-              ? user('current-filtered')
-              : item,
-          ),
-        }),
-      };
-
-      if (stream) {
-        const result = await run(agent, [user('same input')], {
-          ...options,
-          stream: true,
-        });
-        await result.completed;
-      } else {
-        await run(agent, [user('same input')], {
-          ...options,
-          stream: false,
-        });
-      }
-
-      expect(JSON.stringify(await session.getItems())).toContain(
-        'current-filtered',
-      );
-      expect(JSON.stringify(model.requests)).not.toContain(
-        '__openai_agents_internal_context_provenance_',
-      );
-    },
-  );
-
-  it('does not mask a capability error after an intermediate frozen context', async () => {
-    const agent = new SandboxAgent({
-      name: 'ThrowingAfterFrozenContextAgent',
-      model: new RecordingFakeModel([]),
-      capabilities: [
-        new FrozenCloningContextCapability(),
-        new ThrowingContextCapability(),
-      ],
-    });
-
-    await expect(
-      run(agent, [user('input')], {
-        sandbox: { client: new FakeSandboxClient() },
-      }),
-    ).rejects.toThrow('capability context failed');
-  });
 
   it.each([false, true])(
     'persists session input introduced on a later cloned sandbox turn (stream=%s)',

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -288,6 +288,15 @@ class RedactingCloningContextCapability extends Capability {
   }
 }
 
+class RewritingCurrentCloningContextCapability extends Capability {
+  readonly type = 'rewriting_current_cloning_context';
+
+  override processContext(context: AgentInputItem[]): AgentInputItem[] {
+    const cloned = structuredClone(context);
+    return [cloned[1]!, user('redacted current input')];
+  }
+}
+
 class ReplacingHistoryCloningContextCapability extends Capability {
   readonly type = 'replacing_history_cloning_context';
 
@@ -1175,7 +1184,56 @@ describe('sandbox runner integration', () => {
   );
 
   it.each([false, true])(
-    'persists an unchanged current clone when sandbox context replaces equal history (stream=%s)',
+    'rejects a rewritten current input when cloned history surrounds it (stream=%s)',
+    async (stream) => {
+      const response = {
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+      };
+      const model = stream
+        ? new RecordingStreamingModel([response])
+        : new RecordingFakeModel([response]);
+      const agent = new SandboxAgent({
+        name: 'RewritingCurrentCloningContextPersistenceAgent',
+        model,
+        capabilities: [new RewritingCurrentCloningContextCapability()],
+      });
+      const session = new MemorySession({
+        initialItems: [user('same input')],
+      });
+      const options = {
+        session,
+        sandbox: { client: new FakeSandboxClient() },
+        sessionInputCallback: (
+          history: AgentInputItem[],
+          newItems: AgentInputItem[],
+        ) => newItems.concat(history),
+      };
+      const expectedError =
+        'Capability.processContext() cannot replace Session-owned input without preserving its identity. Use callModelInputFilter for persistence-aware input replacement.';
+
+      if (stream) {
+        const result = await run(agent, [user('same input')], {
+          ...options,
+          stream: true,
+        });
+        await expect(result.completed).rejects.toThrowError(expectedError);
+      } else {
+        await expect(
+          run(agent, [user('same input')], {
+            ...options,
+            stream: false,
+          }),
+        ).rejects.toThrowError(expectedError);
+      }
+
+      expect(model.requests).toHaveLength(0);
+      expect(await session.getItems()).toEqual([user('same input')]);
+    },
+  );
+
+  it.each([false, true])(
+    'rejects an ambiguous current clone when sandbox context replaces equal history (stream=%s)',
     async (stream) => {
       const response = {
         output: [fakeModelMessage('done')],
@@ -1196,23 +1254,26 @@ describe('sandbox runner integration', () => {
         session,
         sandbox: { client: new FakeSandboxClient() },
       };
+      const expectedError =
+        'Capability.processContext() cannot replace Session-owned input without preserving its identity. Use callModelInputFilter for persistence-aware input replacement.';
 
       if (stream) {
         const result = await run(agent, [user('same input')], {
           ...options,
           stream: true,
         });
-        await result.completed;
+        await expect(result.completed).rejects.toThrowError(expectedError);
       } else {
-        await run(agent, [user('same input')], {
-          ...options,
-          stream: false,
-        });
+        await expect(
+          run(agent, [user('same input')], {
+            ...options,
+            stream: false,
+          }),
+        ).rejects.toThrowError(expectedError);
       }
 
-      const persisted = JSON.stringify(await session.getItems());
-      expect(persisted.match(/same input/g)).toHaveLength(2);
-      expect(persisted).not.toContain('injected sandbox context');
+      expect(model.requests).toHaveLength(0);
+      expect(await session.getItems()).toEqual([user('same input')]);
     },
   );
 

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -34,6 +34,8 @@ import {
   type Span,
   type Trace,
   type TracingProcessor,
+  type AgentInputItem,
+  type CallModelInputFilterArgs,
 } from '../src';
 import { SandboxRuntimeManager } from '../src/sandbox/runtime';
 import {
@@ -227,6 +229,31 @@ class SamplingRecorderCapability extends Capability {
   ): Record<string, unknown> {
     this.calls.push(samplingParams);
     return {};
+  }
+}
+
+class CloningContextCapability extends Capability {
+  readonly type = 'cloning_context';
+
+  override processContext(context: AgentInputItem[]): AgentInputItem[] {
+    return structuredClone(context);
+  }
+}
+
+class CloningSubsetContextCapability extends Capability {
+  readonly type = 'cloning_subset_context';
+
+  override processContext(context: AgentInputItem[]): AgentInputItem[] {
+    const cloned = structuredClone(context);
+    if (!cloned.some((item) => item.type === 'function_call_result')) {
+      return cloned;
+    }
+    return cloned.filter(
+      (item) =>
+        item.type !== 'message' ||
+        item.role !== 'user' ||
+        !JSON.stringify(item.content).includes('first input'),
+    );
   }
 }
 
@@ -836,6 +863,276 @@ function fakeSandboxSessionStateEnvelope(
 }
 
 describe('sandbox runner integration', () => {
+  it.each([false, true])(
+    'persists reordered equal-content session input when a sandbox capability clones context (stream=%s)',
+    async (stream) => {
+      const client = new FakeSandboxClient();
+      const response = {
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+      };
+      const model = stream
+        ? new RecordingStreamingModel([response])
+        : new RecordingFakeModel([response]);
+      const agent = new SandboxAgent({
+        name: 'CloningContextPersistenceAgent',
+        model,
+        capabilities: [new CloningContextCapability()],
+      });
+      const session = new MemorySession({
+        initialItems: [user('same input')],
+      });
+      const options = {
+        session,
+        sandbox: { client },
+        sessionInputCallback: (
+          history: AgentInputItem[],
+          newItems: AgentInputItem[],
+        ) => newItems.concat(history),
+        callModelInputFilter: ({ modelData }: CallModelInputFilterArgs) => ({
+          ...modelData,
+          input: modelData.input.map((item, index) => {
+            if (item.type !== 'message' || item.role !== 'user') {
+              return item;
+            }
+            return user(index === 0 ? 'current-filtered' : 'history-filtered');
+          }),
+        }),
+      };
+
+      if (stream) {
+        const result = await run(agent, [user('same input')], {
+          ...options,
+          stream: true,
+        });
+        await result.completed;
+      } else {
+        await run(agent, [user('same input')], {
+          ...options,
+          stream: false,
+        });
+      }
+
+      const persisted = await session.getItems();
+      expect(
+        persisted.filter(
+          (item) =>
+            item.type === 'message' &&
+            item.role === 'user' &&
+            Array.isArray(item.content) &&
+            item.content.some(
+              (content) =>
+                content.type === 'input_text' &&
+                content.text === 'current-filtered',
+            ),
+        ),
+      ).toHaveLength(1);
+      expect(
+        persisted.filter(
+          (item) =>
+            item.type === 'message' &&
+            item.role === 'user' &&
+            Array.isArray(item.content) &&
+            item.content.some(
+              (content) =>
+                content.type === 'input_text' &&
+                content.text === 'history-filtered',
+            ),
+        ),
+      ).toHaveLength(0);
+      expect(
+        persisted.filter(
+          (item) =>
+            item.type === 'message' &&
+            item.role === 'assistant' &&
+            Array.isArray(item.content) &&
+            item.content.some(
+              (content) =>
+                content.type === 'output_text' && content.text === 'done',
+            ),
+        ),
+      ).toHaveLength(1);
+    },
+  );
+
+  it.each([false, true])(
+    'persists session input introduced on a later cloned sandbox turn (stream=%s)',
+    async (stream) => {
+      const client = new FakeSandboxClient();
+      const continueTool = tool({
+        name: 'continue_after_filter',
+        description: 'Continues after the first filtered model call.',
+        parameters: z.object({}),
+        execute: async () => 'continued',
+      });
+      const responses: ModelResponse[] = [
+        {
+          output: [
+            {
+              type: 'function_call',
+              callId: 'call_continue_after_filter',
+              name: continueTool.name,
+              arguments: '{}',
+            },
+          ],
+          usage: new Usage(),
+        },
+        {
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        },
+      ];
+      const model = stream
+        ? new RecordingStreamingModel(responses)
+        : new RecordingFakeModel(responses);
+      const agent = new SandboxAgent({
+        name: 'LaterClonedContextPersistenceAgent',
+        model,
+        tools: [continueTool],
+        capabilities: [new CloningContextCapability()],
+      });
+      const session = new MemorySession();
+      let filterCall = 0;
+      const options = {
+        session,
+        sandbox: { client },
+        callModelInputFilter: ({ modelData }: CallModelInputFilterArgs) => {
+          filterCall += 1;
+          if (filterCall === 1) {
+            return {
+              ...modelData,
+              input: modelData.input.filter(
+                (item) => item.type !== 'message' || item.role !== 'user',
+              ),
+            };
+          }
+          return {
+            ...modelData,
+            input: modelData.input.map((item) =>
+              item.type === 'message' && item.role === 'user'
+                ? user('current-filtered')
+                : item,
+            ),
+          };
+        },
+      };
+
+      if (stream) {
+        const result = await run(agent, [user('current input')], {
+          ...options,
+          stream: true,
+        });
+        await result.completed;
+      } else {
+        await run(agent, [user('current input')], {
+          ...options,
+          stream: false,
+        });
+      }
+
+      const persisted = await session.getItems();
+      expect(
+        persisted.filter(
+          (item) =>
+            item.type === 'message' &&
+            item.role === 'user' &&
+            Array.isArray(item.content) &&
+            item.content.some(
+              (content) =>
+                content.type === 'input_text' &&
+                content.text === 'current-filtered',
+            ),
+        ),
+      ).toHaveLength(1);
+    },
+  );
+
+  it.each([false, true])(
+    'preserves session ownership when a later cloned sandbox turn retains a subset (stream=%s)',
+    async (stream) => {
+      const client = new FakeSandboxClient();
+      const continueTool = tool({
+        name: 'continue_after_subset',
+        description: 'Continues after the sandbox context is reduced.',
+        parameters: z.object({}),
+        execute: async () => 'continued',
+      });
+      const responses: ModelResponse[] = [
+        {
+          output: [
+            {
+              type: 'function_call',
+              callId: 'call_continue_after_subset',
+              name: continueTool.name,
+              arguments: '{}',
+            },
+          ],
+          usage: new Usage(),
+        },
+        {
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        },
+      ];
+      const model = stream
+        ? new RecordingStreamingModel(responses)
+        : new RecordingFakeModel(responses);
+      const agent = new SandboxAgent({
+        name: 'SubsetClonedContextPersistenceAgent',
+        model,
+        tools: [continueTool],
+        capabilities: [new CloningSubsetContextCapability()],
+      });
+      const session = new MemorySession();
+      let filterCall = 0;
+      const options = {
+        session,
+        sandbox: { client },
+        callModelInputFilter: ({ modelData }: CallModelInputFilterArgs) => {
+          filterCall += 1;
+          return {
+            ...modelData,
+            input: modelData.input.map((item) => {
+              if (item.type !== 'message' || item.role !== 'user') {
+                return item;
+              }
+              const isFirst = JSON.stringify(item.content).includes(
+                'first input',
+              );
+              return user(
+                isFirst
+                  ? 'first-filtered'
+                  : filterCall === 1
+                    ? 'second-filtered'
+                    : 'second-refiltered',
+              );
+            }),
+          };
+        },
+      };
+
+      if (stream) {
+        const result = await run(
+          agent,
+          [user('first input'), user('second input')],
+          { ...options, stream: true },
+        );
+        await result.completed;
+      } else {
+        await run(agent, [user('first input'), user('second input')], {
+          ...options,
+          stream: false,
+        });
+      }
+
+      const persisted = await session.getItems();
+      const persistedText = JSON.stringify(persisted);
+      expect(persistedText).toContain('first-filtered');
+      expect(persistedText).toContain('second-refiltered');
+      expect(persistedText).not.toContain('second-filtered');
+    },
+  );
+
   it.each([false, true])(
     'persists current session input after sandbox compaction (stream=%s)',
     async (stream) => {

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -240,6 +240,14 @@ class CloningContextCapability extends Capability {
   }
 }
 
+class CloningPrefixContextCapability extends Capability {
+  readonly type = 'cloning_prefix_context';
+
+  override processContext(context: AgentInputItem[]): AgentInputItem[] {
+    return structuredClone(context.slice(0, 1));
+  }
+}
+
 class CloningSubsetContextCapability extends Capability {
   readonly type = 'cloning_subset_context';
 
@@ -956,6 +964,60 @@ describe('sandbox runner integration', () => {
   );
 
   it.each([false, true])(
+    'persists current equal-content input when cloned sandbox context removes a suffix (stream=%s)',
+    async (stream) => {
+      const client = new FakeSandboxClient();
+      const response = {
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+      };
+      const model = stream
+        ? new RecordingStreamingModel([response])
+        : new RecordingFakeModel([response]);
+      const agent = new SandboxAgent({
+        name: 'CloningPrefixPersistenceAgent',
+        model,
+        capabilities: [new CloningPrefixContextCapability()],
+      });
+      const session = new MemorySession({
+        initialItems: [user('same input')],
+      });
+      const options = {
+        session,
+        sandbox: { client },
+        sessionInputCallback: (
+          history: AgentInputItem[],
+          newItems: AgentInputItem[],
+        ) => newItems.concat(history),
+        callModelInputFilter: ({ modelData }: CallModelInputFilterArgs) => ({
+          ...modelData,
+          input: modelData.input.map((item) =>
+            item.type === 'message' && item.role === 'user'
+              ? user('current-filtered')
+              : item,
+          ),
+        }),
+      };
+
+      if (stream) {
+        const result = await run(agent, [user('same input')], {
+          ...options,
+          stream: true,
+        });
+        await result.completed;
+      } else {
+        await run(agent, [user('same input')], {
+          ...options,
+          stream: false,
+        });
+      }
+
+      const persisted = JSON.stringify(await session.getItems());
+      expect(persisted).toContain('current-filtered');
+    },
+  );
+
+  it.each([false, true])(
     'persists session input introduced on a later cloned sandbox turn (stream=%s)',
     async (stream) => {
       const client = new FakeSandboxClient();
@@ -1130,6 +1192,71 @@ describe('sandbox runner integration', () => {
       expect(persistedText).toContain('first-filtered');
       expect(persistedText).toContain('second-refiltered');
       expect(persistedText).not.toContain('second-filtered');
+    },
+  );
+
+  it.each([false, true])(
+    'replaces repeated filter injections across model calls (stream=%s)',
+    async (stream) => {
+      const continueTool = tool({
+        name: 'continue_after_injection',
+        description: 'Continues after the first injected model call.',
+        parameters: z.object({}),
+        execute: async () => 'continued',
+      });
+      const responses: ModelResponse[] = [
+        {
+          output: [
+            {
+              type: 'function_call',
+              callId: 'call_continue_after_injection',
+              name: continueTool.name,
+              arguments: '{}',
+            },
+          ],
+          usage: new Usage(),
+        },
+        {
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        },
+      ];
+      const model = stream
+        ? new RecordingStreamingModel(responses)
+        : new RecordingFakeModel(responses);
+      const agent = new Agent({
+        name: 'RepeatedFilterInjectionAgent',
+        model,
+        tools: [continueTool],
+      });
+      const session = new MemorySession();
+      const options = {
+        session,
+        callModelInputFilter: ({ modelData }: CallModelInputFilterArgs) => ({
+          ...modelData,
+          input: [
+            user('repeated guidance'),
+            user('repeated guidance'),
+            ...modelData.input,
+          ],
+        }),
+      };
+
+      if (stream) {
+        const result = await run(agent, [user('current input')], {
+          ...options,
+          stream: true,
+        });
+        await result.completed;
+      } else {
+        await run(agent, [user('current input')], {
+          ...options,
+          stream: false,
+        });
+      }
+
+      const persisted = JSON.stringify(await session.getItems());
+      expect(persisted.match(/repeated guidance/g)).toHaveLength(2);
     },
   );
 


### PR DESCRIPTION
This pull request fixes duplicate provider-identified model input items by retaining the latest payload while preserving causal ordering for tool calls, reasoning items, and MCP approval requests.

The shared normalization applies to streamed and non-streamed model calls and session persistence. Ordinary messages and items without stable provider identity remain untouched, while callback-injected items and existing callback behavior are preserved.