### PR TITLE
fix(realtime): accept status-less conversation items (#1571)

### DIFF
--- a/.changeset/olive-items-keep-status.md
+++ b/.changeset/olive-items-keep-status.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: accept status-less and incomplete Realtime conversation message items (#1571)

--- a/packages/agents-realtime/src/items.ts
+++ b/packages/agents-realtime/src/items.ts
@@ -19,7 +19,7 @@ export const realtimeMessageItemSchema = z.discriminatedUnion('role', [
     previousItemId: z.string().nullable().optional(),
     type: z.literal('message'),
     role: z.literal('user'),
-    status: z.enum(['in_progress', 'completed']),
+    status: z.enum(['in_progress', 'completed', 'incomplete']),
     content: z.array(
       z.object({ type: z.literal('input_text'), text: z.string() }).or(
         z.object({

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -387,7 +387,11 @@ export abstract class OpenAIRealtimeBase
             parsed.item.role,
             parsed.item.content,
           ),
-          status: parsed.item.status,
+          status:
+            parsed.item.status ??
+            (parsed.type === 'conversation.item.added'
+              ? 'in_progress'
+              : 'completed'),
         });
         this.emit('item_update', item);
         return;

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -691,6 +691,75 @@ describe('OpenAIRealtimeBase helpers', () => {
     expect(approvals[0]?.serverLabel).toBe('s1');
   });
 
+  it('reaches session history when the server omits status', async () => {
+    const { RealtimeSession } = await import('../src/realtimeSession');
+    const { RealtimeAgent } = await import('../src/realtimeAgent');
+
+    const transport = new TestBase();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'a' }), {
+      transport,
+    });
+    await session.connect({ apiKey: 'test' });
+    const historyEvents: any[][] = [];
+    session.on('history_updated', (history) =>
+      historyEvents.push([...history]),
+    );
+
+    (transport as any)._onMessage({
+      data: JSON.stringify({
+        type: 'conversation.item.added',
+        event_id: 'e1',
+        item: {
+          id: 'u1',
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'hello' }],
+        },
+        previous_item_id: null,
+      }),
+    });
+
+    expect(session.history.map((item) => item.itemId)).toEqual(['u1']);
+    expect(session.history[0]).toMatchObject({ status: 'in_progress' });
+    expect(historyEvents.at(-1)?.map((item) => item.itemId)).toEqual(['u1']);
+  });
+
+  it('normalizes missing statuses and preserves explicit statuses', () => {
+    const base = new TestBase();
+    const updates: any[] = [];
+    base.on('item_update', (item) => updates.push(item));
+
+    const send = (type: string, id: string, status?: string) =>
+      (base as any)._onMessage({
+        data: JSON.stringify({
+          type,
+          event_id: `e_${id}`,
+          item: {
+            id,
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'input_text', text: 'hi' }],
+            ...(status ? { status } : {}),
+          },
+          previous_item_id: null,
+        }),
+      });
+
+    send('conversation.item.added', 'a1');
+    send('conversation.item.done', 'd1');
+    send('conversation.item.retrieved', 'r1');
+    send('conversation.item.done', 'p1', 'in_progress');
+    send('conversation.item.done', 'i1', 'incomplete');
+
+    expect(updates.map((update) => [update.itemId, update.status])).toEqual([
+      ['a1', 'in_progress'],
+      ['d1', 'completed'],
+      ['r1', 'completed'],
+      ['p1', 'in_progress'],
+      ['i1', 'incomplete'],
+    ]);
+  });
+
   it('emits function_call and mcp call updates on output items', () => {
     const base = new TestBase();
     const funcs: any[] = [];


### PR DESCRIPTION
This pull request carries forward the fix originally proposed in [#1573](https://github.com/openai/openai-agents-js/pull/1573) by @aryanputta, whose contribution is preserved through the commit's `Co-authored-by` trailer. It resolves #1571.

The Realtime API allows conversation message items to omit `status`, but the SDK previously rejected those events before they reached session history. This change keeps the public history status required while deriving missing values from the event phase: `conversation.item.added` becomes `in_progress`, while `conversation.item.done` and `conversation.item.retrieved` become `completed`.

It also accepts and preserves the API-supported `incomplete` status for user messages. Regression coverage verifies the adapter defaults and confirms that status-less items reach `RealtimeSession.history` and `history_updated`.