### PR TITLE
fix(openai): surface content-filter refusals

### DIFF
--- a/.changeset/quiet-filters-refuse.md
+++ b/.changeset/quiet-filters-refuse.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: surface empty non-streaming content-filter responses as refusals

--- a/.changeset/quiet-filters-refuse.md
+++ b/.changeset/quiet-filters-refuse.md
@@ -2,4 +2,4 @@
 '@openai/agents-openai': patch
 ---
 
-fix: surface empty non-streaming content-filter responses as refusals
+fix: surface empty content-filter responses as refusals in streaming and non-streaming runs

--- a/packages/agents-openai/src/openaiChatCompletionsContentFilter.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsContentFilter.ts
@@ -1,0 +1,23 @@
+import type { ChatCompletion } from 'openai/resources/chat';
+
+export const CONTENT_FILTER_REFUSAL_MESSAGE =
+  "Response withheld by the provider's content filter.";
+
+type ContentFilterState = {
+  finishReason:
+    ChatCompletion['choices'][number]['finish_reason'] | null | undefined;
+  content: string | null | undefined;
+  refusal: string | null | undefined;
+  hasToolCalls: boolean;
+};
+
+export function shouldSynthesizeContentFilterRefusal({
+  finishReason,
+  content,
+  refusal,
+  hasToolCalls,
+}: ContentFilterState): boolean {
+  return (
+    finishReason === 'content_filter' && !content && !refusal && !hasToolCalls
+  );
+}

--- a/packages/agents-openai/src/openaiChatCompletionsContentFilter.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsContentFilter.ts
@@ -6,18 +6,12 @@ export const CONTENT_FILTER_REFUSAL_MESSAGE =
 type ContentFilterState = {
   finishReason:
     ChatCompletion['choices'][number]['finish_reason'] | null | undefined;
-  content: string | null | undefined;
-  refusal: string | null | undefined;
-  hasToolCalls: boolean;
+  hasOutput: boolean;
 };
 
 export function shouldSynthesizeContentFilterRefusal({
   finishReason,
-  content,
-  refusal,
-  hasToolCalls,
+  hasOutput,
 }: ContentFilterState): boolean {
-  return (
-    finishReason === 'content_filter' && !content && !refusal && !hasToolCalls
-  );
+  return finishReason === 'content_filter' && !hasOutput;
 }

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -137,9 +137,12 @@ export class OpenAIChatCompletionsModel implements Model {
           message &&
           shouldSynthesizeContentFilterRefusal({
             finishReason: firstChoice?.finish_reason,
-            content: message.content,
-            refusal: message.refusal,
-            hasToolCalls: Boolean(message.tool_calls?.length),
+            hasOutput: Boolean(
+              message.content ||
+              message.refusal ||
+              message.tool_calls?.length ||
+              message.audio,
+            ),
           })
         ) {
           message.content = null;

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -40,6 +40,10 @@ import { protocol } from '@openai/agents-core';
 import { getOpenAIRetryAdvice } from './retryAdvice';
 import { normalizePromptCacheRetention } from './utils/modelSettings';
 import type { OpenAIClient } from './openaiClient';
+import {
+  CONTENT_FILTER_REFUSAL_MESSAGE,
+  shouldSynthesizeContentFilterRefusal,
+} from './openaiChatCompletionsContentFilter';
 
 type ModelTracingParent = Parameters<typeof createGenerationSpan>[1];
 
@@ -130,15 +134,16 @@ export class OpenAIChatCompletionsModel implements Model {
         // Some providers signal a filtered completion only through the finish reason.
         // Normalize that terminal signal before tracing and protocol conversion.
         if (
-          firstChoice?.finish_reason === 'content_filter' &&
           message &&
-          !message.content &&
-          !message.refusal &&
-          !message.tool_calls?.length
+          shouldSynthesizeContentFilterRefusal({
+            finishReason: firstChoice?.finish_reason,
+            content: message.content,
+            refusal: message.refusal,
+            hasToolCalls: Boolean(message.tool_calls?.length),
+          })
         ) {
           message.content = null;
-          message.refusal =
-            "Response withheld by the provider's content filter.";
+          message.refusal = CONTENT_FILTER_REFUSAL_MESSAGE;
         }
         if (span && request.tracing === true) {
           span.spanData.output = [response];

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -115,7 +115,7 @@ export class OpenAIChatCompletionsModel implements Model {
     this.#handleUnsupportedPrompt(request);
     this.#handleUnsupportedReasoningSettings(request);
 
-    const response = await withGenerationSpan(
+    const { response, rawResponse } = await withGenerationSpan(
       async (span) => {
         span.spanData.model = this.#model;
         span.spanData.model_config = request.modelSettings
@@ -128,15 +128,17 @@ export class OpenAIChatCompletionsModel implements Model {
               verbosity: request.modelSettings.text?.verbosity,
             }
           : { base_url: this.#client.baseURL };
-        const response = await this.#fetchResponse(request, span, false);
-        const firstChoice = response.choices?.[0];
+        const rawResponse = await this.#fetchResponse(request, span, false);
+        let response = rawResponse;
+        const firstChoice = rawResponse.choices?.[0];
         const message = firstChoice?.message;
         // Some providers signal a filtered completion only through the finish reason.
         // Normalize that terminal signal before tracing and protocol conversion.
         if (
+          firstChoice &&
           message &&
           shouldSynthesizeContentFilterRefusal({
-            finishReason: firstChoice?.finish_reason,
+            finishReason: firstChoice.finish_reason,
             hasOutput: Boolean(
               message.content ||
               message.refusal ||
@@ -145,13 +147,25 @@ export class OpenAIChatCompletionsModel implements Model {
             ),
           })
         ) {
-          message.content = null;
-          message.refusal = CONTENT_FILTER_REFUSAL_MESSAGE;
+          response = {
+            ...rawResponse,
+            choices: [
+              {
+                ...firstChoice,
+                message: {
+                  ...message,
+                  content: null,
+                  refusal: CONTENT_FILTER_REFUSAL_MESSAGE,
+                },
+              },
+              ...rawResponse.choices.slice(1),
+            ],
+          };
         }
         if (span && request.tracing === true) {
           span.spanData.output = [response];
         }
-        return response;
+        return { response, rawResponse };
       },
       undefined,
       getModelTracingParent(request),
@@ -264,7 +278,7 @@ export class OpenAIChatCompletionsModel implements Model {
         : new Usage(),
       output,
       responseId: response.id,
-      providerData: response,
+      providerData: rawResponse,
     };
 
     return modelResponse;

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -125,6 +125,21 @@ export class OpenAIChatCompletionsModel implements Model {
             }
           : { base_url: this.#client.baseURL };
         const response = await this.#fetchResponse(request, span, false);
+        const firstChoice = response.choices?.[0];
+        const message = firstChoice?.message;
+        // Some providers signal a filtered completion only through the finish reason.
+        // Normalize that terminal signal before tracing and protocol conversion.
+        if (
+          firstChoice?.finish_reason === 'content_filter' &&
+          message &&
+          !message.content &&
+          !message.refusal &&
+          !message.tool_calls?.length
+        ) {
+          message.content = null;
+          message.refusal =
+            "Response withheld by the provider's content filter.";
+        }
         if (span && request.tracing === true) {
           span.spanData.output = [response];
         }

--- a/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
@@ -5,6 +5,10 @@ import { ChatCompletion, ChatCompletionChunk } from 'openai/resources/chat';
 import { FAKE_ID } from './openaiChatCompletionsModel';
 import { OPENAI_CHAT_COMPLETIONS_RAW_MODEL_EVENT_SOURCE } from './rawModelEvents';
 import logger from './logger';
+import {
+  CONTENT_FILTER_REFUSAL_MESSAGE,
+  shouldSynthesizeContentFilterRefusal,
+} from './openaiChatCompletionsContentFilter';
 
 type StreamingState = {
   started: boolean;
@@ -175,6 +179,22 @@ export async function* convertChatCompletionsStreamToResponses(
   // Final output message
   const outputs: protocol.OutputModelItem[] = [];
   const outputItemId = response.id || FAKE_ID;
+
+  if (
+    shouldSynthesizeContentFilterRefusal({
+      finishReason: state.finishReason,
+      content: state.text_content?.text,
+      refusal: state.refusal_content?.refusal,
+      hasToolCalls:
+        Object.keys(state.function_calls).length > 0 ||
+        state.ignored_tool_call_indexes.size > 0,
+    })
+  ) {
+    state.refusal_content = {
+      type: 'refusal',
+      refusal: CONTENT_FILTER_REFUSAL_MESSAGE,
+    };
+  }
 
   if (state.reasoning) {
     outputs.push({

--- a/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
@@ -183,11 +183,12 @@ export async function* convertChatCompletionsStreamToResponses(
   if (
     shouldSynthesizeContentFilterRefusal({
       finishReason: state.finishReason,
-      content: state.text_content?.text,
-      refusal: state.refusal_content?.refusal,
-      hasToolCalls:
+      hasOutput: Boolean(
+        state.text_content?.text ||
+        state.refusal_content?.refusal ||
         Object.keys(state.function_calls).length > 0 ||
         state.ignored_tool_call_indexes.size > 0,
+      ),
     })
   ) {
     state.refusal_content = {

--- a/packages/agents-openai/test/openaiChatCompletionsModel.scenario.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.scenario.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { setTracingDisabled, withTrace } from '@openai/agents-core';
+import {
+  Agent,
+  ModelRefusalError,
+  Runner,
+  setTracingDisabled,
+  withTrace,
+} from '@openai/agents-core';
 import * as AgentsCore from '@openai/agents-core';
 import { OpenAIChatCompletionsModel } from '../src/openaiChatCompletionsModel';
 import { HEADERS } from '../src/defaults';
@@ -141,6 +147,46 @@ describe('OpenAIChatCompletionsModel streaming scenarios', () => {
       inputTokensDetails: { cached_tokens: 4 },
       outputTokensDetails: { reasoning_tokens: 6 },
     });
+  });
+
+  it('surfaces an empty content-filter terminal to the runner as a refusal', async () => {
+    const create = vi.fn().mockImplementation(async () => ({
+      async *[Symbol.asyncIterator]() {
+        yield {
+          id: 'filtered-response',
+          created: 0,
+          model: 'gpt-stream',
+          object: 'chat.completion.chunk',
+          choices: [{ index: 0, delta: {}, finish_reason: 'content_filter' }],
+        } as any;
+      },
+    }));
+    const client = {
+      chat: { completions: { create } },
+      baseURL: 'https://example',
+    };
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt-stream');
+    const agent = new Agent({ name: 'Filtered agent', model });
+
+    const result = await new Runner().run(agent, 'hello', {
+      stream: true,
+      maxTurns: 2,
+    });
+    const consume = async () => {
+      for await (const _event of result) {
+        // Consume the stream.
+      }
+    };
+
+    const error = await consume().then(
+      () => undefined,
+      (caught) => caught,
+    );
+    expect(error).toBeInstanceOf(ModelRefusalError);
+    expect(error).toMatchObject({
+      refusal: "Response withheld by the provider's content filter.",
+    });
+    expect(create).toHaveBeenCalledTimes(1);
   });
 
   it('preserves usage reported on a non-final chunk when the terminal chunk has no usage', async () => {

--- a/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
@@ -1,9 +1,13 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   Agent,
   Runner,
+  Span,
+  Trace,
+  setTraceProcessors,
   withTrace,
   setTracingDisabled,
+  type TracingProcessor,
 } from '@openai/agents-core';
 import { OpenAIChatCompletionsModel } from '../src/openaiChatCompletionsModel';
 import { HEADERS } from '../src/defaults';
@@ -34,10 +38,28 @@ class FakeClient {
   baseURL = 'base';
 }
 
+class RecordingProcessor implements TracingProcessor {
+  readonly spansEnded: Span<any>[] = [];
+
+  async onTraceStart(_trace: Trace): Promise<void> {}
+  async onTraceEnd(_trace: Trace): Promise<void> {}
+  async onSpanStart(_span: Span<any>): Promise<void> {}
+  async onSpanEnd(span: Span<any>): Promise<void> {
+    this.spansEnded.push(span);
+  }
+  async shutdown(): Promise<void> {}
+  async forceFlush(): Promise<void> {}
+}
+
 describe('OpenAIChatCompletionsModel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setTracingDisabled(true);
+  });
+
+  afterEach(() => {
+    setTracingDisabled(true);
+    setTraceProcessors([]);
   });
 
   it('handles text message output', async () => {
@@ -469,6 +491,210 @@ describe('OpenAIChatCompletionsModel', () => {
         status: 'completed',
         content: [{ type: 'output_text', text: '', providerData: {} }],
       },
+    ]);
+  });
+
+  it.each([null, ''])(
+    'surfaces an empty content-filtered message as a refusal (content: %j)',
+    async (content) => {
+      const client = new FakeClient();
+      const response = {
+        id: 'r',
+        choices: [
+          {
+            finish_reason: 'content_filter',
+            message: {
+              role: 'assistant',
+              content,
+              refusal: '',
+              tool_calls: [],
+            },
+          },
+        ],
+        usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+      } as any;
+      client.chat.completions.create.mockResolvedValue(response);
+
+      const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+      const req: any = {
+        input: 'u',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+      };
+
+      const result = await withTrace('t', () => model.getResponse(req));
+
+      expect(result.output).toEqual([
+        {
+          id: 'r',
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [
+            {
+              type: 'refusal',
+              refusal: "Response withheld by the provider's content filter.",
+              providerData: {
+                role: 'assistant',
+                content: null,
+                tool_calls: [],
+              },
+            },
+          ],
+        },
+      ]);
+    },
+  );
+
+  it('preserves content, provider refusals, and tool calls from content-filtered messages', async () => {
+    const client = new FakeClient();
+    client.chat.completions.create
+      .mockResolvedValueOnce({
+        id: 'content-response',
+        choices: [
+          {
+            finish_reason: 'content_filter',
+            message: { content: 'partial' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        id: 'refusal-response',
+        choices: [
+          {
+            finish_reason: 'content_filter',
+            message: { content: null, refusal: 'provider refusal' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        id: 'tool-response',
+        choices: [
+          {
+            finish_reason: 'content_filter',
+            message: {
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call-1',
+                  type: 'function',
+                  function: { name: 'lookup', arguments: '{}' },
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const req: any = {
+      input: 'u',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+    };
+
+    const contentResult = await withTrace('content', () =>
+      model.getResponse(req),
+    );
+    const refusalResult = await withTrace('refusal', () =>
+      model.getResponse(req),
+    );
+    const toolResult = await withTrace('tool', () => model.getResponse(req));
+
+    expect(contentResult.output[0]).toMatchObject({
+      type: 'message',
+      content: [{ type: 'output_text', text: 'partial' }],
+    });
+    expect(refusalResult.output[0]).toMatchObject({
+      type: 'message',
+      content: [{ type: 'refusal', refusal: 'provider refusal' }],
+    });
+    expect(toolResult.output).toMatchObject([
+      {
+        id: 'tool-response',
+        type: 'function_call',
+        arguments: '{}',
+        name: 'lookup',
+        callId: 'call-1',
+        status: 'completed',
+      },
+    ]);
+  });
+
+  it('does not synthesize a refusal for other finish reasons', async () => {
+    const client = new FakeClient();
+    client.chat.completions.create.mockResolvedValue({
+      id: 'r',
+      choices: [
+        {
+          finish_reason: 'stop',
+          message: { content: null },
+        },
+      ],
+    });
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const result = await withTrace('t', () =>
+      model.getResponse({
+        input: 'u',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+      }),
+    );
+
+    expect(result.output).toEqual([]);
+  });
+
+  it('traces the synthesized content-filter refusal', async () => {
+    const processor = new RecordingProcessor();
+    setTraceProcessors([processor]);
+    setTracingDisabled(false);
+
+    const client = new FakeClient();
+    client.chat.completions.create.mockResolvedValue({
+      id: 'r',
+      choices: [
+        {
+          finish_reason: 'content_filter',
+          message: { role: 'assistant', content: null },
+        },
+      ],
+    });
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+
+    await withTrace('content-filter-refusal', () =>
+      model.getResponse({
+        input: 'u',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: true,
+      }),
+    );
+
+    const generationSpan = processor.spansEnded.find(
+      (span) => span.spanData.type === 'generation',
+    );
+    expect(generationSpan?.spanData.output).toEqual([
+      expect.objectContaining({
+        choices: [
+          expect.objectContaining({
+            message: expect.objectContaining({
+              refusal: "Response withheld by the provider's content filter.",
+            }),
+          }),
+        ],
+      }),
     ]);
   });
 

--- a/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
@@ -819,11 +819,21 @@ describe('OpenAIChatCompletionsModel', () => {
     ]);
   });
 
-  it('handles audio message', async () => {
+  it('preserves audio from a content-filtered message', async () => {
     const client = new FakeClient();
     const response = {
       id: 'r',
-      choices: [{ message: { audio: { data: 'zzz', format: 'mp3' } } }],
+      choices: [
+        {
+          finish_reason: 'content_filter',
+          message: {
+            content: null,
+            refusal: null,
+            tool_calls: [],
+            audio: { data: 'zzz', format: 'mp3' },
+          },
+        },
+      ],
       usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
     } as any;
     client.chat.completions.create.mockResolvedValue(response);

--- a/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
@@ -654,13 +654,13 @@ describe('OpenAIChatCompletionsModel', () => {
     expect(result.output).toEqual([]);
   });
 
-  it('traces the synthesized content-filter refusal', async () => {
+  it('traces the synthesized refusal without mutating raw provider data', async () => {
     const processor = new RecordingProcessor();
     setTraceProcessors([processor]);
     setTracingDisabled(false);
 
     const client = new FakeClient();
-    client.chat.completions.create.mockResolvedValue({
+    const rawResponse = {
       id: 'r',
       choices: [
         {
@@ -668,10 +668,11 @@ describe('OpenAIChatCompletionsModel', () => {
           message: { role: 'assistant', content: null },
         },
       ],
-    });
+    };
+    client.chat.completions.create.mockResolvedValue(rawResponse);
     const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
 
-    await withTrace('content-filter-refusal', () =>
+    const result = await withTrace('content-filter-refusal', () =>
       model.getResponse({
         input: 'u',
         modelSettings: {},
@@ -681,6 +682,12 @@ describe('OpenAIChatCompletionsModel', () => {
         tracing: true,
       }),
     );
+
+    expect(result.providerData).toBe(rawResponse);
+    expect(rawResponse.choices[0].message).toEqual({
+      role: 'assistant',
+      content: null,
+    });
 
     const generationSpan = processor.spansEnded.find(
       (span) => span.spanData.type === 'generation',

--- a/packages/agents-openai/test/openaiChatCompletionsStreaming.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsStreaming.test.ts
@@ -20,6 +20,67 @@ function makeChunk(delta: any, usage?: any) {
 }
 
 describe('convertChatCompletionsStreamToResponses', () => {
+  it('surfaces an empty content-filter terminal as a refusal', async () => {
+    const response: ChatCompletion = {
+      id: 'filtered-response',
+      created: 0,
+      model: 'gpt-test',
+      object: 'chat.completion',
+      choices: [],
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    } as any;
+
+    async function* stream() {
+      yield {
+        id: 'filtered-response',
+        created: 0,
+        model: 'gpt-test',
+        object: 'chat.completion.chunk',
+        choices: [{ index: 0, delta: {}, finish_reason: 'content_filter' }],
+      } as any;
+    }
+
+    const events: any[] = [];
+    for await (const event of convertChatCompletionsStreamToResponses(
+      response,
+      stream() as any,
+    )) {
+      events.push(event);
+    }
+
+    expect(events.at(-1)).toMatchObject({
+      type: 'response_done',
+      response: {
+        output: [
+          {
+            id: 'filtered-response',
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [
+              {
+                type: 'refusal',
+                refusal: "Response withheld by the provider's content filter.",
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(response.choices).toEqual([
+      {
+        index: 0,
+        finish_reason: 'content_filter',
+        logprobs: null,
+        message: {
+          role: 'assistant',
+          content: null,
+          refusal: "Response withheld by the provider's content filter.",
+        },
+      },
+    ]);
+  });
+
   it('emits protocol events for streamed chat completions', async () => {
     const response: ChatCompletion = {
       id: 'res1',


### PR DESCRIPTION
This pull request fixes non-streaming Chat Completions responses that signal filtering only through `finish_reason="content_filter"`. It converts otherwise empty messages into the standard protocol refusal before tracing and conversion, while preserving non-empty content, provider refusals, tool calls, and other finish reasons. It also adds focused regression coverage and a patch changeset for `@openai/agents-openai`.
