### PR TITLE
fix(sandbox): enforce output token budgets

### DIFF
--- a/.changeset/tidy-sandbox-output-budget.md
+++ b/.changeset/tidy-sandbox-output-budget.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-extensions': patch
+---
+
+fix: enforce sandbox output budgets across core and extension providers

--- a/packages/agents-core/src/sandbox/shared/output.ts
+++ b/packages/agents-core/src/sandbox/shared/output.ts
@@ -18,19 +18,44 @@ export function truncateOutput(
 
   const originalTokenCount = approximateTokenCountFromBytes(outputBytes);
   const totalLines = countLines(output);
-  const marker = `...${approximateTokenCountFromBytes(outputBytes - maxBytes)} tokens truncated...`;
-  const preservedPrefix = getPreservedLeadingNotice(output);
-  const prefixBytes = byteLength(preservedPrefix);
-  const body = preservedPrefix ? output.slice(preservedPrefix.length) : output;
-  const bodyBudget = Math.max(0, maxBytes - prefixBytes);
-  const truncatedBody =
-    bodyBudget === 0
-      ? marker
-      : truncateWithByteBudget(body, bodyBudget, marker);
-  const truncated = `${preservedPrefix}${truncatedBody}`;
+  const fullMarker = formatTruncationMarker(originalTokenCount);
+  let lineCountPrefix = `Total output lines: ${totalLines}\n\n`;
+  let preservedNotice = getPreservedLeadingNotice(output);
+  const body = preservedNotice ? output.slice(preservedNotice.length) : output;
+
+  if (byteLength(preservedNotice) > maxBytes) {
+    preservedNotice = '';
+  }
+  if (
+    byteLength(lineCountPrefix) +
+      byteLength(preservedNotice) +
+      byteLength(fullMarker) >
+    maxBytes
+  ) {
+    lineCountPrefix = '';
+  }
+
+  const prefixBytes = byteLength(lineCountPrefix) + byteLength(preservedNotice);
+  if (prefixBytes + byteLength(fullMarker) > maxBytes) {
+    return {
+      text: `${lineCountPrefix}${preservedNotice}${truncateUtf8(
+        fullMarker,
+        maxBytes - prefixBytes,
+      )}`,
+      originalTokenCount,
+    };
+  }
+
+  const bodyBudget = maxBytes - prefixBytes - byteLength(fullMarker);
+  const truncatedBody = truncateWithByteBudget(body, bodyBudget);
+  const retainedBytes =
+    byteLength(preservedNotice) + truncatedBody.retainedBytes;
+  const marker = formatTruncationMarker(
+    approximateTokenCountFromBytes(outputBytes - retainedBytes),
+  );
 
   return {
-    text: `Total output lines: ${totalLines}\n\n${truncated}`,
+    text: `${lineCountPrefix}${preservedNotice}${truncatedBody.prefix}${marker}${truncatedBody.suffix}`,
     originalTokenCount,
   };
 }
@@ -69,8 +94,7 @@ export function elapsedSeconds(start: number): number {
 function truncateWithByteBudget(
   output: string,
   maxBytes: number,
-  marker: string,
-): string {
+): { prefix: string; suffix: string; retainedBytes: number } {
   const leftBudget = Math.floor(maxBytes / 2);
   const rightBudget = maxBytes - leftBudget;
   const totalBytes = byteLength(output);
@@ -108,7 +132,29 @@ function truncateWithByteBudget(
   const bytes = new TextEncoder().encode(output);
   const prefix = new TextDecoder().decode(bytes.slice(0, prefixEnd));
   const suffix = new TextDecoder().decode(bytes.slice(suffixStart));
-  return `${prefix}${marker}${suffix}`;
+  return {
+    prefix,
+    suffix,
+    retainedBytes: prefixEnd + totalBytes - suffixStart,
+  };
+}
+
+function formatTruncationMarker(tokens: number): string {
+  return `...${tokens} tokens truncated...`;
+}
+
+function truncateUtf8(output: string, maxBytes: number): string {
+  let byteIndex = 0;
+  let stringIndex = 0;
+  for (const character of output) {
+    const characterBytes = byteLength(character);
+    if (byteIndex + characterBytes > maxBytes) {
+      break;
+    }
+    byteIndex += characterBytes;
+    stringIndex += character.length;
+  }
+  return output.slice(0, stringIndex);
 }
 
 function getPreservedLeadingNotice(output: string): string {

--- a/packages/agents-core/test/sandboxShared.test.ts
+++ b/packages/agents-core/test/sandboxShared.test.ts
@@ -74,23 +74,75 @@ async function loadDefaultLocalSnapshotBaseDir(args: {
 }
 
 describe('sandbox shared helpers', () => {
-  it('truncates output with a byte budget and keeps head and tail context', () => {
+  it('includes truncation metadata within the output byte budget', () => {
     const result = truncateOutput('0123456789abcdef', 2);
 
     expect(result).toEqual({
-      text: 'Total output lines: 1\n\n0123...2 tokens truncated...cdef',
+      text: '...4 tok',
       originalTokenCount: 4,
     });
+    expect(new TextEncoder().encode(result.text)).toHaveLength(8);
+  });
+
+  it.each([
+    { maxOutputTokens: 0, expected: '' },
+    { maxOutputTokens: 1, expected: '...4' },
+  ])(
+    'does not exceed a $maxOutputTokens-token tiny output budget',
+    ({ maxOutputTokens, expected }) => {
+      const result = truncateOutput('0123456789abcdef', maxOutputTokens);
+
+      expect(result).toEqual({
+        text: expected,
+        originalTokenCount: 4,
+      });
+      expect(
+        new TextEncoder().encode(result.text).byteLength,
+      ).toBeLessThanOrEqual(maxOutputTokens * 4);
+    },
+  );
+
+  it('keeps line metadata plus head and tail context when space permits', () => {
+    const output = '0123456789'.repeat(20);
+    const result = truncateOutput(output, 32);
+
+    expect(result.text).toMatch(/^Total output lines: 1\n\n012345/u);
+    expect(result.text).toContain('tokens truncated');
+    expect(result.text).toMatch(/456789$/u);
+    expect(
+      new TextEncoder().encode(result.text).byteLength,
+    ).toBeLessThanOrEqual(128);
+  });
+
+  it('keeps multibyte output valid and within the byte budget', () => {
+    const result = truncateOutput('🙂漢字'.repeat(20), 32);
+
+    expect(result.text).not.toContain('\uFFFD');
+    expect(result.text).toContain('tokens truncated');
+    expect(
+      new TextEncoder().encode(result.text).byteLength,
+    ).toBeLessThanOrEqual(128);
   });
 
   it('preserves active process truncation notices when applying output budgets', () => {
     const result = truncateOutput(
-      '[...1200 characters truncated from process output...]\n0123456789abcdef',
-      2,
+      `[...1200 characters truncated from process output...]\n${'0123456789'.repeat(1000)}`,
+      20,
     );
 
     expect(result.text).toContain('characters truncated from process output');
-    expect(result.text).toContain('tokens truncated');
+    expect(
+      new TextEncoder().encode(result.text).byteLength,
+    ).toBeLessThanOrEqual(80);
+  });
+
+  it('leaves unlimited and already-fitting output unchanged', () => {
+    expect(truncateOutput('short\noutput')).toEqual({
+      text: 'short\noutput',
+    });
+    expect(truncateOutput('short\noutput', 4)).toEqual({
+      text: 'short\noutput',
+    });
   });
 
   it('sniffs image media types from bytes and falls back to path extensions', () => {

--- a/packages/agents-extensions/test/sandbox/shared.test.ts
+++ b/packages/agents-extensions/test/sandbox/shared.test.ts
@@ -3796,7 +3796,7 @@ describe('remote sandbox path helpers', () => {
 
   test('formats command output and truncates token output', () => {
     expect(truncateOutput('0123456789abcdef', 1)).toEqual({
-      text: 'Total output lines: 1\n\n01...3 tokens truncated...ef',
+      text: '...4',
       originalTokenCount: 4,
     });
     expect(truncateOutput('one two', 3)).toEqual({ text: 'one two' });


### PR DESCRIPTION
This pull request fixes sandbox output truncation so the complete returned text stays within the approximate token budget, including line-count metadata, preserved process-truncation notices, and truncation markers. It preserves valid UTF-8 and useful head/tail context when space permits, while safely shortening or omitting metadata for zero and tiny budgets. The shared core helper remains the single source of truth for core and extension sandbox providers.