### PR TITLE
fix: preserve repeated session history provenance

### DIFF
--- a/.changeset/fix-repeated-history-provenance.md
+++ b/.changeset/fix-repeated-history-provenance.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: preserve repeated session history provenance

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -821,6 +821,9 @@ export async function prepareInputItemsWithSession(
 
   const historySnapshot = history.slice();
   const newInputSnapshot = newInputItems.slice();
+  // Keep the original history objects alive so their identities remain valid even if the
+  // callback removes them from the list it receives.
+  const originalHistoryItems = new Set(historySnapshot);
 
   const combined = await sessionInputCallback(history, newInputItems);
   if (!Array.isArray(combined)) {
@@ -848,6 +851,17 @@ export async function prepareInputItemsWithSession(
       reasoningItemIdPolicy,
     );
     const newInputKey = getAgentInputItemKey(item);
+    if (originalHistoryItems.has(item)) {
+      if (removeAgentInputFromPool(historyRefs, item)) {
+        decrementCount(historyCounts, historyKey);
+      }
+      if (removeAgentInputFromPool(newInputRefs, item)) {
+        decrementCount(newInputCounts, newInputKey);
+      }
+      historyIndexes.add(index);
+      continue;
+    }
+
     if (removeAgentInputFromPool(newInputRefs, item)) {
       decrementCount(newInputCounts, newInputKey);
       appended.push(item);

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -5057,6 +5057,60 @@ describe('Runner.run', () => {
         expect(getFirstTextContent(persistedUsers[0])).toBe('Fresh input');
       });
 
+      it.each([
+        { name: 'run', stream: false },
+        { name: 'stream', stream: true },
+      ])(
+        'does not grow session history from repeated references across $name turns',
+        async ({ stream }) => {
+          const model = stream
+            ? new StreamingModel(fakeModelMessage('assistant'))
+            : new FakeModel(
+                Array.from({ length: 3 }, (_, turn) => ({
+                  ...TEST_MODEL_RESPONSE_BASIC,
+                  output: [fakeModelMessage(`assistant ${turn}`)],
+                })),
+              );
+          const agent = new Agent({ name: 'RepeatedHistorySession', model });
+          const session = new MemorySession();
+          const sessionInputCallback = (
+            history: AgentInputItem[],
+            newItems: AgentInputItem[],
+          ) => {
+            if (history.length === 0) {
+              return newItems;
+            }
+            return history.concat(history[0], newItems);
+          };
+
+          for (let turn = 0; turn < 3; turn += 1) {
+            if (stream) {
+              const result = await run(agent, `user ${turn}`, {
+                session,
+                sessionInputCallback,
+                stream: true,
+              });
+              await result.completed;
+            } else {
+              await run(agent, `user ${turn}`, {
+                session,
+                sessionInputCallback,
+              });
+            }
+          }
+
+          const storedItems = await session.getItems();
+          const storedUserMessages = storedItems.filter(
+            (item): item is protocol.UserMessageItem =>
+              item.type === 'message' && 'role' in item && item.role === 'user',
+          );
+          expect(
+            storedUserMessages.map((item) => getFirstTextContent(item)),
+          ).toEqual(['user 0', 'user 1', 'user 2']);
+          expect(storedItems).toHaveLength(6);
+        },
+      );
+
       it('persists reordered new items ahead of matching history', async () => {
         const model = new RecordingModel([
           {

--- a/packages/agents-core/test/runner/sessionPersistence.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.test.ts
@@ -1827,6 +1827,168 @@ describe('prepareInputItemsWithSession', () => {
     expect(sessionItems[0]).toBe(newItem);
   });
 
+  it('does not persist a repeated original history reference', async () => {
+    const historyItem: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'history',
+    };
+    const newItem: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'new',
+    };
+    const session = new StubSession([historyItem]);
+
+    const result = await prepareInputItemsWithSession(
+      [newItem],
+      session,
+      (history, newItems) => [history[0], history[0], newItems[0]],
+    );
+
+    expect(result.preparedInput).toEqual([historyItem, historyItem, newItem]);
+    expect(result.sessionItems).toEqual([newItem]);
+  });
+
+  it('keeps equal-content new input when history is repeated', async () => {
+    const historyItem: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'same',
+    };
+    const newItem: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'same',
+    };
+    const session = new StubSession([historyItem]);
+
+    const result = await prepareInputItemsWithSession(
+      [newItem],
+      session,
+      (history, newItems) => [history[0], history[0], newItems[0]],
+    );
+
+    expect(result.preparedInput).toEqual([historyItem, historyItem, newItem]);
+    expect(result.sessionItems).toEqual([newItem]);
+    expect(result.sessionItems?.[0]).toBe(newItem);
+  });
+
+  it('persists a clone after shared history and new-input identity is consumed', async () => {
+    const sharedItem: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'shared',
+    };
+    const session = new StubSession([sharedItem]);
+    let reconstructed: AgentInputItem | undefined;
+
+    const result = await prepareInputItemsWithSession(
+      [sharedItem],
+      session,
+      (history) => {
+        reconstructed = structuredClone(history[0]);
+        return [history[0], history[0], reconstructed];
+      },
+    );
+
+    expect(result.preparedInput).toEqual([
+      sharedItem,
+      sharedItem,
+      reconstructed,
+    ]);
+    expect(result.sessionItems).toEqual([reconstructed]);
+  });
+
+  it('preserves history provenance after async pop, move, and repeat', async () => {
+    const historyItem: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'history',
+    };
+    const newItem: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'new',
+    };
+    const session = new StubSession([historyItem]);
+
+    const result = await prepareInputItemsWithSession(
+      [newItem],
+      session,
+      async (history, newItems) => {
+        await Promise.resolve();
+        const moved = history.pop();
+        if (!moved) {
+          throw new Error('Expected history item.');
+        }
+        newItems.unshift(moved);
+        return [...newItems, moved];
+      },
+    );
+
+    expect(result.preparedInput).toEqual([historyItem, newItem, historyItem]);
+    expect(result.sessionItems).toEqual([newItem]);
+  });
+
+  it('persists a replacement history object as injected input', async () => {
+    const historyItem: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'history',
+    };
+    const replacement: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'summary',
+    };
+    const newItem: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'new',
+    };
+    const session = new StubSession([historyItem]);
+
+    const result = await prepareInputItemsWithSession(
+      [newItem],
+      session,
+      (history, newItems) => {
+        history[0] = replacement;
+        return history.concat(newItems);
+      },
+    );
+
+    expect(result.preparedInput).toEqual([replacement, newItem]);
+    expect(result.sessionItems).toEqual([replacement, newItem]);
+  });
+
+  it('persists an extra reconstructed history copy as injected input', async () => {
+    const historyItem: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'history',
+    };
+    const newItem: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'new',
+    };
+    const session = new StubSession([historyItem]);
+    let reconstructed: AgentInputItem | undefined;
+
+    const result = await prepareInputItemsWithSession(
+      [newItem],
+      session,
+      (history, newItems) => {
+        reconstructed = structuredClone(history[0]);
+        return [history[0], reconstructed, newItems[0]];
+      },
+    );
+
+    expect(result.preparedInput).toEqual([historyItem, reconstructed, newItem]);
+    expect(result.sessionItems).toEqual([reconstructed, newItem]);
+  });
+
   it('respects callbacks that intentionally drop new inputs', async () => {
     const historyItem: AgentInputItem = {
       type: 'message',


### PR DESCRIPTION
This pull request fixes session history growth when a `sessionInputCallback` returns the same original history object more than once. It preserves history ownership by object identity across callback mutations while continuing to persist genuinely new, replacement, and reconstructed items after available history occurrences are exhausted.

The change keeps provenance handling inside the existing session input preparation pipeline and preserves callback ordering, asynchronous callbacks, session normalization, compaction, server-managed conversations, and streaming behavior.