### PR TITLE
fix(core): preserve completed tool guardrail results

### DIFF
--- a/.changeset/curly-errors-keep-state.md
+++ b/.changeset/curly-errors-keep-state.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: preserve completed tool guardrail results on run errors

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -118,7 +118,10 @@ import type {
   CallModelInputFilter,
   PreparedModelCall,
 } from './runner/types';
-import { tryHandleRunError } from './runner/errorHandlers';
+import {
+  attachRunStateToError,
+  tryHandleRunError,
+} from './runner/errorHandlers';
 import type { RunErrorHandlers } from './runner/errorHandlers';
 import {
   finalizeSandboxRuntime,
@@ -1393,6 +1396,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         }
       } catch (err) {
         state._currentTurnInProgress = false;
+        attachRunStateToError(err, state);
         const handledResult = await tryHandleRunError({
           error: err,
           state,
@@ -2114,6 +2118,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       }
     } catch (error) {
       result.state._currentTurnInProgress = false;
+      attachRunStateToError(error, result.state);
       suppressStreamInputPersistence =
         error instanceof CompactionItemValidationError;
       if (guardrailTracker.pending) {

--- a/packages/agents-core/src/runner/errorHandlers.ts
+++ b/packages/agents-core/src/runner/errorHandlers.ts
@@ -3,6 +3,9 @@ import {
   MaxTurnsExceededError,
   ModelBehaviorError,
   ModelRefusalError,
+  ToolCallError,
+  ToolInputGuardrailTripwireTriggered,
+  ToolOutputGuardrailTripwireTriggered,
   UserError,
 } from '../errors';
 import { assistant } from '../helpers/message';
@@ -98,6 +101,25 @@ type ResolveRunErrorHandlerArgs<TContext, TAgent extends Agent<any, any>> = {
   errorHandlers?: RunErrorHandlers<TContext, TAgent>;
   context: RunContext<TContext>;
   runData: RunErrorData<TContext, TAgent>;
+};
+
+/**
+ * Attaches the active run state to nested tool guardrail tripwire errors without replacing them.
+ */
+export const attachRunStateToError = <TContext, TAgent extends Agent<any, any>>(
+  error: unknown,
+  state: RunState<TContext, TAgent>,
+): void => {
+  if (!(error instanceof ToolCallError)) {
+    return;
+  }
+
+  if (
+    error.error instanceof ToolInputGuardrailTripwireTriggered ||
+    error.error instanceof ToolOutputGuardrailTripwireTriggered
+  ) {
+    error.error.state ??= state;
+  }
 };
 
 const buildRunData = <TContext, TAgent extends Agent<any, any>>(

--- a/packages/agents-core/test/run.toolGuardrailState.test.ts
+++ b/packages/agents-core/test/run.toolGuardrailState.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import {
+  Agent,
+  MaxTurnsExceededError,
+  Model,
+  ModelRequest,
+  ModelResponse,
+  RunContext,
+  RunState,
+  StreamEvent,
+  ToolCallError,
+  ToolGuardrailFunctionOutputFactory,
+  ToolInputGuardrailTripwireTriggered,
+  ToolOutputGuardrailTripwireTriggered,
+  Usage,
+  defineToolInputGuardrail,
+  defineToolOutputGuardrail,
+  run,
+  runToolInputGuardrails,
+  runToolOutputGuardrails,
+  tool,
+} from '../src';
+import { attachRunStateToError } from '../src/runner/errorHandlers';
+import * as protocol from '../src/types/protocol';
+
+type GuardrailKind = 'input' | 'output';
+
+class QueuedToolCallModel implements Model {
+  readonly #outputs: ModelResponse['output'][];
+  #responseCount = 0;
+
+  constructor(turns: number) {
+    this.#outputs = Array.from({ length: turns }, (_, index) => [
+      functionToolCall(index + 1),
+    ]);
+  }
+
+  async getResponse(_request: ModelRequest): Promise<ModelResponse> {
+    return this.#nextResponse();
+  }
+
+  async *getStreamedResponse(
+    _request: ModelRequest,
+  ): AsyncIterable<StreamEvent> {
+    const response = this.#nextResponse();
+    yield {
+      type: 'response_done',
+      response: {
+        id: response.responseId,
+        usage: {
+          requests: response.usage.requests,
+          inputTokens: response.usage.inputTokens,
+          outputTokens: response.usage.outputTokens,
+          totalTokens: response.usage.totalTokens,
+        },
+        output: response.output,
+      },
+    } as StreamEvent;
+  }
+
+  #nextResponse(): ModelResponse {
+    const output = this.#outputs.shift();
+    if (!output) {
+      throw new Error('No queued model output');
+    }
+    return {
+      output,
+      usage: new Usage(),
+      responseId: `response-${++this.#responseCount}`,
+    };
+  }
+}
+
+function functionToolCall(turn: number): protocol.FunctionCallItem {
+  return {
+    type: 'function_call',
+    id: `function-${turn}`,
+    callId: `call-${turn}`,
+    name: 'guarded_tool',
+    status: 'completed',
+    arguments: JSON.stringify({ turn }),
+  };
+}
+
+async function captureRunError(
+  agent: Agent,
+  streaming: boolean,
+  maxTurns = 10,
+): Promise<unknown> {
+  try {
+    if (streaming) {
+      const result = await run(agent, 'go', { stream: true, maxTurns });
+      await result.completed;
+    } else {
+      await run(agent, 'go', { maxTurns });
+    }
+  } catch (error) {
+    return error;
+  }
+  throw new Error('Expected the run to fail');
+}
+
+function createGuardedAgent({
+  kind,
+  turns,
+  tripOnSecondCall = false,
+}: {
+  kind: GuardrailKind;
+  turns: number;
+  tripOnSecondCall?: boolean;
+}): Agent {
+  let guardrailCalls = 0;
+  const guardedTool = tool({
+    name: 'guarded_tool',
+    description: 'Returns the requested turn.',
+    parameters: z.object({ turn: z.number() }),
+    inputGuardrails:
+      kind === 'input'
+        ? [
+            defineToolInputGuardrail({
+              name: 'input_guardrail',
+              run: async () => {
+                guardrailCalls += 1;
+                const outputInfo = `input-${guardrailCalls}`;
+                return tripOnSecondCall && guardrailCalls === 2
+                  ? ToolGuardrailFunctionOutputFactory.throwException(
+                      outputInfo,
+                    )
+                  : ToolGuardrailFunctionOutputFactory.allow(outputInfo);
+              },
+            }),
+          ]
+        : undefined,
+    outputGuardrails:
+      kind === 'output'
+        ? [
+            defineToolOutputGuardrail({
+              name: 'output_guardrail',
+              run: async () => {
+                guardrailCalls += 1;
+                const outputInfo = `output-${guardrailCalls}`;
+                return tripOnSecondCall && guardrailCalls === 2
+                  ? ToolGuardrailFunctionOutputFactory.throwException(
+                      outputInfo,
+                    )
+                  : ToolGuardrailFunctionOutputFactory.allow(outputInfo);
+              },
+            }),
+          ]
+        : undefined,
+    execute: async ({ turn }) => `turn-${turn}`,
+  });
+
+  return new Agent({
+    name: `${kind}-guardrail-agent`,
+    model: new QueuedToolCallModel(turns),
+    tools: [guardedTool],
+    toolUseBehavior: 'run_llm_again',
+  });
+}
+
+describe.each([
+  { label: 'non-streaming', streaming: false },
+  { label: 'streaming', streaming: true },
+])('Runner tool guardrail error state ($label)', ({ streaming }) => {
+  it.each<GuardrailKind>(['input', 'output'])(
+    'preserves cumulative %s guardrail results when max turns is exceeded',
+    async (kind) => {
+      const error = await captureRunError(
+        createGuardedAgent({ kind, turns: 2 }),
+        streaming,
+        2,
+      );
+
+      expect(error).toBeInstanceOf(MaxTurnsExceededError);
+      const state = (error as MaxTurnsExceededError).state;
+      expect(state).toBeDefined();
+      const results =
+        kind === 'input'
+          ? state?._toolInputGuardrailResults
+          : state?._toolOutputGuardrailResults;
+      expect(results?.map((result) => result.output.outputInfo)).toEqual([
+        `${kind}-1`,
+        `${kind}-2`,
+      ]);
+    },
+  );
+
+  it.each<GuardrailKind>(['input', 'output'])(
+    'attaches cumulative state to a later %s guardrail tripwire',
+    async (kind) => {
+      const error = await captureRunError(
+        createGuardedAgent({ kind, turns: 2, tripOnSecondCall: true }),
+        streaming,
+      );
+
+      expect(error).toBeInstanceOf(ToolCallError);
+      const toolCallError = error as ToolCallError;
+      const tripwire = toolCallError.error;
+      const expectedTripwire =
+        kind === 'input'
+          ? ToolInputGuardrailTripwireTriggered
+          : ToolOutputGuardrailTripwireTriggered;
+      expect(tripwire).toBeInstanceOf(expectedTripwire);
+      expect(toolCallError.state).toBeDefined();
+
+      if (
+        tripwire instanceof ToolInputGuardrailTripwireTriggered ||
+        tripwire instanceof ToolOutputGuardrailTripwireTriggered
+      ) {
+        expect(tripwire.result.output.outputInfo).toBe(`${kind}-2`);
+        expect(tripwire.state).toBe(toolCallError.state);
+        const results =
+          kind === 'input'
+            ? tripwire.state?._toolInputGuardrailResults
+            : tripwire.state?._toolOutputGuardrailResults;
+        expect(results?.map((result) => result.output.outputInfo)).toEqual([
+          `${kind}-1`,
+          `${kind}-2`,
+        ]);
+        expect(results?.[1]).toBe(tripwire.result);
+      }
+    },
+  );
+
+  it('does not attach state to a non-AgentsError tool failure', async () => {
+    const plainError = new Error('plain tool failure');
+    const failingTool = tool({
+      name: 'guarded_tool',
+      description: 'Fails without an SDK error.',
+      parameters: z.object({ turn: z.number() }),
+      errorFunction: null,
+      execute: async () => {
+        throw plainError;
+      },
+    });
+    const agent = new Agent({
+      name: 'plain-error-agent',
+      model: new QueuedToolCallModel(1),
+      tools: [failingTool],
+    });
+
+    const error = await captureRunError(agent, streaming);
+
+    expect(error).toBeInstanceOf(ToolCallError);
+    expect((error as ToolCallError).error).toBe(plainError);
+    expect('state' in plainError).toBe(false);
+  });
+});
+
+describe('standalone tool guardrail errors', () => {
+  it.each<GuardrailKind>(['input', 'output'])(
+    'remains state-less for standalone %s utilities and preserves identity when Runner attaches state',
+    async (kind) => {
+      const agent = new Agent({ name: 'standalone-guardrail-agent' });
+      const context = new RunContext();
+      const outputInfo = `standalone-${kind}`;
+      let caught: unknown;
+
+      try {
+        if (kind === 'input') {
+          await runToolInputGuardrails({
+            guardrails: [
+              defineToolInputGuardrail({
+                name: 'standalone_input_guardrail',
+                run: async () =>
+                  ToolGuardrailFunctionOutputFactory.throwException(outputInfo),
+              }),
+            ],
+            context,
+            agent,
+            toolCall: functionToolCall(1),
+          });
+        } else {
+          await runToolOutputGuardrails({
+            guardrails: [
+              defineToolOutputGuardrail({
+                name: 'standalone_output_guardrail',
+                run: async () =>
+                  ToolGuardrailFunctionOutputFactory.throwException(outputInfo),
+              }),
+            ],
+            context,
+            agent,
+            toolCall: functionToolCall(1),
+            toolOutput: 'raw output',
+          });
+        }
+      } catch (error) {
+        caught = error;
+      }
+
+      const expectedTripwire =
+        kind === 'input'
+          ? ToolInputGuardrailTripwireTriggered
+          : ToolOutputGuardrailTripwireTriggered;
+      expect(caught).toBeInstanceOf(expectedTripwire);
+      if (
+        caught instanceof ToolInputGuardrailTripwireTriggered ||
+        caught instanceof ToolOutputGuardrailTripwireTriggered
+      ) {
+        expect(caught.state).toBeUndefined();
+        expect(caught.result.output.outputInfo).toBe(outputInfo);
+
+        const state = new RunState(context, 'go', agent, 10);
+        const wrapper = new ToolCallError('wrapped tripwire', caught, state);
+        attachRunStateToError(wrapper, state);
+
+        expect(wrapper.error).toBe(caught);
+        expect(caught.state).toBe(state);
+        expect(caught.result.output.outputInfo).toBe(outputInfo);
+      }
+    },
+  );
+});


### PR DESCRIPTION
This pull request fixes Runner failures that previously left nested tool input and output guardrail tripwire errors without access to the active run state. Both streaming and non-streaming executions now preserve cumulative guardrail results while retaining the existing `ToolCallError`, tripwire identity, and `result` property.

Standalone guardrail utilities remain state-less, and unrelated errors retain their existing behavior.