### PR TITLE
fix(extensions): preserve streamed reasoning provider metadata

### DIFF
--- a/.changeset/bright-reasoning-keeps-metadata.md
+++ b/.changeset/bright-reasoning-keeps-metadata.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: preserve streamed reasoning provider metadata across events

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -1626,6 +1626,26 @@ function mergeProviderData(
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
+function mergeProviderMetadata(
+  base: Record<string, any> | undefined,
+  source: Record<string, any> | undefined,
+): Record<string, any> | undefined {
+  const merged = mergeProviderData(base, source);
+  if (!merged || !isRecord(base) || !isRecord(source)) {
+    return merged;
+  }
+
+  for (const provider of Object.keys(source)) {
+    if (isRecord(base[provider]) && isRecord(source[provider])) {
+      merged[provider] = {
+        ...base[provider],
+        ...source[provider],
+      };
+    }
+  }
+  return merged;
+}
+
 function getHostedToolArgs(providerData: unknown): Record<string, any> {
   if (!isRecord(providerData)) {
     return {};
@@ -2275,13 +2295,27 @@ export class AiSdkModel implements Model {
 
       // State for tracking reasoning blocks (for Anthropic extended thinking):
       // Track reasoning deltas so we can preserve Anthropic signatures even when text is redacted.
-      const reasoningBlocks: Record<
+      const reasoningBlocks = new Map<
         string,
         {
           text: string;
           providerMetadata?: Record<string, any>;
         }
-      > = {};
+      >();
+      const getReasoningBlock = (
+        reasoningId: string,
+        providerMetadata: Record<string, any> | undefined,
+      ) => {
+        const reasoningBlock = reasoningBlocks.get(reasoningId) ?? {
+          text: '',
+        };
+        reasoningBlock.providerMetadata = mergeProviderMetadata(
+          reasoningBlock.providerMetadata,
+          providerMetadata,
+        );
+        reasoningBlocks.set(reasoningId, reasoningBlock);
+        return reasoningBlock;
+      };
 
       for await (const part of stream) {
         if (!started) {
@@ -2313,35 +2347,23 @@ export class AiSdkModel implements Model {
           case 'reasoning-start': {
             // Start tracking a new reasoning block
             const reasoningId = (part as any).id ?? 'default';
-            reasoningBlocks[reasoningId] = {
-              text: '',
-              providerMetadata: (part as any).providerMetadata,
-            };
+            getReasoningBlock(reasoningId, (part as any).providerMetadata);
             break;
           }
           case 'reasoning-delta': {
             // Accumulate reasoning text
             const reasoningId = (part as any).id ?? 'default';
-            if (!reasoningBlocks[reasoningId]) {
-              reasoningBlocks[reasoningId] = {
-                text: '',
-                providerMetadata: (part as any).providerMetadata,
-              };
-            }
-            reasoningBlocks[reasoningId].text += (part as any).delta ?? '';
+            const reasoningBlock = getReasoningBlock(
+              reasoningId,
+              (part as any).providerMetadata,
+            );
+            reasoningBlock.text += (part as any).delta ?? '';
             break;
           }
           case 'reasoning-end': {
             // Capture final provider metadata (may contain signature)
             const reasoningId = (part as any).id ?? 'default';
-            if (
-              reasoningBlocks[reasoningId] &&
-              (part as any).providerMetadata
-            ) {
-              reasoningBlocks[reasoningId].providerMetadata = (
-                part as any
-              ).providerMetadata;
-            }
+            getReasoningBlock(reasoningId, (part as any).providerMetadata);
             break;
           }
           case 'tool-call': {
@@ -2425,9 +2447,7 @@ export class AiSdkModel implements Model {
 
       // Add reasoning items FIRST (required by Anthropic: thinking blocks must precede tool_use blocks)
       // Emit reasoning item even when text is empty to preserve signature in providerData for redacted thinking streams
-      for (const [reasoningId, reasoningBlock] of Object.entries(
-        reasoningBlocks,
-      )) {
+      for (const [reasoningId, reasoningBlock] of reasoningBlocks) {
         if (reasoningBlock.text || reasoningBlock.providerMetadata) {
           outputs.push({
             type: 'reasoning',

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -81,6 +81,40 @@ function partsStream(parts: any[]): ReadableStream<any> {
   );
 }
 
+async function collectStreamResponse(
+  parts: any[],
+  specificationVersion = 'v2',
+) {
+  const languageModel = stubModel(
+    {
+      async doStream() {
+        return { stream: partsStream(parts) } as any;
+      },
+    },
+    { specificationVersion },
+  );
+  const model = new AiSdkModel(languageModel);
+  let response: any;
+
+  for await (const event of model.getStreamedResponse({
+    input: 'test',
+    tools: [],
+    handoffs: [],
+    modelSettings: {},
+    outputType: 'text',
+    tracing: false,
+  } as any)) {
+    if (event.type === 'response_done') {
+      response = event.response;
+    }
+  }
+
+  if (!response) {
+    throw new Error('Expected a completed streaming response.');
+  }
+  return { languageModel, response };
+}
+
 class RecordingTracingProcessor implements TracingProcessor {
   readonly spansEnded: Span<any>[] = [];
 
@@ -4694,6 +4728,298 @@ describe('Extended thinking / Reasoning support', () => {
         name: 'search',
       });
     });
+
+    test('preserves Anthropic signatures from empty reasoning deltas', async () => {
+      const { response } = await collectStreamResponse([
+        { type: 'reasoning-start', id: '0' },
+        { type: 'reasoning-delta', id: '0', delta: 'Hidden thought.' },
+        {
+          type: 'reasoning-delta',
+          id: '0',
+          delta: '',
+          providerMetadata: {
+            anthropic: { signature: 'sig_from_signature_delta' },
+          },
+        },
+        { type: 'reasoning-end', id: '0' },
+        { type: 'response-metadata', id: 'resp-signature' },
+      ]);
+
+      expect(response.output).toEqual([
+        {
+          type: 'reasoning',
+          id: '0',
+          content: [{ type: 'input_text', text: 'Hidden thought.' }],
+          rawContent: [{ type: 'reasoning_text', text: 'Hidden thought.' }],
+          providerData: {
+            model: 'stub:m',
+            anthropic: { signature: 'sig_from_signature_delta' },
+            responseId: 'resp-signature',
+          },
+        },
+      ]);
+    });
+
+    test('preserves Anthropic redacted data from reasoning start', async () => {
+      const { response } = await collectStreamResponse([
+        {
+          type: 'reasoning-start',
+          id: '0',
+          providerMetadata: {
+            anthropic: { redactedData: 'redacted_thinking_data' },
+          },
+        },
+        { type: 'reasoning-end', id: '0' },
+      ]);
+
+      expect(response.output[0]).toMatchObject({
+        type: 'reasoning',
+        id: '0',
+        content: [{ type: 'input_text', text: '' }],
+        providerData: {
+          model: 'stub:m',
+          anthropic: { redactedData: 'redacted_thinking_data' },
+        },
+      });
+    });
+
+    test.each(['v2', 'v3', 'v4'])(
+      'merges reasoning metadata from start, delta, and end for %s',
+      async (specificationVersion) => {
+        const { response } = await collectStreamResponse(
+          [
+            {
+              type: 'reasoning-start',
+              id: '0',
+              providerMetadata: {
+                test: { start: true, conflict: 'start' },
+              },
+            },
+            {
+              type: 'reasoning-delta',
+              id: '0',
+              delta: '',
+              providerMetadata: {
+                test: { delta: true, conflict: 'delta' },
+              },
+            },
+            {
+              type: 'reasoning-delta',
+              id: '0',
+              delta: '',
+              providerMetadata: {
+                test: { secondDelta: true },
+              },
+            },
+            {
+              type: 'reasoning-end',
+              id: '0',
+              providerMetadata: {
+                test: { end: true, conflict: 'end' },
+              },
+            },
+          ],
+          specificationVersion,
+        );
+
+        expect(response.output[0].providerData).toEqual({
+          model: 'stub:m',
+          test: {
+            start: true,
+            delta: true,
+            secondDelta: true,
+            end: true,
+            conflict: 'end',
+          },
+        });
+      },
+    );
+
+    test('preserves empty provider metadata namespaces', async () => {
+      const { languageModel, response } = await collectStreamResponse([
+        {
+          type: 'reasoning-start',
+          id: '0',
+          providerMetadata: { vendor: {} },
+        },
+        {
+          type: 'reasoning-delta',
+          id: '0',
+          delta: '',
+          providerMetadata: { vendor: {} },
+        },
+        { type: 'reasoning-end', id: '0' },
+      ]);
+
+      expect(response.output[0].providerData).toEqual({
+        model: 'stub:m',
+        vendor: {},
+      });
+      expect(itemsToLanguageV2Messages(languageModel, response.output)).toEqual(
+        [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'reasoning',
+                text: '',
+                providerOptions: { vendor: {} },
+              },
+            ],
+            providerOptions: { vendor: {} },
+          },
+        ],
+      );
+    });
+
+    test('preserves ordered metadata for multiple reasoning blocks', async () => {
+      const { response } = await collectStreamResponse([
+        {
+          type: 'reasoning-start',
+          id: '10',
+          providerMetadata: {
+            anthropic: { redactedData: 'redacted_block' },
+          },
+        },
+        { type: 'reasoning-end', id: '10' },
+        { type: 'reasoning-start', id: '2' },
+        { type: 'reasoning-delta', id: '2', delta: 'Visible thought.' },
+        {
+          type: 'reasoning-delta',
+          id: '2',
+          delta: '',
+          providerMetadata: { anthropic: { signature: 'signed_block' } },
+        },
+        { type: 'reasoning-end', id: '2' },
+      ]);
+
+      expect(response.output).toMatchObject([
+        {
+          type: 'reasoning',
+          id: '10',
+          content: [{ type: 'input_text', text: '' }],
+          providerData: {
+            anthropic: { redactedData: 'redacted_block' },
+          },
+        },
+        {
+          type: 'reasoning',
+          id: '2',
+          content: [{ type: 'input_text', text: 'Visible thought.' }],
+          providerData: {
+            anthropic: { signature: 'signed_block' },
+          },
+        },
+      ]);
+    });
+
+    test('replays merged reasoning metadata through AI SDK messages', async () => {
+      const { languageModel, response } = await collectStreamResponse([
+        {
+          type: 'reasoning-start',
+          id: '0',
+          providerMetadata: {
+            anthropic: { redactedData: 'redacted_thinking_data' },
+          },
+        },
+        { type: 'reasoning-end', id: '0' },
+        { type: 'reasoning-start', id: '1' },
+        { type: 'reasoning-delta', id: '1', delta: 'Hidden thought.' },
+        {
+          type: 'reasoning-delta',
+          id: '1',
+          delta: '',
+          providerMetadata: {
+            anthropic: { signature: 'sig_from_signature_delta' },
+          },
+        },
+        { type: 'reasoning-end', id: '1' },
+      ]);
+
+      const messages = itemsToLanguageV2Messages(
+        languageModel,
+        response.output,
+      );
+      expect(messages).toEqual([
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'reasoning',
+              text: '',
+              providerOptions: {
+                anthropic: {
+                  redactedData: 'redacted_thinking_data',
+                },
+              },
+            },
+          ],
+          providerOptions: {
+            anthropic: {
+              redactedData: 'redacted_thinking_data',
+            },
+          },
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'reasoning',
+              text: 'Hidden thought.',
+              providerOptions: {
+                anthropic: { signature: 'sig_from_signature_delta' },
+              },
+            },
+          ],
+          providerOptions: {
+            anthropic: { signature: 'sig_from_signature_delta' },
+          },
+        },
+      ]);
+    });
+
+    test.each(['v3', 'v4'])(
+      'replays merged reasoning metadata through AI SDK %s messages',
+      async (specificationVersion) => {
+        const { languageModel, response } = await collectStreamResponse(
+          [
+            { type: 'reasoning-start', id: '0' },
+            {
+              type: 'reasoning-delta',
+              id: '0',
+              delta: '',
+              providerMetadata: {
+                anthropic: { signature: 'sig_from_signature_delta' },
+              },
+            },
+            { type: 'reasoning-end', id: '0' },
+          ],
+          specificationVersion,
+        );
+
+        const messages = itemsToLanguageV2Messages(
+          languageModel,
+          response.output,
+        );
+        expect(messages).toEqual([
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'reasoning',
+                text: '',
+                providerOptions: {
+                  anthropic: { signature: 'sig_from_signature_delta' },
+                },
+              },
+            ],
+            providerOptions: {
+              anthropic: { signature: 'sig_from_signature_delta' },
+            },
+          },
+        ]);
+      },
+    );
 
     test('handles multiple reasoning blocks in streaming', async () => {
       const parts = [


### PR DESCRIPTION
This pull request fixes the AI SDK streaming adapter dropping provider metadata emitted after `reasoning-start`. It merges metadata from every normalized reasoning event per block, preserves block insertion order and empty provider namespaces, and keeps Anthropic signatures and redacted data attached through replay without changing normalized item shapes or adding provider-specific raw schemas.