### PR TITLE
fix: redact invalid tool argument errors

### DIFF
--- a/.changeset/redact-invalid-tool-input-errors.md
+++ b/.changeset/redact-invalid-tool-input-errors.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: redact invalid tool argument errors by default

--- a/packages/agents-core/src/errors.ts
+++ b/packages/agents-core/src/errors.ts
@@ -153,6 +153,9 @@ export class GuardrailExecutionError extends AgentsError {
 /**
  * Error thrown when a tool call fails.
  */
+const toolCallErrors = new WeakSet<ToolCallError>();
+const toolTimeoutErrors = new WeakSet<ToolTimeoutError>();
+
 export class ToolCallError extends AgentsError {
   error: Error;
   constructor(
@@ -162,6 +165,7 @@ export class ToolCallError extends AgentsError {
   ) {
     super(message, state);
     this.error = error;
+    toolCallErrors.add(this);
   }
 }
 
@@ -183,6 +187,38 @@ export class ToolTimeoutError extends AgentsError {
     super(`Tool '${toolName}' timed out after ${timeoutMs}ms.`, state);
     this.toolName = toolName;
     this.timeoutMs = timeoutMs;
+    toolTimeoutErrors.add(this);
+  }
+}
+
+/** @internal */
+export function isToolTimeoutError(error: unknown): error is ToolTimeoutError {
+  return toolTimeoutErrors.has(error as ToolTimeoutError);
+}
+
+/** @internal */
+export function clearToolErrorState(
+  error: unknown,
+  state: RunState<any, Agent<any, any>>,
+): void {
+  const visited = new WeakSet<object>();
+  let current = error;
+  while (toolCallErrors.has(current as ToolCallError)) {
+    const toolCallError = current as ToolCallError;
+    if (visited.has(toolCallError)) {
+      return;
+    }
+    visited.add(toolCallError);
+    if (toolCallError.state === state) {
+      toolCallError.state = undefined;
+    }
+    current = toolCallError.error;
+  }
+  if (toolTimeoutErrors.has(current as ToolTimeoutError)) {
+    const timeoutError = current as ToolTimeoutError;
+    if (timeoutError.state === state) {
+      timeoutError.state = undefined;
+    }
   }
 }
 

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -6,12 +6,15 @@ import {
 } from '../agentToolRunConfig';
 import { consumeAgentToolRunResult } from '../agentToolRunResults';
 import {
-  InvalidToolInputError,
   InvalidToolOutputError,
   ToolCallError,
   ToolTimeoutError,
   UserError,
 } from '../errors';
+import {
+  createInvalidToolInputFailure,
+  isRedactedInvalidToolInputError,
+} from '../toolInputError';
 import { getTransferMessage, HandoffInputData } from '../handoff';
 import {
   RunHandoffCallItem,
@@ -108,7 +111,7 @@ const REDACTED_TOOL_ERROR_MESSAGE =
   'Tool execution failed. Error details are redacted.';
 
 type ParseToolArgumentsResult =
-  { success: true; args: any } | { success: false; error: Error };
+  { success: true; args: any } | { success: false; error: unknown };
 
 type ToolInputGuardrailCheckResult =
   { type: 'allow' } | { type: 'reject'; message: string };
@@ -330,7 +333,7 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
     throw new ToolCallError(
       `Failed to run function tools: ${e}`,
       e as Error,
-      state,
+      isRedactedInvalidToolInputError(e) ? undefined : state,
     );
   }
 }
@@ -418,7 +421,7 @@ function parseToolArguments<TContext>(
     } else {
       logger.debug(`Failed to parse tool arguments for ${toolName}: ${error}`);
     }
-    return { success: false, error: error as Error };
+    return { success: false, error };
   }
 }
 
@@ -502,23 +505,27 @@ async function resolveFunctionFailureOutput<TContext>(
 async function buildParseErrorResult<TContext>(
   deps: FunctionToolCallDeps<TContext>,
   toolRun: ToolRunFunction<TContext>,
-  error: Error,
+  error: unknown,
 ): Promise<FunctionToolResult<TContext>> {
-  const errorMessage = `An error occurred while parsing tool arguments. Please try again with valid JSON. Error: ${error.message}`;
-  const parseError = new InvalidToolInputError(
-    `Invalid input for function tool '${getFunctionToolIdentity(toolRun)}'.`,
-    deps.state,
-    error,
-    {
+  const failure = createInvalidToolInputFailure({
+    message: `Invalid input for function tool '${getFunctionToolIdentity(toolRun)}'.`,
+    state: deps.state,
+    originalError: error,
+    toolInvocation: {
       runContext: deps.state._context,
       input: toolRun.toolCall.arguments,
       details: { toolCall: toolRun.toolCall },
     },
-  );
+  });
+  const baseMessage =
+    'An error occurred while parsing tool arguments. Please try again with valid JSON.';
+  const errorMessage = failure.redacted
+    ? baseMessage
+    : `${baseMessage} Error: ${(error as Error).message}`;
   const output = await resolveFunctionFailureOutput(
     deps,
     toolRun,
-    parseError,
+    failure.error,
     errorMessage,
   );
   return buildFunctionFailureResult(deps, toolRun, output);

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -345,7 +345,7 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
           deps,
           toolRun,
           parseResult.approvalArgs,
-          dynamicApprovalPolicy,
+          false,
           failure,
         );
         if (approvalOutcome !== 'approved') {
@@ -800,13 +800,24 @@ async function handleFunctionApproval<TContext>(
     return 'approved';
   }
 
-  const needsApproval =
-    forceApproval ||
-    (await toolRun.tool.needsApproval(
-      state._context,
-      parsedArgs,
-      toolRun.toolCall.callId,
-    ));
+  let needsApproval = forceApproval;
+  if (!needsApproval) {
+    try {
+      needsApproval = await toolRun.tool.needsApproval(
+        state._context,
+        parsedArgs,
+        toolRun.toolCall.callId,
+      );
+    } catch (error) {
+      if (
+        invalidInputFailure &&
+        refreshInvalidToolInputFailure(invalidInputFailure)
+      ) {
+        throw invalidInputFailure.error;
+      }
+      throw error;
+    }
+  }
 
   if (!needsApproval) {
     return 'approved';

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -6,14 +6,17 @@ import {
 } from '../agentToolRunConfig';
 import { consumeAgentToolRunResult } from '../agentToolRunResults';
 import {
+  clearToolErrorState,
   InvalidToolOutputError,
+  isToolTimeoutError,
   ToolCallError,
-  ToolTimeoutError,
   UserError,
 } from '../errors';
 import {
   createInvalidToolInputFailure,
+  type InvalidToolInputFailure,
   isRedactedInvalidToolInputError,
+  refreshInvalidToolInputFailure,
 } from '../toolInputError';
 import { getTransferMessage, HandoffInputData } from '../handoff';
 import {
@@ -32,14 +35,17 @@ import {
   ComputerSafetyCheckResult,
   ComputerToolCustomDataContext,
   FunctionTool,
+  type FunctionToolPreparedInput,
   FunctionToolResult,
   FunctionToolCustomDataContext,
   ToolCallDetails,
   FUNCTION_TOOL_PARSED_INPUT_CALLBACK,
   ApplyPatchToolCustomDataContext,
   invokeFunctionTool,
+  prepareFunctionToolInput,
   hasDynamicFunctionToolApprovalPolicy,
   hasInspectableFunctionToolArguments,
+  setFunctionToolPreparedInput,
   validateFunctionToolOutput,
   resolveComputer,
   Tool,
@@ -48,8 +54,8 @@ import type { ShellResult } from '../shell';
 import { RunContext } from '../runContext';
 import type { RunResult } from '../result';
 import { isAbortError } from '../utils/abortSignals';
-import { toSmartString } from '../utils/smartString';
 import { isZodObject } from '../utils';
+import { toSmartString } from '../utils/smartString';
 import { withFunctionSpan, withHandoffSpan } from '../tracing/createSpans';
 import { getCurrentTrace } from '../tracing/context';
 import type { FunctionSpanData, Span } from '../tracing/spans';
@@ -73,7 +79,10 @@ import {
   runToolInputGuardrails,
   runToolOutputGuardrails,
 } from '../utils/toolGuardrails';
-import type { ToolInputGuardrailResult } from '../toolGuardrail';
+import type {
+  ToolInputGuardrailResult,
+  ToolOutputGuardrailResult,
+} from '../toolGuardrail';
 import { maybeExtractToolOutputCustomData } from '../utils/customData';
 import {
   resolveApprovalRejectionMessage,
@@ -111,10 +120,25 @@ const REDACTED_TOOL_ERROR_MESSAGE =
   'Tool execution failed. Error details are redacted.';
 
 type ParseToolArgumentsResult =
-  { success: true; args: any } | { success: false; error: unknown };
+  | {
+      success: true;
+      approvalArgs: any;
+      preparedInput?: FunctionToolPreparedInput;
+    }
+  | {
+      success: false;
+      error: unknown;
+      approvalArgs?: any;
+      preparedInput?: FunctionToolPreparedInput;
+    };
 
 type ToolInputGuardrailCheckResult =
   { type: 'allow' } | { type: 'reject'; message: string };
+
+type InvalidToolInputRedactionBoundary = {
+  failure: InvalidToolInputFailure;
+  redactedLegacyOutput: string;
+};
 
 function getFunctionToolIdentity<TContext>(
   toolRun: ToolRunFunction<TContext>,
@@ -128,6 +152,25 @@ function cloneForCustomDataContext<T>(value: T): T {
   } catch {
     return value;
   }
+}
+
+function getFunctionToolCallbackToolCall(
+  toolCall: protocol.FunctionCallItem,
+  redactArguments: boolean,
+): protocol.FunctionCallItem {
+  if (!redactArguments) {
+    return toolCall;
+  }
+  return {
+    type: 'function_call',
+    callId: toolCall.callId,
+    name: toolCall.name,
+    arguments: '',
+    ...(toolCall.id ? { id: toolCall.id } : {}),
+    ...(toolCall.namespace ? { namespace: toolCall.namespace } : {}),
+    ...(toolCall.status ? { status: toolCall.status } : {}),
+    ...(toolCall.caller ? { caller: toolCall.caller } : {}),
+  };
 }
 
 function getFunctionToolTraceName<TContext>(
@@ -269,44 +312,94 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
     signal,
   };
 
+  const startedInvalidInputFailures: InvalidToolInputFailure[] = [];
+
   const executeToolRun = async (toolRun: ToolRunFunction<TContext>) => {
     if (signal?.aborted) {
       return buildFunctionCancellationResult(deps, toolRun);
     }
-
     const parseResult = parseToolArguments(toolRun);
+    let failure: InvalidToolInputFailure | undefined;
+    if (!parseResult.success) {
+      failure = createInvalidToolInputFailure({
+        message: `Invalid input for function tool '${getFunctionToolIdentity(toolRun)}'.`,
+        state: deps.state,
+        originalError: parseResult.error,
+        toolInvocation: {
+          runContext: deps.state._context,
+          input: toolRun.toolCall.arguments,
+          details: { toolCall: toolRun.toolCall },
+        },
+        disposition: parseResult.preparedInput?.disposition,
+      });
+      startedInvalidInputFailures.push(failure);
+    }
+
     const dynamicApprovalPolicy = hasDynamicFunctionToolApprovalPolicy(
       toolRun.tool,
     );
-
     // Handle parse errors gracefully instead of crashing.
     if (!parseResult.success) {
-      if (dynamicApprovalPolicy) {
+      if (parseResult.preparedInput) {
+        const approvalOutcome = await handleFunctionApproval(
+          deps,
+          toolRun,
+          parseResult.approvalArgs,
+          dynamicApprovalPolicy,
+          failure,
+        );
+        if (approvalOutcome !== 'approved') {
+          return approvalOutcome;
+        }
+        try {
+          return await runApprovedFunctionTool(
+            deps,
+            toolRun,
+            parseResult.approvalArgs,
+            parseResult.preparedInput,
+            failure,
+          );
+        } catch (error) {
+          if (
+            signal?.aborted &&
+            (error === signal.reason || isAbortError(error))
+          ) {
+            return buildFunctionCancellationResult(deps, toolRun);
+          }
+          throw error;
+        }
+      } else if (dynamicApprovalPolicy) {
         const approvalOutcome = await handleFunctionApproval(
           deps,
           toolRun,
           undefined,
           true,
+          failure,
         );
         if (approvalOutcome !== 'approved') {
           return approvalOutcome;
         }
       }
-      return buildParseErrorResult(deps, toolRun, parseResult.error);
+      return buildParseErrorResult(deps, toolRun, parseResult.error, failure!);
     }
 
     const approvalOutcome = await handleFunctionApproval(
       deps,
       toolRun,
-      parseResult.args,
+      parseResult.approvalArgs,
       dynamicApprovalPolicy &&
-        !hasInspectableFunctionToolArguments(parseResult.args),
+        !hasInspectableFunctionToolArguments(parseResult.approvalArgs),
     );
     if (approvalOutcome !== 'approved') {
       return approvalOutcome;
     }
     try {
-      return await runApprovedFunctionTool(deps, toolRun, parseResult.args);
+      return await runApprovedFunctionTool(
+        deps,
+        toolRun,
+        parseResult.approvalArgs,
+        parseResult.preparedInput,
+      );
     } catch (error) {
       if (signal?.aborted && (error === signal.reason || isAbortError(error))) {
         return buildFunctionCancellationResult(deps, toolRun);
@@ -325,15 +418,28 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
     );
     return results;
   } catch (e: unknown) {
-    if (e instanceof ToolTimeoutError) {
-      e.state ??= state;
+    const redactInvalidInputFailure = startedInvalidInputFailures.some(
+      (failure) => refreshInvalidToolInputFailure(failure),
+    );
+    if (redactInvalidInputFailure) {
+      clearToolErrorState(e, state);
+    }
+    if (isToolTimeoutError(e)) {
+      if (redactInvalidInputFailure) {
+        e.state = undefined;
+      } else {
+        e.state ??= state;
+      }
       throw e;
     }
 
+    const surfacedError = e as Error;
     throw new ToolCallError(
-      `Failed to run function tools: ${e}`,
-      e as Error,
-      isRedactedInvalidToolInputError(e) ? undefined : state,
+      `Failed to run function tools: ${surfacedError}`,
+      surfacedError,
+      redactInvalidInputFailure || isRedactedInvalidToolInputError(e)
+        ? undefined
+        : state,
     );
   }
 }
@@ -355,12 +461,10 @@ function shouldRunPreApprovalInputGuardrails<TContext>(
   );
 }
 
-async function executeToolRunsWithConcurrency<TContext>(
-  toolRuns: ToolRunFunction<TContext>[],
+async function executeToolRunsWithConcurrency<TContext, TToolRun>(
+  toolRuns: TToolRun[],
   maxConcurrency: number | undefined,
-  executeToolRun: (
-    toolRun: ToolRunFunction<TContext>,
-  ) => Promise<FunctionToolResult<TContext>>,
+  executeToolRun: (toolRun: TToolRun) => Promise<FunctionToolResult<TContext>>,
 ): Promise<FunctionToolResult<TContext>[]> {
   if (
     maxConcurrency === undefined ||
@@ -406,15 +510,27 @@ function parseToolArguments<TContext>(
 ): ParseToolArgumentsResult {
   const toolName = getFunctionToolIdentity(toolRun);
   try {
-    let parsedArgs: any = toolRun.toolCall.arguments;
+    let approvalArgs: any = toolRun.toolCall.arguments;
     if (toolRun.tool.parameters) {
       if (isZodObject(toolRun.tool.parameters)) {
-        parsedArgs = toolRun.tool.parameters.parse(parsedArgs);
+        approvalArgs = toolRun.tool.parameters.parse(approvalArgs);
       } else {
-        parsedArgs = JSON.parse(parsedArgs);
+        approvalArgs = JSON.parse(approvalArgs);
       }
     }
-    return { success: true, args: parsedArgs };
+    const preparedInput = prepareFunctionToolInput(
+      toolRun.tool,
+      toolRun.toolCall.arguments,
+    );
+    if (preparedInput && !preparedInput.result.success) {
+      return {
+        success: false,
+        error: preparedInput.result.error,
+        approvalArgs,
+        preparedInput,
+      };
+    }
+    return { success: true, approvalArgs, preparedInput };
   } catch (error) {
     if (logger.dontLogToolData) {
       logger.debug(`Failed to parse tool arguments for ${toolName}`);
@@ -479,61 +595,122 @@ async function resolveFunctionFailureOutput<TContext>(
   toolRun: ToolRunFunction<TContext>,
   error: Error,
   legacyOutput: string,
+  redactionBoundary?: InvalidToolInputRedactionBoundary,
 ): Promise<unknown> {
+  const redactedBeforeCallback = redactionBoundary
+    ? refreshInvalidToolInputFailure(redactionBoundary.failure)
+    : isRedactedInvalidToolInputError(error);
+  const callbackError = redactedBeforeCallback
+    ? (redactionBoundary?.failure.error ?? error)
+    : error;
+  const effectiveLegacyOutput = redactedBeforeCallback
+    ? (redactionBoundary?.redactedLegacyOutput ?? legacyOutput)
+    : legacyOutput;
+
   if (!toolRun.tool.outputSchema) {
-    return legacyOutput;
+    return effectiveLegacyOutput;
   }
 
   if (!toolRun.tool.errorFunction) {
-    throw error;
+    throw callbackError;
   }
 
-  const details: ToolCallDetails = { toolCall: toolRun.toolCall };
-  const output = await toolRun.tool.errorFunction(
-    deps.state._context,
-    error,
-    details,
-  );
-  return validateFunctionToolOutput({
-    tool: toolRun.tool,
-    output,
-    runContext: deps.state._context,
-    details,
-  });
+  const details: ToolCallDetails | undefined = redactedBeforeCallback
+    ? undefined
+    : { toolCall: toolRun.toolCall };
+  try {
+    const output = await toolRun.tool.errorFunction(
+      deps.state._context,
+      callbackError,
+      details,
+    );
+    if (
+      redactionBoundary &&
+      !redactedBeforeCallback &&
+      refreshInvalidToolInputFailure(redactionBoundary.failure)
+    ) {
+      throw redactionBoundary.failure.error;
+    }
+    const validatedOutput = validateFunctionToolOutput({
+      tool: toolRun.tool,
+      output,
+      runContext: deps.state._context,
+      details,
+    });
+    if (
+      redactionBoundary &&
+      !redactedBeforeCallback &&
+      refreshInvalidToolInputFailure(redactionBoundary.failure)
+    ) {
+      throw redactionBoundary.failure.error;
+    }
+    return validatedOutput;
+  } catch (callbackFailure) {
+    if (
+      redactionBoundary &&
+      refreshInvalidToolInputFailure(redactionBoundary.failure)
+    ) {
+      throw redactionBoundary.failure.error;
+    }
+    throw callbackFailure;
+  }
 }
 
 async function buildParseErrorResult<TContext>(
   deps: FunctionToolCallDeps<TContext>,
   toolRun: ToolRunFunction<TContext>,
   error: unknown,
+  failure: InvalidToolInputFailure,
 ): Promise<FunctionToolResult<TContext>> {
-  const failure = createInvalidToolInputFailure({
-    message: `Invalid input for function tool '${getFunctionToolIdentity(toolRun)}'.`,
-    state: deps.state,
-    originalError: error,
-    toolInvocation: {
-      runContext: deps.state._context,
-      input: toolRun.toolCall.arguments,
-      details: { toolCall: toolRun.toolCall },
-    },
+  const traceToolName = getFunctionToolTraceName(toolRun);
+  return withRunStateToolFunctionSpan(deps, traceToolName, async (span) => {
+    refreshInvalidToolInputFailure(failure);
+    if (
+      span &&
+      deps.runner.config.traceIncludeSensitiveData &&
+      !failure.redacted
+    ) {
+      span.spanData.input = toolRun.toolCall.arguments;
+    }
+    span?.setError({
+      message: 'Error running tool (non-fatal)',
+      data: {
+        tool_name: traceToolName,
+        error: failure.error.toString(),
+      },
+    });
+
+    const baseMessage =
+      'An error occurred while parsing tool arguments. Please try again with valid JSON.';
+    const errorMessage = failure.redacted
+      ? baseMessage
+      : `${baseMessage} Error: ${(error as Error).message}`;
+    let output: unknown;
+    try {
+      output = await resolveFunctionFailureOutput(
+        deps,
+        toolRun,
+        failure.error,
+        errorMessage,
+        { failure, redactedLegacyOutput: baseMessage },
+      );
+    } finally {
+      refreshInvalidToolInputFailure(failure);
+      if (failure.redacted && span) {
+        span.spanData.input = '';
+      }
+    }
+    if (span && deps.runner.config.traceIncludeSensitiveData) {
+      span.spanData.output = toSmartString(output);
+    }
+    return buildFunctionFailureResult(deps, toolRun, output);
   });
-  const baseMessage =
-    'An error occurred while parsing tool arguments. Please try again with valid JSON.';
-  const errorMessage = failure.redacted
-    ? baseMessage
-    : `${baseMessage} Error: ${(error as Error).message}`;
-  const output = await resolveFunctionFailureOutput(
-    deps,
-    toolRun,
-    failure.error,
-    errorMessage,
-  );
-  return buildFunctionFailureResult(deps, toolRun, output);
 }
 
 async function buildApprovalRejectionResult<TContext>(
   deps: FunctionToolCallDeps<TContext>,
   toolRun: ToolRunFunction<TContext>,
+  invalidInputFailure?: InvalidToolInputFailure,
 ): Promise<FunctionToolResult<TContext>> {
   const { runner, state, toolErrorFormatter } = deps;
   const toolName = getFunctionToolIdentity(toolRun);
@@ -549,9 +726,13 @@ async function buildApprovalRejectionResult<TContext>(
       callId: toolRun.toolCall.callId,
       toolErrorFormatter,
     });
-    const traceErrorMessage = runner.config.traceIncludeSensitiveData
-      ? response
-      : TOOL_APPROVAL_REJECTION_MESSAGE;
+    const redactDetails = invalidInputFailure
+      ? refreshInvalidToolInputFailure(invalidInputFailure)
+      : false;
+    const traceErrorMessage =
+      runner.config.traceIncludeSensitiveData && !redactDetails
+        ? response
+        : TOOL_APPROVAL_REJECTION_MESSAGE;
 
     span?.setError({
       message: traceErrorMessage,
@@ -566,7 +747,20 @@ async function buildApprovalRejectionResult<TContext>(
       toolRun,
       new Error(response),
       response,
+      invalidInputFailure
+        ? {
+            failure: invalidInputFailure,
+            redactedLegacyOutput: TOOL_APPROVAL_REJECTION_MESSAGE,
+          }
+        : undefined,
     );
+    if (
+      invalidInputFailure &&
+      refreshInvalidToolInputFailure(invalidInputFailure) &&
+      span
+    ) {
+      span.spanData.input = '';
+    }
     if (span && runner.config.traceIncludeSensitiveData) {
       span.spanData.output = toSmartString(output);
     }
@@ -579,6 +773,7 @@ async function handleFunctionApproval<TContext>(
   toolRun: ToolRunFunction<TContext>,
   parsedArgs: any,
   forceApproval: boolean = false,
+  invalidInputFailure?: InvalidToolInputFailure,
 ): Promise<'approved' | FunctionToolResult<TContext>> {
   const { agent, state } = deps;
   const approvalStateKey = getFunctionToolApprovalStateKey(toolRun);
@@ -594,7 +789,11 @@ async function handleFunctionApproval<TContext>(
     for (const stateKey of pendingStateKeys) {
       state.clearPendingAgentToolRun(stateKey, toolRun.toolCall.callId);
     }
-    return await buildApprovalRejectionResult(deps, toolRun);
+    return await buildApprovalRejectionResult(
+      deps,
+      toolRun,
+      invalidInputFailure,
+    );
   }
 
   if (approval === true) {
@@ -614,21 +813,56 @@ async function handleFunctionApproval<TContext>(
   }
 
   if (shouldRunPreApprovalInputGuardrails(deps)) {
-    const inputGuardrailResult = await runFunctionToolInputGuardrails({
-      guardrails: toolRun.tool.inputGuardrails,
-      context: state._context,
-      agent,
-      toolCall: toolRun.toolCall,
-      onResult: (result) => {
-        state._toolInputGuardrailResults.push(result);
-      },
-    });
+    const redactedBeforeGuardrails = invalidInputFailure
+      ? refreshInvalidToolInputFailure(invalidInputFailure)
+      : false;
+    const guardrailResults: ToolInputGuardrailResult[] = [];
+    let inputGuardrailResult: ToolInputGuardrailCheckResult = { type: 'allow' };
+    let guardrailFailed = false;
+    let guardrailError: unknown;
+    try {
+      inputGuardrailResult = await runFunctionToolInputGuardrails({
+        guardrails: toolRun.tool.inputGuardrails,
+        context: state._context,
+        agent,
+        toolCall: getFunctionToolCallbackToolCall(
+          toolRun.toolCall,
+          redactedBeforeGuardrails,
+        ),
+        onResult: (result) => {
+          guardrailResults.push(result);
+        },
+      });
+    } catch (error) {
+      guardrailFailed = true;
+      guardrailError = error;
+    }
+    const redactedAfterGuardrails = invalidInputFailure
+      ? refreshInvalidToolInputFailure(invalidInputFailure)
+      : false;
+    if (redactedBeforeGuardrails || !redactedAfterGuardrails) {
+      state._toolInputGuardrailResults.push(...guardrailResults);
+    }
+    if (guardrailFailed) {
+      const sdkTripwire = guardrailResults.some(
+        (result) => result.output.behavior?.type === 'throwException',
+      );
+      if (
+        invalidInputFailure &&
+        redactedAfterGuardrails &&
+        (!redactedBeforeGuardrails || !sdkTripwire)
+      ) {
+        throw invalidInputFailure.error;
+      }
+      throw guardrailError;
+    }
 
     if (inputGuardrailResult.type === 'reject') {
       return buildInputGuardrailRejectionResult(
         deps,
         toolRun,
         inputGuardrailResult.message,
+        invalidInputFailure,
       );
     }
   }
@@ -639,12 +873,19 @@ async function buildInputGuardrailRejectionResult<TContext>(
   deps: FunctionToolCallDeps<TContext>,
   toolRun: ToolRunFunction<TContext>,
   message: string,
+  invalidInputFailure?: InvalidToolInputFailure,
 ): Promise<FunctionToolResult<TContext>> {
   const output = await resolveFunctionFailureOutput(
     deps,
     toolRun,
     new Error(message),
     message,
+    invalidInputFailure
+      ? {
+          failure: invalidInputFailure,
+          redactedLegacyOutput: REDACTED_TOOL_ERROR_MESSAGE,
+        }
+      : undefined,
   );
   return buildFunctionFailureResult(deps, toolRun, output);
 }
@@ -674,42 +915,113 @@ async function runFunctionToolInputGuardrails<TContext>({
 async function runApprovedFunctionTool<TContext>(
   deps: FunctionToolCallDeps<TContext>,
   toolRun: ToolRunFunction<TContext>,
-  parsedInput: unknown,
+  approvalArgs: unknown,
+  preparedInput: FunctionToolPreparedInput | undefined,
+  invalidInputFailure?: InvalidToolInputFailure,
 ): Promise<FunctionToolResult<TContext>> {
   const { agent, runner, state, agentToolParentRunConfig, signal } = deps;
   const toolName = getFunctionToolIdentity(toolRun);
   const stateKeys = getFunctionToolPendingStateKeys(toolRun);
   const traceToolName = getFunctionToolTraceName(toolRun);
   return withRunStateToolFunctionSpan(deps, traceToolName, async (span) => {
-    if (span && runner.config.traceIncludeSensitiveData) {
+    let preservedLifecycleError: unknown;
+    const refreshRedaction = () => {
+      const redacted = invalidInputFailure
+        ? refreshInvalidToolInputFailure(invalidInputFailure)
+        : false;
+      if (redacted && span) {
+        span.spanData.input = '';
+      }
+      return redacted;
+    };
+    const throwIfRedactionPromoted = (redactedBefore: boolean) => {
+      if (!redactedBefore && refreshRedaction() && invalidInputFailure) {
+        throw invalidInputFailure.error;
+      }
+    };
+    if (
+      span &&
+      runner.config.traceIncludeSensitiveData &&
+      !refreshRedaction()
+    ) {
       span.spanData.input = toolRun.toolCall.arguments;
     }
 
     try {
-      const inputGuardrailResult = await runFunctionToolInputGuardrails({
-        guardrails: toolRun.tool.inputGuardrails,
-        context: state._context,
-        agent,
-        toolCall: toolRun.toolCall,
-        onResult: (result) => {
-          state._toolInputGuardrailResults.push(result);
-        },
-      });
+      const redactedBeforeInputGuardrails = refreshRedaction();
+      const inputGuardrailResults: ToolInputGuardrailResult[] = [];
+      let inputGuardrailResult: ToolInputGuardrailCheckResult = {
+        type: 'allow',
+      };
+      let inputGuardrailFailed = false;
+      let inputGuardrailError: unknown;
+      try {
+        inputGuardrailResult = await runFunctionToolInputGuardrails({
+          guardrails: toolRun.tool.inputGuardrails,
+          context: state._context,
+          agent,
+          toolCall: getFunctionToolCallbackToolCall(
+            toolRun.toolCall,
+            redactedBeforeInputGuardrails,
+          ),
+          onResult: (result) => {
+            inputGuardrailResults.push(result);
+          },
+        });
+      } catch (error) {
+        inputGuardrailFailed = true;
+        inputGuardrailError = error;
+        if (
+          inputGuardrailResults.some(
+            (result) => result.output.behavior?.type === 'throwException',
+          )
+        ) {
+          preservedLifecycleError = error;
+        }
+      }
+      const redactedAfterInputGuardrails = refreshRedaction();
+      if (redactedBeforeInputGuardrails || !redactedAfterInputGuardrails) {
+        state._toolInputGuardrailResults.push(...inputGuardrailResults);
+      }
+      if (inputGuardrailFailed) {
+        if (
+          !redactedBeforeInputGuardrails &&
+          redactedAfterInputGuardrails &&
+          invalidInputFailure
+        ) {
+          throw invalidInputFailure.error;
+        }
+        throw inputGuardrailError;
+      }
 
       if (signal?.aborted) {
         return buildFunctionCancellationResult(deps, toolRun);
       }
 
-      emitToolStart(
-        runner,
-        state._context,
-        agent,
-        toolRun.tool,
-        toolRun.toolCall,
-      );
+      const redactedBeforeToolStart = refreshRedaction();
+      try {
+        emitFunctionToolStart(
+          runner,
+          state._context,
+          agent,
+          toolRun.tool,
+          toolRun.toolCall,
+          refreshRedaction,
+        );
+      } catch (hookError) {
+        if (
+          !redactedBeforeToolStart &&
+          refreshRedaction() &&
+          invalidInputFailure
+        ) {
+          throw invalidInputFailure.error;
+        }
+        throw hookError;
+      }
+      refreshRedaction();
 
       let toolOutput: unknown;
-      let executedInput = parsedInput;
+      let executedInput = approvalArgs;
       let toolDetails: ToolCallDetails = { toolCall: toolRun.toolCall };
       let shouldValidateToolOutput = false;
       if (inputGuardrailResult.type === 'reject') {
@@ -718,6 +1030,12 @@ async function runApprovedFunctionTool<TContext>(
           toolRun,
           new Error(inputGuardrailResult.message),
           inputGuardrailResult.message,
+          invalidInputFailure
+            ? {
+                failure: invalidInputFailure,
+                redactedLegacyOutput: REDACTED_TOOL_ERROR_MESSAGE,
+              }
+            : undefined,
         );
       } else {
         const resumeState = stateKeys
@@ -725,14 +1043,21 @@ async function runApprovedFunctionTool<TContext>(
             state.getPendingAgentToolRun(stateKey, toolRun.toolCall.callId),
           )
           .find((pendingState) => typeof pendingState !== 'undefined');
+        const redactedBeforeInvocation = refreshRedaction();
         toolDetails = {
-          toolCall: toolRun.toolCall,
+          toolCall: getFunctionToolCallbackToolCall(
+            toolRun.toolCall,
+            redactedBeforeInvocation,
+          ),
           resumeState,
           ...(signal ? { signal } : {}),
           [FUNCTION_TOOL_PARSED_INPUT_CALLBACK]: (input: unknown) => {
             executedInput = cloneForCustomDataContext(input);
           },
         };
+        if (preparedInput) {
+          setFunctionToolPreparedInput(toolDetails, preparedInput);
+        }
         setToolUsageRecorder(toolDetails, getRunStateUsageRecorder(state));
         setAgentToolParentRunConfigOnDetails(
           toolDetails,
@@ -746,51 +1071,97 @@ async function runApprovedFunctionTool<TContext>(
           input: toolRun.toolCall.arguments,
           details: toolDetails,
         });
-        toolOutput = await runToolOutputGuardrails({
-          guardrails: toolRun.tool.outputGuardrails,
-          context: state._context,
-          agent,
-          toolCall: toolRun.toolCall,
-          toolOutput: invokedToolOutput,
-          onResult: (result) => {
-            state._toolOutputGuardrailResults.push(result);
-          },
-        });
+        throwIfRedactionPromoted(redactedBeforeInvocation);
+        const redactedBeforeOutputGuardrails = refreshRedaction();
+        const outputGuardrailResults: ToolOutputGuardrailResult[] = [];
+        try {
+          toolOutput = await runToolOutputGuardrails({
+            guardrails: toolRun.tool.outputGuardrails,
+            context: state._context,
+            agent,
+            toolCall: getFunctionToolCallbackToolCall(
+              toolRun.toolCall,
+              redactedBeforeOutputGuardrails,
+            ),
+            toolOutput: invokedToolOutput,
+            onResult: (result) => {
+              outputGuardrailResults.push(result);
+            },
+          });
+        } catch (guardrailError) {
+          if (
+            outputGuardrailResults.some(
+              (result) => result.output.behavior?.type === 'throwException',
+            )
+          ) {
+            preservedLifecycleError = guardrailError;
+          }
+          throw guardrailError;
+        } finally {
+          throwIfRedactionPromoted(redactedBeforeOutputGuardrails);
+          state._toolOutputGuardrailResults.push(...outputGuardrailResults);
+        }
         shouldValidateToolOutput = toolOutput !== invokedToolOutput;
       }
       if (shouldValidateToolOutput) {
+        const redactedBeforeOutputValidation = refreshRedaction();
         toolOutput = validateFunctionToolOutput({
           tool: toolRun.tool,
           output: toolOutput,
           runContext: state._context,
           details: toolDetails,
         });
+        throwIfRedactionPromoted(redactedBeforeOutputValidation);
       }
       const stringResult = toSmartString(toolOutput);
 
       const rawItem = getToolCallOutputItem(toolRun.toolCall, toolOutput, {
         outputSchema: toolRun.tool.outputSchema,
       });
-      const customData = await maybeExtractToolOutputCustomData(
-        toolRun.tool.customDataExtractor,
-        {
-          runContext: state._context,
-          tool: toolRun.tool,
-          toolCall: cloneForCustomDataContext(toolRun.toolCall),
-          input: cloneForCustomDataContext(executedInput),
-          output: cloneForCustomDataContext(toolOutput),
-          rawItem: cloneForCustomDataContext(rawItem),
-        } satisfies FunctionToolCustomDataContext<TContext>,
-      );
+      if (refreshRedaction()) {
+        executedInput = undefined;
+      }
+      const redactedBeforeCustomData = refreshRedaction();
+      let customData: Awaited<
+        ReturnType<typeof maybeExtractToolOutputCustomData>
+      >;
+      try {
+        customData = await maybeExtractToolOutputCustomData(
+          toolRun.tool.customDataExtractor,
+          {
+            runContext: state._context,
+            tool: toolRun.tool,
+            toolCall: cloneForCustomDataContext(
+              getFunctionToolCallbackToolCall(
+                toolRun.toolCall,
+                redactedBeforeCustomData,
+              ),
+            ),
+            input: cloneForCustomDataContext(executedInput),
+            output: cloneForCustomDataContext(toolOutput),
+            rawItem: cloneForCustomDataContext(rawItem),
+          } satisfies FunctionToolCustomDataContext<TContext>,
+        );
+      } finally {
+        throwIfRedactionPromoted(redactedBeforeCustomData);
+      }
 
-      emitToolEnd(
-        runner,
-        state._context,
-        agent,
-        toolRun.tool,
-        stringResult,
-        toolRun.toolCall,
-      );
+      const redactedBeforeToolEnd = refreshRedaction();
+      try {
+        emitFunctionToolEnd(
+          runner,
+          state._context,
+          agent,
+          toolRun.tool,
+          stringResult,
+          toolRun.toolCall,
+          refreshRedaction,
+        );
+      } catch (hookError) {
+        throwIfRedactionPromoted(redactedBeforeToolEnd);
+        throw hookError;
+      }
+      throwIfRedactionPromoted(redactedBeforeToolEnd);
 
       if (span && runner.config.traceIncludeSensitiveData) {
         span.spanData.output = stringResult;
@@ -833,24 +1204,43 @@ async function runApprovedFunctionTool<TContext>(
 
       return functionResult;
     } catch (error) {
+      const redacted = refreshRedaction();
+      const errorResult = redacted
+        ? REDACTED_TOOL_ERROR_MESSAGE
+        : String(error);
       span?.setError({
         message: 'Error running tool',
         data: {
           tool_name: traceToolName,
-          error: String(error),
+          error: errorResult,
         },
       });
 
-      const errorResult = String(error);
-      emitToolEnd(
-        runner,
-        state._context,
-        agent,
-        toolRun.tool,
-        errorResult,
-        toolRun.toolCall,
-      );
+      try {
+        emitFunctionToolEnd(
+          runner,
+          state._context,
+          agent,
+          toolRun.tool,
+          errorResult,
+          toolRun.toolCall,
+          refreshRedaction,
+        );
+      } catch (hookError) {
+        if (refreshRedaction() && invalidInputFailure) {
+          throw invalidInputFailure.error;
+        }
+        throw hookError;
+      }
 
+      if (
+        refreshRedaction() &&
+        invalidInputFailure &&
+        !isToolTimeoutError(error) &&
+        error !== preservedLifecycleError
+      ) {
+        throw invalidInputFailure.error;
+      }
       throw error;
     }
   });
@@ -1117,6 +1507,59 @@ function emitToolEnd(
   runner.emit('agent_tool_end', runContext, agent, tool, output, { toolCall });
   if (typeof agent.emit === 'function') {
     agent.emit('agent_tool_end', runContext, tool, output, { toolCall });
+  }
+}
+
+function emitFunctionToolStart(
+  runner: Runner,
+  runContext: RunContext,
+  agent: Agent<any, any>,
+  tool: FunctionTool<any, any, any>,
+  toolCall: protocol.FunctionCallItem,
+  refreshRedaction: () => boolean,
+): void {
+  runner.emit('agent_tool_start', runContext, agent, tool, {
+    toolCall: getFunctionToolCallbackToolCall(toolCall, refreshRedaction()),
+  });
+  if (typeof agent.emit === 'function') {
+    agent.emit('agent_tool_start', runContext, tool, {
+      toolCall: getFunctionToolCallbackToolCall(toolCall, refreshRedaction()),
+    });
+  }
+}
+
+function emitFunctionToolEnd(
+  runner: Runner,
+  runContext: RunContext,
+  agent: Agent<any, any>,
+  tool: FunctionTool<any, any, any>,
+  output: string,
+  toolCall: protocol.FunctionCallItem,
+  refreshRedaction: () => boolean,
+): void {
+  const redactedBeforeRunnerHook = refreshRedaction();
+  runner.emit('agent_tool_end', runContext, agent, tool, output, {
+    toolCall: getFunctionToolCallbackToolCall(
+      toolCall,
+      redactedBeforeRunnerHook,
+    ),
+  });
+  if (typeof agent.emit === 'function') {
+    const redactedBeforeAgentHook = refreshRedaction();
+    agent.emit(
+      'agent_tool_end',
+      runContext,
+      tool,
+      !redactedBeforeRunnerHook && redactedBeforeAgentHook
+        ? REDACTED_TOOL_ERROR_MESSAGE
+        : output,
+      {
+        toolCall: getFunctionToolCallbackToolCall(
+          toolCall,
+          redactedBeforeAgentHook,
+        ),
+      },
+    );
   }
 }
 

--- a/packages/agents-core/src/tool.ts
+++ b/packages/agents-core/src/tool.ts
@@ -8,7 +8,6 @@ import {
   JsonObjectSchemaStrict,
   UnknownContext,
 } from './types';
-import { safeExecute } from './utils/safeExecute';
 import { toFunctionToolName } from './utils/tools';
 import { getSchemaAndParserFromInputType } from './utils/tools';
 import { isZodObject } from './utils/typeGuards';
@@ -17,7 +16,14 @@ import { RunContext } from './runContext';
 import type { RunConfig } from './run';
 import type { RunResult } from './result';
 import { InvalidToolOutputError, ToolTimeoutError, UserError } from './errors';
-import { createInvalidToolInputFailure } from './toolInputError';
+import {
+  createInvalidToolInputDisposition,
+  createInvalidToolInputFailure,
+  getInvalidToolInputFailure,
+  type InvalidToolInputDisposition,
+  isRedactedInvalidToolInputError,
+  refreshInvalidToolInputFailure,
+} from './toolInputError';
 import logger, { logToolActionWarning } from './logger';
 import { getCurrentSpan } from './tracing';
 import { RunToolApprovalItem, RunToolCallOutputItem } from './items';
@@ -84,6 +90,87 @@ const FUNCTION_TOOL_OUTPUT_VALIDATOR = Symbol(
 const STATIC_FUNCTION_TOOL_APPROVAL_POLICIES = new WeakSet<
   ToolApprovalFunction<any>
 >();
+type FunctionToolInputParserRegistration = {
+  parser: (input: string) => any;
+  token: object;
+};
+
+type FunctionToolInputParseResult =
+  { success: true; value: any } | { success: false; error: unknown };
+
+export type FunctionToolPreparedInput = {
+  consumed: boolean;
+  input: string;
+  token: object;
+  disposition?: InvalidToolInputDisposition;
+  result: { success: true; value: any } | { success: false; error: unknown };
+};
+
+const functionToolInputParsers = new WeakMap<
+  object,
+  FunctionToolInputParserRegistration
+>();
+const functionToolPreparedInputs = new WeakMap<
+  object,
+  FunctionToolPreparedInput
+>();
+
+function parseFunctionToolInput(
+  parser: (input: string) => any,
+  input: string,
+): FunctionToolInputParseResult {
+  try {
+    return { success: true, value: parser(input) };
+  } catch (error) {
+    return { success: false, error };
+  }
+}
+
+/** @internal */
+export function prepareFunctionToolInput(
+  tool: Pick<FunctionTool<any, any, any>, 'invoke'>,
+  input: string,
+): FunctionToolPreparedInput | undefined {
+  const registration = functionToolInputParsers.get(tool.invoke);
+  if (!registration) {
+    return undefined;
+  }
+  const result = parseFunctionToolInput(registration.parser, input);
+  const base = {
+    consumed: false,
+    input,
+    token: registration.token,
+  };
+  if (result.success) {
+    return { ...base, result };
+  }
+  return {
+    ...base,
+    result,
+    disposition: createInvalidToolInputDisposition(),
+  };
+}
+
+/** @internal */
+export function setFunctionToolPreparedInput(
+  details: object,
+  preparedInput: FunctionToolPreparedInput,
+): void {
+  functionToolPreparedInputs.set(details, preparedInput);
+}
+
+function copyFunctionToolPreparedInput(
+  source: object | undefined,
+  target: object | undefined,
+): void {
+  if (!source || !target) {
+    return;
+  }
+  const preparedInput = functionToolPreparedInputs.get(source);
+  if (preparedInput) {
+    functionToolPreparedInputs.set(target, preparedInput);
+  }
+}
 
 export function hasDynamicFunctionToolApprovalPolicy(
   tool: Pick<FunctionTool<any, any, any>, 'needsApproval'>,
@@ -1989,6 +2076,7 @@ async function invokeFunctionToolWithTimeout<
         })
       : { signal: invocationSignal }
     : details;
+  copyFunctionToolPreparedInput(details, invokeDetails);
   const timeoutError = new ToolTimeoutError({
     toolName,
     timeoutMs,
@@ -2076,6 +2164,7 @@ export async function invokeFunctionTool<
         : cloneObjectWithDescriptorsAndOverrides(invocationDetails, {
             [FUNCTION_TOOL_TIMEOUT_ALREADY_ENFORCED]: true as const,
           });
+    copyFunctionToolPreparedInput(invocationDetails, detailsWithFlag);
 
     return tool.invoke(invocationRunContext, invocationInput, detailsWithFlag);
   };
@@ -2166,6 +2255,7 @@ export function tool<
     name,
     { strict: strictMode },
   );
+  const inputParserToken = {};
   const zodOutputSchema = isZodObject(options.outputSchema)
     ? options.outputSchema
     : undefined;
@@ -2217,22 +2307,42 @@ export function tool<
     input: string,
     details?: ToolCallDetails,
   ): Promise<ToolExecuteResult<TOutputSchema, Result>> {
-    const [error, parsed] = await safeExecute(() => parser(input));
-    if (error !== null) {
-      if (logger.dontLogToolData) {
+    const preparedInput = details
+      ? functionToolPreparedInputs.get(details)
+      : undefined;
+    const canUsePreparedInput =
+      preparedInput !== undefined &&
+      !preparedInput.consumed &&
+      preparedInput.input === input &&
+      preparedInput.token === inputParserToken;
+    if (canUsePreparedInput) {
+      preparedInput.consumed = true;
+    }
+    const parseResult =
+      canUsePreparedInput && preparedInput
+        ? preparedInput.result
+        : parseFunctionToolInput(parser, input);
+    if (!parseResult.success) {
+      // supply the same context as options.execute for consuming
+      // downstream code to implement self-healing and/or tracing
+      const failure = createInvalidToolInputFailure({
+        message: 'Invalid JSON input for tool',
+        originalError: parseResult.error,
+        toolInvocation: { runContext, input, details },
+        disposition:
+          canUsePreparedInput && preparedInput
+            ? preparedInput.disposition
+            : undefined,
+      });
+      if (failure.redacted || logger.dontLogToolData) {
+        refreshInvalidToolInputFailure(failure);
         logger.debug(`Invalid JSON input for tool ${name}`);
       } else {
         logger.debug(`Invalid JSON input for tool ${name}: ${input}`);
       }
-
-      // supply the same context as options.execute for consuming
-      // downstream code to implement self-healing and/or tracing
-      throw createInvalidToolInputFailure({
-        message: 'Invalid JSON input for tool',
-        originalError: error,
-        toolInvocation: { runContext, input, details },
-      }).error;
+      throw failure.error;
     }
+    const parsed = parseResult.value;
 
     if (logger.dontLogToolData) {
       logger.debug(`Invoking tool ${name}`);
@@ -2272,24 +2382,63 @@ export function tool<
         throw error;
       }
 
-      if (toolErrorFunction) {
-        const currentSpan = getCurrentSpan();
-        currentSpan?.setError({
-          message: 'Error running tool (non-fatal)',
-          data: {
-            tool_name: name,
-            error: error.toString(),
-          },
-        });
-        return validateOutput(
-          await toolErrorFunction(runContext, error, details),
-          runContext,
-          details,
-        );
-      }
-
-      throw error;
+      return resolveToolFailure(runContext, error, details);
     });
+  }
+
+  async function resolveToolFailure(
+    runContext: RunContext<Context>,
+    error: any,
+    details?: ToolCallDetails,
+  ): Promise<ToolExecuteResult<TOutputSchema, Result>> {
+    if (!toolErrorFunction) {
+      throw error;
+    }
+    const invalidInputFailure = getInvalidToolInputFailure(error);
+    const redactedBeforeCallback = invalidInputFailure
+      ? refreshInvalidToolInputFailure(invalidInputFailure)
+      : isRedactedInvalidToolInputError(error);
+    const callbackError = invalidInputFailure?.error ?? error;
+    const errorDetails = redactedBeforeCallback ? undefined : details;
+    const currentSpan = getCurrentSpan();
+    currentSpan?.setError({
+      message: 'Error running tool (non-fatal)',
+      data: {
+        tool_name: name,
+        error: callbackError.toString(),
+      },
+    });
+    try {
+      const output = await toolErrorFunction(
+        runContext,
+        callbackError,
+        errorDetails,
+      );
+      if (
+        invalidInputFailure &&
+        !redactedBeforeCallback &&
+        refreshInvalidToolInputFailure(invalidInputFailure)
+      ) {
+        throw invalidInputFailure.error;
+      }
+      const validatedOutput = validateOutput(output, runContext, errorDetails);
+      if (
+        invalidInputFailure &&
+        !redactedBeforeCallback &&
+        refreshInvalidToolInputFailure(invalidInputFailure)
+      ) {
+        throw invalidInputFailure.error;
+      }
+      return validatedOutput;
+    } catch (callbackFailure) {
+      if (
+        invalidInputFailure &&
+        refreshInvalidToolInputFailure(invalidInputFailure)
+      ) {
+        throw invalidInputFailure.error;
+      }
+      throw callbackFailure;
+    }
   }
 
   async function invoke(
@@ -2328,6 +2477,10 @@ export function tool<
   if (typeof options.needsApproval !== 'function') {
     STATIC_FUNCTION_TOOL_APPROVAL_POLICIES.add(needsApproval);
   }
+  functionToolInputParsers.set(invoke, {
+    parser,
+    token: inputParserToken,
+  });
 
   const isEnabled: ToolEnabledFunction<Context> =
     typeof options.isEnabled === 'function'

--- a/packages/agents-core/src/tool.ts
+++ b/packages/agents-core/src/tool.ts
@@ -16,12 +16,8 @@ import { combineAbortSignals, isAbortError } from './utils/abortSignals';
 import { RunContext } from './runContext';
 import type { RunConfig } from './run';
 import type { RunResult } from './result';
-import {
-  InvalidToolInputError,
-  InvalidToolOutputError,
-  ToolTimeoutError,
-  UserError,
-} from './errors';
+import { InvalidToolOutputError, ToolTimeoutError, UserError } from './errors';
+import { createInvalidToolInputFailure } from './toolInputError';
 import logger, { logToolActionWarning } from './logger';
 import { getCurrentSpan } from './tracing';
 import { RunToolApprovalItem, RunToolCallOutputItem } from './items';
@@ -2231,12 +2227,11 @@ export function tool<
 
       // supply the same context as options.execute for consuming
       // downstream code to implement self-healing and/or tracing
-      throw new InvalidToolInputError(
-        'Invalid JSON input for tool',
-        undefined, // no RunState available in this context
-        error,
-        { runContext, input, details },
-      );
+      throw createInvalidToolInputFailure({
+        message: 'Invalid JSON input for tool',
+        originalError: error,
+        toolInvocation: { runContext, input, details },
+      }).error;
     }
 
     if (logger.dontLogToolData) {

--- a/packages/agents-core/src/toolInputError.ts
+++ b/packages/agents-core/src/toolInputError.ts
@@ -11,14 +11,24 @@ type InvalidToolInputFailureOptions = {
   state?: RunState<any, Agent<any, any>>;
   originalError: unknown;
   toolInvocation?: ToolInvocationErrorContext;
+  disposition?: InvalidToolInputDisposition;
 };
 
 export type InvalidToolInputFailure = {
   error: InvalidToolInputError;
   redacted: boolean;
+  disposition: InvalidToolInputDisposition;
+};
+
+export type InvalidToolInputDisposition = {
+  redacted: boolean;
 };
 
 const redactedInvalidToolInputErrors = new WeakSet<InvalidToolInputError>();
+const invalidToolInputFailures = new WeakMap<
+  InvalidToolInputError,
+  InvalidToolInputFailure
+>();
 
 /**
  * Constructs invalid tool input errors without retaining model-produced input
@@ -31,8 +41,14 @@ export function createInvalidToolInputFailure({
   state,
   originalError,
   toolInvocation,
+  disposition: requestedDisposition,
 }: InvalidToolInputFailureOptions): InvalidToolInputFailure {
-  const redacted = logger.dontLogToolData;
+  const disposition =
+    requestedDisposition ?? createInvalidToolInputDisposition();
+  if (logger.dontLogToolData) {
+    disposition.redacted = true;
+  }
+  const redacted = disposition.redacted;
   const error = new InvalidToolInputError(
     message,
     redacted ? undefined : state,
@@ -42,10 +58,37 @@ export function createInvalidToolInputFailure({
   if (redacted) {
     redactedInvalidToolInputErrors.add(error);
   }
-  return {
+  const failure = {
     error,
     redacted,
+    disposition,
   };
+  invalidToolInputFailures.set(error, failure);
+  return failure;
+}
+
+/** @internal */
+export function createInvalidToolInputDisposition(): InvalidToolInputDisposition {
+  return { redacted: logger.dontLogToolData };
+}
+
+/** @internal */
+export function refreshInvalidToolInputFailure(
+  failure: InvalidToolInputFailure,
+): boolean {
+  if (logger.dontLogToolData) {
+    failure.disposition.redacted = true;
+  }
+  if (
+    failure.disposition.redacted &&
+    !redactedInvalidToolInputErrors.has(failure.error)
+  ) {
+    failure.error = new InvalidToolInputError(failure.error.message);
+    redactedInvalidToolInputErrors.add(failure.error);
+    invalidToolInputFailures.set(failure.error, failure);
+  }
+  failure.redacted = failure.disposition.redacted;
+  return failure.redacted;
 }
 
 /** @internal */
@@ -53,4 +96,11 @@ export function isRedactedInvalidToolInputError(
   error: unknown,
 ): error is InvalidToolInputError {
   return redactedInvalidToolInputErrors.has(error as InvalidToolInputError);
+}
+
+/** @internal */
+export function getInvalidToolInputFailure(
+  error: unknown,
+): InvalidToolInputFailure | undefined {
+  return invalidToolInputFailures.get(error as InvalidToolInputError);
 }

--- a/packages/agents-core/src/toolInputError.ts
+++ b/packages/agents-core/src/toolInputError.ts
@@ -1,0 +1,56 @@
+import type { Agent } from './agent';
+import {
+  InvalidToolInputError,
+  type ToolInvocationErrorContext,
+} from './errors';
+import logger from './logger';
+import type { RunState } from './runState';
+
+type InvalidToolInputFailureOptions = {
+  message: string;
+  state?: RunState<any, Agent<any, any>>;
+  originalError: unknown;
+  toolInvocation?: ToolInvocationErrorContext;
+};
+
+export type InvalidToolInputFailure = {
+  error: InvalidToolInputError;
+  redacted: boolean;
+};
+
+const redactedInvalidToolInputErrors = new WeakSet<InvalidToolInputError>();
+
+/**
+ * Constructs invalid tool input errors without retaining model-produced input
+ * or parser details when tool data is redacted.
+ *
+ * @internal
+ */
+export function createInvalidToolInputFailure({
+  message,
+  state,
+  originalError,
+  toolInvocation,
+}: InvalidToolInputFailureOptions): InvalidToolInputFailure {
+  const redacted = logger.dontLogToolData;
+  const error = new InvalidToolInputError(
+    message,
+    redacted ? undefined : state,
+    redacted ? undefined : originalError,
+    redacted ? undefined : toolInvocation,
+  );
+  if (redacted) {
+    redactedInvalidToolInputErrors.add(error);
+  }
+  return {
+    error,
+    redacted,
+  };
+}
+
+/** @internal */
+export function isRedactedInvalidToolInputError(
+  error: unknown,
+): error is InvalidToolInputError {
+  return redactedInvalidToolInputErrors.has(error as InvalidToolInputError);
+}

--- a/packages/agents-core/test/agent.test.ts
+++ b/packages/agents-core/test/agent.test.ts
@@ -704,6 +704,40 @@ describe('Agent', () => {
     expect(result2).toBe('Hello World');
   });
 
+  it.each([
+    ['redacted', true],
+    ['diagnostic', false],
+  ] as const)(
+    'applies %s tool argument diagnostics to Agent.asTool',
+    async (_mode, dontLogToolData) => {
+      const secret = 'SECRET_AGENT_TOOL_ARGUMENT_123';
+      const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+      vi.spyOn(logger, 'dontLogToolData', 'get').mockReturnValue(
+        dontLogToolData,
+      );
+      const agent = new Agent({ name: 'Nested Agent' });
+      const agentTool = agent.asTool({
+        toolName: 'nested_agent',
+        toolDescription: 'Run the nested agent.',
+        parameters: z.object({ value: z.number() }),
+      });
+
+      const output = await agentTool.invoke(
+        new RunContext(),
+        JSON.stringify({ value: secret }),
+      );
+
+      expect(output).toBe(
+        'An error occurred while running the tool. Please try again. Error: InvalidToolInputError: Invalid JSON input for tool',
+      );
+      if (dontLogToolData) {
+        expect(JSON.stringify(debugSpy.mock.calls)).not.toContain(secret);
+      } else {
+        expect(JSON.stringify(debugSpy.mock.calls)).toContain(secret);
+      }
+    },
+  );
+
   it('warns when using asTool with stopAtToolNames behavior without custom extractor', async () => {
     const warnSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
     const runSpy = vi.spyOn(Runner.prototype, 'run').mockResolvedValue({

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -43,6 +43,7 @@ import type { GuardrailFunctionOutput } from '../src/guardrail';
 import { ServerConversationTracker } from '../src/runner/conversation';
 import logger from '../src/logger';
 import { getEventListeners } from 'node:events';
+import { InvalidToolInputError, ToolCallError } from '../src/errors';
 
 function getFirstTextContent(item: AgentInputItem): string | undefined {
   if (item.type !== 'message') {
@@ -596,6 +597,148 @@ describe('Runner.run (streaming)', () => {
         text: "Tool 'missing_tool' not found.",
       },
     });
+  });
+
+  it('streams a redacted invalid-argument output back to the model', async () => {
+    class InvalidArgumentStreamingModel implements Model {
+      readonly requests: ModelRequest[] = [];
+
+      constructor(private readonly responses: ModelResponse[]) {}
+
+      async getResponse(_request: ModelRequest): Promise<ModelResponse> {
+        throw new Error('Unexpected non-streaming model request');
+      }
+
+      async *getStreamedResponse(
+        request: ModelRequest,
+      ): AsyncIterable<StreamEvent> {
+        this.requests.push(request);
+        const response = this.responses.shift();
+        if (!response) {
+          throw new Error('No response found');
+        }
+        yield {
+          type: 'response_done',
+          response: {
+            id: response.responseId ?? 'resp-stream-invalid-argument',
+            usage: {
+              requests: response.usage.requests,
+              inputTokens: response.usage.inputTokens,
+              outputTokens: response.usage.outputTokens,
+              totalTokens: response.usage.totalTokens,
+            },
+            output: response.output.map((item) =>
+              protocol.OutputModelItem.parse(item),
+            ),
+          },
+        } satisfies StreamEvent;
+      }
+    }
+
+    const secret = 'SECRET_STREAMING_MODEL_OUTPUT_123';
+    vi.spyOn(logger, 'dontLogToolData', 'get').mockReturnValue(true);
+    const model = new InvalidArgumentStreamingModel([
+      {
+        output: [
+          {
+            ...TEST_MODEL_FUNCTION_CALL,
+            arguments: secret,
+          },
+        ],
+        usage: new Usage(),
+      },
+      {
+        output: [fakeModelMessage('stream recovered')],
+        usage: new Usage(),
+      },
+    ]);
+    const agent = new Agent({
+      name: 'StreamingInvalidArgumentAgent',
+      model,
+      tools: [
+        tool({
+          name: 'test',
+          description: 'Validate input.',
+          parameters: z.object({ test: z.string() }),
+          execute: async () => 'unexpected',
+        }),
+      ],
+    });
+
+    const result = await run(agent, 'start', { stream: true });
+
+    await result.completed;
+    expect(result.finalOutput).toBe('stream recovered');
+    expect(model.requests).toHaveLength(2);
+    const toolOutput = getRequestInputItems(model.requests[1]).find(
+      (item) => item.type === 'function_call_result',
+    ) as protocol.FunctionCallResultItem | undefined;
+    expect(toolOutput?.output).toEqual({
+      type: 'text',
+      text: 'An error occurred while parsing tool arguments. Please try again with valid JSON.',
+    });
+    expect(JSON.stringify(toolOutput)).not.toContain(secret);
+  });
+
+  it('does not retain invalid arguments in streamed Runner errors', async () => {
+    class InvalidArgumentThrowingStreamModel implements Model {
+      async getResponse(_request: ModelRequest): Promise<ModelResponse> {
+        throw new Error('Unexpected non-streaming model request');
+      }
+
+      async *getStreamedResponse(
+        _request: ModelRequest,
+      ): AsyncIterable<StreamEvent> {
+        yield {
+          type: 'response_done',
+          response: {
+            id: 'resp-stream-invalid-argument-error',
+            usage: {
+              requests: 1,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            output: [
+              protocol.OutputModelItem.parse({
+                ...TEST_MODEL_FUNCTION_CALL,
+                arguments: 'SECRET_STREAMED_RUN_STATE_123',
+              }),
+            ],
+          },
+        } satisfies StreamEvent;
+      }
+    }
+
+    const secret = 'SECRET_STREAMED_RUN_STATE_123';
+    vi.spyOn(logger, 'dontLogToolData', 'get').mockReturnValue(true);
+    const agent = new Agent({
+      name: 'StreamingInvalidArgumentStateAgent',
+      model: new InvalidArgumentThrowingStreamModel(),
+      tools: [
+        tool({
+          name: 'test',
+          description: 'Validate structured input.',
+          parameters: z.object({ test: z.string() }),
+          outputSchema: z.object({ status: z.string() }),
+          errorFunction: null,
+          execute: async () => ({ status: 'unexpected' }),
+        }),
+      ],
+    });
+
+    const result = await run(agent, 'start', { stream: true });
+    const error = await result.completed.catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(ToolCallError);
+    const toolCallError = error as ToolCallError;
+    expect(toolCallError.state).toBeUndefined();
+    expect(toolCallError.error).toBeInstanceOf(InvalidToolInputError);
+    const inputError = toolCallError.error as InvalidToolInputError;
+    expect(inputError.state).toBeUndefined();
+    expect(inputError.originalError).toBeUndefined();
+    expect(inputError.toolInvocation).toBeUndefined();
+    expect(JSON.stringify(toolCallError)).not.toContain(secret);
   });
 
   it('detaches abort listeners after streaming completion when signal is retained', async () => {

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -40,6 +40,7 @@ import {
   type ToolNotFoundBehavior,
 } from '../src';
 import { RunStreamEvent } from '../src/events';
+import { InvalidToolInputError, ToolCallError } from '../src/errors';
 import { ServerConversationTracker } from '../src/runner/conversation';
 import { removeAllTools } from '../src/extensions';
 import { handoff } from '../src/handoff';
@@ -134,6 +135,119 @@ describe('Runner.run', () => {
 
       expect(runner.config.toolExecution).toBe(toolExecution);
     });
+
+    it('returns a redacted invalid-argument output to the model', async () => {
+      const secret = 'SECRET_NON_STREAMING_MODEL_OUTPUT_123';
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(true);
+      const model = new FakeModel([
+        {
+          output: [
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              arguments: secret,
+            },
+          ],
+          usage: new Usage(),
+        },
+        {
+          output: [fakeModelMessage('recovered')],
+          usage: new Usage(),
+        },
+      ]);
+      const getResponseSpy = vi.spyOn(model, 'getResponse');
+      const agent = new Agent({
+        name: 'InvalidArgumentAgent',
+        model,
+        tools: [TEST_TOOL],
+      });
+
+      try {
+        const result = await run(agent, 'start');
+
+        expect(result.finalOutput).toBe('recovered');
+        expect(getResponseSpy).toHaveBeenCalledTimes(2);
+        const secondRequest = getResponseSpy.mock.calls[1][0];
+        const toolOutput = getRequestInputItems(secondRequest).find(
+          (item) => item.type === 'function_call_result',
+        ) as protocol.FunctionCallResultItem | undefined;
+        expect(toolOutput?.output).toEqual({
+          type: 'text',
+          text: 'An error occurred while parsing tool arguments. Please try again with valid JSON.',
+        });
+        expect(JSON.stringify(toolOutput)).not.toContain(secret);
+      } finally {
+        getResponseSpy.mockRestore();
+        flagSpy.mockRestore();
+      }
+    });
+
+    it.each([
+      ['redacted', true],
+      ['diagnostic', false],
+    ] as const)(
+      '%s invalid-argument errors handle real Runner state safely',
+      async (_mode, dontLogToolData) => {
+        const secret = dontLogToolData
+          ? 'SECRET_REDACTED_RUN_STATE_123'
+          : 'SECRET_DIAGNOSTIC_RUN_STATE_123';
+        const flagSpy = vi
+          .spyOn(logger, 'dontLogToolData', 'get')
+          .mockReturnValue(dontLogToolData);
+        const model = new FakeModel([
+          {
+            output: [
+              {
+                ...TEST_MODEL_FUNCTION_CALL,
+                arguments: secret,
+              },
+            ],
+            usage: new Usage(),
+          },
+        ]);
+        const structuredTool = tool({
+          name: 'test',
+          description: 'Validate structured input.',
+          parameters: z.object({ test: z.string() }),
+          outputSchema: z.object({ status: z.string() }),
+          errorFunction: null,
+          execute: async () => ({ status: 'unexpected' }),
+        });
+        const agent = new Agent({
+          name: 'InvalidArgumentStateAgent',
+          model,
+          tools: [structuredTool],
+        });
+
+        try {
+          const error = await run(agent, 'start').catch((caught) => caught);
+
+          expect(error).toBeInstanceOf(ToolCallError);
+          const toolCallError = error as ToolCallError;
+          expect(toolCallError.error).toBeInstanceOf(InvalidToolInputError);
+          const inputError = toolCallError.error as InvalidToolInputError;
+          if (dontLogToolData) {
+            expect(toolCallError.state).toBeUndefined();
+            expect(inputError.state).toBeUndefined();
+            expect(inputError.originalError).toBeUndefined();
+            expect(inputError.toolInvocation).toBeUndefined();
+            expect(JSON.stringify(toolCallError)).not.toContain(secret);
+          } else {
+            expect(toolCallError.state).toBeDefined();
+            expect(inputError.state).toBe(toolCallError.state);
+            expect(inputError.originalError).toBeDefined();
+            expect(inputError.toolInvocation?.input).toBe(secret);
+            expect(
+              inputError.state?._lastProcessedResponse?.functions[0].toolCall
+                .arguments,
+            ).toBe(secret);
+          }
+        } finally {
+          flagSpy.mockRestore();
+        }
+      },
+    );
 
     it('propagates run cancellation to a direct function tool', async () => {
       const controller = new AbortController();

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -3049,6 +3049,161 @@ describe('executeShellActions', () => {
       );
     });
 
+    it('evaluates dynamic approval policies for schema-invalid objects', async () => {
+      const needsApproval = vi.fn(async () => false);
+      const execute = vi.fn(async () => 'unexpected');
+      const t = tool({
+        name: 'schema_invalid_dynamic_approval',
+        description: 'Return a fallback for schema-invalid input.',
+        parameters: z.object({ value: z.number() }),
+        needsApproval,
+        execute,
+      }) as unknown as FunctionTool;
+      const invalidArguments = { value: 'invalid' };
+
+      const [result] = await executeFunctionToolCalls(
+        state._currentAgent,
+        [
+          {
+            toolCall: {
+              ...toolCall,
+              name: 'schema_invalid_dynamic_approval',
+              arguments: JSON.stringify(invalidArguments),
+            },
+            tool: t,
+          },
+        ],
+        runner,
+        state,
+      );
+
+      expect(result).toMatchObject({
+        type: 'function_output',
+        output: expect.stringContaining('running the tool'),
+      });
+      expect(needsApproval).toHaveBeenCalledWith(
+        state._context,
+        invalidArguments,
+        toolCall.callId,
+      );
+      expect(execute).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['secure from start', true],
+      ['promoted by the callback', false],
+    ] as const)(
+      'redacts arbitrary schema-invalid approval failures when %s',
+      async (_mode, initiallyRedacted) => {
+        const secret = 'SECRET_SCHEMA_APPROVAL_FAILURE_123';
+        let redactToolData = initiallyRedacted;
+        const flagSpy = vi
+          .spyOn(logger, 'dontLogToolData', 'get')
+          .mockImplementation(() => redactToolData);
+        const debugSpy = vi.spyOn(logger, 'debug');
+        const invalidArguments = { value: secret };
+        const { proxy, revoke } = Proxy.revocable({ secret }, {});
+        revoke();
+        const thrownValues: unknown[] = [new Error(secret), secret, proxy];
+        let thrownValue: unknown;
+        const needsApproval = vi.fn(async (_context, args) => {
+          expect(args).toEqual(invalidArguments);
+          debugSpy.mockClear();
+          redactToolData = true;
+          throw thrownValue;
+        });
+        const t = tool({
+          name: 'schema_invalid_approval_failure',
+          description: 'Fail while deciding approval for invalid input.',
+          parameters: z.object({ value: z.number() }),
+          needsApproval,
+          execute: vi.fn(async () => 'unexpected'),
+        }) as unknown as FunctionTool;
+
+        try {
+          for (let index = 0; index < thrownValues.length; index += 1) {
+            redactToolData = initiallyRedacted;
+            thrownValue = thrownValues[index];
+            const error = await executeFunctionToolCalls(
+              state._currentAgent,
+              [
+                {
+                  toolCall: {
+                    ...toolCall,
+                    callId: `schema_invalid_approval_failure_${index}`,
+                    name: 'schema_invalid_approval_failure',
+                    arguments: JSON.stringify(invalidArguments),
+                  },
+                  tool: t,
+                },
+              ],
+              runner,
+              state,
+            ).catch((caught) => caught);
+
+            expect(error).toBeInstanceOf(ToolCallError);
+            expect((error as ToolCallError).state).toBeUndefined();
+            expect((error as ToolCallError).error).toBeInstanceOf(
+              InvalidToolInputError,
+            );
+            expect((error as ToolCallError).error).toMatchObject({
+              message:
+                "Invalid input for function tool 'schema_invalid_approval_failure'.",
+            });
+            expect((error as ToolCallError).message).not.toContain(secret);
+            expect(JSON.stringify(error)).not.toContain(secret);
+            expect(JSON.stringify(debugSpy.mock.calls)).not.toContain(secret);
+          }
+        } finally {
+          debugSpy.mockRestore();
+          flagSpy.mockRestore();
+        }
+      },
+    );
+
+    it('preserves diagnostic schema-invalid approval failures', async () => {
+      const secret = 'SECRET_DIAGNOSTIC_SCHEMA_APPROVAL_FAILURE_123';
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(false);
+      const approvalError = new Error(secret);
+      const needsApproval = vi.fn(async () => {
+        throw approvalError;
+      });
+      const t = tool({
+        name: 'diagnostic_schema_invalid_approval_failure',
+        description: 'Preserve diagnostic approval failures.',
+        parameters: z.object({ value: z.number() }),
+        needsApproval,
+        execute: vi.fn(async () => 'unexpected'),
+      }) as unknown as FunctionTool;
+
+      try {
+        const error = await executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                name: 'diagnostic_schema_invalid_approval_failure',
+                arguments: JSON.stringify({ value: secret }),
+              },
+              tool: t,
+            },
+          ],
+          runner,
+          state,
+        ).catch((caught) => caught);
+
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect((error as ToolCallError).state).toBe(state);
+        expect((error as ToolCallError).error).toBe(approvalError);
+        expect((error as ToolCallError).message).toContain(secret);
+      } finally {
+        flagSpy.mockRestore();
+      }
+    });
+
     it('rejects malformed arguments without invoking the approval policy', async () => {
       const needsApproval = vi.fn(async () => false);
       const t = tool({
@@ -6609,7 +6764,11 @@ describe('executeShellActions', () => {
           state,
         ).catch((caught) => caught);
 
-        expect(needsApproval).not.toHaveBeenCalled();
+        expect(needsApproval).toHaveBeenCalledWith(
+          state._context,
+          { value: secret },
+          toolCall.callId,
+        );
         expect(error).toBeInstanceOf(ToolCallError);
         expect((error as ToolCallError).state).toBeUndefined();
         expect(JSON.stringify(error)).not.toContain(secret);

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -58,7 +58,9 @@ import {
 } from '../../src/toolGuardrail';
 import {
   FunctionTool,
+  type FunctionToolCustomDataContext,
   FunctionToolResult,
+  type ToolCallDetails,
   applyPatchTool,
   computerTool,
   shellTool,
@@ -4197,6 +4199,121 @@ describe('executeShellActions', () => {
       expect(startedTools).toEqual(['failing_tool']);
     });
 
+    it('parses capped function calls when their scheduler slot starts', async () => {
+      const order: string[] = [];
+      let ready = false;
+      runner = new Runner({
+        tracingDisabled: true,
+        toolExecution: { maxFunctionToolConcurrency: 1 },
+      });
+      const firstTool = tool({
+        name: 'prepare_refinement_state',
+        description: 'Prepare state for the next parser.',
+        parameters: z.object({}),
+        execute: vi.fn(async () => {
+          order.push('execute-first');
+          ready = true;
+          return 'first-ok';
+        }),
+      }) as unknown as FunctionTool;
+      const secondTool = tool({
+        name: 'observe_refinement_state',
+        description: 'Observe state when parsing starts.',
+        parameters: z.object({
+          value: z.string().refine(() => {
+            order.push(`parse-second-ready-${ready}`);
+            return ready;
+          }),
+        }),
+        execute: vi.fn(async () => 'second-ok'),
+      }) as unknown as FunctionTool;
+
+      const results = await executeFunctionToolCalls(
+        state._currentAgent,
+        [
+          {
+            toolCall: {
+              ...toolCall,
+              name: 'prepare_refinement_state',
+              callId: 'c1',
+              arguments: '{}',
+            },
+            tool: firstTool,
+          },
+          {
+            toolCall: {
+              ...toolCall,
+              name: 'observe_refinement_state',
+              callId: 'c2',
+              arguments: JSON.stringify({ value: 'ok' }),
+            },
+            tool: secondTool,
+          },
+        ],
+        runner,
+        state,
+      );
+
+      expect(order).toEqual(['execute-first', 'parse-second-ready-true']);
+      expect(results).toMatchObject([
+        { type: 'function_output', output: 'first-ok' },
+        { type: 'function_output', output: 'second-ok' },
+      ]);
+    });
+
+    it('does not parse queued function calls after a capped failure', async () => {
+      const queuedRefinement = vi.fn(() => true);
+      runner = new Runner({
+        tracingDisabled: true,
+        toolExecution: { maxFunctionToolConcurrency: 1 },
+      });
+      const failingTool = tool({
+        name: 'fail_before_queued_parser',
+        description: 'Fail before the queued parser starts.',
+        parameters: z.object({}),
+        errorFunction: null,
+        execute: vi.fn(async () => {
+          throw new Error('boom');
+        }),
+      }) as unknown as FunctionTool;
+      const queuedTool = tool({
+        name: 'queued_parser',
+        description: 'Remain queued after the failure.',
+        parameters: z.object({ value: z.string().refine(queuedRefinement) }),
+        execute: vi.fn(async () => 'unexpected'),
+      }) as unknown as FunctionTool;
+
+      await expect(
+        executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                name: 'fail_before_queued_parser',
+                callId: 'c1',
+                arguments: '{}',
+              },
+              tool: failingTool,
+            },
+            {
+              toolCall: {
+                ...toolCall,
+                name: 'queued_parser',
+                callId: 'c2',
+                arguments: JSON.stringify({ value: 'queued' }),
+              },
+              tool: queuedTool,
+            },
+          ],
+          runner,
+          state,
+        ),
+      ).rejects.toThrow(/Failed to run function tools/);
+
+      expect(queuedRefinement).not.toHaveBeenCalled();
+    });
+
     it('does not expose parentRunConfig on public tool callback details', async () => {
       const circularProvider: Record<string, unknown> = {};
       circularProvider.self = circularProvider;
@@ -4908,118 +5025,1872 @@ describe('executeShellActions', () => {
       }
     });
 
-    it('maps parse failures through a structured error fallback', async () => {
-      const secret = 'SECRET_STRUCTURED_PARSE_ARGUMENT_123';
+    it.each([
+      ['redacted', true],
+      ['diagnostic', false],
+    ] as const)(
+      'maps %s parse failures through a structured error fallback',
+      async (_mode, dontLogToolData) => {
+        const secret = 'SECRET_STRUCTURED_PARSE_ARGUMENT_123';
+        const flagSpy = vi
+          .spyOn(logger, 'dontLogToolData', 'get')
+          .mockReturnValue(dontLogToolData);
+        const errorFunction = vi.fn(
+          (
+            _context: RunContext,
+            _error: unknown,
+            details?: ToolCallDetails,
+          ) => ({
+            status: 'invalid_input' as const,
+            detail: details?.toolCall?.arguments ?? 'redacted',
+          }),
+        );
+        const t = tool({
+          name: 'structured_parser',
+          description: 'Parse structured input.',
+          parameters: z.object({ value: z.string() }),
+          outputSchema: z.object({
+            status: z.literal('invalid_input'),
+            detail: z.string(),
+          }),
+          errorFunction,
+          execute: vi.fn(async () => ({
+            status: 'invalid_input' as const,
+            detail: 'unexpected',
+          })),
+        }) as unknown as FunctionTool;
+        const invalidToolCall = {
+          ...toolCall,
+          name: 'structured_parser',
+          arguments: secret,
+        };
+
+        try {
+          const res = await withTrace('test', () =>
+            executeFunctionToolCalls(
+              state._currentAgent,
+              [{ toolCall: invalidToolCall, tool: t }],
+              runner,
+              state,
+            ),
+          );
+
+          expect(res[0]).toMatchObject({
+            type: 'function_output',
+            output: {
+              status: 'invalid_input',
+              detail: dontLogToolData ? 'redacted' : secret,
+            },
+            runItem: {
+              rawItem: {
+                output: {
+                  type: 'text',
+                  text: JSON.stringify({
+                    status: 'invalid_input',
+                    detail: dontLogToolData ? 'redacted' : secret,
+                  }),
+                },
+              },
+            },
+          });
+          expect(errorFunction).toHaveBeenCalledWith(
+            state._context,
+            expect.objectContaining({
+              name: 'InvalidToolInputError',
+              originalError: dontLogToolData ? undefined : expect.anything(),
+              toolInvocation: dontLogToolData
+                ? undefined
+                : expect.objectContaining({ input: secret }),
+            }),
+            dontLogToolData ? undefined : { toolCall: invalidToolCall },
+          );
+          const capturedError = errorFunction.mock.calls[0][1] as
+            InvalidToolInputError | undefined;
+          expect(capturedError).toBeDefined();
+          if (dontLogToolData) {
+            expect(capturedError?.toolInvocation).toBeUndefined();
+            expect(errorFunction.mock.calls[0][2]).toBeUndefined();
+            expect(JSON.stringify(res[0])).not.toContain(secret);
+          } else {
+            expect(capturedError?.toolInvocation).toMatchObject({
+              input: secret,
+            });
+            expect(errorFunction.mock.calls[0][2]).toEqual({
+              toolCall: invalidToolCall,
+            });
+          }
+        } finally {
+          flagSpy.mockRestore();
+        }
+      },
+    );
+
+    it('preserves errorFunction null for runner-detected schema failures', async () => {
+      const secret = 'SECRET_NULL_SCHEMA_ARGUMENT_123';
       const flagSpy = vi
         .spyOn(logger, 'dontLogToolData', 'get')
         .mockReturnValue(true);
-      const errorFunction = vi.fn(
-        (_context: RunContext, _error: unknown, _details?: unknown) => ({
-          status: 'invalid_input' as const,
-        }),
-      );
+      const execute = vi.fn(async () => 'unexpected');
       const t = tool({
-        name: 'structured_parser',
-        description: 'Parse structured input.',
-        parameters: z.object({ value: z.string() }),
-        outputSchema: z.object({ status: z.literal('invalid_input') }),
-        errorFunction,
-        execute: vi.fn(async () => ({ status: 'invalid_input' as const })),
+        name: 'null_schema_parser',
+        description: 'Reject schema input without a fallback.',
+        parameters: z.object({ value: z.number() }),
+        errorFunction: null,
+        execute,
       }) as unknown as FunctionTool;
-      const invalidToolCall = {
-        ...toolCall,
-        name: 'structured_parser',
-        arguments: secret,
-      };
 
       try {
-        const res = await withTrace('test', () =>
-          executeFunctionToolCalls(
-            state._currentAgent,
-            [{ toolCall: invalidToolCall, tool: t }],
-            runner,
-            state,
-          ),
-        );
-
-        expect(res[0]).toMatchObject({
-          type: 'function_output',
-          output: { status: 'invalid_input' },
-          runItem: {
-            rawItem: {
-              output: {
-                type: 'text',
-                text: JSON.stringify({ status: 'invalid_input' }),
+        const error = await executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                name: 'null_schema_parser',
+                arguments: JSON.stringify({ value: secret }),
               },
+              tool: t,
             },
-          },
-        });
-        expect(errorFunction).toHaveBeenCalledWith(
-          state._context,
-          expect.objectContaining({
-            name: 'InvalidToolInputError',
-            originalError: undefined,
-            toolInvocation: undefined,
-          }),
-          { toolCall: invalidToolCall },
+          ],
+          runner,
+          state,
+        ).catch((caught) => caught);
+
+        expect(execute).not.toHaveBeenCalled();
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect((error as ToolCallError).error).toBeInstanceOf(
+          InvalidToolInputError,
         );
-        const capturedError = errorFunction.mock.calls[0][1] as
-          InvalidToolInputError | undefined;
-        expect(capturedError).toBeDefined();
-        expect(capturedError?.toolInvocation).toBeUndefined();
+        expect((error as ToolCallError).state).toBeUndefined();
+        expect(JSON.stringify(error)).not.toContain(secret);
       } finally {
         flagSpy.mockRestore();
       }
     });
 
-    it('redacts schema validation failures from traces and logs', async () => {
-      const secret = 'SECRET_SCHEMA_TRACE_ARGUMENT_123';
+    it.each([
+      ['redacted', true],
+      ['diagnostic', false],
+    ] as const)(
+      'maps %s schema failures through an unstructured error fallback',
+      async (_mode, dontLogToolData) => {
+        const secret = 'SECRET_UNSTRUCTURED_SCHEMA_ARGUMENT_123';
+        const flagSpy = vi
+          .spyOn(logger, 'dontLogToolData', 'get')
+          .mockReturnValue(dontLogToolData);
+        const execute = vi.fn(async () => 'unexpected');
+        const errorFunction = vi.fn(
+          (_context: RunContext, _error: unknown, details?: ToolCallDetails) =>
+            `custom fallback: ${details?.toolCall?.arguments ?? 'redacted'}`,
+        );
+        const t = tool({
+          name: 'unstructured_schema_parser',
+          description: 'Parse schema input with an unstructured fallback.',
+          parameters: z.object({ value: z.number() }),
+          errorFunction,
+          execute,
+        }) as unknown as FunctionTool;
+        const invalidToolCall = {
+          ...toolCall,
+          name: 'unstructured_schema_parser',
+          arguments: JSON.stringify({ value: secret }),
+        };
+
+        try {
+          const [result] = await executeFunctionToolCalls(
+            state._currentAgent,
+            [{ toolCall: invalidToolCall, tool: t }],
+            runner,
+            state,
+          );
+
+          expect(execute).not.toHaveBeenCalled();
+          expect(result).toMatchObject({
+            type: 'function_output',
+            output: `custom fallback: ${
+              dontLogToolData ? 'redacted' : invalidToolCall.arguments
+            }`,
+          });
+          expect(errorFunction).toHaveBeenCalledWith(
+            state._context,
+            expect.objectContaining({
+              name: 'InvalidToolInputError',
+              message: 'Invalid JSON input for tool',
+              state: undefined,
+              originalError: dontLogToolData ? undefined : expect.anything(),
+              toolInvocation: dontLogToolData
+                ? undefined
+                : expect.objectContaining({
+                    input: invalidToolCall.arguments,
+                    details: expect.objectContaining({
+                      toolCall: invalidToolCall,
+                    }),
+                  }),
+            }),
+            dontLogToolData
+              ? undefined
+              : expect.objectContaining({ toolCall: invalidToolCall }),
+          );
+          if (dontLogToolData) {
+            expect(JSON.stringify(result)).not.toContain(secret);
+          }
+        } finally {
+          flagSpy.mockRestore();
+        }
+      },
+    );
+
+    it('preserves the default factory fallback for schema failures', async () => {
+      const [result] = await executeFunctionToolCalls(
+        state._currentAgent,
+        [
+          {
+            toolCall: {
+              ...toolCall,
+              name: 'default_schema_fallback',
+              arguments: JSON.stringify({ value: 'invalid' }),
+            },
+            tool: tool({
+              name: 'default_schema_fallback',
+              description: 'Use the default schema failure fallback.',
+              parameters: z.object({ value: z.number() }),
+              execute: vi.fn(async () => 'unexpected'),
+            }) as unknown as FunctionTool,
+          },
+        ],
+        runner,
+        state,
+      );
+
+      expect(result).toMatchObject({
+        type: 'function_output',
+        output:
+          'An error occurred while running the tool. Please try again. Error: InvalidToolInputError: Invalid JSON input for tool',
+      });
+    });
+
+    it('keeps schema failure fallbacks inside the tool lifecycle', async () => {
+      const secret = 'SECRET_SCHEMA_LIFECYCLE_ARGUMENT_123';
       const flagSpy = vi
         .spyOn(logger, 'dontLogToolData', 'get')
         .mockReturnValue(true);
-      const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+      const start = vi.fn();
+      const end = vi.fn();
+      const outputGuardrail = vi.fn(async () =>
+        ToolGuardrailFunctionOutputFactory.allow(),
+      );
+      const customDataExtractor = vi.fn(
+        (context: FunctionToolCustomDataContext) => ({
+          inputRedacted: typeof context.input === 'undefined',
+        }),
+      );
       const t = tool({
-        name: 'schema_trace_parser',
-        description: 'Parse schema input.',
+        name: 'schema_failure_lifecycle',
+        description: 'Keep schema fallbacks in the normal lifecycle.',
         parameters: z.object({ value: z.number() }),
-        execute: vi.fn(async () => 'success'),
+        errorFunction: () => 'safe fallback',
+        outputGuardrails: [
+          {
+            name: 'observe_fallback',
+            run: outputGuardrail,
+          },
+        ],
+        customDataExtractor,
+        execute: vi.fn(async () => 'unexpected'),
       }) as unknown as FunctionTool;
       const invalidToolCall = {
         ...toolCall,
-        name: 'schema_trace_parser',
+        name: 'schema_failure_lifecycle',
+        arguments: JSON.stringify({ value: secret }),
+      };
+      runner.on('agent_tool_start', start);
+      runner.on('agent_tool_end', end);
+
+      try {
+        const [result] = await executeFunctionToolCalls(
+          state._currentAgent,
+          [{ toolCall: invalidToolCall, tool: t }],
+          runner,
+          state,
+        );
+
+        expect(result).toMatchObject({
+          type: 'function_output',
+          output: 'safe fallback',
+          runItem: { customData: { inputRedacted: true } },
+        });
+        expect(outputGuardrail).toHaveBeenCalledTimes(1);
+        expect(customDataExtractor).toHaveBeenCalledWith(
+          expect.objectContaining({
+            input: undefined,
+            output: 'safe fallback',
+          }),
+        );
+        expect(start).toHaveBeenCalledTimes(1);
+        expect(end).toHaveBeenCalledTimes(1);
+        expect(JSON.stringify(result)).not.toContain(secret);
+      } finally {
+        flagSpy.mockRestore();
+      }
+    });
+
+    it('keeps the classification-time redaction policy across awaits', async () => {
+      const secret = 'SECRET_SCHEMA_POLICY_SNAPSHOT_123';
+      let redactToolData = true;
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockImplementation(() => redactToolData);
+      const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+      const errorFunction = vi.fn(() => 'safe fallback');
+      const t = tool({
+        name: 'schema_policy_snapshot',
+        description: 'Keep the classification-time redaction policy.',
+        parameters: z.object({ value: z.number() }),
+        errorFunction,
+        inputGuardrails: [
+          {
+            name: 'change_policy_after_classification',
+            run: async () => {
+              redactToolData = false;
+              return ToolGuardrailFunctionOutputFactory.allow();
+            },
+          },
+        ],
+        execute: vi.fn(async () => 'unexpected'),
+      }) as unknown as FunctionTool;
+
+      try {
+        const [result] = await executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                name: 'schema_policy_snapshot',
+                arguments: JSON.stringify({ value: secret }),
+              },
+              tool: t,
+            },
+          ],
+          runner,
+          state,
+        );
+
+        expect(result).toMatchObject({
+          type: 'function_output',
+          output: 'safe fallback',
+        });
+        expect(errorFunction).toHaveBeenCalledWith(
+          state._context,
+          expect.objectContaining({
+            message: 'Invalid JSON input for tool',
+            originalError: undefined,
+            toolInvocation: undefined,
+          }),
+          undefined,
+        );
+        expect(JSON.stringify(debugSpy.mock.calls)).not.toContain(secret);
+        expect(JSON.stringify(result)).not.toContain(secret);
+      } finally {
+        debugSpy.mockRestore();
+        flagSpy.mockRestore();
+      }
+    });
+
+    it('promotes prepared failure redaction when secure mode is enabled after classification', async () => {
+      const secret = 'SECRET_SCHEMA_POLICY_PROMOTION_123';
+      let redactToolData = false;
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockImplementation(() => redactToolData);
+      const errorFunction = vi.fn(() => 'safe fallback');
+      const customDataExtractor = vi.fn(
+        (context: FunctionToolCustomDataContext) => ({
+          inputRedacted: typeof context.input === 'undefined',
+        }),
+      );
+      const t = tool({
+        name: 'schema_policy_promotion',
+        description: 'Promote redaction after classification.',
+        parameters: z.object({ value: z.number() }),
+        errorFunction,
+        inputGuardrails: [
+          {
+            name: 'enable_secure_mode',
+            run: async () => {
+              redactToolData = true;
+              return ToolGuardrailFunctionOutputFactory.allow();
+            },
+          },
+        ],
+        customDataExtractor,
+        execute: vi.fn(async () => 'unexpected'),
+      }) as unknown as FunctionTool;
+      const invalidToolCall = {
+        ...toolCall,
+        name: 'schema_policy_promotion',
         arguments: JSON.stringify({ value: secret }),
       };
 
       try {
+        const [result] = await executeFunctionToolCalls(
+          state._currentAgent,
+          [{ toolCall: invalidToolCall, tool: t }],
+          runner,
+          state,
+        );
+
+        expect(errorFunction).toHaveBeenCalledWith(
+          state._context,
+          expect.objectContaining({
+            message: 'Invalid JSON input for tool',
+            originalError: undefined,
+            toolInvocation: undefined,
+          }),
+          undefined,
+        );
+        expect(customDataExtractor).toHaveBeenCalledWith(
+          expect.objectContaining({
+            input: undefined,
+            output: 'safe fallback',
+          }),
+        );
+        expect(result).toMatchObject({
+          type: 'function_output',
+          runItem: { customData: { inputRedacted: true } },
+        });
+        expect(JSON.stringify(result)).not.toContain(secret);
+      } finally {
+        flagSpy.mockRestore();
+      }
+    });
+
+    it.each([
+      ['malformed JSON', 'SECRET_LATE_MALFORMED_ERROR_FUNCTION_123'],
+      [
+        'schema validation',
+        JSON.stringify({ value: 'SECRET_LATE_SCHEMA_ERROR_FUNCTION_123' }),
+      ],
+    ])(
+      'discards %s fallback output when errorFunction enables secure mode',
+      async (_label, input) => {
+        let redactToolData = false;
+        const flagSpy = vi
+          .spyOn(logger, 'dontLogToolData', 'get')
+          .mockImplementation(() => redactToolData);
+        const errorFunction = vi.fn(
+          (
+            _context: RunContext,
+            _error: unknown,
+            details?: ToolCallDetails,
+          ) => {
+            redactToolData = true;
+            return {
+              status: details?.toolCall?.arguments ?? input,
+            };
+          },
+        );
+        const t = tool({
+          name: 'late_error_function_redaction',
+          description: 'Promote redaction while building a fallback.',
+          parameters: z.object({ value: z.number() }),
+          outputSchema: z.object({ status: z.string() }),
+          errorFunction,
+          execute: vi.fn(async () => ({ status: 'unexpected' })),
+        }) as unknown as FunctionTool;
+
+        try {
+          const error = await executeFunctionToolCalls(
+            state._currentAgent,
+            [
+              {
+                toolCall: {
+                  ...toolCall,
+                  name: 'late_error_function_redaction',
+                  arguments: input,
+                },
+                tool: t,
+              },
+            ],
+            runner,
+            state,
+          ).catch((caught) => caught);
+
+          expect(errorFunction).toHaveBeenCalledOnce();
+          expect(error).toBeInstanceOf(ToolCallError);
+          expect((error as ToolCallError).state).toBeUndefined();
+          expect(JSON.stringify(error)).not.toContain(input);
+        } finally {
+          flagSpy.mockRestore();
+        }
+      },
+    );
+
+    it('clears malformed-input trace data after errorFunction enables secure mode', async () => {
+      const secret = 'SECRET_LATE_MALFORMED_TRACE_123';
+      let redactToolData = false;
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockImplementation(() => redactToolData);
+      const t = tool({
+        name: 'late_malformed_trace_redaction',
+        description: 'Promote redaction while building a fallback.',
+        parameters: z.object({ value: z.number() }),
+        outputSchema: z.object({ status: z.string() }),
+        errorFunction: (_context, _error, details) => {
+          redactToolData = true;
+          return { status: details?.toolCall?.arguments ?? secret };
+        },
+        execute: vi.fn(async () => ({ status: 'unexpected' })),
+      }) as unknown as FunctionTool;
+
+      try {
         await withRecordingTrace(async (processor) => {
-          const [result] = await withTrace('test', () =>
+          const error = await withTrace('test', () =>
             executeFunctionToolCalls(
               state._currentAgent,
-              [{ toolCall: invalidToolCall, tool: t }],
+              [
+                {
+                  toolCall: {
+                    ...toolCall,
+                    name: 'late_malformed_trace_redaction',
+                    arguments: secret,
+                  },
+                  tool: t,
+                },
+              ],
               new Runner({
                 tracingDisabled: false,
-                traceIncludeSensitiveData: false,
+                traceIncludeSensitiveData: true,
               }),
               state,
-            ),
+            ).catch((caught) => caught),
           );
 
-          expect(result.type).toBe('function_output');
-          if (result.type === 'function_output') {
-            expect(String(result.output)).not.toContain(secret);
-          }
+          expect(error).toBeInstanceOf(ToolCallError);
           const functionSpan = getEndedFunctionSpan(
             processor,
-            'schema_trace_parser',
+            'late_malformed_trace_redaction',
           );
           expect(JSON.stringify(functionSpan.toJSON())).not.toContain(secret);
+          expect(JSON.stringify(error)).not.toContain(secret);
         });
+      } finally {
+        flagSpy.mockRestore();
+      }
+    });
+
+    it('discards custom data when its extractor enables secure mode', async () => {
+      const secret = 'SECRET_LATE_CUSTOM_DATA_123';
+      let redactToolData = false;
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockImplementation(() => redactToolData);
+      const t = tool({
+        name: 'late_custom_data_redaction',
+        description: 'Promote redaction while extracting custom data.',
+        parameters: z.object({ value: z.number() }),
+        errorFunction: () => 'diagnostic fallback',
+        customDataExtractor: (context) => {
+          redactToolData = true;
+          return { captured: context.input };
+        },
+        execute: vi.fn(async () => 'unexpected'),
+      }) as unknown as FunctionTool;
+
+      try {
+        const error = await executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                name: 'late_custom_data_redaction',
+                arguments: JSON.stringify({ value: secret }),
+              },
+              tool: t,
+            },
+          ],
+          runner,
+          state,
+        ).catch((caught) => caught);
+
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect((error as ToolCallError).state).toBeUndefined();
+        expect(JSON.stringify(error)).not.toContain(secret);
+      } finally {
+        flagSpy.mockRestore();
+      }
+    });
+
+    it('discards output guardrail artifacts when secure mode is enabled', async () => {
+      const secret = 'SECRET_LATE_OUTPUT_GUARDRAIL_123';
+      let redactToolData = false;
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockImplementation(() => redactToolData);
+      const t = tool({
+        name: 'late_output_guardrail_redaction',
+        description: 'Promote redaction in an output guardrail.',
+        parameters: z.object({ value: z.number() }),
+        errorFunction: () => 'diagnostic fallback',
+        outputGuardrails: [
+          {
+            name: 'enable_secure_mode',
+            run: async ({ toolCall: callbackToolCall }) => {
+              redactToolData = true;
+              return ToolGuardrailFunctionOutputFactory.rejectContent(
+                callbackToolCall.arguments,
+              );
+            },
+          },
+        ],
+        execute: vi.fn(async () => 'unexpected'),
+      }) as unknown as FunctionTool;
+
+      try {
+        const error = await executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                name: 'late_output_guardrail_redaction',
+                arguments: JSON.stringify({ value: secret }),
+              },
+              tool: t,
+            },
+          ],
+          runner,
+          state,
+        ).catch((caught) => caught);
+
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect((error as ToolCallError).state).toBeUndefined();
+        expect(state._toolOutputGuardrailResults).toHaveLength(0);
+        expect(JSON.stringify(error)).not.toContain(secret);
+      } finally {
+        flagSpy.mockRestore();
+      }
+    });
+
+    it('preserves SDK guardrail tripwires for already-redacted invalid input', async () => {
+      const secret = 'SECRET_REDACTED_GUARDRAIL_TRIPWIRE_123';
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(true);
+      const t = tool({
+        name: 'redacted_guardrail_tripwire',
+        description: 'Preserve the SDK guardrail failure type.',
+        parameters: z.object({ value: z.number() }),
+        inputGuardrails: [
+          {
+            name: 'tripwire',
+            run: async () =>
+              ToolGuardrailFunctionOutputFactory.throwException(),
+          },
+        ],
+        errorFunction: () => 'unexpected',
+        execute: vi.fn(async () => 'unexpected'),
+      }) as unknown as FunctionTool;
+
+      try {
+        const error = await executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                name: 'redacted_guardrail_tripwire',
+                arguments: JSON.stringify({ value: secret }),
+              },
+              tool: t,
+            },
+          ],
+          runner,
+          state,
+        ).catch((caught) => caught);
+
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect((error as ToolCallError).state).toBeUndefined();
+        expect((error as ToolCallError).error).toBeInstanceOf(
+          ToolInputGuardrailTripwireTriggered,
+        );
+        expect(JSON.stringify(error)).not.toContain(secret);
+      } finally {
+        flagSpy.mockRestore();
+      }
+    });
+
+    it.each([
+      ['secure from start', true],
+      ['promoted in hook', false],
+    ] as const)(
+      'redacts arbitrary end-hook failures when %s',
+      async (_mode, initiallyRedacted) => {
+        const secret = 'SECRET_END_HOOK_THROW_123';
+        let redactToolData = initiallyRedacted;
+        const flagSpy = vi
+          .spyOn(logger, 'dontLogToolData', 'get')
+          .mockImplementation(() => redactToolData);
+        const thrownValues = [
+          new Error(secret),
+          secret,
+          (() => {
+            const { proxy, revoke } = Proxy.revocable({}, {});
+            revoke();
+            return proxy;
+          })(),
+        ];
+        const t = tool({
+          name: 'redacted_end_hook_failure',
+          description: 'Redact arbitrary end-hook failures.',
+          parameters: z.object({ value: z.number() }),
+          errorFunction: () => 'safe fallback',
+          execute: vi.fn(async () => 'unexpected'),
+        }) as unknown as FunctionTool;
+        let currentThrown: unknown;
+        runner.on('agent_tool_end', () => {
+          redactToolData = true;
+          throw currentThrown;
+        });
+
+        try {
+          for (let index = 0; index < thrownValues.length; index += 1) {
+            redactToolData = initiallyRedacted;
+            currentThrown = thrownValues[index];
+            const error = await executeFunctionToolCalls(
+              state._currentAgent,
+              [
+                {
+                  toolCall: {
+                    ...toolCall,
+                    callId: `redacted_end_hook_${index}`,
+                    name: 'redacted_end_hook_failure',
+                    arguments: JSON.stringify({ value: secret }),
+                  },
+                  tool: t,
+                },
+              ],
+              runner,
+              state,
+            ).catch((caught) => caught);
+
+            expect(error).toBeInstanceOf(ToolCallError);
+            expect((error as ToolCallError).state).toBeUndefined();
+            expect((error as ToolCallError).error).toBeInstanceOf(
+              InvalidToolInputError,
+            );
+            expect(JSON.stringify(error)).not.toContain(secret);
+          }
+        } finally {
+          flagSpy.mockRestore();
+        }
+      },
+    );
+
+    it('redacts invalid arguments from later hooks after policy promotion', async () => {
+      const secret = 'SECRET_LATE_HOOK_ARGUMENT_123';
+      let redactToolData = false;
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockImplementation(() => redactToolData);
+      const agentHook = vi.fn();
+      const t = tool({
+        name: 'late_hook_redaction',
+        description: 'Promote redaction between tool hooks.',
+        parameters: z.object({ value: z.number() }),
+        errorFunction: () => 'safe fallback',
+        execute: vi.fn(async () => 'unexpected'),
+      }) as unknown as FunctionTool;
+      runner.on('agent_tool_start', () => {
+        redactToolData = true;
+      });
+      state._currentAgent.on('agent_tool_start', agentHook);
+
+      try {
+        const [result] = await executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                name: 'late_hook_redaction',
+                arguments: JSON.stringify({ value: secret }),
+              },
+              tool: t,
+            },
+          ],
+          runner,
+          state,
+        );
+
+        expect(agentHook).toHaveBeenCalledWith(
+          state._context,
+          t,
+          expect.objectContaining({
+            toolCall: expect.objectContaining({ arguments: '' }),
+          }),
+        );
+        expect(result).toMatchObject({
+          type: 'function_output',
+          output: 'safe fallback',
+        });
+        expect(JSON.stringify(result)).not.toContain(secret);
+      } finally {
+        flagSpy.mockRestore();
+      }
+    });
+
+    it('promotes redaction before a pre-approval guardrail fallback', async () => {
+      const secret = 'SECRET_PREAPPROVAL_POLICY_PROMOTION_123';
+      let redactToolData = false;
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockImplementation(() => redactToolData);
+      const errorFunction = vi.fn(() => ({ status: 'blocked' as const }));
+      const t = tool({
+        name: 'preapproval_policy_promotion',
+        description: 'Promote redaction before approval fallback.',
+        parameters: z.object({ value: z.number() }),
+        outputSchema: z.object({ status: z.literal('blocked') }),
+        needsApproval: async () => true,
+        inputGuardrails: [
+          {
+            name: 'enable_secure_mode_and_reject',
+            run: async () => {
+              redactToolData = true;
+              return ToolGuardrailFunctionOutputFactory.rejectContent(secret);
+            },
+          },
+        ],
+        errorFunction,
+        execute: vi.fn(async () => ({ status: 'blocked' as const })),
+      }) as unknown as FunctionTool;
+      const customRunner = new Runner({
+        tracingDisabled: true,
+        toolExecution: { preApprovalInputGuardrails: true },
+      });
+
+      try {
+        const [result] = await executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                name: 'preapproval_policy_promotion',
+                arguments: JSON.stringify({ value: secret }),
+              },
+              tool: t,
+            },
+          ],
+          customRunner,
+          state,
+        );
+
+        expect(errorFunction).toHaveBeenCalledWith(
+          state._context,
+          expect.objectContaining({
+            message:
+              "Invalid input for function tool 'preapproval_policy_promotion'.",
+          }),
+          undefined,
+        );
+        expect(result).toMatchObject({
+          type: 'function_output',
+          output: { status: 'blocked' },
+        });
+        expect(JSON.stringify(result)).not.toContain(secret);
+      } finally {
+        flagSpy.mockRestore();
+      }
+    });
+
+    it('redacts a pre-approval guardrail tripwire after policy promotion', async () => {
+      const secret = 'SECRET_PREAPPROVAL_TRIPWIRE_PROMOTION_123';
+      let redactToolData = false;
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockImplementation(() => redactToolData);
+      const debugSpy = vi.spyOn(logger, 'debug');
+      const t = tool({
+        name: 'preapproval_tripwire_policy_promotion',
+        description: 'Promote redaction before a guardrail tripwire.',
+        parameters: z.object({ value: z.number() }),
+        needsApproval: async () => true,
+        inputGuardrails: [
+          {
+            name: 'enable_secure_mode_and_throw',
+            run: async ({ toolCall: callbackToolCall }) => {
+              redactToolData = true;
+              return ToolGuardrailFunctionOutputFactory.throwException({
+                captured: callbackToolCall.arguments,
+              });
+            },
+          },
+        ],
+        errorFunction: () => 'unexpected',
+        execute: vi.fn(async () => 'unexpected'),
+      }) as unknown as FunctionTool;
+      const customRunner = new Runner({
+        tracingDisabled: true,
+        toolExecution: { preApprovalInputGuardrails: true },
+      });
+
+      try {
+        const error = await executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                name: 'preapproval_tripwire_policy_promotion',
+                arguments: JSON.stringify({ value: secret }),
+              },
+              tool: t,
+            },
+          ],
+          customRunner,
+          state,
+        ).catch((caught) => caught);
+
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect((error as ToolCallError).state).toBeUndefined();
+        expect((error as ToolCallError).error).toBeInstanceOf(
+          InvalidToolInputError,
+        );
+        expect((error as ToolCallError).error).toMatchObject({
+          message:
+            "Invalid input for function tool 'preapproval_tripwire_policy_promotion'.",
+        });
+        expect(state._toolInputGuardrailResults).toHaveLength(0);
+        expect(JSON.stringify(error)).not.toContain(secret);
         expect(JSON.stringify(debugSpy.mock.calls)).not.toContain(secret);
       } finally {
         debugSpy.mockRestore();
         flagSpy.mockRestore();
       }
     });
+
+    it('promotes malformed-input redaction before a pre-approval fallback', async () => {
+      const secret = 'SECRET_MALFORMED_POLICY_PROMOTION_123';
+      let redactToolData = false;
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockImplementation(() => redactToolData);
+      const errorFunction = vi.fn(() => ({ status: 'blocked' as const }));
+      const t = tool({
+        name: 'malformed_policy_promotion',
+        description: 'Promote malformed-input redaction before fallback.',
+        parameters: z.object({ value: z.number() }),
+        outputSchema: z.object({ status: z.literal('blocked') }),
+        needsApproval: async () => true,
+        inputGuardrails: [
+          {
+            name: 'enable_secure_mode_and_reject',
+            run: async () => {
+              redactToolData = true;
+              return ToolGuardrailFunctionOutputFactory.rejectContent(secret);
+            },
+          },
+        ],
+        errorFunction,
+        execute: vi.fn(async () => ({ status: 'blocked' as const })),
+      }) as unknown as FunctionTool;
+      const customRunner = new Runner({
+        tracingDisabled: true,
+        toolExecution: { preApprovalInputGuardrails: true },
+      });
+
+      try {
+        const [result] = await executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                name: 'malformed_policy_promotion',
+                arguments: secret,
+              },
+              tool: t,
+            },
+          ],
+          customRunner,
+          state,
+        );
+
+        expect(errorFunction).toHaveBeenCalledWith(
+          state._context,
+          expect.objectContaining({
+            message:
+              "Invalid input for function tool 'malformed_policy_promotion'.",
+          }),
+          undefined,
+        );
+        expect(result).toMatchObject({
+          type: 'function_output',
+          output: { status: 'blocked' },
+        });
+        expect(JSON.stringify(result)).not.toContain(secret);
+      } finally {
+        flagSpy.mockRestore();
+      }
+    });
+
+    it('rechecks redaction after an async approval error formatter', async () => {
+      const secret = 'SECRET_FORMATTER_POLICY_PROMOTION_123';
+      let redactToolData = false;
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockImplementation(() => redactToolData);
+      const errorFunction = vi.fn(() => ({ status: 'rejected' as const }));
+      const t = tool({
+        name: 'formatter_policy_promotion',
+        description: 'Promote redaction in the approval formatter.',
+        parameters: z.object({ value: z.number() }),
+        outputSchema: z.object({ status: z.literal('rejected') }),
+        errorFunction,
+        execute: vi.fn(async () => ({ status: 'rejected' as const })),
+      }) as unknown as FunctionTool;
+      const customRunner = new Runner({
+        tracingDisabled: true,
+        toolErrorFormatter: async () => {
+          redactToolData = true;
+          return secret;
+        },
+      });
+      vi.spyOn(state._context, 'isToolApproved').mockReturnValue(false as any);
+
+      try {
+        const [result] = await executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                name: 'formatter_policy_promotion',
+                arguments: JSON.stringify({ value: secret }),
+              },
+              tool: t,
+            },
+          ],
+          customRunner,
+          state,
+          customRunner.config.toolErrorFormatter,
+        );
+
+        expect(errorFunction).toHaveBeenCalledWith(
+          state._context,
+          expect.objectContaining({
+            message:
+              "Invalid input for function tool 'formatter_policy_promotion'.",
+          }),
+          undefined,
+        );
+        expect(result).toMatchObject({
+          type: 'function_output',
+          output: { status: 'rejected' },
+        });
+        expect(JSON.stringify(result)).not.toContain(secret);
+      } finally {
+        flagSpy.mockRestore();
+      }
+    });
+
+    it('removes batch state after redaction is promoted during a sibling run', async () => {
+      const secret = 'SECRET_SIBLING_POLICY_PROMOTION_123';
+      let redactToolData = false;
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockImplementation(() => redactToolData);
+      let releaseSibling = () => {};
+      const policyPromoted = new Promise<void>((resolve) => {
+        releaseSibling = resolve;
+      });
+      const invalidInputTool = tool({
+        name: 'sibling_policy_promotion',
+        description: 'Promote redaction before a sibling failure.',
+        parameters: z.object({ value: z.number() }),
+        inputGuardrails: [
+          {
+            name: 'enable_secure_mode',
+            run: async () => {
+              redactToolData = true;
+              releaseSibling();
+              return ToolGuardrailFunctionOutputFactory.allow();
+            },
+          },
+        ],
+        errorFunction: () => 'safe fallback',
+        execute: vi.fn(async () => 'unexpected'),
+      }) as unknown as FunctionTool;
+      const failingTool = tool({
+        name: 'promoted_policy_sibling_failure',
+        description: 'Fail after secure mode is enabled.',
+        parameters: z.object({}),
+        errorFunction: null,
+        execute: vi.fn(async () => {
+          await policyPromoted;
+          throw new Error('sibling failed');
+        }),
+      }) as unknown as FunctionTool;
+
+      try {
+        const error = await executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                name: 'sibling_policy_promotion',
+                arguments: JSON.stringify({ value: secret }),
+              },
+              tool: invalidInputTool,
+            },
+            {
+              toolCall: {
+                ...toolCall,
+                callId: 'c2',
+                name: 'promoted_policy_sibling_failure',
+                arguments: '{}',
+              },
+              tool: failingTool,
+            },
+          ],
+          runner,
+          state,
+        ).catch((caught) => caught);
+
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect((error as ToolCallError).state).toBeUndefined();
+        expect(JSON.stringify(error)).not.toContain(secret);
+      } finally {
+        releaseSibling();
+        flagSpy.mockRestore();
+      }
+    });
+
+    it('applies tool timeouts to schema failure fallbacks', async () => {
+      let redactToolData = false;
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockImplementation(() => redactToolData);
+      const t = tool({
+        name: 'schema_failure_timeout',
+        description: 'Time out a schema failure fallback.',
+        parameters: z.object({ value: z.number() }),
+        inputGuardrails: [
+          {
+            name: 'enable_secure_mode',
+            run: async () => {
+              redactToolData = true;
+              return ToolGuardrailFunctionOutputFactory.allow();
+            },
+          },
+        ],
+        errorFunction: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 30));
+          return 'late fallback';
+        },
+        timeoutMs: 5,
+        timeoutBehavior: 'raise_exception',
+        execute: vi.fn(async () => 'unexpected'),
+      }) as unknown as FunctionTool;
+
+      try {
+        const error = await executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                name: 'schema_failure_timeout',
+                arguments: JSON.stringify({ value: 'invalid' }),
+              },
+              tool: t,
+            },
+          ],
+          runner,
+          state,
+        ).catch((caught) => caught);
+
+        expect(error).toBeInstanceOf(ToolTimeoutError);
+        expect((error as ToolTimeoutError).state).toBeUndefined();
+      } finally {
+        flagSpy.mockRestore();
+      }
+    });
+
+    it.each([
+      ['malformed JSON', 'throw', 'SECRET_CALLBACK_THROW_MALFORMED_123'],
+      [
+        'schema validation',
+        'throw',
+        JSON.stringify({ value: 'SECRET_CALLBACK_THROW_SCHEMA_123' }),
+      ],
+      ['malformed JSON', 'invalid', 'SECRET_INVALID_FALLBACK_MALFORMED_123'],
+      [
+        'schema validation',
+        'invalid',
+        JSON.stringify({ value: 'SECRET_INVALID_FALLBACK_SCHEMA_123' }),
+      ],
+    ] as const)(
+      'uses a fixed error when redacted %s uses a %s fallback',
+      async (_inputKind, failureMode, secret) => {
+        const flagSpy = vi
+          .spyOn(logger, 'dontLogToolData', 'get')
+          .mockReturnValue(true);
+        const errorFunction = vi.fn(
+          (
+            _context: RunContext,
+            _error: unknown,
+            details?: ToolCallDetails,
+          ) => {
+            expect(details).toBeUndefined();
+            if (failureMode === 'throw') {
+              throw new Error('fallback failed');
+            }
+            return { status: 'invalid' } as any;
+          },
+        );
+        const t = tool({
+          name: 'failing_structured_fallback',
+          description: 'Fail while handling invalid arguments.',
+          parameters: z.object({ value: z.number() }),
+          outputSchema: z.object({ status: z.literal('valid') }),
+          errorFunction,
+          timeoutMs: 1_000,
+          execute: vi.fn(async () => ({ status: 'valid' as const })),
+        }) as unknown as FunctionTool;
+        const invalidToolCall = {
+          ...toolCall,
+          name: 'failing_structured_fallback',
+          arguments: secret,
+        };
+
+        try {
+          const error = await executeFunctionToolCalls(
+            state._currentAgent,
+            [{ toolCall: invalidToolCall, tool: t }],
+            runner,
+            state,
+          ).catch((caught) => caught);
+
+          expect(error).toBeInstanceOf(ToolCallError);
+          expect((error as ToolCallError).state).toBeUndefined();
+          expect((error as ToolCallError).error).toBeInstanceOf(
+            InvalidToolInputError,
+          );
+          expect((error as ToolCallError).error).toMatchObject({
+            message:
+              "Invalid input for function tool 'failing_structured_fallback'.",
+            originalError: undefined,
+            toolInvocation: undefined,
+          });
+          expect(JSON.stringify(error)).not.toContain(secret);
+        } finally {
+          flagSpy.mockRestore();
+        }
+      },
+    );
+
+    it.each([
+      ['redacted', true, 'SECRET_REJECTED_MALFORMED_123'],
+      [
+        'redacted schema',
+        true,
+        JSON.stringify({ value: 'SECRET_REJECTED_SCHEMA_123' }),
+      ],
+      ['diagnostic', false, 'SECRET_REJECTED_DIAGNOSTIC_MALFORMED_123'],
+      [
+        'diagnostic schema',
+        false,
+        JSON.stringify({ value: 'SECRET_REJECTED_DIAGNOSTIC_SCHEMA_123' }),
+      ],
+    ] as const)(
+      'applies %s details policy to rejected invalid input',
+      async (_mode, dontLogToolData, input) => {
+        const flagSpy = vi
+          .spyOn(logger, 'dontLogToolData', 'get')
+          .mockReturnValue(dontLogToolData);
+        const approvalSpy = vi
+          .spyOn(state._context, 'isToolApproved')
+          .mockReturnValue(false as any);
+        const errorFunction = vi.fn(
+          (
+            _context: RunContext,
+            _error: unknown,
+            details?: ToolCallDetails,
+          ) => ({
+            status: 'rejected' as const,
+            detail: details?.toolCall?.arguments ?? 'redacted',
+          }),
+        );
+        const t = tool({
+          name: 'rejected_invalid_input',
+          description: 'Reject invalid input.',
+          parameters: z.object({ value: z.number() }),
+          outputSchema: z.object({
+            status: z.literal('rejected'),
+            detail: z.string(),
+          }),
+          needsApproval: async () => true,
+          errorFunction,
+          execute: vi.fn(async () => ({
+            status: 'rejected' as const,
+            detail: 'unexpected',
+          })),
+        }) as unknown as FunctionTool;
+        const invalidToolCall = {
+          ...toolCall,
+          name: 'rejected_invalid_input',
+          arguments: input,
+        };
+
+        try {
+          const [result] = await executeFunctionToolCalls(
+            state._currentAgent,
+            [{ toolCall: invalidToolCall, tool: t }],
+            runner,
+            state,
+          );
+
+          expect(errorFunction.mock.calls[0][2]).toEqual(
+            dontLogToolData ? undefined : { toolCall: invalidToolCall },
+          );
+          expect(result).toMatchObject({
+            type: 'function_output',
+            output: {
+              status: 'rejected',
+              detail: dontLogToolData ? 'redacted' : input,
+            },
+          });
+          if (dontLogToolData) {
+            expect(JSON.stringify(result)).not.toContain(input);
+          }
+        } finally {
+          approvalSpy.mockRestore();
+          flagSpy.mockRestore();
+        }
+      },
+    );
+
+    it.each([
+      ['throwing callback', 'throw'],
+      ['invalid fallback', 'invalid'],
+    ] as const)(
+      'preserves diagnostic state for a %s after a parse failure',
+      async (_label, failureMode) => {
+        const secret = `SECRET_DIAGNOSTIC_${failureMode.toUpperCase()}_123`;
+        const flagSpy = vi
+          .spyOn(logger, 'dontLogToolData', 'get')
+          .mockReturnValue(false);
+        const errorFunction = vi.fn(
+          (
+            _context: RunContext,
+            _error: unknown,
+            _details?: ToolCallDetails,
+          ) => {
+            if (failureMode === 'throw') {
+              throw new Error('diagnostic fallback failed');
+            }
+            return { status: 'invalid' } as any;
+          },
+        );
+        const t = tool({
+          name: 'diagnostic_failing_fallback',
+          description: 'Preserve diagnostic failure context.',
+          parameters: z.object({ value: z.number() }),
+          outputSchema: z.object({ status: z.literal('valid') }),
+          errorFunction,
+          execute: vi.fn(async () => ({ status: 'valid' as const })),
+        }) as unknown as FunctionTool;
+        const invalidToolCall = {
+          ...toolCall,
+          name: 'diagnostic_failing_fallback',
+          arguments: secret,
+        };
+
+        try {
+          const error = await executeFunctionToolCalls(
+            state._currentAgent,
+            [{ toolCall: invalidToolCall, tool: t }],
+            runner,
+            state,
+          ).catch((caught) => caught);
+
+          expect(error).toBeInstanceOf(ToolCallError);
+          expect((error as ToolCallError).state).toBe(state);
+          expect(errorFunction.mock.calls[0][2]).toEqual({
+            toolCall: invalidToolCall,
+          });
+        } finally {
+          flagSpy.mockRestore();
+        }
+      },
+    );
+
+    it('omits state when a sibling failure wins a batch with redacted invalid input', async () => {
+      const secret = 'SECRET_MIXED_PARSE_FAILURE_123';
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(true);
+      const invalidInputTool = tool({
+        name: 'invalid_input',
+        description: 'Recover from invalid input.',
+        parameters: z.object({ value: z.number() }),
+        execute: vi.fn(async () => 'unexpected'),
+      }) as unknown as FunctionTool;
+      const failingTool = tool({
+        name: 'sibling_failure',
+        description: 'Fail independently.',
+        parameters: z.object({}),
+        errorFunction: null,
+        execute: vi.fn(async () => {
+          throw new Error('sibling failed');
+        }),
+      }) as unknown as FunctionTool;
+
+      try {
+        const error = await executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                name: 'invalid_input',
+                arguments: secret,
+              },
+              tool: invalidInputTool,
+            },
+            {
+              toolCall: {
+                ...toolCall,
+                callId: 'c2',
+                name: 'sibling_failure',
+                arguments: '{}',
+              },
+              tool: failingTool,
+            },
+          ],
+          runner,
+          state,
+        ).catch((caught) => caught);
+
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect((error as ToolCallError).error).toMatchObject({
+          message: 'sibling failed',
+        });
+        expect((error as ToolCallError).state).toBeUndefined();
+        expect(JSON.stringify(error)).not.toContain(secret);
+      } finally {
+        flagSpy.mockRestore();
+      }
+    });
+
+    it('clears matching state from a nested sibling ToolCallError', async () => {
+      const secret = 'SECRET_NESTED_TOOL_CALL_STATE_123';
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(true);
+      const invalidInputTool = tool({
+        name: 'nested_state_invalid_input',
+        description: 'Reject invalid input.',
+        parameters: z.object({ value: z.number() }),
+        execute: vi.fn(async () => 'unexpected'),
+      }) as unknown as FunctionTool;
+      const failingTool = tool({
+        name: 'nested_tool_call_failure',
+        description: 'Throw an SDK tool-call error.',
+        parameters: z.object({}),
+        errorFunction: null,
+        execute: vi.fn(async () => {
+          throw new ToolCallError(
+            'nested tool call failed',
+            new Error('nested failure'),
+            state,
+          );
+        }),
+      }) as unknown as FunctionTool;
+
+      try {
+        const error = await executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                name: 'nested_state_invalid_input',
+                arguments: secret,
+              },
+              tool: invalidInputTool,
+            },
+            {
+              toolCall: {
+                ...toolCall,
+                callId: 'c2',
+                name: 'nested_tool_call_failure',
+                arguments: '{}',
+              },
+              tool: failingTool,
+            },
+          ],
+          runner,
+          state,
+        ).catch((caught) => caught);
+
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect((error as ToolCallError).state).toBeUndefined();
+        expect((error as ToolCallError).error).toBeInstanceOf(ToolCallError);
+        expect(((error as ToolCallError).error as ToolCallError).state).toBe(
+          undefined,
+        );
+        expect(JSON.stringify(error)).not.toContain(secret);
+      } finally {
+        flagSpy.mockRestore();
+      }
+    });
+
+    it('classifies schema-invalid input before dynamic approval and sibling failure', async () => {
+      const secret = 'SECRET_PREAPPROVAL_SCHEMA_FAILURE_123';
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(true);
+      let releaseApproval = () => {};
+      const approvalGate = new Promise<void>((resolve) => {
+        releaseApproval = resolve;
+      });
+      const needsApproval = vi.fn(async () => {
+        await approvalGate;
+        return false;
+      });
+      const invalidInputTool = tool({
+        name: 'schema_invalid_input',
+        description: 'Reject schema-invalid input before approval.',
+        parameters: z.object({ value: z.number() }),
+        needsApproval,
+        execute: vi.fn(async () => 'unexpected'),
+      }) as unknown as FunctionTool;
+      const failingTool = tool({
+        name: 'preapproval_sibling_failure',
+        description: 'Fail while a sibling awaits approval.',
+        parameters: z.object({}),
+        errorFunction: null,
+        execute: vi.fn(async () => {
+          releaseApproval();
+          throw new Error('preapproval sibling failed');
+        }),
+      }) as unknown as FunctionTool;
+
+      try {
+        const error = await executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                name: 'schema_invalid_input',
+                arguments: JSON.stringify({ value: secret }),
+              },
+              tool: invalidInputTool,
+            },
+            {
+              toolCall: {
+                ...toolCall,
+                callId: 'c2',
+                name: 'preapproval_sibling_failure',
+                arguments: '{}',
+              },
+              tool: failingTool,
+            },
+          ],
+          runner,
+          state,
+        ).catch((caught) => caught);
+
+        expect(needsApproval).not.toHaveBeenCalled();
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect((error as ToolCallError).state).toBeUndefined();
+        expect(JSON.stringify(error)).not.toContain(secret);
+      } finally {
+        releaseApproval();
+        flagSpy.mockRestore();
+      }
+    });
+
+    it('reuses the pre-approval parsed input during invocation', async () => {
+      const refine = vi.fn((_value: string) => true);
+      const execute = vi.fn(async (input: { value: string }) => input.value);
+      const t = tool({
+        name: 'single_parse',
+        description: 'Parse input once.',
+        parameters: z.object({ value: z.string().refine(refine) }),
+        execute,
+      }) as unknown as FunctionTool;
+      const inputToolCall = {
+        ...toolCall,
+        name: 'single_parse',
+        arguments: JSON.stringify({ value: 'prepared' }),
+      };
+
+      const result = await executeFunctionToolCalls(
+        state._currentAgent,
+        [{ toolCall: inputToolCall, tool: t }],
+        runner,
+        state,
+      );
+
+      expect(refine).toHaveBeenCalledTimes(1);
+      expect(execute).toHaveBeenCalledWith(
+        { value: 'prepared' },
+        state._context,
+        expect.objectContaining({ toolCall: inputToolCall }),
+      );
+      expect(result[0]).toMatchObject({
+        type: 'function_output',
+        output: 'prepared',
+      });
+    });
+
+    it('does not trust prepared input across a forwarding invoke wrapper', async () => {
+      const execute = vi.fn(async () => 'unexpected');
+      const innerTool = tool({
+        name: 'wrapped_inner',
+        description: 'Validate wrapped input.',
+        parameters: z.object({ value: z.number() }),
+        execute,
+      });
+      const wrappedTool = {
+        ...innerTool,
+        name: 'wrapped_outer',
+        invoke: (
+          context: RunContext,
+          input: string,
+          details?: ToolCallDetails,
+        ) => innerTool.invoke(context, input, details),
+      } as unknown as FunctionTool;
+      const wrappedToolCall = {
+        ...toolCall,
+        name: 'wrapped_outer',
+        arguments: JSON.stringify({ value: 'SECRET_WRAPPED_SCHEMA_123' }),
+      };
+
+      const [result] = await executeFunctionToolCalls(
+        state._currentAgent,
+        [{ toolCall: wrappedToolCall, tool: wrappedTool }],
+        runner,
+        state,
+      );
+
+      expect(execute).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        type: 'function_output',
+        output:
+          'An error occurred while running the tool. Please try again. Error: InvalidToolInputError: Invalid JSON input for tool',
+      });
+    });
+
+    it('does not trust prepared input across tools sharing callback details', async () => {
+      const innerExecute = vi.fn(async () => 'unexpected');
+      const innerTool = tool({
+        name: 'details_inner',
+        description: 'Validate nested input.',
+        parameters: z.object({ value: z.number() }),
+        execute: innerExecute,
+      });
+      const outerTool = tool({
+        name: 'details_outer',
+        description: 'Forward callback details.',
+        parameters: z.object({ outer: z.string() }),
+        execute: async (_input, context, details) =>
+          innerTool.invoke(
+            context!,
+            JSON.stringify({ value: 'SECRET_CROSS_TOOL_SCHEMA_123' }),
+            details,
+          ),
+      }) as unknown as FunctionTool;
+
+      const [result] = await executeFunctionToolCalls(
+        state._currentAgent,
+        [
+          {
+            toolCall: {
+              ...toolCall,
+              name: 'details_outer',
+              arguments: JSON.stringify({ outer: 'ok' }),
+            },
+            tool: outerTool,
+          },
+        ],
+        runner,
+        state,
+      );
+
+      expect(innerExecute).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        type: 'function_output',
+        output:
+          'An error occurred while running the tool. Please try again. Error: InvalidToolInputError: Invalid JSON input for tool',
+      });
+    });
+
+    it('isolates execution input from dynamic approval mutation', async () => {
+      const execute = vi.fn(async (input: { value: string }) => input.value);
+      const needsApproval = vi.fn(
+        async (_context: RunContext, input: { value: string }) => {
+          input.value = 'mutated';
+          return false;
+        },
+      );
+      const t = tool({
+        name: 'approval_input_isolation',
+        description: 'Keep execution input authoritative.',
+        parameters: z.object({ value: z.string() }),
+        needsApproval,
+        execute,
+      }) as unknown as FunctionTool;
+
+      const [result] = await executeFunctionToolCalls(
+        state._currentAgent,
+        [
+          {
+            toolCall: {
+              ...toolCall,
+              name: 'approval_input_isolation',
+              arguments: JSON.stringify({ value: 'original' }),
+            },
+            tool: t,
+          },
+        ],
+        runner,
+        state,
+      );
+
+      expect(needsApproval).toHaveBeenCalledWith(
+        state._context,
+        { value: 'mutated' },
+        toolCall.callId,
+      );
+      expect(execute).toHaveBeenCalledWith(
+        { value: 'original' },
+        state._context,
+        expect.anything(),
+      );
+      expect(result).toMatchObject({
+        type: 'function_output',
+        output: 'original',
+      });
+    });
+
+    it('omits state when a timeout wins a batch with redacted invalid input', async () => {
+      const secret = 'SECRET_MIXED_PARSE_TIMEOUT_123';
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(true);
+      const invalidInputTool = tool({
+        name: 'invalid_input',
+        description: 'Recover from invalid input.',
+        parameters: z.object({ value: z.number() }),
+        execute: vi.fn(async () => 'unexpected'),
+      }) as unknown as FunctionTool;
+      const timeoutTool = tool({
+        name: 'timeout_failure',
+        description: 'Time out independently.',
+        parameters: z.object({}),
+        timeoutMs: 5,
+        timeoutBehavior: 'raise_exception',
+        execute: vi.fn(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 30));
+          return 'late';
+        }),
+      }) as unknown as FunctionTool;
+
+      try {
+        const error = await executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                name: 'invalid_input',
+                arguments: secret,
+              },
+              tool: invalidInputTool,
+            },
+            {
+              toolCall: {
+                ...toolCall,
+                callId: 'c2',
+                name: 'timeout_failure',
+                arguments: '{}',
+              },
+              tool: timeoutTool,
+            },
+          ],
+          runner,
+          state,
+        ).catch((caught) => caught);
+
+        expect(error).toBeInstanceOf(ToolTimeoutError);
+        expect((error as ToolTimeoutError).state).toBeUndefined();
+        expect(JSON.stringify(error)).not.toContain(secret);
+      } finally {
+        flagSpy.mockRestore();
+      }
+    });
+
+    it.each([false, true])(
+      'redacts schema validation failures when traceIncludeSensitiveData is %s',
+      async (traceIncludeSensitiveData) => {
+        const secret = 'SECRET_SCHEMA_TRACE_ARGUMENT_123';
+        const flagSpy = vi
+          .spyOn(logger, 'dontLogToolData', 'get')
+          .mockReturnValue(true);
+        const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+        const t = tool({
+          name: 'schema_trace_parser',
+          description: 'Parse schema input.',
+          parameters: z.object({ value: z.number() }),
+          execute: vi.fn(async () => 'success'),
+        }) as unknown as FunctionTool;
+        const invalidToolCall = {
+          ...toolCall,
+          name: 'schema_trace_parser',
+          arguments: JSON.stringify({ value: secret }),
+        };
+
+        try {
+          await withRecordingTrace(async (processor) => {
+            const [result] = await withTrace('test', () =>
+              executeFunctionToolCalls(
+                state._currentAgent,
+                [{ toolCall: invalidToolCall, tool: t }],
+                new Runner({
+                  tracingDisabled: false,
+                  traceIncludeSensitiveData,
+                }),
+                state,
+              ),
+            );
+
+            expect(result.type).toBe('function_output');
+            if (result.type === 'function_output') {
+              expect(String(result.output)).not.toContain(secret);
+            }
+            const functionSpan = getEndedFunctionSpan(
+              processor,
+              'schema_trace_parser',
+            );
+            expect(JSON.stringify(functionSpan.toJSON())).not.toContain(secret);
+          });
+          expect(JSON.stringify(debugSpy.mock.calls)).not.toContain(secret);
+        } finally {
+          debugSpy.mockRestore();
+          flagSpy.mockRestore();
+        }
+      },
+    );
 
     it('throws structured parse failures without an error fallback', async () => {
       const secret = 'SECRET_THROWN_PARSE_ARGUMENT_123';

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -2727,6 +2727,51 @@ describe('executeShellActions', () => {
       state = new RunState(new RunContext(), '', new Agent({ name: 'T' }), 1);
     });
 
+    it('wraps hostile unrelated errors without inspecting their prototype twice', async () => {
+      let stringifyCount = 0;
+      const { proxy, revoke } = Proxy.revocable(new Error('tool failed'), {
+        get(target, property, receiver) {
+          if (property === 'toString') {
+            return () => {
+              stringifyCount += 1;
+              if (stringifyCount === 2) {
+                revoke();
+              }
+              return 'Error: tool failed';
+            };
+          }
+          return Reflect.get(target, property, receiver);
+        },
+      });
+      const t = tool({
+        name: 'hostile_error',
+        description: 'Throw an error with a hostile prototype trap.',
+        parameters: z.object({}),
+        errorFunction: null,
+        execute: async () => {
+          throw proxy;
+        },
+      }) as unknown as FunctionTool;
+
+      const error = await withTrace('test', () =>
+        executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: { ...toolCall, name: 'hostile_error' },
+              tool: t,
+            },
+          ],
+          runner,
+          state,
+        ).catch((caught) => caught),
+      );
+
+      expect(error).toBeInstanceOf(ToolCallError);
+      expect((error as ToolCallError).error).toBe(proxy);
+      expect((error as ToolCallError).state).toBe(state);
+    });
+
     it('returns approval item when not yet approved', async () => {
       const t = makeTool(true);
       vi.spyOn(state._context, 'isToolApproved').mockReturnValue(
@@ -4777,8 +4822,13 @@ describe('executeShellActions', () => {
       expect(firstResult.interruptions).toEqual([approval]);
     });
 
-    it('handles invalid JSON in tool call arguments gracefully instead of crashing', async () => {
+    it('redacts malformed JSON from the default model-visible output', async () => {
       // Reproduces issue #723: SyntaxError stops agent when LLM generates invalid JSON
+      const secret = 'SECRET_RUNNER_MALFORMED_ARGUMENT_123';
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(true);
+      const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
       const t = tool({
         name: 'checkTagActivity',
         description: 'Check tag activity',
@@ -4792,33 +4842,82 @@ describe('executeShellActions', () => {
       const invalidToolCall = {
         ...toolCall,
         name: 'checkTagActivity',
-        arguments:
-          '{"{"tagIds":["65aafb7e-4293-4376-baf6-1f9d197e960a"],"since":"2025-09-04T13:26:13.991Z"}',
+        arguments: secret,
       };
 
-      const res = await withTrace('test', () =>
-        executeFunctionToolCalls(
+      try {
+        const res = await withTrace('test', () =>
+          executeFunctionToolCalls(
+            state._currentAgent,
+            [{ toolCall: invalidToolCall, tool: t }],
+            runner,
+            state,
+          ),
+        );
+
+        expect(res).toHaveLength(1);
+        const firstResult = res[0];
+
+        expect(firstResult.type).toBe('function_output');
+        if (firstResult.type === 'function_output') {
+          expect(firstResult.output).toBe(
+            'An error occurred while parsing tool arguments. Please try again with valid JSON.',
+          );
+          expect(JSON.stringify(firstResult.runItem.rawItem)).not.toContain(
+            secret,
+          );
+        }
+        expect(JSON.stringify(debugSpy.mock.calls)).not.toContain(secret);
+      } finally {
+        debugSpy.mockRestore();
+        flagSpy.mockRestore();
+      }
+    });
+
+    it('preserves malformed JSON details in diagnostic mode', async () => {
+      const secret = 'SECRT123';
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(false);
+      const t = tool({
+        name: 'diagnostic_parser',
+        description: 'Parse diagnostic input.',
+        parameters: z.object({ value: z.string() }),
+        execute: vi.fn(async () => 'success'),
+      }) as unknown as FunctionTool;
+      const invalidToolCall = {
+        ...toolCall,
+        name: 'diagnostic_parser',
+        arguments: secret,
+      };
+
+      try {
+        const [result] = await executeFunctionToolCalls(
           state._currentAgent,
           [{ toolCall: invalidToolCall, tool: t }],
           runner,
           state,
-        ),
-      );
-
-      expect(res).toHaveLength(1);
-      const firstResult = res[0];
-
-      expect(firstResult.type).toBe('function_output');
-      if (firstResult.type === 'function_output') {
-        expect(String(firstResult.output)).toContain(
-          'An error occurred while parsing tool arguments',
         );
-        expect(String(firstResult.output)).toContain('valid JSON');
+
+        expect(result.type).toBe('function_output');
+        if (result.type === 'function_output') {
+          expect(String(result.output)).toContain(secret);
+        }
+      } finally {
+        flagSpy.mockRestore();
       }
     });
 
     it('maps parse failures through a structured error fallback', async () => {
-      const errorFunction = vi.fn(() => ({ status: 'invalid_input' as const }));
+      const secret = 'SECRET_STRUCTURED_PARSE_ARGUMENT_123';
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(true);
+      const errorFunction = vi.fn(
+        (_context: RunContext, _error: unknown, _details?: unknown) => ({
+          status: 'invalid_input' as const,
+        }),
+      );
       const t = tool({
         name: 'structured_parser',
         description: 'Parse structured input.',
@@ -4830,38 +4929,103 @@ describe('executeShellActions', () => {
       const invalidToolCall = {
         ...toolCall,
         name: 'structured_parser',
-        arguments: '{',
+        arguments: secret,
       };
 
-      const res = await withTrace('test', () =>
-        executeFunctionToolCalls(
-          state._currentAgent,
-          [{ toolCall: invalidToolCall, tool: t }],
-          runner,
-          state,
-        ),
-      );
+      try {
+        const res = await withTrace('test', () =>
+          executeFunctionToolCalls(
+            state._currentAgent,
+            [{ toolCall: invalidToolCall, tool: t }],
+            runner,
+            state,
+          ),
+        );
 
-      expect(res[0]).toMatchObject({
-        type: 'function_output',
-        output: { status: 'invalid_input' },
-        runItem: {
-          rawItem: {
-            output: {
-              type: 'text',
-              text: JSON.stringify({ status: 'invalid_input' }),
+        expect(res[0]).toMatchObject({
+          type: 'function_output',
+          output: { status: 'invalid_input' },
+          runItem: {
+            rawItem: {
+              output: {
+                type: 'text',
+                text: JSON.stringify({ status: 'invalid_input' }),
+              },
             },
           },
-        },
-      });
-      expect(errorFunction).toHaveBeenCalledWith(
-        state._context,
-        expect.objectContaining({ name: 'InvalidToolInputError' }),
-        { toolCall: invalidToolCall },
-      );
+        });
+        expect(errorFunction).toHaveBeenCalledWith(
+          state._context,
+          expect.objectContaining({
+            name: 'InvalidToolInputError',
+            originalError: undefined,
+            toolInvocation: undefined,
+          }),
+          { toolCall: invalidToolCall },
+        );
+        const capturedError = errorFunction.mock.calls[0][1] as
+          InvalidToolInputError | undefined;
+        expect(capturedError).toBeDefined();
+        expect(capturedError?.toolInvocation).toBeUndefined();
+      } finally {
+        flagSpy.mockRestore();
+      }
+    });
+
+    it('redacts schema validation failures from traces and logs', async () => {
+      const secret = 'SECRET_SCHEMA_TRACE_ARGUMENT_123';
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(true);
+      const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+      const t = tool({
+        name: 'schema_trace_parser',
+        description: 'Parse schema input.',
+        parameters: z.object({ value: z.number() }),
+        execute: vi.fn(async () => 'success'),
+      }) as unknown as FunctionTool;
+      const invalidToolCall = {
+        ...toolCall,
+        name: 'schema_trace_parser',
+        arguments: JSON.stringify({ value: secret }),
+      };
+
+      try {
+        await withRecordingTrace(async (processor) => {
+          const [result] = await withTrace('test', () =>
+            executeFunctionToolCalls(
+              state._currentAgent,
+              [{ toolCall: invalidToolCall, tool: t }],
+              new Runner({
+                tracingDisabled: false,
+                traceIncludeSensitiveData: false,
+              }),
+              state,
+            ),
+          );
+
+          expect(result.type).toBe('function_output');
+          if (result.type === 'function_output') {
+            expect(String(result.output)).not.toContain(secret);
+          }
+          const functionSpan = getEndedFunctionSpan(
+            processor,
+            'schema_trace_parser',
+          );
+          expect(JSON.stringify(functionSpan.toJSON())).not.toContain(secret);
+        });
+        expect(JSON.stringify(debugSpy.mock.calls)).not.toContain(secret);
+      } finally {
+        debugSpy.mockRestore();
+        flagSpy.mockRestore();
+      }
     });
 
     it('throws structured parse failures without an error fallback', async () => {
+      const secret = 'SECRET_THROWN_PARSE_ARGUMENT_123';
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(true);
       const t = tool({
         name: 'structured_parser_without_fallback',
         description: 'Parse structured input.',
@@ -4872,22 +5036,32 @@ describe('executeShellActions', () => {
       const invalidToolCall = {
         ...toolCall,
         name: 'structured_parser_without_fallback',
-        arguments: '{',
+        arguments: secret,
       };
 
-      const error = await withTrace('test', () =>
-        executeFunctionToolCalls(
-          state._currentAgent,
-          [{ toolCall: invalidToolCall, tool: t }],
-          runner,
-          state,
-        ).catch((caught) => caught),
-      );
+      try {
+        const error = await withTrace('test', () =>
+          executeFunctionToolCalls(
+            state._currentAgent,
+            [{ toolCall: invalidToolCall, tool: t }],
+            runner,
+            state,
+          ).catch((caught) => caught),
+        );
 
-      expect(error).toBeInstanceOf(ToolCallError);
-      expect((error as ToolCallError).error).toBeInstanceOf(
-        InvalidToolInputError,
-      );
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect((error as ToolCallError).state).toBeUndefined();
+        const inputError = (error as ToolCallError).error;
+        expect(inputError).toBeInstanceOf(InvalidToolInputError);
+        expect(inputError).toMatchObject({
+          state: undefined,
+          originalError: undefined,
+          toolInvocation: undefined,
+        });
+        expect(JSON.stringify(inputError)).not.toContain(secret);
+      } finally {
+        flagSpy.mockRestore();
+      }
     });
   });
 

--- a/packages/agents-core/test/tool.test.ts
+++ b/packages/agents-core/test/tool.test.ts
@@ -1215,38 +1215,136 @@ describe('tool.invoke', () => {
     },
   );
 
-  it('redacts parser context before invoking errorFunction', async () => {
-    const secret = 'SECRET_CUSTOM_ERROR_FUNCTION_123';
+  it.each([
+    ['redacted', true],
+    ['diagnostic', false],
+  ] as const)(
+    'applies %s parser context before invoking errorFunction',
+    async (_mode, dontLogToolData) => {
+      const secret = 'SECRET_CUSTOM_ERROR_FUNCTION_123';
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(dontLogToolData);
+      const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+      let capturedError: unknown;
+      let capturedDetails: unknown;
+      const t = tool({
+        name: 'test',
+        description: 'test',
+        parameters: z.object({ count: z.number() }),
+        execute: async () => 'ok',
+        errorFunction: (_ctx, error, details) => {
+          capturedError = error;
+          capturedDetails = details;
+          return details?.toolCall?.arguments ?? 'handled';
+        },
+      });
+      const ctx = new RunContext();
+      const invalidInput = JSON.stringify({ count: secret });
+      const details = {
+        toolCall: {
+          type: 'function_call' as const,
+          callId: 'call_custom_error_function',
+          name: 'test',
+          arguments: invalidInput,
+        },
+      };
+
+      try {
+        const res = await t.invoke(ctx, invalidInput, details);
+
+        if (dontLogToolData) {
+          expect(res).toBe('handled');
+          expect(capturedError).toMatchObject({
+            message: 'Invalid JSON input for tool',
+            originalError: undefined,
+            toolInvocation: undefined,
+          });
+          expect(capturedDetails).toBeUndefined();
+          expect(JSON.stringify(debugSpy.mock.calls)).not.toContain(secret);
+        } else {
+          expect(res).toBe(invalidInput);
+          expect(capturedError).toMatchObject({
+            message: 'Invalid JSON input for tool',
+            toolInvocation: { runContext: ctx, input: invalidInput, details },
+          });
+          expect(capturedDetails).toBe(details);
+        }
+      } finally {
+        debugSpy.mockRestore();
+        flagSpy.mockRestore();
+      }
+    },
+  );
+
+  it('discards direct fallback output when secure mode is enabled during errorFunction', async () => {
+    const secret = 'SECRET_DIRECT_LATE_ERROR_FUNCTION_123';
+    let redactToolData = false;
     const flagSpy = vi
       .spyOn(logger, 'dontLogToolData', 'get')
-      .mockReturnValue(true);
-    const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
-    let capturedError: unknown;
+      .mockImplementation(() => redactToolData);
     const t = tool({
-      name: 'test',
-      description: 'test',
-      parameters: z.object({ count: z.number() }),
-      execute: async () => 'ok',
-      errorFunction: (_ctx, error) => {
-        capturedError = error;
-        return 'handled';
+      name: 'late_direct_redaction',
+      description: 'Promote redaction while handling invalid input.',
+      parameters: z.object({ value: z.number() }),
+      execute: async () => 'unexpected',
+      errorFunction: (_context, _error, details) => {
+        redactToolData = true;
+        return details?.toolCall?.arguments ?? 'unexpected';
       },
     });
-    const ctx = new RunContext();
-    const invalidInput = JSON.stringify({ count: secret });
+    const input = JSON.stringify({ value: secret });
+    const details = {
+      toolCall: {
+        type: 'function_call' as const,
+        callId: 'call_late_direct_redaction',
+        name: 'late_direct_redaction',
+        arguments: input,
+      },
+    };
 
     try {
-      const res = await t.invoke(ctx, invalidInput);
+      const error = await t
+        .invoke(new RunContext(), input, details)
+        .catch((caught) => caught);
 
-      expect(res).toBe('handled');
-      expect(capturedError).toMatchObject({
+      expect(error).toBeInstanceOf(InvalidToolInputError);
+      expect(error).toMatchObject({
         message: 'Invalid JSON input for tool',
         originalError: undefined,
         toolInvocation: undefined,
       });
-      expect(JSON.stringify(debugSpy.mock.calls)).not.toContain(secret);
+      expect(JSON.stringify(error)).not.toContain(secret);
     } finally {
-      debugSpy.mockRestore();
+      flagSpy.mockRestore();
+    }
+  });
+
+  it('preserves errorFunction details for execution errors in redacted mode', async () => {
+    const flagSpy = vi
+      .spyOn(logger, 'dontLogToolData', 'get')
+      .mockReturnValue(true);
+    const details = { resumeState: 'resume_execution_error' };
+    let capturedDetails: unknown;
+    const t = tool({
+      name: 'execution_error',
+      description: 'test',
+      parameters: z.object({}),
+      execute: async () => {
+        throw new Error('execution failed');
+      },
+      errorFunction: (_ctx, _error, callbackDetails) => {
+        capturedDetails = callbackDetails;
+        return 'handled';
+      },
+    });
+
+    try {
+      const result = await t.invoke(new RunContext(), '{}', details);
+
+      expect(result).toBe('handled');
+      expect(capturedDetails).toBe(details);
+    } finally {
       flagSpy.mockRestore();
     }
   });
@@ -1282,6 +1380,49 @@ describe('tool.invoke', () => {
       );
     } finally {
       debugSpy.mockRestore();
+      flagSpy.mockRestore();
+    }
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['number', 0],
+    ['boolean', false],
+    ['symbol', Symbol('parser failure')],
+  ])('redacts a %s parser-thrown value', async (_label, thrownValue) => {
+    const flagSpy = vi
+      .spyOn(logger, 'dontLogToolData', 'get')
+      .mockReturnValue(true);
+    const execute = vi.fn(async () => 'unexpected');
+    const t = tool({
+      name: 'arbitrary_parser_failure',
+      description: 'test',
+      parameters: z.object({
+        value: z.string().refine(() => {
+          throw thrownValue;
+        }),
+      }),
+      execute,
+      errorFunction: null,
+    });
+    let caught: unknown = 'not thrown';
+
+    try {
+      try {
+        await t.invoke(new RunContext(), '{"value":"trigger"}');
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(execute).not.toHaveBeenCalled();
+      expect(caught).toBeInstanceOf(InvalidToolInputError);
+      expect(caught).toMatchObject({
+        message: 'Invalid JSON input for tool',
+        originalError: undefined,
+        toolInvocation: undefined,
+      });
+    } finally {
       flagSpy.mockRestore();
     }
   });

--- a/packages/agents-core/test/tool.test.ts
+++ b/packages/agents-core/test/tool.test.ts
@@ -18,6 +18,7 @@ import { RunContext } from '../src/runContext';
 import { serializeTool } from '../src/utils/serialize';
 import { FakeEditor, FakeShell } from './stubs';
 import {
+  InvalidToolInputError,
   InvalidToolOutputError,
   ToolTimeoutError,
   UserError,
@@ -1138,27 +1139,17 @@ describe('tool.invoke', () => {
     expect(res).toBe('bad');
   });
 
-  it('throws InvalidToolInputError with context on malformed JSON', async () => {
-    const t = tool({
-      name: 'test',
-      description: 'test',
-      parameters: z.object({ foo: z.string() }),
-      execute: async () => 'ok',
-      errorFunction: null, // disable error handling to let the error propagate
-    });
-    const ctx = new RunContext();
-    const malformedInput = '{invalid json}';
-
-    await expect(t.invoke(ctx, malformedInput)).rejects.toMatchObject({
-      message: 'Invalid JSON input for tool',
-      toolInvocation: {
-        runContext: ctx,
-        input: malformedInput,
-      },
-    });
-  });
-
-  it('throws InvalidToolInputError with context on Zod validation failure', async () => {
+  it.each([
+    ['malformed JSON', 'SECRET_MALFORMED_TOOL_INPUT_123'],
+    [
+      'schema validation',
+      JSON.stringify({ age: 'SECRET_SCHEMA_TOOL_INPUT_123' }),
+    ],
+  ])('redacts %s failures from direct invocation', async (_label, input) => {
+    const flagSpy = vi
+      .spyOn(logger, 'dontLogToolData', 'get')
+      .mockReturnValue(true);
+    const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
     const t = tool({
       name: 'test',
       description: 'test',
@@ -1167,18 +1158,69 @@ describe('tool.invoke', () => {
       errorFunction: null,
     });
     const ctx = new RunContext();
-    const invalidInput = '{"age": "not a number"}';
 
-    await expect(t.invoke(ctx, invalidInput)).rejects.toMatchObject({
-      message: 'Invalid JSON input for tool',
-      toolInvocation: {
-        runContext: ctx,
-        input: invalidInput,
-      },
-    });
+    try {
+      const error = await t.invoke(ctx, input).catch((caught) => caught);
+
+      expect(error).toBeInstanceOf(InvalidToolInputError);
+      expect(error).toMatchObject({
+        message: 'Invalid JSON input for tool',
+        originalError: undefined,
+        toolInvocation: undefined,
+      });
+      expect(error).not.toHaveProperty('cause');
+      expect(JSON.stringify(debugSpy.mock.calls)).not.toContain(input);
+    } finally {
+      debugSpy.mockRestore();
+      flagSpy.mockRestore();
+    }
   });
 
-  it('errorFunction receives InvalidToolInputError with originalError and toolInvocation', async () => {
+  it.each([
+    ['malformed JSON', 'SECRET_MALFORMED_TOOL_DIAGNOSTIC_123'],
+    [
+      'schema validation',
+      JSON.stringify({ age: 'SECRET_SCHEMA_TOOL_DIAGNOSTIC_123' }),
+    ],
+  ])(
+    'preserves %s diagnostics when tool data is enabled',
+    async (_label, input) => {
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(false);
+      const t = tool({
+        name: 'test',
+        description: 'test',
+        parameters: z.object({ age: z.number() }),
+        execute: async () => 'ok',
+        errorFunction: null,
+      });
+      const ctx = new RunContext();
+      const details = { resumeState: 'resume_123' };
+
+      try {
+        const error = await t
+          .invoke(ctx, input, details)
+          .catch((caught) => caught);
+
+        expect(error).toBeInstanceOf(InvalidToolInputError);
+        expect(error).toMatchObject({
+          message: 'Invalid JSON input for tool',
+          toolInvocation: { runContext: ctx, input, details },
+        });
+        expect(error.originalError).toBeDefined();
+      } finally {
+        flagSpy.mockRestore();
+      }
+    },
+  );
+
+  it('redacts parser context before invoking errorFunction', async () => {
+    const secret = 'SECRET_CUSTOM_ERROR_FUNCTION_123';
+    const flagSpy = vi
+      .spyOn(logger, 'dontLogToolData', 'get')
+      .mockReturnValue(true);
+    const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
     let capturedError: unknown;
     const t = tool({
       name: 'test',
@@ -1191,18 +1233,57 @@ describe('tool.invoke', () => {
       },
     });
     const ctx = new RunContext();
-    const invalidInput = '{"count": "not a number"}';
+    const invalidInput = JSON.stringify({ count: secret });
 
-    const res = await t.invoke(ctx, invalidInput);
-    expect(res).toBe('handled');
-    expect(capturedError).toMatchObject({
-      message: 'Invalid JSON input for tool',
-      toolInvocation: {
-        runContext: ctx,
-        input: invalidInput,
-      },
+    try {
+      const res = await t.invoke(ctx, invalidInput);
+
+      expect(res).toBe('handled');
+      expect(capturedError).toMatchObject({
+        message: 'Invalid JSON input for tool',
+        originalError: undefined,
+        toolInvocation: undefined,
+      });
+      expect(JSON.stringify(debugSpy.mock.calls)).not.toContain(secret);
+    } finally {
+      debugSpy.mockRestore();
+      flagSpy.mockRestore();
+    }
+  });
+
+  it('does not inspect hostile parser errors in redacted mode', async () => {
+    const flagSpy = vi
+      .spyOn(logger, 'dontLogToolData', 'get')
+      .mockReturnValue(true);
+    const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+    const { proxy, revoke } = Proxy.revocable({}, {});
+    const t = tool({
+      name: 'hostile_parser',
+      description: 'test',
+      parameters: z.object({
+        value: z.string().refine(() => {
+          revoke();
+          throw proxy;
+        }),
+      }),
+      execute: async () => 'ok',
+      errorFunction: null,
     });
-    expect((capturedError as any).originalError).toBeDefined();
+
+    try {
+      const error = await t
+        .invoke(new RunContext(), '{"value":"trigger"}')
+        .catch((caught) => caught);
+
+      expect(error).toBeInstanceOf(InvalidToolInputError);
+      expect(error.originalError).toBeUndefined();
+      expect(debugSpy).toHaveBeenCalledWith(
+        'Invalid JSON input for tool hostile_parser',
+      );
+    } finally {
+      debugSpy.mockRestore();
+      flagSpy.mockRestore();
+    }
   });
 
   it('needsApproval boolean becomes function', async () => {


### PR DESCRIPTION
This pull request fixes invalid function-tool argument failures that retained raw model-produced arguments and parser details even when tool data logging was disabled. It centralizes policy-aware `InvalidToolInputError` construction for direct tool invocation and Runner parsing, emits fixed model-visible parse failures in secure mode, and prevents redacted errors from retaining `RunState` while preserving existing diagnostic behavior when sensitive logging is explicitly enabled.

It also adds adversarial coverage for malformed JSON, schema validation, custom error callbacks, traces and logs, `Agent.asTool`, streaming and non-streaming runners, and hostile thrown values.