### PR TITLE
fix(tracing): name task spans after Runner workflows

### DIFF
--- a/.changeset/neat-tasks-name-runs.md
+++ b/.changeset/neat-tasks-name-runs.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: name Runner task spans after the configured workflow

--- a/.changeset/neat-tasks-name-runs.md
+++ b/.changeset/neat-tasks-name-runs.md
@@ -2,4 +2,4 @@
 '@openai/agents-core': patch
 ---
 
-fix: name Runner task spans after the configured workflow
+fix: name Runner task spans after their configured or restored workflow

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -580,6 +580,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         input.setCurrentAgentSpan(undefined);
       }
     }
+    const taskSpanName = this.#getTaskSpanName(
+      input instanceof RunState ? input._trace?.name : undefined,
+    );
     const capturedInvocationTraceContext = getCurrentTraceContext();
     const invocationTraceContext = isNoopTrace(
       capturedInvocationTraceContext?.trace,
@@ -714,6 +717,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         const streamResult = await this.#runIndividualStream(
           agent,
           preparedInput,
+          taskSpanName,
           effectiveOptions,
           ensureStreamInputPersisted,
           sessionPersistence?.setPreparedTurnItems,
@@ -732,6 +736,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         agent,
         preparedInput,
         effectiveOptions,
+        taskSpanName,
         sessionPersistence?.setPreparedTurnItems,
         sessionPersistence?.recordTurnItems,
         preserveTurnPersistenceOnResume,
@@ -830,9 +835,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
   //  Internals
   // --------------------------------------------------------------
 
-  #getTaskSpanName(isResumedState: boolean): string {
+  #getTaskSpanName(restoredWorkflowName?: string): string {
     return (
-      (isResumedState ? getCurrentTrace()?.name : undefined) ??
+      this.traceOverrides.workflowName ??
+      restoredWorkflowName ??
       this.config.workflowName ??
       'Agent workflow'
     );
@@ -940,6 +946,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     startingAgent: TAgent,
     input: string | AgentInputItem[] | RunState<TContext, TAgent>,
     options: NonStreamRunOptions<TContext, TAgent>,
+    taskSpanName: string,
     sessionTurnInputUpdate?: (
       preparedInput: AgentInputItem[],
       processedInput: AgentInputItem[],
@@ -1038,7 +1045,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         isResumedState && state._currentStep?.type === 'next_step_interruption';
       const invocationSpans = useTaskAndTurnSpans
         ? startRunnerInvocationSpans({
-            name: this.#getTaskSpanName(isResumedState),
+            name: taskSpanName,
             agent: state._currentAgent,
             restoredAgentSpan: isResumedState
               ? state._currentAgentSpan
@@ -2227,6 +2234,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
   >(
     agent: TAgent,
     input: string | AgentInputItem[] | RunState<TContext, TAgent>,
+    taskSpanName: string,
     options?: StreamRunOptions<TContext, TAgent>,
     ensureStreamInputPersisted?: () => Promise<void>,
     sessionTurnInputUpdate?: (
@@ -2271,7 +2279,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         isResumedState && state._currentStep?.type === 'next_step_interruption';
       const invocationSpans = useTaskAndTurnSpans
         ? startRunnerInvocationSpans({
-            name: this.#getTaskSpanName(isResumedState),
+            name: taskSpanName,
             agent: state._currentAgent,
             restoredAgentSpan: isResumedState
               ? state._currentAgentSpan

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -830,6 +830,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
   //  Internals
   // --------------------------------------------------------------
 
+  #getTaskSpanName(): string {
+    return this.config.workflowName ?? 'Agent workflow';
+  }
+
   private readonly inputGuardrailDefs: InputGuardrailDefinition[];
 
   private readonly outputGuardrailDefs: OutputGuardrailDefinition<
@@ -1030,10 +1034,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         isResumedState && state._currentStep?.type === 'next_step_interruption';
       const invocationSpans = useTaskAndTurnSpans
         ? startRunnerInvocationSpans({
-            name:
-              getCurrentTrace()?.name ??
-              this.config.workflowName ??
-              'Agent workflow',
+            name: this.#getTaskSpanName(),
             agent: state._currentAgent,
             restoredAgentSpan: isResumedState
               ? state._currentAgentSpan
@@ -2266,10 +2267,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         isResumedState && state._currentStep?.type === 'next_step_interruption';
       const invocationSpans = useTaskAndTurnSpans
         ? startRunnerInvocationSpans({
-            name:
-              getCurrentTrace()?.name ??
-              this.config.workflowName ??
-              'Agent workflow',
+            name: this.#getTaskSpanName(),
             agent: state._currentAgent,
             restoredAgentSpan: isResumedState
               ? state._currentAgentSpan

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -830,8 +830,12 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
   //  Internals
   // --------------------------------------------------------------
 
-  #getTaskSpanName(): string {
-    return this.config.workflowName ?? 'Agent workflow';
+  #getTaskSpanName(isResumedState: boolean): string {
+    return (
+      (isResumedState ? getCurrentTrace()?.name : undefined) ??
+      this.config.workflowName ??
+      'Agent workflow'
+    );
   }
 
   private readonly inputGuardrailDefs: InputGuardrailDefinition[];
@@ -1034,7 +1038,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         isResumedState && state._currentStep?.type === 'next_step_interruption';
       const invocationSpans = useTaskAndTurnSpans
         ? startRunnerInvocationSpans({
-            name: this.#getTaskSpanName(),
+            name: this.#getTaskSpanName(isResumedState),
             agent: state._currentAgent,
             restoredAgentSpan: isResumedState
               ? state._currentAgentSpan
@@ -2267,7 +2271,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         isResumedState && state._currentStep?.type === 'next_step_interruption';
       const invocationSpans = useTaskAndTurnSpans
         ? startRunnerInvocationSpans({
-            name: this.#getTaskSpanName(),
+            name: this.#getTaskSpanName(isResumedState),
             agent: state._currentAgent,
             restoredAgentSpan: isResumedState
               ? state._currentAgentSpan

--- a/packages/agents-core/test/taskTurnTracing.test.ts
+++ b/packages/agents-core/test/taskTurnTracing.test.ts
@@ -635,6 +635,36 @@ describe('runner task and turn tracing', () => {
     });
   });
 
+  it.each([false, true])(
+    'uses the Runner workflow name for a task span inside an outer trace (stream=%s)',
+    async (stream) => {
+      const response = responseWithoutUsage();
+      const agent = new Agent({
+        name: 'Nested trace agent',
+        model: stream
+          ? new StreamingModel(response)
+          : new FakeModel([response]),
+      });
+      const runner = new Runner({ workflowName: 'Inner workflow' });
+      let outerTraceId: string | undefined;
+
+      await withTrace('Outer workflow', async (trace) => {
+        outerTraceId = trace.traceId;
+        if (stream) {
+          const result = await runner.run(agent, 'hello', { stream: true });
+          await result.completed;
+        } else {
+          await runner.run(agent, 'hello');
+        }
+      });
+
+      const taskSpan = spanOfType(processor, 'task');
+      expect(taskSpan.spanData.name).toBe('Inner workflow');
+      expect(taskSpan.traceId).toBe(outerTraceId);
+      expect(taskSpan.parentId).toBeNull();
+    },
+  );
+
   it('omits only task and turn spans when explicitly disabled', async () => {
     const agent = new Agent({
       name: 'Researcher',

--- a/packages/agents-core/test/taskTurnTracing.test.ts
+++ b/packages/agents-core/test/taskTurnTracing.test.ts
@@ -665,6 +665,57 @@ describe('runner task and turn tracing', () => {
     },
   );
 
+  it.each([false, true])(
+    'preserves a restored workflow name for resumed task spans (stream=%s)',
+    async (stream) => {
+      const approvalTool = tool({
+        name: 'restore_workflow_name_tool',
+        description: 'Requires approval.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'approved',
+      });
+      const responses = [
+        approvalResponse(approvalTool.name),
+        responseWithoutUsage(),
+      ];
+      const agent = new Agent({
+        name: 'Restored workflow agent',
+        model: stream
+          ? new StreamingModel(responses)
+          : new FakeModel(responses),
+        tools: [approvalTool],
+      });
+      const firstRunner = new Runner({ workflowName: 'Stored workflow' });
+      const first = stream
+        ? await firstRunner.run(agent, 'hello', { stream: true })
+        : await firstRunner.run(agent, 'hello');
+      if ('completed' in first) {
+        await first.completed;
+      }
+
+      const restoredState = await RunState.fromString(
+        agent,
+        first.state.toString(),
+      );
+      restoredState.approve(restoredState.getInterruptions()[0]);
+      const endedBeforeResume = processor.spansEnded.length;
+      const resumed = stream
+        ? await new Runner().run(agent, restoredState, { stream: true })
+        : await new Runner().run(agent, restoredState);
+      if ('completed' in resumed) {
+        await resumed.completed;
+      }
+
+      const taskSpan = processor.spansEnded
+        .slice(endedBeforeResume)
+        .find((span) => span.spanData.type === 'task');
+      expect(taskSpan?.spanData.name).toBe('Stored workflow');
+      expect(taskSpan?.traceId).toBe(restoredState._trace?.traceId);
+      expect(taskSpan?.parentId).toBeNull();
+    },
+  );
+
   it('omits only task and turn spans when explicitly disabled', async () => {
     const agent = new Agent({
       name: 'Researcher',

--- a/packages/agents-core/test/taskTurnTracing.test.ts
+++ b/packages/agents-core/test/taskTurnTracing.test.ts
@@ -716,6 +716,63 @@ describe('runner task and turn tracing', () => {
     },
   );
 
+  it.each([false, true])(
+    'uses the Runner workflow name when resumed state has no trace (stream=%s)',
+    async (stream) => {
+      const approvalTool = tool({
+        name: 'resume_without_trace_tool',
+        description: 'Requires approval.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'approved',
+      });
+      const responses = [
+        approvalResponse(approvalTool.name),
+        responseWithoutUsage(),
+      ];
+      const agent = new Agent({
+        name: 'Resume without trace agent',
+        model: stream
+          ? new StreamingModel(responses)
+          : new FakeModel(responses),
+        tools: [approvalTool],
+      });
+      const firstRunner = new Runner({ tracingDisabled: true });
+      const first = stream
+        ? await firstRunner.run(agent, 'hello', { stream: true })
+        : await firstRunner.run(agent, 'hello');
+      if ('completed' in first) {
+        await first.completed;
+      }
+
+      const restoredState = await RunState.fromString(
+        agent,
+        first.state.toString(),
+      );
+      restoredState.approve(restoredState.getInterruptions()[0]);
+      const endedBeforeResume = processor.spansEnded.length;
+      let outerTraceId: string | undefined;
+
+      await withTrace('Outer workflow', async (trace) => {
+        outerTraceId = trace.traceId;
+        const runner = new Runner({ workflowName: 'Inner workflow' });
+        const resumed = stream
+          ? await runner.run(agent, restoredState, { stream: true })
+          : await runner.run(agent, restoredState);
+        if ('completed' in resumed) {
+          await resumed.completed;
+        }
+      });
+
+      const taskSpan = processor.spansEnded
+        .slice(endedBeforeResume)
+        .find((span) => span.spanData.type === 'task');
+      expect(taskSpan?.spanData.name).toBe('Inner workflow');
+      expect(taskSpan?.traceId).toBe(outerTraceId);
+      expect(taskSpan?.parentId).toBeNull();
+    },
+  );
+
   it('omits only task and turn spans when explicitly disabled', async () => {
     const agent = new Agent({
       name: 'Researcher',


### PR DESCRIPTION
This pull request fixes Runner task spans inheriting the enclosing trace name instead of identifying their own Runner invocation. Both streaming and non-streaming task spans now use the Runner's configured `workflowName`, falling back to `"Agent workflow"`, while preserving the enclosing trace relationship and existing span lifecycle behavior.