### PR TITLE
feat(core): add session history transactions

### DIFF
--- a/.changeset/brave-session-transactions.md
+++ b/.changeset/brave-session-transactions.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents': patch
+'@openai/agents-core': patch
+---
+
+feat: add idempotent session history transactions

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -331,6 +331,11 @@ export type {
   SessionHistoryMutation,
   SessionHistoryRewriteArgs,
   SessionHistoryRewriteAwareSession,
+  SessionHistoryAppendItemsTransaction,
+  SessionHistoryReplaceSuffixTransaction,
+  SessionHistoryTransaction,
+  SessionHistoryTransactionArgs,
+  SessionHistoryTransactionAwareSession,
   OpenAIResponsesCompactionArgs,
   OpenAIResponsesCompactionAwareSession,
   OpenAIResponsesCompactionResult,
@@ -338,6 +343,7 @@ export type {
 export {
   isOpenAIResponsesCompactionAwareSession,
   isSessionHistoryRewriteAwareSession,
+  isSessionHistoryTransactionAwareSession,
 } from './memory/session';
 export { applySessionHistoryMutations } from './memory/historyMutations';
 export { MemorySession } from './memory/memorySession';

--- a/packages/agents-core/src/memory/memorySession.ts
+++ b/packages/agents-core/src/memory/memorySession.ts
@@ -4,9 +4,14 @@ import type { AgentInputItem } from '../types';
 import type {
   SessionHistoryRewriteArgs,
   SessionHistoryRewriteAwareSession,
+  SessionHistoryTransaction,
+  SessionHistoryTransactionArgs,
+  SessionHistoryTransactionAwareSession,
 } from './session';
 import { applySessionHistoryMutations } from './historyMutations';
+import { UserError } from '../errors';
 import { logger, Logger } from '../logger';
+import { ModelItem } from '../types/protocol';
 
 export type MemorySessionOptions = {
   sessionId?: string;
@@ -17,11 +22,19 @@ export type MemorySessionOptions = {
 /**
  * Simple in-memory session store intended for demos or tests. Not recommended for production use.
  */
-export class MemorySession implements SessionHistoryRewriteAwareSession {
+export class MemorySession
+  implements
+    SessionHistoryRewriteAwareSession,
+    SessionHistoryTransactionAwareSession
+{
   private readonly sessionId: string;
   private readonly logger: Logger;
 
   private items: AgentInputItem[];
+  private appliedHistoryTransactions = new Map<
+    string,
+    SessionHistoryTransaction
+  >();
 
   constructor(options: MemorySessionOptions = {}) {
     this.sessionId = options.sessionId ?? randomUUID();
@@ -89,6 +102,7 @@ export class MemorySession implements SessionHistoryRewriteAwareSession {
   async clearSession(): Promise<void> {
     this.logger.debug(`Clearing memory session (${this.sessionId})`);
     this.items = [];
+    this.appliedHistoryTransactions = new Map();
   }
 
   async applyHistoryMutations(args: SessionHistoryRewriteArgs): Promise<void> {
@@ -97,8 +111,316 @@ export class MemorySession implements SessionHistoryRewriteAwareSession {
     }
     this.items = applySessionHistoryMutations(this.items, args.mutations);
   }
+
+  async applyHistoryTransaction(
+    args: SessionHistoryTransactionArgs,
+  ): Promise<void> {
+    const { operationId, transaction } = snapshotHistoryTransactionArgs(args);
+    const existing = this.appliedHistoryTransactions.get(operationId);
+    if (existing) {
+      if (!structurallyEqual(existing, transaction)) {
+        throw new UserError(
+          'Session history operation was already applied with a different transaction.',
+        );
+      }
+      return;
+    }
+
+    let nextItems: AgentInputItem[];
+    if (transaction.type === 'append_items') {
+      nextItems = [...this.items, ...transaction.items.map(cloneAgentItem)];
+    } else {
+      const { expectedSuffix, replacement } = transaction;
+      const suffixStart = this.items.length - expectedSuffix.length;
+      const actualSuffix = suffixStart < 0 ? [] : this.items.slice(suffixStart);
+      const actualSuffixSnapshot = trySnapshotAgentItems(actualSuffix);
+      if (
+        suffixStart < 0 ||
+        !actualSuffixSnapshot ||
+        !structurallyEqual(actualSuffixSnapshot, expectedSuffix)
+      ) {
+        throw new UserError(
+          'Session history suffix no longer matches the transaction precondition.',
+        );
+      }
+      nextItems = [
+        ...this.items.slice(0, suffixStart),
+        ...replacement.map(cloneAgentItem),
+      ];
+    }
+
+    const nextTransactions = new Map(this.appliedHistoryTransactions);
+    nextTransactions.set(operationId, transaction);
+    this.items = nextItems;
+    this.appliedHistoryTransactions = nextTransactions;
+  }
 }
 
 function cloneAgentItem<T extends AgentInputItem>(item: T): T {
   return structuredClone(item);
+}
+
+function snapshotHistoryTransactionArgs(
+  args: SessionHistoryTransactionArgs,
+): SessionHistoryTransactionArgs {
+  let operationId: unknown;
+  let transaction: unknown;
+  try {
+    if (!args || typeof args !== 'object') {
+      throw new Error('Missing transaction arguments.');
+    }
+    operationId = Reflect.get(args, 'operationId');
+    transaction = Reflect.get(args, 'transaction');
+  } catch {
+    throw new UserError('Session history transaction arguments are invalid.');
+  }
+  if (typeof operationId !== 'string' || !operationId.trim()) {
+    throw new UserError(
+      'Session history transaction operationId must be a non-empty string.',
+    );
+  }
+  if (!transaction || typeof transaction !== 'object') {
+    throw new UserError('Session history transaction must be an object.');
+  }
+  return {
+    operationId,
+    transaction: snapshotHistoryTransaction(transaction),
+  };
+}
+
+function snapshotHistoryTransaction(
+  transaction: object,
+): SessionHistoryTransaction {
+  let snapshot: unknown;
+  try {
+    snapshot = snapshotSupportedValue(transaction);
+    structuredClone(transaction);
+  } catch {
+    throw new UserError(
+      'Session history transaction items contain invalid or unsupported data.',
+    );
+  }
+  if (!snapshot || typeof snapshot !== 'object') {
+    throw new UserError('Session history transaction must be an object.');
+  }
+  const record = snapshot as Record<string, unknown>;
+  if (record.type === 'append_items') {
+    if (
+      Object.keys(record).length !== 2 ||
+      !Object.prototype.hasOwnProperty.call(record, 'type') ||
+      !Object.prototype.hasOwnProperty.call(record, 'items') ||
+      !Array.isArray(record.items)
+    ) {
+      throw new UserError(
+        'Session history append transaction fields are invalid.',
+      );
+    }
+    try {
+      return {
+        type: record.type,
+        items: snapshotAgentItems(record.items),
+      };
+    } catch {
+      throw new UserError(
+        'Session history transaction items contain invalid or unsupported data.',
+      );
+    }
+  }
+  if (record.type !== 'replace_suffix') {
+    throw new UserError('Unsupported session history transaction type.');
+  }
+  if (
+    Object.keys(record).length !== 3 ||
+    !Object.prototype.hasOwnProperty.call(record, 'type') ||
+    !Object.prototype.hasOwnProperty.call(record, 'expectedSuffix') ||
+    !Object.prototype.hasOwnProperty.call(record, 'replacement') ||
+    !Array.isArray(record.expectedSuffix) ||
+    !Array.isArray(record.replacement)
+  ) {
+    throw new UserError(
+      'Session history suffix transaction fields are invalid.',
+    );
+  }
+  try {
+    return {
+      type: record.type,
+      expectedSuffix: snapshotAgentItems(record.expectedSuffix),
+      replacement: snapshotAgentItems(record.replacement),
+    };
+  } catch {
+    throw new UserError(
+      'Session history transaction items contain invalid or unsupported data.',
+    );
+  }
+}
+
+function snapshotAgentItems(items: AgentInputItem[]): AgentInputItem[] {
+  const snapshots = snapshotSupportedValue(items) as AgentInputItem[];
+  return snapshots.map((snapshot) => {
+    if (!ModelItem.safeParse(snapshot).success) {
+      throw new Error('Invalid session history item.');
+    }
+    return snapshot;
+  });
+}
+
+function trySnapshotAgentItems(
+  items: AgentInputItem[],
+): AgentInputItem[] | undefined {
+  try {
+    return snapshotAgentItems(items);
+  } catch {
+    return undefined;
+  }
+}
+
+function snapshotSupportedValue(
+  value: unknown,
+  ancestors: WeakSet<object> = new WeakSet(),
+): unknown {
+  if (
+    value === null ||
+    value === undefined ||
+    typeof value === 'string' ||
+    typeof value === 'boolean' ||
+    typeof value === 'number'
+  ) {
+    return value;
+  }
+  if (typeof value !== 'object') {
+    throw new Error('Unsupported session history value.');
+  }
+  if (value instanceof Uint8Array) {
+    const keys = Reflect.ownKeys(value);
+    if (
+      keys.length !== value.length ||
+      keys.some(
+        (key) =>
+          typeof key !== 'string' || !isArrayIndexForLength(key, value.length),
+      )
+    ) {
+      throw new Error('Unsupported session history binary property.');
+    }
+    return new Uint8Array(value);
+  }
+  if (ancestors.has(value)) {
+    throw new Error('Cyclic session history value.');
+  }
+
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      const lengthDescriptor = Object.getOwnPropertyDescriptor(value, 'length');
+      if (!lengthDescriptor || !('value' in lengthDescriptor)) {
+        throw new Error('Unsupported session history array.');
+      }
+      const length = lengthDescriptor.value;
+      const keys = Reflect.ownKeys(value);
+      if (
+        typeof length !== 'number' ||
+        !Number.isSafeInteger(length) ||
+        length < 0 ||
+        keys.length !== length + 1 ||
+        keys.some(
+          (key) =>
+            typeof key !== 'string' ||
+            (key !== 'length' && !isArrayIndexForLength(key, length)),
+        )
+      ) {
+        throw new Error('Unsupported session history array.');
+      }
+      const snapshot = new Array<unknown>(length);
+      for (let index = 0; index < length; index++) {
+        const descriptor = Object.getOwnPropertyDescriptor(
+          value,
+          String(index),
+        );
+        if (!descriptor?.enumerable || !('value' in descriptor)) {
+          throw new Error('Unsupported session history array item.');
+        }
+        snapshot[index] = snapshotSupportedValue(descriptor.value, ancestors);
+      }
+      return snapshot;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new Error('Unsupported session history object.');
+    }
+    const snapshot: Record<string, unknown> = {};
+    for (const key of Reflect.ownKeys(value)) {
+      if (typeof key !== 'string') {
+        throw new Error('Unsupported session history property.');
+      }
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor?.enumerable || !('value' in descriptor)) {
+        throw new Error('Unsupported session history property.');
+      }
+      Object.defineProperty(snapshot, key, {
+        configurable: true,
+        enumerable: true,
+        value: snapshotSupportedValue(descriptor.value, ancestors),
+        writable: true,
+      });
+    }
+    return snapshot;
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function isArrayIndexForLength(key: string, length: number): boolean {
+  if (!/^(0|[1-9]\d*)$/.test(key)) {
+    return false;
+  }
+  const index = Number(key);
+  return Number.isSafeInteger(index) && index >= 0 && index < length;
+}
+
+function structurallyEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) {
+    return true;
+  }
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((entry, index) => structurallyEqual(entry, right[index]))
+    );
+  }
+  if (left instanceof Uint8Array || right instanceof Uint8Array) {
+    return (
+      left instanceof Uint8Array &&
+      right instanceof Uint8Array &&
+      left.length === right.length &&
+      left.every((byte, index) => byte === right[index])
+    );
+  }
+  if (
+    left === null ||
+    right === null ||
+    typeof left !== 'object' ||
+    typeof right !== 'object'
+  ) {
+    return false;
+  }
+  if (
+    Object.getPrototypeOf(left) !== Object.prototype ||
+    Object.getPrototypeOf(right) !== Object.prototype
+  ) {
+    return false;
+  }
+  const leftRecord = left as Record<string, unknown>;
+  const rightRecord = right as Record<string, unknown>;
+  const leftKeys = Object.keys(leftRecord).sort();
+  const rightKeys = Object.keys(rightRecord).sort();
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every(
+      (key, index) =>
+        key === rightKeys[index] &&
+        structurallyEqual(leftRecord[key], rightRecord[key]),
+    )
+  );
 }

--- a/packages/agents-core/src/memory/session.ts
+++ b/packages/agents-core/src/memory/session.ts
@@ -98,6 +98,45 @@ export interface SessionHistoryRewriteAwareSession extends Session {
   applyHistoryMutations(args: SessionHistoryRewriteArgs): Promise<void> | void;
 }
 
+export type SessionHistoryAppendItemsTransaction = {
+  type: 'append_items';
+  items: AgentInputItem[];
+};
+
+export type SessionHistoryReplaceSuffixTransaction = {
+  type: 'replace_suffix';
+  expectedSuffix: AgentInputItem[];
+  replacement: AgentInputItem[];
+};
+
+export type SessionHistoryTransaction =
+  SessionHistoryAppendItemsTransaction | SessionHistoryReplaceSuffixTransaction;
+
+export type SessionHistoryTransactionArgs = {
+  /**
+   * A non-empty identifier that remains stable when this transaction is retried.
+   */
+  operationId: string;
+  transaction: SessionHistoryTransaction;
+};
+
+/**
+ * Optional session capability for atomic, idempotent history changes.
+ *
+ * Implementations must persist the operation identifier and history change atomically. Repeating
+ * an operation identifier with the same transaction must succeed without applying the transaction
+ * again. Reusing an operation identifier with a different transaction, or attempting to replace a
+ * suffix that does not match, must fail without changing history.
+ *
+ * Implementations may reject item metadata that cannot be snapshotted and compared deterministically,
+ * but must do so before changing history or recording the operation identifier.
+ */
+export interface SessionHistoryTransactionAwareSession extends Session {
+  applyHistoryTransaction(
+    args: SessionHistoryTransactionArgs,
+  ): Promise<void> | void;
+}
+
 /**
  * Session subtype that can run compaction logic after a completed turn is persisted.
  */
@@ -165,5 +204,15 @@ export function isSessionHistoryRewriteAwareSession(
     !!session &&
     typeof (session as SessionHistoryRewriteAwareSession)
       .applyHistoryMutations === 'function'
+  );
+}
+
+export function isSessionHistoryTransactionAwareSession(
+  session: Session | undefined,
+): session is SessionHistoryTransactionAwareSession {
+  return (
+    !!session &&
+    typeof (session as SessionHistoryTransactionAwareSession)
+      .applyHistoryTransaction === 'function'
   );
 }

--- a/packages/agents-core/test/index.test.ts
+++ b/packages/agents-core/test/index.test.ts
@@ -9,6 +9,8 @@ import type {
   AgentToolOptionsWithDefault,
   AgentToolOptionsWithParameters,
   RunHookEvents,
+  SessionHistoryTransactionArgs,
+  SessionHistoryTransactionAwareSession,
   ToolNameCollisionPolicy,
 } from '../src/index';
 import * as Sandbox from '../src/sandbox';
@@ -24,6 +26,9 @@ describe('index.ts', () => {
     expect(agent.name).toEqual('TestAgent');
     expect(typeof AgentsCore.setSensitiveDataLoggingEnabled).toBe('function');
     expect(typeof AgentsCore.RunCompactionItem).toBe('function');
+    expect(typeof AgentsCore.isSessionHistoryTransactionAwareSession).toBe(
+      'function',
+    );
   });
 
   test('exposes public lifecycle and agent tool types', () => {
@@ -36,6 +41,8 @@ describe('index.ts', () => {
       AgentToolOptionsWithDefault<undefined, TestAgent>,
       AgentToolOptionsWithParameters<undefined, TestAgent, typeof _parameters>,
       AgentTool<undefined, TestAgent, typeof _parameters>,
+      SessionHistoryTransactionArgs,
+      SessionHistoryTransactionAwareSession,
       ToolNameCollisionPolicy,
     ];
 

--- a/packages/agents-core/test/memorySession.test.ts
+++ b/packages/agents-core/test/memorySession.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from 'vitest';
 
 import { MemorySession } from '../src/memory/memorySession';
 import type { Logger } from '../src/logger';
+import type { SessionHistoryTransactionArgs } from '../src/memory/session';
 import type { AgentInputItem } from '../src/types';
 
 const createUserMessage = (text: string): AgentInputItem => ({
@@ -169,5 +170,445 @@ describe('MemorySession', () => {
       createUserMessage('start'),
       replacement,
     ]);
+  });
+
+  test('applies append transactions idempotently', async () => {
+    const session = new MemorySession({
+      sessionId: 'session-transaction-append',
+      initialItems: [createUserMessage('start')],
+    });
+    const appended = createUserMessage('committed');
+    const args = {
+      operationId: 'operation-append-1',
+      transaction: {
+        type: 'append_items' as const,
+        items: [appended],
+      },
+    };
+
+    await session.applyHistoryTransaction(args);
+    (appended as any).content = 'mutated';
+    await session.addItems([createUserMessage('later')]);
+    await session.applyHistoryTransaction({
+      operationId: args.operationId,
+      transaction: {
+        type: 'append_items',
+        items: [createUserMessage('committed')],
+      },
+    });
+
+    expect(await session.getItems()).toEqual([
+      createUserMessage('start'),
+      createUserMessage('committed'),
+      createUserMessage('later'),
+    ]);
+  });
+
+  test('replaces an exact history suffix idempotently', async () => {
+    const prefix = createUserMessage('start');
+    const expected = createUserMessage('blocked');
+    const replacement = createUserMessage('accepted');
+    const session = new MemorySession({
+      sessionId: 'session-transaction-replace',
+      initialItems: [prefix, expected],
+    });
+    const transaction = {
+      operationId: 'operation-replace-1',
+      transaction: {
+        type: 'replace_suffix' as const,
+        expectedSuffix: [expected],
+        replacement: [replacement],
+      },
+    };
+
+    await session.applyHistoryTransaction(transaction);
+    await session.addItems([createUserMessage('later')]);
+    await session.applyHistoryTransaction(transaction);
+
+    expect(await session.getItems()).toEqual([
+      prefix,
+      replacement,
+      createUserMessage('later'),
+    ]);
+  });
+
+  test('rejects a suffix mismatch without recording the operation', async () => {
+    const start = createUserMessage('start');
+    const session = new MemorySession({
+      sessionId: 'session-transaction-precondition',
+      initialItems: [start],
+    });
+
+    await expect(
+      session.applyHistoryTransaction({
+        operationId: 'operation-replace-after-conflict',
+        transaction: {
+          type: 'replace_suffix',
+          expectedSuffix: [createUserMessage('different')],
+          replacement: [createUserMessage('accepted')],
+        },
+      }),
+    ).rejects.toThrow('suffix no longer matches');
+    expect(await session.getItems()).toEqual([start]);
+
+    await session.applyHistoryTransaction({
+      operationId: 'operation-replace-after-conflict',
+      transaction: {
+        type: 'replace_suffix',
+        expectedSuffix: [start],
+        replacement: [createUserMessage('accepted')],
+      },
+    });
+    expect(await session.getItems()).toEqual([createUserMessage('accepted')]);
+  });
+
+  test('rejects operation ID reuse with different content', async () => {
+    const session = new MemorySession({
+      sessionId: 'session-transaction-operation-conflict',
+    });
+    await session.applyHistoryTransaction({
+      operationId: 'operation-conflict',
+      transaction: {
+        type: 'append_items',
+        items: [createUserMessage('first')],
+      },
+    });
+
+    await expect(
+      session.applyHistoryTransaction({
+        operationId: 'operation-conflict',
+        transaction: {
+          type: 'append_items',
+          items: [createUserMessage('second')],
+        },
+      }),
+    ).rejects.toThrow('already applied with a different transaction');
+    expect(await session.getItems()).toEqual([createUserMessage('first')]);
+  });
+
+  test('records an empty append transaction', async () => {
+    const session = new MemorySession({
+      sessionId: 'session-transaction-empty-append',
+    });
+    await session.applyHistoryTransaction({
+      operationId: 'operation-empty',
+      transaction: { type: 'append_items', items: [] },
+    });
+
+    await expect(
+      session.applyHistoryTransaction({
+        operationId: 'operation-empty',
+        transaction: {
+          type: 'append_items',
+          items: [createUserMessage('unexpected')],
+        },
+      }),
+    ).rejects.toThrow('already applied with a different transaction');
+    expect(await session.getItems()).toEqual([]);
+  });
+
+  test('resets transaction identities when the session is cleared', async () => {
+    const session = new MemorySession({
+      sessionId: 'session-transaction-reset',
+    });
+    const transaction = {
+      operationId: 'operation-after-reset',
+      transaction: {
+        type: 'append_items' as const,
+        items: [createUserMessage('committed')],
+      },
+    };
+
+    await session.applyHistoryTransaction(transaction);
+    await session.clearSession();
+    await session.applyHistoryTransaction(transaction);
+
+    expect(await session.getItems()).toEqual([createUserMessage('committed')]);
+  });
+
+  test('rejects invalid transaction input before mutation', async () => {
+    const start = createUserMessage('start');
+    const session = new MemorySession({
+      sessionId: 'session-transaction-invalid',
+      initialItems: [start],
+    });
+
+    await expect(
+      session.applyHistoryTransaction({
+        operationId: '   ',
+        transaction: { type: 'append_items', items: [] },
+      }),
+    ).rejects.toThrow('operationId must be a non-empty string');
+    await expect(
+      session.applyHistoryTransaction({
+        operationId: 'operation-unknown',
+        transaction: { type: 'unknown' } as any,
+      }),
+    ).rejects.toThrow('Unsupported session history transaction type');
+    await expect(
+      session.applyHistoryTransaction({
+        operationId: 'operation-missing-transaction',
+        transaction: null as any,
+      }),
+    ).rejects.toThrow('transaction must be an object');
+    await expect(
+      session.applyHistoryTransaction({
+        operationId: 'operation-invalid-item',
+        transaction: { type: 'append_items', items: [42] } as any,
+      }),
+    ).rejects.toThrow('items contain invalid or unsupported data');
+    expect(await session.getItems()).toEqual([start]);
+  });
+
+  test('rejects unsupported transaction metadata before mutation', async () => {
+    const start = createUserMessage('start');
+    const session = new MemorySession({
+      sessionId: 'session-transaction-unsupported',
+      initialItems: [start],
+    });
+    const withDate = createUserMessage('unsupported');
+    withDate.providerData = { timestamp: new Date(0) };
+    const withCycle = createUserMessage('cyclic');
+    const cycle: Record<string, unknown> = {};
+    cycle.self = cycle;
+    withCycle.providerData = cycle;
+    const withBigInt = createUserMessage('bigint');
+    withBigInt.providerData = { value: 42n };
+    const sparseItems = new Array<AgentInputItem>(1);
+
+    const unsupportedCases: Array<[string, AgentInputItem[]]> = [
+      ['operation-date', [withDate]],
+      ['operation-cycle', [withCycle]],
+      ['operation-bigint', [withBigInt]],
+      ['operation-sparse', sparseItems],
+    ];
+    for (const [operationId, items] of unsupportedCases) {
+      await expect(
+        session.applyHistoryTransaction({
+          operationId,
+          transaction: { type: 'append_items', items },
+        }),
+      ).rejects.toThrow('items contain invalid or unsupported data');
+    }
+
+    expect(await session.getItems()).toEqual([start]);
+  });
+
+  test('rejects non-enumerable metadata before mutation', async () => {
+    const start = createUserMessage('start');
+    const session = new MemorySession({
+      sessionId: 'session-transaction-non-enumerable',
+      initialItems: [start],
+    });
+    const item = createUserMessage('unsupported');
+    Object.defineProperty(item, 'providerData', {
+      enumerable: false,
+      value: { hidden: true },
+    });
+
+    await expect(
+      session.applyHistoryTransaction({
+        operationId: 'operation-non-enumerable',
+        transaction: { type: 'append_items', items: [item] },
+      }),
+    ).rejects.toThrow('items contain invalid or unsupported data');
+    expect(await session.getItems()).toEqual([start]);
+
+    const retryItem = createUserMessage('retry');
+    await session.applyHistoryTransaction({
+      operationId: 'operation-non-enumerable',
+      transaction: { type: 'append_items', items: [retryItem] },
+    });
+    expect(await session.getItems()).toEqual([start, retryItem]);
+  });
+
+  test('rejects unexpected transaction fields before mutation', async () => {
+    const start = createUserMessage('start');
+    const session = new MemorySession({
+      sessionId: 'session-transaction-unexpected-fields',
+      initialItems: [start],
+    });
+
+    await expect(
+      session.applyHistoryTransaction({
+        operationId: 'operation-unexpected-append-field',
+        transaction: {
+          type: 'append_items',
+          items: [createUserMessage('unsupported')],
+          metadata: { attempt: 1 },
+        } as any,
+      }),
+    ).rejects.toThrow('append transaction fields are invalid');
+    await expect(
+      session.applyHistoryTransaction({
+        operationId: 'operation-unexpected-suffix-field',
+        transaction: {
+          type: 'replace_suffix',
+          expectedSuffix: [start],
+          replacement: [createUserMessage('unsupported')],
+          metadata: { attempt: 1 },
+        } as any,
+      }),
+    ).rejects.toThrow('suffix transaction fields are invalid');
+    expect(await session.getItems()).toEqual([start]);
+
+    const retryItem = createUserMessage('retry');
+    await session.applyHistoryTransaction({
+      operationId: 'operation-unexpected-append-field',
+      transaction: { type: 'append_items', items: [retryItem] },
+    });
+    expect(await session.getItems()).toEqual([start, retryItem]);
+  });
+
+  test('does not expose transaction content in snapshot errors', async () => {
+    const session = new MemorySession({
+      sessionId: 'session-transaction-error-redaction',
+    });
+    const item = createUserMessage('unsupported');
+    item.providerData = { secret: Symbol('api-key-secret') };
+
+    let error: unknown;
+    try {
+      await session.applyHistoryTransaction({
+        operationId: 'operation-sensitive-invalid',
+        transaction: { type: 'append_items', items: [item] },
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(
+      'Session history transaction items contain invalid or unsupported data.',
+    );
+    expect((error as Error).message).not.toContain('api-key-secret');
+    expect(await session.getItems()).toEqual([]);
+  });
+
+  test('copies shared-backed binary transaction data', async () => {
+    const session = new MemorySession({
+      sessionId: 'session-transaction-shared-binary',
+    });
+    const sharedBytes = new Uint8Array(new SharedArrayBuffer(2));
+    sharedBytes.set([3, 7]);
+    const item = createUserMessage('binary');
+    item.providerData = { bytes: sharedBytes };
+
+    await session.applyHistoryTransaction({
+      operationId: 'operation-shared-binary',
+      transaction: { type: 'append_items', items: [item] },
+    });
+    sharedBytes[0] = 9;
+
+    const retryItem = createUserMessage('binary');
+    retryItem.providerData = { bytes: new Uint8Array([3, 7]) };
+    await session.applyHistoryTransaction({
+      operationId: 'operation-shared-binary',
+      transaction: { type: 'append_items', items: [retryItem] },
+    });
+
+    const [stored] = await session.getItems();
+    expect((stored.providerData?.bytes as Uint8Array)[0]).toBe(3);
+  });
+
+  test('canonicalizes ordinary object prototypes for retries and suffixes', async () => {
+    const session = new MemorySession({
+      sessionId: 'session-transaction-canonical-object',
+    });
+    const appended = createUserMessage('canonical');
+    appended.providerData = Object.assign(Object.create(null), {
+      source: 'provider',
+    });
+
+    await session.applyHistoryTransaction({
+      operationId: 'operation-canonical-append',
+      transaction: { type: 'append_items', items: [appended] },
+    });
+    const [roundTripped] = await session.getItems();
+    await session.applyHistoryTransaction({
+      operationId: 'operation-canonical-append',
+      transaction: { type: 'append_items', items: [roundTripped] },
+    });
+    await session.applyHistoryTransaction({
+      operationId: 'operation-canonical-replace',
+      transaction: {
+        type: 'replace_suffix',
+        expectedSuffix: [appended],
+        replacement: [createUserMessage('replaced')],
+      },
+    });
+
+    expect(await session.getItems()).toEqual([createUserMessage('replaced')]);
+  });
+
+  test('rejects unsupported cloned values without recording the operation', async () => {
+    const typedArrayItem = createUserMessage('unsupported-typed-array');
+    typedArrayItem.providerData = { values: new Uint16Array([300]) };
+    const proxiedItems = new Proxy([createUserMessage('proxied')], {});
+    const session = new MemorySession({
+      sessionId: 'session-transaction-unsupported-clones',
+    });
+
+    for (const items of [[typedArrayItem], proxiedItems]) {
+      await expect(
+        session.applyHistoryTransaction({
+          operationId: 'operation-rejected-clone',
+          transaction: { type: 'append_items', items },
+        }),
+      ).rejects.toThrow('items contain invalid or unsupported data');
+    }
+
+    await session.applyHistoryTransaction({
+      operationId: 'operation-rejected-clone',
+      transaction: {
+        type: 'append_items',
+        items: [createUserMessage('accepted-after-rejections')],
+      },
+    });
+    expect(await session.getItems()).toEqual([
+      createUserMessage('accepted-after-rejections'),
+    ]);
+  });
+
+  test('reads the transaction envelope once and redacts accessor errors', async () => {
+    const session = new MemorySession({
+      sessionId: 'session-transaction-envelope',
+    });
+    let operationIdReads = 0;
+    const args = {
+      transaction: {
+        type: 'append_items' as const,
+        items: [createUserMessage('once')],
+      },
+    } as SessionHistoryTransactionArgs;
+    Object.defineProperty(args, 'operationId', {
+      enumerable: true,
+      get: () => {
+        operationIdReads++;
+        return operationIdReads === 1 ? 'operation-read-once' : 'changed';
+      },
+    });
+
+    await session.applyHistoryTransaction(args);
+    expect(operationIdReads).toBe(1);
+    operationIdReads = 0;
+    await session.applyHistoryTransaction(args);
+    expect(operationIdReads).toBe(1);
+    expect(await session.getItems()).toEqual([createUserMessage('once')]);
+
+    const throwingArgs = {} as SessionHistoryTransactionArgs;
+    Object.defineProperty(throwingArgs, 'operationId', {
+      get: () => {
+        throw new Error('api-key-secret');
+      },
+    });
+    await expect(session.applyHistoryTransaction(throwingArgs)).rejects.toThrow(
+      'Session history transaction arguments are invalid.',
+    );
+    try {
+      await session.applyHistoryTransaction(throwingArgs);
+    } catch (error) {
+      expect((error as Error).message).not.toContain('api-key-secret');
+    }
   });
 });

--- a/packages/agents-core/test/session.test.ts
+++ b/packages/agents-core/test/session.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest';
 import {
   isOpenAIResponsesCompactionAwareSession,
   isSessionHistoryRewriteAwareSession,
+  isSessionHistoryTransactionAwareSession,
   type OpenAIResponsesCompactionAwareSession,
   type Session,
   type SessionHistoryRewriteAwareSession,
+  type SessionHistoryTransactionAwareSession,
 } from '../src/memory/session';
 
 function makeSession(overrides: Partial<Session> = {}): Session {
@@ -43,5 +45,18 @@ describe('session type guards', () => {
     expect(isSessionHistoryRewriteAwareSession(historyRewriteSession)).toBe(
       true,
     );
+  });
+
+  it('detects history transaction-aware sessions', () => {
+    const historyTransactionSession: SessionHistoryTransactionAwareSession = {
+      ...makeSession(),
+      applyHistoryTransaction: () => {},
+    };
+
+    expect(isSessionHistoryTransactionAwareSession(undefined)).toBe(false);
+    expect(isSessionHistoryTransactionAwareSession(makeSession())).toBe(false);
+    expect(
+      isSessionHistoryTransactionAwareSession(historyTransactionSession),
+    ).toBe(true);
   });
 });

--- a/packages/agents/test/index.test.ts
+++ b/packages/agents/test/index.test.ts
@@ -6,6 +6,8 @@ import type {
   AgentToolOptionsWithDefault,
   AgentToolOptionsWithParameters,
   RunHookEvents,
+  SessionHistoryTransactionArgs,
+  SessionHistoryTransactionAwareSession,
   ToolNameCollisionPolicy,
 } from '../src/index';
 import * as Sandbox from '../src/sandbox';
@@ -21,6 +23,9 @@ describe('Exports', () => {
     expect(agent.name).toBe('Test');
     expect(typeof Agents.setSensitiveDataLoggingEnabled).toBe('function');
     expect(typeof Agents.RunCompactionItem).toBe('function');
+    expect(typeof Agents.isSessionHistoryTransactionAwareSession).toBe(
+      'function',
+    );
   });
 
   test('lifecycle and agent tool types are out there', () => {
@@ -33,6 +38,8 @@ describe('Exports', () => {
       AgentToolOptionsWithDefault<undefined, TestAgent>,
       AgentToolOptionsWithParameters<undefined, TestAgent, typeof _parameters>,
       AgentTool<undefined, TestAgent, typeof _parameters>,
+      SessionHistoryTransactionArgs,
+      SessionHistoryTransactionAwareSession,
       ToolNameCollisionPolicy,
     ];
 


### PR DESCRIPTION
## Summary

- add an optional `SessionHistoryTransactionAwareSession` capability for idempotent history appends and exact-suffix replacements
- implement atomic transaction application and operation-ID deduplication in `MemorySession`
- validate deterministic transaction snapshots before mutation and reject unsupported values safely
- document the durable-backend requirements while leaving existing sessions and OpenAI Conversations behavior unchanged

## Context and rollout plan

The original work https://github.com/openai/openai-agents-js/pull/1568 attempted to bring the Python output-guardrail persistence fix to the JavaScript SDK. That investigation showed that preserving committed tool effects exactly once cannot be handled reliably as another guardrail-specific session write.

In particular, runner-level read-after-write recovery would mix storage consistency concerns with guardrail behavior and would still leave ambiguity around retries, partial writes, resumed runs, and exact suffix replacement. The review feedback exposed multiple variants of the same missing boundary, so the work is being split into two phases instead of continuing to extend the original guardrail patch.

This PR is phase one only. It introduces an optional storage-level transaction capability and provides `MemorySession` as its reference implementation. It does not change runner persistence, output-guardrail behavior, streaming behavior, compaction ownership, or the existing `Session` contract. Custom sessions that do not implement the capability continue to use the existing history APIs.

Phase two will rebuild blocked-output persistence on top of this capability. That follow-up will cover streaming and non-streaming runs, committed tool effects, replay without re-running side effects, and the provider-complete provenance needed by hosted tools, MCP calls, dynamic tool search, nested program calls, approvals, and reasoning association. OpenAI Conversations will remain server-owned unless its API provides equivalent transactional semantics.