### PR TITLE
fix(core): cancel sibling tool work on failure

### DIFF
--- a/.changeset/calm-tools-cancel-siblings.md
+++ b/.changeset/calm-tools-cancel-siblings.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: cancel and drain sibling tool work after a concurrent failure

--- a/packages/agents-core/src/runner/siblingCancellation.ts
+++ b/packages/agents-core/src/runner/siblingCancellation.ts
@@ -1,0 +1,88 @@
+import { combineAbortSignals, isAbortError } from '../utils/abortSignals';
+
+type ConcurrentTask<T> = (
+  signal?: AbortSignal,
+  cancelSiblings?: () => void,
+) => Promise<T>;
+
+export async function runWithSiblingCancellation<TFirst, TSecond>(
+  tasks: readonly [ConcurrentTask<TFirst>, ConcurrentTask<TSecond>],
+  parentSignal?: AbortSignal,
+  onFirstFailure?: () => void,
+): Promise<[TFirst, TSecond]>;
+export async function runWithSiblingCancellation<T>(
+  tasks: readonly ConcurrentTask<T>[],
+  parentSignal?: AbortSignal,
+  onFirstFailure?: () => void,
+): Promise<T[]>;
+export async function runWithSiblingCancellation(
+  tasks: readonly ConcurrentTask<unknown>[],
+  parentSignal?: AbortSignal,
+  onFirstFailure?: () => void,
+): Promise<unknown[]> {
+  if (tasks.length <= 1) {
+    return Promise.all(tasks.map((task) => task(parentSignal)));
+  }
+
+  const siblingController = new AbortController();
+  const { signal, cleanup } = combineAbortSignals(
+    parentSignal,
+    siblingController.signal,
+  );
+  let firstFailureOwner: number | undefined;
+  let firstFailure: { value: unknown } | undefined;
+  const siblingFailureReason = new Error(
+    'Cancelled because a sibling task failed.',
+  );
+  const cancelSiblings = () => {
+    if (!siblingController.signal.aborted) {
+      siblingController.abort(siblingFailureReason);
+    }
+  };
+  const reserveFailure = (owner: number) => {
+    if (firstFailureOwner === undefined) {
+      firstFailureOwner = owner;
+      try {
+        onFirstFailure?.();
+      } finally {
+        cancelSiblings();
+      }
+    }
+  };
+
+  const pendingTasks = tasks.map(async (task, index) => {
+    try {
+      return await task(signal, () => reserveFailure(index));
+    } catch (error) {
+      reserveFailure(index);
+      if (firstFailureOwner === index && firstFailure === undefined) {
+        const failure =
+          parentSignal?.aborted &&
+          (error === parentSignal.reason || isAbortError(error))
+            ? parentSignal.reason
+            : error;
+        firstFailure = { value: failure };
+      }
+      throw error;
+    }
+  });
+
+  try {
+    const settledTasks = await Promise.allSettled(pendingTasks);
+    if (firstFailureOwner !== undefined) {
+      if (firstFailure === undefined) {
+        const ownerResult = settledTasks[firstFailureOwner];
+        if (ownerResult?.status === 'rejected') {
+          throw ownerResult.reason;
+        }
+        throw new Error('The task that reserved failure ownership completed.');
+      }
+      throw firstFailure.value;
+    }
+    return settledTasks.map(
+      (result) => (result as PromiseFulfilledResult<unknown>).value,
+    );
+  } finally {
+    cleanup();
+  }
+}

--- a/packages/agents-core/src/runner/siblingCancellation.ts
+++ b/packages/agents-core/src/runner/siblingCancellation.ts
@@ -1,16 +1,12 @@
-import { combineAbortSignals, isAbortError } from '../utils/abortSignals';
-
-class SiblingCancellationError extends Error {}
-
-export function isSiblingCancellationSignal(
-  signal: AbortSignal | undefined,
-): boolean {
-  return signal?.reason instanceof SiblingCancellationError;
-}
+import {
+  combineAbortSignals,
+  createSiblingCancellationError,
+  isAbortError,
+} from '../utils/abortSignals';
 
 type ConcurrentTask<T> = (
   signal?: AbortSignal,
-  cancelSiblings?: () => void,
+  reserveFailure?: (error?: unknown) => void,
 ) => Promise<T>;
 
 export async function runWithSiblingCancellation<TFirst, TSecond>(
@@ -38,18 +34,38 @@ export async function runWithSiblingCancellation(
     siblingController.signal,
   );
   let firstFailureOwner: number | undefined;
+  let firstFailureParentWasAborted = false;
   let firstFailure: { value: unknown } | undefined;
-  const siblingFailureReason = new SiblingCancellationError(
-    'Cancelled because a sibling task failed.',
-  );
+  const siblingFailureReason = createSiblingCancellationError();
   const cancelSiblings = () => {
     if (!siblingController.signal.aborted) {
       siblingController.abort(siblingFailureReason);
     }
   };
-  const reserveFailure = (owner: number) => {
+  const reserveFailure = (
+    owner: number,
+    hasFailure: boolean,
+    error?: unknown,
+  ) => {
+    const newlyReserved = firstFailureOwner === undefined;
     if (firstFailureOwner === undefined) {
       firstFailureOwner = owner;
+      firstFailureParentWasAborted = parentSignal?.aborted ?? false;
+    }
+    if (
+      firstFailureOwner === owner &&
+      hasFailure &&
+      firstFailure === undefined
+    ) {
+      const parentReason = parentSignal?.reason;
+      const failure =
+        firstFailureParentWasAborted &&
+        (error === parentReason || isAbortError(error))
+          ? parentReason
+          : error;
+      firstFailure = { value: failure };
+    }
+    if (newlyReserved) {
       try {
         onFirstFailure?.();
       } finally {
@@ -60,18 +76,11 @@ export async function runWithSiblingCancellation(
 
   const pendingTasks = tasks.map(async (task, index) => {
     try {
-      return await task(signal, () => reserveFailure(index));
+      return await task(signal, (...errors: [error?: unknown]) =>
+        reserveFailure(index, errors.length > 0, errors[0]),
+      );
     } catch (error) {
-      const parentWasAborted = parentSignal?.aborted;
-      reserveFailure(index);
-      if (firstFailureOwner === index && firstFailure === undefined) {
-        const failure =
-          parentWasAborted &&
-          (error === parentSignal.reason || isAbortError(error))
-            ? parentSignal.reason
-            : error;
-        firstFailure = { value: failure };
-      }
+      reserveFailure(index, true, error);
       throw error;
     }
   });

--- a/packages/agents-core/src/runner/siblingCancellation.ts
+++ b/packages/agents-core/src/runner/siblingCancellation.ts
@@ -54,10 +54,11 @@ export async function runWithSiblingCancellation(
     try {
       return await task(signal, () => reserveFailure(index));
     } catch (error) {
+      const parentWasAborted = parentSignal?.aborted;
       reserveFailure(index);
       if (firstFailureOwner === index && firstFailure === undefined) {
         const failure =
-          parentSignal?.aborted &&
+          parentWasAborted &&
           (error === parentSignal.reason || isAbortError(error))
             ? parentSignal.reason
             : error;

--- a/packages/agents-core/src/runner/siblingCancellation.ts
+++ b/packages/agents-core/src/runner/siblingCancellation.ts
@@ -1,5 +1,13 @@
 import { combineAbortSignals, isAbortError } from '../utils/abortSignals';
 
+class SiblingCancellationError extends Error {}
+
+export function isSiblingCancellationSignal(
+  signal: AbortSignal | undefined,
+): boolean {
+  return signal?.reason instanceof SiblingCancellationError;
+}
+
 type ConcurrentTask<T> = (
   signal?: AbortSignal,
   cancelSiblings?: () => void,
@@ -31,7 +39,7 @@ export async function runWithSiblingCancellation(
   );
   let firstFailureOwner: number | undefined;
   let firstFailure: { value: unknown } | undefined;
-  const siblingFailureReason = new Error(
+  const siblingFailureReason = new SiblingCancellationError(
     'Cancelled because a sibling task failed.',
   );
   const cancelSiblings = () => {

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -1353,6 +1353,9 @@ async function _runComputerActionAndScreenshot(
   }
   if (typeof computer.screenshot === 'function') {
     const screenshot = await computer.screenshot(runContext);
+    if (signal?.aborted) {
+      return { type: 'cancelled' };
+    }
     if (typeof screenshot !== 'undefined') {
       return { type: 'completed', output: screenshot };
     }
@@ -2128,6 +2131,9 @@ export async function executeComputerActions(
           }
           output = actionResult.output;
         } catch (err) {
+          if (signal?.aborted) {
+            return buildStartedCancellationItem();
+          }
           logToolActionError(
             _logger,
             'Failed to execute computer action:',

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -106,6 +106,7 @@ import {
   buildFunctionAbortResult,
   COMPUTER_FALLBACK_SCREENSHOT_DATA_URL,
 } from './streamReconciliation';
+import { runWithSiblingCancellation } from './siblingCancellation';
 
 type FunctionToolCallDeps<TContext = UnknownContext> = {
   agent: Agent<TContext, any>;
@@ -302,6 +303,7 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
   toolErrorFormatter?: ToolErrorFormatter,
   agentToolParentRunConfig?: Partial<RunConfig>,
   signal?: AbortSignal,
+  onFatalFailure?: () => void,
 ): Promise<FunctionToolResult<TContext>[]> {
   const deps: FunctionToolCallDeps<TContext> = {
     agent,
@@ -314,9 +316,16 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
 
   const startedInvalidInputFailures: InvalidToolInputFailure[] = [];
 
-  const executeToolRun = async (toolRun: ToolRunFunction<TContext>) => {
-    if (signal?.aborted) {
-      return buildFunctionCancellationResult(deps, toolRun);
+  const executeToolRun = async (
+    toolRun: ToolRunFunction<TContext>,
+    executionSignal = signal,
+  ) => {
+    const executionDeps =
+      executionSignal === deps.signal
+        ? deps
+        : { ...deps, signal: executionSignal };
+    if (executionSignal?.aborted) {
+      return buildFunctionCancellationResult(executionDeps, toolRun);
     }
     const parseResult = parseToolArguments(toolRun);
     let failure: InvalidToolInputFailure | undefined;
@@ -342,7 +351,7 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
     if (!parseResult.success) {
       if (parseResult.preparedInput) {
         const approvalOutcome = await handleFunctionApproval(
-          deps,
+          executionDeps,
           toolRun,
           parseResult.approvalArgs,
           false,
@@ -353,7 +362,7 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
         }
         try {
           return await runApprovedFunctionTool(
-            deps,
+            executionDeps,
             toolRun,
             parseResult.approvalArgs,
             parseResult.preparedInput,
@@ -361,16 +370,16 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
           );
         } catch (error) {
           if (
-            signal?.aborted &&
-            (error === signal.reason || isAbortError(error))
+            executionSignal?.aborted &&
+            (error === executionSignal.reason || isAbortError(error))
           ) {
-            return buildFunctionCancellationResult(deps, toolRun);
+            return buildFunctionCancellationResult(executionDeps, toolRun);
           }
           throw error;
         }
       } else if (dynamicApprovalPolicy) {
         const approvalOutcome = await handleFunctionApproval(
-          deps,
+          executionDeps,
           toolRun,
           undefined,
           true,
@@ -380,11 +389,16 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
           return approvalOutcome;
         }
       }
-      return buildParseErrorResult(deps, toolRun, parseResult.error, failure!);
+      return buildParseErrorResult(
+        executionDeps,
+        toolRun,
+        parseResult.error,
+        failure!,
+      );
     }
 
     const approvalOutcome = await handleFunctionApproval(
-      deps,
+      executionDeps,
       toolRun,
       parseResult.approvalArgs,
       dynamicApprovalPolicy &&
@@ -395,14 +409,17 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
     }
     try {
       return await runApprovedFunctionTool(
-        deps,
+        executionDeps,
         toolRun,
         parseResult.approvalArgs,
         parseResult.preparedInput,
       );
     } catch (error) {
-      if (signal?.aborted && (error === signal.reason || isAbortError(error))) {
-        return buildFunctionCancellationResult(deps, toolRun);
+      if (
+        executionSignal?.aborted &&
+        (error === executionSignal.reason || isAbortError(error))
+      ) {
+        return buildFunctionCancellationResult(executionDeps, toolRun);
       }
       throw error;
     }
@@ -415,6 +432,8 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
         agentToolParentRunConfig?.toolExecution ?? runner.config.toolExecution,
       ),
       executeToolRun,
+      signal,
+      onFatalFailure,
     );
     return results;
   } catch (e: unknown) {
@@ -464,44 +483,53 @@ function shouldRunPreApprovalInputGuardrails<TContext>(
 async function executeToolRunsWithConcurrency<TContext, TToolRun>(
   toolRuns: TToolRun[],
   maxConcurrency: number | undefined,
-  executeToolRun: (toolRun: TToolRun) => Promise<FunctionToolResult<TContext>>,
+  executeToolRun: (
+    toolRun: TToolRun,
+    signal?: AbortSignal,
+  ) => Promise<FunctionToolResult<TContext>>,
+  parentSignal?: AbortSignal,
+  onFatalFailure?: () => void,
 ): Promise<FunctionToolResult<TContext>[]> {
   if (
     maxConcurrency === undefined ||
     maxConcurrency >= toolRuns.length ||
     toolRuns.length <= 1
   ) {
-    return Promise.all(toolRuns.map((toolRun) => executeToolRun(toolRun)));
+    return runWithSiblingCancellation(
+      toolRuns.map(
+        (toolRun) => (signal?: AbortSignal) => executeToolRun(toolRun, signal),
+      ),
+      parentSignal,
+      onFatalFailure,
+    );
   }
 
   const results: FunctionToolResult<TContext>[] = [];
   let nextIndex = 0;
-  let firstError: { value: unknown } | undefined;
 
-  const worker = async () => {
-    while (nextIndex < toolRuns.length && firstError === undefined) {
+  const worker = async (signal?: AbortSignal) => {
+    while (
+      nextIndex < toolRuns.length &&
+      (!signal?.aborted || parentSignal?.aborted)
+    ) {
       const currentIndex = nextIndex;
       nextIndex += 1;
-      try {
-        const result = await executeToolRun(toolRuns[currentIndex]);
-        results[currentIndex] = result;
-      } catch (error) {
-        firstError ??= { value: error };
-        break;
-      }
+      const result = await executeToolRun(toolRuns[currentIndex], signal);
+      results[currentIndex] = result;
     }
   };
 
   const workerCount = Math.min(maxConcurrency, toolRuns.length);
   // Drain every started worker before returning so no function tool retains
   // ownership after the run surfaces an error or cancellation.
-  await Promise.allSettled(
-    Array.from({ length: workerCount }, async () => worker()),
+  await runWithSiblingCancellation(
+    Array.from(
+      { length: workerCount },
+      () => (signal?: AbortSignal) => worker(signal),
+    ),
+    parentSignal,
+    onFatalFailure,
   );
-
-  if (firstError !== undefined) {
-    throw firstError.value;
-  }
   return results;
 }
 
@@ -1268,8 +1296,12 @@ async function _runComputerActionAndScreenshot(
   computer: Computer,
   toolCall: protocol.ComputerUseCallItem,
   runContext: RunContext,
-): Promise<string> {
+  signal?: AbortSignal,
+): Promise<{ type: 'completed'; output: string } | { type: 'cancelled' }> {
   for (const action of getComputerToolActions(toolCall)) {
+    if (signal?.aborted) {
+      return { type: 'cancelled' };
+    }
     switch (action.type) {
       case 'click':
         await computer.click(action.x, action.y, action.button, runContext);
@@ -1311,12 +1343,18 @@ async function _runComputerActionAndScreenshot(
         action satisfies never;
         break;
     }
+    if (signal?.aborted) {
+      return { type: 'cancelled' };
+    }
   }
 
+  if (signal?.aborted) {
+    return { type: 'cancelled' };
+  }
   if (typeof computer.screenshot === 'function') {
     const screenshot = await computer.screenshot(runContext);
     if (typeof screenshot !== 'undefined') {
-      return screenshot;
+      return { type: 'completed', output: screenshot };
     }
   }
 
@@ -1937,8 +1975,7 @@ export async function executeComputerActions(
     const toolCall = action.toolCall;
     const computerTool = action.computer;
     if (signal?.aborted) {
-      const rawItem = buildComputerAbortResult(toolCall);
-      results.push(new RunToolCallOutputItem(rawItem, agent, 'aborted'));
+      results.push(buildComputerCancellationItem(agent, toolCall));
       continue;
     }
     const computerActions = getComputerToolActions(toolCall);
@@ -2034,8 +2071,28 @@ export async function executeComputerActions(
             typeof traceInput === 'undefined' ? '' : JSON.stringify(traceInput);
         }
 
+        if (signal?.aborted) {
+          return buildComputerCancellationItem(agent, toolCall);
+        }
+
         // Hooks: on_tool_start (global + agent)
         emitToolStart(runner, runContext, agent, computerTool, toolCall);
+
+        const buildStartedCancellationItem = () => {
+          const item = buildComputerCancellationItem(agent, toolCall);
+          emitToolEnd(
+            runner,
+            runContext,
+            agent,
+            computerTool,
+            'aborted',
+            toolCall,
+          );
+          if (span && runner.config.traceIncludeSensitiveData) {
+            span.spanData.output = 'aborted';
+          }
+          return item;
+        };
 
         const acknowledgedSafetyChecks =
           pendingSafetyChecks && pendingSafetyChecks.length > 0
@@ -2046,6 +2103,9 @@ export async function executeComputerActions(
                 onSafetyCheck: computerTool.onSafetyCheck,
               })
             : undefined;
+        if (signal?.aborted) {
+          return buildStartedCancellationItem();
+        }
 
         // Run the action and get screenshot.
         let output: string;
@@ -2054,11 +2114,19 @@ export async function executeComputerActions(
             tool: computerTool,
             runContext,
           });
-          output = await _runComputerActionAndScreenshot(
+          if (signal?.aborted) {
+            return buildStartedCancellationItem();
+          }
+          const actionResult = await _runComputerActionAndScreenshot(
             computer,
             toolCall,
             runContext,
+            signal,
           );
+          if (actionResult.type === 'cancelled') {
+            return buildStartedCancellationItem();
+          }
+          output = actionResult.output;
         } catch (err) {
           logToolActionError(
             _logger,
@@ -2123,6 +2191,14 @@ export async function executeComputerActions(
     results.push(computerItem);
   }
   return results;
+}
+
+function buildComputerCancellationItem(
+  agent: Agent<any, any>,
+  toolCall: protocol.ComputerUseCallItem,
+): RunToolCallOutputItem {
+  const rawItem = buildComputerAbortResult(toolCall);
+  return new RunToolCallOutputItem(rawItem, agent, 'aborted');
 }
 
 /**

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -106,7 +106,10 @@ import {
   buildFunctionAbortResult,
   COMPUTER_FALLBACK_SCREENSHOT_DATA_URL,
 } from './streamReconciliation';
-import { runWithSiblingCancellation } from './siblingCancellation';
+import {
+  isSiblingCancellationSignal,
+  runWithSiblingCancellation,
+} from './siblingCancellation';
 
 type FunctionToolCallDeps<TContext = UnknownContext> = {
   agent: Agent<TContext, any>;
@@ -1113,6 +1116,9 @@ async function runApprovedFunctionTool<TContext>(
         });
         executionStatus = 'executed';
         throwIfRedactionPromoted(redactedBeforeInvocation);
+        if (isSiblingCancellationSignal(signal)) {
+          signal?.throwIfAborted();
+        }
         const redactedBeforeOutputGuardrails = refreshRedaction();
         const outputGuardrailResults: ToolOutputGuardrailResult[] = [];
         try {

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -53,7 +53,10 @@ import {
 import type { ShellResult } from '../shell';
 import { RunContext } from '../runContext';
 import type { RunResult } from '../result';
-import { isAbortError } from '../utils/abortSignals';
+import {
+  isAbortError,
+  isSiblingCancellationSignal,
+} from '../utils/abortSignals';
 import { isZodObject } from '../utils';
 import { toSmartString } from '../utils/smartString';
 import { withFunctionSpan, withHandoffSpan } from '../tracing/createSpans';
@@ -106,10 +109,7 @@ import {
   buildFunctionAbortResult,
   COMPUTER_FALLBACK_SCREENSHOT_DATA_URL,
 } from './streamReconciliation';
-import {
-  isSiblingCancellationSignal,
-  runWithSiblingCancellation,
-} from './siblingCancellation';
+import { runWithSiblingCancellation } from './siblingCancellation';
 
 type FunctionToolCallDeps<TContext = UnknownContext> = {
   agent: Agent<TContext, any>;
@@ -363,6 +363,9 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
         if (approvalOutcome !== 'approved') {
           return approvalOutcome;
         }
+        if (executionSignal?.aborted) {
+          return buildFunctionCancellationResult(executionDeps, toolRun);
+        }
         try {
           return await runApprovedFunctionTool(
             executionDeps,
@@ -391,6 +394,9 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
         if (approvalOutcome !== 'approved') {
           return approvalOutcome;
         }
+        if (executionSignal?.aborted) {
+          return buildFunctionCancellationResult(executionDeps, toolRun);
+        }
       }
       return buildParseErrorResult(
         executionDeps,
@@ -409,6 +415,9 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
     );
     if (approvalOutcome !== 'approved') {
       return approvalOutcome;
+    }
+    if (executionSignal?.aborted) {
+      return buildFunctionCancellationResult(executionDeps, toolRun);
     }
     try {
       return await runApprovedFunctionTool(
@@ -510,15 +519,21 @@ async function executeToolRunsWithConcurrency<TContext, TToolRun>(
   const results: FunctionToolResult<TContext>[] = [];
   let nextIndex = 0;
 
-  const worker = async (signal?: AbortSignal) => {
+  const worker = async (signal?: AbortSignal, reserveFailure?: () => void) => {
     while (
       nextIndex < toolRuns.length &&
-      (!signal?.aborted || parentSignal?.aborted)
+      (!signal?.aborted ||
+        (parentSignal?.aborted && !isSiblingCancellationSignal(parentSignal)))
     ) {
       const currentIndex = nextIndex;
       nextIndex += 1;
-      const result = await executeToolRun(toolRuns[currentIndex], signal);
-      results[currentIndex] = result;
+      try {
+        const result = await executeToolRun(toolRuns[currentIndex], signal);
+        results[currentIndex] = result;
+      } catch (error) {
+        reserveFailure?.();
+        throw error;
+      }
     }
   };
 
@@ -528,7 +543,8 @@ async function executeToolRunsWithConcurrency<TContext, TToolRun>(
   await runWithSiblingCancellation(
     Array.from(
       { length: workerCount },
-      () => (signal?: AbortSignal) => worker(signal),
+      () => (signal?: AbortSignal, reserveFailure?: () => void) =>
+        worker(signal, reserveFailure),
     ),
     parentSignal,
     onFatalFailure,
@@ -757,6 +773,9 @@ async function buildApprovalRejectionResult<TContext>(
       callId: toolRun.toolCall.callId,
       toolErrorFormatter,
     });
+    if (isSiblingCancellationSignal(deps.signal)) {
+      return buildFunctionCancellationResult(deps, toolRun);
+    }
     const redactDetails = invalidInputFailure
       ? refreshInvalidToolInputFailure(invalidInputFailure)
       : false;
@@ -764,7 +783,29 @@ async function buildApprovalRejectionResult<TContext>(
       runner.config.traceIncludeSensitiveData && !redactDetails
         ? response
         : TOOL_APPROVAL_REJECTION_MESSAGE;
-
+    let output: unknown;
+    let rejectionFallbackFailed = false;
+    let rejectionFallbackError: unknown;
+    try {
+      output = await resolveFunctionFailureOutput(
+        deps,
+        toolRun,
+        new Error(response),
+        response,
+        invalidInputFailure
+          ? {
+              failure: invalidInputFailure,
+              redactedLegacyOutput: TOOL_APPROVAL_REJECTION_MESSAGE,
+            }
+          : undefined,
+      );
+    } catch (error) {
+      rejectionFallbackFailed = true;
+      rejectionFallbackError = error;
+    }
+    if (isSiblingCancellationSignal(deps.signal)) {
+      return buildFunctionCancellationResult(deps, toolRun);
+    }
     span?.setError({
       message: traceErrorMessage,
       data: {
@@ -772,19 +813,9 @@ async function buildApprovalRejectionResult<TContext>(
         error: `Tool execution for ${toolRun.toolCall.callId} was manually rejected by user.`,
       },
     });
-
-    const output = await resolveFunctionFailureOutput(
-      deps,
-      toolRun,
-      new Error(response),
-      response,
-      invalidInputFailure
-        ? {
-            failure: invalidInputFailure,
-            redactedLegacyOutput: TOOL_APPROVAL_REJECTION_MESSAGE,
-          }
-        : undefined,
-    );
+    if (rejectionFallbackFailed) {
+      throw rejectionFallbackError;
+    }
     if (
       invalidInputFailure &&
       refreshInvalidToolInputFailure(invalidInputFailure) &&
@@ -850,6 +881,10 @@ async function handleFunctionApproval<TContext>(
     }
   }
 
+  if (deps.signal?.aborted) {
+    return buildFunctionCancellationResult(deps, toolRun);
+  }
+
   if (!needsApproval) {
     return 'approved';
   }
@@ -884,6 +919,9 @@ async function handleFunctionApproval<TContext>(
       : false;
     if (redactedBeforeGuardrails || !redactedAfterGuardrails) {
       state._toolInputGuardrailResults.push(...guardrailResults);
+    }
+    if (isSiblingCancellationSignal(deps.signal)) {
+      return buildFunctionCancellationResult(deps, toolRun);
     }
     if (guardrailFailed) {
       const sdkTripwire = guardrailResults.some(
@@ -989,6 +1027,30 @@ async function runApprovedFunctionTool<TContext>(
       span.spanData.input = toolRun.toolCall.arguments;
     }
 
+    let toolStarted = false;
+    let invocationPending = false;
+    let cancellationFinalizationAttempted = false;
+    const buildSiblingCancellationResult = () => {
+      if (toolStarted) {
+        toolStarted = false;
+        cancellationFinalizationAttempted = true;
+        if (span && runner.config.traceIncludeSensitiveData) {
+          span.spanData.output = 'aborted';
+        }
+        emitFunctionToolEnd(
+          runner,
+          state._context,
+          agent,
+          toolRun.tool,
+          'aborted',
+          toolRun.toolCall,
+          refreshRedaction,
+          true,
+        );
+      }
+      return buildFunctionCancellationResult(deps, toolRun);
+    };
+
     try {
       const redactedBeforeInputGuardrails = refreshRedaction();
       const inputGuardrailResults: ToolInputGuardrailResult[] = [];
@@ -1025,6 +1087,9 @@ async function runApprovedFunctionTool<TContext>(
       if (redactedBeforeInputGuardrails || !redactedAfterInputGuardrails) {
         state._toolInputGuardrailResults.push(...inputGuardrailResults);
       }
+      if (signal?.aborted) {
+        return buildFunctionCancellationResult(deps, toolRun);
+      }
       if (inputGuardrailFailed) {
         if (
           !redactedBeforeInputGuardrails &&
@@ -1034,10 +1099,6 @@ async function runApprovedFunctionTool<TContext>(
           throw invalidInputFailure.error;
         }
         throw inputGuardrailError;
-      }
-
-      if (signal?.aborted) {
-        return buildFunctionCancellationResult(deps, toolRun);
       }
 
       const redactedBeforeToolStart = refreshRedaction();
@@ -1061,6 +1122,7 @@ async function runApprovedFunctionTool<TContext>(
         throw hookError;
       }
       refreshRedaction();
+      toolStarted = true;
 
       let toolOutput: unknown;
       let executedInput = approvalArgs;
@@ -1068,18 +1130,28 @@ async function runApprovedFunctionTool<TContext>(
       let shouldValidateToolOutput = false;
       let executionStatus: 'executed' | undefined;
       if (inputGuardrailResult.type === 'reject') {
-        toolOutput = await resolveFunctionFailureOutput(
-          deps,
-          toolRun,
-          new Error(inputGuardrailResult.message),
-          inputGuardrailResult.message,
-          invalidInputFailure
-            ? {
-                failure: invalidInputFailure,
-                redactedLegacyOutput: REDACTED_TOOL_ERROR_MESSAGE,
-              }
-            : undefined,
-        );
+        try {
+          toolOutput = await resolveFunctionFailureOutput(
+            deps,
+            toolRun,
+            new Error(inputGuardrailResult.message),
+            inputGuardrailResult.message,
+            invalidInputFailure
+              ? {
+                  failure: invalidInputFailure,
+                  redactedLegacyOutput: REDACTED_TOOL_ERROR_MESSAGE,
+                }
+              : undefined,
+          );
+        } catch (error) {
+          if (isSiblingCancellationSignal(signal)) {
+            return buildSiblingCancellationResult();
+          }
+          throw error;
+        }
+        if (isSiblingCancellationSignal(signal)) {
+          return buildSiblingCancellationResult();
+        }
       } else {
         const resumeState = stateKeys
           .map((stateKey) =>
@@ -1107,6 +1179,7 @@ async function runApprovedFunctionTool<TContext>(
           agentToolParentRunConfig ?? runner.config,
         );
         setToolCallParentSpanOnDetails(toolDetails, span);
+        invocationPending = true;
         signal?.throwIfAborted();
         const invokedToolOutput = await invokeFunctionTool({
           tool: toolRun.tool,
@@ -1115,9 +1188,10 @@ async function runApprovedFunctionTool<TContext>(
           details: toolDetails,
         });
         executionStatus = 'executed';
+        invocationPending = false;
         throwIfRedactionPromoted(redactedBeforeInvocation);
         if (isSiblingCancellationSignal(signal)) {
-          signal?.throwIfAborted();
+          return buildSiblingCancellationResult();
         }
         const redactedBeforeOutputGuardrails = refreshRedaction();
         const outputGuardrailResults: ToolOutputGuardrailResult[] = [];
@@ -1148,6 +1222,9 @@ async function runApprovedFunctionTool<TContext>(
           throwIfRedactionPromoted(redactedBeforeOutputGuardrails);
           state._toolOutputGuardrailResults.push(...outputGuardrailResults);
         }
+        if (isSiblingCancellationSignal(signal)) {
+          return buildSiblingCancellationResult();
+        }
         shouldValidateToolOutput = toolOutput !== invokedToolOutput;
       }
       if (shouldValidateToolOutput) {
@@ -1172,6 +1249,8 @@ async function runApprovedFunctionTool<TContext>(
       let customData: Awaited<
         ReturnType<typeof maybeExtractToolOutputCustomData>
       >;
+      let customDataFailed = false;
+      let customDataError: unknown;
       try {
         customData = await maybeExtractToolOutputCustomData(
           toolRun.tool.customDataExtractor,
@@ -1189,8 +1268,22 @@ async function runApprovedFunctionTool<TContext>(
             rawItem: cloneForCustomDataContext(rawItem),
           } satisfies FunctionToolCustomDataContext<TContext>,
         );
+      } catch (error) {
+        customDataFailed = true;
+        customDataError = error;
       } finally {
-        throwIfRedactionPromoted(redactedBeforeCustomData);
+        try {
+          throwIfRedactionPromoted(redactedBeforeCustomData);
+        } catch (error) {
+          customDataFailed = true;
+          customDataError = error;
+        }
+      }
+      if (isSiblingCancellationSignal(signal)) {
+        return buildSiblingCancellationResult();
+      }
+      if (customDataFailed) {
+        throw customDataError;
       }
 
       const redactedBeforeToolEnd = refreshRedaction();
@@ -1252,6 +1345,12 @@ async function runApprovedFunctionTool<TContext>(
 
       return functionResult;
     } catch (error) {
+      if (cancellationFinalizationAttempted) {
+        throw error;
+      }
+      if (isSiblingCancellationSignal(signal) && invocationPending) {
+        return buildSiblingCancellationResult();
+      }
       const redacted = refreshRedaction();
       const errorResult = redacted
         ? REDACTED_TOOL_ERROR_MESSAGE
@@ -1422,7 +1521,7 @@ async function withRunStateToolFunctionSpan<TContext, T>(
   );
 }
 
-type ApprovalResolution = 'approved' | 'rejected' | 'pending';
+type ApprovalResolution = 'approved' | 'rejected' | 'pending' | 'cancelled';
 
 type LocalApprovalDecision = {
   approve?: boolean;
@@ -1441,6 +1540,7 @@ async function resolveToolApproval(options: {
         approvalItem: RunToolApprovalItem,
       ) => Promise<LocalApprovalDecision>)
     | undefined;
+  isCancelled?: () => boolean;
 }): Promise<ApprovalResolution> {
   const {
     runContext,
@@ -1449,6 +1549,7 @@ async function resolveToolApproval(options: {
     approvalItem,
     needsApproval,
     onApproval,
+    isCancelled,
   } = options;
 
   const existingApproval = runContext.isToolApproved({
@@ -1464,12 +1565,27 @@ async function resolveToolApproval(options: {
     return 'rejected';
   }
 
-  if (!(await needsApproval())) {
+  let approvalRequired: boolean;
+  try {
+    approvalRequired = await needsApproval();
+  } catch (error) {
+    if (isCancelled?.()) {
+      return 'cancelled';
+    }
+    throw error;
+  }
+  if (isCancelled?.()) {
+    return 'cancelled';
+  }
+  if (!approvalRequired) {
     return 'approved';
   }
 
   if (onApproval) {
     const decision = await onApproval(runContext, approvalItem);
+    if (isCancelled?.()) {
+      return 'cancelled';
+    }
     if (decision.approve === true) {
       runContext.approveTool(approvalItem);
     } else if (decision.approve === false) {
@@ -1500,7 +1616,8 @@ async function resolveToolApproval(options: {
 }
 
 type ApprovalDecisionResult =
-  { status: 'approved' } | { status: 'pending' | 'rejected'; item: RunItem };
+  | { status: 'approved' }
+  | { status: 'pending' | 'rejected' | 'cancelled'; item: RunItem };
 
 async function handleToolApprovalDecision(options: {
   runContext: RunContext;
@@ -1515,6 +1632,8 @@ async function handleToolApprovalDecision(options: {
       ) => Promise<LocalApprovalDecision>)
     | undefined;
   buildRejectionItem: () => Promise<RunItem> | RunItem;
+  isCancelled?: () => boolean;
+  buildCancellationItem?: () => RunItem;
 }): Promise<ApprovalDecisionResult> {
   const {
     runContext,
@@ -1524,6 +1643,8 @@ async function handleToolApprovalDecision(options: {
     needsApproval,
     onApproval,
     buildRejectionItem,
+    isCancelled,
+    buildCancellationItem,
   } = options;
 
   const approvalState = await resolveToolApproval({
@@ -1533,8 +1654,21 @@ async function handleToolApprovalDecision(options: {
     approvalItem,
     needsApproval,
     onApproval,
+    isCancelled,
   });
 
+  if (isCancelled?.()) {
+    return {
+      status: 'cancelled',
+      item: buildCancellationItem?.() ?? approvalItem,
+    };
+  }
+  if (approvalState === 'cancelled') {
+    return {
+      status: 'cancelled',
+      item: buildCancellationItem?.() ?? approvalItem,
+    };
+  }
   if (approvalState === 'rejected') {
     return { status: 'rejected', item: await buildRejectionItem() };
   }
@@ -1597,6 +1731,7 @@ function emitFunctionToolEnd(
   output: string,
   toolCall: protocol.FunctionCallItem,
   refreshRedaction: () => boolean,
+  redactionSafeOutput = false,
 ): void {
   const redactedBeforeRunnerHook = refreshRedaction();
   runner.emit('agent_tool_end', runContext, agent, tool, output, {
@@ -1611,7 +1746,9 @@ function emitFunctionToolEnd(
       'agent_tool_end',
       runContext,
       tool,
-      !redactedBeforeRunnerHook && redactedBeforeAgentHook
+      !redactionSafeOutput &&
+        !redactedBeforeRunnerHook &&
+        redactedBeforeAgentHook
         ? REDACTED_TOOL_ERROR_MESSAGE
         : output,
       {
@@ -1977,6 +2114,7 @@ export async function executeComputerActions(
   customLogger: Logger | undefined = undefined,
   toolErrorFormatter?: ToolErrorFormatter,
   signal?: AbortSignal,
+  onFatalFailure?: (error?: unknown) => void,
 ): Promise<RunItem[]> {
   const _logger = customLogger ?? logger;
   const results: RunItem[] = [];
@@ -2015,24 +2153,39 @@ export async function executeComputerActions(
       toolName: computerTool.name,
       callId: toolCall.callId,
       approvalItem,
-      needsApproval: async () =>
-        typeof needsApprovalCandidate === 'function'
-          ? (
-              await Promise.all(
-                computerActions.map((computerAction) =>
-                  (
-                    needsApprovalCandidate as (
-                      runContext: RunContext,
-                      action: protocol.ComputerAction,
-                      callId?: string,
-                    ) => Promise<boolean>
-                  )(runContext, computerAction, toolCall.callId),
-                ),
-              )
-            ).some(Boolean)
-          : typeof needsApprovalCandidate === 'boolean'
+      needsApproval: async () => {
+        if (typeof needsApprovalCandidate !== 'function') {
+          return typeof needsApprovalCandidate === 'boolean'
             ? needsApprovalCandidate
-            : false,
+            : false;
+        }
+        let firstError: { value: unknown } | undefined;
+        const approvalResults = await Promise.allSettled(
+          computerActions.map(async (computerAction) => {
+            try {
+              return await (
+                needsApprovalCandidate as (
+                  runContext: RunContext,
+                  action: protocol.ComputerAction,
+                  callId?: string,
+                ) => Promise<boolean>
+              )(runContext, computerAction, toolCall.callId);
+            } catch (error) {
+              if (!firstError) {
+                firstError = { value: error };
+                onFatalFailure?.(error);
+              }
+              throw error;
+            }
+          }),
+        );
+        if (firstError) {
+          throw firstError.value;
+        }
+        return approvalResults.some(
+          (result) => result.status === 'fulfilled' && result.value,
+        );
+      },
       buildRejectionItem: async () => {
         const rejectionMessage = await getRejectionMessage();
         const rejectionOutput: protocol.ComputerToolOutput = {
@@ -2054,10 +2207,22 @@ export async function executeComputerActions(
           COMPUTER_FALLBACK_SCREENSHOT_DATA_URL,
         );
       },
+      isCancelled: () => isSiblingCancellationSignal(signal),
+      buildCancellationItem: () =>
+        buildComputerCancellationItem(agent, toolCall),
     });
+
+    if (isSiblingCancellationSignal(signal)) {
+      results.push(buildComputerCancellationItem(agent, toolCall));
+      continue;
+    }
 
     if (approvalDecision.status === 'rejected') {
       const rejectionMessage = await getRejectionMessage();
+      if (isSiblingCancellationSignal(signal)) {
+        results.push(buildComputerCancellationItem(agent, toolCall));
+        continue;
+      }
       results.push(approvalDecision.item);
       results.push(
         new RunMessageOutputItem(assistant(rejectionMessage), agent),
@@ -2066,6 +2231,11 @@ export async function executeComputerActions(
     }
 
     if (approvalDecision.status === 'pending') {
+      results.push(approvalDecision.item);
+      continue;
+    }
+
+    if (approvalDecision.status === 'cancelled') {
       results.push(approvalDecision.item);
       continue;
     }
@@ -2087,8 +2257,13 @@ export async function executeComputerActions(
         // Hooks: on_tool_start (global + agent)
         emitToolStart(runner, runContext, agent, computerTool, toolCall);
 
+        let cancellationFinalizationAttempted = false;
         const buildStartedCancellationItem = () => {
           const item = buildComputerCancellationItem(agent, toolCall);
+          cancellationFinalizationAttempted = true;
+          if (span && runner.config.traceIncludeSensitiveData) {
+            span.spanData.output = 'aborted';
+          }
           emitToolEnd(
             runner,
             runContext,
@@ -2097,21 +2272,26 @@ export async function executeComputerActions(
             'aborted',
             toolCall,
           );
-          if (span && runner.config.traceIncludeSensitiveData) {
-            span.spanData.output = 'aborted';
-          }
           return item;
         };
 
-        const acknowledgedSafetyChecks =
-          pendingSafetyChecks && pendingSafetyChecks.length > 0
-            ? await resolveSafetyCheckAcknowledgements({
-                runContext,
-                toolCall,
-                pendingSafetyChecks,
-                onSafetyCheck: computerTool.onSafetyCheck,
-              })
-            : undefined;
+        let acknowledgedSafetyChecks: ComputerSafetyCheck[] | undefined;
+        try {
+          acknowledgedSafetyChecks =
+            pendingSafetyChecks && pendingSafetyChecks.length > 0
+              ? await resolveSafetyCheckAcknowledgements({
+                  runContext,
+                  toolCall,
+                  pendingSafetyChecks,
+                  onSafetyCheck: computerTool.onSafetyCheck,
+                })
+              : undefined;
+        } catch (error) {
+          if (isSiblingCancellationSignal(signal)) {
+            return buildStartedCancellationItem();
+          }
+          throw error;
+        }
         if (signal?.aborted) {
           return buildStartedCancellationItem();
         }
@@ -2132,11 +2312,14 @@ export async function executeComputerActions(
             runContext,
             signal,
           );
-          if (actionResult.type === 'cancelled') {
+          if (signal?.aborted || actionResult.type === 'cancelled') {
             return buildStartedCancellationItem();
           }
           output = actionResult.output;
         } catch (err) {
+          if (cancellationFinalizationAttempted) {
+            throw err;
+          }
           if (signal?.aborted) {
             return buildStartedCancellationItem();
           }
@@ -2172,16 +2355,32 @@ export async function executeComputerActions(
             acknowledgedSafetyChecks,
           };
         }
-        const customData = await maybeExtractToolOutputCustomData(
-          computerTool.customDataExtractor,
-          {
-            runContext,
-            tool: computerTool,
-            toolCall: cloneForCustomDataContext(toolCall),
-            output: imageUrl,
-            rawItem: cloneForCustomDataContext(rawItem),
-          } satisfies ComputerToolCustomDataContext,
-        );
+        let customData: Awaited<
+          ReturnType<typeof maybeExtractToolOutputCustomData>
+        >;
+        let customDataFailed = false;
+        let customDataError: unknown;
+        try {
+          customData = await maybeExtractToolOutputCustomData(
+            computerTool.customDataExtractor,
+            {
+              runContext,
+              tool: computerTool,
+              toolCall: cloneForCustomDataContext(toolCall),
+              output: imageUrl,
+              rawItem: cloneForCustomDataContext(rawItem),
+            } satisfies ComputerToolCustomDataContext,
+          );
+        } catch (error) {
+          customDataFailed = true;
+          customDataError = error;
+        }
+        if (isSiblingCancellationSignal(signal)) {
+          return buildStartedCancellationItem();
+        }
+        if (customDataFailed) {
+          throw customDataError;
+        }
 
         // Hooks: on_tool_end (global + agent)
         emitToolEnd(runner, runContext, agent, computerTool, output, toolCall);

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -1081,7 +1081,10 @@ export async function resolveTurnAfterModelResponse<
       executionSignal,
       cancelSiblingCategories,
     );
-  const runComputerActions = (executionSignal = signal) =>
+  const runComputerActions = (
+    executionSignal = signal,
+    cancelSiblingCategories?: (error?: unknown) => void,
+  ) =>
     executeComputerActions(
       agent,
       processedResponse.computerActions,
@@ -1090,6 +1093,7 @@ export async function resolveTurnAfterModelResponse<
       undefined,
       toolErrorFormatter,
       executionSignal,
+      cancelSiblingCategories,
     );
   const [functionResults, computerResults] =
     processedResponse.functions.length > 0 &&

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -60,6 +60,7 @@ import {
   buildFunctionAbortResult,
   buildShellAbortResult,
 } from './streamReconciliation';
+import { runWithSiblingCancellation } from './siblingCancellation';
 
 const DEFAULT_TOOL_NOT_FOUND_MESSAGE = (toolName: string) =>
   `Tool '${toolName}' not found.`;
@@ -1066,7 +1067,10 @@ export async function resolveTurnAfterModelResponse<
 
   // Run function tools and computer actions in parallel; neither depends on the other's side effects.
   // Shell and apply_patch actions both mutate the sandbox filesystem, so preserve model order.
-  const [functionResults, computerResults] = await Promise.all([
+  const runFunctionTools = (
+    executionSignal = signal,
+    cancelSiblingCategories?: () => void,
+  ) =>
     executeFunctionToolCalls(
       agent,
       processedResponse.functions,
@@ -1074,8 +1078,10 @@ export async function resolveTurnAfterModelResponse<
       state,
       toolErrorFormatter,
       agentToolParentRunConfig,
-      signal,
-    ),
+      executionSignal,
+      cancelSiblingCategories,
+    );
+  const runComputerActions = (executionSignal = signal) =>
     executeComputerActions(
       agent,
       processedResponse.computerActions,
@@ -1083,9 +1089,16 @@ export async function resolveTurnAfterModelResponse<
       state._context,
       undefined,
       toolErrorFormatter,
-      signal,
-    ),
-  ]);
+      executionSignal,
+    );
+  const [functionResults, computerResults] =
+    processedResponse.functions.length > 0 &&
+    processedResponse.computerActions.length > 0
+      ? await runWithSiblingCancellation(
+          [runFunctionTools, runComputerActions],
+          signal,
+        )
+      : await Promise.all([runFunctionTools(), runComputerActions()]);
   const shellAndApplyPatchResults =
     processedResponse.shellActions.length > 0 ||
     processedResponse.applyPatchActions.length > 0

--- a/packages/agents-core/src/tool.ts
+++ b/packages/agents-core/src/tool.ts
@@ -11,7 +11,11 @@ import {
 import { toFunctionToolName } from './utils/tools';
 import { getSchemaAndParserFromInputType } from './utils/tools';
 import { isZodObject } from './utils/typeGuards';
-import { combineAbortSignals, isAbortError } from './utils/abortSignals';
+import {
+  combineAbortSignals,
+  isAbortError,
+  isSiblingCancellationSignal,
+} from './utils/abortSignals';
 import { RunContext } from './runContext';
 import type { RunConfig } from './run';
 import type { RunResult } from './result';
@@ -2082,9 +2086,13 @@ async function invokeFunctionToolWithTimeout<
     timeoutMs,
   });
 
+  let invocationPromise: Promise<string | Result> | undefined;
   try {
-    return await Promise.race([
+    invocationPromise = Promise.resolve(
       invoke(runContext, input, invokeDetails),
+    );
+    return await Promise.race([
+      invocationPromise,
       new Promise<never>((_, reject) => {
         timeoutId = setTimeout(() => {
           timeoutTriggered = true;
@@ -2099,6 +2107,14 @@ async function invokeFunctionToolWithTimeout<
       (timeoutTriggered && timeoutController.signal.reason === timeoutError);
     if (!isTimeoutError) {
       throw error;
+    }
+
+    const siblingCancellationSignal = details?.signal;
+    if (
+      siblingCancellationSignal &&
+      isSiblingCancellationSignal(siblingCancellationSignal)
+    ) {
+      throw siblingCancellationSignal.reason;
     }
 
     if (timeoutBehavior === 'raise_exception') {
@@ -2375,7 +2391,8 @@ export function tool<
     return _invoke(runContext, input, details).catch(async (error) => {
       if (
         details?.signal?.aborted &&
-        (error === details.signal.reason ||
+        (isSiblingCancellationSignal(details.signal) ||
+          error === details.signal.reason ||
           isAbortError(error) ||
           details.signal.reason instanceof ToolTimeoutError)
       ) {

--- a/packages/agents-core/src/utils/abortSignals.ts
+++ b/packages/agents-core/src/utils/abortSignals.ts
@@ -7,6 +7,20 @@ type CombineAbortSignalsOptions = {
   onAbortSignalAnyError?: (error: unknown) => void;
 };
 
+class SiblingCancellationError extends Error {}
+
+export function createSiblingCancellationError(): Error {
+  return new SiblingCancellationError(
+    'Cancelled because a sibling task failed.',
+  );
+}
+
+export function isSiblingCancellationSignal(
+  signal: AbortSignal | undefined,
+): boolean {
+  return signal?.reason instanceof SiblingCancellationError;
+}
+
 export function isAbortError(error: unknown): boolean {
   if (!error) {
     return false;

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -18,6 +18,7 @@ import {
   MaxTurnsExceededError,
   ModelBehaviorError,
   ModelRefusalError,
+  ToolCallError,
   ModelResponse,
   OutputGuardrailTripwireTriggered,
   Session,
@@ -586,6 +587,332 @@ describe('Runner.run', () => {
           (item) => item.rawItem.type === 'computer_call_result',
         ),
       ).toHaveLength(1);
+    });
+
+    it('cancels and drains function work after a computer category failure', async () => {
+      const primaryError = new Error('computer category failed');
+      let markFunctionStarted: (() => void) | undefined;
+      const functionStarted = new Promise<void>((resolve) => {
+        markFunctionStarted = resolve;
+      });
+      let functionCancelled = false;
+      let functionDrained = false;
+      let lateSideEffect = false;
+
+      const abortableTool = tool({
+        name: 'abortable_tool',
+        description: 'waits for sibling category cancellation',
+        parameters: z.object({ test: z.string() }),
+        errorFunction: null,
+        execute: async (_input, _context, details) => {
+          markFunctionStarted?.();
+          if (!details?.signal) {
+            throw new Error('Expected an internal cancellation signal');
+          }
+          try {
+            await setTimeoutPromise(60_000, undefined, {
+              signal: details.signal,
+            });
+            lateSideEffect = true;
+            return 'unexpected tool output';
+          } catch (error) {
+            functionCancelled = true;
+            await Promise.resolve();
+            functionDrained = true;
+            throw error;
+          }
+        },
+      });
+      const computer = new FakeComputer();
+      const computerCall: protocol.ComputerUseCallItem = {
+        type: 'computer_call',
+        id: 'computer-call',
+        callId: 'computer-call',
+        status: 'completed',
+        action: { type: 'screenshot' },
+        providerData: {
+          pending_safety_checks: [
+            {
+              id: 'safety-check',
+              code: 'malicious_instructions',
+            },
+          ],
+        },
+      };
+      const model = new FakeModel([
+        {
+          output: [
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              id: 'abortable-call',
+              callId: 'abortable-call',
+              name: 'abortable_tool',
+            },
+            computerCall,
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'SiblingCategoryFailureAgent',
+        model,
+        tools: [
+          abortableTool,
+          computerTool({
+            computer,
+            onSafetyCheck: async () => {
+              await functionStarted;
+              throw primaryError;
+            },
+          }),
+        ],
+      });
+
+      const error = await run(agent, 'start').catch((caught) => caught);
+
+      expect(error).toBe(primaryError);
+      expect(functionCancelled).toBe(true);
+      expect(functionDrained).toBe(true);
+      expect(lateSideEffect).toBe(false);
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      expect(lateSideEffect).toBe(false);
+    });
+
+    it('drains function post-invocation work after a category failure', async () => {
+      const primaryError = new Error('computer category failed');
+      let markPostInvocationStarted: (() => void) | undefined;
+      const postInvocationStarted = new Promise<void>((resolve) => {
+        markPostInvocationStarted = resolve;
+      });
+      let releasePostInvocation: (() => void) | undefined;
+      const postInvocationCanFinish = new Promise<void>((resolve) => {
+        releasePostInvocation = resolve;
+      });
+      let postInvocationFinished = false;
+
+      const quickTool = tool({
+        name: 'quick_tool',
+        description: 'finishes before sibling category failure',
+        parameters: z.object({ test: z.string() }),
+        execute: async () => 'tool output',
+        customDataExtractor: async () => {
+          markPostInvocationStarted?.();
+          await postInvocationCanFinish;
+          postInvocationFinished = true;
+          return { lifecycle: 'complete' };
+        },
+      });
+      const computerCall: protocol.ComputerUseCallItem = {
+        type: 'computer_call',
+        id: 'computer-call',
+        callId: 'computer-call',
+        status: 'completed',
+        action: { type: 'screenshot' },
+        providerData: {
+          pending_safety_checks: [
+            {
+              id: 'safety-check',
+              code: 'malicious_instructions',
+            },
+          ],
+        },
+      };
+      const model = new FakeModel([
+        {
+          output: [
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              id: 'quick-call',
+              callId: 'quick-call',
+              name: 'quick_tool',
+            },
+            computerCall,
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'PostInvocationDrainAgent',
+        model,
+        tools: [
+          quickTool,
+          computerTool({
+            computer: new FakeComputer(),
+            onSafetyCheck: async () => {
+              await postInvocationStarted;
+              throw primaryError;
+            },
+          }),
+        ],
+      });
+
+      let runSettled = false;
+      const runOutcome = run(agent, 'start').then(
+        () => {
+          runSettled = true;
+          return undefined;
+        },
+        (error: unknown) => {
+          runSettled = true;
+          return error;
+        },
+      );
+      await postInvocationStarted;
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+      expect(runSettled).toBe(false);
+      releasePostInvocation?.();
+      const error = await runOutcome;
+      expect(error).toBe(primaryError);
+      expect(postInvocationFinished).toBe(true);
+    });
+
+    it('stops computer actions while failed function work drains', async () => {
+      const primaryError = new Error('function category failed');
+      let markSlowFunctionStarted: (() => void) | undefined;
+      const slowFunctionStarted = new Promise<void>((resolve) => {
+        markSlowFunctionStarted = resolve;
+      });
+      let markComputerPreparationStarted: (() => void) | undefined;
+      const computerPreparationStarted = new Promise<void>((resolve) => {
+        markComputerPreparationStarted = resolve;
+      });
+      let releaseComputerPreparation: (() => void) | undefined;
+      const computerPreparationCanFinish = new Promise<void>((resolve) => {
+        releaseComputerPreparation = resolve;
+      });
+      let markFunctionCleanupStarted: (() => void) | undefined;
+      const functionCleanupStarted = new Promise<void>((resolve) => {
+        markFunctionCleanupStarted = resolve;
+      });
+      let releaseFunctionCleanup: (() => void) | undefined;
+      const functionCleanupCanFinish = new Promise<void>((resolve) => {
+        releaseFunctionCleanup = resolve;
+      });
+      let functionCleanupFinished = false;
+
+      const failingTool = tool({
+        name: 'failing_tool',
+        description: 'fails after sibling categories start',
+        parameters: z.object({ test: z.string() }),
+        errorFunction: null,
+        execute: async () => {
+          await Promise.all([slowFunctionStarted, computerPreparationStarted]);
+          throw primaryError;
+        },
+      });
+      const slowTool = tool({
+        name: 'slow_tool',
+        description: 'blocks cleanup after cancellation',
+        parameters: z.object({ test: z.string() }),
+        errorFunction: null,
+        execute: async (_input, _context, details) => {
+          markSlowFunctionStarted?.();
+          if (!details?.signal) {
+            throw new Error('Expected an internal cancellation signal');
+          }
+          try {
+            await setTimeoutPromise(60_000, undefined, {
+              signal: details.signal,
+            });
+            return 'unexpected tool output';
+          } catch (error) {
+            markFunctionCleanupStarted?.();
+            await functionCleanupCanFinish;
+            functionCleanupFinished = true;
+            throw error;
+          }
+        },
+      });
+      const computer = new FakeComputer();
+      const screenshot = vi.fn(async () => 'img');
+      computer.screenshot = screenshot;
+      const firstComputerCall: protocol.ComputerUseCallItem = {
+        type: 'computer_call',
+        id: 'computer-call-1',
+        callId: 'computer-call-1',
+        status: 'completed',
+        action: { type: 'screenshot' },
+        providerData: {
+          pending_safety_checks: [
+            {
+              id: 'safety-check',
+              code: 'malicious_instructions',
+            },
+          ],
+        },
+      };
+      const secondComputerCall: protocol.ComputerUseCallItem = {
+        type: 'computer_call',
+        id: 'computer-call-2',
+        callId: 'computer-call-2',
+        status: 'completed',
+        action: { type: 'screenshot' },
+      };
+      const model = new FakeModel([
+        {
+          output: [
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              id: 'failing-call',
+              callId: 'failing-call',
+              name: 'failing_tool',
+            },
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              id: 'slow-call',
+              callId: 'slow-call',
+              name: 'slow_tool',
+            },
+            firstComputerCall,
+            secondComputerCall,
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'FunctionFailureStopsComputerAgent',
+        model,
+        tools: [
+          failingTool,
+          slowTool,
+          computerTool({
+            computer,
+            onSafetyCheck: async () => {
+              markComputerPreparationStarted?.();
+              await computerPreparationCanFinish;
+              return true;
+            },
+          }),
+        ],
+      });
+
+      let runSettled = false;
+      const runOutcome = run(agent, 'start').then(
+        () => {
+          runSettled = true;
+          return undefined;
+        },
+        (error: unknown) => {
+          runSettled = true;
+          return error;
+        },
+      );
+      await functionCleanupStarted;
+
+      releaseComputerPreparation?.();
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      expect(screenshot).not.toHaveBeenCalled();
+      expect(runSettled).toBe(false);
+
+      releaseFunctionCleanup?.();
+      const error = await runOutcome;
+      expect(error).toBeInstanceOf(ToolCallError);
+      expect((error as ToolCallError).error).toBe(primaryError);
+      expect(functionCleanupFinished).toBe(true);
+      expect(screenshot).not.toHaveBeenCalled();
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      expect(screenshot).not.toHaveBeenCalled();
     });
 
     it('reconciles later actions without starting them after cancellation', async () => {

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -18,7 +18,6 @@ import {
   MaxTurnsExceededError,
   ModelBehaviorError,
   ModelRefusalError,
-  ToolCallError,
   ModelResponse,
   OutputGuardrailTripwireTriggered,
   Session,
@@ -678,6 +677,119 @@ describe('Runner.run', () => {
       expect(lateSideEffect).toBe(false);
     });
 
+    it('reserves a batched computer approval failure while sibling callbacks drain', async () => {
+      const primaryError = new Error('computer approval failed');
+      let markFunctionStarted: (() => void) | undefined;
+      const functionStarted = new Promise<void>((resolve) => {
+        markFunctionStarted = resolve;
+      });
+      let markFunctionCancelled: (() => void) | undefined;
+      const functionCancelled = new Promise<void>((resolve) => {
+        markFunctionCancelled = resolve;
+      });
+      let startedApprovals = 0;
+      let markApprovalsStarted: (() => void) | undefined;
+      const approvalsStarted = new Promise<void>((resolve) => {
+        markApprovalsStarted = resolve;
+      });
+      let releaseBlockedApproval: (() => void) | undefined;
+      const blockedApprovalCanFinish = new Promise<void>((resolve) => {
+        releaseBlockedApproval = resolve;
+      });
+      let runSettled = false;
+      let sideEffectAfterRejection = false;
+
+      const abortableTool = tool({
+        name: 'abortable_tool',
+        description: 'waits for sibling category cancellation',
+        parameters: z.object({ test: z.string() }),
+        errorFunction: null,
+        execute: async (_input, _context, details) => {
+          markFunctionStarted?.();
+          if (!details?.signal) {
+            throw new Error('Expected an internal cancellation signal');
+          }
+          await new Promise<void>((resolve) => {
+            if (details.signal?.aborted) {
+              resolve();
+              return;
+            }
+            details.signal?.addEventListener('abort', () => resolve(), {
+              once: true,
+            });
+          });
+          markFunctionCancelled?.();
+          return 'cancelled';
+        },
+      });
+      const computer = new FakeComputer();
+      const screenshot = vi.fn(async () => 'img');
+      computer.screenshot = screenshot;
+      const needsApproval = vi.fn(
+        async (_context: RunContext, action: protocol.ComputerAction) => {
+          startedApprovals += 1;
+          if (startedApprovals === 2) {
+            markApprovalsStarted?.();
+          }
+          await approvalsStarted;
+          if (action.type === 'click') {
+            await functionStarted;
+            throw primaryError;
+          }
+          await blockedApprovalCanFinish;
+          sideEffectAfterRejection = runSettled;
+          return false;
+        },
+      );
+      const computerCall: protocol.ComputerUseCallItem = {
+        type: 'computer_call',
+        id: 'computer-call',
+        callId: 'computer-call',
+        status: 'completed',
+        actions: [
+          { type: 'click', x: 1, y: 2, button: 'left' },
+          { type: 'move', x: 3, y: 4 },
+        ],
+      };
+      const model = new FakeModel([
+        {
+          output: [
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              id: 'abortable-call',
+              callId: 'abortable-call',
+              name: 'abortable_tool',
+            },
+            computerCall,
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'BatchedComputerApprovalFailureAgent',
+        model,
+        tools: [abortableTool, computerTool({ computer, needsApproval })],
+      });
+
+      const runOutcome = run(agent, 'start')
+        .then(
+          () => undefined,
+          (error: unknown) => error,
+        )
+        .finally(() => {
+          runSettled = true;
+        });
+
+      await functionCancelled;
+      expect(runSettled).toBe(false);
+      releaseBlockedApproval?.();
+
+      expect(await runOutcome).toBe(primaryError);
+      expect(sideEffectAfterRejection).toBe(false);
+      expect(needsApproval).toHaveBeenCalledTimes(2);
+      expect(screenshot).not.toHaveBeenCalled();
+    });
+
     it('drains function post-invocation work after a category failure', async () => {
       const primaryError = new Error('computer category failed');
       let markPostInvocationStarted: (() => void) | undefined;
@@ -913,6 +1025,158 @@ describe('Runner.run', () => {
       expect(screenshot).not.toHaveBeenCalled();
       await new Promise<void>((resolve) => setTimeout(resolve, 0));
       expect(screenshot).not.toHaveBeenCalled();
+    });
+
+    it('finishes a rejected computer safety check as aborted after a function failure', async () => {
+      const primaryError = new Error('function category failed');
+      const secondaryError = new Error(
+        'safety check failed after cancellation',
+      );
+      let markSafetyCheckStarted: (() => void) | undefined;
+      const safetyCheckStarted = new Promise<void>((resolve) => {
+        markSafetyCheckStarted = resolve;
+      });
+      let releaseSafetyCheck: (() => void) | undefined;
+      const safetyCheckCanFinish = new Promise<void>((resolve) => {
+        releaseSafetyCheck = resolve;
+      });
+      let markSlowFunctionStarted: (() => void) | undefined;
+      const slowFunctionStarted = new Promise<void>((resolve) => {
+        markSlowFunctionStarted = resolve;
+      });
+      let markCancellationObserved: (() => void) | undefined;
+      const cancellationObserved = new Promise<void>((resolve) => {
+        markCancellationObserved = resolve;
+      });
+
+      const failingTool = tool({
+        name: 'failing_tool',
+        description: 'fails after the computer safety check starts',
+        parameters: z.object({ test: z.string() }),
+        errorFunction: null,
+        execute: async () => {
+          await Promise.all([safetyCheckStarted, slowFunctionStarted]);
+          throw primaryError;
+        },
+      });
+      const slowTool = tool({
+        name: 'slow_tool',
+        description: 'observes sibling cancellation',
+        parameters: z.object({ test: z.string() }),
+        execute: async (_input, _context, details) => {
+          markSlowFunctionStarted?.();
+          await new Promise<void>((resolve) => {
+            details?.signal?.addEventListener(
+              'abort',
+              () => {
+                markCancellationObserved?.();
+                resolve();
+              },
+              { once: true },
+            );
+          });
+          return 'cancelled';
+        },
+      });
+      const queuedParser = vi.fn(() => true);
+      const queuedToolExecute = vi.fn(async () => 'unexpected');
+      const queuedTool = tool({
+        name: 'queued_tool',
+        description: 'must remain unclaimed after the function failure',
+        parameters: z.object({ value: z.string().refine(queuedParser) }),
+        execute: queuedToolExecute,
+      });
+      const fakeComputer = new FakeComputer();
+      const screenshot = vi.fn(async () => 'img');
+      fakeComputer.screenshot = screenshot;
+      const computer = computerTool({
+        computer: fakeComputer,
+        onSafetyCheck: async () => {
+          markSafetyCheckStarted?.();
+          await safetyCheckCanFinish;
+          throw secondaryError;
+        },
+      });
+      const computerCall: protocol.ComputerUseCallItem = {
+        type: 'computer_call',
+        id: 'computer-call',
+        callId: 'computer-call',
+        status: 'completed',
+        action: { type: 'screenshot' },
+        providerData: {
+          pending_safety_checks: [
+            {
+              id: 'safety-check',
+              code: 'malicious_instructions',
+            },
+          ],
+        },
+      };
+      const model = new FakeModel([
+        {
+          output: [
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              id: 'failing-call',
+              callId: 'failing-call',
+              name: 'failing_tool',
+            },
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              id: 'slow-call',
+              callId: 'slow-call',
+              name: 'slow_tool',
+            },
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              id: 'queued-call',
+              callId: 'queued-call',
+              name: 'queued_tool',
+              arguments: JSON.stringify({ value: 'queued' }),
+            },
+            computerCall,
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'RejectedSafetyCheckCancellationAgent',
+        model,
+        tools: [failingTool, slowTool, queuedTool, computer],
+      });
+      const runner = new Runner({
+        toolExecution: { maxFunctionToolConcurrency: 2 },
+      });
+      const end = vi.fn();
+      runner.on('agent_tool_end', end);
+
+      let settled = false;
+      const runOutcome = runner.run(agent, 'start').then(
+        () => {
+          settled = true;
+          return undefined;
+        },
+        (error: unknown) => {
+          settled = true;
+          return error;
+        },
+      );
+      await cancellationObserved;
+
+      expect(settled).toBe(false);
+      releaseSafetyCheck?.();
+
+      const error = await runOutcome;
+      const computerEndCalls = end.mock.calls.filter(
+        ([, , endedTool]) => endedTool === computer,
+      );
+      expect(error).toBeInstanceOf(ToolCallError);
+      expect((error as ToolCallError).error).toBe(primaryError);
+      expect(screenshot).not.toHaveBeenCalled();
+      expect(queuedParser).not.toHaveBeenCalled();
+      expect(queuedToolExecute).not.toHaveBeenCalled();
+      expect(computerEndCalls).toHaveLength(1);
+      expect(computerEndCalls[0]?.[3]).toBe('aborted');
     });
 
     it('reconciles later actions without starting them after cancellation', async () => {

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -4403,6 +4403,98 @@ describe('executeShellActions', () => {
       expect(lateSideEffect).toBe(false);
     });
 
+    it('skips post-invocation work when an uncapped sibling ignores cancellation', async () => {
+      const primaryError = new Error('primary tool failure');
+      let markSlowToolStarted: (() => void) | undefined;
+      const slowToolStarted = new Promise<void>((resolve) => {
+        markSlowToolStarted = resolve;
+      });
+      let markCancellationObserved: (() => void) | undefined;
+      const cancellationObserved = new Promise<void>((resolve) => {
+        markCancellationObserved = resolve;
+      });
+      let releaseSlowTool: (() => void) | undefined;
+      const slowToolCanFinish = new Promise<void>((resolve) => {
+        releaseSlowTool = resolve;
+      });
+      const outputGuardrail = defineToolOutputGuardrail({
+        name: 'should_not_run',
+        run: vi.fn(async () => ToolGuardrailFunctionOutputFactory.allow()),
+      });
+      const customDataExtractor = vi.fn(() => ({ shouldNotRun: true }));
+      const failingTool = tool({
+        name: 'failing_tool',
+        description: 'fails after its sibling starts',
+        parameters: z.object({}),
+        errorFunction: null,
+        execute: async () => {
+          await slowToolStarted;
+          throw primaryError;
+        },
+      }) as unknown as FunctionTool;
+      const slowTool = tool({
+        name: 'slow_tool',
+        description: 'ignores cancellation and resolves later',
+        parameters: z.object({}),
+        outputGuardrails: [outputGuardrail],
+        customDataExtractor,
+        execute: async (_input, _context, details) => {
+          markSlowToolStarted?.();
+          details?.signal?.addEventListener(
+            'abort',
+            () => markCancellationObserved?.(),
+            { once: true },
+          );
+          await slowToolCanFinish;
+          return 'late tool output';
+        },
+      }) as unknown as FunctionTool;
+      const end = vi.fn();
+      runner.on('agent_tool_end', end);
+
+      let settled = false;
+      const resultPromise = executeFunctionToolCalls(
+        state._currentAgent,
+        [
+          {
+            toolCall: {
+              ...toolCall,
+              callId: 'failing-call',
+              name: 'failing_tool',
+            },
+            tool: failingTool,
+          },
+          {
+            toolCall: {
+              ...toolCall,
+              callId: 'slow-call',
+              name: 'slow_tool',
+            },
+            tool: slowTool,
+          },
+        ],
+        runner,
+        state,
+      ).finally(() => {
+        settled = true;
+      });
+      await cancellationObserved;
+
+      expect(settled).toBe(false);
+      releaseSlowTool?.();
+
+      const error = await resultPromise.catch((caught) => caught);
+      const slowToolEndCalls = end.mock.calls.filter(
+        ([, , endedTool]) => endedTool === slowTool,
+      );
+      expect(error).toBeInstanceOf(ToolCallError);
+      expect((error as ToolCallError).error).toBe(primaryError);
+      expect(outputGuardrail.run).not.toHaveBeenCalled();
+      expect(customDataExtractor).not.toHaveBeenCalled();
+      expect(slowToolEndCalls).toHaveLength(1);
+      expect(slowToolEndCalls[0]?.[3]).not.toBe('late tool output');
+    });
+
     it('reserves abort-shaped nested failure ownership while cleanup drains', async () => {
       const primaryError = new Error('primary function failure');
       primaryError.name = 'AbortError';

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -1012,6 +1012,220 @@ describe('executeComputerActions', () => {
     });
   });
 
+  it.each(['fulfills', 'rejects'] as const)(
+    'reconciles computer approval that %s after sibling cancellation',
+    async (settlement) => {
+      const primaryError = new Error('sibling category failed');
+      const approvalError = new Error('approval failed after cancellation');
+      let markApprovalStarted: (() => void) | undefined;
+      const approvalStarted = new Promise<void>((resolve) => {
+        markApprovalStarted = resolve;
+      });
+      let releaseApproval: (() => void) | undefined;
+      const approvalCanFinish = new Promise<void>((resolve) => {
+        releaseApproval = resolve;
+      });
+      let markFatalFailure: (() => void) | undefined;
+      const fatalFailure = new Promise<void>((resolve) => {
+        markFatalFailure = resolve;
+      });
+      const fakeComputer = {
+        environment: 'mac',
+        dimensions: [1, 1] as [number, number],
+        screenshot: vi.fn().mockResolvedValue('img'),
+      } as any;
+      const needsApproval = vi.fn(async () => {
+        markApprovalStarted?.();
+        await approvalCanFinish;
+        if (settlement === 'rejects') {
+          throw approvalError;
+        }
+        return true;
+      });
+      const computer = computerTool({ computer: fakeComputer, needsApproval });
+      const call: protocol.ComputerUseCallItem = {
+        type: 'computer_call',
+        callId: 'cancelled-computer-approval',
+        status: 'completed',
+        action: { type: 'screenshot' } as any,
+      };
+      const runner = new Runner();
+      const agent = new Agent({ name: 'CancelledComputerApproval' });
+      const start = vi.fn();
+      const end = vi.fn();
+      const formatter = vi.fn(() => 'should not format cancellation');
+      runner.on('agent_tool_start', start);
+      runner.on('agent_tool_end', end);
+      let computerItems: Awaited<
+        ReturnType<typeof executeComputerActions>
+      > | null = null;
+
+      let settled = false;
+      const resultPromise = runWithSiblingCancellation([
+        async (signal) => {
+          computerItems = await executeComputerActions(
+            agent,
+            [{ toolCall: call, computer }],
+            runner,
+            new RunContext(),
+            undefined,
+            formatter,
+            signal,
+          );
+        },
+        async (_signal, reserveFailure) => {
+          await approvalStarted;
+          reserveFailure?.();
+          markFatalFailure?.();
+          throw primaryError;
+        },
+      ]).finally(() => {
+        settled = true;
+      });
+      await fatalFailure;
+
+      expect(settled).toBe(false);
+      releaseApproval?.();
+
+      await expect(resultPromise).rejects.toBe(primaryError);
+      expect(needsApproval).toHaveBeenCalledTimes(1);
+      expect(formatter).not.toHaveBeenCalled();
+      expect(fakeComputer.screenshot).not.toHaveBeenCalled();
+      expect(start).not.toHaveBeenCalled();
+      expect(end).not.toHaveBeenCalled();
+      expect(computerItems).toHaveLength(1);
+      expect(computerItems?.[0]).toMatchObject({
+        rawItem: {
+          type: 'computer_call_result',
+          callId: call.callId,
+          providerData: { status: 'incomplete' },
+        },
+      });
+    },
+  );
+
+  it('does not format a rejected computer approval after sibling cancellation', async () => {
+    const primaryError = new Error('sibling category failed');
+    const fakeComputer = {
+      environment: 'mac',
+      dimensions: [1, 1] as [number, number],
+      screenshot: vi.fn().mockResolvedValue('img'),
+    } as any;
+    const computer = computerTool({ computer: fakeComputer });
+    const call: protocol.ComputerUseCallItem = {
+      type: 'computer_call',
+      callId: 'rejected-computer-approval',
+      status: 'completed',
+      action: { type: 'screenshot' } as any,
+    };
+    const agent = new Agent({ name: 'RejectedComputerApproval' });
+    const runContext = new RunContext();
+    runContext.rejectTool(new ToolApprovalItem(call, agent, computer.name));
+    const formatter = vi.fn(() => 'should not format cancellation');
+    let computerItems: Awaited<
+      ReturnType<typeof executeComputerActions>
+    > | null = null;
+
+    const resultPromise = runWithSiblingCancellation([
+      async (signal) => {
+        computerItems = await executeComputerActions(
+          agent,
+          [{ toolCall: call, computer }],
+          new Runner(),
+          runContext,
+          undefined,
+          formatter,
+          signal,
+        );
+      },
+      async (_signal, reserveFailure) => {
+        reserveFailure?.();
+        throw primaryError;
+      },
+    ]);
+
+    await expect(resultPromise).rejects.toBe(primaryError);
+    expect(formatter).not.toHaveBeenCalled();
+    expect(fakeComputer.screenshot).not.toHaveBeenCalled();
+    expect(computerItems).toHaveLength(1);
+    expect(computerItems?.[0]).toMatchObject({
+      rawItem: {
+        type: 'computer_call_result',
+        callId: call.callId,
+        providerData: { status: 'incomplete' },
+      },
+    });
+  });
+
+  it('drains started batched computer approval callbacks before rejecting', async () => {
+    const primaryError = new Error('computer approval failed');
+    let startedApprovals = 0;
+    let markApprovalsStarted: (() => void) | undefined;
+    const approvalsStarted = new Promise<void>((resolve) => {
+      markApprovalsStarted = resolve;
+    });
+    let markApprovalRejected: (() => void) | undefined;
+    const approvalRejected = new Promise<void>((resolve) => {
+      markApprovalRejected = resolve;
+    });
+    let releaseBlockedApproval: (() => void) | undefined;
+    const blockedApprovalCanFinish = new Promise<void>((resolve) => {
+      releaseBlockedApproval = resolve;
+    });
+    let settled = false;
+    let sideEffectAfterRejection = false;
+    const needsApproval = vi.fn(
+      async (_runContext: RunContext, action: protocol.ComputerAction) => {
+        startedApprovals += 1;
+        if (startedApprovals === 2) {
+          markApprovalsStarted?.();
+        }
+        await approvalsStarted;
+        if (action.type === 'click') {
+          markApprovalRejected?.();
+          throw primaryError;
+        }
+        await blockedApprovalCanFinish;
+        sideEffectAfterRejection = settled;
+        return false;
+      },
+    );
+    const fakeComputer = {
+      environment: 'mac',
+      dimensions: [1, 1] as [number, number],
+      screenshot: vi.fn().mockResolvedValue('img'),
+    } as any;
+    const computer = computerTool({ computer: fakeComputer, needsApproval });
+    const call: protocol.ComputerUseCallItem = {
+      type: 'computer_call',
+      callId: 'batched-computer-approval',
+      status: 'completed',
+      actions: [
+        { type: 'click', x: 1, y: 2, button: 'left' },
+        { type: 'move', x: 3, y: 4 },
+      ],
+    };
+
+    const resultPromise = executeComputerActions(
+      new Agent({ name: 'BatchedComputerApproval' }),
+      [{ toolCall: call, computer }],
+      new Runner(),
+      new RunContext(),
+    ).finally(() => {
+      settled = true;
+    });
+    await approvalRejected;
+    await Promise.resolve();
+
+    expect(settled).toBe(false);
+    releaseBlockedApproval?.();
+
+    await expect(resultPromise).rejects.toBe(primaryError);
+    expect(needsApproval).toHaveBeenCalledTimes(2);
+    expect(sideEffectAfterRejection).toBe(false);
+    expect(fakeComputer.screenshot).not.toHaveBeenCalled();
+  });
+
   it('does not emit a success end event when computer customDataExtractor fails', async () => {
     const fakeComputer = {
       environment: 'mac',
@@ -1051,6 +1265,85 @@ describe('executeComputerActions', () => {
 
     expect(end).not.toHaveBeenCalled();
   });
+
+  it.each(['fulfills', 'rejects'] as const)(
+    'reports cancellation when computer custom data extraction %s as aborted',
+    async (settlement) => {
+      const primaryError = new Error('primary category failure');
+      const customDataError = new Error(
+        'custom data failed after cancellation',
+      );
+      let markCustomDataStarted: (() => void) | undefined;
+      const customDataStarted = new Promise<void>((resolve) => {
+        markCustomDataStarted = resolve;
+      });
+      let releaseCustomData: (() => void) | undefined;
+      const customDataCanFinish = new Promise<void>((resolve) => {
+        releaseCustomData = resolve;
+      });
+      let customDataFinished = false;
+      const fakeComputer = {
+        environment: 'mac',
+        dimensions: [1, 1] as [number, number],
+        screenshot: vi.fn().mockResolvedValue('img'),
+      } as any;
+      const computer = computerTool({
+        computer: fakeComputer,
+        customDataExtractor: async () => {
+          markCustomDataStarted?.();
+          await customDataCanFinish;
+          customDataFinished = true;
+          if (settlement === 'rejects') {
+            throw customDataError;
+          }
+          return { extracted: true };
+        },
+      });
+      const call: protocol.ComputerUseCallItem = {
+        type: 'computer_call',
+        callId: `computer-custom-data-${settlement}`,
+        status: 'completed',
+        action: { type: 'screenshot' },
+      };
+      const runner = new Runner();
+      const end = vi.fn();
+      runner.on('agent_tool_end', end);
+
+      let settled = false;
+      const resultPromise = runWithSiblingCancellation([
+        (signal) =>
+          executeComputerActions(
+            new Agent({ name: 'ComputerCustomDataCancellation' }),
+            [{ toolCall: call, computer }],
+            runner,
+            new RunContext(),
+            undefined,
+            undefined,
+            signal,
+          ),
+        async (_signal, reserveFailure) => {
+          await customDataStarted;
+          reserveFailure?.(primaryError);
+          throw primaryError;
+        },
+      ]).finally(() => {
+        settled = true;
+      });
+      await customDataStarted;
+      await Promise.resolve();
+
+      expect(settled).toBe(false);
+      releaseCustomData?.();
+
+      await expect(resultPromise).rejects.toBe(primaryError);
+      const computerEndCalls = end.mock.calls.filter(
+        ([, , endedTool]) => endedTool === computer,
+      );
+      expect(customDataFinished).toBe(true);
+      expect(computerEndCalls).toHaveLength(1);
+      expect(computerEndCalls[0]?.[3]).toBe('aborted');
+    },
+  );
 
   it('passes a cloned computer tool call to customDataExtractor', async () => {
     const fakeComputer = {
@@ -1465,6 +1758,68 @@ describe('executeComputerActions', () => {
       });
     },
   );
+
+  it('rechecks cancellation after the final screenshot helper returns', async () => {
+    const controller = new AbortController();
+    const fakeComputer = {
+      environment: 'mac',
+      dimensions: [1, 1] as [number, number],
+      screenshot: vi.fn(async () => {
+        queueMicrotask(() => {
+          queueMicrotask(() => {
+            controller.abort(new Error('stop after screenshot helper'));
+          });
+        });
+        return 'img';
+      }),
+      click: vi.fn(),
+      doubleClick: vi.fn(),
+      drag: vi.fn(),
+      keypress: vi.fn(),
+      move: vi.fn(),
+      scroll: vi.fn(),
+      type: vi.fn(),
+      wait: vi.fn(),
+    } as any;
+    const customDataExtractor = vi.fn(() => ({ shouldNotRun: true }));
+    const computer = computerTool({
+      computer: fakeComputer,
+      customDataExtractor,
+    });
+    const call: protocol.ComputerUseCallItem = {
+      type: 'computer_call',
+      callId: 'cancelled-after-screenshot-helper',
+      status: 'completed',
+      action: { type: 'screenshot' },
+    };
+    const runner = new Runner();
+    const agent = new Agent({ name: 'Comp' });
+    const runContext = new RunContext();
+    const endHookError = new Error('computer end hook failed');
+    const end = vi.fn(() => {
+      throw endHookError;
+    });
+    runner.on('agent_tool_end', end);
+
+    await expect(
+      executeComputerActions(
+        agent,
+        [{ toolCall: call, computer }],
+        runner,
+        runContext,
+        undefined,
+        undefined,
+        controller.signal,
+      ),
+    ).rejects.toBe(endHookError);
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(customDataExtractor).not.toHaveBeenCalled();
+    expect(end).toHaveBeenCalledTimes(1);
+    expect(end).toHaveBeenCalledWith(runContext, agent, computer, 'aborted', {
+      toolCall: call,
+    });
+  });
 
   it.each(['fulfills', 'rejects'] as const)(
     'treats cancellation when the final screenshot %s as incomplete',
@@ -3752,6 +4107,222 @@ describe('executeShellActions', () => {
       );
     });
 
+    it.each(['formatter', 'fallback', 'fallback-rejection'] as const)(
+      'skips approval rejection processing when cancellation arrives during %s',
+      async (phase) => {
+        const primaryError = new Error('primary tool failure');
+        const fallbackError = new Error('secondary rejection fallback failure');
+        let markPhaseStarted: (() => void) | undefined;
+        const phaseStarted = new Promise<void>((resolve) => {
+          markPhaseStarted = resolve;
+        });
+        let releasePhase: (() => void) | undefined;
+        const phaseCanFinish = new Promise<void>((resolve) => {
+          releasePhase = resolve;
+        });
+        let markFatalFailure: (() => void) | undefined;
+        const fatalFailure = new Promise<void>((resolve) => {
+          markFatalFailure = resolve;
+        });
+        const errorFunction = vi.fn(async () => {
+          if (phase !== 'formatter') {
+            markPhaseStarted?.();
+            await phaseCanFinish;
+          }
+          if (phase === 'fallback-rejection') {
+            throw fallbackError;
+          }
+          return { status: 'rejected' as const };
+        });
+        const rejectedToolExecute = vi.fn(async () => ({
+          status: 'rejected' as const,
+        }));
+        const rejectedTool = tool({
+          name: 'rejected_tool',
+          description: 'waits while processing an approval rejection',
+          parameters: z.object({}),
+          outputSchema: z.object({ status: z.literal('rejected') }),
+          needsApproval: true,
+          errorFunction,
+          execute: rejectedToolExecute,
+        }) as unknown as FunctionTool;
+        const failingTool = tool({
+          name: 'failing_tool',
+          description: 'fails while its sibling processes a rejection',
+          parameters: z.object({}),
+          errorFunction: null,
+          execute: async () => {
+            await phaseStarted;
+            throw primaryError;
+          },
+        }) as unknown as FunctionTool;
+        const toolErrorFormatter = vi.fn(async () => {
+          if (phase === 'formatter') {
+            markPhaseStarted?.();
+            await phaseCanFinish;
+          }
+          return 'formatted rejection';
+        });
+        const customRunner = new Runner({
+          tracingDisabled: false,
+          toolErrorFormatter,
+        });
+        vi.spyOn(state._context, 'isToolApproved').mockImplementation(
+          ({ callId }) =>
+            (callId === 'rejected-call' ? false : undefined) as any,
+        );
+
+        let rejectedToolSpan: Span<any> | undefined;
+        let settled = false;
+        const resultPromise = withRecordingTrace(async (processor) => {
+          const error = await withTrace('test', () =>
+            executeFunctionToolCalls(
+              state._currentAgent,
+              [
+                {
+                  toolCall: {
+                    ...toolCall,
+                    callId: 'rejected-call',
+                    name: 'rejected_tool',
+                  },
+                  tool: rejectedTool,
+                },
+                {
+                  toolCall: {
+                    ...toolCall,
+                    callId: 'failing-call',
+                    name: 'failing_tool',
+                  },
+                  tool: failingTool,
+                },
+              ],
+              customRunner,
+              state,
+              customRunner.config.toolErrorFormatter,
+              undefined,
+              undefined,
+              () => markFatalFailure?.(),
+            ),
+          ).catch((caught) => caught);
+          rejectedToolSpan = getEndedFunctionSpan(processor, 'rejected_tool');
+          return error;
+        }).finally(() => {
+          settled = true;
+        });
+        await fatalFailure;
+
+        expect(settled).toBe(false);
+        releasePhase?.();
+
+        const error = await resultPromise;
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect((error as ToolCallError).error).toBe(primaryError);
+        expect(toolErrorFormatter).toHaveBeenCalledTimes(1);
+        expect(errorFunction).toHaveBeenCalledTimes(
+          phase === 'formatter' ? 0 : 1,
+        );
+        expect(rejectedToolExecute).not.toHaveBeenCalled();
+        expect(rejectedToolSpan?.error).toBeNull();
+        expect(rejectedToolSpan?.spanData.output).toBe('');
+      },
+    );
+
+    it.each(['formatter', 'fallback', 'fallback-rejection'] as const)(
+      'preserves approval rejection processing when parent cancellation arrives during %s',
+      async (phase) => {
+        const parentCancellation = new Error('parent cancellation');
+        const fallbackError = new Error('rejection fallback failure');
+        let markPhaseStarted: (() => void) | undefined;
+        const phaseStarted = new Promise<void>((resolve) => {
+          markPhaseStarted = resolve;
+        });
+        let releasePhase: (() => void) | undefined;
+        const phaseCanFinish = new Promise<void>((resolve) => {
+          releasePhase = resolve;
+        });
+        const errorFunction = vi.fn(async () => {
+          if (phase !== 'formatter') {
+            markPhaseStarted?.();
+            await phaseCanFinish;
+          }
+          if (phase === 'fallback-rejection') {
+            throw fallbackError;
+          }
+          return { status: 'rejected' as const };
+        });
+        const rejectedToolExecute = vi.fn(async () => ({
+          status: 'rejected' as const,
+        }));
+        const rejectedTool = tool({
+          name: 'rejected_tool',
+          description: 'waits while processing an approval rejection',
+          parameters: z.object({}),
+          outputSchema: z.object({ status: z.literal('rejected') }),
+          needsApproval: true,
+          errorFunction,
+          execute: rejectedToolExecute,
+        }) as unknown as FunctionTool;
+        const toolErrorFormatter = vi.fn(async () => {
+          if (phase === 'formatter') {
+            markPhaseStarted?.();
+            await phaseCanFinish;
+          }
+          return 'formatted rejection';
+        });
+        const customRunner = new Runner({
+          tracingDisabled: false,
+          toolErrorFormatter,
+        });
+        const controller = new AbortController();
+        vi.spyOn(state._context, 'isToolApproved').mockReturnValue(
+          false as any,
+        );
+
+        let rejectedToolSpan: Span<any> | undefined;
+        let settled = false;
+        const resultPromise = withRecordingTrace(async (processor) => {
+          const result = await withTrace('test', () =>
+            executeFunctionToolCalls(
+              state._currentAgent,
+              [{ toolCall, tool: rejectedTool }],
+              customRunner,
+              state,
+              customRunner.config.toolErrorFormatter,
+              undefined,
+              controller.signal,
+            ),
+          ).catch((caught) => caught);
+          rejectedToolSpan = getEndedFunctionSpan(processor, 'rejected_tool');
+          return result;
+        }).finally(() => {
+          settled = true;
+        });
+        await phaseStarted;
+
+        controller.abort(parentCancellation);
+        expect(settled).toBe(false);
+        releasePhase?.();
+
+        const result = await resultPromise;
+        if (phase === 'fallback-rejection') {
+          expect(result).toBeInstanceOf(ToolCallError);
+          expect((result as ToolCallError).error).toBe(fallbackError);
+          expect(rejectedToolSpan?.spanData.output).toBe('');
+        } else {
+          expect(result).toMatchObject([
+            {
+              type: 'function_output',
+              output: { status: 'rejected' },
+            },
+          ]);
+        }
+        expect(toolErrorFormatter).toHaveBeenCalledTimes(1);
+        expect(errorFunction).toHaveBeenCalledTimes(1);
+        expect(rejectedToolExecute).not.toHaveBeenCalled();
+        expect(rejectedToolSpan?.error?.message).toBe('formatted rejection');
+      },
+    );
+
     it('uses toolErrorFormatter message when approval is false', async () => {
       const t = makeTool(true);
       vi.spyOn(state._context, 'isToolApproved').mockReturnValue(false as any);
@@ -4403,50 +4974,530 @@ describe('executeShellActions', () => {
       expect(lateSideEffect).toBe(false);
     });
 
-    it('skips post-invocation work when an uncapped sibling ignores cancellation', async () => {
+    it('skips approved tool setup when a sibling fails during async approval', async () => {
       const primaryError = new Error('primary tool failure');
-      let markSlowToolStarted: (() => void) | undefined;
-      const slowToolStarted = new Promise<void>((resolve) => {
-        markSlowToolStarted = resolve;
+      let markApprovalStarted: (() => void) | undefined;
+      const approvalStarted = new Promise<void>((resolve) => {
+        markApprovalStarted = resolve;
       });
-      let markCancellationObserved: (() => void) | undefined;
-      const cancellationObserved = new Promise<void>((resolve) => {
-        markCancellationObserved = resolve;
+      let releaseApproval: (() => void) | undefined;
+      const approvalCanFinish = new Promise<void>((resolve) => {
+        releaseApproval = resolve;
       });
-      let releaseSlowTool: (() => void) | undefined;
-      const slowToolCanFinish = new Promise<void>((resolve) => {
-        releaseSlowTool = resolve;
+      let markFatalFailure: (() => void) | undefined;
+      const fatalFailure = new Promise<void>((resolve) => {
+        markFatalFailure = resolve;
       });
-      const outputGuardrail = defineToolOutputGuardrail({
+      const inputGuardrail = defineToolInputGuardrail({
         name: 'should_not_run',
         run: vi.fn(async () => ToolGuardrailFunctionOutputFactory.allow()),
       });
-      const customDataExtractor = vi.fn(() => ({ shouldNotRun: true }));
+      const approvedToolExecute = vi.fn(async () => 'unexpected');
+      const approvalTool = tool({
+        name: 'approval_tool',
+        description: 'waits for an async approval decision',
+        parameters: z.object({}),
+        needsApproval: async () => {
+          markApprovalStarted?.();
+          await approvalCanFinish;
+          return true;
+        },
+        inputGuardrails: [inputGuardrail],
+        execute: approvedToolExecute,
+      }) as unknown as FunctionTool;
+      runner = new Runner({
+        tracingDisabled: true,
+        toolExecution: { preApprovalInputGuardrails: true },
+      });
       const failingTool = tool({
         name: 'failing_tool',
-        description: 'fails after its sibling starts',
+        description: 'fails while its sibling awaits approval',
         parameters: z.object({}),
         errorFunction: null,
         execute: async () => {
-          await slowToolStarted;
+          await approvalStarted;
           throw primaryError;
         },
       }) as unknown as FunctionTool;
-      const slowTool = tool({
-        name: 'slow_tool',
-        description: 'ignores cancellation and resolves later',
+
+      let settled = false;
+      const resultPromise = executeFunctionToolCalls(
+        state._currentAgent,
+        [
+          {
+            toolCall: {
+              ...toolCall,
+              callId: 'approval-call',
+              name: 'approval_tool',
+            },
+            tool: approvalTool,
+          },
+          {
+            toolCall: {
+              ...toolCall,
+              callId: 'failing-call',
+              name: 'failing_tool',
+            },
+            tool: failingTool,
+          },
+        ],
+        runner,
+        state,
+        undefined,
+        undefined,
+        undefined,
+        () => markFatalFailure?.(),
+      ).finally(() => {
+        settled = true;
+      });
+      await fatalFailure;
+
+      expect(settled).toBe(false);
+      releaseApproval?.();
+
+      const error = await resultPromise.catch((caught) => caught);
+      expect(error).toBeInstanceOf(ToolCallError);
+      expect((error as ToolCallError).error).toBe(primaryError);
+      expect(inputGuardrail.run).not.toHaveBeenCalled();
+      expect(approvedToolExecute).not.toHaveBeenCalled();
+      expect(state._toolInputGuardrailResults).toHaveLength(0);
+    });
+
+    it('skips pre-approval rejection fallback after sibling cancellation', async () => {
+      const primaryError = new Error('primary tool failure');
+      let markGuardrailStarted: (() => void) | undefined;
+      const guardrailStarted = new Promise<void>((resolve) => {
+        markGuardrailStarted = resolve;
+      });
+      let releaseGuardrail: (() => void) | undefined;
+      const guardrailCanFinish = new Promise<void>((resolve) => {
+        releaseGuardrail = resolve;
+      });
+      let markFatalFailure: (() => void) | undefined;
+      const fatalFailure = new Promise<void>((resolve) => {
+        markFatalFailure = resolve;
+      });
+      const inputGuardrail = defineToolInputGuardrail({
+        name: 'blocking_pre_approval_guardrail',
+        run: vi.fn(async () => {
+          markGuardrailStarted?.();
+          await guardrailCanFinish;
+          return ToolGuardrailFunctionOutputFactory.rejectContent('blocked');
+        }),
+      });
+      const errorFunction = vi.fn(() => ({ status: 'blocked' as const }));
+      const guardedToolExecute = vi.fn(async () => ({
+        status: 'blocked' as const,
+      }));
+      const guardedTool = tool({
+        name: 'guarded_tool',
+        description: 'waits in a pre-approval guardrail',
         parameters: z.object({}),
+        outputSchema: z.object({ status: z.literal('blocked') }),
+        needsApproval: true,
+        inputGuardrails: [inputGuardrail],
+        errorFunction,
+        execute: guardedToolExecute,
+      }) as unknown as FunctionTool;
+      const failingTool = tool({
+        name: 'failing_tool',
+        description: 'fails while its sibling guardrail remains active',
+        parameters: z.object({}),
+        errorFunction: null,
+        execute: async () => {
+          await guardrailStarted;
+          throw primaryError;
+        },
+      }) as unknown as FunctionTool;
+      runner = new Runner({
+        tracingDisabled: true,
+        toolExecution: { preApprovalInputGuardrails: true },
+      });
+
+      let settled = false;
+      const resultPromise = executeFunctionToolCalls(
+        state._currentAgent,
+        [
+          {
+            toolCall: {
+              ...toolCall,
+              callId: 'guarded-call',
+              name: 'guarded_tool',
+            },
+            tool: guardedTool,
+          },
+          {
+            toolCall: {
+              ...toolCall,
+              callId: 'failing-call',
+              name: 'failing_tool',
+            },
+            tool: failingTool,
+          },
+        ],
+        runner,
+        state,
+        undefined,
+        undefined,
+        undefined,
+        () => markFatalFailure?.(),
+      ).finally(() => {
+        settled = true;
+      });
+      await fatalFailure;
+
+      expect(settled).toBe(false);
+      releaseGuardrail?.();
+
+      const error = await resultPromise.catch((caught) => caught);
+      expect(error).toBeInstanceOf(ToolCallError);
+      expect((error as ToolCallError).error).toBe(primaryError);
+      expect(inputGuardrail.run).toHaveBeenCalledTimes(1);
+      expect(state._toolInputGuardrailResults).toHaveLength(1);
+      expect(errorFunction).not.toHaveBeenCalled();
+      expect(guardedToolExecute).not.toHaveBeenCalled();
+    });
+
+    it('does not wait past timeout for a cancelled sibling invocation', async () => {
+      vi.useFakeTimers();
+      try {
+        const primaryError = new Error('primary tool failure');
+        let markTimedToolStarted: (() => void) | undefined;
+        const timedToolStarted = new Promise<void>((resolve) => {
+          markTimedToolStarted = resolve;
+        });
+        let releaseTimedTool: (() => void) | undefined;
+        const timedToolCanFinish = new Promise<void>((resolve) => {
+          releaseTimedTool = resolve;
+        });
+        let markFatalFailure: (() => void) | undefined;
+        const fatalFailure = new Promise<void>((resolve) => {
+          markFatalFailure = resolve;
+        });
+        let runRejected = false;
+        let sideEffectAfterRejection = false;
+        let markTimedToolFinished: (() => void) | undefined;
+        const timedToolFinished = new Promise<void>((resolve) => {
+          markTimedToolFinished = resolve;
+        });
+        const timedTool = tool({
+          name: 'timed_tool',
+          description: 'ignores sibling cancellation until after its timeout',
+          parameters: z.object({}),
+          timeoutMs: 1_000,
+          execute: async () => {
+            markTimedToolStarted?.();
+            await timedToolCanFinish;
+            sideEffectAfterRejection = runRejected;
+            markTimedToolFinished?.();
+            return 'late tool output';
+          },
+        }) as unknown as FunctionTool;
+        const failingTool = tool({
+          name: 'failing_tool',
+          description: 'fails while its timed sibling remains active',
+          parameters: z.object({}),
+          errorFunction: null,
+          execute: async () => {
+            await timedToolStarted;
+            throw primaryError;
+          },
+        }) as unknown as FunctionTool;
+
+        const resultPromise = executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                callId: 'timed-call',
+                name: 'timed_tool',
+              },
+              tool: timedTool,
+            },
+            {
+              toolCall: {
+                ...toolCall,
+                callId: 'failing-call',
+                name: 'failing_tool',
+              },
+              tool: failingTool,
+            },
+          ],
+          runner,
+          state,
+          undefined,
+          undefined,
+          undefined,
+          () => markFatalFailure?.(),
+        ).catch((caught) => {
+          runRejected = true;
+          return caught;
+        });
+        await fatalFailure;
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        const error = await resultPromise;
+        expect(runRejected).toBe(true);
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect((error as ToolCallError).error).toBe(primaryError);
+        expect(sideEffectAfterRejection).toBe(false);
+
+        releaseTimedTool?.();
+        await timedToolFinished;
+        expect(sideEffectAfterRejection).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not drain the timed-out owner before raising its failure', async () => {
+      vi.useFakeTimers();
+      let releaseTimedTool: (() => void) | undefined;
+      let resultPromise: Promise<unknown> | undefined;
+      try {
+        let markTimedToolStarted: (() => void) | undefined;
+        const timedToolStarted = new Promise<void>((resolve) => {
+          markTimedToolStarted = resolve;
+        });
+        const timedToolCanFinish = new Promise<void>((resolve) => {
+          releaseTimedTool = resolve;
+        });
+        let markSiblingStarted: (() => void) | undefined;
+        const siblingStarted = new Promise<void>((resolve) => {
+          markSiblingStarted = resolve;
+        });
+        const timedTool = tool({
+          name: 'timed_tool',
+          description: 'owns the first fatal timeout',
+          parameters: z.object({}),
+          timeoutMs: 1_000,
+          timeoutBehavior: 'raise_exception',
+          execute: async () => {
+            markTimedToolStarted?.();
+            await timedToolCanFinish;
+            return 'late tool output';
+          },
+        }) as unknown as FunctionTool;
+        const siblingTool = tool({
+          name: 'sibling_tool',
+          description: 'settles when its timed sibling cancels it',
+          parameters: z.object({}),
+          execute: async (_input, _context, details) => {
+            markSiblingStarted?.();
+            await new Promise<void>((resolve) => {
+              details?.signal?.addEventListener('abort', () => resolve(), {
+                once: true,
+              });
+            });
+            return 'cancelled sibling output';
+          },
+        }) as unknown as FunctionTool;
+
+        let settled = false;
+        let resultError: unknown;
+        resultPromise = executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                callId: 'timed-call',
+                name: 'timed_tool',
+              },
+              tool: timedTool,
+            },
+            {
+              toolCall: {
+                ...toolCall,
+                callId: 'sibling-call',
+                name: 'sibling_tool',
+              },
+              tool: siblingTool,
+            },
+          ],
+          runner,
+          state,
+        )
+          .catch((caught) => {
+            resultError = caught;
+          })
+          .finally(() => {
+            settled = true;
+          });
+        await Promise.all([timedToolStarted, siblingStarted]);
+        await vi.advanceTimersByTimeAsync(1_000);
+
+        expect(settled).toBe(true);
+        expect(resultError).toBeInstanceOf(ToolTimeoutError);
+      } finally {
+        releaseTimedTool?.();
+        await resultPromise;
+        vi.useRealTimers();
+      }
+    });
+
+    it.each(['resolves', 'rejects'] as const)(
+      'reports an uncapped sibling that %s after cancellation as aborted',
+      async (settlement) => {
+        const primaryError = new Error('primary tool failure');
+        let markSlowToolStarted: (() => void) | undefined;
+        const slowToolStarted = new Promise<void>((resolve) => {
+          markSlowToolStarted = resolve;
+        });
+        let markCancellationObserved: (() => void) | undefined;
+        const cancellationObserved = new Promise<void>((resolve) => {
+          markCancellationObserved = resolve;
+        });
+        let releaseSlowTool: (() => void) | undefined;
+        const slowToolCanFinish = new Promise<void>((resolve) => {
+          releaseSlowTool = resolve;
+        });
+        const outputGuardrail = defineToolOutputGuardrail({
+          name: 'should_not_run',
+          run: vi.fn(async () => ToolGuardrailFunctionOutputFactory.allow()),
+        });
+        const customDataExtractor = vi.fn(() => ({ shouldNotRun: true }));
+        const failingTool = tool({
+          name: 'failing_tool',
+          description: 'fails after its sibling starts',
+          parameters: z.object({}),
+          errorFunction: null,
+          execute: async () => {
+            await slowToolStarted;
+            throw primaryError;
+          },
+        }) as unknown as FunctionTool;
+        const slowTool = tool({
+          name: 'slow_tool',
+          description: 'ignores cancellation and resolves later',
+          parameters: z.object({}),
+          outputGuardrails: [outputGuardrail],
+          customDataExtractor,
+          execute: async (_input, _context, details) => {
+            markSlowToolStarted?.();
+            details?.signal?.addEventListener(
+              'abort',
+              () => markCancellationObserved?.(),
+              { once: true },
+            );
+            await slowToolCanFinish;
+            if (settlement === 'rejects') {
+              throw new Error('late invocation rejection');
+            }
+            return 'late tool output';
+          },
+        }) as unknown as FunctionTool;
+        const endHookError = new Error('function end hook failed');
+        const end = vi.fn((...args: unknown[]) => {
+          if (settlement === 'rejects' && args[2] === slowTool) {
+            throw endHookError;
+          }
+        });
+        runner = new Runner({ tracingDisabled: false });
+        runner.on('agent_tool_end', end);
+
+        let settled = false;
+        let slowToolSpan: Span<any> | undefined;
+        const resultPromise = withRecordingTrace(async (processor) => {
+          const error = await withTrace('test', () =>
+            executeFunctionToolCalls(
+              state._currentAgent,
+              [
+                {
+                  toolCall: {
+                    ...toolCall,
+                    callId: 'failing-call',
+                    name: 'failing_tool',
+                  },
+                  tool: failingTool,
+                },
+                {
+                  toolCall: {
+                    ...toolCall,
+                    callId: 'slow-call',
+                    name: 'slow_tool',
+                  },
+                  tool: slowTool,
+                },
+              ],
+              runner,
+              state,
+            ),
+          ).catch((caught) => caught);
+          slowToolSpan = getEndedFunctionSpan(processor, 'slow_tool');
+          return error;
+        }).finally(() => {
+          settled = true;
+        });
+        await cancellationObserved;
+
+        expect(settled).toBe(false);
+        releaseSlowTool?.();
+
+        const error = await resultPromise;
+        const slowToolEndCalls = end.mock.calls.filter(
+          ([, , endedTool]) => endedTool === slowTool,
+        );
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect((error as ToolCallError).error).toBe(primaryError);
+        expect(outputGuardrail.run).not.toHaveBeenCalled();
+        expect(customDataExtractor).not.toHaveBeenCalled();
+        expect(slowToolEndCalls).toHaveLength(1);
+        expect(slowToolEndCalls[0]?.[3]).toBe('aborted');
+        if (settlement === 'rejects') {
+          expect(slowToolSpan?.error).toMatchObject({
+            message: endHookError.message,
+          });
+        } else {
+          expect(slowToolSpan?.error).toBeNull();
+        }
+        expect(slowToolSpan?.spanData.output).toBe('aborted');
+      },
+    );
+
+    it('stops success post-processing after cancellation during output guardrails', async () => {
+      const primaryError = new Error('primary tool failure');
+      let markGuardrailStarted: (() => void) | undefined;
+      const guardrailStarted = new Promise<void>((resolve) => {
+        markGuardrailStarted = resolve;
+      });
+      let releaseGuardrail: (() => void) | undefined;
+      const guardrailCanFinish = new Promise<void>((resolve) => {
+        releaseGuardrail = resolve;
+      });
+      let markFatalFailure: (() => void) | undefined;
+      const fatalFailure = new Promise<void>((resolve) => {
+        markFatalFailure = resolve;
+      });
+      const outputGuardrail = defineToolOutputGuardrail({
+        name: 'blocking_output_guardrail',
+        run: vi.fn(async () => {
+          markGuardrailStarted?.();
+          await guardrailCanFinish;
+          return ToolGuardrailFunctionOutputFactory.rejectContent(
+            'invalid replacement',
+          );
+        }),
+      });
+      const customDataExtractor = vi.fn(() => ({ shouldNotRun: true }));
+      const guardedTool = tool({
+        name: 'guarded_tool',
+        description: 'waits in an output guardrail',
+        parameters: z.object({}),
+        outputSchema: z.object({ status: z.literal('ok') }),
         outputGuardrails: [outputGuardrail],
         customDataExtractor,
-        execute: async (_input, _context, details) => {
-          markSlowToolStarted?.();
-          details?.signal?.addEventListener(
-            'abort',
-            () => markCancellationObserved?.(),
-            { once: true },
-          );
-          await slowToolCanFinish;
-          return 'late tool output';
+        execute: async () => ({ status: 'ok' as const }),
+      }) as unknown as FunctionTool;
+      const failingTool = tool({
+        name: 'failing_tool',
+        description: 'fails while its sibling output guardrail remains active',
+        parameters: z.object({}),
+        errorFunction: null,
+        execute: async () => {
+          await guardrailStarted;
+          throw primaryError;
         },
       }) as unknown as FunctionTool;
       const end = vi.fn();
@@ -4459,40 +5510,493 @@ describe('executeShellActions', () => {
           {
             toolCall: {
               ...toolCall,
+              callId: 'guarded-call',
+              name: 'guarded_tool',
+            },
+            tool: guardedTool,
+          },
+          {
+            toolCall: {
+              ...toolCall,
               callId: 'failing-call',
               name: 'failing_tool',
             },
             tool: failingTool,
           },
-          {
-            toolCall: {
-              ...toolCall,
-              callId: 'slow-call',
-              name: 'slow_tool',
-            },
-            tool: slowTool,
-          },
         ],
         runner,
         state,
+        undefined,
+        undefined,
+        undefined,
+        () => markFatalFailure?.(),
       ).finally(() => {
         settled = true;
       });
-      await cancellationObserved;
-
+      await guardrailStarted;
+      await fatalFailure;
       expect(settled).toBe(false);
-      releaseSlowTool?.();
+      releaseGuardrail?.();
 
       const error = await resultPromise.catch((caught) => caught);
-      const slowToolEndCalls = end.mock.calls.filter(
-        ([, , endedTool]) => endedTool === slowTool,
+      const guardedToolEndCalls = end.mock.calls.filter(
+        ([, , endedTool]) => endedTool === guardedTool,
       );
       expect(error).toBeInstanceOf(ToolCallError);
       expect((error as ToolCallError).error).toBe(primaryError);
-      expect(outputGuardrail.run).not.toHaveBeenCalled();
+      expect(outputGuardrail.run).toHaveBeenCalledTimes(1);
+      expect(state._toolOutputGuardrailResults).toHaveLength(1);
       expect(customDataExtractor).not.toHaveBeenCalled();
-      expect(slowToolEndCalls).toHaveLength(1);
-      expect(slowToolEndCalls[0]?.[3]).not.toBe('late tool output');
+      expect(guardedToolEndCalls).toHaveLength(1);
+      expect(guardedToolEndCalls[0]?.[3]).toBe('aborted');
+    });
+
+    it.each(['fulfills', 'rejects'] as const)(
+      'reports cancellation when function custom data extraction %s as aborted',
+      async (settlement) => {
+        const primaryError = new Error('primary tool failure');
+        const customDataError = new Error(
+          'custom data failed after cancellation',
+        );
+        let markCustomDataStarted: (() => void) | undefined;
+        const customDataStarted = new Promise<void>((resolve) => {
+          markCustomDataStarted = resolve;
+        });
+        let releaseCustomData: (() => void) | undefined;
+        const customDataCanFinish = new Promise<void>((resolve) => {
+          releaseCustomData = resolve;
+        });
+        let markFatalFailure: (() => void) | undefined;
+        const fatalFailure = new Promise<void>((resolve) => {
+          markFatalFailure = resolve;
+        });
+        let customDataFinished = false;
+        const extractingTool = tool({
+          name: 'extracting_tool',
+          description: 'waits while extracting custom data',
+          parameters: z.object({}),
+          execute: async () => 'tool output',
+          customDataExtractor: async () => {
+            markCustomDataStarted?.();
+            await customDataCanFinish;
+            customDataFinished = true;
+            if (settlement === 'rejects') {
+              throw customDataError;
+            }
+            return { extracted: true };
+          },
+        }) as unknown as FunctionTool;
+        const failingTool = tool({
+          name: 'failing_tool',
+          description: 'fails while its sibling extracts custom data',
+          parameters: z.object({}),
+          errorFunction: null,
+          execute: async () => {
+            await customDataStarted;
+            throw primaryError;
+          },
+        }) as unknown as FunctionTool;
+        const end = vi.fn();
+        runner.on('agent_tool_end', end);
+
+        let settled = false;
+        const resultPromise = executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                callId: 'extracting-call',
+                name: 'extracting_tool',
+              },
+              tool: extractingTool,
+            },
+            {
+              toolCall: {
+                ...toolCall,
+                callId: 'failing-call',
+                name: 'failing_tool',
+              },
+              tool: failingTool,
+            },
+          ],
+          runner,
+          state,
+          undefined,
+          undefined,
+          undefined,
+          () => markFatalFailure?.(),
+        ).finally(() => {
+          settled = true;
+        });
+        await fatalFailure;
+
+        expect(settled).toBe(false);
+        releaseCustomData?.();
+
+        const error = await resultPromise.catch((caught) => caught);
+        const extractingToolEndCalls = end.mock.calls.filter(
+          ([, , endedTool]) => endedTool === extractingTool,
+        );
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect((error as ToolCallError).error).toBe(primaryError);
+        expect(customDataFinished).toBe(true);
+        expect(extractingToolEndCalls).toHaveLength(1);
+        expect(extractingToolEndCalls[0]?.[3]).toBe('aborted');
+      },
+    );
+
+    it('prioritizes cancellation after custom data promotes redaction', async () => {
+      const secret = 'SECRET_CANCELLED_CUSTOM_DATA_REDACTION_123';
+      const primaryError = new Error('primary tool failure');
+      let redactToolData = false;
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockImplementation(() => redactToolData);
+      let markCustomDataStarted: (() => void) | undefined;
+      const customDataStarted = new Promise<void>((resolve) => {
+        markCustomDataStarted = resolve;
+      });
+      let releaseCustomData: (() => void) | undefined;
+      const customDataCanFinish = new Promise<void>((resolve) => {
+        releaseCustomData = resolve;
+      });
+      let markFatalFailure: (() => void) | undefined;
+      const fatalFailure = new Promise<void>((resolve) => {
+        markFatalFailure = resolve;
+      });
+      const invalidInputTool = tool({
+        name: 'invalid_input_custom_data',
+        description: 'promotes redaction while extracting custom data',
+        parameters: z.object({ value: z.number() }),
+        errorFunction: () => 'diagnostic fallback',
+        customDataExtractor: async (context) => {
+          markCustomDataStarted?.();
+          await customDataCanFinish;
+          redactToolData = true;
+          return { captured: context.input };
+        },
+        execute: vi.fn(async () => 'unexpected'),
+      }) as unknown as FunctionTool;
+      const failingTool = tool({
+        name: 'failing_tool',
+        description: 'fails while its sibling extracts custom data',
+        parameters: z.object({}),
+        errorFunction: null,
+        execute: async () => {
+          await customDataStarted;
+          throw primaryError;
+        },
+      }) as unknown as FunctionTool;
+      const invalidToolCall = {
+        ...toolCall,
+        callId: 'invalid-custom-data-call',
+        name: 'invalid_input_custom_data',
+        arguments: JSON.stringify({ value: secret }),
+      };
+      const end = vi.fn();
+      runner = new Runner({
+        tracingDisabled: false,
+        traceIncludeSensitiveData: true,
+      });
+      runner.on('agent_tool_end', end);
+
+      try {
+        let invalidToolSpan: Span<any> | undefined;
+        let settled = false;
+        const resultPromise = withRecordingTrace(async (processor) => {
+          const error = await withTrace('test', () =>
+            executeFunctionToolCalls(
+              state._currentAgent,
+              [
+                { toolCall: invalidToolCall, tool: invalidInputTool },
+                {
+                  toolCall: {
+                    ...toolCall,
+                    callId: 'failing-call',
+                    name: 'failing_tool',
+                  },
+                  tool: failingTool,
+                },
+              ],
+              runner,
+              state,
+              undefined,
+              undefined,
+              undefined,
+              () => markFatalFailure?.(),
+            ),
+          ).catch((caught) => caught);
+          invalidToolSpan = getEndedFunctionSpan(
+            processor,
+            'invalid_input_custom_data',
+          );
+          return error;
+        }).finally(() => {
+          settled = true;
+        });
+        await fatalFailure;
+
+        expect(settled).toBe(false);
+        releaseCustomData?.();
+
+        const error = await resultPromise;
+        const invalidToolEndCalls = end.mock.calls.filter(
+          ([, , endedTool]) => endedTool === invalidInputTool,
+        );
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect((error as ToolCallError).error).toBe(primaryError);
+        expect(invalidToolEndCalls).toHaveLength(1);
+        expect(invalidToolEndCalls[0]?.[3]).toBe('aborted');
+        expect(invalidToolSpan?.error).toMatchObject({
+          message: 'Error running tool (non-fatal)',
+        });
+        expect(invalidToolSpan?.spanData.output).toBe('aborted');
+        expect(JSON.stringify(error)).not.toContain(secret);
+      } finally {
+        flagSpy.mockRestore();
+      }
+    });
+
+    it.each(['fulfills', 'rejects'] as const)(
+      'stops success post-processing when an input guardrail fallback %s after cancellation',
+      async (settlement) => {
+        const primaryError = new Error('primary tool failure');
+        const fallbackError = new Error('fallback failed after cancellation');
+        let markFallbackStarted: (() => void) | undefined;
+        const fallbackStarted = new Promise<void>((resolve) => {
+          markFallbackStarted = resolve;
+        });
+        let releaseFallback: (() => void) | undefined;
+        const fallbackCanFinish = new Promise<void>((resolve) => {
+          releaseFallback = resolve;
+        });
+        let markFatalFailure: (() => void) | undefined;
+        const fatalFailure = new Promise<void>((resolve) => {
+          markFatalFailure = resolve;
+        });
+        let fallbackDrained = false;
+        const inputGuardrail = defineToolInputGuardrail({
+          name: 'rejecting_input_guardrail',
+          run: vi.fn(async () =>
+            ToolGuardrailFunctionOutputFactory.rejectContent('blocked'),
+          ),
+        });
+        const guardedToolExecute = vi.fn(async () => ({
+          status: 'unexpected' as const,
+        }));
+        const customDataExtractor = vi.fn(() => ({ shouldNotRun: true }));
+        const guardedTool = tool({
+          name: 'guarded_tool',
+          description: 'waits in an input guardrail fallback',
+          parameters: z.object({}),
+          outputSchema: z.object({ status: z.string() }),
+          inputGuardrails: [inputGuardrail],
+          errorFunction: async () => {
+            markFallbackStarted?.();
+            await fallbackCanFinish;
+            fallbackDrained = true;
+            if (settlement === 'rejects') {
+              throw fallbackError;
+            }
+            return { status: 'blocked' };
+          },
+          customDataExtractor,
+          execute: guardedToolExecute,
+        }) as unknown as FunctionTool;
+        const failingTool = tool({
+          name: 'failing_tool',
+          description: 'fails while its sibling fallback remains active',
+          parameters: z.object({}),
+          errorFunction: null,
+          execute: async () => {
+            await fallbackStarted;
+            throw primaryError;
+          },
+        }) as unknown as FunctionTool;
+        const end = vi.fn();
+        runner = new Runner({ tracingDisabled: false });
+        runner.on('agent_tool_end', end);
+
+        let settled = false;
+        let guardedToolSpan: Span<any> | undefined;
+        const resultPromise = withRecordingTrace(async (processor) => {
+          const error = await withTrace('test', () =>
+            executeFunctionToolCalls(
+              state._currentAgent,
+              [
+                {
+                  toolCall: {
+                    ...toolCall,
+                    callId: 'guarded-call',
+                    name: 'guarded_tool',
+                  },
+                  tool: guardedTool,
+                },
+                {
+                  toolCall: {
+                    ...toolCall,
+                    callId: 'failing-call',
+                    name: 'failing_tool',
+                  },
+                  tool: failingTool,
+                },
+              ],
+              runner,
+              state,
+              undefined,
+              undefined,
+              undefined,
+              () => markFatalFailure?.(),
+            ),
+          ).catch((caught) => caught);
+          guardedToolSpan = getEndedFunctionSpan(processor, 'guarded_tool');
+          return error;
+        }).finally(() => {
+          settled = true;
+        });
+        await fallbackStarted;
+        await fatalFailure;
+
+        expect(settled).toBe(false);
+        releaseFallback?.();
+
+        const error = await resultPromise;
+        const guardedToolEndCalls = end.mock.calls.filter(
+          ([, , endedTool]) => endedTool === guardedTool,
+        );
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect((error as ToolCallError).error).toBe(primaryError);
+        expect(inputGuardrail.run).toHaveBeenCalledTimes(1);
+        expect(fallbackDrained).toBe(true);
+        expect(guardedToolExecute).not.toHaveBeenCalled();
+        expect(customDataExtractor).not.toHaveBeenCalled();
+        expect(guardedToolEndCalls).toHaveLength(1);
+        expect(guardedToolEndCalls[0]?.[3]).toBe('aborted');
+        expect(guardedToolSpan?.error).toBeNull();
+        expect(guardedToolSpan?.spanData.output).toBe('aborted');
+      },
+    );
+
+    it('preserves aborted lifecycle output when an end hook promotes redaction', async () => {
+      const secret = 'SECRET_CANCELLED_INVALID_INPUT_123';
+      const primaryError = new Error('primary tool failure');
+      let redactToolData = false;
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockImplementation(() => redactToolData);
+      let markFallbackStarted: (() => void) | undefined;
+      const fallbackStarted = new Promise<void>((resolve) => {
+        markFallbackStarted = resolve;
+      });
+      let markCancellationObserved: (() => void) | undefined;
+      const cancellationObserved = new Promise<void>((resolve) => {
+        markCancellationObserved = resolve;
+      });
+      let releaseFallback: (() => void) | undefined;
+      const fallbackCanFinish = new Promise<void>((resolve) => {
+        releaseFallback = resolve;
+      });
+      const invalidInputTool = tool({
+        name: 'cancelled_invalid_input',
+        description: 'Wait in an invalid-input fallback until cancelled.',
+        parameters: z.object({ value: z.number() }),
+        errorFunction: async (_context, _error, details) => {
+          markFallbackStarted?.();
+          details?.signal?.addEventListener(
+            'abort',
+            () => markCancellationObserved?.(),
+            { once: true },
+          );
+          await fallbackCanFinish;
+          return 'late fallback';
+        },
+        execute: vi.fn(async () => 'unexpected'),
+      }) as unknown as FunctionTool;
+      const failingTool = tool({
+        name: 'redaction_triggering_sibling_failure',
+        description: 'Fail after the invalid-input fallback starts.',
+        parameters: z.object({}),
+        errorFunction: null,
+        execute: async () => {
+          await fallbackStarted;
+          throw primaryError;
+        },
+      }) as unknown as FunctionTool;
+      const runnerEnd = vi.fn((...args: unknown[]) => {
+        if (args[2] === invalidInputTool) {
+          redactToolData = true;
+        }
+      });
+      const agentEnd = vi.fn();
+      runner = new Runner({ tracingDisabled: false });
+      runner.on('agent_tool_end', runnerEnd);
+      state._currentAgent.on('agent_tool_end', agentEnd);
+
+      try {
+        let cancelledToolSpan: Span<any> | undefined;
+        const resultPromise = withRecordingTrace(async (processor) => {
+          const error = await withTrace('test', () =>
+            executeFunctionToolCalls(
+              state._currentAgent,
+              [
+                {
+                  toolCall: {
+                    ...toolCall,
+                    callId: 'invalid-call',
+                    name: 'cancelled_invalid_input',
+                    arguments: JSON.stringify({ value: secret }),
+                  },
+                  tool: invalidInputTool,
+                },
+                {
+                  toolCall: {
+                    ...toolCall,
+                    callId: 'failing-call',
+                    name: 'redaction_triggering_sibling_failure',
+                    arguments: '{}',
+                  },
+                  tool: failingTool,
+                },
+              ],
+              runner,
+              state,
+            ),
+          ).catch((caught) => caught);
+          cancelledToolSpan = getEndedFunctionSpan(
+            processor,
+            'cancelled_invalid_input',
+          );
+          return error;
+        });
+        await cancellationObserved;
+        releaseFallback?.();
+
+        const error = await resultPromise;
+        const runnerCalls = runnerEnd.mock.calls.filter(
+          ([, , endedTool]) => endedTool === invalidInputTool,
+        );
+        const agentCalls = agentEnd.mock.calls.filter(
+          ([, endedTool]) => endedTool === invalidInputTool,
+        );
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect((error as ToolCallError).error).toBe(primaryError);
+        expect(runnerCalls).toHaveLength(1);
+        expect(runnerCalls[0]?.[3]).toBe('aborted');
+        expect(agentCalls).toHaveLength(1);
+        expect(agentCalls[0]?.[2]).toBe('aborted');
+        expect(agentCalls[0]?.[3]).toEqual({
+          toolCall: expect.objectContaining({ arguments: '' }),
+        });
+        expect(cancelledToolSpan?.error).toMatchObject({
+          message: 'Error running tool (non-fatal)',
+        });
+        expect(cancelledToolSpan?.spanData.input).toBe('');
+        expect(cancelledToolSpan?.spanData.output).toBe('aborted');
+      } finally {
+        releaseFallback?.();
+        flagSpy.mockRestore();
+      }
     });
 
     it('reserves abort-shaped nested failure ownership while cleanup drains', async () => {
@@ -4562,6 +6066,43 @@ describe('executeShellActions', () => {
       );
       expect(rejection).toBe(wrappedPrimaryError);
       expect(wrappedPrimaryError?.error).toBe(primaryError);
+    });
+
+    it('preserves a reserved abort-shaped failure when cancellation aborts the parent', async () => {
+      const primaryError = new Error('primary function failure');
+      primaryError.name = 'AbortError';
+      const parentReason = new Error('parent aborted during cancellation');
+      const parentController = new AbortController();
+      let markSiblingStarted: (() => void) | undefined;
+      const siblingStarted = new Promise<void>((resolve) => {
+        markSiblingStarted = resolve;
+      });
+
+      const resultPromise = runWithSiblingCancellation(
+        [
+          async (_signal, reserveFailure) => {
+            await siblingStarted;
+            reserveFailure?.();
+            throw primaryError;
+          },
+          async (signal) => {
+            markSiblingStarted?.();
+            await new Promise<void>((_resolve, reject) => {
+              signal?.addEventListener(
+                'abort',
+                () => {
+                  parentController.abort(parentReason);
+                  reject(signal.reason);
+                },
+                { once: true },
+              );
+            });
+          },
+        ],
+        parentController.signal,
+      );
+
+      await expect(resultPromise).rejects.toBe(primaryError);
     });
 
     it('preserves undefined rejections in uncapped tools', async () => {
@@ -4696,6 +6237,118 @@ describe('executeShellActions', () => {
       ).rejects.toThrow(/Failed to run function tools/);
 
       expect(startedTools).toEqual(['failing_tool']);
+    });
+
+    it('reserves a capped worker failure before another worker takes queued work', async () => {
+      const startedTools: string[] = [];
+      let activeTools = 0;
+      let markActiveToolsStarted: (() => void) | undefined;
+      const activeToolsStarted = new Promise<void>((resolve) => {
+        markActiveToolsStarted = resolve;
+      });
+      let rejectFailingTool: ((error: Error) => void) | undefined;
+      const failingToolResult = new Promise<string>((_resolve, reject) => {
+        rejectFailingTool = reject;
+      });
+      let resolveCompletingCustomData: (() => void) | undefined;
+      const completingCustomDataCanFinish = new Promise<void>((resolve) => {
+        resolveCompletingCustomData = resolve;
+      });
+      runner = new Runner({
+        tracingDisabled: true,
+        toolExecution: { maxFunctionToolConcurrency: 2 },
+      });
+      const failingTool = {
+        ...tool({
+          name: 'failing_tool',
+          description: 'Fail after the other worker starts.',
+          parameters: z.object({}),
+          errorFunction: null,
+          execute: vi.fn(async () => 'unused'),
+        }),
+        invoke: vi.fn(() => {
+          startedTools.push('failing_tool');
+          activeTools += 1;
+          if (activeTools === 2) {
+            markActiveToolsStarted?.();
+          }
+          return failingToolResult;
+        }),
+      } as unknown as FunctionTool;
+      const completingTool = {
+        ...tool({
+          name: 'completing_tool',
+          description: 'Complete while the failure propagates.',
+          parameters: z.object({}),
+          customDataExtractor: async () => {
+            activeTools += 1;
+            if (activeTools === 2) {
+              markActiveToolsStarted?.();
+            }
+            await completingCustomDataCanFinish;
+            return undefined;
+          },
+          execute: vi.fn(async () => 'unused'),
+        }),
+        invoke: vi.fn(() => {
+          startedTools.push('completing_tool');
+          return Promise.resolve('completed');
+        }),
+      } as unknown as FunctionTool;
+      const queuedParser = vi.fn(() => true);
+      const queuedTool = tool({
+        name: 'queued_tool',
+        description: 'Must remain queued after the active failure.',
+        parameters: z.object({ value: z.string().refine(queuedParser) }),
+        execute: vi.fn(async () => {
+          startedTools.push('queued_tool');
+          return 'should-not-run';
+        }),
+      }) as unknown as FunctionTool;
+
+      const resultPromise = executeFunctionToolCalls(
+        state._currentAgent,
+        [
+          {
+            toolCall: {
+              ...toolCall,
+              name: 'failing_tool',
+              callId: 'c1',
+              arguments: '{}',
+            },
+            tool: failingTool,
+          },
+          {
+            toolCall: {
+              ...toolCall,
+              name: 'completing_tool',
+              callId: 'c2',
+              arguments: '{}',
+            },
+            tool: completingTool,
+          },
+          {
+            toolCall: {
+              ...toolCall,
+              name: 'queued_tool',
+              callId: 'c3',
+              arguments: JSON.stringify({ value: 'queued' }),
+            },
+            tool: queuedTool,
+          },
+        ],
+        runner,
+        state,
+      );
+      await activeToolsStarted;
+      rejectFailingTool?.(new Error('boom'));
+      resolveCompletingCustomData?.();
+
+      await expect(resultPromise).rejects.toThrow(
+        /Failed to run function tools/,
+      );
+      expect(startedTools).toEqual(['failing_tool', 'completing_tool']);
+      expect(queuedParser).not.toHaveBeenCalled();
     });
 
     it('parses capped function calls when their scheduler slot starts', async () => {
@@ -5040,6 +6693,99 @@ describe('executeShellActions', () => {
       });
     });
 
+    it('does not report a rejected input guardrail after sibling cancellation', async () => {
+      const primaryError = new Error('primary tool failure');
+      const secondaryError = new Error('secondary input guardrail failure');
+      let markGuardrailStarted: (() => void) | undefined;
+      const guardrailStarted = new Promise<void>((resolve) => {
+        markGuardrailStarted = resolve;
+      });
+      let releaseGuardrail: (() => void) | undefined;
+      const guardrailCanFinish = new Promise<void>((resolve) => {
+        releaseGuardrail = resolve;
+      });
+      let markFatalFailure: (() => void) | undefined;
+      const fatalFailure = new Promise<void>((resolve) => {
+        markFatalFailure = resolve;
+      });
+      const rejectingGuardrail = defineToolInputGuardrail({
+        name: 'reject_after_cancellation',
+        run: async () => {
+          markGuardrailStarted?.();
+          await guardrailCanFinish;
+          throw secondaryError;
+        },
+      });
+      const guardedExecute = vi.fn(async () => 'should-not-run');
+      const guardedTool = tool({
+        name: 'guarded_tool',
+        description: 'rejects its input guardrail after cancellation',
+        parameters: z.object({}),
+        execute: guardedExecute,
+        inputGuardrails: [rejectingGuardrail],
+      }) as unknown as FunctionTool;
+      const failingTool = tool({
+        name: 'failing_tool',
+        description: 'fails while its sibling input guardrail is pending',
+        parameters: z.object({}),
+        errorFunction: null,
+        execute: async () => {
+          await guardrailStarted;
+          throw primaryError;
+        },
+      }) as unknown as FunctionTool;
+      const end = vi.fn();
+      runner = new Runner({ tracingDisabled: false });
+      runner.on('agent_tool_end', end);
+
+      let guardedToolSpan: Span<any> | undefined;
+      const resultPromise = withRecordingTrace(async (processor) => {
+        const error = await withTrace('test', () =>
+          executeFunctionToolCalls(
+            state._currentAgent,
+            [
+              {
+                toolCall: {
+                  ...toolCall,
+                  callId: 'guarded-call',
+                  name: 'guarded_tool',
+                },
+                tool: guardedTool,
+              },
+              {
+                toolCall: {
+                  ...toolCall,
+                  callId: 'failing-call',
+                  name: 'failing_tool',
+                },
+                tool: failingTool,
+              },
+            ],
+            runner,
+            state,
+            undefined,
+            undefined,
+            undefined,
+            () => markFatalFailure?.(),
+          ),
+        ).catch((caught) => caught);
+        guardedToolSpan = getEndedFunctionSpan(processor, 'guarded_tool');
+        return error;
+      });
+      await fatalFailure;
+      releaseGuardrail?.();
+
+      const error = await resultPromise;
+      const guardedToolEndCalls = end.mock.calls.filter(
+        ([, , endedTool]) => endedTool === guardedTool,
+      );
+      expect(error).toBeInstanceOf(ToolCallError);
+      expect((error as ToolCallError).error).toBe(primaryError);
+      expect(guardedExecute).not.toHaveBeenCalled();
+      expect(guardedToolEndCalls).toHaveLength(0);
+      expect(guardedToolSpan?.error).toBeNull();
+    });
+
     it('rejects input guardrail messages for Zod output schemas without a fallback', async () => {
       const inputGuardrail = defineToolInputGuardrail({
         name: 'block_structured_tool',
@@ -5296,6 +7042,63 @@ describe('executeShellActions', () => {
       }
       expect(secondRun).not.toHaveBeenCalled();
       expect(state._toolInputGuardrailResults).toHaveLength(1);
+    });
+
+    it('does not start prepared-input guardrails after approval aborts', async () => {
+      const controller = new AbortController();
+      const abortReason = new Error('approval aborted');
+      const inputGuardrail = defineToolInputGuardrail({
+        name: 'should_not_run',
+        run: vi.fn(async () => ToolGuardrailFunctionOutputFactory.allow()),
+      });
+      const execute = vi.fn(async () => 'unexpected');
+      const preparedInputTool = tool({
+        name: 'prepared_input_tool',
+        description: 'has schema-invalid prepared input',
+        parameters: z.object({ value: z.number() }),
+        inputGuardrails: [inputGuardrail],
+        execute,
+      }) as unknown as FunctionTool;
+      const approvalSpy = vi
+        .spyOn(state._context, 'isToolApproved')
+        .mockImplementation(({ callId }) => {
+          if (callId === 'prepared-input-call') {
+            controller.abort(abortReason);
+          }
+          return true;
+        });
+
+      try {
+        const [result] = await executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                callId: 'prepared-input-call',
+                name: 'prepared_input_tool',
+                arguments: JSON.stringify({ value: 'invalid' }),
+              },
+              tool: preparedInputTool,
+            },
+          ],
+          runner,
+          state,
+          undefined,
+          undefined,
+          controller.signal,
+        );
+
+        expect(controller.signal.reason).toBe(abortReason);
+        expect(result).toMatchObject({
+          type: 'function_output',
+          output: 'aborted',
+        });
+        expect(inputGuardrail.run).not.toHaveBeenCalled();
+        expect(execute).not.toHaveBeenCalled();
+      } finally {
+        approvalSpy.mockRestore();
+      }
     });
 
     it('stops evaluating further output guardrails after rejectContent and returns replacement', async () => {

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -79,6 +79,7 @@ import {
 } from '../stubs';
 import * as protocol from '../../src/types/protocol';
 import { AgentToolUseTracker } from '../../src/runner/toolUseTracker';
+import { runWithSiblingCancellation } from '../../src/runner/siblingCancellation';
 import { z } from 'zod';
 import {
   defaultProcessor,
@@ -1382,6 +1383,67 @@ describe('executeComputerActions', () => {
     expect(invocations).toEqual(['move', 'click', 'screenshot']);
     expect(items).toHaveLength(1);
     expect((items[0] as any).output).toBe('data:image/png;base64,img');
+  });
+
+  it('does not start later batched computer actions after cancellation', async () => {
+    const controller = new AbortController();
+    let markClickStarted: (() => void) | undefined;
+    const clickStarted = new Promise<void>((resolve) => {
+      markClickStarted = resolve;
+    });
+    let releaseClick: (() => void) | undefined;
+    const clickCanFinish = new Promise<void>((resolve) => {
+      releaseClick = resolve;
+    });
+    const fakeComputer = {
+      environment: 'mac',
+      dimensions: [1, 1] as [number, number],
+      screenshot: vi.fn().mockResolvedValue('img'),
+      click: vi.fn().mockImplementation(async () => {
+        markClickStarted?.();
+        await clickCanFinish;
+      }),
+      doubleClick: vi.fn(),
+      drag: vi.fn(),
+      keypress: vi.fn(),
+      move: vi.fn(),
+      scroll: vi.fn(),
+      type: vi.fn(),
+      wait: vi.fn(),
+    } as any;
+    const computer = computerTool({ computer: fakeComputer });
+    const call: protocol.ComputerUseCallItem = {
+      type: 'computer_call',
+      callId: 'cancelled-batch',
+      status: 'completed',
+      actions: [
+        { type: 'click', x: 1, y: 2, button: 'left' },
+        { type: 'move', x: 3, y: 4 },
+      ],
+    };
+
+    const resultPromise = executeComputerActions(
+      new Agent({ name: 'Comp' }),
+      [{ toolCall: call, computer }],
+      new Runner(),
+      new RunContext(),
+      undefined,
+      undefined,
+      controller.signal,
+    );
+    await clickStarted;
+    controller.abort(new Error('stop batched actions'));
+    releaseClick?.();
+
+    const [item] = await resultPromise;
+    expect(fakeComputer.click).toHaveBeenCalledTimes(1);
+    expect(fakeComputer.move).not.toHaveBeenCalled();
+    expect(fakeComputer.screenshot).not.toHaveBeenCalled();
+    expect(item.rawItem).toMatchObject({
+      type: 'computer_call_result',
+      callId: call.callId,
+      providerData: { status: 'incomplete' },
+    });
   });
 
   it('checks approval against each batched computer action', async () => {
@@ -4156,15 +4218,15 @@ describe('executeShellActions', () => {
       ).toEqual(['ok-1', 'ok-2', 'ok-3']);
     });
 
-    it('surfaces an uncapped tool failure without waiting for a pending sibling', async () => {
+    it('cancels and drains an uncapped sibling after a tool failure', async () => {
       let markSiblingStarted: (() => void) | undefined;
       const siblingStarted = new Promise<void>((resolve) => {
         markSiblingStarted = resolve;
       });
-      let releaseSibling: (() => void) | undefined;
-      const siblingCanFinish = new Promise<void>((resolve) => {
-        releaseSibling = resolve;
-      });
+      const primaryError = new Error('boom');
+      let siblingCancelled = false;
+      let siblingDrained = false;
+      let lateSideEffect = false;
       const failingTool = tool({
         name: 'failing_tool',
         description: 'fails while a sibling remains pending',
@@ -4172,17 +4234,34 @@ describe('executeShellActions', () => {
         errorFunction: null,
         execute: vi.fn(async () => {
           await siblingStarted;
-          throw new Error('boom');
+          throw primaryError;
         }),
       }) as unknown as FunctionTool;
       const pendingTool = tool({
         name: 'pending_tool',
         description: 'remains pending until released',
         parameters: z.object({}),
-        execute: vi.fn(async () => {
+        execute: vi.fn(async (_input, _context, details) => {
           markSiblingStarted?.();
-          await siblingCanFinish;
-          return 'done';
+          if (!details?.signal) {
+            throw new Error('Expected an internal cancellation signal');
+          }
+          try {
+            await new Promise<void>((_resolve, reject) => {
+              details.signal?.addEventListener(
+                'abort',
+                () => reject(details.signal?.reason),
+                { once: true },
+              );
+            });
+            lateSideEffect = true;
+            return 'unexpected';
+          } catch (error) {
+            siblingCancelled = true;
+            await Promise.resolve();
+            siblingDrained = true;
+            throw error;
+          }
         }),
       }) as unknown as FunctionTool;
 
@@ -4211,13 +4290,74 @@ describe('executeShellActions', () => {
       );
       await siblingStarted;
 
-      try {
-        await expect(resultPromise).rejects.toThrow(
-          /Failed to run function tools/,
-        );
-      } finally {
-        releaseSibling?.();
-      }
+      const error = await resultPromise.catch((caught) => caught);
+
+      expect(error).toBeInstanceOf(ToolCallError);
+      expect((error as ToolCallError).error).toBe(primaryError);
+      expect(siblingCancelled).toBe(true);
+      expect(siblingDrained).toBe(true);
+      expect(lateSideEffect).toBe(false);
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      expect(lateSideEffect).toBe(false);
+    });
+
+    it('reserves nested failure ownership while cleanup drains', async () => {
+      const primaryError = new Error('primary function failure');
+      const wrappedPrimaryError = new ToolCallError(
+        'Failed to run function tools',
+        primaryError,
+      );
+      const secondaryError = new Error('secondary category failure');
+      let markCleanupStarted: (() => void) | undefined;
+      const cleanupStarted = new Promise<void>((resolve) => {
+        markCleanupStarted = resolve;
+      });
+      let releaseCleanup: (() => void) | undefined;
+      const cleanupCanFinish = new Promise<void>((resolve) => {
+        releaseCleanup = resolve;
+      });
+
+      const resultPromise = runWithSiblingCancellation([
+        async (signal, reserveFailure) => {
+          try {
+            await runWithSiblingCancellation(
+              [
+                async () => {
+                  throw primaryError;
+                },
+                async (innerSignal) => {
+                  try {
+                    await new Promise<void>((_resolve, reject) => {
+                      innerSignal?.addEventListener(
+                        'abort',
+                        () => reject(innerSignal.reason),
+                        { once: true },
+                      );
+                    });
+                  } catch {
+                    markCleanupStarted?.();
+                    await cleanupCanFinish;
+                  }
+                },
+              ],
+              signal,
+              reserveFailure,
+            );
+          } catch {
+            throw wrappedPrimaryError;
+          }
+        },
+        async (signal) => {
+          await new Promise<void>((resolve) => {
+            signal?.addEventListener('abort', () => resolve(), { once: true });
+          });
+          throw secondaryError;
+        },
+      ]);
+      await cleanupStarted;
+      releaseCleanup?.();
+
+      await expect(resultPromise).rejects.toBe(wrappedPrimaryError);
     });
 
     it('preserves undefined rejections in uncapped tools', async () => {

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -1385,66 +1385,168 @@ describe('executeComputerActions', () => {
     expect((items[0] as any).output).toBe('data:image/png;base64,img');
   });
 
-  it('does not start later batched computer actions after cancellation', async () => {
-    const controller = new AbortController();
-    let markClickStarted: (() => void) | undefined;
-    const clickStarted = new Promise<void>((resolve) => {
-      markClickStarted = resolve;
-    });
-    let releaseClick: (() => void) | undefined;
-    const clickCanFinish = new Promise<void>((resolve) => {
-      releaseClick = resolve;
-    });
-    const fakeComputer = {
-      environment: 'mac',
-      dimensions: [1, 1] as [number, number],
-      screenshot: vi.fn().mockResolvedValue('img'),
-      click: vi.fn().mockImplementation(async () => {
-        markClickStarted?.();
-        await clickCanFinish;
-      }),
-      doubleClick: vi.fn(),
-      drag: vi.fn(),
-      keypress: vi.fn(),
-      move: vi.fn(),
-      scroll: vi.fn(),
-      type: vi.fn(),
-      wait: vi.fn(),
-    } as any;
-    const computer = computerTool({ computer: fakeComputer });
-    const call: protocol.ComputerUseCallItem = {
-      type: 'computer_call',
-      callId: 'cancelled-batch',
-      status: 'completed',
-      actions: [
-        { type: 'click', x: 1, y: 2, button: 'left' },
-        { type: 'move', x: 3, y: 4 },
-      ],
-    };
+  it.each(['fulfills', 'rejects'] as const)(
+    'does not start later batched computer actions when the active action %s after cancellation',
+    async (settlement) => {
+      const controller = new AbortController();
+      let markClickStarted: (() => void) | undefined;
+      const clickStarted = new Promise<void>((resolve) => {
+        markClickStarted = resolve;
+      });
+      let releaseClick: (() => void) | undefined;
+      const clickCanFinish = new Promise<void>((resolve) => {
+        releaseClick = resolve;
+      });
+      const fakeComputer = {
+        environment: 'mac',
+        dimensions: [1, 1] as [number, number],
+        screenshot: vi.fn().mockResolvedValue('img'),
+        click: vi.fn().mockImplementation(async () => {
+          markClickStarted?.();
+          await clickCanFinish;
+          if (settlement === 'rejects') {
+            throw new Error('computer action failed after cancellation');
+          }
+        }),
+        doubleClick: vi.fn(),
+        drag: vi.fn(),
+        keypress: vi.fn(),
+        move: vi.fn(),
+        scroll: vi.fn(),
+        type: vi.fn(),
+        wait: vi.fn(),
+      } as any;
+      const customDataExtractor = vi.fn(() => ({ shouldNotRun: true }));
+      const computer = computerTool({
+        computer: fakeComputer,
+        customDataExtractor,
+      });
+      const call: protocol.ComputerUseCallItem = {
+        type: 'computer_call',
+        callId: 'cancelled-batch',
+        status: 'completed',
+        actions: [
+          { type: 'click', x: 1, y: 2, button: 'left' },
+          { type: 'move', x: 3, y: 4 },
+        ],
+      };
 
-    const resultPromise = executeComputerActions(
-      new Agent({ name: 'Comp' }),
-      [{ toolCall: call, computer }],
-      new Runner(),
-      new RunContext(),
-      undefined,
-      undefined,
-      controller.signal,
-    );
-    await clickStarted;
-    controller.abort(new Error('stop batched actions'));
-    releaseClick?.();
+      const runner = new Runner();
+      const agent = new Agent({ name: 'Comp' });
+      const runContext = new RunContext();
+      const end = vi.fn();
+      runner.on('agent_tool_end', end);
+      const resultPromise = executeComputerActions(
+        agent,
+        [{ toolCall: call, computer }],
+        runner,
+        runContext,
+        undefined,
+        undefined,
+        controller.signal,
+      );
+      await clickStarted;
+      controller.abort(new Error('stop batched actions'));
+      releaseClick?.();
 
-    const [item] = await resultPromise;
-    expect(fakeComputer.click).toHaveBeenCalledTimes(1);
-    expect(fakeComputer.move).not.toHaveBeenCalled();
-    expect(fakeComputer.screenshot).not.toHaveBeenCalled();
-    expect(item.rawItem).toMatchObject({
-      type: 'computer_call_result',
-      callId: call.callId,
-      providerData: { status: 'incomplete' },
-    });
-  });
+      const [item] = await resultPromise;
+      expect(fakeComputer.click).toHaveBeenCalledTimes(1);
+      expect(fakeComputer.move).not.toHaveBeenCalled();
+      expect(fakeComputer.screenshot).not.toHaveBeenCalled();
+      expect(customDataExtractor).not.toHaveBeenCalled();
+      expect(end).toHaveBeenCalledTimes(1);
+      expect(end).toHaveBeenCalledWith(runContext, agent, computer, 'aborted', {
+        toolCall: call,
+      });
+      expect(item.rawItem).toMatchObject({
+        type: 'computer_call_result',
+        callId: call.callId,
+        providerData: { status: 'incomplete' },
+      });
+    },
+  );
+
+  it.each(['fulfills', 'rejects'] as const)(
+    'treats cancellation when the final screenshot %s as incomplete',
+    async (settlement) => {
+      const controller = new AbortController();
+      let markScreenshotStarted: (() => void) | undefined;
+      const screenshotStarted = new Promise<void>((resolve) => {
+        markScreenshotStarted = resolve;
+      });
+      let releaseScreenshot: (() => void) | undefined;
+      const screenshotCanFinish = new Promise<void>((resolve) => {
+        releaseScreenshot = resolve;
+      });
+      const fakeComputer = {
+        environment: 'mac',
+        dimensions: [1, 1] as [number, number],
+        screenshot: vi.fn().mockImplementation(async () => {
+          markScreenshotStarted?.();
+          await screenshotCanFinish;
+          if (settlement === 'rejects') {
+            throw new Error('final screenshot failed after cancellation');
+          }
+          return 'img';
+        }),
+        click: vi.fn(),
+        doubleClick: vi.fn(),
+        drag: vi.fn(),
+        keypress: vi.fn(),
+        move: vi.fn(),
+        scroll: vi.fn(),
+        type: vi.fn(),
+        wait: vi.fn(),
+      } as any;
+      const customDataExtractor = vi.fn(() => ({ shouldNotRun: true }));
+      const computer = computerTool({
+        computer: fakeComputer,
+        customDataExtractor,
+      });
+      const call: protocol.ComputerUseCallItem = {
+        type: 'computer_call',
+        callId: 'cancelled-final-screenshot',
+        status: 'completed',
+        actions: [{ type: 'move', x: 1, y: 2 }],
+      };
+      const runner = new Runner();
+      const agent = new Agent({ name: 'Comp' });
+      const runContext = new RunContext();
+      const end = vi.fn();
+      runner.on('agent_tool_end', end);
+      let settled = false;
+
+      const resultPromise = executeComputerActions(
+        agent,
+        [{ toolCall: call, computer }],
+        runner,
+        runContext,
+        undefined,
+        undefined,
+        controller.signal,
+      ).finally(() => {
+        settled = true;
+      });
+      await screenshotStarted;
+      controller.abort(new Error('stop final screenshot'));
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+      expect(settled).toBe(false);
+      releaseScreenshot?.();
+
+      const [item] = await resultPromise;
+      expect(customDataExtractor).not.toHaveBeenCalled();
+      expect(end).toHaveBeenCalledTimes(1);
+      expect(end).toHaveBeenCalledWith(runContext, agent, computer, 'aborted', {
+        toolCall: call,
+      });
+      expect(item.rawItem).toMatchObject({
+        type: 'computer_call_result',
+        callId: call.callId,
+        providerData: { status: 'incomplete' },
+      });
+    },
+  );
 
   it('checks approval against each batched computer action', async () => {
     const fakeComputer = {
@@ -4301,12 +4403,10 @@ describe('executeShellActions', () => {
       expect(lateSideEffect).toBe(false);
     });
 
-    it('reserves nested failure ownership while cleanup drains', async () => {
+    it('reserves abort-shaped nested failure ownership while cleanup drains', async () => {
       const primaryError = new Error('primary function failure');
-      const wrappedPrimaryError = new ToolCallError(
-        'Failed to run function tools',
-        primaryError,
-      );
+      primaryError.name = 'AbortError';
+      let wrappedPrimaryError: ToolCallError | undefined;
       const secondaryError = new Error('secondary category failure');
       let markCleanupStarted: (() => void) | undefined;
       const cleanupStarted = new Promise<void>((resolve) => {
@@ -4343,7 +4443,14 @@ describe('executeShellActions', () => {
               signal,
               reserveFailure,
             );
-          } catch {
+          } catch (error) {
+            if (!(error instanceof Error)) {
+              throw error;
+            }
+            wrappedPrimaryError = new ToolCallError(
+              'Failed to run function tools',
+              error,
+            );
             throw wrappedPrimaryError;
           }
         },
@@ -4357,7 +4464,12 @@ describe('executeShellActions', () => {
       await cleanupStarted;
       releaseCleanup?.();
 
-      await expect(resultPromise).rejects.toBe(wrappedPrimaryError);
+      const rejection = await resultPromise.then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      expect(rejection).toBe(wrappedPrimaryError);
+      expect(wrappedPrimaryError?.error).toBe(primaryError);
     });
 
     it('preserves undefined rejections in uncapped tools', async () => {


### PR DESCRIPTION
This pull request fixes concurrent tool execution so that a fatal failure cancels unfinished sibling work and drains already-started work before the original error is surfaced. It covers failures across function and computer tool categories and within uncapped function-tool execution, while preserving parent abort reasons, concurrency limits, output ordering, and post-invocation lifecycle completion.

It also prevents queued or subsequent computer actions from starting after cancellation and adds deterministic regression coverage for original-error preservation and the absence of late side effects.